### PR TITLE
Fix crash in Engg UI caused by TOF to dSpacing unit conversion failure

### DIFF
--- a/docs/source/release/v6.3.0/diffraction.rst
+++ b/docs/source/release/v6.3.0/diffraction.rst
@@ -29,6 +29,9 @@ Improvements
 - Improved axes scaling in the plot of the :ref:`Engineering Diffraction interface<Engineering_Diffraction-ref>` :ref:`Fitting tab <ui engineering fitting>`.
 - Automatically disable zoom and pan when opening the fit browser in the :ref:`Fitting tab <ui engineering fitting>` of the Engineering Diffraction interface (as they interfered with the interactive peak adding tool).
 
+Bugfixes
+########
+- Fix crash on :ref:`Fitting tab <ui engineering fitting>` when trying to output fit results. The problem was caused by a unit conversion from TOF to dSpacing not being possible eg when peak centre at a negative TOF value
 
 Single Crystal Diffraction
 --------------------------

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/data_handling/data_model.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/data_handling/data_model.py
@@ -221,9 +221,12 @@ class FittingDataModel(object):
                         # param corresponds to a peak centre in TOF which we also need in dspacing
                         # add another entry into the results dictionary
                         key_d = key + "_dSpacing"
-                        dcen = self._convert_TOF_to_d(params_dict['Value'][irow], wsname)
-                        dcen_er = self._convert_TOFerror_to_derror(params_dict['Error'][irow], dcen, wsname)
-                        self._fit_results[wsname]['results'][key_d].append([dcen, dcen_er])
+                        try:
+                            dcen = self._convert_TOF_to_d(params_dict['Value'][irow], wsname)
+                            dcen_er = self._convert_TOFerror_to_derror(params_dict['Error'][irow], dcen, wsname)
+                            self._fit_results[wsname]['results'][key_d].append([dcen, dcen_er])
+                        except (ValueError, RuntimeError) as e:
+                            logger.warning(f"Unable to output {key_d} parameters for TOF={params_dict['Value'][irow]}: " + str(e))
                 istart += nparams[ifunc]
             # append the cost function value (in this case always chisq/DOF) as don't let user change cost func
             # always last row in parameters table


### PR DESCRIPTION
**Description of work.**

Saurabh reported a crash on the fitting tab when doing some serial fits on a large sequence of runs. The crash was caused by a unit conversion failing and the resulting exception wasn't being handled

**To test:**

I wasn't able to reproduce the crash every single time for some reason but this sequence of steps seemed to do it after 2-3 presses of the "Serial Fit" button:

1. Load the files in the attached zip into the Fitting tab

[ENGINX_FocusedFiles.zip](https://github.com/mantidproject/mantid/files/7312046/ENGINX_FocusedFiles.zip)

2. Plot the data for 329639 and add a peak onto the highest peak

3. Click the serial Fit button and wait a few seconds for the fits to complete (should be some log messages written)

4. Click the serial Fit button again

After one of the serial fits complete you should see some warning like these. Previously Mantid would have crashed:

![image](https://user-images.githubusercontent.com/56295817/136575499-d8801937-b38a-43db-936c-e7ad089da2dc.png)


Fixes #32658. 



<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
