### PR TITLE
Add option to compute dQ

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/LRAutoReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/LRAutoReduction.py
@@ -77,6 +77,8 @@ class LRAutoReduction(PythonAlgorithm):
                              "Force the sequence number value if it's not available")
         self.declareProperty("OrderDirectBeamsByRunNumber", False,
                              "Force the sequence of direct beam files to be ordered by run number")
+        self.declareProperty("ComputeResolution", True,
+                             "If True, the Q resolution will be computed")
         self.declareProperty(FileProperty('OutputFilename', '', action=FileAction.OptionalSave, extensions=["txt"]),
                              doc='Name of the reflectivity file output')
         self.declareProperty(FileProperty("OutputDirectory", "", FileAction.Directory))
@@ -578,10 +580,11 @@ class LRAutoReduction(PythonAlgorithm):
         output_binning = [data_set.q_min, -abs(data_set.q_step), 2.0]
         dQ_constant = data_set.fourth_column_dq0
         dQ_slope = data_set.fourth_column_dq_over_q
-
+        compute_resolution = self.getProperty("ComputeResolution").value
         LRReflectivityOutput(ReducedWorkspaces=input_ws_list, ScaleToUnity=scale_to_unity,
                              ScalingWavelengthCutoff=wl_cutoff, OutputBinning=output_binning,
-                             DQConstant=dQ_constant, DQSlope=dQ_slope, OutputFilename=file_path)
+                             DQConstant=dQ_constant, DQSlope=dQ_slope,
+                             ComputeDQ=compute_resolution, OutputFilename=file_path)
         for ws in input_ws_list:
             AnalysisDataService.remove(str(ws))
 

--- a/Framework/PythonInterface/plugins/algorithms/LRReflectivityOutput.py
+++ b/Framework/PythonInterface/plugins/algorithms/LRReflectivityOutput.py
@@ -230,7 +230,7 @@ class LRReflectivityOutput(PythonAlgorithm):
             # Calibrated constant term for the resolution
             if mtd[scaled_ws_list[0]].getInstrument().hasParameter("dq-constant"):
                 dq0 = mtd[scaled_ws_list[0]].getInstrument().getNumberParameter("dq-constant")[0]
-            
+
             _dq_over_q = self.compute_resolution(mtd[scaled_ws_list[0]])
             if _dq_over_q:
                 dq_over_q = _dq_over_q

--- a/Framework/PythonInterface/plugins/algorithms/LRReflectivityOutput.py
+++ b/Framework/PythonInterface/plugins/algorithms/LRReflectivityOutput.py
@@ -36,6 +36,8 @@ class LRReflectivityOutput(PythonAlgorithm):
         self.declareProperty(FloatArrayProperty("OutputBinning", [0.005, -0.01, 1.0], direction=Direction.Input))
         self.declareProperty("DQConstant", 0.0004, "Constant factor for the resolution dQ = dQ0 + Q dQ/Q")
         self.declareProperty("DQSlope", 0.025, "Slope for the resolution dQ = dQ0 + Q dQ/Q")
+        self.declareProperty("ComputeDQ", True, "If true, the Q resolution will be computed")
+        self.declareProperty("FrontSlitName", "S1", doc="Name of the front slit")
         self.declareProperty(FileProperty('OutputFilename', '', action=FileAction.Save, extensions=["txt"]),
                              doc='Name of the reflectivity file output')
         self.declareProperty("MetaData", "", "Additional meta-data to add to the top of the output file")
@@ -48,6 +50,35 @@ class LRReflectivityOutput(PythonAlgorithm):
 
         # Put the workspaces together
         self.average_points_for_single_q(workspace_list)
+
+    def compute_resolution(self, ws):
+        """
+            Compute the Q resolution from the meta data.
+        """
+        # We can't compute the resolution if the value of xi is not in the logs.
+        # Since it was not always logged, check for it here.
+        if not ws.getRun().hasProperty("BL4B:Mot:xi.RBV"):
+            return None
+
+        # Xi reference would be the position of xi if the si slit were to be positioned
+        # at the sample. The distance from the sample to si is then xi_reference - xi.
+        xi_reference = 445
+        if ws.getInstrument().hasParameter("xi-reference"):
+            ws.getInstrument().getNumberParameter("xi-reference")[0]
+
+        # Distance between the s1 and the sample
+        s1_sample_distance = 1485
+        if ws.getInstrument().hasParameter("s1-sample-distance"):
+            ws.getInstrument().getNumberParameter("s1-sample-distance")[0]
+
+        front_slit = self.getProperty("FrontSlitName").value
+        s1h = abs(ws.getRun().getProperty("%sVHeight" % front_slit).value[0])
+        ths = abs(ws.getRun().getProperty("ths").value[0])
+        xi = abs(ws.getRun().getProperty("BL4B:Mot:xi.RBV").value[0])
+        sample_si_distance = xi_reference - xi
+        slit_distance = s1_sample_distance - sample_si_distance
+        dq_over_q = s1h / slit_distance * 180 / 3.1416 / ths
+        return dq_over_q
 
     def check_scaling(self, workspace_list):
         """
@@ -192,6 +223,18 @@ class LRReflectivityOutput(PythonAlgorithm):
         file_path = self.getProperty("OutputFilename").value
         dq0 = self.getProperty("DQConstant").value
         dq_over_q = self.getProperty("DQSlope").value
+
+        # Check whether we want to compute the Q resolution
+        compute_dq = self.getProperty("ComputeDQ").value
+        if compute_dq:
+            # Calibrated constant term for the resolution
+            if mtd[scaled_ws_list[0]].getInstrument().hasParameter("dq-constant"):
+                dq0 = mtd[scaled_ws_list[0]].getInstrument().getNumberParameter("dq-constant")[0]
+            
+            _dq_over_q = self.compute_resolution(mtd[scaled_ws_list[0]])
+            if _dq_over_q:
+                dq_over_q = _dq_over_q
+
         meta_data = self.getProperty("MetaData").value
 
         data_x = mtd[scaled_ws_list[0] + '_scaled'].dataX(0)

--- a/Framework/PythonInterface/plugins/algorithms/LRReflectivityOutput.py
+++ b/Framework/PythonInterface/plugins/algorithms/LRReflectivityOutput.py
@@ -58,6 +58,7 @@ class LRReflectivityOutput(PythonAlgorithm):
         # We can't compute the resolution if the value of xi is not in the logs.
         # Since it was not always logged, check for it here.
         if not ws.getRun().hasProperty("BL4B:Mot:xi.RBV"):
+            logger.notice("Could not find BL4B:Mot:xi.RBV: using supplied dQ/Q")
             return None
 
         # Xi reference would be the position of xi if the si slit were to be positioned

--- a/Testing/Data/SystemTest/REF_L_190367.nxs.h5.md5
+++ b/Testing/Data/SystemTest/REF_L_190367.nxs.h5.md5
@@ -1,0 +1,1 @@
+b0ddc06ee65483dfbafbea5e0500e99b

--- a/Testing/SystemTests/tests/framework/LiquidsReflectometryReductionTest.py
+++ b/Testing/SystemTests/tests/framework/LiquidsReflectometryReductionTest.py
@@ -106,7 +106,6 @@ class LRReflectivityOutputTest(systemtesting.MantidSystemTest):
                 content = fd.read()
                 if content.startswith('# Experiment IPTS-11601 Run 119814'):
                     self._success = True
-            os.remove(output_path)
         else:
             print("Error: expected output file '{}' not found.".format(output_path))
 

--- a/Testing/SystemTests/tests/framework/LiquidsReflectometryReductionTest.py
+++ b/Testing/SystemTests/tests/framework/LiquidsReflectometryReductionTest.py
@@ -114,6 +114,66 @@ class LRReflectivityOutputTest(systemtesting.MantidSystemTest):
         return self._success
 
 
+class LRReflectivityOutputResolutionTest(systemtesting.MantidSystemTest):
+    """
+        Test the reflectivity output algorithm with resolution calculation
+    """
+    def runTest(self):
+        LiquidsReflectometryReduction(RunNumbers=[190367],
+                                      NormalizationRunNumber=0,
+                                      SignalPeakPixelRange=[142, 152],
+                                      SubtractSignalBackground=True,
+                                      SignalBackgroundPixelRange=[139, 155],
+                                      NormFlag=False,
+                                      NormPeakPixelRange=[142, 151],
+                                      NormBackgroundPixelRange=[139, 154],
+                                      SubtractNormBackground=True,
+                                      LowResDataAxisPixelRangeFlag=True,
+                                      LowResDataAxisPixelRange=[70, 178],
+                                      LowResNormAxisPixelRangeFlag=True,
+                                      LowResNormAxisPixelRange=[70, 178],
+                                      TOFRange=[51978.9, 65266.7],
+                                      IncidentMediumSelected='air',
+                                      GeometryCorrectionFlag=False,
+                                      QMin=0.005,
+                                      QStep=0.02,
+                                      AngleOffset=0.01,
+                                      AngleOffsetError=0.001,
+                                      ApplyScalingFactor=False,
+                                      ScalingFactorFile='',
+                                      SlitsWidthFlag=True,
+                                      CropFirstAndLastPoints=False,
+                                      ApplyPrimaryFraction=False,
+                                      OutputWorkspace='reflectivity_190367')
+
+        output_path = get_file_path('lr_output.txt')
+
+        # Remove the output file if it exists
+        if os.path.isfile(output_path):
+            os.remove(output_path)
+
+        LRReflectivityOutput(ReducedWorkspaces=["reflectivity_190367"],
+                             ComputeDQ=True,
+                             OutputFilename=output_path)
+
+        # Find the dQ/Q value in the output file to determine success
+        self._success = False
+        if os.path.isfile(output_path):
+            with open(output_path, 'r') as fd:
+                for line in fd.readlines():
+                    if line.startswith("# dQ/Q"):
+                    toks = line.split('=')
+                    dq_over_q = float(toks[1])
+                    if abs(dq_over_q - 0.0273679) < 0.00001:
+                        self._success = True
+            os.remove(output_path)
+        else:
+            print("Error: expected output file '{}' not found.".format(output_path))
+
+    def validate(self):
+        return self._success
+
+
 class LiquidsReflectometryReductionSimpleErrorTest(systemtesting.MantidSystemTest):
     """
         Test algorithm LiquidsReflectometryReduction with simple binning

--- a/Testing/SystemTests/tests/framework/LiquidsReflectometryReductionTest.py
+++ b/Testing/SystemTests/tests/framework/LiquidsReflectometryReductionTest.py
@@ -162,10 +162,10 @@ class LRReflectivityOutputResolutionTest(systemtesting.MantidSystemTest):
             with open(output_path, 'r') as fd:
                 for line in fd.readlines():
                     if line.startswith("# dQ/Q"):
-                    toks = line.split('=')
-                    dq_over_q = float(toks[1])
-                    if abs(dq_over_q - 0.0273679) < 0.00001:
-                        self._success = True
+                        toks = line.split('=')
+                        dq_over_q = float(toks[1])
+                        if abs(dq_over_q - 0.0273679) < 0.00001:
+                            self._success = True
             os.remove(output_path)
         else:
             print("Error: expected output file '{}' not found.".format(output_path))

--- a/Testing/SystemTests/tests/framework/LiquidsReflectometryReductionTest.py
+++ b/Testing/SystemTests/tests/framework/LiquidsReflectometryReductionTest.py
@@ -119,7 +119,7 @@ class LRReflectivityOutputTest(systemtesting.MantidSystemTest):
 
         ws_name = "reflectivity_119814"
         if mtd.doesExist(ws_name):
-                mtd.remove(ws_name)
+            mtd.remove(ws_name)
 
 
 class LRReflectivityOutputResolutionTest(systemtesting.MantidSystemTest):
@@ -187,7 +187,7 @@ class LRReflectivityOutputResolutionTest(systemtesting.MantidSystemTest):
 
         ws_name = "reflectivity_190367"
         if mtd.doesExist(ws_name):
-                mtd.remove(ws_name)
+            mtd.remove(ws_name)
 
 
 class LiquidsReflectometryReductionSimpleErrorTest(systemtesting.MantidSystemTest):

--- a/Testing/SystemTests/tests/framework/LiquidsReflectometryReductionTest.py
+++ b/Testing/SystemTests/tests/framework/LiquidsReflectometryReductionTest.py
@@ -113,6 +113,15 @@ class LRReflectivityOutputTest(systemtesting.MantidSystemTest):
     def validate(self):
         return self._success
 
+    def cleanup(self):
+        output_path = get_file_path('lr_output.txt')
+        if os.path.isfile(output_path):
+            os.remove(output_path)
+
+        ws_name = "reflectivity_119814"
+        if mtd.doesExist(ws_name):
+                mtd.remove(ws_name)
+
 
 class LRReflectivityOutputResolutionTest(systemtesting.MantidSystemTest):
     """
@@ -160,18 +169,26 @@ class LRReflectivityOutputResolutionTest(systemtesting.MantidSystemTest):
         self._success = False
         if os.path.isfile(output_path):
             with open(output_path, 'r') as fd:
-                for line in fd.readlines():
+                for line in fd:
                     if line.startswith("# dQ/Q"):
                         toks = line.split('=')
                         dq_over_q = float(toks[1])
                         if abs(dq_over_q - 0.0273679) < 0.00001:
                             self._success = True
-            os.remove(output_path)
         else:
             print("Error: expected output file '{}' not found.".format(output_path))
 
     def validate(self):
         return self._success
+
+    def cleanup(self):
+        output_path = get_file_path('lr_output.txt')
+        if os.path.isfile(output_path):
+            os.remove(output_path)
+
+        ws_name = "reflectivity_190367"
+        if mtd.doesExist(ws_name):
+                mtd.remove(ws_name)
 
 
 class LiquidsReflectometryReductionSimpleErrorTest(systemtesting.MantidSystemTest):

--- a/docs/source/release/v6.3.0/33277_Framework.rst
+++ b/docs/source/release/v6.3.0/33277_Framework.rst
@@ -1,0 +1,8 @@
+Algorithms 
+---------- 
+
+Improvements 
+############
+
+- Improvement for the Liquids Reflectometer at SNS. Added functionality to the `LRReflectivityOutput` algorithm to automatically compute the 
+Q resolution from the data. An option has been added to the `LRAutoReduction` algorithm to switch this feature on and off.

--- a/docs/source/release/v6.3.0/33277_Framework.rst
+++ b/docs/source/release/v6.3.0/33277_Framework.rst
@@ -1,8 +1,7 @@
-Algorithms 
----------- 
+Algorithms
+----------
 
-Improvements 
+Improvements
 ############
 
-- Improvement for the Liquids Reflectometer at SNS. Added functionality to the `LRReflectivityOutput` algorithm to automatically compute the 
-Q resolution from the data. An option has been added to the `LRAutoReduction` algorithm to switch this feature on and off.
+- Improvement for the Liquids Reflectometer at SNS. Added functionality to the `LRReflectivityOutput` algorithm to automatically compute the Q resolution from the data. An option has been added to the `LRAutoReduction` algorithm to switch this feature on and off.


### PR DESCRIPTION
**Description of work.**

The Q resolution is currently a parameter. It is preferable to compute it using the data.
This change adds this option, and defaults to the given algorithm parameters (current functionality) if dQ can't be calculated.

**To test:**

- The existing tests should pass.
- Using a more recent run (taken after Jan 9, 2022) will produce a different number for the `dq_over_q` meta-data entry in the output ascii file.

*There is no associated issue.*


<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
