### PR TITLE
fixed muon autoscale bug

### DIFF
--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/plot_widget/plotting_canvas/plotting_canvas_utils.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/plot_widget/plotting_canvas/plotting_canvas_utils.py
@@ -20,7 +20,6 @@ def get_y_min_max_between_x_range(line, x_min, x_max, y_min, y_max):
     crop = y[start:end]
     if start==end:
         return y_min, y_max
-    print("moo", crop, start, end, y, x_min, x_max,x)
     current_min = np.min(crop)
     current_max = np.max(crop)
     y_min = current_min if current_min < y_min else y_min

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/plot_widget/plotting_canvas/plotting_canvas_utils.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/plot_widget/plotting_canvas/plotting_canvas_utils.py
@@ -18,7 +18,9 @@ def get_y_min_max_between_x_range(line, x_min, x_max, y_min, y_max):
     start = np.searchsorted(x, x_min)
     end = np.searchsorted(x, x_max)
     crop = y[start:end]
-
+    if start==end:
+        return y_min, y_max
+    print("moo", crop, start, end, y, x_min, x_max,x)
     current_min = np.min(crop)
     current_max = np.max(crop)
     y_min = current_min if current_min < y_min else y_min


### PR DESCRIPTION
**Description of work.**

A bug had slipped in to main that caused the muon GUI to crash. When changing the plots in the model analysis tab, there is a moment when the start and end x do not match the axis. This could cause a crash if the axis did not contain start or end x.

**To test:**

<!-- Instructions for testing. -->
Enable model analysis
Open muon analysis
Load MUSR 62260-5
Go tot he fitting tab
Click simultaneous 
Add a GausOsc
Make frequency and sigma global
Set frequency to 1
Go to the sequential tab
Fit all of the data
Go to the results tab
Select the sample_temp and sample_magn_field logs
Create the results table
Go to the model analysis tab
Change the x value to "f0.Phi" and this is where it used to crash. 



*There is no associated issue.*


This does not require release notes because it fixes a bug that we added a couple of days ago


<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
