### PR TITLE
Remove QT4 CMake GUI targets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -168,8 +168,9 @@ Thumbs.db
 # Folder config file
 Desktop.ini
 
-# PyCharm IDE
+# CLion and PyCharm IDE
 .idea/
+cmake-build-*/
 
 # VSCode
 .vscode/

--- a/qt/scientific_interfaces/Direct/CMakeLists.txt
+++ b/qt/scientific_interfaces/Direct/CMakeLists.txt
@@ -14,8 +14,6 @@ set(INC_FILES
     ALFCustomInstrumentModel.h
     ALFCustomInstrumentMocks.h)
 
-# Target
-mtd_add_qt_library(TARGET_NAME MantidScientificInterfacesDirect
                    QT_VERSION 5
                    SRC
                      ${SRC_FILES}

--- a/qt/scientific_interfaces/Direct/CMakeLists.txt
+++ b/qt/scientific_interfaces/Direct/CMakeLists.txt
@@ -14,6 +14,8 @@ set(INC_FILES
     ALFCustomInstrumentModel.h
     ALFCustomInstrumentMocks.h)
 
+#Target
+mtd_add_qt_library(TARGET_NAME MantidScientificInterfacesDirect
                    QT_VERSION 5
                    SRC
                      ${SRC_FILES}

--- a/qt/widgets/common/CMakeLists.txt
+++ b/qt/widgets/common/CMakeLists.txt
@@ -1022,30 +1022,6 @@ set(
   ${CMAKE_CURRENT_LIST_DIR}/test/WidgetsCommonTestInitialization.h
 )
 
-mtd_add_qt_tests(
-  TARGET_NAME MantidQtWidgetsCommonTest
-  QT_VERSION 4
-  SRC ${TEST_FILES}
-  INCLUDE_DIRS
-    ../../../Framework/TestHelpers/inc
-    ../../../Framework/DataObjects/inc
-    ../../../Framework/Crystal/inc
-
-  TEST_HELPER_SRCS
-    ../../../Framework/TestHelpers/src/TearDownWorld.cpp
-    ../../../Framework/TestHelpers/src/ComponentCreationHelper.cpp
-    ../../../Framework/TestHelpers/src/DataProcessorTestHelper.cpp
-    ../../../Framework/TestHelpers/src/InstrumentCreationHelper.cpp
-    ../../../Framework/TestHelpers/src/WorkspaceCreationHelper.cpp
-    ../../../Framework/TestHelpers/src/MDEventsTestHelper.cpp
-  LINK_LIBS
-    ${TARGET_LIBRARIES}
-    DataObjects
-    gmock
-  MTD_QT_LINK_LIBS MantidQtWidgetsCommon
-  PARENT_DEPENDENCIES GUITests
-)
-
 set(
   QT5_TEST_FILES
   test/AddWorkspaceDialogTest.h

--- a/qt/widgets/instrumentview/CMakeLists.txt
+++ b/qt/widgets/instrumentview/CMakeLists.txt
@@ -153,6 +153,8 @@ set(
 
 set(UI_FILES inc/MantidQtWidgets/InstrumentView/UCorrectionDialog.ui)
 
+# Target
+mtd_add_qt_library(TARGET_NAME MantidQtWidgetsInstrumentView
                    QT_VERSION 5
                    SRC
                      ${SRC_FILES}

--- a/qt/widgets/instrumentview/CMakeLists.txt
+++ b/qt/widgets/instrumentview/CMakeLists.txt
@@ -153,8 +153,6 @@ set(
 
 set(UI_FILES inc/MantidQtWidgets/InstrumentView/UCorrectionDialog.ui)
 
-# Target
-mtd_add_qt_library(TARGET_NAME MantidQtWidgetsInstrumentView
                    QT_VERSION 5
                    SRC
                      ${SRC_FILES}


### PR DESCRIPTION
**Description of work.**

Clears down some of the legacy Qt4 stuff, as there's been a number of times I've changed the Qt4 target instead of Qt5 by accident, then spent a significant amount of time wondering why nothing works.

- Removes Qt4 blocks from `mtd_add_target`
- Removes Qt 4 CMake targets from interfaces with a Qt 5 equivalent
- Interfaces with Qt 4 only implementations were *not* affected, these can be removed during maintenance because of the increased risk

**To test:**
- Check tests pass
- Open some affected interfaces, e.g. Instrument View or ISIS Reflectometry. If there are issues these will fail to either compile or load the dynamic lib, so no additional testing is required.

Part of #30268 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
