### PR TITLE
Added release note and updated SHA

### DIFF
--- a/docs/source/release/v6.3.0/MSlice_DirectGeometry.rst
+++ b/docs/source/release/v6.3.0/MSlice_DirectGeometry.rst
@@ -1,0 +1,17 @@
+MSlice
+------
+
+BugFixes
+########
+
+- Fixed bug that prevented the print button from opening the print dialog
+- Fixed bug that caused duplicated colour bars for slice plots and exceptions for cut plots when running a generated script while the original plot is still open
+- Fixed bug in script generation for cut plots
+- Cleaned up File menu for interactive cut plots
+- Enabled editing for Bragg peaks on cut plots
+- Prevented exception when generating script from plot created via script
+- Added legends for recoil lines and Bragg peaks on slice plots
+- Fixed bug that caused exceptions when scaling a workspace
+- Added error message when attempting to load a file by path on the data loading tab
+- Fixed bug that caused infinitely repeating energy unit conversions when changing the default energy unit
+- When closing the dialog for adding a Bragg peak from a CIF file without selecting a CIF file the corresponding menu entry now remains unselected.

--- a/scripts/ExternalInterfaces/CMakeLists.txt
+++ b/scripts/ExternalInterfaces/CMakeLists.txt
@@ -7,7 +7,7 @@ externalproject_add(
   mslice
   PREFIX ${_mslice_external_root}
   GIT_REPOSITORY "https://github.com/mantidproject/mslice.git"
-  GIT_TAG d80e0dfc233854cc0113cff25b298aaeafe801d8
+  GIT_TAG e2b4c07e4398db1cbd52902b2ff5d800d5fc0062
   EXCLUDE_FROM_ALL 1
   CONFIGURE_COMMAND ""
   BUILD_COMMAND ""


### PR DESCRIPTION
**Description of work.**

Replaced MSlice SHA for Mantid with SHA of current MSlice release-next branch.

Added release note in MSlice_DirectGeometry.rst with all changes in MSlice since last MSlice SHA update in Mantid.

**To test:**

Double-check SHA with SHA of current MSlice release-next branch.

There is no associated issue.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
