### PR TITLE
Disabled model fitting in muon analysis for release

### DIFF
--- a/docs/source/release/v6.2.0/muon.rst
+++ b/docs/source/release/v6.2.0/muon.rst
@@ -39,12 +39,6 @@ New Features
 ############
 
 - Users can now copy sequential fitting parameters to all other runs using the ``Copy fit parameters to all`` checkbox.
-- **The** :ref:`Model Fitting Tab <muon_model_fitting_tab-ref>` **allows you to perform fits across the sample logs and fit parameters stored in your results table.**
-
-.. image::  ../../images/muon_model_fitting_tab.PNG
-   :align: center
-   :height: 800px
-
 
 Muon Analysis and Frequency Domain Analysis
 -------------------------------------------

--- a/scripts/Muon/GUI/MuonAnalysis/muon_analysis_2.py
+++ b/scripts/Muon/GUI/MuonAnalysis/muon_analysis_2.py
@@ -28,7 +28,7 @@ from Muon.GUI.Common.home_tab.home_tab_widget import HomeTabWidget
 from Muon.GUI.Common.muon_load_data import MuonLoadData
 from Muon.GUI.Common.corrections_tab_widget.corrections_tab_widget import CorrectionsTabWidget
 from Muon.GUI.Common.fitting_tab_widget.fitting_tab_widget import FittingTabWidget
-from Muon.GUI.Common.model_fitting_tab_widget.model_fitting_tab_widget import ModelFittingTabWidget
+#from Muon.GUI.Common.model_fitting_tab_widget.model_fitting_tab_widget import ModelFittingTabWidget
 from Muon.GUI.Common.seq_fitting_tab_widget.seq_fitting_tab_widget import SeqFittingTabWidget
 from Muon.GUI.MuonAnalysis.load_widget.load_widget import LoadWidget
 from Muon.GUI.Common.phase_table_widget.phase_table_widget import PhaseTabWidget
@@ -129,7 +129,7 @@ class MuonAnalysisGui(QtWidgets.QMainWindow):
         self.phase_tab = PhaseTabWidget(self.context, self)
         self.seq_fitting_tab = SeqFittingTabWidget(self.context, self.fitting_tab.fitting_tab_model, self)
         self.results_tab = ResultsTabWidget(self.context.fitting_context, self.context, self)
-        self.model_fitting_tab = ModelFittingTabWidget(self.context, self)
+        #self.model_fitting_tab = ModelFittingTabWidget(self.context, self)
 
         self.setup_tabs()
         self.help_widget = HelpWidget("Muon Analysis 2")
@@ -194,7 +194,7 @@ class MuonAnalysisGui(QtWidgets.QMainWindow):
         self.tabs.addTabWithOrder(self.fitting_tab.fitting_tab_view, 'Fitting')
         self.tabs.addTabWithOrder(self.seq_fitting_tab.seq_fitting_tab_view, 'Sequential Fitting')
         self.tabs.addTabWithOrder(self.results_tab.results_tab_view, 'Results')
-        self.tabs.addTabWithOrder(self.model_fitting_tab.model_fitting_tab_view, 'Model Fitting')
+        #self.tabs.addTabWithOrder(self.model_fitting_tab.model_fitting_tab_view, 'Model Fitting')
         self.tabs.set_slot_for_tab_changed(self.handle_tab_changed)
         self.tabs.setElideMode(QtCore.Qt.ElideNone)
         self.tabs.setUsesScrollButtons(False)
@@ -207,8 +207,8 @@ class MuonAnalysisGui(QtWidgets.QMainWindow):
         # Plot the displayed workspace
         elif TAB_ORDER[index] in ["Fitting", "Sequential Fitting"]:
             plot_mode = self.plot_widget.fit_index
-        elif TAB_ORDER[index] in ["Model Fitting"]:
-            plot_mode = self.plot_widget.model_fit_index
+        #elif TAB_ORDER[index] in ["Model Fitting"]:
+        #    plot_mode = self.plot_widget.model_fit_index
         else:
             return
         self.plot_widget.set_plot_view(plot_mode)
@@ -230,7 +230,7 @@ class MuonAnalysisGui(QtWidgets.QMainWindow):
 
         self.disable_notifier.add_subscriber(self.fitting_tab.fitting_tab_view.disable_tab_observer)
 
-        self.disable_notifier.add_subscriber(self.model_fitting_tab.model_fitting_tab_view.disable_tab_observer)
+        #self.disable_notifier.add_subscriber(self.model_fitting_tab.model_fitting_tab_view.disable_tab_observer)
 
         self.disable_notifier.add_subscriber(self.phase_tab.phase_table_presenter.disable_tab_observer)
 
@@ -248,7 +248,7 @@ class MuonAnalysisGui(QtWidgets.QMainWindow):
 
         self.enable_notifier.add_subscriber(self.fitting_tab.fitting_tab_view.enable_tab_observer)
 
-        self.enable_notifier.add_subscriber(self.model_fitting_tab.model_fitting_tab_view.enable_tab_observer)
+        #self.enable_notifier.add_subscriber(self.model_fitting_tab.model_fitting_tab_view.enable_tab_observer)
 
         self.enable_notifier.add_subscriber(self.phase_tab.phase_table_presenter.enable_tab_observer)
 
@@ -351,14 +351,14 @@ class MuonAnalysisGui(QtWidgets.QMainWindow):
         self.seq_fitting_tab.seq_fitting_tab_presenter.selected_sequential_fit_notifier.add_subscriber(
             self.plot_widget.fit_mode.plot_selected_fit_observer)
 
-        self.model_fitting_tab.model_fitting_tab_presenter.selected_fit_results_changed.add_subscriber(
-            self.plot_widget.model_fit_mode.plot_selected_fit_observer)
+        #self.model_fitting_tab.model_fitting_tab_presenter.selected_fit_results_changed.add_subscriber(
+        #    self.plot_widget.model_fit_mode.plot_selected_fit_observer)
 
-        self.model_fitting_tab.model_fitting_tab_presenter.update_plot_x_range_notifier.add_subscriber(
-            self.plot_widget.model_fit_mode.update_x_range_observer)
+        #self.model_fitting_tab.model_fitting_tab_presenter.update_plot_x_range_notifier.add_subscriber(
+        #    self.plot_widget.model_fit_mode.update_x_range_observer)
 
-        self.model_fitting_tab.model_fitting_tab_presenter.update_override_tick_labels_notifier.add_subscriber(
-            self.plot_widget.model_fit_mode.update_override_tick_labels_observer)
+        #self.model_fitting_tab.model_fitting_tab_presenter.update_override_tick_labels_notifier.add_subscriber(
+        #    self.plot_widget.model_fit_mode.update_override_tick_labels_observer)
 
     def setup_grouping_changed_observers(self):
         self.grouping_tab_widget.group_tab_presenter.groupingNotifier.add_subscriber(
@@ -410,8 +410,8 @@ class MuonAnalysisGui(QtWidgets.QMainWindow):
         self.phase_tab.phase_table_presenter.enable_editing_notifier.add_subscriber(
             self.enable_observer)
 
-        self.model_fitting_tab.model_fitting_tab_presenter.enable_editing_notifier.add_subscriber(
-            self.enable_observer)
+        #self.model_fitting_tab.model_fitting_tab_presenter.enable_editing_notifier.add_subscriber(
+        #    self.enable_observer)
 
     def setup_group_calculation_disabler_notifier(self):
 
@@ -427,8 +427,8 @@ class MuonAnalysisGui(QtWidgets.QMainWindow):
         self.phase_tab.phase_table_presenter.disable_editing_notifier.add_subscriber(
             self.disable_observer)
 
-        self.model_fitting_tab.model_fitting_tab_presenter.disable_editing_notifier.add_subscriber(
-            self.disable_observer)
+        #self.model_fitting_tab.model_fitting_tab_presenter.disable_editing_notifier.add_subscriber(
+        #    self.disable_observer)
 
     def setup_on_load_enabler(self):
         self.load_widget.load_widget.load_run_widget.enable_notifier.add_subscriber(
@@ -483,16 +483,16 @@ class MuonAnalysisGui(QtWidgets.QMainWindow):
         self.fitting_tab.fitting_tab_presenter.update_plot_guess_notifier.add_subscriber(
             self.plot_widget.fit_mode.update_plot_guess_observer)
 
-        self.model_fitting_tab.model_fitting_tab_presenter.remove_plot_guess_notifier.add_subscriber(
-            self.plot_widget.model_fit_mode.remove_plot_guess_observer)
+        #self.model_fitting_tab.model_fitting_tab_presenter.remove_plot_guess_notifier.add_subscriber(
+        #    self.plot_widget.model_fit_mode.remove_plot_guess_observer)
 
-        self.model_fitting_tab.model_fitting_tab_presenter.update_plot_guess_notifier.add_subscriber(
-            self.plot_widget.model_fit_mode.update_plot_guess_observer)
+        #self.model_fitting_tab.model_fitting_tab_presenter.update_plot_guess_notifier.add_subscriber(
+        #    self.plot_widget.model_fit_mode.update_plot_guess_observer)
 
     def setup_results_notifier(self):
         """Connect results tab to the model fitting tab."""
-        self.results_tab.results_tab_presenter.results_table_created_notifier.add_subscriber(
-            self.model_fitting_tab.model_fitting_tab_presenter.results_table_created_observer)
+        return#self.results_tab.results_tab_presenter.results_table_created_notifier.add_subscriber(
+        #    self.model_fitting_tab.model_fitting_tab_presenter.results_table_created_observer)
 
     def closeEvent(self, event):
         self.removeDockWidget(self.dockable_plot_widget_window)

--- a/scripts/Muon/GUI/MuonAnalysis/plot_widget/muon_analysis_plot_widget.py
+++ b/scripts/Muon/GUI/MuonAnalysis/plot_widget/muon_analysis_plot_widget.py
@@ -11,8 +11,8 @@ from Muon.GUI.Common.plot_widget.data_pane.plot_data_pane_model import PlotDataP
 from Muon.GUI.Common.plot_widget.data_pane.plot_data_pane_presenter import PlotDataPanePresenter
 from Muon.GUI.Common.plot_widget.base_pane.base_pane_view import BasePaneView
 from Muon.GUI.Common.plot_widget.fit_pane.plot_fit_pane_presenter import PlotFitPanePresenter
-from Muon.GUI.Common.plot_widget.model_fit_pane.plot_model_fit_pane_presenter import PlotModelFitPanePresenter
-from Muon.GUI.Common.plot_widget.model_fit_pane.plot_model_fit_pane_model import PlotModelFitPaneModel
+#from Muon.GUI.Common.plot_widget.model_fit_pane.plot_model_fit_pane_presenter import PlotModelFitPanePresenter
+#from Muon.GUI.Common.plot_widget.model_fit_pane.plot_model_fit_pane_model import PlotModelFitPaneModel
 from Muon.GUI.MuonAnalysis.plot_widget.plot_time_fit_pane_model import PlotTimeFitPaneModel
 from Muon.GUI.Common.plot_widget.raw_pane.raw_pane_presenter import RawPanePresenter
 from Muon.GUI.Common.plot_widget.raw_pane.raw_pane_model import RawPaneModel
@@ -25,8 +25,8 @@ class MuonAnalysisPlotWidget(object):
         self.data_model = PlotDataPaneModel(context)
         self.fit_model = PlotTimeFitPaneModel(context)
         self.raw_model = RawPaneModel(context)
-        self.model_fit_model = PlotModelFitPaneModel(context)
-        models = [self.data_model, self.fit_model, self.model_fit_model, self.raw_model]
+        #self.model_fit_model = PlotModelFitPaneModel(context)
+        models = [self.data_model, self.fit_model, self.raw_model]#,self.model_fit_model]
 
         self.view = MainPlotWidgetView(parent)
         self.model = PlotDataPaneModel(context)
@@ -58,17 +58,17 @@ class MuonAnalysisPlotWidget(object):
                                                  context,context.fitting_context,
                                              self.plotting_canvas_widgets[name].presenter)
 
-        name = self.model_fit_model.name
-        self.model_fit_mode = PlotModelFitPanePresenter(self._views[name], self.model_fit_model, context,
-                                                        context.model_fitting_context,
-                                                        self.plotting_canvas_widgets[name].presenter)
+        #name = self.model_fit_model.name
+        #self.model_fit_mode = PlotModelFitPanePresenter(self._views[name], self.model_fit_model, context,
+        #                                                context.model_fitting_context,
+        #                                                self.plotting_canvas_widgets[name].presenter)
 
         name = self.raw_model.name
         self.raw_mode = RawPanePresenter(self._views[name], self.raw_model,
                                                  context,self.plotting_canvas_widgets[name].presenter)
 
         self.presenter = MainPlotWidgetPresenter(self.view,
-                                                   [self.data_mode, self.raw_mode, self.fit_mode, self.model_fit_mode])
+                                                   [self.data_mode, self.raw_mode, self.fit_mode])#, self.model_fit_mode])
 
         self._current_plot_mode = self.presenter.get_plot_mode
         self.presenter.set_plot_mode_changed_slot(self.handle_plot_mode_changed_by_user)


### PR DESCRIPTION
**Description of work.**

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->
We have disabled the model analysis tab as it was causing a significant slow down in the processing of the GUI. It will be enabled at a later date.

**To test:**
Open Muon Analysis
Check that you cannot see the "model fitting tab"
Check in the plot window the combo box on the top does not have the "model data" option
Load MUSR 62260-5
Go to the fitting tab
Change the fitting type to "TF Asymmetry" 
Tick simultaneous 
Add a "StandardSC" function
Set "sigma", "FieldSC", "FieldBG" to global
Go to the sequential fitting tab
Press the "sequential fit all" button
Go to the results tab
Click "output results"
It wont be slow

<!-- Instructions for testing. -->

*There is no associated issue.*

Removed from release notes

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
