### PR TITLE
Add install/uninstall to manual testing.

### DIFF
--- a/dev-docs/source/Testing/Core/Core.rst
+++ b/dev-docs/source/Testing/Core/Core.rst
@@ -45,7 +45,7 @@ Grouped Tasks
 
 In order to test a wide range of functionality and avoid repeating work, areas to test are split into groups. These tasks are for testing how Workbench links to the Framework, through the different :ref:`Toolboxes <main_window>`. The links here are to give you an idea, but please mess around a little too and try to break Mantid!
 
-This was last updated for Release 5.1. Check if the organiser has considered if the Core testers can test on different environments.
+This was last updated for Release 6.2. Check if the organiser has considered if the Core testers can test on different environments.
 
 
 
@@ -53,6 +53,7 @@ This was last updated for Release 5.1. Check if the organiser has considered if 
     :widths: 30 5 5 5 5 50
     :header: "Area", ":r:`1`", ":b:`2`", ":g:`3`", ":o:`4`", "Description and Links"
 
+    Install/Uninstall,:r:`Y`,:b:`Y`,:g:`Y`,:o:`Y`, "**Windows only**: install Mantid, go to the Windows 'Apps & features' list and verify the icon is there for Mantid. Uninstall Mantid from within the 'Apps & features' list and verify that the desktop and start menu shortcuts are removed."
     Project Save/Load,:r:`Y`,:b:`Y`,:g:`Y`,:o:`Y`, "Test the small areas below and do not delete workspaces or plots you produce and manipulate, maybe open a few interfaces. Then File > Save Project and try to reload it! Diagnose any problems."
     About / First Time Setup Menu,:r:`Y`,,,,"Check Opens Successfully + all buttons and links work"
     Help Documentation,,:b:`Y`,:g:`Y`,,"Open all `Help` menu bar options. Load a few algorithm dialogs and click the **?**. Produce some plots (1D, Waterfall,Colorfill,3D Surface) and check **?** links."


### PR DESCRIPTION
**Description of work.**

Added instructions for manual testing of the Windows installer/uninstaller to the core manual testing documentation.

**To test:**
- Build dev-docs-html and compare with https://developer.mantidproject.org/Testing/Core/Core.html
- They should be identical except for the small changes made here.

*There is no associated issue.*

*This does not require release notes* because it is an update to manual testing instructions.

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
