### PR TITLE
Increase logger to warning in CompareWorkspaces mismatch

### DIFF
--- a/Framework/Algorithms/src/CompareWorkspaces.cpp
+++ b/Framework/Algorithms/src/CompareWorkspaces.cpp
@@ -174,7 +174,7 @@ void CompareWorkspaces::exec() {
 
   if (!m_result) {
     std::string message = m_messages->cell<std::string>(0, 0);
-    g_log.notice() << "The workspaces did not match: " << message << '\n';
+    g_log.warning() << "The workspaces did not match: " << message << '\n';
   } else {
     std::string ws1 = Workspace_const_sptr(getProperty("Workspace1"))->getName();
     std::string ws2 = Workspace_const_sptr(getProperty("Workspace2"))->getName();


### PR DESCRIPTION
**Description of work.**
Increases the visibility of the warning in CompareWorkspaces. Many hours
were lost debugging as it's easy to spot "CompareWorkspaces was
successful" rather than the mismatch notice both at notice level.

**To test:**
Run the following and check the mismatch error is obvious
```python
from mantid.simpleapi import *

ws1 = CreateSampleWorkspace(Random=True)
ws2 = CreateSampleWorkspace(Random=False)
CompareWorkspaces(ws1, ws2)
```

*There is no associated issue.*


*This does not require release notes* because it's a very minor change which does not affect functionality beyond changing the "log colour"

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
