### PR TITLE
Close sliceviewer when underlying ws deleted

### DIFF
--- a/qt/python/mantidqt/widgets/sliceviewer/model.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/model.py
@@ -126,6 +126,9 @@ class SliceViewerModel:
         return ws_type == WS_TYPE.MDE or (ws_type == WS_TYPE.MDH and self._get_ws().hasOriginalWorkspace(
             0) and self._get_ws().getOriginalWorkspace(0).getNumDims() == self._get_ws().getNumDims())
 
+    def set_ws_name(self, new_name):
+        self._ws_name = new_name
+
     def get_ws_name(self) -> str:
         """Return the name of the workspace being viewed"""
         return self._ws_name

--- a/qt/python/mantidqt/widgets/sliceviewer/model.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/model.py
@@ -38,6 +38,7 @@ class SliceViewerModel:
     def __init__(self, ws):
         # reference to the workspace requested to be viewed
         self._ws = ws
+        self._ws_name = ws.name()
         if isinstance(ws, MatrixWorkspace):
             if ws.getNumberHistograms() < 2:
                 raise ValueError("workspace must contain at least 2 spectrum")
@@ -53,10 +54,9 @@ class SliceViewerModel:
         else:
             raise ValueError("only works for MatrixWorkspace and MDWorkspace")
 
-        wsname = self.get_ws_name()
-        self._rebinned_name = wsname + '_svrebinned'
-        self._xcut_name, self._ycut_name = wsname + '_cut_x', wsname + '_cut_y'
-        self._roi_name = wsname + '_roi'
+        self._rebinned_name = self._ws_name + '_svrebinned'
+        self._xcut_name, self._ycut_name = self._ws_name + '_cut_x', self._ws_name + '_cut_y'
+        self._roi_name = self._ws_name + '_roi'
 
         ws_type = self.get_ws_type()
         if ws_type == WS_TYPE.MDE:
@@ -128,7 +128,7 @@ class SliceViewerModel:
 
     def get_ws_name(self) -> str:
         """Return the name of the workspace being viewed"""
-        return self._ws.name()
+        return self._ws_name
 
     def get_frame(self) -> SpecialCoordinateSystem:
         """Return the coordinate system of the workspace"""
@@ -139,7 +139,7 @@ class SliceViewerModel:
         of the model's workspace if none supplied.
         """
         if not ws_name:
-            ws_name = self.get_ws_name()
+            ws_name = self.ws_name
         return f'Sliceviewer - {ws_name}'
 
     def get_ws_MDE(self,
@@ -497,7 +497,7 @@ class SliceViewerModel:
         return help_msg
 
     def workspace_equals(self, ws_name):
-        return str(self._get_ws()) == ws_name
+        return self._ws_name == ws_name
 
     # private api
     def _get_ws(self):

--- a/qt/python/mantidqt/widgets/sliceviewer/model.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/model.py
@@ -139,7 +139,7 @@ class SliceViewerModel:
         of the model's workspace if none supplied.
         """
         if not ws_name:
-            ws_name = self.ws_name
+            ws_name = self._ws_name
         return f'Sliceviewer - {ws_name}'
 
     def get_ws_MDE(self,

--- a/qt/python/mantidqt/widgets/sliceviewer/presenter.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/presenter.py
@@ -439,7 +439,8 @@ class SliceViewer(ObservingPresenter):
             ws.unlock()
 
     def rename_workspace(self, old_name, new_name):
-        if str(self.model._get_ws()) == old_name:
+        if self.model.get_ws_name() == old_name:
+            self.model.set_ws_name(new_name)
             self.view.emit_rename(self.model.get_title(new_name))
 
     def delete_workspace(self, ws_name):

--- a/qt/python/mantidqt/widgets/sliceviewer/presenter.py
+++ b/qt/python/mantidqt/widgets/sliceviewer/presenter.py
@@ -443,7 +443,7 @@ class SliceViewer(ObservingPresenter):
             self.view.emit_rename(self.model.get_title(new_name))
 
     def delete_workspace(self, ws_name):
-        if ws_name == str(self.model._ws):
+        if ws_name == self.model.get_ws_name():
             self.view.emit_close()
 
     def ADS_cleared(self):


### PR DESCRIPTION
**Description of work.**
Since the changes in #32204, the slice viewer wasn't closing when the underlying workspace is deleted. The workspace name is now stored in the slice viewer model to avoid the problem.

**To test:**

1. Load some data and open the slice viewer.
2. Delete the workspace and verify that the slice viewer closes.
3. Load some data and open the slice viewer.
4. Rename the workspace and verify that the window title of the slice viewer chnages.
5. Delete the workspace and verify that the slice viewer closes.


Fixes #32638 
<!-- alternative
*There is no associated issue.*
-->

*This does not require release notes* because it was a bug introduced since the last release.

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
