### PR TITLE
Preserve indent when commenting

### DIFF
--- a/docs/source/release/v6.3.0/mantidworkbench.rst
+++ b/docs/source/release/v6.3.0/mantidworkbench.rst
@@ -42,6 +42,6 @@ Bugfixes
 - Workbench will no longer hang if an algorithm was running when workbench was closed.
 - Stopped workbench from ignoring GUIs that want to cancel closing
 - Fixed a bug in the editor where uncommenting using 'ctrl+/' wasn't working correctly for lines of the form '<optional whitespace>#code_here # inline comment'.
-- Commenting code int he editor using 'ctrl+/' will preserve indenting (i.e. `# ` will be inserted at the position of the first non-whitespace character in the line).
+- Commenting code in the editor using 'ctrl+/' will preserve indenting (i.e. `# ` will be inserted at the position of the first non-whitespace character in the line).
 
 :ref:`Release 6.3.0 <v6.3.0>`

--- a/docs/source/release/v6.3.0/mantidworkbench.rst
+++ b/docs/source/release/v6.3.0/mantidworkbench.rst
@@ -42,5 +42,6 @@ Bugfixes
 - Workbench will no longer hang if an algorithm was running when workbench was closed.
 - Stopped workbench from ignoring GUIs that want to cancel closing
 - Fixed a bug in the editor where uncommenting using 'ctrl+/' wasn't working correctly for lines of the form '<optional whitespace>#code_here # inline comment'.
+- Commenting code int he editor using 'ctrl+/' will preserve indenting (i.e. `# ` will be inserted at the position of the first non-whitespace character in the line).
 
 :ref:`Release 6.3.0 <v6.3.0>`

--- a/qt/python/mantidqt/mantidqt/widgets/codeeditor/codecommenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/codeeditor/codecommenter.py
@@ -63,7 +63,12 @@ class CodeCommenter:
 
     def _comment_lines(self, lines):
         for i in range(len(lines)):
-            lines[i] = '# ' + lines[i]
+            str_match = re.match(r"\s+", lines[i])
+            if str_match:
+                i_non_space = str_match.end()
+                lines[i] = lines[i][:i_non_space] + '# ' + lines[i][i_non_space:]
+            else:
+                lines[i] = '# ' + lines[i]
         return lines
 
     def _uncomment_lines(self, lines):

--- a/qt/python/mantidqt/mantidqt/widgets/codeeditor/codecommenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/codeeditor/codecommenter.py
@@ -62,13 +62,10 @@ class CodeCommenter:
         return True
 
     def _comment_lines(self, lines):
+        # find least indented code in selection
+        istart = min(re.match(r"\s*", line).end() for line in lines)  # use of * means will return 0 if no leading \s
         for i in range(len(lines)):
-            str_match = re.match(r"\s+", lines[i])
-            if str_match:
-                i_non_space = str_match.end()
-                lines[i] = lines[i][:i_non_space] + '# ' + lines[i][i_non_space:]
-            else:
-                lines[i] = '# ' + lines[i]
+            lines[i] = lines[i][:istart] + '# ' + lines[i][istart:]
         return lines
 
     def _uncomment_lines(self, lines):

--- a/qt/python/mantidqt/mantidqt/widgets/codeeditor/test/test_codecommenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/codeeditor/test/test_codecommenter.py
@@ -90,14 +90,21 @@ class CodeCommenterTest(unittest.TestCase):
             '# ' + line for line in expected_lines[start_line:end_line + 1]]
         self.assertEqual(self.editor.text(), '\n'.join(expected_lines))
 
-    def test_multiline_comment_preserves_indenting(self):
+    def test_multiline_comment_uses_top_level_indentation(self):
         start_line, end_line = 10, 13
         self.editor.setSelection(start_line, 5, end_line, 5)
         self.commenter.toggle_comment()
         expected_lines = ["# for ii in range(2):",
-                          "   # do_something()",
+                          "#    do_something()",
                           "# do_something_else()"]
         self.assertEqual(self.editor.text().split('\n')[start_line:end_line], expected_lines)
+
+    def test_comment_preserves_indenting_on_single_line(self):
+        iline = 11
+        self.editor.setSelection(iline, 5, iline, 6)
+        self.commenter.toggle_comment()
+        # check commented at indented position
+        self.assertEqual(self.editor.text().split('\n')[iline], "   # do_something()")
 
 
 if __name__ == '__main__':

--- a/qt/python/mantidqt/mantidqt/widgets/codeeditor/test/test_codecommenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/codeeditor/test/test_codecommenter.py
@@ -31,7 +31,9 @@ class CodeCommenterTest(unittest.TestCase):
             "",
             "import numpy",
             "# import mantid",
-            "do_something()"]
+            "for ii in range(2):",
+            "   do_something()",
+            "do_something_else()"]
 
         self.editor = CodeEditor("AlternateCSPython", QFont())
         self.editor.setText('\n'.join(self.lines))
@@ -75,18 +77,27 @@ class CodeCommenterTest(unittest.TestCase):
         self.editor.setSelection(0, 2, 3, 2)
         self.commenter.toggle_comment()
         expected_lines = copy(self.lines)
-        expected_lines[start_line:end_line+1] = [
-            line.replace('# ', '') for line in expected_lines[0:end_line+1]]
+        expected_lines[start_line:end_line + 1] = [
+            line.replace('# ', '') for line in expected_lines[0:end_line + 1]]
         self.assertEqual(self.editor.text(), '\n'.join(expected_lines))
 
-    def test_multiline_comment(self):
+    def test_multiline_comment_for_mix_of_commented_and_uncommented_lines(self):
         start_line, end_line = 5, 8
         self.editor.setSelection(start_line, 5, end_line, 5)
         self.commenter.toggle_comment()
         expected_lines = copy(self.lines)
-        expected_lines[start_line:end_line+1] = [
-            '# ' + line for line in expected_lines[start_line:end_line+1]]
+        expected_lines[start_line:end_line + 1] = [
+            '# ' + line for line in expected_lines[start_line:end_line + 1]]
         self.assertEqual(self.editor.text(), '\n'.join(expected_lines))
+
+    def test_multiline_comment_preserves_indenting(self):
+        start_line, end_line = 10, 13
+        self.editor.setSelection(start_line, 5, end_line, 5)
+        self.commenter.toggle_comment()
+        expected_lines = ["# for ii in range(2):",
+                          "   # do_something()",
+                          "# do_something_else()"]
+        self.assertEqual(self.editor.text().split('\n')[start_line:end_line], expected_lines)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
**Description of work.**

Preserve indent when commenting with `ctrl-/` to give mantid same behaviour as PyCharm.


**To test:**
(1) Copy this into the script editor
```
for ii in range(2):
    print(ii)
print(10*ii)
```
(2) Comment lines with `ctrl-/` - it should produce this
```
# for ii in range(2):
    # print(ii)
# print(10*ii)
```
(3) Uncomment the lines and check the formatting is correct
(4) Play around with adding trailing whitespace etc.

Fixes #33069 

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
