### PR TITLE
Remove curvefitting target from Indirect tests + Clean up CMakeFiles

### DIFF
--- a/qt/scientific_interfaces/Direct/CMakeLists.txt
+++ b/qt/scientific_interfaces/Direct/CMakeLists.txt
@@ -16,41 +16,6 @@ set(INC_FILES
 
 # Target
 mtd_add_qt_library(TARGET_NAME MantidScientificInterfacesDirect
-                   QT_VERSION 4
-                   SRC
-                     ${SRC_FILES}
-                   MOC
-                     ${MOC_FILES}
-                   NOMOC
-                     ${INC_FILES}
-                   DEFS
-                     IN_MANTIDQT_DIRECT
-                   SYSTEM_INCLUDE_DIRS
-                     ${Boost_INCLUDE_DIRS}
-                   LINK_LIBS
-                     DataObjects
-                     ${CORE_MANTIDLIBS}
-                     ${POCO_LIBRARIES}
-                     ${Boost_LIBRARIES}
-                     ${PYTHON_LIBRARIES}
-                     ${OPENGL_gl_LIBRARY}
-                     ${OPENGL_glu_LIBRARY}
-                   QT4_LINK_LIBS
-                     Qt4::QtOpenGL
-                     Qwt5
-                   MTD_QT_LINK_LIBS
-                     MantidQtWidgetsCommon
-                     MantidQtWidgetsInstrumentView
-                     MantidQtWidgetsPlotting
-                   INSTALL_DIR_BASE
-                     ${PLUGINS_DIR}
-                   OSX_INSTALL_RPATH
-                     @loader_path/../../Contents/MacOS
-                     @loader_path/../../plugins/qt4
-                   LINUX_INSTALL_RPATH
-                     "\$ORIGIN/../../${LIB_DIR};\$ORIGIN/../../plugins/qt4/")
-
-mtd_add_qt_library(TARGET_NAME MantidScientificInterfacesDirect
                    QT_VERSION 5
                    SRC
                      ${SRC_FILES}

--- a/qt/scientific_interfaces/Direct/test/CMakeLists.txt
+++ b/qt/scientific_interfaces/Direct/test/CMakeLists.txt
@@ -57,7 +57,6 @@ mtd_add_qt_tests(
     ../../../../Framework/TestHelpers/src/WorkspaceCreationHelper.cpp
     ../../../../Framework/TestHelpers/src/TearDownWorld.cpp
   LINK_LIBS
-    CurveFitting
     DataObjects
     ${GMOCK_LIBRARIES}
     ${GTEST_LIBRARIES}

--- a/qt/scientific_interfaces/Direct/test/CMakeLists.txt
+++ b/qt/scientific_interfaces/Direct/test/CMakeLists.txt
@@ -7,43 +7,6 @@ set(
 
 mtd_add_qt_tests(
   TARGET_NAME MantidQtInterfacesDirectTest
-  QT_VERSION 4
-  SRC ${TEST_FILES}
-  INCLUDE_DIRS
-    ../../../../Framework/CurveFitting/inc
-    ../../../../Framework/DataObjects/inc
-    ../../../../Framework/TestHelpers/inc
-    ../
-  TEST_HELPER_SRCS
-    ../../../../Framework/TestHelpers/src/ComponentCreationHelper.cpp
-    ../../../../Framework/TestHelpers/src/InstrumentCreationHelper.cpp
-    ../../../../Framework/TestHelpers/src/WorkspaceCreationHelper.cpp
-    ../../../../Framework/TestHelpers/src/TearDownWorld.cpp
-  LINK_LIBS
-    CurveFitting
-    DataObjects
-    ${GMOCK_LIBRARIES}
-    ${GTEST_LIBRARIES}
-    ${CORE_MANTIDLIBS}
-    ${POCO_LIBRARIES}
-    ${Boost_LIBRARIES}
-    Python::Python
-    ${OPENGL_gl_LIBRARY}
-    ${OPENGL_glu_LIBRARY}
-    gmock
-  QT4_LINK_LIBS
-    Qt4::QtOpenGL
-    Qwt5
-  MTD_QT_LINK_LIBS
-    MantidScientificInterfacesDirect
-    MantidQtWidgetsCommon
-    MantidQtWidgetsInstrumentView
-    MantidQtWidgetsPlotting
-  PARENT_DEPENDENCIES
-    GUITests)
-
-mtd_add_qt_tests(
-  TARGET_NAME MantidQtInterfacesDirectTest
   QT_VERSION 5
   SRC ${TEST_FILES}
   INCLUDE_DIRS

--- a/qt/scientific_interfaces/General/CMakeLists.txt
+++ b/qt/scientific_interfaces/General/CMakeLists.txt
@@ -30,37 +30,6 @@ set(UI_FILES
     StepScan.ui)
 
 mtd_add_qt_library(TARGET_NAME MantidScientificInterfacesGeneral
-                   QT_VERSION 4
-                   SRC ${SRC_FILES}
-                   MOC ${MOC_FILES}
-                   NOMOC ${INC_FILES}
-                   UI ${UI_FILES}
-                   DEFS IN_MANTIDQT_INTERFACESGENERAL
-                   PRECOMPILED PrecompiledHeader.h
-                   INCLUDE_DIRS
-                     ${CMAKE_CURRENT_SOURCE_DIR}
-                   SYSTEM_INCLUDE_DIRS
-                     ${Boost_INCLUDE_DIRS}
-                   LINK_LIBS
-                     ${CORE_MANTIDLIBS}
-                     ${POCO_LIBRARIES}
-                     ${Boost_LIBRARIES}
-                     ${JSONCPP_LIBRARIES}
-                     Json
-                   QT4_LINK_LIBS
-                     Qwt5
-                   MTD_QT_LINK_LIBS
-                     MantidQtWidgetsCommon
-                     MantidQtWidgetsPlotting
-                   INSTALL_DIR_BASE
-                     ${PLUGINS_DIR}
-                   OSX_INSTALL_RPATH
-                     @loader_path/../../Contents/MacOS
-                     @loader_path/../../Contents/Frameworks
-                   LINUX_INSTALL_RPATH
-                     "\$ORIGIN/../../${LIB_DIR}")
-
-mtd_add_qt_library(TARGET_NAME MantidScientificInterfacesGeneral
                    QT_VERSION 5
                    SRC StepScan.cpp
                    MOC StepScan.h

--- a/qt/scientific_interfaces/ISISReflectometry/CMakeLists.txt
+++ b/qt/scientific_interfaces/ISISReflectometry/CMakeLists.txt
@@ -48,34 +48,6 @@ set(UI_FILES ${GUI_UI_FILES})
 
 mtd_add_qt_library(
   TARGET_NAME MantidScientificInterfacesISISReflectometry
-  QT_VERSION 4
-  SRC ${SRC_FILES}
-  MOC ${MOC_FILES}
-  NOMOC ${INC_FILES}
-  UI ${UI_FILES}
-  DEFS
-    IN_MANTIDQT_ISISREFLECTOMETRY
-    PRECOMPILED
-    PrecompiledHeader.h
-  INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}
-  LINK_LIBS
-    ${CORE_MANTIDLIBS}
-    ${POCO_LIBRARIES}
-    ${Boost_LIBRARIES}
-    ${JSONCPP_LIBRARIES}
-  QT4_LINK_LIBS Qwt5
-  MTD_QT_LINK_LIBS
-    MantidQtWidgetsCommon
-    MantidQtIcons
-  INSTALL_DIR_BASE ${PLUGINS_DIR}
-  OSX_INSTALL_RPATH
-    @loader_path/../../Contents/MacOS
-    @loader_path/../../Contents/Frameworks
-  LINUX_INSTALL_RPATH "\$ORIGIN/../../${LIB_DIR}"
-)
-
-mtd_add_qt_library(
-  TARGET_NAME MantidScientificInterfacesISISReflectometry
   QT_VERSION 5
   SRC ${SRC_FILES}
   MOC ${MOC_FILES}

--- a/qt/scientific_interfaces/ISISReflectometry/test/CMakeLists.txt
+++ b/qt/scientific_interfaces/ISISReflectometry/test/CMakeLists.txt
@@ -57,7 +57,6 @@ mtd_add_qt_tests(
     ../../../../Framework/TestHelpers/src/TearDownWorld.cpp
   LINK_LIBS
     ${CORE_MANTIDLIBS}
-    CurveFitting
     DataObjects
     gmock
     ${POCO_LIBRARIES}

--- a/qt/scientific_interfaces/Indirect/test/CMakeLists.txt
+++ b/qt/scientific_interfaces/Indirect/test/CMakeLists.txt
@@ -35,7 +35,6 @@ mtd_add_qt_tests(
   QT_VERSION 5
   SRC ${TEST_FILES}
   INCLUDE_DIRS
-    ../../../../Framework/CurveFitting/inc
     ../../../../Framework/DataObjects/inc
     ../../../../Framework/TestHelpers/inc
     ../
@@ -48,7 +47,6 @@ mtd_add_qt_tests(
     ../IndirectDataValidationHelper.cpp
   LINK_LIBS
     ${CORE_MANTIDLIBS}
-    CurveFitting
     DataObjects
     gmock
     ${POCO_LIBRARIES}

--- a/qt/scientific_interfaces/Indirect/test/ConvFitModelTest.h
+++ b/qt/scientific_interfaces/Indirect/test/ConvFitModelTest.h
@@ -10,23 +10,19 @@
 
 #include "ConvFitModel.h"
 
+#include "MantidAPI/AlgorithmManager.h"
 #include "MantidAPI/AnalysisDataService.h"
 #include "MantidAPI/FrameworkManager.h"
 #include "MantidAPI/FunctionFactory.h"
 #include "MantidAPI/IFunction.h"
 #include "MantidAPI/MatrixWorkspace_fwd.h"
 #include "MantidAPI/MultiDomainFunction.h"
-#include "MantidCurveFitting/Algorithms/ConvolutionFit.h"
-#include "MantidCurveFitting/Algorithms/QENSFitSequential.h"
 #include "MantidTestHelpers/IndirectFitDataCreationHelper.h"
 
 using namespace Mantid::API;
 using namespace Mantid::IndirectFitDataCreationHelper;
 using namespace MantidQt::CustomInterfaces::IDA;
 using namespace MantidQt::MantidWidgets;
-
-using ConvolutionFitSequential =
-    Mantid::CurveFitting::Algorithms::ConvolutionFit<Mantid::CurveFitting::Algorithms::QENSFitSequential>;
 
 namespace {
 
@@ -52,7 +48,7 @@ void setFittingFunction(std::unique_ptr<ConvFitModel> &model, std::string const 
 }
 
 IAlgorithm_sptr setupFitAlgorithm(const MatrixWorkspace_sptr &workspace, std::string const &functionString) {
-  auto alg = std::make_shared<ConvolutionFitSequential>();
+  auto alg = AlgorithmManager::Instance().create("ConvolutionFitSequential");
   alg->initialize();
   alg->setProperty("InputWorkspace", workspace);
   alg->setProperty("Function", functionString);

--- a/qt/scientific_interfaces/Indirect/test/IndirectFitOutputModelTest.h
+++ b/qt/scientific_interfaces/Indirect/test/IndirectFitOutputModelTest.h
@@ -10,25 +10,21 @@
 #include <utility>
 
 #include "IndirectFitOutputModel.h"
+#include "MantidAPI/AlgorithmManager.h"
 #include "MantidAPI/FrameworkManager.h"
 #include "MantidAPI/FunctionFactory.h"
 #include "MantidAPI/MatrixWorkspace.h"
-#include "MantidCurveFitting/Algorithms/ConvolutionFit.h"
-#include "MantidCurveFitting/Algorithms/QENSFitSequential.h"
 #include "MantidDataObjects/Workspace2D.h"
 #include "MantidTestHelpers/IndirectFitDataCreationHelper.h"
 
 using namespace Mantid::API;
-using namespace Mantid::CurveFitting;
 using namespace Mantid::DataObjects;
 using namespace Mantid::IndirectFitDataCreationHelper;
 using namespace MantidQt::CustomInterfaces::IDA;
 
-using ConvolutionFitSequential = Algorithms::ConvolutionFit<Algorithms::QENSFitSequential>;
-
 namespace {
 IAlgorithm_sptr setupFitAlgorithm(const MatrixWorkspace_sptr &workspace, std::string const &functionString) {
-  auto alg = std::make_shared<ConvolutionFitSequential>();
+  auto alg = AlgorithmManager::Instance().create("ConvolutionFitSequential");
   alg->initialize();
   alg->setProperty("InputWorkspace", workspace);
   alg->setProperty("Function", functionString);

--- a/qt/scientific_interfaces/Indirect/test/IndirectFitPlotModelTest.h
+++ b/qt/scientific_interfaces/Indirect/test/IndirectFitPlotModelTest.h
@@ -11,12 +11,11 @@
 
 #include "ConvFitModel.h"
 #include "IndirectFitPlotModel.h"
+#include "MantidAPI/AlgorithmManager.h"
 #include "MantidAPI/FrameworkManager.h"
 #include "MantidAPI/FunctionFactory.h"
 #include "MantidAPI/MultiDomainFunction.h"
 #include "MantidAPI/TextAxis.h"
-#include "MantidCurveFitting/Algorithms/ConvolutionFit.h"
-#include "MantidCurveFitting/Algorithms/QENSFitSequential.h"
 #include "MantidTestHelpers/IndirectFitDataCreationHelper.h"
 
 using namespace Mantid::API;
@@ -24,8 +23,6 @@ using namespace Mantid::CurveFitting;
 using namespace MantidQt::CustomInterfaces::IDA;
 using namespace Mantid::IndirectFitDataCreationHelper;
 using namespace MantidQt::CustomInterfaces;
-
-using ConvolutionFitSequential = Algorithms::ConvolutionFit<Algorithms::QENSFitSequential>;
 
 namespace {
 
@@ -126,7 +123,7 @@ IndirectFittingModel *createModelWithSingleInstrumentWorkspace(std::string const
 }
 
 IAlgorithm_sptr setupFitAlgorithm(const MatrixWorkspace_sptr &workspace, std::string const &functionString) {
-  auto alg = std::make_shared<ConvolutionFitSequential>();
+  auto alg = AlgorithmManager::Instance().create("ConvolutionFitSequential");
   alg->initialize();
   alg->setProperty("InputWorkspace", workspace);
   alg->setProperty("Function", functionString);

--- a/qt/scientific_interfaces/Indirect/test/IndirectFitPropertyBrowserTest.h
+++ b/qt/scientific_interfaces/Indirect/test/IndirectFitPropertyBrowserTest.h
@@ -18,8 +18,6 @@
 #include "MantidAPI/ITableWorkspace.h"
 #include "MantidAPI/MatrixWorkspace.h"
 #include "MantidAPI/MultiDomainFunction.h"
-#include "MantidCurveFitting/Algorithms/ConvolutionFit.h"
-#include "MantidCurveFitting/Algorithms/QENSFitSequential.h"
 #include "MantidDataObjects/TableWorkspace.h"
 #include "MantidDataObjects/Workspace2D.h"
 #include "MantidKernel/WarningSuppressions.h"
@@ -29,14 +27,11 @@
 #include "ParameterEstimation.h"
 
 using namespace Mantid::API;
-using namespace Mantid::CurveFitting;
 using namespace Mantid::DataObjects;
 using namespace Mantid::IndirectFitDataCreationHelper;
 using namespace MantidQt::CustomInterfaces::IDA;
 using namespace MantidQt::MantidWidgets;
 using namespace testing;
-
-using ConvolutionFitSequential = Algorithms::ConvolutionFit<Algorithms::QENSFitSequential>;
 
 namespace {
 TableWorkspace_sptr createTableWorkspace(std::size_t const &size) { return std::make_shared<TableWorkspace>(size); }

--- a/qt/scientific_interfaces/Indirect/test/IndirectFittingModelTest.h
+++ b/qt/scientific_interfaces/Indirect/test/IndirectFittingModelTest.h
@@ -10,22 +10,18 @@
 #include <utility>
 
 #include "IndirectFittingModel.h"
+#include "MantidAPI/AlgorithmManager.h"
 #include "MantidAPI/FrameworkManager.h"
 #include "MantidAPI/FunctionFactory.h"
 #include "MantidAPI/MatrixWorkspace.h"
-#include "MantidCurveFitting/Algorithms/ConvolutionFit.h"
-#include "MantidCurveFitting/Algorithms/QENSFitSequential.h"
 #include "MantidDataObjects/Workspace2D.h"
 #include "MantidTestHelpers/IndirectFitDataCreationHelper.h"
 
 using namespace Mantid::API;
-using namespace Mantid::CurveFitting;
 using namespace Mantid::DataObjects;
 using namespace MantidQt::CustomInterfaces::IDA;
 using namespace Mantid::IndirectFitDataCreationHelper;
 using namespace MantidQt::CustomInterfaces;
-
-using ConvolutionFitSequential = Algorithms::ConvolutionFit<Algorithms::QENSFitSequential>;
 
 namespace {
 
@@ -93,7 +89,7 @@ void setFittingFunction(std::unique_ptr<DummyModel> &model, std::string const &f
 }
 
 IAlgorithm_sptr setupFitAlgorithm(const MatrixWorkspace_sptr &workspace, std::string const &functionString) {
-  auto alg = std::make_shared<ConvolutionFitSequential>();
+  auto alg = AlgorithmManager::Instance().create("ConvolutionFitSequential");
   alg->initialize();
   alg->setProperty("InputWorkspace", workspace);
   alg->setProperty("Function", functionString);

--- a/qt/widgets/instrumentview/CMakeLists.txt
+++ b/qt/widgets/instrumentview/CMakeLists.txt
@@ -155,50 +155,6 @@ set(UI_FILES inc/MantidQtWidgets/InstrumentView/UCorrectionDialog.ui)
 
 # Target
 mtd_add_qt_library(TARGET_NAME MantidQtWidgetsInstrumentView
-                   QT_VERSION 4
-                   SRC
-                     ${SRC_FILES}
-                     ${QT4_SRC_FILES}
-                   MOC
-                     ${MOC_FILES}
-                     ${QT4_MOC_FILES}
-                   NOMOC
-                     ${INC_FILES}
-                     ${QT4_INC_FILES}
-                   UI
-                     ${UI_FILES}
-                   RES
-                     ../../../images/instrumentview.qrc
-                   DEFS
-                     IN_MANTIDQT_INSTRUMENTVIEW
-                   INCLUDE_DIRS
-                     inc
-                     ../../../Framework/DataObjects/inc
-                   SYSTEM_INCLUDE_DIRS
-                     ${Boost_INCLUDE_DIRS}
-                   LINK_LIBS
-                     ${CORE_MANTIDLIBS}
-                     DataObjects
-                     ${POCO_LIBRARIES}
-                     ${Boost_LIBRARIES}
-                     ${PYTHON_LIBRARIES}
-                     ${OPENGL_gl_LIBRARY}
-                     ${OPENGL_glu_LIBRARY}
-                   QT4_LINK_LIBS
-                     Qt4::QtOpenGL
-                     Qwt5
-                   MTD_QT_LINK_LIBS
-                     MantidQtWidgetsCommon
-                     MantidQtWidgetsPlotting
-                   INSTALL_DIR
-                     ${LIB_DIR}
-                   OSX_INSTALL_RPATH
-                     @loader_path/../MacOS
-                     @loader_path/../Frameworks
-                   LINUX_INSTALL_RPATH
-                     "\$ORIGIN/../${LIB_DIR}")
-
-mtd_add_qt_library(TARGET_NAME MantidQtWidgetsInstrumentView
                    QT_VERSION 5
                    SRC
                      ${SRC_FILES}

--- a/qt/widgets/plugins/algorithm_dialogs/CMakeLists.txt
+++ b/qt/widgets/plugins/algorithm_dialogs/CMakeLists.txt
@@ -58,31 +58,6 @@ include_directories(
 
 mtd_add_qt_library(
   TARGET_NAME MantidQtWidgetsPluginsAlgorithmDialogs
-  QT_VERSION 4
-  SRC ${SRC_FILES}
-  MOC ${MOC_FILES}
-  NOMOC ${INC_FILES}
-  UI
-    ${UI_FILES}
-    PRECOMPILED
-    inc/MantidQtWidgets/Plugins/AlgorithmDialogs/PrecompiledHeader.h
-  SYSTEM_INCLUDE_DIRS
-    ${Boost_INCLUDE_DIRS}
-  LINK_LIBS
-    ${CORE_MANTIDLIBS}
-    ${POCO_LIBRARIES}
-    ${Boost_LIBRARIES}
-    ${QT_LIBRARIES}
-    ${OPENGL_LIBRARIES}
-  QT4_LINK_LIBS Qt4::QtOpenGL Qt4::Qscintilla
-  MTD_QT_LINK_LIBS MantidQtWidgetsCommon
-  OSX_INSTALL_RPATH @loader_path/../../Contents/MacOS
-  LINUX_INSTALL_RPATH "\$ORIGIN/../../${LIB_DIR}"
-  INSTALL_DIR_BASE ${PLUGINS_DIR}
-)
-
-mtd_add_qt_library(
-  TARGET_NAME MantidQtWidgetsPluginsAlgorithmDialogs
   QT_VERSION 5
   SRC ${SRC_FILES}
   MOC ${MOC_FILES}


### PR DESCRIPTION
**Description of work.**
Removing the use of the curvefitting target from Indirect. Its preferable to access this functionality through the API layer. This will become a bigger issue when using a framework conda package as the CurveFitting targets won't be exported.
Also removing qt4 based tests

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**
Builds and tests pass
<!-- Instructions for testing. -->


*There is no associated issue.*


This does not require release notes because its a developer facing change


<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
