### PR TITLE
Remove download test from RepoModelTest

### DIFF
--- a/qt/widgets/common/test/RepoModelTest.h
+++ b/qt/widgets/common/test/RepoModelTest.h
@@ -110,16 +110,6 @@ public:
     }
   }
 
-  // test setData will download file if download selected
-  void test_setData_sets_download() {
-    auto *model = new RepoModel();
-    auto index = getIndex(model, 1, 1);
-    auto isDataSet = model->setData(index, "Download", Qt::EditRole);
-    TS_ASSERT_EQUALS(true, isDataSet);
-    auto row = model->data(index, Qt::DisplayRole).toString();
-    TS_ASSERT_EQUALS("DOWNLOADING", row);
-  }
-
   // test setData will set the file to autoupdate if selected
   void test_setData_sets_autoUpdate() {
     for (const auto &testValue : {true, false}) {


### PR DESCRIPTION
**Description of work.**
Removes this test for a number of reasons:
- The code actually downloads using Qt (which we can assume is tested).
But this makes it flakey depending on network conditions
- The implementation will give a dialog prompt if the file exists, which
cannot be clicked during CI causing timeouts
- The test simply tests it attempts to download, and does not validate
that it actually has
- Unscripted testing explicitly checks this still works each release

This should hopefully fix the run of test failures on [MSVC](https://builds.mantidproject.org/job/main_clean-windows/1705/)

**To test:**
- Ensure RepoModelTest passes

There is no associated issue.

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
