### PR TITLE
Result table global parameters should have a non-zero error

### DIFF
--- a/docs/source/release/v6.2.0/muon.rst
+++ b/docs/source/release/v6.2.0/muon.rst
@@ -82,6 +82,7 @@ Bugfixes
 - A bug has been fixed in the BinWidth for the :ref:`DynamicKobuToyabe <func-DynamicKuboToyabe>` Fitting Function which caused a crash and did not provide
   any information about why the value was invalid. It will now revert to last viable BinWidth used and explain why.
 - The autoscale option when ``All`` is selected will now show the largest and smallest y value for all of the plots.
+- The global parameters in a results table will no longer be given a zero error arbitrarily if one with an error exists.
 
 ALC
 ---

--- a/scripts/Muon/GUI/Common/contexts/fitting_contexts/fitting_context.py
+++ b/scripts/Muon/GUI/Common/contexts/fitting_contexts/fitting_context.py
@@ -71,6 +71,12 @@ def _create_unique_param_lookup(parameter_workspace, global_parameters):
     for row in default_table:
         name = row[NAME_COL]
         exists, is_global = is_in(unique_params, name)
+
+        # If the parameter is global, and its error is zero, skip it so that the global with the error is found instead.
+        is_error_zero = row[ERRORS_COL] == 0.0
+        if is_global and is_error_zero:
+            continue
+
         if not exists:
             parameter = Parameter(name, row[VALUE_COL], row[ERRORS_COL],
                                   is_global)

--- a/scripts/Muon/GUI/Common/fitting_widgets/basic_fitting/basic_fitting_model.py
+++ b/scripts/Muon/GUI/Common/fitting_widgets/basic_fitting/basic_fitting_model.py
@@ -289,7 +289,7 @@ class BasicFittingModel:
         """Clears the undo fit functions and other data for the currently selected index."""
         current_dataset_index = self.fitting_context.current_dataset_index
         for i, dataset_index in reversed(list(enumerate(self.fitting_context.dataset_indices_for_undo))):
-            if dataset_index == current_dataset_index:
+            if dataset_index == current_dataset_index and i < len(self.fitting_context.active_fit_history):
                 del self.fitting_context.active_fit_history[i]
                 del self.fitting_context.dataset_indices_for_undo[i]
                 del self.fitting_context.single_fit_functions_for_undo[i]

--- a/scripts/test/Muon/fitting_context_test.py
+++ b/scripts/test/Muon/fitting_context_test.py
@@ -227,6 +227,18 @@ class FittingContextTest(unittest.TestCase):
             self.assertTrue(
                 name in log_names, msg="{} not found in log list".format(name))
 
+    def test_that_the_non_zero_global_parameter_error_is_saved_in_the_fit_parameter(self):
+        globals = ['Height']
+        test_parameters = OrderedDict([('Height', (10., 0.0)),
+                                       ('Height', (10., 0.4)),
+                                       ('f0.A0', (1, 0.01)),
+                                       ('f1.A0', (1, 0.01)),
+                                       ('Cost function', (0.1, 0.))])
+        fit_params = create_test_fit_parameters(test_parameters, globals)
+
+        self.assertEqual(fit_params.value("Height"), 10.0)
+        self.assertEqual(fit_params.error("Height"), 0.4)
+
 
 if __name__ == '__main__':
     unittest.main(buffer=False, verbosity=2)


### PR DESCRIPTION
**Description of work.**
This PR fixes a bug where the global parameter saved in a results table can sometimes have a zero error arbitrarily. This does not make complete sense as it technically does have an error as it is tied to another parameter which has an error.

This PR makes sure the global parameter with the non-zero error value is used. As a result, a bug found by James is also fixed:
```
I set up a simultaneous fit (e.g. MUSR run 62260, choose Simultaneous across run, choose 
function GausOsc, set A, Frequency, Sigma to Global) and click Fit. Then I go to the next run 
and before clicking Fit I scan through the selected spectra to see their parameters such that a 
different one is selected as I click Fit. Eventually create a Results Table for the whole set. Many 
of the runs will have error=0 for the global parameters. Subsequently in Model Fitting these 
points seem to be omitted or given weight=0.
```

**To test:**
Follow the testing instructions in #32388 . All of the A parameters should have a non-zero error.

Fixes #32388

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
