### PR TITLE
Fix PythonInterfaces systemtest

### DIFF
--- a/scripts/Muon/GUI/FrequencyDomainAnalysis/frequency_domain_analysis.py
+++ b/scripts/Muon/GUI/FrequencyDomainAnalysis/frequency_domain_analysis.py
@@ -422,6 +422,5 @@ class FrequencyAnalysisGui(QtWidgets.QMainWindow):
     def closeEvent(self, event):
         self.tabs.closeEvent(event)
         self.context.ads_observer.unsubscribe()
-        self.context.ads_observer = None
         self.grouping_tab_widget.group_tab_presenter.closePeriodInfoWidget()
         super(FrequencyAnalysisGui, self).closeEvent(event)

--- a/scripts/Muon/GUI/MuonAnalysis/muon_analysis_2.py
+++ b/scripts/Muon/GUI/MuonAnalysis/muon_analysis_2.py
@@ -487,6 +487,5 @@ class MuonAnalysisGui(QtWidgets.QMainWindow):
         self.removeDockWidget(self.dockable_plot_widget_window)
         self.tabs.closeEvent(event)
         self.context.ads_observer.unsubscribe()
-        self.context.ads_observer = None
         self.grouping_tab_widget.group_tab_presenter.closePeriodInfoWidget()
         super(MuonAnalysisGui, self).closeEvent(event)


### PR DESCRIPTION
**Description of work.**
Fixes the python interfaces unit test which was segfaulting. It segfaulted if the Muon analysis GUI was opened up after the FDA GUI. Probably some lifetime issue, which appears to be fixede if we avoid none'ing the context explictly. 

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**
PythonInterfaces system test passes
Builds pass

<!-- Instructions for testing. -->


*There is no associated issue.*



Developer change, no release notes.


<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
