### PR TITLE
Add unit test for invalid background params data in Engineering Diff UI

### DIFF
--- a/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/data_handling/test/test_data_model.py
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/fitting/data_handling/test/test_data_model.py
@@ -11,6 +11,7 @@ from unittest.mock import patch
 from numpy import isnan, nan
 from mantid.kernel import UnitParams, UnitParametersMap
 from Engineering.gui.engineering_diffraction.tabs.fitting.data_handling.data_model import FittingDataModel
+from testhelpers import assertRaisesNothing
 
 data_model_path = "Engineering.gui.engineering_diffraction.tabs.fitting.data_handling.data_model"
 
@@ -195,6 +196,19 @@ class TestFittingDataModel(unittest.TestCase):
         self.assertEqual(self.model._bg_params["name1"], bg_params)
         mock_minus.assert_not_called()
         mock_estimate_bg.assert_not_called()
+
+    @patch(data_model_path + ".SetUncertainties")
+    @patch(data_model_path + ".DeleteWorkspace")
+    @patch(data_model_path + ".EnggEstimateFocussedBackground")
+    @patch(data_model_path + ".Minus")
+    def test_invalid_bg_inputs_dont_throw(self, mock_minus, mock_estimate_bg, mock_delete_ws, mock_set_uncertainties):
+        self.model._loaded_workspaces = {"name1": self.mock_ws}
+        self.model._bg_sub_workspaces = {"name1": None}
+        self.model._bg_params = dict()
+        mock_estimate_bg.side_effect = ValueError("Some problem")
+
+        bg_params = [True, -1, 800, False]
+        assertRaisesNothing(self, self.model.create_or_update_bgsub_ws, "name1", bg_params)
 
     @patch(data_model_path + '.RenameWorkspace')
     @patch(data_model_path + ".ADS")


### PR DESCRIPTION
**Description of work.**

Add unit test for invalid NIter in background params. The model was changed in #32354 to catch the exception raised by EnggEstimateFocussedBackground.

**To test:**

Code review only

Fixes #32444.

*This does not require release notes* because **it only adds a new unit test**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
