### PR TITLE
Fix muon GUI phasequad bug

### DIFF
--- a/scripts/Muon/GUI/Common/phase_table_widget/phase_table_presenter.py
+++ b/scripts/Muon/GUI/Common/phase_table_widget/phase_table_presenter.py
@@ -246,7 +246,7 @@ class PhaseTablePresenter(object):
     def calculate_phasequad(self):
         self.context.group_pair_context.add_phasequad(self._phasequad_obj)
         self.context.calculate_phasequads(
-            self._phasequad_obj.name, self._phasequad_obj)
+             self._phasequad_obj)
 
         self.phasequad_calculation_complete_notifier.notify_subscribers(
             self._phasequad_obj.Re.name)

--- a/scripts/test/Muon/phase_table_widget/phase_table_presenter_test.py
+++ b/scripts/test/Muon/phase_table_widget/phase_table_presenter_test.py
@@ -350,6 +350,21 @@ class PhaseTablePresenterTest(unittest.TestCase):
         self.presenter.add_phasequad_to_analysis.assert_any_call(False, False, phasequad_2)
         self.assertEqual(2, self.presenter.calculation_finished_notifier.notify_subscribers.call_count)
 
+    def test_calculate_phasequad(self):
+        self.presenter.phasequad_calculation_complete_notifier = mock.Mock()
+        self.presenter.phasequad_calculation_complete_notifier.notify_subscribers = mock.Mock()
+        self.context.group_pair_context.add_phasequad = mock.Mock()
+        self.context.calculate_phasequads = mock.Mock()
+        phasequad = MuonPhasequad("test", "table")
+        self.presenter._phasequad_obj = phasequad
+
+        self.presenter.calculate_phasequad()
+        self.context.group_pair_context.add_phasequad.assert_called_once_with(phasequad)
+        self.context.calculate_phasequads.assert_called_once_with(phasequad)
+        self.presenter.phasequad_calculation_complete_notifier.notify_subscribers.assert_any_call(phasequad.Re.name)
+        self.presenter.phasequad_calculation_complete_notifier.notify_subscribers.assert_any_call(phasequad.Im.name)
+        self.assertEqual(self.presenter.phasequad_calculation_complete_notifier.notify_subscribers.call_count, 2)
+
 
 if __name__ == '__main__':
     unittest.main(buffer=False, verbosity=2)


### PR DESCRIPTION
**Description of work.**
The phasequad calculation in the muon GUI was failing and producing an error message. This PR fixes it and adds a test.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**

<!-- Instructions for testing. -->
Open muon analysis
Load MUSR 62260
Go to the phase table tab
Click calculate Phase table (the name you give it is not important)
Click the small `+` below the second table
Enter a phasequad name (again the name is not important) - master throws an error here
A row will appear in the second table and 2 new lines on the plot (so 6 lines in total) 


Fixes #32321. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->
It is not in the release notes as we have added this bug this release 
<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
