### PR TITLE
Fix problem determining bounding box of beam

### DIFF
--- a/Framework/Algorithms/inc/MantidAlgorithms/MonteCarloAbsorption.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/MonteCarloAbsorption.h
@@ -61,6 +61,8 @@ protected:
                                                                  const size_t wavelengthPoints, const size_t rows,
                                                                  const size_t columns);
   virtual std::unique_ptr<InterpolationOption> createInterpolateOption();
+  std::unique_ptr<IBeamProfile> createBeamProfile(const Geometry::Instrument &instrument,
+                                                  const Geometry::IObject &sample) const;
 
 private:
   void init() override;
@@ -73,8 +75,6 @@ private:
                                          const size_t maxScatterPtAttempts,
                                          const MCInteractionVolume::ScatteringPointVicinity pointsIn);
   API::MatrixWorkspace_uptr createOutputWorkspace(const API::MatrixWorkspace &inputWS) const;
-  std::unique_ptr<IBeamProfile> createBeamProfile(const Geometry::Instrument &instrument,
-                                                  const API::Sample &sample) const;
   void interpolateFromSparse(API::MatrixWorkspace &targetWS, const SparseWorkspace &sparseWS,
                              const Mantid::Algorithms::InterpolationOption &interpOpt);
 };

--- a/Framework/Algorithms/inc/MantidAlgorithms/SampleCorrections/RectangularBeamProfile.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/SampleCorrections/RectangularBeamProfile.h
@@ -30,6 +30,15 @@ public:
   IBeamProfile::Ray generatePoint(Kernel::PseudoRandomNumberGenerator &rng,
                                   const Geometry::BoundingBox &bounds) const override;
   Geometry::BoundingBox defineActiveRegion(const Geometry::BoundingBox &) const override;
+  /// Returns the min point of the profile
+  inline Kernel::V3D minPoint() const { return Kernel::V3D{m_min[0], m_min[1], m_min[2]}; }
+  /// Returns the max point of the profile
+  inline Kernel::V3D maxPoint() const {
+    auto maxPt = Kernel::V3D{m_min[0], m_min[1], m_min[2]};
+    maxPt[m_horIdx] += m_width;
+    maxPt[m_upIdx] += m_height;
+    return maxPt;
+  }
 
 private:
   const unsigned short m_upIdx;

--- a/Framework/Algorithms/inc/MantidAlgorithms/SampleCorrections/RectangularBeamProfile.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/SampleCorrections/RectangularBeamProfile.h
@@ -34,7 +34,7 @@ public:
   inline Kernel::V3D minPoint() const { return Kernel::V3D{m_min[0], m_min[1], m_min[2]}; }
   /// Returns the max point of the profile
   inline Kernel::V3D maxPoint() const {
-    auto maxPt = Kernel::V3D{m_min[0], m_min[1], m_min[2]};
+    auto maxPt = minPoint();
     maxPt[m_horIdx] += m_width;
     maxPt[m_upIdx] += m_height;
     return maxPt;
@@ -46,7 +46,7 @@ private:
   const unsigned short m_horIdx;
   const double m_width;
   const double m_height;
-  std::array<double, 3> m_min;
+  /*std::array<double, 3>*/ Kernel::V3D m_min;
   Kernel::V3D m_beamDir;
 };
 

--- a/Framework/Algorithms/src/MonteCarloAbsorption.cpp
+++ b/Framework/Algorithms/src/MonteCarloAbsorption.cpp
@@ -308,7 +308,7 @@ MatrixWorkspace_uptr MonteCarloAbsorption::doSimulation(const MatrixWorkspace &i
   const auto nhists = static_cast<int64_t>(instrumentWS.getNumberHistograms());
 
   EFixedProvider efixed(instrumentWS);
-  auto beamProfile = createBeamProfile(*instrument, inputWS.sample());
+  auto beamProfile = createBeamProfile(*instrument, inputWS.sample().getShape());
 
   // Configure progress
   Progress prog(this, 0.0, 1.0, nhists);
@@ -417,7 +417,7 @@ MatrixWorkspace_uptr MonteCarloAbsorption::createOutputWorkspace(const MatrixWor
  * @return A new IBeamProfile object
  */
 std::unique_ptr<IBeamProfile> MonteCarloAbsorption::createBeamProfile(const Instrument &instrument,
-                                                                      const Sample &sample) const {
+                                                                      const IObject &sample) const {
   const auto frame = instrument.getReferenceFrame();
   const auto source = instrument.getSource();
   double beamWidth(-1.0), beamHeight(-1.0), beamRadius(-1.0);
@@ -438,11 +438,12 @@ std::unique_ptr<IBeamProfile> MonteCarloAbsorption::createBeamProfile(const Inst
       return std::make_unique<CircularBeamProfile>(*frame, source->getPos(), beamRadius);
     }
   } // revert to sample dimensions if no return by this point
-  if (!sample.getShape().hasValidShape())
+  if (!sample.hasValidShape())
     throw std::invalid_argument("Cannot determine beam profile without a sample shape");
-  const auto bbox = sample.getShape().getBoundingBox().width();
-  beamWidth = bbox[frame->pointingHorizontal()];
-  beamHeight = bbox[frame->pointingUp()];
+  const auto bbox = sample.getBoundingBox().width();
+  const auto bboxCentre = sample.getBoundingBox().centrePoint();
+  beamWidth = 2 * bboxCentre[frame->pointingHorizontal()] + bbox[frame->pointingHorizontal()];
+  beamHeight = 2 * bboxCentre[frame->pointingUp()] + bbox[frame->pointingUp()];
   return std::make_unique<RectangularBeamProfile>(*frame, source->getPos(), beamWidth, beamHeight);
 }
 

--- a/docs/source/release/v6.2.0/framework.rst
+++ b/docs/source/release/v6.2.0/framework.rst
@@ -33,6 +33,7 @@ Bugfixes
 - Fix crash when running :ref:`IntegrateEPP <algm-IntegrateEPP>` on a workspace group via the algorithm dialog.
 - Fixed bug in :ref:`FitGaussianPeaks <algm-FitGaussianPeaks>` algorithm in which a peak at the end of range would cause an error due to not enough data point being available to fit parameters
 - Fixed bug where :ref:`LoadRaw <algm-LoadRaw>` would not load all log files for raw files with an alternate data stream.
+- Fix problem calculating default beam size in :ref:`MonteCarloAbsorption <algm-MonteCarloAbsorption>` when sample is offset from origin
 
 Fit Functions
 -------------


### PR DESCRIPTION
**Description of work.**

When run with a sample that is offset from the origin, the calculation of the beam height and width could result in a beam that didn't overlap with the sample. This caused an error when running the MonteCarloAbsorption algorithm

Have added unit test to cover this scenario and have modified the RectangularBeamProfile
class to expose the min\max points on the beam profile to support this

**To test:**

Run script on attached issue and check it completes without an error

Fixes #32236.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
