### PR TITLE
Implement sum banks in refl gui preview tab

### DIFF
--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -859,7 +859,7 @@ unreadVariable:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/Muon/ALCDataLoadingV
 useStlAlgorithm:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/Muon/ALCInterface.cpp:232
 useInitializationList:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/ISISReflectometry/Common/OptionDefaults.cpp:18
 useStlAlgorithm:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/ISISReflectometry/Common/Clipboard.cpp:91
-passedByValue:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/ISISReflectometry/Reduction/PreviewRow.h:18
+passedByValue:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/ISISReflectometry/Reduction/PreviewRow.h:19
 constParameter:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchJobManager.cpp:58
 useStlAlgorithm:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchJobManager.cpp:152
 useStlAlgorithm:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/QtExperimentView.cpp:542
@@ -884,7 +884,7 @@ shadowFunction:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/ISISReflectometry/GU
 shadowFunction:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/ISISReflectometry/GUI/Common/Encoder.cpp:284
 shadowFunction:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/ISISReflectometry/GUI/Common/Encoder.cpp:311
 useStlAlgorithm:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/ISISReflectometry/Reduction/Experiment.cpp:61
-passedByValue:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/ISISReflectometry/Reduction/PreviewRow.cpp:14
+passedByValue:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/ISISReflectometry/Reduction/PreviewRow.cpp:15
 useStlAlgorithm:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/ISISReflectometry/GUI/MainWindow/MainWindowPresenter.cpp:153
 useStlAlgorithm:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/ISISReflectometry/GUI/MainWindow/MainWindowPresenter.cpp:161
 useStlAlgorithm:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/Indirect/DensityOfStates.cpp:121

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/CMakeLists.txt
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/CMakeLists.txt
@@ -8,6 +8,7 @@ set(BATCH_SRC_FILES
     ReflAlgorithmFactory.cpp
     RowPreprocessingAlgorithm.cpp
     RowProcessingAlgorithm.cpp
+    SumBanksAlgorithm.cpp
 )
 
 # Include files aren't required, but this makes them appear in Visual Studio IMPORTANT: Include files are required in
@@ -29,6 +30,7 @@ set(BATCH_INC_FILES
     ReflAlgorithmFactory.h
     RowPreprocessingAlgorithm.h
     RowProcessingAlgorithm.h
+    SumBanksAlgorithm.h
 )
 
 set(BATCH_MOC_FILES QtBatchView.h)

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/IReflAlgorithmFactory.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/IReflAlgorithmFactory.h
@@ -17,5 +17,6 @@ public:
   virtual ~IReflAlgorithmFactory() = default;
 
   virtual MantidQt::API::IConfiguredAlgorithm_sptr makePreprocessingAlgorithm(PreviewRow &row) const = 0;
+  virtual MantidQt::API::IConfiguredAlgorithm_sptr makeSumBanksAlgorithm(PreviewRow &row) const = 0;
 };
 } // namespace MantidQt::CustomInterfaces::ISISReflectometry

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/ReflAlgorithmFactory.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/ReflAlgorithmFactory.cpp
@@ -9,6 +9,7 @@
 #include "Reduction/Batch.h"
 #include "Reduction/PreviewRow.h"
 #include "RowPreprocessingAlgorithm.h"
+#include "SumBanksAlgorithm.h"
 
 namespace MantidQt::CustomInterfaces::ISISReflectometry {
 
@@ -19,8 +20,7 @@ MantidQt::API::IConfiguredAlgorithm_sptr ReflAlgorithmFactory::makePreprocessing
 }
 
 MantidQt::API::IConfiguredAlgorithm_sptr ReflAlgorithmFactory::makeSumBanksAlgorithm(PreviewRow &row) const {
-  // TODO return correct algorithm
-  return PreprocessRow::createConfiguredAlgorithm(m_batch, row, nullptr);
+  return SumBanks::createConfiguredAlgorithm(m_batch, row, nullptr);
 }
 
 } // namespace MantidQt::CustomInterfaces::ISISReflectometry

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/ReflAlgorithmFactory.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/ReflAlgorithmFactory.cpp
@@ -17,4 +17,10 @@ ReflAlgorithmFactory::ReflAlgorithmFactory(IBatch const &batch) : m_batch(batch)
 MantidQt::API::IConfiguredAlgorithm_sptr ReflAlgorithmFactory::makePreprocessingAlgorithm(PreviewRow &row) const {
   return PreprocessRow::createConfiguredAlgorithm(m_batch, row, nullptr);
 }
+
+MantidQt::API::IConfiguredAlgorithm_sptr ReflAlgorithmFactory::makeSumBanksAlgorithm(PreviewRow &row) const {
+  // TODO return correct algorithm
+  return PreprocessRow::createConfiguredAlgorithm(m_batch, row, nullptr);
+}
+
 } // namespace MantidQt::CustomInterfaces::ISISReflectometry

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/ReflAlgorithmFactory.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/ReflAlgorithmFactory.h
@@ -18,6 +18,7 @@ class ReflAlgorithmFactory : public IReflAlgorithmFactory {
 public:
   explicit ReflAlgorithmFactory(IBatch const &batch);
   MantidQt::API::IConfiguredAlgorithm_sptr makePreprocessingAlgorithm(PreviewRow &row) const override;
+  MantidQt::API::IConfiguredAlgorithm_sptr makeSumBanksAlgorithm(PreviewRow &row) const override;
 
 private:
   IBatch const &m_batch;

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/SumBanksAlgorithm.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/SumBanksAlgorithm.cpp
@@ -4,12 +4,12 @@
 //   NScD Oak Ridge National Laboratory, European Spallation Source,
 //   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 // SPDX - License - Identifier: GPL - 3.0 +
-#include "RowPreprocessingAlgorithm.h"
+#include "SumBanksAlgorithm.h"
 #include "AlgorithmProperties.h"
 #include "BatchJobAlgorithm.h"
 #include "MantidAPI/AlgorithmManager.h"
 #include "MantidAPI/IAlgorithm.h"
-#include "MantidQtWidgets/Common/AlgorithmRuntimeProps.h"
+#include "MantidAPI/MatrixWorkspace.h"
 #include "MantidQtWidgets/Common/BatchAlgorithmRunner.h"
 #include "Reduction/Item.h"
 #include "Reduction/PreviewRow.h"
@@ -23,44 +23,48 @@ using MantidQt::API::IConfiguredAlgorithm;
 using MantidQt::API::IConfiguredAlgorithm_sptr;
 
 namespace {
-void updateInputWorkspacesProperties(MantidQt::API::IAlgorithmRuntimeProps &properties,
-                                     std::vector<std::string> const &inputRunNumbers) {
-  AlgorithmProperties::update("InputRunList", inputRunNumbers, properties);
-}
+void updateInputProperties(IConfiguredAlgorithm::AlgorithmRuntimeProps &properties,
+                           MatrixWorkspace_sptr const &workspace, std::vector<Mantid::detid_t> const &detIDs) {
+  // TODO we need to pass the workspace pointer here rather than the name because we can't be sure it's in the ADS
+  AlgorithmProperties::update("InputWorkspace", workspace->getName(), properties);
 
+  auto detIDsStr = Mantid::Kernel::Strings::simpleJoin(detIDs.cbegin(), detIDs.cend(), ",");
+  AlgorithmProperties::update("ROIDetectorIDs", detIDsStr, properties);
+}
 } // namespace
 
-namespace MantidQt::CustomInterfaces::ISISReflectometry::PreprocessRow {
+namespace MantidQt::CustomInterfaces::ISISReflectometry::SumBanks {
 
-/** Create a configured algorithm for preprocessing a row. The algorithm
+/** Create a configured algorithm for summing banks. The algorithm
  * properties are set from the reduction configuration model and the
  * given row.
  * @param model : the reduction configuration model
  * @param row : the row from the preview tab
+ * @param alg : this param allows the caller to override the default algorithm type e.g. for injection of a mock;
+ * in normal usage this should be left as the default nullptr
  */
 IConfiguredAlgorithm_sptr createConfiguredAlgorithm(IBatch const & /*model*/, PreviewRow &row, IAlgorithm_sptr alg) {
   // Create the algorithm
   if (!alg) {
-    alg = Mantid::API::AlgorithmManager::Instance().create("ReflectometryISISPreprocess");
+    alg = Mantid::API::AlgorithmManager::Instance().create("ReflectometryISISSumBanks");
   }
   alg->setRethrows(true);
   alg->setAlwaysStoreInADS(false);
   alg->getPointerToProperty("OutputWorkspace")->createTemporaryValue();
 
   // Set the algorithm properties from the model
-  auto properties = std::make_unique<MantidQt::API::AlgorithmRuntimeProps>();
-  updateInputWorkspacesProperties(*properties, row.runNumbers());
+  auto properties = IConfiguredAlgorithm::AlgorithmRuntimeProps();
+  updateInputProperties(properties, row.getLoadedWs(), row.getSelectedBanks());
 
   // Return the configured algorithm
-  auto jobAlgorithm =
-      std::make_shared<BatchJobAlgorithm>(std::move(alg), std::move(properties), updateRowOnAlgorithmComplete, &row);
+  auto jobAlgorithm = std::make_shared<BatchJobAlgorithm>(alg, properties, updateRowOnAlgorithmComplete, &row);
   return jobAlgorithm;
 }
 
 void updateRowOnAlgorithmComplete(const IAlgorithm_sptr &algorithm, Item &item) {
   auto &row = dynamic_cast<PreviewRow &>(item);
   MatrixWorkspace_sptr outputWs = algorithm->getProperty("OutputWorkspace");
-  row.setLoadedWs(outputWs);
+  row.setSummedWs(outputWs);
   // TODO reset the rest of the workspaces associated with the workflow
 }
-} // namespace MantidQt::CustomInterfaces::ISISReflectometry::PreprocessRow
+} // namespace MantidQt::CustomInterfaces::ISISReflectometry::SumBanks

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/SumBanksAlgorithm.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/SumBanksAlgorithm.h
@@ -1,0 +1,27 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2021 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#pragma once
+#pragma once
+
+#include "Common/DllConfig.h"
+#include "MantidAPI/IAlgorithm_fwd.h"
+#include "MantidQtWidgets/Common/BatchAlgorithmRunner.h"
+
+#include <string>
+#include <vector>
+
+namespace MantidQt::CustomInterfaces::ISISReflectometry {
+class IBatch;
+class PreviewRow;
+class Item;
+} // namespace MantidQt::CustomInterfaces::ISISReflectometry
+
+namespace MantidQt::CustomInterfaces::ISISReflectometry::SumBanks {
+MANTIDQT_ISISREFLECTOMETRY_DLL MantidQt::API::IConfiguredAlgorithm_sptr
+createConfiguredAlgorithm(IBatch const &model, PreviewRow &row, Mantid::API::IAlgorithm_sptr alg = nullptr);
+MANTIDQT_ISISREFLECTOMETRY_DLL void updateRowOnAlgorithmComplete(const Mantid::API::IAlgorithm_sptr &, Item &);
+} // namespace MantidQt::CustomInterfaces::ISISReflectometry::SumBanks

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Common/IJobManager.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Common/IJobManager.h
@@ -25,5 +25,6 @@ public:
 
   virtual void subscribe(JobManagerSubscriber *notifyee) = 0;
   virtual void startPreprocessing(PreviewRow &row) = 0;
+  virtual void startSumBanks(PreviewRow &row) = 0;
 };
 } // namespace MantidQt::CustomInterfaces::ISISReflectometry

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Common/IJobManager.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Common/IJobManager.h
@@ -17,6 +17,7 @@ public:
   virtual ~JobManagerSubscriber() = default;
 
   virtual void notifyLoadWorkspaceCompleted() = 0;
+  virtual void notifySumBanksCompleted() = 0;
 };
 
 class MANTIDQT_ISISREFLECTOMETRY_DLL IJobManager {

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/IInstViewModel.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/IInstViewModel.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include "MantidAPI/MatrixWorkspace_fwd.h"
+#include "MantidGeometry/IDTypes.h"
 #include "MantidQtWidgets/InstrumentView/RotationSurface.h"
 
 #include <memory>
@@ -20,6 +21,6 @@ public:
   virtual MantidWidgets::InstrumentActor *getInstrumentViewActor() const = 0;
   virtual Mantid::Kernel::V3D getSamplePos() const = 0;
   virtual Mantid::Kernel::V3D getAxis() const = 0;
-  virtual std::vector<size_t> detIndicesToWsIndices(std::vector<size_t> const &detIndices) const = 0;
+  virtual std::vector<Mantid::detid_t> detIndicesToDetIDs(std::vector<size_t> const &detIndices) const = 0;
 };
 } // namespace MantidQt::CustomInterfaces::ISISReflectometry

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/IPreviewModel.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/IPreviewModel.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include "MantidAPI/MatrixWorkspace_fwd.h"
+#include "MantidGeometry/IDTypes.h"
 #include <string>
 #include <vector>
 
@@ -22,11 +23,11 @@ public:
   virtual void sumBanksAsync(IJobManager &jobManager) = 0;
 
   virtual Mantid::API::MatrixWorkspace_sptr getLoadedWs() const = 0;
-  virtual std::vector<size_t> getSelectedBanks() const = 0;
+  virtual std::vector<Mantid::detid_t> getSelectedBanks() const = 0;
   virtual Mantid::API::MatrixWorkspace_sptr getSummedWs() const = 0;
 
-  virtual void setSelectedBanks(std::vector<size_t> selectedBanks) = 0;
+  virtual void setSelectedBanks(std::vector<Mantid::detid_t> selectedBanks) = 0;
 
-  virtual std::string indicesToString(std::vector<size_t> const &indices) const = 0;
+  virtual std::string detIDsToString(std::vector<Mantid::detid_t> const &indices) const = 0;
 };
 } // namespace MantidQt::CustomInterfaces::ISISReflectometry

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/IPreviewModel.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/IPreviewModel.h
@@ -19,7 +19,14 @@ public:
   virtual ~IPreviewModel() = default;
   virtual bool loadWorkspaceFromAds(std::string const &workspaceName) = 0;
   virtual void loadAndPreprocessWorkspaceAsync(std::string const &workspaceName, IJobManager &jobManager) = 0;
+  virtual void sumBanksAsync(IJobManager &jobManager) = 0;
+
   virtual Mantid::API::MatrixWorkspace_sptr getLoadedWs() const = 0;
+  virtual std::vector<size_t> getSelectedBanks() const = 0;
+  virtual Mantid::API::MatrixWorkspace_sptr getSummedWs() const = 0;
+
+  virtual void setSelectedBanks(std::vector<size_t> selectedBanks) = 0;
+
   virtual std::string indicesToString(std::vector<size_t> const &indices) const = 0;
 };
 } // namespace MantidQt::CustomInterfaces::ISISReflectometry

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/InstViewModel.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/InstViewModel.cpp
@@ -33,10 +33,11 @@ InstViewModel::createInstrumentViewActor(Mantid::API::MatrixWorkspace_sptr &work
 }
 
 void InstViewModel::updateWorkspace(Mantid::API::MatrixWorkspace_sptr &workspace) {
-  // TODO refactor the component info stuff into the surface constructor so we don't need to get it here
   m_actor = createInstrumentViewActor(workspace);
+  m_actor->initialize(true, true);
 }
 
+// TODO refactor getting the sample pos and axis into the surface constructor so we don't need to get it here
 Mantid::Kernel::V3D InstViewModel::getSamplePos() const {
   const auto &componentInfo = m_actor->componentInfo();
   return componentInfo.samplePosition();

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/InstViewModel.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/InstViewModel.cpp
@@ -6,6 +6,7 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 
 #include "InstViewModel.h"
+#include "MantidGeometry/IDTypes.h"
 #include "MantidGeometry/Instrument/ComponentInfo.h"
 #include "MantidQtWidgets/Common/MessageHandler.h"
 #include "MantidQtWidgets/InstrumentView/InstrumentActor.h"
@@ -47,7 +48,7 @@ Mantid::Kernel::V3D InstViewModel::getAxis() const {
 
 MantidWidgets::InstrumentActor *InstViewModel::getInstrumentViewActor() const { return m_actor.get(); }
 
-std::vector<size_t> InstViewModel::detIndicesToWsIndices(std::vector<size_t> const &detIndices) const {
-  return m_actor->getWorkspaceIndices(detIndices);
+std::vector<Mantid::detid_t> InstViewModel::detIndicesToDetIDs(std::vector<size_t> const &detIndices) const {
+  return m_actor->getDetIDs(detIndices);
 }
 } // namespace MantidQt::CustomInterfaces::ISISReflectometry

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/InstViewModel.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/InstViewModel.h
@@ -8,6 +8,7 @@
 
 #include "Common/DllConfig.h"
 #include "IInstViewModel.h"
+#include "MantidGeometry/IDTypes.h"
 #include "MantidQtWidgets/Common/IMessageHandler.h"
 #include "MantidQtWidgets/InstrumentView/InstrumentActor.h"
 
@@ -22,7 +23,7 @@ public:
   MantidWidgets::InstrumentActor *getInstrumentViewActor() const override;
   Mantid::Kernel::V3D getSamplePos() const override;
   Mantid::Kernel::V3D getAxis() const override;
-  std::vector<size_t> detIndicesToWsIndices(std::vector<size_t> const &detIndices) const override;
+  std::vector<Mantid::detid_t> detIndicesToDetIDs(std::vector<size_t> const &detIndices) const override;
 
 private:
   std::unique_ptr<MantidWidgets::InstrumentActor> m_actor;

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewJobManager.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewJobManager.cpp
@@ -17,7 +17,9 @@
 
 namespace {
 Mantid::Kernel::Logger g_log("Reflectometry Preview Job Manager");
-}
+constexpr auto PREPROCESS_ALG_NAME = "ReflectometryISISPreprocess";
+constexpr auto SUM_BANKS_ALG_NAME = "ReflectometryISISSumBanks";
+} // namespace
 
 namespace MantidQt::CustomInterfaces::ISISReflectometry {
 
@@ -44,9 +46,14 @@ void PreviewJobManager::notifyAlgorithmComplete(API::IConfiguredAlgorithm_sptr &
 
   jobAlgorithm->updateItem();
 
-  // TODO When the full implementation is added we will need to switch between different algorithm cases.
-  // For now we just deal with loading.
-  m_notifyee->notifyLoadWorkspaceCompleted();
+  const auto &name = algorithm->algorithm()->name();
+  if (name == PREPROCESS_ALG_NAME) {
+    m_notifyee->notifyLoadWorkspaceCompleted();
+  } else if (name == SUM_BANKS_ALG_NAME) {
+    m_notifyee->notifySumBanksCompleted();
+  } else {
+    throw std::logic_error("Invalid algorithm. Not implemented.");
+  }
 }
 
 void PreviewJobManager::notifyAlgorithmError(API::IConfiguredAlgorithm_sptr, std::string const &message) {

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewJobManager.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewJobManager.cpp
@@ -60,9 +60,7 @@ void PreviewJobManager::startPreprocessing(PreviewRow &row) {
   executeAlg(m_algFactory->makePreprocessingAlgorithm(row));
 }
 
-void PreviewJobManager::startSumBanks(PreviewRow &row) {
-  // executeAlg(m_algFactory->makeSumBanksAlgorithm(row));
-}
+void PreviewJobManager::startSumBanks(PreviewRow &row) { executeAlg(m_algFactory->makeSumBanksAlgorithm(row)); }
 
 void PreviewJobManager::executeAlg(IConfiguredAlgorithm_sptr alg) {
   m_jobRunner->clearAlgorithmQueue();

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewJobManager.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewJobManager.cpp
@@ -60,6 +60,10 @@ void PreviewJobManager::startPreprocessing(PreviewRow &row) {
   executeAlg(m_algFactory->makePreprocessingAlgorithm(row));
 }
 
+void PreviewJobManager::startSumBanks(PreviewRow &row) {
+  // executeAlg(m_algFactory->makeSumBanksAlgorithm(row));
+}
+
 void PreviewJobManager::executeAlg(IConfiguredAlgorithm_sptr alg) {
   m_jobRunner->clearAlgorithmQueue();
   m_jobRunner->setAlgorithmQueue(std::deque<IConfiguredAlgorithm_sptr>{std::move(alg)});

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewJobManager.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewJobManager.h
@@ -21,6 +21,7 @@ public:
   // IJobManager overrides
   void subscribe(JobManagerSubscriber *notifyee) override;
   void startPreprocessing(PreviewRow &row) override;
+  void startSumBanks(PreviewRow &row) override;
 
   // JobRunnerSubscriber overrides
   void notifyBatchComplete(bool) override;

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewModel.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewModel.cpp
@@ -9,6 +9,7 @@
 #include "GUI/Common/IJobManager.h"
 #include "MantidAPI/AnalysisDataService.h"
 #include "MantidAPI/MatrixWorkspace.h"
+#include "MantidGeometry/IDTypes.h"
 #include "MantidGeometry/Instrument/DetectorInfo.h"
 #include "MantidKernel/Logger.h"
 #include "MantidKernel/Strings.h"
@@ -69,9 +70,9 @@ void PreviewModel::sumBanksAsync(IJobManager &jobManager) { jobManager.startSumB
 MatrixWorkspace_sptr PreviewModel::getLoadedWs() const { return m_runDetails->getLoadedWs(); }
 MatrixWorkspace_sptr PreviewModel::getSummedWs() const { return m_runDetails->getSummedWs(); }
 
-std::vector<size_t> PreviewModel::getSelectedBanks() const { return m_runDetails->getSelectedBanks(); }
+std::vector<Mantid::detid_t> PreviewModel::getSelectedBanks() const { return m_runDetails->getSelectedBanks(); }
 
-void PreviewModel::setSelectedBanks(std::vector<size_t> selectedBanks) {
+void PreviewModel::setSelectedBanks(std::vector<Mantid::detid_t> selectedBanks) {
   m_runDetails->setSelectedBanks(std::move(selectedBanks));
 }
 
@@ -79,7 +80,7 @@ void PreviewModel::createRunDetails(const std::string &workspaceName) {
   m_runDetails = std::make_unique<PreviewRow>(std::vector<std::string>{workspaceName});
 }
 
-std::string PreviewModel::indicesToString(std::vector<size_t> const &indices) const {
+std::string PreviewModel::detIDsToString(std::vector<Mantid::detid_t> const &indices) const {
   return Mantid::Kernel::Strings::simpleJoin(indices.cbegin(), indices.cend(), ",");
 }
 } // namespace MantidQt::CustomInterfaces::ISISReflectometry

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewModel.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewModel.cpp
@@ -25,6 +25,11 @@ Mantid::Kernel::Logger g_log("Reflectometry Preview Model");
 
 namespace MantidQt::CustomInterfaces::ISISReflectometry {
 
+PreviewModel::PreviewModel() {
+  // This simplifies testing greatly
+  createRunDetails("");
+}
+
 /** Set the loaded workspace from the ADS if it exists
  *
  * @param workspaceName : the workspace name to look for
@@ -54,7 +59,21 @@ void PreviewModel::loadAndPreprocessWorkspaceAsync(std::string const &workspaceN
   jobManager.startPreprocessing(*m_runDetails);
 }
 
+/** Sum spectra across banks
+ *
+ * @param wsIndices : the workspace indices of the spectra to sum
+ * @param jobManager : the job manager that will execute the algorithm
+ */
+void PreviewModel::sumBanksAsync(IJobManager &jobManager) { jobManager.startSumBanks(*m_runDetails); }
+
 MatrixWorkspace_sptr PreviewModel::getLoadedWs() const { return m_runDetails->getLoadedWs(); }
+MatrixWorkspace_sptr PreviewModel::getSummedWs() const { return m_runDetails->getSummedWs(); }
+
+std::vector<size_t> PreviewModel::getSelectedBanks() const { return m_runDetails->getSelectedBanks(); }
+
+void PreviewModel::setSelectedBanks(std::vector<size_t> selectedBanks) {
+  m_runDetails->setSelectedBanks(std::move(selectedBanks));
+}
 
 void PreviewModel::createRunDetails(const std::string &workspaceName) {
   m_runDetails = std::make_unique<PreviewRow>(std::vector<std::string>{workspaceName});

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewModel.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewModel.h
@@ -12,20 +12,30 @@
 #include "MantidAPI/MatrixWorkspace_fwd.h"
 #include "Reduction/PreviewRow.h"
 
+#include <cstddef>
 #include <memory>
 #include <string>
+#include <vector>
 
 namespace MantidQt::CustomInterfaces::ISISReflectometry {
 class IJobManager;
 
-class MANTIDQT_ISISREFLECTOMETRY_DLL PreviewModel : public IPreviewModel {
+class MANTIDQT_ISISREFLECTOMETRY_DLL PreviewModel final : public IPreviewModel {
 public:
+  PreviewModel();
   virtual ~PreviewModel() = default;
 
   bool loadWorkspaceFromAds(std::string const &workspaceName) override;
   void loadAndPreprocessWorkspaceAsync(std::string const &workspaceName, IJobManager &jobManager) override;
-  Mantid::API::MatrixWorkspace_sptr getLoadedWs() const override;
+  void sumBanksAsync(IJobManager &jobManager) override;
+
   std::string indicesToString(std::vector<size_t> const &indices) const override;
+
+  Mantid::API::MatrixWorkspace_sptr getLoadedWs() const override;
+  std::vector<size_t> getSelectedBanks() const override;
+  Mantid::API::MatrixWorkspace_sptr getSummedWs() const override;
+
+  void setSelectedBanks(std::vector<size_t> selectedBanks) override;
 
 private:
   // This should be an optional instead of a point, but we have issues reassigning it because boost::optional doesn't

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewModel.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewModel.h
@@ -10,6 +10,7 @@
 #include "Common/DllConfig.h"
 #include "IPreviewModel.h"
 #include "MantidAPI/MatrixWorkspace_fwd.h"
+#include "MantidGeometry/IDTypes.h"
 #include "Reduction/PreviewRow.h"
 
 #include <cstddef>
@@ -29,13 +30,13 @@ public:
   void loadAndPreprocessWorkspaceAsync(std::string const &workspaceName, IJobManager &jobManager) override;
   void sumBanksAsync(IJobManager &jobManager) override;
 
-  std::string indicesToString(std::vector<size_t> const &indices) const override;
+  std::string detIDsToString(std::vector<Mantid::detid_t> const &indices) const override;
 
   Mantid::API::MatrixWorkspace_sptr getLoadedWs() const override;
-  std::vector<size_t> getSelectedBanks() const override;
+  std::vector<Mantid::detid_t> getSelectedBanks() const override;
   Mantid::API::MatrixWorkspace_sptr getSummedWs() const override;
 
-  void setSelectedBanks(std::vector<size_t> selectedBanks) override;
+  void setSelectedBanks(std::vector<Mantid::detid_t> selectedBanks) override;
 
 private:
   // This should be an optional instead of a point, but we have issues reassigning it because boost::optional doesn't

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.cpp
@@ -79,7 +79,7 @@ void PreviewPresenter::notifyInstViewShapeChanged() {
   // Get the masked workspace indices
   auto indices = m_instViewModel->detIndicesToDetIDs(m_view->getSelectedDetectors());
   auto selectionStr = m_model->detIDsToString(indices);
-  g_log.debug(selectionStr);
+  g_log.notice(selectionStr);
 
   m_model->setSelectedBanks(indices);
   m_model->sumBanksAsync(*m_jobManager);

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.cpp
@@ -53,7 +53,11 @@ void PreviewPresenter::notifyLoadWorkspaceCompleted() {
   // TODO reset the other plots (or perhaps re-run the reduction with the new data?)
 }
 
-void PreviewPresenter::notifySumBanksCompleted() { g_log.debug("Sum banks completed"); }
+void PreviewPresenter::notifySumBanksCompleted() {
+  g_log.debug("Sum banks completed");
+  // TODO Implement plotting of the summed workspace
+  // m_view->plotSliceView(m_model->getSummedWs())
+}
 
 void PreviewPresenter::notifyInstViewSelectRectRequested() {
   m_view->setInstViewZoomState(false);
@@ -82,7 +86,7 @@ void PreviewPresenter::notifyInstViewShapeChanged() {
   // Get the masked workspace indices
   auto indices = m_instViewModel->detIndicesToDetIDs(m_view->getSelectedDetectors());
   auto selectionStr = m_model->detIDsToString(indices);
-  g_log.notice(selectionStr);
+  g_log.debug(selectionStr);
 
   m_model->setSelectedBanks(indices);
   m_model->sumBanksAsync(*m_jobManager);

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.cpp
@@ -50,7 +50,10 @@ void PreviewPresenter::notifyLoadWorkspaceCompleted() {
   // Ensure the toolbar is enabled, and reset the instrument view to zoom mode
   m_view->setInstViewToolbarEnabled(true);
   notifyInstViewZoomRequested();
+  // TODO reset the other plots (or perhaps re-run the reduction with the new data?)
 }
+
+void PreviewPresenter::notifySumBanksCompleted() { g_log.debug("Sum banks completed"); }
 
 void PreviewPresenter::notifyInstViewSelectRectRequested() {
   m_view->setInstViewZoomState(false);

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.cpp
@@ -77,8 +77,8 @@ void PreviewPresenter::notifyInstViewShapeChanged() {
   // Change to shape editing after a selection has been done to match instrument viewer default behaviour
   notifyInstViewEditRequested();
   // Get the masked workspace indices
-  auto indices = m_instViewModel->detIndicesToWsIndices(m_view->getSelectedDetectors());
-  auto selectionStr = m_model->indicesToString(indices);
+  auto indices = m_instViewModel->detIndicesToDetIDs(m_view->getSelectedDetectors());
+  auto selectionStr = m_model->detIDsToString(indices);
   g_log.debug(selectionStr);
 
   m_model->setSelectedBanks(indices);

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.cpp
@@ -79,8 +79,9 @@ void PreviewPresenter::notifyInstViewShapeChanged() {
   // Get the masked workspace indices
   auto indices = m_instViewModel->detIndicesToWsIndices(m_view->getSelectedDetectors());
   auto selectionStr = m_model->indicesToString(indices);
-  // TODO Start the algorithm that will sum banks horizontally. For now just print out the masked indices.
-  g_log.information(selectionStr);
-  // m_model->sumBanksAsync(*m_jobManager, m_model->indicesToString(selectedIndices));
+  g_log.debug(selectionStr);
+
+  m_model->setSelectedBanks(indices);
+  m_model->sumBanksAsync(*m_jobManager);
 }
 } // namespace MantidQt::CustomInterfaces::ISISReflectometry

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.h
@@ -42,6 +42,7 @@ public:
 
   // JobManagerSubscriber overrides
   void notifyLoadWorkspaceCompleted() override;
+  void notifySumBanksCompleted() override;
 
 private:
   IPreviewView *m_view{nullptr};

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/PreviewRow.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/PreviewRow.cpp
@@ -6,6 +6,7 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 #include "PreviewRow.h"
 #include "MantidAPI/MatrixWorkspace.h"
+#include "MantidGeometry/IDTypes.h"
 
 #include <string>
 #include <vector>
@@ -31,9 +32,9 @@ Mantid::API::MatrixWorkspace_sptr PreviewRow::getSummedWs() const noexcept { ret
 void PreviewRow::setLoadedWs(Mantid::API::MatrixWorkspace_sptr ws) noexcept { m_loadedWs = std::move(ws); }
 void PreviewRow::setSummedWs(Mantid::API::MatrixWorkspace_sptr ws) noexcept { m_summedWs = std::move(ws); }
 
-std::vector<size_t> PreviewRow::getSelectedBanks() const noexcept { return m_selectedBanks; }
+std::vector<Mantid::detid_t> PreviewRow::getSelectedBanks() const noexcept { return m_selectedBanks; }
 
-void PreviewRow::setSelectedBanks(std::vector<size_t> selectedBanks) noexcept {
+void PreviewRow::setSelectedBanks(std::vector<Mantid::detid_t> selectedBanks) noexcept {
   m_selectedBanks = std::move(selectedBanks);
 }
 } // namespace MantidQt::CustomInterfaces::ISISReflectometry

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/PreviewRow.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/PreviewRow.cpp
@@ -26,6 +26,14 @@ int PreviewRow::totalItems() const { return 1; }
 int PreviewRow::completedItems() const { return 1; }
 
 Mantid::API::MatrixWorkspace_sptr PreviewRow::getLoadedWs() const noexcept { return m_loadedWs; }
+Mantid::API::MatrixWorkspace_sptr PreviewRow::getSummedWs() const noexcept { return m_summedWs; }
 
-void PreviewRow::setLoadedWs(Mantid::API::MatrixWorkspace_sptr ws) noexcept { m_loadedWs = ws; }
+void PreviewRow::setLoadedWs(Mantid::API::MatrixWorkspace_sptr ws) noexcept { m_loadedWs = std::move(ws); }
+void PreviewRow::setSummedWs(Mantid::API::MatrixWorkspace_sptr ws) noexcept { m_summedWs = std::move(ws); }
+
+std::vector<size_t> PreviewRow::getSelectedBanks() const noexcept { return m_selectedBanks; }
+
+void PreviewRow::setSelectedBanks(std::vector<size_t> selectedBanks) noexcept {
+  m_selectedBanks = std::move(selectedBanks);
+}
 } // namespace MantidQt::CustomInterfaces::ISISReflectometry

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/PreviewRow.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/PreviewRow.h
@@ -8,6 +8,7 @@
 #include "Common/DllConfig.h"
 #include "Item.h"
 #include "MantidAPI/MatrixWorkspace_fwd.h"
+#include "MantidGeometry/IDTypes.h"
 
 #include <string>
 #include <vector>
@@ -38,11 +39,11 @@ public:
 
   Mantid::API::MatrixWorkspace_sptr getLoadedWs() const noexcept;
   Mantid::API::MatrixWorkspace_sptr getSummedWs() const noexcept;
-  std::vector<size_t> getSelectedBanks() const noexcept;
+  std::vector<Mantid::detid_t> getSelectedBanks() const noexcept;
 
   void setLoadedWs(Mantid::API::MatrixWorkspace_sptr ws) noexcept;
   void setSummedWs(Mantid::API::MatrixWorkspace_sptr ws) noexcept;
-  void setSelectedBanks(std::vector<size_t> selectedBanks) noexcept;
+  void setSelectedBanks(std::vector<Mantid::detid_t> selectedBanks) noexcept;
 
   friend bool operator==(const PreviewRow &lhs, const PreviewRow &rhs) {
     // Note: This does not consider if the underlying item is equal currently
@@ -52,7 +53,7 @@ public:
 
 private:
   std::vector<std::string> m_runNumbers;
-  std::vector<size_t> m_selectedBanks;
+  std::vector<Mantid::detid_t> m_selectedBanks;
   Mantid::API::MatrixWorkspace_sptr m_loadedWs;
   Mantid::API::MatrixWorkspace_sptr m_summedWs;
 };

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/PreviewRow.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/PreviewRow.h
@@ -37,16 +37,24 @@ public:
   void setOutputNames(std::vector<std::string> const &) override {}
 
   Mantid::API::MatrixWorkspace_sptr getLoadedWs() const noexcept;
+  Mantid::API::MatrixWorkspace_sptr getSummedWs() const noexcept;
+  std::vector<size_t> getSelectedBanks() const noexcept;
+
   void setLoadedWs(Mantid::API::MatrixWorkspace_sptr ws) noexcept;
+  void setSummedWs(Mantid::API::MatrixWorkspace_sptr ws) noexcept;
+  void setSelectedBanks(std::vector<size_t> selectedBanks) noexcept;
 
   friend bool operator==(const PreviewRow &lhs, const PreviewRow &rhs) {
     // Note: This does not consider if the underlying item is equal currently
-    return (&lhs == &rhs) || ((lhs.m_runNumbers == rhs.m_runNumbers) && (lhs.m_loadedWs == rhs.m_loadedWs));
+    return (&lhs == &rhs) || ((lhs.m_runNumbers == rhs.m_runNumbers) && (lhs.m_loadedWs == rhs.m_loadedWs) &&
+                              (lhs.m_selectedBanks == rhs.m_selectedBanks));
   }
 
 private:
   std::vector<std::string> m_runNumbers;
+  std::vector<size_t> m_selectedBanks;
   Mantid::API::MatrixWorkspace_sptr m_loadedWs;
+  Mantid::API::MatrixWorkspace_sptr m_summedWs;
 };
 
 } // namespace MantidQt::CustomInterfaces::ISISReflectometry

--- a/qt/scientific_interfaces/ISISReflectometry/test/Batch/MockReflAlgorithmFactory.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Batch/MockReflAlgorithmFactory.h
@@ -16,4 +16,5 @@
 class MockReflAlgorithmFactory : public IReflAlgorithmFactory {
 public:
   MOCK_METHOD(MantidQt::API::IConfiguredAlgorithm_sptr, makePreprocessingAlgorithm, (PreviewRow &), (const, override));
+  MOCK_METHOD(MantidQt::API::IConfiguredAlgorithm_sptr, makeSumBanksAlgorithm, (PreviewRow &), (const, override));
 };

--- a/qt/scientific_interfaces/ISISReflectometry/test/Batch/SumBanksAlgorithmTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Batch/SumBanksAlgorithmTest.h
@@ -11,9 +11,9 @@
 #include "../../../ISISReflectometry/Reduction/IBatch.h"
 #include "../../../ISISReflectometry/Reduction/PreviewRow.h"
 #include "../../../ISISReflectometry/TestHelpers/ModelCreationHelper.h"
+#include "MantidFrameworkTestHelpers/WorkspaceCreationHelper.h"
 #include "MantidQtWidgets/Common/AlgorithmRuntimeProps.h"
 #include "MantidQtWidgets/Common/BatchAlgorithmRunner.h"
-#include "MantidTestHelpers/WorkspaceCreationHelper.h"
 #include "MockBatch.h"
 
 #include <cxxtest/TestSuite.h>

--- a/qt/scientific_interfaces/ISISReflectometry/test/Batch/SumBanksAlgorithmTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Batch/SumBanksAlgorithmTest.h
@@ -1,0 +1,81 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2021 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#pragma once
+#pragma once
+
+#include "../../../ISISReflectometry/GUI/Batch/SumBanksAlgorithm.h"
+#include "../../../ISISReflectometry/Reduction/IBatch.h"
+#include "../../../ISISReflectometry/Reduction/PreviewRow.h"
+#include "../../../ISISReflectometry/TestHelpers/ModelCreationHelper.h"
+#include "MantidQtWidgets/Common/BatchAlgorithmRunner.h"
+#include "MantidTestHelpers/WorkspaceCreationHelper.h"
+#include "MockBatch.h"
+
+#include <cxxtest/TestSuite.h>
+#include <gmock/gmock.h>
+
+using namespace ::testing;
+
+using namespace MantidQt::CustomInterfaces::ISISReflectometry;
+using namespace MantidQt::CustomInterfaces::ISISReflectometry::SumBanks;
+using namespace MantidQt::CustomInterfaces::ISISReflectometry::ModelCreationHelper;
+using MantidQt::API::IConfiguredAlgorithm;
+
+class SumBanksAlgorithmTest : public CxxTest::TestSuite {
+  class StubbedPreProcess : public WorkspaceCreationHelper::StubAlgorithm {
+  public:
+    StubbedPreProcess() {
+      this->setChild(true);
+      auto prop = std::make_unique<Mantid::API::WorkspaceProperty<>>(m_propName, "", Mantid::Kernel::Direction::Output);
+      declareProperty(std::move(prop));
+    }
+
+    void addOutputWorkspace(Mantid::API::MatrixWorkspace_sptr &ws) {
+      this->getPointerToProperty("OutputWorkspace")->createTemporaryValue();
+      setProperty(m_propName, ws);
+    }
+    const std::string m_propName = "OutputWorkspace";
+  };
+
+public:
+  // This pair of boilerplate methods prevent the suite being created statically
+  // This means the constructor isn't called when running other tests
+  static SumBanksAlgorithmTest *createSuite() { return new SumBanksAlgorithmTest(); }
+  static void destroySuite(SumBanksAlgorithmTest *suite) { delete suite; }
+
+  void test_input_properties_forwarded() {
+    auto batch = MockBatch();
+    const bool isHistogram = true;
+    Mantid::API::MatrixWorkspace_sptr mockWs = WorkspaceCreationHelper::create1DWorkspaceRand(1, isHistogram);
+    auto detIDs = std::vector<Mantid::detid_t>{2, 3};
+    auto row = PreviewRow({});
+    row.setLoadedWs(mockWs);
+    row.setSelectedBanks(detIDs);
+    auto mockAlg = std::make_shared<StubbedPreProcess>();
+
+    auto configuredAlg = createConfiguredAlgorithm(batch, row, mockAlg);
+    TS_ASSERT_EQUALS(configuredAlg->algorithm(), mockAlg);
+    // TODO use workspace pointer instead of string when we update AlgorithmRunimeProps to support this
+    auto expectedProps =
+        IConfiguredAlgorithm::AlgorithmRuntimeProps{{"InputWorkspace", "mockWs"}, {"ROIDetectorIDs", "2, 3"}};
+    TS_ASSERT_EQUALS(configuredAlg->properties(), expectedProps);
+  }
+
+  void xtest_row_is_updated_on_algorithm_complete() {
+    auto mockAlg = std::make_shared<StubbedPreProcess>();
+    const bool isHistogram = true;
+    Mantid::API::MatrixWorkspace_sptr mockWs = WorkspaceCreationHelper::create1DWorkspaceRand(1, isHistogram);
+    mockAlg->addOutputWorkspace(mockWs);
+
+    auto runNumbers = std::vector<std::string>{};
+    auto row = PreviewRow(runNumbers);
+
+    updateRowOnAlgorithmComplete(mockAlg, row);
+
+    TS_ASSERT_EQUALS(row.getLoadedWs(), mockWs);
+  }
+};

--- a/qt/scientific_interfaces/ISISReflectometry/test/CMakeLists.txt
+++ b/qt/scientific_interfaces/ISISReflectometry/test/CMakeLists.txt
@@ -9,6 +9,7 @@ set(TEST_FILES
     Batch/BatchJobManagerProcessingTest.h
     Batch/RowProcessingAlgorithmTest.h
     Batch/RowPreprocessingAlgorithmTest.h
+    Batch/SumBanksAlgorithmTest.h
     Event/EventPresenterTest.h
     MainWindow/MainWindowPresenterTest.h
     RunsTable/RunsTablePresenterRowDeletionTest.h

--- a/qt/scientific_interfaces/ISISReflectometry/test/Preview/InstViewModelTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Preview/InstViewModelTest.h
@@ -64,8 +64,8 @@ public:
     model.updateWorkspace(ws);
 
     auto const detIndices = std::vector<size_t>{1, 2, 3};
-    auto const expected = std::vector<size_t>{1, 2, 3};
-    auto const workspaceIndices = model.detIndicesToWsIndices(detIndices);
+    auto const expected = std::vector<Mantid::detid_t>{2, 3, 4};
+    auto const workspaceIndices = model.detIndicesToDetIDs(detIndices);
     TS_ASSERT_EQUALS(workspaceIndices, expected);
   }
 

--- a/qt/scientific_interfaces/ISISReflectometry/test/Preview/InstViewModelTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Preview/InstViewModelTest.h
@@ -41,6 +41,15 @@ public:
     TS_ASSERT_EQUALS(result->getWorkspace(), ws)
   }
 
+  void test_update_workspace_initializes_actor() {
+    auto model = makeInstViewModel();
+    auto ws = createWorkspace();
+    model.updateWorkspace(ws);
+
+    const auto result = model.getInstrumentViewActor();
+    TS_ASSERT(result->isInitialized());
+  }
+
   void test_get_sample_pos() {
     auto model = makeInstViewModel();
     auto ws = createWorkspace();

--- a/qt/scientific_interfaces/ISISReflectometry/test/Preview/MockInstViewModel.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Preview/MockInstViewModel.h
@@ -23,6 +23,6 @@ public:
   MOCK_METHOD(MantidWidgets::InstrumentActor *, getInstrumentViewActor, (), (const, override));
   MOCK_METHOD(Mantid::Kernel::V3D, getSamplePos, (), (const, override));
   MOCK_METHOD(Mantid::Kernel::V3D, getAxis, (), (const, override));
-  MOCK_METHOD(std::vector<size_t>, detIndicesToWsIndices, (std::vector<size_t> const &), (const, override));
+  MOCK_METHOD(std::vector<Mantid::detid_t>, detIndicesToDetIDs, (std::vector<size_t> const &), (const, override));
 };
 } // namespace MantidQt::CustomInterfaces::ISISReflectometry

--- a/qt/scientific_interfaces/ISISReflectometry/test/Preview/MockPreviewModel.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Preview/MockPreviewModel.h
@@ -9,6 +9,7 @@
 #include "GUI/Common/IJobManager.h"
 #include "IPreviewModel.h"
 #include "MantidAPI/MatrixWorkspace_fwd.h"
+#include "MantidGeometry/IDTypes.h"
 
 #include <gmock/gmock.h>
 
@@ -24,11 +25,11 @@ public:
   MOCK_METHOD(void, loadAndPreprocessWorkspaceAsync, (std::string const &, IJobManager &), (override));
   MOCK_METHOD(MatrixWorkspace_sptr, getLoadedWs, (), (const, override));
   MOCK_METHOD(MatrixWorkspace_sptr, getSummedWs, (), (const, override));
-  MOCK_METHOD(std::vector<size_t>, getSelectedBanks, (), (const, override));
+  MOCK_METHOD(std::vector<Mantid::detid_t>, getSelectedBanks, (), (const, override));
 
-  MOCK_METHOD(void, setSelectedBanks, (std::vector<size_t>), (override));
+  MOCK_METHOD(void, setSelectedBanks, (std::vector<Mantid::detid_t>), (override));
 
   MOCK_METHOD(void, sumBanksAsync, (IJobManager &), (override));
-  MOCK_METHOD(std::string, indicesToString, (std::vector<size_t> const &), (const, override));
+  MOCK_METHOD(std::string, detIDsToString, (std::vector<Mantid::detid_t> const &), (const, override));
 };
 } // namespace MantidQt::CustomInterfaces::ISISReflectometry

--- a/qt/scientific_interfaces/ISISReflectometry/test/Preview/MockPreviewModel.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Preview/MockPreviewModel.h
@@ -23,6 +23,12 @@ public:
   MOCK_METHOD(bool, loadWorkspaceFromAds, (std::string const &workspaceName), (override));
   MOCK_METHOD(void, loadAndPreprocessWorkspaceAsync, (std::string const &, IJobManager &), (override));
   MOCK_METHOD(MatrixWorkspace_sptr, getLoadedWs, (), (const, override));
+  MOCK_METHOD(MatrixWorkspace_sptr, getSummedWs, (), (const, override));
+  MOCK_METHOD(std::vector<size_t>, getSelectedBanks, (), (const, override));
+
+  MOCK_METHOD(void, setSelectedBanks, (std::vector<size_t>), (override));
+
+  MOCK_METHOD(void, sumBanksAsync, (IJobManager &), (override));
   MOCK_METHOD(std::string, indicesToString, (std::vector<size_t> const &), (const, override));
 };
 } // namespace MantidQt::CustomInterfaces::ISISReflectometry

--- a/qt/scientific_interfaces/ISISReflectometry/test/Preview/PreviewJobManagerTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Preview/PreviewJobManagerTest.h
@@ -6,7 +6,6 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 #pragma once
 
-#include "../Reduction/MockBatch.h"
 #include "GUI/Batch/BatchJobAlgorithm.h"
 #include "MantidFrameworkTestHelpers/WorkspaceCreationHelper.h"
 #include "MantidQtWidgets/Common/AlgorithmRuntimeProps.h"
@@ -19,10 +18,14 @@
 
 #include <gmock/gmock.h>
 
+using Mantid::API::IAlgorithm_sptr;
+using MantidQt::API::AlgorithmRuntimeProps;
+using MantidQt::API::ConfiguredAlgorithm;
 using ::testing::ByRef;
 using ::testing::Eq;
 using ::testing::NotNull;
 using ::testing::Return;
+using WorkspaceCreationHelper::StubAlgorithm;
 
 namespace {
 struct AlgCompleteCallback {
@@ -36,117 +39,43 @@ bool AlgCompleteCallback::m_callbackWasCalled = false;
 } // namespace
 
 class PreviewJobManagerTest : public CxxTest::TestSuite {
-  class StubAlgPreprocess : public WorkspaceCreationHelper::StubAlgorithm {
-  public:
-    const std::string name() const override { return "ReflectometryISISPreprocess"; }
-  };
-
-  class StubAlgSumBanks : public WorkspaceCreationHelper::StubAlgorithm {
-  public:
-    const std::string name() const override { return "ReflectometryISISSumBanks"; }
-  };
-
 public:
   // This pair of boilerplate methods prevent the suite being created statically
   // This means the constructor isn't called when running other tests
   static PreviewJobManagerTest *createSuite() { return new PreviewJobManagerTest(); }
   static void destroySuite(PreviewJobManagerTest *suite) { delete suite; }
 
+  void test_subscribe_to_job_runner() {
+    auto mockJobRunner = MockJobRunner();
+    auto jobManager = makeJobManager(&mockJobRunner);
+  }
+
   void test_start_preprocessing() {
     auto mockAlgFactory = std::make_unique<MockReflAlgorithmFactory>();
     auto mockJobRunner = MockJobRunner();
-    auto previewRow = createPreviewRow();
+    auto previewRow = makePreviewRow();
     auto stubAlg = makeConfiguredAlg();
-    EXPECT_CALL(*mockAlgFactory, makePreprocessingAlgorithm(Eq(ByRef(previewRow)))).Times(1).WillOnce(Return(stubAlg));
+
+    expectPreprocessingAlgCreated(*mockAlgFactory, previewRow, stubAlg);
     expectAlgorithmExecuted(stubAlg, mockJobRunner);
 
-    auto batch = MockBatch();
-    auto jobManager = createJobManager(&mockJobRunner, std::move(mockAlgFactory));
+    auto jobManager = makeJobManager(&mockJobRunner, std::move(mockAlgFactory));
     jobManager.startPreprocessing(previewRow);
   }
 
-  void test_start_sum_banks() {
-    auto mockAlgFactory = std::make_unique<MockReflAlgorithmFactory>();
-    auto mockJobRunner = MockJobRunner();
-    auto previewRow = createPreviewRow();
-    auto stubAlg = makeConfiguredAlg();
-    EXPECT_CALL(*mockAlgFactory, makeSumBanksAlgorithm(Eq(ByRef(previewRow)))).Times(1).WillOnce(Return(stubAlg));
-    expectAlgorithmExecuted(stubAlg, mockJobRunner);
-
-    auto batch = MockBatch();
-    auto jobManager = createJobManager(&mockJobRunner, std::move(mockAlgFactory));
-    jobManager.startSumBanks(previewRow);
-  }
-
-  void test_subscribe_to_job_runner() {
-    auto mockAlgFactory = std::make_unique<MockReflAlgorithmFactory>();
-    auto mockJobRunner = MockJobRunner();
-    EXPECT_CALL(mockJobRunner, subscribe(NotNull())).Times(1);
-    auto jobManager = PreviewJobManager(&mockJobRunner, std::move(mockAlgFactory));
-  }
-
   void test_notify_preprocessing_algorithm_complete_notifies_subscriber() {
-    AlgCompleteCallback::m_callbackWasCalled = false;
-
-    auto mockAlgFactory = std::make_unique<MockReflAlgorithmFactory>();
     auto mockJobRunner = MockJobRunner();
     auto mockSubscriber = MockJobManagerSubscriber();
-
-    auto row = PreviewRow({"12345"});
-    Mantid::API::IAlgorithm_sptr mockAlg = std::make_shared<StubAlgPreprocess>();
-    auto properties = std::make_unique<MantidQt::API::AlgorithmRuntimeProps>();
-    auto configuredAlg = std::make_shared<BatchJobAlgorithm>(std::move(mockAlg), std::move(properties),
-                                                             AlgCompleteCallback::updateRowOnAlgorithmComplete, &row);
+    auto previewRow = makePreviewRow();
+    auto stubAlg = makeConfiguredPreprocessAlg(previewRow);
 
     EXPECT_CALL(mockSubscriber, notifyLoadWorkspaceCompleted).Times(1);
-    auto jobManager = PreviewJobManager(&mockJobRunner, std::move(mockAlgFactory));
-    jobManager.subscribe(&mockSubscriber);
 
-    auto configuredAlgRef = std::static_pointer_cast<IConfiguredAlgorithm>(configuredAlg);
-    jobManager.notifyAlgorithmComplete(configuredAlgRef);
-    TS_ASSERT(AlgCompleteCallback::m_callbackWasCalled);
-  }
+    auto jobManager = makeJobManager(&mockJobRunner, mockSubscriber);
+    auto stubAlgRef = std::static_pointer_cast<IConfiguredAlgorithm>(stubAlg);
+    jobManager.notifyAlgorithmComplete(stubAlgRef);
 
-  void test_notify_sum_banks_algorithm_complete_notifies_subscriber() {
-    AlgCompleteCallback::m_callbackWasCalled = false;
-
-    auto mockAlgFactory = std::make_unique<MockReflAlgorithmFactory>();
-    auto mockJobRunner = MockJobRunner();
-    auto mockSubscriber = MockJobManagerSubscriber();
-
-    auto row = PreviewRow({"12345"});
-    Mantid::API::IAlgorithm_sptr mockAlg = std::make_shared<StubAlgSumBanks>();
-    auto properties = std::make_unique<MantidQt::API::AlgorithmRuntimeProps>();
-    auto configuredAlg = std::make_shared<BatchJobAlgorithm>(std::move(mockAlg), std::move(properties),
-                                                             AlgCompleteCallback::updateRowOnAlgorithmComplete, &row);
-
-    EXPECT_CALL(mockSubscriber, notifySumBanksCompleted).Times(1);
-    auto jobManager = PreviewJobManager(&mockJobRunner, std::move(mockAlgFactory));
-    jobManager.subscribe(&mockSubscriber);
-
-    auto configuredAlgRef = std::static_pointer_cast<IConfiguredAlgorithm>(configuredAlg);
-    jobManager.notifyAlgorithmComplete(configuredAlgRef);
-    TS_ASSERT(AlgCompleteCallback::m_callbackWasCalled);
-  }
-
-  void test_notify_algorithm_complete_throws_with_unknown_algorithm() {
-    AlgCompleteCallback::m_callbackWasCalled = false;
-
-    auto mockAlgFactory = std::make_unique<MockReflAlgorithmFactory>();
-    auto mockJobRunner = MockJobRunner();
-    auto mockSubscriber = MockJobManagerSubscriber();
-
-    auto row = PreviewRow({"12345"});
-    Mantid::API::IAlgorithm_sptr mockAlg = std::make_shared<WorkspaceCreationHelper::StubAlgorithm>();
-    auto properties = std::make_unique<MantidQt::API::AlgorithmRuntimeProps>();
-    auto configuredAlg = std::make_shared<BatchJobAlgorithm>(std::move(mockAlg), std::move(properties),
-                                                             AlgCompleteCallback::updateRowOnAlgorithmComplete, &row);
-
-    auto jobManager = PreviewJobManager(&mockJobRunner, std::move(mockAlgFactory));
-    jobManager.subscribe(&mockSubscriber);
-
-    auto configuredAlgRef = std::static_pointer_cast<IConfiguredAlgorithm>(configuredAlg);
-    TS_ASSERT_THROWS(jobManager.notifyAlgorithmComplete(configuredAlgRef), std::logic_error const &);
+    assertUpdateItemCallbackWasCalled();
   }
 
   void test_notify_preprocessing_algorithm_complete_skips_non_preview_items() {
@@ -157,39 +86,118 @@ public:
     auto items = std::array<Item *, 2>{&row, &group};
 
     for (auto *item : items) {
-      auto mockAlgFactory = std::make_unique<MockReflAlgorithmFactory>();
       auto mockJobRunner = MockJobRunner();
       auto mockSubscriber = MockJobManagerSubscriber();
-
       auto configuredAlg = makeConfiguredAlg(*item);
 
       EXPECT_CALL(mockSubscriber, notifyLoadWorkspaceCompleted).Times(0);
 
-      auto jobManager = PreviewJobManager(&mockJobRunner, std::move(mockAlgFactory));
-      jobManager.subscribe(&mockSubscriber);
+      auto jobManager = makeJobManager(&mockJobRunner, mockSubscriber);
       auto configuredAlgRef = std::static_pointer_cast<IConfiguredAlgorithm>(configuredAlg);
       jobManager.notifyAlgorithmComplete(configuredAlgRef);
     }
   }
 
+  void test_start_sum_banks() {
+    auto mockAlgFactory = std::make_unique<MockReflAlgorithmFactory>();
+    auto mockJobRunner = MockJobRunner();
+    auto previewRow = makePreviewRow();
+    auto stubAlg = makeConfiguredAlg();
+
+    expectSumBanksAlgorithmCreated(*mockAlgFactory, previewRow, stubAlg);
+    expectAlgorithmExecuted(stubAlg, mockJobRunner);
+
+    auto jobManager = makeJobManager(&mockJobRunner, std::move(mockAlgFactory));
+    jobManager.startSumBanks(previewRow);
+  }
+
+  void test_notify_sum_banks_algorithm_complete_notifies_subscriber() {
+    auto mockJobRunner = MockJobRunner();
+    auto mockSubscriber = MockJobManagerSubscriber();
+
+    auto previewRow = makePreviewRow();
+    auto stubAlg = makeConfiguredSumBanksAlg(previewRow);
+
+    EXPECT_CALL(mockSubscriber, notifySumBanksCompleted).Times(1);
+
+    auto jobManager = makeJobManager(&mockJobRunner, mockSubscriber);
+    auto stubAlgRef = std::static_pointer_cast<IConfiguredAlgorithm>(stubAlg);
+    jobManager.notifyAlgorithmComplete(stubAlgRef);
+
+    assertUpdateItemCallbackWasCalled();
+  }
+
+  void test_notify_algorithm_complete_throws_with_unknown_algorithm() {
+    auto mockJobRunner = MockJobRunner();
+    auto mockSubscriber = MockJobManagerSubscriber();
+    auto previewRow = makePreviewRow();
+    auto configuredAlg = makeConfiguredAlg(previewRow);
+
+    auto jobManager = makeJobManager(&mockJobRunner, mockSubscriber);
+    auto configuredAlgRef = std::static_pointer_cast<IConfiguredAlgorithm>(configuredAlg);
+
+    TS_ASSERT_THROWS(jobManager.notifyAlgorithmComplete(configuredAlgRef), std::logic_error const &);
+  }
+
 private:
-  PreviewJobManager createJobManager(MockJobRunner *jobRunner, std::unique_ptr<IReflAlgorithmFactory> algFactory) {
-    return PreviewJobManager(jobRunner, std::move(algFactory));
+  class StubAlgPreprocess : public StubAlgorithm {
+  public:
+    const std::string name() const override { return "ReflectometryISISPreprocess"; }
+  };
+
+  class StubAlgSumBanks : public StubAlgorithm {
+  public:
+    const std::string name() const override { return "ReflectometryISISSumBanks"; }
+  };
+
+  PreviewJobManager
+  makeJobManager(MockJobRunner *mockJobRunner,
+                 std::unique_ptr<IReflAlgorithmFactory> algFactory = std::make_unique<MockReflAlgorithmFactory>()) {
+    EXPECT_CALL(*mockJobRunner, subscribe(NotNull())).Times(1);
+    return PreviewJobManager(mockJobRunner, std::move(algFactory));
   }
 
-  PreviewRow createPreviewRow() { return PreviewRow({"12345"}); }
+  PreviewJobManager makeJobManager(MockJobRunner *mockJobRunner, MockJobManagerSubscriber &mockSubscriber) {
+    auto jobManager = makeJobManager(mockJobRunner);
+    jobManager.subscribe(&mockSubscriber);
+    return jobManager;
+  }
 
+  PreviewRow makePreviewRow() { return PreviewRow({"12345"}); }
+
+  // Create a basic configured algorithm using a StubAlgorithm
   IConfiguredAlgorithm_sptr makeConfiguredAlg() {
-    IAlgorithm_sptr stubAlg = std::make_shared<WorkspaceCreationHelper::StubAlgorithm>();
-    auto emptyProps = std::make_unique<MantidQt::API::AlgorithmRuntimeProps>();
-    return std::make_shared<MantidQt::API::ConfiguredAlgorithm>(std::move(stubAlg), std::move(emptyProps));
+    IAlgorithm_sptr stubAlg = std::make_shared<StubAlgorithm>();
+    auto emptyProps = std::make_unique<AlgorithmRuntimeProps>();
+    return std::make_shared<ConfiguredAlgorithm>(std::move(stubAlg), std::move(emptyProps));
   }
 
-  std::shared_ptr<BatchJobAlgorithm> makeConfiguredAlg(Item &item) {
-    Mantid::API::IAlgorithm_sptr mockAlg = std::make_shared<WorkspaceCreationHelper::StubAlgorithm>();
-    auto properties = std::make_unique<MantidQt::API::AlgorithmRuntimeProps>();
-    auto configuredAlg = std::make_shared<BatchJobAlgorithm>(std::move(mockAlg), std::move(properties), nullptr, &item);
-    return configuredAlg;
+  // Create a configured batch job algorithm that has an item and callback function set up on it
+  // Uses StubAlgorithm by default, or can take an override.
+  std::shared_ptr<BatchJobAlgorithm> makeConfiguredAlg(Item &item,
+                                                       IAlgorithm_sptr mockAlg = std::make_shared<StubAlgorithm>()) {
+    AlgCompleteCallback::m_callbackWasCalled = false;
+    auto properties = std::make_unique<AlgorithmRuntimeProps>();
+    return std::make_shared<BatchJobAlgorithm>(std::move(mockAlg), std::move(properties),
+                                               AlgCompleteCallback::updateRowOnAlgorithmComplete, &item);
+  }
+
+  std::shared_ptr<ConfiguredAlgorithm> makeConfiguredPreprocessAlg(Item &item) {
+    return makeConfiguredAlg(item, std::make_shared<StubAlgPreprocess>());
+  }
+
+  std::shared_ptr<ConfiguredAlgorithm> makeConfiguredSumBanksAlg(Item &item) {
+    return makeConfiguredAlg(item, std::make_shared<StubAlgSumBanks>());
+  }
+
+  void expectPreprocessingAlgCreated(MockReflAlgorithmFactory &mockAlgFactory, PreviewRow &previewRow,
+                                     IConfiguredAlgorithm_sptr const &alg) {
+    EXPECT_CALL(mockAlgFactory, makePreprocessingAlgorithm(Eq(ByRef(previewRow)))).Times(1).WillOnce(Return(alg));
+  }
+
+  void expectSumBanksAlgorithmCreated(MockReflAlgorithmFactory &mockAlgFactory, PreviewRow &previewRow,
+                                      IConfiguredAlgorithm_sptr const &alg) {
+    EXPECT_CALL(mockAlgFactory, makeSumBanksAlgorithm(Eq(ByRef(previewRow)))).Times(1).WillOnce(Return(alg));
   }
 
   void expectAlgorithmExecuted(IConfiguredAlgorithm_sptr const &alg, MockJobRunner &mockJobRunner) {
@@ -197,4 +205,7 @@ private:
     EXPECT_CALL(mockJobRunner, setAlgorithmQueue(Eq(std::deque<IConfiguredAlgorithm_sptr>{alg}))).Times(1);
     EXPECT_CALL(mockJobRunner, executeAlgorithmQueue()).Times(1);
   }
+
+  // For a configured batch job algorithm with a callback function set on it, ensure that the callback was called
+  void assertUpdateItemCallbackWasCalled() { TS_ASSERT(AlgCompleteCallback::m_callbackWasCalled); }
 };

--- a/qt/scientific_interfaces/ISISReflectometry/test/Preview/PreviewJobManagerTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Preview/PreviewJobManagerTest.h
@@ -48,13 +48,24 @@ public:
     auto previewRow = createPreviewRow();
     auto stubAlg = makeConfiguredAlg();
     EXPECT_CALL(*mockAlgFactory, makePreprocessingAlgorithm(Eq(ByRef(previewRow)))).Times(1).WillOnce(Return(stubAlg));
-    EXPECT_CALL(mockJobRunner, clearAlgorithmQueue()).Times(1);
-    EXPECT_CALL(mockJobRunner, setAlgorithmQueue(Eq(std::deque<IConfiguredAlgorithm_sptr>{stubAlg}))).Times(1);
-    EXPECT_CALL(mockJobRunner, executeAlgorithmQueue()).Times(1);
+    expectAlgorithmExecuted(stubAlg, mockJobRunner);
 
     auto batch = MockBatch();
     auto jobManager = createJobManager(&mockJobRunner, std::move(mockAlgFactory));
     jobManager.startPreprocessing(previewRow);
+  }
+
+  void test_start_sum_banks() {
+    auto mockAlgFactory = std::make_unique<MockReflAlgorithmFactory>();
+    auto mockJobRunner = MockJobRunner();
+    auto previewRow = createPreviewRow();
+    auto stubAlg = makeConfiguredAlg();
+    EXPECT_CALL(*mockAlgFactory, makeSumBanksAlgorithm(Eq(ByRef(previewRow)))).Times(1).WillOnce(Return(stubAlg));
+    expectAlgorithmExecuted(stubAlg, mockJobRunner);
+
+    auto batch = MockBatch();
+    auto jobManager = createJobManager(&mockJobRunner, std::move(mockAlgFactory));
+    jobManager.startSumBanks(previewRow);
   }
 
   void test_subscribe_to_job_runner() {
@@ -127,5 +138,11 @@ private:
     auto properties = std::make_unique<MantidQt::API::AlgorithmRuntimeProps>();
     auto configuredAlg = std::make_shared<BatchJobAlgorithm>(std::move(mockAlg), std::move(properties), nullptr, &item);
     return configuredAlg;
+  }
+
+  void expectAlgorithmExecuted(IConfiguredAlgorithm_sptr const &alg, MockJobRunner &mockJobRunner) {
+    EXPECT_CALL(mockJobRunner, clearAlgorithmQueue()).Times(1);
+    EXPECT_CALL(mockJobRunner, setAlgorithmQueue(Eq(std::deque<IConfiguredAlgorithm_sptr>{alg}))).Times(1);
+    EXPECT_CALL(mockJobRunner, executeAlgorithmQueue()).Times(1);
   }
 };

--- a/qt/scientific_interfaces/ISISReflectometry/test/Preview/PreviewJobManagerTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Preview/PreviewJobManagerTest.h
@@ -139,6 +139,18 @@ public:
     TS_ASSERT_THROWS(jobManager.notifyAlgorithmComplete(configuredAlgRef), std::logic_error const &);
   }
 
+  void test_notify_algorithm_error_throws_with_unknown_algorithm() {
+    auto mockJobRunner = MockJobRunner();
+    auto mockSubscriber = MockJobManagerSubscriber();
+    auto previewRow = makePreviewRow();
+    auto configuredAlg = makeConfiguredAlg(previewRow);
+
+    auto jobManager = makeJobManager(&mockJobRunner, mockSubscriber);
+    auto configuredAlgRef = std::static_pointer_cast<IConfiguredAlgorithm>(configuredAlg);
+
+    TS_ASSERT_THROWS(jobManager.notifyAlgorithmError(configuredAlgRef, ""), std::logic_error const &);
+  }
+
 private:
   class StubAlgPreprocess : public StubAlgorithm {
   public:

--- a/qt/scientific_interfaces/ISISReflectometry/test/Preview/PreviewModelTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Preview/PreviewModelTest.h
@@ -64,7 +64,7 @@ public:
 
   void test_set_and_get_selected_banks() {
     PreviewModel model;
-    const std::vector<size_t> inputRoi{56, 57, 58, 59};
+    const std::vector<Mantid::detid_t> inputRoi{56, 57, 58, 59};
     model.setSelectedBanks(inputRoi);
     TS_ASSERT_EQUALS(inputRoi, model.getSelectedBanks())
   }
@@ -83,17 +83,17 @@ public:
     TS_ASSERT_EQUALS(workspace, expectedWs);
   }
 
-  void test_convert_indices_to_string() {
+  void test_convert_detIDs_to_string() {
     PreviewModel model;
-    auto const indices = std::vector<size_t>{99, 4, 5};
-    auto result = model.indicesToString(indices);
+    auto const indices = std::vector<Mantid::detid_t>{99, 4, 5};
+    auto result = model.detIDsToString(indices);
     TS_ASSERT_EQUALS(result, "99,4,5");
   }
 
-  void test_convert_empty_indices_to_string() {
+  void test_convert_empty_detIDs_to_string() {
     PreviewModel model;
-    auto const indices = std::vector<size_t>{};
-    auto result = model.indicesToString(indices);
+    auto const indices = std::vector<Mantid::detid_t>{};
+    auto result = model.detIDsToString(indices);
     TS_ASSERT_EQUALS("", result);
   }
 

--- a/qt/scientific_interfaces/ISISReflectometry/test/Preview/PreviewPresenterTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Preview/PreviewPresenterTest.h
@@ -164,12 +164,12 @@ private:
   void expectSumBanksCalledOnSelectedDetectors(MockPreviewView &mockView, MockPreviewModel &mockModel,
                                                MockInstViewModel &mockInstViewModel, MockJobManager &mockJobManager) {
     auto detIndices = std::vector<size_t>{44, 45, 46};
-    auto wsIndices = std::vector<size_t>{2, 3, 4};
-    auto wsIndicesStr = std::string{"2, 3, 4"};
+    auto detIDs = std::vector<Mantid::detid_t>{2, 3, 4};
+    auto detIDsStr = std::string{"2, 3, 4"};
     EXPECT_CALL(mockView, getSelectedDetectors()).Times(1).WillOnce(Return(detIndices));
-    EXPECT_CALL(mockInstViewModel, detIndicesToWsIndices(Eq(detIndices))).Times(1).WillOnce(Return(wsIndices));
-    EXPECT_CALL(mockModel, indicesToString(wsIndices)).Times(1).WillOnce(Return(wsIndicesStr));
-    EXPECT_CALL(mockModel, setSelectedBanks(wsIndices)).Times(1);
+    EXPECT_CALL(mockInstViewModel, detIndicesToDetIDs(Eq(detIndices))).Times(1).WillOnce(Return(detIDs));
+    EXPECT_CALL(mockModel, detIDsToString(detIDs)).Times(1).WillOnce(Return(detIDsStr));
+    EXPECT_CALL(mockModel, setSelectedBanks(detIDs)).Times(1);
     EXPECT_CALL(mockModel, sumBanksAsync(Ref(mockJobManager))).Times(1);
   }
 

--- a/qt/scientific_interfaces/ISISReflectometry/test/Preview/PreviewPresenterTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Preview/PreviewPresenterTest.h
@@ -38,7 +38,7 @@ using ::testing::ReturnRef;
 
 class PreviewPresenterTest : public CxxTest::TestSuite {
   using MockInstViewModelT = std::unique_ptr<MockInstViewModel>;
-  using MockJobManagerT = std::unique_ptr<IJobManager>;
+  using MockJobManagerT = std::unique_ptr<MockJobManager>;
   using MockModelT = std::unique_ptr<MockPreviewModel>;
   using MockViewT = std::unique_ptr<MockPreviewView>;
 
@@ -112,12 +112,12 @@ public:
     auto mockView = makeView();
     auto mockModel = makeModel();
     auto mockInstViewModel = makeInstViewModel();
+    auto mockJobManager = makeJobManager();
     expectInstViewSetToEditMode(*mockView);
-    expectSumBanksCalledOnSelectedDetectors(*mockView, *mockModel, *mockInstViewModel);
+    expectSumBanksCalledOnSelectedDetectors(*mockView, *mockModel, *mockInstViewModel, *mockJobManager);
     // TODO check that the model is called to sum banks
-    auto presenter =
-        PreviewPresenter(packDeps(mockView.get(), std::move(mockModel), std::make_unique<NiceMock<MockJobManager>>(),
-                                  std::move(mockInstViewModel)));
+    auto presenter = PreviewPresenter(
+        packDeps(mockView.get(), std::move(mockModel), std::move(mockJobManager), std::move(mockInstViewModel)));
     presenter.notifyInstViewShapeChanged();
   }
 
@@ -131,7 +131,7 @@ private:
 
   MockModelT makeModel() { return std::make_unique<MockPreviewModel>(); }
 
-  std::unique_ptr<IJobManager> makeJobManager() {
+  MockJobManagerT makeJobManager() {
     auto mockJobManager = std::make_unique<MockJobManager>();
     EXPECT_CALL(*mockJobManager, subscribe(NotNull())).Times(1);
     return mockJobManager;
@@ -162,15 +162,15 @@ private:
   }
 
   void expectSumBanksCalledOnSelectedDetectors(MockPreviewView &mockView, MockPreviewModel &mockModel,
-                                               MockInstViewModel &mockInstViewModel) {
+                                               MockInstViewModel &mockInstViewModel, MockJobManager &mockJobManager) {
     auto detIndices = std::vector<size_t>{44, 45, 46};
     auto wsIndices = std::vector<size_t>{2, 3, 4};
     auto wsIndicesStr = std::string{"2, 3, 4"};
     EXPECT_CALL(mockView, getSelectedDetectors()).Times(1).WillOnce(Return(detIndices));
     EXPECT_CALL(mockInstViewModel, detIndicesToWsIndices(Eq(detIndices))).Times(1).WillOnce(Return(wsIndices));
     EXPECT_CALL(mockModel, indicesToString(wsIndices)).Times(1).WillOnce(Return(wsIndicesStr));
-    // TODO uncomment test when sum banks is implemented
-    // EXPECT_CALL(mockModel, sumBanksAsync(wsIndicesStr)).Times(1);
+    EXPECT_CALL(mockModel, setSelectedBanks(wsIndices)).Times(1);
+    EXPECT_CALL(mockModel, sumBanksAsync(Ref(mockJobManager))).Times(1);
   }
 
   void expectPlotInstView(MockPreviewView &mockView, MockInstViewModel &mockInstViewModel) {

--- a/qt/scientific_interfaces/ISISReflectometry/test/ReflMockObjects.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/ReflMockObjects.h
@@ -291,6 +291,7 @@ public:
 class MockJobManagerSubscriber : public JobManagerSubscriber {
 public:
   MOCK_METHOD0(notifyLoadWorkspaceCompleted, void());
+  MOCK_METHOD0(notifySumBanksCompleted, void());
 };
 
 class MockEncoder : public IEncoder {

--- a/qt/scientific_interfaces/ISISReflectometry/test/ReflMockObjects.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/ReflMockObjects.h
@@ -285,6 +285,7 @@ class MockJobManager : public IJobManager {
 public:
   MOCK_METHOD1(subscribe, void(JobManagerSubscriber *notifyee));
   MOCK_METHOD1(startPreprocessing, void(PreviewRow &row));
+  MOCK_METHOD1(startSumBanks, void(PreviewRow &row));
 };
 
 class MockJobManagerSubscriber : public JobManagerSubscriber {


### PR DESCRIPTION
**Description of work.**

This PR implements summing across banks in the preview tab of the ISIS Reflectometry GUI. When the user changes the selection on the instrument view, the algorithm `ReflectometryISISSumBanks` is called with that selection and the result stored in the model. The presenter is notified when algorithm execution is completed. This is WIP so it currently does nothing further at this point other than log a debug message.

**To test:**

- Load this workspace: [INTER45455_inst.zip](https://github.com/mantidproject/mantid/files/7504266/INTER45455_inst.zip)
- Set the output level to `debug` in the log.
- Open the ISIS Reflectometry GUI
- Select the Preview tab.
- Type in `INTER45455` and click Load. The instrument viewer plot should display the data.
- Click the rectangle-select button and select a region of interest.
- Whenever the ROI is created or changed, you should see the text `Sum banks completed` in the log.

Refs #32772

*This does not require release notes* because **this is part of prototype work on a tab that is disabled in release**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
