### PR TITLE
Model Fitting - Do not look in unit factory for units

### DIFF
--- a/scripts/Muon/GUI/Common/fitting_widgets/model_fitting/model_fitting_model.py
+++ b/scripts/Muon/GUI/Common/fitting_widgets/model_fitting/model_fitting_model.py
@@ -248,15 +248,8 @@ class ModelFittingModel(BasicFittingModel):
 
     def _create_y_label(self, parameter_name: str) -> str:
         """Returns the string to use for the y label of a workspace."""
-        unit = self._get_parameter_unit(parameter_name)
+        unit = self._get_unit_from_sample_logs(parameter_name)
         return f"{parameter_name} ({unit})" if unit != "" else f"{parameter_name}"
-
-    def _get_parameter_unit(self, parameter_name: str) -> str:
-        """Returns the units of a parameter by searching the UnitFactory and Sample logs."""
-        unit = self._get_unit_from_unit_factory(parameter_name)
-        if unit == "":
-            unit = self._get_unit_from_sample_logs(parameter_name)
-        return unit
 
     def _get_unit_from_sample_logs(self, parameter_name: str) -> str:
         """Returns the units of a sample log if the parameter exists as a sample log."""
@@ -264,12 +257,6 @@ class ModelFittingModel(BasicFittingModel):
         if workspace:
             run = workspace.run()
             return run.getLogData(parameter_name).units if run.hasProperty(parameter_name) else ""
-        return ""
-
-    def _get_unit_from_unit_factory(self, parameter_name: str) -> str:
-        """Returns the units of a parameter if it exists in the UnitFactory."""
-        if self._is_in_unit_factory(parameter_name):
-            return UnitFactory.create(parameter_name).label()
         return ""
 
     @ staticmethod


### PR DESCRIPTION
**Description of work.**
This PR ensures that no units are used in the model fit pane for fit parameters. There is no easy way to tell what the units for a fit parameter should be as they can vary depending on the data you are fitting and the fit function you use. Previously, the unit factory was being used to find the units of a parameter, but this isn't always correct. It was therefore decided that its better to provide no units for a fit parameter rather than incorrect units.

In the future we will need to get the units of the fit parameters from somewhere, I am open to suggestions.

**To test:**
Load MUSR 62260
Add function GausOsc
Sequentially fit all
Go to results tab and create the table
Select Phi on the x or y axis. It should have no units. It used to be given as degrees but this was incorrect.

Fixes #32453

*This does not require release notes* because **model fitting is new**

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
