### PR TITLE
Disable nonorthog view in sliceviewer when no UB present

### DIFF
--- a/docs/source/release/v6.2.0/framework.rst
+++ b/docs/source/release/v6.2.0/framework.rst
@@ -79,6 +79,7 @@ SliceViewer
 
 Bugfixes
 ########
+- Fix bug where non-orthogonal view was enabled on an orthogonal workspace with no UB.
 - Fixed cursor tracking from getting stuck and displaying incorrect signals when viewing MDHistogram workspaces in :ref:`sliceviewer`.
 
 

--- a/qt/python/mantidqt/widgets/sliceviewer/sliceinfo.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/sliceinfo.py
@@ -56,7 +56,7 @@ class SliceInfo:
         self._display_x, self._display_y, self._display_z = (None, ) * 3
         self._axes_tr = _unit_transform if nonortho_transform is None else nonortho_transform.tr
         self._axes_inv_tr = _unit_transform if nonortho_transform is None else nonortho_transform.inv_tr
-
+        self._qflags = qflags
         self._init(transpose, qflags)
 
     @property
@@ -79,6 +79,18 @@ class SliceInfo:
         Both display axes must be spatial for this to be supported.
         """
         return self._nonorthogonal_axes_supported
+
+    def set_transform(self, nonortho_transform: NonOrthogonalTransform):
+        if isinstance(nonortho_transform, NonOrthogonalTransform):
+            self._axes_tr = nonortho_transform.tr
+            self._axes_inv_tr = nonortho_transform.inv_tr
+            self._nonorthogonal_axes_supported = (self.frame == SpecialCoordinateSystem.HKL
+                                                  and self._qflags[self._display_x] and self._qflags[self._display_y])
+        else:
+            # e.g if None
+            self._axes_tr = _unit_transform
+            self._axes_inv_tr = _unit_transform
+            self._nonorthogonal_axes_supported = False
 
     def transform(self, point: Sequence) -> np.ndarray:
         """Transform a point to the slice frame.

--- a/qt/python/mantidqt/widgets/sliceviewer/sliceinfo.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/sliceinfo.py
@@ -90,7 +90,7 @@ class SliceInfo:
                          point[self._display_z]))
 
     def inverse_transform(self, point: Sequence) -> np.ndarray:
-        """Does the inverse fransform (inverse of self.transform) from slice
+        """Does the inverse transform (inverse of self.transform) from slice
         frame to data frame
 
         :param point: A 3D point in the slice frame
@@ -128,7 +128,8 @@ class SliceInfo:
             x_index, y_index = y_index, x_index
 
         self._nonorthogonal_axes_supported = (self.frame == SpecialCoordinateSystem.HKL
-                                              and qflags[x_index] and qflags[y_index])
+                                              and qflags[x_index] and qflags[y_index]
+                                              and not self._axes_tr == _unit_transform)
 
         if z_index is not None:
             self._slicevalue_z = self.slicepoint[z_index]

--- a/qt/python/mantidqt/widgets/sliceviewer/test/test_sliceviewer_sliceinfo.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/test/test_sliceviewer_sliceinfo.py
@@ -7,12 +7,14 @@
 #  This file is part of the mantid workbench.
 # std imports
 import unittest
+from numpy import radians
 
 # 3rd party
 from mantid.kernel import SpecialCoordinateSystem
 
 # local imports
 from mantidqt.widgets.sliceviewer.sliceinfo import SliceInfo
+from mantidqt.widgets.sliceviewer.transform import NonOrthogonalTransform
 
 
 class FakeTransform:
@@ -161,6 +163,19 @@ class SliceInfoTest(unittest.TestCase):
             transpose=True,
             range=[(-15, 15), None, None, (-5, -5)],
             qflags=(True, True, True, True))
+
+    def test_set_transform(self):
+        # make sliceinfo with unit transform (default)
+        info = SliceInfo(
+            frame=SpecialCoordinateSystem.HKL,
+            point=(None, None, 0.5),
+            transpose=False,
+            range=[None, None, (-15, 15)],
+            qflags=[True, True, True])
+
+        info.set_transform(NonOrthogonalTransform(angle=radians(120)))
+
+        self.assertEqual(info.can_support_nonorthogonal_axes(), True)
 
     # private
     def _assert_can_support_nonorthogonal_axes(self, expectation, frame, qflags, transform=None):

--- a/qt/python/mantidqt/widgets/sliceviewer/test/test_sliceviewer_sliceinfo.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/test/test_sliceviewer_sliceinfo.py
@@ -15,6 +15,14 @@ from mantid.kernel import SpecialCoordinateSystem
 from mantidqt.widgets.sliceviewer.sliceinfo import SliceInfo
 
 
+class FakeTransform:
+    def tr(self, x, y):
+        return x + 1, y - 1
+
+    def inv_tr(self, x, y):
+        pass
+
+
 class SliceInfoTest(unittest.TestCase):
     def test_construction_with_named_fields(self):
         frame, point, transpose, = SpecialCoordinateSystem.HKL, (None, None, 0.5), False
@@ -53,7 +61,7 @@ class SliceInfoTest(unittest.TestCase):
 
     def test_HKL_workspace_with_two_slice_spatial_dimensions_can_support_nonorthogonal_axes(self):
         self._assert_can_support_nonorthogonal_axes(
-            True, SpecialCoordinateSystem.HKL, qflags=[True, True, False])
+            True, SpecialCoordinateSystem.HKL, qflags=[True, True, False], transform=FakeTransform())
 
     def test_transform_selects_dimensions_correctly_when_not_transposed(self):
         # Set slice info such that display(X,Y) = data(Y,Z)
@@ -129,14 +137,6 @@ class SliceInfoTest(unittest.TestCase):
 
     def test_transform_respects_nonortho_tr_if_given(self):
         # Set slice info such that display(X,Y) = data(Z,Y)
-
-        class FakeTransform:
-            def tr(self, x, y):
-                return x + 1, y - 1
-
-            def inv_tr(self, x, y):
-                pass
-
         info = SliceInfo(
             frame=SpecialCoordinateSystem.HKL,
             point=(None, None, 0.5),
@@ -163,12 +163,13 @@ class SliceInfoTest(unittest.TestCase):
             qflags=(True, True, True, True))
 
     # private
-    def _assert_can_support_nonorthogonal_axes(self, expectation, frame, qflags):
+    def _assert_can_support_nonorthogonal_axes(self, expectation, frame, qflags, transform=None):
         frame, point, transpose, = frame, (None, None, 0.5), False
         dimrange, spatial = (None, None, (-15, 15)), qflags
 
         info = SliceInfo(
-            frame=frame, point=point, transpose=transpose, range=dimrange, qflags=spatial)
+            frame=frame, point=point, transpose=transpose, range=dimrange, qflags=spatial,
+            nonortho_transform=transform)
 
         self.assertEqual(expectation, info.can_support_nonorthogonal_axes())
 


### PR DESCRIPTION
**Description of work.**

Added check in sliceinfo object that a transform had been supplied before enabling non-ortho view - this fixed the original bug described in the issue.

However, still a problem in that the data_view that stores the transform used to make the sliceinfo object is not updated  with the transform unless non-ortho view is enabled, therefore it was still possible to incorrectly disable/enable the non-ortho view button - e.g. open a non-ortho workspace and transposing the non-ortho axes would disable the non-ortho button if it hadn't been clicked.

To fix this properly would require removing the circular dependence of the transform on model, slicinfo and data_view - it would probably be better to remove the transform from the slice-info and keep the data_view up-to-date with the model?
As a temporary bug fix, the sliceinfo is updated with the transform calculated by the model (using the sliceinfo initialised with a n transform supplied). To do this I have added a setter for the transform in the sliceinfo object.

To-Do
- release notes

**To test:**
(1) make workspaces using this script
```
# non orthog
ws_nonortho = CreateMDWorkspace(Dimensions='3', Extents='-6,6,-4,4,-0.5,0.5',
                       Names='H,K,L', Units='r.l.u.,r.l.u.,r.l.u.',
                       Frames='HKL,HKL,HKL',
                       SplitInto='2', SplitThreshold='50')

expt_info = CreateSampleWorkspace()
ws_nonortho.addExperimentInfo(expt_info)
SetUB(ws_nonortho, 1,1,2,90,90,120)

# orthog with UB
ws_ortho = CreateMDWorkspace(Dimensions='3', Extents='-6,6,-4,4,-0.5,0.5',
                       Names='H,K,L', Units='r.l.u.,r.l.u.,r.l.u.',
                       Frames='HKL,HKL,HKL',
                       SplitInto='2', SplitThreshold='50')
expt_info_ortho = CreateSampleWorkspace()
ws_ortho.addExperimentInfo(expt_info_ortho)
SetUB(ws_ortho, 1,1,2,90,90,90)

# orthog no UB
ws_ortho_noUB = CreateMDWorkspace(Dimensions='3', Extents='-6,6,-4,4,-0.5,0.5',
                       Names='H,K,L', Units='r.l.u.,r.l.u.,r.l.u.',
                       Frames='HKL,HKL,HKL',
                       SplitInto='2', SplitThreshold='50')

# orthog no UB 4D
ws_ortho_noUB_4D = CreateMDWorkspace(Dimensions=4, Extents=[-1,1,-1,1,-1,1,-10,10], Names="H,K,L,E", 
    Frames='HKL,HKL,HKL,General Frame',Units='r.l.u.,r.l.u.,r.l.u.,meV')
```
(2) check that the non-orthog view button is disabled for all permutation of viewing axes for orthogonal workspaces without a UB (i.e. `ws_ortho_noUB` and `ws_ortho_noUB_4D`)
(3) Check that for the workspaces with a UB (`ws_nonortho` that the `ws_ortho `) that the non-ortho view is enabled and clicking it gives the expected result (i.e. pairs of non-orthog axes are not perpendicular and orthog ones are). **Note that sliceviewer makes a transform for orthogonal workspaces if a UB exists but it is a unit/identity transform - there is no check for whether the angle between axes is actually != 90 deg.**
(4) Check a MatrixWorkspace has non-orthog disabled and that transposing data and changing viewing axes behaves as normal.

Fixes #32314

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
