### PR TITLE
Remove a couple of project save related errors from Engineering Diffraction UI

### DIFF
--- a/qt/python/mantidqt/project/workspacesaver.py
+++ b/qt/python/mantidqt/project/workspacesaver.py
@@ -9,7 +9,7 @@
 import os.path
 
 from mantid.api import AnalysisDataService as ADS, IMDEventWorkspace
-from mantid.dataobjects import MDHistoWorkspace
+from mantid.dataobjects import MDHistoWorkspace, GroupingWorkspace
 from mantid import logger
 
 
@@ -45,13 +45,16 @@ class WorkspaceSaver(object):
                 if isinstance(workspace, MDHistoWorkspace) or isinstance(workspace, IMDEventWorkspace):
                     # Save normally using SaveMD
                     SaveMD(InputWorkspace=workspace_name, Filename=place_to_save_workspace + ".nxs")
+                elif isinstance(workspace, GroupingWorkspace):
+                    # catch this rather than leave SaveNexusProcessed to raise error to avoid message of type error
+                    # being logged
+                    raise RuntimeError("Grouping Workspaces not supported by SaveNexusProcessed")
                 else:
                     # Save normally using SaveNexusProcessed
                     SaveNexusProcessed(InputWorkspace=workspace_name, Filename=place_to_save_workspace + ".nxs")
+                self.output_list.append(workspace_name)
             except Exception as exc:
                 logger.warning("Couldn't save workspace in project: \"" + workspace_name + "\" because " + str(exc))
-
-            self.output_list.append(workspace_name)
 
     def get_output_list(self):
         """

--- a/scripts/Engineering/gui/engineering_diffraction/test/engineering_diffraction_io_test.py
+++ b/scripts/Engineering/gui/engineering_diffraction/test/engineering_diffraction_io_test.py
@@ -165,6 +165,9 @@ class EngineeringDiffractionDecoderTest(unittest.TestCase):
         _load_test_file()
         _create_fit_workspace()
 
+    def tearDown(self):
+        self.gui.close()
+
     def test_blank_gui_decodes(self):
         blank_dict = {'encoder_version': IO_VERSION, 'current_tab': 0, 'settings_dict': SETTINGS_DICT}
         self.gui = self.decoder.decode(blank_dict)


### PR DESCRIPTION
**Description of work.**

Neither error was blocking any functionality but removes distracting messages:

- error about widget having already been deleted on shutdown of a unit test. This was caused by the ADS being cleared before the UI was closed at the end of the unit test. I've added a tearDown method so the UI is closed first
- error during save of project while the Engineering UI was open with Focus having been run. This was due to the grouping workspace not being saved. We don't need it to be saved since the project save is meant for the Fitting tab rather than Focus tab so I've just added some better handling for grouping workspaces to avoid the red Error message in the log and to avoid the filename being written to the .mtdproj file

**To test:**

Run the unit test suite EngineeringDiffractionDecoderTest (scripts\Engineering\gui\engineering_diffraction\test\engineering_diffraction_io_test.py) and check the error shown on the linked issue isn't present any more (the 2 unit tests used to pass before and should still - so it's just the absence of the error that's the improvement)

To test the project save change:
Open engineering diffraction UI
Run calibration using these run numbers, Vanadium 236516 ceria 193749
Run focus on run 299080
Save Project
Observe there are no errors written to the log

Fixes #31012.

*This does not require release notes* because **the unit test change isn't user facing and the project save error was introduced in this release cycle in https://github.com/mantidproject/mantid/pull/31778**


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
