### PR TITLE
Stop algorithms hanging when workbench is closed

### DIFF
--- a/docs/source/release/v6.3.0/mantidworkbench.rst
+++ b/docs/source/release/v6.3.0/mantidworkbench.rst
@@ -35,6 +35,7 @@ Bugfixes
 - Fixed plot bins not working on data with numeric X-axis.
 - Fixed a bug with autoscaling of colorfill plots from within the figure options.
 - Fixed an issue to plot negative values with logarithm scaling in slice view.
+- Workbench will no longer hang if an algorithm was running when workbench was closed.
 
 
 :ref:`Release 6.3.0 <v6.3.0>`

--- a/qt/applications/workbench/workbench/app/mainwindow.py
+++ b/qt/applications/workbench/workbench/app/mainwindow.py
@@ -13,7 +13,7 @@ Defines the QMainWindow of the application and the main() entry point.
 import builtins
 import os
 
-from mantid.api import FrameworkManager
+from mantid.api import FrameworkManager, AlgorithmManager
 from mantid.kernel import ConfigService, logger
 from workbench.config import SAVE_STATE_VERSION
 from workbench.app import MAIN_WINDOW_OBJECT_NAME, MAIN_WINDOW_TITLE
@@ -587,6 +587,9 @@ class MainWindow(QMainWindow):
             # We don't want this at module scope here
             import matplotlib.pyplot as plt  # noqa
             plt.close('all')
+
+            # Cancel all running (managed) algorithms
+            AlgorithmManager.Instance().cancelAll()
 
             app = QApplication.instance()
             if app is not None:


### PR DESCRIPTION
**Description of work.**
Running algorithms from scripts or some GUIs could sometimes result in them hanging due to deadlocks.

C++ GUIs tended to segfault instead.

This simply attempts to cancel all running (managed) algortihs, which - at the very least - significantly reduces the chance that an algorithm will get stuck and keep the workbench process running until it is manually killed.

**To test:**
Scripts:
1. Run a script that takes a long time, such as:
```
from mantid.simpleapi import *
import matplotlib.pyplot as plt
from matplotlib.colors import LogNorm

data = Load('CNCS_7860')
data = ConvertUnits(InputWorkspace=data,Target='DeltaE', EMode='Direct', EFixed=3)
data = Rebin(InputWorkspace=data, Params='-3,0.025,3', PreserveEvents=False)
md = ConvertToMD(InputWorkspace=data,QDimensions='|Q|',dEAnalysisMode='Direct')
sqw = BinMD(InputWorkspace=md,AlignedDim0='|Q|,0,3,100',AlignedDim1='DeltaE,-3,3,100')

fig, ax = plt.subplots(subplot_kw={'projection':'mantid'})
c = ax.pcolormesh(sqw, cmap='plasma', norm=LogNorm())
cbar=fig.colorbar(c)
cbar.set_label('Intensity (arb. units)') #add text to colorbar
```
2. Close workbench while the script is running
3. Observe the terminal, it may run for a while but should eventually close. It should not ever hang. It may also segfault, but it's better than just hiding in the background forever. 
 
GUIs:
1. Start up a python interface (Eng Diff given as an example)
2. Do something that takes a while (load a calib and focus these)
```
# Calibration
/archive/ndxenginx/Instrument/data/cycle_19_1/ENGINX00305738.nxs
/archive/ndxenginx/Instrument/data/cycle_12_4/ENGINX00193749.nxs
# Sample Run
/archive/ndxenginx/Instrument/data/cycle_19_1/ENGINX00305761.nxs
# Vanadium
/archive/ndxenginx/Instrument/data/cycle_19_1/ENGINX00307521.nxs
/archive/ndxenginx/Instrument/data/cycle_14_3/ENGINX00236516.nxs
```
3. While the focus is running, close workbench
4. The algorithms may run for a while but should eventually end

Fixes #32867 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
