### PR TITLE
FitBrowser: Do not reset FWHM if it is > X range. Just log a warning

### DIFF
--- a/qt/python/mantidqt/widgets/fitpropertybrowser/fitpropertybrowser.py
+++ b/qt/python/mantidqt/widgets/fitpropertybrowser/fitpropertybrowser.py
@@ -458,8 +458,7 @@ class FitPropertyBrowser(FitPropertyBrowserBase):
             c, h, w = self.getPeakCentreOf(prefix), self.getPeakHeightOf(
                 prefix), self.getPeakFwhmOf(prefix)
             if w > (self.endX() - self.startX()):
-                w = (self.endX() - self.startX()) / 20.
-                self.setPeakFwhmOf(prefix, w)
+                logger.warning("Peak FWHM > X range. Width markers will not be shown")
             if prefix in peaks:
                 self.tool.update_peak(peaks[prefix], c, h, w)
                 del peaks[prefix]


### PR DESCRIPTION
**Description of work.**

#28700 introduced a change to reset the FWHM if a new function is added for the case where the FWHM > x range of the plots. This reset happens in a way that doesn't satisfy the ties and causes confusion with the parameter values.

I have removed the resetting and simply logged a warning that the width markers for the peak are not visible.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**

* Run through the instructions in #31738 and confirm the peak centre and sigma are tied
* Run through the instructions in #28700 to check there is no regression.

I tried to add a unit test for the behaviour but the widget is complicated to set up with the plot interaction and much would have to be mocked making the test slightly useless.

Fixes #31738 

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
