### PR TITLE
Remove runtime warning when CommonUBForAll and only one run in IndexPeaks

### DIFF
--- a/Framework/Crystal/src/IndexPeaks.cpp
+++ b/Framework/Crystal/src/IndexPeaks.cpp
@@ -404,18 +404,6 @@ std::map<std::string, std::string> IndexPeaks::validateInputs() {
     return helpMsgs;
   }
 
-  // get all runs which have peaks in the table
-  const bool commonUB = this->getProperty(Prop::COMMONUB);
-  if (commonUB) {
-    std::unordered_map<int, int> peaksPerRun;
-    for (int i = 0; i < ws->getNumberPeaks(); i++)
-      peaksPerRun[ws->getPeak(i).getRunNumber()] = 1;
-    if (peaksPerRun.size() < 2) {
-      helpMsgs[Prop::COMMONUB] = "CommonUBForAll can only be True if there are peaks from more "
-                                 "than one run present in the peaks worksapce";
-    };
-  };
-
   const auto args = Prop::IndexPeaksArgs::parse(*this);
   const bool isSave = this->getProperty(Prop::SAVEMODINFO);
   const bool isMOZero = (args.satellites.maxOrder == 0);
@@ -503,6 +491,10 @@ void IndexPeaks::exec() {
     std::unordered_map<int, std::vector<IPeak *>> peaksPerRun;
     for (int i = 0; i < args.workspace->getNumberPeaks(); i++)
       peaksPerRun[args.workspace->getPeak(i).getRunNumber()].emplace_back(args.workspace->getPeakPtr(i));
+    if (peaksPerRun.size() < 2) {
+      g_log.warning("Peaks from only one run exist but CommonUBForAll=True so peaks will be indexed with an optimised "
+                    "UB which will not be saved in the workspace.");
+    }
     const bool optimizeUB{true};
     for (const auto &runPeaks : peaksPerRun) {
       const auto &peaks = runPeaks.second;

--- a/Framework/PythonInterface/plugins/algorithms/FindGlobalBMatrix.py
+++ b/Framework/PythonInterface/plugins/algorithms/FindGlobalBMatrix.py
@@ -106,6 +106,8 @@ class FindGlobalBMatrix(DataProcessorAlgorithm):
         alatt0 = [a, b, c, alpha, beta, gamma]
         try:
             alatt, cov, info, msg, ier = leastsq(fobj, x0=alatt0, full_output=True)
+            # eval the fobj at optimal solution to set UB (leastsq iteration stops at a next sub-optimal solution)
+            fobj(alatt)
         except ValueError:
             logger.error("CalculateUMatrix failed - check initial lattice parameters and tolerance provided.")
             return

--- a/Framework/PythonInterface/plugins/algorithms/FindGlobalBMatrix.py
+++ b/Framework/PythonInterface/plugins/algorithms/FindGlobalBMatrix.py
@@ -196,10 +196,12 @@ class FindGlobalBMatrix(DataProcessorAlgorithm):
         residsq = np.zeros(sum([AnalysisDataService.retrieve(wsname).getNumberPeaks() for wsname in ws_list]))
         ipk = 0  # normalise by n peaks indexed so no penalty in indexing more peaks
         for wsname in ws_list:
-            nindexed = self.child_IndexPeaks(PeaksWorkspace=wsname, RoundHKLs=True)
+            # index peaks with CommonUBForAll=False (optimises a temp. UB when indexing - helps for bad guesses)
+            nindexed = self.child_IndexPeaks(PeaksWorkspace=wsname, RoundHKLs=True, CommonUBForAll=False)
             if nindexed >= _MIN_NUM_INDEXED_PEAKS:
                 self.child_CalculateUMatrix(wsname, *x0)
-                self.child_IndexPeaks(PeaksWorkspace=wsname, RoundHKLs=False)
+                # don't index with optimisation after this point and don't round HKL (to calc resids)
+                self.child_IndexPeaks(PeaksWorkspace=wsname, RoundHKLs=False, CommonUBForAll=True)
                 ws = AnalysisDataService.retrieve(wsname)
                 UB = 2 * np.pi * ws.sample().getOrientedLattice().getUB()
                 for ii in range(ws.getNumberPeaks()):
@@ -209,11 +211,12 @@ class FindGlobalBMatrix(DataProcessorAlgorithm):
                         ipk += 1
         return np.sqrt(residsq / (ipk + 1))
 
-    def child_IndexPeaks(self, PeaksWorkspace, RoundHKLs=True):
+    def child_IndexPeaks(self, PeaksWorkspace, RoundHKLs=True, CommonUBForAll=False):
         alg = self.createChildAlgorithm("IndexPeaks", enableLogging=False)
         alg.setProperty("PeaksWorkspace", PeaksWorkspace)
         alg.setProperty("Tolerance", self.tol)
         alg.setProperty("RoundHKLs", RoundHKLs)
+        alg.setProperty("CommonUBForAll", CommonUBForAll)  # if False then optimises a temp UB before indexing
         alg.execute()
         return alg.getProperty("NumIndexed").value
 

--- a/docs/source/release/v6.2.0/diffraction.rst
+++ b/docs/source/release/v6.2.0/diffraction.rst
@@ -99,5 +99,6 @@ Improvements
 Bugfixes
 ########
 - Expand the Q space search radius in DetectorSearcher to avoid missing peaks when using :ref:`PredictPeaks <algm-PredictPeaks>`.
+- :ref:`IndexPeaks <algm-IndexPeaks>` can now index peaks in a PeaksWorkspace with only a single run without optimising the UB (i.e. it is now possible to set CommonUBForAll=True in this instance).
 
 :ref:`Release 6.2.0 <v6.2.0>`


### PR DESCRIPTION
**Description of work.**

Remove runtime warning when `CommonUBForAll=True` and only one run in `IndexPeaks` and also added warning when a different UB will be used when peaks from only one run and `CommonUBForAll=False`.

By default `CommonUBForAll=False` and so the UB will be optimised, WISH often use PeakWorkspaces with peaks from only one run but do not want to optimise the UB (e.g. because it has been calculated with some constraints such as fixed lattice parameters) - prior to this change this would throw a runtime warning.

Thanks @zjmorgan for finding this and for the helpful discussion - hope this is what you had in mind?

UPDATE: Have pushed a change to new algorithm `FindGlobalBMatrix` that takes advantage of the newly enabled option to use `CommonUBForAll=True` in `IndexPeaks` for tables with peaks from only one run.

UPDATE 2: Fixed bug in `FindGlobalBMatrix` as realised `leastsq` last eval of the UB is for a sub-optimal solution - in practice the lattice parameters only vary in the 6dp so it has a negligible effect on the indexing. Don't need release notes for this as algorithm was added this release.

**To test:**
(1) Run this script

```
# generate peak table
ws = LoadEmptyInstrument(InstrumentName='SXD', OutputWorkspace='ws')
axis = ws.getAxis(0)
axis.setUnit("TOF")  # need this to add peak to table
UB = 0.5*np.eye(3)
SetUB(ws, UB=UB)
peaks = PredictPeaks(InputWorkspace=ws, 
                     OutputWorkspace='peaks')
IndexPeaks(PeaksWorkspace='peaks', Tolerance=0.15, CommonUBForAll=True)
```
The call to `IndexPeaks` with `CommonUBForAll=True` should not throw an error

(2) Call `IndexPeaks `with `CommonUBForAll=False`
`IndexPeaks(PeaksWorkspace='peaks', Tolerance=0.15, CommonUBForAll=False)`
This should display a warning in the log.

(3) Test the `FindGlobalBMatrix` algorithm again using instructions in #31992 
*There is no associated issue.*

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
