### PR TITLE
Cppcheck suppressions of GeometryTriangulator

### DIFF
--- a/Framework/Geometry/src/Rendering/GeometryTriangulator.cpp
+++ b/Framework/Geometry/src/Rendering/GeometryTriangulator.cpp
@@ -61,10 +61,12 @@ Kernel::Logger g_log("GeometryTriangulator");
 } // namespace
 
 GeometryTriangulator::GeometryTriangulator(const CSGObject *obj)
-    : m_isTriangulated(false), m_nFaces(0), m_nPoints(0), m_csgObj(obj) {
+    : m_isTriangulated(false), m_nFaces(0), m_nPoints(0), m_csgObj(obj)
 #ifdef ENABLE_OPENCASCADE
-  m_objSurface = nullptr;
+      ,
+      m_objSurface(nullptr)
 #endif
+{
 }
 
 GeometryTriangulator::GeometryTriangulator(std::unique_ptr<RenderingMesh> obj)


### PR DESCRIPTION
Try to side-step what cppcheck things of opencascade. This is a combination of the drive to zero cppcheck warnings #32400 combined with a bug from the opencascade state from conda split of #32193 which was fixed in 27e5358eabd36a76cb93378527131fd4bffee856.

**To test:**

It should pass the cppcheck build.

*There is no associated issue.*

*This does not require release notes* because it is taking care of an eroneous cppcheck warning.

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
