### PR TITLE
Bug in plot toolbar with Superplot

### DIFF
--- a/qt/applications/workbench/workbench/plotting/figuremanager.py
+++ b/qt/applications/workbench/workbench/plotting/figuremanager.py
@@ -401,19 +401,13 @@ class FigureManagerWorkbench(FigureManagerBase, QObject):
             self.superplot = None
             self.toolbar._actions["toggle_superplot"].setChecked(False)
         else:
-            self.window.addDockWidget(Qt.LeftDockWidgetArea,
-                                      self.superplot.get_side_view())
-            self.window.addDockWidget(Qt.BottomDockWidgetArea,
-                                      self.superplot.get_bottom_view())
+            self.superplot.show()
             self.toolbar._actions["toggle_superplot"].setChecked(True)
-            self.superplot.get_bottom_view().setFocus()
 
     def _superplot_hide(self):
         """Hide the superplot"""
         if self.superplot is None:
             return
-        self.window.removeDockWidget(self.superplot.get_side_view())
-        self.window.removeDockWidget(self.superplot.get_bottom_view())
         self.superplot.close()
         self.superplot = None
         self.toolbar._actions["toggle_superplot"].setChecked(False)

--- a/qt/python/mantidqt/mantidqt/widgets/superplot/presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/superplot/presenter.py
@@ -117,11 +117,11 @@ class SuperplotPresenter:
         self._update_hold_button()
         self._update_plot()
 
-    def get_side_view(self):
-        return self._view.get_side_widget()
-
-    def get_bottom_view(self):
-        return self._view.get_bottom_widget()
+    def show(self):
+        """
+        Show the superplot.
+        """
+        self._view.show()
 
     def close(self):
         if self.parent:

--- a/qt/python/mantidqt/mantidqt/widgets/superplot/test/test_superplot_presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/superplot/test/test_superplot_presenter.py
@@ -98,13 +98,9 @@ class SuperplotPresenterTest(unittest.TestCase):
         self.m_model.del_workspace.assert_called_once_with("ws1")
         self.m_model.add_workspace.assert_called_once_with("ws2")
 
-    def test_get_side_view(self):
-        self.presenter.get_side_view()
-        self.m_view.get_side_widget.assert_called_once()
-
-    def test_get_bottom_view(self):
-        self.presenter.get_bottom_view()
-        self.m_view.get_bottom_widget.assert_called_once()
+    def test_show(self):
+        self.presenter.show()
+        self.m_view.show.assert_called_once()
 
     def test_close(self):
         self.presenter.close()

--- a/qt/python/mantidqt/mantidqt/widgets/superplot/test/test_superplot_view.py
+++ b/qt/python/mantidqt/mantidqt/widgets/superplot/test/test_superplot_view.py
@@ -10,6 +10,7 @@ from unittest import mock
 import sys
 
 from qtpy.QtWidgets import QApplication
+from qtpy.QtCore import Qt
 
 from mantidqt.widgets.superplot.view import SuperplotView
 
@@ -41,13 +42,15 @@ class SuperplotViewTest(unittest.TestCase):
         self.addCleanup(patch.stop)
 
         self.m_presenter = mock.Mock()
-        self.view = SuperplotView(self.m_presenter)
+        self.m_window = mock.Mock()
+        self.view = SuperplotView(self.m_presenter, self.m_window)
 
-    def test_get_side_widget(self):
-        self.assertEqual(self.view.get_side_widget(), self.view._side_view)
-
-    def test_get_bottom_widget(self):
-        self.assertEqual(self.view.get_bottom_widget(), self.view._bottom_view)
+    def test_show(self):
+        self.view.show()
+        calls = [mock.call(Qt.LeftDockWidgetArea, self.m_dock_side),
+                 mock.call(Qt.BottomDockWidgetArea, self.m_dock_bottom)]
+        self.m_window.addDockWidget.has_calls(calls)
+        self.m_dock_bottom.setFocus.assert_called_once()
 
     def test_close(self):
         self.view.close()

--- a/qt/python/mantidqt/mantidqt/widgets/superplot/view.py
+++ b/qt/python/mantidqt/mantidqt/widgets/superplot/view.py
@@ -229,6 +229,7 @@ class SuperplotView:
     _bottom_view = None
 
     def __init__(self, presenter, parent=None):
+        self._parent = parent
         self._presenter = presenter
         self._side_view = SuperplotViewSide(parent)
         self._bottom_view = SuperplotViewBottom(parent)
@@ -251,11 +252,14 @@ class SuperplotView:
                 self._presenter.on_mode_changed)
         bottom.resized.connect(self._presenter.on_resize)
 
-    def get_side_widget(self):
-        return self._side_view
-
-    def get_bottom_widget(self):
-        return self._bottom_view
+    def show(self):
+        """
+        Show the superplot view. This will add the two dockwidgets to their
+        respective position.
+        """
+        self._parent.addDockWidget(Qt.LeftDockWidgetArea, self._side_view)
+        self._parent.addDockWidget(Qt.BottomDockWidgetArea, self._bottom_view)
+        self._bottom_view.setFocus()
 
     def close(self):
         self._side_view.close()

--- a/qt/python/mantidqt/mantidqt/widgets/superplot/view.py
+++ b/qt/python/mantidqt/mantidqt/widgets/superplot/view.py
@@ -6,7 +6,7 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 
 
-from qtpy.QtWidgets import QDockWidget, QWidget, QHeaderView, QTreeWidgetItem, \
+from qtpy.QtWidgets import QDockWidget, QHeaderView, QTreeWidgetItem, \
                            QToolButton
 from qtpy.QtGui import QColor
 from qtpy.QtCore import *
@@ -222,17 +222,16 @@ class SuperplotViewBottom(QDockWidget):
         self.resized.emit()
 
 
-class SuperplotView(QWidget):
+class SuperplotView:
 
     _presenter = None
     _side_view = None
     _bottom_view = None
 
     def __init__(self, presenter, parent=None):
-        super().__init__(parent)
         self._presenter = presenter
-        self._side_view = SuperplotViewSide(self)
-        self._bottom_view = SuperplotViewBottom(self)
+        self._side_view = SuperplotViewSide(parent)
+        self._bottom_view = SuperplotViewBottom(parent)
 
         side = self._side_view
         side.visibilityChanged.connect(self._presenter.on_visibility_changed)


### PR DESCRIPTION
**Description of work.**

The bug was revealed in #32784.

When the superplot is opened via: right click -> Plot -> Superplot, only the bottom part of the the home, back, and forward buttons is clickable.

**To test:**

* right click on a workspace
* select Plot -> Superplot
* observe that the home, back, and forward buttons behave well and that you can click on their entire surface

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
