### PR TITLE
Fix slice view issue when slicing with Log scaling (Main)

### DIFF
--- a/docs/source/release/v6.3.0/mantidworkbench.rst
+++ b/docs/source/release/v6.3.0/mantidworkbench.rst
@@ -34,5 +34,7 @@ Bugfixes
 - Fixed a bug where copying data from a table displaying a matrix workspace was not working.
 - Fixed plot bins not working on data with numeric X-axis.
 - Fixed a bug with autoscaling of colorfill plots from within the figure options.
+- Fixed an issue to plot negative values with logarithm scaling in slice view.
+
 
 :ref:`Release 6.3.0 <v6.3.0>`

--- a/qt/python/mantidqt/mantidqt/widgets/colorbar/colorbar.py
+++ b/qt/python/mantidqt/mantidqt/widgets/colorbar/colorbar.py
@@ -302,7 +302,7 @@ class ColorbarWidget(QWidget):
                 masked_data = data[~data.mask]
                 # use the smallest positive value as vmin when using log scale,
                 # matplotlib will take care of the data skipping part.
-                masked_data = masked_data[data > 0] if norm == "Log" else masked_data
+                masked_data = masked_data[masked_data > 0] if norm == "Log" else masked_data
                 self.cmin_value = masked_data.min()
                 self.cmax_value = masked_data.max()
             except (AttributeError, IndexError):


### PR DESCRIPTION
**Description of work.**

This is to fix [SCD 428](https://code.ornl.gov/sns-hfir-scse/diffraction/single-crystal/single-crystal-diffraction/-/issues/428),
by fixing a bug in masking negative values to determine the minimum and maximum values for log scale plot in slice view.

**To test:**

Run

```
# import mantid algorithms, numpy and matplotlib
from mantid.simpleapi import *
import matplotlib.pyplot as plt
import numpy as np

nx = 100
ny = 80
nz = 60

ws = CreateMDHistoWorkspace(Dimensionality=3, 
                            Extents=[-10,10,-8,8,-6,6], 
                            Names='x,y,z', 
                            Units='U,V,W',
                            NumberOfBins='{},{},{}'.format(nx,ny,nz),
                            SignalInput=[0]*nx*ny*nz, 
                            ErrorInput=[0]*nx*ny*nz)

EvaluateFunction('name=UserFunctionMD,Formula=sin(x)*sin(y)*sin(z)','ws', OutputWorkspace='out')
```

Then change slice view to log scale with auto scaling, and then move the slider.

Or change the slice view to log scale, turn off and on auto scaling.

Without fix, an exception will be thrown from matplotlib.
---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
