### PR TITLE
Improve manual testing instructions for the refl gui

### DIFF
--- a/dev-docs/source/Testing/ReflectometryGUI/ReflectometryGUITests.rst
+++ b/dev-docs/source/Testing/ReflectometryGUI/ReflectometryGUITests.rst
@@ -56,15 +56,14 @@ The division between the Search Runs and Process Runs sections is a handle. It c
 Processing
 ----------
 
-- Load a batch file.
-- If you have the nexus files make sure their location is in your managed user directories. If you don't have the accompanying nexus files for the batch file make sure the archive enabled.
-- Select a single row by clicking on it.
+- Make sure the sample data directory is in your managed user directories.
+- Load the batch file from the sample data. This should populate the main table with two groups, each containing two rows (you may need to click the little triangle next to the group name to expand the group).
+- Select a single row within a group by clicking on it.
 - Click Process. Some output workspaces should be produced and the row should turn green.
 - The process bar along the bottom should go from empty to full.
 - Repeat this test for multiple lines (selecting using Shift and Ctrl)
-- Repeat this for a group.
+- Repeat this for a group by selecting the group header line and clicking Process.
 - Repeat for the entire table (click off the table to deselect all rows and then Process will process everything that is left).
-- It should be possible to plot the data using the icons at the top of the interface.
 
 Generating Plots and the 'plot' button
 --------------------------------------
@@ -170,12 +169,8 @@ On Exit Prompt
 
 - Open the interface, don't load anything. Type some values into the table.
 - Close the interface by hitting the close button in the title bar.
-- You should receive a prompt with Save, Discard and Cancel (or whatever variation your OS uses), hit 'Save'.
-- A Save As dialog will appear, select a location and provide a file name and hit 'Save'. The Interface will then close.
-- Check using a plain text editor that the file has been created.
-- Re-open the interface, and load a ``*.json`` file and make a modification to it within the interface and follow the same steps, this time pressing save when prompted will overwrite the loaded file.
-- When presented with the prompt also make sure that 'Discard' closes the interface but doesn't save or overwrite anything, and 'Cancel' returns you to the interface without closing.
-- When in the Save As dialog, make sure that pressing cancel doesn't close the interface and doesn't save anything, then try and close it again. The prompt should still appear.
+- You should receive a prompt with OK and Cancel (or whatever variation your OS uses).
+- Make sure that 'Cancel' returns you to the interface without closing it. Try again and make sure that 'OK' closes the interface.
 
 Export as ASCII
 ^^^^^^^^^^^^^^^
@@ -183,14 +178,22 @@ Export as ASCII
 
 - Open the interface, don't load anything.
 - Go to the Save tab. The workspaces list should be empty.
-- Close the dialog.
 - Load a batch file and process it.
-- Go to the Save tab. The workspaces list will contain the names of the workspaces created when you processed.
+- Go to the Save tab and hit Refresh. The workspaces list will contain the names of the workspaces created when you processed.
 - Type an existing path into the Save path textbox.
 - Type something in the prefix field you'd like to use to identify the file. *The files are saved in the form [prefix][workspace][ext]*.
-- Double-click on a workspace name in the left list. The right list should populate with parameters.
-- Select one or more workspaces in the left list.
-- Select as many or as few (including none) parameters form the right list. *This will have no effect when saving in ANSTO format*.
-- Use the checkboxes and radio buttons below the right list to set the output to include Title, Resolution and your chosen separator. *These will only affect the Custom 4-column format*.
-- Save your selections in each format. All are text formats and can be opened in a plain text editor to check their contents. Custom and Ill Cosmos should have notes with the values of the selected parameters, Custom should have the delimiters, title and/or the Q resolution options as specified.
-- Repeat the test, this time entering a non-existent or invalid path, the dialog won't allow you to save as the path doesn't exist.
+- In the File Format section, select ``Custom format (*.dat)``, untick ``Header`` and ``Q resolution`` and set the separator to ``Comma``.
+- Click ``Save`` and open the file that should have been saved to the save directory you specified. It should contain 3 columns of numbers, separated by commas.
+- Tick ``Q resolution`` and re-save. It should now contain 4 columns of numbers.
+- Double-click on a workspace name in the left list, e.g. ``IvsQ_13460``. The right list should be populated with parameters but be disabled.
+- Tick ``Header`` and the parameters list should be enabled. Select a couple of them, e.g. ``nperiods`` and ``run_start``, and re-save.
+
+  - The file should now contain some header text starting with ``MFT``.
+  - Amongst other things this text should contain the logs you selected, e.g. ``nperiods : 1`` and ``run_end : 2011-12-15T14:19:13``.
+
+- Try changing the separator to spaces or tabs and check that the 3 or 4 columns of numbers are separated using that separator.
+- Change the dropdown to ``3 column (*.dat)``. The checkboxes, separators and parameter settings are not applicable so they should be greyed out. Click save and you should get 3 columns of numbers separated by tabs (including a leading tab). At the top there is an integer indicating the number of lines in the data.
+- Change the dropdown to ``ANSTO, MotoFit, 4 Column (*.txt)``. The settings remain greyed out. Click save and you should get 4 columns of numbers separated by tabs (with no leading tab).
+- Change the dropdown to ``ILL Cosmos (*.mft)``. The settings remain greyed out apart from the parameters which should now be enabled. Click save and you should get 3 columns of numbers padded by spaces (including leading spaces). There should be a header starting ``MFT`` which includes any parameters you selected, the same as the Custom format.
+
+- Try entering a non-existent or invalid save path and then try to Save. You should get an error saying that the path is invalid.


### PR DESCRIPTION
Fix some minor confusing language.
Change the Save ASCII instructions to be specific for each output file format.
Chagne the Exit Prompt section to match current behaviour - it was previously documented that there is a Save/Discard/Cancel option but this is not the case; there is only OK/Cancel.

**To test:**

Build the dev-docs and check that the new instructions read ok.

*There is no associated issue.*

*This does not require release notes* because **it is developer documentation**


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
