### PR TITLE
Fix silly != / == bug in beam center finder

### DIFF
--- a/scripts/SANS/sans/gui_logic/presenter/beam_centre_presenter.py
+++ b/scripts/SANS/sans/gui_logic/presenter/beam_centre_presenter.py
@@ -135,8 +135,8 @@ class BeamCentrePresenter(object):
         rear_pos_1 = self._beam_centre_model.rear_pos_1
         rear_pos_2 = self._beam_centre_model.rear_pos_2
 
-        front_pos_1 = self._beam_centre_model.front_pos_1 if self._beam_centre_model.front_pos_1 == '' else rear_pos_1
-        front_pos_2 = self._beam_centre_model.front_pos_2 if self._beam_centre_model.front_pos_2 == '' else rear_pos_2
+        front_pos_1 = self._beam_centre_model.front_pos_1 if self._beam_centre_model.front_pos_1 != '' else rear_pos_1
+        front_pos_2 = self._beam_centre_model.front_pos_2 if self._beam_centre_model.front_pos_2 != '' else rear_pos_2
 
         self._view.rear_pos_1 = self._round(rear_pos_1)
         self._view.rear_pos_2 = self._round(rear_pos_2)

--- a/scripts/test/SANS/gui_logic/beam_centre_presenter_test.py
+++ b/scripts/test/SANS/gui_logic/beam_centre_presenter_test.py
@@ -177,6 +177,43 @@ class BeamCentrePresenterTest(unittest.TestCase):
         self.presenter.on_update_rows()
         self.presenter.update_centre_positions.assert_called_once()
 
+    def test_update_center_positions_with_valid_front(self):
+        self.BeamCentreModel.rear_pos_1 = 1.1
+        self.BeamCentreModel.rear_pos_2 = 1.2
+        self.BeamCentreModel.front_pos_1 = 2.1
+        self.BeamCentreModel.front_pos_2 = 2.2
+        self.presenter.update_centre_positions()
+
+        self.assertEqual(1.1, self.view.rear_pos_1)
+        self.assertEqual(1.2, self.view.rear_pos_2)
+        self.assertEqual(2.1, self.view.front_pos_1)
+        self.assertEqual(2.2, self.view.front_pos_2)
+
+    def test_update_center_positions_with_empty_front(self):
+        self.BeamCentreModel.rear_pos_1 = 1.1
+        self.BeamCentreModel.rear_pos_2 = 1.2
+        self.BeamCentreModel.front_pos_1 = ""
+        self.BeamCentreModel.front_pos_2 = ""
+        self.presenter.update_centre_positions()
+
+        self.assertEqual(1.1, self.view.rear_pos_1)
+        self.assertEqual(1.2, self.view.rear_pos_2)
+        self.assertEqual(self.BeamCentreModel.rear_pos_1, self.view.front_pos_1)
+        self.assertEqual(self.BeamCentreModel.rear_pos_2, self.view.front_pos_2)
+
+    def test_update_center_positions_with_zero_front(self):
+        self.BeamCentreModel.rear_pos_1 = 1.1
+        self.BeamCentreModel.rear_pos_2 = 1.2
+        # Zero is a valid value, so should be respected
+        self.BeamCentreModel.front_pos_1 = 0.
+        self.BeamCentreModel.front_pos_2 = 0.
+        self.presenter.update_centre_positions()
+
+        self.assertEqual(1.1, self.view.rear_pos_1)
+        self.assertEqual(1.2, self.view.rear_pos_2)
+        self.assertEqual(0., self.view.front_pos_1)
+        self.assertEqual(0., self.view.front_pos_2)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
**Description of work.**
Fixes a silly bug, where we checked for the front being not set, rather
than being set, for validity.
This meant when the value was set, we reverted back to using the rear
value.

Add a number of tests to cover this and various similar bugs we see in
on SANS just in-case.

Fixes #32541

**Report to:** @smk78 

**To test:**
- Download user file from #32541 
- Load the user file in ISIS SANS
- Go to beam centre finder
- Check front and rear values don't match (previously front took the rear values)

*This does not require release notes* because it regressed between 6.1 and 6.2

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
