### PR TITLE
Fix Canvas Colour Not Being Preserved by Script Generator

### DIFF
--- a/docs/source/release/v6.3.0/33225_mantidworkbench.rst
+++ b/docs/source/release/v6.3.0/33225_mantidworkbench.rst
@@ -1,0 +1,4 @@
+Bugfixes
+--------
+
+- The colour of the canvas is now preserved when generating a script from a plot.

--- a/qt/applications/workbench/workbench/plotting/plotscriptgenerator/__init__.py
+++ b/qt/applications/workbench/workbench/plotting/plotscriptgenerator/__init__.py
@@ -16,6 +16,7 @@ from workbench.plotting.plotscriptgenerator.axes import (generate_axis_limit_com
                                                          generate_axis_label_commands,
                                                          generate_set_title_command,
                                                          generate_axis_scale_commands,
+                                                         generate_axis_facecolor_commands,
                                                          generate_tick_commands,
                                                          generate_tick_formatter_commands)
 from workbench.plotting.plotscriptgenerator.figure import generate_subplots_command
@@ -87,6 +88,7 @@ def generate_script(fig, exclude_headers=False):
         plot_commands.extend(get_axis_label_cmds(ax, ax_object_var))  # ax.set_label
         plot_commands.extend(get_axis_limit_cmds(ax, ax_object_var))  # ax.set_lim
         plot_commands.extend(get_axis_scale_cmds(ax, ax_object_var))  # ax.set_scale
+        plot_commands.extend(get_axis_facecolor_cmds(ax, ax_object_var))  # ax.set_facecolor
 
         # Only add the ticker import to headers if it's needed.
         formatter_commands = get_tick_formatter_commands(ax, ax_object_var)
@@ -154,6 +156,11 @@ def get_axis_scale_cmds(ax, ax_object_var):
     """Get commands such as axes.set_xscale and axes.set_yscale"""
     axis_scale_cmds = generate_axis_scale_commands(ax)
     return ["{ax_obj}.{cmd}".format(ax_obj=ax_object_var, cmd=cmd) for cmd in axis_scale_cmds]
+
+
+def get_axis_facecolor_cmds(ax, ax_object_var):
+    """Get command ax.set_facecolor"""
+    return ["{ax_obj}.{cmd}".format(ax_obj=ax_object_var, cmd=generate_axis_facecolor_commands(ax))]
 
 
 def get_title_cmds(ax, ax_object_var):

--- a/qt/applications/workbench/workbench/plotting/plotscriptgenerator/__init__.py
+++ b/qt/applications/workbench/workbench/plotting/plotscriptgenerator/__init__.py
@@ -57,6 +57,7 @@ def generate_script(fig, exclude_headers=False):
         axes.set_xlabel and axes.set_ylabel()
         axes.set_xlim() and axes.set_ylim()
         axes.set_xscale() and axes.set_yscale()
+        axes.set_facecolor()
         <Set axes major tick formatters if non-default>
         axes.legend().set_draggable(True)     (if legend present, or just draggable() for earlier matplotlib versions)
         <Legend title and label commands if non-default>

--- a/qt/applications/workbench/workbench/plotting/plotscriptgenerator/axes.py
+++ b/qt/applications/workbench/workbench/plotting/plotscriptgenerator/axes.py
@@ -18,6 +18,7 @@ BASE_AXIS_LABEL_COMMAND = "set_{}label({})"
 BASE_AXIS_LIM_COMMAND = "set_{}lim({})"
 BASE_SET_TITLE_COMMAND = "set_title({})"
 BASE_AXIS_SCALE_COMMAND = "set_{}scale('{}')"
+BASE_SET_FACECOLOR_COMMAND = "set_facecolor({})"
 
 TICK_FORMATTER_CLASSES = {
     "NullFormatter": NullFormatter,
@@ -69,6 +70,10 @@ def generate_axis_scale_commands(ax):
         if scale != 'linear':
             commands.append(BASE_AXIS_SCALE_COMMAND.format(axis, scale))
     return commands
+
+
+def generate_axis_facecolor_commands(ax):
+    return BASE_SET_FACECOLOR_COMMAND.format(ax.get_facecolor())
 
 
 def generate_tick_params_kwargs(axis, tick_type="major"):

--- a/qt/applications/workbench/workbench/plotting/plotscriptgenerator/test/test_plotscriptgenerator.py
+++ b/qt/applications/workbench/workbench/plotting/plotscriptgenerator/test/test_plotscriptgenerator.py
@@ -39,10 +39,12 @@ SAMPLE_SCRIPT = ("import matplotlib.pyplot as plt\n"
                  "axes[0].plot(...)\n"
                  "axes[0].set_xlim(...)\n"
                  "axes[0].set_ylim(...)\n"
+                 "axes[0].set_facecolor((1.0, 1.0, 1.0, 1))\n"
                  "\n"
                  "axes[1].plot(...)\n"
                  "axes[1].set_xlim(...)\n"
                  "axes[1].set_ylim(...)\n"
+                 "axes[1].set_facecolor((1.0, 1.0, 1.0, 1))\n"
                  "\n"
                  "plt.show()"
                  "\n"
@@ -68,10 +70,14 @@ SAMPLE_SCRIPT_WITH_FIT = ("from mantid.simpleapi import Fit\n"
                           "axes[0].plot(...)\n"
                           "axes[0].set_xlim(...)\n"
                           "axes[0].set_ylim(...)\n"
+                          "axes[0].set_facecolor((1.0, 1.0, 1.0, 1))\n"
+
                           "\n"
                           "axes[1].plot(...)\n"
                           "axes[1].set_xlim(...)\n"
                           "axes[1].set_ylim(...)\n"
+                          "axes[1].set_facecolor((1.0, 1.0, 1.0, 1))\n"
+
                           "\n"
                           "plt.show()"
                           "\n"
@@ -104,6 +110,7 @@ class PlotScriptGeneratorTest(unittest.TestCase):
         mock_kwargs = {
             'get_tracked_artists': lambda: [],
             'get_lines': lambda: [Mock()],
+            'get_facecolor': lambda: "(1.0, 1.0, 1.0, 1)",
             'legend_': False,
             'lines': [],
             'collections': [],

--- a/qt/applications/workbench/workbench/plotting/plotscriptgenerator/test/test_plotscriptgeneratoraxes.py
+++ b/qt/applications/workbench/workbench/plotting/plotscriptgenerator/test/test_plotscriptgeneratoraxes.py
@@ -15,7 +15,8 @@ from matplotlib.ticker import LogFormatterSciNotation, ScalarFormatter
 
 from unittest.mock import Mock
 from workbench.plotting.plotscriptgenerator.axes import (generate_axis_limit_commands,
-                                                         generate_axis_label_commands)
+                                                         generate_axis_label_commands,
+                                                         generate_axis_facecolor_commands)
 from workbench.plotting.plotscriptgenerator import generate_script
 
 
@@ -72,6 +73,23 @@ class PlotGeneratorAxisTest(unittest.TestCase):
         ax.set_ylim([0, 4])
         self.assertEqual(['set_xlim([-5.0, 5.0])', 'set_ylim([0.0, 4.0])'],
                          generate_axis_limit_commands(ax))
+        plt.close()
+        del fig
+
+    def test_generate_axis_facecolor_commands_default(self):
+        fig = plt.figure()
+        ax = fig.add_subplot(111)
+        ax.plot([-10, 10], [1, 2])
+        self.assertEqual("set_facecolor((1.0, 1.0, 1.0, 1))", generate_axis_facecolor_commands(ax))
+        plt.close()
+        del fig
+
+    def test_generate_axis_facecolor_commands_custom(self):
+        fig = plt.figure()
+        ax = fig.add_subplot(111)
+        ax.plot([-10, 10], [1, 2])
+        ax.set_facecolor("#000000")
+        self.assertEqual("set_facecolor((0.0, 0.0, 0.0, 1.0))", generate_axis_facecolor_commands(ax))
         plt.close()
         del fig
 

--- a/qt/applications/workbench/workbench/plotting/plotscriptgenerator/test/test_plotscriptgeneratoraxes.py
+++ b/qt/applications/workbench/workbench/plotting/plotscriptgenerator/test/test_plotscriptgeneratoraxes.py
@@ -76,20 +76,12 @@ class PlotGeneratorAxisTest(unittest.TestCase):
         plt.close()
         del fig
 
-    def test_generate_axis_facecolor_commands_default(self):
+    def test_generate_axis_facecolor_commands(self):
         fig = plt.figure()
         ax = fig.add_subplot(111)
         ax.plot([-10, 10], [1, 2])
-        self.assertEqual("set_facecolor((1.0, 1.0, 1.0, 1))", generate_axis_facecolor_commands(ax))
-        plt.close()
-        del fig
-
-    def test_generate_axis_facecolor_commands_custom(self):
-        fig = plt.figure()
-        ax = fig.add_subplot(111)
-        ax.plot([-10, 10], [1, 2])
-        ax.set_facecolor("#000000")
-        self.assertEqual("set_facecolor((0.0, 0.0, 0.0, 1.0))", generate_axis_facecolor_commands(ax))
+        ax.set_facecolor("#00000000")
+        self.assertEqual("set_facecolor((0.0, 0.0, 0.0, 0.0))", generate_axis_facecolor_commands(ax))
         plt.close()
         del fig
 

--- a/qt/python/mantidqt/mantidqt/project/plotsloader.py
+++ b/qt/python/mantidqt/mantidqt/project/plotsloader.py
@@ -321,6 +321,7 @@ class PlotsLoader(object):
         else:
             ax.set_ylim(properties["yLim"])
         ax.show_minor_gridlines = properties["showMinorGrid"]
+        ax.set_facecolor(properties["facecolor"])
 
         # Update X Axis
         if "xAxisProperties" in properties:

--- a/qt/python/mantidqt/mantidqt/project/plotssaver.py
+++ b/qt/python/mantidqt/mantidqt/project/plotssaver.py
@@ -163,6 +163,7 @@ class PlotsSaver(object):
                 "yAxisScale": ax.yaxis.get_scale(),
                 "yLim": ax.get_ylim(),
                 "yAutoScale": ax.get_autoscaley_on(),
+                "facecolor": ax.get_facecolor(),
                 "showMinorGrid": hasattr(ax, 'show_minor_gridlines') and ax.show_minor_gridlines,
                 "tickParams": self.get_dict_from_tick_properties(ax),
                 "spineWidths": self.get_dict_from_spine_widths(ax)}

--- a/qt/python/mantidqt/mantidqt/project/test/test_plotsloader.py
+++ b/qt/python/mantidqt/mantidqt/project/test/test_plotsloader.py
@@ -34,7 +34,7 @@ class PlotsLoaderTest(unittest.TestCase):
         mantid.plots.axesfunctions.plot = mock.MagicMock()
         self.dictionary = {u'legend': {u'exists': False}, u'lines': [],
                            u'properties': {u'axisOn': True, u'bounds': (0.0, 0.0, 0.0, 0.0), u'dynamic': True,
-                                           u'frameOn': True, u'visible': True,
+                                           u'frameOn': True, u'visible': True, u'facecolor': None,
                                            u'xAxisProperties': {u'fontSize': 10.0,
                                                                 u'gridStyle': {u'gridOn': False},
                                                                 u'majorTickFormat': None,

--- a/qt/python/mantidqt/mantidqt/project/test/test_plotssaver.py
+++ b/qt/python/mantidqt/mantidqt/project/test/test_plotssaver.py
@@ -92,7 +92,7 @@ class PlotsSaverTest(unittest.TestCase):
                                                      u'minorTickLocatorValues': None,
                                                      u'visible': True},
                                 u'yAxisScale': u'linear',
-                                u'yLim': (0.0, 1.0),u"yAutoScale":False,
+                                u'yLim': (0.0, 1.0),u"yAutoScale":False,u"facecolor":(0.0,0.0,0.0,0.0),
                                 u'showMinorGrid': False,
                                 u'tickParams': {
                                     'xaxis': {
@@ -263,6 +263,7 @@ class PlotsSaverTest(unittest.TestCase):
 
         self.loader_plot_dict[u'creationArguments'] = expected_creation_args
 
+        self.maxDiff = None
         self.assertDictEqual(return_value, self.loader_plot_dict)
 
     def test_get_dict_from_fig_with_LogNorm(self):
@@ -274,6 +275,7 @@ class PlotsSaverTest(unittest.TestCase):
 
         self.loader_plot_dict[u'creationArguments'] = expected_creation_args
 
+        self.maxDiff = None
         self.assertDictEqual(return_value, self.loader_plot_dict)
 
 


### PR DESCRIPTION
**Description of work.**
Added the ability for the script generator to access and maintain the `facecolor` or canvas colour when generating a script from a plot. 

**To test:**
1. Plot something
2. Enter the figure options and change the canvas colour
3. Generate a script
4. Run the script
5. The shown plot should have preserved its background colour

Fixes #33225 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
