### PR TITLE
Revert "Check if GUIs Need to Keep Running When Closing Workbench"

### DIFF
--- a/docs/source/release/v6.3.0/mantidworkbench.rst
+++ b/docs/source/release/v6.3.0/mantidworkbench.rst
@@ -40,7 +40,6 @@ Bugfixes
 - Fixed a bug with autoscaling of colorfill plots from within the figure options.
 - Fixed an issue to plot negative values with logarithm scaling in slice view.
 - Workbench will no longer hang if an algorithm was running when workbench was closed.
-- Stopped workbench from ignoring GUIs that want to cancel closing
 - Fixed a bug in the editor where uncommenting using 'ctrl+/' wasn't working correctly for lines of the form '<optional whitespace>#code_here # inline comment'.
 
 :ref:`Release 6.3.0 <v6.3.0>`

--- a/qt/applications/workbench/workbench/app/mainwindow.py
+++ b/qt/applications/workbench/workbench/app/mainwindow.py
@@ -577,17 +577,8 @@ class MainWindow(QMainWindow):
                     event.ignore()
                     return
 
-        # Close windows
-        app = QApplication.instance()
-        if app is not None:
-            for window in app.topLevelWindows():
-                if not window.close():
-                    # Allow GUIs to cancel the closure if they want to save
-                    event.ignore()
-                    return
-
         # Close editors
-        if self.editor is None or (self.editor.editors.current_editor() and self.editor.app_closing()):
+        if self.editor is None or self.editor.app_closing():
             # write out any changes to the mantid config file
             ConfigService.saveConfig(ConfigService.getUserFilename())
             # write current window information to global settings object
@@ -597,12 +588,12 @@ class MainWindow(QMainWindow):
             import matplotlib.pyplot as plt  # noqa
             plt.close('all')
 
-            # Close any remaining windows
-            if app is not None:
-                app.closeAllWindows()
-
             # Cancel all running (managed) algorithms
             AlgorithmManager.Instance().cancelAll()
+
+            app = QApplication.instance()
+            if app is not None:
+                app.closeAllWindows()
 
             # Kill the project recovery thread and don't restart should a save be in progress and clear out current
             # recovery checkpoint as it is closing properly

--- a/qt/applications/workbench/workbench/test/test_mainwindow.py
+++ b/qt/applications/workbench/workbench/test/test_mainwindow.py
@@ -245,20 +245,6 @@ class MainWindowTest(unittest.TestCase):
         mock_project.offer_save.assert_called()
         mock_event.ignore.assert_called()
 
-    @patch('workbench.app.mainwindow.QApplication')
-    def test_main_window_does_not_close_if_gui_ignores_event(self, mock_q_app):
-        mock_event = Mock()
-        mock_window = Mock()
-        mock_window.close = Mock(return_value=False)  # Close event was ignored (user cancelled)
-        mock_app = Mock()
-        mock_q_app.instance = Mock(return_value=mock_app)
-        mock_app.topLevelWindows = Mock(return_value=[mock_window])
-
-        self.main_window.closeEvent(mock_event)
-
-        mock_window.close.assert_called()
-        mock_event.ignore.assert_called()
-
     @patch('workbench.app.mainwindow.ConfigService')
     @patch('workbench.app.mainwindow.QApplication')
     @patch('matplotlib.pyplot.close')


### PR DESCRIPTION
Reverts mantidproject/mantid#32878

This issue that was intended to be fixed allowed GUI's to ignore the mainwindow CloseEvent, therefore allowing GUI's to stop workbench closure so that they could save/do some other work if workbench was closed. This worked on Linux, but - due to differences in window handling - does not work on windows and also introduces a bug where the layout is not saved correctly. 

Fixing the underlying issue requires better tracking of what interfaces are currently open so that only those interfaces can be closed *before* the mainwindow shuts down, allowing cancellation early enough to stop breaks.   


Fixes #33013 