### PR TITLE
Stop duplicate workspace created in EnggEstimateFocusedBackground

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/EnggEstimateFocussedBackground.py
+++ b/Framework/PythonInterface/plugins/algorithms/EnggEstimateFocussedBackground.py
@@ -5,7 +5,6 @@
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
 from mantid.api import AlgorithmFactory, MatrixWorkspaceProperty, PythonAlgorithm, Progress
-from mantid.simpleapi import CloneWorkspace
 from mantid.kernel import Direction, IntBoundedValidator, FloatBoundedValidator
 import numpy as np
 from scipy.signal import savgol_filter
@@ -73,7 +72,11 @@ class EnggEstimateFocussedBackground(PythonAlgorithm):
         doSGfilter = self.getProperty('ApplyFilterSG').value
 
         # make output workspace
-        outws = CloneWorkspace(inws, OutputWorkspace=self.getProperty("OutputWorkspace").value)
+        clone_alg = self.createChildAlgorithm("CloneWorkspace", enableLogging=False)
+        clone_alg.setProperty("InputWorkspace", inws)
+        clone_alg.setProperty("OutputWorkspace", self.getProperty("OutputWorkspace").valueAsStr)
+        clone_alg.execute()
+        outws = clone_alg.getProperty("OutputWorkspace").value
 
         # loop over all spectra
         nbins = inws.blocksize()


### PR DESCRIPTION
**Description of work.**
Run clone ws as child algorithm using valueAsStr to get output workspace name - this seems to fix the issue.

**To test:**
Follow instructions in the original issue #32765 - there should be no `__TMP` workspace created. 

Fixes #32765 

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
