### PR TITLE
Fix problem with applying pulse time filtering in LoadEventNexus

### DIFF
--- a/Framework/DataHandling/inc/MantidDataHandling/EventWorkspaceCollection.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/EventWorkspaceCollection.h
@@ -77,7 +77,8 @@ public:
   void setMonitorWorkspace(const std::shared_ptr<API::MatrixWorkspace> &monitorWS);
   void updateSpectraUsing(const API::SpectrumDetectorMapping &map);
   void setTitle(const std::string &title);
-  void applyFilter(const boost::function<void(API::MatrixWorkspace_sptr)> &func);
+  void applyFilterInPlace(const boost::function<void(API::MatrixWorkspace_sptr)> &func);
+  void applyFilter(const boost::function<DataObjects::EventWorkspace_sptr(DataObjects::EventWorkspace_sptr)> &func);
   virtual bool threadSafe() const;
 };
 

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadEventNexus.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadEventNexus.h
@@ -220,6 +220,7 @@ private:
   void runLoadMonitors();
   /// Set the filters on TOF.
   void setTimeFilters(const bool monitors);
+  template <typename T> T filterByTime(T workspace);
 
   /// Load a spectra mapping from the given file
   std::unique_ptr<std::pair<std::vector<int32_t>, std::vector<int32_t>>>

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadEventNexus.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadEventNexus.h
@@ -220,7 +220,9 @@ private:
   void runLoadMonitors();
   /// Set the filters on TOF.
   void setTimeFilters(const bool monitors);
-  template <typename T> T filterByTime(T workspace);
+  template <typename T>
+  T filterEventsByTime(T workspace, Mantid::Types::Core::DateAndTime &startTime,
+                       Mantid::Types::Core::DateAndTime &stopTime);
 
   /// Load a spectra mapping from the given file
   std::unique_ptr<std::pair<std::vector<int32_t>, std::vector<int32_t>>>

--- a/Framework/DataHandling/src/EventWorkspaceCollection.cpp
+++ b/Framework/DataHandling/src/EventWorkspaceCollection.cpp
@@ -236,9 +236,16 @@ void EventWorkspaceCollection::setTitle(const std::string &title) {
   }
 }
 
-void EventWorkspaceCollection::applyFilter(const boost::function<void(MatrixWorkspace_sptr)> &func) {
+void EventWorkspaceCollection::applyFilterInPlace(const boost::function<void(MatrixWorkspace_sptr)> &func) {
   for (auto &ws : m_WsVec) {
     func(ws);
+  }
+}
+
+void EventWorkspaceCollection::applyFilter(
+    const boost::function<DataObjects::EventWorkspace_sptr(DataObjects::EventWorkspace_sptr)> &func) {
+  for (auto &ws : m_WsVec) {
+    ws = func(ws);
   }
 }
 

--- a/Framework/DataHandling/src/LoadBankFromDiskTask.cpp
+++ b/Framework/DataHandling/src/LoadBankFromDiskTask.cpp
@@ -124,40 +124,13 @@ void LoadBankFromDiskTask::prepareEventId(::NeXus::File &file, int64_t &start_ev
     file.openData("event_id");
 
   // By default, use all available indices
-  start_event = 0;
+  start_event = event_index[0];
   ::NeXus::Info id_info = file.getInfo();
   // dims[0] can be negative in ISIS meaning 2^32 + dims[0]. Take that into
   // account
   int64_t dim0 = recalculateDataSize(id_info.dims[0]);
   stop_event = dim0;
 
-  // Handle the time filtering by changing the start/end offsets.
-  for (size_t i = 0; i < thisBankPulseTimes->numPulses; i++) {
-    if (thisBankPulseTimes->pulseTimes[i] >= m_loader.alg->filter_time_start) {
-      start_event = static_cast<int64_t>(event_index[i]);
-      break; // stop looking
-    }
-  }
-
-  if (start_event > dim0) {
-    // If the frame indexes are bad then we can't construct the times of the
-    // events properly and filtering by time
-    // will not work on this data
-    m_loader.alg->getLogger().warning() << this->entry_name
-                                        << "'s field 'event_index' seems to be invalid (start_index > than "
-                                           "the number of events in the bank)."
-                                        << "All events will appear in the same frame and filtering by time "
-                                           "will not be possible on this data.\n";
-    start_event = 0;
-    stop_event = dim0;
-  } else {
-    for (size_t i = 0; i < thisBankPulseTimes->numPulses; i++) {
-      if (thisBankPulseTimes->pulseTimes[i] > m_loader.alg->filter_time_stop) {
-        stop_event = event_index[i];
-        break;
-      }
-    }
-  }
   // We are loading part - work out the event number range
   if (m_loader.chunk != EMPTY_INT()) {
     start_event = static_cast<int64_t>(m_loader.chunk - m_loader.firstChunkForBank) *

--- a/Framework/DataHandling/src/LoadEventNexus.cpp
+++ b/Framework/DataHandling/src/LoadEventNexus.cpp
@@ -1187,7 +1187,6 @@ void LoadEventNexus::loadEvents(API::Progress *const prog, const bool monitors) 
   if (is_time_filtered) {
     // Now filter out the run and events, using the DateAndTime type.
     // This will sort both by pulse time
-    m_ws->mutableRun().filterByTime(filter_time_start, filter_time_stop);
     filterEventsByTime(m_ws, filter_time_start, filter_time_stop);
   }
 }

--- a/docs/source/algorithms/LoadEventNexus-v1.rst
+++ b/docs/source/algorithms/LoadEventNexus-v1.rst
@@ -178,8 +178,8 @@ Output:
 
 .. testcode:: ExLoadEventNexusWithFiltering
 
-   # Load SNS CNCS event dataset between 10 and 20 minutes
-   ws = LoadEventNexus('CNCS_7860_event.nxs', FilterByTimeStart=600, FilterByTimeStop=1200)
+   # Load SNS CNCS event dataset between 1 and 2 minutes
+   ws = LoadEventNexus('CNCS_7860_event.nxs', FilterByTimeStart=60, FilterByTimeStop=120)
 
    print("The number of events: {}".format(ws.getNumberEvents()))
 
@@ -187,7 +187,7 @@ Output:
 
 .. testoutput:: ExLoadEventNexusWithFiltering
 
-   The number of events: 112266
+   The number of events: 29753
 
 
 .. categories::

--- a/docs/source/release/v6.2.0/framework.rst
+++ b/docs/source/release/v6.2.0/framework.rst
@@ -38,7 +38,11 @@ Bugfixes
 - :ref:`LoadNexusLogs <algm-LoadNexusLogs>` now creates a warning message for logs that are poorly formed and the other logs are loaded. Previously it stopped loading logs at that point.
 - Fixed a bug where :ref:`LoadRaw <algm-LoadRaw>` would not load all log files for raw files with an alternate data stream.
 - Fixed a problem calculating default beam size in :ref:`MonteCarloAbsorption <algm-MonteCarloAbsorption>` when sample is offset from origin.
-- Fixed a problem with sorting of events in :ref:`LoadEventNexus <algm-LoadEventNexus>` that was causing :ref:`FilterByTime <algm-FilterByTime>` to give incorrect results
+- Fix problem with filtering of events based on pulse time in :ref:`LoadEventNexus <algm-LoadEventNexus>`. There are two ways of filtering events by pulse time using this algorithm and both
+  were giving incorrect results if the events in the input Nexus file were unsorted:
+
+  - events can be filtered as part of the load by using the FilterByTimeStart and FilterByTimeStop parameters
+  - if the full event file is loaded, the filtering can be applied as a post process using the algorithm :ref:`FilterByTime <algm-FilterByTime>`
 
 Fit Functions
 -------------


### PR DESCRIPTION
**Description of work.**

The WISH instrument scientists filter event nexus files by pulse time using some extra parameters on the LoadEventNexus algorithm:
```
LoadEventNexus(Filename=filename,OutputWorkspace=output,FilterByTimeStart=tmin,FilterByTimeStop=tmax,LoadMonitors='1',MonitorsAsEvents='1',FilterMonByTimeStart=tmin,FilterMonByTimeStop=tmax)
```
The pulse time filtering doesn't work if the input Nexus file isn't sorted on pulse time. A random subset of the events is returned. Note - I've recently fixed a similar problem in the FilterByTime algorithm (in https://github.com/mantidproject/mantid/pull/32499) but this PR fixes a separate bug in the LoadEventNexus code.

The previous approach of assuming you could convert the pulse time filter into an event id from\to range wasn't valid so I've just called the FilterByTime algorithm as a post process. This probably isn't as quick as the original method but don't think the original approach can be fixed.

There's another filter (FilterDuringPause) set up as a template method so I've done the same for the new FilterEventsByTime method This template approach possibly exists so the filter can work on the variety of workspace types that may need filtering (especially if the monitor data is filtered where it could be an event\matrix\group workspace or possibly even an EventWorkspaceCollection). Since FilterByTime doesn't have a feature to apply the filter in place I had to create a new method on EventWorkspaceCollection.

This fix has another positive side effect which is that if a FilterByTimeStart value is supplied that is larger than the duration of the run, no events are returned. The original code returned all the events in this case.

I noticed two other problems but haven't fixed because didn't seem as urgent:
- The parameters FilterMonByTimeStart and FilterMonByTimeStop don't seem to be implemented in the code ie they don't do anything. All the event mode files I've seen seem to have the monitor data captured in histogram mode anyway so maybe not a big deal
- I noticed that LoadEventNexus currently passes m_ws->getSingleHeldWorkspace() to filterDuringPause at one point instead of simply passing m_ws. I don't think this is correct because it only results in the first workspace (first period) being filtered but am leaving it because the pause filtering is not the subject of the bug reported

**To test:**

This load should return only 51098 events whereas before it returned over 11 million:
```
event_ws = Load(Filename=r'POLARIS00129560.nxs', FilterByTimeStart=308, FilterByTimeStop=309)
```

Fixes #32534.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
