### PR TITLE
Set c++ standard for cppcheck to validate against

### DIFF
--- a/Framework/Algorithms/inc/MantidAlgorithms/AddSampleLog.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/AddSampleLog.h
@@ -66,7 +66,7 @@ private:
   void setTimeSeriesData(API::Run &run_obj, const std::string &property_name, bool value_is_int);
 
   /// get run start time
-  Types::Core::DateAndTime getRunStart(API::Run &run_obj);
+  Types::Core::DateAndTime getRunStart(const API::Run &run_obj);
 
   /// get value vector of the integer TimeSeriesProperty entries
   std::vector<int> getIntValues(const API::MatrixWorkspace_const_sptr &dataws, int workspace_index);

--- a/Framework/Algorithms/src/AddSampleLog.cpp
+++ b/Framework/Algorithms/src/AddSampleLog.cpp
@@ -365,7 +365,7 @@ std::vector<Types::Core::DateAndTime> AddSampleLog::getTimes(const API::MatrixWo
  * @param run_obj
  * @return
  */
-Types::Core::DateAndTime AddSampleLog::getRunStart(API::Run &run_obj) {
+Types::Core::DateAndTime AddSampleLog::getRunStart(const API::Run &run_obj) {
   // TODO/ISSUE/NOW - data ws should be the target workspace with run_start or
   // proton_charge property!
   Types::Core::DateAndTime runstart(0);

--- a/buildconfig/CMake/CppCheckSetup.cmake
+++ b/buildconfig/CMake/CppCheckSetup.cmake
@@ -10,6 +10,7 @@ if ( CPPCHECK_EXECUTABLE )
   # setup the standard arguments
   # --inline-suppr appears to be ignored if --suppresions-list is specified
   set ( CPPCHECK_ARGS --enable=all --inline-suppr --max-configs=120
+  --std=c++${CMAKE_CXX_STANDARD}  # use the standard from cmake
   --suppressions-list=${CMAKE_BINARY_DIR}/CppCheck_Suppressions.txt
   --project=${CMAKE_BINARY_DIR}/compile_commands.json
   # Force cppcheck to check when we use project-wide macros


### PR DESCRIPTION
To keep things synchronized with the flags cmake gives the compiler, just use the version set in cmake in the second place. This should help the code be more consistent with the standard.

**To test:**

If the cppcheck build continues to pass, everything is fine.

*There is no associated issue.*

*This does not require release notes* because it only affects a job on the build server.

#32456 is the version into `ornl-next`

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
