### PR TITLE
Embed Contour Plot into Preview Tab

### DIFF
--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/IPreviewView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/IPreviewView.h
@@ -32,6 +32,7 @@ public:
   virtual std::string getWorkspaceName() const = 0;
   virtual void plotInstView(MantidWidgets::InstrumentActor *instActor, Mantid::Kernel::V3D const &samplePos,
                             Mantid::Kernel::V3D const &axis) = 0;
+  virtual void plotContour(Mantid::API::MatrixWorkspace_sptr const &ws) const = 0;
 
   virtual void setInstViewZoomState(bool on) = 0;
   virtual void setInstViewEditState(bool on) = 0;

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.cpp
@@ -57,11 +57,7 @@ void PreviewPresenter::notifyLoadWorkspaceCompleted() {
   // TODO reset the other plots (or perhaps re-run the reduction with the new data?)
 }
 
-void PreviewPresenter::notifySumBanksCompleted() {
-  g_log.debug("Sum banks completed");
-  // TODO Implement plotting of the summed workspace
-  // m_view->plotSliceView(m_model->getSummedWs())
-}
+void PreviewPresenter::notifySumBanksCompleted() { m_view->plotContour(m_model->getSummedWs()); }
 
 void PreviewPresenter::notifyInstViewSelectRectRequested() {
   m_view->setInstViewZoomState(false);

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewWidget.ui
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewWidget.ui
@@ -185,7 +185,7 @@
          </layout>
         </item>
         <item>
-         <widget class="QTreeView" name="treeView_2"/>
+         <widget class="MantidQt::MantidWidgets::ContourPreviewPlot" name="contour_preview_plot" native="true"/>
         </item>
        </layout>
       </widget>
@@ -225,9 +225,17 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>MantidQt::MantidWidgets::ContourPreviewPlot</class>
+   <extends>QWidget</extends>
+   <header>MantidQtWidgets/Plotting/Mpl/ContourPreviewPlot.h</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
  <tabstops>
   <tabstop>workspace_line_edit</tabstop>
-  <tabstop>treeView_2</tabstop>
+  <tabstop>plot_2d_tool_placeholders</tabstop>
   <tabstop>plot_1d_toolbar_placeholder</tabstop>
   <tabstop>treeView</tabstop>
   <tabstop>tableWidget_2</tabstop>

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/QtPreviewView.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/QtPreviewView.cpp
@@ -60,6 +60,10 @@ void QtPreviewView::plotInstView(MantidWidgets::InstrumentActor *instActor, V3D 
   m_instDisplay->setSurface(std::make_shared<MantidWidgets::UnwrappedCylinder>(instActor, samplePos, axis));
   connect(m_instDisplay->getSurface().get(), SIGNAL(shapeChangeFinished()), this, SLOT(onInstViewShapeChanged()));
 }
+void QtPreviewView::plotContour(Mantid::API::MatrixWorkspace_sptr const &ws) const {
+  m_ui.contour_preview_plot->setWorkspace(ws);
+}
+
 void QtPreviewView::setInstViewZoomState(bool isChecked) { m_ui.iv_zoom_button->setDown(isChecked); }
 void QtPreviewView::setInstViewEditState(bool isChecked) { m_ui.iv_edit_button->setDown(isChecked); }
 

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/QtPreviewView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/QtPreviewView.h
@@ -33,6 +33,7 @@ public:
   std::string getWorkspaceName() const override;
   void plotInstView(MantidWidgets::InstrumentActor *instActor, Mantid::Kernel::V3D const &samplePos,
                     Mantid::Kernel::V3D const &axis) override;
+  void plotContour(Mantid::API::MatrixWorkspace_sptr const &ws) const override;
 
   void setInstViewZoomState(bool isChecked) override;
   void setInstViewEditState(bool isChecked) override;

--- a/qt/scientific_interfaces/ISISReflectometry/test/Preview/MockPreviewView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Preview/MockPreviewView.h
@@ -22,6 +22,7 @@ public:
   MOCK_METHOD(std::string, getWorkspaceName, (), (const, override));
   MOCK_METHOD(void, plotInstView,
               (MantidWidgets::InstrumentActor *, Mantid::Kernel::V3D const &, Mantid::Kernel::V3D const &), (override));
+  MOCK_METHOD(void, plotContour, (Mantid::API::MatrixWorkspace_sptr const &), (const, override));
   MOCK_METHOD(void, setInstViewZoomState, (bool), (override));
   MOCK_METHOD(void, setInstViewEditState, (bool), (override));
   MOCK_METHOD(void, setInstViewSelectRectState, (bool), (override));

--- a/qt/scientific_interfaces/ISISReflectometry/test/Preview/PreviewPresenterTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Preview/PreviewPresenterTest.h
@@ -151,6 +151,14 @@ public:
     presenter.notifyInstViewShapeChanged();
   }
 
+  void test_notify_sum_banks_completed() {
+    auto mockView = makeView();
+    EXPECT_CALL(*mockView, plotContour).Times(1);
+    auto presenter = PreviewPresenter(packDeps(mockView.get()));
+
+    presenter.notifySumBanksCompleted();
+  }
+
   void test_notify_contour_export_to_ads_requested() {
     auto mockView = makeView();
     auto mockModel = makeModel();


### PR DESCRIPTION
**Description of work.**
Adds a simple contour plot into the preview tab that shows any selected areas from the instrument preview. 

**To test:**
- Load this workspace: [INTER45455_inst.zip](https://github.com/mantidproject/mantid/files/7504266/INTER45455_inst.zip)
- Set the output level to `debug` in the log.
- Open the ISIS Reflectometry GUI
- Select the Preview tab.
- Type in `INTER45455` and click Load. The instrument viewer plot should display the data.
- Click the rectangle-select button and select a region of interest.
- Whenever the ROI is created or changed, the upper right plot should be updated with a plot of spectrum vs TOF of the resulting workspace summed across the selected banks. 


Refs #32772


*This does not require release notes* because **this tab is not yet visible on release builds.**


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.