### PR TITLE
Fix bug with loading logs for raw files with alternate data stream

### DIFF
--- a/Framework/DataHandling/inc/MantidDataHandling/LoadRawHelper.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadRawHelper.h
@@ -58,11 +58,13 @@ public:
   /// Returns a confidence value that this algorithm can load a file
   int confidence(Kernel::FileDescriptor &descriptor) const override;
 
+  /// Search for the log files in the workspace, and output their names as a list.
+  static std::list<std::string> searchForLogFiles(const Poco::Path &pathToRawFile);
   /// returns true if the Exclude Monitor option(property) selected
   static bool isExcludeMonitors(const std::string &monitorOption);
-  ///  returns true if the Separate Monitor Option  selected
+  /// returns true if the Separate Monitor Option  selected
   static bool isSeparateMonitors(const std::string &monitorOption);
-  ///  returns true if the Include Monitor Option  selected
+  /// returns true if the Include Monitor Option  selected
   static bool isIncludeMonitors(const std::string &monitorOption);
 
   static void ProcessLoadMonitorOptions(bool &bincludeMonitors, bool &bseparateMonitors, bool &bexcludeMonitors,
@@ -73,7 +75,7 @@ public:
                                      API::WorkspaceGroup_sptr &mongrp_sptr, const int64_t mwsSpecs,
                                      const int64_t nwsSpecs, const int64_t numberOfPeriods, const int64_t lengthIn,
                                      const std::string &title, API::Algorithm *const pAlg);
-  /// creates  shared pointer to group workspace
+  /// creates shared pointer to group workspace
   static API::WorkspaceGroup_sptr createGroupWorkspace();
 
   /// creates shared pointer to workspace from parent workspace
@@ -215,9 +217,6 @@ private:
   /// A ptr to the log creator
   std::unique_ptr<ISISRunLogs> m_logCreator;
 
-  /// Search for the log files in the workspace, and output their names as a
-  /// set.
-  std::list<std::string> searchForLogFiles(const Poco::Path &pathToRawFile);
   /// Extract the log name from the path to the specific log file.
   std::string extractLogName(const std::string &path);
 };

--- a/Framework/DataHandling/src/LoadRawHelper.cpp
+++ b/Framework/DataHandling/src/LoadRawHelper.cpp
@@ -79,7 +79,8 @@ std::set<std::string> logFilesFromAlternateDataStream(const Poco::Path &pathToRa
       const size_t asteriskPos = line.find('*');
       if (asteriskPos == std::string::npos)
         continue;
-      Poco::Path logFilePath(dirOfFile.append(line.substr(asteriskPos + 1)));
+      Poco::Path logFilePath(dirOfFile);
+      logFilePath.append(line.substr(asteriskPos + 1));
       if (Poco::File(logFilePath).exists()) {
         logfilesList.insert(logFilePath.toString());
       }

--- a/Framework/DataHandling/src/LoadRawHelper.cpp
+++ b/Framework/DataHandling/src/LoadRawHelper.cpp
@@ -55,7 +55,7 @@ inline bool hasAlternateDataStream([[maybe_unused]] const Poco::Path &pathToFile
  * file and returns the filenames of the log files that exist in the same
  * directory as the given file
  * @param pathToRawFile The path and name of the raw file.
- * @return list of logfile names.
+ * @return set of logfile names.
  */
 std::set<std::string> logFilesFromAlternateDataStream(const Poco::Path &pathToRawFile) {
   std::set<std::string> logfilesList;
@@ -670,7 +670,7 @@ void LoadRawHelper::runLoadMappingTable(const std::string &fileName,
 /// @param progEnd :: ending progress fraction
 void LoadRawHelper::runLoadLog(const std::string &fileName, const DataObjects::Workspace2D_sptr &localWorkspace,
                                double progStart, double progEnd) {
-  // search for the log file to load, and save their names in a set.
+  // search for the log file to load, and save their names in a list.
   std::list<std::string> logFiles = searchForLogFiles(Poco::Path(fileName));
 
   g_log.debug("Loading the log files...");

--- a/Framework/DataHandling/src/LoadRawHelper.cpp
+++ b/Framework/DataHandling/src/LoadRawHelper.cpp
@@ -1161,16 +1161,16 @@ std::list<std::string> LoadRawHelper::searchForLogFiles(const Poco::Path &pathTo
         Kernel::Glob::glob(pattern, potentialLogFiles);
       } catch (std::exception &) {
       }
+      // Check for .log
+      const Poco::File combinedLogPath(Poco::Path(pathToRawFile).setExtension("log"));
+      if (combinedLogPath.exists()) {
+        // Push three column filename to end of list.
+        potentialLogFilesList.insert(potentialLogFilesList.end(), combinedLogPath.path());
+      }
     }
 
     // push potential log files from set to list.
     potentialLogFilesList.insert(potentialLogFilesList.begin(), potentialLogFiles.begin(), potentialLogFiles.end());
-    // Check for .log
-    const Poco::File combinedLogPath(Poco::Path(pathToRawFile).setExtension("log"));
-    if (combinedLogPath.exists()) {
-      // Push three column filename to end of list.
-      potentialLogFilesList.insert(potentialLogFilesList.end(), combinedLogPath.path());
-    }
   }
   return potentialLogFilesList;
 }

--- a/Framework/DataHandling/test/LoadRaw3Test.h
+++ b/Framework/DataHandling/test/LoadRaw3Test.h
@@ -18,6 +18,7 @@
 #include "MantidKernel/ConfigService.h"
 #include "MantidKernel/TimeSeriesProperty.h"
 #include "MantidKernel/Unit.h"
+#include <Poco/Path.h>
 #include <boost/lexical_cast.hpp>
 #include <cxxtest/TestSuite.h>
 

--- a/Framework/DataHandling/test/LoadRaw3Test.h
+++ b/Framework/DataHandling/test/LoadRaw3Test.h
@@ -38,6 +38,59 @@ public:
     inputFile = "HET15869.raw";
   }
 
+  void testAlternateDataStream() {
+#ifdef _WIN32
+    Poco::Path rawFilePath("./fakeRawFile.raw");
+    Poco::File rawFile(rawFilePath);
+
+    std::ofstream file(rawFile.path());
+    file << "data goes here";
+
+    std::string adsFileName = rawFile.path() + ":checksum";
+    std::ofstream adsFile(adsFileName);
+    adsFile << "ad0bc56c4c556fa368565000f01e77f7 *fakeRawFile.log" << std::endl;
+    adsFile << "d5ace6dc7ac6c4365d48ee1f2906c6f4 *fakeRawFile.nxs" << std::endl;
+    adsFile << "9c70ad392023515f775af3d3984882f3 *fakeRawFile.raw" << std::endl;
+    adsFile << "66f74b6c0cc3eb497b92d4956ed8d6b5 *fakeRawFile_ICPdebug.txt" << std::endl;
+    adsFile << "e200aa65186b61e487175d5263b315aa *fakeRawFile_ICPevent.txt" << std::endl;
+    adsFile << "91be40aa4f54d050a9eb4abea394720e *fakeRawFile_ICPstatus.txt" << std::endl;
+    adsFile << "50aa2872110a9b862b01c6c83f8ce9a8 *fakeRawFile_Status.txt" << std::endl;
+
+    file.close();
+    adsFile.close();
+
+    // Create the log files, otherwise the searchForLogFiles function won't include them in the
+    // list of log files.
+    Poco::File logFile("./fakeRawFile.log");
+    logFile.createFile();
+    Poco::File icpDebugFile("./fakeRawFile_ICPdebug.txt");
+    icpDebugFile.createFile();
+    Poco::File icpEventFile("./fakeRawFile_ICPevent.txt");
+    icpEventFile.createFile();
+    Poco::File icpStatusFile("./fakeRawFile_ICPstatus.txt");
+    icpStatusFile.createFile();
+    Poco::File statusFile("./fakeRawFile_Status.txt");
+    statusFile.createFile();
+
+    std::list<std::string> logFiles = LoadRawHelper::searchForLogFiles(rawFilePath);
+
+    // One .log and four .txt files are listed in the alternate data stream.
+    TS_ASSERT_EQUALS(5, logFiles.size());
+    TS_ASSERT(std::find(logFiles.begin(), logFiles.end(), "fakeRawFile.log") != logFiles.end());
+    TS_ASSERT(std::find(logFiles.begin(), logFiles.end(), "fakeRawFile_ICPdebug.txt") != logFiles.end());
+    TS_ASSERT(std::find(logFiles.begin(), logFiles.end(), "fakeRawFile_ICPevent.txt") != logFiles.end());
+    TS_ASSERT(std::find(logFiles.begin(), logFiles.end(), "fakeRawFile_ICPstatus.txt") != logFiles.end());
+    TS_ASSERT(std::find(logFiles.begin(), logFiles.end(), "fakeRawFile_Status.txt") != logFiles.end());
+
+    rawFile.remove();
+    logFile.remove();
+    icpDebugFile.remove();
+    icpEventFile.remove();
+    icpStatusFile.remove();
+    statusFile.remove();
+#endif
+  }
+
   void testConfidence() {
     using Mantid::Kernel::FileDescriptor;
     LoadRaw3 loader;

--- a/Framework/DataHandling/test/LoadRaw3Test.h
+++ b/Framework/DataHandling/test/LoadRaw3Test.h
@@ -8,6 +8,7 @@
 
 #include "MantidAPI/AnalysisDataService.h"
 #include "MantidAPI/Axis.h"
+#include "MantidAPI/FileFinder.h"
 #include "MantidAPI/FrameworkManager.h"
 #include "MantidAPI/WorkspaceGroup.h"
 #include "MantidDataHandling/LoadRaw3.h"
@@ -38,6 +39,9 @@ public:
     inputFile = "HET15869.raw";
   }
 
+  /// <summary>
+  /// Test that the log file paths are correctly found on Windows when using the alternate data stream.
+  /// </summary>
   void testAlternateDataStream() {
 #ifdef _WIN32
     Poco::Path rawFilePath("./fakeRawFile.raw");
@@ -89,6 +93,26 @@ public:
     icpStatusFile.remove();
     statusFile.remove();
 #endif
+  }
+
+  /// <summary>
+  /// Check that the .log file is added to the list of log files when loading a raw file.
+  /// </summary>
+  void testLogFileSearch() {
+    std::string rawFileName = FileFinder::Instance().getFullPath("NIMROD00001097.raw");
+    Poco::Path rawFilePath(rawFileName);
+
+    std::list<std::string> logFiles = LoadRawHelper::searchForLogFiles(rawFilePath);
+
+    // Count number of log files ending in ".log" - should be exactly one.
+    int logCount = 0;
+    for (const auto &logFile : logFiles) {
+      if (boost::algorithm::iends_with(logFile, ".log")) {
+        ++logCount;
+      }
+    }
+
+    TS_ASSERT_EQUALS(1, logCount);
   }
 
   void testConfidence() {

--- a/docs/source/release/v6.2.0/framework.rst
+++ b/docs/source/release/v6.2.0/framework.rst
@@ -31,7 +31,7 @@ Bugfixes
 - Fix rare divide-by zero error when running :ref:`GetEi <algm-GetEi>` on noisy data.
 - Fix crash when running :ref:`IntegrateEPP <algm-IntegrateEPP>` on a workspace group via the algorithm dialog.
 - Fixed bug in :ref:`FitGaussianPeaks <algm-FitGaussianPeaks>` algorithm in which a peak at the end of range would cause an error due to not enough data point being available to fit parameters
-
+- Fixed bug where :ref:`LoadRaw <algm-LoadRaw>` would not load all log files for raw files with an alternate data stream.
 
 Fit Functions
 -------------


### PR DESCRIPTION
**Description of work.**

When loading a .raw file using Windows, the list of associated log files is taken from the alternative data stream if it exists (stored at "raw_file_name:checksum"). There was a bug which meant the list of files wasn't being correctly returned, so the .txt log files were not being loaded. This has been fixed.

**To test:**

**On Windows only**
- Change the log level to information in the messages widget.
- Load this file from the archive: `\\isis\inst$\NDXINES\Instrument\data\cycle_20_3\INS17770.raw`
- Verfiy that the warning message `Cannot process ICPevent log. Period 1 assumed for all data.` is NOT present.
- Confirm that the following messages ARE present:
`Skipping empty log file: \\isis\inst$\NDXINES\Instrument\data\cycle_20_3\INS17770_ICPalarm.txt`
and
`Skipping log file: \\isis\inst$\NDXINES\Instrument\data\cycle_20_3\INS17770_ICPdebug.txt`


Fixes #31986 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
