### PR TITLE
Code editor uncomment bug

### DIFF
--- a/docs/source/release/v6.3.0/mantidworkbench.rst
+++ b/docs/source/release/v6.3.0/mantidworkbench.rst
@@ -41,6 +41,6 @@ Bugfixes
 - Fixed an issue to plot negative values with logarithm scaling in slice view.
 - Workbench will no longer hang if an algorithm was running when workbench was closed.
 - Stopped workbench from ignoring GUIs that want to cancel closing
-
+- Fixed a bug in the editor where uncommenting using 'ctrl+/' wasn't working correctly for lines of the form '<optional whitespace>#code_here # inline comment'.
 
 :ref:`Release 6.3.0 <v6.3.0>`

--- a/qt/python/mantidqt/mantidqt/widgets/codeeditor/codecommenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/codeeditor/codecommenter.py
@@ -6,6 +6,8 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 #  This file is part of the mantidqt package
 
+import re
+
 
 class CodeCommenter:
 
@@ -66,8 +68,10 @@ class CodeCommenter:
 
     def _uncomment_lines(self, lines):
         for i in range(len(lines)):
-            uncommented_line = lines[i].replace('# ', '', 1)
-            if uncommented_line == lines[i]:
-                uncommented_line = lines[i].replace('#', '', 1)
-            lines[i] = uncommented_line
+            # Look for optional whitespace and a hash at the start of a line to determine whether to uncomment it.
+            # Distinguish between the two cases {space, no space} after the hash to preserve indentation.
+            if re.match(r'\s*# ', lines[i]):
+                lines[i] = lines[i].replace('# ', '', 1)
+            elif re.match(r'\s*#', lines[i]):
+                lines[i] = lines[i].replace('#', '', 1)
         return lines

--- a/qt/python/mantidqt/mantidqt/widgets/codeeditor/test/test_codecommenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/codeeditor/test/test_codecommenter.py
@@ -44,6 +44,32 @@ class CodeCommenterTest(unittest.TestCase):
         expected_lines[8] = '# ' + expected_lines[8]
         self.assertEqual(self.editor.text(), '\n'.join(expected_lines))
 
+    def test_uncomment_with_inline_comment(self):
+        """
+        Check that uncommenting works correctly when there is an inline comment on the line of code that is to be
+        uncommented.
+        """
+        commented_lines = [
+            '#do_something() # inline comment',
+            '#do_something() #inline comment',
+            '# do_something() # inline comment',
+            '# do_something() #inline comment',
+            '    #do_something() # inline comment',
+            '    #do_something() #inline comment',
+            '    # do_something() # inline comment',
+            '    # do_something() #inline comment']
+        expected_uncommented_lines = [
+            'do_something() # inline comment',
+            'do_something() #inline comment',
+            'do_something() # inline comment',
+            'do_something() #inline comment',
+            '    do_something() # inline comment',
+            '    do_something() #inline comment',
+            '    do_something() # inline comment',
+            '    do_something() #inline comment']
+        uncommented_lines = self.commenter._uncomment_lines(commented_lines)
+        self.assertEqual(expected_uncommented_lines, uncommented_lines)
+
     def test_multiline_uncomment(self):
         start_line, end_line = 0, 3
         self.editor.setSelection(0, 2, 3, 2)


### PR DESCRIPTION
**Description of work.**
Fixes a bug in the code editor when uncommenting the following type of line using `ctrl+/`:
<optional whitespace>#code_here() # inline comment here
It was uncommenting the inline comment rather than the entire line.

**To test:**
In the python code editor, use `ctrl+/` to uncomment a line of the form:
`#code_here() # inline comment here`
The behaviour should be similar to that in PyCharm. Experiment with putting whitespace in front of the line and verify that the indentation is preserved.


Fixes #32983

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
