### PR TITLE
Clang: Fix race-y Poco startup with logger usage

### DIFF
--- a/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitAnalysisTab.cpp
@@ -22,13 +22,13 @@
 #include <algorithm>
 #include <utility>
 
-/// Logger
-Mantid::Kernel::Logger g_log("IndirectFitAnalysisTab");
-
 using namespace Mantid::API;
 using namespace MantidQt::MantidWidgets;
 
 namespace {
+/// Logger
+Mantid::Kernel::Logger g_log("IndirectFitAnalysisTab");
+
 bool doesExistInADS(std::string const &workspaceName) {
   return AnalysisDataService::Instance().doesExist(workspaceName);
 }


### PR DESCRIPTION

**Description of work.**
Fixes IndirectFitAnalysisTab racing Poco during startup, where the Poco
lib may not be loaded in before we create a logger, as it's in the global namespace.

This was seen using Clang and GDB, so would not appear in "normal" GCC
builds

**To test:**
Using Linux clang (not OSX):
- Run CMake with new clang version, e.g. `CC=clang CXX=clang++ cmake <mantid_path> -DCMAKE_BUILD_TYPE=Debug`
- Build workbench
- Launch workbench
<!-- Instructions for testing. -->

*There is no associated issue. - Fixed tooling whilst trying to debug undefined behaviour* 

*This does not require release notes* because it's an obscure developer only change

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
