### PR TITLE
Fix problem loading calibration on Windows in engineering UI

### DIFF
--- a/scripts/Engineering/gui/engineering_diffraction/tabs/calibration/model.py
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/calibration/model.py
@@ -314,7 +314,7 @@ class CalibrationModel(object):
     @staticmethod
     def get_info_from_file(file_path):
         # TODO: Find a way to reliably get the instrument from the file without using the filename.
-        instrument = file_path.split("/")[-1].split("_", 1)[0]
+        instrument = path.split(file_path)[-1].split("_", 1)[0]
         # Get run numbers from file.
         run_numbers = ""
         params_table = []


### PR DESCRIPTION
**Description of work.**

Fixes crash when trying to load the last calibration on Windows. See linked issue for screenshot of crash.  Problem was caused by code which assumed path separator was a forward "/" slash

Problem exposed by the work done on PR #31999 where the last generated calibration is populated into the "Load Existing Calibration" edit box. If a user ignores this default and finds a prm file using the Browse button it results in paths containing forward slashes which are OK

**To test:**

Requires access to ISIS data archive:

Open the engineering diffraction UI from the Interfaces menu in Workbench
Go to the Calibration tab
Create a new calibration: Vanadium 236516, Calibration Sample: 193749, then press Calibrate
Close down and reopen the UI
The Load Existing Calibration edit box should be populated. Note on Windows the path separator is "\"
Select the Load Existing Calibration radio button and click Load
The calibration should load without an error

Fixes #32128.

*This does not require release notes* because **it fixes a bug created during the current release cycle**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
