### PR TITLE
Use const& over plain & in Python export wrappers

### DIFF
--- a/Framework/Geometry/inc/MantidGeometry/Crystal/ReflectionGenerator.h
+++ b/Framework/Geometry/inc/MantidGeometry/Crystal/ReflectionGenerator.h
@@ -93,7 +93,7 @@ public:
   const CrystalStructure &getCrystalStructure() const;
 
   HKLFilter_const_sptr getDRangeFilter(double dMin, double dMax) const;
-  HKLFilter_const_sptr getReflectionConditionFilter(ReflectionConditionFilter filter);
+  HKLFilter_const_sptr getReflectionConditionFilter(ReflectionConditionFilter filter) const;
 
   std::vector<Kernel::V3D> getHKLs(double dMin, double dMax) const;
   std::vector<Kernel::V3D> getHKLs(double dMin, double dMax,

--- a/Framework/Geometry/src/Crystal/ReflectionGenerator.cpp
+++ b/Framework/Geometry/src/Crystal/ReflectionGenerator.cpp
@@ -42,7 +42,7 @@ HKLFilter_const_sptr ReflectionGenerator::getDRangeFilter(double dMin, double dM
 }
 
 /// Returns a reflection condition HKLFilter based on the supplied enum.
-HKLFilter_const_sptr ReflectionGenerator::getReflectionConditionFilter(ReflectionConditionFilter filter) {
+HKLFilter_const_sptr ReflectionGenerator::getReflectionConditionFilter(ReflectionConditionFilter filter) const {
   switch (filter) {
   case ReflectionConditionFilter::Centering:
     return std::make_shared<const HKLFilterCentering>(m_crystalStructure.centering());

--- a/Framework/PythonInterface/core/inc/MantidPythonInterface/core/DataServiceExporter.h
+++ b/Framework/PythonInterface/core/inc/MantidPythonInterface/core/DataServiceExporter.h
@@ -151,10 +151,10 @@ template <typename SvcType, typename SvcPtrType> struct DataServiceExporter {
    * contain this string
    * @returns A python list created from the set of strings
    */
-  static boost::python::list getObjectNamesAsList(SvcType &self, const std::string &contain) {
+  static boost::python::list getObjectNamesAsList(SvcType const *const self, const std::string &contain) {
     boost::python::list names;
-    const auto keys = self.getObjectNames(Mantid::Kernel::DataServiceSort::Unsorted,
-                                          Mantid::Kernel::DataServiceHidden::Auto, contain);
+    const auto keys = self->getObjectNames(Mantid::Kernel::DataServiceSort::Unsorted,
+                                           Mantid::Kernel::DataServiceHidden::Auto, contain);
     for (auto itr = keys.begin(); itr != keys.end(); ++itr) {
       names.append(*itr);
     }

--- a/Framework/PythonInterface/mantid/api/inc/MantidPythonInterface/api/CloneMatrixWorkspace.h
+++ b/Framework/PythonInterface/mantid/api/inc/MantidPythonInterface/api/CloneMatrixWorkspace.h
@@ -19,13 +19,13 @@ namespace PythonInterface {
 //** @name Numpy clones of data*/
 ///{
 /// Create a numpy array from the X values of the given workspace reference
-PyObject *cloneX(API::MatrixWorkspace &self);
+PyObject *cloneX(const API::MatrixWorkspace &self);
 /// Create a numpy array from the Y values of the given workspace reference
-PyObject *cloneY(API::MatrixWorkspace &self);
+PyObject *cloneY(const API::MatrixWorkspace &self);
 /// Create a numpy array from the E values of the given workspace reference
-PyObject *cloneE(API::MatrixWorkspace &self);
+PyObject *cloneE(const API::MatrixWorkspace &self);
 /// Create a numpy array from the E values of the given workspace reference
-PyObject *cloneDx(API::MatrixWorkspace &self);
+PyObject *cloneDx(const API::MatrixWorkspace &self);
 ///@}
 } // namespace PythonInterface
 } // namespace Mantid

--- a/Framework/PythonInterface/mantid/api/inc/MantidPythonInterface/api/FitFunctions/IFunctionAdapter.h
+++ b/Framework/PythonInterface/mantid/api/inc/MantidPythonInterface/api/FitFunctions/IFunctionAdapter.h
@@ -41,15 +41,15 @@ public:
   /// Declare an attribute with an initial value
   void declareAttribute(const std::string &name, const boost::python::object &defaultValue);
   /// Get a named attribute value
-  static PyObject *getAttributeValue(IFunction &self, const std::string &name);
+  static PyObject *getAttributeValue(const IFunction &self, const std::string &name);
   /// Returns the attribute's value as a Python object
-  static PyObject *getAttributeValue(IFunction &self, const API::IFunction::Attribute &attr);
+  static PyObject *getAttributeValue(const IFunction &self, const API::IFunction::Attribute &attr);
   /// Set the attribute's value
   static void setAttributePythonValue(IFunction &self, const std::string &name, const boost::python::object &value);
   /// Called by the framework when an attribute has been set
   void setAttribute(const std::string &attName, const API::IFunction::Attribute &attr) override;
   /// Split this function (if needed) into a list of independent functions
-  static boost::python::list createPythonEquivalentFunctions(IFunction &self);
+  static boost::python::list createPythonEquivalentFunctions(const IFunction &self);
 
   // Each overload of declareParameter requires a different name as we
   // can't use a function pointer with a virtual base class

--- a/Framework/PythonInterface/mantid/api/src/CloneMatrixWorkspace.cpp
+++ b/Framework/PythonInterface/mantid/api/src/CloneMatrixWorkspace.cpp
@@ -37,7 +37,7 @@ enum DataField { XValues = 0, YValues = 1, EValues = 2, DxValues = 3 };
  *reading the data (similar to .end() for STL)
  *
  */
-PyArrayObject *cloneArray(MatrixWorkspace &workspace, DataField field, const size_t start, const size_t endp1) {
+PyArrayObject *cloneArray(const MatrixWorkspace &workspace, DataField field, const size_t start, const size_t endp1) {
   const npy_intp numHist(endp1 - start);
   npy_intp stride{0};
 
@@ -85,7 +85,7 @@ PyArrayObject *cloneArray(MatrixWorkspace &workspace, DataField field, const siz
  * @param self :: A pointer to a PyObject representing the calling object
  * @return A 2D numpy array created from the X values
  */
-PyObject *cloneX(MatrixWorkspace &self) {
+PyObject *cloneX(const MatrixWorkspace &self) {
   return reinterpret_cast<PyObject *>(cloneArray(self, XValues, 0, self.getNumberHistograms()));
 }
 /* Create a numpy array from the Y values of the given workspace reference
@@ -93,7 +93,7 @@ PyObject *cloneX(MatrixWorkspace &self) {
  * @param self :: A pointer to a PyObject representing the calling object
  * @return A 2D numpy array created from the Y values
  */
-PyObject *cloneY(MatrixWorkspace &self) {
+PyObject *cloneY(const MatrixWorkspace &self) {
   return reinterpret_cast<PyObject *>(cloneArray(self, YValues, 0, self.getNumberHistograms()));
 }
 
@@ -102,7 +102,7 @@ PyObject *cloneY(MatrixWorkspace &self) {
  * @param self :: A pointer to a PyObject representing the calling object
  * @return A 2D numpy array created from the E values
  */
-PyObject *cloneE(MatrixWorkspace &self) {
+PyObject *cloneE(const MatrixWorkspace &self) {
   return reinterpret_cast<PyObject *>(cloneArray(self, EValues, 0, self.getNumberHistograms()));
 }
 
@@ -111,7 +111,7 @@ PyObject *cloneE(MatrixWorkspace &self) {
  * @param self :: A pointer to a PyObject representing the calling object
  * @return A 2D numpy array created from the E values
  */
-PyObject *cloneDx(MatrixWorkspace &self) {
+PyObject *cloneDx(const MatrixWorkspace &self) {
   return reinterpret_cast<PyObject *>(cloneArray(self, DxValues, 0, self.getNumberHistograms()));
 }
 } // namespace Mantid::PythonInterface

--- a/Framework/PythonInterface/mantid/api/src/Exports/AlgorithmFactory.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/AlgorithmFactory.cpp
@@ -44,12 +44,11 @@ namespace {
  * AlgorithmFactory class
  * @param includeHidden :: If true hidden algorithms are included
  */
-dict getRegisteredAlgorithms(AlgorithmFactoryImpl &self, bool includeHidden) {
-  std::vector<std::string> keys = self.getKeys(includeHidden);
-  const size_t nkeys = keys.size();
+dict getRegisteredAlgorithms(AlgorithmFactoryImpl const *const self, bool includeHidden) {
+  const auto keys = self->getKeys(includeHidden);
   dict inventory;
-  for (size_t i = 0; i < nkeys; ++i) {
-    auto algInfo = self.decodeName(keys[i]);
+  for (const auto &key : keys) {
+    auto algInfo = self->decodeName(key);
     object name(handle<>(to_python_value<const std::string &>()(algInfo.first)));
     object ver(handle<>(to_python_value<const int &>()(algInfo.second)));
     // There seems to be no way to "promote" the return of .get to a list
@@ -71,12 +70,11 @@ dict getRegisteredAlgorithms(AlgorithmFactoryImpl &self, bool includeHidden) {
  * @param self :: An instance of AlgorithmFactory.
  * @param includeHidden :: If true hidden algorithms are included.
  */
-list getDescriptors(AlgorithmFactoryImpl &self, bool includeHidden = false, bool includeAlias = false) {
-  auto descriptors = self.getDescriptors(includeHidden, includeAlias);
+list getDescriptors(AlgorithmFactoryImpl const *const self, bool includeHidden = false, bool includeAlias = false) {
+  const auto descriptors = self->getDescriptors(includeHidden, includeAlias);
   list pyDescriptors;
-  for (auto &descr : descriptors) {
-    boost::python::object d(descr);
-    pyDescriptors.append(d);
+  for (const auto &descr : descriptors) {
+    pyDescriptors.append(boost::python::object(descr));
   }
   return pyDescriptors;
 }
@@ -90,8 +88,8 @@ list getDescriptors(AlgorithmFactoryImpl &self, bool includeHidden = false, bool
  * @returns The map of the categories, together with a true false value
  * defining if they are hidden
  */
-dict getCategoriesandState(AlgorithmFactoryImpl &self) {
-  std::map<std::string, bool> categories = self.getCategoriesWithState();
+dict getCategoriesandState(AlgorithmFactoryImpl const *const self) {
+  const auto categories = self->getCategoriesWithState();
   dict pythonCategories;
   for (auto &it : categories) {
     object categoryName(handle<>(to_python_value<const std::string &>()(it.first)));

--- a/Framework/PythonInterface/mantid/api/src/Exports/AlgorithmHistory.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/AlgorithmHistory.cpp
@@ -41,7 +41,7 @@ boost::python::list getChildrenAsList(const std::shared_ptr<AlgorithmHistory> &s
  * @param self :: A reference to the AlgorithmHistory that called this method
  * @returns A python list created from the set of property histories
  */
-boost::python::list getPropertiesAsList(AlgorithmHistory &self) {
+boost::python::list getPropertiesAsList(const AlgorithmHistory &self) {
   boost::python::list names;
   const auto &histories = self.getProperties();
   for (const auto &history : histories) {

--- a/Framework/PythonInterface/mantid/api/src/Exports/AlgorithmManager.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/AlgorithmManager.cpp
@@ -45,8 +45,8 @@ AlgorithmManagerImpl &instance() {
  * @param self The calling object
  * @param id An algorithm ID
  */
-IAlgorithm_sptr getAlgorithm(AlgorithmManagerImpl &self, AlgorithmIDProxy idHolder) {
-  return self.getAlgorithm(idHolder.id);
+IAlgorithm_sptr getAlgorithm(AlgorithmManagerImpl const *const self, AlgorithmIDProxy idHolder) {
+  return self->getAlgorithm(idHolder.id);
 }
 
 /**
@@ -63,14 +63,11 @@ void removeById(AlgorithmManagerImpl &self, AlgorithmIDProxy idHolder) { return 
  * @param algName The name of the algorithm
  * @return A python list of managed algorithms that are currently running
  */
-boost::python::list runningInstancesOf(AlgorithmManagerImpl &self, const std::string &algName) {
+boost::python::list runningInstancesOf(AlgorithmManagerImpl const *const self, const std::string &algName) {
   boost::python::list algs;
-  auto mgrAlgs = self.runningInstancesOf(algName);
+  auto mgrAlgs = self->runningInstancesOf(algName);
   for (auto &mgrAlg : mgrAlgs) {
-    // boost 1.41 (RHEL6) can't handle registering IAlgorithm_const_sptr so we
-    // have to cast to IAlgorithm_sptr and then convert to Python
-    // The constness is pretty-irrelevant by this point anyway
-    algs.append(std::const_pointer_cast<IAlgorithm>(mgrAlg));
+    algs.append(mgrAlg);
   }
 
   return algs;

--- a/Framework/PythonInterface/mantid/api/src/Exports/AnalysisDataService.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/AnalysisDataService.cpp
@@ -49,9 +49,9 @@ AnalysisDataServiceImpl &instance() {
  * @param unrollGroups If true unroll the workspace groups
  * @return a python list of the workspaces in the ADS
  */
-list retrieveWorkspaces(AnalysisDataServiceImpl &self, const list &names, bool unrollGroups = false) {
+list retrieveWorkspaces(AnalysisDataServiceImpl const *const self, const list &names, bool unrollGroups = false) {
   return Converters::ToPyList<Workspace_sptr>()(
-      self.retrieveWorkspaces(Converters::PySequenceToVector<std::string>(names)(), unrollGroups));
+      self->retrieveWorkspaces(Converters::PySequenceToVector<std::string>(names)(), unrollGroups));
 }
 
 GNU_DIAG_OFF("unused-local-typedef")

--- a/Framework/PythonInterface/mantid/api/src/Exports/AnalysisDataServiceObserver.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/AnalysisDataServiceObserver.cpp
@@ -34,6 +34,7 @@ namespace {
  * @param on bool; whether to turn on or off the observer for the specific method
  * @param method ObserverMethod; the method to call with the on parameter.
  */
+// cppcheck-suppress constParameterCallback
 void callReleasingGIL(AnalysisDataServiceObserver &self, bool on, ObserverMethod method) {
   ReleaseGlobalInterpreterLock releaseGil;
   (self.*method)(on);

--- a/Framework/PythonInterface/mantid/api/src/Exports/Citation.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/Citation.cpp
@@ -8,29 +8,29 @@
 #include "MantidKernel/WarningSuppressions.h"
 
 #include <boost/python/class.hpp>
+#include <boost/python/copy_const_reference.hpp>
 #include <boost/python/operators.hpp>
 #include <boost/python/overloads.hpp>
 
 using namespace Mantid::API;
 using namespace boost::python;
 
-std::string description(Citation &self) { return self.description(); }
-std::string url(Citation &self) { return self.url(); }
-std::string doi(Citation &self) { return self.doi(); }
-std::string bibtex(Citation &self) { return self.bibtex(); }
-std::string endnote(Citation &self) { return self.endnote(); }
-
 void export_Citation() {
+  using return_copy = return_value_policy<copy_const_reference>;
+
   class_<Citation, boost::noncopyable>("Citation",
                                        init<optional<const std::string &, const std::string &, const std::string &,
                                                      const std::string &, const std::string &>>())
       .def(init<NeXus::File *, const std::string &>())
-      .def("description", &description, arg("self"), "Returns the description on the citation object")
-      .def("url", &url, arg("self"), "Returns the url on the citation object")
-      .def("doi", &doi, arg("self"), "Returns the doi on the citation object")
-      .def("bibtex", &bibtex, arg("self"), "Returns the bibtex formatted citation from the citation object")
-      .def("endnote", &endnote, arg("self"), "Returns the endnote formatted citation from the citation object")
-      .def("saveNexus", &Citation::saveNexus, (arg("self"), arg("file"), arg("group")),
+      .def("description", &Citation::description, arg("self"), return_copy(),
+           "Returns the description on the citation object")
+      .def("url", &Citation::url, arg("self"), return_copy(), "Returns the url on the citation object")
+      .def("doi", &Citation::doi, arg("self"), return_copy(), "Returns the doi on the citation object")
+      .def("bibtex", &Citation::bibtex, arg("self"), return_copy(),
+           "Returns the bibtex formatted citation from the citation object")
+      .def("endnote", &Citation::endnote, arg("self"), return_copy(),
+           "Returns the endnote formatted citation from the citation object")
+      .def("saveNexus", &Citation::saveNexus, (arg("self"), arg("file"), arg("group")), return_copy(),
            "Save data from this object to a NeXus file")
       .def("__eq__", &Citation::operator==);
 }

--- a/Framework/PythonInterface/mantid/api/src/Exports/FileFinder.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/FileFinder.cpp
@@ -38,7 +38,7 @@ GNU_DIAG_ON("unused-local-typedef")
  * @param useExtsOnly :: bool. If true, use exts_list only. If false, use
  * combination of exts_list and facility_exts.
  */
-std::vector<std::string> runFinderProxy(FileFinderImpl &self, const std::string &hintstr, list exts_list,
+std::vector<std::string> runFinderProxy(const FileFinderImpl &self, const std::string &hintstr, list exts_list,
                                         const bool useExtsOnly) {
   // Convert python list to c++ vector
   std::vector<std::string> exts;

--- a/Framework/PythonInterface/mantid/api/src/Exports/FunctionFactory.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/FunctionFactory.cpp
@@ -79,8 +79,8 @@ namespace {
  * @param self :: Enables it to be called as a member function on the
  * FunctionFactory class
  */
-PyObject *getFunctionNames(FunctionFactoryImpl &self) {
-  const std::vector<std::string> &names = self.getFunctionNames<Mantid::API::IFunction>();
+PyObject *getFunctionNames(FunctionFactoryImpl const *const self) {
+  const auto &names = self->getFunctionNames<Mantid::API::IFunction>();
 
   PyObject *registered = PyList_New(0);
   for (const auto &name : names) {
@@ -98,12 +98,12 @@ PyObject *getFunctionNames(FunctionFactoryImpl &self) {
  * @param self :: Enables it to be called as a member function on the
  * FunctionFactory class
  */
-PyObject *getBackgroundFunctionNames(FunctionFactoryImpl &self) {
-  const std::vector<std::string> &names = self.getFunctionNames<Mantid::API::IFunction>();
+PyObject *getBackgroundFunctionNames(FunctionFactoryImpl const *const self) {
+  const auto &names = self->getFunctionNames<Mantid::API::IFunction>();
 
   PyObject *registered = PyList_New(0);
   for (const auto &name : names) {
-    auto fun = self.createFunction(name);
+    auto fun = self->createFunction(name);
     if (dynamic_cast<IBackgroundFunction *>(fun.get())) {
       PyObject *bkg_function = to_python_value<const std::string &>()(name);
       if (PyList_Append(registered, bkg_function))
@@ -120,12 +120,12 @@ PyObject *getBackgroundFunctionNames(FunctionFactoryImpl &self) {
  * @param self :: Enables it to be called as a member function on the
  * FunctionFactory class
  */
-PyObject *getPeakFunctionNames(FunctionFactoryImpl &self) {
-  const std::vector<std::string> &names = self.getFunctionNames<Mantid::API::IFunction>();
+PyObject *getPeakFunctionNames(FunctionFactoryImpl const *const self) {
+  const auto &names = self->getFunctionNames<Mantid::API::IFunction>();
 
   PyObject *registered = PyList_New(0);
   for (const auto &name : names) {
-    auto fun = self.createFunction(name);
+    auto fun = self->createFunction(name);
     if (dynamic_cast<IPeakFunction *>(fun.get())) {
       PyObject *peak_function = to_python_value<const std::string &>()(name);
       if (PyList_Append(registered, peak_function))
@@ -143,9 +143,8 @@ PyObject *getPeakFunctionNames(FunctionFactoryImpl &self) {
  * FunctionFactory class
  * @param name :: Peak function name
  */
-Mantid::API::IPeakFunction_sptr createPeakFunction(FunctionFactoryImpl &self, const std::string &name) {
-
-  auto fun = self.createFunction(name);
+Mantid::API::IPeakFunction_sptr createPeakFunction(FunctionFactoryImpl const *const self, const std::string &name) {
+  auto fun = self->createFunction(name);
   auto peakFun = std::dynamic_pointer_cast<Mantid::API::IPeakFunction>(fun);
   if (!peakFun) {
     throw std::invalid_argument(name + " is not a PeakFunction");
@@ -163,8 +162,9 @@ Mantid::API::IPeakFunction_sptr createPeakFunction(FunctionFactoryImpl &self, co
  * @param name :: Name of the superclass of composite function,
  * e.g. "ProductFunction".
  */
-Mantid::API::CompositeFunction_sptr createCompositeFunction(FunctionFactoryImpl &self, const std::string &name) {
-  auto fun = self.createFunction(name);
+Mantid::API::CompositeFunction_sptr createCompositeFunction(FunctionFactoryImpl const *const self,
+                                                            const std::string &name) {
+  auto fun = self->createFunction(name);
   auto composite = std::dynamic_pointer_cast<Mantid::API::CompositeFunction>(fun);
   if (composite) {
     return composite;

--- a/Framework/PythonInterface/mantid/api/src/Exports/IAlgorithm.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/IAlgorithm.cpp
@@ -128,7 +128,7 @@ PropertyVector apiOrderedProperties(const IAlgorithm &propMgr) {
  * @return A Python list of strings
  */
 
-list getInputPropertiesWithMandatoryFirst(IAlgorithm &self) {
+list getInputPropertiesWithMandatoryFirst(const IAlgorithm &self) {
   PropertyVector properties(apiOrderedProperties(self));
 
   GlobalInterpreterLock gil;
@@ -149,7 +149,7 @@ list getInputPropertiesWithMandatoryFirst(IAlgorithm &self) {
  * @param self :: A pointer to the python object wrapping and Algorithm.
  * @return A Python list of strings
  */
-list getAlgorithmPropertiesOrdered(IAlgorithm &self) {
+list getAlgorithmPropertiesOrdered(const IAlgorithm &self) {
   PropertyVector properties(apiOrderedProperties(self));
 
   GlobalInterpreterLock gil;
@@ -166,7 +166,7 @@ list getAlgorithmPropertiesOrdered(IAlgorithm &self) {
  * @param self :: A pointer to the python object wrapping and Algorithm.
  * @return A Python list of strings
  */
-list getOutputProperties(IAlgorithm &self) {
+list getOutputProperties(const IAlgorithm &self) {
   const PropertyVector &properties(self.getProperties()); // No copy
 
   GlobalInterpreterLock gil;
@@ -185,7 +185,7 @@ list getOutputProperties(IAlgorithm &self) {
  * @param self :: A pointer to the python object wrapping and Algorithm.
  * @return A Python list of strings
  */
-list getInOutProperties(IAlgorithm &self) {
+list getInOutProperties(const IAlgorithm &self) {
   const PropertyVector &properties(self.getProperties()); // No copy
 
   GlobalInterpreterLock gil;
@@ -204,7 +204,7 @@ list getInOutProperties(IAlgorithm &self) {
  * @param self :: A pointer to the python object wrapping and Algorithm
  * @return A string that documents an algorithm
  */
-std::string createDocString(IAlgorithm &self) {
+std::string createDocString(const IAlgorithm &self) {
   const std::string EOL = "\n";
 
   // Put in the quick overview message
@@ -301,7 +301,7 @@ bool executeProxy(object &self) {
  * Execute the algorithm asynchronously
  * @param self :: A reference to the calling object
  */
-void executeAsync(object &self) {
+void executeAsync(const object &self) {
   auto &calg = extract<IAlgorithm &>(self)();
   calg.executeAsync();
 }
@@ -311,7 +311,7 @@ void executeAsync(object &self) {
  * @return An AlgorithmID wrapped in a AlgorithmIDProxy container or None if
  * there is no ID
  */
-PyObject *getAlgorithmID(IAlgorithm &self) {
+PyObject *getAlgorithmID(const IAlgorithm &self) {
   AlgorithmID id = self.getAlgorithmID();
   if (id)
     return to_python_value<AlgorithmIDProxy>()(AlgorithmIDProxy(id));
@@ -326,7 +326,7 @@ PyObject *getAlgorithmID(IAlgorithm &self) {
  * @param self Reference to the calling object
  * @return Algorithm summary
  */
-std::string getOptionalMessage(IAlgorithm &self) {
+std::string getOptionalMessage(const IAlgorithm &self) {
   PyErr_Warn(PyExc_DeprecationWarning, ".getOptionalMessage() is deprecated. Use .summary() instead.");
   return self.summary();
 }
@@ -335,7 +335,7 @@ std::string getOptionalMessage(IAlgorithm &self) {
  * @param self Reference to the calling object
  * @return Algorithm summary
  */
-std::string getWikiSummary(IAlgorithm &self) {
+std::string getWikiSummary(const IAlgorithm &self) {
   PyErr_Warn(PyExc_DeprecationWarning, ".getWikiSummary() is deprecated. Use .summary() instead.");
   return self.summary();
 }
@@ -361,6 +361,7 @@ void export_ialgorithm() {
   class_<AlgorithmIDProxy>("AlgorithmID", no_init).def(self == self);
 
   register_ptr_to_python<std::shared_ptr<IAlgorithm>>();
+  register_ptr_to_python<std::shared_ptr<const IAlgorithm>>();
 
   class_<IAlgorithm, bases<IPropertyManager>, boost::noncopyable>("IAlgorithm", "Interface for all algorithms", no_init)
       .def("name", &IAlgorithm::name, arg("self"), "Returns the name of the algorithm")

--- a/Framework/PythonInterface/mantid/api/src/Exports/IFunction.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/IFunction.cpp
@@ -39,8 +39,8 @@ namespace {
  * @param self :: Enables it to be called as a member function on the
  * FunctionFactory class
  */
-PyObject *getCategories(IFunction &self) {
-  std::vector<std::string> categories = self.categories();
+PyObject *getCategories(const IFunction &self) {
+  const auto categories = self.categories();
 
   PyObject *registered = PyList_New(0);
   for (const auto &category : categories) {
@@ -180,7 +180,8 @@ void export_IFunction() {
       .def("declareAttribute", &IFunctionAdapter::declareAttribute, (arg("self"), arg("name"), arg("default_value")),
            "Declare an attribute with an initial value")
 
-      .def("getAttributeValue", (PyObject * (*)(IFunction &, const std::string &)) IFunctionAdapter::getAttributeValue,
+      .def("getAttributeValue",
+           (PyObject * (*)(const IFunction &, const std::string &)) IFunctionAdapter::getAttributeValue,
            (arg("self"), arg("name")), "Return the value of the named attribute")
 
       .def("setAttributeValue", &IFunctionAdapter::setAttributePythonValue, (arg("self"), arg("name"), arg("value")),

--- a/Framework/PythonInterface/mantid/api/src/Exports/IMDHistoWorkspace.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/IMDHistoWorkspace.cpp
@@ -85,7 +85,7 @@ std::vector<Py_intptr_t> countDimensions(const IMDHistoWorkspace &self) {
  * Returns the signal array from the workspace as a numpy array
  * @param self :: A reference to the calling object
  */
-PyObject *getSignalArrayAsNumpyArray(IMDHistoWorkspace &self) {
+PyObject *getSignalArrayAsNumpyArray(const IMDHistoWorkspace &self) {
   auto dims = countDimensions(self);
   return WrapReadOnlyNumpyFArray(self.getSignalArray(), dims);
 }
@@ -94,7 +94,7 @@ PyObject *getSignalArrayAsNumpyArray(IMDHistoWorkspace &self) {
  * Returns the error squared array from the workspace as a numpy array
  * @param self :: A reference to the calling object
  */
-PyObject *getErrorSquaredArrayAsNumpyArray(IMDHistoWorkspace &self) {
+PyObject *getErrorSquaredArrayAsNumpyArray(const IMDHistoWorkspace &self) {
   auto dims = countDimensions(self);
   return WrapReadOnlyNumpyFArray(self.getErrorSquaredArray(), dims);
 }
@@ -103,7 +103,7 @@ PyObject *getErrorSquaredArrayAsNumpyArray(IMDHistoWorkspace &self) {
  * Returns the number of events array from the workspace as a numpy array
  * @param self :: A reference to the calling object
  */
-PyObject *getNumEventsArrayAsNumpyArray(IMDHistoWorkspace &self) {
+PyObject *getNumEventsArrayAsNumpyArray(const IMDHistoWorkspace &self) {
   auto dims = countDimensions(self);
   return WrapReadOnlyNumpyFArray(self.getNumEventsArray(), dims);
 }
@@ -115,7 +115,7 @@ PyObject *getNumEventsArrayAsNumpyArray(IMDHistoWorkspace &self) {
  * @param signal :: The new values
  * @param fnLabel :: A message prefix to pass if the sizes are incorrect
  */
-void throwIfSizeIncorrect(IMDHistoWorkspace &self, const NDArray &signal, const std::string &fnLabel) {
+void throwIfSizeIncorrect(const IMDHistoWorkspace &self, const NDArray &signal, const std::string &fnLabel) {
   auto wsShape = countDimensions(self);
   const size_t ndims = wsShape.size();
   auto arrShape = signal.attr("shape");

--- a/Framework/PythonInterface/mantid/api/src/Exports/IPeak.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/IPeak.cpp
@@ -25,7 +25,7 @@ GET_POINTER_SPECIALIZATION(IPeak)
 
 namespace {
 using namespace Mantid::PythonInterface;
-Mantid::Geometry::PeakShape_sptr getPeakShape(IPeak &peak) {
+Mantid::Geometry::PeakShape_sptr getPeakShape(const IPeak &peak) {
   // Use clone to make a copy of the PeakShape.
   return Mantid::Geometry::PeakShape_sptr(peak.getPeakShape().clone());
 }

--- a/Framework/PythonInterface/mantid/api/src/Exports/IPeaksWorkspace.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/IPeaksWorkspace.cpp
@@ -32,28 +32,28 @@ GET_POINTER_SPECIALIZATION(IPeaksWorkspace)
 namespace {
 
 /// Create a peak via it's HKL value from a list or numpy array
-IPeak *createPeakHKL(IPeaksWorkspace &self, const object &data) {
+IPeak *createPeakHKL(const IPeaksWorkspace &self, const object &data) {
   auto peak = self.createPeakHKL(Mantid::PythonInterface::Converters::PyObjectToV3D(data)());
   // Python will manage it
   return peak.release();
 }
 
 /// Create a peak via it's QLab value from a list or numpy array
-IPeak *createPeakQLab(IPeaksWorkspace &self, const object &data) {
+IPeak *createPeakQLab(const IPeaksWorkspace &self, const object &data) {
   auto peak = self.createPeak(Mantid::PythonInterface::Converters::PyObjectToV3D(data)(), boost::none);
   // Python will manage it
   return peak.release();
 }
 
 /// Create a peak via it's QLab value from a list or numpy array
-IPeak *createPeakQLabWithDistance(IPeaksWorkspace &self, const object &data, double detectorDistance) {
+IPeak *createPeakQLabWithDistance(const IPeaksWorkspace &self, const object &data, double detectorDistance) {
   auto peak = self.createPeak(Mantid::PythonInterface::Converters::PyObjectToV3D(data)(), detectorDistance);
   // Python will manage the object
   return peak.release();
 }
 
 /// Create a peak via it's QSample value from a list or numpy array
-IPeak *createPeakQSample(IPeaksWorkspace &self, const object &data) {
+IPeak *createPeakQSample(const IPeaksWorkspace &self, const object &data) {
   auto peak = self.createPeakQSample(Mantid::PythonInterface::Converters::PyObjectToV3D(data)());
   // Python will manage it
   return peak.release();

--- a/Framework/PythonInterface/mantid/api/src/Exports/MultipleFileProperty.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/MultipleFileProperty.cpp
@@ -32,7 +32,7 @@ using HeldType = std::vector<std::vector<std::string>>;
  * @returns A string is there is only a single string in the Property's value,
  * and a list if there are multiple ones
  */
-boost::python::list valueAsPyObject(MultipleFileProperty &self) {
+boost::python::list valueAsPyObject(const MultipleFileProperty &self) {
   const HeldType &propValue = self();
 
   // Build a list of lists to mimic the behaviour of MultipleFileProperty

--- a/Framework/PythonInterface/mantid/api/src/Exports/SpectrumInfo.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/SpectrumInfo.cpp
@@ -29,7 +29,7 @@ SpectrumInfoPythonIterator make_pyiterator(SpectrumInfo &spectrumInfo) {
   return SpectrumInfoPythonIterator(spectrumInfo);
 }
 
-PyObject *geographicalAngles(SpectrumInfo &spectrumInfo, const size_t index) {
+PyObject *geographicalAngles(const SpectrumInfo &spectrumInfo, const size_t index) {
   const auto angles = spectrumInfo.geographicalAngles(index);
   return incref(make_tuple(angles.first, angles.second).ptr());
 }

--- a/Framework/PythonInterface/mantid/api/src/Exports/Workspace.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/Workspace.cpp
@@ -41,7 +41,7 @@ GNU_DIAG_ON("unused-local-typedef")
  * @param self Reference to the calling object
  * @return name of the workspace.
  */
-std::string getName(Workspace &self) {
+std::string getName(const Workspace &self) {
   PyErr_Warn(PyExc_DeprecationWarning, ".getName() is deprecated. Use .name() instead.");
   return self.getName();
 }

--- a/Framework/PythonInterface/mantid/api/src/Exports/WorkspaceFactory.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/WorkspaceFactory.cpp
@@ -43,10 +43,10 @@ namespace {
  *  @throw  std::out_of_range If invalid (0 or less) size arguments are given
  *  @throw  NotFoundException If the class is not registered in the factory
  **/
-Workspace_sptr createFromParentPtr(WorkspaceFactoryImpl &self, const MatrixWorkspace_sptr &parent,
+Workspace_sptr createFromParentPtr(WorkspaceFactoryImpl const *const self, const MatrixWorkspace_sptr &parent,
                                    size_t NVectors = size_t(-1), size_t XLength = size_t(-1),
                                    size_t YLength = size_t(-1)) {
-  return self.create(parent, NVectors, XLength, YLength);
+  return self->create(parent, NVectors, XLength, YLength);
 }
 
 /// Overload generator for create

--- a/Framework/PythonInterface/mantid/api/src/Exports/WorkspaceHistory.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/WorkspaceHistory.cpp
@@ -29,7 +29,7 @@ GET_POINTER_SPECIALIZATION(WorkspaceHistory)
  * @param self :: A reference to the WorkspaceHistory that called this method
  * @returns A python list created from the set of algorithm histories
  */
-boost::python::list getHistoriesAsList(WorkspaceHistory &self) {
+boost::python::list getHistoriesAsList(const WorkspaceHistory &self) {
   boost::python::list names;
   const auto &histories = self.getAlgorithmHistories();
   for (const auto &historie : histories) {

--- a/Framework/PythonInterface/mantid/api/src/FitFunctions/IFunctionAdapter.cpp
+++ b/Framework/PythonInterface/mantid/api/src/FitFunctions/IFunctionAdapter.cpp
@@ -125,7 +125,7 @@ void IFunctionAdapter::declareAttribute(const std::string &name, const object &d
  * @param name :: The name of the new attribute.
  * @returns The value of the attribute
  */
-PyObject *IFunctionAdapter::getAttributeValue(IFunction &self, const std::string &name) {
+PyObject *IFunctionAdapter::getAttributeValue(const IFunction &self, const std::string &name) {
   auto attr = self.getAttribute(name);
   return getAttributeValue(self, attr);
 }
@@ -136,7 +136,7 @@ PyObject *IFunctionAdapter::getAttributeValue(IFunction &self, const std::string
  * @param attr An attribute object
  * @returns The value of the attribute
  */
-PyObject *IFunctionAdapter::getAttributeValue(IFunction &self, const API::IFunction::Attribute &attr) {
+PyObject *IFunctionAdapter::getAttributeValue(const IFunction &self, const API::IFunction::Attribute &attr) {
   UNUSED_ARG(self);
   std::string type = attr.type();
   PyObject *result(nullptr);
@@ -189,7 +189,7 @@ void IFunctionAdapter::setAttribute(const std::string &attName, const Attribute 
  *    For a single domain function it should have a single element (self).
  * @return A python list of IFunction_sprs.
  */
-boost::python::list IFunctionAdapter::createPythonEquivalentFunctions(IFunction &self) {
+boost::python::list IFunctionAdapter::createPythonEquivalentFunctions(const IFunction &self) {
   auto functions = self.createEquivalentFunctions();
   boost::python::list list;
   for (const auto &fun : functions) {

--- a/Framework/PythonInterface/mantid/geometry/src/Exports/CrystalStructure.cpp
+++ b/Framework/PythonInterface/mantid/geometry/src/Exports/CrystalStructure.cpp
@@ -16,10 +16,12 @@ using namespace Mantid::Kernel;
 using namespace boost::python;
 
 namespace {
-SpaceGroup_sptr getSpaceGroup(CrystalStructure &self) { return std::const_pointer_cast<SpaceGroup>(self.spaceGroup()); }
+SpaceGroup_sptr getSpaceGroup(const CrystalStructure &self) {
+  return std::const_pointer_cast<SpaceGroup>(self.spaceGroup());
+}
 
 std::vector<std::string> getScatterers(const CrystalStructure &self) {
-  CompositeBraggScatterer_sptr scatterers = self.getScatterers();
+  auto scatterers = self.getScatterers();
 
   std::vector<std::string> scattererStrings;
   scattererStrings.reserve(scatterers->nScatterers());

--- a/Framework/PythonInterface/mantid/geometry/src/Exports/Group.cpp
+++ b/Framework/PythonInterface/mantid/geometry/src/Exports/Group.cpp
@@ -24,8 +24,8 @@ using namespace boost::python;
 GET_POINTER_SPECIALIZATION(Group)
 
 namespace {
-std::vector<std::string> getSymmetryOperationStrings(Group &self) {
-  const std::vector<SymmetryOperation> &symOps = self.getSymmetryOperations();
+std::vector<std::string> getSymmetryOperationStrings(const Group &self) {
+  const auto &symOps = self.getSymmetryOperations();
 
   std::vector<std::string> pythonSymOps;
   pythonSymOps.reserve(symOps.size());
@@ -54,11 +54,11 @@ Group_sptr constructGroupFromPythonList(const boost::python::list &symOpList) {
   return std::const_pointer_cast<Group>(GroupFactory::create<Group>(operations));
 }
 
-bool isInvariantDefault(Group &self, const boost::python::object &tensor) {
+bool isInvariantDefault(const Group &self, const boost::python::object &tensor) {
   return self.isInvariant(PyObjectToMatrix(tensor)());
 }
 
-bool isInvariantTolerance(Group &self, const boost::python::object &tensor, double tolerance) {
+bool isInvariantTolerance(const Group &self, const boost::python::object &tensor, double tolerance) {
   return self.isInvariant(PyObjectToMatrix(tensor)(), tolerance);
 }
 } // namespace

--- a/Framework/PythonInterface/mantid/geometry/src/Exports/IComponent.cpp
+++ b/Framework/PythonInterface/mantid/geometry/src/Exports/IComponent.cpp
@@ -30,7 +30,7 @@ namespace {
  *calculation
  * @return The distance between self & the other component in metres
  */
-double getDistance(IComponent &self, IComponent &other) { return self.getDistance(other); }
+double getDistance(const IComponent &self, const IComponent &other) { return self.getDistance(other); }
 } // namespace
 
 void export_IComponent() {

--- a/Framework/PythonInterface/mantid/geometry/src/Exports/IMDDimension.cpp
+++ b/Framework/PythonInterface/mantid/geometry/src/Exports/IMDDimension.cpp
@@ -28,7 +28,7 @@ namespace {
  * @param self A reference to the calling object
  * @return A plain-text string giving the units
  */
-std::string getUnitsAsStr(IMDDimension &self) { return self.getUnits().ascii(); }
+std::string getUnitsAsStr(const IMDDimension &self) { return self.getUnits().ascii(); }
 
 /**
  * @brief getMDFrame
@@ -47,7 +47,7 @@ std::shared_ptr<MDFrame> getMDFrame(const IMDDimension &self) {
  * @param self Reference to the calling object
  * @return name of the dimension.
  */
-std::string getName(IMDDimension &self) {
+std::string getName(const IMDDimension &self) {
   PyErr_Warn(PyExc_DeprecationWarning, ".getName() is deprecated. Use .name instead.");
   return self.getName();
 }

--- a/Framework/PythonInterface/mantid/geometry/src/Exports/IObjComponent.cpp
+++ b/Framework/PythonInterface/mantid/geometry/src/Exports/IObjComponent.cpp
@@ -23,7 +23,7 @@ namespace {
  * @param self A reference to the calling object to emulate method on Python
  * object
  */
-std::shared_ptr<Mantid::Geometry::IObject> getShape(IObjComponent &self) {
+std::shared_ptr<Mantid::Geometry::IObject> getShape(const IObjComponent &self) {
   return std::const_pointer_cast<Mantid::Geometry::IObject>(self.shape());
 }
 } // namespace

--- a/Framework/PythonInterface/mantid/geometry/src/Exports/OrientedLattice.cpp
+++ b/Framework/PythonInterface/mantid/geometry/src/Exports/OrientedLattice.cpp
@@ -40,11 +40,11 @@ void setUFromVectors(OrientedLattice &self, const object &vec1, const object &ve
   self.setUFromVectors(Converters::PyObjectToV3D(vec1)(), Converters::PyObjectToV3D(vec2)());
 }
 
-Mantid::Kernel::V3D qFromHKL(OrientedLattice &self, const object &vec) {
+Mantid::Kernel::V3D qFromHKL(const OrientedLattice &self, const object &vec) {
   return self.qFromHKL(Converters::PyObjectToV3D(vec)());
 }
 
-Mantid::Kernel::V3D hklFromQ(OrientedLattice &self, const object &vec) {
+Mantid::Kernel::V3D hklFromQ(const OrientedLattice &self, const object &vec) {
   return self.hklFromQ(Converters::PyObjectToV3D(vec)());
 }
 } // namespace

--- a/Framework/PythonInterface/mantid/geometry/src/Exports/PointGroup.cpp
+++ b/Framework/PythonInterface/mantid/geometry/src/Exports/PointGroup.cpp
@@ -28,12 +28,12 @@ namespace //<unnamed>
 {
 using namespace Mantid::PythonInterface;
 
-bool isEquivalent(PointGroup &self, const object &hkl1, const object &hkl2) {
+bool isEquivalent(const PointGroup &self, const object &hkl1, const object &hkl2) {
   return self.isEquivalent(Converters::PyObjectToV3D(hkl1)(), Converters::PyObjectToV3D(hkl2)());
 }
 
-boost::python::list getEquivalents(PointGroup &self, const object &hkl) {
-  const std::vector<Mantid::Kernel::V3D> &equivalents = self.getEquivalents(Converters::PyObjectToV3D(hkl)());
+boost::python::list getEquivalents(const PointGroup &self, const object &hkl) {
+  const auto &equivalents = self.getEquivalents(Converters::PyObjectToV3D(hkl)());
 
   boost::python::list pythonEquivalents;
   for (const auto &equivalent : equivalents) {
@@ -43,7 +43,7 @@ boost::python::list getEquivalents(PointGroup &self, const object &hkl) {
   return pythonEquivalents;
 }
 
-Mantid::Kernel::V3D getReflectionFamily(PointGroup &self, const object &hkl) {
+Mantid::Kernel::V3D getReflectionFamily(const PointGroup &self, const object &hkl) {
   return self.getReflectionFamily(Converters::PyObjectToV3D(hkl)());
 }
 

--- a/Framework/PythonInterface/mantid/geometry/src/Exports/ReflectionGenerator.cpp
+++ b/Framework/PythonInterface/mantid/geometry/src/Exports/ReflectionGenerator.cpp
@@ -24,31 +24,31 @@ boost::python::list getListFromV3DVector(const std::vector<V3D> &hkls) {
   return hklList;
 }
 
-boost::python::list getHKLsDefaultFilter(ReflectionGenerator &self, double dMin, double dMax) {
+boost::python::list getHKLsDefaultFilter(const ReflectionGenerator &self, double dMin, double dMax) {
   return getListFromV3DVector(self.getHKLs(dMin, dMax));
 }
 
-boost::python::list getHKLsUsingFilter(ReflectionGenerator &self, double dMin, double dMax,
+boost::python::list getHKLsUsingFilter(const ReflectionGenerator &self, double dMin, double dMax,
                                        ReflectionConditionFilter filter) {
-  return getListFromV3DVector(self.getHKLs(dMin, dMax, self.getReflectionConditionFilter(filter)));
+  return getListFromV3DVector(self.getHKLs(dMin, dMax, self.getReflectionConditionFilter(std::move(filter))));
 }
 
-boost::python::list getUniqueHKLsDefaultFilter(ReflectionGenerator &self, double dMin, double dMax) {
+boost::python::list getUniqueHKLsDefaultFilter(const ReflectionGenerator &self, double dMin, double dMax) {
   return getListFromV3DVector(self.getUniqueHKLs(dMin, dMax));
 }
 
 boost::python::list getUniqueHKLsUsingFilter(ReflectionGenerator &self, double dMin, double dMax,
                                              ReflectionConditionFilter filter) {
-  return getListFromV3DVector(self.getUniqueHKLs(dMin, dMax, self.getReflectionConditionFilter(filter)));
+  return getListFromV3DVector(self.getUniqueHKLs(dMin, dMax, self.getReflectionConditionFilter(std::move(filter))));
 }
 
-std::vector<double> getDValues(ReflectionGenerator &self, const boost::python::object &hkls) {
+std::vector<double> getDValues(const ReflectionGenerator &self, const boost::python::object &hkls) {
   Converters::PySequenceToVector<V3D> converter(hkls);
 
   return self.getDValues(converter());
 }
 
-std::vector<double> getFsSquared(ReflectionGenerator &self, const boost::python::object &hkls) {
+std::vector<double> getFsSquared(const ReflectionGenerator &self, const boost::python::object &hkls) {
   Converters::PySequenceToVector<V3D> converter(hkls);
 
   return self.getFsSquared(converter());

--- a/Framework/PythonInterface/mantid/geometry/src/Exports/SpaceGroup.cpp
+++ b/Framework/PythonInterface/mantid/geometry/src/Exports/SpaceGroup.cpp
@@ -27,8 +27,8 @@ namespace //<unnamed>
 {
 using namespace Mantid::PythonInterface;
 
-boost::python::list getEquivalentPositions(SpaceGroup &self, const object &point) {
-  const std::vector<Mantid::Kernel::V3D> &equivalents = self.getEquivalentPositions(Converters::PyObjectToV3D(point)());
+boost::python::list getEquivalentPositions(const SpaceGroup &self, const object &point) {
+  const auto &equivalents = self.getEquivalentPositions(Converters::PyObjectToV3D(point)());
 
   boost::python::list pythonEquivalents;
   for (const auto &equivalent : equivalents) {
@@ -38,18 +38,15 @@ boost::python::list getEquivalentPositions(SpaceGroup &self, const object &point
   return pythonEquivalents;
 }
 
-bool isAllowedReflection(SpaceGroup &self, const object &hkl) {
-  const Mantid::Kernel::V3D &hklV3d = Converters::PyObjectToV3D(hkl)();
+bool isAllowedReflection(const SpaceGroup &self, const object &hkl) {
+  const auto &hklV3d = Converters::PyObjectToV3D(hkl)();
 
   return self.isAllowedReflection(hklV3d);
 }
 
-Mantid::Geometry::Group_sptr getSiteSymmetryGroup(SpaceGroup &self, const object &position) {
-  const Mantid::Kernel::V3D &posV3d = Converters::PyObjectToV3D(position)();
-
-  Mantid::Geometry::Group_sptr group = std::const_pointer_cast<Group>(self.getSiteSymmetryGroup(posV3d));
-
-  return group;
+Mantid::Geometry::Group_sptr getSiteSymmetryGroup(const SpaceGroup &self, const object &position) {
+  const auto &posV3d = Converters::PyObjectToV3D(position)();
+  return std::const_pointer_cast<Group>(self.getSiteSymmetryGroup(posV3d));
 }
 
 std::string __repr__implementation(const SpaceGroup &self) {

--- a/Framework/PythonInterface/mantid/geometry/src/Exports/SpaceGroupFactory.cpp
+++ b/Framework/PythonInterface/mantid/geometry/src/Exports/SpaceGroupFactory.cpp
@@ -18,11 +18,11 @@ GET_POINTER_SPECIALIZATION(SpaceGroupFactoryImpl)
 namespace {
 using namespace Mantid::PythonInterface;
 
-std::vector<std::string> allSpaceGroupSymbols(SpaceGroupFactoryImpl &self) {
+std::vector<std::string> allSpaceGroupSymbols(const SpaceGroupFactoryImpl &self) {
   return self.subscribedSpaceGroupSymbols();
 }
 
-std::vector<std::string> spaceGroupSymbolsForNumber(SpaceGroupFactoryImpl &self, size_t number) {
+std::vector<std::string> spaceGroupSymbolsForNumber(const SpaceGroupFactoryImpl &self, size_t number) {
   return self.subscribedSpaceGroupSymbols(number);
 }
 
@@ -31,13 +31,14 @@ std::vector<std::string> spaceGroupSymbolsForPointGroup(SpaceGroupFactoryImpl &s
   return self.subscribedSpaceGroupSymbols(pointGroup);
 }
 
-bool isSubscribedSymbol(SpaceGroupFactoryImpl &self, const std::string &symbol) { return self.isSubscribed(symbol); }
+bool isSubscribedSymbol(const SpaceGroupFactoryImpl &self, const std::string &symbol) {
+  return self.isSubscribed(symbol);
+}
 
-bool isSubscribedNumber(SpaceGroupFactoryImpl &self, size_t number) { return self.isSubscribed(number); }
+bool isSubscribedNumber(const SpaceGroupFactoryImpl &self, size_t number) { return self.isSubscribed(number); }
 
 SpaceGroup_sptr createSpaceGroup(SpaceGroupFactoryImpl &self, const std::string &symbol) {
-  SpaceGroup_const_sptr spaceGroup = self.createSpaceGroup(symbol);
-  return std::const_pointer_cast<SpaceGroup>(spaceGroup);
+  return std::const_pointer_cast<SpaceGroup>(self.createSpaceGroup(symbol));
 }
 } // namespace
 

--- a/Framework/PythonInterface/mantid/geometry/src/Exports/SymmetryOperation.cpp
+++ b/Framework/PythonInterface/mantid/geometry/src/Exports/SymmetryOperation.cpp
@@ -24,11 +24,11 @@ namespace //<unnamed>
 {
 using namespace Mantid::PythonInterface;
 
-Mantid::Kernel::V3D applyToVector(SymmetryOperation &self, const object &hkl) {
+Mantid::Kernel::V3D applyToVector(const SymmetryOperation &self, const object &hkl) {
   return self.transformHKL(Converters::PyObjectToV3D(hkl)());
 }
 
-Mantid::Kernel::V3D applyToCoordinates(SymmetryOperation &self, const object &coordinates) {
+Mantid::Kernel::V3D applyToCoordinates(const SymmetryOperation &self, const object &coordinates) {
   return self.operator*<Mantid::Kernel::V3D>(Converters::PyObjectToV3D(coordinates)());
 }
 } // namespace

--- a/Framework/PythonInterface/mantid/kernel/src/Exports/Atom.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Exports/Atom.cpp
@@ -22,7 +22,7 @@ namespace {
  * The neutron cross-sections for this atom
  * @return a dict of the neutron cross-sections
  */
-dict neutron(Atom &self) {
+dict neutron(const Atom &self) {
   dict retval;
   retval["coh_scatt_xs"] = self.neutron.coh_scatt_xs;
   retval["inc_scatt_xs"] = self.neutron.inc_scatt_xs;

--- a/Framework/PythonInterface/mantid/kernel/src/Exports/ConfigService.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Exports/ConfigService.cpp
@@ -41,21 +41,22 @@ void setDataSearchDirs(ConfigServiceImpl &self, const object &paths) {
 }
 
 /// Forward call from __getitem__ to getString with use_cache_true
-std::string getStringUsingCache(ConfigServiceImpl &self, const std::string &key) { return self.getString(key, true); }
+std::string getStringUsingCache(ConfigServiceImpl const *const self, const std::string &key) {
+  return self->getString(key, true);
+}
 
-const InstrumentInfo &getInstrument(ConfigServiceImpl &self, const object &name = object()) {
+const InstrumentInfo &getInstrument(ConfigServiceImpl const *const self, const object &name = object()) {
   if (name.is_none())
-    return self.getInstrument();
+    return self->getInstrument();
   else
-    return self.getInstrument(ExtractStdString(name)());
+    return self->getInstrument(ExtractStdString(name)());
 }
 
 /// duck typing emulating dict.get method
-std::string getStringUsingCacheElseDefault(ConfigServiceImpl &self, const std::string &key,
+std::string getStringUsingCacheElseDefault(ConfigServiceImpl const *const self, const std::string &key,
                                            const std::string &defaultValue) {
-  std::vector<std::string> keys = self.keys();
-  if (self.hasProperty(key))
-    return self.getString(key, true);
+  if (self->hasProperty(key))
+    return self->getString(key, true);
   else
     return defaultValue;
 }

--- a/Framework/PythonInterface/mantid/kernel/src/Exports/DateAndTime.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Exports/DateAndTime.cpp
@@ -24,12 +24,12 @@ using boost::python::arg;
  * given
  *  the special treatment that leads to the problem.
  */
-std::string ISO8601StringPlusSpace(DateAndTime &self) {
+std::string ISO8601StringPlusSpace(const DateAndTime &self) {
   // TODO this should cmake check and turn off the behavior
   return self.toISO8601String() + " ";
 }
 
-int64_t total_nanoseconds(DateAndTime &self) {
+int64_t total_nanoseconds(const DateAndTime &self) {
   PyErr_Warn(PyExc_DeprecationWarning, ".total_nanoseconds() is deprecated. Use .totalNanoseconds() instead.");
   return self.totalNanoseconds();
 }

--- a/Framework/PythonInterface/mantid/kernel/src/Exports/IPropertyManager.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Exports/IPropertyManager.cpp
@@ -114,7 +114,7 @@ void deleteProperty(IPropertyManager &self, const std::string &propName) { self.
  * @param self The calling object
  * @return The list of keys.
  */
-boost::python::list getKeys(IPropertyManager &self) {
+boost::python::list getKeys(const IPropertyManager &self) {
   const std::vector<Property *> &props = self.getProperties();
   const size_t numProps = props.size();
 
@@ -138,7 +138,7 @@ boost::python::list getKeys(IPropertyManager &self) {
  * @return      The property with the specified key. If no
  *              such property exists, return the default value.
  */
-Property *get(IPropertyManager &self, const std::string &name, const boost::python::object &value) {
+Property *get(const IPropertyManager &self, const std::string &name, const boost::python::object &value) {
   try {
     return self.getPointerToProperty(name);
   } catch (Exception::NotFoundError &) {

--- a/Framework/PythonInterface/mantid/kernel/src/Exports/Material.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Exports/Material.cpp
@@ -28,7 +28,7 @@ namespace {
  * @param chemicalFormula the chemical formula of the material (compound)
  * @return a tuple consisting of a list of the elements and their proportions
  */
-tuple chemicalFormula(Material &self) {
+tuple chemicalFormula(const Material &self) {
   list atoms, numberAtoms;
   for (const auto &formulaUnit : self.chemicalFormula()) {
     atoms.append(formulaUnit.atom);
@@ -37,7 +37,7 @@ tuple chemicalFormula(Material &self) {
   return make_tuple(atoms, numberAtoms);
 }
 
-bool toBool(Material &self) {
+bool toBool(const Material &self) {
   return (self.cohScatterXSection() != 0.) || (self.incohScatterXSection() != 0.) ||
          (self.totalScatterXSection() != 0.) || (self.absorbXSection() != 0.) || (self.cohScatterLength() != 0.) ||
          (self.incohScatterLength() != 0.) || (self.totalScatterLength() != 0.) ||
@@ -52,7 +52,7 @@ bool toBool(Material &self) {
  * @param rmm the relative molecular (formula) mass of this material
  * @return the relative molecular mass
  */
-double relativeMolecularMass(Material &self) {
+double relativeMolecularMass(const Material &self) {
   const auto &formula = self.chemicalFormula();
   return std::accumulate(formula.cbegin(), formula.cend(), 0., [](double sum, const auto &formulaUnit) {
     return sum + formulaUnit.atom->mass * formulaUnit.multiplicity;

--- a/Framework/PythonInterface/mantid/kernel/src/Exports/Unit.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Exports/Unit.cpp
@@ -23,7 +23,7 @@ namespace {
  * Returns the full name of the unit & raises a deprecation warning
  * @param self A reference to calling object
  */
-const std::string deprecatedName(Unit &self) {
+const std::string deprecatedName(const Unit &self) {
   PyErr_Warn(PyExc_DeprecationWarning, "'name' is deprecated, use 'caption' instead.");
   return self.caption();
 }
@@ -32,12 +32,12 @@ const std::string deprecatedName(Unit &self) {
  * Returns the label of the unit as a std::string & raises a deprecation warning
  * @param self A reference to calling object
  */
-const std::string deprecatedLabel(Unit &self) {
+const std::string deprecatedLabel(const Unit &self) {
   PyErr_Warn(PyExc_DeprecationWarning, "'unit.label()' is deprecated, use 'str(unit.symbol())' instead.");
   return self.label().ascii();
 }
 
-template <class T> tuple quickConversionWrapper(Unit &self, const T &destUnitName) {
+template <class T> tuple quickConversionWrapper(const Unit &self, const T &destUnitName) {
   double wavelengthFactor = 0;
   double wavelengthPower = 0;
   bool converted = self.quickConversion(destUnitName, wavelengthFactor, wavelengthPower);

--- a/Framework/PythonInterface/mantid/kernel/src/Exports/UnitLabel.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Exports/UnitLabel.cpp
@@ -45,7 +45,7 @@ std::shared_ptr<UnitLabel> createLabel(const object &ascii, const object &utf8, 
  * @param self A reference to the calling object
  * @return A new Python unicode string with the contents of the utf8 label
  */
-PyObject *utf8ToUnicode(UnitLabel &self) {
+PyObject *utf8ToUnicode(const UnitLabel &self) {
   const auto &label = self.utf8();
   return PyUnicode_FromWideChar(label.c_str(), label.size());
 }

--- a/buildconfig/Jenkins/cppcheck.sh
+++ b/buildconfig/Jenkins/cppcheck.sh
@@ -4,7 +4,7 @@ SCRIPT_DIR=$(dirname "$0")
 # If errors slip through to master this can be used to set a non-zero
 # allowed count while those errors are dealt with. This avoids breaking all
 # builds for all developers
-ALLOWED_ERRORS_COUNT=1176
+ALLOWED_ERRORS_COUNT=1095
 
 if [[ ${JOB_NAME} == *pull_requests* ]]; then
     # This relies on the fact pull requests use pull/$PR-NAME


### PR DESCRIPTION
**Blocked by: #32465**

**Description of work.**

The Python layer contained many functions cppcheck flagged as being able to accept a `const&` rather than plain `&`. This fixes them for more protection from the compiler. See the commit comment for the `const *const` usage for singletons.

**To test:**

* Code review and all tests should pass.
* Check the cppcheck results have no `constParameterCallback` errors left.

*There is no associated issue.*

*This does not require release notes* because **it is an internal maintenance task.**

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
