### PR TITLE
Set the SIP ABI in the new FindPyQt5

### DIFF
--- a/buildconfig/CMake/FindPyQt5.cmake
+++ b/buildconfig/CMake/FindPyQt5.cmake
@@ -160,13 +160,19 @@ find_path(PYQT5_SIP_DIR
   PATH_SUFFIXES ${_sip_suffixes}
 )
 
+# PyQt5 compiles against v12 of the sip ABI
+set(PYQT5_SIP_ABI_VERSION
+    12
+    CACHE STRING "The sip ABI used to compile PyQt5" FORCE
+)
+
 message("Found PyQt sip dir ${PYQT5_SIP_DIR}")
 if (NOT EXISTS "${PYQT5_SIP_DIR}/QtCore/QtCoremod.sip")
   message (FATAL_ERROR "Unable to find QtCore/QtCoremod.sip in ${PYQT5_SIP_DIR}. PyQt sip files are missing.")
 endif()
 
 include ( FindPackageHandleStandardArgs )
-find_package_handle_standard_args(PyQt5 PYQT5_VERSION PYQT5_VERSION_STR PYQT5_VERSION_TAG PYQT5_SIP_DIR PYQT5_SIP_FLAGS PYQT5_PYUIC)
+find_package_handle_standard_args(PyQt5 PYQT5_VERSION PYQT5_VERSION_STR PYQT5_VERSION_TAG PYQT5_SIP_DIR PYQT5_SIP_FLAGS PYQT5_PYUIC PYQT5_SIP_ABI_VERSION)
 
 mark_as_advanced ( PYQT5_VERSION
                    PYQT5_VERSION_STR
@@ -174,4 +180,5 @@ mark_as_advanced ( PYQT5_VERSION
                    PYQT5_SIP_DIR
                    PYQT5_SIP_FLAGS
                    PYQT5_PYUIC
+                   PYQT5_SIP_ABI_VERSION
                    )


### PR DESCRIPTION
**Description of work.**

The recent refactor of the PyQt finders accidentally removed setting the `PYQT5_SIP_ABI_VERSION` variable in cmake. This is required to build with v >= 5 of the sip build tool that exists homebrew.

Note that I have put this against release-next as it is unused in the current CI configuration but will allow those with the later tools installed to build the code.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**

* In a completely clean build directory, with the latest sip from Homebrew, run cmake and build the Qt code. CMake will configure but generating any Python bindings against Qt code will fail.

*There is no associated issue.*

*This does not require release notes* because **it is an internal fix.**

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
