### PR TITLE
Fix muon plotting rounding bug

### DIFF
--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/plot_widget/plotting_canvas/plotting_canvas_view.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/plot_widget/plotting_canvas/plotting_canvas_view.py
@@ -235,9 +235,9 @@ class PlottingCanvasView(QtWidgets.QWidget, PlottingCanvasViewInterface):
     def _set_text_tick_labels(self, axis_number):
         ax = self.fig.axes[axis_number]
         # set the axes to not "simplify" the values
-        ax.xaxis.set_major_formatter(StrMethodFormatter('{x:.0f}'))
+        ax.xaxis.set_major_formatter(StrMethodFormatter('{x:.3g}'))
         ax.xaxis.set_minor_formatter(NullFormatter())
-        ax.yaxis.set_major_formatter(StrMethodFormatter('{x:.0f}'))
+        ax.yaxis.set_major_formatter(StrMethodFormatter('{x:.3g}'))
         ax.yaxis.set_minor_formatter(NullFormatter())
         if self._x_tick_labels:
             ax.set_xticks(range(len(self._x_tick_labels)))

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/plot_widget/plotting_canvas/plotting_canvas_view.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/plot_widget/plotting_canvas/plotting_canvas_view.py
@@ -235,9 +235,9 @@ class PlottingCanvasView(QtWidgets.QWidget, PlottingCanvasViewInterface):
     def _set_text_tick_labels(self, axis_number):
         ax = self.fig.axes[axis_number]
         # set the axes to not "simplify" the values
-        ax.xaxis.set_major_formatter(StrMethodFormatter('{x:.3g}'))
+        ax.xaxis.set_major_formatter(StrMethodFormatter('{x:g}'))
         ax.xaxis.set_minor_formatter(NullFormatter())
-        ax.yaxis.set_major_formatter(StrMethodFormatter('{x:.3g}'))
+        ax.yaxis.set_major_formatter(StrMethodFormatter('{x:g}'))
         ax.yaxis.set_minor_formatter(NullFormatter())
         if self._x_tick_labels:
             ax.set_xticks(range(len(self._x_tick_labels)))


### PR DESCRIPTION
**Description of work.**

In the muon GUI the axis are rounding all of the values to integers, which is wrong. This allows up to 3 dp of precision in the data.

**To test:**

<!-- Instructions for testing. -->
Before starting Mantid you will need to activate the model analysis tab, https://stfc365.sharepoint.com/:w:/r/sites/Mantid/_layouts/15/Doc.aspx?sourcedoc=%7B908F6EE2-0342-4843-90BE-7217122A9F08%7D&file=Feature%20flag%20instructions.docx&action=default&mobileredirect=true

Open muon analysis
Load MUSR 62260
Check that the y axis has meaningful values (before it was just 0's and 1's)
Zoom in on the plot and check the precision on each tick removes trailing 0's

Go to the fitting tab and do a fit (any will do)
Go to the results tab
Select run number in the top table
Click the button at the bottom
Go to the model analysis tab
Set x and y axis to run number and check that is displayed in full and not using scientific notation

Fixes #33204. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

This does not require release notes because this is bug we introduced. 


<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
