### PR TITLE
Activation Fit Function for Muons

### DIFF
--- a/Framework/CurveFitting/CMakeLists.txt
+++ b/Framework/CurveFitting/CMakeLists.txt
@@ -54,6 +54,7 @@ set(SRC_FILES
     src/FuncMinimizers/TrustRegionMinimizer.cpp
     src/FunctionDomain1DSpectrumCreator.cpp
     src/Functions/Abragam.cpp
+    src/Functions/Activation.cpp
     src/Functions/BSpline.cpp
     src/Functions/BackToBackExponential.cpp
     src/Functions/BackgroundFunction.cpp
@@ -230,6 +231,7 @@ set(INC_FILES
     inc/MantidCurveFitting/FuncMinimizers/TrustRegionMinimizer.h
     inc/MantidCurveFitting/FunctionDomain1DSpectrumCreator.h
     inc/MantidCurveFitting/Functions/Abragam.h
+    inc/MantidCurveFitting/Functions/Activation.h
     inc/MantidCurveFitting/Functions/BSpline.h
     inc/MantidCurveFitting/Functions/BackToBackExponential.h
     inc/MantidCurveFitting/Functions/BackgroundFunction.h

--- a/Framework/CurveFitting/CMakeLists.txt
+++ b/Framework/CurveFitting/CMakeLists.txt
@@ -400,6 +400,7 @@ set(TEST_FILES
     FunctionFactoryConstraintTest.h
     FunctionParameterDecoratorFitTest.h
     Functions/AbragamTest.h
+    Functions/ActivationTest.h
     Functions/BSplineTest.h
     Functions/BackToBackExponentialTest.h
     Functions/BivariateNormalTest.h

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/Activation.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/Activation.h
@@ -44,8 +44,7 @@ protected:
   void init() override;
 
 private:
-  double getExp() const;
-  double getLifetimeMulti() const;
+  double getMeVConv() const;
 };
 
 } // namespace Functions

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/Activation.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/Activation.h
@@ -1,0 +1,53 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2021 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin
+// SPDX - License - Identifier: GPL - 3.0 +
+#pragma once
+
+//----------------------------------------------------------------------
+// Includes
+//----------------------------------------------------------------------
+#include "MantidCurveFitting/Functions/BackgroundFunction.h"
+
+namespace Mantid {
+namespace CurveFitting {
+namespace Functions {
+/**
+Provide Activation fit function interface to IFunction.
+I.e. if the unit is K, the function: y = = height*exp(-lifetime/x)
+or if the unit is meV, the function: y = height*exp(-e*lifetime/(1000 k_B x))
+Activation attributes:
+<UL>
+<LI> Unit - either K or meV (default K)</LI>
+</UL>
+
+Activation parameters:
+<UL>
+<LI> Height - coefficient for height (default 1.0)</LI>
+<LI> Lifetime - coefficient for lifetime (default 1.0)</LI>
+</UL>
+*/
+
+class MANTID_CURVEFITTING_DLL Activation : public BackgroundFunction {
+public:
+  /// overwrite IFunction base class methods
+  std::string name() const override { return "Activation"; }
+  void function1D(double *out, const double *xValues, const size_t nData) const override;
+  void functionDeriv1D(API::Jacobian *out, const double *xValues, const size_t nData) override;
+  const std::string category() const override { return "Muon\\MuonModelling"; }
+  void beforeFunctionSet() const;
+
+protected:
+  /// overwrite IFunction base class method, which declare function parameters
+  void init() override;
+
+private:
+  double getExp() const;
+  double getLifetimeMulti() const;
+};
+
+} // namespace Functions
+} // namespace CurveFitting
+} // namespace Mantid

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/Activation.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/Activation.h
@@ -44,7 +44,7 @@ protected:
   void init() override;
 
 private:
-  double getMeVConv() const;
+  double getmeVConv() const;
 };
 
 } // namespace Functions

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/Activation.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/Activation.h
@@ -16,8 +16,8 @@ namespace CurveFitting {
 namespace Functions {
 /**
 Provide Activation fit function interface to IFunction.
-I.e. if the unit is K, the function: y = = height*exp(-lifetime/x)
-or if the unit is meV, the function: y = height*exp(-e*lifetime/(1000 k_B x))
+I.e. if the unit is K, the function: y = = AttemptRate*exp(-Barrier/x)
+or if the unit is meV, the function: y = AttemptRate*exp(-e*Barrier/(1000 k_B x))
 Activation attributes:
 <UL>
 <LI> Unit - either K or meV (default K)</LI>
@@ -25,8 +25,8 @@ Activation attributes:
 
 Activation parameters:
 <UL>
-<LI> Height - coefficient for height (default 1.0)</LI>
-<LI> Lifetime - coefficient for lifetime (default 1.0)</LI>
+<LI> AttemptRate - coefficient for attempt rate (default 1000.0)</LI>
+<LI> Barrier - coefficient for barrier energy (default 1000.0)</LI>
 </UL>
 */
 

--- a/Framework/CurveFitting/src/Functions/Activation.cpp
+++ b/Framework/CurveFitting/src/Functions/Activation.cpp
@@ -26,34 +26,34 @@ DECLARE_FUNCTION(Activation)
 
 void Activation::init() {
   declareAttribute("Unit", Attribute("K")); // or meV
-  declareParameter("Height", 1.0, "coefficient for height");
-  declareParameter("Lifetime", 1.0, "coefficient for Lifetime");
+  declareParameter("AttemptRate", 1000.0, "coefficient for attempt rate");
+  declareParameter("Barrier", 1000.0, "coefficient for barrier energy");
 }
 
 void Activation::function1D(double *out, const double *xValues, const size_t nData) const {
   beforeFunctionSet();
 
-  const double height = getParameter("Height");
-  const double lifetime = getParameter("Lifetime");
+  const double attemptRate = getParameter("AttemptRate");
+  const double barrier = getParameter("Barrier");
   const double meVConv = getMeVConv();
 
   for (size_t i = 0; i < nData; i++) {
-    out[i] = height * exp(-(meVConv * lifetime) / xValues[i]);
+    out[i] = attemptRate * exp(-(meVConv * barrier) / xValues[i]);
   }
 }
 
 void Activation::functionDeriv1D(Jacobian *out, const double *xValues, const size_t nData) {
   beforeFunctionSet();
 
-  const double height = getParameter("Height");
-  const double lifetime = getParameter("Lifetime");
+  const double attemptRate = getParameter("AttemptRate");
+  const double barrier = getParameter("Barrier");
   const double meVConv = getMeVConv();
 
   for (size_t i = 0; i < nData; i++) {
-    double diffHeight = exp(-(meVConv * lifetime) / xValues[i]);
-    double diffLifetime = (height * meVConv * (exp(-(meVConv * lifetime) / xValues[i]))) / xValues[i];
-    out->set(i, 0, diffHeight);
-    out->set(i, 1, diffLifetime);
+    double diffAR = exp(-(meVConv * barrier) / xValues[i]);
+    double diffBarrier = -(attemptRate * meVConv * (exp(-(meVConv * barrier) / xValues[i]))) / xValues[i];
+    out->set(i, 0, diffAR);
+    out->set(i, 1, diffBarrier);
   }
 }
 

--- a/Framework/CurveFitting/src/Functions/Activation.cpp
+++ b/Framework/CurveFitting/src/Functions/Activation.cpp
@@ -1,0 +1,103 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2021 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin
+// SPDX - License - Identifier: GPL - 3.0 +
+//----------------------------------------------------------------------
+// Includes
+//----------------------------------------------------------------------
+#include "MantidCurveFitting/Functions/Activation.h"
+#include "MantidAPI/FunctionFactory.h"
+#include "MantidKernel/PhysicalConstants.h"
+
+#include <cmath>
+
+namespace Mantid::CurveFitting::Functions {
+
+using namespace CurveFitting;
+
+using namespace Kernel;
+
+using namespace API;
+
+DECLARE_FUNCTION(Activation)
+
+void Activation::init() {
+  declareAttribute("Unit", Attribute("K")); // or meV
+  declareParameter("Height", 1.0, "coefficient for height");
+  declareParameter("Lifetime", 1.0, "coefficient for Lifetime");
+}
+
+void Activation::function1D(double *out, const double *xValues, const size_t nData) const {
+  beforeFunctionSet();
+
+  const double height = getParameter("Height");
+  const double lifetime = getParameter("Lifetime");
+  const double expFunc = getExp();
+
+  for (size_t i = 0; i < nData; i++) {
+    out[i] = height * exp(-expFunc * (1 / xValues[i]));
+  }
+}
+
+void Activation::functionDeriv1D(Jacobian *out, const double *xValues, const size_t nData) {
+  beforeFunctionSet();
+
+  const double height = getParameter("Height");
+  const double lifetime = getParameter("Lifetime");
+  const double expFunc = getExp();
+  // auto unit = getAttribute("Unit").asString();
+  // const double k_B = PhysicalConstants::BoltzmannConstant;
+
+  for (size_t i = 0; i < nData; i++) {
+    double diffHeight = exp(-expFunc * (1 / xValues[i]));
+    double diffLifetimeMulti = getLifetimeMulti();
+    double diffLifetime = diffLifetimeMulti * ((height * exp(-expFunc * (1 / xValues[i])) / xValues[i]));
+    out->set(i, 0, diffHeight);
+    out->set(i, 1, diffLifetime);
+  }
+}
+
+void Activation::beforeFunctionSet() const {
+  auto unit = getAttribute("Unit").asString();
+
+  if (unit.compare("K") != 0 || unit.compare("meV") != 0) {
+    throw std::invalid_argument("Activation function can only be used with K or meV as the unit");
+  }
+}
+
+double Activation::getExp() const {
+  auto unit = getAttribute("Unit").asString();
+  const double lifetime = getParameter("Lifetime");
+
+  if (unit.compare("K") == 0) {
+    return lifetime;
+  }
+
+  if (unit.compare("meV") == 0) {
+    const double k_B = PhysicalConstants::BoltzmannConstant;
+    const double e = 1.0; // elementary charge
+
+    const double unitFunc = (e * lifetime) / (1000 * k_B);
+    return unitFunc;
+  }
+}
+
+double Activation::getLifetimeMulti() const {
+  auto unit = getAttribute("Unit").asString();
+  const double lifetime = getParameter("Lifetime");
+
+  if (unit.compare("K") == 0) {
+    return 1.0;
+  }
+
+  if (unit.compare("meV") == 0) {
+    const double k_B = PhysicalConstants::BoltzmannConstant;
+
+    const double unitFunc = 1 / (1000 * k_B);
+    return unitFunc;
+  }
+}
+
+} // namespace Mantid::CurveFitting::Functions

--- a/Framework/CurveFitting/src/Functions/Activation.cpp
+++ b/Framework/CurveFitting/src/Functions/Activation.cpp
@@ -10,6 +10,7 @@
 #include "MantidCurveFitting/Functions/Activation.h"
 #include "MantidAPI/FunctionFactory.h"
 #include "MantidKernel/PhysicalConstants.h"
+#include <boost/algorithm/string.hpp>
 
 #include <cmath>
 
@@ -58,21 +59,23 @@ void Activation::functionDeriv1D(Jacobian *out, const double *xValues, const siz
 
 void Activation::beforeFunctionSet() const {
   auto unit = getAttribute("Unit").asString();
+  boost::to_lower(unit);
 
-  if (unit.compare("K") != 0 || unit.compare("meV") != 0) {
+  if (unit.compare("k") != 0 && unit.compare("mev") != 0) {
     throw std::invalid_argument("Activation function can only be used with K or meV as the unit");
   }
 }
 
 double Activation::getMeVConv() const {
   auto unit = getAttribute("Unit").asString();
+  boost::to_lower(unit);
   const double meVConv = PhysicalConstants::meVtoKelvin;
 
-  if (unit.compare("K") == 0) {
+  if (unit.compare("k") == 0) {
     return 1.0;
   }
 
-  if (unit.compare("meV") == 0) {
+  if (unit.compare("mev") == 0) {
     return meVConv;
   }
 }

--- a/Framework/CurveFitting/src/Functions/Activation.cpp
+++ b/Framework/CurveFitting/src/Functions/Activation.cpp
@@ -34,10 +34,10 @@ void Activation::function1D(double *out, const double *xValues, const size_t nDa
 
   const double height = getParameter("Height");
   const double lifetime = getParameter("Lifetime");
-  const double expFunc = getExp();
+  const double meVConv = getMeVConv();
 
   for (size_t i = 0; i < nData; i++) {
-    out[i] = height * exp(-expFunc * (1 / xValues[i]));
+    out[i] = height * exp(-(meVConv * lifetime) / xValues[i]);
   }
 }
 
@@ -46,14 +46,11 @@ void Activation::functionDeriv1D(Jacobian *out, const double *xValues, const siz
 
   const double height = getParameter("Height");
   const double lifetime = getParameter("Lifetime");
-  const double expFunc = getExp();
-  // auto unit = getAttribute("Unit").asString();
-  // const double k_B = PhysicalConstants::BoltzmannConstant;
+  const double meVConv = getMeVConv();
 
   for (size_t i = 0; i < nData; i++) {
-    double diffHeight = exp(-expFunc * (1 / xValues[i]));
-    double diffLifetimeMulti = getLifetimeMulti();
-    double diffLifetime = diffLifetimeMulti * ((height * exp(-expFunc * (1 / xValues[i])) / xValues[i]));
+    double diffHeight = exp(-(meVConv * lifetime) / xValues[i]);
+    double diffLifetime = (height * meVConv * (exp(-(meVConv * lifetime) / xValues[i]))) / xValues[i];
     out->set(i, 0, diffHeight);
     out->set(i, 1, diffLifetime);
   }
@@ -67,36 +64,16 @@ void Activation::beforeFunctionSet() const {
   }
 }
 
-double Activation::getExp() const {
+double Activation::getMeVConv() const {
   auto unit = getAttribute("Unit").asString();
-  const double lifetime = getParameter("Lifetime");
-
-  if (unit.compare("K") == 0) {
-    return lifetime;
-  }
-
-  if (unit.compare("meV") == 0) {
-    const double k_B = PhysicalConstants::BoltzmannConstant;
-    const double e = 1.0; // elementary charge
-
-    const double unitFunc = (e * lifetime) / (1000 * k_B);
-    return unitFunc;
-  }
-}
-
-double Activation::getLifetimeMulti() const {
-  auto unit = getAttribute("Unit").asString();
-  const double lifetime = getParameter("Lifetime");
+  const double meVConv = PhysicalConstants::meVtoKelvin;
 
   if (unit.compare("K") == 0) {
     return 1.0;
   }
 
   if (unit.compare("meV") == 0) {
-    const double k_B = PhysicalConstants::BoltzmannConstant;
-
-    const double unitFunc = 1 / (1000 * k_B);
-    return unitFunc;
+    return meVConv;
   }
 }
 

--- a/Framework/CurveFitting/src/Functions/Activation.cpp
+++ b/Framework/CurveFitting/src/Functions/Activation.cpp
@@ -69,15 +69,16 @@ void Activation::beforeFunctionSet() const {
 double Activation::getMeVConv() const {
   auto unit = getAttribute("Unit").asString();
   boost::to_lower(unit);
-  const double meVConv = PhysicalConstants::meVtoKelvin;
+  double meVConv;
 
   if (unit.compare("k") == 0) {
-    return 1.0;
+    meVConv = 1.0;
   }
 
   if (unit.compare("mev") == 0) {
-    return meVConv;
+    meVConv = PhysicalConstants::meVtoKelvin;
   }
+  return meVConv;
 }
 
 } // namespace Mantid::CurveFitting::Functions

--- a/Framework/CurveFitting/src/Functions/Activation.cpp
+++ b/Framework/CurveFitting/src/Functions/Activation.cpp
@@ -25,7 +25,7 @@ using namespace API;
 DECLARE_FUNCTION(Activation)
 
 void Activation::init() {
-  declareAttribute("Unit", Attribute("K")); // this should either be K or MeV
+  declareAttribute("Unit", Attribute("K")); // this should either be K or meV
   declareParameter("AttemptRate", 1000.0, "coefficient for attempt rate");
   declareParameter("Barrier", 1000.0, "coefficient for barrier energy");
 }

--- a/Framework/CurveFitting/src/Functions/Activation.cpp
+++ b/Framework/CurveFitting/src/Functions/Activation.cpp
@@ -10,7 +10,6 @@
 #include "MantidCurveFitting/Functions/Activation.h"
 #include "MantidAPI/FunctionFactory.h"
 #include "MantidKernel/PhysicalConstants.h"
-#include <boost/algorithm/string.hpp>
 
 #include <cmath>
 
@@ -67,14 +66,13 @@ void Activation::beforeFunctionSet() const {
 
 double Activation::getmeVConv() const {
   auto unit = getAttribute("Unit").asString();
-  boost::to_lower(unit);
   double meVConv;
 
-  if (unit.compare("k") == 0) {
+  if (unit.compare("K") == 0) {
     meVConv = 1.0;
   }
 
-  if (unit.compare("mev") == 0) {
+  if (unit.compare("meV") == 0) {
     meVConv = PhysicalConstants::meVtoKelvin;
   }
   return meVConv;

--- a/Framework/CurveFitting/src/Functions/Activation.cpp
+++ b/Framework/CurveFitting/src/Functions/Activation.cpp
@@ -25,7 +25,7 @@ using namespace API;
 DECLARE_FUNCTION(Activation)
 
 void Activation::init() {
-  declareAttribute("Unit", Attribute("K")); // or meV
+  declareAttribute("Unit", Attribute("K")); // this should either be K or MeV
   declareParameter("AttemptRate", 1000.0, "coefficient for attempt rate");
   declareParameter("Barrier", 1000.0, "coefficient for barrier energy");
 }
@@ -35,7 +35,7 @@ void Activation::function1D(double *out, const double *xValues, const size_t nDa
 
   const double attemptRate = getParameter("AttemptRate");
   const double barrier = getParameter("Barrier");
-  const double meVConv = getMeVConv();
+  const double meVConv = getmeVConv();
 
   for (size_t i = 0; i < nData; i++) {
     out[i] = attemptRate * exp(-(meVConv * barrier) / xValues[i]);
@@ -47,7 +47,7 @@ void Activation::functionDeriv1D(Jacobian *out, const double *xValues, const siz
 
   const double attemptRate = getParameter("AttemptRate");
   const double barrier = getParameter("Barrier");
-  const double meVConv = getMeVConv();
+  const double meVConv = getmeVConv();
 
   for (size_t i = 0; i < nData; i++) {
     double diffAR = exp(-(meVConv * barrier) / xValues[i]);
@@ -66,7 +66,7 @@ void Activation::beforeFunctionSet() const {
   }
 }
 
-double Activation::getMeVConv() const {
+double Activation::getmeVConv() const {
   auto unit = getAttribute("Unit").asString();
   boost::to_lower(unit);
   double meVConv;

--- a/Framework/CurveFitting/src/Functions/Activation.cpp
+++ b/Framework/CurveFitting/src/Functions/Activation.cpp
@@ -59,9 +59,8 @@ void Activation::functionDeriv1D(Jacobian *out, const double *xValues, const siz
 
 void Activation::beforeFunctionSet() const {
   auto unit = getAttribute("Unit").asString();
-  boost::to_lower(unit);
 
-  if (unit.compare("k") != 0 && unit.compare("mev") != 0) {
+  if (unit.compare("K") != 0 && unit.compare("meV") != 0) {
     throw std::invalid_argument("Activation function can only be used with K or meV as the unit");
   }
 }

--- a/Framework/CurveFitting/test/Functions/ActivationTest.h
+++ b/Framework/CurveFitting/test/Functions/ActivationTest.h
@@ -63,8 +63,8 @@ public:
     auto activ = createTestActivation();
     activ->setAttributeValue("Unit", "K");
 
-    const double height = activ->getParameter("Height");
-    const double lifetime = activ->getParameter("Lifetime");
+    const double attemptRate = activ->getParameter("AttemptRate");
+    const double barrier = activ->getParameter("Barrier");
 
     const std::size_t numPoints = 100;
     std::array<double, numPoints> xValues;
@@ -73,7 +73,7 @@ public:
     activ->function1D(yValues.data(), xValues.data(), numPoints);
 
     for (size_t i = 0; i < numPoints; i++) {
-      TS_ASSERT_DELTA(yValues[i], height * exp(-(1 * lifetime) / i), 1e-12);
+      TS_ASSERT_DELTA(yValues[i], attemptRate * exp(-(1 * barrier) / i), 1e-12);
     }
   }
 
@@ -81,8 +81,8 @@ public:
     auto activ = createTestActivation();
     activ->setAttributeValue("Unit", "meV");
 
-    const double height = activ->getParameter("Height");
-    const double lifetime = activ->getParameter("Lifetime");
+    const double attemptRate = activ->getParameter("AttemptRate");
+    const double barrier = activ->getParameter("Barrier");
     const double meVConv = Mantid::PhysicalConstants::meVtoKelvin;
 
     const std::size_t numPoints = 100;
@@ -92,7 +92,7 @@ public:
     activ->function1D(yValues.data(), xValues.data(), numPoints);
 
     for (size_t i = 0; i < numPoints; i++) {
-      TS_ASSERT_DELTA(yValues[i], height * exp(-(meVConv * lifetime) / i), 1e-12);
+      TS_ASSERT_DELTA(yValues[i], attemptRate * exp(-(meVConv * barrier) / i), 1e-12);
     }
   }
 
@@ -106,11 +106,11 @@ public:
     Mantid::CurveFitting::Jacobian jacobian(nData, 2);
     activ->functionDeriv1D(&jacobian, xValues.data(), nData);
 
-    double dfdheight = jacobian.get(0, 0);
-    double dfdlifetime = jacobian.get(0, 1);
+    double dfdar = jacobian.get(0, 0);
+    double dfdbarrier = jacobian.get(0, 1);
 
-    TS_ASSERT_DELTA(dfdheight, 0.3189065573, 1e-8);
-    TS_ASSERT_DELTA(dfdlifetime, 0.2095671662, 1e-8);
+    TS_ASSERT_DELTA(dfdar, 0.318906557, 1e-7);
+    TS_ASSERT_DELTA(dfdbarrier, -0.209567166, 1e-7);
   }
 
   void test_jacobian_gives_expected_values_meV() {
@@ -123,11 +123,11 @@ public:
     Mantid::CurveFitting::Jacobian jacobian(nData, 2);
     activ->functionDeriv1D(&jacobian, xValues.data(), nData);
 
-    double dfdheight = jacobian.get(0, 0);
-    double dfdlifetime = jacobian.get(0, 1);
+    double dfdar = jacobian.get(0, 0);
+    double dfdbarrier = jacobian.get(0, 1);
 
-    TS_ASSERT_DELTA(dfdheight, 0.00000173881, 1e-8);
-    TS_ASSERT_DELTA(dfdlifetime, 0.0000132598, 1e-8);
+    TS_ASSERT_DELTA(dfdar, 0.0000017388, 1e-7);
+    TS_ASSERT_DELTA(dfdbarrier, -0.000013260, 1e-7);
   }
 
 private:
@@ -144,8 +144,8 @@ private:
   std::shared_ptr<TestableActivation> createTestActivation() {
     auto func = std::make_shared<TestableActivation>();
     func->initialize();
-    func->setParameter("Height", 2.3);
-    func->setParameter("Lifetime", 4.0);
+    func->setParameter("AttemptRate", 2.3);
+    func->setParameter("Barrier", 4.0);
     return func;
   }
 };

--- a/Framework/CurveFitting/test/Functions/ActivationTest.h
+++ b/Framework/CurveFitting/test/Functions/ActivationTest.h
@@ -1,0 +1,151 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2021 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#pragma once
+
+#include <cxxtest/TestSuite.h>
+
+#include "MantidAPI/AlgorithmManager.h"
+#include "MantidAPI/FunctionFactory.h"
+#include "MantidCurveFitting/Functions/Activation.h"
+#include "MantidCurveFitting/Jacobian.h"
+#include "MantidKernel/PhysicalConstants.h"
+#include "MantidTestHelpers/WorkspaceCreationHelper.h"
+
+using namespace Mantid::API;
+using namespace Mantid::CurveFitting;
+using namespace Mantid::CurveFitting::Functions;
+using Mantid::MantidVec;
+
+class ActivationTest : public CxxTest::TestSuite {
+public:
+  // This pair of boilerplate methods prevent the suite being created statically
+  // This means the constructor isn't called when running other tests
+  static ActivationTest *createSuite() { return new ActivationTest(); }
+  static void destroySuite(ActivationTest *suite) { delete suite; }
+
+  void test_category() {
+    Activation fn;
+    TS_ASSERT_EQUALS(fn.category(), "Muon\\MuonModelling");
+  }
+
+  void test_function_parameter_settings() {
+    auto activ = createTestActivation();
+
+    TS_ASSERT_THROWS(activ->setParameter("X", 1.0), const std::invalid_argument &);
+    TS_ASSERT_THROWS(activ->setParameter("A9", 1.0), const std::invalid_argument &);
+    TS_ASSERT_THROWS(activ->setAttributeValue("type", "thng"), const std::invalid_argument &);
+  }
+
+  void test_unit_checker() {
+    auto activ = createTestActivation();
+
+    activ->setAttributeValue("Unit", "K");
+    TS_ASSERT_THROWS_NOTHING(activ->beforeFunctionSet());
+
+    activ->setAttributeValue("Unit", "k");
+    TS_ASSERT_THROWS_NOTHING(activ->beforeFunctionSet());
+
+    activ->setAttributeValue("Unit", "meV");
+    TS_ASSERT_THROWS_NOTHING(activ->beforeFunctionSet());
+
+    activ->setAttributeValue("Unit", "mev");
+    TS_ASSERT_THROWS_NOTHING(activ->beforeFunctionSet());
+
+    activ->setAttributeValue("Unit", "mevk");
+    TS_ASSERT_THROWS(activ->beforeFunctionSet(), const std::invalid_argument &);
+  }
+
+  void test_function_gives_expected_value_for_K_given_input() {
+    auto activ = createTestActivation();
+    activ->setAttributeValue("Unit", "K");
+
+    const double height = activ->getParameter("Height");
+    const double lifetime = activ->getParameter("Lifetime");
+
+    const std::size_t numPoints = 100;
+    std::array<double, numPoints> xValues;
+    std::iota(xValues.begin(), xValues.end(), 0);
+    std::array<double, numPoints> yValues;
+    activ->function1D(yValues.data(), xValues.data(), numPoints);
+
+    for (size_t i = 0; i < numPoints; i++) {
+      TS_ASSERT_DELTA(yValues[i], height * exp(-(1 * lifetime) / i), 1e-12);
+    }
+  }
+
+  void test_function_gives_expected_value_for_meV_given_input() {
+    auto activ = createTestActivation();
+    activ->setAttributeValue("Unit", "meV");
+
+    const double height = activ->getParameter("Height");
+    const double lifetime = activ->getParameter("Lifetime");
+    const double meVConv = Mantid::PhysicalConstants::meVtoKelvin;
+
+    const std::size_t numPoints = 100;
+    std::array<double, numPoints> xValues;
+    std::iota(xValues.begin(), xValues.end(), 0);
+    std::array<double, numPoints> yValues;
+    activ->function1D(yValues.data(), xValues.data(), numPoints);
+
+    for (size_t i = 0; i < numPoints; i++) {
+      TS_ASSERT_DELTA(yValues[i], height * exp(-(meVConv * lifetime) / i), 1e-12);
+    }
+  }
+
+  void test_jacobian_gives_expected_values_K() {
+    auto activ = createTestActivation();
+    activ->setAttributeValue("Unit", "K");
+
+    const size_t nData(1);
+    std::vector<double> xValues(nData, 3.5);
+
+    Mantid::CurveFitting::Jacobian jacobian(nData, 2);
+    activ->functionDeriv1D(&jacobian, xValues.data(), nData);
+
+    double dfdheight = jacobian.get(0, 0);
+    double dfdlifetime = jacobian.get(0, 1);
+
+    TS_ASSERT_DELTA(dfdheight, 0.3189065573, 1e-8);
+    TS_ASSERT_DELTA(dfdlifetime, 0.2095671662, 1e-8);
+  }
+
+  void test_jacobian_gives_expected_values_meV() {
+    auto activ = createTestActivation();
+    activ->setAttributeValue("Unit", "meV");
+
+    const size_t nData(1);
+    std::vector<double> xValues(nData, 3.5);
+
+    Mantid::CurveFitting::Jacobian jacobian(nData, 2);
+    activ->functionDeriv1D(&jacobian, xValues.data(), nData);
+
+    double dfdheight = jacobian.get(0, 0);
+    double dfdlifetime = jacobian.get(0, 1);
+
+    TS_ASSERT_DELTA(dfdheight, 0.00000173881, 1e-8);
+    TS_ASSERT_DELTA(dfdlifetime, 0.0000132598, 1e-8);
+  }
+
+private:
+  class TestableActivation : public Activation {
+  public:
+    void function1D(double *out, const double *xValues, const size_t nData) const override {
+      Activation::function1D(out, xValues, nData);
+    }
+    void functionDeriv1D(Mantid::API::Jacobian *out, const double *xValues, const size_t nData) override {
+      Activation::functionDeriv1D(out, xValues, nData);
+    }
+  };
+
+  std::shared_ptr<TestableActivation> createTestActivation() {
+    auto func = std::make_shared<TestableActivation>();
+    func->initialize();
+    func->setParameter("Height", 2.3);
+    func->setParameter("Lifetime", 4.0);
+    return func;
+  }
+};

--- a/Framework/CurveFitting/test/Functions/ActivationTest.h
+++ b/Framework/CurveFitting/test/Functions/ActivationTest.h
@@ -12,8 +12,8 @@
 #include "MantidAPI/FunctionFactory.h"
 #include "MantidCurveFitting/Functions/Activation.h"
 #include "MantidCurveFitting/Jacobian.h"
+#include "MantidFrameworkTestHelpers/WorkspaceCreationHelper.h"
 #include "MantidKernel/PhysicalConstants.h"
-#include "MantidTestHelpers/WorkspaceCreationHelper.h"
 
 using namespace Mantid::API;
 using namespace Mantid::CurveFitting;

--- a/Framework/CurveFitting/test/Functions/ActivationTest.h
+++ b/Framework/CurveFitting/test/Functions/ActivationTest.h
@@ -73,7 +73,7 @@ public:
     activ->function1D(yValues.data(), xValues.data(), numPoints);
 
     for (size_t i = 0; i < numPoints; i++) {
-      TS_ASSERT_DELTA(yValues[i], attemptRate * exp(-(1 * barrier) / i), 1e-12);
+      TS_ASSERT_DELTA(yValues[i], attemptRate * exp(-barrier / xValues[i]), 1e-12);
     }
   }
 
@@ -92,7 +92,7 @@ public:
     activ->function1D(yValues.data(), xValues.data(), numPoints);
 
     for (size_t i = 0; i < numPoints; i++) {
-      TS_ASSERT_DELTA(yValues[i], attemptRate * exp(-(meVConv * barrier) / i), 1e-12);
+      TS_ASSERT_DELTA(yValues[i], attemptRate * exp(-(meVConv * barrier) / xValues[i]), 1e-12);
     }
   }
 

--- a/Framework/CurveFitting/test/Functions/ActivationTest.h
+++ b/Framework/CurveFitting/test/Functions/ActivationTest.h
@@ -46,14 +46,14 @@ public:
     activ->setAttributeValue("Unit", "K");
     TS_ASSERT_THROWS_NOTHING(activ->beforeFunctionSet());
 
-    activ->setAttributeValue("Unit", "k");
-    TS_ASSERT_THROWS_NOTHING(activ->beforeFunctionSet());
-
     activ->setAttributeValue("Unit", "meV");
     TS_ASSERT_THROWS_NOTHING(activ->beforeFunctionSet());
 
+    activ->setAttributeValue("Unit", "k");
+    TS_ASSERT_THROWS(activ->beforeFunctionSet(), const std::invalid_argument &);
+
     activ->setAttributeValue("Unit", "mev");
-    TS_ASSERT_THROWS_NOTHING(activ->beforeFunctionSet());
+    TS_ASSERT_THROWS(activ->beforeFunctionSet(), const std::invalid_argument &);
 
     activ->setAttributeValue("Unit", "mevk");
     TS_ASSERT_THROWS(activ->beforeFunctionSet(), const std::invalid_argument &);

--- a/docs/source/fitting/fitfunctions/Activation.rst
+++ b/docs/source/fitting/fitfunctions/Activation.rst
@@ -9,29 +9,30 @@ Activation
 Description
 -----------
 
-An activation fitting function, when using Kelvin, may be used to describe:
+The activation fitting function can be written as:
 
 .. math:: y = A_R\times e^{-\frac{b}{x}}
 
 where:
 - A_R - Attempt Rate
 - b - Barrier energy
+- x - is in Kelvin
 
 
 When fitting to meV instead it can be described as:
 
-.. math:: y = A_R\times e^{-\frac{E\times b}{1000 k_B x}}
+.. math:: y = A_R e^{-\frac{E\times b}{1000 k_B x}}
 
 where:
-E = energy spin
-k_B = Boltzmann Constant
+- E - activation energy
+- k_B - Boltzmann Constant
 
 
 
 Examples
 --------
 
-An example of when this might be used is for examining the muonium state of CdS at low temperatures[1].
+An example of when this might be used is for examining the ion dynamics in flouride-containing polyatomic anion cathodes using muon spectroscopy [1].
 
 
 
@@ -41,7 +42,7 @@ An example of when this might be used is for examining the muonium state of CdS 
 
 References
 ----------
-[1] Gil, J.M et al (1999). Novel Muonium State in CdS. Phys. Rev. Lett., Vol 83 Issue 25, 5294-5297 `doi: 10.1103/PhysRevLett.83.5294 <https://doi.org/10.1103/PhysRevLett.83.5294>`.
+[1] Johnston, B. I., Baker, P. J. & Cussen, S. A. (2021). Ion dynamics in flouride-containing polyatomic anion cathodes by muon spectroscopy. Journal of Physics:Materials, Vol. 4 No. 4, `https://iopscience.iop.org/article/10.1088/2515-7639/ac22ba <https://iopscience.iop.org/article/10.1088/2515-7639/ac22ba>`.
 
 .. categories::
 

--- a/docs/source/fitting/fitfunctions/Activation.rst
+++ b/docs/source/fitting/fitfunctions/Activation.rst
@@ -28,6 +28,7 @@ where:
 - k_B - Boltzmann Constant
 
 
+When using this function the Unit must be set to either K or meV otherwise the fitting function will not be applied.
 
 Examples
 --------

--- a/docs/source/fitting/fitfunctions/Activation.rst
+++ b/docs/source/fitting/fitfunctions/Activation.rst
@@ -1,0 +1,48 @@
+.. _func-Activation:
+
+==========
+Activation
+==========
+
+.. index:: Activation
+
+Description
+-----------
+
+An activation fitting function, when using Kelvin, may be used to describe:
+
+.. math:: y = A_R\times e^{-\frac{b}{x}}
+
+where:
+- A_R - Attempt Rate
+- b - Barrier energy
+
+
+When fitting to meV instead it can be described as:
+
+.. math:: y = A_R\times e^{-\frac{E\times b}{1000 k_B x}}
+
+where:
+E = energy spin
+k_B = Boltzmann Constant
+
+
+
+Examples
+--------
+
+An example of when this might be used is for examining the muonium state of CdS at low temperatures[1].
+
+
+
+.. attributes::
+
+.. properties::
+
+References
+----------
+[1] Gil, J.M et al (1999). Novel Muonium State in CdS. Phys. Rev. Lett., Vol 83 Issue 25, 5294-5297 `doi: 10.1103/PhysRevLett.83.5294 <https://doi.org/10.1103/PhysRevLett.83.5294>`.
+
+.. categories::
+
+.. sourcelink::

--- a/docs/source/fitting/fitfunctions/Activation.rst
+++ b/docs/source/fitting/fitfunctions/Activation.rst
@@ -11,7 +11,7 @@ Description
 
 The activation fitting function can be written as:
 
-.. math:: y = A_R\times e^{-\frac{b}{x}}
+.. math:: y = A_R e^{-\frac{b}{x}}
 
 where:
 - A_R - Attempt Rate

--- a/docs/source/release/v6.3.0/muon.rst
+++ b/docs/source/release/v6.3.0/muon.rst
@@ -78,9 +78,11 @@ Fitting Functions
 -----------------
 New Features
 ############
+- Added an :ref:`Activation <func-Activation>` fitting function to MuonModelling Fit Functions.
 - Added a :ref:`Muonium-style Decoupling Curve <func-MuoniumDecouplingCurve>` function to MuonModelling Fit Functions.
-- Added a :ref:`Power Law <func-PowerLaw>` function to MuonModelling Fit Functions.
+- Added a :ref:`Power Law <func-PowerLaw>` fitting function to MuonModelling Fit Functions.
 - Added a ref:`Smooth Transition <func-SmoothTransition>` function to MuonModelling Fit Functions.
+
 
 Improvements
 ############


### PR DESCRIPTION
**Description of work.**
Added a new Activation Fit function for Muon modelling and associated documentation.

**To test:**
1. Enable the model analysis tab and plot (see #32572 for details on how to do this)
2. Open Muon Analysis GUI
2. Change Instrument to EMU
3. Load runs 20901-18
4. Go to the Grouping Tab 
5. Click Guess Alpha and select run 20918
6. Go to fitting tab and add a DynamicKuboToyabe Fitting Function
7. Set the Field to 0 and Fix it (right click on the attribute and a menu should appear with Fix as one of the options)
8.  Set Delta to 0.35 and Nu to 0.01. Do not fix these.
8. Go to the Sequential Fitting Tab and select runs 20901-17 and then sequentially fit selected
9. Go to the Results Tab
10. Select Temp_Sample from the log results and then click Output Results
11. Open the Model fitting tab and change x axis to Temp_sample and y axis to Nu
12. Add an Activation Fit Function and fit (leave Unit as K). AttemptRate = 33.4 +- 3.6 us^-1 and Barrier = 589.7+-13.9 and ChiSquared should be about 3.75 or better.

Fixes #32579. 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
