### PR TITLE
Increase memory requirement of WAND Q conversion tests

### DIFF
--- a/Testing/SystemTests/tests/framework/ConvertWANDSCDtoQTest.py
+++ b/Testing/SystemTests/tests/framework/ConvertWANDSCDtoQTest.py
@@ -11,7 +11,7 @@ from mantid.simpleapi import *
 
 class ConvertWANDSCDtoQTest(systemtesting.MantidSystemTest):
     def requiredMemoryMB(self):
-        return 8000
+        return 9500
 
     def runTest(self):
         LoadMD('HB2C_WANDSCD_data.nxs', OutputWorkspace='ConvertWANDSCDtoQTest_data')
@@ -69,7 +69,7 @@ class ConvertWANDSCDtoQTest(systemtesting.MantidSystemTest):
 
 class ConvertWANDSCDtoQ_HB3A_Test(systemtesting.MantidSystemTest):
     def requiredMemoryMB(self):
-        return 8000
+        return 9500
 
     def runTest(self):
         LoadMD('HB3A_data.nxs', OutputWorkspace='ConvertWANDSCDtoQ_HB3ATest_data')
@@ -120,7 +120,7 @@ class ConvertWANDSCDtoQ_HB3A_Test(systemtesting.MantidSystemTest):
 
 class ConvertWANDSCDtoQ_Rotate_Test(systemtesting.MantidSystemTest):
     def requiredMemoryMB(self):
-        return 8000
+        return 9500
 
     def runTest(self):
         angleOffset = 45


### PR DESCRIPTION
**Description of work.**

The time command gave a peak usage of 9.5GiB wile running the test

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**

- Run the system test `ConvertWANDSCDtoQTest` and check it passes

*There is no associated issue.*

*This does not require release notes* because **it fixes an internal issue.**

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
