### PR TITLE
Muon freq data with correct y units

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/MuonMaxent.py
+++ b/Framework/PythonInterface/plugins/algorithms/MuonMaxent.py
@@ -463,6 +463,7 @@ class MuonMaxent(PythonAlgorithm):
         outSpec.dataX(0)[:] = fchan
         outSpec.dataY(0)[:] = MAXPAGE_f
         outSpec.getAxis(0).setUnit('Label').setLabel('Field', 'Gauss')
+        outSpec.setYUnitLabel('Probability')
         self.setProperty("OutputWorkspace", outSpec)
         # revised dead times
         if(not self.getProperty("OutputDeadTimeTable").isDefault):

--- a/docs/source/release/v6.3.0/33296_muon.rst
+++ b/docs/source/release/v6.3.0/33296_muon.rst
@@ -1,0 +1,5 @@
+Bugfixes
+########
+
+- FFT's now have y units of intensity.
+- Maxent's now have y units of probability.

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/FrequencyDomainAnalysis/FFT/fft_presenter.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/FrequencyDomainAnalysis/FFT/fft_presenter.py
@@ -193,6 +193,7 @@ class FFTPresenter(object):
     def add_fft_workspace_to_ADS(self, input_workspace, imaginary_input_workspace, fft_workspace_label):
         run = re.search('[0-9]+', input_workspace).group()
         fft_workspace = mantid.AnalysisDataService.retrieve(fft_workspace_label)
+        fft_workspace.setYUnitLabel("Intensity")
         Im_run = ""
         if imaginary_input_workspace != "":
             Im_run = re.search('[0-9]+', imaginary_input_workspace).group()


### PR DESCRIPTION
**Description of work.**


**To test:**

<!-- Instructions for testing. -->

Open the frequency domain analysis GUI (muon)
Load MUSR 62260
Go to the transform tab
Press `Calculate FFT`
Check the y axis label is intensity

At the top of the tab, change it from FFT to MaxEnt
Press Calculate MaxEnt
Check the y axis label is probability


Fixes #33296. and fix https://github.com/mantidproject/mantid/issues/32829<!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

In release notes

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
