### PR TITLE
Ignore NaNs in NormaliseSpectra

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/NormaliseSpectra.py
+++ b/Framework/PythonInterface/plugins/algorithms/NormaliseSpectra.py
@@ -44,7 +44,7 @@ class NormaliseSpectra(DataProcessorAlgorithm):
         for idx in range(num_hists):
             single_spectrum = ExtractSpectra(InputWorkspace=self._input_ws, WorkspaceIndexList=idx)
             y_data = single_spectrum.readY(0)
-            ymax = np.amax(y_data)
+            ymax = np.nanmax(y_data)
             # raises a RuntimeError if the ymax is <= 0
             if ymax <= 0:
                 spectrum_no = single_spectrum.getSpectrum(0).getSpectrumNo()

--- a/Framework/PythonInterface/test/python/plugins/algorithms/NormaliseSpectraTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/NormaliseSpectraTest.py
@@ -6,6 +6,7 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 import unittest
 import platform
+import numpy
 from mantid.simpleapi import *
 from mantid.api import MatrixWorkspace, WorkspaceGroup
 
@@ -45,6 +46,11 @@ class NormaliseSpectraTest(unittest.TestCase):
         out_ws = NormaliseSpectra(InputWorkspace=in_ws)
         self._check_workspace_is_within_boundaries(out_ws, 1, 0)
 
+    def test_with_nan(self):
+        in_ws = self._create_workspace(1, 'test', "nan,2,3,4,5")
+        out_ws = NormaliseSpectra(InputWorkspace=in_ws)
+        self._check_workspace_is_within_boundaries(out_ws, 1, 0)
+
 #--------------------------------Validate results-----------------------------------------
 
     def _check_workspace_is_within_boundaries(self, matrixWs, max, min):
@@ -54,10 +60,14 @@ class NormaliseSpectraTest(unittest.TestCase):
 
     def _check_spectrum_less_than(self, y_data, upper_boundary):
         for i in range(len(y_data)):
+            if numpy.isnan(y_data[i]):
+                continue
             self.assertLessEqual(y_data[i], upper_boundary)
 
     def _check_spectrum_more_than(self, y_data, lower_boundary):
         for i in range(len(y_data)):
+            if numpy.isnan(y_data[i]):
+                continue
             self.assertGreaterEqual(y_data[i], lower_boundary)
 
 #--------------------------------Helper Functions-----------------------------------------


### PR DESCRIPTION
**Description of work.**

With this PR, the NaNs are now ignored in `NormaliseSpectra`.

**To test:**

Use the script provided in the issue description.

Fixes #32510

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
