### PR TITLE
Frequency Domain Analysis - Dataset filter for sequential fitting

### DIFF
--- a/docs/source/release/v6.2.0/muon.rst
+++ b/docs/source/release/v6.2.0/muon.rst
@@ -12,6 +12,7 @@ New Features
 ############
 
 - The Frequency Domain Analysis interface now allows you to perform a sequential fit using the Sequential Fitting tab.
+- The Sequential Fitting tab allows you to choose the type of dataset you want to fit.
 
 Muon Analysis
 -------------

--- a/scripts/Muon/GUI/Common/contexts/data_analysis_context.py
+++ b/scripts/Muon/GUI/Common/contexts/data_analysis_context.py
@@ -55,3 +55,7 @@ class DataAnalysisContext(MuonContext):
     @property
     def window_title(self):
         return "Muon Analysis"
+
+    @staticmethod
+    def data_type_options_for_sequential():
+        return ["All"]

--- a/scripts/Muon/GUI/Common/contexts/frequency_domain_analysis_context.py
+++ b/scripts/Muon/GUI/Common/contexts/frequency_domain_analysis_context.py
@@ -72,3 +72,7 @@ class FrequencyDomainAnalysisContext(MuonContext):
     @property
     def window_title(self):
         return "Frequency Domain Analysis"
+
+    @staticmethod
+    def data_type_options_for_sequential():
+        return ["All", "FFT Real", "FFT Imaginary", "FFT Modulus", "MaxEnt"]

--- a/scripts/Muon/GUI/Common/contexts/frequency_domain_analysis_context.py
+++ b/scripts/Muon/GUI/Common/contexts/frequency_domain_analysis_context.py
@@ -49,12 +49,14 @@ class FrequencyDomainAnalysisContext(MuonContext):
     def get_names_of_frequency_domain_workspaces_to_fit(
             self, runs='', group_and_pair='', frequency_type="None"):
         run_list = self.get_runs(runs)
-        names=[]
+        names = []
         for group_pair in group_and_pair:
             group, pair = self.get_group_and_pair(group_pair)
             names += self._frequency_context.get_frequency_workspace_names(
                 run_list, group, pair, frequency_type)
-        return names
+
+        # Remove duplicates from the list
+        return list(dict.fromkeys(names))
 
     def get_names_of_time_domain_workspaces_to_fit(
             self, runs='', group_and_pair='', rebin=False):

--- a/scripts/Muon/GUI/Common/contexts/frequency_domain_analysis_context.py
+++ b/scripts/Muon/GUI/Common/contexts/frequency_domain_analysis_context.py
@@ -75,4 +75,4 @@ class FrequencyDomainAnalysisContext(MuonContext):
 
     @staticmethod
     def data_type_options_for_sequential():
-        return ["All", "FFT Real", "FFT Imaginary", "FFT Modulus", "MaxEnt"]
+        return ["All", "FD_Re", "FD_Im", "FD_mod", "MaxEnt"]

--- a/scripts/Muon/GUI/Common/fitting_widgets/basic_fitting/basic_fitting_model.py
+++ b/scripts/Muon/GUI/Common/fitting_widgets/basic_fitting/basic_fitting_model.py
@@ -829,22 +829,17 @@ class BasicFittingModel:
         for name in self.fitting_context.dataset_names:
             runs.append(get_run_numbers_as_string_from_workspace_name(name, self.context.data_context.instrument))
             groups_and_pairs.append(get_group_or_pair_from_name(name))
-        return self._get_datasets_containing_string(self.fitting_context.dataset_names, runs, groups_and_pairs,
-                                                    display_type)
+        return self._get_datasets_containing_string(display_type, self.fitting_context.dataset_names, runs,
+                                                    groups_and_pairs)
 
     @staticmethod
-    def _get_datasets_containing_string(dataset_names: list, runs: list, groups_and_pairs: list, display_type: str) -> tuple:
+    def _get_datasets_containing_string(display_type: str, dataset_names: list, *corresponding_dataset_args) -> tuple:
         """Returns the dataset names that contain a string and returns its associated runs/groups/pairs."""
         if display_type == "All":
-            return dataset_names, runs, groups_and_pairs
+            return dataset_names, *corresponding_dataset_args
 
-        filtered_names, filtered_runs, filtered_group_pairs = [], [], []
-        for dataset_name, run, group_and_pair in zip(dataset_names, runs, groups_and_pairs):
-            if display_type in dataset_name:
-                filtered_names.append(dataset_name)
-                filtered_runs.append(run)
-                filtered_group_pairs.append(group_and_pair)
-        return filtered_names, filtered_runs, filtered_group_pairs
+        # Filter the data based on a name in the dataset_names containing a string
+        return zip(*filter(lambda x: display_type in x[0], zip(dataset_names, *corresponding_dataset_args)))
 
     def get_all_fit_function_parameter_values_for(self, fit_function: IFunction) -> list:
         """Returns the values of the fit function parameters."""
@@ -872,8 +867,8 @@ class BasicFittingModel:
         if display_type == "All":
             return self.get_all_fit_functions()
         else:
-            return [function for dataset_name, function in zip(self.dataset_names, fit_functions)
-                    if display_type in dataset_name]
+            _, filtered_functions = self._get_datasets_containing_string(display_type, self.dataset_names, fit_functions)
+            return filtered_functions
 
     def get_fit_workspace_names_from_groups_and_runs(self, runs: list, groups_and_pairs: list) -> list:
         """Returns the workspace names to use for the given runs and groups/pairs."""

--- a/scripts/Muon/GUI/Common/fitting_widgets/basic_fitting/basic_fitting_model.py
+++ b/scripts/Muon/GUI/Common/fitting_widgets/basic_fitting/basic_fitting_model.py
@@ -836,7 +836,7 @@ class BasicFittingModel:
     def _get_datasets_containing_string(display_type: str, dataset_names: list, *corresponding_dataset_args) -> tuple:
         """Returns the dataset names that contain a string and returns its associated runs/groups/pairs."""
         if display_type == "All":
-            return dataset_names, *corresponding_dataset_args
+            return (dataset_names, *corresponding_dataset_args)
 
         # Filter the data based on a name in the dataset_names containing a string
         return zip(*filter(lambda x: display_type in x[0], zip(dataset_names, *corresponding_dataset_args)))

--- a/scripts/Muon/GUI/Common/fitting_widgets/basic_fitting/basic_fitting_model.py
+++ b/scripts/Muon/GUI/Common/fitting_widgets/basic_fitting/basic_fitting_model.py
@@ -823,13 +823,28 @@ class BasicFittingModel:
         else:
             return ""
 
-    def get_runs_groups_and_pairs_for_fits(self) -> tuple:
+    def get_runs_groups_and_pairs_for_fits(self, display_type: str) -> tuple:
         """Returns the runs and group/pairs corresponding to the selected dataset names."""
         runs, groups_and_pairs = [], []
         for name in self.fitting_context.dataset_names:
             runs.append(get_run_numbers_as_string_from_workspace_name(name, self.context.data_context.instrument))
             groups_and_pairs.append(get_group_or_pair_from_name(name))
-        return self.fitting_context.dataset_names, runs, groups_and_pairs
+        return self._get_datasets_containing_string(self.fitting_context.dataset_names, runs, groups_and_pairs,
+                                                    display_type)
+
+    @staticmethod
+    def _get_datasets_containing_string(dataset_names: list, runs: list, groups_and_pairs: list, display_type: str) -> tuple:
+        """Returns the dataset names that contain a string and returns its associated runs/groups/pairs."""
+        if display_type == "All":
+            return dataset_names, runs, groups_and_pairs
+
+        filtered_names, filtered_runs, filtered_group_pairs = [], [], []
+        for dataset_name, run, group_and_pair in zip(dataset_names, runs, groups_and_pairs):
+            if display_type in dataset_name:
+                filtered_names.append(dataset_name)
+                filtered_runs.append(run)
+                filtered_group_pairs.append(group_and_pair)
+        return filtered_names, filtered_runs, filtered_group_pairs
 
     def get_all_fit_function_parameter_values_for(self, fit_function: IFunction) -> list:
         """Returns the values of the fit function parameters."""
@@ -847,6 +862,18 @@ class BasicFittingModel:
     def get_all_fit_functions(self) -> list:
         """Returns all the fit functions for the current fitting mode."""
         return self.fitting_context.single_fit_functions
+
+    def get_all_fit_functions_for(self, display_type: str) -> list:
+        """Returns all the fit functions for datasets with a name containing a string."""
+        return self._filter_functions_by_dataset_string(display_type, self.single_fit_functions)
+
+    def _filter_functions_by_dataset_string(self, display_type: str, fit_functions: list) -> list:
+        """Filters out the fit functions corresponding to dataset names that do not contain a string."""
+        if display_type == "All":
+            return self.get_all_fit_functions()
+        else:
+            return [function for dataset_name, function in zip(self.dataset_names, fit_functions)
+                    if display_type in dataset_name]
 
     def get_fit_workspace_names_from_groups_and_runs(self, runs: list, groups_and_pairs: list) -> list:
         """Returns the workspace names to use for the given runs and groups/pairs."""

--- a/scripts/Muon/GUI/Common/fitting_widgets/general_fitting/general_fitting_model.py
+++ b/scripts/Muon/GUI/Common/fitting_widgets/general_fitting/general_fitting_model.py
@@ -451,8 +451,8 @@ class GeneralFittingModel(BasicFittingModel):
         groups_and_pairs = [get_group_or_pair_from_name(name) for name in self.fitting_context.dataset_names]
         workspace_names = ["/".join(self.get_fit_workspace_names_from_groups_and_runs([run], groups_and_pairs))
                            for run in runs]
-        return self._get_datasets_containing_string(workspace_names, runs, [";".join(groups_and_pairs)] * len(runs),
-                                                    display_type)
+        return self._get_datasets_containing_string(display_type, workspace_names, runs,
+                                                    [";".join(groups_and_pairs)] * len(runs))
 
     def _get_runs_groups_and_pairs_for_simultaneous_fit_by_groups_and_pairs(self, display_type: str):
         """Returns the runs and group/pairs for the selected data in simultaneous fit by group/pairs mode."""
@@ -461,8 +461,8 @@ class GeneralFittingModel(BasicFittingModel):
         groups_and_pairs = self._get_selected_groups_and_pairs()
         workspace_names = ["/".join(self.get_fit_workspace_names_from_groups_and_runs(runs, [group_and_pair]))
                            for group_and_pair in groups_and_pairs]
-        return self._get_datasets_containing_string(workspace_names, [";".join(runs)] * len(groups_and_pairs),
-                                                    groups_and_pairs, display_type)
+        return self._get_datasets_containing_string(display_type, workspace_names,
+                                                    [";".join(runs)] * len(groups_and_pairs), groups_and_pairs)
 
     def get_all_fit_functions(self) -> list:
         """Returns all the fit functions for the current fitting mode."""

--- a/scripts/Muon/GUI/Common/fitting_widgets/general_fitting/general_fitting_model.py
+++ b/scripts/Muon/GUI/Common/fitting_widgets/general_fitting/general_fitting_model.py
@@ -429,38 +429,40 @@ class GeneralFittingModel(BasicFittingModel):
     Methods used by the Sequential Fitting Tab
     """
 
-    def get_runs_groups_and_pairs_for_fits(self):
+    def get_runs_groups_and_pairs_for_fits(self, display_type: str) -> tuple:
         """Returns the runs and group/pairs corresponding to the selected dataset names."""
         if not self.fitting_context.simultaneous_fitting_mode:
-            return super().get_runs_groups_and_pairs_for_fits()
+            return super().get_runs_groups_and_pairs_for_fits(display_type)
         else:
-            return self._get_runs_groups_and_pairs_for_simultaneous_fit()
+            return self._get_runs_groups_and_pairs_for_simultaneous_fit(display_type)
 
-    def _get_runs_groups_and_pairs_for_simultaneous_fit(self) -> tuple:
+    def _get_runs_groups_and_pairs_for_simultaneous_fit(self, display_type: str) -> tuple:
         """Returns the runs and group/pairs corresponding to the selected dataset names in simultaneous fitting mode."""
         if self.fitting_context.simultaneous_fit_by == "Run":
-            return self._get_runs_groups_and_pairs_for_simultaneous_fit_by_runs()
+            return self._get_runs_groups_and_pairs_for_simultaneous_fit_by_runs(display_type)
         elif self.fitting_context.simultaneous_fit_by == "Group/Pair":
-            return self._get_runs_groups_and_pairs_for_simultaneous_fit_by_groups_and_pairs()
+            return self._get_runs_groups_and_pairs_for_simultaneous_fit_by_groups_and_pairs(display_type)
         else:
             return [], [], []
 
-    def _get_runs_groups_and_pairs_for_simultaneous_fit_by_runs(self):
+    def _get_runs_groups_and_pairs_for_simultaneous_fit_by_runs(self, display_type: str):
         """Returns the runs and group/pairs for the selected data in simultaneous fit by runs mode."""
         runs = self._get_selected_runs()
         groups_and_pairs = [get_group_or_pair_from_name(name) for name in self.fitting_context.dataset_names]
         workspace_names = ["/".join(self.get_fit_workspace_names_from_groups_and_runs([run], groups_and_pairs))
                            for run in runs]
-        return workspace_names, runs, [";".join(groups_and_pairs)] * len(runs)
+        return self._get_datasets_containing_string(workspace_names, runs, [";".join(groups_and_pairs)] * len(runs),
+                                                    display_type)
 
-    def _get_runs_groups_and_pairs_for_simultaneous_fit_by_groups_and_pairs(self):
+    def _get_runs_groups_and_pairs_for_simultaneous_fit_by_groups_and_pairs(self, display_type: str):
         """Returns the runs and group/pairs for the selected data in simultaneous fit by group/pairs mode."""
         runs = [get_run_numbers_as_string_from_workspace_name(name, self.context.data_context.instrument)
                 for name in self.fitting_context.dataset_names]
         groups_and_pairs = self._get_selected_groups_and_pairs()
         workspace_names = ["/".join(self.get_fit_workspace_names_from_groups_and_runs(runs, [group_and_pair]))
                            for group_and_pair in groups_and_pairs]
-        return workspace_names, [";".join(runs)] * len(groups_and_pairs), groups_and_pairs
+        return self._get_datasets_containing_string(workspace_names, [";".join(runs)] * len(groups_and_pairs),
+                                                    groups_and_pairs, display_type)
 
     def get_all_fit_functions(self) -> list:
         """Returns all the fit functions for the current fitting mode."""
@@ -468,6 +470,13 @@ class GeneralFittingModel(BasicFittingModel):
             return [self.fitting_context.simultaneous_fit_function]
         else:
             return super().get_all_fit_functions()
+
+    def get_all_fit_functions_for(self, display_type: str) -> list:
+        """Returns all the fit functions for datasets with a name containing a string."""
+        if self.fitting_context.simultaneous_fitting_mode:
+            return [self.fitting_context.simultaneous_fit_function]
+        else:
+            return super().get_all_fit_functions_for(display_type)
 
     def update_ws_fit_function_parameters(self, dataset_names: list, parameter_values: list) -> None:
         """Updates the function parameter values for the given dataset names."""

--- a/scripts/Muon/GUI/Common/fitting_widgets/tf_asymmetry_fitting/tf_asymmetry_fitting_model.py
+++ b/scripts/Muon/GUI/Common/fitting_widgets/tf_asymmetry_fitting/tf_asymmetry_fitting_model.py
@@ -716,6 +716,16 @@ class TFAsymmetryFittingModel(GeneralFittingModel):
         else:
             return super().get_all_fit_functions()
 
+    def get_all_fit_functions_for(self, display_type: str) -> list:
+        """Returns all the fit functions for datasets with a name containing a string."""
+        if self.fitting_context.tf_asymmetry_mode:
+            if self.fitting_context.simultaneous_fitting_mode:
+                return [self.fitting_context.tf_asymmetry_simultaneous_function]
+            else:
+                return self._filter_functions_by_dataset_string(display_type, self.tf_asymmetry_single_functions)
+        else:
+            return super().get_all_fit_functions_for(display_type)
+
     def _parse_parameter_values(self, all_parameter_values: list):
         """Separate the parameter values into the normalisations and ordinary parameter values."""
         if not self.fitting_context.tf_asymmetry_mode:

--- a/scripts/Muon/GUI/Common/fitting_widgets/tf_asymmetry_fitting/tf_asymmetry_fitting_model.py
+++ b/scripts/Muon/GUI/Common/fitting_widgets/tf_asymmetry_fitting/tf_asymmetry_fitting_model.py
@@ -719,10 +719,7 @@ class TFAsymmetryFittingModel(GeneralFittingModel):
     def get_all_fit_functions_for(self, display_type: str) -> list:
         """Returns all the fit functions for datasets with a name containing a string."""
         if self.fitting_context.tf_asymmetry_mode:
-            if self.fitting_context.simultaneous_fitting_mode:
-                return [self.fitting_context.tf_asymmetry_simultaneous_function]
-            else:
-                return self._filter_functions_by_dataset_string(display_type, self.tf_asymmetry_single_functions)
+            return self.get_all_fit_functions()
         else:
             return super().get_all_fit_functions_for(display_type)
 

--- a/scripts/Muon/GUI/Common/seq_fitting_tab_widget/seq_fitting_tab.ui
+++ b/scripts/Muon/GUI/Common/seq_fitting_tab_widget/seq_fitting_tab.ui
@@ -14,7 +14,38 @@
    <string>Form</string>
   </property>
   <layout class="QGridLayout" name="gridLayout_3">
-   <item row="8" column="0" colspan="3">
+   <item row="0" column="2">
+    <widget class="QLabel" name="filter_by_label">
+     <property name="text">
+      <string>Filter by:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="3" colspan="2">
+    <widget class="QComboBox" name="data_type_combo_box">
+     <property name="toolTip">
+      <string>Select the type of data you want to sequentially fit</string>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="0">
+    <widget class="QRadioButton" name="previous_fit_values_radio">
+     <property name="text">
+      <string>Parameters from previous fit</string>
+     </property>
+     <property name="checked">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="1">
+    <widget class="QPushButton" name="fit_selected_button">
+     <property name="text">
+      <string>Fit selected</string>
+     </property>
+    </widget>
+   </item>
+   <item row="7" column="0" colspan="5">
     <widget class="QSplitter" name="splitter">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
@@ -24,24 +55,10 @@
      </widget>
     </widget>
    </item>
-   <item row="5" column="0">
-    <layout class="QHBoxLayout" name="horizontalLayout_2">
-     <item>
-      <widget class="QRadioButton" name="previous_fit_values_radio">
-       <property name="text">
-        <string>Parameters from previous fit</string>
-       </property>
-       <property name="checked">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
-   <item row="5" column="1">
-    <widget class="QRadioButton" name="initial_fit_values_radio">
+   <item row="4" column="2" colspan="3">
+    <widget class="QCheckBox" name="copy_fit_checkbox">
      <property name="text">
-      <string>Initial parameters for each fit</string>
+      <string>Copy fit parameters to all</string>
      </property>
     </widget>
    </item>
@@ -58,27 +75,10 @@
      </property>
     </widget>
    </item>
-   <item row="2" column="0">
-    <layout class="QGridLayout" name="gridLayout"/>
-   </item>
-   <item row="0" column="1">
-    <widget class="QPushButton" name="fit_selected_button">
+   <item row="4" column="1">
+    <widget class="QRadioButton" name="initial_fit_values_radio">
      <property name="text">
-      <string>Fit selected</string>
-     </property>
-    </widget>
-   </item>
-   <item row="5" column="2">
-    <widget class="QCheckBox" name="copy_fit_checkbox">
-     <property name="text">
-      <string>Copy fit parameters to all</string>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="2">
-    <widget class="QComboBox" name="data_type_combo_box">
-     <property name="toolTip">
-      <string>Select the type of data you want to sequentially fit</string>
+      <string>Initial parameters for each fit</string>
      </property>
     </widget>
    </item>

--- a/scripts/Muon/GUI/Common/seq_fitting_tab_widget/seq_fitting_tab.ui
+++ b/scripts/Muon/GUI/Common/seq_fitting_tab_widget/seq_fitting_tab.ui
@@ -75,6 +75,13 @@
      </property>
     </widget>
    </item>
+   <item row="0" column="2">
+    <widget class="QComboBox" name="data_type_combo_box">
+     <property name="toolTip">
+      <string>Select the type of data you want to sequentially fit</string>
+     </property>
+    </widget>
+   </item>
   </layout>
  </widget>
  <resources/>

--- a/scripts/Muon/GUI/Common/seq_fitting_tab_widget/seq_fitting_tab_presenter.py
+++ b/scripts/Muon/GUI/Common/seq_fitting_tab_widget/seq_fitting_tab_presenter.py
@@ -29,6 +29,8 @@ class SeqFittingTabPresenter(object):
         self.fit_parameter_changed_notifier = GenericObservable()
         self.sequential_fit_finished_notifier = GenericObservable()
 
+        self.view.set_slot_for_display_data_type_changed(self.handle_selected_workspaces_changed)
+
         # Observers
         self.selected_workspaces_observer = GenericObserver(self.handle_selected_workspaces_changed)
         self.fit_type_changed_observer = GenericObserver(self.handle_selected_workspaces_changed)
@@ -56,8 +58,10 @@ class SeqFittingTabPresenter(object):
             self.view.fit_table.set_parameters_and_values(parameters, parameter_values)
 
     def _get_fit_function_parameter_values_from_fitting_model(self):
+        display_type = self.view.selected_data_type()
+
         parameter_values = [self.model.get_all_fit_function_parameter_values_for(fit_function)
-                            for row, fit_function in enumerate(self.model.get_all_fit_functions())]
+                            for row, fit_function in enumerate(self.model.get_all_fit_functions_for(display_type))]
         if len(parameter_values) != self.view.fit_table.get_number_of_fits():
             parameter_values *= self.view.fit_table.get_number_of_fits()
         return parameter_values
@@ -69,8 +73,11 @@ class SeqFittingTabPresenter(object):
             self.view.fit_table.set_parameter_values_for_row(row, parameter_values)
 
     def handle_selected_workspaces_changed(self):
-        workspace_names, runs, groups_and_pairs = self.model.get_runs_groups_and_pairs_for_fits()
+        display_type = self.view.selected_data_type()
+
+        workspace_names, runs, groups_and_pairs = self.model.get_runs_groups_and_pairs_for_fits(display_type)
         self.view.fit_table.set_fit_workspaces(workspace_names, runs, groups_and_pairs)
+
         self.handle_fit_function_updated()
 
     def handle_fit_selected_pressed(self):

--- a/scripts/Muon/GUI/Common/seq_fitting_tab_widget/seq_fitting_tab_presenter.py
+++ b/scripts/Muon/GUI/Common/seq_fitting_tab_widget/seq_fitting_tab_presenter.py
@@ -24,6 +24,8 @@ class SeqFittingTabPresenter(object):
         self.calculation_thread = None
         self.fitting_calculation_model = None
 
+        self.view.set_data_type_options(self.context.data_type_options_for_sequential())
+
         self.fit_parameter_changed_notifier = GenericObservable()
         self.sequential_fit_finished_notifier = GenericObservable()
 

--- a/scripts/Muon/GUI/Common/seq_fitting_tab_widget/seq_fitting_tab_view.py
+++ b/scripts/Muon/GUI/Common/seq_fitting_tab_widget/seq_fitting_tab_view.py
@@ -27,6 +27,13 @@ class SeqFittingTabView(QtWidgets.QWidget, ui_seq_fitting_tab):
     def warning_popup(self, message):
         warning(message, parent=self)
 
+    def set_data_type_options(self, data_type_options: list) -> None:
+        self.data_type_combo_box.clear()
+        self.data_type_combo_box.addItems(data_type_options)
+
+    def hide_data_type_combo_box(self):
+        self.data_type_combo_box.hide()
+
     def use_initial_values_for_fits(self):
         return self.initial_fit_values_radio.isChecked()
 

--- a/scripts/Muon/GUI/Common/seq_fitting_tab_widget/seq_fitting_tab_view.py
+++ b/scripts/Muon/GUI/Common/seq_fitting_tab_widget/seq_fitting_tab_view.py
@@ -35,6 +35,7 @@ class SeqFittingTabView(QtWidgets.QWidget, ui_seq_fitting_tab):
         self.data_type_combo_box.addItems(data_type_options)
 
     def hide_data_type_combo_box(self):
+        self.filter_by_label.hide()
         self.data_type_combo_box.hide()
 
     def selected_data_type(self) -> str:

--- a/scripts/Muon/GUI/Common/seq_fitting_tab_widget/seq_fitting_tab_view.py
+++ b/scripts/Muon/GUI/Common/seq_fitting_tab_widget/seq_fitting_tab_view.py
@@ -27,12 +27,18 @@ class SeqFittingTabView(QtWidgets.QWidget, ui_seq_fitting_tab):
     def warning_popup(self, message):
         warning(message, parent=self)
 
+    def set_slot_for_display_data_type_changed(self, slot):
+        self.data_type_combo_box.currentIndexChanged.connect(slot)
+
     def set_data_type_options(self, data_type_options: list) -> None:
         self.data_type_combo_box.clear()
         self.data_type_combo_box.addItems(data_type_options)
 
     def hide_data_type_combo_box(self):
         self.data_type_combo_box.hide()
+
+    def selected_data_type(self) -> str:
+        return self.data_type_combo_box.currentText()
 
     def use_initial_values_for_fits(self):
         return self.initial_fit_values_radio.isChecked()

--- a/scripts/Muon/GUI/Common/seq_fitting_tab_widget/seq_fitting_tab_widget.py
+++ b/scripts/Muon/GUI/Common/seq_fitting_tab_widget/seq_fitting_tab_widget.py
@@ -36,6 +36,7 @@ class SeqFittingTabWidget(object):
             self.seq_fitting_tab_view.fit_table.hide_run_column()
             self.seq_fitting_tab_view.fit_table.hide_group_column()
         else:
+            self.seq_fitting_tab_view.hide_data_type_combo_box()
             self.seq_fitting_tab_view.fit_table.hide_workspace_column()
 
         context.deleted_plots_notifier.add_subscriber(self.seq_fitting_tab_presenter.selected_workspaces_observer)

--- a/scripts/test/Muon/fitting_widgets/basic_fitting/basic_fitting_model_test.py
+++ b/scripts/test/Muon/fitting_widgets/basic_fitting/basic_fitting_model_test.py
@@ -677,7 +677,7 @@ class BasicFittingModelTest(unittest.TestCase):
 
         self.model.dataset_names = self.dataset_names
 
-        workspace_names, runs, groups_and_pairs = self.model.get_runs_groups_and_pairs_for_fits()
+        workspace_names, runs, groups_and_pairs = self.model.get_runs_groups_and_pairs_for_fits("All")
         self.assertEqual(workspace_names, self.dataset_names)
         self.assertEqual(runs, ["20884", "20884"])
         self.assertEqual(groups_and_pairs, ["fwd", "top"])

--- a/scripts/test/Muon/fitting_widgets/basic_fitting/basic_fitting_model_test.py
+++ b/scripts/test/Muon/fitting_widgets/basic_fitting/basic_fitting_model_test.py
@@ -682,6 +682,36 @@ class BasicFittingModelTest(unittest.TestCase):
         self.assertEqual(runs, ["20884", "20884"])
         self.assertEqual(groups_and_pairs, ["fwd", "top"])
 
+    def test_that_get_runs_groups_and_pairs_for_fits_will_attempt_to_get_the_runs_groups_and_pairs_for_a_fwd_type(self):
+        self.mock_context_instrument = mock.PropertyMock(return_value="EMU")
+        type(self.model.context.data_context).instrument = self.mock_context_instrument
+
+        self.model.dataset_names = self.dataset_names
+
+        workspace_names, runs, groups_and_pairs = self.model.get_runs_groups_and_pairs_for_fits("fwd")
+        self.assertEqual(list(workspace_names), ["EMU20884; Group; fwd; Asymmetry"])
+        self.assertEqual(list(runs), ["20884"])
+        self.assertEqual(list(groups_and_pairs), ["fwd"])
+
+    def test_that_get_all_fit_functions_for_will_get_all_the_fit_functions_when_the_display_type_is_all(self):
+        self.model.dataset_names = self.dataset_names
+        self.model.single_fit_functions = self.single_fit_functions
+
+        filtered_functions = self.model.get_all_fit_functions_for("All")
+
+        self.assertEqual(len(filtered_functions), len(self.model.single_fit_functions))
+        self.assertEqual(self.model.get_fit_function_parameter_values(filtered_functions[0])[0], [0.0])
+        self.assertEqual(self.model.get_fit_function_parameter_values(filtered_functions[1])[0], [0.0])
+
+    def test_that_get_all_fit_functions_for_will_get_only_the_fwd_fit_function_when_the_display_type_is_fwd(self):
+        self.model.dataset_names = self.dataset_names
+        self.model.single_fit_functions = self.single_fit_functions
+
+        filtered_functions = self.model.get_all_fit_functions_for("fwd")
+
+        self.assertEqual(len(filtered_functions), 1)
+        self.assertEqual(self.model.get_fit_function_parameter_values(filtered_functions[0])[0], [0.0])
+
     def test_that_get_fit_function_parameter_values_will_return_the_parameter_values_in_the_specified_function(self):
         self.assertEqual(self.model.get_fit_function_parameter_values(self.single_fit_functions[0])[0], [0.0])
 

--- a/scripts/test/Muon/fitting_widgets/general_fitting/general_fitting_model_test.py
+++ b/scripts/test/Muon/fitting_widgets/general_fitting/general_fitting_model_test.py
@@ -497,11 +497,11 @@ class GeneralFittingModelTest(unittest.TestCase):
         self.model.simultaneous_fitting_mode = True
         self.model.simultaneous_fit_by = "Run"
 
-        runs, groups_and_pairs = self.model.get_runs_groups_and_pairs_for_fits()
+        runs, groups_and_pairs = self.model.get_runs_groups_and_pairs_for_fits("All")
         self.assertEqual(runs, ["62260"])
         self.assertEqual(groups_and_pairs, ["fwd;bwd;long"])
 
-        self.model._get_runs_groups_and_pairs_for_simultaneous_fit_by_runs.assert_called_once_with()
+        self.model._get_runs_groups_and_pairs_for_simultaneous_fit_by_runs.assert_called_once_with("All")
 
     def test_that_get_runs_groups_and_pairs_for_fits_will_attempt_to_get_it_by_groups_when_in_simultaneous_fitting_mode(self):
         self.model._get_runs_groups_and_pairs_for_simultaneous_fit_by_groups_and_pairs = \
@@ -509,11 +509,11 @@ class GeneralFittingModelTest(unittest.TestCase):
         self.model.simultaneous_fitting_mode = True
         self.model.simultaneous_fit_by = "Group/Pair"
 
-        runs, groups_and_pairs = self.model.get_runs_groups_and_pairs_for_fits()
+        runs, groups_and_pairs = self.model.get_runs_groups_and_pairs_for_fits("All")
         self.assertEqual(runs, ["62260;62261;62262"])
         self.assertEqual(groups_and_pairs, ["fwd", "bwd"])
 
-        self.model._get_runs_groups_and_pairs_for_simultaneous_fit_by_groups_and_pairs.assert_called_once_with()
+        self.model._get_runs_groups_and_pairs_for_simultaneous_fit_by_groups_and_pairs.assert_called_once_with("All")
 
     def test_that_get_fit_function_parameter_values_will_return_the_parameter_values_in_the_specified_function(self):
         self.assertEqual(self.model.get_fit_function_parameter_values(self.simultaneous_fit_function)[0], [0.0, 0.0])

--- a/scripts/test/Muon/fitting_widgets/general_fitting/general_fitting_model_test.py
+++ b/scripts/test/Muon/fitting_widgets/general_fitting/general_fitting_model_test.py
@@ -515,6 +515,17 @@ class GeneralFittingModelTest(unittest.TestCase):
 
         self.model._get_runs_groups_and_pairs_for_simultaneous_fit_by_groups_and_pairs.assert_called_once_with("All")
 
+    def test_that_get_all_fit_functions_for_will_return_the_simultaneous_fit_function_when_in_simultaneous_mode(self):
+        self.model.dataset_names = self.dataset_names
+        self.model.simultaneous_fit_function = self.simultaneous_fit_function
+        self.model.simultaneous_fitting_mode = True
+
+        filtered_function_all = self.model.get_all_fit_functions_for("All")
+        self.assertEqual(self.model.get_fit_function_parameter_values(filtered_function_all[0]), ([0.0, 0.0], [0.0, 0.0]))
+
+        filtered_function_fwd = self.model.get_all_fit_functions_for("fwd")
+        self.assertEqual(self.model.get_fit_function_parameter_values(filtered_function_fwd[0]), ([0.0, 0.0], [0.0, 0.0]))
+
     def test_that_get_fit_function_parameter_values_will_return_the_parameter_values_in_the_specified_function(self):
         self.assertEqual(self.model.get_fit_function_parameter_values(self.simultaneous_fit_function)[0], [0.0, 0.0])
 

--- a/scripts/test/Muon/fitting_widgets/tf_asymmetry_fitting/tf_asymmetry_fitting_model_test.py
+++ b/scripts/test/Muon/fitting_widgets/tf_asymmetry_fitting/tf_asymmetry_fitting_model_test.py
@@ -656,6 +656,42 @@ class TFAsymmetryFittingModelTest(unittest.TestCase):
         self.assertEqual(message, "Only Groups can be fitted in TF Asymmetry mode. "
                                   "Please unselect the following Pairs/Diffs in the grouping tab: 'bottom', 'top'")
 
+    def test_that_get_all_fit_functions_for_returns_all_the_tf_single_functions_for_the_display_type_all(self):
+        self.model.dataset_names = self.dataset_names
+        self.model.single_fit_functions = self.single_fit_functions
+        self.model.tf_asymmetry_single_functions = [self.tf_single_function.clone(), self.tf_single_function.clone()]
+        self.model.tf_asymmetry_mode = True
+
+        filtered_functions = self.model.get_all_fit_functions_for("All")
+
+        self.assertEqual(len(filtered_functions), len(self.model.single_fit_functions))
+        self.assertEqual(self.model.get_fit_function_parameter_values(filtered_functions[0])[0], [0.0, 0.0, 0.0, 0.2, 0.2])
+        self.assertEqual(self.model.get_fit_function_parameter_values(filtered_functions[1])[0], [0.0, 0.0, 0.0, 0.2, 0.2])
+
+    def test_that_get_all_fit_functions_for_returns_the_fwd_tf_single_functions_for_the_display_type_fwd(self):
+        self.model.dataset_names = self.dataset_names
+        self.model.single_fit_functions = self.single_fit_functions
+        self.model.tf_asymmetry_single_functions = [self.tf_single_function.clone(), self.tf_single_function.clone()]
+        self.model.tf_asymmetry_mode = True
+
+        filtered_functions = self.model.get_all_fit_functions_for("fwd")
+
+        self.assertEqual(len(filtered_functions), 1)
+        self.assertEqual(self.model.get_fit_function_parameter_values(filtered_functions[0])[0], [0.0, 0.0, 0.0, 0.2, 0.2])
+
+    def test_that_get_all_fit_functions_for_returns_the_tf_simultaneous_function_when_in_simultaneous_mode(self):
+        self.model.dataset_names = self.dataset_names
+        self.model.simultaneous_fitting_mode = True
+        self.model.tf_asymmetry_mode = True
+        self.model.simultaneous_fit_function = self.simultaneous_fit_function
+        self.model.tf_asymmetry_simultaneous_function = self.tf_simultaneous_fit_function
+
+        filtered_functions_all = self.model.get_all_fit_functions_for("All")
+        self.assertEqual(str(filtered_functions_all[0]), str(self.tf_simultaneous_fit_function))
+
+        filtered_functions_fwd = self.model.get_all_fit_functions_for("fwd")
+        self.assertEqual(str(filtered_functions_fwd[0]), str(self.tf_simultaneous_fit_function))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/scripts/test/Muon/fitting_widgets/tf_asymmetry_fitting/tf_asymmetry_fitting_model_test.py
+++ b/scripts/test/Muon/fitting_widgets/tf_asymmetry_fitting/tf_asymmetry_fitting_model_test.py
@@ -668,7 +668,7 @@ class TFAsymmetryFittingModelTest(unittest.TestCase):
         self.assertEqual(self.model.get_fit_function_parameter_values(filtered_functions[0])[0], [0.0, 0.0, 0.0, 0.2, 0.2])
         self.assertEqual(self.model.get_fit_function_parameter_values(filtered_functions[1])[0], [0.0, 0.0, 0.0, 0.2, 0.2])
 
-    def test_that_get_all_fit_functions_for_returns_the_fwd_tf_single_functions_for_the_display_type_fwd(self):
+    def test_that_get_all_fit_functions_for_does_not_do_filtering_even_for_a_fwd_display_type(self):
         self.model.dataset_names = self.dataset_names
         self.model.single_fit_functions = self.single_fit_functions
         self.model.tf_asymmetry_single_functions = [self.tf_single_function.clone(), self.tf_single_function.clone()]
@@ -676,8 +676,9 @@ class TFAsymmetryFittingModelTest(unittest.TestCase):
 
         filtered_functions = self.model.get_all_fit_functions_for("fwd")
 
-        self.assertEqual(len(filtered_functions), 1)
+        self.assertEqual(len(filtered_functions), 2)
         self.assertEqual(self.model.get_fit_function_parameter_values(filtered_functions[0])[0], [0.0, 0.0, 0.0, 0.2, 0.2])
+        self.assertEqual(self.model.get_fit_function_parameter_values(filtered_functions[1])[0], [0.0, 0.0, 0.0, 0.2, 0.2])
 
     def test_that_get_all_fit_functions_for_returns_the_tf_simultaneous_function_when_in_simultaneous_mode(self):
         self.model.dataset_names = self.dataset_names

--- a/scripts/test/Muon/seq_fitting_tab_widget/seq_fitting_tab_presenter_test.py
+++ b/scripts/test/Muon/seq_fitting_tab_widget/seq_fitting_tab_presenter_test.py
@@ -70,7 +70,8 @@ class SeqFittingTabPresenterTest(unittest.TestCase):
         fit_values = [0.2, 0.2, 0.1, 0]
         self.model.get_fit_function_parameters = mock.Mock(return_value=parameters)
         self.model.get_all_fit_function_parameter_values_for = mock.Mock(return_value=fit_values)
-        self.model.get_all_fit_functions = mock.Mock(return_value=[None, None])
+        self.model.get_all_fit_functions_for = mock.Mock(return_value=[None, None])
+        self.view.selected_data_type = mock.Mock(return_value="All")
 
         self._setup_test_fit_function(fit_values)
         self.view.fit_table.get_number_of_fits.return_value = 2


### PR DESCRIPTION
**Description of work.**
This PR allows the filtering of datasets in the Sequential Fitting tab of FDA so that the imaginary, real, modulus or maxent domains can be selected before doing a sequential fit.

**To test:**
1. Open Frequency Domain Analysis
2. Load MUSR62260-1
3. Go to the Transform tab
4. Calculate FFT for `MUSR62260; Group; fwd; Asymmetry; FD` and `MUSR62261; Group; fwd; Asymmetry; FD`
5. Calculate MaxEnt for `MUSR62260_raw_data FD` and `MUSR62261_raw_data FD` 
6. Go to the Fitting tab and add a function
7. Go to the Sequential Fitting tab
8. Switch between `All`, `FD_Re`, `FD_Im`, `FD_mod` and `MaxEnt`. Try sequential fitting for each and make sure the relevant dataset names are displayed in the table.
9. Go to Muon Analysis and check that this combo box is hidden, and that `All` datasets are displayed at all times.

Fixes #32050

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
