### PR TITLE
Critial Peak of Relexation Rate fitting function

### DIFF
--- a/Framework/CurveFitting/CMakeLists.txt
+++ b/Framework/CurveFitting/CMakeLists.txt
@@ -415,6 +415,7 @@ set(TEST_FILES
     Functions/ComptonProfileTest.h
     Functions/ComptonScatteringCountRateTest.h
     Functions/ConvolutionTest.h
+    Functions/CriticalPeakRelaxationRateTest.h
     Functions/CrystalFieldControlTest.h
     Functions/CrystalFieldEnergiesTest.h
     Functions/CrystalFieldFunctionTest.h

--- a/Framework/CurveFitting/CMakeLists.txt
+++ b/Framework/CurveFitting/CMakeLists.txt
@@ -66,6 +66,7 @@ set(SRC_FILES
     src/Functions/ComptonProfile.cpp
     src/Functions/ComptonScatteringCountRate.cpp
     src/Functions/Convolution.cpp
+    src/Functions/CriticalPeakRelaxationRate.cpp
     src/Functions/CrystalElectricField.cpp
     src/Functions/CrystalFieldControl.cpp
     src/Functions/CrystalFieldFunction.cpp
@@ -244,6 +245,7 @@ set(INC_FILES
     inc/MantidCurveFitting/Functions/ComptonProfile.h
     inc/MantidCurveFitting/Functions/ComptonScatteringCountRate.h
     inc/MantidCurveFitting/Functions/Convolution.h
+    inc/MantidCurveFitting/Functions/CriticalPeakRelaxationRate.h
     inc/MantidCurveFitting/Functions/CrystalElectricField.h
     inc/MantidCurveFitting/Functions/CrystalFieldControl.h
     inc/MantidCurveFitting/Functions/CrystalFieldFunction.h

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/CriticalPeakRelaxationRate.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/CriticalPeakRelaxationRate.h
@@ -1,0 +1,53 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2021 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin
+// SPDX - License - Identifier: GPL - 3.0 +
+#pragma once
+
+//----------------------------------------------------------------------
+// Includes
+//----------------------------------------------------------------------
+#include "MantidCurveFitting/Functions/BackgroundFunction.h"
+
+namespace Mantid {
+namespace CurveFitting {
+namespace Functions {
+/**
+Provide Critical peak of relaxation rate for fitting interface to IFunction.
+I.e. y = Sc/(|x-Tc|)^a + Bg
+Activation attributes:
+<UL>
+<LI> Sc - Scaling</LI>
+<LI> Tc - critical temperature</LI>
+<LI> a - critical exponent </LI>
+<LI> Bg - non-critical background</LI>
+</UL>
+
+CriticalPeakRelaxationRate parameters:
+<UL>
+<LI> Scaling - coefficient for scaling (default 1.0)</LI>
+<LI> CriticalTemp - coefficient for barrier energy (default 0.01)</LI>
+<LI> Exponent - coefficient for critical exponent (default 1.0)</LI>
+<LI> Background - coefficient for non-critical background (default 0.0)</LI>
+</UL>
+*/
+
+class MANTID_CURVEFITTING_DLL CriticalPeakRelaxationRate : public BackgroundFunction {
+public:
+  /// overwrite IFunction base class methods
+  std::string name() const override { return "CriticalPeakRelaxationRate"; }
+  void function1D(double *out, const double *xValues, const size_t nData) const override;
+  void functionDeriv1D(API::Jacobian *out, const double *xValues, const size_t nData) override;
+  const std::string category() const override { return "Muon\\MuonModelling\\Magnetism"; }
+  void checkParams(const double *xValues, const size_t nData) const;
+
+protected:
+  /// overwrite IFunction base class method, which declare function parameters
+  void init() override;
+};
+
+} // namespace Functions
+} // namespace CurveFitting
+} // namespace Mantid

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/CriticalPeakRelaxationRate.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/CriticalPeakRelaxationRate.h
@@ -30,7 +30,9 @@ CriticalPeakRelaxationRate parameters:
 <LI> Scaling - coefficient for scaling (default 1.0)</LI>
 <LI> CriticalTemp - coefficient for barrier energy (default 0.01)</LI>
 <LI> Exponent - coefficient for critical exponent (default 1.0)</LI>
-<LI> Background - coefficient for non-critical background (default 0.0)</LI>
+<LI> Background1 - coefficient for non-critical background when x < Critical Temperature (default 0.0)</LI>
+<LI> Background2 - coefficient for non-critical background when x > Critical Temperature (default 0.0)</LI>
+<LI> Delta </LI>
 </UL>
 */
 
@@ -39,9 +41,7 @@ public:
   /// overwrite IFunction base class methods
   std::string name() const override { return "CriticalPeakRelaxationRate"; }
   void function1D(double *out, const double *xValues, const size_t nData) const override;
-  void functionDeriv1D(API::Jacobian *out, const double *xValues, const size_t nData) override;
   const std::string category() const override { return "Muon\\MuonModelling\\Magnetism"; }
-  void checkParams(const double *xValues, const size_t nData) const;
 
 protected:
   /// overwrite IFunction base class method, which declare function parameters

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/CriticalPeakRelaxationRate.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/CriticalPeakRelaxationRate.h
@@ -32,7 +32,7 @@ CriticalPeakRelaxationRate parameters:
 <LI> Exponent - coefficient for critical exponent (default 1.0)</LI>
 <LI> Background1 - coefficient for non-critical background when x < Critical Temperature (default 0.0)</LI>
 <LI> Background2 - coefficient for non-critical background when x > Critical Temperature (default 0.0)</LI>
-<LI> Delta </LI>
+<LI> Delta - coefficient to determine distance from the peak to start/end fitting </LI>
 </UL>
 */
 

--- a/Framework/CurveFitting/src/Functions/CriticalPeakRelaxationRate.cpp
+++ b/Framework/CurveFitting/src/Functions/CriticalPeakRelaxationRate.cpp
@@ -41,8 +41,7 @@ void CriticalPeakRelaxationRate::function1D(double *out, const double *xValues, 
   const double Delta = getAttribute("Delta").asDouble();
 
   for (size_t i = 0; i < nData; i++) {
-    auto expression = abs(xValues[i] - Tc);
-    auto denom = pow(expression, Exp);
+    auto denom = pow(fabs(xValues[i] - Tc), Exp);
     if (xValues[i] + Delta < Tc || xValues[i] - Delta > Tc) {
       if (xValues[i] < Tc) {
         out[i] = Bg1 + Scale / denom;

--- a/Framework/CurveFitting/src/Functions/CriticalPeakRelaxationRate.cpp
+++ b/Framework/CurveFitting/src/Functions/CriticalPeakRelaxationRate.cpp
@@ -41,7 +41,7 @@ void CriticalPeakRelaxationRate::function1D(double *out, const double *xValues, 
   const double Delta = getAttribute("Delta").asDouble();
 
   for (size_t i = 0; i < nData; i++) {
-    double expression = abs(xValues[i] - Tc);
+    auto expression = abs(xValues[i] - Tc);
     auto denom = pow(expression, Exp);
     if (xValues[i] + Delta < Tc || xValues[i] - Delta > Tc) {
       if (xValues[i] < Tc) {

--- a/Framework/CurveFitting/src/Functions/CriticalPeakRelaxationRate.cpp
+++ b/Framework/CurveFitting/src/Functions/CriticalPeakRelaxationRate.cpp
@@ -9,7 +9,6 @@
 //----------------------------------------------------------------------
 #include "MantidCurveFitting/Functions/CriticalPeakRelaxationRate.h"
 #include "MantidAPI/FunctionFactory.h"
-#include "MantidKernel/PhysicalConstants.h"
 
 #include <cmath>
 
@@ -50,13 +49,12 @@ void CriticalPeakRelaxationRate::functionDeriv1D(Jacobian *out, const double *xV
   const double scale = getParameter("Scaling");
   const double tc = getParameter("CriticalTemp");
   const double exp = getParameter("Exponent");
-  const double bg = getParameter("Background");
 
   for (size_t i = 0; i < nData; i++) {
-    double expression = abs(tc- xValues[i]);
+    double expression = abs(tc - xValues[i]);
 
     const double diffScale = pow(expression, -exp);
-    const double diffTc = scale * exp * (xValues[i] - tc) * pow(expression, (-exp-2));
+    const double diffTc = scale * exp * (xValues[i] - tc) * pow(expression, (-exp - 2));
     const double diffExp = scale * pow(expression, -exp) * log(expression);
 
     out->set(i, 0, diffScale);
@@ -73,5 +71,5 @@ void CriticalPeakRelaxationRate::checkParams(const double *xValues, const size_t
       throw std::invalid_argument("Use the exclude range option with x=" + std::to_string(xValues[i]) + " and y = inf");
     }
   }
-  }
+}
 } // namespace Mantid::CurveFitting::Functions

--- a/Framework/CurveFitting/src/Functions/CriticalPeakRelaxationRate.cpp
+++ b/Framework/CurveFitting/src/Functions/CriticalPeakRelaxationRate.cpp
@@ -1,0 +1,77 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2021 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin
+// SPDX - License - Identifier: GPL - 3.0 +
+//----------------------------------------------------------------------
+// Includes
+//----------------------------------------------------------------------
+#include "MantidCurveFitting/Functions/CriticalPeakRelaxationRate.h"
+#include "MantidAPI/FunctionFactory.h"
+#include "MantidKernel/PhysicalConstants.h"
+
+#include <cmath>
+
+namespace Mantid::CurveFitting::Functions {
+
+using namespace CurveFitting;
+
+using namespace Kernel;
+
+using namespace API;
+
+DECLARE_FUNCTION(CriticalPeakRelaxationRate)
+
+void CriticalPeakRelaxationRate::init() {
+  declareParameter("Scaling", 1.0, "coefficient for scaling");
+  declareParameter("CriticalTemp", 0.01, "coefficient for critical temperature");
+  declareParameter("Exponent", 1.0, "coefficient for critical exponent");
+  declareParameter("Background", 0.0, "coefficient for non-critical background");
+}
+
+void CriticalPeakRelaxationRate::function1D(double *out, const double *xValues, const size_t nData) const {
+  checkParams(xValues, nData);
+
+  const double scale = getParameter("Scaling");
+  const double tc = getParameter("CriticalTemp");
+  const double exp = getParameter("Exponent");
+  const double bg = getParameter("Background");
+
+  for (size_t i = 0; i < nData; i++) {
+    double expression = abs(xValues[i] - tc);
+    out[i] = scale / pow(expression, exp) + bg;
+  }
+}
+
+void CriticalPeakRelaxationRate::functionDeriv1D(Jacobian *out, const double *xValues, const size_t nData) {
+  checkParams(xValues, nData);
+
+  const double scale = getParameter("Scaling");
+  const double tc = getParameter("CriticalTemp");
+  const double exp = getParameter("Exponent");
+  const double bg = getParameter("Background");
+
+  for (size_t i = 0; i < nData; i++) {
+    double expression = abs(tc- xValues[i]);
+
+    const double diffScale = pow(expression, -exp);
+    const double diffTc = scale * exp * (xValues[i] - tc) * pow(expression, (-exp-2));
+    const double diffExp = scale * pow(expression, -exp) * log(expression);
+
+    out->set(i, 0, diffScale);
+    out->set(i, 1, diffTc);
+    out->set(i, 2, diffExp);
+    out->set(i, 3, 1);
+  }
+}
+
+void CriticalPeakRelaxationRate::checkParams(const double *xValues, const size_t nData) const {
+  const double tc = getParameter("CriticalTemp");
+  for (size_t i = 0; i < nData; i++) {
+    if (xValues[i] == tc) {
+      throw std::invalid_argument("Use the exclude range option with x=" + std::to_string(xValues[i]) + " and y = inf");
+    }
+  }
+  }
+} // namespace Mantid::CurveFitting::Functions

--- a/Framework/CurveFitting/src/Functions/CriticalPeakRelaxationRate.cpp
+++ b/Framework/CurveFitting/src/Functions/CriticalPeakRelaxationRate.cpp
@@ -41,7 +41,8 @@ void CriticalPeakRelaxationRate::function1D(double *out, const double *xValues, 
   const double Delta = getAttribute("Delta").asDouble();
 
   for (size_t i = 0; i < nData; i++) {
-    double denom = pow(abs(xValues[i] - Tc), Exp);
+    double expression = abs(xValues[i] - Tc);
+    auto denom = pow(expression, Exp);
     if (xValues[i] + Delta < Tc || xValues[i] - Delta > Tc) {
       if (xValues[i] < Tc) {
         out[i] = Bg1 + Scale / denom;

--- a/Framework/CurveFitting/src/Functions/CriticalPeakRelaxationRate.cpp
+++ b/Framework/CurveFitting/src/Functions/CriticalPeakRelaxationRate.cpp
@@ -28,61 +28,30 @@ void CriticalPeakRelaxationRate::init() {
   declareParameter("Exponent", 1.0, "coefficient for critical exponent");
   declareParameter("Background1", 0.0, "coefficient for non-critical background when x < Critical Temperature");
   declareParameter("Background2", 0.0, "coefficient for non-critical background when x > Critical Temperature");
-  declareAttribute("Delta", Attribute(0.1));
+  declareAttribute("Delta", Attribute(0.01));
 }
 
 void CriticalPeakRelaxationRate::function1D(double *out, const double *xValues, const size_t nData) const {
-  /*checkParams(xValues, nData);*/
 
-  const double scale = getParameter("Scaling");
-  const double tc = getParameter("CriticalTemp");
-  const double exp = getParameter("Exponent");
-  const double bg1 = getParameter("Background1");
-  const double bg2 = getParameter("Background2");
-  const double d = getAttribute("Delta").asDouble();
+  const double Scale = getParameter("Scaling");
+  const double Tc = getParameter("CriticalTemp");
+  const double Exp = getParameter("Exponent");
+  const double Bg1 = getParameter("Background1");
+  const double Bg2 = getParameter("Background2");
+  const double Delta = getAttribute("Delta").asDouble();
 
   for (size_t i = 0; i < nData; i++) {
-    double denom = pow(abs(xValues[i] - tc), exp);
-    if (xValues[i] + d < tc || xValues[i] - d > tc) {
-      if (xValues[i] < tc) {
-        out[i] = bg1 + scale / denom;
+    double denom = pow(abs(xValues[i] - Tc), Exp);
+    if (xValues[i] + Delta < Tc || xValues[i] - Delta > Tc) {
+      if (xValues[i] < Tc) {
+        out[i] = Bg1 + Scale / denom;
       } else {
-        out[i] = bg2 + scale / denom;
+        out[i] = Bg2 + Scale / denom;
       }
     } else {
-      out[i] = 0.0;
+      out[i] = 1e6;
     }
   }
 }
 
-// void CriticalPeakRelaxationRate::functionDeriv1D(Jacobian *out, const double *xValues, const size_t nData) {
-//  checkParams(xValues, nData);
-//
-//  const double scale = getParameter("Scaling");
-//  const double tc = getParameter("CriticalTemp");
-//  const double exp = getParameter("Exponent");
-//
-//  for (size_t i = 0; i < nData; i++) {
-//    double expression = abs(tc - xValues[i]);
-//
-//    const double diffScale = pow(expression, -exp);
-//    const double diffTc = scale * exp * (xValues[i] - tc) * pow(expression, (-exp - 2));
-//    const double diffExp = scale * pow(expression, -exp) * log(expression);
-//
-//    out->set(i, 0, diffScale);
-//    out->set(i, 1, diffTc);
-//    out->set(i, 2, diffExp);
-//    out->set(i, 3, 1);
-//  }
-//}
-
-// void CriticalPeakRelaxationRate::checkParams(const double *xValues, const size_t nData) const {
-//  const double tc = getParameter("CriticalTemp");
-//  for (size_t i = 0; i < nData; i++) {
-//    if (xValues[i] == tc) {
-//      throw std::invalid_argument("Use the exclude range option with x=" + std::to_string(xValues[i]) + " and y =
-//      inf");
-//    }
-//  }
-//}
 } // namespace Mantid::CurveFitting::Functions

--- a/Framework/CurveFitting/test/Functions/CriticalPeakRelaxationRateTest.h
+++ b/Framework/CurveFitting/test/Functions/CriticalPeakRelaxationRateTest.h
@@ -38,65 +38,37 @@ public:
     TS_ASSERT_THROWS(critprr->setParameter("A9", 1.0), const std::invalid_argument &);
   }
 
-  void test_x_tc_values() {
-    auto critprr = createTestCriticalPeakRelaxationRate();
-
-    // when x and Tc are not the same
-    const std::size_t numPoints = 1;
-    std::array<double, numPoints> xValues;
-    std::iota(xValues.begin(), xValues.end(), 1.2);
-    std::array<double, numPoints> yValues;
-    critprr->function1D(yValues.data(), xValues.data(), numPoints);
-    TS_ASSERT_THROWS_NOTHING(critprr->checkParams(xValues.data(), numPoints));
-
-    // when x and Tc have the same value
-    auto critprr2 = createTestCriticalPeakRelaxationRate();
-    const std::size_t numPoints2 = 1;
-    std::array<double, numPoints2> xValues2;
-    std::iota(xValues2.begin(), xValues2.end(), 0.5);
-    std::array<double, numPoints2> yValues2;
-    TS_ASSERT_THROWS(critprr2->function1D(yValues2.data(), xValues2.data(), numPoints2), const std::invalid_argument &);
-  }
-
   void test_function_gives_expected_value_for_given_input() {
     auto critprr = createTestCriticalPeakRelaxationRate();
 
-    const double scale = critprr->getParameter("Scaling");
-    const double tc = critprr->getParameter("CriticalTemp");
-    const double exp = critprr->getParameter("Exponent");
-    const double bg = critprr->getParameter("Background");
+    const double Scale = critprr->getParameter("Scaling");
+    const double Tc = critprr->getParameter("CriticalTemp");
+    const double Exp = critprr->getParameter("Exponent");
+    const double Bg1 = critprr->getParameter("Background1");
+    const double Bg2 = critprr->getParameter("Background2");
+    const double Delta = critprr->getAttribute("Delta").asDouble();
 
     const std::size_t numPoints = 100;
     std::array<double, numPoints> xValues;
-    std::iota(xValues.begin(), xValues.end(), 0.6);
+    std::iota(xValues.begin(), xValues.end(), 0);
     std::array<double, numPoints> yValues;
     critprr->function1D(yValues.data(), xValues.data(), numPoints);
 
     for (size_t i = 0; i < numPoints; i++) {
-      double expression = abs(xValues[i] - tc);
-      TS_ASSERT_DELTA(yValues[i], scale / pow(expression, exp) + bg, 1e-4);
+      double expression = abs(xValues[i] - Tc);
+      if (xValues[i] + Delta < Tc || xValues[i] - Delta > Tc) {
+        if (xValues[i] < Tc) {
+          TS_ASSERT_DELTA(yValues[i], Bg1 + Scale / pow(expression, Exp), 1e-4);
+        }
+        if (xValues[i] > Tc) {
+          TS_ASSERT_DELTA(yValues[i], Bg2 + Scale / pow(expression, Exp), 1e-4);
+        }
+      } else {
+        TS_ASSERT_DELTA(yValues[i], 1e6, 1e-4);
+      }
     }
   }
 
-  void test_jacobian_gives_expected_values() {
-    auto activ = createTestCriticalPeakRelaxationRate();
-
-    const size_t nData(1);
-    std::vector<double> xValues(nData, 3.5);
-
-    Mantid::CurveFitting::Jacobian jacobian(nData, 4);
-    activ->functionDeriv1D(&jacobian, xValues.data(), nData);
-
-    double dfdsc = jacobian.get(0, 0);
-    double dfdtc = jacobian.get(0, 1);
-    double dfdexp = jacobian.get(0, 2);
-    double dfdbg = jacobian.get(0, 3);
-
-    TS_ASSERT_DELTA(dfdsc, 0.012345679, 1e-7);
-    TS_ASSERT_DELTA(dfdtc, 0.037860082, 1e-7);
-    TS_ASSERT_DELTA(dfdexp, 0.031195163, 1e-7);
-    TS_ASSERT_DELTA(dfdbg, 1.0, 1e-7);
-  }
 
 private:
   class TestableCriticalPeakRelaxationRate : public CriticalPeakRelaxationRate {
@@ -104,18 +76,16 @@ private:
     void function1D(double *out, const double *xValues, const size_t nData) const override {
       CriticalPeakRelaxationRate::function1D(out, xValues, nData);
     }
-    void functionDeriv1D(Mantid::API::Jacobian *out, const double *xValues, const size_t nData) override {
-      CriticalPeakRelaxationRate::functionDeriv1D(out, xValues, nData);
-    }
   };
 
   std::shared_ptr<TestableCriticalPeakRelaxationRate> createTestCriticalPeakRelaxationRate() {
     auto func = std::make_shared<TestableCriticalPeakRelaxationRate>();
     func->initialize();
     func->setParameter("Scaling", 2.3);
-    func->setParameter("CriticalTemp", 0.5);
+    func->setParameter("CriticalTemp", 7.0);
     func->setParameter("Exponent", 4.0);
-    func->setParameter("Background", 4.0);
+    func->setParameter("Background1", 1.3);
+    func->setParameter("Background2", 4.5);
     return func;
   }
 };

--- a/Framework/CurveFitting/test/Functions/CriticalPeakRelaxationRateTest.h
+++ b/Framework/CurveFitting/test/Functions/CriticalPeakRelaxationRateTest.h
@@ -74,7 +74,7 @@ public:
 
     for (size_t i = 0; i < numPoints; i++) {
       double expression = abs(xValues[i] - tc);
-      TS_ASSERT_DELTA(yValues[i], scale / pow(expression, exp) + bg, 1e-12);
+      TS_ASSERT_DELTA(yValues[i], scale / pow(expression, exp) + bg, 1e-4);
     }
   }
 

--- a/Framework/CurveFitting/test/Functions/CriticalPeakRelaxationRateTest.h
+++ b/Framework/CurveFitting/test/Functions/CriticalPeakRelaxationRateTest.h
@@ -69,7 +69,6 @@ public:
     }
   }
 
-
 private:
   class TestableCriticalPeakRelaxationRate : public CriticalPeakRelaxationRate {
   public:

--- a/Framework/CurveFitting/test/Functions/CriticalPeakRelaxationRateTest.h
+++ b/Framework/CurveFitting/test/Functions/CriticalPeakRelaxationRateTest.h
@@ -1,0 +1,122 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2021 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#pragma once
+
+#include <cxxtest/TestSuite.h>
+
+#include "MantidAPI/AlgorithmManager.h"
+#include "MantidAPI/FunctionFactory.h"
+#include "MantidCurveFitting/Functions/CriticalPeakRelaxationRate.h"
+#include "MantidCurveFitting/Jacobian.h"
+#include "MantidFrameworkTestHelpers/WorkspaceCreationHelper.h"
+//#include "MantidKernel/PhysicalConstants.h"
+
+using namespace Mantid::API;
+using namespace Mantid::CurveFitting;
+using namespace Mantid::CurveFitting::Functions;
+using Mantid::MantidVec;
+
+class CriticalPeakRelaxationRateTest : public CxxTest::TestSuite {
+public:
+  // This pair of boilerplate methods prevent the suite being created statically
+  // This means the constructor isn't called when running other tests
+  static CriticalPeakRelaxationRateTest *createSuite() { return new CriticalPeakRelaxationRateTest(); }
+  static void destroySuite(CriticalPeakRelaxationRateTest *suite) { delete suite; }
+
+  void test_category() {
+    CriticalPeakRelaxationRate fn;
+    TS_ASSERT_EQUALS(fn.category(), "Muon\\MuonModelling\\Magnetism");
+  }
+
+  void test_function_parameter_settings() {
+    auto critprr = createTestCriticalPeakRelaxationRate();
+
+    TS_ASSERT_THROWS(critprr->setParameter("X", 1.0), const std::invalid_argument &);
+    TS_ASSERT_THROWS(critprr->setParameter("A9", 1.0), const std::invalid_argument &);
+  }
+
+  void test_x_tc_values() {
+    auto critprr = createTestCriticalPeakRelaxationRate();
+
+    // when x and Tc are not the same
+    const std::size_t numPoints = 1;
+    std::array<double, numPoints> xValues;
+    std::iota(xValues.begin(), xValues.end(), 1.2);
+    std::array<double, numPoints> yValues;
+    critprr->function1D(yValues.data(), xValues.data(), numPoints);
+    TS_ASSERT_THROWS_NOTHING(critprr->checkParams(xValues.data(), numPoints));
+
+    // when x and Tc have the same value
+    auto critprr2 = createTestCriticalPeakRelaxationRate();
+    const std::size_t numPoints2 = 1;
+    std::array<double, numPoints2> xValues2;
+    std::iota(xValues2.begin(), xValues2.end(), 0.5);
+    std::array<double, numPoints2> yValues2;
+    TS_ASSERT_THROWS(critprr2->function1D(yValues2.data(), xValues2.data(), numPoints2), const std::invalid_argument &);
+  }
+
+  void test_function_gives_expected_value_for_given_input() {
+    auto critprr = createTestCriticalPeakRelaxationRate();
+
+    const double scale = critprr->getParameter("Scaling");
+    const double tc = critprr->getParameter("CriticalTemp");
+    const double exp = critprr->getParameter("Exponent");
+    const double bg = critprr->getParameter("Background");
+
+    const std::size_t numPoints = 100;
+    std::array<double, numPoints> xValues;
+    std::iota(xValues.begin(), xValues.end(), 0.6);
+    std::array<double, numPoints> yValues;
+    critprr->function1D(yValues.data(), xValues.data(), numPoints);
+
+    for (size_t i = 0; i < numPoints; i++) {
+      double expression = abs(xValues[i] - tc);
+      TS_ASSERT_DELTA(yValues[i], scale / pow(expression, exp) + bg, 1e-12);
+    }
+  }
+
+  void test_jacobian_gives_expected_values() {
+    auto activ = createTestCriticalPeakRelaxationRate();
+
+    const size_t nData(1);
+    std::vector<double> xValues(nData, 3.5);
+
+    Mantid::CurveFitting::Jacobian jacobian(nData, 4);
+    activ->functionDeriv1D(&jacobian, xValues.data(), nData);
+
+    double dfdsc = jacobian.get(0, 0);
+    double dfdtc = jacobian.get(0, 1);
+    double dfdexp = jacobian.get(0, 2);
+    double dfdbg = jacobian.get(0, 3);
+
+    TS_ASSERT_DELTA(dfdsc, 0.012345679, 1e-7);
+    TS_ASSERT_DELTA(dfdtc, 0.037860082, 1e-7);
+    TS_ASSERT_DELTA(dfdexp, 0.031195163, 1e-7);
+    TS_ASSERT_DELTA(dfdbg, 1.0, 1e-7);
+  }
+
+private:
+  class TestableCriticalPeakRelaxationRate : public CriticalPeakRelaxationRate {
+  public:
+    void function1D(double *out, const double *xValues, const size_t nData) const override {
+      CriticalPeakRelaxationRate::function1D(out, xValues, nData);
+    }
+    void functionDeriv1D(Mantid::API::Jacobian *out, const double *xValues, const size_t nData) override {
+      CriticalPeakRelaxationRate::functionDeriv1D(out, xValues, nData);
+    }
+  };
+
+  std::shared_ptr<TestableCriticalPeakRelaxationRate> createTestCriticalPeakRelaxationRate() {
+    auto func = std::make_shared<TestableCriticalPeakRelaxationRate>();
+    func->initialize();
+    func->setParameter("Scaling", 2.3);
+    func->setParameter("CriticalTemp", 0.5);
+    func->setParameter("Exponent", 4.0);
+    func->setParameter("Background", 4.0);
+    return func;
+  }
+};

--- a/Framework/CurveFitting/test/Functions/CriticalPeakRelaxationRateTest.h
+++ b/Framework/CurveFitting/test/Functions/CriticalPeakRelaxationRateTest.h
@@ -13,7 +13,6 @@
 #include "MantidCurveFitting/Functions/CriticalPeakRelaxationRate.h"
 #include "MantidCurveFitting/Jacobian.h"
 #include "MantidFrameworkTestHelpers/WorkspaceCreationHelper.h"
-//#include "MantidKernel/PhysicalConstants.h"
 
 using namespace Mantid::API;
 using namespace Mantid::CurveFitting;

--- a/Framework/CurveFitting/test/Functions/CriticalPeakRelaxationRateTest.h
+++ b/Framework/CurveFitting/test/Functions/CriticalPeakRelaxationRateTest.h
@@ -55,7 +55,7 @@ public:
     critprr->function1D(yValues.data(), xValues.data(), numPoints);
 
     for (size_t i = 0; i < numPoints; i++) {
-      double expression = abs(xValues[i] - Tc);
+      double expression = fabs(xValues[i] - Tc);
       if (xValues[i] + Delta < Tc || xValues[i] - Delta > Tc) {
         if (xValues[i] < Tc) {
           TS_ASSERT_DELTA(yValues[i], Bg1 + Scale / pow(expression, Exp), 1e-4);

--- a/docs/source/fitting/fitfunctions/CriticalPeakRelaxationRate.rst
+++ b/docs/source/fitting/fitfunctions/CriticalPeakRelaxationRate.rst
@@ -11,7 +11,7 @@ Description
 
 The Critical Peak Relexation Rate is defined as:
 
-.. math:: y = \frac{B_1}{(|x - T_c|)^a} + \frac{B_1}{Theta(x < T_c)} + \frac{B_2}{Theta(x >= T_c)}
+.. math:: y = \frac{B_1}{(|x - T_c|)^a} + B_1\Theta(x < T_c) + B_2\Theta(x >= T_c)
 
 where:
 - :math:`S_c` - Scaling

--- a/docs/source/fitting/fitfunctions/CriticalPeakRelaxationRate.rst
+++ b/docs/source/fitting/fitfunctions/CriticalPeakRelaxationRate.rst
@@ -11,13 +11,14 @@ Description
 
 The Critical Peak Relexation Rate is defined as:
 
-.. math:: y = \frac{S_c}{(|x - T_c|)^a} + B_g
+.. math:: y = \frac{B_1}{(|x - T_c|)^a} + \frac{B_1}{Theta(x < T_c)} + \frac{B_2}{Theta(x >= T_c)}
 
 where:
 - :math:`S_c` - Scaling
 - :math:`T_c` - Critical temperature
 - :math:`a` - Critical exponent
-- :math:`B_g` - is a non-critical background
+- :math:`B_1` - is a non-critical background when :math:`x < T_c`
+- :math:`B_2` - is a non-critical background when :math:`x >= T_c`
 
 When fitting users should set :math:`T_c` as the temperature at which the peak occurs. Users are also asked to supply two values for :math:`B_g`. The first should be the value of y when x is at it's minimum. The second should be the value of y when x is at its maximum, minus the first background value.
 

--- a/docs/source/fitting/fitfunctions/CriticalPeakRelaxationRate.rst
+++ b/docs/source/fitting/fitfunctions/CriticalPeakRelaxationRate.rst
@@ -14,10 +14,12 @@ The Critical Peak Relexation Rate is defined as:
 .. math:: y = \frac{S_c}{(|x - T_c|)^a} + B_g
 
 where:
-- S_c - Scaling
-- T_c - Critical temperature
-- a - Critical exponent
-- B_g - is a non-critical background
+- :math:`S_c` - Scaling
+- :math:`T_c` - Critical temperature
+- :math:`a` - Critical exponent
+- :math:`B_g` - is a non-critical background
+
+When fitting users should set :math:`T_c` as the temperature at which the peak occurs. Users are also asked to supply two values for :math:`B_g`. The first should be the value of y when x is at it's minimum. The second should be the value of y when x is at its maximum, minus the first background value.
 
 
 Examples

--- a/docs/source/fitting/fitfunctions/CriticalPeakRelaxationRate.rst
+++ b/docs/source/fitting/fitfunctions/CriticalPeakRelaxationRate.rst
@@ -1,0 +1,40 @@
+.. _func-CriticalPeakRelaxationRate:
+
+==========================
+CriticalPeakRelaxationRate
+==========================
+
+.. index:: CriticalPeakRelaxationRate
+
+Description
+-----------
+
+The Critical Peak Relexation Rate is defined as:
+
+.. math:: y = \frac{S_c}{(|x - T_c|)^a} + B_g
+
+where:
+- S_c - Scaling
+- T_c - Critical temperature
+- a - Critical exponent
+- B_g - is a non-critical background
+
+
+Examples
+--------
+
+An example of when this might be used is for examining the Chiral-like critical behaviour in antiferromagnet Cobalt Glycerolate[1] or in muon spin relaxation studies of critical fluctuations and diffusive spin dynamics in molecular magnets[2].
+
+
+.. attributes::
+
+.. properties::
+
+References
+----------
+[1] Pratt, F.L, Baker, P.J., Blundell, S.J., Lancaster, T., Green, M.A., and Kurmoo, M. (2007). Chiral-Like Critical Behaviour in the Antiferromagnet Cobalt Glycerolate. Phys. Rev. Lett., Vol 99 Issue 1, 017202 `doi: 10.1103/PhysRevLett.99.017202 <https://doi.org/10.1103/PhysRevLett.99.017202>`_.
+[2] Pratt, F. et al (2009) Muon spin relaxation studies of critical fluctuations and diffusive spin dynamics in molecular magnets. Physica B: Condensed Matter, Volume 404 Issues 5–7, pp585-589 `doi: 10.1016/j.physb.2008.11.123 <https://doi.org/10.1016/j.physb.2008.11.123>`_.
+
+.. categories::
+
+.. sourcelink::

--- a/docs/source/release/v6.3.0/muon.rst
+++ b/docs/source/release/v6.3.0/muon.rst
@@ -86,6 +86,7 @@ Fitting Functions
 New Features
 ############
 - Added an :ref:`Activation <func-Activation>` fitting function to MuonModelling Fit Functions.
+- Added a :ref:`Critical peak of relaxation rate <func-CriticalPeakRelaxationRate>` for fitting to MuonModelling\Magnetism Fit Functions.
 - Added a :ref:`Magentic Order Parameter<func-MagneticOrderParameter>` function to MuonModelling\Magentism Fit Functions.
 - Added a :ref:`Muonium-style Decoupling Curve <func-MuoniumDecouplingCurve>` function to MuonModelling Fit Functions.
 - Added a :ref:`Power Law <func-PowerLaw>` fitting function to MuonModelling Fit Functions.


### PR DESCRIPTION
**Description of work.**

Added a new Critical Peak of Relaxation Rate Fit function for Muon modelling and associated documentation.


**To test:**
1. Contact @sf1919 for a copy of the zflam-data.dat file that is needed to test this fit function
2. Open the file in Mantid
3. Double click file to open the plot and then click the Fit button
4. Add a CriticalPeakRelaxationRate fitting function.
5. Use the documentation to set the CriticalTemp and BG1 and BG2 variables correctly
6. Perform a fit

Fixes #32586 


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
