### PR TITLE
added fit wizard to muon feature flags

### DIFF
--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/features/add_fitting.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/features/add_fitting.py
@@ -1,6 +1,6 @@
 # Mantid Repository : https://github.com/mantidproject/mantid
 #
-# Copyright &copy; 2018 ISIS Rutherford Appleton Laboratory UKRI,
+# Copyright &copy; 2021 ISIS Rutherford Appleton Laboratory UKRI,
 #   NScD Oak Ridge National Laboratory, European Spallation Source,
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/features/add_fitting.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/features/add_fitting.py
@@ -1,0 +1,30 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2018 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+from mantidqtinterfaces.Muon.GUI.Common.features.add_feature import AddFeature
+
+
+FITWIZARD = "fit_wizard"
+ADD = 1
+
+
+class AddFitting(AddFeature):
+    """
+    Add model analysis to the GUI
+    """
+
+    def __init__(self, GUI, feature_dict):
+        super().__init__(GUI, feature_dict)
+
+    def _get_features(self, feature_dict):
+        features = []
+        if FITWIZARD in feature_dict.keys() and feature_dict[FITWIZARD]==ADD:
+            features.append(ADD)
+        return features
+
+    def _add_features(self, GUI):
+        if ADD in self.feature_list:
+            GUI.fitting_tab.show_fit_script_generator()

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/fitting_tab_widget/fitting_tab_widget.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/fitting_tab_widget/fitting_tab_widget.py
@@ -36,3 +36,6 @@ class FittingTabWidget(object):
 
         context.update_view_from_model_notifier.add_subscriber(
             self.fitting_tab_presenter.update_view_from_model_observer)
+
+    def show_fit_script_generator(self)->None:
+        self.fitting_tab_view.show_fit_script_generator()

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/fitting_tab_widget/fitting_tab_widget.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/fitting_tab_widget/fitting_tab_widget.py
@@ -38,4 +38,7 @@ class FittingTabWidget(object):
             self.fitting_tab_presenter.update_view_from_model_observer)
 
     def show_fit_script_generator(self)->None:
+        """
+        Show the fit script generator in the fitting interface
+        """
         self.fitting_tab_view.show_fit_script_generator()

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/fitting_widgets/basic_fitting/basic_fitting_view.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/fitting_widgets/basic_fitting/basic_fitting_view.py
@@ -324,4 +324,7 @@ class BasicFittingView(ui_form, base_widget):
         self.setEnabled(self.workspace_selector.number_of_datasets() != 0)
 
     def show_fit_script_generator(self) ->None:
+        """
+        Show the fit script generator in the fitting interface
+        """
         self.fit_controls.show_fit_script_generator()

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/fitting_widgets/basic_fitting/basic_fitting_view.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/fitting_widgets/basic_fitting/basic_fitting_view.py
@@ -322,3 +322,6 @@ class BasicFittingView(ui_form, base_widget):
     def enable_view(self) -> None:
         """Enable all widgets in this fitting widget."""
         self.setEnabled(self.workspace_selector.number_of_datasets() != 0)
+
+    def show_fit_script_generator(self) ->None:
+        self.fit_controls.show_fit_script_generator()

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/fitting_widgets/basic_fitting/fit_controls_view.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/fitting_widgets/basic_fitting/fit_controls_view.py
@@ -25,7 +25,7 @@ class FitControlsView(ui_form, base_widget):
         # Comment out this line to show the 'Fit Generator' button
         self.fit_generator_button.hide()
 
-    def show_fit_script_generator(self):
+    def show_fit_script_generator(self) -> None:
         self.fit_generator_button.show()
 
     def set_slot_for_fit_generator_clicked(self, slot) -> None:

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/fitting_widgets/basic_fitting/fit_controls_view.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/fitting_widgets/basic_fitting/fit_controls_view.py
@@ -26,6 +26,9 @@ class FitControlsView(ui_form, base_widget):
         self.fit_generator_button.hide()
 
     def show_fit_script_generator(self) -> None:
+        """
+        Show the fit script generator in the fitting interface
+        """
         self.fit_generator_button.show()
 
     def set_slot_for_fit_generator_clicked(self, slot) -> None:

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/fitting_widgets/basic_fitting/fit_controls_view.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/fitting_widgets/basic_fitting/fit_controls_view.py
@@ -25,6 +25,9 @@ class FitControlsView(ui_form, base_widget):
         # Comment out this line to show the 'Fit Generator' button
         self.fit_generator_button.hide()
 
+    def show_fit_script_generator(self):
+        self.fit_generator_button.show()
+
     def set_slot_for_fit_generator_clicked(self, slot) -> None:
         """Connect the slot for the Fit Generator button."""
         self.fit_generator_button.clicked.connect(slot)

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/FrequencyDomainAnalysis/frequency_domain_analysis.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/FrequencyDomainAnalysis/frequency_domain_analysis.py
@@ -42,6 +42,7 @@ from mantidqtinterfaces.Muon.GUI.Common.plotting_dock_widget.plotting_dock_widge
 from mantidqt.utils.observer_pattern import GenericObserver, GenericObserverWithArgPassing, GenericObservable
 from mantidqtinterfaces.Muon.GUI.Common.features.model_analysis import AddModelAnalysis
 from mantidqtinterfaces.Muon.GUI.Common.features.raw_plots import AddRawPlots
+from mantidqtinterfaces.Muon.GUI.Common.features.add_fitting import AddFitting
 from mantidqtinterfaces.Muon.GUI.Common.features.load_features import load_features
 
 from mantidqtinterfaces.Muon.GUI.Common.features.add_grouping_workspaces import AddGroupingWorkspaces
@@ -139,6 +140,8 @@ class FrequencyAnalysisGui(QtWidgets.QMainWindow):
 
         self.add_model_analysis = AddModelAnalysis(self, feature_dict)
         self.add_raw_plots = AddRawPlots(self, feature_dict)
+        self.add_fitting = AddFitting(self, feature_dict)
+
         setup_group_ws = AddGroupingWorkspaces(self, feature_dict)
 
         self.setup_tabs()

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/MuonAnalysis/muon_analysis_2.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/MuonAnalysis/muon_analysis_2.py
@@ -37,6 +37,7 @@ from mantidqt.utils.observer_pattern import GenericObserver, GenericObservable
 from mantidqtinterfaces.Muon.GUI.Common.features.model_analysis import AddModelAnalysis
 from mantidqtinterfaces.Muon.GUI.Common.features.raw_plots import AddRawPlots
 from mantidqtinterfaces.Muon.GUI.Common.features.add_grouping_workspaces import AddGroupingWorkspaces
+from mantidqtinterfaces.Muon.GUI.Common.features.add_fitting import AddFitting
 from mantidqtinterfaces.Muon.GUI.Common.features.load_features import load_features
 
 
@@ -131,6 +132,7 @@ class MuonAnalysisGui(QtWidgets.QMainWindow):
 
         self.add_model_analysis = AddModelAnalysis(self, feature_dict)
         self.add_raw_plots = AddRawPlots(self, feature_dict)
+        self.add_fitting = AddFitting(self, feature_dict)
         setup_group_ws = AddGroupingWorkspaces(self, feature_dict)
 
         self.setup_tabs()

--- a/qt/python/mantidqtinterfaces/test/Muon/CMakeLists.txt
+++ b/qt/python/mantidqtinterfaces/test/Muon/CMakeLists.txt
@@ -49,6 +49,7 @@ set(TEST_PY_FILES
     elemental_analysis_2/EA_auto_tab/ea_auto_tab_presenter_test.py
     elemental_analysis_2/EA_auto_tab/ea_match_table_presenter_test.py
     external_plotting_model_test.py
+    feature_flags/add_fitting_test.py
     feature_flags/add_grouping_workspaces_test.py
     feature_flags/add_model_analysis_test.py
     feature_flags/add_raw_plots_test.py

--- a/qt/python/mantidqtinterfaces/test/Muon/feature_flags/add_fitting_test.py
+++ b/qt/python/mantidqtinterfaces/test/Muon/feature_flags/add_fitting_test.py
@@ -1,0 +1,31 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2021 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+import unittest
+from unittest import mock
+from mantidqtinterfaces.Muon.GUI.Common.features.add_fitting import AddFitting
+from mantidqtinterfaces.Muon.GUI.Common.fitting_tab_widget.fitting_tab_widget import FittingTabWidget
+
+
+class AddFittingTest(unittest.TestCase):
+
+    def setUp(self):
+        self.GUI = mock.Mock()
+        self.GUI.fitting_tab = mock.MagicMock(autospec=FittingTabWidget)
+
+    def test_get_features_success(self):
+        test = {"fit_wizard":1}
+        AddFitting(self.GUI, test)
+        self.GUI.fitting_tab.show_fit_script_generator.assert_called_once_with()
+
+    def test_get_features_fail(self):
+        test = {"fit_wizard":0}
+        AddFitting(self.GUI, test)
+        self.GUI.fitting_tab.show_fit_script_generator.assert_not_called()
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
**Description of work.**

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**

<!-- Instructions for testing. -->
Open muon analysis
Load some data
Go to the fitting tab
There will not be an button called "fit scrip generator"
Close mantid

Open mantid.user.properties
Make sure you have `muon.GUI = fit_wizard:1`
Open muon analysis
Load some data
Go to the fitting tab
There will be an button called "fit scrip generator"
Check that it works


*There is no associated issue.*

This is not in the release notes as its not fully exposed to users.

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
