### PR TITLE
Checkbox for setting global peak type in fit browser

### DIFF
--- a/docs/source/release/v6.2.0/mantidworkbench.rst
+++ b/docs/source/release/v6.2.0/mantidworkbench.rst
@@ -24,6 +24,7 @@ New and Improved
 - Script editor tab completion and call tip support for Numpy 1.21
 - The visibility of a component parameter in the Pick tab of the InstrumentViewer is now steered by the 'visible' atrribute of a parameter in IPF
 - Plot legends can be shown or hidden from the plot context menu.
+- When fitting a plot, selecting the peak type will only update the default peak shape in the settings if the "Set as global default" checkbox is ticked.
 
 Bugfixes
 --------

--- a/qt/applications/workbench/workbench/plotting/test/test_toolbar.py
+++ b/qt/applications/workbench/workbench/plotting/test/test_toolbar.py
@@ -132,7 +132,7 @@ class ToolBarTest(unittest.TestCase):
     def _is_grid_button_checked(cls, fig):
         """
         Create the figure manager and check whether its toolbar is toggled on or off for the given figure.
-        We have to explicity call set_button_visibilty() here, which would otherwise be called within the show()
+        We have to explicitly call set_button_visibility() here, which would otherwise be called within the show()
         function.
         """
         canvas = MantidFigureCanvas(fig)
@@ -145,7 +145,7 @@ class ToolBarTest(unittest.TestCase):
     def _is_button_enabled(cls, fig, button):
         """
         Create the figure manager and check whether its toolbar is toggled on or off for the given figure.
-        We have to explicity call set_button_visibilty() here, which would otherwise be called within the show()
+        We have to explicitly call set_button_visibility() here, which would otherwise be called within the show()
         function.
         """
         canvas = MantidFigureCanvas(fig)

--- a/qt/python/mantidqt/widgets/fitpropertybrowser/addfunctiondialog/presenter.py
+++ b/qt/python/mantidqt/widgets/fitpropertybrowser/addfunctiondialog/presenter.py
@@ -12,9 +12,10 @@ class AddFunctionDialog(object):
     """
     Dialog to add function to fit property browser
     """
-    def __init__(self, parent=None, function_names=None, view=None, default_function_name=None):
-        self.view = view if view else AddFunctionDialogView(parent, function_names,
-                                                            default_function_name)
+
+    def __init__(self, parent=None, function_names=None, view=None, default_function_name=None, default_checkbox=False):
+        self.view = view if view else AddFunctionDialogView(parent, function_names, default_function_name,
+                                                            default_checkbox)
         self.view.ui.buttonBox.accepted.connect(lambda: self.action_add_function())
         self.view.ui.helpButton.clicked.connect(self.function_help_dialog)
 
@@ -24,7 +25,7 @@ class AddFunctionDialog(object):
         if current_function == "":
             current_function = lineedit.placeholderText()
         if self.view.is_text_in_function_list(current_function):
-            self.view.function_added.emit(current_function)
+            self.view.function_added.emit(current_function, self.view.is_set_global_default())
             self.view.accept()
         else:
             self.view.set_error_message("Function %s not found " % current_function)

--- a/qt/python/mantidqt/widgets/fitpropertybrowser/addfunctiondialog/test/test_addfunctiondialogpresenter.py
+++ b/qt/python/mantidqt/widgets/fitpropertybrowser/addfunctiondialog/test/test_addfunctiondialogpresenter.py
@@ -22,9 +22,10 @@ class AddFunctionDialogPresenterTest(unittest.TestCase):
         dialog = AddFunctionDialog(view=mock_view)
         with patch.object(mock_view.ui.functionBox.lineEdit(), 'text', lambda: "Gaussian"):
             with patch.object(mock_view, 'is_text_in_function_list', lambda x: True):
-                dialog.action_add_function()
-                mock_view.function_added.emit.assert_called_once_with("Gaussian")
-                self.assertEqual(1, dialog.view.accept.call_count)
+                with patch.object(mock_view, 'is_set_global_default', lambda: False):
+                    dialog.action_add_function()
+                    mock_view.function_added.emit.assert_called_once_with("Gaussian", False)
+                    self.assertEqual(1, dialog.view.accept.call_count)
 
     def test_add_function_with_placeholder_text_uses_placeholder_if_present(self, mock_view):
         dialog = AddFunctionDialog(view=mock_view)
@@ -32,9 +33,10 @@ class AddFunctionDialogPresenterTest(unittest.TestCase):
             with patch.object(mock_view.ui.functionBox.lineEdit(), 'placeholderText',
                               lambda: "Gaussian"):
                 with patch.object(mock_view, 'is_text_in_function_list', lambda x: True):
-                    dialog.action_add_function()
-                    mock_view.function_added.emit.assert_called_once_with("Gaussian")
-                    self.assertEqual(1, dialog.view.accept.call_count)
+                    with patch.object(mock_view, 'is_set_global_default', lambda: False):
+                        dialog.action_add_function()
+                        mock_view.function_added.emit.assert_called_once_with("Gaussian", False)
+                        self.assertEqual(1, dialog.view.accept.call_count)
 
     def test_add_function_give_error_if_function_not_valid(self, mock_view):
         dialog = AddFunctionDialog(view=mock_view)

--- a/qt/python/mantidqt/widgets/fitpropertybrowser/addfunctiondialog/test/test_addfunctiondialogview.py
+++ b/qt/python/mantidqt/widgets/fitpropertybrowser/addfunctiondialog/test/test_addfunctiondialogview.py
@@ -51,6 +51,14 @@ class AddFunctionDialogPresenterTest(unittest.TestCase):
 
         self.assertEqual(self.TEST_FUNCTION_NAMES[0], view.ui.functionBox.currentText())
 
+    def test_checkbox_exists_if_requested(self):
+        view = AddFunctionDialogView(default_checkbox=True)
+        self.assertTrue(hasattr(view, '_default_checkbox'))
+
+    def test_checkbox_not_exists_if_not_requested(self):
+        view = AddFunctionDialogView()
+        self.assertFalse(hasattr(view, '_default_checkbox'))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/qt/python/mantidqt/widgets/fitpropertybrowser/addfunctiondialog/test/test_addfunctiondialogview.py
+++ b/qt/python/mantidqt/widgets/fitpropertybrowser/addfunctiondialog/test/test_addfunctiondialogview.py
@@ -15,7 +15,7 @@ from mantidqt.utils.qt.testing import start_qapplication
 
 
 @start_qapplication
-class AddFunctionDialogPresenterTest(unittest.TestCase):
+class AddFunctionDialogViewTest(unittest.TestCase):
     TEST_FUNCTION_NAMES = ['func1', 'secondfunc']
 
     def test_construction_with_no_functions_gives_empty_list(self):

--- a/qt/python/mantidqt/widgets/fitpropertybrowser/addfunctiondialog/view.py
+++ b/qt/python/mantidqt/widgets/fitpropertybrowser/addfunctiondialog/view.py
@@ -63,8 +63,7 @@ class AddFunctionDialogView(QDialog):
         super(AddFunctionDialogView, self).__init__(parent)
         self.setWindowIcon(QIcon(':/images/MantidIcon.ico'))
         self.setAttribute(Qt.WA_DeleteOnClose, True)
-        self._has_default_checkbox = default_checkbox
-        self._setup_ui(function_names, default_function_name)
+        self._setup_ui(function_names, default_function_name, default_checkbox)
 
     def is_text_in_function_list(self, function: str) -> bool:
         """Return True if the given str is in the function list"""
@@ -76,12 +75,12 @@ class AddFunctionDialogView(QDialog):
         self.ui.errorMessage.show()
 
     def is_set_global_default(self):
-        if self._has_default_checkbox:
+        if hasattr(self, '_default_checkbox'):
             return self._default_checkbox.checkState() == Qt.Checked
         return False
 
     # private api
-    def _setup_ui(self, function_names, default_function_name):
+    def _setup_ui(self, function_names, default_function_name, default_checkbox):
         self.ui = load_ui(__file__, 'add_function_dialog.ui', self)
         functionBox = self.ui.functionBox
         if function_names:
@@ -95,6 +94,6 @@ class AddFunctionDialogView(QDialog):
         functionBox.installEventFilter(self._key_filter)
         self.ui.errorMessage.hide()
         # Add a checkbox so user is able to explicitly update the global settings.
-        if self._has_default_checkbox:
+        if default_checkbox:
             self._default_checkbox = QCheckBox("Set as global default")
             self.ui.verticalLayout_2.addWidget(self._default_checkbox)

--- a/qt/python/mantidqt/widgets/fitpropertybrowser/addfunctiondialog/view.py
+++ b/qt/python/mantidqt/widgets/fitpropertybrowser/addfunctiondialog/view.py
@@ -6,7 +6,7 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 from qtpy.QtCore import QObject, QEvent, Qt, Signal
 from qtpy.QtGui import QIcon, QKeyEvent
-from qtpy.QtWidgets import QCompleter, QDialog, QLineEdit
+from qtpy.QtWidgets import QCompleter, QDialog, QLineEdit, QCheckBox
 
 from mantidqt.utils.qt import load_ui
 
@@ -48,20 +48,22 @@ class ActivateCompleterOnReturn(QObject):
 
 class AddFunctionDialogView(QDialog):
     # public
-    function_added = Signal(str)
+    function_added = Signal(str, bool)
 
     # private
     _key_filter = None
 
-    def __init__(self, parent=None, function_names=None, default_function_name=None):
+    def __init__(self, parent=None, function_names=None, default_function_name=None, default_checkbox=False):
         """
         :param parent: An optional parent widget
         :param function_names: A list of function names to add to the box
         :param default_function_name: An optional default name to display as a placeholder
+        :param default_checkbox: Whether to add a checkbox for setting the function as the global application default
         """
         super(AddFunctionDialogView, self).__init__(parent)
         self.setWindowIcon(QIcon(':/images/MantidIcon.ico'))
         self.setAttribute(Qt.WA_DeleteOnClose, True)
+        self._has_default_checkbox = default_checkbox
         self._setup_ui(function_names, default_function_name)
 
     def is_text_in_function_list(self, function: str) -> bool:
@@ -72,6 +74,11 @@ class AddFunctionDialogView(QDialog):
         """Show the message as an error on the dialog"""
         self.ui.errorMessage.setText("<span style='color:red'> %s </span>" % text)
         self.ui.errorMessage.show()
+
+    def is_set_global_default(self):
+        if self._has_default_checkbox:
+            return self._default_checkbox.checkState() == Qt.Checked
+        return False
 
     # private api
     def _setup_ui(self, function_names, default_function_name):
@@ -87,3 +94,7 @@ class AddFunctionDialogView(QDialog):
         self._key_filter = ActivateCompleterOnReturn(functionBox)
         functionBox.installEventFilter(self._key_filter)
         self.ui.errorMessage.hide()
+        # Add a checkbox so user is able to explicitly update the global settings.
+        if self._has_default_checkbox:
+            self._default_checkbox = QCheckBox("Set as global default")
+            self.ui.verticalLayout_2.addWidget(self._default_checkbox)

--- a/qt/python/mantidqt/widgets/fitpropertybrowser/interactive_tool.py
+++ b/qt/python/mantidqt/widgets/fitpropertybrowser/interactive_tool.py
@@ -214,7 +214,7 @@ class FitInteractiveTool(QObject):
         self.mouse_state.transition_to('add_peak')
 
         if set_global_default:
-            ConfigService['curvefitting.defaultPeak'] = function_name
+            ConfigService.setString('curvefitting.defaultPeak', function_name)
 
     def add_background_dialog(self):
         """

--- a/qt/python/mantidqt/widgets/fitpropertybrowser/interactive_tool.py
+++ b/qt/python/mantidqt/widgets/fitpropertybrowser/interactive_tool.py
@@ -6,6 +6,7 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 from qtpy.QtCore import QObject, Signal, Slot
 
+from mantid import ConfigService
 from mantidqt.plotting.markers import PeakMarker, RangeMarker
 from .mouse_state_machine import StateMachine
 from .addfunctiondialog.presenter import AddFunctionDialog
@@ -203,13 +204,17 @@ class FitInteractiveTool(QObject):
         """
         dialog = AddFunctionDialog(parent=self.canvas,
                                    function_names=self.peak_names,
-                                   default_function_name=self.current_peak_type)
+                                   default_function_name=self.current_peak_type,
+                                   default_checkbox=True)
         dialog.view.function_added.connect(self.action_peak_added)
         dialog.view.open()
 
-    def action_peak_added(self, function_name):
+    def action_peak_added(self, function_name, set_global_default=False):
         self.peak_type_changed.emit(function_name)
         self.mouse_state.transition_to('add_peak')
+
+        if set_global_default:
+            ConfigService['curvefitting.defaultPeak'] = function_name
 
     def add_background_dialog(self):
         """

--- a/qt/python/mantidqt/widgets/test/test_fitpropertybrowser.py
+++ b/qt/python/mantidqt/widgets/test/test_fitpropertybrowser.py
@@ -11,7 +11,6 @@ import unittest
 import matplotlib
 
 matplotlib.use('AGG')  # noqa
-import matplotlib.pyplot as plt
 
 from numpy import zeros
 
@@ -23,8 +22,7 @@ from mantidqt.plotting.functions import plot
 from mantidqt.utils.qt.testing import start_qapplication
 from mantidqt.utils.testing.strict_mock import StrictMock
 from mantidqt.widgets.fitpropertybrowser.fitpropertybrowser import FitPropertyBrowser
-from testhelpers import assertRaisesNothing
-from workbench.plotting.figuremanager import FigureManagerADSObserver, MantidFigureCanvas
+from workbench.plotting.figuremanager import FigureManagerADSObserver
 
 from qtpy.QtWidgets import QDockWidget
 
@@ -265,7 +263,7 @@ class FitPropertyBrowserTest(unittest.TestCase):
 
     # Private helper functions
     @classmethod
-    def _create_widget(self, canvas=MagicMock(), toolbar_manager=Mock()):
+    def _create_widget(cls, canvas=MagicMock(), toolbar_manager=Mock()):
         return FitPropertyBrowser(canvas, toolbar_manager)
 
     @classmethod
@@ -275,10 +273,12 @@ class FitPropertyBrowserTest(unittest.TestCase):
         Need to mock some functions and call "show()" in order for the fit browser to create its FitInteractiveTool
         object.
         """
-        fig, axes = plt.subplots(subplot_kw={'projection': 'mantid'})
-        canvas = MantidFigureCanvas(fig)
+        _, canvas, _ = cls._create_and_plot_matrix_workspace()
         fit_browser = FitPropertyBrowser(canvas=canvas, toolbar_manager=Mock())
+        # Mock these functions so that we can call show().
+        canvas.draw = Mock()
         fit_browser._get_allowed_spectra = Mock(return_value=True)
+        fit_browser._get_table_workspace = Mock(return_value=False)
         fit_browser._add_spectra = Mock()
         fit_browser.set_output_window_names = Mock(return_value=None)
         # Need to call show() to set up the FitInteractiveTool, but we've mocked the superclass show() function
@@ -287,7 +287,7 @@ class FitPropertyBrowserTest(unittest.TestCase):
         return fit_browser
 
     @classmethod
-    def _create_and_plot_matrix_workspace(self, name="workspace", distribution=False):
+    def _create_and_plot_matrix_workspace(cls, name="workspace", distribution=False):
         ws = CreateWorkspace(OutputWorkspace=name, DataX=zeros(10), DataY=zeros(10),
                              NSpec=5, Distribution=distribution)
         fig = plot([ws], spectrum_nums=[1])

--- a/qt/widgets/common/src/FitPropertyBrowser.cpp
+++ b/qt/widgets/common/src/FitPropertyBrowser.cpp
@@ -1042,7 +1042,6 @@ std::string FitPropertyBrowser::defaultPeakType() {
 void FitPropertyBrowser::setDefaultPeakType(const std::string &fnType) {
   m_defaultPeak = fnType;
   setDefaultFunctionType(fnType);
-  Mantid::Kernel::ConfigService::Instance().setString("curvefitting.defaultPeak", fnType);
 }
 /// Get the default background type
 std::string FitPropertyBrowser::defaultBackgroundType() const { return m_defaultBackground; }

--- a/scripts/Engineering/gui/engineering_diffraction/engineering_diffraction.py
+++ b/scripts/Engineering/gui/engineering_diffraction/engineering_diffraction.py
@@ -7,7 +7,6 @@
 # pylint: disable=invalid-name
 from qtpy import QtCore, QtWidgets
 from mantidqt.icons import get_icon
-from mantid.kernel import ConfigService
 from mantidqt.utils.observer_pattern import GenericObserverWithArgPassing
 from mantidqt.utils.qt import load_ui
 from Engineering.gui.engineering_diffraction.presenter import EngineeringDiffractionPresenter
@@ -28,9 +27,6 @@ class EngineeringDiffractionGui(QtWidgets.QMainWindow, Ui_main_window):
             super(EngineeringDiffractionGui, self).__init__(parent, window_flags)
         else:
             super(EngineeringDiffractionGui, self).__init__(parent)
-
-        # save initial default peak function so can reset on closing UI
-        self._initial_peak_fun = ConfigService.getString("curvefitting.defaultPeak")
 
         # Main Window
         self.setupUi(self)
@@ -105,7 +101,6 @@ class EngineeringDiffractionGui(QtWidgets.QMainWindow, Ui_main_window):
         self.savedir_label.setText(savedir_text)
 
     def closeEvent(self, event):
-        ConfigService.setString("curvefitting.defaultPeak", self._initial_peak_fun)  # reset peak function
         self.presenter.handle_close()
         self.setParent(None)
         event.accept()

--- a/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/plotting/EngDiff_fitpropertybrowser.py
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/plotting/EngDiff_fitpropertybrowser.py
@@ -30,7 +30,7 @@ class EngDiffFitPropertyBrowser(FitPropertyBrowser):
         # overwrite default peak with that in settings (gets init when UI opened)
         default_peak = get_setting(output_settings.INTERFACES_SETTINGS_GROUP, output_settings.ENGINEERING_PREFIX,
                                    "default_peak")
-        self.setDefaultPeakType(default_peak)  # this will also update peak func in config settings
+        self.setDefaultPeakType(default_peak)
         self.fit_notifier = GenericObservable()
         self.fit_enabled_notifier = GenericObservable()
 


### PR DESCRIPTION
**Description of work.**

When selecting a peak type in the fit browser, the dialog now has a checkbox for setting the application's default peak type. This allows you to change the peak type without altering the default setting. Previously it would update the setting whenever the peak type was changed.
![image](https://user-images.githubusercontent.com/8058899/129740962-346039a3-7d37-4fbb-a5bf-558a1ed74891.png)

**To test:**

0. Make a note of the default peak type in `File->Settings->Fitting->Default peak shape`
1. Open a plot and open the fit browser.
2. Right click the plot and click "Select peak type".
3. Choose a peak type different to the default setting. Leave the checkbox **unticked**.
4. Press OK (optionally click the plot to place the peak).
5. Check that `File->Settings->Fitting->Default peak shape` has not changed.
6. Repeat steps 2-5 but this time **tick the checkbox**. Confirm that the default peak type in `File->Settings->Fitting->Default peak shape` has changed appropriately.
7. Make sure the checkbox isn't present in the other related dialogs ("Add background" and "Add other function") accessed via the same context menu.

Fixes #31930 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
