### PR TITLE
rename single fitting button in IDA

### DIFF
--- a/docs/source/release/v6.4.0/indirect_geometry.rst
+++ b/docs/source/release/v6.4.0/indirect_geometry.rst
@@ -10,3 +10,9 @@ Indirect Geometry Changes
     improvements, followed by bug fixes.
 
 :ref:`Release 6.4.0 <v6.4.0>`
+
+
+Changes
+#######
+
+- In Indirect Data analysis the button for fitting the currently plotted spectra has been renamed and rescaled to fit the interface.

--- a/qt/scientific_interfaces/Indirect/IndirectFitPreviewPlot.ui
+++ b/qt/scientific_interfaces/Indirect/IndirectFitPreviewPlot.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>445</width>
+    <width>550</width>
     <height>663</height>
    </rect>
   </property>
@@ -85,12 +85,12 @@
       <widget class="QPushButton" name="pbFitSingle">
        <property name="minimumSize">
         <size>
-         <width>99</width>
+         <width>0</width>
          <height>0</height>
         </size>
        </property>
        <property name="text">
-        <string>Fit Single Spectrum</string>
+        <string>Fit Current Preview</string>
        </property>
       </widget>
      </item>


### PR DESCRIPTION
This PR changes the wording for the button to perform a single fit in indirect data analysis. it also changes the minimum size to allow it to scale propperly in the interface

**To test:**

1. open indirect data analysis. 
2. go to all fitting tabs and check the scaling of the `Fit Current Preview Button`

*There is no associated issue.*

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
