### PR TITLE
Refl GUI error handling for incorrect workspace types

### DIFF
--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/RowPreprocessingAlgorithm.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/RowPreprocessingAlgorithm.cpp
@@ -9,6 +9,7 @@
 #include "BatchJobAlgorithm.h"
 #include "MantidAPI/AlgorithmManager.h"
 #include "MantidAPI/IAlgorithm.h"
+#include "MantidAPI/MatrixWorkspace.h"
 #include "MantidQtWidgets/Common/AlgorithmRuntimeProps.h"
 #include "MantidQtWidgets/Common/BatchAlgorithmRunner.h"
 #include "Reduction/Item.h"
@@ -59,8 +60,11 @@ IConfiguredAlgorithm_sptr createConfiguredAlgorithm(IBatch const & /*model*/, Pr
 
 void updateRowOnAlgorithmComplete(const IAlgorithm_sptr &algorithm, Item &item) {
   auto &row = dynamic_cast<PreviewRow &>(item);
-  MatrixWorkspace_sptr outputWs = algorithm->getProperty("OutputWorkspace");
-  row.setLoadedWs(outputWs);
+  Workspace_sptr outputWs = algorithm->getProperty("OutputWorkspace");
+  auto matrixWs = std::dynamic_pointer_cast<MatrixWorkspace>(outputWs);
+  if (!matrixWs)
+    throw std::runtime_error("Unsupported workspace type; expected MatrixWorkspace");
+  row.setLoadedWs(matrixWs);
   // TODO reset the rest of the workspaces associated with the workflow
 }
 } // namespace MantidQt::CustomInterfaces::ISISReflectometry::PreprocessRow

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewJobManager.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewJobManager.cpp
@@ -58,7 +58,12 @@ void PreviewJobManager::notifyAlgorithmComplete(API::IConfiguredAlgorithm_sptr &
   if (!item || !item->isPreview())
     return;
 
-  jobAlgorithm->updateItem();
+  try {
+    jobAlgorithm->updateItem();
+  } catch (std::runtime_error const &ex) {
+    g_log.error(ex.what());
+    return;
+  }
 
   switch (algorithmType(algorithm)) {
   case AlgorithmType::PREPROCESS:

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewModel.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewModel.cpp
@@ -35,6 +35,7 @@ PreviewModel::PreviewModel() {
  *
  * @param workspaceName : the workspace name to look for
  * @returns : true if the loaded workspace was set, false if it was not found in the ADS
+ * @throws : if the workspace exists in the ADS but is an unexpected type
  */
 bool PreviewModel::loadWorkspaceFromAds(std::string const &workspaceName) {
   auto &adsInstance = AnalysisDataService::Instance();
@@ -42,6 +43,10 @@ bool PreviewModel::loadWorkspaceFromAds(std::string const &workspaceName) {
     return false;
   }
   auto ws = adsInstance.retrieveWS<MatrixWorkspace>(workspaceName);
+  if (!ws) {
+    throw std::runtime_error("Unsupported workspace type; expected MatrixWorkspace");
+  }
+
   createRunDetails(workspaceName);
   m_runDetails->setLoadedWs(ws);
   return true;

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.cpp
@@ -27,10 +27,14 @@ PreviewPresenter::PreviewPresenter(Dependencies dependencies)
  */
 void PreviewPresenter::notifyLoadWorkspaceRequested() {
   auto const name = m_view->getWorkspaceName();
-  if (m_model->loadWorkspaceFromAds(name)) {
-    notifyLoadWorkspaceCompleted();
-  } else {
-    m_model->loadAndPreprocessWorkspaceAsync(name, *m_jobManager);
+  try {
+    if (m_model->loadWorkspaceFromAds(name)) {
+      notifyLoadWorkspaceCompleted();
+    } else {
+      m_model->loadAndPreprocessWorkspaceAsync(name, *m_jobManager);
+    }
+  } catch (std::runtime_error const &ex) {
+    g_log.error(ex.what());
   }
 }
 

--- a/qt/scientific_interfaces/ISISReflectometry/test/Batch/RowPreprocessingAlgorithmTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Batch/RowPreprocessingAlgorithmTest.h
@@ -30,11 +30,12 @@ class RowPreprocessingAlgorithmTest : public CxxTest::TestSuite {
   public:
     StubbedPreProcess() {
       this->setChild(true);
-      auto prop = std::make_unique<Mantid::API::WorkspaceProperty<>>(m_propName, "", Mantid::Kernel::Direction::Output);
+      auto prop = std::make_unique<Mantid::API::WorkspaceProperty<Mantid::API::Workspace>>(
+          m_propName, "", Mantid::Kernel::Direction::Output);
       declareProperty(std::move(prop));
     }
 
-    void addOutputWorkspace(Mantid::API::MatrixWorkspace_sptr &ws) {
+    void addOutputWorkspace(Mantid::API::Workspace_sptr &ws) {
       this->getPointerToProperty("OutputWorkspace")->createTemporaryValue();
       setProperty(m_propName, ws);
     }
@@ -69,7 +70,7 @@ public:
   void test_row_is_updated_on_algorithm_complete() {
     auto mockAlg = std::make_shared<StubbedPreProcess>();
     const bool isHistogram = true;
-    Mantid::API::MatrixWorkspace_sptr mockWs = WorkspaceCreationHelper::create1DWorkspaceRand(1, isHistogram);
+    Mantid::API::Workspace_sptr mockWs = WorkspaceCreationHelper::create1DWorkspaceRand(1, isHistogram);
     mockAlg->addOutputWorkspace(mockWs);
 
     auto runNumbers = std::vector<std::string>{};

--- a/qt/scientific_interfaces/ISISReflectometry/test/Preview/PreviewModelTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Preview/PreviewModelTest.h
@@ -8,6 +8,7 @@
 
 #include "MantidAPI/AnalysisDataService.h"
 #include "MantidAPI/MatrixWorkspace.h"
+#include "MantidAPI/WorkspaceGroup.h"
 #include "MantidFrameworkTestHelpers/WorkspaceCreationHelper.h"
 #include "PreviewModel.h"
 #include "test/ReflMockObjects.h"
@@ -43,6 +44,18 @@ public:
     auto workspace = model.getLoadedWs();
     TS_ASSERT(workspace);
     TS_ASSERT_EQUALS(workspace->getName(), workspaceName);
+  }
+
+  void test_load_workspace_from_ads_throws_if_wrong_type() {
+    auto mockJobManager = MockJobManager();
+    EXPECT_CALL(mockJobManager, startPreprocessing(_)).Times(0);
+
+    PreviewModel model;
+    auto workspaceName = std::string("test workspace");
+    // We don't currently support workspace groups so it should throw with this type
+    AnalysisDataService::Instance().addOrReplace(workspaceName, std::make_shared<WorkspaceGroup>());
+
+    TS_ASSERT_THROWS(model.loadWorkspaceFromAds(workspaceName), std::runtime_error const &);
   }
 
   void test_load_workspace_from_file() {

--- a/qt/scientific_interfaces/ISISReflectometry/test/Preview/PreviewPresenterTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Preview/PreviewPresenterTest.h
@@ -35,6 +35,7 @@ using ::testing::NotNull;
 using ::testing::Ref;
 using ::testing::Return;
 using ::testing::ReturnRef;
+using ::testing::Throw;
 
 class PreviewPresenterTest : public CxxTest::TestSuite {
   using MockInstViewModelT = std::unique_ptr<MockInstViewModel>;
@@ -74,6 +75,35 @@ public:
     presenter.notifyLoadWorkspaceRequested();
   }
 
+  void test_notify_load_workspace_catches_runtime_error() {
+    auto mockModel = makeModel();
+    auto mockView = makeView();
+    auto const workspaceName = std::string("test workspace");
+    auto error = std::runtime_error("Test error");
+
+    EXPECT_CALL(*mockView, getWorkspaceName()).Times(1).WillOnce(Return(workspaceName));
+    EXPECT_CALL(*mockModel, loadWorkspaceFromAds(workspaceName)).Times(1).WillOnce(Throw(error));
+    EXPECT_CALL(*mockModel, loadAndPreprocessWorkspaceAsync(_, _)).Times(0);
+    EXPECT_CALL(*mockView, plotInstView(_, _, _)).Times(0);
+
+    auto presenter = PreviewPresenter(packDeps(mockView.get(), std::move(mockModel)));
+    TS_ASSERT_THROWS_NOTHING(presenter.notifyLoadWorkspaceRequested());
+  }
+
+  void test_notify_load_workspace_does_not_catch_unexpected_error() {
+    auto mockModel = makeModel();
+    auto mockView = makeView();
+    auto const workspaceName = std::string("test workspace");
+    auto error = std::invalid_argument("Test error");
+
+    EXPECT_CALL(*mockView, getWorkspaceName()).Times(1).WillOnce(Return(workspaceName));
+    EXPECT_CALL(*mockModel, loadWorkspaceFromAds(workspaceName)).Times(1).WillOnce(Throw(error));
+    EXPECT_CALL(*mockModel, loadAndPreprocessWorkspaceAsync(_, _)).Times(0);
+    EXPECT_CALL(*mockView, plotInstView(_, _, _)).Times(0);
+
+    auto presenter = PreviewPresenter(packDeps(mockView.get(), std::move(mockModel)));
+    TS_ASSERT_THROWS(presenter.notifyLoadWorkspaceRequested(), std::invalid_argument const &);
+  }
   void test_notify_load_workspace_complete_reloads_inst_view() {
     auto mockModel = makeModel();
     auto mockView = makeView();
@@ -179,7 +209,7 @@ private:
     EXPECT_CALL(mockInstViewModel, getInstrumentViewActor()).Times(1).WillOnce(Return(nullptr));
     EXPECT_CALL(mockInstViewModel, getSamplePos()).Times(1).WillOnce(Return(samplePos));
     EXPECT_CALL(mockInstViewModel, getAxis()).Times(1).WillOnce(Return(axes));
-    EXPECT_CALL(mockView, plotInstView(Eq(nullptr), Eq(samplePos), Eq(axes)));
+    EXPECT_CALL(mockView, plotInstView(Eq(nullptr), Eq(samplePos), Eq(axes))).Times(1);
   }
 
   void expectInstViewToolbarEnabled(MockPreviewView &mockView) {


### PR DESCRIPTION
**Description of work.**
This PR adds error handling for incorrect workspace types on the Preview tab in the ISIS Reflectometry interface. Previously this was causing a crash because null workspace pointers were getting through when they were cast to the wrong type. We now catch this early and throw an expected error.

**To test:**

Check the problem with the ADS is fixed:

- Run this: `Load('INTER13460', OutputWorkspace='INTER13460')`
- Open the ISIS Reflectometry interface, set instrument to `INTER`, and select the Preview tab
- Type `INTER13460`` into the Run box and click Load. The workspace should be displayed in the instrument view plot.
- Delete the workspace from the ADS and click Load again
- It should re-load and re-display in the instrument view plot.

Check the problem with group workspaces is fixed:

- Open the ISIS Reflectometry interface, set  the instrument to `POLREF` and then select the Preview tab
- Type `14966` into the Run box and click Load.
- You should get an error message in the log along the lines of `Unsupported workspace type` and any existing plots should be cleared.
- Run this: `Load('POLREF14966', OutputWorkspace='POLREF14966')`
- Repeat but type `POLREF14966` into the Run box.
- Run this ` ws=Load('POLREF14966')`
- Repeat but type `ws` into the Run box. 

Fixes #32961

*This does not require release notes* because **the Preview tab is WIP and is not exposed in the release build yet**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
