### PR TITLE
Corrected link in Muon release notes

### DIFF
--- a/docs/source/release/v6.2.0/muon.rst
+++ b/docs/source/release/v6.2.0/muon.rst
@@ -71,7 +71,7 @@ Improvements
 - Added a table to store phasequads in the phase tab. Also, phasequads no longer delete themselves automatically.
 - The labels on the tabs in the GUIs will now show in full
 - When running the :ref:`DynamicKobuToyabe <func-DynamicKuboToyabe>` fitting function you should now be able to see the BinWidth to 3 decimal places.
-- It is now possible to select the normalisation (``analysis_asymmetry_norm``) and group (``analysis_group``) in the :ref:`Results Tab <muon-results-tab-ref>`.
+- It is now possible to select the normalisation (``analysis_asymmetry_norm``) and group (``analysis_group``) in the :ref:`Results Tab <muon_results_tab-ref>`.
 
 Bugfixes
 ########


### PR DESCRIPTION
**Description of work.**
One of the links to the Results Tab in the Muon interfaces appears to be incorrect in the release notes. This was not picked up on during either PR that involved adding/changing this link (#32298 and #32333) . 

**To test:**
- remove ```build/docs/doctrees```
- build the documents again and check there are no warnings
- Check the link in line 74 works correctly.

*There is no associated issue.*


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
