### PR TITLE
EngDiff Gui Update default Fit Table values

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/EnggEstimateFocussedBackground.py
+++ b/Framework/PythonInterface/plugins/algorithms/EnggEstimateFocussedBackground.py
@@ -35,7 +35,7 @@ class EnggEstimateFocussedBackground(PythonAlgorithm):
 
         self.declareProperty(
             name="NIterations",
-            defaultValue=40,
+            defaultValue=50,
             direction=Direction.Input,
             validator=IntBoundedValidator(lower=1),
             doc="Number of iterations of the smoothing procedure to perform. Too few iterations and the background will"
@@ -44,7 +44,7 @@ class EnggEstimateFocussedBackground(PythonAlgorithm):
 
         self.declareProperty(
             name="XWindow",
-            defaultValue=1000.0,
+            defaultValue=600.0,
             direction=Direction.Input,
             validator=FloatBoundedValidator(lower=0.0),
             doc="Extent of the convolution window in the x-axis for all spectra. A reasonable value is about 4-8 times"

--- a/docs/source/release/v6.3.0/diffraction.rst
+++ b/docs/source/release/v6.3.0/diffraction.rst
@@ -39,6 +39,7 @@ Improvements
 - Improved axes scaling in the plot of the :ref:`Engineering Diffraction interface<Engineering_Diffraction-ref>` :ref:`Fitting tab <ui engineering fitting>`.
 - Automatically disable zoom and pan when opening the fit browser in the :ref:`Fitting tab <ui engineering fitting>` of the Engineering Diffraction interface (as they interfered with the interactive peak adding tool).
 - The plot on the fitting tab is now made larger when undocked, unless the size of the overall interface has been expanded significantly.
+- Updated the default values for :ref:`EnggEstimateFocussedBackground <algm-EnggEstimateFocussedBackground>` and in the fitting tab table to Niter = 50 and XWindow = { 600 for TOF, 0.02 for dSpacing }.
 
 Bugfixes
 ########

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/data_handling/data_presenter.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/data_handling/data_presenter.py
@@ -264,7 +264,7 @@ class FittingDataPresenter(object):
             return False
         return True
 
-    def _add_row_to_table(self, ws_name, row, run_no=None, bank=None, checked=False, bgsub=False, niter=100,
+    def _add_row_to_table(self, ws_name, row, run_no=None, bank=None, checked=False, bgsub=False, niter=50,
                           xwindow=None, SG=True):
 
         words = ws_name.split("_")
@@ -272,9 +272,9 @@ class FittingDataPresenter(object):
         if not xwindow:
             ws = self.model.get_loaded_workspaces()[ws_name]
             if ws.getAxis(0).getUnit().unitID() == "TOF":
-                xwindow = 1000
+                xwindow = 600
             else:
-                xwindow = 0.05
+                xwindow = 0.02
         if run_no is not None and bank is not None:
             self.view.add_table_row(run_no, bank, checked, bgsub, niter, xwindow, SG)
         elif len(words) == 4 and words[2] == "bank":

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/data_handling/test/test_data_presenter.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/data_handling/test/test_data_presenter.py
@@ -101,8 +101,8 @@ class FittingDataPresenterTest(unittest.TestCase):
         self.presenter._on_worker_success("info")
 
         self.assertEqual(1, self.view.remove_all.call_count)
-        self.view.add_table_row.assert_any_call("bankOrRunNumber", "bankOrRunNumber", False, False, 100, 1000, True)
-        self.view.add_table_row.assert_any_call("bankOrRunNumber", "bankOrRunNumber", False, False, 100, 0.05, True)
+        self.view.add_table_row.assert_any_call("bankOrRunNumber", "bankOrRunNumber", False, False, 50, 600, True)
+        self.view.add_table_row.assert_any_call("bankOrRunNumber", "bankOrRunNumber", False, False, 50, 0.02, True)
 
     @patch(dir_path + ".data_presenter.logger")
     def test_worker_success_invalid_filename(self, mock_logger):
@@ -116,7 +116,7 @@ class FittingDataPresenterTest(unittest.TestCase):
 
         self.assertEqual(1, self.view.remove_all.call_count)
         self.assertEqual(2, self.view.add_table_row.call_count)
-        self.view.add_table_row.assert_any_call("invalid", "N/A", False, False, 100, 1000, True)
+        self.view.add_table_row.assert_any_call("invalid", "N/A", False, False, 50, 600, True)
         self.assertEqual(2, mock_logger.warning.call_count)
 
     @patch(dir_path + ".data_presenter.logger")
@@ -131,8 +131,8 @@ class FittingDataPresenterTest(unittest.TestCase):
 
         self.assertEqual(1, self.view.remove_all.call_count)
         self.assertEqual(2, self.view.add_table_row.call_count)
-        self.view.add_table_row.assert_any_call("10", "2", False, False, 100, 1000, True)
-        self.view.add_table_row.assert_any_call("20", "1", False, False, 100, 1000, True)
+        self.view.add_table_row.assert_any_call("10", "2", False, False, 50, 600, True)
+        self.view.add_table_row.assert_any_call("20", "1", False, False, 50, 600, True)
         self.assertEqual(2, mock_logger.notice.call_count)
 
     def test_remove_workspace_tracked(self):


### PR DESCRIPTION
**Description of work.**
Updated the Niter and XWindow values in the fitting table in EngDiff Gui and for the algorithm EnggEstimateFocusedBackground.

**To test:**
Essentially this should improve the initial guess for the background in the EngDiff interface.
Check the values are reasonable in an easier way by running EnggEstimateFocusedbackground on focused ENGINX data in TOF and in dSpacing(need to provide the XWIndow valu 0.02 for dSpacing data) and decide if the new default values are reasonable.

Fixes #32834

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
