### PR TITLE
Fix issue calling non existent method in phasequad (Muon Analysis)

### DIFF
--- a/scripts/Muon/GUI/Common/phase_table_widget/phase_table_presenter.py
+++ b/scripts/Muon/GUI/Common/phase_table_widget/phase_table_presenter.py
@@ -236,7 +236,7 @@ class PhaseTablePresenter(object):
 
         # Update the table stored in each phasequad
         self.context.group_pair_context.update_phase_tables(new_table)
-        self.context.calculate_all_pairs()  # Updates phasequads
+        self.context.update_phasequads()  # Updates phasequads
         self.calculation_finished_notifier.notify_subscribers()
         self.view.enable_widget()
         self.enable_editing_notifier.notify_subscribers()


### PR DESCRIPTION
**Description of work.**
Fixes a bug where we were calling a non existent method in the phase table tab of Muon Analysis

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**

Load MUSR 62260
Go to the phase table tab
Click "calculate phase table"
Give it a name (e.g. one)
Change on of the groups
Click "calculate phase table" again
Give it a different name (e.g. two)
Below change the "phase table" combo box to the other option. **There should be no issues**
<!-- Instructions for testing. -->

Fixes #32402 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
Fixes #32377
<!-- alternative
*There is no associated issue.*
-->


This does not require release notes as it was an issue introduced in this release.


<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
