### PR TITLE
Added isGroup to the python interface for ws's

### DIFF
--- a/Framework/PythonInterface/mantid/api/src/Exports/Workspace.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/Workspace.cpp
@@ -50,6 +50,7 @@ void export_Workspace() {
   class_<Workspace, bases<DataItem>, boost::noncopyable>("Workspace", no_init)
       .def("getName", &getName, arg("self"), "Returns the name of the workspace. This could be an empty string")
       .def("getTitle", &Workspace::getTitle, arg("self"), "Returns the title of the workspace")
+      .def("isGroup", &Workspace::isGroup, arg("self"), "Returns if it is a group workspace")
       .def("setTitle", &Workspace::setTitle, (arg("self"), arg("title")), "Set the title of the workspace")
       .def("getComment", &Workspace::getComment, arg("self"), return_value_policy<copy_const_reference>(),
            "Returns the comment field on the workspace")

--- a/Framework/PythonInterface/test/python/mantid/api/ITableWorkspaceTest.py
+++ b/Framework/PythonInterface/test/python/mantid/api/ITableWorkspaceTest.py
@@ -28,6 +28,7 @@ class ITableWorkspaceTest(unittest.TestCase):
     def test_meta_information_is_correct(self):
         self.assertEqual(self._test_ws.columnCount(), 19)
         self.assertEqual(self._test_ws.rowCount(), 1)
+        self.assertEqual(self._test_ws.isGroup(), False)
 
         column_names = self._test_ws.getColumnNames()
         self.assertEqual(len(column_names), 19)

--- a/Framework/PythonInterface/test/python/mantid/api/MatrixWorkspaceTest.py
+++ b/Framework/PythonInterface/test/python/mantid/api/MatrixWorkspaceTest.py
@@ -40,6 +40,7 @@ class MatrixWorkspaceTest(unittest.TestCase):
         self.assertEqual(self._test_ws.isDirty(), False)
         self.assertGreater(self._test_ws.getMemorySize(), 0.0)
         self.assertEqual(self._test_ws.threadSafe(), True)
+        self.assertEqual(self._test_ws.isGroup(), False)
 
     def test_workspace_data_information(self):
         self.assertEqual(self._test_ws.getNumberHistograms(), 2)

--- a/Framework/PythonInterface/test/python/mantid/api/WorkspaceGroupTest.py
+++ b/Framework/PythonInterface/test/python/mantid/api/WorkspaceGroupTest.py
@@ -190,6 +190,10 @@ class WorkspaceGroupTest(unittest.TestCase):
         with self.assertRaises(IndexError):
             group.getItem(-400)
 
+    def test_isGroup(self):
+        group = self.create_group_via_GroupWorkspace_algorithm()
+        self.assertEqual(group.isGroup(), True)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/docs/source/release/v6.3.0/framework.rst
+++ b/docs/source/release/v6.3.0/framework.rst
@@ -48,7 +48,7 @@ Data Objects
 Python
 ------
 
-- `isGroup` can not be used to determine if a workspace/table workspace is a grouped workspace object.
+- `isGroup` can now be used to determine if a workspace/table workspace is a grouped workspace object.
 - `createChildAlgorithm` now accepts property keyword arguments to set the child algorithm's properties during creation:
 
   -  Existing arguments, such as version, start and end progress...etc. are unaffected by this change.

--- a/docs/source/release/v6.3.0/framework.rst
+++ b/docs/source/release/v6.3.0/framework.rst
@@ -48,6 +48,7 @@ Data Objects
 Python
 ------
 
+- `isGroup` can not be used to determine if a workspace/table workspace is a grouped workspace object.
 - `createChildAlgorithm` now accepts property keyword arguments to set the child algorithm's properties during creation:
 
   -  Existing arguments, such as version, start and end progress...etc. are unaffected by this change.


### PR DESCRIPTION
**Description of work.**

I wanted to expose the `isGroup` method to Python so we can easily test if an object from the ADS is a group workspace or not. 

**To test:**

<!-- Instructions for testing. -->
Run the below script
```
# import mantid algorithms, numpy and matplotlib
from mantid.simpleapi import *
import matplotlib.pyplot as plt
import numpy as np

table1 = CreateEmptyTableWorkspace()
table2 = CreateEmptyTableWorkspace()

x = np.linspace(0,100,1000)
y = np.sin(x)

for j in range(20):
    CreateWorkspace(x,y,OutputWorkspace=str(j))
    
GroupWorkspaces(["1", "3", "5", "7", "9", "11", "13", "15", "17", "19"], OutputWorkspace="odds")
GroupWorkspaces(["2", "4", "table1"], OutputWorkspace="mixed")


str_names = AnalysisDataService.getObjectNames()
everything = AnalysisDataService.retrieveWorkspaces(str_names)

for item in everything:
    print(item.name(), item.isGroup())
```

only the odds and mixed should give true

*There is no associated issue.*


<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
