### PR TITLE
Auto adjust log scale range in SliceViewer when negative data present

### DIFF
--- a/buildconfig/CMake/VersionNumber.cmake
+++ b/buildconfig/CMake/VersionNumber.cmake
@@ -13,7 +13,7 @@ set ( VERSION_MINOR 1 )
 # examples: First release cadidate for tweak 1 is "-1-rc.1"
 #           Second release cadidate for tweak 1 is "-1-rc.2"
 #           Actual tweak release is "-1"
-set ( VERSION_TWEAK "-2-rc.3" )
+set ( VERSION_TWEAK "-2-rc.4" )
 
 # pep440 is incompatible with semantic versioning
 # https://www.python.org/dev/peps/pep-0440/

--- a/buildconfig/CMake/VersionNumber.cmake
+++ b/buildconfig/CMake/VersionNumber.cmake
@@ -13,7 +13,7 @@ set ( VERSION_MINOR 1 )
 # examples: First release cadidate for tweak 1 is "-1-rc.1"
 #           Second release cadidate for tweak 1 is "-1-rc.2"
 #           Actual tweak release is "-1"
-# set ( VERSION_TWEAK "-2-rc.2" )
+set ( VERSION_TWEAK "-2-rc.3" )
 
 # pep440 is incompatible with semantic versioning
 # https://www.python.org/dev/peps/pep-0440/

--- a/docs/source/release/v6.2.0/mantidworkbench.rst
+++ b/docs/source/release/v6.2.0/mantidworkbench.rst
@@ -28,6 +28,7 @@ New and Improved
 - The plot config dialog notifies the user when there has been an error applying the config to the plot, and allows them to change the config further.
 - When fitting a plot, selecting the peak type will only update the default peak shape in the settings if the "Set as global default" checkbox is ticked.
 - Added help button to the sliceviewer
+- SliceViewer can toggle between different scales again without any issue.
 
 Bugfixes
 --------

--- a/qt/python/mantidqt/widgets/colorbar/colorbar.py
+++ b/qt/python/mantidqt/widgets/colorbar/colorbar.py
@@ -282,7 +282,9 @@ class ColorbarWidget(QWidget):
         try:
             try:
                 masked_data = data[~data.mask]
-                masked_data = masked_data[np.nonzero(data)] if norm == "Log" else masked_data
+                # use the smallest positive value as vmin when using log scale,
+                # matplotlib will take care of the data skipping part.
+                masked_data = masked_data[data > 0] if norm == "Log" else masked_data
                 self.cmin_value = masked_data.min()
                 self.cmax_value = masked_data.max()
             except (AttributeError, IndexError):
@@ -321,7 +323,7 @@ class ColorbarWidget(QWidget):
     def _validate_mappable(self, mappable):
         index = NORM_OPTS.index("Log")
         if mappable.get_array() is not None:
-            if np.any(mappable.get_array() <= 0):
+            if np.all(mappable.get_array() <= 0):
                 self.norm.model().item(index, 0).setEnabled(False)
                 self.norm.setItemData(index, "Log scale is disabled for non-positive data",
                                       Qt.ToolTipRole)

--- a/qt/python/mantidqt/widgets/colorbar/colorbar.py
+++ b/qt/python/mantidqt/widgets/colorbar/colorbar.py
@@ -321,6 +321,7 @@ class ColorbarWidget(QWidget):
         return Normalize(vmin=cmin, vmax=cmax)
 
     def _validate_mappable(self, mappable):
+        """Disable the Log option if no positive value can be found from given data (image)"""
         index = NORM_OPTS.index("Log")
         if mappable.get_array() is not None:
             if np.all(mappable.get_array() <= 0):

--- a/qt/python/mantidqt/widgets/sliceviewer/presenter.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/presenter.py
@@ -75,6 +75,13 @@ class SliceViewer(ObservingPresenter):
         self.ads_observer = SliceViewerADSObserver(self.replace_workspace, self.rename_workspace,
                                                    self.ADS_cleared, self.delete_workspace)
 
+        # simulate clicking on the home button, which will force all signal and slot connections
+        # properly set.
+        # NOTE: Some part of the connections are not set in the correct, resulting in a strange behavior
+        #       where the colorbar and view is not updated with switch between different scales.
+        #       This is a ducktape fix and should be revisited once we have a better way to do this.
+        self.show_all_data_requested()
+
     def new_plot_MDH(self, dimensions_transposing=False, dimensions_changing=False):
         """
         Tell the view to display a new plot of an MDHistoWorkspace

--- a/qt/python/mantidqt/widgets/sliceviewer/presenter.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/presenter.py
@@ -80,7 +80,10 @@ class SliceViewer(ObservingPresenter):
         # NOTE: Some part of the connections are not set in the correct, resulting in a strange behavior
         #       where the colorbar and view is not updated with switch between different scales.
         #       This is a ducktape fix and should be revisited once we have a better way to do this.
-        self.show_all_data_requested()
+        # NOTE: This workaround solve the problem, but it leads to a failure in
+        #       projectroot.qt.python.mantidqt_qt5.test_sliceviewer_presenter.test_sliceviewer_presenter
+        #       Given that this issue is not of high priority, we are leaving it as is for now.
+        # self.show_all_data_requested()
 
     def new_plot_MDH(self, dimensions_transposing=False, dimensions_changing=False):
         """

--- a/qt/python/mantidqt/widgets/sliceviewer/test/test_sliceviewer_view.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/test/test_sliceviewer_view.py
@@ -357,10 +357,7 @@ class SliceViewerViewTest(unittest.TestCase, QtWidgetFinder):
             sys.stderr = stderr_orig
 
 
-
 # private helper functions
-
-
 def toolbar_actions(presenter, text_labels):
     """
     Return a list of actions with the given text labels

--- a/qt/python/mantidqt/widgets/sliceviewer/test/test_sliceviewer_view.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/test/test_sliceviewer_view.py
@@ -247,16 +247,7 @@ class SliceViewerViewTest(unittest.TestCase, QtWidgetFinder):
                                Units='1\\A,1\\A,1\\A')
         FakeMDEventData(ws, UniformParams="1000000")
         pres = SliceViewer(ws)
-        try:
-            # the ads handler catches all exceptions so that the handlers don't
-            # bring down the sliceviewer. Check if anything is writtent to stderr
-            stderr_capture = io.StringIO()
-            stderr_orig = sys.stderr
-            sys.stderr = stderr_capture
-            ws *= 100
-            self.assertTrue('Error occurred in handler' not in stderr_capture.getvalue(), msg=stderr_capture.getvalue())
-        finally:
-            sys.stderr = stderr_orig
+        self._assertNoErrorInADSHandlerFromSeparateThread(partial(scale_ws, ws))
 
         QApplication.sendPostedEvents()
 

--- a/qt/python/mantidqt/widgets/sliceviewer/view.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/view.py
@@ -558,6 +558,7 @@ class SliceViewerDataView(QWidget):
             exponent = self.conf.get(POWERSCALE)
             scale = (scale, exponent)
 
+        scale = "SymmetricLog10" if scale == 'Log' else scale
         return scale
 
     def scale_norm_changed(self):


### PR DESCRIPTION
**Description of work.**

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

- Original Gitlab User Story: [SCD403](https://code.ornl.gov/sns-hfir-scse/diffraction/single-crystal/single-crystal-diffraction/-/issues/403)
- ~~This is #32356 into `release-next`~~

This PR fixes an issue where negative values in the data set disables the Log scale.
In this PR, the following features are improved:
- When negative values are found within the slice of data and Log scale is selected, the minimum value for data mapping is automatically adjusted to the smallest positive value that can be found.
- If the scale of a previous SliceViewer is set to Log, a new sliceviewer will switch to `SymmeticLog10`.
- ~~The data range is automatically reset to full view.~~
> there is a slice viewer unit test preventing this feature, therefore we have to remove it from this PR.

**To test:**

- Build the branch
- Use the following script to create a MDE workspace with negative values

```python
# import mantid algorithms, numpy and matplotlib
from mantid.simpleapi import *
import matplotlib.pyplot as plt
import numpy as np

data_x = np.array([[1, 2, 3, 4, 5],[1, 2, 3, 4, 5],[1, 2, 3, 4, 5],[1, 2, 3, 4, 5]])
data_y= np.array([[0, 1, 10, 100],[-1, 0, 1, 10],[-10, -1, 0, 1],[-100, -10, -1, 0]])
ws = CreateWorkspace(DataX=data_x, DataY=data_y, NSpec=4)
mdws = CreateMDWorkspace(Dimensions=3, Extents='-10,10,-10,10,-10,10', Names='A,B,C', Units='U,U,U')
```
- use the slice viewer to view `ws`, and toggle between different scale to see effects.

<!-- Instructions for testing. -->

<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
