### PR TITLE
Modernize CalculatePlaczekSelfScattering

### DIFF
--- a/Framework/Algorithms/inc/MantidAlgorithms/CalculatePlaczekSelfScattering.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/CalculatePlaczekSelfScattering.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include "MantidAPI/Algorithm.h"
+#include "MantidAPI/MatrixWorkspace_fwd.h"
 #include "MantidAlgorithms/DllConfig.h"
 
 namespace Mantid {
@@ -32,6 +33,7 @@ public:
 private:
   void init() override;
   void exec() override;
+  double getPackingFraction(const API::MatrixWorkspace_const_sptr &ws);
 };
 
 } // namespace Algorithms

--- a/Framework/Algorithms/src/CalculatePlaczekSelfScattering.cpp
+++ b/Framework/Algorithms/src/CalculatePlaczekSelfScattering.cpp
@@ -13,6 +13,7 @@
 #include "MantidDataObjects/WorkspaceCreation.h"
 #include "MantidKernel/Atom.h"
 #include "MantidKernel/Material.h"
+#include "MantidKernel/PhysicalConstants.h"
 #include "MantidKernel/Unit.h"
 
 #include <utility>
@@ -20,28 +21,26 @@
 namespace Mantid {
 namespace Algorithms {
 
-std::map<std::string, std::map<std::string, double>> getSampleSpeciesInfo(const API::MatrixWorkspace_const_sptr &ws) {
-  // get sample information : mass, total scattering length, and concentration
-  // of each species
-  double totalStoich = 0.0;
-  std::map<std::string, std::map<std::string, double>> atomSpecies;
-  const Kernel::Material::ChemicalFormula formula = ws->sample().getMaterial().chemicalFormula();
-  const double xSection = ws->sample().getMaterial().totalScatterXSection();
-  const double bSqrdBar = xSection / (4.0 * M_PI);
+namespace { // anonymous namespace
 
-  for (const auto &element : formula) {
-    const std::map<std::string, double> atomMap{
-        {"mass", element.atom->mass}, {"stoich", element.multiplicity}, {"bSqrdBar", bSqrdBar}};
-    atomSpecies[element.atom->symbol] = atomMap;
-    totalStoich += element.multiplicity;
-  }
-  std::map<std::string, std::map<std::string, double>>::iterator atom = atomSpecies.begin();
-  while (atom != atomSpecies.end()) {
-    atom->second["concentration"] = atom->second["stoich"] / totalStoich;
-    ++atom;
-  }
-  return atomSpecies;
+// calculate summation term w/ neutron mass over molecular mass ratio
+double calculateSummationTerm(const Kernel::Material &material) {
+  // add together the weighted sum
+  const auto &formula = material.chemicalFormula();
+  auto sumLambda = [](double sum, auto &formula_unit) {
+    return sum + formula_unit.multiplicity * formula_unit.atom->neutron.tot_scatt_xs / formula_unit.atom->mass;
+  };
+  const double unnormalizedTerm = std::accumulate(formula.begin(), formula.end(), 0.0, sumLambda);
+
+  // neutron mass converted to atomic mass comes out of the sum
+  constexpr double neutronMass = PhysicalConstants::NeutronMass / PhysicalConstants::AtomicMassUnit;
+  // normalizing by totalStoich (number of atoms) comes out of the sum
+  const double totalStoich = material.totalAtoms();
+  // converting scattering cross section to scattering length square comes out of the sum
+  return neutronMass * unnormalizedTerm / (4. * M_PI * totalStoich);
 }
+
+} // anonymous namespace
 
 DECLARE_ALGORITHM(CalculatePlaczekSelfScattering)
 
@@ -76,34 +75,39 @@ std::map<std::string, std::string> CalculatePlaczekSelfScattering::validateInput
 }
 
 //----------------------------------------------------------------------------------------------
+double CalculatePlaczekSelfScattering::getPackingFraction(const API::MatrixWorkspace_const_sptr &ws) {
+  // get a handle to the material
+  const auto &material = ws->sample().getMaterial();
+
+  // default value is packing fraction
+  double packingFraction = material.packingFraction();
+
+  // see if the user thinks the material wasn't setup right
+  const double crystalDensity = getProperty("CrystalDensity");
+  if (crystalDensity > 0.) {
+    // assume that the number density set in the Material is the effective number density
+    packingFraction = material.numberDensity() / crystalDensity;
+  }
+
+  return packingFraction;
+}
+
+//----------------------------------------------------------------------------------------------
 /** Execute the algorithm.
  */
 void CalculatePlaczekSelfScattering::exec() {
   const API::MatrixWorkspace_sptr inWS = getProperty("InputWorkspace");
   const API::MatrixWorkspace_sptr incidentWS = getProperty("IncidentSpecta");
-  constexpr double factor = 1.0 / 1.66053906660e-27;       // atomic mass unit-kilogram relationship
-  constexpr double neutronMass = factor * 1.674927471e-27; // neutron mass
-  // get sample information : mass, total scattering length, and concentration
-  // of each species
-  auto atomSpecies = getSampleSpeciesInfo(inWS);
+
   // calculate summation term w/ neutron mass over molecular mass ratio
+  const double summationTerm = calculateSummationTerm(inWS->sample().getMaterial());
+  const double packingFraction = getPackingFraction(inWS);
 
-  auto sumLambda = [&neutronMass](double sum, auto &atom) {
-    return sum + atom.second["concentration"] * atom.second["bSqrdBar"] * neutronMass / atom.second["mass"];
-  };
-  double summationTerm = std::accumulate(atomSpecies.begin(), atomSpecies.end(), 0.0, sumLambda);
-
-  double numberDensity = inWS->sample().getMaterial().numberDensity();
-  double crystalDensity = getProperty("CrystalDensity");
-  double densityRatio = 1.0;
-  if (crystalDensity > 0) {
-    densityRatio = numberDensity / crystalDensity;
-  }
   // get incident spectrum and 1st derivative
   const MantidVec xLambda = incidentWS->readX(0);
   const MantidVec incident = incidentWS->readY(0);
   const MantidVec incidentPrime = incidentWS->readY(1);
-  double dx = (xLambda[1] - xLambda[0]) / 2.0;
+  const double dx = (xLambda[1] - xLambda[0]) / 2.0; // assume constant bin width
   std::vector<double> phi1;
   for (size_t i = 0; i < xLambda.size() - 1; i++) {
     phi1.emplace_back((xLambda[i] + dx) * incidentPrime[i] / incident[i]);
@@ -112,7 +116,7 @@ void CalculatePlaczekSelfScattering::exec() {
   std::vector<double> eps1;
   constexpr auto LambdaD = 1.44;
   for (size_t i = 0; i < xLambda.size() - 1; i++) {
-    auto xTerm = -(xLambda[i] + dx) / LambdaD;
+    const auto xTerm = -(xLambda[i] + dx) / LambdaD;
     eps1.emplace_back(xTerm * exp(xTerm) / (1.0 - exp(xTerm)));
   }
   /* Placzek
@@ -169,7 +173,7 @@ void CalculatePlaczekSelfScattering::exec() {
         const double inelasticPlaczekSelfCorrection =
             2.0 * (term1 + term2 - 3) * sinThetaBy2 * sinThetaBy2 * summationTerm;
         x[xIndex] = wavelength.singleToTOF(xLambda[xIndex]);
-        y[xIndex] = (1 + inelasticPlaczekSelfCorrection) * densityRatio;
+        y[xIndex] = (1 + inelasticPlaczekSelfCorrection) * packingFraction;
       }
       x.back() = wavelength.singleToTOF(xLambda.back());
     } else {

--- a/Framework/Kernel/inc/MantidKernel/Material.h
+++ b/Framework/Kernel/inc/MantidKernel/Material.h
@@ -93,6 +93,8 @@ public:
   double numberDensityEffective() const;
   /// Get the packing fraction
   double packingFraction() const;
+  /// The total number of atoms in the formula
+  double totalAtoms() const;
   /// Get the temperature
   double temperature() const;
   /// Get the pressure

--- a/Framework/Kernel/src/Material.cpp
+++ b/Framework/Kernel/src/Material.cpp
@@ -203,6 +203,13 @@ double Material::numberDensityEffective() const { return m_numberDensity * m_pac
 double Material::packingFraction() const { return m_packingFraction; }
 
 /**
+ * The total number of atoms in the chemical formula. This is commonly
+ * used to convert multiplicity into relative values.
+ * @return The total number of atoms
+ */
+double Material::totalAtoms() const { return m_atomTotal; }
+
+/**
  * Get the temperature
  * @returns The temperature of the material in Kelvin
  */

--- a/Framework/Kernel/test/MaterialTest.h
+++ b/Framework/Kernel/test/MaterialTest.h
@@ -63,6 +63,7 @@ public:
     TS_ASSERT_EQUALS(material.numberDensity(), numberDensity);
     TS_ASSERT_EQUALS(material.numberDensityEffective(), numberDensity);
     TS_ASSERT_EQUALS(material.packingFraction(), 1.);
+    TS_ASSERT_EQUALS(material.totalAtoms(), 1.)
     TS_ASSERT_EQUALS(material.temperature(), 300);
     TS_ASSERT_EQUALS(material.pressure(), Mantid::PhysicalConstants::StandardAtmosphere);
 
@@ -86,6 +87,7 @@ public:
     TS_ASSERT_EQUALS(material.numberDensity(), numberDensity);
     TS_ASSERT_EQUALS(material.numberDensityEffective(), numberDensity);
     TS_ASSERT_EQUALS(material.packingFraction(), 1.);
+    TS_ASSERT_EQUALS(material.totalAtoms(), 1.)
 
     // check everything with (default) reference wavelength
     checkMatching(material, atom);
@@ -104,6 +106,7 @@ public:
     TS_ASSERT_EQUALS(TiZr.numberDensity(), numberDensity);
     TS_ASSERT_EQUALS(TiZr.numberDensityEffective(), numberDensity * packingFraction);
     TS_ASSERT_EQUALS(TiZr.packingFraction(), packingFraction);
+    TS_ASSERT_DELTA(TiZr.totalAtoms(), 3.082605, 1.e-5); // string to double changes value
 
     TS_ASSERT_EQUALS(TiZr.cohScatterLengthImg(), 0.);
     TS_ASSERT_DELTA(TiZr.cohScatterLengthReal(), 0., 1.e-5);

--- a/Framework/PythonInterface/mantid/kernel/src/Exports/Material.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Exports/Material.cpp
@@ -73,6 +73,7 @@ void export_Material() {
                     "Packing fraction as a number, ideally, 0 to 1")
       .add_property("temperature", make_function(&Material::temperature), "Temperature")
       .add_property("pressure", make_function(&Material::pressure), "Pressure")
+      .add_property("totalAtoms", make_function(&Material::totalAtoms), "Total number of atoms")
 #if PY_MAJOR_VERSION >= 3
       .def("__bool__", &toBool, "Returns True if any of the scattering values are non-zero")
 #else

--- a/docs/source/release/v6.1.0/diffraction.rst
+++ b/docs/source/release/v6.1.0/diffraction.rst
@@ -56,6 +56,7 @@ Bugfixes
 - Fix the format inconsistency (with data saved from autoreduction workflow) issue for saving GSAS data using :ref:`HB2AReduce <algm-HB2AReduce>` - both are now using :ref:`SaveGSSCW <algm-SaveGSSCW>` for saving GSAS data.
 - Fix out-of-range bug in :ref:`FitPeaks <algm-FitPeaks>` for histogram data.
 - Fix bug in :ref:`FitPeaks <algm-FitPeaks>` not correctly checking right window for an individual peak.
+- Fix :ref:`CalculatePlaczekSelfScattering <algm-CalculatePlaczekSelfScattering>` calculation of mass term for multiple-element materials
 - Fix bug to implement intended sequential fit of DIFC, DIFA, TZERO in :ref:`PDCalibration <algm-PDCalibration>`.
 - Correct unit to TOF for ``_tof_xye`` files output for PEARL, when the focusing mode is set to *all*.
 - Allow a different number of spectra for absorption correction division of PEARL data. This allows ``create_vanadium`` to work for a non-standard dataset.

--- a/docs/source/release/v6.1.0/framework.rst
+++ b/docs/source/release/v6.1.0/framework.rst
@@ -28,6 +28,7 @@ New Features
 Improvements
 ############
 
+- :py:obj:`mantid.kernel.Material` has a new attribute ``totalAtoms`` to aid in converting atom multiplicity to concentration
 - :ref:`LoadNexusLogs <algm-LoadNexusLogs>` has additional parameters to allow or block specific logs from being loaded.
 - :ref:`LoadEventNexus <algm-LoadEventNexus>` now utilizes the log filter provided by `LoadNexusLogs <algm-LoadNexusLogs>`.
 - :ref:`CompareWorkspaces <algm-CompareWorkspaces>` now compares the positions of both source and sample (if extant) when property `checkInstrument` is set.


### PR DESCRIPTION
Refactor code to use more of the `Kernel::Material` class and fix a bug in calculate the summation term. This also added the function `Kernel::Material::totalAtoms()` as it is a reoccurring theme in many calculations involving material.

**To test:**

The tests should still pass as this is just a refactor of existing code.

*There is no associated issue.*


The version into `ornl-next` is #32225.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
