### PR TITLE
Add importance sampling according to DiscusMultipleScatteringCorrection

### DIFF
--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -516,10 +516,9 @@ useStlAlgorithm:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/UpdateInstrumentF
 nullPointer:${CMAKE_SOURCE_DIR}/Framework/Kernel/inc/MantidKernel/IPropertyManager.h:163
 nullPointer:${CMAKE_SOURCE_DIR}/Framework/Kernel/inc/MantidKernel/IPropertyManager.h:163
 funcArgOrderDifferent:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/CalculateEfficiency.cpp:308
-passedByValue:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/DiscusMultipleScatteringCorrection.cpp:482
-useStlAlgorithm:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/DiscusMultipleScatteringCorrection.cpp:257
 constParameter:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/CalculatePlaczekSelfScattering.cpp:29
 constParameter:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/CalculatePlaczek.cpp:45
+useStlAlgorithm:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/DiscusMultipleScatteringCorrection.cpp:253
 redundantInitialization:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/ChangeTimeZero.cpp:133
 constParameter:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/ConvertAxisByFormula.cpp:238
 constParameter:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/ConvertAxisByFormula.cpp:255

--- a/docs/source/algorithms/DiscusMultipleScatteringCorrection-v1.rst
+++ b/docs/source/algorithms/DiscusMultipleScatteringCorrection-v1.rst
@@ -34,7 +34,7 @@ The quantity :math:`J_n` is calculated by performing the following integration:
 
 .. math::
 
-   J_n &= (\frac{\mu}{4 \pi})^n \frac{1}{A} \int dS \int_{0}^{l_1^{max}} dl_1 e^{-\mu_T l_1} \prod\limits_{i=1}^{n-1} [\int_{0}^{l_{i+1}^{max}} dl_{i+1} \int_{0}^{\pi} \sin\theta_i d\theta_i \int_{0}^{2 \pi} d\phi_i (e^{-\mu_T l_{i+1}}) S(Q_i)] e^{-\mu_T l_{out}} S(Q_n) \\
+   J_n &= (\frac{\mu_s}{4 \pi})^n \frac{1}{A} \int dS \int_{0}^{l_1^{max}} dl_1 e^{-\mu_T l_1} \prod\limits_{i=1}^{n-1} [\int_{0}^{l_{i+1}^{max}} dl_{i+1} \int_{0}^{\pi} \sin\theta_i d\theta_i \int_{0}^{2 \pi} d\phi_i (e^{-\mu_T l_{i+1}}) S(Q_i)] e^{-\mu_T l_{out}} S(Q_n) \\
        &=(\frac{\mu_s}{4 \pi})^n \frac{1}{A} \int dS \int_{0}^{l_1^{max}} dl_1 e^{-\mu_T l_1} \prod\limits_{i=1}^{n-1} [\int_{0}^{l_{i+1}^{max}} dl_{i+1} \int_{0}^{2k} dQ_i \int_{0}^{2 \pi} d\phi_i (e^{-\mu_T l_{i+1}}) \frac{Q_i}{k^2} S(Q_i)] e^{-\mu_T l_{out}} S(Q_n)
 
 
@@ -44,35 +44,64 @@ The following substitutions are then performed in order to make it more convenie
 
 :math:`t_i = \frac{1-e^{-\mu_T l_i}}{1-e^{-\mu_T l_i^{max}}}`
 
-:math:`p_i = \frac{\phi_i}{2 \pi}`
+:math:`u_i = \frac{\phi_i}{2 \pi}`
 
-:math:`\int_0^{2k} Q_i S(Q_i) dQ = 2 k^2`
+:math:`2 k^2 = \frac{\sigma_S \int_0^{2k} Q_i S(Q_i) dQ}{\sigma_s(k)}`
 
 Using the new variables the integral is:
 
 .. math::
 
-   J_n = \frac{1}{A} \int dS \int_{0}^{1} dt_1 \frac{1-e^{-\mu_T l_1^{\ max}}}{\sigma_T} \prod\limits_{i=1}^{n-1}[\int_{0}^{1} dt_{i+1} \int_{0}^{2k} dQ_i \int_{0}^{1} dp_i \frac{(1-e^{-\mu_T l_{i+1}^{max}})}{\sigma_T} \frac{Q_i}{\int_0^{2k} Q_i S(Q_i) dQ_i} S(Q_i) \sigma_S] e^{-\mu_T l_{out}} S(Q_n) \frac{\sigma_s}{4 \pi}
+   J_n = \frac{1}{A} \int dS \int_{0}^{1} dt_1 \frac{1-e^{-\mu_T l_1^{\ max}}}{\sigma_T} \prod\limits_{i=1}^{n-1}[\int_{0}^{1} dt_{i+1} \int_{0}^{2k} dQ_i \int_{0}^{1} du_i \frac{(1-e^{-\mu_T l_{i+1}^{max}})}{\sigma_T} \frac{Q_i}{\int_0^{2k} Q_i S(Q_i) dQ_i} S(Q_i) \sigma_s(k)] e^{-\mu_T l_{out}} S(Q_n) \frac{\sigma_s}{4 \pi}
 
-This is evaluated as a Monte Carlo integration by selecting random values for the variables :math:`t_i` and :math:`p_i` between 0 and 1 and values for :math:`Q_i` between 0 and 2k.
+This is evaluated as a Monte Carlo integration by selecting random values for the variables :math:`t_i` and :math:`u_i` between 0 and 1 and values for :math:`Q_i` between 0 and 2k.
 A simulated path is traced through the sample to enable the :math:`l_i^{\ max}` values to be calculated. The path is traced by calculating the :math:`l_i`, :math:`\theta` and :math:`\phi` values as follows from the random variables. The code keeps a note of the start coordinates of the current path segment and updates it when moving to the next segment using these randomly selected lengths and directions:
 
 :math:`l_i = -\frac{1}{\mu_T}ln(1-(1-e^{-\mu_T l_i^{\ max}})t_i)`
 
-:math:`\cos(\theta_i) = 1 - Q_i^2/k^2`
+:math:`\cos\theta_i = 1 - Q_i^2/k^2`
 
-:math:`\phi_i = 2 \pi p_i`
+:math:`\phi_i = 2 \pi u_i`
 
-The final Monte Carlo integration that is actually performed by the code is as follows:
+The final Monte Carlo integration that is actually performed by the code is as follows where N is the number of scenarios:
 
 .. math::
 
-   J_n = \frac{1}{N}\sum \frac{1-e^{-\mu_T l_1^{\ max}}}{\sigma_T} \prod\limits_{i=1}^{n-1}[\frac{(1-e^{-\mu_T l_{i+1}^{max}})}{\sigma_T} \frac{Q_i}{<Q S(Q)>} S(Q_i) \sigma_S] e^{-\mu_T l_{out}} S(Q_n) \frac{\sigma_s}{4 \pi}
+   J_n = \frac{1}{N}\sum \frac{1-e^{-\mu_T l_1^{\ max}}}{\sigma_T} \prod\limits_{i=1}^{n-1}[\frac{(1-e^{-\mu_T l_{i+1}^{max}})}{\sigma_T} \frac{Q_i}{<Q S(Q)>} S(Q_i) \sigma_s(k)] e^{-\mu_T l_{out}} S(Q_n) \frac{\sigma_s}{4 \pi}
 
 The purpose of replacing :math:`2 k^2` with :math:`\int Q S(Q) dQ` can now be seen because it avoids the need to multiply by an integration range across :math:`dQ` when converting the integral to a Monte Carlo integration.
 This is useful in the inelastic version of this algorithm where the integration of the structure factor is over two dimensions :math:`Q` and :math:`\omega` and the area of :math:`Q\omega` space that has been integrated over is less obvious.
 
 This is similar to the formulation described in the Mancinelli paper except there is no random variable to decide whether a particular scattering event is coherent or incoherent.
+
+Importance Sampling
+^^^^^^^^^^^^^^^^^^^
+
+The algorithm includes an option to use importance sampling to improve the results for S(Q) profiles containing spikes.
+Without this option enabled, the contribution from rare, high values in the structure factor is only visible at a very high number of scenarios.
+
+The importance sampling is achieved using a further change of variables as follows:
+
+:math:`v_i = P(Q_i) = \frac{I(Q_i)}{I(2k)}` where :math:`I(x) = \int_{0}^{x} Q S(Q) dQ`
+
+With this approach the Q value for each segment is chosen as follows based on a :math:`v_i` value randomly selected between 0 and 1:
+
+:math:`Q_i = P^{-1}(v_i)`
+
+:math:`\cos\theta_i` is determined from :math:`Q_i` as before. The change of variables gives the following integral for :math:`J_n`:
+
+.. math::
+
+   J_n = \frac{1}{A} \int dS \int_{0}^{1} dt_1 \frac{1-e^{-\mu_T l_1^{\ max}}}{\sigma_T} \prod\limits_{i=1}^{n-1}[\int_{0}^{1} dt_{i+1} \int_{0}^{1} dv_i 2 \frac{I(2k)}{2k^2} \sigma_s \int_{0}^{1} du_i \frac{(1-e^{-\mu_T l_{i+1}^{max}})}{\sigma_T}] e^{-\mu_T l_{out}} S(Q_n) \frac{\sigma_s}{4 \pi}
+
+   J_n = \frac{1}{A} \int dS \int_{0}^{1} dt_1 \frac{1-e^{-\mu_T l_1^{\ max}}}{\sigma_T} \prod\limits_{i=1}^{n-1}[\int_{0}^{1} dt_{i+1} \int_{0}^{1} dv_i 2 \sigma_s(k) \int_{0}^{1} du_i \frac{(1-e^{-\mu_T l_{i+1}^{max}})}{\sigma_T}] e^{-\mu_T l_{out}} S(Q_n) \frac{\sigma_s}{4 \pi}
+
+Finally, the equivalent Monte Carlo integration that the algorithm performs with importance sampling enabled is:
+
+.. math::
+
+   J_n = \frac{1}{N}\sum \frac{1-e^{-\mu_T l_1^{\ max}}}{\sigma_T} \prod\limits_{i=1}^{n-1}[2 \sigma_s(k) \frac{(1-e^{-\mu_T l_{i+1}^{max}})}{\sigma_T}] e^{-\mu_T l_{out}} S(Q_n) \frac{\sigma_s}{4 \pi}
+
 
 Outputs
 #######

--- a/docs/source/release/v6.3.0/framework.rst
+++ b/docs/source/release/v6.3.0/framework.rst
@@ -29,6 +29,7 @@ Improvements
 - Event nexuses produced at ILL can now be loaded using :ref:`LoadEventNexus <algm-LoadEventNexus>`.
 - :ref:`Rebin <algm-Rebin>` now has an option for binning with reverse logarithmic and inverse power bins.
 - :ref:`SetSample <algm-SetSample>` can now load sample environment XML files from any directory using ``SetSample(ws, Environment={'Name': 'NameOfXMLFile', 'Path':'/path/to/file/'})``.
+- An importance sampling option has been added to :ref:`DiscusMultipleScatteringCorrection <algm-DiscusMultipleScatteringCorrection>` so that it handles spikes in the structure factor S(Q) better
 
 Bugfixes
 ########


### PR DESCRIPTION
**Description of work.**

Add importance sampling option to DiscusMultipleScatteringCorrection so that it converges more quickly for situations where S(Q) contains spikes eg diffraction

The previous gaussian interpolation that was used to interpolate the S(Q) distribution has been removed because it didn't work very nicely with the importance sampling. It has been replaced by a more simple "flat" interpolation from the previous point in the distribution. This also removes the need to insist on the S(Q) distribution being >0 at all points and having equally spaced points

**To test:**

The following script calculates a multiple scattering correction that uses an S(Q) profile consisting of a single spike at Q=7. The input workspace has detectors spread over a two theta range 0 to 180 degrees, each spectrum has a single bin centred on wavelength=1 angstrom. The wavelength and the spike position corresponds to a two theta angle of 67.7 degrees.

This should give a multiple scattering correction with a peak at two theta=0 and two theta=2*67.7=135.4 degrees corresponding to two scatters with a smooth U shaped curve in between. The detector with two theta=135.4 degrees is attached to spectrum ~680

If you run the script twice with ImportanceSampling set to True and False you should see that the result with "True" is much cleaner and the peaks at 0 and 135.4 degrees are visible with the U shape in between. If you change the peak width to be x10 narrower the result without importance sampling degenerates further.

I suggest you run it on a release build to save a bit of time.

![image](https://user-images.githubusercontent.com/56295817/136770373-4f80bcf8-3fb0-4ffb-a16f-601208bf66f8.png)

The correction is stored in the Scatter_2 workspace that sits inside a workspace group called MSResults.

```
# import mantid algorithms, numpy and matplotlib
from mantid.simpleapi import *
import matplotlib.pyplot as plt
import numpy as np
from testhelpers import WorkspaceCreationHelper

test_ws = WorkspaceCreationHelper.create2DWorkspaceWithGeographicalDetectors(1, 900, 0.2, 1)
ws_name = "test"
AnalysisDataService.addOrReplace(ws_name, test_ws)

X=[6.9,7.0,7.1]
Y=[0.,1000,0.]
Sofq=CreateWorkspace(DataX=X,DataY=Y,UnitX="MomentumTransfer")

SetSample(InputWorkspace=test_ws,
          Geometry={'Shape': 'FlatPlate', 'Height': 4.0,
                  'Width': 4.0, 'Thick': 1.0,
                  'Center': [0.,0.,0.]},
          Material={'ChemicalFormula': 'Ni'})

DiscusMultipleScatteringCorrection(InputWorkspace=test_ws, SofqWorkspace=Sofq, OutputWorkspace="MSResults",
                                   NeutronPathsSingle=1, NeutronPathsMultiple=10000, NumberScatterings=2,
                                   ImportanceSampling=True)
```

Fixes #32208.

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
