### PR TITLE
Check pair instance is a MuonPair

### DIFF
--- a/scripts/Muon/GUI/Common/contexts/muon_context.py
+++ b/scripts/Muon/GUI/Common/contexts/muon_context.py
@@ -229,7 +229,7 @@ class MuonContext(object):
         """Returns a list of MuonPair's that are formed from one or more groups contained in the provided list."""
         pairs = []
         for pair in self._group_pair_context.pairs:
-            if pair.forward_group in groups or pair.backward_group in groups:
+            if isinstance(pair, MuonPair) and (pair.forward_group in groups or pair.backward_group in groups):
                 pairs.append(pair)
         return pairs
 

--- a/scripts/test/Muon/muon_context_test.py
+++ b/scripts/test/Muon/muon_context_test.py
@@ -15,6 +15,7 @@ from mantid import ConfigService
 from collections import Counter
 from Muon.GUI.Common.utilities.load_utils import load_workspace_from_filename
 from Muon.GUI.Common.test_helpers.context_setup import setup_context
+from Muon.GUI.Common.muon_base_pair import MuonBasePair
 from Muon.GUI.Common.muon_diff import MuonDiff
 from Muon.GUI.Common.muon_group import MuonGroup
 from Muon.GUI.Common.muon_pair import MuonPair
@@ -378,6 +379,14 @@ class MuonContextTest(unittest.TestCase):
         diffs = self.context.find_pairs_containing_groups(groups)
 
         self.assertEqual(len(diffs), 0)
+
+    def test_that_find_pairs_containing_groups_does_not_raise_if_one_of_the_pairs_is_a_MuonBasePair(self):
+        self.group_pair_context.add_pair(MuonBasePair("PhaseQuad_Re_"))
+        groups = ["bwd"]
+        pairs = self.context.find_pairs_containing_groups(groups)
+
+        self.assertEqual(len(pairs), 1)
+        self.assertEqual(pairs[0].name, "long")
 
     def test_that_find_diffs_containing_groups_or_pairs_will_return_diffs_containing_the_provided_pair(self):
         pair_diff = self.add_pair_diff()


### PR DESCRIPTION
**Description of work.**
This PR fixes a bug where it is assumed that the group/pair context only contains `MuonPair`s in the .pairs attribute. This is not true as a `MuonBasePair` is apparently created by the PhaseQuad tab.

The solution is to only perform the check if the pair is a `MuonPair`.

**To test:**
Muon Analysis
Load MUSR 62260
Create a phase table
Create a phasequad (the + button on the phase tab)
Step to the next run and wait
There should be no error message pop-up that appears.


Fixes #32455

*This does not require release notes* because **it was not in the previous mantid version.**

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
