### PR TITLE
Fixed MA corrections crash when changing instrument

### DIFF
--- a/scripts/Muon/GUI/Common/corrections_tab_widget/dead_time_corrections_presenter.py
+++ b/scripts/Muon/GUI/Common/corrections_tab_widget/dead_time_corrections_presenter.py
@@ -37,7 +37,7 @@ class DeadTimeCorrectionsPresenter:
 
     def handle_instrument_changed(self) -> None:
         """User changes the selected instrument."""
-        self.set_dead_time_source_to_from_file()
+        self.model.set_dead_time_source_to_from_file()
         self.view.set_dead_time_from_data_file_selected()
 
     def handle_run_selector_changed(self) -> None:

--- a/scripts/test/Muon/corrections_tab_widget/dead_time_corrections_presenter_test.py
+++ b/scripts/test/Muon/corrections_tab_widget/dead_time_corrections_presenter_test.py
@@ -54,9 +54,10 @@ class DeadTimeCorrectionsPresenterTest(unittest.TestCase):
     def test_that_handle_instrument_changed_will_reset_the_dead_time_source_and_attempt_a_recalculation(self):
         self.presenter.handle_instrument_changed()
 
-        self.model.set_dead_time_source_to_from_file.assert_called_with()
-        self.presenter._notify_perform_dead_time_corrections.assert_called_once_with()
         self.view.set_dead_time_from_data_file_selected.assert_called_once_with()
+        self.model.set_dead_time_source_to_from_file.assert_called_with()
+        # calling this will cause a crash
+        self.presenter._notify_perform_dead_time_corrections.assert_not_called()
 
     def test_that_handle_run_selector_changed_will_update_the_run_string_in_the_model(self):
         self.presenter.update_dead_time_info_text_in_view = mock.Mock()


### PR DESCRIPTION
**Description of work.**
When setting the deadtime table to none and then changing instrument, would lead to a crash. This was because it was sending a notification to recalculate the data, when no data was present.

**To test:**

<!-- Instructions for testing. -->
Open MA
Load some data
Go to the corrections tab
Set the dead time table to none
Go to the home tab
Change the instrument - crash
Fixes #32194. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->
This is not in the release notes as it is a fix for a bug we introduced recently. 

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
