### PR TITLE
SANS: Replace missing mon 4/5 setters using direct attr

### DIFF
--- a/scripts/SANS/sans/state/StateObjects/StateMoveDetectors.py
+++ b/scripts/SANS/sans/state/StateObjects/StateMoveDetectors.py
@@ -50,6 +50,7 @@ class StateMove(metaclass=JsonSerializable):
 
         # The sample offset direction is Z for the ISIS instruments
         self.sample_offset_direction = CanonicalCoordinates.Z
+        self.monitor_4_offset: float = 0.0
 
     def validate(self):
         # If the detectors are empty, then we raise
@@ -88,8 +89,6 @@ class StateMoveSANS2D(StateMove):
         self.lab_detector_x = 0.0  # : Float
         self.lab_detector_z = 0.0  # : Float
 
-        self.monitor_4_offset = 0.0  # : Float
-
         # Setup the detectors
         self.detectors = {DetectorType.LAB.value: StateMoveDetectors(),
                           DetectorType.HAB.value: StateMoveDetectors()}
@@ -116,9 +115,7 @@ class StateMoveZOOM(StateMove):
     def __init__(self):
         super(StateMoveZOOM, self).__init__()
         self.lab_detector_default_sd_m = 0.0  # : Float
-
-        self.monitor_4_offset = 0.0  # : Float
-        self.monitor_5_offset = 0.0  # : Float
+        self.monitor_5_offset: float = 0.0
 
         # Setup the detectors
         self.detectors = {DetectorType.LAB.value: StateMoveDetectors()}
@@ -131,7 +128,6 @@ class StateMoveNoInst(StateMove):
     def __init__(self):
         super(StateMoveNoInst, self).__init__()
         self.lab_detector_default_sd_m = 0.0  # : Float
-        self.monitor_4_offset = 0.0  # : Float
 
         # Setup the detectors
         self.detectors = {DetectorType.LAB.value: StateMoveDetectors(),

--- a/scripts/SANS/sans/user_file/txt_parsers/ParsedDictConverter.py
+++ b/scripts/SANS/sans/user_file/txt_parsers/ParsedDictConverter.py
@@ -5,7 +5,6 @@
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
 import abc
-import collections
 
 from sans.common.enums import DetectorType, RangeStepType, RebinType, FitType, DataType, FitModeForMerge
 from sans.common.general_functions import get_ranges_from_event_slice_setting, get_ranges_for_rebin_setting, \
@@ -722,14 +721,10 @@ class ParsedDictConverter(IStateParser):
             # Should the user have chosen several values, then the last element is selected
             monitor_n_shift = monitor_n_shift[-1]
 
-            # Determine if the object has the set_monitor_X_offset method
-            set_monitor_4_offset = getattr(state_builder, "set_monitor_4_offset", dict())
-            set_monitor_5_offset = getattr(state_builder, "set_monitor_5_offset", dict())
-
-            if spec_num == 4 and isinstance(set_monitor_4_offset, collections.Callable):
-                state_builder.set_monitor_4_offset(_convert_mm_to_m(monitor_n_shift))
-            elif spec_num == 5 and isinstance(set_monitor_5_offset, collections.Callable):
-                state_builder.set_monitor_5_offset(_convert_mm_to_m(monitor_n_shift))
+            if spec_num == 4:  # All detectors have "M4"
+                state_builder.state.monitor_4_offset = _convert_mm_to_m(monitor_n_shift)
+            elif spec_num == 5 and hasattr(state_builder.state, "monitor_5_offset"):
+                state_builder.state.monitor_5_offset = _convert_mm_to_m(monitor_n_shift)
 
         if TransId.SPEC_4_SHIFT in self._input_dict:
             parse_shift(key_to_parse=TransId.SPEC_4_SHIFT, spec_num=4)

--- a/scripts/test/SANS/gui_logic/test_run_tab_presenter.py
+++ b/scripts/test/SANS/gui_logic/test_run_tab_presenter.py
@@ -223,7 +223,9 @@ class RunTabPresenterTest(unittest.TestCase):
         self._remove_files(user_file_path=user_file_path, batch_file_path=batch_file_path)
 
     def test_state_retrieved_from_model(self):
+        # Set values which trigger operators, such as divide or parsing, in StateModels
         self._mock_view.q_1d_step = 1.0
+        self._mock_view.transmission_mn_4_shift = 1.0
 
         expected = self.mock_run_tab_model.get_save_types().to_all_states()
         all_states = self.presenter.update_model_from_view()


### PR DESCRIPTION
**Description of work.**
This adds unit tests + impl to detect when mon 4/5 setters, which we're missing whilst
updating state in ParsedDictConverter.

All instruments have M4, so I've moved this to the base class to avoid potential bugs in the future too related to this.

**Report to:** @smk78 

**To test:**
- Download the user file in #32540 
- Open ISIS SANS
- Open the user file
- Go to settings -> Adjustment
- Check that under M4 it shows `-12.0`

Fixes #32540 .

*This does not require release notes* because it's a regression between 6.1 and 6.2

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
