### PR TITLE
Bug in DrILL settings dialog

### DIFF
--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/drill/presenter/DrillSettingsPresenter.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/drill/presenter/DrillSettingsPresenter.py
@@ -44,6 +44,7 @@ class DrillSettingsPresenter:
             self._dialog.setSettingValue(name, value)
         self._dialog.valueChanged.connect(self.onValueChanged)
         self._dialog.rejected.connect(self.onRejected)
+        self._dialog.applied.connect(self.onApplied)
         self._dialog.show()
 
     def onValueChanged(self, parameterName):
@@ -75,3 +76,10 @@ class DrillSettingsPresenter:
         for name in self._initialValues:
             value = self._initialValues[name]
             self._parameters[name].setValue(value)
+
+    def onApplied(self):
+        """
+        Triggered when the apply button is pressed. This removes the initial
+        values kept in memory.
+        """
+        self._initialValues = dict()

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/drill/view/DrillSettingsDialog.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/drill/view/DrillSettingsDialog.py
@@ -157,6 +157,11 @@ class DrillSettingsDialog(QDialog):
 
     valueChanged = Signal(str)  # setting name
 
+    """
+    Sent when the apply button is clicked.
+    """
+    applied = Signal()
+
     def __init__(self, presenter, parent=None):
         """
         Initialize ths dialog. Connect the static buttons.
@@ -169,7 +174,7 @@ class DrillSettingsDialog(QDialog):
         self.okButton.clicked.connect(self.accept)
         self.cancelButton.clicked.connect(self.reject)
         self.applyButton.clicked.connect(
-                lambda : self.accepted.emit()
+                lambda : self.applied.emit()
                 )
 
         # widgets


### PR DESCRIPTION
**Description of work.**

The "Apply" button in the DrILL settings dialog was not working. Changes were ignored if the "Apply" button was pressed.


**To test:**

* open DrILL (Interfaces -> ILL -> DrILL)
* open the global settings (gear icon in the toolbar)
* change a setting
* press "Apply"
* close the dialog
* reopen the dialog and observe that your value as been applied

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
