### PR TITLE
Add parent to Engineering UI when loaded from a project

### DIFF
--- a/docs/source/release/v6.4.0/diffraction.rst
+++ b/docs/source/release/v6.4.0/diffraction.rst
@@ -15,6 +15,8 @@ Powder Diffraction
 Engineering Diffraction
 -----------------------
 
+Add a parent to an instance of the engineering diffraction interface created by loading a project so that it's a child of the main window. This also resolves an occasional crash when loading a project containing a workspace that was plotted on the Titting tab
+
 Single Crystal Diffraction
 --------------------------
 

--- a/docs/source/release/v6.4.0/diffraction.rst
+++ b/docs/source/release/v6.4.0/diffraction.rst
@@ -15,7 +15,7 @@ Powder Diffraction
 Engineering Diffraction
 -----------------------
 
-Add a parent to an instance of the engineering diffraction interface created by loading a project so that it's a child of the main window. This also resolves an occasional crash when loading a project containing a workspace that was plotted on the Titting tab
+Add a parent to an instance of the engineering diffraction interface created by loading a project so that it's a child of the main window. This also resolves an occasional crash when loading a project containing a workspace that was plotted on the Fitting tab
 
 Single Crystal Diffraction
 --------------------------

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/engineering_diffraction_io.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/engineering_diffraction_io.py
@@ -8,6 +8,8 @@ from mantid.api import AnalysisDataService as ADS  # noqa
 from mantid.simpleapi import logger
 from mantidqtinterfaces.Engineering.gui.engineering_diffraction.engineering_diffraction import EngineeringDiffractionGui
 
+import sys
+
 IO_VERSION = 1
 
 SETTINGS_KEYS_TYPES = {"save_location": str, "full_calibration": str, "recalc_vanadium": bool, "logs": str,
@@ -61,7 +63,13 @@ class EngineeringDiffractionDecoder(EngineeringDiffractionUIAttributes):
             logger.error("Engineering Diffraction Interface encoder used different version, restoration may fail")
 
         ws_names = obj_dic.get("data_workspaces", None)  # workspaces are in ADS, need restoring into interface
-        gui = EngineeringDiffractionGui()
+        if 'workbench' in sys.modules:
+            from workbench.config import get_window_config
+
+            parent, flags = get_window_config()
+        else:
+            parent, flags = None, None
+        gui = EngineeringDiffractionGui(parent=parent, window_flags=flags)
         presenter = gui.presenter
         gui.tabs.setCurrentIndex(obj_dic["current_tab"])
         presenter.settings_presenter.model.set_settings_dict(obj_dic["settings_dict"])


### PR DESCRIPTION
**Description of work.**

Add parent to Engineering UI when loaded from a project. This aligns the properties of the UI with what happens when it's opened normally from the workbench Interfaces menu. It also resolves a crash when loading a project containing a saved state
of the Engineering UI after previously opening the UI from the Interfaces menu

**To test:**

See steps in A on linked issue. Error shouldn't happen any more on final step

Fixes #33303.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
