### PR TITLE
Define the alias.deprecated type of warning

### DIFF
--- a/Framework/Kernel/CMakeLists.txt
+++ b/Framework/Kernel/CMakeLists.txt
@@ -586,6 +586,7 @@ else()
 endif()
 
 set(CONSOLECHANNELCLASS "ConsoleChannel")
+set(ALIASDEPRECATED "Raise")
 configure_file(../Properties/Mantid.properties.template
                ${CMAKE_CURRENT_BINARY_DIR}/Mantid.properties.config)
 
@@ -639,6 +640,7 @@ else()
 endif()
 
 set(CONSOLECHANNELCLASS "StdoutChannel")
+set(ALIASDEPRECATED "Log")
 configure_file(../Properties/Mantid.properties.template
                ${CMAKE_CURRENT_BINARY_DIR}/Mantid.properties.install)
 

--- a/Framework/Properties/Mantid.properties.template
+++ b/Framework/Properties/Mantid.properties.template
@@ -187,7 +187,7 @@ algorithms.categories.hidden=Workflow\\Inelastic\\UsesPropertyManager;Workflow\\
 # Allowed values are:
 #   "Log": log a warning indicating the alias is deprecated, along with the name to be used
 #   "Raise": raise a RuntimeError if the deprecated deadline has been met
-algorithms.alias.deprecated = Log
+algorithms.alias.deprecated = @ALIASDEPRECATED@
 
 # All interface categories are shown by default.
 interfaces.categories.hidden =


### PR DESCRIPTION
Companion to PR #32548

Description:
===========
The user properties are set via [this template file](https://github.com/mantidproject/mantid/blob/master/Framework/Properties/Mantid.properties.template) once [for developers in their build tree](https://github.com/mantidproject/mantid/blob/master/Framework/Kernel/CMakeLists.txt#L579-L607) and once [for the installer](https://github.com/mantidproject/mantid/blob/master/Framework/Kernel/CMakeLists.txt#L630-L657). 
1. Change the template to include the new property that selects if an exception is thrown when a deprecated algorithm is used.
2. Have developers default to throwing an exception
3. Have installs default to having a warning

More details in [PL95](https://code.ornl.gov/sns-hfir-scse/planning/-/issues/105)

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
