### PR TITLE
Get correct extents for MDHisto roi cut exports in sliceviewer

### DIFF
--- a/docs/source/release/v6.3.0/33288_mantidworkbench.rst
+++ b/docs/source/release/v6.3.0/33288_mantidworkbench.rst
@@ -1,0 +1,8 @@
+SliceViewer
+-----------
+
+Bugfixes
+########
+- Now able to export x/y cuts and 2D slice from region of interest tool for MDHisto workspaces.
+
+:ref:`Release 6.3.0 <v6.3.0>`

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/model.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/model.py
@@ -595,7 +595,7 @@ def _dimension_limits(workspace,
     :param workspace: MDEvent of MDHisto workspace that is to be binned
     :param slicepoint: ND sequence of either None or float. A float defines the point
                     in that dimension for the slice.
-    :param bin_params: Alist of ndim elements: nbins if a non-integrated dim or thickness if an integrated dim
+    :param bin_params: list of ndim elements: nbins if a non-integrated dim or thickness if an integrated dim
     :param dimension_indices: list of ndim elements: 0/1 corresponding to x/y axis on plot or None for integrated dim
     :param limits: An optional Sequence of length 2 containing limits for plotting dimensions. If
                     not provided the full extent of each dimension is used.
@@ -610,7 +610,7 @@ def _dimension_limits(workspace,
             dim_min, dim_max = (slice_pt - half_bin_width, slice_pt + half_bin_width)
         elif limits is not None and dimension_indices[idim] is not None:
             # replace min/max of non-integrated dims with limits from ROI if specified
-            # swap ROI limits from plot back to dim order of ws in model
+            # swap ROI limits from plot back to dim order of ws in model (necessary for transposed data)
             dim_min, dim_max = limits[dimension_indices[idim]]
         # check all limits are over minimum width
         if dim_max - dim_min < MIN_WIDTH:

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/model.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/model.py
@@ -339,14 +339,11 @@ class SliceViewerModel:
         :param transpose: If true then the limits are transposed w.r.t to the data
         """
         workspace = self._get_ws()
-        if transpose:
-            # swap back to model order
-            limits = limits[1], limits[0]
-        xindex, yindex = _display_indices(slicepoint)
-        dim_limits = _dimension_limits(workspace, slicepoint, limits)
+        dim_limits = _dimension_limits(workspace, slicepoint, bin_params, dimension_indices, limits)
         # Construct parameters to integrate everything first and override per cut
         params = {f'P{n + 1}Bin': [*dim_limits[n]] for n in range(workspace.getNumDims())}
 
+        xindex, yindex = _display_indices(slicepoint)
         xdim_min, xdim_max = dim_limits[xindex]
         ydim_min, ydim_max = dim_limits[yindex]
         params['OutputWorkspace'] = self._roi_name
@@ -372,10 +369,8 @@ class SliceViewerModel:
         :param cut: A string denoting which type to export. Options=c,x,y.
         """
         workspace = self._get_ws()
-        if transpose:
-            # swap back to model order
-            limits = limits[1], limits[0]
-        dim_limits = _dimension_limits(workspace, slicepoint, limits)
+        dim_limits = _dimension_limits(workspace, slicepoint, bin_params, dimension_indices, limits)
+
         # Construct paramters to integrate everything first and overrid per cut
         params = {f'P{n + 1}Bin': [*dim_limits[n]] for n in range(workspace.getNumDims())}
         xindex, yindex = _display_indices(slicepoint, transpose)
@@ -559,13 +554,13 @@ def _roi_binmd_parameters(workspace, slicepoint: Sequence[Optional[float]],
     :param workspace: MDEventWorkspace that is to be binned
     :param slicepoint: ND sequence of either None or float. A float defines the point
                     in that dimension for the slice.
-    :param bin_params: A list of binning paramaters for each dimension or thickness for slicing dimensions
+    :param bin_params: A list ndims long each element is nbins if a non-integrated dim or thickness if an integrated dim
     :param limits: An optional Sequence of length 2 containing limits for plotting dimensions. If
                     not provided the full extent of each dimension is used.
     :return: 3-tuple (binmd parameters, index of X dimension, index of Y dimension)
     """
     xindex, yindex = _display_indices(slicepoint)
-    dim_limits = _dimension_limits(workspace, dimension_indices, limits)
+    dim_limits = _dimension_limits(workspace, slicepoint, bin_params, dimension_indices, limits)
     ndims = workspace.getNumDims()
     ws_basis = np.eye(ndims)
     output_extents, output_bins = [], []
@@ -575,15 +570,11 @@ def _roi_binmd_parameters(workspace, slicepoint: Sequence[Optional[float]],
     for n in range(ndims):
         dimension = workspace.getDimension(n)
         basis_vec_n = _to_str(ws_basis[:, n])
-        slice_pt = slicepoint[n]
+        dim_min, dim_max = dim_limits[n]
         nbins = bin_params[n] if bin_params is not None else dimension.getNBins()
-        if slice_pt is None:
-            dim_min, dim_max = dim_limits[n]
-        else:
-            dim_min, dim_max = slice_pt - nbins / 2, slice_pt + nbins / 2
+        slice_pt = slicepoint[n]
+        if slice_pt is not None:
             nbins = 1
-        if dim_max - dim_min < MIN_WIDTH:
-            dim_max = dim_min + MIN_WIDTH
         params[f'BasisVector{n}'] = f'{dimension.name},{dimension.getUnits()},{basis_vec_n}'
         output_extents.append(dim_min)
         output_extents.append(dim_max)
@@ -595,24 +586,36 @@ def _roi_binmd_parameters(workspace, slicepoint: Sequence[Optional[float]],
 
 
 def _dimension_limits(workspace,
+                      slicepoint: Sequence[Optional[float]],
+                      bin_params: Optional[Sequence[float]],
                       dimension_indices: Optional[tuple],
                       limits: Optional[Sequence[tuple]] = None) -> Sequence[tuple]:
     """
     Return a sequence of 2-tuples defining the limits for MDEventWorkspace binning
-    :param workspace: MDEventWorkspace that is to be binned
+    :param workspace: MDEvent of MDHisto workspace that is to be binned
     :param slicepoint: ND sequence of either None or float. A float defines the point
                     in that dimension for the slice.
+    :param bin_params: Alist of ndim elements: nbins if a non-integrated dim or thickness if an integrated dim
+    :param dimension_indices: list of ndim elements: 0/1 corresponding to x/y axis on plot or None for integrated dim
     :param limits: An optional Sequence of length 2 containing limits for plotting dimensions. If
                     not provided the full extent of each dimension is used.
     """
     dim_limits = [(dim.getMinimum(), dim.getMaximum())
                   for dim in [workspace.getDimension(i) for i in range(workspace.getNumDims())]]
-    if limits is not None:
-        # Match the view limits to the dimension they're for.
-        for dim, axis in enumerate(dimension_indices):
-            if axis is not None:
-                dim_limits[dim] = limits[axis]
-
+    for idim, (dim_min, dim_max) in enumerate(dim_limits):
+        slice_pt = slicepoint[idim]
+        if slice_pt is not None:
+            # replace extents with integration limits (calc from bin width in bin_params)
+            half_bin_width = bin_params[idim]/2
+            dim_min, dim_max = (slice_pt - half_bin_width, slice_pt + half_bin_width)
+        elif limits is not None and dimension_indices[idim] is not None:
+            # replace min/max of non-integrated dims with limits from ROI if specified
+            # swap ROI limits from plot back to dim order of ws in model
+            dim_min, dim_max = limits[dimension_indices[idim]]
+        # check all limits are over minimum width
+        if dim_max - dim_min < MIN_WIDTH:
+            dim_max = dim_min + MIN_WIDTH
+        dim_limits[idim] = (dim_min, dim_max)
     return dim_limits
 
 

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_sliceviewer_model.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_sliceviewer_model.py
@@ -128,7 +128,7 @@ def _create_mock_workspace(ws_type,
         ws.getSpecialCoordinateSystem.return_value = coords
         run = MagicMock()
         run.get.return_value = MagicMock()
-        run.get().value = np.eye(3).flatten()  #  proj matrix is always 3x3
+        run.get().value = np.eye(3).flatten()  # proj matrix is always 3x3
         expt_info = MagicMock()
         sample = MagicMock()
         sample.hasOrientedLattice.return_value = has_oriented_lattice
@@ -205,7 +205,7 @@ class ArraysEqual:
 def create_mock_sliceinfo(indices: tuple):
     """
     Create mock sliceinfo
-    :param indices: 3D indices defining permuation order of dimensions
+    :param indices: 3D indices defining permutation order of dimensions
     """
     slice_info = MagicMock()
     slice_info.transform.side_effect = lambda x: np.array(
@@ -604,8 +604,8 @@ class SliceViewerModelTest(unittest.TestCase):
 
         axes_angles = model.get_axes_angles()
         self.assertAlmostEqual(axes_angles[1, 2], np.pi / 4, delta=1e-10)
-        for iy in range(1,3):
-            self.assertAlmostEqual(axes_angles[0, iy], np.pi/2, delta=1e-10)
+        for iy in range(1, 3):
+            self.assertAlmostEqual(axes_angles[0, iy], np.pi / 2, delta=1e-10)
         # test force_orthog works
         axes_angles = model.get_axes_angles(force_orthogonal=True)
         self.assertAlmostEqual(axes_angles[1, 2], np.pi / 2, delta=1e-10)
@@ -620,7 +620,7 @@ class SliceViewerModelTest(unittest.TestCase):
         axes_angles = model.get_axes_angles()
         self.assertAlmostEqual(axes_angles[1, 2], np.pi / 2, delta=1e-10)
         for iy in range(1, 3):
-            self.assertAlmostEqual(axes_angles[0, iy], np.pi/2, delta=1e-10)
+            self.assertAlmostEqual(axes_angles[0, iy], np.pi / 2, delta=1e-10)
 
     def test_get_dim_limits_returns_limits_for_display_dimensions_for_matrix(self):
         model = SliceViewerModel(self.ws2d_histo)
@@ -681,12 +681,12 @@ class SliceViewerModelTest(unittest.TestCase):
                 mock_ws.getAxis(1).extractValues.assert_called_once()
 
             ExtractSpectra.assert_called_once_with(InputWorkspace=mock_ws,
-                                                         OutputWorkspace='mock_ws_roi',
-                                                         XMin=exp_xmin,
-                                                         XMax=exp_xmax,
-                                                         StartWorkspaceIndex=exp_start_index,
-                                                         EndWorkspaceIndex=exp_end_index,
-                                                         EnableLogging=True)
+                                                   OutputWorkspace='mock_ws_roi',
+                                                   XMin=exp_xmin,
+                                                   XMax=exp_xmax,
+                                                   StartWorkspaceIndex=exp_start_index,
+                                                   EndWorkspaceIndex=exp_end_index,
+                                                   EnableLogging=True)
             ExtractSpectra.reset_mock()
 
         assert_call_as_expected(xmin, xmax, 3, 5, transpose=False, is_spectra=True)
@@ -777,8 +777,72 @@ class SliceViewerModelTest(unittest.TestCase):
                                     is_ragged=is_ragged)
 
     @patch('mantidqt.widgets.sliceviewer.model.TransposeMD')
+    @patch('mantidqt.widgets.sliceviewer.model.IntegrateMDHistoWorkspace')
+    def test_export_region_for_mdhisto_workspace(self, mock_intMD, mock_transposemd):
+        xmin, xmax, ymin, ymax = -1., 3., 2., 4.
+        slicepoint, bin_params = (None, None, 0.5), (100, 100, 0.1)
+        dimension_indices = [0, 1, None]  # Value at index i is the index of the axis that dimension i is displayed on
+        transposed_dimension_indices = [1, 0, None]
+
+        def assert_call_as_expected(transpose, dimension_indices, export_type):
+            model = SliceViewerModel(self.ws_MD_3D)
+
+            if export_type == 'r':
+                model.export_roi_to_workspace(slicepoint, bin_params,
+                                              ((xmin, xmax), (ymin, ymax)), transpose, dimension_indices)
+            else:
+                model.export_cuts_to_workspace(slicepoint, bin_params,
+                                               ((xmin, xmax), (ymin, ymax)), transpose, dimension_indices, export_type)
+
+            if export_type == 'c':
+                export_type = 'xy'  # will loop over this string as 'c' performs both 'x' and 'y'
+
+            for export in export_type:
+                xbin, ybin = [xmin, xmax], [ymin, ymax]  # create in loop as these are altered in case of both cuts
+                # perform transpose on limits - i.e map x/y on plot to basis of MD workspace p1/p2
+                if not transpose:
+                    p1_bin, p2_bin = xbin, ybin
+                else:
+                    p2_bin, p1_bin = xbin, ybin
+                # determine which axis was binnned
+                if export == 'x':
+                    xbin.insert(1, 0.0)  # insert 0 between min,max - this means preserve binning along this dim
+                    out_name = 'ws_MD_3D_cut_x'
+                    transpose_axes = [1 if transpose else 0]  # Axes argument of TransposeMD
+                elif export == 'y':
+                    ybin.insert(1, 0.0)
+                    out_name = 'ws_MD_3D_cut_y'
+                    # check call to transposeMD
+                    transpose_axes = [0 if transpose else 1]
+                else:
+                    # export == 'r'
+                    xbin.insert(1, 0.0)
+                    ybin.insert(1, 0.0)
+                    out_name = 'ws_MD_3D_roi'
+                    transpose_axes = [1, 0] if transpose else None
+
+                # check call to IntegrateMDHistoWorkspace
+                mock_intMD.assert_has_calls([call(InputWorkspace=self.ws_MD_3D, P1Bin=p1_bin, P2Bin=p2_bin,
+                                                  P3Bin=[slicepoint[2] - bin_params[2] / 2,
+                                                         slicepoint[2] + bin_params[2] / 2],
+                                                  OutputWorkspace=out_name)], any_order=False)
+                if transpose_axes is not None:
+                    mock_transposemd.assert_has_calls([call(InputWorkspace=out_name, OutputWorkspace=out_name,
+                                                            Axes=transpose_axes)], any_order=False)
+                else:
+                    mock_transposemd.assert_not_called()  # ROI with Transpose == False
+
+            mock_intMD.reset_mock()
+            mock_transposemd.reset_mock()
+
+        for export_type in ('r', 'x', 'y', 'c'):
+            assert_call_as_expected(transpose=False, dimension_indices=dimension_indices, export_type=export_type)
+            assert_call_as_expected(transpose=True, dimension_indices=transposed_dimension_indices,
+                                    export_type=export_type)
+
+    @patch('mantidqt.widgets.sliceviewer.model.TransposeMD')
     @patch('mantidqt.widgets.sliceviewer.model.BinMD')
-    def test_export_region_for_mdworkspace(self, mock_binmd, mock_transposemd):
+    def test_export_region_for_mdevent_workspace(self, mock_binmd, mock_transposemd):
         xmin, xmax, ymin, ymax = -1., 3., 2., 4.
         slicepoint, bin_params = (None, None, 0.5), (100, 100, 0.1)
         zmin, zmax = 0.45, 0.55  # 3rd dimension extents
@@ -867,7 +931,8 @@ class SliceViewerModelTest(unittest.TestCase):
 
         for export_type in ('r', 'x', 'y', 'c'):
             assert_call_as_expected(transpose=False, dimension_indices=dimension_indices, export_type=export_type)
-            assert_call_as_expected(transpose=True, dimension_indices=transposed_dimension_indices, export_type=export_type)
+            assert_call_as_expected(transpose=True, dimension_indices=transposed_dimension_indices,
+                                    export_type=export_type)
 
     @patch('mantidqt.widgets.sliceviewer.model.BinMD')
     @patch('mantidqt.widgets.sliceviewer.roi.ExtractSpectra')


### PR DESCRIPTION
**Description of work.**

This was already correct for MDEvent as there was some logic that checked whether there was a slicepoint (if so is an integrated dim) and replaced the  min/max of that dimension/plot limit with the slicepoint +/- bin_width/2. I have put this logic inside the `_dimension_limits` function that is called for both MDEvent and MDHisto workspace - the extents are calculated the same for both now.

Additionally the MDHisto code had another check for whether the data were transposed and if sop swapped the x and y limits of the ROI - this was unnecessary as the axis (x/y) that a limit applied to is stored in the `dimensions_indices` variable which is now used inside `_dimension_limits` - this brings it in line with the MDEvent code.

**To test:**

This change touches one of the most used internal functions `_roi_binmd_parameters` that is called when changing slice point, transposing, zooming etc. so it's worth checking all that behaviour.

Specifically
(1) Make MDEvent and MDHisto datasets
```
ws = CreateMDWorkspace(Dimensions='3', Extents='-3,3,-2,2,-1,1',
                       Names='H,K,L', Units='r.l.u.,r.l.u.,r.l.u.',
                       Frames='HKL,HKL,HKL',
                       SplitInto='2', SplitThreshold='10')
FakeMDEventData(ws, EllipsoidParams='1e+04,0,1,1,1,0,0,0,1,0,0,0,1,0.02,0.06,1,1', RandomSeed='3873875')
BinMD(InputWorkspace='ws', AxisAligned=False, 
    BasisVector0='H,r.l.u.,1.0,0.0,0.0', 
    BasisVector1='K,r.l.u.,0.0,1.0,0.0', 
    BasisVector2='L,r.l.u.,0.0,0.0,1.0', 
    OutputExtents='-3,3,-2,2,-1,1', OutputBins='33,33,33', 
    NormalizeBasisVectors=False, OutputWorkspace='ws_histo')
```

For each type of workspace
(2) Open sliceviewer
(3) Select ROI and draw a ROI on the plot
(4) Export cuts by pressing `c` and export ROI slice by pressing `r`
(5) Check the history of the cuts and roi workspaces to ensure the call to BinMD has the correct extents for the MDEvent `ws` and that call to IntegrateMDHistoWorkspace has the correct min/max in the binning arguments for `ws_histo`
(6) Plot the cuts and check the axes labels are correct and the data looks the same as the corresponding line plot axis in sliceviewer
(7) Transpose X-Y and repeat (2-6)
(8) Swap one of H and K for L (i.e. view the previously integrated dimension) and repeat (2-6)

Fixes #31492 


<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
