### PR TITLE
Fix sort order on date modified column in the Engineering UI

### DIFF
--- a/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/data_handling/data_view.py
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/data_handling/data_view.py
@@ -32,6 +32,9 @@ class FileFilterProxyModel (QtCore.QSortFilterProxyModel):
         else:
             return model.isDir(index0) or fnmatch(fname,self.text_filter)
 
+    def sort(self, column, order):
+        self.sourceModel().sort(column, order)
+
 
 class FittingDataView(QtWidgets.QWidget, Ui_data):
     sig_enable_load_button = QtCore.Signal(bool)


### PR DESCRIPTION
**Description of work.**

Fix problem in the file browse dialog on the Fitting tab of the Engineering Diffraction UI. The sort order on the date modified column wasn't working. This is because this tab uses the non-native QFileDialog in order to implement some advanced filtering on the file list. The sort was treating the date values as strings. Fix by overriding the sort method to call sort on the underlying sourcemodel (which works fine)

**To test:**

Open the Engineering Diffraction UI (from the Interfaces, Diffraction menu)
Go to the Fitting tab
Press the Browse button and navigate to a folder containing some files from different months
Sort on the "Date Modified" column
Check the files are sorted properly (see attached issue for example of problem before this fix)

Fixes #32395.

*This does not require release notes* because **this bug was introduced in this release. The change to use the non-native QFileDialog on the Fitting tab is already covered in the release notes**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
