### PR TITLE
Add try catch to FunctionTreeView

### DIFF
--- a/docs/source/release/v6.2.0/muon.rst
+++ b/docs/source/release/v6.2.0/muon.rst
@@ -32,6 +32,7 @@ Bugfixes
 - In frequency domain analysis the phasetables calculated from :ref:`MuonMaxent <algm-MuonMaxent>` can be used for
   :ref:`PhaseQuad <algm-PhaseQuad>` calculations on the phase tab.
 - A bug has been fixed in ALC that caused mantid to crash when a user changed the PeakPicker in the PeakFitting plot.
+- A bug has been fixed in ALC where setting an invalid function would cause a crash.
 
 Muon Analysis
 -------------

--- a/qt/widgets/common/src/FunctionTreeView.cpp
+++ b/qt/widgets/common/src/FunctionTreeView.cpp
@@ -1903,22 +1903,28 @@ void FunctionTreeView::attributeChanged(QtProperty *prop) {
   // Some attributes require the function to be fully reconstructed, in this
   // case we'd need to emit a function replaced signal. If its not one of these
   // attributes emit an attributeValueChanged signal.
-  if (std::find(REQUIRESRECONSTRUCTIONATTRIBUTES.begin(), REQUIRESRECONSTRUCTIONATTRIBUTES.end(),
-                removePrefix(attributeName)) != REQUIRESRECONSTRUCTIONATTRIBUTES.end()) {
-    auto funProp = m_properties[prop].parent;
-    if (!funProp)
-      return;
-    auto fun = getFunction(funProp, true);
+  try {
+    if (std::find(REQUIRESRECONSTRUCTIONATTRIBUTES.begin(), REQUIRESRECONSTRUCTIONATTRIBUTES.end(),
+                  removePrefix(attributeName)) != REQUIRESRECONSTRUCTIONATTRIBUTES.end()) {
+      auto funProp = m_properties[prop].parent;
+      if (!funProp)
+        return;
+      auto fun = getFunction(funProp, true);
 
-    // delete and recreate all function's properties (attributes, parameters,
-    // etc)
-    setFunction(funProp, fun);
-    updateFunctionIndices();
-    if (m_emitAttributeValueChange)
-      emit functionReplaced(QString::fromStdString(getFunction()->asString()));
-  } else {
-    if (m_emitAttributeValueChange)
-      emit attributePropertyChanged(attributeName);
+      // delete and recreate all function's properties (attributes, parameters,
+      // etc)
+      setFunction(funProp, fun);
+      updateFunctionIndices();
+      if (m_emitAttributeValueChange) {
+        emit functionReplaced(QString::fromStdString(getFunction()->asString()));
+      }
+    } else {
+      if (m_emitAttributeValueChange) {
+        emit attributePropertyChanged(attributeName);
+      }
+    }
+  } catch (std::exception &expt) {
+    QMessageBox::critical(this, "Mantid - Error", QString::fromStdString(expt.what()));
   }
 }
 


### PR DESCRIPTION
**Description of work.**

This PR adds a try catch statement to FunctionTreeView stop a crash in ALC.

**To test:**

1. Open ALC
2. Go to the Baseline Modelling section.
3. Add the Chebyshev function
4. Set n to -1.
5. a series of error dialogues should appear but there should be no crash.
6. repeat on the peak fitting tab

Fixes #32498


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
