### PR TITLE
Check for active ws name in fit results dict when updating tables post-fit in EngDiff UI

### DIFF
--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/data_handling/data_model.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/data_handling/data_model.py
@@ -113,7 +113,7 @@ class FittingWorkspaceRecordContainer:
     def rename(self, old_ws_name, new_ws_name):
         ws_loaded = self.dict.get(old_ws_name, None)
         if ws_loaded:
-            self.dict[new_ws_name]= self.pop(old_ws_name)
+            self.dict[new_ws_name] = self.pop(old_ws_name)
         else:
             ws_loaded_name = self.get_loaded_workspace_name_from_bgsub(old_ws_name)
             if ws_loaded_name:
@@ -375,10 +375,7 @@ class FittingDataModel(object):
             ws = CreateWorkspace(OutputWorkspace=param, DataX=ipeak, DataY=ipeak, NSpec=nruns)
             # axis for labels in workspace
             axis = TextAxis.create(nruns)
-            for iws, wsname in enumerate(self.get_loaded_ws_list()):
-                wsname_bgsub = wsname + "_bgsub"
-                if wsname_bgsub in self._fit_results:
-                    wsname = wsname_bgsub
+            for iws, wsname in enumerate(self.get_active_ws_name_list()):
                 if wsname in self._fit_results and param in self._fit_results[wsname]['results']:
                     fitvals = array(self._fit_results[wsname]['results'][param])
                     data = vstack((fitvals, full((nfuncs - fitvals.shape[0], 2), nan)))
@@ -396,7 +393,7 @@ class FittingDataModel(object):
         model.addColumn(type="float", name="chisq/DOF")  # always is for LM minimiser (users can't change)
         model.addColumn(type="str", name="status")
         model.addColumn(type="str", name="Model")
-        for iws, wsname in enumerate(self.get_loaded_ws_list()):
+        for iws, wsname in enumerate(self.get_active_ws_name_list()):
             if wsname in self._fit_results:
                 row = [wsname, self._fit_results[wsname]['costFunction'],
                        self._fit_results[wsname]['status'], self._fit_results[wsname]['model']]


### PR DESCRIPTION
**Description of work.**

Bug fix to check for active ws name (i.e. `_bgsub` if bg subtracted) in fit results dict when populating tables post-fit.

**To test:**

(1) Load focused spectrum with xunit=TOF in fitting tab of EngDiff UI (see https://developer.mantidproject.org/Testing/EngineeringDiffraction/EngineeringDiffractionTestGuide.html for instructions)
(2) Plot data (check Plot box in UI table)
(3) Open fit browser (Fit in figure toolbar)
(4) Add a peak (Right-click > Add Peak > Left click to add)
(5) Execute Fit in fit browser
(6) Check the `model` table in `_fits` group of workspaces has a row with workspace name, fit status and function string.
(7) Check other output tables for individual parameters also have a row with the correct workspace name (e.g. `BackToBackExponential_X0`)
(8) Uncheck Subtract bg checkbox in UI table
(9) Repeat (3-7) - check that the workspace name in the model table is no longer `_bgsub`

Fixes #33248

*This does not require release notes* because **the bug was introduced this release**

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
