### PR TITLE
SANS: Catch KeyError from CSV parser

### DIFF
--- a/docs/source/release/v6.3.0/33238_SANS.rst
+++ b/docs/source/release/v6.3.0/33238_SANS.rst
@@ -1,0 +1,4 @@
+Bugfixes
+--------
+
+- Loading a CSV file with a missing column now shows an error box explaining the problem. Previously, it showed an uncaught exception.

--- a/scripts/SANS/sans/gui_logic/presenter/run_tab_presenter.py
+++ b/scripts/SANS/sans/gui_logic/presenter/run_tab_presenter.py
@@ -465,7 +465,7 @@ class RunTabPresenter(PresenterCommon):
             # 4. Set the batch file path in the model
             self._model.batch_file = batch_file_path
 
-        except (RuntimeError, ValueError, SyntaxError) as e:
+        except (RuntimeError, ValueError, SyntaxError, IOError, KeyError) as e:
             self.sans_logger.error("Loading of the batch file failed. {}".format(str(e)))
             self.display_warning_box('Warning', 'Loading of the batch file failed', str(e))
 

--- a/scripts/test/SANS/gui_logic/test_run_tab_presenter.py
+++ b/scripts/test/SANS/gui_logic/test_run_tab_presenter.py
@@ -222,6 +222,24 @@ class RunTabPresenterTest(unittest.TestCase):
         # Clean up
         self._remove_files(user_file_path=user_file_path, batch_file_path=batch_file_path)
 
+    def test_that_on_batch_file_load(self):
+        for exception in [RuntimeError, ValueError, SyntaxError, IOError, KeyError]:
+            # XXX: This function should be broken up into a model / presenter long-term
+            self.presenter._csv_parser.parse_batch_file = mock.Mock(side_effect=exception)
+            self.presenter.sans_logger = mock.Mock()
+            self.presenter.display_warning_box = mock.Mock()
+
+            with mock.patch.multiple("sans.gui_logic.presenter.run_tab_presenter",
+                                     add_dir_to_datasearch=mock.DEFAULT,
+                                     ConfigService=mock.DEFAULT,
+                                     os=mock.DEFAULT) as mock_datasearch:
+
+                mock_datasearch["add_dir_to_datasearch"].return_value = (mock.Mock(), mock.Mock())
+                self.presenter.on_batch_file_load()
+
+            self.presenter.sans_logger.error.assert_called_once()
+            self.presenter.display_warning_box.assert_called_once()
+
     def test_state_retrieved_from_model(self):
         # Set values which trigger operators, such as divide or parsing, in StateModels
         self._mock_view.q_1d_step = 1.0


### PR DESCRIPTION
**Description of work.**
Catches a KeyError which wasn't in the list of expected exceptions. This
would be produced if a transposed CSV was used

**To test:**
- Load the following CSV: 
[transp_batch_mode_reduction.csv](https://github.com/mantidproject/mantid/files/7848762/transp_batch_mode_reduction.csv)
- Open ISIS SANS Interface
- Set the Batch File to the above
- This should produce an dialogue error instead of an uncaught exception

Fixes #33238

*This does not require release notes* because it was noticed during testing and not by users

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
