### PR TITLE
Add extra unit test for case where point generation misses

### DIFF
--- a/Framework/Geometry/test/CSGObjectTest.h
+++ b/Framework/Geometry/test/CSGObjectTest.h
@@ -1314,17 +1314,40 @@ public:
     EXPECT_CALL(rng, nextValue()).InSequence(rand).WillOnce(Return(randZ));
 
     constexpr double halfWidth{0.75};
-    auto ball = ComponentCreationHelper::createCuboid(halfWidth);
+    auto cuboid = ComponentCreationHelper::createCuboid(halfWidth);
     // Create a thin infinite rectangular region to restrict point generation
     BoundingBox activeRegion(0.1, 0.1, 0.1, -0.1, -0.1, -0.1);
     constexpr size_t maxAttempts{1};
-    boost::optional<V3D> point = ball->generatePointInObject(rng, activeRegion, maxAttempts);
+    boost::optional<V3D> point = cuboid->generatePointInObject(rng, activeRegion, maxAttempts);
     TS_ASSERT_EQUALS(!point, false);
-    // We should get the point generated from the second 'random' triplet.
     constexpr double tolerance{1e-10};
     TS_ASSERT_DELTA(-0.1 + randX * 0.2, point->X(), tolerance)
     TS_ASSERT_DELTA(-0.1 + randY * 0.2, point->Y(), tolerance)
     TS_ASSERT_DELTA(-0.1 + randZ * 0.2, point->Z(), tolerance)
+  }
+
+  void testGeneratePointSometimesMisses() {
+    // if there's a requirement to fairly sample scatter points between different sample environment
+    // parts then it's important the generatePointInObject method misses sometimes
+    using namespace ::testing;
+
+    // Generate "random" sequence.
+    MockRNG rng;
+    Sequence rand;
+    constexpr double randX{0.92};
+    constexpr double randY{0.14};
+    constexpr double randZ{0.83};
+    EXPECT_CALL(rng, nextValue()).InSequence(rand).WillOnce(Return(randX));
+    EXPECT_CALL(rng, nextValue()).InSequence(rand).WillOnce(Return(randY));
+    EXPECT_CALL(rng, nextValue()).InSequence(rand).WillOnce(Return(randZ));
+
+    constexpr double halfWidth{0.075};
+    auto cuboid = ComponentCreationHelper::createCuboid(halfWidth);
+    // Create a rectangular region to restrict point generation
+    BoundingBox activeRegion(0.1, 0.1, 0.1, -0.1, -0.1, -0.1);
+    constexpr size_t maxAttempts{1};
+    boost::optional<V3D> point = cuboid->generatePointInObject(rng, activeRegion, maxAttempts);
+    TS_ASSERT_EQUALS(!point, true);
   }
 
   void testSolidAngleSphere()


### PR DESCRIPTION
**Description of work.**

Add unit test to cover change in functionality implemented a while ago to allow the point generation in a CSGObject to fail to return a point sometimes when it's run with maxAttempts=1. This is important because it allows scattering points to be sampled fairly between the sample and other sample environment components

This small change has been in the diffraction backlog for a long time since the functional change was done in https://github.com/mantidproject/mantid/pull/27715. Doing as a maintenance task now

**To test:**

Code review. Check Jenkins tests all pass

Fixes #27753.

*This does not require release notes* because **there's no functional change to the user**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
