### PR TITLE
ISIS SANS - Fix reduction mode not valid err

### DIFF
--- a/docs/source/release/v6.2.0/sans.rst
+++ b/docs/source/release/v6.2.0/sans.rst
@@ -26,6 +26,7 @@ Bugfixes
 - The ISIS SANS Interface will now display an error, instead of an unexpected error, if the user does not have permission to save a CSV file to the requested location.
 - The ISIS SANS interface will no longer throw an uncaught exception when a user tries to enter row information without loading a Mask/TOML file.
 - The ISIS SANS beam centre finder correctly accepts zero values (0.0) and won't try to replace them with empty strings.
+- The warning "Reduction Mode 'x' is not valid" will no longer incorrectly show when there are errors with the user's mask file.
 
 Improvements
 ############

--- a/docs/source/techniques/SANS-Toml-v1.rst
+++ b/docs/source/techniques/SANS-Toml-v1.rst
@@ -682,7 +682,7 @@ L/WAV min max step [/LIN]
     [binning]
       # Only for "Lin", "Log"
       wavelength = {start = 2.0, step=0.125, stop=14.0, type = "Lin"}
-      # Only for "RangeLin" or "RangeLog
+      # Only for "RangeLin" or "RangeLog"
       wavelength = {binning="2.0-7.0, 7.0-14.0", type = "RangeLin"}
 
 MASKFILE str

--- a/scripts/SANS/sans/gui_logic/gui_common.py
+++ b/scripts/SANS/sans/gui_logic/gui_common.py
@@ -184,19 +184,15 @@ def get_string_for_gui_from_instrument(instrument):
         return None
 
 
-def get_reduction_mode_from_gui_selection(gui_selection):
-    # TODO when we hit only Python 3 this should use casefold rather than lower
-    case_folded_selection = gui_selection.lower()
-    if case_folded_selection == MERGED.lower():
+def get_reduction_mode_from_gui_selection(gui_selection: str):
+    case_folded_selection = gui_selection.casefold()
+    if case_folded_selection == MERGED.casefold():
         return ReductionMode.MERGED
-
-    elif case_folded_selection == ALL.lower():
+    elif case_folded_selection == ALL.casefold():
         return ReductionMode.ALL
-
-    elif any(case_folded_selection == lab.lower() for lab in LAB_STRINGS.values()):
+    elif any(case_folded_selection == lab.casefold() for lab in LAB_STRINGS.values()):
         return ReductionMode.LAB
-
-    elif any(case_folded_selection == hab.lower() for hab in HAB_STRINGS.values()):
+    elif any(case_folded_selection == hab.casefold() for hab in HAB_STRINGS.values()):
         return ReductionMode.HAB
     else:
         raise RuntimeError("Reduction mode selection {0} is not valid.".format(gui_selection))

--- a/scripts/SANS/sans/gui_logic/gui_common.py
+++ b/scripts/SANS/sans/gui_logic/gui_common.py
@@ -185,7 +185,7 @@ def get_string_for_gui_from_instrument(instrument):
 
 
 def get_reduction_mode_from_gui_selection(gui_selection: str):
-    case_folded_selection = gui_selection.casefold()
+    case_folded_selection = gui_selection.strip().casefold()
     if case_folded_selection == MERGED.casefold():
         return ReductionMode.MERGED
     elif case_folded_selection == ALL.casefold():
@@ -194,6 +194,8 @@ def get_reduction_mode_from_gui_selection(gui_selection: str):
         return ReductionMode.LAB
     elif any(case_folded_selection == hab.casefold() for hab in HAB_STRINGS.values()):
         return ReductionMode.HAB
+    elif not case_folded_selection:
+        return ReductionMode.NOT_SET
     else:
         raise RuntimeError("Reduction mode selection {0} is not valid.".format(gui_selection))
 

--- a/scripts/SANS/sans/gui_logic/models/state_gui_model.py
+++ b/scripts/SANS/sans/gui_logic/models/state_gui_model.py
@@ -9,6 +9,7 @@
 This is one of the two models which is used for the data reduction. It contains generally all the settings which
 are not available in the model associated with the data table.
 """
+from typing import Union
 
 from sans.common.enums import (ReductionDimensionality, ReductionMode, RangeStepType, SaveType,
                                DetectorType, FitModeForMerge)
@@ -207,12 +208,10 @@ class StateGuiModel(ModelCommon):
         return self._get_val_or_default(val, ReductionMode.LAB)
 
     @reduction_mode.setter
-    def reduction_mode(self, value):
-        if (value is ReductionMode.LAB or value is ReductionMode.HAB
-                or value is ReductionMode.MERGED or value is ReductionMode.ALL):  # noqa
-            self._all_states.reduction.reduction_mode = value
-        else:
-            raise ValueError("A reduction mode was expected, got instead {}".format(value))
+    def reduction_mode(self, value: Union[str, ReductionMode]):
+        if isinstance(value, str):
+            value = ReductionMode(value)
+        self._all_states.reduction.reduction_mode = value
 
     @property
     def merge_scale(self):

--- a/scripts/SANS/sans/gui_logic/presenter/run_tab_presenter.py
+++ b/scripts/SANS/sans/gui_logic/presenter/run_tab_presenter.py
@@ -17,6 +17,7 @@ from functools import wraps
 from typing import Optional
 
 from mantidqt.utils.observer_pattern import GenericObserver
+from sans.user_file.toml_parsers.toml_v1_schema import TomlValidationError
 from ui.sans_isis import SANSSaveOtherWindow
 from ui.sans_isis.sans_data_processor_gui import SANSDataProcessorGui
 from ui.sans_isis.sans_gui_observable import SansGuiObservable
@@ -394,7 +395,7 @@ class RunTabPresenter(PresenterCommon):
             # Always set the instrument to NoInstrument unless otherwise specified as our fallback
             user_file_items = FileLoading.load_user_file(file_path=user_file_path,
                                                          file_information=self._file_information)
-        except UserFileLoadException as e:
+        except (UserFileLoadException, TomlValidationError) as e:
             # It is in this exception block that loading fails if the file is invalid (e.g. a csv)
             self._on_user_file_load_failure(e, error_msg + " when reading file.", use_error_name=True)
             return

--- a/scripts/SANS/sans/user_file/toml_parsers/toml_v1_schema.py
+++ b/scripts/SANS/sans/user_file/toml_parsers/toml_v1_schema.py
@@ -38,7 +38,7 @@ class TomlSchemaV1Validator(object):
         unrecognised = [s for s in unrecognised if not any(wild_matcher.match(s) for wild_matcher in wildcard_matchers)]
 
         if len(unrecognised) > 0:
-            err = "The following keys were not recognised\n:"
+            err = "The following keys were not recognised:\n"
             err += "".join("{0} \n".format(k) for k in unrecognised)
             raise TomlValidationError(err)
 

--- a/scripts/test/SANS/gui_logic/gui_common_test.py
+++ b/scripts/test/SANS/gui_logic/gui_common_test.py
@@ -87,6 +87,10 @@ class GuiCommonTest(unittest.TestCase):
         check_all_match(merged_strings, ReductionMode.MERGED)
         check_all_match(all_strings, ReductionMode.ALL)
 
+    def test_get_reduction_mode_ignores_blank_str(self):
+        for blank_str in ["", "   ", "\t"]:
+            self.assertEqual(ReductionMode.NOT_SET, get_reduction_mode_from_gui_selection(blank_str))
+
     def test_that_batch_file_dir_returns_none_if_no_forwardslash(self):
         a_path = "test_batch_file_path.csv"
         result = get_batch_file_dir_from_path(a_path)

--- a/scripts/test/SANS/gui_logic/state_gui_model_test.py
+++ b/scripts/test/SANS/gui_logic/state_gui_model_test.py
@@ -151,12 +151,15 @@ class StateGuiModelTest(unittest.TestCase):
         state_gui_model.reduction_mode = ReductionMode.MERGED
         self.assertEqual(state_gui_model.reduction_mode, ReductionMode.MERGED)
 
-    def test_that_raises_when_setting_with_wrong_input(self):
-        def red_mode_wrapper():
-            state_gui_model = StateGuiModel(AllStates())
-            state_gui_model.reduction_mode = "string"
+    def test_reduction_mode_not_set(self):
+        state_gui_model = StateGuiModel(AllStates())
+        state_gui_model.reduction_mode = ReductionMode.NOT_SET
+        self.assertEqual(state_gui_model.reduction_mode, ReductionMode.NOT_SET)
 
-        self.assertRaises(ValueError, red_mode_wrapper)
+    def test_that_raises_when_setting_with_wrong_input(self):
+        state_gui_model = StateGuiModel(AllStates())
+        with self.assertRaises(ValueError):
+            state_gui_model.reduction_mode = "string"
 
     def test_that_can_update_reduction_mode(self):
         state = AllStates()

--- a/scripts/test/SANS/gui_logic/test_run_tab_presenter.py
+++ b/scripts/test/SANS/gui_logic/test_run_tab_presenter.py
@@ -13,6 +13,7 @@ from sans.command_interface.batch_csv_parser import BatchCsvParser
 from sans.common.enums import (SANSFacility, ReductionDimensionality, SaveType, RowState)
 from sans.common.enums import SANSInstrument
 from sans.gui_logic.models.RowEntries import RowEntries
+from sans.gui_logic.models.file_loading import UserFileLoadException
 from sans.gui_logic.models.run_tab_model import RunTabModel
 from sans.gui_logic.models.state_gui_model import StateGuiModel
 from sans.gui_logic.models.table_model import TableModel
@@ -22,6 +23,7 @@ from sans.test_helper.common import (remove_file)
 from sans.test_helper.mock_objects import (create_mock_view)
 from sans.test_helper.user_file_test_helper import (create_user_file, sample_user_file)
 from ui.sans_isis.sans_gui_observable import SansGuiObservable
+from sans.user_file.toml_parsers.toml_v1_schema import TomlValidationError
 
 BATCH_FILE_TEST_CONTENT_1 = [RowEntries(sample_scatter=1, sample_transmission=2,
                                         sample_direct=3, output_name='test_file',
@@ -132,6 +134,19 @@ class RunTabPresenterTest(unittest.TestCase):
 
         # clean up
         remove_file(user_file_path)
+
+    @mock.patch("sans.gui_logic.presenter.run_tab_presenter.FileLoading")
+    @mock.patch("sans.gui_logic.presenter.run_tab_presenter.FileFinder")
+    def test_user_file_loading_handles_exceptions(self, _, mocked_loader):
+        for e in [UserFileLoadException("e"), TomlValidationError("e")]:
+            self._mock_view.display_message_box.reset_mock()
+            self._mock_view.on_user_file_load_failure.reset_mock()
+
+            mocked_loader.load_user_file.side_effect = e
+            self.presenter.on_user_file_load()
+
+            self._mock_view.on_user_file_load_failure.assert_called_once()
+            self._mock_view.display_message_box.assert_called_once_with(mock.ANY, mock.ANY, "e")
 
     def test_that_checks_default_user_file(self):
         # Setup self.presenter.and mock view


### PR DESCRIPTION
**Description of work.**

Handle empty string case for the reduction mode. This primarily happens
when the parser fails, causing an unrelated error that x "is not a valid reduction mode."
Instead we should mark the attr NOT_SET and let the original exception
explain to the user

I've also cherry-picked ad5d915 from #32081into this PR to make it easier to test. Otherwise it throws a sad Mantid.

**Report to:** @pzt29813

**To test:**
- Create a blank file with the extension .toml
- Open ISIS SANS
- Open this TOML Mask File as the mask file
- There should be one warning box opened, which related to TOML errors and not reduction modes
- Try to re-open this file again (sometimes caused the error to appear again)

There is no associated issue. - Noticed as part of #32081 

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
