### PR TITLE
Fix problem auto populating the full calibration setting on Engineering UI

### DIFF
--- a/docs/source/release/v6.2.0/diffraction.rst
+++ b/docs/source/release/v6.2.0/diffraction.rst
@@ -59,6 +59,7 @@ Improvements
 - The cropping/region of interest selection for Calibration/Focusing is now chosen only on the Calibration tab, to avoid confusion and duplication of input.
 - The region of interest for Calibration/Focusing can now be selected with a user-supplied custom calibration file.
 - The Focused Run Files input box defaults to the last runs focused on the Focus tab, even if multiple runs were focussed
+- The full calibration setting now has a default value consisting of the path to the ENGINX_full_instrument_calibration_193749.nxs file
 
 Bugfixes
 ########

--- a/scripts/Engineering/gui/engineering_diffraction/settings/settings_presenter.py
+++ b/scripts/Engineering/gui/engineering_diffraction/settings/settings_presenter.py
@@ -83,6 +83,7 @@ class SettingsPresenter(object):
         self._save_settings_to_file()
 
     def _collect_new_settings_from_view(self):
+        self._validate_settings()
         self.settings["save_location"] = self.view.get_save_location()
         self.settings["full_calibration"] = self.view.get_full_calibration()
         self.settings["recalc_vanadium"] = self.view.get_van_recalc()
@@ -92,14 +93,14 @@ class SettingsPresenter(object):
         self.settings["default_peak"] = self.view.get_peak_function()
 
     def _show_settings_in_view(self):
-        if self._validate_settings(self.settings):
-            self.view.set_save_location(self.settings["save_location"])
-            self.view.set_full_calibration(self.settings["full_calibration"])
-            self.view.set_van_recalc(self.settings["recalc_vanadium"])
-            self.view.set_checked_logs(self.settings["logs"])
-            self.view.set_primary_log_combobox(self.settings["primary_log"])
-            self.view.set_ascending_checked(self.settings["sort_ascending"])
-            self.view.set_peak_function(self.settings["default_peak"])
+        self._validate_settings()
+        self.view.set_save_location(self.settings["save_location"])
+        self.view.set_full_calibration(self.settings["full_calibration"])
+        self.view.set_van_recalc(self.settings["recalc_vanadium"])
+        self.view.set_checked_logs(self.settings["logs"])
+        self.view.set_primary_log_combobox(self.settings["primary_log"])
+        self.view.set_ascending_checked(self.settings["sort_ascending"])
+        self.view.set_peak_function(self.settings["default_peak"])
         self._find_files()
 
     def _find_files(self):
@@ -107,30 +108,36 @@ class SettingsPresenter(object):
         self.view.find_save()
 
     def _save_settings_to_file(self):
-        if self._validate_settings(self.settings):
-            self.model.set_settings_dict(self.settings)
-            self.savedir_notifier.notify_subscribers(self.settings["save_location"])
+        self._validate_settings()
+        self.model.set_settings_dict(self.settings)
+        self.savedir_notifier.notify_subscribers(self.settings["save_location"])
 
     def load_settings_from_file_or_default(self):
         self.settings = self.model.get_settings_dict(SETTINGS_DICT)
-        if not self._validate_settings(self.settings):
-            self.settings = DEFAULT_SETTINGS.copy()
+
+        self._validate_settings()
+
+        if self.settings != self.model.get_settings_dict(SETTINGS_DICT):
             self._save_settings_to_file()
         self._find_files()
 
-    @staticmethod
-    def _validate_settings(settings):
-        try:
-            all_keys = settings.keys() == SETTINGS_DICT.keys()
-            not_none = all([val is not None for val in settings.values()])
-            save_location = str(settings["save_location"])
-            save_valid = save_location != ""
-            log_valid = settings["logs"] != ""
-            ascending_valid = settings["sort_ascending"] != ""
-            peak_valid = settings["default_peak"] in ALL_PEAKS
-            return all_keys and not_none and save_valid and log_valid and ascending_valid and peak_valid
-        except KeyError:  # Settings contained invalid key.
-            return False
+    def check_and_populate_with_default(self, name):
+        if name not in self.settings or self.settings[name] == "":
+            self.settings[name] = DEFAULT_SETTINGS[name]
+
+    def _validate_settings(self):
+        for key in list(self.settings):
+            if key not in DEFAULT_SETTINGS.keys():
+                del self.settings[key]
+        if "default_peak" not in self.settings or not self.settings["default_peak"] in ALL_PEAKS:
+            self.settings["default_peak"] = DEFAULT_SETTINGS["default_peak"]
+        self.check_and_populate_with_default("save_location")
+        self.check_and_populate_with_default("logs")
+        self.check_and_populate_with_default("full_calibration")
+        self.check_and_populate_with_default("primary_log")
+        self.check_and_populate_with_default("recalc_vanadium")
+        # boolean values already checked to be "" or True or False in settings_helper
+        self.check_and_populate_with_default("sort_ascending")
 
     # -----------------------
     # Observers / Observables


### PR DESCRIPTION
**Description of work.**

The logic to apply a default value to the Full Calibration path inside the Settings screen of the engineering diffraction UI wasn't working. The code was expecting None for the full calibration setting before applying the default. In the absence of a value for this setting the code was actually returning a blank string

Also adjusted the previous behaviour where if any of the settings were invalid they all got overwritten with a default set. The logic now applies the defaults per setting and leaves any other valid settings in place

**To test:**

1. Open up the mantidworkbench.ini file. This will be in your user area eg C:\Users\<fed id>\AppData\Roaming\mantidproject on Windows
2. Delete these settings from the [CustomInterfaces] section: 
- EngineeringDiffraction2\sort_ascending
- EngineeringDiffraction2\save_location
- EngineeringDiffraction2\primary_log
- EngineeringDiffraction2\full_calibration
- EngineeringDiffraction2\logs
- EngineeringDiffraction2\recalc_vanadium

...and put a nonsense value in for this one:
- EngineeringDiffraction2\default_peak (supposed to be a valid peak type)

2. Open up workbench
3. Open up the Engineering diffraction UI from the Interfaces, Diffraction menu
4. Open up the settings dialog
5. Observe that default values have been populated for the settings listed in step 1. In particular the full calibration path setting should have an absolute path ending in scripts\Engineering\calib\ENGINX_full_instrument_calibration_193749.nxs


Fixes #32163. 

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
