### PR TITLE
Fix help button on Algorithm dialog not scaling

### DIFF
--- a/docs/source/release/v6.2.0/mantidworkbench.rst
+++ b/docs/source/release/v6.2.0/mantidworkbench.rst
@@ -48,5 +48,6 @@ Bugfixes
 - Fixed a bug where removing the plot guess line in the fit browser could lead to an exception being thrown.
 - Fixed a bug where marker formatting options were disabled upon opening the figure options.
 - Fixed a bug where the workspace index spinbox in the fit browser wouldn't update when the user added or removed curves from the figure.
+- Fixed the help icon not showing on OSX and high-resolution monitors.
 
 :ref:`Release 6.2.0 <v6.2.0>`

--- a/qt/widgets/common/src/AlgorithmDialog.cpp
+++ b/qt/widgets/common/src/AlgorithmDialog.cpp
@@ -658,7 +658,6 @@ QLayout *AlgorithmDialog::createDefaultButtonLayout(const QString &helpText, con
  */
 QPushButton *AlgorithmDialog::createHelpButton(const QString &helpText) const {
   auto *help = new QPushButton(helpText);
-  help->setMaximumWidth(25);
   connect(help, SIGNAL(clicked()), this, SLOT(helpClicked()));
   return help;
 }


### PR DESCRIPTION
**Description of work.**
This is because it was capped to 25px rather than letting Qt figure it
out.


**To test:**
- I've attached screen shots of this on every platform except for IDaaS and a 4K monitor
- Check this works on a 4k monitor (@sf1919 has volunteered :pray: )

Fixes #32324

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
