### PR TITLE
Fix units for simmultainious fit in model analysis

### DIFF
--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/fitting_widgets/model_fitting/model_fitting_model.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/fitting_widgets/model_fitting/model_fitting_model.py
@@ -262,6 +262,7 @@ class ModelFittingModel(BasicFittingModel):
 
     def _get_parameter_unit(self, parameter_name: str, axis: int) -> str:
         """Returns the units of a parameter by searching the Dictionary, UnitFactory and Sample logs."""
+        parameter_name = parameter_name.split('.')[-1]
         unit = self._get_unit_from_unit_dictionary(parameter_name, axis)
         if unit == "":
             unit = self._get_unit_from_sample_logs(parameter_name)

--- a/qt/python/mantidqtinterfaces/test/Muon/fitting_widgets/model_fitting/model_fitting_model_test.py
+++ b/qt/python/mantidqtinterfaces/test/Muon/fitting_widgets/model_fitting/model_fitting_model_test.py
@@ -21,9 +21,11 @@ def create_results_table():
     table.addColumn(type='float', name='A1')
     table.addColumn(type='float', name='Sigma')
     table.addColumn(type='float', name='Lambda')
-    table.addRow(["MUSR62260; Group; bottom; Asymmetry; MA", 0.1, 0.2, 0.3, 0.4])
-    table.addRow(["MUSR62260; Group; top; Asymmetry; MA", 0.3, 0.4, 0.5, 0.6])
-    table.addRow(["MUSR62260; Group; fwd; Asymmetry; MA", 0.5, 0.6, 0.7, 0.8])
+    table.addColumn(type='float', name='f1.Sigma')
+    table.addColumn(type='float', name='f1.Lambda')
+    table.addRow(["MUSR62260; Group; bottom; Asymmetry; MA", 0.1, 0.2, 0.3, 0.4, 0.5, 0.6])
+    table.addRow(["MUSR62260; Group; top; Asymmetry; MA", 0.3, 0.4, 0.5, 0.6, 0.7, 0.8])
+    table.addRow(["MUSR62260; Group; fwd; Asymmetry; MA", 0.5, 0.6, 0.7, 0.8, 0.9, 1.0])
     return table
 
 
@@ -37,7 +39,7 @@ class ModelFittingModelTest(unittest.TestCase):
         context = setup_context()
         self.model = ModelFittingModel(context, context.model_fitting_context)
         self.result_table_names = ["Result1", "Result2"]
-        self.dataset_names = ["workspace_name_A0", "workspace_name_A1", "A0_A1", "Sigma_Lambda"]
+        self.dataset_names = ["workspace_name_A0", "workspace_name_A1", "A0_A1", "Sigma_Lambda", "f1.Sigma_f1.Lambda"]
         self.fit_function1 = FunctionFactory.createFunction("FlatBackground")
         self.fit_function2 = FunctionFactory.createFunction("LinearBackground")
         self.single_fit_functions = [self.fit_function1.clone(), self.fit_function1.clone(), self.fit_function2.clone()]
@@ -145,8 +147,8 @@ class ModelFittingModelTest(unittest.TestCase):
         x_parameters = self.model.x_parameters()
         y_parameters = self.model.y_parameters()
 
-        self.assertEqual(list(x_parameters), ["workspace_name", "A0", "A1", "Sigma", "Lambda"])
-        self.assertEqual(list(y_parameters), ["workspace_name", "A0", "A1", "Sigma", "Lambda"])
+        self.assertEqual(list(x_parameters), ["workspace_name", "A0", "A1", "Sigma", "Lambda", "f1.Sigma", "f1.Lambda"])
+        self.assertEqual(list(y_parameters), ["workspace_name", "A0", "A1", "Sigma", "Lambda", "f1.Sigma", "f1.Lambda"])
 
         self.assertAlmostEqual(self.model.fitting_context.x_parameters["A0"][0][0], 0.1, delta=0.000001)
         self.assertAlmostEqual(self.model.fitting_context.x_parameters["A0"][0][1], 0.3, delta=0.000001)
@@ -160,6 +162,12 @@ class ModelFittingModelTest(unittest.TestCase):
         self.assertAlmostEqual(self.model.fitting_context.y_parameters["Lambda"][0][0], 0.4, delta=0.000001)
         self.assertAlmostEqual(self.model.fitting_context.y_parameters["Lambda"][0][1], 0.6, delta=0.000001)
         self.assertAlmostEqual(self.model.fitting_context.y_parameters["Lambda"][0][2], 0.8, delta=0.000001)
+        self.assertAlmostEqual(self.model.fitting_context.y_parameters["f1.Sigma"][0][0], 0.5, delta=0.000001)
+        self.assertAlmostEqual(self.model.fitting_context.y_parameters["f1.Sigma"][0][1], 0.7, delta=0.000001)
+        self.assertAlmostEqual(self.model.fitting_context.y_parameters["f1.Sigma"][0][2], 0.9, delta=0.000001)
+        self.assertAlmostEqual(self.model.fitting_context.y_parameters["f1.Lambda"][0][0], 0.6, delta=0.000001)
+        self.assertAlmostEqual(self.model.fitting_context.y_parameters["f1.Lambda"][0][1], 0.8, delta=0.000001)
+        self.assertAlmostEqual(self.model.fitting_context.y_parameters["f1.Lambda"][0][2], 1.0, delta=0.000001)
 
         self.assertEqual(self.model.fitting_context.y_parameters["workspace_name"][0],
                          ["MUSR62260; Group; bottom; Asymmetry; MA", "MUSR62260; Group; top; Asymmetry; MA",
@@ -199,6 +207,7 @@ class ModelFittingModelTest(unittest.TestCase):
         self.model.create_x_and_y_parameter_combination_workspace("A1", "A0")
         self.model.create_x_and_y_parameter_combination_workspace("workspace_name", "A1")
         self.model.create_x_and_y_parameter_combination_workspace("Sigma", "Lambda")
+        self.model.create_x_and_y_parameter_combination_workspace("f1.Sigma", "f1.Lambda")
 
         self.assertTrue(check_if_workspace_exist("Result1; Parameter Combinations"))
 
@@ -206,6 +215,7 @@ class ModelFittingModelTest(unittest.TestCase):
         self.assertTrue(check_if_workspace_exist("Result1; A1 vs workspace_name"))
         self.assertTrue(check_if_workspace_exist("Result1; A0 vs A1"))
         self.assertTrue(check_if_workspace_exist("Result1; Lambda vs Sigma"))
+        self.assertTrue(check_if_workspace_exist("Result1; f1.Lambda vs f1.Sigma"))
 
         self.assertTrue(not check_if_workspace_exist("Result1; workspace_name vs A0"))
         self.assertTrue(not check_if_workspace_exist("Result1; workspace_name vs A1"))
@@ -218,6 +228,10 @@ class ModelFittingModelTest(unittest.TestCase):
         unit_test_ws = retrieve_ws("Result1; Lambda vs Sigma")
         self.assertTrue(str(unit_test_ws.getAxis(0).getUnit().symbol()) == '\\mu s^{-1}')
         self.assertTrue(str(unit_test_ws.YUnit()) == 'Lambda ($\\mu$ $s^{-1}$)')
+
+        unit_test_ws = retrieve_ws("Result1; f1.Lambda vs f1.Sigma")
+        self.assertTrue(str(unit_test_ws.getAxis(0).getUnit().symbol()) == '\\mu s^{-1}')
+        self.assertTrue(str(unit_test_ws.YUnit()) == 'f1.Lambda ($\\mu$ $s^{-1}$)')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
**Description of work.**

in #32762 when we added units for parameters we did not consider that when fitting simultainiously parameters were given a `f0.` prefix. this PR fixes that.

**To test:**

1. Open Muon analysis
1. Load MUSR 62260
1. In the fitting tab add a GausOsc function
2. check `fit simultainiously over`
1. In Sequential fitting tab click Sequentialy fit all
1. In the Results tab check sample_temp and sample_magn_field in Log values
1. Output results table.
1. Go to the model fitting tab
1. Change the selected data in the X axis to different parameters and check that in the plot the units for, sample_temp, 
2. sample_magn_field, f0.sigma, f1.Frequency and f2.Phi are correct.
1. Repeat with the y axis.

Fixes #32973 


*This does not require release notes* because **it fixes a bug introduced in this release**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
