### PR TITLE
Negative tof to d-space conversion error

### DIFF
--- a/Framework/Kernel/src/Unit.cpp
+++ b/Framework/Kernel/src/Unit.cpp
@@ -661,7 +661,7 @@ double dSpacing::singleToTOF(const double x) const {
 /**
  * DIFA * d^2 + DIFC * d + T0 - TOF = 0
  *
- * Use the citardauq formula to solve quadratic in order to minimise loss of precision. citarqauq (quadratic spelled
+ * Use the citardauq formula to solve quadratic in order to minimise loss of precision. citardauq (quadratic spelled
  * backwards) is an alternate formulation of the quadratic formula. DIFC and sqrt term are often similar and the
  * "classic" quadratic formula involves calculating their difference in the numerator
  *
@@ -688,8 +688,8 @@ double dSpacing::singleFromTOF(const double tof) const {
   // non-physical result
   if (tzero > tof) {
     if (difa > 0.) {
-      throw std::runtime_error("Cannot convert to imaginary d spacing because tzero > time-of-flight and difa is "
-                               "positive. Quadratic doesn't have a positive root");
+      throw std::runtime_error("Cannot convert to d spacing because tzero > time-of-flight and difa is positive. "
+                               "Quadratic doesn't have a positive root");
     } else if (difa == 0.) {
       throw std::runtime_error("Cannot convert to d spacing because tzero > time-of-flight");
     }

--- a/Framework/Kernel/test/UnitTest.h
+++ b/Framework/Kernel/test/UnitTest.h
@@ -577,13 +577,19 @@ public:
   }
 
   void testdSpacing_fromTOF() {
-    std::vector<double> x(1, 1001.1), y(1, 1.0);
-    std::vector<double> yy = y;
+    const std::vector<double> x_in{-1., 0., 1001.1, 16000.};
+    const std::vector<double> y_in{1., 2., 3., 4.};
+    std::vector<double> x(x_in.begin(), x_in.end());
+    std::vector<double> y(y_in.begin(), y_in.end());
     double difc =
         2.0 * Mantid::PhysicalConstants::NeutronMass * sin(0.5) * (1.0 + 1.0) * 1e-4 / Mantid::PhysicalConstants::h;
-    TS_ASSERT_THROWS_NOTHING(d.fromTOF(x, y, 1.0, 1, {{UnitParams::difc, difc}}))
-    TS_ASSERT_DELTA(x[0], 2.065172, 0.000001)
-    TS_ASSERT(yy == y)
+    TS_ASSERT_THROWS_NOTHING(d.fromTOF(x, y, 1.0, 1, {{UnitParams::difc, difc}}));
+
+    TS_ASSERT(y == y_in);
+    for (size_t i = 0; i < x.size(); ++i)
+      TS_ASSERT_DELTA(x[i], x_in[i] / difc, 0.000001);
+
+    // test for exception thrown
     x[0] = 1.0;
     TS_ASSERT_THROWS(d.fromTOF(x, y, 1.0, 1, {{UnitParams::difc, -1.0}}), const std::runtime_error &)
   }

--- a/Framework/Kernel/test/UnitTest.h
+++ b/Framework/Kernel/test/UnitTest.h
@@ -577,8 +577,8 @@ public:
   }
 
   void testdSpacing_fromTOF() {
-    const std::vector<double> x_in{-1., 0., 1001.1, 16000.};
-    const std::vector<double> y_in{1., 2., 3., 4.};
+    const std::vector<double> x_in{0., 1001.1, 16000.};
+    const std::vector<double> y_in{2., 3., 4.};
     std::vector<double> x(x_in.begin(), x_in.end());
     std::vector<double> y(y_in.begin(), y_in.end());
     double difc =
@@ -588,6 +588,10 @@ public:
     TS_ASSERT(y == y_in);
     for (size_t i = 0; i < x.size(); ++i)
       TS_ASSERT_DELTA(x[i], x_in[i] / difc, 0.000001);
+
+    // test for exception thrown for negative tof
+    x[0] = -1.0;
+    TS_ASSERT_THROWS(d.fromTOF(x, y, 1.0, 1, {{UnitParams::difc, difc}}), const std::runtime_error &);
 
     // test for exception thrown
     x[0] = 1.0;


### PR DESCRIPTION
Apparently some instruments still have a DAS/DAQ/DAE that sometimes creates a negative time-of-flight in the raw data file. This demonstrated that the quadratic equation was not correctly converting to d-spacing when `DIFA==0`. This PR adds an extra trap to simplify the calculation in this case. Also changes the order of special cases to move calculating intermediate results until as late as possible. In principle, this should execute the case of `DIFA==0` faster as zero is not squared then square rooted (when using instrument geometry).

This was originally discovered when looking at the results of
```python
from mantid.simpleapi import SNAPReduce

SNAPReduce(RunNumbers='52185', Masking='Horizontal', Binning='0.3,0.003,6',
    Normalization='Extracted from Data', PeakClippingWindowSize=12,
    SmoothingRange=5, SaveData=False)
```
The characteristic of it was that the raw data had a time-of-flight=-1 microseconds which exposed a bug in the time-of-flight to d-space conversion using instrument parameters (i.e. `DIFA=0` and `TZERO=0`). This case is captured in the new checks in the unit test. 

**To test:**

Ideally running the script above with mantid v6.1 and this PR and seeing that there is no longer a difference. In practice, the unit test was broken before change to `Unit.cpp` and is fixed now.

*There is no associated issue.*

*This does not require release notes* because it fixes a defect introduced during the release cycle.

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
