### PR TITLE
CppCheck nullptrs IPropertyManager from DevWS

### DIFF
--- a/Framework/Kernel/inc/MantidKernel/IPropertyManager.h
+++ b/Framework/Kernel/inc/MantidKernel/IPropertyManager.h
@@ -130,11 +130,14 @@ public:
    * inout
    *  @throw Exception::ExistsError if a property with the given name already
    * exists
-   *  @throw std::invalid_argument  if the name argument is empty
+   *  @throw std::invalid_argument if the name argument is empty
+   *  @throw std::invalid_argument if value is a nullptr
    */
   void declareProperty(const std::string &name, const char *value,
                        IValidator_sptr validator = std::make_shared<NullValidator>(),
                        const std::string &doc = std::string(), const unsigned int direction = Direction::Input) {
+    if (value == nullptr)
+      throw std::invalid_argument("Attempted to set " + name + " to nullptr");
     // Simply call templated method, converting character array to a string
     declareProperty(name, std::string(value), std::move(validator), doc, direction);
   }
@@ -150,15 +153,20 @@ public:
    *  @param doc :: The (optional) documentation string
    *  @param validator :: Pointer to the (optional) validator. Ownership will be
    * taken over.
+   *
+   *
    *  @param direction :: The (optional) direction of the property, in, out or
    * inout
    *  @throw Exception::ExistsError if a property with the given name already
    * exists
-   *  @throw std::invalid_argument  if the name argument is empty
+   *  @throw std::invalid_argument if the name argument is empty
+   *  @throw std::invalid_argument if value is a nullptr
    */
   void declareProperty(const std::string &name, const char *value, const std::string &doc,
                        IValidator_sptr validator = std::make_shared<NullValidator>(),
                        const unsigned int direction = Direction::Input) {
+    if (value == nullptr)
+      throw std::invalid_argument("Attempted to set " + name + " to nullptr");
     // Simply call templated method, converting character array to a string
     declareProperty(name, std::string(value), std::move(validator), doc, direction);
   }
@@ -278,11 +286,13 @@ public:
    *  @param value :: The value to assign to the property
    *  @throw Exception::NotFoundError If the named property is unknown
    *  @throw std::invalid_argument If an attempt is made to assign to a property
+   *  @throw std::invalid_argument If value is a nullptr
    * of different type
    */
   IPropertyManager *setProperty(const std::string &name, const char *value) {
-    this->setPropertyValue(name, std::string(value));
-    return this;
+    if (value == nullptr)
+      throw std::invalid_argument("Attempted to set " + name + " to nullptr");
+    return setProperty(name, std::string(value));
   }
 
   /** Specialised version of setProperty template method to handle std::string

--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -919,6 +919,3 @@ unreadVariable:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/Indirect/IndirectPlo
 useStlAlgorithm:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/Indirect/IndirectDataValidationHelper.cpp:33
 unreadVariable:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/Indirect/IndirectSymmetrise.cpp:173
 unreadVariable:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/Indirect/Stretch.cpp:220
-ctunullpointer:${CMAKE_SOURCE_DIR}/Framework/Kernel/inc/MantidKernel/IPropertyManager.h:139
-ctunullpointer:${CMAKE_SOURCE_DIR}/Framework/Kernel/inc/MantidKernel/IPropertyManager.h:163
-ctunullpointer:${CMAKE_SOURCE_DIR}/Framework/Kernel/inc/MantidKernel/IPropertyManager.h:284


### PR DESCRIPTION
split off from #33103

**Description of work.**
- A small commit to handle nullptrs in IPropertyManager found in the developer workshop

**To test:**

Check cppcheck passes and code review!

<!-- alternative
*There is no associated issue.*
-->

No release notes as this is an internal change

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
