### PR TITLE
DirectILL: Increased default width of monitor peak integration

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/DirectILLCollectData.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/DirectILLCollectData.py
@@ -476,7 +476,7 @@ class DirectILLCollectData(DataProcessorAlgorithm):
                              doc='Normalisation method.')
         self.setPropertyGroup(common.PROP_NORMALISATION, PROPGROUP_MON_NORMALISATION)
         self.declareProperty(name=common.PROP_MON_PEAK_SIGMA_MULTIPLIER,
-                             defaultValue=3.0,
+                             defaultValue=7.0,
                              validator=positiveFloat,
                              direction=Direction.Input,
                              doc="Width of the monitor peak in multiples " + " of 'Sigma' in monitor's EPP table.")

--- a/Testing/SystemTests/tests/framework/ILLDirectGeometryReductionTest.py
+++ b/Testing/SystemTests/tests/framework/ILLDirectGeometryReductionTest.py
@@ -21,7 +21,8 @@ class IN4(systemtesting.MantidSystemTest):
             Run='ILL/IN4/085801-085802.nxs',
             OutputWorkspace='vanadium',
             OutputEPPWorkspace='vanadium-epps',
-            OutputRawWorkspace='vanadium-raw')
+            OutputRawWorkspace='vanadium-raw',
+            MonitorPeakWidthInSigmas=3.0)
         DirectILLIntegrateVanadium(
             InputWorkspace='vanadium',
             OutputWorkspace='integrated',
@@ -36,13 +37,15 @@ class IN4(systemtesting.MantidSystemTest):
             Run='ILL/IN4/087294+087295.nxs',
             OutputWorkspace='sample',
             OutputIncidentEnergyWorkspace='Ei',
-            OutputElasticChannelWorkspace='Elp')
+            OutputElasticChannelWorkspace='Elp',
+            MonitorPeakWidthInSigmas=3.0)
         # Containers
         DirectILLCollectData(
             Run='ILL/IN4/087306-087309.nxs',
             OutputWorkspace='container',
             IncidentEnergyWorkspace='Ei',
-            ElasticChannelWorkspace='Elp')
+            ElasticChannelWorkspace='Elp',
+            MonitorPeakWidthInSigmas=3.0)
         geometry = {
             'Shape': 'HollowCylinder',
             'Height': 4.0,
@@ -94,7 +97,8 @@ class IN5(systemtesting.MantidSystemTest):
         DirectILLCollectData(
             Run='ILL/IN5/095893.nxs',
             OutputWorkspace='vanadium',
-            OutputEPPWorkspace='vanadium-epps',)
+            OutputEPPWorkspace='vanadium-epps',
+            MonitorPeakWidthInSigmas=3.0)
         DirectILLDiagnostics(
             InputWorkspace='vanadium',
             OutputWorkspace='diagnostics',
@@ -118,7 +122,8 @@ class IN5(systemtesting.MantidSystemTest):
         DirectILLCollectData(
             Run='ILL/IN5/096003.nxs',
             OutputWorkspace='sample',
-            OutputEppWorkspace='epps')
+            OutputEppWorkspace='epps',
+            MonitorPeakWidthInSigmas=3.0)
         DirectILLTubeBackground(
             InputWorkspace='sample',
             OutputWorkspace='bkg',

--- a/docs/source/release/v6.3.0/direct_geometry.rst
+++ b/docs/source/release/v6.3.0/direct_geometry.rst
@@ -5,6 +5,14 @@ Direct Geometry Changes
 .. contents:: Table of Contents
    :local:
 
+Direct Geometry
+---------------
+
+Improvements
+############
+
+- The default value of monitor peak width multiplier (MonitorPeakWidthInSigmas) has been changed from 3 to 7 in :ref:`DirectILLCollectData <algm-DirectILLCollectData>`
+
 .. warning:: **Developers:** Sort changes under appropriate heading
     putting new features at the top of the section, followed by
     improvements, followed by bug fixes.


### PR DESCRIPTION
The ILL direct geometry spectrometer responsible scientists have agreed that the default value for the number of sigmas multiplier for the integration width of the monitor elastic peak had been insufficient. They requested it to be changed from the default of 3.0 to 7.0. This PR implements this requested change.

**Description of work.**

**To test:**
1. Tests should be passing

*There is no associated issue.*

Release notes added to v6.3 notes.

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
