### PR TITLE
Make minor changes to Auto Background Corrections

### DIFF
--- a/scripts/Muon/GUI/Common/corrections_tab_widget/background_corrections_model.py
+++ b/scripts/Muon/GUI/Common/corrections_tab_widget/background_corrections_model.py
@@ -111,7 +111,8 @@ class BackgroundCorrectionData:
                 "EndX": self.end_x,
                 "CreateOutput": create_output,
                 "CalcErrors": True,
-                "MaxIterations": max_iterations}
+                "MaxIterations": max_iterations,
+                "IgnoreInvalidData": True}
 
     def _handle_background_fit_output(self, function: IFunction, fit_status: str, chi_squared: float) -> None:
         """Handles the output of the background fit."""
@@ -166,7 +167,7 @@ class BackgroundCorrectionData:
 
     def _use_raw_data(self) -> bool:
         """Returns true if the raw data should be used to calculate the background."""
-        return self.use_raw or self.rebin_fixed_step == 0
+        return self.use_raw or self.rebin_fixed_step == 0 or self.rebin_workspace_name is None
 
 
 class BackgroundCorrectionsModel:
@@ -300,16 +301,16 @@ class BackgroundCorrectionsModel:
         run, group = run_group
         if run_group in previous_data:
             data = previous_data[run_group]
-            return BackgroundCorrectionData(data.use_raw if is_rebin_fixed else True, rebin_fixed, data.start_x,
+            return BackgroundCorrectionData(data.use_raw if is_rebin_fixed else False, rebin_fixed, data.start_x,
                                             data.end_x, data.flat_background, data.exp_decay)
         else:
             for key, value in previous_data.items():
                 if key[1] == group:
-                    return BackgroundCorrectionData(value.use_raw if is_rebin_fixed else True, rebin_fixed,
+                    return BackgroundCorrectionData(value.use_raw if is_rebin_fixed else False, rebin_fixed,
                                                     value.start_x, value.end_x, value.flat_background, value.exp_decay)
 
         start_x, end_x = self.default_x_range(run, group)
-        return BackgroundCorrectionData(True, rebin_fixed, start_x, end_x)
+        return BackgroundCorrectionData(False, rebin_fixed, start_x, end_x)
 
     def create_background_output_workspaces_for(self, run: str, group: str) -> tuple:
         """Creates the parameter table and normalised covariance matrix for a Run/Group by performing a fit."""

--- a/scripts/Muon/GUI/Common/corrections_tab_widget/background_corrections_model.py
+++ b/scripts/Muon/GUI/Common/corrections_tab_widget/background_corrections_model.py
@@ -20,6 +20,7 @@ from Muon.GUI.Common.utilities.workspace_data_utils import x_limits_of_workspace
 BACKGROUND_PARAM = "A0"
 DEFAULT_A_VALUE = 1e6
 DEFAULT_LAMBDA_VALUE = 1.0e-6 / PhysicalConstants.MuonLifetime
+DEFAULT_USE_RAW = False
 MAX_ACCEPTABLE_CHI_SQUARED = 10.0
 TEMPORARY_BACKGROUND_WORKSPACE_NAME = "__temp_background_workspace"
 
@@ -301,16 +302,16 @@ class BackgroundCorrectionsModel:
         run, group = run_group
         if run_group in previous_data:
             data = previous_data[run_group]
-            return BackgroundCorrectionData(data.use_raw if is_rebin_fixed else False, rebin_fixed, data.start_x,
+            return BackgroundCorrectionData(data.use_raw if is_rebin_fixed else DEFAULT_USE_RAW, rebin_fixed, data.start_x,
                                             data.end_x, data.flat_background, data.exp_decay)
         else:
             for key, value in previous_data.items():
                 if key[1] == group:
-                    return BackgroundCorrectionData(value.use_raw if is_rebin_fixed else False, rebin_fixed,
+                    return BackgroundCorrectionData(value.use_raw if is_rebin_fixed else DEFAULT_USE_RAW, rebin_fixed,
                                                     value.start_x, value.end_x, value.flat_background, value.exp_decay)
 
         start_x, end_x = self.default_x_range(run, group)
-        return BackgroundCorrectionData(False, rebin_fixed, start_x, end_x)
+        return BackgroundCorrectionData(DEFAULT_USE_RAW, rebin_fixed, start_x, end_x)
 
     def create_background_output_workspaces_for(self, run: str, group: str) -> tuple:
         """Creates the parameter table and normalised covariance matrix for a Run/Group by performing a fit."""

--- a/scripts/Muon/GUI/Common/corrections_tab_widget/background_corrections_view.py
+++ b/scripts/Muon/GUI/Common/corrections_tab_widget/background_corrections_view.py
@@ -21,8 +21,8 @@ GROUP_COLUMN_INDEX = 1
 USE_RAW_COLUMN_INDEX = 2
 START_X_COLUMN_INDEX = 3
 END_X_COLUMN_INDEX = 4
-A0_COLUMN_INDEX = 5
-A0_ERROR_COLUMN_INDEX = 6
+BG_COLUMN_INDEX = 5
+BG_ERROR_COLUMN_INDEX = 6
 STATUS_COLUMN_INDEX = 7
 SHOW_MATRIX_COLUMN_INDEX = 8
 
@@ -252,7 +252,7 @@ class BackgroundCorrectionsView(widget, ui_form):
             raise RuntimeError("There is no selected run/group table row.")
 
     def populate_corrections_table(self, runs: list, groups: list, use_raws: list, start_xs: list, end_xs: list,
-                                   backgrounds: list, background_errors: list, statuses: list, use_raw_enabled: bool) -> None:
+                                   backgrounds: list, background_errors: list, statuses: list, use_raw_visible: bool) -> None:
         """Populates the background corrections table with the provided data."""
         self.correction_options_table.blockSignals(True)
         self.correction_options_table.setRowCount(0)
@@ -265,17 +265,18 @@ class BackgroundCorrectionsView(widget, ui_form):
             self.correction_options_table.setItem(row, RUN_COLUMN_INDEX, create_string_table_item(run, False))
             self.correction_options_table.setItem(row, GROUP_COLUMN_INDEX, create_string_table_item(group, False))
             self.correction_options_table.setItem(row, USE_RAW_COLUMN_INDEX,
-                                                  create_checkbox_table_item(use_raw, use_raw_enabled, USE_RAW_TOOLTIP))
+                                                  create_checkbox_table_item(use_raw, tooltip=USE_RAW_TOOLTIP))
             self.correction_options_table.setItem(row, START_X_COLUMN_INDEX, create_double_table_item(start_x))
             self.correction_options_table.setItem(row, END_X_COLUMN_INDEX, create_double_table_item(end_x))
-            self.correction_options_table.setItem(row, A0_COLUMN_INDEX,
+            self.correction_options_table.setItem(row, BG_COLUMN_INDEX,
                                                   create_double_table_item(background, enabled=False))
-            self.correction_options_table.setItem(row, A0_ERROR_COLUMN_INDEX,
+            self.correction_options_table.setItem(row, BG_ERROR_COLUMN_INDEX,
                                                   create_double_table_item(background_error, enabled=False))
             self.correction_options_table.setItem(row, STATUS_COLUMN_INDEX,
                                                   create_string_table_item(status, False, alignment=Qt.AlignVCenter))
             self.correction_options_table.setCellWidget(row, SHOW_MATRIX_COLUMN_INDEX,
                                                         self.create_show_fit_output_button_for_row(row))
+        self.correction_options_table.setColumnHidden(USE_RAW_COLUMN_INDEX, not use_raw_visible)
         self.correction_options_table.blockSignals(False)
         self.correction_options_table.resizeColumnsToContents()
 
@@ -288,8 +289,8 @@ class BackgroundCorrectionsView(widget, ui_form):
         """Setup the correction options table to have a good layout."""
         self._setup_double_item_delegate(START_X_COLUMN_INDEX)
         self._setup_double_item_delegate(END_X_COLUMN_INDEX)
-        self._setup_double_item_delegate(A0_COLUMN_INDEX)
-        self._setup_double_item_delegate(A0_ERROR_COLUMN_INDEX)
+        self._setup_double_item_delegate(BG_COLUMN_INDEX)
+        self._setup_double_item_delegate(BG_ERROR_COLUMN_INDEX)
         self.correction_options_table.setItemDelegateForColumn(STATUS_COLUMN_INDEX,
                                                                StatusItemDelegate(self.correction_options_table))
 

--- a/scripts/Muon/GUI/Common/corrections_tab_widget/background_corrections_view.ui
+++ b/scripts/Muon/GUI/Common/corrections_tab_widget/background_corrections_view.ui
@@ -139,12 +139,12 @@ background-color: #c7e0ff;
         </column>
         <column>
          <property name="text">
-          <string>A0</string>
+          <string>BG</string>
          </property>
         </column>
         <column>
          <property name="text">
-          <string>A0 Error</string>
+          <string>BG Error</string>
          </property>
         </column>
         <column>

--- a/scripts/test/Muon/corrections_tab_widget/background_corrections_model_test.py
+++ b/scripts/test/Muon/corrections_tab_widget/background_corrections_model_test.py
@@ -11,7 +11,8 @@ from mantid.api import AnalysisDataService, FrameworkManager, FunctionFactory
 from mantid.simpleapi import CreateSampleWorkspace
 
 from Muon.GUI.Common.corrections_tab_widget.corrections_model import CorrectionsModel
-from Muon.GUI.Common.corrections_tab_widget.background_corrections_model import BackgroundCorrectionsModel
+from Muon.GUI.Common.corrections_tab_widget.background_corrections_model import (BackgroundCorrectionsModel,
+                                                                                 DEFAULT_USE_RAW)
 from Muon.GUI.Common.test_helpers.context_setup import setup_context
 from Muon.GUI.Common.utilities.workspace_data_utils import DEFAULT_X_LOWER, DEFAULT_X_UPPER
 
@@ -32,7 +33,7 @@ class BackgroundCorrectionsModelTest(unittest.TestCase):
 
         self.runs = ["84447", "84447", "84447", "84447"]
         self.groups = ["fwd", "bwd", "top", "bottom"]
-        self.use_raws = [True, True, True, True]
+        self.use_raws = [DEFAULT_USE_RAW] * len(self.groups)
         self.start_xs = [15.0] * 4
         self.end_xs = [30.0] * 4
         self.a0s = [0.0] * 4
@@ -86,7 +87,7 @@ class BackgroundCorrectionsModelTest(unittest.TestCase):
 
         for run, group in zip(self.runs, self.groups):
             correction_data = self.model._corrections_context.background_correction_data[tuple([run, group])]
-            self.assertEqual(correction_data.use_raw, True)
+            self.assertEqual(correction_data.use_raw, DEFAULT_USE_RAW)
             self.assertEqual(correction_data.start_x, 15.0)
             self.assertEqual(correction_data.end_x, 30.0)
             self.assertEqual(correction_data.flat_background.getParameterValue("A0"), 0.0)
@@ -150,7 +151,7 @@ class BackgroundCorrectionsModelTest(unittest.TestCase):
 
         self.assertEqual(runs, [run])
         self.assertEqual(groups, [group])
-        self.assertEqual(use_raws, [True])
+        self.assertEqual(use_raws, [DEFAULT_USE_RAW])
         self.assertEqual(start_xs, [15.0])
         self.assertEqual(end_xs, [30.0])
         self.assertEqual(a0s, [0.0])

--- a/scripts/test/Muon/corrections_tab_widget/background_corrections_view_test.py
+++ b/scripts/test/Muon/corrections_tab_widget/background_corrections_view_test.py
@@ -16,8 +16,8 @@ from Muon.GUI.Common.corrections_tab_widget.background_corrections_view import (
                                                                                 RUN_COLUMN_INDEX,
                                                                                 GROUP_COLUMN_INDEX,
                                                                                 USE_RAW_COLUMN_INDEX,
-                                                                                A0_COLUMN_INDEX,
-                                                                                A0_ERROR_COLUMN_INDEX,
+                                                                                BG_COLUMN_INDEX,
+                                                                                BG_ERROR_COLUMN_INDEX,
                                                                                 STATUS_COLUMN_INDEX)
 
 from qtpy.QtWidgets import QApplication
@@ -130,9 +130,9 @@ class BackgroundCorrectionsViewTest(unittest.TestCase, QtWidgetFinder):
                              Qt.Checked)
             self.assertEqual(self.view.start_x(self.runs[row_i], self.groups[row_i]), self.start_xs[row_i])
             self.assertEqual(self.view.end_x(self.runs[row_i], self.groups[row_i]), self.end_xs[row_i])
-            self.assertEqual(self.view.correction_options_table.item(row_i, A0_COLUMN_INDEX).text(),
+            self.assertEqual(self.view.correction_options_table.item(row_i, BG_COLUMN_INDEX).text(),
                              f"{self.a0s[row_i]:.3f}")
-            self.assertEqual(self.view.correction_options_table.item(row_i, A0_ERROR_COLUMN_INDEX).text(),
+            self.assertEqual(self.view.correction_options_table.item(row_i, BG_ERROR_COLUMN_INDEX).text(),
                              f"{self.a0_errors[row_i]:.3f}")
             self.assertEqual(self.view.correction_options_table.item(row_i, STATUS_COLUMN_INDEX).text(),
                              self.statuses[row_i])


### PR DESCRIPTION
**Description of work.**
This PR makes several minor changes to the Auto background corrections:
- [x] `IgnoreInvalidData` when doing the background fit
- [x] Hides `Use Raw` when there is no Rebin data. `Use Raw` is also defaulted to be off when there is Rebin data
- [x] Renames the `A0` column to be `BG` as requested by users

**To test:**
Open Muon Analysis
Load PSI data 1249
Go to Corrections tab
Select `Auto` background corrections. This should be processed fine
Go to home tab and select `Fixed` Rebin with 200 width
Go back to corrections tab and make sure the background corrections were successful

The background corrections table should have a `BG` column and a `BG Error` column


**Data for testing**
[deltat_tdc_gps_1249.zip](https://github.com/mantidproject/mantid/files/6960550/deltat_tdc_gps_1249.zip)

*There is no associated issue.*

*This does not require release notes* because **the auto background feature is new and release notes will be added later.**

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
