### PR TITLE
Add name qualification to Kernel in IndexingUtils

### DIFF
--- a/Framework/Geometry/src/Crystal/IndexingUtils.cpp
+++ b/Framework/Geometry/src/Crystal/IndexingUtils.cpp
@@ -1890,11 +1890,11 @@ V3D IndexingUtils::makeCDir(const V3D &a_dir, const V3D &b_dir, const double c, 
       sqrt(1 - cosAlpha * cosAlpha - cosBeta * cosBeta - cosGamma * cosGamma + 2 * cosAlpha * cosBeta * cosGamma);
   double c3 = c * V / sinGamma;
 
-  auto basis_1 = Kernel::toVector3d(a_dir).normalized();
-  auto basis_3 = Kernel::toVector3d(a_dir).cross(Kernel::toVector3d(b_dir)).normalized();
+  auto basis_1 = Mantid::Kernel::toVector3d(a_dir).normalized();
+  auto basis_3 = Mantid::Kernel::toVector3d(a_dir).cross(Mantid::Kernel::toVector3d(b_dir)).normalized();
   auto basis_2 = basis_3.cross(basis_1).normalized();
 
-  return Kernel::toV3D(basis_1 * c1 + basis_2 * c2 + basis_3 * c3);
+  return Mantid::Kernel::toV3D(basis_1 * c1 + basis_2 * c2 + basis_3 * c3);
 }
 
 /**
@@ -2642,7 +2642,8 @@ std::vector<V3D> IndexingUtils::MakeHemisphereDirections(int n_steps) {
   @throws std::invalid_argument exception if the number of steps is <= 0, or
                                 if the axix length is 0.
  */
-std::vector<V3D> IndexingUtils::MakeCircleDirections(int n_steps, const Kernel::V3D &axis, double angle_degrees) {
+std::vector<V3D> IndexingUtils::MakeCircleDirections(int n_steps, const Mantid::Kernel::V3D &axis,
+                                                     double angle_degrees) {
   if (n_steps <= 0) {
     throw std::invalid_argument("MakeCircleDirections(): n_steps must be greater than 0");
   }


### PR DESCRIPTION
**Description of work.**
Adding name qualifcation (`Mantid::`) to `Kernel` uses in IndexingUtils.cpp. Builds were failing because `Kernel::V3D` could not be found, Using just `V3D` worked before beacuse we had a using alias at the top. 


<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**
Builds pass
<!-- Instructions for testing. -->


*There is no associated issue.*



This does not require release notes because its a developer facing change.


<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
