### PR TITLE
Fit range

### DIFF
--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/fitting_widgets/basic_fitting/basic_fitting_model.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/fitting_widgets/basic_fitting/basic_fitting_model.py
@@ -176,6 +176,18 @@ class BasicFittingModel:
         if value > self.current_start_x:
             self.fitting_context.end_xs[self.fitting_context.current_dataset_index] = value
 
+    def set_current_start_and_end_x(self, start_x, end_x):
+        """Need to set these together because of the checks
+        to make sure that start < end"""
+        if start_x > end_x:
+            return
+        elif start_x > self.current_end_x:
+            self.current_end_x = end_x
+            self.current_start_x = start_x
+        else:
+            self.current_start_x = start_x
+            self.current_end_x = end_x
+
     @property
     def exclude_range(self) -> bool:
         """Returns true if the Exclude Range option is on in the context."""

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/fitting_widgets/model_fitting/model_fitting_presenter.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/fitting_widgets/model_fitting/model_fitting_presenter.py
@@ -165,8 +165,7 @@ class ModelFittingPresenter(BasicFittingPresenter):
             # update the x range for the fit
             start_x_list, end_x_list = self.model._get_new_start_xs_and_end_xs_using_existing_datasets([dataset_name])
             # update values in context
-            self.model.current_start_x = start_x_list[0]
-            self.model.current_end_x = end_x_list[0]
+            self.model.set_current_start_and_end_x(start_x_list[0], end_x_list[0])
             #update values in view
             self.view.start_x = start_x_list[0]
             self.view.end_x = end_x_list[0]

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/fitting_widgets/model_fitting/model_fitting_presenter.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/fitting_widgets/model_fitting/model_fitting_presenter.py
@@ -91,7 +91,6 @@ class ModelFittingPresenter(BasicFittingPresenter):
         # Triggers handle_selected_x_changed
         self.view.update_x_parameters(self.model.x_parameters(), self.model.y_parameter_types(), emit_signal=True)
         #update start and end x
-        print("hi")
         self.update_selected_parameter_combination_workspace()
 
     def handle_parameter_combinations_error(self, error: str) -> None:

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/fitting_widgets/model_fitting/model_fitting_presenter.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/fitting_widgets/model_fitting/model_fitting_presenter.py
@@ -90,6 +90,9 @@ class ModelFittingPresenter(BasicFittingPresenter):
         self.view.update_y_parameters(self.model.y_parameters(), self.model.y_parameter_types())
         # Triggers handle_selected_x_changed
         self.view.update_x_parameters(self.model.x_parameters(), self.model.y_parameter_types(), emit_signal=True)
+        #update start and end x
+        print("hi")
+        self.update_selected_parameter_combination_workspace()
 
     def handle_parameter_combinations_error(self, error: str) -> None:
         """Handle when an error occurs while creating workspaces for the different parameter combinations."""
@@ -162,6 +165,10 @@ class ModelFittingPresenter(BasicFittingPresenter):
             self.view.current_dataset_name = dataset_name
             # update the x range for the fit
             start_x_list, end_x_list = self.model._get_new_start_xs_and_end_xs_using_existing_datasets([dataset_name])
+            # update values in context
+            self.model.current_start_x = start_x_list[0]
+            self.model.current_end_x = end_x_list[0]
+            #update values in view
             self.view.start_x = start_x_list[0]
             self.view.end_x = end_x_list[0]
 

--- a/qt/python/mantidqtinterfaces/test/Muon/fitting_widgets/basic_fitting/basic_fitting_model_test.py
+++ b/qt/python/mantidqtinterfaces/test/Muon/fitting_widgets/basic_fitting/basic_fitting_model_test.py
@@ -832,6 +832,54 @@ class BasicFittingModelTest(unittest.TestCase):
         add_to_group.assert_not_called()
         make_group.assert_called_once_with(["ws"], "group")
 
+    def test_set_current_start_and_end_x_as_expected(self):
+
+        self.model.dataset_names = self.dataset_names
+        self.model.current_dataset_index = 0
+        self.model.start_xs = [0.0, 0.0]
+        self.model.end_xs = [15.0, 15.0]
+
+        self.assertEqual(self.model.current_start_x, 0.0)
+        self.assertEqual(self.model.current_end_x, 15.)
+        new_start_x = 5
+        new_end_x = 10
+
+        self.model.set_current_start_and_end_x(new_start_x, new_end_x)
+        self.assertEqual(self.model.current_start_x, new_start_x)
+        self.assertEqual(self.model.current_end_x, new_end_x)
+
+    def test_set_current_start_and_end_x_with_start_bigger_end(self):
+
+        self.model.dataset_names = self.dataset_names
+        self.model.current_dataset_index = 0
+        self.model.start_xs = [0.0, 0.0]
+        self.model.end_xs = [15.0, 15.0]
+
+        self.assertEqual(self.model.current_start_x, 0.0)
+        self.assertEqual(self.model.current_end_x, 15.)
+        new_start_x = 30
+        new_end_x = 50
+
+        self.model.set_current_start_and_end_x(new_start_x, new_end_x)
+        self.assertEqual(self.model.current_start_x, new_start_x)
+        self.assertEqual(self.model.current_end_x, new_end_x)
+
+    def test_set_current_start_and_end_x_fail(self):
+
+        self.model.dataset_names = self.dataset_names
+        self.model.current_dataset_index = 0
+        self.model.start_xs = [0.0, 0.0]
+        self.model.end_xs = [15.0, 15.0]
+
+        self.assertEqual(self.model.current_start_x, 0.0)
+        self.assertEqual(self.model.current_end_x, 15.)
+        new_start_x = 50
+        new_end_x = 10
+
+        self.model.set_current_start_and_end_x(new_start_x, new_end_x)
+        self.assertEqual(self.model.current_start_x, 0.0)
+        self.assertEqual(self.model.current_end_x, 15.0)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/qt/python/mantidqtinterfaces/test/Muon/fitting_widgets/model_fitting/model_fitting_presenter_test.py
+++ b/qt/python/mantidqtinterfaces/test/Muon/fitting_widgets/model_fitting/model_fitting_presenter_test.py
@@ -172,11 +172,12 @@ class ModelFittingPresenterTest(unittest.TestCase):
 
     def test_that_handle_parameter_combinations_created_successfully_will_update_the_view(self):
         self.presenter.handle_selected_x_and_y_changed = mock.Mock()
-
+        self.presenter.update_selected_parameter_combination_workspace = mock.Mock()
         self.presenter.handle_parameter_combinations_created_successfully()
 
         self.mock_model_dataset_names.assert_has_calls([mock.call(), mock.call()])
         self.view.set_datasets_in_function_browser.assert_called_once_with(self.dataset_names)
+        self.presenter.update_selected_parameter_combination_workspace.assert_called_once()
         self.view.update_dataset_name_combo_box.assert_called_once_with(self.dataset_names, emit_signal=False)
         self.view.update_y_parameters.assert_called_once_with(self.y_parameters, self.y_parameter_types)
         self.view.update_x_parameters.assert_called_once_with(self.x_parameters, self.x_parameter_types, emit_signal=True)
@@ -218,6 +219,7 @@ class ModelFittingPresenterTest(unittest.TestCase):
         # set up mocks
         new_start_x = -5.2
         new_end_x = 42.
+        self.model.set_current_start_and_end_x = mock.Mock()
         self.model._get_new_start_xs_and_end_xs_using_existing_datasets = mock.Mock(return_value=([new_start_x],[new_end_x]))
         # check current start and end x
         self.assertEqual(self.view.start_x, 0.0)
@@ -233,6 +235,7 @@ class ModelFittingPresenterTest(unittest.TestCase):
         self.model._get_new_start_xs_and_end_xs_using_existing_datasets.assert_called_once()
         self.assertEqual(self.mock_view_start_x.mock_calls, [mock.call(), mock.call(new_start_x)])
         self.assertEqual(self.mock_view_end_x.mock_calls, [mock.call(), mock.call(new_end_x)])
+        self.model.set_current_start_and_end_x.assert_called_once_with(new_start_x, new_end_x)
 
     def test_that_clear_current_fit_function_for_undo_will_only_clear_the_current_function(self):
         self.presenter.clear_current_fit_function_for_undo()


### PR DESCRIPTION
**Description of work.**

This fixes a crash caused by doing a fit in model analysis.

**To test:**
Open Muon Analysis
Load EMU 20901-5
Go to the fitting tab
Add a function
Go to sequential fitting
Click fit all
Go to the results table tab
Select the "Temp_Sample " log
Click create results table
Go to the model analysis tab
Add a fit function
Press fit - this used to throw an error by the data range being incorrect


There is no associated issue.

This does not require release notes* because it is a bug we accidentally added at the end of last week when doing a new feature. 


<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
