### PR TITLE
Enable /bigobj on MSVC by default

### DIFF
--- a/Framework/DataObjects/CMakeLists.txt
+++ b/Framework/DataObjects/CMakeLists.txt
@@ -234,11 +234,6 @@ elseif(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
   set_target_properties(DataObjects PROPERTIES INSTALL_RPATH "\$ORIGIN/../${LIB_DIR}")
 endif()
 
-# Intensive use of templated libaries can cause large objects to be generated. These require an additional flag in MSVC.
-if(MSVC)
-  set_target_properties(DataObjects PROPERTIES COMPILE_FLAGS "/bigobj")
-endif()
-
 # Add to the 'Framework' group in VS
 set_property(TARGET DataObjects PROPERTY FOLDER "MantidFramework")
 

--- a/Framework/MDAlgorithms/CMakeLists.txt
+++ b/Framework/MDAlgorithms/CMakeLists.txt
@@ -371,10 +371,6 @@ target_include_directories(
 
 # Set the name of the generated library
 set_target_properties(MDAlgorithms PROPERTIES OUTPUT_NAME MantidMDAlgorithms COMPILE_DEFINITIONS IN_MANTID_MDALGORITHMS)
-# set /bigobj for vc due to intensive templating
-if(MSVC)
-  set_target_properties(MDAlgorithms PROPERTIES COMPILE_FLAGS "/bigobj")
-endif()
 
 if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
   set_target_properties(MDAlgorithms PROPERTIES INSTALL_RPATH "@loader_path/../Contents/MacOS")

--- a/Framework/PythonInterface/CMakeLists.txt
+++ b/Framework/PythonInterface/CMakeLists.txt
@@ -58,7 +58,7 @@ function(SET_PYTHON_PROPERTIES TARGET TARGET_NAME)
   set_target_properties(${TARGET} PROPERTIES PREFIX "")
   # Library name needs to end in .pyd for Windows
   if(MSVC)
-    set_target_properties(${TARGET} PROPERTIES SUFFIX .pyd COMPILE_FLAGS "/w44005 /w44244")
+    set_target_properties(${TARGET} PROPERTIES SUFFIX .pyd)
   elseif(APPLE)
     # and in .so on the Mac
     set_target_properties(${TARGET} PROPERTIES SUFFIX .so)

--- a/Framework/PythonInterface/CMakeLists.txt
+++ b/Framework/PythonInterface/CMakeLists.txt
@@ -58,9 +58,7 @@ function(SET_PYTHON_PROPERTIES TARGET TARGET_NAME)
   set_target_properties(${TARGET} PROPERTIES PREFIX "")
   # Library name needs to end in .pyd for Windows
   if(MSVC)
-    set_target_properties(
-      ${TARGET} PROPERTIES SUFFIX .pyd COMPILE_FLAGS "/bigobj /w44005 /w44244"
-    ) # bigobj required for intensive templating
+    set_target_properties(${TARGET} PROPERTIES SUFFIX .pyd COMPILE_FLAGS "/w44005 /w44244")
   elseif(APPLE)
     # and in .so on the Mac
     set_target_properties(${TARGET} PROPERTIES SUFFIX .so)

--- a/Framework/PythonInterface/mantid/kernel/src/Exports/DateAndTime.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Exports/DateAndTime.cpp
@@ -9,6 +9,7 @@
 #include <boost/python/class.hpp>
 #include <boost/python/make_constructor.hpp>
 #include <boost/python/operators.hpp> // Also provides self
+#include <cstddef>
 #include <memory>
 #include <numpy/arrayobject.h>
 #include <numpy/arrayscalars.h>
@@ -70,7 +71,7 @@ void export_DateAndTime() {
       .def(self - self);
 }
 
-long time_duration_total_nanoseconds(time_duration &self) {
+int64_t time_duration_total_nanoseconds(time_duration &self) {
   PyErr_Warn(PyExc_DeprecationWarning, ".total_nanoseconds() is deprecated. Use .totalNanoseconds() instead.");
   return self.total_nanoseconds();
 }

--- a/Framework/PythonInterface/mantid/kernel/src/Exports/V3D.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Exports/V3D.cpp
@@ -28,7 +28,7 @@ namespace {
  */
 V3D directionAnglesDefault(V3D &self) { return self.directionAngles(); }
 
-long hashV3D(V3D &self) {
+Py_hash_t hashV3D(V3D &self) {
   boost::python::object tmpObj(self.toString());
 
   return PyObject_Hash(tmpObj.ptr());

--- a/Framework/PythonInterface/test/cpp/CMakeLists.txt
+++ b/Framework/PythonInterface/test/cpp/CMakeLists.txt
@@ -22,7 +22,7 @@ if(CXXTEST_FOUND)
   set_pythonpath_for_cxxtests(${_pythoninterface_test_target_name} "${TEST_FILES}")
 
   if(WIN32)
-    set_target_properties(${_pythoninterface_test_target_name} PROPERTIES COMPILE_FLAGS "/w44244 /DHAVE_SNPRINTF")
+    set_target_properties(${_pythoninterface_test_target_name} PROPERTIES COMPILE_FLAGS "/DHAVE_SNPRINTF")
   endif()
 
   target_include_directories(${_pythoninterface_test_target_name} PUBLIC ${CMAKE_BINARY_DIR}/Framework/Types)

--- a/buildconfig/CMake/MSVCSetup.cmake
+++ b/buildconfig/CMake/MSVCSetup.cmake
@@ -28,16 +28,17 @@ add_definitions(-D_SILENCE_CXX17_SHARED_PTR_UNIQUE_DEPRECATION_WARNING)
 if(NOT CONDA_BUILD)
   string(REGEX REPLACE "/" "\\\\" THIRD_PARTY_INCLUDE_DIR "${THIRD_PARTY_DIR}/include/")
   string(REGEX REPLACE "/" "\\\\" THIRD_PARTY_LIB_DIR "${THIRD_PARTY_DIR}/lib/")
-  # /MP            - Compile .cpp files in parallel /W3            - Warning Level 3 (This is also the default)
-  # /external:I    - Ignore third party library warnings (similar to "isystem" in GCC)
   set(CMAKE_CXX_FLAGS
       "${CMAKE_CXX_FLAGS} /external:I ${THIRD_PARTY_INCLUDE_DIR} /external:I ${THIRD_PARTY_LIB_DIR}\\python${Python_VERSION_MAJOR}.${Python_VERSION_MINOR}\\ "
   )
 endif()
 
+# /MP - Compile .cpp files in parallel /W3 - Warning Level 3 (This is also the default) /external:I - Ignore third party
+# library  warnings (similar to "isystem" in GCC) /bigobj Compile large test targets by losing compatibility with MSVC
+# 2005
 set(CMAKE_CXX_FLAGS
     "${CMAKE_CXX_FLAGS} \
-  /MP /W3 \
+  /MP /W3 /bigobj \
   /experimental:external /external:W0 "
 )
 


### PR DESCRIPTION
**Description of work.**
This enables the bigobj flag for targets where the number of sections in
an obj file exceeds 2^16 for ISISReflectometryTest targets causing the build to fail on MSVC debug. 
This is because the underlying target pulls in Qt and MantidQtWidgetsCommon
pushing us just over the threshold.

This is enabled by Microsoft by default for UWP apps (so has first party
support). The drawback is linkers pre-2005 cannot read from these
objects, something that will not affect us:
https://stackoverflow.com/a/15110915

**To test:**
- Build MantidScientificInterfacesISISReflectometryTestQt5 on MSVC Debug mode

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
