### PR TITLE
Add option to show/hide legend in plot context menu

### DIFF
--- a/docs/source/release/v6.2.0/mantidworkbench.rst
+++ b/docs/source/release/v6.2.0/mantidworkbench.rst
@@ -23,6 +23,7 @@ New and Improved
 - Added tooltips to all the widgets in the Slice Viewer. Please contact the developers if any are missing.
 - Script editor tab completion and call tip support for Numpy 1.21
 - The visibility of a component parameter in the Pick tab of the InstrumentViewer is now steered by the 'visible' atrribute of a parameter in IPF
+- Plot legends can be shown or hidden from the plot context menu.
 
 Bugfixes
 --------

--- a/qt/applications/workbench/workbench/plotting/figureinteraction.py
+++ b/qt/applications/workbench/workbench/plotting/figureinteraction.py
@@ -22,7 +22,7 @@ from matplotlib.container import ErrorbarContainer
 from matplotlib.contour import QuadContourSet
 from qtpy.QtCore import Qt
 from qtpy.QtGui import QCursor
-from qtpy.QtWidgets import QActionGroup, QMenu, QApplication
+from qtpy.QtWidgets import QActionGroup, QMenu, QApplication, QAction
 from matplotlib.colors import LogNorm, Normalize
 from matplotlib.collections import Collection
 from mpl_toolkits.mplot3d.axes3d import Axes3D
@@ -374,7 +374,7 @@ class FigureInteraction(object):
             self.add_error_bars_menu(menu, event.inaxes)
             self._add_marker_option_menu(menu, event)
             self._add_plot_type_option_menu(menu, event.inaxes)
-            self._add_legend_menu(menu, event)
+            self._add_legend_toggle_action(menu, event)
 
         menu.exec_(QCursor.pos())
 
@@ -510,10 +510,12 @@ class FigureInteraction(object):
 
         menu.addMenu(marker_menu)
 
-    def _add_legend_menu(self, menu, event):
-        legend_menu = QMenu("Legend", menu)
-        legend_menu.addAction("Show/Hide legend", lambda: self._toggle_legend_and_redraw(event.inaxes.axes))
-        menu.addMenu(legend_menu)
+    def _add_legend_toggle_action(self, menu, event):
+        legend = event.inaxes.axes.get_legend()
+        legend_action = QAction("Show legend", menu, checkable=True)
+        legend_action.setChecked(legend is not None and legend.get_visible())
+        legend_action.toggled.connect(lambda: self._toggle_legend_and_redraw(event.inaxes.axes))
+        menu.addAction(legend_action)
 
     def _add_plot_type_option_menu(self, menu, ax):
         with errorbar_caps_removed(ax):

--- a/qt/applications/workbench/workbench/plotting/figureinteraction.py
+++ b/qt/applications/workbench/workbench/plotting/figureinteraction.py
@@ -374,6 +374,7 @@ class FigureInteraction(object):
             self.add_error_bars_menu(menu, event.inaxes)
             self._add_marker_option_menu(menu, event)
             self._add_plot_type_option_menu(menu, event.inaxes)
+            self._add_legend_menu(menu, event)
 
         menu.exec_(QCursor.pos())
 
@@ -508,6 +509,11 @@ class FigureInteraction(object):
             marker_action_group.addAction(action)
 
         menu.addMenu(marker_menu)
+
+    def _add_legend_menu(self, menu, event):
+        legend_menu = QMenu("Legend", menu)
+        legend_menu.addAction("Show/Hide legend", lambda: self._toggle_legend_and_redraw(event.inaxes.axes))
+        menu.addMenu(legend_menu)
 
     def _add_plot_type_option_menu(self, menu, ax):
         with errorbar_caps_removed(ax):
@@ -886,3 +892,11 @@ class FigureInteraction(object):
                                                         image.norm.vmax)
 
         self.canvas.draw_idle()
+
+    def _toggle_legend_and_redraw(self, ax):
+        legend = ax.get_legend()
+        if not legend:
+            ax.legend()
+        else:
+            legend.set_visible(not legend.get_visible())
+        self.canvas.draw()

--- a/qt/applications/workbench/workbench/plotting/test/test_figureinteraction.py
+++ b/qt/applications/workbench/workbench/plotting/test/test_figureinteraction.py
@@ -167,36 +167,33 @@ class FigureInteractionTest(unittest.TestCase):
         mocked_figure_type.return_value = FigureType.Line
 
         # Expect a call to QMenu() for the outer menu followed by two more calls
-        # for the Axes and Normalization menus
-        qmenu_call1 = MagicMock()
+        # for the Axes, Normalization, and Markers menus
+        outer_qmenu_call = MagicMock()
         qmenu_call2 = MagicMock()
         qmenu_call3 = MagicMock()
         qmenu_call4 = MagicMock()
-        qmenu_call5 = MagicMock()
-        mocked_qmenu_cls.side_effect = [qmenu_call1, qmenu_call2, qmenu_call3, qmenu_call4, qmenu_call5]
+        mocked_qmenu_cls.side_effect = [outer_qmenu_call, qmenu_call2, qmenu_call3, qmenu_call4]
 
         with patch('workbench.plotting.figureinteraction.QActionGroup',
                    autospec=True):
-            with patch.object(interactor.toolbar_manager, 'is_tool_active',
-                              lambda: False):
-                with patch.object(interactor, 'add_error_bars_menu', MagicMock()):
-                    interactor.on_mouse_button_press(mouse_event)
-                    self.assertEqual(0, qmenu_call1.addSeparator.call_count)
-                    self.assertEqual(0, qmenu_call1.addAction.call_count)
-                    expected_qmenu_calls = [call(),
-                                            call("Axes", qmenu_call1),
-                                            call("Normalization", qmenu_call1),
-                                            call("Markers", qmenu_call1),
-                                            call("Legend", qmenu_call1)]
-                    self.assertEqual(expected_qmenu_calls, mocked_qmenu_cls.call_args_list)
-                    # 4 actions in Axes submenu
-                    self.assertEqual(4, qmenu_call2.addAction.call_count)
-                    # 2 actions in Normalization submenu
-                    self.assertEqual(2, qmenu_call3.addAction.call_count)
-                    # 3 actions in Markers submenu
-                    self.assertEqual(3, qmenu_call4.addAction.call_count)
-                    # 1 actions in Legend submenu
-                    self.assertEqual(1, qmenu_call5.addAction.call_count)
+            with patch('workbench.plotting.figureinteraction.QAction'):
+                with patch.object(interactor.toolbar_manager, 'is_tool_active',
+                                  lambda: False):
+                    with patch.object(interactor, 'add_error_bars_menu', MagicMock()):
+                        interactor.on_mouse_button_press(mouse_event)
+                        self.assertEqual(0, outer_qmenu_call.addSeparator.call_count)
+                        self.assertEqual(1, outer_qmenu_call.addAction.call_count) # Show/hide legend action
+                        expected_qmenu_calls = [call(),
+                                                call("Axes", outer_qmenu_call),
+                                                call("Normalization", outer_qmenu_call),
+                                                call("Markers", outer_qmenu_call)]
+                        self.assertEqual(expected_qmenu_calls, mocked_qmenu_cls.call_args_list)
+                        # 4 actions in Axes submenu
+                        self.assertEqual(4, qmenu_call2.addAction.call_count)
+                        # 2 actions in Normalization submenu
+                        self.assertEqual(2, qmenu_call3.addAction.call_count)
+                        # 3 actions in Markers submenu
+                        self.assertEqual(3, qmenu_call4.addAction.call_count)
 
     def test_toggle_normalization_no_errorbars(self):
         self._test_toggle_normalization(errorbars_on=False, plot_kwargs={'distribution': True})

--- a/qt/applications/workbench/workbench/plotting/test/test_figureinteraction.py
+++ b/qt/applications/workbench/workbench/plotting/test/test_figureinteraction.py
@@ -172,7 +172,8 @@ class FigureInteractionTest(unittest.TestCase):
         qmenu_call2 = MagicMock()
         qmenu_call3 = MagicMock()
         qmenu_call4 = MagicMock()
-        mocked_qmenu_cls.side_effect = [qmenu_call1, qmenu_call2, qmenu_call3, qmenu_call4]
+        qmenu_call5 = MagicMock()
+        mocked_qmenu_cls.side_effect = [qmenu_call1, qmenu_call2, qmenu_call3, qmenu_call4, qmenu_call5]
 
         with patch('workbench.plotting.figureinteraction.QActionGroup',
                    autospec=True):
@@ -185,7 +186,8 @@ class FigureInteractionTest(unittest.TestCase):
                     expected_qmenu_calls = [call(),
                                             call("Axes", qmenu_call1),
                                             call("Normalization", qmenu_call1),
-                                            call("Markers", qmenu_call1)]
+                                            call("Markers", qmenu_call1),
+                                            call("Legend", qmenu_call1)]
                     self.assertEqual(expected_qmenu_calls, mocked_qmenu_cls.call_args_list)
                     # 4 actions in Axes submenu
                     self.assertEqual(4, qmenu_call2.addAction.call_count)
@@ -193,6 +195,8 @@ class FigureInteractionTest(unittest.TestCase):
                     self.assertEqual(2, qmenu_call3.addAction.call_count)
                     # 3 actions in Markers submenu
                     self.assertEqual(3, qmenu_call4.addAction.call_count)
+                    # 1 actions in Legend submenu
+                    self.assertEqual(1, qmenu_call5.addAction.call_count)
 
     def test_toggle_normalization_no_errorbars(self):
         self._test_toggle_normalization(errorbars_on=False, plot_kwargs={'distribution': True})


### PR DESCRIPTION
Adds option to show/hide legend in plot context menu so that it is quicker to do this!

**To test:**
1. Open a plot on a workspace.
2. Right click on the axes `Legend > Show/hide legend`
3. Test that this hides the legend, then test that doing it again shows the legend.

Additionally, check that when a plot is made with no legend you can still show it via `Legend > Show/hide legend`. For example on the plot generated by this script:
```
from mantid.simpleapi import *
import matplotlib.pyplot as plt

ws = CreateSampleWorkspace()
fig, ax = plt.subplots(subplot_kw={'projection':'mantid'})
ax.plot(ws, specNum=1)
fig.show()

```

Fixes #29679. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
