### PR TITLE
Fix a gcc 11 error 

### DIFF
--- a/Framework/CurveFitting/inc/MantidCurveFitting/ExcludeRangeFinder.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/ExcludeRangeFinder.h
@@ -8,6 +8,7 @@
 
 #include "MantidCurveFitting/DllConfig.h"
 
+#include <cstddef>
 #include <vector>
 
 namespace Mantid {
@@ -31,7 +32,7 @@ private:
   /// Find the range from m_exclude that may contain points x >= p
   void findNextExcludedRange(double p);
   /// Index of current excluded range
-  size_t m_exclIndex;
+  std::size_t m_exclIndex;
   /// Start of current excluded range
   double m_startExcludedRange;
   /// End of current excluded range
@@ -39,7 +40,7 @@ private:
   /// Reference to a list of exclusion ranges.
   const std::vector<double> m_exclude;
   /// Size of m_exclude.
-  const size_t m_size;
+  const std::size_t m_size;
 };
 
 } // namespace CurveFitting

--- a/Framework/CurveFitting/src/ExcludeRangeFinder.cpp
+++ b/Framework/CurveFitting/src/ExcludeRangeFinder.cpp
@@ -69,7 +69,7 @@ void ExcludeRangeFinder::findNextExcludedRange(double p) {
   // the previous point. Keep index m_exclIndex pointing to the start.
   for (auto it = m_exclude.begin() + m_exclIndex; it != m_exclude.end(); ++it) {
     if (*it >= p) {
-      m_exclIndex = static_cast<size_t>(std::distance(m_exclude.begin(), it));
+      m_exclIndex = static_cast<std::size_t>(std::distance(m_exclude.begin(), it));
       if (m_exclIndex % 2 == 0) {
         // A number at an even position in m_exclude starts an exclude
         // range


### PR DESCRIPTION
**Description of work.**
Conda build uses gcc 11 on Linux, this produces an error while building mantid due to a missing definition of std::size_t. 


<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**
Builds pass
<!-- Instructions for testing. -->


*There is no associated issue.*



*This does not require release notes* because its a developer change


<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
