### PR TITLE
Remove temporary fix from conda windows developer instructions

### DIFF
--- a/dev-docs/source/GettingStarted/GettingStartedCondaWindows.rst
+++ b/dev-docs/source/GettingStarted/GettingStartedCondaWindows.rst
@@ -43,7 +43,6 @@ Setup the mantid conda environment
     * Open an Anaconda prompt (Mambaforge).
     * Add the path of your Mambaforge installation to your system path, if you didn't do it during installation (Follow the answers in the `FAQ <https://docs.anaconda.com/anaconda/user-guide/faq/#installing-anaconda>`_). Then you can use conda from the Command Prompt and Powershell.
 
-* Temporary fix for Mambaforge on Windows. Run ``conda config --add channels main`` this will add the main channel and allow Windows developers to install ``cyrus-sasl`` (A dependency of librdkafka) which is not available on Windows yet via conda-forge.
 * Create the mantid conda environment by navigating to your mantid source code directory in your terminal and running ``conda env create -f mantid-developer-win.yml``
 
 Configure CMake and generate build files


### PR DESCRIPTION
**Description of work.**
Deletes a temporary fix from the instructions, as I've now added a windows build of cyrus-sasl to conda-forge

https://anaconda.org/conda-forge/cyrus-sasl

This means we can now build all of mantid without touching the anaconda main channels. 

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**
Using miniforge on windows create a mantid-developer environment. It should now work without needing the main channel.
`conda env create -f mantid-developer-win.yml`
`conda activate mantid-developer`
You can then look at all the packages with `conda list`
You'll notice `cyrus-sasl` is now from conda-forge. 
<!-- Instructions for testing. -->

<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
