### PR TITLE
Resolve warning counting in cppcheck script

### DIFF
--- a/Framework/Algorithms/inc/MantidAlgorithms/CalculateMultipleScattering.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/CalculateMultipleScattering.h
@@ -77,7 +77,7 @@ private:
                               Kernel::V3D sourcePos, Kernel::PseudoRandomNumberGenerator &rng);
   Geometry::Track generateInitialTrack(const Geometry::IObject &shape,
                                        std::shared_ptr<const Geometry::ReferenceFrame> frame,
-                                       const Kernel::V3D sourcePos, Kernel::PseudoRandomNumberGenerator &rng);
+                                       const Kernel::V3D &sourcePos, Kernel::PseudoRandomNumberGenerator &rng);
   void inc_xyz(Geometry::Track &track, double vl);
   void updateWeightAndPosition(Geometry::Track &track, double &weight, const double vmfp, const double sigma_total,
                                Kernel::PseudoRandomNumberGenerator &rng);

--- a/Framework/Algorithms/src/CalculateMultipleScattering.cpp
+++ b/Framework/Algorithms/src/CalculateMultipleScattering.cpp
@@ -686,7 +686,7 @@ void CalculateMultipleScattering::updateWeightAndPosition(Geometry::Track &track
  */
 Geometry::Track CalculateMultipleScattering::generateInitialTrack(const Geometry::IObject &shape,
                                                                   std::shared_ptr<const Geometry::ReferenceFrame> frame,
-                                                                  const V3D sourcePos,
+                                                                  const V3D &sourcePos,
                                                                   Kernel::PseudoRandomNumberGenerator &rng) {
   auto sampleBox = shape.getBoundingBox();
   // generate random point on front surface of sample bounding box

--- a/buildconfig/Jenkins/cppcheck.sh
+++ b/buildconfig/Jenkins/cppcheck.sh
@@ -4,7 +4,7 @@ SCRIPT_DIR=$(dirname "$0")
 # If errors slip through to master this can be used to set a non-zero
 # allowed count while those errors are dealt with. This avoids breaking all
 # builds for all developers
-ALLOWED_ERRORS_COUNT=288
+ALLOWED_ERRORS_COUNT=287
 
 if [[ ${JOB_NAME} == *pull_requests* ]]; then
     # This relies on the fact pull requests use pull/$PR-NAME
@@ -41,7 +41,7 @@ cmake --build . --target cppcheck
 cppcheck-htmlreport --file=cppcheck.xml --title=Embedded --report-dir=cppcheck-report
 
 # Mark build as passed or failed
-errors_count=$(grep -c '</error>' $1)
+errors_count=$(grep -c '</error>' cppcheck.xml)
 if [ $errors_count -gt ${ALLOWED_ERRORS_COUNT} ]; then
   echo "CppCheck found ${ALLOWED_ERRORS_COUNT} errors."
   echo "See CppCheck link on the job page for more detail."


### PR DESCRIPTION
**Description of work.**

Fix problem in cppcheck.sh script in grep command that counts the number of cppcheck warnings. This is causing the Jenkins cppcheck job to fail on any PRs that contain C++ changes

Also in order to ensure the cppcheck job is triggered on this PR I have resolved one of the cppcheck warnings in one of my algorithms and have reduced the expected count by 1.

The cppcheck job has been the subject of some work in the last week on https://github.com/mantidproject/mantid/pull/32156 for example

**To test:**

Check cppcheck job on Jenkins runs and passes

*There is no associated issue.*

*This does not require release notes* because **no functional change to users**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
