### PR TITLE
Fix cppcheck threshold

### DIFF
--- a/Framework/Algorithms/src/GetEi2.cpp
+++ b/Framework/Algorithms/src/GetEi2.cpp
@@ -267,7 +267,7 @@ double GetEi2::calculateEi(const double initial_guess) {
  * passed
  *  @param ws_index :: The workspace index of the detector
  *  @param spectrumInfo :: A spectrum info object for the input workspace
- *  @return The distance between the source and the given detector(or
+ *  @return The distance between the source and the given detector (or
  * DetectorGroup)
  *  @throw runtime_error if there is a problem
  */

--- a/Framework/DataHandling/src/LoadRaw3.cpp
+++ b/Framework/DataHandling/src/LoadRaw3.cpp
@@ -394,12 +394,12 @@ void LoadRaw3::separateMonitors(FILE *file, const int64_t &period, const std::ve
       if (!readData(file, histToRead)) {
         throw std::runtime_error("Error reading raw file");
       }
-      // if this a monitor  store that spectrum to monitor workspace
+      // if this a monitor, store that spectrum to monitor workspace
       if (isMonitor(monitorList, i)) {
         setWorkspaceData(mws_sptr, m_timeChannelsVec, mwsIndex, i, m_noTimeRegimes, m_lengthIn, 1);
         ++mwsIndex;
       } else {
-        // not a monitor,store the spectrum to normal output workspace
+        // not a monitor, store the spectrum to normal output workspace
         setWorkspaceData(ws_sptr, m_timeChannelsVec, wsIndex, i, m_noTimeRegimes, m_lengthIn, 1);
         ++wsIndex;
       }

--- a/buildconfig/Jenkins/cppcheck.sh
+++ b/buildconfig/Jenkins/cppcheck.sh
@@ -4,7 +4,7 @@ SCRIPT_DIR=$(dirname "$0")
 # If errors slip through to master this can be used to set a non-zero
 # allowed count while those errors are dealt with. This avoids breaking all
 # builds for all developers
-ALLOWED_ERRORS_COUNT=1203
+ALLOWED_ERRORS_COUNT=1204
 
 if [[ ${JOB_NAME} == *pull_requests* ]]; then
     # This relies on the fact pull requests use pull/$PR-NAME


### PR DESCRIPTION
**Description of work.**
Set correct threshold for cppcheck defects on release-next.

**To test:**
Make sure cppcheck ran and that the number of defects is equal to the number of allowed defects (1204).

*There is no associated issue.*

*This does not require release notes* because it is not user facing.

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
