### PR TITLE
Stop tight_layout in EngDiff Fitting tab and custom update axes position

### DIFF
--- a/docs/source/release/v6.3.0/diffraction.rst
+++ b/docs/source/release/v6.3.0/diffraction.rst
@@ -21,6 +21,12 @@ Bugfixes
 Engineering Diffraction
 -----------------------
 
+Improvements
+############
+- Improved axes scaling in the plot of the :ref:`Engineering Diffraction interface<Engineering_Diffraction-ref>` :ref:`Fitting tab <ui engineering fitting>`.
+- Automatically disable zoom and pan when opening the fit browser in the :ref:`Fitting tab <ui engineering fitting>` of the Engineering Diffraction interface (as they interfered with the interactive peak adding tool).
+
+
 Single Crystal Diffraction
 --------------------------
 - Existing :ref:`PolDiffILLReduction <algm-PolDiffILLReduction>` and :ref:`D7AbsoluteCrossSections <algm-D7AbsoluteCrossSections>` can now reduce and properly normalise single-crystal data for the D7 ILL instrument.

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/plotting/plot_toolbar.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/plotting/plot_toolbar.py
@@ -34,7 +34,13 @@ class FittingPlotToolbar(MantidNavigationToolbar):
         self.push_current()
 
     def toggle_fit(self):
-        self._actions['toggle_fit']
+        fit_action = self._actions['toggle_fit']
+        if fit_action.isChecked():
+            # disable pan and zoom
+            if self._actions['zoom'].isChecked():
+                self.zoom()
+            if self._actions['pan'].isChecked():
+                self.pan()
         self.sig_toggle_fit_triggered.emit()
 
     def handle_fit_browser_close(self):

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/plotting/plot_view.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/plotting/plot_view.py
@@ -115,9 +115,9 @@ class FittingPlotView(QtWidgets.QWidget, Ui_plot):
         in the UI.
         """
         ax = self.get_axes()[0]
-        y0_lab = ax.xaxis.get_label().get_tightbbox(renderer=self.figure.canvas.get_renderer()).transformed(
+        y0_lab = ax.xaxis.get_tightbbox(renderer=self.figure.canvas.get_renderer()).transformed(
             self.figure.transFigure.inverted()).y0  # vertical coord of bottom left corner of xlabel in fig ref. frame
-        x0_lab = ax.yaxis.get_label().get_tightbbox(renderer=self.figure.canvas.get_renderer()).transformed(
+        x0_lab = ax.yaxis.get_tightbbox(renderer=self.figure.canvas.get_renderer()).transformed(
             self.figure.transFigure.inverted()).x0  # horizontal coord of bottom left corner ylabel in fig ref. frame
         pos = ax.get_position()
         x0_ax = pos.x0 + 0.05 - x0_lab  # move so that ylabel left bottom corner at horizontal coord 0.05

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/plotting/plot_view.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/plotting/plot_view.py
@@ -38,7 +38,6 @@ class FittingPlotView(QtWidgets.QWidget, Ui_plot):
         self.figure.canvas = FigureCanvas(self.figure)
         self.figure.canvas.mpl_connect('button_press_event', self.mouse_click)
         self.figure.add_subplot(111, projection="mantid")
-        self.figure.tight_layout()
         self.toolbar = FittingPlotToolbar(self.figure.canvas, self, False)
         self.toolbar.setMovable(False)
 
@@ -76,7 +75,7 @@ class FittingPlotView(QtWidgets.QWidget, Ui_plot):
             menu.exec_(QCursor.pos())
 
     def resizeEvent(self, QResizeEvent):
-        self.figure.tight_layout()
+        self.update_axes_position()
 
     def ensure_fit_dock_closed(self):
         if self.plot_dock.isFloating():
@@ -100,15 +99,30 @@ class FittingPlotView(QtWidgets.QWidget, Ui_plot):
     def clear_figure(self):
         self.figure.clf()
         self.figure.add_subplot(111, projection="mantid")
-        self.figure.tight_layout()
         self.figure.canvas.draw()
 
     def update_figure(self):
         self.toolbar.update()
-        self.figure.tight_layout()
         self.update_legend(self.get_axes()[0])
+        self.update_axes_position()
         self.figure.canvas.draw()
         self.update_fitbrowser()
+
+    def update_axes_position(self):
+        """
+        Set axes position so that labels are always visible - it deliberately ignores height of ylabel (and less
+        importantly the length of xlabel). This is because the plot window typically has a very small height when docked
+        in the UI.
+        """
+        ax = self.get_axes()[0]
+        y0_lab = ax.xaxis.get_label().get_tightbbox(renderer=self.figure.canvas.get_renderer()).transformed(
+            self.figure.transFigure.inverted()).y0  # vertical coord of bottom left corner of xlabel in fig ref. frame
+        x0_lab = ax.yaxis.get_label().get_tightbbox(renderer=self.figure.canvas.get_renderer()).transformed(
+            self.figure.transFigure.inverted()).x0  # horizontal coord of bottom left corner ylabel in fig ref. frame
+        pos = ax.get_position()
+        x0_ax = pos.x0 + 0.05 - x0_lab  # move so that ylabel left bottom corner at horizontal coord 0.05
+        y0_ax = pos.y0 + 0.05 - y0_lab  # move so that xlabel left bottom corner at vertical coord 0.05
+        ax.set_position([x0_ax, y0_ax, 0.95-x0_ax, 0.95-y0_ax])
 
     def update_fitbrowser(self):
         is_visible = self.fit_browser.isVisible()


### PR DESCRIPTION
**Description of work.**

The plot in the fitting tab of the EngDiff UI would apply a tight layout but because the y-axis label was so long (at least on my screen) it would shrink the plot indefinitely (to 0 height). The presence of a legend with long workspace names would also cause a problem.

Here I no longer apply tight-layout but update the axes positions based on the position of the axes label boxes (and ignore the legend).

I have also added small usability fix to automatically disable zoom and pan when fit browser is opened (because these features interfere with the interactive peak adding tool/menu when the fit browser is open).

**(A) To test the axes position/layout:**
This can be difficult to reproduce so try these steps on **master** first to see the problem/find steps to reproduce

(1) Load a few runs into the fitting tab of the EngDiff UI
(2) try plotting runs one at a time, you should see the plot height shrinking
(2) Click home  - it should shrink again
(2) If the plot doesn't look like it's shrinking as each run is added etc. try reducing the height of the UI window.

Eventually you should get a warning like this
`Tight layout not applied. The left and right margins cannot be made large enough to accommodate all axes decorations. `

On this **PR/branch**

(1) try the steps above, the plot size should be stable as runs are added and occupy a good area of the available space
(2) Try undocking and docking the plot etc. test it still looks OK


**(B) To test the disabling of zoom and pan on opening fit browser:**
(1) Load and plot a run into the fitting tab of the EngDiff UI
(2) Click on zoom
(3) Click Fit to open fit browser - zoom should be automatically disabled
(4) Repeat (2-3) with pan tool

Fixes #30795
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
