### PR TITLE
Fix bug when trying to get distribution flag in MD Workspaces

### DIFF
--- a/Framework/PythonInterface/mantid/plots/mantidaxes.py
+++ b/Framework/PythonInterface/mantid/plots/mantidaxes.py
@@ -666,7 +666,8 @@ class MantidAxes(Axes):
             workspace = args[0]
             spec_num = self.get_spec_number_or_bin(workspace, kwargs)
             normalize_by_bin_width, kwargs = get_normalize_by_bin_width(workspace, self, **kwargs)
-            is_normalized = normalize_by_bin_width or workspace.isDistribution()
+            is_normalized = normalize_by_bin_width or \
+                            (hasattr(workspace, 'isDistribution') and workspace.isDistribution())
 
             with autoscale_on_update(self, autoscale_on):
                 artist = self.track_workspace_artist(workspace,
@@ -786,7 +787,8 @@ class MantidAxes(Axes):
             workspace = args[0]
             spec_num = self.get_spec_number_or_bin(workspace, kwargs)
             normalize_by_bin_width, kwargs = get_normalize_by_bin_width(workspace, self, **kwargs)
-            is_normalized = normalize_by_bin_width or workspace.isDistribution()
+            is_normalized = normalize_by_bin_width or \
+                            (hasattr(workspace, 'isDistribution') and workspace.isDistribution())
 
             with autoscale_on_update(self, autoscale_on):
                 artist = self.track_workspace_artist(workspace,

--- a/docs/source/release/v6.2.0/framework.rst
+++ b/docs/source/release/v6.2.0/framework.rst
@@ -58,6 +58,10 @@ Python
     putting new features at the top of the section, followed by
     improvements, followed by bug fixes.
 
+Bugfixes
+########
+- Fix a bug (crash) in plotting MD workspaces when "Normalize to bin width" is set to False
+
 Installation
 ------------
 


### PR DESCRIPTION
**Description of work.**
When setting the preference "Normalize to bin width" to False, one gets crashes when plotting MD Workspaces

**To test:**

<!-- Instructions for testing. -->
Create a one dimensional MDWorkspace, or have an existing workspace where you want to plot the sample logs:

```python
S  =range(0,10)
ws=CreateMDHistoWorkspace(Dimensionality=1,Extents='-3,3', SignalInput=S, ErrorInput=S, NumberOfBins=10, Names='A', Units='EnergyTransfer')
```
Go to File->Settings, and in the Plots tab uncheck the "Normalize to bin width ...". Right click and plot the workspace. Make sure it does not crash the workbench.

*There is no associated issue.*

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
