### PR TITLE
Make the PropertyManager optional

### DIFF
--- a/Framework/PythonInterface/test/python/mantid/utils/absorptioncorrutilsTest.py
+++ b/Framework/PythonInterface/test/python/mantid/utils/absorptioncorrutilsTest.py
@@ -31,7 +31,10 @@ class AbsorptionCorrUtilsTest(unittest.TestCase):
         PropertyManagerDataService.remove('props')
 
     def test_correction_props(self):
-        self.assertRaises(RuntimeError, absorptioncorrutils.create_absorption_input, '', None)
+        # must supply the filename
+        self.assertRaises(ValueError, absorptioncorrutils.create_absorption_input, '', None)
+        # must supply some way of determining wavelength range
+        self.assertRaises(ValueError, absorptioncorrutils.create_absorption_input, 'PG3_46577.nxs.h5', None)
 
         props = PropertyManagerDataService.retrieve("props")
 


### PR DESCRIPTION
The PropertyManager is only needed to determine the wavelength range if
the user did not supply it. This changes the logic so it is no longer
needed. Also fixes a bug when a user supplies only min OR max wavelength
that it now only calculates the one that wasn't supplied.

**To test:**

A code review is appropriate... and the tests should pass

*There is no associated issue.*

*This does not require release notes* because it is a minor change that will be covered by release notes in follow-on work.

The version into `ornl-next` is #32100.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
