### PR TITLE
Fix problems when running system tests in single thread

### DIFF
--- a/Testing/SystemTests/lib/systemtests/systemtesting.py
+++ b/Testing/SystemTests/lib/systemtests/systemtesting.py
@@ -690,7 +690,6 @@ class TestRunner(object):
         exec_locals = dict()
         exitcode = None
         dual_stdout = DualStdOut()
-        line_number = None
         try:
             write_to_dual_stdout = redirect_stdout(dual_stdout)
             with write_to_dual_stdout:
@@ -702,17 +701,13 @@ class TestRunner(object):
             error_class = e.__class__.__name__
             detail = e.args[0]
             line_number = e.lineno
-        except Exception as ex:
-            import traceback
-            error_class = ex.__class__.__name__
-            detail = ex.args[0]
-            cl, exc, tb = sys.exc_info()
-            line_number = traceback.extract_tb(tb)[-1][1]
-        except SystemExit as ex: # catch sys.exit
-            exitcode=ex.args[0]
-        if line_number:
             print(f"{error_class} at line {line_number} of SystemTest for {script._modname}.{script._test_cls_name}: "
                   f"{detail}")
+        except Exception as ex:
+            import traceback
+            traceback.print_exc()
+        except SystemExit as ex: # catch sys.exit
+            exitcode=ex.args[0]
         if exitcode is None:
             if "exitcode" in exec_locals:
                 exitcode = exec_locals['exitcode']


### PR DESCRIPTION
**Description of work.**

A previous change to allow the system tests to be run in a single thread to assist debugging (https://github.com/mantidproject/mantid/pull/31557) has a couple of glitches which I've fixed up here:

- if a test is skipped then the code calls sys.exit(). When the system tests were all run in multiple threads this caused the child thread to terminate and control was passed back to the parent. In single threaded mode this was causing the only thread to exit and it stopped the whole test sequence (the try catch around the call to the system test only handled Exception and sys.exit raises a BaseException). I noticed this when running ISIS_PowderPEARLTest which has a class with skipTests=True. This would also impact any tests that were skipped based on insufficient memory or missing files.

- The code to print out the names of failed tests at the end wasn't working if the TextResultReporter is used (single threaded mode) instead of XmlResultReporter (which is used when the system tests are run in multithreaded mode). The code relies on a simple success\failed status whereas TextResultReporter was giving more fine grained failure reasons eg "failed validation"

**To test:**

- Edit one of the system tests in ISIS_PowderPEARLTest so that it will fail by inserting `self.assertTrue(False)` in the validate method
- Run the ISIS_PowderPEARLTest system test and observe that the name of the failing test is written out at the end

*There is no associated issue.*

*This does not require release notes* because **it only affects the system tests so not of interest to end users**


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
