### PR TITLE
Expose workspace readLock to python to prevent segfaults

### DIFF
--- a/Framework/Kernel/inc/MantidKernel/DataItem.h
+++ b/Framework/Kernel/inc/MantidKernel/DataItem.h
@@ -54,6 +54,11 @@ public:
   virtual const std::string toString() const = 0;
   //@}
 
+  /// Acquires a read lock. If another thread currently holds a write lock,
+  /// waits until the write lock is released.
+  void readLock();
+  void unlock();
+
 protected:
   Poco::RWLock *getLock() const;
 

--- a/Framework/Kernel/src/DataItem.cpp
+++ b/Framework/Kernel/src/DataItem.cpp
@@ -30,6 +30,9 @@ DataItem::DataItem(const DataItem & /*other*/) {
  */
 DataItem::~DataItem() {}
 
+void DataItem::readLock() { getLock()->readLock(); }
+void DataItem::unlock() { getLock()->unlock(); }
+
 /** Private method to access the RWLock object.
  *
  * @return the RWLock object.

--- a/Framework/PythonInterface/mantid/kernel/src/Exports/DataItem.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Exports/DataItem.cpp
@@ -6,14 +6,28 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 #include "MantidKernel/DataItem.h"
 #include "MantidPythonInterface/core/GetPointer.h"
+#include "MantidPythonInterface/core/ReleaseGlobalInterpreterLock.h"
 
+#include <boost/python/bases.hpp>
 #include <boost/python/class.hpp>
 #include <boost/python/copy_const_reference.hpp>
 #include <boost/python/register_ptr_to_python.hpp>
 #include <boost/python/return_value_policy.hpp>
 
 using Mantid::Kernel::DataItem;
+using namespace Mantid::PythonInterface;
 using namespace boost::python;
+
+namespace {
+void readLock(DataItem &self) {
+  ReleaseGlobalInterpreterLock releaseGIL;
+  self.readLock();
+}
+void unlock(DataItem &self) {
+  ReleaseGlobalInterpreterLock releaseGIL;
+  self.unlock();
+}
+} // namespace
 
 GET_POINTER_SPECIALIZATION(DataItem)
 
@@ -28,6 +42,8 @@ void export_DataItem() {
            "Returns true if the object "
            "can be accessed safely from "
            "multiple threads")
+      .def("readLock", &readLock, arg("self"), "Acquires a read lock on the data item.")
+      .def("unlock", &unlock, arg("self"), "Unlocks a read or write lock on the data item.")
       .def("__str__", &DataItem::getName, arg("self"), "Returns the string name of the object if it has been stored",
            return_value_policy<copy_const_reference>())
       .def("__repr__", &DataItem::toString, arg("self"), "Returns a description of the object");

--- a/qt/python/mantidqt/utils/qt/qappthreadcall.py
+++ b/qt/python/mantidqt/utils/qt/qappthreadcall.py
@@ -48,10 +48,8 @@ class QAppThreadCall(QObject):
         else:
             self._ensure_self_on_qapp_thread()
             self._store_function_args(args, kwargs)
-            if self.blocking:
-                QMetaObject.invokeMethod(self, "on_call", Qt.BlockingQueuedConnection)
-            else:
-                QMetaObject.invokeMethod(self, "on_call", Qt.AutoConnection)
+            connection_type = Qt.BlockingQueuedConnection if self.blocking else Qt.AutoConnection
+            QMetaObject.invokeMethod(self, "on_call", connection_type)
             if self._exc_info is not None:
                 raise self._exc_info[1].with_traceback(self._exc_info[2])
             return self._result

--- a/qt/python/mantidqt/utils/qt/qappthreadcall.py
+++ b/qt/python/mantidqt/utils/qt/qappthreadcall.py
@@ -28,9 +28,10 @@ class QAppThreadCall(QObject):
         qapp = QApplication.instance()
         return qapp is None or (QThread.currentThread() == qapp.thread())
 
-    def __init__(self, callee):
+    def __init__(self, callee, blocking=True):
         QObject.__init__(self)
         self.callee = callee
+        self.blocking = blocking
         functools.update_wrapper(self.__call__.__func__, callee)
         self._moved_to_app = False
         self._store_function_args(None, None)
@@ -47,7 +48,10 @@ class QAppThreadCall(QObject):
         else:
             self._ensure_self_on_qapp_thread()
             self._store_function_args(args, kwargs)
-            QMetaObject.invokeMethod(self, "on_call", Qt.BlockingQueuedConnection)
+            if self.blocking:
+                QMetaObject.invokeMethod(self, "on_call", Qt.BlockingQueuedConnection)
+            else:
+                QMetaObject.invokeMethod(self, "on_call", Qt.AutoConnection)
             if self._exc_info is not None:
                 raise self._exc_info[1].with_traceback(self._exc_info[2])
             return self._result

--- a/qt/python/mantidqt/widgets/sliceviewer/adsobsever.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/adsobsever.py
@@ -33,10 +33,10 @@ class SliceViewerADSObserver(AnalysisDataServiceObserver):
     def __init__(self, on_replace, on_rename, on_clear, on_delete):
         super(SliceViewerADSObserver, self).__init__()
 
-        self.on_replace_workspace = QAppThreadCall(on_replace)
-        self.on_rename_workspace = QAppThreadCall(on_rename)
-        self.on_clear = QAppThreadCall(on_clear)
-        self.on_delete_workspace = QAppThreadCall(on_delete)
+        self.on_replace_workspace = QAppThreadCall(on_replace, blocking=False)
+        self.on_rename_workspace = QAppThreadCall(on_rename, blocking=False)
+        self.on_clear = QAppThreadCall(on_clear, blocking=False)
+        self.on_delete_workspace = QAppThreadCall(on_delete, blocking=False)
 
         self.observeClear(True)
         self.observeDelete(True)

--- a/qt/python/mantidqt/widgets/sliceviewer/peaksviewer/test/test_peaksviewer_sliceviewer_add_delete_peaks_integration.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/peaksviewer/test/test_peaksviewer_sliceviewer_add_delete_peaks_integration.py
@@ -16,6 +16,7 @@ from mantidqt.widgets.sliceviewer.presenter import SliceViewer  # noqa: E402
 from mantidqt.utils.qt.testing import start_qapplication  # noqa: E402
 from mantid.simpleapi import CreatePeaksWorkspace, CreateMDWorkspace, SetUB, mtd  # noqa: E402
 import numpy as np  # noqa: E402
+from qtpy.QtWidgets import QApplication  # noqa: E402
 
 
 @start_qapplication
@@ -25,6 +26,13 @@ class AddDeletePeaksTest(unittest.TestCase):
     in the attached peaksworkspace.
 
     """
+    def tearDown(self):
+        # Close windows after each test to ensure none windows remain before program destruction
+        for widget in QApplication.topLevelWidgets():
+            widget.close()
+        QApplication.sendPostedEvents()
+        QApplication.sendPostedEvents()
+
     def test_Q_Sample(self):
         md = CreateMDWorkspace(Dimensions=3,
                                Extents='0,10,0,10,0,10',

--- a/qt/python/mantidqt/widgets/sliceviewer/presenter.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/presenter.py
@@ -418,10 +418,13 @@ class SliceViewer(ObservingPresenter):
         # the meantime, so check it still exists. See github issue #30406 for detail.
         if sip.isdeleted(self.view):
             return
+        ws = self.model._get_ws()
         # we don't want to use model.get_ws for the image info widget as this needs
         # extra arguments depending on workspace type.
-        self.view.data_view.image_info_widget.setWorkspace(self.model._get_ws())
+        ws.readLock()
+        self.view.data_view.image_info_widget.setWorkspace(ws)
         self.new_plot()
+        ws.unlock()
 
     def rename_workspace(self, old_name, new_name):
         if str(self.model._get_ws()) == old_name:

--- a/qt/python/mantidqt/widgets/sliceviewer/presenter.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/presenter.py
@@ -403,7 +403,7 @@ class SliceViewer(ObservingPresenter):
             # New model is OK, proceed with updating Slice Viewer
             self.model = candidate_model
             self.new_plot, self.update_plot_data = self._decide_plot_update_methods()
-            self.view.delayed_refresh()
+            self.refresh_view()
         except ValueError as err:
             self._close_view_with_message(
                 f"Closing Sliceviewer as the underlying workspace was changed: {str(err)}")

--- a/qt/python/mantidqt/widgets/sliceviewer/presenter.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/presenter.py
@@ -418,13 +418,16 @@ class SliceViewer(ObservingPresenter):
         # the meantime, so check it still exists. See github issue #30406 for detail.
         if sip.isdeleted(self.view):
             return
-        ws = self.model._get_ws()
+
         # we don't want to use model.get_ws for the image info widget as this needs
         # extra arguments depending on workspace type.
+        ws = self.model._get_ws()
         ws.readLock()
-        self.view.data_view.image_info_widget.setWorkspace(ws)
-        self.new_plot()
-        ws.unlock()
+        try:
+            self.view.data_view.image_info_widget.setWorkspace(ws)
+            self.new_plot()
+        finally:
+            ws.unlock()
 
     def rename_workspace(self, old_name, new_name):
         if str(self.model._get_ws()) == old_name:

--- a/qt/python/mantidqt/widgets/sliceviewer/test/test_sliceviewer_presenter.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/test/test_sliceviewer_presenter.py
@@ -11,7 +11,7 @@ import sys
 import unittest
 from unittest import mock
 from unittest.mock import patch
-from mantid.api import MultipleExperimentInfos
+from mantid.api import IMDHistoWorkspace
 
 import matplotlib
 
@@ -52,12 +52,16 @@ def _create_presenter(model, view, mock_sliceinfo_cls, enable_nonortho_axes, sup
     return presenter, data_view_mock
 
 
-def create_workspace_mock():
+def create_mdhistoworkspace_mock():
     # Mock out workspace methods needed for SliceViewerModel.__init__
-    workspace = mock.Mock(spec=MultipleExperimentInfos)
-    workspace.isMDHistoWorkspace = lambda: False
+    workspace = mock.Mock(spec=IMDHistoWorkspace)
+    workspace.isMDHistoWorkspace = lambda: True
+    workspace.getDimension = lambda: mock.MagicMock()
     workspace.getNumDims = lambda: 2
+    workspace.getNumNonIntegratedDims = lambda: 2
     workspace.name = lambda: "workspace"
+    workspace.readLock = mock.MagicMock()
+    workspace.unlock = mock.MagicMock()
 
     return workspace
 
@@ -409,7 +413,7 @@ class SliceViewerTest(unittest.TestCase):
         presenter.refresh_view = mock.Mock()
         presenter._decide_plot_update_methods = mock.Mock()
 
-        workspace = create_workspace_mock()
+        workspace = create_mdhistoworkspace_mock()
 
         # Not equivalent to self.model.get_properties()
         new_model_properties = {
@@ -434,19 +438,18 @@ class SliceViewerTest(unittest.TestCase):
                                          mock.MagicMock(),
                                          enable_nonortho_axes=False,
                                          supports_nonortho=False)
-        self.view.delayed_refresh = mock.Mock()
-        presenter._decide_plot_update_methods = mock.Mock(
-            return_value=(presenter.new_plot_matrix(), presenter.update_plot_data_matrix()))
-        workspace = create_workspace_mock()
+        workspace = create_mdhistoworkspace_mock()
         new_model_properties = self.model.get_properties()
 
         # Patch get_properties so that the properties of the new model match those of self.model
         with patch.object(SliceViewerModel, "get_properties", return_value=new_model_properties):
+            presenter.view.data_view.plot_MDH.assert_called_once()
+            presenter.view.data_view.plot_MDH.reset_mock()
+
             presenter.replace_workspace('workspace', workspace)
 
-            self.view.emit_close.assert_not_called()
-            presenter._decide_plot_update_methods.assert_called_once()
-            self.view.delayed_refresh.assert_called_once()
+            presenter.view.emit_close.assert_not_called()
+            presenter.view.data_view.plot_MDH.assert_called_once()
 
     @patch("sip.isdeleted", return_value=False)
     def test_refresh_view(self, _):

--- a/qt/python/mantidqt/widgets/sliceviewer/test/test_sliceviewer_view.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/test/test_sliceviewer_view.py
@@ -6,10 +6,12 @@
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
 #  This file is part of the mantid workbench.
+from functools import partial
 import io
 import sys
+from threading import Thread
 import unittest
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
 
 import matplotlib as mpl
 from matplotlib.colors import Normalize
@@ -19,8 +21,8 @@ mpl.use('Agg')
 from mantidqt.widgets.colorbar.colorbar import MIN_LOG_VALUE  # noqa: E402
 from mantidqt.widgets.sliceviewer.view import SCALENORM  # noqa: E402
 from mantid.simpleapi import (  # noqa: E402
-    CreateMDHistoWorkspace, CreateMDWorkspace, CreateSampleWorkspace, DeleteWorkspace,
-    FakeMDEventData, ConvertToDistribution, Scale, SetUB, RenameWorkspace)
+    CreateMDHistoWorkspace, CreateMDWorkspace, CreateSampleWorkspace, DeleteWorkspace, FakeMDEventData, ConvertToDistribution, Scale, SetUB,
+    RenameWorkspace)
 from mantid.api import AnalysisDataService  # noqa: E402
 from mantidqt.utils.qt.testing import start_qapplication  # noqa: E402
 from mantidqt.utils.qt.testing.qt_widget_finder import QtWidgetFinder  # noqa: E402
@@ -95,8 +97,7 @@ class SliceViewerViewTest(unittest.TestCase, QtWidgetFinder):
     def test_enable_nonorthogonal_view_disables_lineplots_if_enabled(self):
         pres = SliceViewer(self.hkl_ws)
         line_plots_action, region_sel_action, non_ortho_action = toolbar_actions(
-            pres,
-            (ToolItemText.LINEPLOTS, ToolItemText.REGIONSELECTION, ToolItemText.NONORTHOGONAL_AXES))
+            pres, (ToolItemText.LINEPLOTS, ToolItemText.REGIONSELECTION, ToolItemText.NONORTHOGONAL_AXES))
         line_plots_action.trigger()
         QApplication.sendPostedEvents()
 
@@ -113,8 +114,7 @@ class SliceViewerViewTest(unittest.TestCase, QtWidgetFinder):
 
     def test_disable_lineplots_disables_region_selector(self):
         pres = SliceViewer(self.hkl_ws)
-        line_plots_action, region_sel_action = toolbar_actions(
-            pres, (ToolItemText.LINEPLOTS, ToolItemText.REGIONSELECTION))
+        line_plots_action, region_sel_action = toolbar_actions(pres, (ToolItemText.LINEPLOTS, ToolItemText.REGIONSELECTION))
         line_plots_action.trigger()
         region_sel_action.trigger()
         QApplication.sendPostedEvents()
@@ -229,9 +229,12 @@ class SliceViewerViewTest(unittest.TestCase, QtWidgetFinder):
         self.assertEqual(pres.ads_observer, None)
 
     def test_view_updates_on_replace_when_model_properties_dont_change_matrixws(self):
+        def scale_ws(ws):
+            ws = Scale(ws, 100, "Multiply")
+
         ws = CreateSampleWorkspace()
         pres = SliceViewer(ws)
-        ws = Scale(ws, 100, "Multiply")
+        self._assertNoErrorInADSHandlerFromSeparateThread(partial(scale_ws, ws))
 
         QApplication.sendPostedEvents()
 
@@ -241,6 +244,9 @@ class SliceViewerViewTest(unittest.TestCase, QtWidgetFinder):
         pres.view.close()
 
     def test_view_updates_on_replace_when_model_properties_dont_change_mdeventws(self):
+        def scale_ws(ws):
+            ws = ws * 100
+
         ws = CreateMDWorkspace(Dimensions='3',
                                EventType='MDEvent',
                                Extents='-10,10,-5,5,-1,1',
@@ -248,17 +254,7 @@ class SliceViewerViewTest(unittest.TestCase, QtWidgetFinder):
                                Units='1\\A,1\\A,1\\A')
         FakeMDEventData(ws, UniformParams="1000000")
         pres = SliceViewer(ws)
-        try:
-            # the ads handler catches all exceptions so that the handlers don't
-            # bring down the sliceviewer. Check if anything is writtent to stderr
-            stderr_capture = io.StringIO()
-            stderr_orig = sys.stderr
-            sys.stderr = stderr_capture
-            ws *= 100
-            self.assertTrue('Error occurred in handler' not in stderr_capture.getvalue(),
-                            msg=stderr_capture.getvalue())
-        finally:
-            sys.stderr = stderr_orig
+        self._assertNoErrorInADSHandlerFromSeparateThread(partial(scale_ws, ws))
 
         QApplication.sendPostedEvents()
 
@@ -298,13 +294,12 @@ class SliceViewerViewTest(unittest.TestCase, QtWidgetFinder):
 
     def test_view_closes_on_ADS_cleared(self):
         ws = CreateSampleWorkspace()
-        pres = SliceViewer(ws)
+        SliceViewer(ws)
         AnalysisDataService.clear()
 
         QApplication.sendPostedEvents()
 
         self.assert_no_toplevel_widgets()
-        self.assertEqual(pres.ads_observer, None)
 
     def test_plot_matrix_xlimits_ignores_monitors(self):
         xmin = 5000
@@ -334,11 +329,31 @@ class SliceViewerViewTest(unittest.TestCase, QtWidgetFinder):
         ws = CreateSampleWorkspace()
         pres = SliceViewer(ws)
         self.assert_widget_created()
-        pres.clear_observer = MagicMock()
 
         pres.view.close()
+        pres = None
+        QApplication.sendPostedEvents()
 
-        pres.clear_observer.assert_called()
+        self.assert_no_toplevel_widgets()
+
+    # private methods
+    def _assertNoErrorInADSHandlerFromSeparateThread(self, operation):
+        """Check the error stream for any errors when calling operation.
+        Raise an assertion error if errors are detected
+        """
+        try:
+            # the ads handler catches all exceptions so that the handlers don't
+            # bring down the sliceviewer. Check if anything is written to stderr
+            stderr_capture = io.StringIO()
+            stderr_orig = sys.stderr
+            sys.stderr = stderr_capture
+            op_thread = Thread(target=operation)
+            op_thread.start()
+            op_thread.join()
+            self.assertTrue('Error occurred in handler' not in stderr_capture.getvalue(), msg=stderr_capture.getvalue())
+        finally:
+            sys.stderr = stderr_orig
+
 
 # private helper functions
 

--- a/qt/python/mantidqt/widgets/sliceviewer/test/test_sliceviewer_view.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/test/test_sliceviewer_view.py
@@ -28,6 +28,7 @@ from mantidqt.widgets.sliceviewer.presenter import SliceViewer  # noqa: E402
 from mantidqt.widgets.sliceviewer.toolbar import ToolItemText  # noqa: E402
 from qtpy.QtWidgets import QApplication  # noqa: E402
 from math import inf  # noqa: E402
+from numpy.testing import assert_allclose  # noqa: E402
 
 
 class MockConfig(object):
@@ -177,16 +178,17 @@ class SliceViewerViewTest(unittest.TestCase, QtWidgetFinder):
         pres.view.data_view.dimensions.transpose = False
         pres.update_plot_data()
         extent = pres.view.data_view.image.get_extent()
-        self.assertListEqual(extent, [-10.0, 10.0, -9.0, 9.0])
+        assert_allclose(extent, [-10.0, 10.0, -9.0, 9.0])
 
         # transpose
         pres.view.data_view.dimensions.transpose = True
         pres.update_plot_data()
         extent = pres.view.data_view.image.get_extent()
+
         # Should be the same as before as transposition is handled in the model
-        self.assertListEqual(extent, [-10.0, 10.0, -9.0, 9.0])
-        self.assertListEqual(extent[0:2], list(pres.view.data_view.ax.get_xlim()))
-        self.assertListEqual(extent[2:], list(pres.view.data_view.ax.get_ylim()))
+        assert_allclose(extent, [-10.0, 10.0, -9.0, 9.0])
+        assert_allclose(extent[0:2], list(pres.view.data_view.ax.get_xlim()))
+        assert_allclose(extent[2:], list(pres.view.data_view.ax.get_ylim()))
 
         pres.view.close()
 

--- a/qt/python/mantidqt/widgets/sliceviewer/view.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/view.py
@@ -357,7 +357,7 @@ class SliceViewerDataView(QWidget):
             self._line_plots.plotter.delete_line_plot_lines()
             self._line_plots.plotter.update_line_plot_labels()
 
-        self.canvas.draw_idle()
+        self.canvas.draw()
 
     def export_region(self, limits, cut):
         """

--- a/qt/python/mantidqt/widgets/sliceviewer/view.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/view.py
@@ -17,7 +17,7 @@ from mantid.plots.datafunctions import get_normalize_by_bin_width
 from matplotlib.figure import Figure
 from mpl_toolkits.axisartist import Subplot as CurveLinearSubPlot
 from mpl_toolkits.axisartist.grid_helper_curvelinear import GridHelperCurveLinear
-from qtpy.QtCore import Qt, QTimer, Signal
+from qtpy.QtCore import Qt, Signal
 from qtpy.QtWidgets import (QCheckBox, QComboBox, QGridLayout, QLabel, QHBoxLayout, QSplitter,
                             QStatusBar, QToolButton, QVBoxLayout, QWidget)
 
@@ -617,14 +617,6 @@ class SliceViewerView(QWidget, ObservingView):
             self._splitter.addWidget(self._peaks_view)
 
         return self._peaks_view
-
-    def delayed_refresh(self):
-        """Post an event to the event loop that causes the view to
-        update on the next cycle
-
-        A 1 msec delay is added to appease RHEL7 where in some cases
-        it fails"""
-        QTimer.singleShot(1, self.presenter.refresh_view)
 
     def peaks_overlay_clicked(self):
         """Peaks overlay button has been toggled


### PR DESCRIPTION
#31367 finds a crash that occurs when running `LoadInstrument` multiple times while the `SliceViewer` is open. This is because, on the first run of `LoadInstrument`, the workspace it is running on changes. The `SliceViewerADSObserver` detects this and begins to draw the view, where it accesses some spectra information on the workspace. While this update has been happening, `LoadInstrument` modifies the same workspace again which leads to a segfault.

This PR exposes workspace `readLock` and `unlock` to the python API so that widgets can lock the workspace while they update themselves.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**
1. Load some data, e.g. `INTER38417`
2. Open sliceviewer on this workspace
3. Run an algorithm repeatedly that modifies this workspace e.g. by using the following script
```
ws = mtd["INTER38417"]
while True:
    LoadInstrument(Workspace=ws, RewriteSpectraMap=False, InstrumentName="INTER")
``` 
4. Workbench shouldn't crash

Fixes #31367

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
