### PR TITLE
Fix bug in Integration algorithm when using IncludePartialBins

### DIFF
--- a/Framework/Algorithms/inc/MantidAlgorithms/Integration.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/Integration.h
@@ -10,6 +10,7 @@
 // Includes
 //----------------------------------------------------------------------
 #include "MantidAPI/Algorithm.h"
+#include "MantidAPI/ISpectrum.h"
 #include "MantidAlgorithms/DllConfig.h"
 
 namespace Mantid {
@@ -69,6 +70,8 @@ private:
   /// Create the outputworkspace
   API::MatrixWorkspace_sptr getOutputWorkspace(API::MatrixWorkspace_sptr inWS, const int minSpec, const int maxSpec);
   std::map<std::string, std::string> validateInputs() override;
+  void integrateSpectrum(const API::ISpectrum &inSpec, API::ISpectrum &outSpec, const std::vector<double> *Fin,
+                         std::vector<double> *Fout, double lowerLimit, double upperLimit, bool incPartBins);
 };
 
 } // namespace Algorithms

--- a/Framework/Algorithms/src/Integration.cpp
+++ b/Framework/Algorithms/src/Integration.cpp
@@ -147,7 +147,6 @@ void Integration::exec() {
   auto rebinned_input = std::dynamic_pointer_cast<const RebinnedOutput>(localworkspace);
   auto rebinned_output = std::dynamic_pointer_cast<RebinnedOutput>(outputWorkspace);
 
-  bool is_distrib = outputWorkspace->isDistribution();
   Progress progress(this, progressStart, 1.0, maxWsIndex - minWsIndex + 1);
 
   const bool axisIsText = localworkspace->getAxis(1)->isText();
@@ -179,23 +178,15 @@ void Integration::exec() {
     // Copy spectrum number, detector IDs
     outSpec.copyInfoFrom(inSpec);
 
-    // Retrieve the spectrum into a vector (Histogram)
-    const auto &X = inSpec.x();
-    const auto &Y = inSpec.y();
-    const auto &E = inSpec.e();
+    const MantidVec *Fin(nullptr);
+    MantidVec *Fout(nullptr);
+    if (rebinned_input)
+      Fin = &rebinned_input->readF(i);
+    if (rebinned_output)
+      Fout = &rebinned_output->dataF(outWI);
 
-    // Find the range [min,max]
-    MantidVec::const_iterator lowit, highit;
     const double lowerLimit = minRanges.empty() ? minRange : std::max(minRange, minRanges[outWI]);
     const double upperLimit = maxRanges.empty() ? maxRange : std::min(maxRange, maxRanges[outWI]);
-
-    // If doing partial bins, we want to set the bin boundaries to the specified
-    // values regardless of whether they're 'in range' for this spectrum
-    // Have to do this here, ahead of the 'continue' a bit down from here.
-    if (incPartBins) {
-      outSpec.dataX()[0] = lowerLimit;
-      outSpec.dataX()[1] = upperLimit;
-    }
 
     if (upperLimit < lowerLimit) {
       std::ostringstream sout;
@@ -205,121 +196,8 @@ void Integration::exec() {
       progress.report();
       continue;
     }
-    if (lowerLimit == EMPTY_DBL()) {
-      lowit = X.begin();
-    } else {
-      lowit = std::lower_bound(X.begin(), X.end(), lowerLimit, tolerant_less());
-    }
 
-    if (upperLimit == EMPTY_DBL()) {
-      highit = X.end();
-    } else {
-      highit = std::upper_bound(lowit, X.end(), upperLimit, tolerant_less());
-    }
-
-    // If range specified doesn't overlap with this spectrum then bail out
-    if (lowit == X.end() || highit == X.begin())
-      continue;
-
-    // Upper limit is the bin before, i.e. the last value smaller than MaxRange
-    --highit; // (note: decrementing 'end()' is safe for vectors, at least
-              // according to the C++ standard)
-
-    auto distmin = std::distance(X.begin(), lowit);
-    auto distmax = std::distance(X.begin(), highit);
-
-    double sumY = 0.0;
-    double sumE = 0.0;
-    double sumF = 0.0;
-    double Fmin = 0.0;
-    double Fmax = 0.0;
-    if (distmax <= distmin) {
-      sumY = 0.;
-      sumE = 0.;
-    } else {
-      if (rebinned_input) {
-        // Workspace has fractional area information, need to take into account
-        const MantidVec &F = rebinned_input->readF(i);
-        sumF = std::accumulate(F.begin() + distmin, F.begin() + distmax, 0.0);
-        if (distmin > 0)
-          Fmin = F[distmin - 1];
-        Fmax = F[static_cast<std::size_t>(distmax) < F.size() ? distmax : F.size() - 1];
-      }
-      if (!is_distrib) {
-        // Sum the Y, and sum the E in quadrature
-        {
-          sumY = std::accumulate(Y.begin() + distmin, Y.begin() + distmax, 0.0);
-          sumE = std::accumulate(E.begin() + distmin, E.begin() + distmax, 0.0, VectorHelper::SumSquares<double>());
-        }
-      } else {
-        // Sum Y*binwidth and Sum the (E*binwidth)^2.
-        std::vector<double> widths(X.size());
-        // highit+1 is safe while input workspace guaranteed to be histogram
-        std::adjacent_difference(lowit, highit + 1, widths.begin());
-        sumY = std::inner_product(Y.begin() + distmin, Y.begin() + distmax, widths.begin() + 1, 0.0);
-        sumE = std::inner_product(E.begin() + distmin, E.begin() + distmax, widths.begin() + 1, 0.0,
-                                  std::plus<double>(), VectorHelper::TimesSquares<double>());
-      }
-    }
-    // If partial bins are included, set integration range to exact range
-    // given and add on contributions from partial bins either side of range.
-    if (incPartBins) {
-      if ((distmax <= distmin) && (distmin > 0) && (highit < X.end() - 1)) {
-        // handle special case where lower and upper limit are in the same bin
-        const double lower_bin = *lowit;
-        const double prev_bin = *(lowit - 1);
-        double fraction = (upperLimit - lowerLimit);
-        if (!is_distrib) {
-          fraction /= (lower_bin - prev_bin);
-        }
-        const MantidVec::size_type val_index = distmin - 1;
-        sumY += Y[val_index] * fraction;
-        const double eval = E[val_index];
-        sumE += eval * eval * fraction * fraction;
-        if (rebinned_input) {
-          sumF += Fmin * fraction;
-        }
-      } else {
-        if (distmin > 0) {
-          const double lower_bin = *lowit;
-          const double prev_bin = *(lowit - 1);
-          double fraction = (lower_bin - lowerLimit);
-          if (!is_distrib) {
-            fraction /= (lower_bin - prev_bin);
-          }
-          const MantidVec::size_type val_index = distmin - 1;
-          sumY += Y[val_index] * fraction;
-          const double eval = E[val_index];
-          sumE += eval * eval * fraction * fraction;
-          if (rebinned_input) {
-            sumF += Fmin * fraction;
-          }
-        }
-        if (highit < X.end() - 1) {
-          const double upper_bin = *highit;
-          const double next_bin = *(highit + 1);
-          double fraction = (upperLimit - upper_bin);
-          if (!is_distrib) {
-            fraction /= (next_bin - upper_bin);
-          }
-          sumY += Y[distmax] * fraction;
-          const double eval = E[distmax];
-          sumE += eval * eval * fraction * fraction;
-          if (rebinned_input) {
-            sumF += Fmax * fraction;
-          }
-        }
-      }
-    } else {
-      outSpec.mutableX()[0] = lowit == X.end() ? *(lowit - 1) : *(lowit);
-      outSpec.mutableX()[1] = *highit;
-    }
-
-    outSpec.mutableY()[0] = sumY;
-    outSpec.mutableE()[0] = sqrt(sumE); // Propagate Gaussian error
-    if (rebinned_output) {
-      rebinned_output->dataF(outWI)[0] = sumF;
-    }
+    integrateSpectrum(inSpec, outSpec, Fin, Fout, lowerLimit, upperLimit, incPartBins);
 
     progress.report();
     PARALLEL_END_INTERUPT_REGION
@@ -332,6 +210,145 @@ void Integration::exec() {
 
   // Assign it to the output workspace property
   setProperty("OutputWorkspace", outputWorkspace);
+}
+
+/**
+ * Integrate a single spectrum between the supplied limits
+ */
+void Integration::integrateSpectrum(const API::ISpectrum &inSpec, API::ISpectrum &outSpec,
+                                    const std::vector<double> *Fin, std::vector<double> *Fout, const double lowerLimit,
+                                    const double upperLimit, const bool incPartBins) {
+  // Retrieve the spectrum into a vector (Histogram)
+  const auto &X = inSpec.x();
+  const auto &Y = inSpec.y();
+  const auto &E = inSpec.e();
+
+  // Find the range [min,max]
+  MantidVec::const_iterator lowit, highit;
+
+  // If doing partial bins, we want to set the bin boundaries to the specified
+  // values regardless of whether they're 'in range' for this spectrum
+  // Have to do this here, ahead of the 'continue' a bit down from here.
+  if (incPartBins) {
+    outSpec.dataX()[0] = lowerLimit;
+    outSpec.dataX()[1] = upperLimit;
+  }
+
+  if (lowerLimit == EMPTY_DBL()) {
+    lowit = X.begin();
+  } else {
+    lowit = std::lower_bound(X.begin(), X.end(), lowerLimit, tolerant_less());
+  }
+
+  if (upperLimit == EMPTY_DBL()) {
+    highit = X.end();
+  } else {
+    highit = std::upper_bound(lowit, X.end(), upperLimit, tolerant_less());
+  }
+
+  // If range specified doesn't overlap with this spectrum then bail out
+  if (lowit == X.end() || highit == X.begin())
+    return;
+
+  // Upper limit is the bin before, i.e. the last value smaller than MaxRange
+  --highit; // (note: decrementing 'end()' is safe for vectors, at least
+            // according to the C++ standard)
+
+  auto distmin = std::distance(X.begin(), lowit);
+  auto distmax = std::distance(X.begin(), highit);
+
+  double sumY = 0.0;
+  double sumE = 0.0;
+  double sumF = 0.0;
+  double Fmin = 0.0;
+  double Fmax = 0.0;
+  auto is_distrib = inSpec.yMode() == HistogramData::Histogram::YMode::Frequencies;
+  if (distmax <= distmin) {
+    sumY = 0.;
+    sumE = 0.;
+  } else {
+    if (Fin) {
+      // Workspace has fractional area information, need to take into account
+      sumF = std::accumulate(Fin->begin() + distmin, Fin->begin() + distmax, 0.0);
+      if (distmin > 0)
+        Fmin = (*Fin)[distmin - 1];
+      Fmax = (*Fin)[static_cast<std::size_t>(distmax) < Fin->size() ? distmax : Fin->size() - 1];
+    }
+    if (!is_distrib) {
+      // Sum the Y, and sum the E in quadrature
+      {
+        sumY = std::accumulate(Y.begin() + distmin, Y.begin() + distmax, 0.0);
+        sumE = std::accumulate(E.begin() + distmin, E.begin() + distmax, 0.0, VectorHelper::SumSquares<double>());
+      }
+    } else {
+      // Sum Y*binwidth and Sum the (E*binwidth)^2.
+      std::vector<double> widths(X.size());
+      // highit+1 is safe while input workspace guaranteed to be histogram
+      std::adjacent_difference(lowit, highit + 1, widths.begin());
+      sumY = std::inner_product(Y.begin() + distmin, Y.begin() + distmax, widths.begin() + 1, 0.0);
+      sumE = std::inner_product(E.begin() + distmin, E.begin() + distmax, widths.begin() + 1, 0.0, std::plus<double>(),
+                                VectorHelper::TimesSquares<double>());
+    }
+  }
+  // If partial bins are included, set integration range to exact range
+  // given and add on contributions from partial bins either side of range.
+  if (incPartBins) {
+    if ((distmax <= distmin) && (distmin > 0) && (highit < X.end() - 1)) {
+      // handle special case where lower and upper limit are in the same bin
+      const double lower_bin = *lowit;
+      const double prev_bin = *(lowit - 1);
+      double fraction = (upperLimit - lowerLimit);
+      if (!is_distrib) {
+        fraction /= (lower_bin - prev_bin);
+      }
+      const MantidVec::size_type val_index = distmin - 1;
+      sumY += Y[val_index] * fraction;
+      const double eval = E[val_index];
+      sumE += eval * eval * fraction * fraction;
+      if (Fin) {
+        sumF += Fmin * fraction;
+      }
+    } else {
+      if (distmin > 0) {
+        const double lower_bin = *lowit;
+        const double prev_bin = *(lowit - 1);
+        double fraction = (lower_bin - lowerLimit);
+        if (!is_distrib) {
+          fraction /= (lower_bin - prev_bin);
+        }
+        const MantidVec::size_type val_index = distmin - 1;
+        sumY += Y[val_index] * fraction;
+        const double eval = E[val_index];
+        sumE += eval * eval * fraction * fraction;
+        if (Fin) {
+          sumF += Fmin * fraction;
+        }
+      }
+      if (highit < X.end() - 1) {
+        const double upper_bin = *highit;
+        const double next_bin = *(highit + 1);
+        double fraction = (upperLimit - upper_bin);
+        if (!is_distrib) {
+          fraction /= (next_bin - upper_bin);
+        }
+        sumY += Y[distmax] * fraction;
+        const double eval = E[distmax];
+        sumE += eval * eval * fraction * fraction;
+        if (Fin) {
+          sumF += Fmax * fraction;
+        }
+      }
+    }
+  } else {
+    outSpec.mutableX()[0] = lowit == X.end() ? *(lowit - 1) : *(lowit);
+    outSpec.mutableX()[1] = *highit;
+  }
+
+  outSpec.mutableY()[0] = sumY;
+  outSpec.mutableE()[0] = sqrt(sumE); // Propagate Gaussian error
+  if (Fout) {
+    (*Fout)[0] = sumF;
+  }
 }
 
 /**

--- a/Framework/Algorithms/src/Integration.cpp
+++ b/Framework/Algorithms/src/Integration.cpp
@@ -264,10 +264,11 @@ void Integration::exec() {
     // If partial bins are included, set integration range to exact range
     // given and add on contributions from partial bins either side of range.
     if (incPartBins) {
-      if (distmin > 0) {
+      if ((distmax <= distmin) && (distmin > 0) && (highit < X.end() - 1)) {
+        // handle special case where lower and upper limit are in the same bin
         const double lower_bin = *lowit;
         const double prev_bin = *(lowit - 1);
-        double fraction = (lower_bin - lowerLimit);
+        double fraction = (upperLimit - lowerLimit);
         if (!is_distrib) {
           fraction /= (lower_bin - prev_bin);
         }
@@ -278,19 +279,35 @@ void Integration::exec() {
         if (rebinned_input) {
           sumF += Fmin * fraction;
         }
-      }
-      if (highit < X.end() - 1) {
-        const double upper_bin = *highit;
-        const double next_bin = *(highit + 1);
-        double fraction = (upperLimit - upper_bin);
-        if (!is_distrib) {
-          fraction /= (next_bin - upper_bin);
+      } else {
+        if (distmin > 0) {
+          const double lower_bin = *lowit;
+          const double prev_bin = *(lowit - 1);
+          double fraction = (lower_bin - lowerLimit);
+          if (!is_distrib) {
+            fraction /= (lower_bin - prev_bin);
+          }
+          const MantidVec::size_type val_index = distmin - 1;
+          sumY += Y[val_index] * fraction;
+          const double eval = E[val_index];
+          sumE += eval * eval * fraction * fraction;
+          if (rebinned_input) {
+            sumF += Fmin * fraction;
+          }
         }
-        sumY += Y[distmax] * fraction;
-        const double eval = E[distmax];
-        sumE += eval * eval * fraction * fraction;
-        if (rebinned_input) {
-          sumF += Fmax * fraction;
+        if (highit < X.end() - 1) {
+          const double upper_bin = *highit;
+          const double next_bin = *(highit + 1);
+          double fraction = (upperLimit - upper_bin);
+          if (!is_distrib) {
+            fraction /= (next_bin - upper_bin);
+          }
+          sumY += Y[distmax] * fraction;
+          const double eval = E[distmax];
+          sumE += eval * eval * fraction * fraction;
+          if (rebinned_input) {
+            sumF += Fmax * fraction;
+          }
         }
       }
     } else {

--- a/docs/source/algorithms/Integration-v1.rst
+++ b/docs/source/algorithms/Integration-v1.rst
@@ -35,12 +35,14 @@ can be set to the same value by RangeUpper. If both list and non-list versions
 are given, then the range is chosen which gives stricter limits for each
 histogram.
 
-No rebinning takes place as part of this algorithm: if the ranges given do
-not coincide with a bin boundary then the first bin boundary within the
-range is used. If a value is given that is beyond the limit covered by
-the spectrum then it will be integrated up to its limit. The data that
-falls outside any values set will not contribute to the output
-workspace.
+No rebinning takes place as part of this algorithm. If the integration limits given
+do not coincide with a bin boundary then the behaviour depends on the IncludePartialBins
+parameter. If IncludePartialBins=True then a contribution is calculated for any
+bins that partially sit inside the integration limits. If IncludePartialBins=False
+then the integration only includes bins that sit entirely within the integration limits.
+If an integration limit is given that is beyond the X range covered by the spectrum then
+the integration will proceed up to final bin boundary. The data that falls outside any
+integration limits set will not contribute to the output workspace.
 
 EventWorkspaces
 ###############

--- a/docs/source/release/v6.3.0/framework.rst
+++ b/docs/source/release/v6.3.0/framework.rst
@@ -24,6 +24,11 @@ Improvements
 - Event nexuses produced at ILL can now be loaded using :ref:`LoadEventNexus <algm-LoadEventNexus>`.
 - :ref:`Rebin <algm-Rebin>` now has an option for binning with reverse logarithmic and inverse power bins.
 
+Bugfixes
+########
+
+- Fix bug in :ref:`Integration <algm-Integration>` when using UsePartialBinsOption with integration limits that are either equal or close together
+
 Data Objects
 ------------
 


### PR DESCRIPTION
**Description of work.**

When Integration is run with IncludePartialBins=True and integration limits that are either equal or close together the algorithm was returning the wrong answer. The partial bins logic wasn't working when the RangeLower and RangeUpper values were in between consecutive values in the x data

**To test:**

Run the script attached to the linked issue and observe that the algorithm now returns 0 in the calls with IncludePartialBins where the integration limits are the same

Fixes #32591. 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
