### PR TITLE
Bug in DrILL close event

### DIFF
--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/drill/presenter/DrillSettingsPresenter.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/drill/presenter/DrillSettingsPresenter.py
@@ -74,4 +74,8 @@ class DrillSettingsPresenter:
         """
         for name in self._initialValues:
             value = self._initialValues[name]
+            try:
+                self._parameters[name].checked.disconnect()
+            except:
+                pass
             self._parameters[name].setValue(value)


### PR DESCRIPTION
**Description of work.**

This PR removes a hard crash observed when DrILL was closed with the settings dialog open.

**To test:**

* open DrILL (Interfaces -> ILL -> DrILL)
* open the settings dialog (gear icon in toolbar)
* set a wrong value (text in a field that is accepting a float value). The cell should turn red.
* close the DrILL window without closing the settings dialog first
* no hard crash should be observed

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
