### PR TITLE
SNSPowderReduction allow manual set sample geometry

### DIFF
--- a/Framework/PythonInterface/mantid/utils/absorptioncorrutils.py
+++ b/Framework/PythonInterface/mantid/utils/absorptioncorrutils.py
@@ -269,6 +269,7 @@ def calculate_absorption_correction(
     props,
     sample_formula,
     mass_density,
+    sample_geometry={},
     number_density=Property.EMPTY_DBL,
     container_shape="PAC06",
     num_wl_bins=1000,
@@ -307,6 +308,7 @@ def calculate_absorption_correction(
     :param props: PropertyManager of run characterizations, obtained from PDDetermineCharacterizations
     :param sample_formula: Sample formula to specify the Material for absorption correction
     :param mass_density: Mass density of the sample to specify the Material for absorption correction
+    :param sample_geometry: Dictionary to specify the sample geometry for absorption correction
     :param number_density: Optional number density of sample to be added to the Material for absorption correction
     :param container_shape: Shape definition of container, such as PAC06.
     :param num_wl_bins: Number of bins for calculating wavelength
@@ -336,6 +338,7 @@ def calculate_absorption_correction(
                                       props,
                                       num_wl_bins,
                                       material=material,
+                                      geometry=sample_geometry,
                                       environment=environment,
                                       metaws=metaws)
 

--- a/Framework/PythonInterface/plugins/algorithms/SNSPowderReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/SNSPowderReduction.py
@@ -233,6 +233,7 @@ class SNSPowderReduction(DistributedDataProcessorAlgorithm):
                              StringListValidator(["None", "SampleOnly", "SampleAndContainer", "FullPaalmanPings"]),
                              doc="Specifies the Absorption Correction terms to calculate, if any.")
         self.declareProperty("SampleFormula", "", doc="Chemical formula of the sample")
+        self.declareProperty("SampleGeometry", {}, doc="A dictionary of geometry parameters for the sample.")
         self.declareProperty("MeasuredMassDensity", defaultValue=0.1,
                              validator=FloatBoundedValidator(lower=0., exclusive=True),
                              doc="Measured mass density of sample in g/cc")  # in g/cc, way to validate?
@@ -335,6 +336,7 @@ class SNSPowderReduction(DistributedDataProcessorAlgorithm):
         self._outTypes = self.getProperty("SaveAs").value.lower()
         self._absMethod = self.getProperty("TypeOfCorrection").value
         self._sampleFormula = self.getProperty("SampleFormula").value
+        self._sampleGeometry = self.getProperty("SampleGeometry").value
         self._massDensity = self.getProperty("MeasuredMassDensity").value
         self._numberDensity = self.getProperty("SampleNumberDensity").value
         self._containerShape = self.getProperty("ContainerShape").value
@@ -432,6 +434,7 @@ class SNSPowderReduction(DistributedDataProcessorAlgorithm):
             self._info,  # PropertyManager of run characterizations
             self._sampleFormula,  # Material for absorption correction
             self._massDensity,  # Mass density of the sample
+            self._sampleGeometry, # Geometry parameters for the sample
             self._numberDensity,  # Optional number density of sample to be added
             self._containerShape,  # Shape definition of container
             self._num_wl_bins,  # Number of bins: len(ws.readX(0))-1

--- a/Framework/PythonInterface/plugins/algorithms/SetSampleFromLogs.py
+++ b/Framework/PythonInterface/plugins/algorithms/SetSampleFromLogs.py
@@ -173,6 +173,10 @@ class SetSampleFromLogs(DistributedDataProcessorAlgorithm):
                   ContainerGeometry=geometryContainer,
                   ContainerMaterial=materialContainer)
 
+        # validate that sample shape was set to something with volume!=0
+        if (wksp.sample().getShape().volume() == 0):
+            raise RuntimeError("Resulting sample shape has volume of 0")
+
 
 # Register algorithm with Mantid.
 AlgorithmFactory.subscribe(SetSampleFromLogs)

--- a/Framework/PythonInterface/test/python/plugins/algorithms/SetSampleFromLogsTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/SetSampleFromLogsTest.py
@@ -5,7 +5,7 @@
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
 import unittest
-from mantid.simpleapi import (Load, LoadNexusProcessed, SetSampleFromLogs)
+from mantid.simpleapi import (Load, LoadNexusProcessed, SetSampleFromLogs, AddSampleLog)
 from math import pi
 
 PAC06_RADIUS = 0.00295
@@ -65,6 +65,23 @@ class SetSampleFromLogsTest(unittest.TestCase):
 
         # verify the results
         self.validateSample(wksp.sample(), "Si", PAC06_HEIGHT)
+
+        del wksp  # remove from the ADS
+
+    def testVolumeZero_raises(self):
+        wksp = self.loadPG3Data("testVolumeZero")
+        # Set height to 0, should fail
+        AddSampleLog(wksp,
+                     LogName='BL11A:CS:ITEMS:HeightInContainer',
+                     LogText='0.', LogType='Number Series', NumberType='Double')
+
+        material = {}
+        environment = {"Name": "InAir"}
+        geometry = {}
+
+        with self.assertRaises(RuntimeError):
+            SetSampleFromLogs(InputWorkspace=wksp, Environment=environment,
+                              Material=material, Geometry=geometry)
 
         del wksp  # remove from the ADS
 

--- a/Testing/SystemTests/tests/framework/SNSPowderRedux.py
+++ b/Testing/SystemTests/tests/framework/SNSPowderRedux.py
@@ -487,3 +487,25 @@ class PG3InfoFromLogs(systemtesting.MantidSystemTest):
 
         # Check volume using height value from log - pi*(r^2)*h, r and h in meters
         assert mtd['PG3_46577'].sample().getShape().volume() == np.pi * np.square(.00295) * .040
+
+        # Try manually setting sample geometry, height to 2cm
+        SNSPowderReduction("PG3_46577.nxs.h5",
+                           CalibrationFile=self.cal_file,
+                           CharacterizationRunsFile=charfile,
+                           Binning=-0.001,
+                           SaveAs="nexus",
+                           TypeOfCorrection="FullPaalmanPings",
+                           SampleFormula="Si",
+                           SampleGeometry={'Height': 2.0},
+                           MeasuredMassDensity=1.165,
+                           ContainerShape="",
+                           OutputFilePrefix='PP_absorption_',
+                           OutputDirectory=savedir)
+
+        # Check name, number density, effective density
+        assert mtd['PG3_46577'].sample().getMaterial().name() == 'Si'
+        assert mtd['PG3_46577'].sample().getMaterial().numberDensity == SI_NUMBER_DENSITY
+        assert mtd['PG3_46577'].sample().getMaterial().numberDensityEffective == SI_NUMBER_DENSITY_EFFECTIVE
+
+        # Check volume using height value from log - pi*(r^2)*h, r and h in meters
+        assert mtd['PG3_46577'].sample().getShape().volume() == np.pi * np.square(.00295) * .020

--- a/Testing/SystemTests/tests/framework/SNSPowderRedux.py
+++ b/Testing/SystemTests/tests/framework/SNSPowderRedux.py
@@ -463,6 +463,7 @@ class PG3InfoFromLogs(systemtesting.MantidSystemTest):
                            CharacterizationRunsFile=charfile,
                            Binning=-0.001,
                            SaveAs="nexus",
+                           NumWavelengthBins=1,
                            OutputDirectory=savedir)
 
         assert not mtd['PG3_46577'].sample().getMaterial().name().strip()
@@ -475,6 +476,7 @@ class PG3InfoFromLogs(systemtesting.MantidSystemTest):
                            SaveAs="nexus",
                            TypeOfCorrection="FullPaalmanPings",
                            SampleFormula="Si",
+                           NumWavelengthBins=1,
                            MeasuredMassDensity=1.165,
                            ContainerShape="",
                            OutputFilePrefix='PP_absorption_',
@@ -495,6 +497,7 @@ class PG3InfoFromLogs(systemtesting.MantidSystemTest):
                            Binning=-0.001,
                            SaveAs="nexus",
                            TypeOfCorrection="FullPaalmanPings",
+                           NumWavelengthBins=1,
                            SampleFormula="Si",
                            SampleGeometry={'Height': 2.0},
                            MeasuredMassDensity=1.165,

--- a/docs/source/release/v6.3.0/diffraction.rst
+++ b/docs/source/release/v6.3.0/diffraction.rst
@@ -16,6 +16,7 @@ Powder Diffraction
 - `CalibrateRectangularDetectors`, which is deprecate since v6.2.0, is removed. And system test CalibrateRectangularDetectors_Test is removed.
 - Extending :ref:`MultipleScatteringCorrection <algm-MultipleScatteringCorrection>` to the sample and container case.
 - `absorptioncorrutils` now have the capability to calculate effective absorption correction (considering both absorption and multiple scattering).
+- :ref:`SNSPowderReduction <algm-SNSPowderReduction>` now has an option to manually specify sample geometry for absorption correction.
 - Both :ref:`MultipleScatteringCorrection <algm-MultipleScatteringCorrection>` and :ref:`PaalmanPingsAbsorptionCorrection <algm-PaalmanPingsAbsorptionCorrection>` can use a different element size for container now.
 
 Bugfixes

--- a/docs/source/release/v6.3.0/framework.rst
+++ b/docs/source/release/v6.3.0/framework.rst
@@ -23,6 +23,7 @@ Improvements
 - :ref:`GenerateLogbook <algm-GenerateLogbook>` now allows to perform binary operations even when certain entries do not exist, e.g. to create a string with all polarisation orientations contained in a collection of data files
 - Event nexuses produced at ILL can now be loaded using :ref:`LoadEventNexus <algm-LoadEventNexus>`.
 - :ref:`Rebin <algm-Rebin>` now has an option for binning with reverse logarithmic and inverse power bins.
+- :ref:`SetSampleFromLogs <algm-SetSampleFromLogs>` will now fail if the resulting sample shape has a volume of 0.
 - :ref:`SetSample <algm-SetSample>` can now load sample environment XML files from any directory using ``SetSample(ws, Environment={'Name': 'NameOfXMLFile', 'Path':'/path/to/file/'})``.
 
 Data Objects


### PR DESCRIPTION
**Description of work.**

This allows for a fix in the cases where the sample log  `HeightInContainer` was set to 0 resulting in sample geometry with 0 volume, which then causes the absorption correction to be incorrect.

Fixes [PD398](https://code.ornl.gov/sns-hfir-scse/diffraction/powder/powder-diffraction/-/issues/398)

**To test:**

Try the original script at `/SNS/NOM/shared/User_story_test/PG3_51580/PG3_51580.py`, it should fail quickly now with a useful error message. Try with the new option of `SampleGeometry={'Height': 2.4}` and it should run successfully with non-zero output.

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
