### PR TITLE
Ban all cfg files from LoadLotsOfFiles

### DIFF
--- a/Testing/SystemTests/tests/framework/LoadLotsOfFiles.py
+++ b/Testing/SystemTests/tests/framework/LoadLotsOfFiles.py
@@ -16,7 +16,6 @@ BANNED_FILES = ['80_tubes_Top_and_Bottom_April_2015.xml',
                 '80tubeCalibration_18-04-2016_r9330-9335.nxs',
                 '80tube_DIRECT_3146_M1_30April15_r3146.dat',
                 '992 Descriptions.txt',
-                'directBeamDatabaseFall2014_IPTS_11601_2.cfg',
                 'BASIS_AutoReduction_Mask.xml',
                 'BioSANS_dark_current.xml',
                 'BioSANS_empty_cell.xml',
@@ -145,7 +144,8 @@ BANNED_REGEXP = [r'SANS2D\d+.log$',
                  r'.*\.cif',
                  r'.*\.toml',
                  r'.*\.h5',
-                 r'.*\.p2d']
+                 r'.*\.p2d',
+                 r'.*\.cfg']
 
 BANNED_DIRS = ["DocTest", "UnitTest", "reference"]
 


### PR DESCRIPTION
Description of work.

Remove all cfg files from LoadLotsOfFiles.

To test:

- Builds should pass
- LoadLotsofFiles system test should pass locally (it won't run in PRs). You'll need 30gb+ of ram to run this.

There is no associated issue.

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
