### PR TITLE
StartLiveDataDialog does not set start time correctly

### DIFF
--- a/docs/source/release/v6.3.0/mantidworkbench.rst
+++ b/docs/source/release/v6.3.0/mantidworkbench.rst
@@ -10,7 +10,7 @@ New and Improved
 
 Bugfixes
 --------
-- Fixed an issue to set up "Start Time" in `StartLiveDataDialog`.
+- Fixed arbitrary values not being accepted as the "Start Time" in StartLiveDataDialog.
 
 
 :ref:`Release 6.3.0 <v6.3.0>`

--- a/docs/source/release/v6.3.0/mantidworkbench.rst
+++ b/docs/source/release/v6.3.0/mantidworkbench.rst
@@ -10,5 +10,7 @@ New and Improved
 
 Bugfixes
 --------
+- Fixed an issue to set up "Start Time" in `StartLiveDataDialog`.
+
 
 :ref:`Release 6.3.0 <v6.3.0>`

--- a/qt/widgets/plugins/algorithm_dialogs/inc/MantidQtWidgets/Plugins/AlgorithmDialogs/StartLiveDataDialog.h
+++ b/qt/widgets/plugins/algorithm_dialogs/inc/MantidQtWidgets/Plugins/AlgorithmDialogs/StartLiveDataDialog.h
@@ -38,7 +38,7 @@ private slots:
   void setDefaultAccumulationMethod(const QString & /*listener*/);
   void updateUiElements(const QString & /*inst*/);
   void accept() override;
-  void initListenerPropLayout(const QString & /*listener*/);
+  void initListenerPropLayout();
   void updateConnectionChoices(const QString &inst_name);
   void updateConnectionDetails(const QString &connection);
 

--- a/qt/widgets/plugins/algorithm_dialogs/src/StartLiveDataDialog.cpp
+++ b/qt/widgets/plugins/algorithm_dialogs/src/StartLiveDataDialog.cpp
@@ -185,7 +185,7 @@ void StartLiveDataDialog::initLayout() {
   updateConnectionChoices(ui.cmbInstrument->currentText());
   updateConnectionDetails(ui.cmbConnection->currentText());
   setDefaultAccumulationMethod(ui.cmbConnListener->currentText());
-  initListenerPropLayout(ui.cmbConnListener->currentText());
+  initListenerPropLayout();
 
   //=========== SLOTS =============
   connect(ui.processingAlgo, SIGNAL(changedAlgorithm()), this, SLOT(changeProcessingAlgorithm()));
@@ -394,7 +394,7 @@ void StartLiveDataDialog::accept() {
  *
  * @param listener Name of the LiveListener class that is selected
  */
-void StartLiveDataDialog::initListenerPropLayout(const QString &listener) {
+void StartLiveDataDialog::initListenerPropLayout() {
   // remove previous listener's properties
   auto props = m_algorithm->getPropertiesInGroup("ListenerProperties");
   for (auto &prop : props) {
@@ -406,12 +406,7 @@ void StartLiveDataDialog::initListenerPropLayout(const QString &listener) {
 
   // update algorithm's properties
   if (ui.cmbInstrument->currentText().toStdString() != "") {
-    // There is no need to set up m_algorithm property here.  It is done in parseInput()
-    //    m_algorithm->setPropertyValue("Instrument", ui.cmbInstrument->currentText().toStdString());
-    //    m_algorithm->setPropertyValue("Listener", listener.toStdString());
     // create or clear the layout
-    std::cout << "Listerner " << listener.toStdString() << " will not be used here"
-              << "\n";
     QLayout *layout = ui.listenerProps->layout();
     if (!layout) {
       QGridLayout *listenerPropLayout = new QGridLayout(ui.listenerProps);

--- a/qt/widgets/plugins/algorithm_dialogs/src/StartLiveDataDialog.cpp
+++ b/qt/widgets/plugins/algorithm_dialogs/src/StartLiveDataDialog.cpp
@@ -392,7 +392,6 @@ void StartLiveDataDialog::accept() {
 /**
  * Update the Listener Properties group box for the current LiveListener.
  *
- * @param listener Name of the LiveListener class that is selected
  */
 void StartLiveDataDialog::initListenerPropLayout() {
   // remove previous listener's properties

--- a/qt/widgets/plugins/algorithm_dialogs/src/StartLiveDataDialog.cpp
+++ b/qt/widgets/plugins/algorithm_dialogs/src/StartLiveDataDialog.cpp
@@ -410,6 +410,8 @@ void StartLiveDataDialog::initListenerPropLayout(const QString &listener) {
     //    m_algorithm->setPropertyValue("Instrument", ui.cmbInstrument->currentText().toStdString());
     //    m_algorithm->setPropertyValue("Listener", listener.toStdString());
     // create or clear the layout
+    std::cout << "Listerner " << listener.toStdString() << " will not be used here"
+              << "\n";
     QLayout *layout = ui.listenerProps->layout();
     if (!layout) {
       QGridLayout *listenerPropLayout = new QGridLayout(ui.listenerProps);

--- a/qt/widgets/plugins/algorithm_dialogs/src/StartLiveDataDialog.cpp
+++ b/qt/widgets/plugins/algorithm_dialogs/src/StartLiveDataDialog.cpp
@@ -406,8 +406,9 @@ void StartLiveDataDialog::initListenerPropLayout(const QString &listener) {
 
   // update algorithm's properties
   if (ui.cmbInstrument->currentText().toStdString() != "") {
-    m_algorithm->setPropertyValue("Instrument", ui.cmbInstrument->currentText().toStdString());
-    m_algorithm->setPropertyValue("Listener", listener.toStdString());
+    // There is no need to set up m_algorithm property here.  It is done in parseInput()
+    //    m_algorithm->setPropertyValue("Instrument", ui.cmbInstrument->currentText().toStdString());
+    //    m_algorithm->setPropertyValue("Listener", listener.toStdString());
     // create or clear the layout
     QLayout *layout = ui.listenerProps->layout();
     if (!layout) {

--- a/qt/widgets/plugins/algorithm_dialogs/src/StartLiveDataDialog.cpp
+++ b/qt/widgets/plugins/algorithm_dialogs/src/StartLiveDataDialog.cpp
@@ -378,8 +378,14 @@ void StartLiveDataDialog::updateUiElements(const QString &inst) {
 void StartLiveDataDialog::accept() {
   // Now manually set the StartTime property as there's a computation needed
   DateAndTime startTime = DateAndTime::getCurrentTime() - ui.dateTimeEdit->value() * 60.0;
-  m_algorithm->setPropertyValue("StartTime", startTime.toISO8601String());
+  std::string starttime = startTime.toISO8601String();
+  // Store the value to property value map: property value can be only set from the map to m_algorithm
+  // as the last step before executing
+  QString propertyname = QString::fromStdString("StartTime");
+  QString propertyvalue = QString::fromStdString(starttime);
+  this->storePropertyValue(propertyname, propertyvalue);
 
+  // Call base class
   AlgorithmDialog::accept(); // accept executes the algorithm
 }
 


### PR DESCRIPTION
Replace #32407

**Description of work.**

In  **StartLiveDataDialog** , if a user sets the *Starting Time* to an arbitrary value, as soon as algorithm is execute, an error message is issued and execute quits as failure.  The error message is 

```
Error in execution of algorithm StartLiveData:  Error interpreting string '' as a date/time.
```

The reason is that all the property value set by `setProperty` before `accept()` is called will be replaced by the value recorded in `AlgorithmDialog::m_propertyValueMap` in method `AlgorithmDialog::accept()`, which is called to execute the algorithm.

The solution is to replace `setProperty` by `storePropertyValue`.

This is to resolve [ORNL ED #68](https://code.ornl.gov/sns-hfir-scse/diffraction/engineering-diffraction/engineering-diffraction/-/issues/68)

**To test:**

1. Check all tests are passed (no test is about the algorithm that has defect fixed)
2. Manual test
   - Launch Mantid workbench
   - Run `StartLiveData` from algorithm dialog.
   - Select `Starting Time` as 4 or 5 minutes ago.
   - Do arbitrary setup for the others. 
   - Execute
   - Without the fix, there will be an error message complaining about converting an empty string to DateAndTime
   - With the fix, the `StartTime` in `StartLiveData` algorithm will be set to a correct DateAndTime in ISO format.

<!-- Instructions for testing. -->

Fixes [ORNL ED #68](https://code.ornl.gov/sns-hfir-scse/diffraction/engineering-diffraction/engineering-diffraction/-/issues/68)

-----------------------

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
