### PR TITLE
Fix sort order in LoadEventNexus

### DIFF
--- a/Framework/DataHandling/src/ProcessBankData.cpp
+++ b/Framework/DataHandling/src/ProcessBankData.cpp
@@ -207,18 +207,21 @@ void ProcessBankData::run() { // override {
 
   //------------ Compress Events (or set sort order) ------------------
   // Do it on all the detector IDs we touched
+  const size_t numEventLists = outputWS.getNumberHistograms();
   for (detid_t pixID = m_min_id; pixID <= m_max_id; ++pixID) {
     if (usedDetIds[pixID - m_min_id]) {
       // Find the the workspace index corresponding to that pixel ID
       size_t wi = getWorkspaceIndexFromPixelID(pixID);
-      auto &el = outputWS.getSpectrum(wi);
-      if (compress)
-        el.compressEvents(alg->compressTolerance, &el);
-      else {
-        if (pulsetimesincreasing)
-          el.setSortOrder(DataObjects::PULSETIME_SORT);
-        else
-          el.setSortOrder(DataObjects::UNSORTED);
+      if (wi < numEventLists) {
+        auto &el = outputWS.getSpectrum(wi);
+        if (compress)
+          el.compressEvents(alg->compressTolerance, &el);
+        else {
+          if (pulsetimesincreasing)
+            el.setSortOrder(DataObjects::PULSETIME_SORT);
+          else
+            el.setSortOrder(DataObjects::UNSORTED);
+        }
       }
     }
   }

--- a/Framework/DataHandling/test/LoadEventNexusTest.h
+++ b/Framework/DataHandling/test/LoadEventNexusTest.h
@@ -181,6 +181,19 @@ private:
     TS_ASSERT_EQUALS("2010-Mar-25 16:11:51.558003540", filteredLogEndTime.toSimpleString());
   }
 
+  void validate_pulse_time_sorting(EventWorkspace_sptr eventWS) {
+    for (size_t i = 0; i < eventWS->getNumberHistograms(); i++) {
+      auto eventList = eventWS->getSpectrum(i);
+      if (eventList.getSortType() == DataObjects::PULSETIME_SORT) {
+        std::vector<DateAndTime> pulsetimes;
+        for (auto &event : eventList.getEvents()) {
+          pulsetimes.emplace_back(event.pulseTime());
+        }
+        TS_ASSERT(std::is_sorted(pulsetimes.cbegin(), pulsetimes.cend()));
+      }
+    }
+  }
+
 public:
   void test_load_event_nexus_v20_ess() {
     const std::string file = "V20_ESS_example.nxs";
@@ -219,6 +232,8 @@ public:
     TS_ASSERT_EQUALS(eventWS->getNumberEvents(), 1439);
     TS_ASSERT_EQUALS(eventWS->detectorInfo().size(),
                      (150 * 150) + 2) // Two monitors
+
+    validate_pulse_time_sorting(eventWS);
   }
 
   void test_load_event_nexus_v20_ess_integration_2018() {
@@ -241,6 +256,8 @@ public:
                        (300 * 300) + 2) // Two monitors
       TS_ASSERT_DELTA(eventWS->getTofMin(), 9.815, 1.0e-3);
       TS_ASSERT_DELTA(eventWS->getTofMax(), 130748.563, 1.0e-3);
+
+      validate_pulse_time_sorting(eventWS);
     }
   }
 

--- a/docs/source/release/v6.2.0/framework.rst
+++ b/docs/source/release/v6.2.0/framework.rst
@@ -38,6 +38,7 @@ Bugfixes
 - :ref:`LoadNexusLogs <algm-LoadNexusLogs>` now creates a warning message for logs that are poorly formed and the other logs are loaded. Previously it stopped loading logs at that point.
 - Fixed a bug where :ref:`LoadRaw <algm-LoadRaw>` would not load all log files for raw files with an alternate data stream.
 - Fixed a problem calculating default beam size in :ref:`MonteCarloAbsorption <algm-MonteCarloAbsorption>` when sample is offset from origin.
+- Fixed a problem with sorting of events in :ref:`LoadEventNexus <algm-LoadEventNexus>` that was causing :ref:`FilterByTime <algm-FilterByTime>` to give incorrect results
 
 Fit Functions
 -------------


### PR DESCRIPTION
**Description of work.**

When LoadEventNexus algorithm is run without compression and the events in the Nexus file are not already sorted by pulse time, the algorithm is incorrectly labelling them as sorted by pulse time. This change fixes the problem by always running the code that sets the sort order even if loading without compression (more detail on linked issue)

This problem was causing FilterByTime to incorrectly slice up an event file by time. A lot of events were being assigned to the last second of a run.

I did a few measurements before and after on the load time for a POLARIS nexus file (run 128780) containing 480 million events. There wasn't an increase in the load time. The code changes just means the sort order is set on each event list (one per spectrum) so perhaps not very expensive. The POLARIS file has ~3000 spectra and a single bank which I think gets loaded in 2 threads (splitProcessing=true)

**To test:**

Run this script. The initial nexus file has ~26.5 million events in it spanning a run lasting about 5 minutes. When FilterByTime is run on the workspace with a timestamp range matching the last 1 second of the run it should return ~50,000 events. Before the fix it was returning ~11 million events:

```
# import mantid algorithms, numpy and matplotlib
from mantid.simpleapi import *
import matplotlib.pyplot as plt
import numpy as np

event_ws = Load(Filename=r'POLARIS00129560.nxs')

print("The total number of events: %i" % mtd["event_ws"].getNumberEvents())

event_ws_last_sec = FilterByTime(event_ws,308,309) #11,501,579 events before vs 51098 after code change
```

Fixes #32495. 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
