### PR TITLE
Remove unused function getSelectedDetectors

### DIFF
--- a/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/Projection3D.h
+++ b/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/Projection3D.h
@@ -36,7 +36,6 @@ public:
   void setWireframe(bool on);
 
   void componentSelected(size_t componentIndex) override;
-  void getSelectedDetectors(std::vector<size_t> &detIndices) override;
   void getMaskedDetectors(std::vector<size_t> &detIndices) const override;
   void resize(int /*unused*/, int /*unused*/) override;
   QString getInfoText() const override;

--- a/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/ProjectionSurface.h
+++ b/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/ProjectionSurface.h
@@ -116,9 +116,6 @@ public:
   virtual size_t getDetector(int x, int y) const;
   /// NULL deselects components and selects the whole instrument
   virtual void componentSelected(size_t componentIndex) = 0;
-  /// fill in a list of detector indices which were selected by the selction
-  /// tool
-  virtual void getSelectedDetectors(std::vector<size_t> &detIndices) = 0;
   /// fill in a list of detector indices which were masked by the mask shapes
   virtual void getMaskedDetectors(std::vector<size_t> &detIndices) const = 0;
 

--- a/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/UnwrappedSurface.h
+++ b/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/UnwrappedSurface.h
@@ -66,7 +66,6 @@ public:
   /** @name Implemented public virtual methods */
   //@{
   void componentSelected(size_t componentIndex) override;
-  void getSelectedDetectors(std::vector<size_t> &detIndices) override;
   void getMaskedDetectors(std::vector<size_t> &detIndices) const override;
   void setPeaksWorkspace(const std::shared_ptr<Mantid::API::IPeaksWorkspace> &pws);
   QString getInfoText() const override;

--- a/qt/widgets/instrumentview/src/Projection3D.cpp
+++ b/qt/widgets/instrumentview/src/Projection3D.cpp
@@ -195,37 +195,6 @@ void Projection3D::set3DAxesState(bool on) { m_drawAxes = on; }
 void Projection3D::setWireframe(bool on) { m_wireframe = on; }
 
 //-----------------------------------------------------------------------------
-/** This seems to be called when the user has selected a rectangle
- * using the mouse.
- *
- * @param detIndices :: returns a list of detector Indices selected.
- */
-void Projection3D::getSelectedDetectors(std::vector<size_t> &detIndices) {
-  detIndices.clear();
-  if (!hasSelection())
-    return;
-  double xmin, xmax, ymin, ymax, zmin, zmax;
-  m_viewport.getInstantProjection(xmin, xmax, ymin, ymax, zmin, zmax);
-  QRect rect = selectionRect();
-  auto size = m_viewport.dimensions();
-  const auto w(size.width()), h(size.height());
-
-  double xLeft = xmin + (xmax - xmin) * rect.left() / w;
-  double xRight = xmin + (xmax - xmin) * rect.right() / w;
-  double yBottom = ymin + (ymax - ymin) * (h - rect.bottom()) / h;
-  double yTop = ymin + (ymax - ymin) * (h - rect.top()) / h;
-  size_t ndet = m_instrActor->ndetectors();
-
-  for (size_t i = 0; i < ndet; ++i) {
-    V3D pos = m_instrActor->getDetPos(i);
-    m_viewport.transform(pos);
-    if (pos.X() >= xLeft && pos.X() <= xRight && pos.Y() >= yBottom && pos.Y() <= yTop) {
-      detIndices.emplace_back(i);
-    }
-  }
-}
-
-//-----------------------------------------------------------------------------
 /** Select detectors to mask, using the mouse.
  * From the Instrument Window's mask tab.
  *

--- a/qt/widgets/instrumentview/src/UnwrappedSurface.cpp
+++ b/qt/widgets/instrumentview/src/UnwrappedSurface.cpp
@@ -256,64 +256,6 @@ void UnwrappedSurface::componentSelected(size_t componentIndex) {
   }
 }
 
-void UnwrappedSurface::getSelectedDetectors(std::vector<size_t> &detIndices) {
-  if (m_selectRect.isNull()) {
-    return;
-  }
-  QRect rect = selectionRect();
-
-  double vtop = m_v_min;
-  double vbottom = m_v_min;
-  double uleft = m_u_min;
-  double uright = m_u_min;
-
-  // find the first picking colours different from black (0,0,0) to get the
-  // top-left
-  // and bottom-right detectors
-  int rwidth = rect.width();
-  int rheight = rect.height();
-  for (int i = 0; i < rwidth; ++i) {
-    bool stop = false;
-    for (int j = 0; j < rheight; ++j) {
-      int x = rect.x() + i;
-      int y = rect.y() + j;
-      size_t ind = getPickID(x, y);
-      if (ind < m_unwrappedDetectors.size()) {
-        uleft = m_unwrappedDetectors[ind].u - m_unwrappedDetectors[ind].width / 2;
-        vtop = m_unwrappedDetectors[ind].v + m_unwrappedDetectors[ind].height / 2;
-        stop = true;
-        break;
-      }
-    }
-    if (stop)
-      break;
-  }
-
-  for (int i = rwidth - 1; i >= 0; --i) {
-    bool stop = false;
-    for (int j = rheight - 1; j >= 0; --j) {
-      int x = rect.x() + i;
-      int y = rect.y() + j;
-      size_t ind = getPickID(x, y);
-      if (ind < m_unwrappedDetectors.size()) {
-        uright = m_unwrappedDetectors[ind].u + m_unwrappedDetectors[ind].width / 2;
-        vbottom = m_unwrappedDetectors[ind].v - m_unwrappedDetectors[ind].height / 2;
-        stop = true;
-        break;
-      }
-    }
-    if (stop)
-      break;
-  }
-
-  // select detectors with u,v within the allowed boundaries
-  for (auto &udet : m_unwrappedDetectors) {
-    if (udet.u >= uleft && udet.u <= uright && udet.v >= vbottom && udet.v <= vtop) {
-      detIndices.emplace_back(udet.detIndex);
-    }
-  }
-}
-
 void UnwrappedSurface::getMaskedDetectors(std::vector<size_t> &detIndices) const {
   detIndices.clear();
   if (m_maskShapes.isEmpty())

--- a/qt/widgets/instrumentview/test/InstrumentWidget/MockProjectionSurface.h
+++ b/qt/widgets/instrumentview/test/InstrumentWidget/MockProjectionSurface.h
@@ -18,7 +18,6 @@ public:
   virtual ~MockProjectionSurface() = default;
   MOCK_METHOD(void, init, (), (override));
   MOCK_METHOD(void, componentSelected, (size_t), (override));
-  MOCK_METHOD(void, getSelectedDetectors, (std::vector<size_t> &), (override));
   MOCK_METHOD(void, getMaskedDetectors, (std::vector<size_t> &), (const, override));
   MOCK_METHOD(void, drawSurface, (GLDisplay *, bool), (const, override));
   MOCK_METHOD(void, changeColorMap, (), (override));


### PR DESCRIPTION
**Description of work.**

This PR removes the function getSelectedDetectors from ProjectionSurface because it is not used anywhere in the code. It also does some minor refactoring to getMaskedDetectors to avoid a spurious cppcheck warning (see the commit message for details).

**To test:**

Check that masking still works in instrument viewer with the 3D projection view.

Refs #32034

*This does not require release notes* because **it does not affect functionality**

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
