### PR TITLE
Add missing livedata addressses for 3 HFIR instruments and fix SNSLiveEventDataListener

### DIFF
--- a/Framework/LiveData/src/SNSLiveEventDataListener.cpp
+++ b/Framework/LiveData/src/SNSLiveEventDataListener.cpp
@@ -320,6 +320,13 @@ void SNSLiveEventDataListener::run() {
     std::string newMsg("Invalid argument exception thrown from the background thread: ");
     newMsg += e.what();
     m_backgroundException = std::make_shared<std::runtime_error>(newMsg);
+  } catch (std::exception &e) { // exception handler for generic exceptions
+    g_log.fatal() << "Caught an exception.\n"
+                  << "Exception message: " << e.what() << ".\n"
+                  << "Thread will exit.\n";
+    m_isConnected = false;
+
+    m_backgroundException = std::make_shared<std::runtime_error>(e.what());
   } catch (...) { // Default exception handler
     g_log.fatal("Uncaught exception in SNSLiveEventDataListener network read thread."
                 " Thread is exiting.");

--- a/docs/source/release/v6.3.0/framework.rst
+++ b/docs/source/release/v6.3.0/framework.rst
@@ -56,5 +56,6 @@ Bugfixes
 ########
 
 - Fixed bug in :ref:`Run <Run>` goniometer when using :ref:`algm-Plus`.
+- Fixed issue in SNSLiveEventDataListener when the instrument doesn't have monitors
 
 :ref:`Release 6.3.0 <v6.3.0>`

--- a/instrument/Facilities.xml
+++ b/instrument/Facilities.xml
@@ -414,6 +414,9 @@
 
    <instrument name="HB2B">
       <technique>technique</technique>
+     <livedata>
+       <connection name="event" address="hb2b-daq1.ornl.gov:31415" listener="SNSLiveEventDataListener" />
+     </livedata>
    </instrument>
 
    <instrument name="WAND" shortname="HB2C">
@@ -439,6 +442,9 @@
 
    <instrument name="GPSANS" shortname="CG2">
       <technique>Small Angle Scattering</technique>
+     <livedata>
+       <connection name="event" address="cg2-daq1.ornl.gov:31415" listener="SNSLiveEventDataListener" />
+     </livedata>
    </instrument>
 
    <instrument name="CG2" shortname="CG2">
@@ -447,6 +453,9 @@
 
    <instrument name="BIOSANS"  shortname="CG3">
       <technique>Small Angle Scattering</technique>
+     <livedata>
+       <connection name="event" address="cg3-daq1.ornl.gov:31415" listener="SNSLiveEventDataListener" />
+     </livedata>
    </instrument>
 
    <instrument name="HIRESSANS">


### PR DESCRIPTION
**Description of work.**
This adds the livedata address for CG2, CG3 and HB2B at HFIR

**To test:**

Run `StartLiveData` and check that it can connect to the new servers, HFIR isn't running so we can't do more testing yett.


Fixes [ED83](https://code.ornl.gov/sns-hfir-scse/diffraction/engineering-diffraction/engineering-diffraction/-/issues/83)


<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
