### PR TITLE
Prevented crash from incorrect file load in Elwin

### DIFF
--- a/docs/source/release/v6.2.0/indirect_geometry.rst
+++ b/docs/source/release/v6.2.0/indirect_geometry.rst
@@ -25,6 +25,7 @@ Bugfixes
 - A bug has been fixed in :ref:`Inelastic Data Analysis <interface-inelastic-data-analysis>` on the :ref:`F(Q)Fit <fqfit>` tab, Multiple Input tab that allowed duplicate spectra to be added.
 - A bug has been fixed that stopped additional spectra being added to :ref:`Inelastic Data Analysis <interface-inelastic-data-analysis>` if spectra from that workspace had already been added.
 - A bug has been fixed in :ref:`Inelastic Data Analysis <interface-inelastic-data-analysis>` that limited the integration range on the tabs to between -1 and 1.
+- A bug has been fixed in :ref:`Elwin <Elwin-iqt-ref>` tab that caused Mantid to crash if a file of the wrong format was loaded.
 
 Algorithms
 ----------

--- a/qt/scientific_interfaces/Indirect/IndirectDataAnalysisElwinTab.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectDataAnalysisElwinTab.cpp
@@ -954,7 +954,7 @@ size_t IndirectDataAnalysisElwinTab::findWorkspaceID() {
 
 void IndirectDataAnalysisElwinTab::checkLoadedFiles() {
   UserInputValidator uiv;
-  auto noOfFiles = m_uiForm.dsInputFiles->getFilenames().size();
+  size_t noOfFiles = m_uiForm.dsInputFiles->getFilenames().size();
   auto const suffixes = getFilteredSuffixes(m_uiForm.dsInputFiles->getFilenames());
   if (suffixes.size() != noOfFiles) {
     uiv.addErrorMessage("The input files must be all _red or all _sqw.");

--- a/qt/scientific_interfaces/Indirect/IndirectDataAnalysisElwinTab.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectDataAnalysisElwinTab.cpp
@@ -235,9 +235,7 @@ void IndirectDataAnalysisElwinTab::setup() {
   connect(m_blnManager, SIGNAL(valueChanged(QtProperty *, bool)), this, SLOT(twoRanges(QtProperty *, bool)));
   twoRanges(m_properties["BackgroundSubtraction"], false);
 
-  connect(m_uiForm.dsInputFiles, SIGNAL(filesFound()), this, SLOT(newInputFiles()));
-  connect(m_uiForm.dsInputFiles, SIGNAL(filesFound()), this, SLOT(plotInput()));
-  connect(m_uiForm.dsInputFiles, SIGNAL(filesFound()), this, SLOT(updateIntegrationRange()));
+  connect(m_uiForm.dsInputFiles, SIGNAL(filesFound()), this, SLOT(checkLoadedFiles()));
   connect(m_uiForm.cbPreviewFile, SIGNAL(currentIndexChanged(int)), this, SLOT(checkNewPreviewSelected(int)));
   connect(m_uiForm.spPlotSpectrum, SIGNAL(valueChanged(int)), this, SLOT(setSelectedSpectrum(int)));
   connect(m_uiForm.spPlotSpectrum, SIGNAL(valueChanged(int)), this, SLOT(handlePreviewSpectrumChanged()));
@@ -797,12 +795,27 @@ void IndirectDataAnalysisElwinTab::addData() { addData(m_addWorkspaceDialog.get(
 
 void IndirectDataAnalysisElwinTab::addData(IAddWorkspaceDialog const *dialog) {
   try {
-    addDataToModel(dialog);
-    updateTableFromModel();
-    emit dataAdded();
-    emit dataChanged();
-    newInputFilesFromDialog(dialog);
-    plotInput();
+    UserInputValidator uiv;
+    const auto indirectDialog = dynamic_cast<IndirectAddWorkspaceDialog const *>(dialog);
+    QList<QString> allFiles;
+    allFiles.append(QString::fromStdString(indirectDialog->getFileName()));
+    auto const suffixes = getFilteredSuffixes(allFiles);
+    if (suffixes.size() < 1) {
+      uiv.addErrorMessage("The input files must be all _red or all _sqw.");
+      m_uiForm.dsInputFiles->clear();
+      closeDialog();
+    }
+    QString error = uiv.generateErrorMessage();
+    showMessageBox(error);
+
+    if (error.isEmpty()) {
+      addDataToModel(dialog);
+      updateTableFromModel();
+      emit dataAdded();
+      emit dataChanged();
+      newInputFilesFromDialog(dialog);
+      plotInput();
+    }
   } catch (const std::runtime_error &ex) {
     displayWarning(ex.what());
   }
@@ -937,6 +950,24 @@ size_t IndirectDataAnalysisElwinTab::findWorkspaceID() {
   auto findWorkspace = find(allWorkspaces.begin(), allWorkspaces.end(), currentWorkspace);
   size_t workspaceID = findWorkspace - allWorkspaces.begin();
   return workspaceID;
+}
+
+void IndirectDataAnalysisElwinTab::checkLoadedFiles() {
+  UserInputValidator uiv;
+  auto noOfFiles = m_uiForm.dsInputFiles->getFilenames().size();
+  auto const suffixes = getFilteredSuffixes(m_uiForm.dsInputFiles->getFilenames());
+  if (suffixes.size() != noOfFiles) {
+    uiv.addErrorMessage("The input files must be all _red or all _sqw.");
+    m_uiForm.dsInputFiles->clear();
+  }
+  QString error = uiv.generateErrorMessage();
+  showMessageBox(error);
+
+  if (error.isEmpty()) {
+    newInputFiles();
+    plotInput();
+    updateIntegrationRange();
+  }
 }
 
 } // namespace IDA

--- a/qt/scientific_interfaces/Indirect/IndirectDataAnalysisElwinTab.h
+++ b/qt/scientific_interfaces/Indirect/IndirectDataAnalysisElwinTab.h
@@ -98,11 +98,11 @@ private:
   void newPreviewFileSelected(const QString workspaceName, const QString filename);
   void newPreviewWorkspaceSelected(const QString workspaceName);
   size_t findWorkspaceID();
-
-private slots:
   void newInputFiles();
   void checkNewPreviewSelected(int index);
   void plotInput();
+
+private slots:
   void handlePreviewSpectrumChanged();
   void twoRanges(QtProperty *prop, bool enabled);
   void minChanged(double val);
@@ -113,6 +113,7 @@ private slots:
   void saveClicked();
   void updateIntegrationRange();
   void addData();
+  void checkLoadedFiles();
 
   /// Slot called when the current view is changed
   void handleViewChanged(int index);


### PR DESCRIPTION
**Description of work.**
The Elwin file load and the file loading in the add workspace dialog now check whether the file being loaded is of the correct type. If not loading is stopped and the user receives an error message. Mantid does not crash and the user can continue to use the Elwin interface.

**To test:**
Test file load
1. Open ```Indirect->Data Analysis``` GUI
2. Click Browse button
3. Find a file that does not have a ```_red``` or ```_sqw``` ending - for example ```EMU00020884.nxs``` from the Training Course data
4. You should receive a pop up explaining that the file is incorrect and why. Close the dialog box and the Input File box should be empty.

Test Add Workspace Dialog
1. Open ```Indirect->Data Analysis``` GUI
2. From the drop down menu choose Workspace
3. Click Add Workspace
4. Click Browse button
5. Find a file that does not have a ```_red``` or ```_sqw``` ending - for example ```EMU00020884.nxs``` from the Training Course data
6. Tick All Spectra and click Add.
7. You should receive a pop up explaining that the file is incorrect and why. The Add Workspace Dialog box closes.


Fixes #32416

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
