### PR TITLE
Superplot preserve colours while sliding

### DIFF
--- a/qt/python/mantidqt/widgets/superplot/model.py
+++ b/qt/python/mantidqt/widgets/superplot/model.py
@@ -114,6 +114,9 @@ class SuperplotModel(QObject):
         if not self._plotted_data:
             self._plot_mode = None
 
+        if name in self._ws_colors:
+            del self._ws_colors[name]
+
     def get_workspaces(self):
         """
         Get the list of workspace names.

--- a/qt/python/mantidqt/widgets/superplot/model.py
+++ b/qt/python/mantidqt/widgets/superplot/model.py
@@ -61,10 +61,16 @@ class SuperplotModel(QObject):
     """
     _plot_mode = None
 
+    """
+    Colors of workspaces.
+    """
+    _ws_colors = None
+
     def __init__(self):
         super().__init__()
         self._workspaces = list()
         self._plotted_data = list()
+        self._ws_colors = dict()
         self._ads_observer = SuperplotAdsObserver()
         self._ads_observer.signals.sig_ws_deleted.connect(
                 self.on_workspace_deleted)
@@ -116,6 +122,31 @@ class SuperplotModel(QObject):
             list(str): list of workspace names
         """
         return self._workspaces.copy()
+
+    def set_workspace_color(self, ws_name, color):
+        """
+        Set the color of a workspace.
+
+        Args:
+            ws_name (str): workspace name
+            color (str): color (directly coming (and usable) from (by)
+                         matplotlib)
+        """
+        self._ws_colors[ws_name] = color
+
+    def get_workspace_color(self, ws_name):
+        """
+        Get the color of a workspace.
+
+        Args:
+            ws_name (str): workspace name
+
+        Returns:
+            (str): color or None
+        """
+        if ws_name in self._ws_colors:
+            return self._ws_colors[ws_name]
+        return None
 
     def set_bin_mode(self):
         """

--- a/qt/python/mantidqt/widgets/superplot/presenter.py
+++ b/qt/python/mantidqt/widgets/superplot/presenter.py
@@ -351,6 +351,8 @@ class SuperplotPresenter:
                     color = artist.get_color()
                 except:
                     color = artist.lines[0].get_color()
+                if color == self._model.get_workspace_color(ws_name):
+                    self._model.set_workspace_color(ws_name, None)
                 self._view.modify_spectrum_label(ws_name, sp, label, color)
 
         # add selection to plot
@@ -371,6 +373,9 @@ class SuperplotPresenter:
                         kwargs["axis"] = MantidAxType.BIN
                         kwargs["wkspIndex"] = sp
 
+                    color = self._model.get_workspace_color(ws_name)
+                    if color:
+                        kwargs["color"] = color
                     if self._error_bars:
                         lines = axes.errorbar(ws, **kwargs)
                         label = lines.get_label()
@@ -379,7 +384,7 @@ class SuperplotPresenter:
                         lines = axes.plot(ws, **kwargs)
                         label = lines[0].get_label()
                         color = lines[0].get_color()
-                    self._view.modify_spectrum_label(ws_name, sp, label, color)
+                    self._model.set_workspace_color(ws_name, color)
 
         if selection or plotted_data:
             axes.set_axis_on()

--- a/qt/python/mantidqt/widgets/superplot/presenter.py
+++ b/qt/python/mantidqt/widgets/superplot/presenter.py
@@ -215,6 +215,20 @@ class SuperplotPresenter:
                 pass
             self._canvas.draw_idle()
 
+    def on_drop(self, name):
+        """
+        Triggered when a drop event is received in the list widget. Here, name
+        is assumed to be a workspace name.
+
+        Args:
+            name (str): workspace name
+        """
+        selection = self._view.get_selection()
+        self._model.add_workspace(name)
+        self._update_list()
+        self._view.set_selection(selection)
+        self._update_plot()
+
     def on_add_button_clicked(self):
         """
         Triggered when the add button is pressed. This function adds the

--- a/qt/python/mantidqt/widgets/superplot/test/test_superplot_model.py
+++ b/qt/python/mantidqt/widgets/superplot/test/test_superplot_model.py
@@ -32,6 +32,7 @@ class SuperplotModelTest(unittest.TestCase):
     def test_init(self):
         self.assertEqual(self.model._workspaces, [])
         self.assertEqual(self.model._plotted_data, [])
+        self.assertEqual(self.model._ws_colors, {})
         self.assertIsNone(self.model._plot_mode)
         self.m_obs.signals.sig_ws_deleted.connect.assert_called_once()
         self.m_obs.signals.sig_ws_renamed.connect.assert_called_once()
@@ -84,6 +85,24 @@ class SuperplotModelTest(unittest.TestCase):
         wsList = wsList[0:2]
         self.assertEqual(wsList, ["ws1", "ws2"])
         self.assertEqual(self.model._workspaces, ["ws1", "ws2", "ws3"])
+
+    def test_set_workspace_color(self):
+        self.assertEqual(self.model._ws_colors, {})
+        self.model.set_workspace_color("ws1", "color1")
+        self.assertDictEqual(self.model._ws_colors, {"ws1": "color1"})
+        self.model.set_workspace_color("ws2", "color2")
+        self.assertDictEqual(self.model._ws_colors, {"ws1": "color1",
+                                                     "ws2": "color2"})
+        self.model.set_workspace_color("ws1", "color3")
+        self.assertDictEqual(self.model._ws_colors, {"ws1": "color3",
+                                                     "ws2": "color2"})
+
+    def test_get_workspace_color(self):
+        self.model._ws_colors = {"ws1": "color1", "ws2": "color2"}
+        color = self.model.get_workspace_color("ws1")
+        self.assertEqual(color, "color1")
+        color = self.model.get_workspace_color("ws3")
+        self.assertIsNone(color)
 
     def test_set_bin_mode(self):
         self.assertIsNone(self.model._plot_mode)

--- a/qt/python/mantidqt/widgets/superplot/test/test_superplot_presenter.py
+++ b/qt/python/mantidqt/widgets/superplot/test/test_superplot_presenter.py
@@ -228,12 +228,14 @@ class SuperplotPresenterTest(unittest.TestCase):
         line.get_label.return_value = "label"
         line.get_color.return_value = "color"
         self.m_axes.plot.return_value = [line]
+        self.m_model.get_workspace_color.return_value = "memorized_color"
         self.presenter._update_plot()
         self.m_axes.remove_artists_if.assert_called_once()
         calls = [mock.call("ws5", 5, "label", "color"),
-                 mock.call("ws2", 1, "label", "color"),
-                 mock.call("ws1", 10, "label", "color")]
+                 mock.call("ws2", 1, "label", "color")]
         self.m_view.modify_spectrum_label.assert_has_calls(calls)
+        self.m_model.set_workspace_color.assert_called_once_with("ws1", "color")
+        self.m_axes.plot.assert_called_once()
 
     def test_on_workspace_selection_changed(self):
         self.presenter._update_plot = mock.Mock()

--- a/qt/python/mantidqt/widgets/superplot/view.py
+++ b/qt/python/mantidqt/widgets/superplot/view.py
@@ -139,6 +139,13 @@ class SuperplotViewSide(QDockWidget):
     """
     resized = Signal()
 
+    """
+    Sent when a drop event is received.
+    Args:
+        str: the event mime type text (assumed to be a workspace name)
+    """
+    drop = Signal(str)
+
     def __init__(self, parent=None):
         super().__init__(parent)
         self.here = os.path.dirname(os.path.realpath(__file__))
@@ -155,6 +162,19 @@ class SuperplotViewSide(QDockWidget):
         self.workspaceSelector.setWorkspaceTypes(["Workspace2D",
                                                   "WorkspaceGroup",
                                                   "EventWorkspace"])
+        self.setAcceptDrops(True)
+
+    def dragEnterEvent(self, event):
+        """
+        Override QDockWidget::dragEnterEvent.
+        """
+        event.acceptProposedAction()
+
+    def dropEvent(self, event):
+        """
+        Override QDockWidget::dropEvent. Emit the drop signal.
+        """
+        self.drop.emit(event.mimeData().text())
 
     def resizeEvent(self, event):
         """
@@ -220,6 +240,7 @@ class SuperplotView(QWidget):
         side.workspacesList.itemSelectionChanged.connect(
                 self._presenter.on_workspace_selection_changed)
         side.resized.connect(self._presenter.on_resize)
+        side.drop.connect(self._presenter.on_drop)
         bottom = self._bottom_view
         bottom.holdButton.clicked.connect(
                 self._presenter.on_hold_button_clicked)


### PR DESCRIPTION
**Description of work.**

This PR contains two improvements for the superplot that our users suggested:
* possibility to drag and drop a workspace in the superplot list
* maintain the same color for the curve(s) when sliding through a workspace, unless the curves are persisted


**To test:**

* create some sample workspaces
* open the superplot (right click on a workspace, plot->Superplot)
* drag and drop a workspace in the list
* select several workspaces in the list, slide over the spectra in the selected workspace(s) observing the colours of the curves
* try to persist some (either with the Add button or hitting the space bar) and keep sliding

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
