### PR TITLE
Fixed ALC bug allowed decimal detector groupings

### DIFF
--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -727,7 +727,7 @@ unreadVariable:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/General/StepScan.cpp
 useStlAlgorithm:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/Muon/ALCBaselineModellingModel.cpp:115
 useStlAlgorithm:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/Muon/ALCDataLoadingView.cpp:343
 unreadVariable:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/Muon/ALCDataLoadingView.cpp:168
-useStlAlgorithm:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/Muon/ALCDataLoadingPresenter.cpp:308
+useStlAlgorithm:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/Muon/ALCDataLoadingPresenter.cpp:310
 useStlAlgorithm:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/Muon/ALCInterface.cpp:232
 useStlAlgorithm:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/ISISReflectometry/Common/Clipboard.cpp:91
 useInitializationList:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/ISISReflectometry/Common/OptionDefaults.cpp:18

--- a/docs/source/release/v6.3.0/33283_muon.rst
+++ b/docs/source/release/v6.3.0/33283_muon.rst
@@ -1,0 +1,7 @@
+ALC
+---
+
+Bugfixes
+########
+
+- Fixed a bug that allowed decimal values for custom groupings.

--- a/qt/scientific_interfaces/Muon/ALCDataLoadingPresenter.cpp
+++ b/qt/scientific_interfaces/Muon/ALCDataLoadingPresenter.cpp
@@ -31,7 +31,7 @@ const int RUNS_WARNING_LIMIT = 200;
 // must include the "."
 const std::vector<std::string> ADDITIONAL_EXTENSIONS{".nxs", ".nxs_v2", ".bin"};
 
-bool is_decimal(const char character) { return (character == '.') ? true : false; };
+bool is_decimal(const char character) { return (character == '.') ? true : false; }
 } // namespace
 
 using namespace Mantid::Kernel;

--- a/qt/scientific_interfaces/Muon/ALCDataLoadingPresenter.cpp
+++ b/qt/scientific_interfaces/Muon/ALCDataLoadingPresenter.cpp
@@ -31,7 +31,7 @@ const int RUNS_WARNING_LIMIT = 200;
 // must include the "."
 const std::vector<std::string> ADDITIONAL_EXTENSIONS{".nxs", ".nxs_v2", ".bin"};
 
-bool is_decimal(const char character) { return (character == '.') ? true : false; }
+bool is_decimal(const char character) { return character == '.'; }
 } // namespace
 
 using namespace Mantid::Kernel;

--- a/qt/scientific_interfaces/Muon/ALCDataLoadingPresenter.cpp
+++ b/qt/scientific_interfaces/Muon/ALCDataLoadingPresenter.cpp
@@ -30,6 +30,8 @@ namespace {
 const int RUNS_WARNING_LIMIT = 200;
 // must include the "."
 const std::vector<std::string> ADDITIONAL_EXTENSIONS{".nxs", ".nxs_v2", ".bin"};
+
+bool is_decimal(const char character) { return (character == '.') ? true : false; };
 } // namespace
 
 using namespace Mantid::Kernel;
@@ -419,7 +421,8 @@ bool ALCDataLoadingPresenter::checkCustomGrouping() {
  * @returns :: True if grouping OK, false if bad
  */
 std::string ALCDataLoadingPresenter::isCustomGroupingValid(const std::string &group, bool &isValid) {
-  if (!std::isdigit(group[0]) || std::any_of(std::begin(group), std::end(group), ::isalpha)) {
+  if (!std::isdigit(group[0]) || std::any_of(std::begin(group), std::end(group), ::isalpha) ||
+      std::any_of(std::begin(group), std::end(group), is_decimal)) {
     isValid = false;
     return "";
   }

--- a/qt/scientific_interfaces/Muon/test/ALCDataLoadingPresenterTest.h
+++ b/qt/scientific_interfaces/Muon/test/ALCDataLoadingPresenterTest.h
@@ -238,11 +238,46 @@ public:
     m_view->foundRuns();
   }
 
-  void test_badCustomGrouping() {
+  void test_badCustomGroupingOutofRange() {
     ON_CALL(*m_view, detectorGroupingType()).WillByDefault(Return("Custom"));
     ON_CALL(*m_view, getForwardGrouping()).WillByDefault(Return("1-48"));
     // Too many detectors (MUSR has only 64)
     ON_CALL(*m_view, getBackwardGrouping()).WillByDefault(Return("49-96"));
+
+    EXPECT_CALL(*m_view, enableLoad(true)).Times(1);
+    EXPECT_CALL(*m_view, setLoadStatus(foundString, "green")).Times(1);
+    EXPECT_CALL(*m_view, setLoadStatus(loadingString, "orange")).Times(1);
+    EXPECT_CALL(*m_view, setLoadStatus("Error", "red")).Times(1);
+    EXPECT_CALL(*m_view, enableRunsAutoAdd(false)).Times(1);
+    EXPECT_CALL(*m_view, enableAll()).Times(1);
+    EXPECT_CALL(*m_view, displayError(StrNe(""))).Times(1);
+
+    m_view->foundRuns();
+    m_view->requestLoading();
+  }
+
+  void test_badCustomGroupingLetter() {
+    ON_CALL(*m_view, detectorGroupingType()).WillByDefault(Return("Custom"));
+    ON_CALL(*m_view, getForwardGrouping()).WillByDefault(Return("1,2"));
+    ON_CALL(*m_view, getBackwardGrouping()).WillByDefault(Return("3,a"));
+
+    EXPECT_CALL(*m_view, enableLoad(true)).Times(1);
+    EXPECT_CALL(*m_view, setLoadStatus(foundString, "green")).Times(1);
+    EXPECT_CALL(*m_view, setLoadStatus(loadingString, "orange")).Times(1);
+    EXPECT_CALL(*m_view, setLoadStatus("Error", "red")).Times(1);
+    EXPECT_CALL(*m_view, enableRunsAutoAdd(false)).Times(1);
+    EXPECT_CALL(*m_view, enableAll()).Times(1);
+    EXPECT_CALL(*m_view, displayError(StrNe(""))).Times(1);
+
+    m_view->foundRuns();
+    m_view->requestLoading();
+  }
+
+  void test_badCustomGroupingDecimal() {
+    ON_CALL(*m_view, detectorGroupingType()).WillByDefault(Return("Custom"));
+    ON_CALL(*m_view, getForwardGrouping()).WillByDefault(Return("1.2,2"));
+    // Too many detectors (MUSR has only 64)
+    ON_CALL(*m_view, getBackwardGrouping()).WillByDefault(Return("3,4"));
 
     EXPECT_CALL(*m_view, enableLoad(true)).Times(1);
     EXPECT_CALL(*m_view, setLoadStatus(foundString, "green")).Times(1);


### PR DESCRIPTION
**Description of work.**

The ALC was allowing users to enter a custom grouping with a decimal detector ID. This caused Mantid to crash. 

**To test:**

<!-- Instructions for testing. -->
Open ALC
Set the instrument to MUSR
In the load bar put 62260
Press the load button - it should be fine

In the grouping section change from auto to custom
In the forward box put "1,2"
In the backward box put "3,4"
Press the load button - it should be fine

In the forward box put "1,2000" (out of range)
In the backward box put "3,4"
Press the load button - it should give a warning pop up 
The message in the load section will be read and say error

In the forward box put "1,2" (out of range)
In the backward box put "a,4"
Press the load button - it should give a warning pop up 
The message in the load section will be read and say error

In the forward box put "1.5 ,2"
In the backward box put "a,4"
Press the load button - it should give a warning pop up 
The message in the load section will be read and say error


Fixes #33283. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

In release notes

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
