### PR TITLE
Fix bug limiting fit range on IDA fitting tabs

### DIFF
--- a/docs/source/release/v6.2.0/indirect_geometry.rst
+++ b/docs/source/release/v6.2.0/indirect_geometry.rst
@@ -41,6 +41,7 @@ Bug Fixes
 - A bug has been fixed in Indirect data analysis on the F(Q)Fit tab, Multiple Input tab that allowed duplicate spectra to be added.
 - A bug has been fixed that stopped additional spectra being added to Indirect Data Analysis if spectra from that workspace had already been added.
 - :ref:`IndirectILLEnertyTransfer <algm-IndirectILLEnertyTransfer>` will now perform the monitor normalisation correctly; that is, in wavelength instead of energy. It will also provide the monitor workspace as a diagnostic output, if requested.
+- A bug has been fixed in Indirect Data Analysis that limited the integration range on the tabs to between -1 and 1.
 
 
 :ref:`Release 6.2.0 <v6.2.0>`

--- a/qt/scientific_interfaces/Indirect/IndirectDataAnalysisElwinTab.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectDataAnalysisElwinTab.cpp
@@ -219,13 +219,13 @@ void IndirectDataAnalysisElwinTab::setup() {
   // We always want one range selector... the second one can be controlled from
   // within the elwinTwoRanges(bool state) function
   auto integrationRangeSelector = m_uiForm.ppPlot->addRangeSelector("ElwinIntegrationRange");
-  integrationRangeSelector->setBounds(-1.0, 1.0);
+  integrationRangeSelector->setBounds(-DBL_MAX, DBL_MAX);
   connect(integrationRangeSelector, SIGNAL(minValueChanged(double)), this, SLOT(minChanged(double)));
   connect(integrationRangeSelector, SIGNAL(maxValueChanged(double)), this, SLOT(maxChanged(double)));
   // create the second range
   auto backgroundRangeSelector = m_uiForm.ppPlot->addRangeSelector("ElwinBackgroundRange");
   backgroundRangeSelector->setColour(Qt::darkGreen); // dark green for background
-  backgroundRangeSelector->setBounds(-1.0, 1.0);
+  backgroundRangeSelector->setBounds(-DBL_MAX, DBL_MAX);
   connect(integrationRangeSelector, SIGNAL(selectionChanged(double, double)), backgroundRangeSelector,
           SLOT(setRange(double, double)));
   connect(backgroundRangeSelector, SIGNAL(minValueChanged(double)), this, SLOT(minChanged(double)));

--- a/qt/scientific_interfaces/Indirect/IndirectDataAnalysisElwinTab.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectDataAnalysisElwinTab.cpp
@@ -852,11 +852,7 @@ void IndirectDataAnalysisElwinTab::setHorizontalHeaders(const QStringList &heade
   m_dataTable->setHorizontalHeaderLabels(headers);
 
   auto header = m_dataTable->horizontalHeader();
-#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
-  header->setResizeMode(0, QHeaderView::Stretch);
-#elif QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
   header->setSectionResizeMode(0, QHeaderView::Stretch);
-#endif
 }
 
 void IndirectDataAnalysisElwinTab::removeSelectedData() {

--- a/qt/scientific_interfaces/Indirect/IndirectDataAnalysisElwinTab.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectDataAnalysisElwinTab.cpp
@@ -852,7 +852,11 @@ void IndirectDataAnalysisElwinTab::setHorizontalHeaders(const QStringList &heade
   m_dataTable->setHorizontalHeaderLabels(headers);
 
   auto header = m_dataTable->horizontalHeader();
+#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
+  header->setResizeMode(0, QHeaderView::Stretch);
+#elif QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
   header->setSectionResizeMode(0, QHeaderView::Stretch);
+#endif
 }
 
 void IndirectDataAnalysisElwinTab::removeSelectedData() {

--- a/qt/scientific_interfaces/Indirect/IndirectDataAnalysisIqtTab.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectDataAnalysisIqtTab.cpp
@@ -190,7 +190,7 @@ void IndirectDataAnalysisIqtTab::setup() {
   setPreviewSpectrumMaximum(0);
 
   auto xRangeSelector = m_uiForm.ppPlot->addRangeSelector("IqtRange");
-  xRangeSelector->setBounds(-1.0, 1.0);
+  xRangeSelector->setBounds(-DBL_MAX, DBL_MAX);
 
   // signals / slots & validators
   connect(xRangeSelector, SIGNAL(selectionChanged(double, double)), this, SLOT(rangeChanged(double, double)));

--- a/qt/scientific_interfaces/Indirect/IndirectFitPlotView.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitPlotView.cpp
@@ -12,6 +12,7 @@
 
 #include <QMessageBox>
 #include <QTimer>
+#include <limits>
 
 #if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
 #include "MantidQtIcons/Icon.h"
@@ -277,7 +278,7 @@ void IndirectFitPlotView::setHWHMMinimum(double maximum) {
 
 void IndirectFitPlotView::addFitRangeSelector() {
   auto fitRangeSelector = m_topPlot->addRangeSelector("FitRange");
-  fitRangeSelector->setBounds(-1.0, 1.0);
+  fitRangeSelector->setBounds(-DBL_MAX, DBL_MAX);
 
   connect(fitRangeSelector, SIGNAL(minValueChanged(double)), this, SIGNAL(startXChanged(double)));
   connect(fitRangeSelector, SIGNAL(maxValueChanged(double)), this, SIGNAL(endXChanged(double)));
@@ -304,7 +305,7 @@ void IndirectFitPlotView::setBackgroundBounds() {
 
 void IndirectFitPlotView::addHWHMRangeSelector() {
   auto hwhmRangeSelector = m_topPlot->addRangeSelector("HWHM");
-  hwhmRangeSelector->setBounds(-1.0, 1.0);
+  hwhmRangeSelector->setBounds(-DBL_MAX, DBL_MAX);
   hwhmRangeSelector->setColour(Qt::red);
   hwhmRangeSelector->setRange(0.0, 0.0);
   hwhmRangeSelector->setVisible(false);


### PR DESCRIPTION
**Description of work.**

This PR fixes the range selectors in the indirect sdata analysis fit tabs so they can be set to any value

@SpencerHowells

**To test:**

1. open indirect data analysis
2. in each tab load some data
3. check that the default integretion rage is set to a sencible value
4. check that the min and max values can be set to any range.

*There is no associated issue.*

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
