### PR TITLE
Make muon GUI's show doubles in a nicer format

### DIFF
--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/corrections_tab_widget/background_corrections_view.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/corrections_tab_widget/background_corrections_view.py
@@ -8,11 +8,11 @@ from mantid.api import ITableWorkspace
 from mantidqt.utils.qt import load_ui
 from mantidqt.widgets.workspacedisplay.table.presenter import TableWorkspaceDisplay
 from mantidqtinterfaces.Muon.GUI.Common.utilities.table_utils import (create_checkbox_table_item, create_double_table_item,
-                                                                      create_string_table_item)
+                                                                      create_string_table_item, DoubleItemDelegate)
 
 from qtpy.QtCore import Qt
-from qtpy.QtGui import QDoubleValidator, QPalette
-from qtpy.QtWidgets import QLineEdit, QPushButton, QStyledItemDelegate, QStyleOptionViewItem, QTableWidgetItem, QWidget
+from qtpy.QtGui import QPalette
+from qtpy.QtWidgets import QPushButton, QStyledItemDelegate, QStyleOptionViewItem, QTableWidgetItem, QWidget
 
 ui_form, widget = load_ui(__file__, "background_corrections_view.ui")
 
@@ -27,17 +27,6 @@ STATUS_COLUMN_INDEX = 7
 SHOW_MATRIX_COLUMN_INDEX = 8
 
 USE_RAW_TOOLTIP = "Calculate the background using the raw data or the rebinned data."
-
-
-class DoubleItemDelegate(QStyledItemDelegate):
-    """
-    An item delegate that has a QDoubleValidator. The __init__ is the default QStyledItemDelegate __init__.
-    """
-
-    def createEditor(self, parent, option, index):
-        line_edit = QLineEdit(parent)
-        line_edit.setValidator(QDoubleValidator())
-        return line_edit
 
 
 class StatusItemDelegate(QStyledItemDelegate):
@@ -400,6 +389,7 @@ class BackgroundCorrectionsView(widget, ui_form):
         if self._selected_row is not None and self._selected_column is not None and self._selected_column != USE_RAW_COLUMN_INDEX:
             value = float(self.correction_options_table.item(self._selected_row, self._selected_column).text())
             self._set_selected_value(value)
+            print("waaa", value, self.correction_options_table.item(self._selected_row, self._selected_column).text())
 
     def _set_selected_value(self, value: float) -> None:
         """Sets the currently selected cell to the float value provided."""

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/corrections_tab_widget/background_corrections_view.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/corrections_tab_widget/background_corrections_view.py
@@ -389,7 +389,6 @@ class BackgroundCorrectionsView(widget, ui_form):
         if self._selected_row is not None and self._selected_column is not None and self._selected_column != USE_RAW_COLUMN_INDEX:
             value = float(self.correction_options_table.item(self._selected_row, self._selected_column).text())
             self._set_selected_value(value)
-            print("waaa", value, self.correction_options_table.item(self._selected_row, self._selected_column).text())
 
     def _set_selected_value(self, value: float) -> None:
         """Sets the currently selected cell to the float value provided."""

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/seq_fitting_tab_widget/QSequentialTableModel.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/seq_fitting_tab_widget/QSequentialTableModel.py
@@ -180,7 +180,7 @@ class QSequentialTableModel(QAbstractTableModel):
         return self.data(index, Qt.DisplayRole)
 
     def get_fit_parameters(self, row):
-        return self._parameterData[row]
+        return [float(value) for value in self._parameterData[row]]
 
     @property
     def number_of_parameters(self):

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/seq_fitting_tab_widget/QSequentialTableView.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/seq_fitting_tab_widget/QSequentialTableView.py
@@ -6,8 +6,9 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 from qtpy import QtWidgets
 from qtpy.QtCore import Qt, Signal
-from mantidqtinterfaces.Muon.GUI.Common.seq_fitting_tab_widget.QSequentialTableModel import FIT_STATUS_COLUMN
+from mantidqtinterfaces.Muon.GUI.Common.seq_fitting_tab_widget.QSequentialTableModel import FIT_STATUS_COLUMN, NUM_DEFAULT_COLUMNS
 from mantidqtinterfaces.Muon.GUI.Common.seq_fitting_tab_widget.SequentialTableDelegates import FitQualityDelegate
+from mantidqtinterfaces.Muon.GUI.Common.utilities.table_utils import DoubleItemDelegate
 
 
 class QSequentialTableView(QtWidgets.QTableView):
@@ -20,6 +21,7 @@ class QSequentialTableView(QtWidgets.QTableView):
         self.setSizePolicy(QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Expanding)
         self.setHorizontalScrollBarPolicy(Qt.ScrollBarAsNeeded)
         self.setItemDelegateForColumn(FIT_STATUS_COLUMN, FitQualityDelegate(self))
+        self.setItemDelegateForColumn(NUM_DEFAULT_COLUMNS+1, FitQualityDelegate(self))
         self.setAlternatingRowColors(True)
 
     def resizeColumnsToContents(self):
@@ -28,6 +30,10 @@ class QSequentialTableView(QtWidgets.QTableView):
         for col in range(self.model().columnCount()):
             if col == 0:
                 self.horizontalHeader().setSectionResizeMode(col, QtWidgets.QHeaderView.Stretch)
+            elif col > NUM_DEFAULT_COLUMNS-1:
+                self.horizontalHeader().setSectionResizeMode(col, QtWidgets.QHeaderView.ResizeToContents)
+                self.setItemDelegateForColumn(col, DoubleItemDelegate(self))
+
             else:
                 self.horizontalHeader().setSectionResizeMode(col, QtWidgets.QHeaderView.ResizeToContents)
 

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/seq_fitting_tab_widget/SequentialTableWidget.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/seq_fitting_tab_widget/SequentialTableWidget.py
@@ -45,12 +45,14 @@ class SequentialTableWidget(object):
         if not self._check_parameter_and_values_length(parameters, values):
             return
         self.block_signals(True)
+        print("moo", values)
         self._model.set_fit_parameters_and_values(parameters, values)
         self.block_signals(False)
         self._view.resizeColumnsToContents()
 
     def set_parameter_values_for_row(self, row, parameter_values):
         self.block_signals(True)
+        print("boo", row)
         self._model.set_fit_parameter_values_for_row(row, parameter_values)
         self.block_signals(False)
         self._view.resizeColumnsToContents()

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/seq_fitting_tab_widget/SequentialTableWidget.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/seq_fitting_tab_widget/SequentialTableWidget.py
@@ -45,14 +45,12 @@ class SequentialTableWidget(object):
         if not self._check_parameter_and_values_length(parameters, values):
             return
         self.block_signals(True)
-        print("moo", values)
         self._model.set_fit_parameters_and_values(parameters, values)
         self.block_signals(False)
         self._view.resizeColumnsToContents()
 
     def set_parameter_values_for_row(self, row, parameter_values):
         self.block_signals(True)
-        print("boo", row)
         self._model.set_fit_parameter_values_for_row(row, parameter_values)
         self.block_signals(False)
         self._view.resizeColumnsToContents()

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/utilities/table_utils.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/utilities/table_utils.py
@@ -207,12 +207,18 @@ class DoubleItemDelegate(QStyledItemDelegate):
         validator = LineEditDoubleValidator(line_edit, float(0.0))
         validator.setBottom(-sys.float_info.max)
         validator.setTop(sys.float_info.max)
-        validator.setDecimals(6)
         line_edit.setValidator(validator)
         return line_edit
 
+    @staticmethod
+    def convert_for_display(number):
+        """need to convert to a float then
+        back to a string to make sure it
+        always has scientific notation"""
+        return str(float(number))
+
     def setEditorData(self, editor, index):
-        editor.setText(str(index.data()))
+        editor.setText(self.convert_for_display(index.data()))
 
     def setModelData(self, editor, model, index):
-        model.setData(index, editor.text(), QtCore.Qt.EditRole)
+        model.setData(index, self.convert_for_display(editor.text()), QtCore.Qt.EditRole)

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/utilities/table_utils.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/utilities/table_utils.py
@@ -8,7 +8,7 @@ from functools import wraps
 import sys
 from qtpy import QtWidgets, QtCore
 from mantidqt.utils.qt.line_edit_double_validator import LineEditDoubleValidator
-
+from qtpy.QtWidgets import QLineEdit, QStyledItemDelegate
 """
 This module contains the methods for
 adding information to tables.
@@ -127,12 +127,12 @@ def addComboToTable(table,row,options,col=1):
     return combo
 
 
-def addDoubleToTable(table, value, row, col=1, minimum=None):
+def addDoubleToTable(table, value, row, col=1, minimum=None, decimals=3):
     number_widget = QtWidgets.QLineEdit(str(value))
     validator = LineEditDoubleValidator(number_widget, float(value))
     validator.setBottom(minimum if minimum is not None else -sys.float_info.max)
     validator.setTop(sys.float_info.max)
-    validator.setDecimals(3)
+    validator.setDecimals(decimals)
     number_widget.setValidator(validator)
     table.setCellWidget(row, col, number_widget)
     return number_widget, validator
@@ -195,3 +195,24 @@ def setTableHeaders(table):
         table.setStyleSheet(styleSheet)
         return styleSheet
     return
+
+
+class DoubleItemDelegate(QStyledItemDelegate):
+    """
+    An item delegate that has a QDoubleValidator. The __init__ is the default QStyledItemDelegate __init__.
+    """
+
+    def createEditor(self, parent, option, index):
+        line_edit = QLineEdit(parent)
+        validator = LineEditDoubleValidator(line_edit, float(0.0))
+        validator.setBottom(-sys.float_info.max)
+        validator.setTop(sys.float_info.max)
+        validator.setDecimals(6)
+        line_edit.setValidator(validator)
+        return line_edit
+
+    def setEditorData(self, editor, index):
+        editor.setText(str(index.data()))
+
+    def setModelData(self, editor, model, index):
+        model.setData(index, editor.text(), QtCore.Qt.EditRole)


### PR DESCRIPTION
**Description of work.**

The sequential fitting tab in the muon GUI was limiting the precision of the numbers to 1e-3. This was not desired behaviour. I have replaced the spin box that was previously used with a line edit that reports the number using scientific notation. I have also refactored a bit of code to allow the same line edit to be used in the sequential fitting table and the corrections table.

**To test:**

<!-- Instructions for testing. -->
Open muon analysis
Load some data
Go to the fitting tab and add a fitting function
Go to the sequential fitting tab
Check that you can edit the values of the parameters
If you enter a number that is close-ish to 1 it should display as a normal number (e.g. 100.00)
If you enter a very large or small number it will use scientific notation
Check you can enter scientific notation directly
Check it rejects invalid values (i.e. letters)

Go to the corrections tab
Set BG corrections to manual
Set the correction to 100
The table should update
The plots will change (bend)

Fixes #32979. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
