### PR TITLE
Instrument viewer projection fix

### DIFF
--- a/Framework/Beamline/inc/MantidBeamline/ComponentInfo.h
+++ b/Framework/Beamline/inc/MantidBeamline/ComponentInfo.h
@@ -90,6 +90,7 @@ public:
   bool isDetector(const size_t componentIndex) const {
     return componentIndex < m_assemblySortedDetectorIndices->size();
   }
+  bool isMonitor(const size_t componentIndex) const;
   size_t compOffsetIndex(const size_t componentIndex) const {
     return componentIndex - m_assemblySortedDetectorIndices->size();
   }

--- a/Framework/Beamline/src/ComponentInfo.cpp
+++ b/Framework/Beamline/src/ComponentInfo.cpp
@@ -162,6 +162,13 @@ size_t ComponentInfo::numberOfDetectorsInSubtree(const size_t componentIndex) co
   return std::distance(range.begin(), range.end());
 }
 
+bool ComponentInfo::isMonitor(const size_t componentIndex) const {
+  if (hasDetectorInfo()) {
+    return this->m_detectorInfo->isMonitor(componentIndex);
+  }
+  return false;
+}
+
 const Eigen::Vector3d &ComponentInfo::position(const size_t componentIndex) const {
   checkNoTimeDependence();
   if (isDetector(componentIndex)) {

--- a/Framework/Geometry/inc/MantidGeometry/Instrument/ComponentInfo.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument/ComponentInfo.h
@@ -49,14 +49,15 @@ private:
   /// Shapes for each component
   std::shared_ptr<std::vector<std::shared_ptr<const Geometry::IObject>>> m_shapes;
 
-  BoundingBox componentBoundingBox(const size_t index, const BoundingBox *reference) const;
+  BoundingBox componentBoundingBox(const size_t index, const BoundingBox *reference,
+                                   const bool excludeMonitors = false) const;
 
   /// Private copy constructor. Do not make public.
   ComponentInfo(const ComponentInfo &other);
   void growBoundingBoxAsRectuangularBank(size_t index, const Geometry::BoundingBox *reference,
-                                         Geometry::BoundingBox &mutableBB) const;
-  void growBoundingBoxAsOutline(size_t index, const Geometry::BoundingBox *reference,
-                                Geometry::BoundingBox &mutableBB) const;
+                                         Geometry::BoundingBox &mutableBB, const bool excludeMonitors = false) const;
+  void growBoundingBoxAsOutline(size_t index, const Geometry::BoundingBox *reference, Geometry::BoundingBox &mutableBB,
+                                const bool excludeMonitors = false) const;
 
 public:
   struct QuadrilateralComponent {
@@ -121,7 +122,8 @@ public:
   const Geometry::IObject &shape(const size_t componentIndex) const;
 
   double solidAngle(const size_t componentIndex, const Kernel::V3D &observer) const;
-  BoundingBox boundingBox(const size_t componentIndex, const BoundingBox *reference = nullptr) const;
+  BoundingBox boundingBox(const size_t componentIndex, const BoundingBox *reference = nullptr,
+                          const bool excludeMonitors = false) const;
   Beamline::ComponentType componentType(const size_t componentIndex) const;
   void setScanInterval(const std::pair<Types::Core::DateAndTime, Types::Core::DateAndTime> &interval);
   size_t scanCount() const;

--- a/Framework/Geometry/src/Instrument/ComponentInfo.cpp
+++ b/Framework/Geometry/src/Instrument/ComponentInfo.cpp
@@ -279,15 +279,17 @@ double ComponentInfo::solidAngle(const size_t componentIndex, const Kernel::V3D 
  * @param index : Index of the component to get the bounding box for
  * @param reference : Reference bounding box (optional)
  * @param mutableBB : Output bounding box. This will be grown.
+ * @param excludeMonitors : Optional flag to exclude monitors and choppers
  */
 void ComponentInfo::growBoundingBoxAsRectuangularBank(size_t index, const Geometry::BoundingBox *reference,
-                                                      Geometry::BoundingBox &mutableBB) const {
+                                                      Geometry::BoundingBox &mutableBB,
+                                                      const bool excludeMonitors) const {
 
   auto panel = quadrilateralComponent(index);
-  mutableBB.grow(componentBoundingBox(panel.bottomLeft, reference));
-  mutableBB.grow(componentBoundingBox(panel.topRight, reference));
-  mutableBB.grow(componentBoundingBox(panel.topLeft, reference));
-  mutableBB.grow(componentBoundingBox(panel.bottomRight, reference));
+  mutableBB.grow(componentBoundingBox(panel.bottomLeft, reference, excludeMonitors));
+  mutableBB.grow(componentBoundingBox(panel.topRight, reference, excludeMonitors));
+  mutableBB.grow(componentBoundingBox(panel.topLeft, reference, excludeMonitors));
+  mutableBB.grow(componentBoundingBox(panel.bottomRight, reference, excludeMonitors));
 }
 
 /**
@@ -298,9 +300,11 @@ void ComponentInfo::growBoundingBoxAsRectuangularBank(size_t index, const Geomet
  * @param index : Index of the component to get the bounding box for
  * @param reference : Reference bounding box (optional)
  * @param mutableBB : Output bounding box. This will be grown.
+ * @param excludeMonitors : Optional flag to exclude monitors and choppers
  */
-void ComponentInfo::growBoundingBoxAsOutline(size_t index, const BoundingBox *reference, BoundingBox &mutableBB) const {
-  mutableBB.grow(componentBoundingBox(index, reference));
+void ComponentInfo::growBoundingBoxAsOutline(size_t index, const BoundingBox *reference, BoundingBox &mutableBB,
+                                             const bool excludeMonitors) const {
+  mutableBB.grow(componentBoundingBox(index, reference, excludeMonitors));
 }
 
 /**
@@ -309,12 +313,24 @@ void ComponentInfo::growBoundingBoxAsOutline(size_t index, const BoundingBox *re
  * @param index : Component index
  * @param reference : Optional reference for coordinate system for non-axis
  *aligned bounding boxes
+ * @param excludeMonitors : Optional flag to exclude monitor and choppers
  * @return Absolute bounding box.
  */
-BoundingBox ComponentInfo::componentBoundingBox(const size_t index, const BoundingBox *reference) const {
+BoundingBox ComponentInfo::componentBoundingBox(const size_t index, const BoundingBox *reference,
+                                                const bool excludeMonitors) const {
   // Check that we have a valid shape here
   if (componentType(index) == Beamline::ComponentType::Infinite) {
     return BoundingBox(); // Return null bounding box
+  }
+  if (excludeMonitors) {
+    // skip monitors
+    if (isDetector(index) && m_componentInfo->isMonitor(index)) {
+      return BoundingBox();
+    }
+    // skip other components such as choppers, etc
+    if (componentType(index) == Beamline::ComponentType::Generic) {
+      return BoundingBox();
+    }
   }
   if (!hasValidShape(index)) {
     return BoundingBox(this->position(index).X(), this->position(index).Y(), this->position(index).Z(),
@@ -366,11 +382,13 @@ BoundingBox ComponentInfo::componentBoundingBox(const size_t index, const Boundi
  * @param componentIndex : Component index to get the bounding box for
  * @param reference : Optional reference for coordinate system for non-axis
  *aligned bounding boxes
+ * @param excludeMonitors : Optional flag to exclude monitors and choppers
  * @return Absolute bounding box
  */
-BoundingBox ComponentInfo::boundingBox(const size_t componentIndex, const BoundingBox *reference) const {
+BoundingBox ComponentInfo::boundingBox(const size_t componentIndex, const BoundingBox *reference,
+                                       const bool excludeMonitors) const {
   if (isDetector(componentIndex) || componentType(componentIndex) == Beamline::ComponentType::Infinite) {
-    return componentBoundingBox(componentIndex, reference);
+    return componentBoundingBox(componentIndex, reference, excludeMonitors);
   }
 
   BoundingBox absoluteBB;
@@ -385,20 +403,20 @@ BoundingBox ComponentInfo::boundingBox(const size_t componentIndex, const Boundi
     // box calculations.
   } else if (compFlag == Beamline::ComponentType::Unstructured) {
     for (const auto &childIndex : this->children(componentIndex)) {
-      absoluteBB.grow(boundingBox(childIndex, reference));
+      absoluteBB.grow(boundingBox(childIndex, reference, excludeMonitors));
     }
   } else if (compFlag == Beamline::ComponentType::Grid) {
     for (const auto &childIndex : this->children(componentIndex)) {
-      growBoundingBoxAsRectuangularBank(childIndex, reference, absoluteBB);
+      growBoundingBoxAsRectuangularBank(childIndex, reference, absoluteBB, excludeMonitors);
     }
   } else if (compFlag == Beamline::ComponentType::Rectangular || compFlag == Beamline::ComponentType::Structured ||
              parentFlag == Beamline::ComponentType::Grid) {
-    growBoundingBoxAsRectuangularBank(componentIndex, reference, absoluteBB);
+    growBoundingBoxAsRectuangularBank(componentIndex, reference, absoluteBB, excludeMonitors);
   } else if (compFlag == Beamline::ComponentType::OutlineComposite) {
-    growBoundingBoxAsOutline(componentIndex, reference, absoluteBB);
+    growBoundingBoxAsOutline(componentIndex, reference, absoluteBB, excludeMonitors);
   } else {
     // General case
-    absoluteBB.grow(componentBoundingBox(componentIndex, reference));
+    absoluteBB.grow(componentBoundingBox(componentIndex, reference, excludeMonitors));
   }
   return absoluteBB;
 }

--- a/docs/source/release/v6.2.0/mantidworkbench.rst
+++ b/docs/source/release/v6.2.0/mantidworkbench.rst
@@ -54,6 +54,7 @@ Bugfixes
 - Fixed the help icon not showing on OSX and high-resolution monitors.
 - Tabbing between fields in the error reporter now works as expected, rather than jumping to a random place each time.
 - Fixed the advanced plotting dialog incorrectly laying out, causing the options to be partially occluded.
+- Fixed a bug in the Instrument Viewer causing the projection to not be updated when different axis views were selected in Full 3D.
 
 
 :ref:`Release 6.2.0 <v6.2.0>`

--- a/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/InstrumentActor.h
+++ b/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/InstrumentActor.h
@@ -63,8 +63,7 @@ public:
   static constexpr double INVALID_VALUE = std::numeric_limits<double>::lowest();
 
   /// Constructor
-  InstrumentActor(const QString &wsName, bool autoscaling = true,
-                  double scaleMin = 0.0, double scaleMax = 0.0);
+  InstrumentActor(const QString &wsName, bool autoscaling = true, double scaleMin = 0.0, double scaleMax = 0.0);
   ///< Destructor
   ~InstrumentActor();
   /// Draw the instrument in 3D
@@ -162,11 +161,9 @@ public:
   /// Get the integrated counts of a detector by its detector Index.
   double getIntegratedCounts(size_t index) const;
   /// Sum the counts in detectors
-  void sumDetectors(const std::vector<size_t> &dets, std::vector<double> &x,
-                    std::vector<double> &y, size_t size) const;
+  void sumDetectors(const std::vector<size_t> &dets, std::vector<double> &x, std::vector<double> &y, size_t size) const;
   /// Sum the counts in detectors.
-  void sumDetectors(const std::vector<size_t> &dets, std::vector<double> &x,
-                    std::vector<double> &y) const;
+  void sumDetectors(const std::vector<size_t> &dets, std::vector<double> &x, std::vector<double> &y) const;
   /// Calc indexes for min and max bin values
   void getBinMinMaxIndex(size_t wi, size_t &imin, size_t &imax) const;
 
@@ -178,17 +175,12 @@ public:
   /// Get the guide visibility status
   bool areGuidesShown() const { return m_showGuides; }
 
-  static void BasisRotation(const Mantid::Kernel::V3D &Xfrom,
-                            const Mantid::Kernel::V3D &Yfrom,
-                            const Mantid::Kernel::V3D &Zfrom,
-                            const Mantid::Kernel::V3D &Xto,
-                            const Mantid::Kernel::V3D &Yto,
-                            const Mantid::Kernel::V3D &Zto,
-                            Mantid::Kernel::Quat &R, bool out = false);
+  static void BasisRotation(const Mantid::Kernel::V3D &Xfrom, const Mantid::Kernel::V3D &Yfrom,
+                            const Mantid::Kernel::V3D &Zfrom, const Mantid::Kernel::V3D &Xto,
+                            const Mantid::Kernel::V3D &Yto, const Mantid::Kernel::V3D &Zto, Mantid::Kernel::Quat &R,
+                            bool out = false);
 
-  static void rotateToLookAt(const Mantid::Kernel::V3D &eye,
-                             const Mantid::Kernel::V3D &up,
-                             Mantid::Kernel::Quat &R);
+  static void rotateToLookAt(const Mantid::Kernel::V3D &eye, const Mantid::Kernel::V3D &up, Mantid::Kernel::Quat &R);
 
   /* Masking */
 
@@ -199,8 +191,7 @@ public:
   std::string getDefaultAxis() const;
   std::string getDefaultView() const;
   std::string getInstrumentName() const;
-  std::vector<std::string> getStringParameter(const std::string &name,
-                                              bool recursive = true) const;
+  std::vector<std::string> getStringParameter(const std::string &name, bool recursive = true) const;
   /// Load the state of the actor from a Mantid project file.
   void loadFromProject(const std::string &lines);
   /// Save the state of the actor to a Mantid project file.
@@ -219,25 +210,20 @@ signals:
 private:
   static constexpr double TOLERANCE = 0.00001;
 
-  void setUpWorkspace(const std::shared_ptr<const Mantid::API::MatrixWorkspace>
-                          &sharedWorkspace,
-                      double scaleMin, double scaleMax);
+  void setUpWorkspace(const std::shared_ptr<const Mantid::API::MatrixWorkspace> &sharedWorkspace, double scaleMin,
+                      double scaleMax);
   void setupPhysicalInstrumentIfExists();
   void resetColors();
   void loadSettings();
   void saveSettings();
   void setDataMinMaxRange(double vmin, double vmax);
   void setDataIntegrationRange(const double &xmin, const double &xmax);
-  void
-  calculateIntegratedSpectra(const Mantid::API::MatrixWorkspace &workspace);
+  void calculateIntegratedSpectra(const Mantid::API::MatrixWorkspace &workspace);
   /// Sum the counts in detectors if the workspace has equal bins for all
   /// spectra
-  void sumDetectorsUniform(const std::vector<size_t> &dets,
-                           std::vector<double> &x,
-                           std::vector<double> &y) const;
+  void sumDetectorsUniform(const std::vector<size_t> &dets, std::vector<double> &x, std::vector<double> &y) const;
   /// Sum the counts in detectors if the workspace is ragged
-  void sumDetectorsRagged(const std::vector<size_t> &dets,
-                          std::vector<double> &x, std::vector<double> &y,
+  void sumDetectorsRagged(const std::vector<size_t> &dets, std::vector<double> &x, std::vector<double> &y,
                           size_t size) const;
 
   /// The workspace whose data are shown

--- a/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/InstrumentActor.h
+++ b/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/InstrumentActor.h
@@ -70,8 +70,7 @@ public:
   /// Draw the instrument in 3D
   void draw(bool picking = false) const;
   /// Return the bounding box in 3D
-  void getBoundingBox(Mantid::Kernel::V3D &minBound,
-                      Mantid::Kernel::V3D &maxBound) const;
+  void getBoundingBox(Mantid::Kernel::V3D &minBound, Mantid::Kernel::V3D &maxBound, const bool excludeMonitors) const;
   /// Set a component (and all its children) visible.
   void setComponentVisible(size_t componentIndex);
   /// Set visibilit of all components.

--- a/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/Viewport.h
+++ b/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/Viewport.h
@@ -85,8 +85,7 @@ public:
   /// Call to set the View to Z- direction
   void setViewToZNegative();
 
-  void adjustProjection(unsigned int axis);
-  void getProjection(Mantid::Kernel::V3D &minBound, Mantid::Kernel::V3D &maxBound) const;
+  void adjustProjection(const unsigned int axis);
 
   /// Init rotation at a point on the screen
   void initRotationFrom(int a, int b);

--- a/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/Viewport.h
+++ b/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/Viewport.h
@@ -85,6 +85,9 @@ public:
   /// Call to set the View to Z- direction
   void setViewToZNegative();
 
+  void adjustProjection();
+  void getProjection(Mantid::Kernel::V3D &minBound, Mantid::Kernel::V3D &maxBound) const;
+
   /// Init rotation at a point on the screen
   void initRotationFrom(int a, int b);
   /// Generate a new rotation matrix
@@ -152,6 +155,12 @@ protected:
   /// z axis)
   double m_far; ///< Ortho/Prespective Projection zmax value (Far side of the z
   /// axis)
+  double m_leftOrig;
+  double m_rightOrig;
+  double m_bottomOrig;
+  double m_topOrig;
+  double m_nearOrig;
+  double m_farOrig;
 
   /* Trackball rotation */
 

--- a/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/Viewport.h
+++ b/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/Viewport.h
@@ -63,6 +63,7 @@ public:
   void setProjection(const Mantid::Kernel::V3D &minBounds,
                      const Mantid::Kernel::V3D &maxBounds,
                      ProjectionType type = Viewport::ORTHO);
+  void setProjectionZPlane(const Mantid::Kernel::V3D &minBounds, const Mantid::Kernel::V3D &maxBounds);
   /// Apply the projection to OpenGL engine
   void applyProjection() const;
   /// Rotate the model

--- a/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/Viewport.h
+++ b/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/Viewport.h
@@ -56,12 +56,10 @@ public:
   /// Return the projection type.
   ProjectionType getProjectionType() const;
   /// Set a projection.
-  void setProjection(double /*l*/, double /*r*/, double /*b*/, double /*t*/,
-                     double /*nearz*/, double /*farz*/,
+  void setProjection(double /*l*/, double /*r*/, double /*b*/, double /*t*/, double /*nearz*/, double /*farz*/,
                      ProjectionType type = Viewport::ORTHO);
   /// Set a projection.
-  void setProjection(const Mantid::Kernel::V3D &minBounds,
-                     const Mantid::Kernel::V3D &maxBounds,
+  void setProjection(const Mantid::Kernel::V3D &minBounds, const Mantid::Kernel::V3D &maxBounds,
                      ProjectionType type = Viewport::ORTHO);
   void setProjectionZPlane(const Mantid::Kernel::V3D &minBounds, const Mantid::Kernel::V3D &maxBounds);
   /// Apply the projection to OpenGL engine
@@ -118,8 +116,7 @@ public:
   void setTranslation(double /*xval*/, double /*yval*/);
 
   // void getProjection(double&,double&,double&,double&,double&,double&);
-  void getInstantProjection(double & /*xmin*/, double & /*xmax*/,
-                            double & /*ymin*/, double & /*ymax*/,
+  void getInstantProjection(double & /*xmin*/, double & /*xmax*/, double & /*ymin*/, double & /*ymax*/,
                             double & /*zmin*/, double & /*zmax*/) const;
 
   /// Apply the transformation to a vector
@@ -131,8 +128,7 @@ public:
 
 protected:
   /// Correct for aspect ratio
-  void correctForAspectRatioAndZoom(double &xmin, double &xmax, double &ymin,
-                                    double &ymax, double &zmin,
+  void correctForAspectRatioAndZoom(double &xmin, double &xmax, double &ymin, double &ymax, double &zmin,
                                     double &zmax) const;
   /// Project a point onto a sphere centered at rotation point
   void projectOnSphere(int a, int b, Mantid::Kernel::V3D &point) const;

--- a/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/Viewport.h
+++ b/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/Viewport.h
@@ -85,7 +85,7 @@ public:
   /// Call to set the View to Z- direction
   void setViewToZNegative();
 
-  void adjustProjection();
+  void adjustProjection(unsigned int axis);
   void getProjection(Mantid::Kernel::V3D &minBound, Mantid::Kernel::V3D &maxBound) const;
 
   /// Init rotation at a point on the screen

--- a/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/Viewport.h
+++ b/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/Viewport.h
@@ -85,7 +85,7 @@ public:
   /// Call to set the View to Z- direction
   void setViewToZNegative();
 
-  void adjustProjection(const unsigned int axis);
+  void adjustProjection();
 
   /// Init rotation at a point on the screen
   void initRotationFrom(int a, int b);
@@ -158,8 +158,10 @@ protected:
   double m_rightOrig;
   double m_bottomOrig;
   double m_topOrig;
-  double m_nearOrig;
-  double m_farOrig;
+  double m_zminOrig;
+  double m_zmaxOrig;
+  double m_zmin;
+  double m_zmax;
 
   /* Trackball rotation */
 

--- a/qt/widgets/instrumentview/src/InstrumentActor.cpp
+++ b/qt/widgets/instrumentview/src/InstrumentActor.cpp
@@ -221,9 +221,10 @@ MatrixWorkspace_const_sptr InstrumentActor::getWorkspace() const {
   return sharedWorkspace;
 }
 
-void InstrumentActor::getBoundingBox(Mantid::Kernel::V3D &minBound, Mantid::Kernel::V3D &maxBound) const {
+void InstrumentActor::getBoundingBox(Mantid::Kernel::V3D &minBound, Mantid::Kernel::V3D &maxBound,
+                                     const bool excludeMonitors) const {
   const auto &compInfo = componentInfo();
-  auto bb = compInfo.boundingBox(compInfo.root());
+  auto bb = compInfo.boundingBox(compInfo.root(), nullptr, excludeMonitors);
   minBound = bb.minPoint();
   maxBound = bb.maxPoint();
 }

--- a/qt/widgets/instrumentview/src/Projection3D.cpp
+++ b/qt/widgets/instrumentview/src/Projection3D.cpp
@@ -50,9 +50,14 @@ namespace MantidWidgets {
 Projection3D::Projection3D(const InstrumentActor *rootActor, QSize viewportSize)
     : ProjectionSurface(rootActor), m_drawAxes(true), m_wireframe(false), m_viewport(std::move(viewportSize)) {
   V3D minBounds, maxBounds;
-  m_instrActor->getBoundingBox(minBounds, maxBounds);
+  // exclude monitors and choppers from bounding box to set tighter view bounds
+  m_instrActor->getBoundingBox(minBounds, maxBounds, true);
 
   m_viewport.setProjection(minBounds, maxBounds);
+
+  // use the full bounding box to get the Z bounds for the clipping plane
+  m_instrActor->getBoundingBox(minBounds, maxBounds, false);
+  m_viewport.setProjectionZPlane(minBounds, maxBounds);
 
   changeColorMap();
 

--- a/qt/widgets/instrumentview/src/Viewport.cpp
+++ b/qt/widgets/instrumentview/src/Viewport.cpp
@@ -260,7 +260,7 @@ void Viewport::setViewToXPositive() {
                              Mantid::Kernel::V3D(-1.0, 0.0, 0.0));
   m_quaternion = tempy;
   m_quaternion.GLMatrix(&m_rotationmatrix[0]);
-  adjustProjection();
+  adjustProjection(0);
 }
 
 /**
@@ -273,7 +273,7 @@ void Viewport::setViewToYPositive() {
                              Mantid::Kernel::V3D(0.0, -1.0, 0.0));
   m_quaternion = tempy;
   m_quaternion.GLMatrix(&m_rotationmatrix[0]);
-  adjustProjection();
+  adjustProjection(1);
 }
 
 /**
@@ -284,7 +284,7 @@ void Viewport::setViewToZPositive() {
   reset();
   m_quaternion.init();
   m_quaternion.GLMatrix(&m_rotationmatrix[0]);
-  adjustProjection();
+  adjustProjection(2);
 }
 
 /**
@@ -297,7 +297,7 @@ void Viewport::setViewToXNegative() {
                              Mantid::Kernel::V3D(1.0, 0.0, 0.0));
   m_quaternion = tempy;
   m_quaternion.GLMatrix(&m_rotationmatrix[0]);
-  adjustProjection();
+  adjustProjection(0);
 }
 
 /**
@@ -310,7 +310,7 @@ void Viewport::setViewToYNegative() {
                              Mantid::Kernel::V3D(0.0, 1.0, 0.0));
   m_quaternion = tempy;
   m_quaternion.GLMatrix(&m_rotationmatrix[0]);
-  adjustProjection();
+  adjustProjection(1);
 }
 
 /**
@@ -322,20 +322,29 @@ void Viewport::setViewToZNegative() {
   Mantid::Kernel::Quat tempy(180.0, Mantid::Kernel::V3D(0.0, 1.0, 0.0));
   m_quaternion = tempy;
   m_quaternion.GLMatrix(&m_rotationmatrix[0]);
-  adjustProjection();
+  adjustProjection(2);
 }
 
-void Viewport::adjustProjection() {
+void Viewport::adjustProjection(unsigned int axis) {
   // reset the projection bounds to the original values
   m_left = m_leftOrig;
   m_right = m_rightOrig;
   m_top = m_topOrig;
   m_bottom = m_bottomOrig;
-  m_near = 0.0;
-  m_far = 0.0;
+  m_near = m_nearOrig;
+  m_far = m_farOrig;
   // rotate the original projection based on the new quaternion
   m_quaternion.rotateBB(m_left, m_bottom, m_near, m_right, m_top, m_far);
-  // restore the Z bounds
+  if (axis == 0) {
+    // X axis rotation, so use rotated Z values as new X
+    m_left = m_near;
+    m_right = m_far;
+  } else if (axis == 1) {
+    // Y axis rotation, so use rotated Z values as new Y
+    m_bottom = m_near;
+    m_top = m_far;
+  }
+  // restore the Z projection bounds
   m_near = m_nearOrig;
   m_far = m_farOrig;
   // update the GL projection with the new bounds

--- a/qt/widgets/instrumentview/src/Viewport.cpp
+++ b/qt/widgets/instrumentview/src/Viewport.cpp
@@ -109,6 +109,22 @@ void Viewport::setProjection(const Mantid::Kernel::V3D &minBounds,
 }
 
 /**
+ * Sets the near and far clipping plane based on the size of given points
+ *
+ * @param minBounds :: Near-bottom-left corner of the scene.
+ * @param maxBounds :: Far-top-right corner of the scene.
+ */
+void Viewport::setProjectionZPlane(const Mantid::Kernel::V3D &minBounds, const Mantid::Kernel::V3D &maxBounds) {
+  double radius = minBounds.norm();
+  double tmp = maxBounds.norm();
+  if (tmp > radius)
+    radius = tmp;
+
+  m_near = -radius;
+  m_far = radius;
+}
+
+/**
  * Return XY plane bounds corrected for the aspect ratio.
  */
 void Viewport::correctForAspectRatioAndZoom(double &xmin, double &xmax,
@@ -338,6 +354,7 @@ void Viewport::adjustProjection() {
   m_zmin = m_zminOrig;
   m_zmax = m_zmaxOrig;
 
+  // rotate the original projection based on the new quaternion
   m_quaternion.rotateBB(m_left, m_bottom, m_zmin, m_right, m_top, m_zmax);
 
   // update the GL projection with the new bounds

--- a/qt/widgets/instrumentview/src/Viewport.cpp
+++ b/qt/widgets/instrumentview/src/Viewport.cpp
@@ -23,10 +23,9 @@ namespace MantidWidgets {
  * @param glWidgetDimensions Viewport width/height in device pixels
  */
 Viewport::Viewport(QSize dimensions)
-    : m_projectionType(Viewport::ORTHO), m_dimensions(std::move(dimensions)),
-      m_left(-1), m_right(1), m_bottom(-1), m_top(1), m_near(-1), m_far(1),
-      m_rotationspeed(180.0 / M_PI), m_zoomFactor(1.0), m_xTrans(0.0),
-      m_yTrans(0.0), m_zTrans(0.0) {
+    : m_projectionType(Viewport::ORTHO), m_dimensions(std::move(dimensions)), m_left(-1), m_right(1), m_bottom(-1),
+      m_top(1), m_near(-1), m_far(1), m_rotationspeed(180.0 / M_PI), m_zoomFactor(1.0), m_xTrans(0.0), m_yTrans(0.0),
+      m_zTrans(0.0) {
   m_quaternion.GLMatrix(&m_rotationmatrix[0]);
 }
 
@@ -34,9 +33,7 @@ Viewport::Viewport(QSize dimensions)
  * Resize the viewport = size of the displaying widget.
  * @param dimensions Viewport width/height in device pixels
  */
-void Viewport::resize(QSize dimensions) {
-  m_dimensions = std::move(dimensions);
-}
+void Viewport::resize(QSize dimensions) { m_dimensions = std::move(dimensions); }
 
 /**
  * Get the size of the viewport in logical pixels (size of the displaying
@@ -61,8 +58,7 @@ QSize Viewport::dimensions() const { return m_dimensions; }
  * @param type :: Projection type: ORTHO or PERSPECTIVE. PERSPECTIVE isn't fully
  *implemented
  */
-void Viewport::setProjection(double l, double r, double b, double t,
-                             double nearz, double farz,
+void Viewport::setProjection(double l, double r, double b, double t, double nearz, double farz,
                              Viewport::ProjectionType type) {
   m_projectionType = type;
   m_left = l;
@@ -90,8 +86,7 @@ void Viewport::setProjection(double l, double r, double b, double t,
  * @param type :: Projection type: ORTHO or PERSPECTIVE. PERSPECTIVE isn't fully
  *implemented
  */
-void Viewport::setProjection(const Mantid::Kernel::V3D &minBounds,
-                             const Mantid::Kernel::V3D &maxBounds,
+void Viewport::setProjection(const Mantid::Kernel::V3D &minBounds, const Mantid::Kernel::V3D &maxBounds,
                              ProjectionType type) {
   double radius = minBounds.norm();
   double tmp = maxBounds.norm();
@@ -104,8 +99,7 @@ void Viewport::setProjection(const Mantid::Kernel::V3D &minBounds,
   m_zminOrig = m_zmin;
   m_zmaxOrig = m_zmax;
 
-  setProjection(minBounds.X(), maxBounds.X(), minBounds.Y(), maxBounds.Y(),
-                -radius, radius, type);
+  setProjection(minBounds.X(), maxBounds.X(), minBounds.Y(), maxBounds.Y(), -radius, radius, type);
 }
 
 /**
@@ -127,9 +121,8 @@ void Viewport::setProjectionZPlane(const Mantid::Kernel::V3D &minBounds, const M
 /**
  * Return XY plane bounds corrected for the aspect ratio.
  */
-void Viewport::correctForAspectRatioAndZoom(double &xmin, double &xmax,
-                                            double &ymin, double &ymax,
-                                            double &zmin, double &zmax) const {
+void Viewport::correctForAspectRatioAndZoom(double &xmin, double &xmax, double &ymin, double &ymax, double &zmin,
+                                            double &zmax) const {
   xmin = m_left;
   xmax = m_right;
   ymin = m_bottom;
@@ -154,9 +147,7 @@ void Viewport::correctForAspectRatioAndZoom(double &xmin, double &xmax,
   zmax = m_far * m_zoomFactor;
 }
 
-Viewport::ProjectionType Viewport::getProjectionType() const {
-  return m_projectionType;
-}
+Viewport::ProjectionType Viewport::getProjectionType() const { return m_projectionType; }
 
 /**
  * Get the projection bounds.
@@ -167,8 +158,7 @@ Viewport::ProjectionType Viewport::getProjectionType() const {
  * @param zmin :: near side of the Ortho Projection
  * @param zmax :: far side of the Ortho Projection
  */
-void Viewport::getInstantProjection(double &xmin, double &xmax, double &ymin,
-                                    double &ymax, double &zmin,
+void Viewport::getInstantProjection(double &xmin, double &xmax, double &ymin, double &ymax, double &zmin,
                                     double &zmax) const {
   correctForAspectRatioAndZoom(xmin, xmax, ymin, ymax, zmin, zmax);
 }
@@ -208,9 +198,7 @@ void Viewport::applyProjection() const {
 
     if (OpenGLError::hasError("GLViewport::issueGL()")) {
       OpenGLError::log() << "Arguments to glOrtho:\n";
-      OpenGLError::log() << xmin << ' ' << xmax << '\n'
-                         << ymin << ' ' << ymax << '\n'
-                         << zmin << ' ' << zmax << "\n\n";
+      OpenGLError::log() << xmin << ' ' << xmax << '\n' << ymin << ' ' << ymax << '\n' << zmin << ' ' << zmax << "\n\n";
     }
   }
   // Reset the rendering options just in case
@@ -228,10 +216,8 @@ void Viewport::applyProjection() const {
 void Viewport::projectOnSphere(int a, int b, Mantid::Kernel::V3D &point) const {
   // z initiaised to zero if out of the sphere
   double z = 0;
-  auto x = static_cast<double>((2.0 * a - m_dimensions.width()) /
-                               m_dimensions.width());
-  auto y = static_cast<double>((m_dimensions.height() - 2.0 * b) /
-                               m_dimensions.height());
+  auto x = static_cast<double>((2.0 * a - m_dimensions.width()) / m_dimensions.width());
+  auto y = static_cast<double>((m_dimensions.height() - 2.0 * b) / m_dimensions.height());
   double norm = x * x + y * y;
   if (norm > 1.0) // The point is inside the sphere
   {
@@ -276,8 +262,7 @@ void Viewport::reset() {
  */
 void Viewport::setViewToXPositive() {
   reset();
-  Mantid::Kernel::Quat tempy(Mantid::Kernel::V3D(0.0, 0.0, 1.0),
-                             Mantid::Kernel::V3D(-1.0, 0.0, 0.0));
+  Mantid::Kernel::Quat tempy(Mantid::Kernel::V3D(0.0, 0.0, 1.0), Mantid::Kernel::V3D(-1.0, 0.0, 0.0));
   m_quaternion = tempy;
   m_quaternion.GLMatrix(&m_rotationmatrix[0]);
   adjustProjection();
@@ -289,8 +274,7 @@ void Viewport::setViewToXPositive() {
  */
 void Viewport::setViewToYPositive() {
   reset();
-  Mantid::Kernel::Quat tempy(Mantid::Kernel::V3D(0.0, 0.0, 1.0),
-                             Mantid::Kernel::V3D(0.0, -1.0, 0.0));
+  Mantid::Kernel::Quat tempy(Mantid::Kernel::V3D(0.0, 0.0, 1.0), Mantid::Kernel::V3D(0.0, -1.0, 0.0));
   m_quaternion = tempy;
   m_quaternion.GLMatrix(&m_rotationmatrix[0]);
   adjustProjection();
@@ -313,8 +297,7 @@ void Viewport::setViewToZPositive() {
  */
 void Viewport::setViewToXNegative() {
   reset();
-  Mantid::Kernel::Quat tempy(Mantid::Kernel::V3D(0.0, 0.0, 1.0),
-                             Mantid::Kernel::V3D(1.0, 0.0, 0.0));
+  Mantid::Kernel::Quat tempy(Mantid::Kernel::V3D(0.0, 0.0, 1.0), Mantid::Kernel::V3D(1.0, 0.0, 0.0));
   m_quaternion = tempy;
   m_quaternion.GLMatrix(&m_rotationmatrix[0]);
   adjustProjection();
@@ -326,8 +309,7 @@ void Viewport::setViewToXNegative() {
  */
 void Viewport::setViewToYNegative() {
   reset();
-  Mantid::Kernel::Quat tempy(Mantid::Kernel::V3D(0.0, 0.0, 1.0),
-                             Mantid::Kernel::V3D(0.0, 1.0, 0.0));
+  Mantid::Kernel::Quat tempy(Mantid::Kernel::V3D(0.0, 0.0, 1.0), Mantid::Kernel::V3D(0.0, 1.0, 0.0));
   m_quaternion = tempy;
   m_quaternion.GLMatrix(&m_rotationmatrix[0]);
   adjustProjection();
@@ -395,8 +377,7 @@ void Viewport::initZoomFrom(int a, int b) {
  * @param b :: The y mouse coordinate
  */
 void Viewport::generateZoomTo(int a, int b) {
-  if (a >= m_dimensions.width() || b >= m_dimensions.height() || a <= 0 ||
-      b <= 0)
+  if (a >= m_dimensions.width() || b >= m_dimensions.height() || a <= 0 || b <= 0)
     return;
   auto y = static_cast<double>(b - m_dimensions.height());
   if (y == 0)
@@ -445,9 +426,7 @@ void Viewport::setZoom(double zoom) {
  * @param a :: The x mouse coordinate
  * @param b :: The y mouse coordinate
  */
-void Viewport::initRotationFrom(int a, int b) {
-  projectOnSphere(a, b, m_lastpoint);
-}
+void Viewport::initRotationFrom(int a, int b) { projectOnSphere(a, b, m_lastpoint); }
 
 /**
  * Generate the rotation matrix to rotate to this point.
@@ -475,9 +454,7 @@ void Viewport::generateRotationTo(int a, int b) {
  * @param a :: The x mouse coordinate
  * @param b :: The y mouse coordinate
  */
-void Viewport::initTranslateFrom(int a, int b) {
-  generateTranslationPoint(a, b, m_lastpoint);
-}
+void Viewport::initTranslateFrom(int a, int b) { generateTranslationPoint(a, b, m_lastpoint); }
 
 /**
  * Generate scene translation such that a point of the last initTranslateFrom
@@ -500,15 +477,12 @@ void Viewport::generateTranslationTo(int a, int b) {
  * @param b :: The y mouse coordinate
  * @param point :: Return the result through this reference.
  */
-void Viewport::generateTranslationPoint(int a, int b,
-                                        Mantid::Kernel::V3D &point) const {
+void Viewport::generateTranslationPoint(int a, int b, Mantid::Kernel::V3D &point) const {
   double x, y, z = 0.0;
   double xmin, xmax, ymin, ymax, zmin, zmax;
   correctForAspectRatioAndZoom(xmin, xmax, ymin, ymax, zmin, zmax);
-  x = static_cast<double>(
-      (xmin + ((xmax - xmin) * ((double)a / (double)m_dimensions.width()))));
-  y = static_cast<double>((ymin + ((ymax - ymin) * (m_dimensions.height() - b) /
-                                   m_dimensions.height())));
+  x = static_cast<double>((xmin + ((xmax - xmin) * ((double)a / (double)m_dimensions.width()))));
+  y = static_cast<double>((ymin + ((ymax - ymin) * (m_dimensions.height() - b) / m_dimensions.height())));
   point(x, y, z);
 }
 
@@ -544,8 +518,7 @@ void Viewport::loadFromProject(const std::string &lines) {
   setRotation(quat);
 #else
   Q_UNUSED(lines);
-  throw std::runtime_error(
-      "Viewport::loadFromProject not implemented for Qt >= 5");
+  throw std::runtime_error("Viewport::loadFromProject not implemented for Qt >= 5");
 #endif
 }
 

--- a/qt/widgets/instrumentview/src/Viewport.cpp
+++ b/qt/widgets/instrumentview/src/Viewport.cpp
@@ -75,6 +75,13 @@ void Viewport::setProjection(double l, double r, double b, double t,
     std::swap(m_bottom, m_top);
   m_near = nearz;
   m_far = farz;
+  // save the current projection bounds to reuse on view changes
+  m_leftOrig = m_left;
+  m_rightOrig = m_right;
+  m_topOrig = m_top;
+  m_bottomOrig = m_bottom;
+  m_nearOrig = m_near;
+  m_farOrig = m_far;
 }
 
 /**
@@ -253,6 +260,7 @@ void Viewport::setViewToXPositive() {
                              Mantid::Kernel::V3D(-1.0, 0.0, 0.0));
   m_quaternion = tempy;
   m_quaternion.GLMatrix(&m_rotationmatrix[0]);
+  adjustProjection();
 }
 
 /**
@@ -265,6 +273,7 @@ void Viewport::setViewToYPositive() {
                              Mantid::Kernel::V3D(0.0, -1.0, 0.0));
   m_quaternion = tempy;
   m_quaternion.GLMatrix(&m_rotationmatrix[0]);
+  adjustProjection();
 }
 
 /**
@@ -275,6 +284,7 @@ void Viewport::setViewToZPositive() {
   reset();
   m_quaternion.init();
   m_quaternion.GLMatrix(&m_rotationmatrix[0]);
+  adjustProjection();
 }
 
 /**
@@ -287,6 +297,7 @@ void Viewport::setViewToXNegative() {
                              Mantid::Kernel::V3D(1.0, 0.0, 0.0));
   m_quaternion = tempy;
   m_quaternion.GLMatrix(&m_rotationmatrix[0]);
+  adjustProjection();
 }
 
 /**
@@ -299,6 +310,7 @@ void Viewport::setViewToYNegative() {
                              Mantid::Kernel::V3D(0.0, 1.0, 0.0));
   m_quaternion = tempy;
   m_quaternion.GLMatrix(&m_rotationmatrix[0]);
+  adjustProjection();
 }
 
 /**
@@ -310,6 +322,29 @@ void Viewport::setViewToZNegative() {
   Mantid::Kernel::Quat tempy(180.0, Mantid::Kernel::V3D(0.0, 1.0, 0.0));
   m_quaternion = tempy;
   m_quaternion.GLMatrix(&m_rotationmatrix[0]);
+  adjustProjection();
+}
+
+void Viewport::adjustProjection() {
+  // reset the projection bounds to the original values
+  m_left = m_leftOrig;
+  m_right = m_rightOrig;
+  m_top = m_topOrig;
+  m_bottom = m_bottomOrig;
+  m_near = 0.0;
+  m_far = 0.0;
+  // rotate the original projection based on the new quaternion
+  m_quaternion.rotateBB(m_left, m_bottom, m_near, m_right, m_top, m_far);
+  // restore the Z bounds
+  m_near = m_nearOrig;
+  m_far = m_farOrig;
+  // update the GL projection with the new bounds
+  applyProjection();
+}
+
+void Viewport::getProjection(Mantid::Kernel::V3D &minBound, Mantid::Kernel::V3D &maxBound) const {
+  minBound = Mantid::Kernel::V3D(m_left, m_bottom, m_near);
+  maxBound = Mantid::Kernel::V3D(m_right, m_top, m_far);
 }
 
 /**

--- a/qt/widgets/instrumentview/src/Viewport.cpp
+++ b/qt/widgets/instrumentview/src/Viewport.cpp
@@ -325,7 +325,7 @@ void Viewport::setViewToZNegative() {
   adjustProjection(2);
 }
 
-void Viewport::adjustProjection(unsigned int axis) {
+void Viewport::adjustProjection(const unsigned int axis) {
   // reset the projection bounds to the original values
   m_left = m_leftOrig;
   m_right = m_rightOrig;
@@ -349,11 +349,6 @@ void Viewport::adjustProjection(unsigned int axis) {
   m_far = m_farOrig;
   // update the GL projection with the new bounds
   applyProjection();
-}
-
-void Viewport::getProjection(Mantid::Kernel::V3D &minBound, Mantid::Kernel::V3D &maxBound) const {
-  minBound = Mantid::Kernel::V3D(m_left, m_bottom, m_near);
-  maxBound = Mantid::Kernel::V3D(m_right, m_top, m_far);
 }
 
 /**


### PR DESCRIPTION
**Description of work.**

Fixes the camera projection when changing views  (Z+, Z-, etc) in the Instrument Viewer. The original camera projection was set, but never updated when a different view was selected. In some cases, this would cause the instrument to be off the screen.

**To test:**

<!-- Instructions for testing. -->

Load several instruments and open the Instrument Viewer. Change the axis view to all combinations to verify the view changes and the instrument is displayed properly.

Load an instrument that is offset, such as `/HFIR/CG2/IPTS-20794/nexus/CG2_18339.nxs.h5`. The default Z- view should display the entire instrument. Switching between other views should also work.

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

Version into `ornl-next`: #32346

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
