### PR TITLE
Manually remove extra include/share directories from macOS bundle

### DIFF
--- a/qt/applications/workbench/CMakeLists.txt
+++ b/qt/applications/workbench/CMakeLists.txt
@@ -183,6 +183,12 @@ if(APPLE AND NOT CONDA_BUILD)
 
   # We can't do this in a conda_env as it looks for homebrew packages
   if(NOT CONDA_ENV)
+    if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+      # This is a horrible hack to remove the directories that eigen installs as it does not seem possible to change the
+      # location without editing the install command within the eigen source. This will not be an issue when we stop
+      # using eigen as an external project.
+      install(CODE "file(REMOVE_RECURSE \${CMAKE_INSTALL_PREFIX}/include \${CMAKE_INSTALL_PREFIX}/share)")
+    endif()
     install(
       CODE "
       execute_process(COMMAND ${CMAKE_SOURCE_DIR}/installers/MacInstaller/make_package.rb
@@ -194,6 +200,7 @@ if(APPLE AND NOT CONDA_BUILD)
       endif()
   "
     )
+
   else()
     include(BundleOSXConda)
   endif()


### PR DESCRIPTION
**Description of work.**

Including eigen using FetchContent registers its install rules with
mantid. For macOS this resulted in the include/share directories
being copied to the root of the package and visible to users when
opening the dmg

See screenshot in #33206 for the error that this fixes.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**

* On macOS, enable cpack on your build and build the package:
```
build>cmake -DENABLE_CPACK=ON .
build>ninja package
build>open <name of .dmg file> 
```
See that there is only the `Applications` and `MantidWorkbench` links

Fixes #33206.

*This does not require release notes* because **it fixes an internal development error introduced this cycle**

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
