### PR TITLE
Remove qApplication from muon tests.

### DIFF
--- a/qt/python/mantidqtinterfaces/test/Muon/corrections_tab_widget/background_corrections_view_test.py
+++ b/qt/python/mantidqtinterfaces/test/Muon/corrections_tab_widget/background_corrections_view_test.py
@@ -23,8 +23,6 @@ from mantidqtinterfaces.Muon.GUI.Common.corrections_tab_widget.background_correc
                                                                                                    STATUS_COLUMN_INDEX,
                                                                                                    SHOW_MATRIX_COLUMN_INDEX)
 
-from qtpy.QtWidgets import QApplication
-
 
 @start_qapplication
 class BackgroundCorrectionsViewTest(unittest.TestCase, QtWidgetFinder):
@@ -47,7 +45,6 @@ class BackgroundCorrectionsViewTest(unittest.TestCase, QtWidgetFinder):
 
     def tearDown(self):
         self.assertTrue(self.view.close())
-        QApplication.sendPostedEvents()
 
     def test_that_the_view_has_been_initialized_with_most_background_correction_options_invisible(self):
         self.assertTrue(self.view.select_function_label.isHidden())

--- a/qt/python/mantidqtinterfaces/test/Muon/corrections_tab_widget/background_corrections_view_test.py
+++ b/qt/python/mantidqtinterfaces/test/Muon/corrections_tab_widget/background_corrections_view_test.py
@@ -10,7 +10,6 @@ from qtpy.QtTest import QTest
 from qtpy.QtCore import Qt, QPoint
 
 from mantidqt.utils.qt.testing import start_qapplication
-from mantidqt.utils.qt.testing.qt_widget_finder import QtWidgetFinder
 
 from mantidqtinterfaces.Muon.GUI.Common.corrections_tab_widget.background_corrections_view import (BackgroundCorrectionsView,
                                                                                                    RUN_COLUMN_INDEX,
@@ -25,12 +24,11 @@ from mantidqtinterfaces.Muon.GUI.Common.corrections_tab_widget.background_correc
 
 
 @start_qapplication
-class BackgroundCorrectionsViewTest(unittest.TestCase, QtWidgetFinder):
+class BackgroundCorrectionsViewTest(unittest.TestCase):
 
     def setUp(self):
         self.view = BackgroundCorrectionsView()
         self.view.show()
-        self.assert_widget_created()
 
         self.runs = ["84447", "84447", "84447", "84447"]
         self.groups = ["fwd", "bwd", "top", "bottom"]

--- a/qt/python/mantidqtinterfaces/test/Muon/corrections_tab_widget/corrections_view_test.py
+++ b/qt/python/mantidqtinterfaces/test/Muon/corrections_tab_widget/corrections_view_test.py
@@ -11,8 +11,6 @@ from mantidqt.utils.qt.testing.qt_widget_finder import QtWidgetFinder
 
 from mantidqtinterfaces.Muon.GUI.Common.corrections_tab_widget.corrections_view import CorrectionsView
 
-from qtpy.QtWidgets import QApplication
-
 
 @start_qapplication
 class CorrectionsViewTest(unittest.TestCase, QtWidgetFinder):
@@ -24,7 +22,6 @@ class CorrectionsViewTest(unittest.TestCase, QtWidgetFinder):
 
     def tearDown(self):
         self.assertTrue(self.view.close())
-        QApplication.sendPostedEvents()
 
     def test_that_the_view_is_disabled_when_initialized(self):
         self.assertTrue(not self.view.isEnabled())

--- a/qt/python/mantidqtinterfaces/test/Muon/corrections_tab_widget/corrections_view_test.py
+++ b/qt/python/mantidqtinterfaces/test/Muon/corrections_tab_widget/corrections_view_test.py
@@ -7,18 +7,16 @@
 import unittest
 
 from mantidqt.utils.qt.testing import start_qapplication
-from mantidqt.utils.qt.testing.qt_widget_finder import QtWidgetFinder
 
 from mantidqtinterfaces.Muon.GUI.Common.corrections_tab_widget.corrections_view import CorrectionsView
 
 
 @start_qapplication
-class CorrectionsViewTest(unittest.TestCase, QtWidgetFinder):
+class CorrectionsViewTest(unittest.TestCase):
 
     def setUp(self):
         self.view = CorrectionsView()
         self.view.show()
-        self.assert_widget_created()
 
     def tearDown(self):
         self.assertTrue(self.view.close())

--- a/qt/python/mantidqtinterfaces/test/Muon/corrections_tab_widget/dead_time_corrections_view_test.py
+++ b/qt/python/mantidqtinterfaces/test/Muon/corrections_tab_widget/dead_time_corrections_view_test.py
@@ -7,18 +7,16 @@
 import unittest
 
 from mantidqt.utils.qt.testing import start_qapplication
-from mantidqt.utils.qt.testing.qt_widget_finder import QtWidgetFinder
 
 from mantidqtinterfaces.Muon.GUI.Common.corrections_tab_widget.dead_time_corrections_view import DeadTimeCorrectionsView
 
 
 @start_qapplication
-class DeadTimeCorrectionsViewTest(unittest.TestCase, QtWidgetFinder):
+class DeadTimeCorrectionsViewTest(unittest.TestCase):
 
     def setUp(self):
         self.view = DeadTimeCorrectionsView()
         self.view.show()
-        self.assert_widget_created()
 
     def tearDown(self):
         self.assertTrue(self.view.close())

--- a/qt/python/mantidqtinterfaces/test/Muon/corrections_tab_widget/dead_time_corrections_view_test.py
+++ b/qt/python/mantidqtinterfaces/test/Muon/corrections_tab_widget/dead_time_corrections_view_test.py
@@ -11,8 +11,6 @@ from mantidqt.utils.qt.testing.qt_widget_finder import QtWidgetFinder
 
 from mantidqtinterfaces.Muon.GUI.Common.corrections_tab_widget.dead_time_corrections_view import DeadTimeCorrectionsView
 
-from qtpy.QtWidgets import QApplication
-
 
 @start_qapplication
 class DeadTimeCorrectionsViewTest(unittest.TestCase, QtWidgetFinder):
@@ -24,7 +22,6 @@ class DeadTimeCorrectionsViewTest(unittest.TestCase, QtWidgetFinder):
 
     def tearDown(self):
         self.assertTrue(self.view.close())
-        QApplication.sendPostedEvents()
 
     def test_that_the_view_has_been_initialized_with_the_workspace_selector_and_other_file_options_invisible(self):
         self.assertTrue(self.view.dead_time_workspace_label.isHidden())

--- a/qt/python/mantidqtinterfaces/test/Muon/data_selectors/cyclic_data_selector_view_test.py
+++ b/qt/python/mantidqtinterfaces/test/Muon/data_selectors/cyclic_data_selector_view_test.py
@@ -11,8 +11,6 @@ from mantidqt.utils.qt.testing.qt_widget_finder import QtWidgetFinder
 
 from mantidqtinterfaces.Muon.GUI.Common.data_selectors.cyclic_data_selector_view import CyclicDataSelectorView
 
-from qtpy.QtWidgets import QApplication
-
 
 @start_qapplication
 class CyclicDataSelectorViewTest(unittest.TestCase, QtWidgetFinder):
@@ -24,7 +22,6 @@ class CyclicDataSelectorViewTest(unittest.TestCase, QtWidgetFinder):
 
     def tearDown(self):
         self.assertTrue(self.view.close())
-        QApplication.sendPostedEvents()
 
     def test_that_update_dataset_name_combo_box_will_set_the_names_in_the_dataset_name_combobox(self):
         dataset_names = ["Name1", "Name2", "Name3"]

--- a/qt/python/mantidqtinterfaces/test/Muon/data_selectors/cyclic_data_selector_view_test.py
+++ b/qt/python/mantidqtinterfaces/test/Muon/data_selectors/cyclic_data_selector_view_test.py
@@ -7,18 +7,16 @@
 import unittest
 
 from mantidqt.utils.qt.testing import start_qapplication
-from mantidqt.utils.qt.testing.qt_widget_finder import QtWidgetFinder
 
 from mantidqtinterfaces.Muon.GUI.Common.data_selectors.cyclic_data_selector_view import CyclicDataSelectorView
 
 
 @start_qapplication
-class CyclicDataSelectorViewTest(unittest.TestCase, QtWidgetFinder):
+class CyclicDataSelectorViewTest(unittest.TestCase):
 
     def setUp(self):
         self.view = CyclicDataSelectorView()
         self.view.show()
-        self.assert_widget_created()
 
     def tearDown(self):
         self.assertTrue(self.view.close())

--- a/qt/python/mantidqtinterfaces/test/Muon/elemental_analysis_2/EA_loading_tab/elemental_analysis_loadrun_presenter_increment_decrement_test.py
+++ b/qt/python/mantidqtinterfaces/test/Muon/elemental_analysis_2/EA_loading_tab/elemental_analysis_loadrun_presenter_increment_decrement_test.py
@@ -21,7 +21,6 @@ class LoadRunWidgetIncrementDecrementSingleFileModeTest(unittest.TestCase):
     def wait_for_thread(self, thread_model):
         if thread_model and thread_model.worker:
             while thread_model.worker.is_alive():
-                QApplication.sendPostedEvents()
                 time.sleep(0.1)
             QApplication.sendPostedEvents()
 

--- a/qt/python/mantidqtinterfaces/test/Muon/elemental_analysis_2/EA_loading_tab/elemental_analysis_loadrun_presenter_single_run_test.py
+++ b/qt/python/mantidqtinterfaces/test/Muon/elemental_analysis_2/EA_loading_tab/elemental_analysis_loadrun_presenter_single_run_test.py
@@ -22,7 +22,6 @@ class LoadRunWidgetPresenterTest(unittest.TestCase):
     def wait_for_thread(self, thread_model):
         if thread_model and thread_model.worker:
             while thread_model.worker.is_alive():
-                QApplication.sendPostedEvents()
                 time.sleep(0.1)
             QApplication.sendPostedEvents()
 

--- a/qt/python/mantidqtinterfaces/test/Muon/fitting_widgets/basic_fitting/basic_fitting_view_test.py
+++ b/qt/python/mantidqtinterfaces/test/Muon/fitting_widgets/basic_fitting/basic_fitting_view_test.py
@@ -8,7 +8,6 @@ import unittest
 
 from mantid.api import FrameworkManager
 from mantidqt.utils.qt.testing import start_qapplication
-from mantidqt.utils.qt.testing.qt_widget_finder import QtWidgetFinder
 
 from mantidqtinterfaces.Muon.GUI.Common.fitting_widgets.basic_fitting.basic_fitting_view import BasicFittingView
 from mantidqtinterfaces.Muon.GUI.Common.fitting_widgets.basic_fitting.fit_function_options_view import (EVALUATE_AS_TABLE_ROW,
@@ -22,7 +21,7 @@ from mantidqtinterfaces.Muon.GUI.Common.fitting_widgets.basic_fitting.fit_functi
 
 
 @start_qapplication
-class BasicFittingViewTest(unittest.TestCase, QtWidgetFinder):
+class BasicFittingViewTest(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
@@ -32,7 +31,6 @@ class BasicFittingViewTest(unittest.TestCase, QtWidgetFinder):
         self.dataset_names = ["MUSR62260; Group; fwd; Asymmetry; MA", "MUSR62260; Group; bwd; Asymmetry; MA"]
         self.view = BasicFittingView()
         self.view.show()
-        self.assert_widget_created()
 
     def tearDown(self):
         self.assertTrue(self.view.close())

--- a/qt/python/mantidqtinterfaces/test/Muon/fitting_widgets/basic_fitting/basic_fitting_view_test.py
+++ b/qt/python/mantidqtinterfaces/test/Muon/fitting_widgets/basic_fitting/basic_fitting_view_test.py
@@ -20,8 +20,6 @@ from mantidqtinterfaces.Muon.GUI.Common.fitting_widgets.basic_fitting.fit_functi
                                                                                                         PLOT_GUESS_START_X,
                                                                                                         PLOT_GUESS_END_X)
 
-from qtpy.QtWidgets import QApplication
-
 
 @start_qapplication
 class BasicFittingViewTest(unittest.TestCase, QtWidgetFinder):
@@ -38,7 +36,6 @@ class BasicFittingViewTest(unittest.TestCase, QtWidgetFinder):
 
     def tearDown(self):
         self.assertTrue(self.view.close())
-        QApplication.sendPostedEvents()
 
     def test_that_the_plot_guess_checkbox_can_be_ticked_as_expected(self):
         self.view.plot_guess = True

--- a/qt/python/mantidqtinterfaces/test/Muon/fitting_widgets/basic_fitting/fit_controls_view_test.py
+++ b/qt/python/mantidqtinterfaces/test/Muon/fitting_widgets/basic_fitting/fit_controls_view_test.py
@@ -7,18 +7,16 @@
 import unittest
 
 from mantidqt.utils.qt.testing import start_qapplication
-from mantidqt.utils.qt.testing.qt_widget_finder import QtWidgetFinder
 
 from mantidqtinterfaces.Muon.GUI.Common.fitting_widgets.basic_fitting.fit_controls_view import FitControlsView
 
 
 @start_qapplication
-class FitControlsViewTest(unittest.TestCase, QtWidgetFinder):
+class FitControlsViewTest(unittest.TestCase):
 
     def setUp(self):
         self.view = FitControlsView()
         self.view.show()
-        self.assert_widget_created()
 
     def tearDown(self):
         self.assertTrue(self.view.close())

--- a/qt/python/mantidqtinterfaces/test/Muon/fitting_widgets/basic_fitting/fit_controls_view_test.py
+++ b/qt/python/mantidqtinterfaces/test/Muon/fitting_widgets/basic_fitting/fit_controls_view_test.py
@@ -11,8 +11,6 @@ from mantidqt.utils.qt.testing.qt_widget_finder import QtWidgetFinder
 
 from mantidqtinterfaces.Muon.GUI.Common.fitting_widgets.basic_fitting.fit_controls_view import FitControlsView
 
-from qtpy.QtWidgets import QApplication
-
 
 @start_qapplication
 class FitControlsViewTest(unittest.TestCase, QtWidgetFinder):
@@ -24,7 +22,6 @@ class FitControlsViewTest(unittest.TestCase, QtWidgetFinder):
 
     def tearDown(self):
         self.assertTrue(self.view.close())
-        QApplication.sendPostedEvents()
 
     def test_that_the_view_has_been_initialized_with_the_undo_fit_button_disabled_and_plot_guess_unchecked(self):
         self.assertTrue(not self.view.undo_fit_button.isEnabled())

--- a/qt/python/mantidqtinterfaces/test/Muon/fitting_widgets/basic_fitting/fit_function_options_view_test.py
+++ b/qt/python/mantidqtinterfaces/test/Muon/fitting_widgets/basic_fitting/fit_function_options_view_test.py
@@ -15,8 +15,6 @@ from mantidqtinterfaces.Muon.GUI.Common.fitting_widgets.basic_fitting.fit_functi
                                                                                                         RAW_DATA_TABLE_ROW)
 from mantidqtinterfaces.Muon.GUI.Common.utilities.workspace_utils import StaticWorkspaceWrapper
 
-from qtpy.QtWidgets import QApplication
-
 
 @start_qapplication
 class FitFunctionOptionsViewTest(unittest.TestCase, QtWidgetFinder):
@@ -32,7 +30,6 @@ class FitFunctionOptionsViewTest(unittest.TestCase, QtWidgetFinder):
 
     def tearDown(self):
         self.assertTrue(self.view.close())
-        QApplication.sendPostedEvents()
 
     def test_that_the_view_has_been_initialized_with_the_raw_data_option_shown(self):
         self.view = FitFunctionOptionsView()

--- a/qt/python/mantidqtinterfaces/test/Muon/fitting_widgets/basic_fitting/fit_function_options_view_test.py
+++ b/qt/python/mantidqtinterfaces/test/Muon/fitting_widgets/basic_fitting/fit_function_options_view_test.py
@@ -9,7 +9,6 @@ import unittest
 from mantid.api import FrameworkManager, FunctionFactory
 from mantid.simpleapi import CreateEmptyTableWorkspace
 from mantidqt.utils.qt.testing import start_qapplication
-from mantidqt.utils.qt.testing.qt_widget_finder import QtWidgetFinder
 
 from mantidqtinterfaces.Muon.GUI.Common.fitting_widgets.basic_fitting.fit_function_options_view import (FitFunctionOptionsView,
                                                                                                         RAW_DATA_TABLE_ROW)
@@ -17,7 +16,7 @@ from mantidqtinterfaces.Muon.GUI.Common.utilities.workspace_utils import StaticW
 
 
 @start_qapplication
-class FitFunctionOptionsViewTest(unittest.TestCase, QtWidgetFinder):
+class FitFunctionOptionsViewTest(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
@@ -26,7 +25,6 @@ class FitFunctionOptionsViewTest(unittest.TestCase, QtWidgetFinder):
     def setUp(self):
         self.view = FitFunctionOptionsView()
         self.view.show()
-        self.assert_widget_created()
 
     def tearDown(self):
         self.assertTrue(self.view.close())

--- a/qt/python/mantidqtinterfaces/test/Muon/fitting_widgets/general_fitting/general_fitting_options_view_test.py
+++ b/qt/python/mantidqtinterfaces/test/Muon/fitting_widgets/general_fitting/general_fitting_options_view_test.py
@@ -11,8 +11,6 @@ from mantidqt.utils.qt.testing.qt_widget_finder import QtWidgetFinder
 
 from mantidqtinterfaces.Muon.GUI.Common.fitting_widgets.general_fitting.general_fitting_options_view import GeneralFittingOptionsView
 
-from qtpy.QtWidgets import QApplication
-
 
 @start_qapplication
 class GeneralFittingOptionsViewTest(unittest.TestCase, QtWidgetFinder):
@@ -24,7 +22,6 @@ class GeneralFittingOptionsViewTest(unittest.TestCase, QtWidgetFinder):
 
     def tearDown(self):
         self.assertTrue(self.view.close())
-        QApplication.sendPostedEvents()
 
     def test_that_the_view_can_be_initialized_without_an_error(self):
         self.view = GeneralFittingOptionsView()

--- a/qt/python/mantidqtinterfaces/test/Muon/fitting_widgets/general_fitting/general_fitting_options_view_test.py
+++ b/qt/python/mantidqtinterfaces/test/Muon/fitting_widgets/general_fitting/general_fitting_options_view_test.py
@@ -7,18 +7,16 @@
 import unittest
 
 from mantidqt.utils.qt.testing import start_qapplication
-from mantidqt.utils.qt.testing.qt_widget_finder import QtWidgetFinder
 
 from mantidqtinterfaces.Muon.GUI.Common.fitting_widgets.general_fitting.general_fitting_options_view import GeneralFittingOptionsView
 
 
 @start_qapplication
-class GeneralFittingOptionsViewTest(unittest.TestCase, QtWidgetFinder):
+class GeneralFittingOptionsViewTest(unittest.TestCase):
 
     def setUp(self):
         self.view = GeneralFittingOptionsView()
         self.view.show()
-        self.assert_widget_created()
 
     def tearDown(self):
         self.assertTrue(self.view.close())

--- a/qt/python/mantidqtinterfaces/test/Muon/fitting_widgets/general_fitting/general_fitting_view_test.py
+++ b/qt/python/mantidqtinterfaces/test/Muon/fitting_widgets/general_fitting/general_fitting_view_test.py
@@ -13,8 +13,6 @@ from mantidqtinterfaces.Muon.GUI.Common.fitting_widgets.general_fitting.general_
                                                                                                      SIMULTANEOUS_FIT_LABEL,
                                                                                                      SINGLE_FIT_LABEL)
 
-from qtpy.QtWidgets import QApplication
-
 
 @start_qapplication
 class GeneralFittingViewTest(unittest.TestCase, QtWidgetFinder):
@@ -25,7 +23,6 @@ class GeneralFittingViewTest(unittest.TestCase, QtWidgetFinder):
 
     def tearDown(self):
         self.assertTrue(self.view.close())
-        QApplication.sendPostedEvents()
 
     def test_that_the_view_can_be_initialized_without_an_error(self):
         self.view = GeneralFittingView()

--- a/qt/python/mantidqtinterfaces/test/Muon/fitting_widgets/general_fitting/general_fitting_view_test.py
+++ b/qt/python/mantidqtinterfaces/test/Muon/fitting_widgets/general_fitting/general_fitting_view_test.py
@@ -7,7 +7,6 @@
 import unittest
 
 from mantidqt.utils.qt.testing import start_qapplication
-from mantidqt.utils.qt.testing.qt_widget_finder import QtWidgetFinder
 
 from mantidqtinterfaces.Muon.GUI.Common.fitting_widgets.general_fitting.general_fitting_view import (GeneralFittingView,
                                                                                                      SIMULTANEOUS_FIT_LABEL,
@@ -15,11 +14,10 @@ from mantidqtinterfaces.Muon.GUI.Common.fitting_widgets.general_fitting.general_
 
 
 @start_qapplication
-class GeneralFittingViewTest(unittest.TestCase, QtWidgetFinder):
+class GeneralFittingViewTest(unittest.TestCase):
 
     def setUp(self):
         self.view = GeneralFittingView()
-        self.assert_widget_created()
 
     def tearDown(self):
         self.assertTrue(self.view.close())

--- a/qt/python/mantidqtinterfaces/test/Muon/fitting_widgets/model_fitting/model_fitting_data_selector_view_test.py
+++ b/qt/python/mantidqtinterfaces/test/Muon/fitting_widgets/model_fitting/model_fitting_data_selector_view_test.py
@@ -12,8 +12,6 @@ from mantidqt.utils.qt.testing.qt_widget_finder import QtWidgetFinder
 from mantidqtinterfaces.Muon.GUI.Common.fitting_widgets.model_fitting.model_fitting_data_selector_view import ModelFittingDataSelectorView
 from mantidqtinterfaces.Muon.GUI.Common.results_tab_widget.results_tab_model import TableColumnType
 
-from qtpy.QtWidgets import QApplication
-
 
 @start_qapplication
 class ModelFittingDataSelectorViewTest(unittest.TestCase, QtWidgetFinder):
@@ -25,7 +23,6 @@ class ModelFittingDataSelectorViewTest(unittest.TestCase, QtWidgetFinder):
 
     def tearDown(self):
         self.assertTrue(self.view.close())
-        QApplication.sendPostedEvents()
 
     def test_that_update_result_table_names_will_set_the_names_in_the_result_table_names_combobox(self):
         result_table_names = ["Name1", "Name2", "Name3"]

--- a/qt/python/mantidqtinterfaces/test/Muon/fitting_widgets/model_fitting/model_fitting_data_selector_view_test.py
+++ b/qt/python/mantidqtinterfaces/test/Muon/fitting_widgets/model_fitting/model_fitting_data_selector_view_test.py
@@ -7,19 +7,17 @@
 import unittest
 
 from mantidqt.utils.qt.testing import start_qapplication
-from mantidqt.utils.qt.testing.qt_widget_finder import QtWidgetFinder
 
 from mantidqtinterfaces.Muon.GUI.Common.fitting_widgets.model_fitting.model_fitting_data_selector_view import ModelFittingDataSelectorView
 from mantidqtinterfaces.Muon.GUI.Common.results_tab_widget.results_tab_model import TableColumnType
 
 
 @start_qapplication
-class ModelFittingDataSelectorViewTest(unittest.TestCase, QtWidgetFinder):
+class ModelFittingDataSelectorViewTest(unittest.TestCase):
 
     def setUp(self):
         self.view = ModelFittingDataSelectorView()
         self.view.show()
-        self.assert_widget_created()
 
     def tearDown(self):
         self.assertTrue(self.view.close())

--- a/qt/python/mantidqtinterfaces/test/Muon/fitting_widgets/model_fitting/model_fitting_view_test.py
+++ b/qt/python/mantidqtinterfaces/test/Muon/fitting_widgets/model_fitting/model_fitting_view_test.py
@@ -12,8 +12,6 @@ from mantidqt.utils.qt.testing.qt_widget_finder import QtWidgetFinder
 from mantidqtinterfaces.Muon.GUI.Common.fitting_widgets.model_fitting.model_fitting_view import ModelFittingView
 from mantidqtinterfaces.Muon.GUI.Common.results_tab_widget.results_tab_model import TableColumnType
 
-from qtpy.QtWidgets import QApplication
-
 
 @start_qapplication
 class ModelFittingViewTest(unittest.TestCase, QtWidgetFinder):
@@ -25,7 +23,6 @@ class ModelFittingViewTest(unittest.TestCase, QtWidgetFinder):
 
     def tearDown(self):
         self.assertTrue(self.view.close())
-        QApplication.sendPostedEvents()
 
     def test_that_the_dataset_workspace_selector_is_hidden_by_default(self):
         self.assertTrue(self.view.workspace_selector.isHidden())

--- a/qt/python/mantidqtinterfaces/test/Muon/fitting_widgets/model_fitting/model_fitting_view_test.py
+++ b/qt/python/mantidqtinterfaces/test/Muon/fitting_widgets/model_fitting/model_fitting_view_test.py
@@ -7,19 +7,17 @@
 import unittest
 
 from mantidqt.utils.qt.testing import start_qapplication
-from mantidqt.utils.qt.testing.qt_widget_finder import QtWidgetFinder
 
 from mantidqtinterfaces.Muon.GUI.Common.fitting_widgets.model_fitting.model_fitting_view import ModelFittingView
 from mantidqtinterfaces.Muon.GUI.Common.results_tab_widget.results_tab_model import TableColumnType
 
 
 @start_qapplication
-class ModelFittingViewTest(unittest.TestCase, QtWidgetFinder):
+class ModelFittingViewTest(unittest.TestCase):
 
     def setUp(self):
         self.view = ModelFittingView()
         self.view.show()
-        self.assert_widget_created()
 
     def tearDown(self):
         self.assertTrue(self.view.close())

--- a/qt/python/mantidqtinterfaces/test/Muon/fitting_widgets/tf_asymmetry_fitting/tf_asymmetry_fitting_options_view_test.py
+++ b/qt/python/mantidqtinterfaces/test/Muon/fitting_widgets/tf_asymmetry_fitting/tf_asymmetry_fitting_options_view_test.py
@@ -13,8 +13,6 @@ from mantidqt.utils.qt.testing.qt_widget_finder import QtWidgetFinder
 from mantidqtinterfaces.Muon.GUI.Common.fitting_widgets.tf_asymmetry_fitting.tf_asymmetry_fitting_options_view import \
     TFAsymmetryFittingOptionsView
 
-from qtpy.QtWidgets import QApplication
-
 
 @start_qapplication
 class TFAsymmetryFittingOptionsViewTest(unittest.TestCase, QtWidgetFinder):
@@ -26,7 +24,6 @@ class TFAsymmetryFittingOptionsViewTest(unittest.TestCase, QtWidgetFinder):
 
     def tearDown(self):
         self.assertTrue(self.view.close())
-        QApplication.sendPostedEvents()
 
     def test_that_the_view_has_been_initialized_with_a_normalisation_line_edit_which_has_a_validator(self):
         self.assertTrue(isinstance(self.view.normalisation_line_edit.validator(), LineEditDoubleValidator))

--- a/qt/python/mantidqtinterfaces/test/Muon/fitting_widgets/tf_asymmetry_fitting/tf_asymmetry_fitting_options_view_test.py
+++ b/qt/python/mantidqtinterfaces/test/Muon/fitting_widgets/tf_asymmetry_fitting/tf_asymmetry_fitting_options_view_test.py
@@ -8,19 +8,17 @@ import unittest
 
 from mantidqt.utils.qt.line_edit_double_validator import LineEditDoubleValidator
 from mantidqt.utils.qt.testing import start_qapplication
-from mantidqt.utils.qt.testing.qt_widget_finder import QtWidgetFinder
 
 from mantidqtinterfaces.Muon.GUI.Common.fitting_widgets.tf_asymmetry_fitting.tf_asymmetry_fitting_options_view import \
     TFAsymmetryFittingOptionsView
 
 
 @start_qapplication
-class TFAsymmetryFittingOptionsViewTest(unittest.TestCase, QtWidgetFinder):
+class TFAsymmetryFittingOptionsViewTest(unittest.TestCase):
 
     def setUp(self):
         self.view = TFAsymmetryFittingOptionsView()
         self.view.show()
-        self.assert_widget_created()
 
     def tearDown(self):
         self.assertTrue(self.view.close())

--- a/qt/python/mantidqtinterfaces/test/Muon/fitting_widgets/tf_asymmetry_fitting/tf_asymmetry_fitting_view_test.py
+++ b/qt/python/mantidqtinterfaces/test/Muon/fitting_widgets/tf_asymmetry_fitting/tf_asymmetry_fitting_view_test.py
@@ -7,18 +7,16 @@
 import unittest
 
 from mantidqt.utils.qt.testing import start_qapplication
-from mantidqt.utils.qt.testing.qt_widget_finder import QtWidgetFinder
 
 from mantidqtinterfaces.Muon.GUI.Common.fitting_widgets.tf_asymmetry_fitting.tf_asymmetry_fitting_view import TFAsymmetryFittingView
 
 
 @start_qapplication
-class TFAsymmetryFittingViewTest(unittest.TestCase, QtWidgetFinder):
+class TFAsymmetryFittingViewTest(unittest.TestCase):
 
     def setUp(self):
         self.view = TFAsymmetryFittingView()
         self.view.show()
-        self.assert_widget_created()
 
     def tearDown(self):
         self.assertTrue(self.view.close())

--- a/qt/python/mantidqtinterfaces/test/Muon/fitting_widgets/tf_asymmetry_fitting/tf_asymmetry_fitting_view_test.py
+++ b/qt/python/mantidqtinterfaces/test/Muon/fitting_widgets/tf_asymmetry_fitting/tf_asymmetry_fitting_view_test.py
@@ -11,8 +11,6 @@ from mantidqt.utils.qt.testing.qt_widget_finder import QtWidgetFinder
 
 from mantidqtinterfaces.Muon.GUI.Common.fitting_widgets.tf_asymmetry_fitting.tf_asymmetry_fitting_view import TFAsymmetryFittingView
 
-from qtpy.QtWidgets import QApplication
-
 
 @start_qapplication
 class TFAsymmetryFittingViewTest(unittest.TestCase, QtWidgetFinder):
@@ -24,7 +22,6 @@ class TFAsymmetryFittingViewTest(unittest.TestCase, QtWidgetFinder):
 
     def tearDown(self):
         self.assertTrue(self.view.close())
-        QApplication.sendPostedEvents()
 
     def test_that_the_view_has_been_initialized_with_the_tf_asymmetry_mode_turned_off_and_the_relevant_widgets_hidden(self):
         self.assertTrue(not self.view.tf_asymmetry_mode)

--- a/qt/python/mantidqtinterfaces/test/Muon/fitting_widgets/tf_asymmetry_fitting/tf_asymmetry_mode_switcher_view_test.py
+++ b/qt/python/mantidqtinterfaces/test/Muon/fitting_widgets/tf_asymmetry_fitting/tf_asymmetry_mode_switcher_view_test.py
@@ -7,19 +7,17 @@
 import unittest
 
 from mantidqt.utils.qt.testing import start_qapplication
-from mantidqt.utils.qt.testing.qt_widget_finder import QtWidgetFinder
 
 from mantidqtinterfaces.Muon.GUI.Common.fitting_widgets.tf_asymmetry_fitting.tf_asymmetry_mode_switcher_view import \
     TFAsymmetryModeSwitcherView
 
 
 @start_qapplication
-class TFAsymmetryModeSwitcherViewTest(unittest.TestCase, QtWidgetFinder):
+class TFAsymmetryModeSwitcherViewTest(unittest.TestCase):
 
     def setUp(self):
         self.view = TFAsymmetryModeSwitcherView()
         self.view.show()
-        self.assert_widget_created()
 
     def tearDown(self):
         self.assertTrue(self.view.close())

--- a/qt/python/mantidqtinterfaces/test/Muon/fitting_widgets/tf_asymmetry_fitting/tf_asymmetry_mode_switcher_view_test.py
+++ b/qt/python/mantidqtinterfaces/test/Muon/fitting_widgets/tf_asymmetry_fitting/tf_asymmetry_mode_switcher_view_test.py
@@ -12,8 +12,6 @@ from mantidqt.utils.qt.testing.qt_widget_finder import QtWidgetFinder
 from mantidqtinterfaces.Muon.GUI.Common.fitting_widgets.tf_asymmetry_fitting.tf_asymmetry_mode_switcher_view import \
     TFAsymmetryModeSwitcherView
 
-from qtpy.QtWidgets import QApplication
-
 
 @start_qapplication
 class TFAsymmetryModeSwitcherViewTest(unittest.TestCase, QtWidgetFinder):
@@ -25,7 +23,6 @@ class TFAsymmetryModeSwitcherViewTest(unittest.TestCase, QtWidgetFinder):
 
     def tearDown(self):
         self.assertTrue(self.view.close())
-        QApplication.sendPostedEvents()
 
     def test_that_the_tf_asymmetry_mode_can_be_set_to_be_on(self):
         self.view.tf_asymmetry_mode = False

--- a/qt/python/mantidqtinterfaces/test/Muon/load_file_widget/loadfile_presenter_multiple_file_test.py
+++ b/qt/python/mantidqtinterfaces/test/Muon/load_file_widget/loadfile_presenter_multiple_file_test.py
@@ -58,7 +58,6 @@ class LoadFileWidgetPresenterMultipleFileModeTest(unittest.TestCase):
     def wait_for_thread(self, thread_model):
         if thread_model and thread_model.worker:
             while thread_model.worker.is_alive():
-                QApplication.sendPostedEvents()
                 time.sleep(0.1)
             QApplication.sendPostedEvents()
 

--- a/qt/python/mantidqtinterfaces/test/Muon/load_file_widget/loadfile_presenter_single_file_test.py
+++ b/qt/python/mantidqtinterfaces/test/Muon/load_file_widget/loadfile_presenter_single_file_test.py
@@ -32,7 +32,6 @@ class LoadFileWidgetPresenterTest(unittest.TestCase):
     def wait_for_thread(self, thread_model):
         if thread_model and thread_model.worker:
             while thread_model.worker.is_alive():
-                QApplication.sendPostedEvents()
                 time.sleep(0.1)
             QApplication.sendPostedEvents()
 

--- a/qt/python/mantidqtinterfaces/test/Muon/load_run_widget/loadrun_presenter_current_run_test.py
+++ b/qt/python/mantidqtinterfaces/test/Muon/load_run_widget/loadrun_presenter_current_run_test.py
@@ -49,7 +49,6 @@ class LoadRunWidgetLoadCurrentRunTest(unittest.TestCase):
     def wait_for_thread(self, thread_model):
         if thread_model and thread_model.worker:
             while thread_model.worker.is_alive():
-                QApplication.sendPostedEvents()
                 time.sleep(0.1)
             QApplication.sendPostedEvents()
 

--- a/qt/python/mantidqtinterfaces/test/Muon/load_run_widget/loadrun_presenter_increment_decrement_test.py
+++ b/qt/python/mantidqtinterfaces/test/Muon/load_run_widget/loadrun_presenter_increment_decrement_test.py
@@ -32,7 +32,6 @@ class LoadRunWidgetIncrementDecrementSingleFileModeTest(unittest.TestCase):
     def wait_for_thread(self, thread_model):
         if thread_model and thread_model.worker:
             while thread_model.worker.is_alive():
-                QApplication.sendPostedEvents()
                 time.sleep(0.1)
             QApplication.sendPostedEvents()
 

--- a/qt/python/mantidqtinterfaces/test/Muon/load_run_widget/loadrun_presenter_multiple_file_test.py
+++ b/qt/python/mantidqtinterfaces/test/Muon/load_run_widget/loadrun_presenter_multiple_file_test.py
@@ -30,7 +30,6 @@ class LoadRunWidgetIncrementDecrementMultipleFileModeTest(unittest.TestCase):
     def wait_for_thread(self, thread_model):
         if thread_model and thread_model.worker:
             while thread_model.worker.is_alive():
-                QApplication.sendPostedEvents()
                 time.sleep(0.1)
             QApplication.sendPostedEvents()
 

--- a/qt/python/mantidqtinterfaces/test/Muon/load_run_widget/loadrun_presenter_single_file_test.py
+++ b/qt/python/mantidqtinterfaces/test/Muon/load_run_widget/loadrun_presenter_single_file_test.py
@@ -31,7 +31,6 @@ class LoadRunWidgetPresenterTest(unittest.TestCase):
     def wait_for_thread(self, thread_model):
         if thread_model and thread_model.worker:
             while thread_model.worker.is_alive():
-                QApplication.sendPostedEvents()
                 time.sleep(0.1)
             QApplication.sendPostedEvents()
 

--- a/qt/python/mantidqtinterfaces/test/Muon/loading_tab/loadwidget_presenter_failure_test.py
+++ b/qt/python/mantidqtinterfaces/test/Muon/loading_tab/loadwidget_presenter_failure_test.py
@@ -30,7 +30,6 @@ class LoadRunWidgetPresenterLoadFailTest(unittest.TestCase):
     def wait_for_thread(self, thread_model):
         if thread_model and thread_model.worker:
             while thread_model.worker.is_alive():
-                QApplication.sendPostedEvents()
                 time.sleep(0.1)
             QApplication.sendPostedEvents()
 

--- a/qt/python/mantidqtinterfaces/test/Muon/loading_tab/loadwidget_presenter_test.py
+++ b/qt/python/mantidqtinterfaces/test/Muon/loading_tab/loadwidget_presenter_test.py
@@ -31,7 +31,6 @@ class LoadRunWidgetPresenterTest(unittest.TestCase):
     def wait_for_thread(self, thread_model):
         if thread_model and thread_model.worker:
             while thread_model.worker.is_alive():
-                QApplication.sendPostedEvents()
                 time.sleep(0.1)
             QApplication.sendPostedEvents()
 

--- a/qt/python/mantidqtinterfaces/test/Muon/phase_table_widget/phase_table_presenter_test.py
+++ b/qt/python/mantidqtinterfaces/test/Muon/phase_table_widget/phase_table_presenter_test.py
@@ -28,7 +28,6 @@ class PhaseTablePresenterTest(unittest.TestCase):
     def wait_for_thread(self, thread_model):
         if thread_model and thread_model.worker:
             while thread_model.worker.is_alive():
-                QApplication.sendPostedEvents()
                 time.sleep(0.1)
             QApplication.sendPostedEvents()
 

--- a/qt/python/mantidqtinterfaces/test/Muon/plotting_canvas/plotting_canvas_view_test.py
+++ b/qt/python/mantidqtinterfaces/test/Muon/plotting_canvas/plotting_canvas_view_test.py
@@ -13,7 +13,6 @@ from mantidqtinterfaces.Muon.GUI.Common.contexts.plotting_context import Plottin
 from mantidqtinterfaces.Muon.GUI.Common.plot_widget.plotting_canvas.plotting_canvas_view import PlottingCanvasView
 from mantidqtinterfaces.Muon.GUI.Common.plot_widget.quick_edit.quick_edit_widget import QuickEditWidget
 
-from qtpy.QtWidgets import QApplication
 import numpy as np
 
 
@@ -33,7 +32,6 @@ class PlottingCanvasViewTest(unittest.TestCase, QtWidgetFinder):
 
     def tearDown(self):
         self.assertTrue(self.view.close())
-        QApplication.sendPostedEvents()
 
     def make_plot_side_effect(self, _unused):
         self._count +=1

--- a/qt/python/mantidqtinterfaces/test/Muon/plotting_canvas/plotting_canvas_view_test.py
+++ b/qt/python/mantidqtinterfaces/test/Muon/plotting_canvas/plotting_canvas_view_test.py
@@ -8,7 +8,6 @@ import unittest
 
 from unittest import mock
 from mantidqt.utils.qt.testing import start_qapplication
-from mantidqt.utils.qt.testing.qt_widget_finder import QtWidgetFinder
 from mantidqtinterfaces.Muon.GUI.Common.contexts.plotting_context import PlottingContext
 from mantidqtinterfaces.Muon.GUI.Common.plot_widget.plotting_canvas.plotting_canvas_view import PlottingCanvasView
 from mantidqtinterfaces.Muon.GUI.Common.plot_widget.quick_edit.quick_edit_widget import QuickEditWidget
@@ -17,7 +16,7 @@ import numpy as np
 
 
 @start_qapplication
-class PlottingCanvasViewTest(unittest.TestCase, QtWidgetFinder):
+class PlottingCanvasViewTest(unittest.TestCase):
 
     def setUp(self):
         self.context = PlottingContext()
@@ -28,7 +27,6 @@ class PlottingCanvasViewTest(unittest.TestCase, QtWidgetFinder):
         self.view.fig.tight_layout = mock.Mock()
         self.view.show()
         self._count = -1
-        self.assert_widget_created()
 
     def tearDown(self):
         self.assertTrue(self.view.close())

--- a/qt/python/mantidqtinterfaces/test/Muon/seq_fitting_tab_widget/seq_fitting_tab_presenter_test.py
+++ b/qt/python/mantidqtinterfaces/test/Muon/seq_fitting_tab_widget/seq_fitting_tab_presenter_test.py
@@ -21,7 +21,6 @@ from mantid.simpleapi import CreateSampleWorkspace, DeleteWorkspace
 def wait_for_thread(thread_model):
     if thread_model and thread_model.worker:
         while thread_model.worker.is_alive():
-            QApplication.sendPostedEvents()
             time.sleep(0.1)
         QApplication.sendPostedEvents()
 

--- a/qt/python/mantidqtinterfaces/test/Muon/utilities/thread_model_test.py
+++ b/qt/python/mantidqtinterfaces/test/Muon/utilities/thread_model_test.py
@@ -79,7 +79,6 @@ class LoadFileWidgetViewTest(unittest.TestCase):
     def wait_for_thread(self, thread_model):
         if thread_model and thread_model.worker:
             while thread_model.worker.is_alive():
-                QApplication.sendPostedEvents()
                 time.sleep(0.1)
             QApplication.sendPostedEvents()
 


### PR DESCRIPTION
**Description of work.**
This PR removes uses of qApplication in muon tests

**To test:**

Code review and check tests pass

Fixes #32246

*This does not require release notes* because it is a change to unit tests

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
