### PR TITLE
Use better initial path in file browse dialog

### DIFF
--- a/docs/source/release/v6.3.0/mantidworkbench.rst
+++ b/docs/source/release/v6.3.0/mantidworkbench.rst
@@ -24,6 +24,8 @@ New and Improved
 .. image::  ../../images/ErrorReporter_RememberMe.png
     :align: center
 
+- The browse dialog in the file finder widget now opens at the path specified in the widget's edit box (if the edit box contains a full path)
+
 Bugfixes
 --------
 - Fixed arbitrary values not being accepted as the "Start Time" in StartLiveDataDialog.

--- a/qt/widgets/common/src/FileFinderWidget.cpp
+++ b/qt/widgets/common/src/FileFinderWidget.cpp
@@ -778,7 +778,12 @@ QStringList FileFinderWidget::getFileExtensionsFromAlgorithm(const QString &algN
  */
 QString FileFinderWidget::openFileDialog() {
   QStringList filenames;
-  QString dir = m_lastDir;
+  QString dir;
+  if (QFileInfo(getText()).isAbsolute()) {
+    dir = QFileInfo(getText()).absoluteDir().path();
+  } else {
+    dir = m_lastDir;
+  }
 
   if (m_fileFilter.isEmpty()) {
     m_fileFilter = createFileFilter();

--- a/qt/widgets/common/src/FileFinderWidget.cpp
+++ b/qt/widgets/common/src/FileFinderWidget.cpp
@@ -785,7 +785,11 @@ QString FileFinderWidget::openFileDialog() {
     prevFileName = prevFileName.trimmed();
 
   if (!prevFileNames.empty() && QFileInfo(prevFileNames[0]).isAbsolute()) {
-    dir = QFileInfo(prevFileNames[0]).absoluteDir().path();
+    if (QFileInfo(prevFileNames[0]).isFile()) {
+      dir = QFileInfo(prevFileNames[0]).absoluteDir().path();
+    } else {
+      dir = prevFileNames[0];
+    }
   } else {
     dir = m_lastDir;
   }

--- a/qt/widgets/common/src/FileFinderWidget.cpp
+++ b/qt/widgets/common/src/FileFinderWidget.cpp
@@ -779,8 +779,13 @@ QStringList FileFinderWidget::getFileExtensionsFromAlgorithm(const QString &algN
 QString FileFinderWidget::openFileDialog() {
   QStringList filenames;
   QString dir;
-  if (QFileInfo(getText()).isAbsolute()) {
-    dir = QFileInfo(getText()).absoluteDir().path();
+
+  auto prevFileNames = getText().split(",", QString::SkipEmptyParts);
+  for (auto &prevFileName : prevFileNames)
+    prevFileName = prevFileName.trimmed();
+
+  if (!prevFileNames.empty() && QFileInfo(prevFileNames[0]).isAbsolute()) {
+    dir = QFileInfo(prevFileNames[0]).absoluteDir().path();
   } else {
     dir = m_lastDir;
   }


### PR DESCRIPTION
**Description of work.**

The browse dialog in the file finder widget now opens at the directory specified in the widget's edit box (if the edit box contains a full path). This means that if a path is set programmatically and the user decides to browse for a new file, the initial directory is the same as the "current" file

![image](https://user-images.githubusercontent.com/56295817/140044402-3f1da652-9974-46d9-9ab4-b36b82b8ac84.png)

This is the way browse dialogs in other applications work that I've looked at on Windows\Ubuntu.

The motivation for this change came from the Engineering Diffraction UI where default paths are set in various file finder widgets and it seemed odd that the Browse button opened up a dialog in a different place. It seems like a useful change for everyone though so I've added this without any conditions\switch to main widget. This means it affects all file browse\load dialogs including the main Load dialog in workbench.

There are a couple of special cases:
- the file finder's edit box contains multiple paths: the initial directory in the file browser is taken from the first path. 
- the file finder's edit box doesn't contain an absolute path (eg it contains a file name or a run number): the behaviour is the same as before this change ie it uses the directory of the last file selected in the widget (saved in the ini file) or if that's not present the default save location

**To test:**

1. Visit the Engineering Diffraction user interface
2. Go to the Calibration tab
3. If the "Path" in the Load Existing Calibration section is empty create a new calibration by:
a) selecting the "Create New Calibration" radio button and entering 305738 as the Calibration Sample \#
b) Hitting the Calibrate button
This process should populate the "Path" edit box with a path to a .prm file once it completes
4. Select the Load Calibration radio button
5. Hit the Browse button

The file browse dialog should open at the same folder as the .prm file specified in the Path edit box

Fixes #32678.


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
