### PR TITLE
Fix dev docs warnings

### DIFF
--- a/buildconfig/Jenkins/Conda/build
+++ b/buildconfig/Jenkins/Conda/build
@@ -58,6 +58,8 @@ if [[ $ENABLE_DOCS == true ]]; then
 fi
 
 # Build dev-docs turned off until dev docs run without error
-# if [[ $ENABLE_DEV_DOCS == true ]]; then
-#     cmake --build . --target dev-docs-html
-# fi
+if [[ $ENABLE_DEV_DOCS == true ]]; then
+    rm -fr $BUILD_DIR/dev-docs/doctree/*
+    rm -f $BUILD_DIR/dev-docs/dev_docs_warnings.txt
+    cmake --build . --target dev-docs-html
+fi

--- a/buildconfig/Jenkins/buildscript
+++ b/buildconfig/Jenkins/buildscript
@@ -442,12 +442,11 @@ fi
 # Developer Documentation
 ###############################################################################
 # Uncomment this when the dev-docs are ready to build without warnings
-# if [[ ${DO_BUILD_DEVDOCS} == true ]]; then
-#   if [ -d $BUILD_DIR/dev-docs/doctree ]; then
-#     rm -fr $BUILD_DIR/dev-docs/doctree/*
-#   fi
-#   ${CMAKE_EXE} --build . --target dev-docs-html
-# fi
+if [[ ${DO_BUILD_DEVDOCS} == true ]]; then
+  rm -fr $BUILD_DIR/dev-docs/doctree/*
+  rm -f $BUILD_DIR/dev-docs/dev_docs_warnings.txt
+  ${CMAKE_EXE} --build . --target dev-docs-html
+fi
 
 ###############################################################################
 # Create the install kit if required. This includes building the Qt help

--- a/dev-docs/CMakeLists.txt
+++ b/dev-docs/CMakeLists.txt
@@ -12,13 +12,15 @@ set(DOCTREE_DIR ${CMAKE_CURRENT_BINARY_DIR}/doctree)
 # in these cases
 if(EXISTS ${SPHINX_PACKAGE_DIR}/__main__.py)
   add_custom_target(dev-docs-${BUILDER}
-                    COMMAND ${Python_EXECUTABLE} -m sphinx -b ${BUILDER} -d
+                    COMMAND ${Python_EXECUTABLE} -m sphinx -w dev_docs_warnings.txt
+                            -W --keep-going -b ${BUILDER} -d
                             ${DOCTREE_DIR} ${CMAKE_CURRENT_LIST_DIR}/source
                             ${OUT_DIR}
                     COMMENT "Building html developer documentation")
 else()
   add_custom_target(dev-docs-${BUILDER}
-                    COMMAND sphinx-build -b ${BUILDER} -d ${DOCTREE_DIR}
+                    COMMAND sphinx-build -w dev_docs_warnings.txt
+                            -W --keep-going -b ${BUILDER} -d ${DOCTREE_DIR}
                             ${CMAKE_CURRENT_LIST_DIR}/source ${OUT_DIR}
                     COMMENT "Building html developer documentation")
 endif()

--- a/dev-docs/source/CodeCoverage.rst
+++ b/dev-docs/source/CodeCoverage.rst
@@ -108,7 +108,7 @@ IDE
 
 Your IDE may already have an option to run the test with coverage enabled if it can already run the test directly.
 
-To setup unit tests for Pycharm see the :ref:`Pycharm` page.
+To setup unit tests for Pycharm see the :ref:`pycharm-ref` page.
 
 CLI
 ###

--- a/dev-docs/source/GettingStarted/GettingStartedNoneConda.rst
+++ b/dev-docs/source/GettingStarted/GettingStartedNoneConda.rst
@@ -119,13 +119,13 @@ Install pre-commit for use in our current developer workflow
 
 if you wish to setup eclipse for use developing mantid, then instructions can be found :ref:`here <Eclipse>`.
 
-Now you can :ref:`here <Getting the Mantid code>`, and build it:
+Now you can :ref:`Clone Mantid <wsl-cloning-mantid-ref>`, and build as follows:
 
 .. code-block:: sh
 
   mkdir build
   cd build
-  cmake -GNinja [mantid source]
+  cmake -G Ninja [mantid source]
   cmake --build .
 
 See the instructions on :ref:`this <RunningTheUnitTests>` page to run the Mantid unit tests.

--- a/dev-docs/source/PyCharm.rst
+++ b/dev-docs/source/PyCharm.rst
@@ -1,4 +1,4 @@
-.. _PyCharm:
+.. _pycharm-ref:
 
 =======
 PyCharm
@@ -48,6 +48,8 @@ At any point in these instructions where ``RelWithDebInfo`` is used (including i
 - On Windows, select the ``{BUILD}/bin/RelWithDeb`` file and mark as Source by clicking the ``Sources`` button whilst it's selected.
 - On Linux or MacOS, select your ``{BUILD}/bin`` directory and mark as Source by clicking the ``Sources`` button whilst it's selected.
 - Click Apply, and then Ok to close the window.
+
+.. _debug-workbench-in-pycharm-ref:
 
 Debug Python in Workbench
 #########################
@@ -164,6 +166,7 @@ Setting up PyCharm on Windows
 
 NOTE : In some cases, imports in the code will still be highlighted red when they come from folders within the ``script/`` folder, or from other folders entirely. To fix this simply add the relevant folder that contains the module you are importing in the same fashion as step 3 above.
 
+.. _pycharm-debugging-env-file:
 
 Running Files in the Debugger with EnvFile extension
 ####################################################
@@ -260,7 +263,7 @@ This **does not** require a PyCharm Professional license for debugging, but requ
 1. Go to your Run/Debug Configurations.
 2. Open Templates > Python tests > Unittests configuration.
 3. Set the working directory to ``<Mantid Build Dir>/bin/Debug``, for a Debug build, or ``<Mantid Build Dir>/bin/Release`` for a Release build.
-4. Add the EnvFile to the Unittests configuration, instructions in :ref:`running-file-debug-with-envfile-extension`.
+4. Add the EnvFile to the Unittests configuration, instructions in :ref:`pycharm-debugging-env-file`.
 5. You should now be able to click the Run/Debug icons next to each unit test method or class to run/debug them.
 
 Setting up PyCharm on Linux

--- a/dev-docs/source/Testing/SliceViewer/SliceViewer.rst
+++ b/dev-docs/source/Testing/SliceViewer/SliceViewer.rst
@@ -30,6 +30,7 @@ Data
 	# Create a histogrammed (binned) workspace with 100 bins in each of the H, K and L dimensions
 	mdHisto_3D = BinMD(InputWorkspace=md_4D, AlignedDim0='H,-1,1,100', AlignedDim1='K,-1,1,100', AlignedDim2='L,-1,1,100') # 3D cut
 	mdHisto_2D = BinMD(InputWorkspace=md_4D, AlignedDim0='H,-1,1,100', AlignedDim1='K,-1,1,100') # 2D cut
+
 - Create an MD workspace with non-orthogonal axes:
 
 .. code-block:: python

--- a/dev-docs/source/UserSupport.rst
+++ b/dev-docs/source/UserSupport.rst
@@ -59,13 +59,13 @@ For a full release, ``C:\MantidInstall\`` is likely the correct install path. Ta
 
 3. Try launching from a command prompt:
 
-.. code-block:: python
+.. code-block:: shell
 
 	C:\MantidInstall\bin\MantidWorkbench
 
 If this does not work, try launching with:
 
-.. code-block:: python
+.. code-block:: shell
 
 	cd C:\MantidInstall\bin
 	set QT_PLUGIN_PATH=%CD%\..\plugins\qt5
@@ -75,7 +75,7 @@ If this does not work, try launching with:
 
 4. Does **Qt** import correctly? In a command prompt / terminal window, run the following:
 
-.. code-block:: python
+.. code-block:: shell
 
     C:\MantidInstall\bin\mantidpython.bat --classic
     import qtpy.QtCore
@@ -83,7 +83,7 @@ If this does not work, try launching with:
 
 5. Do **Mantid Algorithms** import correctly?
 
-.. code-block:: python
+.. code-block:: shell
 
     C:\MantidInstall\bin\mantidpython.bat --classic
     import mantid.simpleapi
@@ -98,7 +98,7 @@ If this does not work, try launching with:
 
 7. Try renaming **Config Files**:
 
-.. code-block:: python
+.. code-block:: shell
 
 	cd %APPDATA%\mantidproject
 	mv mantidproject.ini mantidproject.ini.backup
@@ -112,11 +112,11 @@ Advanced options:
 
 8. Check the PATH for conflicts with Mantid:
 
-.. code-block:: python
+.. code-block:: shell
 
 	echo %PATH%
 
-.. code-block:: python
+.. code-block:: shell
 
     cd C:\MantidInstall\bin\
     python -c "import sys; import os; import pprint; pprint.pprint(sys.path); pprint.pprint(os.environ)"
@@ -145,14 +145,14 @@ For a full release, ``/opt/Mantid/`` is likely the correct install path. Take ca
 
 3. Try launching from the terminal:
 
-.. code-block:: python
+.. code-block:: shell
 
 	/opt/Mantid/bin/mantidworkbench
 
 
 4. Does **Qt** import correctly? In terminal, run the following:
 
-.. code-block:: python
+.. code-block:: shell
 
     /opt/Mantid/bin/mantidpython --classic
     import qtpy.QtCore
@@ -160,7 +160,7 @@ For a full release, ``/opt/Mantid/`` is likely the correct install path. Take ca
 
 5. Do **Mantid Algorithms** import correctly?
 
-.. code-block:: python
+.. code-block:: shell
 
     /opt/Mantid/bin/mantidpython --classic
     import mantid.simpleapi
@@ -168,7 +168,7 @@ For a full release, ``/opt/Mantid/`` is likely the correct install path. Take ca
 
 6. Try renaming **Config Files**:
 
-.. code-block:: python
+.. code-block:: shell
 
 	cd $HOME/.config/mantidproject
 	mv mantidproject.ini mantidproject.ini.backup
@@ -191,11 +191,11 @@ Advanced Options:
 
 8. Check the PATH for conflicts with Mantid: e.g. Anything relating to ``.local`` could be a problem.
 
-.. code-block:: python
+.. code-block:: shell
 
 	echo $PATH
 
-.. code-block:: python
+.. code-block:: shell
 
     cd /opt/Mantid/bin/
     python -c "import sys; import os; import pprint; pprint.pprint(sys.path); pprint.pprint(os.environ)"
@@ -221,13 +221,13 @@ MacOS
 
 3. Try launching from terminal, by running the following:
 
-.. code-block:: python
+.. code-block:: shell
 
 	/Applications/MantidWorkbench.app/Contents/MacOS/MantidWorkbench
 
 If this does not work, try launching with:
 
-.. code-block:: python
+.. code-block:: shell
 
 	cd /Applications/MantidWorkbench.app/Contents/MacOS
 	export QT_PLUGIN_PATH=$PWD/../PlugIns/
@@ -237,7 +237,7 @@ If this does not work, try launching with:
 
 4. Does **Qt** import correctly?
 
-.. code-block:: python
+.. code-block:: shell
 
     /Applications/MantidWorkbench.app/Contents/MacOS/mantidpython --classic
     import qtpy.QtCore
@@ -245,7 +245,7 @@ If this does not work, try launching with:
 
 5. Do **Mantid Algorithms** import correctly?
 
-.. code-block:: python
+.. code-block:: shell
 
     /Applications/MantidWorkbench.app/Contents/MacOS/mantidpython --classic
     import mantid.simpleapi
@@ -260,7 +260,7 @@ If this does not work, try launching with:
 
 7. Try renaming **Config files**:
 
-.. code-block:: python
+.. code-block:: shell
 
 	cd $HOME/.config/mantidproject
 	mv mantidproject.ini mantidproject.ini.backup
@@ -275,11 +275,11 @@ Advanced Options:
 
 8. Check the PATH for conflicts with Mantid: e.g. Anything relating to ``.local`` could be a problem.
 
-.. code-block:: python
+.. code-block:: shell
 
 	echo $PATH
 
-.. code-block:: python
+.. code-block:: shell
 
     cd /Applications/MantidWorkbench.app/Contents/MacOS/
     python -c "import sys; import os; import pprint; pprint.pprint(sys.path); pprint.pprint(os.environ)"

--- a/dev-docs/source/WindowsSubsystemForLinux.rst
+++ b/dev-docs/source/WindowsSubsystemForLinux.rst
@@ -65,10 +65,12 @@ You can run either of these linux subsystems from the Windows command prompt usi
 
 where [OS] is replaced by `Ubuntu-18.04` or `Centos7`.
 
-Getting the Mantid Code
-#######################
+.. _wsl-cloning-mantid-ref:
 
-Before you get the Mantid code, follow the :ref:`getting started <GettingStarted>` instructions to install all of the required dependencies for your linux environment.
+Cloning Mantid
+##############
+
+Before you clone Mantid code, follow the :ref:`getting started <GettingStarted>` instructions to install all of the required dependencies for your linux environment.
 
 The Mantid code can then be retrieved in the usual way using `git clone` from the Ubuntu or Centos7 terminal. The first time you do this you might need to set up an `ssh key <https://docs.github.com/en/github/authenticating-to-github/connecting-to-github-with-ssh>`_ for authentication.
 

--- a/dev-docs/source/Workbench/index.rst
+++ b/dev-docs/source/Workbench/index.rst
@@ -16,10 +16,11 @@ interacting with the mantid framework. The plotting is provided by
 
    BuildingWorkbench
    ProjectSaveInterfaces
-   UsingPycharmWithWorkbench
 
 :doc:`Build Workbench <BuildingWorkbench>`
    A document detailing how to build and package the workbench alongside MantidPlot.
 
 :doc:`Project Save <ProjectSaveInterfaces>`
    This document details Project Save on workbench and gives details on how to allow the saving and loading of interfaces in workbench.
+
+:ref:`Debugging workbench with Pycharm <debug-workbench-in-pycharm-ref>`.


### PR DESCRIPTION
**Description of work.**
This resolves the problem where we simply ignore warnings whilst
building on Jenkins and, by specifying a file name, we can emit them
through the warning parsing.

This PR:
- Explicitly adds the warning flag for dev-doc builds
- Emits warnings to a file
- Enables the step in Jenkins builds
- Fixes all warnings

**To test:**
- Check dev docs build without warnings

There is no associated issue.

*This does not require release notes* because it was noticed reviewing #32197 

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
