### PR TITLE
Offset the x range of a fit in muon GUIs

### DIFF
--- a/docs/source/release/v6.2.0/muon.rst
+++ b/docs/source/release/v6.2.0/muon.rst
@@ -75,6 +75,7 @@ Improvements
 
 Bugfixes
 ########
+- The fit ranges will now always allow you to encompass the entire x range of the loaded data.
 - The GUIs will no longer crash if there are any whitespaces in the run range (e.g. 6010- 3).
 - The GUIs will now cope with a range of runs that span between two different decades where the second number
   in the range is smaller than the final digit of the first number in the range (e.g. 6018-3 can be used for the range 6018-6023).

--- a/scripts/Muon/GUI/Common/utilities/workspace_data_utils.py
+++ b/scripts/Muon/GUI/Common/utilities/workspace_data_utils.py
@@ -18,9 +18,10 @@ def x_limits_of_workspace(workspace_name: str, default_limits: tuple = (DEFAULT_
         if len(x_data) > 0:
             x_data.sort()
             x_lower, x_higher = x_data[0], x_data[-1]
-            if x_lower == x_higher:
-                return x_lower - X_OFFSET, x_higher + X_OFFSET
-            return x_lower, x_higher
+            # An offset is applied because if the x_lower is rounded up due to the precision of the Muon GUI, then some
+            # data points could be missed out unintentionally. A similar issue could happen if the x_higher were rounded
+            # down due to the GUI precision.
+            return x_lower - X_OFFSET, x_higher + X_OFFSET
     return default_limits
 
 

--- a/scripts/test/Muon/corrections_tab_widget/background_corrections_model_test.py
+++ b/scripts/test/Muon/corrections_tab_widget/background_corrections_model_test.py
@@ -14,7 +14,7 @@ from Muon.GUI.Common.corrections_tab_widget.corrections_model import Corrections
 from Muon.GUI.Common.corrections_tab_widget.background_corrections_model import (BackgroundCorrectionsModel,
                                                                                  DEFAULT_USE_RAW)
 from Muon.GUI.Common.test_helpers.context_setup import setup_context
-from Muon.GUI.Common.utilities.workspace_data_utils import DEFAULT_X_LOWER, DEFAULT_X_UPPER
+from Muon.GUI.Common.utilities.workspace_data_utils import DEFAULT_X_LOWER, DEFAULT_X_UPPER, X_OFFSET
 
 
 class BackgroundCorrectionsModelTest(unittest.TestCase):
@@ -203,8 +203,8 @@ class BackgroundCorrectionsModelTest(unittest.TestCase):
 
         x_lower, x_upper = self.model.x_limits_of_workspace(run, group)
 
-        self.assertEqual(x_lower, 0.0)
-        self.assertEqual(x_upper, 20000.0)
+        self.assertEqual(x_lower, 0.0 - X_OFFSET)
+        self.assertEqual(x_upper, 20000.0 + X_OFFSET)
 
     def test_that_x_limits_of_workspace_will_return_the_default_x_values_if_there_are_no_workspaces_loaded(self):
         run, group = "84447", "top"

--- a/scripts/test/Muon/fitting_widgets/basic_fitting/basic_fitting_model_test.py
+++ b/scripts/test/Muon/fitting_widgets/basic_fitting/basic_fitting_model_test.py
@@ -14,6 +14,7 @@ from Muon.GUI.Common.fitting_widgets.basic_fitting.basic_fitting_model import Ba
 from Muon.GUI.Common.muon_pair import MuonPair
 from Muon.GUI.Common.muon_base_pair import MuonBasePair
 from Muon.GUI.Common.test_helpers.context_setup import setup_context
+from Muon.GUI.Common.utilities.workspace_data_utils import X_OFFSET
 from Muon.GUI.Common.utilities.workspace_utils import StaticWorkspaceWrapper
 
 
@@ -652,8 +653,8 @@ class BasicFittingModelTest(unittest.TestCase):
 
         x_lower, x_upper = self.model.x_limits_of_workspace(self.model.current_dataset_name)
 
-        self.assertEqual(x_lower, 0.0)
-        self.assertEqual(x_upper, 20000.0)
+        self.assertEqual(x_lower, 0.0 - X_OFFSET)
+        self.assertEqual(x_upper, 20000.0 + X_OFFSET)
 
     def test_that_x_limits_of_current_dataset_will_return_the_default_x_values_if_there_are_no_workspaces_loaded(self):
         x_lower, x_upper = self.model.x_limits_of_workspace(self.model.current_dataset_name)


### PR DESCRIPTION
**Description of work.**
This PR fixes an issue where the x range of a fit is sometimes not allowed to encompass the entire range of the actual data in the x axis. This is due to the GUI only allowing a certain precision, and so some data points at the start or end of the data can be cut off when doing a fit.

**To test:**
Follow the instructions in #32442 . Ensure that the first data point is included in the fit. The start X should be 4.599

Fixes #32442


#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
