### PR TITLE
32703 muon GUI to do async threads

### DIFF
--- a/docs/source/release/v6.3.0/muon.rst
+++ b/docs/source/release/v6.3.0/muon.rst
@@ -42,6 +42,7 @@ Improvements
 
 - The `alpha` values on grouping tab are now to six decimal places.
 - The numerical values in the `run info` box on the home tab are now rounded to either 4 significant figures or a whole number, whichever is more precise.
+- Changes have been made to improve the speed of Muon Analysis and Frequency Domain Analysis
 
 Bugfixes
 ########

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/load_file_widget/model.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/load_file_widget/model.py
@@ -32,10 +32,6 @@ class BrowseFileWidgetModel(object):
         return self._loaded_data_store.get_parameter("run")
 
     # Used with load thread
-    def output(self):
-        pass
-
-    # Used with load thread
     def cancel(self):
         pass
 

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/load_file_widget/presenter.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/load_file_widget/presenter.py
@@ -124,7 +124,6 @@ class BrowseFileWidgetPresenter(object):
         self._view.warning_popup(message)
 
     def handle_load_thread_finished(self):
-        self._load_thread.deleteLater()
         self._load_thread = None
 
         if not self.thread_success:

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/load_run_widget/load_run_model.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/load_run_widget/load_run_model.py
@@ -43,10 +43,6 @@ class LoadRunWidgetModel(object):
                       "\n - The file was not found locally (please check the user directories)."
             raise ValueError(message)
 
-    # This is needed to work with thread model
-    def output(self):
-        pass
-
     def cancel(self):
         pass
 

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/phase_table_widget/phase_table_presenter.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/phase_table_widget/phase_table_presenter.py
@@ -109,7 +109,7 @@ class PhaseTablePresenter(object):
     def handle_thread_calculation_error(self, error):
         """Generic handling of error from calculation threads"""
         self.enable_editing_notifier.notify_subscribers()
-        self.view.warning_popup(error)
+        self.view.warning_popup(error.exc_value)
         self.current_alg = None
 
     """=============== Phase table methods ==============="""

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/thread_model.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/thread_model.py
@@ -7,6 +7,7 @@
 from qtpy import QtWidgets, QtCore
 from qtpy.QtCore import Signal
 from qtpy.QtCore import Slot
+from mantidqt.utils.async_qt_adaptor import AsyncTaskQtAdaptor
 from mantidqtinterfaces.Muon.GUI.Common.message_box import warning
 
 
@@ -67,11 +68,6 @@ class ThreadModel(QtWidgets.QWidget):
         super(ThreadModel, self).__init__()
         self.model = model
 
-        # The ThreadModelWorker wrapping the code to be executed
-        self._worker = ThreadModelWorker(self.model)
-        # The QThread instance on which the execution of the code will be performed
-        self._thread = QtCore.QThread(self)
-
         # callbacks for the .started() and .finished() signals of the worker
         self.start_slot = lambda: 0
         self.end_slot = lambda: 0
@@ -86,19 +82,21 @@ class ThreadModel(QtWidgets.QWidget):
                              " execute() and output() methods")
 
     def setup_thread_and_start(self):
+        worker = AsyncTaskQtAdaptor(target=self.model.execute, error_cb=self.warning, success_cb=self.end_slot,
+                                    finished_cb=self.threadWrapperTearDown)
+        worker.start()
+        self.start_slot()
         # create the ThreadModelWorker and connect its signals up
-        self._worker.signals.start.connect(self._worker.run)
-        self._worker.signals.started.connect(self.start_slot)
-        self._worker.signals.finished.connect(self.end_slot)
-        self._worker.signals.finished.connect(self.threadWrapperTearDown)
-        self._worker.signals.error.connect(self.warning)
+
+        #self._worker.signals.start.connect(self._worker.run)
+        #self._worker.signals.started.connect(self.start_slot)
 
         # Create the thread and pass it the worker
-        self._thread.start()
-        self._worker.moveToThread(self._thread)
+        #self._thread.start()
+        #self._worker.moveToThread(self._thread)
 
         # start the worker code inside the thread
-        self._worker.signals.start.emit()
+        #self._worker.signals.start.emit()
 
     def start(self):
         # keep this method to maintain consistency with older usages of the ThreadModel
@@ -142,12 +140,6 @@ class ThreadModel(QtWidgets.QWidget):
             self._exception_callback = self._default_exception_callback
 
     def threadWrapperTearDown(self):
-        self._thread.wait()
-        self._thread = QtCore.QThread(self)
-        self._worker.signals.started.disconnect(self.start_slot)
-        self._worker.signals.finished.disconnect(self.end_slot)
-        self._worker.signals.finished.disconnect(self.threadWrapperTearDown)
-        self._worker.signals.error.disconnect(self.warning)
         self.start_slot = lambda: 0
         self.end_slot = lambda: 0
 

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/thread_model.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/thread_model.py
@@ -67,7 +67,7 @@ class ThreadModel(QtWidgets.QWidget):
     def __init__(self, model):
         super(ThreadModel, self).__init__()
         self.model = model
-
+        self.worker = None
         # callbacks for the .started() and .finished() signals of the worker
         self.start_slot = lambda: 0
         self.end_slot = lambda: 0
@@ -83,9 +83,9 @@ class ThreadModel(QtWidgets.QWidget):
 
     def setup_thread_and_start(self):
         # Construct the Async thread
-        worker = AsyncTaskQtAdaptor(target=self.model.execute, error_cb=self._exception_callback, success_cb=self.end_slot,
-                                    finished_cb=self.threadWrapperTearDown)
-        worker.start()
+        self.worker = AsyncTaskQtAdaptor(target=self.model.execute, error_cb=self.warning,
+                                         finished_cb=self.threadWrapperTearDown)
+        self.worker.start()
 
         # trigger the slot for the start of the process
         self.start_slot()
@@ -132,6 +132,7 @@ class ThreadModel(QtWidgets.QWidget):
             self._exception_callback = self._default_exception_callback
 
     def threadWrapperTearDown(self):
+        self.end_slot()
         self.start_slot = lambda: 0
         self.end_slot = lambda: 0
 

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/thread_model.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/thread_model.py
@@ -76,27 +76,19 @@ class ThreadModel(QtWidgets.QWidget):
         self.check_model_has_correct_attributes()
 
     def check_model_has_correct_attributes(self):
-        if hasattr(self.model, "execute") and hasattr(self.model, "output"):
+        if hasattr(self.model, "execute"):
             return
         raise AttributeError("Please ensure the model passed to ThreadModel has implemented"
-                             " execute() and output() methods")
+                             " execute() method")
 
     def setup_thread_and_start(self):
-        worker = AsyncTaskQtAdaptor(target=self.model.execute, error_cb=self.warning, success_cb=self.end_slot,
+        # Construct the Async thread
+        worker = AsyncTaskQtAdaptor(target=self.model.execute, error_cb=self._exception_callback, success_cb=self.end_slot,
                                     finished_cb=self.threadWrapperTearDown)
         worker.start()
+
+        # trigger the slot for the start of the process
         self.start_slot()
-        # create the ThreadModelWorker and connect its signals up
-
-        #self._worker.signals.start.connect(self._worker.run)
-        #self._worker.signals.started.connect(self.start_slot)
-
-        # Create the thread and pass it the worker
-        #self._thread.start()
-        #self._worker.moveToThread(self._thread)
-
-        # start the worker code inside the thread
-        #self._worker.signals.start.emit()
 
     def start(self):
         # keep this method to maintain consistency with older usages of the ThreadModel

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/thread_model_wrapper.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/thread_model_wrapper.py
@@ -16,9 +16,6 @@ class ThreadModelWrapper(object):
     def cancel(self):
         pass
 
-    def output(self):
-        pass
-
     def execute(self):
         self.callback()
 
@@ -33,9 +30,6 @@ class ThreadModelWrapperWithOutput(object):
         pass
 
     def cancel(self):
-        pass
-
-    def output(self):
         pass
 
     def execute(self):

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/ElementalAnalysis/LoadWidget/load_utils.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/ElementalAnalysis/LoadWidget/load_utils.py
@@ -60,9 +60,6 @@ class LModel(object):
         self.last_loaded_runs.append(self.run)
         return self.loaded_runs[self.run]
 
-    def output(self):
-        return
-
     def cancel(self):
         return
 

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/ElementalAnalysis2/load_widget/load_models.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/ElementalAnalysis2/load_widget/load_models.py
@@ -100,10 +100,6 @@ class LoadRunWidgetModel(object):
                       "\n - The file was not found locally (please check the user directories)."
             raise ValueError(message)
 
-    # This is needed to work with thread model
-    def output(self):
-        pass
-
     def cancel(self):
         pass
 

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/FrequencyDomainAnalysis/FFT/fft_model.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/FrequencyDomainAnalysis/FFT/fft_model.py
@@ -63,9 +63,6 @@ class FFTWrapper(object):
         if self.FFT is not None:
             self.model.FFTAlg(self.FFT)
 
-    def output(self):
-        return
-
 
 class FFTModel(object):
 

--- a/qt/python/mantidqtinterfaces/test/Muon/elemental_analysis_2/EA_loading_tab/elemental_analysis_loadrun_presenter_increment_decrement_test.py
+++ b/qt/python/mantidqtinterfaces/test/Muon/elemental_analysis_2/EA_loading_tab/elemental_analysis_loadrun_presenter_increment_decrement_test.py
@@ -5,6 +5,7 @@
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
 import unittest
+import time
 
 from unittest import mock
 from mantidqt.utils.qt.testing import start_qapplication
@@ -18,8 +19,10 @@ from mantidqtinterfaces.Muon.GUI.Common.test_helpers.context_setup import setup_
 @start_qapplication
 class LoadRunWidgetIncrementDecrementSingleFileModeTest(unittest.TestCase):
     def wait_for_thread(self, thread_model):
-        if thread_model:
-            thread_model._thread.wait()
+        if thread_model and thread_model.worker:
+            while thread_model.worker.is_alive():
+                QApplication.sendPostedEvents()
+                time.sleep(0.1)
             QApplication.sendPostedEvents()
 
     def setUp(self):

--- a/qt/python/mantidqtinterfaces/test/Muon/elemental_analysis_2/EA_loading_tab/elemental_analysis_loadrun_presenter_single_run_test.py
+++ b/qt/python/mantidqtinterfaces/test/Muon/elemental_analysis_2/EA_loading_tab/elemental_analysis_loadrun_presenter_single_run_test.py
@@ -5,6 +5,7 @@
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
 import unittest
+import time
 
 from unittest import mock
 from mantidqt.utils.qt.testing import start_qapplication
@@ -19,8 +20,10 @@ from mantidqtinterfaces.Muon.GUI.Common.test_helpers.context_setup import setup_
 @start_qapplication
 class LoadRunWidgetPresenterTest(unittest.TestCase):
     def wait_for_thread(self, thread_model):
-        if thread_model:
-            thread_model._thread.wait()
+        if thread_model and thread_model.worker:
+            while thread_model.worker.is_alive():
+                QApplication.sendPostedEvents()
+                time.sleep(0.1)
             QApplication.sendPostedEvents()
 
     def setUp(self):

--- a/qt/python/mantidqtinterfaces/test/Muon/load_file_widget/loadfile_presenter_multiple_file_test.py
+++ b/qt/python/mantidqtinterfaces/test/Muon/load_file_widget/loadfile_presenter_multiple_file_test.py
@@ -5,6 +5,7 @@
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
 import unittest
+import time
 
 from unittest import mock
 from mantidqt.utils.qt.testing import start_qapplication
@@ -55,8 +56,10 @@ class LoadFileWidgetPresenterMultipleFileModeTest(unittest.TestCase):
         return run_twice
 
     def wait_for_thread(self, thread_model):
-        if thread_model:
-            thread_model._thread.wait()
+        if thread_model and thread_model.worker:
+            while thread_model.worker.is_alive():
+                QApplication.sendPostedEvents()
+                time.sleep(0.1)
             QApplication.sendPostedEvents()
 
     def setUp(self):

--- a/qt/python/mantidqtinterfaces/test/Muon/load_file_widget/loadfile_presenter_single_file_test.py
+++ b/qt/python/mantidqtinterfaces/test/Muon/load_file_widget/loadfile_presenter_single_file_test.py
@@ -5,6 +5,7 @@
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
 import unittest
+import time
 
 from unittest import mock
 from mantidqt.utils.qt.testing import start_qapplication
@@ -29,8 +30,10 @@ class LoadFileWidgetPresenterTest(unittest.TestCase):
         return run_twice
 
     def wait_for_thread(self, thread_model):
-        if thread_model:
-            thread_model._thread.wait()
+        if thread_model and thread_model.worker:
+            while thread_model.worker.is_alive():
+                QApplication.sendPostedEvents()
+                time.sleep(0.1)
             QApplication.sendPostedEvents()
 
     def setUp(self):

--- a/qt/python/mantidqtinterfaces/test/Muon/load_run_widget/loadrun_presenter_current_run_test.py
+++ b/qt/python/mantidqtinterfaces/test/Muon/load_run_widget/loadrun_presenter_current_run_test.py
@@ -47,7 +47,6 @@ class LoadRunWidgetLoadCurrentRunTest(unittest.TestCase):
 
     def wait_for_thread(self, thread_model):
         if thread_model:
-            thread_model._thread.wait()
             QApplication.sendPostedEvents()
 
     def create_fake_workspace(self):

--- a/qt/python/mantidqtinterfaces/test/Muon/load_run_widget/loadrun_presenter_current_run_test.py
+++ b/qt/python/mantidqtinterfaces/test/Muon/load_run_widget/loadrun_presenter_current_run_test.py
@@ -5,6 +5,7 @@
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
 import unittest
+import time
 from unittest import mock
 from unittest.mock import patch
 
@@ -46,7 +47,10 @@ class LoadRunWidgetLoadCurrentRunTest(unittest.TestCase):
         raise ValueError("Error text")
 
     def wait_for_thread(self, thread_model):
-        if thread_model:
+        if thread_model and thread_model.worker:
+            while thread_model.worker.is_alive():
+                QApplication.sendPostedEvents()
+                time.sleep(0.1)
             QApplication.sendPostedEvents()
 
     def create_fake_workspace(self):

--- a/qt/python/mantidqtinterfaces/test/Muon/load_run_widget/loadrun_presenter_increment_decrement_test.py
+++ b/qt/python/mantidqtinterfaces/test/Muon/load_run_widget/loadrun_presenter_increment_decrement_test.py
@@ -6,6 +6,7 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 import os
 import unittest
+import time
 
 from unittest import mock
 from mantidqt.utils.qt.testing import start_qapplication
@@ -29,8 +30,10 @@ class LoadRunWidgetIncrementDecrementSingleFileModeTest(unittest.TestCase):
         return run_twice
 
     def wait_for_thread(self, thread_model):
-        if thread_model:
-            thread_model._thread.wait()
+        if thread_model and thread_model.worker:
+            while thread_model.worker.is_alive():
+                QApplication.sendPostedEvents()
+                time.sleep(0.1)
             QApplication.sendPostedEvents()
 
     def setUp(self):

--- a/qt/python/mantidqtinterfaces/test/Muon/load_run_widget/loadrun_presenter_multiple_file_test.py
+++ b/qt/python/mantidqtinterfaces/test/Muon/load_run_widget/loadrun_presenter_multiple_file_test.py
@@ -5,6 +5,7 @@
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
 import unittest
+import time
 
 from unittest import mock
 from mantidqt.utils.qt.testing import start_qapplication
@@ -27,8 +28,10 @@ class LoadRunWidgetIncrementDecrementMultipleFileModeTest(unittest.TestCase):
         return run_twice
 
     def wait_for_thread(self, thread_model):
-        if thread_model:
-            thread_model._thread.wait()
+        if thread_model and thread_model.worker:
+            while thread_model.worker.is_alive():
+                QApplication.sendPostedEvents()
+                time.sleep(0.1)
             QApplication.sendPostedEvents()
 
     def setUp(self):

--- a/qt/python/mantidqtinterfaces/test/Muon/load_run_widget/loadrun_presenter_single_file_test.py
+++ b/qt/python/mantidqtinterfaces/test/Muon/load_run_widget/loadrun_presenter_single_file_test.py
@@ -5,6 +5,7 @@
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
 import unittest
+import time
 
 from unittest import mock
 from mantidqt.utils.qt.testing import start_qapplication
@@ -28,8 +29,10 @@ class LoadRunWidgetPresenterTest(unittest.TestCase):
         return run_twice
 
     def wait_for_thread(self, thread_model):
-        if thread_model:
-            thread_model._thread.wait()
+        if thread_model and thread_model.worker:
+            while thread_model.worker.is_alive():
+                QApplication.sendPostedEvents()
+                time.sleep(0.1)
             QApplication.sendPostedEvents()
 
     def setUp(self):

--- a/qt/python/mantidqtinterfaces/test/Muon/loading_tab/loadwidget_presenter_failure_test.py
+++ b/qt/python/mantidqtinterfaces/test/Muon/loading_tab/loadwidget_presenter_failure_test.py
@@ -5,6 +5,7 @@
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
 import unittest
+import time
 from unittest import mock
 from mantidqt.utils.qt.testing import start_qapplication
 from qtpy.QtWidgets import QApplication, QWidget
@@ -27,8 +28,10 @@ from mantidqtinterfaces.Muon.GUI.Common.ADSHandler.muon_workspace_wrapper import
 @start_qapplication
 class LoadRunWidgetPresenterLoadFailTest(unittest.TestCase):
     def wait_for_thread(self, thread_model):
-        if thread_model:
-            thread_model._thread.wait()
+        if thread_model and thread_model.worker:
+            while thread_model.worker.is_alive():
+                QApplication.sendPostedEvents()
+                time.sleep(0.1)
             QApplication.sendPostedEvents()
 
     def create_fake_workspace(self, name):

--- a/qt/python/mantidqtinterfaces/test/Muon/loading_tab/loadwidget_presenter_multiple_file_test.py
+++ b/qt/python/mantidqtinterfaces/test/Muon/loading_tab/loadwidget_presenter_multiple_file_test.py
@@ -29,10 +29,11 @@ from mantidqtinterfaces.Muon.GUI.MuonAnalysis.load_widget.load_widget_view impor
 @start_qapplication
 class LoadRunWidgetPresenterMultipleFileTest(unittest.TestCase):
     def wait_for_thread(self, thread_model):
-        while(thread_model._thread.isRunning()):
+        if thread_model and thread_model.worker:
+            while thread_model.worker.is_alive():
+                QApplication.sendPostedEvents()
+                time.sleep(0.1)
             QApplication.sendPostedEvents()
-            time.sleep(0.1)
-        QApplication.sendPostedEvents()
 
     def setUp(self):
         # Store an empty widget to parent all the views, and ensure they are deleted correctly

--- a/qt/python/mantidqtinterfaces/test/Muon/loading_tab/loadwidget_presenter_test.py
+++ b/qt/python/mantidqtinterfaces/test/Muon/loading_tab/loadwidget_presenter_test.py
@@ -5,6 +5,7 @@
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
 import unittest
+import time
 from mantid.api import FileFinder
 from unittest import mock
 from mantidqt.utils.qt.testing import start_qapplication
@@ -28,8 +29,10 @@ from mantidqtinterfaces.Muon.GUI.Common.ADSHandler.muon_workspace_wrapper import
 @start_qapplication
 class LoadRunWidgetPresenterTest(unittest.TestCase):
     def wait_for_thread(self, thread_model):
-        if thread_model:
-            thread_model._thread.wait()
+        if thread_model and thread_model.worker:
+            while thread_model.worker.is_alive():
+                QApplication.sendPostedEvents()
+                time.sleep(0.1)
             QApplication.sendPostedEvents()
 
     def setUp(self):

--- a/qt/python/mantidqtinterfaces/test/Muon/phase_table_widget/phase_table_presenter_test.py
+++ b/qt/python/mantidqtinterfaces/test/Muon/phase_table_widget/phase_table_presenter_test.py
@@ -5,6 +5,7 @@
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
 import unittest
+import time
 
 from unittest import mock
 from mantidqt.utils.qt.testing import start_qapplication
@@ -25,8 +26,10 @@ def phase_table_name_side_effect():
 @start_qapplication
 class PhaseTablePresenterTest(unittest.TestCase):
     def wait_for_thread(self, thread_model):
-        if thread_model:
-            thread_model._thread.wait()
+        if thread_model and thread_model.worker:
+            while thread_model.worker.is_alive():
+                QApplication.sendPostedEvents()
+                time.sleep(0.1)
             QApplication.sendPostedEvents()
 
     def setUp(self):
@@ -120,7 +123,8 @@ class PhaseTablePresenterTest(unittest.TestCase):
         self.context.getGroupedWorkspaceNames = mock.MagicMock(return_value=['MUSR22222_raw_data_period_1'])
         self.context.phase_context.options_dict['input_workspace'] = 'MUSR22222_raw_data_period_1'
         self.presenter.update_view_from_model()
-        run_algorithm_mock.side_effect = RuntimeError('CalMuonDetectorPhases has failed')
+        runtime_error = RuntimeError('CalMuonDetectorPhases has failed')
+        run_algorithm_mock.side_effect = runtime_error
         self.presenter.add_phase_table_to_ADS = mock.MagicMock()
         self.presenter.calculate_base_name_and_group = mock.MagicMock(
             return_value=('MUSR22222_raw_data_period_1', 'MUSR22222 PhaseTable'))
@@ -130,7 +134,7 @@ class PhaseTablePresenterTest(unittest.TestCase):
         self.wait_for_thread(self.presenter.calculation_thread)
 
         self.assertTrue(self.view.isEnabled())
-        self.view.warning_popup.assert_called_once_with('CalMuonDetectorPhases has failed')
+        self.view.warning_popup.assert_called_once_with(runtime_error)
 
     def test_update_current_phase_table_list_retrieves_all_correct_tables(self):
         self.view.set_phase_table_combo_box = mock.MagicMock()

--- a/qt/python/mantidqtinterfaces/test/Muon/seq_fitting_tab_widget/seq_fitting_tab_presenter_test.py
+++ b/qt/python/mantidqtinterfaces/test/Muon/seq_fitting_tab_widget/seq_fitting_tab_presenter_test.py
@@ -5,6 +5,7 @@
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
 import unittest
+import time
 from unittest import mock
 
 from mantidqtinterfaces.Muon.GUI.Common.seq_fitting_tab_widget.seq_fitting_tab_widget import SeqFittingTabWidget
@@ -18,8 +19,10 @@ from mantid.simpleapi import CreateSampleWorkspace, DeleteWorkspace
 
 
 def wait_for_thread(thread_model):
-    if thread_model:
-        thread_model._thread.wait()
+    if thread_model and thread_model.worker:
+        while thread_model.worker.is_alive():
+            QApplication.sendPostedEvents()
+            time.sleep(0.1)
         QApplication.sendPostedEvents()
 
 

--- a/qt/python/mantidqtinterfaces/test/Muon/utilities/thread_model_test.py
+++ b/qt/python/mantidqtinterfaces/test/Muon/utilities/thread_model_test.py
@@ -18,9 +18,6 @@ class testModelWithoutExecute:
     def __init__(self):
         pass
 
-    def output(self):
-        pass
-
 
 class testModelWithoutOutput:
 
@@ -39,9 +36,6 @@ class testModelWithoutLoadData:
     def execute(self):
         pass
 
-    def output(self):
-        pass
-
 
 class testModel:
 
@@ -50,9 +44,6 @@ class testModel:
 
     def loadData(self, data):
         self._data = data
-
-    def output(self):
-        pass
 
     def execute(self):
         pass
@@ -100,20 +91,9 @@ class LoadFileWidgetViewTest(unittest.TestCase):
         self.model.execute = mock.Mock()
 
         self.Runner(self.thread)
-        self.thread._thread.wait()
         self._qapp.processEvents()
 
         self.assertEqual(self.model.execute.call_count, 1)
-
-    def test_that_output_is_called_if_thread_executes_successfully(self):
-        self.model.execute = mock.Mock()
-        self.model.output = mock.Mock()
-
-        self.Runner(self.thread)
-        self.thread._thread.wait()
-        self._qapp.processEvents()
-
-        self.assertEqual(self.model.output.call_count, 1)
 
     def test_that_starting_and_finishing_callbacks_are_called_when_thread_starts_and_finishes(self):
         start_slot = mock.Mock()
@@ -122,7 +102,6 @@ class LoadFileWidgetViewTest(unittest.TestCase):
         self.thread.threadWrapperSetUp(start_slot, end_slot)
 
         self.Runner(self.thread)
-        self.thread._thread.wait()
         self._qapp.processEvents()
 
         self.assertEqual(start_slot.call_count, 1)
@@ -141,12 +120,6 @@ class LoadFileWidgetViewTest(unittest.TestCase):
         with self.assertRaises(AttributeError):
             ThreadModel(model)
 
-    def test_that_attribute_error_raised_if_model_does_not_contain_output_method(self):
-        model = testModelWithoutOutput
-
-        with self.assertRaises(AttributeError):
-            ThreadModel(model)
-
     def test_that_tearDown_function_called_automatically(self):
         start_slot = mock.Mock()
         end_slot = mock.Mock()
@@ -154,7 +127,6 @@ class LoadFileWidgetViewTest(unittest.TestCase):
         self.thread.threadWrapperSetUp(start_slot, end_slot)
 
         self.Runner(self.thread)
-        self.thread._thread.wait()
         self._qapp.processEvents()
 
         self.assertEqual(start_slot.call_count, 1)
@@ -167,7 +139,6 @@ class LoadFileWidgetViewTest(unittest.TestCase):
         self.model.execute = mock.Mock(side_effect=raise_error)
 
         self.Runner(self.thread)
-        self.thread._thread.wait()
         self._qapp.processEvents()
 
         self.assertEqual(self.warning_box_patcher.call_count, 1)

--- a/qt/python/mantidqtinterfaces/test/Muon/utilities/thread_model_test.py
+++ b/qt/python/mantidqtinterfaces/test/Muon/utilities/thread_model_test.py
@@ -5,6 +5,7 @@
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
 import unittest
+import time
 
 from unittest import mock
 from mantidqt.utils.qt.testing import start_qapplication
@@ -75,6 +76,13 @@ class LoadFileWidgetViewTest(unittest.TestCase):
         model.output = mock.Mock()
         return model
 
+    def wait_for_thread(self, thread_model):
+        if thread_model and thread_model.worker:
+            while thread_model.worker.is_alive():
+                QApplication.sendPostedEvents()
+                time.sleep(0.1)
+            QApplication.sendPostedEvents()
+
     # ------------------------------------------------------------------------------------------------------------------
     # TESTS
     # ------------------------------------------------------------------------------------------------------------------
@@ -91,6 +99,7 @@ class LoadFileWidgetViewTest(unittest.TestCase):
         self.model.execute = mock.Mock()
 
         self.Runner(self.thread)
+        self.wait_for_thread(self.thread)
         self._qapp.processEvents()
 
         self.assertEqual(self.model.execute.call_count, 1)
@@ -102,6 +111,7 @@ class LoadFileWidgetViewTest(unittest.TestCase):
         self.thread.threadWrapperSetUp(start_slot, end_slot)
 
         self.Runner(self.thread)
+        self.wait_for_thread(self.thread)
         self._qapp.processEvents()
 
         self.assertEqual(start_slot.call_count, 1)
@@ -127,6 +137,7 @@ class LoadFileWidgetViewTest(unittest.TestCase):
         self.thread.threadWrapperSetUp(start_slot, end_slot)
 
         self.Runner(self.thread)
+        self.wait_for_thread(self.thread)
         self._qapp.processEvents()
 
         self.assertEqual(start_slot.call_count, 1)
@@ -139,6 +150,7 @@ class LoadFileWidgetViewTest(unittest.TestCase):
         self.model.execute = mock.Mock(side_effect=raise_error)
 
         self.Runner(self.thread)
+        self.wait_for_thread(self.thread)
         self._qapp.processEvents()
 
         self.assertEqual(self.warning_box_patcher.call_count, 1)


### PR DESCRIPTION
**Description of work.**

This PR changes the thredding used by the Muon GUI to use AsyncTaskQtAdaptor

**To test:**

1. build mantid in release and run through a profiler https://developer.mantidproject.org/ProfilingOverview.html
1. open muon analysis 
2. load MUSR62260-5
3. check profileing and see the run speed of functions coming from load_run_presenter.

Fixes #32703

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
