### PR TITLE
Allow IAlgorithm.alias to be overriden in Python algorithms

### DIFF
--- a/Framework/API/inc/MantidAPI/Algorithm.h
+++ b/Framework/API/inc/MantidAPI/Algorithm.h
@@ -168,8 +168,7 @@ public:
   /// Function to return all of the seeAlso (these are not validated) algorithms
   /// related to this algorithm.A default implementation is provided.
   const std::vector<std::string> seeAlso() const override { return {}; };
-  /// function to return any aliases to the algorithm;  A default implementation
-  /// is provided
+  /// function to return any aliases to the algorithm;  A default implementation is provided
   const std::string alias() const override { return ""; }
 
   /// function to return URL for algorithm documentation; A default

--- a/Framework/PythonInterface/mantid/api/inc/MantidPythonInterface/api/PythonAlgorithm/AlgorithmAdapter.h
+++ b/Framework/PythonInterface/mantid/api/inc/MantidPythonInterface/api/PythonAlgorithm/AlgorithmAdapter.h
@@ -53,6 +53,8 @@ public:
   const std::string category() const override;
   /// Returns seeAlso related algorithms.
   const std::vector<std::string> seeAlso() const override;
+  /// Allow the method returning the algorithm aliases to be overridden
+  const std::string alias() const override;
   /// Returns optional documentation URL of the algorithm
   const std::string helpURL() const override;
   /// Allow the isRunning method to be overridden

--- a/Framework/PythonInterface/mantid/api/src/PythonAlgorithm/AlgorithmAdapter.cpp
+++ b/Framework/PythonInterface/mantid/api/src/PythonAlgorithm/AlgorithmAdapter.cpp
@@ -108,6 +108,17 @@ template <typename BaseAlgorithm> const std::vector<std::string> AlgorithmAdapte
 }
 
 /**
+ * Returns the aliases of the algorithm. If not overridden returns the base algorithm implementation
+ */
+template <typename BaseAlgorithm> const std::string AlgorithmAdapter<BaseAlgorithm>::alias() const {
+  try {
+    return callMethod<std::string>(getSelf(), "alias");
+  } catch (UndefinedAttributeError &) {
+    return BaseAlgorithm::alias();
+  }
+}
+
+/**
  * Returns the summary of the algorithm. If not overridden
  * it returns defaultSummary
  */


### PR DESCRIPTION
Companion to PR #32504 

Description:
===========
Allow this in python algorithms:
```python
def alias(self):
    return "AlgAlias"
```
For details, see [PL106](https://code.ornl.gov/sns-hfir-scse/planning/-/issues/106)

**Description of work.**
- [x] override `IAlgorithm.alias` in `AlgorithmAdapter< >`
- [x] manual test

**To test:**
Run the following in mantidworkbench:
```python
from mantid.api import AlgorithmFactory, PythonAlgorithm
from mantid.kernel import logger
class MyNamePython(PythonAlgorithm):
    def category(self):
        return 'Testing'
    def alias(self):
        return 'MyAliasPython'
    def PyInit(self):
        self.declareProperty('Meaning', 42, 'Assign a meaning to the Universe')
    def PyExec(self):
        logger.error(f'The meaning of the Universe is {self.getPropertyValue("Meaning")}')
AlgorithmFactory.subscribe(MyNamePython)
```
Check now that  `MyNamePython` and `MyAliasPython` are both accesible from the algorithm browser widget

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
