### PR TITLE
Allow minimum TOF to be equal to zero

### DIFF
--- a/Framework/WorkflowAlgorithms/src/AlignAndFocusPowder.cpp
+++ b/Framework/WorkflowAlgorithms/src/AlignAndFocusPowder.cpp
@@ -502,7 +502,8 @@ void AlignAndFocusPowder::exec() {
   }
   m_progress->report();
 
-  if (xmin > 0. || xmax > 0.) {
+  // crop the workspace in time-of-flight
+  if (xmin >= 0. || xmax > 0.) {
     double tempmin;
     double tempmax;
     m_outputW->getXMinMax(tempmin, tempmax);
@@ -512,7 +513,7 @@ void AlignAndFocusPowder::exec() {
     API::IAlgorithm_sptr cropAlg = createChildAlgorithm("CropWorkspace");
     cropAlg->setProperty("InputWorkspace", m_outputW);
     cropAlg->setProperty("OutputWorkspace", m_outputW);
-    if ((xmin > 0.) && (xmin > tempmin))
+    if ((xmin >= 0.) && (xmin > tempmin))
       cropAlg->setProperty("Xmin", xmin);
     if ((xmax > 0.) && (xmax < tempmax))
       cropAlg->setProperty("Xmax", xmax);

--- a/docs/source/release/v6.2.0/diffraction.rst
+++ b/docs/source/release/v6.2.0/diffraction.rst
@@ -52,6 +52,7 @@ Bugfixes
 - Fixed the issue with :ref:`SNSPowderReduction <algm-SNSPowderReduction>` - when an invalid height unit is encountered while reading sample log the geometry is ignored and it relies purely on user input.
 - Fixed a bug when converting TOF to d-spacing using diffractometer constants with non-zero DIFA when a parabolic model is selected.
 - Corrected the equation for pseudo-voigt FWHM and mixing parameter in peak profile function :ref:`Bk2BkExpConvPV <func-Bk2BkExpConvPV>`.
+- Fixed a bug when filtering events in :ref:`AlignAndFocusPowder <algm-AlignAndFocusPowder-v1>` based on time-of-flight. The code now allows setting the minimum time-of-flight to zero (inclusive).
 
 Engineering Diffraction
 -----------------------


### PR DESCRIPTION
This will get rid of negative time-of-flight values in the cases when the DAS writes them to the raw data file. `SNAPReduce` was requesting to filter events between 0->50000 microseconds. This allows for that specification to actually have an effect in practice.

This PR prevents non-physical time-of-flight from getting into `ConvertUnits` which required the fix in #32479.

**To test:**

```python
from mantid.simpleapi import SNAPReduce

SNAPReduce(RunNumbers='52185', Masking='Horizontal', Binning='0.3,0.003,6',
    Normalization='Extracted from Data', PeakClippingWindowSize=12,
    SmoothingRange=5, SaveData=False)

```

*There is no associated issue.*

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
