### PR TITLE
Replace imp imports with importlib

### DIFF
--- a/Framework/PythonInterface/mantid/kernel/plugins.py
+++ b/Framework/PythonInterface/mantid/kernel/plugins.py
@@ -14,24 +14,7 @@ algorithms, fit functions etc.
 
 import os as _os
 from traceback import format_exc
-try:
-    from importlib.machinery import SourceFileLoader
-except ImportError:
-    # imp is deprecated in Python 3 but importlib doesn't exist
-    # in Python 2.
-    # We only use a single function so implement a handwritten compatability
-    # class
-    import imp as _imp
-
-    class SourceFileLoader(object):
-
-        def __init__(self, name, pathname):
-            self._name = name
-            self._pathname = pathname
-
-        def load_module(self):
-            return _imp.load_source(self._name, self._pathname)
-
+from importlib.machinery import SourceFileLoader
 from . import logger, Logger, config
 
 

--- a/Framework/PythonInterface/test/testhelpers/testrunner.py
+++ b/Framework/PythonInterface/test/testhelpers/testrunner.py
@@ -11,7 +11,7 @@ once qtpy is universally used.
 It is intended to be used as a launcher script for a given unit test file.
 The reports are output to the current working directory.
 """
-import importlib as imp
+from importlib.machinery import SourceFileLoader
 import os
 import sys
 import unittest
@@ -51,7 +51,7 @@ def main(argv):
 
     # Load the test and copy over any module variables so that we have
     # the same environment defined here
-    test_module = imp.load_source(module_name(pathname), pathname)
+    test_module = SourceFileLoader(module_name(pathname), pathname).load_module()
     test_module_globals = dir(test_module)
     this_globals = globals()
     for key in test_module_globals:

--- a/Framework/PythonInterface/test/testhelpers/testrunner.py
+++ b/Framework/PythonInterface/test/testhelpers/testrunner.py
@@ -11,7 +11,7 @@ once qtpy is universally used.
 It is intended to be used as a launcher script for a given unit test file.
 The reports are output to the current working directory.
 """
-import imp
+import importlib as imp
 import os
 import sys
 import unittest

--- a/Testing/Tools/cxxtest/sample/SCons/SConstruct
+++ b/Testing/Tools/cxxtest/sample/SCons/SConstruct
@@ -6,7 +6,7 @@ cxxtest_path = '../..'
 # without having to copy it into a particular path.
 # for nicer examples you *should* use, see the cxxtest builder tests in the
 # build_tools/SCons/test directory.
-import imp
+import importlib as imp
 cxxtest = imp.load_source('cxxtest', cxxtestbuilder_path)
 
 # First build the 'real' library, when working on an embedded system
@@ -37,4 +37,3 @@ lib_to_test = env_test.StaticLibrary('build/dev_platform/tested',
                                      env.Glob('build/dev_platform/*.c'))
 env_test.Append(LIBS=lib_to_test)
 env_test.CxxTest(env_test.Glob('tests/*.h'))
-

--- a/Testing/Tools/cxxtest/sample/SCons/SConstruct
+++ b/Testing/Tools/cxxtest/sample/SCons/SConstruct
@@ -6,8 +6,8 @@ cxxtest_path = '../..'
 # without having to copy it into a particular path.
 # for nicer examples you *should* use, see the cxxtest builder tests in the
 # build_tools/SCons/test directory.
-import importlib as imp
-cxxtest = imp.load_source('cxxtest', cxxtestbuilder_path)
+from importlib.machinery import SourceFileLoader
+cxxtest = SourceFileLoader('cxxtest', cxxtestbuilder_path).load_module()
 
 # First build the 'real' library, when working on an embedded system
 # this may involve a cross compiler.

--- a/Testing/Tools/cxxtest/test/unit/SConstruct
+++ b/Testing/Tools/cxxtest/test/unit/SConstruct
@@ -2,8 +2,8 @@ CxxTestBuilder_path = '../../build_tools/SCons/cxxtest.py'
 CxxTest_dir = '../..'
 
 # First a little python magic to pull in CxxTestBuilder
-import importlib as imp
-cxxtest = imp.load_source('cxxtest', CxxTestBuilder_path)
+from importlib.machinery import SourceFileLoader
+cxxtest = SourceFileLoader('cxxtest', CxxTestBuilder_path).load_module()
 env = Environment()
 cxxtest.generate(env, CXXTEST_INSTALL_DIR=CxxTest_dir)
 

--- a/Testing/Tools/cxxtest/test/unit/SConstruct
+++ b/Testing/Tools/cxxtest/test/unit/SConstruct
@@ -2,11 +2,10 @@ CxxTestBuilder_path = '../../build_tools/SCons/cxxtest.py'
 CxxTest_dir = '../..'
 
 # First a little python magic to pull in CxxTestBuilder
-import imp
+import importlib as imp
 cxxtest = imp.load_source('cxxtest', CxxTestBuilder_path)
 env = Environment()
 cxxtest.generate(env, CXXTEST_INSTALL_DIR=CxxTest_dir)
 
 for test in env.Glob('*.t.h'):
   env.CxxTest(test)
-

--- a/scripts/test/ReductionWrapperTest.py
+++ b/scripts/test/ReductionWrapperTest.py
@@ -7,16 +7,14 @@
 import os
 import sys
 from tempfile import TemporaryDirectory
+import unittest
+import importlib as imp
 
 from mantid.simpleapi import *
 from mantid import api, config
 
 from Direct.ReductionWrapper import *
 import MariReduction as mr
-
-#
-import unittest
-import imp
 
 
 class test_helper(ReductionWrapper):


### PR DESCRIPTION
**Description of work.**
`imp` module is deprecated in python3. As the support for python2 is dropped since a while, we can replace the use of `imp` with the new `importlib`.

**To test:**
If the builds pass, code review should suffice.

<!-- Instructions for testing. -->

*There is no associated issue.*

*This does not require release notes as it is an internal change*.



<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
