### PR TITLE
Muon autoscale bug

### DIFF
--- a/docs/source/release/v6.2.0/muon.rst
+++ b/docs/source/release/v6.2.0/muon.rst
@@ -22,6 +22,7 @@ BugFixes
 ############
 - A bug has been fixed in the BinWidth for the Dynamic Kobu Toyabe Fitting Function which caused a crash and did not provide
   any information about why the value was invalid. Will now revert to last viable BinWidth used and explain why.
+- The autoscale option when `All` is selected will now show the largest and smallest y value from the all of the plots.
 
 Muon Analysis and Frequency Domain Analysis
 -------------------------------------------

--- a/scripts/Muon/GUI/Common/plot_widget/plotting_canvas/plotting_canvas_presenter.py
+++ b/scripts/Muon/GUI/Common/plot_widget/plotting_canvas/plotting_canvas_presenter.py
@@ -353,7 +353,12 @@ class PlottingCanvasPresenter(PlottingCanvasPresenterInterface):
             return y_list[plot]
 
     def update_y_limits_of_subplots(self, y_limits_list, selected_subplots, axes):
+        # these are seperate to make it easier for debugging if it ever breaks
         if len(selected_subplots)==0:
+            return
+        elif len(selected_subplots) != len(y_limits_list):
+            return
+        elif len(selected_subplots) != len(axes):
             return
         # get max and min across all plots
         y_mins = [y_limits_list[plot][0] for plot in selected_subplots]

--- a/scripts/Muon/GUI/Common/plot_widget/plotting_canvas/plotting_canvas_presenter.py
+++ b/scripts/Muon/GUI/Common/plot_widget/plotting_canvas/plotting_canvas_presenter.py
@@ -12,9 +12,7 @@ from Muon.GUI.Common.plot_widget.quick_edit.quick_edit_widget import QuickEditWi
 from Muon.GUI.Common.plot_widget.plotting_canvas.plotting_canvas_view_interface import PlottingCanvasViewInterface
 from mantid import AnalysisDataService
 from mantidqt.utils.observer_pattern import GenericObserver
-
-Y_MIN = -9.9e9
-Y_MAX = 9.9e9
+import numpy as np
 
 
 class PlottingCanvasPresenter(PlottingCanvasPresenterInterface):
@@ -346,26 +344,42 @@ class PlottingCanvasPresenter(PlottingCanvasPresenterInterface):
         self.force_autoscale()
         self._options_presenter.disable_yaxis_changer()
 
+    def _get_y_limits_for_subplot(self, global_limits, y_list, plot):
+        if self._context.settings.is_condensed:
+            # global min and max
+            return global_limits
+        else:
+            # local min and max
+            return y_list[plot]
+
+    def update_y_limits_of_subplots(self, y_limits_list, selected_subplots, axes):
+        if len(selected_subplots)==0:
+            return
+        # get max and min across all plots
+        y_mins = [y_limits_list[plot][0] for plot in selected_subplots]
+        y_maxs = [y_limits_list[plot][1] for plot in selected_subplots]
+        global_limits = [np.amin(y_mins), np.amax(y_maxs)]
+
+        for axis_num, plot in zip(axes, selected_subplots):
+            y_limits = self._get_y_limits_for_subplot(global_limits, y_limits_list, plot)
+            self._context.update_ylim(plot, y_limits)
+            self._view.set_axis_ylimits(axis_num, y_limits)
+        if self.should_update_all(selected_subplots):
+            self._context.update_ylim_all(global_limits)
+        # either have multiple plots -> global limits or 1 plot (global = plot limits)
+        self._options_presenter.set_plot_y_range(global_limits)
+        self._view.redraw_figure()
+
     def force_autoscale(self):
         selected_subplots, axes = self._get_selected_subplots_from_quick_edit_widget()
-        # get min and max
-        ymin = Y_MIN
-        ymax = Y_MAX
+        # get min and max for each subplot
+        y_limits_list = {}
         for axis_num, plot in zip(axes, selected_subplots):
             self._view.autoscale_selected_y_axis(axis_num)
             _, _, y_min, y_max = self._view.get_axis_limits(axis_num)
-            if y_min > ymin:
-                ymin = y_min
-            if y_max < ymax:
-                ymax = y_max
+            y_limits_list[plot] = [y_min, y_max]
         # update y vales
-        for plot in selected_subplots:
-            self._context.update_ylim(plot, [ymin, ymax])
-        if self.should_update_all(selected_subplots):
-            self._context.update_ylim_all([ymin, ymax])
-
-        self._options_presenter.set_plot_y_range([ymin, ymax])
-        self._view.redraw_figure()
+        self.update_y_limits_of_subplots(y_limits_list, selected_subplots, axes)
 
     def autoscale_y_axes(self):
         """Autoscales all y-axes in the figure using the existing x axis"""


### PR DESCRIPTION
**Description of work.**

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

The muon GUI's were not behaving in a predictable way when using tiled plots with autoscale ticked. The y values displayed were just from the first subplot and each subplot had different y axis. 

**To test:**

<!-- Instructions for testing. -->
Open muon analysis
Load the current run from chronus
select tiled plot
untick autoscale
set y min to 0
tick autoscale
The subplots should all have different y axis
The y limits in the quick edit will show the largest and smallest y values from the subplots

When using raw view, the axis will all match.

Fixes #32041. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->
In the release notes
<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
