### PR TITLE
Add check to convert PropertyManager value directly to pointer

### DIFF
--- a/Framework/PythonInterface/mantid/utils/absorptioncorrutils.py
+++ b/Framework/PythonInterface/mantid/utils/absorptioncorrutils.py
@@ -311,7 +311,10 @@ def calculate_absorption_correction(
     if number_density != Property.EMPTY_DBL:
         material["SampleNumberDensity"] = number_density
 
-    environment = {'Name': 'InAir', 'Container': container_shape}
+    environment = {}
+    if container_shape:
+        environment['Name'] = 'InAir'
+        environment['Container'] = container_shape
 
     donorWS = create_absorption_input(filename,
                                       props,

--- a/Framework/PythonInterface/plugins/algorithms/SetSampleFromLogs.py
+++ b/Framework/PythonInterface/plugins/algorithms/SetSampleFromLogs.py
@@ -6,21 +6,10 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 from mantid.api import (AlgorithmFactory, DistributedDataProcessorAlgorithm)
 from mantid.kernel import (ConfigService)
-from mantid import _kernel as mtd_kernel
 from mantid.simpleapi import (SetSample)
 
 
 PROPS_FOR_SETSAMPLE = ["InputWorkspace", "Geometry", "Material", "Environment", "ContainerGeometry", "ContainerMaterial"]
-
-
-def _toDict(propertyManager):
-    result = {}
-    if propertyManager:
-        for key in propertyManager.keys():
-            result[key] = propertyManager[key].value
-            if isinstance(result[key], mtd_kernel.std_vector_dbl):
-                result[key] = list(result[key])
-    return result
 
 
 def _findKey(dictlike, *args):
@@ -65,7 +54,7 @@ class SetSampleFromLogs(DistributedDataProcessorAlgorithm):
     def _createMaterial(self, runObject):
         '''Create the sample material by combining the supplied material information with things found in the logs'''
         # grab the starting information from the algorithm property
-        material = _toDict(self.getProperty("Material").value)
+        material = self.getProperty("Material").value
         # only look in the logs if the user asks for it
         if self.getProperty("FindSample").value:  # SetSample calls it the material
             if (not _hasValue(material, 'ChemicalFormula')) and _hasValue(runObject, "SampleFormula"):
@@ -86,7 +75,7 @@ class SetSampleFromLogs(DistributedDataProcessorAlgorithm):
     def _createGeometry(self, runObject, instrEnum):
         # get height of sample from the logs
         # this assumes the shape has a "Height" property
-        geometry = _toDict(self.getProperty("Geometry").value)
+        geometry = self.getProperty("Geometry").value
 
         if self.getProperty("FindGeometry").value:
             if not _hasValue(geometry, "Height"):
@@ -142,7 +131,7 @@ class SetSampleFromLogs(DistributedDataProcessorAlgorithm):
     def _createEnvironment(self, runObject, instrEnum):
         '''Create the sample material by combining the supplied environment information with things found in the logs'''
         # grab the starting information from the algorithm property
-        environment = _toDict(self.getProperty("Environment").value)
+        environment = self.getProperty("Environment").value
         # get the container from the logs
         if self.getProperty("FindEnvironment").value:
             if (not _hasValue(environment, "Container")) and _hasValue(runObject, "SampleContainer"):
@@ -160,8 +149,8 @@ class SetSampleFromLogs(DistributedDataProcessorAlgorithm):
     def PyExec(self):
         wksp = self.getProperty("InputWorkspace").value
         # these items are not grabbed from the logs
-        geometryContainer = _toDict(self.getProperty("ContainerGeometry").value)
-        materialContainer = _toDict(self.getProperty("ContainerMaterial").value)
+        geometryContainer = self.getProperty("ContainerGeometry").value
+        materialContainer = self.getProperty("ContainerMaterial").value
 
         # get a convenient handle to the logs
         runObject = wksp.run()

--- a/Framework/PythonInterface/test/python/mantid/kernel/PropertyManagerPropertyTest.py
+++ b/Framework/PythonInterface/test/python/mantid/kernel/PropertyManagerPropertyTest.py
@@ -83,15 +83,17 @@ class PropertyManagerPropertyTest(unittest.TestCase):
         self.assertTrue('J' in nested_l2_pmgr)
         self.assertEqual(120.6, nested_l2_pmgr['J'].value)
 
+    def test_set_property_on_algorithm_property_manager(self):
+        # set the property directly from a PropertyManager
+        fake = FakeAlgorithm()
+        fake.initialize()
+        fake.setProperty("Args", PropertyManager())
+
     def test_that_empty_sequence_in_property_manager_raises(self):
         fake = FakeAlgorithm()
         fake.initialize()
-        try:
+        with self.assertRaises(RuntimeError):
             fake.setProperty("Args", {'A': []})
-            has_raised = False
-        except RuntimeError:
-            has_raised = True
-        self.assertTrue(has_raised)
 
     def test_create_with_dictionary_as_default_value(self):
         default = { 'A' : {}, 'B' : 1 }


### PR DESCRIPTION
It was discovered while writing `SetSampleFromLogs` that a `PropertyManager` could not be directly used from python as a property value. This adds a check for the conversion and removes unnecessary code from the algorithm.

**To test:**

See that `SetSampleFromLogs` now works without forceably converting the values.

*There is no associated issue.*

*This does not require release notes* because it is an expansion of supported types in the API.

The version into `ornl-next` is #32237.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
