### PR TITLE
LoadEventNexus stops reading logs (ornlnext)

### DIFF
--- a/Framework/DataHandling/src/LoadNexusLogs.cpp
+++ b/Framework/DataHandling/src/LoadNexusLogs.cpp
@@ -880,6 +880,8 @@ void LoadNexusLogs::loadNXLog(::NeXus::File &file, const std::string &absolute_e
     }
   } catch (::NeXus::Exception &e) {
     g_log.warning() << "NXlog entry " << entry_name << " gave an error when loading:'" << e.what() << "'.\n";
+  } catch (std::invalid_argument &e) {
+    g_log.warning() << "NXlog entry " << entry_name << " gave an error when loading:'" << e.what() << "'.\n";
   }
 
   file.closeGroup();

--- a/Framework/DataHandling/src/LoadNexusMonitors2.cpp
+++ b/Framework/DataHandling/src/LoadNexusMonitors2.cpp
@@ -38,6 +38,8 @@ using Mantid::DataObjects::EventWorkspace_sptr;
 using Mantid::HistogramData::BinEdges;
 using Mantid::HistogramData::Counts;
 using Mantid::HistogramData::Histogram;
+using Mantid::Kernel::Direction;
+using Mantid::Kernel::PropertyWithValue;
 
 namespace Mantid {
 namespace DataHandling {
@@ -78,6 +80,11 @@ void loadSampleDataISIScompatibilityInfo(::NeXus::File &file, Mantid::API::Matri
 
 const std::string LOAD_EVENTS("Events");
 const std::string LOAD_HISTO("Histogram");
+
+namespace PropertyNames {
+const std::string LOGS_ALLOW("AllowList");
+const std::string LOGS_BLOCK("BlockList");
+} // namespace PropertyNames
 
 // collection of static methods to inspect monitors to determine type
 bool keyExists(std::string const &key, std::map<std::string, std::string> const &entries) {
@@ -133,6 +140,15 @@ void LoadNexusMonitors2::init() {
                   "If multiple repesentations exist, which one to load. "
                   "Default is to load the one that is present, and Histogram "
                   "if both are present.");
+
+  declareProperty(std::make_unique<PropertyWithValue<std::vector<std::string>>>(
+                      PropertyNames::LOGS_ALLOW, std::vector<std::string>(), Direction::Input),
+                  "If specified, only these logs will be loaded from the file (each "
+                  "separated by a comma).");
+  declareProperty(std::make_unique<PropertyWithValue<std::vector<std::string>>>(
+                      PropertyNames::LOGS_BLOCK, std::vector<std::string>(), Direction::Input),
+                  "If specified, these logs will NOT be loaded from the file (each "
+                  "separated by a comma).");
 }
 
 //------------------------------------------------------------------------------
@@ -382,6 +398,10 @@ void LoadNexusMonitors2::fixUDets(::NeXus::File &file) {
 }
 
 void LoadNexusMonitors2::runLoadLogs(const std::string &filename, const API::MatrixWorkspace_sptr &localWorkspace) {
+  // get the properties for which logs to use
+  const std::vector<std::string> allow_list = getProperty(PropertyNames::LOGS_ALLOW);
+  const std::vector<std::string> block_list = getProperty(PropertyNames::LOGS_BLOCK);
+
   // do the actual work
   API::IAlgorithm_sptr loadLogs = createChildAlgorithm("LoadNexusLogs");
 
@@ -390,6 +410,9 @@ void LoadNexusMonitors2::runLoadLogs(const std::string &filename, const API::Mat
     g_log.information() << "Loading logs from NeXus file...\n";
     loadLogs->setPropertyValue("Filename", filename);
     loadLogs->setProperty<API::MatrixWorkspace_sptr>("Workspace", localWorkspace);
+    // copy properties for which logs to use/not use
+    loadLogs->setProperty<std::vector<std::string>>(PropertyNames::LOGS_ALLOW, allow_list);
+    loadLogs->setProperty<std::vector<std::string>>(PropertyNames::LOGS_BLOCK, block_list);
     loadLogs->execute();
   } catch (...) {
     g_log.error() << "Error while loading Logs from Nexus. Some sample logs "

--- a/Framework/Kernel/src/TimeSeriesProperty.cpp
+++ b/Framework/Kernel/src/TimeSeriesProperty.cpp
@@ -1369,9 +1369,12 @@ template <typename TYPE> void TimeSeriesProperty<TYPE>::clearOutdated() {
 template <typename TYPE>
 void TimeSeriesProperty<TYPE>::create(const Types::Core::DateAndTime &start_time, const std::vector<double> &time_sec,
                                       const std::vector<TYPE> &new_values) {
-  if (time_sec.size() != new_values.size())
-    throw std::invalid_argument("TimeSeriesProperty::create: mismatched size "
-                                "for the time and values vectors.");
+  if (time_sec.size() != new_values.size()) {
+    std::stringstream msg;
+    msg << "TimeSeriesProperty \"" << name() << "\" create: mismatched size "
+        << "for the time and values vectors.";
+    throw std::invalid_argument(msg.str());
+  }
 
   // Make the times(as seconds) into a vector of DateAndTime in one go.
   std::vector<DateAndTime> times;

--- a/docs/source/release/v6.2.0/framework.rst
+++ b/docs/source/release/v6.2.0/framework.rst
@@ -47,6 +47,17 @@ MantidWorkbench
 
 See :doc:`mantidworkbench`.
 
+Algorithms
+----------
+
+Improvements
+############
+- :ref:`LoadNexusMonitors <algm-LoadNexusMonitors-v2>` now utilizes the log filter provided by `LoadNexusLogs <algm-LoadNexusLogs>`
+
+Bugfixes
+########
+- :ref:`LoadNexusLogs <algm-LoadNexusLogs>` now logs that are poorly formed create a warning message and the other logs are loaded. Previously it stopped loading logs at that point.
+
 SliceViewer
 -----------
 


### PR DESCRIPTION
This is the version of #32198 into `ornl-next`