### PR TITLE
Various small fixes to the Engineering UI Fitting tab

### DIFF
--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -655,7 +655,6 @@ knownConditionTrueFalse:${CMAKE_SOURCE_DIR}/qt/widgets/common/src/FitPropertyBro
 knownConditionTrueFalse:${CMAKE_SOURCE_DIR}/qt/widgets/common/src/FitPropertyBrowser.cpp:1634
 shadowVariable:${CMAKE_SOURCE_DIR}/qt/widgets/common/src/FitPropertyBrowser.cpp:512
 shadowVariable:${CMAKE_SOURCE_DIR}/qt/widgets/common/src/FitPropertyBrowser.cpp:1791
-shadowVariable:${CMAKE_SOURCE_DIR}/qt/widgets/common/src/FitPropertyBrowser.cpp:1812
 constParameter:${CMAKE_SOURCE_DIR}/qt/widgets/common/inc/MantidQtWidgets/Common/PropertyHandler.h:194
 useStlAlgorithm:${CMAKE_SOURCE_DIR}/qt/widgets/common/src/FitPropertyBrowser.cpp:3243
 useStlAlgorithm:${CMAKE_SOURCE_DIR}/qt/widgets/common/src/FitScriptGeneratorDataTable.cpp:200

--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -656,7 +656,7 @@ knownConditionTrueFalse:${CMAKE_SOURCE_DIR}/qt/widgets/common/src/FitPropertyBro
 shadowVariable:${CMAKE_SOURCE_DIR}/qt/widgets/common/src/FitPropertyBrowser.cpp:512
 shadowVariable:${CMAKE_SOURCE_DIR}/qt/widgets/common/src/FitPropertyBrowser.cpp:1791
 constParameter:${CMAKE_SOURCE_DIR}/qt/widgets/common/inc/MantidQtWidgets/Common/PropertyHandler.h:194
-useStlAlgorithm:${CMAKE_SOURCE_DIR}/qt/widgets/common/src/FitPropertyBrowser.cpp:3243
+useStlAlgorithm:${CMAKE_SOURCE_DIR}/qt/widgets/common/src/FitPropertyBrowser.cpp:3251
 useStlAlgorithm:${CMAKE_SOURCE_DIR}/qt/widgets/common/src/FitScriptGeneratorDataTable.cpp:200
 unsignedLessThanZero:${CMAKE_SOURCE_DIR}/qt/widgets/common/src/FitScriptGeneratorModel.cpp:611
 useInitializationList:${CMAKE_SOURCE_DIR}/qt/widgets/common/src/FindFilesThreadPoolManager.cpp:52

--- a/qt/python/mantidqt/mantidqt/_common.sip
+++ b/qt/python/mantidqt/mantidqt/_common.sip
@@ -592,7 +592,7 @@ SIP_PYOBJECT defaultBackgroundType();
     double getPeakHeightOf(QString);
     void setPeakHeightOf(QString, double);
     double getPeakFwhmOf(QString);
-    void setPeakFwhmOf(QString, double);
+    void setPeakFwhmOf(QString, double) throw (std::invalid_argument);
     std::string getWidthParameterNameOf(QString);
     std::string getCentreParameterNameOf(QString);
     bool isParameterExplicitlySetOf(QString, std::string);

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/data_handling/data_model.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/data_handling/data_model.py
@@ -236,7 +236,10 @@ class FittingDataModel(object):
         # update log tables
         self.remove_all_log_rows()
         for irow, (ws_name, ws) in enumerate(self._data_workspaces.get_loaded_ws_dict().items()):
-            self.add_log_to_table(ws_name, ws, irow)
+            try:
+                self.add_log_to_table(ws_name, ws, irow)
+            except Exception as e:
+                logger.warning(f"Unable to output log workspaces for workspace {ws_name}: " + str(e))
 
     def add_log_to_table(self, ws_name, ws, irow):
         # both ws and name needed in event a ws is renamed and ws.name() is no longer correct
@@ -245,7 +248,7 @@ class FittingDataModel(object):
             self._log_values[ws_name] = dict()
         # add run info
         run = ws.getRun()
-        row = [ws.getInstrument().getFullName(), ws.getRunNumber(), run.getProperty('bankid').value,
+        row = [ws.getInstrument().getFullName(), ws.getRunNumber(), str(run.getProperty('bankid').value),
                run.getProtonCharge(), ws.getTitle()]
         self.write_table_row(ADS.retrieve("run_info"), row, irow)
         # add log data - loop over existing log workspaces not logs in settings as these might have changed

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/fitting_ads_observer.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/fitting_ads_observer.py
@@ -78,3 +78,4 @@ class FittingADSObserver(AnalysisDataServiceObserver):
         self.observeDelete(False)
         self.observeRename(False)
         self.observeClear(False)
+        self.observeReplace(False)

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/plotting/EngDiff_fitpropertybrowser.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/plotting/EngDiff_fitpropertybrowser.py
@@ -13,6 +13,7 @@ from mantidqt.utils.qt import import_qt
 from mantidqt.utils.observer_pattern import GenericObservable
 from mantidqt.widgets.fitpropertybrowser import FitPropertyBrowser
 from mantid.api import AnalysisDataService as ADS
+from mantid.simpleapi import logger
 from mantidqtinterfaces.Engineering.gui.engineering_diffraction.settings.settings_helper import get_setting
 from mantidqtinterfaces.Engineering.gui.engineering_diffraction.tabs.common import output_settings
 
@@ -88,6 +89,12 @@ class EngDiffFitPropertyBrowser(FitPropertyBrowser):
         """
         Override the base class method. Hide the peak editing tool.
         """
+        for ax in self.canvas.figure.get_axes():
+            try:
+                for ws_name, artists in ax.tracked_workspaces.items():
+                    self.ws_is_valid(ws_name, True)
+            except AttributeError:  # scripted plots have no tracked_workspaces
+                pass
         super(EngDiffFitPropertyBrowser, self).show()
         self.fit_enabled_notifier.notify_subscribers(self.isFitEnabled() and self.isVisible())
 
@@ -97,6 +104,12 @@ class EngDiffFitPropertyBrowser(FitPropertyBrowser):
         """
         super(EngDiffFitPropertyBrowser, self).hide()
         self.fit_enabled_notifier.notify_subscribers(self.isFitEnabled() and self.isVisible())
+
+    def ws_is_valid(self, ws_name, warn):
+        is_valid = ADS.retrieve(ws_name).getAxis(0).getUnit().caption() == 'Time-of-flight'
+        if not is_valid and warn:
+            logger.warning(f"Workspace {ws_name} will not be available for fitting because it doesn't have units of TOF")
+        return is_valid
 
     def _get_allowed_spectra(self):
         """
@@ -109,10 +122,10 @@ class EngDiffFitPropertyBrowser(FitPropertyBrowser):
             try:
                 for ws_name, artists in ax.tracked_workspaces.items():
                     # don't allow existing output workspaces (fitted curves) to be added
-                    if ws_name not in output_wsnames and \
-                            ADS.retrieve(ws_name).getAxis(0).getUnit().caption() == 'Time-of-flight':
-                        spectrum_list = [artist.spec_num for artist in artists]
-                        allowed_spectra[ws_name] = spectrum_list
+                    if ws_name not in output_wsnames:
+                        if self.ws_is_valid(ws_name, False):
+                            spectrum_list = [artist.spec_num for artist in artists]
+                            allowed_spectra[ws_name] = spectrum_list
             except AttributeError:  # scripted plots have no tracked_workspaces
                 pass
         return allowed_spectra

--- a/qt/widgets/common/src/FitPropertyBrowser.cpp
+++ b/qt/widgets/common/src/FitPropertyBrowser.cpp
@@ -1810,9 +1810,9 @@ void FitPropertyBrowser::renameHandle(const std::string &oldName, const std::str
     m_allowedSpectra.remove(oldNameQ);
     m_allowedSpectra.insert(newNameQ, indices);
   }
-  int i = m_workspaceNames.indexOf(oldNameQ);
-  if (i >= 0) {
-    m_workspaceNames.replace(i, newNameQ);
+  int iWorkspace = m_workspaceNames.indexOf(oldNameQ);
+  if (iWorkspace >= 0) {
+    m_workspaceNames.replace(iWorkspace, newNameQ);
     m_enumManager->setEnumNames(m_workspace, m_workspaceNames);
   }
   workspaceChange(newNameQ);

--- a/qt/widgets/common/src/FitPropertyBrowser.cpp
+++ b/qt/widgets/common/src/FitPropertyBrowser.cpp
@@ -1802,18 +1802,26 @@ void FitPropertyBrowser::removeWorkspace(const std::string &wsName) {
 }
 
 void FitPropertyBrowser::renameHandle(const std::string &oldName, const std::string &newName) {
-  int i = m_workspaceNames.indexOf(QString(oldName.c_str()));
+  QString oldNameQ = QString::fromStdString(oldName);
+  QString newNameQ = QString::fromStdString(newName);
+  auto it = m_allowedSpectra.find(oldNameQ);
+  if (it != m_allowedSpectra.end()) {
+    auto indices = m_allowedSpectra.value(oldNameQ);
+    m_allowedSpectra.remove(oldNameQ);
+    m_allowedSpectra.insert(newNameQ, indices);
+  }
+  int i = m_workspaceNames.indexOf(oldNameQ);
   if (i >= 0) {
-    m_workspaceNames.replace(i, QString::fromStdString(newName));
+    m_workspaceNames.replace(i, newNameQ);
     m_enumManager->setEnumNames(m_workspace, m_workspaceNames);
   }
-  workspaceChange(QString::fromStdString(newName));
+  workspaceChange(newNameQ);
 
   for (auto i = 0; i < m_wsListWidget->count(); ++i) {
     auto item = m_wsListWidget->item(i);
     if (item->text().toStdString() == oldName) {
       m_wsListWidget->takeItem(m_wsListWidget->row(item));
-      m_wsListWidget->insertItem(m_wsListWidget->row(item), QString::fromStdString(newName));
+      m_wsListWidget->insertItem(m_wsListWidget->row(item), newNameQ);
     }
   }
 }


### PR DESCRIPTION
**Description of work.**

Various related bug fixes that have come out of manual testing for the 6.3 release:

- remove error when renaming a workspace that has been plotted on the fitting tab (#33281). The same code change may also fix #33244 but I've not been able to reproduce that one
- I've occasionally seen the addition of a BackToBackExponential peak generating an error message that simply says "unknown" from a call to the setPeakFwhmOf function. I've updated the sip file to generate a better message. Annoyingly I've not managed to reproduce this today but I've left the change in place because it's small\low risk
- some old workspaces from earlier versions of the UI don't load at the moment because the bank log value used to be an integer and it's now a string. Just cast the value to a string in all cases. I've also added code to catch\log any problems creating the log data in case there are other similar issues
- if the user opens the fit property browser on the Fitting tab with a d Spacing file loaded, a warning message is printed indicating it's not available for fitting (TOF only)

**To test:**

open workbench
open Engg UI
Load a single focused file on fitting tab
rename the bgsub workspace in ADS (no error)
close Engg UI
Clear ADS
open Engg UI
Load a single focused file on fitting tab
rename the bgsub workspace in ADS (used to be an error - now there's not)

Fixes #33281.

*This does not require release notes* because **the main bug fix is covered by the release note for PR https://github.com/mantidproject/mantid/pull/33004**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
