### PR TITLE
Add a Citation file to Mantid

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -5,9 +5,9 @@ authors:
   - name: "The Mantid Project team"
     email: mantid-help@mantidproject.org
     website: https://www.mantidproject.org/
-title: The Manipulation and Analysis Toolkit for Instrument Data
+title: Manipulation and Analysis Toolkit for Instrument Data
 version: 6.2.0
-doi: 10.5281/zenodo.5171937
+doi: 10.5286/SOFTWARE/MANTID6.2
 date-released: 2021-09-29
 keywords:
   - mantid

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,6 +1,6 @@
 cff-version: 1.2.0
 message: "If you use Mantid in your research, please cite it using this metadata."
-abstract: "The Mantid project provides a framework that supports high-performance computing and visualisation of scientific data. Mantid has been created to manipulate and analyse Neutron and Muon scattering data, but could be applied to many other techniques. The framework is open source and supported on multiple target platforms (Windows, Linux, Mac OS X)."
+abstract: "The Mantid project provides a framework that supports high-performance computing and visualisation of scientific data. Mantid has been created to manipulate and analyse Neutron and Muon scattering data, but could be applied to many other techniques. The framework is open source and is supported on multiple target platforms (Windows, Linux, macOS)."
 authors:
   - name: "The Mantid Project team"
     email: mantid-help@mantidproject.org

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,21 @@
+cff-version: 1.2.0
+message: "If you use Mantid in your research, please cite it using this metadata."
+abstract: "The Mantid project provides a framework that supports high-performance computing and visualisation of scientific data. Mantid has been created to manipulate and analyse Neutron and Muon scattering data, but could be applied to many other techniques. The framework is open source and supported on multiple target platforms (Windows, Linux, Mac OS X)."
+authors:
+  - name: "The Mantid Project team"
+    email: mantid-help@mantidproject.org
+    website: https://www.mantidproject.org/
+title: The Manipulation and Analysis Toolkit for Instrument Data
+version: 6.2.0
+doi: 10.5281/zenodo.5171937
+date-released: 2021-09-29
+keywords:
+  - mantid
+  - neutron
+  - muon
+  - particle physics
+  - instrument
+  - reduction
+  - analysis
+license:
+  - GPL-3.0

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Mantid
 ======
 
-The Mantid project provides a framework that supports high-performance computing and visualisation of scientific data. Mantid has been created to manipulate and analyse Neutron and Muon scattering data, but could be applied to many other techniques. The framework is open source and supported on multiple target platforms (Windows, Linux, Mac OS X).
+The Mantid project provides a framework that supports high-performance computing and visualisation of scientific data. Mantid has been created to manipulate and analyse Neutron and Muon scattering data, but could be applied to many other techniques. The framework is open source and is supported on multiple target platforms (Windows, Linux, macOS).
 
 Useful links
 ------------

--- a/dev-docs/source/PatchReleaseChecklist.rst
+++ b/dev-docs/source/PatchReleaseChecklist.rst
@@ -138,6 +138,8 @@ Once the testing has passed:
   deploy an MPI version of the patch release.
 * Create new DOI using the scripts in the codebase and instructions on
   :ref:`release checklist <ReleaseChecklist>`.
+* Open a PR to update the relevant metadata in the ``CITATION.cff`` file as
+  explained in the :ref:`release checklist <ReleaseChecklist>`.
 * Send an email, including the text of the release notes, to the
   following lists
 * ``nobugs@nobugsconference.org``

--- a/dev-docs/source/ReleaseChecklist.rst
+++ b/dev-docs/source/ReleaseChecklist.rst
@@ -378,4 +378,10 @@ publish a new `release <https://github.com/mantidproject/mantid/releases>`__ on 
 
 *  The script will prompt you for the password. Ask a senior developer to share the username and
    password with you if you do not already have access to it.
-*  Notify the Release Manager when you complete all your tasks.
+
+**Update Citation File**
+
+Open a PR updating the software ``doi``, ``date-released`` and ``version`` in the ``CITATION.cff`` file
+at the root of the repository.
+
+Notify the Release Manager when you complete all your tasks.


### PR DESCRIPTION
**Description of work.**
This PR adds a CFF file to the main mantid repo. When this gets merged we should see a cite button in the 'About' section of the repository.

Every time we release, the `doi`, `date-released` and `version` will need updating in the CITATION.cff file. This will be added to the release checklist for the Technical Release Manager.

The overhead of maintaining a list of `authors` in the CITATION file would be too much, and the risk of missing someone out would be high. So I have opted to give the name of the project instead as seen by the second CFF example
![image](https://user-images.githubusercontent.com/40830825/146930965-a59f8696-0334-4cd0-99bf-951fa266a151.png)

Something to consider in the future is whether there are other works we should be referencing in a `references` section. See this link for more details https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md#referencing-other-work

Part of #33154 

**To test:**
Read through the metadata and make sure it is correct, or can be improved.

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
