### PR TITLE
Add ability to rotate Ellipse and Rectangle shapes in Instrument Viewer Widget

### DIFF
--- a/docs/source/release/v6.3.0/mantidworkbench.rst
+++ b/docs/source/release/v6.3.0/mantidworkbench.rst
@@ -8,6 +8,8 @@ Mantid Workbench Changes
 New and Improved
 ----------------
 
+- Add ability to rotate Ellipse and Rectangle shapes in :ref:`InstrumentViewer`.
+
 Bugfixes
 --------
 - Fixed arbitrary values not being accepted as the "Start Time" in StartLiveDataDialog.

--- a/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/InstrumentWidgetMaskTab.h
+++ b/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/InstrumentWidgetMaskTab.h
@@ -208,6 +208,7 @@ protected:
   QtProperty *m_top;
   QtProperty *m_right;
   QtProperty *m_bottom;
+  QtProperty *m_rotation;
 
   QMap<QtProperty *, QString> m_doublePropertyMap;
   QMap<QString, QtProperty *> m_pointPropertyMap;

--- a/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/InstrumentWidgetMaskTab.h
+++ b/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/InstrumentWidgetMaskTab.h
@@ -146,6 +146,7 @@ private:
   void loadMaskViewFromProject(const std::string &name);
   /// Run the LoadMask algorithm to get a MaskWorkspace
   std::shared_ptr<Mantid::API::MatrixWorkspace> loadMask(const std::string &fileName);
+  bool isRotationSupported();
 
 protected:
   /// Is it used?

--- a/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/ProjectionSurface.h
+++ b/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/ProjectionSurface.h
@@ -167,6 +167,20 @@ public:
   /// This method resizes the shape to fit into the new rectangle.
   void setCurrentBoundingRect(const RectF &rect) { m_maskShapes.setCurrentBoundingRect(rect); }
 
+  /// Return bounding rotation of the currently selected shape in the "original"
+  /// coord system.
+  /// It doesn't depend on the zooming of the surface
+  double getCurrentBoundingRotation() const {
+    return m_maskShapes.getCurrentBoundingRotation();
+  }
+
+  /// Set new bounding rect of the currently selected shape in the "original"
+  /// coord system.
+  /// This method resizes the shape to fit into the new rectangle.
+  void setCurrentBoundingRotation(const double rotation) {
+    m_maskShapes.setCurrentBoundingRotation(rotation);
+  }
+
   /// Initialize interactive shape creation.
   /// @param type :: Type of the shape. For available types see code of
   /// Shape2DCollection::createShape(const QString& type,int x,int y) const

--- a/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/ProjectionSurface.h
+++ b/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/ProjectionSurface.h
@@ -170,20 +170,14 @@ public:
   /// Return bounding rotation of the currently selected shape in the "original"
   /// coord system.
   /// It doesn't depend on the zooming of the surface
-  double getCurrentBoundingRotation() const {
-    return m_maskShapes.getCurrentBoundingRotation();
-  }
+  double getCurrentBoundingRotation() const { return m_maskShapes.getCurrentBoundingRotation(); }
 
   /// Set new bounding rect of the currently selected shape in the "original"
   /// coord system.
   /// This method resizes the shape to fit into the new rectangle.
-  void setCurrentBoundingRotation(const double rotation) {
-    m_maskShapes.setCurrentBoundingRotation(rotation);
-  }
+  void setCurrentBoundingRotation(const double rotation) { m_maskShapes.setCurrentBoundingRotation(rotation); }
 
-  std::string getCurrentShapeType() const {
-    return m_maskShapes.getCurrentShapeType();
-  }
+  std::string getCurrentShapeType() const { return m_maskShapes.getCurrentShapeType(); }
 
   /// Initialize interactive shape creation.
   /// @param type :: Type of the shape. For available types see code of

--- a/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/ProjectionSurface.h
+++ b/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/ProjectionSurface.h
@@ -181,6 +181,10 @@ public:
     m_maskShapes.setCurrentBoundingRotation(rotation);
   }
 
+  std::string getCurrentShapeType() const {
+    return m_maskShapes.getCurrentShapeType();
+  }
+
   /// Initialize interactive shape creation.
   /// @param type :: Type of the shape. For available types see code of
   /// Shape2DCollection::createShape(const QString& type,int x,int y) const

--- a/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/Shape2D.h
+++ b/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/Shape2D.h
@@ -87,6 +87,10 @@ public:
   virtual void adjustBoundingRect(double dx1, double dy1, double dx2, double dy2);
   /// Set new bounding rect.
   virtual void setBoundingRect(const RectF &rect);
+  /// Return the bounding rotation of the shape.
+  virtual double getBoundingRotation() const { return m_boundingRotation; }
+  /// Set new bounding rotation
+  virtual void setBoundingRotation(const double rotation) { m_boundingRotation = rotation; };
   /// will the shape be selected if clicked at a point? By default return false.
   virtual bool selectAt(const QPointF & /*unused*/) const { return false; }
   /// is a point inside the shape (closed line)? By default return false.
@@ -175,6 +179,7 @@ protected:
   static const size_t NCommonCP;
   static const qreal sizeCP;
   RectF m_boundingRect;
+  double m_boundingRotation = 0.0;
   QColor m_color;
   QColor m_fill_color;
   bool m_scalable; ///< shape can be scaled when zoomed

--- a/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/Shape2DCollection.h
+++ b/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/Shape2DCollection.h
@@ -71,6 +71,8 @@ public:
 
   RectF getCurrentBoundingRect() const;
   void setCurrentBoundingRect(const RectF &rect);
+  double getCurrentBoundingRotation() const;
+  void setCurrentBoundingRotation(const double rotation);
   // double properties
   QStringList getCurrentDoubleNames() const;
   double getCurrentDouble(const QString &prop) const;

--- a/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/Shape2DCollection.h
+++ b/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/Shape2DCollection.h
@@ -73,6 +73,7 @@ public:
   void setCurrentBoundingRect(const RectF &rect);
   double getCurrentBoundingRotation() const;
   void setCurrentBoundingRotation(const double rotation);
+  std::string getCurrentShapeType() const;
   // double properties
   QStringList getCurrentDoubleNames() const;
   double getCurrentDouble(const QString &prop) const;

--- a/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/Shape2DCollection.h
+++ b/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/Shape2DCollection.h
@@ -99,8 +99,7 @@ public:
   /// Save shape collection to a Table workspace
   void saveToTableWorkspace();
   /// Load shape collectio from a Table workspace
-  void
-  loadFromTableWorkspace(const Mantid::API::ITableWorkspace_const_sptr &ws);
+  void loadFromTableWorkspace(const Mantid::API::ITableWorkspace_const_sptr &ws);
   /// Load settings for the shape 2D collection from a project file
   virtual void loadFromProject(const std::string &lines);
   /// Save settings for the shape 2D collection to a project file
@@ -117,10 +116,8 @@ signals:
   void cleared();
 
 public slots:
-  void addShape(const QString &type, int x, int y, const QColor &borderColor,
-                const QColor &fillColor);
-  void addFreeShape(const QPolygonF & /*poly*/, const QColor &borderColor,
-                    const QColor &fillColor);
+  void addShape(const QString &type, int x, int y, const QColor &borderColor, const QColor &fillColor);
+  void addFreeShape(const QPolygonF & /*poly*/, const QColor &borderColor, const QColor &fillColor);
   void deselectAll();
   void moveRightBottomTo(int /*x*/, int /*y*/);
   void selectShapeOrControlPointAt(int x, int y);
@@ -152,19 +149,16 @@ protected:
   QList<Shape2D *> getSelectedShapes() const { return m_selectedShapes; }
 
   QList<Shape2D *> m_shapes;
-  mutable RectF
-      m_surfaceRect; ///< original surface window in "real" coordinates
+  mutable RectF m_surfaceRect; ///< original surface window in "real" coordinates
   mutable double m_wx, m_wy;
   mutable int m_h;                ///< original screen viewport height
   mutable QRect m_viewport;       ///< current screen viewport
   mutable QTransform m_transform; ///< current transform
 
-  Shape2D *m_currentShape; ///< shape selected to edit (change size/shape)
-  size_t m_currentCP;      ///< control point of m_currentShape selected to edit
-  QList<Shape2D *>
-      m_selectedShapes; ///< A list of selected shapes (can be moved or deleted)
-  QList<Shape2D *>
-      m_copiedShapes; ///< A list of shapes to be pasted if requiered
+  Shape2D *m_currentShape;           ///< shape selected to edit (change size/shape)
+  size_t m_currentCP;                ///< control point of m_currentShape selected to edit
+  QList<Shape2D *> m_selectedShapes; ///< A list of selected shapes (can be moved or deleted)
+  QList<Shape2D *> m_copiedShapes;   ///< A list of shapes to be pasted if requiered
   bool m_overridingCursor;
   friend class InstrumentWidgetEncoder;
   friend class InstrumentWidgetDecoder;

--- a/qt/widgets/instrumentview/src/InstrumentWidgetDecoder.cpp
+++ b/qt/widgets/instrumentview/src/InstrumentWidgetDecoder.cpp
@@ -282,8 +282,11 @@ Shape2D *InstrumentWidgetDecoder::decodeEllipse(const QMap<QString, QVariant> &m
   const auto radius2 = map[QString("radius2")].toDouble();
   const auto x = map[QString("x")].toDouble();
   const auto y = map[QString("y")].toDouble();
+  const auto rot = map[QString("rotation")].toDouble();
 
-  return new Shape2DEllipse(QPointF(x, y), radius1, radius2);
+  auto shape = new Shape2DEllipse(QPointF(x, y), radius1, radius2);
+  shape->setBoundingRotation(rot);
+  return shape;
 }
 
 Shape2D *InstrumentWidgetDecoder::decodeRectangle(const QMap<QString, QVariant> &map) {
@@ -291,10 +294,13 @@ Shape2D *InstrumentWidgetDecoder::decodeRectangle(const QMap<QString, QVariant> 
   const auto y0 = map[QString("y0")].toDouble();
   const auto x1 = map[QString("x1")].toDouble();
   const auto y1 = map[QString("y1")].toDouble();
+  const auto rot = map[QString("rotation")].toDouble();
 
   const QPointF point1(x0, y0);
   const QPointF point2(x1, y1);
-  return new Shape2DRectangle(point1, point2);
+  auto shape = new Shape2DRectangle(point1, point2);
+  shape->setBoundingRotation(rot);
+  return shape;
 }
 
 Shape2D *InstrumentWidgetDecoder::decodeRing(const QMap<QString, QVariant> &map) {

--- a/qt/widgets/instrumentview/src/InstrumentWidgetEncoder.cpp
+++ b/qt/widgets/instrumentview/src/InstrumentWidgetEncoder.cpp
@@ -323,6 +323,7 @@ QMap<QString, QVariant> InstrumentWidgetEncoder::encodeEllipse(const Shape2DElli
   const double radius1 = obj->getDouble("radius1");
   const double radius2 = obj->getDouble("radius2");
   const auto centre = obj->getPoint("centre");
+  const auto rot = obj->getBoundingRotation();
 
   QMap<QString, QVariant> map;
 
@@ -330,6 +331,7 @@ QMap<QString, QVariant> InstrumentWidgetEncoder::encodeEllipse(const Shape2DElli
   map.insert(QString("radius2"), QVariant(radius2));
   map.insert(QString("x"), QVariant(centre.x()));
   map.insert(QString("y"), QVariant(centre.y()));
+  map.insert(QString("rotation"), QVariant(rot));
 
   return map;
 }
@@ -339,6 +341,7 @@ QMap<QString, QVariant> InstrumentWidgetEncoder::encodeRectangle(const Shape2DRe
   const auto x1 = obj->m_boundingRect.x1();
   const auto y0 = obj->m_boundingRect.y0();
   const auto y1 = obj->m_boundingRect.y1();
+  const auto rot = obj->getBoundingRotation();
 
   QMap<QString, QVariant> map;
 
@@ -346,6 +349,7 @@ QMap<QString, QVariant> InstrumentWidgetEncoder::encodeRectangle(const Shape2DRe
   map.insert(QString("y0"), QVariant(y0));
   map.insert(QString("x1"), QVariant(x1));
   map.insert(QString("y1"), QVariant(y1));
+  map.insert(QString("rotation"), QVariant(rot));
 
   return map;
 }

--- a/qt/widgets/instrumentview/src/InstrumentWidgetMaskTab.cpp
+++ b/qt/widgets/instrumentview/src/InstrumentWidgetMaskTab.cpp
@@ -75,7 +75,7 @@ namespace MantidQt::MantidWidgets {
 InstrumentWidgetMaskTab::InstrumentWidgetMaskTab(InstrumentWidget *instrWidget)
     : InstrumentWidgetTab(instrWidget), m_activity(Select), m_hasMaskToApply(false), m_maskBins(false),
       m_userEditing(true), m_groupManager(nullptr), m_stringManager(nullptr), m_doubleManager(nullptr),
-      m_browser(nullptr), m_left(nullptr), m_top(nullptr), m_right(nullptr), m_bottom(nullptr) {
+      m_browser(nullptr), m_left(nullptr), m_top(nullptr), m_right(nullptr), m_bottom(nullptr), m_rotation(nullptr) {
 
   // main layout
   QVBoxLayout *layout = new QVBoxLayout(this);
@@ -564,6 +564,7 @@ void InstrumentWidgetMaskTab::shapeChanged() {
   m_doubleManager->setValue(m_top, std::max(rect.y0(), rect.y1()));
   m_doubleManager->setValue(m_right, std::max(rect.x0(), rect.x1()));
   m_doubleManager->setValue(m_bottom, std::min(rect.y0(), rect.y1()));
+
   for (QMap<QtProperty *, QString>::iterator it = m_doublePropertyMap.begin(); it != m_doublePropertyMap.end(); ++it) {
     m_doubleManager->setValue(it.key(), m_instrWidget->getSurface()->getCurrentDouble(it.value()));
   }
@@ -628,8 +629,8 @@ void InstrumentWidgetMaskTab::setProperties() {
   boundingRectGroup->addSubProperty(m_top);
   boundingRectGroup->addSubProperty(m_right);
   boundingRectGroup->addSubProperty(m_bottom);
-  
-  if(isRotationSupported()) {
+
+  if (isRotationSupported()) {
     m_rotation = addDoubleProperty("rotation");
     boundingRectGroup->addSubProperty(m_rotation);
   }
@@ -656,8 +657,8 @@ void InstrumentWidgetMaskTab::setProperties() {
     m_doublePropertyMap[prop] = name;
   }
 
-  //rotation property
-  if(isRotationSupported())
+  // rotation property
+  if (isRotationSupported())
     m_doubleManager->setValue(m_rotation, m_instrWidget->getSurface()->getCurrentBoundingRotation());
 
   shapeChanged();
@@ -682,8 +683,8 @@ void InstrumentWidgetMaskTab::doubleChanged(QtProperty *prop) {
     QRectF rect(QPointF(x0, y0), QPointF(x1, y1));
     m_instrWidget->getSurface()->setCurrentBoundingRect(RectF(rect));
 
-    if(isRotationSupported())
-        m_instrWidget->getSurface()->setCurrentBoundingRotation(m_doubleManager->value(m_rotation));
+    if (isRotationSupported())
+      m_instrWidget->getSurface()->setCurrentBoundingRotation(m_doubleManager->value(m_rotation));
 
   } else {
     QString name = m_doublePropertyMap[prop];
@@ -1436,7 +1437,7 @@ bool InstrumentWidgetMaskTab::saveMaskViewToProject(const std::string &name, con
   return true;
 }
 
-bool InstrumentWidgetMaskTab::isRotationSupported(){
+bool InstrumentWidgetMaskTab::isRotationSupported() {
   const auto shapeType = m_instrWidget->getSurface()->getCurrentShapeType();
   return shapeType == "rectangle" || shapeType == "ellipse";
 }

--- a/qt/widgets/instrumentview/src/InstrumentWidgetMaskTab.cpp
+++ b/qt/widgets/instrumentview/src/InstrumentWidgetMaskTab.cpp
@@ -652,6 +652,9 @@ void InstrumentWidgetMaskTab::setProperties() {
     m_doublePropertyMap[prop] = name;
   }
 
+  //rotation property
+  m_doubleManager->setValue(m_rotation, m_instrWidget->getSurface()->getCurrentBoundingRotation());
+
   shapeChanged();
 }
 
@@ -673,6 +676,7 @@ void InstrumentWidgetMaskTab::doubleChanged(QtProperty *prop) {
 
     QRectF rect(QPointF(x0, y0), QPointF(x1, y1));
     m_instrWidget->getSurface()->setCurrentBoundingRect(RectF(rect));
+    m_instrWidget->getSurface()->setCurrentBoundingRotation(m_doubleManager->value(m_rotation));
 
   } else {
     QString name = m_doublePropertyMap[prop];

--- a/qt/widgets/instrumentview/src/InstrumentWidgetMaskTab.cpp
+++ b/qt/widgets/instrumentview/src/InstrumentWidgetMaskTab.cpp
@@ -609,6 +609,7 @@ void InstrumentWidgetMaskTab::clearProperties() {
   m_top = nullptr;
   m_right = nullptr;
   m_bottom = nullptr;
+  m_rotation = nullptr;
 }
 
 void InstrumentWidgetMaskTab::setProperties() {
@@ -622,10 +623,12 @@ void InstrumentWidgetMaskTab::setProperties() {
   m_top = addDoubleProperty("top");
   m_right = addDoubleProperty("right");
   m_bottom = addDoubleProperty("bottom");
+  m_rotation = addDoubleProperty("rotation");
   boundingRectGroup->addSubProperty(m_left);
   boundingRectGroup->addSubProperty(m_top);
   boundingRectGroup->addSubProperty(m_right);
   boundingRectGroup->addSubProperty(m_bottom);
+  boundingRectGroup->addSubProperty(m_rotation);
 
   // point properties
   QStringList pointProperties = m_instrWidget->getSurface()->getCurrentPointNames();
@@ -661,7 +664,7 @@ void InstrumentWidgetMaskTab::doubleChanged(QtProperty *prop) {
   if (!m_userEditing)
     return;
 
-  if (prop == m_left || prop == m_top || prop == m_right || prop == m_bottom) {
+  if (prop == m_left || prop == m_top || prop == m_right || prop == m_bottom || prop == m_rotation) {
     m_userEditing = false;
     double x0 = std::min(m_doubleManager->value(m_left), m_doubleManager->value(m_right));
     double x1 = std::max(m_doubleManager->value(m_left), m_doubleManager->value(m_right));

--- a/qt/widgets/instrumentview/src/InstrumentWidgetMaskTab.cpp
+++ b/qt/widgets/instrumentview/src/InstrumentWidgetMaskTab.cpp
@@ -623,12 +623,16 @@ void InstrumentWidgetMaskTab::setProperties() {
   m_top = addDoubleProperty("top");
   m_right = addDoubleProperty("right");
   m_bottom = addDoubleProperty("bottom");
-  m_rotation = addDoubleProperty("rotation");
+
   boundingRectGroup->addSubProperty(m_left);
   boundingRectGroup->addSubProperty(m_top);
   boundingRectGroup->addSubProperty(m_right);
   boundingRectGroup->addSubProperty(m_bottom);
-  boundingRectGroup->addSubProperty(m_rotation);
+  
+  if(isRotationSupported()) {
+    m_rotation = addDoubleProperty("rotation");
+    boundingRectGroup->addSubProperty(m_rotation);
+  }
 
   // point properties
   QStringList pointProperties = m_instrWidget->getSurface()->getCurrentPointNames();
@@ -653,7 +657,8 @@ void InstrumentWidgetMaskTab::setProperties() {
   }
 
   //rotation property
-  m_doubleManager->setValue(m_rotation, m_instrWidget->getSurface()->getCurrentBoundingRotation());
+  if(isRotationSupported())
+    m_doubleManager->setValue(m_rotation, m_instrWidget->getSurface()->getCurrentBoundingRotation());
 
   shapeChanged();
 }
@@ -676,7 +681,9 @@ void InstrumentWidgetMaskTab::doubleChanged(QtProperty *prop) {
 
     QRectF rect(QPointF(x0, y0), QPointF(x1, y1));
     m_instrWidget->getSurface()->setCurrentBoundingRect(RectF(rect));
-    m_instrWidget->getSurface()->setCurrentBoundingRotation(m_doubleManager->value(m_rotation));
+
+    if(isRotationSupported())
+        m_instrWidget->getSurface()->setCurrentBoundingRotation(m_doubleManager->value(m_rotation));
 
   } else {
     QString name = m_doublePropertyMap[prop];
@@ -1427,6 +1434,11 @@ bool InstrumentWidgetMaskTab::saveMaskViewToProject(const std::string &name, con
   }
 
   return true;
+}
+
+bool InstrumentWidgetMaskTab::isRotationSupported(){
+  const auto shapeType = m_instrWidget->getSurface()->getCurrentShapeType();
+  return shapeType == "rectangle" || shapeType == "ellipse";
 }
 
 } // namespace MantidQt::MantidWidgets

--- a/qt/widgets/instrumentview/src/Shape2D.cpp
+++ b/qt/widgets/instrumentview/src/Shape2D.cpp
@@ -392,13 +392,19 @@ bool Shape2DRectangle::selectAt(const QPointF &p) const {
 }
 
 void Shape2DRectangle::drawShape(QPainter &painter) const {
-  QRectF drawRect = m_boundingRect.toQRectF();
+  auto center = m_boundingRect.center();
+  QRectF drawRect = m_boundingRect.translated(-center).toQRectF();
+  painter.save();
+  double rotation = 20;
+  painter.rotate(rotation);
+  painter.translate(QTransform().rotate(-rotation).map(center));
   painter.drawRect(drawRect);
   if (m_fill_color != QColor()) {
     QPainterPath path;
     path.addRect(drawRect);
     painter.fillPath(path, m_fill_color);
   }
+  painter.restore();
 }
 
 void Shape2DRectangle::addToPath(QPainterPath &path) const { path.addRect(m_boundingRect.toQRectF()); }

--- a/qt/widgets/instrumentview/src/Shape2D.cpp
+++ b/qt/widgets/instrumentview/src/Shape2D.cpp
@@ -48,8 +48,15 @@ void Shape2D::draw(QPainter &painter) const {
   painter.setPen(QPen(m_color, 0));
   this->drawShape(painter);
   if (m_editing || m_selected) {
+    auto center = m_boundingRect.center();
+    QRectF drawRect = m_boundingRect.translated(-center).toQRectF();
+    painter.save();
+    double rotation = 20;
+    painter.rotate(rotation);
+    painter.translate(QTransform().rotate(-rotation).map(center));
     painter.setPen(QPen(QColor(255, 255, 255, 100), 0));
-    painter.drawRect(m_boundingRect.toQRectF());
+    painter.drawRect(drawRect);
+    painter.restore();
     size_t np = NCommonCP;
     double rsize = 2;
     int alpha = 100;
@@ -88,8 +95,13 @@ QPointF Shape2D::getControlPoint(size_t i) const {
     throw std::range_error("Control point index is out of range");
   }
 
-  if (i < 4)
-    return m_boundingRect.vertex(i);
+  if (i < 4) {
+    auto center = m_boundingRect.center();
+    QPointF vertex = m_boundingRect.vertex(i);
+    double rotation = 20;
+    vertex = QTransform().rotate(rotation).map(vertex-center)+center;
+    return vertex;
+  }
 
   return getShapeControlPoint(i - NCommonCP);
 }
@@ -100,7 +112,9 @@ void Shape2D::setControlPoint(size_t i, const QPointF &pos) {
   }
 
   if (i < 4) {
-    m_boundingRect.setVertex(i, pos);
+    auto center = m_boundingRect.center();
+    double rotation = 20;
+    m_boundingRect.setVertex(i, QTransform().rotate(-rotation).map(pos-center)+center);
 
     refit();
   }
@@ -381,7 +395,9 @@ Shape2DRectangle::Shape2DRectangle(const QPointF &p0, const QSizeF &size) { m_bo
 
 bool Shape2DRectangle::selectAt(const QPointF &p) const {
   if (m_fill_color != QColor()) { // filled rectangle
-    return contains(p);
+    auto center = m_boundingRect.center();
+    double rotation = 20;
+    return contains(QTransform().rotate(-rotation).map(p-center)+center);
   }
 
   RectF outer(m_boundingRect);

--- a/qt/widgets/instrumentview/src/Shape2D.cpp
+++ b/qt/widgets/instrumentview/src/Shape2D.cpp
@@ -51,9 +51,8 @@ void Shape2D::draw(QPainter &painter) const {
     auto center = m_boundingRect.center();
     QRectF drawRect = m_boundingRect.translated(-center).toQRectF();
     painter.save();
-    double rotation = 20;
-    painter.rotate(rotation);
-    painter.translate(QTransform().rotate(-rotation).map(center));
+    painter.rotate(m_boundingRotation);
+    painter.translate(QTransform().rotate(-m_boundingRotation).map(center));
     painter.setPen(QPen(QColor(255, 255, 255, 100), 0));
     painter.drawRect(drawRect);
     painter.restore();
@@ -98,8 +97,7 @@ QPointF Shape2D::getControlPoint(size_t i) const {
   if (i < 4) {
     auto center = m_boundingRect.center();
     QPointF vertex = m_boundingRect.vertex(i);
-    double rotation = 20;
-    vertex = QTransform().rotate(rotation).map(vertex-center)+center;
+    vertex = QTransform().rotate(m_boundingRotation).map(vertex-center)+center;
     return vertex;
   }
 
@@ -113,8 +111,7 @@ void Shape2D::setControlPoint(size_t i, const QPointF &pos) {
 
   if (i < 4) {
     auto center = m_boundingRect.center();
-    double rotation = 20;
-    m_boundingRect.setVertex(i, QTransform().rotate(-rotation).map(pos-center)+center);
+    m_boundingRect.setVertex(i, QTransform().rotate(-m_boundingRotation).map(pos-center)+center);
 
     refit();
   }
@@ -396,8 +393,7 @@ Shape2DRectangle::Shape2DRectangle(const QPointF &p0, const QSizeF &size) { m_bo
 bool Shape2DRectangle::selectAt(const QPointF &p) const {
   if (m_fill_color != QColor()) { // filled rectangle
     auto center = m_boundingRect.center();
-    double rotation = 20;
-    return contains(QTransform().rotate(-rotation).map(p-center)+center);
+    return contains(QTransform().rotate(-m_boundingRotation).map(p-center)+center);
   }
 
   RectF outer(m_boundingRect);
@@ -411,9 +407,8 @@ void Shape2DRectangle::drawShape(QPainter &painter) const {
   auto center = m_boundingRect.center();
   QRectF drawRect = m_boundingRect.translated(-center).toQRectF();
   painter.save();
-  double rotation = 20;
-  painter.rotate(rotation);
-  painter.translate(QTransform().rotate(-rotation).map(center));
+  painter.rotate(m_boundingRotation);
+  painter.translate(QTransform().rotate(-m_boundingRotation).map(center));
   painter.drawRect(drawRect);
   if (m_fill_color != QColor()) {
     QPainterPath path;

--- a/qt/widgets/instrumentview/src/Shape2D.cpp
+++ b/qt/widgets/instrumentview/src/Shape2D.cpp
@@ -281,7 +281,8 @@ void Shape2DEllipse::addToPath(QPainterPath &path) const { path.addEllipse(m_bou
 
 bool Shape2DEllipse::selectAt(const QPointF &p) const {
   if (m_fill_color != QColor()) { // filled ellipse
-    return contains(p);
+    return contains(QTransform().rotate(-m_boundingRotation).map(p - m_boundingRect.center()) +
+                    m_boundingRect.center());
   }
 
   double a = m_boundingRect.xSpan() / 2;

--- a/qt/widgets/instrumentview/src/Shape2D.cpp
+++ b/qt/widgets/instrumentview/src/Shape2D.cpp
@@ -94,7 +94,8 @@ QPointF Shape2D::getControlPoint(size_t i) const {
   }
 
   if (i < 4)
-    return QTransform().rotate(m_boundingRotation).map(m_boundingRect.vertex(i)-m_boundingRect.center())+m_boundingRect.center();
+    return QTransform().rotate(m_boundingRotation).map(m_boundingRect.vertex(i) - m_boundingRect.center()) +
+           m_boundingRect.center();
 
   return getShapeControlPoint(i - NCommonCP);
 }
@@ -105,7 +106,8 @@ void Shape2D::setControlPoint(size_t i, const QPointF &pos) {
   }
 
   if (i < 4) {
-    m_boundingRect.setVertex(i, QTransform().rotate(-m_boundingRotation).map(pos-m_boundingRect.center())+m_boundingRect.center());
+    m_boundingRect.setVertex(i, QTransform().rotate(-m_boundingRotation).map(pos - m_boundingRect.center()) +
+                                    m_boundingRect.center());
 
     refit();
   }
@@ -161,7 +163,8 @@ void Shape2D::setBoundingRect(const RectF &rect) {
  * @param p :: Point to check.
  */
 bool Shape2D::isMasked(const QPointF &p) const {
-  return m_fill_color != QColor() && contains(QTransform().rotate(-m_boundingRotation).map(p-m_boundingRect.center())+m_boundingRect.center());
+  return m_fill_color != QColor() &&
+         contains(QTransform().rotate(-m_boundingRotation).map(p - m_boundingRect.center()) + m_boundingRect.center());
 }
 
 /** Load shape 2D state from a Mantid project file
@@ -261,13 +264,17 @@ Shape2DEllipse::Shape2DEllipse(const QPointF &center, double radius1, double rad
 }
 
 void Shape2DEllipse::drawShape(QPainter &painter) const {
-  QRectF drawRect = m_boundingRect.toQRectF();
+  QRectF drawRect = m_boundingRect.translated(-m_boundingRect.center()).toQRectF();
+  painter.save();
+  painter.rotate(m_boundingRotation);
+  painter.translate(QTransform().rotate(-m_boundingRotation).map(m_boundingRect.center()));
   painter.drawEllipse(drawRect);
   if (m_fill_color != QColor()) {
     QPainterPath path;
     path.addEllipse(drawRect);
     painter.fillPath(path, m_fill_color);
   }
+  painter.restore();
 }
 
 void Shape2DEllipse::addToPath(QPainterPath &path) const { path.addEllipse(m_boundingRect.toQRectF()); }
@@ -388,8 +395,8 @@ Shape2DRectangle::Shape2DRectangle(const QPointF &p0, const QSizeF &size) { m_bo
 
 bool Shape2DRectangle::selectAt(const QPointF &p) const {
   if (m_fill_color != QColor()) { // filled rectangle
-    auto center = m_boundingRect.center();
-    return contains(QTransform().rotate(-m_boundingRotation).map(p-center)+center);
+    return contains(QTransform().rotate(-m_boundingRotation).map(p - m_boundingRect.center()) +
+                    m_boundingRect.center());
   }
 
   RectF outer(m_boundingRect);
@@ -400,11 +407,10 @@ bool Shape2DRectangle::selectAt(const QPointF &p) const {
 }
 
 void Shape2DRectangle::drawShape(QPainter &painter) const {
-  auto center = m_boundingRect.center();
-  QRectF drawRect = m_boundingRect.translated(-center).toQRectF();
+  QRectF drawRect = m_boundingRect.translated(-m_boundingRect.center()).toQRectF();
   painter.save();
   painter.rotate(m_boundingRotation);
-  painter.translate(QTransform().rotate(-m_boundingRotation).map(center));
+  painter.translate(QTransform().rotate(-m_boundingRotation).map(m_boundingRect.center()));
   painter.drawRect(drawRect);
   if (m_fill_color != QColor()) {
     QPainterPath path;

--- a/qt/widgets/instrumentview/src/Shape2DCollection.cpp
+++ b/qt/widgets/instrumentview/src/Shape2DCollection.cpp
@@ -634,6 +634,20 @@ void Shape2DCollection::setCurrentBoundingRect(const RectF &rect) {
   }
 }
 
+double Shape2DCollection::getCurrentBoundingRotation() const {
+  if (m_currentShape) {
+    return m_currentShape->getBoundingRotation();
+  }
+  return 0.0;
+}
+
+void Shape2DCollection::setCurrentBoundingRotation(const double rotation) {
+  if (m_currentShape) {
+    m_currentShape->setBoundingRotation(rotation);
+    emit shapeChanged();
+  }
+}
+
 bool Shape2DCollection::isMasked(double x, double y) const {
   QPointF p(x, y);
   foreach (Shape2D *shape, m_shapes) {

--- a/qt/widgets/instrumentview/src/Shape2DCollection.cpp
+++ b/qt/widgets/instrumentview/src/Shape2DCollection.cpp
@@ -578,6 +578,13 @@ void Shape2DCollection::clear() {
   emit shapesDeselected();
 }
 
+std::string Shape2DCollection::getCurrentShapeType() const {
+  if (m_currentShape) {
+    return m_currentShape->type();
+  }
+  return "none";
+}
+
 QStringList Shape2DCollection::getCurrentDoubleNames() const {
   if (m_currentShape) {
     return m_currentShape->getDoubleNames();


### PR DESCRIPTION
**Description of work.**

This adds the rotation property to Ellipse and Rectangle shape. This does not add control points for rotation.

**To test:**

Draw an Ellipse or Rectangle, then edit the rotation property of that shape.

![2021-09-15-104014_1124x763_scrot](https://user-images.githubusercontent.com/5595210/133454991-f5a28bcf-5abe-48ff-9b19-907c4434dda9.png)

Check that applying as Mask, ROI or Group works as expected.

![2021-09-15-104032_1124x763_scrot](https://user-images.githubusercontent.com/5595210/133455008-a9e1b4fd-284e-4262-abe1-073924a13220.png)

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
