### PR TITLE
Avoid globals() for Engg UI startup check

### DIFF
--- a/scripts/Engineering_Diffraction.py
+++ b/scripts/Engineering_Diffraction.py
@@ -10,14 +10,18 @@ from qtpy import QtCore
 import sys
 
 
+# Single instance. If minimized the menu should show it and not create a new one
+ENGG_UI_INSTANCE = None
+
+
 def _on_delete():
-    del globals()['engineering_gui']
+    global ENGG_UI_INSTANCE
+    ENGG_UI_INSTANCE = None
 
 
-if 'engineering_gui' in globals() and not globals()['engineering_gui'].isHidden():
-    engineering_gui = globals()['engineering_gui']
-    engineering_gui.setWindowState(engineering_gui.windowState() & ~QtCore.Qt.WindowMinimized | QtCore.Qt.WindowActive)
-    engineering_gui.activateWindow()
+if ENGG_UI_INSTANCE is not None and ENGG_UI_INSTANCE.isHidden():
+    ENGG_UI_INSTANCE.setWindowState(ENGG_UI_INSTANCE.windowState() & ~QtCore.Qt.WindowMinimized | QtCore.Qt.WindowActive)
+    ENGG_UI_INSTANCE.activateWindow()
 else:
     if 'workbench' in sys.modules:
         from workbench.config import get_window_config
@@ -25,6 +29,6 @@ else:
         parent, flags = get_window_config()
     else:
         parent, flags = None, None
-    engineering_gui = EngineeringDiffractionGui(parent=parent, window_flags=flags)
-    engineering_gui.destroyed.connect(_on_delete)
-    engineering_gui.show()
+    ENGG_UI_INSTANCE = EngineeringDiffractionGui(parent=parent, window_flags=flags)
+    ENGG_UI_INSTANCE.destroyed.connect(_on_delete)
+    ENGG_UI_INSTANCE.show()


### PR DESCRIPTION
**Description of work.**

If the script is run in a different namespace, i.e.
with exec, then the variable will appear in that
namespace and not that returned by globals().

The system test only seems to fail on Ubuntu 18.04

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**

* On Ubuntu 18.04 run `./systemtest -R PythonInterfacesSt` and it should pass.
* Check that the issue solved by #31980 has not been reintroduced.

*There is no associated issue.*

*This does not require release notes* because **fixes a system test**

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
