### PR TITLE
Fix unstable PythonInterfacesTest on macOS

### DIFF
--- a/Testing/SystemTests/tests/qt/PythonInterfacesStartupTest.py
+++ b/Testing/SystemTests/tests/qt/PythonInterfacesStartupTest.py
@@ -11,16 +11,10 @@ from mantid.kernel import ConfigService
 from mantidqt.utils.qt.testing import get_application
 
 from qtpy.QtCore import QCoreApplication, QSettings
-from qtpy.QtWidgets import QApplication
 
+INSTRUMENT_SWITCHER = {"DGS_Reduction.py": "ARCS", "ORNL_SANS.py": "EQSANS", "Powder_Diffraction_Reduction.py": "NOM"}
 
-INSTRUMENT_SWITCHER = {"DGS_Reduction.py": "ARCS",
-                       "ORNL_SANS.py": "EQSANS",
-                       "Powder_Diffraction_Reduction.py": "NOM"}
-
-APP_NAME_SWITCHER = {"DGS_Reduction.py": "python",
-                     "ORNL_SANS.py": "python",
-                     "Powder_Diffraction_Reduction.py": "python"}
+APP_NAME_SWITCHER = {"DGS_Reduction.py": "python", "ORNL_SANS.py": "python", "Powder_Diffraction_Reduction.py": "python"}
 
 
 def set_instrument(interface_script_name):
@@ -43,36 +37,38 @@ class PythonInterfacesStartupTest(systemtesting.MantidSystemTest):
         super(PythonInterfacesStartupTest, self).__init__()
 
         self._interface_directory = ConfigService.getString('mantidqt.python_interfaces_directory')
-        self._interface_scripts = [interface.split("/")[1] for interface in
-                                   ConfigService.getString('mantidqt.python_interfaces').split()]
+        self._interface_scripts = [interface.split("/")[1] for interface in ConfigService.getString('mantidqt.python_interfaces').split()]
 
     def runTest(self):
         if len(self._interface_scripts) == 0:
             self.fail("Failed to find any python interface scripts.")
 
-        for interface_script in self._interface_scripts:
-            self._attempt_to_open_python_interface(interface_script)
+        self._qapp = get_application()  # keep QApp reference alive
+        try:
+            for interface_script in self._interface_scripts:
+                self._attempt_to_open_and_close_python_interface(interface_script)
+        finally:
+            self._qapp = None
 
-    def _attempt_to_open_python_interface(self, interface_script):
+    def _attempt_to_open_and_close_python_interface(self, interface_script):
         # Ensures the interfaces close after their script has been executed
         set_application_name(interface_script)
         # Prevents a QDialog popping up when opening certain interfaces
         set_instrument(interface_script)
 
         try:
-            self._app = get_application()
             exec(open(os.path.join(self._interface_directory, interface_script)).read())
             self._close_interface()
         except Exception as ex:
             self.fail(f"Exception thrown when attempting to open the {interface_script} interface: {ex}.")
 
-    @staticmethod
-    def _close_interface():
-        """Close the interface after opening to ensure it is unsubscribed from the ADS. Must be done before the
+    def _close_interface(self):
+        """
+        Close all opened windows after opening to ensure it is unsubscribed from the ADS. Must be done before the
         next interface is opened because it appears the Qt objects of the previous interface get deleted when a
         python script runs to completion, but the python object itself is not. This means it is still subscribed to the
         ADS because the 'close_event' is not called, but the Qt objects no longer exist. This causes problems when
-        an ADS change is observed."""
-        for widget in QApplication.topLevelWidgets():
-            if not widget.isHidden():
-                widget.close()
+        an ADS change is observed.
+        """
+        self._qapp.closeAllWindows()
+        self._qapp.sendPostedEvents()


### PR DESCRIPTION
**Description of work.**

Dangling references were being left around such that when the program came to delete QApplication late in the lifecycle it would be attempting to access invalid references and segfault randomly depending on quite when that happened.

Adds a call to send internal events for Qt to process with the aim of clearing away stale references.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**

I built the code in release and ran the following:
```sh
> for i in `seq 1 10`; do ./systemtest -R PythonInterfacesStartup -j2; if [ $? -ne 0 ]; then echo FAILED; break; fi;done;
```

If it **does not** stop and print `FAILED` then we are good.

*There is no associated issue.*

*This does not require release notes* because **it fixes an internal test item.**

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
