### PR TITLE
Remove predefined size for seq fit button

### DIFF
--- a/docs/source/release/v6.3.0/muon.rst
+++ b/docs/source/release/v6.3.0/muon.rst
@@ -48,6 +48,7 @@ Improvements
 - Changes have been made to improve the speed of Muon Analysis and Frequency Domain Analysis.
 - The plots no longer use scientific notation for the axis values.
 - On resizing priority is given to plotting.
+- The Sequentially Fit all button is now visible for 4K displays
 
 Bugfixes
 ########

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/seq_fitting_tab_widget/seq_fitting_tab.ui
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/seq_fitting_tab_widget/seq_fitting_tab.ui
@@ -64,12 +64,6 @@
    </item>
    <item row="0" column="0">
     <widget class="QPushButton" name="seq_fit_button">
-     <property name="maximumSize">
-      <size>
-       <width>200</width>
-       <height>50</height>
-      </size>
-     </property>
      <property name="text">
       <string>Sequentially fit all</string>
      </property>


### PR DESCRIPTION
**Description of work.**
Removed the size constraints for the Sequentially Fit all button in the Muon GUIs. This was preventing the button from sizing properly on 4K monitors.


**Report to:** Adrian Hillier

**To test:**
1. Open Muon Analysis GUI
2. Load MUSR 62260
3. Open the Sequential Fitting Tab - the buttons should all be readable

This needs to be checked on 
- a 4K display at resolution 3840 x 2160
- A non-4k display
- Mac OS (@DanielMurphy22 & @DavidFair could you help with this?)

Fixes #32978. 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
