### PR TITLE
Muon model tab is not cleared and results warning

### DIFF
--- a/docs/source/release/v6.3.0/muon.rst
+++ b/docs/source/release/v6.3.0/muon.rst
@@ -46,11 +46,11 @@ Improvements
 - The numerical values in the `run info` box on the home tab are now rounded to either 4 significant figures or a whole number, whichever is more precise.
 - The results table now produces errors for log values (when they are available).
 - Changes have been made to improve the speed of Muon Analysis and Frequency Domain Analysis
+- The results tab will now dispay a warning (red text and a tooltip) if the results table already exists.
 
 Bugfixes
 ########
 
-- On the model analysis tab, the fit range will now update when the x axis is changed.
 - Fixed a bug that prevented the model analysis plot showing when data was binned.
 - When a new results table is created the Model Analysis tab selects the default parameters to plot based on log values or parameters in the results table.
 
@@ -102,5 +102,7 @@ Improvements
   - A bug has been fixed that caused Model fitting to not update it's results table list.
   - Plotting in Model fitting now features a greater number of units for parameters and sample logs.
   - The dates and times for relevant parameters in model fitting have been formatted so that they can be plotted with relative spacing.
+  - On the model analysis tab, the fit range will now update when the x axis is changed.
+  - The model analysis tab no longer resets when the instrument is changed.
 
 

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/features/model_analysis.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/features/model_analysis.py
@@ -49,6 +49,9 @@ class AddModelAnalysis(AddFeature):
 
             GUI.enable_notifier.add_subscriber(GUI.model_fitting_tab.model_fitting_tab_view.enable_tab_observer)
 
+            GUI.context.data_context.instrumentNotifier.add_subscriber(
+                GUI.model_fitting_tab.model_fitting_tab_presenter.instrument_changed_notifier)
+
     def set_feature_observables(self, GUI):
         if TABONLY in self.feature_list or TABANDPLOT in self.feature_list:
 

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/features/model_analysis.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/features/model_analysis.py
@@ -49,9 +49,6 @@ class AddModelAnalysis(AddFeature):
 
             GUI.enable_notifier.add_subscriber(GUI.model_fitting_tab.model_fitting_tab_view.enable_tab_observer)
 
-            GUI.context.data_context.instrumentNotifier.add_subscriber(
-                GUI.model_fitting_tab.model_fitting_tab_presenter.instrument_changed_notifier)
-
     def set_feature_observables(self, GUI):
         if TABONLY in self.feature_list or TABANDPLOT in self.feature_list:
 

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/fitting_widgets/model_fitting/model_fitting_presenter.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/fitting_widgets/model_fitting/model_fitting_presenter.py
@@ -4,7 +4,7 @@
 #   NScD Oak Ridge National Laboratory, European Spallation Source,
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
-from mantidqt.utils.observer_pattern import GenericObservable, GenericObserverWithArgPassing, GenericObserver
+from mantidqt.utils.observer_pattern import GenericObservable, GenericObserverWithArgPassing
 from mantidqtinterfaces.Muon.GUI.Common.ADSHandler.ADS_calls import check_if_workspace_exist
 from mantidqtinterfaces.Muon.GUI.Common.fitting_widgets.basic_fitting.basic_fitting_presenter import BasicFittingPresenter
 from mantidqtinterfaces.Muon.GUI.Common.fitting_widgets.model_fitting.model_fitting_model import ModelFittingModel
@@ -28,8 +28,6 @@ class ModelFittingPresenter(BasicFittingPresenter):
         self.update_plot_x_range_notifier = GenericObservable()
 
         self.results_table_created_observer = GenericObserverWithArgPassing(self.handle_new_results_table_created)
-
-        self.instrument_changed_notifier = GenericObserver(self.handle_instrument_changed)
 
         self.view.set_slot_for_results_table_changed(self.handle_results_table_changed)
         self.view.set_slot_for_selected_x_changed(self.handle_selected_x_changed)
@@ -139,11 +137,6 @@ class ModelFittingPresenter(BasicFittingPresenter):
             self._create_parameter_combination_workspaces(self.handle_parameter_combinations_finished_before_fit)
         else:
             super().handle_fit_clicked()
-
-    def handle_instrument_changed(self) -> None:
-        """Handle when the Instrument is changed."""
-        self.model.result_table_names = []
-        self.view.update_result_table_names([])
 
     def update_dataset_names_in_view_and_model(self) -> None:
         """Updates the results tables currently displayed."""

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/fitting_widgets/model_fitting/model_fitting_presenter.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/fitting_widgets/model_fitting/model_fitting_presenter.py
@@ -4,7 +4,7 @@
 #   NScD Oak Ridge National Laboratory, European Spallation Source,
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
-from mantidqt.utils.observer_pattern import GenericObservable, GenericObserverWithArgPassing
+from mantidqt.utils.observer_pattern import GenericObservable, GenericObserverWithArgPassing, GenericObserver
 from mantidqtinterfaces.Muon.GUI.Common.ADSHandler.ADS_calls import check_if_workspace_exist
 from mantidqtinterfaces.Muon.GUI.Common.fitting_widgets.basic_fitting.basic_fitting_presenter import BasicFittingPresenter
 from mantidqtinterfaces.Muon.GUI.Common.fitting_widgets.model_fitting.model_fitting_model import ModelFittingModel
@@ -28,6 +28,8 @@ class ModelFittingPresenter(BasicFittingPresenter):
         self.update_plot_x_range_notifier = GenericObservable()
 
         self.results_table_created_observer = GenericObserverWithArgPassing(self.handle_new_results_table_created)
+
+        self.instrument_changed_notifier = GenericObserver(self.handle_instrument_changed)
 
         self.view.set_slot_for_results_table_changed(self.handle_results_table_changed)
         self.view.set_slot_for_selected_x_changed(self.handle_selected_x_changed)
@@ -137,6 +139,10 @@ class ModelFittingPresenter(BasicFittingPresenter):
             self._create_parameter_combination_workspaces(self.handle_parameter_combinations_finished_before_fit)
         else:
             super().handle_fit_clicked()
+
+    def handle_instrument_changed(self) -> None:
+        """Handle when the Instrument is changed."""
+        self.update_selected_parameter_combination_workspace()
 
     def update_dataset_names_in_view_and_model(self) -> None:
         """Updates the results tables currently displayed."""

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/results_tab_widget/results_tab_presenter.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/results_tab_widget/results_tab_presenter.py
@@ -5,7 +5,7 @@
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
 from qtpy.QtCore import QMetaObject, QObject, Slot
-
+from mantidqtinterfaces.Muon.GUI.Common.ADSHandler.ADS_calls import check_if_workspace_exist
 from mantidqt.utils.observer_pattern import GenericObservable, GenericObserver
 
 
@@ -32,11 +32,18 @@ class ResultsTabPresenter(QObject):
                                                    setEnabled(True))
 
         self.results_table_created_notifier = GenericObservable()
+        self.view.set_output_results_button_no_warning()
 
     # callbacks
     def on_results_table_name_edited(self):
         """React to the results table name being edited"""
-        self.model.set_results_table_name(self.view.results_table_name())
+        name = self.view.results_table_name()
+        self.model.set_results_table_name(name)
+        # add a check for if it exists
+        if check_if_workspace_exist(name):
+            self.view.set_output_results_button_warning()
+        else:
+            self.view.set_output_results_button_no_warning()
 
     def on_new_fit_performed(self):
         """React to a new fit created in the fitting tab"""
@@ -57,6 +64,8 @@ class ResultsTabPresenter(QObject):
         try:
             self.model.create_results_table(log_selection, results_selection)
             QMetaObject.invokeMethod(self, "_notify_results_table_created")
+            self.view.set_output_results_button_warning()
+
         except Exception as exc:
             self.view.show_warning(str(exc))
 

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/results_tab_widget/results_tab_view.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/results_tab_widget/results_tab_view.py
@@ -39,6 +39,14 @@ class ResultsTabView(QtWidgets.QWidget, ui_fitting_tab):
         """
         self.output_results_table_btn.setEnabled(on)
 
+    def set_output_results_button_warning(self):
+        self.output_results_table_btn.setToolTip('A table with this name already exists')
+        self.output_results_table_btn.setStyleSheet('QPushButton {color:red;}')
+
+    def set_output_results_button_no_warning(self):
+        self.output_results_table_btn.setToolTip('')
+        self.output_results_table_btn.setStyleSheet('QPushButton {color:black;}')
+
     def results_table_name(self):
         """Return the name of the output table."""
         return self.results_name_editor.text()

--- a/qt/python/mantidqtinterfaces/test/Muon/fitting_widgets/model_fitting/model_fitting_presenter_test.py
+++ b/qt/python/mantidqtinterfaces/test/Muon/fitting_widgets/model_fitting/model_fitting_presenter_test.py
@@ -203,11 +203,6 @@ class ModelFittingPresenterTest(unittest.TestCase):
         self.model.update_plot_guess.assert_called_once_with()
         self.presenter.fit_function_changed_notifier.notify_subscribers.assert_called_once_with()
 
-    def test_that_handle_instrument_changed_clears_results_tables(self):
-        self.presenter.handle_instrument_changed()
-        self.mock_model_result_table_names.assert_called_once_with(mock.call())
-        self.view.update_result_table_names.assert_called_once_with([])
-
     def test_that_update_dataset_names_in_view_and_model_will_update_the_datasets_in_the_model_and_view(self):
         self.presenter.update_dataset_names_in_view_and_model()
 

--- a/qt/python/mantidqtinterfaces/test/Muon/results_tab_widget/results_tab_presenter_test.py
+++ b/qt/python/mantidqtinterfaces/test/Muon/results_tab_widget/results_tab_presenter_test.py
@@ -45,15 +45,35 @@ class ResultsTabPresenterTest(unittest.TestCase):
         self.mock_view.set_output_results_button_enabled.assert_called_once_with(
             False)
 
-    def test_editing_results_name_updates_model_value(self):
+    @mock.patch('mantidqtinterfaces.Muon.GUI.Common.results_tab_widget.results_tab_presenter.check_if_workspace_exist')
+    def test_editing_results_name_updates_model_value(self, mock_check_ADS):
+        mock_check_ADS.return_value = False
         new_name = 'edited_name'
         self.mock_view.results_table_name.return_value = new_name
         presenter = ResultsTabPresenter(self.mock_view, self.mock_model)
+        self.assertEqual(self.mock_view.set_output_results_button_no_warning.call_count, 1)
         presenter.on_results_table_name_edited()
 
         self.mock_view.results_table_name.assert_called_once_with()
         self.mock_model.set_results_table_name.assert_called_once_with(
             new_name)
+        self.assertEqual(self.mock_view.set_output_results_button_no_warning.call_count, 2)
+        self.mock_view.set_output_results_button_warning.assert_not_called()
+
+    @mock.patch('mantidqtinterfaces.Muon.GUI.Common.results_tab_widget.results_tab_presenter.check_if_workspace_exist')
+    def test_editing_results_name_updates_model_value_already_used_name(self, mock_check_ADS):
+        mock_check_ADS.return_value = True
+        new_name = 'edited_name'
+        self.mock_view.results_table_name.return_value = new_name
+        presenter = ResultsTabPresenter(self.mock_view, self.mock_model)
+        self.assertEqual(self.mock_view.set_output_results_button_no_warning.call_count, 1)
+        presenter.on_results_table_name_edited()
+
+        self.mock_view.results_table_name.assert_called_once_with()
+        self.mock_model.set_results_table_name.assert_called_once_with(
+            new_name)
+        self.assertEqual(self.mock_view.set_output_results_button_no_warning.call_count, 1)
+        self.mock_view.set_output_results_button_warning.assert_called_once_with()
 
     def test_changing_function_selection(self):
         new_name = 'func 2'
@@ -132,6 +152,7 @@ class ResultsTabPresenterTest(unittest.TestCase):
         self.mock_view.selected_result_workspaces.return_value = fit_selection
         self.mock_view.selected_log_values.return_value = log_selection
         presenter = ResultsTabPresenter(self.mock_view, self.mock_model)
+        self.assertEqual(self.mock_view.set_output_results_button_warning.call_count, 0)
         # previous test verifies this is correct on construction
         self.mock_view.set_output_results_button_enabled.reset_mock()
 
@@ -139,6 +160,7 @@ class ResultsTabPresenterTest(unittest.TestCase):
 
         self.mock_model.create_results_table.assert_called_once_with(
             log_selection, fit_selection)
+        self.assertEqual(self.mock_view.set_output_results_button_warning.call_count, 1)
 
     def test_results_table_request_with_empty_results_does_nothing(self):
         self.mock_view.selected_result_workspaces.return_value = []


### PR DESCRIPTION
**Description of work.**

The model analysis tab was being cleared when the instrument was changed. We have been asked to prevent this. However, it became apparent that it would be easy to accidentally overwrite a results table. Therefore, a warning has been added. 

**To test:**

<!-- Instructions for testing. -->
Open muon analysis
Load EMU 20901-5
Go to fitting and add a fit function
Go to sequential and fit all
Go to the results tab
Create a results table
The button will now have red text and have a tooltip
Change the results table name - the button will return to normal
Change the results table name back - the button will have red text again

Go to the home tab
Change the instrument to MUSR
Load 62260-5
Go to sequential and fit all
Go to results tab
Change the results table name (no warning)
Produce the results table

Go to the model analysis tab
Check that you have both results table


Fixes #32982. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
