### PR TITLE
Fix OSX build with OCCT 7.6.0

### DIFF
--- a/Framework/Geometry/src/Rendering/GeometryTriangulator.cpp
+++ b/Framework/Geometry/src/Rendering/GeometryTriangulator.cpp
@@ -37,6 +37,7 @@ GNU_DIAG_OFF("cast-qual")
 #include <BRepMesh_IncrementalMesh.hxx>
 #include <BRep_Tool.hxx>
 #include <Poly_Triangulation.hxx>
+#include <Standard_Version.hxx>
 #include <StdFail_NotDone.hxx>
 #include <TopExp_Explorer.hxx>
 #include <TopoDS.hxx>
@@ -52,6 +53,29 @@ GNU_DIAG_ON("cast-qual")
 #pragma warning enable 191
 #endif
 
+namespace {
+auto getNode(const Handle(Poly_Triangulation) facing, Standard_Integer i) {
+#if OCC_VERSION_MAJOR >= 7 && OCC_VERSION_MINOR >= 6
+  return facing->Node(i);
+#else
+  // Compat shim to support OCCT 7.5 and below
+  TColgp_Array1OfPnt tab(1, (facing->NbNodes()));
+  tab = facing->Nodes();
+  return tab.Value(i);
+#endif
+}
+
+auto getTriangle(const Handle(Poly_Triangulation) facing, Standard_Integer i) {
+#if OCC_VERSION_MAJOR >= 7 && OCC_VERSION_MINOR >= 6
+  return facing->Triangle(i);
+#else
+  // Compat shim to support OCCT 7.5 and below
+  Poly_Array1OfTriangle tri(1, facing->NbTriangles());
+  tri = facing->Triangles();
+  return tri.Value(i);
+#endif
+}
+} // namespace
 #endif // ENABLE_OPENCASCADE
 
 namespace Mantid::Geometry::detail {
@@ -194,10 +218,8 @@ void GeometryTriangulator::setupPoints() {
       TopoDS_Face F = TopoDS::Face(Ex.Current());
       TopLoc_Location L;
       Handle(Poly_Triangulation) facing = BRep_Tool::Triangulation(F, L);
-      TColgp_Array1OfPnt tab(1, (facing->NbNodes()));
-      tab = facing->Nodes();
       for (Standard_Integer i = 1; i <= (facing->NbNodes()); i++) {
-        gp_Pnt pnt = tab.Value(i);
+        const auto pnt = getNode(facing, i);
         m_points[index * 3 + 0] = pnt.X();
         m_points[index * 3 + 1] = pnt.Y();
         m_points[index * 3 + 2] = pnt.Z();
@@ -218,12 +240,8 @@ void GeometryTriangulator::setupFaces() {
       TopoDS_Face F = TopoDS::Face(Ex.Current());
       TopLoc_Location L;
       Handle(Poly_Triangulation) facing = BRep_Tool::Triangulation(F, L);
-      TColgp_Array1OfPnt tab(1, (facing->NbNodes()));
-      tab = facing->Nodes();
-      Poly_Array1OfTriangle tri(1, facing->NbTriangles());
-      tri = facing->Triangles();
       for (Standard_Integer i = 1; i <= (facing->NbTriangles()); i++) {
-        Poly_Triangle trian = tri.Value(i);
+        Poly_Triangle trian = getTriangle(facing, i);
         Standard_Integer index1, index2, index3;
         trian.Get(index1, index2, index3);
         m_faces[index * 3 + 0] = static_cast<uint32_t>(maxindex + index1 - 1);


### PR DESCRIPTION
**Description of work.**
As of this commit https://github.com/Open-Cascade-SAS/OCCT/commit/a8b605eb5e7f181c7bed7c7ef89108c4fd7ba054 access to the internal
array of pointers underlying the triangle nodes has been removed. Instead we need to ask for the number of nodes (which we already
do) then simply call a getter for that index. This simplifies code on our side too.

There's a place where we are manually doing the normal of the triangles. Whilst the framework has a method built in, I'm not
comfortable changing this. Long-term we're going to have to migrate from OpenGL anyway on OSX so....

**To test:**
- Update Conda env to use latest Mantid Developer OSX: `conda env update --file mantid-developer-osx.yml --prune`
- Ensure OCCT is 7.6.0 in conda env: `conda list occt`
- Build and check OpenGL rendering in Instrument View still works

Fixes #32927 

*This does not require release notes* because it's internal API breakage

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
