### PR TITLE
Fix flaky NOMAD test

### DIFF
--- a/Testing/SystemTests/tests/framework/NOMADTest.py
+++ b/Testing/SystemTests/tests/framework/NOMADTest.py
@@ -8,7 +8,6 @@
 # package imports
 import systemtesting
 from mantid.simpleapi import CompareWorkspaces, LoadMask, LoadNexusProcessed, NOMADMedianDetectorTest
-from mantid.api import AnalysisDataService
 
 # standard imports
 import tempfile
@@ -18,9 +17,6 @@ class MedianDetectorTestTest(systemtesting.MantidSystemTest):
 
     def requiredFiles(self):
         return ['NOM_144974_SingleBin.nxs', 'NOMAD_mask_gen_config.yml', 'NOM_144974_mask.xml']
-
-    def tearDownClass(cls) -> None:
-        AnalysisDataService.Instance().clear()
 
     def runTest(self):
         with tempfile.NamedTemporaryFile(suffix='.xml') as xml_handle, \
@@ -37,11 +33,11 @@ class MedianDetectorTestTest(systemtesting.MantidSystemTest):
             self.loaded_ws = LoadMask(Instrument='NOMAD',
                                       InputFile=file_xml_mask,
                                       RefWorkspace='NOM_144974',
-                                      OutputWorkspace="mask_test")
+                                      StoreInADS=False)
 
     def validate(self):
         ref = LoadMask(Instrument='NOMAD',
                        InputFile="NOM_144974_mask.xml",
                        RefWorkspace='NOM_144974',
-                       OutputWorkspace="reference")
+                       StoreInADS=False)
         return CompareWorkspaces(Workspace1=self.loaded_ws, Workspace2=ref, CheckMasking=True).Result


### PR DESCRIPTION
**Description of work.**
Windows was failing with an OS error if the file was locked.
Fixes possible causes for a flakey NOMAD test pre-emptively:

- Use context manager as NamedTempFile will do a better job cleaning up
than us
- Clear the ADS after we finish
- Use pointers to workspaces instead of hard-coded names
- Use validate in the system test instead of assertTrue, as per other
system tests

Edit: this was caused by Python trying to be helpful and provide an handle to the open file

**To test:**
Run the following a few times. I suspect it was the anti-virus locking the file so it's hard to truly replicate 
- `systemtest.bat -C <build_type> -R NOMAD`

There is no associated issue. - Fixes a flaky test

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
