### PR TITLE
Handle RHEL using cmake3 instead of cmake in cppcheck

### DIFF
--- a/buildconfig/Jenkins/cppcheck.sh
+++ b/buildconfig/Jenkins/cppcheck.sh
@@ -27,15 +27,24 @@ cd $WORKSPACE/build
 find -name cppcheck.xml -delete
 
 # configure cmake
+if [ $(command -v scl) ]; then
+    CMAKE_EXE=cmake3
+    SCL_ENABLE="scl enable devtoolset-7"
+else
+    CMAKE_EXE=cmake
+    SCL_ENABLE=""
+fi
+$SCL_ENABLE "$CMAKE_EXE --version"
+
 if [ "$(command -v ninja)" ]; then
   CMAKE_GENERATOR="-G Ninja"
 elif [ "$(command -v ninja-build)" ]; then
   CMAKE_GENERATOR="-G Ninja"
 fi
-cmake ${CMAKE_GENERATOR} -DCMAKE_BUILD_TYPE=Debug -DCPPCHECK_GENERATE_XML=TRUE -DCPPCHECK_NUM_THREADS=$BUILD_THREADS ..
+$SCL_ENABLE "$CMAKE_EXE ${CMAKE_GENERATOR} -DCMAKE_BUILD_TYPE=Debug -DCPPCHECK_GENERATE_XML=TRUE -DCPPCHECK_NUM_THREADS=$BUILD_THREADS .."
 
 # run cppcheck
-cmake --build . --target cppcheck
+$SCL_ENABLE "$CMAKE_EXE --build . --target cppcheck"
 
 # Generate HTML report
 cppcheck-htmlreport --file=cppcheck.xml --title=Embedded --report-dir=cppcheck-report


### PR DESCRIPTION
**Description of work.**
This explicitly checks which instance we have instead of hard coding. This was failing some cppcheck builds on our new RHEL builders

**To test:**
- Grab the latest docker image for CentOS (as this matches the build servers):
- `docker run -it mantidproject/mantid-development-centos7`
- Clone mantid and cd into source directory
- Run the script as follows (note the env var is required)
`WORKSPACE=$(pwd) buildconfig/jenkins/cppcheck.sh`
- Ensure CMake starts and it starts the cppcheck step, you don't need to wait for this to complete
---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
