### PR TITLE
Fix flaky test for EnggEstimateFocusedBackground

### DIFF
--- a/Framework/PythonInterface/test/python/plugins/algorithms/EnggEstimateFocussedBackgroundTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/EnggEstimateFocussedBackgroundTest.py
@@ -28,13 +28,14 @@ class EnggEstimateFocussedBackground_Test(unittest.TestCase):
     def setUp(self):
         # create some fairly realistic fake data with peaks and background
         x = np.linspace(0, 160, 401)
-        mask = np.ones(x.shape, dtype=bool)
         cens = [60, 70, 100]
+        mask = np.ones(x.shape, dtype=bool)
+        mask[(x > cens[0] - 4) & (x < cens[-1] + 4)] = False  # mask that includes xvalues at each end (away from peaks)
         pin = []
         for ipk in range(0, len(cens)):
             pin += [3, cens[ipk], 1]  # height, centre, sig
-            mask[(x > cens[ipk] - 4) & (x < cens[ipk] + 4)] = False  # mask points at peak for comparing bg residuals
         pin += [3, 80, 20]  # broad peak as background
+
         y = mgauss(x, pin)
         self.ws = CreateWorkspace(OutputWorkspace = 'ws', DataX=x, DataY=y + np.random.normal(y, 0.2 * np.sqrt(y)))
         self.mask = mask

--- a/Framework/PythonInterface/test/python/plugins/algorithms/EnggEstimateFocussedBackgroundTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/EnggEstimateFocussedBackgroundTest.py
@@ -37,7 +37,8 @@ class EnggEstimateFocussedBackground_Test(unittest.TestCase):
         pin += [3, 80, 20]  # broad peak as background
 
         y = mgauss(x, pin)
-        self.ws = CreateWorkspace(OutputWorkspace = 'ws', DataX=x, DataY=y + np.random.normal(y, 0.2 * np.sqrt(y)))
+        np.random.seed(0)
+        self.ws = CreateWorkspace(OutputWorkspace='ws', DataX=x, DataY=y + np.random.normal(y, 0.2 * np.sqrt(y)))
         self.mask = mask
 
     def tearDown(self):
@@ -50,8 +51,8 @@ class EnggEstimateFocussedBackground_Test(unittest.TestCase):
         ws_diff = self.ws - ws_bg
 
         # test residuals to ensure background is well approximated
-        self.assertAlmostEqual(np.mean(ws_diff.readY(0)[self.mask]), 0, delta=0.04)
-        self.assertAlmostEqual(np.median(ws_diff.readY(0)[self.mask]), 0, delta=0.02)
+        self.assertAlmostEqual(np.mean(ws_diff.readY(0)[self.mask]), 0, delta=0.01)
+        self.assertAlmostEqual(np.median(ws_diff.readY(0)[self.mask]), 0, delta=0.01)
 
     def test_window_validation(self):
         # test too small a window


### PR DESCRIPTION
**Description of work.**

Couple of improvements to fix flaky test
- Added seed for random noise on simulated data
- Adjusted mask to exclude a region where we would expect bg estimation to be poor (see picture below)

![image](https://user-images.githubusercontent.com/55979119/148084739-2716a101-0a0d-49ed-90dd-810d2752236d.png)

Successive iterative smoothing will cause the height of the central background peak to be underestimated - so now only evaluate background at the end of the data. Note that the old and new simulated data are different because the seed wasn't specified!

**To test:**

(1) Run test locally and check it passes

*There is no associated issue.*

*This does not require release notes* because **change to unit test only**


<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
