### PR TITLE
Change indirect import handling

### DIFF
--- a/docs/source/release/v6.3.0/indirect_geometry.rst
+++ b/docs/source/release/v6.3.0/indirect_geometry.rst
@@ -13,6 +13,8 @@ New Features
 ------------
 
 - In Indirect Data Analysis fitting tabs a button has been added that will unify the fit range for all spectra selected.
+- The Bayes Fortran libraries can now be installed on OSX and Linux using the bayesfitting python package https://pypi.org/project/bayesfitting/0.1.0/. This can be installed with `python -m pip install bayesfitting`
+  using the Mantid Python executable.
 
 Improvements
 ------------

--- a/scripts/Inelastic/IndirectImport.py
+++ b/scripts/Inelastic/IndirectImport.py
@@ -59,14 +59,16 @@ def is_pip_version_of_libs():
     Which will import the binaries from the python path,
     most likely the site-packages folder
     """
-    # Test if one of the fortran libs is already imported
+    # Test if one of the fortran libs is importable
     name = 'Quest'
-    if name in sys.modules:
-        return True
-    elif importlib.util.find_spec(name) is not None:
-        return True
+    # Early version of library placed extensions in sitepackages, so importable through the extension name
+    if importlib.util.find_spec(name) is not None:
+        return True, ""
+    # now they are nested in mantidindirect.bayes.
+    elif importlib.util.find_spec("mantidindirect.bayes." + name) is not None:
+        return True, "mantidindirect.bayes."
     else:
-        return False
+        return False, ""
 
 
 def _lib_suffix():
@@ -82,7 +84,8 @@ def _lib_suffix():
     import QLdata_win64
     Thefore, if we are using the pip versions we don't add a suffix.
     """
-    if is_pip_version_of_libs():
+    is_pip, _ = is_pip_version_of_libs()
+    if is_pip:
         return ""
     else:
         if platform.system() == "Windows":
@@ -123,7 +126,7 @@ def is_supported_f2py_platform():
     # check if we have pip installed the fortran libraries
     # first check the numpy abi is correct
     if _numpy_abi_ver() == F2PY_MODULES_REQUIRED_C_ABI:
-        return is_pip_version_of_libs()
+        return is_pip_version_of_libs()[0]
     return False
 
 
@@ -150,9 +153,9 @@ def import_f2py(lib_base_name):
         sys.path.insert(0, directory)
         yield
         sys.path.pop(0)
-
-    lib_name = lib_base_name + _lib_suffix()
-    return __import__(lib_name)
+    _, package_base = is_pip_version_of_libs()
+    lib_name = package_base + lib_base_name + _lib_suffix()
+    return __import__(lib_name, fromlist=[None])
 
 
 def run_f2py_compatibility_test():

--- a/scripts/Inelastic/IndirectImport.py
+++ b/scripts/Inelastic/IndirectImport.py
@@ -52,9 +52,10 @@ def _os_env():
 
 def is_pip_version_of_libs():
     """
-    If we are using a pip version of the libs they are importable with:
-    import Quest
-    import QLdata
+    If we are using a pip version of the libs we can import them from the bayesfitting package
+    import bayesfitting
+    # imports bayesfitting.QLdata ect., i.e. the libraries are usable with:
+    bayesfitting.QLdata.qldata(....)
     ...
     Which will import the binaries from the python path,
     most likely the site-packages folder
@@ -65,8 +66,8 @@ def is_pip_version_of_libs():
     if importlib.util.find_spec(name) is not None:
         return True, ""
     # now they are nested in mantidindirect.bayes.
-    elif importlib.util.find_spec("mantidindirect.bayes." + name) is not None:
-        return True, "mantidindirect.bayes."
+    elif importlib.util.find_spec("bayesfitting") is not None:
+        return True, "bayesfitting."
     else:
         return False, ""
 


### PR DESCRIPTION
**Description of work.**
The package containing the fortran libs has been renamed to bayesfitting (https://pypi.org/project/bayesfitting/0.1.0/). This PR addresses this name change by adding a new route to import the fortran libs from 
<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**
You should be able to pip install bayesfitting and then use the Bayes interfaces.
1. pip install bayesfitting
2. Open mantid
3. Got to Indirect -> Bayes
4. Go to quasi tab
5. Load sample and resolution files (these should be on the system - or slack me.)
Sample: iris26176_graphite002_red.nxs
Resolution: iris26173_graphite002_res.nxs
6. Click run
7. It should work
8. Change program to stretched exponential - it should work 
It should continue working with both the windows (in tree libs) and the original mantidindirect package.

*There is no associated issue.*

*This does not require release notes* because *its an internal change*

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
