### PR TITLE
stop results table from selecting all when a new fit is performed.

### DIFF
--- a/docs/source/release/v6.3.0/muon.rst
+++ b/docs/source/release/v6.3.0/muon.rst
@@ -98,5 +98,6 @@ Improvements
   - A bug has been fixed that caused Model fitting to not update it's results table list.
   - Plotting in Model fitting now features a greater number of units for parameters and sample logs.
   - The dates and times for relevant parameters in model fitting have been formatted so that they can be plotted with relative spacing.
+  - When a new fit is performed in Muon Analysis it no longer reselects all parameter workspaces in the results tab.
 
 

--- a/docs/source/release/v6.3.0/muon.rst
+++ b/docs/source/release/v6.3.0/muon.rst
@@ -51,6 +51,7 @@ Bugfixes
 - On the model analysis tab, the fit range will now update when the x axis is changed.
 - Fixed a bug that prevented the model analysis plot showing when data was binned.
 - When a new results table is created the Model Analysis tab selects the default parameters to plot based on log values or parameters in the results table.
+- When a new fit is performed in Muon Analysis it no longer reselects all parameter workspaces in the results tab.
 
 ALC
 ---
@@ -98,6 +99,5 @@ Improvements
   - A bug has been fixed that caused Model fitting to not update it's results table list.
   - Plotting in Model fitting now features a greater number of units for parameters and sample logs.
   - The dates and times for relevant parameters in model fitting have been formatted so that they can be plotted with relative spacing.
-  - When a new fit is performed in Muon Analysis it no longer reselects all parameter workspaces in the results tab.
 
 

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/results_tab_widget/results_tab_presenter.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/results_tab_widget/results_tab_presenter.py
@@ -107,6 +107,11 @@ class ResultsTabPresenter(QObject):
         """Update the view of results workspaces based on the current model"""
         workspace_list, function_name = self._get_workspace_list()
         self.view.set_selected_fit_function(function_name)
+
+        current_view = self.view.fit_result_workspaces()
+        not_selected = [key for key in current_view.keys() if not current_view[key][1]]
+        workspace_list = [ws for ws in workspace_list if ws not in not_selected]
+
         selection = self.model.fit_selection(workspace_list)
         self.view.set_fit_result_workspaces(selection)
 

--- a/qt/python/mantidqtinterfaces/test/Muon/results_tab_widget/results_tab_presenter_test.py
+++ b/qt/python/mantidqtinterfaces/test/Muon/results_tab_widget/results_tab_presenter_test.py
@@ -1,3 +1,4 @@
+
 # Mantid Repository : https://github.com/mantidproject/mantid
 #
 # Copyright &copy; 2019 ISIS Rutherford Appleton Laboratory UKRI,
@@ -67,7 +68,7 @@ class ResultsTabPresenterTest(unittest.TestCase):
 
     def test_adding_new_fit_to_existing_fits_preserves_current_selections(
             self):
-        orig_ws_list_state = ['ws1', 'ws3']
+        orig_ws_list_state = {'ws1': [0, True, True], 'ws3': [1, False, True]}
         final_ws_list_state = ['ws1', 'ws3']
         test_functions = ['func1', 'func2']
         self.mock_model.fit_functions.return_value = test_functions
@@ -81,7 +82,7 @@ class ResultsTabPresenterTest(unittest.TestCase):
         presenter.on_new_fit_performed()
 
         self.mock_model.fit_functions.assert_called_once_with()
-        self.mock_model.fit_selection.assert_called_once_with(orig_ws_list_state)
+        self.mock_model.fit_selection.assert_called_once_with(['ws1'])
         self.mock_view.set_fit_function_names.assert_called_once_with(
             test_functions)
         self.mock_view.set_fit_result_workspaces.assert_called_once_with(


### PR DESCRIPTION
**Description of work.**

This PR makes sure that the results tab retains the previously selected parameters when a new fit is performed.

**Report to:** James Lord

**To test:**

1. Muon Analysis
2. Load MUSR 62260
3. Go Fitting tab and add a GausOsc function
4. Do a fit
5. Go to results tab and unselect the parameters table you just created
6. Go to fitting tab and step to a different group
7. Do a fit
8. Go to results tab and you can see that the parameters to deselected are still unselected

Fixes #32470

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
