### PR TITLE
Two new analysis modes for VesuvioAnalysis

### DIFF
--- a/docs/source/release/v6.3.0/indirect_geometry.rst
+++ b/docs/source/release/v6.3.0/indirect_geometry.rst
@@ -25,5 +25,8 @@ Improvements
   currently included in the Mantid release, an installer is provided
   in the Script Repository.
 - In indirect Data analysis the Elwin Tab has had its UI updated to be more user friendly.
+- Based on existing options for AnalysisMode in the VesuvioAnalysis algorithm two new
+  options were introduced to allow reduction and analysis of spectra in the TOF domain
+  without automatically carrying out a Y space analysis afterwards.
 
 :ref:`Release 6.3.0 <v6.3.0>`


### PR DESCRIPTION
**Description of work.**

Initially VesuvioAnalysis allowed to use three different analysis modes which influenced which parts of the script were run. The two new analysis modes are subsets of existing modes as opposed to new functionality.

The documentation for VesuvioAnalysis has also been updated to reflect these changes and clarify existing functionality.

**To test:**

Open Mantid and run the following script:

`from mantid.simpleapi import *
import matplotlib.pyplot as plt
import numpy as np
 
table = CreateEmptyTableWorkspace()
table.addColumn(type="str", name="Symbol")
table.addColumn(type="double", name="Mass (a.u.)")
table.addColumn(type="double", name="Intensity lower limit")
table.addColumn(type="double", name="Intensity value")
table.addColumn(type="double", name="Intensity upper limit")
table.addColumn(type="double", name="Width lower limit")
table.addColumn(type="double", name="Width value")
table.addColumn(type="double", name="Width upper limit")
table.addColumn(type="double", name="Centre lower limit")
table.addColumn(type="double", name="Centre value")
table.addColumn(type="double", name="Centre upper limit")
table.addRow(['C', 12.0,    0.,1.,9.9e9,  10., 15.5, 30., -1.5, 0., 0.5])
 
VesuvioAnalysis(IPFile = "ip2018.par", ComptonProfile = table, AnalysisMode = "LoadReduce",
                NumberOfIterations = 2, OutputName = "polyethylene", Runs = "38898-38906", TOFRangeVector = [110.,1.5,460.],
                Spectra = [3,134], MonteCarloEvents = 1e6, ConstraintsProfileNumbers = [0,0],
                ConstraintsProfileScatteringCrossSection = None, SpectraToBeMasked = [18,34,42,62],
                SubtractResonancesFunction = None,
                YSpaceFitFunctionTies = "(c6=0., c4=0.)")`

The following workspaces should get created:
- polyethylene
- polyethylene_cor
- polyethylene_cor_fit
- polyethylene_gamma_background
- polyethylene_MulScattering
- polyethylene_TotScattering
- table

There should be no workspace name starting with 'polyethylene_H'.

_Please note that this script will be very slow when Mantid is compiled in debug mode. To speed it up please use release mode instead._

Fixes #[32781](https://github.com/mantidproject/mantid/issues/32781). 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
