### PR TITLE
 Enable SCDCalibratePanels to calibrate detector size (ORNL)

### DIFF
--- a/Framework/Crystal/CMakeLists.txt
+++ b/Framework/Crystal/CMakeLists.txt
@@ -204,6 +204,7 @@ set(TEST_FILES
     PredictPeaksTest.h
     PredictSatellitePeaksTest.h
     SCDCalibratePanels2Test.h
+    SCDCalibratePanels2ObjFuncTest.h
     SCDCalibratePanelsTest.h
     SaveHKLTest.h
     SaveIsawPeaksTest.h

--- a/Framework/Crystal/CMakeLists.txt
+++ b/Framework/Crystal/CMakeLists.txt
@@ -206,6 +206,7 @@ set(TEST_FILES
     PredictPeaksTest.h
     PredictSatellitePeaksTest.h
     SCDCalibratePanels2Test.h
+    SCDCalibratePanels2ObjFuncTest.h
     SCDCalibratePanelsTest.h
     SaveHKLTest.h
     SaveIsawPeaksTest.h

--- a/Framework/Crystal/inc/MantidCrystal/SCDCalibratePanels2.h
+++ b/Framework/Crystal/inc/MantidCrystal/SCDCalibratePanels2.h
@@ -86,7 +86,8 @@ private:
   void optimizeL1(Mantid::API::IPeaksWorkspace_sptr pws, Mantid::API::IPeaksWorkspace_sptr pws_original);
 
   /// Private function for calibrating banks
-  void optimizeBanks(Mantid::API::IPeaksWorkspace_sptr pws, const Mantid::API::IPeaksWorkspace_sptr &pws_original);
+  void optimizeBanks(Mantid::API::IPeaksWorkspace_sptr pws, const Mantid::API::IPeaksWorkspace_sptr &pws_original,
+                     const bool &docalibsize, const double &sizesearchradius, const bool &fixdetxyratio);
 
   /// Private function for fine tunning sample position
   void optimizeSamplePos(Mantid::API::IPeaksWorkspace_sptr pws, Mantid::API::IPeaksWorkspace_sptr pws_original);
@@ -140,11 +141,11 @@ private:
   static constexpr double Tolerance = std::numeric_limits<double>::epsilon();
 
   // Column names and types
-  const std::vector<std::string> calibrationTableColumnNames = {
+  const std::vector<std::string> calibrationTableColumnNames{
       "ComponentName",    "Xposition",        "Yposition",     "Zposition", "XdirectionCosine",
       "YdirectionCosine", "ZdirectionCosine", "RotationAngle", "ScaleX",    "ScaleY"};
-  const std::string calibrationTableColumnTypes[10] = {"str",    "double", "double", "double", "double",
-                                                       "double", "double", "double", "double", "double"};
+  const std::vector<std::string> calibrationTableColumnTypes{"str",    "double", "double", "double", "double",
+                                                             "double", "double", "double", "double", "double"};
 
   boost::container::flat_set<std::string> m_BankNames;
   Mantid::API::ITableWorkspace_sptr mCaliTable;

--- a/Framework/Crystal/inc/MantidCrystal/SCDCalibratePanels2.h
+++ b/Framework/Crystal/inc/MantidCrystal/SCDCalibratePanels2.h
@@ -105,11 +105,11 @@ private:
 
   /// Generate a Table workspace to store the calibration results
   Mantid::API::ITableWorkspace_sptr generateCalibrationTable(std::shared_ptr<Geometry::Instrument> &instrument,
-                                                             Geometry::ParameterMap &pmap);
+                                                             const Geometry::ParameterMap &pmap);
 
   /// Save to xml file for Mantid to load by manual crafting
-  void saveXmlFile(const std::string &FileName, boost::container::flat_set<std::string> &AllBankNames,
-                   std::shared_ptr<Geometry::Instrument> &instrument, Geometry::ParameterMap &pmap);
+  void saveXmlFile(const std::string &FileName, const boost::container::flat_set<std::string> &AllBankNames,
+                   std::shared_ptr<Geometry::Instrument> &instrument, const Geometry::ParameterMap &pmap);
 
   /// Save to ISAW type det calibration output for backward compatiblity
   void saveIsawDetCal(const std::string &filename, boost::container::flat_set<std::string> &AllBankName,

--- a/Framework/Crystal/inc/MantidCrystal/SCDCalibratePanels2.h
+++ b/Framework/Crystal/inc/MantidCrystal/SCDCalibratePanels2.h
@@ -100,15 +100,16 @@ private:
   Mantid::API::MatrixWorkspace_sptr getIdealQSampleAsHistogram1D(const Mantid::API::IPeaksWorkspace_sptr &pws);
 
   /// Helper functions for adjusting components
-  void adjustComponent(double dx, double dy, double dz, double drx, double dry, double drz, const std::string &cmptName,
-                       Mantid::API::IPeaksWorkspace_sptr &pws);
+  void adjustComponent(double dx, double dy, double dz, double drx, double dry, double drz, double scalex,
+                       double scaley, const std::string &cmptName, Mantid::API::IPeaksWorkspace_sptr &pws);
 
   /// Generate a Table workspace to store the calibration results
-  Mantid::API::ITableWorkspace_sptr generateCalibrationTable(std::shared_ptr<Geometry::Instrument> &instrument);
+  Mantid::API::ITableWorkspace_sptr generateCalibrationTable(std::shared_ptr<Geometry::Instrument> &instrument,
+                                                             Geometry::ParameterMap &pmap);
 
   /// Save to xml file for Mantid to load by manual crafting
   void saveXmlFile(const std::string &FileName, boost::container::flat_set<std::string> &AllBankNames,
-                   std::shared_ptr<Geometry::Instrument> &instrument);
+                   std::shared_ptr<Geometry::Instrument> &instrument, Geometry::ParameterMap &pmap);
 
   /// Save to ISAW type det calibration output for backward compatiblity
   void saveIsawDetCal(const std::string &filename, boost::container::flat_set<std::string> &AllBankName,
@@ -127,16 +128,18 @@ private:
   double m_a, m_b, m_c, m_alpha, m_beta, m_gamma;
   double m_T0 = 0.0;
   bool LOGCHILDALG{true};
+  int maxFitIterations{500};
   const int MINIMUM_PEAKS_PER_BANK{6};
+  std::string mCalibBankName{""};
   const double PI{3.1415926535897932384626433832795028841971693993751058209};
   static constexpr double Tolerance = std::numeric_limits<double>::epsilon();
 
   // Column names and types
-  const std::string calibrationTableColumnNames[8] = {"ComponentName",    "Xposition",        "Yposition",
-                                                      "Zposition",        "XdirectionCosine", "YdirectionCosine",
-                                                      "ZdirectionCosine", "RotationAngle"};
-  const std::string calibrationTableColumnTypes[8] = {"str",    "double", "double", "double",
-                                                      "double", "double", "double", "double"};
+  const std::vector<std::string> calibrationTableColumnNames = {
+      "ComponentName",    "Xposition",        "Yposition",     "Zposition", "XdirectionCosine",
+      "YdirectionCosine", "ZdirectionCosine", "RotationAngle", "ScaleX",    "ScaleY"};
+  const std::string calibrationTableColumnTypes[10] = {"str",    "double", "double", "double", "double",
+                                                       "double", "double", "double", "double", "double"};
 
   boost::container::flat_set<std::string> m_BankNames;
   Mantid::API::ITableWorkspace_sptr mCaliTable;

--- a/Framework/Crystal/inc/MantidCrystal/SCDCalibratePanels2.h
+++ b/Framework/Crystal/inc/MantidCrystal/SCDCalibratePanels2.h
@@ -124,6 +124,11 @@ private:
   void profileT0(Mantid::API::IPeaksWorkspace_sptr &pws, Mantid::API::IPeaksWorkspace_sptr pws_original);
   void profileL1T0(Mantid::API::IPeaksWorkspace_sptr &pws, Mantid::API::IPeaksWorkspace_sptr pws_original);
 
+  /// Retrieve "scalex" and "scaley" from a workspace's parameter map if the component is rectangular detector
+  std::pair<double, double> getRectangularDetectorScaleFactors(std::shared_ptr<Geometry::Instrument> &instrument,
+                                                               const std::string &bankname,
+                                                               const Geometry::ParameterMap &pmap);
+
   /// unique vars for a given instance of calibration
   double m_a, m_b, m_c, m_alpha, m_beta, m_gamma;
   double m_T0 = 0.0;

--- a/Framework/Crystal/inc/MantidCrystal/SCDCalibratePanels2ObjFunc.h
+++ b/Framework/Crystal/inc/MantidCrystal/SCDCalibratePanels2ObjFunc.h
@@ -54,6 +54,10 @@ private:
   Mantid::API::IPeaksWorkspace_sptr rotateInstrumentComponentBy(double rotX, double rotY, double rotZ,
                                                                 const std::string &componentName,
                                                                 Mantid::API::IPeaksWorkspace_sptr &pws) const;
+
+  Mantid::API::IPeaksWorkspace_sptr scaleRectagularDetectorSize(const double &scalex, const double &scaley,
+                                                                const std::string &componentName,
+                                                                Mantid::API::IPeaksWorkspace_sptr &pws) const;
 };
 
 } // namespace Crystal

--- a/Framework/Crystal/src/SCDCalibratePanels2.cpp
+++ b/Framework/Crystal/src/SCDCalibratePanels2.cpp
@@ -1113,7 +1113,7 @@ void SCDCalibratePanels2::adjustComponent(double dx, double dy, double dz, doubl
  * @return DataObjects::TableWorkspace_sptr
  */
 ITableWorkspace_sptr SCDCalibratePanels2::generateCalibrationTable(std::shared_ptr<Geometry::Instrument> &instrument,
-                                                                   Geometry::ParameterMap &pmap) {
+                                                                   const Geometry::ParameterMap &pmap) {
   g_log.notice() << "Generate a TableWorkspace to store calibration results.\n";
 
   // Create table workspace
@@ -1191,8 +1191,8 @@ ITableWorkspace_sptr SCDCalibratePanels2::generateCalibrationTable(std::shared_p
  * in Groups
  */
 void SCDCalibratePanels2::saveXmlFile(const std::string &FileName,
-                                      boost::container::flat_set<std::string> &AllBankNames,
-                                      std::shared_ptr<Instrument> &instrument, Geometry::ParameterMap &pmap) {
+                                      const boost::container::flat_set<std::string> &AllBankNames,
+                                      std::shared_ptr<Instrument> &instrument, const Geometry::ParameterMap &pmap) {
   g_log.notice() << "Generating xml tree \n";
 
   using boost::property_tree::ptree;

--- a/Framework/Crystal/src/SCDCalibratePanels2.cpp
+++ b/Framework/Crystal/src/SCDCalibratePanels2.cpp
@@ -1110,6 +1110,7 @@ void SCDCalibratePanels2::adjustComponent(double dx, double dy, double dz, doubl
  * @brief Generate a tableworkspace to store the calibration results
  *
  * @param instrument  :: calibrated instrument
+ * @package pmap :: parameter map from workspace
  * @return DataObjects::TableWorkspace_sptr
  */
 ITableWorkspace_sptr SCDCalibratePanels2::generateCalibrationTable(std::shared_ptr<Geometry::Instrument> &instrument,
@@ -1189,6 +1190,9 @@ ITableWorkspace_sptr SCDCalibratePanels2::generateCalibrationTable(std::shared_p
  *
  * @param instrument   The instrument with the new values for the banks
  * in Groups
+ *
+ * @param pmap :: parameter map from workspace
+ *
  */
 void SCDCalibratePanels2::saveXmlFile(const std::string &FileName,
                                       const boost::container::flat_set<std::string> &AllBankNames,

--- a/Framework/Crystal/src/SCDCalibratePanels2.cpp
+++ b/Framework/Crystal/src/SCDCalibratePanels2.cpp
@@ -132,6 +132,14 @@ void SCDCalibratePanels2::init() {
   declareProperty("SearchradiusRotZBank", 1.0, mustBeNonNegative,
                   "This is the search radius (in deg) when calibrating component reorientation, used to constrain "
                   "optimization search space");
+  declareProperty("CalibrateSize", false, "Calibrate detector size for each bank.");
+  declareProperty("SearchRadiusSize", 0.0, mustBeNonNegative,
+                  "This is the search radius (unit less) of scale factor around at value 1.0 "
+                  "when calibrating component size if it is a rectangualr detector.");
+  declareProperty("FixAspectRatio", true,
+                  "If true, the scaling factor for detector along X- and Y-axis "
+                  "must be the same.  Otherwise, the 2 scaling factors are free.");
+
   // editability
   setPropertySettings("SearchRadiusTransBank",
                       std::make_unique<EnabledWhenProperty>("CalibrateBanks", IS_EQUAL_TO, "1"));
@@ -141,12 +149,19 @@ void SCDCalibratePanels2::init() {
                       std::make_unique<EnabledWhenProperty>("CalibrateBanks", IS_EQUAL_TO, "1"));
   setPropertySettings("SearchradiusRotZBank",
                       std::make_unique<EnabledWhenProperty>("CalibrateBanks", IS_EQUAL_TO, "1"));
+  setPropertySettings("CalibrateSize", std::make_unique<EnabledWhenProperty>("CalibrateBanks", IS_EQUAL_TO, "1"));
+  setPropertySettings("SearchRadiusSize", std::make_unique<EnabledWhenProperty>("CalibrateSize", IS_EQUAL_TO, "1"));
+  setPropertySettings("FixAspectRatio", std::make_unique<EnabledWhenProperty>("CalibrateSize", IS_EQUAL_TO, "1"));
   // grouping
   setPropertyGroup("CalibrateBanks", CALIBRATION);
   setPropertyGroup("SearchRadiusTransBank", CALIBRATION);
   setPropertyGroup("SearchradiusRotXBank", CALIBRATION);
   setPropertyGroup("SearchradiusRotYBank", CALIBRATION);
   setPropertyGroup("SearchradiusRotZBank", CALIBRATION);
+  setPropertyGroup("CalibrateSize", CALIBRATION);
+  setPropertyGroup("SearchRadiusSize", CALIBRATION);
+  setPropertyGroup("FixAspectRatio", CALIBRATION);
+
   // --------------
   // ----- T0 -----
   // --------------
@@ -564,6 +579,10 @@ void SCDCalibratePanels2::optimizeBanks(IPeaksWorkspace_sptr pws, const IPeaksWo
     fitBank_alg->setProperty("InputWorkspace", wsBankCali);
     fitBank_alg->setProperty("CreateOutput", true);
     fitBank_alg->setProperty("Output", "fit");
+
+    // TODO - make it an input option
+    fitBank_alg->setProperty("MaxIterations", 5);
+
     fitBank_alg->executeAsChildAlg();
 
     //---- cache results

--- a/Framework/Crystal/src/SCDCalibratePanels2.cpp
+++ b/Framework/Crystal/src/SCDCalibratePanels2.cpp
@@ -387,7 +387,7 @@ void SCDCalibratePanels2::exec() {
   // STEP_4: generate a table workspace to save the calibration results
   g_log.notice() << "-- Generate calibration table\n";
   Instrument_sptr instCalibrated = std::const_pointer_cast<Geometry::Instrument>(m_pws->getInstrument());
-  Geometry::ParameterMap &pmap = m_pws->instrumentParameters();
+  const Geometry::ParameterMap &pmap = m_pws->instrumentParameters();
   ITableWorkspace_sptr tablews = generateCalibrationTable(instCalibrated, pmap);
 
   // STEP_5: Write to disk if required

--- a/Framework/Crystal/src/SCDCalibratePanels2.cpp
+++ b/Framework/Crystal/src/SCDCalibratePanels2.cpp
@@ -1258,22 +1258,6 @@ void SCDCalibratePanels2::saveXmlFile(const std::string &FileName,
     Quat relRot = bank->getRelativeRot();
     std::vector<double> relRotAngles = relRot.getEulerAngles("XYZ");
     V3D pos1 = bank->getRelativePos();
-    // scale X and scale Y: retrieve from component if it is rectangualr detector
-    //    double scalex{1.0}, scaley{1.0};
-    //    Geometry::IComponent_const_sptr comp = instrument->getComponentByName(bankName);
-    //    std::shared_ptr<const Geometry::RectangularDetector> rectDet =
-    //        std::dynamic_pointer_cast<const Geometry::RectangularDetector>(comp);
-    //    if (rectDet) {
-    //      // get instrument parameter map and find out whether the
-    //      // Geometry::ParameterMap &pmap = pws->instrumentParameters();
-    //      auto scalexparams = pmap.getDouble(rectDet->getName(), "scalex");
-    //      auto scaleyparams = pmap.getDouble(rectDet->getName(), "scaley");
-    //      if (!scalexparams.empty())
-    //        scalex = scalexparams[0];
-    //      if (!scaleyparams.empty())
-    //        scaley = scaleyparams[0];
-    //    }
-
     std::pair<double, double> scales = getRectangularDetectorScaleFactors(instrument, bankName, pmap);
 
     // prepare node

--- a/Framework/Crystal/src/SCDCalibratePanels2.cpp
+++ b/Framework/Crystal/src/SCDCalibratePanels2.cpp
@@ -649,7 +649,8 @@ void SCDCalibratePanels2::optimizeBanks(IPeaksWorkspace_sptr pws, const IPeaksWo
       else
         fittie += "," + scaleties.str();
     }
-    g_log.notice("Final constraint: " + fitconstraint + "\n\t tie: " + fittie);
+
+    g_log.information("Fitting " + bankname + ": constraint = " + fitconstraint + "\n\t tie = " + fittie);
 
     //---- set&go
     if (fittie != "")

--- a/Framework/Crystal/src/SCDCalibratePanels2ObjFunc.cpp
+++ b/Framework/Crystal/src/SCDCalibratePanels2ObjFunc.cpp
@@ -286,14 +286,13 @@ SCDCalibratePanels2ObjFunc::scaleRectagularDetectorSize(const double &scalex, co
     Geometry::ParameterMap &pmap = pws->instrumentParameters();
     auto oldscalex = pmap.getDouble(rectDet->getName(), "scalex");
     auto oldscaley = pmap.getDouble(rectDet->getName(), "scaley");
-    double relscalex = scalex;
-    double relscaley = scaley;
+    double relscalex{scalex}, relscaley{scaley};
     if (!oldscalex.empty())
       relscalex /= oldscalex[0];
     if (!oldscaley.empty())
       relscaley /= oldscaley[0];
-    applyRectangularDetectorScaleToComponentInfo(pws->mutableComponentInfo(), rectDet->getComponentID(), scalex,
-                                                 scaley);
+    applyRectangularDetectorScaleToComponentInfo(pws->mutableComponentInfo(), rectDet->getComponentID(), relscalex,
+                                                 relscaley);
   }
 
   return pws;

--- a/Framework/Crystal/src/SCDCalibratePanels2ObjFunc.cpp
+++ b/Framework/Crystal/src/SCDCalibratePanels2ObjFunc.cpp
@@ -55,6 +55,7 @@ SCDCalibratePanels2ObjFunc::SCDCalibratePanels2ObjFunc() {
   declareParameter("DeltaSampleX", 0.0, "relative shift of sample position along X.");
   declareParameter("DeltaSampleY", 0.0, "relative shift of sample position along Y.");
   declareParameter("DeltaSampleZ", 0.0, "relative shift of sample position along Z.");
+  // Detector size scale factors
   declareParameter("ScaleX", 1.0, "Scale of detector along X-direction (i.e., width).");
   declareParameter("ScaleY", 1.0, "Scale of detector along Y-direction (i.e., height).");
 }
@@ -116,9 +117,6 @@ void SCDCalibratePanels2ObjFunc::function1D(double *out, const double *xValues, 
 
   // -- always working on a copy only
   IPeaksWorkspace_sptr pws = m_pws->clone();
-
-  // Debugging related
-  IPeaksWorkspace_sptr pws_ref = m_pws->clone();
 
   // NOTE: when optimizing T0, a none component will be passed in.
   //       -- For Corelli, this will be none/sixteenpack
@@ -284,6 +282,16 @@ SCDCalibratePanels2ObjFunc::scaleRectagularDetectorSize(const double &scalex, co
   std::shared_ptr<const Geometry::RectangularDetector> rectDet =
       std::dynamic_pointer_cast<const Geometry::RectangularDetector>(comp);
   if (rectDet) {
+    // get instrument parameter map and find out whether the
+    Geometry::ParameterMap &pmap = pws->instrumentParameters();
+    auto oldscalex = pmap.getDouble(rectDet->getName(), "scalex");
+    auto oldscaley = pmap.getDouble(rectDet->getName(), "scaley");
+    double relscalex = scalex;
+    double relscaley = scaley;
+    if (!oldscalex.empty())
+      relscalex /= oldscalex[0];
+    if (!oldscaley.empty())
+      relscaley /= oldscaley[0];
     applyRectangularDetectorScaleToComponentInfo(pws->mutableComponentInfo(), rectDet->getComponentID(), scalex,
                                                  scaley);
   }

--- a/Framework/Crystal/test/SCDCalibratePanels2ObjFuncTest.h
+++ b/Framework/Crystal/test/SCDCalibratePanels2ObjFuncTest.h
@@ -118,8 +118,6 @@ public:
     testfunc.initialize();
     testfunc.setPeakWorkspace(ipws, bankname, tofs);
 
-    std::cout << "Name: " << testfunc.name() << "\n";
-
     const int n_peaks = pws->getNumberPeaks();
     TS_ASSERT_EQUALS(n_peaks, 11076);
 
@@ -199,12 +197,6 @@ public:
       int ipeak = peakindexes[i];
       long int det_i = pws->getPeak(ipeak).getDetectorID();
       TS_ASSERT_EQUALS(det_i, detids[i]);
-
-      std::cout << ipeak << ": ";
-      for (size_t d = 0; d < 3; ++d) {
-        std::cout << out[ipeak * 3 + d] << "  ";
-      }
-      std::cout << "\n";
     }
 
     // Calculate value with scaling (1.1, 0.9) on  bank27
@@ -244,11 +236,9 @@ public:
       long int det_i = pws->getPeak(ipeak).getDetectorID();
       TS_ASSERT_EQUALS(det_i, detids[i]);
 
-      std::cout << ipeak << ": ";
       for (size_t d = 0; d < 3; ++d) {
         TS_ASSERT_DELTA(out[ipeak * 3 + d], goldvalue2[i * 3 + d], 0.00001);
       }
-      std::cout << "\n";
     }
   }
 

--- a/Framework/Crystal/test/SCDCalibratePanels2ObjFuncTest.h
+++ b/Framework/Crystal/test/SCDCalibratePanels2ObjFuncTest.h
@@ -237,6 +237,84 @@ public:
       std::cout << "\n";
     }
 
+    // Set up function parameters values
+    testfunc.setParameter("ScaleX", 1.1);
+    testfunc.setParameter("ScaleY", 0.9);
+    // calcualte function value for bank27 (related to the object function)
+    testfunc.function1D(out.get(), useless, order);
+
+    std::cout << "Scale (1.1, 0.9)\n";
+    for (size_t i = 0; i < peakindexes.size(); ++i) {
+      // Assert detector IDs
+      int ipeak = peakindexes[i];
+      long int det_i = pws->getPeak(ipeak).getDetectorID();
+      TS_ASSERT_EQUALS(det_i, detids[i]);
+
+      std::cout << ipeak << ": ";
+      for (size_t d = 0; d < 3; ++d) {
+        std::cout << out[ipeak * 3 + d] << "  ";
+      }
+      std::cout << "\n";
+    }
+
+    std::cout << "Scale (0.9, 1.1)\n";
+    testfunc.setParameter("ScaleX", 0.9);
+    testfunc.setParameter("ScaleY", 1.1);
+    // calcualte function value for bank27 (related to the object function)
+    testfunc.function1D(out.get(), useless, order);
+
+    // show result
+    // Peak indexes
+    //    std::vector<int> peakindexes{64, 65, 66, 67, 254, 255, 256, 257, 10955, 10956, 10957, 10958};
+    //    std::vector<long int> detids{1780254, 1800379, 1814619, 1790397, 1811588, 1825313,
+    //                                 1788132, 1801093, 1803923, 1788915, 1771352, 1824577};
+    for (size_t i = 0; i < peakindexes.size(); ++i) {
+      // Assert detector IDs
+      int ipeak = peakindexes[i];
+      long int det_i = pws->getPeak(ipeak).getDetectorID();
+      TS_ASSERT_EQUALS(det_i, detids[i]);
+
+      std::cout << ipeak << ": ";
+      for (size_t d = 0; d < 3; ++d) {
+        std::cout << out[ipeak * 3 + d] << "  ";
+      }
+      std::cout << "\n";
+    }
+    TS_ASSERT_EQUALS(135, 246);
+
+    // TODO - write these into unit tests!
+
+    /*
+     * Scale (1.1, 0.9)
+64: -4.04172  1.91418  -4.04384
+65: -4.37725  0.988898  -3.80048
+66: -3.71589  0.927614  -3.78026
+67: -3.69851  0.996146  -3.09986
+254: -4.38616  0.944574  -3.79285
+255: -3.72545  0.896009  -3.77312
+256: -4.37156  1.02298  -3.11404
+257: -3.70605  0.964197  -3.09218
+10955: 3.70692  0.961802  3.78894
+10956: 4.36969  1.03149  3.80559
+10957: 4.02371  1.94577  4.05188
+10958: 3.72025  0.903004  4.4747
+Scale (0.9, 1.1)
+64: -4.04381  1.92244  -4.20213
+65: -4.38515  0.930843  -3.75479
+66: -3.69941  0.989064  -3.77225
+67: -3.71802  0.91721  -3.08782
+254: -4.37735  0.970865  -3.75927
+255: -3.68901  1.02111  -3.77964
+256: -4.39288  0.892533  -3.0754
+257: -3.70793  0.957278  -3.09125
+10955: 3.70922  0.951834  3.76849
+10956: 4.39379  0.878827  3.7513
+10957: 4.06492  1.88495  4.1947
+10958: 3.6933  1.01796  4.45579
+     *
+     *
+     */
+
     //      for (int i = 0; i < n_peaks; ++i) {
     //          // search bank27
     //          if (1769472 <= pws->getPeak(i).getDetectorID() && pws->getPeak(i).getDetectorID() < 1835008) {

--- a/Framework/Crystal/test/SCDCalibratePanels2ObjFuncTest.h
+++ b/Framework/Crystal/test/SCDCalibratePanels2ObjFuncTest.h
@@ -62,18 +62,8 @@ public:
    */
   SCDCalibratePanels2ObjFuncTest()
       : wsname("wsSCDCalibratePanels2ObjFuncTest"), pwsname("pwsSCDCalibratePanels2ObjFuncTest"),
-        tmppwsname("tmppwsSCDCalibratePanels2ObjFuncTest"),     // fixed workspace name
-        silicon_a(5.431), silicon_b(5.431), silicon_c(5.431),   // angstrom
-        silicon_alpha(90), silicon_beta(90), silicon_gamma(90), // degree
-        silicon_cs(CrystalStructure("5.431 5.431 5.431", "F d -3 m", "Si 0 0 0 1.0 0.02")), dspacing_min(1.0),
-        dspacing_max(10.0),                      //
-        wavelength_min(0.1), wavelength_max(10), //
-        omega_step(6.0),                         //
-        TOLERANCE_L(1e-3),                       // this calibration has intrinsic accuracy limit of
-                                                 // 1 mm for translation on a panel detector
-        TOLERANCE_R(1e-1),                       // this calibration has intrinsic accuracy limit of
-                                                 // 0.1 deg for rotation on a panel detector
-        LOGCHILDALG(false) {
+        tmppwsname("tmppwsSCDCalibratePanels2ObjFuncTest"), // fixed workspace name
+        silicon_cs(CrystalStructure("5.431 5.431 5.431", "F d -3 m", "Si 0 0 0 1.0 0.02")), LOGCHILDALG(false) {
 
     // NOTE:
     // PredictPeaks
@@ -325,27 +315,10 @@ private:
   MatrixWorkspace_sptr m_ws;
   PeaksWorkspace_sptr m_pws;
 
-  // lattice constants of silicon
-  const double silicon_a;
-  const double silicon_b;
-  const double silicon_c;
-  const double silicon_alpha;
-  const double silicon_beta;
-  const double silicon_gamma;
-
   // silicon crystal structure
   CrystalStructure silicon_cs;
 
-  // constants that select the recriprocal space
-  const double dspacing_min;
-  const double dspacing_max;
-  const double wavelength_min;
-  const double wavelength_max;
-  const double omega_step;
-
   // check praramerter
-  const double TOLERANCE_L; // distance
-  const double TOLERANCE_R; // rotation angle
-  const bool LOGCHILDALG;   // whether to show individual alg log
+  const bool LOGCHILDALG; // whether to show individual alg log
   const double PI{3.1415926535897932384626433832795028841971693993751058209};
 };

--- a/Framework/Crystal/test/SCDCalibratePanels2ObjFuncTest.h
+++ b/Framework/Crystal/test/SCDCalibratePanels2ObjFuncTest.h
@@ -150,24 +150,6 @@ public:
                                      2.40752, 4.04829,  -3.82838, 2.74896};
     for (size_t i = 33219; i < 33228; ++i)
       TS_ASSERT_DELTA(out[i], golderrorend[i - 33219], 0.00001);
-
-    //    // Peak indexes
-    //    std::vector<int> peakindexes{64,    65,    66,    67,    254,   255,   256,   257,   10955, 10956, 10957,
-    //    10958}; std::vector<long int> detids{1780254, 1800379, 1814619, 1790397, 1811588, 1825313, 1788132, 1801093,
-    //    1803923, 1788915, 1771352, 1824577}; for (size_t i = 0; i < peakindexes.size(); ++i) {
-    //        // Assert detector IDs
-    //        int ipeak = peakindexes[i];
-    //        long int det_i = pws->getPeak(ipeak).getDetectorID();
-    //        TS_ASSERT_EQUALS(det_i, detids[i]);
-
-    //        std::cout << ipeak << ": ";
-    //        for (size_t d = 0; d < 3; ++d) {
-    //            std::cout << out[ipeak * 3 + d] << "  ";
-    //        }
-    //        std::cout << "\n";
-    //    }
-    //    TS_ASSERT_EQUALS(121, 212);
-    return;
   }
 
   void test_detector_resize() {
@@ -206,8 +188,6 @@ public:
     testfunc.initialize();
     testfunc.setPeakWorkspace(ipws, bankname, tofs);
 
-    std::cout << "Name: " << testfunc.name() << "\n";
-
     const int n_peaks = pws->getNumberPeaks();
     TS_ASSERT_EQUALS(n_peaks, 11076);
 
@@ -237,37 +217,37 @@ public:
       std::cout << "\n";
     }
 
-    // Set up function parameters values
+    // Calculate value with scaling (1.1, 0.9) on  bank27
     testfunc.setParameter("ScaleX", 1.1);
     testfunc.setParameter("ScaleY", 0.9);
-    // calcualte function value for bank27 (related to the object function)
     testfunc.function1D(out.get(), useless, order);
-
-    std::cout << "Scale (1.1, 0.9)\n";
+    // verify values
+    std::vector<double> goldvalue1{-4.04172, 1.914180, -4.04384, -4.37725, 0.988898, -3.80048, -3.71589, 0.927614,
+                                   -3.78026, -3.69851, 0.996146, -3.09986, -4.38616, 0.944574, -3.79285, -3.72545,
+                                   0.896009, -3.77312, -4.37156, 1.022980, -3.11404, -3.70605, 0.964197, -3.09218,
+                                   3.70692,  0.961802, 3.78894,  4.36969,  1.031490, 3.80559,  4.02371,  1.945770,
+                                   4.05188,  3.72025,  0.903004, 4.47470};
     for (size_t i = 0; i < peakindexes.size(); ++i) {
       // Assert detector IDs
       int ipeak = peakindexes[i];
       long int det_i = pws->getPeak(ipeak).getDetectorID();
       TS_ASSERT_EQUALS(det_i, detids[i]);
 
-      std::cout << ipeak << ": ";
       for (size_t d = 0; d < 3; ++d) {
-        std::cout << out[ipeak * 3 + d] << "  ";
+        TS_ASSERT_DELTA(out[ipeak * 3 + d], goldvalue1[i * 3 + d], 0.00001);
       }
-      std::cout << "\n";
     }
 
-    std::cout << "Scale (0.9, 1.1)\n";
+    // Evalulate with detector of bank27 scaled to (0.9, 1.1)
     testfunc.setParameter("ScaleX", 0.9);
     testfunc.setParameter("ScaleY", 1.1);
-    // calcualte function value for bank27 (related to the object function)
     testfunc.function1D(out.get(), useless, order);
-
-    // show result
-    // Peak indexes
-    //    std::vector<int> peakindexes{64, 65, 66, 67, 254, 255, 256, 257, 10955, 10956, 10957, 10958};
-    //    std::vector<long int> detids{1780254, 1800379, 1814619, 1790397, 1811588, 1825313,
-    //                                 1788132, 1801093, 1803923, 1788915, 1771352, 1824577};
+    // verify values
+    std::vector<double> goldvalue2{-4.04381, 1.922440, -4.20213, -4.38515, 0.930843, -3.75479, -3.69941, 0.989064,
+                                   -3.77225, -3.71802, 0.917210, -3.08782, -4.37735, 0.970865, -3.75927, -3.68901,
+                                   1.021110, -3.77964, -4.39288, 0.892533, -3.07540, -3.70793, 0.957278, -3.09125,
+                                   3.70922,  0.951834, 3.76849,  4.39379,  0.878827, 3.75130,  4.06492,  1.884950,
+                                   4.19470,  3.69330,  1.017960, 4.45579};
     for (size_t i = 0; i < peakindexes.size(); ++i) {
       // Assert detector IDs
       int ipeak = peakindexes[i];
@@ -276,98 +256,10 @@ public:
 
       std::cout << ipeak << ": ";
       for (size_t d = 0; d < 3; ++d) {
-        std::cout << out[ipeak * 3 + d] << "  ";
+        TS_ASSERT_DELTA(out[ipeak * 3 + d], goldvalue2[i * 3 + d], 0.00001);
       }
       std::cout << "\n";
     }
-    TS_ASSERT_EQUALS(135, 246);
-
-    // TODO - write these into unit tests!
-
-    /*
-     * Scale (1.1, 0.9)
-64: -4.04172  1.91418  -4.04384
-65: -4.37725  0.988898  -3.80048
-66: -3.71589  0.927614  -3.78026
-67: -3.69851  0.996146  -3.09986
-254: -4.38616  0.944574  -3.79285
-255: -3.72545  0.896009  -3.77312
-256: -4.37156  1.02298  -3.11404
-257: -3.70605  0.964197  -3.09218
-10955: 3.70692  0.961802  3.78894
-10956: 4.36969  1.03149  3.80559
-10957: 4.02371  1.94577  4.05188
-10958: 3.72025  0.903004  4.4747
-Scale (0.9, 1.1)
-64: -4.04381  1.92244  -4.20213
-65: -4.38515  0.930843  -3.75479
-66: -3.69941  0.989064  -3.77225
-67: -3.71802  0.91721  -3.08782
-254: -4.37735  0.970865  -3.75927
-255: -3.68901  1.02111  -3.77964
-256: -4.39288  0.892533  -3.0754
-257: -3.70793  0.957278  -3.09125
-10955: 3.70922  0.951834  3.76849
-10956: 4.39379  0.878827  3.7513
-10957: 4.06492  1.88495  4.1947
-10958: 3.6933  1.01796  4.45579
-     *
-     *
-     */
-
-    //      for (int i = 0; i < n_peaks; ++i) {
-    //          // search bank27
-    //          if (1769472 <= pws->getPeak(i).getDetectorID() && pws->getPeak(i).getDetectorID() < 1835008) {
-    //             std::cout << i << ": " << pws->getPeak(i).getDetectorID() << "\n";
-    //          }
-    //      }
-
-    // TS_ASSERT_EQUALS(1, 123321123);
-  }
-
-  // NOTE: skipped to prevent time out on build server
-  void NotUsed_run_Exec() {
-    // Shall not run this now
-    TS_ASSERT_EQUALS(1, 12321);
-
-    // Generate unique temp files
-    auto filenamebase = boost::filesystem::temp_directory_path();
-    filenamebase /= boost::filesystem::unique_path("testExec_%%%%%%%%");
-    // Make a clone of the standard peak workspace
-    PeaksWorkspace_sptr pws = m_pws->clone();
-
-    // Adjust L1 and banks
-    //-- source
-    const double dL1 = boost::math::constants::e<double>() / 100;
-    //-- bank27
-    const std::string bank27 = "bank27";
-    double dx1 = 1.1e-3;
-    double dy1 = -0.9e-3;
-    double dz1 = 1.5e-3;
-    double theta1 = PI / 3;
-    double phi1 = PI / 8;
-    double rvx1 = sin(theta1) * cos(phi1);
-    double rvy1 = sin(theta1) * sin(phi1);
-    double rvz1 = cos(theta1);
-    double ang1 = 0.01; // degrees
-    //-- bank16
-    const std::string bank16 = "bank16";
-    double dx2 = 0.5e-3;
-    double dy2 = 1.3e-3;
-    double dz2 = -1.9e-3;
-    double theta2 = PI / 4;
-    double phi2 = PI / 3;
-    double rvx2 = sin(theta2) * cos(phi2);
-    double rvy2 = sin(theta2) * sin(phi2);
-    double rvz2 = cos(theta2);
-    double ang2 = 0.01; // degrees
-
-    // source
-    adjustComponent(0.0, 0.0, dL1, 1.0, 0.0, 0.0, 0.0, pws->getInstrument()->getSource()->getName(), pws);
-    // bank27
-    adjustComponent(dx1, dy1, dz1, rvx1, rvy1, rvz1, ang1, bank27, pws);
-    // bank16
-    adjustComponent(dx2, dy2, dz2, rvx2, rvy2, rvz2, ang2, bank16, pws);
   }
 
 private:

--- a/Framework/Crystal/test/SCDCalibratePanels2ObjFuncTest.h
+++ b/Framework/Crystal/test/SCDCalibratePanels2ObjFuncTest.h
@@ -1,0 +1,381 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2020 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+
+// DEVNOTE:
+//  - cos, sin func uses radians
+//  - Quat class uses degrees
+//  - The overall strategy here is that the correct answer is always the engineering position,
+//    and we are moving the insturment to the wrong location (i.e. needs calibration) so that
+//    the calibration can move it back to the correct position
+
+#pragma once
+
+#include "MantidAPI/AlgorithmManager.h"
+#include "MantidAPI/AnalysisDataService.h"
+#include "MantidAPI/ExperimentInfo.h"
+#include "MantidAPI/IPeaksWorkspace.h"
+#include "MantidAPI/Run.h"
+#include "MantidAPI/Sample.h"
+#include "MantidCrystal/SCDCalibratePanels2.h"
+#include "MantidCrystal/SCDCalibratePanels2ObjFunc.h"
+#include "MantidDataObjects/EventWorkspace.h"
+#include "MantidDataObjects/Workspace2D.h"
+#include "MantidGeometry/Crystal/CrystalStructure.h"
+#include "MantidGeometry/Crystal/OrientedLattice.h"
+#include "MantidKernel/Logger.h"
+#include "MantidKernel/Unit.h"
+
+#include <boost/filesystem.hpp>
+#include <boost/math/constants/constants.hpp>
+#include <boost/math/special_functions/round.hpp>
+#include <cxxtest/TestSuite.h>
+#include <stdexcept>
+
+using namespace Mantid::API;
+using namespace Mantid::Crystal;
+using namespace Mantid::DataObjects;
+using namespace Mantid::Geometry;
+using namespace Mantid::Kernel;
+
+namespace {
+/// static logger
+Logger g_log("SCDCalibratePanels2ObjFuncTest");
+} // namespace
+
+class SCDCalibratePanels2ObjFuncTest : public CxxTest::TestSuite {
+public:
+  // This pair of boilerplate methods prevent the suite being created statically
+  // This means the constructor isn't called when running other tests
+  static SCDCalibratePanels2ObjFuncTest *createSuite() { return new SCDCalibratePanels2ObjFuncTest(); }
+  static void destroySuite(SCDCalibratePanels2ObjFuncTest *suite) { delete suite; }
+
+  // ----------------- //
+  // ----- Setup ----- //
+  // ----------------- //
+  /**
+   * @brief Construct a new SCDCalibratePanels2Test object
+   *
+   */
+  SCDCalibratePanels2ObjFuncTest()
+      : wsname("wsSCDCalibratePanels2ObjFuncTest"), pwsname("pwsSCDCalibratePanels2ObjFuncTest"),
+        tmppwsname("tmppwsSCDCalibratePanels2ObjFuncTest"),     // fixed workspace name
+        silicon_a(5.431), silicon_b(5.431), silicon_c(5.431),   // angstrom
+        silicon_alpha(90), silicon_beta(90), silicon_gamma(90), // degree
+        silicon_cs(CrystalStructure("5.431 5.431 5.431", "F d -3 m", "Si 0 0 0 1.0 0.02")), dspacing_min(1.0),
+        dspacing_max(10.0),                      //
+        wavelength_min(0.1), wavelength_max(10), //
+        omega_step(6.0),                         //
+        TOLERANCE_L(1e-3),                       // this calibration has intrinsic accuracy limit of
+                                                 // 1 mm for translation on a panel detector
+        TOLERANCE_R(1e-1),                       // this calibration has intrinsic accuracy limit of
+                                                 // 0.1 deg for rotation on a panel detector
+        LOGCHILDALG(false) {
+
+    // NOTE:
+    // PredictPeaks
+    //     m_pws = generateSimulatedPeaksWorkspace(m_ws);
+    // takes way too long, use the pre-generated one
+    std::shared_ptr<Algorithm> loadalg = AlgorithmFactory::Instance().create("Load", 1);
+    loadalg->initialize();
+    loadalg->setProperty("Filename", "PwsTOPAZIDeal.nxs");
+    loadalg->setProperty("OutputWorkspace", "mpws");
+    loadalg->execute();
+    m_pws = AnalysisDataService::Instance().retrieveWS<PeaksWorkspace>("mpws");
+  }
+
+  /**
+   * @brief test object function with rotation and shift
+   */
+  void test_rot_shift() {
+    g_log.notice() << "test_rot_shift() starts.\n";
+
+    // Generate unique temp files
+    auto filenamebase = boost::filesystem::temp_directory_path();
+    filenamebase /= boost::filesystem::unique_path("testBank_%%%%%%%%");
+    // Make a clone of the standard peak workspace
+    PeaksWorkspace_sptr pws = m_pws->clone();
+    Mantid::API::IPeaksWorkspace_sptr ipws = std::dynamic_pointer_cast<Mantid::API::IPeaksWorkspace>(pws);
+
+    // Move one bank to the wrong location
+    // NOTE: the common range for dx, dy ,dz is +-5cm
+    const std::string bankname = "bank27";
+    double dx = 1.1e-3;
+    double dy = -0.9e-3;
+    double dz = 1.5e-3;
+    // prescribed rotation
+    double theta = PI / 3;
+    double phi = PI / 8;
+    double rvx = sin(theta) * cos(phi);
+    double rvy = sin(theta) * sin(phi);
+    double rvz = cos(theta);
+    double ang = 0.02; // degrees
+
+    // Adjust bank but really doing nothing
+    adjustComponent(dx, dy, dz, rvx, rvy, rvz, ang, bankname, pws);
+
+    // capture TOF
+    std::vector<double> tofs;
+    for (int i = 0; i < pws->getNumberPeaks(); ++i) {
+      tofs.emplace_back(pws->getPeak(i).getTOF());
+    }
+
+    // Init and set up function
+    SCDCalibratePanels2ObjFunc testfunc;
+    testfunc.initialize();
+    testfunc.setPeakWorkspace(ipws, bankname, tofs);
+
+    std::cout << "Name: " << testfunc.name() << "\n";
+
+    const int n_peaks = pws->getNumberPeaks();
+    TS_ASSERT_EQUALS(n_peaks, 11076);
+
+    std::unique_ptr<double[]> out(new double[n_peaks * 3]);
+
+    // useless parameters
+    double useless[5];
+    size_t order(1000);
+
+    // calcualte function value
+    testfunc.function1D(out.get(), useless, order);
+
+    std::vector<double> golderrorstart{2.69624,  1.91549, -4.81046, 3.37157, 1.91529,
+                                       -4.80595, 2.02136, 1.91584,  -4.12417};
+    for (size_t i = 0; i < 9; ++i)
+      TS_ASSERT_DELTA(out[i], golderrorstart[i], 0.00001);
+    std::vector<double> golderrorend{3.36926, -3.83431, 2.06252,  3.71041, -2.87334,
+                                     2.40752, 4.04829,  -3.82838, 2.74896};
+    for (size_t i = 33219; i < 33228; ++i)
+      TS_ASSERT_DELTA(out[i], golderrorend[i - 33219], 0.00001);
+
+    //    // Peak indexes
+    //    std::vector<int> peakindexes{64,    65,    66,    67,    254,   255,   256,   257,   10955, 10956, 10957,
+    //    10958}; std::vector<long int> detids{1780254, 1800379, 1814619, 1790397, 1811588, 1825313, 1788132, 1801093,
+    //    1803923, 1788915, 1771352, 1824577}; for (size_t i = 0; i < peakindexes.size(); ++i) {
+    //        // Assert detector IDs
+    //        int ipeak = peakindexes[i];
+    //        long int det_i = pws->getPeak(ipeak).getDetectorID();
+    //        TS_ASSERT_EQUALS(det_i, detids[i]);
+
+    //        std::cout << ipeak << ": ";
+    //        for (size_t d = 0; d < 3; ++d) {
+    //            std::cout << out[ipeak * 3 + d] << "  ";
+    //        }
+    //        std::cout << "\n";
+    //    }
+    //    TS_ASSERT_EQUALS(121, 212);
+    return;
+  }
+
+  void test_detector_resize() {
+    g_log.notice() << "test_Bank() starts.\n";
+
+    // Generate unique temp files
+    auto filenamebase = boost::filesystem::temp_directory_path();
+    filenamebase /= boost::filesystem::unique_path("testBank_%%%%%%%%");
+    // Make a clone of the standard peak workspace
+    PeaksWorkspace_sptr pws = m_pws->clone();
+    Mantid::API::IPeaksWorkspace_sptr ipws = std::dynamic_pointer_cast<Mantid::API::IPeaksWorkspace>(pws);
+
+    // Move one bank to the wrong location
+    // NOTE: the common range for dx, dy ,dz is +-5cm
+    const std::string bankname = "bank27";
+    double dx = 0.;
+    double dy = 0.;
+    double dz = 0.;
+    // prescribed rotation
+    double theta = PI / 3;
+    double phi = PI / 8;
+    double rvx = sin(theta) * cos(phi);
+    double rvy = sin(theta) * sin(phi);
+    double rvz = cos(theta);
+    double ang = 0.02; // degrees
+    //
+    adjustComponent(dx, dy, dz, rvx, rvy, rvz, ang, bankname, pws);
+    // capture TOF
+    std::vector<double> tofs;
+    for (int i = 0; i < pws->getNumberPeaks(); ++i) {
+      tofs.emplace_back(pws->getPeak(i).getTOF());
+    }
+
+    // Init and set up function
+    SCDCalibratePanels2ObjFunc testfunc;
+    testfunc.initialize();
+    testfunc.setPeakWorkspace(ipws, bankname, tofs);
+
+    std::cout << "Name: " << testfunc.name() << "\n";
+
+    const int n_peaks = pws->getNumberPeaks();
+    TS_ASSERT_EQUALS(n_peaks, 11076);
+
+    std::unique_ptr<double[]> out(new double[n_peaks * 3]);
+
+    // useless parameters
+    double useless[5];
+    size_t order(1000);
+
+    // calcualte function value
+    testfunc.function1D(out.get(), useless, order);
+
+    // Peak indexes
+    std::vector<int> peakindexes{64, 65, 66, 67, 254, 255, 256, 257, 10955, 10956, 10957, 10958};
+    std::vector<long int> detids{1780254, 1800379, 1814619, 1790397, 1811588, 1825313,
+                                 1788132, 1801093, 1803923, 1788915, 1771352, 1824577};
+    for (size_t i = 0; i < peakindexes.size(); ++i) {
+      // Assert detector IDs
+      int ipeak = peakindexes[i];
+      long int det_i = pws->getPeak(ipeak).getDetectorID();
+      TS_ASSERT_EQUALS(det_i, detids[i]);
+
+      std::cout << ipeak << ": ";
+      for (size_t d = 0; d < 3; ++d) {
+        std::cout << out[ipeak * 3 + d] << "  ";
+      }
+      std::cout << "\n";
+    }
+
+    //      for (int i = 0; i < n_peaks; ++i) {
+    //          // search bank27
+    //          if (1769472 <= pws->getPeak(i).getDetectorID() && pws->getPeak(i).getDetectorID() < 1835008) {
+    //             std::cout << i << ": " << pws->getPeak(i).getDetectorID() << "\n";
+    //          }
+    //      }
+
+    // TS_ASSERT_EQUALS(1, 123321123);
+  }
+
+  // NOTE: skipped to prevent time out on build server
+  void NotUsed_run_Exec() {
+    // Shall not run this now
+    TS_ASSERT_EQUALS(1, 12321);
+
+    // Generate unique temp files
+    auto filenamebase = boost::filesystem::temp_directory_path();
+    filenamebase /= boost::filesystem::unique_path("testExec_%%%%%%%%");
+    // Make a clone of the standard peak workspace
+    PeaksWorkspace_sptr pws = m_pws->clone();
+
+    // Adjust L1 and banks
+    //-- source
+    const double dL1 = boost::math::constants::e<double>() / 100;
+    //-- bank27
+    const std::string bank27 = "bank27";
+    double dx1 = 1.1e-3;
+    double dy1 = -0.9e-3;
+    double dz1 = 1.5e-3;
+    double theta1 = PI / 3;
+    double phi1 = PI / 8;
+    double rvx1 = sin(theta1) * cos(phi1);
+    double rvy1 = sin(theta1) * sin(phi1);
+    double rvz1 = cos(theta1);
+    double ang1 = 0.01; // degrees
+    //-- bank16
+    const std::string bank16 = "bank16";
+    double dx2 = 0.5e-3;
+    double dy2 = 1.3e-3;
+    double dz2 = -1.9e-3;
+    double theta2 = PI / 4;
+    double phi2 = PI / 3;
+    double rvx2 = sin(theta2) * cos(phi2);
+    double rvy2 = sin(theta2) * sin(phi2);
+    double rvz2 = cos(theta2);
+    double ang2 = 0.01; // degrees
+
+    // source
+    adjustComponent(0.0, 0.0, dL1, 1.0, 0.0, 0.0, 0.0, pws->getInstrument()->getSource()->getName(), pws);
+    // bank27
+    adjustComponent(dx1, dy1, dz1, rvx1, rvy1, rvz1, ang1, bank27, pws);
+    // bank16
+    adjustComponent(dx2, dy2, dz2, rvx2, rvy2, rvz2, ang2, bank16, pws);
+  }
+
+private:
+  /**
+   * @brief Adjust the position of a component through translation and rotation
+   *
+   * @param dx
+   * @param dy
+   * @param dz
+   * @param rvx  x-component of rotation axis
+   * @param rvy  y-component of rotation axis
+   * @param rvz  z-component of rotation axis
+   * @param drotang  rotation angle
+   * @param cmptName
+   * @param ws
+   */
+  void adjustComponent(double dx, double dy, double dz, double rvx, double rvy, double rvz, double drotang,
+                       std::string cmptName, PeaksWorkspace_sptr &pws) {
+
+    // rotation
+    auto rot_alg = Mantid::API::AlgorithmFactory::Instance().create("RotateInstrumentComponent", -1);
+    rot_alg->initialize();
+    rot_alg->setLogging(LOGCHILDALG);
+    rot_alg->setProperty("Workspace", pws);
+    rot_alg->setProperty("ComponentName", cmptName);
+    rot_alg->setProperty("X", rvx);
+    rot_alg->setProperty("Y", rvy);
+    rot_alg->setProperty("Z", rvz);
+    rot_alg->setProperty("Angle", drotang);
+    rot_alg->setProperty("RelativeRotation", true);
+    rot_alg->execute();
+
+    // translation
+    auto mv_alg = Mantid::API::AlgorithmFactory::Instance().create("MoveInstrumentComponent", -1);
+    mv_alg->initialize();
+    mv_alg->setLogging(LOGCHILDALG);
+    mv_alg->setProperty("Workspace", pws);
+    mv_alg->setProperty("ComponentName", cmptName);
+    mv_alg->setProperty("X", dx);
+    mv_alg->setProperty("Y", dy);
+    mv_alg->setProperty("Z", dz);
+    mv_alg->setProperty("RelativePosition", true);
+    mv_alg->execute();
+  }
+
+  /**
+   * @brief remove all workspace memory after one test is done
+   *
+   */
+  void doCleanup() {
+    AnalysisDataService::Instance().remove(pwsname);
+    AnalysisDataService::Instance().remove(tmppwsname);
+  }
+
+  // ------------------- //
+  // ----- members ----- //
+  // ------------------- //
+  // workspace names
+  const std::string wsname;
+  const std::string pwsname;
+  const std::string tmppwsname;
+
+  MatrixWorkspace_sptr m_ws;
+  PeaksWorkspace_sptr m_pws;
+
+  // lattice constants of silicon
+  const double silicon_a;
+  const double silicon_b;
+  const double silicon_c;
+  const double silicon_alpha;
+  const double silicon_beta;
+  const double silicon_gamma;
+
+  // silicon crystal structure
+  CrystalStructure silicon_cs;
+
+  // constants that select the recriprocal space
+  const double dspacing_min;
+  const double dspacing_max;
+  const double wavelength_min;
+  const double wavelength_max;
+  const double omega_step;
+
+  // check praramerter
+  const double TOLERANCE_L; // distance
+  const double TOLERANCE_R; // rotation angle
+  const bool LOGCHILDALG;   // whether to show individual alg log
+  const double PI{3.1415926535897932384626433832795028841971693993751058209};
+};

--- a/Framework/Crystal/test/SCDCalibratePanels2Test.h
+++ b/Framework/Crystal/test/SCDCalibratePanels2Test.h
@@ -304,7 +304,78 @@ public:
     //  It is recommended to have L1 and T0 calibrated at the same time.
   }
 
-  void test_samplePos() {
+  /**
+   * @brief Test on calibrating detector size
+   */
+  void test_calibrateDetectorSize() {
+
+    // Generate unique temp files
+    auto filenamebase = boost::filesystem::temp_directory_path();
+    filenamebase /= boost::filesystem::unique_path("testBank_%%%%%%%%");
+    std::string filenameBase = filenamebase.string();
+    // Make a clone of the standard peak workspace
+    PeaksWorkspace_sptr pws = m_pws->clone();
+    // Resize
+    const std::string compname("bank27");
+    const double scalex(1.1), scaley(1.1);
+    auto resizeAlg = AlgorithmFactory::Instance().create("ResizeRectangularDetector", 1);
+    resizeAlg->initialize();
+    resizeAlg->setProperty("Workspace", pws);
+    resizeAlg->setProperty("ComponentName", compname);
+    resizeAlg->setProperty("ScaleX", scalex);
+    resizeAlg->setProperty("ScaleY", scaley);
+    resizeAlg->execute();
+    // Retrieve
+    Mantid::API::IPeaksWorkspace_sptr ipws = std::dynamic_pointer_cast<Mantid::API::IPeaksWorkspace>(pws);
+    // Check
+    TS_ASSERT(ipws);
+    auto input = std::dynamic_pointer_cast<ExperimentInfo>(pws);
+    Mantid::Geometry::ParameterMap &pmap = input->instrumentParameters();
+    auto checkscalex = pmap.getDouble(compname, std::string("scalex"));
+    auto checkscaley = pmap.getDouble(compname, std::string("scaley"));
+
+    TS_ASSERT_DELTA(scalex, checkscalex[0], 0.00000001);
+    TS_ASSERT_DELTA(scaley, checkscaley[0], 0.00000001);
+
+    // Init, config and run Calibration
+    const std::string isawFilename = filenameBase + ".DetCal";
+    const std::string xmlFilename = filenameBase + ".xml";
+    const std::string csvFilename = filenameBase + ".csv";
+
+    // execute the calibration
+    SCDCalibratePanels2 alg;
+    alg.initialize();
+    alg.setProperty("PeakWorkspace", pws);
+    alg.setProperty("a", silicon_a);
+    alg.setProperty("b", silicon_b);
+    alg.setProperty("c", silicon_c);
+    alg.setProperty("alpha", silicon_alpha);
+    alg.setProperty("beta", silicon_beta);
+    alg.setProperty("gamma", silicon_gamma);
+    alg.setProperty("RecalculateUB", false);
+    alg.setProperty("CalibrateL1", false);
+    alg.setProperty("CalibrateT0", false);
+    // special about det size calibration
+    alg.setProperty("CalibrateBanks", true);
+    alg.setProperty("SearchRadiusTransBank", 0.0);
+    alg.setProperty("SearchradiusRotXBank", 0.0);
+    alg.setProperty("SearchradiusRotYBank", 0.0);
+    alg.setProperty("SearchradiusRotZBank", 0.0);
+
+    alg.setProperty("CalibrateSize", true);
+    alg.setProperty("SearchRadiusSize", 0.2);
+    alg.setProperty("FixAspectRatio", true);
+
+    alg.setProperty("TuneSamplePosition", false);
+    alg.setProperty("OutputWorkspace", "caliTableDetSizeTest");
+    alg.setProperty("DetCalFilename", isawFilename);
+    alg.setProperty("XmlFilename", xmlFilename);
+    alg.setProperty("CSVFilename", csvFilename);
+    alg.execute();
+    TS_ASSERT(alg.isExecuted());
+  }
+
+  void SaveTime_test_samplePos() {
     g_log.notice() << "test_samplePos() starts.\n";
     // Generate unique temp files
     auto filenamebase = boost::filesystem::temp_directory_path();

--- a/Framework/Crystal/test/SCDCalibratePanels2Test.h
+++ b/Framework/Crystal/test/SCDCalibratePanels2Test.h
@@ -371,6 +371,9 @@ public:
     alg.setProperty("DetCalFilename", isawFilename);
     alg.setProperty("XmlFilename", xmlFilename);
     alg.setProperty("CSVFilename", csvFilename);
+
+    alg.setProperty("MaxFitIterations", 5);
+    alg.setProperty("BankName", "bank27");
     alg.execute();
     TS_ASSERT(alg.isExecuted());
   }

--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -731,7 +731,7 @@ constParameter:${CMAKE_SOURCE_DIR}/Framework/Crystal/src/PredictSatellitePeaks.c
 constParameter:${CMAKE_SOURCE_DIR}/Framework/Crystal/src/PredictSatellitePeaks.cpp:330
 constParameter:${CMAKE_SOURCE_DIR}/Framework/Crystal/src/PredictSatellitePeaks.cpp:333
 constParameter:${CMAKE_SOURCE_DIR}/Framework/Crystal/src/PredictSatellitePeaks.cpp:334
-unreadVariable:${CMAKE_SOURCE_DIR}/Framework/Crystal/src/SCDCalibratePanels2ObjFunc.cpp:114
+//--> Disable unreadVariable:${CMAKE_SOURCE_DIR}/Framework/Crystal/src/SCDCalibratePanels2ObjFunc.cpp:114
 knownConditionTrueFalse:${CMAKE_SOURCE_DIR}/Framework/Crystal/src/IntegratePeakTimeSlices.cpp:100
 nullPointer:${CMAKE_SOURCE_DIR}/Framework/Kernel/inc/MantidKernel/IPropertyManager.h:163
 nullPointer:${CMAKE_SOURCE_DIR}/Framework/Kernel/inc/MantidKernel/IPropertyManager.h:163
@@ -746,9 +746,9 @@ nullPointer:${CMAKE_SOURCE_DIR}/Framework/Kernel/inc/MantidKernel/IPropertyManag
 knownConditionTrueFalse:${CMAKE_SOURCE_DIR}/Framework/Crystal/src/SaveIsawPeaks.cpp:404
 unreadVariable:${CMAKE_SOURCE_DIR}/Framework/Crystal/src/SetSpecialCoordinates.cpp:86
 unreadVariable:${CMAKE_SOURCE_DIR}/Framework/Crystal/src/SetSpecialCoordinates.cpp:98
-constParameter:${CMAKE_SOURCE_DIR}/Framework/Crystal/src/SCDCalibratePanels2.cpp:1046
-unreadVariable:${CMAKE_SOURCE_DIR}/Framework/Crystal/src/SCDCalibratePanels2.cpp:799
-unreadVariable:${CMAKE_SOURCE_DIR}/Framework/Crystal/src/SCDCalibratePanels2.cpp:856
+//--> Disable constParameter:${CMAKE_SOURCE_DIR}/Framework/Crystal/src/SCDCalibratePanels2.cpp:1046
+//--> Disable unreadVariable:${CMAKE_SOURCE_DIR}/Framework/Crystal/src/SCDCalibratePanels2.cpp:799
+//--> Disable unreadVariable:${CMAKE_SOURCE_DIR}/Framework/Crystal/src/SCDCalibratePanels2.cpp:856
 useInitializationList:${CMAKE_SOURCE_DIR}/Framework/ICat/test/ICatTestHelper.cpp:16
 identicalInnerCondition:${CMAKE_SOURCE_DIR}/Framework/LiveData/src/ADARA/ADARAPackets.cpp:184
 identicalInnerCondition:${CMAKE_SOURCE_DIR}/Framework/LiveData/src/ADARA/ADARAPackets.cpp:220

--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -731,7 +731,6 @@ constParameter:${CMAKE_SOURCE_DIR}/Framework/Crystal/src/PredictSatellitePeaks.c
 constParameter:${CMAKE_SOURCE_DIR}/Framework/Crystal/src/PredictSatellitePeaks.cpp:330
 constParameter:${CMAKE_SOURCE_DIR}/Framework/Crystal/src/PredictSatellitePeaks.cpp:333
 constParameter:${CMAKE_SOURCE_DIR}/Framework/Crystal/src/PredictSatellitePeaks.cpp:334
-//--> Disable unreadVariable:${CMAKE_SOURCE_DIR}/Framework/Crystal/src/SCDCalibratePanels2ObjFunc.cpp:114
 knownConditionTrueFalse:${CMAKE_SOURCE_DIR}/Framework/Crystal/src/IntegratePeakTimeSlices.cpp:100
 nullPointer:${CMAKE_SOURCE_DIR}/Framework/Kernel/inc/MantidKernel/IPropertyManager.h:163
 nullPointer:${CMAKE_SOURCE_DIR}/Framework/Kernel/inc/MantidKernel/IPropertyManager.h:163
@@ -746,9 +745,6 @@ nullPointer:${CMAKE_SOURCE_DIR}/Framework/Kernel/inc/MantidKernel/IPropertyManag
 knownConditionTrueFalse:${CMAKE_SOURCE_DIR}/Framework/Crystal/src/SaveIsawPeaks.cpp:404
 unreadVariable:${CMAKE_SOURCE_DIR}/Framework/Crystal/src/SetSpecialCoordinates.cpp:86
 unreadVariable:${CMAKE_SOURCE_DIR}/Framework/Crystal/src/SetSpecialCoordinates.cpp:98
-//--> Disable constParameter:${CMAKE_SOURCE_DIR}/Framework/Crystal/src/SCDCalibratePanels2.cpp:1046
-//--> Disable unreadVariable:${CMAKE_SOURCE_DIR}/Framework/Crystal/src/SCDCalibratePanels2.cpp:799
-//--> Disable unreadVariable:${CMAKE_SOURCE_DIR}/Framework/Crystal/src/SCDCalibratePanels2.cpp:856
 useInitializationList:${CMAKE_SOURCE_DIR}/Framework/ICat/test/ICatTestHelper.cpp:16
 identicalInnerCondition:${CMAKE_SOURCE_DIR}/Framework/LiveData/src/ADARA/ADARAPackets.cpp:184
 identicalInnerCondition:${CMAKE_SOURCE_DIR}/Framework/LiveData/src/ADARA/ADARAPackets.cpp:220

--- a/docs/source/release/v6.3.0/diffraction.rst
+++ b/docs/source/release/v6.3.0/diffraction.rst
@@ -28,5 +28,6 @@ Engineering Diffraction
 Single Crystal Diffraction
 --------------------------
 - Existing :ref:`PolDiffILLReduction <algm-PolDiffILLReduction>` and :ref:`D7AbsoluteCrossSections <algm-D7AbsoluteCrossSections>` can now reduce and properly normalise single-crystal data for the D7 ILL instrument.
+- Enabling :ref:`SCDCalibratePanels <algm-SCDCalibratePanels-v2>` to calibrate each detector bank's size if it is a rectagular detector optionally.
 
 :ref:`Release 6.3.0 <v6.3.0>`


### PR DESCRIPTION
**Description of work.**

This PR is the ORNL companion to https://github.com/mantidproject/mantid/pull/32776.

The work includes

1. Enable [SCDCalibratePanels2ObjFunc](https://github.com/mantidproject/mantid/blob/main/Framework/Crystal/inc/MantidCrystal/SCDCalibratePanels2ObjFunc.h) to support detector size scaling.
2. Implement unit test for [SCDCalibratePanels2ObjFunc](https://github.com/mantidproject/mantid/blob/main/Framework/Crystal/inc/MantidCrystal/SCDCalibratePanels2ObjFunc.h)
3. Enable [SCDCalibratePanels2](https://github.com/mantidproject/mantid/blob/main/Framework/Crystal/src/SCDCalibratePanels2.cpp) to allow user to specify maximum fitting iterations and specific bank to calibrate
4.  Enable [SCDCalibratePanels2](https://github.com/mantidproject/mantid/blob/main/Framework/Crystal/src/SCDCalibratePanels2.cpp) to calibrate detector size scale and export the calibrated scale factor to CSV and TableWorkspace.


**To test:**

1. All unit and integration test
2. CIS specified acceptance test.
```
# import mantid algorithms, numpy and matplotlib
from mantid.simpleapi import *
import matplotlib.pyplot as plt
import numpy as np

# necessary import
import numpy as np
from collections import namedtuple
from mantid.simpleapi import *
from mantid.geometry import CrystalStructure
from mantid.kernel import V3D

def convert(dictionary):
    return namedtuple('GenericDict', dictionary.keys())(**dictionary)

import os
directory = os.path.dirname(os.path.realpath(__file__))

lc_natrolite = {
    "a": 18.29,  # A
    "b": 18.64,  # A
    "c": 6.56,  # A
    "alpha": 90,  # deg
    "beta": 90,  # deg
    "gamma": 90,  # deg
}

natrolite = convert(lc_natrolite)

# Generate simulated workspace for MANDI
CreateSimulationWorkspace(
    Instrument='MANDI',
    BinParams='1,100,10000',
    UnitX='TOF',
    OutputWorkspace='cws',
)

cws = mtd['cws']

# Set the UB matrix for the sample
SetUB(
    Workspace='cws',
    u='1,1,0',  # vector along k_i, when goniometer is at 0
    v='-1,1,2',  # in-plane vector normal to k_i, when goniometer is at 0
    **lc_natrolite,
)

# Generate predicted peak workspace
dspacings = convert({'min': 3.0, 'max': 18.0})
wavelengths = convert({'min': 0.4, 'max': 3.5})

# Collect peaks over a range of omegas
CreatePeaksWorkspace(InstrumentWorkspace='cws', OutputWorkspace='pws', NumberOfPeaks=0)
omegas = range(0, 180, 6)

# resize bank 31
ResizeRectangularDetector(cws, 'bank31', ScaleX=1.1, ScaleY=1.1)

for omega in omegas:
    SetGoniometer(
        Workspace="cws",
        Axis0=f"{omega},0,1,0,1",
        Axis1=f"135,0,0,1,1",
    )

    PredictPeaks(
        InputWorkspace='cws',
        MinDSpacing=dspacings.min,
        MaxDSpacing=dspacings.max,
        WavelengthMin=wavelengths.min,
        WavelengthMax=wavelengths.max,
        ReflectionCondition='All-face centred',
        OutputWorkspace='_pws',
    )
    
    for i in range(mtd['_pws'].getNumberPeaks()):
        mtd['_pws'].getPeak(i).setRunNumber(omega)

    CombinePeaksWorkspaces(
        LHSWorkspace="_pws",
        RHSWorkspace="pws",
        OutputWorkspace="pws",
    )

# ResizeRectangularDetector(cws, 'bank13', ScaleX=1/1.1, ScaleY=1/1.1)

SaveNexus(InputWorkspace='pws', Filename=directory+'/test_predicted.peaks')

# Calibrate
SCDCalibratePanels(PeakWorkspace='pws', a=18.289999999999999, b=18.640000000000001, c=6.5599999999999996, alpha=90, beta=90, gamma=90, 
                   CalibrateL1=False, CalibrateBanks=True, SearchRadiusTransBank=0, SearchradiusRotXBank=0, SearchradiusRotYBank=0, SearchradiusRotZBank=0, 
                   CalibrateSize=True, SearchRadiusSize=0.20000000000000001, OutputWorkspace='calibresult')
```

And you shall only see the scale factor of bank 31 are close to 1.1, while the others are close to 1.0

```
Resize bank31 by (absolute) 1.10044, 1.10044
```

Fixes [ORNL SCD #406](https://code.ornl.gov/sns-hfir-scse/diffraction/single-crystal/single-crystal-diffraction/-/issues/406) through [Task 427](https://code.ornl.gov/sns-hfir-scse/diffraction/single-crystal/single-crystal-diffraction/-/issues/427).

<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
