### PR TITLE
New method "get" for the ConfigService class

### DIFF
--- a/Framework/PythonInterface/mantid/kernel/src/Exports/ConfigService.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Exports/ConfigService.cpp
@@ -54,7 +54,7 @@ const InstrumentInfo &getInstrument(ConfigServiceImpl &self, const object &name 
 std::string getStringUsingCacheElseDefault(ConfigServiceImpl &self, const std::string &key,
                                            const std::string &defaultValue) {
   std::vector<std::string> keys = self.keys();
-  if (std::find(keys.begin(), keys.end(), key) != keys.end())
+  if (self.hasProperty(key))
     return self.getString(key, true);
   else
     return defaultValue;
@@ -144,9 +144,12 @@ void export_ConfigService() {
       .def("keys", &ConfigServiceImpl::keys, arg("self"))
 
       // Treat this as a dictionary
-      .def("get", &getStringUsingCache, (arg("self"), arg("key")))
+      .def("get", &getStringUsingCache, (arg("self"), arg("key")),
+           "get the string value of a property; return empty string value if the property "
+           "is not found in the configuration")
       .def("get", &getStringUsingCacheElseDefault, (arg("self"), arg("key")), arg("default"),
-           "get the value of a property; return a default value if the property is not found in the configuration")
+           "get the string value of a property; return a default string value if the property "
+           "is not found in the configuration")
       .def("__getitem__", &getStringUsingCache, (arg("self"), arg("key")))
       .def("__setitem__", &ConfigServiceImpl::setString, (arg("self"), arg("key"), arg("value")))
       .def("__contains__", &ConfigServiceImpl::hasProperty, (arg("self"), arg("key")))

--- a/Framework/PythonInterface/mantid/kernel/src/Exports/ConfigService.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Exports/ConfigService.cpp
@@ -53,10 +53,11 @@ const InstrumentInfo &getInstrument(ConfigServiceImpl &self, const object &name 
 /// duck typing emulating dict.get method
 std::string getStringUsingCacheElseDefault(ConfigServiceImpl &self, const std::string &key,
                                            const std::string &defaultValue) {
-  std::string value = self.getString(key, true);
-  if (value.empty())
+  std::vector<std::string> keys = self.keys();
+  if (std::find(keys.begin(), keys.end(), key) != keys.end())
+    return self.getString(key, true);
+  else
     return defaultValue;
-  return value;
 }
 
 GNU_DIAG_OFF("unused-local-typedef")
@@ -143,6 +144,7 @@ void export_ConfigService() {
       .def("keys", &ConfigServiceImpl::keys, arg("self"))
 
       // Treat this as a dictionary
+      .def("get", &getStringUsingCache, (arg("self"), arg("key")))
       .def("get", &getStringUsingCacheElseDefault, (arg("self"), arg("key")), arg("default"),
            "get the value of a property; return a default value if the property is not found in the configuration")
       .def("__getitem__", &getStringUsingCache, (arg("self"), arg("key")))

--- a/Framework/PythonInterface/mantid/kernel/src/Exports/ConfigService.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Exports/ConfigService.cpp
@@ -50,6 +50,15 @@ const InstrumentInfo &getInstrument(ConfigServiceImpl &self, const object &name 
     return self.getInstrument(ExtractStdString(name)());
 }
 
+/// duck typing emulating dict.get method
+std::string getStringUsingCacheElseDefault(ConfigServiceImpl &self, const std::string &key,
+                                           const std::string &defaultValue) {
+  std::string value = self.getString(key, true);
+  if (value.empty())
+    return defaultValue;
+  return value;
+}
+
 GNU_DIAG_OFF("unused-local-typedef")
 // Ignore -Wconversion warnings coming from boost::python
 // Seen with GCC 7.1.1 and Boost 1.63.0
@@ -134,6 +143,8 @@ void export_ConfigService() {
       .def("keys", &ConfigServiceImpl::keys, arg("self"))
 
       // Treat this as a dictionary
+      .def("get", &getStringUsingCacheElseDefault, (arg("self"), arg("key")), arg("default"),
+           "get the value of a property; return a default value if the property is not found in the configuration")
       .def("__getitem__", &getStringUsingCache, (arg("self"), arg("key")))
       .def("__setitem__", &ConfigServiceImpl::setString, (arg("self"), arg("key"), arg("value")))
       .def("__contains__", &ConfigServiceImpl::hasProperty, (arg("self"), arg("key")))

--- a/Framework/PythonInterface/test/python/mantid/kernel/ConfigServiceTest.py
+++ b/Framework/PythonInterface/test/python/mantid/kernel/ConfigServiceTest.py
@@ -64,6 +64,9 @@ class ConfigServiceTest(unittest.TestCase):
         self.assertRaises(RuntimeError, config.getInstrument, "MadeUpInstrument")
 
     def test_service_acts_like_dictionary(self):
+        dictcall = config.get("property_not_found")
+        self.assertEqual(dictcall, "")
+
         test_prop = "projectRecovery.secondsBetween"
         self.assertTrue(config.hasProperty(test_prop))
         dictcall = config[test_prop]

--- a/Framework/PythonInterface/test/python/mantid/kernel/ConfigServiceTest.py
+++ b/Framework/PythonInterface/test/python/mantid/kernel/ConfigServiceTest.py
@@ -68,13 +68,22 @@ class ConfigServiceTest(unittest.TestCase):
         self.assertTrue(config.hasProperty(test_prop))
         dictcall = config[test_prop]
         fncall = config.getString(test_prop)
+
+        # Use brackets to retrieve a value
+        dictcall = config[test_prop]
         self.assertEqual(dictcall, fncall)
         self.assertNotEqual(config[test_prop], "")
+
+        # Use "get" to retrieve a value or a default
+        dictcall = config.get(test_prop, "other")
+        self.assertEqual(dictcall, fncall)
+        dictcall = config.get("property_not_found", "default_alternative")
+        self.assertEqual(dictcall, "default_alternative")
 
         old_value = fncall
         config.setString(test_prop, "1")
         self.assertEqual(config.getString(test_prop), "1")
-        config[test_prop] =  "2"
+        config[test_prop] = "2"
         self.assertEqual(config.getString(test_prop), "2")
 
         config.setString(test_prop, old_value)


### PR DESCRIPTION
Companion to PR #32506 

Description:
===========
The python API of Mantid's `ConfigService` class duck-types the python dictionary, but it doesn't have a `.get` method, e.g.
```python
from mantid.kernel import ConfigService
conf = ConfigService.Instance()
behavior = conf.get('algorithms.alias.deprecated', 'Warn')
```
The default value `Warn` above avoids some boiler plate code with a `try..except` block:
```python
try:
    behavior = conf['algorithms.alias.deprecated']
except AttributeError:
    behavior = 'Warn'
```

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
