### PR TITLE
Set EngDiff plot 25% larger when undocked

### DIFF
--- a/docs/source/release/v6.3.0/diffraction.rst
+++ b/docs/source/release/v6.3.0/diffraction.rst
@@ -30,6 +30,7 @@ Improvements
 ############
 - Improved axes scaling in the plot of the :ref:`Engineering Diffraction interface<Engineering_Diffraction-ref>` :ref:`Fitting tab <ui engineering fitting>`.
 - Automatically disable zoom and pan when opening the fit browser in the :ref:`Fitting tab <ui engineering fitting>` of the Engineering Diffraction interface (as they interfered with the interactive peak adding tool).
+- The plot on the fitting tab is now made larger when undocked, unless the size of the overall interface has been expanded significantly.
 
 Bugfixes
 ########


### PR DESCRIPTION
Set the plot in the EngDiff fitting tab to 25% larger than the initial figure 
unless the docked plot size is greater than this
and this only happens the first time the plot is undocked

**Description of work.**
When the Engineering interface is opened the size of the plot window (bottom half of the fitting tab), that the plot exists within, is recorded. When the plot is first undocked, the plot will be increased to 125% x (size of the recorded initial plot size) unless the EngDiff interface has been enlarged significantly to make the docked plot window larger!

**To test:**
- 3 different ways of undocking (double-click the top of the plot bar, click on the undock button in the corner of the plot, click on the plot bar and drag it out of the interface).
- 2 different sizes of the docked plot (Make the plot small by loading + plotting data, then opening the fitpropertybrowser, Make the plot large by making the EngDiff interface the size of your screen and closing the fitpropertybrowser)
- Try all combinations of the undocking types and different docked plot sizes above and check the undocked plot size is sensible. (Note that the undocked plot size remembers its size after it has first been undocked, so to test these different scenarios, you will need to close and reopen the EngDiff interface)

Fixes #32662 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
