### PR TITLE
Allow norm and group name in results tab of muon GUI

### DIFF
--- a/docs/source/release/v6.2.0/muon.rst
+++ b/docs/source/release/v6.2.0/muon.rst
@@ -41,6 +41,7 @@ Improvements
 ############
 
 - When running the Dynamic Kubo Toyabe fit function you should now be able to see the BinWidth to 3 decimal places.
+- Can now select the normalisation (``analysis_asymmetry_norm``) and group (``analysis_group``) in the results table tab.
 
 Bug Fixes
 #########

--- a/scripts/Muon/GUI/Common/results_tab_widget/results_tab_model.py
+++ b/scripts/Muon/GUI/Common/results_tab_widget/results_tab_model.py
@@ -12,7 +12,8 @@ from enum import Enum
 # Constants
 DEFAULT_TABLE_NAME = 'ResultsTable'
 ALLOWED_NON_TIME_SERIES_LOGS = ("run_number", "run_start", "run_end", "group",
-                                "period", "sample_temp", "sample_magn_field")
+                                "period", "sample_temp", "sample_magn_field",
+                                "analysis_asymmetry_norm", "analysis_group_name")
 ERROR_COL_SUFFIX = 'Error'
 # This is not a particularly robust way of ignoring this as it
 # depends on how Fit chooses to output the name of that value


### PR DESCRIPTION
**Description of work.**
This allows the user to select the norm and group as part of the results tab.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**
Open Muon Analysis
Load MUSR 62260
Do a fit
Go to the results tab
You should be able to select "analysis_asymmetry_norm" and "analysis_group"
Check they look good in the modelling tab

<!-- Instructions for testing. -->

Fixes #31381

This also Fixes #31348, as it gives the only other parameter of interest from the fit


<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
