### PR TITLE
keep tab when save_as

### DIFF
--- a/docs/source/release/v6.3.0/mantidworkbench.rst
+++ b/docs/source/release/v6.3.0/mantidworkbench.rst
@@ -18,9 +18,9 @@ New and Improved
 
 Bugfixes
 --------
+- Fixed an issue when save_as a running script leads to crash upon script completion.
 - Fixed arbitrary values not being accepted as the "Start Time" in StartLiveDataDialog.
 - Calls to :ref:`EvaluateFunction <algm-EvaluateFunction>` when plotting a guess or fit result in the fit browser of a figure correctly ignores invalid data when requested.
 - Fixed an issue to plot negative values with logarithm scaling in slice view.
-
 
 :ref:`Release 6.3.0 <v6.3.0>`

--- a/qt/python/mantidqt/mantidqt/widgets/codeeditor/multifileinterpreter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/codeeditor/multifileinterpreter.py
@@ -339,7 +339,6 @@ class MultiPythonFileInterpreter(QWidget):
         previous_filename = self.current_editor().filename
         saved, filename = self.current_editor().save_as()
         if saved:
-            self.current_editor().close()
             self.open_file_in_new_tab(filename)
             if previous_filename:
                 self.sig_file_name_changed.emit(previous_filename, filename)


### PR DESCRIPTION
- Original Gitlab defect: SCD435
- This is #33083  into `ornl-next`