### PR TITLE
Fixed muon plotting to reset on instrument change

### DIFF
--- a/scripts/Muon/GUI/Common/plot_widget/base_pane/base_pane_presenter.py
+++ b/scripts/Muon/GUI/Common/plot_widget/base_pane/base_pane_presenter.py
@@ -30,6 +30,7 @@ class BasePanePresenter():
         self._view.on_rebin_options_changed(self.handle_use_raw_workspaces_changed)
         self.workspace_replaced_in_ads_observer = GenericObserverWithArgPassing(self.handle_workspace_replaced_in_ads)
         self.workspace_deleted_from_ads_observer = GenericObserverWithArgPassing(self.handle_workspace_deleted_from_ads)
+        self.clear_plot_observer = GenericObserver(self.create_empty_plot)
 
         self._setup_view_connections()
 
@@ -209,3 +210,6 @@ class BasePanePresenter():
 
     def clear_subplots(self):
         self._figure_presenter.clear_subplots()
+
+    def create_empty_plot(self):
+        self._figure_presenter.create_single_plot()

--- a/scripts/Muon/GUI/Common/plot_widget/fit_pane/plot_fit_pane_presenter.py
+++ b/scripts/Muon/GUI/Common/plot_widget/fit_pane/plot_fit_pane_presenter.py
@@ -80,3 +80,8 @@ class PlotFitPanePresenter(BasePanePresenter):
     def handle_update_plot_guess(self):
         if self._fitting_context.guess_workspace_name is not None and self._fitting_context.plot_guess:
             self._figure_presenter.plot_guess_workspace(self._fitting_context.guess_workspace_name)
+
+    def create_empty_plot(self):
+        self._figure_presenter.create_single_plot()
+        # need to do this manually
+        self._current_fit_info = None

--- a/scripts/Muon/GUI/Common/plot_widget/main_plot_widget_presenter.py
+++ b/scripts/Muon/GUI/Common/plot_widget/main_plot_widget_presenter.py
@@ -37,6 +37,10 @@ class MainPlotWidgetPresenter(HomeTabSubWidget):
         return [self._plot_modes[mode].data_changed_observer for mode in list(self._plot_modes.keys())]
 
     @property
+    def clear_plot_observers(self):
+        return [self._plot_modes[mode].clear_plot_observer for mode in list(self._plot_modes.keys())]
+
+    @property
     def rebin_options_set_observers(self):
         return [self._plot_modes[mode].rebin_options_set_observer for mode in list(self._plot_modes.keys())]
 

--- a/scripts/Muon/GUI/FrequencyDomainAnalysis/frequency_domain_analysis.py
+++ b/scripts/Muon/GUI/FrequencyDomainAnalysis/frequency_domain_analysis.py
@@ -386,6 +386,9 @@ class FrequencyAnalysisGui(QtWidgets.QMainWindow):
         self.context.data_context.instrumentNotifier.add_subscriber(
             self.fitting_tab.fitting_tab_presenter.instrument_changed_observer)
 
+        for observer in self.plot_widget.clear_plot_observers:
+            self.context.data_context.instrumentNotifier.add_subscriber(observer)
+
     def setup_group_calculation_enable_notifier(self):
         self.grouping_tab_widget.group_tab_presenter.enable_editing_notifier.add_subscriber(
             self.enable_observer)

--- a/scripts/Muon/GUI/FrequencyDomainAnalysis/plot_widget/frequency_analysis_plot_widget.py
+++ b/scripts/Muon/GUI/FrequencyDomainAnalysis/plot_widget/frequency_analysis_plot_widget.py
@@ -95,6 +95,10 @@ class FrequencyAnalysisPlotWidget(object):
         self.view.set_plot_mode(plot_mode)
 
     @property
+    def clear_plot_observers(self):
+        return self.presenter.clear_plot_observers
+
+    @property
     def data_changed_observers(self):
         return [self.data_mode.data_changed_observer]
 

--- a/scripts/Muon/GUI/MuonAnalysis/muon_analysis_2.py
+++ b/scripts/Muon/GUI/MuonAnalysis/muon_analysis_2.py
@@ -393,6 +393,9 @@ class MuonAnalysisGui(QtWidgets.QMainWindow):
         self.context.data_context.instrumentNotifier.add_subscriber(
             self.fitting_tab.fitting_tab_presenter.instrument_changed_observer)
 
+        for observer in self.plot_widget.clear_plot_observers:
+            self.context.data_context.instrumentNotifier.add_subscriber(observer)
+
     def setup_group_calculation_enable_notifier(self):
 
         self.grouping_tab_widget.group_tab_presenter.enable_editing_notifier.add_subscriber(

--- a/scripts/Muon/GUI/MuonAnalysis/plot_widget/muon_analysis_plot_widget.py
+++ b/scripts/Muon/GUI/MuonAnalysis/plot_widget/muon_analysis_plot_widget.py
@@ -82,6 +82,10 @@ class MuonAnalysisPlotWidget(object):
         self.view.set_plot_mode(plot_mode)
 
     @property
+    def clear_plot_observers(self):
+        return self.presenter.clear_plot_observers
+
+    @property
     def data_changed_observers(self):
         return self.presenter.data_changed_observers
 


### PR DESCRIPTION
**Description of work.**
When doing the tests in https://developer.mantidproject.org/Testing/MuonInterface/MuonTesting.html it was annoying that the plots did not clear when changing instrument. Clearing the plots gives a clear indication to the user that it is ready for new data. The old plotting (previous release) did do this.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**

<!-- Instructions for testing. -->
Open muon analysis
Load MUSR 62260
Go to fitting and add a flat background
Go to sequential fitting and click fit all
Go to results and click output results table
Go to model and add a flat background, then do a fit
So now all of the plot panes will have some data (you can check by changing the combo box at the top of the plot window)
Go to the home tab
Change the instrument
Check that all of the plots are now empty
Load some data (which doesnt matter)
Check that the plots for (data, raw and fit) are populated with the data you just loaded and that model is empty
Close muon analysis

Open frequency domain analysis
Load MUSR 62660
Go to the transform tab
Change the combo box at the top from FFT to Maxent
Tick the `output reconstructed data` checkbox
Click calculate
A new plot will appear.
At the top of the plot window change it to `maxent dual plot`
You should see 5 subplots
Go to the home tab
Change the instrument
Check that all of the plots are now empty by changing the plot mode (combo box at the top of the plot window)
Load some new data
Check that Frequency data and dual maxent are both empty



There is no associated issue.


<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->
Not in the release notes as the plotting in the previous release did this.

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
