### PR TITLE
Add button to IDA fit tabs to set fit range for multiple spectra to the same value

### DIFF
--- a/docs/source/interfaces/indirect/QENS Fitting.rst
+++ b/docs/source/interfaces/indirect/QENS Fitting.rst
@@ -29,8 +29,10 @@ Input
 The input section for QENSFitting tabs consists of, a table along with two buttons 'Add Workspace' and 'Remove'.
 Clicking 'Add Workspace' will allow you to add a new data-set to the fit (this will bring up a menu allowing you
 to select a file/workspace and the spectra to load). Once the data has been loaded, it will be displayed in the table.
-Highlighting data in the table and selecting 'Remove' will allow you to remove data from the fit. Above the preview
-plots there is a drop-down menu with which can be used to select the active data-set, which will be shown in the plots.
+Highlighting data in the table and selecting 'Remove' will allow you to remove data from the fit. The `Unify Range`
+button changes the startX and endX values for all selected spectra in the table to be the same as the first spectra
+selected. Above the preview plots there is a drop-down menu with which can be used to select the active data-set, which
+will be shown in the plots.
 
 Sequential and Simultaneous fits
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/release/v6.3.0/indirect_geometry.rst
+++ b/docs/source/release/v6.3.0/indirect_geometry.rst
@@ -10,7 +10,7 @@ Indirect Geometry Changes
     improvements, followed by bug fixes.
 
 New Features
-############
+------------
 
 - In Indirect Data Analysis fitting tabs a button has been added that will unify the fit range for all spectra selected.
 

--- a/docs/source/release/v6.3.0/indirect_geometry.rst
+++ b/docs/source/release/v6.3.0/indirect_geometry.rst
@@ -9,6 +9,11 @@ Indirect Geometry Changes
     putting new features at the top of the section, followed by
     improvements, followed by bug fixes.
 
+New Features
+############
+
+- In Indirect Data Analysis fitting tabs a button has been added that will unify the fit range for all spectra selected.
+
 Improvements
 ------------
 

--- a/qt/scientific_interfaces/Indirect/IIndirectFitDataModel.h
+++ b/qt/scientific_interfaces/Indirect/IIndirectFitDataModel.h
@@ -56,8 +56,10 @@ public:
   virtual std::vector<double> getExcludeRegionVector(WorkspaceID workspaceID, WorkspaceIndex spectrum) const = 0;
   virtual void setStartX(double startX, WorkspaceID workspaceID, WorkspaceIndex spectrum) = 0;
   virtual void setStartX(double startX, WorkspaceID workspaceID) = 0;
+  virtual void setStartX(double startX, FitDomainIndex fitDomainIndex) = 0;
   virtual void setEndX(double endX, WorkspaceID workspaceID, WorkspaceIndex spectrum) = 0;
   virtual void setEndX(double endX, WorkspaceID workspaceID) = 0;
+  virtual void setEndX(double startX, FitDomainIndex fitDomainIndex) = 0;
   virtual void setExcludeRegion(const std::string &exclude, WorkspaceID workspaceID, WorkspaceIndex spectrum) = 0;
   virtual void setResolution(const std::string &name) = 0;
   virtual void setResolution(const std::string &name, WorkspaceID workspaceID) = 0;

--- a/qt/scientific_interfaces/Indirect/IIndirectFitDataView.h
+++ b/qt/scientific_interfaces/Indirect/IIndirectFitDataView.h
@@ -55,6 +55,7 @@ signals:
   void cellChanged(int, int);
   void addClicked();
   void removeClicked();
+  void unifyClicked();
   void startXChanged(double);
   void endXChanged(double);
 };

--- a/qt/scientific_interfaces/Indirect/IndirectFitDataModel.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitDataModel.cpp
@@ -244,6 +244,13 @@ void IndirectFitDataModel::setStartX(double startX, WorkspaceID workspaceID) {
   m_fittingData->at(workspaceID.value).setStartX(startX);
 }
 
+void IndirectFitDataModel::setStartX(double startX, FitDomainIndex fitDomainIndex) {
+  auto subIndices = getSubIndices(fitDomainIndex);
+  if (m_fittingData->empty())
+    return;
+  m_fittingData->at(subIndices.first.value).setStartX(startX, subIndices.second);
+}
+
 void IndirectFitDataModel::setEndX(double endX, WorkspaceID workspaceID, WorkspaceIndex spectrum) {
   if (m_fittingData->empty())
     return;
@@ -254,6 +261,13 @@ void IndirectFitDataModel::setEndX(double endX, WorkspaceID workspaceID) {
   if (m_fittingData->empty())
     return;
   m_fittingData->at(workspaceID.value).setEndX(endX);
+}
+
+void IndirectFitDataModel::setEndX(double endX, FitDomainIndex fitDomainIndex) {
+  auto subIndices = getSubIndices(fitDomainIndex);
+  if (m_fittingData->empty())
+    return;
+  m_fittingData->at(subIndices.first.value).setEndX(endX, subIndices.second);
 }
 
 void IndirectFitDataModel::setExcludeRegion(const std::string &exclude, WorkspaceID workspaceID,

--- a/qt/scientific_interfaces/Indirect/IndirectFitDataModel.h
+++ b/qt/scientific_interfaces/Indirect/IndirectFitDataModel.h
@@ -60,8 +60,10 @@ public:
 
   void setStartX(double startX, WorkspaceID workspaceID, WorkspaceIndex spectrum) override;
   void setStartX(double startX, WorkspaceID workspaceID) override;
+  void setStartX(double startX, FitDomainIndex fitDomainIndex) override;
   void setEndX(double endX, WorkspaceID workspaceID, WorkspaceIndex spectrum) override;
   void setEndX(double endX, WorkspaceID workspaceID) override;
+  void setEndX(double startX, FitDomainIndex fitDomainIndex) override;
   void setExcludeRegion(const std::string &exclude, WorkspaceID workspaceID, WorkspaceIndex spectrum) override;
   void setExcludeRegion(const std::string &exclude, FitDomainIndex index) override;
   void setResolution(const std::string &name) override;

--- a/qt/scientific_interfaces/Indirect/IndirectFitDataPresenter.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitDataPresenter.cpp
@@ -240,11 +240,11 @@ void IndirectFitDataPresenter::removeSelectedData() {
 
 void IndirectFitDataPresenter::unifyRangeToSelectedData() {
   auto selectedIndices = m_view->getSelectedIndexes();
-  std::sort(selectedIndices.begin(), selectedIndices.end());
   if (selectedIndices.size() == 0) {
     // check that there are selected indexes.
     return;
   }
+  std::sort(selectedIndices.begin(), selectedIndices.end());
   auto fitRange = m_model->getFittingRange(FitDomainIndex(selectedIndices.begin()->row()));
   for (auto item = selectedIndices.end(); item != selectedIndices.begin();) {
     --item;

--- a/qt/scientific_interfaces/Indirect/IndirectFitDataPresenter.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitDataPresenter.cpp
@@ -34,8 +34,9 @@ IndirectFitDataPresenter::IndirectFitDataPresenter(IIndirectFitDataModel *model,
   connect(m_view, SIGNAL(addClicked()), this, SLOT(showAddWorkspaceDialog()));
 
   connect(m_view, SIGNAL(removeClicked()), this, SLOT(removeSelectedData()));
-  connect(m_view, SIGNAL(removeClicked()), this, SIGNAL(dataRemoved()));
-  connect(m_view, SIGNAL(removeClicked()), this, SIGNAL(dataChanged()));
+
+  connect(m_view, SIGNAL(unifyClicked()), this, SLOT(unifyRangeToSelectedData()));
+
   connect(m_view, SIGNAL(cellChanged(int, int)), this, SLOT(handleCellChanged(int, int)));
   connect(m_view, SIGNAL(startXChanged(double)), this, SIGNAL(startXChanged(double)));
   connect(m_view, SIGNAL(endXChanged(double)), this, SIGNAL(endXChanged(double)));
@@ -224,9 +225,31 @@ void IndirectFitDataPresenter::setModelExcludeAndEmit(const std::string &exclude
 void IndirectFitDataPresenter::removeSelectedData() {
   auto selectedIndices = m_view->getSelectedIndexes();
   std::sort(selectedIndices.begin(), selectedIndices.end());
+  if (selectedIndices.size() == 0) {
+    // check that there are selected indexes.
+    return;
+  }
   for (auto item = selectedIndices.end(); item != selectedIndices.begin();) {
     --item;
     m_model->removeDataByIndex(FitDomainIndex(item->row()));
+  }
+  updateTableFromModel();
+  emit dataRemoved();
+  emit dataChanged();
+}
+
+void IndirectFitDataPresenter::unifyRangeToSelectedData() {
+  auto selectedIndices = m_view->getSelectedIndexes();
+  std::sort(selectedIndices.begin(), selectedIndices.end());
+  if (selectedIndices.size() == 0) {
+    // check that there are selected indexes.
+    return;
+  }
+  auto fitRange = m_model->getFittingRange(FitDomainIndex(selectedIndices.begin()->row()));
+  for (auto item = selectedIndices.end(); item != selectedIndices.begin();) {
+    --item;
+    m_model->setStartX(fitRange.first, FitDomainIndex(item->row()));
+    m_model->setEndX(fitRange.second, FitDomainIndex(item->row()));
   }
   updateTableFromModel();
 }

--- a/qt/scientific_interfaces/Indirect/IndirectFitDataPresenter.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitDataPresenter.cpp
@@ -248,8 +248,8 @@ void IndirectFitDataPresenter::unifyRangeToSelectedData() {
   auto fitRange = m_model->getFittingRange(FitDomainIndex(selectedIndices.begin()->row()));
   for (auto item = selectedIndices.end(); item != selectedIndices.begin();) {
     --item;
-    m_model->setStartX(fitRange.first, FitDomainIndex(item->row()));
-    m_model->setEndX(fitRange.second, FitDomainIndex(item->row()));
+    setModelStartXAndEmit(fitRange.first, FitDomainIndex(item->row()));
+    setModelEndXAndEmit(fitRange.second, FitDomainIndex(item->row()));
   }
   updateTableFromModel();
 }

--- a/qt/scientific_interfaces/Indirect/IndirectFitDataPresenter.h
+++ b/qt/scientific_interfaces/Indirect/IndirectFitDataPresenter.h
@@ -102,6 +102,7 @@ private slots:
   void addData();
   void handleCellChanged(int row, int column);
   void removeSelectedData();
+  void unifyRangeToSelectedData();
 
 private:
   virtual std::unique_ptr<IAddWorkspaceDialog> getAddWorkspaceDialog(QWidget *parent) const;

--- a/qt/scientific_interfaces/Indirect/IndirectFitDataView.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitDataView.cpp
@@ -77,6 +77,7 @@ IndirectFitDataView::IndirectFitDataView(const QStringList &headers, QWidget *pa
   connect(m_uiForm->tbFitData, SIGNAL(cellChanged(int, int)), this, SIGNAL(cellChanged(int, int)));
   connect(m_uiForm->pbAdd, SIGNAL(clicked()), this, SIGNAL(addClicked()));
   connect(m_uiForm->pbRemove, SIGNAL(clicked()), this, SIGNAL(removeClicked()));
+  connect(m_uiForm->pbUnify, SIGNAL(clicked()), this, SIGNAL(unifyClicked()));
 }
 
 QTableWidget *IndirectFitDataView::getDataTable() const { return m_uiForm->tbFitData; }

--- a/qt/scientific_interfaces/Indirect/IndirectFitDataView.ui
+++ b/qt/scientific_interfaces/Indirect/IndirectFitDataView.ui
@@ -40,7 +40,7 @@
     </widget>
    </item>
    <item>
-    <layout class="QVBoxLayout" name="loDataControl" stretch="0,0,0">
+    <layout class="QVBoxLayout" name="loDataControl" stretch="0,0,0,0">
      <property name="rightMargin">
       <number>0</number>
      </property>
@@ -55,6 +55,13 @@
       <widget class="QPushButton" name="pbRemove">
        <property name="text">
         <string>Remove</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="pbUnify">
+       <property name="text">
+        <string>Unify Range</string>
        </property>
       </widget>
      </item>

--- a/qt/scientific_interfaces/Indirect/test/ConvFitDataPresenterTest.h
+++ b/qt/scientific_interfaces/Indirect/test/ConvFitDataPresenterTest.h
@@ -94,8 +94,10 @@ public:
 
   MOCK_METHOD3(setStartX, void(double startX, WorkspaceID workspaceID, WorkspaceIndex spectrum));
   MOCK_METHOD2(setStartX, void(double startX, WorkspaceID workspaceID));
+  MOCK_METHOD2(setStartX, void(double startX, FitDomainIndex fitDomainIndex));
   MOCK_METHOD3(setEndX, void(double endX, WorkspaceID workspaceID, WorkspaceIndex spectrum));
   MOCK_METHOD2(setEndX, void(double endX, WorkspaceID workspaceID));
+  MOCK_METHOD2(setEndX, void(double endX, FitDomainIndex fitDomainIndex));
   MOCK_METHOD3(setExcludeRegion, void(const std::string &exclude, WorkspaceID workspaceID, WorkspaceIndex spectrum));
   MOCK_METHOD2(setExcludeRegion, void(const std::string &exclude, FitDomainIndex index));
   MOCK_METHOD1(setResolution, void(const std::string &name));

--- a/qt/scientific_interfaces/Indirect/test/FqFitDataPresenterTest.h
+++ b/qt/scientific_interfaces/Indirect/test/FqFitDataPresenterTest.h
@@ -101,8 +101,10 @@ public:
 
   MOCK_METHOD3(setStartX, void(double startX, WorkspaceID workspaceID, WorkspaceIndex spectrum));
   MOCK_METHOD2(setStartX, void(double startX, WorkspaceID workspaceID));
+  MOCK_METHOD2(setStartX, void(double startX, FitDomainIndex fitDomainIndex));
   MOCK_METHOD3(setEndX, void(double endX, WorkspaceID workspaceID, WorkspaceIndex spectrum));
   MOCK_METHOD2(setEndX, void(double endX, WorkspaceID workspaceID));
+  MOCK_METHOD2(setEndX, void(double endX, FitDomainIndex fitDomainIndex));
   MOCK_METHOD3(setExcludeRegion, void(const std::string &exclude, WorkspaceID workspaceID, WorkspaceIndex spectrum));
   MOCK_METHOD2(setExcludeRegion, void(const std::string &exclude, FitDomainIndex index));
   MOCK_METHOD1(setResolution, void(const std::string &name));

--- a/qt/scientific_interfaces/Indirect/test/IndirectFitDataModelTest.h
+++ b/qt/scientific_interfaces/Indirect/test/IndirectFitDataModelTest.h
@@ -181,6 +181,7 @@ public:
   void test_that_setting_startX_on_non_existent_workspace_throws_exception() {
     TS_ASSERT_THROWS(m_fitData->setStartX(0, WorkspaceID{2}), const std::out_of_range &)
     TS_ASSERT_THROWS(m_fitData->setStartX(0, WorkspaceID{2}, WorkspaceIndex{10}), const std::out_of_range &)
+    TS_ASSERT_THROWS(m_fitData->setStartX(0, FitDomainIndex{20}), const std::runtime_error &)
   }
 
 private:

--- a/qt/scientific_interfaces/Indirect/test/IndirectFitDataPresenterTest.h
+++ b/qt/scientific_interfaces/Indirect/test/IndirectFitDataPresenterTest.h
@@ -109,8 +109,10 @@ public:
 
   MOCK_METHOD3(setStartX, void(double startX, WorkspaceID workspaceID, WorkspaceIndex spectrum));
   MOCK_METHOD2(setStartX, void(double startX, WorkspaceID workspaceID));
+  MOCK_METHOD2(setStartX, void(double startX, FitDomainIndex fitDomainIndex));
   MOCK_METHOD3(setEndX, void(double endX, WorkspaceID workspaceID, WorkspaceIndex spectrum));
   MOCK_METHOD2(setEndX, void(double endX, WorkspaceID workspaceID));
+  MOCK_METHOD2(setEndX, void(double endX, FitDomainIndex fitDomainIndex));
   MOCK_METHOD3(setExcludeRegion, void(const std::string &exclude, WorkspaceID workspaceID, WorkspaceIndex spectrum));
   MOCK_METHOD2(setExcludeRegion, void(const std::string &exclude, FitDomainIndex index));
   MOCK_METHOD1(setResolution, void(const std::string &name));


### PR DESCRIPTION
**Description of work.**

this PR adds a button to the indirect data analysis tab that sets the vlues for startX and endX to be the same as the first spectrum selected.

**To test:**

1. Open indirect data analysis.
2. In each of the fit tabs do the follownig:
3. Load multiple spectra.
4. change the startX value in one of the spectra.
5. select multiple spectra with the changed one being at the top.
6. click unify range, the startX should all be the same for the selected spectra.
7. do the same with the endX
8. Remove all spectra, click unify range and there should be no error.

Fixes #32476 

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
