### PR TITLE
Fix a bug in maxpooling logic (Colorfill and sliceviewer)

### DIFF
--- a/Framework/PythonInterface/mantid/plots/datafunctions.py
+++ b/Framework/PythonInterface/mantid/plots/datafunctions.py
@@ -556,9 +556,15 @@ def _workspace_indices_maxpooling(y_bins, workspace):
     workspace_indices = []
     for y_range in pairwise(y_bins):
         try:
-            workspace_range = range(workspace.getAxis(1).indexOfValue(np.math.floor(y_range[0])),
-                                    workspace.getAxis(1).indexOfValue(np.math.ceil(y_range[1])))
-            workspace_index = workspace_range[np.argmax(summed_spectra[workspace_range])]
+            workspace_range = [workspace.getAxis(1).indexOfValue(y_range[0]),
+                               workspace.getAxis(1).indexOfValue(y_range[1])]
+            # if the range doesn't span more than one spectra just grab the first element
+            # else we need to pick the spectra which has the highest intensity
+            if np.diff(workspace_range)[0] > 1:
+                workspace_range = range(workspace_range[0], workspace_range[1])
+                workspace_index = workspace_range[np.argmax(summed_spectra[workspace_range])]
+            else:
+                workspace_index = workspace_range[0]
             workspace_indices.append(workspace_index)
         except IndexError:
             workspace_indices.append(-1)

--- a/docs/source/release/v6.2.0/mantidworkbench.rst
+++ b/docs/source/release/v6.2.0/mantidworkbench.rst
@@ -37,5 +37,6 @@ Bugfixes
 - Added missing icon for the uninstaller in Windows "Apps & features" list.
 - Fixed a bug where output workspaces of different types would interfere with successive calls to binary operations, such as multiply.
 - Fixed JSON serialization issue of MantidAxType by explicitly extracting its value
+- Fixed a bug in colorfill plots which lead to the loss of a spectrum from the resulting image.
 
 :ref:`Release 6.2.0 <v6.2.0>`


### PR DESCRIPTION
**Description of work.**

Fixes a bug in the maxpooling logic used for colorfill and sliceviewer images. This caused it to lose the first 0.5 and last 0.5 bins of the image, which meant the image was shifted up wrongly. 

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**
Run this script to produce a pcolormesh and compare with sliceviewer and a colorfill, they should be the same. 
```
from mantid.simpleapi import *
import matplotlib.pyplot as plt
import numpy as np
from mantid import plots
 
x=np.arange(100)
xs=np.zeros((6,100))
ys=np.zeros((6,99))
es=ys*0
for i in range(6):
    xs[i]=x
    ys[i]=np.sin(x[:-1]+i)
ws=CreateWorkspace(xs,ys,es,6)
 
fig, ax =plt.subplots(subplot_kw={'projection':'mantid'})
ax.pcolormesh(ws)
fig.show()
```
Check maxpooling still works - Load MAR27283.nxs and check you can see the high counting spectra around 780
<!-- Instructions for testing. -->

Fixes #32040 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
