### PR TITLE
Get radius from sample in AnvredCorrection

### DIFF
--- a/Framework/Algorithms/src/SphericalAbsorption.cpp
+++ b/Framework/Algorithms/src/SphericalAbsorption.cpp
@@ -64,7 +64,8 @@ void SphericalAbsorption::init() {
                   "The number density of the sample in number of atoms per "
                   "cubic angstrom, if not set with SetSampleMaterial");
   declareProperty("SphericalSampleRadius", EMPTY_DBL(), mustBePositive,
-                  "The radius of the spherical sample in centimetres");
+                  "The radius of the spherical sample in centimetresif "
+                  "not set with SetSample.");
 }
 
 void SphericalAbsorption::exec() {

--- a/Framework/Crystal/inc/MantidCrystal/AnvredCorrection.h
+++ b/Framework/Crystal/inc/MantidCrystal/AnvredCorrection.h
@@ -97,6 +97,8 @@ private:
   void execEvent();
   /// Algorithm cleanup
   void cleanup();
+  /// validate inputs
+  std::map<std::string, std::string> validateInputs() override;
 
   void retrieveBaseProperties();
   // void constructSample(API::Sample& sample);

--- a/Framework/Crystal/src/AnvredCorrection.cpp
+++ b/Framework/Crystal/src/AnvredCorrection.cpp
@@ -94,7 +94,9 @@ void AnvredCorrection::init() {
   declareProperty("LinearAbsorptionCoef", EMPTY_DBL(), mustBePositive,
                   "Linear absorption coefficient at 1.8 Angstroms in 1/cm if "
                   "not set with SetSampleMaterial");
-  declareProperty("Radius", EMPTY_DBL(), mustBePositive, "Radius of the sample in centimeters");
+  declareProperty("Radius", EMPTY_DBL(), mustBePositive,
+                  "Radius of the sample in centimeters if "
+                  "not set with SetSample.");
   declareProperty("PreserveEvents", true,
                   "Keep the output workspace as an EventWorkspace, if the "
                   "input has events (default).\n"

--- a/Framework/Crystal/test/AnvredCorrectionTest.h
+++ b/Framework/Crystal/test/AnvredCorrectionTest.h
@@ -6,6 +6,7 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 #pragma once
 
+#include "MantidAPI/AlgorithmManager.h"
 #include "MantidAPI/Axis.h"
 #include "MantidCrystal/AnvredCorrection.h"
 #include "MantidDataHandling/LoadInstrument.h"
@@ -135,6 +136,29 @@ public:
     alg.setProperty("Radius", 0.1);               // large
     TS_ASSERT_THROWS_NOTHING(alg.execute();)
     TS_ASSERT(alg.isExecuted())
+  }
+
+  void test_throws_when_no_radius_and_not_spherical_shape() {
+    workspace->getAxis(0)->setUnit("Wavelength");
+    // set sample to be cylinder
+    auto setSampleAlg = AlgorithmManager::Instance().createUnmanaged("SetSample");
+    setSampleAlg->initialize();
+    setSampleAlg->setProperty("InputWorkspace", workspace);
+    setSampleAlg->setPropertyValue("Geometry",
+                                   R"({"Shape": "Cylinder", "Height": 1.0, "Radius": 0.2, "Center": [0., 0., 0.]})");
+    setSampleAlg->execute();
+
+    AnvredCorrection alg;
+    TS_ASSERT_THROWS_NOTHING(alg.initialize())
+    TS_ASSERT(alg.isInitialized())
+    alg.setProperty("InputWorkspace", workspace);
+    alg.setProperty("OutputWorkspace", "TOPAZ");
+    alg.setProperty("PreserveEvents", false);
+    alg.setProperty("OnlySphericalAbsorption", true);
+    alg.setProperty("LinearScatteringCoef", 0.1);
+    alg.setProperty("LinearAbsorptionCoef", 0.1); // large
+    TS_ASSERT_THROWS(alg.execute(), const std::runtime_error &);
+    TS_ASSERT(!alg.isExecuted());
   }
 
 private:

--- a/docs/source/release/v6.3.0/diffraction.rst
+++ b/docs/source/release/v6.3.0/diffraction.rst
@@ -18,6 +18,7 @@ Powder Diffraction
 - `absorptioncorrutils` now have the capability to calculate effective absorption correction (considering both absorption and multiple scattering).
 - Both :ref:`MultipleScatteringCorrection <algm-MultipleScatteringCorrection>` and :ref:`PaalmanPingsAbsorptionCorrection <algm-PaalmanPingsAbsorptionCorrection>` can use a different element size for container now.
 - PEARL powder diffraction scripts now cope if absorption correction workspace is different size to the Vanadium workspace without generating NaN values
+- :ref:`AnvredCorrection <algm-AnvredCorrection>` (and :ref:`SphericalAbsorption <algm-SphericalAbsorption>` which calls it) will now take the radius of a spherical sample from the workspace if the radius isn't specified (if the sample is not a sphere this will produce an error).
 
 Bugfixes
 ########


### PR DESCRIPTION
**Description of work.**

Added validation to input to `AnvredCorrection` to check that if a radius is not supplied then the sample must have a spherical sample with a radius (this is technically a breaking change, but if users hadn't supplied a radius (it has always been optional) then the result would be nonsense so it is probably good to throw an error).

Also corrected a polynomial coefficient at one theta - further details can be found here
https://github.com/mantidproject/mantid/issues/31342#issuecomment-960816860

**To test:**
Test it using `SphericalAbsorption` (which calls `AnvredCorrection`)
(1) Run this script without error
```
ws = CreateSampleWorkspace()
ConvertUnits(InputWorkspace='ws', OutputWorkspace='ws', Target='Wavelength')
shape = '''<sphere id="V-sphere">
    <centre x="0.0"  y="0.0" z="0.0" />
    <radius val="0.0025"/>
    </sphere>'''
SetSample(ws, Geometry={'Shape': 'CSG', 'Value': shape},
          Material={'ChemicalFormula': 'V0.95-Nb0.05', 'SampleNumberDensity': 0.0119}) 
SphericalAbsorption(InputWorkspace=ws, OutputWorkspace='van_abs_corr')
```
It should print in the log that the radius was 0.25 cm
(2) Check that the radius used (printed in the log) is the one supplied rather than from sample (backward compatibility)
```
SphericalAbsorption(InputWorkspace=ws, OutputWorkspace='van_abs_corr', SphericalSampleRadius=0.5)
```
(3) Try setting a non-spherical sample - it should throw an error
```
SetSample(ws, Geometry={'Shape': 'HollowCylinder', 'Height': 4.0, 'InnerRadius': 0.8, 'OuterRadius': 1.0, 'Center': [0.,0.,0.]},
    Material={'ChemicalFormula': 'V0.95-Nb0.05', 'SampleNumberDensity': 0.0119})
SphericalAbsorption(InputWorkspace=ws, OutputWorkspace='van_abs_corr_cylinder')
```

Fixes #32893 
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
