### PR TITLE
Support rasterizing container with a different element size in MultipleScatteringCorrection and PaalmanPingsAbsorptionCorrection

### DIFF
--- a/Framework/Algorithms/inc/MantidAlgorithms/MultipleScatteringCorrection.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/MultipleScatteringCorrection.h
@@ -33,7 +33,7 @@ public:
   /// Algorithm's summary
   const std::string summary() const override {
     return "Calculate Multiple Scattering Correction using numerical integration with the assumption of"
-           "elastic scattering only, and isotropic scattering within the sample.";
+           "elastic and isotropic scattering only.";
   };
 
   /// Algorithm's see also

--- a/Framework/Algorithms/inc/MantidAlgorithms/MultipleScatteringCorrection.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/MultipleScatteringCorrection.h
@@ -45,7 +45,8 @@ protected:
   API::MatrixWorkspace_sptr m_inputWS; ///< A pointer to the input workspace
   Kernel::V3D m_beamDirection;         ///< The direction of the beam.
   int64_t m_num_lambda;                ///< The number of points in wavelength, the rest is interpolated linearly
-  double m_elementSize;                ///< The size of the sample in meters
+  double m_sampleElementSize;          ///< The size of the integration element for sample in meters
+  double m_containerElementSize;       ///< the size of the integration element for container in meters
 
 private:
   void init() override;
@@ -53,7 +54,8 @@ private:
   std::map<std::string, std::string> validateInputs() override;
 
   void parseInputs();
-  void calculateSingleComponent(const API::MatrixWorkspace_sptr &outws, const Geometry::IObject &shape);
+  void calculateSingleComponent(const API::MatrixWorkspace_sptr &outws, const Geometry::IObject &shape,
+                                const double elementSize);
   void calculateSampleAndContainer(const API::MatrixWorkspace_sptr &outws);
   // For single component case
   void calculateLS1s(const MultipleScatteringCorrectionDistGraber &distGraber, //

--- a/Framework/Algorithms/inc/MantidAlgorithms/PaalmanPingsAbsorptionCorrection.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/PaalmanPingsAbsorptionCorrection.h
@@ -104,7 +104,8 @@ private:
 
   /// Create the gague volume for the correction
   std::shared_ptr<const Geometry::IObject> constructGaugeVolume();
-  double m_cubeSide; ///< The length of the side of an element cube in m
+  double m_cubeSideSample;    ///< The length of the side of an element cube in m
+  double m_cubeSideContainer; ///< The length of the side of an element cube in m
 };
 
 } // namespace Algorithms

--- a/Framework/Algorithms/src/MultipleScatteringCorrection.cpp
+++ b/Framework/Algorithms/src/MultipleScatteringCorrection.cpp
@@ -229,7 +229,8 @@ void MultipleScatteringCorrection::parseInputs() {
   m_xStep = std::max(int64_t(1), specSize / m_num_lambda); // Bin step between points to calculate
   // -- notify the user of the bin step
   std::ostringstream msg;
-  msg << "Numerical integration performed every " << m_xStep << " wavelength points\n";
+  msg << "Numerical integration performed every " << m_xStep << " wavelength points";
+  g_log.information(msg.str());
   g_log.information() << msg.str();
 
   // Get the element size

--- a/Framework/Algorithms/src/MultipleScatteringCorrection.cpp
+++ b/Framework/Algorithms/src/MultipleScatteringCorrection.cpp
@@ -229,7 +229,7 @@ void MultipleScatteringCorrection::parseInputs() {
   m_xStep = std::max(int64_t(1), specSize / m_num_lambda); // Bin step between points to calculate
   // -- notify the user of the bin step
   std::ostringstream msg;
-  msg << "Numerical integration performed every " << m_xStep << " wavelength points";
+  msg << "Numerical integration performed every " << m_xStep << " wavelength points\n";
   g_log.information() << msg.str();
 
   // Get the element size
@@ -321,11 +321,11 @@ void MultipleScatteringCorrection::calculateSingleComponent(const API::MatrixWor
       // debug output
 #ifndef NDEBUG
       std::ostringstream msg_debug;
-      msg_debug << "Det_" << workspaceIndex << "@spectrum_" << wvBinsIndex << ":\n"
-                << "\trho = " << rho << ", sigma_s = " << sigma_s << "\n"
-                << "\tA1 = " << A1 << "\n"
-                << "\tA2 = " << A2 << "\n"
-                << "\tms_factor = " << output[wvBinsIndex] << "\n";
+      msg_debug << "Det_" << workspaceIndex << "@spectrum_" << wvBinsIndex << '\n'
+                << "\trho = " << rho << ", sigma_s = " << sigma_s << '\n'
+                << "\tA1 = " << A1 << '\n'
+                << "\tA2 = " << A2 << '\n'
+                << "\tms_factor = " << output[wvBinsIndex] << '\n';
       g_log.notice(msg_debug.str());
 #endif
 
@@ -417,8 +417,8 @@ void MultipleScatteringCorrection::calculateSampleAndContainer(const API::Matrix
       const auto idx = calcLinearIdxFromUpperTriangular(numVolumeElements, i, j);
       const auto l12 = L12_container[idx] + L12_sample[idx];
       if (l12 < 1e-9) {
-        g_log.notice() << "L12_container(" << i << "," << j << ")=" << L12_container[idx] << "\n"
-                       << "L12_sample(" << i << "," << j << ")=" << L12_sample[idx] << "\n";
+        g_log.notice() << "L12_container(" << i << "," << j << ")=" << L12_container[idx] << '\n'
+                       << "L12_sample(" << i << "," << j << ")=" << L12_sample[idx] << '\n';
       }
     }
   }
@@ -432,17 +432,17 @@ void MultipleScatteringCorrection::calculateSampleAndContainer(const API::Matrix
 #ifndef NDEBUG
   for (size_t i = 0; i < elementVolumes.size(); ++i) {
     if (elementVolumes[i] < 1e-16) {
-      g_log.notice() << "Element_" << i << " has near zero volume: " << elementVolumes[i] << "\n";
+      g_log.notice() << "Element_" << i << " has near zero volume: " << elementVolumes[i] << '\n';
     }
   }
   g_log.notice() << "V_container = "
                  << std::accumulate(distGraberContainer.m_elementVolumes.begin(),
                                     distGraberContainer.m_elementVolumes.end(), 0.0)
-                 << "\n"
+                 << '\n'
                  << "V_sample = "
                  << std::accumulate(distGraberSample.m_elementVolumes.begin(), distGraberSample.m_elementVolumes.end(),
                                     0.0)
-                 << "\n";
+                 << '\n';
 #endif
 
   // NOTE: Unit is important
@@ -505,16 +505,16 @@ void MultipleScatteringCorrection::calculateSampleAndContainer(const API::Matrix
       // debug output
 #ifndef NDEBUG
       std::ostringstream msg_debug;
-      msg_debug << "Det_" << workspaceIndex << "@spectrum_" << wvBinsIndex << ":\n"
-                << "-containerLinearCoefAbs[wvBinsIndex] = " << -containerLinearCoefAbs[wvBinsIndex] << "\n"
-                << "-sampleLinearCoefAbs[wvBinsIndex] = " << -sampleLinearCoefAbs[wvBinsIndex] << "\n"
-                << "numVolumeElementsContainer = " << numVolumeElementsContainer << "\n"
-                << "numVolumeElements = " << numVolumeElements << "\n"
-                << "totScatterCoef_container = " << totScatterCoef_container << "\n"
-                << "totScatterCoef_sample = " << totScatterCoef_sample << "\n"
-                << "\tA1 = " << A1 << "\n"
-                << "\tA2 = " << A2 << "\n"
-                << "\tms_factor = " << output[wvBinsIndex] << "\n";
+      msg_debug << "Det_" << workspaceIndex << "@spectrum_" << wvBinsIndex << "\n"
+                << "-containerLinearCoefAbs[wvBinsIndex] = " << -containerLinearCoefAbs[wvBinsIndex] << '\n'
+                << "-sampleLinearCoefAbs[wvBinsIndex] = " << -sampleLinearCoefAbs[wvBinsIndex] << '\n'
+                << "numVolumeElementsContainer = " << numVolumeElementsContainer << '\n'
+                << "numVolumeElements = " << numVolumeElements << '\n'
+                << "totScatterCoef_container = " << totScatterCoef_container << '\n'
+                << "totScatterCoef_sample = " << totScatterCoef_sample << '\n'
+                << "\tA1 = " << A1 << '\n'
+                << "\tA2 = " << A2 << '\n'
+                << "\tms_factor = " << output[wvBinsIndex] << '\n';
       g_log.notice(msg_debug.str());
 #endif
 
@@ -604,13 +604,13 @@ void MultipleScatteringCorrection::calculateLS1s(const MultipleScatteringCorrect
 #ifndef NDEBUG
     // debug
     std::ostringstream msg_debug;
-    msg_debug << "idx=" << idx << ", pos=" << pos << ", vec=" << vec << "\n";
+    msg_debug << "idx=" << idx << ", pos=" << pos << ", vec=" << vec << '\n';
     if (idx < numVolumeElementsContainer) {
-      msg_debug << "Container element " << idx << "\n";
+      msg_debug << "Container element " << idx << '\n';
     } else {
-      msg_debug << "Sample element " << idx - numVolumeElementsContainer << "\n";
+      msg_debug << "Sample element " << idx - numVolumeElementsContainer << '\n';
     }
-    msg_debug << "LS1_container=" << LS1sContainer[idx] << ", LS1_sample=" << LS1sSample[idx] << "\n";
+    msg_debug << "LS1_container=" << LS1sContainer[idx] << ", LS1_sample=" << LS1sSample[idx] << '\n';
     g_log.notice(msg_debug.str());
 #endif
   }

--- a/Framework/Algorithms/src/MultipleScatteringCorrection.cpp
+++ b/Framework/Algorithms/src/MultipleScatteringCorrection.cpp
@@ -505,7 +505,7 @@ void MultipleScatteringCorrection::calculateSampleAndContainer(const API::Matrix
       // debug output
 #ifndef NDEBUG
       std::ostringstream msg_debug;
-      msg_debug << "Det_" << workspaceIndex << "@spectrum_" << wvBinsIndex << "\n"
+      msg_debug << "Det_" << workspaceIndex << "@spectrum_" << wvBinsIndex << '\n'
                 << "-containerLinearCoefAbs[wvBinsIndex] = " << -containerLinearCoefAbs[wvBinsIndex] << '\n'
                 << "-sampleLinearCoefAbs[wvBinsIndex] = " << -sampleLinearCoefAbs[wvBinsIndex] << '\n'
                 << "numVolumeElementsContainer = " << numVolumeElementsContainer << '\n'

--- a/Framework/Algorithms/src/MultipleScatteringCorrection.cpp
+++ b/Framework/Algorithms/src/MultipleScatteringCorrection.cpp
@@ -244,6 +244,7 @@ void MultipleScatteringCorrection::parseInputs() {
  *
  * @param outws
  * @param shape
+ * @param elementSize length of cube size used to rasterize given shape
  */
 void MultipleScatteringCorrection::calculateSingleComponent(const API::MatrixWorkspace_sptr &outws,
                                                             const Geometry::IObject &shape, const double elementSize) {

--- a/Framework/Algorithms/src/PaalmanPingsAbsorptionCorrection.cpp
+++ b/Framework/Algorithms/src/PaalmanPingsAbsorptionCorrection.cpp
@@ -52,7 +52,8 @@ PaalmanPingsAbsorptionCorrection::PaalmanPingsAbsorptionCorrection()
       m_sample_containerL1s(), m_sampleElementVolumes(), m_sampleElementPositions(), m_numSampleVolumeElements(0),
       m_sampleVolume(0.0), m_containerL1s(), m_container_sampleL1s(), m_containerElementVolumes(),
       m_containerElementPositions(), m_numContainerVolumeElements(0), m_containerVolume(0.0),
-      m_ampleLinearCoefTotScatt(0), m_containerLinearCoefTotScatt(0), m_num_lambda(0), m_xStep(0), m_cubeSide(0.0) {}
+      m_ampleLinearCoefTotScatt(0), m_containerLinearCoefTotScatt(0), m_num_lambda(0), m_xStep(0),
+      m_cubeSideSample(0.0), m_cubeSideContainer(0.0) {}
 
 void PaalmanPingsAbsorptionCorrection::init() {
 
@@ -75,6 +76,10 @@ void PaalmanPingsAbsorptionCorrection::init() {
   auto moreThanZero = std::make_shared<BoundedValidator<double>>();
   moreThanZero->setLower(0.001);
   declareProperty("ElementSize", 1.0, moreThanZero, "The size of one side of an integration element cube in mm");
+
+  declareProperty("ContainerElementSize", EMPTY_DBL(),
+                  "The size of one side of an integration element cube in mm for container."
+                  "Default to be the same as ElementSize.");
 }
 
 std::map<std::string, std::string> PaalmanPingsAbsorptionCorrection::validateInputs() {
@@ -281,7 +286,7 @@ void PaalmanPingsAbsorptionCorrection::initialiseCachedDistances() {
     integrationVolume = constructGaugeVolume();
   }
 
-  auto raster = Geometry::Rasterize::calculate(m_beamDirection, *integrationVolume, m_cubeSide);
+  auto raster = Geometry::Rasterize::calculate(m_beamDirection, *integrationVolume, m_cubeSideSample);
   m_sampleVolume = raster.totalvolume;
   if (raster.l1.size() == 0)
     throw std::runtime_error("Failed to rasterize shape");
@@ -297,7 +302,7 @@ void PaalmanPingsAbsorptionCorrection::initialiseCachedDistances() {
     integrationVolume = constructGaugeVolume();
   }
 
-  raster = Geometry::Rasterize::calculate(m_beamDirection, *integrationVolume, m_cubeSide);
+  raster = Geometry::Rasterize::calculate(m_beamDirection, *integrationVolume, m_cubeSideContainer);
   m_containerVolume = raster.totalvolume;
   if (raster.l1.size() == 0)
     throw std::runtime_error("Failed to rasterize shape");
@@ -354,8 +359,11 @@ void PaalmanPingsAbsorptionCorrection::retrieveBaseProperties() {
   m_num_lambda = getProperty("NumberOfWavelengthPoints");
 
   // Call the virtual function for any further properties
-  m_cubeSide = getProperty("ElementSize"); // in mm
-  m_cubeSide *= 0.001;                     // now in m
+  m_cubeSideSample = getProperty("ElementSize"); // in mm
+  m_cubeSideSample *= 0.001;                     // now in m
+  // use the same elementsize for container if not specified, otherwise use the specified value
+  m_cubeSideContainer = getProperty("ContainerElementSize"); // in mm
+  m_cubeSideContainer = isDefault("ContainerElementSize") ? m_cubeSideSample : m_cubeSideContainer * 1e-3;
 }
 
 /// Create the sample object using the Geometry classes, or use the existing one

--- a/docs/source/algorithms/MultipleScatteringCorrection-v1.rst
+++ b/docs/source/algorithms/MultipleScatteringCorrection-v1.rst
@@ -230,6 +230,71 @@ Notice that the output workspace group now contains ``_containerOnly`` and ``_sa
 
 .. testcleanup:: SampleAndContainer
 
+The following code demonstrates a workaround to deal with thin container walls where a separate
+element size for container is needed.
+
+.. testcode:: SampleAndContainerWithDifferentContainerElementSize
+
+    # ----------------------- #
+    # make an empty workspace #
+    # ----------------------- #
+    # Create a fake workspace with TOF data
+    ws = CreateSampleWorkspace(Function='Powder Diffraction',
+                                NumBanks=2,
+                                BankPixelWidth=1,
+                                XUnit='TOF',
+                                XMin=1000,
+                                XMax=10000,)
+    # Fake instrument
+    EditInstrumentGeometry(ws,
+                            PrimaryFlightPath=5.0,
+                            SpectrumIDs=[1, 2],
+                            L2=[2.0, 2.0],
+                            Polar=[10.0, 90.0],
+                            Azimuthal=[0.0, 45.0],
+                            DetectorIDs=[1, 2],
+                            InstrumentName="Instrument")
+    # set sample and container
+    SetSample(
+            ws,
+            Geometry={
+                "Shape": "Cylinder",
+                "Center": [0., 0., 0.],
+                "Height": 1.0,  # cm
+                "Radius": 0.3,  # cm
+            },
+            Material = {
+                "ChemicalFormula": "La-(B11)5.94-(B10)0.06",
+                "SampleNumberDensity": 0.1,
+            },
+            ContainerMaterial = {
+                "ChemicalFormula": "V",
+                "SampleNumberDensity": 0.0721,
+            },
+            ContainerGeometry = {
+                "Shape": "HollowCylinder",
+                "Height": 1.0,  # cm
+                "InnerRadius": 0.3,  # cm
+                "OuterRadius": 0.35,  # cm
+                "Center": [0., 0., 0.],
+            }
+        )
+    # to wavelength
+    ConvertUnits(InputWorkspace=ws,
+                    OutputWorkspace=ws,
+                    Target="Wavelength",
+                    EMode="Elastic")
+    # call
+    MultipleScatteringCorrection(
+        InputWorkspace = ws,
+        Method="SampleAndContainer",
+        ElementSize=0.5,
+        ContainerElementSize=0.1,
+        OutputWorkspace="rst",
+    )
+
+.. testcleanup:: SampleAndContainerWithDifferentContainerElementSize
+
 .. categories::
 
 .. sourcelink::

--- a/docs/source/algorithms/PaalmanPingsAbsorptionCorrection-v1.rst
+++ b/docs/source/algorithms/PaalmanPingsAbsorptionCorrection-v1.rst
@@ -45,6 +45,11 @@ shape <HowToDefineGeometricShape>` to a :ref:`Run <Run>` property called
 (and the sample) is integrated, because this is all the detector can
 'see'. The full sample is still used for the neutron paths.
 
+It is worth pointing out that the parameter ``ContainerElementSize`` has very
+limited impact on the final absorption correction factor, therefore it is generally
+safe to use the same element size for both sample and container regardless of
+the actual geometry difference when running this algorithm.
+
 Usage
 -----
 

--- a/docs/source/release/v6.3.0/diffraction.rst
+++ b/docs/source/release/v6.3.0/diffraction.rst
@@ -15,6 +15,7 @@ Powder Diffraction
 - `CalibrateRectangularDetectors`, which is deprecate since v6.2.0, is removed. And system test CalibrateRectangularDetectors_Test is removed.
 - Extending :ref:`MultipleScatteringCorrection <algm-MultipleScatteringCorrection>` to the sample and container case.
 - `absorptioncorrutils` now have the capability to calculate effective absorption correction (considering both absorption and multiple scattering).
+- Both :ref:`MultipleScatteringCorrection <algm-MultipleScatteringCorrection>` and :ref:`PaalmanPingsAbsorptionCorrection <algm-PaalmanPingsAbsorptionCorrection>` can use a different element size for container now.
 
 Bugfixes
 ########


### PR DESCRIPTION
**Description of work.**

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

- Original Gitlab user story: [PD377](https://code.ornl.gov/sns-hfir-scse/diffraction/powder/powder-diffraction/-/issues/377)
- This is #32751  into `main`.

Existing `MultipleScatteringCorrection` caches the cross term `L12` in memory, which can lead to a memory allocation error when the element size is very small (a common requirement for thin-wall containers).
To circumvent this limitation, this PR allows users to use a different element size to rasterize the container so that the main sample can be rasterize with relatively larger element size, consequently reducing the memory pressure coming from caching `L12`.

As an accompany change, the same feature is also introduced into `PaalmanPingsAbsorptionCorrection`.
However, it is generally not necessary to specify a different element size in `PaalmanPingsAbsorptionCorrection` as it does not have second order absorption and the associated memory pressure from caching cross terms.

**To test:**

- Use the following script to create a fake instrument with only two detectors

```python
from mantid.simpleapi import (
    ConvertUnits,
    CreateSampleWorkspace,
    EditInstrumentGeometry,
    SetSample,
    MultipleScatteringCorrection,
    PaalmanPingsAbsorptionCorrection,
    mtd,
)

# ----------------------- #
# make an empty workspace #
# ----------------------- #
# Create a fake workspace with TOF data
ws = CreateSampleWorkspace(Function='Powder Diffraction',
                            NumBanks=2,
                            BankPixelWidth=1,
                            XUnit='TOF',
                            XMin=1000,
                            XMax=10000,)
# Fake instrument
EditInstrumentGeometry(ws,
                        PrimaryFlightPath=5.0,
                        SpectrumIDs=[1, 2],
                        L2=[2.0, 2.0],
                        Polar=[10.0, 90.0],
                        Azimuthal=[0.0, 45.0],
                        DetectorIDs=[1, 2],
                        InstrumentName="Instrument")
# set sample and container
SetSample(
        ws,
        Geometry={
            "Shape": "Cylinder",
            "Center": [0., 0., 0.],
            "Height": 1.0,  # cm
            "Radius": 0.3,  # cm
        },
        Material = {
            "ChemicalFormula": "La-(B11)5.94-(B10)0.06",
            "SampleNumberDensity": 0.1,
        },
        ContainerMaterial = {
            "ChemicalFormula": "V",
            "SampleNumberDensity": 0.0721,
        },
        ContainerGeometry = {
            "Shape": "HollowCylinder",
            "Height": 1.0,  # cm
            "InnerRadius": 0.3,  # cm
            "OuterRadius": 0.35,  # cm
            "Center": [0., 0., 0.],
        }
    )

# to wavelength
ConvertUnits(InputWorkspace=ws,
                OutputWorkspace=ws,
                Target="Wavelength",
                EMode="Elastic")
```

- Use the following code to calculate the multiple scattering correction factor
```python
MultipleScatteringCorrection(
        InputWorkspace = ws,
        Method="SampleAndContainer",
        ElementSize=0.5,  # mm
        ContainerElementSize=0.1,  # mm
        OutputWorkspace="rst",
    )
```

- Use the following code to calculate the absorption correction with PaalmanPings formula
```python
PaalmanPingsAbsorptionCorrection(
        InputWorkspace = ws,
        ElementSize=0.5,
        ContainerElementSize=0.1,
        OutputWorkspace="rst",
    )
```

<!-- Instructions for testing. -->

<!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
