### PR TITLE
Save Indirect contour ws in Bayes Stretch

### DIFF
--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -918,4 +918,3 @@ stlFindInsert:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/Indirect/IndirectPlot
 unreadVariable:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/Indirect/IndirectPlotOptionsView.cpp:113
 useStlAlgorithm:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/Indirect/IndirectDataValidationHelper.cpp:33
 unreadVariable:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/Indirect/IndirectSymmetrise.cpp:173
-unreadVariable:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/Indirect/Stretch.cpp:220

--- a/docs/source/release/v6.3.0/indirect_geometry.rst
+++ b/docs/source/release/v6.3.0/indirect_geometry.rst
@@ -38,7 +38,7 @@ Bugfixes
 
 - Fixed a bug which prevented workspaces being loaded into Elwin.
 - Fixed a bug which caused VesuvioAnalysis to crash when run with a single element.
-
+- Contour workspaces are now saved when saving in Bayes stretch.
 - The Abins algorithm can also import force constants data from CASTEP
   or Phonopy calculations, using the Euphonic library. (See above.)
 

--- a/qt/scientific_interfaces/Indirect/Stretch.cpp
+++ b/qt/scientific_interfaces/Indirect/Stretch.cpp
@@ -214,12 +214,13 @@ void Stretch::saveWorkspaces() {
   IndirectTab::checkADSForPlotSaveWorkspace(m_fitWorkspaceName, false);
   IndirectTab::checkADSForPlotSaveWorkspace(m_contourWorkspaceName, false);
 
-  auto saveDir = QString::fromStdString(Mantid::Kernel::ConfigService::Instance().getString("defaultsave.directory"));
+  const auto saveDir =
+      QString::fromStdString(Mantid::Kernel::ConfigService::Instance().getString("defaultsave.directory"));
   // Check validity of save path
-  const auto fitFullPath = saveDir.append(fitWorkspace).append(".nxs");
-  const auto contourFullPath = saveDir.append(contourWorkspace).append(".nxs");
+  const auto fitFullPath = saveDir + fitWorkspace + QString::fromStdString(".nxs");
+  const auto contourFullPath = saveDir + contourWorkspace + QString::fromStdString(".nxs");
   addSaveWorkspaceToQueue(fitWorkspace, fitFullPath);
-  addSaveWorkspaceToQueue(contourWorkspace, fitFullPath);
+  addSaveWorkspaceToQueue(contourWorkspace, contourFullPath);
   m_batchAlgoRunner->executeBatchAsync();
 }
 


### PR DESCRIPTION
Co-authored-by: Conor Finn <ConorMFinn@users.noreply.github.com>
Co-authored-by: Rob Applin <robertapplin@users.noreply.github.com>
Co-authored-by: thomashampson <thomashampson@users.noreply.github.com>

**Description of work.**
- Found as a problem in CppCheck in developer workshop
- The fit file that was saved was being overwritten by the contour file, when they should be saved separately!
-split out from PR: #33097

**To test:**

- Open Indirect Bayes interface. 
- In the stretch tab load a sample and resolution file. (See #26631 for some test data (a res and red file))
- Set up your save directory in ManageUserDirectories
- Click `Run` and output workspaces should appear in the Workspaces Toolbox
- Click Save Result to save these Fit and Contour workspaces to your save directory. Currently only a file named with the word Fit is output, but with this fix another file with the name Contour should also be output!

<!-- alternative
*There is no associated issue.*
-->


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
