### PR TITLE
Cppcheck - Ignore build dir in invocation

### DIFF
--- a/Framework/Kernel/inc/MantidKernel/Strings.h
+++ b/Framework/Kernel/inc/MantidKernel/Strings.h
@@ -359,13 +359,11 @@ template <typename Integer> std::vector<std::vector<Integer>> parseGroups(const 
   auto translateAdd = [&groups](const std::string &str) {
     const auto tokens = Kernel::StringTokenizer(
         str, "+", Kernel::StringTokenizer::TOK_TRIM | Kernel::StringTokenizer::TOK_IGNORE_EMPTY);
-    std::vector<Integer> group;
-    group.reserve(tokens.count());
-    for (const auto &t : tokens) {
-      // add this number to the group we're about to add
-      group.emplace_back(boost::lexical_cast<Integer>(t));
-    }
-    groups.emplace_back(std::move(group));
+    std::vector<Integer> currentGroup;
+    currentGroup.reserve(tokens.count());
+    std::transform(tokens.cbegin(), tokens.cend(), std::back_inserter(currentGroup),
+                   [](const auto &t) { return boost::lexical_cast<Integer>(t); });
+    groups.emplace_back(std::move(currentGroup));
   };
 
   auto translateSumRange = [&groups](const std::string &str) {

--- a/buildconfig/CMake/CppCheckSetup.cmake
+++ b/buildconfig/CMake/CppCheckSetup.cmake
@@ -19,7 +19,8 @@ if(CPPCHECK_EXECUTABLE)
       --std=c++${CMAKE_CXX_STANDARD} # use the standard from cmake
       --cppcheck-build-dir="${CPPCHECK_BUILD_DIR}/cache"
       --suppressions-list="${CPPCHECK_BUILD_DIR}/CppCheck_Suppressions.txt"
-      --project=${CMAKE_BINARY_DIR}/compile_commands.json
+      --project="${CMAKE_BINARY_DIR}/compile_commands.json"
+      -i"${CMAKE_BINARY_DIR}"
       # Force cppcheck to check when we use project-wide macros
       -DDLLExport=
       -DMANTID_ALGORITHMS_DLL=

--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -67,7 +67,6 @@ noCopyConstructor:${CMAKE_SOURCE_DIR}/Framework/Geometry/inc/MantidGeometry/Rend
 // ----------- New list of supressions after updating to cppcheck 2.5 -------------
 // - If the line number changes then update it here, or resolve the defect and remove from list
 
-useStlAlgorithm:${CMAKE_SOURCE_DIR}/Framework/Kernel/inc/MantidKernel/Strings.h:366
 useStlAlgorithm:${CMAKE_SOURCE_DIR}/Framework/Kernel/inc/MantidKernel/CompositeValidator.h:57
 useInitializationList:${CMAKE_SOURCE_DIR}/Framework/Kernel/src/ComputeResourceInfo.cpp:37
 nullPointerRedundantCheck:${CMAKE_SOURCE_DIR}/Framework/Kernel/src/ComputeResourceInfo.cpp:37


### PR DESCRIPTION
**Description of work.**
Ignore build dir in cppcheck invocation

This should stop cppcheck completely checking the dir.
Currently it checks the files, then matches the suppression and discards
the result

**To test:**
- Check cppcheck job runs

Noticed in #33028 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
