### PR TITLE
Handle OSError from parsing hdf tree

### DIFF
--- a/scripts/SANS/sans/gui_logic/presenter/run_tab_presenter.py
+++ b/scripts/SANS/sans/gui_logic/presenter/run_tab_presenter.py
@@ -485,7 +485,7 @@ class RunTabPresenter(PresenterCommon):
         for row in self._table_model.get_non_empty_rows():
             try:
                 file_info = row.file_information
-            except (ValueError, RuntimeError):
+            except (ValueError, RuntimeError, OSError):
                 pass
 
         if self._file_information != file_info:

--- a/scripts/test/SANS/gui_logic/test_run_tab_presenter.py
+++ b/scripts/test/SANS/gui_logic/test_run_tab_presenter.py
@@ -170,6 +170,15 @@ class RunTabPresenterTest(unittest.TestCase):
 
         self.assertIsNone(self.presenter.on_user_file_load())
 
+    def test_file_information_exceptions_handled(self):
+        for e in [ValueError, RuntimeError, OSError]:
+            mocked_row = mock.Mock()
+            type(mocked_row).file_information = mock.PropertyMock(side_effect=e)
+            exception_rows = [mocked_row, mocked_row]
+            self._mock_table.get_non_empty_rows = mock.Mock(return_value=exception_rows)
+
+            self.presenter.on_update_rows()  # should not throw
+
     def test_that_gets_states_from_view(self):
         # Arrange
         batch_file_path, user_file_path, _ = self._get_files_and_mock_presenter(BATCH_FILE_TEST_CONTENT_2)


### PR DESCRIPTION
**Description of work.**
If we try to open a "nxs" file which does not contain the attributes
expected hdf5 will throw an OSError. This was not being caught by the
presenter causing an uncaught exception.

Fixes #32310

**To test:**
- Using a text editor / `touch` create a blank file called `1.nxs` 
- Make sure the folder with this file is in the manage user directories
- Open ISIS SANS GUI
- Ensure you have the ISIS Training Data / loqdemo folder
- Load either the .toml or .txt as the mask file
- In the first row and column enter `1` then click elsewhere, this previously crashed
- Click process all, the row should turn blue
- Hover over the row, the error message should be sane (an incorrect signature is fine)
<!-- Instructions for testing. -->

Fixes #32310 

*This does not require release notes* because it was noticed by a developer loading very very old data (~1997). If we hit this is means either the format has changed, the file isn't really a .nxs or it's corrupted.

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
