### PR TITLE
Set bin errors in CreateSimulationWorkspace

### DIFF
--- a/Framework/DataHandling/src/CreateSimulationWorkspace.cpp
+++ b/Framework/DataHandling/src/CreateSimulationWorkspace.cpp
@@ -118,7 +118,7 @@ void CreateSimulationWorkspace::init() {
       "An optional filename (currently RAW or ISIS NeXus) that "
       "contains UDET & SPEC tables to access hardware grouping");
 
-  declareProperty("SetErrors", true, "Whether to set histogram bin errors to sqrt of intensity.");
+  declareProperty("SetErrors", false, "Whether to set histogram bin errors to sqrt of intensity.");
 }
 
 //----------------------------------------------------------------------------------------------

--- a/Framework/DataHandling/src/CreateSimulationWorkspace.cpp
+++ b/Framework/DataHandling/src/CreateSimulationWorkspace.cpp
@@ -117,6 +117,8 @@ void CreateSimulationWorkspace::init() {
       std::make_unique<FileProperty>("DetectorTableFilename", "", FileProperty::OptionalLoad, "", Direction::Input),
       "An optional filename (currently RAW or ISIS NeXus) that "
       "contains UDET & SPEC tables to access hardware grouping");
+
+  declareProperty("SetErrors", true, "Whether to set histogram bin errors to sqrt of intensity.");
 }
 
 //----------------------------------------------------------------------------------------------
@@ -167,6 +169,7 @@ void CreateSimulationWorkspace::createOutputWorkspace() {
   const auto binBoundaries = createBinBoundaries();
   const size_t xlength = binBoundaries.size();
   const size_t ylength = xlength - 1;
+  const bool setError = getProperty("SetErrors");
 
   m_outputWS = WorkspaceFactory::Instance().create("Workspace2D", nhistograms, xlength, ylength);
   m_outputWS->setInstrument(m_instrument);
@@ -181,6 +184,9 @@ void CreateSimulationWorkspace::createOutputWorkspace() {
   for (int64_t i = 0; i < static_cast<int64_t>(nhistograms); ++i) {
     m_outputWS->setBinEdges(i, binBoundaries);
     m_outputWS->mutableY(i) = 1.0;
+    if (setError) {
+      m_outputWS->mutableE(i).assign(m_outputWS->getNumberBins(i), sqrt(1.0));
+    }
 
     m_progress->report("Setting X values");
   }

--- a/Framework/DataHandling/test/CreateSimulationWorkspaceTest.h
+++ b/Framework/DataHandling/test/CreateSimulationWorkspaceTest.h
@@ -151,9 +151,25 @@ public:
     TS_ASSERT_EQUALS(outputWS->getAxis(0)->unit()->unitID(), unitx);
   }
 
+  void test_Bin_Errors() {
+    auto outputWS = runAlgorithm("HET");
+
+    const Mantid::MantidVec &bins = outputWS->readE(0);
+    for (size_t i = 0; i < bins.size(); ++i) {
+      TS_ASSERT_DELTA(bins[i], sqrt(outputWS->readY(0)[i]), 1e-10);
+    }
+
+    // Re-run to verify errors are 0 when flag is unset
+    outputWS = runAlgorithm("HET", "", "", false);
+    const Mantid::MantidVec &binsNoErr = outputWS->readE(0);
+    for (size_t i = 0; i < binsNoErr.size(); ++i) {
+      TS_ASSERT_DELTA(binsNoErr[i], 0.0, 1e-10);
+    }
+  }
+
 private:
   Mantid::API::MatrixWorkspace_sptr runAlgorithm(const std::string &inst, const std::string &unitx = "",
-                                                 const std::string &maptable = "") {
+                                                 const std::string &maptable = "", bool setErrors = true) {
     using namespace Mantid::API;
     auto alg = createAlgorithm(m_wsName);
 
@@ -163,6 +179,7 @@ private:
       TS_ASSERT_THROWS_NOTHING(alg->setPropertyValue("UnitX", unitx));
     if (!maptable.empty())
       TS_ASSERT_THROWS_NOTHING(alg->setPropertyValue("DetectorTableFilename", maptable));
+    TS_ASSERT_THROWS_NOTHING(alg->setProperty("SetErrors", setErrors));
 
     TS_ASSERT_THROWS_NOTHING(alg->execute());
 

--- a/docs/source/release/v6.3.0/33147_Framework.rst
+++ b/docs/source/release/v6.3.0/33147_Framework.rst
@@ -1,0 +1,7 @@
+Algorithms
+----------
+
+Improvements
+############
+
+- Added option to :ref:`CreateSimulationWorkspace <algm-CreateSimulationWorkspace>` to set bin errors.

--- a/docs/source/release/v6.3.0/framework.rst
+++ b/docs/source/release/v6.3.0/framework.rst
@@ -30,7 +30,6 @@ Improvements
 - :ref:`Rebin <algm-Rebin>` now has an option for binning with reverse logarithmic and inverse power bins.
 - :ref:`SetSampleFromLogs <algm-SetSampleFromLogs>` will now fail if the resulting sample shape has a volume of 0.
 - :ref:`SetSample <algm-SetSample>` can now load sample environment XML files from any directory using ``SetSample(ws, Environment={'Name': 'NameOfXMLFile', 'Path':'/path/to/file/'})``.
-- Changed :ref:`CreateSimulationWorkspace <algm-CreateSimulationWorkspace>` to set bin errors and added option to leave them unset.
 - An importance sampling option has been added to :ref:`DiscusMultipleScatteringCorrection <algm-DiscusMultipleScatteringCorrection>` so that it handles spikes in the structure factor S(Q) better
 - Added parameter to :ref:`DiscusMultipleScatteringCorrection <algm-DiscusMultipleScatteringCorrection>` to control number of attempts to generate initial scatter point
 

--- a/docs/source/release/v6.3.0/framework.rst
+++ b/docs/source/release/v6.3.0/framework.rst
@@ -30,6 +30,7 @@ Improvements
 - :ref:`Rebin <algm-Rebin>` now has an option for binning with reverse logarithmic and inverse power bins.
 - :ref:`SetSampleFromLogs <algm-SetSampleFromLogs>` will now fail if the resulting sample shape has a volume of 0.
 - :ref:`SetSample <algm-SetSample>` can now load sample environment XML files from any directory using ``SetSample(ws, Environment={'Name': 'NameOfXMLFile', 'Path':'/path/to/file/'})``.
+- Changed :ref:`CreateSimulationWorkspace <algm-CreateSimulationWorkspace>` to set bin errors and added option to leave them unset.
 - An importance sampling option has been added to :ref:`DiscusMultipleScatteringCorrection <algm-DiscusMultipleScatteringCorrection>` so that it handles spikes in the structure factor S(Q) better
 - Added parameter to :ref:`DiscusMultipleScatteringCorrection <algm-DiscusMultipleScatteringCorrection>` to control number of attempts to generate initial scatter point
 


### PR DESCRIPTION
**Description of work.**

Sets the bin errors in `CreateSimulationWorkspace` to prevent an issue where workspace bin errors would be zero when used later in `IntegrateEllipsoids`. An option was added to `CreateSimulationWorkspace` to revert to the original behavior of having zero errors.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**

Unit tests for `CreateSimulationWorkspace` should pass.

<!-- Instructions for testing. -->


<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

Version into  `ornl-next`: #33148 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
