### PR TITLE
Fix unreliable matrix workspace display test

### DIFF
--- a/qt/python/mantidqt/widgets/workspacedisplay/matrix/view.py
+++ b/qt/python/mantidqt/widgets/workspacedisplay/matrix/view.py
@@ -147,13 +147,13 @@ class MatrixWorkspaceDisplayView(QTabWidget):
         return True if reply == QMessageBox.Yes else False
 
     def setup_bin_context_menu(self, table):
-        context_menu = QMenu()
+        context_menu = QMenu(self)
         self.setup_copy_bin_actions(context_menu, table)
         self.setup_plot_bin_actions(context_menu, table)
         return context_menu
 
     def setup_spectra_context_menu(self, table):
-        context_menu = QMenu()
+        context_menu = QMenu(self)
         self.setup_copy_spectrum_actions(context_menu, table)
         self.setup_plot_spectrum_actions(context_menu, table)
         return context_menu


### PR DESCRIPTION
**Description of work.**

The unit test test_matrixworkspacedisplay_view has been unstable recently on the RHEL7 PR Jenkins jobs and seems to have got worse over the last few days. The problem seems to be worse on some build servers than others eg consistently fails on ornl-baldrick and isis-ndw1456.

It's not been possible to reproduce the problem on a local CentOS virtual machine.

The "assert_no_toplevel_widgets" assertion in the tests test_window_deleted_correctly and test_window_force_deleted_correctly have been failing - they report there is 1 top level widget left. By adding some debug code I've determined that the remaining top level widget is a QMenu containing 0 actions. At the start of the two tests mentioned above there are 4 top level widgets present including a QMenu. The QMenu present at the start is the right click menu on the header. It appears to have its actions cleared out by the end of the test - not sure why:

```
        a = QApplication.topLevelWidgets()
        print("DH number of top level widgets at start=" + str(len(a)))
        for w in a:
            print("class=" + type(w).__name__)
            print("windowTitle=" + str(w.windowTitle()))
            print("objectName=" + str(w.objectName()))
            if isinstance(w, QMenu):
                print("QMenu=" + w.title())
                print("QMenu action count=" + str(len(w.actions())))
                for action in w.actions():
                    print("action text=" + action.text())
```

![image](https://user-images.githubusercontent.com/56295817/128847895-287ca074-3a53-40fc-ae69-1be9bd1a1851.png)

To resolve the problem I have added a parent to the QMenu objects created in the matrix workspace display view. This means they QMenu's will be deleted when the parent MatrixWorkspaceTableView is deleted.

**To test:**

Open a matrix workspace in workbench and check right click menu still works.

Check the RHEL7 job has succeeded on this PR. I reran the job on few times to be sure. Prior to squashing the commits, the PR has passed OK in the following Jenkins jobs on RHEL7:

https://builds.mantidproject.org/job/pull_requests-rhel7/46105 (ornl-baldrick)
https://builds.mantidproject.org/job/pull_requests-rhel7/46106 (ornl-baldrick)
https://builds.mantidproject.org/job/pull_requests-rhel7/46107 (isis-ndw1456)

*There is no associated issue.*

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
