### PR TITLE
Cppcheck threshold fix release-next

### DIFF
--- a/Framework/Algorithms/src/GetEi.cpp
+++ b/Framework/Algorithms/src/GetEi.cpp
@@ -44,7 +44,7 @@ const double GetEi::CROP = 0.15;
 const double GetEi::GET_COUNT_RATE = 0.15;
 const double GetEi::FIT_PEAK = 0.2;
 
-/// Empty default constructor algorith() calls the constructor in the base class
+/// Empty default constructor algorithm() calls the constructor in the base class
 GetEi::GetEi() : Algorithm(), m_tempWS(), m_fracCompl(0.0) {}
 
 void GetEi::init() {

--- a/buildconfig/Jenkins/cppcheck.sh
+++ b/buildconfig/Jenkins/cppcheck.sh
@@ -4,7 +4,7 @@ SCRIPT_DIR=$(dirname "$0")
 # If errors slip through to master this can be used to set a non-zero
 # allowed count while those errors are dealt with. This avoids breaking all
 # builds for all developers
-ALLOWED_ERRORS_COUNT=1204
+ALLOWED_ERRORS_COUNT=1203
 
 if [[ ${JOB_NAME} == *pull_requests* ]]; then
     # This relies on the fact pull requests use pull/$PR-NAME
@@ -42,9 +42,9 @@ cppcheck-htmlreport --file=cppcheck.xml --title=Embedded --report-dir=cppcheck-r
 
 # Mark build as passed or failed
 errors_count=$(grep -c '</error>' cppcheck.xml)
-if [ $errors_count -gt ${ALLOWED_ERRORS_COUNT} ]; then
-  echo "CppCheck found ${ALLOWED_ERRORS_COUNT} errors."
-  echo "See CppCheck link on the job page for more detail."
+if [ $errors_count -ne ${ALLOWED_ERRORS_COUNT} ]; then
+  echo "CppCheck found ${errors_count} errors."
+  echo "See CppCheck link on the job page for more detail, or adjust the count."
   exit 1
 else
   echo "CppCheck found no errors"


### PR DESCRIPTION
**Description of work.**
There was a gap for an extra cppcheck defect to enter the code base, which could merge into master and cause jobs to fail. The number of allowed errors has been decreased by one to match the current state on release-next. The cppcheck failure check comparison has been changed from `greater than` to `not equal` so that the same thing doesn't happen again.

**To test:**
Make sure cppcheck job passes.

*There is no associated issue.*

*This does not require release notes* because it is not user facing.


<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
