### PR TITLE
Fix SANS not producing a range list when parsing files

### DIFF
--- a/docs/source/release/v6.3.0/sans.rst
+++ b/docs/source/release/v6.3.0/sans.rst
@@ -14,4 +14,10 @@ Improvements
 
 - Added missing logs to save in the header of ASCII files by DrILL for D11lr and D22lr ILL instruments
 
+Bugfixes
+--------
+
+- The :ref:`ISIS SANS Interface <ISIS_Sans_interface_contents>` will now generate and display a range of wavelength bins
+  specified in TOML files. This previously showed an empty field, despite correctly using the input from the TOML file.
+
 :ref:`Release 6.3.0 <v6.3.0>`

--- a/scripts/Interface/ui/sans_isis/sans_data_processor_gui.py
+++ b/scripts/Interface/ui/sans_isis/sans_data_processor_gui.py
@@ -1335,7 +1335,7 @@ class SANSDataProcessorGui(QMainWindow,
 
     @wavelength_range.setter
     def wavelength_range(self, value):
-        self.wavelength_slices.setText(value)
+        self.wavelength_slices_line_edit.setText(value)
 
     # ------------------------------------------------------------------------------------------------------------------
     # Scale Group

--- a/scripts/SANS/sans/common/general_functions.py
+++ b/scripts/SANS/sans/common/general_functions.py
@@ -7,12 +7,12 @@
 """ The elements of this module contain various general-purpose functions for the SANS reduction framework."""
 
 # pylint: disable=invalid-name
-
+import copy
 from math import (acos, sqrt, degrees)
 import re
 from copy import deepcopy
 import json
-from typing import Tuple, Optional
+from typing import Tuple, Optional, List
 
 import numpy as np
 from mantid.api import (AlgorithmManager, AnalysisDataService, isSameWorkspaceObject)
@@ -641,6 +641,14 @@ def get_ranges_for_rebin_array(rebin_array):
 def get_wav_range_from_ws(workspace) -> Tuple[float, float]:
     range_str = workspace.getRun().getProperty("Wavelength Range").valueAsStr
     return range_str.split('-')
+
+
+def wav_ranges_to_str(wav_ranges: List[Tuple[float, float]], *, remove_full_range: bool = False) -> str:
+    ranges = copy.deepcopy(wav_ranges)
+    if remove_full_range:
+        min_value, max_value = min(wav_ranges, key=lambda t: t[0])[0], max(wav_ranges, key=lambda t: t[1])[1]
+        ranges.remove((min_value, max_value))
+    return ", ".join(wav_range_to_str(i) for i in ranges)
 
 
 def wav_range_to_str(wav_range: Tuple[float, float]) -> str:

--- a/scripts/SANS/sans/gui_logic/models/state_gui_model.py
+++ b/scripts/SANS/sans/gui_logic/models/state_gui_model.py
@@ -13,7 +13,7 @@ from typing import Union
 
 from sans.common.enums import (ReductionDimensionality, ReductionMode, RangeStepType, SaveType,
                                DetectorType, FitModeForMerge)
-from sans.common.general_functions import get_ranges_from_event_slice_setting
+from sans.common.general_functions import get_ranges_from_event_slice_setting, wav_ranges_to_str
 from sans.gui_logic.models.model_common import ModelCommon
 from sans.state.AllStates import AllStates
 from sans.gui_logic.gui_common import (meter_2_millimeter, millimeter_2_meter, apply_selective_view_scaling,
@@ -410,6 +410,9 @@ class StateGuiModel(ModelCommon):
     @property
     def wavelength_range(self):
         val = self._wavelength_range
+        if not val:
+            val = wav_ranges_to_str(self.all_states.wavelength.wavelength_interval.selected_ranges,
+                                    remove_full_range=True)
         return self._get_val_or_default(val)
 
     @wavelength_range.setter

--- a/scripts/SANS/sans/gui_logic/presenter/run_tab_presenter.py
+++ b/scripts/SANS/sans/gui_logic/presenter/run_tab_presenter.py
@@ -994,6 +994,7 @@ class RunTabPresenter(PresenterCommon):
         self._set_on_view("wavelength_min")
         self._set_on_view("wavelength_max")
         self._set_on_view("wavelength_step")
+        self._set_on_view("wavelength_range")
 
         self._set_on_view("absolute_scale")
         self._set_on_view("z_offset", self.DEFAULT_DECIMAL_PLACES_MM)

--- a/scripts/test/SANS/common/general_functions_test.py
+++ b/scripts/test/SANS/common/general_functions_test.py
@@ -19,7 +19,8 @@ from sans.common.general_functions import (quaternion_to_angle_and_axis, create_
                                            convert_instrument_and_detector_type_to_bank_name,
                                            convert_bank_name_to_detector_type_isis,
                                            get_facility, parse_diagnostic_settings, get_transmission_output_name,
-                                           get_output_name, parse_event_slice_setting, wav_range_to_str)
+                                           get_output_name, parse_event_slice_setting, wav_range_to_str,
+                                           wav_ranges_to_str)
 from sans.state.StateObjects.StateData import StateData
 from sans.test_helper.test_director import TestDirector
 
@@ -603,6 +604,16 @@ class SANSFunctionsTest(unittest.TestCase):
         alg_manager_mock.reset_mock()
         create_managed_non_child_algorithm("TestAlg", **{"test_val": 5})
         alg_manager_mock.create.assert_called_once_with("TestAlg")
+
+    def test_wav_ranges_to_str_full_range_removed(self):
+        input_values = [(2, 600), (2, 200), (4, 400), (6, 600)]
+        expected_output = "2-200, 4-400, 6-600"
+        self.assertEqual(expected_output, wav_ranges_to_str(input_values, remove_full_range=True))
+
+    def test_wav_ranges_to_str(self):
+        input_values = [(2, 200), (4, 400), (6, 600)]
+        expected_output = "2-200, 4-400, 6-600"
+        self.assertEqual(expected_output, wav_ranges_to_str(input_values))
 
     def test_wav_range_to_str(self):
         input_values = (2, 200)

--- a/scripts/test/SANS/gui_logic/state_gui_model_test.py
+++ b/scripts/test/SANS/gui_logic/state_gui_model_test.py
@@ -264,6 +264,22 @@ class StateGuiModelTest(unittest.TestCase):
         state_gui_model.wavelength_step_type = RangeStepType.NOT_SET
         self.assertEqual(state_gui_model.wavelength_step_type, RangeStepType.LIN)
 
+    def test_wavelength_range_returns_user_string(self):
+        # We should return exactly the user string when we have it
+        state_gui_model = StateGuiModel(AllStates())
+        user_input = "1-3,3-5"
+        state_gui_model.wavelength_range = user_input
+        self.assertEqual(state_gui_model.wavelength_range, user_input)
+        self.assertEqual([(1., 5.), (1., 3.), (3., 5.)],
+                         state_gui_model.all_states.wavelength.wavelength_interval.selected_ranges)
+
+    def test_wavelength_range_builds_user_string(self):
+        # We need to build this string when the user hasn't interacted with the GUI
+        state_gui_model = StateGuiModel(AllStates())
+        ranges = [(1., 7.), (1., 3.), (3., 5.), (5., 7.)]
+        state_gui_model.all_states.wavelength.wavelength_interval.selected_ranges = ranges
+        self.assertEqual(state_gui_model.wavelength_range, "1.0-3.0, 3.0-5.0, 5.0-7.0")
+
     def test_wavelength_step_type_resets_range_for_non_range(self):
         state_gui_model = StateGuiModel(AllStates())
 


### PR DESCRIPTION
**Description of work.**
New TOML files allow us to accept and parse a range of log/lin
wavelength bins.
The old parser never accepted this, so a long-standing bug where the
GUI didn't update parser values from the user's input went unnoticed.

This commit will now construct a string from the list of wavelengths in
the GUI if we don't have the user's input.

**To test:**
- Download this TOML file: 
[USER_SANS2D_211O_2p4_4m_M4_Sans2d_Team_8mm_Changer.toml.txt](https://github.com/mantidproject/mantid/files/7279474/USER_SANS2D_211O_2p4_4m_M4_Sans2d_Team_8mm_Changer.toml.txt)
- Rename the `.toml.txt` to `.toml` (Github limitation)
- Open the ISIS SANS interface
- Click user file, select above TOML file
- Go to settings, `Q, Wavelength...`
- Under the wavelength section ensure `RANGELOG` is selected
- Check in ranges box the field is populated and contains something similar to `1.75-3, 3-5, 5-7, 7-9, 9-11, 11-13, 13-16.5` (formatting is not important, just that the pairs are there)

There is no associated issue - Noticed whilst working on #31866

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
