### PR TITLE
DrILL - automatic export

### DIFF
--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/drill/model/DrillExportModel.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/drill/model/DrillExportModel.py
@@ -257,6 +257,8 @@ class DrillExportModel:
                 if isinstance(mtd[wsName], WorkspaceGroup):
                     continue
 
+                if not wsName.startswith(workspaceName):
+                    continue
                 filename = os.path.join(
                         exportPath,
                         wsName + RundexSettings.EXPORT_ALGO_EXTENSION[algo])

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/drill/test/DrillExportModelTest.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/drill/test/DrillExportModelTest.py
@@ -158,7 +158,8 @@ class DrillExportModelTest(unittest.TestCase):
         mGroup.getNames.return_value = ["workspace"]
         self.mMtd.__getitem__.return_value = mGroup
         self.mMtd.getObjectNames.return_value = ["workspace_1",
-                                                 "workspace_2"]
+                                                 "workspace_2",
+                                                 "_workspace_3"]
         self.exportModel._validCriteria = mock.Mock()
         self.exportModel._validCriteria.return_value = True
         self.exportModel.run(mSample)


### PR DESCRIPTION
**Description of work.**

With this PR, the automatic exports in DrILL are done for workspaces that contains the sample name (instead of name starting with the sample name).

**To test:**

* create two workspaces, one with name starting with "test" and one with name containing "test":
```python
from mantid.simpleapi import CreateSampleWorkspace

CreateSampleWorkspace(OutputWorkspace="test_exported")
CreateSampleWorkspace(OutputWorkspace="_test_not_exported")
```
* open DrILL
* change the selected export algorithm to `SaveNexusProcessed` only (`mdi-application-export` icon in the toolbar)
* check that the user directories list contains `ExternalData/Testing/Data/UnitTest/ILL/D11/` and that you have write permission in your default save directory
* add "10413" in `SampleRuns` column and "test" in `OutputWorkspace` column
* process the row
* check that your export directory contains `test_#1_d20.0m_c20.5m_w6.0A.nxs` and `test_exported.nxs` and not `_test_not_exported.nxs`

Part of #31403 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
