### PR TITLE
Pd358 failover run title to title if missing release next

### DIFF
--- a/Framework/DataHandling/src/LoadNexusProcessed.cpp
+++ b/Framework/DataHandling/src/LoadNexusProcessed.cpp
@@ -1798,8 +1798,12 @@ API::Workspace_sptr LoadNexusProcessed::loadEntry(NXRoot &root, const std::strin
 
   progress(progressStart + 0.2 * progressRange, "Reading the workspace history...");
 
-  if (local_workspace->getTitle().empty())
-    local_workspace->setTitle(mtd_entry.getString("title"));
+  try {
+    if (local_workspace->getTitle().empty())
+      local_workspace->setTitle(mtd_entry.getString("title"));
+  } catch (std::runtime_error &) {
+    g_log.debug() << "No title was found in the input file, " << getPropertyValue("Filename") << '\n';
+  }
 
   return std::static_pointer_cast<API::Workspace>(local_workspace);
 }

--- a/Framework/DataHandling/src/LoadNexusProcessed.cpp
+++ b/Framework/DataHandling/src/LoadNexusProcessed.cpp
@@ -1798,6 +1798,9 @@ API::Workspace_sptr LoadNexusProcessed::loadEntry(NXRoot &root, const std::strin
 
   progress(progressStart + 0.2 * progressRange, "Reading the workspace history...");
 
+  if (local_workspace->getTitle().empty())
+    local_workspace->setTitle(mtd_entry.getString("title"));
+
   return std::static_pointer_cast<API::Workspace>(local_workspace);
 }
 


### PR DESCRIPTION
**Description of work.**
PR addresses the issue of workspaces loaded through `LoadNexusProcessed` not loading with a `run_title`, the solution being to use the `title` field set during `SaveNexusProcessed`  if available, else leave it empty.

- [x] pr against `ornl-next` #32425

Companion to PR ornl-next [![GitHub issue/pull request detail](https://img.shields.io/github/issues/detail/state/mantidproject/mantid/32425)](https://github.com/mantidproject/mantid/pull/32425)

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**

Run the following script in the Mantid workbench, checking the title field of the workspaces suffixed with `_loaded`.  The first set should always have a title, the second set originally is missing a title in the `_loaded` version but with this fix should now use the title provided at save.

```

# Workspace title is created at the same time as the data
CreateWorkspace(DataX=[1,2], DataY=[10,20], OutputWorkspace='workspace1', WorkspaceTitle='CreateWorkspace')
SaveNexusProcessed(InputWorkspace='workspace1', Filename='/tmp/workspace1.nxs')
LoadNexusProcessed(Filename='/tmp/workspace1.nxs', OutputWorkspace='workspace1_loaded')

# Workspace title is created when saving to file
CreateWorkspace(DataX=[1,2], DataY=[10,20], OutputWorkspace='workspace2')
SaveNexusProcessed(InputWorkspace='workspace2', Filename='/tmp/workspace2.nxs', Title='SaveNexusProcessed')
LoadNexusProcessed(Filename='/tmp/workspace2.nxs', OutputWorkspace='workspace2_loaded')


```

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.