### PR TITLE
fix muon plot bug with shade region

### DIFF
--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/plot_widget/plotting_canvas/plotting_canvas_model.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/plot_widget/plotting_canvas/plotting_canvas_model.py
@@ -4,7 +4,7 @@
 #   NScD Oak Ridge National Laboratory, European Spallation Source,
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
-from typing import NamedTuple, List
+from typing import List
 from mantidqtinterfaces.Muon.GUI.Common.utilities.algorithm_utils import run_convert_to_points, run_convert_to_histogram
 from mantidqtinterfaces.Muon.GUI.Common.ADSHandler.ADS_calls import retrieve_ws
 
@@ -12,13 +12,21 @@ from mantidqtinterfaces.Muon.GUI.Common.ADSHandler.ADS_calls import retrieve_ws
 FIT_FUNCTION_GUESS_LABEL = "Fit function guess"
 
 
-class WorkspacePlotInformation(NamedTuple):
-    workspace_name: str
-    index: int
-    axis: int
-    normalised: bool
-    errors: bool
-    label: str
+class WorkspacePlotInformation(object):
+
+    def __init__(self,
+                 workspace_name: str,
+                 index: int,
+                 axis: int,
+                 normalised: bool,
+                 errors: bool,
+                 label: str):
+        self.workspace_name = workspace_name
+        self.index = index
+        self.axis = axis
+        self.normalised = normalised
+        self.errors = errors
+        self.label = label
 
     # equal only checks for workspace, axis, and spec num, as the user could have changed the other states
     def __eq__(self, other):

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/plot_widget/plotting_canvas/plotting_canvas_presenter.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/plot_widget/plotting_canvas/plotting_canvas_presenter.py
@@ -140,7 +140,7 @@ class PlottingCanvasPresenter(PlottingCanvasPresenterInterface):
         for name, index in zip(workspaces, indices):
             x_data, y1_data, y2_data = self._model.get_shade_lines(name, index)
             self._view.add_shaded_region(workspace_name = name,
-                                         axis = index,
+                                         axis_number = index,
                                          x_values = x_data,
                                          y1_values = y1_data,
                                          y2_values = y2_data)

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/plot_widget/plotting_canvas/plotting_canvas_view.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/plot_widget/plotting_canvas/plotting_canvas_view.py
@@ -338,7 +338,7 @@ class PlottingCanvasView(QtWidgets.QWidget, PlottingCanvasViewInterface):
     # not used for tiled plots
     def replot_workspace_with_error_state(self, workspace_name, with_errors: bool):
         for plot_info in self.plotted_workspace_information:
-            # update plot info error state -> important for shadeing
+            # update plot info error state -> important for shading
             plot_info.errors= with_errors
             if plot_info.workspace_name == workspace_name:
                 axis = self.fig.axes[plot_info.axis]

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/plot_widget/plotting_canvas/plotting_canvas_view.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/plot_widget/plotting_canvas/plotting_canvas_view.py
@@ -33,7 +33,7 @@ DEFAULT_COLOR_CYCLE = ["C" + str(index) for index in range(NUMBER_OF_COLOURS)]
 
 class ShadedRegionInfo(object):
     def __init__(self, workspace_name: str,
-                 axis: int,
+                 axis,
                  x_values: List[float],
                  y1_values: List[float],
                  y2_values: List[float]):
@@ -44,11 +44,24 @@ class ShadedRegionInfo(object):
         self.y2_values = y2_values
         self.ID = None
 
-    def shade_region(self, axis, color):
+    def update(self, axis,
+               x_values: List[float],
+               y1_values: List[float],
+               y2_values: List[float]):
+        self.axis = axis
+        self.x_values = x_values
+        self.y1_values = y1_values
+        self.y2_values = y2_values
+        if self.ID:
+            color = self.ID.get_facecolor()
+            self.remove()
+            self.shade_region(color)
+
+    def shade_region(self, color):
         x_values = self.x_values
         y1 = self.y1_values
         y2 = self.y2_values
-        self.ID = axis.fill_between(x_values, y1, y2, facecolor=color, interpolate=True, alpha=0.25)
+        self.ID = self.axis.fill_between(x_values, y1, y2, facecolor=color, interpolate=True, alpha=0.25)
 
     def remove(self):
         if self.ID:
@@ -157,6 +170,10 @@ class PlottingCanvasView(QtWidgets.QWidget, PlottingCanvasViewInterface):
         for color_queue in self._color_queue:
             color_queue.reset()
 
+        for shaded_region in self._shaded_regions:
+            shaded_region.remove()
+        self._shaded_regions={}
+
         self._plot_information_list = []
 
     def _make_plot(self, workspace_plot_info: WorkspacePlotInformation):
@@ -174,7 +191,7 @@ class PlottingCanvasView(QtWidgets.QWidget, PlottingCanvasViewInterface):
         plot_kwargs['color'] = self._color_queue[axis_number]()
         if workspace_name in self._shaded_regions.keys() and errors:
             errors = False
-            self.shade_region(ax, plot_kwargs['color'], workspace_name)
+            self.shade_region(plot_kwargs['color'], workspace_name)
 
         _do_single_plot(ax, workspace, ws_index, errors=errors,
                         plot_kwargs=plot_kwargs)
@@ -196,12 +213,20 @@ class PlottingCanvasView(QtWidgets.QWidget, PlottingCanvasViewInterface):
             for axis_number in range(int(self._number_of_axes), int(nrows*ncols)):
                 self.hide_axis(axis_number, nrows, ncols)
 
-    def add_shaded_region(self, workspace_name, axis, x_values, y1_values, y2_values):
-        self._shaded_regions[workspace_name] = ShadedRegionInfo(workspace_name = workspace_name,
-                                                                axis = axis,
-                                                                x_values = x_values,
-                                                                y1_values = y1_values,
-                                                                y2_values = y2_values)
+    def add_shaded_region(self, workspace_name, axis_number, x_values, y1_values, y2_values):
+        # -1 to count from 0 instead of 1
+        axis = self.fig.axes[axis_number-1]
+        if workspace_name in self._shaded_regions.keys():
+            self._shaded_regions[workspace_name].update(axis = axis,
+                                                        x_values = x_values,
+                                                        y1_values = y1_values,
+                                                        y2_values = y2_values)
+        else:
+            self._shaded_regions[workspace_name] = ShadedRegionInfo(workspace_name = workspace_name,
+                                                                    axis = axis,
+                                                                    x_values = x_values,
+                                                                    y1_values = y1_values,
+                                                                    y2_values = y2_values)
 
     def _wrap_labels(self, labels: list) -> list:
         """Wraps a list of labels so that every line is at most self._settings.wrap_width characters long."""
@@ -269,6 +294,7 @@ class PlottingCanvasView(QtWidgets.QWidget, PlottingCanvasViewInterface):
                 axis.remove_workspace_artists(workspace)
                 self._plot_information_list.remove(workspace_plot_info)
                 if workspace_name in self._shaded_regions.keys():
+                    self._shaded_regions[workspace_name].remove()
                     del self._shaded_regions[workspace_name]
 
     def _update_color_queue_on_workspace_removal(self, axis_number, workspace_name):
@@ -303,13 +329,17 @@ class PlottingCanvasView(QtWidgets.QWidget, PlottingCanvasViewInterface):
                 if workspace_name in self._shaded_regions.keys() and workspace_plot_info.errors:
                     # remove old shade first
                     self._shaded_regions[workspace_name].remove()
-                    color = get_color_from_artist(artists)
-                    self.shade_region(axis, color, workspace_name)
+                    ws_artist = axis.tracked_workspaces[workspace_name][0]
+                    color = get_color_from_artist(ws_artist._artists[0])
+                    self.shade_region(color, workspace_name)
+
         self.redraw_figure()
 
     # not used for tiled plots
     def replot_workspace_with_error_state(self, workspace_name, with_errors: bool):
         for plot_info in self.plotted_workspace_information:
+            # update plot info error state -> important for shadeing
+            plot_info.errors= with_errors
             if plot_info.workspace_name == workspace_name:
                 axis = self.fig.axes[plot_info.axis]
                 workspace_name = plot_info.workspace_name
@@ -323,15 +353,15 @@ class PlottingCanvasView(QtWidgets.QWidget, PlottingCanvasViewInterface):
                             if with_errors:
                                 # replot without errors to get the fit on top
                                 axis.replot_artist(artist, False, **plot_kwargs)
-                                self.shade_region(axis, color, workspace_name)
-                            elif len(axis.collections)>0:
-                                axis.collections.pop()
+                                self.shade_region(color, workspace_name)
+                            else:
+                                self._shaded_regions[workspace_name].remove()
                         else:
                             axis.replot_artist(artist, with_errors, **plot_kwargs)
         self.redraw_figure()
 
-    def shade_region(self, axis, color, name):
-        self._shaded_regions[name].shade_region(axis, color)
+    def shade_region(self, color, name):
+        self._shaded_regions[name].shade_region(color)
 
     def set_axis_xlimits(self, axis_number, xlims):
         ax = self.fig.axes[axis_number]

--- a/qt/python/mantidqtinterfaces/test/Muon/plotting_canvas/plotting_canvas_presenter_test.py
+++ b/qt/python/mantidqtinterfaces/test/Muon/plotting_canvas/plotting_canvas_presenter_test.py
@@ -608,12 +608,12 @@ class PlottingCanvasPresenterTest(unittest.TestCase):
         self.model.get_shade_lines.side_effect = shade_mock
         self.presenter.add_shaded_region(["unit", "test"], [0,1])
         self.view.add_shaded_region.assert_any_call(workspace_name="unit",
-                                                    axis=0,
+                                                    axis_number=0,
                                                     x_values=0,
                                                     y1_values=1,
                                                     y2_values=2)
         self.view.add_shaded_region.assert_any_call(workspace_name="test",
-                                                    axis=1,
+                                                    axis_number=1,
                                                     x_values=1,
                                                     y1_values=2,
                                                     y2_values=3)

--- a/qt/python/mantidqtinterfaces/test/Muon/plotting_canvas/plotting_canvas_view_test.py
+++ b/qt/python/mantidqtinterfaces/test/Muon/plotting_canvas/plotting_canvas_view_test.py
@@ -301,6 +301,79 @@ class PlottingCanvasViewTest(unittest.TestCase, QtWidgetFinder):
         # one from start up
         self.assertEqual(1, self.view.fig.tight_layout.call_count)
 
+    def mock_axis(self):
+        axes = mock.Mock()
+        axes.cla = mock.Mock()
+        axes.tracked_workspaces = mock.Mock()
+        axes.tracked_workspaces.clear = mock.Mock()
+        axes.set_prop_cycle = mock.Mock()
+
+        return axes
+
+    def test_clear_all_workspaces_from_plot(self):
+        self.view.fig = mock.Mock()
+        axis = self.mock_axis()
+        self.view.fig.axes = [axis]
+
+        color_queue = mock.Mock()
+        color_queue.reset = mock.Mock()
+        self.view._color_queue = [color_queue]
+
+        shade_region = mock.Mock()
+        shade_region.remove = mock.Mock()
+        self.view._shaded_regions = [shade_region]
+
+        self.view.clear_all_workspaces_from_plot()
+
+        axis.cla.assert_called_once_with()
+        axis.tracked_workspaces.clear.assert_called_once_with()
+        axis.set_prop_cycle.assert_called_once_with(None)
+
+        color_queue.reset.assert_called_once_with()
+
+        shade_region.remove.assert_called_once_with()
+
+    def test_add_shaded_region(self):
+        self.view.fig.axes = [1,2]
+        x_data = [0,1,2,3]
+        y1_data = [1,2,3,4]
+        y2_data = [ 4,3,2,1]
+        axis = 1
+        name = "unit test"
+
+        self.assertEqual(self.view._shaded_regions, {})
+
+        self.view.add_shaded_region(name, axis, x_data, y1_data, y2_data)
+
+        self.assertEqual(list(self.view._shaded_regions.keys()), [name])
+        self.assertEqual(self.view._shaded_regions[name].axis, 1)
+        self.assertEqual(self.view._shaded_regions[name].x_values, x_data)
+        self.assertEqual(self.view._shaded_regions[name].y1_values, y1_data)
+        self.assertEqual(self.view._shaded_regions[name].y2_values, y2_data)
+
+    def test_update_shaded_region(self):
+        self.view.fig.axes = [1,2]
+        x_data = [0,1,2,3]
+        y1_data = [1,2,3,4]
+        y2_data = [ 4,3,2,1]
+        axis = 1
+        name = "unit test"
+
+        self.assertEqual(self.view._shaded_regions, {})
+
+        self.view.add_shaded_region(name, axis, x_data, y1_data, y2_data)
+
+        new_x = [5,4,3,2,1]
+        new_y1 = [4,2,0,-2,-4]
+        new_y2 = [1,2,3,4,5]
+
+        self.view.add_shaded_region(name, axis, new_x, new_y1, new_y2)
+        self.assertEqual(list(self.view._shaded_regions.keys()), [name])
+        self.assertEqual(self.view._shaded_regions[name].axis, 1)
+        self.assertEqual(self.view._shaded_regions[name].x_values, new_x)
+        self.assertEqual(self.view._shaded_regions[name].y1_values, new_y1)
+        self.assertEqual(self.view._shaded_regions[name].y2_values, new_y2)
+
 
 if __name__ == '__main__':
     unittest.main(buffer=False, verbosity=2)


### PR DESCRIPTION
**Description of work.**
The shaded region in muon plotting was causing errors. This fixes the cleaning up and a bug.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**

<!-- Instructions for testing. -->
Open muon analysi
Load EMU 96116-9
Go to fitting
add a linear BG
go to sequential
fit all
go to results
select `sample_temp`
make the results table
Go to model analysis
Add a linear background
do a fit
do another fit
do another fit
do another fit - in main it would have thrown at least one error by now and the shaded region would be getting darker after each fit
Turn off the errors
Do a fit - there should be no shaded region (it was reappearing) 

Load MUSR 62260
Go to fitting
Tick tiled plot in the plotting window
Tick errors
Tick simultaneous in the fitting tab
Do a fit
There should be a shaded region on each plot (you might need to zoom in)

*There is no associated issue.*


This does not require release notes because it fixes a bug we added last week.


<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
