### PR TITLE
Replace logging to file with in-memory buffer

### DIFF
--- a/Framework/PythonInterface/test/python/mantid/utils/CMakeLists.txt
+++ b/Framework/PythonInterface/test/python/mantid/utils/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 add_subdirectory(nomad)
 
-set(TEST_PY_FILES absorptioncorrutilsTest.py dgsTest.py)
+set(TEST_PY_FILES absorptioncorrutilsTest.py deprecatorTest.py dgsTest.py loggingTest.py pathTest.py)
 
 check_tests_valid(${CMAKE_CURRENT_SOURCE_DIR} ${TEST_PY_FILES})
 

--- a/Framework/PythonInterface/test/python/mantid/utils/loggingTest.py
+++ b/Framework/PythonInterface/test/python/mantid/utils/loggingTest.py
@@ -7,7 +7,7 @@
 
 # package imports
 from mantid.kernel import ConfigService, logger
-from mantid.utils.logging import to_file
+from mantid.utils.logging import capture_logs
 
 # standard imports
 from pathlib import Path
@@ -16,27 +16,23 @@ import unittest
 
 
 class loggingTest(unittest.TestCase):
+    def test_capture_logs(self):
 
-    def test_to_file(self):
-
-        with to_file() as log_file:
+        with capture_logs() as logs:
             logger.error('Error message')
-            self.assertTrue('Error message' in open(log_file, 'r').read())
-        self.assertFalse(Path(log_file).exists())
-
-        with to_file(filename='my_one_and_only_one_log_file.log') as log_file:
-            logger.error('Error message')
-            self.assertTrue('Error message' in open(log_file, 'r').read())
-        self.assertTrue(Path(log_file).exists())
-        os.remove(log_file)
+            self.assertTrue('Error message' in logs.getvalue())
 
         config = ConfigService.Instance()
         config['logging.loggers.root.level'] = 'information'
-        with to_file(level='error') as log_file:
+        with capture_logs(level='error') as logs:
             self.assertTrue(config['logging.loggers.root.level'] == 'error')
             logger.error('Error-message')
             logger.debug('Debug-message')
-            self.assertTrue('Error-message' in open(log_file, 'r').read())
-            self.assertFalse('Debug-message' in open(log_file, 'r').read())
-        self.assertFalse(Path(log_file).exists())
+            self.assertTrue('Error-message' in logs.getvalue())
+            self.assertFalse('Debug-message' in logs.getvalue())
+
         self.assertTrue(config['logging.loggers.root.level'] == 'information')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/Testing/SystemTests/tests/framework/AlignComponentsTest.py
+++ b/Testing/SystemTests/tests/framework/AlignComponentsTest.py
@@ -6,7 +6,7 @@
 
 # package imports
 from mantid.simpleapi import AlignComponents, DeleteWorkspaces, LoadAscii, LoadEmptyInstrument
-from mantid.utils.logging import to_file
+from mantid.utils.logging import capture_logs
 
 # standard imports
 from systemtesting import MantidSystemTest
@@ -30,7 +30,7 @@ class DetectorIDTest(MantidSystemTest):
                   Unit='Dimensionless', OutputWorkspace=prefix + 'peak_centers')
         LoadEmptyInstrument(InstrumentName='SNAP', OutputWorkspace=prefix + 'snap')
 
-        with to_file(level='debug') as log_file:
+        with capture_logs(level='debug') as logs:
             AlignComponents(PeakCentersTofTable=prefix + 'peak_centers',
                             PeakPositions='1.3143, 1.3854,1.6967, 1.8587, 2.0781',
                             AdjustmentsTable=prefix + 'adjustments',
@@ -41,7 +41,7 @@ class DetectorIDTest(MantidSystemTest):
                             ComponentList='Column1',
                             XPosition=False, YPosition=False, ZPosition=True,
                             AlphaRotation=False, BetaRotation=False, GammaRotation=False)
-            assert 'First and last detectorID for Column1 are 0, 196607' in open(log_file, 'r').read()
+            assert 'First and last detectorID for Column1 are 0, 196607' in logs.getvalue()
 
         # Clean up workspaces
         temporary = ['peak_centers', 'snap', 'adjustments', 'displacements', 'snap_modified']


### PR DESCRIPTION
**Description of work.**

On Windows a file cannot deleted if a file
handle to it is still open. Instead we use a
temporary in-memory string buffer to capture
the log messages and read from this.

An error related to this appeared in a [system test](https://builds.mantidproject.org/view/Main%20Pipeline/job/main_systemtests-windows/1430/testReport/junit/SystemTests/AlignComponentsTest/DetectorIDTest/) recently.

Note that the unit test `loggingTest.py` was actually not running as it had not been added to the `CMakeLists.txt`. This has been fixed here.

**To test:**

* Code review
* Check tests pass

*There is no associated issue.*

<!-- delete this if you added release notes
*This does not require release notes* because **it is an internal change**
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
