### PR TITLE
Enable NSIS packaging of files with long path names

### DIFF
--- a/buildconfig/CMake/NSIS.template.in
+++ b/buildconfig/CMake/NSIS.template.in
@@ -1,5 +1,9 @@
 ; CPack install script designed for a nmake build
 
+;This must be set for long paths to work properly.
+;Unicode only defaults to true in NSIS 3.07 onwards.
+Unicode True
+
 ;--------------------------------
 ; You must define these values
 

--- a/buildconfig/CMake/NSIS.template.in
+++ b/buildconfig/CMake/NSIS.template.in
@@ -39,6 +39,12 @@
   ;Set compression
   SetCompressor @CPACK_NSIS_COMPRESSOR@
 
+  ;Allow users to install to relatively highly nested directories if they have
+  ;the follwing reg key set to 1 (requires admin login):
+  ;HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\FileSystem\LongPathsEnabled
+  ;Otherwise, the user is limited by the max path length set in Windows.
+  ManifestLongPathAware true
+
 @CPACK_NSIS_DEFINES@
 
   !include Sections.nsh
@@ -661,9 +667,17 @@ FunctionEnd
 Section "-Core installation"
   ;Use the entire tree produced by the INSTALL target.  Keep the
   ;list of directories here in sync with the RMDir commands below.
+
   SetOutPath "$INSTDIR"
+
   @CPACK_NSIS_EXTRA_PREINSTALL_COMMANDS@
-  @CPACK_NSIS_FULL_INSTALL@
+
+  ;Replace the forward slashes in the temporary install directory INST_DIR with backslashes
+  ;otherwise the syntax for long path names ("\\?\") will not work.
+  Var /GLOBAL INST_DIR_BACKSLASHES
+  StrCpy $INST_DIR_BACKSLASHES "dummy" ;We need this line to avoid an unused variable warning!
+  !searchreplace INST_DIR_BACKSLASHES ${INST_DIR} "/" "\"
+  File /r "\\?\${INST_DIR_BACKSLASHES}\*.*"
 
   ;Store installation folder
   WriteRegStr SHCTX "Software\@CPACK_PACKAGE_VENDOR@\@CPACK_PACKAGE_INSTALL_REGISTRY_KEY@" "" $INSTDIR


### PR DESCRIPTION
**Description of work.**
Building of the Windows installer is currently failing because some third party files are in highly nested directories, e.g.
`File: failed opening file "C:/Jenkins/workspace/master_clean-windows/build/_CPack_Packages/win64/NSIS/mantidnightly-6.1.20210923.1259-win64\bin\mantidqtinterfaces\Muon\GUI\FrequencyDomainAnalysis\plot_widget\dual_plot_maxent_pane\__pycache__\dual_plot_maxent_pane_model.cpython-38.opt-1.pyc"`
The temporary install location used for packaging on Jenkins pushes the path length for some files above the default limit set in Windows. This limit has effectively been removed by prepending `\\?\` to the file names, which alloaws us to exceed the MAX_PATH value of 260. See here:
https://docs.microsoft.com/en-gb/windows/win32/fileio/naming-a-file?redirectedfrom=MSDN#maximum-path-length-limitation

Also, this flag has been added to the script:
`ManifestLongPathAware true`
which will allow users to install Mantid to a path which is very long. However, admin access is required to set the registry key:
`HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\FileSystem\LongPathsEnabled`
to 1 for this to work.

**To test:**
1. Attempt to build the NSIS package in a directory with a length that would push this over the limit of 260 characters:
`BUILD_DIRECTORY/_CPack_Packages/win64/NSIS/mantidnightly-6.1.20210923.1259-win64\bin\mantidqtinterfaces\Muon\GUI\FrequencyDomainAnalysis\plot_widget\dual_plot_maxent_pane\__pycache__\dual_plot_maxent_pane_model.cpython-38.opt-1.pyc`
i.e. replace `BUILD_DIRECTORY` with something that is a total of at least 46 characters. The build should run without any errors and produce the installer executable.
**OR**
Checking that the Windows package was buillt by Jenkins for this PR is probably sufficient

2. (Optional) Try installing Mantid to a directory with a silly long name or nested structure; something of similar length or greater than:
`C:/Jenkins/workspace/master_clean-windows/build/_CPack_Packages/win64/NSIS/mantidnightly-6.1.20210923.1259-win64`.
This will only work with the LongPathsEnabled reg key set to 1.


Fixes #32676 

*This does not require release notes* because it fixes our internal build system.

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
