### PR TITLE
Expose IPeak getCol getRow to python

### DIFF
--- a/Framework/DataObjects/inc/MantidDataObjects/LeanElasticPeak.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/LeanElasticPeak.h
@@ -57,6 +57,9 @@ public:
 
   std::shared_ptr<const Geometry::ReferenceFrame> getReferenceFrame() const override;
 
+  int getCol() const override;
+  int getRow() const override;
+
   Mantid::Kernel::V3D getQLabFrame() const override;
   Mantid::Kernel::V3D getQSampleFrame() const override;
 

--- a/Framework/DataObjects/inc/MantidDataObjects/Peak.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/Peak.h
@@ -82,10 +82,10 @@ public:
   Geometry::Instrument_const_sptr getInstrument() const;
   std::shared_ptr<const Geometry::ReferenceFrame> getReferenceFrame() const override;
 
-  int getCol() const;
+  int getCol() const override;
   void setCol(int col);
 
-  int getRow() const;
+  int getRow() const override;
   void setRow(int row);
 
   std::string getBankName() const;

--- a/Framework/DataObjects/src/LeanElasticPeak.cpp
+++ b/Framework/DataObjects/src/LeanElasticPeak.cpp
@@ -115,6 +115,16 @@ double LeanElasticPeak::getTOF() const {
   throw Exception::NotImplementedError("LeanElasticPeak::getTOF(): no detector infomation in LeanElasticPeak");
 }
 
+/// returns the row (y) of the pixel of the detector, throws NotImplementedError for LeanElasticPeak
+int LeanElasticPeak::getRow() const {
+  throw Exception::NotImplementedError("LeanElasticPeak::getRow(): no detector infomation in LeanElasticPeak");
+}
+
+/// returns the column (x) of the pixel of the detector, throws NotImplementedError for LeanElasticPeak
+int LeanElasticPeak::getCol() const {
+  throw Exception::NotImplementedError("LeanElasticPeak::getCol(): no detector infomation in LeanElasticPeak");
+}
+
 // -------------------------------------------------------------------------------------
 /** Calculate the scattering angle of the peak  */
 double LeanElasticPeak::getScattering() const { return asin(getWavelength() / (2 * getDSpacing())) * 2; }

--- a/Framework/DataObjects/test/LeanElasticPeakTest.h
+++ b/Framework/DataObjects/test/LeanElasticPeakTest.h
@@ -39,6 +39,8 @@ public:
     TS_ASSERT_THROWS(p.getTOF(), const Exception::NotImplementedError &)
     TS_ASSERT_EQUALS(p.getScattering(), 0.)
     TS_ASSERT_EQUALS(p.getAzimuthal(), -M_PI)
+    TS_ASSERT_THROWS(p.getRow(), const Exception::NotImplementedError &)
+    TS_ASSERT_THROWS(p.getCol(), const Exception::NotImplementedError &)
     TS_ASSERT_THROWS(p.getL1(), const Exception::NotImplementedError &)
     TS_ASSERT_THROWS(p.getL2(), const Exception::NotImplementedError &)
   }

--- a/Framework/Geometry/inc/MantidGeometry/Crystal/IPeak.h
+++ b/Framework/Geometry/inc/MantidGeometry/Crystal/IPeak.h
@@ -86,6 +86,9 @@ public:
   virtual Mantid::Kernel::Matrix<double> getGoniometerMatrix() const = 0;
   virtual void setGoniometerMatrix(const Mantid::Kernel::Matrix<double> &m_GoniometerMatrix) = 0;
 
+  virtual int getRow() const = 0;
+  virtual int getCol() const = 0;
+
   virtual double getL1() const = 0;
   virtual double getL2() const = 0;
 

--- a/Framework/PythonInterface/mantid/api/src/Exports/IPeak.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/IPeak.cpp
@@ -165,6 +165,14 @@ void export_IPeak() {
       .def("setGoniometerMatrix", &setGoniometerMatrix, (arg("self"), arg("goniometerMatrix")),
            "Set the :class:`~mantid.geometry.Goniometer` rotation matrix of "
            "this peak.")
+      .def("getRow", &IPeak::getRow, arg("self"),
+           "For :class:`~mantid.geometry.RectangularDetector` s only, returns "
+           "the row (y) of the pixel of the "
+           "detector.")
+      .def("getCol", &IPeak::getCol, arg("self"),
+           "For :class:`~mantid.geometry.RectangularDetector` s only, returns "
+           "the column (x) of the pixel of the "
+           ":class:`~mantid.geometry.Detector`.")
       .def("getL1", &IPeak::getL1, arg("self"),
            "Return the L1 flight path length (source to "
            ":class:`~mantid.api.Sample`), in meters. ")

--- a/Framework/PythonInterface/test/python/mantid/geometry/IPeakTest.py
+++ b/Framework/PythonInterface/test/python/mantid/geometry/IPeakTest.py
@@ -147,6 +147,11 @@ class IPeakTest(unittest.TestCase):
         self._peak.setBinCount(bin_count)
         self.assertAlmostEqual(self._peak.getBinCount(), bin_count)
 
+    def test_get_row_and_column(self):
+        row, col = 0, 0  # this is the very first detector
+        self.assertEqual(self._peak.getRow(), row)
+        self.assertEqual(self._peak.getCol(), col)
+
     def test_get_l1(self):
         expected_l1 = 8.3
         self.assertEqual(self._peak.getL1(), expected_l1)

--- a/docs/source/release/v6.2.0/diffraction.rst
+++ b/docs/source/release/v6.2.0/diffraction.rst
@@ -41,6 +41,7 @@ New features
 - New algorithm :ref:`ApplyInstrumentToPeaks <algm-ApplyInstrumentToPeaks>` to update the instrument of peaks within a PeaksWorkspace.
 - New plotting script that provides diagnostic plots of SCDCalibratePanels output.
 - New plotting script that provides diagnositc plots of SCDCalibratePanels2 on a per panel/bank basis.
+- Exposed :meth:`mantid.api.IPeak.getCol` and :meth:`mantid.api.IPeak.getRow` to python
 - Added two integration methods to :ref:`HB3AIntegrateDetectorPeaks <algm-HB3AIntegrateDetectorPeaks>` for simple cuboid integration with and without fitted background.
 - New algorithm :ref:`ConvertPeaksWorkspace <algm-ConvertPeaksWorkspace>` for quick conversion between PeaksWorkspace and LeanElasticPeaksWorkspace.
 


### PR DESCRIPTION
**Description of work.**

This was removed as part of #31042 We are adding this back in as requested. This means we need to implement this for LeanElasticPeak as well, so we will just throw NotImplementedError in that case.

[SCD375](https://code.ornl.gov/sns-hfir-scse/diffraction/single-crystal/single-crystal-diffraction/-/issues/375)

**To test:**

```python
ws=LoadIsawPeaks("TOPAZ_3007.peaks")
ws.getPeak(0).getRow()
ws.getPeak(0).getCol()
```

*There is no associated issue.*

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
