### PR TITLE
Fix fit parameters not updating in fit browser

### DIFF
--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FitPropertyBrowser.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FitPropertyBrowser.h
@@ -471,7 +471,7 @@ protected:
   /// Adds the workspace index property to the browser.
   virtual void addWorkspaceIndexToBrowser();
   /// Set the parameters to the fit outcome
-  void getFitResults();
+  void updateBrowserFromFitResults(const Mantid::API::IFunction_sptr &finalFunction);
   /// Create a double property and set some settings
   QtProperty *addDoubleProperty(const QString &name, QtDoublePropertyManager *manager = nullptr) const;
   /// Called when the minimizer changes. Creates minimizes's properties.

--- a/qt/widgets/common/src/FitPropertyBrowser.cpp
+++ b/qt/widgets/common/src/FitPropertyBrowser.cpp
@@ -1629,7 +1629,8 @@ void FitPropertyBrowser::finishHandle(const Mantid::API::IAlgorithm *alg) {
   else // else fitting to current workspace, group under same name.
     emit fittingDone(name);
 
-  getFitResults();
+  IFunction_sptr function = alg->getProperty("Function");
+  updateBrowserFromFitResults(function);
   if (!isWorkspaceAGroup() && alg->existsProperty("OutputWorkspace")) {
     std::string out = alg->getProperty("OutputWorkspace");
     emit algorithmFinished(QString::fromStdString(out));
@@ -2024,30 +2025,13 @@ void FitPropertyBrowser::clearBrowser() {
 }
 
 /// Set the parameters to the fit outcome
-void FitPropertyBrowser::getFitResults() {
-  std::string wsName = outputName() + "_Parameters";
-  if (Mantid::API::AnalysisDataService::Instance().doesExist(wsName)) {
-    Mantid::API::ITableWorkspace_sptr ws = std::dynamic_pointer_cast<Mantid::API::ITableWorkspace>(
-        Mantid::API::AnalysisDataService::Instance().retrieve(wsName));
-
-    Mantid::API::TableRow row = ws->getFirstRow();
-    do {
-      try {
-        std::string name;
-        double value, error;
-        row >> name >> value >> error;
-
-        size_t paramIndex = compositeFunction()->parameterIndex(name);
-
-        compositeFunction()->setParameter(paramIndex, value);
-        compositeFunction()->setError(paramIndex, error);
-      } catch (...) {
-        // do nothing
-      }
-    } while (row.next());
-    updateParameters();
-    getHandler()->updateErrors();
+void FitPropertyBrowser::updateBrowserFromFitResults(const IFunction_sptr &finalFunction) {
+  for (auto paramIndex = 0u; paramIndex < finalFunction->nParams(); ++paramIndex) {
+    compositeFunction()->setParameter(paramIndex, finalFunction->getParameter(paramIndex));
+    compositeFunction()->setError(paramIndex, finalFunction->getError(paramIndex));
   }
+  updateParameters();
+  getHandler()->updateErrors();
 }
 
 /**


### PR DESCRIPTION
**Description of work.**
This PR fixes an issue where the parameters from a fit were not updating in the fit browser. This was only an issue for single functions, as the parameters from the table were unprefixed, but due to design the fit browser, it treats every function as a composite function. So when it went to set the parameter values, using the table parameter names it threw (which was caught by the fit browser without any warnings or information). I believe a better way of updating the parameters is to use the output of the fit algorithm, rather than using the table workspace, which doesn't necessarily conform to our parameter naming conventions (and nor should it have to). But maybe there's some edge case I haven't considered...

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**

- Create a workspace, plot it - add a single function and do a fit. The parameters should update.
- Add multiple functions, the parameters should update. 
- Try various combinations of functions and ties, every time we should expect the parameters to update.

<!-- Instructions for testing. -->

Fixes #32439. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
