### PR TITLE
Prevent crash in PyChop when no Ei specified

### DIFF
--- a/docs/source/release/v6.2.0/direct_geometry.rst
+++ b/docs/source/release/v6.2.0/direct_geometry.rst
@@ -35,5 +35,6 @@ BugFixes
 - Peaks are (re)set upon rebuilding the single spectrum function as a multi-spectrum function
   due to the physical properties. This re-setting peaks is needed to maintain the intended ties.
 - A bug has been fixed in :ref:`ConvertToMD <algm-ConvertToMD>` that sometimes crashes Mantid when files are summed together.
+- A bug has been fixed in PyChop that caused crashes when no Ei was specified.
 
 :ref:`Release 6.2.0 <v6.2.0>`

--- a/scripts/PyChop/PyChopGui.py
+++ b/scripts/PyChop/PyChopGui.py
@@ -213,11 +213,11 @@ class PyChopGui(QMainWindow):
         """
         try:
             eitxt = float(self.widgets['EiEdit']['Edit'].text())
-            self.engine.setEi(eitxt)
-            if self.eiPlots.isChecked():
-                self.calc_callback()
         except ValueError:
             raise ValueError('No Ei specified, or Ei string not understood')
+        self.engine.setEi(eitxt)
+        if self.eiPlots.isChecked():
+            self.calc_callback()
 
     def setS2(self):
         """
@@ -254,8 +254,9 @@ class PyChopGui(QMainWindow):
                 self.update_script()
         except ValueError as err:
             self.errormessage(err)
-        self.plot_flux_ei()
-        self.plot_flux_hz()
+        else:
+            self.plot_flux_ei()
+            self.plot_flux_hz()
 
     def calculate(self):
         """

--- a/scripts/test/PyChopTest.py
+++ b/scripts/test/PyChopTest.py
@@ -266,6 +266,16 @@ class PyChopGuiTests(unittest.TestCase):
             self.window.calc_callback()
             setS2.assert_called()
 
+    def test_plot_flux_ei(self):
+        # Tests that Hyspec routines are only called when the instrument is Hyspec
+        with patch.object(self.window, 'plot_flux_ei') as plot_flux_ei:
+            self.window.widgets['EiEdit']['Edit'].text = mock.MagicMock(return_value='')
+            self.window.calc_callback()
+            plot_flux_ei.assert_not_called()
+            self.window.widgets['EiEdit']['Edit'].text = mock.MagicMock(return_value=120)
+            self.window.calc_callback()
+            plot_flux_ei.assert_called()
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
**Description of work.**

Slightly modified the exception for Ei not specified to prevent crash after clicking Ok on the pop up error message.

**To test:**

Follow the steps to reproduce the error descripted in https://github.com/mantidproject/mantid/issues/28380 and check that Mantid does not crash anymore.

Fixes #[28380](https://github.com/mantidproject/mantid/issues/28380). 


<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
