### PR TITLE
Muon resize fix

### DIFF
--- a/docs/source/release/v6.3.0/muon.rst
+++ b/docs/source/release/v6.3.0/muon.rst
@@ -43,7 +43,8 @@ Improvements
 - The `alpha` values on grouping tab are now to six decimal places.
 - The numerical values in the `run info` box on the home tab are now rounded to either 4 significant figures or a whole number, whichever is more precise.
 - The results table now produces errors for log values (when they are available).
-- Changes have been made to improve the speed of Muon Analysis and Frequency Domain Analysis
+- Changes have been made to improve the speed of Muon Analysis and Frequency Domain Analysis.
+- On resizing priority is given to plotting.
 
 Bugfixes
 ########
@@ -51,6 +52,7 @@ Bugfixes
 - On the model analysis tab, the fit range will now update when the x axis is changed.
 - Fixed a bug that prevented the model analysis plot showing when data was binned.
 - When a new results table is created the Model Analysis tab selects the default parameters to plot based on log values or parameters in the results table.
+- Detaching tabs, then closing Mantid no longer causes a crash.
 
 ALC
 ---

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/dock/dockable_tabs.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/dock/dockable_tabs.py
@@ -265,11 +265,11 @@ class DetachableTabWidget(QtWidgets.QTabWidget):
         Close all tabs that are currently detached.
         """
         list_of_detached_tabs = []
-
         for key in self.detachedTabs:
             list_of_detached_tabs.append(self.detachedTabs[key])
 
         for detachedTab in list_of_detached_tabs:
+            detachedTab.onCloseSignal.disconnect()
             detachedTab.close()
 
     class DetachedTab(QtWidgets.QMainWindow):

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/dock/dockable_tabs.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/dock/dockable_tabs.py
@@ -151,7 +151,8 @@ class DetachableTabWidget(QtWidgets.QTabWidget):
         self.attached_tab_names.insert(insert_at, name)
         # Make the content widget a child of this widget
         content_widget.setParent(self)
-
+        # Remove the signal
+        self.detachedTabs[name].onCloseSignal.disconnect()
         # Remove the reference
         del self.detachedTabs[name]
 

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/FrequencyDomainAnalysis/frequency_domain_analysis.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/FrequencyDomainAnalysis/frequency_domain_analysis.py
@@ -153,7 +153,8 @@ class FrequencyAnalysisGui(QtWidgets.QMainWindow):
         vertical_layout.addWidget(self.tabs)
         vertical_layout.addWidget(self.help_widget.view)
         central_widget.setLayout(vertical_layout)
-
+        central_widget.setSizePolicy(QtWidgets.QSizePolicy(QtWidgets.QSizePolicy.Maximum,
+                                     QtWidgets.QSizePolicy.Maximum))
         self.disable_notifier = GenericObservable()
         self.disable_observer = GenericObserver(
             self.disable_notifier.notify_subscribers)

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/MuonAnalysis/muon_analysis_2.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/MuonAnalysis/muon_analysis_2.py
@@ -144,7 +144,8 @@ class MuonAnalysisGui(QtWidgets.QMainWindow):
         vertical_layout.addWidget(self.tabs)
         vertical_layout.addWidget(self.help_widget.view)
         central_widget.setLayout(vertical_layout)
-
+        central_widget.setSizePolicy(QtWidgets.QSizePolicy(QtWidgets.QSizePolicy.Maximum,
+                                     QtWidgets.QSizePolicy.Maximum))
         self.setCentralWidget(central_widget)
         self.setWindowTitle(self.context.window_title)
 


### PR DESCRIPTION
**Description of work.**

We got some complaints that the muon GUI would not provide priority to the plotting when being resized. This PR fixes this.

It also fixes a bug that caused Mantid to crash after undocking some tabs.

**To test:**

<!-- Instructions for testing. -->
Open muon analysis
Resize the window and the plot should change but not the tabs
If you remove the tabs (double click them) then the tab area will shrink
Close muon analysis (not the tabs)
The tabs will vanish as expected
Close Mantid - no longer throws an error

Open Mantid
Open Frequency Domain Analysis
Resize the window and the plot should change but not the tabs

Fixes #32791. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
