### PR TITLE
Restore old behavior in ConvertUnits

### DIFF
--- a/Framework/Kernel/src/Unit.cpp
+++ b/Framework/Kernel/src/Unit.cpp
@@ -680,13 +680,21 @@ double dSpacing::singleFromTOF(const double tof) const {
   if (!toDSpacingError.empty())
     throw std::runtime_error(toDSpacingError);
 
+  // this is with the opposite sign from the equation above
+  // as it reduces number of individual flops
+  const double negativeConstantTerm = tof - tzero;
+
+  // don't need to solve a quadratic when difa==0
+  // this allows negative d-spacing to be returned
+  // which was the behavior before v6.2 was released
+  if (difa == 0.)
+    return negativeConstantTerm / difc;
+
   // non-physical result
   if (tzero > tof) {
     if (difa > 0.) {
       throw std::runtime_error("Cannot convert to d spacing because tzero > time-of-flight and difa is positive. "
                                "Quadratic doesn't have a positive root");
-    } else if (difa == 0.) {
-      throw std::runtime_error("Cannot convert to d spacing because tzero > time-of-flight");
     }
   }
 
@@ -698,14 +706,6 @@ double dSpacing::singleFromTOF(const double tof) const {
     else
       return 0.;
   }
-
-  // this is with the opposite sign from the equation above
-  // as it reduces number of individual flops
-  const double negativeConstantTerm = tof - tzero;
-
-  // don't need to solve a quadratic when difa==0
-  if (difa == 0.)
-    return negativeConstantTerm / difc;
 
   // general citarqauq equation
   const double sqrtTerm = 1 + 4 * difa * negativeConstantTerm / (difc * difc);

--- a/Framework/Kernel/test/UnitTest.h
+++ b/Framework/Kernel/test/UnitTest.h
@@ -577,8 +577,8 @@ public:
   }
 
   void testdSpacing_fromTOF() {
-    const std::vector<double> x_in{0., 1001.1, 16000.};
-    const std::vector<double> y_in{2., 3., 4.};
+    const std::vector<double> x_in{-1., 0., 1001.1, 16000.};
+    const std::vector<double> y_in{1., 2., 3., 4.};
     std::vector<double> x(x_in.begin(), x_in.end());
     std::vector<double> y(y_in.begin(), y_in.end());
     double difc =
@@ -588,10 +588,6 @@ public:
     TS_ASSERT(y == y_in);
     for (size_t i = 0; i < x.size(); ++i)
       TS_ASSERT_DELTA(x[i], x_in[i] / difc, 0.000001);
-
-    // test for exception thrown for negative tof
-    x[0] = -1.0;
-    TS_ASSERT_THROWS(d.fromTOF(x, y, 1.0, 1, {{UnitParams::difc, difc}}), const std::runtime_error &);
 
     // test for exception thrown
     x[0] = 1.0;

--- a/docs/source/release/v6.3.0/diffraction.rst
+++ b/docs/source/release/v6.3.0/diffraction.rst
@@ -20,6 +20,7 @@ Powder Diffraction
 Bugfixes
 ########
 - For processing vanadium run, we don't want to find environment automatically in :ref:`SetSampleFromLogs <algm-SetSampleFromLogs>`.
+- Restored behavior in :ref:`ConvertUnits <algm-ConvertUnits>` where negative time-of-flight converts to negative d-spacing when ``DIFA==0``
 - Identification in :ref:`AlignComponents <algm-AlignComponents>` of the first and last detector-ID for an instrument component with unsorted detector-ID's.
 
 Engineering Diffraction


### PR DESCRIPTION
tof<0 converts to d-spacing<0 rather than mask the entire pixel

**To test:**

The unit test was added to confirm the old behavior.

*There is no associated issue.*

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
