### PR TITLE
Fix scaling of waterfall plots on open

### DIFF
--- a/Framework/PythonInterface/mantid/plots/plotfunctions.py
+++ b/Framework/PythonInterface/mantid/plots/plotfunctions.py
@@ -206,16 +206,13 @@ def plot(workspaces, spectrum_nums=None, wksp_indices=None, errors=False,
         fig.canvas.set_window_title(figure_title(workspaces, fig.number))
     else:
         if ax.is_waterfall():
-            for i in range(len(nums)*len(workspaces)):
-                errorbar_cap_lines = datafunctions.remove_and_return_errorbar_cap_lines(ax)
-                datafunctions.convert_single_line_to_waterfall(ax, len(ax.get_lines()) - (i + 1))
+            _overplot_waterfall(ax,len(nums)*len(workspaces))
 
-                if ax.waterfall_has_fill():
-                    datafunctions.waterfall_update_fill(ax)
-
-                ax.lines += errorbar_cap_lines
-
-    if superplot and not waterfall and not tiled:
+    if ax.is_waterfall():
+        #If axes is waterfall, update axes limits following line offset.
+        ax.relim()
+        ax.autoscale()
+    elif superplot and not tiled:
         fig.canvas.manager.superplot_toggle()
         if not spectrum_nums and not wksp_indices:
             workspace_names = [ws.name() for ws in workspaces]
@@ -225,6 +222,17 @@ def plot(workspaces, spectrum_nums=None, wksp_indices=None, errors=False,
 
     # update and show figure
     return _update_show_figure(fig)
+
+
+def _overplot_waterfall(ax, no_of_lines):
+    for i in range(no_of_lines):
+        errorbar_cap_lines = datafunctions.remove_and_return_errorbar_cap_lines(ax)
+        datafunctions.convert_single_line_to_waterfall(ax, len(ax.get_lines()) - (i + 1))
+
+        if ax.waterfall_has_fill():
+            datafunctions.waterfall_update_fill(ax)
+
+        ax.lines += errorbar_cap_lines
 
 
 def _update_show_figure(fig):

--- a/Framework/PythonInterface/mantid/plots/plotfunctions.py
+++ b/Framework/PythonInterface/mantid/plots/plotfunctions.py
@@ -204,9 +204,8 @@ def plot(workspaces, spectrum_nums=None, wksp_indices=None, errors=False,
 
     if not overplot:
         fig.canvas.set_window_title(figure_title(workspaces, fig.number))
-    else:
-        if ax.is_waterfall():
-            _overplot_waterfall(ax,len(nums)*len(workspaces))
+    elif ax.is_waterfall():
+        _overplot_waterfall(ax,len(nums)*len(workspaces))
 
     if ax.is_waterfall():
         #If axes is waterfall, update axes limits following line offset.
@@ -225,7 +224,12 @@ def plot(workspaces, spectrum_nums=None, wksp_indices=None, errors=False,
 
 
 def _overplot_waterfall(ax, no_of_lines):
-    #If overplotting onto a waterfall axes, convert lines to overplot to waterfall.
+    """
+    If overplotting onto a waterfall axes, convert lines to waterfall (add x and y offset) before overplotting.
+
+    :param ax: object of MantidAxes type to overplot onto.
+    :param no_of_lines: number of lines to overplot onto input axes.
+    """
     for i in range(no_of_lines):
         errorbar_cap_lines = datafunctions.remove_and_return_errorbar_cap_lines(ax)
         datafunctions.convert_single_line_to_waterfall(ax, len(ax.get_lines()) - (i + 1))

--- a/Framework/PythonInterface/mantid/plots/plotfunctions.py
+++ b/Framework/PythonInterface/mantid/plots/plotfunctions.py
@@ -225,6 +225,7 @@ def plot(workspaces, spectrum_nums=None, wksp_indices=None, errors=False,
 
 
 def _overplot_waterfall(ax, no_of_lines):
+    #If overplotting onto a waterfall axes, convert lines to overplot to waterfall.
     for i in range(no_of_lines):
         errorbar_cap_lines = datafunctions.remove_and_return_errorbar_cap_lines(ax)
         datafunctions.convert_single_line_to_waterfall(ax, len(ax.get_lines()) - (i + 1))

--- a/docs/source/release/v6.3.0/mantidworkbench.rst
+++ b/docs/source/release/v6.3.0/mantidworkbench.rst
@@ -43,5 +43,6 @@ Bugfixes
 - Workbench will no longer hang if an algorithm was running when workbench was closed.
 - Fixed a bug in the editor where uncommenting using 'ctrl+/' wasn't working correctly for lines of the form '<optional whitespace>#code_here # inline comment'.
 - Commenting code in the editor using 'ctrl+/' will preserve indenting (i.e. `# ` will be inserted at the position of the first non-whitespace character in the line).
+- The axes limits of Waterfall plots will now scale correctly upon initial plotting and overplotting.
 
 :ref:`Release 6.3.0 <v6.3.0>`


### PR DESCRIPTION
**Description of work.**

This fixes the issue of waterfall plots not scaling on open. If the axes is waterfall, following adjustment of the lines, the plot function now calls the relim and autoscale functions to readjust the x and y limits.

In addition, the part of the plot function that overplots lines onto existing waterfall axes has been separated out into its own function to reduce complexity of the plot function (flake 8 complexity check failed).

**To test:**

1) Import data (HRP39182 from training course data used).
2) Plot desired spectra with plot type as waterfall.
3) Confirm suitable axis limits/scaling.
3) Overplot additional spectra onto plotted waterfall, confirm correct plotting and suitable axis limits/scaling.

Fixes #32951.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
