### PR TITLE
Fix crash on instrument viewer draw tab

### DIFF
--- a/docs/source/release/v6.3.0/33251_mantidworkbench.rst
+++ b/docs/source/release/v6.3.0/33251_mantidworkbench.rst
@@ -1,0 +1,4 @@
+Bugfixes
+--------
+
+Fix crash on Draw tab of instrument viewer when trying to sum detectors on a workspace which doesn't have common bin edges across all spectra

--- a/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/InstrumentWidgetMaskTab.h
+++ b/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/InstrumentWidgetMaskTab.h
@@ -138,6 +138,8 @@ protected:
   QColor getShapeFillColor() const;
   /// Add a double property to the shape property browser
   QtProperty *addDoubleProperty(const QString &name) const;
+  /// Show a modal message box
+  virtual void showMessageBox(const QString &message);
 
 private:
   /// Save masks applied to the view but not to the workspace

--- a/qt/widgets/instrumentview/src/InstrumentWidgetMaskTab.cpp
+++ b/qt/widgets/instrumentview/src/InstrumentWidgetMaskTab.cpp
@@ -791,6 +791,10 @@ void InstrumentWidgetMaskTab::saveInvertedMaskToCalFile() { saveMaskingToCalFile
 
 void InstrumentWidgetMaskTab::saveMaskToTable() { saveMaskingToTableWorkspace(false); }
 
+void InstrumentWidgetMaskTab::showMessageBox(const QString &message) {
+  QMessageBox::information(this, "GroupDetectors Error", message, "OK");
+}
+
 /**
  * Extract selected detectors to a new workspace
  */
@@ -813,7 +817,7 @@ void InstrumentWidgetMaskTab::extractDetsToWorkspace() {
       alg->setPropertyValue("OutputWorkspace", workspaceName + "_selection");
       alg->execute();
     } catch (std::exception &e) {
-      QMessageBox::information(this, "GroupDetectors Error", e.what(), "OK");
+      showMessageBox(e.what());
     }
   }
   QApplication::restoreOverrideCursor();
@@ -841,7 +845,7 @@ void InstrumentWidgetMaskTab::sumDetsToWorkspace() {
       alg->setPropertyValue("OutputWorkspace", workspaceName + "_sum");
       alg->execute();
     } catch (std::exception &e) {
-      QMessageBox::information(this, "GroupDetectors Error", e.what(), "OK");
+      showMessageBox(e.what());
     }
   }
   QApplication::restoreOverrideCursor();

--- a/qt/widgets/instrumentview/src/InstrumentWidgetMaskTab.cpp
+++ b/qt/widgets/instrumentview/src/InstrumentWidgetMaskTab.cpp
@@ -807,10 +807,14 @@ void InstrumentWidgetMaskTab::extractDetsToWorkspace() {
   if (!fname.empty()) {
     std::string workspaceName = m_instrWidget->getWorkspaceName().toStdString();
     auto alg = AlgorithmManager::Instance().create("GroupDetectors");
-    alg->setPropertyValue("InputWorkspace", workspaceName);
-    alg->setPropertyValue("MapFile", fname);
-    alg->setPropertyValue("OutputWorkspace", workspaceName + "_selection");
-    alg->execute();
+    try {
+      alg->setPropertyValue("InputWorkspace", workspaceName);
+      alg->setPropertyValue("MapFile", fname);
+      alg->setPropertyValue("OutputWorkspace", workspaceName + "_selection");
+      alg->execute();
+    } catch (std::exception &e) {
+      QMessageBox::information(this, "GroupDetectors Error", e.what(), "OK");
+    }
   }
   QApplication::restoreOverrideCursor();
 }
@@ -831,10 +835,14 @@ void InstrumentWidgetMaskTab::sumDetsToWorkspace() {
   if (!fname.empty()) {
     std::string workspaceName = m_instrWidget->getWorkspaceName().toStdString();
     auto alg = AlgorithmManager::Instance().create("GroupDetectors");
-    alg->setPropertyValue("InputWorkspace", workspaceName);
-    alg->setPropertyValue("MapFile", fname);
-    alg->setPropertyValue("OutputWorkspace", workspaceName + "_sum");
-    alg->execute();
+    try {
+      alg->setPropertyValue("InputWorkspace", workspaceName);
+      alg->setPropertyValue("MapFile", fname);
+      alg->setPropertyValue("OutputWorkspace", workspaceName + "_sum");
+      alg->execute();
+    } catch (std::exception &e) {
+      QMessageBox::information(this, "GroupDetectors Error", e.what(), "OK");
+    }
   }
   QApplication::restoreOverrideCursor();
 }

--- a/qt/widgets/instrumentview/test/InstrumentWidget/MockProjectionSurface.h
+++ b/qt/widgets/instrumentview/test/InstrumentWidget/MockProjectionSurface.h
@@ -22,5 +22,6 @@ public:
   MOCK_METHOD(void, getMaskedDetectors, (std::vector<size_t> &), (const, override));
   MOCK_METHOD(void, drawSurface, (GLDisplay *, bool), (const, override));
   MOCK_METHOD(void, changeColorMap, (), (override));
+  MOCK_METHOD(void, setInteractionMode, (int), (override));
 };
 } // namespace MantidQt::MantidWidgets


### PR DESCRIPTION
**Description of work.**

Some of the items on the "Apply and Save" drop down on the Draw tab calls GroupDetectors. This can fail for certain types of workspace (eg if workspace doesn't have common bins). This was previously causing workbench to crash so I've made a change to catch any exceptions from the GroupDetectors call and report the error to the user.

**To test:**

See linked issue

Fixes #33232.


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
