### PR TITLE
Correct Integration range in PDFFourierTransform2

### DIFF
--- a/Framework/Algorithms/inc/MantidAlgorithms/PDFFourierTransform2.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/PDFFourierTransform2.h
@@ -33,14 +33,16 @@ public:
   /// @copydoc Algorithm::validateInputs()
   std::map<std::string, std::string> validateInputs() override;
 
+protected:
+  size_t determineMinIndex(double min, const std::vector<double> &X, const std::vector<double> &Y);
+  size_t determineMaxIndex(double max, const std::vector<double> &X, const std::vector<double> &Y);
+
 private:
   /// Initialize the properties
   void init() override;
   /// Run the algorithm
   void exec() override;
 
-  size_t determineMinIndex(double min, const std::vector<double> &X, const std::vector<double> &Y);
-  size_t determineMaxIndex(double max, const std::vector<double> &X, const std::vector<double> &Y);
   double determineRho0();
   void convertToSQMinus1(std::vector<double> &FOfQ, std::vector<double> &Q, std::vector<double> &DFOfQ,
                          std::vector<double> &DQ);

--- a/Framework/Algorithms/inc/MantidAlgorithms/PDFFourierTransform2.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/PDFFourierTransform2.h
@@ -45,12 +45,12 @@ private:
 
   double determineRho0();
   void convertToSQMinus1(std::vector<double> &FOfQ, std::vector<double> &Q, std::vector<double> &DFOfQ,
-                         std::vector<double> &DQ);
-  void convertToLittleGRMinus1(std::vector<double> &FOfR, std::vector<double> &R, std::vector<double> &DFOfR,
-                               std::vector<double> &DR);
-  void convertFromSQMinus1(HistogramData::HistogramY &FOfQ, HistogramData::HistogramX &Q,
+                         const std::vector<double> &DQ);
+  void convertToLittleGRMinus1(std::vector<double> &FOfR, const std::vector<double> &R, std::vector<double> &DFOfR,
+                               const std::vector<double> &DR);
+  void convertFromSQMinus1(HistogramData::HistogramY &FOfQ, const HistogramData::HistogramX &Q,
                            HistogramData::HistogramE &DFOfQ);
-  void convertFromLittleGRMinus1(HistogramData::HistogramY &FOfR, HistogramData::HistogramX &R,
+  void convertFromLittleGRMinus1(HistogramData::HistogramY &FOfR, const HistogramData::HistogramX &R,
                                  HistogramData::HistogramE &DFOfR);
 };
 

--- a/Framework/Algorithms/src/PDFFourierTransform2.cpp
+++ b/Framework/Algorithms/src/PDFFourierTransform2.cpp
@@ -231,7 +231,7 @@ double PDFFourierTransform2::determineRho0() {
 }
 
 void PDFFourierTransform2::convertToSQMinus1(std::vector<double> &FOfQ, std::vector<double> &Q,
-                                             std::vector<double> &DFOfQ, std::vector<double> &DQ) {
+                                             std::vector<double> &DFOfQ, const std::vector<double> &DQ) {
   // convert to S(Q)-1
   string soqType = getProperty("SofQType");
   string inputSOQType = getProperty("InputSofQType");
@@ -264,8 +264,8 @@ void PDFFourierTransform2::convertToSQMinus1(std::vector<double> &FOfQ, std::vec
   return;
 }
 
-void PDFFourierTransform2::convertToLittleGRMinus1(std::vector<double> &FOfR, std::vector<double> &R,
-                                                   std::vector<double> &DFOfR, std::vector<double> &DR) {
+void PDFFourierTransform2::convertToLittleGRMinus1(std::vector<double> &FOfR, const std::vector<double> &R,
+                                                   std::vector<double> &DFOfR, const std::vector<double> &DR) {
   string PDFType = getProperty("PDFType");
   double rho0 = determineRho0();
   if (PDFType == LITTLE_G_OF_R) {
@@ -293,7 +293,7 @@ void PDFFourierTransform2::convertToLittleGRMinus1(std::vector<double> &FOfR, st
   return;
 }
 
-void PDFFourierTransform2::convertFromSQMinus1(HistogramData::HistogramY &FOfQ, HistogramData::HistogramX &Q,
+void PDFFourierTransform2::convertFromSQMinus1(HistogramData::HistogramY &FOfQ, const HistogramData::HistogramX &Q,
                                                HistogramData::HistogramE &DFOfQ) {
   // convert to S(Q)-1string
   string soqType = getProperty("SofQType");
@@ -316,7 +316,7 @@ void PDFFourierTransform2::convertFromSQMinus1(HistogramData::HistogramY &FOfQ, 
   return;
 }
 
-void PDFFourierTransform2::convertFromLittleGRMinus1(HistogramData::HistogramY &FOfR, HistogramData::HistogramX &R,
+void PDFFourierTransform2::convertFromLittleGRMinus1(HistogramData::HistogramY &FOfR, const HistogramData::HistogramX &R,
                                                      HistogramData::HistogramE &DFOfR) {
   // convert to the correct form of PDF
   double rho0 = determineRho0();

--- a/Framework/Algorithms/src/PDFFourierTransform2.cpp
+++ b/Framework/Algorithms/src/PDFFourierTransform2.cpp
@@ -200,8 +200,9 @@ size_t PDFFourierTransform2::determineMaxIndex(double max, const std::vector<dou
   auto iter = std::upper_bound(X.begin(), X.end(), max) - 1;
   size_t max_index = std::distance(X.begin(), iter);
 
-  // go to first non-nan value. This works for histogram (bin edge) data and
-  // also point data, where point integration ends at the Y value to the left of the max bound
+  // go to first non-nan value. This works for both histogram (bin edge) data and
+  // point data, as the integration proceeds by calculating rectangles between pairs of X values.
+  // For point data the Y value corresponding to the left of this pair is used in the nested for loop in the exec.
   auto back_iter = std::find_if(Y.rbegin(), Y.rend(), static_cast<bool (*)(double)>(std::isnormal));
   size_t first_normal_index = Y.size() - std::distance(Y.rbegin(), back_iter);
   if (first_normal_index < max_index) {
@@ -316,7 +317,8 @@ void PDFFourierTransform2::convertFromSQMinus1(HistogramData::HistogramY &FOfQ, 
   return;
 }
 
-void PDFFourierTransform2::convertFromLittleGRMinus1(HistogramData::HistogramY &FOfR, const HistogramData::HistogramX &R,
+void PDFFourierTransform2::convertFromLittleGRMinus1(HistogramData::HistogramY &FOfR,
+                                                     const HistogramData::HistogramX &R,
                                                      HistogramData::HistogramE &DFOfR) {
   // convert to the correct form of PDF
   double rho0 = determineRho0();

--- a/Framework/Algorithms/test/PDFFourierTransform2Test.h
+++ b/Framework/Algorithms/test/PDFFourierTransform2Test.h
@@ -26,6 +26,17 @@ using namespace Mantid::Algorithms;
 using namespace Mantid::Kernel;
 using namespace Mantid;
 
+// allow testing of protected methods
+class PDFFourierTransform2Wrapper : public PDFFourierTransform2 {
+public:
+  size_t determineMinIndex(double min, const std::vector<double> &X, const std::vector<double> &Y){
+    return PDFFourierTransform2::determineMinIndex(min, X, Y);
+  };
+  size_t determineMaxIndex(double max, const std::vector<double> &X, const std::vector<double> &Y){
+    return PDFFourierTransform2::determineMaxIndex(max, X, Y);
+  };
+};
+
 namespace {
 /**
  * Create Workspace from 0 to N*dx
@@ -211,6 +222,43 @@ public:
     TS_ASSERT_DELTA(SofQ[0], 5.1875, 0.0001);
     TS_ASSERT_DELTA(SofQ[249], 1.1068, 0.0001);
     TS_ASSERT_EQUALS(SofQUnit->caption(), "q");
+  }
+
+  void test_integration_range() {
+    std::vector<double> X;
+    std::vector<double> Y;
+
+    for (size_t i = 0; i < 100; i++) {
+      X.push_back(double(i) * 0.1);
+      Y.push_back(X[i] + 1.0);
+    }
+    X.push_back(double(100) * 0.1);
+    // For a distribution workspace, X.size() = Y.size() + 1
+    // This data has 100 bins and 101 bin edges
+
+    std::vector<double> badValuesY = Y;
+    badValuesY[0] = std::numeric_limits<double>::quiet_NaN();
+    badValuesY[badValuesY.size() - 1] = std::numeric_limits<double>::quiet_NaN();
+    PDFFourierTransform2Wrapper alg;
+    TS_ASSERT_EQUALS(alg.determineMinIndex(0.0, X, Y), 0);
+    TS_ASSERT_EQUALS(alg.determineMinIndex(1.0, X, Y), 10);
+    TS_ASSERT_EQUALS(alg.determineMinIndex(0.0, X, badValuesY), 1);
+    TS_ASSERT_EQUALS(alg.determineMinIndex(1.0, X, badValuesY), 10);
+
+    TS_ASSERT_EQUALS(alg.determineMaxIndex(5.0, X, Y), 50);
+    TS_ASSERT_EQUALS(alg.determineMaxIndex(20.0, X, Y), 100);
+    TS_ASSERT_EQUALS(alg.determineMaxIndex(5.0, X, badValuesY), 50);
+    TS_ASSERT_EQUALS(alg.determineMaxIndex(20.0, X, badValuesY), 99);
+
+    std::vector<double> endZeroValuesY = Y;
+    endZeroValuesY[0] = 0.0;
+    endZeroValuesY[1] = 0.0;
+    endZeroValuesY[2] = 0.0;
+    endZeroValuesY[97] = 0.0;
+    endZeroValuesY[98] = 0.0;
+    endZeroValuesY[99] = 0.0;
+    TS_ASSERT_EQUALS(alg.determineMinIndex(0.0, X, endZeroValuesY), 3);
+    TS_ASSERT_EQUALS(alg.determineMaxIndex(20.0, X, endZeroValuesY), 97);
   }
 };
 

--- a/Testing/SystemTests/tests/framework/ISIS_PowderPolarisTest.py
+++ b/Testing/SystemTests/tests/framework/ISIS_PowderPolarisTest.py
@@ -165,11 +165,11 @@ class TotalScatteringTest(systemtesting.MantidSystemTest):
         # Whilst total scattering is in development, the validation will avoid using reference files as they will have
         # to be updated very frequently. In the meantime, the expected peak in the PDF at ~3.9 Angstrom will be checked.
         # After rebin this is at X index 37
-        expected_peak_values = [0.0008175,
-                                0.2500,
-                                0.4410,
-                                0.2002,
-                                0.9767]
+        expected_peak_values = [-0.00092,
+                                0.24875,
+                                0.43894,
+                                0.20343,
+                                0.9777]
         for index, ws in enumerate(self.pdf_output):
             self.assertAlmostEqual(ws.dataY(0)[37], expected_peak_values[index], places=3)
 
@@ -189,7 +189,7 @@ class TotalScatteringMergedTest(systemtesting.MantidSystemTest):
         # Whilst total scattering is in development, the validation will avoid using reference files as they will have
         # to be updated very frequently. In the meantime, the expected peak in the PDF at ~3.9 Angstrom will be checked.
         # After rebin this is at X index 37
-        self.assertAlmostEqual(self.pdf_output.dataY(0)[37], 1.00480, places=3)
+        self.assertAlmostEqual(self.pdf_output.dataY(0)[37], 1.00835, places=3)
 
 
 class TotalScatteringPDFRebinTest(systemtesting.MantidSystemTest):
@@ -261,7 +261,7 @@ class TotalScatteringFilterTest(systemtesting.MantidSystemTest):
         # Whilst total scattering is in development, the validation will avoid using reference files as they will have
         # to be updated very frequently. In the meantime, the expected peak in the PDF at ~3.9 Angstrom will be checked.
         # After rebin this is at X index 37
-        self.assertAlmostEqual(self.pdf_output.dataY(0)[37], 0.90376, places=3)
+        self.assertAlmostEqual(self.pdf_output.dataY(0)[37], 0.90692, places=3)
 
 
 class TotalScatteringLorchFilterTest(systemtesting.MantidSystemTest):
@@ -279,7 +279,7 @@ class TotalScatteringLorchFilterTest(systemtesting.MantidSystemTest):
         # Whilst total scattering is in development, the validation will avoid using reference files as they will have
         # to be updated very frequently. In the meantime, the expected peak in the PDF at ~3.9 Angstrom will be checked.
         # After rebin this is at X index 37
-        self.assertAlmostEqual(self.pdf_output.dataY(0)[37], 6.9326, places=3)
+        self.assertAlmostEqual(self.pdf_output.dataY(0)[37], 6.93898, places=3)
 
 
 def run_total_scattering(run_number, merge_banks, q_lims=None, delta_q=None, delta_r=None, pdf_type="G(r)",

--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -552,11 +552,6 @@ useInitializationList:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/GravitySANSHe
 passedByValue:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/He3TubeEfficiency.cpp:289
 unreadVariable:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/IntegrateByComponent.cpp:192
 useStlAlgorithm:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/PDCalibration.cpp:1293
-constParameter:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/PDFFourierTransform2.cpp:234
-constParameter:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/PDFFourierTransform2.cpp:267
-constParameter:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/PDFFourierTransform2.cpp:268
-constParameter:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/PDFFourierTransform2.cpp:296
-constParameter:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/PDFFourierTransform2.cpp:319
 constParameter:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/PeakParameterHelper.cpp:102
 constStatement:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/PolarizationCorrectionWildes.cpp:96
 constStatement:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/PolarizationCorrectionWildes.cpp:101

--- a/docs/source/algorithms/CropWorkspaceRagged-v1.rst
+++ b/docs/source/algorithms/CropWorkspaceRagged-v1.rst
@@ -76,9 +76,9 @@ Output:
 
 .. testoutput:: RaggedWorkFlow
 
-    y values: 0.6285
-    y values: 0.6237
-    y values: 0.6486
+    y values: 0.6287
+    y values: 0.6235
+    y values: 0.6487
 
 .. categories::
 

--- a/docs/source/algorithms/PDFFourierTransform-v2.rst
+++ b/docs/source/algorithms/PDFFourierTransform-v2.rst
@@ -125,11 +125,12 @@ Usage
     import numpy as np;
     xx = np.array(range(0,100))*0.1
     yy = np.exp(-(2.0 * xx)**2)
+    yy = np.delete(yy,-1) # need one less Y value than X value for histogram data
     ws = CreateWorkspace(DataX=xx, DataY=yy, UnitX='MomentumTransfer')
-    Rt = PDFFourierTransform(ws, SofQType='S(Q)', PDFType='g(r)')
+    Rt = PDFFourierTransform(ws, SofQType='S(Q)-1', PDFType='g(r)')
 
     # Look at sample results:
-    print('part of S(Q) and its correlation function')
+    print('part of S(Q)-1 and its correlation function')
     for i in range(10):
        print('! {0:4.2f} ! {1:5f} ! {2:f} ! {3:5f} !'.format(xx[i], yy[i], Rt.readX(0)[i], Rt.readY(0)[i]))
 
@@ -143,17 +144,17 @@ Usage
 
 .. testoutput:: ExPDFFourierTransform
 
-   part of S(Q) and its correlation function
-   ! 0.00 ! 1.000000 ! 0.317333 ! -3.977042 !
-   ! 0.10 ! 0.960789 ! 0.634665 ! 2.248558 !
-   ! 0.20 ! 0.852144 ! 0.951998 ! 0.449916 !
-   ! 0.30 ! 0.697676 ! 1.269330 ! 1.314437 !
-   ! 0.40 ! 0.527292 ! 1.586663 ! 0.803744 !
-   ! 0.50 ! 0.367879 ! 1.903996 ! 1.141098 !
-   ! 0.60 ! 0.236928 ! 2.221328 ! 0.900872 !
-   ! 0.70 ! 0.140858 ! 2.538661 ! 1.080090 !
-   ! 0.80 ! 0.077305 ! 2.855993 ! 0.940530 !
-   ! 0.90 ! 0.039164 ! 3.173326 ! 1.051576 !
+   part of S(Q)-1 and its correlation function
+   ! 0.00 ! 1.000000 ! 0.317333 ! 1.003494 !
+   ! 0.10 ! 0.960789 ! 0.634665 ! 1.003423 !
+   ! 0.20 ! 0.852144 ! 0.951998 ! 1.003308 !
+   ! 0.30 ! 0.697676 ! 1.269330 ! 1.003154 !
+   ! 0.40 ! 0.527292 ! 1.586663 ! 1.002965 !
+   ! 0.50 ! 0.367879 ! 1.903996 ! 1.002750 !
+   ! 0.60 ! 0.236928 ! 2.221328 ! 1.002515 !
+   ! 0.70 ! 0.140858 ! 2.538661 ! 1.002269 !
+   ! 0.80 ! 0.077305 ! 2.855993 ! 1.002018 !
+   ! 0.90 ! 0.039164 ! 3.173326 ! 1.001770 !
 
 
 .. categories::

--- a/docs/source/release/v6.3.0/diffraction.rst
+++ b/docs/source/release/v6.3.0/diffraction.rst
@@ -37,6 +37,8 @@ Bugfixes
 - Restored behavior in :ref:`ConvertUnits <algm-ConvertUnits>` where negative time-of-flight converts to negative d-spacing when ``DIFA==0``
 - Identification in :ref:`AlignComponents <algm-AlignComponents>` of the first and last detector-ID for an instrument component with unsorted detector-ID's.
 - Fix issue in :ref:`WANDPowderReduction <algm-WANDPowderReduction>` where in some cases you end up with zeros as output.
+- The integration range has been corrected inside :ref:`PDFFourierTransform v2 <algm-PDFFourierTransform-v2>`.
+
 
 Engineering Diffraction
 -----------------------


### PR DESCRIPTION
**Description of work.**
The integration range in PDFFourierTransform was too narrow, so a few fixes have allowed the full valid range of data to be included.
- Fixed problem where first_normal_index would consider 0 as not a normal value (when we want to only ignore Nan/Inf values).
- Added test for protected functions for determining the min/max indexes
- Cppcheck suppressions removed


- Also at line 385 there's an odd commented out section: https://github.com/mantidproject/mantid/pull/32947/files#diff-035333f5620c218e00e51a6236d91a87b7427912b735a847ec6aa550cf168b1aL385-L396

**To test:**

- Debug with a break point on line 440 of PDFForuierTransform2.cpp
and run this doctest example to check the integration range is from 0 - 99 (the values of Xmin_index and XMax_index).

Doctest:
```
from mantid.simpleapi import *
import numpy as np;
xx = np.array(range(0,100))*0.1
yy = np.exp(-(2.0 * xx)**2)
yy = np.delete(yy,-1)
ws = CreateWorkspace(DataX=xx, DataY=yy, UnitX='MomentumTransfer')
Rt = PDFFourierTransform(ws, SofQType='S(Q)', PDFType='g(r)')
print(yy)
# Look at sample results:
print('part of S(Q)-1 and its correlation function')
for i in range(10):
   print('! {0:4.2f} ! {1:5f} ! {2:f} ! {3:5f} !'.format(xx[i], yy[i], Rt.readX(0)[i], Rt.readY(0)[i]))
```

- Review the new unit test.

Fixes #30606 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
