### PR TITLE
Replace checkbox for plot guess in muon with a push button.

### DIFF
--- a/docs/source/release/v6.4.0/muon.rst
+++ b/docs/source/release/v6.4.0/muon.rst
@@ -25,3 +25,9 @@ MuSR Changes
   - The Model Fitting tab no longer resets when the instrument is changed.
   - When a new results table is created the Model Fitting tab selects the default parameters to plot based on log values or parameters in the results table.
   - Fixed a bug that prevented the Model Fitting plot showing when data was binned.
+
+
+Changes
+#######
+
+- The plot guess checkbox in Muon Analysis and Frequency Domain Analysis has been replaced with a push button.

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/fitting_widgets/basic_fitting/basic_fitting_model.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/fitting_widgets/basic_fitting/basic_fitting_model.py
@@ -362,16 +362,6 @@ class BasicFittingModel:
         self.fitting_context.chi_squared[self.fitting_context.current_dataset_index] = chi_squared
 
     @property
-    def plot_guess(self) -> bool:
-        """Returns true if plot guess is turned on."""
-        return self.fitting_context.plot_guess
-
-    @plot_guess.setter
-    def plot_guess(self, plot_guess: bool) -> None:
-        """Sets that the plot guess should or should not be plotted."""
-        self.fitting_context.plot_guess = plot_guess
-
-    @property
     def plot_guess_type(self) -> str:
         """Returns the guess plot range type."""
         return self.fitting_context.plot_guess_type
@@ -490,7 +480,7 @@ class BasicFittingModel:
 
     def update_plot_guess(self) -> None:
         """Updates the guess plot using the current dataset and function."""
-        self.fitting_context.guess_workspace_name = self._evaluate_plot_guess(self.plot_guess)
+        self.fitting_context.guess_workspace_name = self._evaluate_plot_guess()
 
     def remove_all_fits_from_context(self) -> None:
         """Removes all fit results from the context."""
@@ -805,9 +795,9 @@ class BasicFittingModel:
         except AttributeError:
             return function.name()
 
-    def _evaluate_plot_guess(self, plot_guess: bool) -> str:
+    def _evaluate_plot_guess(self) -> str:
         """Evaluate the plot guess fit function and returns the name of the resulting guess workspace."""
-        if not plot_guess or self.current_dataset_name is None:
+        if self.current_dataset_name is None:
             return ""
 
         fit_function = self._get_plot_guess_fit_function()

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/fitting_widgets/basic_fitting/basic_fitting_presenter.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/fitting_widgets/basic_fitting/basic_fitting_presenter.py
@@ -64,7 +64,7 @@ class BasicFittingPresenter:
         self.view.set_slot_for_fit_generator_clicked(self.handle_fit_generator_clicked)
         self.view.set_slot_for_fit_button_clicked(self.handle_fit_clicked)
         self.view.set_slot_for_undo_fit_clicked(self.handle_undo_fit_clicked)
-        self.view.set_slot_for_plot_guess_changed(self.handle_plot_guess_changed)
+        self.view.set_slot_for_plot_guess_clicked(self.handle_plot_guess_clicked)
         self.view.set_slot_for_fit_name_changed(self.handle_function_name_changed_by_user)
         self.view.set_slot_for_dataset_changed(self.handle_dataset_name_changed)
         self.view.set_slot_for_covariance_matrix_clicked(self.handle_covariance_matrix_clicked)
@@ -111,7 +111,6 @@ class BasicFittingPresenter:
         """Handle when new data has been loaded into the interface."""
         self.update_and_reset_all_data()
 
-        self.view.plot_guess, self.model.plot_guess = False, False
         self.clear_undo_data()
 
         if self.model.number_of_datasets == 0:
@@ -134,9 +133,8 @@ class BasicFittingPresenter:
         if "DoublePulseEnabled" in updated_variables:
             self.update_and_reset_all_data()
 
-    def handle_plot_guess_changed(self) -> None:
+    def handle_plot_guess_clicked(self) -> None:
         """Handle when plot guess is ticked or un-ticked."""
-        self.model.plot_guess = self.view.plot_guess
         self.update_guess_parameters()
         self.update_plot_guess()
 
@@ -258,22 +256,17 @@ class BasicFittingPresenter:
             self.view.show_plot_guess_start_x(True)
             self.view.show_plot_guess_end_x(True)
 
-        self.update_plot_guess()
-
     def handle_plot_guess_points_changed(self) -> None:
         """Handle when the evaluation type is changed."""
         self.model.plot_guess_points = self.view.plot_guess_points
-        self.update_plot_guess()
 
     def handle_plot_guess_start_x_changed(self) -> None:
         """Handle when the evaluation type is changed."""
         self.model.plot_guess_start_x = self.view.plot_guess_start_x
-        self.update_plot_guess()
 
     def handle_plot_guess_end_x_changed(self) -> None:
         """Handle when the evaluation type is changed."""
         self.model.plot_guess_end_x = self.view.plot_guess_end_x
-        self.update_plot_guess()
 
     def handle_function_structure_changed(self) -> None:
         """Handle when the function structure is changed."""
@@ -286,8 +279,6 @@ class BasicFittingPresenter:
 
         self.reset_fit_status_and_chi_squared_information()
 
-        self.update_plot_guess()
-
         self.fit_function_changed_notifier.notify_subscribers()
 
         # Required to update the function browser to display the errors when first adding a function.
@@ -297,8 +288,6 @@ class BasicFittingPresenter:
         """Handle when the value of a parameter in a function is changed."""
         full_parameter = f"{function_index}{parameter}"
         self.model.update_parameter_value(full_parameter, self.view.parameter_value(full_parameter))
-
-        self.update_plot_guess()
 
         self.fit_function_changed_notifier.notify_subscribers()
         self.fit_parameter_changed_notifier.notify_subscribers()
@@ -449,8 +438,6 @@ class BasicFittingPresenter:
         """Updates the start and end x in the model using the provided values."""
         self.view.start_x, self.view.end_x = start_x, end_x
         self.model.current_start_x, self.model.current_end_x = start_x, end_x
-
-        self.update_plot_guess()
 
     def update_plot_guess(self) -> None:
         """Updates the guess plot using the current dataset and function."""

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/fitting_widgets/basic_fitting/basic_fitting_view.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/fitting_widgets/basic_fitting/basic_fitting_view.py
@@ -53,9 +53,9 @@ class BasicFittingView(ui_form, base_widget):
         """Connect the slot for the Undo Fit button."""
         self.fit_controls.set_slot_for_undo_fit_clicked(slot)
 
-    def set_slot_for_plot_guess_changed(self, slot) -> None:
+    def set_slot_for_plot_guess_clicked(self, slot) -> None:
         """Connect the slot for the Plot Guess checkbox."""
-        self.fit_controls.set_slot_for_plot_guess_changed(slot)
+        self.fit_controls.set_slot_for_plot_guess_clicked(slot)
 
     def set_slot_for_dataset_changed(self, slot) -> None:
         """Connect the slot for the display workspace combo box being changed."""
@@ -287,16 +287,6 @@ class BasicFittingView(ui_form, base_widget):
     def fit_to_raw(self, check: bool) -> None:
         """Sets whether or not you are fitting to raw data."""
         self.fit_function_options.fit_to_raw = check
-
-    @property
-    def plot_guess(self) -> bool:
-        """Returns true if plot guess is ticked."""
-        return self.fit_controls.plot_guess
-
-    @plot_guess.setter
-    def plot_guess(self, check: bool) -> None:
-        """Sets whether or not plot guess is ticked."""
-        self.fit_controls.plot_guess = check
 
     @property
     def function_name(self) -> str:

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/fitting_widgets/basic_fitting/fit_controls.ui
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/fitting_widgets/basic_fitting/fit_controls.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>595</width>
-    <height>25</height>
+    <width>688</width>
+    <height>28</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -27,21 +27,9 @@
     <number>0</number>
    </property>
    <item row="0" column="0">
-    <widget class="QCheckBox" name="plot_guess_checkbox">
-     <property name="minimumSize">
-      <size>
-       <width>250</width>
-       <height>0</height>
-      </size>
-     </property>
-     <property name="maximumSize">
-      <size>
-       <width>250</width>
-       <height>16777215</height>
-      </size>
-     </property>
+    <widget class="QPushButton" name="plot_guess_button">
      <property name="text">
-      <string>Plot guess</string>
+      <string>Plot Guess</string>
      </property>
     </widget>
    </item>

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/fitting_widgets/basic_fitting/fit_controls.ui
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/fitting_widgets/basic_fitting/fit_controls.ui
@@ -26,14 +26,7 @@
    <property name="bottomMargin">
     <number>0</number>
    </property>
-   <item row="0" column="0">
-    <widget class="QPushButton" name="plot_guess_button">
-     <property name="text">
-      <string>Plot Guess</string>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="1">
+   <item row="0" column="2">
     <widget class="QFrame" name="frame">
      <layout class="QHBoxLayout" name="horizontalLayout">
       <property name="leftMargin">
@@ -90,6 +83,30 @@
       </item>
      </layout>
     </widget>
+   </item>
+   <item row="0" column="1">
+    <layout class="QHBoxLayout" name="horizontalLayout_2">
+     <item>
+      <widget class="QPushButton" name="plot_guess_button">
+       <property name="text">
+        <string>Plot Guess</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+    </layout>
    </item>
   </layout>
  </widget>

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/fitting_widgets/basic_fitting/fit_controls_view.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/fitting_widgets/basic_fitting/fit_controls_view.py
@@ -43,24 +43,14 @@ class FitControlsView(ui_form, base_widget):
         """Connect the slot for the Undo Fit button."""
         self.undo_fit_button.clicked.connect(slot)
 
-    def set_slot_for_plot_guess_changed(self, slot) -> None:
+    def set_slot_for_plot_guess_clicked(self, slot) -> None:
         """Connect the slot for the Plot Guess checkbox."""
-        self.plot_guess_checkbox.stateChanged.connect(slot)
+        self.plot_guess_button.clicked.connect(slot)
 
     def set_number_of_undos(self, number_of_undos: int) -> None:
         """Sets the allowed number of 'Undo Fit' events."""
         self.undo_fit_button.setText(f"Undo Fit ({number_of_undos})")
         self.undo_fit_button.setEnabled(number_of_undos != 0)
-
-    @property
-    def plot_guess(self) -> bool:
-        """Returns true if plot guess is ticked."""
-        return self.plot_guess_checkbox.isChecked()
-
-    @plot_guess.setter
-    def plot_guess(self, check: bool) -> None:
-        """Sets whether or not plot guess is ticked."""
-        self.plot_guess_checkbox.setChecked(check)
 
     def update_global_fit_status_label(self, fit_success: list) -> None:
         """Updates the global fit status label."""

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/plot_widget/fit_pane/plot_fit_pane_presenter.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/plot_widget/fit_pane/plot_fit_pane_presenter.py
@@ -82,7 +82,7 @@ class PlotFitPanePresenter(BasePanePresenter):
             self._figure_presenter.remove_workspace_names_from_plot([self._fitting_context.guess_workspace_name])
 
     def handle_update_plot_guess(self):
-        if self._fitting_context.guess_workspace_name is not None and self._fitting_context.plot_guess:
+        if self._fitting_context.guess_workspace_name is not None:
             self._figure_presenter.plot_guess_workspace(self._fitting_context.guess_workspace_name)
 
     def create_empty_plot(self):

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/test_helpers/fitting_mock_setup.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/test_helpers/fitting_mock_setup.py
@@ -17,7 +17,7 @@ def add_mock_methods_to_basic_fitting_view(view):
     view.set_slot_for_fit_generator_clicked = mock.Mock()
     view.set_slot_for_fit_button_clicked = mock.Mock()
     view.set_slot_for_undo_fit_clicked = mock.Mock()
-    view.set_slot_for_plot_guess_changed = mock.Mock()
+    view.set_slot_for_plot_guess_clicked = mock.Mock()
     view.set_slot_for_fit_name_changed = mock.Mock()
     view.set_slot_for_covariance_matrix_clicked = mock.Mock()
     view.set_slot_for_function_structure_changed = mock.Mock()

--- a/qt/python/mantidqtinterfaces/test/Muon/fitting_widgets/basic_fitting/basic_fitting_model_test.py
+++ b/qt/python/mantidqtinterfaces/test/Muon/fitting_widgets/basic_fitting/basic_fitting_model_test.py
@@ -538,23 +538,6 @@ class BasicFittingModelTest(unittest.TestCase):
         self.assertEqual(1, self.mock_context_guess_workspace_name.call_count)
         self.mock_context_guess_workspace_name.assert_called_with(guess_workspace_name)
 
-    def test_update_plot_guess_notifies_subscribers_with_the_guess_workspace_name_as_none_if_plot_guess_is_false(self):
-        self.model.dataset_names = self.dataset_names
-        self.model.single_fit_functions = self.single_fit_functions
-        self.model.start_xs = [0.0, 1.0]
-        self.model.end_xs = [10.0, 11.0]
-        self.model.current_dataset_index = 0
-        self.model.plot_guess = False
-        self.model.plot_guess_type = X_FROM_FIT_RANGE
-
-        self.model.context = mock.Mock()
-        self.mock_context_guess_workspace_name = mock.PropertyMock(return_value=None)
-        type(self.model.fitting_context).guess_workspace_name = self.mock_context_guess_workspace_name
-        self.model.update_plot_guess()
-
-        self.assertEqual(1, self.mock_context_guess_workspace_name.call_count)
-        self.mock_context_guess_workspace_name.assert_called_with("")
-
     def test_update_plot_guess_will_evaluate_the_function_when_in_double_fit_mode(self):
         guess_workspace_name = "__frequency_domain_analysis_fitting_guessName1"
         self.model.dataset_names = self.dataset_names

--- a/qt/python/mantidqtinterfaces/test/Muon/fitting_widgets/basic_fitting/basic_fitting_presenter_test.py
+++ b/qt/python/mantidqtinterfaces/test/Muon/fitting_widgets/basic_fitting/basic_fitting_presenter_test.py
@@ -52,7 +52,7 @@ class BasicFittingPresenterTest(unittest.TestCase, MockBasicFitting):
         self.assertEqual(self.view.set_slot_for_fit_generator_clicked.call_count, 1)
         self.assertEqual(self.view.set_slot_for_fit_button_clicked.call_count, 1)
         self.assertEqual(self.view.set_slot_for_undo_fit_clicked.call_count, 1)
-        self.assertEqual(self.view.set_slot_for_plot_guess_changed.call_count, 1)
+        self.assertEqual(self.view.set_slot_for_plot_guess_clicked.call_count, 1)
         self.assertEqual(self.view.set_slot_for_fit_name_changed.call_count, 1)
         self.assertEqual(self.view.set_slot_for_covariance_matrix_clicked.call_count, 1)
         self.assertEqual(self.view.set_slot_for_function_structure_changed.call_count, 1)
@@ -101,8 +101,6 @@ class BasicFittingPresenterTest(unittest.TestCase, MockBasicFitting):
         self.presenter.handle_new_data_loaded()
 
         self.presenter.update_and_reset_all_data.assert_called_with()
-        self.mock_view_plot_guess.assert_called_once_with(False)
-        self.mock_model_plot_guess.assert_called_once_with(False)
         self.presenter.clear_undo_data.assert_called_with()
         self.presenter.enable_editing_notifier.notify_subscribers.assert_called_once_with()
 
@@ -114,8 +112,6 @@ class BasicFittingPresenterTest(unittest.TestCase, MockBasicFitting):
         self.presenter.handle_new_data_loaded()
 
         self.presenter.update_and_reset_all_data.assert_called_with()
-        self.mock_view_plot_guess.assert_called_once_with(False)
-        self.mock_model_plot_guess.assert_called_once_with(False)
         self.presenter.clear_undo_data.assert_called_with()
         self.view.disable_view.assert_called_once_with()
 
@@ -140,7 +136,7 @@ class BasicFittingPresenterTest(unittest.TestCase, MockBasicFitting):
         self.presenter.selected_fit_results_changed.notify_subscribers.assert_called_once_with([])
 
     def test_that_handle_plot_guess_changed_will_update_plot_guess_using_the_model(self):
-        self.presenter.handle_plot_guess_changed()
+        self.presenter.handle_plot_guess_clicked()
         self.model.update_plot_guess.assert_called_once_with()
 
     def test_that_handle_undo_fit_clicked_will_attempt_to_reset_the_fit_data_and_notify_that_the_data_has_changed(self):
@@ -285,7 +281,6 @@ class BasicFittingPresenterTest(unittest.TestCase, MockBasicFitting):
         self.presenter.clear_undo_data.assert_called_once_with()
         self.model.get_active_fit_function.assert_called_once_with()
         self.presenter.reset_fit_status_and_chi_squared_information.assert_called_once_with()
-        self.model.update_plot_guess.assert_called_once_with()
         self.presenter.fit_function_changed_notifier.notify_subscribers.assert_called_once_with()
 
     def test_that_handle_plot_guess_type_changed_will_set_guess_parameters_for_plot_range(self):
@@ -309,18 +304,6 @@ class BasicFittingPresenterTest(unittest.TestCase, MockBasicFitting):
         self.view.show_plot_guess_start_x.assert_called_with(True)
         self.view.show_plot_guess_end_x.assert_called_with(True)
 
-    def test_that_handle_plot_guess_points_changed_will_update_the_guess(self):
-        self.presenter.handle_plot_guess_points_changed()
-        self.model.update_plot_guess.assert_called_once_with()
-
-    def test_that_handle_plot_guess_start_x_changed_will_update_the_guess(self):
-        self.presenter.handle_plot_guess_start_x_changed()
-        self.model.update_plot_guess.assert_called_once_with()
-
-    def test_that_handle_plot_guess_end_x_changed_will_update_the_guess(self):
-        self.presenter.handle_plot_guess_end_x_changed()
-        self.model.update_plot_guess.assert_called_once_with()
-
     def test_that_handle_function_parameter_changed_will_update_the_fit_functions_and_notify_they_are_updated(self):
         function_index = ""
         parameter = "A0"
@@ -336,7 +319,6 @@ class BasicFittingPresenterTest(unittest.TestCase, MockBasicFitting):
         self.view.parameter_value.assert_called_once_with(full_parameter)
         self.model.update_parameter_value.assert_called_once_with(full_parameter, parameter_value)
 
-        self.model.update_plot_guess.assert_called_once_with()
         self.presenter.fit_parameter_changed_notifier.notify_subscribers.assert_called_once_with()
 
     def test_that_handle_start_x_updated_will_attempt_to_update_the_start_x_in_the_model(self):

--- a/qt/python/mantidqtinterfaces/test/Muon/fitting_widgets/basic_fitting/basic_fitting_view_test.py
+++ b/qt/python/mantidqtinterfaces/test/Muon/fitting_widgets/basic_fitting/basic_fitting_view_test.py
@@ -40,10 +40,6 @@ class BasicFittingViewTest(unittest.TestCase, QtWidgetFinder):
         self.assertTrue(self.view.close())
         QApplication.sendPostedEvents()
 
-    def test_that_the_plot_guess_checkbox_can_be_ticked_as_expected(self):
-        self.view.plot_guess = True
-        self.assertTrue(self.view.plot_guess)
-
     def test_that_enable_view_does_not_enable_the_tab_if_there_are_no_datasets_loaded(self):
         self.view.enable_view()
         self.assertTrue(not self.view.isEnabled())

--- a/qt/python/mantidqtinterfaces/test/Muon/fitting_widgets/basic_fitting/fit_controls_view_test.py
+++ b/qt/python/mantidqtinterfaces/test/Muon/fitting_widgets/basic_fitting/fit_controls_view_test.py
@@ -30,10 +30,6 @@ class FitControlsViewTest(unittest.TestCase, QtWidgetFinder):
         self.assertTrue(not self.view.undo_fit_button.isEnabled())
         self.assertTrue(not self.view.plot_guess)
 
-    def test_that_the_plot_guess_checkbox_can_be_ticked_as_expected(self):
-        self.view.plot_guess = True
-        self.assertTrue(self.view.plot_guess)
-
     def test_that_the_undo_fit_button_can_be_enabled_when_you_set_more_than_zero_undos(self):
         self.view.set_number_of_undos(2)
         self.assertTrue(self.view.undo_fit_button.isEnabled())

--- a/qt/python/mantidqtinterfaces/test/Muon/fitting_widgets/basic_fitting/fit_controls_view_test.py
+++ b/qt/python/mantidqtinterfaces/test/Muon/fitting_widgets/basic_fitting/fit_controls_view_test.py
@@ -26,9 +26,8 @@ class FitControlsViewTest(unittest.TestCase, QtWidgetFinder):
         self.assertTrue(self.view.close())
         QApplication.sendPostedEvents()
 
-    def test_that_the_view_has_been_initialized_with_the_undo_fit_button_disabled_and_plot_guess_unchecked(self):
+    def test_that_the_view_has_been_initialized_with_the_undo_fit_button_disabled(self):
         self.assertTrue(not self.view.undo_fit_button.isEnabled())
-        self.assertTrue(not self.view.plot_guess)
 
     def test_that_the_undo_fit_button_can_be_enabled_when_you_set_more_than_zero_undos(self):
         self.view.set_number_of_undos(2)

--- a/qt/python/mantidqtinterfaces/test/Muon/fitting_widgets/general_fitting/general_fitting_presenter_test.py
+++ b/qt/python/mantidqtinterfaces/test/Muon/fitting_widgets/general_fitting/general_fitting_presenter_test.py
@@ -61,7 +61,7 @@ class GeneralFittingPresenterTest(unittest.TestCase):
         self.assertEqual(self.view.set_slot_for_fit_generator_clicked.call_count, 1)
         self.assertEqual(self.view.set_slot_for_fit_button_clicked.call_count, 1)
         self.assertEqual(self.view.set_slot_for_undo_fit_clicked.call_count, 1)
-        self.assertEqual(self.view.set_slot_for_plot_guess_changed.call_count, 1)
+        self.assertEqual(self.view.set_slot_for_plot_guess_clicked.call_count, 1)
         self.assertEqual(self.view.set_slot_for_fit_name_changed.call_count, 1)
         self.assertEqual(self.view.set_slot_for_function_structure_changed.call_count, 1)
         self.assertEqual(self.view.set_slot_for_function_parameter_changed.call_count, 1)

--- a/qt/python/mantidqtinterfaces/test/Muon/fitting_widgets/model_fitting/model_fitting_presenter_test.py
+++ b/qt/python/mantidqtinterfaces/test/Muon/fitting_widgets/model_fitting/model_fitting_presenter_test.py
@@ -68,7 +68,7 @@ class ModelFittingPresenterTest(unittest.TestCase):
         self.assertEqual(self.view.set_slot_for_fit_generator_clicked.call_count, 1)
         self.assertEqual(self.view.set_slot_for_fit_button_clicked.call_count, 1)
         self.assertEqual(self.view.set_slot_for_undo_fit_clicked.call_count, 1)
-        self.assertEqual(self.view.set_slot_for_plot_guess_changed.call_count, 1)
+        self.assertEqual(self.view.set_slot_for_plot_guess_clicked.call_count, 1)
         self.assertEqual(self.view.set_slot_for_fit_name_changed.call_count, 1)
         self.assertEqual(self.view.set_slot_for_function_structure_changed.call_count, 1)
         self.assertEqual(self.view.set_slot_for_function_parameter_changed.call_count, 1)

--- a/qt/python/mantidqtinterfaces/test/Muon/fitting_widgets/tf_asymmetry_fitting/tf_asymmetry_fitting_presenter_test.py
+++ b/qt/python/mantidqtinterfaces/test/Muon/fitting_widgets/tf_asymmetry_fitting/tf_asymmetry_fitting_presenter_test.py
@@ -65,7 +65,7 @@ class TFAsymmetryFittingPresenterTest(unittest.TestCase):
         self.assertEqual(self.view.set_slot_for_fit_generator_clicked.call_count, 1)
         self.assertEqual(self.view.set_slot_for_fit_button_clicked.call_count, 1)
         self.assertEqual(self.view.set_slot_for_undo_fit_clicked.call_count, 1)
-        self.assertEqual(self.view.set_slot_for_plot_guess_changed.call_count, 1)
+        self.assertEqual(self.view.set_slot_for_plot_guess_clicked.call_count, 1)
         self.assertEqual(self.view.set_slot_for_fit_name_changed.call_count, 1)
         self.assertEqual(self.view.set_slot_for_function_structure_changed.call_count, 1)
         self.assertEqual(self.view.set_slot_for_function_parameter_changed.call_count, 1)
@@ -134,8 +134,6 @@ class TFAsymmetryFittingPresenterTest(unittest.TestCase):
         self.presenter.handle_new_data_loaded()
 
         self.presenter.update_and_reset_all_data.assert_called_with()
-        self.mock_view_plot_guess.assert_called_once_with(False)
-        self.mock_model_plot_guess.assert_called_once_with(False)
         self.presenter.clear_undo_data.assert_called_with()
         self.presenter.enable_editing_notifier.notify_subscribers.assert_called_once_with()
         self.assertEqual(self.mock_view_tf_asymmetry_mode.call_count, 1)
@@ -150,8 +148,6 @@ class TFAsymmetryFittingPresenterTest(unittest.TestCase):
         self.presenter.handle_new_data_loaded()
 
         self.presenter.update_and_reset_all_data.assert_called_with()
-        self.mock_view_plot_guess.assert_called_once_with(False)
-        self.mock_model_plot_guess.assert_called_once_with(False)
         self.presenter.clear_undo_data.assert_called_with()
         self.view.disable_view.assert_called_once_with()
         self.mock_view_tf_asymmetry_mode.assert_called_with(False)
@@ -299,8 +295,6 @@ class TFAsymmetryFittingPresenterTest(unittest.TestCase):
         type(self.view).start_x = self.mock_view_start_x
         self.mock_view_end_x = mock.PropertyMock(return_value=self.end_x)
         type(self.view).end_x = self.mock_view_end_x
-        self.mock_view_plot_guess = mock.PropertyMock(return_value=self.plot_guess)
-        type(self.view).plot_guess = self.mock_view_plot_guess
         self.mock_view_function_name = mock.PropertyMock(return_value=self.function_name)
         type(self.view).function_name = self.mock_view_function_name
         self.mock_view_simultaneous_fitting_mode = mock.PropertyMock(return_value=self.simultaneous_fitting_mode)
@@ -314,7 +308,7 @@ class TFAsymmetryFittingPresenterTest(unittest.TestCase):
         self.view.set_slot_for_fit_generator_clicked = mock.Mock()
         self.view.set_slot_for_fit_button_clicked = mock.Mock()
         self.view.set_slot_for_undo_fit_clicked = mock.Mock()
-        self.view.set_slot_for_plot_guess_changed = mock.Mock()
+        self.view.set_slot_for_plot_guess_clicked = mock.Mock()
         self.view.set_slot_for_fit_name_changed = mock.Mock()
         self.view.set_slot_for_function_structure_changed = mock.Mock()
         self.view.set_slot_for_function_parameter_changed = mock.Mock()


### PR DESCRIPTION
**Description of work.**

This commit replaces the checkbox for plotting the guess with a push button.

**To test:**

1. open Muon Analysis.
2. Load MUSR62260
3. go to the fitting tab and add the `GausOsc` function.
4. Click the plot guess button, it should plot the current function.
5. Change frequency to 0.5, the guess should not update.
6. click plot guess again, it should update with frequency of 0.5
7. Click Fit, the guess should be replaced by fit.
8. change the parameters, and click guess, the guess should be plotted over the previous fit.

Fixes #33126

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
