### PR TITLE
Allow TF Asymmetry Fitting for Diffs between Groups

### DIFF
--- a/docs/source/release/v6.2.0/muon.rst
+++ b/docs/source/release/v6.2.0/muon.rst
@@ -28,6 +28,7 @@ Improvements
 ############
 
 - When running the Dynamic Kubo Toyabe fit function you should now be able to see the BinWidth to 3 decimal places.
+- TF Asymmetry fitting is now allowed for diffs between groups.
 
 BugFixes
 ############

--- a/scripts/Muon/GUI/Common/ADSHandler/ADS_calls.py
+++ b/scripts/Muon/GUI/Common/ADSHandler/ADS_calls.py
@@ -26,3 +26,14 @@ def check_if_workspace_exist(name):
 
 def add_ws_to_ads(name, workspace):
     AnalysisDataService.addOrReplace(name, workspace)
+
+
+# this requires a call to the ADS
+def get_sample_log(ws_name, log_name):
+    ws = retrieve_ws(ws_name)
+    run = ws.run()
+    return run.getProperty(log_name).value
+
+
+def get_normalisation(name):
+    return float(get_sample_log(name, "analysis_asymmetry_norm"))

--- a/scripts/Muon/GUI/Common/ADSHandler/workspace_naming.py
+++ b/scripts/Muon/GUI/Common/ADSHandler/workspace_naming.py
@@ -17,6 +17,7 @@ REBIN_STR = 'Rebin'
 FFT_STR = 'FFT'
 MAXENT_STR = 'MaxEnt'
 PERIOD_STR = "_period_"
+UNNORM = '_unnorm'
 
 
 def get_raw_data_workspace_name(instrument, run, multi_period, period='1', workspace_suffix=' MA'):
@@ -136,7 +137,7 @@ def get_group_or_pair_from_name(name):
 
 
 def get_group_asymmetry_unnorm_name(context, group_name, run, periods, rebin):
-    return '__' + get_group_asymmetry_name(context, group_name, run, periods, rebin) + '_unnorm'
+    return '__' + get_group_asymmetry_name(context, group_name, run, periods, rebin) + UNNORM
 
 
 def get_base_data_directory(context, run):

--- a/scripts/Muon/GUI/Common/contexts/muon_group_pair_context.py
+++ b/scripts/Muon/GUI/Common/contexts/muon_group_pair_context.py
@@ -436,6 +436,12 @@ class MuonGroupPairContext(object):
             unnormalised_workspace = group.find_unormalised(workspace)
             if unnormalised_workspace:
                 return unnormalised_workspace
+        for diff in self.diffs:
+            if diff.group_or_pair == "group":
+                unnormalised_workspace = diff.find_unormalised(workspace)
+                print("ttt", unnormalised_workspace)
+                if unnormalised_workspace:
+                    return unnormalised_workspace
 
     def get_group_pair_name_and_run_from_workspace_name(self, workspace_name):
         for group_pair in self.all_groups_and_pairs:

--- a/scripts/Muon/GUI/Common/contexts/muon_group_pair_context.py
+++ b/scripts/Muon/GUI/Common/contexts/muon_group_pair_context.py
@@ -169,6 +169,9 @@ class MuonGroupPairContext(object):
         """Returns the selected diff names. Ensures the order of the returned diff names is correct."""
         return [diff.name for diff in self.diffs if diff.name in self._selected_diffs]
 
+    def get_selected_diffs(self, group_or_pair) -> list:
+        return [diff for diff in self.diffs if diff.name in self._selected_diffs and diff.group_or_pair == group_or_pair]
+
     @property
     def selected_groups_and_pairs(self):
         return self.selected_groups + self.selected_pairs + self.selected_diffs

--- a/scripts/Muon/GUI/Common/fitting_widgets/tf_asymmetry_fitting/tf_asymmetry_fitting_model.py
+++ b/scripts/Muon/GUI/Common/fitting_widgets/tf_asymmetry_fitting/tf_asymmetry_fitting_model.py
@@ -230,10 +230,19 @@ class TFAsymmetryFittingModel(GeneralFittingModel):
     def check_datasets_are_tf_asymmetry_compliant(self, workspace_names: list = None) -> bool:
         """Returns true if the datasets stored in the model are compatible with TF Asymmetry mode."""
         workspace_names = self.fitting_context.dataset_names if workspace_names is None else workspace_names
-        pair_names = [get_group_or_pair_from_name(name) for name in workspace_names if "Group" not in name]
         # Remove duplicates from the list
-        pair_names = list(dict.fromkeys(pair_names))
+        pair_names = list(dict.fromkeys(self._get_pair_and_pair_diff_names(workspace_names)))
         return len(pair_names) == 0, "'" + "', '".join(pair_names) + "'"
+
+    def _get_pair_and_pair_diff_names(self, workspace_names: list) -> list:
+        """Returns the names of pairs and pair diffs which are in the provided workspace name list."""
+        group_diff_names = [diff.name for diff in self.context.group_pair_context.get_diffs("group")]
+        pair_or_diff_names = []
+        for workspace_name in workspace_names:
+            name = get_group_or_pair_from_name(workspace_name)
+            if "Group" not in workspace_name and name not in group_diff_names:
+                pair_or_diff_names.append(name)
+        return pair_or_diff_names
 
     def undo_previous_fit(self) -> None:
         """Undoes the previous fit using the saved undo data."""

--- a/scripts/Muon/GUI/Common/fitting_widgets/tf_asymmetry_fitting/tf_asymmetry_fitting_model.py
+++ b/scripts/Muon/GUI/Common/fitting_widgets/tf_asymmetry_fitting/tf_asymmetry_fitting_model.py
@@ -577,7 +577,9 @@ class TFAsymmetryFittingModel(GeneralFittingModel):
         params = self._get_common_tf_asymmetry_parameters()
         params["InputFunction"] = tf_single_function.clone()
         params["ReNormalizedWorkspaceList"] = dataset_name
+        print("moo")
         params["UnNormalizedWorkspaceList"] = self._get_unnormalised_workspace_list([dataset_name])[0]
+        print("hi")
 
         fit_workspace_name, _ = create_fitted_workspace_name(dataset_name, self.fitting_context.function_name)
         params["OutputFitWorkspace"] = fit_workspace_name
@@ -590,9 +592,10 @@ class TFAsymmetryFittingModel(GeneralFittingModel):
         params["InputFunction"] = str(tf_simultaneous_function) + self._construct_global_tie_appendage()
         params["ReNormalizedWorkspaceList"] = dataset_names
         params["UnNormalizedWorkspaceList"] = self._get_unnormalised_workspace_list(dataset_names)
-
+        print("hhhh", params)
         fit_workspace_name, _ = create_multi_domain_fitted_workspace_name(dataset_names[0],
                                                                           self.fitting_context.function_name)
+        print("fff", params)
         params["OutputFitWorkspace"] = fit_workspace_name
         return params
 

--- a/scripts/Muon/GUI/Common/muon_diff.py
+++ b/scripts/Muon/GUI/Common/muon_diff.py
@@ -6,6 +6,11 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 # pylint: disable=C0111
 from Muon.GUI.Common.muon_base import MuonBase
+from Muon.GUI.Common.muon_base import MuonRun
+from Muon.GUI.Common.ADSHandler.muon_workspace_wrapper import MuonWorkspaceWrapper
+
+
+GROUP = "group"
 
 
 class MuonDiff(MuonBase):
@@ -17,11 +22,13 @@ class MuonDiff(MuonBase):
     - The workspace associated to the difference can be set, but must be of type MuonWorkspaceWrapper.
     """
 
-    def __init__(self, diff_name, positive, negative, group_or_pair="group", periods=[1]):
+    def __init__(self, diff_name, positive, negative, group_or_pair=GROUP, periods=[1]):
         super(MuonDiff, self).__init__(diff_name, periods)
         self._positive = positive
         self._negative = negative
         self._group_or_pair = group_or_pair
+        self._asymmetry_unnormalised = {}
+        self._asymmetry_rebin_unnormalised = {}
 
     @property
     def positive(self):
@@ -34,3 +41,25 @@ class MuonDiff(MuonBase):
     @property
     def group_or_pair(self):
         return self._group_or_pair
+
+    def update_unnormalised_asymmetry_workspace(
+            self,
+            asymmetry_workspace,
+            run,
+            rebin=False):
+        run_object = MuonRun(run)
+        if not rebin and self.group_or_pair==GROUP:
+            self._asymmetry_unnormalised.update(
+                {run_object: MuonWorkspaceWrapper(asymmetry_workspace)})
+        elif self.group_or_pair==GROUP:
+            self._asymmetry_rebin_unnormalised.update(
+                {run_object: MuonWorkspaceWrapper(asymmetry_workspace)})
+
+    def find_unormalised(self, workspace):
+        for key, value in self.workspace.items():
+            if value.workspace_name == workspace:
+                return self._asymmetry_unnormalised[key].workspace_name
+
+        for key, value in self.workspace_rebin.items():
+            if value.workspace_name == workspace:
+                return self._asymmetry_rebin_unnormalised[key].workspace_name

--- a/scripts/Muon/GUI/Common/muon_group.py
+++ b/scripts/Muon/GUI/Common/muon_group.py
@@ -62,6 +62,12 @@ class MuonGroup(object):
         else:
             return self._asymmetry_estimate[MuonRun(run)].workspace_name
 
+    def get_asymmetry_unormalised_workspace_for_run(self, run, rebin):
+        if rebin:
+            return self._asymmetry_estimate_rebin_unormalised[MuonRun(run)].workspace_name
+        else:
+            return self._asymmetry_estimate_unormalised[MuonRun(run)].workspace_name
+
     @property
     def name(self):
         return self._group_name

--- a/scripts/Muon/GUI/Common/utilities/algorithm_utils.py
+++ b/scripts/Muon/GUI/Common/utilities/algorithm_utils.py
@@ -189,6 +189,7 @@ def run_CalculateMuonAsymmetry(parameters_dict, alg):
     alg.setAlwaysStoreInADS(True)
     alg.setRethrows(True)
     alg.setProperties(parameters_dict)
+    print("gi", parameters_dict)
     alg.execute()
     return alg.getProperty('OutputWorkspace').valueAsStr, alg.getProperty('OutputParameters').valueAsStr, \
         alg.getProperty("OutputFunction").value, alg.getProperty('OutputStatus').value, \
@@ -317,5 +318,19 @@ def run_crop_workspace(ws, start, end):
     alg.setProperty("OutputWorkspace", ws)
     alg.setProperty("XMin", start)
     alg.setProperty("XMax", end)
+    alg.execute()
+    return alg.getProperty("OutputWorkspace").valueAsStr
+
+
+def run_apply_norm(input_name, ouput_name, norm=0):
+    alg = mantid.AlgorithmManager.create("EstimateMuonAsymmetryFromCounts")
+    alg.initialize()
+    alg.setAlwaysStoreInADS(True)
+    alg.setProperty("InputWorkspace", input_name)
+    alg.setProperty("OutputWorkspace", ouput_name)
+    alg.setProperty("NormalizationIn", norm)
+    # unnorm data = input
+    alg.setProperty("NormaliseCounts", False)
+    alg.setProperty("AllowNegativeNorm", True)
     alg.execute()
     return alg.getProperty("OutputWorkspace").valueAsStr

--- a/scripts/test/Muon/fitting_widgets/tf_asymmetry_fitting/tf_asymmetry_fitting_model_test.py
+++ b/scripts/test/Muon/fitting_widgets/tf_asymmetry_fitting/tf_asymmetry_fitting_model_test.py
@@ -11,6 +11,7 @@ from mantid.api import FrameworkManager, FunctionFactory
 from mantid.simpleapi import CreateSampleWorkspace
 
 from Muon.GUI.Common.fitting_widgets.tf_asymmetry_fitting.tf_asymmetry_fitting_model import TFAsymmetryFittingModel
+from Muon.GUI.Common.muon_diff import MuonDiff
 from Muon.GUI.Common.test_helpers.context_setup import setup_context
 
 
@@ -348,6 +349,26 @@ class TFAsymmetryFittingModelTest(unittest.TestCase):
 
         self.assertTrue(tf_compliant)
         self.assertEqual(non_compliant_names, "''")
+
+    def test_that_check_datasets_are_tf_asymmetry_compliant_returns_true_for_a_group_diff(self):
+        self.model.dataset_names = ["MUSR62260; Diff; diff_group; Asymmetry; MA"]
+
+        self.model.context.group_pair_context.add_diff(MuonDiff("diff_group", "fwd", "bwd", "group"))
+
+        tf_compliant, non_compliant_names = self.model.check_datasets_are_tf_asymmetry_compliant()
+
+        self.assertTrue(tf_compliant)
+        self.assertEqual(non_compliant_names, "''")
+
+    def test_that_check_datasets_are_tf_asymmetry_compliant_returns_true_for_a_pair_diff(self):
+        self.model.dataset_names = ["MUSR62260; Diff; diff_pair; Asymmetry; MA"]
+
+        self.model.context.group_pair_context.add_diff(MuonDiff("diff_pair", "long1", "long2", "pair"))
+
+        tf_compliant, non_compliant_names = self.model.check_datasets_are_tf_asymmetry_compliant()
+
+        self.assertTrue(not tf_compliant)
+        self.assertEqual(non_compliant_names, "'diff_pair'")
 
     def test_that_get_fit_function_parameter_values_returns_the_expected_parameter_values(self):
         self.model.dataset_names = self.dataset_names


### PR DESCRIPTION
**Description of work.**
This PR ensures that TF Asymmetry fitting is allowed for the diff between groups.

**To test:**
1. Open Muon Analysis
2. Load `MUSR62260`
3. Go to Grouping tab and create a Diff between groups called `diff_group`
4. Tick `Analyse (Plot/Fit)`
5. Go to the Fitting tab and select `TF Asymmetry` fitting mode
6. It should switch without a popup warning
7. Create a pair diff and ensure that these are not allowed for TF Asymmetry fitting mode

Fixes #31456

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
