### PR TITLE
Activate stale bot for pull requests

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,31 +1,64 @@
-# Number of days of inactivity before an issue becomes stale
-daysUntilStale: 180
-# Number of days of inactivity before a stale issue is closed
-daysUntilClose: 7
-# Issues with these labels will never be considered stale
-exemptLabels:
-  - Induction
-  - Roadmap
 # Label to use when marking an issue as stale
 staleLabel: Stale
-# Comment to post when marking an issue as stale. Set to `false` to disable
-markComment: >
-  This issue has been automatically marked as stale because it has not had
-  activity in 6 months. It will be closed in 7 days if no further activity occurs.
 
-  Allowing issues to close as stale helps us filter out issues which can wait
-  for future development time. All issues closed by stale bot act like normal issues; they can be searched for, commented on or reopened at any point.
+# Options specific to issues
+issues:
+  # Number of days of inactivity before an issue becomes stale
+  daysUntilStale: 180
 
-  If you'd like a closed stale issue to be considered,
-  feel free to either re-open the issue directly or contact a developer.
+  # Number of days of inactivity before a stale issue is closed
+  daysUntilClose: 7
 
-  To extend the lifetime of an issue please comment below,
-  it helps us see that this is still affecting you and you want
-  it fixed in the near-future. Extending the lifetime of an issue
-  may cause the development team to prioritise it over other issues,
-  which may be closed as stale instead.
+  # Issues with these labels will never be considered stale
+  exemptLabels:
+    - Induction
+    - Roadmap
 
-# Comment to post when closing a stale issue. Set to `false` to disable
-closeComment: >
-  This issue has been closed automatically. If this still affects you please
-  re-open this issue with a comment or contact us so we can look into resolving it.
+  # Comment to post when marking an issue as stale. Set to `false` to disable
+  markComment: >
+    This issue has been automatically marked as stale because it has not had
+    activity in 6 months. It will be closed in 7 days if no further activity occurs.
+
+    Allowing issues to close as stale helps us filter out issues which can wait
+    for future development time. All issues closed by stale bot act like normal issues; they can be searched for, commented on or reopened at any point.
+
+    If you'd like a closed stale issue to be considered,
+    feel free to either re-open the issue directly or contact a developer.
+
+    To extend the lifetime of an issue please comment below,
+    it helps us see that this is still affecting you and you want
+    it fixed in the near-future. Extending the lifetime of an issue
+    may cause the development team to prioritise it over other issues,
+    which may be closed as stale instead.
+
+  # Comment to post when closing a stale issue. Set to `false` to disable
+  closeComment: >
+    This issue has been closed automatically. If this still affects you please
+    re-open this issue with a comment or contact us so we can look into resolving it.
+
+pulls:
+  # Number of days of inactivity before a pull request becomes stale
+  daysUntilStale: 90
+
+  # Number of days of inactivity before a stale pull request is closed
+  daysUntilClose: 7
+
+  # Comment to post when marking an issue as stale. Set to `false` to disable
+  markComment: >
+    This pull request has been automatically marked as stale because it has not had
+    activity in 3 months. It will be closed in 7 days if no further activity occurs.
+
+    Allowing pull requests to close as stale helps us filter out old work that is no longer
+    relevant and helps developers focus on reviewing current work.
+
+    All pull requests closed by this bot act like normal pull requests;
+    they can be searched for, commented on or reopened at any point.
+
+    If these changes are still relevant then please comment and tag \@mantidproject/gatekeepers to highlight
+    that it needs to have a reviewer assigned.
+
+  # Comment to post when closing a pull request. Set to `false` to disable
+  closeComment: >
+    This pull request has been closed automatically. If these changes are still relevant
+    then please re-open this pull request with a comment and tag \@mantidproject/gatekeepers
+    to highlight it needs to have a reviewer assigned.


### PR DESCRIPTION
**Description of work.**

The stale bot has worked well for issues since activation.
Activating this for pull requests will allow developers to focus
their efforts on reviewing relevant work.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**

* Review the changes, particularly the comments applied to the pull requests when the bot runs

*There is no associated issue.*

*This does not require release notes* because **it does not alter the code base and is a process change**

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
