### PR TITLE
Muon shade region

### DIFF
--- a/docs/source/release/v6.3.0/muon.rst
+++ b/docs/source/release/v6.3.0/muon.rst
@@ -37,6 +37,8 @@ Muon Analysis and Frequency Domain Analysis
 New Features
 ############
 
+- Instead of plotting the confidence interval of a fit as an error bar, it is now represented by a shaded region.
+
 Improvements
 ############
 

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/plot_widget/fit_pane/plot_fit_pane_model.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/plot_widget/fit_pane/plot_fit_pane_model.py
@@ -48,3 +48,11 @@ class PlotFitPaneModel(BasePaneModel):
 
     def _is_guess_workspace(self, workspace_name):
         return self.context.guess_workspace_prefix in workspace_name
+
+    @staticmethod
+    def get_shade_lines(ws, index):
+        x_data = ws.readX(index)
+        y_data = ws.readY(index)
+        e_data = ws.readE(index)
+
+        return x_data, y_data + e_data, y_data - e_data

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/plot_widget/fit_pane/plot_fit_pane_model.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/plot_widget/fit_pane/plot_fit_pane_model.py
@@ -5,6 +5,7 @@
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 from mantidqtinterfaces.Muon.GUI.Common.plot_widget.base_pane.base_pane_model import BasePaneModel
 from mantidqtinterfaces.Muon.GUI.Common.ADSHandler.workspace_naming import get_fit_function_name_from_workspace
+from copy import copy
 
 
 class PlotFitPaneModel(BasePaneModel):
@@ -51,8 +52,8 @@ class PlotFitPaneModel(BasePaneModel):
 
     @staticmethod
     def get_shade_lines(ws, index):
-        x_data = ws.readX(index)
+        # need to copy the x data because if switch from points to hist data it causes errors
+        x_data = copy(ws.readX(index))
         y_data = ws.readY(index)
         e_data = ws.readE(index)
-
         return x_data, y_data + e_data, y_data - e_data

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/plot_widget/fit_pane/plot_fit_pane_presenter.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/plot_widget/fit_pane/plot_fit_pane_presenter.py
@@ -48,7 +48,6 @@ class PlotFitPanePresenter(BasePanePresenter):
                 workspace_list += self.match_raw_selection(fit_information.input_workspaces,raw) + fit_workspaces
                 indices += [0] * len(fit_information.input_workspaces) + fit_indices
                 # dont shade the data but do shade the fit lines
-                print("wsadddfs", fit_workspaces)
                 self._figure_presenter.add_shaded_region(fit_workspaces, fit_indices)
         self._figure_presenter.plot_workspaces(workspace_list, indices, hold_on=False, autoscale=autoscale)
         # the data change probably means its the wrong scale

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/plot_widget/fit_pane/plot_fit_pane_presenter.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/plot_widget/fit_pane/plot_fit_pane_presenter.py
@@ -38,6 +38,7 @@ class PlotFitPanePresenter(BasePanePresenter):
         """
         workspace_list = []
         indices = []
+        shade_list = []
         raw = self._view.is_raw_plot()
         with_diff = self._view.is_plot_diff()
         if fit_information_list:
@@ -47,7 +48,9 @@ class PlotFitPanePresenter(BasePanePresenter):
                 fit_workspaces, fit_indices = self._model.get_fit_workspace_and_indices(fit,with_diff)
                 workspace_list += self.match_raw_selection(fit_information.input_workspaces,raw) + fit_workspaces
                 indices += [0] * len(fit_information.input_workspaces) + fit_indices
-        self._figure_presenter.plot_workspaces(workspace_list, indices, hold_on=False, autoscale=autoscale)
+                # dont shade the data but do shade the fit lines
+                shade_list += [False] * len(fit_information.input_workspaces) + [True]*len(fit_indices)
+        self._figure_presenter.plot_workspaces(workspace_list, indices, hold_on=False, autoscale=autoscale, shades=shade_list)
         # the data change probably means its the wrong scale
         self._figure_presenter.force_autoscale()
 

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/plot_widget/fit_pane/plot_fit_pane_presenter.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/plot_widget/fit_pane/plot_fit_pane_presenter.py
@@ -38,7 +38,6 @@ class PlotFitPanePresenter(BasePanePresenter):
         """
         workspace_list = []
         indices = []
-        shade_list = []
         raw = self._view.is_raw_plot()
         with_diff = self._view.is_plot_diff()
         if fit_information_list:
@@ -49,8 +48,8 @@ class PlotFitPanePresenter(BasePanePresenter):
                 workspace_list += self.match_raw_selection(fit_information.input_workspaces,raw) + fit_workspaces
                 indices += [0] * len(fit_information.input_workspaces) + fit_indices
                 # dont shade the data but do shade the fit lines
-                shade_list += [False] * len(fit_information.input_workspaces) + [True]*len(fit_indices)
-        self._figure_presenter.plot_workspaces(workspace_list, indices, hold_on=False, autoscale=autoscale, shades=shade_list)
+                self._figure_presenter.add_shaded_region(fit_workspaces, fit_indices)
+        self._figure_presenter.plot_workspaces(workspace_list, indices, hold_on=False, autoscale=autoscale)
         # the data change probably means its the wrong scale
         self._figure_presenter.force_autoscale()
 

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/plot_widget/fit_pane/plot_fit_pane_presenter.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/plot_widget/fit_pane/plot_fit_pane_presenter.py
@@ -48,6 +48,7 @@ class PlotFitPanePresenter(BasePanePresenter):
                 workspace_list += self.match_raw_selection(fit_information.input_workspaces,raw) + fit_workspaces
                 indices += [0] * len(fit_information.input_workspaces) + fit_indices
                 # dont shade the data but do shade the fit lines
+                print("wsadddfs", fit_workspaces)
                 self._figure_presenter.add_shaded_region(fit_workspaces, fit_indices)
         self._figure_presenter.plot_workspaces(workspace_list, indices, hold_on=False, autoscale=autoscale)
         # the data change probably means its the wrong scale

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/plot_widget/plotting_canvas/plotting_canvas_model.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/plot_widget/plotting_canvas/plotting_canvas_model.py
@@ -17,6 +17,7 @@ class WorkspacePlotInformation(NamedTuple):
     normalised: bool
     errors: bool
     label: str
+    shade: bool
 
     # equal only checks for workspace, axis, and spec num, as the user could have changed the other states
     def __eq__(self, other):
@@ -48,7 +49,7 @@ class PlottingCanvasModel(object):
         self._is_tiled = state
 
     def create_workspace_plot_information(self, input_workspace_names: List[str], input_indices: List[int],
-                                          errors: bool) -> List[WorkspacePlotInformation]:
+                                          errors: bool, shade_list:List[bool]) -> List[WorkspacePlotInformation]:
         """
         Creates a list of workspace plot information (workspace name, index, axis..) from a input list
         of indices and workspace names
@@ -58,10 +59,10 @@ class PlottingCanvasModel(object):
         :return: A list of WorkspacePlotInformation
         """
         workspace_plot_information = []
-        for workspace_name, index in zip(input_workspace_names, input_indices):
+        for workspace_name, index, shade in zip(input_workspace_names, input_indices, shade_list):
             axis = self._plot_model._get_workspace_plot_axis(workspace_name, self._axes_workspace_map, index)
             if not self._plot_model._is_guess_workspace(workspace_name):
-                workspace_plot_information += [self.create_plot_information(workspace_name, index, axis, errors)]
+                workspace_plot_information += [self.create_plot_information(workspace_name, index, axis, errors, shade)]
             else:
                 workspace_plot_information += [self.create_plot_information_for_guess_ws(workspace_name)]
 
@@ -80,7 +81,7 @@ class PlottingCanvasModel(object):
             self._axes_workspace_map[key] = axis_number
 
     def create_plot_information(self, workspace_name: str, index: int, axis: int,
-                                errors: bool) -> WorkspacePlotInformation:
+                                errors: bool, shade: bool) -> WorkspacePlotInformation:
         """
         Creates a workspace plot information instance (workspace name, index, axis..) from an input
         workspace name, index, axis and errors flag.
@@ -93,7 +94,7 @@ class PlottingCanvasModel(object):
         label = self._plot_model._create_workspace_label(workspace_name, index)
         return WorkspacePlotInformation(workspace_name=workspace_name, index=index, axis=axis,
                                         normalised=self._normalised,
-                                        errors=errors, label=label)
+                                        errors=errors, label=label, shade=shade)
 
     def create_plot_information_for_guess_ws(self, guess_ws_name: str) -> WorkspacePlotInformation:
         """

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/plot_widget/plotting_canvas/plotting_canvas_presenter.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/plot_widget/plotting_canvas/plotting_canvas_presenter.py
@@ -113,12 +113,15 @@ class PlottingCanvasPresenter(PlottingCanvasPresenterInterface):
 
     # Interface implementation
     def plot_workspaces(self, workspace_names: List[str], workspace_indices: List[int], hold_on: bool,
-                        autoscale: bool):
+                        autoscale: bool, shades:List[bool]=[]):
         """Plots the input workspace names and indices in the figure window
         If hold_on is True the existing workspaces plotted in the figure are kept"""
         # Create workspace information named tuple from input list
+        shade_list = shades
+        if shade_list ==[]:
+            shade_list=[False]*len(workspace_indices)
         workspace_plot_info = self._model.create_workspace_plot_information(workspace_names, workspace_indices,
-                                                                            self._options_presenter.get_errors())
+                                                                            self._options_presenter.get_errors(), shade_list)
         if not hold_on:
             # Remove data which is currently plotted and not in the new workspace_plot_info
             workspaces_info_to_remove = [plot_info for plot_info in self._view.plotted_workspace_information

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/plot_widget/plotting_canvas/plotting_canvas_presenter.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/plot_widget/plotting_canvas/plotting_canvas_presenter.py
@@ -57,16 +57,16 @@ class PlottingCanvasPresenter(PlottingCanvasPresenterInterface):
     def convert_plot_to_tiled_plot(self, keys):
         """Converts the current plot into a tiled plot specified by the keys and tiled by type
         In then replots the existing data on the new tiles"""
-        workspaces, indices = self._view.plotted_workspaces_and_indices
+        workspaces, indices, shade_list = self._view.plotted_workspaces_and_indices_and_shade
         self.create_tiled_plot(keys)
-        self.plot_workspaces(workspaces, indices, hold_on=False, autoscale=False)
+        self.plot_workspaces(workspaces, indices, hold_on=False, autoscale=False, shades=shade_list)
 
     def convert_plot_to_single_plot(self):
         """Converts the current plot into a single plot
         In then replots the existing data on the new tiles"""
-        workspaces, indices = self._view.plotted_workspaces_and_indices
+        workspaces, indices, shade_list = self._view.plotted_workspaces_and_indices_and_shade
         self.create_single_plot()
-        self.plot_workspaces(workspaces, indices, hold_on=False, autoscale=False)
+        self.plot_workspaces(workspaces, indices, hold_on=False, autoscale=False, shades=shade_list)
 
     def clear_subplots(self):
         self._context.clear_subplots()
@@ -89,7 +89,7 @@ class PlottingCanvasPresenter(PlottingCanvasPresenterInterface):
 
     def get_plotted_workspaces_and_indices(self):
         """Returns the workspace names and indices which are plotted in the figure """
-        plotted_workspaces, indices = self._view.plotted_workspaces_and_indices
+        plotted_workspaces, indices,_ = self._view.plotted_workspaces_and_indices_and_shade
         return plotted_workspaces, indices
 
     def plot_guess_workspace(self, guess_ws_name: str):
@@ -411,7 +411,7 @@ class PlottingCanvasPresenter(PlottingCanvasPresenterInterface):
         # update the state of errors
         selected_subplots, _ = self._get_selected_subplots_from_quick_edit_widget()
         state = self._options_presenter.get_errors()
-        plotted_workspaces, plot_indices = self._view.plotted_workspaces_and_indices
+        plotted_workspaces, plot_indices, _ = self._view.plotted_workspaces_and_indices_and_shade
 
         if self.should_update_all(selected_subplots):
             self._context.set_error_all(state)

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/plot_widget/plotting_canvas/plotting_canvas_presenter_interface.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/plot_widget/plotting_canvas/plotting_canvas_presenter_interface.py
@@ -24,6 +24,14 @@ class PlottingCanvasPresenterInterface(abc.ABC):
         pass
 
     @abc.abstractmethod
+    def add_shaded_region(self, workspaces, indices):
+        """Adds shaded regions to the plot instead of errors
+        :param workspaces: List of workspaces
+        :param indices: List of the workspace indices
+        """
+        pass
+
+    @abc.abstractmethod
     def remove_workspace_names_from_plot(self, workspace_names: List[str]):
         """Removes the input workspace names from the plot
         :param workspace_names: List of workspace names

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/plot_widget/plotting_canvas/plotting_canvas_view.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/plot_widget/plotting_canvas/plotting_canvas_view.py
@@ -172,8 +172,6 @@ class PlottingCanvasView(QtWidgets.QWidget, PlottingCanvasViewInterface):
                 self.hide_axis(axis_number, nrows, ncols)
 
     def add_shaded_region(self, workspace_name, axis, x_values, y1_values, y2_values):
-        #if workspace_name in self._shaded_regions:
-        #    del self._shaded_regions[workspace_name]
         self._shaded_regions[workspace_name] = ShadedRegionInfo(workspace_name = workspace_name,
                                                                 axis = axis,
                                                                 x_values = x_values,

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/plot_widget/plotting_canvas/plotting_canvas_view.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/plot_widget/plotting_canvas/plotting_canvas_view.py
@@ -4,8 +4,9 @@
 #   NScD Oak Ridge National Laboratory, European Spallation Source,
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
-from typing import List, NamedTuple
+from typing import List
 from matplotlib.container import ErrorbarContainer
+from matplotlib.artist import Artist
 from qtpy import QtWidgets, QtCore
 from mantidqtinterfaces.Muon.GUI.Common.plot_widget.plotting_canvas.plot_toolbar import PlotToolbar
 from mantidqtinterfaces.Muon.GUI.Common.plot_widget.plotting_canvas.plotting_canvas_model import WorkspacePlotInformation
@@ -30,12 +31,36 @@ NUMBER_OF_COLOURS = 10
 DEFAULT_COLOR_CYCLE = ["C" + str(index) for index in range(NUMBER_OF_COLOURS)]
 
 
-class ShadedRegionInfo(NamedTuple):
-    workspace_name: str
-    axis: int
-    x_values: List[float]
-    y1_values: List[float]
-    y2_values: List[float]
+class ShadedRegionInfo(object):
+    def __init__(self, workspace_name: str,
+                 axis: int,
+                 x_values: List[float],
+                 y1_values: List[float],
+                 y2_values: List[float]):
+        self.workspace_name = workspace_name
+        self.axis = axis
+        self.x_values = x_values
+        self.y1_values = y1_values
+        self.y2_values = y2_values
+        self.ID = None
+
+    def shade_region(self, axis, color):
+        x_values = self.x_values
+        y1 = self.y1_values
+        y2 = self.y2_values
+        self.ID = axis.fill_between(x_values, y1, y2, facecolor=color, interpolate=True, alpha=0.25)
+
+    def remove(self):
+        if self.ID:
+            self.ID.remove()
+            self.ID = None
+
+
+def get_color_from_artist(artist:Artist):
+    if isinstance(artist, ErrorbarContainer):
+        return artist[0].get_color()
+    else:
+        return artist.get_color()
 
 
 class PlottingCanvasView(QtWidgets.QWidget, PlottingCanvasViewInterface):
@@ -226,8 +251,8 @@ class PlottingCanvasView(QtWidgets.QWidget, PlottingCanvasViewInterface):
                     axis.remove_workspace_artists(workspace)
                     self._plot_information_list.remove(plotted_information)
                     # clear shaded regions from plot
-                    if len(axis.collections)>0:
-                        axis.collections.pop()
+                    if len(axis.collections)>0 and plotted_information.workspace_name in self._shaded_regions.keys():
+                        self._shaded_regions[plotted_information.workspace_name].remove()
         # If we have no plotted lines, reset the color cycle
         if self.num_plotted_workspaces == 0:
             self._reset_color_cycle()
@@ -251,10 +276,7 @@ class PlottingCanvasView(QtWidgets.QWidget, PlottingCanvasViewInterface):
             return
         for ws_artist in artist_info:
             for artist in ws_artist._artists:
-                if isinstance(artist, ErrorbarContainer):
-                    color = artist[0].get_color()
-                else:
-                    color = artist.get_color()
+                color = get_color_from_artist(artist)
                 # When we repeat colors we don't want to add colors to the queue if they are already plotted.
                 # We know we are repeating colors if we have more lines than colors, then we check if the color
                 # removed is already the color of an existing line. If it is we don't manually re-add the color
@@ -276,6 +298,13 @@ class PlottingCanvasView(QtWidgets.QWidget, PlottingCanvasViewInterface):
             if workspace_name == plotted_workspace_name:
                 axis = self.fig.axes[workspace_plot_info.axis]
                 axis.replace_workspace_artists(workspace)
+                if workspace_name in self._shaded_regions.keys() and workspace_plot_info.errors:
+                    # remove old shade first
+                    self._shaded_regions[workspace_name].remove()
+                    # clean up the way we get colours -> function
+                    # add safety to pop on the collection and add note to why it works
+                    color = get_color_from_artist(artists)
+                    self.shade_region(axis, color, workspace_name)
         self.redraw_figure()
 
     # not used for tiled plots
@@ -287,10 +316,7 @@ class PlottingCanvasView(QtWidgets.QWidget, PlottingCanvasViewInterface):
                 artist_info = axis.tracked_workspaces[workspace_name]
                 for ws_artist in artist_info:
                     for artist in ws_artist._artists:
-                        if isinstance(artist, ErrorbarContainer):
-                            color = artist[0].get_color()
-                        else:
-                            color = artist.get_color()
+                        color = get_color_from_artist(artist)
                         plot_kwargs = self._get_plot_kwargs(plot_info)
                         plot_kwargs["color"] = color
                         if workspace_name in self._shaded_regions.keys():
@@ -305,10 +331,7 @@ class PlottingCanvasView(QtWidgets.QWidget, PlottingCanvasViewInterface):
         self.redraw_figure()
 
     def shade_region(self, axis, color, name):
-        x_values = self._shaded_regions[name].x_values
-        y1 = self._shaded_regions[name].y1_values
-        y2 = self._shaded_regions[name].y2_values
-        axis.fill_between(x_values, y1, y2, facecolor=color, interpolate=True, alpha=0.25)
+        self._shaded_regions[name].shade_region(axis, color)
 
     def set_axis_xlimits(self, axis_number, xlims):
         ax = self.fig.axes[axis_number]

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/plot_widget/plotting_canvas/plotting_canvas_view.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/plot_widget/plotting_canvas/plotting_canvas_view.py
@@ -301,8 +301,6 @@ class PlottingCanvasView(QtWidgets.QWidget, PlottingCanvasViewInterface):
                 if workspace_name in self._shaded_regions.keys() and workspace_plot_info.errors:
                     # remove old shade first
                     self._shaded_regions[workspace_name].remove()
-                    # clean up the way we get colours -> function
-                    # add safety to pop on the collection and add note to why it works
                     color = get_color_from_artist(artists)
                     self.shade_region(axis, color, workspace_name)
         self.redraw_figure()

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/plot_widget/plotting_canvas/plotting_canvas_view.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/plot_widget/plotting_canvas/plotting_canvas_view.py
@@ -133,7 +133,7 @@ class PlottingCanvasView(QtWidgets.QWidget, PlottingCanvasViewInterface):
         except (RuntimeError, KeyError):
             return -1
         self._plot_information_list.append(workspace_plot_info)
-        errors = workspace_plot_info.errors
+        errors = workspace_plot_info.errors if not workspace_plot_info.shade else False
         ws_index = workspace_plot_info.index
         axis_number = workspace_plot_info.axis
         ax = self.fig.axes[axis_number]
@@ -269,7 +269,10 @@ class PlottingCanvasView(QtWidgets.QWidget, PlottingCanvasViewInterface):
                             color = artist.get_color()
                         plot_kwargs = self._get_plot_kwargs(plot_info)
                         plot_kwargs["color"] = color
-                        axis.replot_artist(artist, with_errors, **plot_kwargs)
+                        if plot_info.shade:
+                            print("do nothing")
+                        else:
+                            axis.replot_artist(artist, with_errors, **plot_kwargs)
         self.redraw_figure()
 
     def set_axis_xlimits(self, axis_number, xlims):

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/plot_widget/plotting_canvas/plotting_canvas_view.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/plot_widget/plotting_canvas/plotting_canvas_view.py
@@ -147,7 +147,6 @@ class PlottingCanvasView(QtWidgets.QWidget, PlottingCanvasViewInterface):
         ax = self.fig.axes[axis_number]
         plot_kwargs = self._get_plot_kwargs(workspace_plot_info)
         plot_kwargs['color'] = self._color_queue[axis_number]()
-
         if workspace_name in self._shaded_regions.keys() and errors:
             errors = False
             self.shade_region(ax, plot_kwargs['color'], workspace_name)
@@ -173,6 +172,8 @@ class PlottingCanvasView(QtWidgets.QWidget, PlottingCanvasViewInterface):
                 self.hide_axis(axis_number, nrows, ncols)
 
     def add_shaded_region(self, workspace_name, axis, x_values, y1_values, y2_values):
+        #if workspace_name in self._shaded_regions:
+        #    del self._shaded_regions[workspace_name]
         self._shaded_regions[workspace_name] = ShadedRegionInfo(workspace_name = workspace_name,
                                                                 axis = axis,
                                                                 x_values = x_values,
@@ -226,8 +227,9 @@ class PlottingCanvasView(QtWidgets.QWidget, PlottingCanvasViewInterface):
                     axis = self.fig.axes[workspace_plot_info.axis]
                     axis.remove_workspace_artists(workspace)
                     self._plot_information_list.remove(plotted_information)
-        # empty shaded region list
-        self._shaded_regions = {}
+                    # clear shaded regions from plot
+                    if len(axis.collections)>0:
+                        axis.collections.pop()
         # If we have no plotted lines, reset the color cycle
         if self.num_plotted_workspaces == 0:
             self._reset_color_cycle()
@@ -295,6 +297,8 @@ class PlottingCanvasView(QtWidgets.QWidget, PlottingCanvasViewInterface):
                         plot_kwargs["color"] = color
                         if workspace_name in self._shaded_regions.keys():
                             if with_errors:
+                                # replot without errors to get the fit on top
+                                axis.replot_artist(artist, False, **plot_kwargs)
                                 self.shade_region(axis, color, workspace_name)
                             elif len(axis.collections)>0:
                                 axis.collections.pop()

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/plot_widget/plotting_canvas/plotting_canvas_view_interface.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/plot_widget/plotting_canvas/plotting_canvas_view_interface.py
@@ -76,6 +76,10 @@ class PlottingCanvasViewInterface(metaclass=PlottingViewMeta):
         pass
 
     @abc.abstractmethod
+    def add_shaded_region(self, workspace_name, axis, x_values, y1_values, y2_values):
+        pass
+
+    @abc.abstractmethod
     def remove_workspace_info_from_plot(self, workspace_plot_info_list: List[WorkspacePlotInformation]):
         """Remove a list of workspaces to the plot - The workspaces are contained in a list PlotInformation
         The PlotInformation contains the workspace name, workspace index and target axis."""

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/plot_widget/plotting_canvas/plotting_canvas_view_interface.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/plot_widget/plotting_canvas/plotting_canvas_view_interface.py
@@ -37,7 +37,7 @@ class PlottingCanvasViewInterface(metaclass=PlottingViewMeta):
 
     @property
     @abc.abstractmethod
-    def plotted_workspaces_and_indices(self):
+    def plotted_workspaces_and_indices_and_shade(self):
         """Returns plotted workspaces and indices"""
         pass
 

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/plot_widget/plotting_canvas/plotting_canvas_view_interface.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/plot_widget/plotting_canvas/plotting_canvas_view_interface.py
@@ -37,7 +37,7 @@ class PlottingCanvasViewInterface(metaclass=PlottingViewMeta):
 
     @property
     @abc.abstractmethod
-    def plotted_workspaces_and_indices_and_shade(self):
+    def plotted_workspaces_and_indices(self):
         """Returns plotted workspaces and indices"""
         pass
 

--- a/qt/python/mantidqtinterfaces/test/Muon/plot_fit_panes/plot_fit_pane_model_test.py
+++ b/qt/python/mantidqtinterfaces/test/Muon/plot_fit_panes/plot_fit_pane_model_test.py
@@ -5,6 +5,7 @@
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
 import unittest
+from mantid.simpleapi import CreateWorkspace
 from mantidqtinterfaces.Muon.GUI.Common.plot_widget.fit_pane.plot_fit_pane_model import PlotFitPaneModel
 from mantidqt.utils.qt.testing import start_qapplication
 from mantidqtinterfaces.Muon.GUI.Common.test_helpers.context_setup import setup_context
@@ -49,6 +50,20 @@ class PlotFitPaneModelTest(unittest.TestCase):
 
         self.assertEqual(ws, ["test", "test", "unit", "unit"])
         self.assertEqual(indices, [1,2,1,2])
+
+    def test_get_shade_lines(self):
+        ws = CreateWorkspace(OutputWorkspace="test",
+                             DataX=[0,1,2,3,4,5,6,7,8],
+                             DataY=[2,1,0,5,4,3,8,7,6],
+                             DataE=[.1,.2,.3,.4,.5,.6,.7,.8,.9],
+                             NSpec=3)
+
+        x_data, y1, y2 = self.model.get_shade_lines(ws, 1)
+        self.assertEqual(x_data.tolist(), [3, 4, 5])
+        # y1 = y_data + e_data
+        self.assertEqual(y1.tolist(), [5.4, 4.5, 3.6])
+        # y2 = y_data - e_data
+        self.assertEqual(y2.tolist(), [4.6, 3.5, 2.4])
 
 
 if __name__ == '__main__':

--- a/qt/python/mantidqtinterfaces/test/Muon/plotting_canvas/plotting_canvas_model_test.py
+++ b/qt/python/mantidqtinterfaces/test/Muon/plotting_canvas/plotting_canvas_model_test.py
@@ -40,6 +40,44 @@ class PlottingCanvasModelTest(unittest.TestCase):
         self.model.create_plot_information.assert_any_call(test_ws_names[0], test_indies[0], axis, False)
         self.model.create_plot_information.assert_any_call(test_ws_names[1], test_indies[1], axis, False)
 
+    @mock.patch('mantidqtinterfaces.Muon.GUI.Common.plot_widget.plotting_canvas.plotting_canvas_model.retrieve_ws')
+    @mock.patch('mantidqtinterfaces.Muon.GUI.Common.plot_widget.plotting_canvas.plotting_canvas_model.run_convert_to_points')
+    @mock.patch('mantidqtinterfaces.Muon.GUI.Common.plot_widget.plotting_canvas.plotting_canvas_model.run_convert_to_histogram')
+    def test_get_shade_lines_hist_data(self, hist_mock, point_mock,ws_mock):
+        ws = mock.Mock()
+        ws.isHistogramData = mock.Mock(return_value=True)
+        ws_mock.return_value = ws
+        name = "unit"
+        axis = 2
+        point_mock.return_value = "test"
+        self.model._plot_model.get_shade_lines = mock.Mock(return_value=(1,2,3))
+
+        self.assertEqual(self.model.get_shade_lines(name, axis), (1,2,3))
+        point_mock.assert_called_once_with(name)
+        ws_mock.assert_any_call("test")
+        self.assertEqual(ws_mock.call_count, 2)
+        self.model._plot_model.get_shade_lines.assert_called_once_with(ws, axis)
+        hist_mock.assert_called_once_with("unit")
+
+    @mock.patch('mantidqtinterfaces.Muon.GUI.Common.plot_widget.plotting_canvas.plotting_canvas_model.retrieve_ws')
+    @mock.patch('mantidqtinterfaces.Muon.GUI.Common.plot_widget.plotting_canvas.plotting_canvas_model.run_convert_to_points')
+    @mock.patch('mantidqtinterfaces.Muon.GUI.Common.plot_widget.plotting_canvas.plotting_canvas_model.run_convert_to_histogram')
+    def test_get_shade_lines_points_data(self, hist_mock, point_mock,ws_mock):
+        ws = mock.Mock()
+        ws.isHistogramData = mock.Mock(return_value=False)
+        ws_mock.return_value = ws
+        name = "unit"
+        axis = 2
+        point_mock.return_value = "test"
+        self.model._plot_model.get_shade_lines = mock.Mock(return_value=(1,2,3))
+
+        self.assertEqual(self.model.get_shade_lines(name, axis), (1,2,3))
+        point_mock.assert_not_called()
+        ws_mock.assert_any_call("unit")
+        self.assertEqual(ws_mock.call_count, 1)
+        self.model._plot_model.get_shade_lines.assert_called_once_with(ws, axis)
+        hist_mock.assert_not_called()
+
 
 if __name__ == '__main__':
     unittest.main(buffer=False, verbosity=2)

--- a/qt/python/mantidqtinterfaces/test/Muon/plotting_canvas/plotting_canvas_presenter_test.py
+++ b/qt/python/mantidqtinterfaces/test/Muon/plotting_canvas/plotting_canvas_presenter_test.py
@@ -602,6 +602,23 @@ class PlottingCanvasPresenterTest(unittest.TestCase):
 
         self.assertFalse(self.presenter.should_update_all(selected_subplots))
 
+    def test_add_shaded_region(self):
+        def shade_mock(name, index):
+            return index, index+1, index+2
+        self.model.get_shade_lines.side_effect = shade_mock
+        self.presenter.add_shaded_region(["unit", "test"], [0,1])
+        self.view.add_shaded_region.assert_any_call(workspace_name="unit",
+                                                    axis=0,
+                                                    x_values=0,
+                                                    y1_values=1,
+                                                    y2_values=2)
+        self.view.add_shaded_region.assert_any_call(workspace_name="test",
+                                                    axis=1,
+                                                    x_values=1,
+                                                    y1_values=2,
+                                                    y2_values=3)
+        self.assertEqual(self.view.add_shaded_region.call_count,2)
+
 
 if __name__ == '__main__':
     unittest.main(buffer=False, verbosity=2)


### PR DESCRIPTION
**Description of work.**

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**

<!-- Instructions for testing. -->
Enable the model analysis
Open muon analysis
Load MUSR 62260
Turn errors on and off. This should look unchanged from the current version (i.e. bars on the data)
Go to the fitting tab
Add a LinearBackground
Do a fit
Turn the errors on and off
This time the data will still have bars, but the fit will have a shaded region instead

Load MUSR 62260-5
Tick simultaneous 
Do a fit
The simultaneous fit, will not have any errors on the fit so instead, use the script below to add some (only do this when errors are off)

```

name = "MUSR62260; Group; top; Asymmetry; MA; Fitted; LinearBackground; Workspace; Simultaneous"
name2 = "MUSR62260; Group; bkwd; Asymmetry; MA; Fitted; LinearBackground; Workspace; Simultaneous"
name3 = "MUSR62260; Group; fwd; Asymmetry; MA; Fitted; LinearBackground; Workspace; Simultaneous"
name4 = "MUSR62260; Group; bottom; Asymmetry; MA; Fitted; LinearBackground; Workspace; Simultaneous"
 
ws0 = mtd[name]

ws = ws0
y= ws.dataE(1)
x = ws.readX(1)
for i in range(len(y)):
    y[i]= 0.1*0.01*x[i]
# 
AnalysisDataService.addOrReplace(name, ws)

ws2 = mtd[name2]

ws2=ConvertToPointData(ws2)
y= ws2.dataE(1)
x = ws2.readX(1)
t =  0.1*np.sin(x)
for i in range(len(y)):
    y[i]=t[i]
AnalysisDataService.addOrReplace(name2, ws2)

ws3 = mtd[name3]

ws3=ConvertToPointData(ws3)
y= ws3.dataE(1)
x = ws3.readX(1)
t= 0.1*np.cos(.5*x)
for i in range(len(y)):
    y[i]=t[i]
AnalysisDataService.addOrReplace(name3, ws3)

ws4 = mtd[name4]

ws4=ConvertToPointData(ws4)
y= ws4.dataE(1)
x = ws4.readX(1)
t= 0.1*np.exp(-x)
for i in range(len(y)):
    y[i]=t[i]
AnalysisDataService.addOrReplace(name4, ws4)
```

Go to the sequential tab
Do fit all
Go to the results tab
Select run number and then create the results table
Go to model analysis
Set x to be run number and y to be a fitting parameter
Add a FlatBackground and do a fit
The fit should have a shaded region when errors are turned on
Go back to the fitting tab
Change the mode from normal to TF asymmetry
Clear the fit function
Add a GausOsc
Set frequency to 1
Do a fit
Check that the fit has a shaded region instead of errors
Close muon analysis


Clear the ADS
Open frequency domain analysis
Load MUSR 62260
Go to the transform tab
Change it from FFT to MaxEnt
Click calculate - it takes a little while
Go to the fitting tab
Add a flat background
Do a fit
When the errors are turned on the fit should have a shaded region. The frequency data will not have any errors.

Fixes #32386. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
