### PR TITLE
Deprecate GetDetOffsetsMultiPeaks and CalibrateRectangularDetectors

### DIFF
--- a/Framework/Algorithms/inc/MantidAlgorithms/GetDetOffsetsMultiPeaks.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/GetDetOffsetsMultiPeaks.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include "MantidAPI/Algorithm.h"
+#include "MantidAPI/DeprecatedAlgorithm.h"
 #include "MantidAPI/MatrixWorkspace_fwd.h"
 #include "MantidAlgorithms/DllConfig.h"
 #include "MantidDataObjects/EventWorkspace.h"
@@ -46,7 +47,7 @@ struct FitPeakOffsetResult {
  @author Vickie Lynch, SNS
  @date 12/12/2011
  */
-class MANTID_ALGORITHMS_DLL GetDetOffsetsMultiPeaks : public API::Algorithm {
+class MANTID_ALGORITHMS_DLL GetDetOffsetsMultiPeaks : public API::Algorithm, public API::DeprecatedAlgorithm {
 public:
   /// Default constructorMatrix
   GetDetOffsetsMultiPeaks();

--- a/Framework/PythonInterface/plugins/algorithms/CalibrateRectangularDetectors.py
+++ b/Framework/PythonInterface/plugins/algorithms/CalibrateRectangularDetectors.py
@@ -15,7 +15,7 @@ from mantid.kernel import Direction
 COMPRESS_TOL_TOF = .01
 EXTENSIONS_NXS = ["_event.nxs", ".nxs.h5"]
 
-DEPRECATION_NOTICE = """CalibrateRectangularDetectors is deprecated from v6.3.0.
+DEPRECATION_NOTICE = """CalibrateRectangularDetectors is deprecated from v6.2.0.
 Instead, use PDCalibration."""
 
 

--- a/Framework/PythonInterface/plugins/algorithms/CalibrateRectangularDetectors.py
+++ b/Framework/PythonInterface/plugins/algorithms/CalibrateRectangularDetectors.py
@@ -15,6 +15,9 @@ from mantid.kernel import Direction
 COMPRESS_TOL_TOF = .01
 EXTENSIONS_NXS = ["_event.nxs", ".nxs.h5"]
 
+DEPRECATION_NOTICE = """CalibrateRectangularDetectors is deprecated from v6.3.0.
+Instead, use PDCalibration."""
+
 
 def getBasename(filename):
     name = os.path.split(filename)[-1]
@@ -62,8 +65,11 @@ class CalibrateRectangularDetectors(PythonAlgorithm):
     def name(self):
         return "CalibrateRectangularDetectors"
 
+    # def summary(self):
+    #     return "Calibrate the detector pixels and write a calibration file"
+    @classmethod
     def summary(self):
-        return "Calibrate the detector pixels and write a calibration file"
+        return DEPRECATION_NOTICE
 
     def PyInit(self):
         self.declareProperty(MultipleFileProperty(name="RunNumber",
@@ -423,6 +429,10 @@ class CalibrateRectangularDetectors(PythonAlgorithm):
 
     #pylint: disable=too-many-branches
     def PyExec(self):
+
+        # Exit with deprecation notice
+        self.log().error(DEPRECATION_NOTICE)
+
         # get generic information
         self._binning = self.getProperty("Binning").value
         if len(self._binning) != 1 and len(self._binning) != 3:

--- a/Framework/PythonInterface/plugins/algorithms/CalibrateRectangularDetectors.py
+++ b/Framework/PythonInterface/plugins/algorithms/CalibrateRectangularDetectors.py
@@ -57,7 +57,7 @@ class CalibrateRectangularDetectors(PythonAlgorithm):
     _binning = None
 
     def category(self):
-        return "Diffraction\\Calibration"
+        return "Diffraction\\Calibration;Deprecated"
 
     def seeAlso(self):
         return [ "GetDetectorOffsets" ]

--- a/Testing/SystemTests/tests/framework/SphinxWarnings.py
+++ b/Testing/SystemTests/tests/framework/SphinxWarnings.py
@@ -22,6 +22,7 @@ class SphinxWarnings(systemtesting.MantidSystemTest):
                                 'CorrectionFunctions',
                                 'Crystal',
                                 'DataHandling',
+                                'Deprecated',
                                 'Diagnostics',
                                 'Diffraction',
                                 'Events',

--- a/docs/source/release/v6.2.0/diffraction.rst
+++ b/docs/source/release/v6.2.0/diffraction.rst
@@ -54,6 +54,13 @@ Bugfixes
 - Corrected the equation for pseudo-voigt FWHM and mixing parameter in peak profile function :ref:`Bk2BkExpConvPV <func-Bk2BkExpConvPV>`.
 - Fixed a bug when filtering events in :ref:`AlignAndFocusPowder <algm-AlignAndFocusPowder-v1>` based on time-of-flight. The code now allows setting the minimum time-of-flight to zero (inclusive).
 
+
+Deprecation
+###########
+- Existing :ref:`CalibrateRectangularDetectors <algm-CalibrateRectangularDetectors>` is deprecated.
+- Existing :ref:`GetDetOffsetsMultiPeaks <algm-GetDetOffsetsMultiPeaks>` is deprecated.
+
+
 Engineering Diffraction
 -----------------------
 New features


### PR DESCRIPTION
**Description of work.**

Deprecate CalibrateRectangularDetectors and GetDetOffsetsMultiPeaks.

**To test:**

- Visual check
- All tests shall be passed.

There is no associated Mantid issue.

It is associated with https://code.ornl.gov/sns-hfir-scse/spectroscopy/spectroscopy/-/issues/117

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
