### PR TITLE
Move slow LoadWANDSCD unittest to systemtest

### DIFF
--- a/Framework/PythonInterface/test/python/plugins/algorithms/LoadWANDSCDTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/LoadWANDSCDTest.py
@@ -4,12 +4,8 @@
 #   NScD Oak Ridge National Laboratory, European Spallation Source,
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
-from mantid.simpleapi import (
-    AddSampleLog,
-    LoadWANDSCD,
-)
+from mantid.simpleapi import LoadWANDSCD
 import unittest
-import numpy as np
 
 
 class LoadWANDTest(unittest.TestCase):
@@ -64,33 +60,6 @@ class LoadWANDTest(unittest.TestCase):
         self.assertEqual(run.getNumGoniometers(), 2)
         self.assertAlmostEqual(run.getGoniometer(0).getEulerAngles('YZY')[0], -142.6) # s1 from HB2C_7000
         self.assertAlmostEqual(run.getGoniometer(1).getEulerAngles('YZY')[0], -142.5) # s1 from HB2C_7001
-
-        LoadWANDTest_ws.delete()
-
-    def test_withNorm(self):
-        # create van data
-        van = LoadWANDSCD('HB2C_7000.nxs.h5')
-        van.setSignalArray(np.full_like(van.getSignalArray(), 25))
-        van.setErrorSquaredArray(np.full_like(van.getSignalArray(), 25))
-        AddSampleLog(van, LogName='duration', LogText='42', LogType='Number Series', NumberType='Double')
-        AddSampleLog(van, LogName='monitor_count', LogText='420', LogType='Number Series', NumberType='Double')
-        # NOTE: all reference values are copied from terminal after confirm the code is correct
-        LoadWANDTest_ws = LoadWANDSCD(Filename='HB2C_7000.nxs.h5,HB2C_7001.nxs.h5', VanadiumWorkspace=van, NormalizedBy='Monitor')
-        ref_val = 0.00012953253733973653
-        self.assertAlmostEqual(LoadWANDTest_ws.getSignalArray().max(), ref_val, 5)
-        self.assertAlmostEqual(LoadWANDTest_ws.getErrorSquaredArray().max(), 0.0, 5)
-        #
-        LoadWANDTest_ws = LoadWANDSCD(Filename='HB2C_7000.nxs.h5,HB2C_7001.nxs.h5', VanadiumWorkspace=van, NormalizedBy='Counts')
-        ref_val = 0.0112
-        self.assertAlmostEqual(LoadWANDTest_ws.getSignalArray().max(), ref_val, 5)
-        ref_err = 2.29376e-05
-        self.assertAlmostEqual(LoadWANDTest_ws.getErrorSquaredArray().max(), ref_err, 5)
-        #
-        LoadWANDTest_ws = LoadWANDSCD(Filename='HB2C_7000.nxs.h5,HB2C_7001.nxs.h5', VanadiumWorkspace=van, NormalizedBy='Time')
-        ref_val = 0.29363296439511044
-        self.assertAlmostEqual(LoadWANDTest_ws.getSignalArray().max(), ref_val, 5)
-        ref_err = 0.0157660
-        self.assertAlmostEqual(LoadWANDTest_ws.getErrorSquaredArray().max(), ref_err, 5)
 
         LoadWANDTest_ws.delete()
 

--- a/Testing/SystemTests/tests/framework/LoadWANDSCDTest.py
+++ b/Testing/SystemTests/tests/framework/LoadWANDSCDTest.py
@@ -1,6 +1,6 @@
 # Mantid Repository : https://github.com/mantidproject/mantid
 #
-# Copyright &copy; 2018 ISIS Rutherford Appleton Laboratory UKRI,
+# Copyright &copy; 2021 ISIS Rutherford Appleton Laboratory UKRI,
 #   NScD Oak Ridge National Laboratory, European Spallation Source,
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +

--- a/Testing/SystemTests/tests/framework/LoadWANDSCDTest.py
+++ b/Testing/SystemTests/tests/framework/LoadWANDSCDTest.py
@@ -1,0 +1,39 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2018 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+import systemtesting
+import numpy as np
+from mantid.simpleapi import AddSampleLog, LoadWANDSCD
+
+
+class LoadWANDSCDTest(systemtesting.MantidSystemTest):
+    def runTest(self):
+        # create van data
+        van = LoadWANDSCD('HB2C_7000.nxs.h5')
+        van.setSignalArray(np.full_like(van.getSignalArray(), 25))
+        van.setErrorSquaredArray(np.full_like(van.getSignalArray(), 25))
+        AddSampleLog(van, LogName='duration', LogText='42', LogType='Number Series', NumberType='Double')
+        AddSampleLog(van, LogName='monitor_count', LogText='420', LogType='Number Series', NumberType='Double')
+        # NOTE: all reference values are copied from terminal after confirm the code is correct
+        LoadWANDTest_ws = LoadWANDSCD(Filename='HB2C_7000.nxs.h5,HB2C_7001.nxs.h5', VanadiumWorkspace=van, NormalizedBy='Monitor')
+        ref_val = 0.00012953253733973653
+        self.assertAlmostEqual(LoadWANDTest_ws.getSignalArray().max(), ref_val, 5)
+        self.assertAlmostEqual(LoadWANDTest_ws.getErrorSquaredArray().max(), 0.0, 5)
+        #
+        LoadWANDTest_ws = LoadWANDSCD(Filename='HB2C_7000.nxs.h5,HB2C_7001.nxs.h5', VanadiumWorkspace=van, NormalizedBy='Counts')
+        ref_val = 0.0112
+        self.assertAlmostEqual(LoadWANDTest_ws.getSignalArray().max(), ref_val, 5)
+        ref_err = 2.29376e-05
+        self.assertAlmostEqual(LoadWANDTest_ws.getErrorSquaredArray().max(), ref_err, 5)
+        #
+        LoadWANDTest_ws = LoadWANDSCD(Filename='HB2C_7000.nxs.h5,HB2C_7001.nxs.h5', VanadiumWorkspace=van, NormalizedBy='Time')
+        ref_val = 0.29363296439511044
+        self.assertAlmostEqual(LoadWANDTest_ws.getSignalArray().max(), ref_val, 5)
+        ref_err = 0.0157660
+        self.assertAlmostEqual(LoadWANDTest_ws.getErrorSquaredArray().max(), ref_err, 5)
+
+        LoadWANDTest_ws.delete()
+        van.delete()


### PR DESCRIPTION
**Description of work.**

This unittest was timing out on a few slow computers, so move it to a systemtest. It was added by #32182

https://builds.mantidproject.org/job/master_clean-windows/1647/

**To test:**

You can try running the system test yourself or just check that the build servers do.

```shell
./systemtest -R LoadWANDSCD
```


*This does not require release notes* because internally testing change only, added this release

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
