### PR TITLE
Powgen gui new element

### DIFF
--- a/Framework/Json/src/Json.cpp
+++ b/Framework/Json/src/Json.cpp
@@ -11,7 +11,7 @@
 
 namespace Mantid::JsonHelpers {
 
-void replaceAll(std::string& str, const std::string& from, const std::string& to);
+void replaceAll(std::string &str, const std::string &from, const std::string &to);
 
 /**
  * @brief Useful function for replacing all instances of characters in string.
@@ -21,11 +21,11 @@ void replaceAll(std::string& str, const std::string& from, const std::string& to
  * @param to the string to replace with.
  * @return std::string
  */
-void replaceAll(std::string& str, const std::string& from, const std::string& to) {
-  if(from.empty())
+void replaceAll(std::string &str, const std::string &from, const std::string &to) {
+  if (from.empty())
     return;
   size_t start_pos = 0;
-  while((start_pos = str.find(from, start_pos)) != std::string::npos) {
+  while ((start_pos = str.find(from, start_pos)) != std::string::npos) {
     str.replace(start_pos, from.length(), to);
     start_pos += to.length();
   }

--- a/Framework/Json/src/Json.cpp
+++ b/Framework/Json/src/Json.cpp
@@ -9,10 +9,6 @@
 #include <memory>
 #include <sstream>
 
-namespace Mantid::JsonHelpers {
-
-void replaceAll(std::string &str, const std::string &from, const std::string &to);
-
 /**
  * @brief Useful function for replacing all instances of characters in string.
  *
@@ -30,6 +26,8 @@ void replaceAll(std::string &str, const std::string &from, const std::string &to
     start_pos += to.length();
   }
 }
+
+namespace Mantid::JsonHelpers {
 
 /**
  * @brief Return a string given the json value passed, this function handles errors by throwing instead of returning

--- a/Framework/Json/src/Json.cpp
+++ b/Framework/Json/src/Json.cpp
@@ -11,6 +11,26 @@
 
 namespace Mantid::JsonHelpers {
 
+void replaceAll(std::string& str, const std::string& from, const std::string& to);
+
+/**
+ * @brief Useful function for replacing all instances of characters in string.
+ *
+ * @param str the input string.
+ * @param from the substring to replace.
+ * @param to the string to replace with.
+ * @return std::string
+ */
+void replaceAll(std::string& str, const std::string& from, const std::string& to) {
+  if(from.empty())
+    return;
+  size_t start_pos = 0;
+  while((start_pos = str.find(from, start_pos)) != std::string::npos) {
+    str.replace(start_pos, from.length(), to);
+    start_pos += to.length();
+  }
+}
+
 /**
  * @brief Return a string given the json value passed, this function handles errors by throwing instead of returning
  * false and writing to a string the error.
@@ -28,6 +48,9 @@ std::string jsonToString(const Json::Value &json, const std::string &indentation
   Json::StreamWriterBuilder builder;
   builder.settings_["indentation"] = indentation;
   auto string = Json::writeString(builder, json);
+  replaceAll(string, "\"{", "{");
+  replaceAll(string, "}\"", "}");
+  replaceAll(string, "\\\"", "\"");
   return string;
 }
 

--- a/docs/source/release/v6.2.0/diffraction.rst
+++ b/docs/source/release/v6.2.0/diffraction.rst
@@ -9,6 +9,7 @@ Powder Diffraction
 ------------------
 New features
 ############
+- Add new input concerning sample height information from :ref:`SNSPowderReduction <algm-SNSPowderReduction>` to Powder Diffraction Reduction GUI.
 - New algorithm :ref:`CalculatePlaczek <algm-CalculatePlaczek>` to compute both first and second Placzek correction factors.
 - New algorithm :ref:`CalculatePlaczekSelfScattering2 <algm-CalculatePlaczekSelfScattering-v2>` utilizes :ref:`CalculatePlaczek <algm-CalculatePlaczek>` to compute first order correction.
 - New algorithm :ref:`CombineDiffCal <algm-CombineDiffCal>` to calibrate groups of pixels after cross correlation so that diffraction peaks can be adjusted to the correct positions.

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/reduction_gui/widgets/diffraction/diffraction_adv_setup.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/reduction_gui/widgets/diffraction/diffraction_adv_setup.py
@@ -170,7 +170,8 @@ class AdvancedSetupWidget(BaseWidget):
         self._content.sampleformula_edit.setText(str(state.sampleformula))
         self._content.numberdensity_edit.setText(str(state.samplenumberdensity))
         self._content.massdensity_edit.setText(str(state.measuredmassdensity))
-        self._content.sampleheight_edit.setText(str(state.sampleheight))
+        if state.samplegeometry:
+            self._content.sampleheight_edit.setText(str(state.samplegeometry['Height']))
         self._content.containertype_combo.setCurrentIndex(
             self._content.containertype_combo.findText(state.containershape))
         self._content.correctiontype_combo.setCurrentIndex(
@@ -220,7 +221,10 @@ class AdvancedSetupWidget(BaseWidget):
         s.sampleformula = self._content.sampleformula_edit.text()
         s.samplenumberdensity = self._content.numberdensity_edit.text()
         s.measuredmassdensity = self._content.massdensity_edit.text()
-        s.sampleheight = self._content.sampleheight_edit.text()
+        try:
+            s.samplegeometry = {'Height': float(self._content.sampleheight_edit.text())}
+        except ValueError:
+            s.samplegeometry = {'Height': self._content.sampleheight_edit.text()}
         s.containershape = self._content.containertype_combo.currentText()
         s.typeofcorrection = self._content.correctiontype_combo.currentText()
 

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/reduction_gui/widgets/diffraction/diffraction_adv_setup.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/reduction_gui/widgets/diffraction/diffraction_adv_setup.py
@@ -170,6 +170,7 @@ class AdvancedSetupWidget(BaseWidget):
         self._content.sampleformula_edit.setText(str(state.sampleformula))
         self._content.numberdensity_edit.setText(str(state.samplenumberdensity))
         self._content.massdensity_edit.setText(str(state.measuredmassdensity))
+        self._content.sampleheight_edit.setText(str(state.sampleheight))
         self._content.containertype_combo.setCurrentIndex(
             self._content.containertype_combo.findText(state.containershape))
         self._content.correctiontype_combo.setCurrentIndex(
@@ -219,6 +220,7 @@ class AdvancedSetupWidget(BaseWidget):
         s.sampleformula = self._content.sampleformula_edit.text()
         s.samplenumberdensity = self._content.numberdensity_edit.text()
         s.measuredmassdensity = self._content.massdensity_edit.text()
+        s.sampleheight = self._content.sampleheight_edit.text()
         s.containershape = self._content.containertype_combo.currentText()
         s.typeofcorrection = self._content.correctiontype_combo.currentText()
 

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/ui/diffraction/diffraction_adv_setup.ui
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/ui/diffraction/diffraction_adv_setup.ui
@@ -1039,6 +1039,9 @@
             <item row="1" column="6">
              <widget class="QLineEdit" name="massdensity_edit"/>
             </item>
+            <item row="3" column="6">
+             <widget class="QLineEdit" name="sampleheight_edit"/>
+            </item>
             <item row="2" column="5">
              <widget class="QLabel" name="label_14">
               <property name="text">
@@ -1112,6 +1115,13 @@
              <widget class="QLabel" name="label_9">
               <property name="text">
                <string>Measured Mass Density (g/cc)</string>
+              </property>
+             </widget>
+            </item>
+            <item row="3" column="5">
+             <widget class="QLabel" name="label_sh">
+              <property name="text">
+               <string>Sample Height</string>
               </property>
              </widget>
             </item>

--- a/scripts/reduction_gui/reduction/diffraction/diffraction_adv_setup_script.py
+++ b/scripts/reduction_gui/reduction/diffraction/diffraction_adv_setup_script.py
@@ -70,6 +70,7 @@ class AdvancedSetupScript(BaseScriptElement):
     sampleformula = ""
     samplenumberdensity = ""
     measuredmassdensity = ""
+    sampleheight = ""
     containershape = ""
     typeofcorrection = ""
     parnamelist = None
@@ -120,6 +121,7 @@ class AdvancedSetupScript(BaseScriptElement):
             'TypeOfCorrection',
             'SampleFormula',
             'MeasuredMassDensity',
+            'SampleGeometry',
             'SampleNumberDensity',
             'ContainerShape',
             # Caching options
@@ -176,6 +178,10 @@ class AdvancedSetupScript(BaseScriptElement):
         pardict["TypeOfCorrection"] = self.typeofcorrection
         pardict["SampleFormula"] = self.sampleformula
         pardict["MeasuredMassDensity"] = self.measuredmassdensity
+        if self.sampleheight is not "":
+            pardict["SampleGeometry"] = {'Height': self.sampleheight}
+        else:
+            pardict["SampleGeometry"] = ""
         pardict["SampleNumberDensity"] = self.samplenumberdensity
         pardict["ContainerShape"] = self.containershape
         #Caching options
@@ -278,6 +284,9 @@ class AdvancedSetupScript(BaseScriptElement):
 
             self.measuredmassdensity = getFloatElement(instrument_dom, "measuredmassdensity",
                                                        AdvancedSetupScript.measuredmassdensity)
+
+            self.sampleheight = getFloatElement(instrument_dom, "sampleheight",
+                                                AdvancedSetupScript.sampleheight)
 
             self.containershape = BaseScriptElement.getStringElement(instrument_dom, "containershape",
                                                                      default=AdvancedSetupScript.containershape)

--- a/scripts/reduction_gui/reduction/diffraction/diffraction_adv_setup_script.py
+++ b/scripts/reduction_gui/reduction/diffraction/diffraction_adv_setup_script.py
@@ -70,7 +70,7 @@ class AdvancedSetupScript(BaseScriptElement):
     sampleformula = ""
     samplenumberdensity = ""
     measuredmassdensity = ""
-    sampleheight = ""
+    samplegeometry = {}
     containershape = ""
     typeofcorrection = ""
     parnamelist = None
@@ -148,7 +148,10 @@ class AdvancedSetupScript(BaseScriptElement):
                     parvalue = "1"
                 elif str(parvalue) == "False":
                     parvalue = "0"
-                script += "%-10s = \"%s\",\n" % (parname, parvalue)
+                if not isinstance(parvalue, dict):
+                    script += "%-10s = \"%s\",\n" % (parname, parvalue)
+                else:
+                    script += "%-10s = %s,\n" % (parname, parvalue)
         #ENDFOR
 
         return script
@@ -178,10 +181,7 @@ class AdvancedSetupScript(BaseScriptElement):
         pardict["TypeOfCorrection"] = self.typeofcorrection
         pardict["SampleFormula"] = self.sampleformula
         pardict["MeasuredMassDensity"] = self.measuredmassdensity
-        if self.sampleheight is not "":
-            pardict["SampleGeometry"] = {'Height': self.sampleheight}
-        else:
-            pardict["SampleGeometry"] = ""
+        pardict["SampleGeometry"] = self.samplegeometry
         pardict["SampleNumberDensity"] = self.samplenumberdensity
         pardict["ContainerShape"] = self.containershape
         #Caching options
@@ -285,8 +285,15 @@ class AdvancedSetupScript(BaseScriptElement):
             self.measuredmassdensity = getFloatElement(instrument_dom, "measuredmassdensity",
                                                        AdvancedSetupScript.measuredmassdensity)
 
-            self.sampleheight = getFloatElement(instrument_dom, "sampleheight",
-                                                AdvancedSetupScript.sampleheight)
+            string_tmp = BaseScriptElement.getStringElement(instrument_dom, "samplegeometry",
+                                                            default=AdvancedSetupScript.samplegeometry)
+            self.samplegeometry = {}
+            if string_tmp:
+                items = string_tmp.replace("{", "").replace("}", "").split(",")
+                keys_tmp = [item.split(":")[0].replace("'", "") for item in items]
+                vals_tmp = [float(item.split(":")[1].replace("'", "")) for item in items]
+                for count, value in enumerate(keys_tmp):
+                    self.samplegeometry[value] = vals_tmp[count]
 
             self.containershape = BaseScriptElement.getStringElement(instrument_dom, "containershape",
                                                                      default=AdvancedSetupScript.containershape)

--- a/scripts/reduction_gui/reduction/diffraction/diffraction_reduction_script.py
+++ b/scripts/reduction_gui/reduction/diffraction/diffraction_reduction_script.py
@@ -334,7 +334,10 @@ class DiffractionReductionScripter(BaseReductionScripter):
                 continue
 
             # Add to script
-            script += "{}{} = '{}',\n".format(DiffractionReductionScripter.WIDTH, propname, propvalue)
+            if '{' in propvalue and '}' in propvalue:
+                script += "{}{} = {},\n".format(DiffractionReductionScripter.WIDTH, propname, propvalue)
+            else:
+                script += "{}{} = '{}',\n".format(DiffractionReductionScripter.WIDTH, propname, propvalue)
         # ENDFOR
 
         # 3. Optional spliter workspace


### PR DESCRIPTION
**Description of work.**

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

The entry for sample height input is added in POWGEN reduction GUI to stay consistent with the recent update of [`SNSPowderReduction`](https://docs.mantidproject.org/nightly/algorithms/SNSPowderReduction-v1.html) which can now take user-input of sample geometry.

**To test:**

To test the implementation, grab the attached XML file below and load it in the new POWGEN GUI to kick off the reduction.

[snspowderreduction.xml.zip](https://github.com/mantidproject/mantid/files/7591150/snspowderreduction.xml.zip)

<!-- Instructions for testing. -->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
