### PR TITLE
Create Model Fitting workspaces on the fly

### DIFF
--- a/scripts/Muon/GUI/Common/fitting_widgets/model_fitting/model_fitting_model.py
+++ b/scripts/Muon/GUI/Common/fitting_widgets/model_fitting/model_fitting_model.py
@@ -163,7 +163,8 @@ class ModelFittingModel(BasicFittingModel):
     def _create_matrix_workspaces_for_parameter_combination(self, workspace_group: WorkspaceGroup,
                                                             x_parameter_name: str, y_parameter_name: str) -> None:
         """Creates the matrix workspace for a specific x and y parameter, and adds it to the workspace group."""
-        if x_parameter_name != y_parameter_name:
+        if x_parameter_name != y_parameter_name and x_parameter_name in self.x_parameters() \
+                and y_parameter_name in self.y_parameters():
             x_values = self._convert_str_column_values_to_int(x_parameter_name,
                                                               self.fitting_context.x_parameters)
             x_errors = self.fitting_context.x_parameter_errors[x_parameter_name]

--- a/scripts/Muon/GUI/Common/fitting_widgets/model_fitting/model_fitting_presenter.py
+++ b/scripts/Muon/GUI/Common/fitting_widgets/model_fitting/model_fitting_presenter.py
@@ -102,6 +102,8 @@ class ModelFittingPresenter(BasicFittingPresenter):
         self.model.current_dataset_index = self.view.current_dataset_index
         self.automatically_update_function_name()
 
+        self.model.create_x_and_y_parameter_combination_workspace(self.view.x_parameter(), self.view.y_parameter())
+
         self.update_fit_statuses_and_chi_squared_in_view_from_model()
         self.update_covariance_matrix_button()
         self.update_fit_function_in_view_from_model()
@@ -178,7 +180,7 @@ class ModelFittingPresenter(BasicFittingPresenter):
         """Creates a matrix workspace for each possible parameter combination to be used for fitting."""
         try:
             self.parameter_combination_thread = self._create_parameter_combinations_thread(
-                self.model.create_x_and_y_parameter_combination_workspaces)
+                self.model.create_x_and_y_parameter_combinations)
             self.parameter_combination_thread.threadWrapperSetUp(self.handle_parameter_combinations_started,
                                                                  finished_callback,
                                                                  self.handle_parameter_combinations_error)

--- a/scripts/test/Muon/fitting_widgets/model_fitting/model_fitting_model_test.py
+++ b/scripts/test/Muon/fitting_widgets/model_fitting/model_fitting_model_test.py
@@ -6,7 +6,7 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 import unittest
 
-from mantid.api import FrameworkManager, FunctionFactory, WorkspaceFactory
+from mantid.api import AnalysisDataService, FrameworkManager, FunctionFactory, WorkspaceFactory
 
 from Muon.GUI.Common.ADSHandler.ADS_calls import add_ws_to_ads, check_if_workspace_exist
 from Muon.GUI.Common.fitting_widgets.model_fitting.model_fitting_model import ModelFittingModel
@@ -42,6 +42,7 @@ class ModelFittingModelTest(unittest.TestCase):
 
     def tearDown(self):
         self.model = None
+        AnalysisDataService.clear()
 
     def test_that_the_model_has_been_instantiated_with_empty_fit_data(self):
         self.assertEqual(self.model.result_table_names, [])
@@ -131,14 +132,14 @@ class ModelFittingModelTest(unittest.TestCase):
 
         self.assertEqual(self.model.get_workspace_names_to_display_from_context(), ["Result1"])
 
-    def test_that_create_x_and_y_parameter_combination_workspaces_will_create_the_expected_parameter_data(self):
+    def test_that_create_x_and_y_parameter_combinations_will_create_the_expected_parameter_data(self):
         self.model.result_table_names = self.result_table_names
         self.model.current_result_table_index = 0
 
         table = create_results_table()
         add_ws_to_ads("Result1", table)
 
-        self.model.create_x_and_y_parameter_combination_workspaces()
+        self.model.create_x_and_y_parameter_combinations()
         x_parameters = self.model.x_parameters()
         y_parameters = self.model.y_parameters()
 
@@ -156,23 +157,49 @@ class ModelFittingModelTest(unittest.TestCase):
                          ["MUSR62260; Group; bottom; Asymmetry; MA", "MUSR62260; Group; top; Asymmetry; MA",
                           "MUSR62260; Group; fwd; Asymmetry; MA"])
 
-    def test_that_create_x_and_y_parameter_combination_workspaces_will_create_the_expected_parameter_workspaces(self):
+    def test_that_create_x_and_y_parameter_combinations_will_not_create_the_parameter_workspaces(self):
         self.model.result_table_names = self.result_table_names
         self.model.current_result_table_index = 0
 
         table = create_results_table()
         add_ws_to_ads("Result1", table)
 
-        self.model.create_x_and_y_parameter_combination_workspaces()
+        self.model.create_x_and_y_parameter_combinations()
+
+        self.assertTrue(not check_if_workspace_exist("Result1; Parameter Combinations"))
+
+        self.assertTrue(not check_if_workspace_exist("Result1; workspace_name vs A0"))
+        self.assertTrue(not check_if_workspace_exist("Result1; workspace_name vs A1"))
+        self.assertTrue(not check_if_workspace_exist("Result1; A0 vs workspace_name"))
+        self.assertTrue(not check_if_workspace_exist("Result1; A0 vs A1"))
+        self.assertTrue(not check_if_workspace_exist("Result1; A1 vs workspace_name"))
+        self.assertTrue(not check_if_workspace_exist("Result1; A1 vs A0"))
+
+        self.assertTrue(not check_if_workspace_exist("Result1; workspace_name vs workspace_name"))
+        self.assertTrue(not check_if_workspace_exist("Result1; A0 vs A0"))
+        self.assertTrue(not check_if_workspace_exist("Result1; A1 vs A1"))
+
+    def test_that_create_x_and_y_parameter_combination_workspace_will_create_the_expected_parameter_workspaces(self):
+        self.model.result_table_names = self.result_table_names
+        self.model.current_result_table_index = 0
+
+        table = create_results_table()
+        add_ws_to_ads("Result1", table)
+
+        self.model.create_x_and_y_parameter_combinations()
+        self.model.create_x_and_y_parameter_combination_workspace("workspace_name", "A0")
+        self.model.create_x_and_y_parameter_combination_workspace("A1", "A0")
+        self.model.create_x_and_y_parameter_combination_workspace("workspace_name", "A1")
 
         self.assertTrue(check_if_workspace_exist("Result1; Parameter Combinations"))
 
-        self.assertTrue(check_if_workspace_exist("Result1; workspace_name vs A0"))
-        self.assertTrue(check_if_workspace_exist("Result1; workspace_name vs A1"))
         self.assertTrue(check_if_workspace_exist("Result1; A0 vs workspace_name"))
-        self.assertTrue(check_if_workspace_exist("Result1; A0 vs A1"))
         self.assertTrue(check_if_workspace_exist("Result1; A1 vs workspace_name"))
-        self.assertTrue(check_if_workspace_exist("Result1; A1 vs A0"))
+        self.assertTrue(check_if_workspace_exist("Result1; A0 vs A1"))
+
+        self.assertTrue(not check_if_workspace_exist("Result1; workspace_name vs A0"))
+        self.assertTrue(not check_if_workspace_exist("Result1; workspace_name vs A1"))
+        self.assertTrue(not check_if_workspace_exist("Result1; A1 vs A0"))
 
         self.assertTrue(not check_if_workspace_exist("Result1; workspace_name vs workspace_name"))
         self.assertTrue(not check_if_workspace_exist("Result1; A0 vs A0"))


### PR DESCRIPTION
**Description of work.**
This PR make a small change to model fitting. The parameter combination workspaces are no longer created all at once after creating a results table from the results tab. Instead, the parameter workspaces are created individually when selecting different parameters in the model fitting tab.

**To test:**
Follow instructions in #32411
The GUI will no longer take a long to process and generate all the workspaces after clicking `Create Results table` on the results tab. Instead, each workspace is created individually when selecting different parameters in the model fitting tab.

*There is no associated issue.*

*This does not require release notes* because **model fitting is new.**



#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
