### PR TITLE
Fix error reporter

### DIFF
--- a/Framework/Json/src/Json.cpp
+++ b/Framework/Json/src/Json.cpp
@@ -9,24 +9,6 @@
 #include <memory>
 #include <sstream>
 
-/**
- * @brief Useful function for replacing all instances of characters in string.
- *
- * @param str the input string.
- * @param from the substring to replace.
- * @param to the string to replace with.
- * @return std::string
- */
-void replaceAll(std::string &str, const std::string &from, const std::string &to) {
-  if (from.empty())
-    return;
-  size_t start_pos = 0;
-  while ((start_pos = str.find(from, start_pos)) != std::string::npos) {
-    str.replace(start_pos, from.length(), to);
-    start_pos += to.length();
-  }
-}
-
 namespace Mantid::JsonHelpers {
 
 /**
@@ -46,9 +28,6 @@ std::string jsonToString(const Json::Value &json, const std::string &indentation
   Json::StreamWriterBuilder builder;
   builder.settings_["indentation"] = indentation;
   auto string = Json::writeString(builder, json);
-  replaceAll(string, "\"{", "{");
-  replaceAll(string, "}\"", "}");
-  replaceAll(string, "\\\"", "\"");
   return string;
 }
 

--- a/Framework/Json/test/JsonTest.h
+++ b/Framework/Json/test/JsonTest.h
@@ -19,6 +19,14 @@ public:
     TS_ASSERT_EQUALS(initialString.str(), Mantid::JsonHelpers::jsonToString(json))
   }
 
+  void testJsonToStringWithEscapedQuotes() {
+    // Check that escaped quotes inside json string values are preserved.
+    std::stringstream initialString("{\"string with quotes\":\"filename = \\\"file.txt\\\" \"}");
+    Json::Value json;
+    initialString >> json;
+    TS_ASSERT_EQUALS(initialString.str(), Mantid::JsonHelpers::jsonToString(json))
+  }
+
   void testStringToJson() {
     const std::string initialString = "{\"bar\":2,\"baz\":3.1400000000000001,\"foo\":1,\"hello world\":\"HelloWorld\"}";
     const Json::Value json = Mantid::JsonHelpers::stringToJson(initialString);

--- a/Framework/Kernel/test/ErrorReporterTest.h
+++ b/Framework/Kernel/test/ErrorReporterTest.h
@@ -61,6 +61,18 @@ public:
     TS_ASSERT_EQUALS(root["exitCode"].asString(), "0");
   }
 
+  void test_stackTraceWithQuotes() {
+    const std::string appName = "My testing application name";
+    const Mantid::Types::Core::time_duration upTime(5, 0, 7, 0);
+    const std::string stackTrace = "File \" C :\\file\\path\\file.py\", line 194, in broken_function";
+    TestableErrorReporter reporter(appName, upTime, "0", true, "name", "email", "textBox", stackTrace);
+    const std::string message = reporter.generateErrorMessage();
+
+    ::Json::Value root;
+    Mantid::JsonHelpers::parse(message, &root);
+    TS_ASSERT_EQUALS(root["stacktrace"].asString(), stackTrace);
+  }
+
   void test_errorMessageWithShare() {
     const std::string name = "My testing application name";
     const Mantid::Types::Core::time_duration upTime(5, 0, 7, 0);


### PR DESCRIPTION
Co-authored-by: Daniel Murphy <DanielMurphy22@users.noreply.github.com>

**Description of work.**

The error reporter was broken because escape characters were being removed from quotes in json strings, so the json parsing failed. This meant that both:
- stack traces (which normally contain `"`s)
- entering a quotation mark in any other fields  (name, email, decription box)
would result in a problem when either:
- clicking the "Show more details" button, or
- clicking the "Yes, share information" button.

We've added tests to ensure that strings with escaped quotes are preserved when converting to json, as well as removing the seemingly unused code that caused the problem.

The lines that we've removed were added in #33056.

**To test:**

1. Soft crash mantid to bring up the error reporter e.g. by doing this:
Load the file Training_Exercise3a_SNS.nxs from the training course data and execute the algorithm `NormaliseToMonitor`
2. Check that the "show more details" button works and displays the stack trace.
3. Check that the error report can be sent by clicking "Yes, share information".
4. Try to send an error report after entering quotation marks in some of the fields.

Fixes #33219 

*This does not require release notes* because it is a bug that was introduced since the last release.

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
