### PR TITLE
Explain how property is invalid as well

### DIFF
--- a/Framework/API/src/Algorithm.cpp
+++ b/Framework/API/src/Algorithm.cpp
@@ -613,11 +613,10 @@ bool Algorithm::executeInternal() {
       // Throw because something was invalid
       if (numErrors > 0) {
         std::stringstream msg;
-        msg << "Some invalid Properties found: [ ";
+        msg << "Some invalid Properties found: ";
         for (auto &error : errors) {
-          msg << error.first << " ";
+          msg << "\n " << error.first << ": " << error.second;
         }
-        msg << "]";
         notificationCenter().postNotification(new ErrorNotification(this, "Some invalid Properties found"));
         throw std::runtime_error(msg.str());
       }

--- a/Framework/Algorithms/test/ConjoinXRunsTest.h
+++ b/Framework/Algorithms/test/ConjoinXRunsTest.h
@@ -112,8 +112,9 @@ public:
     group.execute();
     m_testee.setProperty("InputWorkspaces", "group");
     m_testee.setProperty("OutputWorkspace", "out");
-    TS_ASSERT_THROWS_EQUALS(m_testee.execute(), const std::runtime_error &e, std::string(e.what()),
-                            "Some invalid Properties found: [ InputWorkspaces ]");
+    std::string err_msg(
+        "Some invalid Properties found: \n InputWorkspaces: Workspace table is not a MatrixWorkspace\n");
+    TS_ASSERT_THROWS_EQUALS(m_testee.execute(), const std::runtime_error &e, std::string(e.what()), err_msg);
   }
 
   void testWSWithoutDxValues() {

--- a/Framework/Algorithms/test/StitchTest.h
+++ b/Framework/Algorithms/test/StitchTest.h
@@ -131,8 +131,10 @@ public:
     alg.initialize();
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("InputWorkspaces", std::vector<std::string>({"ws1", "ws2"})));
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("OutputWorkspace", "out"))
-    TS_ASSERT_THROWS_EQUALS(alg.execute(), const std::runtime_error &e, std::string(e.what()),
-                            "Some invalid Properties found: [ InputWorkspaces ]");
+    std::string err_msg(
+        "Some invalid Properties found: \n InputWorkspaces: Workspace ws1 is ragged which is not supported.\n"
+        "Workspace ws2 is ragged which is not supported.\n");
+    TS_ASSERT_THROWS_EQUALS(alg.execute(), const std::runtime_error &e, std::string(e.what()), err_msg);
   }
 
   void test_OneWorkspace() {
@@ -142,8 +144,9 @@ public:
     alg.initialize();
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("InputWorkspaces", std::vector<std::string>({"ws1"})));
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("OutputWorkspace", "out"))
-    TS_ASSERT_THROWS_EQUALS(alg.execute(), const std::runtime_error &e, std::string(e.what()),
-                            "Some invalid Properties found: [ InputWorkspaces ]");
+    std::string err_msg(
+        "Some invalid Properties found: \n InputWorkspaces: Please provide at least 2 workspaces to stitch.");
+    TS_ASSERT_THROWS_EQUALS(alg.execute(), const std::runtime_error &e, std::string(e.what()), err_msg);
   }
 
   void test_HistogramData() {
@@ -154,8 +157,10 @@ public:
     alg.initialize();
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("InputWorkspaces", std::vector<std::string>({"ws1", "ws2"})));
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("OutputWorkspace", "out"))
-    TS_ASSERT_THROWS_EQUALS(alg.execute(), const std::runtime_error &e, std::string(e.what()),
-                            "Some invalid Properties found: [ InputWorkspaces ]");
+    std::string err_msg("Some invalid Properties found: \n"
+                        " InputWorkspaces: Workspace ws1 contains histogram data, only point data are supported.\n"
+                        "Workspace ws2 contains histogram data, only point data are supported.\n");
+    TS_ASSERT_THROWS_EQUALS(alg.execute(), const std::runtime_error &e, std::string(e.what()), err_msg);
   }
 
   void test_IncompatibleWorkspaces() {
@@ -166,8 +171,9 @@ public:
     alg.initialize();
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("InputWorkspaces", std::vector<std::string>({"ws1", "ws2"})));
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("OutputWorkspace", "out"))
-    TS_ASSERT_THROWS_EQUALS(alg.execute(), const std::runtime_error &e, std::string(e.what()),
-                            "Some invalid Properties found: [ InputWorkspaces ]");
+    std::string err_msg("Some invalid Properties found: \n"
+                        " InputWorkspaces: Workspace ws2 is not compatible: different number of histograms; \n");
+    TS_ASSERT_THROWS_EQUALS(alg.execute(), const std::runtime_error &e, std::string(e.what()), err_msg);
   }
 
   void test_NotEnoughOverlap() {

--- a/Framework/DataHandling/test/LoadILLDiffractionTest.h
+++ b/Framework/DataHandling/test/LoadILLDiffractionTest.h
@@ -182,8 +182,9 @@ public:
     TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("Filename", "967100.nxs"))
     TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("OutputWorkspace", "_unused_for_child"))
     TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("DataType", "Calibrated"))
-    TS_ASSERT_THROWS_EQUALS(alg.execute(), std::runtime_error & e, std::string(e.what()),
-                            "Some invalid Properties found: [ DataType ]")
+    std::string err_msg("Some invalid Properties found: \n"
+                        " DataType: Calibrated data requested, but only raw data exists in this NeXus file.");
+    TS_ASSERT_THROWS_EQUALS(alg.execute(), std::runtime_error & e, std::string(e.what()), err_msg);
   }
 
   void test_D20_scan() {

--- a/Framework/PythonInterface/test/python/plugins/algorithms/MatchPeaksTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/MatchPeaksTest.py
@@ -119,12 +119,14 @@ class MatchPeaksTest(unittest.TestCase):
             self._args['InputWorkspace'] = self._in1
             run1 = run_algorithm('MatchPeaks', **self._args)
             self.assertTrue(run1.isExecuted())
-        self.assertEqual('Some invalid Properties found: [ InputWorkspace2 ]', str(contextManager.exception))
+        # InputWorkspace2
+        self.assertTrue(str(contextManager.exception).startswith('Some invalid Properties found: '))
         with self.assertRaises(RuntimeError) as contextManager:
             self._args['InputWorkspace'] = self._in2
             run2 = run_algorithm('MatchPeaks', **self._args)
             self.assertTrue(run2.isExecuted())
-        self.assertEqual('Some invalid Properties found: [ InputWorkspace2 ]', str(contextManager.exception))
+        # InputWorkspace2
+        self.assertTrue(str(contextManager.exception).startswith('Some invalid Properties found: '))
 
     def testValidateInputWorkspace2(self):
         self._args['InputWorkspace'] = self._ws_shift
@@ -132,11 +134,13 @@ class MatchPeaksTest(unittest.TestCase):
         with self.assertRaises(RuntimeError) as contextManager:
             self._args['InputWorkspace2'] = self._in1
             run_algorithm('MatchPeaks', **self._args)
-        self.assertEqual('Some invalid Properties found: [ InputWorkspace2 InputWorkspace3 ]', str(contextManager.exception))
+        # InputWorkspace2 InputWorkspace3
+        self.assertTrue(str(contextManager.exception).startswith('Some invalid Properties found: '))
         with self.assertRaises(RuntimeError) as contextManager:
             self._args['InputWorkspace2'] = self._in2
             run_algorithm('MatchPeaks', **self._args)
-        self.assertEqual('Some invalid Properties found: [ InputWorkspace2 InputWorkspace3 ]', str(contextManager.exception))
+        # InputWorkspace2 InputWorkspace3
+        self.assertTrue(str(contextManager.exception).startswith('Some invalid Properties found: '))
 
     def testValidateInputWorkspace3(self):
         self._args['InputWorkspace'] = self._ws_shift
@@ -144,7 +148,8 @@ class MatchPeaksTest(unittest.TestCase):
         self._args['OutputWorkspace'] = 'output'
         with self.assertRaises(RuntimeError) as contextManager:
             run_algorithm('MatchPeaks', **self._args)
-        self.assertEqual('Some invalid Properties found: [ InputWorkspace2 InputWorkspace3 ]', str(contextManager.exception))
+        # InputWorkspace2 InputWorkspace3
+        self.assertTrue(str(contextManager.exception).startswith('Some invalid Properties found: '))
 
     def testMatchCenter(self):
         # Input workspace should match its center

--- a/Framework/Reflectometry/test/FindReflectometryLines2Test.h
+++ b/Framework/Reflectometry/test/FindReflectometryLines2Test.h
@@ -139,8 +139,9 @@ public:
     TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("OutputWorkspace", "_unused_for_child"))
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("RangeLower", 2.))
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("RangeUpper", 1.))
-    TS_ASSERT_THROWS_EQUALS(alg.execute(), std::runtime_error const &e, e.what(),
-                            std::string("Some invalid Properties found: [ RangeUpper ]"))
+    std::string err_msg("Some invalid Properties found: \n"
+                        " RangeUpper: The upper limit is smaller than the lower.");
+    TS_ASSERT_THROWS_EQUALS(alg.execute(), std::runtime_error const &e, e.what(), err_msg)
   }
 
   void test_invalidEndAndStartIndicesThrows() {
@@ -156,8 +157,9 @@ public:
     TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("OutputWorkspace", "_unused_for_child"))
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("StartWorkspaceIndex", 2))
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("EndWorkspaceIndex", 1))
-    TS_ASSERT_THROWS_EQUALS(alg.execute(), std::runtime_error const &e, e.what(),
-                            std::string("Some invalid Properties found: [ EndWorkspaceIndex ]"))
+    std::string err_msg("Some invalid Properties found: \n"
+                        " EndWorkspaceIndex: The index is smaller than the start.");
+    TS_ASSERT_THROWS_EQUALS(alg.execute(), std::runtime_error const &e, e.what(), err_msg);
   }
 
 private:

--- a/Framework/Reflectometry/test/ReflectometryBeamStatisticsTest.h
+++ b/Framework/Reflectometry/test/ReflectometryBeamStatisticsTest.h
@@ -151,11 +151,13 @@ private:
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("SecondSlitName", slit2))
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("SecondSlitSizeSampleLog", "slit2.size"));
     if (slit == 1) {
-      TS_ASSERT_THROWS_EQUALS(alg.execute(), std::runtime_error & e, e.what(),
-                              std::string("Some invalid Properties found: [ FirstSlitName ]"));
+      std::string err_msg("Some invalid Properties found: \n"
+                          " FirstSlitName: No component called 'non-existent' found in ReflectedBeamWorkspace");
+      TS_ASSERT_THROWS_EQUALS(alg.execute(), std::runtime_error & e, e.what(), err_msg);
     } else if (slit == 2) {
-      TS_ASSERT_THROWS_EQUALS(alg.execute(), std::runtime_error & e, e.what(),
-                              std::string("Some invalid Properties found: [ SecondSlitName ]"));
+      std::string err_msg("Some invalid Properties found: \n"
+                          " SecondSlitName: No component called 'non-existent' found in ReflectedBeamWorkspace");
+      TS_ASSERT_THROWS_EQUALS(alg.execute(), std::runtime_error & e, e.what(), err_msg);
     }
     TS_ASSERT(!alg.isExecuted())
   }

--- a/Framework/Reflectometry/test/ReflectometryMomentumTransferTest.h
+++ b/Framework/Reflectometry/test/ReflectometryMomentumTransferTest.h
@@ -248,8 +248,10 @@ private:
     TS_ASSERT_THROWS_NOTHING(alg->setProperty("SecondSlitName", slit1))
     TS_ASSERT_THROWS_NOTHING(alg->setProperty("SecondSlitSizeSampleLog", slit2))
     TS_ASSERT_THROWS_NOTHING(alg->setProperty("TOFChannelWidth", TOF_BIN_WIDTH))
-    TS_ASSERT_THROWS_EQUALS(alg->execute(), const std::runtime_error &e, e.what(),
-                            std::string("Some invalid Properties found: [ FirstSlitName SecondSlitName ]"))
+    std::string err_msg("Some invalid Properties found: \n"
+                        " FirstSlitName: No component called 'non-existent' found in InputWorkspace\n"
+                        " SecondSlitName: No component called 'non-existent' found in InputWorkspace");
+    TS_ASSERT_THROWS_EQUALS(alg->execute(), const std::runtime_error &e, e.what(), err_msg);
     TS_ASSERT(!alg->isExecuted())
   }
 

--- a/Framework/Reflectometry/test/ReflectometrySumInQTest.h
+++ b/Framework/Reflectometry/test/ReflectometrySumInQTest.h
@@ -231,9 +231,10 @@ public:
     TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("OutputWorkspace", "_unused_for_child"))
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("BeamCentre", static_cast<double>(detectorIdx)))
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("FlatSample", true))
-    TS_ASSERT_THROWS_EQUALS(alg.execute(), const std::runtime_error &e, e.what(),
-                            std::string("Some invalid Properties found: [ "
-                                        "BeamCentre InputWorkspaceIndexSet ]"))
+    std::string err_msg("Some invalid Properties found: \n"
+                        " BeamCentre: Beam centre is not included in InputWorkspaceIndexSet.\n"
+                        " InputWorkspaceIndexSet: A neighbour to any detector in the index set cannot be a monitor");
+    TS_ASSERT_THROWS_EQUALS(alg.execute(), const std::runtime_error &e, e.what(), err_msg)
   }
 
   void test_monitorInIndexSetThrows() {
@@ -250,9 +251,10 @@ public:
     TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("OutputWorkspace", "_unused_for_child"))
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("BeamCentre", static_cast<double>(monitorIdx)))
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("FlatSample", true))
-    TS_ASSERT_THROWS_EQUALS(alg.execute(), const std::runtime_error &e, e.what(),
-                            std::string("Some invalid Properties found: [ "
-                                        "BeamCentre InputWorkspaceIndexSet ]"))
+    std::string err_msg("Some invalid Properties found: \n"
+                        " BeamCentre: Beam centre is not included in InputWorkspaceIndexSet.\n"
+                        " InputWorkspaceIndexSet: Index set cannot include monitors.");
+    TS_ASSERT_THROWS_EQUALS(alg.execute(), const std::runtime_error &e, e.what(), err_msg);
   }
 
   void test_BeamCentreNotInIndexSetThrows() {
@@ -268,8 +270,9 @@ public:
     TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("OutputWorkspace", "_unused_for_child"))
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("BeamCentre", 2.))
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("FlatSample", true))
-    TS_ASSERT_THROWS_EQUALS(alg.execute(), const std::runtime_error &e, e.what(),
-                            std::string("Some invalid Properties found: [ BeamCentre ]"))
+    std::string err_msg("Some invalid Properties found: \n"
+                        " BeamCentre: Beam centre is not included in InputWorkspaceIndexSet.");
+    TS_ASSERT_THROWS_EQUALS(alg.execute(), const std::runtime_error &e, e.what(), err_msg);
   }
 
 private:


### PR DESCRIPTION
For algorithms that customized `validateProperties`, they would give useful errors in the algorithm guis, but only listed which properties were invalid in the exception. This PR adds the "why." The intent is to make it easier for users to follow exceptions and better understand what is wrong.

**To test:**

A code review should be sufficient

*There is no associated issue.*

*This does not require release notes* because it is a minor change in an exception message.

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
