### PR TITLE
Remove `QT_VERSION_CHECK`'s from Indirect interfaces

### DIFF
--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -589,7 +589,7 @@ knownConditionTrueFalse:${CMAKE_SOURCE_DIR}/qt/widgets/common/src/FitPropertyBro
 shadowVariable:${CMAKE_SOURCE_DIR}/qt/widgets/common/src/FitPropertyBrowser.cpp:512
 shadowVariable:${CMAKE_SOURCE_DIR}/qt/widgets/common/src/FitPropertyBrowser.cpp:1801
 constParameter:${CMAKE_SOURCE_DIR}/qt/widgets/common/inc/MantidQtWidgets/Common/PropertyHandler.h:194
-useStlAlgorithm:${CMAKE_SOURCE_DIR}/qt/widgets/common/src/FitPropertyBrowser.cpp:3281
+useStlAlgorithm:${CMAKE_SOURCE_DIR}/qt/widgets/common/src/FitPropertyBrowser.cpp:3277
 useStlAlgorithm:${CMAKE_SOURCE_DIR}/qt/widgets/common/src/FitScriptGeneratorDataTable.cpp:200
 unsignedLessThanZero:${CMAKE_SOURCE_DIR}/qt/widgets/common/src/FitScriptGeneratorModel.cpp:611
 knownConditionTrueFalse:${CMAKE_SOURCE_DIR}/qt/widgets/common/src/FlowLayout.cpp:131
@@ -690,7 +690,7 @@ stlFindInsert:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/Indirect/IndirectPlot
 stlFindInsert:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/Indirect/IndirectPlotOptionsModel.cpp:103
 stlFindInsert:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/Indirect/IndirectPlotOptionsModel.cpp:105
 stlFindInsert:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/Indirect/IndirectPlotOptionsModel.cpp:107
-unreadVariable:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/Indirect/IndirectPlotOptionsView.cpp:113
+unreadVariable:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/Indirect/IndirectPlotOptionsView.cpp:92
 unreadVariable:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/Indirect/IndirectSymmetrise.cpp:173
 useStlAlgorithm:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/Indirect/IndirectDataValidationHelper.cpp:33
 unreadVariable:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/Indirect/IndirectLoadILL.cpp:129

--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -589,7 +589,6 @@ knownConditionTrueFalse:${CMAKE_SOURCE_DIR}/qt/widgets/common/src/FitPropertyBro
 shadowVariable:${CMAKE_SOURCE_DIR}/qt/widgets/common/src/FitPropertyBrowser.cpp:512
 shadowVariable:${CMAKE_SOURCE_DIR}/qt/widgets/common/src/FitPropertyBrowser.cpp:1801
 constParameter:${CMAKE_SOURCE_DIR}/qt/widgets/common/inc/MantidQtWidgets/Common/PropertyHandler.h:194
-useStlAlgorithm:${CMAKE_SOURCE_DIR}/qt/widgets/common/src/FitPropertyBrowser.cpp:3277
 useStlAlgorithm:${CMAKE_SOURCE_DIR}/qt/widgets/common/src/FitScriptGeneratorDataTable.cpp:200
 unsignedLessThanZero:${CMAKE_SOURCE_DIR}/qt/widgets/common/src/FitScriptGeneratorModel.cpp:611
 knownConditionTrueFalse:${CMAKE_SOURCE_DIR}/qt/widgets/common/src/FlowLayout.cpp:131
@@ -690,7 +689,6 @@ stlFindInsert:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/Indirect/IndirectPlot
 stlFindInsert:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/Indirect/IndirectPlotOptionsModel.cpp:103
 stlFindInsert:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/Indirect/IndirectPlotOptionsModel.cpp:105
 stlFindInsert:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/Indirect/IndirectPlotOptionsModel.cpp:107
-unreadVariable:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/Indirect/IndirectPlotOptionsView.cpp:92
 unreadVariable:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/Indirect/IndirectSymmetrise.cpp:173
 useStlAlgorithm:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/Indirect/IndirectDataValidationHelper.cpp:33
 unreadVariable:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/Indirect/IndirectLoadILL.cpp:129

--- a/qt/scientific_interfaces/Indirect/ISISCalibration.cpp
+++ b/qt/scientific_interfaces/Indirect/ISISCalibration.cpp
@@ -129,7 +129,6 @@ ISISCalibration::ISISCalibration(IndirectDataReduction *idrUI, QWidget *parent)
   auto resPeak = m_uiForm.ppResolution->addRangeSelector("ResPeak");
   resPeak->setColour(Qt::red);
 
-  // SIGNAL/SLOT CONNECTIONS
   // Update instrument information when a new instrument config is selected
   connect(this, SIGNAL(newInstrumentConfiguration()), this, SLOT(setDefaultInstDetails()));
 

--- a/qt/scientific_interfaces/Indirect/IndirectFitPlotView.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitPlotView.cpp
@@ -6,6 +6,7 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 #include "IndirectFitPlotView.h"
 
+#include "MantidQtIcons/Icon.h"
 #include "MantidQtWidgets/Common/SignalBlocker.h"
 
 #include <boost/numeric/conversion/cast.hpp>
@@ -13,9 +14,6 @@
 #include <QMessageBox>
 #include <QTimer>
 #include <limits>
-
-#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
-#include "MantidQtIcons/Icon.h"
 
 namespace {
 
@@ -26,8 +24,6 @@ QHash<QString, QVariant> tightLayoutKwargs() {
 }
 
 } // namespace
-
-#endif
 
 namespace MantidQt::CustomInterfaces::IDA {
 
@@ -63,12 +59,8 @@ void IndirectFitPlotView::createSplitterWithPlots() {
 }
 
 void IndirectFitPlotView::createSplitter() {
-#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
   auto const dragIcon = Icons::getIcon("mdi.dots-horizontal");
   m_splitter = std::make_unique<Splitter>(dragIcon);
-#else
-  m_splitter = std::make_unique<QSplitter>();
-#endif
   m_splitter->setOrientation(Qt::Vertical);
   m_splitter->setStyleSheet("QSplitter::handle { background-color: transparent; }");
 }
@@ -91,10 +83,8 @@ PreviewPlot *IndirectFitPlotView::createPlot(PreviewPlot *plot, QSize const &min
   plot->setProperty("showLegend", QVariant(true));
   plot->setProperty("canvasColour", QVariant(QColor(255, 255, 255)));
 
-  // Avoids squished plots for >qt5
-#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
+  // Avoids squished plots
   plot->setTightLayout(tightLayoutKwargs());
-#endif
 
   return plot;
 }
@@ -290,9 +280,7 @@ void IndirectFitPlotView::addBackgroundRangeSelector() {
   backRangeSelector->setUpperBound(10.0);
 
   connect(backRangeSelector, SIGNAL(valueChanged(double)), this, SIGNAL(backgroundChanged(double)));
-#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
   connect(backRangeSelector, SIGNAL(resetScientificBounds()), this, SLOT(setBackgroundBounds()));
-#endif
 }
 
 void IndirectFitPlotView::setBackgroundBounds() {

--- a/qt/scientific_interfaces/Indirect/IndirectFitPlotView.h
+++ b/qt/scientific_interfaces/Indirect/IndirectFitPlotView.h
@@ -13,12 +13,10 @@
 #include "MantidAPI/MatrixWorkspace.h"
 #include "MantidQtWidgets/Plotting/PreviewPlot.h"
 
-#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
 #include <QIcon>
 #include <QPainter>
-#include <QSplitterHandle>
-#endif
 #include <QSplitter>
+#include <QSplitterHandle>
 #include <utility>
 
 namespace MantidQt {
@@ -26,7 +24,6 @@ namespace CustomInterfaces {
 namespace IDA {
 
 // Used for painting an Icon onto the handle of the splitter on workbench
-#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
 class SplitterHandle : public QSplitterHandle {
 public:
   SplitterHandle(QIcon icon, Qt::Orientation orientation, QSplitter *parent = nullptr)
@@ -53,7 +50,6 @@ public:
 private:
   QIcon m_icon;
 };
-#endif
 
 class MANTIDQT_INDIRECT_DLL IndirectFitPlotView : public IIndirectFitPlotView {
   Q_OBJECT

--- a/qt/scientific_interfaces/Indirect/IndirectPlotOptionsView.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectPlotOptionsView.cpp
@@ -6,15 +6,12 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 #include "IndirectPlotOptionsView.h"
 
+#include "MantidQtIcons/Icon.h"
 #include "MantidQtWidgets/Common/SignalBlocker.h"
 
 #include <QMenu>
 #include <QMessageBox>
 #include <QSettings>
-
-#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
-#include "MantidQtIcons/Icon.h"
-#endif
 
 namespace {
 
@@ -45,29 +42,11 @@ QString getAction(std::map<std::string, std::string> const &actions, std::string
   return "";
 }
 
-QIcon plotCurveIcon() {
-#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
-  return QIcon(":/curves.png");
-#else
-  return MantidQt::Icons::getIcon("mdi.chart-line");
-#endif
-}
+QIcon plotCurveIcon() { return MantidQt::Icons::getIcon("mdi.chart-line"); }
 
-QIcon plotContourIcon() {
-#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
-  return QIcon(":/contour_map.png");
-#else
-  return MantidQt::Icons::getIcon("mdi.chart-scatterplot-hexbin");
-#endif
-}
+QIcon plotContourIcon() { return MantidQt::Icons::getIcon("mdi.chart-scatterplot-hexbin"); }
 
-QIcon plotTiledIcon() {
-#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
-  return QIcon(":/arrangeLayers.png");
-#else
-  return MantidQt::Icons::getIcon("mdi.chart-line-stacked");
-#endif
-}
+QIcon plotTiledIcon() { return MantidQt::Icons::getIcon("mdi.chart-line-stacked"); }
 
 } // namespace
 

--- a/qt/scientific_interfaces/Indirect/IndirectPlotOptionsView.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectPlotOptionsView.cpp
@@ -89,7 +89,6 @@ void IndirectPlotOptionsView::emitSelectedIndicesChanged() {
 }
 
 void IndirectPlotOptionsView::emitSelectedIndicesChanged(QString const &spectra) {
-  QString nonConstCopy = spectra;
   if (spectra.isEmpty()) {
     emit selectedIndicesChanged(spectra.toStdString());
   }

--- a/qt/scientific_interfaces/Indirect/IndirectSettings.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectSettings.cpp
@@ -7,24 +7,16 @@
 #include "IndirectSettings.h"
 #include "IndirectInterface.h"
 #include "IndirectSettingsHelper.h"
-#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
 #include "MantidQtIcons/Icon.h"
 
 constexpr auto SETTINGS_ICON = "mdi.settings";
-#endif
 
 namespace MantidQt::CustomInterfaces {
 DECLARE_SUBWINDOW(IndirectSettings)
 
 IndirectSettings::IndirectSettings(QWidget *parent) : MantidQt::API::UserSubWindow(parent) { m_uiForm.setupUi(this); }
 
-QIcon IndirectSettings::icon() {
-#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
-  return QIcon(":/configure.png");
-#else
-  return Icons::getIcon(SETTINGS_ICON);
-#endif
-}
+QIcon IndirectSettings::icon() { return Icons::getIcon(SETTINGS_ICON); }
 
 void IndirectSettings::initLayout() {
   m_presenter = std::make_unique<IndirectSettingsPresenter>(this);
@@ -58,25 +50,8 @@ std::map<std::string, QVariant> IndirectSettings::getSettings() const {
 void IndirectSettings::loadSettings() { m_presenter->loadSettings(); }
 
 void IndirectSettings::closeSettings() {
-#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
-  getDockedOrFloatingWindow()->close();
-#else
   if (auto settingsWindow = window())
     settingsWindow->close();
-#endif
 }
-
-#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
-QWidget *IndirectSettings::getDockedOrFloatingWindow() {
-  QWidget *widget = this;
-  while (widget) {
-    auto const className = std::string(widget->metaObject()->className());
-    if (className == "DockedWindow" || widget->isWindow())
-      return widget;
-    widget = widget->parentWidget();
-  }
-  return window();
-}
-#endif
 
 } // namespace MantidQt::CustomInterfaces

--- a/qt/scientific_interfaces/Indirect/IndirectSettings.h
+++ b/qt/scientific_interfaces/Indirect/IndirectSettings.h
@@ -51,8 +51,6 @@ private:
 
   void connectIndirectInterface(const QPointer<UserSubWindow> &window);
 
-  QWidget *getDockedOrFloatingWindow();
-
   std::unique_ptr<IndirectSettingsPresenter> m_presenter;
   Ui::IndirectSettings m_uiForm;
 };

--- a/qt/scientific_interfaces/Indirect/IndirectSqw.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectSqw.cpp
@@ -67,12 +67,7 @@ IndirectSqw::IndirectSqw(IndirectDataReduction *idrUI, QWidget *parent) : Indire
   connect(this, SIGNAL(updateRunButton(bool, std::string const &, QString const &, QString const &)), this,
           SLOT(updateRunButton(bool, std::string const &, QString const &, QString const &)));
 
-#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
-  m_uiForm.rqwPlot2D->setXAxisLabel("Energy (meV)");
-  m_uiForm.rqwPlot2D->setYAxisLabel("Q (A-1)");
-#else
   m_uiForm.rqwPlot2D->setCanvasColour(QColor(240, 240, 240));
-#endif
 
   // Allows empty workspace selector when initially selected
   m_uiForm.dsSampleInput->isOptional(true);

--- a/qt/scientific_interfaces/Indirect/LazyAsyncRunner.h
+++ b/qt/scientific_interfaces/Indirect/LazyAsyncRunner.h
@@ -8,11 +8,8 @@
 
 #include "DllConfig.h"
 
-#include <QtCore>
-
-#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
 #include <QtConcurrent>
-#endif
+#include <QtCore>
 
 #include <boost/optional.hpp>
 

--- a/qt/widgets/common/src/EditLocalParameterDialog.cpp
+++ b/qt/widgets/common/src/EditLocalParameterDialog.cpp
@@ -70,11 +70,7 @@ void EditLocalParameterDialog::doSetup(const QString &parName, const QStringList
   m_uiForm.logValueSelector->setCheckboxShown(true);
   connect(m_uiForm.logValueSelector, SIGNAL(logOptionsEnabled(bool)), this, SIGNAL(logOptionsChecked(bool)));
   QHeaderView *header = m_uiForm.tableWidget->horizontalHeader();
-#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
-  header->setResizeMode(0, QHeaderView::Stretch);
-#else
   header->setSectionResizeMode(QHeaderView::Stretch);
-#endif
   connect(m_uiForm.tableWidget, SIGNAL(cellChanged(int, int)), this, SLOT(valueChanged(int, int)));
   m_uiForm.lblParameterName->setText("Parameter: " + parName);
 

--- a/qt/widgets/common/src/FitPropertyBrowser.cpp
+++ b/qt/widgets/common/src/FitPropertyBrowser.cpp
@@ -3273,9 +3273,10 @@ void FitPropertyBrowser::addAllowedSpectra(const QString &wsName, const QList<in
   auto ws = AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(name);
   if (ws) {
     QList<int> indices;
-    for (auto const i : wsSpectra) {
-      indices.push_back(static_cast<int>(ws->getIndexFromSpectrumNumber(i)));
-    }
+    indices.reserve(wsSpectra.size());
+    std::transform(wsSpectra.cbegin(), wsSpectra.cend(), std::back_inserter(indices),
+                   [&ws](const auto i) { return static_cast<int>(ws->getIndexFromSpectrumNumber(i)); });
+
     auto wsFound = m_allowedSpectra.find(wsName);
     m_allowedSpectra.insert(wsName, indices);
     if (wsFound != m_allowedSpectra.end()) {

--- a/qt/widgets/common/src/FitPropertyBrowser.cpp
+++ b/qt/widgets/common/src/FitPropertyBrowser.cpp
@@ -1872,14 +1872,11 @@ double FitPropertyBrowser::endX() const { return m_doubleManager->value(m_endX);
 void FitPropertyBrowser::setEndX(double value) { m_doubleManager->setValue(m_endX, value); }
 
 void FitPropertyBrowser::setXRange(double start, double end) {
-#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
   disconnect(m_doubleManager, SIGNAL(propertyChanged(QtProperty *)), this, SLOT(doubleChanged(QtProperty *)));
-#endif
 
   m_doubleManager->setValue(m_startX, start);
   m_doubleManager->setValue(m_endX, end);
 
-#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
   setWorkspace(m_compositeFunction);
   m_doubleManager->setMinimum(m_endX, start);
   m_doubleManager->setMaximum(m_startX, end);
@@ -1888,7 +1885,6 @@ void FitPropertyBrowser::setXRange(double start, double end) {
   getHandler()->setAttribute("EndX", end);
 
   connect(m_doubleManager, SIGNAL(propertyChanged(QtProperty *)), this, SLOT(doubleChanged(QtProperty *)));
-#endif
 }
 
 QVector<double> FitPropertyBrowser::getXRange() {


### PR DESCRIPTION
**Description of work.**
This PR removes all the Qt4 and 5 version checks from the Indirect interfaces.

**To test:**
A code review and make sure the tests pass.

Part of #30268

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
