### PR TITLE
Muon plots dont use sci notation for axis

### DIFF
--- a/docs/source/release/v6.3.0/muon.rst
+++ b/docs/source/release/v6.3.0/muon.rst
@@ -45,7 +45,8 @@ Improvements
 - The `alpha` values on grouping tab are now to six decimal places.
 - The numerical values in the `run info` box on the home tab are now rounded to either 4 significant figures or a whole number, whichever is more precise.
 - The results table now produces errors for log values (when they are available).
-- Changes have been made to improve the speed of Muon Analysis and Frequency Domain Analysis
+- Changes have been made to improve the speed of Muon Analysis and Frequency Domain Analysis.
+- The plots no longer use scientific notation for the axis values.
 
 Bugfixes
 ########

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/contexts/plot_settings_context.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/contexts/plot_settings_context.py
@@ -21,6 +21,7 @@ class PlotSettingsContext(object):
         self._wrap_width = 30# determines the width of text on axis ticks
         self._font_size = "xx-small"
         self._rotation = 45 # degrees
+        self._sci_notation = False
 
     def set_condensed(self, state):
         self._is_condensed = state
@@ -68,6 +69,10 @@ class PlotSettingsContext(object):
     def x_axis_margin(self):
         # stored as a percentage, but return decimal
         return self._x_axis_margin/100.
+
+    @property
+    def sci_notation(self):
+        return self._sci_notation
 
     def set_linestyle(self, name, linestyle):
         self._linestyle[name] = linestyle

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/plot_widget/plotting_canvas/plotting_canvas_view.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/plot_widget/plotting_canvas/plotting_canvas_view.py
@@ -209,6 +209,8 @@ class PlottingCanvasView(QtWidgets.QWidget, PlottingCanvasViewInterface):
 
     def _set_text_tick_labels(self, axis_number):
         ax = self.fig.axes[axis_number]
+        # set the axes to not "simplify" the values
+        ax.ticklabel_format(useOffset=self._settings.sci_notation)
         if self._x_tick_labels:
             ax.set_xticks(range(len(self._x_tick_labels)))
             labels = self._wrap_labels(self._x_tick_labels)


### PR DESCRIPTION
**Description of work.**
The muon plots would sometimes simplify the axis by using scientific notation. This PR prevents the axis from using scientific notation, in such a way that it can be added as a user setting at a later date.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**

<!-- Instructions for testing. -->
Open muon analysis
Load EMU20901-5
Go to fitting
Add a function
Go to sequential fitting
Fit to all
Go to the results tab
Tick run number
Generate the results table
Go to the model analysis tab
The x axis should now read "20901" etc. instead of having a +20900 at the end of the axis.


Fixes #32804. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
