### PR TITLE
Add usage tracking to Mantid-Help

### DIFF
--- a/qt/applications/workbench/workbench/app/mainwindow.py
+++ b/qt/applications/workbench/workbench/app/mainwindow.py
@@ -14,7 +14,7 @@ import builtins
 import os
 
 from mantid.api import FrameworkManager, AlgorithmManager
-from mantid.kernel import ConfigService, logger
+from mantid.kernel import (ConfigService, logger, UsageService, FeatureType)
 from workbench.config import SAVE_STATE_VERSION
 from workbench.app import MAIN_WINDOW_OBJECT_NAME, MAIN_WINDOW_TITLE
 from workbench.utils.windowfinder import find_window
@@ -711,6 +711,7 @@ class MainWindow(QMainWindow):
         self.interface_manager.showConceptHelp('')
 
     def open_mantid_help(self):
+        UsageService.registerFeatureUsage(FeatureType.Feature.Interface, ["Mantid Help"], False)
         self.interface_manager.showHelpPage('')
 
     def open_mantid_homepage(self):


### PR DESCRIPTION
**Description of work.**
This should help us track how many users are actively using this each
release. Especially since Qt-Webkit provides a bit of a packaging burden
compared to other Qt components.

By measuring user interaction with this interface we can make informed
decisions down the road.

**To test:**
- Ensure usage reporting is off
- Open the Mantid Help Page (if the interface appears but states the file is missing this is fine)
- Turn usage reporting on, try the help page again
- **Ensure you turn usage reporting back off**, this avoids our usage data getting potentially polluted with dev releases

There is no associated issue. - Raised by @Pasarus  

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
