### PR TITLE
Fix a bug in what units were generated for G(r) files

### DIFF
--- a/Framework/DataHandling/src/LoadPDFgetNFile.cpp
+++ b/Framework/DataHandling/src/LoadPDFgetNFile.cpp
@@ -257,10 +257,7 @@ void LoadPDFgetNFile::setUnit(const Workspace2D_sptr &ws) {
     string unit = "MomentumTransfer";
     ws->getAxis(0)->setUnit(unit);
   } else if (xcolname == "r") {
-    ws->getAxis(0)->unit() = UnitFactory::Instance().create("Label");
-    Unit_sptr unit = ws->getAxis(0)->unit();
-    std::shared_ptr<Units::Label> label = std::dynamic_pointer_cast<Units::Label>(unit);
-    label->setLabel("AtomicDistance", "Angstrom");
+    ws->getAxis(0)->setUnit("AtomicDistance");
   } else {
     stringstream errss;
     errss << "X axis " << xcolname << " is not supported for unit. \n";

--- a/Framework/DataHandling/test/LoadPDFgetNFileTest.h
+++ b/Framework/DataHandling/test/LoadPDFgetNFileTest.h
@@ -9,8 +9,10 @@
 #include <cxxtest/TestSuite.h>
 
 #include "MantidAPI/AnalysisDataService.h"
+#include "MantidAPI/Axis.h"
 #include "MantidDataHandling/LoadPDFgetNFile.h"
 #include "MantidDataObjects/Workspace2D.h"
+#include "MantidKernel/UnitFactory.h"
 
 using Mantid::DataHandling::LoadPDFgetNFile;
 using namespace Mantid;
@@ -24,91 +26,68 @@ public:
   static LoadPDFgetNFileTest *createSuite() { return new LoadPDFgetNFileTest(); }
   static void destroySuite(LoadPDFgetNFileTest *suite) { delete suite; }
 
-  /** Test to load .sq file
-   */
-  void test_LoadSqFile() {
-    // 1. Init
+  /// inner functionality for running the algorithm and doing simple checks
+  DataObjects::Workspace2D_sptr runLoadPDFgetNFile(const std::string &datafilename, const std::string &wksp_name,
+                                                   const size_t expNumHist, const std::string &expUnits) {
     LoadPDFgetNFile loader;
     loader.initialize();
     TS_ASSERT(loader.isInitialized());
 
-    // 2. Set property
-    std::string datafilename("NOM_5429.sqa");
-
+    // Set property
     TS_ASSERT_THROWS_NOTHING(loader.setProperty("Filename", datafilename));
-    TS_ASSERT_THROWS_NOTHING(loader.setProperty("OutputWorkspace", "NOM_Sqa"));
+    TS_ASSERT_THROWS_NOTHING(loader.setProperty("OutputWorkspace", wksp_name));
 
-    // 3. Execute
+    // Execute
     TS_ASSERT_THROWS_NOTHING(loader.execute());
     TS_ASSERT(loader.isExecuted());
 
-    // 4.
+    // Get the output
     DataObjects::Workspace2D_sptr outws =
-        std::dynamic_pointer_cast<DataObjects::Workspace2D>(API::AnalysisDataService::Instance().retrieve("NOM_Sqa"));
+        std::dynamic_pointer_cast<DataObjects::Workspace2D>(API::AnalysisDataService::Instance().retrieve(wksp_name));
 
+    // universal checks
     TS_ASSERT(outws);
+    TS_ASSERT_EQUALS(outws->getNumberHistograms(), expNumHist);
+    TS_ASSERT_EQUALS(outws->getAxis(0)->unit()->unitID(), UnitFactory::Instance().create(expUnits)->unitID());
 
-    TS_ASSERT_EQUALS(outws->getNumberHistograms(), 2);
-
-    TS_ASSERT_DELTA(outws->x(0)[2], 0.17986950, 1.0E-8);
+    // Return the workspace
+    return outws;
   }
 
   /** Test to load .sq file
    */
+  void test_LoadSqFile() {
+    // run the algorithm and get the output
+    const std::string OUTPUT_NAME("NOM_Sqa");
+    auto outws = runLoadPDFgetNFile("NOM_5429.sqa", OUTPUT_NAME, 2, "MomentumTransfer");
+
+    // compare the results
+    TS_ASSERT_DELTA(outws->x(0)[2], 0.17986950, 1.0E-8);
+
+    // cleanup
+    AnalysisDataService::Instance().remove(OUTPUT_NAME);
+  }
+
+  /** Test to load .gr file
+   */
   void test_LoadGrFile() {
-    // 1. Init
-    LoadPDFgetNFile loader;
-    loader.initialize();
-    TS_ASSERT(loader.isInitialized());
+    // run the algorithm and get the output
+    const std::string OUTPUT_NAME("NOM_Gr");
+    auto outws = runLoadPDFgetNFile("NOM_5429.gr", OUTPUT_NAME, 1, "AtomicDistance");
 
-    // 2. Set property
-    std::string datafilename("NOM_5429.gr");
-
-    TS_ASSERT_THROWS_NOTHING(loader.setProperty("Filename", datafilename));
-    TS_ASSERT_THROWS_NOTHING(loader.setProperty("OutputWorkspace", "NOM_Gr"));
-
-    // 3. Execute
-    TS_ASSERT_THROWS_NOTHING(loader.execute());
-    TS_ASSERT(loader.isExecuted());
-
-    // 4.
-    DataObjects::Workspace2D_sptr outws =
-        std::dynamic_pointer_cast<DataObjects::Workspace2D>(API::AnalysisDataService::Instance().retrieve("NOM_Gr"));
-
-    TS_ASSERT(outws);
-
-    TS_ASSERT_EQUALS(outws->getNumberHistograms(), 1);
+    // cleanup
+    AnalysisDataService::Instance().remove(OUTPUT_NAME);
   }
 
   /** Test to load .bsmo file.
    * .bsmo and .braw file record Q in descending order.
    */
   void test_LoadBackgroundFile() {
-    // 1. Init
-    LoadPDFgetNFile loader;
-    loader.initialize();
-    TS_ASSERT(loader.isInitialized());
+    // run the algorithm and get the output
+    const std::string OUTPUT_NAME("NOM_SmoothBackground");
+    auto outws = runLoadPDFgetNFile("NOM_5429.bsmo", OUTPUT_NAME, 2, "MomentumTransfer");
 
-    // 2. Set property
-    std::string datafilename("NOM_5429.bsmo");
-
-    TS_ASSERT_THROWS_NOTHING(loader.setProperty("Filename", datafilename));
-    TS_ASSERT_THROWS_NOTHING(loader.setProperty("OutputWorkspace", "NOM_SmoothBackground"));
-
-    // 3. Execute
-    TS_ASSERT_THROWS_NOTHING(loader.execute());
-    TS_ASSERT(loader.isExecuted());
-
-    // 4.
-    DataObjects::Workspace2D_sptr outws = std::dynamic_pointer_cast<DataObjects::Workspace2D>(
-        API::AnalysisDataService::Instance().retrieve("NOM_SmoothBackground"));
-
-    TS_ASSERT(outws);
-
-    TS_ASSERT_EQUALS(outws->getNumberHistograms(), 2);
-
-    AnalysisDataService::Instance().remove("NOM_SmoothBackground");
-
-    return;
+    // cleanup
+    AnalysisDataService::Instance().remove(OUTPUT_NAME);
   }
 };

--- a/docs/source/release/v6.3.0/diffraction.rst
+++ b/docs/source/release/v6.3.0/diffraction.rst
@@ -27,6 +27,7 @@ Bugfixes
 ########
 - For processing vanadium run, we don't want to find environment automatically in :ref:`SetSampleFromLogs <algm-SetSampleFromLogs>`.
 - Identification in :ref:`AlignComponents <algm-AlignComponents>` of the first and last detector-ID for an instrument component with unsorted detector-ID's.
+- :ref:`LoadPDFgetNFile <algm-LoadPDFgetNFile>` now returns standard units for atomic distance rather than label
 - Fix issue in :ref:`WANDPowderReduction <algm-WANDPowderReduction>` where in some cases you end up with zeros as output.
 
 Engineering Diffraction


### PR DESCRIPTION
The difference between old and new is small, but the corrected version uses the proper `Kernel::Unit` rather than creating a string/label. Also modernization of the unit tests and added check for units.

**To test:**

The unit test now exercises the correct behavior. TDD for the win!

*There is no associated issue.*

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
