### PR TITLE
Fix default peak in fit browser when first set in EngDiff UI settings

### DIFF
--- a/scripts/Engineering/gui/engineering_diffraction/engineering_diffraction.py
+++ b/scripts/Engineering/gui/engineering_diffraction/engineering_diffraction.py
@@ -75,10 +75,10 @@ class EngineeringDiffractionGui(QtWidgets.QMainWindow, Ui_main_window):
 
     def setup_presenter(self):
         presenter = EngineeringDiffractionPresenter()
+        presenter.setup_settings(self)  # init before fitting otherwise default peak not populated on first time opened
         presenter.setup_calibration(self)
         presenter.setup_focus(self)
         presenter.setup_fitting(self)
-        presenter.setup_settings(self)
         presenter.setup_calibration_notifier()
         presenter.statusbar_observable.add_subscriber(self.update_statusbar_text_observable)
         presenter.savedir_observable.add_subscriber(self.update_savedir_observable)

--- a/scripts/Engineering/gui/engineering_diffraction/settings/settings_presenter.py
+++ b/scripts/Engineering/gui/engineering_diffraction/settings/settings_presenter.py
@@ -126,7 +126,8 @@ class SettingsPresenter(object):
         for key in list(self.settings):
             if key not in DEFAULT_SETTINGS.keys():
                 del self.settings[key]
-        if "default_peak" not in self.settings or not self.settings["default_peak"] in ALL_PEAKS:
+        self.check_and_populate_with_default("default_peak")
+        if not self.settings["default_peak"] in ALL_PEAKS:
             self.settings["default_peak"] = DEFAULT_SETTINGS["default_peak"]
         self.check_and_populate_with_default("save_location")
         self.check_and_populate_with_default("logs")


### PR DESCRIPTION
**Description of work.**

1. Correctly set default peak to the defaul value in the settings if no present in .ini file (i.e. not set before)
2. Init settings before fit browser so that default peak setting is present on init of browser


**To test:**

(0) Go to  C:\Users<fed id>\AppData\Roaming\mantidproject (on windows) and delete the line
`EngineeringDiffraction2\default_peak=BackToBackExponential`
(1) Start mantid and open EngDiffUI
(2) Go to fitting tab
(3) Load data (instructions for making data can be found here https://developer.mantidproject.org/Testing/EngineeringDiffraction/EngineeringDiffractionTestGuide.html)
(4) Plot the data
(5) Click Fit in the plot toolbar to open the fit browser
(6) Right-click on plot and add a peak (it should be `BackToBackExponential` NOT a `Gaussian`)

*There is no associated issue.*

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
