### PR TITLE
Add relative error to PeaksWorkspaces in CompareWorkspaces

### DIFF
--- a/Framework/Algorithms/src/CompareWorkspaces.cpp
+++ b/Framework/Algorithms/src/CompareWorkspaces.cpp
@@ -1013,6 +1013,7 @@ void CompareWorkspaces::doPeaksComparison(PeaksWorkspace_sptr tws1, PeaksWorkspa
   }
 
   const double tolerance = getProperty("Tolerance");
+  const bool isRelErr = getProperty("ToleranceRelErr");
   for (int i = 0; i < tws1->getNumberPeaks(); i++) {
     const Peak &peak1 = tws1->getPeak(i);
     const Peak &peak2 = tws2->getPeak(i);
@@ -1066,13 +1067,18 @@ void CompareWorkspaces::doPeaksComparison(PeaksWorkspace_sptr tws1, PeaksWorkspa
       } else {
         g_log.information() << "Column " << name << " is not compared\n";
       }
-      if (std::fabs(s1 - s2) > tolerance) {
+      bool mismatch = false;
+      if (isRelErr && relErr(s1, s2, tolerance)) {
+        mismatch = true;
+      } else if (std::fabs(s1 - s2) > tolerance) {
+        mismatch = true;
+      }
+      if (mismatch) {
         g_log.notice(name);
-        g_log.notice() << "s1 = " << s1 << "\n"
-                       << "s2 = " << s2 << "\n"
-                       << "std::fabs(s1 - s2) = " << std::fabs(s1 - s2) << "\n"
-                       << "tolerance = " << tolerance << "\n";
-        g_log.notice() << "Data mismatch at cell (row#,col#): (" << i << "," << j << ")\n";
+        g_log.notice() << "data mismatch in column name = " << name << "\n"
+                       << "cell (row#, col#): (" << i << "," << j << ")\n"
+                       << "value1 = " << s1 << "\n"
+                       << "value2 = " << s2 << "\n";
         recordMismatch("Data mismatch");
         return;
       }
@@ -1109,6 +1115,7 @@ void CompareWorkspaces::doLeanElasticPeaksComparison(const LeanElasticPeaksWorks
   IPeaksWorkspace_sptr ipws2 = sortPeaks->getProperty("OutputWorkspace");
 
   const double tolerance = getProperty("Tolerance");
+  const bool isRelErr = getProperty("ToleranceRelErr");
   for (int peakIndex = 0; peakIndex < ipws1->getNumberPeaks(); peakIndex++) {
     for (size_t j = 0; j < ipws1->columnCount(); j++) {
       std::shared_ptr<const API::Column> col = ipws1->getColumn(j);
@@ -1161,13 +1168,18 @@ void CompareWorkspaces::doLeanElasticPeaksComparison(const LeanElasticPeaksWorks
       } else {
         g_log.information() << "Column " << name << " is not compared\n";
       }
-      if (std::fabs(s1 - s2) > tolerance) {
+      bool mismatch = false;
+      if (isRelErr && relErr(s1, s2, tolerance)) {
+        mismatch = true;
+      } else if (std::fabs(s1 - s2) > tolerance) {
+        mismatch = true;
+      }
+      if (mismatch) {
         g_log.notice(name);
-        g_log.notice() << "s1 = " << s1 << "\n"
-                       << "s2 = " << s2 << "\n"
-                       << "std::fabs(s1 - s2) = " << std::fabs(s1 - s2) << "\n"
-                       << "tolerance = " << tolerance << "\n";
-        g_log.notice() << "Data mismatch at cell (row#,col#): (" << peakIndex << "," << j << ")\n";
+        g_log.notice() << "data mismatch in column name = " << name << "\n"
+                       << "cell (row#, col#): (" << peakIndex << "," << j << ")\n"
+                       << "value1 = " << s1 << "\n"
+                       << "value2 = " << s2 << "\n";
         recordMismatch("Data mismatch");
         return;
       }

--- a/Framework/Algorithms/src/CompareWorkspaces.cpp
+++ b/Framework/Algorithms/src/CompareWorkspaces.cpp
@@ -1157,6 +1157,10 @@ void CompareWorkspaces::doLeanElasticPeaksComparison(const LeanElasticPeaksWorks
           s1 += (q1[i] - q2[i]) * (q1[i] - q2[i]);
         }
         s1 = std::sqrt(s1);
+        if (isRelErr) {
+          // divide diff by avg |Q| and then compare to 0 using absolute tol
+          s1 /= 0.5 * (q1.norm() + q2.norm());
+        }
       } else if (name == "QSample") {
         V3D q1 = ipws1->getPeak(peakIndex).getQSampleFrame();
         V3D q2 = ipws2->getPeak(peakIndex).getQSampleFrame();
@@ -1165,11 +1169,15 @@ void CompareWorkspaces::doLeanElasticPeaksComparison(const LeanElasticPeaksWorks
           s1 += (q1[i] - q2[i]) * (q1[i] - q2[i]);
         }
         s1 = std::sqrt(s1);
+        if (isRelErr) {
+          // divide diff by avg |Q| and then compare to 0 using absolute tol
+          s1 /= 0.5 * (q1.norm() + q2.norm());
+        }
       } else {
         g_log.information() << "Column " << name << " is not compared\n";
       }
       bool mismatch = false;
-      if (isRelErr && relErr(s1, s2, tolerance)) {
+      if (isRelErr && relErr(s1, s2, tolerance) && name != "QLab" && name != "QSample") {
         mismatch = true;
       } else if (std::fabs(s1 - s2) > tolerance) {
         mismatch = true;

--- a/Framework/Algorithms/src/CompareWorkspaces.cpp
+++ b/Framework/Algorithms/src/CompareWorkspaces.cpp
@@ -1068,8 +1068,10 @@ void CompareWorkspaces::doPeaksComparison(PeaksWorkspace_sptr tws1, PeaksWorkspa
         g_log.information() << "Column " << name << " is not compared\n";
       }
       bool mismatch = false;
-      if (isRelErr && relErr(s1, s2, tolerance)) {
-        mismatch = true;
+      if (isRelErr) {
+        if (relErr(s1, s2, tolerance)) {
+          mismatch = true;
+        }
       } else if (std::fabs(s1 - s2) > tolerance) {
         mismatch = true;
       }
@@ -1177,8 +1179,10 @@ void CompareWorkspaces::doLeanElasticPeaksComparison(const LeanElasticPeaksWorks
         g_log.information() << "Column " << name << " is not compared\n";
       }
       bool mismatch = false;
-      if (isRelErr && relErr(s1, s2, tolerance) && name != "QLab" && name != "QSample") {
-        mismatch = true;
+      if (isRelErr && name != "QLab" && name != "QSample") {
+        if (relErr(s1, s2, tolerance)) {
+          mismatch = true;
+        }
       } else if (std::fabs(s1 - s2) > tolerance) {
         mismatch = true;
       }

--- a/Framework/Algorithms/test/CompareWorkspacesTest.h
+++ b/Framework/Algorithms/test/CompareWorkspacesTest.h
@@ -126,6 +126,26 @@ public:
     TS_ASSERT_EQUALS(checker.getPropertyValue("Result"), PROPERTY_VALUE_TRUE);
   }
 
+  void test_RelativeErrorInPeaksWorkspace() {
+    if (!checker.isInitialized())
+      checker.initialize();
+
+    const double tol = checker.getProperty("Tolerance");
+    auto pws1 = std::make_shared<LeanElasticPeaksWorkspace>();
+    auto pws2 = std::make_shared<LeanElasticPeaksWorkspace>();
+    LeanElasticPeak pk1(V3D(4.0, 0.0, 0.0));
+    pws1->addPeak(pk1);
+    LeanElasticPeak pk2(V3D(4.0 + 2.0 * tol, 0.0, 0.0));
+    pws2->addPeak(pk2);
+
+    // check matches with relative error
+    TS_ASSERT_THROWS_NOTHING(checker.setProperty("Workspace1", std::dynamic_pointer_cast<Workspace>(pws1)));
+    TS_ASSERT_THROWS_NOTHING(checker.setProperty("Workspace2", std::dynamic_pointer_cast<Workspace>(pws2)));
+    TS_ASSERT_THROWS_NOTHING(checker.setProperty("ToleranceRelErr", true));
+    TS_ASSERT(checker.execute());
+    TS_ASSERT_EQUALS(checker.getPropertyValue("Result"), PROPERTY_VALUE_TRUE);
+  }
+
   void testPeaks_extrapeak() {
     if (!checker.isInitialized())
       checker.initialize();

--- a/docs/source/release/v6.3.0/framework.rst
+++ b/docs/source/release/v6.3.0/framework.rst
@@ -32,6 +32,7 @@ Improvements
 - :ref:`SetSample <algm-SetSample>` can now load sample environment XML files from any directory using ``SetSample(ws, Environment={'Name': 'NameOfXMLFile', 'Path':'/path/to/file/'})``.
 - An importance sampling option has been added to :ref:`DiscusMultipleScatteringCorrection <algm-DiscusMultipleScatteringCorrection>` so that it handles spikes in the structure factor S(Q) better
 - Added parameter to :ref:`DiscusMultipleScatteringCorrection <algm-DiscusMultipleScatteringCorrection>` to control number of attempts to generate initial scatter point
+- Relative error option now enabled for peak table workspaces in :ref:`CompareWorkspaces <algm-CompareWorkspaces>`.
 
 Bugfixes
 ########


### PR DESCRIPTION
**Description of work.**

PeaksWorkspaces can now be compared using a relative tolerance (i.e. fractional tolerance).
This is useful because TOF and d-spacing are very different magnitudes, but the fractional error between the workspaces should be the same (TOF \propto d).

**To test:**

(1) Run this script and check that changing relative error changes whether the workspaces match

```
ws = LoadEmptyInstrument(InstrumentName='SXD', OutputWorkspace='empty_SXD')
axis = ws.getAxis(0)
axis.setUnit("TOF")
peaks1 = CreatePeaksWorkspace(InstrumentWorkspace=ws, NumberOfPeaks=0)
AddPeak(PeaksWorkspace='peaks1', RunWorkspace='empty_SXD', TOF=10000, DetectorID=28741)
peaks2 = CreatePeaksWorkspace(InstrumentWorkspace=ws, NumberOfPeaks=0)
AddPeak(PeaksWorkspace='peaks2', RunWorkspace='empty_SXD', TOF=10010, DetectorID=28741)

# Check with RelErr = True
CompareWorkspaces(Workspace1=peaks1, Workspace2=peaks2, Tolerance=0.002, 
    CheckType=False, CheckAxes=False, CheckSpectraMap=False, CheckInstrument=False, 
    CheckMasking=False, ToleranceRelErr=True, CheckAllData=True) # should match

# Check with RelErr = False
CompareWorkspaces(Workspace1=peaks1, Workspace2=peaks2, Tolerance=0.002, 
    CheckType=False, CheckAxes=False, CheckSpectraMap=False, CheckInstrument=False, 
    CheckMasking=False, ToleranceRelErr=False, CheckAllData=True) # shouldn't match
```


*There is no associated issue.*

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
