### PR TITLE
Fix formatting of milestone link

### DIFF
--- a/docs/source/release/v6.0.0/index.rst
+++ b/docs/source/release/v6.0.0/index.rst
@@ -91,6 +91,6 @@ For a full list of all issues addressed during this release please see the `GitH
 
 .. _forum: https://forum.mantidproject.org
 
-.. _GitHub milestone: https://github.com/mantidproject/mantid/pulls?utf8=%E2%9C%93&q=is%3Apr+milestone%3A"Release Release 6.0"+is%3Amerged
+.. _GitHub milestone: https://github.com/mantidproject/mantid/pulls?utf8=%E2%9C%93&q=is%3Apr+milestone%3A%22Release+6.0%22+is%3Amerged
 
 .. _GitHub release page: https://github.com/mantidproject/mantid/releases/tag/v6.0.0

--- a/docs/source/release/v6.2.0/index.rst
+++ b/docs/source/release/v6.2.0/index.rst
@@ -80,6 +80,6 @@ For a full list of all issues addressed during this release please see the `GitH
 
 .. _forum: https://forum.mantidproject.org
 
-.. _GitHub milestone: https://github.com/mantidproject/mantid/pulls?utf8=%E2%9C%93&q=is%3Apr+milestone%3A"Release 6.2"+is%3Amerged
+.. _GitHub milestone: https://github.com/mantidproject/mantid/pulls?utf8=%E2%9C%93&q=is%3Apr+is%3Amerged+milestone%3A%22Release+6.2%22
 
 .. _GitHub release page: https://github.com/mantidproject/mantid/releases/tag/v6.2.0

--- a/tools/release_generator/release.py
+++ b/tools/release_generator/release.py
@@ -91,7 +91,7 @@ For a full list of all issues addressed during this release please see the `GitH
 
 .. _forum: https://forum.mantidproject.org
 
-.. _GitHub milestone: https://github.com/mantidproject/mantid/pulls?utf8=%E2%9C%93&q=is%3Apr+milestone%3A"{sanitized_milestone}"+is%3Amerged
+.. _GitHub milestone: {milestone_link}
 
 .. _GitHub release page: https://github.com/mantidproject/mantid/releases/tag/v{version}
 ''',
@@ -256,7 +256,7 @@ def fixReleaseName(name):
 
 def toMilestoneName(version):
     version = version[1:].split('.')
-    version = '"Release+{major}.{minor}"'.format(major=version[0], minor=version[1])
+    version = 'Release+{major}.{minor}'.format(major=version[0], minor=version[1])
     return version
 
 
@@ -295,7 +295,8 @@ if __name__ == '__main__':
     print('milestone:', args.milestone)
     release_root = getReleaseRoot()
     print('     root:', release_root)
-
+    milestone_link='https://github.com/mantidproject/mantid/pulls?utf8=%E2%9C%93&q=is%3Apr+' \
+        + f'milestone%3A%22{sanitized_milestone}%22+is%3Amerged'
     # add the new sub-site to the index
     addToReleaseList(release_root, args.release)
 


### PR DESCRIPTION
The links to some of the release milestones needed `"` escaped for html. This does that and fixes up the tool.

**To test:**

Build the docs and look at the release notes.

*There is no associated issue.*

*This does not require release notes* because it is correcting mistakes in the release notes.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
