### PR TITLE
add log for run_start and _end in seconds to model fitting

### DIFF
--- a/docs/source/release/v6.3.0/muon.rst
+++ b/docs/source/release/v6.3.0/muon.rst
@@ -97,5 +97,6 @@ Improvements
   ########
   - A bug has been fixed that caused Model fitting to not update it's results table list.
   - Plotting in Model fitting now features a greater number of units for parameters and sample logs.
+  - The dates and times for relevant parameters in model fitting have been formatted so that they can be plotted with relative spacing.
 
 

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/contexts/fitting_contexts/model_fitting_context.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/contexts/fitting_contexts/model_fitting_context.py
@@ -12,6 +12,8 @@ PARAMETERUNITS = {
     'Frequency': ['MHz', 'MHz'],
     'Lambda': [r'\mu s^{-1}', r'$\mu$ $s^{-1}$'],
     'Phi': ['Radians', 'Radians'],
+    'run_start_seconds': ['s', 's'],
+    'run_end_seconds': ['s', 's'],
     'sample_magn_field': ['G', 'G'],
     'sample_temp': ['K', 'K'],
     'Sigma': [r'\mu s^{-1}', r'$\mu$ $s^{-1}$']

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/fitting_widgets/model_fitting/model_fitting_model.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/fitting_widgets/model_fitting/model_fitting_model.py
@@ -140,8 +140,13 @@ class ModelFittingModel(BasicFittingModel):
     def _save_values_from_table_column(self, column_name: str, values: list, type: int) -> None:
         """Saves the values from a results table column in the correct location based on the column name."""
         if "Error" not in column_name:
-            self.fitting_context.x_parameters[column_name] = [values, type]
-            self.fitting_context.y_parameters[column_name] = [values, type]
+            if column_name in ['run_start_seconds', 'run_end_seconds']:
+                values = [value-values[0] for value in values]
+                self.fitting_context.x_parameters[column_name] = [values, type]
+                self.fitting_context.y_parameters[column_name] = [values, type]
+            else:
+                self.fitting_context.x_parameters[column_name] = [values, type]
+                self.fitting_context.y_parameters[column_name] = [values, type]
         else:
             self.fitting_context.x_parameter_errors[column_name.replace("Error", "")] = values
             self.fitting_context.y_parameter_errors[column_name.replace("Error", "")] = values

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/results_tab_widget/results_tab_model.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/results_tab_widget/results_tab_model.py
@@ -5,6 +5,7 @@
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
 #  This file is part of the mantid workbench.
+from datetime import datetime
 from mantid.api import AnalysisDataService as ads, WorkspaceFactory
 from mantid.kernel import FloatTimeSeriesProperty
 from enum import Enum
@@ -159,6 +160,11 @@ class ResultsTabModel(object):
         :param log_selection: The current selection of logs as a list of names
         :return: The updated row values dict
         """
+        def format_values_for_time_parameters(value: str) -> str:
+            value = value.split(' to')[0]
+            val = datetime.strptime(value, '%Y-%m-%dT%H:%M:%S')
+            return (val - datetime(1970, 1, 1)).total_seconds()
+
         if not log_selection:
             return row_dict
 
@@ -167,7 +173,8 @@ class ResultsTabModel(object):
             row_dict.update({log_name: values[0]})
             if values[1]!="":
                 row_dict.update({_error_column_name(log_name): values[1]})
-
+            if log_name in ['run_start', 'run_end']:
+                row_dict.update({log_name+'_seconds': format_values_for_time_parameters(fit.log_value(log_name))})
         return row_dict
 
     def _add_parameters_to_table(self, row_dict, fit_parameters):
@@ -269,12 +276,16 @@ class ResultsTabModel(object):
 
         for log_name in log_selection:
             wksp_name = all_fits[0].input_workspaces[0]
-            if float_log(wksp_name, log_name):
-                table.addColumn('float', log_name, TableColumnType.X.value)
-                # only add the errors column if the value is numerical
-                table.addColumn('float', _error_column_name(log_name), TableColumnType.XErr.value)
-            else:
+            if log_name in ['run_start', 'run_end']:
                 table.addColumn('str', log_name, TableColumnType.X.value)
+                table.addColumn('float', log_name+'_seconds', TableColumnType.X.value)
+            else:
+                if float_log(wksp_name, log_name):
+                    table.addColumn('float', log_name, TableColumnType.X.value)
+                    # only add the errors column if the value is numerical
+                    table.addColumn('float', _error_column_name(log_name), TableColumnType.XErr.value)
+                else:
+                    table.addColumn('str', log_name, TableColumnType.X.value)
         # assume all fit functions are the same in fit_selection and take
         # the parameter names from the first fit.
         parameters = self._find_parameters_for_table(results_selection)

--- a/qt/python/mantidqtinterfaces/test/Muon/results_tab_widget/results_tab_model_test.py
+++ b/qt/python/mantidqtinterfaces/test/Muon/results_tab_widget/results_tab_model_test.py
@@ -137,7 +137,7 @@ class ResultsTabModelTest(unittest.TestCase):
                                        ('Cost function value',
                                         self.cost_function)])
 
-        self.log_names = ['sample_temp', 'sample_magn_field']
+        self.log_names = ['run_start', 'sample_temp', 'sample_magn_field']
         self.logs = [(self.log_names[0], (50., 60.)),
                      (self.log_names[1], (2., 3.))]
 
@@ -254,6 +254,7 @@ class ResultsTabModelTest(unittest.TestCase):
 
     def test_create_results_table_with_logs_selected(self):
         workspace = CreateWorkspace([0,1,2,3,4,5],[0,1,2,3,4,5])
+        workspace.mutableRun().addProperty("run_start", "1970-01-01T00:00:01 to 1970-01-01T00:00:01", True)
         AddTimeSeriesLog(workspace, Name="sample_temp", Time="2010-01-01T00:00:00", Value=100)
         AddTimeSeriesLog(workspace, Name="sample_temp", Time="2010-01-01T00:30:00", Value=65)
         AddTimeSeriesLog(workspace, Name="sample_temp", Time="2010-01-01T00:50:00", Value=100.2)
@@ -266,13 +267,14 @@ class ResultsTabModelTest(unittest.TestCase):
         # workspace_name => no error col as its a string
         # sample_temp => time series and will have non-zero error
         # sample_magn_field => just a number
-        expected_cols = ['workspace_name',  'sample_temp', 'sample_tempError',
+        expected_cols = ['workspace_name', 'run_start', 'run_start_seconds',  'sample_temp', 'sample_tempError',
                          'sample_magn_field', 'sample_magn_fieldError',
                          'f0.Height', 'f0.HeightError', 'f0.PeakCentre',
                          'f0.PeakCentreError', 'f0.Sigma', 'f0.SigmaError', 'f1.Height',
                          'f1.HeightError', 'f1.PeakCentre', 'f1.PeakCentreError',
                          'f1.Sigma', 'f1.SigmaError', 'Cost function value']
         expected_types = (TableColumnType.NoType, TableColumnType.X,
+                          TableColumnType.X, TableColumnType.X,
                           TableColumnType.XErr, TableColumnType.X,
                           TableColumnType.XErr, TableColumnType.Y,
                           TableColumnType.YErr, TableColumnType.Y,
@@ -281,15 +283,12 @@ class ResultsTabModelTest(unittest.TestCase):
                           TableColumnType.YErr, TableColumnType.Y,
                           TableColumnType.YErr, TableColumnType.Y,
                           TableColumnType.YErr, TableColumnType.Y)
-        avg_log_values = 86., 2.0
+        avg_log_values = "1970-01-01T00:00:01 to 1970-01-01T00:00:01", 1, 86., 2.0
         expected_content = [
-            ('ws1_Parameters', avg_log_values[0], 17.146,  avg_log_values[1], 0.,
-             self.f0_height[0], self.f0_height[1], self.f0_centre[0],
-             self.f0_centre[1], self.f0_sigma[0], self.f0_sigma[1],
-             self.f1_height[0], self.f1_height[1], self.f1_centre[0],
-             self.f1_centre[1], self.f1_sigma[0], self.f1_sigma[1],
-             self.cost_function[0])
-        ]
+            ('ws1_Parameters', avg_log_values[0], avg_log_values[1], avg_log_values[2], 17.146, avg_log_values[3], 0.,
+             self.f0_height[0], self.f0_height[1], self.f0_centre[0], self.f0_centre[1], self.f0_sigma[0],
+             self.f0_sigma[1], self.f1_height[0], self.f1_height[1], self.f1_centre[0], self.f1_centre[1],
+             self.f1_sigma[0], self.f1_sigma[1], self.cost_function[0])]
         self._assert_table_matches_expected(zip(expected_cols, expected_types),
                                             expected_content, table,
                                             model.results_table_name())


### PR DESCRIPTION
**Description of work.**

This PR adds an extra column to results tables made in muon analysis that contain the `run_start` or `run_end`, this puts them into units of seconds, counting from the first entry.

**To test:**

1. open muon analysis
2. load MUSR 62260-5
3. go to the fitting tab, check fit simultainious
4. add any function
5. go to the sequntial tab
6. fit all
7. go to the results tab and check run_start and run_end
8. create results table
9. go to the model analysis tab.
10. in the x and y parameter lists there should be `run_start_seconds` and `run_end_seconds`
11. plot each of them and check that they each are in units of seconds.

Fixes #32726

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
