### PR TITLE
Fix Incorrect Runs Being Processed After Loading Batch

### DIFF
--- a/docs/source/release/v6.3.0/reflectometry.rst
+++ b/docs/source/release/v6.3.0/reflectometry.rst
@@ -15,6 +15,6 @@ Bugfixes
 --------
 - The Add Row button is now disabled in the Experiment settings tab when runs are being processed.
 - Invalid per-angle defaults values that are saved into a batch will now be marked as invalid when loaded back into the GUI.
-- Fixed un-selected runs/groups being processed after loading a batch.
+- Fixed un-selected groups being processed after loading a batch.
 
 :ref:`Release 6.3.0 <v6.3.0>`

--- a/docs/source/release/v6.3.0/reflectometry.rst
+++ b/docs/source/release/v6.3.0/reflectometry.rst
@@ -15,5 +15,6 @@ Bugfixes
 --------
 - The Add Row button is now disabled in the Experiment settings tab when runs are being processed.
 - Invalid per-angle defaults values that are saved into a batch will now be marked as invalid when loaded back into the GUI.
+- Fixed un-selected runs/groups being processed after loading a batch.
 
 :ref:`Release 6.3.0 <v6.3.0>`

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchPresenter.cpp
@@ -258,6 +258,8 @@ void BatchPresenter::notifyAnyBatchAutoreductionResumed() { m_runsPresenter->not
 
 void BatchPresenter::notifyAnyBatchAutoreductionPaused() { m_runsPresenter->notifyAnyBatchAutoreductionPaused(); }
 
+void BatchPresenter::notifyBatchLoaded() { m_runsPresenter->notifyBatchLoaded(); }
+
 Mantid::Geometry::Instrument_const_sptr BatchPresenter::instrument() const { return m_mainPresenter->instrument(); }
 
 std::string BatchPresenter::instrumentName() const { return m_mainPresenter->instrumentName(); }

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchPresenter.h
@@ -71,6 +71,7 @@ public:
   void notifyAnyBatchAutoreductionResumed() override;
   void notifyAnyBatchAutoreductionPaused() override;
   void notifyReductionPaused() override;
+  void notifyBatchLoaded() override;
   bool requestClose() const override;
   bool isProcessing() const override;
   bool isAutoreducing() const override;

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/IBatchPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/IBatchPresenter.h
@@ -47,6 +47,7 @@ public:
   virtual void notifyAnyBatchAutoreductionResumed() = 0;
   virtual void notifyAnyBatchAutoreductionPaused() = 0;
   virtual void notifyReductionPaused() = 0;
+  virtual void notifyBatchLoaded() = 0;
 
   /// Data processing check for all groups
   virtual bool isProcessing() const = 0;

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/MainWindow/MainWindowPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/MainWindow/MainWindowPresenter.cpp
@@ -320,6 +320,7 @@ void MainWindowPresenter::notifyLoadBatchRequested(int tabIndex) {
   }
   m_decoder->decodeBatch(m_view, tabIndex, map);
   m_batchPresenters[tabIndex].get()->notifyChangesSaved();
+  m_batchPresenters[tabIndex].get()->notifyBatchLoaded();
 }
 
 void MainWindowPresenter::disableSaveAndLoadBatch() { m_view->disableSaveAndLoadBatch(); }

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/IRunsPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/IRunsPresenter.h
@@ -35,6 +35,7 @@ public:
   virtual void notifyRowStateChanged(boost::optional<Item const &> item) = 0;
   virtual void notifyRowOutputsChanged(boost::optional<Item const &> item) = 0;
   virtual void notifyRowOutputsChanged() = 0;
+  virtual void notifyBatchLoaded() = 0;
 
   virtual void notifyReductionPaused() = 0;
   virtual void notifyReductionResumed() = 0;

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/RunsPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/RunsPresenter.cpp
@@ -169,6 +169,8 @@ void RunsPresenter::notifyRowOutputsChanged(boost::optional<Item const &> item) 
   tablePresenter()->notifyRowOutputsChanged(item);
 }
 
+void RunsPresenter::notifyBatchLoaded() { m_tablePresenter->notifyBatchLoaded(); }
+
 void RunsPresenter::notifyReductionResumed() {
   updateWidgetEnabledState();
   tablePresenter()->notifyReductionResumed();

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/RunsPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/RunsPresenter.h
@@ -82,6 +82,7 @@ public:
   void notifyRowStateChanged(boost::optional<Item const &> item) override;
   void notifyRowOutputsChanged() override;
   void notifyRowOutputsChanged(boost::optional<Item const &> item) override;
+  void notifyBatchLoaded() override;
 
   void notifyReductionPaused() override;
   void notifyReductionResumed() override;

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/RunsTable/IRunsTablePresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/RunsTable/IRunsTablePresenter.h
@@ -47,6 +47,7 @@ public:
   virtual void notifyAnyBatchAutoreductionPaused() = 0;
   virtual void notifyAnyBatchAutoreductionResumed() = 0;
   virtual void notifyInstrumentChanged(std::string const &instrumentName) = 0;
+  virtual void notifyBatchLoaded() = 0;
   virtual void setTablePrecision(int &precision) = 0;
   virtual void resetTablePrecision() = 0;
   virtual void settingsChanged() = 0;

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/RunsTable/RunsTablePresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/RunsTable/RunsTablePresenter.cpp
@@ -479,6 +479,8 @@ void RunsTablePresenter::notifyCellTextChanged(MantidWidgets::Batch::RowLocation
   notifyRowStateChanged();
 }
 
+void RunsTablePresenter::notifyBatchLoaded() { notifySelectionChanged(); }
+
 void RunsTablePresenter::notifySelectionChanged() {
   m_model.setSelectedRowLocations(m_view->jobs().selectedRowLocations());
 }

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/RunsTable/RunsTablePresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/RunsTable/RunsTablePresenter.h
@@ -42,6 +42,7 @@ public:
   RunsTable &mutableRunsTable() override;
   void mergeAdditionalJobs(ReductionJobs const &jobs) override;
   void notifyInstrumentChanged(std::string const &instrumentName) override;
+  void notifyBatchLoaded() override;
   void setTablePrecision(int &precision) override;
   void resetTablePrecision() override;
   void settingsChanged() override;

--- a/qt/scientific_interfaces/ISISReflectometry/test/Batch/BatchPresenterTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Batch/BatchPresenterTest.h
@@ -498,6 +498,13 @@ public:
     verifyAndClear();
   }
 
+  void testNotifyBatchLoaded() {
+    auto presenter = makePresenter();
+    EXPECT_CALL(*m_runsPresenter, notifyBatchLoaded());
+    presenter->notifyBatchLoaded();
+    verifyAndClear();
+  }
+
 private:
   NiceMock<MockBatchView> m_view;
   NiceMock<MockBatchJobManager> *m_jobManager;

--- a/qt/scientific_interfaces/ISISReflectometry/test/ReflMockObjects.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/ReflMockObjects.h
@@ -82,6 +82,7 @@ public:
   MOCK_METHOD0(notifySettingsChanged, void());
   MOCK_METHOD1(notifySetRoundPrecision, void(int &));
   MOCK_METHOD0(notifyResetRoundPrecision, void());
+  MOCK_METHOD0(notifyBatchLoaded, void());
   MOCK_CONST_METHOD0(isProcessing, bool());
   MOCK_CONST_METHOD0(isAutoreducing, bool());
   MOCK_CONST_METHOD0(isAnyBatchProcessing, bool());
@@ -127,6 +128,7 @@ public:
   MOCK_METHOD0(notifyTableChanged, void());
   MOCK_METHOD0(settingsChanged, void());
   MOCK_METHOD0(notifyChangesSaved, void());
+  MOCK_METHOD0(notifyBatchLoaded, void());
   MOCK_CONST_METHOD0(hasUnsavedChanges, bool());
   MOCK_CONST_METHOD0(isAnyBatchProcessing, bool());
   MOCK_CONST_METHOD0(isAnyBatchAutoreducing, bool());

--- a/qt/scientific_interfaces/ISISReflectometry/test/Runs/RunsPresenterTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Runs/RunsPresenterTest.h
@@ -751,6 +751,13 @@ public:
     verifyAndClear();
   }
 
+  void testNotifyBatchLoaded() {
+    auto presenter = makePresenter();
+    EXPECT_CALL(*m_runsTablePresenter, notifyBatchLoaded()).Times(1);
+    presenter.notifyBatchLoaded();
+    verifyAndClear();
+  }
+
 private:
   class RunsPresenterFriend : public RunsPresenter {
     friend class RunsPresenterTest;

--- a/qt/scientific_interfaces/ISISReflectometry/test/RunsTable/MockRunsTablePresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/RunsTable/MockRunsTablePresenter.h
@@ -37,6 +37,7 @@ public:
   MOCK_METHOD0(notifyAnyBatchAutoreductionPaused, void());
   MOCK_METHOD0(notifyAnyBatchAutoreductionResumed, void());
   MOCK_METHOD1(notifyInstrumentChanged, void(std::string const &));
+  MOCK_METHOD0(notifyBatchLoaded, void());
   MOCK_METHOD0(settingsChanged, void());
   MOCK_METHOD1(setTablePrecision, void(int &));
   MOCK_METHOD0(resetTablePrecision, void());

--- a/qt/scientific_interfaces/ISISReflectometry/test/RunsTable/RunsTablePresenterDisplayTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/RunsTable/RunsTablePresenterDisplayTest.h
@@ -238,6 +238,13 @@ public:
     verifyAndClearExpectations();
   }
 
+  void testNotifyBatchLoaded() {
+    auto presenter = makePresenter(m_view, twoGroupsWithMixedRowsModel());
+    EXPECT_CALL(m_view, jobs()).Times(1);
+    presenter.notifyBatchLoaded();
+    verifyAndClearExpectations();
+  }
+
 private:
   ReductionJobs oneGroupWithTwoRowsWithSrcAndDestTransRuns() {
     auto reductionJobs = ReductionJobs();


### PR DESCRIPTION
**Description of work.**
When loading a new batch the selection could update on the table but the model wouldn't track the changed selection. This sends a notification all the way down to the table to update the current selection so the correct runs/groups are processed. 

**To test:**
1. Open the Refl GUI
2. Load a batch from the sample data
3. Select group 2
4. Load the same batch file again
5. Click process
6. Only the selected row should be processed


Fixes #28001 


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
