### PR TITLE
Fix Advanced Plot not laying-out correctly

### DIFF
--- a/docs/source/release/v6.2.0/mantidworkbench.rst
+++ b/docs/source/release/v6.2.0/mantidworkbench.rst
@@ -50,5 +50,6 @@ Bugfixes
 - Fixed a bug where the workspace index spinbox in the fit browser wouldn't update when the user added or removed curves from the figure.
 - Fixed out of range errors in the Sliceviewer that sometimes occured whilst hovering over transposed data.
 - Fixed the help icon not showing on OSX and high-resolution monitors.
+- Fixed the advanced plotting dialog incorrectly laying out, causing the options to be partially occluded.
 
 :ref:`Release 6.2.0 <v6.2.0>`

--- a/qt/python/mantidqt/dialogs/advancedplotswidget.ui
+++ b/qt/python/mantidqt/dialogs/advancedplotswidget.ui
@@ -15,7 +15,7 @@
   </property>
   <layout class="QGridLayout" name="gridLayout">
    <item row="0" column="0">
-    <layout class="QVBoxLayout" name="verticalLayout">
+    <layout class="QVBoxLayout" name="adv_plot_settings_layout">
      <item>
       <widget class="QCheckBox" name="error_bars_check_box">
        <property name="text">
@@ -24,20 +24,41 @@
       </widget>
      </item>
      <item>
-      <widget class="QGroupBox" name="log_options_group_box">
+      <widget class="QFrame" name="log_options_group_box">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
          <horstretch>0</horstretch>
          <verstretch>0</verstretch>
         </sizepolicy>
        </property>
-       <property name="title">
-        <string>Log Options</string>
-       </property>
-       <layout class="QGridLayout" name="gridLayout_3">
-        <item row="0" column="0">
-         <layout class="QGridLayout" name="gridLayout_2">
-          <item row="3" column="0">
+       <layout class="QVBoxLayout" name="verticalLayout_2">
+        <item>
+         <widget class="QLabel" name="label">
+          <property name="text">
+           <string>Log value to plot against:</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QComboBox" name="log_value_combo_box">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLabel" name="label_2">
+          <property name="text">
+           <string>Custom log values:</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <layout class="QHBoxLayout" name="log_entry_layout">
+          <item>
            <widget class="QLineEdit" name="custom_log_line_edit">
             <property name="enabled">
              <bool>false</bool>
@@ -47,7 +68,7 @@
             </property>
            </widget>
           </item>
-          <item row="3" column="1">
+          <item>
            <widget class="QPushButton" name="logs_valid">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
@@ -75,45 +96,21 @@
             </property>
            </widget>
           </item>
-          <item row="0" column="0" colspan="2">
-           <widget class="QLabel" name="label">
-            <property name="text">
-             <string>Log value to plot against:</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="0" colspan="2">
-           <widget class="QComboBox" name="log_value_combo_box">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="0" colspan="2">
-           <widget class="QLabel" name="label_2">
-            <property name="text">
-             <string>Custom log values:</string>
-            </property>
-           </widget>
-          </item>
-          <item row="4" column="0" colspan="2">
-           <widget class="QLabel" name="label_3">
-            <property name="text">
-             <string>Label for plot axis:</string>
-            </property>
-           </widget>
-          </item>
-          <item row="5" column="0" colspan="2">
-           <widget class="QLineEdit" name="plot_axis_label_line_edit">
-            <property name="enabled">
-             <bool>false</bool>
-            </property>
-           </widget>
-          </item>
          </layout>
+        </item>
+        <item>
+         <widget class="QLabel" name="label_3">
+          <property name="text">
+           <string>Label for plot axis:</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLineEdit" name="plot_axis_label_line_edit">
+          <property name="enabled">
+           <bool>false</bool>
+          </property>
+         </widget>
         </item>
        </layout>
       </widget>

--- a/qt/python/mantidqt/dialogs/spectraselectordialog.py
+++ b/qt/python/mantidqt/dialogs/spectraselectordialog.py
@@ -153,7 +153,6 @@ class SpectraSelectionDialog(SpectraSelectionDialogUIBase):
 
         if self._advanced:
             ui.advanced_options_widget = AdvancedPlottingOptionsWidget(parent=self)
-            self.setMinimumSize(300,351)
             ui.layout.replaceWidget(ui.advanced_plots_dummy_widget, ui.advanced_options_widget)
             if len(self._workspaces) > 2:
                 ui.plotType.addItem(SURFACE)


### PR DESCRIPTION
**Description of work.**
Fixes advanced plotting laying out correctly. This was a culmination of
issues:
- QGroupBox not respecting a layout (doing it's own thing)
- Us trying to "help" Qt by providing a minimum size, which then causes
it to start at that size

Additionally simplify the layout from a grid layout to the following:
- Top level vertical layout
- Embedded horizontal layout for the rebin options / indicator

This should give Qt an easier time than grid layout to maximise our
chances

**To test:**
- Create a sample workspace
- Open Plot Advanced and check it lays out correctly

Fixes #31680 

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
