### PR TITLE
Use global plot options in superplot

### DIFF
--- a/qt/python/mantidqt/mantidqt/widgets/superplot/presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/superplot/presenter.py
@@ -8,8 +8,10 @@
 from .view import SuperplotView
 from .model import SuperplotModel
 
+from mantid.kernel import ConfigService
 from mantid.api import mtd
 from mantid.plots.utility import MantidAxType, legend_set_draggable
+from mantid.plots.plotfunctions import MARKER_MAP
 from mantid.plots import MantidAxes
 
 
@@ -148,6 +150,7 @@ class SuperplotPresenter:
         first checks that the plotted data are consistent (i.e. only bins, only
         spectra), if not, it returns without updating the model.
         """
+
         figure = self._canvas.figure
         axes = figure.gca()
         artists = axes.get_tracked_artists()
@@ -198,6 +201,20 @@ class SuperplotPresenter:
             ws_name = ws.name()
             self._model.add_workspace(ws_name)
             self._model.add_data(ws_name, spec_index)
+
+    def get_kwargs_from_settings(self):
+        """
+        Get the useful plot keywork arguments from the global settings.
+
+        Returns:
+            dict(str: str): plot keywork arguments
+        """
+        kwargs = dict()
+        kwargs['linestyle'] = ConfigService.getString("plots.line.Style")
+        kwargs['drawstyle'] = ConfigService.getString("plots.line.DrawStyle")
+        kwargs['linewidth'] = ConfigService.getString("plots.line.Width")
+        kwargs['marker'] = MARKER_MAP[ConfigService.getString("plots.marker.Style")]
+        return kwargs
 
     def on_visibility_changed(self, visible):
         """
@@ -379,7 +396,7 @@ class SuperplotPresenter:
                     continue
                 if (ws_name, sp) not in plotted_data:
                     ws = mtd[ws_name]
-                    kwargs = {}
+                    kwargs = self.get_kwargs_from_settings()
                     if mode == self.SPECTRUM_MODE_TEXT:
                         kwargs["axis"] = MantidAxType.SPECTRUM
                         kwargs["specNum"] = ws.getSpectrumNumbers()[sp]

--- a/qt/python/mantidqt/mantidqt/widgets/superplot/presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/superplot/presenter.py
@@ -204,10 +204,10 @@ class SuperplotPresenter:
 
     def get_kwargs_from_settings(self):
         """
-        Get the useful plot keywork arguments from the global settings.
+        Get the useful plot keyword arguments from the global settings.
 
         Returns:
-            dict(str: str): plot keywork arguments
+            dict(str: str): plot keyword arguments
         """
         kwargs = dict()
         kwargs['linestyle'] = ConfigService.getString("plots.line.Style")

--- a/qt/python/mantidqt/mantidqt/widgets/superplot/presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/superplot/presenter.py
@@ -212,8 +212,13 @@ class SuperplotPresenter:
         kwargs = dict()
         kwargs['linestyle'] = ConfigService.getString("plots.line.Style")
         kwargs['drawstyle'] = ConfigService.getString("plots.line.DrawStyle")
-        kwargs['linewidth'] = ConfigService.getString("plots.line.Width")
+        kwargs['linewidth'] = float(ConfigService.getString("plots.line.Width"))
         kwargs['marker'] = MARKER_MAP[ConfigService.getString("plots.marker.Style")]
+        if self._error_bars:
+            kwargs['capsize'] = float(ConfigService.getString("plots.errorbar.Capsize"))
+            kwargs['capthick'] = float(ConfigService.getString("plots.errorbar.CapThickness"))
+            kwargs['errorevery'] = int(ConfigService.getString("plots.errorbar.errorEvery"))
+            kwargs['elinewidth'] = float(ConfigService.getString("plots.errorbar.Width"))
         return kwargs
 
     def on_visibility_changed(self, visible):

--- a/qt/python/mantidqt/mantidqt/widgets/superplot/test/test_superplot_presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/superplot/test/test_superplot_presenter.py
@@ -114,12 +114,30 @@ class SuperplotPresenterTest(unittest.TestCase):
     @mock.patch("mantidqt.widgets.superplot.presenter.MARKER_MAP")
     def test_get_kwargs_from_settings(self, m_marker_map, m_config_service):
         m_marker_map.__getitem__.return_value = "test"
-        m_config_service.getString.return_value = "test"
+        setting_values = {"plots.line.Style": "test",
+                          "plots.line.DrawStyle": "test",
+                          "plots.line.Width": 10.0,
+                          "plots.marker.Style": "test",
+                          "plots.errorbar.Capsize": 10.0,
+                          "plots.errorbar.CapThickness": 10.0,
+                          "plots.errorbar.errorEvery": 10.0,
+                          "plots.errorbar.Width": 10.0}
+        m_config_service.getString = setting_values.__getitem__
         kwargs = self.presenter.get_kwargs_from_settings()
         self.assertDictEqual(kwargs, {"linestyle": "test",
-                                        "drawstyle": "test",
-                                        "linewidth": "test",
-                                        "marker": "test"})
+                                      "drawstyle": "test",
+                                      "linewidth": 10.0,
+                                      "marker": "test"})
+        self.presenter._error_bars = True
+        kwargs = self.presenter.get_kwargs_from_settings()
+        self.assertDictEqual(kwargs, {"linestyle": "test",
+                                      "drawstyle": "test",
+                                      "linewidth": 10.0,
+                                      "marker": "test",
+                                      "capsize": 10.0,
+                                      "capthick": 10.0,
+                                      "errorevery": 10.0,
+                                      "elinewidth": 10.0})
 
     def test_on_visibility_changed(self):
         self.m_canvas.reset_mock()

--- a/qt/python/mantidqt/mantidqt/widgets/superplot/test/test_superplot_presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/superplot/test/test_superplot_presenter.py
@@ -110,6 +110,17 @@ class SuperplotPresenterTest(unittest.TestCase):
         self.presenter.close()
         self.m_view.close.assert_called_once()
 
+    @mock.patch("mantidqt.widgets.superplot.presenter.ConfigService")
+    @mock.patch("mantidqt.widgets.superplot.presenter.MARKER_MAP")
+    def test_get_kwargs_from_settings(self, m_marker_map, m_config_service):
+        m_marker_map.__getitem__.return_value = "test"
+        m_config_service.getString.return_value = "test"
+        kwargs = self.presenter.get_kwargs_from_settings()
+        self.assertDictEqual(kwargs, {"linestyle": "test",
+                                        "drawstyle": "test",
+                                        "linewidth": "test",
+                                        "marker": "test"})
+
     def test_on_visibility_changed(self):
         self.m_canvas.reset_mock()
         self.m_figure.resetMock()


### PR DESCRIPTION
**Description of work.**

With this PR, the plot options of the global settings are taken into account in the superplot.

**To test:**

Modify the plot settings (File -> Settings -> Plots) and open the superplot on some workspace. The displayed plot should follow the settings.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
