### PR TITLE
Add default parameter selector to model fitting in muon analysis

### DIFF
--- a/docs/source/release/v6.3.0/muon.rst
+++ b/docs/source/release/v6.3.0/muon.rst
@@ -49,6 +49,7 @@ Bugfixes
 
 - On the model analysis tab, the fit range will now update when the x axis is changed.
 - Fixed a bug that prevented the model analysis plot showing when data was binned.
+- When a new results table is created the Model Analysis tab selects the default parameters to plot based on log values or parameters in the results table.
 
 ALC
 ---

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/fitting_widgets/model_fitting/model_fitting_data_selector_view.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/fitting_widgets/model_fitting/model_fitting_data_selector_view.py
@@ -6,6 +6,7 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 from mantidqt.utils.qt import load_ui
 from mantidqtinterfaces.Muon.GUI.Common.data_selectors.cyclic_data_selector_view import CyclicDataSelectorView
+from mantidqtinterfaces.Muon.GUI.Common.results_tab_widget.results_tab_model import TableColumnType
 
 from qtpy.QtWidgets import QWidget
 
@@ -103,7 +104,7 @@ class ModelFittingDataSelectorView(ui_form, base_widget):
     def _get_x_parameter_for_update(self, old_x_parameter: str, x_parameters: list, x_parameter_types: list) -> str:
         if self.y_selector.findText(old_x_parameter) != -1:
             return old_x_parameter
-        elif 1 in x_parameter_types:
+        elif TableColumnType.X.value in x_parameter_types:
             return x_parameters[x_parameter_types.index(1)]
         else:
             return ''
@@ -111,7 +112,7 @@ class ModelFittingDataSelectorView(ui_form, base_widget):
     def _get_y_parameter_for_update(self, old_y_parameter: str, y_parameters: list, y_parameter_types: list) -> str:
         if self.x_selector.findText(old_y_parameter) != -1:
             return old_y_parameter
-        elif 2 in y_parameter_types:
+        elif TableColumnType.Y.value in y_parameter_types:
             return y_parameters[y_parameter_types.index(2)]
         else:
             return ''

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/fitting_widgets/model_fitting/model_fitting_data_selector_view.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/fitting_widgets/model_fitting/model_fitting_data_selector_view.py
@@ -52,7 +52,7 @@ class ModelFittingDataSelectorView(ui_form, base_widget):
         """Update the data in the parameter display combo box."""
         self.result_table_selector.update_dataset_name_combo_box(table_names)
 
-    def update_x_parameters(self, x_parameters: list, emit_signal: bool = False) -> None:
+    def update_x_parameters(self, x_parameters: list, x_parameter_types: list, emit_signal: bool = False) -> None:
         """Update the available X parameters."""
         old_x_parameter = self.x_selector.currentText()
 
@@ -61,13 +61,14 @@ class ModelFittingDataSelectorView(ui_form, base_widget):
         self.x_selector.addItems(x_parameters)
         self.x_selector.blockSignals(False)
 
-        new_index = self.set_selected_x_parameter(old_x_parameter)
+        new_x_parameter = self._get_x_parameter_for_update(old_x_parameter, x_parameters, x_parameter_types)
+        new_index = self.set_selected_x_parameter(new_x_parameter)
 
         if emit_signal:
             # Signal is emitted manually in case the index has not changed (but the loaded parameter may be different)
             self.x_selector.currentIndexChanged.emit(new_index)
 
-    def update_y_parameters(self, y_parameters: list, emit_signal: bool = False) -> None:
+    def update_y_parameters(self, y_parameters: list, y_parameter_types: list, emit_signal: bool = False) -> None:
         """Update the available Y parameters."""
         old_y_parameter = self.y_selector.currentText()
 
@@ -76,7 +77,8 @@ class ModelFittingDataSelectorView(ui_form, base_widget):
         self.y_selector.addItems(y_parameters)
         self.y_selector.blockSignals(False)
 
-        new_index = self.set_selected_y_parameter(old_y_parameter)
+        new_y_parameter = self._get_y_parameter_for_update(old_y_parameter, y_parameters, y_parameter_types)
+        new_index = self.set_selected_y_parameter(new_y_parameter)
 
         if emit_signal:
             # Signal is emitted manually in case the index has not changed (but the loaded parameter may be different)
@@ -97,6 +99,22 @@ class ModelFittingDataSelectorView(ui_form, base_widget):
         self.y_selector.setCurrentIndex(new_index if new_index != -1 else 0)
         self.y_selector.blockSignals(False)
         return new_index
+
+    def _get_x_parameter_for_update(self, old_x_parameter: str, x_parameters: list, x_parameter_types: list) -> str:
+        if self.y_selector.findText(old_x_parameter) != -1:
+            return old_x_parameter
+        elif 1 in x_parameter_types:
+            return x_parameters[x_parameter_types.index(1)]
+        else:
+            return ''
+
+    def _get_y_parameter_for_update(self, old_y_parameter: str, y_parameters: list, y_parameter_types: list) -> str:
+        if self.x_selector.findText(old_y_parameter) != -1:
+            return old_y_parameter
+        elif 2 in y_parameter_types:
+            return y_parameters[y_parameter_types.index(2)]
+        else:
+            return ''
 
     def number_of_result_tables(self) -> int:
         """Returns the number of result tables loaded into the widget."""

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/fitting_widgets/model_fitting/model_fitting_presenter.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/fitting_widgets/model_fitting/model_fitting_presenter.py
@@ -87,9 +87,9 @@ class ModelFittingPresenter(BasicFittingPresenter):
         self.view.update_dataset_name_combo_box(self.model.dataset_names, emit_signal=False)
 
         # Initially, the y parameters should be updated before the x parameters.
-        self.view.update_y_parameters(self.model.y_parameters())
+        self.view.update_y_parameters(self.model.y_parameters(), self.model.y_parameter_types())
         # Triggers handle_selected_x_changed
-        self.view.update_x_parameters(self.model.x_parameters(), emit_signal=True)
+        self.view.update_x_parameters(self.model.x_parameters(), self.model.y_parameter_types(), emit_signal=True)
 
     def handle_parameter_combinations_error(self, error: str) -> None:
         """Handle when an error occurs while creating workspaces for the different parameter combinations."""

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/fitting_widgets/model_fitting/model_fitting_view.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/fitting_widgets/model_fitting/model_fitting_view.py
@@ -50,13 +50,13 @@ class ModelFittingView(BasicFittingView):
         """Update the data in the results table combo box."""
         self.model_fitting_data_selector.update_result_table_names(table_names)
 
-    def update_x_parameters(self, x_parameters: list, emit_signal: bool = False) -> None:
+    def update_x_parameters(self, x_parameters: list, x_parameter_types: list, emit_signal: bool = False) -> None:
         """Update the available X parameters."""
-        self.model_fitting_data_selector.update_x_parameters(x_parameters, emit_signal)
+        self.model_fitting_data_selector.update_x_parameters(x_parameters, x_parameter_types, emit_signal)
 
-    def update_y_parameters(self, y_parameters: list, emit_signal: bool = False) -> None:
+    def update_y_parameters(self, y_parameters: list, y_parameter_types: list, emit_signal: bool = False) -> None:
         """Update the available Y parameters."""
-        self.model_fitting_data_selector.update_y_parameters(y_parameters, emit_signal)
+        self.model_fitting_data_selector.update_y_parameters(y_parameters, y_parameter_types, emit_signal)
 
     def update_fit_function(self, fit_function: IFunction) -> None:
         """Updates the fit function shown in the view."""

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/test_helpers/fitting_mock_setup.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/test_helpers/fitting_mock_setup.py
@@ -122,7 +122,8 @@ def add_mock_methods_to_model_fitting_view(view):
 
 def add_mock_methods_to_model_fitting_model(model, dataset_names, current_dataset_index, fit_function, start_x, end_x,
                                             fit_status, chi_squared, param_combination_name, param_group_name,
-                                            results_table_names, x_parameters, y_parameters):
+                                            results_table_names, x_parameters, y_parameters, x_parameter_types,
+                                            y_parameter_types):
     model = add_mock_methods_to_basic_fitting_model(model, dataset_names, current_dataset_index, fit_function, start_x,
                                                     end_x, fit_status, chi_squared)
 
@@ -134,6 +135,8 @@ def add_mock_methods_to_model_fitting_model(model, dataset_names, current_datase
     model.get_first_y_parameter_not = mock.Mock(return_value="A1")
     model.x_parameters = mock.Mock(return_value=x_parameters)
     model.y_parameters = mock.Mock(return_value=y_parameters)
+    model.x_parameter_types = mock.Mock(return_value=x_parameter_types)
+    model.y_parameter_types = mock.Mock(return_value=y_parameter_types)
 
     return model
 

--- a/qt/python/mantidqtinterfaces/test/Muon/fitting_widgets/model_fitting/model_fitting_data_selector_view_test.py
+++ b/qt/python/mantidqtinterfaces/test/Muon/fitting_widgets/model_fitting/model_fitting_data_selector_view_test.py
@@ -10,6 +10,7 @@ from mantidqt.utils.qt.testing import start_qapplication
 from mantidqt.utils.qt.testing.qt_widget_finder import QtWidgetFinder
 
 from mantidqtinterfaces.Muon.GUI.Common.fitting_widgets.model_fitting.model_fitting_data_selector_view import ModelFittingDataSelectorView
+from mantidqtinterfaces.Muon.GUI.Common.results_tab_widget.results_tab_model import TableColumnType
 
 from qtpy.QtWidgets import QApplication
 
@@ -59,10 +60,12 @@ class ModelFittingDataSelectorViewTest(unittest.TestCase, QtWidgetFinder):
         self.assertEqual(self.view.current_result_table_index, 3)
 
     def test_that_update_x_and_y_parameters_will_update_the_x_and_y_parameters(self):
-        x_parameters = ["workspace_name", "A0", "A1"]
-        x_parameter_types = [0, 2, 2]
-        y_parameters = ["workspace_name", "A0", "A1", "Chi Squared"]
-        y_parameter_types = [0, 2, 2, 2]
+        x_parameters = ["workspace_name", "sample_temp", "A0", "A1"]
+        x_parameter_types = [TableColumnType.NoType.value, TableColumnType.X.value, TableColumnType.Y.value,
+                             TableColumnType.Y.value]
+        y_parameters = ["workspace_name", "sample_temp", "A0", "A1", "Chi Squared"]
+        y_parameter_types = [TableColumnType.NoType.value, TableColumnType.X.value, TableColumnType.Y.value,
+                             TableColumnType.Y.value, TableColumnType.Y.value]
 
         self.view.update_x_parameters(x_parameters, x_parameter_types)
         self.view.update_y_parameters(y_parameters, y_parameter_types)
@@ -71,7 +74,7 @@ class ModelFittingDataSelectorViewTest(unittest.TestCase, QtWidgetFinder):
         y_data = [self.view.y_selector.itemText(i) for i in range(self.view.y_selector.count())]
         self.assertEqual(x_data, x_parameters)
         self.assertEqual(y_data, y_parameters)
-        self.assertEqual(self.view.x_parameter, "workspace_name")
+        self.assertEqual(self.view.x_parameter, "sample_temp")
         self.assertEqual(self.view.y_parameter, "A0")
 
 

--- a/qt/python/mantidqtinterfaces/test/Muon/fitting_widgets/model_fitting/model_fitting_data_selector_view_test.py
+++ b/qt/python/mantidqtinterfaces/test/Muon/fitting_widgets/model_fitting/model_fitting_data_selector_view_test.py
@@ -60,16 +60,19 @@ class ModelFittingDataSelectorViewTest(unittest.TestCase, QtWidgetFinder):
 
     def test_that_update_x_and_y_parameters_will_update_the_x_and_y_parameters(self):
         x_parameters = ["workspace_name", "A0", "A1"]
+        x_parameter_types = [0, 2, 2]
         y_parameters = ["workspace_name", "A0", "A1", "Chi Squared"]
+        y_parameter_types = [0, 2, 2, 2]
 
-        self.view.update_x_parameters(x_parameters)
-        self.view.update_y_parameters(y_parameters)
+        self.view.update_x_parameters(x_parameters, x_parameter_types)
+        self.view.update_y_parameters(y_parameters, y_parameter_types)
 
         x_data = [self.view.x_selector.itemText(i) for i in range(self.view.x_selector.count())]
         y_data = [self.view.y_selector.itemText(i) for i in range(self.view.y_selector.count())]
-
-        self.assertTrue(x_data, x_parameters)
-        self.assertTrue(y_data, y_parameters)
+        self.assertEqual(x_data, x_parameters)
+        self.assertEqual(y_data, y_parameters)
+        self.assertEqual(self.view.x_parameter, "workspace_name")
+        self.assertEqual(self.view.y_parameter, "A0")
 
 
 if __name__ == '__main__':

--- a/qt/python/mantidqtinterfaces/test/Muon/fitting_widgets/model_fitting/model_fitting_model_test.py
+++ b/qt/python/mantidqtinterfaces/test/Muon/fitting_widgets/model_fitting/model_fitting_model_test.py
@@ -148,20 +148,20 @@ class ModelFittingModelTest(unittest.TestCase):
         self.assertEqual(list(x_parameters), ["workspace_name", "A0", "A1", "Sigma", "Lambda"])
         self.assertEqual(list(y_parameters), ["workspace_name", "A0", "A1", "Sigma", "Lambda"])
 
-        self.assertAlmostEqual(self.model.fitting_context.x_parameters["A0"][0], 0.1, delta=0.000001)
-        self.assertAlmostEqual(self.model.fitting_context.x_parameters["A0"][1], 0.3, delta=0.000001)
-        self.assertAlmostEqual(self.model.fitting_context.x_parameters["A0"][2], 0.5, delta=0.000001)
-        self.assertAlmostEqual(self.model.fitting_context.y_parameters["A1"][0], 0.2, delta=0.000001)
-        self.assertAlmostEqual(self.model.fitting_context.y_parameters["A1"][1], 0.4, delta=0.000001)
-        self.assertAlmostEqual(self.model.fitting_context.y_parameters["A1"][2], 0.6, delta=0.000001)
-        self.assertAlmostEqual(self.model.fitting_context.y_parameters["Sigma"][0], 0.3, delta=0.000001)
-        self.assertAlmostEqual(self.model.fitting_context.y_parameters["Sigma"][1], 0.5, delta=0.000001)
-        self.assertAlmostEqual(self.model.fitting_context.y_parameters["Sigma"][2], 0.7, delta=0.000001)
-        self.assertAlmostEqual(self.model.fitting_context.y_parameters["Lambda"][0], 0.4, delta=0.000001)
-        self.assertAlmostEqual(self.model.fitting_context.y_parameters["Lambda"][1], 0.6, delta=0.000001)
-        self.assertAlmostEqual(self.model.fitting_context.y_parameters["Lambda"][2], 0.8, delta=0.000001)
+        self.assertAlmostEqual(self.model.fitting_context.x_parameters["A0"][0][0], 0.1, delta=0.000001)
+        self.assertAlmostEqual(self.model.fitting_context.x_parameters["A0"][0][1], 0.3, delta=0.000001)
+        self.assertAlmostEqual(self.model.fitting_context.x_parameters["A0"][0][2], 0.5, delta=0.000001)
+        self.assertAlmostEqual(self.model.fitting_context.y_parameters["A1"][0][0], 0.2, delta=0.000001)
+        self.assertAlmostEqual(self.model.fitting_context.y_parameters["A1"][0][1], 0.4, delta=0.000001)
+        self.assertAlmostEqual(self.model.fitting_context.y_parameters["A1"][0][2], 0.6, delta=0.000001)
+        self.assertAlmostEqual(self.model.fitting_context.y_parameters["Sigma"][0][0], 0.3, delta=0.000001)
+        self.assertAlmostEqual(self.model.fitting_context.y_parameters["Sigma"][0][1], 0.5, delta=0.000001)
+        self.assertAlmostEqual(self.model.fitting_context.y_parameters["Sigma"][0][2], 0.7, delta=0.000001)
+        self.assertAlmostEqual(self.model.fitting_context.y_parameters["Lambda"][0][0], 0.4, delta=0.000001)
+        self.assertAlmostEqual(self.model.fitting_context.y_parameters["Lambda"][0][1], 0.6, delta=0.000001)
+        self.assertAlmostEqual(self.model.fitting_context.y_parameters["Lambda"][0][2], 0.8, delta=0.000001)
 
-        self.assertEqual(self.model.fitting_context.y_parameters["workspace_name"],
+        self.assertEqual(self.model.fitting_context.y_parameters["workspace_name"][0],
                          ["MUSR62260; Group; bottom; Asymmetry; MA", "MUSR62260; Group; top; Asymmetry; MA",
                           "MUSR62260; Group; fwd; Asymmetry; MA"])
 

--- a/qt/python/mantidqtinterfaces/test/Muon/fitting_widgets/model_fitting/model_fitting_presenter_test.py
+++ b/qt/python/mantidqtinterfaces/test/Muon/fitting_widgets/model_fitting/model_fitting_presenter_test.py
@@ -44,6 +44,8 @@ class ModelFittingPresenterTest(unittest.TestCase):
         self.result_table_names = ["Results1", "Results2"]
         self.x_parameters = ["A0", "A1"]
         self.y_parameters = ["A0", "A1"]
+        self.x_parameter_types = [2, 2]
+        self.y_parameter_types = [2, 2]
 
         self._setup_mock_view()
         self._setup_mock_model()
@@ -175,8 +177,8 @@ class ModelFittingPresenterTest(unittest.TestCase):
         self.mock_model_dataset_names.assert_has_calls([mock.call(), mock.call()])
         self.view.set_datasets_in_function_browser.assert_called_once_with(self.dataset_names)
         self.view.update_dataset_name_combo_box.assert_called_once_with(self.dataset_names, emit_signal=False)
-        self.view.update_y_parameters.assert_called_once_with(self.y_parameters)
-        self.view.update_x_parameters.assert_called_once_with(self.x_parameters, emit_signal=True)
+        self.view.update_y_parameters.assert_called_once_with(self.y_parameters, self.y_parameter_types)
+        self.view.update_x_parameters.assert_called_once_with(self.x_parameters, self.x_parameter_types, emit_signal=True)
 
     def test_that_handle_parameter_combinations_error_will_show_a_warning_in_the_view(self):
         error = "Error message"
@@ -271,7 +273,8 @@ class ModelFittingPresenterTest(unittest.TestCase):
                                                              self.fit_status, self.chi_squared,
                                                              self.param_combination_name, self.param_group_name,
                                                              self.result_table_names, self.x_parameters,
-                                                             self.y_parameters)
+                                                             self.y_parameters, self.x_parameter_types,
+                                                             self.y_parameter_types)
 
         # Mock the properties of the model
         self.mock_model_current_dataset_index = mock.PropertyMock(return_value=self.current_dataset_index)

--- a/qt/python/mantidqtinterfaces/test/Muon/fitting_widgets/model_fitting/model_fitting_presenter_test.py
+++ b/qt/python/mantidqtinterfaces/test/Muon/fitting_widgets/model_fitting/model_fitting_presenter_test.py
@@ -12,6 +12,7 @@ from mantid.api import FrameworkManager, FunctionFactory
 from mantidqtinterfaces.Muon.GUI.Common.fitting_widgets.model_fitting.model_fitting_model import ModelFittingModel
 from mantidqtinterfaces.Muon.GUI.Common.fitting_widgets.model_fitting.model_fitting_presenter import ModelFittingPresenter
 from mantidqtinterfaces.Muon.GUI.Common.fitting_widgets.model_fitting.model_fitting_view import ModelFittingView
+from mantidqtinterfaces.Muon.GUI.Common.results_tab_widget.results_tab_model import TableColumnType
 from mantidqtinterfaces.Muon.GUI.Common.test_helpers.fitting_mock_setup import (add_mock_methods_to_model_fitting_model,
                                                                                 add_mock_methods_to_model_fitting_presenter,
                                                                                 add_mock_methods_to_model_fitting_view)
@@ -44,8 +45,8 @@ class ModelFittingPresenterTest(unittest.TestCase):
         self.result_table_names = ["Results1", "Results2"]
         self.x_parameters = ["A0", "A1"]
         self.y_parameters = ["A0", "A1"]
-        self.x_parameter_types = [2, 2]
-        self.y_parameter_types = [2, 2]
+        self.x_parameter_types = [TableColumnType.Y.value, TableColumnType.Y.value]
+        self.y_parameter_types = [TableColumnType.Y.value, TableColumnType.Y.value]
 
         self._setup_mock_view()
         self._setup_mock_model()

--- a/qt/python/mantidqtinterfaces/test/Muon/fitting_widgets/model_fitting/model_fitting_view_test.py
+++ b/qt/python/mantidqtinterfaces/test/Muon/fitting_widgets/model_fitting/model_fitting_view_test.py
@@ -10,6 +10,7 @@ from mantidqt.utils.qt.testing import start_qapplication
 from mantidqt.utils.qt.testing.qt_widget_finder import QtWidgetFinder
 
 from mantidqtinterfaces.Muon.GUI.Common.fitting_widgets.model_fitting.model_fitting_view import ModelFittingView
+from mantidqtinterfaces.Muon.GUI.Common.results_tab_widget.results_tab_model import TableColumnType
 
 from qtpy.QtWidgets import QApplication
 
@@ -62,9 +63,9 @@ class ModelFittingViewTest(unittest.TestCase, QtWidgetFinder):
 
     def test_that_update_x_and_y_parameters_will_update_the_x_and_y_parameters(self):
         x_parameters = ["workspace_name", "A0", "A1"]
-        x_parameter_types = [0, 2, 2]
+        x_parameter_types = [TableColumnType.NoType.value, TableColumnType.Y.value, TableColumnType.Y.value]
         y_parameters = ["workspace_name", "A0", "A1", "Chi Squared"]
-        y_parameter_types = [0, 2, 2, 2]
+        y_parameter_types = [TableColumnType.NoType.value, TableColumnType.Y.value, TableColumnType.Y.value, TableColumnType.Y.value]
 
         self.view.update_x_parameters(x_parameters, x_parameter_types)
         self.view.update_y_parameters(y_parameters, y_parameter_types)

--- a/qt/python/mantidqtinterfaces/test/Muon/fitting_widgets/model_fitting/model_fitting_view_test.py
+++ b/qt/python/mantidqtinterfaces/test/Muon/fitting_widgets/model_fitting/model_fitting_view_test.py
@@ -62,10 +62,12 @@ class ModelFittingViewTest(unittest.TestCase, QtWidgetFinder):
 
     def test_that_update_x_and_y_parameters_will_update_the_x_and_y_parameters(self):
         x_parameters = ["workspace_name", "A0", "A1"]
+        x_parameter_types = [0, 2, 2]
         y_parameters = ["workspace_name", "A0", "A1", "Chi Squared"]
+        y_parameter_types = [0, 2, 2, 2]
 
-        self.view.update_x_parameters(x_parameters)
-        self.view.update_y_parameters(y_parameters)
+        self.view.update_x_parameters(x_parameters, x_parameter_types)
+        self.view.update_y_parameters(y_parameters, y_parameter_types)
 
         x_data = [self.view.model_fitting_data_selector.x_selector.itemText(i)
                   for i in range(self.view.model_fitting_data_selector.x_selector.count())]
@@ -75,7 +77,7 @@ class ModelFittingViewTest(unittest.TestCase, QtWidgetFinder):
         self.assertTrue(x_data, x_parameters)
         self.assertTrue(y_data, y_parameters)
         self.assertEqual(self.view.x_parameter(), "workspace_name")
-        self.assertEqual(self.view.y_parameter(), "workspace_name")
+        self.assertEqual(self.view.y_parameter(), "A0")
 
     def test_that_current_result_table_index_returns_the_expected_index(self):
         result_table_names = ["Name1", "Name2", "Name3"]


### PR DESCRIPTION
**Description of work.**

This PR adds methods to model fitting data selector so that it is able to by default plot log values or fit parameters.

**To test:**

1. Enable model analysis
1. Open muon analysis
1. Load MUSR 62260-5
1. Go to the fitting tab
1. Click simultaneous
1. Add any function
1. Go to the sequential tab
1. Fit all of the data
1. Go to the results tab
1. Select the sample_temp log
1. Create the results table
1. Go to the model analysis tab
1. The model analysis fit should be sample_temp on the x axis and the first parameter of the fit on the y axis.
1. return to the results tab and deselect sample_temp and select and sample_magn_field. Create the results table.
2. return to the model anaysis tab and now sample_magn_field should be on the x axis.

Fixes #32795

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
