### PR TITLE
muon phasequad bug

### DIFF
--- a/docs/source/release/v6.2.0/muon.rst
+++ b/docs/source/release/v6.2.0/muon.rst
@@ -85,6 +85,7 @@ Bugfixes
 - The attribute values in a :ref:`Chebyshev <func-Chebyshev>` fitting function will no longer reset after performing a simultaneous fit.
 - Fixed a crash caused by fitting to rebinned :ref:`PhaseQuad <algm-PhaseQuad>` data.
 - When :ref:`PhaseQuad <algm-PhaseQuad>` data is rebinned it now divides by the fractional change in the bin size (to keep the asymmetry to about 0.3).
+- Fixed a bug that is caused by changing instrument and loading a run, after creating a phasequad.
 
 ALC
 ---

--- a/scripts/Muon/GUI/Common/contexts/muon_group_pair_context.py
+++ b/scripts/Muon/GUI/Common/contexts/muon_group_pair_context.py
@@ -176,6 +176,10 @@ class MuonGroupPairContext(object):
     def clear(self):
         self.clear_groups()
         self.clear_pairs()
+        self.clear_phasequads()
+
+    def clear_phasequads(self):
+        self._phasequad = []
 
     def clear_groups(self):
         self._groups = []

--- a/scripts/Muon/GUI/FrequencyDomainAnalysis/frequency_domain_analysis.py
+++ b/scripts/Muon/GUI/FrequencyDomainAnalysis/frequency_domain_analysis.py
@@ -368,6 +368,11 @@ class FrequencyAnalysisGui(QtWidgets.QMainWindow):
         self.context.data_context.instrumentNotifier.add_subscriber(
             self.home_tab.home_tab_widget.instrumentObserver)
 
+        self.clear_observer =  GenericObserver(self.clear)
+
+        self.context.data_context.instrumentNotifier.add_subscriber(
+            self.clear_observer)
+
         self.context.data_context.instrumentNotifier.add_subscriber(
             self.load_widget.load_widget.instrumentObserver)
 
@@ -388,6 +393,9 @@ class FrequencyAnalysisGui(QtWidgets.QMainWindow):
 
         for observer in self.plot_widget.clear_plot_observers:
             self.context.data_context.instrumentNotifier.add_subscriber(observer)
+
+    def clear(self):
+        self.context.clear_context()
 
     def setup_group_calculation_enable_notifier(self):
         self.grouping_tab_widget.group_tab_presenter.enable_editing_notifier.add_subscriber(

--- a/scripts/Muon/GUI/MuonAnalysis/muon_analysis_2.py
+++ b/scripts/Muon/GUI/MuonAnalysis/muon_analysis_2.py
@@ -378,6 +378,11 @@ class MuonAnalysisGui(QtWidgets.QMainWindow):
         self.context.data_context.instrumentNotifier.add_subscriber(
             self.home_tab.home_tab_widget.instrumentObserver)
 
+        self.clear_observer =  GenericObserver(self.clear)
+
+        self.context.data_context.instrumentNotifier.add_subscriber(
+            self.clear_observer)
+
         self.context.data_context.instrumentNotifier.add_subscriber(
             self.load_widget.load_widget.instrumentObserver)
 
@@ -395,6 +400,9 @@ class MuonAnalysisGui(QtWidgets.QMainWindow):
 
         for observer in self.plot_widget.clear_plot_observers:
             self.context.data_context.instrumentNotifier.add_subscriber(observer)
+
+    def clear(self):
+        self.context.clear_context()
 
     def setup_group_calculation_enable_notifier(self):
 


### PR DESCRIPTION
**Description of work.**
The muon GUI was crashing because the phasequads were not getting cleared from the context when the instrument was changed. To fix this I have added an explicit clearing of the data when the instrument is changed.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**

<!-- Instructions for testing. -->
Open muon analysis
Load MUSR 62260
Go to the phase tab
Create a phase table
Create a phasequad by pressing the `+`
Go to the home tab
Change the instrument to EMU
Load run 113190
This use to cause a crash
Close muon analysis

Repeat the above steps but in the frequency domain analysis GUI


Fixes #32645 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->
In release notes
<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
