### PR TITLE
Scd421 s1offset ConverTWanscdToQ fix

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/ConvertWANDSCDtoQ.py
+++ b/Framework/PythonInterface/plugins/algorithms/ConvertWANDSCDtoQ.py
@@ -291,8 +291,14 @@ class ConvertWANDSCDtoQ(PythonAlgorithm):
         assert not data_array[:,:,0].ravel('F').flags.owndata
         assert data_array[:,:,0].flags.fnc
 
+        s1offset = np.deg2rad(self.getProperty("S1Offset").value)
+        s1offset = np.array([[ np.cos(s1offset), 0, np.sin(s1offset)],
+                             [             0,    1,                0],
+                             [-np.sin(s1offset), 0, np.cos(s1offset)]])
+
         for n in range(number_of_runs):
             R = inWS.getExperimentInfo(0).run().getGoniometer(n).getR()
+            R = np.dot(s1offset, R)
             RUBW = np.dot(R,UBW)
             q = np.round(np.dot(np.linalg.inv(RUBW),qlab.T)/bin_size-offset).astype(np.int)
             q_index = np.ravel_multi_index(q, (dim0_bins+2, dim1_bins+2, dim2_bins+2), mode='clip')

--- a/Testing/SystemTests/tests/framework/ConvertWANDSCDtoQTest.py
+++ b/Testing/SystemTests/tests/framework/ConvertWANDSCDtoQTest.py
@@ -141,10 +141,8 @@ class ConvertWANDSCDtoQ_Rotate_Test(systemtesting.MantidSystemTest):
 
         # ---
 
-        data = LoadMD(Filename='/HFIR/HB2C/shared/WANDscripts/test_data/data.nxs')
-
-        LoadIsawUB(InputWorkspace='data',
-                    Filename='/HFIR/HB2C/shared/WANDscripts/test_data/data.mat')
+        data = LoadMD(Filename='HB2C_WANDSCD_data.nxs')
+        SetGoniometer('data', Axis0='s1,0,1,0,1', Average=False)
 
         ConvertHFIRSCDtoMDE(data,
                             Wavelength=wavelength,
@@ -161,17 +159,11 @@ class ConvertWANDSCDtoQ_Rotate_Test(systemtesting.MantidSystemTest):
                                     S1Offset=angleOffset,
                                     BinningDim1='-1,1,1')
 
-        tableQ = FindPeaksMD(InputWorkspace=Q,
-                                PeakDistanceThreshold=0.2,
-                                MaxPeaks=20,
-                                DensityThresholdFactor=10000,
-                                OutputType='LeanElasticPeak')
+        tableQ = FindPeaksMD(InputWorkspace=Q, PeakDistanceThreshold=2,
+                             CalculateGoniometerForCW=True, Wavelength=1.488)
 
-        tableQrot = FindPeaksMD(InputWorkspace=Qrot,
-                                PeakDistanceThreshold=0.2,
-                                MaxPeaks=20,
-                                DensityThresholdFactor=10000,
-                                OutputType='LeanElasticPeak')
+        tableQrot = FindPeaksMD(InputWorkspace=Qrot, PeakDistanceThreshold=2,
+                                CalculateGoniometerForCW=True, Wavelength=1.488)
 
         self.assertEqual(tableQrot.getNumberPeaks(),tableQ.getNumberPeaks())
 

--- a/Testing/SystemTests/tests/framework/ConvertWANDSCDtoQTest.py
+++ b/Testing/SystemTests/tests/framework/ConvertWANDSCDtoQTest.py
@@ -150,14 +150,15 @@ class ConvertWANDSCDtoQ_Rotate_Test(systemtesting.MantidSystemTest):
                             Wavelength=wavelength,
                             ObliquityParallaxCoefficient=cop,
                             MinValues='{},{},{}'.format(*min_values),
-                            MaxValues='{},{},{}'.format(*max_values))
+                            MaxValues='{},{},{}'.format(*max_values),
+                            OutputWorkspace='qb')
 
         Q = ConvertWANDSCDtoQ(InputWorkspace='data',
                                 S1Offset='0',
                                 BinningDim1='-1,1,1')
 
         Qrot = ConvertWANDSCDtoQ(InputWorkspace='data',
-                                    S1Offset=45,
+                                    S1Offset=angleOffset,
                                     BinningDim1='-1,1,1')
 
         tableQ = FindPeaksMD(InputWorkspace=Q,


### PR DESCRIPTION
**Description of work.**
PR addresses a defect where argument `s1offset` of the algo `ConverTWanscdToQ` was not actually affecting the rotation, it should now rotate.

- [x] pr against `ornl-next` #32667

Companion to PR ornl-next [![GitHub issue/pull request detail](https://img.shields.io/github/issues/detail/state/mantidproject/mantid/32667)](https://github.com/mantidproject/mantid/pull/32667)

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**

<!-- test instructions -->

Run this script, and open Q and Qrot in the slice viewer, confirm Qrot is a rotated version of Q

```

# import mantid algorithms, numpy and matplotlib
from mantid.simpleapi import *
import matplotlib.pyplot as plt
import numpy as np

from mantid import config
config['Q.convention'] = "Inelastic"

# wavelength (angstrom) --------------------------------------------------------
wavelength = 1.486 

# minimum and maximum values for Q sample --------------------------------------
min_values = [-7.5,-0.65,-4.4]
max_values = [6.8,0.65,7.5]

# obliquity parallax coefficient
cop = 1.022

# ---

data = LoadMD(Filename='/HFIR/HB2C/shared/WANDscripts/test_data/data.nxs')

UB =  LoadIsawUB(InputWorkspace='data', 
                 Filename='/HFIR/HB2C/shared/WANDscripts/test_data/data.mat')

data_norm = ConvertHFIRSCDtoMDE(data, 
                                Wavelength=wavelength, 
                                ObliquityParallaxCoefficient=cop,
                                MinValues='{},{},{}'.format(*min_values),
                                MaxValues='{},{},{}'.format(*max_values))

Q = ConvertWANDSCDtoQ(InputWorkspace='data',
                      S1Offset='0',
                      BinningDim1='-1,1,1')
                       
Qrot = ConvertWANDSCDtoQ(InputWorkspace='data',
                         S1Offset='45',
                         BinningDim1='-1,1,1')


```


#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.