### PR TITLE
Bump Sphinx to 1.8.5 on MSVC

### DIFF
--- a/buildconfig/CMake/Bootstrap.cmake
+++ b/buildconfig/CMake/Bootstrap.cmake
@@ -15,7 +15,7 @@ if(MSVC AND NOT CONDA_BUILD)
   set(THIRD_PARTY_GIT_URL
       "https://github.com/mantidproject/thirdparty-msvc2015.git"
   )
-  set(THIRD_PARTY_GIT_SHA1 9cef05cc24a447b760ec2d3f289315514fc264ab)
+  set(THIRD_PARTY_GIT_SHA1 1f44d901442239ae12c11e33187b3d877bb9f2b2)
   set(THIRD_PARTY_DIR ${EXTERNAL_ROOT}/src/ThirdParty)
   # Generates a script to do the clone/update in tmp
   set(_project_name ThirdParty)

--- a/buildconfig/CMake/Bootstrap.cmake
+++ b/buildconfig/CMake/Bootstrap.cmake
@@ -15,7 +15,7 @@ if(MSVC AND NOT CONDA_BUILD)
   set(THIRD_PARTY_GIT_URL
       "https://github.com/mantidproject/thirdparty-msvc2015.git"
   )
-  set(THIRD_PARTY_GIT_SHA1 0a4c81cb2a6809125867022d2d5320c22075a0c6)
+  set(THIRD_PARTY_GIT_SHA1 9cef05cc24a447b760ec2d3f289315514fc264ab)
   set(THIRD_PARTY_DIR ${EXTERNAL_ROOT}/src/ThirdParty)
   # Generates a script to do the clone/update in tmp
   set(_project_name ThirdParty)

--- a/dev-docs/source/conf.py
+++ b/dev-docs/source/conf.py
@@ -11,16 +11,10 @@ from distutils.version import LooseVersion
 
 
 # -- General configuration ------------------------------------------------
-
-if LooseVersion(sphinx_version) > LooseVersion("1.6"):
-    def setup(app):
-        """Called automatically by Sphinx when starting the build process
-        """
-        # Add support for multiple Sphinx versions
-        if hasattr(app, "add_css_file"):
-            app.add_css_file("custom.css")
-        else:
-            app.add_stylesheet("custom.css")
+def setup(app):
+    """Called automatically by Sphinx when starting the build process
+    """
+    app.add_stylesheet("custom.css")
 
 
 # Add any Sphinx extension module names here, as strings. They can be

--- a/dev-docs/source/conf.py
+++ b/dev-docs/source/conf.py
@@ -14,7 +14,7 @@ from distutils.version import LooseVersion
 def setup(app):
     """Called automatically by Sphinx when starting the build process
     """
-    app.add_stylesheet("custom.css")
+    app.add_css_file("custom.css")
 
 
 # Add any Sphinx extension module names here, as strings. They can be


### PR DESCRIPTION
**Description of work.**
Bumps MSVC to use Sphinx 1.8.5 (matching Ubuntu 18.04). This allows us
to build dev-docs with warnings enabled on both platforms.

RHEL is the odd one out now, but as we have (comparitvely) few
developers on RHEL and this only affects dev docs we can cross that
bridge when Conda is complete

**To test:**
On Windows:
- Build dev-docs-html
- Build docs-html
<!-- Instructions for testing. -->

Pre-requisite of #32222 

Accompanying PR: https://github.com/mantidproject/thirdparty-msvc2015/pull/64

*This does not require release notes* because it's an internal change not visible to users.

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
