### PR TITLE
Seperated periodic table functionality from elemental analysis widget

### DIFF
--- a/docs/source/release/v6.2.0/muon.rst
+++ b/docs/source/release/v6.2.0/muon.rst
@@ -63,6 +63,7 @@ Elemental Analysis
 Improvements
 ############
 - Updated :ref:`LoadElementalAnalysisData <algm-LoadElementalAnalysisData>` algorithm to include Poisson errors for the counts data.
+- The periodic table has been updated for better stability.
 
 Algorithms
 ----------

--- a/scripts/Muon/GUI/ElementalAnalysis/elemental_analysis.py
+++ b/scripts/Muon/GUI/ElementalAnalysis/elemental_analysis.py
@@ -6,7 +6,6 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 from copy import deepcopy
 
-import matplotlib as mpl
 from qtpy import QtWidgets
 
 import mantid.simpleapi as mantid
@@ -22,37 +21,17 @@ from Muon.GUI.ElementalAnalysis.LoadWidget.load_utils import spectrum_index
 from Muon.GUI.ElementalAnalysis.Peaks.peaks_view import PeaksView
 from Muon.GUI.ElementalAnalysis.PeriodicTable.periodic_table_view import PeriodicTableView
 from Muon.GUI.ElementalAnalysis.periodic_table_widget_presenter import PeriodicTableWidgetPresenter
-
-offset = 0.9
-
-
-def is_string(value):
-    if isinstance(value, str):
-        return True
-
-    return False
-
-
-def gen_name(element, name):
-    msg = None
-    if not is_string(element):
-        msg = "'{}' expected element to be 'str', found '{}' instead".format(
-            str(element), type(element))
-    if not is_string(name):
-        msg = "'{}' expected name to be 'str', found '{}' instead".format(str(name), type(name))
-
-    if msg is not None:
-        raise TypeError(msg)
-
-    if element in name:
-        return name
-    return element + " " + name
+from Muon.GUI.Common import message_box
 
 
 class ElementalAnalysisGui(QtWidgets.QMainWindow):
     BLUE = 'C0'
     ORANGE = 'C1'
     GREEN = 'C2'
+
+    @staticmethod
+    def warning_popup(message):
+        message_box.warning(message)
 
     def __init__(self, parent=None, window_flags=None):
         super(ElementalAnalysisGui, self).__init__(parent)
@@ -72,8 +51,6 @@ class ElementalAnalysisGui(QtWidgets.QMainWindow):
         # plotting
         self._plot_window = None
         self._plotting = None
-        self.num_colors = len(mpl.rcParams['axes.prop_cycle'])
-        self.used_colors = {}
 
         # setup periodic table and peaks
         self.ptable_view = PeriodicTableView()
@@ -131,33 +108,6 @@ class ElementalAnalysisGui(QtWidgets.QMainWindow):
     def plotting(self, plotting):
         self._plotting = plotting
         self.ptable.plotting = plotting
-
-    def get_color(self, element):
-        """
-        When requesting the colour for a new element, return the first unused colour of the matplotlib
-        default colour cycle (i.e. mpl.rcParams['axes.prop_cycle']).
-        If all colours are used, return the first among the least used ones.
-        That is if C0-4 are all used twice and C5-9 are used once, C5 will be returned.
-
-        When requesting the colour for an element that is already plotted return the colour of that element.
-        This prevents the same element from being displayed in different colours in separate plots
-
-        :param element: Chemical symbol of the element that one wants the colour of
-        :return: Matplotlib colour string: C0, C1, ..., C9 to be used as plt.plot(..., color='C3')
-        """
-        if element in self.used_colors:
-            return self.used_colors[element]
-
-        occurrences = [
-            list(self.used_colors.values()).count('C{}'.format(i)) for i in range(self.num_colors)
-        ]
-
-        color_index = occurrences.index(min(occurrences))
-
-        color = "C{}".format(color_index)
-        self.used_colors[element] = color
-
-        return color
 
     def closeEvent(self, event):
         if self.plot_window is not None:

--- a/scripts/Muon/GUI/ElementalAnalysis/elemental_analysis.py
+++ b/scripts/Muon/GUI/ElementalAnalysis/elemental_analysis.py
@@ -18,9 +18,8 @@ from Muon.GUI.ElementalAnalysis.LineSelector.LineSelectorPresenter import LineSe
 from Muon.GUI.ElementalAnalysis.LineSelector.LineSelectorView import LineSelectorView
 from Muon.GUI.ElementalAnalysis.LoadWidget.load_model import LoadModel, CoLoadModel
 from Muon.GUI.ElementalAnalysis.LoadWidget.load_utils import spectrum_index
-from Muon.GUI.ElementalAnalysis.Peaks.peaks_view import PeaksView
-from Muon.GUI.ElementalAnalysis.PeriodicTable.periodic_table_view import PeriodicTableView
 from Muon.GUI.ElementalAnalysis.periodic_table_widget_presenter import PeriodicTableWidgetPresenter
+from Muon.GUI.ElementalAnalysis.periodic_table_widget_view import PeriodicTableWidgetView
 from Muon.GUI.Common import message_box
 
 
@@ -53,9 +52,8 @@ class ElementalAnalysisGui(QtWidgets.QMainWindow):
         self._plotting = None
 
         # setup periodic table and peaks
-        self.ptable_view = PeriodicTableView()
-        self.peaks_view = PeaksView()
-        self.ptable = PeriodicTableWidgetPresenter(self)
+        self.ptable_view = PeriodicTableWidgetView(self)
+        self.ptable = PeriodicTableWidgetPresenter(self.ptable_view)
 
         # set menu
         self.menu = self.menuBar()
@@ -76,16 +74,13 @@ class ElementalAnalysisGui(QtWidgets.QMainWindow):
         self.lines.delayed.on_checkbox_unchecked(self.line_delayed_changed)
 
         # set up
-        self.widget_list = QtWidgets.QVBoxLayout()
-        self.widget_list.addWidget(self.peaks_view)
-        self.widget_list.addWidget(self.lines.view)
-        self.widget_list.addWidget(self.detectors.view)
-        self.widget_list.addWidget(self.load_widget.view)
+        self.ptable_view.add_widget_to_view(self.lines.view)
+        self.ptable_view.add_widget_to_view(self.detectors.view)
+        self.ptable_view.add_widget_to_view(self.load_widget.view)
 
         # layout
         self.box = QtWidgets.QHBoxLayout()
         self.box.addWidget(self.ptable_view)
-        self.box.addLayout(self.widget_list)
 
         self.setCentralWidget(QtWidgets.QWidget(self))
         self.centralWidget().setLayout(self.box)

--- a/scripts/Muon/GUI/ElementalAnalysis/elemental_analysis.py
+++ b/scripts/Muon/GUI/ElementalAnalysis/elemental_analysis.py
@@ -4,37 +4,24 @@
 #   NScD Oak Ridge National Laboratory, European Spallation Source,
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
-from qtpy import QtWidgets
 from copy import deepcopy
+
 import matplotlib as mpl
-
-from Muon.GUI.ElementalAnalysis.PeriodicTable.periodic_table_presenter import PeriodicTablePresenter
-from Muon.GUI.ElementalAnalysis.PeriodicTable.periodic_table_view import PeriodicTableView
-from Muon.GUI.ElementalAnalysis.PeriodicTable.periodic_table_model import PeriodicTableModel
-
-from MultiPlotting.multi_plotting_widget import MultiPlotWindow
-from MultiPlotting.label import Label
-
-from Muon.GUI.ElementalAnalysis.LoadWidget.load_model import LoadModel, CoLoadModel
-from Muon.GUI.ElementalAnalysis.LoadWidget.load_utils import spectrum_index
-
-from Muon.GUI.Common.load_widget.load_view import LoadView
-from Muon.GUI.Common.load_widget.load_presenter import LoadPresenter
-
-from Muon.GUI.ElementalAnalysis.Detectors.detectors_presenter import DetectorsPresenter
-from Muon.GUI.ElementalAnalysis.Detectors.detectors_view import DetectorsView
-from Muon.GUI.ElementalAnalysis.Peaks.peaks_presenter import PeaksPresenter
-from Muon.GUI.ElementalAnalysis.Peaks.peaks_view import PeaksView
-
-from Muon.GUI.ElementalAnalysis.PeriodicTable.PeakSelector.peak_selector_presenter import PeakSelectorPresenter
-from Muon.GUI.ElementalAnalysis.PeriodicTable.PeakSelector.peak_selector_view import PeakSelectorView
-
-from Muon.GUI.ElementalAnalysis.LineSelector.LineSelectorPresenter import LineSelectorPresenter
-from Muon.GUI.ElementalAnalysis.LineSelector.LineSelectorView import LineSelectorView
-
-from Muon.GUI.Common import message_box
+from qtpy import QtWidgets
 
 import mantid.simpleapi as mantid
+from MultiPlotting.multi_plotting_widget import MultiPlotWindow
+from Muon.GUI.Common.load_widget.load_presenter import LoadPresenter
+from Muon.GUI.Common.load_widget.load_view import LoadView
+from Muon.GUI.ElementalAnalysis.Detectors.detectors_presenter import DetectorsPresenter
+from Muon.GUI.ElementalAnalysis.Detectors.detectors_view import DetectorsView
+from Muon.GUI.ElementalAnalysis.LineSelector.LineSelectorPresenter import LineSelectorPresenter
+from Muon.GUI.ElementalAnalysis.LineSelector.LineSelectorView import LineSelectorView
+from Muon.GUI.ElementalAnalysis.LoadWidget.load_model import LoadModel, CoLoadModel
+from Muon.GUI.ElementalAnalysis.LoadWidget.load_utils import spectrum_index
+from Muon.GUI.ElementalAnalysis.Peaks.peaks_view import PeaksView
+from Muon.GUI.ElementalAnalysis.PeriodicTable.periodic_table_view import PeriodicTableView
+from Muon.GUI.ElementalAnalysis.periodic_table_widget_presenter import PeriodicTableWidgetPresenter
 
 offset = 0.9
 
@@ -71,18 +58,6 @@ class ElementalAnalysisGui(QtWidgets.QMainWindow):
         super(ElementalAnalysisGui, self).__init__(parent)
         if window_flags:
             self.setWindowFlags(window_flags)
-        # set menu
-        self.menu = self.menuBar()
-        self.menu.addAction("File")
-        edit_menu = self.menu.addMenu("Edit")
-        edit_menu.addAction("Change Peak Data file", self.select_data_file)
-        self.menu.addAction("Binning")
-        self.menu.addAction("Normalise")
-
-        # periodic table stuff
-        self.ptable = PeriodicTablePresenter(PeriodicTableView(), PeriodicTableModel())
-        self.ptable.register_table_lclicked(self.table_left_clicked)
-        self.ptable.register_table_rclicked(self.table_right_clicked)
 
         # load stuff
         self.load_widget = LoadPresenter(LoadView(), LoadModel(), CoLoadModel())
@@ -94,18 +69,24 @@ class ElementalAnalysisGui(QtWidgets.QMainWindow):
             detector.on_checkbox_checked(self.add_plot)
             detector.on_checkbox_unchecked(self.del_plot)
 
-        # peaks boxes
-        self.peaks = PeaksPresenter(PeaksView())
-        self.peaks.major.setChecked(True)
-        self.peaks.major.on_checkbox_checked(self.major_peaks_changed)
-        self.peaks.major.on_checkbox_unchecked(self.major_peaks_changed)
-        self.peaks.minor.on_checkbox_checked(self.minor_peaks_changed)
-        self.peaks.minor.on_checkbox_unchecked(self.minor_peaks_changed)
-        self.peaks.gamma.on_checkbox_checked(self.gammas_changed)
-        self.peaks.gamma.on_checkbox_unchecked(self.gammas_changed)
-        self.peaks.electron.on_checkbox_checked(self.electrons_changed)
-        self.peaks.electron.on_checkbox_unchecked(self.electrons_changed)
-        self.peaks.set_deselect_elements_slot(self.deselect_elements)
+        # plotting
+        self._plot_window = None
+        self._plotting = None
+        self.num_colors = len(mpl.rcParams['axes.prop_cycle'])
+        self.used_colors = {}
+
+        # setup periodic table and peaks
+        self.ptable_view = PeriodicTableView()
+        self.peaks_view = PeaksView()
+        self.ptable = PeriodicTableWidgetPresenter(self)
+
+        # set menu
+        self.menu = self.menuBar()
+        self.menu.addAction("File")
+        edit_menu = self.menu.addMenu("Edit")
+        edit_menu.addAction("Change Peak Data file", self.ptable.select_data_file)
+        self.menu.addAction("Binning")
+        self.menu.addAction("Normalise")
 
         # Line type boxes
         self.lines = LineSelectorPresenter(LineSelectorView())
@@ -119,29 +100,37 @@ class ElementalAnalysisGui(QtWidgets.QMainWindow):
 
         # set up
         self.widget_list = QtWidgets.QVBoxLayout()
-        self.widget_list.addWidget(self.peaks.view)
+        self.widget_list.addWidget(self.peaks_view)
         self.widget_list.addWidget(self.lines.view)
         self.widget_list.addWidget(self.detectors.view)
         self.widget_list.addWidget(self.load_widget.view)
 
-        # plotting
-        self.plot_window = None
-        self.num_colors = len(mpl.rcParams['axes.prop_cycle'])
-        self.used_colors = {}
-
         # layout
         self.box = QtWidgets.QHBoxLayout()
-        self.box.addWidget(self.ptable.view)
+        self.box.addWidget(self.ptable_view)
         self.box.addLayout(self.widget_list)
 
         self.setCentralWidget(QtWidgets.QWidget(self))
         self.centralWidget().setLayout(self.box)
         self.setWindowTitle("Elemental Analysis")
 
-        self.element_widgets = {}
-        self.element_lines = {}
-        self.electron_peaks = {}
-        self._generate_element_widgets()
+    @property
+    def plot_window(self):
+        return self._plot_window
+
+    @plot_window.setter
+    def plot_window(self, plot_window):
+        self._plot_window = plot_window
+        self.ptable.plot_window = plot_window
+
+    @property
+    def plotting(self):
+        return self._plotting
+
+    @plotting.setter
+    def plotting(self, plotting):
+        self._plotting = plotting
+        self.ptable.plotting = plotting
 
     def get_color(self, element):
         """
@@ -174,93 +163,6 @@ class ElementalAnalysisGui(QtWidgets.QMainWindow):
         if self.plot_window is not None:
             self.plot_window.closeEvent(event)
         super(ElementalAnalysisGui, self).closeEvent(event)
-
-    # general functions
-
-    def _gen_label(self, name, x_value_in, element=None):
-        if element is None:
-            return
-        # check x value is a float
-        try:
-            x_value = float(x_value_in)
-        except:
-            return
-        if name not in self.element_lines[element]:
-            self.element_lines[element].append(name)
-        # make sure the names are strings and x values are numbers
-        return Label(str(name), x_value, False, offset, True, rotation=-90, protected=True)
-
-    def _plot_line(self, name, x_value_in, color, element=None):
-        label = self._gen_label(name, x_value_in, element)
-        if self.plot_window is None:
-            return
-        for subplot in self.plotting.get_subplots():
-            self._plot_line_once(subplot, x_value_in, label, color)
-
-    def _plot_line_once(self, subplot, x_value, label, color):
-        self.plotting.add_vline_and_annotate(subplot, x_value, label, color)
-
-    def _rm_line(self, name):
-        if self.plot_window is None:
-            return
-        for subplot in self.plotting.get_subplots():
-            self.plotting.rm_vline_and_annotate(subplot, name)
-
-    # setup element pop up
-    def _generate_element_widgets(self):
-        self.element_widgets = {}
-        for element in self.ptable.peak_data:
-            data = self.ptable.element_data(element)
-            widget = PeakSelectorPresenter(PeakSelectorView(data, element))
-            widget.on_finished(self._update_peak_data)
-            self.element_widgets[element] = widget
-
-    # interact with periodic table
-    def table_right_clicked(self, item):
-        self.element_widgets[item.symbol].view.show()
-
-    def table_left_clicked(self, item):
-        if self.ptable.is_selected(item.symbol):
-            self._add_element_lines(item.symbol)
-        else:
-            self._remove_element_lines(item.symbol)
-
-    def _add_element_lines(self, element, data=None):
-        if data is None:
-            data = self.element_widgets[element].get_checked()
-        if element not in self.element_lines:
-            self.element_lines[element] = []
-
-        # Select a different color, if all used then use the first
-        color = self.get_color(element)
-
-        for name, x_value in data.items():
-            try:
-                x_value = float(x_value)
-            except ValueError:
-                continue
-            full_name = gen_name(element, name)
-            if full_name not in self.element_lines[element]:
-                self.element_lines[element].append(full_name)
-            self._plot_line(full_name, x_value, color, element)
-
-    def _remove_element_lines(self, element):
-        if element not in self.element_lines:
-            return
-        names = deepcopy(self.element_lines[element])
-        for name in names:
-            try:
-                self.element_lines[element].remove(name)
-                self._rm_line(name)
-                if not self.element_lines[element]:
-                    del self.element_lines[element]
-                    if element in self.used_colors:
-                        del self.used_colors[element]
-            except:
-                continue
-
-        if element in self.element_lines and not self.element_lines[element]:
-            del self.element_lines[element]
 
     # loading
     def load_run(self, detector, run):
@@ -322,7 +224,7 @@ class ElementalAnalysisGui(QtWidgets.QMainWindow):
             self.plotting.plot(detector, ws.name(), spec_num=spectrum_index["Delayed"], color=self.GREEN)
 
         # add current selection of lines
-        for element in self.ptable.selection:
+        for element in self.ptable.ptable.selection:
             self.add_peak_data(element.symbol, detector)
 
     def _unset_detectors(self):
@@ -332,34 +234,13 @@ class ElementalAnalysisGui(QtWidgets.QMainWindow):
             self.detectors.setStateQuietly(name, False)
         self.uncheck_detectors_if_no_line_plotted()
 
-    # plotting
-    def add_peak_data(self, element, subplot, data=None):
-        # if already selected add to just new plot
-        if data is None:
-            data = self.element_widgets[element].get_checked()
-        color = self.get_color(element)
-        for name, x_value in data.items():
-            if isinstance(x_value, float):
-                full_name = gen_name(element, name)
-                label = self._gen_label(full_name, x_value, element)
-                self._plot_line_once(subplot, x_value, label, color)
-
-    def _update_peak_data(self, element):
-        if self.ptable.is_selected(element):
-            # remove all of the lines for the element
-            self._remove_element_lines(element)
-            # add the ticked lines to the plot
-            self._add_element_lines(element)
-        else:
-            self._remove_element_lines(element)
-
     def add_plot(self, checkbox):
         detector = checkbox.name
         last_run = self.load_widget.last_loaded_run()
         # not using load_last_run prevents two calls to last_loaded_run()
         if last_run is not None:
             self.load_run(detector, last_run)
-            self._update_checked_data()
+            self.ptable._update_checked_data()
 
     def del_plot(self, checkbox):
         if self.load_widget.last_loaded_run() is not None:
@@ -375,69 +256,6 @@ class ElementalAnalysisGui(QtWidgets.QMainWindow):
         if not self.plotting.get_subplots():
             self.plot_window.close()
             self.plot_window = None
-
-    # sets data file for periodic table
-    def select_data_file(self):
-        old_lines = deepcopy(list(self.element_lines.keys()))
-
-        filename = QtWidgets.QFileDialog.getOpenFileName()
-        if isinstance(filename, tuple):
-            filename = filename[0]
-        filename = str(filename)
-        if filename:
-            self.ptable.set_peak_datafile(filename)
-
-        try:
-            self._generate_element_widgets()
-        except ValueError:
-            message_box.warning(
-                'The file does not contain correctly formatted data, resetting to default data file.'
-                'See "https://docs.mantidproject.org/nightly/interfaces/'
-                'Muon%20Elemental%20Analysis.html" for more information.')
-            self.ptable.set_peak_datafile(None)
-            self._generate_element_widgets()
-
-        for element in old_lines:
-            if element in self.element_widgets.keys():
-                self.ptable.select_element(element)
-            else:
-                self._remove_element_lines(element)
-        self._update_checked_data()
-
-    def _update_checked_data(self):
-        self.major_peaks_changed(self.peaks.major)
-        self.minor_peaks_changed(self.peaks.minor)
-        self.gammas_changed(self.peaks.gamma)
-        self.electrons_changed(self.peaks.electron)
-
-    # general checked data
-    def checked_data(self, element, selection, state):
-        for checkbox in selection:
-            checkbox.setChecked(state)
-        self._update_peak_data(element)
-
-    def electrons_changed(self, electron_peaks):
-        for element, selector in self.element_widgets.items():
-            self.checked_data(element, selector.electron_checkboxes, electron_peaks.isChecked())
-
-    def gammas_changed(self, gamma_peaks):
-        for element, selector in self.element_widgets.items():
-            self.checked_data(element, selector.gamma_checkboxes, gamma_peaks.isChecked())
-
-    def major_peaks_changed(self, major_peaks):
-        for element, selector in self.element_widgets.items():
-            self.checked_data(element, selector.primary_checkboxes, major_peaks.isChecked())
-
-    def minor_peaks_changed(self, minor_peaks):
-        for element, selector in self.element_widgets.items():
-            self.checked_data(element, selector.secondary_checkboxes, minor_peaks.isChecked())
-
-    def deselect_elements(self):
-        self.peaks.disable_deselect_elements_btn()
-        for element in self.element_widgets.keys():
-            self.ptable.deselect_element(element)
-            self._remove_element_lines(element)
-        self.peaks.enable_deselect_elements_btn()
 
     def add_line_by_type(self, run, _type):
         # Ensure all detectors are enabled

--- a/scripts/Muon/GUI/ElementalAnalysis/elemental_analysis.py
+++ b/scripts/Muon/GUI/ElementalAnalysis/elemental_analysis.py
@@ -175,7 +175,7 @@ class ElementalAnalysisGui(QtWidgets.QMainWindow):
 
         # add current selection of lines
         for element in self.ptable.ptable.selection:
-            self.add_peak_data(element.symbol, detector)
+            self.ptable.add_peak_data(element.symbol, detector)
 
     def _unset_detectors(self):
         self.plot_window.windowClosedSignal.disconnect()

--- a/scripts/Muon/GUI/ElementalAnalysis/periodic_table_widget_presenter.py
+++ b/scripts/Muon/GUI/ElementalAnalysis/periodic_table_widget_presenter.py
@@ -8,7 +8,6 @@ from Muon.GUI.ElementalAnalysis.PeriodicTable.periodic_table_model import Period
 from Muon.GUI.ElementalAnalysis.PeriodicTable.PeakSelector.peak_selector_presenter import PeakSelectorPresenter
 from Muon.GUI.ElementalAnalysis.PeriodicTable.PeakSelector.peak_selector_view import PeakSelectorView
 from Muon.GUI.ElementalAnalysis.Peaks.peaks_presenter import PeaksPresenter
-from Muon.GUI.Common import message_box
 
 offset = 0.9
 
@@ -236,9 +235,9 @@ class PeriodicTableWidgetPresenter(object):
         try:
             self._generate_element_widgets()
         except ValueError:
-            message_box.warning(
+            self.view.warning_popup(
                 'The file does not contain correctly formatted data, resetting to default data file.'
-                'See "https://docs.mantidproject.org/nightly/interfaces/'
+                'See "https://docs.mantidproject.org/nightly/interfaces/muon/'
                 'Muon%20Elemental%20Analysis.html" for more information.')
             self.ptable.set_peak_datafile(None)
             self._generate_element_widgets()
@@ -249,3 +248,14 @@ class PeriodicTableWidgetPresenter(object):
             else:
                 self._remove_element_lines(element)
         self._update_checked_data()
+
+    def add_peak_data(self, element, subplot, data=None):
+        # if already selected add to just new plot
+        if data is None:
+            data = self.element_widgets[element].get_checked()
+        color = self.get_color(element)
+        for name, x_value in data.items():
+            if isinstance(x_value, float):
+                full_name = gen_name(element, name)
+                label = self._gen_label(full_name, x_value, element)
+                self._plot_line_once(subplot, x_value, label, color)

--- a/scripts/Muon/GUI/ElementalAnalysis/periodic_table_widget_presenter.py
+++ b/scripts/Muon/GUI/ElementalAnalysis/periodic_table_widget_presenter.py
@@ -1,0 +1,251 @@
+import matplotlib as mpl
+from qtpy.QtWidgets import QFileDialog
+from copy import deepcopy
+
+from MultiPlotting.label import Label
+from Muon.GUI.ElementalAnalysis.PeriodicTable.periodic_table_presenter import PeriodicTablePresenter
+from Muon.GUI.ElementalAnalysis.PeriodicTable.periodic_table_model import PeriodicTableModel
+from Muon.GUI.ElementalAnalysis.PeriodicTable.PeakSelector.peak_selector_presenter import PeakSelectorPresenter
+from Muon.GUI.ElementalAnalysis.PeriodicTable.PeakSelector.peak_selector_view import PeakSelectorView
+from Muon.GUI.ElementalAnalysis.Peaks.peaks_presenter import PeaksPresenter
+from Muon.GUI.Common import message_box
+
+offset = 0.9
+
+
+def is_string(value):
+    if isinstance(value, str):
+        return True
+
+    return False
+
+
+def gen_name(element, name):
+    msg = None
+    if not is_string(element):
+        msg = "'{}' expected element to be 'str', found '{}' instead".format(
+            str(element), type(element))
+    if not is_string(name):
+        msg = "'{}' expected name to be 'str', found '{}' instead".format(str(name), type(name))
+
+    if msg is not None:
+        raise TypeError(msg)
+
+    if element in name:
+        return name
+    return element + " " + name
+
+
+class PeriodicTableWidgetPresenter(object):
+
+    def __init__(self, view):
+        self.view = view
+        self.plotting = None
+        self.plot_window = None
+        self.ptable_model = PeriodicTableModel()
+        self.ptable = PeriodicTablePresenter(self.view.ptable_view, self.ptable_model)
+        self.peakpresenter = PeaksPresenter(self.view.peaks_view)
+
+        self.element_widgets = {}
+        self.element_lines = {}
+
+        self.num_colors = len(mpl.rcParams['axes.prop_cycle'])
+        self.used_colors = {}
+        self.ptable.register_table_lclicked(self.table_left_clicked)
+        self.ptable.register_table_rclicked(self.table_right_clicked)
+        self._generate_element_widgets()
+        self._setup_peaks_widget()
+
+    def _setup_peaks_widget(self):
+        self.peakpresenter.major.setChecked(True)
+        self.peakpresenter.major.on_checkbox_checked(self.major_peaks_changed)
+        self.peakpresenter.major.on_checkbox_unchecked(self.major_peaks_changed)
+        self.peakpresenter.minor.on_checkbox_checked(self.minor_peaks_changed)
+        self.peakpresenter.minor.on_checkbox_unchecked(self.minor_peaks_changed)
+        self.peakpresenter.gamma.on_checkbox_checked(self.gammas_changed)
+        self.peakpresenter.gamma.on_checkbox_unchecked(self.gammas_changed)
+        self.peakpresenter.electron.on_checkbox_checked(self.electrons_changed)
+        self.peakpresenter.electron.on_checkbox_unchecked(self.electrons_changed)
+        self.peakpresenter.set_deselect_elements_slot(self.deselect_elements)
+
+    # interact with periodic table
+    def table_right_clicked(self, item):
+        self.element_widgets[item.symbol].view.show()
+
+    def table_left_clicked(self, item):
+        if self.ptable.is_selected(item.symbol):
+            self._add_element_lines(item.symbol)
+        else:
+            self._remove_element_lines(item.symbol)
+
+    # setup element pop up
+    def _generate_element_widgets(self):
+        self.element_widgets = {}
+        for element in self.ptable.peak_data:
+            data = self.ptable.element_data(element)
+            widget = PeakSelectorPresenter(PeakSelectorView(data, element))
+            widget.on_finished(self._update_peak_data)
+            self.element_widgets[element] = widget
+
+    def _update_peak_data(self, element):
+        if self.ptable.is_selected(element):
+            # remove all of the lines for the element
+            self._remove_element_lines(element)
+            # add the ticked lines to the plot
+            self._add_element_lines(element)
+        else:
+            self._remove_element_lines(element)
+
+    def _remove_element_lines(self, element):
+        if element not in self.element_lines:
+            return
+        names = deepcopy(self.element_lines[element])
+        for name in names:
+            try:
+                self.element_lines[element].remove(name)
+                self._rm_line(name)
+                if not self.element_lines[element]:
+                    del self.element_lines[element]
+                    if element in self.used_colors:
+                        del self.used_colors[element]
+            except:
+                continue
+
+        if element in self.element_lines and not self.element_lines[element]:
+            del self.element_lines[element]
+
+    def _add_element_lines(self, element, data=None):
+        if data is None:
+            data = self.element_widgets[element].get_checked()
+        if element not in self.element_lines:
+            self.element_lines[element] = []
+
+        # Select a different color, if all used then use the first
+        color = self.get_color(element)
+
+        for name, x_value in data.items():
+            try:
+                x_value = float(x_value)
+            except ValueError:
+                continue
+            full_name = gen_name(element, name)
+            if full_name not in self.element_lines[element]:
+                self.element_lines[element].append(full_name)
+            self._plot_line(full_name, x_value, color, element)
+
+    def get_color(self, element):
+        """
+        When requesting the colour for a new element, return the first unused colour of the matplotlib
+        default colour cycle (i.e. mpl.rcParams['axes.prop_cycle']).
+        If all colours are used, return the first among the least used ones.
+        That is if C0-4 are all used twice and C5-9 are used once, C5 will be returned.
+        When requesting the colour for an element that is already plotted return the colour of that element.
+        This prevents the same element from being displayed in different colours in separate plots
+        :param element: Chemical symbol of the element that one wants the colour of
+        :return: Matplotlib colour string: C0, C1, ..., C9 to be used as plt.plot(..., color='C3')
+        """
+        if element in self.used_colors:
+            return self.used_colors[element]
+
+        occurrences = [
+            list(self.used_colors.values()).count('C{}'.format(i)) for i in range(self.num_colors)
+        ]
+
+        color_index = occurrences.index(min(occurrences))
+
+        color = "C{}".format(color_index)
+        self.used_colors[element] = color
+
+        return color
+
+    def _gen_label(self, name, x_value_in, element=None):
+        if element is None:
+            return
+        # check x value is a float
+        try:
+            x_value = float(x_value_in)
+        except:
+            return
+        if name not in self.element_lines[element]:
+            self.element_lines[element].append(name)
+        # make sure the names are strings and x values are numbers
+        return Label(str(name), x_value, False, offset, True, rotation=-90, protected=True)
+
+    def _plot_line(self, name, x_value_in, color, element=None):
+        label = self._gen_label(name, x_value_in, element)
+        if self.plot_window is None:
+            return
+        for subplot in self.plotting.get_subplots():
+            self._plot_line_once(subplot, x_value_in, label, color)
+
+    def _plot_line_once(self, subplot, x_value, label, color):
+        self.plotting.add_vline_and_annotate(subplot, x_value, label, color)
+
+    def _rm_line(self, name):
+        if self.plot_window is None:
+            return
+        for subplot in self.plotting.get_subplots():
+            self.plotting.rm_vline_and_annotate(subplot, name)
+
+    def electrons_changed(self, electron_peaks):
+        for element, selector in self.element_widgets.items():
+            self.checked_data(element, selector.electron_checkboxes, electron_peaks.isChecked())
+
+    def gammas_changed(self, gamma_peaks):
+        for element, selector in self.element_widgets.items():
+            self.checked_data(element, selector.gamma_checkboxes, gamma_peaks.isChecked())
+
+    def major_peaks_changed(self, major_peaks):
+        for element, selector in self.element_widgets.items():
+            self.checked_data(element, selector.primary_checkboxes, major_peaks.isChecked())
+
+    def minor_peaks_changed(self, minor_peaks):
+        for element, selector in self.element_widgets.items():
+            self.checked_data(element, selector.secondary_checkboxes, minor_peaks.isChecked())
+
+    def deselect_elements(self):
+        self.peakpresenter.disable_deselect_elements_btn()
+        for element in self.element_widgets.keys():
+            self.ptable.deselect_element(element)
+            self._remove_element_lines(element)
+        self.peakpresenter.enable_deselect_elements_btn()
+
+    # general checked data
+    def checked_data(self, element, selection, state):
+        for checkbox in selection:
+            checkbox.setChecked(state)
+        self._update_peak_data(element)
+
+    def _update_checked_data(self):
+        self.major_peaks_changed(self.peakpresenter.major)
+        self.minor_peaks_changed(self.peakpresenter.minor)
+        self.gammas_changed(self.peakpresenter.gamma)
+        self.electrons_changed(self.peakpresenter.electron)
+
+    # sets data file for periodic table
+    def select_data_file(self):
+        old_lines = deepcopy(list(self.element_lines.keys()))
+
+        filename = QFileDialog.getOpenFileName()
+        if isinstance(filename, tuple):
+            filename = filename[0]
+        filename = str(filename)
+        if filename:
+            self.ptable.set_peak_datafile(filename)
+
+        try:
+            self._generate_element_widgets()
+        except ValueError:
+            message_box.warning(
+                'The file does not contain correctly formatted data, resetting to default data file.'
+                'See "https://docs.mantidproject.org/nightly/interfaces/'
+                'Muon%20Elemental%20Analysis.html" for more information.')
+            self.ptable.set_peak_datafile(None)
+            self._generate_element_widgets()
+
+        for element in old_lines:
+            if element in self.element_widgets.keys():
+                self.ptable.select_element(element)
+            else:
+                self._remove_element_lines(element)
+        self._update_checked_data()

--- a/scripts/Muon/GUI/ElementalAnalysis/periodic_table_widget_view.py
+++ b/scripts/Muon/GUI/ElementalAnalysis/periodic_table_widget_view.py
@@ -1,0 +1,39 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2018 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+from Muon.GUI.ElementalAnalysis.Peaks.peaks_view import PeaksView
+from Muon.GUI.ElementalAnalysis.PeriodicTable.periodic_table_view import PeriodicTableView
+from qtpy import QtWidgets
+from Muon.GUI.Common import message_box
+
+
+class PeriodicTableWidgetView(QtWidgets.QWidget):
+
+    @staticmethod
+    def warning_popup(message):
+        message_box.warning(message)
+
+    def __init__(self, parent=None):
+        super(PeriodicTableWidgetView, self).__init__(parent)
+        # setup periodic table and peaks
+        self.ptable_view = PeriodicTableView()
+        self.peaks_view = PeaksView()
+        self.widget_list = QtWidgets.QVBoxLayout()
+        self.layout = QtWidgets.QHBoxLayout()
+        self.setup_widget()
+
+    def setup_widget(self):
+        self.layout.addWidget(self.ptable_view)
+
+        self.widget_list.addWidget(self.peaks_view)
+        self.layout.addLayout(self.widget_list)
+        self.setLayout(self.layout)
+
+    def add_widget_to_view(self, widget: QtWidgets.QWidget):
+        self.widget_list.addWidget(widget)
+
+    def add_layout_to_view(self, layout: QtWidgets.QBoxLayout):
+        self.widget_list.addLayout(layout)

--- a/scripts/test/Muon/elemental_analysis/elemental_analysis_test.py
+++ b/scripts/test/Muon/elemental_analysis/elemental_analysis_test.py
@@ -13,13 +13,9 @@ from testhelpers import assertRaisesNothing
 
 from qtpy.QtGui import QCloseEvent
 
-import matplotlib
 from Muon.GUI.ElementalAnalysis.elemental_analysis import ElementalAnalysisGui
 from Muon.GUI.ElementalAnalysis.LoadWidget.load_utils import spectrum_index
-from Muon.GUI.ElementalAnalysis.elemental_analysis import gen_name
 from MultiPlotting.multi_plotting_widget import MultiPlotWindow
-from MultiPlotting.multi_plotting_widget import MultiPlotWidget
-from MultiPlotting.label import Label
 
 
 @start_qapplication
@@ -47,43 +43,6 @@ class ElementalAnalysisTest(unittest.TestCase):
             self.has_raise_ValueError_been_called_once = True
             raise ValueError()
 
-    def test_that_get_color_returns_C0_as_first_color(self):
-        self.assertEqual('C0', self.gui.get_color('bla'))
-
-    def test_that_default_colour_cycle_is_used(self):
-        cycle = len(matplotlib.rcParams['axes.prop_cycle'])
-        self.assertEqual(cycle, self.gui.num_colors)
-
-        expected = ['C%d' % i for i in range(cycle)]
-        returned = [self.gui.get_color('el_{}'.format(i)) for i in range(cycle)]
-        self.assertEqual(expected, returned)
-
-    def test_that_get_color_returns_the_same_color_for_the_same_element(self):
-        self.assertEqual(self.gui.used_colors, {})
-
-        colors = [self.gui.get_color('Cu') for _ in range(10)]
-        colors += [self.gui.get_color('Fe') for _ in range(10)]
-        colors = sorted(list(set(colors)))
-
-        self.assertEqual(colors, ['C0', 'C1'])
-
-    def test_that_get_color_returns_a_color_if_it_has_been_freed(self):
-        elements = ['Cu', 'Fe', 'Ni']
-        colors = [self.gui.get_color(el) for el in elements]
-
-        self.assertEqual(colors, ['C0', 'C1', 'C2'])
-
-        del self.gui.used_colors['Fe']
-
-        new_col = self.gui.get_color('O')
-        self.assertEqual(new_col, 'C1')
-
-    def test_that_get_color_wraps_around_when_all_colors_in_cycle_have_been_used(self):
-        [self.gui.get_color(i) for i in range(self.gui.num_colors)]
-
-        self.assertEqual(self.gui.get_color('Cu'), 'C0')
-        self.assertEqual(self.gui.get_color('Fe'), 'C1')
-
     def test_that_closing_with_no_plot_will_not_throw(self):
         self.gui.plot_window = None
 
@@ -94,151 +53,6 @@ class ElementalAnalysisTest(unittest.TestCase):
         self.gui.closeEvent(QCloseEvent())
 
         self.assertEqual(self.gui.plot_window.closeEvent.call_count, 1)
-
-    def test_that_gen_label_does_not_throw_with_non_float_x_values(self):
-        assertRaisesNothing(self, self.gui._gen_label, 'name', 'not_a_float', 'Cu')
-        assertRaisesNothing(self, self.gui._gen_label, 'name', u'not_a_float', 'Cu')
-        assertRaisesNothing(self, self.gui._gen_label, 'name', None, 'Cu')
-        assertRaisesNothing(self, self.gui._gen_label, 'name', ('not', 'a', 'float'), 'Cu')
-        assertRaisesNothing(self, self.gui._gen_label, 'name', ['not', 'a', 'float'], 'Cu')
-
-    def test_gen_label_output_is_Label_type(self):
-        name = "string"
-        x_value_in = 1.0
-        self.gui.element_lines["H"] = []
-        gen_label_output = self.gui._gen_label(name, x_value_in, element="H")
-        self.assertEquals(Label, type(gen_label_output))
-
-    def test_that_gen_label_with_element_none_returns_none(self):
-        self.assertEqual(self.gui._gen_label('label', 0.0), None)
-
-    @mock.patch('Muon.GUI.ElementalAnalysis.elemental_analysis.Label')
-    def test_that_gen_label_name_is_appended_to_list_if_not_present(self, mock_label):
-        element = 'Cu'
-        name = u'new_label'
-        self.gui.element_lines = {'Cu': [u'old_label']}
-        self.gui._gen_label(name, 1.0, element)
-
-        self.assertIn(name, self.gui.element_lines[element])
-        mock_label.assert_called_with(str(name),
-                                      1.0,
-                                      False,
-                                      0.9,
-                                      True,
-                                      rotation=-90,
-                                      protected=True)
-
-    @mock.patch('Muon.GUI.ElementalAnalysis.elemental_analysis.Label')
-    def test_that_gen_label_name_is_not_duplicated_in_list_if_already_present(self, mock_label):
-        element = 'Cu'
-        name = u'old_label'
-        self.gui.element_lines = {'Cu': [u'old_label']}
-        self.gui._gen_label(name, 1.0, element)
-
-        self.assertIn(name, self.gui.element_lines[element])
-        self.assertEqual(self.gui.element_lines[element].count(name), 1)
-        mock_label.assert_called_with(str(name),
-                                      1.0,
-                                      False,
-                                      0.9,
-                                      True,
-                                      rotation=-90,
-                                      protected=True)
-
-    @mock.patch('Muon.GUI.ElementalAnalysis.elemental_analysis.ElementalAnalysisGui._gen_label')
-    @mock.patch('Muon.GUI.ElementalAnalysis.elemental_analysis.ElementalAnalysisGui._plot_line_once')
-    def test_that_plot_line_returns_if_plot_window_is_none(self, mock_plot_line_once,
-                                                           mock_gen_label):
-        self.gui.plot_window = None
-        mock_gen_label.return_value = 'name of the label'
-        self.gui._plot_line('name', 1.0, 'C0', None)
-
-        self.assertEqual(mock_plot_line_once.call_count, 0)
-
-    @mock.patch('Muon.GUI.ElementalAnalysis.elemental_analysis.ElementalAnalysisGui._gen_label')
-    @mock.patch('Muon.GUI.ElementalAnalysis.elemental_analysis.ElementalAnalysisGui._plot_line_once')
-    def test_that_plot_line_calls_plot_line_once_if_window_not_none(self, mock_plot_line_once,
-                                                                    mock_gen_label):
-        self.gui.plot_window = mock.create_autospec(MultiPlotWindow)
-        self.gui.plotting = MultiPlotWidget(mock.Mock())
-        self.gui.plotting.get_subplots = mock.Mock(return_value=['plot1'])
-        mock_gen_label.return_value = 'name of the label'
-        self.gui._plot_line('name', 1.0, 'C0', None)
-
-        self.assertEqual(mock_plot_line_once.call_count, 1)
-        mock_plot_line_once.assert_called_with('plot1', 1.0, 'name of the label', 'C0')
-
-    def test_plot_line_once_calls_correct_multiplot_function(self):
-        self.gui.plotting = mock.create_autospec(MultiPlotWidget)
-        self.gui._plot_line_once('GE1', 1.0, 'label', 'C0')
-
-        self.assertEqual(self.gui.plotting.add_vline_and_annotate.call_count, 1)
-
-    def test_that_rm_line_returns_if_plot_window_is_none(self):
-        self.gui.plotting = MultiPlotWidget(mock.Mock())
-        self.gui.plotting.get_subplots = mock.Mock(return_value=['plot1', 'plot2', 'plot3'])
-        self.gui.plot_window = None
-
-        self.gui._rm_line('line')
-
-        self.assertEqual(self.gui.plotting.get_subplots.call_count, 0)
-
-    def test_that_rm_line_calls_correct_function_if_window_not_none(self):
-        self.gui.plotting = MultiPlotWidget(mock.Mock())
-        self.gui.plotting.get_subplots = mock.Mock(return_value=['plot1', 'plot2', 'plot3'])
-        self.gui.plotting.rm_vline_and_annotate = mock.Mock()
-        self.gui.plot_window = mock.create_autospec(MultiPlotWindow)
-        self.gui._rm_line('line')
-
-        self.assertEqual(self.gui.plotting.get_subplots.call_count, 1)
-        self.assertEqual(self.gui.plotting.rm_vline_and_annotate.call_count, 3)
-        self.gui.plotting.rm_vline_and_annotate.assert_called_with('plot3', 'line')
-
-    def test_that_generate_element_widgets_creates_widget_once_for_each_element(self):
-        elem = len(self.gui.ptable.peak_data)
-        self.assertEqual(len(self.gui.element_widgets), elem)
-
-    @mock.patch('Muon.GUI.ElementalAnalysis.elemental_analysis.ElementalAnalysisGui._add_element_lines')
-    def test_table_left_clicked_adds_lines_if_element_selected(self, mock_add_element_lines):
-        self.gui.ptable.is_selected = mock.Mock(return_value=True)
-        self.gui._add_element_lines(mock.Mock())
-        self.assertEqual(mock_add_element_lines.call_count, 1)
-
-    @mock.patch('Muon.GUI.ElementalAnalysis.elemental_analysis.ElementalAnalysisGui._remove_element_lines')
-    def test_table_left_clicked_removed_lines_if_element_not_selected(self,
-                                                                      mock_remove_element_lines):
-        self.gui.ptable.is_selected = mock.Mock(return_value=False)
-        self.gui.table_left_clicked(mock.Mock())
-        self.assertEqual(mock_remove_element_lines.call_count, 1)
-
-    @mock.patch('Muon.GUI.ElementalAnalysis.elemental_analysis.ElementalAnalysisGui.get_color')
-    def test_that_add_element_lines_will_call_get_color(self, mock_get_color):
-        self.gui._add_element_lines('Cu')
-        self.assertEqual(mock_get_color.call_count, 1)
-
-    @mock.patch('Muon.GUI.ElementalAnalysis.elemental_analysis.ElementalAnalysisGui._plot_line')
-    def test_that_add_element_lines_will_call_plot_line(self, mock_plot_line):
-        data = {'line1': 10.0, 'line2': 20.0, 'line3': 30.0}
-        self.gui._add_element_lines('Cu', data)
-        self.assertEqual(mock_plot_line.call_count, 3)
-        call_list = [
-            mock.call(gen_name('Cu', 'line3'), 30.0, 'C0', 'Cu'),
-            mock.call(gen_name('Cu', 'line2'), 20.0, 'C0', 'Cu'),
-            mock.call(gen_name('Cu', 'line1'), 10.0, 'C0', 'Cu')
-        ]
-        mock_plot_line.assert_has_calls(call_list, any_order=True)
-
-    @mock.patch('Muon.GUI.ElementalAnalysis.elemental_analysis.ElementalAnalysisGui._rm_line')
-    def test_remove_element_lines_does_nothing_if_element_not_in_element_lines(self, mock_rm_line):
-        self.gui.element_lines['H'] = ['alpha', 'beta']
-        self.gui._remove_element_lines('He')
-        self.assertEqual(mock_rm_line.call_count, 0)
-
-    @mock.patch('Muon.GUI.ElementalAnalysis.elemental_analysis.ElementalAnalysisGui._rm_line')
-    def test_remove_element_lines_removes_all_values_for_a_given_element(self, mock_rm_line):
-        self.gui.element_lines['H'] = ['alpha', 'beta']
-        self.gui._remove_element_lines('H')
-        self.assertEqual(mock_rm_line.call_count, 2)
 
     @mock.patch('Muon.GUI.ElementalAnalysis.elemental_analysis.MultiPlotWindow')
     def test_load_run_opens_new_plot_window_if_none_open(self, mock_multi_plot_window):
@@ -304,13 +118,13 @@ class ElementalAnalysisTest(unittest.TestCase):
 
         self.gui.loading_finished()
         # should have set the states of num_detectors - num_loaded_detectors
-        self.assertEqual(self.gui.detectors.setStateQuietly.call_count,num_detectors-num_loaded_detectors)
+        self.assertEqual(self.gui.detectors.setStateQuietly.call_count, num_detectors - num_loaded_detectors)
         # should have only enabled the detector we have loaded
         self.assertEqual(self.gui.detectors.enableDetector.call_count, num_loaded_detectors)
         # Should disable (num_detectors - num_loaded_detectors) detectors
-        self.assertEqual(self.gui.detectors.disableDetector.call_count, num_detectors-num_loaded_detectors)
+        self.assertEqual(self.gui.detectors.disableDetector.call_count, num_detectors - num_loaded_detectors)
 
-    @mock.patch('Muon.GUI.ElementalAnalysis.elemental_analysis.ElementalAnalysisGui.add_peak_data')
+    @mock.patch('Muon.GUI.ElementalAnalysis.elemental_analysis.PeriodicTableWidgetPresenter.add_peak_data')
     @mock.patch('Muon.GUI.ElementalAnalysis.elemental_analysis.mantid')
     def test_add_detectors_to_plot_plots_all_given_ws_and_all_selected_elements(
             self, mock_mantid, mock_add_peak_data):
@@ -337,45 +151,17 @@ class ElementalAnalysisTest(unittest.TestCase):
         self.assertEqual(self.gui.detectors.setStateQuietly.call_count, 3)
         self.assertEqual(self.gui.plot_window, None)
 
-    @mock.patch('Muon.GUI.ElementalAnalysis.elemental_analysis.ElementalAnalysisGui._gen_label')
-    @mock.patch('Muon.GUI.ElementalAnalysis.elemental_analysis.ElementalAnalysisGui._plot_line_once')
-    def test_add_peak_data_plot_line_called_with_correct_terms(self, mock_plot_line_once,
-                                                               mock_gen_label):
-        mock_subplot = mock.Mock()
-        mock_gen_label.return_value = 'label'
-        test_data = {'name1': 1.0}
-        self.gui.add_peak_data('H', mock_subplot, data=test_data)
-        mock_plot_line_once.assert_called_with(mock_subplot, 1.0, 'label', 'C0')
-
-    @mock.patch('Muon.GUI.ElementalAnalysis.elemental_analysis.ElementalAnalysisGui._add_element_lines')
-    @mock.patch('Muon.GUI.ElementalAnalysis.elemental_analysis.ElementalAnalysisGui._remove_element_lines')
-    def test_update_peak_data_element_is_selected(self, mock_remove_element_lines,
-                                                  mock_add_element_lines):
-        self.gui.ptable.is_selected = mock.Mock(return_value=True)
-        self.gui._update_peak_data('test_element')
-        mock_remove_element_lines.assert_called_with('test_element')
-        mock_add_element_lines.assert_called_with('test_element')
-
-    @mock.patch('Muon.GUI.ElementalAnalysis.elemental_analysis.ElementalAnalysisGui._add_element_lines')
-    @mock.patch('Muon.GUI.ElementalAnalysis.elemental_analysis.ElementalAnalysisGui._remove_element_lines')
-    def test_update_peak_data_element_is_not_selected(self, mock_remove_element_lines,
-                                                      mock_add_element_lines):
-        self.gui.ptable.is_selected = mock.Mock(return_value=False)
-        self.gui._update_peak_data('test_element')
-        mock_remove_element_lines.assert_called_with('test_element')
-        self.assertEqual(mock_add_element_lines.call_count, 0)
-
     @mock.patch('Muon.GUI.ElementalAnalysis.elemental_analysis.ElementalAnalysisGui.load_run')
     def test_add_plot_does_nothing_is_no_loaded_run(self, mock_load_run):
         self.gui.load_widget.last_loaded_run = mock.Mock(return_value=None)
         self.gui.add_plot(mock.Mock())
         self.assertEqual(mock_load_run.call_count, 0)
 
-    @mock.patch('Muon.GUI.ElementalAnalysis.elemental_analysis.ElementalAnalysisGui.add_peak_data')
+    @mock.patch('Muon.GUI.ElementalAnalysis.elemental_analysis.PeriodicTableWidgetPresenter.add_peak_data')
     @mock.patch('Muon.GUI.ElementalAnalysis.elemental_analysis.ElementalAnalysisGui.load_run')
     def test_add_plot_loads_run_and_electron_peaks_not_plotted(self, mock_load_run, add_peak_data):
         self.gui.load_widget.last_loaded_run = mock.Mock(return_value=2695)
-        self.gui.peaks.electron.isChecked = mock.Mock(return_value=False)
+        self.gui.ptable.peakpresenter.electron.isChecked = mock.Mock(return_value=False)
         mock_checkbox = mock.Mock()
         mock_checkbox.name = 'GE1'
 
@@ -419,6 +205,7 @@ class ElementalAnalysisTest(unittest.TestCase):
 
     def test_del_plot_closes_plot_if_no_subplots_left(self):
         self.gui.load_widget.last_loaded_run = mock.Mock(return_value=2695)
+        self.gui.plotting = mock.Mock()
         self.gui.plotting.remove_subplot = mock.Mock()
         self.gui.plotting.get_subplots = mock.Mock(return_value=False)
         self.gui.plot_window = mock.Mock()
@@ -449,106 +236,6 @@ class ElementalAnalysisTest(unittest.TestCase):
 
         self.assertEqual(self.gui.detectors.setStateQuietly.call_count, 1)
         self.assertEqual(self.gui.plot_window, None)
-
-    @mock.patch('Muon.GUI.ElementalAnalysis.elemental_analysis.message_box.warning')
-    @mock.patch('Muon.GUI.ElementalAnalysis.elemental_analysis.PeriodicTablePresenter.set_peak_datafile')
-    @mock.patch('Muon.GUI.ElementalAnalysis.elemental_analysis.QtWidgets.QFileDialog.getOpenFileName')
-    def test_that_set_peak_datafile_is_called_with_select_data_file(self,
-                                                                    mock_get_open_file_name,
-                                                                    mock_set_peak_datafile,
-                                                                    mock_warning):
-        mock_get_open_file_name.return_value = 'filename'
-        self.gui.select_data_file()
-        mock_set_peak_datafile.assert_called_with('filename')
-        self.assertEqual(0, mock_warning.call_count)
-
-    @mock.patch('Muon.GUI.ElementalAnalysis.elemental_analysis.PeriodicTablePresenter.set_peak_datafile')
-    @mock.patch('Muon.GUI.ElementalAnalysis.elemental_analysis.QtWidgets.QFileDialog.getOpenFileName')
-    def test_that_select_data_file_uses_the_first_element_of_a_tuple_when_given_as_a_filename(self,
-                                                                                              mock_get_open_file_name,
-                                                                                              mock_set_peak_datafile):
-        mock_get_open_file_name.return_value = ('string1', 'string2')
-        self.gui.select_data_file()
-        mock_set_peak_datafile.assert_called_with('string1')
-
-    @mock.patch('Muon.GUI.ElementalAnalysis.elemental_analysis.message_box.warning')
-    @mock.patch('Muon.GUI.ElementalAnalysis.elemental_analysis.ElementalAnalysisGui._generate_element_widgets')
-    @mock.patch('Muon.GUI.ElementalAnalysis.elemental_analysis.QtWidgets.QFileDialog.getOpenFileName')
-    def test_that_select_data_file_raises_warning_with_correct_text(self,
-                                                                    mock_get_open_file_name,
-                                                                    mock_generate_element_widgets,
-                                                                    mock_warning):
-        mock_get_open_file_name.return_value = 'filename'
-        mock_generate_element_widgets.side_effect = self.raise_ValueError_once
-        self.gui.select_data_file()
-        warning_text = 'The file does not contain correctly formatted data, resetting to default data file.' \
-                       'See "https://docs.mantidproject.org/nightly/interfaces/' \
-                       'Muon%20Elemental%20Analysis.html" for more information.'
-        mock_warning.assert_called_with(warning_text)
-
-    @mock.patch('Muon.GUI.ElementalAnalysis.elemental_analysis.message_box.warning')
-    @mock.patch('Muon.GUI.ElementalAnalysis.elemental_analysis.QtWidgets.QFileDialog.getOpenFileName')
-    def test_select_data_file_calls_update_checked_data(self, mock_getOpenFileName, mock_warning):
-        mock_getOpenFileName.return_value = 'filename'
-        tmp = self.gui._update_checked_data
-        self.gui._update_checked_data = mock.Mock()
-        self.gui.select_data_file()
-
-        self.assertEqual(1, self.gui._update_checked_data.call_count)
-        self.gui._update_checked_data = tmp
-
-    def test_update_checked_data_calls_the_right_functions(self):
-        self.gui.major_peaks_changed = mock.Mock()
-        self.gui.minor_peaks_changed = mock.Mock()
-        self.gui.gammas_changed = mock.Mock()
-        self.gui.electrons_changed = mock.Mock()
-
-        self.gui._update_checked_data()
-
-        self.assertEqual(1, self.gui.major_peaks_changed.call_count)
-        self.assertEqual(1, self.gui.minor_peaks_changed.call_count)
-        self.assertEqual(1, self.gui.gammas_changed.call_count)
-        self.assertEqual(1, self.gui.electrons_changed.call_count)
-        self.gui.major_peaks_changed.assert_called_with(self.gui.peaks.major)
-        self.gui.minor_peaks_changed.assert_called_with(self.gui.peaks.minor)
-        self.gui.gammas_changed.assert_called_with(self.gui.peaks.gamma)
-        self.gui.electrons_changed.assert_called_with(self.gui.peaks.electron)
-
-    def test_major_changed_calls_checked_data_for_each_element(self):
-        elem = len(self.gui.ptable.peak_data)
-        self.gui.checked_data = mock.Mock()
-        self.gui.major_peaks_changed(self.gui.peaks.major)
-        self.assertEqual(self.gui.checked_data.call_count, elem)
-
-    def test_minor_changed_calls_checked_data_for_each_element(self):
-        elem = len(self.gui.ptable.peak_data)
-        self.gui.checked_data = mock.Mock()
-        self.gui.minor_peaks_changed(self.gui.peaks.minor)
-        self.assertEqual(self.gui.checked_data.call_count, elem)
-
-    def test_gammas_changed_calls_checked_data_for_each_element(self):
-        elem = len(self.gui.ptable.peak_data)
-        self.gui.checked_data = mock.Mock()
-        self.gui.gammas_changed(self.gui.peaks.gamma)
-        self.assertEqual(self.gui.checked_data.call_count, elem)
-
-    def test_electrons_changed_calls_checked_data_for_each_element(self):
-        elem = len(self.gui.ptable.peak_data)
-        self.gui.checked_data = mock.Mock()
-        self.gui.electrons_changed(self.gui.peaks.electron)
-        self.assertEqual(self.gui.checked_data.call_count, elem)
-
-    @mock.patch('Muon.GUI.ElementalAnalysis.elemental_analysis.ElementalAnalysisGui._update_peak_data')
-    def test_checked_data_changes_all_states_in_list(self, mock_update_peak_data):
-        selection = [mock.Mock() for i in range(10)]
-        self.gui.checked_data('Cu', selection, True)
-
-        self.assertTrue(all(map(lambda m: m.setChecked.call_count == 1, selection)))
-        mock_update_peak_data.assert_called_with('Cu')
-
-    def test_that_ptable_contains_no_peak_not_part_of_an_element(self):
-        self.assertTrue('Electrons' not in self.gui.ptable.peak_data)
-        self.assertTrue('Gammas' not in self.gui.ptable.peak_data)
 
     def test_that_add_line_by_type_enables_all_detectors(self):
         self.gui.detectors.detectors = [mock.Mock(), mock.Mock(), mock.Mock(), mock.Mock()]
@@ -695,42 +382,6 @@ class ElementalAnalysisTest(unittest.TestCase):
 
         self.gui.lines.delayed.setChecked.assert_called_with(True)
         self.assertEqual(1, mock_add_line_by_type.call_count)
-
-    @mock.patch('Muon.GUI.ElementalAnalysis.elemental_analysis.ElementalAnalysisGui._remove_element_lines')
-    def test_deselect_elements(self,mock_remove_element_lines):
-
-        self.gui.ptable.deselect_element = mock.Mock()
-
-        self.gui.peaks.enable_deselect_elements_btn = mock.Mock()
-        self.gui.peaks.disable_deselect_elements_btn = mock.Mock()
-
-        self.gui.deselect_elements()
-
-        self.assertEquals(self.gui.peaks.enable_deselect_elements_btn.call_count , 1)
-        self.assertEquals(self.gui.peaks.disable_deselect_elements_btn.call_count , 1)
-
-        self.assertEquals(self.gui.ptable.deselect_element.call_count , len(self.gui.element_widgets))
-        self.assertEquals(mock_remove_element_lines.call_count , len(self.gui.element_widgets))
-
-        calls = [mock.call(element) for element in self.gui.element_widgets.keys()]
-        self.gui.ptable.deselect_element.assert_has_calls(calls)
-        mock_remove_element_lines.assert_has_calls(calls)
-
-    @mock.patch('Muon.GUI.ElementalAnalysis.elemental_analysis.ElementalAnalysisGui._remove_element_lines')
-    def test_deselect_elements_fails(self,mock_remove_element_lines):
-
-        self.gui.ptable.deselect_element = mock.Mock()
-
-        self.gui.peaks.enable_deselect_elements_btn = mock.Mock()
-        self.gui.peaks.disable_deselect_elements_btn = mock.Mock()
-
-        self.gui.deselect_elements()
-        #Test passes only if deselect_element is not called with "Hydrogen"
-        with self.assertRaises(AssertionError):
-            self.gui.ptable.deselect_element.assert_any_call("Hydrogen")
-
-        with self.assertRaises(AssertionError):
-            mock_remove_element_lines.assert_any_call("Hydrogen")
 
 
 if __name__ == '__main__':

--- a/scripts/test/Muon/elemental_analysis/name_generator_test.py
+++ b/scripts/test/Muon/elemental_analysis/name_generator_test.py
@@ -6,7 +6,7 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 import unittest
 
-from Muon.GUI.ElementalAnalysis.elemental_analysis import gen_name
+from Muon.GUI.ElementalAnalysis.periodic_table_widget_presenter import gen_name
 
 
 class NameGeneratorTest(unittest.TestCase):

--- a/scripts/test/Muon/elemental_analysis/periodic_table_widget_presenter_test.py
+++ b/scripts/test/Muon/elemental_analysis/periodic_table_widget_presenter_test.py
@@ -1,0 +1,402 @@
+import unittest
+import unittest.mock as mock
+import matplotlib
+from mantidqt.utils.qt.testing import start_qapplication
+from Muon.GUI.ElementalAnalysis.periodic_table_widget_presenter import gen_name
+from MultiPlotting.multi_plotting_widget import MultiPlotWindow
+from MultiPlotting.multi_plotting_widget import MultiPlotWidget
+from Muon.GUI.ElementalAnalysis.elemental_analysis import ElementalAnalysisGui
+from MultiPlotting.label import Label
+from testhelpers import assertRaisesNothing
+
+
+@start_qapplication
+class PeriodicTableWidgetPresenterTest(unittest.TestCase):
+
+    def raise_ValueError_once(self):
+        if not self.has_raise_ValueError_been_called_once:
+            self.has_raise_ValueError_been_called_once = True
+            raise ValueError()
+
+    @classmethod
+    def setUpClass(cls):
+        cls.view = ElementalAnalysisGui()
+        cls.periodic_table = cls.view.ptable
+
+    def setUp(self):
+        self.periodic_table.plot_window = None
+        self.periodic_table.used_colors = {}
+        self.periodic_table.element_lines = {}
+        self.has_raise_ValueError_been_called_once = False
+
+    def test_that_get_color_returns_C0_as_first_color(self):
+        self.assertEqual('C0', self.periodic_table.get_color('bla'))
+
+    def test_that_default_colour_cycle_is_used(self):
+        cycle = len(matplotlib.rcParams['axes.prop_cycle'])
+        self.assertEqual(cycle, self.periodic_table.num_colors)
+
+        expected = ['C%d' % i for i in range(cycle)]
+        returned = [self.periodic_table.get_color('el_{}'.format(i)) for i in range(cycle)]
+        self.assertEqual(expected, returned)
+
+    def test_that_get_color_returns_the_same_color_for_the_same_element(self):
+        self.assertEqual(self.periodic_table.used_colors, {})
+
+        colors = [self.periodic_table.get_color('Cu') for _ in range(10)]
+        colors += [self.periodic_table.get_color('Fe') for _ in range(10)]
+        colors = sorted(list(set(colors)))
+
+        self.assertEqual(colors, ['C0', 'C1'])
+
+    def test_that_get_color_returns_a_color_if_it_has_been_freed(self):
+        elements = ['Cu', 'Fe', 'Ni']
+        colors = [self.periodic_table.get_color(el) for el in elements]
+
+        self.assertEqual(colors, ['C0', 'C1', 'C2'])
+
+        del self.periodic_table.used_colors['Fe']
+
+        new_col = self.periodic_table.get_color('O')
+        self.assertEqual(new_col, 'C1')
+
+    def test_that_get_color_wraps_around_when_all_colors_in_cycle_have_been_used(self):
+        [self.periodic_table.get_color(i) for i in range(self.periodic_table.num_colors)]
+
+        self.assertEqual(self.periodic_table.get_color('Cu'), 'C0')
+        self.assertEqual(self.periodic_table.get_color('Fe'), 'C1')
+
+    def test_that_generate_element_widgets_creates_widget_once_for_each_element(self):
+        elem = len(self.periodic_table.ptable.peak_data)
+        self.assertEqual(len(self.periodic_table.element_widgets), elem)
+
+    @mock.patch('Muon.GUI.ElementalAnalysis.periodic_table_widget_presenter.PeriodicTableWidgetPresenter.'
+                '_add_element_lines')
+    def test_table_left_clicked_adds_lines_if_element_selected(self, mock_add_element_lines):
+        self.periodic_table.ptable.is_selected = mock.Mock(return_value=True)
+        self.periodic_table._add_element_lines(mock.Mock())
+        self.assertEqual(mock_add_element_lines.call_count, 1)
+
+    @mock.patch('Muon.GUI.ElementalAnalysis.periodic_table_widget_presenter.PeriodicTableWidgetPresenter.'
+                '_remove_element_lines')
+    def test_table_left_clicked_removed_lines_if_element_not_selected(self,
+                                                                      mock_remove_element_lines):
+        self.periodic_table.ptable.is_selected = mock.Mock(return_value=False)
+        self.periodic_table.table_left_clicked(mock.Mock())
+        self.assertEqual(mock_remove_element_lines.call_count, 1)
+
+    @mock.patch('Muon.GUI.ElementalAnalysis.periodic_table_widget_presenter.PeriodicTableWidgetPresenter.'
+                'get_color')
+    def test_that_add_element_lines_will_call_get_color(self, mock_get_color):
+        self.periodic_table._add_element_lines('Cu')
+        self.assertEqual(mock_get_color.call_count, 1)
+
+    @mock.patch('Muon.GUI.ElementalAnalysis.periodic_table_widget_presenter.PeriodicTableWidgetPresenter.'
+                '_plot_line')
+    def test_that_add_element_lines_will_call_plot_line(self, mock_plot_line):
+        data = {'line1': 10.0, 'line2': 20.0, 'line3': 30.0}
+        self.periodic_table._add_element_lines('Cu', data)
+        self.assertEqual(mock_plot_line.call_count, 3)
+        call_list = [
+            mock.call(gen_name('Cu', 'line3'), 30.0, 'C0', 'Cu'),
+            mock.call(gen_name('Cu', 'line2'), 20.0, 'C0', 'Cu'),
+            mock.call(gen_name('Cu', 'line1'), 10.0, 'C0', 'Cu')
+        ]
+        mock_plot_line.assert_has_calls(call_list, any_order=True)
+
+    @mock.patch('Muon.GUI.ElementalAnalysis.periodic_table_widget_presenter.PeriodicTableWidgetPresenter'
+                '._rm_line')
+    def test_remove_element_lines_does_nothing_if_element_not_in_element_lines(self, mock_rm_line):
+        self.periodic_table.element_lines['H'] = ['alpha', 'beta']
+        self.periodic_table._remove_element_lines('He')
+        self.assertEqual(mock_rm_line.call_count, 0)
+
+    @mock.patch('Muon.GUI.ElementalAnalysis.periodic_table_widget_presenter.PeriodicTableWidgetPresenter'
+                '._rm_line')
+    def test_remove_element_lines_removes_all_values_for_a_given_element(self, mock_rm_line):
+        self.periodic_table.element_lines['H'] = ['alpha', 'beta']
+        self.periodic_table._remove_element_lines('H')
+        self.assertEqual(mock_rm_line.call_count, 2)
+
+    @mock.patch('Muon.GUI.ElementalAnalysis.periodic_table_widget_presenter.PeriodicTableWidgetPresenter.'
+                '_gen_label')
+    @mock.patch('Muon.GUI.ElementalAnalysis.periodic_table_widget_presenter.PeriodicTableWidgetPresenter'
+                '._plot_line_once')
+    def test_add_peak_data_plot_line_called_with_correct_terms(self, mock_plot_line_once,
+                                                               mock_gen_label):
+        mock_subplot = mock.Mock()
+        mock_gen_label.return_value = 'label'
+        test_data = {'name1': 1.0}
+        self.periodic_table.add_peak_data('H', mock_subplot, data=test_data)
+        mock_plot_line_once.assert_called_with(mock_subplot, 1.0, 'label', 'C0')
+
+    @mock.patch('Muon.GUI.ElementalAnalysis.periodic_table_widget_presenter.PeriodicTableWidgetPresenter.'
+                '_add_element_lines')
+    @mock.patch('Muon.GUI.ElementalAnalysis.periodic_table_widget_presenter.PeriodicTableWidgetPresenter'
+                '._remove_element_lines')
+    def test_update_peak_data_element_is_selected(self, mock_remove_element_lines,
+                                                  mock_add_element_lines):
+        self.periodic_table.ptable.is_selected = mock.Mock(return_value=True)
+        self.periodic_table._update_peak_data('test_element')
+        mock_remove_element_lines.assert_called_with('test_element')
+        mock_add_element_lines.assert_called_with('test_element')
+
+    @mock.patch('Muon.GUI.ElementalAnalysis.periodic_table_widget_presenter.PeriodicTableWidgetPresenter.'
+                '_add_element_lines')
+    @mock.patch('Muon.GUI.ElementalAnalysis.periodic_table_widget_presenter.PeriodicTableWidgetPresenter.'
+                '_remove_element_lines')
+    def test_update_peak_data_element_is_not_selected(self, mock_remove_element_lines,
+                                                      mock_add_element_lines):
+        self.periodic_table.ptable.is_selected = mock.Mock(return_value=False)
+        self.periodic_table._update_peak_data('test_element')
+        mock_remove_element_lines.assert_called_with('test_element')
+        self.assertEqual(mock_add_element_lines.call_count, 0)
+
+    @mock.patch('Muon.GUI.Common.message_box.warning')
+    @mock.patch('Muon.GUI.ElementalAnalysis.periodic_table_widget_presenter.QFileDialog.getOpenFileName')
+    @mock.patch('Muon.GUI.ElementalAnalysis.elemental_analysis.ElementalAnalysisGui.warning_popup')
+    @mock.patch('Muon.GUI.ElementalAnalysis.periodic_table_widget_presenter.PeriodicTableWidgetPresenter.'
+                '_generate_element_widgets')
+    def test_that_select_data_file_raises_warning_with_correct_text(self, mock_generate_element_widgets, mock_warning,
+                                                                    mock_getOpenFileName, mock_message_box):
+        mock_generate_element_widgets.side_effect = self.raise_ValueError_once
+        mock_getOpenFileName.return_value = 'filename'
+        self.periodic_table.select_data_file()
+        warning_text = 'The file does not contain correctly formatted data, resetting to default data file.' \
+                       'See "https://docs.mantidproject.org/nightly/interfaces/muon/' \
+                       'Muon%20Elemental%20Analysis.html" for more information.'
+        mock_warning.assert_called_with(warning_text)
+        mock_message_box.assert_called_once()
+
+    @mock.patch('Muon.GUI.ElementalAnalysis.elemental_analysis.ElementalAnalysisGui.warning_popup')
+    @mock.patch('Muon.GUI.ElementalAnalysis.PeriodicTable.periodic_table_presenter.PeriodicTablePresenter.'
+                'set_peak_datafile')
+    @mock.patch('Muon.GUI.ElementalAnalysis.elemental_analysis.QtWidgets.QFileDialog.getOpenFileName')
+    def test_that_set_peak_datafile_is_called_with_select_data_file(self,
+                                                                    mock_get_open_file_name,
+                                                                    mock_set_peak_datafile,
+                                                                    mock_warning):
+        mock_get_open_file_name.return_value = 'filename'
+        self.periodic_table.select_data_file()
+        mock_set_peak_datafile.assert_called_with('filename')
+        self.assertEqual(0, mock_warning.call_count)
+
+    @mock.patch('Muon.GUI.ElementalAnalysis.periodic_table_widget_presenter.PeriodicTablePresenter.'
+                'set_peak_datafile')
+    @mock.patch('Muon.GUI.ElementalAnalysis.periodic_table_widget_presenter.QFileDialog.getOpenFileName')
+    def test_that_select_data_file_uses_the_first_element_of_a_tuple_when_given_as_a_filename(self,
+                                                                                              mock_get_open_file_name,
+                                                                                              mock_set_peak_datafile):
+        mock_get_open_file_name.return_value = ('string1', 'string2')
+        self.periodic_table.select_data_file()
+        mock_set_peak_datafile.assert_called_with('string1')
+
+    @mock.patch('Muon.GUI.Common.message_box.warning')
+    @mock.patch('Muon.GUI.ElementalAnalysis.periodic_table_widget_presenter.QFileDialog.getOpenFileName')
+    def test_select_data_file_calls_update_checked_data(self, mock_getOpenFileName, mock_warning):
+        mock_getOpenFileName.return_value = 'filename'
+        tmp = self.periodic_table._update_checked_data
+        self.periodic_table._update_checked_data = mock.Mock()
+        self.periodic_table.select_data_file()
+
+        self.assertEqual(1, self.periodic_table._update_checked_data.call_count)
+        mock_warning.assert_called_once()
+        self.periodic_table._update_checked_data = tmp
+
+    def test_update_checked_data_calls_the_right_functions(self):
+        self.periodic_table.major_peaks_changed = mock.Mock()
+        self.periodic_table.minor_peaks_changed = mock.Mock()
+        self.periodic_table.gammas_changed = mock.Mock()
+        self.periodic_table.electrons_changed = mock.Mock()
+
+        self.periodic_table._update_checked_data()
+
+        self.assertEqual(1, self.periodic_table.major_peaks_changed.call_count)
+        self.assertEqual(1, self.periodic_table.minor_peaks_changed.call_count)
+        self.assertEqual(1, self.periodic_table.gammas_changed.call_count)
+        self.assertEqual(1, self.periodic_table.electrons_changed.call_count)
+        self.periodic_table.major_peaks_changed.assert_called_with(self.periodic_table.peakpresenter.major)
+        self.periodic_table.minor_peaks_changed.assert_called_with(self.periodic_table.peakpresenter.minor)
+        self.periodic_table.gammas_changed.assert_called_with(self.periodic_table.peakpresenter.gamma)
+        self.periodic_table.electrons_changed.assert_called_with(self.periodic_table.peakpresenter.electron)
+
+    def test_major_changed_calls_checked_data_for_each_element(self):
+        elem = len(self.periodic_table.ptable.peak_data)
+        self.periodic_table.checked_data = mock.Mock()
+        self.periodic_table.major_peaks_changed(self.periodic_table.peakpresenter.major)
+        self.assertEqual(self.periodic_table.checked_data.call_count, elem)
+
+    def test_minor_changed_calls_checked_data_for_each_element(self):
+        elem = len(self.periodic_table.ptable.peak_data)
+        self.periodic_table.checked_data = mock.Mock()
+        self.periodic_table.minor_peaks_changed(self.periodic_table.peakpresenter.minor)
+        self.assertEqual(self.periodic_table.checked_data.call_count, elem)
+
+    def test_gammas_changed_calls_checked_data_for_each_element(self):
+        elem = len(self.periodic_table.ptable.peak_data)
+        self.periodic_table.checked_data = mock.Mock()
+        self.periodic_table.gammas_changed(self.periodic_table.peakpresenter.gamma)
+        self.assertEqual(self.periodic_table.checked_data.call_count, elem)
+
+    def test_electrons_changed_calls_checked_data_for_each_element(self):
+        elem = len(self.periodic_table.ptable.peak_data)
+        self.periodic_table.checked_data = mock.Mock()
+        self.periodic_table.electrons_changed(self.periodic_table.peakpresenter.electron)
+        self.assertEqual(self.periodic_table.checked_data.call_count, elem)
+
+    @mock.patch('Muon.GUI.ElementalAnalysis.periodic_table_widget_presenter.PeriodicTableWidgetPresenter'
+                '._update_peak_data')
+    def test_checked_data_changes_all_states_in_list(self, mock_update_peak_data):
+        selection = [mock.Mock() for i in range(10)]
+        self.periodic_table.checked_data('Cu', selection, True)
+
+        self.assertTrue(all(map(lambda m: m.setChecked.call_count == 1, selection)))
+        mock_update_peak_data.assert_called_with('Cu')
+
+    def test_that_ptable_contains_no_peak_not_part_of_an_element(self):
+        self.assertTrue('Electrons' not in self.periodic_table.ptable.peak_data)
+        self.assertTrue('Gammas' not in self.periodic_table.ptable.peak_data)
+
+    @mock.patch('Muon.GUI.ElementalAnalysis.periodic_table_widget_presenter.PeriodicTableWidgetPresenter'
+                '._remove_element_lines')
+    def test_deselect_elements(self, mock_remove_element_lines):
+        self.periodic_table.ptable.deselect_element = mock.Mock()
+
+        self.periodic_table.peakpresenter.enable_deselect_elements_btn = mock.Mock()
+        self.periodic_table.peakpresenter.disable_deselect_elements_btn = mock.Mock()
+
+        self.periodic_table.deselect_elements()
+
+        self.assertEquals(self.periodic_table.peakpresenter.enable_deselect_elements_btn.call_count, 1)
+        self.assertEquals(self.periodic_table.peakpresenter.disable_deselect_elements_btn.call_count, 1)
+
+        self.assertEquals(self.periodic_table.ptable.deselect_element.call_count,
+                          len(self.periodic_table.element_widgets))
+        self.assertEquals(mock_remove_element_lines.call_count, len(self.periodic_table.element_widgets))
+
+        calls = [mock.call(element) for element in self.periodic_table.element_widgets.keys()]
+        self.periodic_table.ptable.deselect_element.assert_has_calls(calls)
+        mock_remove_element_lines.assert_has_calls(calls)
+
+    @mock.patch('Muon.GUI.ElementalAnalysis.periodic_table_widget_presenter.PeriodicTableWidgetPresenter'
+                '._remove_element_lines')
+    def test_deselect_elements_fails(self, mock_remove_element_lines):
+        self.periodic_table.ptable.deselect_element = mock.Mock()
+
+        self.periodic_table.peakpresenter.enable_deselect_elements_btn = mock.Mock()
+        self.periodic_table.peakpresenter.disable_deselect_elements_btn = mock.Mock()
+
+        self.periodic_table.deselect_elements()
+        # Test passes only if deselect_element is not called with "Hydrogen"
+        with self.assertRaises(AssertionError):
+            self.periodic_table.ptable.deselect_element.assert_any_call("Hydrogen")
+
+        with self.assertRaises(AssertionError):
+            mock_remove_element_lines.assert_any_call("Hydrogen")
+
+    def test_that_rm_line_returns_if_plot_window_is_none(self):
+        self.periodic_table.plotting = MultiPlotWidget(mock.Mock())
+        self.periodic_table.plotting.get_subplots = mock.Mock(return_value=['plot1', 'plot2', 'plot3'])
+        self.periodic_table.plot_window = None
+
+        self.periodic_table._rm_line('line')
+
+        self.assertEqual(self.periodic_table.plotting.get_subplots.call_count, 0)
+
+    def test_that_rm_line_calls_correct_function_if_window_not_none(self):
+        self.periodic_table.plotting = MultiPlotWidget(mock.Mock())
+        self.periodic_table.plotting.get_subplots = mock.Mock(return_value=['plot1', 'plot2', 'plot3'])
+        self.periodic_table.plotting.rm_vline_and_annotate = mock.Mock()
+        self.periodic_table.plot_window = mock.create_autospec(MultiPlotWindow)
+        self.periodic_table._rm_line('line')
+
+        self.assertEqual(self.periodic_table.plotting.get_subplots.call_count, 1)
+        self.assertEqual(self.periodic_table.plotting.rm_vline_and_annotate.call_count, 3)
+        self.periodic_table.plotting.rm_vline_and_annotate.assert_called_with('plot3', 'line')
+
+    def test_that_gen_label_does_not_throw_with_non_float_x_values(self):
+        assertRaisesNothing(self, self.periodic_table._gen_label, 'name', 'not_a_float', 'Cu')
+        assertRaisesNothing(self, self.periodic_table._gen_label, 'name', u'not_a_float', 'Cu')
+        assertRaisesNothing(self, self.periodic_table._gen_label, 'name', None, 'Cu')
+        assertRaisesNothing(self, self.periodic_table._gen_label, 'name', ('not', 'a', 'float'), 'Cu')
+        assertRaisesNothing(self, self.periodic_table._gen_label, 'name', ['not', 'a', 'float'], 'Cu')
+
+    def test_gen_label_output_is_Label_type(self):
+        name = "string"
+        x_value_in = 1.0
+        self.periodic_table.element_lines["H"] = []
+        gen_label_output = self.periodic_table._gen_label(name, x_value_in, element="H")
+        self.assertEquals(Label, type(gen_label_output))
+
+    def test_that_gen_label_with_element_none_returns_none(self):
+        self.assertEqual(self.periodic_table._gen_label('label', 0.0), None)
+
+    @mock.patch('Muon.GUI.ElementalAnalysis.periodic_table_widget_presenter.Label')
+    def test_that_gen_label_name_is_appended_to_list_if_not_present(self, mock_label):
+        element = 'Cu'
+        name = u'new_label'
+        self.periodic_table.element_lines = {'Cu': [u'old_label']}
+        self.periodic_table._gen_label(name, 1.0, element)
+
+        self.assertIn(name, self.periodic_table.element_lines[element])
+        mock_label.assert_called_with(str(name),
+                                      1.0,
+                                      False,
+                                      0.9,
+                                      True,
+                                      rotation=-90,
+                                      protected=True)
+
+    @mock.patch('Muon.GUI.ElementalAnalysis.periodic_table_widget_presenter.Label')
+    def test_that_gen_label_name_is_not_duplicated_in_list_if_already_present(self, mock_label):
+        element = 'Cu'
+        name = u'old_label'
+        self.periodic_table.element_lines = {'Cu': [u'old_label']}
+        self.periodic_table._gen_label(name, 1.0, element)
+
+        self.assertIn(name, self.periodic_table.element_lines[element])
+        self.assertEqual(self.periodic_table.element_lines[element].count(name), 1)
+        mock_label.assert_called_with(str(name),
+                                      1.0,
+                                      False,
+                                      0.9,
+                                      True,
+                                      rotation=-90,
+                                      protected=True)
+
+    @mock.patch('Muon.GUI.ElementalAnalysis.periodic_table_widget_presenter.PeriodicTableWidgetPresenter'
+                '._gen_label')
+    @mock.patch('Muon.GUI.ElementalAnalysis.periodic_table_widget_presenter.PeriodicTableWidgetPresenter'
+                '._plot_line_once')
+    def test_that_plot_line_returns_if_plot_window_is_none(self, mock_plot_line_once,
+                                                           mock_gen_label):
+        self.periodic_table.plot_window = None
+        mock_gen_label.return_value = 'name of the label'
+        self.periodic_table._plot_line('name', 1.0, 'C0', None)
+
+        self.assertEqual(mock_plot_line_once.call_count, 0)
+
+    @mock.patch('Muon.GUI.ElementalAnalysis.periodic_table_widget_presenter.PeriodicTableWidgetPresenter'
+                '._gen_label')
+    @mock.patch('Muon.GUI.ElementalAnalysis.periodic_table_widget_presenter.PeriodicTableWidgetPresenter'
+                '._plot_line_once')
+    def test_that_plot_line_calls_plot_line_once_if_window_not_none(self, mock_plot_line_once,
+                                                                    mock_gen_label):
+        self.periodic_table.plot_window = mock.create_autospec(MultiPlotWindow)
+        self.periodic_table.plotting = MultiPlotWidget(mock.Mock())
+        self.periodic_table.plotting.get_subplots = mock.Mock(return_value=['plot1'])
+        mock_gen_label.return_value = 'name of the label'
+        self.periodic_table._plot_line('name', 1.0, 'C0', None)
+
+        self.assertEqual(mock_plot_line_once.call_count, 1)
+        mock_plot_line_once.assert_called_with('plot1', 1.0, 'name of the label', 'C0')
+
+    def test_plot_line_once_calls_correct_multiplot_function(self):
+        self.periodic_table.plotting = mock.create_autospec(MultiPlotWidget)
+        self.periodic_table._plot_line_once('GE1', 1.0, 'label', 'C0')
+
+        self.assertEqual(self.periodic_table.plotting.add_vline_and_annotate.call_count, 1)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/scripts/test/Muon/elemental_analysis/periodic_table_widget_presenter_test.py
+++ b/scripts/test/Muon/elemental_analysis/periodic_table_widget_presenter_test.py
@@ -5,7 +5,8 @@ from mantidqt.utils.qt.testing import start_qapplication
 from Muon.GUI.ElementalAnalysis.periodic_table_widget_presenter import gen_name
 from MultiPlotting.multi_plotting_widget import MultiPlotWindow
 from MultiPlotting.multi_plotting_widget import MultiPlotWidget
-from Muon.GUI.ElementalAnalysis.elemental_analysis import ElementalAnalysisGui
+from Muon.GUI.ElementalAnalysis.periodic_table_widget_view import PeriodicTableWidgetView
+from Muon.GUI.ElementalAnalysis.periodic_table_widget_presenter import PeriodicTableWidgetPresenter
 from MultiPlotting.label import Label
 from testhelpers import assertRaisesNothing
 
@@ -20,8 +21,8 @@ class PeriodicTableWidgetPresenterTest(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.view = ElementalAnalysisGui()
-        cls.periodic_table = cls.view.ptable
+        cls.view = PeriodicTableWidgetView()
+        cls.periodic_table = PeriodicTableWidgetPresenter(cls.view)
 
     def setUp(self):
         self.periodic_table.plot_window = None
@@ -154,7 +155,7 @@ class PeriodicTableWidgetPresenterTest(unittest.TestCase):
 
     @mock.patch('Muon.GUI.Common.message_box.warning')
     @mock.patch('Muon.GUI.ElementalAnalysis.periodic_table_widget_presenter.QFileDialog.getOpenFileName')
-    @mock.patch('Muon.GUI.ElementalAnalysis.elemental_analysis.ElementalAnalysisGui.warning_popup')
+    @mock.patch('Muon.GUI.ElementalAnalysis.periodic_table_widget_view.PeriodicTableWidgetView.warning_popup')
     @mock.patch('Muon.GUI.ElementalAnalysis.periodic_table_widget_presenter.PeriodicTableWidgetPresenter.'
                 '_generate_element_widgets')
     def test_that_select_data_file_raises_warning_with_correct_text(self, mock_generate_element_widgets, mock_warning,
@@ -168,7 +169,7 @@ class PeriodicTableWidgetPresenterTest(unittest.TestCase):
         mock_warning.assert_called_with(warning_text)
         mock_message_box.assert_called_once()
 
-    @mock.patch('Muon.GUI.ElementalAnalysis.elemental_analysis.ElementalAnalysisGui.warning_popup')
+    @mock.patch('Muon.GUI.ElementalAnalysis.periodic_table_widget_view.PeriodicTableWidgetView.warning_popup')
     @mock.patch('Muon.GUI.ElementalAnalysis.PeriodicTable.periodic_table_presenter.PeriodicTablePresenter.'
                 'set_peak_datafile')
     @mock.patch('Muon.GUI.ElementalAnalysis.elemental_analysis.QtWidgets.QFileDialog.getOpenFileName')


### PR DESCRIPTION
**Description of work.**
This pull request seperates all functionality relating to the periodic table in the elemental analysis gui into one entity.

**To test:**
1. As there was no changes to functionality, ensure tests pass and gui works as usual


Fixes #32142 . 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
