### PR TITLE
View updated with parameters from formula in UserFunction

### DIFF
--- a/docs/source/release/v6.3.0/framework.rst
+++ b/docs/source/release/v6.3.0/framework.rst
@@ -34,6 +34,13 @@ Bugfixes
 
 - Fix bug in :ref:`Integration <algm-Integration>` when using UsePartialBinsOption with integration limits that are either equal or close together
 
+
+Fit Functions
+-------------
+New Features
+############
+- Fixed a bug in :ref:`UserFunction<func-UserFunction>` where the view would not be updated with the parameters in the formula entered.
+
 Data Objects
 ------------
 

--- a/qt/widgets/common/src/FunctionTreeView.cpp
+++ b/qt/widgets/common/src/FunctionTreeView.cpp
@@ -89,7 +89,7 @@ bool containsOneOf(std::string const &str, std::string const &delimiters) {
 
 // These attributes require the function to be fully reconstructed, as a
 // different number of properties will be required
-const std::vector<QString> REQUIRESRECONSTRUCTIONATTRIBUTES = {QString("n")};
+const std::vector<QString> REQUIRESRECONSTRUCTIONATTRIBUTES = {QString("n"), QString("Formula")};
 } // namespace
 
 namespace MantidQt::MantidWidgets {


### PR DESCRIPTION
**Description of work.**

The FunctionTreeView has been updated so that when a user adds a formula as part of UserFunction the view is updated with the parameters to allow the user to input specific parameter values.

Report to James.

**To test:**
1. Open the Muon Analysis GUI
2. Load a run (e.g. MUSR 15189)
3. Click on the Fitting Tab
4. Add ```UserFunction```
5.  Enter a user function (e.g. a*x+b)
6. The specific parameters (e.g. a and b) are added to the function and can be changed by you
7. Click Fit
8. There should be no crash or error message.

Fixes #32783


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
