### PR TITLE
Fix crash on Frequency Domain Analysis UI when updating fit function parameters

### DIFF
--- a/scripts/Muon/GUI/Common/seq_fitting_tab_widget/seq_fitting_tab_presenter.py
+++ b/scripts/Muon/GUI/Common/seq_fitting_tab_widget/seq_fitting_tab_presenter.py
@@ -68,7 +68,8 @@ class SeqFittingTabPresenter(object):
 
     def handle_fit_function_parameter_changed(self):
         self.view.fit_table.reset_fit_quality()
-        for row, fit_function in enumerate(self.model.get_all_fit_functions()):
+        display_type = self.view.selected_data_type()
+        for row, fit_function in enumerate(self.model.get_all_fit_functions_for(display_type)):
             parameter_values = self.model.get_all_fit_function_parameter_values_for(fit_function)
             self.view.fit_table.set_parameter_values_for_row(row, parameter_values)
 

--- a/scripts/test/Muon/seq_fitting_tab_widget/seq_fitting_tab_presenter_test.py
+++ b/scripts/test/Muon/seq_fitting_tab_widget/seq_fitting_tab_presenter_test.py
@@ -80,6 +80,20 @@ class SeqFittingTabPresenterTest(unittest.TestCase):
 
         self.view.fit_table.set_parameters_and_values.assert_called_once_with(parameters, [fit_values, fit_values])
 
+    def test_handle_fit_function_parameter_changed_correctly_updates_fit_table_parameters(self):
+        parameters = ['A', 'Sigma', 'Frequency', 'Phi']
+        fit_values = [0.2, 0.2, 0.1, 0]
+        self.model.get_fit_function_parameters = mock.Mock(return_value=parameters)
+        self.model.get_all_fit_functions = mock.Mock(return_value=[None, None, None])
+        self.model.get_all_fit_function_parameter_values_for = mock.Mock(return_value=fit_values)
+        self.model.get_all_fit_functions_for = mock.Mock(return_value=[None])
+        self.view.selected_data_type = mock.Mock(return_value="FD_Re")
+
+        self._setup_test_fit_function(fit_values)
+
+        self.presenter.handle_fit_function_parameter_changed()
+        self.view.fit_table.set_parameter_values_for_row.assert_called_once_with(0, fit_values)
+
     def test_handle_fit_started_updates_view(self):
         self.presenter.handle_fit_started()
 


### PR DESCRIPTION
**Description of work.**

Fix a crash if the user updates the parameters on a fit function on the Fitting tab that isn't displayed on the Sequential tab due to a filter being in place (on the Sequential tab). The code that handles the fitting function update in scripts\Muon\GUI\Common\seq_fitting_tab_widget\seq_fitting_tab_presenter.py now only tries to update fit functions that are displayed in the table on Sequential tab

**To test:**

Follow instruction on linked issue

Fixes #32454.

*This does not require release notes* because **bug introduced in this release cycle as part of https://github.com/mantidproject/mantid/pull/32173**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
