### PR TITLE
Remove pyqt from framework

### DIFF
--- a/Framework/PythonInterface/test/python/mantid/SimpleAPITest.py
+++ b/Framework/PythonInterface/test/python/mantid/SimpleAPITest.py
@@ -27,6 +27,20 @@ class SimpleAPITest(unittest.TestCase):
     def test_version_number_equals_2(self):
         self.assertEqual(simpleapi.apiVersion(), 2)
 
+    def test_simpleapi_does_not_import_qt(self):
+        import sys
+        modules = [mod for mod in sys.modules]
+        qt_import = 'qtpy'
+        matching_qtpy_imports = [mod for mod in modules if qt_import in mod]
+        self.assertFalse(len(matching_qtpy_imports) > 0)
+
+    def test_simpleapi_does_not_import_mantidqt(self):
+        import sys
+        modules = [mod for mod in sys.modules]
+        mantidqt_import = 'mantidqt'
+        matching_mantidqt_imports = [mod for mod in modules if mantidqt_import in mod]
+        self.assertFalse(len(matching_mantidqt_imports) > 0)
+
     def test_module_dict_seems_to_be_correct_size(self):
         # Check that the module has at least the same number
         # of attributes as unique algorithms

--- a/Framework/PythonInterface/test/python/mantid/SimpleAPITest.py
+++ b/Framework/PythonInterface/test/python/mantid/SimpleAPITest.py
@@ -32,14 +32,19 @@ class SimpleAPITest(unittest.TestCase):
         modules = [mod for mod in sys.modules]
         qt_import = 'qtpy'
         matching_qtpy_imports = [mod for mod in modules if qt_import in mod]
-        self.assertFalse(len(matching_qtpy_imports) > 0)
+        self.assertFalse(len(matching_qtpy_imports) > 0, msg="The simpleapi shouldn't import qtpy, one or more of "
+                                                             "imports you've added includes a package which imports "
+                                                             "qtpy, please amend your imports.")
 
     def test_simpleapi_does_not_import_mantidqt(self):
         import sys
         modules = [mod for mod in sys.modules]
         mantidqt_import = 'mantidqt'
         matching_mantidqt_imports = [mod for mod in modules if mantidqt_import in mod]
-        self.assertFalse(len(matching_mantidqt_imports) > 0)
+        self.assertFalse(len(matching_mantidqt_imports) > 0,
+                         msg="The simpleapi shouldn't import mantidqt, one or more of "
+                             "imports you've added includes a package which imports "
+                             "mantidqt, please amend your imports.")
 
     def test_module_dict_seems_to_be_correct_size(self):
         # Check that the module has at least the same number

--- a/scripts/Engineering/common/path_handling.py
+++ b/scripts/Engineering/common/path_handling.py
@@ -7,19 +7,10 @@
 from os import path
 from mantid.kernel import logger
 from mantid.simpleapi import Load
-from Engineering.gui.engineering_diffraction.settings.settings_helper import get_setting
-
-INTERFACES_SETTINGS_GROUP = "CustomInterfaces"
-ENGINEERING_PREFIX = "EngineeringDiffraction2/"
 
 
 def get_run_number_from_path(run_path, instrument):
     return path.splitext(path.basename(run_path))[0].replace(instrument, '').lstrip('0')
-
-
-def get_output_path():
-    location = get_setting(INTERFACES_SETTINGS_GROUP, ENGINEERING_PREFIX, "save_location")
-    return location if location is not None else ""
 
 
 def load_workspace(file_path):

--- a/scripts/Engineering/gui/engineering_diffraction/presenter.py
+++ b/scripts/Engineering/gui/engineering_diffraction/presenter.py
@@ -6,6 +6,7 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 
 from Engineering.common import path_handling
+from Engineering.gui.engineering_diffraction.tabs.common import output_settings
 from .tabs.common import CalibrationObserver
 from .tabs.calibration.model import CalibrationModel
 from .tabs.calibration.view import CalibrationView
@@ -97,9 +98,11 @@ class EngineeringDiffractionPresenter(object):
 
     @staticmethod
     def get_saved_rb_number() -> str:
-        rb_number = get_setting(path_handling.INTERFACES_SETTINGS_GROUP, path_handling.ENGINEERING_PREFIX, "rb_number")
+        rb_number = get_setting(output_settings.INTERFACES_SETTINGS_GROUP,
+                                output_settings.ENGINEERING_PREFIX, "rb_number")
         return rb_number
 
     @staticmethod
     def set_saved_rb_number(rb_number) -> None:
-        set_setting(path_handling.INTERFACES_SETTINGS_GROUP, path_handling.ENGINEERING_PREFIX, "rb_number", rb_number)
+        set_setting(output_settings.INTERFACES_SETTINGS_GROUP,
+                    output_settings.ENGINEERING_PREFIX, "rb_number", rb_number)

--- a/scripts/Engineering/gui/engineering_diffraction/settings/settings_model.py
+++ b/scripts/Engineering/gui/engineering_diffraction/settings/settings_model.py
@@ -5,7 +5,7 @@
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
 from Engineering.gui.engineering_diffraction.settings.settings_helper import get_setting, set_setting
-from Engineering.common import path_handling
+from Engineering.gui.engineering_diffraction.tabs.common import output_settings
 
 
 class SettingsModel(object):
@@ -21,9 +21,9 @@ class SettingsModel(object):
 
     @staticmethod
     def get_setting(name, return_type=str):
-        return get_setting(path_handling.INTERFACES_SETTINGS_GROUP, path_handling.ENGINEERING_PREFIX, name,
+        return get_setting(output_settings.INTERFACES_SETTINGS_GROUP, output_settings.ENGINEERING_PREFIX, name,
                            return_type=return_type)
 
     @staticmethod
     def set_setting(name, value):
-        set_setting(path_handling.INTERFACES_SETTINGS_GROUP, path_handling.ENGINEERING_PREFIX, name, value)
+        set_setting(output_settings.INTERFACES_SETTINGS_GROUP, output_settings.ENGINEERING_PREFIX, name, value)

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/calibration/model.py
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/calibration/model.py
@@ -12,7 +12,7 @@ from mantid.simpleapi import PDCalibration, DeleteWorkspace, CloneWorkspace, Dif
     CreateEmptyTableWorkspace, NormaliseByCurrent, ConvertUnits, Load, SaveNexus, ApplyDiffCal
 import Engineering.EnggUtils as EnggUtils
 from Engineering.gui.engineering_diffraction.settings.settings_helper import get_setting, set_setting
-from Engineering.gui.engineering_diffraction.tabs.common import vanadium_corrections
+from Engineering.gui.engineering_diffraction.tabs.common import vanadium_corrections, output_settings
 from Engineering.common import path_handling
 
 CALIB_PARAMS_WORKSPACE_NAME = "engggui_calibration_banks_parameters"
@@ -45,8 +45,8 @@ class CalibrationModel(object):
         # vanadium corrections workspaces not used at this stage, but ensure they exist and create if not
         vanadium_corrections.fetch_correction_workspaces(vanadium_path, instrument, rb_num=rb_num)
         ceria_workspace = path_handling.load_workspace(ceria_path)
-        full_calib_path = get_setting(path_handling.INTERFACES_SETTINGS_GROUP,
-                                      path_handling.ENGINEERING_PREFIX, "full_calibration")
+        full_calib_path = get_setting(output_settings.INTERFACES_SETTINGS_GROUP,
+                                      output_settings.ENGINEERING_PREFIX, "full_calibration")
         try:
             full_calib = Load(full_calib_path, OutputWorkspace="full_inst_calib")
         except ValueError:
@@ -85,7 +85,7 @@ class CalibrationModel(object):
             params_table.append([i, difc[i], difa[i], tzero[i]])
         self.update_calibration_params_table(params_table)
 
-        calib_dir = path.join(path_handling.get_output_path(), "Calibration", "")
+        calib_dir = path.join(output_settings.get_output_path(), "Calibration", "")
         if calfile:
             EnggUtils.save_grouping_workspace(grp_ws, calib_dir, ceria_path, vanadium_path, instrument, calfile=calfile)
         elif spectrum_numbers:
@@ -94,7 +94,7 @@ class CalibrationModel(object):
         self.create_output_files(calib_dir, difa, difc, tzero, bk2bk_params, ceria_path, vanadium_path, instrument,
                                  bank, spectrum_numbers, calfile)
         if rb_num:
-            user_calib_dir = path.join(path_handling.get_output_path(), "User", rb_num,
+            user_calib_dir = path.join(output_settings.get_output_path(), "User", rb_num,
                                        "Calibration", "")
             self.create_output_files(user_calib_dir, difa, difc, tzero, bk2bk_params, ceria_path, vanadium_path,
                                      instrument, bank, spectrum_numbers, calfile)
@@ -272,7 +272,7 @@ class CalibrationModel(object):
                                                                               bank=bank_name)
             EnggUtils.write_ENGINX_GSAS_iparam_file(file_path, difa_list, difc_list, tzero_list, bk2bk_params,
                                                     **kwargs_to_pass)
-            set_setting(path_handling.INTERFACES_SETTINGS_GROUP, path_handling.ENGINEERING_PREFIX,
+            set_setting(output_settings.INTERFACES_SETTINGS_GROUP, output_settings.ENGINEERING_PREFIX,
                         "last_calibration_path", file_path)
 
         def save_pdcal_output_file(ws_name_suffix, bank_name):

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/calibration/presenter.py
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/calibration/presenter.py
@@ -7,8 +7,7 @@
 # pylint: disable=invalid-name
 from copy import deepcopy
 
-from Engineering.common import path_handling
-from Engineering.gui.engineering_diffraction.tabs.common import INSTRUMENT_DICT, create_error_message
+from Engineering.gui.engineering_diffraction.tabs.common import INSTRUMENT_DICT, create_error_message, output_settings
 from Engineering.gui.engineering_diffraction.tabs.common.calibration_info import CalibrationInfo
 from Engineering.gui.engineering_diffraction.tabs.common.cropping.cropping_presenter import CroppingPresenter
 from Engineering.gui.engineering_diffraction.settings.settings_helper import get_setting, set_setting
@@ -65,7 +64,7 @@ class CalibrationPresenter(object):
             self.pending_calibration.set_calibration(vanadium_file, sample_file, instrument)
             self.pending_calibration.set_roi_info_load(banks, grp_ws_name, roi_text)
             self.set_current_calibration()
-            set_setting(path_handling.INTERFACES_SETTINGS_GROUP, path_handling.ENGINEERING_PREFIX,
+            set_setting(output_settings.INTERFACES_SETTINGS_GROUP, output_settings.ENGINEERING_PREFIX,
                         "last_calibration_path", filename)
 
     def start_calibration_worker(self, vanadium_path, sample_path, plot_output, rb_num, bank=None, calfile=None,
@@ -120,7 +119,7 @@ class CalibrationPresenter(object):
         Loads the most recently created or loaded calibration into the interface instance. To be used on interface
         startup.
         """
-        last_cal_path = get_setting(path_handling.INTERFACES_SETTINGS_GROUP, path_handling.ENGINEERING_PREFIX,
+        last_cal_path = get_setting(output_settings.INTERFACES_SETTINGS_GROUP, output_settings.ENGINEERING_PREFIX,
                                     "last_calibration_path")
         if last_cal_path:
             self.view.set_load_checked(True)

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/common/output_settings.py
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/common/output_settings.py
@@ -1,0 +1,18 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2021 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+"""
+Holds some common constants across all tabs.
+"""
+from Engineering.gui.engineering_diffraction.settings.settings_helper import get_setting
+
+INTERFACES_SETTINGS_GROUP = "CustomInterfaces"
+ENGINEERING_PREFIX = "EngineeringDiffraction2/"
+
+
+def get_output_path():
+    location = get_setting(INTERFACES_SETTINGS_GROUP, ENGINEERING_PREFIX, "save_location")
+    return location if location is not None else ""

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/common/test/test_vanadium_corrections.py
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/common/test/test_vanadium_corrections.py
@@ -74,7 +74,7 @@ class VanadiumCorrectionsTest(unittest.TestCase):
         vanadium_corrections.save_van_workspace("ws", "out/path")
         self.assertEqual(1, save.call_count)
 
-    @patch(dir_path + ".vanadium_corrections.path_handling.get_output_path")
+    @patch(dir_path + ".vanadium_corrections.output_settings.get_output_path")
     @patch(dir_path + ".vanadium_corrections.makedirs")
     def test_generate_van_ws_file_paths_no_rb(self, makedirs, out_path):
         usr_path = path.expanduser("~")
@@ -91,7 +91,7 @@ class VanadiumCorrectionsTest(unittest.TestCase):
         self.assertEqual((expected_integral, expected_processed), output)
         self.assertEqual(1, makedirs.call_count)
 
-    @patch(dir_path + ".vanadium_corrections.path_handling.get_output_path")
+    @patch(dir_path + ".vanadium_corrections.output_settings.get_output_path")
     @patch(dir_path + ".vanadium_corrections.makedirs")
     def test_generate_van_ws_file_paths_with_rb(self, makedirs, out_path):
         usr_path = path.expanduser("~")

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/common/vanadium_corrections.py
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/common/vanadium_corrections.py
@@ -11,6 +11,7 @@ from mantid.simpleapi import logger, Load, SaveNexus, NormaliseByCurrent, Integr
 from mantid.simpleapi import AnalysisDataService as Ads
 
 from Engineering.common import path_handling
+from Engineering.gui.engineering_diffraction.tabs.common import output_settings
 from Engineering.gui.engineering_diffraction.settings.settings_helper import get_setting
 
 VANADIUM_INPUT_WORKSPACE_NAME = "engggui_vanadium_ws"
@@ -38,8 +39,8 @@ def fetch_correction_workspaces(vanadium_path: str, instrument: str, rb_num: str
     if is_load:
         force_recalc = False
     else:
-        force_recalc = get_setting(path_handling.INTERFACES_SETTINGS_GROUP,
-                                   path_handling.ENGINEERING_PREFIX, "recalc_vanadium", return_type=bool)
+        force_recalc = get_setting(output_settings.INTERFACES_SETTINGS_GROUP,
+                                   output_settings.ENGINEERING_PREFIX, "recalc_vanadium", return_type=bool)
     if path.exists(processed_path) and path.exists(integ_path) and not force_recalc:  # Check if the cached files exist.
         try:
             integ_workspace = Load(Filename=integ_path, OutputWorkspace=INTEGRATED_WORKSPACE_NAME)
@@ -86,8 +87,8 @@ def create_vanadium_corrections(vanadium_path: str):  # -> Workspace, Workspace
                      + str(vanadium_path) + ". Error description: " + str(e))
         raise RuntimeError
     # get full instrument calibration for instrument processing calculation
-    full_calib_path = get_setting(path_handling.INTERFACES_SETTINGS_GROUP,
-                                  path_handling.ENGINEERING_PREFIX, "full_calibration")
+    full_calib_path = get_setting(output_settings.INTERFACES_SETTINGS_GROUP,
+                                  output_settings.ENGINEERING_PREFIX, "full_calibration")
     try:
         full_calib_ws = Load(full_calib_path, OutputWorkspace="full_inst_calib")
     except ValueError:
@@ -149,10 +150,10 @@ def _generate_vanadium_saves_file_path(rb_num: str = "") -> str:
     :return: The full path to the file.
     """
     if rb_num:
-        vanadium_dir = path.join(path_handling.get_output_path(), "User", rb_num,
+        vanadium_dir = path.join(output_settings.get_output_path(), "User", rb_num,
                                  VANADIUM_DIRECTORY_NAME)
     else:
-        vanadium_dir = path.join(path_handling.get_output_path(), VANADIUM_DIRECTORY_NAME)
+        vanadium_dir = path.join(output_settings.get_output_path(), VANADIUM_DIRECTORY_NAME)
     if not path.exists(vanadium_dir):
         makedirs(vanadium_dir)
     return vanadium_dir

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/data_handling/data_model.py
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/data_handling/data_model.py
@@ -9,7 +9,7 @@ from os import path
 from mantid.simpleapi import Load, logger, EnggEstimateFocussedBackground, ConvertUnits, Minus, AverageLogData, \
     CreateEmptyTableWorkspace, GroupWorkspaces, DeleteWorkspace, DeleteTableRows, RenameWorkspace, CreateWorkspace
 from Engineering.gui.engineering_diffraction.settings.settings_helper import get_setting
-from Engineering.common import path_handling
+from Engineering.gui.engineering_diffraction.tabs.common import output_settings
 from mantid.api import AnalysisDataService as ADS
 from mantid.api import TextAxis
 from mantid.kernel import UnitConversion, DeltaEModeType, UnitParams
@@ -88,7 +88,7 @@ class FittingDataModel(object):
         run_info = self.make_runinfo_table()
         self._log_workspaces = GroupWorkspaces([run_info], OutputWorkspace='logs')
         # a table per logs
-        logs = get_setting(path_handling.INTERFACES_SETTINGS_GROUP, path_handling.ENGINEERING_PREFIX, "logs")
+        logs = get_setting(output_settings.INTERFACES_SETTINGS_GROUP, output_settings.ENGINEERING_PREFIX, "logs")
         if logs:
             self._log_names = logs.split(',')
             for log in self._log_names:
@@ -184,9 +184,9 @@ class FittingDataModel(object):
         ws_list = self.get_ws_list()
         tof_ws_inds = [ind for ind, ws in enumerate(ws_list) if
                        self._loaded_workspaces[ws].getAxis(0).getUnit().caption() == 'Time-of-flight']
-        primary_log = get_setting(path_handling.INTERFACES_SETTINGS_GROUP, path_handling.ENGINEERING_PREFIX,
+        primary_log = get_setting(output_settings.INTERFACES_SETTINGS_GROUP, output_settings.ENGINEERING_PREFIX,
                                   "primary_log")
-        sort_ascending = get_setting(path_handling.INTERFACES_SETTINGS_GROUP, path_handling.ENGINEERING_PREFIX,
+        sort_ascending = get_setting(output_settings.INTERFACES_SETTINGS_GROUP, output_settings.ENGINEERING_PREFIX,
                                      "sort_ascending")
         if primary_log:
             log_table = ADS.retrieve(primary_log)

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/plotting/EngDiff_fitpropertybrowser.py
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/plotting/EngDiff_fitpropertybrowser.py
@@ -13,7 +13,7 @@ from mantidqt.utils.qt import import_qt
 from mantidqt.utils.observer_pattern import GenericObservable
 from mantidqt.widgets.fitpropertybrowser import FitPropertyBrowser
 from mantid.api import AnalysisDataService as ADS
-from Engineering.common import path_handling
+from Engineering.gui.engineering_diffraction.tabs.common import output_settings
 from Engineering.gui.engineering_diffraction.settings.settings_helper import get_setting
 
 BaseBrowser = import_qt('.._common', 'mantidqt.widgets', 'FitPropertyBrowser')
@@ -28,7 +28,7 @@ class EngDiffFitPropertyBrowser(FitPropertyBrowser):
     def __init__(self, canvas, toolbar_manager, parent=None):
         super(EngDiffFitPropertyBrowser, self).__init__(canvas, toolbar_manager, parent)
         # overwrite default peak with that in settings (gets init when UI opened)
-        default_peak = get_setting(path_handling.INTERFACES_SETTINGS_GROUP, path_handling.ENGINEERING_PREFIX,
+        default_peak = get_setting(output_settings.INTERFACES_SETTINGS_GROUP, output_settings.ENGINEERING_PREFIX,
                                    "default_peak")
         self.setDefaultPeakType(default_peak)  # this will also update peak func in config settings
         self.fit_notifier = GenericObservable()

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/focus/model.py
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/focus/model.py
@@ -11,6 +11,7 @@ import matplotlib.pyplot as plt
 
 from Engineering.common import path_handling
 from Engineering.gui.engineering_diffraction.tabs.common import vanadium_corrections
+from Engineering.gui.engineering_diffraction.tabs.common import output_settings
 from Engineering.gui.engineering_diffraction.settings.settings_helper import get_setting
 from Engineering import EnggUtils
 from mantid.simpleapi import logger, AnalysisDataService as Ads, SaveNexus, SaveGSS, SaveFocusedXYE, \
@@ -46,8 +47,8 @@ class FocusModel(object):
         :param rb_num: Number to signify the user who is running this focus
         :param regions_dict: dict region name -> grp_ws_name, defining region(s) of interest to focus over
         """
-        full_calib_path = get_setting(path_handling.INTERFACES_SETTINGS_GROUP,
-                                      path_handling.ENGINEERING_PREFIX, "full_calibration")
+        full_calib_path = get_setting(output_settings.INTERFACES_SETTINGS_GROUP,
+                                      output_settings.ENGINEERING_PREFIX, "full_calibration")
         if not Ads.doesExist("full_inst_calib"):
             try:
                 full_calib_workspace = Load(full_calib_path, OutputWorkspace="full_inst_calib")
@@ -263,49 +264,44 @@ class FocusModel(object):
                                                rb_num, unit)
         self._save_focused_output_files_as_topas_xye(instrument, sample_path, bank, sample_workspace,
                                                      rb_num, unit)
-        output_path = path.join(path_handling.get_output_path(), 'Focus')
+        output_path = path.join(output_settings.get_output_path(), 'Focus')
         logger.notice(f"\n\nFocus files saved to: \"{output_path}\"\n\n")
         if rb_num:
-            output_path = path.join(path_handling.get_output_path(), 'User', rb_num, 'Focus')
+            output_path = path.join(output_settings.get_output_path(), 'User', rb_num, 'Focus')
             logger.notice(f"\n\nFocus files also saved to: \"{output_path}\"\n\n")
 
     def _save_focused_output_files_as_gss(self, instrument, sample_path, bank, sample_workspace,
                                           rb_num, unit):
-        gss_output_path = path.join(
-            path_handling.get_output_path(), "Focus",
-            self._generate_output_file_name(instrument, sample_path, bank, unit, ".gss"))
+        gss_output_path = path.join(output_settings.get_output_path(), "Focus",
+                                    self._generate_output_file_name(instrument, sample_path, bank, unit, ".gss"))
         SaveGSS(InputWorkspace=sample_workspace, Filename=gss_output_path)
         if rb_num:
-            gss_output_path = path.join(
-                path_handling.get_output_path(), "User", rb_num, "Focus",
-                self._generate_output_file_name(instrument, sample_path, bank, unit, ".gss"))
+            gss_output_path = path.join(output_settings.get_output_path(), "User", rb_num, "Focus",
+                                        self._generate_output_file_name(instrument, sample_path, bank, unit, ".gss"))
             SaveGSS(InputWorkspace=sample_workspace, Filename=gss_output_path)
 
     def _save_focused_output_files_as_nexus(self, instrument, sample_path, bank, sample_workspace,
                                             rb_num, unit):
         file_name = self._generate_output_file_name(instrument, sample_path, bank, unit, ".nxs")
-        nexus_output_path = path.join(path_handling.get_output_path(), "Focus", file_name)
+        nexus_output_path = path.join(output_settings.get_output_path(), "Focus", file_name)
         SaveNexus(InputWorkspace=sample_workspace, Filename=nexus_output_path)
         if rb_num:
-            nexus_output_path = path.join(
-                path_handling.get_output_path(), "User", rb_num, "Focus", file_name)
+            nexus_output_path = path.join(output_settings.get_output_path(), "User", rb_num, "Focus", file_name)
             SaveNexus(InputWorkspace=sample_workspace, Filename=nexus_output_path)
         if unit == "TOF":
             self._last_focused_files.append(nexus_output_path)
 
     def _save_focused_output_files_as_topas_xye(self, instrument, sample_path, bank,
                                                 sample_workspace, rb_num, unit):
-        xye_output_path = path.join(
-            path_handling.get_output_path(), "Focus",
-            self._generate_output_file_name(instrument, sample_path, bank, unit, ".abc"))
+        xye_output_path = path.join(output_settings.get_output_path(), "Focus",
+                                    self._generate_output_file_name(instrument, sample_path, bank, unit, ".abc"))
         SaveFocusedXYE(InputWorkspace=sample_workspace,
                        Filename=xye_output_path,
                        SplitFiles=False,
                        Format="TOPAS")
         if rb_num:
-            xye_output_path = path.join(
-                path_handling.get_output_path(), "User", rb_num, "Focus",
-                self._generate_output_file_name(instrument, sample_path, bank, unit, ".abc"))
+            xye_output_path = path.join(output_settings.get_output_path(), "User", rb_num, "Focus",
+                                        self._generate_output_file_name(instrument, sample_path, bank, unit, ".abc"))
             SaveFocusedXYE(InputWorkspace=sample_workspace,
                            Filename=xye_output_path,
                            SplitFiles=False,
@@ -329,13 +325,13 @@ class FocusModel(object):
             except ValueError:
                 logger.information(f"Could not convert {name} to a numerical value. It will not be included in the "
                                    f"sample logs output file.")
-        focus_dir = path.join(path_handling.get_output_path(), "Focus")
+        focus_dir = path.join(output_settings.get_output_path(), "Focus")
         if not path.exists(focus_dir):
             makedirs(focus_dir)
         output_path = path.join(focus_dir, (instrument + "_" + run_number + "_sample_logs.csv"))
         write_to_file()
         if rb_num:
-            focus_user_dir = path.join(path_handling.get_output_path(), "User", rb_num, "Focus")
+            focus_user_dir = path.join(output_settings.get_output_path(), "User", rb_num, "Focus")
             if not path.exists(focus_user_dir):
                 makedirs(focus_user_dir)
             output_path = path.join(focus_user_dir, (instrument + "_" + run_number + "_sample_logs.csv"))

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/focus/test/test_focus_model.py
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/focus/test/test_focus_model.py
@@ -13,6 +13,7 @@ from unittest.mock import patch, MagicMock, call
 from mantid.simpleapi import CreateSampleWorkspace
 from Engineering.common import path_handling
 from Engineering.gui.engineering_diffraction.tabs.focus import model
+from Engineering.gui.engineering_diffraction.tabs.common import output_settings
 from Engineering.gui.engineering_diffraction.tabs.common.calibration_info import CalibrationInfo
 
 file_path = "Engineering.gui.engineering_diffraction.tabs.focus.model"
@@ -191,7 +192,7 @@ class FocusModelTest(unittest.TestCase):
     @patch(file_path + ".SaveNexus")
     def test_last_path_updates_with_no_RB_number(self, nexus, gss, xye):
         mocked_workspace = "mocked-workspace"
-        output_file = path.join(path_handling.get_output_path(), "Focus",
+        output_file = path.join(output_settings.get_output_path(), "Focus",
                                 "ENGINX_123_North_TOF.nxs")
 
         self.model._last_path_ws = 'ENGINX_123_North_TOF.nxs'
@@ -207,7 +208,7 @@ class FocusModelTest(unittest.TestCase):
     def test_last_path_updates_with_RB_number(self, nexus, gss, xye):
         mocked_workspace = "mocked-workspace"
         rb_num = '2'
-        output_file = path.join(path_handling.get_output_path(), "User", rb_num, "Focus",
+        output_file = path.join(output_settings.get_output_path(), "User", rb_num, "Focus",
                                 "ENGINX_123_North_TOF.nxs")
 
         self.model._last_path_ws = 'ENGINX_123_North_TOF.nxs'

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/focus/test/test_focus_model.py
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/focus/test/test_focus_model.py
@@ -11,7 +11,6 @@ from os import path
 
 from unittest.mock import patch, MagicMock, call
 from mantid.simpleapi import CreateSampleWorkspace
-from Engineering.common import path_handling
 from Engineering.gui.engineering_diffraction.tabs.focus import model
 from Engineering.gui.engineering_diffraction.tabs.common import output_settings
 from Engineering.gui.engineering_diffraction.tabs.common.calibration_info import CalibrationInfo
@@ -136,7 +135,7 @@ class FocusModelTest(unittest.TestCase):
     @patch(file_path + ".SaveNexus")
     def test_save_output_files_with_no_RB_number(self, nexus, gss, xye):
         mocked_workspace = "mocked-workspace"
-        output_file = path.join(path_handling.get_output_path(), "Focus",
+        output_file = path.join(output_settings.get_output_path(), "Focus",
                                 "ENGINX_123_North_TOF.nxs")
 
         self.model._save_output("ENGINX", "Path/To/ENGINX000123.whatever", "North",
@@ -158,7 +157,7 @@ class FocusModelTest(unittest.TestCase):
         self.assertEqual(xye.call_count, 2)
 
     @patch(file_path + ".logger")
-    @patch(file_path + ".path_handling.get_output_path")
+    @patch(file_path + ".output_settings.get_output_path")
     @patch(file_path + ".csv")
     def test_output_sample_logs_with_rb_number(self, mock_csv, mock_path, mock_logger):
         mock_writer = MagicMock()
@@ -173,7 +172,7 @@ class FocusModelTest(unittest.TestCase):
         self.assertEqual(8, mock_writer.writerow.call_count)
 
     @patch(file_path + ".logger")
-    @patch(file_path + ".path_handling.get_output_path")
+    @patch(file_path + ".output_settings.get_output_path")
     @patch(file_path + ".csv")
     def test_output_sample_logs_without_rb_number(self, mock_csv, mock_path, mock_logger):
         mock_writer = MagicMock()


### PR DESCRIPTION
**Description of work.**
Removes usage of pyqt in a framework build. Related to an issue I fixed previously by moving common code (which algorithms were using) out of a GUI directory (which imported mantidqt). However, I didn't realise that the common code imported a module which used QSettings.
<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**
Builds and tests pass

<!-- Instructions for testing. -->



*There is no associated issue.*



This does not require release notes because its a developer facing change


<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
