### PR TITLE
Added release note for vesuvio parallelisation

### DIFF
--- a/docs/source/release/v6.2.0/indirect_geometry.rst
+++ b/docs/source/release/v6.2.0/indirect_geometry.rst
@@ -35,5 +35,6 @@ Improvements
 
 - Single input has been removed from the Indirect Data Analysis Fit tabs. All data input is now done via the multiple input dialog.
 - The data input widgets in the Indirect Data Analysis fit tabs has been made dockable and can be resized once undocked.
+- Introduced multithreading for detectors/spectra to VesuvioCalculateMS in order to speed up the VesuvioAnalysis algorithm.
 
 :ref:`Release 6.2.0 <v6.2.0>`


### PR DESCRIPTION
**Description of work.**

Added missing release note for vesuvio parallelisation for Mantid release 6.2.

**To test:**
Release note update, therefore no test required. 

Fixes #[31706.](https://github.com/mantidproject/mantid/issues/31706) 

*This does not require release notes* because **the change is adding a release note**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
