### PR TITLE
Fix error when running Engineering diffraction calibration

### DIFF
--- a/instrument/ENGIN-X_Parameters.xml
+++ b/instrument/ENGIN-X_Parameters.xml
@@ -4,7 +4,7 @@
 the create a distinct ENTITY for each bank-->
 
 <!DOCTYPE parameter-file [
-    <!ENTITY alpha "0.0968">
+    <!ENTITY alpha_0 "0.0968">
     <!ENTITY beta_0 "0.0216">
     <!ENTITY beta_1 "0.0123">
     <!ENTITY sigma_0_sq "0.0">
@@ -25,11 +25,30 @@ the create a distinct ENTITY for each bank-->
 
 <component-link name="NorthBank" >
 
+  <parameter name="alpha_0" type="number">
+    <value val="&alpha_0;" />
+  </parameter>
+  <parameter name="beta_0" type="number">
+    <value val="&beta_0;" />
+  </parameter>
+  <parameter name="beta_1" type="number">
+    <value val="&beta_1;" />
+  </parameter>
+  <parameter name="sigma_0_sq" type="number">
+    <value val="&sigma_0_sq;" />
+  </parameter>
+  <parameter name="sigma_1_sq" type="number">
+    <value val="&sigma_1_sq;" />
+  </parameter>
+  <parameter name="sigma_2_sq" type="number">
+    <value val="&sigma_2_sq;" />
+  </parameter>
+
   <parameter name="BackToBackExponential:S" type="fitting">
     <formula eq="sqrt((&sigma_2_sq;)*centre^4+(&sigma_1_sq;)*centre^2+(&sigma_0_sq;))" unit="dSpacing" result-unit="TOF" />
   </parameter>
   <parameter name="BackToBackExponential:A" type="fitting">
-    <formula eq="((&alpha;)/centre)" unit="dSpacing" result-unit="1/TOF" /> <fixed />
+    <formula eq="((&alpha_0;)/centre)" unit="dSpacing" result-unit="1/TOF" /> <fixed />
   </parameter>
   <parameter name="BackToBackExponential:B" type="fitting">
     <formula eq="((&beta_0;)+(&beta_1;)/(centre^4))" unit="dSpacing" result-unit="1/TOF" /> <fixed />
@@ -52,11 +71,30 @@ the create a distinct ENTITY for each bank-->
 
 <component-link name="SouthBank" >
 
+  <parameter name="alpha_0" type="number">
+    <value val="&alpha_0;" />
+  </parameter>
+  <parameter name="beta_0" type="number">
+    <value val="&beta_0;" />
+  </parameter>
+  <parameter name="beta_1" type="number">
+    <value val="&beta_1;" />
+  </parameter>
+  <parameter name="sigma_0_sq" type="number">
+    <value val="&sigma_0_sq;" />
+  </parameter>
+  <parameter name="sigma_1_sq" type="number">
+    <value val="&sigma_1_sq;" />
+  </parameter>
+  <parameter name="sigma_2_sq" type="number">
+    <value val="&sigma_2_sq;" />
+  </parameter>
+
   <parameter name="BackToBackExponential:S" type="fitting">
     <formula eq="sqrt((&sigma_2_sq;)*centre^4+(&sigma_1_sq;)*centre^2+(&sigma_0_sq;))" unit="dSpacing" result-unit="TOF" />
   </parameter>
   <parameter name="BackToBackExponential:A" type="fitting">
-    <formula eq="((&alpha;)/centre)" unit="dSpacing" result-unit="1/TOF" /> <fixed />
+    <formula eq="((&alpha_0;)/centre)" unit="dSpacing" result-unit="1/TOF" /> <fixed />
   </parameter>
   <parameter name="BackToBackExponential:B" type="fitting">
     <formula eq="((&beta_0;)+(&beta_1;)/(centre^4))" unit="dSpacing" result-unit="1/TOF" /> <fixed />

--- a/scripts/Engineering/EnginX.py
+++ b/scripts/Engineering/EnginX.py
@@ -434,7 +434,7 @@ def extract_b2b_params(workspace):
     SouthBank = ws_inst.getComponentByName("SouthBank")
     params_north = []
     params_south = []
-    for param_name in ["alpha", "beta_0", "beta_1", "sigma_0_sq", "sigma_1_sq", "sigma_2_sq"]:
+    for param_name in ["alpha_0", "beta_0", "beta_1", "sigma_0_sq", "sigma_1_sq", "sigma_2_sq"]:
         params_north += [NorthBank.getNumberParameter(param_name)[0]]
         params_south += [SouthBank.getNumberParameter(param_name)[0]]
 

--- a/scripts/Engineering/EnginX.py
+++ b/scripts/Engineering/EnginX.py
@@ -268,13 +268,14 @@ def create_calibration_files(ceria_run, van_run, full_inst_calib, int_van, van_c
             spectrum_numbers = None
             bank = None
 
-    output, curves = run_calibration(sample_ws=ceria_ws,
-                                     vanadium_workspace=van_ws,
-                                     van_integration=van_integrated_ws,
-                                     bank=bank,
-                                     spectrum_numbers=spectrum_numbers,
-                                     full_inst_calib=full_inst_calib)
+    output, ceria_raw, curves = run_calibration(sample_ws=ceria_ws,
+                                                vanadium_workspace=van_ws,
+                                                van_integration=van_integrated_ws,
+                                                bank=bank,
+                                                spectrum_numbers=spectrum_numbers,
+                                                full_inst_calib=full_inst_calib)
     handle_van_curves(curves, van_curves_file)
+    bk2bk_params = extract_b2b_params(ceria_raw)
     if len(output) == 1:
         # get the values needed for saving out the .prm files
         difa = [output[0]['difa']]
@@ -282,13 +283,13 @@ def create_calibration_files(ceria_run, van_run, full_inst_calib, int_van, van_c
         tzero = [output[0]['tzero']]
         if bank is None and spectrum_numbers is None:
             save_calibration(ceria_run, van_run, calibration_directory, calibration_general, "all_banks", [crop_name],
-                             tzero, difc, difa)
+                             tzero, difc, difa, bk2bk_params)
         if spectrum_numbers is not None:
             save_calibration(ceria_run, van_run, calibration_directory, calibration_general,
-                             "bank_cropped", [crop_name], tzero, difc, difa)
+                             "bank_cropped", [crop_name], tzero, difc, difa, bk2bk_params)
         else:
             save_calibration(ceria_run, van_run, calibration_directory, calibration_general,
-                             "bank_{}".format(spec_nos), [crop_name], tzero, difc, difa)
+                             "bank_{}".format(spec_nos), [crop_name], tzero, difc, difa, bk2bk_params)
         # create the table workspace containing the parameters
         param_tbl_name = crop_name if crop_name is not None else "Cropped"
         create_params_table(difc, tzero, difa)
@@ -302,10 +303,10 @@ def create_calibration_files(ceria_run, van_run, full_inst_calib, int_van, van_c
         for i in range(1, 3):
             save_calibration(ceria_run, van_run, calibration_directory, calibration_general,
                              f"bank_{i}", [bank_names[i - 1]],
-                             [tzeros[i - 1]], [difcs[i - 1]], [difas[i - 1]])
+                             [tzeros[i - 1]], [difcs[i - 1]], [difas[i - 1]], bk2bk_params)
             plot_dicts.append(Utils.generate_tof_fit_dictionary(f"bank_{i}"))
         save_calibration(ceria_run, van_run, calibration_directory, calibration_general, "all_banks", bank_names,
-                         tzeros, difcs, difas)
+                         tzeros, difcs, difas, bk2bk_params)
         # create the table workspace containing the parameters
         create_params_table(difcs, tzeros, difas)
         Utils.plot_tof_fit(plot_dicts, ["bank_1", "bank_2"])
@@ -406,7 +407,6 @@ def run_calibration(sample_ws,
         df_kwarg = {"GroupingWorkspace": grp_ws}
         calibrate_region_of_interest("Cropped", df_kwarg)
 
-    simple.DeleteWorkspace(sample_raw)
     simple.DeleteWorkspace(ws_van)
     simple.DeleteWorkspace("tof_focused")
 
@@ -424,7 +424,21 @@ def run_calibration(sample_ws,
         row = cal_output[bank_cal].row(read)
         current_fit_params = {'difc': row['difc'], 'difa': row['difa'], 'tzero': row['tzero']}
         cal_params.append(current_fit_params)
-    return cal_params, curves_output
+    return cal_params, sample_raw, curves_output
+
+
+def extract_b2b_params(workspace):
+
+    ws_inst = workspace.getInstrument()
+    NorthBank = ws_inst.getComponentByName("NorthBank")
+    SouthBank = ws_inst.getComponentByName("SouthBank")
+    params_north = []
+    params_south = []
+    for param_name in ["alpha", "beta_0", "beta_1", "sigma_0_sq", "sigma_1_sq", "sigma_2_sq"]:
+        params_north += [NorthBank.getNumberParameter(param_name)[0]]
+        params_south += [SouthBank.getNumberParameter(param_name)[0]]
+
+    return [params_north, params_south]
 
 
 def load_van_integration_file(ints_van):
@@ -450,7 +464,7 @@ def load_van_curves_file(curves_van):
 
 
 def save_calibration(ceria_run, van_run, calibration_directory, calibration_general, name, bank_names, zeros, difcs,
-                     difas):
+                     difas, bk2bk_params):
     """
     save the calibration data
 
@@ -486,7 +500,7 @@ def save_calibration(ceria_run, van_run, calibration_directory, calibration_gene
 
     Utils.write_ENGINX_GSAS_iparam_file(output_file=gsas_iparm_fname, bank_names=bank_names, difa=difas, difc=difcs,
                                         tzero=zeros, ceria_run=ceria_run, vanadium_run=van_run,
-                                        template_file=template_file)
+                                        template_file=template_file, bk2bk_params=bk2bk_params)
     for fname, ws in pdcals_to_save.items():
         simple.SaveNexus(InputWorkspace=ws, Filename=fname)
     if not calibration_general == calibration_directory:

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/calibration/model.py
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/calibration/model.py
@@ -107,7 +107,7 @@ class CalibrationModel(object):
         SouthBank = ws_inst.getComponentByName("SouthBank")
         params_north = []
         params_south = []
-        for param_name in ["alpha", "beta_0", "beta_1", "sigma_0_sq", "sigma_1_sq", "sigma_2_sq"]:
+        for param_name in ["alpha_0", "beta_0", "beta_1", "sigma_0_sq", "sigma_1_sq", "sigma_2_sq"]:
             params_north += [NorthBank.getNumberParameter(param_name)[0]]
             params_south += [SouthBank.getNumberParameter(param_name)[0]]
 


### PR DESCRIPTION
**Description of work.**

Fix "parameter of incorrect type" error when running a calibration from the engineering diffraction UI

Reinstate the alpha value as an instrument parameter so it can be retrieved at the end of the calibration and written out to the prm file.

Also rename alpha to alpha_0 to avoid name clash with new Bk2BkExpConvPV alpha parameter

**To test:**

Open the engineering diffraction user interface (Interfaces, Diffraction menu)
Go to the Calibration tab
Run a calibration by selecting the "Create New Calibration" radio button and use Vanadium 236516, Calibration Sample 193749 (note these are in the local test data files in case the ISIS data archive isn't accessible - it's been quite slow in the last few days)
Check it completes without any errors

Fixes #32165.

*This does not require release notes* because **the problem was introduced in this release in https://github.com/mantidproject/mantid/pull/31888**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
