### PR TITLE
cleanup default handling with bilby xml param (no ticket)

### DIFF
--- a/Framework/DataHandling/src/LoadBBY.cpp
+++ b/Framework/DataHandling/src/LoadBBY.cpp
@@ -489,10 +489,10 @@ void LoadBBY::loadInstrumentParameters(NeXus::NXEntry &entry, std::map<std::stri
         auto hdfTag = boost::algorithm::trim_copy(details[0]);
         try {
           // extract the parameter and add it to the parameter dictionary,
-          // check the default for value numeric and string
+          // check the scale factor for numeric and string
           auto updateOk = false;
           if (!hdfTag.empty()) {
-            if (isNumeric(details[2])) {
+            if (isNumeric(details[1])) {
               if (loadNXDataSet(entry, hdfTag, tmpFloat)) {
                 auto factor = std::stod(details[1]);
                 logParams[logTag] = factor * tmpFloat;
@@ -504,12 +504,17 @@ void LoadBBY::loadInstrumentParameters(NeXus::NXEntry &entry, std::map<std::stri
             }
           }
           if (!updateOk) {
-            if (isNumeric(details[2]))
-              logParams[logTag] = std::stod(details[2]);
-            else
-              logStrings[logTag] = details[2];
-            if (!hdfTag.empty())
-              g_log.warning() << "Cannot find hdf parameter " << hdfTag << ", using default.\n";
+            // if the hdf is missing the tag then add the default if
+            // it is provided
+            auto defValue = boost::algorithm::trim_copy(details[2]);
+            if (!defValue.empty()) {
+              if (isNumeric(defValue))
+                logParams[logTag] = std::stod(defValue);
+              else
+                logStrings[logTag] = defValue;
+              if (!hdfTag.empty())
+                g_log.warning() << "Cannot find hdf parameter " << hdfTag << ", using default.\n";
+            }
           }
         } catch (const std::invalid_argument &) {
           g_log.warning() << "Invalid format for BILBY parameter " << x.first << std::endl;

--- a/Framework/DataHandling/test/LoadBBYTest.h
+++ b/Framework/DataHandling/test/LoadBBYTest.h
@@ -167,6 +167,34 @@ public:
     TS_ASSERT_LESS_THAN(0.0399999, minTime);
   }
 
+  void test_default_parameters_logged() {
+    LoadBBY algToBeTested;
+
+    if (!algToBeTested.isInitialized())
+      algToBeTested.initialize();
+
+    std::string outputSpace = "LoadBBYTestB";
+    algToBeTested.setPropertyValue("OutputWorkspace", outputSpace);
+    std::string inputFile = "BBY0000014.tar";
+    algToBeTested.setPropertyValue("Filename", inputFile);
+
+    // execute and get workspace generated
+    TS_ASSERT_THROWS_NOTHING(algToBeTested.execute());
+    TS_ASSERT(algToBeTested.isExecuted());
+    EventWorkspace_sptr output = AnalysisDataService::Instance().retrieveWS<EventWorkspace>(outputSpace);
+    auto run = output->run();
+
+    // confirm that the sample_aperture which is not included in the hdf file
+    // is present in the log and set to the default value
+    TS_ASSERT_DELTA(dynamic_cast<TimeSeriesProperty<double> *>(run.getProperty("sample_aperture"))->firstValue(), 0.0,
+                    1.0e-3);
+    TS_ASSERT_DELTA(dynamic_cast<TimeSeriesProperty<double> *>(run.getProperty("source_aperture"))->firstValue(), 0.0,
+                    1.0e-3);
+
+    // confirm that the dummy test parameter in the xml without a default is not added to the log
+    TS_ASSERT(!run.hasProperty("sample_xxx"))
+  }
+
   void test_invalid_event_logged() {
     LoadBBY algToBeTested;
 

--- a/instrument/BILBY_Parameters.xml
+++ b/instrument/BILBY_Parameters.xml
@@ -96,7 +96,7 @@
       <value val=",,10.0"/>
     </parameter>
 	
-	<!-- dummy parameter to support unit testing
+	<!-- dummy parameter to support unit testing,
 		the parameter is not present in the data file and does not
 		have a default value so is not added to the workspace log -->
     <parameter name="log_sample_xxx" type="string">

--- a/instrument/BILBY_Parameters.xml
+++ b/instrument/BILBY_Parameters.xml
@@ -14,7 +14,7 @@
 	<!-- following parameters are saved to the run log,
 	     parameters are entered as log_[log_name] and the 
 	     and the value is: "hdf_tag,scale,def_value"
-		the default value determines if the value is
+		the scale value determines if the value is
 		interpreted as a numeric or string-->
     <parameter name="log_sample_aperture" type="string">
       <value val="sample/sample_aperture, 1.0, 0.0"/>
@@ -33,26 +33,26 @@
     </parameter>	
 	
     <parameter name="log_Lt0_value" type="string">
-      <value val="instrument/Lt0, 0.001, 0.0"/>
+      <value val="instrument/Lt0, 0.001,"/>
     </parameter>		 
     <parameter name="log_Ltof_curtainl_value" type="string">
-      <value val="instrument/Ltof_curtainl, 0.001, 0.0"/>
+      <value val="instrument/Ltof_curtainl, 0.001,"/>
     </parameter>		 
     <parameter name="log_Ltof_curtainr_value" type="string">
-      <value val="instrument/Ltof_curtainr, 0.001, 0.0"/>
+      <value val="instrument/Ltof_curtainr, 0.001,"/>
     </parameter>		 
     <parameter name="log_Ltof_curtainu_value" type="string">
-      <value val="instrument/Ltof_curtainu, 0.001, 0.0"/>
+      <value val="instrument/Ltof_curtainu, 0.001,"/>
     </parameter>		 
     <parameter name="log_Ltof_curtaind_value" type="string">
-      <value val="instrument/Ltof_curtaind, 0.001, 0.0"/>
+      <value val="instrument/Ltof_curtaind, 0.001,"/>
     </parameter>	
 
     <parameter name="log_L2_det_value" type="string">
       <value val="instrument/L2_det, 0.001, 33.1562"/>
     </parameter>	
     <parameter name="log_Ltof_det_value" type="string">
-      <value val="instrument/Ltof_det, 0.001, 0.0"/>
+      <value val="instrument/Ltof_det, 0.001,"/>
     </parameter>	
     <parameter name="log_L1" type="string">
       <value val="instrument/L1, 0.001, 16.671"/>
@@ -85,15 +85,22 @@
     </parameter>
 
 	<parameter name="log_rough_40" type="string">
-      <value val="instrument/shutters/rough_40, 1, in"/>
+      <value val="instrument/shutters/rough_40, na, in"/>
     </parameter>	
 	<parameter name="log_rough_100" type="string">
-      <value val="instrument/shutters/rough_100, 1, in"/>
+      <value val="instrument/shutters/rough_100, na, in"/>
     </parameter>
 	
 	<!-- parameter to be added to log that is not in the hdf file -->
 	<parameter name="log_curtain_rotation" type="string">
       <value val=",,10.0"/>
+    </parameter>
+	
+	<!-- dummy parameter to support unit testing
+		the parameter is not present in the data file and does not
+		have a default value so is not added to the workspace log -->
+    <parameter name="log_sample_xxx" type="string">
+      <value val="sample/sample_xxx, na,"/>
     </parameter>
 	
 	


### PR DESCRIPTION
**Description of work.**

Clean up the Bilby loader so that unused parameters, with invalid defaults, are not added to the workspace log for monochromatic datasets.

**To test:**
This case was added to the bilby loader unit tests.  

<!-- delete this if you added release notes
*This does not require release notes* because it just cleans up unused parameters in the log without any change to the Bilby processing functions.
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
