### PR TITLE
Fix problem with NaN values being generated during absorption correction in PEARL scripts

### DIFF
--- a/docs/source/release/v6.3.0/diffraction.rst
+++ b/docs/source/release/v6.3.0/diffraction.rst
@@ -16,6 +16,7 @@ Powder Diffraction
 - Extending :ref:`MultipleScatteringCorrection <algm-MultipleScatteringCorrection>` to the sample and container case.
 - `absorptioncorrutils` now have the capability to calculate effective absorption correction (considering both absorption and multiple scattering).
 - Both :ref:`MultipleScatteringCorrection <algm-MultipleScatteringCorrection>` and :ref:`PaalmanPingsAbsorptionCorrection <algm-PaalmanPingsAbsorptionCorrection>` can use a different element size for container now.
+- PEARL powder diffraction scripts now cope if absorption correction workspace is different size to the Vanadium workspace without generating NaN values
 
 Bugfixes
 ########

--- a/scripts/Diffraction/isis_powder/pearl_routines/pearl_algs.py
+++ b/scripts/Diffraction/isis_powder/pearl_routines/pearl_algs.py
@@ -5,6 +5,7 @@
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
 import mantid.simpleapi as mantid
+from mantid.kernel import logger
 
 import isis_powder.routines.common as common
 from isis_powder.routines.run_details import create_run_details_object, get_cal_mapping_dict
@@ -26,6 +27,20 @@ def attenuate_workspace(attenuation_file_path, ws_to_correct):
 
 
 def apply_vanadium_absorb_corrections(van_ws, run_details, absorb_ws=None):
+
+    def generate_det_id_list(ws):
+        det_id_list = []
+        for i in range(0, ws.getNumberHistograms()):
+            try:
+                det_ids = ws.getSpectrum(i).getDetectorIDs()
+
+            except RuntimeError:
+                pass
+            else:
+                for det_id in det_ids:
+                    det_id_list.append(det_id)
+        return det_id_list
+
     if absorb_ws is None:
         absorb_ws = mantid.Load(Filename=run_details.vanadium_absorption_path)
 
@@ -33,6 +48,21 @@ def apply_vanadium_absorb_corrections(van_ws, run_details, absorb_ws=None):
     absorb_units = absorb_ws.getAxis(0).getUnit().unitID()
     if van_original_units != absorb_units:
         van_ws = mantid.ConvertUnits(InputWorkspace=van_ws, Target=absorb_units, OutputWorkspace=van_ws)
+
+    # PEARL sometimes do special runs with different detector cards so extract common spectra before doing
+    # RebinToWorkspace to ensure histogram by histogram by rebin
+    abs_det_id_list = generate_det_id_list(absorb_ws)
+    van_det_id_list = generate_det_id_list(van_ws)
+
+    common_det_ids = [det_id for det_id in abs_det_id_list if det_id in van_det_id_list]
+
+    MSG_STEM = "Vanadium workspace and absorption workspaces have different spectra. "
+    if common_det_ids != van_det_id_list:
+        logger.warning(MSG_STEM + "Removing unmatched spectra from the Vanadium workspace")
+        van_ws = mantid.ExtractSpectra(InputWorkspace=van_ws, DetectorList=common_det_ids)
+    if common_det_ids != abs_det_id_list:
+        logger.warning(MSG_STEM + "Removing unmatched spectra from the absorption workspace")
+        absorb_ws = mantid.ExtractSpectra(InputWorkspace=absorb_ws, DetectorList=common_det_ids)
 
     absorb_ws = mantid.RebinToWorkspace(WorkspaceToRebin=absorb_ws, WorkspaceToMatch=van_ws, OutputWorkspace=absorb_ws)
     van_ws = mantid.Divide(LHSWorkspace=van_ws, RHSWorkspace=absorb_ws, OutputWorkspace=van_ws, AllowDifferentNumberSpectra=True)

--- a/scripts/Diffraction/isis_powder/pearl_routines/pearl_algs.py
+++ b/scripts/Diffraction/isis_powder/pearl_routines/pearl_algs.py
@@ -55,12 +55,14 @@ def apply_vanadium_absorb_corrections(van_ws, run_details, absorb_ws=None):
     van_det_id_list = generate_det_id_list(van_ws)
 
     common_det_ids = [det_id for det_id in abs_det_id_list if det_id in van_det_id_list]
+    if not common_det_ids:
+        raise RuntimeError("No common detectors in Vanadium and sample workspaces")
 
     MSG_STEM = "Vanadium workspace and absorption workspaces have different spectra. "
-    if common_det_ids != van_det_id_list:
+    if sorted(common_det_ids) != sorted(van_det_id_list):
         logger.warning(MSG_STEM + "Removing unmatched spectra from the Vanadium workspace")
         van_ws = mantid.ExtractSpectra(InputWorkspace=van_ws, DetectorList=common_det_ids)
-    if common_det_ids != abs_det_id_list:
+    if sorted(common_det_ids) != sorted(abs_det_id_list):
         logger.warning(MSG_STEM + "Removing unmatched spectra from the absorption workspace")
         absorb_ws = mantid.ExtractSpectra(InputWorkspace=absorb_ws, DetectorList=common_det_ids)
 

--- a/scripts/Diffraction/isis_powder/pearl_routines/pearl_algs.py
+++ b/scripts/Diffraction/isis_powder/pearl_routines/pearl_algs.py
@@ -59,10 +59,10 @@ def apply_vanadium_absorb_corrections(van_ws, run_details, absorb_ws=None):
         raise RuntimeError("No common detectors in Vanadium and sample workspaces")
 
     MSG_STEM = "Vanadium workspace and absorption workspaces have different spectra. "
-    if sorted(common_det_ids) != sorted(van_det_id_list):
+    if common_det_ids != van_det_id_list:
         logger.warning(MSG_STEM + "Removing unmatched spectra from the Vanadium workspace")
         van_ws = mantid.ExtractSpectra(InputWorkspace=van_ws, DetectorList=common_det_ids)
-    if sorted(common_det_ids) != sorted(abs_det_id_list):
+    if common_det_ids != abs_det_id_list:
         logger.warning(MSG_STEM + "Removing unmatched spectra from the absorption workspace")
         absorb_ws = mantid.ExtractSpectra(InputWorkspace=absorb_ws, DetectorList=common_det_ids)
 


### PR DESCRIPTION
**Description of work.**

Fix problem with NaN values being generated during absorption correction when absorption workspace is different size to the Vanadium workspace. This was causing a crash later on in the reduction process in a call to FindPeaks

Occurs on PEARL runs from 19_1 and 19_2 cycle where HRPD detector cards used

The fix is to remove spectra from the absorption correction and V workspaces so they contain a common set of spectra

**To test:**

Unzip the file \\olympic\Babylon5\Public\DannyHindson\PR32759_files.zip
Update the script below to replace <folder> with the path to the folder where you unzipped the file
Run this script and it should complete without an error. You'll need access to the ISIS data archive to run this:

```
from mantid.simpleapi import *
import matplotlib.pyplot as plt
import numpy as np
from isis_powder.pearl import Pearl

pearl_focus = Pearl(user_name="Calib",
                    output_directory=r"<folder>\output",   #directory above cycle number 
                    config_file=r"<folder>\Calibration.yaml",
                    calibration_directory=r"<folder>\calib_critical_files",
                    calibration_mapping_file=r"<folder>\pearl.yaml")

pearl_focus.create_vanadium(run_in_cycle=110388,tt_mode="tt35",do_absorb_corrections=True,long_mode=True)
pearl_focus.create_vanadium(run_in_cycle=110388,tt_mode="tt70",do_absorb_corrections=True,long_mode=True)
pearl_focus.create_vanadium(run_in_cycle=110388,tt_mode="tt88",do_absorb_corrections=True,long_mode=True)
```

Fixes #32568.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
