### PR TITLE
FDA Sequential tab - Filter By error when no data to select

### DIFF
--- a/scripts/Muon/GUI/Common/fitting_widgets/basic_fitting/basic_fitting_model.py
+++ b/scripts/Muon/GUI/Common/fitting_widgets/basic_fitting/basic_fitting_model.py
@@ -839,7 +839,10 @@ class BasicFittingModel:
             return (dataset_names, *corresponding_dataset_args)
 
         # Filter the data based on a name in the dataset_names containing a string
-        return zip(*filter(lambda x: display_type in x[0], zip(dataset_names, *corresponding_dataset_args)))
+        filtered_data = list(zip(*filter(lambda x: display_type in x[0], zip(dataset_names, *corresponding_dataset_args))))
+
+        # Return a tuple of empty lists if the filtered data is empty
+        return tuple(filtered_data) if len(filtered_data) != 0 else ([] for _ in range(len(corresponding_dataset_args) + 1))
 
     def get_all_fit_function_parameter_values_for(self, fit_function: IFunction) -> list:
         """Returns the values of the fit function parameters."""

--- a/scripts/Muon/GUI/Common/seq_fitting_tab_widget/seq_fitting_tab_presenter.py
+++ b/scripts/Muon/GUI/Common/seq_fitting_tab_widget/seq_fitting_tab_presenter.py
@@ -41,7 +41,7 @@ class SeqFittingTabPresenter(object):
         self.disable_tab_observer = GenericObserver(lambda: self.view.
                                                     setEnabled(False))
         self.enable_tab_observer = GenericObserver(lambda: self.view.
-                                                   setEnabled(True))
+                                                   setEnabled(self.model.number_of_datasets > 0))
 
     def create_thread(self, callback):
         self.fitting_calculation_model = ThreadModelWrapperWithOutput(callback)

--- a/scripts/test/Muon/fitting_widgets/basic_fitting/basic_fitting_model_test.py
+++ b/scripts/test/Muon/fitting_widgets/basic_fitting/basic_fitting_model_test.py
@@ -693,6 +693,17 @@ class BasicFittingModelTest(unittest.TestCase):
         self.assertEqual(list(runs), ["20884"])
         self.assertEqual(list(groups_and_pairs), ["fwd"])
 
+    def test_that_get_runs_groups_and_pairs_for_fits_will_return_a_tuple_of_empty_lists_when_all_data_is_filtered_out(self):
+        self.mock_context_instrument = mock.PropertyMock(return_value="EMU")
+        type(self.model.context.data_context).instrument = self.mock_context_instrument
+
+        self.model.dataset_names = self.dataset_names
+
+        workspace_names, runs, groups_and_pairs = self.model.get_runs_groups_and_pairs_for_fits("Non-matching string")
+        self.assertEqual(list(workspace_names), [])
+        self.assertEqual(list(runs), [])
+        self.assertEqual(list(groups_and_pairs), [])
+
     def test_that_get_all_fit_functions_for_will_get_all_the_fit_functions_when_the_display_type_is_all(self):
         self.model.dataset_names = self.dataset_names
         self.model.single_fit_functions = self.single_fit_functions

--- a/scripts/test/Muon/seq_fitting_tab_widget/seq_fitting_tab_presenter_test.py
+++ b/scripts/test/Muon/seq_fitting_tab_widget/seq_fitting_tab_presenter_test.py
@@ -228,13 +228,29 @@ class SeqFittingTabPresenterTest(unittest.TestCase):
         disable_notifier.notify_subscribers()
         self.view.setEnabled.assert_called_once_with(False)
 
-    def test_that_enable_observer_calls_on_view_when_triggered(self):
+    def test_that_enable_observer_will_enable_the_view_when_there_is_one_of_more_datasets(self):
+        mock_model_number_of_datasets = mock.PropertyMock(return_value=1)
+        type(self.model).number_of_datasets = mock_model_number_of_datasets
+
         enable_notifier = GenericObservable()
         enable_notifier.add_subscriber(self.presenter.enable_tab_observer)
         self.view.setEnabled = mock.MagicMock()
 
         enable_notifier.notify_subscribers()
+        mock_model_number_of_datasets.assert_called_once_with()
         self.view.setEnabled.assert_called_once_with(True)
+
+    def test_that_enable_observer_will_disable_the_view_when_there_is_zero_datasets(self):
+        mock_model_number_of_datasets = mock.PropertyMock(return_value=0)
+        type(self.model).number_of_datasets = mock_model_number_of_datasets
+
+        enable_notifier = GenericObservable()
+        enable_notifier.add_subscriber(self.presenter.enable_tab_observer)
+        self.view.setEnabled = mock.MagicMock()
+
+        enable_notifier.notify_subscribers()
+        mock_model_number_of_datasets.assert_called_once_with()
+        self.view.setEnabled.assert_called_once_with(False)
 
     def test_handle_updated_fit_parameter_in_table_without_copying_fit_param(self):
         workspaces = ["EMU20884; Group; fwd; Asymmetry"]


### PR DESCRIPTION
**Description of work.**
This PR fixes a bug on the FDA sequential fitting tab where changing the Filter By option would cause an exception. Two changes have been made:
- A tuple of empty lists is now returned when the filtered data is empty
- The tab is only enabled if datasets exist in the fitting tab

**To test:**
See the issue for testing instructions

Fixes #32249

*This does not require release notes* because **the filter by feature did not exist in the previous mantid version**

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
