### PR TITLE
Fix ADS observer behaviour on Fitting tab in Engineering Diffraction UI

### DIFF
--- a/docs/source/release/v6.3.0/diffraction.rst
+++ b/docs/source/release/v6.3.0/diffraction.rst
@@ -48,12 +48,14 @@ Improvements
 - The plot on the fitting tab is now made larger when undocked, unless the size of the overall interface has been expanded significantly.
 - Updated the default values for :ref:`EnggEstimateFocussedBackground <algm-EnggEstimateFocussedBackground>` and in the fitting tab table to Niter = 50 and XWindow = { 600 for TOF, 0.02 for dSpacing }.
 - The file filter in the Focus tab for calibration Region includes "No Region Filter", North, South and now also Cropped, Custom, Texture and Both Banks. The text for "No Unit/Region Filter" are colored grey.
+- The fitting tab has been made more tolerant to users deleting or renaming the workspaces in the workbench Workspaces widget.
 
 Bugfixes
 ########
 - Save .prm file from :ref:`Calibration tab <ui engineering calibration>` with correct L2 and two-theta for each group in arbitrary groupings (previously only correct for the two ENGIN-X banks).
 - The last calibration file (.prm) populated in the :ref:`Calibration tab <ui engineering calibration>` is now correct when both banks are focused (previously was populated with just the South bank .prm)
 - Fix crash on :ref:`Fitting tab <ui engineering fitting>` when trying to output fit results. The problem was caused by a unit conversion from TOF to dSpacing not being possible eg when peak centre at a negative TOF value
+- The Serial and Sequential fit features on the Fitting tab now respect the "Subtract BG" checkbox in the table and use the background subtracted workspace where this is checked
 
 
 Single Crystal Diffraction

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/engineering_diffraction_io.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/engineering_diffraction_io.py
@@ -36,7 +36,7 @@ class EngineeringDiffractionEncoder(EngineeringDiffractionUIAttributes):
         else:
             obj_dic["settings_dict"] = presenter.settings_presenter.model.get_settings_dict(SETTINGS_KEYS_TYPES)
         if data_widget.model._data_workspaces.get_ws_names_dict():
-            obj_dic["data_loaded_workspaces"] = [*data_widget.model._data_workspaces.get_ws_names_dict()]
+            obj_dic["data_workspaces"] = data_widget.model._data_workspaces.get_ws_names_dict()
             obj_dic["fit_results"] = data_widget.model.get_fit_results()
             obj_dic["plotted_workspaces"] = [*data_widget.presenter.plotted]
             if plot_widget.view.fit_browser.read_current_fitprop():
@@ -60,7 +60,7 @@ class EngineeringDiffractionDecoder(EngineeringDiffractionUIAttributes):
         if obj_dic["encoder_version"] != IO_VERSION:
             logger.error("Engineering Diffraction Interface encoder used different version, restoration may fail")
 
-        ws_names = obj_dic.get("data_loaded_workspaces", None)  # workspaces are in ADS, need restoring into interface
+        ws_names = obj_dic.get("data_workspaces", None)  # workspaces are in ADS, need restoring into interface
         gui = EngineeringDiffractionGui()
         presenter = gui.presenter
         gui.tabs.setCurrentIndex(obj_dic["current_tab"])

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/engineering_diffraction_io.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/engineering_diffraction_io.py
@@ -35,8 +35,8 @@ class EngineeringDiffractionEncoder(EngineeringDiffractionUIAttributes):
             obj_dic["settings_dict"] = presenter.settings_presenter.settings
         else:
             obj_dic["settings_dict"] = presenter.settings_presenter.model.get_settings_dict(SETTINGS_KEYS_TYPES)
-        if data_widget.model._workspaces.get_ws_names_dict():
-            obj_dic["data_loaded_workspaces"] = [*data_widget.model._workspaces.get_ws_names_dict()]
+        if data_widget.model._data_workspaces.get_ws_names_dict():
+            obj_dic["data_loaded_workspaces"] = [*data_widget.model._data_workspaces.get_ws_names_dict()]
             obj_dic["fit_results"] = data_widget.model.get_fit_results()
             obj_dic["plotted_workspaces"] = [*data_widget.presenter.plotted]
             if plot_widget.view.fit_browser.read_current_fitprop():

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/engineering_diffraction_io.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/engineering_diffraction_io.py
@@ -35,11 +35,10 @@ class EngineeringDiffractionEncoder(EngineeringDiffractionUIAttributes):
             obj_dic["settings_dict"] = presenter.settings_presenter.settings
         else:
             obj_dic["settings_dict"] = presenter.settings_presenter.model.get_settings_dict(SETTINGS_KEYS_TYPES)
-        if data_widget.presenter.get_loaded_workspaces():
-            obj_dic["data_loaded_workspaces"] = [*data_widget.presenter.get_loaded_workspaces().keys()]
+        if data_widget.model._workspaces.get_ws_names_dict():
+            obj_dic["data_loaded_workspaces"] = [*data_widget.model._workspaces.get_ws_names_dict()]
             obj_dic["fit_results"] = data_widget.model.get_fit_results()
             obj_dic["plotted_workspaces"] = [*data_widget.presenter.plotted]
-            obj_dic["background_params"] = data_widget.model.get_bg_params()
             if plot_widget.view.fit_browser.read_current_fitprop():
                 obj_dic["fit_properties"] = plot_widget.view.fit_browser.read_current_fitprop()
                 obj_dic["plot_diff"] = str(plot_widget.view.fit_browser.plotDiff())
@@ -69,7 +68,6 @@ class EngineeringDiffractionDecoder(EngineeringDiffractionUIAttributes):
         presenter.settings_presenter.settings = obj_dic["settings_dict"]
         if ws_names is not None:
             fit_data_widget = presenter.fitting_presenter.data_widget
-            fit_data_widget.model._bg_params = obj_dic["background_params"]
             fit_data_widget.model.restore_files(ws_names)
             fit_data_widget.presenter.plotted = set(obj_dic["plotted_workspaces"])
             fit_data_widget.presenter.restore_table()

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/common/calibration_info.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/common/calibration_info.py
@@ -127,7 +127,12 @@ class CalibrationInfo:
         """
         filepath = path.splitext(self.prm_filepath)[0] + '.nxs'  # change extension to .nxs
         self.calibration_table = output_prefix + "_calibration_" + self.get_group_suffix()
-        Load(Filename=filepath, OutputWorkspace=self.calibration_table)
+
+        try:
+            Load(Filename=filepath, OutputWorkspace=self.calibration_table)
+        except Exception as e:
+            logger.error("Unable to loading calibration file " + filepath + ". Error: " + str(e))
+
         # load in custom grouping - checks if applicable inside method
         if not self.group.banks:
             self.load_custom_grouping_workspace()

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/common/calibration_info.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/common/calibration_info.py
@@ -131,7 +131,7 @@ class CalibrationInfo:
         try:
             Load(Filename=filepath, OutputWorkspace=self.calibration_table)
         except Exception as e:
-            logger.error("Unable to loading calibration file " + filepath + ". Error: " + str(e))
+            logger.error("Unable to load calibration file " + filepath + ". Error: " + str(e))
 
         # load in custom grouping - checks if applicable inside method
         if not self.group.banks:

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/data_handling/data_model.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/data_handling/data_model.py
@@ -20,7 +20,7 @@ from collections import defaultdict, OrderedDict
 from re import findall, sub
 
 
-class WorkspaceRecord:
+class FittingWorkspaceRecord:
     """ Record that maps the workspace the user has loaded to the derived background-subtracted workspace"""
     def __init__(self, **kwargs):
         self.loaded_ws = kwargs.get('loaded_ws', None)
@@ -42,7 +42,7 @@ class WorkspaceRecord:
             return self.loaded_ws
 
 
-class WorkspaceRecordContainer:
+class FittingWorkspaceRecordContainer:
     def __init__(self):
         self.dict = OrderedDict()
 
@@ -59,7 +59,7 @@ class WorkspaceRecordContainer:
         return self.dict.get(key, default_value)
 
     def add(self, ws_name, **kwargs):
-        self.dict[ws_name] = WorkspaceRecord(**kwargs)
+        self.dict[ws_name] = FittingWorkspaceRecord(**kwargs)
 
     def add_from_names_dict(self, dict):
         for key, value in dict.items():
@@ -71,7 +71,7 @@ class WorkspaceRecordContainer:
     def get_bgsub_workpace_names(self):
         return [w.bgsub_ws_name for w in self.dict.values()]
 
-    # Set of methods that each return a two column dictionary for the various fields in WorkspaceRecord
+    # Set of methods that each return a two column dictionary for the various fields in FittingWorkspaceRecord
     def get_loaded_ws_dict(self):
         return dict([(key, value.loaded_ws) for key, value in self.dict.items()])
 
@@ -136,7 +136,7 @@ class FittingDataModel(object):
         self._fit_results = {}  # {WorkspaceName: fit_result_dict}
         self._fit_workspaces = None
         self._last_added = []  # List of workspace names loaded in the last load action.
-        self._data_workspaces = WorkspaceRecordContainer()
+        self._data_workspaces = FittingWorkspaceRecordContainer()
 
     def restore_files(self, ws_names):
         self._data_workspaces.add_from_names_dict(ws_names)

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/data_handling/data_model.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/data_handling/data_model.py
@@ -295,8 +295,8 @@ class FittingDataModel(object):
     def get_active_ws_name(self, loaded_ws_name):
         return self._data_workspaces.get_active_ws_name(loaded_ws_name)
 
-    def get_ws_sorted_by_primary_log(self, ws_list):
-        tof_ws_inds = [ind for ind, ws in enumerate(ws_list) if
+    def get_ws_sorted_by_primary_log(self, ws_name_list):
+        tof_ws_inds = [ind for ind, ws in enumerate(ws_name_list) if
                        self._data_workspaces[ws].getAxis(0).getUnit().caption() == 'Time-of-flight']
         primary_log = get_setting(output_settings.INTERFACES_SETTINGS_GROUP, output_settings.ENGINEERING_PREFIX,
                                   "primary_log")
@@ -305,9 +305,9 @@ class FittingDataModel(object):
         if primary_log:
             log_table = ADS.retrieve(primary_log)
             isort = argsort(array(log_table.column('avg')))
-            ws_list_tof = [ws_list[iws] for iws in isort if iws in tof_ws_inds]
+            ws_list_tof = [ws_name_list[iws] for iws in isort if iws in tof_ws_inds]
         else:
-            ws_list_tof = ws_list
+            ws_list_tof = ws_name_list
         if sort_ascending == 'false':
             # settings can only be saved as text
             ws_list_tof = ws_list_tof[::-1]

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/data_handling/data_model.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/data_handling/data_model.py
@@ -20,31 +20,107 @@ from collections import defaultdict
 from re import findall, sub
 
 
+class WorkspaceRecord:
+    def __init__(self, **kwargs):
+        self.loaded_ws = kwargs.get('loaded_ws', None)
+        self.bgsub_ws_name = kwargs.get('bgsub_ws_name', None)
+        self.bgsub_ws = kwargs.get('bgsub_ws', None)
+        self.bg_params = kwargs.get('bg_params', [])  # [isSub, niter, xwindow, doSG]
+
+    def get_active_ws(self):
+        if self.bgsub_ws and self.bg_params[0]:
+            # first element is isSub checkbox
+            return self.bgsub_ws
+        else:
+            return self.loaded_ws
+
+
+class WorkspaceRecordContainer:
+    def __init__(self):
+        self.dict = {}
+
+    def __getitem__(self, key):
+        return self.dict[key]
+
+    def add(self, ws_name, **kwargs):
+        self.dict[ws_name] = WorkspaceRecord(**kwargs)
+
+    def add_from_names_dict(self, dict):
+        for key, value in dict.items():
+            self.add(key, ws_name=value.ws_name, bgsub_name=value.bgsub_ws_name, bg_params=value.bg_params)
+
+    def get_loaded_workpace_names(self):
+        return list(self.dict.keys())
+
+    def get_bgsub_workpace_names(self):
+        return [w.bgsub_ws_name for w in self.dict.values()]
+
+    def get_bg_params_dict(self):
+        return dict([(key, value.bg_params) for key, value in self.dict.items()])
+
+    def get_loaded_ws_dict(self):
+        return dict([(key, value.loaded_ws) for key, value in self.dict.items()])
+
+    def get_bgsub_ws_dict(self):
+        return dict([(key, value.bgsub_ws) for key, value in self.dict.items()])
+
+    def get_ws_names_dict(self):
+        return dict([(key, [value.bgsub_ws_name, value.bg_params]) for key, value in self.dict.items()])
+
+    def get_loaded_workspace_from_bgsub(self, bgsub_ws_name):
+        return next((key for key, val in self.dict.items() if val.bgsub_ws_name == bgsub_ws_name), None)
+
+    def get_active_ws_list(self):
+        return dict([(key, value.bgsub_ws if value.bg_params and value.bg_params[0] else value.loaded_ws)
+                     for key, value in self.dict.items()])
+
+    def rename(self, old_ws_name, new_ws_name):
+        ws_loaded = self.dict.get(old_ws_name, None)
+        if ws_loaded:
+            self.dict[new_ws_name]= self.pop(old_ws_name)
+        else:
+            ws_loaded = self.get_loaded_workspace_from_bgsub(old_ws_name)
+            if ws_loaded:
+                self.dict[ws_loaded].bgsub_ws_name = new_ws_name
+
+    def replace_workspace(self, name, workspace):
+        ws_loaded = self.dict.get(name, None)
+        if ws_loaded:
+            self.dict[name].loaded_ws = workspace
+        else:
+            ws_loaded = self.get_loaded_workspace_from_bgsub(name)
+            if ws_loaded:
+                self.dict[ws_loaded].bgsub_ws = workspace
+
+    def pop(self, ws_name):
+        return self.dict.pop(ws_name)
+
+    def clear(self):
+        self.dict.clear()
+
+
 class FittingDataModel(object):
     def __init__(self):
         self._log_names = []
         self._log_workspaces = None
         self._log_values = dict()  # {ws_name: {log_name: [avg, er]} }
-        self._loaded_workspaces = {}  # Map stores using {WorkspaceName: Workspace}
-        self._bg_sub_workspaces = {}  # Map as above, this contains the workspaces with the background sub applied
         self._fit_results = {}  # {WorkspaceName: fit_result_dict}
         self._fit_workspaces = None
         self._last_added = []  # List of workspace names loaded in the last load action.
-        self._bg_params = dict()  # {ws_name: [isSub, niter, xwindow, doSG]}
+        self._workspaces = WorkspaceRecordContainer()
 
     def restore_files(self, ws_names):
+        self._workspaces.add_from_names_dict(ws_names)
         for ws_name in ws_names:
             try:
                 ws = ADS.retrieve(ws_name)
                 if ws.getNumberHistograms() == 1:
-                    self._loaded_workspaces[ws_name] = ws
-                    if self._bg_params[ws_name]:
-                        self._bg_sub_workspaces[ws_name] = ADS.retrieve(ws_name + "_bgsub")
-                    else:
-                        self._bg_sub_workspaces[ws_name] = None
-                    if ws_name not in self._bg_params:
-                        self._bg_params[ws_name] = []
+                    bgsubws = None
+                    if self._workspaces[ws_name].bg_params:
+                        bgsubws= ADS.retrieve(self._workspaces[ws_name].bgsub_ws_name)
                     self._last_added.append(ws_name)
+                    self._workspaces.set_ws(ws_name, ws)
+                    self._workspaces[ws_name].bgsub_ws=bgsubws
                 else:
                     logger.warning(
                         f"Invalid number of spectra in workspace {ws_name}. Skipping restoration of workspace.")
@@ -58,19 +134,15 @@ class FittingDataModel(object):
         filenames = [name.strip() for name in filenames_string.split(",")]
         for filename in filenames:
             ws_name = self._generate_workspace_name(filename)
-            if ws_name not in self._loaded_workspaces:
+            if ws_name not in self._workspaces.get_loaded_workpace_names():
                 try:
                     if not ADS.doesExist(ws_name):
                         ws = Load(filename, OutputWorkspace=ws_name)
                     else:
                         ws = ADS.retrieve(ws_name)
                     if ws.getNumberHistograms() == 1:
-                        self._loaded_workspaces[ws_name] = ws
-                        if ws_name not in self._bg_sub_workspaces:
-                            self._bg_sub_workspaces[ws_name] = None
-                        if ws_name not in self._bg_params:
-                            self._bg_params[ws_name] = []
                         self._last_added.append(ws_name)
+                        self._workspaces.add(ws_name, loaded_ws=ws)
                     else:
                         logger.warning(
                             f"Invalid number of spectra in workspace {ws_name}. Skipping loading of file.")
@@ -121,7 +193,7 @@ class FittingDataModel(object):
                 self.make_runinfo_table()
                 self._log_workspaces.add("run_info")
         # update log tables
-        for irow, (ws_name, ws) in enumerate(self._loaded_workspaces.items()):
+        for irow, (ws_name, ws) in enumerate(self._workspaces.get_loaded_ws_dict().items()):
             self.add_log_to_table(ws_name, ws, irow)  # rename write_log_row
 
     def add_log_to_table(self, ws_name, ws, irow):
@@ -175,13 +247,18 @@ class FittingDataModel(object):
         else:
             self.clear_logs()
 
-    def get_ws_list(self):
-        return list(self._loaded_workspaces.keys())
+    def get_loaded_ws_list(self):
+        return list(self._workspaces.get_loaded_ws_dict().keys())
 
-    def get_ws_sorted_by_primary_log(self):
-        ws_list = self.get_ws_list()
+    def get_active_ws_list(self):
+        return self._workspaces.get_active_ws_list()
+
+    def get_active_ws(self, ws_name):
+        return self._workspaces[ws_name].get_active_ws()
+
+    def get_ws_sorted_by_primary_log(self, ws_list):
         tof_ws_inds = [ind for ind, ws in enumerate(ws_list) if
-                       self._loaded_workspaces[ws].getAxis(0).getUnit().caption() == 'Time-of-flight']
+                       self._workspaces[ws].getAxis(0).getUnit().caption() == 'Time-of-flight']
         primary_log = get_setting(output_settings.INTERFACES_SETTINGS_GROUP, output_settings.ENGINEERING_PREFIX,
                                   "primary_log")
         sort_ascending = get_setting(output_settings.INTERFACES_SETTINGS_GROUP, output_settings.ENGINEERING_PREFIX,
@@ -236,7 +313,7 @@ class FittingDataModel(object):
     def create_fit_tables(self):
         wslist = []  # ws to be grouped
         # extract fit parameters and errors
-        nruns = len(self._loaded_workspaces.keys())  # num of rows of output workspace
+        nruns = len(self.get_ws_list())  # num of rows of output workspace
         # get unique set of function parameters across all workspaces
         func_params = set(chain(*[list(d['results'].keys()) for d in self._fit_results.values()]))
         for param in func_params:
@@ -247,7 +324,7 @@ class FittingDataModel(object):
             ws = CreateWorkspace(OutputWorkspace=param, DataX=ipeak, DataY=ipeak, NSpec=nruns)
             # axis for labels in workspace
             axis = TextAxis.create(nruns)
-            for iws, wsname in enumerate(self._loaded_workspaces.keys()):
+            for iws, wsname in enumerate(self.get_ws_list()):
                 wsname_bgsub = wsname + "_bgsub"
                 if wsname_bgsub in self._fit_results:
                     wsname = wsname_bgsub
@@ -268,7 +345,7 @@ class FittingDataModel(object):
         model.addColumn(type="float", name="chisq/DOF")  # always is for LM minimiser (users can't change)
         model.addColumn(type="str", name="status")
         model.addColumn(type="str", name="Model")
-        for iws, wsname in enumerate(self._loaded_workspaces.keys()):
+        for iws, wsname in enumerate(self.get_ws_list()):
             if wsname in self._fit_results:
                 row = [wsname, self._fit_results[wsname]['costFunction'],
                        self._fit_results[wsname]['status'], self._fit_results[wsname]['model']]
@@ -279,49 +356,63 @@ class FittingDataModel(object):
         group_name = self._log_workspaces.name().split('_log')[0] + '_fits'
         self._fit_workspaces = GroupWorkspaces(wslist, OutputWorkspace=group_name)
 
+    def replace_workspace(self, name, workspace):
+        self._workspaces.replace_workspace(name, workspace)
+
     def update_workspace_name(self, old_name, new_name):
-        if new_name not in self._loaded_workspaces:
-            self._loaded_workspaces[new_name] = self._loaded_workspaces.pop(old_name)
-            if old_name in self._bg_sub_workspaces:
-                self._bg_sub_workspaces[new_name] = self._bg_sub_workspaces.pop(old_name)
-            if old_name in self._bg_params:
-                self._bg_params[new_name] = self._bg_params.pop(old_name)
+        if new_name not in self.get_all_workspace_names():
+            self._workspaces.rename(old_name, new_name)
             if old_name in self._log_values:
                 self._log_values[new_name] = self._log_values.pop(old_name)
         else:
             logger.warning(f"There already exists a workspace with name {new_name}.")
 
+    def clear_workspaces(self):
+        self._workspaces.clear()
+
+    def clear_workspace(self, loaded_ws_name):
+        removed = self._workspaces.pop(loaded_ws_name)
+        removed_ws_list = [removed.loaded_ws]
+        if removed.bgsub_ws:
+            removed_ws_list.append((removed.bgsub_ws))
+        return removed_ws_list
+
     def get_loaded_workspaces(self):
-        return self._loaded_workspaces
+        return self._workspaces.get_loaded_ws_dict()
+
+    def get_all_workspace_names(self):
+        return self._workspaces.get_loaded_workpace_names() + self._workspaces.get_bgsub_workpace_names()
 
     def get_log_workspaces_name(self):
         return [ws.name() for ws in self._log_workspaces] if self._log_workspaces else ''
 
     def get_bgsub_workspaces(self):
-        return self._bg_sub_workspaces
+        return self._workspaces.get_bgsub_ws_dict()
 
     def get_bg_params(self):
-        return self._bg_params
+        return self._workspaces.get_bg_params_dict()
 
     def get_fit_results(self):
         return self._fit_results
 
     def create_or_update_bgsub_ws(self, ws_name, bg_params):
-        ws = self._loaded_workspaces[ws_name]
-        ws_bg = self._bg_sub_workspaces[ws_name]
-        if not ws_bg or self._bg_params[ws_name] == [] or bg_params[1:] != self._bg_params[ws_name][1:]:
+        ws = self._workspaces[ws_name].loaded_ws
+        ws_bg = self._workspaces[ws_name].bgsub_ws
+        ws_bg_params = self._workspaces[ws_name].bg_params
+        if not ws_bg or ws_bg_params == [] or bg_params[1:] != ws_bg_params[1:]:
             background = self.estimate_background(ws_name, *bg_params[1:])
-            self._bg_params[ws_name] = bg_params
+            self._workspaces[ws_name].bg_params=bg_params
             bgsub_ws_name = ws_name + "_bgsub"
             bgsub_ws = Minus(LHSWorkspace=ws, RHSWorkspace=background, OutputWorkspace=bgsub_ws_name)
-            self._bg_sub_workspaces[ws_name] = bgsub_ws
+            self._workspaces[ws_name].bgsub_ws = bgsub_ws
+            self._workspaces[ws_name].bgsub_ws_name = bgsub_ws_name
             DeleteWorkspace(background)
         else:
             logger.notice("Background workspace already calculated")
 
     def update_bgsub_status(self, ws_name, status):
-        if self._bg_params[ws_name]:
-            self._bg_params[ws_name][0] = status
+        if self._workspaces[ws_name].bg_params:
+            self._workspaces[ws_name].bg_params[0] = status
 
     def estimate_background(self, ws_name, niter, xwindow, doSGfilter):
         try:
@@ -335,8 +426,8 @@ class FittingDataModel(object):
         return ws_bg
 
     def plot_background_figure(self, ws_name):
-        ws = self._loaded_workspaces[ws_name]
-        ws_bgsub = self._bg_sub_workspaces[ws_name]
+        ws = self._workspaces[ws_name].loaded_ws
+        ws_bgsub = self._workspaces[ws_name].bgsub_ws
         if ws_bgsub:
             fig, ax = subplots(2, 1, sharex=True, gridspec_kw={'height_ratios': [2, 1]},
                                subplot_kw={'projection': 'mantid'})
@@ -350,7 +441,7 @@ class FittingDataModel(object):
         return self._last_added
 
     def get_sample_log_from_ws(self, ws_name, log_name):
-        return self._loaded_workspaces[ws_name].getSampleDetails().getLogData(log_name).value
+        return self._workspaces[ws_name].loaded_ws.getSampleDetails().getLogData(log_name).value
 
     def set_log_workspaces_none(self):
         # to be used in the event of Ads clear, as trying to reference the deleted grp ws results in an error

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/data_handling/data_presenter.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/data_handling/data_presenter.py
@@ -72,8 +72,8 @@ class FittingDataPresenter(object):
 
     def remove_workspace(self, ws_name):
         if ws_name in self.model.get_all_workspace_names():
-            removed = self.model.remove_workspace(ws_name)
-            self.plot_removed_notifier.notify_subscribers(removed)
+            self.model.remove_workspace(ws_name)
+            # plot_presenter will already be notified of ws being removed via its own ADS observer
             self.plotted.discard(ws_name)
             self._repopulate_table()
         elif ws_name in self.model.get_log_workspaces_name():
@@ -99,15 +99,6 @@ class FittingDataPresenter(object):
         if name in self.model.get_all_workspace_names():
             self.model.replace_workspace(name, workspace)
             self._repopulate_table()
-
-    def get_loaded_workspaces(self):
-        return self.model.get_loaded_workspaces()
-
-    def get_bgsub_workspaces(self):
-        return self.model.get_bgsub_workspaces()
-
-    def get_bg_params(self):
-        return self.model.get_bg_params()
 
     def restore_table(self):  # used when the interface is being restored from a save or crash
         self._repopulate_table()
@@ -144,7 +135,7 @@ class FittingDataPresenter(object):
         self._remove_all_table_rows()
         self.row_numbers.clear()
         self.all_plots_removed_notifier.notify_subscribers()
-        workspaces = self.get_loaded_workspaces()
+        workspaces = self.model.get_loaded_workspaces()
         for i, name in enumerate(workspaces):
             try:
                 run_no = self.model.get_sample_log_from_ws(name, "run_number")

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/data_handling/data_presenter.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/data_handling/data_presenter.py
@@ -55,7 +55,7 @@ class FittingDataPresenter(object):
 
     def _start_seq_fit(self):
         ws_list = self.model.get_active_ws_list()
-        ws_list = self.model.get_ws_sorted_by_primary_log(ws_list)
+        ws_list = self.model.get_ws_sorted_by_primary_log(ws_list.keys())
         self.fit_all_started_notifier.notify_subscribers(ws_list, do_sequential=True)
 
     def _start_serial_fit(self):

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/data_handling/data_presenter.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/data_handling/data_presenter.py
@@ -80,12 +80,17 @@ class FittingDataPresenter(object):
 
     def rename_workspace(self, old_name, new_name):
         # Note - ws.name() not updated yet so need to rely on new_name parameter
+        # Also Note - ADS rename is always associated with a ADS replace so
+        # rely on the replace to _repopulate_table. Prefer not to call twice
+        # to avoid issue with legend entries doubling up
         if old_name in self.model.get_all_workspace_names():
             self.model.update_workspace_name(old_name, new_name)
             if old_name in self.plotted:
                 self.plotted.remove(old_name)
                 self.plotted.add(new_name)
-            self._repopulate_table()
+            if old_name in self.row_numbers: #bgsub not in row_numbers
+                row_no = self.row_numbers.pop(old_name)
+                self.row_numbers[new_name] = row_no
 
     # handle ADS clear
     def clear_workspaces(self):

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/data_handling/data_view.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/data_handling/data_view.py
@@ -95,7 +95,9 @@ class FittingDataView(QtWidgets.QWidget, Ui_data):
         self.button_SerialFit.clicked.connect(slot)
 
     def set_on_table_cell_changed(self, slot):
-        self.table_selection.cellChanged.connect(slot)  # Row, Col
+        # this signal gets triggered from a separate thread sometimes (eg load). So to make the handler
+        # more simple, always issue as a queued signal
+        self.table_selection.cellChanged.connect(slot, QtCore.Qt.QueuedConnection)
 
     def set_table_selection_changed(self, slot):
         self.table_selection.itemSelectionChanged.connect(slot)
@@ -172,11 +174,11 @@ class FittingDataView(QtWidgets.QWidget, Ui_data):
         SG_check_box.setFlags(SG_check_box.flags() & ~QtCore.Qt.ItemIsEditable)
         SG_check_box.setToolTip(
             'Apply linear Savitzky–Golay filter before first iteration of background subtraction (recommended)')
-        self.table_selection.setItem(row_no, 6, SG_check_box)
         if SG:
             SG_check_box.setCheckState(QtCore.Qt.Checked)
         else:
             SG_check_box.setCheckState(QtCore.Qt.Unchecked)
+        self.table_selection.setItem(row_no, 6, SG_check_box)
 
     def remove_table_row(self, row_no):
         self.table_selection.removeRow(row_no)

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/data_handling/data_view.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/data_handling/data_view.py
@@ -138,21 +138,23 @@ class FittingDataView(QtWidgets.QWidget, Ui_data):
         self.table_selection.setItem(row_no, 1, bank_item)
 
         plotted_check_box = QtWidgets.QTableWidgetItem()
+
         plotted_check_box.setFlags(plotted_check_box.flags() & ~QtCore.Qt.ItemIsEditable)
-        self.table_selection.setItem(row_no, 2, plotted_check_box)
         if plotted:
             plotted_check_box.setCheckState(QtCore.Qt.Checked)
         else:
             plotted_check_box.setCheckState(QtCore.Qt.Unchecked)
+        # setItem last so that cellChanged signal only fired once
+        self.table_selection.setItem(row_no, 2, plotted_check_box)
 
         bgsub_check_box = QtWidgets.QTableWidgetItem()
         bgsub_check_box.setFlags(bgsub_check_box.flags() & ~QtCore.Qt.ItemIsEditable)
         bgsub_check_box.setToolTip('Estimate the background using iterative low-pass (smoothing) filter algorithm')
-        self.table_selection.setItem(row_no, 3, bgsub_check_box)
         if bgsub:
             bgsub_check_box.setCheckState(QtCore.Qt.Checked)
         else:
             bgsub_check_box.setCheckState(QtCore.Qt.Unchecked)
+        self.table_selection.setItem(row_no, 3, bgsub_check_box)
 
         niter_item = QtWidgets.QTableWidgetItem()
         niter_item.setData(QtCore.Qt.EditRole, int(niter))

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/data_handling/data_view.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/data_handling/data_view.py
@@ -125,7 +125,7 @@ class FittingDataView(QtWidgets.QWidget, Ui_data):
         self.button_SeqFit.setEnabled(enabled)
         self.button_SerialFit.setEnabled(enabled)
 
-    def add_table_row(self, run_no, bank, checked, bgsub, niter, xwindow, SG):
+    def add_table_row(self, run_no, bank, plotted, bgsub, niter, xwindow, SG):
         row_no = self.table_selection.rowCount()
         self.table_selection.insertRow(row_no)
 
@@ -137,13 +137,13 @@ class FittingDataView(QtWidgets.QWidget, Ui_data):
         bank_item.setFlags(name_item.flags() & ~QtCore.Qt.ItemIsEditable)
         self.table_selection.setItem(row_no, 1, bank_item)
 
-        check_box = QtWidgets.QTableWidgetItem()
-        check_box.setFlags(check_box.flags() & ~QtCore.Qt.ItemIsEditable)
-        self.table_selection.setItem(row_no, 2, check_box)
-        if checked:
-            check_box.setCheckState(QtCore.Qt.Checked)
+        plotted_check_box = QtWidgets.QTableWidgetItem()
+        plotted_check_box.setFlags(plotted_check_box.flags() & ~QtCore.Qt.ItemIsEditable)
+        self.table_selection.setItem(row_no, 2, plotted_check_box)
+        if plotted:
+            plotted_check_box.setCheckState(QtCore.Qt.Checked)
         else:
-            check_box.setCheckState(QtCore.Qt.Unchecked)
+            plotted_check_box.setCheckState(QtCore.Qt.Unchecked)
 
         bgsub_check_box = QtWidgets.QTableWidgetItem()
         bgsub_check_box.setFlags(bgsub_check_box.flags() & ~QtCore.Qt.ItemIsEditable)

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/data_handling/data_widget.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/data_handling/data_widget.py
@@ -31,8 +31,6 @@ class FittingDataWidget(object):
         self.presenter.remove_workspace(workspace)
 
     def rename_workspace(self, old_name, new_name):
-        import pydevd_pycharm
-        pydevd_pycharm.settrace(stdoutToServer = True, stderrToServer = True)
         self.presenter.rename_workspace(old_name, new_name)
 
     def clear_workspaces(self):

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/data_handling/data_widget.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/data_handling/data_widget.py
@@ -31,6 +31,8 @@ class FittingDataWidget(object):
         self.presenter.remove_workspace(workspace)
 
     def rename_workspace(self, old_name, new_name):
+        import pydevd_pycharm
+        pydevd_pycharm.settrace(stdoutToServer = True, stderrToServer = True)
         self.presenter.rename_workspace(old_name, new_name)
 
     def clear_workspaces(self):

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/data_handling/test/test_data_model.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/data_handling/test/test_data_model.py
@@ -50,8 +50,8 @@ class TestFittingDataModel(unittest.TestCase):
 
         self.model.load_files("/ar/a_filename.whatever")
 
-        self.assertEqual(1, len(self.model._loaded_workspaces))
-        self.assertEqual(self.mock_ws, self.model._loaded_workspaces["a_filename"])
+        self.assertEqual(1, len(self.model._data_workspaces))
+        self.assertEqual(self.mock_ws, self.model._data_workspaces["a_filename"].loaded_ws)
         mock_load.assert_called_with("/ar/a_filename.whatever", OutputWorkspace="a_filename")
         mock_update_logws_group.assert_called_once()
 
@@ -64,7 +64,7 @@ class TestFittingDataModel(unittest.TestCase):
 
         self.model.load_files("/ar/a_filename.whatever")
 
-        self.assertEqual(1, len(self.model._loaded_workspaces))
+        self.assertEqual(1, len(self.model._data_workspaces))
         mock_load.assert_not_called()
         mock_update_logws_group.assert_called_once()
 
@@ -72,11 +72,11 @@ class TestFittingDataModel(unittest.TestCase):
     @patch(data_model_path + ".Load")
     def test_loading_single_file_already_loaded_tracked(self, mock_load, mock_update_logws_group):
         fpath = "/ar/a_filename.whatever"
-        self.model._loaded_workspaces = {self.model._generate_workspace_name(fpath): self.mock_ws}
+        self.model._data_workspaces.add(self.model._generate_workspace_name(fpath), loaded_ws=self.mock_ws)
 
         self.model.load_files(fpath)
 
-        self.assertEqual(1, len(self.model._loaded_workspaces))
+        self.assertEqual(1, len(self.model._data_workspaces))
         mock_load.assert_not_called()
         mock_update_logws_group.assert_called()
 
@@ -91,8 +91,8 @@ class TestFittingDataModel(unittest.TestCase):
 
         self.model.load_files("/ar/a_filename.whatever")
 
-        self.assertEqual(1, len(self.model._loaded_workspaces))
-        self.assertEqual(self.mock_ws, self.model._loaded_workspaces["a_filename"])
+        self.assertEqual(1, len(self.model._data_workspaces))
+        self.assertEqual(self.mock_ws, self.model._data_workspaces["a_filename"].loaded_ws)
         mock_load.assert_called_with("/ar/a_filename.whatever", OutputWorkspace="a_filename")
         self.assertEqual(1 + len(log_names), len(self.model._log_workspaces))
         for ilog in range(0, len(log_names)):
@@ -105,7 +105,7 @@ class TestFittingDataModel(unittest.TestCase):
         mock_load.side_effect = RuntimeError("Invalid Path")
 
         self.model.load_files("/ar/a_filename.whatever")
-        self.assertEqual(0, len(self.model._loaded_workspaces))
+        self.assertEqual(0, len(self.model._data_workspaces))
         mock_load.assert_called_with("/ar/a_filename.whatever", OutputWorkspace="a_filename")
         self.assertEqual(1, mock_logger.error.call_count)
 
@@ -116,9 +116,9 @@ class TestFittingDataModel(unittest.TestCase):
 
         self.model.load_files("/dir/file1.txt, /dir/file2.nxs")
 
-        self.assertEqual(2, len(self.model._loaded_workspaces))
-        self.assertEqual(self.mock_ws, self.model._loaded_workspaces["file1"])
-        self.assertEqual(self.mock_ws, self.model._loaded_workspaces["file2"])
+        self.assertEqual(2, len(self.model._data_workspaces))
+        self.assertEqual(self.mock_ws, self.model._data_workspaces["file1"].loaded_ws)
+        self.assertEqual(self.mock_ws, self.model._data_workspaces["file2"].loaded_ws)
         mock_load.assert_any_call("/dir/file1.txt", OutputWorkspace="file1")
         mock_load.assert_any_call("/dir/file2.nxs", OutputWorkspace="file2")
         mock_update_logws_group.assert_called_once()
@@ -131,7 +131,7 @@ class TestFittingDataModel(unittest.TestCase):
 
         self.model.load_files("/dir/file1.txt, /dir/file2.nxs")
 
-        self.assertEqual(0, len(self.model._loaded_workspaces))
+        self.assertEqual(0, len(self.model._data_workspaces))
         mock_load.assert_any_call("/dir/file1.txt", OutputWorkspace="file1")
         mock_load.assert_any_call("/dir/file2.nxs", OutputWorkspace="file2")
         self.assertEqual(2, mock_logger.warning.call_count)
@@ -143,7 +143,7 @@ class TestFittingDataModel(unittest.TestCase):
 
         self.model.load_files("/dir/file1.txt, /dir/file2.nxs")
 
-        self.assertEqual(0, len(self.model._loaded_workspaces))
+        self.assertEqual(0, len(self.model._data_workspaces))
         mock_load.assert_any_call("/dir/file1.txt", OutputWorkspace="file1")
         mock_load.assert_any_call("/dir/file2.nxs", OutputWorkspace="file2")
         self.assertEqual(2, mock_logger.error.call_count)
@@ -239,23 +239,24 @@ class TestFittingDataModel(unittest.TestCase):
         mock_delws.assert_called_with(name)
         self.assertEqual(None, self.model._log_workspaces)
 
-    def test_update_workspace_name(self):
-        self.model._loaded_workspaces = {"name1": self.mock_ws, "name2": self.mock_ws}
-        self.model._bg_sub_workspaces = {"name1": self.mock_ws, "name2": self.mock_ws}
-        self.model._bg_params = {"name1": [True, 80, 1000, False]}
-        self.model._log_values = {"name1": 1, "name2": 2}
+    @patch(data_model_path + ".FittingDataModel.update_log_workspace_group")
+    def test_update_workspace_name(self, mock_update_log_ws_group):
+        self.model._data_workspaces.add("name1", loaded_ws=self.mock_ws, bgsub_ws=self.mock_ws, bg_params=[True, 80, 1000, False])
+        self.model._data_workspaces.add("name2", loaded_ws=self.mock_ws, bgsub_ws=self.mock_ws)
+        self.model._log_values = {"name1": {"log_name1" : 1}, "name2": {"log_name1": 2}}
 
         self.model.update_workspace_name("name1", "new_name")
 
-        self.assertEqual({"new_name": self.mock_ws, "name2": self.mock_ws}, self.model._loaded_workspaces)
-        self.assertEqual({"new_name": self.mock_ws, "name2": self.mock_ws}, self.model._bg_sub_workspaces)
-        self.assertEqual({"new_name": [True, 80, 1000, False]}, self.model._bg_params)
-        self.assertEqual({"new_name": 1, "name2": 2}, self.model._log_values)
+        self.assertEqual({"new_name": self.mock_ws, "name2": self.mock_ws}, self.model._data_workspaces.get_loaded_ws_dict())
+        self.assertEqual({"new_name": self.mock_ws, "name2": self.mock_ws}, self.model._data_workspaces.get_bgsub_ws_dict())
+        self.assertEqual({"name2":[], "new_name": [True, 80, 1000, False]}, self.model._data_workspaces.get_bg_params_dict())
+        self.assertEqual({"new_name": {"log_name1" : 1}, "name2": {"log_name1": 2}}, self.model._log_values)
 
+    @patch(data_model_path + ".FittingDataModel.remove_all_log_rows")
     @patch(data_model_path + ".FittingDataModel.create_log_workspace_group")
     @patch(data_model_path + ".FittingDataModel.add_log_to_table")
-    def test_update_logs_initial(self, mock_add_log, mock_create_log_group):
-        self.model._loaded_workspaces = {"name1": self.mock_ws}
+    def test_update_logs_initial(self, mock_add_log, mock_create_log_group, mock_remove_all_log_rows):
+        self.model._data_workspaces.add("name1", loaded_ws=self.mock_ws)
         self.model._log_workspaces = None
 
         self.model.update_log_workspace_group()
@@ -269,7 +270,7 @@ class TestFittingDataModel(unittest.TestCase):
     @patch(data_model_path + ".ADS")
     def test_update_logs_deleted(self, mock_ads, mock_add_log, mock_create_log_group, mock_make_runinfo,
                                  mock_make_log_table):
-        self.model._loaded_workspaces = {"name1": self.mock_ws}
+        self.model._data_workspaces.add("name1", loaded_ws=self.mock_ws)
         self.model._log_workspaces = mock.MagicMock()
         self.model._log_names = ['LogName1', 'LogName2']
         # simulate LogName2 and run_info tables being deleted
@@ -405,7 +406,8 @@ class TestFittingDataModel(unittest.TestCase):
         mock_create_table.return_value = mock.MagicMock()
         mock_groupws.side_effect = lambda wslist, OutputWorkspace: wslist
         # setup fit results
-        self.model._loaded_workspaces = {"name1": self.mock_ws, "name2": self.mock_ws}
+        self.model._data_workspaces.add("name1", loaded_ws=self.mock_ws)
+        self.model._data_workspaces.add("name2", loaded_ws=self.mock_ws)
         self.model._log_workspaces = mock.MagicMock()
         self.model._log_workspaces.name.return_value = 'some_log'
         func_str = 'name=Gaussian,Height=11,PeakCentre=40000,Sigma=54;name=Gaussian,Height=10,PeakCentre=30000,Sigma=51'
@@ -445,7 +447,7 @@ class TestFittingDataModel(unittest.TestCase):
         self.assertEqual(sorted(ws_names), sorted(self.model._fit_results['name1']['results'].keys()))
         # check the first call to setY and setE for one of the parameters
         for im, m in enumerate(self.model._fit_workspaces[:-2]):
-            for iws, ws in enumerate(self.model._loaded_workspaces.keys()):
+            for iws, ws in enumerate(self.model._data_workspaces.get_loaded_workpace_names()):
                 _, argsY, _ = m.setY.mock_calls[iws]
                 _, argsE, _ = m.setE.mock_calls[iws]
                 self.assertEqual([argsY[0], argsE[0]], [iws, iws])
@@ -518,33 +520,36 @@ class TestFittingDataModel(unittest.TestCase):
         mock_log_table.column.return_value = [2, 0, 1]  # fake log values
         mock_ads.retrieve.return_value = mock_log_table
 
-        ws_list = self.model.get_active_ws_list()
-        ws_list = self.model.get_ws_sorted_by_primary_log(ws_list)
+        ws_list = self.model.get_active_ws_sorted_by_primary_log()
 
         self.assertEqual(ws_list, ["name2", "name3", "name1"])
 
     @patch(data_model_path + '.get_setting')
     @patch(data_model_path + '.ADS')
     def test_get_ws_sorted_by_primary_log_descending(self, mock_ads, mock_getsetting):
-        self.model._loaded_workspaces = {"name1": self.mock_ws, "name2": self.mock_ws, "name3": self.mock_ws}
+        self.model._data_workspaces.add("name1", loaded_ws=self.mock_ws)
+        self.model._data_workspaces.add("name2", loaded_ws=self.mock_ws)
+        self.model._data_workspaces.add("name3", loaded_ws=self.mock_ws)
         mock_getsetting.side_effect = ['log', 'false']  # primary log, sort_ascending
         mock_log_table = mock.MagicMock()
         mock_log_table.column.return_value = [2, 0, 1]  # fake log values
         mock_ads.retrieve.return_value = mock_log_table
 
-        ws_list = self.model.get_ws_sorted_by_primary_log()
+        ws_list = self.model.get_active_ws_sorted_by_primary_log()
 
         self.assertEqual(ws_list, ["name1", "name3", "name2"])
 
     @patch(data_model_path + '.get_setting')
     @patch(data_model_path + '.ADS')
     def test_get_ws_sorted_by_primary_log_not_specified(self, mock_ads, mock_getsetting):
-        self.model._loaded_workspaces = {"name1": self.mock_ws, "name2": self.mock_ws, "name3": self.mock_ws}
+        self.model._data_workspaces.add("name1", loaded_ws=self.mock_ws)
+        self.model._data_workspaces.add("name2", loaded_ws=self.mock_ws)
+        self.model._data_workspaces.add("name3", loaded_ws=self.mock_ws)
         mock_getsetting.side_effect = ['', 'false']  # primary log, sort_ascending
 
-        ws_list = self.model.get_ws_sorted_by_primary_log()
+        ws_list = self.model.get_active_ws_sorted_by_primary_log()
 
-        self.assertEqual(ws_list, list(self.model._loaded_workspaces.keys())[::-1])
+        self.assertEqual(ws_list, list(self.model._data_workspaces.get_loaded_workpace_names())[::-1])
         mock_ads.retrieve.assert_not_called()
 
     def _setup_model_log_workspaces(self):

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/data_handling/test/test_data_presenter.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/data_handling/test/test_data_presenter.py
@@ -162,7 +162,7 @@ class FittingDataPresenterTest(unittest.TestCase):
     def test_rename_workspace_tracked(self):
         model_dict = {"name1": self.ws1, "name2": self.ws2}
         self.model.get_loaded_workspaces.return_value = model_dict
-        self.model.get_all_workspace_names.return_value = ["name1", "name2"]
+        self.model.get_all_workspace_names.return_value = ["name1", "name2", "new"] # just return all so has no effect
         # lambda function to replace dict with new key and same ordering as before
         self.model.update_workspace_name.side_effect = lambda old, new: model_dict.update(
             {(key if key != old else new): val for key, val in (list(model_dict.items()), model_dict.clear())[0]})
@@ -170,6 +170,8 @@ class FittingDataPresenterTest(unittest.TestCase):
         self.presenter.all_plots_removed_notifier = mock.MagicMock()
 
         self.presenter.rename_workspace("name1", "new")
+        # ADS rename always accompanied by replace so call that as well here
+        self.presenter.replace_workspace("new", self.ws1)
         self.assertEqual({"new": self.ws1, "name2": self.ws2}, model_dict)
         self.assertTrue("new" in self.presenter.row_numbers)
         self.assertFalse("name1" == self.presenter.row_numbers)

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/plotting/plot_model.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/plotting/plot_model.py
@@ -21,6 +21,8 @@ class FittingPlotModel(object):
         if ws in self.plotted_workspaces:
             self._remove_workspace_from_plot(ws, ax)
             self.plotted_workspaces.remove(ws)
+        if not self.plotted_workspaces:
+            ax.cla()
 
     @staticmethod
     def _remove_workspace_from_plot(ws, ax):

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/plotting/plot_presenter.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/plotting/plot_presenter.py
@@ -48,15 +48,15 @@ class FittingPlotPresenter(object):
         self.view.clear_figure()
         self.view.update_fitbrowser()
 
-    def do_fit_all(self, ws_list, do_sequential=True):
+    def do_fit_all(self, ws_name_list, do_sequential=True):
         fitprop_list = []
         prev_fitprop = self.view.read_fitprop_from_browser()
-        for ws in ws_list:
-            logger.notice(f'Starting to fit workspace {ws}')
+        for ws_name in ws_name_list:
+            logger.notice(f'Starting to fit workspace {ws_name}')
             fitprop = deepcopy(prev_fitprop)
             # update I/O workspace name
-            fitprop['properties']['Output'] = ws
-            fitprop['properties']['InputWorkspace'] = ws
+            fitprop['properties']['Output'] = ws_name
+            fitprop['properties']['InputWorkspace'] = ws_name
             # do fit
             fit_output = Fit(**fitprop['properties'])
             # update results
@@ -67,7 +67,7 @@ class FittingPlotPresenter(object):
                 # update function in prev fitprop to use for next workspace
                 prev_fitprop['properties']['Function'] = funcstr
             # update last fit in fit browser and save setup
-            self.view.update_browser(fit_output.OutputStatus, funcstr, ws)
+            self.view.update_browser(fit_output.OutputStatus, funcstr, ws_name)
             # append a deep copy to output list (will be initial parameters if not successful)
             fitprop_list.append(fitprop)
 

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/plotting/plot_view.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/plotting/plot_view.py
@@ -156,7 +156,10 @@ class FittingPlotView(QtWidgets.QWidget, Ui_plot):
 
     def remove_ws_from_fitbrowser(self, ws):
         # only one spectra per workspace
-        self.fit_browser.removeWorkspaceAndSpectra(ws.name())
+        try:
+            self.fit_browser.removeWorkspaceAndSpectra(ws.name())
+        except:
+            pass # name may not be available if ws has just been deleted
 
     def update_legend(self, ax):
         if ax.get_lines():

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/test/engineering_diffraction_io_test.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/test/engineering_diffraction_io_test.py
@@ -56,10 +56,10 @@ SETTINGS_DICT = {
     "sort_ascending": False  # this is changed to false to show a deviation from the default
 }
 
-ENCODED_DICT = {'encoder_version': IO_VERSION, 'current_tab': 2, 'data_loaded_workspaces': [TEST_WS],
+ENCODED_DICT = {'encoder_version': IO_VERSION, 'current_tab': 2,
+                'data_workspaces': {TEST_WS : [TEST_WS + "_bgsub", [True, 70, 4000, True]]},
                 'plotted_workspaces': [TEST_WS + 'bgsub'], 'fit_properties': FIT_DICT, 'plot_diff': 'True',
-                'fit_results': FIT_RESULTS, 'settings_dict': SETTINGS_DICT,
-                'background_params': {TEST_WS: [True, 70, 4000, True]}}
+                'fit_results': FIT_RESULTS, 'settings_dict': SETTINGS_DICT}
 
 
 def _create_fit_workspace():
@@ -128,20 +128,18 @@ class EngineeringDiffractionEncoderTest(unittest.TestCase):
         self.presenter.fitting_presenter.data_widget.presenter.model.load_files(TEST_FILE)
         self.fitprop_browser.read_current_fitprop.return_value = None
         test_dic = self.encoder.encode(self.mock_view)
-        self.assertEqual({'encoder_version': IO_VERSION, 'current_tab': 0, 'data_loaded_workspaces': [TEST_WS],
+        self.assertEqual({'encoder_version': IO_VERSION, 'current_tab': 0, 'data_workspaces': {TEST_WS: [None, []]},
                           'plotted_workspaces': [], 'fit_properties': None, 'fit_results': {},
-                          'settings_dict': SETTINGS_DICT,
-                          'background_params': {'ENGINX_277208_focused_bank_2': []}}, test_dic)
+                          'settings_dict': SETTINGS_DICT}, test_dic)
 
     def test_background_params_encode(self):
         self.presenter.fitting_presenter.data_widget.presenter.model.load_files(TEST_FILE)
         self.fitprop_browser.read_current_fitprop.return_value = None
-        self.presenter.fitting_presenter.data_widget.model._bg_params = {TEST_WS: [True, 70, 4000, True]}
+        self.presenter.fitting_presenter.data_widget.model._data_workspaces[TEST_WS].bg_params = [True, 70, 4000, True]
         test_dic = self.encoder.encode(self.mock_view)
-        self.assertEqual({'encoder_version': IO_VERSION, 'current_tab': 0, 'data_loaded_workspaces': [TEST_WS],
+        self.assertEqual({'encoder_version': IO_VERSION, 'current_tab': 0, 'data_workspaces': {TEST_WS: [None, [True, 70, 4000, True]]},
                           'plotted_workspaces': [], 'fit_properties': None, 'fit_results': {},
-                          'settings_dict': SETTINGS_DICT,
-                          'background_params': {TEST_WS: [True, 70, 4000, True]}}, test_dic)
+                          'settings_dict': SETTINGS_DICT}, test_dic)
 
     def test_fits_encode(self):
         self.presenter.fitting_presenter.data_widget.presenter.model.load_files(TEST_FILE)
@@ -150,10 +148,9 @@ class EngineeringDiffractionEncoderTest(unittest.TestCase):
         self.fitprop_browser.plotDiff.return_value = True
         self.presenter.fitting_presenter.data_widget.presenter.plotted = {FIT_WS}
         test_dic = self.encoder.encode(self.mock_view)
-        self.assertEqual({'encoder_version': IO_VERSION, 'current_tab': 0, 'data_loaded_workspaces': [TEST_WS],
+        self.assertEqual({'encoder_version': IO_VERSION, 'current_tab': 0, 'data_workspaces': {TEST_WS: [None, []]},
                           'plotted_workspaces': [FIT_WS], 'fit_properties': FIT_DICT, 'fit_results': FIT_RESULTS,
-                          'plot_diff': 'True', 'settings_dict': SETTINGS_DICT,
-                          'background_params': {'ENGINX_277208_focused_bank_2': []}}, test_dic)
+                          'plot_diff': 'True', 'settings_dict': SETTINGS_DICT}, test_dic)
 
 
 @start_qapplication


### PR DESCRIPTION
**Description of work.**

The fitting tab creates ~3 workspaces when you load a workspace:
a) the focussed workspace the user has loaded
b) a derived workspace that has background subtracted
c) a log group workspace

If the user renamed or deleted any of these the UI would often crash or log a nasty looking error message. The ADS observer behaviour has been reworked to sort this out. This relies on a new class called WorkspaceContainer in the fitting tab's model that links together the a) and b) workspaces in the list above

As part of this I noticed that the serial and sequential fit weren't taking into account the Subtract BG checkbox which indicates whether a) or b) is active for each loaded workspace. So I've fixed this bug also.

**To test:**

Open up the Engineering Diffraction interface
Go to the Fitting Tab
Load a focused data file - you can load the one in the attached zip file
[ENGINX_299080_307521_bank_2_TOF.zip](https://github.com/mantidproject/mantid/files/7556728/ENGINX_299080_307521_bank_2_TOF.zip)
Check the "Plot" and "Subtract BG" checkbox on the row created for this file in the table
Try renaming or deleting the workspaces in ADS and check the UI does something sensible


Fixes #32837.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
