### PR TITLE
Stop updating slicepoint when slider updated post spinbox changed

### DIFF
--- a/docs/source/release/v6.3.0/33203_framework.rst
+++ b/docs/source/release/v6.3.0/33203_framework.rst
@@ -1,0 +1,8 @@
+SliceViewer
+-----------
+
+Bugfixes
+########
+- When entering a specific value for the center of the slicepoint of an integrated dimension/axis it will no longer jump to the nearest bin-center (this fix also affects MDEvent workspaces as it was assumed each dimension had 100 bins for the purpose of updating the slider for a integrated dimension/axis).
+
+:ref:`Release 6.3.0 <v6.3.0>`

--- a/docs/source/release/v6.3.0/33203_framework.rst
+++ b/docs/source/release/v6.3.0/33203_framework.rst
@@ -4,5 +4,6 @@ SliceViewer
 Bugfixes
 ########
 - When entering a specific value for the center of the slicepoint of an integrated dimension/axis it will no longer jump to the nearest bin-center (this fix also affects MDEvent workspaces as it was assumed each dimension had 100 bins for the purpose of updating the slider for a integrated dimension/axis).
+- Slicepoint center now set to correct initial value (consistent with position of slider) for MDHisto workspaces.
 
 :ref:`Release 6.3.0 <v6.3.0>`

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/dimensionwidget.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/dimensionwidget.py
@@ -221,6 +221,8 @@ class Dimension(QWidget):
         self.spinbox.setDecimals(3)
         self.spinbox.setRange(self.get_bin_center(0), self.get_bin_center(self.nbins - 1))
         self.spinbox.setSingleStep(self.width)
+        self.set_value(self.spinbox.minimum())
+        self.update_spinbox()  # not updated with set_value unless instance of DimensionNonIntegrated
         self.spinbox.editingFinished.connect(self.spinbox_changed)
 
         self.layout.addWidget(self.name)
@@ -235,7 +237,6 @@ class Dimension(QWidget):
         self.layout.addWidget(self.spinbox)
         self.layout.addWidget(self.units)
 
-        self.set_value(self.spinbox.minimum())
         if self.nbins < 2:
             state = State.DISABLE
 

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/dimensionwidget.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/dimensionwidget.py
@@ -289,8 +289,7 @@ class Dimension(QWidget):
             self.valueChanged.emit()
 
     def spinbox_changed(self):
-        self.value = self.spinbox.value()
-        self.update_slider()
+        self.set_value(self.spinbox.value())  # For MDE this won't update value when updating slider
 
     def slider_changed(self):
         if self.update_value_from_slider:


### PR DESCRIPTION
**Description of work.**

Bug when spin-box (of integrated dimension) changed - the value (of the slicepoint) would be set then overridden to the nearest bin center when the slider was updated with the new value. This now calls `set_value` method which is overridden depending on whether the workspace supports rebinning along that dimension.  

Also fixed separate issue #33234 - this was the initial value of the spin box being 0 rather than the first bin along the integrated dimension for MDHisto workspaces only. This was because when the value of the spinbox was set (with the minimum of the range) the object in the UI wasn't updated - this didn't happen for MEvent workspaces because they have rebinnable dimensions which are a different class (`DimensionNonIntegrated`) for which  `set_value` is overridden and does call `self.update_spinbox()`

**To test:**
(1) Create an MDEvent workspace
```
ws = CreateMDWorkspace(Dimensions='3', Extents='-3,3,-3,3,-3,3',
                       Names='H,K,L', Units='r.l.u.,r.l.u.,r.l.u.',
                       Frames='HKL,HKL,HKL',
                       SplitInto='2', SplitThreshold='10')
```
(2) Open workspace created in sliceviewer
(3) Type 0 in spinbox along L axis and press enter
(4) You should see the value of the spin box stays at 0 (previously went to nearest bin center, 0.03 - note MDEvent doesn't have a bin center really., the slider was hacked for MDEvent to have default nbins=100) 
(5) Check history of the `ws_svrebinned` workspace - it should have been integrated along L in a range centered on L=0 (e.g. +/- 0.05 r.l.u.)
(6) Make an MDHisto workspace
```
BinMD(InputWorkspace='ws', AxisAligned=False, 
    BasisVector0='H,r.l.u.,1.0,0.0,0.0', 
    BasisVector1='K,r.l.u.,0.0,1.0,0.0', 
    BasisVector2='L,r.l.u.,0.0,0.0,1.0', 
    OutputExtents='-3,3,-3,3,-3,3', OutputBins='30,30,30', 
    NormalizeBasisVectors=False, OutputWorkspace='ws_histo')
```
(7) Repeat steps (2-5) - you should see the same because it rebins the original MDEvent
(8) Delete the original MDEvent workspace
`DeleteWorkspace(ws)`
(9) Repeat steps (2-5) - this time the spinbox should jump to the nearest bin center (-0.1) - and when the workspace is first opened in sliceviewer the spinbox will now display -2.9 (not 0 as in #33234)

Fixes #31285
Fixes #33234 


<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
