### PR TITLE
Algorithm history uses load version for "Load"

### DIFF
--- a/Framework/API/src/ScriptBuilder.cpp
+++ b/Framework/API/src/ScriptBuilder.cpp
@@ -177,8 +177,8 @@ const std::string ScriptBuilder::buildAlgorithmString(const AlgorithmHistory &al
     Mantid::API::Algorithm_sptr algFresh;
     // create a fresh version of the algorithm - unmanaged
     if (name == "Load") {
-      algFresh =
-          AlgorithmManager::Instance().createUnmanaged(algHistory.getPropertyValue("LoaderName"), algHistory.version());
+      int version = atoi(algHistory.getPropertyValue("LoaderVersion").c_str());
+      algFresh = AlgorithmManager::Instance().createUnmanaged(algHistory.getPropertyValue("LoaderName"), version);
     } else {
       algFresh = AlgorithmManager::Instance().createUnmanaged(name, algHistory.version());
     }

--- a/Framework/API/src/ScriptBuilder.cpp
+++ b/Framework/API/src/ScriptBuilder.cpp
@@ -177,7 +177,7 @@ const std::string ScriptBuilder::buildAlgorithmString(const AlgorithmHistory &al
     Mantid::API::Algorithm_sptr algFresh;
     // create a fresh version of the algorithm - unmanaged
     if (name == "Load") {
-      int version = atoi(algHistory.getPropertyValue("LoaderVersion").c_str());
+      int version = std::stoi(algHistory.getPropertyValue("LoaderVersion").c_str());
       algFresh = AlgorithmManager::Instance().createUnmanaged(algHistory.getPropertyValue("LoaderName"), version);
     } else {
       algFresh = AlgorithmManager::Instance().createUnmanaged(name, algHistory.version());

--- a/Framework/API/src/ScriptBuilder.cpp
+++ b/Framework/API/src/ScriptBuilder.cpp
@@ -177,7 +177,7 @@ const std::string ScriptBuilder::buildAlgorithmString(const AlgorithmHistory &al
     Mantid::API::Algorithm_sptr algFresh;
     // create a fresh version of the algorithm - unmanaged
     if (name == "Load") {
-      int version = std::stoi(algHistory.getPropertyValue("LoaderVersion").c_str());
+      int version = std::stoi(algHistory.getPropertyValue("LoaderVersion"));
       algFresh = AlgorithmManager::Instance().createUnmanaged(algHistory.getPropertyValue("LoaderName"), version);
     } else {
       algFresh = AlgorithmManager::Instance().createUnmanaged(name, algHistory.version());

--- a/Framework/API/test/ScriptBuilderTest.h
+++ b/Framework/API/test/ScriptBuilderTest.h
@@ -579,6 +579,7 @@ public:
     alg->setRethrows(true);
     alg->setProperty("Filename", "IRS21360.raw");
     alg->setProperty("OutputWorkspace", "IRS21360");
+    alg->execute();
 
     auto ws = m_ads.retrieveWS<MatrixWorkspace>("IRS21360");
     auto wsHist = ws->getHistory();

--- a/Framework/API/test/ScriptBuilderTest.h
+++ b/Framework/API/test/ScriptBuilderTest.h
@@ -573,6 +573,26 @@ public:
     m_ads.remove("MUSR00022725");
   }
 
+  void test_Build_Load_Uses_Correct_version() {
+    auto alg = m_algFactory.create("Load", 1);
+    alg->initialize();
+    alg->setRethrows(true);
+    alg->setProperty("Filename", "IRS21360.raw");
+    alg->setProperty("OutputWorkspace", "IRS21360");
+
+    auto ws = m_ads.retrieveWS<MatrixWorkspace>("IRS21360");
+    auto wsHist = ws->getHistory();
+
+    ScriptBuilder builder(wsHist.createView());
+    std::string scriptText = builder.build();
+    const std::string input_string = "IRS21360.raw";
+    const std::string output_string = "IRS21360";
+    TS_ASSERT(scriptText.find(input_string) != std::string::npos);
+    TS_ASSERT(scriptText.find(output_string) != std::string::npos);
+
+    m_ads.remove("IRS21360");
+  }
+
 private:
   AlgorithmFactoryImpl &m_algFactory;
   AnalysisDataServiceImpl &m_ads;


### PR DESCRIPTION
**Description of work.**
After loading some data sets into Mantid and trying to generate a history (either by specifically asking for it or project recovery) an error message would appear in the log `Could not create a fresh version of Load version 1`. This was caused by the algorithm creation using the wrong version (it was the version of Load being called and not of the actual loader).
-->

**To test:**

<!-- Instructions for testing. -->
Open Mantid
Load `SXD23767`
Get the history - no warnings should appear in the log
Paste the history into a script
Clear the ADS
Run the script (to check it works)



Fixes #33076 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

This does not require release notes because its a bug that I added a couple of weeks ago.


<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
