### PR TITLE
Scd340 fix convert qto hklmd histo results

### DIFF
--- a/Framework/PythonInterface/mantid/utils/absorptioncorrutils.py
+++ b/Framework/PythonInterface/mantid/utils/absorptioncorrutils.py
@@ -269,6 +269,7 @@ def calculate_absorption_correction(
     props,
     sample_formula,
     mass_density,
+    sample_geometry={},
     number_density=Property.EMPTY_DBL,
     container_shape="PAC06",
     num_wl_bins=1000,
@@ -307,6 +308,7 @@ def calculate_absorption_correction(
     :param props: PropertyManager of run characterizations, obtained from PDDetermineCharacterizations
     :param sample_formula: Sample formula to specify the Material for absorption correction
     :param mass_density: Mass density of the sample to specify the Material for absorption correction
+    :param sample_geometry: Dictionary to specify the sample geometry for absorption correction
     :param number_density: Optional number density of sample to be added to the Material for absorption correction
     :param container_shape: Shape definition of container, such as PAC06.
     :param num_wl_bins: Number of bins for calculating wavelength
@@ -336,6 +338,7 @@ def calculate_absorption_correction(
                                       props,
                                       num_wl_bins,
                                       material=material,
+                                      geometry=sample_geometry,
                                       environment=environment,
                                       metaws=metaws)
 

--- a/Framework/PythonInterface/plugins/algorithms/ConvertQtoHKLMDHisto.py
+++ b/Framework/PythonInterface/plugins/algorithms/ConvertQtoHKLMDHisto.py
@@ -136,6 +136,8 @@ class ConvertQtoHKLMDHisto(PythonAlgorithm):
                        OutputExtents=extents,
                        OutputBins=bins)
 
+        SetMDFrame(mdhist, MDFrame='HKL', Axes='0, 1, 2')
+
         self.setProperty("OutputWorkspace", mdhist)
         mdhist.clearOriginalWorkspaces()
         DeleteWorkspace(mdhist)

--- a/Framework/PythonInterface/plugins/algorithms/ConvertQtoHKLMDHisto.py
+++ b/Framework/PythonInterface/plugins/algorithms/ConvertQtoHKLMDHisto.py
@@ -7,7 +7,7 @@
 from mantid.api import AlgorithmFactory, IMDEventWorkspaceProperty, IMDHistoWorkspaceProperty, IPeaksWorkspaceProperty,\
     PythonAlgorithm, PropertyMode
 from mantid.kernel import Direction, FloatArrayLengthValidator, FloatArrayProperty, IntArrayProperty
-from mantid.simpleapi import BinMD, DeleteWorkspace, SetMDFrame, mtd
+from mantid.simpleapi import BinMD, CloneMDWorkspace, DeleteWorkspace, SetMDFrame, mtd
 import numpy as np
 
 
@@ -127,16 +127,16 @@ class ConvertQtoHKLMDHisto(PythonAlgorithm):
 
         units = ['in {:.3f} A^-1'.format(q[i].norm()) for i in range(3)]
 
-        SetMDFrame(input_ws, MDFrame='HKL', Axes='0,1,2')
+        output_name = self.getPropertyValue("OutputWorkspace")
+        CloneMDWorkspace(InputWorkspace=input_ws, OutputWorkspace=output_name)
+        SetMDFrame(InputWorkspace=output_name, MDFrame='HKL', Axes='0,1,2')
 
-        mdhist = BinMD(InputWorkspace=input_ws, AxisAligned=False, NormalizeBasisVectors=False,
+        mdhist = BinMD(InputWorkspace=output_name, AxisAligned=False, NormalizeBasisVectors=False,
                        BasisVector0='{},{},{},{},{}'.format(names[0], units[0], q[0].X(), q[0].Y(), q[0].Z()),
                        BasisVector1='{},{},{},{},{}'.format(names[1], units[1], q[1].X(), q[1].Y(), q[1].Z()),
                        BasisVector2='{},{},{},{},{}'.format(names[2], units[2], q[2].X(), q[2].Y(), q[2].Z()),
                        OutputExtents=extents,
                        OutputBins=bins)
-
-        SetMDFrame(mdhist, MDFrame='HKL', Axes='0, 1, 2')
 
         self.setProperty("OutputWorkspace", mdhist)
         mdhist.clearOriginalWorkspaces()

--- a/Framework/PythonInterface/plugins/algorithms/ConvertQtoHKLMDHisto.py
+++ b/Framework/PythonInterface/plugins/algorithms/ConvertQtoHKLMDHisto.py
@@ -123,9 +123,11 @@ class ConvertQtoHKLMDHisto(PythonAlgorithm):
         names = ['[' + ','.join(char_dict.get(j, '{0}{1}')
                                 .format(j, chars[np.argmax(np.abs(w[:, i]))]) for j in w[:, i]) + ']' for i in range(3)]
 
-        q = [self._lattice.qFromHKL(w[i]) for i in range(3)]
+        q = [self._lattice.qFromHKL(w[:,i]) for i in range(3)]
 
         units = ['in {:.3f} A^-1'.format(q[i].norm()) for i in range(3)]
+
+        SetMDFrame(input_ws, MDFrame='HKL', Axes='0,1,2')
 
         mdhist = BinMD(InputWorkspace=input_ws, AxisAligned=False, NormalizeBasisVectors=False,
                        BasisVector0='{},{},{},{},{}'.format(names[0], units[0], q[0].X(), q[0].Y(), q[0].Z()),
@@ -133,8 +135,6 @@ class ConvertQtoHKLMDHisto(PythonAlgorithm):
                        BasisVector2='{},{},{},{},{}'.format(names[2], units[2], q[2].X(), q[2].Y(), q[2].Z()),
                        OutputExtents=extents,
                        OutputBins=bins)
-
-        SetMDFrame(mdhist, MDFrame='HKL', Axes='0, 1, 2')
 
         self.setProperty("OutputWorkspace", mdhist)
         mdhist.clearOriginalWorkspaces()

--- a/Framework/PythonInterface/plugins/algorithms/ConvertWANDSCDtoQ.py
+++ b/Framework/PythonInterface/plugins/algorithms/ConvertWANDSCDtoQ.py
@@ -227,6 +227,7 @@ class ConvertWANDSCDtoQ(PythonAlgorithm):
             chars=['H','K','L']
             names = ['['+','.join(char_dict.get(j, '{0}{1}')
                                   .format(j,chars[np.argmax(np.abs(W[:,i]))]) for j in W[:,i])+']' for i in range(3)]
+            # Slicing because we want the column vector and not the row vector
             units = 'in {:.3f} A^-1,in {:.3f} A^-1,in {:.3f} A^-1'.format(ol.qFromHKL(W[:,0]).norm(),
                                                                           ol.qFromHKL(W[:,1]).norm(),
                                                                           ol.qFromHKL(W[:,2]).norm())

--- a/Framework/PythonInterface/plugins/algorithms/ConvertWANDSCDtoQ.py
+++ b/Framework/PythonInterface/plugins/algorithms/ConvertWANDSCDtoQ.py
@@ -227,9 +227,9 @@ class ConvertWANDSCDtoQ(PythonAlgorithm):
             chars=['H','K','L']
             names = ['['+','.join(char_dict.get(j, '{0}{1}')
                                   .format(j,chars[np.argmax(np.abs(W[:,i]))]) for j in W[:,i])+']' for i in range(3)]
-            units = 'in {:.3f} A^-1,in {:.3f} A^-1,in {:.3f} A^-1'.format(ol.qFromHKL(W[0]).norm(),
-                                                                          ol.qFromHKL(W[1]).norm(),
-                                                                          ol.qFromHKL(W[2]).norm())
+            units = 'in {:.3f} A^-1,in {:.3f} A^-1,in {:.3f} A^-1'.format(ol.qFromHKL(W[:,0]).norm(),
+                                                                          ol.qFromHKL(W[:,1]).norm(),
+                                                                          ol.qFromHKL(W[:,2]).norm())
             frames = 'HKL,HKL,HKL'
             k = 1/self.getProperty("Wavelength").value # Not 2pi/wavelength to save dividing by 2pi later
         else:

--- a/Framework/PythonInterface/plugins/algorithms/SNSPowderReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/SNSPowderReduction.py
@@ -233,6 +233,7 @@ class SNSPowderReduction(DistributedDataProcessorAlgorithm):
                              StringListValidator(["None", "SampleOnly", "SampleAndContainer", "FullPaalmanPings"]),
                              doc="Specifies the Absorption Correction terms to calculate, if any.")
         self.declareProperty("SampleFormula", "", doc="Chemical formula of the sample")
+        self.declareProperty("SampleGeometry", {}, doc="A dictionary of geometry parameters for the sample.")
         self.declareProperty("MeasuredMassDensity", defaultValue=0.1,
                              validator=FloatBoundedValidator(lower=0., exclusive=True),
                              doc="Measured mass density of sample in g/cc")  # in g/cc, way to validate?
@@ -335,6 +336,7 @@ class SNSPowderReduction(DistributedDataProcessorAlgorithm):
         self._outTypes = self.getProperty("SaveAs").value.lower()
         self._absMethod = self.getProperty("TypeOfCorrection").value
         self._sampleFormula = self.getProperty("SampleFormula").value
+        self._sampleGeometry = self.getProperty("SampleGeometry").value
         self._massDensity = self.getProperty("MeasuredMassDensity").value
         self._numberDensity = self.getProperty("SampleNumberDensity").value
         self._containerShape = self.getProperty("ContainerShape").value
@@ -432,6 +434,7 @@ class SNSPowderReduction(DistributedDataProcessorAlgorithm):
             self._info,  # PropertyManager of run characterizations
             self._sampleFormula,  # Material for absorption correction
             self._massDensity,  # Mass density of the sample
+            self._sampleGeometry, # Geometry parameters for the sample
             self._numberDensity,  # Optional number density of sample to be added
             self._containerShape,  # Shape definition of container
             self._num_wl_bins,  # Number of bins: len(ws.readX(0))-1

--- a/Framework/PythonInterface/plugins/algorithms/SetSampleFromLogs.py
+++ b/Framework/PythonInterface/plugins/algorithms/SetSampleFromLogs.py
@@ -173,6 +173,10 @@ class SetSampleFromLogs(DistributedDataProcessorAlgorithm):
                   ContainerGeometry=geometryContainer,
                   ContainerMaterial=materialContainer)
 
+        # validate that sample shape was set to something with volume!=0
+        if (wksp.sample().getShape().volume() == 0):
+            raise RuntimeError("Resulting sample shape has volume of 0")
+
 
 # Register algorithm with Mantid.
 AlgorithmFactory.subscribe(SetSampleFromLogs)

--- a/Framework/PythonInterface/test/python/plugins/algorithms/ConvertQtoHKLMDHistoTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/ConvertQtoHKLMDHistoTest.py
@@ -23,7 +23,7 @@ class ConvertQtoHKLMDHistoTest(unittest.TestCase):
         self.assertEqual(hkl.getSpecialCoordinateSystem().name, "HKL")
 
         # Test with getting UB from peaks
-        HB3AFindPeaks(InputWorkspace=mtd["mde_ws"],
+        HB3AFindPeaks(InputWorkspace="mde_ws",
                       CellType="Tetragonal",
                       Centering="I",
                       PeakDistanceThreshold=0.25,

--- a/Framework/PythonInterface/test/python/plugins/algorithms/SetSampleFromLogsTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/SetSampleFromLogsTest.py
@@ -5,7 +5,7 @@
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
 import unittest
-from mantid.simpleapi import (Load, LoadNexusProcessed, SetSampleFromLogs)
+from mantid.simpleapi import (Load, LoadNexusProcessed, SetSampleFromLogs, AddSampleLog)
 from math import pi
 
 PAC06_RADIUS = 0.00295
@@ -65,6 +65,23 @@ class SetSampleFromLogsTest(unittest.TestCase):
 
         # verify the results
         self.validateSample(wksp.sample(), "Si", PAC06_HEIGHT)
+
+        del wksp  # remove from the ADS
+
+    def testVolumeZero_raises(self):
+        wksp = self.loadPG3Data("testVolumeZero")
+        # Set height to 0, should fail
+        AddSampleLog(wksp,
+                     LogName='BL11A:CS:ITEMS:HeightInContainer',
+                     LogText='0.', LogType='Number Series', NumberType='Double')
+
+        material = {}
+        environment = {"Name": "InAir"}
+        geometry = {}
+
+        with self.assertRaises(RuntimeError):
+            SetSampleFromLogs(InputWorkspace=wksp, Environment=environment,
+                              Material=material, Geometry=geometry)
 
         del wksp  # remove from the ADS
 

--- a/Testing/SystemTests/tests/framework/ConvertQtoHKLMDHistoTest.py
+++ b/Testing/SystemTests/tests/framework/ConvertQtoHKLMDHistoTest.py
@@ -1,0 +1,136 @@
+from mantid.simpleapi import (
+    LoadMD,
+    CreatePeaksWorkspace,
+    CreateSingleValuedWorkspace,
+    LoadIsawUB,
+    SetUB,
+    ConvertWANDSCDtoQ,
+    ConvertHFIRSCDtoMDE,
+    ConvertQtoHKLMDHisto,
+    mtd,
+)
+import systemtesting
+import numpy as np
+
+from mantid import config
+
+
+class ConvertQtoHKLMDHistoTest_match_ConvertWANDSCDtoQ_test(
+    systemtesting.MantidSystemTest
+):
+    def requiredMemoryMB(self):
+        return 8000
+
+    def runTest(self):
+        config["Q.convention"] = "Inelastic"
+
+        # wavelength (angstrom) -----
+        wavelength = 1.486
+
+        # minimum and maximum values for Q sample -----
+        min_values = [-7.5, -0.65, -4.4]
+        max_values = [6.8, 0.65, 7.5]
+
+        # ---
+
+        data = LoadMD(
+            Filename="/HFIR/HB2C/shared/WANDscripts/test_data/data.nxs"
+        )
+
+        peaks = CreatePeaksWorkspace(
+            NumberOfPeaks=0,
+            OutputType="LeanElasticPeak"
+        )
+
+        ws = CreateSingleValuedWorkspace()
+        LoadIsawUB(
+            InputWorkspace=ws,
+            Filename="/HFIR/HB2C/shared/WANDscripts/test_data/data.mat",
+        )
+        UB = ws.sample().getOrientedLattice().getUB()
+
+        SetUB(peaks, UB=UB)
+
+        Q = ConvertWANDSCDtoQ(
+            InputWorkspace="data",
+            UBWorkspace="peaks",
+            Wavelength=wavelength,
+            Frame="HKL",
+            Uproj="1,1,0",
+            Vproj="-1,1,0",
+            BinningDim0="-6.02,6.02,301",
+            BinningDim1="-6.02,6.02,301",
+            BinningDim2="-6.02,6.02,301",
+        )
+
+        data_norm = ConvertHFIRSCDtoMDE(
+            data,
+            Wavelength=wavelength,
+            MinValues="{},{},{}".format(*min_values),
+            MaxValues="{},{},{}".format(*max_values),
+        )
+
+        HKL = ConvertQtoHKLMDHisto(
+            data_norm,
+            PeaksWorkspace="peaks",
+            Uproj="1,1,0",
+            Vproj="-1,1,0",
+            Extents="-6.02,6.02,-6.02,6.02,-6.02,6.02",
+            Bins="301,301,301",
+        )
+
+        for i in range(HKL.getNumDims()):
+            print(HKL.getDimension(i).getUnits(), Q.getDimension(i).getUnits())
+            np.testing.assert_equal(
+                HKL.getDimension(i).getUnits(), Q.getDimension(i).getUnits()
+            )
+
+        hkl_data = mtd["HKL"].getSignalArray()
+        Q_data = mtd["Q"].getSignalArray()
+
+        print(np.isnan(Q_data).sum())
+        print(np.isclose(hkl_data, 0).sum())
+
+        xaxis = mtd["HKL"].getXDimension()
+        yaxis = mtd["HKL"].getYDimension()
+        zaxis = mtd["HKL"].getZDimension()
+
+        x, y, z = np.meshgrid(
+            np.linspace(xaxis.getMinimum(),
+                        xaxis.getMaximum(),
+                        xaxis.getNBins()),
+            np.linspace(yaxis.getMinimum(),
+                        yaxis.getMaximum(),
+                        yaxis.getNBins()),
+            np.linspace(zaxis.getMinimum(),
+                        zaxis.getMaximum(),
+                        zaxis.getNBins()),
+            indexing="ij",
+            copy=False,
+        )
+
+        print(
+            x[~np.isnan(Q_data)].mean(),
+            y[~np.isnan(Q_data)].mean(),
+            z[~np.isnan(Q_data)].mean(),
+        )
+        print(
+            x[~np.isclose(hkl_data, 0)].mean(),
+            y[~np.isclose(hkl_data, 0)].mean(),
+            z[~np.isclose(hkl_data, 0)].mean(),
+        )
+        np.testing.assert_almost_equal(
+            x[~np.isnan(Q_data)].mean(),
+            x[~np.isclose(hkl_data, 0)].mean(),
+            decimal=2
+        )
+        np.testing.assert_almost_equal(
+            y[~np.isnan(Q_data)].mean(),
+            y[~np.isclose(hkl_data, 0)].mean(),
+            decimal=2
+        )
+        np.testing.assert_almost_equal(
+            z[~np.isnan(Q_data)].mean(),
+            z[~np.isclose(hkl_data, 0)].mean(),
+            decimal=2
+        )

--- a/Testing/SystemTests/tests/framework/SNSPowderRedux.py
+++ b/Testing/SystemTests/tests/framework/SNSPowderRedux.py
@@ -463,6 +463,7 @@ class PG3InfoFromLogs(systemtesting.MantidSystemTest):
                            CharacterizationRunsFile=charfile,
                            Binning=-0.001,
                            SaveAs="nexus",
+                           NumWavelengthBins=1,
                            OutputDirectory=savedir)
 
         assert not mtd['PG3_46577'].sample().getMaterial().name().strip()
@@ -475,6 +476,7 @@ class PG3InfoFromLogs(systemtesting.MantidSystemTest):
                            SaveAs="nexus",
                            TypeOfCorrection="FullPaalmanPings",
                            SampleFormula="Si",
+                           NumWavelengthBins=1,
                            MeasuredMassDensity=1.165,
                            ContainerShape="",
                            OutputFilePrefix='PP_absorption_',
@@ -487,3 +489,26 @@ class PG3InfoFromLogs(systemtesting.MantidSystemTest):
 
         # Check volume using height value from log - pi*(r^2)*h, r and h in meters
         assert mtd['PG3_46577'].sample().getShape().volume() == np.pi * np.square(.00295) * .040
+
+        # Try manually setting sample geometry, height to 2cm
+        SNSPowderReduction("PG3_46577.nxs.h5",
+                           CalibrationFile=self.cal_file,
+                           CharacterizationRunsFile=charfile,
+                           Binning=-0.001,
+                           SaveAs="nexus",
+                           TypeOfCorrection="FullPaalmanPings",
+                           NumWavelengthBins=1,
+                           SampleFormula="Si",
+                           SampleGeometry={'Height': 2.0},
+                           MeasuredMassDensity=1.165,
+                           ContainerShape="",
+                           OutputFilePrefix='PP_absorption_',
+                           OutputDirectory=savedir)
+
+        # Check name, number density, effective density
+        assert mtd['PG3_46577'].sample().getMaterial().name() == 'Si'
+        assert mtd['PG3_46577'].sample().getMaterial().numberDensity == SI_NUMBER_DENSITY
+        assert mtd['PG3_46577'].sample().getMaterial().numberDensityEffective == SI_NUMBER_DENSITY_EFFECTIVE
+
+        # Check volume using height value from log - pi*(r^2)*h, r and h in meters
+        assert mtd['PG3_46577'].sample().getShape().volume() == np.pi * np.square(.00295) * .020

--- a/docs/source/release/v6.3.0/diffraction.rst
+++ b/docs/source/release/v6.3.0/diffraction.rst
@@ -37,4 +37,8 @@ Single Crystal Diffraction
 - Existing :ref:`PolDiffILLReduction <algm-PolDiffILLReduction>` and :ref:`D7AbsoluteCrossSections <algm-D7AbsoluteCrossSections>` can now reduce and properly normalise single-crystal data for the D7 ILL instrument.
 - Enabling :ref:`SCDCalibratePanels <algm-SCDCalibratePanels-v2>` to calibrate each detector bank's size if it is a rectagular detector optionally.
 
+Bugfixes
+########
+- :ref:`ConvertWANDSCDtoQ<algm-ConvertWANDSCDtoQ>` and :ref:`ConvertQtoHKLMDHisto<algm-ConvertQtoHKLMDHisto>` units now display correctly in terms of 'in X.XXX A^-1'
+- :ref:`ConvertQtoHKLMDHisto<algm-ConvertQtoHKLMDHisto>` output orientation fixed
 :ref:`Release 6.3.0 <v6.3.0>`

--- a/docs/source/release/v6.3.0/diffraction.rst
+++ b/docs/source/release/v6.3.0/diffraction.rst
@@ -16,6 +16,7 @@ Powder Diffraction
 - `CalibrateRectangularDetectors`, which is deprecate since v6.2.0, is removed. And system test CalibrateRectangularDetectors_Test is removed.
 - Extending :ref:`MultipleScatteringCorrection <algm-MultipleScatteringCorrection>` to the sample and container case.
 - `absorptioncorrutils` now have the capability to calculate effective absorption correction (considering both absorption and multiple scattering).
+- :ref:`SNSPowderReduction <algm-SNSPowderReduction>` now has an option to manually specify sample geometry for absorption correction.
 - Both :ref:`MultipleScatteringCorrection <algm-MultipleScatteringCorrection>` and :ref:`PaalmanPingsAbsorptionCorrection <algm-PaalmanPingsAbsorptionCorrection>` can use a different element size for container now.
 
 Improvements

--- a/docs/source/release/v6.3.0/framework.rst
+++ b/docs/source/release/v6.3.0/framework.rst
@@ -23,6 +23,7 @@ Improvements
 - :ref:`GenerateLogbook <algm-GenerateLogbook>` now allows to perform binary operations even when certain entries do not exist, e.g. to create a string with all polarisation orientations contained in a collection of data files
 - Event nexuses produced at ILL can now be loaded using :ref:`LoadEventNexus <algm-LoadEventNexus>`.
 - :ref:`Rebin <algm-Rebin>` now has an option for binning with reverse logarithmic and inverse power bins.
+- :ref:`SetSampleFromLogs <algm-SetSampleFromLogs>` will now fail if the resulting sample shape has a volume of 0.
 - :ref:`SetSample <algm-SetSample>` can now load sample environment XML files from any directory using ``SetSample(ws, Environment={'Name': 'NameOfXMLFile', 'Path':'/path/to/file/'})``.
 
 Data Objects


### PR DESCRIPTION
**Description of work.**
PR addresses ConvertQtoHKLMDHisto returning incorrect units and orientation, and ConvertWANDSCDtoQ also having incorrect units.

**NOTE:** *I am not sure where these fit peaks changes came from, I rebased this branch off ornl-next.  Perhaps a desync?*

- [x] pr against `ornl-next` #32935

Companion to PR ornl-next [![GitHub issue/pull request detail](https://img.shields.io/github/issues/detail/state/mantidproject/mantid/32935)](https://github.com/mantidproject/mantid/pull/32935) 

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**

<!-- test instructions -->

run this script in the Mantid workbench, view Q and HKL in the slice viewer.  Confirm the units are in terms of 'in X.XXX A^-1' and that their orientations match. (Adjustment of the slider at the top of the slice viewer window may be necessary to see the shape on the graph)

```

# import mantid algorithms, numpy and matplotlib
from mantid.simpleapi import *
import matplotlib.pyplot as plt
import numpy as np

from mantid import config
config['Q.convention'] = "Inelastic"

# wavelength (angstrom) --------------------------------------------------------
wavelength = 1.486 

# minimum and maximum values for Q sample --------------------------------------
min_values = [-7.5,-0.65,-4.4]
max_values = [6.8,0.65,7.5]

# ---

data = LoadMD(Filename='/HFIR/HB2C/shared/WANDscripts/test_data/data.nxs')

peaks = CreatePeaksWorkspace(NumberOfPeaks=0, OutputType='LeanElasticPeak')

ws = CreateSingleValuedWorkspace()
LoadIsawUB(InputWorkspace=ws, Filename='/HFIR/HB2C/shared/WANDscripts/test_data/data.mat')
UB = ws.sample().getOrientedLattice().getUB() 

SetUB('peaks', UB=UB)

Q = ConvertWANDSCDtoQ(InputWorkspace='data',
                      UBWorkspace='peaks',
                      Wavelength=wavelength,
                      Frame='HKL',
                      Uproj='1,1,0',
                      Vproj='-1,1,0',
                      BinningDim0='-6.02,6.02,301',
                      BinningDim1='-6.02,6.02,301',
                      BinningDim2='-6.02,6.02,301')

data_norm = ConvertHFIRSCDtoMDE(data, 
                                Wavelength=wavelength, 
                                MinValues='{},{},{}'.format(*min_values),
                                MaxValues='{},{},{}'.format(*max_values))
                                
HKL = ConvertQtoHKLMDHisto(data_norm,  
                           PeaksWorkspace='peaks',
                           Uproj='1,1,0',
                           Vproj='-1,1,0',
                           Extents='-6.02,6.02,-6.02,6.02,-6.02,6.02',
                           Bins='301,301,301')


```
#### Release Notes
Diffraction Release Notes v6.3.0

Bugfixes
########
- `ConvertWANDSCDtoQ` and `ConvertQtoHKLMDHisto` units now display correctly in terms of 'in X.XXX A^-1'
- `ConvertQtoHKLMDHisto` output orientation fixed


#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.