### PR TITLE
Crop focused data in dSpacing Eng Diff UI to remove noise from vanadium norm

### DIFF
--- a/scripts/Engineering/gui/engineering_diffraction/tabs/focus/model.py
+++ b/scripts/Engineering/gui/engineering_diffraction/tabs/focus/model.py
@@ -16,7 +16,7 @@ from Engineering.gui.engineering_diffraction.settings.settings_helper import get
 from Engineering import EnggUtils
 from mantid.simpleapi import logger, AnalysisDataService as Ads, SaveNexus, SaveGSS, SaveFocusedXYE, \
     Load, NormaliseByCurrent, Divide, DiffractionFocussing, RebinToWorkspace, DeleteWorkspace, ApplyDiffCal, \
-    ConvertUnits, ReplaceSpecialValues, EnggEstimateFocussedBackground, AddSampleLog
+    ConvertUnits, ReplaceSpecialValues, EnggEstimateFocussedBackground, AddSampleLog, CropWorkspace
 
 SAMPLE_RUN_WORKSPACE_NAME = "engggui_focusing_input_ws"
 FOCUSED_OUTPUT_WORKSPACE_NAME = "engggui_focusing_output_ws_"
@@ -159,6 +159,7 @@ class FocusModel(object):
         else:
             run.addProperty("bankid", 3, True)
         # output in both dSpacing and TOF
+        CropWorkspace(InputWorkspace=focused_sample, OutputWorkspace=focused_sample, XMin=0.45)
         ConvertUnits(InputWorkspace=focused_sample, OutputWorkspace=tof_output_name, Target='TOF')
         DeleteWorkspace(curves_rebinned)
 


### PR DESCRIPTION
**Description of work.**

Crop focused data to remove data below 0.45 Ang to remove noise due to vanadium normalisation. 
This is a usability fix for the release - long term it'd be good not to hard-code 0.45 Ang but let the user set the cutoff in the settings.

**To test:**

<!-- Instructions for testing. -->
(1) Open EngDiffUI
(2) Go to fitting tab
(3) Load data (instructions for making data can be found here https://developer.mantidproject.org/Testing/EngineeringDiffraction/EngineeringDiffractionTestGuide.html)
(4) Plot the focused d-Spacing spectra

There should be no data < 0.45 Ang


*There is no associated issue.*


*This does not require release notes* because **vanadium normalisation that lead to this issue was changed this release**


<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
