### PR TITLE
Prevent x axis scale reset in Muon Analysis

### DIFF
--- a/scripts/Muon/GUI/MuonAnalysis/plot_widget/muon_analysis_plot_widget.py
+++ b/scripts/Muon/GUI/MuonAnalysis/plot_widget/muon_analysis_plot_widget.py
@@ -116,13 +116,10 @@ class MuonAnalysisPlotWidget(object):
     def handle_plot_mode_changed_by_user(self):
         old_plot_mode = self._current_plot_mode
         self._current_plot_mode = self.presenter.get_plot_mode
-        if old_plot_mode == self.data_mode.name or old_plot_mode == self.fit_mode.name:
-            pane_to_match = self.fit_mode.name if old_plot_mode == self.data_mode.name else self.data_mode.name
-            selection, x_range, auto, y_range, errors = self.plotting_canvas_widgets[pane_to_match].get_quick_edit_info
-            self.plotting_canvas_widgets[pane_to_match].set_quick_edit_info(selection, x_range, auto, y_range, errors)
-
+        selection, x_range, auto, y_range, errors = self.plotting_canvas_widgets[old_plot_mode].get_quick_edit_info
+        self.plotting_canvas_widgets[self._current_plot_mode].set_quick_edit_info(selection, x_range, auto, y_range,
+                                                                                  errors)
         #if self._current_plot_mode==self.raw_mode.name:
         #    self.raw_mode.handle_data_updated()
-
         self.presenter.hide(old_plot_mode)
         self.presenter.show(self._current_plot_mode)

--- a/scripts/test/Muon/CMakeLists.txt
+++ b/scripts/test/Muon/CMakeLists.txt
@@ -118,6 +118,7 @@ set ( TEST_PY_FILES
    plot_fit_panes/plot_freq_fit_pane_model_test.py
    plot_fit_panes/plot_model_fit_pane_model_test.py
    plot_fit_panes/plot_model_fit_pane_presenter_test.py
+   plot_fit_panes/plot_widget_test.py
    plotting_canvas/plot_color_queue_test.py
    plotting_canvas/plotting_canvas_model_test.py
    plotting_canvas/plotting_canvas_presenter_test.py

--- a/scripts/test/Muon/plot_fit_panes/plot_widget_test.py
+++ b/scripts/test/Muon/plot_fit_panes/plot_widget_test.py
@@ -18,37 +18,53 @@ from Muon.GUI.Common.test_helpers.context_setup import setup_context
 from Muon.GUI.Common.plot_widget.plotting_canvas.plotting_canvas_widget import PlottingCanvasWidget
 from Muon.GUI.Common.plot_widget.data_pane.plot_data_pane_model import PlotDataPaneModel
 from Muon.GUI.Common.plot_widget.main_plot_widget_view import MainPlotWidgetView
+from Muon.GUI.Common.plot_widget.main_plot_widget_presenter import MainPlotWidgetPresenter
 
 
 @start_qapplication
 class PlotWidgetTest(unittest.TestCase):
 
     @mock.patch('Muon.GUI.Common.plot_widget.base_pane.base_pane_view.BasePaneView')
-    @mock.patch('Muon.GUI.Common.plot_widget.main_plot_widget_presenter.MainPlotWidgetPresenter.get_plot_mode')
-    def setUp(self, plot_mode_mock, basepane_mock):
+    def setUp(self, basepane_mock):
         self.context = setup_context()
         self.count = 0
-        self.data_canvas = mock.Mock(spec=PlottingCanvasWidget)
-        self.data_canvas.get_quick_edit_info = mock.Mock(return_value=["one", [3.0, 8.0], 2, [-0.323, 0.436], False])
+        user_mocked_vals = "one", [3.0, 8.0], 2, [-0.323, 0.436], False
+        self.data_canvas = self.set_plot_values(user_mocked_vals)
         self.fit_canvas = mock.Mock(spec=PlottingCanvasWidget)
         basepane_mock_return = mock.MagicMock()
         basepane_mock.return_value = basepane_mock_return
-        plot_mode_mock.side_effect = self.change_plot_mode
         self.plot_widget = MuonAnalysisPlotWidget(self.context)
         self.plot_widget.data_model = mock.Mock(spec=PlotDataPaneModel)
         self.plot_widget.fit_model = mock.Mock(spec=PlotTimeFitPaneModel)
         self.plot_widget.view = mock.Mock(spec=MainPlotWidgetView)
         self.plot_widget.models = mock.Mock()
+        self.plot_widget._current_plot_mode = self.change_plot_mode()
+        self.plot_widget.presenter = mock.Mock(spec=MainPlotWidgetPresenter)
+        self.plot_widget.plotting_canvas_widgets["Plot Data"] = self.data_canvas
+        self.plot_widget.plotting_canvas_widgets["Fit Data"] = self.fit_canvas
 
     def change_plot_mode(self):
         if self.count == 0:
             self.count += 1
-            return self.data_canvas
+            return "Plot Data"
         else:
-            return self.fit_canvas
+            return "Fit Data"
+
+    #sets the values of the Plotting Canvas Widget
+    def set_plot_values(self, mocked_vals):
+        mock_injector = mock.NonCallableMock()
+        mock_injector.get_quick_edit_info = mocked_vals
+        return mock_injector
 
     def test_handle_plot_mode_changed_by_user_correct_x_axis(self):
+        self.assertEqual(self.plot_widget._current_plot_mode, "Plot Data")
+        self.plot_widget.presenter.get_plot_mode = self.change_plot_mode()
+
         self.plot_widget.handle_plot_mode_changed_by_user()
+
+        self.assertEqual(self.plot_widget._current_plot_mode, "Fit Data")
+        self.plot_widget.plotting_canvas_widgets["Fit Data"].set_quick_edit_info.assert_called_once_with\
+            ("one", [3.0, 8.0], 2, [-0.323, 0.436], False)
 
 
 if __name__ == '__main__':

--- a/scripts/test/Muon/plot_fit_panes/plot_widget_test.py
+++ b/scripts/test/Muon/plot_fit_panes/plot_widget_test.py
@@ -1,0 +1,55 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2021 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+import unittest
+
+from mantidqt.utils.qt.testing import start_qapplication
+
+from unittest import mock
+
+from Muon.GUI.MuonAnalysis.plot_widget.plot_time_fit_pane_model import PlotTimeFitPaneModel
+
+
+from Muon.GUI.MuonAnalysis.plot_widget.muon_analysis_plot_widget import MuonAnalysisPlotWidget
+from Muon.GUI.Common.test_helpers.context_setup import setup_context
+from Muon.GUI.Common.plot_widget.plotting_canvas.plotting_canvas_widget import PlottingCanvasWidget
+from Muon.GUI.Common.plot_widget.data_pane.plot_data_pane_model import PlotDataPaneModel
+from Muon.GUI.Common.plot_widget.main_plot_widget_view import MainPlotWidgetView
+
+
+@start_qapplication
+class PlotWidgetTest(unittest.TestCase):
+
+    @mock.patch('Muon.GUI.Common.plot_widget.base_pane.base_pane_view.BasePaneView')
+    @mock.patch('Muon.GUI.Common.plot_widget.main_plot_widget_presenter.MainPlotWidgetPresenter.get_plot_mode')
+    def setUp(self, plot_mode_mock, basepane_mock):
+        self.context = setup_context()
+        self.count = 0
+        self.data_canvas = mock.Mock(spec=PlottingCanvasWidget)
+        self.data_canvas.get_quick_edit_info = mock.Mock(return_value=["one", [3.0, 8.0], 2, [-0.323, 0.436], False])
+        self.fit_canvas = mock.Mock(spec=PlottingCanvasWidget)
+        basepane_mock_return = mock.MagicMock()
+        basepane_mock.return_value = basepane_mock_return
+        plot_mode_mock.side_effect = self.change_plot_mode
+        self.plot_widget = MuonAnalysisPlotWidget(self.context)
+        self.plot_widget.data_model = mock.Mock(spec=PlotDataPaneModel)
+        self.plot_widget.fit_model = mock.Mock(spec=PlotTimeFitPaneModel)
+        self.plot_widget.view = mock.Mock(spec=MainPlotWidgetView)
+        self.plot_widget.models = mock.Mock()
+
+    def change_plot_mode(self):
+        if self.count == 0:
+            self.count += 1
+            return self.data_canvas
+        else:
+            return self.fit_canvas
+
+    def test_handle_plot_mode_changed_by_user_correct_x_axis(self):
+        self.plot_widget.handle_plot_mode_changed_by_user()
+
+
+if __name__ == '__main__':
+    unittest.main(buffer=False, verbosity=2)


### PR DESCRIPTION
Fixed a bug whereby any user values enetered for the x-axis in Muon Analysis would not be kept when tabbing to new panes.

**Report to:** Aidy


**To test:**

1. Open Muon Analysis
2 Load MUSR85100
3. Change Start X and End X (e.g. 3.0 and 8.0 as used in screenshot below)
4. Click on the Fitting Tab, then Sequential Fitting Tab then Results - for all three the plot should retain X axis values as set in step 3


Fixes #32473 

*This does not require release notes* because **bug caused by feature developed during this release that will now be included in a future release instead**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
