### PR TITLE
Use property manager in batch algorithm runner

### DIFF
--- a/Framework/API/inc/MantidAPI/Algorithm.h
+++ b/Framework/API/inc/MantidAPI/Algorithm.h
@@ -332,6 +332,7 @@ public:
 
   std::string getPropertyValue(const std::string &name) const override;
   const std::vector<Kernel::Property *> &getProperties() const override;
+  std::vector<std::string> getDeclaredPropertyNames() const noexcept override;
 
   /// Get the value of a property
   TypedValue getProperty(const std::string &name) const override;

--- a/Framework/API/src/Algorithm.cpp
+++ b/Framework/API/src/Algorithm.cpp
@@ -2050,6 +2050,19 @@ Property *Algorithm::getPointerToPropertyOrdinal(const int &index) const {
  */
 const std::vector<Property *> &Algorithm::getProperties() const { return m_properties.getProperties(); }
 
+/**
+ * Return the list of declared property names.
+ * @return A vector holding strings of property names
+ */
+std::vector<std::string> Algorithm::getDeclaredPropertyNames() const noexcept {
+  std::vector<std::string> names;
+  const auto &props = getProperties();
+  names.reserve(props.size());
+  std::transform(props.cbegin(), props.cend(), std::back_inserter(names),
+                 [](auto &propPtr) { return propPtr->name(); });
+  return names;
+}
+
 /** Get the value of a property. Allows you to assign directly to a variable of
  *the property's type
  *  (if a supported type).

--- a/Framework/API/src/Algorithm.cpp
+++ b/Framework/API/src/Algorithm.cpp
@@ -2055,12 +2055,7 @@ const std::vector<Property *> &Algorithm::getProperties() const { return m_prope
  * @return A vector holding strings of property names
  */
 std::vector<std::string> Algorithm::getDeclaredPropertyNames() const noexcept {
-  std::vector<std::string> names;
-  const auto &props = getProperties();
-  names.reserve(props.size());
-  std::transform(props.cbegin(), props.cend(), std::back_inserter(names),
-                 [](auto &propPtr) { return propPtr->name(); });
-  return names;
+  return m_properties.getDeclaredPropertyNames();
 }
 
 /** Get the value of a property. Allows you to assign directly to a variable of

--- a/Framework/Kernel/inc/MantidKernel/IPropertyManager.h
+++ b/Framework/Kernel/inc/MantidKernel/IPropertyManager.h
@@ -245,6 +245,9 @@ public:
   /// Get the list of managed properties.
   virtual const std::vector<Property *> &getProperties() const = 0;
 
+  /// Get the list of managed property names.
+  virtual std::vector<std::string> getDeclaredPropertyNames() const noexcept = 0;
+
   /** Templated method to set the value of a PropertyWithValue
    *  @param name :: The name of the property (case insensitive)
    *  @param value :: The value to assign to the property

--- a/Framework/Kernel/inc/MantidKernel/PropertyManager.h
+++ b/Framework/Kernel/inc/MantidKernel/PropertyManager.h
@@ -89,6 +89,7 @@ public:
   size_t propertyCount() const override;
   std::string getPropertyValue(const std::string &name) const override;
   const std::vector<Property *> &getProperties() const override;
+  std::vector<std::string> getDeclaredPropertyNames() const noexcept override;
 
   /// removes the property from properties map
   void removeProperty(const std::string &name, const bool delproperty = true) override;

--- a/Framework/Kernel/inc/MantidKernel/PropertyManager.h
+++ b/Framework/Kernel/inc/MantidKernel/PropertyManager.h
@@ -58,7 +58,7 @@ public:
   void filterByProperty(const TimeSeriesProperty<bool> &filter,
                         const std::vector<std::string> &excludedFromFiltering = std::vector<std::string>()) override;
 
-  ~PropertyManager() override;
+  virtual ~PropertyManager() override;
 
   // Function to declare properties (i.e. store them)
   void declareProperty(std::unique_ptr<Property> p, const std::string &doc = "") override;

--- a/Framework/Kernel/inc/MantidKernel/PropertyManagerOwner.h
+++ b/Framework/Kernel/inc/MantidKernel/PropertyManagerOwner.h
@@ -72,6 +72,7 @@ public:
 
   std::string getPropertyValue(const std::string &name) const override;
   const std::vector<Property *> &getProperties() const override;
+  std::vector<std::string> getDeclaredPropertyNames() const noexcept override;
 
   /// Get the value of a property
   TypedValue getProperty(const std::string &name) const override;

--- a/Framework/Kernel/src/PropertyManager.cpp
+++ b/Framework/Kernel/src/PropertyManager.cpp
@@ -660,6 +660,20 @@ Property *PropertyManager::getPointerToPropertyOrdinal(const int &index) const {
 const std::vector<Property *> &PropertyManager::getProperties() const { return m_orderedProperties; }
 
 //-----------------------------------------------------------------------------------------------
+/**
+ * Return the list of declared property names.
+ * @return A vector holding strings of property names
+ */
+std::vector<std::string> PropertyManager::getDeclaredPropertyNames() const noexcept {
+  std::vector<std::string> names;
+  const auto &props = getProperties();
+  names.reserve(props.size());
+  std::transform(props.cbegin(), props.cend(), std::back_inserter(names),
+                 [](auto &propPtr) { return propPtr->name(); });
+  return names;
+}
+
+//-----------------------------------------------------------------------------------------------
 /** Get the value of a property. Allows you to assign directly to a variable of
  *the property's type
  *  (if a supported type).

--- a/Framework/Kernel/src/PropertyManagerOwner.cpp
+++ b/Framework/Kernel/src/PropertyManagerOwner.cpp
@@ -179,6 +179,19 @@ Property *PropertyManagerOwner::getPointerToPropertyOrdinal(const int &index) co
  */
 const std::vector<Property *> &PropertyManagerOwner::getProperties() const { return m_properties->getProperties(); }
 
+/**
+ * Return the list of declared property names.
+ * @return A vector holding strings of property names
+ */
+std::vector<std::string> PropertyManagerOwner::getDeclaredPropertyNames() const noexcept {
+  std::vector<std::string> names;
+  const auto &props = getProperties();
+  names.reserve(props.size());
+  std::transform(props.cbegin(), props.cend(), std::back_inserter(names),
+                 [](auto &propPtr) { return propPtr->name(); });
+  return names;
+}
+
 /** Get the value of a property. Allows you to assign directly to a variable of
  *the property's type
  *  (if a supported type).

--- a/Framework/Kernel/test/PropertyManagerTest.h
+++ b/Framework/Kernel/test/PropertyManagerTest.h
@@ -307,14 +307,9 @@ public:
   }
 
   void testExistsProperty() {
-    Property *p = new PropertyWithValue<int>("sjfudh", 0);
+    auto p = std::make_unique<PropertyWithValue<int>>("sjfudh", 0);
     TS_ASSERT(!manager->existsProperty(p->name()));
-    Property *pp = new PropertyWithValue<double>("APROP", 9.99);
-    // Note that although the name of the property is the same, the type is
-    // different - yet it passes
-    TS_ASSERT(manager->existsProperty(pp->name()));
-    delete p;
-    delete pp;
+    TS_ASSERT(manager->existsProperty("APROP"));
   }
 
   void testValidateProperties() {

--- a/Framework/Kernel/test/PropertyManagerTest.h
+++ b/Framework/Kernel/test/PropertyManagerTest.h
@@ -312,6 +312,11 @@ public:
     TS_ASSERT(manager->existsProperty("APROP"));
   }
 
+  void testGetPropertyNames() {
+    std::vector<std::string> expected{"aProp", "anotherProp", "yetAnotherProp"};
+    TS_ASSERT_EQUALS(std::move(expected), manager->getDeclaredPropertyNames());
+  }
+
   void testValidateProperties() {
     TS_ASSERT(manager->validateProperties());
     PropertyManagerHelper mgr;

--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -368,7 +368,7 @@ constParameter:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/DataBlockComposite
 uninitMemberVarPrivate:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/DefaultEventLoader.cpp:49
 uninitMemberVarPrivate:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/DefaultEventLoader.cpp:49
 useStlAlgorithm:${CMAKE_SOURCE_DIR}/Framework/DataHandling/inc/MantidDataHandling/LoadEventNexus.h:347
-nullPointer:${CMAKE_SOURCE_DIR}/Framework/Kernel/inc/MantidKernel/IPropertyManager.h:281
+nullPointer:${CMAKE_SOURCE_DIR}/Framework/Kernel/inc/MantidKernel/IPropertyManager.h:284
 useStlAlgorithm:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/EventWorkspaceCollection.cpp:191
 useStlAlgorithm:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/FilterEventsByLogValuePreNexus.cpp:780
 useStlAlgorithm:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/FilterEventsByLogValuePreNexus.cpp:1988
@@ -928,9 +928,8 @@ stlFindInsert:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/Indirect/IndirectPlot
 stlFindInsert:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/Indirect/IndirectPlotOptionsModel.cpp:107
 unreadVariable:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/Indirect/IndirectPlotOptionsView.cpp:113
 useStlAlgorithm:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/Indirect/IndirectDataValidationHelper.cpp:33
-useStlAlgorithm:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/Indirect/IndirectTab.cpp:604
 unreadVariable:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/Indirect/IndirectSymmetrise.cpp:173
 unreadVariable:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/Indirect/Stretch.cpp:220
 ctunullpointer:${CMAKE_SOURCE_DIR}/Framework/Kernel/inc/MantidKernel/IPropertyManager.h:139
 ctunullpointer:${CMAKE_SOURCE_DIR}/Framework/Kernel/inc/MantidKernel/IPropertyManager.h:163
-ctunullpointer:${CMAKE_SOURCE_DIR}/Framework/Kernel/inc/MantidKernel/IPropertyManager.h:281
+ctunullpointer:${CMAKE_SOURCE_DIR}/Framework/Kernel/inc/MantidKernel/IPropertyManager.h:284

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/AlgorithmProperties.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/AlgorithmProperties.cpp
@@ -19,7 +19,7 @@ std::string boolToString(bool value) { return value ? "1" : "0"; }
 
 void update(std::string const &property, std::string const &value, AlgorithmRuntimeProps &properties) {
   if (!value.empty())
-    properties[property] = value;
+    properties.setPropertyValue(property, value);
 }
 
 void update(std::string const &property, boost::optional<std::string> const &value, AlgorithmRuntimeProps &properties) {

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/AlgorithmProperties.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/AlgorithmProperties.h
@@ -8,6 +8,7 @@
 
 #include "MantidAPI/IAlgorithm_fwd.h"
 #include "MantidKernel/Strings.h"
+#include "MantidQtWidgets/Common/IAlgorithmRuntimeProps.h"
 
 #include <boost/optional.hpp>
 #include <map>
@@ -18,7 +19,7 @@ namespace CustomInterfaces {
 namespace ISISReflectometry {
 namespace AlgorithmProperties {
 
-using AlgorithmRuntimeProps = std::map<std::string, std::string>;
+using AlgorithmRuntimeProps = MantidQt::API::IAlgorithmRuntimeProps;
 
 // These convenience functions convert properties of various types into
 // strings to set the relevant property in an AlgorithmRuntimeProps

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchJobAlgorithm.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchJobAlgorithm.cpp
@@ -5,10 +5,11 @@
 //   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 // SPDX - License - Identifier: GPL - 3.0 +
 #include "BatchJobAlgorithm.h"
+#include "MantidAPI/IAlgorithm.h"
+#include "MantidQtWidgets/Common/AlgorithmRuntimeProps.h"
+#include "MantidQtWidgets/Common/IAlgorithmRuntimeProps.h"
 
 #include <utility>
-
-#include "MantidAPI/IAlgorithm.h"
 
 namespace MantidQt::CustomInterfaces::ISISReflectometry {
 
@@ -16,7 +17,7 @@ using API::IConfiguredAlgorithm_sptr;
 using Mantid::API::IAlgorithm_sptr;
 
 BatchJobAlgorithm::BatchJobAlgorithm(Mantid::API::IAlgorithm_sptr algorithm,
-                                     MantidQt::API::ConfiguredAlgorithm::AlgorithmRuntimeProps properties,
+                                     std::unique_ptr<MantidQt::API::IAlgorithmRuntimeProps> properties,
                                      UpdateFunction updateFunction, Item *item)
     : ConfiguredAlgorithm(std::move(algorithm), std::move(properties)), m_item(item), m_updateFunction(updateFunction) {
 }

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchJobAlgorithm.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchJobAlgorithm.h
@@ -10,6 +10,8 @@
 #include "IBatchJobAlgorithm.h"
 #include "MantidAPI/IAlgorithm_fwd.h"
 #include "MantidQtWidgets/Common/BatchAlgorithmRunner.h"
+#include "MantidQtWidgets/Common/ConfiguredAlgorithm.h"
+#include "MantidQtWidgets/Common/IAlgorithmRuntimeProps.h"
 
 namespace MantidQt {
 namespace CustomInterfaces {
@@ -25,7 +27,7 @@ public:
   using UpdateFunction = void (*)(const Mantid::API::IAlgorithm_sptr &algorithm, Item &item);
 
   BatchJobAlgorithm(Mantid::API::IAlgorithm_sptr algorithm,
-                    MantidQt::API::ConfiguredAlgorithm::AlgorithmRuntimeProps properties, UpdateFunction updateFunction,
+                    std::unique_ptr<MantidQt::API::IAlgorithmRuntimeProps> properties, UpdateFunction updateFunction,
                     Item *item);
 
   Item *item() override;

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchJobManager.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchJobManager.cpp
@@ -214,7 +214,9 @@ void BatchJobManager::addAlgorithmForProcessingRow(Row &row, std::deque<IConfigu
   algorithms.emplace_back(std::move(algorithm));
 }
 
-AlgorithmRuntimeProps BatchJobManager::rowProcessingProperties() const { return createAlgorithmRuntimeProps(m_batch); }
+std::unique_ptr<MantidQt::API::IAlgorithmRuntimeProps> BatchJobManager::rowProcessingProperties() const {
+  return createAlgorithmRuntimeProps(m_batch);
+}
 
 void BatchJobManager::algorithmStarted(IConfiguredAlgorithm_sptr algorithm) {
   auto item = getRunsTableItem(algorithm);

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchJobManager.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchJobManager.h
@@ -12,6 +12,7 @@
 #include "MantidAPI/IAlgorithm_fwd.h"
 #include "MantidAPI/Workspace_fwd.h"
 #include "MantidQtWidgets/Common/BatchAlgorithmRunner.h"
+#include "MantidQtWidgets/Common/IAlgorithmRuntimeProps.h"
 #include "Reduction/Batch.h"
 
 #include <boost/optional.hpp>
@@ -56,7 +57,7 @@ public:
   void notifyAllWorkspacesDeleted() override;
 
   std::deque<MantidQt::API::IConfiguredAlgorithm_sptr> getAlgorithms() override;
-  API::IConfiguredAlgorithm::AlgorithmRuntimeProps rowProcessingProperties() const override;
+  std::unique_ptr<MantidQt::API::IAlgorithmRuntimeProps> rowProcessingProperties() const override;
 
   bool getProcessPartial() const override;
   bool getProcessAll() const override;

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchPresenter.cpp
@@ -321,7 +321,7 @@ void BatchPresenter::notifyResetRoundPrecision() { m_runsPresenter->resetRoundPr
  */
 int BatchPresenter::percentComplete() const { return m_jobManager->percentComplete(); }
 
-API::IConfiguredAlgorithm::AlgorithmRuntimeProps BatchPresenter::rowProcessingProperties() const {
+std::unique_ptr<MantidQt::API::IAlgorithmRuntimeProps> BatchPresenter::rowProcessingProperties() const {
   return m_jobManager->rowProcessingProperties();
 }
 

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchPresenter.h
@@ -85,7 +85,7 @@ public:
   Mantid::Geometry::Instrument_const_sptr instrument() const override;
   std::string instrumentName() const override;
   int percentComplete() const override;
-  API::IConfiguredAlgorithm::AlgorithmRuntimeProps rowProcessingProperties() const override;
+  std::unique_ptr<MantidQt::API::IAlgorithmRuntimeProps> rowProcessingProperties() const override;
 
   // WorkspaceObserver overrides
   void postDeleteHandle(const std::string &wsName) override;

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/GroupProcessingAlgorithm.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/GroupProcessingAlgorithm.cpp
@@ -14,13 +14,14 @@
 #include "BatchJobAlgorithm.h"
 #include "MantidAPI/AlgorithmManager.h"
 #include "MantidAPI/IAlgorithm.h"
+#include "MantidQtWidgets/Common/AlgorithmRuntimeProps.h"
 #include "MantidQtWidgets/Common/BatchAlgorithmRunner.h"
+#include "MantidQtWidgets/Common/IAlgorithmRuntimeProps.h"
 
 namespace MantidQt::CustomInterfaces::ISISReflectometry {
 
 using API::IConfiguredAlgorithm_sptr;
 using Mantid::API::IAlgorithm_sptr;
-using AlgorithmRuntimeProps = std::map<std::string, std::string>;
 namespace { // unnamed namespace
 
 std::string removePrefix(std::string const &value, std::string const &prefix) {
@@ -119,20 +120,22 @@ IConfiguredAlgorithm_sptr createConfiguredAlgorithm(Batch const &model, Group &g
   auto properties = createAlgorithmRuntimeProps(model, group);
 
   // Return the configured algorithm
-  auto jobAlgorithm = std::make_shared<BatchJobAlgorithm>(alg, properties, updateGroupFromOutputProperties, &group);
+  auto jobAlgorithm = std::make_shared<BatchJobAlgorithm>(std::move(alg), std::move(properties),
+                                                          updateGroupFromOutputProperties, &group);
   return jobAlgorithm;
 }
 
-AlgorithmRuntimeProps createAlgorithmRuntimeProps(Batch const &model, Group const &group) {
-  auto properties = AlgorithmRuntimeProps();
-  updateWorkspaceProperties(properties, group);
+std::unique_ptr<MantidQt::API::IAlgorithmRuntimeProps> createAlgorithmRuntimeProps(Batch const &model,
+                                                                                   Group const &group) {
+  auto properties = std::make_unique<MantidQt::API::AlgorithmRuntimeProps>();
+  updateWorkspaceProperties(*properties, group);
   // Set the rebin Params from the lookup row resolution, if given
-  updateLookupRowProperties(properties, model.findLookupRow());
+  updateLookupRowProperties(*properties, model.findLookupRow());
   // Override the lookup row with the group's rows' resolution,
   // if given
-  updateGroupProperties(properties, group);
+  updateGroupProperties(*properties, group);
   // Override the rebin Params from the user-specified stitch params, if given
-  updateStitchProperties(properties, model.experiment().stitchParameters());
+  updateStitchProperties(*properties, model.experiment().stitchParameters());
   return properties;
 }
 } // namespace MantidQt::CustomInterfaces::ISISReflectometry

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/GroupProcessingAlgorithm.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/GroupProcessingAlgorithm.h
@@ -8,6 +8,9 @@
 
 #include "Common/DllConfig.h"
 #include "MantidQtWidgets/Common/BatchAlgorithmRunner.h"
+#include "MantidQtWidgets/Common/IAlgorithmRuntimeProps.h"
+#include "MantidQtWidgets/Common/IConfiguredAlgorithm.h"
+
 #include <boost/optional.hpp>
 #include <map>
 #include <string>
@@ -20,12 +23,12 @@ class Batch;
 class Group;
 class IConfiguredAlgorithm;
 
-using AlgorithmRuntimeProps = std::map<std::string, std::string>;
+using AlgorithmRuntimeProps = MantidQt::API::IAlgorithmRuntimeProps;
 
 MANTIDQT_ISISREFLECTOMETRY_DLL MantidQt::API::IConfiguredAlgorithm_sptr createConfiguredAlgorithm(Batch const &model,
                                                                                                   Group &group);
-MANTIDQT_ISISREFLECTOMETRY_DLL AlgorithmRuntimeProps createAlgorithmRuntimeProps(Batch const &model,
-                                                                                 Group const &group);
+MANTIDQT_ISISREFLECTOMETRY_DLL std::unique_ptr<MantidQt::API::IAlgorithmRuntimeProps>
+createAlgorithmRuntimeProps(Batch const &model, Group const &group);
 } // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/IBatchJobManager.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/IBatchJobManager.h
@@ -9,9 +9,11 @@
 #include "Common/DllConfig.h"
 #include "GUI/Batch/RowProcessingAlgorithm.h"
 #include "MantidQtWidgets/Common/BatchAlgorithmRunner.h"
+#include "MantidQtWidgets/Common/IAlgorithmRuntimeProps.h"
 #include "Reduction/Batch.h"
 
 #include <boost/optional.hpp>
+#include <memory>
 
 namespace MantidQt {
 namespace CustomInterfaces {
@@ -42,7 +44,7 @@ public:
                                                                std::string const &newName) = 0;
   virtual void notifyAllWorkspacesDeleted() = 0;
   virtual std::deque<MantidQt::API::IConfiguredAlgorithm_sptr> getAlgorithms() = 0;
-  virtual API::IConfiguredAlgorithm::AlgorithmRuntimeProps rowProcessingProperties() const = 0;
+  virtual std::unique_ptr<MantidQt::API::IAlgorithmRuntimeProps> rowProcessingProperties() const = 0;
   virtual bool getProcessPartial() const = 0;
   virtual bool getProcessAll() const = 0;
 };

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/IBatchPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/IBatchPresenter.h
@@ -8,7 +8,9 @@
 
 #include "GUI/Batch/RowProcessingAlgorithm.h"
 #include "MantidGeometry/Instrument_fwd.h"
+#include "MantidQtWidgets/Common/IAlgorithmRuntimeProps.h"
 
+#include <memory>
 #include <string>
 
 namespace MantidQt {
@@ -58,7 +60,7 @@ public:
   virtual bool discardChanges(std::string const &message) const = 0;
   virtual bool requestClose() const = 0;
   virtual int percentComplete() const = 0;
-  virtual API::IConfiguredAlgorithm::AlgorithmRuntimeProps rowProcessingProperties() const = 0;
+  virtual std::unique_ptr<MantidQt::API::IAlgorithmRuntimeProps> rowProcessingProperties() const = 0;
 
   virtual bool isBatchUnsaved() const = 0;
   virtual void setBatchUnsaved() = 0;

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/RowPreprocessingAlgorithm.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/RowPreprocessingAlgorithm.cpp
@@ -9,6 +9,7 @@
 #include "BatchJobAlgorithm.h"
 #include "MantidAPI/AlgorithmManager.h"
 #include "MantidAPI/IAlgorithm.h"
+#include "MantidQtWidgets/Common/AlgorithmRuntimeProps.h"
 #include "MantidQtWidgets/Common/BatchAlgorithmRunner.h"
 #include "Reduction/Item.h"
 #include "Reduction/PreviewRow.h"
@@ -22,7 +23,7 @@ using MantidQt::API::IConfiguredAlgorithm;
 using MantidQt::API::IConfiguredAlgorithm_sptr;
 
 namespace {
-void updateInputWorkspacesProperties(IConfiguredAlgorithm::AlgorithmRuntimeProps &properties,
+void updateInputWorkspacesProperties(MantidQt::API::IAlgorithmRuntimeProps &properties,
                                      std::vector<std::string> const &inputRunNumbers) {
   AlgorithmProperties::update("InputRunList", inputRunNumbers, properties);
 }
@@ -47,11 +48,12 @@ IConfiguredAlgorithm_sptr createConfiguredAlgorithm(IBatch const & /*model*/, Pr
   alg->getPointerToProperty("OutputWorkspace")->createTemporaryValue();
 
   // Set the algorithm properties from the model
-  auto properties = IConfiguredAlgorithm::AlgorithmRuntimeProps();
-  updateInputWorkspacesProperties(properties, row.runNumbers());
+  auto properties = std::make_unique<MantidQt::API::AlgorithmRuntimeProps>();
+  updateInputWorkspacesProperties(*properties, row.runNumbers());
 
   // Return the configured algorithm
-  auto jobAlgorithm = std::make_shared<BatchJobAlgorithm>(alg, properties, updateRowOnAlgorithmComplete, &row);
+  auto jobAlgorithm =
+      std::make_shared<BatchJobAlgorithm>(std::move(alg), std::move(properties), updateRowOnAlgorithmComplete, &row);
   return jobAlgorithm;
 }
 

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/RowProcessingAlgorithm.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/RowProcessingAlgorithm.h
@@ -7,9 +7,12 @@
 #pragma once
 
 #include "Common/DllConfig.h"
-#include "MantidQtWidgets/Common/BatchAlgorithmRunner.h"
+#include "MantidQtWidgets/Common/IAlgorithmRuntimeProps.h"
+#include "MantidQtWidgets/Common/IConfiguredAlgorithm.h"
 #include <boost/optional.hpp>
+
 #include <map>
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -22,9 +25,9 @@ class Row;
 MANTIDQT_ISISREFLECTOMETRY_DLL MantidQt::API::IConfiguredAlgorithm_sptr createConfiguredAlgorithm(Batch const &model,
                                                                                                   Row &row);
 
-MANTIDQT_ISISREFLECTOMETRY_DLL API::IConfiguredAlgorithm::AlgorithmRuntimeProps
+MANTIDQT_ISISREFLECTOMETRY_DLL std::unique_ptr<MantidQt::API::IAlgorithmRuntimeProps>
 createAlgorithmRuntimeProps(Batch const &model, Row const &row);
-MANTIDQT_ISISREFLECTOMETRY_DLL API::IConfiguredAlgorithm::AlgorithmRuntimeProps
+MANTIDQT_ISISREFLECTOMETRY_DLL std::unique_ptr<MantidQt::API::IAlgorithmRuntimeProps>
 createAlgorithmRuntimeProps(Batch const &model);
 } // namespace ISISReflectometry
 } // namespace CustomInterfaces

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/RunsPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/RunsPresenter.cpp
@@ -469,16 +469,16 @@ void RunsPresenter::handleError(const std::string &message) { m_messageHandler->
 
 std::string RunsPresenter::liveDataReductionAlgorithm() { return "ReflectometryReductionOneLiveData"; }
 
-std::string RunsPresenter::liveDataReductionOptions(const std::string &inputWorkspace, const std::string &instrument) {
+std::unique_ptr<MantidQt::API::IAlgorithmRuntimeProps>
+RunsPresenter::liveDataReductionOptions(const std::string &inputWorkspace, const std::string &instrument) {
   // Get the properties for the reduction algorithm from the settings tabs
-  API::IConfiguredAlgorithm::AlgorithmRuntimeProps options = m_mainPresenter->rowProcessingProperties();
+  auto options = m_mainPresenter->rowProcessingProperties();
   // Add other required input properties to the live data reduction algorithnm
-  options["InputWorkspace"] = inputWorkspace;
-  options["Instrument"] = instrument;
-  options["GetLiveValueAlgorithm"] = "GetLiveInstrumentValue";
+  options->setPropertyValue("InputWorkspace", inputWorkspace);
+  options->setPropertyValue("Instrument", instrument);
+  options->setPropertyValue("GetLiveValueAlgorithm", "GetLiveInstrumentValue");
   // Convert the properties to a string to pass to the algorithm
-  auto const optionsString = convertMapToString(options, ';', false);
-  return optionsString;
+  return options;
 }
 
 IAlgorithm_sptr RunsPresenter::setupLiveDataMonitorAlgorithm() {

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/RunsPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/RunsPresenter.cpp
@@ -469,16 +469,15 @@ void RunsPresenter::handleError(const std::string &message) { m_messageHandler->
 
 std::string RunsPresenter::liveDataReductionAlgorithm() { return "ReflectometryReductionOneLiveData"; }
 
-std::unique_ptr<MantidQt::API::IAlgorithmRuntimeProps>
-RunsPresenter::liveDataReductionOptions(const std::string &inputWorkspace, const std::string &instrument) {
+std::string RunsPresenter::liveDataReductionOptions(const std::string &inputWorkspace, const std::string &instrument) {
   // Get the properties for the reduction algorithm from the settings tabs
   auto options = m_mainPresenter->rowProcessingProperties();
   // Add other required input properties to the live data reduction algorithnm
   options->setPropertyValue("InputWorkspace", inputWorkspace);
   options->setPropertyValue("Instrument", instrument);
   options->setPropertyValue("GetLiveValueAlgorithm", "GetLiveInstrumentValue");
-  // Convert the properties to a string to pass to the algorithm
-  return options;
+
+  return convertAlgPropsToString(*options);
 }
 
 IAlgorithm_sptr RunsPresenter::setupLiveDataMonitorAlgorithm() {

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/RunsPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/RunsPresenter.h
@@ -173,8 +173,7 @@ private:
   void stopMonitor();
   void startMonitorComplete();
   std::string liveDataReductionAlgorithm();
-  std::unique_ptr<MantidQt::API::IAlgorithmRuntimeProps> liveDataReductionOptions(const std::string &inputWorkspace,
-                                                                                  const std::string &instrument);
+  std::string liveDataReductionOptions(const std::string &inputWorkspace, const std::string &instrument);
 
   Mantid::API::IAlgorithm_sptr setupLiveDataMonitorAlgorithm();
 

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/RunsPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/RunsPresenter.h
@@ -173,7 +173,8 @@ private:
   void stopMonitor();
   void startMonitorComplete();
   std::string liveDataReductionAlgorithm();
-  std::string liveDataReductionOptions(const std::string &inputWorkspace, const std::string &instrument);
+  std::unique_ptr<MantidQt::API::IAlgorithmRuntimeProps> liveDataReductionOptions(const std::string &inputWorkspace,
+                                                                                  const std::string &instrument);
 
   Mantid::API::IAlgorithm_sptr setupLiveDataMonitorAlgorithm();
 

--- a/qt/scientific_interfaces/ISISReflectometry/test/Batch/GroupProcessingAlgorithmTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Batch/GroupProcessingAlgorithmTest.h
@@ -36,14 +36,14 @@ public:
     auto model = Batch(m_experiment, m_instrument, m_runsTable, m_slicing);
     auto group = makeGroupWithTwoRows();
     auto result = createAlgorithmRuntimeProps(model, group);
-    TS_ASSERT_EQUALS(result["InputWorkspaces"], "IvsQ_1, IvsQ_2");
+    TS_ASSERT_EQUALS(result->getPropertyValue("InputWorkspaces"), "IvsQ_1, IvsQ_2");
   }
 
   void testInputWorkspaceListForRowsWithNonStandardNames() {
     auto model = Batch(m_experiment, m_instrument, m_runsTable, m_slicing);
     auto group = makeGroupWithTwoRowsWithNonstandardNames();
     auto result = createAlgorithmRuntimeProps(model, group);
-    TS_ASSERT_EQUALS(result["InputWorkspaces"], "testQ1, testQ2");
+    TS_ASSERT_EQUALS(result->getPropertyValue("InputWorkspaces"), "testQ1, testQ2");
   }
 
   void testOutputNameForTwoRowGroup() {
@@ -52,7 +52,7 @@ public:
     auto result = createAlgorithmRuntimeProps(model, group);
     // The standard IvsQ_ prefix is removed from the individual names so it
     // only appears once at the beginning.
-    TS_ASSERT_EQUALS(result["OutputWorkspace"], "IvsQ_1_2");
+    TS_ASSERT_EQUALS(result->getPropertyValue("OutputWorkspace"), "IvsQ_1_2");
   }
 
   void testOutputNameForRowsWithNonStandardNames() {
@@ -61,7 +61,7 @@ public:
     auto result = createAlgorithmRuntimeProps(model, group);
     // The output is constructed from an IvsQ_ prefix and the original
     // output workspace names
-    TS_ASSERT_EQUALS(result["OutputWorkspace"], "IvsQ_testQ1_testQ2");
+    TS_ASSERT_EQUALS(result->getPropertyValue("OutputWorkspace"), "IvsQ_testQ1_testQ2");
   }
 
   void testStitchParamsSetFromStitchingOptions() {
@@ -73,9 +73,9 @@ public:
     auto model = Batch(experiment, m_instrument, m_runsTable, m_slicing);
     auto group = makeGroupWithTwoRows();
     auto result = createAlgorithmRuntimeProps(model, group);
-    TS_ASSERT_EQUALS(result["key1"], "value1");
-    TS_ASSERT_EQUALS(result["key2"], "value2");
-    TS_ASSERT_EQUALS(result.find("Params"), result.cend());
+    TS_ASSERT_EQUALS(result->getPropertyValue("key1"), "value1");
+    TS_ASSERT_EQUALS(result->getPropertyValue("key2"), "value2");
+    TS_ASSERT(!result->existsProperty("Params"));
   }
 
   void testLookupRowQResolutionUsedForParamsIfStitchingOptionsEmpty() {
@@ -87,7 +87,7 @@ public:
     auto model = Batch(experiment, m_instrument, m_runsTable, m_slicing);
     auto group = makeGroupWithTwoRows();
     auto result = createAlgorithmRuntimeProps(model, group);
-    TS_ASSERT_EQUALS(result["Params"], "-0.010000");
+    TS_ASSERT_EQUALS(result->getPropertyValue("Params"), "-0.010000");
   }
 
   void testQResolutionForFirstValidRowUsedForParamsIfStitchingOptionsEmpty() {
@@ -99,7 +99,7 @@ public:
     auto model = Batch(experiment, m_instrument, m_runsTable, m_slicing);
     auto group = makeGroupWithTwoRowsWithMixedQResolutions();
     auto result = createAlgorithmRuntimeProps(model, group);
-    TS_ASSERT_EQUALS(result["Params"], "-0.015000");
+    TS_ASSERT_EQUALS(result->getPropertyValue("Params"), "-0.015000");
   }
 
   void testQOutputResolutionForFirstValidRowUsedForParamsIfStitchingOptionsEmpty() {
@@ -111,7 +111,7 @@ public:
     auto model = Batch(experiment, m_instrument, m_runsTable, m_slicing);
     auto group = makeGroupWithTwoRowsWithOutputQResolutions();
     auto result = createAlgorithmRuntimeProps(model, group);
-    TS_ASSERT_EQUALS(result["Params"], "-0.016000");
+    TS_ASSERT_EQUALS(result->getPropertyValue("Params"), "-0.016000");
   }
 
 private:

--- a/qt/scientific_interfaces/ISISReflectometry/test/Batch/RowPreprocessingAlgorithmTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Batch/RowPreprocessingAlgorithmTest.h
@@ -57,9 +57,13 @@ public:
     TS_ASSERT_EQUALS(configuredAlg->algorithm(), mockAlg);
     MantidQt::API::AlgorithmRuntimeProps expectedProps;
     expectedProps.setPropertyValue("InputRunList", inputRuns[0]);
-    TS_ASSERT_EQUALS(
-        dynamic_cast<const MantidQt::API::AlgorithmRuntimeProps &>(configuredAlg->getAlgorithmRuntimeProps()),
-        expectedProps);
+    const auto &setProps = configuredAlg->getAlgorithmRuntimeProps();
+    const auto &propNames = expectedProps.getDeclaredPropertyNames();
+
+    TS_ASSERT(std::all_of(propNames.cbegin(), propNames.cend(), [&setProps, &expectedProps](const std::string &name) {
+      return setProps.existsProperty(name) &&
+             expectedProps.getPropertyValue(name) == expectedProps.getPropertyValue(name);
+    }))
   }
 
   void test_row_is_updated_on_algorithm_complete() {

--- a/qt/scientific_interfaces/ISISReflectometry/test/Batch/RowPreprocessingAlgorithmTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Batch/RowPreprocessingAlgorithmTest.h
@@ -11,6 +11,7 @@
 #include "../../../ISISReflectometry/Reduction/PreviewRow.h"
 #include "../../../ISISReflectometry/TestHelpers/ModelCreationHelper.h"
 #include "MantidFrameworkTestHelpers/WorkspaceCreationHelper.h"
+#include "MantidQtWidgets/Common/AlgorithmRuntimeProps.h"
 #include "MantidQtWidgets/Common/BatchAlgorithmRunner.h"
 #include "MockBatch.h"
 
@@ -54,8 +55,10 @@ public:
 
     auto configuredAlg = createConfiguredAlgorithm(batch, row, mockAlg);
     TS_ASSERT_EQUALS(configuredAlg->algorithm(), mockAlg);
-    auto expectedProps = IConfiguredAlgorithm::AlgorithmRuntimeProps{{"InputRunList", inputRuns[0]}};
-    TS_ASSERT_EQUALS(configuredAlg->properties(), expectedProps);
+    MantidQt::API::AlgorithmRuntimeProps expectedProps;
+    expectedProps.setPropertyValue("InputRunList", inputRuns[0]);
+    TS_ASSERT_EQUALS(dynamic_cast<const MantidQt::API::AlgorithmRuntimeProps &>(configuredAlg->properties()),
+                     expectedProps);
   }
 
   void test_row_is_updated_on_algorithm_complete() {

--- a/qt/scientific_interfaces/ISISReflectometry/test/Batch/RowPreprocessingAlgorithmTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Batch/RowPreprocessingAlgorithmTest.h
@@ -57,8 +57,9 @@ public:
     TS_ASSERT_EQUALS(configuredAlg->algorithm(), mockAlg);
     MantidQt::API::AlgorithmRuntimeProps expectedProps;
     expectedProps.setPropertyValue("InputRunList", inputRuns[0]);
-    TS_ASSERT_EQUALS(dynamic_cast<const MantidQt::API::AlgorithmRuntimeProps &>(configuredAlg->properties()),
-                     expectedProps);
+    TS_ASSERT_EQUALS(
+        dynamic_cast<const MantidQt::API::AlgorithmRuntimeProps &>(configuredAlg->getAlgorithmRuntimeProps()),
+        expectedProps);
   }
 
   void test_row_is_updated_on_algorithm_complete() {

--- a/qt/scientific_interfaces/ISISReflectometry/test/Batch/RowProcessingAlgorithmTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Batch/RowProcessingAlgorithmTest.h
@@ -29,42 +29,42 @@ public:
   void testExperimentSettings() {
     auto model = Batch(m_experiment, m_instrument, m_runsTable, m_slicing);
     auto result = createAlgorithmRuntimeProps(model);
-    TS_ASSERT_EQUALS(result["AnalysisMode"], "MultiDetectorAnalysis");
-    TS_ASSERT_EQUALS(result["ReductionType"], "NonFlatSample");
-    TS_ASSERT_EQUALS(result["SummationType"], "SumInQ");
-    TS_ASSERT_EQUALS(result["IncludePartialBins"], "1");
-    TS_ASSERT_EQUALS(result["Debug"], "1");
-    TS_ASSERT_EQUALS(result["SubtractBackground"], "1");
-    TS_ASSERT_EQUALS(result["BackgroundCalculationMethod"], "Polynomial");
-    TS_ASSERT_EQUALS(result["DegreeOfPolynomial"], "3");
-    TS_ASSERT_EQUALS(result["CostFunction"], "Unweighted least squares");
-    TS_ASSERT_EQUALS(result["PolarizationAnalysis"], "1");
-    TS_ASSERT_EQUALS(result["FloodCorrection"], "Workspace");
-    TS_ASSERT_EQUALS(result["FloodWorkspace"], "test_workspace");
-    TS_ASSERT_EQUALS(result["StartOverlap"], "7.500000");
-    TS_ASSERT_EQUALS(result["EndOverlap"], "9.200000");
-    TS_ASSERT_EQUALS(result["Params"], "-0.02");
-    TS_ASSERT_EQUALS(result["ScaleRHSWorkspace"], "1");
+    TS_ASSERT_EQUALS(result->getPropertyValue("AnalysisMode"), "MultiDetectorAnalysis");
+    TS_ASSERT_EQUALS(result->getPropertyValue("ReductionType"), "NonFlatSample");
+    TS_ASSERT_EQUALS(result->getPropertyValue("SummationType"), "SumInQ");
+    TS_ASSERT_EQUALS(result->getPropertyValue("IncludePartialBins"), "1");
+    TS_ASSERT_EQUALS(result->getPropertyValue("Debug"), "1");
+    TS_ASSERT_EQUALS(result->getPropertyValue("SubtractBackground"), "1");
+    TS_ASSERT_EQUALS(result->getPropertyValue("BackgroundCalculationMethod"), "Polynomial");
+    TS_ASSERT_EQUALS(result->getPropertyValue("DegreeOfPolynomial"), "3");
+    TS_ASSERT_EQUALS(result->getPropertyValue("CostFunction"), "Unweighted least squares");
+    TS_ASSERT_EQUALS(result->getPropertyValue("PolarizationAnalysis"), "1");
+    TS_ASSERT_EQUALS(result->getPropertyValue("FloodCorrection"), "Workspace");
+    TS_ASSERT_EQUALS(result->getPropertyValue("FloodWorkspace"), "test_workspace");
+    TS_ASSERT_EQUALS(result->getPropertyValue("StartOverlap"), "7.500000");
+    TS_ASSERT_EQUALS(result->getPropertyValue("EndOverlap"), "9.200000");
+    TS_ASSERT_EQUALS(result->getPropertyValue("Params"), "-0.02");
+    TS_ASSERT_EQUALS(result->getPropertyValue("ScaleRHSWorkspace"), "1");
   }
 
   void testExperimentSettingsWithEmptyRow() {
     auto model = Batch(m_experiment, m_instrument, m_runsTable, m_slicing);
     auto row = makeEmptyRow();
     auto result = createAlgorithmRuntimeProps(model, row);
-    TS_ASSERT_EQUALS(result["AnalysisMode"], "MultiDetectorAnalysis");
-    TS_ASSERT_EQUALS(result["ReductionType"], "NonFlatSample");
-    TS_ASSERT_EQUALS(result["SummationType"], "SumInQ");
-    TS_ASSERT_EQUALS(result["IncludePartialBins"], "1");
-    TS_ASSERT_EQUALS(result["Debug"], "1");
-    TS_ASSERT_EQUALS(result["SubtractBackground"], "1");
-    TS_ASSERT_EQUALS(result["BackgroundCalculationMethod"], "Polynomial");
-    TS_ASSERT_EQUALS(result["DegreeOfPolynomial"], "3");
-    TS_ASSERT_EQUALS(result["CostFunction"], "Unweighted least squares");
-    TS_ASSERT_EQUALS(result["PolarizationAnalysis"], "1");
-    TS_ASSERT_EQUALS(result["FloodCorrection"], "Workspace");
-    TS_ASSERT_EQUALS(result["FloodWorkspace"], "test_workspace");
-    TS_ASSERT_EQUALS(result["StartOverlap"], "7.500000");
-    TS_ASSERT_EQUALS(result["EndOverlap"], "9.200000");
+    TS_ASSERT_EQUALS(result->getPropertyValue("AnalysisMode"), "MultiDetectorAnalysis");
+    TS_ASSERT_EQUALS(result->getPropertyValue("ReductionType"), "NonFlatSample");
+    TS_ASSERT_EQUALS(result->getPropertyValue("SummationType"), "SumInQ");
+    TS_ASSERT_EQUALS(result->getPropertyValue("IncludePartialBins"), "1");
+    TS_ASSERT_EQUALS(result->getPropertyValue("Debug"), "1");
+    TS_ASSERT_EQUALS(result->getPropertyValue("SubtractBackground"), "1");
+    TS_ASSERT_EQUALS(result->getPropertyValue("BackgroundCalculationMethod"), "Polynomial");
+    TS_ASSERT_EQUALS(result->getPropertyValue("DegreeOfPolynomial"), "3");
+    TS_ASSERT_EQUALS(result->getPropertyValue("CostFunction"), "Unweighted least squares");
+    TS_ASSERT_EQUALS(result->getPropertyValue("PolarizationAnalysis"), "1");
+    TS_ASSERT_EQUALS(result->getPropertyValue("FloodCorrection"), "Workspace");
+    TS_ASSERT_EQUALS(result->getPropertyValue("FloodWorkspace"), "test_workspace");
+    TS_ASSERT_EQUALS(result->getPropertyValue("StartOverlap"), "7.500000");
+    TS_ASSERT_EQUALS(result->getPropertyValue("EndOverlap"), "9.200000");
   }
 
   void testLookupRowWithAngleLookup() {
@@ -72,15 +72,15 @@ public:
     // angle within tolerance of 2.3
     auto row = makeRow(2.29);
     auto result = createAlgorithmRuntimeProps(model, row);
-    TS_ASSERT_EQUALS(result["FirstTransmissionRunList"], "22348, 22349");
-    TS_ASSERT_EQUALS(result["SecondTransmissionRunList"], "22358, 22359");
-    TS_ASSERT_EQUALS(result["TransmissionProcessingInstructions"], "4");
-    TS_ASSERT_EQUALS(result["MomentumTransferMin"], "0.009000");
-    TS_ASSERT_EQUALS(result["MomentumTransferStep"], "0.030000");
-    TS_ASSERT_EQUALS(result["MomentumTransferMax"], "1.300000");
-    TS_ASSERT_EQUALS(result["ScaleFactor"], "0.900000");
-    TS_ASSERT_EQUALS(result["ProcessingInstructions"], "4-6");
-    TS_ASSERT_EQUALS(result["BackgroundProcessingInstructions"], "2-3,7-8");
+    TS_ASSERT_EQUALS(result->getPropertyValue("FirstTransmissionRunList"), "22348, 22349");
+    TS_ASSERT_EQUALS(result->getPropertyValue("SecondTransmissionRunList"), "22358, 22359");
+    TS_ASSERT_EQUALS(result->getPropertyValue("TransmissionProcessingInstructions"), "4");
+    TS_ASSERT_EQUALS(result->getPropertyValue("MomentumTransferMin"), "0.009000");
+    TS_ASSERT_EQUALS(result->getPropertyValue("MomentumTransferStep"), "0.030000");
+    TS_ASSERT_EQUALS(result->getPropertyValue("MomentumTransferMax"), "1.300000");
+    TS_ASSERT_EQUALS(result->getPropertyValue("ScaleFactor"), "0.900000");
+    TS_ASSERT_EQUALS(result->getPropertyValue("ProcessingInstructions"), "4-6");
+    TS_ASSERT_EQUALS(result->getPropertyValue("BackgroundProcessingInstructions"), "2-3,7-8");
   }
 
   void testLookupRowWithWildcardLookup() {
@@ -88,46 +88,47 @@ public:
     // angle outside tolerance of any angle matches wildcard row instead
     auto row = makeRow(2.28);
     auto result = createAlgorithmRuntimeProps(model, row);
-    TS_ASSERT_EQUALS(result["FirstTransmissionRunList"], "22345");
-    TS_ASSERT_EQUALS(result["SecondTransmissionRunList"], "22346");
-    TS_ASSERT_EQUALS(result["TransmissionProcessingInstructions"], "5-6");
-    TS_ASSERT_EQUALS(result["MomentumTransferMin"], "0.007000");
-    TS_ASSERT_EQUALS(result["MomentumTransferStep"], "0.010000");
-    TS_ASSERT_EQUALS(result["MomentumTransferMax"], "1.100000");
-    TS_ASSERT_EQUALS(result["ScaleFactor"], "0.700000");
-    TS_ASSERT_EQUALS(result["ProcessingInstructions"], "1");
-    TS_ASSERT_EQUALS(result["BackgroundProcessingInstructions"], "3,7");
+    TS_ASSERT_EQUALS(result->getPropertyValue("FirstTransmissionRunList"), "22345");
+    TS_ASSERT_EQUALS(result->getPropertyValue("SecondTransmissionRunList"), "22346");
+    TS_ASSERT_EQUALS(result->getPropertyValue("TransmissionProcessingInstructions"), "5-6");
+    TS_ASSERT_EQUALS(result->getPropertyValue("MomentumTransferMin"), "0.007000");
+    TS_ASSERT_EQUALS(result->getPropertyValue("MomentumTransferStep"), "0.010000");
+    TS_ASSERT_EQUALS(result->getPropertyValue("MomentumTransferMax"), "1.100000");
+    TS_ASSERT_EQUALS(result->getPropertyValue("ScaleFactor"), "0.700000");
+    TS_ASSERT_EQUALS(result->getPropertyValue("ProcessingInstructions"), "1");
+    TS_ASSERT_EQUALS(result->getPropertyValue("BackgroundProcessingInstructions"), "3,7");
   }
 
   void testInstrumentSettings() {
     auto model = Batch(m_experiment, m_instrument, m_runsTable, m_slicing);
     auto result = createAlgorithmRuntimeProps(model);
-    TS_ASSERT_EQUALS(result["WavelengthMin"], "2.300000");
-    TS_ASSERT_EQUALS(result["WavelengthMax"], "14.400000");
-    TS_ASSERT_EQUALS(result["I0MonitorIndex"], "2");
-    TS_ASSERT_EQUALS(result["NormalizeByIntegratedMonitors"], "1");
-    TS_ASSERT_EQUALS(result["MonitorBackgroundWavelengthMin"], "1.100000");
-    TS_ASSERT_EQUALS(result["MonitorBackgroundWavelengthMax"], "17.200000");
-    TS_ASSERT_EQUALS(result["MonitorIntegrationWavelengthMin"], "3.400000");
-    TS_ASSERT_EQUALS(result["MonitorIntegrationWavelengthMax"], "10.800000");
-    TS_ASSERT_EQUALS(result["CorrectDetectors"], "1");
-    TS_ASSERT_EQUALS(result["DetectorCorrectionType"], "RotateAroundSample");
+    TS_ASSERT_EQUALS(result->getPropertyValue("WavelengthMin"), "2.300000");
+    TS_ASSERT_EQUALS(result->getPropertyValue("WavelengthMax"), "14.400000");
+    TS_ASSERT_EQUALS(result->getPropertyValue("I0MonitorIndex"), "2");
+    TS_ASSERT_EQUALS(result->getPropertyValue("NormalizeByIntegratedMonitors"), "1");
+    TS_ASSERT_EQUALS(result->getPropertyValue("MonitorBackgroundWavelengthMin"), "1.100000");
+    TS_ASSERT_EQUALS(result->getPropertyValue("MonitorBackgroundWavelengthMax"), "17.200000");
+    TS_ASSERT_EQUALS(result->getPropertyValue("MonitorIntegrationWavelengthMin"), "3.400000");
+    TS_ASSERT_EQUALS(result->getPropertyValue("MonitorIntegrationWavelengthMax"), "10.800000");
+    TS_ASSERT_EQUALS(result->getPropertyValue("CorrectDetectors"), "1");
+    TS_ASSERT_EQUALS(result->getPropertyValue("DetectorCorrectionType"), "RotateAroundSample");
   }
 
   void testInstrumentSettingsWithEmptyRow() {
     auto model = Batch(m_experiment, m_instrument, m_runsTable, m_slicing);
     auto row = makeEmptyRow();
     auto result = createAlgorithmRuntimeProps(model, row);
-    TS_ASSERT_EQUALS(result["WavelengthMin"], "2.300000");
-    TS_ASSERT_EQUALS(result["WavelengthMax"], "14.400000");
-    TS_ASSERT_EQUALS(result["I0MonitorIndex"], "2");
-    TS_ASSERT_EQUALS(result["NormalizeByIntegratedMonitors"], "1");
-    TS_ASSERT_EQUALS(result["MonitorBackgroundWavelengthMin"], "1.100000");
-    TS_ASSERT_EQUALS(result["MonitorBackgroundWavelengthMax"], "17.200000");
-    TS_ASSERT_EQUALS(result["MonitorIntegrationWavelengthMin"], "3.400000");
-    TS_ASSERT_EQUALS(result["MonitorIntegrationWavelengthMax"], "10.800000");
-    TS_ASSERT_EQUALS(result["CorrectDetectors"], "1");
-    TS_ASSERT_EQUALS(result["DetectorCorrectionType"], "RotateAroundSample");
+
+    TS_ASSERT_EQUALS(result->getPropertyValue("WavelengthMin"), "2.300000");
+    TS_ASSERT_EQUALS(result->getPropertyValue("WavelengthMax"), "14.400000");
+    TS_ASSERT_EQUALS(result->getPropertyValue("I0MonitorIndex"), "2");
+    TS_ASSERT_EQUALS(result->getPropertyValue("NormalizeByIntegratedMonitors"), "1");
+    TS_ASSERT_EQUALS(result->getPropertyValue("MonitorBackgroundWavelengthMin"), "1.100000");
+    TS_ASSERT_EQUALS(result->getPropertyValue("MonitorBackgroundWavelengthMax"), "17.200000");
+    TS_ASSERT_EQUALS(result->getPropertyValue("MonitorIntegrationWavelengthMin"), "3.400000");
+    TS_ASSERT_EQUALS(result->getPropertyValue("MonitorIntegrationWavelengthMax"), "10.800000");
+    TS_ASSERT_EQUALS(result->getPropertyValue("CorrectDetectors"), "1");
+    TS_ASSERT_EQUALS(result->getPropertyValue("DetectorCorrectionType"), "RotateAroundSample");
   }
 
   void testSettingsForSlicingWithEmptyRow() {
@@ -135,36 +136,36 @@ public:
     auto model = Batch(m_experiment, m_instrument, m_runsTable, slicing);
     auto row = makeEmptyRow();
     auto result = createAlgorithmRuntimeProps(model, row);
-    TS_ASSERT_EQUALS(result["TimeInterval"], "123.400000");
+    TS_ASSERT_EQUALS(result->getPropertyValue("TimeInterval"), "123.400000");
   }
 
   void testSettingsForSlicingByTime() {
     auto slicing = Slicing(UniformSlicingByTime(123.4));
     auto model = Batch(m_experiment, m_instrument, m_runsTable, slicing);
     auto result = createAlgorithmRuntimeProps(model);
-    TS_ASSERT_EQUALS(result["TimeInterval"], "123.400000");
+    TS_ASSERT_EQUALS(result->getPropertyValue("TimeInterval"), "123.400000");
   }
 
   void testSettingsForSlicingByNumberOfSlices() {
     auto slicing = Slicing(UniformSlicingByNumberOfSlices(3));
     auto model = Batch(m_experiment, m_instrument, m_runsTable, slicing);
     auto result = createAlgorithmRuntimeProps(model);
-    TS_ASSERT_EQUALS(result["NumberOfSlices"], "3");
+    TS_ASSERT_EQUALS(result->getPropertyValue("NumberOfSlices"), "3");
   }
 
   void testSettingsForSlicingByList() {
     auto slicing = Slicing(CustomSlicingByList({3.1, 10.2, 47.35}));
     auto model = Batch(m_experiment, m_instrument, m_runsTable, slicing);
     auto result = createAlgorithmRuntimeProps(model);
-    TS_ASSERT_EQUALS(result["TimeInterval"], "3.1, 10.2, 47.35");
+    TS_ASSERT_EQUALS(result->getPropertyValue("TimeInterval"), "3.1, 10.2, 47.35");
   }
 
   void testSettingsForSlicingByLog() {
     auto slicing = Slicing(SlicingByEventLog({18.2}, "test_log_name"));
     auto model = Batch(m_experiment, m_instrument, m_runsTable, slicing);
     auto result = createAlgorithmRuntimeProps(model);
-    TS_ASSERT_EQUALS(result["LogName"], "test_log_name");
-    TS_ASSERT_EQUALS(result["LogValueInterval"], "18.200000");
+    TS_ASSERT_EQUALS(result->getPropertyValue("LogName"), "test_log_name");
+    TS_ASSERT_EQUALS(result->getPropertyValue("LogValueInterval"), "18.200000");
   }
 
   void testSettingsForRowCellValues() {
@@ -173,14 +174,15 @@ public:
     // overridden by the cell values
     auto row = makeRowWithMainCellsFilled(2.3);
     auto result = createAlgorithmRuntimeProps(model, row);
-    TS_ASSERT_EQUALS(result["InputRunList"], "12345, 12346");
-    TS_ASSERT_EQUALS(result["FirstTransmissionRunList"], "92345");
-    TS_ASSERT_EQUALS(result["SecondTransmissionRunList"], "92346");
-    TS_ASSERT_EQUALS(result["ThetaIn"], "2.300000");
-    TS_ASSERT_EQUALS(result["MomentumTransferMin"], "0.100000");
-    TS_ASSERT_EQUALS(result["MomentumTransferStep"], "0.090000");
-    TS_ASSERT_EQUALS(result["MomentumTransferMax"], "0.910000");
-    TS_ASSERT_EQUALS(result["ScaleFactor"], "2.200000");
+
+    TS_ASSERT_EQUALS(result->getPropertyValue("InputRunList"), "12345, 12346");
+    TS_ASSERT_EQUALS(result->getPropertyValue("FirstTransmissionRunList"), "92345");
+    TS_ASSERT_EQUALS(result->getPropertyValue("SecondTransmissionRunList"), "92346");
+    TS_ASSERT_EQUALS(result->getPropertyValue("ThetaIn"), "2.300000");
+    TS_ASSERT_EQUALS(result->getPropertyValue("MomentumTransferMin"), "0.100000");
+    TS_ASSERT_EQUALS(result->getPropertyValue("MomentumTransferStep"), "0.090000");
+    TS_ASSERT_EQUALS(result->getPropertyValue("MomentumTransferMax"), "0.910000");
+    TS_ASSERT_EQUALS(result->getPropertyValue("ScaleFactor"), "2.200000");
   }
 
   void testAddingPropertyViaOptionsCell() {
@@ -189,7 +191,7 @@ public:
     auto model = Batch(m_experiment, m_instrument, m_runsTable, m_slicing);
     auto row = makeRowWithOptionsCellFilled(2.3, ReductionOptionsMap{{"ThetaLogName", "theta_log_name"}});
     auto result = createAlgorithmRuntimeProps(model, row);
-    TS_ASSERT_EQUALS(result["ThetaLogName"], "theta_log_name");
+    TS_ASSERT_EQUALS(result->getPropertyValue("ThetaLogName"), "theta_log_name");
   }
 
   void testOptionsCellOverridesExperimentSettings() {
@@ -197,8 +199,8 @@ public:
     auto row = makeRowWithOptionsCellFilled(
         2.3, ReductionOptionsMap{{"AnalysisMode", "PointDetectorAnalysis"}, {"ReductionType", "DivergentBeam"}});
     auto result = createAlgorithmRuntimeProps(model, row);
-    TS_ASSERT_EQUALS(result["AnalysisMode"], "PointDetectorAnalysis");
-    TS_ASSERT_EQUALS(result["ReductionType"], "DivergentBeam");
+    TS_ASSERT_EQUALS(result->getPropertyValue("AnalysisMode"), "PointDetectorAnalysis");
+    TS_ASSERT_EQUALS(result->getPropertyValue("ReductionType"), "DivergentBeam");
   }
 
   void testOptionsCellOverridesLookupRow() {
@@ -207,14 +209,14 @@ public:
     // overridden by the cell values
     auto row = makeRowWithOptionsCellFilled(2.3, ReductionOptionsMap{{"ProcessingInstructions", "390-410"}});
     auto result = createAlgorithmRuntimeProps(model, row);
-    TS_ASSERT_EQUALS(result["ProcessingInstructions"], "390-410");
+    TS_ASSERT_EQUALS(result->getPropertyValue("ProcessingInstructions"), "390-410");
   }
 
   void testOptionsCellOverridesInstrumentSettings() {
     auto model = Batch(m_experiment, m_instrument, m_runsTable, m_slicing);
     auto row = makeRowWithOptionsCellFilled(2.3, ReductionOptionsMap{{"WavelengthMin", "3.3"}});
     auto result = createAlgorithmRuntimeProps(model, row);
-    TS_ASSERT_EQUALS(result["WavelengthMin"], "3.3");
+    TS_ASSERT_EQUALS(result->getPropertyValue("WavelengthMin"), "3.3");
   }
 
   void testOptionsCellOverridesSubtractBackgroundAndStillPicksUpSettings() {
@@ -227,10 +229,11 @@ public:
     auto model = Batch(experiment, m_instrument, m_runsTable, m_slicing);
     auto row = makeRowWithOptionsCellFilled(2.3, ReductionOptionsMap{{"SubtractBackground", "1"}});
     auto result = createAlgorithmRuntimeProps(model, row);
-    TS_ASSERT_EQUALS(result["SubtractBackground"], "1");
-    TS_ASSERT_EQUALS(result["BackgroundCalculationMethod"], "AveragePixelFit");
-    TS_ASSERT_EQUALS(result["DegreeOfPolynomial"], "3");
-    TS_ASSERT_EQUALS(result["CostFunction"], "Unweighted least squares");
+
+    TS_ASSERT_EQUALS(result->getPropertyValue("SubtractBackground"), "1");
+    TS_ASSERT_EQUALS(result->getPropertyValue("BackgroundCalculationMethod"), "AveragePixelFit");
+    TS_ASSERT_EQUALS(result->getPropertyValue("DegreeOfPolynomial"), "3");
+    TS_ASSERT_EQUALS(result->getPropertyValue("CostFunction"), "Unweighted least squares");
   }
 
 private:

--- a/qt/scientific_interfaces/ISISReflectometry/test/Preview/PreviewJobManagerTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Preview/PreviewJobManagerTest.h
@@ -9,6 +9,7 @@
 #include "../Reduction/MockBatch.h"
 #include "GUI/Batch/BatchJobAlgorithm.h"
 #include "MantidFrameworkTestHelpers/WorkspaceCreationHelper.h"
+#include "MantidQtWidgets/Common/AlgorithmRuntimeProps.h"
 #include "MantidQtWidgets/Common/BatchAlgorithmRunner.h"
 #include "PreviewJobManager.h"
 
@@ -72,8 +73,8 @@ public:
 
     auto row = PreviewRow({"12345"});
     Mantid::API::IAlgorithm_sptr mockAlg = std::make_shared<WorkspaceCreationHelper::StubAlgorithm>();
-    auto properties = IConfiguredAlgorithm::AlgorithmRuntimeProps();
-    auto configuredAlg = std::make_shared<BatchJobAlgorithm>(mockAlg, properties,
+    auto properties = std::make_unique<MantidQt::API::AlgorithmRuntimeProps>();
+    auto configuredAlg = std::make_shared<BatchJobAlgorithm>(std::move(mockAlg), std::move(properties),
                                                              AlgCompleteCallback::updateRowOnAlgorithmComplete, &row);
 
     EXPECT_CALL(mockSubscriber, notifyLoadWorkspaceCompleted).Times(1);
@@ -117,14 +118,14 @@ private:
 
   IConfiguredAlgorithm_sptr makeConfiguredAlg() {
     IAlgorithm_sptr stubAlg = std::make_shared<WorkspaceCreationHelper::StubAlgorithm>();
-    auto emptyProps = MantidQt::API::ConfiguredAlgorithm::AlgorithmRuntimeProps();
-    return std::make_shared<MantidQt::API::ConfiguredAlgorithm>(stubAlg, emptyProps);
+    auto emptyProps = std::make_unique<MantidQt::API::AlgorithmRuntimeProps>();
+    return std::make_shared<MantidQt::API::ConfiguredAlgorithm>(std::move(stubAlg), std::move(emptyProps));
   }
 
   std::shared_ptr<BatchJobAlgorithm> makeConfiguredAlg(Item &item) {
     Mantid::API::IAlgorithm_sptr mockAlg = std::make_shared<WorkspaceCreationHelper::StubAlgorithm>();
-    auto properties = IConfiguredAlgorithm::AlgorithmRuntimeProps();
-    auto configuredAlg = std::make_shared<BatchJobAlgorithm>(mockAlg, properties, nullptr, &item);
+    auto properties = std::make_unique<MantidQt::API::AlgorithmRuntimeProps>();
+    auto configuredAlg = std::make_shared<BatchJobAlgorithm>(std::move(mockAlg), std::move(properties), nullptr, &item);
     return configuredAlg;
   }
 };

--- a/qt/scientific_interfaces/ISISReflectometry/test/ReflMockObjects.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/ReflMockObjects.h
@@ -353,7 +353,8 @@ class MockBatchJobAlgorithm : public IBatchJobAlgorithm, public MantidQt::API::I
 public:
   MockBatchJobAlgorithm() {}
   MOCK_CONST_METHOD0(algorithm, Mantid::API::IAlgorithm_sptr());
-  MOCK_METHOD((const MantidQt::API::IAlgorithmRuntimeProps &), properties, (), (const, override, noexcept));
+  MOCK_METHOD((const MantidQt::API::IAlgorithmRuntimeProps &), getAlgorithmRuntimeProps, (),
+              (const, override, noexcept));
   MOCK_METHOD0(item, Item *());
   MOCK_METHOD0(updateItem, void());
   MOCK_CONST_METHOD0(outputWorkspaceNames, std::vector<std::string>());

--- a/qt/scientific_interfaces/ISISReflectometry/test/ReflMockObjects.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/ReflMockObjects.h
@@ -92,7 +92,7 @@ public:
   MOCK_CONST_METHOD0(getUnsavedBatchFlag, bool());
   MOCK_METHOD1(setUnsavedBatchFlag, void(bool));
   MOCK_CONST_METHOD0(percentComplete, int());
-  MOCK_CONST_METHOD0(rowProcessingProperties, MantidQt::API::IConfiguredAlgorithm::AlgorithmRuntimeProps());
+  MOCK_CONST_METHOD0(rowProcessingProperties, std::unique_ptr<MantidQt::API::IAlgorithmRuntimeProps>());
   MOCK_CONST_METHOD0(requestClose, bool());
   MOCK_CONST_METHOD0(instrument, Mantid::Geometry::Instrument_const_sptr());
   MOCK_CONST_METHOD0(instrumentName, std::string());
@@ -344,7 +344,7 @@ public:
   MOCK_METHOD2(notifyWorkspaceRenamed, boost::optional<Item const &>(std::string const &, std::string const &));
   MOCK_METHOD0(notifyAllWorkspacesDeleted, void());
   MOCK_METHOD0(getAlgorithms, std::deque<MantidQt::API::IConfiguredAlgorithm_sptr>());
-  MOCK_CONST_METHOD0(rowProcessingProperties, MantidQt::API::IConfiguredAlgorithm::AlgorithmRuntimeProps());
+  MOCK_CONST_METHOD0(rowProcessingProperties, std::unique_ptr<MantidQt::API::IAlgorithmRuntimeProps>());
   MOCK_CONST_METHOD0(getProcessPartial, bool());
   MOCK_CONST_METHOD0(getProcessAll, bool());
 };
@@ -353,7 +353,7 @@ class MockBatchJobAlgorithm : public IBatchJobAlgorithm, public MantidQt::API::I
 public:
   MockBatchJobAlgorithm() {}
   MOCK_CONST_METHOD0(algorithm, Mantid::API::IAlgorithm_sptr());
-  MOCK_CONST_METHOD0(properties, MantidQt::API::IConfiguredAlgorithm::AlgorithmRuntimeProps());
+  MOCK_METHOD((const MantidQt::API::IAlgorithmRuntimeProps &), properties, (), (const, override, noexcept));
   MOCK_METHOD0(item, Item *());
   MOCK_METHOD0(updateItem, void());
   MOCK_CONST_METHOD0(outputWorkspaceNames, std::vector<std::string>());

--- a/qt/scientific_interfaces/ISISReflectometry/test/Runs/RunsPresenterTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Runs/RunsPresenterTest.h
@@ -15,6 +15,7 @@
 #include "MantidAPI/AlgorithmManager.h"
 #include "MantidAPI/FrameworkManager.h"
 #include "MantidKernel/ConfigService.h"
+#include "MantidQtWidgets/Common/AlgorithmRuntimeProps.h"
 #include "MantidQtWidgets/Common/Batch/MockJobTreeView.h"
 #include "MantidQtWidgets/Common/MockAlgorithmRunner.h"
 #include "MantidQtWidgets/Common/MockProgressableView.h"
@@ -30,6 +31,7 @@ using namespace MantidQt::CustomInterfaces::ISISReflectometry::ModelCreationHelp
 using namespace MantidQt::API;
 using testing::_;
 using testing::AtLeast;
+using testing::ByMove;
 using testing::Mock;
 using testing::NiceMock;
 using testing::Return;
@@ -682,27 +684,30 @@ public:
     auto algRunner = expectGetAlgorithmRunner();
     presenter.notifyStartMonitor();
     auto expected = defaultLiveMonitorAlgorithmOptions(instrument, updateInterval);
-    assertAlgorithmPropertiesContainOptions(expected, algRunner);
+    assertAlgorithmPropertiesContainOptions(*expected, algRunner);
     verifyAndClear();
   }
 
   void testStartMonitorSetsDefaultPostProcessingProperties() {
     auto presenter = makePresenter();
     auto options = defaultLiveMonitorReductionOptions();
-    expectGetLiveDataOptions(options);
+    expectGetLiveDataOptions(
+        std::make_unique<AlgorithmRuntimeProps>(dynamic_cast<const MantidQt::API::AlgorithmRuntimeProps &>(*options)));
     auto algRunner = expectGetAlgorithmRunner();
     presenter.notifyStartMonitor();
-    assertPostProcessingPropertiesContainOptions(options, algRunner);
+    assertPostProcessingPropertiesContainOptions(*options, algRunner);
     verifyAndClear();
   }
 
   void testStartMonitorSetsUserSpecifiedPostProcessingProperties() {
     auto presenter = makePresenter();
-    auto options = IConfiguredAlgorithm::AlgorithmRuntimeProps{{"Prop1", "val1"}, {"Prop2", "val2"}};
-    expectGetLiveDataOptions(options);
+    auto options = std::make_unique<MantidQt::API::AlgorithmRuntimeProps>();
+    options->setPropertyValue("Prop1", "val1");
+    options->setPropertyValue("Prop2", "val2");
+    expectGetLiveDataOptions(std::make_unique<MantidQt::API::AlgorithmRuntimeProps>(*options));
     auto algRunner = expectGetAlgorithmRunner();
     presenter.notifyStartMonitor();
-    assertPostProcessingPropertiesContainOptions(options, algRunner);
+    assertPostProcessingPropertiesContainOptions(*options, algRunner);
     verifyAndClear();
   }
 
@@ -807,26 +812,29 @@ private:
     TS_ASSERT(Mock::VerifyAndClearExpectations(&m_jobs));
   }
 
-  IConfiguredAlgorithm::AlgorithmRuntimeProps
+  std::unique_ptr<MantidQt::API::IAlgorithmRuntimeProps>
   defaultLiveMonitorAlgorithmOptions(const std::string &instrument = std::string("OFFSPEC"),
                                      const int &updateInterval = 15) {
     const std::string updateIntervalString = std::to_string(updateInterval);
-    return IConfiguredAlgorithm::AlgorithmRuntimeProps{
-        {"Instrument", instrument},
-        {"OutputWorkspace", "IvsQ_binned_live"},
-        {"AccumulationWorkspace", "TOF_live"},
-        {"AccumulationMethod", "Replace"},
-        {"UpdateEvery", updateIntervalString},
-        {"PostProcessingAlgorithm", "ReflectometryReductionOneLiveData"},
-        {"RunTransitionBehavior", "Restart"},
-    };
+    auto props = std::make_unique<MantidQt::API::AlgorithmRuntimeProps>();
+
+    props->setPropertyValue("Instrument", instrument);
+    props->setPropertyValue("OutputWorkspace", "IvsQ_binned_live");
+    props->setPropertyValue("AccumulationWorkspace", "TOF_live");
+    props->setPropertyValue("AccumulationMethod", "Replace");
+    props->setPropertyValue("UpdateEvery", updateIntervalString);
+    props->setPropertyValue("PostProcessingAlgorithm", "ReflectometryReductionOneLiveData");
+    props->setPropertyValue("RunTransitionBehavior", "Restart");
+    return props;
   }
 
-  IConfiguredAlgorithm::AlgorithmRuntimeProps
+  std::unique_ptr<MantidQt::API::IAlgorithmRuntimeProps>
   defaultLiveMonitorReductionOptions(const std::string &instrument = std::string("OFFSPEC")) {
-    return IConfiguredAlgorithm::AlgorithmRuntimeProps{{"GetLiveValueAlgorithm", "GetLiveInstrumentValue"},
-                                                       {"InputWorkspace", "TOF_live"},
-                                                       {"Instrument", instrument}};
+    auto props = std::make_unique<MantidQt::API::AlgorithmRuntimeProps>();
+    props->setPropertyValue("GetLiveValueAlgorithm", "GetLiveInstrumentValue");
+    props->setPropertyValue("InputWorkspace", "TOF_live");
+    props->setPropertyValue("Instrument", instrument);
+    return props;
   }
 
   void expectRunsTableWithContent(RunsTable &runsTable) {
@@ -1081,16 +1089,16 @@ private:
     EXPECT_CALL(m_view, getLiveDataUpdateInterval()).Times(AtLeast(1)).WillRepeatedly(Return(updateInterval));
   }
 
-  void expectGetLiveDataOptions(
-      IConfiguredAlgorithm::AlgorithmRuntimeProps options = IConfiguredAlgorithm::AlgorithmRuntimeProps(),
-      std::string const &instrument = std::string("OFFSPEC"), int const &updateInterval = 15) {
+  void
+  expectGetLiveDataOptions(std::unique_ptr<IAlgorithmRuntimeProps> options = std::make_unique<AlgorithmRuntimeProps>(),
+                           std::string const &instrument = std::string("OFFSPEC"), int const &updateInterval = 15) {
     expectSearchInstrument(instrument);
     expectGetUpdateInterval(updateInterval);
-    EXPECT_CALL(m_mainPresenter, rowProcessingProperties()).Times(1).WillOnce(Return(std::move(options)));
+    EXPECT_CALL(m_mainPresenter, rowProcessingProperties()).Times(1).WillOnce(Return(ByMove(std::move(options))));
   }
 
   void expectGetLiveDataOptions(std::string const &instrument, const int &updateInterval) {
-    expectGetLiveDataOptions(IConfiguredAlgorithm::AlgorithmRuntimeProps(), instrument, updateInterval);
+    expectGetLiveDataOptions(std::make_unique<AlgorithmRuntimeProps>(), instrument, updateInterval);
   }
 
   std::shared_ptr<NiceMock<MockAlgorithmRunner>> expectGetAlgorithmRunner() {
@@ -1112,23 +1120,18 @@ private:
     EXPECT_CALL(m_mainPresenter, discardChanges(_)).Times(AtLeast(1)).WillRepeatedly(Return(false));
   }
 
-  void assertAlgorithmPropertiesContainOptions(IConfiguredAlgorithm::AlgorithmRuntimeProps const &expected,
+  void assertAlgorithmPropertiesContainOptions(IAlgorithmRuntimeProps const &expected,
                                                std::shared_ptr<NiceMock<MockAlgorithmRunner>> &algRunner) {
     auto alg = algRunner->algorithm();
-    for (auto const &kvp : expected) {
-      TS_ASSERT_EQUALS(alg->getPropertyValue(kvp.first), kvp.second);
-    }
+    TS_ASSERT_EQUALS(dynamic_cast<const Mantid::Kernel::PropertyManager &>(expected),
+                     dynamic_cast<const Mantid::Kernel::PropertyManager &>(*alg))
   }
 
-  void assertPostProcessingPropertiesContainOptions(IConfiguredAlgorithm::AlgorithmRuntimeProps &expected,
+  void assertPostProcessingPropertiesContainOptions(IAlgorithmRuntimeProps &expected,
                                                     std::shared_ptr<NiceMock<MockAlgorithmRunner>> &algRunner) {
     auto alg = algRunner->algorithm();
-    auto resultString = alg->getPropertyValue("PostProcessingProperties");
-    auto result = parseKeyValueString(resultString, ";");
-    for (auto const &kvp : expected) {
-      TS_ASSERT(result.find(kvp.first) != result.end());
-      TS_ASSERT_EQUALS(result[kvp.first], expected[kvp.first]);
-    }
+    TS_ASSERT_EQUALS(expected.getPropertyValue("PostProcessingProperties"),
+                     alg->getPropertyValue("PostProcessingProperties"))
   }
 
   double m_thetaTolerance;

--- a/qt/scientific_interfaces/ISISReflectometry/test/Runs/RunsPresenterTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Runs/RunsPresenterTest.h
@@ -690,12 +690,11 @@ public:
 
   void testStartMonitorSetsDefaultPostProcessingProperties() {
     auto presenter = makePresenter();
-    auto options = defaultLiveMonitorReductionOptions();
-    expectGetLiveDataOptions(
-        std::make_unique<AlgorithmRuntimeProps>(dynamic_cast<const MantidQt::API::AlgorithmRuntimeProps &>(*options)));
+    expectGetLiveDataOptions(defaultLiveMonitorReductionOptions());
     auto algRunner = expectGetAlgorithmRunner();
     presenter.notifyStartMonitor();
-    assertPostProcessingPropertiesContainOptions(*options, algRunner);
+    auto expected = defaultLiveMonitorReductionOptions();
+    assertPostProcessingPropertiesContainOptions(*expected, algRunner);
     verifyAndClear();
   }
 

--- a/qt/scientific_interfaces/Indirect/ApplyAbsorptionCorrections.cpp
+++ b/qt/scientific_interfaces/Indirect/ApplyAbsorptionCorrections.cpp
@@ -13,6 +13,7 @@
 #include "MantidAPI/Run.h"
 #include "MantidAPI/TextAxis.h"
 #include "MantidAPI/WorkspaceGroup.h"
+#include "MantidQtWidgets/Common/AlgorithmRuntimeProps.h"
 #include "MantidQtWidgets/Common/SignalBlocker.h"
 
 #include <QStringList>
@@ -179,13 +180,13 @@ void ApplyAbsorptionCorrections::run() {
   setRunIsRunning(true);
 
   // Create / Initialize algorithm
-  API::BatchAlgorithmRunner::AlgorithmRuntimeProps absCorProps;
+  std::unique_ptr<MantidQt::API::AlgorithmRuntimeProps> absCorProps;
   IAlgorithm_sptr applyCorrAlg = AlgorithmManager::Instance().create("ApplyPaalmanPingsCorrection");
   applyCorrAlg->initialize();
 
   // get Sample Workspace
   auto const sampleWs = getADSWorkspace(m_sampleWorkspaceName);
-  absCorProps["SampleWorkspace"] = m_sampleWorkspaceName;
+  absCorProps->setPropertyValue("SampleWorkspace", m_sampleWorkspaceName);
 
   const bool useCan = m_uiForm.ckUseCan->isChecked();
   // Get Can and Clone
@@ -221,7 +222,7 @@ void ApplyAbsorptionCorrections::run() {
       }
     }
 
-    absCorProps["CanWorkspace"] = cloneName;
+    absCorProps->setPropertyValue("CanWorkspace", cloneName);
 
     const bool useCanScale = m_uiForm.ckScaleCan->isChecked();
     if (useCanScale) {
@@ -263,7 +264,7 @@ void ApplyAbsorptionCorrections::run() {
         interpolateAll = true;
       // fall through
       case QMessageBox::Yes:
-        addInterpolationStep(factorWs, absCorProps["SampleWorkspace"]);
+        addInterpolationStep(factorWs, absCorProps->getProperty("SampleWorkspace"));
         break;
       default:
         m_batchAlgoRunner->clearQueue();
@@ -321,7 +322,7 @@ void ApplyAbsorptionCorrections::run() {
   applyCorrAlg->setProperty("OutputWorkspace", outputWsName.toStdString());
 
   // Add corrections algorithm to queue
-  m_batchAlgoRunner->addAlgorithm(applyCorrAlg, absCorProps);
+  m_batchAlgoRunner->addAlgorithm(applyCorrAlg, std::move(absCorProps));
 
   // Run algorithm queue
   connect(m_batchAlgoRunner, SIGNAL(batchComplete(bool)), this, SLOT(absCorComplete(bool)));
@@ -342,8 +343,8 @@ void ApplyAbsorptionCorrections::run() {
  * @param toMatch Name of the workspace to match
  */
 void ApplyAbsorptionCorrections::addInterpolationStep(const MatrixWorkspace_sptr &toInterpolate, std::string toMatch) {
-  API::BatchAlgorithmRunner::AlgorithmRuntimeProps interpolationProps;
-  interpolationProps["WorkspaceToMatch"] = std::move(toMatch);
+  auto interpolationProps = std::make_unique<MantidQt::API::AlgorithmRuntimeProps>();
+  interpolationProps->setPropertyValue("WorkspaceToMatch", std::move(toMatch));
 
   IAlgorithm_sptr interpolationAlg = AlgorithmManager::Instance().create("SplineInterpolation");
   interpolationAlg->initialize();
@@ -351,7 +352,7 @@ void ApplyAbsorptionCorrections::addInterpolationStep(const MatrixWorkspace_sptr
   interpolationAlg->setProperty("WorkspaceToInterpolate", toInterpolate->getName());
   interpolationAlg->setProperty("OutputWorkspace", toInterpolate->getName());
 
-  m_batchAlgoRunner->addAlgorithm(interpolationAlg, interpolationProps);
+  m_batchAlgoRunner->addAlgorithm(interpolationAlg, std::move(interpolationProps));
 }
 
 /**

--- a/qt/scientific_interfaces/Indirect/ApplyAbsorptionCorrections.cpp
+++ b/qt/scientific_interfaces/Indirect/ApplyAbsorptionCorrections.cpp
@@ -180,7 +180,7 @@ void ApplyAbsorptionCorrections::run() {
   setRunIsRunning(true);
 
   // Create / Initialize algorithm
-  std::unique_ptr<MantidQt::API::AlgorithmRuntimeProps> absCorProps;
+  auto absCorProps = std::unique_ptr<MantidQt::API::AlgorithmRuntimeProps>();
   IAlgorithm_sptr applyCorrAlg = AlgorithmManager::Instance().create("ApplyPaalmanPingsCorrection");
   applyCorrAlg->initialize();
 

--- a/qt/scientific_interfaces/Indirect/CalculatePaalmanPings.cpp
+++ b/qt/scientific_interfaces/Indirect/CalculatePaalmanPings.cpp
@@ -12,14 +12,12 @@
 #include "MantidGeometry/Instrument.h"
 #include "MantidKernel/Material.h"
 #include "MantidKernel/Unit.h"
+#include "MantidQtWidgets/Common/AlgorithmRuntimeProps.h"
 #include "MantidQtWidgets/Common/SignalBlocker.h"
 #include "MantidQtWidgets/Common/UserInputValidator.h"
 #include "MantidQtWidgets/Common/WorkspaceSelector.h"
 
-#include <QDoubleValidator>
 #include <QLineEdit>
-#include <QList>
-#include <QRegExpValidator>
 #include <QValidator>
 
 using namespace Mantid::API;
@@ -100,7 +98,7 @@ void CalculatePaalmanPings::run() {
   auto algorithmName = sampleShape.replace(" ", "") + "PaalmanPingsCorrection";
   algorithmName = algorithmName.replace("Annulus", "Cylinder"); // Use the cylinder algorithm for annulus
 
-  API::BatchAlgorithmRunner::AlgorithmRuntimeProps absCorProps;
+  std::unique_ptr<MantidQt::API::AlgorithmRuntimeProps> absCorProps;
   auto absCorAlgo = AlgorithmManager::Instance().create(algorithmName.toStdString());
   absCorAlgo->initialize();
 
@@ -128,14 +126,14 @@ void CalculatePaalmanPings::run() {
 
     auto const convertedSampleWorkspace = addConvertUnitsStep(sampleWs, "Wavelength", "UNIT", emode, efixed);
     if (convertedSampleWorkspace)
-      absCorProps["SampleWorkspace"] = convertedSampleWorkspace.get();
+      absCorProps->setPropertyValue("SampleWorkspace", convertedSampleWorkspace.get());
     else {
       setRunIsRunning(false);
       return;
     }
 
   } else {
-    absCorProps["SampleWorkspace"] = sampleWsName.toStdString();
+    absCorProps->setPropertyValue("SampleWorkspace", sampleWsName.toStdString());
   }
 
   auto const sampleDensityType = m_uiForm.cbSampleDensity->currentText().toStdString();
@@ -168,14 +166,14 @@ void CalculatePaalmanPings::run() {
 
       auto const convertedWorkspace = addConvertUnitsStep(canWs, "Wavelength", "UNIT", emode);
       if (convertedWorkspace)
-        absCorProps["CanWorkspace"] = convertedWorkspace.get();
+        absCorProps->setPropertyValue("CanWorkspace", convertedWorkspace.get());
       else {
         setRunIsRunning(false);
         return;
       }
 
     } else {
-      absCorProps["CanWorkspace"] = canWsName;
+      absCorProps->setPropertyValue("CanWorkspace", canWsName);
     }
 
     auto const canDensityType = m_uiForm.cbCanDensity->currentText().toStdString();
@@ -206,7 +204,7 @@ void CalculatePaalmanPings::run() {
   absCorAlgo->setProperty("OutputWorkspace", outputWsName.toStdString());
 
   // Add corrections algorithm to queue
-  m_batchAlgoRunner->addAlgorithm(absCorAlgo, absCorProps);
+  m_batchAlgoRunner->addAlgorithm(absCorAlgo, std::move(absCorProps));
 
   // Run algorithm queue
   connect(m_batchAlgoRunner, SIGNAL(batchComplete(bool)), this, SLOT(absCorComplete(bool)));

--- a/qt/scientific_interfaces/Indirect/CalculatePaalmanPings.cpp
+++ b/qt/scientific_interfaces/Indirect/CalculatePaalmanPings.cpp
@@ -98,7 +98,7 @@ void CalculatePaalmanPings::run() {
   auto algorithmName = sampleShape.replace(" ", "") + "PaalmanPingsCorrection";
   algorithmName = algorithmName.replace("Annulus", "Cylinder"); // Use the cylinder algorithm for annulus
 
-  std::unique_ptr<MantidQt::API::AlgorithmRuntimeProps> absCorProps;
+  auto absCorProps = std::make_unique<MantidQt::API::AlgorithmRuntimeProps>();
   auto absCorAlgo = AlgorithmManager::Instance().create(algorithmName.toStdString());
   absCorAlgo->initialize();
 

--- a/qt/scientific_interfaces/Indirect/ISISCalibration.cpp
+++ b/qt/scientific_interfaces/Indirect/ISISCalibration.cpp
@@ -10,6 +10,7 @@
 #include "MantidAPI/WorkspaceGroup.h"
 #include "MantidGeometry/Instrument.h"
 #include "MantidKernel/Logger.h"
+#include "MantidQtWidgets/Common/AlgorithmRuntimeProps.h"
 
 #include <QDebug>
 #include <QFileInfo>
@@ -654,9 +655,9 @@ void ISISCalibration::addRuntimeSmoothing(const QString &workspaceName) {
   smoothAlg->initialize();
   smoothAlg->setProperty("OutputWorkspace", workspaceName.toStdString());
 
-  BatchAlgorithmRunner::AlgorithmRuntimeProps smoothAlgInputProps;
-  smoothAlgInputProps["InputWorkspace"] = workspaceName.toStdString() + "_pre_smooth";
-  m_batchAlgoRunner->addAlgorithm(smoothAlg, smoothAlgInputProps);
+  auto smoothAlgInputProps = std::make_unique<MantidQt::API::AlgorithmRuntimeProps>();
+  smoothAlgInputProps->setPropertyValue("InputWorkspace", workspaceName.toStdString() + "_pre_smooth");
+  m_batchAlgoRunner->addAlgorithm(smoothAlg, std::move(smoothAlgInputProps));
 }
 
 IAlgorithm_sptr ISISCalibration::calibrationAlgorithm(const QString &inputFiles) {

--- a/qt/scientific_interfaces/Indirect/IndirectDataAnalysisElwinTab.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectDataAnalysisElwinTab.cpp
@@ -5,6 +5,7 @@
 //   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 // SPDX - License - Identifier: GPL - 3.0 +
 #include "IndirectDataAnalysisElwinTab.h"
+#include "MantidQtWidgets/Common/AlgorithmRuntimeProps.h"
 #include "MantidQtWidgets/Common/UserInputValidator.h"
 
 #include "MantidAPI/MatrixWorkspace.h"
@@ -317,11 +318,11 @@ void IndirectDataAnalysisElwinTab::runFileInput() {
   // Group input workspaces
   auto groupWsAlg = AlgorithmManager::Instance().create("GroupWorkspaces");
   groupWsAlg->initialize();
-  API::BatchAlgorithmRunner::AlgorithmRuntimeProps runTimeProps;
-  runTimeProps["InputWorkspaces"] = inputWorkspacesString;
+  auto runTimeProps = std::make_unique<MantidQt::API::AlgorithmRuntimeProps>();
+  runTimeProps->setPropertyValue("InputWorkspaces", inputWorkspacesString);
   groupWsAlg->setProperty("OutputWorkspace", inputGroupWsName);
 
-  m_batchAlgoRunner->addAlgorithm(groupWsAlg, runTimeProps);
+  m_batchAlgoRunner->addAlgorithm(groupWsAlg, std::move(runTimeProps));
 
   // Configure ElasticWindowMultiple algorithm
   auto elwinMultAlg = AlgorithmManager::Instance().create("ElasticWindowMultiple");
@@ -346,10 +347,10 @@ void IndirectDataAnalysisElwinTab::runFileInput() {
     elwinMultAlg->setProperty("OutputELT", eltWorkspace);
   }
 
-  BatchAlgorithmRunner::AlgorithmRuntimeProps elwinInputProps;
-  elwinInputProps["InputWorkspaces"] = inputGroupWsName;
+  auto elwinInputProps = std::make_unique<MantidQt::API::AlgorithmRuntimeProps>();
+  elwinInputProps->setPropertyValue("InputWorkspaces", inputGroupWsName);
 
-  m_batchAlgoRunner->addAlgorithm(elwinMultAlg, elwinInputProps);
+  m_batchAlgoRunner->addAlgorithm(elwinMultAlg, std::move(elwinInputProps));
 
   connect(m_batchAlgoRunner, SIGNAL(batchComplete(bool)), this, SLOT(unGroupInput(bool)));
   m_batchAlgoRunner->executeBatchAsync();
@@ -379,11 +380,11 @@ void IndirectDataAnalysisElwinTab::runWorkspaceInput() {
   // Group input workspaces
   auto groupWsAlg = AlgorithmManager::Instance().create("GroupWorkspaces");
   groupWsAlg->initialize();
-  API::BatchAlgorithmRunner::AlgorithmRuntimeProps runTimeProps;
-  runTimeProps["InputWorkspaces"] = inputWorkspacesString;
+  auto runTimeProps = std::make_unique<MantidQt::API::AlgorithmRuntimeProps>();
+  runTimeProps->setPropertyValue("InputWorkspaces", inputWorkspacesString);
   groupWsAlg->setProperty("OutputWorkspace", inputGroupWsName);
 
-  m_batchAlgoRunner->addAlgorithm(groupWsAlg, runTimeProps);
+  m_batchAlgoRunner->addAlgorithm(groupWsAlg, std::move(runTimeProps));
 
   // Configure ElasticWindowMultiple algorithm
   auto elwinMultAlg = AlgorithmManager::Instance().create("ElasticWindowMultiple");
@@ -408,10 +409,10 @@ void IndirectDataAnalysisElwinTab::runWorkspaceInput() {
     elwinMultAlg->setProperty("OutputELT", eltWorkspace);
   }
 
-  BatchAlgorithmRunner::AlgorithmRuntimeProps elwinInputProps;
-  elwinInputProps["InputWorkspaces"] = inputGroupWsName;
+  auto elwinInputProps = std::make_unique<MantidQt::API::AlgorithmRuntimeProps>();
+  elwinInputProps->setPropertyValue("InputWorkspaces", inputGroupWsName);
 
-  m_batchAlgoRunner->addAlgorithm(elwinMultAlg, elwinInputProps);
+  m_batchAlgoRunner->addAlgorithm(elwinMultAlg, std::move(elwinInputProps));
 
   connect(m_batchAlgoRunner, SIGNAL(batchComplete(bool)), this, SLOT(unGroupInput(bool)));
   m_batchAlgoRunner->executeBatchAsync();

--- a/qt/scientific_interfaces/Indirect/IndirectSqw.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectSqw.cpp
@@ -8,6 +8,7 @@
 #include "IndirectDataValidationHelper.h"
 
 #include "MantidAPI/MatrixWorkspace.h"
+#include "MantidQtWidgets/Common/AlgorithmRuntimeProps.h"
 #include "MantidQtWidgets/Common/SignalBlocker.h"
 #include "MantidQtWidgets/Common/UserInputValidator.h"
 #include "MantidQtWidgets/Plotting/AxisID.h"
@@ -172,10 +173,11 @@ void IndirectSqw::run() {
   sqwAlg->setProperty("Method", "NormalisedPolygon");
   sqwAlg->setProperty("ReplaceNaNs", true);
 
-  BatchAlgorithmRunner::AlgorithmRuntimeProps sqwInputProps;
-  sqwInputProps["InputWorkspace"] = rebinInEnergy ? eRebinWsName.toStdString() : sampleWsName.toStdString();
+  auto sqwInputProps = std::make_unique<MantidQt::API::AlgorithmRuntimeProps>();
+  sqwInputProps->setPropertyValue("InputWorkspace",
+                                  rebinInEnergy ? eRebinWsName.toStdString() : sampleWsName.toStdString());
 
-  m_batchAlgoRunner->addAlgorithm(sqwAlg, sqwInputProps);
+  m_batchAlgoRunner->addAlgorithm(sqwAlg, std::move(sqwInputProps));
 
   // Add sample log for S(Q, w) algorithm used
   auto sampleLogAlg = AlgorithmManager::Instance().create("AddSampleLog");
@@ -184,10 +186,10 @@ void IndirectSqw::run() {
   sampleLogAlg->setProperty("LogType", "String");
   sampleLogAlg->setProperty("LogText", "NormalisedPolygon");
 
-  BatchAlgorithmRunner::AlgorithmRuntimeProps inputToAddSampleLogProps;
-  inputToAddSampleLogProps["Workspace"] = sqwWsName.toStdString();
+  auto inputToAddSampleLogProps = std::make_unique<MantidQt::API::AlgorithmRuntimeProps>();
+  inputToAddSampleLogProps->setPropertyValue("Workspace", sqwWsName.toStdString());
 
-  m_batchAlgoRunner->addAlgorithm(sampleLogAlg, inputToAddSampleLogProps);
+  m_batchAlgoRunner->addAlgorithm(sampleLogAlg, std::move(inputToAddSampleLogProps));
 
   // Set the name of the result workspace for Python export
   m_pythonExportWsName = sqwWsName.toStdString();

--- a/qt/scientific_interfaces/Indirect/IndirectTab.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectTab.cpp
@@ -15,6 +15,7 @@
 #include "MantidKernel/Strings.h"
 #include "MantidKernel/Unit.h"
 #include "MantidQtWidgets/Common/AlgorithmDialog.h"
+#include "MantidQtWidgets/Common/AlgorithmRuntimeProps.h"
 #include "MantidQtWidgets/Common/InterfaceManager.h"
 #include "MantidQtWidgets/Plotting/RangeSelector.h"
 
@@ -291,8 +292,8 @@ void IndirectTab::addSaveWorkspaceToQueue(const QString &wsName, const QString &
 
 void IndirectTab::addSaveWorkspaceToQueue(const std::string &wsName, const std::string &filename) {
   // Setup the input workspace property
-  API::BatchAlgorithmRunner::AlgorithmRuntimeProps saveProps;
-  saveProps["InputWorkspace"] = wsName;
+  auto saveProps = std::make_unique<MantidQt::API::AlgorithmRuntimeProps>();
+  saveProps->setPropertyValue("InputWorkspace", wsName);
 
   // Setup the algorithm
   auto saveAlgo = AlgorithmManager::Instance().create("SaveNexusProcessed");
@@ -304,7 +305,7 @@ void IndirectTab::addSaveWorkspaceToQueue(const std::string &wsName, const std::
     saveAlgo->setProperty("Filename", filename);
 
   // Add the save algorithm to the batch
-  m_batchAlgoRunner->addAlgorithm(saveAlgo, saveProps);
+  m_batchAlgoRunner->addAlgorithm(saveAlgo, std::move(saveProps));
 }
 
 /**

--- a/qt/scientific_interfaces/Indirect/IndirectTab.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectTab.cpp
@@ -601,9 +601,8 @@ QVector<QString> IndirectTab::convertStdStringVector(const std::vector<std::stri
   QVector<QString> resultVec;
   resultVec.reserve(boost::numeric_cast<int>(stringVec.size()));
 
-  for (auto &str : stringVec) {
-    resultVec.push_back(QString::fromStdString(str));
-  }
+  std::transform(stringVec.cbegin(), stringVec.cend(), std::back_inserter(resultVec),
+                 [](const auto &str) { return QString::fromStdString(str); });
   return resultVec;
 }
 

--- a/qt/widgets/common/CMakeLists.txt
+++ b/qt/widgets/common/CMakeLists.txt
@@ -823,6 +823,7 @@ set(QT5_TEST_FILES
     test/MuonPeriodInfoTest.h
     test/QtJSONUtilsTest.h
     test/RepoModelTest.h
+    test/ParseKeyValueStringTest.h
     test/Batch/BuildSubtreeItemsTest.h
     test/Batch/ExtractSubtreesTest.h
     test/Batch/FindSubtreeRootsTest.h

--- a/qt/widgets/common/CMakeLists.txt
+++ b/qt/widgets/common/CMakeLists.txt
@@ -1,15 +1,17 @@
-set(QT5_SRC_FILES
+set(SRC_FILES
     src/AddWorkspaceDialog.cpp
     src/AlgorithmDialog.cpp
     src/AlgorithmHistoryWindow.cpp
     src/AlgorithmInputHistory.cpp
     src/AlgorithmPropertiesWidget.cpp
     src/AlgorithmRunner.cpp
+    src/AlgorithmRuntimeProps.cpp
     src/AlgorithmSelectorWidget.cpp
     src/AlternateCSPythonLexer.cpp
-    src/ConvolutionFunctionModel.cpp
     src/BatchAlgorithmRunner.cpp
     src/BoolPropertyWidget.cpp
+    src/ConfiguredAlgorithm.cpp
+    src/ConvolutionFunctionModel.cpp
     src/DataSelector.cpp
     src/DropEventHelper.cpp
     src/EditLocalParameterDialog.cpp
@@ -259,6 +261,7 @@ set(QT5_INC_FILES
     inc/MantidQtWidgets/Common/AlgorithmDialogFactory.h
     inc/MantidQtWidgets/Common/AlternateCSPythonLexer.h
     inc/MantidQtWidgets/Common/BatchAlgorithmRunner.h
+    inc/MantidQtWidgets/Common/ConfiguredAlgorithm.h
     inc/MantidQtWidgets/Common/DropEventHelper.h
     inc/MantidQtWidgets/Common/FileDialogHandler.h
     inc/MantidQtWidgets/Common/FitDomain.h
@@ -271,6 +274,8 @@ set(QT5_INC_FILES
     inc/MantidQtWidgets/Common/FunctionMultiDomainPresenter.h
     inc/MantidQtWidgets/Common/HelpWindow.h
     inc/MantidQtWidgets/Common/Hint.h
+    inc/MantidQtWidgets/Common/IAlgorithmRuntimeProps.h
+    inc/MantidQtWidgets/Common/IConfiguredAlgorithm.h
     inc/MantidQtWidgets/Common/IFitScriptGeneratorModel.h
     inc/MantidQtWidgets/Common/IFitScriptGeneratorPresenter.h
     inc/MantidQtWidgets/Common/IFunctionBrowser.h
@@ -343,191 +348,6 @@ set(QT5_UI_FILES
     inc/MantidQtWidgets/Common/SelectFunctionDialog.ui
     inc/MantidQtWidgets/Common/SlitCalculator.ui
     inc/MantidQtWidgets/Common/UserFunctionDialog.ui
-)
-
-set(SRC_FILES
-    src/AddWorkspaceDialog.cpp
-    src/AlgorithmDialog.cpp
-    src/AlgorithmHistoryWindow.cpp
-    src/AlgorithmInputHistory.cpp
-    src/AlgorithmPropertiesWidget.cpp
-    src/AlgorithmRunner.cpp
-    src/AlternateCSPythonLexer.cpp
-    src/BatchAlgorithmRunner.cpp
-    src/BoolPropertyWidget.cpp
-    src/DropEventHelper.cpp
-    src/EditLocalParameterDialog.cpp
-    src/FileDialogHandler.cpp
-    src/FilePropertyWidget.cpp
-    src/GenericDialog.cpp
-    src/HelpWindow.cpp
-    src/FlowLayout.cpp
-    src/Hint.cpp
-    src/ImageInfoModel.cpp
-    src/ImageInfoModelMatrixWS.cpp
-    src/ImageInfoModelMD.cpp
-    src/ImageInfoPresenter.cpp
-    src/ImageInfoWidget.cpp
-    src/InterfaceManager.cpp
-    src/ListPropertyWidget.cpp
-    src/LocalParameterEditor.cpp
-    src/LocalParameterItemDelegate.cpp
-    src/LogValueFinder.cpp
-    src/ManageUserDirectories.cpp
-    src/MantidDesktopServices.cpp
-    src/MantidDialog.cpp
-    src/MantidHelpInterface.cpp
-    src/MantidWidget.cpp
-    src/Message.cpp
-    src/MuonPeriodInfo.cpp
-    src/NonOrthogonal.cpp
-    src/FileFinderWidget.cpp
-    src/OptionsPropertyWidget.cpp
-    src/pixmaps.cpp
-    src/PlotAxis.cpp
-    src/PluginLibraries.cpp
-    src/PropertyWidget.cpp
-    src/PropertyWidgetFactory.cpp
-    src/PythonRunner.cpp
-    src/QScienceSpinBox.cpp
-    src/QtSignalChannel.cpp
-    src/QtJSONUtils.cpp
-    src/RepoModel.cpp
-    src/ScriptRepositoryView.cpp
-    src/SelectionNotificationService.cpp
-    src/SignalBlocker.cpp
-    src/SyncedCheckboxes.cpp
-    src/TextPropertyWidget.cpp
-    src/TSVSerialiser.cpp
-    src/UserInputValidator.cpp
-    src/UserSubWindow.cpp
-    src/UserSubWindowFactory.cpp
-    src/WidgetScrollbarDecorator.cpp
-    src/WindowIcons.cpp
-    src/WorkspaceObserver.cpp
-    src/WorkspaceIcons.cpp
-    src/AlgorithmSelectorWidget.cpp
-    src/CatalogHelper.cpp
-    src/CatalogSearch.cpp
-    src/CatalogSelector.cpp
-    src/ConvolutionFunctionModel.cpp
-    src/CheckboxHeader.cpp
-    src/DataProcessorUI/AbstractTreeModel.cpp
-    src/DataProcessorUI/TreeData.cpp
-    src/DataProcessorUI/GenerateNotebook.cpp
-    src/DataProcessorUI/OneLevelTreeManager.cpp
-    src/DataProcessorUI/OptionsMap.cpp
-    src/DataProcessorUI/PostprocessingAlgorithm.cpp
-    src/DataProcessorUI/PreprocessingAlgorithm.cpp
-    src/DataProcessorUI/PreprocessMap.cpp
-    src/DataProcessorUI/ProcessingAlgorithm.cpp
-    src/DataProcessorUI/ProcessingAlgorithmBase.cpp
-    src/DataProcessorUI/TreeData.cpp
-    src/DataProcessorUI/TwoLevelTreeManager.cpp
-    src/DataProcessorUI/WhiteList.cpp
-    src/DataProcessorUI/WorkspaceNameUtils.cpp
-    src/DataProcessorUI/PostprocessingStep.cpp
-    src/DataProcessorUI/GenericDataProcessorPresenter.cpp
-    src/DataProcessorUI/Column.cpp
-    src/DataProcessorUI/ConstColumnIterator.cpp
-    src/ParseKeyValueString.cpp
-    src/ParseNumerics.cpp
-    src/DataProcessorUI/QOneLevelTreeModel.cpp
-    src/DataProcessorUI/QTwoLevelTreeModel.cpp
-    src/DataProcessorUI/QDataProcessorWidget.cpp
-    src/DataProcessorUI/QtDataProcessorOptionsDialog.cpp
-    src/DataProcessorUI/VectorString.cpp
-    src/Batch/RowLocation.cpp
-    src/Batch/RowLocationAdapter.cpp
-    src/Batch/RowPredicate.cpp
-    src/Batch/Row.cpp
-    src/Batch/Cell.cpp
-    src/Batch/CellStandardItem.cpp
-    src/Batch/ExtractSubtrees.cpp
-    src/Batch/FindSubtreeRoots.cpp
-    src/Batch/JobTreeView.cpp
-    src/Batch/JobTreeViewSignalAdapter.cpp
-    src/Batch/QtStandardItemTreeAdapter.cpp
-    src/Batch/FilteredTreeModel.cpp
-    src/Batch/QtBasicNavigation.cpp
-    src/Batch/QtTreeCursorNavigation.cpp
-    src/Batch/CellDelegate.cpp
-    src/Batch/BuildSubtreeItems.cpp
-    src/DataSelector.cpp
-    src/DiagResults.cpp
-    src/DoubleSpinBox.cpp
-    src/FindDialog.cpp
-    src/FindFilesThreadPoolManager.cpp
-    src/FindFilesWorker.cpp
-    src/FindReplaceDialog.cpp
-    src/FitDomain.cpp
-    src/FitOptionsBrowser.cpp
-    src/FitPropertyBrowser.cpp
-    src/FitScriptGeneratorDataTable.cpp
-    src/FitScriptGeneratorModel.cpp
-    src/FitScriptGeneratorPresenter.cpp
-    src/FitScriptGeneratorView.cpp
-    src/FittingGlobals.cpp
-    src/FunctionBrowser/FunctionBrowserUtils.cpp
-    src/FunctionBrowser.cpp
-    src/FunctionModel.cpp
-    src/FunctionModelDataset.cpp
-    src/FunctionModelSpectra.cpp
-    src/FunctionMultiDomainPresenter.cpp
-    src/FunctionTreeView.cpp
-    src/HintingLineEdit.cpp
-    src/IFunctionModel.cpp
-    src/InputController.cpp
-    src/InstrumentSelector.cpp
-    src/LineEditWithClear.cpp
-    src/LogValueSelector.cpp
-    src/MantidHelpWindow.cpp
-    src/MantidTreeModel.cpp
-    src/MantidTreeWidget.cpp
-    src/MantidTreeWidgetItem.cpp
-    src/MantidWSIndexDialog.cpp
-    src/MessageDisplay.cpp
-    src/MultifitSetupDialog.cpp
-    src/MuonFitDataSelector.cpp
-    src/MuonFitPropertyBrowser.cpp
-    src/MuonFunctionBrowser.cpp
-    src/ProcessingAlgoWidget.cpp
-    src/ProgressableView.cpp
-    src/ProjectSavePresenter.cpp
-    src/ProjectSaveModel.cpp
-    src/PropertyHandler.cpp
-    src/RenameParDialog.cpp
-    src/SaveWorkspaces.cpp
-    src/ScriptEditor.cpp
-    src/SelectFunctionDialog.cpp
-    src/SelectWorkspacesDialog.cpp
-    src/SequentialFitDialog.cpp
-    src/SlicingAlgorithmDialog.cpp
-    src/SlitCalculator.cpp
-    src/TrackedAction.cpp
-    src/UserFunctionDialog.cpp
-    src/WorkspacePresenter/ADSAdapter.cpp
-    src/WorkspacePresenter/WorkspacePresenter.cpp
-    src/WorkspacePresenter/WorkspaceTreeWidget.cpp
-    src/WorkspacePresenter/WorkspaceTreeWidgetSimple.cpp
-    src/WorkspaceSelector.cpp
-    src/pqHelpWindow.cxx
-    src/QtPropertyBrowser/qtpropertybrowser.cpp
-    src/QtPropertyBrowser/qtpropertymanager.cpp
-    src/QtPropertyBrowser/qteditorfactory.cpp
-    src/QtPropertyBrowser/qtvariantproperty.cpp
-    src/QtPropertyBrowser/qttreepropertybrowser.cpp
-    src/QtPropertyBrowser/qtbuttonpropertybrowser.cpp
-    src/QtPropertyBrowser/qtgroupboxpropertybrowser.cpp
-    src/QtPropertyBrowser/qtpropertybrowserutils.cpp
-    src/QtPropertyBrowser/DoubleDialogEditor.cpp
-    src/QtPropertyBrowser/DoubleEditorFactory.cpp
-    src/QtPropertyBrowser/FilenameDialogEditor.cpp
-    src/QtPropertyBrowser/FormulaDialogEditor.cpp
-    src/QtPropertyBrowser/ParameterPropertyManager.cpp
-    src/QtPropertyBrowser/StringDialogEditor.cpp
-    src/QtPropertyBrowser/StringEditorFactory.cpp
-    src/QtPropertyBrowser/WorkspaceEditorFactory.cpp
 )
 
 set(MOC_FILES
@@ -912,7 +732,7 @@ endif()
 mtd_add_qt_library(
   TARGET_NAME MantidQtWidgetsCommon
   QT_VERSION 5
-  SRC ${QT5_SRC_FILES}
+  SRC ${SRC_FILES}
   MOC ${QT5_MOC_FILES}
   NOMOC ${QT5_INC_FILES} ${_sip_include_dir}/sip.h
   UI ${QT5_UI_FILES}
@@ -981,6 +801,7 @@ set(CXXTEST_EXTRA_HEADER_INCLUDE ${CMAKE_CURRENT_LIST_DIR}/test/WidgetsCommonTes
 
 set(QT5_TEST_FILES
     test/AddWorkspaceDialogTest.h
+    test/AlgorithmRuntimePropsTest.h
     test/BatchAlgorithmRunnerTest.h
     test/FileDialogHandlerTest.h
     test/FindFilesThreadPoolManagerTest.h

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/AlgorithmRuntimeProps.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/AlgorithmRuntimeProps.h
@@ -16,7 +16,7 @@ class EXPORT_OPT_MANTIDQT_COMMON AlgorithmRuntimeProps final : private Mantid::K
 public:
   AlgorithmRuntimeProps() = default;
   AlgorithmRuntimeProps(const AlgorithmRuntimeProps &) = default;
-  AlgorithmRuntimeProps(AlgorithmRuntimeProps &&) noexcept = default;
+  AlgorithmRuntimeProps(AlgorithmRuntimeProps &&) = default;
   ~AlgorithmRuntimeProps() = default;
 
   bool operator==(const Mantid::Kernel::IPropertyManager &other) override = delete;

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/AlgorithmRuntimeProps.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/AlgorithmRuntimeProps.h
@@ -12,14 +12,15 @@
 
 namespace MantidQt::API {
 class EXPORT_OPT_MANTIDQT_COMMON AlgorithmRuntimeProps final : private Mantid::Kernel::PropertyManager,
-                                                               public IAlgorithmRuntimeProps {
+                                                               public MantidQt::API::IAlgorithmRuntimeProps {
 public:
   AlgorithmRuntimeProps() = default;
   AlgorithmRuntimeProps(const AlgorithmRuntimeProps &) = default;
-  AlgorithmRuntimeProps(AlgorithmRuntimeProps &&) = default;
+  AlgorithmRuntimeProps(AlgorithmRuntimeProps &&) noexcept = default;
   ~AlgorithmRuntimeProps() = default;
 
-  bool operator==(const AlgorithmRuntimeProps &);
+  bool operator==(const Mantid::Kernel::IPropertyManager &other) override = delete;
+  using Mantid::Kernel::PropertyManager::getDeclaredPropertyNames;
   using Mantid::Kernel::PropertyManager::getPropertyValue;
 
   TypedValue getProperty(const std::string &name) const noexcept override;

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/AlgorithmRuntimeProps.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/AlgorithmRuntimeProps.h
@@ -1,6 +1,6 @@
 // Mantid Repository : https://github.com/mantidproject/mantid
 //
-// Copyright &copy; 2012 ISIS Rutherford Appleton Laboratory UKRI,
+// Copyright &copy; 2021 ISIS Rutherford Appleton Laboratory UKRI,
 //   NScD Oak Ridge National Laboratory, European Spallation Source,
 //   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 // SPDX - License - Identifier: GPL - 3.0 +

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/AlgorithmRuntimeProps.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/AlgorithmRuntimeProps.h
@@ -1,0 +1,29 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2012 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#pragma once
+
+#include "IAlgorithmRuntimeProps.h"
+
+#include "MantidKernel/PropertyManager.h"
+
+namespace MantidQt::API {
+class EXPORT_OPT_MANTIDQT_COMMON AlgorithmRuntimeProps final : private Mantid::Kernel::PropertyManager,
+                                                               public IAlgorithmRuntimeProps {
+public:
+  AlgorithmRuntimeProps() = default;
+  AlgorithmRuntimeProps(const AlgorithmRuntimeProps &) = default;
+  AlgorithmRuntimeProps(AlgorithmRuntimeProps &&) = default;
+  ~AlgorithmRuntimeProps() = default;
+
+  bool operator==(const AlgorithmRuntimeProps &);
+  using Mantid::Kernel::PropertyManager::getPropertyValue;
+
+  TypedValue getProperty(const std::string &name) const noexcept override;
+  void setPropertyValue(const std::string &name, const std::string &value) override;
+};
+
+} // namespace MantidQt::API

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/BatchAlgorithmRunner.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/BatchAlgorithmRunner.h
@@ -1,12 +1,13 @@
 // Mantid Repository : https://github.com/mantidproject/mantid
 //
-// Copyright &copy; 2012 ISIS Rutherford Appleton Laboratory UKRI,
+// Copyright &copy; 2021 ISIS Rutherford Appleton Laboratory UKRI,
 //   NScD Oak Ridge National Laboratory, European Spallation Source,
 //   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 // SPDX - License - Identifier: GPL - 3.0 +
 #pragma once
 
 #include "DllOption.h"
+#include "IConfiguredAlgorithm.h"
 #include "MantidAPI/Algorithm.h"
 
 #include <QObject>
@@ -21,32 +22,7 @@
 #include <mutex>
 #include <utility>
 
-namespace MantidQt {
-namespace API {
-class EXPORT_OPT_MANTIDQT_COMMON IConfiguredAlgorithm {
-public:
-  using AlgorithmRuntimeProps = std::map<std::string, std::string>;
-
-  virtual Mantid::API::IAlgorithm_sptr algorithm() const = 0;
-  virtual AlgorithmRuntimeProps properties() const = 0;
-};
-
-class EXPORT_OPT_MANTIDQT_COMMON ConfiguredAlgorithm : public IConfiguredAlgorithm {
-public:
-  ConfiguredAlgorithm(Mantid::API::IAlgorithm_sptr algorithm, AlgorithmRuntimeProps properties);
-  virtual ~ConfiguredAlgorithm();
-
-  Mantid::API::IAlgorithm_sptr algorithm() const override;
-  AlgorithmRuntimeProps properties() const override;
-
-protected:
-  Mantid::API::IAlgorithm_sptr m_algorithm;
-
-private:
-  AlgorithmRuntimeProps m_properties;
-};
-
-using IConfiguredAlgorithm_sptr = std::shared_ptr<IConfiguredAlgorithm>;
+namespace MantidQt::API {
 
 class BatchCompleteNotification : public Poco::Notification {
 public:
@@ -111,14 +87,13 @@ class EXPORT_OPT_MANTIDQT_COMMON BatchAlgorithmRunner : public QObject {
   Q_OBJECT
 
 public:
-  using AlgorithmRuntimeProps = std::map<std::string, std::string>;
-
   explicit BatchAlgorithmRunner(QObject *parent = nullptr);
   ~BatchAlgorithmRunner() override;
 
   /// Adds an algorithm to the execution queue
-  void addAlgorithm(const Mantid::API::IAlgorithm_sptr &algo,
-                    const AlgorithmRuntimeProps &props = AlgorithmRuntimeProps());
+  void addAlgorithm(const Mantid::API::IAlgorithm_sptr &algo);
+  void addAlgorithm(const Mantid::API::IAlgorithm_sptr &algo, std::unique_ptr<IAlgorithmRuntimeProps> props);
+
   void setQueue(std::deque<IConfiguredAlgorithm_sptr> algorithm);
   /// Clears all algorithms from queue
   void clearQueue();
@@ -188,5 +163,4 @@ private:
   void addAllObservers();
   void removeAllObservers();
 };
-} // namespace API
-} // namespace MantidQt
+} // namespace MantidQt::API

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/ConfiguredAlgorithm.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/ConfiguredAlgorithm.h
@@ -1,0 +1,29 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2021 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#pragma once
+
+#include "IConfiguredAlgorithm.h"
+#include "MantidQtWidgets/Common/IAlgorithmRuntimeProps.h"
+
+namespace MantidQt::API {
+
+class EXPORT_OPT_MANTIDQT_COMMON ConfiguredAlgorithm : public IConfiguredAlgorithm {
+public:
+  ConfiguredAlgorithm(Mantid::API::IAlgorithm_sptr algorithm,
+                      std::unique_ptr<MantidQt::API::IAlgorithmRuntimeProps> properties);
+  virtual ~ConfiguredAlgorithm() = default;
+
+  Mantid::API::IAlgorithm_sptr algorithm() const override;
+  const MantidQt::API::IAlgorithmRuntimeProps &properties() const noexcept override;
+
+protected:
+  Mantid::API::IAlgorithm_sptr m_algorithm;
+
+private:
+  std::unique_ptr<IAlgorithmRuntimeProps> m_properties;
+};
+} // namespace MantidQt::API

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/ConfiguredAlgorithm.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/ConfiguredAlgorithm.h
@@ -18,7 +18,7 @@ public:
   virtual ~ConfiguredAlgorithm() = default;
 
   Mantid::API::IAlgorithm_sptr algorithm() const override;
-  const MantidQt::API::IAlgorithmRuntimeProps &properties() const noexcept override;
+  const MantidQt::API::IAlgorithmRuntimeProps &getAlgorithmRuntimeProps() const noexcept override;
 
 protected:
   Mantid::API::IAlgorithm_sptr m_algorithm;

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/IAlgorithmRuntimeProps.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/IAlgorithmRuntimeProps.h
@@ -1,0 +1,30 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2012 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#pragma once
+
+#include "DllOption.h"
+#include "MantidKernel/IPropertyManager.h"
+
+namespace MantidQt::API {
+class EXPORT_OPT_MANTIDQT_COMMON IAlgorithmRuntimeProps : public virtual Mantid::Kernel::IPropertyManager {
+public:
+  IAlgorithmRuntimeProps() = default;
+  virtual ~IAlgorithmRuntimeProps() = default;
+
+  template <typename T> void setProperty(const std::string &name, const T &value) {
+    if (!existsProperty(name)) {
+      declareProperty(name, value);
+    } else {
+      Mantid::Kernel::IPropertyManager::setProperty(name, value);
+    }
+  }
+
+  virtual void setPropertyValue(const std::string &, const std::string &) override = 0;
+  virtual TypedValue getProperty(const std::string &name) const noexcept override = 0;
+};
+
+} // namespace MantidQt::API

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/IAlgorithmRuntimeProps.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/IAlgorithmRuntimeProps.h
@@ -1,6 +1,6 @@
 // Mantid Repository : https://github.com/mantidproject/mantid
 //
-// Copyright &copy; 2012 ISIS Rutherford Appleton Laboratory UKRI,
+// Copyright &copy; 2021 ISIS Rutherford Appleton Laboratory UKRI,
 //   NScD Oak Ridge National Laboratory, European Spallation Source,
 //   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 // SPDX - License - Identifier: GPL - 3.0 +

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/IAlgorithmRuntimeProps.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/IAlgorithmRuntimeProps.h
@@ -15,6 +15,12 @@ public:
   IAlgorithmRuntimeProps() = default;
   virtual ~IAlgorithmRuntimeProps() = default;
 
+  using Mantid::Kernel::IPropertyManager::getDeclaredPropertyNames;
+
+  // Trying to compare properties downcasts to string types, which results in a bad_cast for sptr types
+  // so you will need to manually call getProperty(name) and cast to type T before comparing
+  virtual bool operator==(const Mantid::Kernel::IPropertyManager &) = delete;
+
   template <typename T> void setProperty(const std::string &name, const T &value) {
     if (!existsProperty(name)) {
       declareProperty(name, value);

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/IConfiguredAlgorithm.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/IConfiguredAlgorithm.h
@@ -1,0 +1,25 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2021 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#pragma once
+
+#include "DllOption.h"
+#include "IAlgorithmRuntimeProps.h"
+#include "MantidAPI/Algorithm.h"
+
+#include <memory>
+
+namespace MantidQt::API {
+class EXPORT_OPT_MANTIDQT_COMMON IConfiguredAlgorithm {
+public:
+  virtual ~IConfiguredAlgorithm() = default;
+  virtual Mantid::API::IAlgorithm_sptr algorithm() const = 0;
+  virtual const MantidQt::API::IAlgorithmRuntimeProps &properties() const noexcept = 0;
+};
+
+using IConfiguredAlgorithm_sptr = std::shared_ptr<IConfiguredAlgorithm>;
+
+} // namespace MantidQt::API

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/IConfiguredAlgorithm.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/IConfiguredAlgorithm.h
@@ -17,7 +17,7 @@ class EXPORT_OPT_MANTIDQT_COMMON IConfiguredAlgorithm {
 public:
   virtual ~IConfiguredAlgorithm() = default;
   virtual Mantid::API::IAlgorithm_sptr algorithm() const = 0;
-  virtual const MantidQt::API::IAlgorithmRuntimeProps &properties() const noexcept = 0;
+  virtual const MantidQt::API::IAlgorithmRuntimeProps &getAlgorithmRuntimeProps() const noexcept = 0;
 };
 
 using IConfiguredAlgorithm_sptr = std::shared_ptr<IConfiguredAlgorithm>;

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/ParseKeyValueString.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/ParseKeyValueString.h
@@ -15,10 +15,13 @@ into a map of key/value pairs.
 #include "DllOption.h"
 #include "MantidKernel/System.h"
 #include "MantidQtWidgets/Common/DataProcessorUI/OptionsMap.h"
+#include "MantidQtWidgets/Common/IAlgorithmRuntimeProps.h"
+
 #include <QString>
-#include <map>
 #include <sstream>
 #include <string>
+
+#include <map>
 
 namespace MantidQt {
 namespace MantidWidgets {
@@ -36,6 +39,7 @@ QString EXPORT_OPT_MANTIDQT_COMMON convertMapToString(const std::map<QString, QS
                                                       const char separator = ',', const bool quoteValues = true);
 std::string EXPORT_OPT_MANTIDQT_COMMON convertMapToString(const std::map<std::string, std::string> &optionsMap,
                                                           const char separator, const bool quoteValues);
+std::string EXPORT_OPT_MANTIDQT_COMMON convertAlgPropsToString(MantidQt::API::IAlgorithmRuntimeProps const &options);
 std::string EXPORT_OPT_MANTIDQT_COMMON optionsToString(std::map<std::string, std::string> const &options,
                                                        const bool quoteValues = true,
                                                        const std::string &separator = ", ");

--- a/qt/widgets/common/src/AlgorithmRuntimeProps.cpp
+++ b/qt/widgets/common/src/AlgorithmRuntimeProps.cpp
@@ -6,14 +6,11 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 #include "MantidQtWidgets/Common/AlgorithmRuntimeProps.h"
 #include "MantidKernel/IPropertyManager.h"
+#include "MantidQtWidgets/Common/IAlgorithmRuntimeProps.h"
 
 #include <string>
 
 namespace MantidQt::API {
-bool AlgorithmRuntimeProps::operator==(const AlgorithmRuntimeProps &other) {
-  return Mantid::Kernel::PropertyManager::operator==(other);
-}
-
 Mantid::Kernel::IPropertyManager::TypedValue
 AlgorithmRuntimeProps::getProperty(const std::string &name) const noexcept {
   return Mantid::Kernel::PropertyManager::getProperty(name);

--- a/qt/widgets/common/src/AlgorithmRuntimeProps.cpp
+++ b/qt/widgets/common/src/AlgorithmRuntimeProps.cpp
@@ -1,6 +1,6 @@
 // Mantid Repository : https://github.com/mantidproject/mantid
 //
-// Copyright &copy; 2012 ISIS Rutherford Appleton Laboratory UKRI,
+// Copyright &copy; 2021 ISIS Rutherford Appleton Laboratory UKRI,
 //   NScD Oak Ridge National Laboratory, European Spallation Source,
 //   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 // SPDX - License - Identifier: GPL - 3.0 +

--- a/qt/widgets/common/src/AlgorithmRuntimeProps.cpp
+++ b/qt/widgets/common/src/AlgorithmRuntimeProps.cpp
@@ -1,0 +1,28 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2012 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#include "MantidQtWidgets/Common/AlgorithmRuntimeProps.h"
+#include "MantidKernel/IPropertyManager.h"
+
+#include <string>
+
+namespace MantidQt::API {
+bool AlgorithmRuntimeProps::operator==(const AlgorithmRuntimeProps &other) {
+  return Mantid::Kernel::PropertyManager::operator==(other);
+}
+
+Mantid::Kernel::IPropertyManager::TypedValue
+AlgorithmRuntimeProps::getProperty(const std::string &name) const noexcept {
+  return Mantid::Kernel::PropertyManager::getProperty(name);
+}
+void AlgorithmRuntimeProps::setPropertyValue(const std::string &name, const std::string &value) {
+  if (!existsProperty(name)) {
+    declareProperty(name, value);
+  } else {
+    Mantid::Kernel::PropertyManager::setPropertyValue(name, value);
+  }
+}
+} // namespace MantidQt::API

--- a/qt/widgets/common/src/BatchAlgorithmRunner.cpp
+++ b/qt/widgets/common/src/BatchAlgorithmRunner.cpp
@@ -216,7 +216,9 @@ bool BatchAlgorithmRunner::executeAlgo(const IConfiguredAlgorithm_sptr &algorith
     std::set_difference(propNamesToUpdate.cbegin(), propNamesToUpdate.cend(), allowedPropNames.cbegin(),
                         allowedPropNames.cend(), std::back_inserter(invalidProps));
     if (invalidProps.size() > 0) {
-      throw Mantid::Kernel::Exception::NotFoundError("Invalid Properties given", "NameOfProp"); // TODO
+      const auto invalidPropsStr = std::accumulate(invalidProps.cbegin(), invalidProps.cend(), invalidProps[0],
+                                                   [](const auto &a, const auto &b) { return a + "," + b; });
+      throw Mantid::Kernel::Exception::NotFoundError("Invalid Properties given:", invalidPropsStr);
     }
 
     // Assign the properties to be set at runtime

--- a/qt/widgets/common/src/BatchAlgorithmRunner.cpp
+++ b/qt/widgets/common/src/BatchAlgorithmRunner.cpp
@@ -207,7 +207,7 @@ bool BatchAlgorithmRunner::executeAlgo(const IConfiguredAlgorithm_sptr &algorith
   try {
     m_currentAlgorithm = algorithm->algorithm();
 
-    auto const &props = algorithm->properties();
+    auto const &props = algorithm->getAlgorithmRuntimeProps();
 
     auto const allowedPropNames = m_currentAlgorithm->getDeclaredPropertyNames();
     auto const propNamesToUpdate = props.getDeclaredPropertyNames();
@@ -218,7 +218,7 @@ bool BatchAlgorithmRunner::executeAlgo(const IConfiguredAlgorithm_sptr &algorith
     if (invalidProps.size() > 0) {
       const auto invalidPropsStr = std::accumulate(invalidProps.cbegin(), invalidProps.cend(), invalidProps[0],
                                                    [](const auto &a, const auto &b) { return a + "," + b; });
-      throw Mantid::Kernel::Exception::NotFoundError("Invalid Properties given:", invalidPropsStr);
+      throw Mantid::Kernel::Exception::NotFoundError("Invalid Properties given: ", invalidPropsStr);
     }
 
     // Assign the properties to be set at runtime

--- a/qt/widgets/common/src/BatchAlgorithmRunner.cpp
+++ b/qt/widgets/common/src/BatchAlgorithmRunner.cpp
@@ -216,8 +216,9 @@ bool BatchAlgorithmRunner::executeAlgo(const IConfiguredAlgorithm_sptr &algorith
     std::set_difference(propNamesToUpdate.cbegin(), propNamesToUpdate.cend(), allowedPropNames.cbegin(),
                         allowedPropNames.cend(), std::back_inserter(invalidProps));
     if (invalidProps.size() > 0) {
-      const auto invalidPropsStr = std::accumulate(invalidProps.cbegin(), invalidProps.cend(), invalidProps[0],
-                                                   [](const auto &a, const auto &b) { return a + "," + b; });
+      const auto invalidPropsStr =
+          std::accumulate(std::next(invalidProps.cbegin()), invalidProps.cend(), invalidProps[0],
+                          [](const auto &a, const auto &b) { return a + "," + b; });
       throw Mantid::Kernel::Exception::NotFoundError("Invalid Properties given: ", invalidPropsStr);
     }
 

--- a/qt/widgets/common/src/ConfiguredAlgorithm.cpp
+++ b/qt/widgets/common/src/ConfiguredAlgorithm.cpp
@@ -1,6 +1,6 @@
 // Mantid Repository : https://github.com/mantidproject/mantid
 //
-// Copyright &copy; 2012 ISIS Rutherford Appleton Laboratory UKRI,
+// Copyright &copy; 2021 ISIS Rutherford Appleton Laboratory UKRI,
 //   NScD Oak Ridge National Laboratory, European Spallation Source,
 //   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 // SPDX - License - Identifier: GPL - 3.0 +
@@ -16,6 +16,8 @@ ConfiguredAlgorithm::ConfiguredAlgorithm(Mantid::API::IAlgorithm_sptr algorithm,
 
 Mantid::API::IAlgorithm_sptr ConfiguredAlgorithm::algorithm() const { return m_algorithm; }
 
-const MantidQt::API::IAlgorithmRuntimeProps &ConfiguredAlgorithm::properties() const noexcept { return *m_properties; }
+const MantidQt::API::IAlgorithmRuntimeProps &ConfiguredAlgorithm::getAlgorithmRuntimeProps() const noexcept {
+  return *m_properties;
+}
 
 } // namespace MantidQt::API

--- a/qt/widgets/common/src/ConfiguredAlgorithm.cpp
+++ b/qt/widgets/common/src/ConfiguredAlgorithm.cpp
@@ -1,0 +1,21 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2012 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#include "MantidQtWidgets/Common/ConfiguredAlgorithm.h"
+#include "MantidAPI/IAlgorithm.h"
+#include "MantidQtWidgets/Common/IAlgorithmRuntimeProps.h"
+
+namespace MantidQt::API {
+
+ConfiguredAlgorithm::ConfiguredAlgorithm(Mantid::API::IAlgorithm_sptr algorithm,
+                                         std::unique_ptr<MantidQt::API::IAlgorithmRuntimeProps> properties)
+    : m_algorithm(std::move(algorithm)), m_properties(std::move(properties)) {}
+
+Mantid::API::IAlgorithm_sptr ConfiguredAlgorithm::algorithm() const { return m_algorithm; }
+
+const MantidQt::API::IAlgorithmRuntimeProps &ConfiguredAlgorithm::properties() const noexcept { return *m_properties; }
+
+} // namespace MantidQt::API

--- a/qt/widgets/common/src/ParseKeyValueString.cpp
+++ b/qt/widgets/common/src/ParseKeyValueString.cpp
@@ -5,9 +5,12 @@
 //   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 // SPDX - License - Identifier: GPL - 3.0 +
 #include "MantidQtWidgets/Common/ParseKeyValueString.h"
+#include "MantidQtWidgets/Common/IAlgorithmRuntimeProps.h"
+
 #include <QStringList>
 #include <boost/algorithm/string.hpp>
 #include <boost/tokenizer.hpp>
+
 #include <vector>
 
 namespace MantidQt::MantidWidgets {
@@ -256,5 +259,16 @@ std::string optionsToString(std::map<std::string, std::string> const &options, c
   } else {
     return std::string();
   }
+}
+
+std::string convertAlgPropsToString(MantidQt::API::IAlgorithmRuntimeProps const &options) {
+  auto props = options.getDeclaredPropertyNames();
+  if (props.empty()) {
+    return std::string();
+  }
+  auto result = std::string(props[0] + std::string("=") + options.getPropertyValue(props[0]));
+  return std::accumulate(++props.cbegin(), props.cend(), result, [&options](auto const &result, auto const &prop) {
+    return result + std::string(";") + prop + std::string("=") + options.getPropertyValue(prop);
+  });
 }
 } // namespace MantidQt::MantidWidgets

--- a/qt/widgets/common/test/AlgorithmRuntimePropsTest.h
+++ b/qt/widgets/common/test/AlgorithmRuntimePropsTest.h
@@ -5,8 +5,8 @@
 //   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 // SPDX - License - Identifier: GPL - 3.0 +
 #pragma once
+#include "MantidFrameworkTestHelpers/WorkspaceCreationHelper.h"
 #include "MantidQtWidgets/Common/AlgorithmRuntimeProps.h"
-#include "MantidTestHelpers/WorkspaceCreationHelper.h"
 
 #include <cxxtest/TestSuite.h>
 

--- a/qt/widgets/common/test/AlgorithmRuntimePropsTest.h
+++ b/qt/widgets/common/test/AlgorithmRuntimePropsTest.h
@@ -1,0 +1,45 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2018 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#pragma once
+#include "MantidQtWidgets/Common/AlgorithmRuntimeProps.h"
+#include "MantidTestHelpers/WorkspaceCreationHelper.h"
+
+#include <cxxtest/TestSuite.h>
+
+using AlgorithmRuntimeProps = MantidQt::API::AlgorithmRuntimeProps;
+
+class AlgorithmRuntimePropsTest : public CxxTest::TestSuite {
+public:
+  template <typename T> void assert_set_get(const T &val) {
+    AlgorithmRuntimeProps props;
+    props.setProperty("property", val);
+    TS_ASSERT_EQUALS(val, static_cast<T>(props.getProperty("property")));
+  }
+
+  void test_set_property_with_type_t() {
+    assert_set_get(0);
+    assert_set_get(1.123);
+    assert_set_get(WorkspaceCreationHelper::createWorkspaceSingleValue(1.0));
+  }
+
+  void test_set_property_called_multiple_times() {
+    AlgorithmRuntimeProps props;
+    const std::string propName = "test";
+    props.setProperty(propName, 1);
+    TS_ASSERT_EQUALS(1, static_cast<int>(props.getProperty(propName)))
+
+    props.setProperty(propName, 2);
+    TS_ASSERT_EQUALS(2, static_cast<int>(props.getProperty(propName)))
+  }
+
+  void test_set_property_with_string() {
+    AlgorithmRuntimeProps props;
+    const std::string expected_value = "a string";
+    props.setPropertyValue("test", expected_value);
+    TS_ASSERT_EQUALS(expected_value, props.getPropertyValue("test"))
+  }
+};

--- a/qt/widgets/common/test/AlgorithmRuntimePropsTest.h
+++ b/qt/widgets/common/test/AlgorithmRuntimePropsTest.h
@@ -1,6 +1,6 @@
 // Mantid Repository : https://github.com/mantidproject/mantid
 //
-// Copyright &copy; 2018 ISIS Rutherford Appleton Laboratory UKRI,
+// Copyright &copy; 2021 ISIS Rutherford Appleton Laboratory UKRI,
 //   NScD Oak Ridge National Laboratory, European Spallation Source,
 //   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 // SPDX - License - Identifier: GPL - 3.0 +

--- a/qt/widgets/common/test/BatchAlgorithmRunnerTest.h
+++ b/qt/widgets/common/test/BatchAlgorithmRunnerTest.h
@@ -227,7 +227,7 @@ public:
 
     TS_ASSERT_EQUALS(batchCompleteSpy.count(), 1);
     TS_ASSERT_EQUALS(batchCancelledSpy.count(), 0);
-    TS_ASSERT_EQUALS(algStartSpy.count(), 1);
+    TS_ASSERT_EQUALS(algStartSpy.count(), 2);
     TS_ASSERT_EQUALS(algCompleteSpy.count(), 1);
     TS_ASSERT_EQUALS(algErrorSpy.count(), 1);
     // Check the batch error flag is true
@@ -269,8 +269,7 @@ public:
 
     TS_ASSERT_EQUALS(batchCompleteSpy.count(), 1);
     TS_ASSERT_EQUALS(batchCancelledSpy.count(), 0);
-    // Only the first algorithm completes because it quits after the failure
-    TS_ASSERT_EQUALS(algStartSpy.count(), 1);
+    TS_ASSERT_EQUALS(algStartSpy.count(), 2);
     TS_ASSERT_EQUALS(algCompleteSpy.count(), 1);
     TS_ASSERT_EQUALS(algErrorSpy.count(), 1);
     // Check the batch error flag is true
@@ -292,8 +291,7 @@ public:
 
     TS_ASSERT_EQUALS(batchCompleteSpy.count(), 1);
     TS_ASSERT_EQUALS(batchCancelledSpy.count(), 0);
-    // We continue after the failure so the first and third algorithms both complete
-    TS_ASSERT_EQUALS(algStartSpy.count(), 2);
+    TS_ASSERT_EQUALS(algStartSpy.count(), 3);
     TS_ASSERT_EQUALS(algCompleteSpy.count(), 2);
     TS_ASSERT_EQUALS(algErrorSpy.count(), 1);
     // The error flag is false if not stopping on failure

--- a/qt/widgets/common/test/BatchAlgorithmRunnerTest.h
+++ b/qt/widgets/common/test/BatchAlgorithmRunnerTest.h
@@ -124,6 +124,34 @@ public:
   }
 
   /**
+   * Tests passing properties via AlgorithmRuntimeProps.
+   */
+  void test_AlgorithmRuntimeProps() {
+    BatchAlgorithmRunner runner(nullptr);
+
+    // Create an algorithm with a separate AlgorithmRuntimeProps for the properties
+    auto alg = AlgorithmManager::Instance().create("CreateSampleWorkspace", -1);
+    auto props = std::make_unique<AlgorithmRuntimeProps>();
+    props->setProperty("OutputWorkspace", "BatchAlgorithmRunnerTest_Create");
+    props->setProperty("Function", "Exp Decay");
+    props->setProperty("XMax", 20.0);
+    props->setProperty("BinWidth", 1.0);
+    runner.addAlgorithm(alg, std::move(props));
+
+    // Run queue
+    TS_ASSERT(runner.executeBatch());
+    TS_ASSERT_EQUALS(runner.queueLength(), 0);
+
+    // Get workspace history
+    std::string wsName = "BatchAlgorithmRunnerTest_Create";
+    auto history = AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(wsName)->getHistory();
+
+    // Check the algorithm history of the workspace matches what should have
+    // been done to it
+    TS_ASSERT_EQUALS("CreateSampleWorkspace", history.getAlgorithmHistory(0)->name())
+  }
+
+  /**
    * Tests failure caused by setting a property such that it fails validation.
    */
   void test_basicBatchWorkspaceFailure() {

--- a/qt/widgets/common/test/MockConfiguredAlgorithm.h
+++ b/qt/widgets/common/test/MockConfiguredAlgorithm.h
@@ -7,16 +7,23 @@
 #pragma once
 
 #include "MantidAPI/Algorithm.h"
-#include "MantidKernel/WarningSuppressions.h"
 #include "MantidQtWidgets/Common/BatchAlgorithmRunner.h"
+#include "MantidQtWidgets/Common/IAlgorithmRuntimeProps.h"
+
 #include <gmock/gmock.h>
 
-GNU_DIAG_OFF_SUGGEST_OVERRIDE
+#include <memory>
 
 class MockConfiguredAlgorithm : public MantidQt::API::IConfiguredAlgorithm {
 public:
-  MOCK_CONST_METHOD0(algorithm, Mantid::API::IAlgorithm_sptr());
-  MOCK_CONST_METHOD0(properties, AlgorithmRuntimeProps());
-};
+  MockConfiguredAlgorithm(std::unique_ptr<MantidQt::API::IAlgorithmRuntimeProps> runtimeProps)
+      : m_runtimeProps(std::move(runtimeProps)) {
+    ON_CALL(*this, properties).WillByDefault(::testing::ReturnRef(*m_runtimeProps));
+  }
 
-GNU_DIAG_ON_SUGGEST_OVERRIDE
+  MOCK_METHOD(Mantid::API::IAlgorithm_sptr, algorithm, (), (const, override));
+  MOCK_METHOD((const MantidQt::API::IAlgorithmRuntimeProps &), properties, (), (const, noexcept, override));
+
+private:
+  std::unique_ptr<MantidQt::API::IAlgorithmRuntimeProps> m_runtimeProps;
+};

--- a/qt/widgets/common/test/MockConfiguredAlgorithm.h
+++ b/qt/widgets/common/test/MockConfiguredAlgorithm.h
@@ -18,11 +18,13 @@ class MockConfiguredAlgorithm : public MantidQt::API::IConfiguredAlgorithm {
 public:
   MockConfiguredAlgorithm(std::unique_ptr<MantidQt::API::IAlgorithmRuntimeProps> runtimeProps)
       : m_runtimeProps(std::move(runtimeProps)) {
-    ON_CALL(*this, properties).WillByDefault(::testing::ReturnRef(*m_runtimeProps));
+    // Explicitly hold a reference to the props we return by reference, so the tests don't get this wrong
+    ON_CALL(*this, getAlgorithmRuntimeProps).WillByDefault(::testing::ReturnRef(*m_runtimeProps));
   }
 
   MOCK_METHOD(Mantid::API::IAlgorithm_sptr, algorithm, (), (const, override));
-  MOCK_METHOD((const MantidQt::API::IAlgorithmRuntimeProps &), properties, (), (const, noexcept, override));
+  MOCK_METHOD((const MantidQt::API::IAlgorithmRuntimeProps &), getAlgorithmRuntimeProps, (),
+              (const, noexcept, override));
 
 private:
   std::unique_ptr<MantidQt::API::IAlgorithmRuntimeProps> m_runtimeProps;

--- a/qt/widgets/common/test/ParseKeyValueStringTest.h
+++ b/qt/widgets/common/test/ParseKeyValueStringTest.h
@@ -6,6 +6,7 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 #pragma once
 
+#include "MantidQtWidgets/Common/AlgorithmRuntimeProps.h"
 #include "MantidQtWidgets/Common/ParseKeyValueString.h"
 #include <cxxtest/TestSuite.h>
 
@@ -78,6 +79,20 @@ public:
     QtMap kvp = parseKeyValueQString(R"(a=1;b=2)", ";");
     TS_ASSERT_EQUALS(kvp["a"], "1");
     TS_ASSERT_EQUALS(kvp["b"], "2");
+  }
+
+  void testConvertAlgPropsToString() {
+    auto algProps = MantidQt::API::AlgorithmRuntimeProps();
+    algProps.setPropertyValue("prop1", "val1");
+    algProps.setPropertyValue("prop2", "val2");
+    auto result = MantidQt::MantidWidgets::convertAlgPropsToString(algProps);
+    TS_ASSERT_EQUALS("prop1=val1;prop2=val2", result);
+  }
+
+  void testConvertEmptyAlgPropsToString() {
+    auto algProps = MantidQt::API::AlgorithmRuntimeProps();
+    auto result = MantidQt::MantidWidgets::convertAlgPropsToString(algProps);
+    TS_ASSERT_EQUALS("", result);
   }
 
 private:


### PR DESCRIPTION
Note that this work is by @DavidFair and @ConorMFinn rather than myself.

This PR makes changes to the BatchAlgorithmRunner and related classes to change from using AlgorithmRuntimeProps which was previously a map of string to string, to using the property manager so that we can set proper property types. This is required for upstream work in the reflectometry GUI which will need to pass workspaces as pointers rather than string names, because they will not be in the ADS.

**To test:**

Check that:
- Test something in Reflectometry GUI that relies on it still works
  - Open the ISIS Reflectometry GUI
  - Set instrument INTER. Enter run number 13460, angle 0.4
  - Click process. The row should turn green when processing completes successfully.
- Test something in Indirect (from their testing instructions) still works

Refs #32772

*This does not require release notes* because **it is an internal changes that does not affect functionality**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
