### PR TITLE
fix muon plot offset bug

### DIFF
--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/contexts/plot_settings_context.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/contexts/plot_settings_context.py
@@ -21,7 +21,6 @@ class PlotSettingsContext(object):
         self._wrap_width = 30# determines the width of text on axis ticks
         self._font_size = "xx-small"
         self._rotation = 45 # degrees
-        self._sci_notation = False
 
     def set_condensed(self, state):
         self._is_condensed = state
@@ -69,10 +68,6 @@ class PlotSettingsContext(object):
     def x_axis_margin(self):
         # stored as a percentage, but return decimal
         return self._x_axis_margin/100.
-
-    @property
-    def sci_notation(self):
-        return self._sci_notation
 
     def set_linestyle(self, name, linestyle):
         self._linestyle[name] = linestyle

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/plot_widget/plotting_canvas/plotting_canvas_view.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/plot_widget/plotting_canvas/plotting_canvas_view.py
@@ -23,7 +23,7 @@ from matplotlib.figure import Figure
 import matplotlib.pyplot as plt
 import numpy as np
 from textwrap import wrap
-
+from matplotlib.ticker import StrMethodFormatter, NullFormatter
 from mantidqt.MPLwidgets import FigureCanvas
 
 # Default color cycle using Matplotlib color codes C0, C1...ect
@@ -210,7 +210,10 @@ class PlottingCanvasView(QtWidgets.QWidget, PlottingCanvasViewInterface):
     def _set_text_tick_labels(self, axis_number):
         ax = self.fig.axes[axis_number]
         # set the axes to not "simplify" the values
-        ax.ticklabel_format(useOffset=self._settings.sci_notation)
+        ax.xaxis.set_major_formatter(StrMethodFormatter('{x:.0f}'))
+        ax.xaxis.set_minor_formatter(NullFormatter())
+        ax.yaxis.set_major_formatter(StrMethodFormatter('{x:.0f}'))
+        ax.yaxis.set_minor_formatter(NullFormatter())
         if self._x_tick_labels:
             ax.set_xticks(range(len(self._x_tick_labels)))
             labels = self._wrap_labels(self._x_tick_labels)


### PR DESCRIPTION
We recently made a change to prevent the muon plots from using scientific notation. However, we did not test this for tiled plots and the old solution did not work https://github.com/mantidproject/mantid/pull/33006.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**

Open muon analysis
Load EMU20901-5
Go to fitting
Add a function
Go to sequential fitting
Fit to all
Go to the results tab
Tick run number
Generate the results table
Go to the model analysis tab
The x axis should now read "20901" etc. instead of having a +20900 at the end of the axis.
Put run number on the y axis and check it looks ok

Close muon analysis and clear the ADS
Open muon analysis 
Tick tiled plot
Load HIFI 84447
It shouldnt crash.

Fixes #33072. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
This does not require release notes* because  it is already covered. 


<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
