### PR TITLE
Deprecated alias dev build

### DIFF
--- a/Framework/Kernel/CMakeLists.txt
+++ b/Framework/Kernel/CMakeLists.txt
@@ -586,6 +586,7 @@ else()
 endif()
 
 set(CONSOLECHANNELCLASS "ConsoleChannel")
+set(ALIASDEPRECATED "Raise")
 configure_file(../Properties/Mantid.properties.template
                ${CMAKE_CURRENT_BINARY_DIR}/Mantid.properties.config)
 
@@ -639,6 +640,7 @@ else()
 endif()
 
 set(CONSOLECHANNELCLASS "StdoutChannel")
+set(ALIASDEPRECATED "Log")
 configure_file(../Properties/Mantid.properties.template
                ${CMAKE_CURRENT_BINARY_DIR}/Mantid.properties.install)
 

--- a/Framework/Properties/Mantid.properties.template
+++ b/Framework/Properties/Mantid.properties.template
@@ -187,7 +187,7 @@ algorithms.categories.hidden=Workflow\\Inelastic\\UsesPropertyManager;Workflow\\
 # Allowed values are:
 #   "Log": log a warning indicating the alias is deprecated, along with the name to be used
 #   "Raise": raise a RuntimeError if the deprecated deadline has been met
-algorithms.alias.deprecated = Log
+algorithms.alias.deprecated = @ALIASDEPRECATED@
 
 # All interface categories are shown by default.
 interfaces.categories.hidden =

--- a/Framework/PythonInterface/mantid/utils/absorptioncorrutils.py
+++ b/Framework/PythonInterface/mantid/utils/absorptioncorrutils.py
@@ -425,6 +425,7 @@ def create_absorption_input(
     material={},
     geometry={},
     environment={},
+    find_environment=True,
     opt_wl_min=0,
     opt_wl_max=Property.EMPTY_DBL,
     metaws=None,
@@ -438,6 +439,7 @@ def create_absorption_input(
     :param material: Optional material to use in SetSample
     :param geometry: Optional geometry to use in SetSample
     :param environment: Optional environment to use in SetSample
+    :param find_environment: Optional find_environment to control whether to figure out environment automatically.
     :param opt_wl_min: Optional minimum wavelength. If specified, this is used instead of from the props
     :param opt_wl_max: Optional maximum wavelength. If specified, this is used instead of from the props
     :param metaws: Optional workspace name with metadata to use for donor workspace instead of reading from filename
@@ -538,6 +540,10 @@ def create_absorption_input(
 
     # Make sure one is set before calling SetSample
     if material or geometry or environment:
-        mantid.simpleapi.SetSampleFromLogs(InputWorkspace=absName, Material=material, Geometry=geometry, Environment=environment)
+        mantid.simpleapi.SetSampleFromLogs(InputWorkspace=absName,
+                                           Material=material,
+                                           Geometry=geometry,
+                                           Environment=environment,
+                                           FindEnvironment=find_environment)
 
     return absName

--- a/Framework/PythonInterface/mantid/utils/absorptioncorrutils.py
+++ b/Framework/PythonInterface/mantid/utils/absorptioncorrutils.py
@@ -538,6 +538,14 @@ def create_absorption_input(
 
     # Make sure one is set before calling SetSample
     if material or geometry or environment:
-        mantid.simpleapi.SetSampleFromLogs(InputWorkspace=absName, Material=material, Geometry=geometry, Environment=environment)
+        if environment:
+            mantid.simpleapi.SetSampleFromLogs(InputWorkspace=absName,
+                                               Material=material,
+                                               Geometry=geometry,
+                                               Environment=environment)
+        else:
+            mantid.simpleapi.SetSample(InputWorkspace=absName,
+                                       Material=material,
+                                       Geometry=geometry)
 
     return absName

--- a/Framework/PythonInterface/mantid/utils/absorptioncorrutils.py
+++ b/Framework/PythonInterface/mantid/utils/absorptioncorrutils.py
@@ -538,14 +538,6 @@ def create_absorption_input(
 
     # Make sure one is set before calling SetSample
     if material or geometry or environment:
-        if environment:
-            mantid.simpleapi.SetSampleFromLogs(InputWorkspace=absName,
-                                               Material=material,
-                                               Geometry=geometry,
-                                               Environment=environment)
-        else:
-            mantid.simpleapi.SetSample(InputWorkspace=absName,
-                                       Material=material,
-                                       Geometry=geometry)
+        mantid.simpleapi.SetSampleFromLogs(InputWorkspace=absName, Material=material, Geometry=geometry, Environment=environment)
 
     return absName

--- a/Framework/PythonInterface/plugins/algorithms/SNSPowderReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/SNSPowderReduction.py
@@ -1416,6 +1416,7 @@ class SNSPowderReduction(DistributedDataProcessorAlgorithm):
                                                                             'Height': 7.,
                                                                             'Radius': self._vanRadius,
                                                                             'Center': [0., 0., 0.]},
+                                                                  find_environment=False,
                                                                   opt_wl_min=self._wavelengthMin,
                                                                   opt_wl_max=self._wavelengthMax)
 

--- a/Framework/PythonInterface/plugins/algorithms/SetSampleFromLogs.py
+++ b/Framework/PythonInterface/plugins/algorithms/SetSampleFromLogs.py
@@ -166,13 +166,18 @@ class SetSampleFromLogs(DistributedDataProcessorAlgorithm):
         environment = self._createEnvironment(runObject, instrEnum)
 
         # let SetSample generate errors if anything is wrong
-        SetSample(InputWorkspace=wksp,
-                  Material=material,
-                  Geometry=geometry,
-                  Environment=environment,
-                  ContainerGeometry=geometryContainer,
-                  ContainerMaterial=materialContainer)
-
+        try:
+            SetSample(InputWorkspace=wksp,
+                      Material=material,
+                      Geometry=geometry,
+                      Environment=environment,
+                      ContainerGeometry=geometryContainer,
+                      ContainerMaterial=materialContainer)
+        except Exception as inst:
+            self.log().warning(inst.args[0])
+            SetSample(InputWorkspace=wksp,
+                      Material=material,
+                      Geometry=geometry)
 
 # Register algorithm with Mantid.
 AlgorithmFactory.subscribe(SetSampleFromLogs)

--- a/Framework/PythonInterface/plugins/algorithms/SetSampleFromLogs.py
+++ b/Framework/PythonInterface/plugins/algorithms/SetSampleFromLogs.py
@@ -166,18 +166,17 @@ class SetSampleFromLogs(DistributedDataProcessorAlgorithm):
         environment = self._createEnvironment(runObject, instrEnum)
 
         # let SetSample generate errors if anything is wrong
-        try:
+        if self.getProperty("Environment").value.values():
+            SetSample(InputWorkspace=wksp,
+                      Material=material,
+                      Geometry=geometry)
+        else:
             SetSample(InputWorkspace=wksp,
                       Material=material,
                       Geometry=geometry,
                       Environment=environment,
                       ContainerGeometry=geometryContainer,
                       ContainerMaterial=materialContainer)
-        except Exception as inst:
-            self.log().warning(inst.args[0])
-            SetSample(InputWorkspace=wksp,
-                      Material=material,
-                      Geometry=geometry)
 
 
 # Register algorithm with Mantid.

--- a/Framework/PythonInterface/plugins/algorithms/SetSampleFromLogs.py
+++ b/Framework/PythonInterface/plugins/algorithms/SetSampleFromLogs.py
@@ -179,5 +179,6 @@ class SetSampleFromLogs(DistributedDataProcessorAlgorithm):
                       Material=material,
                       Geometry=geometry)
 
+
 # Register algorithm with Mantid.
 AlgorithmFactory.subscribe(SetSampleFromLogs)

--- a/Framework/PythonInterface/plugins/algorithms/SetSampleFromLogs.py
+++ b/Framework/PythonInterface/plugins/algorithms/SetSampleFromLogs.py
@@ -169,14 +169,14 @@ class SetSampleFromLogs(DistributedDataProcessorAlgorithm):
         if self.getProperty("Environment").value.values():
             SetSample(InputWorkspace=wksp,
                       Material=material,
-                      Geometry=geometry)
-        else:
-            SetSample(InputWorkspace=wksp,
-                      Material=material,
                       Geometry=geometry,
                       Environment=environment,
                       ContainerGeometry=geometryContainer,
                       ContainerMaterial=materialContainer)
+        else:
+            SetSample(InputWorkspace=wksp,
+                      Material=material,
+                      Geometry=geometry)
 
 
 # Register algorithm with Mantid.

--- a/Framework/PythonInterface/plugins/algorithms/SetSampleFromLogs.py
+++ b/Framework/PythonInterface/plugins/algorithms/SetSampleFromLogs.py
@@ -166,17 +166,12 @@ class SetSampleFromLogs(DistributedDataProcessorAlgorithm):
         environment = self._createEnvironment(runObject, instrEnum)
 
         # let SetSample generate errors if anything is wrong
-        if self.getProperty("Environment").value.values():
-            SetSample(InputWorkspace=wksp,
-                      Material=material,
-                      Geometry=geometry,
-                      Environment=environment,
-                      ContainerGeometry=geometryContainer,
-                      ContainerMaterial=materialContainer)
-        else:
-            SetSample(InputWorkspace=wksp,
-                      Material=material,
-                      Geometry=geometry)
+        SetSample(InputWorkspace=wksp,
+                  Material=material,
+                  Geometry=geometry,
+                  Environment=environment,
+                  ContainerGeometry=geometryContainer,
+                  ContainerMaterial=materialContainer)
 
 
 # Register algorithm with Mantid.

--- a/Framework/PythonInterface/plugins/algorithms/SetSampleFromLogs.py
+++ b/Framework/PythonInterface/plugins/algorithms/SetSampleFromLogs.py
@@ -92,7 +92,7 @@ class SetSampleFromLogs(DistributedDataProcessorAlgorithm):
                         beamline = 'BL11A'
                     else:
                         warningMsg = 'Do not know how to create lognames for "{}"'.format(instrEnum.name())
-                        self.log().warn(warningMsg)
+                        self.log().warning(warningMsg)
                     if beamline:
                         # "internal" log names at SNS are templated from the beamline number
                         heightInContainerUnitsNames.append('{}:CS:ITEMS:HeightInContainerUnits'.format(beamline))
@@ -115,14 +115,16 @@ class SetSampleFromLogs(DistributedDataProcessorAlgorithm):
                     warningMsg = "HeightInContainerUnits expects cm or mm;" + \
                                 " specified units not recognized: {:s};".format(units) + \
                                 " we will reply on user input for sample density information."
-                    self.log().warn(warningMsg)
+                    self.log().warning(warningMsg)
 
                 # set the height
                 heightKey = _findKey(runObject, *heightInContainerNames)
                 if heightKey:
                     geometry['Height'] = conversion * _getLogValue(runObject, heightKey)
                 else:
-                    raise RuntimeError("Failed to determine the height from the logs")
+                    warningMsg = "No valid height found in sample logs;" + \
+                                 "we will reply on user input for sample density information."
+                    self.log().warning(warningMsg)
 
         # log the results and return
         self.log().information('GEOMETRY (in cm): ' + str(geometry))
@@ -150,6 +152,7 @@ class SetSampleFromLogs(DistributedDataProcessorAlgorithm):
         wksp = self.getProperty("InputWorkspace").value
         # these items are not grabbed from the logs
         geometryContainer = self.getProperty("ContainerGeometry").value
+        
         materialContainer = self.getProperty("ContainerMaterial").value
 
         # get a convenient handle to the logs

--- a/Framework/PythonInterface/plugins/algorithms/SetSampleFromLogs.py
+++ b/Framework/PythonInterface/plugins/algorithms/SetSampleFromLogs.py
@@ -152,7 +152,6 @@ class SetSampleFromLogs(DistributedDataProcessorAlgorithm):
         wksp = self.getProperty("InputWorkspace").value
         # these items are not grabbed from the logs
         geometryContainer = self.getProperty("ContainerGeometry").value
-        
         materialContainer = self.getProperty("ContainerMaterial").value
 
         # get a convenient handle to the logs

--- a/Framework/PythonInterface/plugins/algorithms/SetSampleFromLogs.py
+++ b/Framework/PythonInterface/plugins/algorithms/SetSampleFromLogs.py
@@ -123,7 +123,7 @@ class SetSampleFromLogs(DistributedDataProcessorAlgorithm):
                     geometry['Height'] = conversion * _getLogValue(runObject, heightKey)
                 else:
                     warningMsg = "No valid height found in sample logs;" + \
-                                 "we will reply on user input for sample density information."
+                                 "we will rely on user input for sample density information."
                     self.log().warning(warningMsg)
 
         # log the results and return

--- a/docs/source/release/v6.2.0/diffraction.rst
+++ b/docs/source/release/v6.2.0/diffraction.rst
@@ -129,7 +129,6 @@ Improvements
 
 Bugfixes
 ########
-- For processing vanadium run, we don't want to find environment automatically in :ref:`SetSampleFromLogs <algm-SetSampleFromLogs>`.
 - :ref:`IndexPeaks <algm-IndexPeaks>` can now index peaks in a PeaksWorkspace with only a single run without optimising the UB (i.e. it is now possible to set CommonUBForAll=True in this instance).
 - Expanded the Q space search radius in DetectorSearcher to avoid missing peaks when using :ref:`PredictPeaks <algm-PredictPeaks>`.
 

--- a/docs/source/release/v6.2.0/diffraction.rst
+++ b/docs/source/release/v6.2.0/diffraction.rst
@@ -129,6 +129,7 @@ Improvements
 
 Bugfixes
 ########
+- For processing vanadium run, we don't want to find environment automatically in :ref:`SetSampleFromLogs <algm-SetSampleFromLogs>`.
 - :ref:`IndexPeaks <algm-IndexPeaks>` can now index peaks in a PeaksWorkspace with only a single run without optimising the UB (i.e. it is now possible to set CommonUBForAll=True in this instance).
 - Expanded the Q space search radius in DetectorSearcher to avoid missing peaks when using :ref:`PredictPeaks <algm-PredictPeaks>`.
 

--- a/docs/source/release/v6.3.0/diffraction.rst
+++ b/docs/source/release/v6.3.0/diffraction.rst
@@ -14,6 +14,10 @@ Powder Diffraction
 - `GetDetOffsetsMultiPeaks`, which is deprecate since v6.2.0, is removed.
 - `CalibrateRectangularDetectors`, which is deprecate since v6.2.0, is removed. And system test CalibrateRectangularDetectors_Test is removed.
 
+Bugfixes
+########
+- For processing vanadium run, we don't want to find environment automatically in :ref:`SetSampleFromLogs <algm-SetSampleFromLogs>`.
+
 Engineering Diffraction
 -----------------------
 


### PR DESCRIPTION
Companion to PR #32558

Description:
===========
The user properties are set via [this template file](https://github.com/mantidproject/mantid/blob/master/Framework/Properties/Mantid.properties.template) once [for developers in their build tree](https://github.com/mantidproject/mantid/blob/master/Framework/Kernel/CMakeLists.txt#L579-L607) and once [for the installer](https://github.com/mantidproject/mantid/blob/master/Framework/Kernel/CMakeLists.txt#L630-L657). 
1. Change the template to include the new property that selects if an exception is thrown when a deprecated algorithm is used.
2. Have developers default to throwing an exception
3. Have installs default to having a warning

More details in [PL95](https://code.ornl.gov/sns-hfir-scse/planning/-/issues/105)

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
