### PR TITLE
Workbench Logging: Remove logger channel on exit

### DIFF
--- a/qt/widgets/common/src/MessageDisplay.cpp
+++ b/qt/widgets/common/src/MessageDisplay.cpp
@@ -33,8 +33,6 @@
 #include <Poco/Version.h>
 
 namespace {
-// Track number of attachments to generate a unique channel name
-int ATTACH_COUNT = 0;
 
 int DEFAULT_LINE_COUNT_MAX = 8192;
 const char *PRIORITY_KEY_NAME = "MessageDisplayPriority";
@@ -130,7 +128,6 @@ void MessageDisplay::attachLoggingChannel(int logLevel) {
   if (logLevel > 0) {
     configSvc.setLogLevel(logLevel, true);
   }
-  ++ATTACH_COUNT;
 }
 
 /**

--- a/qt/widgets/common/src/MessageDisplay.cpp
+++ b/qt/widgets/common/src/MessageDisplay.cpp
@@ -96,8 +96,17 @@ MessageDisplay::MessageDisplay(const QFont &font, QWidget *parent)
 }
 
 MessageDisplay::~MessageDisplay() {
-  // The Channel class is ref counted and will
-  // delete itself when required
+  // We only attach to splitter channels but we may not have been attached...
+  auto rootChannel = Poco::Logger::root().getChannel();
+#if POCO_VERSION > 0x01090400
+  // getChannel changed to return an AutoPtr
+  if (auto *splitChannel = dynamic_cast<Poco::SplitterChannel *>(rootChannel.get())) {
+#else
+  if (auto *splitChannel = dynamic_cast<Poco::SplitterChannel *>(rootChannel)) {
+#endif
+    splitChannel->removeChannel(m_logChannel);
+  }
+  // The Channel class is ref counted and will delete itself when required
   m_logChannel->release();
   delete m_textDisplay;
 }
@@ -111,7 +120,6 @@ MessageDisplay::~MessageDisplay() {
 void MessageDisplay::attachLoggingChannel(int logLevel) {
   // Setup logging. ConfigService needs to be started
   auto &configSvc = ConfigService::Instance();
-  auto &rootLogger = Poco::Logger::root();
   // The root channel might be a SplitterChannel
   auto rootChannel = Poco::Logger::root().getChannel();
 #if POCO_VERSION > 0x01090400
@@ -122,7 +130,8 @@ void MessageDisplay::attachLoggingChannel(int logLevel) {
 #endif
     splitChannel->addChannel(m_logChannel);
   } else {
-    Poco::Logger::setChannel(rootLogger.name(), m_logChannel);
+    throw std::runtime_error("MessageDisplay requires the root logger to be configured with a SplitterChannel.\n"
+                             "Set 'logging.loggers.root.channel.class = SplitterChannel' in properties file.");
   }
   connect(m_logChannel, SIGNAL(messageReceived(const Message &)), this, SLOT(append(const Message &)));
   if (logLevel > 0) {


### PR DESCRIPTION
**Description of work.**

The message widget in mantidqt that hooks up to the mantid logger uses a custom Poco::Channel that is subscribed to the Logger channel list. The channel is now removed from the Logger's channel list on destruction of the widget so that any further log statements will not using a dangling pointer when logging to the channels list and avoid a seg fault.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**

* See the attached issue and follow the reproduction instructions and no crash should happen.

Fixes #33270

*This does not require release notes* because **it is a niche bug that has existed for many years that I don't think is necessary to put in the notes.**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
