### PR TITLE
Add user friendly error handling to the PlotConfigDialog

### DIFF
--- a/docs/source/release/v6.2.0/mantidworkbench.rst
+++ b/docs/source/release/v6.2.0/mantidworkbench.rst
@@ -24,6 +24,7 @@ New and Improved
 - Script editor tab completion and call tip support for Numpy 1.21
 - The visibility of a component parameter in the Pick tab of the InstrumentViewer is now steered by the 'visible' atrribute of a parameter in IPF
 - Plot legends can be shown or hidden from the plot context menu.
+- The plot config dialog notifies the user when there has been an error applying the config to the plot, and allows them to change the config further.
 
 Bugfixes
 --------

--- a/qt/python/mantidqt/widgets/plotconfigdialog/axestabwidget/presenter.py
+++ b/qt/python/mantidqt/widgets/plotconfigdialog/axestabwidget/presenter.py
@@ -16,12 +16,14 @@ from mantidqt.widgets.plotconfigdialog.axestabwidget.view import AxesTabWidgetVi
 
 class AxesTabWidgetPresenter:
 
-    def __init__(self, fig, view=None, parent=None):
+    def __init__(self, fig, view=None, parent=None, success_callback=None, error_callback=None):
         self.fig = fig
         if not view:
             self.view = AxesTabWidgetView(parent)
         else:
             self.view = view
+        self.success_callback = success_callback
+        self.error_callback = error_callback
 
         # Store a copy of the current view props.
         self.current_view_props = {}
@@ -40,10 +42,13 @@ class AxesTabWidgetPresenter:
             self.update_view)
         self.view.axis_tab_bar.currentChanged.connect(
             self.axis_changed)
-        self.view.apply_all_button.clicked.connect(self.apply_all_properties)
         self.view.show_minor_ticks_check_box.toggled.connect(
             self.show_minor_ticks_checked)
         self.view.autoscale.toggled.connect(self.autoscale_changed)
+        if self.success_callback and self.error_callback:
+            self.view.apply_all_button.clicked.connect(self._apply_all_properties_with_errors)
+        else:
+            self.view.apply_all_button.clicked.connect(self.apply_all_properties)
 
     def apply_properties(self):
         """Update the axes with the user inputted properties"""
@@ -293,3 +298,12 @@ class AxesTabWidgetPresenter:
 
         if not checked:
             self.view.set_show_minor_gridlines(False)
+
+    def _apply_all_properties_with_errors(self):
+        """Call apply_all_properties, notifying the parent presenter of whether there were any errors"""
+        try:
+            self.apply_all_properties()
+        except Exception as exception:
+            self.error_callback(str(exception))
+            return
+        self.success_callback()

--- a/qt/python/mantidqt/widgets/plotconfigdialog/axestabwidget/presenter.py
+++ b/qt/python/mantidqt/widgets/plotconfigdialog/axestabwidget/presenter.py
@@ -303,7 +303,7 @@ class AxesTabWidgetPresenter:
         """Call apply_all_properties, notifying the parent presenter of whether there were any errors"""
         try:
             self.apply_all_properties()
-        except Exception as exception:
+        except (AssertionError, IndexError, KeyError, TypeError, ValueError) as exception:
             self.error_callback(str(exception))
             return
         self.success_callback()

--- a/qt/python/mantidqt/widgets/plotconfigdialog/axestabwidget/test/test_axestabwidgetpresenter.py
+++ b/qt/python/mantidqt/widgets/plotconfigdialog/axestabwidget/test/test_axestabwidgetpresenter.py
@@ -276,6 +276,39 @@ class AxesTabWidgetPresenterTest(unittest.TestCase):
 
         self.assertEqual(presenter.current_view_props["xlim"], (-1.0, 10.0))
 
+    def test_apply_all_properties_with_errors_notifies_parent_presenter_on_exception(self):
+        canvas_draw_exception = Exception("Exception in canvas.draw")
+
+        def raise_():
+            raise canvas_draw_exception
+
+        mock_view = mock.Mock(get_selected_ax_name=lambda: "My Axes: (0, 0)",
+                              get_axis=lambda: "x",
+                              get_properties=lambda: {})
+        mock_success_callback, mock_error_callback = mock.Mock(), mock.Mock()
+        presenter = Presenter(self.fig, view=mock_view, success_callback=mock_success_callback,
+                              error_callback=mock_error_callback)
+        presenter.apply_all_properties = mock.Mock(side_effect=lambda: raise_())
+
+        presenter._apply_all_properties_with_errors()
+
+        mock_success_callback.assert_not_called()
+        mock_error_callback.assert_called()
+
+    def test_apply_all_properties_with_errors_notifies_parent_presenter_on_success(self):
+        mock_view = mock.Mock(get_selected_ax_name=lambda: "My Axes: (0, 0)",
+                              get_axis=lambda: "x",
+                              get_properties=lambda: {})
+        mock_success_callback, mock_error_callback = mock.Mock(), mock.Mock()
+        presenter = Presenter(self.fig, view=mock_view, success_callback=mock_success_callback,
+                              error_callback=mock_error_callback)
+        presenter.apply_all_properties = mock.Mock()
+
+        presenter._apply_all_properties_with_errors()
+
+        mock_success_callback.assert_called()
+        mock_error_callback.assert_not_called()
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/qt/python/mantidqt/widgets/plotconfigdialog/axestabwidget/test/test_axestabwidgetpresenter.py
+++ b/qt/python/mantidqt/widgets/plotconfigdialog/axestabwidget/test/test_axestabwidgetpresenter.py
@@ -276,24 +276,25 @@ class AxesTabWidgetPresenterTest(unittest.TestCase):
 
         self.assertEqual(presenter.current_view_props["xlim"], (-1.0, 10.0))
 
-    def test_apply_all_properties_with_errors_notifies_parent_presenter_on_exception(self):
-        canvas_draw_exception = Exception("Exception in canvas.draw")
-
-        def raise_():
-            raise canvas_draw_exception
-
+    def test_apply_all_properties_with_errors_notifies_parent_presenter_on_allowed_exceptions(self):
         mock_view = mock.Mock(get_selected_ax_name=lambda: "My Axes: (0, 0)",
                               get_axis=lambda: "x",
                               get_properties=lambda: {})
         mock_success_callback, mock_error_callback = mock.Mock(), mock.Mock()
         presenter = Presenter(self.fig, view=mock_view, success_callback=mock_success_callback,
                               error_callback=mock_error_callback)
-        presenter.apply_all_properties = mock.Mock(side_effect=lambda: raise_())
 
-        presenter._apply_all_properties_with_errors()
+        # Only these exceptions should be caught by the axes tab.
+        for exception in [AssertionError, IndexError, KeyError, TypeError, ValueError]:
+            presenter.apply_all_properties = mock.Mock(side_effect=exception("This exception should be caught!"))
+            presenter._apply_all_properties_with_errors()
 
-        mock_success_callback.assert_not_called()
-        mock_error_callback.assert_called()
+            mock_success_callback.assert_not_called()
+            mock_error_callback.assert_called()
+
+            presenter.apply_all_properties.reset_mock()
+            mock_success_callback.reset_mock()
+            mock_error_callback.reset_mock()
 
     def test_apply_all_properties_with_errors_notifies_parent_presenter_on_success(self):
         mock_view = mock.Mock(get_selected_ax_name=lambda: "My Axes: (0, 0)",

--- a/qt/python/mantidqt/widgets/plotconfigdialog/plot_config_dialog.ui
+++ b/qt/python/mantidqt/widgets/plotconfigdialog/plot_config_dialog.ui
@@ -2,6 +2,14 @@
 <ui version="4.0">
  <class>Dialog</class>
  <widget class="QDialog" name="Dialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>316</width>
+    <height>132</height>
+   </rect>
+  </property>
   <property name="windowTitle">
    <string>Figure Options</string>
   </property>
@@ -11,6 +19,16 @@
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
     <layout class="QVBoxLayout" name="main_v_layout">
+     <item>
+      <widget class="QLabel" name="errors">
+       <property name="styleSheet">
+        <string notr="true">.QLabel{background-color: #F18888; border: 1px solid gray; border-radius: 5px}</string>
+       </property>
+       <property name="text">
+        <string>Error Text</string>
+       </property>
+      </widget>
+     </item>
      <item>
       <widget class="QTabWidget" name="main_tab_widget">
        <property name="sizePolicy">

--- a/qt/python/mantidqt/widgets/plotconfigdialog/view.py
+++ b/qt/python/mantidqt/widgets/plotconfigdialog/view.py
@@ -8,7 +8,7 @@
 
 from qtpy.QtCore import Qt
 from qtpy.QtGui import QIcon
-from qtpy.QtWidgets import QDialog
+from qtpy.QtWidgets import QDialog, QMessageBox
 
 from mantidqt.utils.qt import load_ui
 
@@ -23,8 +23,30 @@ class PlotConfigDialogView(QDialog):
         self.setWindowModality(Qt.WindowModal)
         self.setAttribute(Qt.WA_DeleteOnClose, True)
 
+        self.errors_label = self.ui.errors
+        self.minimum_errors_text = self.errors_label.text()
+        self.errors_label.hide()
+
     def add_tab_widget(self, tab_widget):
         self.main_tab_widget.addTab(*tab_widget)
 
     def set_current_tab_widget(self, tab_widget):
         self.main_tab_widget.setCurrentWidget(tab_widget)
+
+    def set_error_text(self, text=None):
+        if not text:
+            self.errors_label.hide()
+            return
+
+        self.errors_label.setText(self.minimum_errors_text + text)
+        self.errors_label.show()
+
+    def closeEvent(self, event):
+        if self.errors_label.isVisible():
+            reply = QMessageBox().question(self, "Are you sure?",
+                                           "There are errors applying plot settings, are you sure?",
+                                           QMessageBox.Yes | QMessageBox.No, QMessageBox.No)
+            if reply == QMessageBox.Yes:
+                event.accept()
+            else:
+                event.ignore()


### PR DESCRIPTION
If there is an error in drawing the plot when applying the properties configured in the dialog, the user is presented with a red text box at the top of the dialog containing the error. If they try to exit the dialog while the error is showing, they are asked if they are sure they want to exit, as the plot may be 'damaged' (`canvas.draw()` may not have finished because an exception was raised part way through, for example). If they apply the properties again and it is successful, the text box will disappear.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**
1. Load a plot and open the plot config
2. Attempt to apply some settings that will result in an error, e.g. by setting the axes title to `($\A$)` 
4. Fix what is causing the error and apply, check that the error disappears and you can close plot config
5. Repeat 2-4 but by clicking `Ok` first in the plot config. The plot config should not close after this if there is an error
6. Repeat 2-4 but by clicking `Apply to All` in the Axes tab.

Fixes #28854


<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
