### PR TITLE
33218 fix IDA crash on spectra removal

### DIFF
--- a/qt/scientific_interfaces/Indirect/IndirectFittingModel.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFittingModel.cpp
@@ -295,7 +295,11 @@ void IndirectFittingModel::addDefaultParameters() {
   m_defaultParameters.emplace_back(createDefaultParameters(WorkspaceID{0}));
 }
 
-void IndirectFittingModel::removeDefaultParameters() { m_defaultParameters.remove(WorkspaceID{0}); }
+void IndirectFittingModel::removeDefaultParameters() {
+  if (m_fitDataModel->getNumberOfWorkspaces() < m_defaultParameters.size()) {
+    m_defaultParameters.remove(WorkspaceID{0});
+  }
+}
 
 void IndirectFittingModel::clearWorkspaces() {
   m_fitOutput->clear();


### PR DESCRIPTION
**Description of work.**

This PR fixes an issue in Indirect Data analysis that causes a crash on the second time a spectra is removed from one of the fit tabs.

**To test:**

1. open Indirect Data Analysis
2. go to IqtFit tab
3. load relivent data from training data with more than one spectra.
4. remove a spectra from the data table.
5. remove a second spectra. This should not cause a crash.
6. remove all spectra. this should also work normaly.
7. retry with other tabs that utalise this data interface.

Fixes #33218

*This does not require release notes* because it is a bug introduced in thsi release.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
