### PR TITLE
Source occt from conda-forge in environment files

### DIFF
--- a/mantid-developer-linux.yml
+++ b/mantid-developer-linux.yml
@@ -2,7 +2,6 @@ name: mantid-developer
 
 channels:
   - conda-forge
-  - DLR-SC # Required for OpenCascade
 
 dependencies:
   # Common packages
@@ -23,7 +22,7 @@ dependencies:
   - nexus=4.4.*
   - ninja>=1.10.2
   - numpy>=1.20.2
-  - opencascade>=7.4.0
+  - occt>=7.4.0
   - pip>=21.0.1
   - poco=1.10.*
   - psutil>=5.8.0

--- a/mantid-developer-osx.yml
+++ b/mantid-developer-osx.yml
@@ -2,7 +2,6 @@ name: mantid-developer
 
 channels:
   - conda-forge
-  - DLR-SC # Required for OpenCascade
 
 dependencies:
   - boost=1.75.* # Also pulls in boost-cpp
@@ -22,7 +21,7 @@ dependencies:
   - nexus=4.4.*
   - ninja>=1.10.2
   - numpy>=1.20.2
-  - opencascade>=7.4.0
+  - occt
   - pip>=21.0.1
   - poco=1.10.*
   - psutil>=5.8.0

--- a/mantid-developer-win.yml
+++ b/mantid-developer-win.yml
@@ -2,7 +2,6 @@ name: mantid-developer
 
 channels:
   - conda-forge
-  - DLR-SC # Required for OpenCascade
 
 dependencies:
   - boost=1.75.* # Also pulls in boost-cpp
@@ -22,7 +21,7 @@ dependencies:
   - nexus=4.4.*
   - ninja>=1.10.2
   - numpy>=1.20.2
-  - opencascade>=7.4.0
+  - occt>=7.4.0
   - conda-wrappers
   - pip>=21.0.1
   - poco=1.10.*


### PR DESCRIPTION
**Description of work.**
Previously we were getting open cascade from a separate conda channel. We can instead get it from conda-forge using the occt package
<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**
It should just work. But you could also test you can suitably create an environment. 
<!-- Instructions for testing. -->


*This does not require release notes* because it's an internal change. 

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
