### PR TITLE
Change return type of onSurface

### DIFF
--- a/Framework/Geometry/inc/MantidGeometry/Surfaces/Cone.h
+++ b/Framework/Geometry/inc/MantidGeometry/Surfaces/Cone.h
@@ -50,8 +50,8 @@ public:
   /// Calculate if the point R is within the cone (return -1) or outside (return
   /// 1)
   int side(const Kernel::V3D &R) const override;
-  /// Calculate if the point R is on the cone(1=on the surface, 0=not)
-  int onSurface(const Kernel::V3D &R) const override;
+  /// Calculate if the point R is on the cone
+  bool onSurface(const Kernel::V3D &R) const override;
 
   /// Accept visitor for line calculation
   void acceptVisitor(BaseVisit &A) const override { A.Accept(*this); }

--- a/Framework/Geometry/inc/MantidGeometry/Surfaces/Cylinder.h
+++ b/Framework/Geometry/inc/MantidGeometry/Surfaces/Cylinder.h
@@ -65,7 +65,7 @@ public:
   virtual double lineIntersect(const Kernel::V3D &, const Kernel::V3D &) const;
 
   int side(const Kernel::V3D &) const override;
-  int onSurface(const Kernel::V3D &) const override;
+  bool onSurface(const Kernel::V3D &) const override;
   double distance(const Kernel::V3D &) const override;
 
   int setSurface(const std::string &) override;

--- a/Framework/Geometry/inc/MantidGeometry/Surfaces/Plane.h
+++ b/Framework/Geometry/inc/MantidGeometry/Surfaces/Plane.h
@@ -56,7 +56,7 @@ public:
   int setPlane(const Kernel::V3D &, const Kernel::V3D &);
   //  int setPlane(const std::string&);
   int side(const Kernel::V3D &) const override;
-  int onSurface(const Kernel::V3D &) const override;
+  bool onSurface(const Kernel::V3D &) const override;
   // stuff for finding intersections etc.
   double dotProd(const Plane &) const;                 ///< returns normal dot product
   Kernel::V3D crossProd(const Plane &) const;          ///< returns normal cross product

--- a/Framework/Geometry/inc/MantidGeometry/Surfaces/Quadratic.h
+++ b/Framework/Geometry/inc/MantidGeometry/Surfaces/Quadratic.h
@@ -55,7 +55,7 @@ public:
   virtual void setBaseEqn() = 0; ///< Abstract set baseEqn
   double eqnValue(const Kernel::V3D &) const;
 
-  int onSurface(const Kernel::V3D &) const override;             ///< is point valid on surface
+  bool onSurface(const Kernel::V3D &) const override;            ///< is point valid on surface
   double distance(const Kernel::V3D &) const override;           ///< distance between point and surface (approx)
   Kernel::V3D surfaceNormal(const Kernel::V3D &) const override; ///< Normal at surface
 

--- a/Framework/Geometry/inc/MantidGeometry/Surfaces/Sphere.h
+++ b/Framework/Geometry/inc/MantidGeometry/Surfaces/Sphere.h
@@ -54,7 +54,7 @@ public:
   /// sphere
   int side(const Kernel::V3D &) const override;
   /// Checks whether the give input point is on the surface
-  int onSurface(const Kernel::V3D &) const override;
+  bool onSurface(const Kernel::V3D &) const override;
   /// Gets the distance from the sphere to the input point
   double distance(const Kernel::V3D &) const override;
   /// Setter for centre of sphere

--- a/Framework/Geometry/inc/MantidGeometry/Surfaces/Surface.h
+++ b/Framework/Geometry/inc/MantidGeometry/Surfaces/Surface.h
@@ -60,7 +60,7 @@ public:
   virtual int side(const Kernel::V3D &) const;
 
   /// is point valid on surface
-  virtual int onSurface(const Kernel::V3D &R) const = 0;
+  virtual bool onSurface(const Kernel::V3D &R) const = 0;
 
   /// returns the minimum distance to the surface
   virtual double distance(const Kernel::V3D &) const = 0;

--- a/Framework/Geometry/inc/MantidGeometry/Surfaces/Torus.h
+++ b/Framework/Geometry/inc/MantidGeometry/Surfaces/Torus.h
@@ -56,7 +56,7 @@ public:
 
   int setSurface(const std::string &Pstr) override;
   int side(const Kernel::V3D &R) const override;
-  int onSurface(const Kernel::V3D &R) const override;
+  bool onSurface(const Kernel::V3D &R) const override;
   double distance(const Kernel::V3D &Pt) const override;
 
   /// Return centre point

--- a/Framework/Geometry/src/Surfaces/Cone.cpp
+++ b/Framework/Geometry/src/Surfaces/Cone.cpp
@@ -278,16 +278,15 @@ int Cone::side(const Kernel::V3D &R) const {
  since angle calcuation calcuates an angle.
  We need a distance for tolerance!)
  @param R :: Point to check
- @return 1 if on surface and 0 if not not on surface
  */
-int Cone::onSurface(const Kernel::V3D &R) const {
+bool Cone::onSurface(const Kernel::V3D &R) const {
 
   const Kernel::V3D cR = R - Centre;
   double rptAngle = cR.scalar_prod(Normal);
   rptAngle *= rptAngle / cR.scalar_prod(cR);
   const double eqn(sqrt(rptAngle));
 
-  return (std::abs(eqn - cangle) > Tolerance) ? 0 : 1;
+  return (std::abs(eqn - cangle) <= Tolerance);
 }
 
 void Cone::write(std::ostream &OX) const

--- a/Framework/Geometry/src/Surfaces/Cylinder.cpp
+++ b/Framework/Geometry/src/Surfaces/Cylinder.cpp
@@ -146,12 +146,10 @@ int Cylinder::side(const Kernel::V3D &Pt) const
   return Quadratic::side(Pt);
 }
 
-int Cylinder::onSurface(const Kernel::V3D &Pt) const
+bool Cylinder::onSurface(const Kernel::V3D &Pt) const
 /**
  Calculate if the point PT on the cylinder
  @param Pt :: Kernel::V3D to test
- @retval 1 :: on the surface
- @retval 0 :: not on the surface
  */
 {
   if (m_normVec > 0) // m_normVec =1-3 (point to exclude == m_normVec-1)
@@ -160,7 +158,7 @@ int Cylinder::onSurface(const Kernel::V3D &Pt) const
     x *= x;
     double y = Pt[(m_normVec + 1) % 3] - m_centre[(m_normVec + 1) % 3];
     y *= y;
-    return (std::abs((x + y) - m_radius * m_radius) > Tolerance) ? 0 : 1;
+    return (std::abs((x + y) - m_radius * m_radius) <= Tolerance);
   }
   return Quadratic::onSurface(Pt);
 }

--- a/Framework/Geometry/src/Surfaces/Plane.cpp
+++ b/Framework/Geometry/src/Surfaces/Plane.cpp
@@ -216,17 +216,14 @@ int Plane::side(const Kernel::V3D &A) const
   return 0;
 }
 
-int Plane::onSurface(const Kernel::V3D &A) const
+bool Plane::onSurface(const Kernel::V3D &A) const
 /**
    Calcuate the side that the point is on
    and returns success if it is on the surface.
    - Uses getSurfaceTolerance to determine the closeness
-   @retval 1 if on the surface
-   @retval 0 if off the surface
-
 */
 {
-  return (side(A) != 0) ? 0 : 1;
+  return (side(A) == 0);
 }
 
 void Plane::print() const

--- a/Framework/Geometry/src/Surfaces/Quadratic.cpp
+++ b/Framework/Geometry/src/Surfaces/Quadratic.cpp
@@ -230,7 +230,7 @@ double Quadratic::distance(const Kernel::V3D &Pt) const
   return Out;
 }
 
-int Quadratic::onSurface(const Kernel::V3D &Pt) const
+bool Quadratic::onSurface(const Kernel::V3D &Pt) const
 /**
   Test to see if a point is on the surface
   @param Pt :: Point to test
@@ -238,7 +238,7 @@ int Quadratic::onSurface(const Kernel::V3D &Pt) const
 */
 {
   const double res = eqnValue(Pt);
-  return (std::abs(res) > Tolerance) ? 0 : 1;
+  return (std::abs(res) <= Tolerance);
 }
 
 void Quadratic::displace(const Kernel::V3D &Pt)

--- a/Framework/Geometry/src/Surfaces/Sphere.cpp
+++ b/Framework/Geometry/src/Surfaces/Sphere.cpp
@@ -125,14 +125,8 @@ int Sphere::side(const Kernel::V3D &Pt) const
  * Calculate if the point Pt on the surface of the sphere
  * (within tolerance CTolerance)
  * @param Pt :: Point to check
- * @return 1 :: on the surfacae or 0 if not.
  */
-int Sphere::onSurface(const Kernel::V3D &Pt) const {
-  if (distance(Pt) > Tolerance) {
-    return 0;
-  }
-  return 1;
-}
+bool Sphere::onSurface(const Kernel::V3D &Pt) const { return (distance(Pt) <= Tolerance); }
 
 /**
  * Determine the shortest distance from the Surface

--- a/Framework/Geometry/src/Surfaces/Torus.cpp
+++ b/Framework/Geometry/src/Surfaces/Torus.cpp
@@ -250,17 +250,21 @@ int Torus::side(const Kernel::V3D &R) const
   return -1;
 }
 
-int Torus::onSurface(const Kernel::V3D &R) const {
+bool Torus::onSurface(const Kernel::V3D &R) const {
   /**
      Calculate if the point R is on
      the cone (Note: have to be careful here
      since angle calcuation calcuates an angle.
      We need a distance for tolerance!)
      @param R :: Point to check
-     @return 1 if on surface and -1 if not no surface
   */
   UNUSED_ARG(R);
-  return -1;
+  // was formerly alwasy returning -1 which bool(-1) == true
+  // which appears to be an accidental bug
+
+  // the previous doxygen comment was
+  // return 1 if on surface and -1 if not no surface
+  return false;
 }
 
 void Torus::write(std::ostream &OX) const

--- a/Framework/Geometry/test/ConeTest.h
+++ b/Framework/Geometry/test/ConeTest.h
@@ -82,24 +82,24 @@ public:
 
     double val = 0.1 * M_SQRT1_2;
     // Point outside Cone
-    TS_ASSERT_EQUALS(A.onSurface(V3D(0.1, 0.0, 0.0)), 0);
-    TS_ASSERT_EQUALS(A.onSurface(V3D(0.1, val - 0.1, val - 0.1)), 0);
-    TS_ASSERT_EQUALS(A.onSurface(V3D(0.1, val - 0.1, val)), 0);
-    TS_ASSERT_EQUALS(A.onSurface(V3D(0.1, val, val - 0.1)), 0);
+    TS_ASSERT(!A.onSurface(V3D(0.1, 0.0, 0.0)));
+    TS_ASSERT(!A.onSurface(V3D(0.1, val - 0.1, val - 0.1)));
+    TS_ASSERT(!A.onSurface(V3D(0.1, val - 0.1, val)));
+    TS_ASSERT(!A.onSurface(V3D(0.1, val, val - 0.1)));
     // Point on the Cone
-    TS_ASSERT_EQUALS(A.onSurface(V3D(0.1, val, val)), 1);
+    TS_ASSERT(A.onSurface(V3D(0.1, val, val)));
     // tolerance at default 1e-6
-    TS_ASSERT_EQUALS(A.onSurface(V3D(0.1, val + 1e-7, val + 1e-7)), 1);
-    TS_ASSERT_EQUALS(A.onSurface(V3D(0.1, val + 2e-6, val + 2e-6)), 0);
-    TS_ASSERT_EQUALS(A.onSurface(V3D(0.1, val - 1e-7, val - 1e-7)), 1);
-    TS_ASSERT_EQUALS(A.onSurface(V3D(0.1, val - 2e-6, val - 2e-6)), 0);
+    TS_ASSERT(A.onSurface(V3D(0.1, val + 1e-7, val + 1e-7)));
+    TS_ASSERT(!A.onSurface(V3D(0.1, val + 2e-6, val + 2e-6)));
+    TS_ASSERT(A.onSurface(V3D(0.1, val - 1e-7, val - 1e-7)));
+    TS_ASSERT(!A.onSurface(V3D(0.1, val - 2e-6, val - 2e-6)));
     // Point inside the cone
-    TS_ASSERT_EQUALS(A.onSurface(V3D(0.1, val + 0.001, val + 0.001)), 0);
-    TS_ASSERT_EQUALS(A.onSurface(V3D(0.1, val + 0.001, val)), 0);
-    TS_ASSERT_EQUALS(A.onSurface(V3D(0.1, val, val + 0.001)), 0);
-    TS_ASSERT_EQUALS(A.onSurface(V3D(0, 0, 2)), 0);
-    TS_ASSERT_EQUALS(A.onSurface(V3D(10, 10, 1)), 0);
-    TS_ASSERT_EQUALS(A.onSurface(V3D(10, 10, 4.9)), 0);
+    TS_ASSERT(!A.onSurface(V3D(0.1, val + 0.001, val + 0.001)));
+    TS_ASSERT(!A.onSurface(V3D(0.1, val + 0.001, val)));
+    TS_ASSERT(!A.onSurface(V3D(0.1, val, val + 0.001)));
+    TS_ASSERT(!A.onSurface(V3D(0, 0, 2)));
+    TS_ASSERT(!A.onSurface(V3D(10, 10, 1)));
+    TS_ASSERT(!A.onSurface(V3D(10, 10, 4.9)));
   }
 
   void testDistance() {

--- a/Framework/Geometry/test/CylinderTest.h
+++ b/Framework/Geometry/test/CylinderTest.h
@@ -95,36 +95,36 @@ public:
     TS_ASSERT_EQUALS(extractString(A), "-1 cx 2\n");
 
     // inside
-    TS_ASSERT_EQUALS(A.onSurface(V3D(0, 0, 0)), 0);
-    TS_ASSERT_EQUALS(A.onSurface(V3D(1.9, 0, 0)), 0);
-    TS_ASSERT_EQUALS(A.onSurface(V3D(0, 1.9, 0)), 0);
-    TS_ASSERT_EQUALS(A.onSurface(V3D(0, 0, 1.9)), 0);
-    TS_ASSERT_EQUALS(A.onSurface(V3D(0, 0, -1.9)), 0);
-    TS_ASSERT_EQUALS(A.onSurface(V3D(-1.9, 0, 0)), 0);
-    TS_ASSERT_EQUALS(A.onSurface(V3D(0, -1.9, 0)), 0);
+    TS_ASSERT(!A.onSurface(V3D(0, 0, 0)));
+    TS_ASSERT(!A.onSurface(V3D(1.9, 0, 0)));
+    TS_ASSERT(!A.onSurface(V3D(0, 1.9, 0)));
+    TS_ASSERT(!A.onSurface(V3D(0, 0, 1.9)));
+    TS_ASSERT(!A.onSurface(V3D(0, 0, -1.9)));
+    TS_ASSERT(!A.onSurface(V3D(-1.9, 0, 0)));
+    TS_ASSERT(!A.onSurface(V3D(0, -1.9, 0)));
 
     // all these are inoside - infinite Cylinder on x
-    TS_ASSERT_EQUALS(A.onSurface(V3D(2, 0, 0)), 0);
-    TS_ASSERT_EQUALS(A.onSurface(V3D(-2, 0, 0)), 0);
-    TS_ASSERT_EQUALS(A.onSurface(V3D(2.1, 0, 0)), 0);
-    TS_ASSERT_EQUALS(A.onSurface(V3D(-2.1, 0, 0)), 0);
+    TS_ASSERT(!A.onSurface(V3D(2, 0, 0)));
+    TS_ASSERT(!A.onSurface(V3D(-2, 0, 0)));
+    TS_ASSERT(!A.onSurface(V3D(2.1, 0, 0)));
+    TS_ASSERT(!A.onSurface(V3D(-2.1, 0, 0)));
 
     // should be on the surface
-    TS_ASSERT_EQUALS(A.onSurface(V3D(0, 2, 0)), 1);
-    TS_ASSERT_EQUALS(A.onSurface(V3D(0, 0, 2)), 1);
-    TS_ASSERT_EQUALS(A.onSurface(V3D(0, 0, -2)), 1);
-    TS_ASSERT_EQUALS(A.onSurface(V3D(0, -2, 0)), 1);
+    TS_ASSERT(A.onSurface(V3D(0, 2, 0)));
+    TS_ASSERT(A.onSurface(V3D(0, 0, 2)));
+    TS_ASSERT(A.onSurface(V3D(0, 0, -2)));
+    TS_ASSERT(A.onSurface(V3D(0, -2, 0)));
     // test tolerance at default 1e-6
-    TS_ASSERT_EQUALS(A.onSurface(V3D(0, -2 + 1e-7, 0)), 1);
-    TS_ASSERT_EQUALS(A.onSurface(V3D(0, -2 - 1e-7, 0)), 1);
-    TS_ASSERT_EQUALS(A.onSurface(V3D(0, -2 - 2e-6, 0)), 0);
-    TS_ASSERT_EQUALS(A.onSurface(V3D(0, -2 + 2e-6, 0)), 0);
+    TS_ASSERT(A.onSurface(V3D(0, -2 + 1e-7, 0)));
+    TS_ASSERT(A.onSurface(V3D(0, -2 - 1e-7, 0)));
+    TS_ASSERT(!A.onSurface(V3D(0, -2 - 2e-6, 0)));
+    TS_ASSERT(!A.onSurface(V3D(0, -2 + 2e-6, 0)));
     // should be outside
-    TS_ASSERT_EQUALS(A.onSurface(V3D(0, 2.1, 0)), 0);
-    TS_ASSERT_EQUALS(A.onSurface(V3D(0, 0, 2.1)), 0);
-    TS_ASSERT_EQUALS(A.onSurface(V3D(0, -2.1, 0)), 0);
-    TS_ASSERT_EQUALS(A.onSurface(V3D(0, 0, -2.1)), 0);
-    TS_ASSERT_EQUALS(A.onSurface(V3D(0, 0.1, 2)), 0);
+    TS_ASSERT(!A.onSurface(V3D(0, 2.1, 0)));
+    TS_ASSERT(!A.onSurface(V3D(0, 0, 2.1)));
+    TS_ASSERT(!A.onSurface(V3D(0, -2.1, 0)));
+    TS_ASSERT(!A.onSurface(V3D(0, 0, -2.1)));
+    TS_ASSERT(!A.onSurface(V3D(0, 0.1, 2)));
   }
 
   void testCylinderDistance() {

--- a/Framework/Geometry/test/PlaneTest.h
+++ b/Framework/Geometry/test/PlaneTest.h
@@ -75,21 +75,21 @@ public:
     TS_ASSERT_EQUALS(extractString(A), "-1 pz 5\n");
 
     // Point outside plane on the same side of the normal
-    TS_ASSERT_EQUALS(A.onSurface(V3D(0, 0, 6)), 0);
-    TS_ASSERT_EQUALS(A.onSurface(V3D(10, 10, 8)), 0);
-    TS_ASSERT_EQUALS(A.onSurface(V3D(10, 10, 5.1)), 0);
+    TS_ASSERT(!A.onSurface(V3D(0, 0, 6)));
+    TS_ASSERT(!A.onSurface(V3D(10, 10, 8)));
+    TS_ASSERT(!A.onSurface(V3D(10, 10, 5.1)));
     // Point on the plane
-    TS_ASSERT_EQUALS(A.onSurface(V3D(0, 0, 5)), 1);
-    TS_ASSERT_EQUALS(A.onSurface(V3D(10, 10, 5)), 1);
+    TS_ASSERT(A.onSurface(V3D(0, 0, 5)));
+    TS_ASSERT(A.onSurface(V3D(10, 10, 5)));
     // test tolerance default 1e-6
-    TS_ASSERT_EQUALS(A.onSurface(V3D(10, 10, 5 + 1e-7)), 1);
-    TS_ASSERT_EQUALS(A.onSurface(V3D(10, 10, 5 + 2e-6)), 0);
-    TS_ASSERT_EQUALS(A.onSurface(V3D(10, 10, 5 - 1e-7)), 1);
-    TS_ASSERT_EQUALS(A.onSurface(V3D(10, 10, 5 - 2e-6)), 0);
+    TS_ASSERT(A.onSurface(V3D(10, 10, 5 + 1e-7)));
+    TS_ASSERT(!A.onSurface(V3D(10, 10, 5 + 2e-6)));
+    TS_ASSERT(A.onSurface(V3D(10, 10, 5 - 1e-7)));
+    TS_ASSERT(!A.onSurface(V3D(10, 10, 5 - 2e-6)));
     // Point on flip side of the plane
-    TS_ASSERT_EQUALS(A.onSurface(V3D(0, 0, 2)), 0);
-    TS_ASSERT_EQUALS(A.onSurface(V3D(10, 10, 1)), 0);
-    TS_ASSERT_EQUALS(A.onSurface(V3D(10, 10, 4.9)), 0);
+    TS_ASSERT(!A.onSurface(V3D(0, 0, 2)));
+    TS_ASSERT(!A.onSurface(V3D(10, 10, 1)));
+    TS_ASSERT(!A.onSurface(V3D(10, 10, 4.9)));
   }
 
   void testDotProduct() {

--- a/Framework/Geometry/test/SphereTest.h
+++ b/Framework/Geometry/test/SphereTest.h
@@ -106,37 +106,38 @@ public:
     A.setSurface("so 2");
     TS_ASSERT_EQUALS(extractString(A), "-1 so 2\n");
 
-    // Origin should be inonSurface
-    TS_ASSERT_EQUALS(A.onSurface(V3D(0, 0, 0)), 0);
-    TS_ASSERT_EQUALS(A.onSurface(V3D(1.9, 0, 0)), 0);
-    TS_ASSERT_EQUALS(A.onSurface(V3D(0, 1.9, 0)), 0);
-    TS_ASSERT_EQUALS(A.onSurface(V3D(0, 0, 1.9)), 0);
-    TS_ASSERT_EQUALS(A.onSurface(V3D(0, 0, -1.9)), 0);
-    TS_ASSERT_EQUALS(A.onSurface(V3D(-1.9, 0, 0)), 0);
-    TS_ASSERT_EQUALS(A.onSurface(V3D(0, -1.9, 0)), 0);
+    // Origin should not be on the surface
+    TS_ASSERT(!A.onSurface(V3D(0, 0, 0)));
+    TS_ASSERT(!A.onSurface(V3D(0, 0, 0)));
+    TS_ASSERT(!A.onSurface(V3D(1.9, 0, 0)));
+    TS_ASSERT(!A.onSurface(V3D(0, 1.9, 0)));
+    TS_ASSERT(!A.onSurface(V3D(0, 0, 1.9)));
+    TS_ASSERT(!A.onSurface(V3D(0, 0, -1.9)));
+    TS_ASSERT(!A.onSurface(V3D(-1.9, 0, 0)));
+    TS_ASSERT(!A.onSurface(V3D(0, -1.9, 0)));
 
-    // should be on the onSurface
-    TS_ASSERT_EQUALS(A.onSurface(V3D(2, 0, 0)), 1);
-    TS_ASSERT_EQUALS(A.onSurface(V3D(0, 2, 0)), 1);
-    TS_ASSERT_EQUALS(A.onSurface(V3D(0, 0, 2)), 1);
-    TS_ASSERT_EQUALS(A.onSurface(V3D(0, 0, -2)), 1);
-    TS_ASSERT_EQUALS(A.onSurface(V3D(-2, 0, 0)), 1);
-    TS_ASSERT_EQUALS(A.onSurface(V3D(0, -2, 0)), 1);
+    // should be on the surface
+    TS_ASSERT(A.onSurface(V3D(2, 0, 0)));
+    TS_ASSERT(A.onSurface(V3D(0, 2, 0)));
+    TS_ASSERT(A.onSurface(V3D(0, 0, 2)));
+    TS_ASSERT(A.onSurface(V3D(0, 0, -2)));
+    TS_ASSERT(A.onSurface(V3D(-2, 0, 0)));
+    TS_ASSERT(A.onSurface(V3D(0, -2, 0)));
     // test tolerance at default 1e-6
-    TS_ASSERT_EQUALS(A.onSurface(V3D(0, -2 + 1e-7, 0)), 1);
-    TS_ASSERT_EQUALS(A.onSurface(V3D(0, -2 - 1e-7, 0)), 1);
-    TS_ASSERT_EQUALS(A.onSurface(V3D(0, -2 - 2e-6, 0)), 0);
-    TS_ASSERT_EQUALS(A.onSurface(V3D(0, -2 + 2e-6, 0)), 0);
-    // should be outonSurface
-    TS_ASSERT_EQUALS(A.onSurface(V3D(2.1, 0, 0)), 0);
-    TS_ASSERT_EQUALS(A.onSurface(V3D(0, 2.1, 0)), 0);
-    TS_ASSERT_EQUALS(A.onSurface(V3D(0, 0, 2.1)), 0);
-    TS_ASSERT_EQUALS(A.onSurface(V3D(-2.1, 0, 0)), 0);
-    TS_ASSERT_EQUALS(A.onSurface(V3D(0, -2.1, 0)), 0);
-    TS_ASSERT_EQUALS(A.onSurface(V3D(0, 0, -2.1)), 0);
-    TS_ASSERT_EQUALS(A.onSurface(V3D(2, 0.1, 0)), 0);
-    TS_ASSERT_EQUALS(A.onSurface(V3D(0.1, 2, 0)), 0);
-    TS_ASSERT_EQUALS(A.onSurface(V3D(0, 0.1, 2)), 0);
+    TS_ASSERT(A.onSurface(V3D(0, -2 + 1e-7, 0)));
+    TS_ASSERT(A.onSurface(V3D(0, -2 - 1e-7, 0)));
+    TS_ASSERT(!A.onSurface(V3D(0, -2 - 2e-6, 0)));
+    TS_ASSERT(!A.onSurface(V3D(0, -2 + 2e-6, 0)));
+    // should not be on the surface
+    TS_ASSERT(!A.onSurface(V3D(2.1, 0, 0)));
+    TS_ASSERT(!A.onSurface(V3D(0, 2.1, 0)));
+    TS_ASSERT(!A.onSurface(V3D(0, 0, 2.1)));
+    TS_ASSERT(!A.onSurface(V3D(-2.1, 0, 0)));
+    TS_ASSERT(!A.onSurface(V3D(0, -2.1, 0)));
+    TS_ASSERT(!A.onSurface(V3D(0, 0, -2.1)));
+    TS_ASSERT(!A.onSurface(V3D(2, 0.1, 0)));
+    TS_ASSERT(!A.onSurface(V3D(0.1, 2, 0)));
+    TS_ASSERT(!A.onSurface(V3D(0, 0.1, 2)));
   }
 
   void testSphereDistance() {


### PR DESCRIPTION
Previously it returned 0 for "no" and 1 for "yes." Since this is very much what a `bool` is, just change to the language native object. The only exception was `Torus::onSurface` which was hard coded to always return -1. This would be interpreted as "true," but the comments in the code suggest that it was meant to always return false.

The only place this method is called, other than in tests, is in `bool CSGObject::isOnSide(const & V3D)`.

**To test:**

This is best verified by a code review. Since it is a refactor, all the tests should still pass.

*There is no associated issue.*

*This does not require release notes* because it is an internal refactor of the code that preserves behavior.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
