### PR TITLE
Autoscale colorfill from figure options bug

### DIFF
--- a/Framework/PythonInterface/mantid/plots/axesfunctions.py
+++ b/Framework/PythonInterface/mantid/plots/axesfunctions.py
@@ -815,11 +815,12 @@ def tricontourf(axes, workspace, *args, **kwargs):
     return axes.tricontourf(x, y, z, *args, **kwargs)
 
 
-def update_colorplot_datalimits(axes, mappables):
+def update_colorplot_datalimits(axes, mappables, axis='both'):
     """
-    For an colorplot (imshow, pcolor*) plots update the data limits on the axes
+    For a colorplot (imshow, pcolor*) plots update the data limits on the axes
     to circumvent bugs in matplotlib
     :param mappables: An iterable of mappable for this axes
+    :param axis: {'both', 'x', 'y'} which axis to operate on.
     """
     # ax.relim in matplotlib < 2.2 doesn't take into account of images
     # and it doesn't support collections at all as of verison 3 so we'll take
@@ -831,11 +832,14 @@ def update_colorplot_datalimits(axes, mappables):
         xmin, xmax, ymin, ymax = get_colorplot_extents(mappable)
         xmin_all, xmax_all = min(xmin_all, xmin), max(xmax_all, xmax)
         ymin_all, ymax_all = min(ymin_all, ymin), max(ymax_all, ymax)
-    axes.update_datalim(((xmin_all, ymin_all), (xmax_all, ymax_all)))
-    axes.autoscale()
-    if axes._autoscaleXon:
+
+    update_x = axis in ['x', 'both']
+    update_y = axis in ['y', 'both']
+    axes.update_datalim(((xmin_all, ymin_all), (xmax_all, ymax_all)), update_x, update_y)
+    axes.autoscale(axis=axis)
+    if axes.get_autoscalex_on():
         axes.set_xlim((xmin_all, xmax_all), auto=None)
-    if axes._autoscaleYon:
+    if axes.get_autoscaley_on():
         axes.set_ylim((ymin_all, ymax_all), auto=None)
 
 

--- a/Framework/PythonInterface/test/python/mantid/plots/axesfunctionsTest.py
+++ b/Framework/PythonInterface/test/python/mantid/plots/axesfunctionsTest.py
@@ -12,6 +12,7 @@ matplotlib.use('AGG')  # noqa
 import matplotlib.pyplot as plt
 import numpy as np
 
+from unittest import mock
 import mantid.api
 import mantid.plots.axesfunctions as funcs
 from mantid.plots.utility import MantidAxType
@@ -189,6 +190,27 @@ class PlotFunctionsTest(unittest.TestCase):
 
     def test_update_colorplot_datalimits_for_imshow(self):
         self._do_update_colorplot_datalimits(funcs.imshow)
+
+    def test_update_colorplot_datalimits_for_x_axis(self):
+        """Check that the function is only operating on the x-axis"""
+        ax_mock = mock.MagicMock()
+        funcs.update_colorplot_datalimits(ax_mock, ax_mock.images, 'x')
+        ax_mock.update_datalim.assert_called_once_with(mock.ANY, True, False)
+        ax_mock.autoscale.assert_called_once_with(axis='x')
+
+    def test_update_colorplot_datalimits_for_y_axis(self):
+        """Check that the function is only operating on y-axis"""
+        ax_mock = mock.MagicMock()
+        funcs.update_colorplot_datalimits(ax_mock, ax_mock.images, 'y')
+        ax_mock.update_datalim.assert_called_once_with(mock.ANY, False, True)
+        ax_mock.autoscale.assert_called_once_with(axis='y')
+
+    def test_update_colorplot_datalimits_for_both_axis(self):
+        """Check that the function is only operating on y-axis"""
+        ax_mock = mock.MagicMock()
+        funcs.update_colorplot_datalimits(ax_mock, ax_mock.images, 'both')
+        ax_mock.update_datalim.assert_called_once_with(mock.ANY, True, True)
+        ax_mock.autoscale.assert_called_once_with(axis='both')
 
     def test_1d_plots_with_unplottable_type_raises_attributeerror(self):
         table = CreateEmptyTableWorkspace()

--- a/docs/source/release/v6.3.0/mantidworkbench.rst
+++ b/docs/source/release/v6.3.0/mantidworkbench.rst
@@ -26,5 +26,6 @@ Bugfixes
 - Fixed issue in DrILL when ASCII output was requested but the logs to save were not defined for that instrument.
 - Fixed a bug where copying data from a table displaying a matrix workspace was not working.
 - Fixed plot bins not working on data with numeric X-axis.
+- Fixed a bug with autoscaling of colorfill plots from within the figure options.
 
 :ref:`Release 6.3.0 <v6.3.0>`

--- a/qt/python/mantidqt/mantidqt/widgets/plotconfigdialog/axestabwidget/presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/plotconfigdialog/axestabwidget/presenter.py
@@ -54,10 +54,22 @@ class AxesTabWidgetPresenter:
         """Update the axes with the user inputted properties"""
         # Make sure current_view_props is up to date if values have been changed
         self.axis_changed()
-
         ax = self.get_selected_ax()
-
         self.set_ax_title(ax, self.current_view_props['title'])
+        self._apply_properties_to_axes(ax)
+        self.update_view()
+
+    def apply_all_properties(self):
+        """Update the axes with the user inputted properties"""
+        # Make sure current_view_props is up to date if values have been changed
+        self.axis_changed()
+        for ax in self.axes_names_dict.values():
+            self._apply_properties_to_axes(ax)
+            ax.figure.canvas.draw()
+        self.update_view()
+
+    def _apply_properties_to_axes(self, ax):
+        """Apply current properties to given set of axes"""
         self.set_ax_canvas_color(ax, self.current_view_props['canvas_color'])
 
         if not isinstance(ax, Axes3D):
@@ -110,69 +122,6 @@ class AxesTabWidgetPresenter:
                 ax.autoscale(True, axis="z")
             else:
                 ax.set_zlim3d(self.current_view_props['zlim'])
-
-        self.update_view()
-
-    def apply_all_properties(self):
-        """Update the axes with the user inputted properties"""
-        # Make sure current_view_props is up to date if values have been changed
-        self.axis_changed()
-        view_props = self.current_view_props
-        for ax in self.axes_names_dict.values():
-
-            self.set_ax_canvas_color(ax, view_props['canvas_color'])
-
-            if self.current_view_props['minor_ticks']:
-                ax.minorticks_on()
-            else:
-                ax.minorticks_off()
-
-            ax.show_minor_gridlines = self.current_view_props['minor_gridlines']
-
-            # If the grid is enabled update it
-            if ax.show_minor_gridlines:
-                if ax.xaxis._gridOnMajor and ax.yaxis._gridOnMajor:
-                    ax.grid(True, which='minor')
-                elif ax.xaxis._gridOnMajor:
-                    ax.grid(True, axis='x', which='minor')
-                elif ax.yaxis._gridOnMajor:
-                    ax.grid(True, axis='y', which='minor')
-            else:
-                ax.grid(False, which='minor')
-
-            if "xlabel" in view_props:
-                ax.set_xlabel(view_props['xlabel'])
-                ax.set_xscale(view_props['xscale'])
-
-                if self.current_view_props['xautoscale']:
-                    ax.autoscale(True, axis="x")
-                else:
-                    if isinstance(ax, Axes3D):
-                        ax.set_xlim3d(view_props['xlim'])
-                    else:
-                        ax.set_xlim(view_props['xlim'])
-
-            if "ylabel" in view_props:
-                ax.set_ylabel(view_props['ylabel'])
-                ax.set_yscale(view_props['yscale'])
-
-                if self.current_view_props['yautoscale']:
-                    ax.autoscale(True, axis="y")
-                else:
-                    if isinstance(ax, Axes3D):
-                        ax.set_ylim3d(view_props['ylim'])
-                    else:
-                        ax.set_ylim(view_props['ylim'])
-
-            if isinstance(ax, Axes3D) and "zlabel" in view_props:
-                ax.set_zlabel(view_props['zlabel'])
-                ax.set_zscale(view_props['zscale'])
-                if self.current_view_props['zautoscale']:
-                    ax.autoscale(True, axis="z")
-                else:
-                    ax.set_zlim3d(view_props['zlim'])
-            ax.figure.canvas.draw()
-        self.update_view()
 
     def get_selected_ax(self):
         """Get Axes object of selected axes"""

--- a/qt/python/mantidqt/mantidqt/widgets/plotconfigdialog/axestabwidget/presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/plotconfigdialog/axestabwidget/presenter.py
@@ -8,7 +8,7 @@
 
 from mpl_toolkits.mplot3d.axes3d import Axes3D
 
-from mantid.plots import convert_color_to_hex
+from mantid.plots import convert_color_to_hex, axesfunctions
 from mantidqt.widgets.plotconfigdialog import generate_ax_name, get_axes_names_dict
 from mantidqt.widgets.plotconfigdialog.axestabwidget import AxProperties
 from mantidqt.widgets.plotconfigdialog.axestabwidget.view import AxesTabWidgetView
@@ -96,7 +96,10 @@ class AxesTabWidgetPresenter:
             ax.set_xscale(self.current_view_props['xscale'])
 
             if self.current_view_props['xautoscale']:
-                ax.autoscale(True, axis="x")
+                if ax.images:
+                    axesfunctions.update_colorplot_datalimits(ax, ax.images, axis='x')
+                else:
+                    ax.autoscale(True, axis="x")
             else:
                 if isinstance(ax, Axes3D):
                     ax.set_xlim3d(self.current_view_props['xlim'])
@@ -108,7 +111,10 @@ class AxesTabWidgetPresenter:
             ax.set_yscale(self.current_view_props['yscale'])
 
             if self.current_view_props['yautoscale']:
-                ax.autoscale(True, axis="y")
+                if ax.images:
+                    axesfunctions.update_colorplot_datalimits(ax, ax.images, axis='y')
+                else:
+                    ax.autoscale(True, axis="y")
             else:
                 if isinstance(ax, Axes3D):
                     ax.set_ylim3d(self.current_view_props['ylim'])

--- a/qt/python/mantidqt/mantidqt/widgets/plotconfigdialog/axestabwidget/test/test_axestabwidgetpresenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/plotconfigdialog/axestabwidget/test/test_axestabwidgetpresenter.py
@@ -82,7 +82,7 @@ class AxesTabWidgetPresenterTest(unittest.TestCase):
                         presenter.current_view_props.canvas_color)
 
     def test_apply_properties_calls_setters_with_correct_properties_autoscale(self):
-        ax_mock = mock.MagicMock()
+        ax_mock = mock.MagicMock(images=None)
         ax_mock.get_autoscalex_on = mock.Mock(return_value=True)
         ax_mock.get_autoscaley_on = mock.Mock(return_value=True)
         presenter = self._generate_presenter()
@@ -145,8 +145,8 @@ class AxesTabWidgetPresenterTest(unittest.TestCase):
                             presenter.current_view_props.canvas_color)
 
     def test_apply_all_properties_calls_setters_with_correct_properties_autoscale(self):
-        ax_mock_1 = mock.MagicMock()
-        ax_mock_2 = mock.MagicMock()
+        ax_mock_1 = mock.MagicMock(images=None)
+        ax_mock_2 = mock.MagicMock(images=None)
         ax_mock_1.get_autoscalex_on = mock.Mock(return_value=True)
         ax_mock_1.get_autoscaley_on = mock.Mock(return_value=True)
         presenter = self._generate_presenter()

--- a/qt/python/mantidqt/mantidqt/widgets/plotconfigdialog/axestabwidget/test/test_axestabwidgetpresenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/plotconfigdialog/axestabwidget/test/test_axestabwidgetpresenter.py
@@ -81,7 +81,8 @@ class AxesTabWidgetPresenterTest(unittest.TestCase):
                     ax_mock.set_facecolor.assert_called_once_with(
                         presenter.current_view_props.canvas_color)
 
-    def test_apply_properties_calls_setters_with_correct_properties_autoscale(self):
+    @mock.patch('mantid.plots.axesfunctions.update_colorplot_datalimits')
+    def test_apply_properties_calls_setters_with_correct_properties_autoscale(self, mock_colorplot_autoscale):
         ax_mock = mock.MagicMock(images=None)
         ax_mock.get_autoscalex_on = mock.Mock(return_value=True)
         ax_mock.get_autoscaley_on = mock.Mock(return_value=True)
@@ -112,6 +113,8 @@ class AxesTabWidgetPresenterTest(unittest.TestCase):
                         presenter.current_view_props.canvas_color)
                     ax_mock.set_xlim.assert_not_called()
                     ax_mock.set_ylim.assert_not_called()
+                    # update_colorplot_datalimits shouldn't be called for this axes
+                    mock_colorplot_autoscale.assert_not_called()
 
     def test_apply_all_properties_calls_setters_with_correct_properties(self):
         ax_mock_1 = mock.MagicMock()
@@ -176,6 +179,25 @@ class AxesTabWidgetPresenterTest(unittest.TestCase):
                             presenter.current_view_props.canvas_color)
                         ax_mock.set_xlim.assert_not_called()
                         ax_mock.set_ylim.assert_not_called()
+
+    @mock.patch('mantid.plots.axesfunctions.update_colorplot_datalimits')
+    def test_apply_calls_correct_autoscale_for_colorfill_plot(self, mock_colorplot_autoscale):
+        """Check that the correct autoscaling function is called for a colorfill plot"""
+        # Set images to True to simulate a colorfill plot.
+        ax_mock = mock.MagicMock(images=True)
+        ax_mock.get_autoscalex_on = mock.Mock(return_value=True)
+        ax_mock.get_autoscaley_on = mock.Mock(return_value=True)
+        presenter = self._generate_presenter()
+        with mock.patch.object(presenter, 'get_selected_ax', lambda: ax_mock):
+            with mock.patch.object(presenter, 'update_view', lambda: None):
+                with mock.patch.object(presenter, 'axis_changed', lambda: None):
+                    presenter.current_view_props = presenter.get_selected_ax_properties()
+                    presenter.apply_properties()
+                    # update_colorplot_datalimits() should be called once for each axis (x and y)
+                    self.assertEqual(2, mock_colorplot_autoscale.call_count)
+                    x_call = mock.call(ax_mock, ax_mock.images, axis='x')
+                    y_call = mock.call(ax_mock, ax_mock.images, axis='y')
+                    mock_colorplot_autoscale.assert_has_calls([x_call, y_call])
 
     def test_get_axes_names_dict(self):
         actual_dict = get_axes_names_dict(self.fig)

--- a/qt/python/mantidqt/mantidqt/widgets/plotconfigdialog/axestabwidget/view.py
+++ b/qt/python/mantidqt/mantidqt/widgets/plotconfigdialog/axestabwidget/view.py
@@ -32,8 +32,8 @@ class AxesTabWidgetView(QWidget):
         # QTabWidget not suitable because we reuse controls for each axis
         self.axis_tab_bar = QTabBar(parent=self)
         self.x_tab = self.axis_tab_bar.addTab("x")
-        self.x_tab = self.axis_tab_bar.addTab("y")
-        self.x_tab = self.axis_tab_bar.addTab("z")
+        self.y_tab = self.axis_tab_bar.addTab("y")
+        self.z_tab = self.axis_tab_bar.addTab("z")
         self.axis_tab_bar_layout.replaceWidget(self.dummy_axis_tab_bar, self.axis_tab_bar)
 
         self.lower_limit_validator = LineEditDoubleValidator(self.lower_limit_line_edit, 0.0)


### PR DESCRIPTION
**Description of work.**
Fixes a bug where autoscaling from the figure options wasn't working properly for colorfill plots.

**To test:**
1. Load some data
2. Open a colorfill plot by right clicking the workspace and selecting `Plot > Colorfill`
3. zoom out of the plot by using the scroll wheel
4. Open the figure options and check the `Auto scale` box in the `Limits` groupbox of the `Axes` tab.
5. Click "Apply" and the axis limits should reset to fit the data on the plot.
6. Do the same for both the x- and y-axis

Repeat the above but with "Apply to all" instead of "Apply". It should do the same thing.

Fixes #32675

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
