### PR TITLE
Delete DrILL instance at close event

### DIFF
--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Drill.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Drill.py
@@ -24,6 +24,15 @@ else:
         app, within_mantid = get_qapplication()
         if 'drillInterface' not in globals():
             drillInterface = DrillView()
+        else:
+            drillInterface = globals()["drillInterface"]
+            try:
+                visible = drillInterface.isVisible()
+            except:
+                #underlying Qt object has been deleted
+                visible = False
+            if not visible:
+                drillInterface = DrillView()
         drillInterface.show()
         if not within_mantid:
             sys.exit(app.exec_())

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/drill/view/DrillView.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/drill/view/DrillView.py
@@ -133,6 +133,7 @@ class DrillView(QMainWindow):
 
     def __init__(self, parent=None, window_flags=None):
         super(DrillView, self).__init__(parent)
+        self.setAttribute(Qt.WA_DeleteOnClose)
         if window_flags:
             self.setWindowFlags(window_flags)
         self.here = os.path.dirname(os.path.realpath(__file__))


### PR DESCRIPTION
**Description of work.**

This PR changes the way the DrILL instances are created and deleted.

This was causing a problem in #32878 because a previously closed instance of DrILL was preventing worbench to close.

When the DrILL window was closed, the instance was not deleted but only hidden. Opening again DrILL was grabbing the old instance and showing it (this can be verified by entering some value in DrILL table, closing it and reopening it -> the table is not empty).

Now, the `Qt::WA_DeleteOnClose` flag as been added to properly deleted DrILL and a new instance is created each time. This means that when DrILL is opened again, the user will get a fresh table.

**To test:**

* open DrILL (interfaces -> ILL -> DrILL)
* fill some cells with random values
* close DrILL without saving
* open DrILL again
* The table should be empty

Test also #32878 on top of this PR.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
