### PR TITLE
Fix error transposing 2D MDworkspaces in sliceviewer

### DIFF
--- a/docs/source/release/v6.3.0/33297_mantidworkbench.rst
+++ b/docs/source/release/v6.3.0/33297_mantidworkbench.rst
@@ -1,0 +1,9 @@
+
+SliceViewer
+-----------
+
+Bugfixes
+########
+- Transposing data (i.e. swapping x and y axes) of 2D MD workspace now works without error.
+
+:ref:`Release 6.3.0 <v6.3.0>`

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/model.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/model.py
@@ -131,6 +131,10 @@ class SliceViewerModel:
         """Return the name of the workspace being viewed"""
         return self._ws.name()
 
+    def get_number_dimensions(self):
+        """Return number of dimensions in workspace"""
+        return self._get_ws().getNumDims()
+
     def get_frame(self) -> SpecialCoordinateSystem:
         """Return the coordinate system of the workspace"""
         return self._ws.getSpecialCoordinateSystem()

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/presenter.py
@@ -204,7 +204,8 @@ class SliceViewer(ObservingPresenter):
 
         ws_type = self.model.get_ws_type()
         if ws_type == WS_TYPE.MDH or ws_type == WS_TYPE.MDE:
-            if sliceinfo.slicepoint[data_view.dimensions.get_previous_states().index(None)] is None:
+            if self.model.get_number_dimensions() > 2 and \
+                    sliceinfo.slicepoint[data_view.dimensions.get_previous_states().index(None)] is None:
                 # The dimension of the slicepoint has changed
                 self.new_plot(dimensions_changing=True)
             else:


### PR DESCRIPTION
**Description of work.**

Add check for ndim > 2 before attempting to access slicepoint of an integrated dim - a 2D workspace doesn't have a slicepoint, the `dimensions_changed` can only be triggered by a transposition of the axes. have added a test to stop regression.

I added a method in the model to get the number of dimensions of the workspace - I could have got this from e.g.  ` len(sliceinfo.slicepoint)` or similar, but I thought it is more obvious/readable to have a `get_number_dimensions()` - happy to change.


**To test:**

Follow instructions in issue

Fixes #33241 

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
