### PR TITLE
Add button to Export Summed Ws to ADS

### DIFF
--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/IPreviewModel.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/IPreviewModel.h
@@ -29,5 +29,6 @@ public:
   virtual void setSelectedBanks(std::vector<Mantid::detid_t> selectedBanks) = 0;
 
   virtual std::string detIDsToString(std::vector<Mantid::detid_t> const &indices) const = 0;
+  virtual void exportSummedWsToAds() const = 0;
 };
 } // namespace MantidQt::CustomInterfaces::ISISReflectometry

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/IPreviewView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/IPreviewView.h
@@ -21,6 +21,8 @@ public:
   virtual void notifyInstViewEditRequested() = 0;
   virtual void notifyInstViewSelectRectRequested() = 0;
   virtual void notifyInstViewShapeChanged() = 0;
+
+  virtual void notifyContourExportAdsRequested() = 0;
 };
 
 class IPreviewView {

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewModel.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewModel.cpp
@@ -27,7 +27,7 @@ Mantid::Kernel::Logger g_log("Reflectometry Preview Model");
 namespace MantidQt::CustomInterfaces::ISISReflectometry {
 
 PreviewModel::PreviewModel() {
-  // This simplifies testing greatly
+  // This simplifies testing greatly, as it ensures that m_runDetails is never null
   createRunDetails("");
 }
 
@@ -82,5 +82,13 @@ void PreviewModel::createRunDetails(const std::string &workspaceName) {
 
 std::string PreviewModel::detIDsToString(std::vector<Mantid::detid_t> const &indices) const {
   return Mantid::Kernel::Strings::simpleJoin(indices.cbegin(), indices.cend(), ",");
+}
+
+void PreviewModel::exportSummedWsToAds() const {
+  if (auto summedWs = m_runDetails->getSummedWs()) {
+    AnalysisDataService::Instance().addOrReplace("preview_summed_ws", summedWs);
+  } else {
+    g_log.error("Could not export summed WS. No rectangular selection has been made on the instrument viewer.");
+  }
 }
 } // namespace MantidQt::CustomInterfaces::ISISReflectometry

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewModel.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewModel.h
@@ -37,6 +37,7 @@ public:
   Mantid::API::MatrixWorkspace_sptr getSummedWs() const override;
 
   void setSelectedBanks(std::vector<Mantid::detid_t> selectedBanks) override;
+  void exportSummedWsToAds() const override;
 
 private:
   // This should be an optional instead of a point, but we have issues reassigning it because boost::optional doesn't

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.cpp
@@ -91,4 +91,6 @@ void PreviewPresenter::notifyInstViewShapeChanged() {
   m_model->setSelectedBanks(indices);
   m_model->sumBanksAsync(*m_jobManager);
 }
+
+void PreviewPresenter::notifyContourExportAdsRequested() { m_model->exportSummedWsToAds(); }
 } // namespace MantidQt::CustomInterfaces::ISISReflectometry

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.h
@@ -40,6 +40,8 @@ public:
   void notifyInstViewSelectRectRequested() override;
   void notifyInstViewShapeChanged() override;
 
+  void notifyContourExportAdsRequested() override;
+
   // JobManagerSubscriber overrides
   void notifyLoadWorkspaceCompleted() override;
   void notifySumBanksCompleted() override;

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewWidget.ui
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewWidget.ui
@@ -158,11 +158,31 @@
       <widget class="QWidget" name="contourPlotLayoutWidget">
        <layout class="QVBoxLayout" name="contour_plot_layout">
         <item>
-         <widget class="QPushButton" name="plot_2d_tool_placeholders">
-          <property name="text">
-           <string>Toolbar 2d</string>
-          </property>
-         </widget>
+         <layout class="QHBoxLayout" name="horizontalLayout">
+          <item>
+           <widget class="QToolButton" name="contour_ads_export_button">
+            <property name="toolTip">
+             <string>Export the summed workspace to the ADS</string>
+            </property>
+            <property name="text">
+             <string>ADS Export</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <spacer name="contour_toolbar_spacer">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>40</width>
+              <height>20</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+         </layout>
         </item>
         <item>
          <widget class="QTreeView" name="treeView_2"/>
@@ -207,7 +227,6 @@
  </widget>
  <tabstops>
   <tabstop>workspace_line_edit</tabstop>
-  <tabstop>plot_2d_tool_placeholders</tabstop>
   <tabstop>treeView_2</tabstop>
   <tabstop>plot_1d_toolbar_placeholder</tabstop>
   <tabstop>treeView</tabstop>

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/QtPreviewView.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/QtPreviewView.cpp
@@ -27,6 +27,7 @@ void QtPreviewView::loadToolbarIcons() {
   m_ui.iv_zoom_button->setIcon(MantidQt::Icons::getIcon("mdi.magnify", "black", 1.3));
   m_ui.iv_edit_button->setIcon(MantidQt::Icons::getIcon("mdi.pencil", "black", 1.3));
   m_ui.iv_rect_select_button->setIcon(MantidQt::Icons::getIcon("mdi.selection", "black", 1.3));
+  m_ui.contour_ads_export_button->setIcon(MantidQt::Icons::getIcon("mdi.file-export", "black", 1.3));
 }
 
 void QtPreviewView::subscribe(PreviewViewSubscriber *notifyee) noexcept { m_notifyee = notifyee; }

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/QtPreviewView.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/QtPreviewView.cpp
@@ -38,6 +38,7 @@ void QtPreviewView::connectSignals() const {
   connect(m_ui.iv_zoom_button, SIGNAL(clicked()), this, SLOT(onInstViewZoomClicked()));
   connect(m_ui.iv_edit_button, SIGNAL(clicked()), this, SLOT(onInstViewEditClicked()));
   connect(m_ui.iv_rect_select_button, SIGNAL(clicked()), this, SLOT(onInstViewSelectRectClicked()));
+  connect(m_ui.contour_ads_export_button, SIGNAL(clicked()), this, SLOT(onContourExportToAdsClicked()));
 }
 
 void QtPreviewView::onLoadWorkspaceRequested() const { m_notifyee->notifyLoadWorkspaceRequested(); }
@@ -45,6 +46,9 @@ void QtPreviewView::onLoadWorkspaceRequested() const { m_notifyee->notifyLoadWor
 void QtPreviewView::onInstViewZoomClicked() const { m_notifyee->notifyInstViewZoomRequested(); }
 void QtPreviewView::onInstViewEditClicked() const { m_notifyee->notifyInstViewEditRequested(); }
 void QtPreviewView::onInstViewSelectRectClicked() const { m_notifyee->notifyInstViewSelectRectRequested(); }
+void QtPreviewView::onInstViewShapeChanged() const { m_notifyee->notifyInstViewShapeChanged(); }
+
+void QtPreviewView::onContourExportToAdsClicked() const { m_notifyee->notifyContourExportAdsRequested(); }
 
 std::string QtPreviewView::getWorkspaceName() const { return m_ui.workspace_line_edit->text().toStdString(); }
 
@@ -56,9 +60,9 @@ void QtPreviewView::plotInstView(MantidWidgets::InstrumentActor *instActor, V3D 
   m_instDisplay->setSurface(std::make_shared<MantidWidgets::UnwrappedCylinder>(instActor, samplePos, axis));
   connect(m_instDisplay->getSurface().get(), SIGNAL(shapeChangeFinished()), this, SLOT(onInstViewShapeChanged()));
 }
-
 void QtPreviewView::setInstViewZoomState(bool isChecked) { m_ui.iv_zoom_button->setDown(isChecked); }
 void QtPreviewView::setInstViewEditState(bool isChecked) { m_ui.iv_edit_button->setDown(isChecked); }
+
 void QtPreviewView::setInstViewSelectRectState(bool isChecked) { m_ui.iv_rect_select_button->setDown(isChecked); }
 
 void QtPreviewView::setInstViewZoomMode() {
@@ -73,8 +77,6 @@ void QtPreviewView::setInstViewSelectRectMode() {
   m_instDisplay->getSurface()->setInteractionMode(ProjectionSurface::EditShapeMode);
   m_instDisplay->getSurface()->startCreatingShape2D("rectangle", Qt::green, QColor(255, 255, 255, 80));
 }
-
-void QtPreviewView::onInstViewShapeChanged() const { m_notifyee->notifyInstViewShapeChanged(); }
 
 void QtPreviewView::setInstViewToolbarEnabled(bool enable) {
   m_ui.iv_zoom_button->setEnabled(enable);

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/QtPreviewView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/QtPreviewView.h
@@ -58,5 +58,6 @@ private slots:
   void onInstViewZoomClicked() const;
   void onInstViewEditClicked() const;
   void onInstViewShapeChanged() const;
+  void onContourExportToAdsClicked() const;
 };
 } // namespace MantidQt::CustomInterfaces::ISISReflectometry

--- a/qt/scientific_interfaces/ISISReflectometry/test/Preview/MockPreviewModel.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Preview/MockPreviewModel.h
@@ -31,5 +31,6 @@ public:
 
   MOCK_METHOD(void, sumBanksAsync, (IJobManager &), (override));
   MOCK_METHOD(std::string, detIDsToString, (std::vector<Mantid::detid_t> const &), (const, override));
+  MOCK_METHOD(void, exportSummedWsToAds, (), (const, override));
 };
 } // namespace MantidQt::CustomInterfaces::ISISReflectometry

--- a/qt/scientific_interfaces/ISISReflectometry/test/Preview/PreviewModelTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Preview/PreviewModelTest.h
@@ -100,15 +100,15 @@ public:
   void test_export_summed_ws_to_ads() {
     PreviewModel model;
     auto mockJobManager = MockJobManager();
-
-    // TODO refactor this block
-    auto expectedWs = createWorkspace();
-    auto wsSumBanksEffect = [&expectedWs](PreviewRow &row) { row.setSummedWs(expectedWs); };
-    ON_CALL(mockJobManager, startSumBanks(_)).WillByDefault(Invoke(wsSumBanksEffect));
-    model.sumBanksAsync(mockJobManager);
+    auto ws = generateSummedWs(mockJobManager, model);
 
     model.exportSummedWsToAds();
-    TS_ASSERT(AnalysisDataService::Instance().doesExist("preview_summed_ws"));
+    auto &ads = AnalysisDataService::Instance();
+    const std::string expectedName = "preview_summed_ws";
+
+    TS_ASSERT(ads.doesExist(expectedName));
+    TS_ASSERT_EQUALS(ws, ads.retrieveWS<MatrixWorkspace>(expectedName));
+    ads.remove(expectedName);
   }
 
   void test_export_summed_ws_with_no_ws_set_does_not_throw() {
@@ -118,5 +118,13 @@ public:
   }
 
 private:
+  MatrixWorkspace_sptr generateSummedWs(MockJobManager &mockJobManager, PreviewModel &model) {
+    auto expectedWs = createWorkspace();
+    auto wsSumBanksEffect = [&expectedWs](PreviewRow &row) { row.setSummedWs(expectedWs); };
+    ON_CALL(mockJobManager, startSumBanks(_)).WillByDefault(Invoke(wsSumBanksEffect));
+    model.sumBanksAsync(mockJobManager);
+    return expectedWs;
+  }
+
   MatrixWorkspace_sptr createWorkspace() { return WorkspaceCreationHelper::create2DWorkspace(1, 1); }
 };

--- a/qt/scientific_interfaces/ISISReflectometry/test/Preview/PreviewModelTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Preview/PreviewModelTest.h
@@ -97,6 +97,26 @@ public:
     TS_ASSERT_EQUALS("", result);
   }
 
+  void test_export_summed_ws_to_ads() {
+    PreviewModel model;
+    auto mockJobManager = MockJobManager();
+
+    // TODO refactor this block
+    auto expectedWs = createWorkspace();
+    auto wsSumBanksEffect = [&expectedWs](PreviewRow &row) { row.setSummedWs(expectedWs); };
+    ON_CALL(mockJobManager, startSumBanks(_)).WillByDefault(Invoke(wsSumBanksEffect));
+    model.sumBanksAsync(mockJobManager);
+
+    model.exportSummedWsToAds();
+    TS_ASSERT(AnalysisDataService::Instance().doesExist("preview_summed_ws"));
+  }
+
+  void test_export_summed_ws_with_no_ws_set_does_not_throw() {
+    PreviewModel model;
+    // This should emit an error, but we cannot observe this from our test
+    model.exportSummedWsToAds();
+  }
+
 private:
   MatrixWorkspace_sptr createWorkspace() { return WorkspaceCreationHelper::create2DWorkspace(1, 1); }
 };

--- a/qt/scientific_interfaces/ISISReflectometry/test/Preview/PreviewPresenterTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Preview/PreviewPresenterTest.h
@@ -121,6 +121,16 @@ public:
     presenter.notifyInstViewShapeChanged();
   }
 
+  void test_notify_contour_export_to_ads_requested() {
+    auto mockView = makeView();
+    auto mockModel = makeModel();
+
+    EXPECT_CALL(*mockModel, exportSummedWsToAds()).Times(1);
+    auto presenter = PreviewPresenter(packDeps(mockView.get(), std::move(mockModel)));
+
+    presenter.notifyContourExportAdsRequested();
+  }
+
 private:
   MockViewT makeView() {
     auto mockView = std::make_unique<MockPreviewView>();


### PR DESCRIPTION
**Description of work.**
A button now appears above the contour plot areato allow the summed workspace to be exported to the ads. This allows for more fine tuning of the workspace and therefore plots for testing and demo purposes. 

**To test:**

- Load this workspace: [INTER45455_inst.zip](https://github.com/mantidproject/mantid/files/7504266/INTER45455_inst.zip)
- Open the ISIS Reflectometry GUI
- Select the Preview tab.
- Type in `INTER45455_inst` and click Load. The instrument viewer plot should display the data.
- Click the rectangle-select button and select a region of interest.
- Click the export button and make a colourfill of the produced workspace. Check that the correct summation has been done. 

Refs: #32772

*This does not require release notes* because **the tab only appears in debug, so these changes are not user facing.**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
