### PR TITLE
Major refactor of 6.3 framework release notes

### DIFF
--- a/docs/source/release/v6.3.0/33147_Framework.rst
+++ b/docs/source/release/v6.3.0/33147_Framework.rst
@@ -1,7 +1,0 @@
-Algorithms
-----------
-
-Improvements
-############
-
-- Added option to :ref:`CreateSimulationWorkspace <algm-CreateSimulationWorkspace>` to set bin errors.

--- a/docs/source/release/v6.3.0/33173_Framework.rst
+++ b/docs/source/release/v6.3.0/33173_Framework.rst
@@ -1,7 +1,0 @@
-Algorithms
-----------
-
-Bugfixes
-########
-
-- Fixed a bug with algorithm :ref:`CalculatePlaczek <algm-CalculatePlaczek>` for computing Placzek correction factors. There were a few flaws in previously implemented formulation.

--- a/docs/source/release/v6.3.0/framework.rst
+++ b/docs/source/release/v6.3.0/framework.rst
@@ -31,7 +31,6 @@ Improvements
 - :ref:`SetSample <algm-SetSample>` can now load sample environment XML files from any directory using ``SetSample(ws, Environment={'Name': 'NameOfXMLFile', 'Path':'/path/to/file/'})``.
 - :ref:`SetSampleFromLogs <algm-SetSampleFromLogs>` will now fail if the resulting sample shape has a volume of 0.
 
-
 Bugfixes
 ########
 - Fixed a bug with :ref:`CalculatePlaczek <algm-CalculatePlaczek>` algorithm for computing Placzek correction factors. There were a few flaws in the previously implemented formulation.
@@ -51,26 +50,28 @@ New Features
 - Fixed a bug in :ref:`UserFunction<func-UserFunction>` where the view would not be updated with the parameters in the formula entered.
 
 Geometry
-----------
-- add additional unit test for Rasterize class.
-- fix an issue in CSGObject such that the intercept type is no longer tied to an arbitrary value that make Track returns unstable results.
+---------
+Bugfixes
+########
+- Fixed an issue in ``CSGObject`` such that the intercept type is no longer tied to an arbitrary value that make Track returns unstable results.
 
 Python
 ------
-- `isGroup` can now be used to determine if a workspace/table workspace is a grouped workspace object.
-- `createChildAlgorithm` now accepts property keyword arguments to set the child algorithm's properties during creation:
+New features
+############
+* ``isGroup`` can now be used to determine if a workspace/table workspace is a grouped workspace object.
+* ``createChildAlgorithm`` now accepts property keyword arguments to set the child algorithm's properties during creation:
 
-  -  Existing arguments, such as version, start and end progress...etc. are unaffected by this change.
-  -  E.g. `createChildAlgorithm("CreateSampleWorkspace", version=1, XUnit="Wavelength")`
-- The package on Windows now includes the `euphonic <https://pypi.org/project/euphonic/>`_ package
+  *  Existing arguments, such as ``version``, ``start`` and ``end progress`` etc. are unaffected by this change.
+  *  E.g. ``createChildAlgorithm("CreateSampleWorkspace", version=1, XUnit="Wavelength")``.
+
+* The package on Windows now includes the `euphonic <https://pypi.org/project/euphonic/>`_ package
   for calculating phonon bandstructures.
 
 
 MantidWorkbench
 ---------------
-
 See :doc:`mantidworkbench`.
-
 
 
 :ref:`Release 6.3.0 <v6.3.0>`

--- a/docs/source/release/v6.3.0/framework.rst
+++ b/docs/source/release/v6.3.0/framework.rst
@@ -5,9 +5,6 @@ Framework Changes
 .. contents:: Table of Contents
    :local:
 
-.. warning:: **Developers:** Sort changes under appropriate heading
-    putting new features at the top of the section, followed by
-    improvements, followed by bug fixes.
 
 Removals
 --------
@@ -15,49 +12,43 @@ Removals
 
 Algorithms
 ----------
-- Introducing a naming convention for algorithms, and *deprecated aliases* as the preferred method for renaming a C++ or Python algorithm.
-- Enabling deprecation of Python algorithms; instructions on how to deprecate a C++ or Python algorithm in the developer documentation.
-
 New Features
 ############
+- Introduced a naming convention for ``algorithms``, and ``deprecated aliases`` as the preferred method for renaming a C++ or Python algorithms.
+- Enabled deprecation of Python algorithms; instructions on how to deprecate a C++ or Python algorithm are available in the developer documentation.
 - Added a :ref:`Power Law <func-PowerLaw>` function to General Fit Functions.
 
 Improvements
 ############
-
-- :ref:`SaveAscii <algm-SaveAscii>` and :ref:`SaveCanSAS1D <algm-SaveCanSAS1D>` have a new property OneSpectrumPerFile, controlling whether or not to save each spectrum in an individual file or all the spectra into a single file.
+- A relative error option, ``ToleranceRelErr``, is now enabled for peak table workspaces in :ref:`CompareWorkspaces <algm-CompareWorkspaces>`.
+- Added the option ``SetErrors`` to :ref:`CreateSimulationWorkspace <algm-CreateSimulationWorkspace>` algorithm to set bin errors.
+- The option ``ImportanceSampling`` has been added to :ref:`DiscusMultipleScatteringCorrection <algm-DiscusMultipleScatteringCorrection>` so that it handles spikes in the structure factor S(Q) better.
+- Added the parameter ``MaxScatterPtAttempts`` to :ref:`DiscusMultipleScatteringCorrection <algm-DiscusMultipleScatteringCorrection>` to control number of attempts to generate initial scatter point.
 - :ref:`GenerateLogbook <algm-GenerateLogbook>` now allows to perform binary operations even when certain entries do not exist, e.g. to create a string with all polarisation orientations contained in a collection of data files.
 - Event nexuses produced at ILL can now be loaded using :ref:`LoadEventNexus <algm-LoadEventNexus>`.
-- :ref:`Rebin <algm-Rebin>` now has an option for binning with reverse logarithmic and inverse power bins.
-- :ref:`SetSampleFromLogs <algm-SetSampleFromLogs>` will now fail if the resulting sample shape has a volume of 0.
+- :ref:`Rebin <algm-Rebin>` now has an option ``UseReverseLogarithmic`` for binning with reverse logarithmic and inverse power bins.
+- :ref:`SaveAscii <algm-SaveAscii>` and :ref:`SaveCanSAS1D <algm-SaveCanSAS1D>` have a new property ``OneSpectrumPerFile``, controlling whether or not to save each spectrum in an individual file or all the spectra into a single file.
 - :ref:`SetSample <algm-SetSample>` can now load sample environment XML files from any directory using ``SetSample(ws, Environment={'Name': 'NameOfXMLFile', 'Path':'/path/to/file/'})``.
-- An importance sampling option has been added to :ref:`DiscusMultipleScatteringCorrection <algm-DiscusMultipleScatteringCorrection>` so that it handles spikes in the structure factor S(Q) better
-- Added parameter to :ref:`DiscusMultipleScatteringCorrection <algm-DiscusMultipleScatteringCorrection>` to control number of attempts to generate initial scatter point
-- Relative error option now enabled for peak table workspaces in :ref:`CompareWorkspaces <algm-CompareWorkspaces>`.
-- Added option to :ref:`CreateSimulationWorkspace <algm-CreateSimulationWorkspace>` to set bin errors.
+- :ref:`SetSampleFromLogs <algm-SetSampleFromLogs>` will now fail if the resulting sample shape has a volume of 0.
+
 
 Bugfixes
 ########
-
-- Fix bug in :ref:`LoadEventNexus <algm-LoadEventNexus>` in checking valid event ID's and make sure to always exclude data in ``error`` and ``unmapped`` banks.
-- Fix bug in :ref:`Integration <algm-Integration>` when using UsePartialBinsOption with integration limits that are either equal or close together
-- Fix bug in :ref:`DiscusMultipleScatteringCorrection <algm-DiscusMultipleScatteringCorrection>` where calculation aborts with exception due to floating point rounding error when track segment close to vertical
-  Also fixed bug in calculation of track direction after scatter if pre-scatter track was pointing exactly down - sign of z component of new direction was incorrect
+- Fixed a bug with :ref:`CalculatePlaczek <algm-CalculatePlaczek>` algorithm for computing Placzek correction factors. There were a few flaws in the previously implemented formulation.
+- Fixed a bug in :ref:`DiscusMultipleScatteringCorrection <algm-DiscusMultipleScatteringCorrection>` where calculation aborts with an exception due to a floating point rounding error when the track segment is close to vertical. Also fixed bug in calculation of track direction after scatter if pre-scatter track was pointing exactly down - sign of z component of new direction was incorrect.
+- Fixed a bug in :ref:`Integration <algm-Integration>` when using ``UsePartialBinsOption`` with integration limits that are either equal or close together.
 - The :ref:`Load <algm-Load>` algorithm now reports the correct history.
-- Fix bug in :ref:`LoadAndMerge <algm-LoadAndMerge>` where LoaderVersion choice was previously ignored
-- Fix bug in :ref:`SaveNexus <algm-SaveNexus>` - ragged workspace x-values are saved correctly when workspace indices are supplied.
-- Fix bug in :ref:`MonteCarloAbsorption <algm-MonteCarloAbsorption>`. If the algorithm was run with the Sparse Workspace feature enabled on a workspace containing spectra
-  that didn't have any detectors it failed with an error
-- Fixed a bug with algorithm :ref:`CalculatePlaczek <algm-CalculatePlaczek>` for computing Placzek correction factors. There were a few flaws in previously implemented formulation.
+- Fixed a bug in :ref:`LoadAndMerge <algm-LoadAndMerge>` where ``LoaderVersion`` choice was previously ignored.
+- Fixed a bug in :ref:`LoadEventNexus <algm-LoadEventNexus>` in checking valid event ID's and to make sure to always exclude data in ``error`` and ``unmapped`` banks.
+- Fixed a bug in :ref:`MonteCarloAbsorption <algm-MonteCarloAbsorption>`. If the algorithm was run with the Sparse Workspace feature enabled on a workspace containing spectra
+  that didn't have any detectors, it failed with an error.
+- Fixed a bug in :ref:`SaveNexus <algm-SaveNexus>` - ragged workspace x-values are saved correctly when workspace indices are supplied.
 
 Fit Functions
 -------------
 New Features
 ############
 - Fixed a bug in :ref:`UserFunction<func-UserFunction>` where the view would not be updated with the parameters in the formula entered.
-
-Data Objects
-------------
 
 Geometry
 ----------
@@ -66,7 +57,6 @@ Geometry
 
 Python
 ------
-
 - `isGroup` can now be used to determine if a workspace/table workspace is a grouped workspace object.
 - `createChildAlgorithm` now accepts property keyword arguments to set the child algorithm's properties during creation:
 
@@ -75,9 +65,6 @@ Python
 - The package on Windows now includes the `euphonic <https://pypi.org/project/euphonic/>`_ package
   for calculating phonon bandstructures.
 
-
-Installation
-------------
 
 MantidWorkbench
 ---------------

--- a/docs/source/release/v6.3.0/framework.rst
+++ b/docs/source/release/v6.3.0/framework.rst
@@ -33,15 +33,15 @@ Improvements
 
 Bugfixes
 ########
-- Fixed a bug with :ref:`CalculatePlaczek <algm-CalculatePlaczek>` algorithm for computing Placzek correction factors. There were a few flaws in the previously implemented formulation.
-- Fixed a bug in :ref:`DiscusMultipleScatteringCorrection <algm-DiscusMultipleScatteringCorrection>` where calculation aborts with an exception due to a floating point rounding error when the track segment is close to vertical. Also fixed bug in calculation of track direction after scatter if pre-scatter track was pointing exactly down - sign of z component of new direction was incorrect.
+- Fixed a bug with :ref:`CalculatePlaczek <algm-CalculatePlaczek>` algorithm for computing Placzek correction factors that fixed the previously implemented formula for transforming k to e, and the summation for second order Placezek corrections.
+- Fixed a bug in :ref:`DiscusMultipleScatteringCorrection <algm-DiscusMultipleScatteringCorrection>` where the calculation aborts with an exception due to a floating point rounding error when the track segment is close to vertical. Also fixed bug in calculation of track direction after scatter if pre-scatter track was pointing exactly down - sign of z component of new direction was incorrect.
 - Fixed a bug in :ref:`Integration <algm-Integration>` when using ``UsePartialBinsOption`` with integration limits that are either equal or close together.
 - The :ref:`Load <algm-Load>` algorithm now reports the correct history.
 - Fixed a bug in :ref:`LoadAndMerge <algm-LoadAndMerge>` where ``LoaderVersion`` choice was previously ignored.
 - Fixed a bug in :ref:`LoadEventNexus <algm-LoadEventNexus>` in checking valid event ID's and to make sure to always exclude data in ``error`` and ``unmapped`` banks.
 - Fixed a bug in :ref:`MonteCarloAbsorption <algm-MonteCarloAbsorption>`. If the algorithm was run with the Sparse Workspace feature enabled on a workspace containing spectra
   that didn't have any detectors, it failed with an error.
-- Fixed a bug in :ref:`SaveNexus <algm-SaveNexus>` - ragged workspace x-values are saved correctly when workspace indices are supplied.
+- Fixed a bug in :ref:`SaveNexus <algm-SaveNexus>` - ragged workspace x-values are now saved correctly when workspace indices are supplied.
 
 Fit Functions
 -------------

--- a/docs/source/release/v6.3.0/framework.rst
+++ b/docs/source/release/v6.3.0/framework.rst
@@ -34,6 +34,7 @@ Improvements
 - An importance sampling option has been added to :ref:`DiscusMultipleScatteringCorrection <algm-DiscusMultipleScatteringCorrection>` so that it handles spikes in the structure factor S(Q) better
 - Added parameter to :ref:`DiscusMultipleScatteringCorrection <algm-DiscusMultipleScatteringCorrection>` to control number of attempts to generate initial scatter point
 - Relative error option now enabled for peak table workspaces in :ref:`CompareWorkspaces <algm-CompareWorkspaces>`.
+- Added option to :ref:`CreateSimulationWorkspace <algm-CreateSimulationWorkspace>` to set bin errors.
 
 Bugfixes
 ########
@@ -47,6 +48,7 @@ Bugfixes
 - Fix bug in :ref:`SaveNexus <algm-SaveNexus>` - ragged workspace x-values are saved correctly when workspace indices are supplied.
 - Fix bug in :ref:`MonteCarloAbsorption <algm-MonteCarloAbsorption>`. If the algorithm was run with the Sparse Workspace feature enabled on a workspace containing spectra
   that didn't have any detectors it failed with an error
+- Fixed a bug with algorithm :ref:`CalculatePlaczek <algm-CalculatePlaczek>` for computing Placzek correction factors. There were a few flaws in previously implemented formulation.
 
 Fit Functions
 -------------


### PR DESCRIPTION
**Description of work.**

The main refactoring the the Framework release notes ahead of release of 6.3. Includes:-

- Removing extraneous headings and developer warning
- Reordering of notes where appropriate
- Rewording notes to improve consistency
- Reformatting of notes.
- Spelling & Grammar check

This PR incorporates some release notes that were saved in separate files (see first commit). These files have been deleted as the release notes have been moved. Further changes will be made later when any additional separate files for v6.3 diffraction release notes are amalgamated into the final release notes.

**To test:**

- remove `build/docs/doctrees`
- build the documents again and check there are no warnings
- Check that the links work
- Check the information is still correct
- Grammar/Spelling check

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
