### PR TITLE
Allow Setting of Read Only Columns on table workspaces. 

### DIFF
--- a/Framework/API/inc/MantidAPI/Column.h
+++ b/Framework/API/inc/MantidAPI/Column.h
@@ -34,7 +34,7 @@ namespace API {
 */
 class MANTID_API_DLL Column {
 public:
-  Column() : m_type("int"), m_plotType(-1000), m_isReadOnly(true){};
+  Column() : m_type("int"), m_plotType(-1000), m_isReadOnly(false){};
 
   /// Virtual destructor
   virtual ~Column() = default;

--- a/Framework/PythonInterface/mantid/api/src/Exports/ITableWorkspace.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/ITableWorkspace.cpp
@@ -194,6 +194,22 @@ bool addColumnSimple(ITableWorkspace &self, const std::string &type, const std::
 }
 
 /**
+ * Add a column to the TableWorkspace that cannot be edited.
+ * @param self A reference to the TableWorkspace python object that we were
+ * called on
+ * @param type The data type of the column to add
+ * @param name The name of the column to add
+ * @return A boolean indicating success or failure. Note that this is different
+ * to the corresponding C++ method, which returns a pointer to the
+ * newly-created column (as the Column class is not exposed to python).
+ */
+bool addReadOnlyColumn(ITableWorkspace &self, const std::string &type, const std::string &name) {
+  auto newColumn = self.addColumn(type, name);
+  newColumn->setReadOnly(true);
+  return newColumn != nullptr;
+}
+
+/**
  * Get the plot type of a column given by name or index
  * @param self Reference to TableWorkspace this is called on
  * @param column Name or index of column
@@ -668,6 +684,10 @@ void export_ITableWorkspace() {
            "(int,float,double,bool,str,V3D,long64) "
            "\nand plottype "
            "(0 = None, 1 = X, 2 = Y, 3 = Z, 4 = xErr, 5 = yErr, 6 = Label).")
+
+      .def("addReadOnlyColumn", &addReadOnlyColumn, (arg("self"), arg("type"), arg("name")),
+           "Add a read-only, named column with the given type. Recognized types are: "
+           "int,float,double,bool,str,V3D,long64")
 
       .def("getPlotType", &getPlotType, (arg("self"), arg("column")),
            "Get the plot type of given column as an integer. "

--- a/Framework/PythonInterface/mantid/api/src/Exports/ITableWorkspace.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/ITableWorkspace.cpp
@@ -508,6 +508,42 @@ void setCell(ITableWorkspace &self, const object &col_or_row, const int row_or_c
     self.modified();
   }
 }
+
+/**
+ * Get whether or not a column given by name or index is read only.
+ * @param self Reference to TableWorkspace this is called on
+ * @param column Name or index of column
+ * @return True if read only, False otherwise.
+ */
+int getReadOnly(ITableWorkspace &self, const object &column) {
+  // Find the column
+  Mantid::API::Column_const_sptr colptr;
+  if (STR_CHECK(column.ptr())) {
+    colptr = self.getColumn(extract<std::string>(column)());
+  } else {
+    colptr = self.getColumn(extract<int>(column)());
+  }
+
+  return colptr->getReadOnly();
+}
+
+/**
+ * Set whether or not a column given by name or index should be read only.
+ * @param self Reference to the TableWorkspace this was called on.
+ * @param column Name or index of column.
+ * @param readOnly True if read only, False otherwise.
+ */
+void setReadOnly(ITableWorkspace &self, const object &column, const bool readOnly) {
+  // Find the column
+  Mantid::API::Column_sptr colptr;
+  if (STR_CHECK(column.ptr())) {
+    colptr = self.getColumn(extract<std::string>(column)());
+  } else {
+    colptr = self.getColumn(extract<int>(column)());
+  }
+  colptr->setReadOnly(readOnly);
+  self.modified();
+}
 } // namespace
 
 /**
@@ -699,7 +735,15 @@ void export_ITableWorkspace() {
       .def("toDict", &toDict, (arg("self")),
            "Gets the values of this workspace as a dictionary. The keys of the "
            "dictionary will be the names of the columns of the table. The "
-           "values of the entries will be lists of values for each column.");
+           "values of the entries will be lists of values for each column.")
+
+      .def("setReadOnly", &setReadOnly, (arg("self"), arg("column"), arg("read_only")),
+           "Sets whether or not a given column of this workspace should be read-only. Columns can be "
+           "selected by name or by index")
+
+      .def("getReadOnly", &getReadOnly, (arg("self"), arg("column")),
+           "Gets whether or not a given column of this workspace is be read-only. Columns can be "
+           "selected by name or by index");
 
   //-------------------------------------------------------------------------------------------------
 

--- a/Framework/PythonInterface/mantid/api/src/Exports/ITableWorkspace.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/ITableWorkspace.cpp
@@ -515,7 +515,7 @@ void setCell(ITableWorkspace &self, const object &col_or_row, const int row_or_c
  * @param column Name or index of column
  * @return True if read only, False otherwise.
  */
-int getReadOnly(ITableWorkspace &self, const object &column) {
+int getColumnReadOnly(ITableWorkspace &self, const object &column) {
   // Find the column
   Mantid::API::Column_const_sptr colptr;
   if (STR_CHECK(column.ptr())) {
@@ -533,7 +533,7 @@ int getReadOnly(ITableWorkspace &self, const object &column) {
  * @param column Name or index of column.
  * @param readOnly True if read only, False otherwise.
  */
-void setReadOnly(ITableWorkspace &self, const object &column, const bool readOnly) {
+void setColumnReadOnly(ITableWorkspace &self, const object &column, const bool readOnly) {
   // Find the column
   Mantid::API::Column_sptr colptr;
   if (STR_CHECK(column.ptr())) {
@@ -737,11 +737,11 @@ void export_ITableWorkspace() {
            "dictionary will be the names of the columns of the table. The "
            "values of the entries will be lists of values for each column.")
 
-      .def("setReadOnly", &setReadOnly, (arg("self"), arg("column"), arg("read_only")),
+      .def("setColumnReadOnly", &setColumnReadOnly, (arg("self"), arg("column"), arg("read_only")),
            "Sets whether or not a given column of this workspace should be read-only. Columns can be "
            "selected by name or by index")
 
-      .def("getReadOnly", &getReadOnly, (arg("self"), arg("column")),
+      .def("getColumnReadOnly", &getColumnReadOnly, (arg("self"), arg("column")),
            "Gets whether or not a given column of this workspace is be read-only. Columns can be "
            "selected by name or by index");
 

--- a/Framework/PythonInterface/mantid/api/src/Exports/ITableWorkspace.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/ITableWorkspace.cpp
@@ -531,7 +531,7 @@ void setCell(ITableWorkspace &self, const object &col_or_row, const int row_or_c
  * @param column Name or index of column
  * @return True if read only, False otherwise.
  */
-int getColumnReadOnly(ITableWorkspace &self, const object &column) {
+bool isColumnReadOnly(ITableWorkspace &self, const object &column) {
   // Find the column
   Mantid::API::Column_const_sptr colptr;
   if (STR_CHECK(column.ptr())) {
@@ -539,7 +539,6 @@ int getColumnReadOnly(ITableWorkspace &self, const object &column) {
   } else {
     colptr = self.getColumn(extract<int>(column)());
   }
-
   return colptr->getReadOnly();
 }
 
@@ -761,7 +760,7 @@ void export_ITableWorkspace() {
            "Sets whether or not a given column of this workspace should be read-only. Columns can be "
            "selected by name or by index")
 
-      .def("getColumnReadOnly", &getColumnReadOnly, (arg("self"), arg("column")),
+      .def("isColumnReadOnly", &isColumnReadOnly, (arg("self"), arg("column")),
            "Gets whether or not a given column of this workspace is be read-only. Columns can be "
            "selected by name or by index");
 

--- a/Framework/PythonInterface/mantid/api/src/Exports/ITableWorkspace.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/ITableWorkspace.cpp
@@ -206,7 +206,7 @@ bool addColumnSimple(ITableWorkspace &self, const std::string &type, const std::
 bool addReadOnlyColumn(ITableWorkspace &self, const std::string &type, const std::string &name) {
   auto newColumn = self.addColumn(type, name);
   newColumn->setReadOnly(true);
-  return newColumn != nullptr;
+  return true;
 }
 
 /**

--- a/Framework/PythonInterface/test/python/mantid/api/ITableWorkspaceTest.py
+++ b/Framework/PythonInterface/test/python/mantid/api/ITableWorkspaceTest.py
@@ -268,6 +268,22 @@ class ITableWorkspaceTest(unittest.TestCase):
         self.assertTrue(name in AnalysisDataService)
         AnalysisDataService.remove(name)
 
+    def test_default_table_columns_are_editable(self):
+        test_table = self._create_test_table()
+        self.assertFalse(test_table.getColumnReadOnly(0))
+        self.assertFalse(test_table.getColumnReadOnly(1))
+
+    def test_add_read_only_column_makes_non_editable(self):
+        test_table = self._create_test_table()
+        test_table.addReadOnlyColumn(type='int', name='roCol')
+        self.assertTrue(test_table.getColumnReadOnly(2))
+
+    def test_set_read_only_column(self):
+        test_table = self._create_test_table()
+        self.assertFalse(test_table.getColumnReadOnly(0))
+        test_table.setColumnReadOnly(0, True)
+        self.assertTrue(test_table.getColumnReadOnly(0))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/Framework/PythonInterface/test/python/mantid/api/ITableWorkspaceTest.py
+++ b/Framework/PythonInterface/test/python/mantid/api/ITableWorkspaceTest.py
@@ -270,19 +270,19 @@ class ITableWorkspaceTest(unittest.TestCase):
 
     def test_default_table_columns_are_editable(self):
         test_table = self._create_test_table()
-        self.assertFalse(test_table.getColumnReadOnly(0))
-        self.assertFalse(test_table.getColumnReadOnly(1))
+        self.assertFalse(test_table.isColumnReadOnly(0))
+        self.assertFalse(test_table.isColumnReadOnly(1))
 
     def test_add_read_only_column_makes_non_editable(self):
         test_table = self._create_test_table()
         test_table.addReadOnlyColumn(type='int', name='roCol')
-        self.assertTrue(test_table.getColumnReadOnly(2))
+        self.assertTrue(test_table.isColumnReadOnly(2))
 
     def test_set_read_only_column(self):
         test_table = self._create_test_table()
-        self.assertFalse(test_table.getColumnReadOnly(0))
+        self.assertFalse(test_table.isColumnReadOnly(0))
         test_table.setColumnReadOnly(0, True)
-        self.assertTrue(test_table.getColumnReadOnly(0))
+        self.assertTrue(test_table.isColumnReadOnly(0))
 
 
 if __name__ == '__main__':

--- a/docs/source/release/v6.3.0/mantidworkbench.rst
+++ b/docs/source/release/v6.3.0/mantidworkbench.rst
@@ -15,7 +15,7 @@ New and Improved
     :align: center
 - The integration slider in the instrument viewer now support discrete steps when the axis has discrete values.
 - The algorithm browser has been tidied to reduce the number of single algorithm categories.
-- Table workspaces can now have read-only columns added to them. Existing columns can also be set to be read-only.
+- Table workspaces can now have read-only columns added to them (`ws.addReadOnlyColumn(<TYPE>, <NAME>)`). Existing columns can also be set to be read-only (`ws.setColumnReadOnly(<INDEX>, <TRUE/FALSE>)`).
 
 Bugfixes
 --------

--- a/docs/source/release/v6.3.0/mantidworkbench.rst
+++ b/docs/source/release/v6.3.0/mantidworkbench.rst
@@ -15,6 +15,7 @@ New and Improved
     :align: center
 - The integration slider in the instrument viewer now support discrete steps when the axis has discrete values.
 - The algorithm browser has been tidied to reduce the number of single algorithm categories.
+- Table workspaces can now have read-only columns added to them. Existing columns can also be set to be read-only.
 
 Bugfixes
 --------

--- a/qt/python/mantidqt/mantidqt/utils/testing/mocks/mock_mantid.py
+++ b/qt/python/mantidqt/mantidqt/utils/testing/mocks/mock_mantid.py
@@ -105,7 +105,7 @@ class MockWorkspace:
         self.getColumnNames = StrictMock(return_value=self._column_names)
         self.column_count = self.COLS
         self.columnCount = StrictMock(return_value=self.column_count)
-        self.getColumnReadOnly = StrictMock(return_value=False)
+        self.isColumnReadOnly = StrictMock(return_value=False)
 
         self.row_count = self.ROWS
         self.rowCount = StrictMock(return_value=self.row_count)

--- a/qt/python/mantidqt/mantidqt/utils/testing/mocks/mock_mantid.py
+++ b/qt/python/mantidqt/mantidqt/utils/testing/mocks/mock_mantid.py
@@ -105,6 +105,7 @@ class MockWorkspace:
         self.getColumnNames = StrictMock(return_value=self._column_names)
         self.column_count = self.COLS
         self.columnCount = StrictMock(return_value=self.column_count)
+        self.getColumnReadOnly = StrictMock(return_value=False)
 
         self.row_count = self.ROWS
         self.rowCount = StrictMock(return_value=self.row_count)

--- a/qt/python/mantidqt/mantidqt/widgets/workspacedisplay/table/model.py
+++ b/qt/python/mantidqt/mantidqt/widgets/workspacedisplay/table/model.py
@@ -110,7 +110,7 @@ class TableWorkspaceDisplayModel:
         if self.is_peaks_workspace():
             return self.ws.getColumnNames()[icol] in self.EDITABLE_COLUMN_NAMES
         else:
-            return not self.ws.getColumnReadOnly(icol)
+            return not self.ws.isColumnReadOnly(icol)
 
     def is_peaks_workspace(self):
         return isinstance(self.ws, IPeaksWorkspace)

--- a/qt/python/mantidqt/mantidqt/widgets/workspacedisplay/table/model.py
+++ b/qt/python/mantidqt/mantidqt/widgets/workspacedisplay/table/model.py
@@ -110,7 +110,7 @@ class TableWorkspaceDisplayModel:
         if self.is_peaks_workspace():
             return self.ws.getColumnNames()[icol] in self.EDITABLE_COLUMN_NAMES
         else:
-            return True
+            return not self.ws.getReadOnly(icol)
 
     def is_peaks_workspace(self):
         return isinstance(self.ws, IPeaksWorkspace)

--- a/qt/python/mantidqt/mantidqt/widgets/workspacedisplay/table/model.py
+++ b/qt/python/mantidqt/mantidqt/widgets/workspacedisplay/table/model.py
@@ -110,7 +110,7 @@ class TableWorkspaceDisplayModel:
         if self.is_peaks_workspace():
             return self.ws.getColumnNames()[icol] in self.EDITABLE_COLUMN_NAMES
         else:
-            return not self.ws.getReadOnly(icol)
+            return not self.ws.getColumnReadOnly(icol)
 
     def is_peaks_workspace(self):
         return isinstance(self.ws, IPeaksWorkspace)

--- a/qt/python/mantidqt/mantidqt/widgets/workspacedisplay/table/test/test_tableworkspacedisplay_model.py
+++ b/qt/python/mantidqt/mantidqt/widgets/workspacedisplay/table/test/test_tableworkspacedisplay_model.py
@@ -163,6 +163,14 @@ class TableWorkspaceDisplayModelTest(unittest.TestCase):
         self.assertEqual(3, model.marked_columns.as_y_err[1].related_y_column)
         self.assertEqual(4, model.marked_columns.as_y_err[2].related_y_column)
 
+    def test_is_editable_column(self):
+        ws = MockWorkspace()
+        model = TableWorkspaceDisplayModel(ws)
+        ws.getColumnReadOnly = StrictMock(return_value=False)
+        self.assertTrue(model.is_editable_column(0))
+        ws.getColumnReadOnly = StrictMock(return_value=True)
+        self.assertFalse(model.is_editable_column(0))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/qt/python/mantidqt/mantidqt/widgets/workspacedisplay/table/test/test_tableworkspacedisplay_model.py
+++ b/qt/python/mantidqt/mantidqt/widgets/workspacedisplay/table/test/test_tableworkspacedisplay_model.py
@@ -166,9 +166,9 @@ class TableWorkspaceDisplayModelTest(unittest.TestCase):
     def test_is_editable_column(self):
         ws = MockWorkspace()
         model = TableWorkspaceDisplayModel(ws)
-        ws.getColumnReadOnly = StrictMock(return_value=False)
+        ws.isColumnReadOnly = StrictMock(return_value=False)
         self.assertTrue(model.is_editable_column(0))
-        ws.getColumnReadOnly = StrictMock(return_value=True)
+        ws.isColumnReadOnly = StrictMock(return_value=True)
         self.assertFalse(model.is_editable_column(0))
 
 


### PR DESCRIPTION
**Description of work.**
Added the ability to use scripts to set columns in table workspaces to be read only when opened in the mantid viewer. 

**To test:**
1. This script covers most of the new functionality:
```
ws = CreateEmptyTableWorkspace()

ws.addReadOnlyColumn("int", "what")
ws.addColumn("str", "huh")
ws.addColumn("int", "eh")

ws.addRow([0, "aaa", 2])
ws.addRow([1, "bbb", 3])

ws.setCell(0, 0, 10)

ws.setColumnReadOnly("huh", True)
```
2. Check that only the `eh` column is editable in the workspace viewer. 

Fixes #20662 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
