### PR TITLE
VesuvioAnalysis: Allow constraints for more than two masses

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/VesuvioAnalysis.py
+++ b/Framework/PythonInterface/plugins/algorithms/VesuvioAnalysis.py
@@ -170,7 +170,7 @@ class VesuvioAnalysis(PythonAlgorithm):
         if len(TOF) != 3:
             issues["TOFRangeVector"] = "TOFRangeVector should have length 3 (lower, binning, upper)."
         constraints: TableWorkspace = self.getProperty("ConstraintsProfile").value
-        if constraints not None:
+        if constraints:
             if constraints constraints.columnCount()!= len(constraintCols) or \
                     sorted(cleanNames(constraintCols))!=sorted(cleanNames(constraints.getColumnNames())):
                 issues["ConstraintsProfile"] = "The constraints table should be of the form: "

--- a/Framework/PythonInterface/plugins/algorithms/VesuvioAnalysis.py
+++ b/Framework/PythonInterface/plugins/algorithms/VesuvioAnalysis.py
@@ -169,31 +169,23 @@ class VesuvioAnalysis(PythonAlgorithm):
         TOF = self.getProperty("TOFRangeVector").value
         if len(TOF) != 3:
             issues["TOFRangeVector"] = "TOFRangeVector should have length 3 (lower, binning, upper)."
-        constraints = self.getProperty("ConstraintsProfileNumbers").value
-        if len(constraints) != 0 and len(constraints) != 2:
-            issues["ConstraintsProfileNumbers"] = "ConstraintsProfileNumbers should either be empty or only contain 2 numbers."
-        #check arithmetic is safe
-        if len(constraints) != 0:
-            cross_section = self.getProperty("ConstraintsProfileScatteringCrossSection").value
-            for ch in cross_section:
-                if ch not in ["+","-","*","/",".","(",")"] and not ch.isdigit():
-                    issues["ConstraintsProfileScatteringCrossSection"]= "Must be a valid mathmatical expression. "+ch
         constraints: TableWorkspace = self.getProperty("ConstraintsProfile").value
-        if constraints.columnCount()!= len(constraintCols) or \
-                sorted(cleanNames(constraintCols))!=sorted(cleanNames(constraints.getColumnNames())):
-            issues["ConstraintsProfile"] = "The constraints table should be of the form: "
-            for name in constraintCols:
-                issues["ConstraintsProfile"] += name + ", "
-        #check arithmetic is safe
-        cross_section = constraints.column('ScatteringCrossSection')
-        for section in cross_section:
-            for ch in section:
-                if ch not in ["+","-","*","/",".","(",")"] and not ch.isdigit():
-                    issues["ConstraintsProfile"]= "ScatteringCrossSection must be a valid mathmatical expression. "+ch
-        state = constraints.column('State')
-        for f in [flag for flag in state]:
-            if f not in ["eq", "ineq"]:
-                issues["ConstraintsProfile"]= "State can only have the values ['eq','ineq']"+f
+        if constraints not None:
+            if constraints constraints.columnCount()!= len(constraintCols) or \
+                    sorted(cleanNames(constraintCols))!=sorted(cleanNames(constraints.getColumnNames())):
+                issues["ConstraintsProfile"] = "The constraints table should be of the form: "
+                for name in constraintCols:
+                    issues["ConstraintsProfile"] += name + ", "
+            #check arithmetic is safe
+            cross_section = constraints.column('ScatteringCrossSection')
+            for section in cross_section:
+                for ch in section:
+                    if ch not in ["+","-","*","/",".","(",")"] and not ch.isdigit():
+                        issues["ConstraintsProfile"]= "ScatteringCrossSection must be a valid mathmatical expression. "+ch
+            state = constraints.column('State')
+            for f in [flag for flag in state]:
+                if f not in ["eq", "ineq"]:
+                    issues["ConstraintsProfile"]= "State can only have the values ['eq','ineq']"+f
         spectra = self.getProperty("Spectra").value
         if len(spectra) != 2:
             issues["Spectra"] = "Spectra should be of the form [first, last]"

--- a/Framework/PythonInterface/plugins/algorithms/VesuvioAnalysis.py
+++ b/Framework/PythonInterface/plugins/algorithms/VesuvioAnalysis.py
@@ -112,6 +112,7 @@ class VesuvioAnalysis(PythonAlgorithm):
         self.declareProperty(ITableWorkspaceProperty("ComptonProfile",
                                                      "",
                                                      direction=Direction.Input),doc="Table for Compton profiles")
+<<<<<<< HEAD
         self.declareProperty(IntArrayProperty("ConstraintsProfileNumbers", []), doc="List with LHS and RHS element of constraint on "
                                               "intensities of element peaks. A constraint can only be set when there are at least two "
                                               "elements in the ComptonProfile.")
@@ -123,6 +124,14 @@ class VesuvioAnalysis(PythonAlgorithm):
             "ConstraintsProfileNumbers are set.")
         self.declareProperty("ConstraintsProfileState", "eq", doc="This setting is ignored when no ConstraintsProfileNumbers are set.",
                              validator=StringListValidator(["eq","ineq"]))
+        self.declareProperty(ITableWorkspaceProperty("ConstraintsProfile",
+                                                     "",
+                                                     direction=Direction.Input),doc="Table with LHS and RHS element of constraint on "
+                                              "intensities of element peaks. A constraint can only be set when there are at least two "
+                                              "elements in the ComptonProfile. For each constraint the ratio of the first to second "
+                                              "intensities, each equal to atom stoichiometry times bound scattering "
+                                              "cross section is defined in the column ScatteringCrossSection. Simple arithmetic can be "
+                                              "included but the result may be rounded. The column State allows the values [eq,ineq].")
         self.declareProperty(IntArrayProperty("SpectraToBeMasked", []))#173,174,181
         self.declareProperty("SubtractResonancesFunction", "", doc="Function for resonance subtraction. Empty means no subtraction.")
         self.declareProperty("YSpaceFitFunctionTies", "",doc="The TOF spectra are subtracted by all the fitted profiles"
@@ -144,8 +153,13 @@ class VesuvioAnalysis(PythonAlgorithm):
             "Centre lower limit",
             "Centre value",
             "Centre upper limit"]
+        constraintCols = [
+            "LHS element",
+            "RHS element",
+            "ScatteringCrossSection",
+            "State"]
         issues = dict()
-        table = self.getProperty("ComptonProfile").value
+        table: TableWorkspace = self.getProperty("ComptonProfile").value
         if(not table):
             issues["ComptonProfile"] = "An elements table should be provided."
         elif(table.columnCount()!= len(tableCols) or sorted(cleanNames(tableCols))!=sorted(cleanNames(table.getColumnNames())) ):
@@ -155,6 +169,7 @@ class VesuvioAnalysis(PythonAlgorithm):
         TOF = self.getProperty("TOFRangeVector").value
         if len(TOF) != 3:
             issues["TOFRangeVector"] = "TOFRangeVector should have length 3 (lower, binning, upper)."
+<<<<<<< HEAD
         constraints = self.getProperty("ConstraintsProfileNumbers").value
         if len(constraints) != 0 and len(constraints) != 2:
             issues["ConstraintsProfileNumbers"] = "ConstraintsProfileNumbers should either be empty or only contain 2 numbers."
@@ -164,6 +179,30 @@ class VesuvioAnalysis(PythonAlgorithm):
             for ch in cross_section:
                 if ch not in ["+","-","*","/",".","(",")"] and not ch.isdigit():
                     issues["ConstraintsProfileScatteringCrossSection"]= "Must be a valid mathmatical expression. "+ch
+||||||| parent of 6f8ac4f985f (Replaced constraint properties with table)
+        constraints = self.getProperty("ConstraintsProfileNumbers").value
+        if len(constraints)!=2:
+            issues["ConstraintsProfileNumbers"] = "ConstraintsProfileNumbers should only contain 2 numbers."
+        #check aritmatic is safe
+        cross_section = self.getProperty("ConstraintsProfileScatteringCrossSection").value
+        for ch in cross_section:
+            if ch not in ["+","-","*","/",".","(",")"] and not ch.isdigit():
+                issues["ConstraintsProfileScatteringCrossSection"]= "Must be a valid mathmatical expression. "+ch
+=======
+        constraints: TableWorkspace = self.getProperty("ConstraintsProfile").value
+        if constraints.columnCount()!= len(constraintCols) or \
+                sorted(cleanNames(constraintCols))!=sorted(cleanNames(constraints.getColumnNames())):
+            issues["ConstraintsProfile"] = "The constraints table should be of the form: "
+            for name in constraintCols:
+                issues["ConstraintsProfile"] += name + ", "
+        if len(constraints)!=2:#?
+            issues["ConstraintsProfileNumbers"] = "ConstraintsProfileNumbers should only contain 2 numbers."#?
+        #check aritmatic is safe
+        cross_section = self.getProperty("ConstraintsProfileScatteringCrossSection").value#?
+        for ch in cross_section:#?
+            if ch not in ["+","-","*","/",".","(",")"] and not ch.isdigit():#?
+                issues["ConstraintsProfileScatteringCrossSection"]= "Must be a valid mathmatical expression. "+ch#?
+>>>>>>> 6f8ac4f985f (Replaced constraint properties with table)
         spectra = self.getProperty("Spectra").value
         if len(spectra) != 2:
             issues["Spectra"] = "Spectra should be of the form [first, last]"

--- a/Framework/PythonInterface/plugins/algorithms/VesuvioAnalysis.py
+++ b/Framework/PythonInterface/plugins/algorithms/VesuvioAnalysis.py
@@ -120,7 +120,7 @@ class VesuvioAnalysis(PythonAlgorithm):
                                               "elements in the ComptonProfile. For each constraint the ratio of the first to second "
                                               "intensities, each equal to atom stoichiometry times bound scattering "
                                               "cross section is defined in the column ScatteringCrossSection. Simple arithmetic can be "
-                                              "included but the result may be rounded. The column State allows the values ['eq','ineq'].")
+                                              "included but the result may be rounded. The column State allows the values 'eq' and 'ineq'.")
         self.declareProperty(IntArrayProperty("SpectraToBeMasked", []))#173,174,181
         self.declareProperty("SubtractResonancesFunction", "", doc="Function for resonance subtraction. Empty means no subtraction.")
         self.declareProperty("YSpaceFitFunctionTies", "",doc="The TOF spectra are subtracted by all the fitted profiles"

--- a/Framework/PythonInterface/plugins/algorithms/VesuvioAnalysis.py
+++ b/Framework/PythonInterface/plugins/algorithms/VesuvioAnalysis.py
@@ -171,7 +171,7 @@ class VesuvioAnalysis(PythonAlgorithm):
             issues["TOFRangeVector"] = "TOFRangeVector should have length 3 (lower, binning, upper)."
         constraints: TableWorkspace = self.getProperty("ConstraintsProfile").value
         if constraints:
-            if constraints constraints.columnCount()!= len(constraintCols) or \
+            if constraints.columnCount()!= len(constraintCols) or \
                     sorted(cleanNames(constraintCols))!=sorted(cleanNames(constraints.getColumnNames())):
                 issues["ConstraintsProfile"] = "The constraints table should be of the form: "
                 for name in constraintCols:

--- a/Framework/PythonInterface/plugins/algorithms/VesuvioAnalysis.py
+++ b/Framework/PythonInterface/plugins/algorithms/VesuvioAnalysis.py
@@ -131,7 +131,7 @@ class VesuvioAnalysis(PythonAlgorithm):
                                               "elements in the ComptonProfile. For each constraint the ratio of the first to second "
                                               "intensities, each equal to atom stoichiometry times bound scattering "
                                               "cross section is defined in the column ScatteringCrossSection. Simple arithmetic can be "
-                                              "included but the result may be rounded. The column State allows the values [eq,ineq].")
+                                              "included but the result may be rounded. The column State allows the values ['eq','ineq'].")
         self.declareProperty(IntArrayProperty("SpectraToBeMasked", []))#173,174,181
         self.declareProperty("SubtractResonancesFunction", "", doc="Function for resonance subtraction. Empty means no subtraction.")
         self.declareProperty("YSpaceFitFunctionTies", "",doc="The TOF spectra are subtracted by all the fitted profiles"
@@ -169,7 +169,6 @@ class VesuvioAnalysis(PythonAlgorithm):
         TOF = self.getProperty("TOFRangeVector").value
         if len(TOF) != 3:
             issues["TOFRangeVector"] = "TOFRangeVector should have length 3 (lower, binning, upper)."
-<<<<<<< HEAD
         constraints = self.getProperty("ConstraintsProfileNumbers").value
         if len(constraints) != 0 and len(constraints) != 2:
             issues["ConstraintsProfileNumbers"] = "ConstraintsProfileNumbers should either be empty or only contain 2 numbers."
@@ -179,30 +178,22 @@ class VesuvioAnalysis(PythonAlgorithm):
             for ch in cross_section:
                 if ch not in ["+","-","*","/",".","(",")"] and not ch.isdigit():
                     issues["ConstraintsProfileScatteringCrossSection"]= "Must be a valid mathmatical expression. "+ch
-||||||| parent of 6f8ac4f985f (Replaced constraint properties with table)
-        constraints = self.getProperty("ConstraintsProfileNumbers").value
-        if len(constraints)!=2:
-            issues["ConstraintsProfileNumbers"] = "ConstraintsProfileNumbers should only contain 2 numbers."
-        #check aritmatic is safe
-        cross_section = self.getProperty("ConstraintsProfileScatteringCrossSection").value
-        for ch in cross_section:
-            if ch not in ["+","-","*","/",".","(",")"] and not ch.isdigit():
-                issues["ConstraintsProfileScatteringCrossSection"]= "Must be a valid mathmatical expression. "+ch
-=======
         constraints: TableWorkspace = self.getProperty("ConstraintsProfile").value
         if constraints.columnCount()!= len(constraintCols) or \
                 sorted(cleanNames(constraintCols))!=sorted(cleanNames(constraints.getColumnNames())):
             issues["ConstraintsProfile"] = "The constraints table should be of the form: "
             for name in constraintCols:
                 issues["ConstraintsProfile"] += name + ", "
-        if len(constraints)!=2:#?
-            issues["ConstraintsProfileNumbers"] = "ConstraintsProfileNumbers should only contain 2 numbers."#?
-        #check aritmatic is safe
-        cross_section = self.getProperty("ConstraintsProfileScatteringCrossSection").value#?
-        for ch in cross_section:#?
-            if ch not in ["+","-","*","/",".","(",")"] and not ch.isdigit():#?
-                issues["ConstraintsProfileScatteringCrossSection"]= "Must be a valid mathmatical expression. "+ch#?
->>>>>>> 6f8ac4f985f (Replaced constraint properties with table)
+        #check arithmetic is safe
+        cross_section = constraints.column('ScatteringCrossSection')
+        for section in cross_section:
+            for ch in section:
+                if ch not in ["+","-","*","/",".","(",")"] and not ch.isdigit():
+                    issues["ConstraintsProfile"]= "ScatteringCrossSection must be a valid mathmatical expression. "+ch
+        state = constraints.column('State')
+        for f in [flag for flag in state]:
+            if f not in ["eq", "ineq"]:
+                issues["ConstraintsProfile"]= "State can only have the values ['eq','ineq']"+f
         spectra = self.getProperty("Spectra").value
         if len(spectra) != 2:
             issues["Spectra"] = "Spectra should be of the form [first, last]"
@@ -239,6 +230,7 @@ class VesuvioAnalysis(PythonAlgorithm):
         elements = generate_elements(self.getProperty("ComptonProfile").value)
 
         # constraint on the intensities of element peaks
+<<<<<<< HEAD
         #provide LHS element, RHS element, mult. factor, flag
         # if flag=True inequality; if flag = False equality
         constraints_profile_num = self.getProperty("ConstraintsProfileNumbers").value
@@ -249,6 +241,18 @@ class VesuvioAnalysis(PythonAlgorithm):
             state = self.getProperty("ConstraintsProfileState").value
             C1 = constraint( constraints_profile_num[0], constraints_profile_num[1], cross_section ,state)
             constraints = [C1]
+||||||| parent of 02259267673 (Process constraint table)
+        #provide LHS element, RHS element, mult. factor, flag
+        # if flag=True inequality; if flag = False equality
+        constraints_profile_num = self.getProperty("ConstraintsProfileNumbers").value
+        # check this is valid in the validate inputs
+        cross_section = evaluate(self.getProperty("ConstraintsProfileScatteringCrossSection").value)
+        state = self.getProperty("ConstraintsProfileState").value
+        C1 = constraint( constraints_profile_num[0], constraints_profile_num[1], cross_section ,state)
+        constraints = [C1]
+=======
+        constraints = generate_constraints(self.getProperty("ConstraintsProfile").value)
+>>>>>>> 02259267673 (Process constraint table)
 
         # spectra to be masked
         spectra_to_be_masked = self.getProperty("SpectraToBeMasked").value

--- a/Framework/PythonInterface/plugins/algorithms/VesuvioAnalysis.py
+++ b/Framework/PythonInterface/plugins/algorithms/VesuvioAnalysis.py
@@ -126,7 +126,8 @@ class VesuvioAnalysis(PythonAlgorithm):
                              validator=StringListValidator(["eq","ineq"]))
         self.declareProperty(ITableWorkspaceProperty("ConstraintsProfile",
                                                      "",
-                                                     direction=Direction.Input),doc="Table with LHS and RHS element of constraint on "
+                                                     Direction.Input, PropertyMode.Optional),
+                                                     doc="Table with LHS and RHS element of constraint on "
                                               "intensities of element peaks. A constraint can only be set when there are at least two "
                                               "elements in the ComptonProfile. For each constraint the ratio of the first to second "
                                               "intensities, each equal to atom stoichiometry times bound scattering "
@@ -170,7 +171,7 @@ class VesuvioAnalysis(PythonAlgorithm):
         if len(TOF) != 3:
             issues["TOFRangeVector"] = "TOFRangeVector should have length 3 (lower, binning, upper)."
         constraints: TableWorkspace = self.getProperty("ConstraintsProfile").value
-        if constraints:
+        if constraints and constraints.rowCount() > 0:
             if constraints.columnCount()!= len(constraintCols) or \
                     sorted(cleanNames(constraintCols))!=sorted(cleanNames(constraints.getColumnNames())):
                 issues["ConstraintsProfile"] = "The constraints table should be of the form: "

--- a/Framework/PythonInterface/plugins/algorithms/VesuvioAnalysis.py
+++ b/Framework/PythonInterface/plugins/algorithms/VesuvioAnalysis.py
@@ -165,16 +165,17 @@ class VesuvioAnalysis(PythonAlgorithm):
                 issues["ConstraintsProfile"] = "The constraints table should be of the form: "
                 for name in constraintCols:
                     issues["ConstraintsProfile"] += name + ", "
-            #check arithmetic is safe
-            cross_section = constraints.column('ScatteringCrossSection')
-            for section in cross_section:
-                for ch in section:
-                    if ch not in ["+","-","*","/",".","(",")"] and not ch.isdigit():
-                        issues["ConstraintsProfile"]= "ScatteringCrossSection must be a valid mathmatical expression. "+ch
-            state = constraints.column('State')
-            for f in [flag for flag in state]:
-                if f not in ["eq", "ineq"]:
-                    issues["ConstraintsProfile"]= "State can only have the values ['eq','ineq']"+f
+            else:
+                #check arithmetic is safe
+                cross_section = constraints.column('ScatteringCrossSection')
+                for section in cross_section:
+                    for ch in section:
+                        if ch not in ["+","-","*","/",".","(",")"] and not ch.isdigit():
+                            issues["ConstraintsProfile"]= "ScatteringCrossSection must be a valid mathmatical expression. "+ch
+                state = constraints.column('State')
+                for f in [flag for flag in state]:
+                    if f not in ["eq", "ineq"]:
+                        issues["ConstraintsProfile"]= "State can only have the values ['eq','ineq']"+f
         spectra = self.getProperty("Spectra").value
         if len(spectra) != 2:
             issues["Spectra"] = "Spectra should be of the form [first, last]"

--- a/Framework/PythonInterface/plugins/algorithms/VesuvioAnalysis.py
+++ b/Framework/PythonInterface/plugins/algorithms/VesuvioAnalysis.py
@@ -112,18 +112,6 @@ class VesuvioAnalysis(PythonAlgorithm):
         self.declareProperty(ITableWorkspaceProperty("ComptonProfile",
                                                      "",
                                                      direction=Direction.Input),doc="Table for Compton profiles")
-<<<<<<< HEAD
-        self.declareProperty(IntArrayProperty("ConstraintsProfileNumbers", []), doc="List with LHS and RHS element of constraint on "
-                                              "intensities of element peaks. A constraint can only be set when there are at least two "
-                                              "elements in the ComptonProfile.")
-        self.declareProperty(
-            "ConstraintsProfileScatteringCrossSection",
-            "2.*82.03/5.551",
-            doc="The ratio of the first to second intensities, each equal to atom stoichiometry times bound scattering "
-            "cross section. Simple arithmetic can be included but the result may be rounded. This setting is ignored when no "
-            "ConstraintsProfileNumbers are set.")
-        self.declareProperty("ConstraintsProfileState", "eq", doc="This setting is ignored when no ConstraintsProfileNumbers are set.",
-                             validator=StringListValidator(["eq","ineq"]))
         self.declareProperty(ITableWorkspaceProperty("ConstraintsProfile",
                                                      "",
                                                      Direction.Input, PropertyMode.Optional),
@@ -223,29 +211,7 @@ class VesuvioAnalysis(PythonAlgorithm):
         elements = generate_elements(self.getProperty("ComptonProfile").value)
 
         # constraint on the intensities of element peaks
-<<<<<<< HEAD
-        #provide LHS element, RHS element, mult. factor, flag
-        # if flag=True inequality; if flag = False equality
-        constraints_profile_num = self.getProperty("ConstraintsProfileNumbers").value
-        # check this is valid in the validate inputs
-        constraints = []
-        if len(constraints_profile_num) > 0:
-            cross_section = evaluate(self.getProperty("ConstraintsProfileScatteringCrossSection").value)
-            state = self.getProperty("ConstraintsProfileState").value
-            C1 = constraint( constraints_profile_num[0], constraints_profile_num[1], cross_section ,state)
-            constraints = [C1]
-||||||| parent of 02259267673 (Process constraint table)
-        #provide LHS element, RHS element, mult. factor, flag
-        # if flag=True inequality; if flag = False equality
-        constraints_profile_num = self.getProperty("ConstraintsProfileNumbers").value
-        # check this is valid in the validate inputs
-        cross_section = evaluate(self.getProperty("ConstraintsProfileScatteringCrossSection").value)
-        state = self.getProperty("ConstraintsProfileState").value
-        C1 = constraint( constraints_profile_num[0], constraints_profile_num[1], cross_section ,state)
-        constraints = [C1]
-=======
         constraints = generate_constraints(self.getProperty("ConstraintsProfile").value)
->>>>>>> 02259267673 (Process constraint table)
 
         # spectra to be masked
         spectra_to_be_masked = self.getProperty("SpectraToBeMasked").value

--- a/Framework/PythonInterface/test/python/plugins/algorithms/VesuvioAnalysisTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/VesuvioAnalysisTest.py
@@ -101,7 +101,7 @@ class VesuvioAnalysisTest(unittest.TestCase):
         constraints.addColumn(type="int", name="LHS element")
         constraints.addColumn(type="int", name="RHS element")
         constraints.addColumn(type="str", name="State")
-        constraints.addRow([0, 1, "2.*82.03/5.551", "eq"])
+        constraints.addRow([0, 1, "eq"])
 
         alg = self.set_up_alg()
         alg.setProperty('Spectra', [135, 182])

--- a/Framework/PythonInterface/test/python/plugins/algorithms/VesuvioAnalysisTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/VesuvioAnalysisTest.py
@@ -42,7 +42,6 @@ class VesuvioAnalysisTest(unittest.TestCase):
 
         return table
 
-<<<<<<< HEAD
     def generate_constraints_table(self):
         constraints = CreateEmptyTableWorkspace()
         constraints.addColumn(type="int", name="LHS element")
@@ -52,18 +51,6 @@ class VesuvioAnalysisTest(unittest.TestCase):
 
         return constraints
 
-||||||| parent of da707f2f33b (Cleaned up unit tests)
-=======
-    def generate_constraints_table(self):
-        constraints = CreateEmptyTableWorkspace()
-        constraints.addColumn(type="int", name="lhs element")
-        constraints.addColumn(type="int", name="RHS element")
-        constraints.addColumn(type="str", name="ScatteringCrossSection")
-        constraints.addColumn(type="str", name="State")
-
-        return constraints
-
->>>>>>> da707f2f33b (Cleaned up unit tests)
     def test_no_elements(self):
         alg = self.set_up_alg()
         alg.setProperty('Spectra', [135, 182])
@@ -96,34 +83,8 @@ class VesuvioAnalysisTest(unittest.TestCase):
 
     def test_bad_column_in_constraints_table(self):
         table = self.generate_table()
-<<<<<<< HEAD
         constraints = self.generate_constraints_table()
         constraints.removeColumn("ScatteringCrossSection")
-        constraints.addRow([0, 1, "eq"])
-
-        alg = self.set_up_alg()
-        alg.setProperty('Spectra', [135, 182])
-        alg.setProperty('ComptonProfile', table)
-        alg.setProperty('ConstraintsProfile', constraints)
-        errors = alg.validateInputs()
-        self.assertTrue("ConstraintsProfile" in errors)
-        self.assertEquals(len(errors),1)
-
-    def test_bad_column_in_constraints_table(self):
-        table = self.generate_table()
-        constraints = CreateEmptyTableWorkspace()
-        constraints.addColumn(type="int", name="LHS element")
-        constraints.addColumn(type="int", name="RHS element")
-        constraints.addColumn(type="str", name="State")
-||||||| parent of da707f2f33b (Cleaned up unit tests)
-        constraints = CreateEmptyTableWorkspace()
-        constraints.addColumn(type="int", name="LHS element")
-        constraints.addColumn(type="int", name="RHS element")
-        constraints.addColumn(type="str", name="State")
-=======
-        constraints = self.generate_constraints_table()
-        constraints.removeColumn("ScatteringCrossSection")
->>>>>>> da707f2f33b (Cleaned up unit tests)
         constraints.addRow([0, 1, "eq"])
 
         alg = self.set_up_alg()
@@ -158,23 +119,12 @@ class VesuvioAnalysisTest(unittest.TestCase):
 
     def test_case_insensitive_constraints_table(self):
         table = self.generate_table()
-<<<<<<< HEAD
         constraints = self.generate_constraints_table()
         constraints.removeColumn("LHS element")
         constraints.addColumn("lhs element")
-||||||| parent of da707f2f33b (Cleaned up unit tests)
-        constraints = CreateEmptyTableWorkspace()
-        constraints.addColumn(type="int", name="lhs element")
-        constraints.addColumn(type="int", name="RHS element")
-        constraints.addColumn(type="str", name="ScatteringCrossSection")
-        constraints.addColumn(type="str", name="State")
-        constraints.addRow([0, 1, "2.*82.03/5.551", "eq"])
-
-=======
         constraints = self.generate_constraints_table()
         constraints.addRow([0, 1, "2.*82.03/5.551", "eq"])
 
->>>>>>> da707f2f33b (Cleaned up unit tests)
         alg = self.set_up_alg()
         alg.setProperty('ConstraintsProfile', constraints)
         alg.setProperty('Spectra', [135, 182])

--- a/Framework/PythonInterface/test/python/plugins/algorithms/VesuvioAnalysisTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/VesuvioAnalysisTest.py
@@ -121,7 +121,7 @@ class VesuvioAnalysisTest(unittest.TestCase):
         table = self.generate_table()
         constraints = self.generate_constraints_table()
         constraints.removeColumn("LHS element")
-        constraints.addColumn("lhs element")
+        constraints.addColumn(type="int", name="lhs element")
         constraints = self.generate_constraints_table()
         constraints.addRow([0, 1, "2.*82.03/5.551", "eq"])
 

--- a/Framework/PythonInterface/test/python/plugins/algorithms/VesuvioAnalysisTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/VesuvioAnalysisTest.py
@@ -161,7 +161,7 @@ class VesuvioAnalysisTest(unittest.TestCase):
     def test_maths_is_safe_fails(self):
         table = self.generate_table()
         constraints = self.generate_constraints_table()
-        bad_expressions = [ "2*r", "2,3", "4£", "rm -r *"]
+        bad_expressions = [ "2*r", "2,3", "4@", "rm -r *"]
         for expression in bad_expressions:
             alg = self.set_up_alg()
             constraints.addRow([0, 1, expression, "eq"])

--- a/Framework/PythonInterface/test/python/plugins/algorithms/VesuvioAnalysisTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/VesuvioAnalysisTest.py
@@ -43,14 +43,13 @@ class VesuvioAnalysisTest(unittest.TestCase):
         return table = CreateEmptyTableWorkspace()
 
     def generate_constraints_table(self):
-        table = CreateEmptyTableWorkspace()
-        table.addColumn(type="int", name="LHS element")
-        table.addColumn(type="int", name="RHS element")
-        table.addColumn(type="str", name="ScatteringCrossSection")
-        table.addColumn(type="str", name="State")
-        table.addRow([0, 1, "2.*82.03/5.551", "eq"])
+        constraints = CreateEmptyTableWorkspace()
+        constraints.addColumn(type="int", name="LHS element")
+        constraints.addColumn(type="int", name="RHS element")
+        constraints.addColumn(type="str", name="ScatteringCrossSection")
+        constraints.addColumn(type="str", name="State")
 
-        return table = CreateEmptyTableWorkspace()
+        return constraints
 
     def test_no_elements(self):
         alg = self.set_up_alg()
@@ -96,6 +95,22 @@ class VesuvioAnalysisTest(unittest.TestCase):
         self.assertTrue("ConstraintsProfile" in errors)
         self.assertEquals(len(errors),1)
 
+    def test_bad_column_in_constraints_table(self):
+        table = self.generate_table()
+        constraints = CreateEmptyTableWorkspace()
+        constraints.addColumn(type="int", name="LHS element")
+        constraints.addColumn(type="int", name="RHS element")
+        constraints.addColumn(type="str", name="State")
+        constraints.addRow([0, 1, "2.*82.03/5.551", "eq"])
+
+        alg = self.set_up_alg()
+        alg.setProperty('Spectra', [135, 182])
+        alg.setProperty('ComptonProfile', table)
+        alg.setProperty('ConstraintsProfile', constraints)
+        errors = alg.validateInputs()
+        self.assertTrue("ConstraintsProfile" in errors)
+        self.assertEquals(len(errors),1)
+
     def test_case_insensitive_table(self):
         table = CreateEmptyTableWorkspace()
         table.addColumn(type="str", name="Symbol")
@@ -126,9 +141,13 @@ class VesuvioAnalysisTest(unittest.TestCase):
         alg = self.set_up_alg()
         alg.setProperty('ConstraintsProfile', constraints)
         alg.setProperty('Spectra', [135, 182])
+        alg.setProperty('TOFRangeVector', [1,2])
         alg.setProperty('ComptonProfile', table)
+        alg.setProperty('Spectra', [135, 182])
+
         errors = alg.validateInputs()
-        self.assertEquals(len(errors),0)
+        self.assertEquals(len(errors),1)
+        self.assertTrue("TOFRangeVector" in errors)
 
     def test_TOF_range_short(self):
         table = self.generate_table()

--- a/Framework/PythonInterface/test/python/plugins/algorithms/VesuvioAnalysisTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/VesuvioAnalysisTest.py
@@ -42,6 +42,7 @@ class VesuvioAnalysisTest(unittest.TestCase):
 
         return table
 
+<<<<<<< HEAD
     def generate_constraints_table(self):
         constraints = CreateEmptyTableWorkspace()
         constraints.addColumn(type="int", name="LHS element")
@@ -51,6 +52,18 @@ class VesuvioAnalysisTest(unittest.TestCase):
 
         return constraints
 
+||||||| parent of da707f2f33b (Cleaned up unit tests)
+=======
+    def generate_constraints_table(self):
+        constraints = CreateEmptyTableWorkspace()
+        constraints.addColumn(type="int", name="lhs element")
+        constraints.addColumn(type="int", name="RHS element")
+        constraints.addColumn(type="str", name="ScatteringCrossSection")
+        constraints.addColumn(type="str", name="State")
+
+        return constraints
+
+>>>>>>> da707f2f33b (Cleaned up unit tests)
     def test_no_elements(self):
         alg = self.set_up_alg()
         alg.setProperty('Spectra', [135, 182])
@@ -83,6 +96,7 @@ class VesuvioAnalysisTest(unittest.TestCase):
 
     def test_bad_column_in_constraints_table(self):
         table = self.generate_table()
+<<<<<<< HEAD
         constraints = self.generate_constraints_table()
         constraints.removeColumn("ScatteringCrossSection")
         constraints.addRow([0, 1, "eq"])
@@ -101,6 +115,15 @@ class VesuvioAnalysisTest(unittest.TestCase):
         constraints.addColumn(type="int", name="LHS element")
         constraints.addColumn(type="int", name="RHS element")
         constraints.addColumn(type="str", name="State")
+||||||| parent of da707f2f33b (Cleaned up unit tests)
+        constraints = CreateEmptyTableWorkspace()
+        constraints.addColumn(type="int", name="LHS element")
+        constraints.addColumn(type="int", name="RHS element")
+        constraints.addColumn(type="str", name="State")
+=======
+        constraints = self.generate_constraints_table()
+        constraints.removeColumn("ScatteringCrossSection")
+>>>>>>> da707f2f33b (Cleaned up unit tests)
         constraints.addRow([0, 1, "eq"])
 
         alg = self.set_up_alg()
@@ -135,9 +158,23 @@ class VesuvioAnalysisTest(unittest.TestCase):
 
     def test_case_insensitive_constraints_table(self):
         table = self.generate_table()
+<<<<<<< HEAD
         constraints = self.generate_constraints_table()
         constraints.removeColumn("LHS element")
         constraints.addColumn("lhs element")
+||||||| parent of da707f2f33b (Cleaned up unit tests)
+        constraints = CreateEmptyTableWorkspace()
+        constraints.addColumn(type="int", name="lhs element")
+        constraints.addColumn(type="int", name="RHS element")
+        constraints.addColumn(type="str", name="ScatteringCrossSection")
+        constraints.addColumn(type="str", name="State")
+        constraints.addRow([0, 1, "2.*82.03/5.551", "eq"])
+
+=======
+        constraints = self.generate_constraints_table()
+        constraints.addRow([0, 1, "2.*82.03/5.551", "eq"])
+
+>>>>>>> da707f2f33b (Cleaned up unit tests)
         alg = self.set_up_alg()
         alg.setProperty('ConstraintsProfile', constraints)
         alg.setProperty('Spectra', [135, 182])

--- a/Framework/PythonInterface/test/python/plugins/algorithms/VesuvioAnalysisTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/VesuvioAnalysisTest.py
@@ -40,7 +40,7 @@ class VesuvioAnalysisTest(unittest.TestCase):
         table.addRow(['H', 1.0079,  0.,1.,9.9e9,  3.,  4.5,  6.,  -1.5, 0., 0.5])
         table.addRow(['C', 12.0,    0.,1.,9.9e9,  10., 15.5, 30., -1.5, 0., 0.5])
 
-        return table = CreateEmptyTableWorkspace()
+        return table
 
     def generate_constraints_table(self):
         constraints = CreateEmptyTableWorkspace()

--- a/docs/source/algorithms/VesuvioAnalysis-v1.rst
+++ b/docs/source/algorithms/VesuvioAnalysis-v1.rst
@@ -59,10 +59,17 @@ Usage:
    table.addRow(['H', 1.0079,  0.,1.,9.9e9,  3.,  4.5,  6.,  -1.5, 0., 0.5])
    table.addRow(['C', 12.0,    0.,1.,9.9e9,  10., 15.5, 30., -1.5, 0., 0.5])
 
+   # create table of constraints
+   constraints = CreateEmptyTableWorkspace()
+   constraints.addColumn(type="int", name="LHS element")
+   constraints.addColumn(type="int", name="RHS element")
+   constraints.addColumn(type="str", name="ScatteringCrossSection")
+   constraints.addColumn(type="str", name="State")
+   constraints.addRow([0, 1, "2.*82.03/5.51", "eq"])
+
    VesuvioAnalysis(IPFile = "ip2018.par", ComptonProfile = table, AnalysisMode = "LoadReduceAnalyse",
                    NumberOfIterations = 2, OutputName = "polyethylene", Runs = "38898-38906", TOFRangeVector = [110.,1.5,460.],
-                   Spectra = [135,182], MonteCarloEvents = 1e3, ConstraintsProfileNumbers = [0,1],
-                   ConstraintsProfileScatteringCrossSection = "2.*82.03/5.51", SpectraToBeMasked = [173,174,181],
+                   Spectra = [135,182], MonteCarloEvents = 1e3, ConstraintsProfile = constraints, SpectraToBeMasked = [173,174,181],
                    SubtractResonancesFunction = 'name=Voigt,LorentzAmp=1.,LorentzPos=284.131,LorentzFWHM=2,GaussianFWHM=3;',
                    YSpaceFitFunctionTies = "(c6=0., c4=0.)")
 

--- a/docs/source/release/v6.3.0/indirect_geometry.rst
+++ b/docs/source/release/v6.3.0/indirect_geometry.rst
@@ -15,6 +15,7 @@ New Features
 - In Indirect Data Analysis fitting tabs a button has been added that will unify the fit range for all spectra selected.
 - The Bayes Fortran libraries can now be installed on OSX and Linux using the bayesfitting python package https://pypi.org/project/bayesfitting/0.1.0/. This can be installed with `python -m pip install bayesfitting`
   using the Mantid Python executable.
+- VesuvioAnalysis now allows defining constraints for more than two masses.
 
 Improvements
 ------------

--- a/docs/source/release/v6.3.0/indirect_geometry.rst
+++ b/docs/source/release/v6.3.0/indirect_geometry.rst
@@ -15,7 +15,7 @@ New Features
 - In Indirect Data Analysis fitting tabs a button has been added that will unify the fit range for all spectra selected.
 - The Bayes Fortran libraries can now be installed on OSX and Linux using the bayesfitting python package https://pypi.org/project/bayesfitting/0.1.0/. This can be installed with `python -m pip install bayesfitting`
   using the Mantid Python executable.
-- VesuvioAnalysis now allows defining constraints for more than two masses.
+- VesuvioAnalysis now allows defining constraints for more than two masses using the ConstraintsProfile, see :ref:`VesuvioAnalysis <algm-VesuvioAnalysis>`.
 
 Improvements
 ------------

--- a/qt/python/mantidqt/mantidqt/project/test/test_projectparser_mantidplot.py
+++ b/qt/python/mantidqt/mantidqt/project/test/test_projectparser_mantidplot.py
@@ -62,7 +62,7 @@ class ProjectParserMantidPlotTest(unittest.TestCase):
         self.assertEqual(plot_dict["label"], "MUSR00062261-1")
         self.assertEqual(axes_dict[0]["title"], "MUSR00062261")
         self.assertEqual(axes_dict[0]["xAxisTitle"], "Time (μs)")
-        self.assertEqual(axes_dict[0]["yAxisTitle"], "Counts (μs)⁻¹")
+        self.assertEqual(axes_dict[0]["yAxisTitle"], "Counts (μs)")
         self.assertEqual(axes_dict[0]["title"], "MUSR00062261")
         self.assertEqual(axes_properties["xLim"], [-5, 35])
         self.assertEqual(axes_properties["yLim"], [0, 300000.0])

--- a/qt/python/mantidqt/mantidqt/project/test/test_projectparser_mantidplot.py
+++ b/qt/python/mantidqt/mantidqt/project/test/test_projectparser_mantidplot.py
@@ -62,7 +62,7 @@ class ProjectParserMantidPlotTest(unittest.TestCase):
         self.assertEqual(plot_dict["label"], "MUSR00062261-1")
         self.assertEqual(axes_dict[0]["title"], "MUSR00062261")
         self.assertEqual(axes_dict[0]["xAxisTitle"], "Time (μs)")
-        self.assertEqual(axes_dict[0]["yAxisTitle"], "Counts (μs)")
+        self.assertEqual(axes_dict[0]["yAxisTitle"], "Counts (μs)⁻¹")
         self.assertEqual(axes_dict[0]["title"], "MUSR00062261")
         self.assertEqual(axes_properties["xLim"], [-5, 35])
         self.assertEqual(axes_properties["yLim"], [0, 300000.0])

--- a/scripts/Inelastic/vesuvio/analysisHelpers.py
+++ b/scripts/Inelastic/vesuvio/analysisHelpers.py
@@ -522,7 +522,7 @@ class element:
 
 
 class constraint: # with reference to the "elements" vector positions
-    def __init__(self, lhs_element_position, rhs_element_position, rhs_factor , type):
+    def __init__(self, lhs_element_position, rhs_element_position, rhs_factor, type):
         self.lhs_element_position = lhs_element_position
         self.rhs_element_position = rhs_element_position
         self.rhs_factor = rhs_factor
@@ -575,6 +575,23 @@ def generate_elements(table):
         el = element(mass=value["mass(a.u.)"], intensity_range=intensity, width_range=width, centre_range=centre)
         elements.append(el)
     return elements
+
+
+def generate_constraints(table):
+    table_cols = table.getColumnNames()
+    clean_names = cleanNames(table.getColumnNames())
+    num_rows = table.rowCount()
+    constraints =[]
+    for row in range(num_rows):
+        value = {}
+        for name, clean in zip(table_cols, clean_names):
+            data = table.row(row)[name]
+            value[clean] = data
+        # provide LHS element, RHS element, mult. factor, flag
+        # if flag=True inequality; if flag = False equality
+        cons = constraint(value["lhselement"], value["rhselement"], evaluate(value["scatteringcrosssection"]), value["state"])
+        constraints.append(cons)
+    return constraints
 
 
 def evaluate(input):

--- a/scripts/Inelastic/vesuvio/analysisHelpers.py
+++ b/scripts/Inelastic/vesuvio/analysisHelpers.py
@@ -578,19 +578,20 @@ def generate_elements(table):
 
 
 def generate_constraints(table):
-    table_cols = table.getColumnNames()
-    clean_names = cleanNames(table.getColumnNames())
-    num_rows = table.rowCount()
     constraints =[]
-    for row in range(num_rows):
-        value = {}
-        for name, clean in zip(table_cols, clean_names):
-            data = table.row(row)[name]
-            value[clean] = data
-        # provide LHS element, RHS element, mult. factor, flag
-        # if flag=True inequality; if flag = False equality
-        cons = constraint(value["lhselement"], value["rhselement"], evaluate(value["scatteringcrosssection"]), value["state"])
-        constraints.append(cons)
+    if table and table.rowCount() > 0:
+        table_cols = table.getColumnNames()
+        clean_names = cleanNames(table.getColumnNames())
+        num_rows = table.rowCount()
+        for row in range(num_rows):
+            value = {}
+            for name, clean in zip(table_cols, clean_names):
+                data = table.row(row)[name]
+                value[clean] = data
+            # provide LHS element, RHS element, mult. factor, flag
+            # if flag=True inequality; if flag = False equality
+            cons = constraint(value["lhselement"], value["rhselement"], evaluate(value["scatteringcrosssection"]), value["state"])
+            constraints.append(cons)
     return constraints
 
 


### PR DESCRIPTION
**Description of work.**

In the past VesuvioAnalysis only allowed to set a single constraint on element peaks with help of a list of two items. Usually there are more than two element peaks though and it would be beneficial to use several constraints simultaneously.

There were three properties involved to define a single constraint, ConstraintsProfileNumbers, ConstraintsProfileScatteringCrossSection and ConstraintsProfileState. ConstraintsProfileNumbers was an IntArrayProperty. 
Now the constraints are defined using a ITableWorkspaceProperty with columns for ConstraintsProfileNumbers, ConstraintsProfileScatteringCrossSection and ConstraintsProfileState. The table allows to set several rows with each row defining a separate constraint.

**To test:**

Code review and check Jenkins jobs all succeed

<!-- Instructions for testing. -->

Fixes #[32880](https://github.com/mantidproject/mantid/issues/32880). 


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
