### PR TITLE
Fix ErrorModHKL calculation in FindUBUsingIndexedPeak

### DIFF
--- a/Framework/Crystal/inc/MantidCrystal/FindUBUsingIndexedPeaks.h
+++ b/Framework/Crystal/inc/MantidCrystal/FindUBUsingIndexedPeaks.h
@@ -45,7 +45,7 @@ private:
 
   /// Run the algorithm
   void exec() override;
-  void logLattice(Geometry::OrientedLattice &o_lattice, int &ModDim);
+  void logLattice(const Geometry::OrientedLattice &o_lattice, const int &ModDim);
   int getModulationDimension(Kernel::V3D &mnp);
   bool isPeakIndexed(const Geometry::IPeak &peak);
 };

--- a/Framework/Crystal/test/FindUBUsingIndexedPeaksTest.h
+++ b/Framework/Crystal/test/FindUBUsingIndexedPeaksTest.h
@@ -13,6 +13,7 @@
 #include <cxxtest/TestSuite.h>
 
 #include "MantidCrystal/FindUBUsingIndexedPeaks.h"
+#include "MantidCrystal/IndexPeaks.h"
 #include "MantidCrystal/LoadIsawPeaks.h"
 #include "MantidCrystal/LoadIsawUB.h"
 #include "MantidDataHandling/LoadNexusProcessed.h"
@@ -178,6 +179,99 @@ public:
     for (size_t i = 0; i < 3; i++) {
       TS_ASSERT_DELTA(correct_err1[i], err_calculated1[i], 5e-4);
       TS_ASSERT_DELTA(correct_err2[i], err_calculated2[i], 5e-4);
+    }
+
+    // Remove workspace from the data service.
+    AnalysisDataService::Instance().remove("peaks");
+  }
+
+  void test_mod_multiple_runs_common_UB() {
+    // Create fake peaks workspace with two different runs with mod vectors
+    auto pw = std::make_shared<LeanElasticPeaksWorkspace>();
+    pw->mutableSample().setOrientedLattice(std::make_unique<OrientedLattice>(5, 6, 7, 90, 90, 90));
+    for (int h = 0; h < 2; h++) {
+      for (int k = 0; k < 2; k++) {
+        for (int l = 0; l < 2; l++) {
+          if (h == 0 && k == 0 && l == 0)
+            continue;
+          auto p1 = pw->createPeakHKL(V3D(h, k, l));
+          auto p2 = pw->createPeakHKL(V3D(h + 0.250, k, l));
+          auto p3 = pw->createPeakHKL(V3D(h - 0.252, k, l));
+          p1->setRunNumber(1);
+          p2->setRunNumber(1);
+          p3->setRunNumber(1);
+          pw->addPeak(*p1);
+          pw->addPeak(*p2);
+          pw->addPeak(*p3);
+          auto p4 = pw->createPeakHKL(V3D(h, k, l));
+          auto p5 = pw->createPeakHKL(V3D(h + 0.252, k, l));
+          auto p6 = pw->createPeakHKL(V3D(h - 0.250, k, l));
+          p4->setRunNumber(2);
+          p5->setRunNumber(2);
+          p6->setRunNumber(2);
+          pw->addPeak(*p4);
+          pw->addPeak(*p5);
+          pw->addPeak(*p6);
+        }
+      }
+    }
+
+    AnalysisDataService::Instance().addOrReplace("peaks", pw);
+
+    IndexPeaks alg;
+    alg.initialize();
+    alg.setPropertyValue("PeaksWorkspace", "peaks");
+    alg.setProperty("RoundHKLs", false);
+    alg.setPropertyValue("ModVector1", "0.25,0,0");
+    alg.setProperty("MaxOrder", 1);
+    alg.execute();
+
+    // Check starting oriented lattice, mod vectors should be all 0
+    OrientedLattice latt = pw->mutableSample().getOrientedLattice();
+
+    V3D start_vec = latt.getModVec(0);
+    V3D start_err = latt.getVecErr(0);
+
+    for (size_t i = 0; i < 3; i++) {
+      TS_ASSERT_EQUALS(0, start_vec[i]);
+      TS_ASSERT_EQUALS(0, start_err[i]);
+    }
+
+    // Run with CommonUBForAll=False
+    FindUBUsingIndexedPeaks alg2;
+    TS_ASSERT_THROWS_NOTHING(alg2.initialize())
+    TS_ASSERT(alg2.isInitialized())
+    TS_ASSERT_THROWS_NOTHING(alg2.setPropertyValue("PeaksWorkspace", "peaks"));
+    TS_ASSERT_THROWS_NOTHING(alg2.execute(););
+    TS_ASSERT(alg2.isExecuted());
+
+    latt = pw->mutableSample().getOrientedLattice();
+    V3D correct_vec = V3D(0.251, 0, 0);
+    V3D correct_err = V3D(0.00026, 0, 0);
+
+    V3D current_vec = latt.getModVec(0);
+    V3D current_err = latt.getVecErr(0);
+
+    for (size_t i = 0; i < 3; i++) {
+      TS_ASSERT_DELTA(correct_vec[i], current_vec[i], 1e-5);
+      TS_ASSERT_DELTA(correct_err[i], current_err[i], 1e-5);
+    }
+
+    // Now with CommonUBForAll=True, should have same mod vectors but larger errors
+    TS_ASSERT_THROWS_NOTHING(alg2.setProperty("CommonUBForAll", true));
+    TS_ASSERT_THROWS_NOTHING(alg2.execute(););
+    TS_ASSERT(alg2.isExecuted());
+
+    latt = pw->mutableSample().getOrientedLattice();
+    correct_vec = V3D(0.251, 0, 0);
+    correct_err = V3D(0.00061, 0, 0);
+
+    current_vec = latt.getModVec(0);
+    current_err = latt.getVecErr(0);
+
+    for (size_t i = 0; i < 3; i++) {
+      TS_ASSERT_DELTA(correct_vec[i], current_vec[i], 1e-5);
+      TS_ASSERT_DELTA(correct_err[i], current_err[i], 1e-5);
     }
 
     // Remove workspace from the data service.

--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -656,8 +656,6 @@ constParameter:${CMAKE_SOURCE_DIR}/Framework/CurveFitting/src/RalNlls/TrustRegio
 constParameter:${CMAKE_SOURCE_DIR}/Framework/CurveFitting/src/RalNlls/TrustRegion.cpp:288
 useInitializationList:${CMAKE_SOURCE_DIR}/Framework/CurveFitting/src/SeqDomainSpectrumCreator.cpp:38
 passedByValue:${CMAKE_SOURCE_DIR}/Framework/Crystal/inc/MantidCrystal/FilterPeaks.h:85
-constParameter:${CMAKE_SOURCE_DIR}/Framework/Crystal/src/FindUBUsingIndexedPeaks.cpp:208
-constParameter:${CMAKE_SOURCE_DIR}/Framework/Crystal/src/FindUBUsingIndexedPeaks.cpp:208
 shadowFunction:${CMAKE_SOURCE_DIR}/Framework/Crystal/inc/MantidCrystal/IndexSXPeaks.h:104
 containerOutOfBounds:${CMAKE_SOURCE_DIR}/Framework/Crystal/src/IndexSXPeaks.cpp:210
 containerOutOfBounds:${CMAKE_SOURCE_DIR}/Framework/Crystal/src/IndexSXPeaks.cpp:218

--- a/docs/source/algorithms/FindUBUsingIndexedPeaks-v1.rst
+++ b/docs/source/algorithms/FindUBUsingIndexedPeaks-v1.rst
@@ -19,6 +19,10 @@ system of equations representing the mapping from (h,k,l) to Q for each
 indexed peak. The system of linear equations is then solved in the least
 squares sense, using QR factorization.
 
+The option ``CommonUBForAll`` only effects the calculation of the
+uncertainty in the modulation UB. If ``True`` the UB will be optimized
+separately for each subset of runs before calculating the error.
+
 Usage
 -----
 

--- a/docs/source/release/v6.3.0/diffraction.rst
+++ b/docs/source/release/v6.3.0/diffraction.rst
@@ -36,5 +36,6 @@ Single Crystal Diffraction
 --------------------------
 - Existing :ref:`PolDiffILLReduction <algm-PolDiffILLReduction>` and :ref:`D7AbsoluteCrossSections <algm-D7AbsoluteCrossSections>` can now reduce and properly normalise single-crystal data for the D7 ILL instrument.
 - Enabling :ref:`SCDCalibratePanels <algm-SCDCalibratePanels-v2>` to calibrate each detector bank's size if it is a rectagular detector optionally.
+- Fixed calculation of modulation vector uncertainty in :ref:`FindUBUsingIndexedPeaks <algm-FindUBUsingIndexedPeaks>`, new option ``CommonUBForAll`` allow selection of calculation handling multiple run the same as :ref:`IndexPeaks <algm-IndexPeaks>`.
 
 :ref:`Release 6.3.0 <v6.3.0>`


### PR DESCRIPTION
**Description of work.**

When running on a data set modulation vectors and multiple runs it was optimizing the UB separately for each run and only use the results of the last set as the final output. This fixes that and adds an option to change this behaviour when calculating the ErrorModHKL. See [SCD433](https://code.ornl.gov/sns-hfir-scse/diffraction/single-crystal/single-crystal-diffraction/-/issues/433)

**To test:**

Test file, run gunzip, [MnCoGeAS_90K_Niggli.integrate.gz](https://github.com/mantidproject/mantid/files/7520754/MnCoGeAS_90K_Niggli.integrate.gz)


Before this would fail but now should pass and have the correct final UB

```python
LoadIsawPeaks(Filename='/SNS/TOPAZ/IPTS-23996/shared/MnCoGeAS_90K/find_peaks_sat_q1_q2/MnCoGeAS_90K_Niggli.integrate', 
              OutputWorkspace='test_peaks')
FindUBUsingFFT(PeaksWorkspace='test_peaks', MinD=5, MaxD=7, Tolerance=0.10, Iterations=100)
IndexPeaks(PeaksWorkspace='test_peaks', Tolerance=0.08, ToleranceForSatellite=0.08, RoundHKLs=False)
SelectCellOfType(PeaksWorkspace='test_peaks', CellType='Hexagonal', Apply=True, TransformationMatrix='0,1,0,0,0,1,1,0,0')

IndexPeaks(PeaksWorkspace='test_peaks', Tolerance=0.08, ToleranceForSatellite=0.08, RoundHKLs=False)
FindUBUsingIndexedPeaks(PeaksWorkspace='test_peaks', Tolerance=0.082, ToleranceForSatellite=0.08)

IndexPeaks(PeaksWorkspace='test_peaks', Tolerance=0.08, ToleranceForSatellite=0.08, RoundHKLs=False, 
           ModVector1='0.12,0,0', MaxOrder=1, SaveModulationInfo=True)
FindUBUsingIndexedPeaks(PeaksWorkspace='test_peaks', Tolerance=0.08, ToleranceForSatellite=0.08)
IndexPeaks(PeaksWorkspace='test_peaks', Tolerance=0.08, ToleranceForSatellite=0.08, RoundHKLs=False, 
           ModVector1='0.12,0,0', ModVector2='0,0.12,0', MaxOrder=1, SaveModulationInfo=True)
FindUBUsingIndexedPeaks(PeaksWorkspace='test_peaks', Tolerance=0.08, ToleranceForSatellite=0.08)
```

then compare with `CommonUBForAll`

```python
FindUBUsingIndexedPeaks(PeaksWorkspace='test_peaks', Tolerance=0.08, ToleranceForSatellite=0.08, CommonUBForAll=True)
```


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
