### PR TITLE
Bump Gtest 1.11

### DIFF
--- a/Framework/API/CMakeLists.txt
+++ b/Framework/API/CMakeLists.txt
@@ -13,7 +13,6 @@ set(SRC_FILES
     src/ArchiveSearchFactory.cpp
     src/Axis.cpp
     src/BinEdgeAxis.cpp
-    src/BoostOptionalToAlgorithmProperty.cpp
     src/BoxController.cpp
     src/BoxControllerSettingsAlgorithm.cpp
     src/CatalogManager.cpp
@@ -143,6 +142,7 @@ set(SRC_FILES
     src/SpectraAxisValidator.cpp
     src/SpectrumDetectorMapping.cpp
     src/SpectrumInfo.cpp
+    src/StdOptionalToAlgorithmProperty.cpp
     src/TableRow.cpp
     src/TextAxis.cpp
     src/TransformScaleFactory.cpp
@@ -184,7 +184,6 @@ set(INC_FILES
     inc/MantidAPI/ArchiveSearchFactory.h
     inc/MantidAPI/Axis.h
     inc/MantidAPI/BinEdgeAxis.h
-    inc/MantidAPI/BoostOptionalToAlgorithmProperty.h
     inc/MantidAPI/BoxController.h
     inc/MantidAPI/BoxControllerSettingsAlgorithm.h
     inc/MantidAPI/CatalogFactory.h
@@ -352,6 +351,7 @@ set(INC_FILES
     inc/MantidAPI/SpectrumInfo.h
     inc/MantidAPI/SpectrumInfoItem.h
     inc/MantidAPI/SpectrumInfoIterator.h
+    inc/MantidAPI/StdOptionalToAlgorithmProperty.h
     inc/MantidAPI/TableRow.h
     inc/MantidAPI/TextAxis.h
     inc/MantidAPI/TransformScaleFactory.h

--- a/Framework/API/inc/MantidAPI/ILiveListener.h
+++ b/Framework/API/inc/MantidAPI/ILiveListener.h
@@ -15,6 +15,7 @@
 #include "MantidKernel/PropertyManager.h"
 #include <Poco/Net/SocketAddress.h>
 #include <string>
+#include <string_view>
 
 namespace Mantid {
 namespace API {
@@ -49,7 +50,10 @@ public:
    * @param address The IP address and port to contact
    * @return True if the connection was successfully established
    */
-  virtual bool connect(const Poco::Net::SocketAddress &address) = 0;
+  // Workaround https://github.com/google/googletest/issues/3384
+  // Which is fixed in GCC 12+, by replacing SocketAddress with std::string
+  // which emulates our usage closely enough
+  virtual bool connect(const std::string_view address) = 0;
 
   /** Commence the collection of data from the DAS. Must be called before
    * extractData().

--- a/Framework/API/inc/MantidAPI/StdOptionalToAlgorithmProperty.h
+++ b/Framework/API/inc/MantidAPI/StdOptionalToAlgorithmProperty.h
@@ -10,7 +10,8 @@
 #include "MantidAPI/DllConfig.h"
 #include "MantidGeometry/Instrument.h"
 #include <boost/lexical_cast.hpp>
-#include <boost/optional.hpp>
+
+#include <optional>
 #include <string>
 
 namespace Mantid {
@@ -67,8 +68,8 @@ T checkForMandatoryInstrumentDefault(Mantid::API::Algorithm *const alg, const st
  */
 template <typename T>
 std::optional<T> checkForOptionalInstrumentDefault(Mantid::API::Algorithm *const alg, const std::string &propName,
-                                                     const Mantid::Geometry::Instrument_const_sptr &instrument,
-                                                     const std::string &idf_name) {
+                                                   const Mantid::Geometry::Instrument_const_sptr &instrument,
+                                                   const std::string &idf_name) {
   auto algProperty = alg->getPointerToProperty(propName);
   if (algProperty->isDefault()) {
     auto defaults = instrument->getNumberParameter(idf_name);

--- a/Framework/API/inc/MantidAPI/StdOptionalToAlgorithmProperty.h
+++ b/Framework/API/inc/MantidAPI/StdOptionalToAlgorithmProperty.h
@@ -15,10 +15,10 @@
 
 namespace Mantid {
 namespace API {
-/** BoostOptionalToAlgorithmProperty : Checks for default values of an
+/** StdOptionalToAlgorithmProperty : Checks for default values of an
 algorithm property if the user has not supplied the value. If it is a mandatory
 property then the value will be returned, if the property is optional then a
-value of type boost::optional<T> will be returned.
+value of type std::optional<T> will be returned.
 */
 
 /**
@@ -62,24 +62,24 @@ T checkForMandatoryInstrumentDefault(Mantid::API::Algorithm *const alg, const st
  * @param instrument : A pointer to the instrument
  * @param idf_name : The name of the property in the Instrument Defintion
  * @return A boost optional value of type T that is either the default value,
- * the user supplied value or an uninitialized boost::optional.
+ * the user supplied value or an uninitialized std::optional.
  *
  */
 template <typename T>
-boost::optional<T> checkForOptionalInstrumentDefault(Mantid::API::Algorithm *const alg, const std::string &propName,
+std::optional<T> checkForOptionalInstrumentDefault(Mantid::API::Algorithm *const alg, const std::string &propName,
                                                      const Mantid::Geometry::Instrument_const_sptr &instrument,
                                                      const std::string &idf_name) {
   auto algProperty = alg->getPointerToProperty(propName);
   if (algProperty->isDefault()) {
     auto defaults = instrument->getNumberParameter(idf_name);
     if (!defaults.empty()) {
-      return boost::optional<T>(static_cast<T>(defaults[0]));
+      return std::optional<T>(static_cast<T>(defaults[0]));
     } else {
-      return boost::optional<T>();
+      return std::optional<T>();
     }
   } else {
     double value = boost::lexical_cast<double, std::string>(algProperty->value());
-    return boost::optional<T>(static_cast<T>(value));
+    return std::optional<T>(static_cast<T>(value));
   }
 }
 
@@ -93,7 +93,7 @@ MANTID_API_DLL std::string checkForMandatoryInstrumentDefault(Mantid::API::Algor
                                                               const std::string &idf_name);
 
 template <>
-MANTID_API_DLL boost::optional<std::string>
+MANTID_API_DLL std::optional<std::string>
 checkForOptionalInstrumentDefault(Mantid::API::Algorithm *const alg, const std::string &propName,
                                   const Mantid::Geometry::Instrument_const_sptr &instrument,
                                   const std::string &idf_name);

--- a/Framework/API/src/LiveListenerFactory.cpp
+++ b/Framework/API/src/LiveListenerFactory.cpp
@@ -79,11 +79,11 @@ std::shared_ptr<ILiveListener> LiveListenerFactoryImpl::create(const Kernel::Liv
 
   if (connect) {
     try {
-      Poco::Net::SocketAddress address;
+      std::string address;
 
       // To allow listener::connect to be called even when no address is given
       if (!info.address().empty())
-        address = Poco::Net::SocketAddress(info.address());
+        address = info.address();
 
       // If we can't connect, throw an exception to be handled below
       if (!listener->connect(address)) {

--- a/Framework/API/src/StdOptionalToAlgorithmProperty.cpp
+++ b/Framework/API/src/StdOptionalToAlgorithmProperty.cpp
@@ -4,7 +4,7 @@
 //   NScD Oak Ridge National Laboratory, European Spallation Source,
 //   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 // SPDX - License - Identifier: GPL - 3.0 +
-#include "MantidAPI/BoostOptionalToAlgorithmProperty.h"
+#include "MantidAPI/StdOptionalToAlgorithmProperty.h"
 
 namespace Mantid::API {
 template <>
@@ -26,20 +26,20 @@ std::string checkForMandatoryInstrumentDefault(Mantid::API::Algorithm *const alg
 }
 
 template <>
-boost::optional<std::string>
-checkForOptionalInstrumentDefault(Mantid::API::Algorithm *const alg, const std::string &propName,
-                                  const Mantid::Geometry::Instrument_const_sptr &instrument,
-                                  const std::string &idf_name) {
+std::optional<std::string> checkForOptionalInstrumentDefault(Mantid::API::Algorithm *const alg,
+                                                             const std::string &propName,
+                                                             const Mantid::Geometry::Instrument_const_sptr &instrument,
+                                                             const std::string &idf_name) {
   auto algProperty = alg->getPointerToProperty(propName);
   if (algProperty->isDefault()) {
     auto defaults = instrument->getStringParameter(idf_name);
     if (!defaults.empty()) {
-      return boost::optional<std::string>(defaults[0]);
+      return std::optional<std::string>(defaults[0]);
     } else {
-      return boost::optional<std::string>();
+      return std::optional<std::string>();
     }
   } else {
-    return boost::optional<std::string>(algProperty->value());
+    return std::optional<std::string>(algProperty->value());
   }
 }
 } // namespace Mantid::API

--- a/Framework/API/test/LiveListenerTest.h
+++ b/Framework/API/test/LiveListenerTest.h
@@ -19,18 +19,18 @@ public:
     // Set this flag to true for testing
     m_dataReset = true;
   }
-  GNU_DIAG_OFF_SUGGEST_OVERRIDE
-  MOCK_CONST_METHOD0(name, std::string());
-  MOCK_CONST_METHOD0(supportsHistory, bool());
-  MOCK_CONST_METHOD0(buffersEvents, bool());
-  MOCK_METHOD1(connect, bool(const Poco::Net::SocketAddress &));
-  MOCK_METHOD1(start, void(Mantid::Types::Core::DateAndTime));
-  MOCK_METHOD0(extractData, std::shared_ptr<Mantid::API::Workspace>());
-  MOCK_METHOD0(isConnected, bool());
-  MOCK_METHOD0(runStatus, RunStatus());
-  MOCK_CONST_METHOD0(runNumber, int());
-  MOCK_METHOD1(setAlgorithm, void(const Mantid::API::IAlgorithm &));
-  GNU_DIAG_ON_SUGGEST_OVERRIDE
+
+  MOCK_METHOD(std::string, name, (), (const, override));
+  MOCK_METHOD(bool, supportsHistory, (), (const, override));
+  MOCK_METHOD(bool, buffersEvents, (), (const, override));
+  MOCK_METHOD(int, runNumber, (), (const, override));
+
+  MOCK_METHOD(void, setAlgorithm, (const Mantid::API::IAlgorithm &), (override));
+  MOCK_METHOD(bool, connect, (const std::string_view), (override));
+  MOCK_METHOD(void, start, (Mantid::Types::Core::DateAndTime), (override));
+  MOCK_METHOD(std::shared_ptr<Mantid::API::Workspace>, extractData, (), (override));
+  MOCK_METHOD(bool, isConnected, (), (override));
+  MOCK_METHOD(RunStatus, runStatus, (), (override));
 };
 
 class LiveListenerTest : public CxxTest::TestSuite {

--- a/Framework/DataObjects/inc/MantidDataObjects/NoShape.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/NoShape.h
@@ -29,7 +29,7 @@ public:
   std::string shapeName() const override;
   /// Get the coordinate frame
   Kernel::SpecialCoordinateSystem frame() const override;
-  boost::optional<double> radius(RadiusType) const override { return boost::optional<double>{}; }
+  std::optional<double> radius(RadiusType) const override { return std::optional<double>{}; }
   /// Return the shape name
   static const std::string noShapeName();
 };

--- a/Framework/DataObjects/inc/MantidDataObjects/PeakShapeEllipsoid.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/PeakShapeEllipsoid.h
@@ -47,7 +47,7 @@ public:
   std::string shapeName() const override;
 
   /// PeakBase interface
-  boost::optional<double> radius(RadiusType type = RadiusType::Radius) const override;
+  std::optional<double> radius(RadiusType type = RadiusType::Radius) const override;
   static const std::string ellipsoidShapeName();
 
 private:

--- a/Framework/DataObjects/inc/MantidDataObjects/PeakShapeSpherical.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/PeakShapeSpherical.h
@@ -9,7 +9,7 @@
 #include "MantidDataObjects/PeakShapeBase.h"
 #include "MantidKernel/SpecialCoordinateSystem.h"
 #include "MantidKernel/System.h"
-#include <boost/optional.hpp>
+#include <optional>
 #include <string>
 
 namespace Mantid {
@@ -35,11 +35,11 @@ public:
   /// Equals operator
   bool operator==(const PeakShapeSpherical &other) const;
   /// Peak radius
-  boost::optional<double> radius(RadiusType type = RadiusType::Radius) const override;
+  std::optional<double> radius(RadiusType type = RadiusType::Radius) const override;
   /// Peak outer background radius
-  boost::optional<double> backgroundOuterRadius() const;
+  std::optional<double> backgroundOuterRadius() const;
   /// Peak inner background radius
-  boost::optional<double> backgroundInnerRadius() const;
+  std::optional<double> backgroundInnerRadius() const;
   /// Non-instance shape name
   static const std::string sphereShapeName();
 
@@ -47,9 +47,9 @@ private:
   /// Peak radius
   double m_radius;
   /// Background inner radius;
-  boost::optional<double> m_backgroundInnerRadius;
+  std::optional<double> m_backgroundInnerRadius;
   /// Background outer radius
-  boost::optional<double> m_backgroundOuterRadius;
+  std::optional<double> m_backgroundOuterRadius;
 };
 
 } // namespace DataObjects

--- a/Framework/DataObjects/src/PeakShapeEllipsoid.cpp
+++ b/Framework/DataObjects/src/PeakShapeEllipsoid.cpp
@@ -99,7 +99,7 @@ PeakShapeEllipsoid *PeakShapeEllipsoid::clone() const { return new PeakShapeElli
 
 std::string PeakShapeEllipsoid::shapeName() const { return PeakShapeEllipsoid::ellipsoidShapeName(); }
 
-boost::optional<double> PeakShapeEllipsoid::radius(RadiusType type) const {
+std::optional<double> PeakShapeEllipsoid::radius(RadiusType type) const {
   std::vector<double>::const_iterator it;
   switch (type) {
   case (RadiusType::Radius):
@@ -112,7 +112,7 @@ boost::optional<double> PeakShapeEllipsoid::radius(RadiusType type) const {
     it = std::max_element(m_abc_radiiBackgroundInner.cbegin(), m_abc_radiiBackgroundInner.cend());
     break;
   }
-  return boost::optional<double>{*it};
+  return std::optional<double>{*it};
 }
 
 const std::string PeakShapeEllipsoid::ellipsoidShapeName() { return "ellipsoid"; }

--- a/Framework/DataObjects/src/PeakShapeSpherical.cpp
+++ b/Framework/DataObjects/src/PeakShapeSpherical.cpp
@@ -52,8 +52,8 @@ std::string PeakShapeSpherical::toJSON() const {
   root["radius"] = Json::Value(m_radius);
 
   if (m_backgroundInnerRadius && m_backgroundOuterRadius) {
-    root["background_outer_radius"] = Json::Value(m_backgroundOuterRadius.get());
-    root["background_inner_radius"] = Json::Value(m_backgroundInnerRadius.get());
+    root["background_outer_radius"] = Json::Value(m_backgroundOuterRadius.value());
+    root["background_inner_radius"] = Json::Value(m_backgroundInnerRadius.value());
   }
 
   return Mantid::JsonHelpers::jsonToString(root);
@@ -78,12 +78,12 @@ bool PeakShapeSpherical::operator==(const PeakShapeSpherical &other) const {
  * @param type Which radius to get.
  * @return radius
  */
-boost::optional<double> PeakShapeSpherical::radius(RadiusType type) const {
+std::optional<double> PeakShapeSpherical::radius(RadiusType type) const {
 
-  boost::optional<double> value;
+  std::optional<double> value;
   switch (type) {
   case (RadiusType::Radius):
-    value = boost::optional<double>{m_radius};
+    value = m_radius;
     break;
   case (RadiusType::OuterRadius):
     value = m_backgroundOuterRadius;
@@ -100,14 +100,14 @@ boost::optional<double> PeakShapeSpherical::radius(RadiusType type) const {
  * this is optional.
  * @return boost optional outer radius
  */
-boost::optional<double> PeakShapeSpherical::backgroundOuterRadius() const { return m_backgroundOuterRadius; }
+std::optional<double> PeakShapeSpherical::backgroundOuterRadius() const { return m_backgroundOuterRadius; }
 
 /**
  * @brief Get the background inner radius. The inner radius may not be set, so
  * this is optional.
  * @return boost optional inner radius.
  */
-boost::optional<double> PeakShapeSpherical::backgroundInnerRadius() const { return m_backgroundInnerRadius; }
+std::optional<double> PeakShapeSpherical::backgroundInnerRadius() const { return m_backgroundInnerRadius; }
 
 /**
  * @brief PeakShapeSpherical::sphereShapeName

--- a/Framework/DataObjects/test/MockObjects.h
+++ b/Framework/DataObjects/test/MockObjects.h
@@ -32,7 +32,7 @@ public:
   MOCK_CONST_METHOD0(algorithmName, std::string());
   MOCK_CONST_METHOD0(algorithmVersion, int());
   MOCK_CONST_METHOD0(shapeName, std::string());
-  MOCK_CONST_METHOD1(radius, boost::optional<double>(Mantid::Geometry::PeakShape::RadiusType));
+  MOCK_CONST_METHOD1(radius, std::optional<double>(Mantid::Geometry::PeakShape::RadiusType));
   ~MockPeakShape() override {}
 };
 } // namespace DataObjects

--- a/Framework/DataObjects/test/PeakShapeSphericalTest.h
+++ b/Framework/DataObjects/test/PeakShapeSphericalTest.h
@@ -46,8 +46,8 @@ public:
     TS_ASSERT_EQUALS(frame, shape.frame());
     TS_ASSERT_EQUALS(algorithmName, shape.algorithmName());
     TS_ASSERT_EQUALS(algorithmVersion, shape.algorithmVersion());
-    TS_ASSERT(!shape.backgroundInnerRadius().is_initialized());
-    TS_ASSERT(!shape.backgroundOuterRadius().is_initialized());
+    TS_ASSERT(!shape.backgroundInnerRadius().has_value());
+    TS_ASSERT(!shape.backgroundOuterRadius().has_value());
   }
 
   void test_multiple_radii_constructor() {
@@ -70,15 +70,15 @@ public:
     TS_ASSERT_EQUALS(frame, shape.frame());
     TS_ASSERT_EQUALS(algorithmName, shape.algorithmName());
     TS_ASSERT_EQUALS(algorithmVersion, shape.algorithmVersion());
-    TS_ASSERT_EQUALS(backgroundInnerRadius, shape.backgroundInnerRadius().get());
-    TS_ASSERT_EQUALS(backgroundOuterRadius, shape.backgroundOuterRadius().get());
+    TS_ASSERT_EQUALS(backgroundInnerRadius, shape.backgroundInnerRadius().value());
+    TS_ASSERT_EQUALS(backgroundOuterRadius, shape.backgroundOuterRadius().value());
 
     PeakShapeSpherical badShape(radius, radius, radius, frame, algorithmName, algorithmVersion);
 
     TSM_ASSERT("Background inner radius should be set even when same as radius",
-               badShape.backgroundInnerRadius().is_initialized());
+               badShape.backgroundInnerRadius().has_value());
     TSM_ASSERT("Background outer radius should be unset since is same as radius",
-               !badShape.backgroundOuterRadius().is_initialized());
+               !badShape.backgroundOuterRadius().has_value());
   }
 
   void test_copy_constructor() {
@@ -98,8 +98,8 @@ public:
     TS_ASSERT_EQUALS(frame, b.frame());
     TS_ASSERT_EQUALS(algorithmName, b.algorithmName());
     TS_ASSERT_EQUALS(algorithmVersion, b.algorithmVersion());
-    TS_ASSERT_EQUALS(backgroundInnerRadius, b.backgroundInnerRadius().get());
-    TS_ASSERT_EQUALS(backgroundOuterRadius, b.backgroundOuterRadius().get());
+    TS_ASSERT_EQUALS(backgroundInnerRadius, b.backgroundInnerRadius().value());
+    TS_ASSERT_EQUALS(backgroundOuterRadius, b.backgroundOuterRadius().value());
   }
 
   void test_assignment() {
@@ -122,8 +122,8 @@ public:
     TS_ASSERT_EQUALS(a.frame(), b.frame());
     TS_ASSERT_EQUALS(a.algorithmName(), b.algorithmName());
     TS_ASSERT_EQUALS(a.algorithmVersion(), b.algorithmVersion());
-    TS_ASSERT_EQUALS(a.backgroundInnerRadius(), b.backgroundInnerRadius().get());
-    TS_ASSERT_EQUALS(a.backgroundOuterRadius(), b.backgroundOuterRadius().get());
+    TS_ASSERT_EQUALS(a.backgroundInnerRadius(), b.backgroundInnerRadius().value());
+    TS_ASSERT_EQUALS(a.backgroundOuterRadius(), b.backgroundOuterRadius().value());
   }
 
   void test_clone() {
@@ -142,8 +142,8 @@ public:
     TS_ASSERT_EQUALS(a.frame(), clone->frame());
     TS_ASSERT_EQUALS(a.algorithmName(), clone->algorithmName());
     TS_ASSERT_EQUALS(a.algorithmVersion(), clone->algorithmVersion());
-    TS_ASSERT_EQUALS(a.backgroundInnerRadius(), clone->backgroundInnerRadius().get());
-    TS_ASSERT_EQUALS(a.backgroundOuterRadius(), clone->backgroundOuterRadius().get());
+    TS_ASSERT_EQUALS(a.backgroundInnerRadius(), clone->backgroundInnerRadius().value());
+    TS_ASSERT_EQUALS(a.backgroundOuterRadius(), clone->backgroundOuterRadius().value());
     TS_ASSERT_DIFFERS(clone, &a);
     delete clone;
   }

--- a/Framework/Geometry/inc/MantidGeometry/Crystal/PeakShape.h
+++ b/Framework/Geometry/inc/MantidGeometry/Crystal/PeakShape.h
@@ -8,8 +8,9 @@
 
 #include "MantidKernel/SpecialCoordinateSystem.h"
 #include "MantidKernel/System.h"
-#include <boost/optional.hpp>
+
 #include <memory>
+#include <optional>
 #include <string>
 
 namespace Mantid {
@@ -34,7 +35,7 @@ public:
   /// For selecting different radius types.
   enum RadiusType { Radius = 0, OuterRadius = 1, InnerRadius = 2 };
   /// Radius
-  virtual boost::optional<double> radius(RadiusType type) const = 0;
+  virtual std::optional<double> radius(RadiusType type) const = 0;
   /// Destructor
   virtual ~PeakShape() = default;
 };

--- a/Framework/LiveData/inc/MantidLiveData/FakeEventDataListener.h
+++ b/Framework/LiveData/inc/MantidLiveData/FakeEventDataListener.h
@@ -30,7 +30,7 @@ public:
   bool supportsHistory() const override { return false; } // For the time being at least
   bool buffersEvents() const override { return true; }
 
-  bool connect(const Poco::Net::SocketAddress &address) override;
+  bool connect(const std::string_view address) override;
   void start(Types::Core::DateAndTime startTime = Types::Core::DateAndTime()) override;
   std::shared_ptr<API::Workspace> extractData() override;
 

--- a/Framework/LiveData/inc/MantidLiveData/FileEventDataListener.h
+++ b/Framework/LiveData/inc/MantidLiveData/FileEventDataListener.h
@@ -36,7 +36,7 @@ public:
   bool supportsHistory() const override { return false; } // For the time being at least
   bool buffersEvents() const override { return true; }
 
-  bool connect(const Poco::Net::SocketAddress &address) override;
+  bool connect(const std::string_view address) override;
   void start(Types::Core::DateAndTime startTime = Types::Core::DateAndTime()) override;
   std::shared_ptr<API::Workspace> extractData() override;
 

--- a/Framework/LiveData/inc/MantidLiveData/ISIS/ISISHistoDataListener.h
+++ b/Framework/LiveData/inc/MantidLiveData/ISIS/ISISHistoDataListener.h
@@ -43,7 +43,7 @@ public:
   bool supportsHistory() const override { return false; }
   bool buffersEvents() const override { return false; }
 
-  bool connect(const Poco::Net::SocketAddress &address) override;
+  bool connect(const std::string_view address) override;
   void start(Types::Core::DateAndTime startTime = Types::Core::DateAndTime()) override;
   std::shared_ptr<API::Workspace> extractData() override;
 

--- a/Framework/LiveData/inc/MantidLiveData/ISIS/ISISLiveEventDataListener.h
+++ b/Framework/LiveData/inc/MantidLiveData/ISIS/ISISLiveEventDataListener.h
@@ -66,7 +66,7 @@ public:
    *  @param address   The IP address and port to contact
    *  @return True if the connection was successfully established
    */
-  bool connect(const Poco::Net::SocketAddress &address) override;
+  bool connect(const std::string_view address) override;
 
   /** Commence the collection of data from the DAS. Must be called before
    * extractData().

--- a/Framework/LiveData/inc/MantidLiveData/Kafka/KafkaEventListener.h
+++ b/Framework/LiveData/inc/MantidLiveData/Kafka/KafkaEventListener.h
@@ -51,7 +51,7 @@ public:
   // Actions
   //----------------------------------------------------------------------
 
-  bool connect(const Poco::Net::SocketAddress &address) override;
+  bool connect(const std::string_view address) override;
   void start(Types::Core::DateAndTime startTime = Types::Core::DateAndTime()) override;
   std::shared_ptr<API::Workspace> extractData() override;
   void setAlgorithm(const Mantid::API::IAlgorithm &callingAlgorithm) override;

--- a/Framework/LiveData/inc/MantidLiveData/Kafka/KafkaHistoListener.h
+++ b/Framework/LiveData/inc/MantidLiveData/Kafka/KafkaHistoListener.h
@@ -43,7 +43,7 @@ public:
   //----------------------------------------------------------------------
   // Actions
   //----------------------------------------------------------------------
-  bool connect(const Poco::Net::SocketAddress &address) override;
+  bool connect(const std::string_view address) override;
   void start(Types::Core::DateAndTime startTime = Types::Core::DateAndTime()) override;
   std::shared_ptr<API::Workspace> extractData() override;
 

--- a/Framework/LiveData/inc/MantidLiveData/SNSLiveEventDataListener.h
+++ b/Framework/LiveData/inc/MantidLiveData/SNSLiveEventDataListener.h
@@ -33,7 +33,7 @@ public:
   bool supportsHistory() const override { return true; }
   bool buffersEvents() const override { return true; }
 
-  bool connect(const Poco::Net::SocketAddress &address) override;
+  bool connect(const std::string_view address) override;
   void start(const Types::Core::DateAndTime startTime = Types::Core::DateAndTime()) override;
   std::shared_ptr<API::Workspace> extractData() override;
 

--- a/Framework/LiveData/src/FakeEventDataListener.cpp
+++ b/Framework/LiveData/src/FakeEventDataListener.cpp
@@ -40,7 +40,7 @@ FakeEventDataListener::FakeEventDataListener()
 /// Destructor
 FakeEventDataListener::~FakeEventDataListener() { m_timer.stop(); }
 
-bool FakeEventDataListener::connect(const Poco::Net::SocketAddress & /*address*/) {
+bool FakeEventDataListener::connect(const std::string_view /*address*/) {
   // Do nothing for now. Later, put in stuff to help test failure modes.
   return true;
 }

--- a/Framework/LiveData/src/FileEventDataListener.cpp
+++ b/Framework/LiveData/src/FileEventDataListener.cpp
@@ -83,7 +83,7 @@ FileEventDataListener::~FileEventDataListener() {
   }
 }
 
-bool FileEventDataListener::connect(const Poco::Net::SocketAddress & /*address*/) {
+bool FileEventDataListener::connect(const std::string_view /*address*/) {
   // Do nothing for now. Later, put in stuff to help test failure modes.
   return true;
 }

--- a/Framework/LiveData/src/ISIS/ISISHistoDataListener.cpp
+++ b/Framework/LiveData/src/ISIS/ISISHistoDataListener.cpp
@@ -89,10 +89,9 @@ void ISISHistoDataListener::IDCReporter(int status, int code, const char *messag
  * required for the connection
  *  @return True if the connection was successfully established
  */
-bool ISISHistoDataListener::connect(const Poco::Net::SocketAddress &address) {
-
-  m_daeName = address.toString();
+bool ISISHistoDataListener::connect(const std::string_view address) {
   // remove the port part
+  m_daeName = address;
   auto i = m_daeName.find(':');
   if (i != std::string::npos) {
     m_daeName.erase(i);
@@ -101,7 +100,7 @@ bool ISISHistoDataListener::connect(const Poco::Net::SocketAddress &address) {
   // set IDC reporter function for errors
   IDCsetreportfunc(&ISISHistoDataListener::IDCReporter);
 
-  if (IDCopen(m_daeName.c_str(), 0, 0, &m_daeHandle, address.port()) != 0) {
+  if (IDCopen(m_daeName.c_str(), 0, 0, &m_daeHandle, Poco::Net::SocketAddress(std::string{address}).port()) != 0) {
     m_daeHandle = nullptr;
     return false;
   }

--- a/Framework/LiveData/src/Kafka/KafkaEventListener.cpp
+++ b/Framework/LiveData/src/Kafka/KafkaEventListener.cpp
@@ -39,7 +39,7 @@ void KafkaEventListener::setAlgorithm(const Mantid::API::IAlgorithm &callingAlgo
 }
 
 /// @copydoc ILiveListener::connect
-bool KafkaEventListener::connect(const Poco::Net::SocketAddress &address) {
+bool KafkaEventListener::connect(const std::string_view address) {
   if (m_instrumentName.empty()) {
     g_log.error("KafkaEventListener::connect requires a non-empty instrument name");
   }
@@ -76,7 +76,7 @@ bool KafkaEventListener::connect(const Poco::Net::SocketAddress &address) {
   }
 
   const std::size_t bufferThreshold = getProperty("BufferThreshold");
-  auto broker = std::make_shared<KafkaBroker>(address.toString());
+  auto broker = std::make_shared<KafkaBroker>(std::string(address));
   try {
     m_decoder = std::make_unique<KafkaEventStreamDecoder>(broker, eventTopic, runInfoTopic, sampleEnvTopic,
                                                           chopperTopic, monitorTopic, bufferThreshold);

--- a/Framework/LiveData/src/Kafka/KafkaHistoListener.cpp
+++ b/Framework/LiveData/src/Kafka/KafkaHistoListener.cpp
@@ -34,7 +34,7 @@ void KafkaHistoListener::setAlgorithm(const Mantid::API::IAlgorithm &callingAlgo
 }
 
 /// @copydoc ILiveListener::connect
-bool KafkaHistoListener::connect(const Poco::Net::SocketAddress &address) {
+bool KafkaHistoListener::connect(const std::string_view address) {
   if (m_instrumentName.empty()) {
     g_log.error("KafkaHistoListener::connect requires a non-empty instrument name");
   }
@@ -45,8 +45,9 @@ bool KafkaHistoListener::connect(const Poco::Net::SocketAddress &address) {
         sampleEnvTopic(m_instrumentName + KafkaTopicSubscriber::SAMPLE_ENV_TOPIC_SUFFIX),
         chopperTimestampTopic(m_instrumentName + KafkaTopicSubscriber::CHOPPER_TOPIC_SUFFIX);
 
-    m_decoder = std::make_unique<KafkaHistoStreamDecoder>(std::make_shared<KafkaBroker>(address.toString()), histoTopic,
-                                                          runInfoTopic, sampleEnvTopic, chopperTimestampTopic);
+    m_decoder =
+        std::make_unique<KafkaHistoStreamDecoder>(std::make_shared<KafkaBroker>(std::string{address}), histoTopic,
+                                                  runInfoTopic, sampleEnvTopic, chopperTimestampTopic);
   } catch (std::exception &exc) {
     g_log.error() << "KafkaHistoListener::connect - Connection Error: " << exc.what() << "\n";
     return false;

--- a/Framework/LiveData/src/SNSLiveEventDataListener.cpp
+++ b/Framework/LiveData/src/SNSLiveEventDataListener.cpp
@@ -130,7 +130,7 @@ SNSLiveEventDataListener::~SNSLiveEventDataListener() {
 /// debugging and testing).
 /// @param address The address to attempt to connect to
 /// @return Returns true if the connection succeeds.  False otherwise.
-bool SNSLiveEventDataListener::connect(const Poco::Net::SocketAddress &address)
+bool SNSLiveEventDataListener::connect(const std::string_view address)
 // The SocketAddress class will throw various exceptions if it encounters an
 // error.  We're assuming the calling function will catch any exceptions
 // that are important.
@@ -141,7 +141,7 @@ bool SNSLiveEventDataListener::connect(const Poco::Net::SocketAddress &address)
   // If we don't have an address, force a connection to the test server running
   // on
   // localhost on the default port
-  if (address.host().toString() == "0.0.0.0") {
+  if (Poco::Net::SocketAddress socketAddress(std::string{address}); socketAddress.host().toString() == "0.0.0.0") {
     Poco::Net::SocketAddress tempAddress("localhost:31415");
     try {
       m_socket.connect(tempAddress); // BLOCKING connect
@@ -151,9 +151,9 @@ bool SNSLiveEventDataListener::connect(const Poco::Net::SocketAddress &address)
     }
   } else {
     try {
-      m_socket.connect(address); // BLOCKING connect
+      m_socket.connect(socketAddress); // BLOCKING connect
     } catch (...) {
-      g_log.debug() << "Connection to " << address.toString() << " failed.\n";
+      g_log.debug() << "Connection to " << address << " failed.\n";
       return false;
     }
   }

--- a/Framework/LiveData/test/TestDataListener.cpp
+++ b/Framework/LiveData/test/TestDataListener.cpp
@@ -56,7 +56,7 @@ TestDataListener::TestDataListener()
 /// Destructor
 TestDataListener::~TestDataListener() { delete m_rand; }
 
-bool TestDataListener::connect(const Poco::Net::SocketAddress &) {
+bool TestDataListener::connect(const std::string_view) {
   // Do nothing for now. Later, put in stuff to help test failure modes.
   return true;
 }

--- a/Framework/LiveData/test/TestDataListener.h
+++ b/Framework/LiveData/test/TestDataListener.h
@@ -30,7 +30,7 @@ public:
   bool supportsHistory() const override { return false; }
   bool buffersEvents() const override { return true; }
 
-  bool connect(const Poco::Net::SocketAddress &address) override;
+  bool connect(const std::string_view address) override;
   void start(Types::Core::DateAndTime startTime = Types::Core::DateAndTime()) override;
   std::shared_ptr<API::Workspace> extractData() override;
 

--- a/Framework/LiveData/test/TestGroupDataListener.cpp
+++ b/Framework/LiveData/test/TestGroupDataListener.cpp
@@ -25,7 +25,7 @@ TestGroupDataListener::TestGroupDataListener() : ILiveListener(), m_buffer() {
   this->createWorkspace();
 }
 
-bool TestGroupDataListener::connect(const Poco::Net::SocketAddress &) {
+bool TestGroupDataListener::connect(const std::string_view) {
   // Do nothing.
   return true;
 }

--- a/Framework/LiveData/test/TestGroupDataListener.h
+++ b/Framework/LiveData/test/TestGroupDataListener.h
@@ -26,7 +26,7 @@ public:
   bool supportsHistory() const override { return false; }
   bool buffersEvents() const override { return true; }
 
-  bool connect(const Poco::Net::SocketAddress &address) override;
+  bool connect(const std::string_view address) override;
   void start(Types::Core::DateAndTime startTime = Types::Core::DateAndTime()) override;
   std::shared_ptr<API::Workspace> extractData() override;
 

--- a/Framework/MDAlgorithms/test/IntegratePeaksMD2Test.h
+++ b/Framework/MDAlgorithms/test/IntegratePeaksMD2Test.h
@@ -1015,8 +1015,8 @@ public:
         dynamic_cast<PeakShapeSpherical *>(const_cast<PeakShape *>(&shape));
     TS_ASSERT(sphericalShape);
     TS_ASSERT_EQUALS(peakRadius, sphericalShape->radius());
-    TS_ASSERT_EQUALS(backgroundOuterRadius, sphericalShape->backgroundOuterRadius().get());
-    TS_ASSERT_EQUALS(backgroundInnerRadius, sphericalShape->backgroundInnerRadius().get());
+    TS_ASSERT_EQUALS(backgroundOuterRadius, sphericalShape->backgroundOuterRadius().value());
+    TS_ASSERT_EQUALS(backgroundInnerRadius, sphericalShape->backgroundInnerRadius().value());
   }
 
   void test_writes_out_peak_shape() {
@@ -1041,8 +1041,8 @@ public:
 
     // Check the shape is what we expect
     TS_ASSERT_EQUALS(peakRadius, sphericalShape->radius());
-    TS_ASSERT_EQUALS(backgroundOuterRadius, sphericalShape->backgroundOuterRadius().get());
-    TS_ASSERT_EQUALS(backgroundInnerRadius, sphericalShape->backgroundInnerRadius().get());
+    TS_ASSERT_EQUALS(backgroundOuterRadius, sphericalShape->backgroundOuterRadius().value());
+    TS_ASSERT_EQUALS(backgroundInnerRadius, sphericalShape->backgroundInnerRadius().value());
   }
 
   void test_exec_EllipsoidRadii_with_LeanElasticPeaks() {

--- a/Framework/MDAlgorithms/test/IntegratePeaksMDTest.h
+++ b/Framework/MDAlgorithms/test/IntegratePeaksMDTest.h
@@ -373,8 +373,8 @@ public:
 
     // Check the shape is what we expect
     TS_ASSERT_EQUALS(peakRadius, sphericalShape->radius());
-    TS_ASSERT_EQUALS(backgroundOuterRadius, sphericalShape->backgroundOuterRadius().get());
-    TS_ASSERT_EQUALS(backgroundInnerRadius, sphericalShape->backgroundInnerRadius().get());
+    TS_ASSERT_EQUALS(backgroundOuterRadius, sphericalShape->backgroundOuterRadius().value());
+    TS_ASSERT_EQUALS(backgroundInnerRadius, sphericalShape->backgroundInnerRadius().value());
   }
 };
 

--- a/Framework/Reflectometry/src/CreateTransmissionWorkspaceAuto2.cpp
+++ b/Framework/Reflectometry/src/CreateTransmissionWorkspaceAuto2.cpp
@@ -5,7 +5,7 @@
 //   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 // SPDX - License - Identifier: GPL - 3.0 +
 #include "MantidReflectometry/CreateTransmissionWorkspaceAuto2.h"
-#include "MantidAPI/BoostOptionalToAlgorithmProperty.h"
+#include "MantidAPI/StdOptionalToAlgorithmProperty.h"
 #include "MantidAPI/WorkspaceUnitValidator.h"
 #include "MantidKernel/ListValidator.h"
 #include "MantidReflectometry/ReflectometryWorkflowBase2.h"

--- a/Framework/Reflectometry/src/ReflectometryReductionOneAuto2.cpp
+++ b/Framework/Reflectometry/src/ReflectometryReductionOneAuto2.cpp
@@ -5,7 +5,7 @@
 //   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 // SPDX - License - Identifier: GPL - 3.0 +
 #include "MantidReflectometry/ReflectometryReductionOneAuto2.h"
-#include "MantidAPI/BoostOptionalToAlgorithmProperty.h"
+#include "MantidAPI/StdOptionalToAlgorithmProperty.h"
 #include "MantidAPI/MatrixWorkspace.h"
 #include "MantidAPI/WorkspaceGroup.h"
 #include "MantidKernel/ArrayProperty.h"

--- a/Framework/Reflectometry/src/ReflectometryReductionOneAuto3.cpp
+++ b/Framework/Reflectometry/src/ReflectometryReductionOneAuto3.cpp
@@ -5,8 +5,8 @@
 //   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 // SPDX - License - Identifier: GPL - 3.0 +
 #include "MantidReflectometry/ReflectometryReductionOneAuto3.h"
-#include "MantidAPI/BoostOptionalToAlgorithmProperty.h"
 #include "MantidAPI/MatrixWorkspace.h"
+#include "MantidAPI/StdOptionalToAlgorithmProperty.h"
 #include "MantidAPI/WorkspaceGroup.h"
 #include "MantidKernel/ArrayProperty.h"
 #include "MantidKernel/CompositeValidator.h"

--- a/Framework/Reflectometry/src/ReflectometryWorkflowBase2.cpp
+++ b/Framework/Reflectometry/src/ReflectometryWorkflowBase2.cpp
@@ -7,9 +7,9 @@
 #include "MantidReflectometry/ReflectometryWorkflowBase2.h"
 
 #include "MantidAPI/Axis.h"
-#include "MantidAPI/BoostOptionalToAlgorithmProperty.h"
 #include "MantidAPI/MatrixWorkspace.h"
 #include "MantidAPI/Run.h"
+#include "MantidAPI/StdOptionalToAlgorithmProperty.h"
 #include "MantidAPI/WorkspaceUnitValidator.h"
 #include "MantidGeometry/Instrument.h"
 #include "MantidIndexing/IndexInfo.h"
@@ -632,43 +632,43 @@ void ReflectometryWorkflowBase2::populateMonitorProperties(const IAlgorithm_sptr
 
   const auto startOverlap =
       checkForOptionalInstrumentDefault<double>(this, "StartOverlap", instrument, "TransRunStartOverlap");
-  if (startOverlap.is_initialized())
-    alg->setProperty("StartOverlap", startOverlap.get());
+  if (startOverlap.has_value())
+    alg->setProperty("StartOverlap", startOverlap.value());
 
   const auto endOverlap =
       checkForOptionalInstrumentDefault<double>(this, "EndOverlap", instrument, "TransRunEndOverlap");
-  if (endOverlap.is_initialized())
-    alg->setProperty("EndOverlap", endOverlap.get());
+  if (endOverlap.has_value())
+    alg->setProperty("EndOverlap", endOverlap.value());
 
   const auto monitorIndex =
       checkForOptionalInstrumentDefault<int>(this, "I0MonitorIndex", instrument, "I0MonitorIndex");
-  if (monitorIndex.is_initialized())
-    alg->setProperty("I0MonitorIndex", monitorIndex.get());
+  if (monitorIndex.has_value())
+    alg->setProperty("I0MonitorIndex", monitorIndex.value());
 
   const auto backgroundMin = checkForOptionalInstrumentDefault<double>(this, "MonitorBackgroundWavelengthMin",
                                                                        instrument, "MonitorBackgroundMin");
-  if (backgroundMin.is_initialized())
-    alg->setProperty("MonitorBackgroundWavelengthMin", backgroundMin.get());
+  if (backgroundMin.has_value())
+    alg->setProperty("MonitorBackgroundWavelengthMin", backgroundMin.value());
 
   const auto backgroundMax = checkForOptionalInstrumentDefault<double>(this, "MonitorBackgroundWavelengthMax",
                                                                        instrument, "MonitorBackgroundMax");
-  if (backgroundMax.is_initialized())
-    alg->setProperty("MonitorBackgroundWavelengthMax", backgroundMax.get());
+  if (backgroundMax.has_value())
+    alg->setProperty("MonitorBackgroundWavelengthMax", backgroundMax.value());
 
   const auto integrationMin = checkForOptionalInstrumentDefault<double>(this, "MonitorIntegrationWavelengthMin",
                                                                         instrument, "MonitorIntegralMin");
-  if (integrationMin.is_initialized())
-    alg->setProperty("MonitorIntegrationWavelengthMin", integrationMin.get());
+  if (integrationMin.has_value())
+    alg->setProperty("MonitorIntegrationWavelengthMin", integrationMin.value());
 
   const auto integrationMax = checkForOptionalInstrumentDefault<double>(this, "MonitorIntegrationWavelengthMax",
                                                                         instrument, "MonitorIntegralMax");
-  if (integrationMax.is_initialized())
-    alg->setProperty("MonitorIntegrationWavelengthMax", integrationMax.get());
+  if (integrationMax.has_value())
+    alg->setProperty("MonitorIntegrationWavelengthMax", integrationMax.value());
 
   const auto integrationBool = checkForOptionalInstrumentDefault<bool>(this, "NormalizeByIntegratedMonitors",
                                                                        instrument, "NormalizeByIntegratedMonitors");
-  if (integrationBool.is_initialized())
-    alg->setProperty("NormalizeByIntegratedMonitors", integrationBool.get());
+  if (integrationBool.has_value())
+    alg->setProperty("NormalizeByIntegratedMonitors", integrationBool.value());
 }
 
 /** Finding processing instructions from the parameters file

--- a/Framework/SINQ/inc/MantidSINQ/SINQHMListener.h
+++ b/Framework/SINQ/inc/MantidSINQ/SINQHMListener.h
@@ -33,7 +33,7 @@ public:
   bool supportsHistory() const override { return false; }
   bool buffersEvents() const override { return false; }
 
-  bool connect(const Poco::Net::SocketAddress &address) override;
+  bool connect(const std::string_view address) override;
   void start(Mantid::Types::Core::DateAndTime startTime = Mantid::Types::Core::DateAndTime()) override;
   std::shared_ptr<Mantid::API::Workspace> extractData() override;
   bool isConnected() override;

--- a/Framework/SINQ/src/SINQHMListener.cpp
+++ b/Framework/SINQ/src/SINQHMListener.cpp
@@ -42,7 +42,7 @@ SINQHMListener::SINQHMListener() : LiveListener(), httpcon(), response(), oldSta
   rank = 0;
 }
 
-bool SINQHMListener::connect(const Poco::Net::SocketAddress &address) {
+bool SINQHMListener::connect(const std::string_view address) {
   std::string host = address.toString();
   std::string::size_type i = host.find(':');
   if (i != std::string::npos) {

--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -861,8 +861,6 @@ useStlAlgorithm:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/ISISReflectometry/G
 useStlAlgorithm:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/QtExperimentView.cpp:542
 constParameter:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/ISISReflectometry/GUI/Instrument/InstrumentPresenter.cpp:18
 useStlAlgorithm:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/ISISReflectometry/GUI/MainWindow/MainWindowPresenter.cpp:153
-constParameter:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/ISISReflectometry/Reduction/Group.cpp:185
-constParameter:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/ISISReflectometry/Reduction/Group.cpp:197
 shadowFunction:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/ISISReflectometry/GUI/Common/Encoder.cpp:40
 shadowFunction:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/ISISReflectometry/GUI/Common/Encoder.cpp:63
 shadowFunction:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/ISISReflectometry/GUI/Common/Encoder.cpp:74

--- a/buildconfig/CMake/GoogleTest.cmake
+++ b/buildconfig/CMake/GoogleTest.cmake
@@ -2,7 +2,7 @@
 
 # Make gtest_version available everywhere
 set(gtest_version
-    "1.10.0"
+    "1.11.0"
     CACHE INTERNAL ""
 )
 
@@ -17,7 +17,7 @@ set(gtest_force_shared_crt
 fetchcontent_declare(
   googletest
   GIT_REPOSITORY https://github.com/google/googletest.git
-  GIT_TAG release-1.10.0
+  GIT_TAG release-1.11.0
   GIT_SHALLOW TRUE
 )
 

--- a/qt/python/mantidqt/mantidqt/_common.sip
+++ b/qt/python/mantidqt/mantidqt/_common.sip
@@ -800,8 +800,8 @@ public:
     Cell deadCell() const;
 
     std::vector<MantidQt::MantidWidgets::Batch::RowLocation> selectedRowLocations() const;
-    boost::optional<std::vector<std::vector<Row>>> selectedSubtrees() const;
-    boost::optional<std::vector<MantidQt::MantidWidgets::Batch::RowLocation>> selectedSubtreeRoots() const;
+    std::optional<std::vector<std::vector<Row>>> selectedSubtrees() const;
+    std::optional<std::vector<MantidQt::MantidWidgets::Batch::RowLocation>> selectedSubtreeRoots() const;
 };
 
 class Cell {

--- a/qt/python/mantidqt/sip/vector.sip
+++ b/qt/python/mantidqt/sip/vector.sip
@@ -39,10 +39,10 @@ template<TYPE>
     // Check if type is compatible
     return isIterable(sipPy);
   } else {
-    auto cppValue = pythonListToVector<TYPE>(sipPy, [&](PyObject* pyItem) -> boost::optional<TYPE> {
+    auto cppValue = pythonListToVector<TYPE>(sipPy, [&](PyObject* pyItem) -> std::optional<TYPE> {
       if (!sipCanConvertToType(pyItem, sipType_TYPE, SIP_NOT_NONE)) {
         PyErr_Format(PyExc_TypeError, "object in iterable cannot be converted to TYPE");
-        return boost::none;
+        return std::nullopt;
       } else {
         int state;
         auto* cppItemPtr = reinterpret_cast<TYPE*>(
@@ -58,11 +58,11 @@ template<TYPE>
 };
 
 template<TYPE>
-%MappedType boost::optional<std::vector<TYPE>>
+%MappedType std::optional<std::vector<TYPE>>
 {
 %TypeHeaderCode
 #include <vector>
-#include <boost/optional.hpp>
+#include <optional>
 %End
 
 %ConvertFromTypeCode
@@ -79,11 +79,11 @@ template<TYPE>
       // Check if type is compatible
       return isIterable(sipPy) || sipPy == Py_None;
     } else {
-      auto cppValue = pythonObjectToOptional<std::vector<TYPE>>(sipPy, [&](PyObject* pythonList) -> boost::optional<std::vector<TYPE>> {
-        return pythonListToVector<TYPE>(pythonList, [&](PyObject* pyItem) -> boost::optional<TYPE> {
+      auto cppValue = pythonObjectToOptional<std::vector<TYPE>>(sipPy, [&](PyObject* pythonList) -> std::optional<std::vector<TYPE>> {
+        return pythonListToVector<TYPE>(pythonList, [&](PyObject* pyItem) -> std::optional<TYPE> {
           if (!sipCanConvertToType(pyItem, sipType_TYPE, SIP_NOT_NONE)) {
             PyErr_Format(PyExc_TypeError, "object in iterable cannot be converted to TYPE");
-            return boost::none;
+            return std::nullopt;
           } else {
             int state;
             auto* cppItemPtr = reinterpret_cast<TYPE*>(
@@ -119,10 +119,10 @@ template<TYPE>
     // Check if type is compatible
     return isIterable(sipPy) || sipPy == Py_None;
   } else {
-    auto cppValue = pythonListToVector<double>(sipPy, [&](PyObject* pyItem) -> boost::optional<double> {
+    auto cppValue = pythonListToVector<double>(sipPy, [&](PyObject* pyItem) -> std::optional<double> {
       if (!PyNumber_Check(pyItem)) {
         PyErr_Format(PyExc_TypeError, "object in iterable is not a number");
-        return boost::none;
+        return std::nullopt;
       } else {
         return PyFloat_AsDouble(pyItem);
       }
@@ -153,10 +153,10 @@ template<TYPE>
     // Check if type is compatible
     return isIterable(sipPy) || sipPy == Py_None;
   } else {
-    auto cppValue = pythonListToVector<int>(sipPy, [&](PyObject* pyItem) -> boost::optional<int> {
+    auto cppValue = pythonListToVector<int>(sipPy, [&](PyObject* pyItem) -> std::optional<int> {
       if (!INT_CHECK(pyItem)) {
         PyErr_Format(PyExc_TypeError, "object in iterable is not an int");
-        return boost::none;
+        return std::nullopt;
       } else {
         return static_cast<int>(TO_LONG(pyItem));
       }
@@ -188,10 +188,10 @@ template<TYPE>
     // Check if type is compatible
     return isIterable(sipPy) || sipPy == Py_None;
   } else {
-    auto cppValue = pythonListToVector<unsigned int>(sipPy, [&](PyObject* pyItem) -> boost::optional<unsigned int> {
+    auto cppValue = pythonListToVector<unsigned int>(sipPy, [&](PyObject* pyItem) -> std::optional<unsigned int> {
       if (!INT_CHECK(pyItem)) {
         PyErr_Format(PyExc_TypeError, "object in iterable is not an int");
-        return boost::none;
+        return std::nullopt;
       } else {
         return static_cast<unsigned int>(TO_LONG(pyItem));
       }
@@ -221,7 +221,7 @@ template<TYPE>
     // Check if type is compatible
     return isIterable(sipPy) || sipPy == Py_None;
   } else {
-    auto cppValue = pythonListToVector<std::string>(sipPy, [&](PyObject* pyItem) -> boost::optional<std::string> {
+    auto cppValue = pythonListToVector<std::string>(sipPy, [&](PyObject* pyItem) -> std::optional<std::string> {
       auto maybeValue = pythonStringToStdString(pyItem);
       return typeErrorIfNoneElseValue(maybeValue, "object in iterable is not a string.");
     });
@@ -256,11 +256,11 @@ template<TYPE>
     // Check if type is compatible
     return isIterable(sipPy);
   } else {
-    auto cppValue = pythonListToVector<std::vector<TYPE>>(sipPy, [&](PyObject* pyItem) -> boost::optional<std::vector<TYPE>> {
-      return pythonListToVector<TYPE>(pyItem, [&](PyObject* pyInnerItem) -> boost::optional<TYPE> {
+    auto cppValue = pythonListToVector<std::vector<TYPE>>(sipPy, [&](PyObject* pyItem) -> std::optional<std::vector<TYPE>> {
+      return pythonListToVector<TYPE>(pyItem, [&](PyObject* pyInnerItem) -> std::optional<TYPE> {
         if (!sipCanConvertToType(pyInnerItem, sipType_TYPE, SIP_NOT_NONE)) {
           PyErr_Format(PyExc_TypeError, "object in iterable cannot be converted to the damn TYPE");
-          return boost::none;
+          return std::nullopt;
         } else {
           int state;
           auto* cppItemPtr = reinterpret_cast<TYPE*>(
@@ -280,7 +280,7 @@ template<TYPE>
 // ****************************************************
 
 template<TYPE>
-%MappedType boost::optional<std::vector<std::vector<TYPE>>>
+%MappedType std::optional<std::vector<std::vector<TYPE>>>
 {
 %TypeHeaderCode
 #include <vector>
@@ -306,12 +306,12 @@ template<TYPE>
     return isIterable(sipPy) || sipPy == Py_None;
   } else {
     auto cppValue = pythonObjectToOptional<std::vector<std::vector<TYPE>>>(sipPy,
-        [&](PyObject* pythonList) -> boost::optional<std::vector<std::vector<TYPE>>> {
-          return pythonListToVector<std::vector<TYPE>>(pythonList, [&](PyObject* pythonInnerList) -> boost::optional<std::vector<TYPE>> {
-            return pythonListToVector<TYPE>(pythonInnerList, [&](PyObject* pyItem) -> boost::optional<TYPE> {
+        [&](PyObject* pythonList) -> std::optional<std::vector<std::vector<TYPE>>> {
+          return pythonListToVector<std::vector<TYPE>>(pythonList, [&](PyObject* pythonInnerList) -> std::optional<std::vector<TYPE>> {
+            return pythonListToVector<TYPE>(pythonInnerList, [&](PyObject* pyItem) -> std::optional<TYPE> {
               if (!sipCanConvertToType(pyItem, sipType_TYPE, SIP_NOT_NONE)) {
                 PyErr_Format(PyExc_TypeError, "object in iterable cannot be converted to TYPE");
-                return boost::none;
+                return std::nullopt;
               } else {
                 int state;
                 auto* cppItemPtr = reinterpret_cast<TYPE*>(

--- a/qt/scientific_interfaces/ISISReflectometry/Common/Clipboard.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/Common/Clipboard.cpp
@@ -11,13 +11,13 @@
 
 namespace MantidQt::CustomInterfaces::ISISReflectometry {
 
-Clipboard::Clipboard() : m_subtrees(boost::none), m_subtreeRoots(boost::none) {}
+Clipboard::Clipboard() : m_subtrees(std::nullopt), m_subtreeRoots(std::nullopt) {}
 
-Clipboard::Clipboard(boost::optional<std::vector<MantidQt::MantidWidgets::Batch::Subtree>> subtrees,
-                     boost::optional<std::vector<MantidQt::MantidWidgets::Batch::RowLocation>> subtreeRoots)
+Clipboard::Clipboard(std::optional<std::vector<MantidQt::MantidWidgets::Batch::Subtree>> subtrees,
+                     std::optional<std::vector<MantidQt::MantidWidgets::Batch::RowLocation>> subtreeRoots)
     : m_subtrees(std::move(subtrees)), m_subtreeRoots(std::move(subtreeRoots)) {}
 
-bool Clipboard::isInitialized() const { return m_subtrees.is_initialized() && m_subtreeRoots.is_initialized(); }
+bool Clipboard::isInitialized() const { return m_subtrees.has_value() && m_subtreeRoots.has_value(); }
 
 int Clipboard::numberOfRoots() const {
   if (!isInitialized())
@@ -80,11 +80,11 @@ Group Clipboard::createGroupForRoot(int rootIndex) const {
   return result;
 }
 
-std::vector<boost::optional<Row>> Clipboard::createRowsForAllRoots() const {
+std::vector<std::optional<Row>> Clipboard::createRowsForAllRoots() const {
   if (containsGroups(*this))
     throw std::runtime_error("Attempted to get row for group clipboard item");
 
-  auto result = std::vector<boost::optional<Row>>();
+  auto result = std::vector<std::optional<Row>>();
   for (auto const &subtree : subtrees()) {
     auto rowsToAdd = createRowsForSubtree(subtree);
     for (auto &row : rowsToAdd)
@@ -93,13 +93,13 @@ std::vector<boost::optional<Row>> Clipboard::createRowsForAllRoots() const {
   return result;
 }
 
-std::vector<boost::optional<Row>> Clipboard::createRowsForRootChildren(int rootIndex) const {
+std::vector<std::optional<Row>> Clipboard::createRowsForRootChildren(int rootIndex) const {
   return createRowsForSubtree(subtrees()[rootIndex]);
 }
 
-std::vector<boost::optional<Row>>
+std::vector<std::optional<Row>>
 Clipboard::createRowsForSubtree(MantidQt::MantidWidgets::Batch::Subtree const &subtree) const {
-  auto result = std::vector<boost::optional<Row>>();
+  auto result = std::vector<std::optional<Row>>();
 
   for (auto const &row : subtree) {
     // Skip the root item if it is a group
@@ -113,22 +113,22 @@ Clipboard::createRowsForSubtree(MantidQt::MantidWidgets::Batch::Subtree const &s
     if (validationResult.isValid())
       result.emplace_back(validationResult.assertValid());
     else
-      result.emplace_back(boost::none);
+      result.emplace_back(std::nullopt);
   }
 
   return result;
 }
 
-std::vector<MantidQt::MantidWidgets::Batch::Subtree> &Clipboard::mutableSubtrees() { return m_subtrees.get(); }
+std::vector<MantidQt::MantidWidgets::Batch::Subtree> &Clipboard::mutableSubtrees() { return m_subtrees.value(); }
 
-std::vector<MantidQt::MantidWidgets::Batch::Subtree> const &Clipboard::subtrees() const { return m_subtrees.get(); }
+std::vector<MantidQt::MantidWidgets::Batch::Subtree> const &Clipboard::subtrees() const { return m_subtrees.value(); }
 
 std::vector<MantidQt::MantidWidgets::Batch::RowLocation> const &Clipboard::subtreeRoots() const {
-  return m_subtreeRoots.get();
+  return m_subtreeRoots.value();
 }
 
 std::vector<MantidQt::MantidWidgets::Batch::RowLocation> &Clipboard::mutableSubtreeRoots() {
-  return m_subtreeRoots.get();
+  return m_subtreeRoots.value();
 }
 
 bool containsGroups(Clipboard const &clipboard) {

--- a/qt/scientific_interfaces/ISISReflectometry/Common/Clipboard.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Common/Clipboard.h
@@ -25,8 +25,8 @@ public:
   };
 
   Clipboard();
-  Clipboard(boost::optional<std::vector<MantidQt::MantidWidgets::Batch::Subtree>> subtrees,
-            boost::optional<std::vector<MantidQt::MantidWidgets::Batch::RowLocation>> subtreeRoots);
+  Clipboard(std::optional<std::vector<MantidQt::MantidWidgets::Batch::Subtree>> subtrees,
+            std::optional<std::vector<MantidQt::MantidWidgets::Batch::RowLocation>> subtreeRoots);
 
   bool isInitialized() const;
   int numberOfRoots() const;
@@ -34,7 +34,7 @@ public:
   std::string groupName(int rootIndex) const;
   void setGroupName(int rootIndex, std::string const &groupName);
   Group createGroupForRoot(int rootIndex) const;
-  std::vector<boost::optional<Row>> createRowsForAllRoots() const;
+  std::vector<std::optional<Row>> createRowsForAllRoots() const;
 
   std::vector<MantidQt::MantidWidgets::Batch::Subtree> const &subtrees() const;
   std::vector<MantidQt::MantidWidgets::Batch::Subtree> &mutableSubtrees();
@@ -44,16 +44,16 @@ public:
 private:
   // The subtrees for each of the roots. Note that the Rows here contain
   // relative paths
-  boost::optional<std::vector<MantidQt::MantidWidgets::Batch::Subtree>> m_subtrees;
+  std::optional<std::vector<MantidQt::MantidWidgets::Batch::Subtree>> m_subtrees;
   // The actual locations of the roots that were copied. This allows us to work
   // out the actual paths that were copied and determine whether items are rows
   // or groups in the reflectometry GUI sense. Note that these locations may
   // not be valid in the table if other edits have been made so this should
   // only be used for checking whether copied values were rows/groups.
-  boost::optional<std::vector<MantidQt::MantidWidgets::Batch::RowLocation>> m_subtreeRoots;
+  std::optional<std::vector<MantidQt::MantidWidgets::Batch::RowLocation>> m_subtreeRoots;
 
-  std::vector<boost::optional<Row>> createRowsForRootChildren(int rootIndex) const;
-  std::vector<boost::optional<Row>> createRowsForSubtree(MantidQt::MantidWidgets::Batch::Subtree const &subtree) const;
+  std::vector<std::optional<Row>> createRowsForRootChildren(int rootIndex) const;
+  std::vector<std::optional<Row>> createRowsForSubtree(MantidQt::MantidWidgets::Batch::Subtree const &subtree) const;
 };
 
 bool MANTIDQT_ISISREFLECTOMETRY_DLL containsGroups(Clipboard const &clipboard);

--- a/qt/scientific_interfaces/ISISReflectometry/Common/First.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Common/First.h
@@ -5,19 +5,19 @@
 //   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 // SPDX - License - Identifier: GPL - 3.0 +
 #pragma once
-#include <boost/optional.hpp>
 #include <boost/variant.hpp>
+#include <optional>
 #include <vector>
 
 namespace MantidQt {
 namespace CustomInterfaces {
 namespace ISISReflectometry {
 
-template <typename T> boost::optional<T> first(std::vector<T> const &values) {
+template <typename T> std::optional<T> first(std::vector<T> const &values) {
   if (values.size() > 0)
-    return boost::optional<T>(values[0]);
+    return std::optional<T>(values[0]);
   else
-    return boost::none;
+    return std::nullopt;
 }
 
 /**
@@ -25,14 +25,14 @@ template <typename T> boost::optional<T> first(std::vector<T> const &values) {
  * returning it as a optional<variant<T>> where the optional is empty if
  * the vector held by the variant<vector<T>> held no values.
  */
-template <typename... Ts> class FirstVisitor : public boost::static_visitor<boost::optional<boost::variant<Ts...>>> {
+template <typename... Ts> class FirstVisitor : public boost::static_visitor<std::optional<boost::variant<Ts...>>> {
 public:
-  template <typename T> boost::optional<boost::variant<Ts...>> operator()(std::vector<T> const &values) const {
+  template <typename T> std::optional<boost::variant<Ts...>> operator()(std::vector<T> const &values) const {
     auto value = first(values);
     if (value)
-      return boost::variant<Ts...>(value.get());
+      return boost::variant<Ts...>(value.value());
     else
-      return boost::none;
+      return std::nullopt;
   }
 };
 } // namespace ISISReflectometry

--- a/qt/scientific_interfaces/ISISReflectometry/Common/IndexOf.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Common/IndexOf.h
@@ -6,7 +6,7 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 #pragma once
 #include <algorithm>
-#include <boost/optional.hpp>
+#include <optional>
 #include <iterator>
 
 namespace MantidQt {
@@ -14,21 +14,21 @@ namespace CustomInterfaces {
 namespace ISISReflectometry {
 
 template <typename Container, typename Predicate>
-boost::optional<int> indexOf(Container const &container, Predicate pred) {
+std::optional<int> indexOf(Container const &container, Predicate pred) {
   auto maybeItemIt = std::find_if(container.cbegin(), container.cend(), pred);
   if (maybeItemIt != container.cend())
     return static_cast<int>(std::distance(container.cbegin(), maybeItemIt));
   else
-    return boost::none;
+    return std::nullopt;
 }
 
 template <typename Container, typename ValueType>
-boost::optional<int> indexOfValue(Container const &container, ValueType value) {
+std::optional<int> indexOfValue(Container const &container, ValueType value) {
   auto maybeItemIt = std::find(container.cbegin(), container.cend(), value);
   if (maybeItemIt != container.cend())
     return static_cast<int>(std::distance(container.cbegin(), maybeItemIt));
   else
-    return boost::none;
+    return std::nullopt;
 }
 } // namespace ISISReflectometry
 } // namespace CustomInterfaces

--- a/qt/scientific_interfaces/ISISReflectometry/Common/InstrumentParameters.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Common/InstrumentParameters.h
@@ -8,7 +8,7 @@
 #include "Common/First.h"
 #include "Common/ValueOr.h"
 #include "GetInstrumentParameter.h"
-#include <boost/optional.hpp>
+#include <optional>
 #include <vector>
 
 namespace MantidQt {
@@ -16,13 +16,13 @@ namespace CustomInterfaces {
 namespace ISISReflectometry {
 
 template <typename T>
-boost::optional<T> firstFromParameterFile(Mantid::Geometry::Instrument_const_sptr instrument,
+std::optional<T> firstFromParameterFile(Mantid::Geometry::Instrument_const_sptr instrument,
                                           std::string const &parameterName) {
   return first(getInstrumentParameter<T>(instrument, parameterName));
 }
 
 template <typename... Ts>
-boost::optional<boost::variant<Ts...>> firstFromParameterFileVariant(Mantid::Geometry::Instrument_const_sptr instrument,
+std::optional<boost::variant<Ts...>> firstFromParameterFileVariant(Mantid::Geometry::Instrument_const_sptr instrument,
                                                                      std::string const &parameterName) {
   auto values = getInstrumentParameter<boost::variant<Ts...>>(instrument, parameterName);
   return boost::apply_visitor(FirstVisitor<Ts...>(), values);
@@ -52,14 +52,14 @@ public:
     return fromFileOrDefaultConstruct<T>(parameterName);
   }
 
-  template <typename T> boost::optional<T> optional(std::string const &parameterName) {
+  template <typename T> std::optional<T> optional(std::string const &parameterName) {
     return fromFile<T>(parameterName);
   }
 
   template <typename Default, typename T>
-  T handleMandatoryIfMissing(boost::optional<T> const &value, std::string const &parameterName) {
+  T handleMandatoryIfMissing(std::optional<T> const &value, std::string const &parameterName) {
     if (value)
-      return value.get();
+      return value.value();
     else {
       m_missingValueErrors.emplace_back(parameterName);
       return Default();
@@ -107,12 +107,12 @@ private:
     return value_or(fromFile<T>(parameterName), T());
   }
 
-  template <typename T> boost::optional<T> fromFile(std::string const &parameterName) {
+  template <typename T> std::optional<T> fromFile(std::string const &parameterName) {
     try {
       return firstFromParameterFile<T>(m_instrument, parameterName);
     } catch (InstrumentParameterTypeMissmatch const &ex) {
       m_typeErrors.emplace_back(ex);
-      return boost::none;
+      return std::nullopt;
     }
   }
 

--- a/qt/scientific_interfaces/ISISReflectometry/Common/Map.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Common/Map.h
@@ -6,7 +6,7 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 #pragma once
 #include <algorithm>
-#include <boost/optional.hpp>
+#include <optional>
 #include <iterator>
 #include <sstream>
 #include <type_traits>
@@ -26,11 +26,11 @@ std::vector<Out> map(Container const &in, Transform transform) {
 }
 
 template <typename In, typename Transform, typename Out = typename std::result_of<Transform(In)>::type>
-boost::optional<Out> map(boost::optional<In> const &in, Transform transform) {
-  if (in.is_initialized())
-    return transform(in.get());
+std::optional<Out> map(std::optional<In> const &in, Transform transform) {
+  if (in.has_value())
+    return transform(in.value());
   else
-    return boost::none;
+    return std::nullopt;
 }
 
 /** Converts an optional value to string
@@ -39,9 +39,9 @@ boost::optional<Out> map(boost::optional<In> const &in, Transform transform) {
  * @return The value as a string or an empty string
  *
  */
-template <typename T> std::string optionalToString(boost::optional<T> maybeValue) {
+template <typename T> std::string optionalToString(std::optional<T> maybeValue) {
   return map(maybeValue, [](T const &value) -> std::string { return std::to_string(value); })
-      .get_value_or(std::string());
+      .value_or(std::string());
 }
 
 /** Converts value to string with specified precision
@@ -65,9 +65,9 @@ template <typename T> std::string valueToString(T value, int precision) {
  * @return The value as a string (with specified precision if given)
  *
  */
-template <typename T> std::string valueToString(T value, boost::optional<int> precision) {
-  if (precision.is_initialized())
-    return valueToString(value, precision.get());
+template <typename T> std::string valueToString(T value, std::optional<int> precision) {
+  if (precision.has_value())
+    return valueToString(value, precision.value());
   return std::to_string(value);
 }
 
@@ -79,10 +79,10 @@ template <typename T> std::string valueToString(T value, boost::optional<int> pr
  * string
  *
  */
-template <typename T> std::string optionalToString(boost::optional<T> maybeValue, boost::optional<int> precision) {
-  if (maybeValue.is_initialized()) {
-    if (precision.is_initialized()) {
-      return valueToString(maybeValue.get(), precision.get());
+template <typename T> std::string optionalToString(std::optional<T> maybeValue, std::optional<int> precision) {
+  if (maybeValue.has_value()) {
+    if (precision.has_value()) {
+      return valueToString(maybeValue.value(), precision.value());
     }
     return optionalToString(maybeValue);
   }

--- a/qt/scientific_interfaces/ISISReflectometry/Common/OptionDefaults.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Common/OptionDefaults.h
@@ -6,7 +6,7 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 #pragma once
 #include "Common/DllConfig.h"
-#include "MantidAPI/BoostOptionalToAlgorithmProperty.h"
+#include "MantidAPI/StdOptionalToAlgorithmProperty.h"
 #include "MantidGeometry/Instrument_fwd.h"
 #include <string>
 
@@ -25,7 +25,7 @@ public:
   template <typename T>
   T getValueOrDefault(std::string const &propertyName, std::string const &parameterName, T defaultValue) const;
   template <typename T>
-  boost::optional<T> getOptionalValue(std::string const &propertyName, std::string const &parameterName) const;
+  std::optional<T> getOptionalValue(std::string const &propertyName, std::string const &parameterName) const;
   template <typename T> T getValue(std::string const &propertyName, std::string const &parameterName) const;
 
   int getIntOrZero(std::string const &propertyName, std::string const &parameterName) const;
@@ -47,13 +47,13 @@ T OptionDefaults::getValueOrDefault(std::string const &propertyName, std::string
                                     T defaultValue) const {
   auto maybeValue =
       Mantid::API::checkForOptionalInstrumentDefault<T>(m_algorithm.get(), propertyName, m_instrument, parameterName);
-  if (maybeValue.is_initialized())
-    return maybeValue.get();
+  if (maybeValue.has_value())
+    return maybeValue.value();
   return defaultValue;
 }
 
 template <typename T>
-boost::optional<T> OptionDefaults::getOptionalValue(std::string const &propertyName,
+std::optional<T> OptionDefaults::getOptionalValue(std::string const &propertyName,
                                                     std::string const &parameterName) const {
   return Mantid::API::checkForOptionalInstrumentDefault<T>(m_algorithm.get(), propertyName, m_instrument,
                                                            parameterName);

--- a/qt/scientific_interfaces/ISISReflectometry/Common/Parse.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/Common/Parse.cpp
@@ -13,7 +13,7 @@ bool isEntirelyWhitespace(std::string const &string) {
   return std::all_of(string.cbegin(), string.cend(), [](unsigned char c) { return std::isspace(c); });
 }
 
-boost::optional<double> parseDouble(std::string string) {
+std::optional<double> parseDouble(std::string string) {
   boost::trim(string);
   auto end = std::size_t();
   try {
@@ -21,31 +21,31 @@ boost::optional<double> parseDouble(std::string string) {
     if (end == string.size())
       return result;
     else
-      return boost::none;
+      return std::nullopt;
   } catch (std::invalid_argument &) {
-    return boost::none;
+    return std::nullopt;
   } catch (std::out_of_range &) {
-    return boost::none;
+    return std::nullopt;
   }
 }
 
-boost::optional<double> parseNonNegativeDouble(std::string string) {
+std::optional<double> parseNonNegativeDouble(std::string string) {
   auto maybeNegative = parseDouble(std::move(string));
-  if (maybeNegative.is_initialized() && maybeNegative.get() >= 0.0)
-    return maybeNegative.get();
+  if (maybeNegative.has_value() && maybeNegative.value() >= 0.0)
+    return maybeNegative.value();
   else
-    return boost::none;
+    return std::nullopt;
 }
 
-boost::optional<double> parseNonNegativeNonZeroDouble(std::string string) {
+std::optional<double> parseNonNegativeNonZeroDouble(std::string string) {
   auto maybeNegative = parseDouble(std::move(string));
-  if (maybeNegative.is_initialized() && maybeNegative.get() > 0.0)
-    return maybeNegative.get();
+  if (maybeNegative.has_value() && maybeNegative.value() > 0.0)
+    return maybeNegative.value();
   else
-    return boost::none;
+    return std::nullopt;
 }
 
-boost::optional<int> parseInt(std::string string) {
+std::optional<int> parseInt(std::string string) {
   boost::trim(string);
   auto end = std::size_t();
   try {
@@ -53,19 +53,19 @@ boost::optional<int> parseInt(std::string string) {
     if (end == string.size())
       return result;
     else
-      return boost::none;
+      return std::nullopt;
   } catch (std::invalid_argument &) {
-    return boost::none;
+    return std::nullopt;
   } catch (std::out_of_range &) {
-    return boost::none;
+    return std::nullopt;
   }
 }
 
-boost::optional<int> parseNonNegativeInt(std::string string) {
+std::optional<int> parseNonNegativeInt(std::string string) {
   auto maybeNegative = parseInt(std::move(string));
-  if (maybeNegative.is_initialized() && maybeNegative.get() >= 0)
-    return maybeNegative.get();
+  if (maybeNegative.has_value() && maybeNegative.value() >= 0)
+    return maybeNegative.value();
   else
-    return boost::none;
+    return std::nullopt;
 }
 } // namespace MantidQt::CustomInterfaces::ISISReflectometry

--- a/qt/scientific_interfaces/ISISReflectometry/Common/Parse.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Common/Parse.h
@@ -7,27 +7,27 @@
 #pragma once
 #include "DllConfig.h"
 #include <boost/algorithm/string.hpp>
-#include <boost/optional.hpp>
+#include <optional>
 #include <vector>
 
 namespace MantidQt {
 namespace CustomInterfaces {
 namespace ISISReflectometry {
 
-MANTIDQT_ISISREFLECTOMETRY_DLL boost::optional<double> parseDouble(std::string string);
+MANTIDQT_ISISREFLECTOMETRY_DLL std::optional<double> parseDouble(std::string string);
 
-MANTIDQT_ISISREFLECTOMETRY_DLL boost::optional<double> parseNonNegativeDouble(std::string string);
+MANTIDQT_ISISREFLECTOMETRY_DLL std::optional<double> parseNonNegativeDouble(std::string string);
 
-MANTIDQT_ISISREFLECTOMETRY_DLL boost::optional<double> parseNonNegativeNonZeroDouble(std::string string);
+MANTIDQT_ISISREFLECTOMETRY_DLL std::optional<double> parseNonNegativeNonZeroDouble(std::string string);
 
-MANTIDQT_ISISREFLECTOMETRY_DLL boost::optional<int> parseInt(std::string string);
+MANTIDQT_ISISREFLECTOMETRY_DLL std::optional<int> parseInt(std::string string);
 
-MANTIDQT_ISISREFLECTOMETRY_DLL boost::optional<int> parseNonNegativeInt(std::string string);
+MANTIDQT_ISISREFLECTOMETRY_DLL std::optional<int> parseNonNegativeInt(std::string string);
 
 bool MANTIDQT_ISISREFLECTOMETRY_DLL isEntirelyWhitespace(std::string const &string);
 
 template <typename ParseItemFunction>
-boost::optional<std::vector<typename std::result_of<ParseItemFunction(std::string const &)>::type::value_type>>
+std::optional<std::vector<typename std::result_of<ParseItemFunction(std::string const &)>::type::value_type>>
 parseList(std::string commaSeparatedValues, ParseItemFunction parseItem) {
   using ParsedItem = typename std::result_of<ParseItemFunction(std::string const &)>::type::value_type;
   if (!commaSeparatedValues.empty()) {
@@ -37,10 +37,10 @@ parseList(std::string commaSeparatedValues, ParseItemFunction parseItem) {
     parsedItems.reserve(items.size());
     for (auto const &item : items) {
       auto maybeParsedItem = parseItem(item);
-      if (maybeParsedItem.is_initialized())
-        parsedItems.emplace_back(maybeParsedItem.get());
+      if (maybeParsedItem.has_value())
+        parsedItems.emplace_back(maybeParsedItem.value());
       else
-        return boost::none;
+        return std::nullopt;
     }
     return parsedItems;
   } else {

--- a/qt/scientific_interfaces/ISISReflectometry/Common/ValidationResult.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Common/ValidationResult.h
@@ -5,7 +5,7 @@
 //   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 // SPDX - License - Identifier: GPL - 3.0 +
 #pragma once
-#include <boost/optional.hpp>
+#include <optional>
 #include <boost/variant.hpp>
 
 namespace MantidQt {
@@ -22,7 +22,7 @@ public:
   bool isError() const;
   Validated const &assertValid() const;
   Error const &assertError() const;
-  boost::optional<Validated> validElseNone() const;
+  std::optional<Validated> validElseNone() const;
 
 private:
   boost::variant<Validated, Error> m_innerResult;
@@ -55,11 +55,11 @@ template <typename Validated, typename Error> Error const &ValidationResult<Vali
 }
 
 template <typename Validated, typename Error>
-boost::optional<Validated> ValidationResult<Validated, Error>::validElseNone() const {
+std::optional<Validated> ValidationResult<Validated, Error>::validElseNone() const {
   if (isValid())
     return assertValid();
   else
-    return boost::none;
+    return std::nullopt;
 }
 } // namespace ISISReflectometry
 } // namespace CustomInterfaces

--- a/qt/scientific_interfaces/ISISReflectometry/Common/ValueOr.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Common/ValueOr.h
@@ -5,16 +5,16 @@
 //   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 // SPDX - License - Identifier: GPL - 3.0 +
 #pragma once
-#include <boost/optional.hpp>
+#include <optional>
 
 /**
  * This method is required to support RHEL7 since it uses boost 1.53.
- * which only has get_value_or unlike std::optional (c++17) or later boost
+ * which only has value_or unlike std::optional (c++17) or later boost
  * versions.
  *
  * Once RHEL7 support is dropped usages should be replaced with the more
  * readable .value_or member function.
  */
-template <typename T, typename U> T value_or(boost::optional<T> const &value, U &&ifEmpty) {
-  return value.get_value_or(ifEmpty);
+template <typename T, typename U> T value_or(std::optional<T> const &value, U &&ifEmpty) {
+  return value.value_or(ifEmpty);
 }

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/AlgorithmProperties.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/AlgorithmProperties.cpp
@@ -22,9 +22,9 @@ void update(std::string const &property, std::string const &value, AlgorithmRunt
     properties.setPropertyValue(property, value);
 }
 
-void update(std::string const &property, boost::optional<std::string> const &value, AlgorithmRuntimeProps &properties) {
+void update(std::string const &property, std::optional<std::string> const &value, AlgorithmRuntimeProps &properties) {
   if (value)
-    update(property, value.get(), properties);
+    update(property, value.value(), properties);
 }
 
 void update(std::string const &property, bool value, AlgorithmRuntimeProps &properties) {
@@ -43,9 +43,9 @@ void update(std::string const &property, double value, AlgorithmRuntimeProps &pr
   update(property, std::to_string(value), properties);
 }
 
-void update(std::string const &property, boost::optional<double> const &value, AlgorithmRuntimeProps &properties) {
+void update(std::string const &property, std::optional<double> const &value, AlgorithmRuntimeProps &properties) {
   if (value)
-    update(property, value.get(), properties);
+    update(property, value.value(), properties);
 }
 
 void updateFromMap(AlgorithmRuntimeProps &properties, std::map<std::string, std::string> const &parameterMap) {

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/AlgorithmProperties.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/AlgorithmProperties.h
@@ -10,7 +10,7 @@
 #include "MantidKernel/Strings.h"
 #include "MantidQtWidgets/Common/IAlgorithmRuntimeProps.h"
 
-#include <boost/optional.hpp>
+#include <optional>
 #include <map>
 #include <string>
 
@@ -25,7 +25,7 @@ using AlgorithmRuntimeProps = MantidQt::API::IAlgorithmRuntimeProps;
 // strings to set the relevant property in an AlgorithmRuntimeProps
 
 void update(std::string const &property, std::string const &value, AlgorithmRuntimeProps &properties);
-void update(std::string const &property, boost::optional<std::string> const &value, AlgorithmRuntimeProps &properties);
+void update(std::string const &property, std::optional<std::string> const &value, AlgorithmRuntimeProps &properties);
 
 void update(std::string const &property, bool value, AlgorithmRuntimeProps &properties);
 
@@ -35,7 +35,7 @@ void update(std::string const &property, size_t value, AlgorithmRuntimeProps &pr
 
 void update(std::string const &property, double value, AlgorithmRuntimeProps &properties);
 
-void update(std::string const &property, boost::optional<double> const &value, AlgorithmRuntimeProps &properties);
+void update(std::string const &property, std::optional<double> const &value, AlgorithmRuntimeProps &properties);
 
 void updateFromMap(AlgorithmRuntimeProps &properties, std::map<std::string, std::string> const &parameterMap);
 

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchJobManager.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchJobManager.h
@@ -15,7 +15,7 @@
 #include "MantidQtWidgets/Common/IAlgorithmRuntimeProps.h"
 #include "Reduction/Batch.h"
 
-#include <boost/optional.hpp>
+#include <optional>
 #include <memory>
 
 namespace MantidQt {
@@ -43,7 +43,7 @@ public:
 
   void setReprocessFailedItems(bool reprocessFailed) override;
 
-  boost::optional<Item &> getRunsTableItem(API::IConfiguredAlgorithm_sptr const &algorithm) override;
+  Item* getRunsTableItem(API::IConfiguredAlgorithm_sptr const &algorithm) override;
 
   void algorithmStarted(MantidQt::API::IConfiguredAlgorithm_sptr algorithm) override;
   void algorithmComplete(MantidQt::API::IConfiguredAlgorithm_sptr algorithm) override;
@@ -52,8 +52,8 @@ public:
   std::vector<std::string>
   algorithmOutputWorkspacesToSave(MantidQt::API::IConfiguredAlgorithm_sptr algorithm) const override;
 
-  boost::optional<Item const &> notifyWorkspaceDeleted(std::string const &wsName) override;
-  boost::optional<Item const &> notifyWorkspaceRenamed(std::string const &oldName, std::string const &newName) override;
+  Item * notifyWorkspaceDeleted(std::string const &wsName) override;
+  Item * notifyWorkspaceRenamed(std::string const &oldName, std::string const &newName) override;
   void notifyAllWorkspacesDeleted() override;
 
   std::deque<MantidQt::API::IConfiguredAlgorithm_sptr> getAlgorithms() override;

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchPresenter.cpp
@@ -119,8 +119,8 @@ void BatchPresenter::notifyAlgorithmStarted(IConfiguredAlgorithm_sptr &algorithm
     return;
   }
   m_jobManager->algorithmStarted(algorithm);
-  m_runsPresenter->notifyRowOutputsChanged(item.value());
-  m_runsPresenter->notifyRowStateChanged(item.value());
+  m_runsPresenter->notifyRowOutputsChanged(item);
+  m_runsPresenter->notifyRowStateChanged(item);
 }
 
 void BatchPresenter::notifyAlgorithmComplete(IConfiguredAlgorithm_sptr &algorithm) {
@@ -129,8 +129,8 @@ void BatchPresenter::notifyAlgorithmComplete(IConfiguredAlgorithm_sptr &algorith
     return;
   }
   m_jobManager->algorithmComplete(algorithm);
-  m_runsPresenter->notifyRowOutputsChanged(item.value());
-  m_runsPresenter->notifyRowStateChanged(item.value());
+  m_runsPresenter->notifyRowOutputsChanged(item);
+  m_runsPresenter->notifyRowStateChanged(item);
   /// TODO Longer term it would probably be better if algorithms took care
   /// of saving their outputs so we could remove this callback
   if (m_savePresenter->shouldAutosave()) {
@@ -145,8 +145,8 @@ void BatchPresenter::notifyAlgorithmError(IConfiguredAlgorithm_sptr algorithm, s
     return;
   }
   m_jobManager->algorithmError(algorithm, message);
-  m_runsPresenter->notifyRowOutputsChanged(item.value());
-  m_runsPresenter->notifyRowStateChanged(item.value());
+  m_runsPresenter->notifyRowOutputsChanged(item);
+  m_runsPresenter->notifyRowStateChanged(item);
 }
 
 /** Start processing the next batch of algorithms.

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/GroupProcessingAlgorithm.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/GroupProcessingAlgorithm.cpp
@@ -39,7 +39,7 @@ void updateWorkspaceProperties(AlgorithmRuntimeProps &properties, Group const &g
 
   // Get the list of input workspaces from the output of each row
   auto workspaces = std::vector<std::string>();
-  std::for_each(group.rows().cbegin(), group.rows().cend(), [&workspaces](boost::optional<Row> const &row) -> void {
+  std::for_each(group.rows().cbegin(), group.rows().cend(), [&workspaces](std::optional<Row> const &row) -> void {
     if (row)
       workspaces.emplace_back(row->reducedWorkspaceNames().iVsQ());
   });
@@ -62,12 +62,12 @@ void updateGroupFromOutputProperties(const IAlgorithm_sptr &algorithm, Item &gro
   group.setOutputNames(std::vector<std::string>{stitched});
 }
 
-void updateParamsFromResolution(AlgorithmRuntimeProps &properties, boost::optional<double> const &resolution) {
-  if (!resolution.is_initialized())
+void updateParamsFromResolution(AlgorithmRuntimeProps &properties, std::optional<double> const &resolution) {
+  if (!resolution.has_value())
     return;
 
   // Negate the resolution to give logarithmic binning
-  AlgorithmProperties::update("Params", -(resolution.get()), properties);
+  AlgorithmProperties::update("Params", -(resolution.value()), properties);
 }
 
 void updateLookupRowProperties(AlgorithmRuntimeProps &properties, LookupRow const *lookupRow) {
@@ -78,22 +78,22 @@ void updateLookupRowProperties(AlgorithmRuntimeProps &properties, LookupRow cons
 }
 
 void updateGroupProperties(AlgorithmRuntimeProps &properties, Group const &group) {
-  auto resolution = boost::make_optional<double>(false, double());
+  std::optional<double> resolution;
 
   for (auto const &row : group.rows()) {
-    if (!row.is_initialized())
+    if (!row.has_value())
       continue;
 
     // Use the input Q step if provided, or the output Q step otherwise, if set
-    if (row->qRange().step().is_initialized())
+    if (row->qRange().step().has_value())
       resolution = row->qRange().step();
-    else if (row->qRangeOutput().step().is_initialized())
+    else if (row->qRangeOutput().step().has_value())
       resolution = row->qRangeOutput().step();
 
     // For now just use the first resolution found. Longer term it would be
     // better to check that all rows have the same resolution and set a warning
     // if not.
-    if (resolution.is_initialized())
+    if (resolution.has_value())
       break;
   }
 

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/GroupProcessingAlgorithm.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/GroupProcessingAlgorithm.h
@@ -11,8 +11,8 @@
 #include "MantidQtWidgets/Common/IAlgorithmRuntimeProps.h"
 #include "MantidQtWidgets/Common/IConfiguredAlgorithm.h"
 
-#include <boost/optional.hpp>
 #include <map>
+#include <optional>
 #include <string>
 #include <vector>
 

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/IBatchJobManager.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/IBatchJobManager.h
@@ -12,8 +12,8 @@
 #include "MantidQtWidgets/Common/IAlgorithmRuntimeProps.h"
 #include "Reduction/Batch.h"
 
-#include <boost/optional.hpp>
 #include <memory>
+#include <optional>
 
 namespace MantidQt {
 namespace CustomInterfaces {
@@ -33,15 +33,14 @@ public:
   virtual void notifyAutoreductionResumed() = 0;
   virtual void notifyAutoreductionPaused() = 0;
   virtual void setReprocessFailedItems(bool reprocessFailed) = 0;
-  virtual boost::optional<Item &> getRunsTableItem(API::IConfiguredAlgorithm_sptr const &algorithm) = 0;
+  virtual Item *getRunsTableItem(API::IConfiguredAlgorithm_sptr const &algorithm) = 0;
   virtual void algorithmStarted(MantidQt::API::IConfiguredAlgorithm_sptr algorithm) = 0;
   virtual void algorithmComplete(MantidQt::API::IConfiguredAlgorithm_sptr algorithm) = 0;
   virtual void algorithmError(MantidQt::API::IConfiguredAlgorithm_sptr algorithm, std::string const &message) = 0;
   virtual std::vector<std::string>
   algorithmOutputWorkspacesToSave(MantidQt::API::IConfiguredAlgorithm_sptr algorithm) const = 0;
-  virtual boost::optional<Item const &> notifyWorkspaceDeleted(std::string const &wsName) = 0;
-  virtual boost::optional<Item const &> notifyWorkspaceRenamed(std::string const &oldName,
-                                                               std::string const &newName) = 0;
+  virtual Item *notifyWorkspaceDeleted(std::string const &wsName) = 0;
+  virtual Item *notifyWorkspaceRenamed(std::string const &oldName, std::string const &newName) = 0;
   virtual void notifyAllWorkspacesDeleted() = 0;
   virtual std::deque<MantidQt::API::IConfiguredAlgorithm_sptr> getAlgorithms() = 0;
   virtual std::unique_ptr<MantidQt::API::IAlgorithmRuntimeProps> rowProcessingProperties() const = 0;

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/RowProcessingAlgorithm.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/RowProcessingAlgorithm.cpp
@@ -117,7 +117,7 @@ void updateLookupRowProperties(AlgorithmRuntimeProps &properties, LookupRow cons
 }
 
 void updateWavelengthRangeProperties(AlgorithmRuntimeProps &properties,
-                                     boost::optional<RangeInLambda> const &rangeInLambda) {
+                                     std::optional<RangeInLambda> const &rangeInLambda) {
   if (!rangeInLambda)
     return;
 
@@ -193,7 +193,7 @@ void updateEventProperties(AlgorithmRuntimeProps &properties, Slicing const &sli
   boost::apply_visitor(UpdateEventPropertiesVisitor(properties), slicing);
 }
 
-boost::optional<double> getDouble(const IAlgorithm_sptr &algorithm, std::string const &property) {
+std::optional<double> getDouble(const IAlgorithm_sptr &algorithm, std::string const &property) {
   double result = algorithm->getProperty(property);
   return result;
 }

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/RowProcessingAlgorithm.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/RowProcessingAlgorithm.h
@@ -7,9 +7,10 @@
 #pragma once
 
 #include "Common/DllConfig.h"
-#include "MantidQtWidgets/Common/IAlgorithmRuntimeProps.h"
+#include "MantidQtWidgets/Common/BatchAlgorithmRunner.h"
 #include "MantidQtWidgets/Common/IConfiguredAlgorithm.h"
-#include <boost/optional.hpp>
+
+#include <optional>
 
 #include <map>
 #include <memory>

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Common/Decoder.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Common/Decoder.h
@@ -15,7 +15,7 @@
 #include <QString>
 #include <QTableWidget>
 #include <QVariant>
-#include <boost/optional.hpp>
+#include <optional>
 #include <string>
 
 namespace MantidQt {
@@ -59,14 +59,14 @@ private:
   void decodePerAngleDefaultsRows(QTableWidget *tab, int rowsNum, int columnsNum, const QList<QVariant> &list);
   void decodeInstrument(const QtInstrumentView *gui, const QMap<QString, QVariant> &map);
   void decodeRuns(QtRunsView *gui, ReductionJobs *redJobs, RunsTablePresenter *presenter,
-                  const QMap<QString, QVariant> &map, boost::optional<int> precision, QtCatalogSearcher *searcher);
+                  const QMap<QString, QVariant> &map, std::optional<int> precision, QtCatalogSearcher *searcher);
   void decodeRunsTable(QtRunsTableView *gui, ReductionJobs *redJobs, RunsTablePresenter *presenter,
-                       const QMap<QString, QVariant> &map, boost::optional<int> precision);
+                       const QMap<QString, QVariant> &map, std::optional<int> precision);
   void decodeRunsTableModel(ReductionJobs *jobs, const QList<QVariant> &list);
   MantidQt::CustomInterfaces::ISISReflectometry::Group decodeGroup(const QMap<QString, QVariant> &map);
-  std::vector<boost::optional<MantidQt::CustomInterfaces::ISISReflectometry::Row>>
+  std::vector<std::optional<MantidQt::CustomInterfaces::ISISReflectometry::Row>>
   decodeRows(const QList<QVariant> &list);
-  boost::optional<MantidQt::CustomInterfaces::ISISReflectometry::Row> decodeRow(const QMap<QString, QVariant> &map);
+  std::optional<MantidQt::CustomInterfaces::ISISReflectometry::Row> decodeRow(const QMap<QString, QVariant> &map);
   RangeInQ decodeRangeInQ(const QMap<QString, QVariant> &map);
   TransmissionRunPair decodeTransmissionRunPair(const QMap<QString, QVariant> &map);
   MantidQt::CustomInterfaces::ISISReflectometry::SearchResults decodeSearchResults(const QList<QVariant> &list);
@@ -75,7 +75,7 @@ private:
   void decodeSave(const QtSaveView *gui, const QMap<QString, QVariant> &map);
   void decodeEvent(const QtEventView *gui, const QMap<QString, QVariant> &map);
   void updateRunsTableViewFromModel(QtRunsTableView *view, const ReductionJobs *model,
-                                    const boost::optional<int> &precision);
+                                    const std::optional<int> &precision);
   bool m_projectSave = false;
   friend class CoderCommonTester;
 };

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Common/Encoder.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Common/Encoder.cpp
@@ -117,7 +117,7 @@ QList<QVariant> Encoder::encodeRows(const MantidQt::CustomInterfaces::ISISReflec
   QList<QVariant> rows;
   for (const auto &row : group.m_rows) {
     if (row) {
-      rows.append(QVariant(encodeRow(row.get())));
+      rows.append(QVariant(encodeRow(row.value())));
     } else {
       rows.append(QVariant(QMap<QString, QVariant>()));
     }
@@ -132,13 +132,13 @@ QMap<QString, QVariant> Encoder::encodeRangeInQ(const RangeInQ &rangeInQ) {
   auto step = rangeInQ.step();
   map.insert(QString("minPresent"), QVariant(static_cast<bool>(min)));
   if (min)
-    map.insert(QString("min"), QVariant(min.get()));
+    map.insert(QString("min"), QVariant(min.value()));
   map.insert(QString("maxPresent"), QVariant(static_cast<bool>(max)));
   if (max)
-    map.insert(QString("max"), QVariant(max.get()));
+    map.insert(QString("max"), QVariant(max.value()));
   map.insert(QString("stepPresent"), QVariant(static_cast<bool>(step)));
   if (step)
-    map.insert(QString("step"), QVariant(step.get()));
+    map.insert(QString("step"), QVariant(step.value()));
   return map;
 }
 
@@ -192,7 +192,7 @@ QMap<QString, QVariant> Encoder::encodeRow(const MantidQt::CustomInterfaces::ISI
   map.insert(QString("qRangeOutput"), QVariant(encodeRangeInQ(row.m_qRangeOutput)));
   map.insert(QString("scaleFactorPresent"), QVariant(static_cast<bool>(row.m_scaleFactor)));
   if (row.m_scaleFactor) {
-    map.insert(QString("scaleFactor"), QVariant(row.m_scaleFactor.get()));
+    map.insert(QString("scaleFactor"), QVariant(row.m_scaleFactor.value()));
   }
   map.insert(QString("transRunNums"), QVariant(encodeTransmissionRunPair(row.m_transmissionRuns)));
   map.insert(QString("reductionWorkspaces"), QVariant(encodeReductionWorkspace(row.m_reducedWorkspaceNames)));

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Common/Plotter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Common/Plotter.cpp
@@ -68,7 +68,7 @@ void Plotter::reflectometryPlot(const std::vector<std::string> &workspaces) cons
     }
   }
 
-  plot(actualWorkspaces, boost::none, wksp_indices, boost::none, boost::none, ax_properties, window_title,
+  plot(actualWorkspaces, std::nullopt, wksp_indices, std::nullopt, std::nullopt, ax_properties, window_title,
        plotErrorBars, false);
 #endif
 }

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Event/EventPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Event/EventPresenter.cpp
@@ -88,9 +88,9 @@ void EventPresenter::setUniformSlicingByNumberOfSlicesFromView() {
 
 void EventPresenter::setCustomSlicingFromView() {
   auto maybeCustomBreakpoints = parseList(m_view->customBreakpoints(), parseNonNegativeDouble);
-  if (maybeCustomBreakpoints.is_initialized()) {
+  if (maybeCustomBreakpoints.has_value()) {
     m_view->showCustomBreakpointsValid();
-    m_slicing = CustomSlicingByList(maybeCustomBreakpoints.get());
+    m_slicing = CustomSlicingByList(maybeCustomBreakpoints.value());
   } else {
     m_view->showCustomBreakpointsInvalid();
     m_slicing = InvalidSlicing();
@@ -104,9 +104,9 @@ void EventPresenter::setLogValueSlicingFromView() {
   // more than one item in the list then show that as invalid. We intend to add
   // this though which is why this is still a free text field rather than a
   // spin box
-  if (maybeBreakpoints.is_initialized() && maybeBreakpoints.get().size() <= 1) {
+  if (maybeBreakpoints.has_value() && maybeBreakpoints.value().size() <= 1) {
     m_view->showLogBreakpointsValid();
-    m_slicing = SlicingByEventLog(maybeBreakpoints.get(), blockName);
+    m_slicing = SlicingByEventLog(maybeBreakpoints.value(), blockName);
   } else {
     m_view->showLogBreakpointsInvalid();
     m_slicing = InvalidSlicing();

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/ExperimentOptionDefaults.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/ExperimentOptionDefaults.cpp
@@ -19,7 +19,7 @@ namespace MantidQt::CustomInterfaces::ISISReflectometry {
 namespace {
 Mantid::Kernel::Logger g_log("Reflectometry GUI");
 
-std::string stringValueOrEmpty(boost::optional<double> value) { return value ? std::to_string(*value) : ""; }
+std::string stringValueOrEmpty(std::optional<double> value) { return value ? std::to_string(*value) : ""; }
 
 Experiment getExperimentDefaults(Mantid::Geometry::Instrument_const_sptr instrument) {
   auto defaults = OptionDefaults(std::move(instrument));

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/ExperimentPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/ExperimentPresenter.cpp
@@ -181,7 +181,7 @@ void ExperimentPresenter::updateFloodCorrectionEnabledState() {
     m_view->disableFloodCorrectionInputs();
 }
 
-boost::optional<RangeInLambda> ExperimentPresenter::transmissionRunRangeFromView() {
+std::optional<RangeInLambda> ExperimentPresenter::transmissionRunRangeFromView() {
   auto const range = RangeInLambda(m_view->getTransmissionStartOverlap(), m_view->getTransmissionEndOverlap());
   auto const bothOrNoneMustBeSet = false;
 
@@ -191,7 +191,7 @@ boost::optional<RangeInLambda> ExperimentPresenter::transmissionRunRangeFromView
     m_view->showTransmissionRangeInvalid();
 
   if (range.unset() || !range.isValid(bothOrNoneMustBeSet))
-    return boost::none;
+    return std::nullopt;
   else
     return range;
 }
@@ -207,7 +207,7 @@ std::string ExperimentPresenter::transmissionStitchParamsFromView() {
   // If set, the params should be a list containing an odd number of double
   // values (as per the Params property of Rebin)
   auto maybeParamsList = parseList(stitchParams, parseDouble);
-  if (maybeParamsList.is_initialized() && maybeParamsList->size() % 2 != 0) {
+  if (maybeParamsList.has_value() && maybeParamsList->size() % 2 != 0) {
     m_view->showTransmissionStitchParamsValid();
     return stitchParams;
   }
@@ -225,9 +225,9 @@ TransmissionStitchOptions ExperimentPresenter::transmissionStitchOptionsFromView
 
 std::map<std::string, std::string> ExperimentPresenter::stitchParametersFromView() {
   auto maybeStitchParameters = parseOptions(m_view->getStitchOptions());
-  if (maybeStitchParameters.is_initialized()) {
+  if (maybeStitchParameters.has_value()) {
     m_view->showStitchParametersValid();
-    return maybeStitchParameters.get();
+    return maybeStitchParameters.value();
   }
 
   m_view->showStitchParametersInvalid();
@@ -315,7 +315,7 @@ void ExperimentPresenter::updateViewFromModel() {
                                           PolarizationCorrectionType::None);
   m_view->setFloodCorrectionType(floodCorrectionTypeToString(m_model.floodCorrections().correctionType()));
   if (m_model.floodCorrections().workspace())
-    m_view->setFloodWorkspace(m_model.floodCorrections().workspace().get());
+    m_view->setFloodWorkspace(m_model.floodCorrections().workspace().value());
   else
     m_view->setFloodWorkspace("");
   m_view->setStitchOptions(m_model.stitchParametersString());

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/ExperimentPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/ExperimentPresenter.h
@@ -13,7 +13,7 @@
 #include "IExperimentView.h"
 #include "LookupTableValidationError.h"
 #include "Reduction/Experiment.h"
-#include <boost/optional.hpp>
+#include <optional>
 
 namespace MantidQt {
 namespace CustomInterfaces {
@@ -73,7 +73,7 @@ private:
   BackgroundSubtraction backgroundSubtractionFromView();
   PolarizationCorrections polarizationCorrectionsFromView();
   FloodCorrections floodCorrectionsFromView();
-  boost::optional<RangeInLambda> transmissionRunRangeFromView();
+  std::optional<RangeInLambda> transmissionRunRangeFromView();
   std::string transmissionStitchParamsFromView();
   TransmissionStitchOptions transmissionStitchOptionsFromView();
 

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/LookupTableValidationError.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/LookupTableValidationError.cpp
@@ -13,12 +13,12 @@ namespace MantidQt::CustomInterfaces::ISISReflectometry {
 
 LookupTableValidationError::LookupTableValidationError(
 
-    std::vector<InvalidDefaultsError> validationErrors, boost::optional<ThetaValuesValidationError> fullTableError)
+    std::vector<InvalidDefaultsError> validationErrors, std::optional<ThetaValuesValidationError> fullTableError)
     : m_validationErrors(std::move(validationErrors)), m_fullTableError(std::move(fullTableError)) {}
 
 std::vector<InvalidDefaultsError> const &LookupTableValidationError::errors() const { return m_validationErrors; }
 
-boost::optional<ThetaValuesValidationError> LookupTableValidationError::fullTableError() const {
+std::optional<ThetaValuesValidationError> LookupTableValidationError::fullTableError() const {
   return m_fullTableError;
 }
 } // namespace MantidQt::CustomInterfaces::ISISReflectometry

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/LookupTableValidationError.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/LookupTableValidationError.h
@@ -17,14 +17,14 @@ namespace ISISReflectometry {
 class MANTIDQT_ISISREFLECTOMETRY_DLL LookupTableValidationError {
 public:
   LookupTableValidationError(std::vector<InvalidDefaultsError> validationErrors,
-                             boost::optional<ThetaValuesValidationError> fullTableError);
+                             std::optional<ThetaValuesValidationError> fullTableError);
 
   std::vector<InvalidDefaultsError> const &errors() const;
-  boost::optional<ThetaValuesValidationError> fullTableError() const;
+  std::optional<ThetaValuesValidationError> fullTableError() const;
 
 private:
   std::vector<InvalidDefaultsError> m_validationErrors;
-  boost::optional<ThetaValuesValidationError> m_fullTableError;
+  std::optional<ThetaValuesValidationError> m_fullTableError;
 };
 
 } // namespace ISISReflectometry

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/LookupTableValidator.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/LookupTableValidator.cpp
@@ -22,7 +22,7 @@ auto LookupTableValidator::operator()(ContentType const &lookupTableContent, dou
     if (validationErrors.empty())
       return ResultType(std::move(lookupTable));
     else
-      return ResultType(LookupTableValidationError(std::move(validationErrors), boost::none));
+      return ResultType(LookupTableValidationError(std::move(validationErrors), std::nullopt));
   } else {
     appendThetaErrorForAllRows(validationErrors, lookupTableContent.size());
     return ResultType(LookupTableValidationError(std::move(validationErrors), thetaValidationResult.assertError()));
@@ -67,7 +67,7 @@ bool LookupTableValidator::hasUniqueThetas(LookupTable lookupTable, int wildcard
 
   sortInPlaceWildcardsFirstThenByTheta(lookupTable);
   auto thetasWithinTolerance = [tolerance](LookupRow const &lhs, LookupRow const &rhs) -> bool {
-    double const difference = lhs.thetaOrWildcard().get() - rhs.thetaOrWildcard().get();
+    double const difference = lhs.thetaOrWildcard().value() - rhs.thetaOrWildcard().value();
     return std::abs(difference) < tolerance;
   };
 
@@ -91,7 +91,7 @@ void LookupTableValidator::sortInPlaceWildcardsFirstThenByTheta(LookupTable &loo
     else if (rhs.isWildcard())
       return false;
     else
-      return lhs.thetaOrWildcard().get() < rhs.thetaOrWildcard().get();
+      return lhs.thetaOrWildcard().value() < rhs.thetaOrWildcard().value();
   };
   std::sort(lookupTable.begin(), lookupTable.end(), thetaLessThan);
 }

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/QtExperimentView.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/QtExperimentView.cpp
@@ -346,17 +346,17 @@ void QtExperimentView::setSelected(QComboBox &box, std::string const &str) {
     box.setCurrentIndex(index);
 }
 
-void QtExperimentView::setText(QLineEdit &lineEdit, boost::optional<double> value) {
+void QtExperimentView::setText(QLineEdit &lineEdit, std::optional<double> value) {
   if (value)
-    setText(lineEdit, value.get());
+    setText(lineEdit, value.value());
 }
 
-void QtExperimentView::setText(QLineEdit &lineEdit, boost::optional<int> value) {
+void QtExperimentView::setText(QLineEdit &lineEdit, std::optional<int> value) {
   if (value)
-    setText(lineEdit, value.get());
+    setText(lineEdit, value.value());
 }
 
-void QtExperimentView::setText(QLineEdit &lineEdit, boost::optional<std::string> const &text) {
+void QtExperimentView::setText(QLineEdit &lineEdit, std::optional<std::string> const &text) {
   if (text && !text->empty())
     setText(lineEdit, text);
 }
@@ -378,9 +378,9 @@ void QtExperimentView::setText(QLineEdit &lineEdit, std::string const &text) {
 
 // void QtExperimentView::setText(QTableWidget &table,
 //                             std::string const &propertyName,
-//                             boost::optional<double> value) {
+//                             std::optional<double> value) {
 //  if (value)
-//    setText(table, propertyName, value.get());
+//    setText(table, propertyName, value.value());
 //}
 //
 // void QtExperimentView::setText(QTableWidget &table,
@@ -391,9 +391,9 @@ void QtExperimentView::setText(QLineEdit &lineEdit, std::string const &text) {
 //
 // void QtExperimentView::setText(QTableWidget &table,
 //                             std::string const &propertyName,
-//                             boost::optional<std::string> text) {
+//                             std::optional<std::string> text) {
 //  if (text && !text->empty())
-//    setText(table, propertyName, text.get());
+//    setText(table, propertyName, text.value());
 //}
 //
 // void QtExperimentView::setText(QTableWidget &table,

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/QtExperimentView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/QtExperimentView.h
@@ -163,16 +163,16 @@ private:
   void setText(QLineEdit &lineEdit, int value);
   void setText(QLineEdit &lineEdit, double value);
   void setText(QLineEdit &lineEdit, std::string const &value);
-  void setText(QLineEdit &lineEdit, boost::optional<int> value);
-  void setText(QLineEdit &lineEdit, boost::optional<double> value);
-  void setText(QLineEdit &lineEdit, boost::optional<std::string> const &value);
+  void setText(QLineEdit &lineEdit, std::optional<int> value);
+  void setText(QLineEdit &lineEdit, std::optional<double> value);
+  void setText(QLineEdit &lineEdit, std::optional<std::string> const &value);
   std::string textFromCell(QTableWidgetItem const *maybeNullItem) const;
   //  void setText(QTableWidget &table, std::string const &propertyName,
   //               double value);
   //  void setText(QTableWidget &table, std::string const &propertyName,
-  //               boost::optional<double> value);
+  //               std::optional<double> value);
   //  void setText(QTableWidget &table, std::string const &propertyName,
-  //               boost::optional<std::string> value);
+  //               std::optional<std::string> value);
   //  void setText(QTableWidget &table, std::string const &propertyName,
   //               std::string const &value);
   //  void setText(QTableWidget &table, std::string const &propertyName,

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Instrument/InstrumentOptionDefaults.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Instrument/InstrumentOptionDefaults.h
@@ -6,7 +6,7 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 #pragma once
 #include "Common/DllConfig.h"
-#include "MantidAPI/BoostOptionalToAlgorithmProperty.h"
+#include "MantidAPI/StdOptionalToAlgorithmProperty.h"
 #include "MantidGeometry/Instrument_fwd.h"
 #include "Reduction/Instrument.h"
 #include <string>

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Instrument/InstrumentPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Instrument/InstrumentPresenter.cpp
@@ -15,9 +15,9 @@ namespace MantidQt::CustomInterfaces::ISISReflectometry {
 namespace {
 Mantid::Kernel::Logger g_log("Reflectometry GUI");
 
-boost::optional<RangeInLambda> rangeOrNone(RangeInLambda &range, bool bothOrNoneMustBeSet) {
+std::optional<RangeInLambda> rangeOrNone(RangeInLambda &range, bool bothOrNoneMustBeSet) {
   if (range.unset() || !range.isValid(bothOrNoneMustBeSet))
-    return boost::none;
+    return std::nullopt;
   else
     return range;
 }
@@ -113,7 +113,7 @@ void InstrumentPresenter::restoreDefaults() {
   updateViewFromModel();
 }
 
-boost::optional<RangeInLambda> InstrumentPresenter::wavelengthRangeFromView() {
+std::optional<RangeInLambda> InstrumentPresenter::wavelengthRangeFromView() {
   auto range = RangeInLambda(m_view->getLambdaMin(), m_view->getLambdaMax());
   bool const bothOrNoneMustBeSet = false;
 
@@ -125,7 +125,7 @@ boost::optional<RangeInLambda> InstrumentPresenter::wavelengthRangeFromView() {
   return rangeOrNone(range, bothOrNoneMustBeSet);
 }
 
-boost::optional<RangeInLambda> InstrumentPresenter::monitorBackgroundRangeFromView() {
+std::optional<RangeInLambda> InstrumentPresenter::monitorBackgroundRangeFromView() {
   auto range = RangeInLambda(m_view->getMonitorBackgroundMin(), m_view->getMonitorBackgroundMax());
   bool const bothOrNoneMustBeSet = true;
 
@@ -137,7 +137,7 @@ boost::optional<RangeInLambda> InstrumentPresenter::monitorBackgroundRangeFromVi
   return rangeOrNone(range, bothOrNoneMustBeSet);
 }
 
-boost::optional<RangeInLambda> InstrumentPresenter::monitorIntegralRangeFromView() {
+std::optional<RangeInLambda> InstrumentPresenter::monitorIntegralRangeFromView() {
   auto range = RangeInLambda(m_view->getMonitorIntegralMin(), m_view->getMonitorIntegralMax());
   bool const bothOrNoneMustBeSet = false;
 

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Instrument/InstrumentPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Instrument/InstrumentPresenter.h
@@ -12,7 +12,7 @@
 #include "IInstrumentView.h"
 #include "InstrumentOptionDefaults.h"
 #include "MantidGeometry/Instrument_fwd.h"
-#include <boost/optional.hpp>
+#include <optional>
 
 namespace MantidQt {
 namespace CustomInterfaces {
@@ -52,9 +52,9 @@ private:
   Instrument m_model;
   IBatchPresenter *m_mainPresenter;
 
-  boost::optional<RangeInLambda> wavelengthRangeFromView();
-  boost::optional<RangeInLambda> monitorBackgroundRangeFromView();
-  boost::optional<RangeInLambda> monitorIntegralRangeFromView();
+  std::optional<RangeInLambda> wavelengthRangeFromView();
+  std::optional<RangeInLambda> monitorBackgroundRangeFromView();
+  std::optional<RangeInLambda> monitorIntegralRangeFromView();
   MonitorCorrections monitorCorrectionsFromView();
   DetectorCorrectionType detectorCorrectionTypeFromView();
   DetectorCorrections detectorCorrectionsFromView();

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Instrument/QtInstrumentView.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Instrument/QtInstrumentView.cpp
@@ -168,17 +168,17 @@ void QtInstrumentView::setSelected(QComboBox &box, std::string const &str) {
     box.setCurrentIndex(index);
 }
 
-void QtInstrumentView::setText(QLineEdit &lineEdit, boost::optional<double> value) {
+void QtInstrumentView::setText(QLineEdit &lineEdit, std::optional<double> value) {
   if (value)
-    setText(lineEdit, value.get());
+    setText(lineEdit, value.value());
 }
 
-void QtInstrumentView::setText(QLineEdit &lineEdit, boost::optional<int> value) {
+void QtInstrumentView::setText(QLineEdit &lineEdit, std::optional<int> value) {
   if (value)
-    setText(lineEdit, value.get());
+    setText(lineEdit, value.value());
 }
 
-void QtInstrumentView::setText(QLineEdit &lineEdit, boost::optional<std::string> const &text) {
+void QtInstrumentView::setText(QLineEdit &lineEdit, std::optional<std::string> const &text) {
   if (text && !text->empty())
     setText(lineEdit, text);
 }

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Instrument/QtInstrumentView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Instrument/QtInstrumentView.h
@@ -92,9 +92,9 @@ private:
   void setText(QLineEdit &lineEdit, int value);
   void setText(QLineEdit &lineEdit, double value);
   void setText(QLineEdit &lineEdit, std::string const &value);
-  void setText(QLineEdit &lineEdit, boost::optional<int> value);
-  void setText(QLineEdit &lineEdit, boost::optional<double> value);
-  void setText(QLineEdit &lineEdit, boost::optional<std::string> const &value);
+  void setText(QLineEdit &lineEdit, std::optional<int> value);
+  void setText(QLineEdit &lineEdit, std::optional<double> value);
+  void setText(QLineEdit &lineEdit, std::optional<std::string> const &value);
   void setChecked(QCheckBox &checkBox, bool checked);
   std::string getText(QLineEdit const &lineEdit) const;
   std::string getText(QComboBox const &box) const;

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/MainWindow/IMainWindowPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/MainWindow/IMainWindowPresenter.h
@@ -31,7 +31,7 @@ public:
   virtual bool isProcessPartialGroupPrevented() const = 0;
   virtual bool isRoundChecked() const = 0;
   virtual int &getRoundPrecision() const = 0;
-  virtual boost::optional<int> roundPrecision() const = 0;
+  virtual std::optional<int> roundPrecision() const = 0;
   virtual bool isCloseEventPrevented() = 0;
   virtual bool isCloseBatchPrevented(int batchIndex) const = 0;
   virtual bool isOverwriteBatchPrevented(int tabIndex) const = 0;

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/MainWindow/MainWindowPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/MainWindow/MainWindowPresenter.cpp
@@ -184,10 +184,10 @@ int &MainWindowPresenter::getRoundPrecision() const {
   return m_optionsDialogPresenter->getIntOption(std::string("RoundPrecision"));
 }
 
-boost::optional<int> MainWindowPresenter::roundPrecision() const {
+std::optional<int> MainWindowPresenter::roundPrecision() const {
   if (isRoundChecked())
     return getRoundPrecision();
-  return boost::none;
+  return std::nullopt;
 }
 
 bool MainWindowPresenter::discardChanges(std::string const &message) const {
@@ -272,12 +272,12 @@ void MainWindowPresenter::addNewBatch(IBatchView *batchView) {
 }
 
 void MainWindowPresenter::initNewBatch(IBatchPresenter *batchPresenter, std::string const &instrument,
-                                       boost::optional<int> precision) {
+                                       std::optional<int> precision) {
 
   batchPresenter->initInstrumentList();
   batchPresenter->notifyInstrumentChanged(instrument);
-  if (precision.is_initialized())
-    batchPresenter->notifySetRoundPrecision(precision.get());
+  if (precision.has_value())
+    batchPresenter->notifySetRoundPrecision(precision.value());
 
   // starts in the paused state
   batchPresenter->notifyReductionPaused();

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/MainWindow/MainWindowPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/MainWindow/MainWindowPresenter.h
@@ -99,7 +99,7 @@ private:
   bool isAnyBatchUnsaved() const override;
   bool isRoundChecked() const override;
   int &getRoundPrecision() const override;
-  boost::optional<int> roundPrecision() const override;
+  std::optional<int> roundPrecision() const override;
   bool isWarnProcessAllChecked() const override;
   bool isWarnProcessPartialGroupChecked() const override;
   bool isCloseBatchPrevented(int batchIndex) const override;
@@ -108,7 +108,7 @@ private:
   void optionsChanged() const;
   void showHelp();
   void addNewBatch(IBatchView *batchView);
-  void initNewBatch(IBatchPresenter *batchPresenter, std::string const &instrument, boost::optional<int> precision);
+  void initNewBatch(IBatchPresenter *batchPresenter, std::string const &instrument, std::optional<int> precision);
   void updateInstrument(const std::string &instrumentName);
   void setDefaultInstrument(const std::string &newInstrument);
   void onInstrumentChanged();

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewModel.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewModel.h
@@ -40,7 +40,7 @@ public:
   void exportSummedWsToAds() const override;
 
 private:
-  // This should be an optional instead of a point, but we have issues reassigning it because boost::optional doesn't
+  // This should be an optional instead of a point, but we have issues reassigning it because std::optional doesn't
   // play well with non-copyables. This should be fixable when we can use std::make_optional, but that is disabled on
   // Mac right now.
   std::unique_ptr<PreviewRow> m_runDetails{nullptr};

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/IRunsPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/IRunsPresenter.h
@@ -32,8 +32,8 @@ public:
   virtual void notifyResumeReductionRequested() = 0;
   virtual void notifyPauseReductionRequested() = 0;
   virtual void notifyRowStateChanged() = 0;
-  virtual void notifyRowStateChanged(boost::optional<Item const &> item) = 0;
-  virtual void notifyRowOutputsChanged(boost::optional<Item const &> item) = 0;
+  virtual void notifyRowStateChanged(Item * item) = 0;
+  virtual void notifyRowOutputsChanged(Item * item) = 0;
   virtual void notifyRowOutputsChanged() = 0;
   virtual void notifyBatchLoaded() = 0;
 

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/RunsPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/RunsPresenter.cpp
@@ -159,15 +159,11 @@ void RunsPresenter::notifyStartMonitorComplete() { startMonitorComplete(); }
 
 void RunsPresenter::notifyRowStateChanged() { tablePresenter()->notifyRowStateChanged(); }
 
-void RunsPresenter::notifyRowStateChanged(boost::optional<Item const &> item) {
-  tablePresenter()->notifyRowStateChanged(item);
-}
+void RunsPresenter::notifyRowStateChanged(Item *item) { tablePresenter()->notifyRowStateChanged(item); }
 
 void RunsPresenter::notifyRowOutputsChanged() { tablePresenter()->notifyRowOutputsChanged(); }
 
-void RunsPresenter::notifyRowOutputsChanged(boost::optional<Item const &> item) {
-  tablePresenter()->notifyRowOutputsChanged(item);
-}
+void RunsPresenter::notifyRowOutputsChanged(Item *item) { tablePresenter()->notifyRowOutputsChanged(item); }
 
 void RunsPresenter::notifyBatchLoaded() { m_tablePresenter->notifyBatchLoaded(); }
 
@@ -436,8 +432,8 @@ void RunsPresenter::transfer(const std::set<int> &rowsToTransfer, const Transfer
       if (result.hasError() || result.exclude())
         continue;
       auto row = validateRowFromRunAndTheta(result.runNumber(), result.theta());
-      assert(row.is_initialized());
-      mergeRowIntoGroup(jobs, row.get(), m_thetaTolerance, result.groupName());
+      assert(row.has_value());
+      mergeRowIntoGroup(jobs, row.value(), m_thetaTolerance, result.groupName());
     }
 
     tablePresenter()->mergeAdditionalJobs(jobs);

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/RunsPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/RunsPresenter.h
@@ -79,9 +79,9 @@ public:
   void notifyResumeReductionRequested() override;
   void notifyPauseReductionRequested() override;
   void notifyRowStateChanged() override;
-  void notifyRowStateChanged(boost::optional<Item const &> item) override;
+  void notifyRowStateChanged(Item * item) override;
   void notifyRowOutputsChanged() override;
-  void notifyRowOutputsChanged(boost::optional<Item const &> item) override;
+  void notifyRowOutputsChanged(Item * item) override;
   void notifyBatchLoaded() override;
 
   void notifyReductionPaused() override;

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/SearchResult.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/SearchResult.cpp
@@ -24,8 +24,8 @@ SearchResult::SearchResult(std::string runNumber, std::string title, std::string
 
 void SearchResult::parseRun(std::string const &runNumber) {
   auto const maybeRunNumber = parseRunNumber(runNumber);
-  if (maybeRunNumber.is_initialized())
-    m_runNumber = maybeRunNumber.get();
+  if (maybeRunNumber.has_value())
+    m_runNumber = maybeRunNumber.value();
   else
     addError("Run number is not specified");
 }
@@ -52,7 +52,7 @@ void SearchResult::parseMetadataFromTitle() {
 
   // Validate that the angle parses correctly
   auto const maybeTheta = parseTheta(m_theta);
-  if (!maybeTheta.is_initialized())
+  if (!maybeTheta.has_value())
     addError(std::string("Invalid theta value in run title: ").append(m_theta));
 }
 

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/RunsTable/IRunsTablePresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/RunsTable/IRunsTablePresenter.h
@@ -30,10 +30,10 @@ public:
   virtual RunsTable &mutableRunsTable() = 0;
 
   virtual void notifyRowStateChanged() = 0;
-  virtual void notifyRowStateChanged(boost::optional<Item const &> item) = 0;
+  virtual void notifyRowStateChanged(Item * item) = 0;
 
   virtual void notifyRowOutputsChanged() = 0;
-  virtual void notifyRowOutputsChanged(boost::optional<Item const &> item) = 0;
+  virtual void notifyRowOutputsChanged(Item * item) = 0;
   virtual void notifyRemoveAllRowsAndGroupsRequested() = 0;
 
   virtual void mergeAdditionalJobs(ReductionJobs const &jobs) = 0;

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/RunsTable/JobsViewUpdater.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/RunsTable/JobsViewUpdater.cpp
@@ -9,7 +9,7 @@
 
 namespace MantidQt::CustomInterfaces::ISISReflectometry {
 
-using ValueFunction = boost::optional<double> (RangeInQ::*)() const;
+using ValueFunction = std::optional<double> (RangeInQ::*)() const;
 
 namespace { // unnamed
 std::vector<MantidQt::MantidWidgets::Batch::Cell> cellsFromGroup(Group const &group,
@@ -20,10 +20,10 @@ std::vector<MantidQt::MantidWidgets::Batch::Cell> cellsFromGroup(Group const &gr
 }
 
 MantidWidgets::Batch::Cell qRangeCellOrDefault(RangeInQ const &qRangeInput, RangeInQ const &qRangeOutput,
-                                               ValueFunction valueFunction, boost::optional<int> precision) {
+                                               ValueFunction valueFunction, std::optional<int> precision) {
   auto maybeValue = (qRangeInput.*valueFunction)();
   auto useOutputValue = false;
-  if (!maybeValue.is_initialized()) {
+  if (!maybeValue.has_value()) {
     maybeValue = (qRangeOutput.*valueFunction)();
     useOutputValue = true;
   }
@@ -35,7 +35,7 @@ MantidWidgets::Batch::Cell qRangeCellOrDefault(RangeInQ const &qRangeInput, Rang
   return result;
 }
 
-std::vector<MantidQt::MantidWidgets::Batch::Cell> cellsFromRow(Row const &row, boost::optional<int> precision) {
+std::vector<MantidQt::MantidWidgets::Batch::Cell> cellsFromRow(Row const &row, std::optional<int> precision) {
   return std::vector<MantidQt::MantidWidgets::Batch::Cell>(
       {MantidQt::MantidWidgets::Batch::Cell(boost::join(row.runNumbers(), "+")),
        MantidQt::MantidWidgets::Batch::Cell(valueToString(row.theta(), precision)),
@@ -52,9 +52,9 @@ std::vector<MantidQt::MantidWidgets::Batch::Cell> cellsFromRow(Row const &row, b
 void JobsViewUpdater::groupAppended(int groupIndex, Group const &group) {
   m_view.appendChildRowOf(MantidQt::MantidWidgets::Batch::RowLocation(), cellsFromGroup(group, m_view.deadCell()));
   for (auto const &row : group.rows())
-    if (row.is_initialized())
+    if (row.has_value())
       m_view.appendChildRowOf(MantidQt::MantidWidgets::Batch::RowLocation({groupIndex}),
-                              cellsFromRow(row.get(), m_precision));
+                              cellsFromRow(row.value(), m_precision));
 }
 
 void JobsViewUpdater::groupRemoved(int groupIndex) {
@@ -73,6 +73,6 @@ void JobsViewUpdater::rowModified(int groupIndex, int rowIndex, Row const &row) 
 
 void JobsViewUpdater::setPrecision(const int &precision) { m_precision = precision; }
 
-void JobsViewUpdater::resetPrecision() { m_precision = boost::none; }
+void JobsViewUpdater::resetPrecision() { m_precision = std::nullopt; }
 
 } // namespace MantidQt::CustomInterfaces::ISISReflectometry

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/RunsTable/JobsViewUpdater.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/RunsTable/JobsViewUpdater.h
@@ -32,7 +32,7 @@ public:
 
 private:
   MantidQt::MantidWidgets::Batch::IJobTreeView &m_view;
-  boost::optional<int> m_precision;
+  std::optional<int> m_precision;
 };
 } // namespace ISISReflectometry
 } // namespace CustomInterfaces

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/RunsTable/QtRunsTableView.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/RunsTable/QtRunsTableView.cpp
@@ -245,6 +245,6 @@ RunsTableViewFactory::RunsTableViewFactory(std::vector<std::string> instruments)
 QtRunsTableView *RunsTableViewFactory::operator()() const { return new QtRunsTableView(m_instruments); }
 
 int RunsTableViewFactory::indexOfElseFirst(std::string const &instrument) const {
-  return indexOf(m_instruments, [&instrument](std::string const &inst) { return instrument == inst; }).get_value_or(0);
+  return indexOf(m_instruments, [&instrument](std::string const &inst) { return instrument == inst; }).value_or(0);
 }
 } // namespace MantidQt::CustomInterfaces::ISISReflectometry

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/RunsTable/RunsTablePresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/RunsTable/RunsTablePresenter.cpp
@@ -53,11 +53,11 @@ bool groupNameExists(std::string const &groupName, ReductionJobs const &jobs,
 
   // Check if the group name exists in the jobs
   auto maybeExistingGroupIndex = jobs.indexOfGroupWithName(groupName);
-  if (!maybeExistingGroupIndex.is_initialized())
+  if (!maybeExistingGroupIndex.has_value())
     return false;
 
   // If it exists but in one of the roots to ignore, return false
-  auto existingGroupLocation = MantidWidgets::Batch::RowLocation({maybeExistingGroupIndex.get()});
+  auto existingGroupLocation = MantidWidgets::Batch::RowLocation({maybeExistingGroupIndex.value()});
   if (std::find(rootsToIgnore.cbegin(), rootsToIgnore.cend(), existingGroupLocation) != rootsToIgnore.cend())
     return false;
 
@@ -601,8 +601,8 @@ void RunsTablePresenter::notifyPasteRowsRequested() {
     return;
 
   auto maybeReplacementRoots = m_view->jobs().selectedSubtreeRoots();
-  if (maybeReplacementRoots.is_initialized() && m_clipboard.isInitialized()) {
-    auto &replacementRoots = maybeReplacementRoots.get();
+  if (maybeReplacementRoots.has_value() && m_clipboard.isInitialized()) {
+    auto &replacementRoots = maybeReplacementRoots.value();
     makePastedGroupNamesUnique(m_clipboard, replacementRoots, m_model.reductionJobs());
     if (replacementRoots.empty())
       pasteGroupsAtEnd();
@@ -742,13 +742,13 @@ void RunsTablePresenter::notifyRowStateChanged() {
   }
 }
 
-void RunsTablePresenter::notifyRowStateChanged(boost::optional<Item const &> item) {
+void RunsTablePresenter::notifyRowStateChanged(Item * item) {
   if (!item)
     return;
 
   updateProgressBar();
-  auto const location = m_model.reductionJobs().getLocation(item.get());
-  setRowStylingForItem(location, item.get());
+  auto const location = m_model.reductionJobs().getLocation(*item);
+  setRowStylingForItem(location, *item);
 }
 
 void RunsTablePresenter::notifyRowOutputsChanged() {
@@ -767,11 +767,11 @@ void RunsTablePresenter::notifyRowOutputsChanged() {
   }
 }
 
-void RunsTablePresenter::notifyRowOutputsChanged(boost::optional<Item const &> item) {
-  if (!item.is_initialized() || item->isGroup())
+void RunsTablePresenter::notifyRowOutputsChanged(Item * item) {
+  if (!item || item->isGroup())
     return;
 
-  auto const &row = dynamic_cast<Row const &>(item.get());
+  auto const &row = dynamic_cast<Row const &>(*item);
   auto const location = m_model.reductionJobs().getLocation(row);
   m_jobViewUpdater.rowModified(groupOf(location), rowOf(location), row);
 }

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/RunsTable/RunsTablePresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/RunsTable/RunsTablePresenter.h
@@ -85,9 +85,9 @@ public:
   void notifyPasteRowsRequested() override;
   void notifyFilterReset() override;
   void notifyRowStateChanged() override;
-  void notifyRowStateChanged(boost::optional<Item const &> item) override;
+  void notifyRowStateChanged(Item *item) override;
   void notifyRowOutputsChanged() override;
-  void notifyRowOutputsChanged(boost::optional<Item const &> item) override;
+  void notifyRowOutputsChanged(Item *item) override;
 
 private:
   void applyGroupStylingToRow(MantidWidgets::Batch::RowLocation const &location);

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Save/SavePresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Save/SavePresenter.h
@@ -11,7 +11,7 @@
 #include "ISavePresenter.h"
 #include "ISaveView.h"
 #include "MantidKernel/ConfigPropertyObserver.h"
-#include <boost/optional.hpp>
+#include <optional>
 #include <memory>
 #include <string>
 #include <vector>

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/AllInitialized.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/AllInitialized.h
@@ -5,26 +5,26 @@
 //   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 // SPDX - License - Identifier: GPL - 3.0 +
 #pragma once
-#include <boost/optional.hpp>
+#include <optional>
 
 namespace MantidQt {
 namespace CustomInterfaces {
 namespace ISISReflectometry {
 
-template <typename Param> bool allInitialized(boost::optional<Param> const &param) { return param.is_initialized(); }
+template <typename Param> bool allInitialized(std::optional<Param> const &param) { return param.has_value(); }
 
 template <typename FirstParam, typename SecondParam, typename... Params>
-bool allInitialized(boost::optional<FirstParam> const &first, boost::optional<SecondParam> const &second,
-                    boost::optional<Params> const &...params) {
-  return first.is_initialized() && allInitialized(second, params...);
+bool allInitialized(std::optional<FirstParam> const &first, std::optional<SecondParam> const &second,
+                    std::optional<Params> const &...params) {
+  return first.has_value() && allInitialized(second, params...);
 }
 
 template <typename Result, typename... Params>
-boost::optional<Result> makeIfAllInitialized(boost::optional<Params> const &...params) {
+std::optional<Result> makeIfAllInitialized(std::optional<Params> const &...params) {
   if (allInitialized(params...))
-    return Result(params.get()...);
+    return Result(params.value()...);
   else
-    return boost::none;
+    return std::nullopt;
 }
 
 } // namespace ISISReflectometry

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/BackgroundSubtraction.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/BackgroundSubtraction.h
@@ -7,7 +7,7 @@
 #pragma once
 
 #include "Common/DllConfig.h"
-#include <boost/optional.hpp>
+#include <optional>
 #include <stdexcept>
 #include <string>
 namespace MantidQt {

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/Batch.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/Batch.cpp
@@ -29,7 +29,7 @@ std::vector<MantidWidgets::Batch::RowLocation> Batch::selectedRowLocations() con
 
 std::vector<Group> Batch::selectedGroups() const { return m_runsTable.selectedGroups(); }
 
-LookupRow const *Batch::findLookupRow(boost::optional<double> thetaAngle) const {
+LookupRow const *Batch::findLookupRow(std::optional<double> thetaAngle) const {
   return experiment().findLookupRow(thetaAngle, runsTable().thetaTolerance());
 }
 
@@ -37,7 +37,7 @@ void Batch::resetState() { m_runsTable.resetState(); }
 
 void Batch::resetSkippedItems() { m_runsTable.resetSkippedItems(); }
 
-boost::optional<Item &> Batch::getItemWithOutputWorkspaceOrNone(std::string const &wsName) {
+Item* Batch::getItemWithOutputWorkspaceOrNone(std::string const &wsName) {
   return m_runsTable.getItemWithOutputWorkspaceOrNone(wsName);
 }
 } // namespace MantidQt::CustomInterfaces::ISISReflectometry

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/Batch.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/Batch.cpp
@@ -37,7 +37,7 @@ void Batch::resetState() { m_runsTable.resetState(); }
 
 void Batch::resetSkippedItems() { m_runsTable.resetSkippedItems(); }
 
-Item* Batch::getItemWithOutputWorkspaceOrNone(std::string const &wsName) {
+Item *Batch::getItemWithOutputWorkspaceOrNone(std::string const &wsName) {
   return m_runsTable.getItemWithOutputWorkspaceOrNone(wsName);
 }
 } // namespace MantidQt::CustomInterfaces::ISISReflectometry

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/Batch.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/Batch.h
@@ -13,7 +13,7 @@
 #include "RunsTable.h"
 #include "Slicing.h"
 
-#include <boost/optional.hpp>
+#include <optional>
 #include <vector>
 
 namespace MantidQt {
@@ -39,10 +39,10 @@ public:
   std::vector<Group> selectedGroups() const;
   template <typename T>
   bool isInSelection(T const &item, std::vector<MantidWidgets::Batch::RowLocation> const &selectedRowLocations) const;
-  LookupRow const *findLookupRow(boost::optional<double> thetaAngle = boost::none) const;
+  LookupRow const *findLookupRow(std::optional<double> thetaAngle = std::nullopt) const;
   void resetState();
   void resetSkippedItems();
-  boost::optional<Item &> getItemWithOutputWorkspaceOrNone(std::string const &wsName);
+  Item* getItemWithOutputWorkspaceOrNone(std::string const &wsName);
 
 private:
   Experiment const &m_experiment;

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/Experiment.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/Experiment.cpp
@@ -17,8 +17,8 @@ Experiment::Experiment()
       m_polarizationCorrections(PolarizationCorrections(PolarizationCorrectionType::None)),
       m_floodCorrections(FloodCorrections(FloodCorrectionType::Workspace)), m_transmissionStitchOptions(),
       m_stitchParameters(std::map<std::string, std::string>()),
-      m_lookupTable(LookupTable({LookupRow(boost::none, TransmissionRunPair(), boost::none, RangeInQ(), boost::none,
-                                           ProcessingInstructions(), boost::none)})) {}
+      m_lookupTable(LookupTable({LookupRow(std::nullopt, TransmissionRunPair(), std::nullopt, RangeInQ(), std::nullopt,
+                                           ProcessingInstructions(), std::nullopt)})) {}
 
 Experiment::Experiment(AnalysisMode analysisMode, ReductionType reductionType, SummationType summationType,
                        bool includePartialBins, bool debug, BackgroundSubtraction backgroundSubtraction,
@@ -62,12 +62,12 @@ std::vector<LookupRow::ValueArray> Experiment::lookupTableToArray() const {
   return result;
 }
 
-LookupRow const *Experiment::findLookupRow(const boost::optional<double> &thetaAngle, double tolerance) const {
+LookupRow const *Experiment::findLookupRow(const std::optional<double> &thetaAngle, double tolerance) const {
   LookupTable::const_iterator match;
   if (thetaAngle) {
     match = std::find_if(
         m_lookupTable.cbegin(), m_lookupTable.cend(), [thetaAngle, tolerance](LookupRow const &candiate) -> bool {
-          return !candiate.isWildcard() && std::abs(*thetaAngle - candiate.thetaOrWildcard().get()) <= tolerance;
+          return !candiate.isWildcard() && std::abs(*thetaAngle - candiate.thetaOrWildcard().value()) <= tolerance;
         });
   } else {
     match = std::find_if(m_lookupTable.cbegin(), m_lookupTable.cend(),
@@ -78,7 +78,7 @@ LookupRow const *Experiment::findLookupRow(const boost::optional<double> &thetaA
     return &(*match);
   } else if (thetaAngle) {
     // Try again without a specific angle i.e. look for a wildcard row
-    return findLookupRow(boost::none, tolerance);
+    return findLookupRow(std::nullopt, tolerance);
   } else {
     return nullptr;
   }

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/Experiment.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/Experiment.h
@@ -51,7 +51,7 @@ public:
   LookupTable const &lookupTable() const;
   std::vector<LookupRow::ValueArray> lookupTableToArray() const;
 
-  LookupRow const *findLookupRow(const boost::optional<double> &thetaAngle, double tolerance) const;
+  LookupRow const *findLookupRow(const std::optional<double> &thetaAngle, double tolerance) const;
 
 private:
   AnalysisMode m_analysisMode;

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/FloodCorrections.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/FloodCorrections.cpp
@@ -10,12 +10,12 @@
 
 namespace MantidQt::CustomInterfaces::ISISReflectometry {
 
-FloodCorrections::FloodCorrections(FloodCorrectionType correctionType, boost::optional<std::string> workspace)
+FloodCorrections::FloodCorrections(FloodCorrectionType correctionType, std::optional<std::string> workspace)
     : m_correctionType(correctionType), m_workspace(std::move(workspace)) {}
 
 FloodCorrectionType FloodCorrections::correctionType() const { return m_correctionType; }
 
-boost::optional<std::string> FloodCorrections::workspace() const { return m_workspace; }
+std::optional<std::string> FloodCorrections::workspace() const { return m_workspace; }
 
 bool operator!=(FloodCorrections const &lhs, FloodCorrections const &rhs) { return !(lhs == rhs); }
 

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/FloodCorrections.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/FloodCorrections.h
@@ -6,7 +6,7 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 #pragma once
 #include "Common/DllConfig.h"
-#include <boost/optional.hpp>
+#include <optional>
 #include <string>
 namespace MantidQt {
 namespace CustomInterfaces {
@@ -43,14 +43,14 @@ inline bool floodCorrectionRequiresInputs(FloodCorrectionType correctionType) {
  */
 class MANTIDQT_ISISREFLECTOMETRY_DLL FloodCorrections {
 public:
-  FloodCorrections(FloodCorrectionType correctionType, boost::optional<std::string> workspace = boost::none);
+  FloodCorrections(FloodCorrectionType correctionType, std::optional<std::string> workspace = std::nullopt);
 
   FloodCorrectionType correctionType() const;
-  boost::optional<std::string> workspace() const;
+  std::optional<std::string> workspace() const;
 
 private:
   FloodCorrectionType m_correctionType;
-  boost::optional<std::string> m_workspace;
+  std::optional<std::string> m_workspace;
 };
 
 MANTIDQT_ISISREFLECTOMETRY_DLL bool operator==(FloodCorrections const &lhs, FloodCorrections const &rhs);

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/Group.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/Group.cpp
@@ -183,7 +183,7 @@ int Group::totalItems() const {
   // Include the group if postprocessing is applicable
   auto initCount = hasPostprocessing() ? 1 : 0;
   // Include all valid rows
-  return std::accumulate(rows().cbegin(), rows().cend(), initCount, [](int &count, std::optional<Row> const &row) {
+  return std::accumulate(rows().cbegin(), rows().cend(), initCount, [](int count, std::optional<Row> const &row) {
     if (row.has_value())
       return count + 1;
     else
@@ -195,7 +195,7 @@ int Group::completedItems() const {
   // Include the group if it has been postprocessing
   auto initCount = complete() ? 1 : 0;
   // Include all valid rows that have been processed
-  return std::accumulate(rows().cbegin(), rows().cend(), initCount, [](int &count, std::optional<Row> const &row) {
+  return std::accumulate(rows().cbegin(), rows().cend(), initCount, [](int count, std::optional<Row> const &row) {
     if (row.has_value() && row->complete())
       return count + 1;
     else

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/Group.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/Group.h
@@ -8,7 +8,8 @@
 #include "Common/DllConfig.h"
 #include "Item.h"
 #include "Row.h"
-#include <boost/optional.hpp>
+
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -23,7 +24,7 @@ namespace ISISReflectometry {
 class MANTIDQT_ISISREFLECTOMETRY_DLL Group : public Item {
 public:
   explicit Group(std::string name);
-  Group(std::string name, std::vector<boost::optional<Row>> rows);
+  Group(std::string name, std::vector<std::optional<Row>> rows);
 
   bool isGroup() const override;
   bool isPreview() const override;
@@ -37,11 +38,11 @@ public:
   void resetOutputs() override;
 
   void appendEmptyRow();
-  void appendRow(boost::optional<Row> const &row);
-  void insertRow(boost::optional<Row> const &row, int beforeRowAtIndex);
-  int insertRowSortedByAngle(boost::optional<Row> const &row);
+  void appendRow(std::optional<Row> const &row);
+  void insertRow(std::optional<Row> const &row, int beforeRowAtIndex);
+  int insertRowSortedByAngle(std::optional<Row> const &row);
   void removeRow(int rowIndex);
-  void updateRow(int rowIndex, boost::optional<Row> const &row);
+  void updateRow(int rowIndex, std::optional<Row> const &row);
 
   int totalItems() const override;
   int completedItems() const override;
@@ -50,18 +51,18 @@ public:
   void resetSkipped();
   void renameOutputWorkspace(std::string const &oldName, std::string const &newName) override;
 
-  boost::optional<int> indexOfRowWithTheta(double angle, double tolerance) const;
+  std::optional<int> indexOfRowWithTheta(double angle, double tolerance) const;
 
-  boost::optional<Row> const &operator[](int rowIndex) const;
-  std::vector<boost::optional<Row>> const &rows() const;
-  std::vector<boost::optional<Row>> &mutableRows();
+  std::optional<Row> const &operator[](int rowIndex) const;
+  std::vector<std::optional<Row>> const &rows() const;
+  std::vector<std::optional<Row>> &mutableRows();
 
-  boost::optional<Item &> getItemWithOutputWorkspaceOrNone(std::string const &wsName);
+  Item* getItemWithOutputWorkspaceOrNone(std::string const &wsName);
 
 private:
   std::string m_name;
   std::string m_postprocessedWorkspaceName;
-  std::vector<boost::optional<Row>> m_rows;
+  std::vector<std::optional<Row>> m_rows;
 
   friend class Encoder;
   friend class Decoder;
@@ -72,12 +73,12 @@ template <typename ModificationListener>
 void mergeRowsInto(Group &intoHere, Group const &fromHere, int groupIndex, double thetaTolerance,
                    ModificationListener &listener) {
   for (auto const &maybeRow : fromHere.rows()) {
-    if (maybeRow.is_initialized()) {
-      auto const &fromRow = maybeRow.get();
+    if (maybeRow.has_value()) {
+      auto const &fromRow = maybeRow.value();
       auto index = intoHere.indexOfRowWithTheta(fromRow.theta(), thetaTolerance);
-      if (index.is_initialized()) {
-        auto const updateAtIndex = index.get();
-        auto const &intoRow = intoHere[updateAtIndex].get();
+      if (index.has_value()) {
+        auto const updateAtIndex = index.value();
+        auto const &intoRow = intoHere[updateAtIndex].value();
         auto updatedRow = mergedRow(intoRow, fromRow);
         intoHere.updateRow(updateAtIndex, updatedRow);
         listener.rowModified(groupIndex, updateAtIndex, updatedRow);

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/Instrument.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/Instrument.cpp
@@ -12,12 +12,12 @@ Instrument::Instrument()
       m_monitorCorrections(MonitorCorrections(0, true, RangeInLambda(0.0, 0.0), RangeInLambda(0.0, 0.0))),
       m_detectorCorrections(DetectorCorrections(false, DetectorCorrectionType::VerticalShift)) {}
 
-Instrument::Instrument(boost::optional<RangeInLambda> wavelengthRange, MonitorCorrections monitorCorrections,
+Instrument::Instrument(std::optional<RangeInLambda> wavelengthRange, MonitorCorrections monitorCorrections,
                        DetectorCorrections detectorCorrections)
     : m_wavelengthRange(std::move(wavelengthRange)), m_monitorCorrections(std::move(monitorCorrections)),
       m_detectorCorrections(detectorCorrections) {}
 
-boost::optional<RangeInLambda> const &Instrument::wavelengthRange() const { return m_wavelengthRange; }
+std::optional<RangeInLambda> const &Instrument::wavelengthRange() const { return m_wavelengthRange; }
 
 MonitorCorrections const &Instrument::monitorCorrections() const { return m_monitorCorrections; }
 
@@ -27,9 +27,9 @@ size_t Instrument::monitorIndex() const { return m_monitorCorrections.monitorInd
 
 bool Instrument::integratedMonitors() const { return m_monitorCorrections.integrate(); }
 
-boost::optional<RangeInLambda> Instrument::monitorIntegralRange() const { return m_monitorCorrections.integralRange(); }
+std::optional<RangeInLambda> Instrument::monitorIntegralRange() const { return m_monitorCorrections.integralRange(); }
 
-boost::optional<RangeInLambda> Instrument::monitorBackgroundRange() const {
+std::optional<RangeInLambda> Instrument::monitorBackgroundRange() const {
   return m_monitorCorrections.backgroundRange();
 }
 

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/Instrument.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/Instrument.h
@@ -23,22 +23,22 @@ namespace ISISReflectometry {
 class MANTIDQT_ISISREFLECTOMETRY_DLL Instrument {
 public:
   Instrument();
-  Instrument(boost::optional<RangeInLambda> wavelengthRange, MonitorCorrections monitorCorrections,
+  Instrument(std::optional<RangeInLambda> wavelengthRange, MonitorCorrections monitorCorrections,
              DetectorCorrections detectorCorrections);
 
-  boost::optional<RangeInLambda> const &wavelengthRange() const;
+  std::optional<RangeInLambda> const &wavelengthRange() const;
   bool integratedMonitors() const;
   MonitorCorrections const &monitorCorrections() const;
   DetectorCorrections const &detectorCorrections() const;
 
   size_t monitorIndex() const;
-  boost::optional<RangeInLambda> monitorIntegralRange() const;
-  boost::optional<RangeInLambda> monitorBackgroundRange() const;
+  std::optional<RangeInLambda> monitorIntegralRange() const;
+  std::optional<RangeInLambda> monitorBackgroundRange() const;
   bool correctDetectors() const;
   DetectorCorrectionType detectorCorrectionType() const;
 
 private:
-  boost::optional<RangeInLambda> m_wavelengthRange;
+  std::optional<RangeInLambda> m_wavelengthRange;
   MonitorCorrections m_monitorCorrections;
   DetectorCorrections m_detectorCorrections;
 };

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/ItemState.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/ItemState.cpp
@@ -8,15 +8,15 @@
 
 namespace MantidQt::CustomInterfaces::ISISReflectometry {
 
-ItemState::ItemState() : m_state(State::ITEM_NOT_STARTED), m_message(boost::none), m_progress(0.0) {}
+ItemState::ItemState() : m_state(State::ITEM_NOT_STARTED), m_message(std::nullopt), m_progress(0.0) {}
 
-ItemState::ItemState(State state) : m_state(state), m_message(boost::none), m_progress(0.0) {}
+ItemState::ItemState(State state) : m_state(state), m_message(std::nullopt), m_progress(0.0) {}
 
 State ItemState::state() const { return m_state; }
 
 std::string ItemState::message() const {
   if (m_message)
-    return m_message.get();
+    return m_message.value();
   return "";
 }
 

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/ItemState.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/ItemState.h
@@ -6,7 +6,7 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 #pragma once
 #include "Common/DllConfig.h"
-#include <boost/optional.hpp>
+#include <optional>
 #include <string>
 
 namespace MantidQt {
@@ -46,7 +46,7 @@ public:
 
 private:
   State m_state;
-  boost::optional<std::string> m_message;
+  std::optional<std::string> m_message;
   double m_progress;
 
   bool requiresMessage() const;

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/LookupRow.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/LookupRow.cpp
@@ -12,8 +12,7 @@ LookupRow::LookupRow(std::optional<double> theta,
 
                      TransmissionRunPair transmissionRuns,
                      std::optional<ProcessingInstructions> transmissionProcessingInstructions, RangeInQ qRange,
-                     std::optional<double> scaleFactor,
-                     std::optional<ProcessingInstructions> processingInstructions,
+                     std::optional<double> scaleFactor, std::optional<ProcessingInstructions> processingInstructions,
                      std::optional<ProcessingInstructions> backgroundProcessingInstructions)
     : m_theta(std::move(theta)), m_transmissionRuns(std::move(transmissionRuns)), m_qRange(std::move(qRange)),
       m_scaleFactor(std::move(scaleFactor)),

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/LookupRow.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/LookupRow.cpp
@@ -8,13 +8,13 @@
 
 namespace MantidQt::CustomInterfaces::ISISReflectometry {
 
-LookupRow::LookupRow(boost::optional<double> theta,
+LookupRow::LookupRow(std::optional<double> theta,
 
                      TransmissionRunPair transmissionRuns,
-                     boost::optional<ProcessingInstructions> transmissionProcessingInstructions, RangeInQ qRange,
-                     boost::optional<double> scaleFactor,
-                     boost::optional<ProcessingInstructions> processingInstructions,
-                     boost::optional<ProcessingInstructions> backgroundProcessingInstructions)
+                     std::optional<ProcessingInstructions> transmissionProcessingInstructions, RangeInQ qRange,
+                     std::optional<double> scaleFactor,
+                     std::optional<ProcessingInstructions> processingInstructions,
+                     std::optional<ProcessingInstructions> backgroundProcessingInstructions)
     : m_theta(std::move(theta)), m_transmissionRuns(std::move(transmissionRuns)), m_qRange(std::move(qRange)),
       m_scaleFactor(std::move(scaleFactor)),
       m_transmissionProcessingInstructions(std::move(transmissionProcessingInstructions)),
@@ -23,21 +23,21 @@ LookupRow::LookupRow(boost::optional<double> theta,
 
 TransmissionRunPair const &LookupRow::transmissionWorkspaceNames() const { return m_transmissionRuns; }
 
-bool LookupRow::isWildcard() const { return !m_theta.is_initialized(); }
+bool LookupRow::isWildcard() const { return !m_theta.has_value(); }
 
-boost::optional<double> LookupRow::thetaOrWildcard() const { return m_theta; }
+std::optional<double> LookupRow::thetaOrWildcard() const { return m_theta; }
 
 RangeInQ const &LookupRow::qRange() const { return m_qRange; }
 
-boost::optional<double> LookupRow::scaleFactor() const { return m_scaleFactor; }
+std::optional<double> LookupRow::scaleFactor() const { return m_scaleFactor; }
 
-boost::optional<ProcessingInstructions> LookupRow::processingInstructions() const { return m_processingInstructions; }
+std::optional<ProcessingInstructions> LookupRow::processingInstructions() const { return m_processingInstructions; }
 
-boost::optional<ProcessingInstructions> LookupRow::transmissionProcessingInstructions() const {
+std::optional<ProcessingInstructions> LookupRow::transmissionProcessingInstructions() const {
   return m_transmissionProcessingInstructions;
 }
 
-boost::optional<ProcessingInstructions> LookupRow::backgroundProcessingInstructions() const {
+std::optional<ProcessingInstructions> LookupRow::backgroundProcessingInstructions() const {
   return m_backgroundProcessingInstructions;
 }
 

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/LookupRow.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/LookupRow.h
@@ -9,8 +9,9 @@
 #include "ProcessingInstructions.h"
 #include "RangeInQ.h"
 #include "TransmissionRunPair.h"
+
 #include <array>
-#include <boost/optional.hpp>
+#include <optional>
 #include <string>
 namespace MantidQt {
 namespace CustomInterfaces {
@@ -55,28 +56,28 @@ public:
                                                            "ProcessingInstructions",
                                                            "BackgroundProcessingInstructions"};
 
-  LookupRow(boost::optional<double> theta, TransmissionRunPair tranmissionRuns,
-            boost::optional<ProcessingInstructions> transmissionProcessingInstructions, RangeInQ qRange,
-            boost::optional<double> scaleFactor, boost::optional<ProcessingInstructions> processingInstructions,
-            boost::optional<ProcessingInstructions> backgroundProcessingInstructions);
+  LookupRow(std::optional<double> theta, TransmissionRunPair tranmissionRuns,
+            std::optional<ProcessingInstructions> transmissionProcessingInstructions, RangeInQ qRange,
+            std::optional<double> scaleFactor, std::optional<ProcessingInstructions> processingInstructions,
+            std::optional<ProcessingInstructions> backgroundProcessingInstructions);
 
   TransmissionRunPair const &transmissionWorkspaceNames() const;
   bool isWildcard() const;
-  boost::optional<double> thetaOrWildcard() const;
+  std::optional<double> thetaOrWildcard() const;
   RangeInQ const &qRange() const;
-  boost::optional<double> scaleFactor() const;
-  boost::optional<ProcessingInstructions> transmissionProcessingInstructions() const;
-  boost::optional<ProcessingInstructions> processingInstructions() const;
-  boost::optional<ProcessingInstructions> backgroundProcessingInstructions() const;
+  std::optional<double> scaleFactor() const;
+  std::optional<ProcessingInstructions> transmissionProcessingInstructions() const;
+  std::optional<ProcessingInstructions> processingInstructions() const;
+  std::optional<ProcessingInstructions> backgroundProcessingInstructions() const;
 
 private:
-  boost::optional<double> m_theta;
+  std::optional<double> m_theta;
   TransmissionRunPair m_transmissionRuns;
   RangeInQ m_qRange;
-  boost::optional<double> m_scaleFactor;
-  boost::optional<ProcessingInstructions> m_transmissionProcessingInstructions;
-  boost::optional<ProcessingInstructions> m_processingInstructions;
-  boost::optional<ProcessingInstructions> m_backgroundProcessingInstructions;
+  std::optional<double> m_scaleFactor;
+  std::optional<ProcessingInstructions> m_transmissionProcessingInstructions;
+  std::optional<ProcessingInstructions> m_processingInstructions;
+  std::optional<ProcessingInstructions> m_backgroundProcessingInstructions;
 };
 
 MANTIDQT_ISISREFLECTOMETRY_DLL bool operator==(LookupRow const &lhs, LookupRow const &rhs);

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/MonitorCorrections.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/MonitorCorrections.cpp
@@ -11,8 +11,8 @@
 namespace MantidQt::CustomInterfaces::ISISReflectometry {
 
 MonitorCorrections::MonitorCorrections(size_t monitorIndex, bool integrate,
-                                       boost::optional<RangeInLambda> backgroundRange,
-                                       boost::optional<RangeInLambda> integralRange)
+                                       std::optional<RangeInLambda> backgroundRange,
+                                       std::optional<RangeInLambda> integralRange)
     : m_monitorIndex(monitorIndex), m_integrate(integrate), m_backgroundRange(std::move(backgroundRange)),
       m_integralRange(std::move(integralRange)) {}
 
@@ -20,9 +20,9 @@ size_t MonitorCorrections::monitorIndex() const { return m_monitorIndex; }
 
 bool MonitorCorrections::integrate() const { return m_integrate; }
 
-boost::optional<RangeInLambda> MonitorCorrections::backgroundRange() const { return m_backgroundRange; }
+std::optional<RangeInLambda> MonitorCorrections::backgroundRange() const { return m_backgroundRange; }
 
-boost::optional<RangeInLambda> MonitorCorrections::integralRange() const { return m_integralRange; }
+std::optional<RangeInLambda> MonitorCorrections::integralRange() const { return m_integralRange; }
 
 bool operator!=(MonitorCorrections const &lhs, MonitorCorrections const &rhs) { return !(lhs == rhs); }
 

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/MonitorCorrections.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/MonitorCorrections.h
@@ -7,7 +7,7 @@
 #pragma once
 #include "Common/DllConfig.h"
 #include "RangeInLambda.h"
-#include <boost/optional.hpp>
+#include <optional>
 namespace MantidQt {
 namespace CustomInterfaces {
 namespace ISISReflectometry {
@@ -19,19 +19,19 @@ namespace ISISReflectometry {
  */
 class MANTIDQT_ISISREFLECTOMETRY_DLL MonitorCorrections {
 public:
-  MonitorCorrections(size_t monitorIndex, bool integrate, boost::optional<RangeInLambda> backgroundRange,
-                     boost::optional<RangeInLambda> integralRange);
+  MonitorCorrections(size_t monitorIndex, bool integrate, std::optional<RangeInLambda> backgroundRange,
+                     std::optional<RangeInLambda> integralRange);
 
   size_t monitorIndex() const;
   bool integrate() const;
-  boost::optional<RangeInLambda> backgroundRange() const;
-  boost::optional<RangeInLambda> integralRange() const;
+  std::optional<RangeInLambda> backgroundRange() const;
+  std::optional<RangeInLambda> integralRange() const;
 
 private:
   size_t m_monitorIndex;
   bool m_integrate;
-  boost::optional<RangeInLambda> m_backgroundRange;
-  boost::optional<RangeInLambda> m_integralRange;
+  std::optional<RangeInLambda> m_backgroundRange;
+  std::optional<RangeInLambda> m_integralRange;
 };
 
 MANTIDQT_ISISREFLECTOMETRY_DLL bool operator!=(MonitorCorrections const &lhs, MonitorCorrections const &rhs);

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/ParseReflectometryStrings.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/ParseReflectometryStrings.cpp
@@ -10,21 +10,22 @@
 #include "MantidKernel/Strings.h"
 #include "MantidQtWidgets/Common/ParseKeyValueString.h"
 #include <boost/algorithm/string.hpp>
+#include <optional>
 #include <set>
 namespace MantidQt::CustomInterfaces::ISISReflectometry {
 
 namespace { // unnamed
-boost::optional<std::vector<std::string>> parseRunNumbersOrWhitespace(std::string const &runNumberString) {
+std::optional<std::vector<std::string>> parseRunNumbersOrWhitespace(std::string const &runNumberString) {
   auto runNumbers = std::vector<std::string>();
   auto runNumberCandidates = boost::tokenizer<boost::escaped_list_separator<char>>(
       runNumberString, boost::escaped_list_separator<char>("\\", ",+", "\"'"));
 
   for (auto const &runNumberCandidate : runNumberCandidates) {
     auto const maybeRunNumber = parseRunNumberOrWhitespace(runNumberCandidate);
-    if (maybeRunNumber.is_initialized()) {
-      runNumbers.emplace_back(maybeRunNumber.get());
+    if (maybeRunNumber.has_value()) {
+      runNumbers.emplace_back(maybeRunNumber.value());
     } else {
-      return boost::none;
+      return std::nullopt;
     }
   }
 
@@ -32,7 +33,7 @@ boost::optional<std::vector<std::string>> parseRunNumbersOrWhitespace(std::strin
 }
 } // unnamed namespace
 
-boost::optional<std::string> parseRunNumber(std::string const &runNumberString) {
+std::optional<std::string> parseRunNumber(std::string const &runNumberString) {
   // We support any workspace name, as well as run numbers, so for just return
   // the input string, but trimmed of whitespace (or none if the result is
   // empty)
@@ -40,91 +41,91 @@ boost::optional<std::string> parseRunNumber(std::string const &runNumberString) 
   boost::trim(result);
 
   if (result.empty())
-    return boost::none;
+    return std::nullopt;
 
   return result;
 }
 
-boost::optional<std::string> parseRunNumberOrWhitespace(std::string const &runNumberString) {
+std::optional<std::string> parseRunNumberOrWhitespace(std::string const &runNumberString) {
   if (isEntirelyWhitespace(runNumberString)) {
     return std::string();
   } else {
     auto maybeRunNumber = parseRunNumber(runNumberString);
-    if (maybeRunNumber.is_initialized())
+    if (maybeRunNumber.has_value())
       return maybeRunNumber;
   }
-  return boost::none;
+  return std::nullopt;
 }
 
-boost::optional<double> parseTheta(std::string const &theta) {
+std::optional<double> parseTheta(std::string const &theta) {
   auto maybeTheta = parseNonNegativeDouble(theta);
-  if (maybeTheta.is_initialized() && maybeTheta.get() > 0.0)
+  if (maybeTheta.has_value() && maybeTheta.value() > 0.0)
     return maybeTheta;
   else
-    return boost::none;
+    return std::nullopt;
 }
 
-boost::optional<std::map<std::string, std::string>> parseOptions(std::string const &options) {
+std::optional<std::map<std::string, std::string>> parseOptions(std::string const &options) {
   try {
     return MantidQt::MantidWidgets::parseKeyValueString(options);
   } catch (std::runtime_error &) {
-    return boost::none;
+    return std::nullopt;
   }
 }
 
-boost::optional<boost::optional<std::string>> parseProcessingInstructions(std::string const &instructions) {
+std::optional<std::optional<std::string>> parseProcessingInstructions(std::string const &instructions) {
   if (isEntirelyWhitespace(instructions)) {
-    return boost::optional<std::string>(boost::none);
+    return std::optional<std::string>(std::nullopt);
   } else {
     try {
       auto const groups = Mantid::Kernel::Strings::parseGroups<size_t>(instructions);
-      return boost::optional<std::string>(instructions);
+      return std::optional<std::string>(instructions);
     } catch (std::runtime_error &) {
-      return boost::none;
+      return std::nullopt;
     }
   }
-  return boost::none;
+  return std::nullopt;
 }
 
-boost::optional<boost::optional<double>> parseScaleFactor(std::string const &scaleFactor) {
+std::optional<std::optional<double>> parseScaleFactor(std::string const &scaleFactor) {
   if (isEntirelyWhitespace(scaleFactor)) {
-    return boost::optional<double>(boost::none);
+    return std::optional<double>(std::nullopt);
   }
 
   auto value = parseDouble(scaleFactor);
-  if (value.is_initialized() && value != 0.0)
+  if (value.has_value() && value != 0.0)
     return value;
-  return boost::none;
+  return std::nullopt;
 }
 
 boost::variant<RangeInQ, std::vector<int>> parseQRange(std::string const &min, std::string const &max,
                                                        std::string const &step) {
   auto invalidParams = std::vector<int>();
-  auto minimum = boost::make_optional(false, double());
-  auto maximum = boost::make_optional(false, double());
-  auto stepValue = boost::make_optional(false, double());
+  std::optional<double> minimum;
+  std::optional<double> maximum;
+  std::optional<double> stepValue;
 
   // If any values are set, check they parse ok
   if (!isEntirelyWhitespace(min)) {
     minimum = parseNonNegativeDouble(min);
-    if (!minimum.is_initialized())
+    if (!minimum.has_value())
       invalidParams.emplace_back(0);
   }
 
   if (!isEntirelyWhitespace(max)) {
     maximum = parseNonNegativeDouble(max);
-    if (!maximum.is_initialized())
+    if (!maximum.has_value())
       invalidParams.emplace_back(1);
   }
 
   if (!isEntirelyWhitespace(step)) {
     stepValue = parseNonNegativeDouble(step);
-    if (!stepValue.is_initialized())
+    if (!stepValue.has_value())
       invalidParams.emplace_back(2);
   }
 
   // Check max is not less than min
-  if (maximum.is_initialized() && minimum.is_initialized() && maximum.get() < minimum.get()) {
+  if (maximum.has_value() && minimum.has_value() && maximum.value() < minimum.value()) {
     invalidParams.emplace_back(0);
     invalidParams.emplace_back(1);
   }
@@ -136,22 +137,22 @@ boost::variant<RangeInQ, std::vector<int>> parseQRange(std::string const &min, s
     return RangeInQ(minimum, stepValue, maximum);
 }
 
-boost::optional<std::vector<std::string>> parseRunNumbers(std::string const &runNumberString) {
+std::optional<std::vector<std::string>> parseRunNumbers(std::string const &runNumberString) {
   auto runNumbers = std::vector<std::string>();
   auto runNumberCandidates = boost::tokenizer<boost::escaped_list_separator<char>>(
       runNumberString, boost::escaped_list_separator<char>("\\", ",+", "\"'"));
 
   for (auto const &runNumberCandidate : runNumberCandidates) {
     auto maybeRunNumber = parseRunNumber(runNumberCandidate);
-    if (maybeRunNumber.is_initialized()) {
-      runNumbers.emplace_back(maybeRunNumber.get());
+    if (maybeRunNumber.has_value()) {
+      runNumbers.emplace_back(maybeRunNumber.value());
     } else {
-      return boost::none;
+      return std::nullopt;
     }
   }
 
   if (runNumbers.empty())
-    return boost::none;
+    return std::nullopt;
   else
     return runNumbers;
 }
@@ -163,16 +164,16 @@ boost::variant<TransmissionRunPair, std::vector<int>> parseTransmissionRuns(std:
   auto second = parseRunNumbersOrWhitespace(secondTransmissionRun);
 
   if (allInitialized(first, second)) {
-    if (first.get().empty() && !second.get().empty()) {
+    if (first.value().empty() && !second.value().empty()) {
       errorColumns.emplace_back(0);
       return errorColumns;
     } else {
-      return TransmissionRunPair(first.get(), second.get());
+      return TransmissionRunPair(first.value(), second.value());
     }
   } else {
-    if (!first.is_initialized())
+    if (!first.has_value())
       errorColumns.emplace_back(0);
-    if (!second.is_initialized())
+    if (!second.has_value())
       errorColumns.emplace_back(1);
     return errorColumns;
   }

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/ParseReflectometryStrings.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/ParseReflectometryStrings.h
@@ -8,7 +8,7 @@
 #include "Common/DllConfig.h"
 #include "RangeInQ.h"
 #include "TransmissionRunPair.h"
-#include <boost/optional.hpp>
+#include <optional>
 #include <boost/tokenizer.hpp>
 #include <boost/variant.hpp>
 #include <map>
@@ -18,14 +18,14 @@ namespace MantidQt {
 namespace CustomInterfaces {
 namespace ISISReflectometry {
 
-MANTIDQT_ISISREFLECTOMETRY_DLL boost::optional<std::vector<std::string>> parseRunNumbers(std::string const &runNumbers);
+MANTIDQT_ISISREFLECTOMETRY_DLL std::optional<std::vector<std::string>> parseRunNumbers(std::string const &runNumbers);
 
-MANTIDQT_ISISREFLECTOMETRY_DLL boost::optional<std::string> parseRunNumber(std::string const &runNumberString);
+MANTIDQT_ISISREFLECTOMETRY_DLL std::optional<std::string> parseRunNumber(std::string const &runNumberString);
 
-MANTIDQT_ISISREFLECTOMETRY_DLL boost::optional<std::string>
+MANTIDQT_ISISREFLECTOMETRY_DLL std::optional<std::string>
 parseRunNumberOrWhitespace(std::string const &runNumberString);
 
-MANTIDQT_ISISREFLECTOMETRY_DLL boost::optional<double> parseTheta(std::string const &theta);
+MANTIDQT_ISISREFLECTOMETRY_DLL std::optional<double> parseTheta(std::string const &theta);
 
 MANTIDQT_ISISREFLECTOMETRY_DLL
 boost::variant<TransmissionRunPair, std::vector<int>> parseTransmissionRuns(std::string const &firstTransmissionRun,
@@ -36,13 +36,13 @@ boost::variant<RangeInQ, std::vector<int>> parseQRange(std::string const &min, s
                                                        std::string const &step);
 
 MANTIDQT_ISISREFLECTOMETRY_DLL
-boost::optional<boost::optional<double>> parseScaleFactor(std::string const &scaleFactor);
+std::optional<std::optional<double>> parseScaleFactor(std::string const &scaleFactor);
 
 MANTIDQT_ISISREFLECTOMETRY_DLL
-boost::optional<std::map<std::string, std::string>> parseOptions(std::string const &options);
+std::optional<std::map<std::string, std::string>> parseOptions(std::string const &options);
 
 MANTIDQT_ISISREFLECTOMETRY_DLL
-boost::optional<boost::optional<std::string>> parseProcessingInstructions(std::string const &instructions);
+std::optional<std::optional<std::string>> parseProcessingInstructions(std::string const &instructions);
 
 } // namespace ISISReflectometry
 } // namespace CustomInterfaces

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/PolarizationCorrections.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/PolarizationCorrections.h
@@ -6,7 +6,7 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 #pragma once
 #include "Common/DllConfig.h"
-#include <boost/optional.hpp>
+#include <optional>
 #include <stdexcept>
 #include <string>
 namespace MantidQt {

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/ProcessingInstructions.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/ProcessingInstructions.h
@@ -7,7 +7,7 @@
 #pragma once
 
 #include "Common/DllConfig.h"
-#include <boost/optional.hpp>
+#include <optional>
 namespace MantidQt {
 namespace CustomInterfaces {
 namespace ISISReflectometry {

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/RangeInQ.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/RangeInQ.cpp
@@ -10,16 +10,16 @@
 
 namespace MantidQt::CustomInterfaces::ISISReflectometry {
 
-RangeInQ::RangeInQ(boost::optional<double> min, boost::optional<double> step, boost::optional<double> max)
+RangeInQ::RangeInQ(std::optional<double> min, std::optional<double> step, std::optional<double> max)
     : m_min(std::move(min)), m_step(std::move(step)), m_max(std::move(max)) {
-  assert(!(m_min.is_initialized() && m_max.is_initialized() && m_max < m_min));
+  assert(!(m_min.has_value() && m_max.has_value() && m_max < m_min));
 }
 
-boost::optional<double> RangeInQ::min() const { return m_min; }
+std::optional<double> RangeInQ::min() const { return m_min; }
 
-boost::optional<double> RangeInQ::max() const { return m_max; }
+std::optional<double> RangeInQ::max() const { return m_max; }
 
-boost::optional<double> RangeInQ::step() const { return m_step; }
+std::optional<double> RangeInQ::step() const { return m_step; }
 
 bool operator==(RangeInQ const &lhs, RangeInQ const &rhs) {
   return lhs.min() == rhs.min() && lhs.max() == rhs.max() && lhs.step() == rhs.step();

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/RangeInQ.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/RangeInQ.h
@@ -6,7 +6,7 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 #pragma once
 #include "Common/DllConfig.h"
-#include <boost/optional.hpp>
+#include <optional>
 
 namespace MantidQt {
 namespace CustomInterfaces {
@@ -14,17 +14,17 @@ namespace ISISReflectometry {
 
 class MANTIDQT_ISISREFLECTOMETRY_DLL RangeInQ {
 public:
-  RangeInQ(boost::optional<double> min = boost::none, boost::optional<double> step = boost::none,
-           boost::optional<double> max = boost::none);
+  RangeInQ(std::optional<double> min = std::nullopt, std::optional<double> step = std::nullopt,
+           std::optional<double> max = std::nullopt);
 
-  boost::optional<double> min() const;
-  boost::optional<double> max() const;
-  boost::optional<double> step() const;
+  std::optional<double> min() const;
+  std::optional<double> max() const;
+  std::optional<double> step() const;
 
 private:
-  boost::optional<double> m_min;
-  boost::optional<double> m_step;
-  boost::optional<double> m_max;
+  std::optional<double> m_min;
+  std::optional<double> m_step;
+  std::optional<double> m_max;
 };
 
 MANTIDQT_ISISREFLECTOMETRY_DLL bool operator==(RangeInQ const &lhs, RangeInQ const &rhs);

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/ReductionJobs.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/ReductionJobs.h
@@ -7,7 +7,7 @@
 #pragma once
 #include "Common/DllConfig.h"
 #include "MantidQtWidgets/Common/Batch/RowLocation.h"
-#include <boost/optional.hpp>
+#include <optional>
 
 #include "Group.h"
 
@@ -28,7 +28,7 @@ public:
   Group &insertGroup(Group group, int beforeIndex);
   bool hasGroupWithName(std::string const &groupName) const;
   bool containsSingleEmptyGroup() const;
-  boost::optional<int> indexOfGroupWithName(std::string const &groupName) const;
+  std::optional<int> indexOfGroupWithName(std::string const &groupName) const;
   void removeGroup(int index);
   void removeAllGroups();
   void resetState();
@@ -43,11 +43,11 @@ public:
   MantidWidgets::Batch::RowLocation getLocation(Group const &group) const;
   MantidWidgets::Batch::RowLocation getLocation(Row const &row) const;
   Group const &getParentGroup(Row const &row) const;
-  boost::optional<Item &> getItemWithOutputWorkspaceOrNone(std::string const &wsName);
+  Item *getItemWithOutputWorkspaceOrNone(std::string const &wsName);
 
   bool validItemAtPath(const MantidWidgets::Batch::RowLocation &rowLocation) const;
   Group const &getGroupFromPath(const MantidWidgets::Batch::RowLocation &path) const;
-  boost::optional<Row> const &getRowFromPath(const MantidWidgets::Batch::RowLocation &path) const;
+  std::optional<Row> const &getRowFromPath(const MantidWidgets::Batch::RowLocation &path) const;
   Item const &getItemFromPath(const MantidWidgets::Batch::RowLocation &path) const;
 
 private:
@@ -63,7 +63,7 @@ MANTIDQT_ISISREFLECTOMETRY_DLL bool operator==(ReductionJobs const &lhs, Reducti
 void appendEmptyRow(ReductionJobs &jobs, int groupIndex);
 void insertEmptyRow(ReductionJobs &jobs, int groupIndex, int beforeRow);
 void removeRow(ReductionJobs &jobs, int groupIndex, int rowIndex);
-void updateRow(ReductionJobs &jobs, int groupIndex, int rowIndex, boost::optional<Row> const &newValue);
+void updateRow(ReductionJobs &jobs, int groupIndex, int rowIndex, std::optional<Row> const &newValue);
 
 void appendEmptyGroup(ReductionJobs &jobs);
 void insertEmptyGroup(ReductionJobs &jobs, int beforeGroup);
@@ -87,8 +87,8 @@ void mergeJobsInto(ReductionJobs &intoHere, ReductionJobs const &fromHere, doubl
   auto removeFirstGroup = intoHere.containsSingleEmptyGroup();
   for (auto const &group : fromHere.groups()) {
     auto maybeGroupIndex = intoHere.indexOfGroupWithName(group.name());
-    if (maybeGroupIndex.is_initialized()) {
-      auto indexToUpdateAt = maybeGroupIndex.get();
+    if (maybeGroupIndex.has_value()) {
+      auto indexToUpdateAt = maybeGroupIndex.value();
       auto &intoGroup = intoHere.mutableGroups()[indexToUpdateAt];
       mergeRowsInto(intoGroup, group, indexToUpdateAt, thetaTolerance, listener);
     } else {

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/ReductionType.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/ReductionType.h
@@ -6,7 +6,7 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 #pragma once
 #include "Common/DllConfig.h"
-#include <boost/optional.hpp>
+#include <optional>
 namespace MantidQt {
 namespace CustomInterfaces {
 namespace ISISReflectometry {

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/ReductionWorkspaces.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/ReductionWorkspaces.h
@@ -9,7 +9,7 @@
 #include "Common/DllConfig.h"
 #include "TransmissionRunPair.h"
 #include <boost/algorithm/string/join.hpp>
-#include <boost/optional.hpp>
+#include <optional>
 #include <string>
 #include <vector>
 

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/Row.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/Row.cpp
@@ -13,7 +13,7 @@ namespace MantidQt::CustomInterfaces::ISISReflectometry {
 
 Row::Row(std::vector<std::string> runNumbers, double theta,
 
-         TransmissionRunPair transmissionRuns, RangeInQ qRange, boost::optional<double> scaleFactor,
+         TransmissionRunPair transmissionRuns, RangeInQ qRange, std::optional<double> scaleFactor,
          ReductionOptionsMap reductionOptions,
 
          ReductionWorkspaces reducedWorkspaceNames)
@@ -37,7 +37,7 @@ RangeInQ const &Row::qRange() const { return m_qRange; }
 
 RangeInQ const &Row::qRangeOutput() const { return m_qRangeOutput; }
 
-boost::optional<double> Row::scaleFactor() const { return m_scaleFactor; }
+std::optional<double> Row::scaleFactor() const { return m_scaleFactor; }
 
 ReductionOptionsMap const &Row::reductionOptions() const { return m_reductionOptions; }
 

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/Row.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/Row.h
@@ -10,7 +10,7 @@
 #include "RangeInQ.h"
 #include "ReductionOptionsMap.h"
 #include "ReductionWorkspaces.h"
-#include <boost/optional.hpp>
+#include <optional>
 #include <boost/range/algorithm/set_algorithm.hpp>
 #include <boost/variant.hpp>
 #include <string>
@@ -28,7 +28,7 @@ namespace ISISReflectometry {
 class MANTIDQT_ISISREFLECTOMETRY_DLL Row : public Item {
 public:
   Row(std::vector<std::string> number, double theta, TransmissionRunPair tranmissionRuns, RangeInQ qRange,
-      boost::optional<double> scaleFactor, ReductionOptionsMap reductionOptions,
+      std::optional<double> scaleFactor, ReductionOptionsMap reductionOptions,
       ReductionWorkspaces reducedWorkspaceNames);
 
   bool isGroup() const override;
@@ -38,7 +38,7 @@ public:
   double theta() const;
   RangeInQ const &qRange() const;
   RangeInQ const &qRangeOutput() const;
-  boost::optional<double> scaleFactor() const;
+  std::optional<double> scaleFactor() const;
   ReductionOptionsMap const &reductionOptions() const;
   ReductionWorkspaces const &reducedWorkspaceNames() const;
 
@@ -58,7 +58,7 @@ private:
   double m_theta;
   RangeInQ m_qRange;       // user-defined Q values
   RangeInQ m_qRangeOutput; // output Q values if inputs were not specified
-  boost::optional<double> m_scaleFactor;
+  std::optional<double> m_scaleFactor;
   TransmissionRunPair m_transmissionRuns;
   ReductionWorkspaces m_reducedWorkspaceNames;
   ReductionOptionsMap m_reductionOptions;

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/RunsTable.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/RunsTable.cpp
@@ -37,7 +37,7 @@ void RunsTable::resetState() { m_reductionJobs.resetState(); }
 
 void RunsTable::resetSkippedItems() { m_reductionJobs.resetSkippedItems(); }
 
-Item* RunsTable::getItemWithOutputWorkspaceOrNone(std::string const &wsName) {
+Item *RunsTable::getItemWithOutputWorkspaceOrNone(std::string const &wsName) {
   return m_reductionJobs.getItemWithOutputWorkspaceOrNone(wsName);
 }
 

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/RunsTable.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/RunsTable.cpp
@@ -37,7 +37,7 @@ void RunsTable::resetState() { m_reductionJobs.resetState(); }
 
 void RunsTable::resetSkippedItems() { m_reductionJobs.resetSkippedItems(); }
 
-boost::optional<Item &> RunsTable::getItemWithOutputWorkspaceOrNone(std::string const &wsName) {
+Item* RunsTable::getItemWithOutputWorkspaceOrNone(std::string const &wsName) {
   return m_reductionJobs.getItemWithOutputWorkspaceOrNone(wsName);
 }
 
@@ -58,8 +58,8 @@ std::vector<Row> RunsTable::selectedRows() const {
     if (!isRowLocation(rowLocation))
       continue;
     const auto row = m_reductionJobs.getRowFromPath(rowLocation);
-    if (row.is_initialized())
-      rows.emplace_back(row.get());
+    if (row.has_value())
+      rows.emplace_back(row.value());
   }
   return rows;
 }

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/RunsTable.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/RunsTable.h
@@ -35,7 +35,7 @@ public:
   bool isInSelection(T const &item, std::vector<MantidWidgets::Batch::RowLocation> const &selectedRowLocations) const;
   void resetState();
   void resetSkippedItems();
-  boost::optional<Item &> getItemWithOutputWorkspaceOrNone(std::string const &wsName);
+  Item* getItemWithOutputWorkspaceOrNone(std::string const &wsName);
   std::vector<Group> selectedGroups() const;
   std::vector<Row> selectedRows() const;
 

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/SummationType.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/SummationType.h
@@ -5,7 +5,7 @@
 //   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 // SPDX - License - Identifier: GPL - 3.0 +
 #pragma once
-#include <boost/optional.hpp>
+#include <optional>
 #include <stdexcept>
 #include <string>
 

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/TransmissionStitchOptions.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/TransmissionStitchOptions.cpp
@@ -9,13 +9,13 @@
 namespace MantidQt::CustomInterfaces::ISISReflectometry {
 
 TransmissionStitchOptions::TransmissionStitchOptions()
-    : m_overlapRange(boost::none), m_rebinParameters(), m_scaleRHS(false) {}
+    : m_overlapRange(std::nullopt), m_rebinParameters(), m_scaleRHS(false) {}
 
-TransmissionStitchOptions::TransmissionStitchOptions(boost::optional<RangeInLambda> overlapRange,
+TransmissionStitchOptions::TransmissionStitchOptions(std::optional<RangeInLambda> overlapRange,
                                                      RebinParameters rebinParameters, bool scaleRHS)
     : m_overlapRange(std::move(overlapRange)), m_rebinParameters(std::move(rebinParameters)), m_scaleRHS(scaleRHS) {}
 
-boost::optional<RangeInLambda> TransmissionStitchOptions::overlapRange() const { return m_overlapRange; }
+std::optional<RangeInLambda> TransmissionStitchOptions::overlapRange() const { return m_overlapRange; }
 
 RebinParameters TransmissionStitchOptions::rebinParameters() const { return m_rebinParameters; }
 

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/TransmissionStitchOptions.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/TransmissionStitchOptions.h
@@ -8,7 +8,7 @@
 #include "Common/DllConfig.h"
 #include "ProcessingInstructions.h"
 #include "RangeInLambda.h"
-#include <boost/optional.hpp>
+#include <optional>
 #include <string>
 namespace MantidQt {
 namespace CustomInterfaces {
@@ -27,15 +27,14 @@ using RebinParameters = std::string;
 class MANTIDQT_ISISREFLECTOMETRY_DLL TransmissionStitchOptions {
 public:
   TransmissionStitchOptions();
-  TransmissionStitchOptions(boost::optional<RangeInLambda> overlapRange, RebinParameters rebinParameters,
-                            bool scaleRHS);
+  TransmissionStitchOptions(std::optional<RangeInLambda> overlapRange, RebinParameters rebinParameters, bool scaleRHS);
 
-  boost::optional<RangeInLambda> overlapRange() const;
+  std::optional<RangeInLambda> overlapRange() const;
   RebinParameters rebinParameters() const;
   bool scaleRHS() const;
 
 private:
-  boost::optional<RangeInLambda> m_overlapRange;
+  std::optional<RangeInLambda> m_overlapRange;
   RebinParameters m_rebinParameters;
   bool m_scaleRHS;
 };

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/ValidateLookupRow.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/ValidateLookupRow.cpp
@@ -15,22 +15,22 @@ using namespace MantidQt::CustomInterfaces::ISISReflectometry;
 
 namespace MantidQt::CustomInterfaces::ISISReflectometry {
 
-template <typename T> class AppendErrorIfNotType : public boost::static_visitor<boost::optional<T>> {
+template <typename T> class AppendErrorIfNotType : public boost::static_visitor<std::optional<T>> {
 public:
   AppendErrorIfNotType(std::vector<int> &invalidParams, int baseColumn)
       : m_invalidParams(invalidParams), m_baseColumn(baseColumn) {}
 
-  boost::optional<T> operator()(T const &result) const { return result; }
+  std::optional<T> operator()(T const &result) const { return result; }
 
-  boost::optional<T> operator()(int errorColumn) const {
+  std::optional<T> operator()(int errorColumn) const {
     m_invalidParams.emplace_back(m_baseColumn + errorColumn);
-    return boost::none;
+    return std::nullopt;
   }
 
-  boost::optional<T> operator()(const std::vector<int> &errorColumns) const {
+  std::optional<T> operator()(const std::vector<int> &errorColumns) const {
     std::transform(errorColumns.cbegin(), errorColumns.cend(), std::back_inserter(m_invalidParams),
                    [this](int column) -> int { return m_baseColumn + column; });
-    return boost::none;
+    return std::nullopt;
   }
 
 private:
@@ -40,20 +40,20 @@ private:
 
 using CellText = LookupRow::ValueArray;
 
-boost::optional<boost::optional<double>> LookupRowValidator::parseThetaOrWhitespace(CellText const &cellText) {
+std::optional<std::optional<double>> LookupRowValidator::parseThetaOrWhitespace(CellText const &cellText) {
   if (isEntirelyWhitespace(cellText[LookupRow::Column::THETA])) {
-    return boost::optional<double>();
+    return std::optional<double>();
   } else {
     auto theta = ISISReflectometry::parseTheta(cellText[LookupRow::Column::THETA]);
-    if (theta.is_initialized()) {
+    if (theta.has_value()) {
       return theta;
     }
   }
   m_invalidColumns.emplace_back(LookupRow::Column::THETA);
-  return boost::none;
+  return std::nullopt;
 }
 
-boost::optional<TransmissionRunPair> LookupRowValidator::parseTransmissionRuns(CellText const &cellText) {
+std::optional<TransmissionRunPair> LookupRowValidator::parseTransmissionRuns(CellText const &cellText) {
   auto transmissionRunsOrError = ISISReflectometry::parseTransmissionRuns(cellText[LookupRow::Column::FIRST_TRANS],
                                                                           cellText[LookupRow::Column::SECOND_TRANS]);
   return boost::apply_visitor(
@@ -61,42 +61,42 @@ boost::optional<TransmissionRunPair> LookupRowValidator::parseTransmissionRuns(C
       transmissionRunsOrError);
 }
 
-boost::optional<boost::optional<std::string>>
+std::optional<std::optional<std::string>>
 LookupRowValidator::parseTransmissionProcessingInstructions(CellText const &cellText) {
   auto optionalInstructionsOrNoneIfError =
       ISISReflectometry::parseProcessingInstructions(cellText[LookupRow::Column::TRANS_SPECTRA]);
-  if (!optionalInstructionsOrNoneIfError.is_initialized())
+  if (!optionalInstructionsOrNoneIfError.has_value())
     m_invalidColumns.emplace_back(LookupRow::Column::TRANS_SPECTRA);
   return optionalInstructionsOrNoneIfError;
 }
 
-boost::optional<RangeInQ> LookupRowValidator::parseQRange(CellText const &cellText) {
+std::optional<RangeInQ> LookupRowValidator::parseQRange(CellText const &cellText) {
   auto qRangeOrError = ISISReflectometry::parseQRange(
       cellText[LookupRow::Column::QMIN], cellText[LookupRow::Column::QMAX], cellText[LookupRow::Column::QSTEP]);
   return boost::apply_visitor(AppendErrorIfNotType<RangeInQ>(m_invalidColumns, LookupRow::Column::QMIN), qRangeOrError);
 }
 
-boost::optional<boost::optional<double>> LookupRowValidator::parseScaleFactor(CellText const &cellText) {
+std::optional<std::optional<double>> LookupRowValidator::parseScaleFactor(CellText const &cellText) {
   auto optionalScaleFactorOrNoneIfError = ISISReflectometry::parseScaleFactor(cellText[LookupRow::Column::SCALE]);
-  if (!optionalScaleFactorOrNoneIfError.is_initialized())
+  if (!optionalScaleFactorOrNoneIfError.has_value())
     m_invalidColumns.emplace_back(LookupRow::Column::SCALE);
   return optionalScaleFactorOrNoneIfError;
 }
 
-boost::optional<boost::optional<std::string>>
+std::optional<std::optional<std::string>>
 LookupRowValidator::parseProcessingInstructions(CellText const &cellText) {
   auto optionalInstructionsOrNoneIfError =
       ISISReflectometry::parseProcessingInstructions(cellText[LookupRow::Column::RUN_SPECTRA]);
-  if (!optionalInstructionsOrNoneIfError.is_initialized())
+  if (!optionalInstructionsOrNoneIfError.has_value())
     m_invalidColumns.emplace_back(LookupRow::Column::RUN_SPECTRA);
   return optionalInstructionsOrNoneIfError;
 }
 
-boost::optional<boost::optional<std::string>>
+std::optional<std::optional<std::string>>
 LookupRowValidator::parseBackgroundProcessingInstructions(CellText const &cellText) {
   auto optionalInstructionsOrNoneIfError =
       ISISReflectometry::parseProcessingInstructions(cellText[LookupRow::Column::BACKGROUND_SPECTRA]);
-  if (!optionalInstructionsOrNoneIfError.is_initialized())
+  if (!optionalInstructionsOrNoneIfError.has_value())
     m_invalidColumns.emplace_back(LookupRow::Column::BACKGROUND_SPECTRA);
   return optionalInstructionsOrNoneIfError;
 }
@@ -113,8 +113,8 @@ ValidationResult<LookupRow, std::vector<int>> LookupRowValidator::operator()(Cel
       maybeTheta, maybeTransmissionRuns, maybeTransmissionProcessingInstructions, maybeQRange, maybeScaleFactor,
       maybeProcessingInstructions, maybeBackgroundProcessingInstructions);
 
-  if (maybeDefaults.is_initialized())
-    return ValidationResult<LookupRow, std::vector<int>>(maybeDefaults.get());
+  if (maybeDefaults.has_value())
+    return ValidationResult<LookupRow, std::vector<int>>(maybeDefaults.value());
   else
     return ValidationResult<LookupRow, std::vector<int>>(m_invalidColumns);
 }

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/ValidateLookupRow.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/ValidateLookupRow.h
@@ -11,7 +11,7 @@
 #include "ParseReflectometryStrings.h"
 #include "TransmissionRunPair.h"
 #include <array>
-#include <boost/optional.hpp>
+#include <optional>
 namespace MantidQt {
 namespace CustomInterfaces {
 namespace ISISReflectometry {
@@ -26,15 +26,15 @@ public:
   ValidationResult<LookupRow, std::vector<int>> operator()(LookupRow::ValueArray const &cellText);
 
 private:
-  boost::optional<boost::optional<double>> parseThetaOrWhitespace(LookupRow::ValueArray const &cellText);
-  boost::optional<TransmissionRunPair> parseTransmissionRuns(LookupRow::ValueArray const &cellText);
-  boost::optional<boost::optional<std::string>>
+  std::optional<std::optional<double>> parseThetaOrWhitespace(LookupRow::ValueArray const &cellText);
+  std::optional<TransmissionRunPair> parseTransmissionRuns(LookupRow::ValueArray const &cellText);
+  std::optional<std::optional<std::string>>
   parseTransmissionProcessingInstructions(LookupRow::ValueArray const &cellText);
-  boost::optional<RangeInQ> parseQRange(LookupRow::ValueArray const &cellText);
-  boost::optional<boost::optional<double>> parseScaleFactor(LookupRow::ValueArray const &cellText);
-  boost::optional<std::map<std::string, std::string>> parseOptions(LookupRow::ValueArray const &cellText);
-  boost::optional<boost::optional<std::string>> parseProcessingInstructions(LookupRow::ValueArray const &cellText);
-  boost::optional<boost::optional<std::string>>
+  std::optional<RangeInQ> parseQRange(LookupRow::ValueArray const &cellText);
+  std::optional<std::optional<double>> parseScaleFactor(LookupRow::ValueArray const &cellText);
+  std::optional<std::map<std::string, std::string>> parseOptions(LookupRow::ValueArray const &cellText);
+  std::optional<std::optional<std::string>> parseProcessingInstructions(LookupRow::ValueArray const &cellText);
+  std::optional<std::optional<std::string>>
   parseBackgroundProcessingInstructions(LookupRow::ValueArray const &cellText);
 
   std::vector<int> m_invalidColumns;

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/ValidateRow.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/ValidateRow.cpp
@@ -88,8 +88,7 @@ std::optional<std::optional<double>> RowValidator::parseScaleFactor(std::vector<
   return optionalScaleFactorOrNoneIfError;
 }
 
-std::optional<std::map<std::string, std::string>>
-RowValidator::parseOptions(std::vector<std::string> const &cellText) {
+std::optional<std::map<std::string, std::string>> RowValidator::parseOptions(std::vector<std::string> const &cellText) {
   auto options = ::MantidQt::CustomInterfaces::ISISReflectometry::parseOptions(cellText[OPTIONS_COLUMN]);
   if (!options.has_value())
     m_invalidColumns.emplace_back(OPTIONS_COLUMN);

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/ValidateRow.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/ValidateRow.cpp
@@ -29,22 +29,22 @@ enum ColumnNumber {
 };
 }
 
-template <typename T> class AppendErrorIfNotType : public boost::static_visitor<boost::optional<T>> {
+template <typename T> class AppendErrorIfNotType : public boost::static_visitor<std::optional<T>> {
 public:
   AppendErrorIfNotType(std::vector<int> &invalidParams, int baseColumn)
       : m_invalidParams(invalidParams), m_baseColumn(baseColumn) {}
 
-  boost::optional<T> operator()(T const &result) const { return result; }
+  std::optional<T> operator()(T const &result) const { return result; }
 
-  boost::optional<T> operator()(int errorColumn) const {
+  std::optional<T> operator()(int errorColumn) const {
     m_invalidParams.emplace_back(m_baseColumn + errorColumn);
-    return boost::none;
+    return std::nullopt;
   }
 
-  boost::optional<T> operator()(const std::vector<int> &errorColumns) const {
+  std::optional<T> operator()(const std::vector<int> &errorColumns) const {
     std::transform(errorColumns.cbegin(), errorColumns.cend(), std::back_inserter(m_invalidParams),
                    [this](int column) -> int { return m_baseColumn + column; });
-    return boost::none;
+    return std::nullopt;
   }
 
 private:
@@ -52,46 +52,46 @@ private:
   int m_baseColumn;
 };
 
-boost::optional<std::vector<std::string>> RowValidator::parseRunNumbers(std::vector<std::string> const &cellText) {
+std::optional<std::vector<std::string>> RowValidator::parseRunNumbers(std::vector<std::string> const &cellText) {
   auto runNumbers = ::MantidQt::CustomInterfaces::ISISReflectometry::parseRunNumbers(cellText[RUNS_COLUMN]);
-  if (!runNumbers.is_initialized())
+  if (!runNumbers.has_value())
     m_invalidColumns.emplace_back(RUNS_COLUMN);
   return runNumbers;
 }
 
-boost::optional<double> RowValidator::parseTheta(std::vector<std::string> const &cellText) {
+std::optional<double> RowValidator::parseTheta(std::vector<std::string> const &cellText) {
   auto theta = ::MantidQt::CustomInterfaces::ISISReflectometry::parseTheta(cellText[THETA_COLUMN]);
-  if (!theta.is_initialized())
+  if (!theta.has_value())
     m_invalidColumns.emplace_back(THETA_COLUMN);
   return theta;
 }
 
-boost::optional<TransmissionRunPair> RowValidator::parseTransmissionRuns(std::vector<std::string> const &cellText) {
+std::optional<TransmissionRunPair> RowValidator::parseTransmissionRuns(std::vector<std::string> const &cellText) {
   auto transmissionRunsOrError = ::MantidQt::CustomInterfaces::ISISReflectometry::parseTransmissionRuns(
       cellText[FIRST_TRANS_COLUMN], cellText[SECOND_TRANS_COLUMN]);
   return boost::apply_visitor(AppendErrorIfNotType<TransmissionRunPair>(m_invalidColumns, FIRST_TRANS_COLUMN),
                               transmissionRunsOrError);
 }
 
-boost::optional<RangeInQ> RowValidator::parseQRange(std::vector<std::string> const &cellText) {
+std::optional<RangeInQ> RowValidator::parseQRange(std::vector<std::string> const &cellText) {
   auto qRangeOrError = ::MantidQt::CustomInterfaces::ISISReflectometry::parseQRange(
       cellText[QMIN_COLUMN], cellText[QMAX_COLUMN], cellText[QSTEP_COLUMN]);
   return boost::apply_visitor(AppendErrorIfNotType<RangeInQ>(m_invalidColumns, QMIN_COLUMN), qRangeOrError);
 }
 
-boost::optional<boost::optional<double>> RowValidator::parseScaleFactor(std::vector<std::string> const &cellText) {
+std::optional<std::optional<double>> RowValidator::parseScaleFactor(std::vector<std::string> const &cellText) {
   auto optionalScaleFactorOrNoneIfError =
       ::MantidQt::CustomInterfaces::ISISReflectometry::parseScaleFactor(cellText[SCALE_COLUMN]);
-  if (!optionalScaleFactorOrNoneIfError.is_initialized())
+  if (!optionalScaleFactorOrNoneIfError.has_value())
     m_invalidColumns.emplace_back(SCALE_COLUMN);
 
   return optionalScaleFactorOrNoneIfError;
 }
 
-boost::optional<std::map<std::string, std::string>>
+std::optional<std::map<std::string, std::string>>
 RowValidator::parseOptions(std::vector<std::string> const &cellText) {
   auto options = ::MantidQt::CustomInterfaces::ISISReflectometry::parseOptions(cellText[OPTIONS_COLUMN]);
-  if (!options.is_initialized())
+  if (!options.has_value())
     m_invalidColumns.emplace_back(OPTIONS_COLUMN);
   return options;
 }
@@ -105,12 +105,12 @@ ValidationResult<Row, std::vector<int>> RowValidator::operator()(std::vector<std
   auto maybeOptions = parseOptions(cellText);
 
   if (allInitialized(maybeRunNumbers, maybeTransmissionRuns)) {
-    auto wsNames = workspaceNames(maybeRunNumbers.get(), maybeTransmissionRuns.get());
+    auto wsNames = workspaceNames(maybeRunNumbers.value(), maybeTransmissionRuns.value());
     auto maybeRow =
         makeIfAllInitialized<Row>(maybeRunNumbers, maybeTheta, maybeTransmissionRuns, maybeQRange, maybeScaleFactor,
-                                  maybeOptions, boost::optional<ReductionWorkspaces>(wsNames));
-    if (maybeRow.is_initialized())
-      return RowValidationResult(maybeRow.get());
+                                  maybeOptions, std::optional<ReductionWorkspaces>(wsNames));
+    if (maybeRow.has_value())
+      return RowValidationResult(maybeRow.value());
     else
       return RowValidationResult(m_invalidColumns);
   } else {
@@ -124,7 +124,7 @@ RowValidationResult validateRow(std::vector<std::string> const &cells) {
   return result;
 }
 
-boost::optional<Row> validateRowFromRunAndTheta(std::string const &run, std::string const &theta) {
+std::optional<Row> validateRowFromRunAndTheta(std::string const &run, std::string const &theta) {
   std::vector<std::string> cells = {run, theta, "", "", "", "", "", "", ""};
   return validateRow(cells).validElseNone();
 }

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/ValidateRow.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/ValidateRow.h
@@ -11,7 +11,7 @@
 #include "Reduction/ReductionJobs.h"
 #include "Row.h"
 #include "TransmissionRunPair.h"
-#include <boost/optional.hpp>
+#include <optional>
 namespace MantidQt {
 namespace CustomInterfaces {
 namespace ISISReflectometry {
@@ -26,12 +26,12 @@ public:
   ValidationResult<Row, std::vector<int>> operator()(std::vector<std::string> const &cellText);
 
 private:
-  boost::optional<std::vector<std::string>> parseRunNumbers(std::vector<std::string> const &cellText);
-  boost::optional<double> parseTheta(std::vector<std::string> const &cellText);
-  boost::optional<TransmissionRunPair> parseTransmissionRuns(std::vector<std::string> const &cellText);
-  boost::optional<RangeInQ> parseQRange(std::vector<std::string> const &cellText);
-  boost::optional<boost::optional<double>> parseScaleFactor(std::vector<std::string> const &cellText);
-  boost::optional<std::map<std::string, std::string>> parseOptions(std::vector<std::string> const &cellText);
+  std::optional<std::vector<std::string>> parseRunNumbers(std::vector<std::string> const &cellText);
+  std::optional<double> parseTheta(std::vector<std::string> const &cellText);
+  std::optional<TransmissionRunPair> parseTransmissionRuns(std::vector<std::string> const &cellText);
+  std::optional<RangeInQ> parseQRange(std::vector<std::string> const &cellText);
+  std::optional<std::optional<double>> parseScaleFactor(std::vector<std::string> const &cellText);
+  std::optional<std::map<std::string, std::string>> parseOptions(std::vector<std::string> const &cellText);
 
   std::vector<int> m_invalidColumns;
 };
@@ -40,7 +40,7 @@ using RowValidationResult = ValidationResult<Row, std::vector<int>>;
 
 RowValidationResult validateRow(std::vector<std::string> const &cellText);
 
-boost::optional<Row> validateRowFromRunAndTheta(std::string const &run, std::string const &theta);
+std::optional<Row> validateRowFromRunAndTheta(std::string const &run, std::string const &theta);
 } // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt

--- a/qt/scientific_interfaces/ISISReflectometry/TestHelpers/ModelCreationHelper.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/TestHelpers/ModelCreationHelper.cpp
@@ -14,7 +14,7 @@ namespace MantidQt::CustomInterfaces::ISISReflectometry::ModelCreationHelper {
 
 namespace { // unnamed
 Row makeRowWithOutputNames(std::vector<std::string> const &outputNames) {
-  auto row = Row({}, 0.0, TransmissionRunPair(), RangeInQ(), boost::none, ReductionOptionsMap(),
+  auto row = Row({}, 0.0, TransmissionRunPair(), RangeInQ(), std::nullopt, ReductionOptionsMap(),
                  ReductionWorkspaces({}, TransmissionRunPair()));
   row.setOutputNames(outputNames);
   return row;
@@ -24,40 +24,40 @@ Row makeRowWithOutputNames(std::vector<std::string> const &outputNames) {
 /* Rows */
 
 Row makeEmptyRow() {
-  return Row({}, 0.0, TransmissionRunPair(), RangeInQ(), boost::none, ReductionOptionsMap(),
+  return Row({}, 0.0, TransmissionRunPair(), RangeInQ(), std::nullopt, ReductionOptionsMap(),
              ReductionWorkspaces({}, TransmissionRunPair()));
 }
 
 Row makeRow(double theta) {
-  return Row({}, theta, TransmissionRunPair({"22348", "22349"}), RangeInQ(), boost::none, ReductionOptionsMap(),
+  return Row({}, theta, TransmissionRunPair({"22348", "22349"}), RangeInQ(), std::nullopt, ReductionOptionsMap(),
              ReductionWorkspaces({}, TransmissionRunPair()));
 }
 
 Row makeRow(std::string const &run, double theta) {
-  return Row({run}, theta, TransmissionRunPair({"Trans A", "Trans B"}), RangeInQ(), boost::none, ReductionOptionsMap(),
+  return Row({run}, theta, TransmissionRunPair({"Trans A", "Trans B"}), RangeInQ(), std::nullopt, ReductionOptionsMap(),
              ReductionWorkspaces({run}, TransmissionRunPair({"Trans A", "Trans B"})));
 }
 
 Row makeSimpleRow(std::string const &run, double theta) {
-  return Row({run}, theta, TransmissionRunPair(), RangeInQ(), boost::none, ReductionOptionsMap(),
+  return Row({run}, theta, TransmissionRunPair(), RangeInQ(), std::nullopt, ReductionOptionsMap(),
              ReductionWorkspaces({run}, TransmissionRunPair()));
 }
 
 Row makeRow(std::string const &run, double theta, std::string const &trans1, std::string const &trans2,
-            boost::optional<double> qMin, boost::optional<double> qMax, boost::optional<double> qStep,
-            boost::optional<double> scale, ReductionOptionsMap const &optionsMap) {
+            std::optional<double> qMin, std::optional<double> qMax, std::optional<double> qStep,
+            std::optional<double> scale, ReductionOptionsMap const &optionsMap) {
   return Row({run}, theta, TransmissionRunPair({trans1, trans2}),
              RangeInQ(std::move(qMin), std::move(qMax), std::move(qStep)), std::move(scale), optionsMap,
              ReductionWorkspaces({run}, TransmissionRunPair({trans1, trans2})));
 }
 
 Row makeRow(std::vector<std::string> const &runs, double theta) {
-  return Row(runs, theta, TransmissionRunPair({"Trans A", "Trans B"}), RangeInQ(), boost::none, ReductionOptionsMap(),
+  return Row(runs, theta, TransmissionRunPair({"Trans A", "Trans B"}), RangeInQ(), std::nullopt, ReductionOptionsMap(),
              ReductionWorkspaces(runs, TransmissionRunPair({"Trans A", "Trans B"})));
 }
 
 Row makeCompletedRow() {
-  auto row = Row({}, 0.0, TransmissionRunPair(), RangeInQ(), boost::none, ReductionOptionsMap(),
+  auto row = Row({}, 0.0, TransmissionRunPair(), RangeInQ(), std::nullopt, ReductionOptionsMap(),
                  ReductionWorkspaces({}, TransmissionRunPair()));
   row.setSuccess();
   return row;
@@ -69,7 +69,7 @@ Row makeRowWithMainCellsFilled(double theta) {
 }
 
 Row makeRowWithOptionsCellFilled(double theta, ReductionOptionsMap options) {
-  return Row({}, theta, TransmissionRunPair(), RangeInQ(), boost::none, std::move(options),
+  return Row({}, theta, TransmissionRunPair(), RangeInQ(), std::nullopt, std::move(options),
              ReductionWorkspaces({}, TransmissionRunPair()));
 }
 
@@ -79,32 +79,32 @@ Group makeEmptyGroup() { return Group("Test group 1"); }
 
 Group makeGroupWithOneRow() {
   return Group("single_row_group",
-               std::vector<boost::optional<Row>>{makeRowWithOutputNames({"IvsLam", "IvsQ", "IvsQBin"})});
+               std::vector<std::optional<Row>>{makeRowWithOutputNames({"IvsLam", "IvsQ", "IvsQBin"})});
 }
 
 Group makeGroupWithTwoRows() {
   return Group("multi_row_group",
-               std::vector<boost::optional<Row>>{makeRowWithOutputNames({"IvsLam_1", "IvsQ_1", "IvsQ_binned_1"}),
+               std::vector<std::optional<Row>>{makeRowWithOutputNames({"IvsLam_1", "IvsQ_1", "IvsQ_binned_1"}),
                                                  makeRowWithOutputNames({"IvsLam_2", "IvsQ_2", "IvsQ_binned_2"})});
 }
 
 Group makeGroupWithTwoRowsWithDifferentAngles() {
-  return Group("multi_angle_group", std::vector<boost::optional<Row>>{makeRow("12345", 0.2), makeRow("12346", 0.9)});
+  return Group("multi_angle_group", std::vector<std::optional<Row>>{makeRow("12345", 0.2), makeRow("12346", 0.9)});
 }
 
 Group makeGroupWithTwoRowsWithNonstandardNames() {
   return Group("multi_row_group",
-               std::vector<boost::optional<Row>>{makeRowWithOutputNames({"testLam1", "testQ1", "testQBin1"}),
+               std::vector<std::optional<Row>>{makeRowWithOutputNames({"testLam1", "testQ1", "testQBin1"}),
                                                  makeRowWithOutputNames({"testLam2", "testQ2", "testQBin2"})});
 }
 
 Group makeGroupWithTwoRowsWithMixedQResolutions() {
   auto group1 = Group("Test group 1");
-  group1.appendRow(boost::none);
+  group1.appendRow(std::nullopt);
   group1.appendRow(makeRow());
-  group1.appendRow(Row({"22222"}, 0.5, TransmissionRunPair({}), RangeInQ(0.5, 0.015, 0.9), boost::none,
+  group1.appendRow(Row({"22222"}, 0.5, TransmissionRunPair({}), RangeInQ(0.5, 0.015, 0.9), std::nullopt,
                        ReductionOptionsMap(), ReductionWorkspaces({"22222"}, TransmissionRunPair({}))));
-  group1.appendRow(Row({"33333"}, 0.5, TransmissionRunPair({}), RangeInQ(0.5, 0.016, 0.9), boost::none,
+  group1.appendRow(Row({"33333"}, 0.5, TransmissionRunPair({}), RangeInQ(0.5, 0.016, 0.9), std::nullopt,
                        ReductionOptionsMap(), ReductionWorkspaces({"33333"}, TransmissionRunPair({}))));
   return group1;
 }
@@ -112,9 +112,9 @@ Group makeGroupWithTwoRowsWithMixedQResolutions() {
 Group makeGroupWithTwoRowsWithOutputQResolutions() {
   auto group1 = Group("Test group 1");
   group1.appendRow(makeRow());
-  group1.appendRow(Row({"22222"}, 0.5, TransmissionRunPair({}), RangeInQ(), boost::none, ReductionOptionsMap(),
+  group1.appendRow(Row({"22222"}, 0.5, TransmissionRunPair({}), RangeInQ(), std::nullopt, ReductionOptionsMap(),
                        ReductionWorkspaces({"22222"}, TransmissionRunPair({}))));
-  auto row = Row({"33333"}, 0.5, TransmissionRunPair({}), RangeInQ(), boost::none, ReductionOptionsMap(),
+  auto row = Row({"33333"}, 0.5, TransmissionRunPair({}), RangeInQ(), std::nullopt, ReductionOptionsMap(),
                  ReductionWorkspaces({"33333"}, TransmissionRunPair({})));
   row.setOutputQRange(RangeInQ(0.5, 0.016, 0.9));
   group1.appendRow(row);
@@ -139,7 +139,7 @@ ReductionJobs twoEmptyGroupsModel() {
 ReductionJobs oneGroupWithAnInvalidRowModel() {
   auto reductionJobs = ReductionJobs();
   auto group1 = Group("Test group 1");
-  group1.appendRow(boost::none);
+  group1.appendRow(std::nullopt);
   reductionJobs.appendGroup(group1);
   return reductionJobs;
 }
@@ -155,7 +155,7 @@ ReductionJobs oneGroupWithARowModel() {
 ReductionJobs oneGroupWithARowWithInputQRangeModel() {
   auto reductionJobs = ReductionJobs();
   auto group1 = Group("Test group 1");
-  auto row = Row({"12345"}, 0.5, TransmissionRunPair({"Trans A", "Trans B"}), RangeInQ(0.5, 0.01, 0.9), boost::none,
+  auto row = Row({"12345"}, 0.5, TransmissionRunPair({"Trans A", "Trans B"}), RangeInQ(0.5, 0.01, 0.9), std::nullopt,
                  ReductionOptionsMap(), ReductionWorkspaces({"12345"}, TransmissionRunPair({"Trans A", "Trans B"})));
   group1.appendRow(row);
   reductionJobs.appendGroup(group1);
@@ -176,7 +176,7 @@ ReductionJobs oneGroupWithARowWithInputQRangeModelMixedPrecision() {
   auto reductionJobs = ReductionJobs();
   auto group1 = Group("Test group 1");
   auto row =
-      Row({"12345"}, 0.555555, TransmissionRunPair({"Trans A", "Trans B"}), RangeInQ(0.55567, 0.012, 0.9), boost::none,
+      Row({"12345"}, 0.555555, TransmissionRunPair({"Trans A", "Trans B"}), RangeInQ(0.55567, 0.012, 0.9), std::nullopt,
           ReductionOptionsMap(), ReductionWorkspaces({"12345"}, TransmissionRunPair({"Trans A", "Trans B"})));
   group1.appendRow(row);
   reductionJobs.appendGroup(group1);
@@ -281,12 +281,12 @@ ReductionJobs twoGroupsWithTwoRowsAndOneEmptyGroupModel() {
 ReductionJobs twoGroupsWithOneRowAndOneInvalidRowModel() {
   auto reductionJobs = ReductionJobs();
   auto group1 = Group("Test group 1");
-  group1.appendRow(boost::none);
+  group1.appendRow(std::nullopt);
   reductionJobs.appendGroup(std::move(group1));
 
   auto group2 = Group("Test group 2");
   group2.appendRow(makeRow("22345", 0.5));
-  group2.appendRow(boost::none);
+  group2.appendRow(std::nullopt);
   reductionJobs.appendGroup(std::move(group2));
 
   return reductionJobs;
@@ -300,7 +300,7 @@ ReductionJobs oneGroupWithOneRowAndOneGroupWithOneRowAndOneInvalidRowModel() {
 
   auto group2 = Group("Test group 2");
   group2.appendRow(makeRow("22345", 0.5));
-  group2.appendRow(boost::none);
+  group2.appendRow(std::nullopt);
   reductionJobs.appendGroup(std::move(group2));
 
   return reductionJobs;
@@ -310,7 +310,7 @@ ReductionJobs twoGroupsWithMixedRowsModel() {
   auto reductionJobs = ReductionJobs();
   auto group1 = Group("Test group 1");
   group1.appendRow(makeRow("12345", 0.5));
-  group1.appendRow(boost::none);
+  group1.appendRow(std::nullopt);
   group1.appendRow(makeRow("12346", 0.8));
   reductionJobs.appendGroup(std::move(group1));
 
@@ -342,19 +342,19 @@ ReductionJobs oneGroupWithTwoRowsWithOutputNamesModel() {
 /* Experiment */
 
 LookupTable makeLookupTable() {
-  auto lookupRow = LookupRow(boost::none, TransmissionRunPair(), boost::none,
-                             RangeInQ(boost::none, boost::none, boost::none), boost::none, boost::none, boost::none);
+  auto lookupRow = LookupRow(std::nullopt, TransmissionRunPair(), std::nullopt,
+                             RangeInQ(std::nullopt, std::nullopt, std::nullopt), std::nullopt, std::nullopt, std::nullopt);
   return LookupTable{std::move(lookupRow)};
 }
 
 LookupTable makeLookupTableWithTwoAnglesAndWildcard() {
   return LookupTable{
       // wildcard row with no angle
-      LookupRow(boost::none, TransmissionRunPair("22345", "22346"), ProcessingInstructions("5-6"),
+      LookupRow(std::nullopt, TransmissionRunPair("22345", "22346"), ProcessingInstructions("5-6"),
                 RangeInQ(0.007, 0.01, 1.1), 0.7, ProcessingInstructions("1"), ProcessingInstructions("3,7")),
       // two angle rows
-      LookupRow(0.5, TransmissionRunPair("22347", ""), boost::none, RangeInQ(0.008, 0.02, 1.2), 0.8,
-                ProcessingInstructions("2-3"), boost::none),
+      LookupRow(0.5, TransmissionRunPair("22347", ""), std::nullopt, RangeInQ(0.008, 0.02, 1.2), 0.8,
+                ProcessingInstructions("2-3"), std::nullopt),
       LookupRow(
           2.3,
           TransmissionRunPair(std::vector<std::string>{"22348", "22349"}, std::vector<std::string>{"22358", "22359"}),
@@ -384,7 +384,7 @@ PolarizationCorrections makeEmptyPolarizationCorrections() {
 }
 
 FloodCorrections makeFloodCorrections() {
-  return FloodCorrections(FloodCorrectionType::Workspace, boost::optional<std::string>("test_workspace"));
+  return FloodCorrections(FloodCorrectionType::Workspace, std::optional<std::string>("test_workspace"));
 }
 
 TransmissionStitchOptions makeTransmissionStitchOptions() {

--- a/qt/scientific_interfaces/ISISReflectometry/TestHelpers/ModelCreationHelper.h
+++ b/qt/scientific_interfaces/ISISReflectometry/TestHelpers/ModelCreationHelper.h
@@ -25,10 +25,10 @@ MANTIDQT_ISISREFLECTOMETRY_DLL Row makeRow(double theta = 0.5);
 MANTIDQT_ISISREFLECTOMETRY_DLL Row makeRow(std::string const &run, double theta = 0.5);
 MANTIDQT_ISISREFLECTOMETRY_DLL Row makeSimpleRow(std::string const &run, double theta = 0.5);
 MANTIDQT_ISISREFLECTOMETRY_DLL Row makeRow(std::string const &run, double theta, std::string const &trans1,
-                                           std::string const &trans2, boost::optional<double> qMin = boost::none,
-                                           boost::optional<double> qMax = boost::none,
-                                           boost::optional<double> qStep = boost::none,
-                                           boost::optional<double> scale = boost::none,
+                                           std::string const &trans2, std::optional<double> qMin = std::nullopt,
+                                           std::optional<double> qMax = std::nullopt,
+                                           std::optional<double> qStep = std::nullopt,
+                                           std::optional<double> scale = std::nullopt,
                                            ReductionOptionsMap const &optionsMap = ReductionOptionsMap());
 MANTIDQT_ISISREFLECTOMETRY_DLL Row makeRow(std::vector<std::string> const &runs, double theta = 0.5);
 MANTIDQT_ISISREFLECTOMETRY_DLL Row makeRowWithMainCellsFilled(double theta = 0.5);

--- a/qt/scientific_interfaces/ISISReflectometry/test/Batch/BatchJobManagerTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Batch/BatchJobManagerTest.h
@@ -90,7 +90,7 @@ protected:
 
   Row *getRow(BatchJobManagerFriend &jobManager, int groupIndex, int rowIndex) {
     auto &reductionJobs = jobManager.m_batch.mutableRunsTable().mutableReductionJobs();
-    auto *row = &reductionJobs.mutableGroups()[groupIndex].mutableRows()[rowIndex].get();
+    auto *row = &reductionJobs.mutableGroups()[groupIndex].mutableRows()[rowIndex].value();
     return row;
   }
 

--- a/qt/scientific_interfaces/ISISReflectometry/test/Batch/BatchPresenterTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Batch/BatchPresenterTest.h
@@ -334,7 +334,7 @@ public:
     auto presenter = makePresenter();
     IConfiguredAlgorithm_sptr algorithm = std::make_shared<MockBatchJobAlgorithm>();
     auto row = makeRow();
-    EXPECT_CALL(*m_jobManager, getRunsTableItem(algorithm)).Times(1).WillOnce(Return(row));
+    EXPECT_CALL(*m_jobManager, getRunsTableItem(algorithm)).Times(1).WillOnce(Return(&row));
     EXPECT_CALL(*m_jobManager, algorithmStarted(algorithm)).Times(1);
     EXPECT_CALL(*m_runsPresenter, notifyRowOutputsChanged(_)).Times(1);
     EXPECT_CALL(*m_runsPresenter, notifyRowStateChanged(_)).Times(1);
@@ -346,7 +346,7 @@ public:
     auto presenter = makePresenter();
     IConfiguredAlgorithm_sptr algorithm = std::make_shared<MockBatchJobAlgorithm>();
     auto row = makeRow();
-    EXPECT_CALL(*m_jobManager, getRunsTableItem(algorithm)).Times(1).WillOnce(Return(row));
+    EXPECT_CALL(*m_jobManager, getRunsTableItem(algorithm)).Times(1).WillOnce(Return(&row));
     EXPECT_CALL(*m_jobManager, algorithmComplete(algorithm)).Times(1);
     EXPECT_CALL(*m_runsPresenter, notifyRowOutputsChanged(_)).Times(1);
     EXPECT_CALL(*m_runsPresenter, notifyRowStateChanged(_)).Times(1);
@@ -357,7 +357,7 @@ public:
   void testNotifyAlgorithmStartedSkipsNonItems() {
     auto presenter = makePresenter();
     IConfiguredAlgorithm_sptr algorithm = std::make_shared<MockBatchJobAlgorithm>();
-    EXPECT_CALL(*m_jobManager, getRunsTableItem(algorithm)).Times(1).WillOnce(Return(boost::none));
+    EXPECT_CALL(*m_jobManager, getRunsTableItem(algorithm)).Times(1).WillOnce(Return(nullptr));
     EXPECT_CALL(*m_jobManager, algorithmStarted(_)).Times(0);
     EXPECT_CALL(*m_runsPresenter, notifyRowOutputsChanged(_)).Times(0);
     EXPECT_CALL(*m_runsPresenter, notifyRowStateChanged(_)).Times(0);
@@ -368,7 +368,7 @@ public:
   void testNotifyAlgorithmCompleteSkipsNonItems() {
     auto presenter = makePresenter();
     IConfiguredAlgorithm_sptr algorithm = std::make_shared<MockBatchJobAlgorithm>();
-    EXPECT_CALL(*m_jobManager, getRunsTableItem(algorithm)).Times(1).WillOnce(Return(boost::none));
+    EXPECT_CALL(*m_jobManager, getRunsTableItem(algorithm)).Times(1).WillOnce(Return(nullptr));
     EXPECT_CALL(*m_jobManager, algorithmComplete(_)).Times(0);
     EXPECT_CALL(*m_runsPresenter, notifyRowOutputsChanged(_)).Times(0);
     EXPECT_CALL(*m_runsPresenter, notifyRowStateChanged(_)).Times(0);
@@ -379,7 +379,7 @@ public:
   void testNotifyAlgorithmErrorSkipsNonItems() {
     auto presenter = makePresenter();
     IConfiguredAlgorithm_sptr algorithm = std::make_shared<MockBatchJobAlgorithm>();
-    EXPECT_CALL(*m_jobManager, getRunsTableItem(algorithm)).Times(1).WillOnce(Return(boost::none));
+    EXPECT_CALL(*m_jobManager, getRunsTableItem(algorithm)).Times(1).WillOnce(Return(nullptr));
     EXPECT_CALL(*m_jobManager, algorithmError(_, _)).Times(0);
     EXPECT_CALL(*m_runsPresenter, notifyRowOutputsChanged(_)).Times(0);
     EXPECT_CALL(*m_runsPresenter, notifyRowStateChanged(_)).Times(0);
@@ -393,7 +393,7 @@ public:
     EXPECT_CALL(*m_savePresenter, shouldAutosave()).Times(1).WillOnce(Return(true));
     auto const workspaces = std::vector<std::string>{"test1", "test2"};
     auto row = makeRow();
-    EXPECT_CALL(*m_jobManager, getRunsTableItem(algorithm)).Times(1).WillOnce(Return(row));
+    EXPECT_CALL(*m_jobManager, getRunsTableItem(algorithm)).Times(1).WillOnce(Return(&row));
     EXPECT_CALL(*m_jobManager, algorithmComplete(algorithm)).Times(1);
     EXPECT_CALL(*m_jobManager, algorithmOutputWorkspacesToSave(algorithm)).Times(1).WillOnce(Return(workspaces));
     EXPECT_CALL(*m_savePresenter, saveWorkspaces(workspaces)).Times(1);
@@ -406,7 +406,7 @@ public:
     IConfiguredAlgorithm_sptr algorithm = std::make_shared<MockBatchJobAlgorithm>();
     EXPECT_CALL(*m_savePresenter, shouldAutosave()).Times(1).WillOnce(Return(false));
     auto row = makeRow();
-    EXPECT_CALL(*m_jobManager, getRunsTableItem(algorithm)).Times(1).WillOnce(Return(row));
+    EXPECT_CALL(*m_jobManager, getRunsTableItem(algorithm)).Times(1).WillOnce(Return(&row));
     EXPECT_CALL(*m_jobManager, algorithmComplete(algorithm)).Times(1);
     EXPECT_CALL(*m_jobManager, algorithmOutputWorkspacesToSave(_)).Times(0);
     EXPECT_CALL(*m_savePresenter, saveWorkspaces(_)).Times(0);
@@ -419,7 +419,7 @@ public:
     IConfiguredAlgorithm_sptr algorithm = std::make_shared<MockBatchJobAlgorithm>();
     auto const errorMessage = std::string("test error");
     auto row = makeRow();
-    EXPECT_CALL(*m_jobManager, getRunsTableItem(algorithm)).Times(1).WillOnce(Return(row));
+    EXPECT_CALL(*m_jobManager, getRunsTableItem(algorithm)).Times(1).WillOnce(Return(&row));
     EXPECT_CALL(*m_jobManager, algorithmError(algorithm, errorMessage)).Times(1);
     EXPECT_CALL(*m_runsPresenter, notifyRowStateChanged(_)).Times(1);
     EXPECT_CALL(*m_runsPresenter, notifyRowOutputsChanged(_)).Times(1);

--- a/qt/scientific_interfaces/ISISReflectometry/test/Common/ClipboardTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Common/ClipboardTest.h
@@ -92,7 +92,7 @@ public:
   void testCreateRowsForAllRootsSucceeds() {
     auto clipboard = clipboardWithARow();
     auto result = clipboard.createRowsForAllRoots();
-    auto expected = std::vector<boost::optional<Row>>{makeRow("12345", 0.5)};
+    auto expected = std::vector<std::optional<Row>>{makeRow("12345", 0.5)};
     TS_ASSERT_EQUALS(result, expected);
   }
 

--- a/qt/scientific_interfaces/ISISReflectometry/test/Common/CoderCommonTester.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Common/CoderCommonTester.h
@@ -153,24 +153,24 @@ private:
     }
   }
 
-  void testRow(const boost::optional<MantidQt::CustomInterfaces::ISISReflectometry::Row> &row,
+  void testRow(const std::optional<MantidQt::CustomInterfaces::ISISReflectometry::Row> &row,
                const QMap<QString, QVariant> &map) {
     if (row) {
-      auto runNumbers = row.get().runNumbers();
+      auto runNumbers = row.value().runNumbers();
       auto runNumbersVariants = map[QString("runNumbers")].toList();
       for (auto index = 0u; index < runNumbers.size(); ++index) {
         TS_ASSERT_EQUALS(runNumbers[index], runNumbersVariants[index].toString().toStdString());
       }
-      TS_ASSERT_EQUALS(row.get().theta(), map[QString("theta")].toDouble())
-      testRangeInQ(row.get().qRange(), map[QString("qRange")].toMap());
-      auto scaleFactorPresent = static_cast<bool>(row.get().scaleFactor());
+      TS_ASSERT_EQUALS(row.value().theta(), map[QString("theta")].toDouble())
+      testRangeInQ(row.value().qRange(), map[QString("qRange")].toMap());
+      auto scaleFactorPresent = static_cast<bool>(row.value().scaleFactor());
       TS_ASSERT_EQUALS(scaleFactorPresent, map[QString("scaleFactorPresent")].toBool());
       if (scaleFactorPresent) {
-        TS_ASSERT_EQUALS(row.get().scaleFactor().get(), map[QString("scaleFactor")].toDouble())
+        TS_ASSERT_EQUALS(row.value().scaleFactor().value(), map[QString("scaleFactor")].toDouble())
       }
-      testTransmissionRunPair(row.get().transmissionWorkspaceNames(), map[QString("transRunNums")].toMap());
-      testReductionWorkspaces(row.get().reducedWorkspaceNames(), map[QString("reductionWorkspaces")].toMap());
-      testReductionOptions(row.get().reductionOptions(), map[QString("reductionOptions")].toMap());
+      testTransmissionRunPair(row.value().transmissionWorkspaceNames(), map[QString("transRunNums")].toMap());
+      testReductionWorkspaces(row.value().reducedWorkspaceNames(), map[QString("reductionWorkspaces")].toMap());
+      testReductionOptions(row.value().reductionOptions(), map[QString("reductionOptions")].toMap());
     } else {
       // Row is an empty boost optional so map size should be 0
       TS_ASSERT_EQUALS(0, map.size())
@@ -185,11 +185,11 @@ private:
     TS_ASSERT_EQUALS(static_cast<bool>(max), map[QString("maxPresent")].toBool())
     TS_ASSERT_EQUALS(static_cast<bool>(step), map[QString("stepPresent")].toBool())
     if (min)
-      TS_ASSERT_EQUALS(min.get(), map[QString("min")].toDouble())
+      TS_ASSERT_EQUALS(min.value(), map[QString("min")].toDouble())
     if (max)
-      TS_ASSERT_EQUALS(max.get(), map[QString("max")].toDouble())
+      TS_ASSERT_EQUALS(max.value(), map[QString("max")].toDouble())
     if (step)
-      TS_ASSERT_EQUALS(step.get(), map[QString("step")].toDouble())
+      TS_ASSERT_EQUALS(step.value(), map[QString("step")].toDouble())
   }
 
   void testTransmissionRunPair(const TransmissionRunPair &pair, const QMap<QString, QVariant> &map) {

--- a/qt/scientific_interfaces/ISISReflectometry/test/Experiment/ExperimentOptionDefaultsTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Experiment/ExperimentOptionDefaultsTest.h
@@ -72,15 +72,16 @@ public:
 
   void testDefaultLookupRowOptions() {
     auto result = getDefaults();
-    auto expected = LookupRow(boost::none, TransmissionRunPair(), boost::none,
-                              RangeInQ(boost::none, boost::none, boost::none), boost::none, boost::none, boost::none);
+    auto expected =
+        LookupRow(std::nullopt, TransmissionRunPair(), std::nullopt, RangeInQ(std::nullopt, std::nullopt, std::nullopt),
+                  std::nullopt, std::nullopt, std::nullopt);
     TS_ASSERT_EQUALS(result.lookupTable().size(), 1);
     TS_ASSERT_EQUALS(result.lookupTable().front(), expected);
   }
 
   void testValidLookupRowOptionsFromParamsFile() {
     auto result = getDefaultsFromParamsFile("Experiment");
-    auto expected = LookupRow(boost::none, TransmissionRunPair(), boost::none, RangeInQ(0.01, 0.03, 0.2), 0.7,
+    auto expected = LookupRow(std::nullopt, TransmissionRunPair(), std::nullopt, RangeInQ(0.01, 0.03, 0.2), 0.7,
                               std::string("390-415"), std::string("370-389,416-430"));
     TS_ASSERT_EQUALS(result.lookupTable().size(), 1);
     TS_ASSERT_EQUALS(result.lookupTable().front(), expected);

--- a/qt/scientific_interfaces/ISISReflectometry/test/Experiment/ExperimentPresenterTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Experiment/ExperimentPresenterTest.h
@@ -219,7 +219,7 @@ public:
     FloodCorrections floodCorr(FloodCorrectionType::Workspace, std::string{"testWS"});
 
     EXPECT_CALL(m_view, getFloodCorrectionType()).WillOnce(Return("Workspace"));
-    EXPECT_CALL(m_view, getFloodWorkspace()).WillOnce(Return(floodCorr.workspace().get()));
+    EXPECT_CALL(m_view, getFloodWorkspace()).WillOnce(Return(floodCorr.workspace().value()));
     presenter.notifySettingsChanged();
 
     TS_ASSERT_EQUALS(presenter.experiment().floodCorrections(), floodCorr);
@@ -257,7 +257,7 @@ public:
 
   void testTransmissionRunRangeIsValidButNotUpdatedIfUnset() {
     RangeInLambda range(0.0, 0.0);
-    runTestForValidTransmissionRunRange(range, boost::none);
+    runTestForValidTransmissionRunRange(range, std::nullopt);
   }
 
   void testTransmissionParamsAreValidWithPositiveValue() { runTestForValidTransmissionParams("0.02"); }
@@ -557,7 +557,7 @@ public:
   }
 
   void testInstrumentChangedUpdatesLookupRowInView() {
-    auto lookupRow = LookupRow(boost::none, TransmissionRunPair(), boost::none, RangeInQ(0.01, 0.03, 0.2), 0.7,
+    auto lookupRow = LookupRow(std::nullopt, TransmissionRunPair(), std::nullopt, RangeInQ(0.01, 0.03, 0.2), 0.7,
                                std::string("390-415"), std::string("370-389,416-430"));
     auto model = makeModelWithLookupRow(std::move(lookupRow));
     auto defaultOptions = expectDefaults(model);
@@ -571,12 +571,12 @@ public:
 
   void testInstrumentChangedUpdatesLookupRowInModel() {
     auto model =
-        makeModelWithLookupRow(LookupRow(boost::none, TransmissionRunPair(), boost::none, RangeInQ(0.01, 0.03, 0.2),
+        makeModelWithLookupRow(LookupRow(std::nullopt, TransmissionRunPair(), std::nullopt, RangeInQ(0.01, 0.03, 0.2),
                                          0.7, std::string("390-415"), std::string("370-389,416-430")));
     auto defaultOptions = expectDefaults(model);
     auto presenter = makePresenter(std::move(defaultOptions));
     presenter.notifyInstrumentChanged("POLREF");
-    auto expected = LookupRow(boost::none, TransmissionRunPair(), boost::none, RangeInQ(0.01, 0.03, 0.2), 0.7,
+    auto expected = LookupRow(std::nullopt, TransmissionRunPair(), std::nullopt, RangeInQ(0.01, 0.03, 0.2), 0.7,
                               std::string("390-415"), std::string("370-389,416-430"));
     TS_ASSERT_EQUALS(presenter.experiment().lookupTable().size(), 1);
     TS_ASSERT_EQUALS(presenter.experiment().lookupTable().front(), expected);
@@ -819,7 +819,7 @@ private:
     verifyAndClear();
   }
 
-  void runTestForValidTransmissionRunRange(RangeInLambda const &range, boost::optional<RangeInLambda> const &result) {
+  void runTestForValidTransmissionRunRange(RangeInLambda const &range, std::optional<RangeInLambda> const &result) {
     auto presenter = makePresenter();
     EXPECT_CALL(m_view, getTransmissionStartOverlap()).WillOnce(Return(range.min()));
     EXPECT_CALL(m_view, getTransmissionEndOverlap()).WillOnce(Return(range.max()));
@@ -835,7 +835,7 @@ private:
     EXPECT_CALL(m_view, getTransmissionEndOverlap()).WillOnce(Return(range.max()));
     EXPECT_CALL(m_view, showTransmissionRangeInvalid()).Times(1);
     presenter.notifySettingsChanged();
-    TS_ASSERT_EQUALS(presenter.experiment().transmissionStitchOptions().overlapRange(), boost::none);
+    TS_ASSERT_EQUALS(presenter.experiment().transmissionStitchOptions().overlapRange(), std::nullopt);
     verifyAndClear();
   }
 
@@ -843,14 +843,14 @@ private:
   // either as an input array of strings or an output model
   OptionsRow optionsRowWithFirstAngle() { return {"0.5", "13463", ""}; }
   LookupRow defaultsWithFirstAngle() {
-    return LookupRow(0.5, TransmissionRunPair("13463", ""), boost::none, RangeInQ(), boost::none, boost::none,
-                     boost::none);
+    return LookupRow(0.5, TransmissionRunPair("13463", ""), std::nullopt, RangeInQ(), std::nullopt, std::nullopt,
+                     std::nullopt);
   }
 
   OptionsRow optionsRowWithSecondAngle() { return {"2.3", "13463", "13464"}; }
   LookupRow defaultsWithSecondAngle() {
-    return LookupRow(2.3, TransmissionRunPair("13463", "13464"), boost::none, RangeInQ(), boost::none, boost::none,
-                     boost::none);
+    return LookupRow(2.3, TransmissionRunPair("13463", "13464"), std::nullopt, RangeInQ(), std::nullopt, std::nullopt,
+                     std::nullopt);
   }
   OptionsRow optionsRowWithWildcard() { return {"", "13463", "13464"}; }
   OptionsRow optionsRowWithFirstTransmissionRun() { return {"", "13463"}; }

--- a/qt/scientific_interfaces/ISISReflectometry/test/Experiment/LookupTableValidatorTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Experiment/LookupTableValidatorTest.h
@@ -48,18 +48,18 @@ public:
     auto table = Table({Cells({"0.5"})});
     auto results = runTestValid(table);
     TS_ASSERT_EQUALS(results.size(), 1);
-    TS_ASSERT(results[0].thetaOrWildcard().is_initialized());
-    TS_ASSERT_EQUALS(results[0].thetaOrWildcard().get(), 0.5);
+    TS_ASSERT(results[0].thetaOrWildcard().has_value());
+    TS_ASSERT_EQUALS(results[0].thetaOrWildcard().value(), 0.5);
   }
 
   void testTwoUniqueAngleRows() {
     auto table = Table({Cells({"0.5"}), Cells({"2.3"})});
     auto results = runTestValid(table);
     TS_ASSERT_EQUALS(results.size(), 2);
-    TS_ASSERT(results[0].thetaOrWildcard().is_initialized());
-    TS_ASSERT_EQUALS(results[0].thetaOrWildcard().get(), 0.5);
-    TS_ASSERT(results[1].thetaOrWildcard().is_initialized());
-    TS_ASSERT_EQUALS(results[1].thetaOrWildcard().get(), 2.3);
+    TS_ASSERT(results[0].thetaOrWildcard().has_value());
+    TS_ASSERT_EQUALS(results[0].thetaOrWildcard().value(), 0.5);
+    TS_ASSERT(results[1].thetaOrWildcard().has_value());
+    TS_ASSERT_EQUALS(results[1].thetaOrWildcard().value(), 2.3);
   }
 
   void testTwoNonUniqueAngleRowsIsInvalid() {
@@ -92,8 +92,8 @@ public:
     auto table = Table({Cells({"", "", "", "1-3"})});
     auto results = runTestValid(table);
     TS_ASSERT_EQUALS(results.size(), 1);
-    TS_ASSERT(results[0].transmissionProcessingInstructions().is_initialized());
-    TS_ASSERT_EQUALS(results[0].transmissionProcessingInstructions().get(), "1-3");
+    TS_ASSERT(results[0].transmissionProcessingInstructions().has_value());
+    TS_ASSERT_EQUALS(results[0].transmissionProcessingInstructions().value(), "1-3");
   }
 
   void testInvalidTransmissionProcessingInstructions() {
@@ -130,8 +130,8 @@ public:
     auto table = Table({Cells({"", "", "", "", "", "", "", "", "1-3"})});
     auto results = runTestValid(table);
     TS_ASSERT_EQUALS(results.size(), 1);
-    TS_ASSERT(results[0].processingInstructions().is_initialized());
-    TS_ASSERT_EQUALS(results[0].processingInstructions().get(), "1-3");
+    TS_ASSERT(results[0].processingInstructions().has_value());
+    TS_ASSERT_EQUALS(results[0].processingInstructions().value(), "1-3");
   }
 
   void testInvalidProcessingInstructions() {
@@ -143,8 +143,8 @@ public:
     auto table = Table({Cells({"", "", "", "", "", "", "", "", "", "1-3"})});
     auto results = runTestValid(table);
     TS_ASSERT_EQUALS(results.size(), 1);
-    TS_ASSERT(results[0].backgroundProcessingInstructions().is_initialized());
-    TS_ASSERT_EQUALS(results[0].backgroundProcessingInstructions().get(), "1-3");
+    TS_ASSERT(results[0].backgroundProcessingInstructions().has_value());
+    TS_ASSERT_EQUALS(results[0].backgroundProcessingInstructions().value(), "1-3");
   }
 
   void testInvalidBackgroundProcessingInstructions() {
@@ -156,10 +156,10 @@ public:
     auto table = Table({Cells({"0.5"}), Cells({"0.501"})});
     auto results = runTestValid(table);
     TS_ASSERT_EQUALS(results.size(), 2);
-    TS_ASSERT(results[0].thetaOrWildcard().is_initialized());
-    TS_ASSERT_EQUALS(results[0].thetaOrWildcard().get(), 0.5);
-    TS_ASSERT(results[1].thetaOrWildcard().is_initialized());
-    TS_ASSERT_EQUALS(results[1].thetaOrWildcard().get(), 0.501);
+    TS_ASSERT(results[0].thetaOrWildcard().has_value());
+    TS_ASSERT_EQUALS(results[0].thetaOrWildcard().value(), 0.5);
+    TS_ASSERT(results[1].thetaOrWildcard().has_value());
+    TS_ASSERT_EQUALS(results[1].thetaOrWildcard().value(), 0.501);
   }
 
   void testAnglesThatDifferByLessThanTolerance() {
@@ -200,8 +200,8 @@ private:
     auto result = validator(table, TOLERANCE);
     TS_ASSERT(result.isError());
     auto validationError = result.assertError();
-    TS_ASSERT(validationError.fullTableError().is_initialized());
-    TS_ASSERT_EQUALS(validationError.fullTableError().get(), thetaValuesError);
+    TS_ASSERT(validationError.fullTableError().has_value());
+    TS_ASSERT_EQUALS(validationError.fullTableError().value(), thetaValuesError);
     TS_ASSERT_EQUALS(validationError.errors(), expectedErrors);
   }
 

--- a/qt/scientific_interfaces/ISISReflectometry/test/Instrument/InstrumentPresenterTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Instrument/InstrumentPresenterTest.h
@@ -69,7 +69,7 @@ public:
 
   void testWavelengthRangeIsValidButNotUpdatedIfUnset() {
     auto const range = RangeInLambda(0.0, 0.0);
-    runTestForValidWavelengthRange(range, boost::none);
+    runTestForValidWavelengthRange(range, std::nullopt);
   }
 
   void testIntegratedMonitorsToggled() {
@@ -121,7 +121,7 @@ public:
 
   void testMonitorIntegralRangeIsValidButNotUpdatedIfUnset() {
     auto const range = RangeInLambda(0.0, 0.0);
-    runTestForValidMonitorIntegralRange(range, boost::none);
+    runTestForValidMonitorIntegralRange(range, std::nullopt);
   }
 
   void testSetValidMonitorBackgroundRange() {
@@ -151,7 +151,7 @@ public:
 
   void testMonitorBackgroundRangeIsValidButNotUpdatedIfUnset() {
     auto const range = RangeInLambda(0.0, 0.0);
-    runTestForValidMonitorBackgroundRange(range, boost::none);
+    runTestForValidMonitorBackgroundRange(range, std::nullopt);
   }
 
   void testCorrectDetectorsToggledUpdatesModel() {
@@ -372,7 +372,7 @@ private:
     EXPECT_CALL(m_mainPresenter, isAutoreducing()).Times(1).WillOnce(Return(false));
   }
 
-  void runTestForValidWavelengthRange(RangeInLambda const &range, boost::optional<RangeInLambda> const &result) {
+  void runTestForValidWavelengthRange(RangeInLambda const &range, std::optional<RangeInLambda> const &result) {
     auto presenter = makePresenter();
     EXPECT_CALL(m_view, getLambdaMin()).WillOnce(Return(range.min()));
     EXPECT_CALL(m_view, getLambdaMax()).WillOnce(Return(range.max()));
@@ -388,11 +388,11 @@ private:
     EXPECT_CALL(m_view, getLambdaMax()).WillOnce(Return(range.max()));
     EXPECT_CALL(m_view, showLambdaRangeInvalid()).Times(1);
     presenter.notifySettingsChanged();
-    TS_ASSERT_EQUALS(presenter.instrument().wavelengthRange(), boost::none);
+    TS_ASSERT_EQUALS(presenter.instrument().wavelengthRange(), std::nullopt);
     verifyAndClear();
   }
 
-  void runTestForValidMonitorIntegralRange(RangeInLambda const &range, boost::optional<RangeInLambda> const &result) {
+  void runTestForValidMonitorIntegralRange(RangeInLambda const &range, std::optional<RangeInLambda> const &result) {
     auto presenter = makePresenter();
     EXPECT_CALL(m_view, getMonitorIntegralMin()).WillOnce(Return(range.min()));
     EXPECT_CALL(m_view, getMonitorIntegralMax()).WillOnce(Return(range.max()));
@@ -408,11 +408,11 @@ private:
     EXPECT_CALL(m_view, getMonitorIntegralMax()).WillOnce(Return(range.max()));
     EXPECT_CALL(m_view, showMonitorIntegralRangeInvalid()).Times(1);
     presenter.notifySettingsChanged();
-    TS_ASSERT_EQUALS(presenter.instrument().monitorIntegralRange(), boost::none);
+    TS_ASSERT_EQUALS(presenter.instrument().monitorIntegralRange(), std::nullopt);
     verifyAndClear();
   }
 
-  void runTestForValidMonitorBackgroundRange(RangeInLambda const &range, boost::optional<RangeInLambda> const &result) {
+  void runTestForValidMonitorBackgroundRange(RangeInLambda const &range, std::optional<RangeInLambda> const &result) {
     auto presenter = makePresenter();
     EXPECT_CALL(m_view, getMonitorBackgroundMin()).WillOnce(Return(range.min()));
     EXPECT_CALL(m_view, getMonitorBackgroundMax()).WillOnce(Return(range.max()));
@@ -428,7 +428,7 @@ private:
     EXPECT_CALL(m_view, getMonitorBackgroundMax()).WillOnce(Return(range.max()));
     EXPECT_CALL(m_view, showMonitorBackgroundRangeInvalid()).Times(1);
     presenter.notifySettingsChanged();
-    TS_ASSERT_EQUALS(presenter.instrument().monitorBackgroundRange(), boost::none);
+    TS_ASSERT_EQUALS(presenter.instrument().monitorBackgroundRange(), std::nullopt);
     verifyAndClear();
   }
 };

--- a/qt/scientific_interfaces/ISISReflectometry/test/MainWindow/MockMainWindowPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/MainWindow/MockMainWindowPresenter.h
@@ -25,7 +25,7 @@ public:
   MOCK_CONST_METHOD0(isWarnDiscardChangesChecked, bool());
   MOCK_CONST_METHOD0(isRoundChecked, bool());
   MOCK_CONST_METHOD0(getRoundPrecision, int &());
-  MOCK_CONST_METHOD0(roundPrecision, boost::optional<int>());
+  MOCK_CONST_METHOD0(roundPrecision, std::optional<int>());
   MOCK_METHOD0(isCloseEventPrevented, bool());
   MOCK_CONST_METHOD1(isCloseBatchPrevented, bool(int));
   MOCK_CONST_METHOD1(isOverwriteBatchPrevented, bool(int));

--- a/qt/scientific_interfaces/ISISReflectometry/test/Reduction/GroupTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Reduction/GroupTest.h
@@ -162,7 +162,7 @@ public:
 
   void test_no_postprocessing_if_one_valid_and_one_invalid_row() {
     auto group = makeGroupWithOneRow();
-    group.appendRow(boost::none);
+    group.appendRow(std::nullopt);
     checkPostprocessingNotApplicable(group);
   }
 
@@ -174,7 +174,7 @@ public:
 
   void test_has_postprocessing_if_two_valid_rows_and_one_invalid_row() {
     auto group = makeGroupWithTwoRows();
-    group.appendRow(boost::none);
+    group.appendRow(std::nullopt);
     checkPostprocessingIsApplicable(group);
     checkDoesNotRequirePostprocessing(group);
   }
@@ -298,24 +298,24 @@ public:
     auto rowToAdd = makeRow("12345", 0.5);
     group.appendRow(rowToAdd);
     TS_ASSERT_EQUALS(group.rows().size(), 1);
-    TS_ASSERT(group[0].is_initialized());
-    TS_ASSERT_EQUALS(group[0].get(), rowToAdd);
+    TS_ASSERT(group[0].has_value());
+    TS_ASSERT_EQUALS(group[0].value(), rowToAdd);
   }
 
   void test_append_empty_row() {
     auto group = makeEmptyGroup();
     group.appendEmptyRow();
     TS_ASSERT_EQUALS(group.rows().size(), 1);
-    TS_ASSERT_EQUALS(group[0].is_initialized(), false);
+    TS_ASSERT_EQUALS(group[0].has_value(), false);
   }
 
   void test_append_uninitialized_row() {
     // manually append an empty (uninitialized) row
     auto group = makeEmptyGroup();
-    auto rowToAdd = boost::optional<Row>{boost::none};
+    auto rowToAdd = std::optional<Row>{std::nullopt};
     group.appendRow(rowToAdd);
     TS_ASSERT_EQUALS(group.rows().size(), 1);
-    TS_ASSERT_EQUALS(group[0].is_initialized(), false);
+    TS_ASSERT_EQUALS(group[0].has_value(), false);
   }
 
   void test_insert_row_at_position() {
@@ -324,8 +324,8 @@ public:
     auto const index = 1;
     group.insertRow(rowToAdd, index);
     TS_ASSERT_EQUALS(group.rows().size(), 3);
-    TS_ASSERT(group[index].is_initialized());
-    TS_ASSERT_EQUALS(group[index].get(), rowToAdd);
+    TS_ASSERT(group[index].has_value());
+    TS_ASSERT_EQUALS(group[index].value(), rowToAdd);
   }
 
   void test_insert_row_sorted_by_angle() {
@@ -334,8 +334,8 @@ public:
     auto const index = 1; // angle 0.5 is between the two existing rows
     group.insertRowSortedByAngle(rowToAdd);
     TS_ASSERT_EQUALS(group.rows().size(), 3);
-    TS_ASSERT(group[index].is_initialized());
-    TS_ASSERT_EQUALS(group[index].get(), rowToAdd);
+    TS_ASSERT(group[index].has_value());
+    TS_ASSERT_EQUALS(group[index].value(), rowToAdd);
   }
 
   void test_insert_row_sorted_by_angle_at_start() {
@@ -344,8 +344,8 @@ public:
     auto const index = 0; // angle 0.1 is before the current two rows
     group.insertRowSortedByAngle(rowToAdd);
     TS_ASSERT_EQUALS(group.rows().size(), 3);
-    TS_ASSERT(group[index].is_initialized());
-    TS_ASSERT_EQUALS(group[index].get(), rowToAdd);
+    TS_ASSERT(group[index].has_value());
+    TS_ASSERT_EQUALS(group[index].value(), rowToAdd);
   }
 
   void test_insert_row_sorted_by_angle_at_end() {
@@ -354,8 +354,8 @@ public:
     auto const index = 2; // angle 1.5 is after the current two rows
     group.insertRowSortedByAngle(rowToAdd);
     TS_ASSERT_EQUALS(group.rows().size(), 3);
-    TS_ASSERT(group[index].is_initialized());
-    TS_ASSERT_EQUALS(group[index].get(), rowToAdd);
+    TS_ASSERT(group[index].has_value());
+    TS_ASSERT_EQUALS(group[index].value(), rowToAdd);
   }
 
   void test_insert_row_sorted_by_angle_into_empty_group() {
@@ -364,26 +364,26 @@ public:
     auto const index = 0;
     group.insertRowSortedByAngle(rowToAdd);
     TS_ASSERT_EQUALS(group.rows().size(), 1);
-    TS_ASSERT(group[index].is_initialized());
-    TS_ASSERT_EQUALS(group[index].get(), rowToAdd);
+    TS_ASSERT(group[index].has_value());
+    TS_ASSERT_EQUALS(group[index].value(), rowToAdd);
   }
 
   void test_insert_row_sorted_by_angle_adds_uninitialized_row_at_end() {
     auto group = makeGroupWithTwoRowsWithDifferentAngles();
-    auto rowToAdd = boost::optional<Row>{boost::none};
+    auto rowToAdd = std::optional<Row>{std::nullopt};
     auto const index = 2; // should be added at the end
     group.insertRowSortedByAngle(rowToAdd);
     TS_ASSERT_EQUALS(group.rows().size(), 3);
-    TS_ASSERT_EQUALS(group[index].is_initialized(), false);
+    TS_ASSERT_EQUALS(group[index].has_value(), false);
   }
 
   void test_insert_uninitialized_row_sorted_by_angle_into_empty_group() {
     auto group = makeEmptyGroup();
-    auto rowToAdd = boost::optional<Row>{boost::none};
+    auto rowToAdd = std::optional<Row>{std::nullopt};
     auto const index = 0;
     group.insertRowSortedByAngle(rowToAdd);
     TS_ASSERT_EQUALS(group.rows().size(), 1);
-    TS_ASSERT_EQUALS(group[index].is_initialized(), false);
+    TS_ASSERT_EQUALS(group[index].has_value(), false);
   }
 
   /** Removing rows
@@ -498,23 +498,23 @@ public:
   void test_index_of_row_with_theta_exact_match() {
     auto group = makeGroupWithThreeRows();
     auto maybeIndex = group.indexOfRowWithTheta(0.2, 0.01);
-    TS_ASSERT(maybeIndex.is_initialized());
-    if (maybeIndex.is_initialized())
+    TS_ASSERT(maybeIndex.has_value());
+    if (maybeIndex.has_value())
       TS_ASSERT_EQUALS(*maybeIndex, 1);
   }
 
   void test_index_of_row_with_theta_within_tolerance() {
     auto group = makeGroupWithThreeRows();
     auto maybeIndex = group.indexOfRowWithTheta(0.209, 0.01);
-    TS_ASSERT(maybeIndex.is_initialized());
-    if (maybeIndex.is_initialized())
+    TS_ASSERT(maybeIndex.has_value());
+    if (maybeIndex.has_value())
       TS_ASSERT_EQUALS(*maybeIndex, 1);
   }
 
   void test_index_of_row_with_theta_outside_tolerance() {
     auto group = makeGroupWithThreeRows();
     auto maybeIndex = group.indexOfRowWithTheta(0.23, 0.01);
-    TS_ASSERT(!maybeIndex.is_initialized());
+    TS_ASSERT(!maybeIndex.has_value());
   }
 
   void test_find_row_with_output_name() {
@@ -522,21 +522,20 @@ public:
     // mark the row complete as an easy way to check we find the right one
     group.mutableRows()[1]->setOutputNames({"12346_Lam", "12346_Q", "12346_QBin"});
     group.mutableRows()[1]->setSuccess();
-    auto maybeRow = group.getItemWithOutputWorkspaceOrNone("12346_Q");
-    TS_ASSERT(maybeRow.is_initialized());
-    if (maybeRow.is_initialized())
-      TS_ASSERT(maybeRow->success());
+    Item* maybeRow = group.getItemWithOutputWorkspaceOrNone("12346_Q");
+    TS_ASSERT(maybeRow);
+    TS_ASSERT(maybeRow->success());
   }
 
   void test_find_row_by_output_name_fails() {
     auto group = makeGroupWithThreeRows();
-    auto maybeRow = group.getItemWithOutputWorkspaceOrNone("99999");
-    TS_ASSERT(!maybeRow.is_initialized());
+    Item* maybeRow = group.getItemWithOutputWorkspaceOrNone("99999");
+    TS_ASSERT(!maybeRow);
   }
 
 private:
   Group makeGroupWithThreeRows() {
-    return Group("three_row_group", std::vector<boost::optional<Row>>{makeRow("12345", 0.1), makeRow("12346", 0.2),
+    return Group("three_row_group", std::vector<std::optional<Row>>{makeRow("12345", 0.1), makeRow("12346", 0.2),
                                                                       makeRow("12347", 0.3)});
   }
 

--- a/qt/scientific_interfaces/ISISReflectometry/test/Reduction/ParseReflectometryStringsTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Reduction/ParseReflectometryStringsTest.h
@@ -20,129 +20,129 @@ public:
 
   void testParseRunNumber() {
     auto result = parseRunNumber("13460");
-    TS_ASSERT(result.is_initialized());
-    TS_ASSERT_EQUALS(result.get(), "13460");
+    TS_ASSERT(result.has_value());
+    TS_ASSERT_EQUALS(result.value(), "13460");
   }
 
   void testParseRunNumberRemovesWhitespace() {
     auto result = parseRunNumber("  13460\t");
-    TS_ASSERT(result.is_initialized());
-    TS_ASSERT_EQUALS(result.get(), "13460");
+    TS_ASSERT(result.has_value());
+    TS_ASSERT_EQUALS(result.value(), "13460");
   }
 
   void testParseRunNumberConsidersAllWhitespaceInvalid() {
     auto result = parseRunNumber("");
-    TS_ASSERT(!result.is_initialized());
+    TS_ASSERT(!result.has_value());
   }
 
   void testRunNumberHandlesFreeTextInput() {
     auto result = parseRunNumber("some workspace name");
-    TS_ASSERT(result.is_initialized());
+    TS_ASSERT(result.has_value());
   }
 
   void testParseRunNumberOrWhitespaceExtractsRun() {
     auto result = parseRunNumberOrWhitespace("  13460\t");
-    TS_ASSERT(result.is_initialized());
-    TS_ASSERT_EQUALS(result.get(), "13460");
+    TS_ASSERT(result.has_value());
+    TS_ASSERT_EQUALS(result.value(), "13460");
   }
 
   void testParseRunNumberOrWhitespaceReturnsEmptyString() {
     auto result = parseRunNumberOrWhitespace("  \t");
-    TS_ASSERT(result.is_initialized());
-    TS_ASSERT_EQUALS(result.get(), "");
+    TS_ASSERT(result.has_value());
+    TS_ASSERT_EQUALS(result.value(), "");
   }
 
   void testParseTheta() {
     auto result = parseTheta("0.23");
-    TS_ASSERT(result.is_initialized());
-    TS_ASSERT_EQUALS(result.get(), 0.23);
+    TS_ASSERT(result.has_value());
+    TS_ASSERT_EQUALS(result.value(), 0.23);
   }
 
   void testParseThetaEmpty() {
     auto result = parseTheta("  \t");
-    TS_ASSERT(!result.is_initialized());
+    TS_ASSERT(!result.has_value());
   }
 
   void testParseThetaIgnoresWhitespace() {
     auto result = parseTheta("  \t0.23 ");
-    TS_ASSERT(result.is_initialized());
-    TS_ASSERT_EQUALS(result.get(), 0.23);
+    TS_ASSERT(result.has_value());
+    TS_ASSERT_EQUALS(result.value(), 0.23);
   }
 
   void testParseThetaConsidersNegativeDoubleInvalid() {
     auto result = parseTheta("-0.23");
-    TS_ASSERT(!result.is_initialized());
+    TS_ASSERT(!result.has_value());
   }
 
   void testParseThetaHandlesInvalidCharacters() {
     auto result = parseTheta("bad");
-    TS_ASSERT(!result.is_initialized());
+    TS_ASSERT(!result.has_value());
   }
 
   void testParseOptions() {
     auto result = parseOptions("key1=value1, key2=value2");
     std::map<std::string, std::string> expected = {{"key1", "value1"}, {"key2", "value2"}};
-    TS_ASSERT(result.is_initialized());
-    TS_ASSERT_EQUALS(result.get(), expected);
+    TS_ASSERT(result.has_value());
+    TS_ASSERT_EQUALS(result.value(), expected);
   }
 
   void testParseOptionsHandlesWhitespace() {
     auto result = parseOptions("\t key1=value1,   key2  =value2\t");
     std::map<std::string, std::string> expected = {{"key1", "value1"}, {"key2", "value2"}};
-    TS_ASSERT(result.is_initialized());
-    TS_ASSERT_EQUALS(result.get(), expected);
+    TS_ASSERT(result.has_value());
+    TS_ASSERT_EQUALS(result.value(), expected);
   }
 
   void testParseOptionsHandlesInvalidInput() {
     auto result = parseOptions("bad");
-    TS_ASSERT(!result.is_initialized());
+    TS_ASSERT(!result.has_value());
   }
 
   void testParseProcessingInstructions() {
     auto result = parseProcessingInstructions("1-3");
-    TS_ASSERT(result.is_initialized());
-    TS_ASSERT(result.get().is_initialized());
-    TS_ASSERT_EQUALS(result.get().get(), "1-3");
+    TS_ASSERT(result.has_value());
+    TS_ASSERT(result.value().has_value());
+    TS_ASSERT_EQUALS(result.value().value(), "1-3");
   }
 
   void testParseProcessingInstructionsWhitespace() {
     auto result = parseProcessingInstructions("");
-    TS_ASSERT(result.is_initialized());
-    TS_ASSERT(!result.get().is_initialized());
+    TS_ASSERT(result.has_value());
+    TS_ASSERT(!result.value().has_value());
   }
 
   void testParseProcessingInstructionsInvalid() {
     auto result = parseProcessingInstructions("bad");
-    TS_ASSERT(!result.is_initialized());
+    TS_ASSERT(!result.has_value());
   }
 
   void testParseScaleFactor() {
     auto result = parseScaleFactor("1.5");
-    TS_ASSERT(result.is_initialized());
-    TS_ASSERT(result.get().is_initialized());
-    TS_ASSERT_EQUALS(result.get().get(), 1.5);
+    TS_ASSERT(result.has_value());
+    TS_ASSERT(result.value().has_value());
+    TS_ASSERT_EQUALS(result.value().value(), 1.5);
   }
 
   void testParseScaleFactorWhitespace() {
     auto result = parseScaleFactor("");
-    TS_ASSERT(result.is_initialized());
-    TS_ASSERT(!result.get().is_initialized());
+    TS_ASSERT(result.has_value());
+    TS_ASSERT(!result.value().has_value());
   }
 
   void testParseScaleFactorInvalid() {
     auto result = parseScaleFactor("bad");
-    TS_ASSERT(!result.is_initialized());
+    TS_ASSERT(!result.has_value());
   }
 
   void testParseScaleFactorRejectsZero() {
     auto result = parseScaleFactor("0.0");
-    TS_ASSERT(!result.is_initialized());
+    TS_ASSERT(!result.has_value());
   }
 
   void testParseScaleFactorNegative() {
     auto result = parseScaleFactor("-1.0");
-    TS_ASSERT(result.get().is_initialized());
-    TS_ASSERT_EQUALS(result.get().get(), -1.0);
+    TS_ASSERT(result.value().has_value());
+    TS_ASSERT_EQUALS(result.value().value(), -1.0);
   }
 
   void testParseQRange() {
@@ -182,39 +182,39 @@ public:
   void testParseRunNumbersSingle() {
     auto result = parseRunNumbers("13460");
     std::vector<std::string> expected = {"13460"};
-    TS_ASSERT(result.is_initialized());
-    TS_ASSERT_EQUALS(result.get(), expected);
+    TS_ASSERT(result.has_value());
+    TS_ASSERT_EQUALS(result.value(), expected);
   }
 
   void testParseRunNumbersWithCommaSeparator() {
     auto result = parseRunNumbers("13460, 13461");
     std::vector<std::string> expected = {"13460", "13461"};
-    TS_ASSERT(result.is_initialized());
-    TS_ASSERT_EQUALS(result.get(), expected);
+    TS_ASSERT(result.has_value());
+    TS_ASSERT_EQUALS(result.value(), expected);
   }
 
   void testParseRunNumbersWithPlusSeparator() {
     auto result = parseRunNumbers("13460+13461");
     std::vector<std::string> expected = {"13460", "13461"};
-    TS_ASSERT(result.is_initialized());
-    TS_ASSERT_EQUALS(result.get(), expected);
+    TS_ASSERT(result.has_value());
+    TS_ASSERT_EQUALS(result.value(), expected);
   }
 
   void testParseRunNumbersIgnoresWhitespace() {
     auto result = parseRunNumbers("  13460,\t13461");
     std::vector<std::string> expected = {"13460", "13461"};
-    TS_ASSERT(result.is_initialized());
-    TS_ASSERT_EQUALS(result.get(), expected);
+    TS_ASSERT(result.has_value());
+    TS_ASSERT_EQUALS(result.value(), expected);
   }
 
   void testParseRunNumbersEmptyExceptWhitespace() {
     auto result = parseRunNumbers("  \t");
-    TS_ASSERT(!result.is_initialized());
+    TS_ASSERT(!result.has_value());
   }
 
   void testParseRunNumbersHandlesFreeTextInput() {
     auto result = parseRunNumbers("13460, some workspace");
-    TS_ASSERT(result.is_initialized());
+    TS_ASSERT(result.has_value());
   }
 
   void testParseTransmissionRuns() {

--- a/qt/scientific_interfaces/ISISReflectometry/test/Reduction/ReductionJobsMergeTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Reduction/ReductionJobsMergeTest.h
@@ -40,12 +40,12 @@ public:
 
   Row rowWithNameAndAngle(std::string const &name, double angle) {
     auto wsNames = ReductionWorkspaces({"TOF_" + name}, TransmissionRunPair{});
-    return Row({name}, angle, {"", ""}, RangeInQ(), boost::none, {}, wsNames);
+    return Row({name}, angle, {"", ""}, RangeInQ(), std::nullopt, {}, wsNames);
   }
 
   Row rowWithNamesAndAngle(std::vector<std::string> const &names, double angle) {
     auto wsNames = ReductionWorkspaces(names, TransmissionRunPair{});
-    return Row(names, angle, {"", ""}, RangeInQ(), boost::none, {}, wsNames);
+    return Row(names, angle, {"", ""}, RangeInQ(), std::nullopt, {}, wsNames);
   }
 
   void testMergeEmptyModels() {
@@ -149,7 +149,7 @@ public:
 
     TS_ASSERT_EQUALS(1u, target.groups().size());
     TS_ASSERT_EQUALS(1u, target.groups()[0].rows().size());
-    TS_ASSERT_EQUALS(std::vector<std::string>({"C", "D"}), target.groups()[0].rows()[0].get().runNumbers());
+    TS_ASSERT_EQUALS(std::vector<std::string>({"C", "D"}), target.groups()[0].rows()[0].value().runNumbers());
     TS_ASSERT(Mock::VerifyAndClearExpectations(&listener));
   }
 
@@ -165,7 +165,7 @@ public:
 
     TS_ASSERT_EQUALS(1u, target.groups().size());
     TS_ASSERT_EQUALS(1u, target.groups()[0].rows().size());
-    TS_ASSERT_EQUALS(std::vector<std::string>({"C", "D"}), target.groups()[0].rows()[0].get().runNumbers());
+    TS_ASSERT_EQUALS(std::vector<std::string>({"C", "D"}), target.groups()[0].rows()[0].value().runNumbers());
     TS_ASSERT(Mock::VerifyAndClearExpectations(&listener));
   }
 
@@ -175,10 +175,10 @@ public:
         for (auto rowPair : zip_range(boost::get<0>(groupPair).rows(), boost::get<1>(groupPair).rows())) {
           auto const &lhsRow = boost::get<0>(rowPair);
           auto const &rhsRow = boost::get<1>(rowPair);
-          if (lhsRow.is_initialized() != rhsRow.is_initialized())
+          if (lhsRow.has_value() != rhsRow.has_value())
             return false;
-          else if (lhsRow.is_initialized())
-            if (lhsRow.get().runNumbers() != rhsRow.get().runNumbers())
+          else if (lhsRow.has_value())
+            if (lhsRow.value().runNumbers() != rhsRow.value().runNumbers())
               return false;
         }
       }

--- a/qt/scientific_interfaces/ISISReflectometry/test/Reduction/ValidateLookupRowTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Reduction/ValidateLookupRowTest.h
@@ -26,15 +26,15 @@ public:
     LookupRowValidator validator;
     auto result = validator({"1.3"});
     TS_ASSERT(result.isValid());
-    TS_ASSERT(result.assertValid().thetaOrWildcard().is_initialized());
-    TS_ASSERT_EQUALS(result.assertValid().thetaOrWildcard().get(), 1.3);
+    TS_ASSERT(result.assertValid().thetaOrWildcard().has_value());
+    TS_ASSERT_EQUALS(result.assertValid().thetaOrWildcard().value(), 1.3);
   }
 
   void testParseThetaWildcard() {
     LookupRowValidator validator;
     auto result = validator({""});
     TS_ASSERT(result.isValid());
-    TS_ASSERT(!result.assertValid().thetaOrWildcard().is_initialized());
+    TS_ASSERT(!result.assertValid().thetaOrWildcard().has_value());
   }
 
   void testParseThetaError() {
@@ -65,8 +65,8 @@ public:
     LookupRowValidator validator;
     auto result = validator({"", "", "", "4-7"});
     TS_ASSERT(result.isValid());
-    TS_ASSERT(result.assertValid().transmissionProcessingInstructions().is_initialized());
-    TS_ASSERT_EQUALS(result.assertValid().transmissionProcessingInstructions().get(), "4-7");
+    TS_ASSERT(result.assertValid().transmissionProcessingInstructions().has_value());
+    TS_ASSERT_EQUALS(result.assertValid().transmissionProcessingInstructions().value(), "4-7");
   }
 
   void testParseTransmissionProcessingInstructionsError() {
@@ -111,8 +111,8 @@ public:
     LookupRowValidator validator;
     auto result = validator({"", "", "", "", "", "", "", "", "1-3"});
     TS_ASSERT(result.isValid());
-    TS_ASSERT(result.assertValid().processingInstructions().is_initialized());
-    TS_ASSERT_EQUALS(result.assertValid().processingInstructions().get(), "1-3");
+    TS_ASSERT(result.assertValid().processingInstructions().has_value());
+    TS_ASSERT_EQUALS(result.assertValid().processingInstructions().value(), "1-3");
   }
 
   void testParseProcessingInstructionsError() {
@@ -127,8 +127,8 @@ public:
     LookupRowValidator validator;
     auto result = validator({"", "", "", "", "", "", "", "", "", "4-7"});
     TS_ASSERT(result.isValid());
-    TS_ASSERT(result.assertValid().backgroundProcessingInstructions().is_initialized());
-    TS_ASSERT_EQUALS(result.assertValid().backgroundProcessingInstructions().get(), "4-7");
+    TS_ASSERT(result.assertValid().backgroundProcessingInstructions().has_value());
+    TS_ASSERT_EQUALS(result.assertValid().backgroundProcessingInstructions().value(), "4-7");
   }
 
   void testParseBackgroundProcessingInstructionsError() {

--- a/qt/scientific_interfaces/ISISReflectometry/test/Reduction/ValidateRowTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Reduction/ValidateRowTest.h
@@ -23,126 +23,126 @@ public:
   void test() {}
 
   void testParsesTriviallyValidDoubles() {
-    TS_ASSERT_DELTA(1.0, parseDouble("1.0").get(), TOLERANCE);
-    TS_ASSERT_DELTA(6.4, parseDouble("6.4").get(), TOLERANCE);
-    TS_ASSERT_DELTA(0.0, parseDouble("0").get(), TOLERANCE);
-    TS_ASSERT_DELTA(-7000.3, parseDouble("-7000.3").get(), TOLERANCE);
+    TS_ASSERT_DELTA(1.0, parseDouble("1.0").value(), TOLERANCE);
+    TS_ASSERT_DELTA(6.4, parseDouble("6.4").value(), TOLERANCE);
+    TS_ASSERT_DELTA(0.0, parseDouble("0").value(), TOLERANCE);
+    TS_ASSERT_DELTA(-7000.3, parseDouble("-7000.3").value(), TOLERANCE);
   }
 
   void testParsesValidDoublesWithLeadingAndTrailingWhitespace() {
-    TS_ASSERT_DELTA(1.0, parseDouble("  1.0  ").get(), TOLERANCE);
-    TS_ASSERT_DELTA(6.4, parseDouble("\n   6.4").get(), TOLERANCE);
-    TS_ASSERT_DELTA(0.0, parseDouble("0").get(), TOLERANCE);
-    TS_ASSERT_DELTA(-7000.3, parseDouble("\t-7000.3\t").get(), TOLERANCE);
+    TS_ASSERT_DELTA(1.0, parseDouble("  1.0  ").value(), TOLERANCE);
+    TS_ASSERT_DELTA(6.4, parseDouble("\n   6.4").value(), TOLERANCE);
+    TS_ASSERT_DELTA(0.0, parseDouble("0").value(), TOLERANCE);
+    TS_ASSERT_DELTA(-7000.3, parseDouble("\t-7000.3\t").value(), TOLERANCE);
   }
 
   void testFailsForTriviallyInvalidDoubles() {
-    TS_ASSERT_EQUALS(boost::none, parseDouble(""));
-    TS_ASSERT_EQUALS(boost::none, parseDouble("ABCD"));
-    TS_ASSERT_EQUALS(boost::none, parseDouble("A0.12"));
-    TS_ASSERT_EQUALS(boost::none, parseDouble("O.12"));
+    TS_ASSERT_EQUALS(std::nullopt, parseDouble(""));
+    TS_ASSERT_EQUALS(std::nullopt, parseDouble("ABCD"));
+    TS_ASSERT_EQUALS(std::nullopt, parseDouble("A0.12"));
+    TS_ASSERT_EQUALS(std::nullopt, parseDouble("O.12"));
   }
 
   void testFailsForOutOfRangeDoubles() {
     auto bigPositiveDoubleAsString = std::string(380, '9');
-    TS_ASSERT_EQUALS(boost::none, parseDouble(bigPositiveDoubleAsString));
+    TS_ASSERT_EQUALS(std::nullopt, parseDouble(bigPositiveDoubleAsString));
     auto smallNegativeDoubleAsString = "-" + bigPositiveDoubleAsString;
-    TS_ASSERT_EQUALS(boost::none, parseDouble(smallNegativeDoubleAsString));
+    TS_ASSERT_EQUALS(std::nullopt, parseDouble(smallNegativeDoubleAsString));
   }
 
   void testParsesTriviallyValidInts() {
-    TS_ASSERT_EQUALS(1, parseInt("1").get());
-    TS_ASSERT_EQUALS(64, parseInt("64").get());
-    TS_ASSERT_EQUALS(0, parseInt("0").get());
-    TS_ASSERT_EQUALS(-7000, parseInt("-7000").get());
+    TS_ASSERT_EQUALS(1, parseInt("1").value());
+    TS_ASSERT_EQUALS(64, parseInt("64").value());
+    TS_ASSERT_EQUALS(0, parseInt("0").value());
+    TS_ASSERT_EQUALS(-7000, parseInt("-7000").value());
   }
 
   void testParsesValidIntsWithLeadingAndTrailingWhitespace() {
-    TS_ASSERT_EQUALS(10, parseInt("  10  ").get());
-    TS_ASSERT_EQUALS(64, parseInt("\n   64").get());
-    TS_ASSERT_EQUALS(0, parseInt("  0\r\n").get());
-    TS_ASSERT_EQUALS(-7003, parseInt("\t-7003\t").get());
+    TS_ASSERT_EQUALS(10, parseInt("  10  ").value());
+    TS_ASSERT_EQUALS(64, parseInt("\n   64").value());
+    TS_ASSERT_EQUALS(0, parseInt("  0\r\n").value());
+    TS_ASSERT_EQUALS(-7003, parseInt("\t-7003\t").value());
   }
 
   void testParsesValidIntsWithLeadingZeroes() {
-    TS_ASSERT_EQUALS(30, parseInt("000030").get());
-    TS_ASSERT_EQUALS(64, parseInt(" 00064").get());
-    TS_ASSERT_EQUALS(100, parseInt("00100").get());
+    TS_ASSERT_EQUALS(30, parseInt("000030").value());
+    TS_ASSERT_EQUALS(64, parseInt(" 00064").value());
+    TS_ASSERT_EQUALS(100, parseInt("00100").value());
   }
 
   void testFailsForTriviallyInvalidInts() {
-    TS_ASSERT_EQUALS(boost::none, parseInt(""));
-    TS_ASSERT_EQUALS(boost::none, parseInt("ABCD"));
-    TS_ASSERT_EQUALS(boost::none, parseInt("A0"));
-    TS_ASSERT_EQUALS(boost::none, parseInt("O.12"));
+    TS_ASSERT_EQUALS(std::nullopt, parseInt(""));
+    TS_ASSERT_EQUALS(std::nullopt, parseInt("ABCD"));
+    TS_ASSERT_EQUALS(std::nullopt, parseInt("A0"));
+    TS_ASSERT_EQUALS(std::nullopt, parseInt("O.12"));
   }
 
   void testFailsForOutOfRangeInts() {
     auto bigPositiveIntAsString = std::string(380, '9');
-    TS_ASSERT_EQUALS(boost::none, parseInt(bigPositiveIntAsString));
+    TS_ASSERT_EQUALS(std::nullopt, parseInt(bigPositiveIntAsString));
     auto smallNegativeIntAsString = "-" + bigPositiveIntAsString;
-    TS_ASSERT_EQUALS(boost::none, parseInt(smallNegativeIntAsString));
+    TS_ASSERT_EQUALS(std::nullopt, parseInt(smallNegativeIntAsString));
   }
 
   void testParsesTriviallyValidNonNegativeInts() {
-    TS_ASSERT_EQUALS(1, parseNonNegativeInt("1").get());
-    TS_ASSERT_EQUALS(64, parseNonNegativeInt("64").get());
-    TS_ASSERT_EQUALS(0, parseNonNegativeInt("0").get());
-    TS_ASSERT_EQUALS(6999, parseNonNegativeInt("6999").get());
+    TS_ASSERT_EQUALS(1, parseNonNegativeInt("1").value());
+    TS_ASSERT_EQUALS(64, parseNonNegativeInt("64").value());
+    TS_ASSERT_EQUALS(0, parseNonNegativeInt("0").value());
+    TS_ASSERT_EQUALS(6999, parseNonNegativeInt("6999").value());
   }
 
   void testParsesValidNonNegativeIntsWithLeadingAndTrailingWhitespace() {
-    TS_ASSERT_EQUALS(13, parseNonNegativeInt("  13  ").get());
-    TS_ASSERT_EQUALS(58, parseNonNegativeInt("\n   58").get());
-    TS_ASSERT_EQUALS(0, parseNonNegativeInt("  0\r\n").get());
-    TS_ASSERT_EQUALS(7003, parseNonNegativeInt("\t7003\t").get());
+    TS_ASSERT_EQUALS(13, parseNonNegativeInt("  13  ").value());
+    TS_ASSERT_EQUALS(58, parseNonNegativeInt("\n   58").value());
+    TS_ASSERT_EQUALS(0, parseNonNegativeInt("  0\r\n").value());
+    TS_ASSERT_EQUALS(7003, parseNonNegativeInt("\t7003\t").value());
   }
 
   void testParsesValidNonNegativeIntsWithLeadingZeroes() {
-    TS_ASSERT_EQUALS(30, parseNonNegativeInt("000030").get());
-    TS_ASSERT_EQUALS(64, parseNonNegativeInt(" 00064").get());
-    TS_ASSERT_EQUALS(100, parseNonNegativeInt("00100").get());
+    TS_ASSERT_EQUALS(30, parseNonNegativeInt("000030").value());
+    TS_ASSERT_EQUALS(64, parseNonNegativeInt(" 00064").value());
+    TS_ASSERT_EQUALS(100, parseNonNegativeInt("00100").value());
   }
 
   void testFailsForTriviallyInvalidNonNegativeInts() {
-    TS_ASSERT_EQUALS(boost::none, parseNonNegativeInt(""));
-    TS_ASSERT_EQUALS(boost::none, parseNonNegativeInt("ABCD"));
-    TS_ASSERT_EQUALS(boost::none, parseNonNegativeInt("A0"));
-    TS_ASSERT_EQUALS(boost::none, parseNonNegativeInt("O.12"));
+    TS_ASSERT_EQUALS(std::nullopt, parseNonNegativeInt(""));
+    TS_ASSERT_EQUALS(std::nullopt, parseNonNegativeInt("ABCD"));
+    TS_ASSERT_EQUALS(std::nullopt, parseNonNegativeInt("A0"));
+    TS_ASSERT_EQUALS(std::nullopt, parseNonNegativeInt("O.12"));
   }
 
   void testFailsForOutOfRangeNonNegativeInts() {
     auto bigPositiveIntAsString = std::string(380, '9');
-    TS_ASSERT_EQUALS(boost::none, parseNonNegativeInt(bigPositiveIntAsString));
+    TS_ASSERT_EQUALS(std::nullopt, parseNonNegativeInt(bigPositiveIntAsString));
     auto smallNegativeIntAsString = "-" + bigPositiveIntAsString;
-    TS_ASSERT_EQUALS(boost::none, parseNonNegativeInt(smallNegativeIntAsString));
+    TS_ASSERT_EQUALS(std::nullopt, parseNonNegativeInt(smallNegativeIntAsString));
   }
 
   void testFailsForNegativeInts() {
-    TS_ASSERT_EQUALS(boost::none, parseNonNegativeInt("-1"));
-    TS_ASSERT_EQUALS(boost::none, parseNonNegativeInt("-3400"));
+    TS_ASSERT_EQUALS(std::nullopt, parseNonNegativeInt("-1"));
+    TS_ASSERT_EQUALS(std::nullopt, parseNonNegativeInt("-3400"));
   }
 
   void testParsesSingleRunNumber() {
-    TS_ASSERT_EQUALS(std::vector<std::string>({"100"}), parseRunNumbers("100").get());
-    TS_ASSERT_EQUALS(std::vector<std::string>({"000102"}), parseRunNumbers("000102").get());
+    TS_ASSERT_EQUALS(std::vector<std::string>({"100"}), parseRunNumbers("100").value());
+    TS_ASSERT_EQUALS(std::vector<std::string>({"000102"}), parseRunNumbers("000102").value());
   }
 
   void testParsesMultipleRunNumbersSeparatedByPlus() {
-    TS_ASSERT_EQUALS(std::vector<std::string>({"100", "1002"}), parseRunNumbers("100+1002").get());
-    TS_ASSERT_EQUALS(std::vector<std::string>({"000102", "111102", "010"}), parseRunNumbers("000102+111102+010").get());
+    TS_ASSERT_EQUALS(std::vector<std::string>({"100", "1002"}), parseRunNumbers("100+1002").value());
+    TS_ASSERT_EQUALS(std::vector<std::string>({"000102", "111102", "010"}), parseRunNumbers("000102+111102+010").value());
   }
 
   void testParsesMultipleRunNumbersSeparatedByComma() {
-    TS_ASSERT_EQUALS(std::vector<std::string>({"100", "1002"}), parseRunNumbers("100,1002").get());
-    TS_ASSERT_EQUALS(std::vector<std::string>({"000102", "111102", "010"}), parseRunNumbers("000102+111102+010").get());
+    TS_ASSERT_EQUALS(std::vector<std::string>({"100", "1002"}), parseRunNumbers("100,1002").value());
+    TS_ASSERT_EQUALS(std::vector<std::string>({"000102", "111102", "010"}), parseRunNumbers("000102+111102+010").value());
   }
 
   void testFailsForNoRunNumbers() {
-    TS_ASSERT_EQUALS(boost::none, parseRunNumbers(""));
-    TS_ASSERT_EQUALS(boost::none, parseRunNumbers("   "));
-    TS_ASSERT_EQUALS(boost::none, parseRunNumbers("\n\n"));
-    TS_ASSERT_EQUALS(boost::none, parseRunNumbers("+"));
+    TS_ASSERT_EQUALS(std::nullopt, parseRunNumbers(""));
+    TS_ASSERT_EQUALS(std::nullopt, parseRunNumbers("   "));
+    TS_ASSERT_EQUALS(std::nullopt, parseRunNumbers("\n\n"));
+    TS_ASSERT_EQUALS(std::nullopt, parseRunNumbers("+"));
   }
 
   void testParsesRunNumbersMixedWithWorkspaceNames() {
@@ -159,16 +159,16 @@ public:
   }
 
   void testParseThetaFailsForNegativeAndZeroValues() {
-    TS_ASSERT_EQUALS(boost::none, parseTheta("-0.01"));
-    TS_ASSERT_EQUALS(boost::none, parseTheta("-0.12"));
-    TS_ASSERT_EQUALS(boost::none, parseTheta("-1"));
-    TS_ASSERT_EQUALS(boost::none, parseTheta("0.0"));
+    TS_ASSERT_EQUALS(std::nullopt, parseTheta("-0.01"));
+    TS_ASSERT_EQUALS(std::nullopt, parseTheta("-0.12"));
+    TS_ASSERT_EQUALS(std::nullopt, parseTheta("-1"));
+    TS_ASSERT_EQUALS(std::nullopt, parseTheta("0.0"));
   }
 
   void testParseScaleFactor() {
-    TS_ASSERT_EQUALS(boost::none, parseScaleFactor("ABSC"));
-    TS_ASSERT_EQUALS(boost::none, parseScaleFactor("").get());
-    TS_ASSERT_EQUALS(0.1, parseScaleFactor("0.1").get().get());
+    TS_ASSERT_EQUALS(std::nullopt, parseScaleFactor("ABSC"));
+    TS_ASSERT_EQUALS(std::nullopt, parseScaleFactor("").value());
+    TS_ASSERT_EQUALS(0.1, parseScaleFactor("0.1").value().value());
   }
 
   void testParsesFirstTransmissionRun() {

--- a/qt/scientific_interfaces/ISISReflectometry/test/ReflMockObjects.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/ReflMockObjects.h
@@ -111,9 +111,9 @@ public:
   MOCK_METHOD0(notifyResumeReductionRequested, void());
   MOCK_METHOD0(notifyPauseReductionRequested, void());
   MOCK_METHOD0(notifyRowStateChanged, void());
-  MOCK_METHOD1(notifyRowStateChanged, void(boost::optional<Item const &>));
+  MOCK_METHOD1(notifyRowStateChanged, void(Item *));
   MOCK_METHOD0(notifyRowOutputsChanged, void());
-  MOCK_METHOD1(notifyRowOutputsChanged, void(boost::optional<Item const &>));
+  MOCK_METHOD1(notifyRowOutputsChanged, void(Item *));
   MOCK_METHOD0(notifyReductionPaused, void());
   MOCK_METHOD0(notifyReductionResumed, void());
   MOCK_METHOD0(resumeAutoreduction, bool());
@@ -336,14 +336,14 @@ public:
   MOCK_METHOD0(notifyAutoreductionResumed, void());
   MOCK_METHOD0(notifyAutoreductionPaused, void());
   MOCK_METHOD1(setReprocessFailedItems, void(bool));
-  MOCK_METHOD1(getRunsTableItem, boost::optional<Item &>(MantidQt::API::IConfiguredAlgorithm_sptr const &algorithm));
+  MOCK_METHOD1(getRunsTableItem, Item*(MantidQt::API::IConfiguredAlgorithm_sptr const &algorithm));
   MOCK_METHOD1(algorithmStarted, void(MantidQt::API::IConfiguredAlgorithm_sptr));
   MOCK_METHOD1(algorithmComplete, void(MantidQt::API::IConfiguredAlgorithm_sptr));
   MOCK_METHOD2(algorithmError, void(MantidQt::API::IConfiguredAlgorithm_sptr, std::string const &));
   MOCK_CONST_METHOD1(algorithmOutputWorkspacesToSave,
                      std::vector<std::string>(MantidQt::API::IConfiguredAlgorithm_sptr));
-  MOCK_METHOD1(notifyWorkspaceDeleted, boost::optional<Item const &>(std::string const &));
-  MOCK_METHOD2(notifyWorkspaceRenamed, boost::optional<Item const &>(std::string const &, std::string const &));
+  MOCK_METHOD1(notifyWorkspaceDeleted, Item *(std::string const &));
+  MOCK_METHOD2(notifyWorkspaceRenamed, Item *(std::string const &, std::string const &));
   MOCK_METHOD0(notifyAllWorkspacesDeleted, void());
   MOCK_METHOD0(getAlgorithms, std::deque<MantidQt::API::IConfiguredAlgorithm_sptr>());
   MOCK_CONST_METHOD0(rowProcessingProperties, std::unique_ptr<MantidQt::API::IAlgorithmRuntimeProps>());

--- a/qt/scientific_interfaces/ISISReflectometry/test/Runs/RunsPresenterTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Runs/RunsPresenterTest.h
@@ -632,7 +632,7 @@ public:
     auto presenter = makePresenter();
     auto row = makeRow();
     EXPECT_CALL(*m_runsTablePresenter, notifyRowStateChanged(_)).Times(1);
-    presenter.notifyRowStateChanged(row);
+    presenter.notifyRowStateChanged(&row);
     verifyAndClear();
   }
 
@@ -647,7 +647,7 @@ public:
     auto presenter = makePresenter();
     auto row = makeRow();
     EXPECT_CALL(*m_runsTablePresenter, notifyRowOutputsChanged(_)).Times(1);
-    presenter.notifyRowOutputsChanged(row);
+    presenter.notifyRowOutputsChanged(&row);
     verifyAndClear();
   }
 
@@ -923,7 +923,7 @@ private:
     // Construct the corresponding model expected in the main table
     auto jobs = ReductionJobs();
     auto group = Group(groupName);
-    group.appendRow(Row({run}, theta, TransmissionRunPair(), RangeInQ(), boost::none, ReductionOptionsMap(),
+    group.appendRow(Row({run}, theta, TransmissionRunPair(), RangeInQ(), std::nullopt, ReductionOptionsMap(),
                         ReductionWorkspaces({run}, TransmissionRunPair())));
     jobs.appendGroup(group);
     return jobs;

--- a/qt/scientific_interfaces/ISISReflectometry/test/RunsTable/MockRunsTablePresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/RunsTable/MockRunsTablePresenter.h
@@ -23,9 +23,9 @@ public:
   MOCK_CONST_METHOD0(runsTable, RunsTable const &());
   MOCK_METHOD0(mutableRunsTable, RunsTable &());
   MOCK_METHOD0(notifyRowStateChanged, void());
-  MOCK_METHOD1(notifyRowStateChanged, void(boost::optional<Item const &>));
+  MOCK_METHOD1(notifyRowStateChanged, void(Item *));
   MOCK_METHOD0(notifyRowOutputsChanged, void());
-  MOCK_METHOD1(notifyRowOutputsChanged, void(boost::optional<Item const &>));
+  MOCK_METHOD1(notifyRowOutputsChanged, void(Item *));
   MOCK_METHOD0(notifyRemoveAllRowsAndGroupsRequested, void());
   MOCK_METHOD1(mergeAdditionalJobs, void(ReductionJobs const &));
   MOCK_METHOD0(notifyReductionPaused, void());

--- a/qt/scientific_interfaces/ISISReflectometry/test/RunsTable/RunsTablePresenterDisplayTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/RunsTable/RunsTablePresenterDisplayTest.h
@@ -215,7 +215,7 @@ public:
     TS_ASSERT_EQUALS(getRow(presenter, 0, 2)->theta(), srcValue);
     TS_ASSERT_EQUALS(getRow(presenter, 1, 1)->theta(), srcValue);
     // Check that the uninitialized row is still uninitialized
-    TS_ASSERT_EQUALS(presenter.runsTable().reductionJobs()[0][1].is_initialized(), false);
+    TS_ASSERT_EQUALS(presenter.runsTable().reductionJobs()[0][1].has_value(), false);
 
     verifyAndClearExpectations();
   }

--- a/qt/scientific_interfaces/ISISReflectometry/test/RunsTable/RunsTablePresenterTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/RunsTable/RunsTablePresenterTest.h
@@ -80,7 +80,7 @@ public:
 
   Row *getRow(RunsTablePresenter &presenter, int groupIndex, int rowIndex) {
     auto &reductionJobs = presenter.mutableRunsTable().mutableReductionJobs();
-    auto *row = &reductionJobs.mutableGroups()[groupIndex].mutableRows()[rowIndex].get();
+    auto *row = &reductionJobs.mutableGroups()[groupIndex].mutableRows()[rowIndex].value();
     return row;
   }
 

--- a/qt/scientific_interfaces/Indirect/test/IndirectPlotOptionsModelTest.h
+++ b/qt/scientific_interfaces/Indirect/test/IndirectPlotOptionsModelTest.h
@@ -86,7 +86,7 @@ class MockExternalPlotter : public ExternalPlotter {
 public:
   /// Public Methods
   MOCK_METHOD4(plotSpectra, void(std::string const &workspaceName, std::string const &workspaceIndices, bool errorBars,
-                                 boost::optional<QHash<QString, QVariant>> const &kwargs));
+                                 std::optional<QHash<QString, QVariant>> const &kwargs));
   MOCK_METHOD3(plotSpectra,
                void(std::string const &workspaceName, std::string const &workspaceIndices, bool errorBars));
   MOCK_METHOD3(plotBins, void(std::string const &workspaceName, std::string const &binIndices, bool errorBars));

--- a/qt/scientific_interfaces/Muon/ALCInterface.cpp
+++ b/qt/scientific_interfaces/Muon/ALCInterface.cpp
@@ -50,8 +50,8 @@ QHash<QString, QVariant> createLineKwargs() {
   return kwargs;
 }
 
-std::vector<boost::optional<QHash<QString, QVariant>>> createPointAndLineKwargs() {
-  std::vector<boost::optional<QHash<QString, QVariant>>> kwargs;
+std::vector<std::optional<QHash<QString, QVariant>>> createPointAndLineKwargs() {
+  std::vector<std::optional<QHash<QString, QVariant>>> kwargs;
   kwargs.emplace_back(createPointKwargs());
   kwargs.emplace_back(createLineKwargs());
   return kwargs;
@@ -332,7 +332,7 @@ void ALCInterface::externalPlotRequested() {
  */
 void ALCInterface::externallyPlotWorkspace(MatrixWorkspace_sptr &data, std::string const &workspaceName,
                                            std::string const &workspaceIndices, bool errorBars,
-                                           boost::optional<QHash<QString, QVariant>> const &kwargs) {
+                                           std::optional<QHash<QString, QVariant>> const &kwargs) {
   AnalysisDataService::Instance().addOrReplace(workspaceName, data);
   m_externalPlotter->plotSpectra(workspaceName, workspaceIndices, errorBars, kwargs);
 }
@@ -348,7 +348,7 @@ void ALCInterface::externallyPlotWorkspace(MatrixWorkspace_sptr &data, std::stri
 void ALCInterface::externallyPlotWorkspaces(MatrixWorkspace_sptr &data, std::vector<std::string> const &workspaceNames,
                                             std::vector<int> const &workspaceIndices,
                                             std::vector<bool> const &errorBars,
-                                            std::vector<boost::optional<QHash<QString, QVariant>>> const &kwargs) {
+                                            std::vector<std::optional<QHash<QString, QVariant>>> const &kwargs) {
   AnalysisDataService::Instance().addOrReplace(workspaceNames[0], data);
   m_externalPlotter->plotCorrespondingSpectra(workspaceNames, workspaceIndices, errorBars, kwargs);
 }

--- a/qt/scientific_interfaces/Muon/ALCInterface.h
+++ b/qt/scientific_interfaces/Muon/ALCInterface.h
@@ -62,10 +62,10 @@ private:
   void importPeakData(const std::string &workspaceName);
   void externallyPlotWorkspace(Mantid::API ::MatrixWorkspace_sptr &data, std::string const &workspaceName,
                                std::string const &workspaceIndices, bool errorBars,
-                               boost::optional<QHash<QString, QVariant>> const &kwargs);
+                               std::optional<QHash<QString, QVariant>> const &kwargs);
   void externallyPlotWorkspaces(Mantid::API::MatrixWorkspace_sptr &data, std::vector<std::string> const &workspaceNames,
                                 std::vector<int> const &workspaceIndices, std::vector<bool> const &errorBars,
-                                std::vector<boost::optional<QHash<QString, QVariant>>> const &spectraKwargs);
+                                std::vector<std::optional<QHash<QString, QVariant>>> const &spectraKwargs);
   void externalPlotDataLoading();
   void externalPlotBaselineModel();
   void externalPlotPeakFitting();

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/Batch/ExtractSubtrees.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/Batch/ExtractSubtrees.h
@@ -14,7 +14,8 @@ developer.mantidproject.org/BatchWidget/index.html
 #include "MantidQtWidgets/Common/Batch/RowLocation.h"
 #include "MantidQtWidgets/Common/Batch/Subtree.h"
 #include "MantidQtWidgets/Common/DllOption.h"
-#include <boost/optional.hpp>
+
+#include <optional>
 #include <string>
 #include <vector>
 namespace MantidQt {
@@ -25,7 +26,7 @@ class EXPORT_OPT_MANTIDQT_COMMON ExtractSubtrees {
 public:
   using RandomAccessRowIterator = std::vector<Row>::iterator;
   using RandomAccessConstRowIterator = std::vector<Row>::const_iterator;
-  boost::optional<std::vector<Subtree>> operator()(std::vector<Row> region) const;
+  std::optional<std::vector<Subtree>> operator()(std::vector<Row> region) const;
 
 private:
   RandomAccessConstRowIterator findEndOfSubtree(RandomAccessConstRowIterator subtreeBegin,

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/Batch/FindSubtreeRoots.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/Batch/FindSubtreeRoots.h
@@ -12,7 +12,8 @@ developer.mantidproject.org/BatchWidget/index.html
 #include "MantidQtWidgets/Common/Batch/AssertOrThrow.h"
 #include "MantidQtWidgets/Common/Batch/RowLocation.h"
 #include "MantidQtWidgets/Common/DllOption.h"
-#include <boost/optional.hpp>
+
+#include <optional>
 #include <string>
 #include <vector>
 namespace MantidQt {
@@ -21,7 +22,7 @@ namespace Batch {
 
 class EXPORT_OPT_MANTIDQT_COMMON FindSubtreeRoots {
 public:
-  boost::optional<std::vector<RowLocation>> operator()(std::vector<RowLocation> region);
+  std::optional<std::vector<RowLocation>> operator()(std::vector<RowLocation> region);
 
 private:
   void removeIfDepthNotEqualTo(std::vector<RowLocation> &region, int expectedDepth) const;

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/Batch/IJobTreeView.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/Batch/IJobTreeView.h
@@ -13,7 +13,8 @@
 #include "MantidQtWidgets/Common/Batch/Subtree.h"
 #include "MantidQtWidgets/Common/DllOption.h"
 #include "MantidQtWidgets/Common/HintStrategy.h"
-#include <boost/optional.hpp>
+
+#include <optional>
 
 namespace MantidQt {
 namespace MantidWidgets {
@@ -81,8 +82,8 @@ public:
   virtual void collapseAll() = 0;
 
   virtual std::vector<RowLocation> selectedRowLocations() const = 0;
-  virtual boost::optional<std::vector<Subtree>> selectedSubtrees() const = 0;
-  virtual boost::optional<std::vector<RowLocation>> selectedSubtreeRoots() const = 0;
+  virtual std::optional<std::vector<Subtree>> selectedSubtrees() const = 0;
+  virtual std::optional<std::vector<RowLocation>> selectedSubtreeRoots() const = 0;
   virtual int currentColumn() const = 0;
   virtual Cell deadCell() const = 0;
   virtual ~IJobTreeView() = default;

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/Batch/JobTreeView.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/Batch/JobTreeView.h
@@ -74,8 +74,8 @@ public:
 
   QModelIndex moveCursor(CursorAction cursorAction, Qt::KeyboardModifiers modifiers) override;
   std::vector<RowLocation> selectedRowLocations() const override;
-  boost::optional<std::vector<Subtree>> selectedSubtrees() const override;
-  boost::optional<std::vector<RowLocation>> selectedSubtreeRoots() const override;
+  std::optional<std::vector<Subtree>> selectedSubtrees() const override;
+  std::optional<std::vector<RowLocation>> selectedSubtreeRoots() const override;
 
   bool hasNoSelectedDescendants(QModelIndex const &index) const;
   void appendAllUnselectedDescendants(QModelIndexList &selectedRows, QModelIndex const &index) const;

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/Batch/MockJobTreeView.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/Batch/MockJobTreeView.h
@@ -7,6 +7,7 @@
 #pragma once
 #include "MantidKernel/WarningSuppressions.h"
 #include "MantidQtWidgets/Common/Batch/IJobTreeView.h"
+
 #include <gmock/gmock.h>
 
 using testing::Return;
@@ -67,8 +68,8 @@ public:
   }
 
   MOCK_CONST_METHOD0(selectedRowLocations, std::vector<RowLocation>());
-  MOCK_CONST_METHOD0(selectedSubtrees, boost::optional<std::vector<Subtree>>());
-  MOCK_CONST_METHOD0(selectedSubtreeRoots, boost::optional<std::vector<RowLocation>>());
+  MOCK_CONST_METHOD0(selectedSubtrees, std::optional<std::vector<Subtree>>());
+  MOCK_CONST_METHOD0(selectedSubtreeRoots, std::optional<std::vector<RowLocation>>());
   MOCK_CONST_METHOD0(currentColumn, int());
   MOCK_CONST_METHOD0(deadCell, Cell());
 

--- a/qt/widgets/common/src/Batch/ExtractSubtrees.cpp
+++ b/qt/widgets/common/src/Batch/ExtractSubtrees.cpp
@@ -43,7 +43,7 @@ std::vector<Subtree> ExtractSubtrees::makeSubtreesFromRows(std::vector<Row> cons
 
 RowLocation rowToRowLocation(Row const &row) { return row.location(); }
 
-auto ExtractSubtrees::operator()(std::vector<Row> region) const -> boost::optional<std::vector<Subtree>> {
+auto ExtractSubtrees::operator()(std::vector<Row> region) const -> std::optional<std::vector<Subtree>> {
   std::sort(region.begin(), region.end());
   if (!region.empty()) {
     auto subtreeRootDepth = rowToRowLocation(region[0]).depth();
@@ -53,7 +53,7 @@ auto ExtractSubtrees::operator()(std::vector<Row> region) const -> boost::option
     if (allSubtreeRootsShareAParentAndAllSubtreeNodesAreConnected(subtreeRootDepth, rowLocationBegin, rowLocationEnd))
       return makeSubtreesFromRows(region, subtreeRootDepth);
     else
-      return boost::none;
+      return std::nullopt;
   } else {
     return std::vector<Subtree>();
   }

--- a/qt/widgets/common/src/Batch/FindSubtreeRoots.cpp
+++ b/qt/widgets/common/src/Batch/FindSubtreeRoots.cpp
@@ -8,7 +8,7 @@
 #include "MantidQtWidgets/Common/Batch/Subtree.h"
 namespace MantidQt::MantidWidgets::Batch {
 
-auto FindSubtreeRoots::operator()(std::vector<RowLocation> region) -> boost::optional<std::vector<RowLocation>> {
+auto FindSubtreeRoots::operator()(std::vector<RowLocation> region) -> std::optional<std::vector<RowLocation>> {
   std::sort(region.begin(), region.end());
   if (!region.empty()) {
     auto subtreeRootDepth = region[0].depth();
@@ -16,7 +16,7 @@ auto FindSubtreeRoots::operator()(std::vector<RowLocation> region) -> boost::opt
       removeIfDepthNotEqualTo(region, subtreeRootDepth);
       return region;
     } else {
-      return boost::none;
+      return std::nullopt;
     }
   } else {
     return std::vector<RowLocation>();

--- a/qt/widgets/common/src/Batch/JobTreeView.cpp
+++ b/qt/widgets/common/src/Batch/JobTreeView.cpp
@@ -86,7 +86,7 @@ bool JobTreeView::edit(const QModelIndex &index, EditTrigger trigger, QEvent *ev
 
 Cell JobTreeView::deadCell() const { return g_deadCell; }
 
-boost::optional<std::vector<Subtree>> JobTreeView::selectedSubtrees() const {
+std::optional<std::vector<Subtree>> JobTreeView::selectedSubtrees() const {
   auto selected = selectedRowLocations();
   std::sort(selected.begin(), selected.end());
 
@@ -100,7 +100,7 @@ boost::optional<std::vector<Subtree>> JobTreeView::selectedSubtrees() const {
   return extractSubtrees(selectedRows);
 }
 
-boost::optional<std::vector<RowLocation>> JobTreeView::selectedSubtreeRoots() const {
+std::optional<std::vector<RowLocation>> JobTreeView::selectedSubtreeRoots() const {
   auto findSubtreeRoots = FindSubtreeRoots();
   return findSubtreeRoots(selectedRowLocations());
 }

--- a/qt/widgets/common/test/Batch/ExtractSubtreesTest.h
+++ b/qt/widgets/common/test/Batch/ExtractSubtreesTest.h
@@ -34,7 +34,7 @@ public:
   void testForSingleLocation() {
     auto extractSubtrees = ExtractSubtrees();
     auto region = std::vector<Row>({Row(RowLocation({1}), cells("Root"))});
-    auto roots = extractSubtrees(region).get();
+    auto roots = extractSubtrees(region).value();
 
     // clang-format off
     auto expectedSubtrees =
@@ -63,7 +63,7 @@ public:
         });
     // clang-format on
 
-    auto roots = extractSubtrees(region).get();
+    auto roots = extractSubtrees(region).value();
     TS_ASSERT_EQUALS(expectedSubtrees, roots);
   }
 
@@ -81,7 +81,7 @@ public:
         });
     // clang-format on
 
-    auto roots = extractSubtrees(region).get();
+    auto roots = extractSubtrees(region).value();
     TS_ASSERT_EQUALS(expectedSubtrees, roots);
   }
 
@@ -108,7 +108,7 @@ public:
         });
     // clang-format on
 
-    auto roots = extractSubtrees(region).get();
+    auto roots = extractSubtrees(region).value();
     TS_ASSERT_EQUALS(expectedSubtrees, roots);
   }
 
@@ -135,7 +135,7 @@ public:
         });
     // clang-format on
 
-    auto roots = extractSubtrees(region).get();
+    auto roots = extractSubtrees(region).value();
     TS_ASSERT_EQUALS(expectedSubtrees, roots);
   }
 
@@ -149,7 +149,7 @@ public:
     });
     // clang-format on
 
-    TS_ASSERT(!extractSubtrees(region).is_initialized());
+    TS_ASSERT(!extractSubtrees(region).has_value());
   }
 
   void testFailsForLevelGapBetweenSubtrees() {
@@ -165,7 +165,7 @@ public:
     });
     // clang-format on
 
-    TS_ASSERT(!extractSubtrees(region).is_initialized());
+    TS_ASSERT(!extractSubtrees(region).has_value());
   }
 
   void testForRealisticTree() {
@@ -212,7 +212,7 @@ public:
         });
     // clang-format on
 
-    auto roots = extractSubtrees(region).get();
+    auto roots = extractSubtrees(region).value();
     TS_ASSERT_EQUALS(expectedSubtrees, roots);
   }
 
@@ -231,7 +231,7 @@ public:
     // clang-format on
 
     auto subtrees = extractSubtrees(region);
-    TS_ASSERT(!subtrees.is_initialized())
+    TS_ASSERT(!subtrees.has_value())
   }
 
   void testFailsForDeepRoot() {
@@ -249,7 +249,7 @@ public:
     // clang-format on
 
     auto subtrees = extractSubtrees(region);
-    TS_ASSERT(!subtrees.is_initialized())
+    TS_ASSERT(!subtrees.has_value())
   }
 
   void testFailsForDeepRootImmediatelyAfterFirstRoot() {
@@ -262,7 +262,7 @@ public:
     // clang-format on
 
     auto roots = extractSubtrees(region);
-    TS_ASSERT(!roots.is_initialized())
+    TS_ASSERT(!roots.has_value())
   }
 
   void testFailsForShallowRootImmediatelyAfterFirstRoot() {
@@ -275,6 +275,6 @@ public:
     // clang-format on
 
     auto roots = extractSubtrees(region);
-    TS_ASSERT(!roots.is_initialized())
+    TS_ASSERT(!roots.has_value())
   }
 };

--- a/qt/widgets/common/test/Batch/FindSubtreeRootsTest.h
+++ b/qt/widgets/common/test/Batch/FindSubtreeRootsTest.h
@@ -32,8 +32,8 @@ public:
 
     auto expectedRoots = std::vector<RowLocation>({RowLocation({1})});
 
-    TS_ASSERT(roots.is_initialized());
-    TS_ASSERT_EQUALS(expectedRoots, roots.get());
+    TS_ASSERT(roots.has_value());
+    TS_ASSERT_EQUALS(expectedRoots, roots.value());
   }
 
   void testTwoSiblingsResultsInTwoRoots() {
@@ -48,8 +48,8 @@ public:
     // clang-format on
 
     auto roots = findSubtreeRoots(region);
-    TS_ASSERT(roots.is_initialized());
-    TS_ASSERT_EQUALS(expectedRoots, roots.get());
+    TS_ASSERT(roots.has_value());
+    TS_ASSERT_EQUALS(expectedRoots, roots.value());
   }
 
   void testParentAndChildResultsInParent() {
@@ -59,8 +59,8 @@ public:
     auto expectedRoots = std::vector<RowLocation>({RowLocation({1})});
 
     auto roots = findSubtreeRoots(region);
-    TS_ASSERT(roots.is_initialized());
-    TS_ASSERT_EQUALS(expectedRoots, roots.get());
+    TS_ASSERT(roots.has_value());
+    TS_ASSERT_EQUALS(expectedRoots, roots.value());
   }
 
   void testParentWithChildAndSiblingResultsInParentAndSibling() {
@@ -76,8 +76,8 @@ public:
     auto expectedRoots = std::vector<RowLocation>({RowLocation({1}), RowLocation({2})});
 
     auto roots = findSubtreeRoots(region);
-    TS_ASSERT(roots.is_initialized());
-    TS_ASSERT_EQUALS(expectedRoots, roots.get());
+    TS_ASSERT(roots.has_value());
+    TS_ASSERT_EQUALS(expectedRoots, roots.value());
   }
 
   void testFindsRootOfNonTrivialTree() {
@@ -94,8 +94,8 @@ public:
     auto expectedRoots = std::vector<RowLocation>({RowLocation({1})});
 
     auto roots = findSubtreeRoots(region);
-    TS_ASSERT(roots.is_initialized());
-    TS_ASSERT_EQUALS(expectedRoots, roots.get());
+    TS_ASSERT(roots.has_value());
+    TS_ASSERT_EQUALS(expectedRoots, roots.value());
   }
 
   void testFailsForLevelGap() {
@@ -108,7 +108,7 @@ public:
     });
     // clang-format on
 
-    TS_ASSERT(!findSubtreeRoots(region).is_initialized());
+    TS_ASSERT(!findSubtreeRoots(region).has_value());
   }
 
   void testForRealisticTree() {
@@ -140,8 +140,8 @@ public:
     // clang-format on
 
     auto roots = findSubtreeRoots(region);
-    TS_ASSERT(roots.is_initialized());
-    TS_ASSERT_EQUALS(expectedRoots, roots.get());
+    TS_ASSERT(roots.has_value());
+    TS_ASSERT_EQUALS(expectedRoots, roots.value());
   }
 
   void testFailsForShallowRoot() {
@@ -159,7 +159,7 @@ public:
     // clang-format on
 
     auto roots = findSubtreeRoots(region);
-    TS_ASSERT(!roots.is_initialized())
+    TS_ASSERT(!roots.has_value())
   }
 
   void testFailsForDeepRoot() {
@@ -177,7 +177,7 @@ public:
     // clang-format on
 
     auto roots = findSubtreeRoots(region);
-    TS_ASSERT(!roots.is_initialized())
+    TS_ASSERT(!roots.has_value())
   }
 
   void testFailsForDeepRootImmediatelyAfterFirstRoot() {
@@ -190,7 +190,7 @@ public:
     // clang-format on
 
     auto roots = findSubtreeRoots(region);
-    TS_ASSERT(!roots.is_initialized())
+    TS_ASSERT(!roots.has_value())
   }
 
   void testFailsForShallowRootImmediatelyAfterFirstRoot() {
@@ -203,7 +203,7 @@ public:
     // clang-format on
 
     auto roots = findSubtreeRoots(region);
-    TS_ASSERT(!roots.is_initialized())
+    TS_ASSERT(!roots.has_value())
   }
 
   void testFailsForDisconnectedRoots() {
@@ -216,7 +216,7 @@ public:
     // clang-format on
 
     auto roots = findSubtreeRoots(region);
-    TS_ASSERT(!roots.is_initialized())
+    TS_ASSERT(!roots.has_value())
   }
 
   void testForDocumentationFailTree() {
@@ -233,6 +233,6 @@ public:
     });
     // clang-format on
     auto roots = findSubtreeRoots(region);
-    TS_ASSERT(!roots.is_initialized())
+    TS_ASSERT(!roots.has_value())
   }
 };

--- a/qt/widgets/mplcpp/inc/MantidQtWidgets/MplCpp/Plot.h
+++ b/qt/widgets/mplcpp/inc/MantidQtWidgets/MplCpp/Plot.h
@@ -13,8 +13,7 @@
 #include <QString>
 #include <QStringList>
 #include <QVariant>
-#include <boost/none_t.hpp>
-#include <boost/optional.hpp>
+#include <optional>
 #include <vector>
 
 namespace MantidQt {
@@ -33,8 +32,8 @@ enum class MantidAxType : int { Bin = 0, Spectrum = 1 };
  * Makes a call to mantidqt.plotting.plot.
  *
  * Each of the inputs to this function are optional and thus can be replaced
- * with boost::none if no other item should be given. However it does require
- * that boost::none be given for all items that are not the defaulted bools, on
+ * with std::nullopt if no other item should be given. However it does require
+ * that std::nullopt be given for all items that are not the defaulted bools, on
  * every call.
  *
  * @param workspaces A vector of workspace names that are present in the ADS
@@ -66,31 +65,31 @@ enum class MantidAxType : int { Bin = 0, Spectrum = 1 };
  * function in Python
  */
 MANTID_MPLCPP_DLL Common::Python::Object plot(const std::vector<std::string> &workspaces,
-                                              boost::optional<std::vector<int>> spectrumNums,
-                                              boost::optional<std::vector<int>> wkspIndices,
-                                              boost::optional<Common::Python::Object> fig = boost::none,
-                                              boost::optional<QHash<QString, QVariant>> plotKwargs = boost::none,
-                                              boost::optional<QHash<QString, QVariant>> axProperties = boost::none,
-                                              boost::optional<std::string> windowTitle = boost::none,
+                                              std::optional<std::vector<int>> spectrumNums,
+                                              std::optional<std::vector<int>> wkspIndices,
+                                              std::optional<Common::Python::Object> fig = std::nullopt,
+                                              std::optional<QHash<QString, QVariant>> plotKwargs = std::nullopt,
+                                              std::optional<QHash<QString, QVariant>> axProperties = std::nullopt,
+                                              std::optional<std::string> windowTitle = std::nullopt,
                                               bool errors = false, bool overplot = false, bool tiled = false);
 
 /**
  * \overload plot(const std::vector<std::string> &workspaces,
-     boost::optional<std::vector<int>> spectrumNums,
-     boost::optional<std::vector<int>> wkspIndices,
-     boost::optional<Common::Python::Object> fig = boost::none,
-     boost::optional<QHash<QString, QVariant>> plotKwargs = boost::none,
-     boost::optional<QHash<QString, QVariant>> axProperties = boost::none,
-     boost::optional<std::string> windowTitle = boost::none,
+     std::optional<std::vector<int>> spectrumNums,
+     std::optional<std::vector<int>> wkspIndices,
+     std::optional<Common::Python::Object> fig = std::nullopt,
+     std::optional<QHash<QString, QVariant>> plotKwargs = std::nullopt,
+     std::optional<QHash<QString, QVariant>> axProperties = std::nullopt,
+     std::optional<std::string> windowTitle = std::nullopt,
      bool errors = false, bool overplot = false)
  */
 MANTID_MPLCPP_DLL Common::Python::Object plot(const QStringList &workspaces,
-                                              boost::optional<std::vector<int>> spectrumNums,
-                                              boost::optional<std::vector<int>> wkspIndices,
-                                              boost::optional<Common::Python::Object> fig = boost::none,
-                                              boost::optional<QHash<QString, QVariant>> plotKwargs = boost::none,
-                                              boost::optional<QHash<QString, QVariant>> axProperties = boost::none,
-                                              boost::optional<std::string> windowTitle = boost::none,
+                                              std::optional<std::vector<int>> spectrumNums,
+                                              std::optional<std::vector<int>> wkspIndices,
+                                              std::optional<Common::Python::Object> fig = std::nullopt,
+                                              std::optional<QHash<QString, QVariant>> plotKwargs = std::nullopt,
+                                              std::optional<QHash<QString, QVariant>> axProperties = std::nullopt,
+                                              std::optional<std::string> windowTitle = std::nullopt,
                                               bool errors = false, bool overplot = false, bool tiled = false);
 
 /**
@@ -123,11 +122,11 @@ MANTID_MPLCPP_DLL Common::Python::Object plot(const QStringList &workspaces,
  * function in Python
  */
 MANTID_MPLCPP_DLL Common::Python::Object
-plotsubplots(const QStringList &workspaces, boost::optional<std::vector<int>> spectrumNums,
-             boost::optional<std::vector<int>> wkspIndices, boost::optional<Common::Python::Object> fig = boost::none,
-             boost::optional<QHash<QString, QVariant>> plotKwargs = boost::none,
-             boost::optional<QHash<QString, QVariant>> axProperties = boost::none,
-             boost::optional<std::string> windowTitle = boost::none, bool errors = false);
+plotsubplots(const QStringList &workspaces, std::optional<std::vector<int>> spectrumNums,
+             std::optional<std::vector<int>> wkspIndices, std::optional<Common::Python::Object> fig = std::nullopt,
+             std::optional<QHash<QString, QVariant>> plotKwargs = std::nullopt,
+             std::optional<QHash<QString, QVariant>> axProperties = std::nullopt,
+             std::optional<std::string> windowTitle = std::nullopt, bool errors = false);
 
 /**
  * Makes a call to mantidqt.plotting.pcolormesh.
@@ -140,7 +139,7 @@ plotsubplots(const QStringList &workspaces, boost::optional<std::vector<int>> sp
  * function in Python
  */
 MANTID_MPLCPP_DLL Common::Python::Object pcolormesh(const QStringList &workspaces,
-                                                    boost::optional<Common::Python::Object> fig = boost::none);
+                                                    std::optional<Common::Python::Object> fig = std::nullopt);
 
 } // namespace MplCpp
 } // namespace Widgets

--- a/qt/widgets/mplcpp/src/Plot.cpp
+++ b/qt/widgets/mplcpp/src/Plot.cpp
@@ -51,46 +51,46 @@ Python::Object constructArgs(const QStringList &workspaces) {
 /**
  * Construct kwargs list for the plot function
  */
-Python::Object constructKwargs(boost::optional<std::vector<int>> spectrumNums,
-                               boost::optional<std::vector<int>> wkspIndices, boost::optional<Python::Object> fig,
-                               boost::optional<QHash<QString, QVariant>> plotKwargs,
-                               boost::optional<QHash<QString, QVariant>> axProperties,
-                               boost::optional<std::string> windowTitle, boost::optional<bool> errors,
-                               boost::optional<bool> overplot, boost::optional<bool> tiled) {
+Python::Object constructKwargs(std::optional<std::vector<int>> spectrumNums,
+                               std::optional<std::vector<int>> wkspIndices, std::optional<Python::Object> fig,
+                               std::optional<QHash<QString, QVariant>> plotKwargs,
+                               std::optional<QHash<QString, QVariant>> axProperties,
+                               std::optional<std::string> windowTitle, std::optional<bool> errors,
+                               std::optional<bool> overplot, std::optional<bool> tiled) {
   // Make sure to decide whether spectrum numbers or workspace indices
   Python::Dict kwargs;
 
   if (spectrumNums && !wkspIndices) {
-    kwargs["spectrum_nums"] = Converters::ToPyList<int>()(spectrumNums.get());
+    kwargs["spectrum_nums"] = Converters::ToPyList<int>()(spectrumNums.value());
   } else if (wkspIndices && !spectrumNums) {
-    kwargs["wksp_indices"] = Converters::ToPyList<int>()(wkspIndices.get());
+    kwargs["wksp_indices"] = Converters::ToPyList<int>()(wkspIndices.value());
   } else {
     throw std::invalid_argument("Passed spectrum numbers and workspace indices, please only pass one, "
-                                "with the other being boost::none.");
+                                "with the other being std::nullopt.");
   }
 
   if (errors)
-    kwargs["errors"] = errors.get();
+    kwargs["errors"] = errors.value();
   if (overplot)
-    kwargs["overplot"] = overplot.get();
+    kwargs["overplot"] = overplot.value();
   if (tiled)
-    kwargs["tiled"] = tiled.get();
+    kwargs["tiled"] = tiled.value();
   if (fig)
-    kwargs["fig"] = fig.get();
+    kwargs["fig"] = fig.value();
   if (plotKwargs)
-    kwargs["plot_kwargs"] = Python::qHashToDict(plotKwargs.get());
+    kwargs["plot_kwargs"] = Python::qHashToDict(plotKwargs.value());
   if (axProperties)
-    kwargs["ax_properties"] = Python::qHashToDict(axProperties.get());
+    kwargs["ax_properties"] = Python::qHashToDict(axProperties.value());
   if (windowTitle)
-    kwargs["window_title"] = windowTitle.get();
+    kwargs["window_title"] = windowTitle.value();
 
   return std::move(kwargs);
 }
 
-Python::Object plot(const Python::Object &args, boost::optional<std::vector<int>> spectrumNums,
-                    boost::optional<std::vector<int>> wkspIndices, boost::optional<Python::Object> fig,
-                    boost::optional<QHash<QString, QVariant>> plotKwargs,
-                    boost::optional<QHash<QString, QVariant>> axProperties, boost::optional<std::string> windowTitle,
+Python::Object plot(const Python::Object &args, std::optional<std::vector<int>> spectrumNums,
+                    std::optional<std::vector<int>> wkspIndices, std::optional<Python::Object> fig,
+                    std::optional<QHash<QString, QVariant>> plotKwargs,
+                    std::optional<QHash<QString, QVariant>> axProperties, std::optional<std::string> windowTitle,
                     bool errors, bool overplot, bool tiled) {
   const auto kwargs =
       constructKwargs(std::move(spectrumNums), std::move(wkspIndices), std::move(fig), std::move(plotKwargs),
@@ -104,33 +104,33 @@ Python::Object plot(const Python::Object &args, boost::optional<std::vector<int>
 
 } // namespace
 
-Python::Object plot(const std::vector<std::string> &workspaces, boost::optional<std::vector<int>> spectrumNums,
-                    boost::optional<std::vector<int>> wkspIndices, boost::optional<Python::Object> fig,
-                    boost::optional<QHash<QString, QVariant>> plotKwargs,
-                    boost::optional<QHash<QString, QVariant>> axProperties, boost::optional<std::string> windowTitle,
+Python::Object plot(const std::vector<std::string> &workspaces, std::optional<std::vector<int>> spectrumNums,
+                    std::optional<std::vector<int>> wkspIndices, std::optional<Python::Object> fig,
+                    std::optional<QHash<QString, QVariant>> plotKwargs,
+                    std::optional<QHash<QString, QVariant>> axProperties, std::optional<std::string> windowTitle,
                     bool errors, bool overplot, bool tiled) {
   GlobalInterpreterLock lock;
   return plot(constructArgs(workspaces), std::move(spectrumNums), std::move(wkspIndices), std::move(fig),
               std::move(plotKwargs), std::move(axProperties), std::move(windowTitle), errors, overplot, tiled);
 }
 
-Python::Object plot(const QStringList &workspaces, boost::optional<std::vector<int>> spectrumNums,
-                    boost::optional<std::vector<int>> wkspIndices, boost::optional<Python::Object> fig,
-                    boost::optional<QHash<QString, QVariant>> plotKwargs,
-                    boost::optional<QHash<QString, QVariant>> axProperties, boost::optional<std::string> windowTitle,
+Python::Object plot(const QStringList &workspaces, std::optional<std::vector<int>> spectrumNums,
+                    std::optional<std::vector<int>> wkspIndices, std::optional<Python::Object> fig,
+                    std::optional<QHash<QString, QVariant>> plotKwargs,
+                    std::optional<QHash<QString, QVariant>> axProperties, std::optional<std::string> windowTitle,
                     bool errors, bool overplot, bool tiled) {
   GlobalInterpreterLock lock;
   return plot(constructArgs(workspaces), std::move(spectrumNums), std::move(wkspIndices), std::move(fig),
               std::move(plotKwargs), std::move(axProperties), std::move(windowTitle), errors, overplot, tiled);
 }
 
-Python::Object pcolormesh(const QStringList &workspaces, boost::optional<Python::Object> fig) {
+Python::Object pcolormesh(const QStringList &workspaces, std::optional<Python::Object> fig) {
   GlobalInterpreterLock lock;
   try {
     const auto args = constructArgs(workspaces);
     Python::Dict kwargs;
     if (fig)
-      kwargs["fig"] = fig.get();
+      kwargs["fig"] = fig.value();
     return functionsModule().attr("pcolormesh")(*args, **kwargs);
   } catch (Python::ErrorAlreadySet &) {
     throw PythonException();

--- a/qt/widgets/mplcpp/test/PlotTest.h
+++ b/qt/widgets/mplcpp/test/PlotTest.h
@@ -29,19 +29,19 @@ public:
   void testPlottingWorksWithWorkspaceIndex() {
     const std::vector<std::string> workspaces = {m_testws_name};
     const std::vector<int> index = {1};
-    TS_ASSERT_THROWS_NOTHING(plot(workspaces, boost::none, index))
+    TS_ASSERT_THROWS_NOTHING(plot(workspaces, std::nullopt, index))
   }
 
   void testPlottingWorksQStrings() {
     const QStringList workspaces = {m_testws_name};
     const std::vector<int> index = {1};
-    TS_ASSERT_THROWS_NOTHING(plot(workspaces, boost::none, index))
+    TS_ASSERT_THROWS_NOTHING(plot(workspaces, std::nullopt, index))
   }
 
   void testPlottingWorksWithSpecNum() {
     const std::vector<std::string> workspaces = {m_testws_name};
     const std::vector<int> index = {1};
-    TS_ASSERT_THROWS_NOTHING(plot(workspaces, index, boost::none))
+    TS_ASSERT_THROWS_NOTHING(plot(workspaces, index, std::nullopt))
   }
 
   void testPlottingThrowsWithSpecNumAndWorkspaceIndex() {
@@ -55,7 +55,7 @@ public:
     const std::vector<int> index = {1};
     QHash<QString, QVariant> hash;
     hash.insert(QString("linewidth"), QVariant(10));
-    TS_ASSERT_THROWS_NOTHING(plot(workspaces, index, boost::none, boost::none, hash))
+    TS_ASSERT_THROWS_NOTHING(plot(workspaces, index, std::nullopt, std::nullopt, hash))
   }
 
   void testPlottingWorksWhenPlottingABin() {
@@ -64,7 +64,7 @@ public:
     QHash<QString, QVariant> hash;
     hash["axis"] = static_cast<int>(MantidAxType::Bin);
 
-    TS_ASSERT_THROWS_NOTHING(plot(workspaces, index, boost::none, boost::none, hash))
+    TS_ASSERT_THROWS_NOTHING(plot(workspaces, index, std::nullopt, std::nullopt, hash))
   }
 
   void testPlottingWithIncorrectPlotKwargsThrows() {
@@ -72,7 +72,7 @@ public:
     const std::vector<int> index = {1};
     QHash<QString, QVariant> hash;
     hash.insert(QString("asdasdasdasdasd"), QVariant(1));
-    TS_ASSERT_THROWS(plot(workspaces, index, boost::none, boost::none, hash), const PythonException &)
+    TS_ASSERT_THROWS(plot(workspaces, index, std::nullopt, std::nullopt, hash), const PythonException &)
   }
 
   void testPlottingWithAxProperties() {
@@ -80,7 +80,7 @@ public:
     const std::vector<int> index = {1};
     QHash<QString, QVariant> hash;
     hash.insert(QString("xscale"), QVariant("log"));
-    TS_ASSERT_THROWS_NOTHING(plot(workspaces, index, boost::none, boost::none, boost::none, hash))
+    TS_ASSERT_THROWS_NOTHING(plot(workspaces, index, std::nullopt, std::nullopt, std::nullopt, hash))
   }
 
   void testPlottingWithIncorrectAxPropertiesThrows() {
@@ -88,21 +88,22 @@ public:
     const std::vector<int> index = {1};
     QHash<QString, QVariant> hash;
     hash.insert(QString("asdasdasdasdasd"), QVariant(QString(1)));
-    TS_ASSERT_THROWS(plot(workspaces, index, boost::none, boost::none, boost::none, hash), const PythonException &)
+    TS_ASSERT_THROWS(plot(workspaces, index, std::nullopt, std::nullopt, std::nullopt, hash), const PythonException &)
   }
 
   void testPlottingWithWindowTitle() {
     const std::vector<std::string> workspaces = {m_testws_name};
     const std::vector<int> index = {1};
     const std::string window_title = "window_title";
-    TS_ASSERT_THROWS_NOTHING(plot(workspaces, boost::none, index, boost::none, boost::none, boost::none, window_title))
+    TS_ASSERT_THROWS_NOTHING(
+        plot(workspaces, std::nullopt, index, std::nullopt, std::nullopt, std::nullopt, window_title))
   }
 
   void testPlottingWithErrors() {
     const std::vector<std::string> workspaces = {m_testws_name};
     const std::vector<int> index = {1};
     TS_ASSERT_THROWS_NOTHING(
-        plot(workspaces, boost::none, index, boost::none, boost::none, boost::none, boost::none, true))
+        plot(workspaces, std::nullopt, index, std::nullopt, std::nullopt, std::nullopt, std::nullopt, true))
   }
 
   void testPlottingWithOverplotAndMultipleWorkspaces() {
@@ -111,7 +112,7 @@ public:
     const std::vector<std::string> workspaces = {m_testws_name, "ws1", "ws2"};
     const std::vector<int> index = {1, 1, 1};
     TS_ASSERT_THROWS_NOTHING(
-        plot(workspaces, boost::none, index, boost::none, boost::none, boost::none, boost::none, false, true))
+        plot(workspaces, std::nullopt, index, std::nullopt, std::nullopt, std::nullopt, std::nullopt, false, true))
   }
 
   void testPlottingWithoutOverplotButWithMultipleWorkspace() {
@@ -120,7 +121,7 @@ public:
     const std::vector<std::string> workspaces = {"ws", "ws1", "ws2"};
     const std::vector<int> index = {1, 1, 1};
     TS_ASSERT_THROWS_NOTHING(
-        plot(workspaces, boost::none, index, boost::none, boost::none, boost::none, boost::none, false, false))
+        plot(workspaces, std::nullopt, index, std::nullopt, std::nullopt, std::nullopt, std::nullopt, false, false))
   }
 
   void testPcolormesh() {
@@ -133,7 +134,8 @@ public:
     const std::vector<int> index = {1};
     const std::string window_title = "window_title";
 
-    TS_ASSERT_THROWS_NOTHING(plot(workspaces, boost::none, index, boost::none, boost::none, boost::none, window_title))
+    TS_ASSERT_THROWS_NOTHING(
+        plot(workspaces, std::nullopt, index, std::nullopt, std::nullopt, std::nullopt, window_title))
   }
 
   void testPlottingSubplotsWithErrorsWillNotThrow() {
@@ -141,7 +143,7 @@ public:
     const std::vector<int> index = {1};
 
     TS_ASSERT_THROWS_NOTHING(
-        plot(workspaces, boost::none, index, boost::none, boost::none, boost::none, boost::none, true))
+        plot(workspaces, std::nullopt, index, std::nullopt, std::nullopt, std::nullopt, std::nullopt, true))
   }
 
 private:

--- a/qt/widgets/plotting/CMakeLists.txt
+++ b/qt/widgets/plotting/CMakeLists.txt
@@ -6,15 +6,16 @@ set(MPL_SRC_FILES src/Mpl/ContourPreviewPlot.cpp src/Mpl/ExternalPlotter.cpp src
 )
 
 set(MPL_MOC_FILES
-    inc/MantidQtWidgets/Plotting/Mpl/ContourPreviewPlot.h inc/MantidQtWidgets/Plotting/Mpl/ExternalPlotter.h
-    inc/MantidQtWidgets/Plotting/Mpl/PeakPicker.h inc/MantidQtWidgets/Plotting/Mpl/PreviewPlot.h
-    inc/MantidQtWidgets/Plotting/Mpl/RangeSelector.h inc/MantidQtWidgets/Plotting/Mpl/SingleSelector.h
+    inc/MantidQtWidgets/Plotting/Mpl/ContourPreviewPlot.h inc/MantidQtWidgets/Plotting/Mpl/PeakPicker.h
+    inc/MantidQtWidgets/Plotting/Mpl/PreviewPlot.h inc/MantidQtWidgets/Plotting/Mpl/RangeSelector.h
+    inc/MantidQtWidgets/Plotting/Mpl/SingleSelector.h
 )
 
 # Include files aren't required, but this makes them appear in Visual Studio
 set(MPL_INC_FILES
     ${MPL_MOC_FILES} inc/MantidQtWidgets/Plotting/AxisID.h inc/MantidQtWidgets/Plotting/ContourPreviewPlot.h
     inc/MantidQtWidgets/Plotting/PeakPicker.h inc/MantidQtWidgets/Plotting/PreviewPlot.h
+    inc/MantidQtWidgets/Plotting/Mpl/ExternalPlotter.h
 )
 
 set(MPL_UI_FILES inc/MantidQtWidgets/Plotting/ContourPreviewPlot.ui inc/MantidQtWidgets/Plotting/PreviewPlot.ui)

--- a/qt/widgets/plotting/inc/MantidQtWidgets/Plotting/Mpl/ExternalPlotter.h
+++ b/qt/widgets/plotting/inc/MantidQtWidgets/Plotting/Mpl/ExternalPlotter.h
@@ -10,7 +10,7 @@
 #include "MantidQtWidgets/Plotting/DllOption.h"
 
 #include <boost/none_t.hpp>
-#include <boost/optional.hpp>
+#include <optional>
 
 #include <QHash>
 #include <QVariant>
@@ -33,23 +33,23 @@ public:
 
   virtual void plotSpectra(std::string const &workspaceName, std::string const &workspaceIndices, bool errorBars);
   virtual void plotSpectra(std::string const &workspaceName, std::string const &workspaceIndices, bool errorBars,
-                           boost::optional<QHash<QString, QVariant>> const &kwargs);
+                           std::optional<QHash<QString, QVariant>> const &kwargs);
   virtual void plotCorrespondingSpectra(std::vector<std::string> const &workspaceNames,
                                         std::vector<int> const &workspaceIndices, std::vector<bool> const &errorBars);
   virtual void plotCorrespondingSpectra(std::vector<std::string> const &workspaceNames,
                                         std::vector<int> const &workspaceIndices, std::vector<bool> const &errorBars,
-                                        std::vector<boost::optional<QHash<QString, QVariant>>> const &kwargs);
+                                        std::vector<std::optional<QHash<QString, QVariant>>> const &kwargs);
   virtual void plotBins(std::string const &workspaceName, std::string const &binIndices, bool errorBars);
   virtual void plotContour(std::string const &workspaceName);
   virtual void plotTiled(std::string const &workspaceName, std::string const &workspaceIndices, bool errorBars);
 
-  bool validate(std::string const &workspaceName, boost::optional<std::string> const &workspaceIndices = boost::none,
-                boost::optional<MantidAxis> const &axisType = boost::none) const;
+  bool validate(std::string const &workspaceName, std::optional<std::string> const &workspaceIndices = std::nullopt,
+                std::optional<MantidAxis> const &axisType = std::nullopt) const;
 
 private:
   bool validate(const Mantid::API::MatrixWorkspace_const_sptr &workspace,
-                boost::optional<std::string> const &workspaceIndices = boost::none,
-                boost::optional<MantidAxis> const &axisType = boost::none) const;
+                std::optional<std::string> const &workspaceIndices = std::nullopt,
+                std::optional<MantidAxis> const &axisType = std::nullopt) const;
   bool validateSpectra(const Mantid::API::MatrixWorkspace_const_sptr &workspace,
                        std::string const &workspaceIndices) const;
   bool validateBins(const Mantid::API::MatrixWorkspace_const_sptr &workspace, std::string const &binIndices) const;


### PR DESCRIPTION
**Description of work.**
See commits for descriptions

Tl;dr switch `boost::optional` to `std::optional` in GUI Mocks to make gtest 1.11 work, so I can compile with new(ish) versions of clang to fix a race

**To test:**
- Check all unit tests pass

There is no associated issue.

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
