### PR TITLE
Check if GUIs Need to Keep Running When Closing Workbench

### DIFF
--- a/docs/source/release/v6.3.0/mantidworkbench.rst
+++ b/docs/source/release/v6.3.0/mantidworkbench.rst
@@ -37,5 +37,6 @@ Bugfixes
 - Fixed a bug with autoscaling of colorfill plots from within the figure options.
 - Fixed an issue to plot negative values with logarithm scaling in slice view.
 - Workbench will no longer hang if an algorithm was running when workbench was closed.
+- Stopped workbench from ignoring GUIs that want to cancel closing
 
 :ref:`Release 6.3.0 <v6.3.0>`

--- a/qt/applications/workbench/workbench/app/mainwindow.py
+++ b/qt/applications/workbench/workbench/app/mainwindow.py
@@ -580,13 +580,11 @@ class MainWindow(QMainWindow):
         # Close windows
         app = QApplication.instance()
         if app is not None:
-            #  closeAllWindows() does no checking.
-            #  This loop lets GUIs and such refuse the close if they need to save or something.
             for window in app.topLevelWindows():
                 if not window.close():
+                    # Allow GUIs to cancel the closure if they want to save
                     event.ignore()
                     return
-            app.closeAllWindows()
 
         # Close editors
         if self.editor is None or self.editor.app_closing():
@@ -598,6 +596,9 @@ class MainWindow(QMainWindow):
             # We don't want this at module scope here
             import matplotlib.pyplot as plt  # noqa
             plt.close('all')
+
+            # Close any remaining windows
+            app.closeAllWindows()
 
             # Cancel all running (managed) algorithms
             AlgorithmManager.Instance().cancelAll()

--- a/qt/applications/workbench/workbench/app/mainwindow.py
+++ b/qt/applications/workbench/workbench/app/mainwindow.py
@@ -598,7 +598,8 @@ class MainWindow(QMainWindow):
             plt.close('all')
 
             # Close any remaining windows
-            app.closeAllWindows()
+            if app is not None:
+                app.closeAllWindows()
 
             # Cancel all running (managed) algorithms
             AlgorithmManager.Instance().cancelAll()

--- a/qt/applications/workbench/workbench/app/mainwindow.py
+++ b/qt/applications/workbench/workbench/app/mainwindow.py
@@ -577,8 +577,11 @@ class MainWindow(QMainWindow):
                     event.ignore()
                     return
 
+        # Close windows
         app = QApplication.instance()
         if app is not None:
+            #  closeAllWindows() does no checking.
+            #  This loop lets GUIs and such refuse the close if they need to save or something.
             for window in app.topLevelWindows():
                 if not window.close():
                     event.ignore()

--- a/qt/applications/workbench/workbench/app/mainwindow.py
+++ b/qt/applications/workbench/workbench/app/mainwindow.py
@@ -587,7 +587,7 @@ class MainWindow(QMainWindow):
                     return
 
         # Close editors
-        if self.editor is None or self.editor.app_closing():
+        if self.editor is None or (self.editor.editors.current_editor() and self.editor.app_closing()):
             # write out any changes to the mantid config file
             ConfigService.saveConfig(ConfigService.getUserFilename())
             # write current window information to global settings object

--- a/qt/applications/workbench/workbench/app/mainwindow.py
+++ b/qt/applications/workbench/workbench/app/mainwindow.py
@@ -577,6 +577,14 @@ class MainWindow(QMainWindow):
                     event.ignore()
                     return
 
+        app = QApplication.instance()
+        if app is not None:
+            for window in app.topLevelWindows():
+                if not window.close():
+                    event.ignore()
+                    return
+            app.closeAllWindows()
+
         # Close editors
         if self.editor is None or self.editor.app_closing():
             # write out any changes to the mantid config file
@@ -590,10 +598,6 @@ class MainWindow(QMainWindow):
 
             # Cancel all running (managed) algorithms
             AlgorithmManager.Instance().cancelAll()
-
-            app = QApplication.instance()
-            if app is not None:
-                app.closeAllWindows()
 
             # Kill the project recovery thread and don't restart should a save be in progress and clear out current
             # recovery checkpoint as it is closing properly

--- a/qt/applications/workbench/workbench/test/test_mainwindow.py
+++ b/qt/applications/workbench/workbench/test/test_mainwindow.py
@@ -254,9 +254,6 @@ class MainWindowTest(unittest.TestCase):
         mock_q_app.instance = Mock(return_value=mock_app)
         mock_app.topLevelWindows = Mock(return_value=[mock_window])
 
-        if __name__ == '__main__':
-            self.main_window.app
-
         self.main_window.closeEvent(mock_event)
 
         mock_window.close.assert_called()

--- a/qt/applications/workbench/workbench/test/test_mainwindow.py
+++ b/qt/applications/workbench/workbench/test/test_mainwindow.py
@@ -245,6 +245,23 @@ class MainWindowTest(unittest.TestCase):
         mock_project.offer_save.assert_called()
         mock_event.ignore.assert_called()
 
+    @patch('workbench.app.mainwindow.QApplication')
+    def test_main_window_does_not_close_if_gui_ignores_event(self, mock_q_app):
+        mock_event = Mock()
+        mock_window = Mock()
+        mock_window.close = Mock(return_value=False)  # Close event was ignored (user cancelled)
+        mock_app = Mock()
+        mock_q_app.instance = Mock(return_value=mock_app)
+        mock_app.topLevelWindows = Mock(return_value=[mock_window])
+
+        if __name__ == '__main__':
+            self.main_window.app
+
+        self.main_window.closeEvent(mock_event)
+
+        mock_window.close.assert_called()
+        mock_event.ignore.assert_called()
+
     @patch('workbench.app.mainwindow.ConfigService')
     @patch('workbench.app.mainwindow.QApplication')
     @patch('matplotlib.pyplot.close')


### PR DESCRIPTION
**Description of work.**
Adds a loop to the main window close event to check that all the sub-windows close cleanly. 

Interfaces that had saveable features could request that the GUI does not close if work was unsaved. Originally, they would would be ignored by the main window and the program would close anyway, in some cases resulting in a segfault. This is now fixed. 

**To test:**
1. Open the ISIS Reflectometry GUI
2. Open and check  `Tools -> Options -> Warn when discarding ...` 
2. Enter something in one of the table cells (anything is fine, even if it's invalid it's just to get the unsaved changes warning to appear)
3. Close workbench
4. Click cancel
5. Workbench should stay open
6. Close workbench
7. Click okay
8. Workbench should close

*There is no associated issue.*

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
