### PR TITLE
Make the divider in slice viewer more visible to users

### DIFF
--- a/docs/source/release/v6.2.0/mantidworkbench.rst
+++ b/docs/source/release/v6.2.0/mantidworkbench.rst
@@ -29,6 +29,7 @@ New and Improved
 - When fitting a plot, selecting the peak type will only update the default peak shape in the settings if the "Set as global default" checkbox is ticked.
 - Added help button to the sliceviewer
 - SliceViewer can toggle between different scales again without any issue.
+- SliceViewer uses a more visible divider between the main data view and the peaks table view.
 
 Bugfixes
 --------

--- a/qt/python/mantidqt/widgets/sliceviewer/view.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/view.py
@@ -18,8 +18,8 @@ from matplotlib.figure import Figure
 from mpl_toolkits.axisartist import Subplot as CurveLinearSubPlot
 from mpl_toolkits.axisartist.grid_helper_curvelinear import GridHelperCurveLinear
 from qtpy.QtCore import Qt, Signal
-from qtpy.QtWidgets import (QCheckBox, QComboBox, QGridLayout, QLabel, QHBoxLayout, QSplitter,
-                            QStatusBar, QToolButton, QVBoxLayout, QWidget)
+from qtpy.QtWidgets import (QCheckBox, QComboBox, QGridLayout, QLabel, QHBoxLayout, QSplitter, QStatusBar, QToolButton, QVBoxLayout,
+                            QWidget)
 
 # local imports
 from workbench.plotting.mantidfigurecanvas import MantidFigureCanvas
@@ -592,6 +592,15 @@ class SliceViewerView(QWidget, ObservingView):
         #  peaks viewer off by default
         self._peaks_view = None
 
+        # config the splitter appearance
+        splitterStyleStr = """QSplitter::handle{
+            border: 1px dotted gray;
+            min-height: 10px;
+            max-height: 20px;
+            }"""
+        self._splitter.setStyleSheet(splitterStyleStr)
+        self._splitter.setHandleWidth(1)
+
         layout = QHBoxLayout(self)
         layout.setContentsMargins(0, 0, 0, 0)
         layout.addWidget(self._splitter)
@@ -637,7 +646,7 @@ class SliceViewerView(QWidget, ObservingView):
 
     def set_peaks_viewer_visible(self, on):
         """
-        Set the visiblity of the PeaksViewer.
+        Set the visibility of the PeaksViewer.
         :param on: If True make the view visible, else make it invisible
         :return: The PeaksViewerCollectionView
         """


### PR DESCRIPTION
**Description of work.**

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

- Original Defect on Gitlab: [SCD203](https://code.ornl.gov/sns-hfir-scse/diffraction/single-crystal/single-crystal-diffraction/-/issues/203)

Users are complaining that the resize handle within slice viewer is difficult to locate when the peaks table view is enabled (see figure below).
![image](https://user-images.githubusercontent.com/5064852/132036144-f17c9883-865d-4a7f-9056-8fe6485c72be.png)

This PR modifies the appearance of the separator (QSplitter) such that it is more prominent and easy to grab (see figure below)
![image](https://user-images.githubusercontent.com/5064852/132036293-34a4caf8-d4e5-46d9-ae59-11f497341c21.png)

**To test:**
- Build the branch locally
- Download the testing data: 
[SXD23767.zip](https://github.com/mantidproject/mantid/files/7107273/SXD23767.zip)
- Use the following script to create a small workspace
```python
# import mantid algorithms, numpy and matplotlib
from mantid.simpleapi import *
import matplotlib.pyplot as plt
import numpy as np

import os

Load(Filename='SXD23767.raw',
     OutputWorkspace='SXD23767',
     LoaderName='LoadRaw',
     LoaderVersion='3')
ConvertToDiffractionMDWorkspace(InputWorkspace='SXD23767',
                                OutputWorkspace='SXD23767MD',
                                OneEventPerBin='0')
FindSXPeaks(InputWorkspace='SXD23767',
            PeakFindingStrategy='AllPeaks',
            AbsoluteBackground=2000,
            ResolutionStrategy='AbsoluteResolution',
            XResolution=200,
            PhiResolution=3,
            TwoThetaResolution=3,
            OutputWorkspace='peaks')
```
- Use the slice viewer to view `SXD23767MD` and toggle on the peaks overlay.

<!-- Instructions for testing. -->

<!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
