### PR TITLE
Fix broken cppcheck

### DIFF
--- a/Framework/Kernel/src/DataItem.cpp
+++ b/Framework/Kernel/src/DataItem.cpp
@@ -14,14 +14,12 @@ namespace Mantid::Kernel {
 
 /** Default constructor
  */
-DataItem::DataItem() { m_lock = std::make_unique<Poco::RWLock>(); }
+DataItem::DataItem() : m_lock(std::make_unique<Poco::RWLock>()) {}
 
 /** Copy constructor
+ * Always makes a unique lock
  */
-DataItem::DataItem(const DataItem & /*other*/) {
-  // Always make a unique lock!
-  m_lock = std::make_unique<Poco::RWLock>();
-}
+DataItem::DataItem(const DataItem & /*other*/) : m_lock(std::make_unique<Poco::RWLock>()) {}
 
 /**
  * Destructor. Required in cpp do avoid linker errors when other projects try to

--- a/buildconfig/Jenkins/cppcheck.sh
+++ b/buildconfig/Jenkins/cppcheck.sh
@@ -4,7 +4,7 @@ SCRIPT_DIR=$(dirname "$0")
 # If errors slip through to master this can be used to set a non-zero
 # allowed count while those errors are dealt with. This avoids breaking all
 # builds for all developers
-ALLOWED_ERRORS_COUNT=1069
+ALLOWED_ERRORS_COUNT=1067
 
 if [[ ${JOB_NAME} == *pull_requests* ]]; then
     # This relies on the fact pull requests use pull/$PR-NAME

--- a/buildconfig/Jenkins/cppcheck.sh
+++ b/buildconfig/Jenkins/cppcheck.sh
@@ -32,7 +32,7 @@ if [ $(command -v scl) ]; then
     SCL_ENABLE="scl enable devtoolset-7"
 else
     CMAKE_EXE=cmake
-    SCL_ENABLE=""
+    SCL_ENABLE="eval"
 fi
 $SCL_ENABLE "$CMAKE_EXE --version"
 


### PR DESCRIPTION
**Description of work.**

Add missing eval to prefix command

This was missing causing bash to run the command with quotes incorrectly
on Ubuntu.
This was originally missed as the script skips the checks if no cpp files are touched

**To test:**
- Check cppcheck actually runs (woops)
- Check it passes on Ubuntu this time

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
