### PR TITLE
Fix not being able to set z axis limits on linux

### DIFF
--- a/docs/source/release/v6.3.0/30014_mantidworkbench.rst
+++ b/docs/source/release/v6.3.0/30014_mantidworkbench.rst
@@ -1,0 +1,3 @@
+Bugfixes
+--------
+- The Z Axis limits of 3D plots can now be set on linux machines.

--- a/qt/applications/workbench/workbench/plotting/propertiesdialog.py
+++ b/qt/applications/workbench/workbench/plotting/propertiesdialog.py
@@ -233,7 +233,7 @@ class AxisEditor(PropertiesEditorBase):
             fmt = ScalarFormatter(useOffset=True)
         elif formatter == SCIENTIFIC_FORMAT:
             fmt = LogFormatterSciNotation()
-        getattr(self.axes, 'get_{}axis'.format(self.axis_id))().set_major_formatter(fmt)
+        getattr(self.axes, '{}axis'.format(self.axis_id)).set_major_formatter(fmt)
         return
 
 


### PR DESCRIPTION
**Description of work.**

The `get_zaxis()` method did not exist in the older version of mpl used on linux (incl. IDaaS). This simply accesses the value of the attribute directly which exists in the same form in both versions we use.


**To test:**
Ideally the functional testing should be done on both windows/mac **and** linux to check that the functionality has not changed for the former and is fixed for the latter. 

1. Run:
```
# import mantid algorithms, numpy and matplotlib
from mantid.simpleapi import *
import matplotlib.pyplot as plt
import numpy as np

ws = CreateSampleWorkspace(Function = 'Exp Decay')
fig, ax = plt.subplots(subplot_kw={'projection':'mantid3d'})
ax.plot_surface(ws)
plt.show()
```
2. Attempt to change all the axes limits, they should all change properly. 

Fixes #30014 


<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
