### PR TITLE
Rework CONDA_BUILD CMake build variable and add some more CMake docs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,11 +71,22 @@ endif()
 
 set(CPACK_INSTALL_CMAKE_PROJECTS "${CMAKE_BINARY_DIR}" "Mantid" "ALL" "/")
 
-# Conda build variable
+# Conda build variables
+set(CONDA_ENV
+    FALSE
+    CACHE BOOL "If True then we are building in a conda environment.
+          This predominately changes the operation of some the finders FindXXX.cmake
+          On windows it also prevents the use of the 3rdparty dependency directory"
+)
 set(CONDA_BUILD
     FALSE
-    CACHE BOOL
-          "If True, proceed with a Conda build. This setting adds some conda specific configuration to the mantid build"
+    CACHE
+      BOOL
+      "If True then we are using conda-build to build and package mantid.
+          This stops a few things from occuring:
+          - A bundle is no longer generated on OSX
+          - Linux custom handling on the install is ommitted
+          - Prevents site-package manipulation by the installer"
 )
 
 # Ensure that if we are running any sanitizers the compiler options are known in sub targets

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -19,7 +19,7 @@
                 "Qt5_DIR": "$env{CONDA_PREFIX}/lib/cmake/qt5",
                 "HDF5_ROOT": "$env{CONDA_PREFIX}",
                 "OpenSSL_ROOT": "$env{CONDA_PREFIX}",
-                "CONDA_BUILD": true,
+                "CONDA_ENV": true,
                 "CMAKE_BUILD_TYPE": "Debug"
             }
         },
@@ -31,7 +31,7 @@
             "generator": "Visual Studio 16 2019",
             "cacheVariables": {
                 "CMAKE_PREFIX_PATH": "$env{CONDA_PREFIX}",
-                "CONDA_BUILD": true
+                "CONDA_ENV": true
             }
         },
         {
@@ -42,7 +42,7 @@
             "generator": "Ninja",
             "cacheVariables": {
                 "CMAKE_PREFIX_PATH": "$env{CONDA_PREFIX}",
-                "CONDA_BUILD": true,
+                "CONDA_ENV": true,
                 "CMAKE_FIND_USE_SYSTEM_ENVIRONMENT_PATH": "FALSE",
                 "CMAKE_FIND_USE_CMAKE_ENVIRONMENT_PATH": "FALSE",
                 "CMAKE_BUILD_TYPE": "Debug"
@@ -56,7 +56,7 @@
             "generator": "Ninja",
             "cacheVariables": {
                 "CMAKE_PREFIX_PATH": "$env{CONDA_PREFIX}",
-                "CONDA_BUILD": true,
+                "CONDA_ENV": true,
                 "CMAKE_FIND_USE_SYSTEM_ENVIRONMENT_PATH": "FALSE",
                 "CMAKE_FIND_USE_CMAKE_ENVIRONMENT_PATH": "FALSE",
                 "CMAKE_BUILD_TYPE": "Release",
@@ -75,7 +75,7 @@
             "generator": "Ninja",
             "cacheVariables": {
                 "CMAKE_PREFIX_PATH": "$env{CONDA_PREFIX}",
-                "CONDA_BUILD": true,
+                "CONDA_ENV": true,
                 "CMAKE_FIND_USE_SYSTEM_ENVIRONMENT_PATH": "FALSE",
                 "CMAKE_FIND_USE_CMAKE_ENVIRONMENT_PATH": "FALSE",
                 "CMAKE_BUILD_TYPE": "RelWithDebInfo",
@@ -95,7 +95,7 @@
             "generator": "Ninja",
             "cacheVariables": {
                 "CMAKE_PREFIX_PATH": "$env{CONDA_PREFIX}",
-                "CONDA_BUILD": true,
+                "CONDA_ENV": true,
                 "CMAKE_FIND_USE_SYSTEM_ENVIRONMENT_PATH": "FALSE",
                 "CMAKE_FIND_USE_CMAKE_ENVIRONMENT_PATH": "FALSE",
                 "CMAKE_BUILD_TYPE": "RelWithDebInfo",
@@ -115,7 +115,7 @@
             "generator": "Ninja",
             "cacheVariables": {
                 "CMAKE_PREFIX_PATH": "$env{CONDA_PREFIX}",
-                "CONDA_BUILD": true,
+                "CONDA_ENV": true,
                 "CMAKE_FIND_USE_SYSTEM_ENVIRONMENT_PATH": "FALSE",
                 "CMAKE_FIND_USE_CMAKE_ENVIRONMENT_PATH": "FALSE",
                 "CMAKE_BUILD_TYPE": "RelWithDebInfo",
@@ -135,7 +135,7 @@
             "generator": "Ninja",
             "cacheVariables": {
                 "CMAKE_PREFIX_PATH": "$env{CONDA_PREFIX}",
-                "CONDA_BUILD": true,
+                "CONDA_ENV": true,
                 "CMAKE_FIND_USE_SYSTEM_ENVIRONMENT_PATH": "FALSE",
                 "CMAKE_FIND_USE_CMAKE_ENVIRONMENT_PATH": "FALSE",
                 "CMAKE_BUILD_TYPE": "Debug",

--- a/Framework/Catalog/CMakeLists.txt
+++ b/Framework/Catalog/CMakeLists.txt
@@ -52,7 +52,7 @@ target_include_directories(
 generate_mantid_export_header(Catalog TRUE)
 
 # Installation settings
-if(CONDA_BUILD)
+if(CONDA_ENV)
   set(TARGET_EXPORT_NAME "MantidCatalogTargets")
   mtd_install_framework_lib(TARGETS Catalog INSTALL_EXPORT_FILE EXPORT_NAME ${TARGET_EXPORT_NAME})
 else()

--- a/Framework/Crystal/CMakeLists.txt
+++ b/Framework/Crystal/CMakeLists.txt
@@ -276,7 +276,7 @@ target_include_directories(
 generate_mantid_export_header(Crystal FALSE)
 
 # Installation settings
-if(CONDA_BUILD)
+if(CONDA_ENV)
   mtd_install_framework_lib(TARGETS Crystal PLUGIN_LIB)
 else()
   mtd_install_targets(TARGETS Crystal INSTALL_DIRS ${PLUGINS_DIR} ${WORKBENCH_PLUGINS_DIR})

--- a/Framework/CurveFitting/CMakeLists.txt
+++ b/Framework/CurveFitting/CMakeLists.txt
@@ -537,7 +537,7 @@ target_include_directories(
 generate_mantid_export_header(CurveFitting FALSE)
 
 # Installation settings
-if(CONDA_BUILD)
+if(CONDA_ENV)
   mtd_install_framework_lib(TARGETS CurveFitting PLUGIN_LIB)
 else()
   mtd_install_targets(TARGETS CurveFitting INSTALL_DIRS ${PLUGINS_DIR} ${WORKBENCH_PLUGINS_DIR})

--- a/Framework/DataHandling/CMakeLists.txt
+++ b/Framework/DataHandling/CMakeLists.txt
@@ -681,7 +681,7 @@ target_link_libraries(
 # Lib3mf is technically a public dependency as it is in our public headers. We are assuming here that it won't be used.
 if(ENABLE_LIB3MF)
   target_link_libraries(DataHandling PRIVATE ${LIB3MF_LIBRARIES})
-  if(CONDA_BUILD)
+  if(CONDA_ENV)
     target_include_directories(DataHandling PRIVATE ${LIB3MF_INCLUDE_DIR})
   else()
     target_include_directories(DataHandling PRIVATE ${LIB3MF_INCLUDE_DIR}/lib3mf)
@@ -692,7 +692,7 @@ endif()
 add_subdirectory(test)
 
 # Installation settings
-if(CONDA_BUILD)
+if(CONDA_ENV)
   mtd_install_framework_lib(TARGETS DataHandling PLUGIN_LIB)
 else()
   mtd_install_targets(TARGETS DataHandling INSTALL_DIRS ${PLUGINS_DIR} ${WORKBENCH_PLUGINS_DIR})

--- a/Framework/DataHandling/test/CMakeLists.txt
+++ b/Framework/DataHandling/test/CMakeLists.txt
@@ -35,7 +35,7 @@ if(CXXTEST_FOUND)
 
   if(ENABLE_LIB3MF)
     target_link_libraries(DataHandlingTest LINK_PRIVATE ${LIB3MF_LIBRARIES})
-    if(CONDA_BUILD)
+    if(CONDA_ENV)
       target_include_directories(DataHandlingTest PRIVATE ${LIB3MF_INCLUDE_DIR})
     else()
       target_include_directories(DataHandlingTest PRIVATE ${LIB3MF_INCLUDE_DIR}/lib3mf)

--- a/Framework/DataObjects/CMakeLists.txt
+++ b/Framework/DataObjects/CMakeLists.txt
@@ -252,7 +252,7 @@ target_link_libraries(
 add_subdirectory(test)
 
 # Installation settings
-if(CONDA_BUILD)
+if(CONDA_ENV)
   set(TARGET_EXPORT_NAME "MantidDataObjectsTargets")
   mtd_install_framework_lib(TARGETS DataObjects EXPORT_NAME ${TARGET_EXPORT_NAME})
 else()

--- a/Framework/Geometry/CMakeLists.txt
+++ b/Framework/Geometry/CMakeLists.txt
@@ -502,7 +502,7 @@ target_include_directories(
 )
 
 # Installation settings
-if(CONDA_BUILD)
+if(CONDA_ENV)
   set(TARGET_EXPORT_NAME "MantidGeometryTargets")
   mtd_install_framework_lib(TARGETS Geometry EXPORT_NAME ${TARGET_EXPORT_NAME})
 else()

--- a/Framework/HistogramData/CMakeLists.txt
+++ b/Framework/HistogramData/CMakeLists.txt
@@ -146,7 +146,7 @@ target_include_directories(
 generate_mantid_export_header(HistogramData FALSE)
 
 # Installation settings
-if(CONDA_BUILD)
+if(CONDA_ENV)
   set(TARGET_EXPORT_NAME "MantidHistogramDataTargets")
   mtd_install_framework_lib(TARGETS HistogramData INSTALL_EXPORT_FILE EXPORT_NAME ${TARGET_EXPORT_NAME})
 else()

--- a/Framework/ICat/CMakeLists.txt
+++ b/Framework/ICat/CMakeLists.txt
@@ -115,7 +115,7 @@ target_include_directories(
 generate_mantid_export_header(ICat True)
 
 # Installation settings
-if(CONDA_BUILD)
+if(CONDA_ENV)
   mtd_install_framework_lib(TARGETS ICat PLUGIN_LIB)
 else()
   mtd_install_targets(TARGETS ICat INSTALL_DIRS ${PLUGINS_DIR} ${WORKBENCH_PLUGINS_DIR})

--- a/Framework/Indexing/CMakeLists.txt
+++ b/Framework/Indexing/CMakeLists.txt
@@ -101,7 +101,7 @@ target_include_directories(
 generate_mantid_export_header(Indexing TRUE)
 
 # Installation settings
-if(CONDA_BUILD)
+if(CONDA_ENV)
   set(TARGET_EXPORT_NAME "MantidIndexingTargets")
   mtd_install_framework_lib(TARGETS Indexing INSTALL_EXPORT_FILE EXPORT_NAME ${TARGET_EXPORT_NAME})
 else()

--- a/Framework/Json/CMakeLists.txt
+++ b/Framework/Json/CMakeLists.txt
@@ -44,7 +44,7 @@ if(CXXTEST_FOUND)
 endif()
 
 # Installation settings
-if(CONDA_BUILD)
+if(CONDA_ENV)
   set(TARGET_EXPORT_NAME "MantidJsonTargets")
   mtd_install_framework_lib(TARGETS Json INSTALL_EXPORT_FILE EXPORT_NAME ${TARGET_EXPORT_NAME})
 else()

--- a/Framework/Kernel/CMakeLists.txt
+++ b/Framework/Kernel/CMakeLists.txt
@@ -498,9 +498,9 @@ endif()
 set_property(TARGET Kernel PROPERTY FOLDER "MantidFramework")
 target_compile_features(Kernel PUBLIC cxx_std_17)
 
-# if we are not on conda build ${HDF5_LIBRARIES} are full paths to the libs and not cmake targets, therefore we need to
+# if we are not in a conda env ${HDF5_LIBRARIES} are full paths to the libs and not cmake targets, therefore we need to
 # include the headers
-if(NOT CONDA_BUILD)
+if(NOT CONDA_ENV)
   target_include_directories(Kernel SYSTEM PUBLIC ${HDF5_INCLUDE_DIRS})
 endif()
 

--- a/Framework/LiveData/CMakeLists.txt
+++ b/Framework/LiveData/CMakeLists.txt
@@ -150,7 +150,7 @@ target_include_directories(
 generate_mantid_export_header(LiveData FALSE)
 
 # Installation settings
-if(CONDA_BUILD)
+if(CONDA_ENV)
   mtd_install_framework_lib(TARGETS LiveData PLUGIN_LIB)
 else()
   mtd_install_targets(TARGETS LiveData INSTALL_DIRS ${PLUGINS_DIR} ${WORKBENCH_PLUGINS_DIR})

--- a/Framework/MDAlgorithms/CMakeLists.txt
+++ b/Framework/MDAlgorithms/CMakeLists.txt
@@ -391,7 +391,7 @@ target_link_libraries(MDAlgorithms PUBLIC Mantid::API Mantid::DataObjects Mantid
 add_subdirectory(test)
 
 # Installation settings
-if(CONDA_BUILD)
+if(CONDA_ENV)
   mtd_install_framework_lib(TARGETS MDAlgorithms PLUGIN_LIB)
 else()
   mtd_install_targets(TARGETS MDAlgorithms INSTALL_DIRS ${PLUGINS_DIR} ${WORKBENCH_PLUGINS_DIR})

--- a/Framework/Muon/CMakeLists.txt
+++ b/Framework/Muon/CMakeLists.txt
@@ -116,7 +116,7 @@ target_include_directories(
 generate_mantid_export_header(Muon FALSE)
 
 # Installation settings
-if(CONDA_BUILD)
+if(CONDA_ENV)
   set(TARGET_EXPORT_NAME "MantidMuonTargets")
   mtd_install_framework_lib(TARGETS Muon PLUGIN_LIB)
 else()

--- a/Framework/Nexus/CMakeLists.txt
+++ b/Framework/Nexus/CMakeLists.txt
@@ -39,7 +39,7 @@ target_link_libraries(Nexus PUBLIC Mantid::API Mantid::DataObjects Mantid::Kerne
 add_subdirectory(test)
 
 # Installation settings
-if(CONDA_BUILD)
+if(CONDA_ENV)
   set(TARGET_EXPORT_NAME "MantidNexusTargets")
   mtd_install_framework_lib(TARGETS Nexus EXPORT_NAME ${TARGET_EXPORT_NAME})
 else()

--- a/Framework/NexusGeometry/CMakeLists.txt
+++ b/Framework/NexusGeometry/CMakeLists.txt
@@ -81,7 +81,7 @@ target_include_directories(
 generate_mantid_export_header(NexusGeometry TRUE)
 
 # Installation settings
-if(CONDA_BUILD)
+if(CONDA_ENV)
   set(TARGET_EXPORT_NAME "MantidNexusGeometryTargets")
   mtd_install_framework_lib(TARGETS NexusGeometry INSTALL_EXPORT_FILE EXPORT_NAME ${TARGET_EXPORT_NAME})
 else()

--- a/Framework/Parallel/CMakeLists.txt
+++ b/Framework/Parallel/CMakeLists.txt
@@ -121,7 +121,7 @@ endif()
 add_subdirectory(test)
 
 # Installation settings
-if(CONDA_BUILD)
+if(CONDA_ENV)
   set(TARGET_EXPORT_NAME "MantidParallelTargets")
   mtd_install_framework_lib(TARGETS Parallel EXPORT_NAME ${TARGET_EXPORT_NAME})
 else()

--- a/Framework/Reflectometry/CMakeLists.txt
+++ b/Framework/Reflectometry/CMakeLists.txt
@@ -123,7 +123,7 @@ target_include_directories(
 generate_mantid_export_header(Reflectometry FALSE)
 
 # Installation settings
-if(CONDA_BUILD)
+if(CONDA_ENV)
   mtd_install_framework_lib(TARGETS Reflectometry PLUGIN_LIB)
 else()
   mtd_install_targets(TARGETS Reflectometry INSTALL_DIRS ${PLUGINS_DIR} ${WORKBENCH_PLUGINS_DIR})

--- a/Framework/RemoteAlgorithms/CMakeLists.txt
+++ b/Framework/RemoteAlgorithms/CMakeLists.txt
@@ -79,7 +79,7 @@ target_link_libraries(
 add_subdirectory(test) # Note: No tests yet for many remote algorithms...
 
 # Installation settings
-if(CONDA_BUILD)
+if(CONDA_ENV)
   mtd_install_framework_lib(TARGETS RemoteAlgorithms PLUGIN_LIB)
 else()
   mtd_install_targets(TARGETS RemoteAlgorithms INSTALL_DIRS ${PLUGINS_DIR} ${WORKBENCH_PLUGINS_DIR})

--- a/Framework/RemoteJobManagers/CMakeLists.txt
+++ b/Framework/RemoteJobManagers/CMakeLists.txt
@@ -45,7 +45,7 @@ target_link_libraries(RemoteJobManagers PUBLIC Mantid::Kernel Mantid::API)
 add_subdirectory(test)
 
 # Installation settings
-if(CONDA_BUILD)
+if(CONDA_ENV)
   mtd_install_framework_lib(TARGETS RemoteJobManagers PLUGIN_LIB)
 else()
   mtd_install_targets(TARGETS RemoteJobManagers INSTALL_DIRS ${PLUGINS_DIR} ${WORKBENCH_PLUGINS_DIR})

--- a/Framework/SINQ/CMakeLists.txt
+++ b/Framework/SINQ/CMakeLists.txt
@@ -170,7 +170,7 @@ target_link_libraries(SINQ PUBLIC Mantid::Kernel Mantid::Geometry Mantid::API Ma
 add_subdirectory(test)
 
 # Installation settings
-if(CONDA_BUILD)
+if(CONDA_ENV)
   mtd_install_framework_lib(TARGETS SINQ PLUGIN_LIB)
 else()
   mtd_install_targets(TARGETS SINQ INSTALL_DIRS ${PLUGINS_DIR} ${WORKBENCH_PLUGINS_DIR})

--- a/Framework/ScriptRepository/CMakeLists.txt
+++ b/Framework/ScriptRepository/CMakeLists.txt
@@ -38,7 +38,7 @@ target_link_libraries(
   PRIVATE Mantid::Json
 )
 
-if(CONDA_BUILD)
+if(CONDA_ENV)
   mtd_install_framework_lib(TARGETS ScriptRepository PLUGIN_LIB)
 else()
   mtd_install_targets(TARGETS ScriptRepository INSTALL_DIRS ${PLUGINS_DIR} ${WORKBENCH_PLUGINS_DIR})

--- a/Framework/Types/CMakeLists.txt
+++ b/Framework/Types/CMakeLists.txt
@@ -31,7 +31,7 @@ target_link_libraries(Types PUBLIC Boost::date_time Boost::regex)
 generate_mantid_export_header(Types FALSE)
 
 # Installation settings
-if(CONDA_BUILD)
+if(CONDA_ENV)
   set(TARGET_EXPORT_NAME "MantidTypesTargets")
   mtd_install_framework_lib(TARGETS Types INSTALL_EXPORT_FILE EXPORT_NAME ${TARGET_EXPORT_NAME})
 else()

--- a/Framework/WorkflowAlgorithms/CMakeLists.txt
+++ b/Framework/WorkflowAlgorithms/CMakeLists.txt
@@ -139,7 +139,7 @@ target_link_libraries(
 add_subdirectory(test)
 
 # Installation settings
-if(CONDA_BUILD)
+if(CONDA_ENV)
   mtd_install_framework_lib(TARGETS WorkflowAlgorithms PLUGIN_LIB)
 else()
   mtd_install_targets(TARGETS WorkflowAlgorithms INSTALL_DIRS ${PLUGINS_DIR} ${WORKBENCH_PLUGINS_DIR})

--- a/buildconfig/CMake/MSVCSetup.cmake
+++ b/buildconfig/CMake/MSVCSetup.cmake
@@ -25,7 +25,7 @@ add_definitions(-D_SILENCE_CXX17_SHARED_PTR_UNIQUE_DEPRECATION_WARNING)
 # Additional compiler flags
 # ######################################################################################################################
 # Replace "/" with "\" for use in command prompt
-if(NOT CONDA_BUILD)
+if(NOT CONDA_ENV)
   string(REGEX REPLACE "/" "\\\\" THIRD_PARTY_INCLUDE_DIR "${THIRD_PARTY_DIR}/include/")
   string(REGEX REPLACE "/" "\\\\" THIRD_PARTY_LIB_DIR "${THIRD_PARTY_DIR}/lib/")
   # /MP            - Compile .cpp files in parallel /W3            - Warning Level 3 (This is also the default)
@@ -59,7 +59,7 @@ find_package(Threads)
 # ######################################################################################################################
 # Qt5 is always in the same place
 # ######################################################################################################################
-if(NOT CONDA_BUILD)
+if(NOT CONDA_ENV)
   set(Qt5_DIR ${THIRD_PARTY_DIR}/lib/qt5/lib/cmake/Qt5)
 endif()
 
@@ -74,7 +74,7 @@ set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/bin)
 # Configure IDE/commandline startup scripts
 # ######################################################################################################################
 set(WINDOWS_BUILDCONFIG ${PROJECT_SOURCE_DIR}/buildconfig/windows)
-if(NOT CONDA_BUILD)
+if(NOT CONDA_ENV)
   configure_file(${WINDOWS_BUILDCONFIG}/thirdpartypaths.bat.in ${PROJECT_BINARY_DIR}/thirdpartypaths.bat @ONLY)
 else()
   set(CONDA_BASE_DIR $ENV{CONDA_PREFIX})
@@ -92,7 +92,7 @@ else()
 endif()
 
 # Setup debugger environment to launch in VS without setting paths
-if(NOT CONDA_BUILD)
+if(NOT CONDA_ENV)
   set(MSVC_PATHS "${THIRD_PARTY_DIR}/bin$<SEMICOLON>${THIRD_PARTY_DIR}/lib/qt5/bin$<SEMICOLON>%PATH%")
 else()
   set(MSVC_PATHS "$ENV{CONDA_PREFIX}/Library/bin$<SEMICOLON>$ENV{CONDA_PREFIX}/Library/lib$<SEMICOLON>%PATH%")
@@ -113,13 +113,13 @@ configure_file(${WINDOWS_BUILDCONFIG}/pycharm.env.in ${PROJECT_BINARY_DIR}/pycha
 
 # The IDE may not be installed as we could be just using the build tools
 if(EXISTS ${MSVC_IDE_LOCATION}/devenv.exe)
-  if(CONDA_BUILD)
+  if(CONDA_ENV)
     configure_file(${WINDOWS_BUILDCONFIG}/visual-studio_conda.bat.in ${PROJECT_BINARY_DIR}/visual-studio.bat @ONLY)
   else()
     configure_file(${WINDOWS_BUILDCONFIG}/visual-studio.bat.in ${PROJECT_BINARY_DIR}/visual-studio.bat @ONLY)
   endif()
 endif()
-if(CONDA_BUILD)
+if(CONDA_ENV)
   configure_file(${WINDOWS_BUILDCONFIG}/pycharm_conda.bat.in ${PROJECT_BINARY_DIR}/pycharm.bat @ONLY)
 else()
   configure_file(${WINDOWS_BUILDCONFIG}/pycharm.bat.in ${PROJECT_BINARY_DIR}/pycharm.bat @ONLY)

--- a/dev-docs/source/BuildingWithCMake.rst
+++ b/dev-docs/source/BuildingWithCMake.rst
@@ -142,3 +142,38 @@ Tips
 
 * Running unit test executables directly with the CMake-generated ``Mantid.properties`` file will lead to a bunch of logging output to the console. You are encouraged to use CTest instead, which suppresses this output automatically. Otherwise, adding the line ``logging.channels.consoleChannel.class = NullChannel`` to your Mantid.user.properties file will turn if off.
 * If you have more than one gcc and want to build with a version other than the default (e.g. on RedHat), setting CC & CXX environment variables is one way to make it so.
+
+Build system customisation using CMake variables
+###########################################################
+
+The Mantid CMake build can be configured using several ENABLE_XXX variables, for instance ENABLE_DOCS, ENABLE_WORKBENCH and ENABLE_OPENGL
+A full list of these variables, with a description, can be viewed in the CMake GUI after the project has been configured.
+
+Along side these general build options, there are the conda specific options `CONDA_ENV` and `CONDA_BUILD`. The former should be used whenever you are building within a conda env, as it ensures our finders (e.g FindNexus.cmake) look in the correct locations for libraries.
+The CONDA_BUILD parameter is used to customise our installation, which is required when we are using the conda-build tool to build and package Mantid.
+
+Component builds of mantid can be performed using the `MANTID_FRAMEWORK_LIB`, `MANTID_QT_LIB` and `ENABLE_WORKBENCH` cmake variables.
+For instance, we can build just the framework element using,
+
+.. code-block:: sh
+
+  cmake \
+  -DMANTID_FRAMEWORK_LIB=BUILD \
+  -DMANTID_QT_LIB=OFF \
+  -DENABLE_WORKBENCH=OFF \
+  -GNinja \
+  ../
+
+and likewise a mantidqt only build with,
+
+.. code-block:: sh
+
+  cmake \
+  -DMANTID_FRAMEWORK_LIB=SYSTEM \
+  -DMANTID_QT_LIB=BUILD \
+  -DENABLE_WORKBENCH=OFF \
+  -GNinja \
+  ../
+
+Specifying `MANTID_FRAMEWORK_LIB=SYSTEM` requires that we have installed the Framework and its cmake config files somewhere on the CMAKE_PREFIX_PATH.
+This will enable the framework to be found using `find_package(MantidFramework)`.

--- a/dev-docs/source/BuildingWithCMake.rst
+++ b/dev-docs/source/BuildingWithCMake.rst
@@ -149,9 +149,6 @@ Build system customisation using CMake variables
 The Mantid CMake build can be configured using several ENABLE_XXX variables, for instance ENABLE_DOCS, ENABLE_WORKBENCH and ENABLE_OPENGL
 A full list of these variables, with a description, can be viewed in the CMake GUI after the project has been configured.
 
-Along side these general build options, there are the conda specific options `CONDA_ENV` and `CONDA_BUILD`. The former should be used whenever you are building within a conda env, as it ensures our finders (e.g FindNexus.cmake) look in the correct locations for libraries.
-The CONDA_BUILD parameter is used to customise our installation, which is required when we are using the conda-build tool to build and package Mantid.
-
 Component builds of mantid can be performed using the `MANTID_FRAMEWORK_LIB`, `MANTID_QT_LIB` and `ENABLE_WORKBENCH` cmake variables.
 For instance, we can build just the framework element using,
 

--- a/dev-docs/source/GettingStarted/GettingStartedCondaLinux.rst
+++ b/dev-docs/source/GettingStarted/GettingStartedCondaLinux.rst
@@ -61,3 +61,8 @@ It is also useful to have your terminals in CLion also run with this environment
 * Start CLion using the above steps
 * Navigate to ``File > Settings > Tools > Terminal``.
 * To the end of the ``Shell path`` option, add: ``--rcfile ~/.clionrc``.
+
+CMake conda variables
+-----------------------
+There are two conda specific CMake options `CONDA_ENV` and `CONDA_BUILD`. The former should be used whenever you are building within a conda env, as it ensures our finders (e.g FindNexus.cmake) look in the correct locations for libraries.
+The CONDA_BUILD parameter is used to customise our installation, which is required when we are using the conda-build tool to build and package Mantid.

--- a/dev-docs/source/GettingStarted/GettingStartedCondaLinux.rst
+++ b/dev-docs/source/GettingStarted/GettingStartedCondaLinux.rst
@@ -62,7 +62,7 @@ It is also useful to have your terminals in CLion also run with this environment
 * Navigate to ``File > Settings > Tools > Terminal``.
 * To the end of the ``Shell path`` option, add: ``--rcfile ~/.clionrc``.
 
-CMake conda variables
+CMake Conda variables
 -----------------------
-There are two conda specific CMake options `CONDA_ENV` and `CONDA_BUILD`. The former should be used whenever you are building within a conda env, as it ensures our finders (e.g FindNexus.cmake) look in the correct locations for libraries.
-The CONDA_BUILD parameter is used to customise our installation, which is required when we are using the conda-build tool to build and package Mantid.
+There are two Conda specific CMake options `CONDA_ENV` and `CONDA_BUILD`. The former should be used whenever you are building within a Conda environment, as it ensures our finders (e.g FindNexus.cmake) look in the correct locations for libraries.
+The CONDA_BUILD parameter is used to customise our installation, which is required when we are using the conda-build tool to build and package Mantid. These options can be passed to CMake on the command line using -DCONDA_ENV=True for example.

--- a/dev-docs/source/GettingStarted/GettingStartedCondaOSX.rst
+++ b/dev-docs/source/GettingStarted/GettingStartedCondaOSX.rst
@@ -40,3 +40,8 @@ How to build
 * Navigate to the build directory.
 * To build Mantid Workbench use: ``ninja``
 * To build Unit Tests use: ``ninja AllTests``
+
+CMake conda variables
+-----------------------
+There are two conda specific CMake options `CONDA_ENV` and `CONDA_BUILD`. The former should be used whenever you are building within a conda env, as it ensures our finders (e.g FindNexus.cmake) look in the correct locations for libraries.
+The CONDA_BUILD parameter is used to customise our installation, which is required when we are using the conda-build tool to build and package Mantid.

--- a/dev-docs/source/GettingStarted/GettingStartedCondaOSX.rst
+++ b/dev-docs/source/GettingStarted/GettingStartedCondaOSX.rst
@@ -41,7 +41,7 @@ How to build
 * To build Mantid Workbench use: ``ninja``
 * To build Unit Tests use: ``ninja AllTests``
 
-CMake conda variables
+CMake Conda variables
 -----------------------
-There are two conda specific CMake options `CONDA_ENV` and `CONDA_BUILD`. The former should be used whenever you are building within a conda env, as it ensures our finders (e.g FindNexus.cmake) look in the correct locations for libraries.
-The CONDA_BUILD parameter is used to customise our installation, which is required when we are using the conda-build tool to build and package Mantid.
+There are two Conda specific CMake options `CONDA_ENV` and `CONDA_BUILD`. The former should be used whenever you are building within a Conda environment, as it ensures our finders (e.g FindNexus.cmake) look in the correct locations for libraries.
+The CONDA_BUILD parameter is used to customise our installation, which is required when we are using the conda-build tool to build and package Mantid. These options can be passed to CMake on the command line using -DCONDA_ENV=True for example.

--- a/dev-docs/source/GettingStarted/GettingStartedCondaWindows.rst
+++ b/dev-docs/source/GettingStarted/GettingStartedCondaWindows.rst
@@ -62,7 +62,7 @@ Compile and Build using Visual Studio
 * It's not possible to compile in Debug on Windows with conda libraries, however Release, and RelWithDebInfo for Debugging will compile fine.
 * Once in visual studio, the correct target to use as a startup project in visual studio is ``workbench``, not ``MantidWorkbench``. You can then press F5 to start workbench.
 
-CMake conda variables
+CMake Conda variables
 -----------------------
-There are two conda specific CMake options `CONDA_ENV` and `CONDA_BUILD`. The former should be used whenever you are building within a conda env, as it ensures our finders (e.g FindNexus.cmake) look in the correct locations for libraries.
-The CONDA_BUILD parameter is used to customise our installation, which is required when we are using the conda-build tool to build and package Mantid.
+There are two Conda specific CMake options `CONDA_ENV` and `CONDA_BUILD`. The former should be used whenever you are building within a Conda environment, as it ensures our finders (e.g FindNexus.cmake) look in the correct locations for libraries.
+The CONDA_BUILD parameter is used to customise our installation, which is required when we are using the conda-build tool to build and package Mantid. These options can be passed to CMake on the command line using -DCONDA_ENV=True for example.

--- a/dev-docs/source/GettingStarted/GettingStartedCondaWindows.rst
+++ b/dev-docs/source/GettingStarted/GettingStartedCondaWindows.rst
@@ -61,3 +61,8 @@ Compile and Build using Visual Studio
 * Open visual studio with ``visualstudio.bat`` then click build.
 * It's not possible to compile in Debug on Windows with conda libraries, however Release, and RelWithDebInfo for Debugging will compile fine.
 * Once in visual studio, the correct target to use as a startup project in visual studio is ``workbench``, not ``MantidWorkbench``. You can then press F5 to start workbench.
+
+CMake conda variables
+-----------------------
+There are two conda specific CMake options `CONDA_ENV` and `CONDA_BUILD`. The former should be used whenever you are building within a conda env, as it ensures our finders (e.g FindNexus.cmake) look in the correct locations for libraries.
+The CONDA_BUILD parameter is used to customise our installation, which is required when we are using the conda-build tool to build and package Mantid.


### PR DESCRIPTION
**Description of work.**
The use of the CONDA_BUILD cmake variable has become a little jumbled. In one case its invoked as we are building in a conda environment, in the other case because we are using conda build to create a mantid package. Two situations which can suitably be described by a CONDA_BUILD variable, but are in fact two DISTINCT use cases..

This PR clarifies their use cases.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**
The builds and tests should pass. 
The docs should make sense

<!-- Instructions for testing. -->

Fixes #32761 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
