### PR TITLE
Fix framework release notes template

### DIFF
--- a/tools/release_generator/release.py
+++ b/tools/release_generator/release.py
@@ -118,17 +118,8 @@ Data Objects
 Python
 ------
 
-
-.. contents:: Table of Contents
-   :local:
-
-.. warning:: **Developers:** Sort changes under appropriate heading
-    putting new features at the top of the section, followed by
-    improvements, followed by bug fixes.
-
 Installation
 ------------
-
 
 MantidWorkbench
 ---------------


### PR DESCRIPTION
**Description of work.**
Removed an unnecessary duplication in the skeleton release notes generator for the framework release notes.

**To test:**
1. Go to `mantid/tools/release_generator`
2. Run `python release.py --release 6.4.0 --milestone "Release 6.4"`
3. Check that the skeleton release notes file `mantid/docs/source/release/v6.4.0/framework.rst` looks good.

*There is no associated issue.*

*This does not require release notes* because it is release notes.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
