### PR TITLE
Muon TF asymmetry bug

### DIFF
--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/plot_widget/plotting_canvas/plotting_canvas_presenter.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/plot_widget/plotting_canvas/plotting_canvas_presenter.py
@@ -142,11 +142,10 @@ class PlottingCanvasPresenter(PlottingCanvasPresenterInterface):
         for plot_info in workspace_plot_info:
             name = plot_info.workspace_name
             index = plot_info.index
-            axis = plot_info.axis
             x_data, y1_data, y2_data = self._model.get_shade_lines(name, index)
 
             self._view.add_shaded_region(workspace_name = name,
-                                         axis_number = axis,
+                                         axis_number = plot_info.axis,
                                          x_values = x_data,
                                          y1_values = y1_data,
                                          y2_values = y2_data)

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/plot_widget/plotting_canvas/plotting_canvas_presenter.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/plot_widget/plotting_canvas/plotting_canvas_presenter.py
@@ -137,10 +137,16 @@ class PlottingCanvasPresenter(PlottingCanvasPresenterInterface):
         self._set_axes_limits_and_titles(autoscale)
 
     def add_shaded_region(self, workspaces, indices):
-        for name, index in zip(workspaces, indices):
+        workspace_plot_info = self._model.create_workspace_plot_information(workspaces, indices,
+                                                                            self._options_presenter.get_errors())
+        for plot_info in workspace_plot_info:
+            name = plot_info.workspace_name
+            index = plot_info.index
+            axis = plot_info.axis
             x_data, y1_data, y2_data = self._model.get_shade_lines(name, index)
+
             self._view.add_shaded_region(workspace_name = name,
-                                         axis_number = index,
+                                         axis_number = axis,
                                          x_values = x_data,
                                          y1_values = y1_data,
                                          y2_values = y2_data)

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/plot_widget/plotting_canvas/plotting_canvas_view.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/plot_widget/plotting_canvas/plotting_canvas_view.py
@@ -214,8 +214,7 @@ class PlottingCanvasView(QtWidgets.QWidget, PlottingCanvasViewInterface):
                 self.hide_axis(axis_number, nrows, ncols)
 
     def add_shaded_region(self, workspace_name, axis_number, x_values, y1_values, y2_values):
-        # -1 to count from 0 instead of 1
-        axis = self.fig.axes[axis_number-1]
+        axis = self.fig.axes[axis_number]
         if workspace_name in self._shaded_regions.keys():
             self._shaded_regions[workspace_name].update(axis = axis,
                                                         x_values = x_values,

--- a/qt/python/mantidqtinterfaces/test/Muon/plotting_canvas/plotting_canvas_presenter_test.py
+++ b/qt/python/mantidqtinterfaces/test/Muon/plotting_canvas/plotting_canvas_presenter_test.py
@@ -603,9 +603,17 @@ class PlottingCanvasPresenterTest(unittest.TestCase):
         self.assertFalse(self.presenter.should_update_all(selected_subplots))
 
     def test_add_shaded_region(self):
+        def plot_info_mock(ws_list, indices, errors):
+            plot_info_list = []
+            for ws, index in zip(ws_list, indices):
+                plot_info_list.append(create_test_plot_information(name=ws, index=index, axis=index,
+                                      normalised=False, errors=False, label=ws))
+            return plot_info_list
+
         def shade_mock(name, index):
             return index, index+1, index+2
         self.model.get_shade_lines.side_effect = shade_mock
+        self.model.create_workspace_plot_information.side_effect = plot_info_mock
         self.presenter.add_shaded_region(["unit", "test"], [0,1])
         self.view.add_shaded_region.assert_any_call(workspace_name="unit",
                                                     axis_number=0,

--- a/qt/python/mantidqtinterfaces/test/Muon/plotting_canvas/plotting_canvas_view_test.py
+++ b/qt/python/mantidqtinterfaces/test/Muon/plotting_canvas/plotting_canvas_view_test.py
@@ -346,7 +346,7 @@ class PlottingCanvasViewTest(unittest.TestCase, QtWidgetFinder):
         self.view.add_shaded_region(name, axis, x_data, y1_data, y2_data)
 
         self.assertEqual(list(self.view._shaded_regions.keys()), [name])
-        self.assertEqual(self.view._shaded_regions[name].axis, 1)
+        self.assertEqual(self.view._shaded_regions[name].axis, 2)
         self.assertEqual(self.view._shaded_regions[name].x_values, x_data)
         self.assertEqual(self.view._shaded_regions[name].y1_values, y1_data)
         self.assertEqual(self.view._shaded_regions[name].y2_values, y2_data)
@@ -369,7 +369,7 @@ class PlottingCanvasViewTest(unittest.TestCase, QtWidgetFinder):
 
         self.view.add_shaded_region(name, axis, new_x, new_y1, new_y2)
         self.assertEqual(list(self.view._shaded_regions.keys()), [name])
-        self.assertEqual(self.view._shaded_regions[name].axis, 1)
+        self.assertEqual(self.view._shaded_regions[name].axis, 2)
         self.assertEqual(self.view._shaded_regions[name].x_values, new_x)
         self.assertEqual(self.view._shaded_regions[name].y1_values, new_y1)
         self.assertEqual(self.view._shaded_regions[name].y2_values, new_y2)


### PR DESCRIPTION
**Description of work.**

The errors in the muon plotting are shown by a shaded region. However, the axis was incorrect as it was using the workspace index instead.

**To test:**
<!-- Instructions for testing. -->

Open muon analysis
Load MUSR62260
Go to the fitting tab
Change from `Normal` to `TF Asymmetry`
Add a fitting function
Press fit - this was a crash
Tick the errors box below the plot
Check that a shaded region has appeared (you may need to zoom in)

Tick `tiled plot` checkbox that is above the plot
You will see 4 plot areas (3 will be empty)
Check that the fit, shaded region and data are all on the same subplot
Press the `>` on the fitting tab to go to the next data set - the subplot showing data will change
Do a fit
Check that the fit, shaded region and data are all on the same subplot
Press the `>` on the fitting tab to go to the next data set - the subplot showing data will change
Do a fit
Check that the fit, shaded region and data are all on the same subplot
Press the `>` on the fitting tab to go to the next data set - the subplot showing data will change
Do a fit
Check that the fit, shaded region and data are all on the same subplot

If you do a simultaneous fit, the errors are all 0. Hence, no shaded region will be present.

Fixes #33227. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

Not i nthe release notes as this is a bug we have added this release.

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
