### PR TITLE
Correctly toggle "Grids on/off" button for 3D surface plot

### DIFF
--- a/docs/source/release/v6.3.0/mantidworkbench.rst
+++ b/docs/source/release/v6.3.0/mantidworkbench.rst
@@ -20,6 +20,6 @@ Bugfixes
 --------
 - Fixed arbitrary values not being accepted as the "Start Time" in StartLiveDataDialog.
 - Fixed a bug where the option "SignedInPlaneTwoTheta" in :ref:`ConvertSpectrumAxis <algm-ConvertSpectrumAxis-v2>` would not give signed results.
-
+- Fixed a bug where the toggle state of the "Grids on/off" toolbar button was incorrect when opening a 3D surface plot.
 
 :ref:`Release 6.3.0 <v6.3.0>`

--- a/qt/applications/workbench/workbench/plotting/test/test_toolbar.py
+++ b/qt/applications/workbench/workbench/plotting/test/test_toolbar.py
@@ -15,6 +15,7 @@ matplotlib.use("Agg")  # noqa
 import matplotlib.pyplot as plt
 
 from mantidqt.utils.qt.testing import start_qapplication
+from mantidqt.plotting.functions import plot_surface
 from workbench.plotting.figuremanager import MantidFigureCanvas, FigureManagerWorkbench
 from mantid.plots.plotfunctions import plot
 from mantid.simpleapi import CreateSampleWorkspace
@@ -126,6 +127,27 @@ class ToolBarTest(unittest.TestCase):
         axes[0][1].grid()
         axes[1][0].grid()
         # Grid button should be OFF because not all subplots have grids.
+        self.assertFalse(self._is_grid_button_checked(fig))
+
+    @patch("workbench.plotting.figuremanager.QAppThreadCall")
+    def test_button_checked_for_3d_surface_plot_with_grid(self, mock_qappthread):
+        mock_qappthread.return_value = mock_qappthread
+        ws = CreateSampleWorkspace()
+        fig = plt.figure()
+        plot_surface([ws], fig)
+        # Grid button should be on because grid is on by default in surface plot.
+        self.assertTrue(self._is_grid_button_checked(fig))
+
+    @patch("workbench.plotting.figuremanager.QAppThreadCall")
+    def test_button_unchecked_for_3d_surface_plot_without_grid(self, mock_qappthread):
+        mock_qappthread.return_value = mock_qappthread
+        ws = CreateSampleWorkspace()
+        fig = plt.figure()
+        plot_surface([ws], fig)
+        ax = fig.get_axes()
+        # Turn grids off for the plot, they're on by default.
+        ax[0].grid(False)
+        # Grid button should be on because grid is on by default in surface plot.
         self.assertFalse(self._is_grid_button_checked(fig))
 
     @classmethod

--- a/qt/applications/workbench/workbench/plotting/test/test_toolbar.py
+++ b/qt/applications/workbench/workbench/plotting/test/test_toolbar.py
@@ -17,6 +17,7 @@ import matplotlib.pyplot as plt
 from mantidqt.utils.qt.testing import start_qapplication
 from mantidqt.plotting import functions
 from workbench.plotting.figuremanager import MantidFigureCanvas, FigureManagerWorkbench
+from workbench.plotting.toolbar import WorkbenchNavigationToolbar
 from mantid.plots.plotfunctions import plot
 from mantid.simpleapi import CreateSampleWorkspace
 
@@ -128,6 +129,17 @@ class ToolBarTest(unittest.TestCase):
         axes[1][0].grid()
         # Grid button should be OFF because not all subplots have grids.
         self.assertFalse(self._is_grid_button_checked(fig))
+
+    def test_is_colorbar(self):
+        """Verify the functionality of _is_colorbar, which determines whether a set of axes is a colorbar."""
+        ws = CreateSampleWorkspace()
+        fig = plt.figure()
+        fig = functions.plot_surface([ws], fig=fig)
+        axes = fig.get_axes()
+        # First set of axes is the surface plot
+        self.assertFalse(WorkbenchNavigationToolbar._is_colorbar(axes[0]))
+        # Second set of axes is the colorbar
+        self.assertTrue(WorkbenchNavigationToolbar._is_colorbar(axes[1]))
 
     @patch("workbench.plotting.figuremanager.QAppThreadCall")
     def test_grid_button_state_for_3d_plots(self, mock_qappthread):

--- a/qt/applications/workbench/workbench/plotting/test/test_toolbar.py
+++ b/qt/applications/workbench/workbench/plotting/test/test_toolbar.py
@@ -15,7 +15,7 @@ matplotlib.use("Agg")  # noqa
 import matplotlib.pyplot as plt
 
 from mantidqt.utils.qt.testing import start_qapplication
-from mantidqt.plotting.functions import plot_surface
+from mantidqt.plotting.functions import plot_surface, plot_wireframe
 from workbench.plotting.figuremanager import MantidFigureCanvas, FigureManagerWorkbench
 from mantid.plots.plotfunctions import plot
 from mantid.simpleapi import CreateSampleWorkspace
@@ -147,7 +147,28 @@ class ToolBarTest(unittest.TestCase):
         ax = fig.get_axes()
         # Turn grids off for the plot, they're on by default.
         ax[0].grid(False)
-        # Grid button should be on because grid is on by default in surface plot.
+        # Grid button should be off because we turned it off.
+        self.assertFalse(self._is_grid_button_checked(fig))
+
+    @patch("workbench.plotting.figuremanager.QAppThreadCall")
+    def test_button_checked_for_3d_wireframe_plot_with_grid(self, mock_qappthread):
+        mock_qappthread.return_value = mock_qappthread
+        ws = CreateSampleWorkspace()
+        fig = plt.figure()
+        plot_wireframe([ws], fig)
+        # Grid button should be on because grid is on by default in wireframe plot.
+        self.assertTrue(self._is_grid_button_checked(fig))
+
+    @patch("workbench.plotting.figuremanager.QAppThreadCall")
+    def test_button_unchecked_for_3d_wireframe_plot_without_grid(self, mock_qappthread):
+        mock_qappthread.return_value = mock_qappthread
+        ws = CreateSampleWorkspace()
+        fig = plt.figure()
+        plot_wireframe([ws], fig)
+        ax = fig.get_axes()
+        # Turn grids off for the plot, they're on by default.
+        ax[0].grid(False)
+        # Grid button should be on because we turned it off.
         self.assertFalse(self._is_grid_button_checked(fig))
 
     @classmethod

--- a/qt/applications/workbench/workbench/plotting/toolbar.py
+++ b/qt/applications/workbench/workbench/plotting/toolbar.py
@@ -241,9 +241,12 @@ class WorkbenchNavigationToolbar(MantidNavigationToolbar):
         if figure_type(fig) in [FigureType.Surface, FigureType.Wireframe, FigureType.Mesh]:
             self.adjust_for_3d_plots()
 
-        # Toggle grid on/off button in case plot is created from a script.
+        # Determine the toggle state of the grid button. If all subplots have grids, then set it to on.
         is_major_grid_on = False
         for ax in fig.get_axes():
+            # Don't look for grids on colour bars.
+            if self._is_colorbar(ax):
+                continue
             if hasattr(ax, 'grid_on'):
                 is_major_grid_on = ax.grid_on()
             else:
@@ -254,13 +257,17 @@ class WorkbenchNavigationToolbar(MantidNavigationToolbar):
         self._actions['toggle_grid'].setChecked(is_major_grid_on)
 
     def is_colormap(self, fig):
-        """Identify as a single colopur map if it has a axes, one with the plot and the other the colorbar"""
+        """Identify as a single colour map if it has a axes, one with the plot and the other the colorbar"""
         if figure_type(fig) in [FigureType.Image] and len(fig.get_axes()) == 2:
             if len(fig.get_axes()[0].get_images()) == 1 and len(fig.get_axes()[1].get_images()) == 0 \
-                    and not hasattr(fig.get_axes()[1], 'get_subplotspec'):
+                    and self._is_colorbar(fig.get_axes()[1]):
                 return True
         else:
             return False
+
+    def _is_colorbar(self, ax):
+        """Determine whether an axes object is a colorbar"""
+        return not hasattr(ax, 'get_subplotspec')
 
     def set_up_color_selector_toolbar_button(self, fig):
         # check if the action is already in the toolbar

--- a/qt/applications/workbench/workbench/plotting/toolbar.py
+++ b/qt/applications/workbench/workbench/plotting/toolbar.py
@@ -265,7 +265,8 @@ class WorkbenchNavigationToolbar(MantidNavigationToolbar):
         else:
             return False
 
-    def _is_colorbar(self, ax):
+    @classmethod
+    def _is_colorbar(cls, ax):
         """Determine whether an axes object is a colorbar"""
         return not hasattr(ax, 'get_subplotspec')
 


### PR DESCRIPTION
**Description of work.**
When opening a 3D surface plot, the "Grids on/off" toolbar button was toggled off, despite the grids being visibile on the plot. This bug was introduced in 6.1, but is resolved by this PR. Tests have been added to help prevent similar regressions.

**To test:**
1. Load a workspace and open a 3D surface plot by right clicking the workspace and selecting `Plot > 3D > Surface`.
2. By default, grid lines are visible in the plot. Verify that the "Grids on/off" toolbar button has the correct check state.

Fixes #32674.


#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
