### PR TITLE
Fix bug in WANDPowderReduction that resulted in zeroed output

### DIFF
--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/WANDPowderReductionTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/WANDPowderReductionTest.py
@@ -12,6 +12,9 @@ from mantid.simpleapi import (
     CloneWorkspace,
     AddSampleLog,
     GroupWorkspaces,
+    LoadInstrument,
+    CreateWorkspace,
+    mtd
 )
 from mantid.api import (
     MatrixWorkspace,
@@ -454,6 +457,37 @@ class WANDPowderReductionTest(unittest.TestCase):
 
         assert isinstance(pd_out, WorkspaceGroup)
         assert len(pd_out) == 2
+
+    def test_edge_case(self):
+        # This is to capture the case where there are identical theta
+        # values for multiple spectra which cause problems when
+        # ResampleX is run with particular Xmin and Xmax causing the
+        # output to be all zeros.
+
+        # Create more real test workspace, using same properties as
+        # HB2C_558131
+        data = np.ones((256, 1920))
+        CreateWorkspace(
+            DataX=[0, 1],
+            DataY=data,
+            DataE=np.sqrt(data),
+            UnitX='Empty',
+            YUnitLabel='Counts',
+            NSpec=1966080 // 4,
+            OutputWorkspace='tmp_ws')
+        AddSampleLog('tmp_ws', LogName='HB2C:Mot:s2.RBV', LogText='29.9774', LogType='Number Series', NumberType='Double')
+        AddSampleLog('tmp_ws', LogName='HB2C:Mot:detz.RBV', LogText='0', LogType='Number Series', NumberType='Double')
+        tmp_ws = mtd['tmp_ws']
+
+        for n in range(tmp_ws.getNumberHistograms()):
+            s = tmp_ws.getSpectrum(n)
+            for i in range(2):
+                for j in range(2):
+                    s.addDetectorID(int(n * 2 % 512 + n // (512 / 2) * 512 * 2 + j + i * 512))
+        LoadInstrument('tmp_ws', InstrumentName='WAND', RewriteSpectraMap=False)
+
+        out = WANDPowderReduction('tmp_ws', Target='Theta', XMin=29, XMax=31, NumberBins=10, NormaliseBy='None')
+        np.testing.assert_allclose(out.readY(0), [0, 0, 0, 0, 269.068237, 486.311606, 618.125152, 720.37274, 811.141863, 821.032586], rtol=5e-4)
 
 
 if __name__ == "__main__":

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/WANDPowderReductionTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/WANDPowderReductionTest.py
@@ -489,6 +489,9 @@ class WANDPowderReductionTest(unittest.TestCase):
         out = WANDPowderReduction('tmp_ws', Target='Theta', XMin=29, XMax=31, NumberBins=10, NormaliseBy='None')
         np.testing.assert_allclose(out.readY(0), [0, 0, 0, 0, 269.068237, 486.311606, 618.125152, 720.37274, 811.141863, 821.032586], rtol=5e-4)
 
+        tmp_ws.delete()
+        out.delete()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/docs/source/release/v6.3.0/diffraction.rst
+++ b/docs/source/release/v6.3.0/diffraction.rst
@@ -22,6 +22,7 @@ Bugfixes
 ########
 - For processing vanadium run, we don't want to find environment automatically in :ref:`SetSampleFromLogs <algm-SetSampleFromLogs>`.
 - Identification in :ref:`AlignComponents <algm-AlignComponents>` of the first and last detector-ID for an instrument component with unsorted detector-ID's.
+- Fix issue in :ref:`WANDPowderReduction <algm-WANDPowderReduction>` where in some cases you end up with zeros as output.
 
 Engineering Diffraction
 -----------------------


### PR DESCRIPTION
**Description of work.**

There was an issues if you had identical x-values after `Transpose` going to `ResampleX` where the output is just `0`. This groups spectra with the same "x-values" before `Transpose`.


**To test:**

Previously running this code would results in empty output for the `2nd` workspace.

```
LoadWAND(IPTS=23858, RunNumbers=558129, ApplyMask=True, Grouping='2x2', OutputWorkspace='vana')
LoadWAND(IPTS=27692, RunNumbers=558130, ApplyMask=True, Grouping='2x2', OutputWorkspace='1st')
LoadWAND(IPTS=27692, RunNumbers=558131, ApplyMask=True, Grouping='2x2', OutputWorkspace='2nd')

reduced = WANDPowderReduction(InputWorkspace='1st, 2nd', CalibrationWorkspace='vana', NumberBins=1500 , Target='Theta')
```


Fixes [PD359](https://code.ornl.gov/sns-hfir-scse/diffraction/powder/powder-diffraction/-/issues/359)


<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
