### PR TITLE
Fixed VesuvioAnalysis crashes caused by single mass calculation

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/VesuvioAnalysis.py
+++ b/Framework/PythonInterface/plugins/algorithms/VesuvioAnalysis.py
@@ -115,7 +115,7 @@ class VesuvioAnalysis(PythonAlgorithm):
         self.declareProperty(ITableWorkspaceProperty("ComptonProfile",
                                                      "",
                                                      direction=Direction.Input),doc="Table for Compton profiles")
-        self.declareProperty(IntArrayProperty("ConstraintsProfileNumbers", [0,1]))
+        self.declareProperty(IntArrayProperty("ConstraintsProfileNumbers", []))
         self.declareProperty(
             "ConstraintsProfileScatteringCrossSection",
             "2.*82.03/5.551",
@@ -155,8 +155,8 @@ class VesuvioAnalysis(PythonAlgorithm):
         if len(TOF) != 3:
             issues["TOFRangeVector"] = "TOFRangeVector should have length 3 (lower, binning, upper)."
         constraints = self.getProperty("ConstraintsProfileNumbers").value
-        if len(constraints)!=2:
-            issues["ConstraintsProfileNumbers"] = "ConstraintsProfileNumbers should only contain 2 numbers."
+        if len(constraints) != 0 and len(constraints) != 2:
+            issues["ConstraintsProfileNumbers"] = "ConstraintsProfileNumbers should either be empty or only contain 2 numbers."
         #check aritmatic is safe
         cross_section = self.getProperty("ConstraintsProfileScatteringCrossSection").value
         for ch in cross_section:
@@ -202,10 +202,12 @@ class VesuvioAnalysis(PythonAlgorithm):
         # if flag=True inequality; if flag = False equality
         constraints_profile_num = self.getProperty("ConstraintsProfileNumbers").value
         # check this is valid in the validate inputs
-        cross_section = evaluate(self.getProperty("ConstraintsProfileScatteringCrossSection").value)
-        state = self.getProperty("ConstraintsProfileState").value
-        C1 = constraint( constraints_profile_num[0], constraints_profile_num[1], cross_section ,state)
-        constraints = [C1]
+        constraints = []
+        if len(constraints_profile_num) > 0:
+            cross_section = evaluate(self.getProperty("ConstraintsProfileScatteringCrossSection").value)
+            state = self.getProperty("ConstraintsProfileState").value
+            C1 = constraint( constraints_profile_num[0], constraints_profile_num[1], cross_section ,state)
+            constraints = [C1]
 
         # spectra to be masked
         spectra_to_be_masked = self.getProperty("SpectraToBeMasked").value

--- a/Framework/PythonInterface/plugins/algorithms/VesuvioAnalysis.py
+++ b/Framework/PythonInterface/plugins/algorithms/VesuvioAnalysis.py
@@ -95,10 +95,7 @@ class VesuvioAnalysis(PythonAlgorithm):
                              validator=IntListValidator([0,1,2,3,4]))
         self.declareProperty("OutputName", "polyethylene",doc="The base name for the outputs." )
         self.declareProperty("Runs", "38898-38906", doc="List of Vesuvio run numbers (e.g. 20934-20937, 30924)")
-        self.declareProperty(IntArrayProperty("Spectra",[135,182]), doc="Range of spectra to be analysed (first, last). Please note that "
-                                                                         "spectra with a number lower than 135 are treated as back "
-                                                                         "scattering spectra, with a number of 135 or above as forward "
-                                                                         "scattering spectra.")
+        self.declareProperty(IntArrayProperty("Spectra",[135,182]), doc="Range of spectra to be analysed (first, last).")
         self.declareProperty(FloatArrayProperty("TOFRangeVector", [110.,1.5,460.]),
                              doc="In micro seconds (lower bound, binning, upper bound).")
         self.declareProperty(
@@ -115,11 +112,13 @@ class VesuvioAnalysis(PythonAlgorithm):
         self.declareProperty(ITableWorkspaceProperty("ComptonProfile",
                                                      "",
                                                      direction=Direction.Input),doc="Table for Compton profiles")
-        self.declareProperty(IntArrayProperty("ConstraintsProfileNumbers", []))
+        self.declareProperty(IntArrayProperty("ConstraintsProfileNumbers", []), doc="List with LHS and RHS element of constraint on "
+                                              "intensities of element peaks. A constraint can only be set when there are at least two "
+                                              "elements in the ComptonProfile.")
         self.declareProperty(
             "ConstraintsProfileScatteringCrossSection",
             "2.*82.03/5.551",
-            doc="The ratio of the first to second intensities, each equal to atom stoichiometry times bound scattering"
+            doc="The ratio of the first to second intensities, each equal to atom stoichiometry times bound scattering "
             "cross section. Simple arithmetic can be included but the result may be rounded. This setting is ignored when no "
             "ConstraintsProfileNumbers are set.")
         self.declareProperty("ConstraintsProfileState", "eq", doc="This setting is ignored when no ConstraintsProfileNumbers are set.",
@@ -130,7 +129,7 @@ class VesuvioAnalysis(PythonAlgorithm):
                              " about the first element specified in the elements string. Then such spectra are converted to the Y space"
                              " of the first element (using the ConvertToYSPace algorithm). The spectra are summed together and"
                              " symmetrised. A fit on the resulting spectrum is performed using a Gauss Hermite function up to the sixth"
-                             "order.")
+                             " order.")
 
     def validateInputs(self):
         tableCols = [

--- a/Framework/PythonInterface/plugins/algorithms/VesuvioAnalysis.py
+++ b/Framework/PythonInterface/plugins/algorithms/VesuvioAnalysis.py
@@ -120,8 +120,10 @@ class VesuvioAnalysis(PythonAlgorithm):
             "ConstraintsProfileScatteringCrossSection",
             "2.*82.03/5.551",
             doc="The ratio of the first to second intensities, each equal to atom stoichiometry times bound scattering"
-            "cross section. Simple arithmetic can be included but the result may be rounded.")
-        self.declareProperty("ConstraintsProfileState", "eq", validator=StringListValidator(["eq","ineq"]))
+            "cross section. Simple arithmetic can be included but the result may be rounded. This setting is ignored when no "
+            "ConstraintsProfileNumbers are set.")
+        self.declareProperty("ConstraintsProfileState", "eq", doc="This setting is ignored when no ConstraintsProfileNumbers are set.",
+                             validator=StringListValidator(["eq","ineq"]))
         self.declareProperty(IntArrayProperty("SpectraToBeMasked", []))#173,174,181
         self.declareProperty("SubtractResonancesFunction", "", doc="Function for resonance subtraction. Empty means no subtraction.")
         self.declareProperty("YSpaceFitFunctionTies", "",doc="The TOF spectra are subtracted by all the fitted profiles"

--- a/Framework/PythonInterface/plugins/algorithms/VesuvioAnalysis.py
+++ b/Framework/PythonInterface/plugins/algorithms/VesuvioAnalysis.py
@@ -157,11 +157,12 @@ class VesuvioAnalysis(PythonAlgorithm):
         constraints = self.getProperty("ConstraintsProfileNumbers").value
         if len(constraints) != 0 and len(constraints) != 2:
             issues["ConstraintsProfileNumbers"] = "ConstraintsProfileNumbers should either be empty or only contain 2 numbers."
-        #check aritmatic is safe
-        cross_section = self.getProperty("ConstraintsProfileScatteringCrossSection").value
-        for ch in cross_section:
-            if ch not in ["+","-","*","/",".","(",")"] and not ch.isdigit():
-                issues["ConstraintsProfileScatteringCrossSection"]= "Must be a valid mathmatical expression. "+ch
+        #check arithmetic is safe
+        if len(constraints) != 0:
+            cross_section = self.getProperty("ConstraintsProfileScatteringCrossSection").value
+            for ch in cross_section:
+                if ch not in ["+","-","*","/",".","(",")"] and not ch.isdigit():
+                    issues["ConstraintsProfileScatteringCrossSection"]= "Must be a valid mathmatical expression. "+ch
         spectra = self.getProperty("Spectra").value
         if len(spectra) != 2:
             issues["Spectra"] = "Spectra should be of the form [first, last]"

--- a/Framework/PythonInterface/test/python/plugins/algorithms/VesuvioAnalysisTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/VesuvioAnalysisTest.py
@@ -143,6 +143,7 @@ class VesuvioAnalysisTest(unittest.TestCase):
         bad_expressions = [ "2*r", "2,3", "4£", "rm -r *"]
         for expression in bad_expressions:
             alg = self.set_up_alg()
+            alg.setProperty('ConstraintsProfileNumbers', [0,1])
             alg.setProperty('ConstraintsProfileScatteringCrossSection',expression )
             alg.setProperty('ComptonProfile', table)
             alg.setProperty('Spectra', [135, 182])
@@ -155,6 +156,7 @@ class VesuvioAnalysisTest(unittest.TestCase):
         good_expressions = [ "2*3", "2+3", "4-1", "5/2", "(3+2)", "2.3+4.5"]
         for expression in good_expressions:
             alg = self.set_up_alg()
+            alg.setProperty('ConstraintsProfileNumbers', [0,1])
             alg.setProperty('ConstraintsProfileScatteringCrossSection',expression )
             alg.setProperty('ComptonProfile', table)
             alg.setProperty('Spectra', [135, 182])

--- a/docs/source/algorithms/VesuvioAnalysis-v1.rst
+++ b/docs/source/algorithms/VesuvioAnalysis-v1.rst
@@ -8,7 +8,7 @@
 
 Description
 -----------
-This algorithm allows the loading, reduction, and analysis of data obtained using Deep Inelastic Neutron Scattering (DINS), also referred to as Neutron Compton Scattering (NCS), at the VESUVIO spectrometer.
+This algorithm allows the loading, reduction, and analysis of forward scattering data obtained using Deep Inelastic Neutron Scattering (DINS), also referred to as Neutron Compton Scattering (NCS), at the VESUVIO spectrometer.
 The algorithm has been developed by the VESUVIO Instrument Scientists, Giovanni Romanelli and Matthew Krzystyniak.
 A previous version of the algorithm was described in: G. Romanelli et al.; Journal of Physics: Conf. Series 1055 (2018) 012016.
 

--- a/docs/source/release/v6.3.0/indirect_geometry.rst
+++ b/docs/source/release/v6.3.0/indirect_geometry.rst
@@ -30,10 +30,12 @@ Improvements
 - Based on existing options for AnalysisMode in the VesuvioAnalysis algorithm two new
   options were introduced to allow reduction and analysis of spectra in the TOF domain
   without automatically carrying out a Y space analysis afterwards.
+- Updated documentation for VesuvioAnalysis
 
 Bugfixes
 --------
 
 - Fixed a bug which prevented workspaces being loaded into Elwin.
+- Fixed a bug which caused VesuvioAnalysis to crash when run with a single element.
 
 :ref:`Release 6.3.0 <v6.3.0>`

--- a/scripts/Inelastic/vesuvio/analysisHelpers.py
+++ b/scripts/Inelastic/vesuvio/analysisHelpers.py
@@ -550,7 +550,6 @@ def prepare_fit_arguments(elements, constraints) :
         # from element position in elements to intensity position in par
         lhs_int, rhs_int = 3*constraints[k].lhs_element_position, 3*constraints[k].rhs_element_position
         fit_constraints.append({'type': constraints[k].type, 'fun': lambda par:  par[lhs_int] -constraints[k].rhs_factor*par[rhs_int] })
-    print(bounds)
     return masses, par, bounds, fit_constraints
 
 

--- a/scripts/Inelastic/vesuvio/analysisHelpers.py
+++ b/scripts/Inelastic/vesuvio/analysisHelpers.py
@@ -545,10 +545,12 @@ def prepare_fit_arguments(elements, constraints) :
                                                                               elements[m].width_high),
                     (elements[m].centre_low,
                      elements[m].centre_high) )
+    fit_constraints = []
     for k in range(len(constraints) ):
         # from element position in elements to intensity position in par
         lhs_int, rhs_int = 3*constraints[k].lhs_element_position, 3*constraints[k].rhs_element_position
-        fit_constraints = ({'type': constraints[k].type, 'fun': lambda par:  par[lhs_int] -constraints[k].rhs_factor*par[rhs_int] })
+        fit_constraints.append({'type': constraints[k].type, 'fun': lambda par:  par[lhs_int] -constraints[k].rhs_factor*par[rhs_int] })
+    print(bounds)
     return masses, par, bounds, fit_constraints
 
 


### PR DESCRIPTION
**Description of work.**

VesuvioAnalysis used to crash when run with a single element in the ComptonProfile. The reason for this was a hard coded default for ConstraintsProfileNumbers that assumed at least two elements in the ComptonProfile. This resulted in a constraint for the fitting function that could not fulfilled with only one element and therefore caused the crash.

This has been fixed by setting an empty list for ConstraintsProfileNumbers as a default. If not overwritten by the user there is no constraint based on ConstraintsProfileNumbers added and the fitting function can run successfully. The documentation for VesuvioAnalysis has been updated accordingly as this fix has an impact on several properties used for defining constraints. With the documentation update a second open issue was fixed (https://github.com/mantidproject/mantid/issues/32877). 

While working on this fix another issue with VesuvioAnalysis was found (https://github.com/mantidproject/mantid/issues/32930) as it turned out that the processing of backscattering data is not fully implemented yet. For now the documentation for VesuvioAnalysis has been updated to indicate that only forward scattering data can be processed at the moment.

**Report to:** Matthew Krzystyniak


**To test:**

Check the documentation for VesuvioAnalysis and also run the script in https://github.com/mantidproject/mantid/issues/32916.

Fixes #[32916](https://github.com/mantidproject/mantid/issues/32916) and #[32877](https://github.com/mantidproject/mantid/issues/32877)

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
