### PR TITLE
Only build mantidqt tests if also building framework.

### DIFF
--- a/qt/scientific_interfaces/Direct/CMakeLists.txt
+++ b/qt/scientific_interfaces/Direct/CMakeLists.txt
@@ -26,5 +26,8 @@ mtd_add_qt_library(
   OSX_INSTALL_RPATH @loader_path/../../Contents/MacOS @loader_path/../../plugins/qt5
   LINUX_INSTALL_RPATH "\$ORIGIN/../../${LIB_DIR};\$ORIGIN/../../plugins/qt5/"
 )
-# Testing target
-add_subdirectory(test)
+# Testing target We can currently only include the tests if we are building the framework. This is bceause we depend on
+# a non-exported library of frameworks in the tests.
+if(MANTID_FRAMEWORK_LIB STREQUAL "BUILD")
+  add_subdirectory(test)
+endif()

--- a/qt/scientific_interfaces/ISISReflectometry/CMakeLists.txt
+++ b/qt/scientific_interfaces/ISISReflectometry/CMakeLists.txt
@@ -41,4 +41,6 @@ mtd_add_qt_library(
   LINUX_INSTALL_RPATH "\$ORIGIN/../../${LIB_DIR}"
 )
 
-add_subdirectory(test)
+if(MANTID_FRAMEWORK_LIB STREQUAL "BUILD")
+  add_subdirectory(test)
+endif()

--- a/qt/scientific_interfaces/Indirect/CMakeLists.txt
+++ b/qt/scientific_interfaces/Indirect/CMakeLists.txt
@@ -273,4 +273,6 @@ mtd_add_qt_library(
 )
 
 # Testing target
-add_subdirectory(test)
+if(MANTID_FRAMEWORK_LIB STREQUAL "BUILD")
+  add_subdirectory(test)
+endif()

--- a/qt/scientific_interfaces/Muon/CMakeLists.txt
+++ b/qt/scientific_interfaces/Muon/CMakeLists.txt
@@ -64,4 +64,6 @@ mtd_add_qt_library(
 )
 
 # Testing target
-add_subdirectory(test)
+if(MANTID_FRAMEWORK_LIB STREQUAL "BUILD")
+  add_subdirectory(test)
+endif()

--- a/qt/widgets/common/CMakeLists.txt
+++ b/qt/widgets/common/CMakeLists.txt
@@ -1016,21 +1016,21 @@ set(QT5_TEST_FILES
 if(NOT APPLE)
   list(APPEND QT5_TEST_FILES test/Python/SipTest.h)
 endif()
-
-mtd_add_qt_tests(
-  TARGET_NAME MantidQtWidgetsCommonTest
-  QT_VERSION 5
-  SRC ${QT5_TEST_FILES}
-  INCLUDE_DIRS ../../../Framework/DataObjects/inc ../../../Framework/Crystal/inc
-  LINK_LIBS ${TARGET_LIBRARIES}
-            ${Boost_LIBRARIES}
-            Mantid::PythonInterfaceCore
-            Mantid::DataObjects
-            gmock
-            Qt5::Test
-            Python::Python
-  MTD_QT_LINK_LIBS MantidQtWidgetsCommon
-  PARENT_DEPENDENCIES GUITests
-)
-
-add_framework_test_helpers(MantidQtWidgetsCommonTestQt5)
+if(MANTID_FRAMEWORK_LIB STREQUAL "BUILD")
+  mtd_add_qt_tests(
+    TARGET_NAME MantidQtWidgetsCommonTest
+    QT_VERSION 5
+    SRC ${QT5_TEST_FILES}
+    INCLUDE_DIRS ../../../Framework/DataObjects/inc ../../../Framework/Crystal/inc
+    LINK_LIBS ${TARGET_LIBRARIES}
+              ${Boost_LIBRARIES}
+              Mantid::PythonInterfaceCore
+              Mantid::DataObjects
+              gmock
+              Qt5::Test
+              Python::Python
+    MTD_QT_LINK_LIBS MantidQtWidgetsCommon
+    PARENT_DEPENDENCIES GUITests
+  )
+  add_framework_test_helpers(MantidQtWidgetsCommonTestQt5)
+endif()

--- a/qt/widgets/instrumentview/CMakeLists.txt
+++ b/qt/widgets/instrumentview/CMakeLists.txt
@@ -171,4 +171,7 @@ mtd_add_qt_library(
   LINUX_INSTALL_RPATH "\$ORIGIN/../${WORKBENCH_LIB_DIR}"
 )
 
-add_subdirectory(test)
+# Testing target
+if(MANTID_FRAMEWORK_LIB STREQUAL "BUILD")
+  add_subdirectory(test)
+endif()

--- a/qt/widgets/plotting/CMakeLists.txt
+++ b/qt/widgets/plotting/CMakeLists.txt
@@ -38,21 +38,23 @@ mtd_add_qt_library(
 set(TEST_FILES test/ContourPreviewPlotTest.h test/ExternalPlotterTest.h)
 
 set(CXXTEST_EXTRA_HEADER_INCLUDE "${CMAKE_CURRENT_LIST_DIR}/test/PlottingTestInitialization.h")
+# Testing target
+if(MANTID_FRAMEWORK_LIB STREQUAL "BUILD")
+  mtd_add_qt_tests(
+    TARGET_NAME MantidQtWidgetsPlottingTest
+    QT_VERSION 5
+    INCLUDE_DIRS inc ../common/inc ../../../Framework/DataObjects/inc
+    SRC ${TEST_FILES}
+    LINK_LIBS ${CORE_MANTIDLIBS}
+              Mantid::DataObjects
+              ${POCO_LIBRARIES}
+              ${Boost_LIBRARIES}
+              Mantid::PythonInterfaceCore
+              gmock
+              Python::Python
+    MTD_QT_LINK_LIBS MantidQtWidgetsCommon MantidQtWidgetsPlotting MantidQtWidgetsMplCpp
+    PARENT_DEPENDENCIES GUITests
+  )
 
-mtd_add_qt_tests(
-  TARGET_NAME MantidQtWidgetsPlottingTest
-  QT_VERSION 5
-  INCLUDE_DIRS inc ../common/inc ../../../Framework/DataObjects/inc
-  SRC ${TEST_FILES}
-  LINK_LIBS ${CORE_MANTIDLIBS}
-            Mantid::DataObjects
-            ${POCO_LIBRARIES}
-            ${Boost_LIBRARIES}
-            Mantid::PythonInterfaceCore
-            gmock
-            Python::Python
-  MTD_QT_LINK_LIBS MantidQtWidgetsCommon MantidQtWidgetsPlotting MantidQtWidgetsMplCpp
-  PARENT_DEPENDENCIES GUITests
-)
-
-add_framework_test_helpers(MantidQtWidgetsPlottingTestQt5)
+  add_framework_test_helpers(MantidQtWidgetsPlottingTestQt5)
+endif()


### PR DESCRIPTION
**Description of work.**
Mantidqt tests need the framework test helpers. These are not exported by CMake. So if we are using a system framework lib (as with a conda mantidqt build) we can't build the tests.

Long term we can add a mantidqt test helpers target. As it would never make sense to export the framework test helpers.


<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**
- Best to test the recipes at this PR https://github.com/mantidproject/conda-recipes/pull/58
- change the git tag of mantid_qt to this branch, i.e.
` git_tag: standalone_mantidqt`
It should work.

<!-- Instructions for testing. -->


*There is no associated issue.*


<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
