### PR TITLE
ensure monospace fonts in python editor and ipython

### DIFF
--- a/docs/source/release/v6.3.0/mantidworkbench.rst
+++ b/docs/source/release/v6.3.0/mantidworkbench.rst
@@ -26,6 +26,8 @@ New and Improved
 
 - The browse dialog in the file finder widget now opens at the path specified in the widget's edit box (if the edit box contains a full path)
 
+- The font in python editor and IPython console are ensured to be monospace on KDE Neon distribution, too.
+
 Bugfixes
 --------
 - Fixed an issue when save_as a running script leads to crash upon script completion.

--- a/qt/applications/workbench/workbench/app/mainwindow.py
+++ b/qt/applications/workbench/workbench/app/mainwindow.py
@@ -738,6 +738,9 @@ class MainWindow(QMainWindow):
             font = QFontDatabase().font(font_string[0], font_string[-1], int(font_string[1]))
             qapp.setFont(font)
 
+        # reset font for ipython console to ensure it stays monospace
+        self.ipythonconsole.console.reset_font()
+
         # make sure main window is smaller than the desktop
         desktop = QDesktopWidget()
 

--- a/qt/applications/workbench/workbench/config/fonts.py
+++ b/qt/applications/workbench/workbench/config/fonts.py
@@ -24,7 +24,7 @@ def is_ubuntu() -> bool:
     if sys.platform.startswith('linux') and osp.isfile('/etc/lsb-release'):
         with open('/etc/lsb-release') as handle:
             release_info = handle.read()
-            return bool('Ubuntu' in release_info)
+            return bool('Ubuntu' in release_info or 'neon' in release_info)
     else:
         return False
 


### PR DESCRIPTION
**Description of work.**
Currently, the font chosen for the application is set also on IPython console, which is not good.
This makes sure that the IPython console font stays monospace no matter the user chosen font for the application.
Also ensures monospace font in python editor on KDE neon linux.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**
1. Start workbench, navigate to mantid general settings, pick a main font, such as Comic Sans.
2. Restart workbench, make sure that while the labels on all the widgets are now in that font, the python editor and ipython console are still monospace.

<!-- Instructions for testing. -->


<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
