### PR TITLE
Revert removal of cmake COMPONENT installs 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,6 +108,7 @@ build/
 Framework/Kernel/inc/MantidKernel/GitHubApiHelper.h
 qt/python/mantidqt/mantidqt/resources.py
 qt/applications/workbench/workbench/app/resources.py
+qt/applications/workbench/qt.conf
 
 # Visual C++ cache files
 ipch/

--- a/Framework/CMakeLists.txt
+++ b/Framework/CMakeLists.txt
@@ -104,6 +104,7 @@ foreach(_bundle ${BUNDLES})
   install(
     DIRECTORY ../instrument/
     DESTINATION ${_bundle}/instrument
+    COMPONENT Runtime
     PATTERN "*UNIT_TESTING*" EXCLUDE
     PATTERN ".gitignore" EXCLUDE
   )
@@ -114,6 +115,7 @@ foreach(_bundle ${BUNDLES})
       install(
         DIRECTORY ../scripts/
         DESTINATION ${_bundle}/scripts
+        COMPONENT Runtime
         PATTERN "*.pyc" EXCLUDE
         PATTERN ".svn" EXCLUDE
         PATTERN ".gitignore" EXCLUDE
@@ -127,6 +129,7 @@ foreach(_bundle ${BUNDLES})
       install(
         DIRECTORY ../scripts/
         DESTINATION ${_bundle}scripts
+        COMPONENT Runtime
         PATTERN "*.pyc" EXCLUDE
         PATTERN ".svn" EXCLUDE
         PATTERN ".gitignore" EXCLUDE
@@ -144,6 +147,7 @@ foreach(_bundle ${BUNDLES})
     install(
       DIRECTORY ../scripts/
       DESTINATION ${_bundle}scripts
+      COMPONENT Runtime
       PATTERN "*.pyc" EXCLUDE
       PATTERN ".svn" EXCLUDE
       PATTERN ".gitignore" EXCLUDE
@@ -174,14 +178,17 @@ if(CONDA_ENV)
     COMPATIBILITY SameMajorVersion
   )
 
-  install(FILES "${CMAKE_CURRENT_BINARY_DIR}/MantidFrameworkConfig.cmake"
-                "${CMAKE_CURRENT_BINARY_DIR}/MantidFrameworkConfigVersion.cmake"
-          DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/MantidFramework
+  install(
+    FILES "${CMAKE_CURRENT_BINARY_DIR}/MantidFrameworkConfig.cmake"
+          "${CMAKE_CURRENT_BINARY_DIR}/MantidFrameworkConfigVersion.cmake"
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/MantidFramework
+    COMPONENT Devel
   )
 
   install(
     FILES ${CMAKE_SOURCE_DIR}/buildconfig/CMake/FindNexus.cmake ${CMAKE_SOURCE_DIR}/buildconfig/CMake/FindJsonCPP.cmake
           ${CMAKE_SOURCE_DIR}/buildconfig/CMake/FindTBB.cmake ${CMAKE_SOURCE_DIR}/buildconfig/CMake/FindMuParser.cmake
     DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/MantidFramework/find_modules
+    COMPONENT Devel
   )
 endif()

--- a/Framework/PythonInterface/CMakeLists.txt
+++ b/Framework/PythonInterface/CMakeLists.txt
@@ -78,7 +78,7 @@ endfunction()
 # ######################################################################################################################
 # Common install RPATH setting for all extension modules
 if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
-  set(EXT_INSTALL_RPATH ${DL_ORIGIN_TAG}/../../../MacOS)
+  set(EXT_INSTALL_RPATH "${DL_ORIGIN_TAG}/../../../MacOS;${DL_ORIGIN_TAG}/../../../Frameworks")
 elseif(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
   set(EXT_INSTALL_RPATH ${DL_ORIGIN_TAG}/../../../${LIB_DIR})
 endif()

--- a/buildconfig/CMake/BundleOSXConda.cmake
+++ b/buildconfig/CMake/BundleOSXConda.cmake
@@ -1,0 +1,45 @@
+macro(install_qt5_plugin_osx _qt_plugin_name _qt_plugins_var _prefix)
+  get_target_property(_qt_plugin_path "${_qt_plugin_name}" LOCATION)
+  if(EXISTS "${_qt_plugin_path}")
+    get_filename_component(_qt_plugin_file "${_qt_plugin_path}" NAME)
+    get_filename_component(_qt_plugin_type "${_qt_plugin_path}" PATH)
+    get_filename_component(_qt_plugin_type "${_qt_plugin_type}" NAME)
+    set(_qt_plugin_dest "${_prefix}/PlugIns/${_qt_plugin_type}")
+    install(
+      FILES "${_qt_plugin_path}"
+      DESTINATION "${_qt_plugin_dest}"
+      COMPONENT Runtime
+    )
+    set(${_qt_plugins_var}
+        "${${_qt_plugins_var}};\$ENV{DEST_DIR}\${CMAKE_INSTALL_PREFIX}/${_qt_plugin_dest}/${_qt_plugin_file}"
+    )
+  else()
+    message(FATAL_ERROR "QT plugin ${_qt_plugin_name} not found")
+  endif()
+endmacro()
+
+install(CODE "set(WORKBENCH_APP \"${WORKBENCH_APP}\")" COMPONENT Runtime)
+# Manually sort out the dependencies using cmake
+install(
+  CODE [[ file(GET_RUNTIME_DEPENDENCIES EXECUTABLES $<TARGET_FILE:MantidWorkbenchInstalled>
+LIBRARIES $<TARGET_FILE:Qt5::QCocoaIntegrationPlugin> $<TARGET_FILE:Qt5::QMacStylePlugin> $<TARGET_FILE:Kernel> $<TARGET_FILE:API> $<TARGET_FILE:Json> $<TARGET_FILE:mantidqt_commonqt5> $<TARGET_FILE:LiveData>
+RESOLVED_DEPENDENCIES_VAR _r_deps UNRESOLVED_DEPENDENCIES_VAR _u_deps
+DIRECTORIES ${MY_DEPENDENCY_PATHS} )
+foreach(_file ${_r_deps})
+if(NOT ${_file} MATCHES "Mantid")
+file(INSTALL DESTINATION
+"${CMAKE_INSTALL_PREFIX}/${WORKBENCH_APP}/Contents/Frameworks" TYPE
+SHARED_LIBRARY FOLLOW_SYMLINK_CHAIN FILES "${_file}" )
+endif()
+endforeach()
+list(LENGTH _u_deps _u_length)
+if("${_u_length}" GREATER 0)
+message(WARNING
+"Unresolved dependencies detected!")
+ endif()
+]]
+  COMPONENT Runtime
+)
+
+install_qt5_plugin_osx("Qt5::QCocoaIntegrationPlugin" QT_PLUGINS ${CMAKE_INSTALL_PREFIX}/${WORKBENCH_APP}/Contents/)
+install_qt5_plugin_osx("Qt5::QMacStylePlugin" QT_PLUGINS ${CMAKE_INSTALL_PREFIX}/${WORKBENCH_APP}/Contents/)

--- a/buildconfig/CMake/CPackCommon.cmake
+++ b/buildconfig/CMake/CPackCommon.cmake
@@ -14,9 +14,17 @@ set(CPACK_PACKAGE_VERSION_MAJOR ${VERSION_MAJOR})
 set(CPACK_PACKAGE_VERSION_MINOR ${VERSION_MINOR})
 set(CPACK_PACKAGE_VERSION_PATCH ${VERSION_PATCH}${VERSION_TWEAK})
 
-# Sets install for the /opt/mantid* directory
-if(NOT ${CMAKE_SYSTEM_NAME} STREQUAL "Windows")
-  set(CPACK_PACKAGING_INSTALL_PREFIX ${CMAKE_INSTALL_PREFIX})
+if(NOT CONDA_ENV)
+  # Legacy whole bundle
+  set(CPACK_MONOLITHIC_INSTALL ON)
+  # Sets install for the /opt/mantid* directory
+  if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
+    set(CPACK_PACKAGING_INSTALL_PREFIX ${CMAKE_INSTALL_PREFIX})
+  else()
+    set(CPACK_PACKAGING_INSTALL_PREFIX "")
+  endif()
+  set(CPACK_INCLUDE_TOPLEVEL_DIRECTORY OFF)
+  set(CPACK_COMPONENT_INCLUDE_TOPLEVEL_DIRECTORY OFF)
 endif()
 
 # RPM information - only used if generating a rpm the release number is an option set in LinuxPackageScripts.cmake

--- a/buildconfig/CMake/DarwinSetup.cmake
+++ b/buildconfig/CMake/DarwinSetup.cmake
@@ -123,7 +123,10 @@ endif()
 
 if(ENABLE_WORKBENCH AND NOT CONDA_BUILD)
   set(CPACK_GENERATOR DragNDrop)
-  set(CMAKE_INSTALL_PREFIX "")
+  set(CMAKE_INSTALL_PREFIX
+      ""
+      CACHE PATH ""
+  )
   # Replace hdiutil command to retry on detach failure
   set(CPACK_COMMAND_HDIUTIL ${CMAKE_SOURCE_DIR}/installers/MacInstaller/hdiutilwrap)
   set(CMAKE_MACOSX_RPATH 1)
@@ -138,13 +141,17 @@ if(ENABLE_WORKBENCH AND NOT CONDA_BUILD)
   set(WORKBENCH_SITE_PACKAGES ${WORKBENCH_BUNDLE}MacOS)
   set(WORKBENCH_PLUGINS_DIR ${WORKBENCH_BUNDLE}PlugIns)
 
+  if(NOT CONDA_ENV)
+    install(
+      PROGRAMS ${CMAKE_BINARY_DIR}/mantidpython_osx_install
+      DESTINATION ${WORKBENCH_BUNDLE}/MacOS/
+      RENAME mantidpython
+    )
+  endif()
   install(
-    PROGRAMS ${CMAKE_BINARY_DIR}/mantidpython_osx_install
-    DESTINATION ${WORKBENCH_BUNDLE}/MacOS/
-    RENAME mantidpython
-  )
-  install(FILES ${CMAKE_SOURCE_DIR}/images/mantid_workbench${CPACK_PACKAGE_SUFFIX}.icns
-          DESTINATION ${WORKBENCH_BUNDLE}Resources/
+    FILES ${CMAKE_SOURCE_DIR}/images/mantid_workbench${CPACK_PACKAGE_SUFFIX}.icns
+    DESTINATION ${WORKBENCH_BUNDLE}Resources/
+    COMPONENT Runtime
   )
   set(BUNDLES ${INBUNDLE} ${WORKBENCH_BUNDLE})
 

--- a/buildconfig/CMake/PyStoG.cmake
+++ b/buildconfig/CMake/PyStoG.cmake
@@ -79,5 +79,9 @@ file(WRITE ${_PyStoG_scripts_dir}/__init__.py ${_PyStoG_INIT_CONTENTS})
 
 # install the results
 foreach(_bundle ${BUNDLES})
-  install(DIRECTORY ${_PyStoG_scripts_dir} DESTINATION ${_bundle}scripts)
+  install(
+    DIRECTORY ${_PyStoG_scripts_dir}
+    DESTINATION ${_bundle}scripts
+    COMPONENT Runtime
+  )
 endforeach()

--- a/buildconfig/CMake/PythonPackageTargetFunctions.cmake
+++ b/buildconfig/CMake/PythonPackageTargetFunctions.cmake
@@ -79,6 +79,7 @@ function(add_python_package pkg_name)
   if(CONDA_BUILD)
     install(CODE "execute_process(COMMAND ${CMAKE_COMMAND} -E env MANTID_VERSION_STR=${_version_str} \
     ${Python_EXECUTABLE} -m pip install ${CMAKE_CURRENT_SOURCE_DIR} --no-deps --ignore-installed --no-cache-dir -vvv)"
+            COMPONENT Runtime
     )
   else()
     install(
@@ -86,6 +87,7 @@ function(add_python_package pkg_name)
     ${Python_EXECUTABLE} ${_setup_py} install -O1 --single-version-externally-managed \
     --root=${_setup_py_build_root}/install --install-scripts=bin --install-lib=lib \
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})"
+      COMPONENT Runtime
     )
   endif()
 
@@ -96,6 +98,7 @@ function(add_python_package pkg_name)
         install(
           DIRECTORY ${_setup_py_build_root}/install/lib/
           DESTINATION ${_dest}
+          COMPONENT Runtime
           PATTERN "test" EXCLUDE
           REGEX "${_parsed_arg_EXCLUDE_FROM_INSTALL}" EXCLUDE
         )
@@ -105,13 +108,18 @@ function(add_python_package pkg_name)
         install(
           DIRECTORY ${_setup_py_build_root}/install/lib/
           DESTINATION ${_dest}
+          COMPONENT Runtime
           PATTERN "test" EXCLUDE
         )
       endforeach()
     endif()
     # install the generated executable
     if(_parsed_arg_EXECUTABLE AND _parsed_arg_INSTALL_BIN_DIR)
-      install(PROGRAMS ${_setup_py_build_root}/install/bin/${pkg_name} DESTINATION ${_parsed_arg_INSTALL_BIN_DIR})
+      install(
+        PROGRAMS ${_setup_py_build_root}/install/bin/${pkg_name}
+        DESTINATION ${_parsed_arg_INSTALL_BIN_DIR}
+        COMPONENT Runtime
+      )
     endif()
   endif()
 endfunction()

--- a/buildconfig/CMake/QtTargetFunctions.cmake
+++ b/buildconfig/CMake/QtTargetFunctions.cmake
@@ -222,7 +222,11 @@ endfunction()
 # install_prefix
 function(mtd_install_qt_library qt_version target install_target_type install_dir)
   if(qt_version EQUAL 5 AND (ENABLE_WORKBENCH OR BUILD_MANTIDQT))
-    install(TARGETS ${target} ${install_target_type} DESTINATION ${install_dir})
+    install(
+      TARGETS ${target} ${install_target_type}
+      DESTINATION ${install_dir}
+      COMPONENT Runtime
+    )
   endif()
 endfunction()
 

--- a/buildconfig/CMake/TargetFunctions.cmake
+++ b/buildconfig/CMake/TargetFunctions.cmake
@@ -15,7 +15,11 @@ function(mtd_install_targets)
   endif()
   _sanitize_install_dirs(_install_dirs ${PARSED_INSTALL_DIRS})
   foreach(_dir ${_install_dirs})
-    install(TARGETS ${PARSED_TARGETS} ${SYSTEM_PACKAGE_TARGET} DESTINATION ${_dir})
+    install(
+      TARGETS ${PARSED_TARGETS} ${SYSTEM_PACKAGE_TARGET}
+      DESTINATION ${_dir}
+      COMPONENT Runtime
+    )
   endforeach()
 endfunction()
 
@@ -29,8 +33,8 @@ function(mtd_install_framework_lib)
   if(PARSED_PLUGIN_LIB)
     install(
       TARGETS ${PARSED_TARGETS}
-      RUNTIME DESTINATION plugins
-      LIBRARY DESTINATION plugins
+      RUNTIME DESTINATION ${WORKBENCH_PLUGINS_DIR} COMPONENT Runtime
+      LIBRARY DESTINATION ${WORKBENCH_PLUGINS_DIR} COMPONENT Runtime
     )
   else()
     install(
@@ -49,9 +53,9 @@ function(mtd_install_framework_lib)
     install(
       TARGETS ${PARSED_TARGETS}
       EXPORT ${PARSED_EXPORT_NAME}
-      LIBRARY DESTINATION lib
-      ARCHIVE DESTINATION lib
-      RUNTIME DESTINATION bin
+      LIBRARY DESTINATION ${WORKBENCH_LIB_DIR} COMPONENT Runtime
+      ARCHIVE DESTINATION ${WORKBENCH_LIB_DIR} COMPONENT Devel
+      RUNTIME DESTINATION ${WORKBENCH_BIN_DIR} COMPONENT Runtime
     )
 
     install(
@@ -89,6 +93,7 @@ function(mtd_install_files)
       FILES ${PARSED_FILES}
       DESTINATION ${_dir}
       RENAME ${PARSED_RENAME}
+      COMPONENT Runtime
     )
   endforeach()
 endfunction()
@@ -114,6 +119,7 @@ function(mtd_install_dirs)
     install(
       DIRECTORY ${PARSED_DIRECTORY}
       DESTINATION ${_dir}
+      COMPONENT Runtime
       PATTERN ${PARSED_EXCLUDE} EXCLUDE
     )
   endforeach()

--- a/qt/applications/workbench/CMakeLists.txt
+++ b/qt/applications/workbench/CMakeLists.txt
@@ -65,7 +65,14 @@ if(APPLE OR WIN32)
   if(WIN32)
     target_link_libraries(MantidWorkbenchInstalled PRIVATE Qt5::WinMain)
   endif()
-  install(TARGETS MantidWorkbenchInstalled DESTINATION ${WORKBENCH_BIN_DIR})
+  install(
+    TARGETS MantidWorkbenchInstalled
+    DESTINATION ${WORKBENCH_BIN_DIR}
+    COMPONENT Runtime
+  )
+  if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+    set_target_properties(MantidWorkbenchInstalled PROPERTIES INSTALL_RPATH "@loader_path/../Frameworks")
+  endif()
 endif()
 
 # process resources files
@@ -118,12 +125,23 @@ if(WIN32)
     FILES ${CMAKE_CURRENT_BINARY_DIR}/resources.py.install
     DESTINATION ${WORKBENCH_SITE_PACKAGES}/workbench/app
     RENAME resources.py
+    COMPONENT Runtime
   )
 else()
   if(CONDA_BUILD)
     set(_output_res_py ${WORKBENCH_SITE_PACKAGES}/workbench/app/resources.py)
   else()
     set(_output_res_py ${CMAKE_CURRENT_LIST_DIR}/workbench/app/resources.py)
+  endif()
+  if(APPLE AND CONDA_ENV)
+    file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/qt.conf"
+         "[Paths]\nPlugins = PlugIns\nImports = Resources/qml\nQml2Imports = Resources/qml"
+    )
+    install(
+      FILES "${CMAKE_CURRENT_BINARY_DIR}/qt.conf"
+      DESTINATION "${WORKBENCH_LIB_DIR}/../Resources"
+      COMPONENT Runtime
+    )
   endif()
   add_custom_command(
     OUTPUT ${_output_res_py}
@@ -157,9 +175,16 @@ if(APPLE AND NOT CONDA_BUILD)
   foreach(_i RANGE 2)
     get_filename_component(_qt_install_prefix ${_qt_install_prefix} DIRECTORY)
   endforeach()
-  install(FILES ${CMAKE_CURRENT_BINARY_DIR}/Info.plist DESTINATION ${WORKBENCH_BUNDLE})
   install(
-    CODE "
+    FILES ${CMAKE_CURRENT_BINARY_DIR}/Info.plist
+    DESTINATION ${WORKBENCH_BUNDLE}
+    COMPONENT Runtime
+  )
+
+  # We can't do this in a conda_env as it looks for homebrew packages
+  if(NOT CONDA_ENV)
+    install(
+      CODE "
       execute_process(COMMAND ${CMAKE_SOURCE_DIR}/installers/MacInstaller/make_package.rb
                               \${CMAKE_INSTALL_PREFIX}/${WORKBENCH_APP} ${Python_EXECUTABLE} ${_qt_install_prefix}
                       RESULT_VARIABLE install_name_tool_result OUTPUT_VARIABLE _out ERROR_VARIABLE _out COMMAND_ECHO STDOUT)
@@ -168,7 +193,11 @@ if(APPLE AND NOT CONDA_BUILD)
         message(FATAL_ERROR \"Package script failed!!!\n\")
       endif()
   "
-  )
+    )
+  else()
+    include(BundleOSXConda)
+  endif()
+
 endif()
 
 # Testing

--- a/qt/python/mantidqt/mantidqt/CMakeLists.txt
+++ b/qt/python/mantidqt/mantidqt/CMakeLists.txt
@@ -38,7 +38,7 @@ mtd_add_sip_module(
             Mantid::API
   INSTALL_DIR ${WORKBENCH_SITE_PACKAGES}/mantidqt
   LINUX_INSTALL_RPATH "\$ORIGIN/.."
-  OSX_INSTALL_RPATH "@loader_path/.."
+  OSX_INSTALL_RPATH "@loader_path/..;@loader_path/../../Frameworks"
   FOLDER Qt5
 )
 

--- a/qt/python/mantidqt/mantidqt/icons/CMakeLists.txt
+++ b/qt/python/mantidqt/mantidqt/icons/CMakeLists.txt
@@ -19,7 +19,7 @@ mtd_add_sip_module(
   LINK_LIBS ${WORKBENCH_LINK_LIBS}
   INSTALL_DIR ${WORKBENCH_SITE_PACKAGES}/mantidqt/icons
   LINUX_INSTALL_RPATH "\$ORIGIN/../.."
-  OSX_INSTALL_RPATH "@loader_path/../.."
+  OSX_INSTALL_RPATH "@loader_path/../..;@loader_path/../../Frameworks"
   FOLDER Qt5
 )
 

--- a/qt/scientific_interfaces/Direct/CMakeLists.txt
+++ b/qt/scientific_interfaces/Direct/CMakeLists.txt
@@ -23,7 +23,7 @@ mtd_add_qt_library(
   QT5_LINK_LIBS Qt5::OpenGL
   MTD_QT_LINK_LIBS MantidQtWidgetsCommon MantidQtWidgetsInstrumentView MantidQtWidgetsPlotting MantidQtWidgetsMplCpp
   INSTALL_DIR_BASE ${WORKBENCH_PLUGINS_DIR}
-  OSX_INSTALL_RPATH @loader_path/../../Contents/MacOS @loader_path/../../plugins/qt5
+  OSX_INSTALL_RPATH @loader_path/../../MacOS @loader_path/../../plugins/qt5
   LINUX_INSTALL_RPATH "\$ORIGIN/../../${LIB_DIR};\$ORIGIN/../../plugins/qt5/"
 )
 # Testing target We can currently only include the tests if we are building the framework. This is bceause we depend on

--- a/qt/scientific_interfaces/General/CMakeLists.txt
+++ b/qt/scientific_interfaces/General/CMakeLists.txt
@@ -29,6 +29,6 @@ mtd_add_qt_library(
   LINK_LIBS ${CORE_MANTIDLIBS} ${POCO_LIBRARIES} ${Boost_LIBRARIES} ${JSONCPP_LIBRARIES} Mantid::Json
   MTD_QT_LINK_LIBS MantidQtWidgetsCommon MantidQtWidgetsMplCpp
   INSTALL_DIR_BASE ${WORKBENCH_PLUGINS_DIR}
-  OSX_INSTALL_RPATH @loader_path/../../Contents/MacOS @loader_path/../../Contents/Frameworks
+  OSX_INSTALL_RPATH @loader_path/../../MacOS @loader_path/../../Frameworks
   LINUX_INSTALL_RPATH "\$ORIGIN/../../${LIB_DIR}"
 )

--- a/qt/scientific_interfaces/ISISReflectometry/CMakeLists.txt
+++ b/qt/scientific_interfaces/ISISReflectometry/CMakeLists.txt
@@ -36,8 +36,7 @@ mtd_add_qt_library(
   LINK_LIBS ${CORE_MANTIDLIBS} ${POCO_LIBRARIES} ${Boost_LIBRARIES} ${JSONCPP_LIBRARIES} ${PYTHON_LIBRARIES}
   MTD_QT_LINK_LIBS MantidQtWidgetsCommon MantidQtWidgetsInstrumentView MantidQtIcons MantidQtWidgetsMplCpp
   INSTALL_DIR_BASE ${WORKBENCH_PLUGINS_DIR}
-  OSX_INSTALL_RPATH @loader_path/../../Contents/MacOS @loader_path/../../Contents/Frameworks
-                    @loader_path/../../plugins/qt5
+  OSX_INSTALL_RPATH @loader_path/../../MacOS @loader_path/../../Frameworks @loader_path/../../plugins/qt5
   LINUX_INSTALL_RPATH "\$ORIGIN/../../${LIB_DIR}"
 )
 

--- a/qt/scientific_interfaces/Indirect/CMakeLists.txt
+++ b/qt/scientific_interfaces/Indirect/CMakeLists.txt
@@ -267,8 +267,7 @@ mtd_add_qt_library(
             Qt5::Xml
   MTD_QT_LINK_LIBS MantidQtWidgetsCommon MantidQtWidgetsPlotting MantidQtWidgetsMplCpp MantidQtIcons
   INSTALL_DIR_BASE ${WORKBENCH_PLUGINS_DIR}
-  OSX_INSTALL_RPATH @loader_path/../../Contents/MacOS @loader_path/../../Contents/Frameworks
-                    @loader_path/../../plugins/qt5
+  OSX_INSTALL_RPATH @loader_path/../../MacOS @loader_path/../../Frameworks @loader_path/../../plugins/qt5
   LINUX_INSTALL_RPATH "\$ORIGIN/../../${LIB_DIR};\$ORIGIN/../../plugins/qt5/"
 )
 

--- a/qt/scientific_interfaces/MultiDatasetFit/CMakeLists.txt
+++ b/qt/scientific_interfaces/MultiDatasetFit/CMakeLists.txt
@@ -27,6 +27,6 @@ mtd_add_qt_library(
   QT4_LINK_LIBS Qwt5
   MTD_QT_LINK_LIBS MantidQtWidgetsCommon MantidQtWidgetsPlotting
   INSTALL_DIR_BASE ${PLUGINS_DIR}
-  OSX_INSTALL_RPATH @loader_path/../../Contents/MacOS @loader_path/../../Contents/Frameworks
+  OSX_INSTALL_RPATH @loader_path/../../MacOS @loader_path/../../Frameworks
   LINUX_INSTALL_RPATH "\$ORIGIN/../../${LIB_DIR}"
 )

--- a/qt/scientific_interfaces/Muon/CMakeLists.txt
+++ b/qt/scientific_interfaces/Muon/CMakeLists.txt
@@ -59,7 +59,7 @@ mtd_add_qt_library(
   LINK_LIBS ${CORE_MANTIDLIBS} ${POCO_LIBRARIES} ${Boost_LIBRARIES} ${JSONCPP_LIBRARIES}
   MTD_QT_LINK_LIBS MantidQtWidgetsCommon MantidQtWidgetsMplCpp MantidQtWidgetsPlotting
   INSTALL_DIR_BASE ${WORKBENCH_PLUGINS_DIR}
-  OSX_INSTALL_RPATH @loader_path/../../Contents/MacOS @loader_path/../../plugins/qt5
+  OSX_INSTALL_RPATH @loader_path/../../MacOS @loader_path/../../plugins/qt5
   LINUX_INSTALL_RPATH "\$ORIGIN/../../${LIB_DIR};\$ORIGIN/../../plugins/qt5/"
 )
 

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/QtPropertyBrowser/CMakeLists.txt
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/QtPropertyBrowser/CMakeLists.txt
@@ -98,4 +98,8 @@ elseif(${CMAKE_CXX_COMPILER_ID} MATCHES "GNU")
 endif()
 
 # Installation settings
-install(TARGETS ${PROJECT_NAME} DESTINATION ${LIB_DIR})
+install(
+  TARGETS ${PROJECT_NAME}
+  DESTINATION ${LIB_DIR}
+  COMPONENT Runtime
+)

--- a/qt/widgets/plugins/algorithm_dialogs/CMakeLists.txt
+++ b/qt/widgets/plugins/algorithm_dialogs/CMakeLists.txt
@@ -60,7 +60,7 @@ mtd_add_qt_library(
   LINK_LIBS ${CORE_MANTIDLIBS} ${POCO_LIBRARIES} ${Boost_LIBRARIES} ${QT_LIBRARIES} ${OPENGL_LIBRARIES}
   QT5_LINK_LIBS Qt5::OpenGL Qt5::Qscintilla
   MTD_QT_LINK_LIBS MantidQtWidgetsCommon
-  OSX_INSTALL_RPATH @loader_path/../../Contents/MacOS
+  OSX_INSTALL_RPATH @loader_path/../../MacOS
   LINUX_INSTALL_RPATH "\$ORIGIN/../../${LIB_DIR}"
   INSTALL_DIR_BASE ${WORKBENCH_PLUGINS_DIR}
 )

--- a/scripts/ExternalInterfaces/CMakeLists.txt
+++ b/scripts/ExternalInterfaces/CMakeLists.txt
@@ -36,5 +36,9 @@ set(MSLICE_DEV
 
 # Installation MSLICE_DEV is only set in PARENT_SCOPE! so don't use it here
 foreach(_bundle ${BUNDLES})
-  install(DIRECTORY ${_mslice_external_root}/src/mslice/mslice/ DESTINATION ${_bundle}scripts/ExternalInterfaces/mslice)
+  install(
+    DIRECTORY ${_mslice_external_root}/src/mslice/mslice/
+    DESTINATION ${_bundle}scripts/ExternalInterfaces/mslice
+    COMPONENT Runtime
+  )
 endforeach()


### PR DESCRIPTION
**Description of work.**

Originally added in #32903, in order to make a package of just runtime components, the changes were reverted by #32996 as they broken the current bundling on Windows/macOS.

These changes add the necessary cpack flags to disable the component installs/prefixes in non-conda mode.

**To test:**

These changes need to be tested on all 3 operating systems for the non-conda package build and in addition using the instructions in the original issue to build a standalone bundle based on conda on macOS. See #32903.


Refs #33024 

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
