### PR TITLE
Total Scattering improvements

### DIFF
--- a/Framework/Algorithms/src/CalculatePlaczekSelfScattering2.cpp
+++ b/Framework/Algorithms/src/CalculatePlaczekSelfScattering2.cpp
@@ -31,7 +31,7 @@ void CalculatePlaczekSelfScattering2::init() {
       "calculated for. Workspace must have instrument and sample data.");
   declareProperty(
       std::make_unique<API::WorkspaceProperty<API::MatrixWorkspace>>("IncidentSpecta", "", Kernel::Direction::Input),
-      "Workspace of fitted incident spectrum with it's first derivative.");
+      "Workspace of fitted incident spectrum with it's first derivative. Must be in units of Wavelength.");
   declareProperty(
       std::make_unique<API::WorkspaceProperty<API::MatrixWorkspace>>("OutputWorkspace", "", Kernel::Direction::Output),
       "Workspace with the Self scattering correction");

--- a/Framework/Algorithms/test/CalculatePlaczekSelfScatteringTest.h
+++ b/Framework/Algorithms/test/CalculatePlaczekSelfScatteringTest.h
@@ -90,6 +90,7 @@ public:
     alg->setProperty("DataX", x);
     alg->setProperty("DataY", y);
     alg->setProperty("NSpec", 2);
+    alg->setProperty("UnitX", "Wavelength");
     alg->execute();
     // retreve output workspace from ADS
     MatrixWorkspace_sptr outWs =
@@ -123,37 +124,37 @@ public:
   }
 
   void testCalculatePlaczekSelfScatteringExecutes() {
-    MatrixWorkspace_sptr IncidentSpecta = generateIncidentSpectrum();
+    MatrixWorkspace_sptr IncidentSpectra = generateIncidentSpectrum();
     auto alg = makeAlgorithm();
     Mantid::DataObjects::Workspace2D_sptr InputWorkspace =
         WorkspaceCreationHelper::create2DWorkspaceWithRectangularInstrument(5, 100, 380);
     Mantid::API::AnalysisDataService::Instance().addOrReplace("InputWorkspace", InputWorkspace);
     addSampleMaterialToWorkspace();
-    alg->setProperty("IncidentSpecta", IncidentSpecta);
+    alg->setProperty("IncidentSpectra", IncidentSpectra);
     alg->setProperty("InputWorkspace", "InputWorkspace");
     alg->setProperty("OutputWorkspace", "correction_ws");
     TS_ASSERT_THROWS_NOTHING(alg->execute());
   }
 
   void testCalculatePlaczekSelfScatteringDoesNotRunWithNoDetectors() {
-    MatrixWorkspace_sptr IncidentSpecta = generateIncidentSpectrum();
+    MatrixWorkspace_sptr IncidentSpectra = generateIncidentSpectrum();
     Mantid::DataObjects::Workspace2D_sptr InputWorkspace = WorkspaceCreationHelper::create2DWorkspace(30, 381);
     Mantid::API::AnalysisDataService::Instance().addOrReplace("InputWorkspace", InputWorkspace);
     addSampleMaterialToWorkspace();
     auto alg = makeAlgorithm();
-    alg->setProperty("IncidentSpecta", IncidentSpecta);
+    alg->setProperty("IncidentSpectra", IncidentSpectra);
     alg->setProperty("InputWorkspace", InputWorkspace);
     alg->setProperty("OutputWorkspace", "correction_ws");
     TS_ASSERT_THROWS(alg->execute(), const std::runtime_error &)
   }
 
   void testCalculatePlaczekSelfScatteringDoesNotRunWithNoSample() {
-    MatrixWorkspace_sptr IncidentSpecta = generateIncidentSpectrum();
+    MatrixWorkspace_sptr IncidentSpectra = generateIncidentSpectrum();
     Mantid::DataObjects::Workspace2D_sptr InputWorkspace =
         WorkspaceCreationHelper::create2DWorkspaceWithRectangularInstrument(5, 100, 380);
     Mantid::API::AnalysisDataService::Instance().addOrReplace("InputWorkspace", InputWorkspace);
     auto alg = makeAlgorithm();
-    alg->setProperty("IncidentSpecta", IncidentSpecta);
+    alg->setProperty("IncidentSpectra", IncidentSpectra);
     alg->setProperty("InputWorkspace", InputWorkspace);
     alg->setProperty("OutputWorkspace", "correction_ws");
     TS_ASSERT_THROWS(alg->execute(), const std::runtime_error &)

--- a/Testing/SystemTests/tests/framework/ISIS_PowderPolarisTest.py
+++ b/Testing/SystemTests/tests/framework/ISIS_PowderPolarisTest.py
@@ -165,11 +165,11 @@ class TotalScatteringTest(systemtesting.MantidSystemTest):
         # Whilst total scattering is in development, the validation will avoid using reference files as they will have
         # to be updated very frequently. In the meantime, the expected peak in the PDF at ~3.9 Angstrom will be checked.
         # After rebin this is at X index 37
-        expected_peak_values = [-0.00365,
-                                0.18790,
-                                0.38707,
-                                0.37882,
-                                0.72237]
+        expected_peak_values = [0.0008175,
+                                0.2500,
+                                0.4410,
+                                0.2002,
+                                0.9767]
         for index, ws in enumerate(self.pdf_output):
             self.assertAlmostEqual(ws.dataY(0)[37], expected_peak_values[index], places=3)
 
@@ -189,7 +189,7 @@ class TotalScatteringMergedTest(systemtesting.MantidSystemTest):
         # Whilst total scattering is in development, the validation will avoid using reference files as they will have
         # to be updated very frequently. In the meantime, the expected peak in the PDF at ~3.9 Angstrom will be checked.
         # After rebin this is at X index 37
-        self.assertAlmostEqual(self.pdf_output.dataY(0)[37], 0.7376667, places=3)
+        self.assertAlmostEqual(self.pdf_output.dataY(0)[37], 1.00480, places=3)
 
 
 class TotalScatteringPDFRebinTest(systemtesting.MantidSystemTest):
@@ -243,7 +243,7 @@ class TotalScatteringPdfTypeTest(systemtesting.MantidSystemTest):
         # Whilst total scattering is in development, the validation will avoid using reference files as they will have
         # to be updated very frequently. In the meantime, the expected peak in the PDF at ~3.9 Angstrom will be checked.
         # After rebin this is at X index 37
-        self.assertAlmostEqual(self.pdf_output.dataY(0)[37], 1.01521, places=3)
+        self.assertAlmostEqual(self.pdf_output.dataY(0)[37], 1.0207, places=3)
 
 
 class TotalScatteringFilterTest(systemtesting.MantidSystemTest):
@@ -261,7 +261,7 @@ class TotalScatteringFilterTest(systemtesting.MantidSystemTest):
         # Whilst total scattering is in development, the validation will avoid using reference files as they will have
         # to be updated very frequently. In the meantime, the expected peak in the PDF at ~3.9 Angstrom will be checked.
         # After rebin this is at X index 37
-        self.assertAlmostEqual(self.pdf_output.dataY(0)[37], 0.63779, places=3)
+        self.assertAlmostEqual(self.pdf_output.dataY(0)[37], 0.90376, places=3)
 
 
 class TotalScatteringLorchFilterTest(systemtesting.MantidSystemTest):
@@ -279,7 +279,7 @@ class TotalScatteringLorchFilterTest(systemtesting.MantidSystemTest):
         # Whilst total scattering is in development, the validation will avoid using reference files as they will have
         # to be updated very frequently. In the meantime, the expected peak in the PDF at ~3.9 Angstrom will be checked.
         # After rebin this is at X index 37
-        self.assertAlmostEqual(self.pdf_output.dataY(0)[37], 3.11435, places=3)
+        self.assertAlmostEqual(self.pdf_output.dataY(0)[37], 6.9326, places=3)
 
 
 def run_total_scattering(run_number, merge_banks, q_lims=None, delta_q=None, delta_r=None, pdf_type="G(r)",

--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -516,7 +516,6 @@ useStlAlgorithm:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/UpdateInstrumentF
 nullPointer:${CMAKE_SOURCE_DIR}/Framework/Kernel/inc/MantidKernel/IPropertyManager.h:163
 nullPointer:${CMAKE_SOURCE_DIR}/Framework/Kernel/inc/MantidKernel/IPropertyManager.h:163
 funcArgOrderDifferent:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/CalculateEfficiency.cpp:308
-constParameter:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/CalculatePlaczekSelfScattering.cpp:29
 constParameter:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/CalculatePlaczek.cpp:45
 redundantInitialization:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/ChangeTimeZero.cpp:133
 constParameter:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/ConvertAxisByFormula.cpp:238

--- a/docs/source/algorithms/TotScatCalculateSelfScattering-v1.rst
+++ b/docs/source/algorithms/TotScatCalculateSelfScattering-v1.rst
@@ -18,12 +18,12 @@ sub-algorithms as listed below.
 #. :ref:`algm-ConvertUnits` Converts incident spectrum to wavelength.
 #. :ref:`algm-FitIncidentSpectrum` Fit a curve to the incident spectrum.
 #. :ref:`algm-CalculatePlaczekSelfScattering` Calculate the Placzek self scattering factor for each pixel.
+#. :ref:`algm-ConvertUnits` Convert the Placzek correction into MomentumTransfer
+#. :ref:`algm-Rebin` Rebin correction before GroupDetectors.
 #. :ref:`algm-LoadCalFile` Loads the detector calibration.
-#. :ref:`algm-DiffractionFocussing` Focus the Placzek self scattering factor into detector banks.
+#. :ref:`algm-GroupDetectors` Group the Placzek self scattering factor into detector banks.
 #. :ref:`algm-CreateWorkspace` Create a workspace containing the number of pixels in each detector bank.
 #. :ref:`algm-Divide` Normalize the Placzek correction by pixel number in bank
-#. :ref:`algm-ConvertToDistribution` Change the workspace into a format that can be subtracted.
-#. :ref:`algm-ConvertUnits` Converts correction into MomentumTransfer.
 
 Workflow
 ########

--- a/docs/source/diagrams/TotScatCalculateSelfScattering-v1_wkflw.dot
+++ b/docs/source/diagrams/TotScatCalculateSelfScattering-v1_wkflw.dot
@@ -19,11 +19,11 @@ subgraph algorithms {
   FitIncidentSpectrum               [label="FitIncidentSpectrum v1"]
   CalculatePlaczekSelfScattering    [label="CalculatePlaczekSelfScattering v1"]
   LoadCalFile                       [label="LoadCalFile v1"]
-  DiffractionFocussing              [label="DiffractionFocussing v2"]
+  GroupDetectors                    [label="GroupDetectors v2"]
   CreateWorkspace                   [label="CreateWorkspace v1"]
   Divide                            [label="Divide v1"]
-  ConvertToDistribution             [label="ConvertToDistribution v1"]
   ConvertUnits2                     [label="ConvertUnits v1"]
+  Rebin                             [label="Rebin v1"]
 }
 
 subgraph process  {
@@ -42,13 +42,13 @@ ExtractSpectra                  -> ConvertUnits1
 ConvertUnits1                   -> FitIncidentSpectrum
 FitIncidentSpectrum             -> CalculatePlaczekSelfScattering
 calFileName                     -> LoadCalFile
-LoadCalFile                     -> DiffractionFocussing
-CalculatePlaczekSelfScattering  -> DiffractionFocussing
+LoadCalFile                     -> GroupDetectors
+CalculatePlaczekSelfScattering  -> ConvertUnits2
+ConvertUnits2                   -> Rebin
+Rebin                           -> GroupDetectors
 LoadCalFile                     -> GetPixelNumberInDetector
 GetPixelNumberInDetector        -> CreateWorkspace
 CreateWorkspace                 -> Divide
-DiffractionFocussing            -> Divide
-Divide                          -> ConvertToDistribution
-ConvertToDistribution           -> ConvertUnits2
-ConvertUnits2                   -> outputWorkspace
+GroupDetectors                  -> Divide
+Divide                          -> outputWorkspace
 }

--- a/docs/source/release/v6.3.0/diffraction.rst
+++ b/docs/source/release/v6.3.0/diffraction.rst
@@ -20,6 +20,11 @@ Powder Diffraction
 - Both :ref:`MultipleScatteringCorrection <algm-MultipleScatteringCorrection>` and :ref:`PaalmanPingsAbsorptionCorrection <algm-PaalmanPingsAbsorptionCorrection>` can use a different element size for container now.
 - PEARL powder diffraction scripts now cope if absorption correction workspace is different size to the Vanadium workspace without generating NaN values
 - :ref:`AnvredCorrection <algm-AnvredCorrection>` (and :ref:`SphericalAbsorption <algm-SphericalAbsorption>` which calls it) will now take the radius of a spherical sample from the workspace if the radius isn't specified (if the sample is not a sphere this will produce an error).
+- :ref:`TotScatCalculateSelfScattering <algm-TotScatCalculateSelfScattering>` now groups the correction by detector bank in MomentumTransfer (rather than TOF)
+  and includes the following update.
+- :ref:`CalculatePlaczekSelfScattering v1 <algm-CalculatePlaczekSelfScattering-v1>` now validates that the IncidentSpectra
+  is in units of Wavelength and will output in the same unit as the InputWorkspace. The parameter IncidentSpectra for :ref:`CalculatePlaczekSelfScattering <algm-CalculatePlaczekSelfScattering-v1>` has been
+  renamed to fix a typo, which is a breaking change for this algorithm. Note that the addition of 1 to the Placzek correction has been moved out of this algorithm.
 
 Improvements
 ############

--- a/scripts/Diffraction/isis_powder/polaris_routines/polaris_algs.py
+++ b/scripts/Diffraction/isis_powder/polaris_routines/polaris_algs.py
@@ -106,6 +106,7 @@ def generate_ts_pdf(run_number, focus_file_path, merge_banks=False, q_lims=None,
                                                          WorkspaceToMatch=focused_ws)
 
     focused_ws = mantid.Subtract(LHSWorkspace=focused_ws, RHSWorkspace=self_scattering_correction)
+    focused_ws -= 1  # This -1 to the correction has been moved out of CalculatePlaczekSelfScattering
     if delta_q:
         focused_ws = mantid.Rebin(InputWorkspace=focused_ws, Params=delta_q)
     if merge_banks:


### PR DESCRIPTION
**Description of work.**
- Improved CalculatePlaczekSelfScattering version 1 to output in whatever units the input workspace has, added validation that the IncidentSpecta is in units of Wavelength
- Altered TotScattCalculateSelfScattering algorithm to run DiffractionFoccussing in Q and actually use CalculatePlaczekSelfScattering version

**To test:**

Check the current main branch behaviour first: 
I added the command:
`daniel_ssc = mantid.CloneWorkspace(InputWorkspace=self_scattering_correction, OutputWorkspace="daniel_ssc")`
to output the self_scattering_correction workspace on [Line97 of polaris_alg.py](https://github.com/mantidproject/mantid/blob/main/scripts/Diffraction/isis_powder/polaris_routines/polaris_algs.py#L97)
Then run this script (ask me if I need to email data):
```
from mantid.simpleapi import *
import numpy as np
from isis_powder import polaris, SampleDetails
import time

start_time = time.time()
config_file_path = r"/home/danielmurphy/Downloads/polaris-calculate-pdf/polaris_config_example.yaml"
polaris = polaris.Polaris(config_file=config_file_path, user_name="test", mode="PDF")

sample_details = SampleDetails(height=4.0, radius=0.2985, center=[0, 0, 0], shape='cylinder')
sample_details.set_material(chemical_formula='Si')
polaris.set_sample_details(sample=sample_details)

polaris.create_vanadium(first_cycle_run_no="98532", multiple_scattering=False)
polaris.focus(run_number="98533", input_mode='Summed')
polaris.create_total_scattering_pdf(run_number="98533", merge_banks=False)
print("Script run time", time.time() - start_time)
```
The current main code gives these plots:
<img width="1822" alt="Screenshot 2021-10-12 at 14 40 43" src="https://user-images.githubusercontent.com/55980573/136982594-ab988b08-dac9-4211-b12b-979786dc9074.png">

Next please, check out my changes, make sure you still have the CloneWorkspace command and have built. The new result is as so:
<img width="1816" alt="Screenshot 2021-10-12 at 14 30 15" src="https://user-images.githubusercontent.com/55980573/136983249-737449ff-6dd3-4190-81ce-67affdee13ed.png">

I have found that there is only a negligible difference (10E-16 for values ~ 0.3) in the output of the old and new CalculatePlaczekSelfScattering v1 algorithms. There is a noticeable difference in the PDF output from TotScattCalcSelfScattering due to focussing in Q instead of TOF. I think the differences are small or in unimportant places that they don't seem to have much of an effect on the final PDF. See the images below for some of my comparisons.

<img width="1849" alt="Screenshot 2021-10-12 at 14 58 24" src="https://user-images.githubusercontent.com/55980573/136984541-710cb51c-c0dc-4cf1-8d5e-7ca05329f64d.png">

Above: The self scattering correction workspaces (rebinning gave the vertical lines!) from the CloneWorkspace command, focused in TOF (main) focused in Q (this PR branch) and on the left their difference. The big features seem to be where the old and new ways give different end values for each spectrum.
Below are zoomed in plots to display the extent of the differences
<img width="1838" alt="Screenshot 2021-10-12 at 15 00 09" src="https://user-images.githubusercontent.com/55980573/136984555-525ec13e-f7f7-4d93-b38f-aaae14bf8682.png">
Below show the differences for the focused_Q and PDF_R workspaces which are output from the create_pdf call in the script at the top of these instructions (again with zoomed in versions).
<img width="1219" alt="Screenshot 2021-10-12 at 14 49 39" src="https://user-images.githubusercontent.com/55980573/136984605-d789c36d-c809-4859-84d1-fba4a24c50a4.png">

Fixes #32446 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
