### PR TITLE
Set c++ standard for cppcheck to validate against (ornlnext)

### DIFF
--- a/Framework/Algorithms/inc/MantidAlgorithms/AddSampleLog.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/AddSampleLog.h
@@ -66,7 +66,7 @@ private:
   void setTimeSeriesData(API::Run &run_obj, const std::string &property_name, bool value_is_int);
 
   /// get run start time
-  Types::Core::DateAndTime getRunStart(API::Run &run_obj);
+  Types::Core::DateAndTime getRunStart(const API::Run &run_obj);
 
   /// get value vector of the integer TimeSeriesProperty entries
   std::vector<int> getIntValues(const API::MatrixWorkspace_const_sptr &dataws, int workspace_index);

--- a/Framework/Algorithms/src/AddSampleLog.cpp
+++ b/Framework/Algorithms/src/AddSampleLog.cpp
@@ -365,7 +365,7 @@ std::vector<Types::Core::DateAndTime> AddSampleLog::getTimes(const API::MatrixWo
  * @param run_obj
  * @return
  */
-Types::Core::DateAndTime AddSampleLog::getRunStart(API::Run &run_obj) {
+Types::Core::DateAndTime AddSampleLog::getRunStart(const API::Run &run_obj) {
   // TODO/ISSUE/NOW - data ws should be the target workspace with run_start or
   // proton_charge property!
   Types::Core::DateAndTime runstart(0);

--- a/buildconfig/CMake/CppCheckSetup.cmake
+++ b/buildconfig/CMake/CppCheckSetup.cmake
@@ -10,6 +10,7 @@ if ( CPPCHECK_EXECUTABLE )
   # setup the standard arguments
   # --inline-suppr appears to be ignored if --suppresions-list is specified
   set ( CPPCHECK_ARGS --enable=all --inline-suppr --max-configs=120
+  --std=c++${CMAKE_CXX_STANDARD}  # use the standard from cmake
   --suppressions-list=${CMAKE_BINARY_DIR}/CppCheck_Suppressions.txt
   --project=${CMAKE_BINARY_DIR}/compile_commands.json
   # Force cppcheck to check when we use project-wide macros


### PR DESCRIPTION
This is a version of #32458 into `ornl-next`