### PR TITLE
Fix rebin of phasequads in muon GUI

### DIFF
--- a/docs/source/release/v6.2.0/muon.rst
+++ b/docs/source/release/v6.2.0/muon.rst
@@ -62,7 +62,7 @@ Improvements
 - The plotting has been updated for better stability.
 - The plotting now has autoscale active by default.
 - It is now possible to load nexusV2 files in the GUI.
-- Added a table to store phasequads in the phase tab. Also, phasequads no longer delete themselves automatically.
+- Added a table to store :ref:`PhaseQuads <algm-PhaseQuad>` in the phase tab. Also, phasequads no longer delete themselves automatically.
 - The labels on the tabs in the GUIs will now show in full
 - When running the :ref:`DynamicKobuToyabe <func-DynamicKuboToyabe>` fitting function you should now be able to see the BinWidth to 3 decimal places.
 - It is now possible to select the normalisation (``analysis_asymmetry_norm``) and group (``analysis_group``) in the :ref:`Results Tab <muon_results_tab-ref>`.
@@ -79,6 +79,8 @@ Bugfixes
 - The autoscale option when ``All`` is selected will now show the largest and smallest y value for all of the plots.
 - The global parameters in a results table will no longer be given a zero error arbitrarily if one with an error exists.
 - The attribute values in a Chebyshev function will no longer get reset after performing a simultaneous fit.
+- Fixed a crash caused by fitting to rebinned :ref:`PhaseQuad <algm-PhaseQuad>` data.
+- When :ref:`PhaseQuad <algm-PhaseQuad>` data is rebinned it now divides by the fractional change in the bin size (to keep the asymmetry to about 0.3).
 
 ALC
 ---

--- a/scripts/Muon/GUI/Common/ADSHandler/ADS_calls.py
+++ b/scripts/Muon/GUI/Common/ADSHandler/ADS_calls.py
@@ -5,6 +5,7 @@
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
 from mantid.api import AnalysisDataService
+import mantid.simpleapi as mantid
 
 
 def remove_ws(name):
@@ -26,3 +27,11 @@ def check_if_workspace_exist(name):
 
 def add_ws_to_ads(name, workspace):
     AnalysisDataService.addOrReplace(name, workspace)
+
+
+# these are algs, but are related to the ADS
+def delete_ws(name):
+    alg = mantid.AlgorithmManager.create("DeleteWorkspace")
+    alg.initialize()
+    alg.setProperty("Workspace", name)
+    alg.execute()

--- a/scripts/Muon/GUI/Common/contexts/muon_context.py
+++ b/scripts/Muon/GUI/Common/contexts/muon_context.py
@@ -15,9 +15,9 @@ from Muon.GUI.Common.calculate_pair_and_group import calculate_group_data, calcu
     estimate_group_asymmetry_data, run_pre_processing
 from Muon.GUI.Common.utilities.run_string_utils import run_list_to_string, run_string_to_list
 from Muon.GUI.Common.utilities.algorithm_utils import run_PhaseQuad, split_phasequad, rebin_ws, apply_deadtime, \
-    run_minus, run_crop_workspace
+    run_minus, run_crop_workspace, run_create_workspace, run_convert_to_points, run_convert_to_histogram, run_divide
 import Muon.GUI.Common.ADSHandler.workspace_naming as wsName
-from Muon.GUI.Common.ADSHandler.ADS_calls import retrieve_ws
+from Muon.GUI.Common.ADSHandler.ADS_calls import retrieve_ws, delete_ws
 from Muon.GUI.Common.contexts.muon_group_pair_context import get_default_grouping
 from Muon.GUI.Common.contexts.muon_context_ADS_observer import MuonContextADSObserver
 from Muon.GUI.Common.ADSHandler.muon_workspace_wrapper import MuonWorkspaceWrapper, WorkspaceGroupDefinition
@@ -272,15 +272,36 @@ class MuonContext(object):
 
         parameters['InputWorkspace'] = self._run_deadtime(run_string, ws_name)
         runs = self._data_context.current_runs
+
         if runs:
             parameters['InputWorkspace'] = run_crop_workspace(parameters['InputWorkspace'], self.first_good_data(runs[0]),
                                                               self.last_good_data(runs[0]))
 
         phase_quad = run_PhaseQuad(parameters, ws_name)
+        tmp = retrieve_ws(phase_quad)
+        dt = tmp.readX(0)[1]-tmp.readX(0)[0]
+
         phase_quad = self._run_rebin(phase_quad, rebin)
+        phase_quad = self._average_by_bin_widths(phase_quad, dt)
 
         workspaces = split_phasequad(phase_quad)
         return workspaces
+
+    def _average_by_bin_widths(self, ws_name, dt):
+        #convert to Histogram to get bin widths and divide by how much bin widths have changed
+        ws_name= run_convert_to_histogram(ws_name)
+        data = retrieve_ws(ws_name)
+        ws_x = data.readX(0)
+
+        # assume constant binning in raw data
+        dx = [ (ws_x[j+1]-ws_x[j])/(dt) for j in range(len(ws_x)-1)]
+        tmp = run_create_workspace(ws_x, dx, "tmp")
+
+        tmp = run_convert_to_points(tmp)
+        ws_name = run_convert_to_points(ws_name)
+        output = run_divide(ws_name, tmp, ws_name)
+        delete_ws(tmp)
+        return output
 
     def _calculate_phasequads(self, phasequad_obj, rebin):
         for run in self._data_context.current_runs:
@@ -477,9 +498,6 @@ class MuonContext(object):
         equivalent_list = []
 
         for item in input_list:
-            if 'PhaseQuad' in item:
-                equivalent_list.append(item)
-
             equivalent_group_pair = self.group_pair_context.get_equivalent_group_pair(
                 item)
             if equivalent_group_pair:

--- a/scripts/Muon/GUI/Common/contexts/muon_context.py
+++ b/scripts/Muon/GUI/Common/contexts/muon_context.py
@@ -278,20 +278,26 @@ class MuonContext(object):
                                                               self.last_good_data(runs[0]))
 
         phase_quad = run_PhaseQuad(parameters, ws_name)
-        tmp = retrieve_ws(phase_quad)
-        dt = tmp.readX(0)[1]-tmp.readX(0)[0]
-
-        phase_quad = self._run_rebin(phase_quad, rebin)
-        phase_quad = self._average_by_bin_widths(phase_quad, dt)
+        if rebin:
+            dt = self._get_bin_width(phase_quad)
+            phase_quad = self._run_rebin(phase_quad, True)
+            phase_quad = self._average_by_bin_widths(phase_quad, dt)
 
         workspaces = split_phasequad(phase_quad)
         return workspaces
 
+    def _get_bin_width(self, name):
+        tmp = self._get_x_data(name)
+        return tmp[1]-tmp[0]
+
+    def _get_x_data(self, name):
+        tmp = retrieve_ws(name)
+        return tmp.readX(0)
+
     def _average_by_bin_widths(self, ws_name, dt):
         #convert to Histogram to get bin widths and divide by how much bin widths have changed
         ws_name= run_convert_to_histogram(ws_name)
-        data = retrieve_ws(ws_name)
-        ws_x = data.readX(0)
+        ws_x = self._get_x_data(ws_name)
 
         # assume constant binning in raw data
         dx = [ (ws_x[j+1]-ws_x[j])/(dt) for j in range(len(ws_x)-1)]

--- a/scripts/Muon/GUI/Common/utilities/algorithm_utils.py
+++ b/scripts/Muon/GUI/Common/utilities/algorithm_utils.py
@@ -344,3 +344,41 @@ def run_clone_workspace(parameter_dict):
     alg.setProperties(parameter_dict)
     alg.execute()
     return alg.getProperty("OutputWorkspace").valueAsStr
+
+
+def run_convert_to_points(name):
+    alg = mantid.AlgorithmManager.create("ConvertToPointData")
+    alg.initialize()
+    alg.setProperty("InputWorkspace", name)
+    alg.setProperty("OutputWorkspace", name)
+    alg.execute()
+    return alg.getProperty("OutputWorkspace").valueAsStr
+
+
+def run_convert_to_histogram(name):
+    alg = mantid.AlgorithmManager.create("ConvertToHistogram")
+    alg.initialize()
+    alg.setProperty("InputWorkspace", name)
+    alg.setProperty("OutputWorkspace", name)
+    alg.execute()
+    return alg.getProperty("OutputWorkspace").valueAsStr
+
+
+def run_divide(LHS, RHS, name):
+    alg = mantid.AlgorithmManager.create("Divide")
+    alg.initialize()
+    alg.setProperty("LHSWorkspace", LHS)
+    alg.setProperty("RHSWorkspace", RHS)
+    alg.setProperty("OutputWorkspace", name)
+    alg.execute()
+    return alg.getProperty("OutputWorkspace").valueAsStr
+
+
+def run_create_workspace(x_data, y_data, name):
+    alg = mantid.AlgorithmManager.create("CreateWorkspace")
+    alg.initialize()
+    alg.setProperty("DataX", x_data)
+    alg.setProperty("DataY", y_data)
+    alg.setProperty("OutputWorkspace", name)
+    alg.execute()
+    return alg.getProperty("OutputWorkspace").valueAsStr


### PR DESCRIPTION
**Description of work.**
The phasequads in the muon GUI had 2 problems. The first was that it was possible to cause a hard crash when using binned data. The second was that the binned data was not normalised.

Reported by James
<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**

<!-- Instructions for testing. -->
Set binning to 4 (or use the log rebin args)
Load MUSR run 62260
Go to the phase tab
Create a phase table e.g. top, bottom (press the button and enter a name in the pop up)
Create a Phase Quad from it by pressing the `+` button and give it a name
Go to the grouping tab
De-select the groups (top table) 
Go to Fitting tab
Tick the Simultaneous box
Add an ExpDecayOsc. . Make A, Frequency, Lambda be Global
Un-select “Fit to Raw Data” below
Try a fit. This is where it used to throw an error.

Go to the grouping tab
Select one of the groups (which does not matter)
Go back to the home tab
Try different rebin parameters in the rebin box (it takes the same args as the alg)
Make sure that the plots of the phasequad are roughly the same amplitude as the group you have selected (about 0.3)

Fixes #32519. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
