### PR TITLE
Allow Deletion of Empty Workspace Groups

### DIFF
--- a/Framework/Algorithms/inc/MantidAlgorithms/DeleteWorkspace.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/DeleteWorkspace.h
@@ -40,6 +40,8 @@ private:
 
   const std::string workspaceMethodName() const override { return "delete"; }
   const std::string workspaceMethodInputProperty() const override { return "Workspace"; }
+
+  bool checkGroups() override;
 };
 
 } // namespace Algorithms

--- a/Framework/Algorithms/src/DeleteWorkspace.cpp
+++ b/Framework/Algorithms/src/DeleteWorkspace.cpp
@@ -34,11 +34,15 @@ void DeleteWorkspace::exec() {
 bool DeleteWorkspace::checkGroups() {
   AnalysisDataServiceImpl &dataStore = AnalysisDataService::Instance();
   const std::string wsName = getProperty("Workspace");
-  auto wsPtr = dataStore.retrieve(wsName);
-  if (wsPtr->isGroup() && !dataStore.retrieveWS<WorkspaceGroup>(wsName)->isEmpty()) {
+  if (dataStore.doesExist(wsName)) {
+    auto wsPtr = dataStore.retrieve(wsName);
+    if (wsPtr->isGroup() && !dataStore.retrieveWS<WorkspaceGroup>(wsName)->isEmpty()) {
+      return Algorithm::checkGroups();
+    }
+    return false;
+  } else {
     return Algorithm::checkGroups();
   }
-  return false;
 }
 
 } // namespace Mantid::Algorithms

--- a/Framework/Algorithms/src/DeleteWorkspace.cpp
+++ b/Framework/Algorithms/src/DeleteWorkspace.cpp
@@ -31,6 +31,11 @@ void DeleteWorkspace::exec() {
   dataStore.remove(wsName); // Logs if it doesn't exist
 }
 
+/**
+ * We want most of the functionality from checkGroups, but will handle empty groups separately as we still
+ * want to be able to delete them.
+ * @return If the workspace should be processed using processGroups.
+ */
 bool DeleteWorkspace::checkGroups() {
   AnalysisDataServiceImpl &dataStore = AnalysisDataService::Instance();
   const std::string wsName = getProperty("Workspace");

--- a/Framework/Algorithms/src/DeleteWorkspace.cpp
+++ b/Framework/Algorithms/src/DeleteWorkspace.cpp
@@ -6,8 +6,12 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 #include "MantidAlgorithms/DeleteWorkspace.h"
 #include "MantidAPI/AnalysisDataService.h"
+#include "MantidAPI/WorkspaceGroup.h"
 
 namespace Mantid::Algorithms {
+
+using namespace Kernel;
+using namespace API;
 
 // Register the algorithm
 DECLARE_ALGORITHM(DeleteWorkspace)
@@ -26,4 +30,15 @@ void DeleteWorkspace::exec() {
   const std::string wsName = getProperty("Workspace");
   dataStore.remove(wsName); // Logs if it doesn't exist
 }
+
+bool DeleteWorkspace::checkGroups() {
+  AnalysisDataServiceImpl &dataStore = AnalysisDataService::Instance();
+  const std::string wsName = getProperty("Workspace");
+  auto wsPtr = dataStore.retrieve(wsName);
+  if (wsPtr->isGroup() && !dataStore.retrieveWS<WorkspaceGroup>(wsName)->isEmpty()) {
+    return Algorithm::checkGroups();
+  }
+  return false;
+}
+
 } // namespace Mantid::Algorithms

--- a/Framework/Algorithms/src/DeleteWorkspaces.cpp
+++ b/Framework/Algorithms/src/DeleteWorkspaces.cpp
@@ -7,7 +7,6 @@
 #include "MantidAlgorithms/DeleteWorkspaces.h"
 #include "MantidAPI/ADSValidator.h"
 #include "MantidAPI/AnalysisDataService.h"
-#include "MantidAPI/WorkspaceGroup.h"
 #include "MantidKernel/ArrayProperty.h"
 
 namespace Mantid::Algorithms {

--- a/Framework/Algorithms/src/DeleteWorkspaces.cpp
+++ b/Framework/Algorithms/src/DeleteWorkspaces.cpp
@@ -7,6 +7,7 @@
 #include "MantidAlgorithms/DeleteWorkspaces.h"
 #include "MantidAPI/ADSValidator.h"
 #include "MantidAPI/AnalysisDataService.h"
+#include "MantidAPI/WorkspaceGroup.h"
 #include "MantidKernel/ArrayProperty.h"
 
 namespace Mantid::Algorithms {
@@ -35,26 +36,11 @@ void DeleteWorkspaces::exec() {
       // properties were set. If a workspace is missing, it was probably
       // a group workspace whose contents were deleted before the group
       // itself.
-      bool success = false;
-      bool executed = false;
-      try {
-        auto deleteAlg = createChildAlgorithm("DeleteWorkspace", -1, -1, false);
-        deleteAlg->initialize();
-        deleteAlg->setPropertyValue("Workspace", wsName);
-        success = deleteAlg->execute();
-        executed = deleteAlg->isExecuted();
-      } catch (std::invalid_argument &e) {
-        // Empty group workspaces cannot be deleted, they need to be ungrouped to remove them.
-        if (std::string(e.what()) == "Empty group passed as input") {
-          auto unGroupAlg = createChildAlgorithm("UnGroupWorkspace", -1, -1, false);
-          unGroupAlg->initialize();
-          unGroupAlg->setPropertyValue("InputWorkspace", wsName);
-          success = unGroupAlg->execute();
-          executed = unGroupAlg->isExecuted();
-        } else {
-          throw e;
-        }
-      }
+      auto deleteAlg = createChildAlgorithm("DeleteWorkspace", -1, -1, false);
+      deleteAlg->initialize();
+      deleteAlg->setPropertyValue("Workspace", wsName);
+      auto success = deleteAlg->execute();
+      auto executed = deleteAlg->isExecuted();
       if (!executed || !success) {
         g_log.error() << "Failed to delete " << wsName << ".\n";
       }

--- a/Framework/Algorithms/src/DeleteWorkspaces.cpp
+++ b/Framework/Algorithms/src/DeleteWorkspaces.cpp
@@ -44,9 +44,8 @@ void DeleteWorkspaces::exec() {
         success = deleteAlg->execute();
         executed = deleteAlg->isExecuted();
       } catch (std::invalid_argument &e) {
-        std::string const msg = e.what();
         // Empty group workspaces cannot be deleted, they need to be ungrouped to remove them.
-        if (msg == "Empty group passed as input") {
+        if (std::string(e.what()) == "Empty group passed as input") {
           auto unGroupAlg = createChildAlgorithm("UnGroupWorkspace", -1, -1, false);
           unGroupAlg->initialize();
           unGroupAlg->setPropertyValue("InputWorkspace", wsName);

--- a/Framework/Algorithms/test/DeleteWorkspaceTest.h
+++ b/Framework/Algorithms/test/DeleteWorkspaceTest.h
@@ -87,4 +87,27 @@ public:
 
     dataStore.clear();
   }
+
+  void test_deleting_empty_group() {
+    using namespace Mantid::API;
+    using namespace Mantid::DataObjects;
+    AnalysisDataServiceImpl &dataStore = AnalysisDataService::Instance();
+    const size_t storeSizeAtStart(dataStore.size());
+
+    const auto groupName = "emptyGroup";
+    auto group = WorkspaceCreationHelper::createWorkspaceGroup(0, 0, 0, groupName);
+    dataStore.addOrReplace(groupName, group);
+    TS_ASSERT_EQUALS(storeSizeAtStart + 1, dataStore.size())
+    Mantid::Algorithms::DeleteWorkspace alg;
+    alg.initialize();
+    alg.setRethrows(true);
+    alg.setPropertyValue("Workspace", groupName);
+
+    auto success = alg.execute();
+
+    TS_ASSERT(alg.isExecuted());
+    TS_ASSERT(success);
+    TS_ASSERT_EQUALS(storeSizeAtStart, dataStore.size())
+    dataStore.clear();
+  }
 };

--- a/Framework/Algorithms/test/DeleteWorkspacesTest.h
+++ b/Framework/Algorithms/test/DeleteWorkspacesTest.h
@@ -114,6 +114,28 @@ public:
     TS_ASSERT_EQUALS(dataStore.size(), storeSizeAtStart);
   }
 
+  void test_deleting_empty_group() {
+    using namespace Mantid::API;
+    using namespace Mantid::DataObjects;
+    AnalysisDataServiceImpl &dataStore = AnalysisDataService::Instance();
+    const size_t storeSizeAtStart(dataStore.size());
+
+    const auto groupName = "emptyGroup";
+    auto group = WorkspaceCreationHelper::createWorkspaceGroup(0, 0, 0, groupName);
+    dataStore.addOrReplace(groupName, group);
+    TS_ASSERT_EQUALS(storeSizeAtStart + 1, dataStore.size())
+    Mantid::Algorithms::DeleteWorkspaces alg;
+    alg.initialize();
+    alg.setRethrows(true);
+    alg.setPropertyValue("WorkspaceList", groupName);
+
+    auto success = alg.execute();
+
+    TS_ASSERT(alg.isExecuted());
+    TS_ASSERT(success);
+    TS_ASSERT_EQUALS(storeSizeAtStart, dataStore.size())
+  }
+
   void createAndStoreWorkspace(const std::string &name, int ylength = 10) {
     using namespace Mantid::API;
     using namespace Mantid::DataObjects;

--- a/docs/source/release/v6.3.0/33221_mantidworkbench.rst
+++ b/docs/source/release/v6.3.0/33221_mantidworkbench.rst
@@ -1,0 +1,4 @@
+Bugfixes
+--------
+
+- Empty group workspaces can now be deleted rather than needing to be ungrouped.


### PR DESCRIPTION
**Description of work.**
Allows the deleteWorkspaces algorithm used in the GUI for the Delete key and button to work on empty groups. There is a check in Algorithm for empty groups that throws if it finds one. Rather than adding checks in  deleteWorkspace, which could have greater reaching consequesnses, we now simply make use of the UngroupWorkspace algorithm if the base class throws a specific error. 

**To test:**
Run the following
```python
from mantid import api
group = api.WorkspaceGroup()
mtd.addOrReplace("group", group)
```

Try to delete this by using the delete key or GUI button. It should be removed without errors. 

Fixes #33221

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
