### PR TITLE
Add Only update vanadium checkbox to EngDiff calibration tab

### DIFF
--- a/docs/source/release/v6.1.0/diffraction.rst
+++ b/docs/source/release/v6.1.0/diffraction.rst
@@ -28,6 +28,8 @@ New features
 - A new caching feature is added to :ref:`SNSPowderReduction <algm-SNSPowderReduction>` to speed up calculation using same sample and container.
 - New property `CleanCache` in algorithm :ref:`SNSPowderReduction <algm-SNSPowderReduction>`.
 - Including three options for "cache directory" and one for "clean cache" in the Advanced Setup tab of the SNS Powder Reduction interface.
+- Only Update Vanadium checkbox has been added, to allow the vanadium dataset to be updated, without rerunning a sample
+  calibration. This checkbox is only enabled after a successful calibration.
 
 Improvements
 ############

--- a/scripts/Engineering/EnggUtils.py
+++ b/scripts/Engineering/EnggUtils.py
@@ -52,7 +52,7 @@ def load_relevant_calibration_files(file_path, output_prefix="engggui") -> list:
     """
     basepath, fname = path.split(file_path)
     fname_words = fname.split('_')
-    prefix = '_'.join(fname_words[0:3])
+    prefix = '_'.join(fname_words[0:2])
     roi = determine_roi_from_prm_fname(fname)
     bank = None
     if roi == "BOTH":
@@ -106,12 +106,12 @@ def load_custom_grouping_workspace(file_path: str) -> (str, str):
     return ws_name, roi_text
 
 
-def save_grouping_workspace(grp_ws, directory: str, ceria_path: str, vanadium_path: str, instrument: str,
+def save_grouping_workspace(grp_ws, directory: str, ceria_path: str, instrument: str,
                             calfile: str = None, spec_nos=None) -> None:
     if calfile:
-        name = generate_output_file_name(vanadium_path, ceria_path, instrument, "Custom", '.xml')
+        name = generate_output_file_name(ceria_path, instrument, "Custom", '.xml')
     elif spec_nos:
-        name = generate_output_file_name(vanadium_path, ceria_path, instrument, "Cropped", '.xml')
+        name = generate_output_file_name(ceria_path, instrument, "Cropped", '.xml')
     else:
         logger.warning("No Calfile or Spectra given, no grouping workspace saved")
         return
@@ -119,9 +119,9 @@ def save_grouping_workspace(grp_ws, directory: str, ceria_path: str, vanadium_pa
     mantid.SaveDetectorsGrouping(InputWorkspace=grp_ws, OutputFile=save_path)
 
 
-def generate_output_file_name(vanadium_path, ceria_path, instrument, bank, ext='.prm'):
+def generate_output_file_name(ceria_path, instrument, bank, ext='.prm'):
     """
-    Generate an output filename in the form INSTRUMENT_VanadiumRunNo_ceriaRunNo_BANKS
+    Generate an output filename in the form INSTRUMENT_ceriaRunNo_BANKS
     :param vanadium_path: Path to vanadium data file
     :param ceria_path: Path to ceria data file
     :param instrument: The instrument in use.
@@ -129,9 +129,8 @@ def generate_output_file_name(vanadium_path, ceria_path, instrument, bank, ext='
     :param ext: Extension to be used on the saved file
     :return: The filename, the vanadium run number, and ceria run number.
     """
-    vanadium_no = path_handling.get_run_number_from_path(vanadium_path, instrument)
     ceria_no = path_handling.get_run_number_from_path(ceria_path, instrument)
-    filename = instrument + "_" + vanadium_no + "_" + ceria_no + "_"
+    filename = instrument + "_" + ceria_no + "_"
     if bank == "all":
         filename = filename + "all_banks" + ext
     elif bank == "north":

--- a/scripts/Engineering/gui/engineering_diffraction/presenter.py
+++ b/scripts/Engineering/gui/engineering_diffraction/presenter.py
@@ -93,8 +93,14 @@ class EngineeringDiffractionPresenter(object):
 
     def update_calibration(self, calibration):
         instrument = calibration.get_instrument()
-        van_no = path_handling.get_run_number_from_path(calibration.get_vanadium(), instrument)
-        sample_no = path_handling.get_run_number_from_path(calibration.get_sample(), instrument)
+        if calibration.get_vanadium():
+            van_no = path_handling.get_run_number_from_path(calibration.get_vanadium(), instrument)
+        else:
+            van_no = "Empty"
+        if calibration.get_sample():
+            sample_no = path_handling.get_run_number_from_path(calibration.get_sample(), instrument)
+        else:
+            sample_no = "Empty"
         self.statusbar_observable.notify_subscribers(f"V: {van_no}, CeO2: {sample_no}, Instrument: {instrument}")
 
     @staticmethod

--- a/scripts/Engineering/gui/engineering_diffraction/settings/settings_presenter.py
+++ b/scripts/Engineering/gui/engineering_diffraction/settings/settings_presenter.py
@@ -86,7 +86,6 @@ class SettingsPresenter(object):
         self._validate_settings()
         self.settings["save_location"] = self.view.get_save_location()
         self.settings["full_calibration"] = self.view.get_full_calibration()
-        self.settings["recalc_vanadium"] = self.view.get_van_recalc()
         self.settings["logs"] = self.view.get_checked_logs()
         self.settings["primary_log"] = self.view.get_primary_log()
         self.settings["sort_ascending"] = self.view.get_ascending_checked()
@@ -96,7 +95,6 @@ class SettingsPresenter(object):
         self._validate_settings()
         self.view.set_save_location(self.settings["save_location"])
         self.view.set_full_calibration(self.settings["full_calibration"])
-        self.view.set_van_recalc(self.settings["recalc_vanadium"])
         self.view.set_checked_logs(self.settings["logs"])
         self.view.set_primary_log_combobox(self.settings["primary_log"])
         self.view.set_ascending_checked(self.settings["sort_ascending"])
@@ -135,7 +133,6 @@ class SettingsPresenter(object):
         self.check_and_populate_with_default("logs")
         self.check_and_populate_with_default("full_calibration")
         self.check_and_populate_with_default("primary_log")
-        self.check_and_populate_with_default("recalc_vanadium")
         # boolean values already checked to be "" or True or False in settings_helper
         self.check_and_populate_with_default("sort_ascending")
 

--- a/scripts/Engineering/gui/engineering_diffraction/settings/settings_view.py
+++ b/scripts/Engineering/gui/engineering_diffraction/settings/settings_view.py
@@ -64,9 +64,6 @@ class SettingsView(QtWidgets.QDialog, Ui_settings):
     def get_full_calibration(self):
         return self.finder_fullCalib.getFirstFilename()
 
-    def get_van_recalc(self):
-        return self.check_vanRecalc.isChecked()
-
     def get_checked_logs(self):
         return ','.join([self.log_list.item(ilog).text() for ilog in range(self.log_list.count()) if
                          self.log_list.item(ilog).checkState() == QtCore.Qt.Checked])

--- a/scripts/Engineering/gui/engineering_diffraction/settings/settings_widget.ui
+++ b/scripts/Engineering/gui/engineering_diffraction/settings/settings_widget.ui
@@ -47,13 +47,6 @@ QGroupBox:title {
      </property>
      <layout class="QGridLayout" name="gridLayout_2">
       <item row="0" column="0">
-       <widget class="QCheckBox" name="check_vanRecalc">
-        <property name="text">
-         <string>Force Vanadium Recalculation</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0">
        <widget class="FileFinderWidget" name="finder_fullCalib" native="true"/>
       </item>
      </layout>

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/calibration/calibration_tab.ui
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/calibration/calibration_tab.ui
@@ -73,14 +73,14 @@ QGroupBox:title {
        </property>
        <layout class="QGridLayout" name="gridLayout_2">
         <item row="1" column="0">
-         <layout class="QGridLayout" name="gridLayout" rowstretch="0,0,0,0,0,0,0,0,0,0,0" columnstretch="0,0,0">
+         <layout class="QGridLayout" name="gridLayout" rowstretch="0,0,0,0,0,0,0,0,0,0,0,0" columnstretch="0,0,0">
           <property name="sizeConstraint">
            <enum>QLayout::SetDefaultConstraint</enum>
           </property>
           <property name="verticalSpacing">
            <number>6</number>
           </property>
-          <item row="6" column="0" colspan="3">
+          <item row="7" column="0" colspan="3">
            <widget class="Line" name="line_crop">
             <property name="minimumSize">
              <size>
@@ -93,7 +93,7 @@ QGroupBox:title {
             </property>
            </widget>
           </item>
-          <item row="5" column="0" colspan="3">
+          <item row="6" column="0" colspan="3">
            <widget class="FileFinderWidget" name="finder_path" native="true">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
@@ -112,7 +112,7 @@ QGroupBox:title {
             </property>
            </widget>
           </item>
-          <item row="3" column="0" colspan="3">
+          <item row="4" column="0" colspan="3">
            <spacer name="spacer_new_exist">
             <property name="orientation">
              <enum>Qt::Vertical</enum>
@@ -170,27 +170,27 @@ QGroupBox:title {
             </property>
            </widget>
           </item>
-          <item row="10" column="0" colspan="2">
+          <item row="11" column="0" colspan="2">
            <widget class="QCheckBox" name="check_plotOutput">
             <property name="enabled">
-             <bool>true</bool>
-            </property>
-		    <property name="checked">
              <bool>true</bool>
             </property>
             <property name="text">
              <string>Plot Calibrated Workspace</string>
             </property>
+            <property name="checked">
+             <bool>true</bool>
+            </property>
            </widget>
           </item>
-          <item row="7" column="0" colspan="3">
+          <item row="8" column="0" colspan="3">
            <widget class="QCheckBox" name="check_cropCalib">
             <property name="text">
              <string>Crop Calibration</string>
             </property>
            </widget>
           </item>
-          <item row="10" column="2">
+          <item row="11" column="2">
            <widget class="QPushButton" name="button_calibrate">
             <property name="enabled">
              <bool>true</bool>
@@ -200,7 +200,7 @@ QGroupBox:title {
             </property>
            </widget>
           </item>
-          <item row="4" column="0" colspan="3">
+          <item row="5" column="0" colspan="3">
            <widget class="QRadioButton" name="radio_loadCalib">
             <property name="text">
              <string>Load Existing Calibration</string>
@@ -210,20 +210,36 @@ QGroupBox:title {
             </property>
            </widget>
           </item>
-          <item row="9" column="0" colspan="3">
+          <item row="10" column="0" colspan="3">
            <widget class="Line" name="line_go">
             <property name="orientation">
              <enum>Qt::Horizontal</enum>
             </property>
            </widget>
           </item>
-          <item row="8" column="0" colspan="3">
+          <item row="9" column="0" colspan="3">
            <widget class="CroppingView" name="widget_cropping" native="true">
             <property name="minimumSize">
              <size>
               <width>0</width>
               <height>0</height>
              </size>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="2">
+           <widget class="QCheckBox" name="check_updateVan">
+            <property name="text">
+             <string>Only Update Vanadium</string>
+            </property>
+            <property name="enabled">
+             <bool>true</bool>
+            </property>
+            <property name="checked">
+             <bool>false</bool>
+            </property>
+            <property name="focusPolicy">
+             <enum>Qt::NoFocus</enum>
             </property>
            </widget>
           </item>

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/calibration/calibration_tab.ui
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/calibration/calibration_tab.ui
@@ -10,7 +10,7 @@
     <x>0</x>
     <y>0</y>
     <width>673</width>
-    <height>305</height>
+    <height>600</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -38,12 +38,12 @@ QGroupBox:title {
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_2">
    <item>
-    <layout class="QVBoxLayout" name="verticalLayout" stretch="1,0">
+    <layout class="QVBoxLayout" name="verticalLayout" stretch="1,0,0">
      <property name="sizeConstraint">
       <enum>QLayout::SetDefaultConstraint</enum>
      </property>
      <item>
-      <widget class="QGroupBox" name="loadingGroup">
+      <widget class="QGroupBox" name="CalibrationGroup">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
          <horstretch>0</horstretch>
@@ -80,7 +80,7 @@ QGroupBox:title {
           <property name="verticalSpacing">
            <number>6</number>
           </property>
-          <item row="7" column="0" colspan="3">
+          <item row="6" column="0" colspan="3">
            <widget class="Line" name="line_crop">
             <property name="minimumSize">
              <size>
@@ -93,7 +93,7 @@ QGroupBox:title {
             </property>
            </widget>
           </item>
-          <item row="6" column="0" colspan="3">
+          <item row="5" column="0" colspan="3">
            <widget class="FileFinderWidget" name="finder_path" native="true">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
@@ -112,7 +112,7 @@ QGroupBox:title {
             </property>
            </widget>
           </item>
-          <item row="4" column="0" colspan="3">
+          <item row="3" column="0" colspan="3">
            <spacer name="spacer_new_exist">
             <property name="orientation">
              <enum>Qt::Vertical</enum>
@@ -128,19 +128,6 @@ QGroupBox:title {
             </property>
            </spacer>
           </item>
-          <item row="1" column="0" colspan="3">
-           <widget class="FileFinderWidget" name="finder_vanadium" native="true">
-            <property name="minimumSize">
-             <size>
-              <width>0</width>
-              <height>0</height>
-             </size>
-            </property>
-            <property name="focusPolicy">
-             <enum>Qt::NoFocus</enum>
-            </property>
-           </widget>
-          </item>
           <item row="0" column="0" colspan="3">
            <widget class="QRadioButton" name="radio_newCalib">
             <property name="text">
@@ -151,7 +138,7 @@ QGroupBox:title {
             </property>
            </widget>
           </item>
-          <item row="2" column="0" colspan="3">
+          <item row="1" column="0" colspan="3">
            <widget class="FileFinderWidget" name="finder_sample" native="true">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
@@ -170,7 +157,7 @@ QGroupBox:title {
             </property>
            </widget>
           </item>
-          <item row="11" column="0" colspan="2">
+          <item row="10" column="0" colspan="2">
            <widget class="QCheckBox" name="check_plotOutput">
             <property name="enabled">
              <bool>true</bool>
@@ -183,14 +170,14 @@ QGroupBox:title {
             </property>
            </widget>
           </item>
-          <item row="8" column="0" colspan="3">
+          <item row="7" column="0" colspan="3">
            <widget class="QCheckBox" name="check_cropCalib">
             <property name="text">
              <string>Crop Calibration</string>
             </property>
            </widget>
           </item>
-          <item row="11" column="2">
+          <item row="10" column="2">
            <widget class="QPushButton" name="button_calibrate">
             <property name="enabled">
              <bool>true</bool>
@@ -200,7 +187,7 @@ QGroupBox:title {
             </property>
            </widget>
           </item>
-          <item row="5" column="0" colspan="3">
+          <item row="4" column="0" colspan="3">
            <widget class="QRadioButton" name="radio_loadCalib">
             <property name="text">
              <string>Load Existing Calibration</string>
@@ -210,14 +197,14 @@ QGroupBox:title {
             </property>
            </widget>
           </item>
-          <item row="10" column="0" colspan="3">
+          <item row="9" column="0" colspan="3">
            <widget class="Line" name="line_go">
             <property name="orientation">
              <enum>Qt::Horizontal</enum>
             </property>
            </widget>
           </item>
-          <item row="9" column="0" colspan="3">
+          <item row="8" column="0" colspan="3">
            <widget class="CroppingView" name="widget_cropping" native="true">
             <property name="minimumSize">
              <size>
@@ -227,19 +214,84 @@ QGroupBox:title {
             </property>
            </widget>
           </item>
-          <item row="3" column="2">
-           <widget class="QCheckBox" name="check_updateVan">
+         </layout>
+        </item>
+       </layout>
+      </widget>
+     </item>
+     <item>
+      <widget class="QGroupBox" name="VanadiumGroup">
+       <property name="title">
+        <string>Load Vanadium</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignBottom|Qt::AlignHCenter</set>
+       </property>
+       <layout class="QGridLayout" name="gridLayout_4">
+        <item row="0" column="0">
+         <layout class="QGridLayout" name="gridLayout_3">
+          <item row="0" column="0">
+           <widget class="QRadioButton" name="radio_new_van">
             <property name="text">
-             <string>Only Update Vanadium</string>
+             <string>Create New Vanadium</string>
             </property>
-            <property name="enabled">
+            <property name="checked">
              <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0" colspan="3">
+           <widget class="FileFinderWidget" name="finder_vanadium" native="true">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="minimumSize">
+             <size>
+              <width>0</width>
+              <height>0</height>
+             </size>
+            </property>
+            <property name="focusPolicy">
+             <enum>Qt::NoFocus</enum>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0">
+           <widget class="QRadioButton" name="radio_load_van">
+            <property name="text">
+             <string>Load Existing Vanadium</string>
             </property>
             <property name="checked">
              <bool>false</bool>
             </property>
+           </widget>
+          </item>
+          <item row="3" column="0" colspan="3">
+           <widget class="FileFinderWidget" name="finder_path_van" native="true">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="minimumSize">
+             <size>
+              <width>0</width>
+              <height>0</height>
+             </size>
+            </property>
             <property name="focusPolicy">
              <enum>Qt::NoFocus</enum>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="2">
+           <widget class="QPushButton" name="button_create_v">
+            <property name="text">
+             <string>Create Vanadium</string>
             </property>
            </widget>
           </item>
@@ -281,13 +333,17 @@ QGroupBox:title {
  </customwidgets>
  <tabstops>
   <tabstop>radio_newCalib</tabstop>
-  <tabstop>finder_vanadium</tabstop>
   <tabstop>finder_sample</tabstop>
   <tabstop>radio_loadCalib</tabstop>
   <tabstop>finder_path</tabstop>
   <tabstop>check_cropCalib</tabstop>
   <tabstop>check_plotOutput</tabstop>
   <tabstop>button_calibrate</tabstop>
+  <tabstop>radio_new_van</tabstop>
+  <tabstop>finder_vanadium</tabstop>
+  <tabstop>radio_load_van</tabstop>
+  <tabstop>finder_path_van</tabstop>
+  <tabstop>button_create_v</tabstop>
  </tabstops>
  <resources/>
  <connections/>

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/calibration/model.py
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/calibration/model.py
@@ -102,23 +102,6 @@ class CalibrationModel(object):
                 self.create_output_files(user_calib_dir, difa, difc, tzero, bk2bk_params, ceria_path, vanadium_path,
                                          instrument, bank, spectrum_numbers, calfile)
 
-        else:
-            if plot_output:
-                plot_dicts = list()
-                if bank is not None:
-                    if calfile:
-                        bank_name = "Custom"
-                    elif spectrum_numbers:
-                        bank_name = "Cropped"
-                    else:
-                        bank_name = bank
-                    plot_dicts.append(EnggUtils.generate_tof_fit_dictionary(bank_name))
-                    EnggUtils.plot_tof_fit(plot_dicts, [bank_name])
-                else:
-                    plot_dicts.append(EnggUtils.generate_tof_fit_dictionary("bank_1"))
-                    plot_dicts.append(EnggUtils.generate_tof_fit_dictionary("bank_2"))
-                    EnggUtils.plot_tof_fit(plot_dicts, ["bank_1", "bank_2"])
-
     @staticmethod
     def extract_b2b_params(workspace):
 

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/calibration/model.py
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/calibration/model.py
@@ -45,16 +45,17 @@ class CalibrationModel(object):
         """
         # vanadium corrections workspaces not used at this stage, but ensure they exist and create if not
         vanadium_corrections.fetch_correction_workspaces(vanadium_path, instrument, rb_num=rb_num)
-        full_calib_path = get_setting(output_settings.INTERFACES_SETTINGS_GROUP,
-                                      output_settings.ENGINEERING_PREFIX, "full_calibration")
-        try:
-            full_calib = Load(full_calib_path, OutputWorkspace="full_inst_calib")
-        except ValueError:
-            logger.error("Error loading Full instrument calibration - this is set in the interface settings.")
-            return
 
         if not only_update_vanadium:
             ceria_workspace = path_handling.load_workspace(ceria_path)
+            full_calib_path = get_setting(output_settings.INTERFACES_SETTINGS_GROUP,
+                                          output_settings.ENGINEERING_PREFIX, "full_calibration")
+            try:
+                full_calib = Load(full_calib_path, OutputWorkspace="full_inst_calib")
+            except ValueError:
+                logger.error("Error loading Full instrument calibration - this is set in the interface settings.")
+                return
+
             cal_params, ceria_raw, grp_ws = self.run_calibration(ceria_workspace,
                                                                  bank,
                                                                  calfile,

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/calibration/presenter.py
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/calibration/presenter.py
@@ -38,6 +38,8 @@ class CalibrationPresenter(object):
         self.cropping_widget = CroppingPresenter(parent=self.view, view=self.view.get_cropping_widget())
         self.show_cropping(False)
 
+        self.set_create_new_enabled(True)
+
     def connect_view_signals(self):
         self.view.set_on_calibrate_clicked(self.on_calibrate_clicked)
         self.view.set_enable_controls_connection(self.set_calibrate_controls_enabled)
@@ -201,7 +203,6 @@ class CalibrationPresenter(object):
     def set_create_new_enabled(self, enabled):
         self.view.set_vanadium_enabled(enabled)
         if enabled:
-            self.set_calibrate_button_text("Calibrate")
             self.view.set_check_plot_output_enabled(True)
             self.disable_sample_crop_and_plot(self.view.get_update_vanadium_checked())
             self.view.set_check_update_vanadium_enabled(self.last_calibration_successful)

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/calibration/presenter.py
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/calibration/presenter.py
@@ -46,6 +46,7 @@ class CalibrationPresenter(object):
         self.view.set_on_radio_existing_toggled(self.set_load_existing_enabled)
         self.view.set_on_check_cropping_state_changed(self.show_cropping)
         self.view.set_on_check_update_vanadium_state_changed(self.disable_sample_and_crop)
+        self.view.set_enable_update_vanadium(self.try_enable_update_vanadium)
 
     def on_calibrate_clicked(self):
         plot_output = self.view.get_plot_output()
@@ -176,6 +177,9 @@ class CalibrationPresenter(object):
     def emit_enable_button_signal(self):
         self.view.sig_enable_controls.emit(True)
 
+    def emit_enable_update_van(self, cal_success):
+        self.view.sig_enable_only_update_van.emit(cal_success)
+
     def emit_update_fields_signal(self):
         self.view.sig_update_fields.emit()
 
@@ -186,19 +190,12 @@ class CalibrationPresenter(object):
     def _on_error(self, error_info):
         logger.error(str(error_info))
         self.emit_enable_button_signal()
-        self.try_enable_update_vanadium(False)
+        self.emit_enable_update_van(False)
 
     def _on_success(self, success_info):
         self.set_current_calibration(success_info)
         self.emit_enable_button_signal()
-        self.try_enable_update_vanadium(True)
-
-    def try_enable_update_vanadium(self, cal_success):
-        self.last_calibration_successful = cal_success
-        if cal_success and self.view.get_new_checked():
-            self.view.set_check_update_vanadium_enabled(True)
-        else:
-            self.view.set_check_update_vanadium_enabled(False)
+        self.emit_enable_update_van(True)
 
     def set_create_new_enabled(self, enabled):
         self.view.set_vanadium_enabled(enabled)
@@ -239,6 +236,13 @@ class CalibrationPresenter(object):
             self.set_calibrate_button_text("Update Vanadium")
         else:
             self.set_calibrate_button_text("Calibrate")
+
+    def try_enable_update_vanadium(self, cal_success):
+        self.last_calibration_successful = cal_success
+        if cal_success and self.view.get_new_checked():
+            self.view.set_check_update_vanadium_enabled(True)
+        else:
+            self.view.set_check_update_vanadium_enabled(False)
 
     # -----------------------
     # Observers / Observables

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/calibration/presenter.py
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/calibration/presenter.py
@@ -202,20 +202,14 @@ class CalibrationPresenter(object):
 
     def set_create_new_enabled(self, enabled):
         self.view.set_vanadium_enabled(enabled)
-        self.view.set_sample_enabled(enabled)
         if enabled:
             self.set_calibrate_button_text("Calibrate")
             self.view.set_check_plot_output_enabled(True)
             self.disable_sample_and_crop(self.view.get_update_vanadium_checked())
             self.view.set_check_update_vanadium_enabled(self.last_calibration_successful)
             self.find_files()
-            # if self.view.get_update_vanadium_checked():
-            #     self.set_calibrate_button_text("Update Vanadium")
-            # else:
-            #     self.set_calibrate_button_text("Calibrate")
-
-        if enabled and self.view.get_update_vanadium_checked():
-            self.disable_sample_and_crop(True)
+        else:
+            self.view.set_sample_enabled(enabled)
 
     def set_load_existing_enabled(self, enabled):
         self.view.set_path_enabled(enabled)

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/calibration/presenter.py
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/calibration/presenter.py
@@ -45,7 +45,7 @@ class CalibrationPresenter(object):
         self.view.set_on_radio_new_toggled(self.set_create_new_enabled)
         self.view.set_on_radio_existing_toggled(self.set_load_existing_enabled)
         self.view.set_on_check_cropping_state_changed(self.show_cropping)
-        self.view.set_on_check_update_vanadium_state_changed(self.disable_sample_and_crop)
+        self.view.set_on_check_update_vanadium_state_changed(self.disable_sample_crop_and_plot)
         self.view.set_enable_update_vanadium(self.try_enable_update_vanadium)
 
     def on_calibrate_clicked(self):
@@ -185,7 +185,8 @@ class CalibrationPresenter(object):
 
     def set_calibrate_controls_enabled(self, enabled):
         self.view.set_calibrate_button_enabled(enabled)
-        self.view.set_check_plot_output_enabled(enabled)
+        if not self.view.get_update_vanadium_checked():
+            self.view.set_check_plot_output_enabled(enabled)
 
     def _on_error(self, error_info):
         logger.error(str(error_info))
@@ -202,7 +203,7 @@ class CalibrationPresenter(object):
         if enabled:
             self.set_calibrate_button_text("Calibrate")
             self.view.set_check_plot_output_enabled(True)
-            self.disable_sample_and_crop(self.view.get_update_vanadium_checked())
+            self.disable_sample_crop_and_plot(self.view.get_update_vanadium_checked())
             self.view.set_check_update_vanadium_enabled(self.last_calibration_successful)
             self.find_files()
         else:
@@ -227,10 +228,11 @@ class CalibrationPresenter(object):
     def show_cropping(self, show):
         self.view.set_cropping_widget_visibility(show)
 
-    def disable_sample_and_crop(self, disable):
+    def disable_sample_crop_and_plot(self, disable):
         show = not disable
         self.view.set_sample_enabled(show)
         self.view.set_check_cropping_enabled(show)
+        self.view.set_check_plot_output_enabled(show)
         if disable:
             self.view.set_check_cropping_checked(show)
             self.set_calibrate_button_text("Update Vanadium")

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/calibration/test/test_calib_presenter.py
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/calibration/test/test_calib_presenter.py
@@ -168,12 +168,14 @@ class CalibrationPresenterTest(unittest.TestCase):
         self.view.set_check_plot_output_enabled.assert_called_with(True)
 
     @patch(tab_path + ".presenter.CalibrationPresenter.emit_enable_button_signal")
-    def test_on_error_posts_to_logger_and_enables_controls(self, emit):
+    @patch(tab_path + ".presenter.CalibrationPresenter.emit_enable_update_van")
+    def test_on_error_posts_to_logger_and_enables_controls(self, emit_button, emit_update_van):
         fail_info = 2024278
 
         self.presenter._on_error(fail_info)
 
-        self.assertEqual(emit.call_count, 1)
+        self.assertEqual(emit_button.call_count, 1)
+        self.assertEqual(emit_update_van.call_count, 1)
 
     def test_validation_of_run_numbers(self):
         self.view.get_sample_valid.return_value = False

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/calibration/test/test_calib_presenter.py
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/calibration/test/test_calib_presenter.py
@@ -156,12 +156,14 @@ class CalibrationPresenterTest(unittest.TestCase):
         self.assertEqual(err_msg.call_count, 1)
 
     def test_controls_disabled_disables_both(self):
+        self.view.get_update_vanadium_checked.return_value = False
         self.presenter.set_calibrate_controls_enabled(False)
 
         self.view.set_calibrate_button_enabled.assert_called_with(False)
         self.view.set_check_plot_output_enabled.assert_called_with(False)
 
     def test_controls_enabled_enables_both(self):
+        self.view.get_update_vanadium_checked.return_value = False
         self.presenter.set_calibrate_controls_enabled(True)
 
         self.view.set_calibrate_button_enabled.assert_called_with(True)

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/calibration/view.py
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/calibration/view.py
@@ -13,8 +13,8 @@ Ui_calib, _ = load_ui(__file__, "calibration_tab.ui")
 
 class CalibrationView(QtWidgets.QWidget, Ui_calib):
     sig_enable_controls = QtCore.Signal(bool)
-    sig_update_fields = QtCore.Signal()
-    sig_enable_only_update_van = QtCore.Signal(bool)
+    sig_update_sample_field = QtCore.Signal()
+    sig_update_van_field = QtCore.Signal()
 
     def __init__(self, parent=None, instrument="ENGINX"):
         super(CalibrationView, self).__init__(parent)
@@ -30,6 +30,11 @@ class CalibrationView(QtWidgets.QWidget, Ui_calib):
         self.finder_path.isForRunFiles(False)
         self.finder_path.setEnabled(False)
         self.finder_path.setFileExtensions([".prm"])
+
+        self.finder_path_van.setLabelText("Path")
+        self.finder_path_van.isForRunFiles(False)
+        self.finder_path_van.setEnabled(False)
+        self.finder_path_van.setFileExtensions([".nxs"])
 
     # =================
     # Slot Connectors
@@ -55,17 +60,23 @@ class CalibrationView(QtWidgets.QWidget, Ui_calib):
     def set_enable_controls_connection(self, slot):
         self.sig_enable_controls.connect(slot)
 
-    def set_update_fields_connection(self, slot):
-        self.sig_update_fields.connect(slot)
+    def set_update_sample_field_connection(self, slot):
+        self.sig_update_sample_field.connect(slot)
 
     def set_on_check_cropping_state_changed(self, slot):
         self.check_cropCalib.stateChanged.connect(slot)
 
-    def set_on_check_update_vanadium_state_changed(self, slot):
-        self.check_updateVan.stateChanged.connect(slot)
+    def set_on_create_van_clicked(self, slot):
+        self.button_create_v.clicked.connect(slot)
 
-    def set_enable_update_vanadium(self, slot):
-        self.sig_enable_only_update_van.connect(slot)
+    def set_update_van_field_connection(self, slot):
+        self.sig_update_van_field.connect(slot)
+
+    def set_on_radio_new_van_toggled(self, slot):
+        self.radio_new_van.toggled.connect(slot)
+
+    def set_on_radio_existing_van_toggled(self, slot):
+        self.radio_load_van.toggled.connect(slot)
 
     # =================
     # Component Setters
@@ -87,7 +98,7 @@ class CalibrationView(QtWidgets.QWidget, Ui_calib):
     def set_sample_enabled(self, set_to):
         self.finder_sample.setEnabled(set_to)
 
-    def set_path_enabled(self, set_to):
+    def set_calib_path_enabled(self, set_to):
         self.finder_path.setEnabled(set_to)
 
     def set_vanadium_text(self, text):
@@ -99,10 +110,10 @@ class CalibrationView(QtWidgets.QWidget, Ui_calib):
     def set_calibrate_button_text(self, text):
         self.button_calibrate.setText(text)
 
-    def set_load_checked(self, ticked: bool):
+    def set_load_calib_checked(self, ticked: bool):
         self.radio_loadCalib.setChecked(ticked)
 
-    def set_file_text_with_search(self, text: str):
+    def set_calib_file_text_with_search(self, text: str):
         self.finder_path.setFileTextWithSearch(text)
 
     def set_cropping_widget_visibility(self, visible):
@@ -114,11 +125,21 @@ class CalibrationView(QtWidgets.QWidget, Ui_calib):
     def set_check_cropping_checked(self, checked):
         self.check_cropCalib.setChecked(checked)
 
-    def set_check_update_vanadium_enabled(self, enabled):
-        self.check_updateVan.setEnabled(enabled)
+    def set_create_van_button_enabled(self, enabled):
+        self.button_create_v.setEnabled(enabled)
 
-    def set_check_update_vanadium_checked(self, checked):
-        self.check_updateVan.setChecked(checked)
+    def set_create_van_button_text(self, text):
+        self.button_create_v.setText(text)
+
+    def set_van_path_enabled(self, set_to):
+        self.finder_path_van.setEnabled(set_to)
+
+    def set_load_van_checked(self, ticked: bool):
+        self.radio_load_van.setChecked(ticked)
+
+    def set_van_file_text_with_search(self, text: str):
+        self.finder_path_van.setFileTextWithSearch(text)
+
     # =================
     # Component Getters
     # =================
@@ -138,16 +159,16 @@ class CalibrationView(QtWidgets.QWidget, Ui_calib):
     def get_path_filename(self):
         return self.finder_path.getFirstFilename()
 
-    def get_path_valid(self):
+    def get_calib_path_valid(self):
         return self.finder_path.isValid() and self.finder_path.getText()
 
     def get_plot_output(self):
         return self.check_plotOutput.isChecked()
 
-    def get_new_checked(self):
+    def get_new_calib_checked(self):
         return self.radio_newCalib.isChecked()
 
-    def get_load_checked(self):
+    def get_load_calib_checked(self):
         return self.radio_loadCalib.isChecked()
 
     def get_crop_checked(self):
@@ -156,8 +177,17 @@ class CalibrationView(QtWidgets.QWidget, Ui_calib):
     def get_cropping_widget(self):
         return self.widget_cropping
 
-    def get_update_vanadium_checked(self):
-        return self.check_updateVan.isChecked()
+    def get_new_van_checked(self):
+        return self.radio_new_van.isChecked()
+
+    def get_load_van_checked(self):
+        return self.radio_load_van.isChecked()
+
+    def get_van_path_filename(self):
+        return self.finder_path_van.getFirstFilename()
+
+    def get_van_path_valid(self):
+        return self.finder_path_van.isValid() and self.finder_path_van.getText()
 
     # =================
     # State Getters
@@ -165,6 +195,9 @@ class CalibrationView(QtWidgets.QWidget, Ui_calib):
 
     def is_searching(self):
         return self.finder_sample.isSearching() or self.finder_sample.isSearching()
+
+    def is_searching_van(self):
+        return self.finder_vanadium.isSearching() or self.finder_vanadium.isSearching()
 
     # =================
     # Force Actions
@@ -184,11 +217,15 @@ class CalibrationView(QtWidgets.QWidget, Ui_calib):
         self.finder_vanadium.focusProxy().setFocusPolicy(QtCore.Qt.StrongFocus)
         self.finder_sample.focusProxy().setFocusPolicy(QtCore.Qt.StrongFocus)
         self.finder_path.focusProxy().setFocusPolicy(QtCore.Qt.StrongFocus)
+        self.finder_path_van.focusProxy().setFocusPolicy(QtCore.Qt.StrongFocus)
 
-        self.setTabOrder(self.radio_newCalib, self.finder_vanadium.focusProxy())
-        self.setTabOrder(self.finder_vanadium.focusProxy(), self.finder_sample.focusProxy())
-        self.setTabOrder(self.finder_sample.focusProxy(), self.finder_path.focusProxy())
+        self.setTabOrder(self.radio_newCalib, self.finder_sample.focusProxy())
+        self.setTabOrder(self.finder_sample.focusProxy(), self.radio_loadCalib)
+        self.setTabOrder(self.radio_loadCalib, self.finder_path.focusProxy())
         self.setTabOrder(self.finder_path.focusProxy(), self.check_cropCalib)
         self.setTabOrder(self.check_cropCalib, self.widget_cropping)
         self.setTabOrder(self.widget_cropping, self.check_plotOutput)
         self.setTabOrder(self.check_plotOutput, self.button_calibrate)
+        self.setTabOrder(self.button_calibrate, self.finder_vanadium.focusProxy())
+        self.setTabOrder(self.finder_vanadium.focusProxy(), self.finder_path_van.focusProxy())
+        self.setTabOrder(self.finder_path_van.focusProxy(), self.button_create_v)

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/calibration/view.py
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/calibration/view.py
@@ -60,6 +60,9 @@ class CalibrationView(QtWidgets.QWidget, Ui_calib):
     def set_on_check_cropping_state_changed(self, slot):
         self.check_cropCalib.stateChanged.connect(slot)
 
+    def set_on_check_update_vanadium_state_changed(self, slot):
+        self.check_updateVan.stateChanged.connect(slot)
+
     # =================
     # Component Setters
     # =================
@@ -107,6 +110,11 @@ class CalibrationView(QtWidgets.QWidget, Ui_calib):
     def set_check_cropping_checked(self, checked):
         self.check_cropCalib.setChecked(checked)
 
+    def set_check_update_vanadium_enabled(self, enabled):
+        self.check_updateVan.setEnabled(enabled)
+
+    def set_check_update_vanadium_checked(self, checked):
+        self.check_updateVan.setChecked(checked)
     # =================
     # Component Getters
     # =================
@@ -143,6 +151,9 @@ class CalibrationView(QtWidgets.QWidget, Ui_calib):
 
     def get_cropping_widget(self):
         return self.widget_cropping
+
+    def get_update_vanadium_checked(self):
+        return self.check_updateVan.isChecked()
 
     # =================
     # State Getters

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/calibration/view.py
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/calibration/view.py
@@ -14,6 +14,7 @@ Ui_calib, _ = load_ui(__file__, "calibration_tab.ui")
 class CalibrationView(QtWidgets.QWidget, Ui_calib):
     sig_enable_controls = QtCore.Signal(bool)
     sig_update_fields = QtCore.Signal()
+    sig_enable_only_update_van = QtCore.Signal(bool)
 
     def __init__(self, parent=None, instrument="ENGINX"):
         super(CalibrationView, self).__init__(parent)
@@ -62,6 +63,9 @@ class CalibrationView(QtWidgets.QWidget, Ui_calib):
 
     def set_on_check_update_vanadium_state_changed(self, slot):
         self.check_updateVan.stateChanged.connect(slot)
+
+    def set_enable_update_vanadium(self, slot):
+        self.sig_enable_only_update_van.connect(slot)
 
     # =================
     # Component Setters

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/common/calibration_info.py
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/common/calibration_info.py
@@ -10,7 +10,7 @@ class CalibrationInfo(object):
     """
     Keeps track of the parameters that went into a calibration created by the engineering diffraction GUI.
     """
-    def __init__(self, vanadium_path=None, sample_path=None, instrument=None, grouping_ws=None, roi_text: str = ""):
+    def __init__(self, vanadium_path=None, sample_path=None, instrument=None, grouping_ws=None, roi_text: str = "Not loaded"):
         self.vanadium_path = vanadium_path
         self.sample_path = sample_path
         self.instrument = instrument
@@ -18,15 +18,22 @@ class CalibrationInfo(object):
         self.roi_text = roi_text
         self.bank = None
 
-    def set_calibration(self, vanadium_path, sample_path, instrument):
+    def set_calibration(self, sample_path, instrument):
         """
-        Set the values of the calibration. requires a complete set of calibration info to be supplied.
-        :param vanadium_path: Path to the vanadium data file used in the calibration.
+        Set the values of the calibration
         :param sample_path: Path to the sample data file used.
         :param instrument: String defining the instrument the data came from.
         """
-        self.vanadium_path = vanadium_path
         self.sample_path = sample_path
+        self.instrument = instrument
+
+    def set_vanadium(self, vanadium_path, instrument):
+        """
+        Set the Vanadium data
+        :param vanadium_path: Path to the Vanadium data file used.
+        :param instrument: String defining the instrument the data came from.
+        """
+        self.vanadium_path = vanadium_path
         self.instrument = instrument
 
     def set_roi_info_load(self, banks: list, grp_ws: str, roi_text: str) -> None:

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/focus/focus_tab.ui
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/focus/focus_tab.ui
@@ -116,7 +116,7 @@ QGroupBox:title {
           <item row="4" column="1" colspan="2">
            <widget class="QLabel" name="regionDisplay">
             <property name="text">
-             <string>Calibration not loaded</string>
+             <string></string>
             </property>
            </widget>
           </item>

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/focus/presenter.py
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/focus/presenter.py
@@ -31,7 +31,7 @@ class FocusPresenter(object):
         self.view.set_enable_controls_connection(self.set_focus_controls_enabled)
 
         # Variables from other GUI tabs.
-        self.current_calibration = CalibrationInfo()
+        self.update_calibration(CalibrationInfo())
         self.instrument = "ENGINX"
         self.rb_num = None
 


### PR DESCRIPTION
**Description of work.**

Add OnlyUpdateVanadium checkbox to skip calibration if checked
    
Only_Update_vanadium checkbox is enabled if Create_New_calibration is enabled
and the last calibration was successful.
When Only_update_vanadium is checked, crop is disabled and unchecked,
Sample path is disabled, its path not validated,
and the Main action button is renamed to "Update Vanadium"


**To test:**

- run `git test-pr origin 32184`
- Open Workbench and the Engineering Diffraction interface

_Enabling_
- The Only Update Vanadium checkbox should be disabled (greyed out)
- For Vanadium Path enter: .`../cycle_19_1/ENGINX00307521.nxs` or your favourite dataset
- For Sample Path enter: `.../cycle_19_1/ENGINX00305738.nxs` or your favourite dataset
- make sure Plot Calibrated workspace is ticked
- Then click Calibrate
- Screenshot or just keep open the plots that appear
- After it runs successfully, the Only Update Vanadium checkbox should be enabled

_Ticking/Checking_
- Tick Crop Calibration
- Now tick Only Update Vanadium and notice that this has:
    - Disabled Sample Path
    - Disabled and unticked Crop Calibration
    - The main action button is renamed from "Calibrate" to "Update Vanadium"
- The enabled/disabled state of these inputs persist after toggling to Load Existing Calibration and then toggling back to Create New Calibration

_Validation and Behaviour_
- Firstly, untick OnlyUpdateVanadium, and change the Sample path to another dataset, such as: `.../cycle_12_4/ENGINX00193749.nxs`
- Now retick Only Update Vanadium and click the main action button "Update Vanadium"
- The output plots should be the same as before!!
- Now untick OnlyUpdateVanadium and click Calibrate
- The newly output plot should be different, which proves that the sample path was ignored when OnlyUpdateVanadium was ticked.

Questions for tester:
- **Should the calibration be replotted if Only_update_vanadium is ticked? (calibration should not change!)** -> I've decided Yes!
- Are there any other tests that should be added?

Fixes #31904 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
