### PR TITLE
Remove assertion difc greater than zero in unit conversion

### DIFF
--- a/Framework/Kernel/src/Unit.cpp
+++ b/Framework/Kernel/src/Unit.cpp
@@ -644,8 +644,6 @@ void dSpacing::init() {
       }
     }
   }
-  // force the assumption that difc is positive in debug builds
-  assert(difc > 0.);
 }
 
 double dSpacing::singleToTOF(const double x) const {
@@ -681,9 +679,6 @@ double dSpacing::singleFromTOF(const double tof) const {
                              "has been initialized.");
   if (!toDSpacingError.empty())
     throw std::runtime_error(toDSpacingError);
-
-  // force the assumption that difc is positive in debug builds
-  assert(difc > 0.);
 
   // non-physical result
   if (tzero > tof) {

--- a/Framework/Kernel/src/Unit.cpp
+++ b/Framework/Kernel/src/Unit.cpp
@@ -596,12 +596,7 @@ Unit *dSpacing::clone() const { return new dSpacing(*this); }
 
 void dSpacing::validateUnitParams(const int, const UnitParametersMap &params) {
   double difc = 0.;
-  if (!ParamPresentAndSet(&params, UnitParams::difc, difc)) {
-    if (!ParamPresent(params, UnitParams::twoTheta) || (!ParamPresent(params, UnitParams::l2)))
-      throw std::runtime_error("A difc value or L2/two theta must be supplied "
-                               "in the extra parameters when initialising " +
-                               this->unitID() + " for conversion via TOF");
-  } else {
+  if (ParamPresentAndSet(&params, UnitParams::difc, difc)) {
     // check validations only applicable to fromTOF
     toDSpacingError = "";
     double difa = 0.;
@@ -614,6 +609,12 @@ void dSpacing::validateUnitParams(const int, const UnitParametersMap &params) {
       toDSpacingError = "A positive difc value must be supplied in the extra parameters when "
                         "initialising " +
                         this->unitID() + " for conversion via TOF";
+    }
+  } else {
+    if (!ParamPresent(params, UnitParams::twoTheta) || (!ParamPresent(params, UnitParams::l2))) {
+      throw std::runtime_error("A difc value or L2/two theta must be supplied "
+                               "in the extra parameters when initialising " +
+                               this->unitID() + " for conversion via TOF");
     }
   }
 }


### PR DESCRIPTION
**Description of work.**
Recently added assertions that difc is >0 in PR #32479 cause exceptions in debug build for common use-case: for example when workspaces have monitors which may have difc = 0.

There is already validation for difc is >=0 in `dSpacing::validateUnitParams` - I don't think the assertions add anything, but I can change them to assert that difc >= 0 instead of removing them if that is preferable.

**To test:**

(1) Run this script without error
```
Load(Filename='ENGINX00193749.nxs', OutputWorkspace='193749')
calib_path = r'C:\mantid\scripts\Engineering\calib\ENGINX_full_instrument_calibration_193749.nxs'
Load(Filename=calib_path, OutputWorkspace='full_inst_calib')
ApplyDiffCal(InstrumentWorkspace='193749', CalibrationWorkspace='full_inst_calib')
ConvertUnits(InputWorkspace='193749', OutputWorkspace='193749', Target='dSpacing')
```

*There is no associated issue.*

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
