### PR TITLE
Disable peak picker in ALC PeakFitting

### DIFF
--- a/docs/source/release/v6.2.0/muon.rst
+++ b/docs/source/release/v6.2.0/muon.rst
@@ -31,6 +31,7 @@ Bugfixes
 
 - In frequency domain analysis the phasetables calculated from :ref:`MuonMaxent <algm-MuonMaxent>` can be used for
   :ref:`PhaseQuad <algm-PhaseQuad>` calculations on the phase tab.
+- A bug has been fixed in ALC that caused mantid to crash when a user changed the PeakPicker in the PeakFitting plot.
 
 Muon Analysis
 -------------

--- a/qt/scientific_interfaces/Muon/ALCPeakFittingView.cpp
+++ b/qt/scientific_interfaces/Muon/ALCPeakFittingView.cpp
@@ -37,13 +37,14 @@ void ALCPeakFittingView::initialize() {
   m_ui.plot->setLinesWithErrors(plotsWithErrors);
 
   // XXX: Being a QwtPlotItem, should get deleted when m_ui.plot gets deleted
+  // TODO: the peak picker is broken, these are being dissabled for release and will be fixed in maintinance.
   // (auto-delete option)
-  m_peakPicker = new MantidWidgets::PeakPicker(m_ui.plot, Qt::red);
+  // m_peakPicker = new MantidWidgets::PeakPicker(m_ui.plot, Qt::red);
 
-  connect(m_peakPicker, SIGNAL(changed()), SIGNAL(peakPickerChanged()));
+  // connect(m_peakPicker, SIGNAL(changed()), SIGNAL(peakPickerChanged()));
 
-  connect(m_ui.peaks, SIGNAL(currentFunctionChanged()), SIGNAL(currentFunctionChanged()));
-  connect(m_ui.peaks, SIGNAL(parameterChanged(QString, QString)), SIGNAL(parameterChanged(QString, QString)));
+  // connect(m_ui.peaks, SIGNAL(functionStructureChanged()), SIGNAL(currentFunctionChanged()));
+  // connect(m_ui.peaks, SIGNAL(parameterChanged(QString, QString)), SIGNAL(parameterChanged(QString, QString)));
 
   connect(m_ui.help, SIGNAL(clicked()), this, SLOT(help()));
   connect(m_ui.plotGuess, SIGNAL(clicked()), this, SLOT(plotGuess()));


### PR DESCRIPTION
**Description of work.**

This PR disables the peak fitter and it's signals in ALC, this its to stop a crash that would have been an issue for the release. this will be fixed and re enabled during maintenance.

**To test:**

1. Follow the steps in the associated issue.
2. On the PeakFitting interface there should not be a PeakPicker on the plot, and clicking on the lpot will not create one.

Fixes #32441

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
