### PR TITLE
Frequency Domain Analysis - Only enable tab if datasets are loaded

### DIFF
--- a/scripts/Muon/GUI/Common/fitting_widgets/basic_fitting/basic_fitting_view.py
+++ b/scripts/Muon/GUI/Common/fitting_widgets/basic_fitting/basic_fitting_view.py
@@ -313,4 +313,4 @@ class BasicFittingView(ui_form, base_widget):
 
     def enable_view(self) -> None:
         """Enable all widgets in this fitting widget."""
-        self.setEnabled(True)
+        self.setEnabled(self.workspace_selector.number_of_datasets() != 0)

--- a/scripts/Muon/GUI/Common/fitting_widgets/model_fitting/model_fitting_presenter.py
+++ b/scripts/Muon/GUI/Common/fitting_widgets/model_fitting/model_fitting_presenter.py
@@ -103,6 +103,7 @@ class ModelFittingPresenter(BasicFittingPresenter):
         self.automatically_update_function_name()
 
         self.update_fit_statuses_and_chi_squared_in_view_from_model()
+        self.update_covariance_matrix_button()
         self.update_fit_function_in_view_from_model()
         self.update_start_and_end_x_in_view_from_model()
 

--- a/scripts/test/Muon/fitting_widgets/basic_fitting/basic_fitting_view_test.py
+++ b/scripts/test/Muon/fitting_widgets/basic_fitting/basic_fitting_view_test.py
@@ -28,6 +28,7 @@ class BasicFittingViewTest(unittest.TestCase, QtWidgetFinder):
         FrameworkManager.Instance()
 
     def setUp(self):
+        self.dataset_names = ["MUSR62260; Group; fwd; Asymmetry; MA", "MUSR62260; Group; bwd; Asymmetry; MA"]
         self.view = BasicFittingView()
         self.view.show()
         self.assert_widget_created()
@@ -40,7 +41,17 @@ class BasicFittingViewTest(unittest.TestCase, QtWidgetFinder):
         self.view.plot_guess = True
         self.assertTrue(self.view.plot_guess)
 
+    def test_that_enable_view_does_not_enable_the_tab_if_there_are_no_datasets_loaded(self):
+        self.view.enable_view()
+        self.assertTrue(not self.view.isEnabled())
+
+    def test_that_enable_view_does_enable_the_tab_if_there_are_datasets_loaded(self):
+        self.view.update_dataset_name_combo_box(self.dataset_names)
+        self.view.enable_view()
+        self.assertTrue(self.view.isEnabled())
+
     def test_that_the_undo_fit_button_can_be_enabled_as_expected_when_the_number_of_undos_is_above_zero(self):
+        self.view.update_dataset_name_combo_box(self.dataset_names)
         self.view.enable_view()
         self.view.set_number_of_undos(2)
         self.assertTrue(self.view.fit_controls.undo_fit_button.isEnabled())


### PR DESCRIPTION
**Description of work.**
This PR ensures the fitting tab remains disabled when there are no datasets loaded into the tab.

**To test:**
Follow the testing instructions in the issue.

Fixes #32120

*This does not require release notes* because **this is a regression since the last release**.

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
