### PR TITLE
Remove instructions for cmake-format

### DIFF
--- a/dev-docs/source/ToolsOverview.rst
+++ b/dev-docs/source/ToolsOverview.rst
@@ -256,33 +256,3 @@ To add optional arguments, add the following onto the end of ``CLANG_TIDY_CHECKS
 For example, to convert all loops classified as *risky* or above, we would append::
 
     ;-config={CheckOptions: [ {key: modernize-loop-convert.MinConfidence, value: risky} ]}
-
-CMake-format
----------------------
-
-`CMake-format <https://github.com/cheshirekow/cmake_format/>`__ is a tool which is used to format individual ``CMakeLists.txt`` to make them easier to read.
-The package can be installed using ``pip install cmake_format`` or ``sudo pip install cmake_format``.
-
-To use cmake-format on a specific ``CMakeLists.txt`` file in the command line run
-
-.. code::
-
-	python -m cmake_format -c /path/to/mantid/.cmake-format.json -i /path/to/CMakeLists.txt
-
-This will format the file using the config file ``.cmake-format.json`` which can be found in the root of the mantid directory.
-
-There is an official Visual Studio extension, details of which can be found `here <https://marketplace.visualstudio.com/items?itemName=cheshirekow.cmake-format>`__.
-
-To format on all the CMakeLists run the following from within the mantid source folder:
-
-.. code::
-
-	import os
-
-	dir = os.getcwd()
-	for path, subdirs, files in os.walk(dir):
-		for file in files:
-			if file.endswith("CMakeLists.txt"):
-				cmakefile = os.path.join(path, file)
-				print("Formatting " + cmakefile)
-				os.system('python -m cmake_format -c ' + os.path.join(dir, '.cmake-format.json') +' -i ' + cmakefile)


### PR DESCRIPTION
This is now done automatically in pre-commit

**To test:**

Reviewing source code is enough

*There is no associated issue.*

*This does not require release notes* because it is a minor change to the developer site

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
