### PR TITLE
Add test for handle_phase_table_changed

### DIFF
--- a/qt/python/mantidqtinterfaces/test/Muon/phase_table_widget/phase_table_presenter_test.py
+++ b/qt/python/mantidqtinterfaces/test/Muon/phase_table_widget/phase_table_presenter_test.py
@@ -369,6 +369,19 @@ class PhaseTablePresenterTest(unittest.TestCase):
         self.presenter.phasequad_calculation_complete_notifier.notify_subscribers.assert_any_call(phasequad.Im.name)
         self.assertEqual(self.presenter.phasequad_calculation_complete_notifier.notify_subscribers.call_count, 2)
 
+    def test_handle_phase_table_changed_to_new_table(self):
+        self.context.phase_context.options_dict['phase_table_for_phase_quad'] = 'MUSR22222_raw_data_period_1'
+        self.view.get_phase_table = mock.Mock(return_value='MUSR33333_raw_data_period_2')
+        self.context.group_pair_context.update_phase_tables = mock.Mock()
+        self.context.update_phasequads = mock.Mock()
+
+        self.presenter.handle_phase_table_changed()
+
+        self.assertEqual(self.context.phase_context.options_dict['phase_table_for_phase_quad'],
+                         'MUSR33333_raw_data_period_2')
+        self.context.group_pair_context.update_phase_tables.assert_called_once_with('MUSR33333_raw_data_period_2')
+        self.assertEqual(1, self.context.update_phasequads.call_count)
+
 
 if __name__ == '__main__':
     unittest.main(buffer=False, verbosity=2)


### PR DESCRIPTION

**Description of work.**
The handle_phase_table_changed method in the phase table presenter was not previously tested. This is a new unit test written for that method. It tests that the table is changed accordingly  (when a new table is chosen) and that specific methods are called in order to update the phase tables. The test will also fail if the method includes calls to any methods that don't exist (as happened with #32415 ). 

**To test:**
Check that the test passes.

Fixes #32423 

This does not require release notes because this is a unit test and has no impact on the user experience.


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
