### PR TITLE
Muon Fitting - update attribute values when changed

### DIFF
--- a/docs/source/release/v6.2.0/muon.rst
+++ b/docs/source/release/v6.2.0/muon.rst
@@ -83,6 +83,7 @@ Bugfixes
   any information about why the value was invalid. It will now revert to last viable BinWidth used and explain why.
 - The autoscale option when ``All`` is selected will now show the largest and smallest y value for all of the plots.
 - The global parameters in a results table will no longer be given a zero error arbitrarily if one with an error exists.
+- The attribute values in a Chebyshev function will no longer get reset after performing a simultaneous fit.
 
 ALC
 ---

--- a/qt/python/mantidqt/_common.sip
+++ b/qt/python/mantidqt/_common.sip
@@ -978,6 +978,7 @@ public:
 signals:
     void functionStructureChanged();
     void parameterChanged(const QString &funcIndex, const QString &paramName);
+    void attributeChanged(const QString &attributeName);
 };
 
 // ---------------------------------

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FunctionBrowser.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FunctionBrowser.h
@@ -124,6 +124,7 @@ public:
 
 signals:
   void parameterChanged(const QString &funcIndex, const QString &paramName);
+  void attributeChanged(const QString &attributeName);
   void functionStructureChanged();
   /// User selects a different function (or one of it's sub-properties)
   void currentFunctionChanged();

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FunctionMultiDomainPresenter.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FunctionMultiDomainPresenter.h
@@ -80,6 +80,7 @@ public:
 signals:
   void functionStructureChanged();
   void parameterChanged(const QString &funcIndex, const QString &paramName);
+  void attributeChanged(const QString &attributeName);
 private slots:
   void viewChangedParameter(const QString &parName);
   void viewChangedAttribute(const QString &attrName);

--- a/qt/widgets/common/src/FunctionBrowser.cpp
+++ b/qt/widgets/common/src/FunctionBrowser.cpp
@@ -54,6 +54,8 @@ FunctionBrowser::FunctionBrowser(QWidget *parent, bool multi, const std::vector<
   connect(m_presenter.get(), SIGNAL(functionStructureChanged()), this, SIGNAL(functionStructureChanged()));
   connect(m_presenter.get(), SIGNAL(parameterChanged(const QString &, const QString &)), this,
           SIGNAL(parameterChanged(const QString &, const QString &)));
+  connect(m_presenter.get(), SIGNAL(attributeChanged(const QString &)), this,
+          SIGNAL(attributeChanged(const QString &)));
 }
 
 /**

--- a/qt/widgets/common/src/FunctionMultiDomainPresenter.cpp
+++ b/qt/widgets/common/src/FunctionMultiDomainPresenter.cpp
@@ -298,6 +298,7 @@ void FunctionMultiDomainPresenter::viewChangedAttribute(const QString &attrName)
   try {
     auto value = m_view->getAttribute(attrName);
     m_model->setAttribute(attrName, value);
+    emit attributeChanged(attrName);
   } catch (const std::invalid_argument &e) {
     updateViewAttributesFromModel();
     g_log.error(e.what());

--- a/scripts/Muon/GUI/Common/fitting_widgets/basic_fitting/basic_fitting_model.py
+++ b/scripts/Muon/GUI/Common/fitting_widgets/basic_fitting/basic_fitting_model.py
@@ -427,6 +427,11 @@ class BasicFittingModel:
         if self.current_single_fit_function is not None:
             self.current_single_fit_function.setParameter(full_parameter, value)
 
+    def update_attribute_value(self, full_attribute: str, value: float) -> None:
+        """Update the value of an attribute in the fit function."""
+        if self.current_single_fit_function is not None:
+            self.current_single_fit_function.setAttributeValue(full_attribute, value)
+
     @property
     def do_rebin(self) -> bool:
         """Returns true if rebin is selected within the context."""

--- a/scripts/Muon/GUI/Common/fitting_widgets/basic_fitting/basic_fitting_presenter.py
+++ b/scripts/Muon/GUI/Common/fitting_widgets/basic_fitting/basic_fitting_presenter.py
@@ -68,6 +68,8 @@ class BasicFittingPresenter:
         self.view.set_slot_for_function_structure_changed(self.handle_function_structure_changed)
         self.view.set_slot_for_function_parameter_changed(
             lambda function_index, parameter: self.handle_function_parameter_changed(function_index, parameter))
+        self.view.set_slot_for_function_attribute_changed(
+            lambda attribute: self.handle_function_attribute_changed(attribute))
         self.view.set_slot_for_start_x_updated(self.handle_start_x_updated)
         self.view.set_slot_for_end_x_updated(self.handle_end_x_updated)
         self.view.set_slot_for_exclude_range_state_changed(self.handle_exclude_range_state_changed)
@@ -249,7 +251,7 @@ class BasicFittingPresenter:
         # Required to update the function browser to display the errors when first adding a function.
         self.view.set_current_dataset_index(self.model.current_dataset_index)
 
-    def handle_function_parameter_changed(self, function_index, parameter) -> None:
+    def handle_function_parameter_changed(self, function_index: str, parameter: str) -> None:
         """Handle when the value of a parameter in a function is changed."""
         full_parameter = f"{function_index}{parameter}"
         self.model.update_parameter_value(full_parameter, self.view.parameter_value(full_parameter))
@@ -258,6 +260,10 @@ class BasicFittingPresenter:
 
         self.fit_function_changed_notifier.notify_subscribers()
         self.fit_parameter_changed_notifier.notify_subscribers()
+
+    def handle_function_attribute_changed(self, attribute: str) -> None:
+        """Handle when the value of a attribute in a function is changed."""
+        self.model.update_attribute_value(attribute, self.view.attribute_value(attribute))
 
     def handle_start_x_updated(self) -> None:
         """Handle when the start X is changed."""

--- a/scripts/Muon/GUI/Common/fitting_widgets/basic_fitting/basic_fitting_view.py
+++ b/scripts/Muon/GUI/Common/fitting_widgets/basic_fitting/basic_fitting_view.py
@@ -77,6 +77,10 @@ class BasicFittingView(ui_form, base_widget):
         """Connect the slot for a function parameter changing."""
         self.fit_function_options.set_slot_for_function_parameter_changed(slot)
 
+    def set_slot_for_function_attribute_changed(self, slot) -> None:
+        """Connect the slot for a function attribute changing."""
+        self.fit_function_options.set_slot_for_function_attribute_changed(slot)
+
     def set_slot_for_start_x_updated(self, slot) -> None:
         """Connect the slot for the start x option."""
         self.fit_function_options.set_slot_for_start_x_updated(slot)
@@ -270,6 +274,10 @@ class BasicFittingView(ui_form, base_widget):
     def parameter_value(self, full_parameter: str) -> float:
         """Returns the value of the specified parameter."""
         return self.fit_function_options.parameter_value(full_parameter)
+
+    def attribute_value(self, full_attribute: str):
+        """Returns the value of the specified attribute."""
+        return self.fit_function_options.attribute_value(full_attribute)
 
     def switch_to_simultaneous(self) -> None:
         """Switches the view to simultaneous fit mode."""

--- a/scripts/Muon/GUI/Common/fitting_widgets/basic_fitting/fit_function_options_view.py
+++ b/scripts/Muon/GUI/Common/fitting_widgets/basic_fitting/fit_function_options_view.py
@@ -78,6 +78,10 @@ class FitFunctionOptionsView(ui_form, base_widget):
         """Connect the slot for a function parameter changing."""
         self.function_browser.parameterChanged.connect(slot)
 
+    def set_slot_for_function_attribute_changed(self, slot) -> None:
+        """Connect the slot for a function attribute changing."""
+        self.function_browser.attributeChanged.connect(slot)
+
     def set_slot_for_start_x_updated(self, slot) -> None:
         """Connect the slot for the start x option."""
         self.start_x_line_edit.editingFinished.connect(slot)
@@ -274,6 +278,10 @@ class FitFunctionOptionsView(ui_form, base_widget):
     def parameter_value(self, full_parameter: str) -> float:
         """Returns the value of the specified parameter."""
         return self.function_browser.getParameter(full_parameter)
+
+    def attribute_value(self, full_attribute: str):
+        """Returns the value of the specified attribute."""
+        return self.current_fit_function().getAttributeValue(full_attribute)
 
     def switch_to_simultaneous(self) -> None:
         """Switches the view to simultaneous mode."""

--- a/scripts/Muon/GUI/Common/fitting_widgets/general_fitting/general_fitting_model.py
+++ b/scripts/Muon/GUI/Common/fitting_widgets/general_fitting/general_fitting_model.py
@@ -101,6 +101,15 @@ class GeneralFittingModel(BasicFittingModel):
         else:
             super().update_parameter_value(full_parameter, value)
 
+    def update_attribute_value(self, full_attribute: str, value: float) -> None:
+        """Update the value of an attribute in the fit function."""
+        if self.fitting_context.simultaneous_fitting_mode:
+            current_domain_function = self.current_domain_fit_function()
+            if current_domain_function is not None:
+                current_domain_function.setAttributeValue(full_attribute, value)
+        else:
+            super().update_attribute_value(full_attribute, value)
+
     def automatically_update_function_name(self) -> None:
         """Attempt to update the function name automatically."""
         if self.fitting_context.function_name_auto_update:

--- a/scripts/Muon/GUI/Common/test_helpers/fitting_mock_setup.py
+++ b/scripts/Muon/GUI/Common/test_helpers/fitting_mock_setup.py
@@ -22,6 +22,7 @@ def add_mock_methods_to_basic_fitting_view(view):
     view.set_slot_for_covariance_matrix_clicked = mock.Mock()
     view.set_slot_for_function_structure_changed = mock.Mock()
     view.set_slot_for_function_parameter_changed = mock.Mock()
+    view.set_slot_for_function_attribute_changed = mock.Mock()
     view.set_slot_for_start_x_updated = mock.Mock()
     view.set_slot_for_end_x_updated = mock.Mock()
     view.set_slot_for_exclude_range_state_changed = mock.Mock()

--- a/scripts/test/Muon/fitting_widgets/basic_fitting/basic_fitting_presenter_test.py
+++ b/scripts/test/Muon/fitting_widgets/basic_fitting/basic_fitting_presenter_test.py
@@ -54,6 +54,7 @@ class BasicFittingPresenterTest(unittest.TestCase, MockBasicFitting):
         self.assertEqual(self.view.set_slot_for_covariance_matrix_clicked.call_count, 1)
         self.assertEqual(self.view.set_slot_for_function_structure_changed.call_count, 1)
         self.assertEqual(self.view.set_slot_for_function_parameter_changed.call_count, 1)
+        self.assertEqual(self.view.set_slot_for_function_attribute_changed.call_count, 1)
         self.assertEqual(self.view.set_slot_for_start_x_updated.call_count, 1)
         self.assertEqual(self.view.set_slot_for_end_x_updated.call_count, 1)
         self.assertEqual(self.view.set_slot_for_exclude_range_state_changed.call_count, 1)
@@ -300,6 +301,17 @@ class BasicFittingPresenterTest(unittest.TestCase, MockBasicFitting):
 
         self.model.update_plot_guess.assert_called_once_with()
         self.presenter.fit_parameter_changed_notifier.notify_subscribers.assert_called_once_with()
+
+    def test_that_handle_function_attribute_changed_will_update_the_attribute_values_in_the_model(self):
+        attribute_value = True
+        full_attribute = "NumDeriv"
+        self.view.attribute_value = mock.Mock(return_value=attribute_value)
+        self.model.update_attribute_value = mock.Mock()
+
+        self.presenter.handle_function_attribute_changed(full_attribute)
+
+        self.view.attribute_value.assert_called_once_with(full_attribute)
+        self.model.update_attribute_value.assert_called_once_with(full_attribute, attribute_value)
 
     def test_that_handle_start_x_updated_will_attempt_to_update_the_start_x_in_the_model(self):
         self.presenter.handle_start_x_updated()

--- a/scripts/test/Muon/fitting_widgets/general_fitting/general_fitting_model_test.py
+++ b/scripts/test/Muon/fitting_widgets/general_fitting/general_fitting_model_test.py
@@ -224,6 +224,32 @@ class GeneralFittingModelTest(unittest.TestCase):
                                                                     "name=FlatBackground,A0=0,$domains=i;"
                                                                     "name=FlatBackground,A0=5,$domains=i")
 
+    def test_that_update_attribute_value_will_update_the_value_of_a_parameter_in_single_fit_mode(self):
+        self.model.dataset_names = self.dataset_names
+        self.model.single_fit_functions = [FunctionFactory.createFunction("Chebyshev"), None]
+
+        self.model.update_attribute_value("StartX", 0.0)
+        self.model.update_attribute_value("EndX", 15.0)
+
+        self.assertEqual(str(self.model.current_single_fit_function), "name=Chebyshev,EndX=15,StartX=0,n=0,A0=0")
+
+    def test_that_update_attribute_value_will_update_the_value_of_a_parameter_in_simultaneous_fit_mode(self):
+        self.model.dataset_names = self.dataset_names
+
+        self.fit_function = FunctionFactory.createFunction("Chebyshev")
+        self.model.simultaneous_fit_function = FunctionFactory.createInitializedMultiDomainFunction(
+            str(self.fit_function), len(self.dataset_names))
+
+        self.model.simultaneous_fitting_mode = True
+        self.model.current_dataset_index = 1
+
+        self.model.update_attribute_value("StartX", 0.0)
+        self.model.update_attribute_value("EndX", 15.0)
+
+        self.assertEqual(str(self.model.simultaneous_fit_function), "composite=MultiDomainFunction,NumDeriv=true;"
+                                                                    "name=Chebyshev,EndX=1,StartX=-1,n=0,A0=0,$domains=i;"
+                                                                    "name=Chebyshev,EndX=15,StartX=0,n=0,A0=0,$domains=i")
+
     def test_that_setting_new_dataset_names_will_reset_the_fit_functions_but_attempt_to_use_the_previous_function(self):
         self.model.dataset_names = self.dataset_names
         self.model.single_fit_functions = self.single_fit_functions


### PR DESCRIPTION
**Description of work.**
This PR fixes a bug in the fitting widgets used in Muon Analysis and FDA where attribute values do not get updates in the model. This causes a reset of the parameter values after a fit is performed.

**To test:**
Muon Analysis. Load HIFI 77766-67
Tick Simultaneous fit by. Choose Group/Pair. There should now be two datasets in the dataset combobox
Fitting tab, add Chebyshev with n=4 and ExpDecayOsc with Frequency =1
Change the StartX and EndX in the Chebyshev function to 0 and 15
Do a fit. The StartX and EndX in the Chebyshev function should not get reset to -1 and 1.

Fixes #32451

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
