### PR TITLE
Write all spectra to single file when not split in SaveFocusedXYE

### DIFF
--- a/Framework/DataHandling/src/SaveFocusedXYE.cpp
+++ b/Framework/DataHandling/src/SaveFocusedXYE.cpp
@@ -106,6 +106,15 @@ void SaveFocusedXYE::exec() {
 
   const auto &detectorInfo = inputWS->detectorInfo();
 
+  if (!split) {
+    const std::string file(std::string(filename).append(".").append(ext));
+    Poco::File fileObj(file);
+    const bool exists = fileObj.exists();
+    out.open(file.c_str(), mode);
+    if (headers && (!exists || !append))
+      writeHeaders(out, inputWS);
+  }
+
   Progress progress(this, 0.0, 1.0, nHist);
   for (size_t i = 0; i < nHist; i++) {
     const auto &X = inputWS->x(i);
@@ -130,17 +139,8 @@ void SaveFocusedXYE::exec() {
       }
     }
 
-    if ((!split) && out) // Assign only one file
-    {
-      const std::string file(std::string(filename).append(".").append(ext));
-      Poco::File fileObj(file);
-      const bool exists = fileObj.exists();
-      out.open(file.c_str(), mode);
-      if (headers && (!exists || !append))
-        writeHeaders(out, inputWS);
-    } else if (split) // Several files will be created with names:
-                      // filename-i.ext
-    {
+    if (split) {
+      // Several files will be created with names filename-i.ext
       number << "-" << i + startingbank;
       const std::string file(std::string(filename).append(number.str()).append(".").append(ext));
       Poco::File fileObj(file);

--- a/Framework/DataHandling/test/SaveFocusedXYETest.h
+++ b/Framework/DataHandling/test/SaveFocusedXYETest.h
@@ -79,10 +79,11 @@ public:
     }
   }
 
-  void testHistogram() {
+  void testHistogramFileNotSplit() {
     using namespace Mantid::API;
     using namespace Mantid::DataObjects;
-    Workspace2D_sptr workspace = WorkspaceCreationHelper::create2DWorkspaceBinned(1, 3, 1.0, 1.0);
+    size_t nbins = 3;
+    Workspace2D_sptr workspace = WorkspaceCreationHelper::create2DWorkspaceBinned(2, nbins, 1.0, 1.0);
     workspace->getAxis(0)->unit() = Mantid::Kernel::UnitFactory::Instance().create("TOF");
 
     TS_ASSERT_DIFFERS(workspace, std::shared_ptr<Workspace2D>());
@@ -112,40 +113,31 @@ public:
                                                   "# Data for spectra :0",
                                                   "# Spectrum 1 ",
                                                   "# Time-of-flight              Y                 E"};
-    int bin_no(1);
     size_t lineNumber = 0;
+    int bin_no(1);
+    bool twoSpectraWritten(false);
     while (getline(filestrm, line)) {
-      lineNumber++;
       std::istringstream is(line);
-      if (lineNumber <= expectedHeader.size()) {
-        TS_ASSERT_EQUALS(is.str(), expectedHeader[lineNumber - 1]);
-        continue;
+      if (lineNumber < expectedHeader.size()) {
+        TS_ASSERT_EQUALS(is.str(), expectedHeader[lineNumber]);
+      } else if (lineNumber < expectedHeader.size() + nbins || lineNumber > expectedHeader.size() + nbins + 2) {
+        // entered the second spectrum block - note blocks are separated by 2 lines of additional header
+        if (bin_no > nbins) {
+          bin_no = 1;
+          twoSpectraWritten = true;
+        }
+        double x(0.0), y(0.0), e(0.);
+        is >> x >> y >> e;
+        TS_ASSERT_DELTA(x, static_cast<double>(bin_no) + 0.5, m_tol);
+        TS_ASSERT_DELTA(y, 2.0, m_tol);
+        TS_ASSERT_DELTA(e, M_SQRT2, m_tol);
+        ++bin_no;
       }
-      double x(0.0), y(0.0), e(0.);
-      is >> x >> y >> e;
-      switch (bin_no) {
-      case 1:
-        TS_ASSERT_DELTA(x, 1.5, m_tol);
-        TS_ASSERT_DELTA(y, 2.0, m_tol);
-        TS_ASSERT_DELTA(e, M_SQRT2, m_tol);
-        break;
-      case 2:
-        TS_ASSERT_DELTA(x, 2.5, m_tol);
-        TS_ASSERT_DELTA(y, 2.0, m_tol);
-        TS_ASSERT_DELTA(e, M_SQRT2, m_tol);
-        break;
-      case 3:
-        TS_ASSERT_DELTA(x, 3.5, m_tol);
-        TS_ASSERT_DELTA(y, 2.0, m_tol);
-        TS_ASSERT_DELTA(e, M_SQRT2, m_tol);
-        break;
-      default:
-        TS_ASSERT(false);
-      }
-      ++bin_no;
+      lineNumber++;
     }
     filestrm.close();
     focusfile.remove();
+    TS_ASSERT(twoSpectraWritten)
     AnalysisDataService::Instance().remove(resultWS);
   }
 

--- a/Framework/DataHandling/test/SaveFocusedXYETest.h
+++ b/Framework/DataHandling/test/SaveFocusedXYETest.h
@@ -122,7 +122,7 @@ public:
         TS_ASSERT_EQUALS(is.str(), expectedHeader[lineNumber]);
       } else if (lineNumber < expectedHeader.size() + nbins || lineNumber > expectedHeader.size() + nbins + 2) {
         // entered the second spectrum block - note blocks are separated by 2 lines of additional header
-        if (bin_no > nbins) {
+        if (static_cast<size_t>(bin_no) > nbins) {
           bin_no = 1;
           twoSpectraWritten = true;
         }

--- a/docs/source/release/v6.3.0/diffraction.rst
+++ b/docs/source/release/v6.3.0/diffraction.rst
@@ -18,6 +18,7 @@ Powder Diffraction
 
 Bugfixes
 ########
+- :ref:`SaveFocusedXYE <algm-SaveFocusedXYE>` now correctly writes all spectra to a single file when SplitFiles is False (previously wrote only a single spectrum).
 - For processing vanadium run, we don't want to find environment automatically in :ref:`SetSampleFromLogs <algm-SetSampleFromLogs>`.
 - Identification in :ref:`AlignComponents <algm-AlignComponents>` of the first and last detector-ID for an instrument component with unsorted detector-ID's.
 


### PR DESCRIPTION
**Description of work.**

Fixed bug such that all spectra are written to a single file when not split in `SaveFocusedXYE` (as in `SaveGSS` etc.)

**To test:**

(1) Run this script taken from docs of `SaveFocusedXYE`
```
ws = CreateSampleWorkspace()
ws = CropWorkspace(ws, StartWorkspaceIndex=0, EndWorkspaceIndex=4)

file_name = "myworkspace.ascii"
path = os.path.join(os.path.expanduser("~"), file_name)

SaveFocusedXYE(ws, path, SplitFiles=False, IncludeHeader=True, Format='XYE')
```
(2) Check there is a single file output that contains all 5 spectra in the workspace (separated by a header) - previously there would be only one spectrum written to file.
(3) Set `SplitFiles=True` and check this is not impacted (should be a file per spectrum)


*There is no associated issue.*

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
