### PR TITLE
Fix bug in goniometer using Run assignment operator

### DIFF
--- a/Framework/API/src/Run.cpp
+++ b/Framework/API/src/Run.cpp
@@ -56,6 +56,8 @@ Run::Run(const Run &other) : LogManager(other), m_histoBins(other.m_histoBins) {
 Run::~Run() = default;
 
 Run &Run::operator=(const Run &other) {
+  if (this == &other)
+    return *this;
   LogManager::operator=(other);
   copyGoniometers(other);
   m_histoBins = other.m_histoBins;

--- a/Framework/API/test/RunTest.h
+++ b/Framework/API/test/RunTest.h
@@ -112,12 +112,16 @@ public:
     Property *p = new ConcreteProperty();
     TS_ASSERT_THROWS_NOTHING(runInfo.addProperty(p));
     TS_ASSERT_EQUALS(runInfo.getProperties().size(), 2);
+    TS_ASSERT_EQUALS(runInfo.getNumGoniometers(), 1);
+    TS_ASSERT_EQUALS(runInfo.getGoniometer(), Goniometer());
 
     // Copy constructor
     Run runInfo_2(runInfo);
     TS_ASSERT_EQUALS(runInfo_2.getProperties().size(), 2);
     TS_ASSERT_DELTA(runInfo_2.getProtonCharge(), 10.0, 1e-8);
     TS_ASSERT_EQUALS(runInfo_2.getLogData("Test")->value(), "Nothing");
+    TS_ASSERT_EQUALS(runInfo_2.getNumGoniometers(), 1);
+    TS_ASSERT_EQUALS(runInfo_2.getGoniometer(), Goniometer());
 
     // Now assignment
     runInfo.setProtonCharge(15.0);
@@ -125,6 +129,15 @@ public:
     runInfo_2 = runInfo;
     TS_ASSERT_EQUALS(runInfo_2.getProperties().size(), 1);
     TS_ASSERT_DELTA(runInfo_2.getProtonCharge(), 15.0, 1e-8);
+    TS_ASSERT_EQUALS(runInfo_2.getNumGoniometers(), 1);
+    TS_ASSERT_EQUALS(runInfo_2.getGoniometer(), Goniometer());
+
+    // Check self assignment
+    runInfo = runInfo;
+    TS_ASSERT_EQUALS(runInfo.getProperties().size(), 1);
+    TS_ASSERT_DELTA(runInfo.getProtonCharge(), 15.0, 1e-8);
+    TS_ASSERT_EQUALS(runInfo.getNumGoniometers(), 1);
+    TS_ASSERT_EQUALS(runInfo.getGoniometer(), Goniometer());
   }
 
   void testMemory() {

--- a/docs/source/release/v6.3.0/framework.rst
+++ b/docs/source/release/v6.3.0/framework.rst
@@ -48,4 +48,6 @@ Improvements
 Bugfixes
 ########
 
+- Fixed bug in :ref:`Run <Run>` goniometer when using :ref:`algm-Plus`.
+
 :ref:`Release 6.3.0 <v6.3.0>`


### PR DESCRIPTION
**Description of work.**

[PD373](https://code.ornl.gov/sns-hfir-scse/diffraction/powder/powder-diffraction/-/issues/373).

This bug came from using the `Plus` algorithm when `LHSWorkspace == OutputWorkspace`. It exist in 6.1 and 6.2 but not 6.0. 

**To test:**

```python
from mantid.simpleapi import CreateSampleWorkspace, Plus
ws1 = CreateSampleWorkspace()
ws2 = CreateSampleWorkspace()
ws1 = Plus(ws1, ws2)
print(ws1.run().getGoniometer().getR())
```

On master this is giving

```
---------------------------------------------------------------------------
IndexError                                Traceback (most recent call last)
<ipython-input-7-84968bb2f938> in <module>()
----> 1 print(ws1.run().getGoniometer().getR())

IndexError: Run::getGoniometer() const: index is out of range.
```

After the fix it correctly prints

```
[[ 1.  0.  0.]
 [ 0.  1.  0.]
 [ 0.  0.  1.]]
```

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
