### PR TITLE
Add missing window title to plot settings dialog in Muon Analysis

### DIFF
--- a/qt/python/mantidqt/mantidqt/plotting/mantid_navigation_toolbar.py
+++ b/qt/python/mantidqt/mantidqt/plotting/mantid_navigation_toolbar.py
@@ -49,8 +49,8 @@ class MantidNavigationTool:
 class MantidStandardNavigationTools:
     """
     Standard navigation tools.
-    Cnnected to the callbacks:
-    home, back, foward, pan, save_figure, zoom
+    Connected to the callbacks:
+    home, back, forward, pan, save_figure, zoom
     """
     HOME = MantidNavigationTool('Home', 'Reset axes limits', 'mdi.home', 'home', None)
     BACK = MantidNavigationTool('Back', 'Back to previous view', 'mdi.arrow-left', 'back', None)
@@ -122,7 +122,7 @@ class MantidNavigationToolbar(NavigationToolbar2, QToolBar):
         NavigationToolbar2.__init__(self, canvas)
 
     def _init_toolbar(self):
-        # Empty init_toolbar method kept for backwards compatability
+        # Empty init_toolbar method kept for backwards compatibility
         pass
 
     def set_message(self, s):
@@ -202,15 +202,16 @@ class MantidNavigationToolbar(NavigationToolbar2, QToolBar):
     def _update_buttons_checked(self):
         # sync button checkstates to match active mode
         if 'pan' in self._actions:
-            self._actions['pan'].setChecked(self._get_mode() == 'PAN' or self._get_mode() == 'pan/zoom'  )
+            self._actions['pan'].setChecked(self._get_mode() == 'PAN' or self._get_mode() == 'pan/zoom')
         if 'zoom' in self._actions:
-            self._actions['zoom'].setChecked(self._get_mode()  == 'ZOOM' or self._get_mode() == 'zoom rect' )
+            self._actions['zoom'].setChecked(self._get_mode() == 'ZOOM' or self._get_mode() == 'zoom rect')
 
     def configure_subplots(self):
         image = os.path.join(matplotlib.get_data_path(),
                              'images', 'matplotlib.png')
         dia = SubplotToolQt(self.canvas.figure, self.canvas.parent())
         dia.setWindowIcon(QIcon(image))
+        dia.setWindowTitle(MantidStandardNavigationTools.CONFIGURE.tooltip)
         dia.exec_()
 
     def set_action_enabled(self, text: str, state: bool):


### PR DESCRIPTION
**Description of work.**
The "edit subplots" toolbar button in the Muon Analysis GUI opens a dialog with "mantidworkbench" as the title.
![image](https://user-images.githubusercontent.com/8058899/141507774-e7b1d10c-7f86-43af-8460-eb8a7d4cc98a.png)
The title has been changed so that it's the same as the tooltip for the toolbar button.

**To test:**
Open the "Muon Analysis" interface and click the "Edit subplots" toolbar button to open the dialog. Check that the window title is good.

*There is no associated issue.*

*This does not require release notes* because it is something that nobody will ever notice

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
