### PR TITLE
Fix workbench crashing issue when save_as a running script (2nd try)

### DIFF
--- a/docs/source/release/v6.3.0/mantidworkbench.rst
+++ b/docs/source/release/v6.3.0/mantidworkbench.rst
@@ -28,6 +28,7 @@ New and Improved
 
 Bugfixes
 --------
+- Fixed an issue when save_as a running script leads to crash upon script completion.
 - Fixed arbitrary values not being accepted as the "Start Time" in StartLiveDataDialog.
 - Fixed a bug where the option "SignedInPlaneTwoTheta" in :ref:`ConvertSpectrumAxis <algm-ConvertSpectrumAxis-v2>` would not give signed results.
 - Fixed a bug where the toggle state of the "Grids on/off" toolbar button was incorrect when opening a 3D surface plot.
@@ -39,8 +40,11 @@ Bugfixes
 - Fixed a bug where the z-axis editor dialog was being initialised from the y-axis for a 3D plot.
 - Fixed a bug with autoscaling of colorfill plots from within the figure options.
 - Fixed an issue to plot negative values with logarithm scaling in slice view.
+<<<<<<< HEAD
 - Workbench will no longer hang if an algorithm was running when workbench was closed.
 - Stopped workbench from ignoring GUIs that want to cancel closing
 - Fixed a bug in the editor where uncommenting using 'ctrl+/' wasn't working correctly for lines of the form '<optional whitespace>#code_here # inline comment'.
+=======
+>>>>>>> 0489d2b9fa2 (update release doc)
 
 :ref:`Release 6.3.0 <v6.3.0>`

--- a/docs/source/release/v6.3.0/mantidworkbench.rst
+++ b/docs/source/release/v6.3.0/mantidworkbench.rst
@@ -40,11 +40,8 @@ Bugfixes
 - Fixed a bug where the z-axis editor dialog was being initialised from the y-axis for a 3D plot.
 - Fixed a bug with autoscaling of colorfill plots from within the figure options.
 - Fixed an issue to plot negative values with logarithm scaling in slice view.
-<<<<<<< HEAD
 - Workbench will no longer hang if an algorithm was running when workbench was closed.
 - Stopped workbench from ignoring GUIs that want to cancel closing
 - Fixed a bug in the editor where uncommenting using 'ctrl+/' wasn't working correctly for lines of the form '<optional whitespace>#code_here # inline comment'.
-=======
->>>>>>> 0489d2b9fa2 (update release doc)
 
 :ref:`Release 6.3.0 <v6.3.0>`

--- a/qt/python/mantidqt/mantidqt/widgets/codeeditor/multifileinterpreter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/codeeditor/multifileinterpreter.py
@@ -339,7 +339,6 @@ class MultiPythonFileInterpreter(QWidget):
         previous_filename = self.current_editor().filename
         saved, filename = self.current_editor().save_as()
         if saved:
-            self.current_editor().close()
             self.open_file_in_new_tab(filename)
             if previous_filename:
                 self.sig_file_name_changed.emit(previous_filename, filename)


### PR DESCRIPTION
**Description of work.**

- Original Gitlab defect: [SCD435](https://code.ornl.gov/sns-hfir-scse/diffraction/single-crystal/single-crystal-diffraction/-/issues/435)
- This is #33081 into `main`

This PR fixes an issue where the workbench crashes when `save_as` a running script.
The issue behind is that original `save_as` closes the current running tab, resulting in an error when child thread is trying to report the completion of the script running.
This PR removes the force close of the running tab.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**

- Run the following script in workbench script editor.
```python
from time import sleep

sleep(60)
```
- Save it if it is not saved already
- While the script is running, use the `save_as` to save a copy of the script
- Instead of losing the current running tab, you should see a new tab created for the copy.

<!-- Instructions for testing. -->

<!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
