### PR TITLE
Fix behaviour on ADS deletion of workspaces and peaks workspaces in sliceviewer

### DIFF
--- a/docs/source/release/v6.3.0/33253_mantidworkbench.rst
+++ b/docs/source/release/v6.3.0/33253_mantidworkbench.rst
@@ -1,0 +1,17 @@
+========================
+Mantid Workbench Changes
+========================
+
+.. contents:: Table of Contents
+   :local:
+
+SliceViewer
+-----------
+
+Bugfixes
+########
+- Close sliceviewer when underlying workspace deleted
+- Remove peak table from peak viewer in sliceviewer when table deleted in ADS (and close peak viewer if there are no more peak tables overlaid).
+- Update peak actions combobox when overlain peak table is deleted.
+
+:ref:`Release 6.3.0 <v6.3.0>`

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/model.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/model.py
@@ -51,10 +51,10 @@ class SliceViewerModel:
         else:
             raise ValueError("only works for MatrixWorkspace and MDWorkspace")
 
-        wsname = self.get_ws_name()
-        self._rebinned_name = wsname + '_svrebinned'
-        self._xcut_name, self._ycut_name = wsname + '_cut_x', wsname + '_cut_y'
-        self._roi_name = wsname + '_roi'
+        self._ws_name = ws.name()
+        self._rebinned_name = self._ws_name+ '_svrebinned'
+        self._xcut_name, self._ycut_name = self._ws_name + '_cut_x', self._ws_name + '_cut_y'
+        self._roi_name = self._ws_name + '_roi'
 
         ws_type = self.get_ws_type()
         if ws_type == WS_TYPE.MDE:
@@ -127,9 +127,12 @@ class SliceViewerModel:
         return ws_type == WS_TYPE.MDE or (ws_type == WS_TYPE.MDH and self._get_ws().hasOriginalWorkspace(
             0) and self._get_ws().getOriginalWorkspace(0).getNumDims() == self._get_ws().getNumDims())
 
+    def set_ws_name(self, new_name):
+        self._ws_name = new_name
+
     def get_ws_name(self) -> str:
         """Return the name of the workspace being viewed"""
-        return self._ws.name()
+        return self._ws_name
 
     def get_frame(self) -> SpecialCoordinateSystem:
         """Return the coordinate system of the workspace"""
@@ -140,7 +143,7 @@ class SliceViewerModel:
         of the model's workspace if none supplied.
         """
         if not ws_name:
-            ws_name = self.get_ws_name()
+            ws_name = self._ws_name
         return f'Sliceviewer - {ws_name}'
 
     def get_ws_MDE(self,
@@ -485,8 +488,7 @@ class SliceViewerModel:
         return help_msg
 
     def workspace_equals(self, ws_name):
-        # TODO put something better here
-        return str(self._get_ws()) == ws_name
+        return self._ws_name == ws_name
 
     # private api
     def _get_ws(self):

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/model.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/model.py
@@ -36,6 +36,8 @@ class SliceViewerModel:
     def __init__(self, ws):
         # reference to the workspace requested to be viewed
         self._ws = ws
+        self.set_ws_name(ws.name())
+
         if isinstance(ws, MatrixWorkspace):
             if ws.getNumberHistograms() < 2:
                 raise ValueError("workspace must contain at least 2 spectrum")
@@ -51,10 +53,10 @@ class SliceViewerModel:
         else:
             raise ValueError("only works for MatrixWorkspace and MDWorkspace")
 
-        self._ws_name = ws.name()
-        self._rebinned_name = self._ws_name+ '_svrebinned'
-        self._xcut_name, self._ycut_name = self._ws_name + '_cut_x', self._ws_name + '_cut_y'
-        self._roi_name = self._ws_name + '_roi'
+        wsname = self.get_ws_name()
+        self._rebinned_name = wsname + '_svrebinned'
+        self._xcut_name, self._ycut_name = wsname + '_cut_x', wsname + '_cut_y'
+        self._roi_name = wsname + '_roi'
 
         ws_type = self.get_ws_type()
         if ws_type == WS_TYPE.MDE:
@@ -143,7 +145,7 @@ class SliceViewerModel:
         of the model's workspace if none supplied.
         """
         if not ws_name:
-            ws_name = self._ws_name
+            ws_name = self.get_ws_name()
         return f'Sliceviewer - {ws_name}'
 
     def get_ws_MDE(self,

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/peaksviewer/model.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/peaksviewer/model.py
@@ -45,6 +45,7 @@ class PeaksViewerModel(TableWorkspaceDisplayModel):
             raise ValueError("Expected a PeaksWorkspace type but found a {}".format(type(peaks_ws)))
 
         super().__init__(peaks_ws)
+        self._peaks_ws_name = peaks_ws.name()
         self._fg_color = fg_color
         self._bg_color = bg_color
         self._representations: List[Painted] = []

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/peaksviewer/model.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/peaksviewer/model.py
@@ -62,6 +62,9 @@ class PeaksViewerModel(TableWorkspaceDisplayModel):
     def peaks_workspace(self):
         return self.ws
 
+    def get_peaks_workspace_name(self):
+        return self._peaks_ws_name
+
     def clear_peak_representations(self):
         """
         Remove drawn peaks from the view

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/peaksviewer/presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/peaksviewer/presenter.py
@@ -248,7 +248,7 @@ class PeaksViewerCollectionPresenter:
         child_presenters = self._child_presenters
         presenter_to_remove = None
         for child in child_presenters:
-            if child.model._peaks_ws_name == name:
+            if child.model.get_peaks_workspace_name() == name:
                 presenter_to_remove = child
                 child.notify(PeaksViewerPresenter.Event.ClearPeaks)
                 index = self._view.remove_peaksviewer(child.view)
@@ -270,7 +270,7 @@ class PeaksViewerCollectionPresenter:
         """
         names = []
         for presenter in self._child_presenters:
-            names.append(presenter.model._peaks_ws_name)
+            names.append(presenter.model.get_peaks_workspace_name())
 
         return names
 

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/peaksviewer/presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/peaksviewer/presenter.py
@@ -248,12 +248,16 @@ class PeaksViewerCollectionPresenter:
         child_presenters = self._child_presenters
         presenter_to_remove = None
         for child in child_presenters:
-            if child.model.peaks_workspace.name() == name:
+            if child.model._peaks_ws_name == name:
                 presenter_to_remove = child
                 child.notify(PeaksViewerPresenter.Event.ClearPeaks)
                 index = self._view.remove_peaksviewer(child.view)
 
         child_presenters.remove(presenter_to_remove)
+
+        # update combo box for add/remove peak actions
+        self._actions_view.set_peaksworkspace(self.workspace_names())
+
         return index
 
     def workspace_names(self):
@@ -262,7 +266,7 @@ class PeaksViewerCollectionPresenter:
         """
         names = []
         for presenter in self._child_presenters:
-            names.append(presenter.model.peaks_workspace.name())
+            names.append(presenter.model._peaks_ws_name)
 
         return names
 

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/peaksviewer/presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/peaksviewer/presenter.py
@@ -258,6 +258,10 @@ class PeaksViewerCollectionPresenter:
         # update combo box for add/remove peak actions
         self._actions_view.set_peaksworkspace(self.workspace_names())
 
+        # hide if no peak tables remain
+        if not child_presenters:
+            self._view.hide()
+
         return index
 
     def workspace_names(self):

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/peaksviewer/test/test_peaksviewer_peaksviewercollectionpresenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/peaksviewer/test/test_peaksviewer_peaksviewercollectionpresenter.py
@@ -72,7 +72,19 @@ class PeaksViewerCollectionPresenterTest(unittest.TestCase):
 
         presenter.remove_peaksworkspace(names[1])
 
+        presenter._actions_view.set_peaksworkspace.assert_called_with([names[0], names[2]])
         self.assertEqual([names[0], names[2]], presenter.workspace_names())
+        presenter._view.hide.assert_not_called()
+
+    def test_hides_view_when_last_named_workspace_removed(self, mock_create_model):
+        names = ["peaks1"]
+        presenter = PeaksViewerCollectionPresenter(MagicMock())
+        presenter.append_peaksworkspace(names[0])
+
+        presenter.remove_peaksworkspace(names[0])
+
+        presenter._actions_view.set_peaksworkspace.assert_called_with([])
+        presenter._view.hide.assert_called()
 
     def test_notify_called_for_each_subpresenter(self, mock_create_model):
         presenter = PeaksViewerCollectionPresenter(MagicMock())

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/presenter.py
@@ -438,11 +438,12 @@ class SliceViewer(ObservingPresenter):
             ws.unlock()
 
     def rename_workspace(self, old_name, new_name):
-        if str(self.model._get_ws()) == old_name:
+        if self.model.workspace_equals(old_name):
+            self.model.set_ws_name(new_name)
             self.view.emit_rename(self.model.get_title(new_name))
 
     def delete_workspace(self, ws_name):
-        if ws_name == str(self.model._ws):
+        if self.model.workspace_equals(ws_name):
             self.view.emit_close()
 
     def ADS_cleared(self):

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_sliceviewer_presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_sliceviewer_presenter.py
@@ -501,15 +501,15 @@ class SliceViewerTest(unittest.TestCase):
         mock_model = mock.MagicMock()
         mock_view = mock.MagicMock()
         pres = SliceViewer(mock.Mock(), model=mock_model, view=mock_view)
-        mock_model._ws = "test_name"
-        pres.delete_workspace(mock_model._ws)
+        mock_model.workspace_equals.return_value = True
+        pres.delete_workspace("test_name")
         mock_view.emit_close.assert_called_once()
 
     def test_workspace_not_deleted_with_different_name(self):
         mock_model = mock.MagicMock()
         mock_view = mock.MagicMock()
         pres = SliceViewer(mock.Mock(), model=mock_model, view=mock_view)
-        mock_model._ws = "test_name"
+        mock_model.workspace_equals.return_value = False
         pres.delete_workspace("different_name")
         mock_view.emit_close.assert_not_called()
 
@@ -541,16 +541,18 @@ class SliceViewerTest(unittest.TestCase):
         mock_model = mock.MagicMock()
         mock_view = mock.MagicMock()
         pres = SliceViewer(mock.Mock(), model=mock_model, view=mock_view)
-        mock_model._get_ws.return_value = "old_name"
+        mock_model.workspace_equals.return_value = True
         pres.rename_workspace("old_name", "new_name")
+        mock_model.set_ws_name.assert_called_with("new_name")
         mock_view.emit_rename.assert_called_once_with(mock_model.get_title.return_value)
 
     def test_rename_workspace_not_renamed_with_different_name(self):
         mock_model = mock.MagicMock()
         mock_view = mock.MagicMock()
         pres = SliceViewer(mock.Mock(), model=mock_model, view=mock_view)
-        mock_model._get_ws.return_value = "different_name"
+        mock_model.workspace_equals.return_value = False
         pres.rename_workspace("old_name", "new_name")
+        mock_model.set_ws_name.assert_not_called()
         mock_view.emit_rename.assert_not_called()
 
     def test_clear_ADS(self):


### PR DESCRIPTION
**Description of work.**

Changes in PR #32642 seem to have been removed - this PR puts them back in and (workspace name is now stored in the slice viewer model and updated on rename because on delete the workspace `.name() == ""` - an empty string) and tests have been updated (this change did break tests as the check for whether the workspace name is that in the model is now performed by a method of the model - which already existed - which needed to be mocked).

A similar fix has been done for the peaksviewer as well, and now the peak actions combobox is updated when a peak table is removed (unreported bug for which there is no issue) and the peakviewer is hidden if the last peak table overlaid was deleted (tests have been updated and added for the combobox and hiding of view respectively). 

This also fixes behaviour of window title not updating with renamed workspace name (issue #33239)

**To test**
Closes sliceviewer when underlying workspace deleted

1. Make data
```
ws = CreateMDWorkspace(Dimensions='3', Extents='-6,6,-4,4,-2,2',
                       Names='H,K,L', Units='r.l.u.,r.l.u.,r.l.u.',
                       Frames='HKL,HKL,HKL',
                       SplitInto='2', SplitThreshold='50')
```
2. Open in sliceviewer
3. Delete the workspace and verify that the slice viewer closes.
4. Load some data and open the slice viewer.
5. Rename the workspace and verify that the window title of the slice viewer changes.
6. Delete the workspace and verify that the slice viewer closes.

Updates peaksviewer when peaks workspace deleted
1. Make a peaks workspace for the above data
```
expt_info = CreateSampleWorkspace()
ws.addExperimentInfo(expt_info)
# add peak
peaks = CreatePeaksWorkspace(InstrumentWorkspace='ws', NumberOfPeaks=0, OutputWorkspace='peaks')
SetUB(peaks, 1,1,2,90,90,120)
pk = peaks.createPeakHKL([0,1,1]) # axes aligned with viewing axes
peaks.addPeak(pk)
```
2. Open ws in sliceviewer and overlay `peaks` workspace
3. Delete peaks workspace - this should hide the peaksviewer
4. Repeat 1-2 then rename the peaks workspace that is overlain
5. Delete the peaks workspace and check the behaviour is the same as in 3.
6. Remake the peaks workspace and make another with an additional peak (to easily differentiate the two)
```
peaks2 = CloneWorkspace(peaks)
pk = peaks2.createPeakHKL([1,0,1]) # axes aligned with viewing axes
peaks2.addPeak(pk)
```
7. Overlay both peak workspaces in sliceviewer and delete one peaks workspace in the ADS
8. There should only be one peak table in the sliceviewer (and it will have the correct number of peaks) - the peak actions combobox above will show the remaining peaks workspace and no others will be available to select.

Fixes #33230
Fixes #33239


<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
