### PR TITLE
Stop ADS remove overwriting ws name with empty string and delete ws name attribute from sliceviewer models

### DIFF
--- a/Framework/API/src/AnalysisDataService.cpp
+++ b/Framework/API/src/AnalysisDataService.cpp
@@ -162,9 +162,6 @@ void AnalysisDataServiceImpl::remove(const std::string &name) {
     // do nothing - remove will do what's needed
   }
   Kernel::DataService<API::Workspace>::remove(name);
-  if (ws) {
-    ws->setName("");
-  }
 }
 
 /**

--- a/docs/source/interfaces/reflectometry/ISIS Reflectometry.rst
+++ b/docs/source/interfaces/reflectometry/ISIS Reflectometry.rst
@@ -764,6 +764,8 @@ The four slicing options are described in more detail below:
 Workspaces will be named with a suffix providing information about the slice, e.g
 ``IvsQ_13460_slice_50_75``, ``IvsQ_13460_slice_75_100``, etc.
 
+.. _refl_exp_instrument_settings:
+
 Experiment and Instrument Settings Tabs
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/source/release/v6.3.0/33253_mantidworkbench.rst
+++ b/docs/source/release/v6.3.0/33253_mantidworkbench.rst
@@ -1,0 +1,17 @@
+========================
+Mantid Workbench Changes
+========================
+
+.. contents:: Table of Contents
+   :local:
+
+SliceViewer
+-----------
+
+Bugfixes
+########
+- Close sliceviewer when underlying workspace deleted
+- Remove peak table from peak viewer in sliceviewer when table deleted in ADS (and close peak viewer if there are no more peak tables overlaid).
+- Update peak actions combobox when overlain peak table is deleted.
+
+:ref:`Release 6.3.0 <v6.3.0>`

--- a/docs/source/release/v6.3.0/reflectometry.rst
+++ b/docs/source/release/v6.3.0/reflectometry.rst
@@ -5,16 +5,16 @@ Reflectometry Changes
 .. contents:: Table of Contents
    :local:
 
-New and Improved
-----------------
+Improvements
+------------
 
 - Increased the size of the run(s) column for ease of use.
-- `MagnetismReflectometryReduction` will raise a value error when none of the input list can be processed.
+- ``MagnetismReflectometryReduction`` will raise a value error when none of the input list can be processed.
 
 Bugfixes
 --------
-- The Add Row button is now disabled in the Experiment settings tab when runs are being processed.
-- Invalid per-angle defaults values that are saved into a batch will now be marked as invalid when loaded back into the GUI.
+- The Add Row button is now disabled in the :ref:`Experiment Settings Tab <refl_exp_instrument_settings>` when runs are being processed.
+- Invalid Per-Angle default values that are saved into a batch will now be marked as invalid when loaded back into the GUI.
 - Fixed un-selected groups being processed after loading a batch.
 
 :ref:`Release 6.3.0 <v6.3.0>`

--- a/docs/source/release/v6.3.0/sans.rst
+++ b/docs/source/release/v6.3.0/sans.rst
@@ -5,15 +5,11 @@ SANS Changes
 .. contents:: Table of Contents
    :local:
 
-.. warning:: **Developers:** Sort changes under appropriate heading
-    putting new features at the top of the section, followed by
-    improvements, followed by bug fixes.
-
 Improvements
 ------------
 
-- Added missing logs to save in the header of ASCII files by DrILL for D11lr and D22lr ILL instruments
-- The ISIS SANS reduction algorithm now converts to wavelength once, instead of n times for each wavelength pair specified. This reduces the runtime by up to 50%.
+- Added missing logs to save in the header of ASCII files by :ref:`DrILL <DrILL-ref>` for D11lr and D22lr ILL instruments.
+- ISIS SANS data reduction now converts to wavelength once, instead of n times for each wavelength pair specified. This reduces the runtime by up to 50%.
 
 Bugfixes
 --------
@@ -21,10 +17,5 @@ Bugfixes
 - The :ref:`ISIS SANS Interface <ISIS_Sans_interface_contents>` will now generate and display a range of wavelength bins
   specified in TOML files. This previously showed an empty field, despite correctly using the input from the TOML file.
 
-Bugfixes
---------
-
-- The :ref:`ISIS SANS Interface <ISIS_Sans_interface_contents>` will now generate and display a range of wavelength bins
-  specified in TOML files. This previously showed an empty field, despite correctly using the input from the TOML file.
 
 :ref:`Release 6.3.0 <v6.3.0>`

--- a/qt/applications/workbench/CMakeLists.txt
+++ b/qt/applications/workbench/CMakeLists.txt
@@ -183,6 +183,12 @@ if(APPLE AND NOT CONDA_BUILD)
 
   # We can't do this in a conda_env as it looks for homebrew packages
   if(NOT CONDA_ENV)
+    if(CMAKE_SYSTEM_NAME STREQUAL "Darwin")
+      # This is a horrible hack to remove the directories that eigen installs as it does not seem possible to change the
+      # location without editing the install command within the eigen source. This will not be an issue when we stop
+      # using eigen as an external project.
+      install(CODE "file(REMOVE_RECURSE \${CMAKE_INSTALL_PREFIX}/include \${CMAKE_INSTALL_PREFIX}/share)")
+    endif()
     install(
       CODE "
       execute_process(COMMAND ${CMAKE_SOURCE_DIR}/installers/MacInstaller/make_package.rb
@@ -194,6 +200,7 @@ if(APPLE AND NOT CONDA_BUILD)
       endif()
   "
     )
+
   else()
     include(BundleOSXConda)
   endif()

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/model.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/model.py
@@ -51,10 +51,10 @@ class SliceViewerModel:
         else:
             raise ValueError("only works for MatrixWorkspace and MDWorkspace")
 
-        wsname = self.get_ws_name()
-        self._rebinned_name = wsname + '_svrebinned'
-        self._xcut_name, self._ycut_name = wsname + '_cut_x', wsname + '_cut_y'
-        self._roi_name = wsname + '_roi'
+        self._ws_name = ws.name()
+        self._rebinned_name = self._ws_name+ '_svrebinned'
+        self._xcut_name, self._ycut_name = self._ws_name + '_cut_x', self._ws_name + '_cut_y'
+        self._roi_name = self._ws_name + '_roi'
 
         ws_type = self.get_ws_type()
         if ws_type == WS_TYPE.MDE:
@@ -127,9 +127,12 @@ class SliceViewerModel:
         return ws_type == WS_TYPE.MDE or (ws_type == WS_TYPE.MDH and self._get_ws().hasOriginalWorkspace(
             0) and self._get_ws().getOriginalWorkspace(0).getNumDims() == self._get_ws().getNumDims())
 
+    def set_ws_name(self, new_name):
+        self._ws_name = new_name
+
     def get_ws_name(self) -> str:
         """Return the name of the workspace being viewed"""
-        return self._ws.name()
+        return self._ws_name
 
     def get_frame(self) -> SpecialCoordinateSystem:
         """Return the coordinate system of the workspace"""
@@ -140,7 +143,7 @@ class SliceViewerModel:
         of the model's workspace if none supplied.
         """
         if not ws_name:
-            ws_name = self.get_ws_name()
+            ws_name = self._ws_name
         return f'Sliceviewer - {ws_name}'
 
     def get_ws_MDE(self,
@@ -485,8 +488,7 @@ class SliceViewerModel:
         return help_msg
 
     def workspace_equals(self, ws_name):
-        # TODO put something better here
-        return str(self._get_ws()) == ws_name
+        return self._ws_name == ws_name
 
     # private api
     def _get_ws(self):

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/model.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/model.py
@@ -51,10 +51,10 @@ class SliceViewerModel:
         else:
             raise ValueError("only works for MatrixWorkspace and MDWorkspace")
 
-        self._ws_name = ws.name()
-        self._rebinned_name = self._ws_name+ '_svrebinned'
-        self._xcut_name, self._ycut_name = self._ws_name + '_cut_x', self._ws_name + '_cut_y'
-        self._roi_name = self._ws_name + '_roi'
+        ws_name = self.get_ws_name()
+        self._rebinned_name = ws_name + '_svrebinned'
+        self._xcut_name, self._ycut_name = ws_name + '_cut_x', ws_name + '_cut_y'
+        self._roi_name = ws_name + '_roi'
 
         ws_type = self.get_ws_type()
         if ws_type == WS_TYPE.MDE:
@@ -127,12 +127,9 @@ class SliceViewerModel:
         return ws_type == WS_TYPE.MDE or (ws_type == WS_TYPE.MDH and self._get_ws().hasOriginalWorkspace(
             0) and self._get_ws().getOriginalWorkspace(0).getNumDims() == self._get_ws().getNumDims())
 
-    def set_ws_name(self, new_name):
-        self._ws_name = new_name
-
     def get_ws_name(self) -> str:
         """Return the name of the workspace being viewed"""
-        return self._ws_name
+        return self._ws.name()
 
     def get_frame(self) -> SpecialCoordinateSystem:
         """Return the coordinate system of the workspace"""
@@ -488,7 +485,7 @@ class SliceViewerModel:
         return help_msg
 
     def workspace_equals(self, ws_name):
-        return self._ws_name == ws_name
+        return self.get_ws_name() == ws_name
 
     # private api
     def _get_ws(self):

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/model.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/model.py
@@ -143,7 +143,7 @@ class SliceViewerModel:
         of the model's workspace if none supplied.
         """
         if not ws_name:
-            ws_name = self._ws_name
+            ws_name = self.get_ws_name()
         return f'Sliceviewer - {ws_name}'
 
     def get_ws_MDE(self,

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/peaksviewer/model.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/peaksviewer/model.py
@@ -45,7 +45,6 @@ class PeaksViewerModel(TableWorkspaceDisplayModel):
             raise ValueError("Expected a PeaksWorkspace type but found a {}".format(type(peaks_ws)))
 
         super().__init__(peaks_ws)
-        self._peaks_ws_name = peaks_ws.name()
         self._fg_color = fg_color
         self._bg_color = bg_color
         self._representations: List[Painted] = []

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/peaksviewer/model.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/peaksviewer/model.py
@@ -45,6 +45,7 @@ class PeaksViewerModel(TableWorkspaceDisplayModel):
             raise ValueError("Expected a PeaksWorkspace type but found a {}".format(type(peaks_ws)))
 
         super().__init__(peaks_ws)
+        self._peaks_ws_name = peaks_ws.name()
         self._fg_color = fg_color
         self._bg_color = bg_color
         self._representations: List[Painted] = []

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/peaksviewer/presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/peaksviewer/presenter.py
@@ -248,12 +248,16 @@ class PeaksViewerCollectionPresenter:
         child_presenters = self._child_presenters
         presenter_to_remove = None
         for child in child_presenters:
-            if child.model.peaks_workspace.name() == name:
+            if child.model._peaks_ws_name == name:
                 presenter_to_remove = child
                 child.notify(PeaksViewerPresenter.Event.ClearPeaks)
                 index = self._view.remove_peaksviewer(child.view)
 
         child_presenters.remove(presenter_to_remove)
+
+        # update combo box for add/remove peak actions
+        self._actions_view.set_peaksworkspace(self.workspace_names())
+
         return index
 
     def workspace_names(self):
@@ -262,7 +266,7 @@ class PeaksViewerCollectionPresenter:
         """
         names = []
         for presenter in self._child_presenters:
-            names.append(presenter.model.peaks_workspace.name())
+            names.append(presenter.model._peaks_ws_name)
 
         return names
 

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/peaksviewer/presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/peaksviewer/presenter.py
@@ -258,6 +258,10 @@ class PeaksViewerCollectionPresenter:
         # update combo box for add/remove peak actions
         self._actions_view.set_peaksworkspace(self.workspace_names())
 
+        # hide if no peak tables remain
+        if not child_presenters:
+            self._view.hide()
+
         return index
 
     def workspace_names(self):

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/peaksviewer/presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/peaksviewer/presenter.py
@@ -248,7 +248,7 @@ class PeaksViewerCollectionPresenter:
         child_presenters = self._child_presenters
         presenter_to_remove = None
         for child in child_presenters:
-            if child.model._peaks_ws_name == name:
+            if child.model.peaks_workspace.name() == name:
                 presenter_to_remove = child
                 child.notify(PeaksViewerPresenter.Event.ClearPeaks)
                 index = self._view.remove_peaksviewer(child.view)
@@ -270,7 +270,7 @@ class PeaksViewerCollectionPresenter:
         """
         names = []
         for presenter in self._child_presenters:
-            names.append(presenter.model._peaks_ws_name)
+            names.append(presenter.model.peaks_workspace.name())
 
         return names
 

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/peaksviewer/test/test_peaksviewer_peaksviewercollectionpresenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/peaksviewer/test/test_peaksviewer_peaksviewercollectionpresenter.py
@@ -72,7 +72,19 @@ class PeaksViewerCollectionPresenterTest(unittest.TestCase):
 
         presenter.remove_peaksworkspace(names[1])
 
+        presenter._actions_view.set_peaksworkspace.assert_called_with([names[0], names[2]])
         self.assertEqual([names[0], names[2]], presenter.workspace_names())
+        presenter._view.hide.assert_not_called()
+
+    def test_hides_view_when_last_named_workspace_removed(self, mock_create_model):
+        names = ["peaks1"]
+        presenter = PeaksViewerCollectionPresenter(MagicMock())
+        presenter.append_peaksworkspace(names[0])
+
+        presenter.remove_peaksworkspace(names[0])
+
+        presenter._actions_view.set_peaksworkspace.assert_called_with([])
+        presenter._view.hide.assert_called()
 
     def test_notify_called_for_each_subpresenter(self, mock_create_model):
         presenter = PeaksViewerCollectionPresenter(MagicMock())

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/presenter.py
@@ -439,7 +439,6 @@ class SliceViewer(ObservingPresenter):
 
     def rename_workspace(self, old_name, new_name):
         if self.model.workspace_equals(old_name):
-            self.model.set_ws_name(new_name)
             self.view.emit_rename(self.model.get_title(new_name))
 
     def delete_workspace(self, ws_name):

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/presenter.py
@@ -438,8 +438,9 @@ class SliceViewer(ObservingPresenter):
             ws.unlock()
 
     def rename_workspace(self, old_name, new_name):
-        if self.model.workspace_equals(old_name):
-            self.view.emit_rename(self.model.get_title(new_name))
+        # check if model ws has new name (ADS observer runs post-rename)
+        if self.model.workspace_equals(new_name):
+            self.view.emit_rename(self.model.get_title())
 
     def delete_workspace(self, ws_name):
         if self.model.workspace_equals(ws_name):

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/presenter.py
@@ -438,11 +438,12 @@ class SliceViewer(ObservingPresenter):
             ws.unlock()
 
     def rename_workspace(self, old_name, new_name):
-        if str(self.model._get_ws()) == old_name:
+        if self.model.workspace_equals(old_name):
+            self.model.set_ws_name(new_name)
             self.view.emit_rename(self.model.get_title(new_name))
 
     def delete_workspace(self, ws_name):
-        if ws_name == str(self.model._ws):
+        if self.model.workspace_equals(ws_name):
             self.view.emit_close()
 
     def ADS_cleared(self):

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_sliceviewer_presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_sliceviewer_presenter.py
@@ -501,15 +501,15 @@ class SliceViewerTest(unittest.TestCase):
         mock_model = mock.MagicMock()
         mock_view = mock.MagicMock()
         pres = SliceViewer(mock.Mock(), model=mock_model, view=mock_view)
-        mock_model._ws = "test_name"
-        pres.delete_workspace(mock_model._ws)
+        mock_model.workspace_equals.return_value = True
+        pres.delete_workspace("test_name")
         mock_view.emit_close.assert_called_once()
 
     def test_workspace_not_deleted_with_different_name(self):
         mock_model = mock.MagicMock()
         mock_view = mock.MagicMock()
         pres = SliceViewer(mock.Mock(), model=mock_model, view=mock_view)
-        mock_model._ws = "test_name"
+        mock_model.workspace_equals.return_value = False
         pres.delete_workspace("different_name")
         mock_view.emit_close.assert_not_called()
 
@@ -541,16 +541,18 @@ class SliceViewerTest(unittest.TestCase):
         mock_model = mock.MagicMock()
         mock_view = mock.MagicMock()
         pres = SliceViewer(mock.Mock(), model=mock_model, view=mock_view)
-        mock_model._get_ws.return_value = "old_name"
+        mock_model.workspace_equals.return_value = True
         pres.rename_workspace("old_name", "new_name")
+        mock_model.set_ws_name.assert_called_with("new_name")
         mock_view.emit_rename.assert_called_once_with(mock_model.get_title.return_value)
 
     def test_rename_workspace_not_renamed_with_different_name(self):
         mock_model = mock.MagicMock()
         mock_view = mock.MagicMock()
         pres = SliceViewer(mock.Mock(), model=mock_model, view=mock_view)
-        mock_model._get_ws.return_value = "different_name"
+        mock_model.workspace_equals.return_value = False
         pres.rename_workspace("old_name", "new_name")
+        mock_model.set_ws_name.assert_not_called()
         mock_view.emit_rename.assert_not_called()
 
     def test_clear_ADS(self):


### PR DESCRIPTION
**Description of work.**

PR #33253 fixed ADS issues for sliceviewer and peaksviewer by storing the workspace name as an attribute in the respective model classes. This was necessary because the ADS remove method overwrote the workspace name with an empty string.

This PR stops the ADS remove overwriting the workspace name with an empty string and now the model classes can retrieve the name from the workspace to be deleted/removed from ADS (ADS observer sends notification before the delete actually occurs). The ws_name attribute has been removed from the model classes and I have also fixed the rename behaviour to stop regression of #33239 that was fixed in #33253 (there is a bug where the old name was checked against the model workspace, but the rename observer runs after then rename event, so the workspace name has already changed - i.e. it should check against the new name). 

**To test:**

Follow instructions in #33253 - it should behave the same

*There is no associated issue.*

*This does not require release notes* because **there is no change in behaviour for the user**


<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
