### PR TITLE
DrILL - zero filling in increment

### DIFF
--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/drill/presenter/DrillPresenter.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/drill/presenter/DrillPresenter.py
@@ -122,6 +122,7 @@ class DrillPresenter:
             ("10+20,100", 2)          -> "12+22,102"
             ("Sample_1,Sample10", 2)  -> "Sample_3,Sample12"
             ("Sample,sample10", 1)    -> "Sample,sample11"
+            ("Sample_01", 1)          -> "Sample_02"
 
             Args:
                 value (str): a string to increment

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/drill/presenter/DrillPresenter.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/drill/presenter/DrillPresenter.py
@@ -161,10 +161,10 @@ class DrillPresenter:
             suffix = re.search(r"\d+$", value)
             if suffix:
                 n = suffix.group(0)
-                ni = int(n) + i
-                if ni < 0:
-                    ni = 0
-                return value[0:-len(n)] + str(ni)
+                ni = str(int(n) + i).zfill(len(n))
+                if int(ni) < 0:
+                    ni = "0".zfill(len(n))
+                return value[0:-len(n)] + ni
 
             return value
 

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/drill/test/DrillPresenterTest.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/drill/test/DrillPresenterTest.py
@@ -63,7 +63,7 @@ class DrillPresenterTest(unittest.TestCase):
         # multiple columns
         self.view.increment.value.return_value = 7
         self.mTable.getSelectedCells.return_value = [(0, 0), (1, 0),
-                                                         (0, 1), (1, 1)]
+                                                     (0, 1), (1, 1)]
         self.mTable.getRowsFromSelectedCells.return_value = [0, 1]
         self.mTable.getCellContents.return_value = "10+15,100:200,1:10:2"
         self.presenter.onAutomaticFilling()

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/drill/test/DrillPresenterTest.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/drill/test/DrillPresenterTest.py
@@ -55,10 +55,10 @@ class DrillPresenterTest(unittest.TestCase):
         self.presenter.onAutomaticFilling()
         self.mTable.setCellContents.assert_called_with(0, 1, "11,101,1001")
         self.mTable.setCellContents.reset_mock()
-        self.mTable.getCellContents.return_value = "test1,test,test_10"
+        self.mTable.getCellContents.return_value = "test01,test,test_10"
         self.presenter.onAutomaticFilling()
         self.mTable.setCellContents.assert_called_with(0, 1,
-                                                           "test2,test,test_11")
+                                                       "test02,test,test_11")
         self.mTable.setCellContents.reset_mock()
         # multiple columns
         self.view.increment.value.return_value = 7


### PR DESCRIPTION
**Description of work.**

This PR changes the way the text are incremented in DrILL:
* previous behaviour: "sample_01" -> "sample_2"
* now: "sample_01" -> "sample_02"

**To test:**

* Open DrILL: Interfaces -> ILL -> DrILL
* add some rows
* fill the top cell of a column with something like "sample_01"
* select the whole column and press increment fill (`mdi-arrow-expand-down` icon -> https://pictogrammers.github.io/@mdi/font/3.6.95/)
* you should get something like this:

| <column_title> |
|----------------|
| sample_01 |
| sample_02 |
| sample_03 |


Part of #31403 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
