### PR TITLE
Update fit browser when curves added/removed

### DIFF
--- a/docs/source/release/v6.2.0/mantidworkbench.rst
+++ b/docs/source/release/v6.2.0/mantidworkbench.rst
@@ -39,5 +39,6 @@ Bugfixes
 - Fixed a bug where output workspaces of different types would interfere with successive calls to binary operations, such as multiply.
 - Fixed JSON serialization issue of MantidAxType by explicitly extracting its value
 - Fixed a bug in colorfill plots which lead to the loss of a spectrum from the resulting image.
+- Fixed a bug where the workspace index spinbox in the fit browser wouldn't update when the user added or removed curves from the figure.
 
 :ref:`Release 6.2.0 <v6.2.0>`

--- a/qt/python/mantidqt/widgets/fitpropertybrowser/fitpropertybrowser.py
+++ b/qt/python/mantidqt/widgets/fitpropertybrowser/fitpropertybrowser.py
@@ -16,6 +16,7 @@ from mantidqt.plotting.functions import plot
 from mantidqt.utils.qt import import_qt
 from .fitpropertybrowserplotinteraction import FitPropertyBrowserPlotInteraction
 from .interactive_tool import FitInteractiveTool
+import numpy as np
 
 BaseBrowser = import_qt('.._common', 'mantidqt.widgets', 'FitPropertyBrowser')
 
@@ -51,6 +52,7 @@ class FitPropertyBrowser(FitPropertyBrowserBase):
         self.peak_ids = {}
         self._connect_signals()
         self.canvas_draw_signal = None
+        self.allowed_spectra = {}
 
     def _connect_signals(self):
         self.xRangeChanged.connect(self.move_x_range)
@@ -65,19 +67,16 @@ class FitPropertyBrowser(FitPropertyBrowserBase):
 
     def _update_workspace_info_slot(self, event):
         "Callback when the matplotlib canvas updates"
-        if not self._update_allowed_spectra():
+        if not self._update_workspace_info():
             self.hide()
 
-    def _update_allowed_spectra(self):
+    def _update_workspace_info(self):
         " Update the allowed spectra/tableworkspace in the fit browser"
+        allowed_spectra_old = self.allowed_spectra
         allowed_spectra = self._get_allowed_spectra()
         table = self._get_table_workspace()
         if allowed_spectra:
-            previous_selected_index = self.workspaceIndex()
-            self._add_spectra(allowed_spectra)
-            workspace_index = self.workspaceIndex()
-            if workspace_index != previous_selected_index:
-                self.clear_fit_result_lines()
+            self._update_spectra(allowed_spectra, allowed_spectra_old)
         elif table:
             self.addAllowedTableWorkspace(table)
         else:
@@ -85,6 +84,16 @@ class FitPropertyBrowser(FitPropertyBrowserBase):
             logger.warning("Cannot use fitting tool: No valid workspaces to fit to.")
             return False
         return True
+
+    def _update_spectra(self, allowed_spectra, allowed_spectra_old):
+        previous_workspace_index = self.workspaceIndex()
+        previous_name = self.workspaceName()
+        # remove workspaces that are no longer plotted
+        for workspace in np.setdiff1d(list(allowed_spectra_old.keys()), list(allowed_spectra.keys())):
+            self.removeWorkspaceAndSpectra(workspace)
+        self._add_spectra(allowed_spectra)
+        if (self.workspaceName(), self.workspaceIndex()) != (previous_name, previous_workspace_index):
+            self.clear_fit_result_lines()
 
     def _add_spectra(self, spectra):
         """
@@ -104,11 +113,17 @@ class FitPropertyBrowser(FitPropertyBrowserBase):
         for ax in self.canvas.figure.get_axes():
             try:
                 for ws_name, artists in ax.tracked_workspaces.items():
+                    # we don't want to include the fit workspace in our selection
+                    # unfortunately, this might catch some workspaces which have _Workspace appended to their name
+                    # hopefully this is an unlikely scenario.
+                    if ws_name.endswith("_Workspace"):
+                        continue
                     spectrum_list = [artist.spec_num for artist in artists]
                     spectrum_list = sorted(list(set(spectrum_list)))
                     allowed_spectra[ws_name] = spectrum_list
             except AttributeError:  # scripted plots have no tracked_workspaces
                 pass
+        self.allowed_spectra = allowed_spectra
         return allowed_spectra
 
     def _get_table_workspace(self):
@@ -179,7 +194,7 @@ class FitPropertyBrowser(FitPropertyBrowserBase):
             self.addAllowedTableWorkspace(table)
         else:
             self.toolbar_manager.toggle_fit_button_checked()
-            logger.warning("Cannot use fitting tool: No valid workspaces to fit to.")
+            logger.warning("Cannot open fitting tool: No valid workspaces to fit to.")
             return
 
         self.canvas_draw_signal = self.canvas.mpl_connect('draw_event', self._update_workspace_info_slot)

--- a/qt/python/mantidqt/widgets/fitpropertybrowser/fitpropertybrowser.py
+++ b/qt/python/mantidqt/widgets/fitpropertybrowser/fitpropertybrowser.py
@@ -110,13 +110,12 @@ class FitPropertyBrowser(FitPropertyBrowserBase):
         tracked workspaces.
         """
         allowed_spectra = {}
+        output_wsnames = [self.getWorkspaceList().item(ii).text() for ii in range(self.getWorkspaceList().count())]
         for ax in self.canvas.figure.get_axes():
             try:
                 for ws_name, artists in ax.tracked_workspaces.items():
                     # we don't want to include the fit workspace in our selection
-                    # unfortunately, this might catch some workspaces which have _Workspace appended to their name
-                    # hopefully this is an unlikely scenario.
-                    if ws_name.endswith("_Workspace"):
+                    if ws_name in output_wsnames:
                         continue
                     spectrum_list = [artist.spec_num for artist in artists]
                     spectrum_list = sorted(list(set(spectrum_list)))

--- a/qt/python/mantidqt/widgets/test/test_fitpropertybrowser.py
+++ b/qt/python/mantidqt/widgets/test/test_fitpropertybrowser.py
@@ -21,7 +21,6 @@ from mantidqt.utils.qt.testing import start_qapplication
 from mantidqt.widgets.fitpropertybrowser.fitpropertybrowser import FitPropertyBrowser
 from workbench.plotting.figuremanager import FigureManagerADSObserver
 
-from qtpy import PYQT5
 from qtpy.QtWidgets import QDockWidget
 
 
@@ -29,12 +28,6 @@ from qtpy.QtWidgets import QDockWidget
 class FitPropertyBrowserTest(unittest.TestCase):
     def tearDown(self):
         AnalysisDataService.clear()
-
-    def test_initialization_does_not_raise(self):
-        try:
-            self._create_widget()
-        except:
-            self.assertTrue(False)
 
     @patch('mantidqt.widgets.fitpropertybrowser.fitpropertybrowser.FitPropertyBrowser.normaliseData')
     def test_normalise_data_set_on_fit_menu_shown(self, normaliseData_mock):
@@ -135,9 +128,6 @@ class FitPropertyBrowserTest(unittest.TestCase):
         self.assertEqual(name + "_Workspace", workspaceList.item(2).text())
 
     def test_fit_result_matrix_workspace_in_browser_is_viewed_when_clicked(self):
-        if not PYQT5:
-            self.skipTest("MatrixWorkspaceDisplay and TableWorkspaceDisplay cannot be "
-                          "imported in qt4 so the test fails with an error.")
         from mantidqt.widgets.workspacedisplay.table.presenter import TableWorkspaceDisplay
 
         name = "ws"

--- a/qt/python/mantidqt/widgets/test/test_fitpropertybrowser.py
+++ b/qt/python/mantidqt/widgets/test/test_fitpropertybrowser.py
@@ -19,7 +19,6 @@ from mantid.simpleapi import CreateSampleWorkspace, CreateWorkspace
 from mantidqt.plotting.functions import plot
 from mantidqt.utils.qt.testing import start_qapplication
 from mantidqt.widgets.fitpropertybrowser.fitpropertybrowser import FitPropertyBrowser
-from testhelpers import assertRaisesNothing
 from workbench.plotting.figuremanager import FigureManagerADSObserver
 
 from qtpy import PYQT5
@@ -32,7 +31,10 @@ class FitPropertyBrowserTest(unittest.TestCase):
         AnalysisDataService.clear()
 
     def test_initialization_does_not_raise(self):
-        assertRaisesNothing(self, self._create_widget)
+        try:
+            self._create_widget()
+        except:
+            self.assertTrue(False)
 
     @patch('mantidqt.widgets.fitpropertybrowser.fitpropertybrowser.FitPropertyBrowser.normaliseData')
     def test_normalise_data_set_on_fit_menu_shown(self, normaliseData_mock):
@@ -48,14 +50,37 @@ class FitPropertyBrowserTest(unittest.TestCase):
 
     @patch('mantidqt.widgets.fitpropertybrowser.fitpropertybrowser.FitPropertyBrowser.normaliseData')
     def test_normalise_data_set_to_false_for_distribution_workspace(self, normaliseData_mock):
-        fig, canvas = self._create_and_plot_matrix_workspace('ws_name', distribution=True)
+        fig, canvas, _ = self._create_and_plot_matrix_workspace('ws_name', distribution=True)
         property_browser = self._create_widget(canvas=canvas)
         with patch.object(property_browser, 'workspaceName', lambda: 'ws_name'):
             property_browser.getFitMenu().aboutToShow.emit()
         property_browser.normaliseData.assert_called_once_with(False)
 
+    def test_workspace_index_selector_updates_if_new_curve_added(self):
+        fig, canvas, ws = self._create_and_plot_matrix_workspace('ws_name', distribution=True)
+        property_browser = self._create_widget(canvas=canvas)
+        property_browser.setWorkspaceName('ws_name')
+        plot([ws], spectrum_nums=[3], overplot=True, fig=fig)
+        property_browser.show()
+        property_browser.setWorkspaceIndex(2)
+        self.assertEqual(property_browser.workspaceIndex(), 2)
+        property_browser.hide()
+
+    def test_workspace_index_selector_updates_if_curve_removed(self):
+        fig, canvas, ws = self._create_and_plot_matrix_workspace('ws_name', distribution=True)
+        property_browser = self._create_widget(canvas=canvas)
+        property_browser.setWorkspaceName('ws_name')
+        plot([ws], spectrum_nums=[3], overplot=True, fig=fig)
+        property_browser.show()
+        # remove first spectrum
+        fig.axes[0].tracked_workspaces['ws_name'].pop(0)
+        fig.canvas.draw()
+        # we removed the workspaceIndex 0 line, so spinbox should now show 2.
+        self.assertEqual(property_browser.workspaceIndex(), 2)
+        property_browser.hide()
+
     def test_fit_curves_removed_when_workspaces_deleted(self):
-        fig, canvas = self._create_and_plot_matrix_workspace(name="ws")
+        fig, canvas, _ = self._create_and_plot_matrix_workspace(name="ws")
         property_browser = self._create_widget(canvas=canvas)
 
         manager_mock = Mock()
@@ -90,7 +115,7 @@ class FitPropertyBrowserTest(unittest.TestCase):
 
     def test_fit_result_workspaces_are_added_to_browser_when_fitting_done(self):
         name = "ws"
-        fig, canvas = self._create_and_plot_matrix_workspace(name)
+        fig, canvas, _ = self._create_and_plot_matrix_workspace(name)
         property_browser = self._create_widget(canvas=canvas)
         property_browser.setOutputName(name)
 
@@ -113,34 +138,10 @@ class FitPropertyBrowserTest(unittest.TestCase):
         if not PYQT5:
             self.skipTest("MatrixWorkspaceDisplay and TableWorkspaceDisplay cannot be "
                           "imported in qt4 so the test fails with an error.")
-        from mantidqt.widgets.workspacedisplay.matrix.presenter import MatrixWorkspaceDisplay
-
-        name = "ws"
-        fig, canvas = self._create_and_plot_matrix_workspace(name)
-        property_browser = self._create_widget(canvas=canvas)
-        property_browser.setOutputName(name)
-
-        # create fake fit output results
-        matrixWorkspace = WorkspaceFactory.Instance().create("Workspace2D", NVectors=3, YLength=5, XLength=5)
-        AnalysisDataService.Instance().addOrReplace(name + "_Workspace", matrixWorkspace)
-
-        property_browser.fitting_done_slot(name + "_Workspace")
-        wsList = property_browser.getWorkspaceList()
-
-        # click on matrix workspace
-        MatrixWorkspaceDisplay.show_view = Mock()
-        item = wsList.item(0).text()
-        property_browser.workspaceClicked.emit(item)
-        self.assertEqual(1, MatrixWorkspaceDisplay.show_view.call_count)
-
-    def test_fit_parameter_table_workspaces_in_browser_is_viewed_when_clicked(self):
-        if not PYQT5:
-            self.skipTest("MatrixWorkspaceDisplay and TableWorkspaceDisplay cannot be "
-                          "imported in qt4 so the test fails with an error.")
         from mantidqt.widgets.workspacedisplay.table.presenter import TableWorkspaceDisplay
 
         name = "ws"
-        fig, canvas = self._create_and_plot_matrix_workspace(name)
+        fig, canvas, _ = self._create_and_plot_matrix_workspace(name)
         property_browser = self._create_widget(canvas=canvas)
         property_browser.setOutputName(name)
 
@@ -161,7 +162,7 @@ class FitPropertyBrowserTest(unittest.TestCase):
 
     def test_workspaces_removed_from_workspace_list_widget_if_deleted_from_ADS(self):
         name = "ws"
-        fig, canvas_mock = self._create_and_plot_matrix_workspace(name)
+        fig, canvas_mock, _ = self._create_and_plot_matrix_workspace(name)
         property_browser = self._create_widget(canvas=canvas_mock)
         property_browser.setOutputName(name)
 
@@ -179,7 +180,7 @@ class FitPropertyBrowserTest(unittest.TestCase):
         self.assertEqual(1, len(wsList))
 
     def test_plot_limits_are_not_changed_when_plotting_fit_lines(self):
-        fig, canvas = self._create_and_plot_matrix_workspace()
+        fig, canvas, _ = self._create_and_plot_matrix_workspace()
         ax_limits = fig.get_axes()[0].axis()
         widget = self._create_widget(canvas=canvas)
         fit_ws_name = "fit_ws"
@@ -227,10 +228,10 @@ class FitPropertyBrowserTest(unittest.TestCase):
 
     def _create_and_plot_matrix_workspace(self, name="workspace", distribution=False):
         ws = CreateWorkspace(OutputWorkspace=name, DataX=zeros(10), DataY=zeros(10),
-                             NSpec=2, Distribution=distribution)
+                             NSpec=5, Distribution=distribution)
         fig = plot([ws], spectrum_nums=[1])
         canvas = fig.canvas
-        return fig, canvas
+        return fig, canvas, ws
 
 
 if __name__ == '__main__':

--- a/qt/widgets/common/src/FitPropertyBrowser.cpp
+++ b/qt/widgets/common/src/FitPropertyBrowser.cpp
@@ -1296,6 +1296,7 @@ void FitPropertyBrowser::intChanged(QtProperty *prop) {
     return;
 
   if (prop == m_workspaceIndex) {
+    // Get current value displayed by the workspace index spinbox
     auto const currentIndex = workspaceIndex();
     auto const allowedIndex = getAllowedIndex(currentIndex);
     if (allowedIndex != currentIndex) {
@@ -2451,10 +2452,6 @@ int FitPropertyBrowser::getAllowedIndex(int currentIndex) const {
     return 0;
   }
 
-  if (currentIndex == m_oldWorkspaceIndex) {
-    return currentIndex < 0 ? 0 : currentIndex;
-  }
-
   auto const allowedIndices =
       m_allowedSpectra.empty() ? QList<int>() : m_allowedSpectra[QString::fromStdString(workspaceName())];
   auto const firstIndex = m_allowedSpectra.empty() ? 0 : allowedIndices.front();
@@ -3265,6 +3262,7 @@ void FitPropertyBrowser::addAllowedSpectra(const QString &wsName, const QList<in
   } else {
     throw std::runtime_error("Workspace " + name + " is not a MatrixWorkspace");
   }
+  intChanged(m_workspaceIndex);
 }
 
 void FitPropertyBrowser::removeWorkspaceAndSpectra(const std::string &wsName) {

--- a/qt/widgets/common/src/FitPropertyBrowser.cpp
+++ b/qt/widgets/common/src/FitPropertyBrowser.cpp
@@ -1232,6 +1232,7 @@ void FitPropertyBrowser::enumChanged(QtProperty *prop) {
   if (prop == m_workspace) {
     workspaceChange(QString::fromStdString(workspaceName()));
     setWorkspaceProperties();
+    intChanged(m_workspaceIndex);
     m_storedWorkspaceName = workspaceName();
   } else if (prop->propertyName() == "Type") {
     disableUndo();
@@ -3258,11 +3259,19 @@ void FitPropertyBrowser::addAllowedSpectra(const QString &wsName, const QList<in
     for (auto const i : wsSpectra) {
       indices.push_back(static_cast<int>(ws->getIndexFromSpectrumNumber(i)));
     }
+    auto wsFound = m_allowedSpectra.find(wsName);
     m_allowedSpectra.insert(wsName, indices);
+    if (wsFound != m_allowedSpectra.end()) {
+      // we already knew about this workspace
+      // update workspace index list
+      intChanged(m_workspaceIndex);
+    } else {
+      // new workspace, update workspace names
+      populateWorkspaceNames();
+    }
   } else {
     throw std::runtime_error("Workspace " + name + " is not a MatrixWorkspace");
   }
-  intChanged(m_workspaceIndex);
 }
 
 void FitPropertyBrowser::removeWorkspaceAndSpectra(const std::string &wsName) {


### PR DESCRIPTION
**Description of work.**
This PR ensures the workspace index spinbox in the fit browser update when curves are added / removed.
<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**
(1) Plot the first spectrum from some data
(2) Open the fit browser
(3) Plot the second spectrum (i.e. workspace index = 1)
(4) You should now be able to select the new spectrum
(6) Go to the plot settings > curves > remove the second spectrum (index = 1)
(7) You should no longer be able to select that spectrum in the spinbox

<!-- Instructions for testing. -->

Fixes #31661  <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->


<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
