### PR TITLE
Copy over v6.2 and v6.3 release notes (ornlnext)

### DIFF
--- a/docs/source/release/v6.2.0/diffraction.rst
+++ b/docs/source/release/v6.2.0/diffraction.rst
@@ -5,110 +5,124 @@ Diffraction Changes
 .. contents:: Table of Contents
    :local:
 
-.. warning:: **Developers:** Sort changes under appropriate heading
-    putting new features at the top of the section, followed by
-    improvements, followed by bug fixes.
-
 Powder Diffraction
 ------------------
 New features
 ############
-- New algorithm :ref:`CombineDiffCal <algm-CombineDiffCal>` to calibrate groups of pixels after cross correlation so that diffraction peaks can be adjusted to the correct positions
-- New algorithm :ref:`SetSampleFromLogs <algm-SetSampleFromLogs>` inspects the sample enviroment logs for sample material and geometry information
-- New script for doing calibration by groups, :ref:`PowderDiffractionCalibration <calibration_tofpd_group_calibration-ref>`
 - New algorithm :ref:`CalculatePlaczek <algm-CalculatePlaczek>` to compute both first and second Placzek correction factors.
 - New algorithm :ref:`CacculatePlaczekSelfScattering2 <algm-CalculatePlaczekSelfScattering-v2>` utilizes :ref:`CalculatePlaczek <algm-CalculatePlaczek>` to compute first order correction.
-- New algorithm :ref:`MultipleScatteringCorrection <algm-MultipleScatteringCorrection>` to compute the multiple scattering correction factor for sample using numerical integration.
+- New algorithm :ref:`CombineDiffCal <algm-CombineDiffCal>` to calibrate groups of pixels after cross correlation so that diffraction peaks can be adjusted to the correct positions.
+- New algorithm :ref:`MultipleScatteringCorrection <algm-MultipleScatteringCorrection>` to compute the multiple scattering correction factor for a sample using numerical integration.
 - New algorithm :ref:`NOMADMedianDetectorTest <algm-NOMADMedianDetectorTest>` to mask pixels showing deficient or excessive total counts.
+- New script for doing calibration by groups, :ref:`PowderDiffractionCalibration <calibration_tofpd_group_calibration-ref>`.
+- New algorithm :ref:`SetSampleFromLogs <algm-SetSampleFromLogs>` inspects the sample enviroment logs for sample material and geometry information.
 
 Improvements
 ############
-- More input control parameters added to the group calibration routine, including peak function type for estimating offset after cross correlation and an option to turn on or off the smoothing of data for cross correlation purpose. The workflow of group calibration script is also polished to make it smoother. Accordingly, unit tests have been updated.
-- Documentation added for the group calibration routine for :ref:`PowderDiffractionCalibration <calibration_tofpd_group_calibration-ref>`, as as guidance for general users.
-- The group calibration routine for :ref:`PowderDiffractionCalibration <calibration_tofpd_group_calibration-ref>` is made more generic. Groups are now allowed with dedicated control parameters.
-- :ref:`ConvertDiffCal <algm-ConvertDiffCal-v1>` now optionally updates a previous calibration when converting offsets.
-- :ref:`SCDCalibratePanels <algm-SCDCalibratePanels-v2>` major interface update along with enabling the calibration of T0 and sample position.
-- :ref:`SCDCalibratePanels <algm-SCDCalibratePanels-v2>` minor interface update that allows fine control of bank rotation calibration.
-- :ref:`PDCalibration <algm-PDCalibration-v1>` has a new option to use the :ref:`IkedaCarpenterPV <func-IkedaCarpenterPV>` peak function.
-- :ref:`AlignAndFocusPowder <algm-AlignAndFocusPowder-v1>` permits masking of discrete wavelength ranges to zero, for resonance filtering
-- :ref:`SNAPReduce <algm-SNAPReduce-v1>` permits saving selected property names and values to file, to aid autoreduction.
-- Add a custom ttmode to the PEARL powder diffraction scripts for running with a custom grouping file
-- improve performance of :ref:`ApplyDiffCal <algm-ApplyDiffCal>` on large instruments eg WISH. This in turn improves the performance of :ref:`AlignAndFocusPowder <algm-AlignAndFocusPowder>`
-- :ref:`LoadILLPolarizedDiffraction <algm-LoadILLPolarizedDiffraction>` now sorts the polarization orientations and enforces spin-flip, then non-spin-flip order
-- :ref:`PolDiffILLReduction <algm-PolDiffILLReduction>` received a number of improvements: changes names of input workspaces to contain polarization information,
-  transmission can be provided as a number or a workspace group, new data averaging option depending on measurement 2theta, option to display all measured points
-  on a scatter plot, new option for self-attenuation treatment using measured tranmission.
-- added a 3mf format file describing the PEARL sample and environment shapes for the P-E press. Also fixed a couple of minor issues in the 3mf file format loader used in ref:`LoadSampleEnvironment  <algm-LoadSampleEnvironment>`
-- :ref:`LoadILLDiffraction <algm-LoadILLDiffraction>` now adds input run number also to a metadata field `run_list`, indended to contain a full list of numors, handled by :ref:`MergeRuns <algm-MergeRuns>`
-- :ref:`LoadWANDSCD <algm-LoadWANDSCD-v1>` now has a new option to perform normalization in the same loading process.
+* :ref:`AlignAndFocusPowder <algm-AlignAndFocusPowder-v1>` permits masking of discrete wavelength ranges to zero, for resonance filtering.
+* Improved performance of :ref:`ApplyDiffCal <algm-ApplyDiffCal>` on large instruments e.g. WISH. This in turn improves the performance of :ref:`AlignAndFocusPowder <algm-AlignAndFocusPowder>`.
+* :ref:`ConvertDiffCal <algm-ConvertDiffCal-v1>` now optionally updates a previous calibration when converting offsets.
+* :ref:`LoadILLDiffraction <algm-LoadILLDiffraction>` now adds input run number also to a metadata field `run_list`, intended to contain a full list of numbers, handled by :ref:`MergeRuns <algm-MergeRuns>`.
+* :ref:`LoadILLPolarizedDiffraction <algm-LoadILLPolarizedDiffraction>` now sorts the polarization orientations and enforces spin-flip, then non-spin-flip order.
+* :ref:`LoadWANDSCD <algm-LoadWANDSCD-v1>` has a new option to perform normalization in the same loading process.
+* :ref:`PDCalibration <algm-PDCalibration-v1>` has a new option to use the :ref:`IkedaCarpenterPV <func-IkedaCarpenterPV>` peak function.
+* :ref:`PolDiffILLReduction <algm-PolDiffILLReduction>` received a number of improvements
+
+  * Changes names of input workspaces to contain polarization information.
+  * Transmission can be provided as a number or a workspace group.
+  * New data averaging option depending on measurement 2theta.
+  * Option to display all measured points on a scatter plot.
+  * New option for self-attenuation treatment using measured transmission.
+
+* Several improvements have been made to the group calibration routine including
+
+  * More input control parameters, including peak function type for estimating offset after cross correlation and an option to turn on or off the smoothing of data for cross correlation purpose.
+  * The workflow of group calibration script is also polished to make it smoother. Accordingly, unit tests have been updated.
+  * Groups are now allowed with dedicated control parameters.
+  * Documentation has been added as a guidance for general users.
+  * Making it more generic.
+
+* :ref:`SNAPReduce <algm-SNAPReduce-v1>` permits saving selected property names and values to file, to aid autoreduction.
+* Add a custom ttmode to the PEARL powder diffraction scripts for running with a custom grouping file.
+* Added a 3mf format file describing the PEARL sample and environment shapes for the P-E press. Also fixed a couple of minor issues in the 3mf file format loader used in :ref:`LoadSampleEnvironment  <algm-LoadSampleEnvironment>`.
 
 Bugfixes
 ########
-- Fix the issue with the calibration diagnostics script when dealing with instruments of which the detector ID does not start from 0.
-- Fix the issue with :ref:`SNSPowderReduction <algm-SNSPowderReduction>` - when invalid height unit is encountered while reading sample log, we should continue by ignoring geometry and rely purely on user input.
-- fix d-spacing calculation when parabolic model is selected.
-- Correct equation for pseudo-voigt FWHM and mixing parameter in peak profile function :ref:`Bk2BkExpConvPV <func-Bk2BkExpConvPV>`.
+- Fixed the issue with the calibration diagnostics script when dealing with instruments of which the detector ID does not start from 0.
+- Fixed the issue with :ref:`SNSPowderReduction <algm-SNSPowderReduction>` - when an invalid height unit is encountered while reading sample log the geometry is ignored and it relies purely on user input.
+- Fixed a bug when converting TOF to d-spacing using diffractometer constants with non-zero DIFA when a parabolic model is selected.
+- Corrected the equation for pseudo-voigt FWHM and mixing parameter in peak profile function :ref:`Bk2BkExpConvPV <func-Bk2BkExpConvPV>`.
 
 Engineering Diffraction
 -----------------------
 New features
 ############
-- New setting for default peak function to fit in the Engineering Diffraction interface (initial default is :ref:`BackToBackExponential <func-BackToBackExponential>`).
-- Added serial fit capability to fitting tab in EngDiff UI - this fits all loaded workspaces with same initial parameters.
-- Add GSAS coefficients for parameters of peak profile function :ref:`Bk2BkExpConvPV <func-Bk2BkExpConvPV>` for ENGIN-X.
-- Automatically subtract background from runs on loading in EngDiff UI.
+- New setting for default peak function to fit in the :ref:`Engineering Diffraction interface<Engineering_Diffraction-ref>` (initial default is :ref:`BackToBackExponential <func-BackToBackExponential>`).
+- Added serial fit capability to :ref:`Fitting tab <ui engineering fitting>` in :ref:`Engineering Diffraction interface<Engineering_Diffraction-ref>` - this fits all loaded workspaces with same initial parameters.
+- Added GSAS coefficients for parameters of peak profile function :ref:`Bk2BkExpConvPV <func-Bk2BkExpConvPV>` for ENGIN-X.
+- Automatically subtracts background from runs on loading in :ref:`Engineering Diffraction interface<Engineering_Diffraction-ref>`.
 - The most recently created or loaded Calibration is now selected by default in the load path when the interface is opened.
-- The last used RB number is now saved for the next session
-- The generation of the files required for Vanadium normalization is now done on the Focus tab of the user interface. This means the Vanadium data can be updated without
-having to rerun the Ceria calibration. As part of this change the setting "Force Vanadium Recalculation" has been removed and the Vanadium run number input has been
-moved from the Calibration tab to the Focus tab. The Vanadium run number is also no longer written to the prm generated on the Calibration tab (Note: this is a breaking
-change and means .prm files generated from the EngDiff UI with older versions of Mantid won't load successfully)
+- The last used RB number is now saved for the next session.
+- The generation of the files required for Vanadium normalization is now done on the :ref:`Focus tab <ui engineering focus>` of the :ref:`Engineering Diffraction interface<Engineering_Diffraction-ref>`. This means the Vanadium data can be updated without
+  having to rerun the Ceria calibration. As part of this change the setting ``Force Vanadium Recalculation`` has been removed and the Vanadium run number input has been
+  moved from the :ref:`Calibration tab <ui engineering calibration>` to the :ref:`Focus tab <ui engineering focus>`. The Vanadium run number is also no longer written to the prm generated on the Calibration tab `(Note: this is a breaking
+  change and means .prm files generated from the EngDiff UI with older versions of Mantid won't load successfully)`.
 
 
 Improvements
 ############
-- The workflows for Calibration and Focusing in the EnggDiffraction GUI and EnginX scripts have been replaced to make use of faster, better tested C++ algorithms (PDCalibration) - as a result the following algorithms have been deprecated, and will likely be removed entirely in the next release: EnggCalibrate, EnggCalibrateFull, EnggFocus, EnggVanadiumCorrections.
-- The cropping/region of interest selection for Calibration/Focusing is now chosen only on the Calibration tab, to avoid confusion and duplication of input.
+- The workflows for Calibration and Focusing in the :ref:`Engineering Diffraction interface<Engineering_Diffraction-ref>` and EnginX scripts have been replaced to make use of faster, better tested C++ algorithms (:ref:`PDCalibration <algm-PDCalibration>`) - as a result the following algorithms have been deprecated, and will likely be removed entirely in the next release: :ref:`EnggCalibrate <algm-EnggCalibrate>`, :ref:`EnggCalibrateFull <algm-EnggCalibrateFull>`, :ref:`EnggFocus <algm-EnggFocus>`, :ref:`EnggVanadiumCorrections <algm-EnggVanadiumCorrections>`.
+- The cropping/region of interest selection for Calibration/Focusing is now chosen only on the :ref:`Calibration tab <ui engineering calibration>`, to avoid confusion and duplication of input.
 - The region of interest for Calibration/Focusing can now be selected with a user-supplied custom calibration file.
-- The Focused Run Files input box defaults to the last runs focused on the Focus tab, even if multiple runs were focussed
-- The full calibration setting now has a default value consisting of the path to the ENGINX_full_instrument_calibration_193749.nxs file
-- The usability of the file finder on the Fitting tab has been improved by the addition of file filters based on unit and/or bank
+- The Focused Run Files input box defaults to the last runs focused on the :ref:`Focus tab <ui engineering focus>`, even if multiple runs were focussed.
+- The full calibration setting now has a default value consisting of the path to the ``ENGINX_full_instrument_calibration_193749.nxs file``.
+- **The usability of the file finder on the** :ref:`Fitting tab <ui engineering fitting>` **has been improved by the addition of file filters based on unit and/or bank.**
+
+.. image::  ../../images/EngDiff_Fit_Browse_Filters.png
+   :align: center
+   :height: 400px
+
 
 Bugfixes
 ########
-- Sequential fitting in the EngDiff UI now uses the output of the last successful fit (as opposed to the previous fit) as the initial parameters for the next fit.
-- An empty Engineering Diffraction interface is no longer saved if the user saves a project having previously had the interface open at some point in that session
-- The help button on the Engineering Diffraction interface points to the correct page, having been broken in the last release
-- Using the Clear button on the Workspace widget while using the Fitting tab no longer causes issues when you try to load runs back in.
-- On the fitting tab of the EngDiff UI the background can be inspected whether the background subtraction box is checked or not.
+- Sequential fitting in the :ref:`Engineering Diffraction interface<Engineering_Diffraction-ref>` now uses the output of the last successful fit (as opposed to the previous fit) as the initial parameters for the next fit.
+- If the user saves a project having previously opened and closed the :ref:`Engineering Diffraction interface<Engineering_Diffraction-ref>`, loading the project will not re-open the interface.
+- The help button on the :ref:`Engineering Diffraction interface<Engineering_Diffraction-ref>` points to the correct page, having been broken in the last release.
+- Using the Clear button on the Workspace widget while using the :ref:`Fitting tab <ui engineering fitting>` no longer causes errors when you try to load runs back in.
+- On the :ref:`Fitting tab <ui engineering fitting>` of the :ref:`Engineering Diffraction interface<Engineering_Diffraction-ref>` the background can be inspected whether the background subtraction box is checked or not.
 
 Single Crystal Diffraction
 --------------------------
 New features
 ############
-- New algorithm :ref:`HB3AIntegrateDetectorPeaks <algm-HB3AIntegrateDetectorPeaks>` for integrating four-circle data from HB3A in detector space.
 - New algorithm :ref:`ApplyInstrumentToPeaks <algm-ApplyInstrumentToPeaks>` to update the instrument of peaks within a PeaksWorkspace.
-- New plotting script that provides diagnostic plots of SCDCalibratePanels output.
-- New plotting script that provides diagnositc plots of SCDCalibratePanels2 on a per panel/bank basis.
-- Exposed :meth:`mantid.api.IPeak.getCol` and :meth:`mantid.api.IPeak.getRow` to python
-- Added two integration methods to :ref:`HB3AIntegrateDetectorPeaks <algm-HB3AIntegrateDetectorPeaks>` for simple cuboid integration with and without fitted background.
 - New algorithm :ref:`ConvertPeaksWorkspace <algm-ConvertPeaksWorkspace>` for quick conversion between PeaksWorkspace and LeanElasticPeaksWorkspace.
-- New definition file for D19 ILL instrument added.
 - New algorithm :ref:`FindGlobalBMatrix <algm-FindGlobalBMatrix>` that refines common lattice parameters across peak workspaces from multiple runs with a different U matrix (which encodes the orientation) per run.
+- New algorithm :ref:`HB3AIntegrateDetectorPeaks <algm-HB3AIntegrateDetectorPeaks>` for integrating four-circle data from HB3A in detector space using simple cuboid integration with and without fitted background.
+- New plotting script that provides diagnostic plots of :ref:`SCDCalibratePanels <algm-SCDCalibratePanels-v2>` on a per panel/bank basis.
+- Exposed :meth:`mantid.api.IPeak.getCol` and :meth:`mantid.api.IPeak.getRow` to python.
+- New definition file for D19 ILL instrument added.
 
 Improvements
 ############
-- Find detector in peaks will check which det is closer when dealing with peak-in-gap situation for tube-type detectors.
-- Existing :ref:`SCDCalibratePanels <algm-SCDCalibratePanels-v2>` now provides better calibration of panel orientation for flat panel detectors.
-- Existing :ref:`DGSPlanner <dgsplanner-ref>` expanded to support WAND²
-- Existing :ref:`MaskPeaksWorkspace <algm-MaskPeaksWorkspace-v1>` now also supports tube-type detectors used at the CORELLI instrument.
-- Existing :ref:`SCDCalibratePanels <algm-SCDCalibratePanels-v2>` now retains the value of small optimization results instead of zeroing them.
-- Existing :ref:`IntegrateEllipsoids <algm-IntegrateEllipsoids-v1>` now can use a different integrator for satellite peaks.
-- New option in :ref:`IntegrateEllipsoids <algm-IntegrateEllipsoids-v1>` to share Bragg peak background with satellite peaks.
+
+* Existing :ref:`DGSPlanner <dgsplanner-ref>` expanded to support WAND².
+* Existing algorithm :ref:`IntegrateEllipsoids <algm-IntegrateEllipsoids-v1>` now can use a different integrator for satellite peaks.
+* New option in :ref:`IntegrateEllipsoids <algm-IntegrateEllipsoids-v1>` to share Bragg peak background with satellite peaks.
+* Existing algorithm :ref:`MaskPeaksWorkspace <algm-MaskPeaksWorkspace-v1>` now also supports tube-type detectors used at the CORELLI instrument.
+* Improvements to :ref:`SCDCalibratePanels <algm-SCDCalibratePanels-v2>` including
+
+  * major interface update
+  * enabling the calibration of T0 and sample position
+  * fine control of bank rotation calibration
+  * better calibration of panel orientation for flat panel detectors
+  * retains the value of small optimization results instead of zeroing them.
+
+* Find detector in peaks will check which detector is closer when dealing with peak-in-gap situation for tube-type detectors.
 
 Bugfixes
 ########
-- Expand the Q space search radius in DetectorSearcher to avoid missing peaks when using :ref:`PredictPeaks <algm-PredictPeaks>`.
 - :ref:`IndexPeaks <algm-IndexPeaks>` can now index peaks in a PeaksWorkspace with only a single run without optimising the UB (i.e. it is now possible to set CommonUBForAll=True in this instance).
+- Expanded the Q space search radius in DetectorSearcher to avoid missing peaks when using :ref:`PredictPeaks <algm-PredictPeaks>`.
 
 :ref:`Release 6.2.0 <v6.2.0>`

--- a/docs/source/release/v6.2.0/direct_geometry.rst
+++ b/docs/source/release/v6.2.0/direct_geometry.rst
@@ -11,12 +11,8 @@ Direct Geometry
 New Algorithms
 ##############
 
-- :ref:`ApplyDetailedBalanceMD <algm-ApplyDetailedBalanceMD>` to apply detailed balance to MDEvents
+- :ref:`ApplyDetailedBalanceMD <algm-ApplyDetailedBalanceMD>` to apply detailed balance to MDEvents.
 - :ref:`DgsScatteredTransmissionCorrectionMD <algm-DgsScatteredTransmissionCorrectionMD>` weights the intensity of each detected event according to its final energy.
-
-.. warning:: **Developers:** Sort changes under appropriate heading
-    putting new features at the top of the section, followed by
-    improvements, followed by bug fixes.
 
 
 CrystalField
@@ -24,14 +20,40 @@ CrystalField
 
 Improvements
 ############
-- Added documentation and warning messages in the :ref:`Crystal Field Python Interface` related to IntensityScaling
+- Added documentation and warning messages in the :ref:`Crystal Field Python Interface` related to IntensityScaling.
+- The order of detector efficiency correction and rebinning in :ref:`algm-DirectILLReduction` has been inversed.
+- :ref:`LoadILLTOF <algm-LoadILLTOF>` now adds input run number to a metadata field `run_list`, intended to contain a full list of run numbers, handled by :ref:`MergeRuns <algm-MergeRuns>`.
 
 BugFixes
 ########
-- A bug has been fixed in the plot methods for CrystalField and CrystalFieldMultiSite
-- Fixed a bug in the :ref:`Crystal Field Python Interface` which prevented the application of IntensityScaling factors
+- A bug has been fixed in :ref:`ConvertToMD <algm-ConvertToMD>` that sometimes crashes Mantid when files are summed together.
+- Fixed a bug in the :ref:`Crystal Field Python Interface` which prevented the application of IntensityScaling factors.
+- A bug has been fixed in the plot methods for CrystalField and CrystalFieldMultiSite.
 - Peaks are (re)set upon rebuilding the single spectrum function as a multi-spectrum function
   due to the physical properties. This re-setting peaks is needed to maintain the intended ties.
-- A bug has been fixed in :ref:`ConvertToMD <algm-ConvertToMD>` that sometimes crashes Mantid when files are summed together.
+- A bug has been fixed in :ref:`PyChop` that caused crashes when no Ei was specified.
+
+
+MSlice
+------
+
+Improvements
+############
+- Added tests for script generation functions.
+- **Added new tab with plots manager to** :ref:`MSlice GUI<MSlice-ref>`.
+
+.. image::  ../../images/MSlice_plot_manager.png
+   :align: center
+   :height: 650px
+
+- **Enable powder (Bragg) peaks on cut plots.**
+
+.. image::  ../../images/Bragg_peak_cut_plot.png
+   :align: center
+   :height: 700px
+
+BugFixes
+########
+- Fixed an issue that caused overplot information on slice plots to get lost after replotting.
 
 :ref:`Release 6.2.0 <v6.2.0>`

--- a/docs/source/release/v6.2.0/framework.rst
+++ b/docs/source/release/v6.2.0/framework.rst
@@ -5,45 +5,67 @@ Framework Changes
 .. contents:: Table of Contents
    :local:
 
-.. warning:: **Developers:** Sort changes under appropriate heading
-    putting new features at the top of the section, followed by
-    improvements, followed by bug fixes.
-
-Concepts
---------
-
 Algorithms
 ----------
+
+New Features
+############
+
+- A new algorithm :ref:`Stitch <algm-Stitch>` will perform stitching of multiple 2D workspaces by calculating the scale factors as medians of point-wise ratios in the overlap regions.
+- All remote algorithms have been deprecated as they have not been used since v3.8.
+
 
 Improvements
 ############
 
-- :ref:`CrossCorrelate <algm-CrossCorrelate>` has additional parameter to set the maximum d-space shift during cross correlation
-
-Fit Functions
--------------
-- new method `IPeakFunction::intensityError` calculates the error in the integrated intensity of the peak due to uncertainties in the values of the fit parameters.
-
-Data Objects
-------------
-
-Python
-------
-
-
-.. contents:: Table of Contents
-   :local:
-
-.. warning:: **Developers:** Sort changes under appropriate heading
-    putting new features at the top of the section, followed by
-    improvements, followed by bug fixes.
+- :ref:`CreateSampleWorkspace <algm-CreateSampleWorkspace>` has new property InstrumentName.
+- :ref:`CrossCorrelate <algm-CrossCorrelate>` has additional parameter to set the maximum d-space shift during cross correlation.
+- :ref:`Load <algm-Load>` will now set output properties of all types, not just workspaces.
+- :ref:`LoadNexusMonitors <algm-LoadNexusMonitors-v2>` now utilizes the log filter provided by :ref:`LoadNexusLogs <algm-LoadNexusLogs>`.
+- :ref:`LoadRaw <algm-LoadRaw>` will now ignore empty ICPalarm log files.
+- :ref:`SaveAscii <algm-SaveAscii>` will no longer throw an error if `WriteXErrors` is requested, but there are no `Dx` data present in the workspace.
 
 Bugfixes
 ########
-- Fix a bug (crash) in plotting MD workspaces when "Normalize to bin width" is set to False
 
-Installation
+- Fix bug in :ref:`CalculateMultipleScattering <algm-CalculateMultipleScattering>` where detector position was incorrectly determined on a workspace where the workspace index didn't match the detector
+  index e.g. if the workspace was loaded with ``SpectrumMin`` specified to exclude some monitors.
+- Fixed bug in :ref:`algm-ConvertToMDMinMaxLocal` where wrong min max calculated if the workspace includes monitor spectra or spectra without any detectors.
+- Added parser for input Names to :ref:`algm-CreateMDHistoWorkspace` to allow inputs such as `Names='[H,0,0],[0,K,0],[0,0,L]'`.
+- Fixed a bug in :ref:`FitGaussianPeaks <algm-FitGaussianPeaks>` algorithm in which a peak at the end of range would cause an error due to not enough data point being available to fit parameters.
+- Fixed a rare divide-by zero error when running :ref:`GetEi <algm-GetEi>` on noisy data.
+- Fixed a crash when running :ref:`IntegrateEPP <algm-IntegrateEPP>` on a workspace group via the algorithm dialog.
+- :ref:`LoadNexusLogs <algm-LoadNexusLogs>` now creates a warning message for logs that are poorly formed and the other logs are loaded. Previously it stopped loading logs at that point.
+- Fixed a bug where :ref:`LoadRaw <algm-LoadRaw>` would not load all log files for raw files with an alternate data stream.
+- Fixed a problem calculating default beam size in :ref:`MonteCarloAbsorption <algm-MonteCarloAbsorption>` when sample is offset from origin.
+
+Fit Functions
+-------------
+New Features
+############
+- A new method, ``IPeakFunction.intensityError``, calculates the error in the integrated intensity of the peak due to uncertainties in the values of the fit parameters. For more details see :ref:`IPeakFunction<mantid.api.IPeakFunction>`.
+- Exposed the method ``functionDeriv`` to the python interface.
+
+
+Data Objects
 ------------
+New Features
+############
+- **Sample shapes which are CSGObjects can now be plotted. Shapes can also be merged, such as a sphere with a cylindrical hole. For more details see** :ref:`Mesh_Plots`.
+
+.. image::  ../../images/MeshPlotHelp-2.png
+   :align: center
+   :height: 500px
+
+- CSGObject Sample Shapes defined with :ref:`SetSample <algm-SetSample>` can be manually rotated using the ``rotate`` and ``rotate-all`` tags.
+  Also, Sample shapes (both MeshObjects and CSGObjects) are automatically rotated by any rotations from :ref:`SetGoniometer <algm-SetGoniometer>`.
+  This works with :ref:`CopySample <algm-CopySample>`, so the copied shape can be plotted, but the goniometer angle set on the new workspace is applied.
+
+Python
+------
+Bugfixes
+########
+- Fixed a crash that occurs in plotting MD workspaces when "Normalize to bin width" is set to False.
 
 
 MantidWorkbench
@@ -51,25 +73,13 @@ MantidWorkbench
 
 See :doc:`mantidworkbench`.
 
-Algorithms
-----------
-
-Improvements
-############
-- :ref:`LoadNexusMonitors <algm-LoadNexusMonitors-v2>` now utilizes the log filter provided by `LoadNexusLogs <algm-LoadNexusLogs>`
-
-Bugfixes
-########
-- :ref:`LoadNexusLogs <algm-LoadNexusLogs>` now logs that are poorly formed create a warning message and the other logs are loaded. Previously it stopped loading logs at that point.
 
 SliceViewer
 -----------
 
-Improvements
-############
-
 Bugfixes
 ########
-- Fix cursor tracking from getting stuck and displaying incorrect signals when viewing MDHistogram workspaces in :ref:`sliceviewer`.
+- Fixed cursor tracking from getting stuck and displaying incorrect signals when viewing MDHistogram workspaces in :ref:`sliceviewer`.
+- Fixed bug in resetting axes limits in nonorthogonal view when a plot is updated in sliceviewer.
 
 :ref:`Release 6.2.0 <v6.2.0>`

--- a/docs/source/release/v6.2.0/indirect_geometry.rst
+++ b/docs/source/release/v6.2.0/indirect_geometry.rst
@@ -5,8 +5,42 @@ Indirect Geometry Changes
 .. contents:: Table of Contents
    :local:
 
-.. warning:: **Developers:** Sort changes under appropriate heading
-    putting new features at the top of the section, followed by
-    improvements, followed by bug fixes.
+New Features
+############
+- Fit functions `ElasticIsoRotDiff` and `InelasticIsoRotDiff` have been made available in the ConvFit tab in the Indirect Data Analysis
+- A new option "Autoconvolution" is added to the Abins Algorithm.
+  This enables simulation of quantum orders up to order 10 by
+  convolving the highest calculated spectrum (order 1 or 2) against
+  the fundamentals spectrum repeatedly, before applying Debye-Waller
+  terms. (NB: This has introduced small numerical differences from
+  previous versions of Abins, because data is now binned before
+  applying Debye-Waller terms. This difference will converge with
+  small bin sizes.)
+
+Improvements
+############
+- Single input has been removed from the Indirect Data Analysis Fit tabs. All data input is now done via the multiple input dialog.
+- The data input widgets in the Indirect Data Analysis fit tabs has been made dockable and can be resized once undocked.
+- Introduced multithreading for detectors/spectra to VesuvioCalculateMS in order to speed up the VesuvioAnalysis algorithm.
+- The Elwin tab in Indirect Data Analysis has a new loader which now allows users to add workspaces.
+- The Abins Algorithm can now import XML data from VASP calculations
+  using "selective dynamics" to restrict the set of atoms active in
+  vibrations. The data is imported and processed as though these are
+  the only atoms in the system, with appropriately-dimensioned
+  displacement data. This approximation is useful for the study of
+  light (e.g. organic) molecules adsorbed to surfaces of heavy
+  (e.g. noble-metal) catalysts.
+- Abins: Thresholding of low-intensity modes has been changed. This
+  impacts the second-order spectrum, especially at elevated
+  temperature; excitations were being discarded on the basis of a low
+  intensity in the fundamental spectrum, when they could contribute to a
+  noticable peak in the second-order spectrum.
+
+Bug Fixes
+#########
+- A bug has been fixed in Indirect data analysis on the F(Q)Fit tab, Multiple Input tab that allowed duplicate spectra to be added.
+- A bug has been fixed that stopped additional spectra being added to Indirect Data Analysis if spectra from that workspace had already been added.
+- :ref:`IndirectILLEnertyTransfer <algm-IndirectILLEnertyTransfer>` will now perform the monitor normalisation correctly; that is, in wavelength instead of energy. It will also provide the monitor workspace as a diagnostic output, if requested.
+
 
 :ref:`Release 6.2.0 <v6.2.0>`

--- a/docs/source/release/v6.2.0/mantidworkbench.rst
+++ b/docs/source/release/v6.2.0/mantidworkbench.rst
@@ -8,12 +8,52 @@ Mantid Workbench Changes
 New and Improved
 ----------------
 
+- Superplot is a new decorator widget for the plot window. It facilitates over-plotting and manipulation of overplotted data. See :ref:`Superplot documentation <WorkbenchSuperplot>` for more information.
+
+.. figure:: ../../images/superplot_1.png
+    :width: 500px
+    :align: center
+
 - Workflow diagrams in help pages are now ``.svg`` rather than ``.png``
 - Peaks can now be added or removed from a PeaksWorkspace using the :ref:`peaks overlay <sliceviewer_peaks_overlay>` in :ref:`sliceviewer`.
+- The list of eligible workspaces in the `WorkspaceSelector` can now be sorted by name
+- New widget and workbench plugin: `WorkspaceCalculator`, allows to perform binary operations and scaling by a floating number on workspaces;
+  This will require your widget layout to be reset when starting workbench v6.2.0 for the first time. Previously saved layouts accessible from ``View > User Layouts``
+  may need to be saved again to include the workspace calculator widget.
+- Added tooltips to all the widgets in the Slice Viewer. Please contact the developers if any are missing.
+- Script editor tab completion and call tip support for Numpy 1.21
+- The visibility of a component parameter in the Pick tab of the InstrumentViewer is now steered by the 'visible' atrribute of a parameter in IPF
+- Plot legends can be shown or hidden from the plot context menu.
+- ADS signal handlers are now synchronized in `WorkspaceSelector`. This reduces the probability of hard crash when interacting with the widget while a script manipulating a large number of workspaces is being run.
+- The plot config dialog notifies the user when there has been an error applying the config to the plot, and allows them to change the config further.
+- When fitting a plot, selecting the peak type will only update the default peak shape in the settings if the "Set as global default" checkbox is ticked.
+- Added help button to the sliceviewer
+- SliceViewer can toggle between different scales again without any issue.
+- SliceViewer uses a more visible divider between the main data view and the peaks table view.
 
 Bugfixes
 --------
 
+- "Grid" checkbox in "Edit axis" dialog, and "Grids on/off" toolbar button will now have the correct checked state when running a plot script with major grid lines.
+- Scroll bars added to about dialog if screen resolution is too low.
+- Fixed missing 'on top' windowing behaviour for the matrix and table workspace data displays.
+- Sliceviewer now doesn't normalise basis vectors for HKL data such that Bragg peaks appear at integer HKL for cuts along e.g. HH0
+- Uninstalling from Windows "Apps & features" list will now run the uninstaller as the current Windows user and delete all shortcuts.
+- Fixed a bug where parameters wouldn't update in the fit property browser when fitting a single function with ties.
+- Fixed a bug retrieving algorithm history from a workspace when the retrieval methods were chained together.
+- Added missing icon for the uninstaller in Windows "Apps & features" list.
+- Fixed a bug where output workspaces of different types would interfere with successive calls to binary operations, such as multiply.
+- Fixed JSON serialization issue of MantidAxType by explicitly extracting its value
 - Fixed a bug in the Sliceviewer when transposing MDE workspaces multiple times would cause the data to become all zeros.
+- Fixed a bug in colorfill plots which lead to the loss of a spectrum from the resulting image.
+- Fixed a bug where the errorbar tab in the figure options was wrongly enabled while selecting multiple curves.
+- Fixed a bug where removing the plot guess line in the fit browser could lead to an exception being thrown.
+- Fixed a bug where marker formatting options were disabled upon opening the figure options.
+- Fixed a bug where the workspace index spinbox in the fit browser wouldn't update when the user added or removed curves from the figure.
+- Fixed out of range errors in the Sliceviewer that sometimes occured whilst hovering over transposed data.
+- Fixed the help icon not showing on OSX and high-resolution monitors.
+- Tabbing between fields in the error reporter now works as expected, rather than jumping to a random place each time.
+- Fixed the advanced plotting dialog incorrectly laying out, causing the options to be partially occluded.
+
 
 :ref:`Release 6.2.0 <v6.2.0>`

--- a/docs/source/release/v6.2.0/muon.rst
+++ b/docs/source/release/v6.2.0/muon.rst
@@ -5,8 +5,131 @@ MuSR Changes
 .. contents:: Table of Contents
    :local:
 
-.. warning:: **Developers:** Sort changes under appropriate heading
-    putting new features at the top of the section, followed by
-    improvements, followed by bug fixes.
+Frequency Domain Analysis
+-------------------------
+
+New Features
+############
+
+- The Frequency Domain Analysis interface now allows you to perform a sequential fit using the :ref:`Sequential Fitting Tab <muon_sequential_fitting_tab-ref>`.
+- The :ref:`Sequential Fitting Tab <muon_sequential_fitting_tab-ref>` allows you to choose the type of dataset you want to fit.
+- **New** :ref:`Maxent Dual Plot <Maxent_Dual_Plot-ref>` **option has been added to the plotting. This will show the reconstructed data and the
+  raw data together, along with the frequency domain data.**
+
+.. image::  ../../images/maxent_dual_plot.png
+   :align: center
+   :height: 800px
+
+Improvements
+############
+
+- Frequency Domain Analysis can now use groups in :ref:`MuonMaxent <algm-MuonMaxent>` calculations.
+- It is easier to select data for Maxent calculations.
+
+Bugfixes
+########
+
+- In frequency domain analysis the phasetables calculated from :ref:`MuonMaxent <algm-MuonMaxent>` can be used for
+  :ref:`PhaseQuad <algm-PhaseQuad>` calculations on the phase tab.
+
+Muon Analysis
+-------------
+
+New Features
+############
+
+- Users can now copy sequential fitting parameters to all other runs using the ``Copy fit parameters to all`` checkbox.
+- **The** :ref:`Model Fitting Tab <muon_model_fitting_tab-ref>` **allows you to perform fits across the sample logs and fit parameters stored in your results table.**
+
+.. image::  ../../images/muon_model_fitting_tab.PNG
+   :align: center
+   :height: 800px
+
+
+Muon Analysis and Frequency Domain Analysis
+-------------------------------------------
+
+New Features
+############
+
+- It is now possible to exclude a single range from a fit range when doing a fit on the :ref:`Fitting Tab <muon_fitting_tab-ref>`.
+- Added a ``Covariance Matrix`` button to the :ref:`Fitting Tab <muon_fitting_tab-ref>` that can be used to open and inspect the normalised covariance parameters of a fit.
+- It is now possible to plot the raw count data in the GUI.
+- **It is now possible to perform an Automatic or Manual background correction in the new** :ref:`Corrections Tab <muon_corrections_tab-ref>`.
+
+.. image::  ../../images/muon_corrections_tab.PNG
+   :align: center
+   :height: 800px
+
+Improvements
+############
+
+- It is now possible to do a vertical resize of the plot in Muon Analysis and Frequency Domain Analysis.
+- The plotting has been updated for better stability.
+- The plotting now has autoscale active by default.
+- It is now possible to load nexusV2 files in the GUI.
+- Added a table to store phasequads in the phase tab. Also, phasequads no longer delete themselves automatically.
+- The labels on the tabs in the GUIs will now show in full
+- When running the :ref:`DynamicKobuToyabe <func-DynamicKuboToyabe>` fitting function you should now be able to see the BinWidth to 3 decimal places.
+- It is now possible to select the normalisation (``analysis_asymmetry_norm``) and group (``analysis_group``) in the :ref:`Results Tab <muon_results_tab-ref>`.
+
+Bugfixes
+########
+- The GUIs will no longer crash if there are any whitespaces in the run range (e.g. 6010- 3).
+- The GUIs will now cope with a range of runs that span between two different decades where the second number
+  in the range is smaller than the final digit of the first number in the range (e.g. 6018-3 can be used for the range 6018-6023).
+- In the :ref:`Fitting Tab <muon_fitting_tab-ref>` the ``fit to raw`` checkbox can no longer be unchecked if no rebinned data is present.
+- A bug has been fixed in the BinWidth for the :ref:`DynamicKobuToyabe <func-DynamicKuboToyabe>` Fitting Function which caused a crash and did not provide
+  any information about why the value was invalid. It will now revert to last viable BinWidth used and explain why.
+- The autoscale option when ``All`` is selected will now show the largest and smallest y value for all of the plots.
+
+ALC
+---
+
+New Features
+############
+
+- Added an external plot button to the :ref:`ALC interface <MuonALC-ref>` which will plot in workbench the current tab's plot
+- **Added a period info button to the** :ref:`ALC interface <MuonALC-ref>` **which displays a table of period information from the loaded runs
+  (this is equivalent to the periods button in the** :ref:`Muon Analysis <Muon_Analysis-ref>` **and** :ref:`Frequency Domain Analysis <Frequency_Domain_Analysis-ref>` **Interfaces)**.
+
+.. image::  ../../images/ALC_period_table.png
+   :align: center
+   :height: 500px
+
+- If the sample log has a unit, it will now be displayed on the axis of the plot
+
+
+Improvements
+############
+- The plots are no longer normalised by bin width
+
+Elemental Analysis
+------------------
+
+Improvements
+############
+- Updated :ref:`LoadElementalAnalysisData <algm-LoadElementalAnalysisData>` algorithm to include Poisson errors for the counts data.
+
+Bugfixes
+########
+
+- No longer crashes when the input file contains a non-existant element.
+
+Algorithms
+----------
+
+Improvements
+############
+- Updated :ref:`LoadMuonLog <algm-LoadMuonLog>` to read units for most log values.
+- :ref:`LoadMuonNexus <algm-LoadMuonNexus>`, :ref:`LoadMuonNexusV2 <algm-LoadMuonNexusV2>` and :ref:`LoadPSIMuonBin <algm-LoadPSIMuonBin>`
+  have all been updated to return the same outputs. Check their documentation pages for more.
+- It is now possible to exclude a fit range when executing the :ref:`CalculateMuonAsymmetry <algm-CalculateMuonAsymmetry>` algorithm.
+- The :ref:`PlotAsymmetryByLogValue <algm-PlotAsymmetryByLogValue>` algorithm will include the units for the log value (when they are available)
+- :ref:`LoadMuonNexusV2 <algm-LoadMuonNexusV2>` now loads the period information.
+
+Bugfixes
+########
+- Fixed bug in :ref:`FitGaussianPeaks <algm-FitGaussianPeaks>` algorithm in which a peak at the end of range would cause an error due to not enough data point being available to fit parameters.
 
 :ref:`Release 6.2.0 <v6.2.0>`

--- a/docs/source/release/v6.2.0/reflectometry.rst
+++ b/docs/source/release/v6.2.0/reflectometry.rst
@@ -17,5 +17,7 @@ Improvements
 - :ref:`LRSubtractAverageBackground <algm-LRSubtractAverageBackground-v1>` now optionally uses weighted error for background with new input property ErrorWeighting.
 - :ref:`LiquidsReflectometryReduction <algm-LiquidsReflectometryReduction-v1>` now optionally uses weighted error for background with new input property ErrorWeighting with the default as False.
 
+- Version 2 of :ref:`ConvertToReflectometryQ <algm-ConvertToReflectometryQ>` has been added which assumes detectors are at :math:`2\theta` rather than :math:`\theta_f`. Use version 1 if you require detectors at :math:`\theta_f`.
+
 :ref:`Release 6.2.0 <v6.2.0>`
 

--- a/docs/source/release/v6.2.0/sans.rst
+++ b/docs/source/release/v6.2.0/sans.rst
@@ -9,4 +9,35 @@ SANS Changes
     putting new features at the top of the section, followed by
     improvements, followed by bug fixes.
 
+New
+---
+
+- :ref:`SANSILLIntegration <algm-SANSILLIntegration>` has new resolution calculation option alternative to Mildner-Carpenter based on fitting horizontal size of direct beam. The fitting is handled in :ref:`SANSILLReduction <algm-SANSILLReduction>` while processing beam.
+- :ref:`LoadILLSANS <algm-LoadILLSANS>` is extended to support loading monochromatic kinetic files from the new D11.
+- :ref:`SANSILLReduction <algm-SANSILLReduction>` is extended to support processing of monochromatic kinetic runs.
+- A series of improvements have been introduced to :ref:`SANSILLAutoProcess <algm-SANSILLAutoProcess>` such as the use of the new :ref:`Stitch <algm-Stitch>`, allowing for semi-automatic q binning, supporting attenuator 2 on D22, as well as improved naming and grouping for the output workspaces.
+- ISIS SANS GUI will automatically toggle between Can SAS and NXS Can SAS when switching between 1D and 2D reductions.
+  If you have toggled any save options it will not update the selected methods until the interface is restarted to avoid interfering with the user's save selection.
+- :ref:`Q1DWeighted <algm-Q1DWeighted>` now supports kinetic data from SANS, with multiple samples instead of time bins.
+
+Bugfixes
+--------
+
+- The ISIS SANS Interface will now display an error, instead of an unexpected error, if the user does not have permission to save a CSV file to the requested location.
+- The ISIS SANS interface will no longer throw an uncaught exception when a user tries to enter row information without loading a Mask/TOML file.
+- The ISIS SANS beam centre finder correctly accepts zero values (0.0) and won't try to replace them with empty strings.
+- The warning "Reduction Mode 'x' is not valid" will no longer incorrectly show when there are errors with the user's mask file.
+
+Improvements
+############
+
+- :ref:The ANSTO Bilby loader `LoadBBY <algm-LoadBBY>` logs the occurence of invalid events detected in the file as a warning.
+- The ISIS SANS threading has been switched to use Python native threading. This provides users with much clearer error messages
+  if something goes wrong, and improves tool compatibility for future development.
+- :ref:`DeadTimeCorrection <algm-DeadTimeCorrection>` now does not integrate TOF axis if the unit is `Empty`, allowing to correct multi-frame monochromatic SANS data.
+- The ISIS SANS TOML V0 format was updated with several incompatible changes as-per testing feedback.
+  A full list of changes can be found on the :ref:`TOML documentation page <sans_toml_v1-ref>` along with more conversion entries.
+- ISIS SANS now uses Front / Rear instead of HAB / LAB respectively in the UI. This only affects the text in the interface, and does
+  not affect compatibility with existing user files.
+
 :ref:`Release 6.2.0 <v6.2.0>`

--- a/docs/source/release/v6.3.0/diffraction.rst
+++ b/docs/source/release/v6.3.0/diffraction.rst
@@ -1,0 +1,22 @@
+===================
+Diffraction Changes
+===================
+
+.. contents:: Table of Contents
+   :local:
+
+.. warning:: **Developers:** Sort changes under appropriate heading
+    putting new features at the top of the section, followed by
+    improvements, followed by bug fixes.
+
+Powder Diffraction
+------------------
+
+Engineering Diffraction
+-----------------------
+
+Single Crystal Diffraction
+--------------------------
+- Existing :ref:`PolDiffILLReduction <algm-PolDiffILLReduction>` and :ref:`D7AbsoluteCrossSections <algm-D7AbsoluteCrossSections>` can now reduce and properly normalise single-crystal data for the D7 ILL instrument.
+
+:ref:`Release 6.3.0 <v6.3.0>`

--- a/docs/source/release/v6.3.0/direct_geometry.rst
+++ b/docs/source/release/v6.3.0/direct_geometry.rst
@@ -1,0 +1,12 @@
+=======================
+Direct Geometry Changes
+=======================
+
+.. contents:: Table of Contents
+   :local:
+
+.. warning:: **Developers:** Sort changes under appropriate heading
+    putting new features at the top of the section, followed by
+    improvements, followed by bug fixes.
+
+:ref:`Release 6.3.0 <v6.3.0>`

--- a/docs/source/release/v6.3.0/framework.rst
+++ b/docs/source/release/v6.3.0/framework.rst
@@ -1,0 +1,49 @@
+=================
+Framework Changes
+=================
+
+.. contents:: Table of Contents
+   :local:
+
+.. warning:: **Developers:** Sort changes under appropriate heading
+    putting new features at the top of the section, followed by
+    improvements, followed by bug fixes.
+
+Concepts
+--------
+
+Algorithms
+----------
+
+Improvements
+############
+
+- :ref:`GenerateLogbook <algm-GenerateLogbook>` now allows to perform binary operations even when certain entries do not exist, e.g. to create a string with all polarisation orientations contained in a collection of data files
+- Event nexuses produced at ILL can now be loaded using :ref:`LoadEventNexus <algm-LoadEventNexus>`.
+
+Data Objects
+------------
+
+Python
+------
+
+Installation
+------------
+
+MantidWorkbench
+---------------
+
+See :doc:`mantidworkbench`.
+
+SliceViewer
+-----------
+
+Improvements
+############
+
+- :ref:`SaveAscii <algm-SaveAscii>` has new property OneSpectrumPerFile.
+
+Bugfixes
+########
+
+:ref:`Release 6.3.0 <v6.3.0>`

--- a/docs/source/release/v6.3.0/index.rst
+++ b/docs/source/release/v6.3.0/index.rst
@@ -1,7 +1,7 @@
-.. _v6.2.0:
+.. _v6.3.0:
 
 ===========================
-Mantid 6.2.0 Release Notes
+Mantid 6.3.0 Release Notes
 ===========================
 
 .. figure:: ../../images/ImageNotFound.png
@@ -14,7 +14,7 @@ Mantid 6.2.0 Release Notes
 
 .. warning:: This release is still under construction. The changes can be found in the nightly builds on the `download page`_.
 
-We are proud to announce version 6.2.0 of Mantid.
+We are proud to announce version 6.3.0 of Mantid.
 
 **TODO: Add paragraph summarizing big changes**
 
@@ -39,7 +39,7 @@ Citation
 
 Please cite any usage of Mantid as follows:
 
-- *Mantid 6.2.0: Manipulation and Analysis Toolkit for Instrument Data.; Mantid Project*. `doi: 10.5286/SOFTWARE/MANTID6.2 <https://dx.doi.org/10.5286/SOFTWARE/MANTID6.2>`_
+- *Mantid 6.3.0: Manipulation and Analysis Toolkit for Instrument Data.; Mantid Project*. `doi: 10.5286/SOFTWARE/MANTID6.3 <https://dx.doi.org/10.5286/SOFTWARE/MANTID6.3>`_
 
 - Arnold, O. et al. *Mantid-Data Analysis and Visualization Package for Neutron Scattering and mu-SR Experiments.* Nuclear Instruments
   and Methods in Physics Research Section A: Accelerators, Spectrometers, Detectors and Associated Equipment 764 (2014): 156-166
@@ -80,6 +80,6 @@ For a full list of all issues addressed during this release please see the `GitH
 
 .. _forum: https://forum.mantidproject.org
 
-.. _GitHub milestone: https://github.com/mantidproject/mantid/pulls?utf8=%E2%9C%93&q=is%3Apr+milestone%3A"Release 6.2"+is%3Amerged
+.. _GitHub milestone: https://github.com/mantidproject/mantid/pulls?utf8=%E2%9C%93&q=is%3Apr+milestone%3A"Release+6.3"+is%3Amerged
 
-.. _GitHub release page: https://github.com/mantidproject/mantid/releases/tag/v6.2.0
+.. _GitHub release page: https://github.com/mantidproject/mantid/releases/tag/v6.3.0

--- a/docs/source/release/v6.3.0/indirect_geometry.rst
+++ b/docs/source/release/v6.3.0/indirect_geometry.rst
@@ -1,0 +1,12 @@
+=========================
+Indirect Geometry Changes
+=========================
+
+.. contents:: Table of Contents
+   :local:
+
+.. warning:: **Developers:** Sort changes under appropriate heading
+    putting new features at the top of the section, followed by
+    improvements, followed by bug fixes.
+
+:ref:`Release 6.3.0 <v6.3.0>`

--- a/docs/source/release/v6.3.0/mantidworkbench.rst
+++ b/docs/source/release/v6.3.0/mantidworkbench.rst
@@ -1,0 +1,14 @@
+========================
+Mantid Workbench Changes
+========================
+
+.. contents:: Table of Contents
+   :local:
+
+New and Improved
+----------------
+
+Bugfixes
+--------
+
+:ref:`Release 6.3.0 <v6.3.0>`

--- a/docs/source/release/v6.3.0/muon.rst
+++ b/docs/source/release/v6.3.0/muon.rst
@@ -1,0 +1,12 @@
+============
+MuSR Changes
+============
+
+.. contents:: Table of Contents
+   :local:
+
+.. warning:: **Developers:** Sort changes under appropriate heading
+    putting new features at the top of the section, followed by
+    improvements, followed by bug fixes.
+
+:ref:`Release 6.3.0 <v6.3.0>`

--- a/docs/source/release/v6.3.0/reflectometry.rst
+++ b/docs/source/release/v6.3.0/reflectometry.rst
@@ -1,0 +1,12 @@
+=====================
+Reflectometry Changes
+=====================
+
+.. contents:: Table of Contents
+   :local:
+
+.. warning:: **Developers:** Sort changes under appropriate heading
+    putting new features at the top of the section, followed by
+    improvements, followed by bug fixes.
+
+:ref:`Release 6.3.0 <v6.3.0>`

--- a/docs/source/release/v6.3.0/sans.rst
+++ b/docs/source/release/v6.3.0/sans.rst
@@ -1,0 +1,12 @@
+============
+SANS Changes
+============
+
+.. contents:: Table of Contents
+   :local:
+
+.. warning:: **Developers:** Sort changes under appropriate heading
+    putting new features at the top of the section, followed by
+    improvements, followed by bug fixes.
+
+:ref:`Release 6.3.0 <v6.3.0>`


### PR DESCRIPTION
As part of preparing for the v6.2 release branch being merged in, this pulls in the release notes from v6.2 and v6.3 into `ornl-next`.