### PR TITLE
EA Fitting tab

### DIFF
--- a/scripts/Muon/GUI/Common/test_helpers/context_setup.py
+++ b/scripts/Muon/GUI/Common/test_helpers/context_setup.py
@@ -15,6 +15,7 @@ from Muon.GUI.Common.muon_load_data import MuonLoadData
 from Muon.GUI.Common.contexts.phase_table_context import PhaseTableContext
 from Muon.GUI.Common.contexts.plot_pane_context import PlotPanesContext
 from Muon.GUI.Common.contexts.fitting_contexts.basic_fitting_context import BasicFittingContext
+from Muon.GUI.Common.contexts.fitting_contexts.general_fitting_context import GeneralFittingContext
 from Muon.GUI.Common.contexts.fitting_contexts.model_fitting_context import ModelFittingContext
 from Muon.GUI.Common.contexts.fitting_contexts.tf_asymmetry_fitting_context import TFAsymmetryFittingContext
 from Muon.GUI.ElementalAnalysis2.context.context import ElementalAnalysisContext
@@ -84,6 +85,8 @@ def setup_context_for_ea_tests(parent_object):
     parent_object.data_context = DataContext(load_data=parent_object.loaded_data)
     parent_object.gui_context = MuonGuiContext()
     parent_object.plot_panes_context = PlotPanesContext()
+    parent_object.fitting_context = GeneralFittingContext()
     parent_object.group_context = EAGroupContext(parent_object.data_context.check_group_contains_valid_detectors)
     parent_object.context = ElementalAnalysisContext(parent_object.data_context, parent_object.group_context,
-                                                     parent_object.gui_context, parent_object.plot_panes_context)
+                                                     parent_object.gui_context, parent_object.plot_panes_context,
+                                                     parent_object.fitting_context,)

--- a/scripts/Muon/GUI/Common/utilities/algorithm_utils.py
+++ b/scripts/Muon/GUI/Common/utilities/algorithm_utils.py
@@ -11,7 +11,6 @@ from Muon.GUI.Common.ADSHandler.ADS_calls import remove_ws
 from copy import copy
 from mantid.kernel import PhysicalConstants as const
 
-
 muon_logger = Logger('Muon-Algs')
 
 
@@ -142,14 +141,18 @@ def run_Fit(parameters_dict, alg):
     alg.setRethrows(True)
     alg.setProperty('CreateOutput', create_output)
     pruned_parameter_dict = {key: value for key, value in parameters_dict.items() if
-                             key not in ['InputWorkspace', 'StartX', 'EndX', 'Exclude']}
+                             key not in ['InputWorkspace', 'StartX', 'EndX', 'Exclude', 'WorkspaceIndex']}
+
     alg.setProperties(pruned_parameter_dict)
     alg.setProperty('InputWorkspace', parameters_dict['InputWorkspace'])
+    if 'WorkspaceIndex' in parameters_dict:
+        alg.setProperty('WorkspaceIndex', parameters_dict['WorkspaceIndex'])
     alg.setProperty('StartX', parameters_dict['StartX'])
     alg.setProperty('EndX', parameters_dict['EndX'])
     if 'Exclude' in parameters_dict:
         alg.setProperty('Exclude', parameters_dict['Exclude'])
     alg.execute()
+
     if create_output:
         return alg.getProperty("OutputWorkspace").valueAsStr, alg.getProperty("OutputParameters").valueAsStr, \
                alg.getProperty("Function").value, alg.getProperty('OutputStatus').value, \
@@ -164,13 +167,17 @@ def run_simultaneous_Fit(parameters_dict, alg):
     alg.setAlwaysStoreInADS(True)
     alg.setRethrows(True)
     alg.setProperty('CreateOutput', True)
-    pruned_parameter_dict = {key: value for key,value in parameters_dict.items() if
-                             key not in ['InputWorkspace', 'StartX', 'EndX', 'Exclude']}
+
+    pruned_parameter_dict = {key: value for key, value in parameters_dict.items() if
+                             key not in ['InputWorkspace', 'StartX', 'EndX', 'Exclude', 'WorkspaceIndex']}
+
     alg.setProperties(pruned_parameter_dict)
 
     for index, input_workspace in enumerate(parameters_dict['InputWorkspace']):
         index_str = '_' + str(index) if index else ''
         alg.setProperty('InputWorkspace' + index_str, input_workspace)
+        if 'WorkspaceIndex' in parameters_dict:
+            alg.setProperty('WorkspaceIndex' + index_str, parameters_dict['WorkspaceIndex'])
         alg.setProperty('StartX' + index_str, parameters_dict['StartX'][index])
         alg.setProperty('EndX' + index_str, parameters_dict['EndX'][index])
         if 'Exclude' in parameters_dict:
@@ -179,9 +186,9 @@ def run_simultaneous_Fit(parameters_dict, alg):
     alg.execute()
 
     return alg.getProperty('OutputWorkspace').valueAsStr, alg.getProperty('OutputParameters').valueAsStr, \
-        alg.getProperty('Function').value, alg.getProperty('OutputStatus').value, alg.getProperty(
+           alg.getProperty('Function').value, alg.getProperty('OutputStatus').value, alg.getProperty(
         'OutputChi2overDoF').value, \
-        alg.getProperty("OutputNormalisedCovarianceMatrix").valueAsStr
+           alg.getProperty("OutputNormalisedCovarianceMatrix").valueAsStr
 
 
 def run_CalculateMuonAsymmetry(parameters_dict, alg):
@@ -191,8 +198,8 @@ def run_CalculateMuonAsymmetry(parameters_dict, alg):
     alg.setProperties(parameters_dict)
     alg.execute()
     return alg.getProperty('OutputWorkspace').valueAsStr, alg.getProperty('OutputParameters').valueAsStr, \
-        alg.getProperty("OutputFunction").value, alg.getProperty('OutputStatus').value, \
-        alg.getProperty('ChiSquared').value, alg.getProperty("OutputNormalisedCovarianceMatrix").valueAsStr
+           alg.getProperty("OutputFunction").value, alg.getProperty('OutputStatus').value, \
+           alg.getProperty('ChiSquared').value, alg.getProperty("OutputNormalisedCovarianceMatrix").valueAsStr
 
 
 def run_AppendSpectra(ws1, ws2):
@@ -248,7 +255,7 @@ def convert_to_field(workspace_name):
     alg.setAlwaysStoreInADS(True)
     alg.setProperty("InputWorkspace", workspace_name)
     alg.setProperty("OutputWorkspace", workspace_name)
-    alg.setProperty("Formula", 'x * 1. / '+str(const.MuonGyromagneticRatio))
+    alg.setProperty("Formula", 'x * 1. / ' + str(const.MuonGyromagneticRatio))
     alg.setProperty("AxisTitle", 'Field')
     alg.setProperty('AxisUnits', 'Gauss')
     alg.execute()

--- a/scripts/Muon/GUI/ElementalAnalysis2/context/context.py
+++ b/scripts/Muon/GUI/ElementalAnalysis2/context/context.py
@@ -11,29 +11,33 @@ from mantid.simpleapi import CloneWorkspace
 from Muon.GUI.Common.ADSHandler.ADS_calls import retrieve_ws, remove_ws_if_present
 from Muon.GUI.Common.utilities.algorithm_utils import rebin_ws
 from Muon.GUI.Common.contexts.muon_context_ADS_observer import MuonContextADSObserver
+from Muon.GUI.Common.contexts.muon_context import MuonContext
 
 REBINNED_FIXED_WS_SUFFIX = "_EA_Rebinned_Fixed"
 REBINNED_VARIABLE_WS_SUFFIX = "_EA_Rebinned_Variable"
 
 
-class ElementalAnalysisContext(object):
+class ElementalAnalysisContext(MuonContext):
 
     def __init__(self, data_context, ea_group_context=None, muon_gui_context=None, plot_panes_context=None,
-                 error_notifier=None, workspace_suffix=' EA'):
+                 fitting_context=None,error_notifier=None, workspace_suffix=' EA'):
+
+        super(ElementalAnalysisContext, self).__init__(muon_data_context=data_context,
+                                                       muon_gui_context=muon_gui_context,
+                                                       plot_panes_context=plot_panes_context,
+                                                       fitting_context=fitting_context)
+
         self._window_title = "Elemental Analysis 2"
-        self.data_context = data_context
-        self._gui_context = muon_gui_context
         self._group_context = ea_group_context
-        self._plot_panes_context = plot_panes_context
         self.workspace_suffix = workspace_suffix
+        # unsubscribe to ads observer in muon context as it does not have a delete_group_callback
+        self.ads_observer.unsubscribe()
         self.ads_observer = MuonContextADSObserver(delete_callback=self.remove_workspace,
                                                    clear_callback=self.clear_context,
                                                    replace_callback=self.workspace_replaced,
                                                    delete_group_callback=self.remove_workspace)
 
-        self.update_view_from_model_notifier = GenericObservable()
-        self.update_plots_notifier = GenericObservable()
-        self.deleted_plots_notifier = GenericObservable()
+        self.default_end_x = 1000.0
         self.calculation_started_notifier = GenericObservable()
         self.calculation_finished_notifier = GenericObservable()
         self.error_notifier = error_notifier
@@ -52,6 +56,11 @@ class ElementalAnalysisContext(object):
 
     @property
     def group_context(self):
+        return self._group_context
+
+    # To allow compatibility with fitting context and tab
+    @property
+    def group_pair_context(self):
         return self._group_context
 
     def update_current_data(self):
@@ -135,3 +144,65 @@ class ElementalAnalysisContext(object):
 
     def show_all_groups(self):
         pass
+
+    def get_workspace_names_for(self, runs: str, groups: list, fit_to_raw: bool,
+                                simultaneous_fitting_mode: bool = False) -> list:
+        """Returns the workspace names of the loaded data for the provided runs and groups/pairs."""
+        if simultaneous_fitting_mode:
+            return self.get_workspace_names_for_simultaneous_fit(runs, groups)
+        else:
+            return self.get_workspace_names_for_single_fit(groups)
+
+    def get_workspace_names_for_single_fit(self, groups: list):
+        workspace_to_fit = []
+        for group_name in groups:
+            workspace = self.group_context[group_name].get_counts_workspace_for_run()
+            workspace_to_fit.append(workspace)
+
+        return workspace_to_fit
+
+    def get_workspace_names_for_simultaneous_fit(self, runs: str, groups: list):
+        workspace_to_fit = []
+
+        if runs == "All":
+            detector = groups[0]
+            for group_name in self.group_context.selected_groups:
+                group = self.group_context[group_name]
+                if group.detector == detector:
+                    workspace = group.get_counts_workspace_for_run()
+                    workspace_to_fit.append(workspace)
+
+        else:
+            for group_name in self.group_context.selected_groups:
+                group = self.group_context[group_name]
+                if group.run_number == runs:
+                    workspace = group.get_counts_workspace_for_run()
+                    workspace_to_fit.append(workspace)
+
+        return workspace_to_fit
+
+    def get_list_of_binned_or_unbinned_workspaces_from_equivalents(self, input_list):
+        equivalent_list = []
+        for item in input_list:
+            if "Rebin" in item:
+                item = item.replace(REBINNED_FIXED_WS_SUFFIX, "")
+                item = item.replace(REBINNED_VARIABLE_WS_SUFFIX, "")
+                equivalent_workspace = self.group_context[item].get_counts_workspace_for_run()
+                equivalent_list.append(equivalent_workspace)
+            else:
+                equivalent_workspace = self.group_context[
+                    item].get_rebined_or_unbinned_version_of_workspace_if_it_exists()
+                equivalent_list.append(equivalent_workspace)
+        return equivalent_list
+
+    @property
+    def guess_workspace_prefix(self):
+        return "__Elemental_analysis_fitting_guess__"
+
+    def get_group_name(self, workspace_name):
+        run, detector = self.group_context.get_detector_and_run_from_workspace_name(workspace_name)
+        group_name = "; ".join([run, detector])
+        return group_name
+
+    def _do_rebin(self):
+        return self.group_context.check_if_any_group_rebinned()

--- a/scripts/Muon/GUI/ElementalAnalysis2/context/ea_group_context.py
+++ b/scripts/Muon/GUI/ElementalAnalysis2/context/ea_group_context.py
@@ -79,6 +79,11 @@ class EAGroupContext(object):
     def selected_groups(self):
         return self._selected_groups
 
+    # To allow compatibility with fitting context
+    @property
+    def selected_groups_and_pairs(self):
+        return self._selected_groups
+
     def clear(self):
         self._groups = []
 
@@ -141,7 +146,7 @@ class EAGroupContext(object):
             if suffix in workspace_name:
                 workspace_name = workspace_name.replace(suffix, "")
 
-        run, detector = workspace_name.split(";")
+        run, detector, *_ = workspace_name.split(";")
 
         return run.strip(), detector.strip()
 
@@ -167,3 +172,13 @@ class EAGroupContext(object):
 
                 elif workspace_name.endswith(MATCH_GROUP_WS_SUFFIX):
                     group.remove_matches_group()
+
+    def check_if_any_group_rebinned(self):
+        """
+        checks if any group pin selected groups has been rebinned
+        :return:
+        """
+        for group_name in self._selected_groups:
+            if self[group_name].is_rebinned_workspace_present():
+                return True
+        return False

--- a/scripts/Muon/GUI/ElementalAnalysis2/elemental_analysis.py
+++ b/scripts/Muon/GUI/ElementalAnalysis2/elemental_analysis.py
@@ -103,7 +103,6 @@ class ElementalAnalysisGui(QtWidgets.QMainWindow):
         self.setup_group_calculation_disable_notifier()
         self.setup_grouping_changed_observers()
         self.setup_update_view_notifier()
-        #self.setup_fitting_notifier()
 
         self.setMinimumHeight(800)
 
@@ -131,9 +130,6 @@ class ElementalAnalysisGui(QtWidgets.QMainWindow):
         # the plot mode indices are from the order the plots are stored
         if TAB_ORDER[index] in ["Home", "Grouping", "Automatic"]:  # Plot all the selected data
             plot_mode = self.plot_widget.data_index
-        # Plot the displayed workspace
-        #elif TAB_ORDER[index] in ["Fitting"]:
-            #plot_mode = self.plot_widget.fit_index
         else:
             return
         self.plot_widget.set_plot_view(plot_mode)
@@ -177,9 +173,6 @@ class ElementalAnalysisGui(QtWidgets.QMainWindow):
     def setup_gui_variable_observers(self):
         self.context.gui_context.gui_variables_notifier.add_subscriber(
             self.grouping_tab_widget.group_tab_presenter.gui_variables_observer)
-
-        #self.fitting_tab.fitting_tab_presenter.selected_fit_results_changed.add_subscriber(
-        #    self.plot_widget.fit_mode.plot_selected_fit_observer)
 
     def setup_grouping_changed_observers(self):
         self.grouping_tab_widget.grouping_table_widget.data_changed_notifier.add_subscriber(
@@ -241,12 +234,3 @@ class ElementalAnalysisGui(QtWidgets.QMainWindow):
 
         self.context.update_view_from_model_notifier.add_subscriber(
             self.fitting_tab.fitting_tab_presenter.update_view_from_model_observer)
-
-    """def setup_fitting_notifier(self):
-        #Connect fitting tab to inform of new fits
-
-        self.fitting_tab.fitting_tab_presenter.remove_plot_guess_notifier.add_subscriber(
-            self.plot_widget.fit_mode.remove_plot_guess_observer)
-
-        self.fitting_tab.fitting_tab_presenter.update_plot_guess_notifier.add_subscriber(
-            self.plot_widget.fit_mode.update_plot_guess_observer)"""

--- a/scripts/Muon/GUI/ElementalAnalysis2/fitting_tab/ea_fitting_option_view.py
+++ b/scripts/Muon/GUI/ElementalAnalysis2/fitting_tab/ea_fitting_option_view.py
@@ -1,0 +1,23 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2021 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+from Muon.GUI.Common.fitting_widgets.general_fitting.general_fitting_options_view import GeneralFittingOptionsView
+
+from qtpy.QtWidgets import QWidget
+
+EA_FIT_BY_OPTIONS = ["Run", "Detector"]
+
+
+class EAFittingOptionsView(GeneralFittingOptionsView):
+    """
+    The GeneralFittingOptionsView includes the Simultaneous fitting options, and the cyclic dataset display combobox.
+    """
+
+    def __init__(self, parent: QWidget = None):
+        """Initializes the GeneralFittingOptionsView. By default the simultaneous options are disabled."""
+        super(EAFittingOptionsView, self).__init__(parent)
+        self.simul_fit_by_combo.clear()
+        self._setup_simultaneous_fit_by_combo_box(EA_FIT_BY_OPTIONS)

--- a/scripts/Muon/GUI/ElementalAnalysis2/fitting_tab/ea_fitting_option_view.py
+++ b/scripts/Muon/GUI/ElementalAnalysis2/fitting_tab/ea_fitting_option_view.py
@@ -12,12 +12,8 @@ EA_FIT_BY_OPTIONS = ["Run", "Detector"]
 
 
 class EAFittingOptionsView(GeneralFittingOptionsView):
-    """
-    The GeneralFittingOptionsView includes the Simultaneous fitting options, and the cyclic dataset display combobox.
-    """
 
     def __init__(self, parent: QWidget = None):
-        """Initializes the GeneralFittingOptionsView. By default the simultaneous options are disabled."""
         super(EAFittingOptionsView, self).__init__(parent)
         self.simul_fit_by_combo.clear()
         self._setup_simultaneous_fit_by_combo_box(EA_FIT_BY_OPTIONS)

--- a/scripts/Muon/GUI/ElementalAnalysis2/fitting_tab/ea_fitting_tab.py
+++ b/scripts/Muon/GUI/ElementalAnalysis2/fitting_tab/ea_fitting_tab.py
@@ -1,0 +1,21 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2021 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+from Muon.GUI.ElementalAnalysis2.fitting_tab.ea_fitting_tab_presenter import EAFittingTabPresenter
+from Muon.GUI.ElementalAnalysis2.fitting_tab.ea_fitting_tab_view import EAFittingTabView
+from Muon.GUI.ElementalAnalysis2.fitting_tab.ea_fitting_tab_model import EAFittingTabModel
+
+
+class EAFittingTabWidget(object):
+    """
+    The FittingTabWidget creates the tab used for fitting in Elemental analysis widget.
+    """
+
+    def __init__(self, context, parent):
+        self.fitting_tab_view = EAFittingTabView(parent)
+        self.fitting_tab_view.set_start_and_end_x_labels("Energy (Kev) Start", "Energy (KeV) End")
+        self.fitting_tab_model = EAFittingTabModel(context, context.fitting_context)
+        self.fitting_tab_presenter = EAFittingTabPresenter(self.fitting_tab_view, self.fitting_tab_model)

--- a/scripts/Muon/GUI/ElementalAnalysis2/fitting_tab/ea_fitting_tab.py
+++ b/scripts/Muon/GUI/ElementalAnalysis2/fitting_tab/ea_fitting_tab.py
@@ -11,7 +11,7 @@ from Muon.GUI.ElementalAnalysis2.fitting_tab.ea_fitting_tab_model import EAFitti
 
 class EAFittingTabWidget(object):
     """
-    The FittingTabWidget creates the tab used for fitting in Elemental analysis widget.
+    The EAFittingTabWidget creates the tab used for fitting in Elemental analysis widget.
     """
 
     def __init__(self, context, parent):

--- a/scripts/Muon/GUI/ElementalAnalysis2/fitting_tab/ea_fitting_tab_model.py
+++ b/scripts/Muon/GUI/ElementalAnalysis2/fitting_tab/ea_fitting_tab_model.py
@@ -1,0 +1,81 @@
+from Muon.GUI.Common.utilities.load_utils import flatten_run_list
+from mantid.api import IFunction
+from Muon.GUI.Common.fitting_widgets.general_fitting.general_fitting_model import GeneralFittingModel
+from Muon.GUI.ElementalAnalysis2.context.context import ElementalAnalysisContext
+from Muon.GUI.Common.contexts.fitting_contexts.general_fitting_context import GeneralFittingContext
+
+
+class EAFittingTabModel(GeneralFittingModel):
+
+    def __init__(self, context: ElementalAnalysisContext, fitting_context: GeneralFittingContext):
+        super(EAFittingTabModel, self).__init__(context, fitting_context)
+        self._current_spectrum = 0
+
+    @property
+    def current_spectrum(self):
+        return self._current_spectrum
+
+    @current_spectrum.setter
+    def current_spectrum(self, spectrum):
+        self._current_spectrum = spectrum
+
+    def get_simultaneous_fit_by_specifiers_to_display_from_context(self) -> list:
+        """Returns the simultaneous fit by specifiers to display in the view from the context."""
+        runs, detectors = self._get_selected_runs_and_detectors()
+        if self.simultaneous_fit_by == "Run":
+            return runs
+        elif self.simultaneous_fit_by == "Detector":
+            return detectors
+        return []
+
+    def _get_selected_runs_and_detectors(self):
+        selected_runs = []
+        selected_detectors = []
+        for group_name in self.context.group_context.selected_groups:
+            run, detector = self.context.group_context.get_detector_and_run_from_workspace_name(group_name)
+            selected_runs.append(run)
+            selected_detectors.append(detector)
+        return list(set(selected_runs)), list(set(selected_detectors))
+
+    def _get_selected_runs_from_run_list(self) -> list:
+        """Extract runs from run list of lists, which is in the format [ [run,...,runs],[runs],...,[runs] ]"""
+        current_runs = self.context.data_context.current_runs
+        return [str(run) for run in flatten_run_list(current_runs)]
+
+    def get_workspace_names_to_display_from_context(self) -> list:
+        """Returns the workspace names to display in the view based on the selected run and group/pair options."""
+        runs, groups_and_pairs = self.get_selected_runs_groups_and_pairs()
+        workspace_names = self.context.get_workspace_names_for(runs, groups_and_pairs, self.fitting_context.fit_to_raw,
+                                                               self.simultaneous_fitting_mode)
+
+        return self._check_data_exists(workspace_names)
+
+    def _get_selected_runs_groups_and_pairs_for_simultaneous_fit_mode(self) -> tuple:
+        """Returns the runs, groups and pairs that are currently selected for simultaneous fit mode."""
+        runs, Detectors = "All", []
+
+        if self.simultaneous_fit_by == "Run":
+            runs = self.simultaneous_fit_by_specifier
+        elif self.simultaneous_fit_by == "Detector":
+            Detectors = [self.simultaneous_fit_by_specifier]
+        return runs, Detectors
+
+    def _get_parameters_for_single_fit(self, dataset_name: str, single_fit_function: IFunction) -> dict:
+        """Returns the parameters used for a single fit."""
+        params = self._get_common_parameters()
+        params["Function"] = single_fit_function
+        params["WorkspaceIndex"] = self.current_spectrum
+        params["InputWorkspace"] = dataset_name
+        params["StartX"] = self.current_start_x
+        params["EndX"] = self.current_end_x
+        return params
+
+    def _get_parameters_for_simultaneous_fit(self, dataset_names: list, simultaneous_function: IFunction) -> dict:
+        """Gets the parameters to use for a simultaneous fit."""
+        params = self._get_common_parameters()
+        params["Function"] = simultaneous_function
+        params["WorkspaceIndex"] = self.current_spectrum
+        params["InputWorkspace"] = dataset_names
+        params["StartX"] = self.fitting_context.start_xs
+        params["EndX"] = self.fitting_context.end_xs
+        return params

--- a/scripts/Muon/GUI/ElementalAnalysis2/fitting_tab/ea_fitting_tab_model.py
+++ b/scripts/Muon/GUI/ElementalAnalysis2/fitting_tab/ea_fitting_tab_model.py
@@ -9,7 +9,7 @@ class EAFittingTabModel(GeneralFittingModel):
 
     def __init__(self, context: ElementalAnalysisContext, fitting_context: GeneralFittingContext):
         super(EAFittingTabModel, self).__init__(context, fitting_context)
-        self._current_spectrum = 0
+        self._current_spectrum = 2
 
     @property
     def current_spectrum(self):

--- a/scripts/Muon/GUI/ElementalAnalysis2/fitting_tab/ea_fitting_tab_model.py
+++ b/scripts/Muon/GUI/ElementalAnalysis2/fitting_tab/ea_fitting_tab_model.py
@@ -28,6 +28,11 @@ class EAFittingTabModel(GeneralFittingModel):
             return detectors
         return []
 
+    def _get_equivalent_binned_or_unbinned_workspaces(self):
+        """Returns the equivalent binned or unbinned workspaces for the current datasets."""
+        return self.context.get_list_of_binned_or_unbinned_workspaces_from_equivalents(
+            self.fitting_context.dataset_names, self.fit_to_raw)
+
     def _get_selected_runs_and_detectors(self):
         selected_runs = []
         selected_detectors = []
@@ -45,8 +50,7 @@ class EAFittingTabModel(GeneralFittingModel):
     def get_workspace_names_to_display_from_context(self) -> list:
         """Returns the workspace names to display in the view based on the selected run and group/pair options."""
         runs, groups_and_pairs = self.get_selected_runs_groups_and_pairs()
-        workspace_names = self.context.get_workspace_names_for(runs, groups_and_pairs, self.fitting_context.fit_to_raw,
-                                                               self.simultaneous_fitting_mode)
+        workspace_names = self.context.get_workspace_names_for(runs, groups_and_pairs, self.simultaneous_fitting_mode)
 
         return self._check_data_exists(workspace_names)
 

--- a/scripts/Muon/GUI/ElementalAnalysis2/fitting_tab/ea_fitting_tab_presenter.py
+++ b/scripts/Muon/GUI/ElementalAnalysis2/fitting_tab/ea_fitting_tab_presenter.py
@@ -14,6 +14,7 @@ class EAFittingTabPresenter(GeneralFittingPresenter):
     def __init__(self, view: EAFittingTabView, model: EAFittingTabModel):
         super(EAFittingTabPresenter, self).__init__(view, model)
         self.view.set_slot_for_spectrum_changed(self.handle_spectrum_changed)
+        self.handle_spectrum_changed()
 
     def handle_spectrum_changed(self):
         self.model.current_spectrum = self.view.current_workspace_index

--- a/scripts/Muon/GUI/ElementalAnalysis2/fitting_tab/ea_fitting_tab_presenter.py
+++ b/scripts/Muon/GUI/ElementalAnalysis2/fitting_tab/ea_fitting_tab_presenter.py
@@ -1,0 +1,19 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2021 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+from Muon.GUI.Common.fitting_widgets.general_fitting.general_fitting_presenter import GeneralFittingPresenter
+from Muon.GUI.ElementalAnalysis2.fitting_tab.ea_fitting_tab_view import EAFittingTabView
+from Muon.GUI.ElementalAnalysis2.fitting_tab.ea_fitting_tab_model import EAFittingTabModel
+
+
+class EAFittingTabPresenter(GeneralFittingPresenter):
+
+    def __init__(self, view: EAFittingTabView, model: EAFittingTabModel):
+        super(EAFittingTabPresenter, self).__init__(view, model)
+        self.view.set_slot_for_spectrum_changed(self.handle_spectrum_changed)
+
+    def handle_spectrum_changed(self):
+        self.model.current_spectrum = self.view.current_workspace_index

--- a/scripts/Muon/GUI/ElementalAnalysis2/fitting_tab/ea_fitting_tab_presenter.py
+++ b/scripts/Muon/GUI/ElementalAnalysis2/fitting_tab/ea_fitting_tab_presenter.py
@@ -18,3 +18,14 @@ class EAFittingTabPresenter(GeneralFittingPresenter):
 
     def handle_spectrum_changed(self):
         self.model.current_spectrum = self.view.current_workspace_index
+
+    def handle_fit_clicked(self) -> None:
+        """Handle when the fit button is clicked."""
+        if self.model.number_of_datasets < 1:
+            self.view.warning_popup("No data selected for fitting.")
+            return
+        if not self.view.fit_object:
+            return
+        self.model.fitting_context.dataset_names = self.model._get_equivalent_binned_or_unbinned_workspaces()
+        self.model.save_current_fit_function_to_undo_data()
+        self._perform_fit()

--- a/scripts/Muon/GUI/ElementalAnalysis2/fitting_tab/ea_fitting_tab_view.py
+++ b/scripts/Muon/GUI/ElementalAnalysis2/fitting_tab/ea_fitting_tab_view.py
@@ -1,0 +1,30 @@
+from Muon.GUI.Common.fitting_widgets.general_fitting.general_fitting_view import GeneralFittingView
+from Muon.GUI.ElementalAnalysis2.fitting_tab.ea_fitting_option_view import EAFittingOptionsView
+from Muon.GUI.Common.data_selectors.cyclic_data_selector_view import CyclicDataSelectorView
+from Muon.GUI.ElementalAnalysis2.plotting_widget.EA_plotting_pane.EA_plot_data_pane_model import SPECTRA_INDICES
+from qtpy.QtWidgets import QWidget
+
+
+class EAFittingTabView(GeneralFittingView):
+
+    def __init__(self, parent: QWidget = None):
+        super(GeneralFittingView, self).__init__(parent)
+        self.general_fitting_options = EAFittingOptionsView(self)
+        self.general_fitting_options_layout.addWidget(self.general_fitting_options)
+        self.spectrum_selector = CyclicDataSelectorView(self)
+        self.workspace_selector_layout.addWidget(self.spectrum_selector)
+        self.set_workspace_combo_box_label("Select workspace")
+        self.set_spectrum_combo_box_label("Select spectrum")
+        self.spectrum_selector.update_dataset_name_combo_box(reversed(list(SPECTRA_INDICES)))
+
+    def set_slot_for_spectrum_changed(self, slot) -> None:
+        self.spectrum_selector.set_slot_for_dataset_changed(slot)
+
+    def set_spectrum_combo_box_label(self, text: str) -> None:
+        """Sets the label text next to the workspace selector combobox."""
+        self.spectrum_selector.set_data_combo_box_label(text)
+
+    @property
+    def current_workspace_index(self) -> int:
+        """Returns the selected dataset name."""
+        return SPECTRA_INDICES[self.spectrum_selector.current_dataset_name]

--- a/scripts/test/Muon/elemental_analysis_2/EA_auto_tab/ea_auto_tab_model_test.py
+++ b/scripts/test/Muon/elemental_analysis_2/EA_auto_tab/ea_auto_tab_model_test.py
@@ -2,9 +2,8 @@ import unittest
 import unittest.mock as mock
 from mantid.simpleapi import CreateEmptyTableWorkspace, DeleteWorkspace
 from Muon.GUI.ElementalAnalysis2.auto_widget.ea_auto_tab_model import EAAutoTabModel
-from Muon.GUI.ElementalAnalysis2.context.context import ElementalAnalysisContext
-from Muon.GUI.ElementalAnalysis2.context.ea_group_context import EAGroupContext
 from Muon.GUI.ElementalAnalysis2.ea_group import EAGroup
+from Muon.GUI.Common.test_helpers.context_setup import setup_context_for_ea_tests
 from mantid.api import mtd
 
 
@@ -12,12 +11,10 @@ class EAAutoTabModelTest(unittest.TestCase):
 
     def setUp(self):
         workspaces = ["9999; Detector 1", "9999; Detector 2", "9999; Detector 3", "9999; Detector 4"]
-        self.group_context = EAGroupContext()
+        setup_context_for_ea_tests(self)
         for group_name in workspaces:
             self.group_context.add_group(EAGroup(group_name, group_name.split(";")[1].strip(),
                                                  group_name.split(";")[0].strip()))
-
-        self.context = ElementalAnalysisContext(None, self.group_context)
         self.model = EAAutoTabModel(self.context)
 
     @staticmethod

--- a/scripts/test/Muon/elemental_analysis_2/EA_auto_tab/ea_auto_tab_presenter_test.py
+++ b/scripts/test/Muon/elemental_analysis_2/EA_auto_tab/ea_auto_tab_presenter_test.py
@@ -2,9 +2,8 @@ import unittest
 import unittest.mock as mock
 from copy import deepcopy
 from Muon.GUI.ElementalAnalysis2.auto_widget.ea_auto_tab_presenter import EAAutoTabPresenter
-from Muon.GUI.ElementalAnalysis2.context.context import ElementalAnalysisContext
-from Muon.GUI.ElementalAnalysis2.context.ea_group_context import EAGroupContext
 from Muon.GUI.ElementalAnalysis2.ea_group import EAGroup
+from Muon.GUI.Common.test_helpers.context_setup import setup_context_for_ea_tests
 from Muon.GUI.ElementalAnalysis2.auto_widget.ea_auto_tab_model import PEAKS_WS_SUFFIX, MATCH_GROUP_WS_SUFFIX
 
 
@@ -12,7 +11,7 @@ class EAAutoTabPresenterTest(unittest.TestCase):
 
     def setUp(self):
         workspaces = ["9999; Detector 1", "9999; Detector 2", "9999; Detector 3", "9999; Detector 4"]
-        self.group_context = EAGroupContext()
+        setup_context_for_ea_tests(self)
         for group_name in workspaces:
             group = EAGroup(group_name, group_name.split(";")[1].strip(),
                             group_name.split(";")[0].strip())
@@ -20,7 +19,6 @@ class EAAutoTabPresenterTest(unittest.TestCase):
             group.update_matches_table(group_name + MATCH_GROUP_WS_SUFFIX)
             self.group_context.add_group(group)
 
-        self.context = ElementalAnalysisContext(None, self.group_context)
         self.presenter = EAAutoTabPresenter(self.context, mock.Mock(), mock.Mock(), mock.Mock())
 
     def test_run_find_peak_algorithms_if_parameters_is_None(self):

--- a/scripts/test/Muon/elemental_analysis_2/EA_fitting_tab/EA_fitting_tab_model_test.py
+++ b/scripts/test/Muon/elemental_analysis_2/EA_fitting_tab/EA_fitting_tab_model_test.py
@@ -1,0 +1,119 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2018 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+import unittest
+from unittest import mock
+from Muon.GUI.ElementalAnalysis2.fitting_tab.ea_fitting_tab_model import EAFittingTabModel
+from Muon.GUI.ElementalAnalysis2.ea_group import EAGroup
+from Muon.GUI.Common.test_helpers.context_setup import setup_context_for_ea_tests
+from mantid.api import IFunction
+
+
+class EAFittingTabModelTest(unittest.TestCase):
+
+    def setUp(self):
+        setup_context_for_ea_tests(self)
+        self.model = EAFittingTabModel(self.context, self.fitting_context)
+
+        group1 = EAGroup("9999; Detector 1", "Detector 1", "9999")
+        self.group_context.add_group(group1)
+        self.group_context.add_group_to_selected_groups("9999; Detector 1")
+
+        group2 = EAGroup("9999; Detector 2", "Detector 2", "9999")
+        self.group_context.add_group(group2)
+        self.group_context.add_group_to_selected_groups("9999; Detector 2")
+
+        group3 = EAGroup("9998; Detector 1", "Detector 1", "9999")
+        self.group_context.add_group(group3)
+        self.group_context.add_group_to_selected_groups("9998; Detector 1")
+
+    def test_get_selected_runs_and_detectors(self):
+        runs, detectors = self.model._get_selected_runs_and_detectors()
+        self.assertCountEqual(runs, ["9999", "9998"])
+        self.assertCountEqual(detectors, ["Detector 1", "Detector 2"])
+
+    def test_get_workspace_names_to_display_from_context_when_simultaneously_fitting(self):
+        self.model._check_data_exists = mock.Mock()
+        self.context.get_workspace_names_for = mock.Mock(return_value="mock_value")
+        self.model._get_selected_runs_groups_and_pairs_for_simultaneous_fit_mode = mock.Mock(return_value=["All",
+                                                                                             ["Detector 1"]])
+        self.fitting_context.fit_to_raw = True
+        self.fitting_context.simultaneous_fitting_mode = True
+        self.model.get_workspace_names_to_display_from_context()
+        self.context.get_workspace_names_for.assert_called_once_with("All", ["Detector 1"], True)
+        self.model._check_data_exists.assert_called_once_with("mock_value")
+
+    def test_get_workspace_names_to_display_from_context_when_fitting(self):
+        self.model._check_data_exists = mock.Mock()
+        self.context.get_workspace_names_for = mock.Mock(return_value="mock_value")
+        self.fitting_context.simultaneous_fitting_mode = False
+        self.model.get_workspace_names_to_display_from_context()
+        self.context.get_workspace_names_for.assert_called_once_with("All", ["9999; Detector 1", "9999; Detector 2",
+                                                                             "9998; Detector 1"], False)
+        self.model._check_data_exists.assert_called_once_with("mock_value")
+
+    def test_get_selected_runs_groups_and_pairs_for_simultaneous_fit_mode_when_fitting_by_run(self):
+        self.model.simultaneous_fit_by = "Run"
+        self.model.simultaneous_fit_by_specifier = "9999"
+        run, detector = self.model._get_selected_runs_groups_and_pairs_for_simultaneous_fit_mode()
+        self.assertEqual(run, "9999")
+        self.assertEqual(detector, [])
+
+    def test_get_selected_runs_groups_and_pairs_for_simultaneous_fit_mode_when_fitting_by_detector(self):
+        self.model.simultaneous_fit_by = "Detector"
+        self.model.simultaneous_fit_by_specifier = "Detector 1"
+        run, detector = self.model._get_selected_runs_groups_and_pairs_for_simultaneous_fit_mode()
+        self.assertEqual(run, "All")
+        self.assertEqual(detector, ["Detector 1"])
+
+    def test_get_parameters_for_single_fit(self):
+        self.model._get_common_parameters = mock.Mock(return_value={"Minimizer": "1", "EvaluationType": "2"})
+        self.model.current_spectrum = "3"
+        start_x = 0.0
+        end_x = 1000.0
+        function = mock.Mock(spec=IFunction)
+        dataset_name = "9999; Detector 1"
+        params = self.model._get_parameters_for_single_fit(dataset_name, function)
+        correct_params = {"Minimizer": "1", "EvaluationType": "2", "Function": function, "WorkspaceIndex": "3",
+                          "InputWorkspace": dataset_name, "StartX": start_x, "EndX": end_x}
+        self.assertEqual(params, correct_params)
+
+    def test_get_parameters_for_simultaneous_fit(self):
+        self.model._get_common_parameters = mock.Mock(return_value={"Minimizer": "1", "EvaluationType": "2"})
+        self.model.current_spectrum = "3"
+        self.fitting_context._start_xs = [0, 2]
+        self.fitting_context._end_xs = [8, 10]
+        function = mock.Mock(spec=IFunction)
+        dataset_names = ["9999; Detector 1", "9999; Detector 2"]
+        params = self.model._get_parameters_for_simultaneous_fit(dataset_names, function)
+        correct_params = {"Minimizer": "1", "EvaluationType": "2", "Function": function, "WorkspaceIndex": "3",
+                          "InputWorkspace": dataset_names, "StartX": [0, 2], "EndX": [8, 10]}
+        self.assertEqual(params, correct_params)
+
+    def test_get_simultaneous_fit_by_specifiers_to_display_from_context_when_detector_selected(self):
+        self.model.simultaneous_fit_by = "Detector"
+        specifiers = self.model.get_simultaneous_fit_by_specifiers_to_display_from_context()
+        self.assertCountEqual(specifiers, ["Detector 1", "Detector 2"])
+
+    def test_get_simultaneous_fit_by_specifiers_to_display_from_context_when_run_selected(self):
+        self.model.simultaneous_fit_by = "Run"
+        specifiers = self.model.get_simultaneous_fit_by_specifiers_to_display_from_context()
+        self.assertCountEqual(specifiers, ["9999", "9998"])
+
+    def test_get_equivalent_binned_or_unbinned_workspaces(self):
+        input_list = ["mock_workspace"]
+        self.fitting_context.fit_to_raw = True
+        self.context.get_list_of_binned_or_unbinned_workspaces_from_equivalents = mock.Mock()
+        self.fitting_context.dataset_names = input_list
+
+        self.model._get_equivalent_binned_or_unbinned_workspaces()
+
+        self.context.get_list_of_binned_or_unbinned_workspaces_from_equivalents.assert_called_once_with(input_list,
+                                                                                                        True)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/scripts/test/Muon/elemental_analysis_2/EA_fitting_tab/EA_fitting_tab_presenter_test.py
+++ b/scripts/test/Muon/elemental_analysis_2/EA_fitting_tab/EA_fitting_tab_presenter_test.py
@@ -1,0 +1,36 @@
+import unittest
+from unittest import mock
+from Muon.GUI.ElementalAnalysis2.fitting_tab.ea_fitting_tab_presenter import EAFittingTabPresenter
+from Muon.GUI.ElementalAnalysis2.fitting_tab.ea_fitting_tab_model import EAFittingTabModel
+from Muon.GUI.ElementalAnalysis2.fitting_tab.ea_fitting_tab_view import EAFittingTabView
+from Muon.GUI.Common.test_helpers.context_setup import setup_context_for_ea_tests
+
+
+class EAFittingTabPresenterTest(unittest.TestCase):
+    def setUp(self):
+        setup_context_for_ea_tests(self)
+        self.model = mock.Mock(spec=EAFittingTabModel)
+        self.model.context = self.context
+        self.model.fitting_context = self.fitting_context
+        self.view = mock.Mock(spec=EAFittingTabView)
+        self.presenter = EAFittingTabPresenter(self.view, self.model)
+
+    def test_handle_fit_clicked_when_there_are_no_datasets(self):
+        self.model.number_of_datasets = 0
+        self.presenter.handle_fit_clicked()
+
+        self.view.warning_popup.assert_called_once_with("No data selected for fitting.")
+
+    def test_handle_fit_clicked_when_datasets_are_present(self):
+        self.model.number_of_datasets = 3
+        self.presenter._perform_fit = mock.Mock()
+        self.presenter.handle_fit_clicked()
+
+        self.view.warning_popup.assert_not_called()
+        self.model._get_equivalent_binned_or_unbinned_workspaces.assert_called_once()
+        self.model.save_current_fit_function_to_undo_data.assert_called_once()
+        self.presenter._perform_fit.assert_called_once()
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
**Description of work.**
This pull request adds a fitting tab to the new elemental analysis GUI.

**To test:**
1. Before starting Mantid go to https://github.com/mantidproject/mantid/blob/master/Framework/Properties/Mantid.properties.template#L24 , add Muon/Elemental_Analysis_2.py to the end of the line and build Mantid.

2. Download the test files from PR #29958 and add to User Directories.

3. Open the elemental analysis 2 GUI and load 9997.
4. Use fitting tab to fit data and try simultaneous fit option 
5. Try fitting rebinned data 
6. Fits will not be seen as fit plotting pane has not been added.




Fixes #29385. 

*This does not require release notes* because  new GUI is not being released yet


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
