### PR TITLE
Moved Crystal Field Python interface documentation from indirect to direct

### DIFF
--- a/docs/source/interfaces/direct/Crystal Field Python Interface.rst
+++ b/docs/source/interfaces/direct/Crystal Field Python Interface.rst
@@ -939,4 +939,4 @@ Or these parameters may be specified using keyword arguments, with the keywords:
 physical properties). The default values (`Hdir=[0,0,1]`, `Hmag=1`, `Inverse=False`, `Unit='cgs'` and
 `Temperature=1` are used if nothing is specified for a particular attribute.
 
-.. categories:: Interfaces Indirect
+.. categories:: Interfaces Direct


### PR DESCRIPTION
**Description of work.**

The documentation for the Crystal Field Python interface used to be in the indirect interface folder although it makes more sense for it to be in the direct interface folder so it got moved.

**To test:**

Check that references to the Crystal Field Python interface page still work.

Fixes #[32576](https://github.com/mantidproject/mantid/issues/32576).

*This does not require release notes* because **it only involved moving existing documentation from one interface folder to the other.**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
