### PR TITLE
Update Inspect bg plot when parameters changed in EngDiff UI fitting tab

### DIFF
--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/data_handling/data_model.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/data_handling/data_model.py
@@ -534,8 +534,10 @@ class FittingDataModel(object):
                                subplot_kw={'projection': 'mantid'})
             bg = Minus(LHSWorkspace=ws_name, RHSWorkspace=ws_bgsub, StoreInADS=False)
             ax[0].plot(ws, 'x')
-            ax[1].plot(ws_bgsub, 'x')
+            ax[1].plot(ws_bgsub, 'x', label='background subtracted data')
             ax[0].plot(bg, '-r', label='background')
+            ax[0].legend(fontsize=8.0).set_draggable(True).legend
+            ax[1].legend(fontsize=8.0).set_draggable(True).legend
             fig.canvas.mpl_connect("draw_event", on_draw)
             fig.show()
 

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/data_handling/data_model.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/data_handling/data_model.py
@@ -13,7 +13,7 @@ from mantidqtinterfaces.Engineering.gui.engineering_diffraction.tabs.common impo
 from mantid.api import AnalysisDataService as ADS
 from mantid.api import TextAxis
 from mantid.kernel import UnitConversion, DeltaEModeType, UnitParams
-from matplotlib.pyplot import subplots, close
+from matplotlib.pyplot import subplots
 from numpy import full, nan, max, array, vstack, argsort
 from itertools import chain
 from collections import defaultdict, OrderedDict
@@ -144,7 +144,6 @@ class FittingDataModel(object):
         self._fit_workspaces = None
         self._last_added = []  # List of workspace names loaded in the last load action.
         self._data_workspaces = FittingWorkspaceRecordContainer()
-        self.inspect_bg_fig = None
 
     def restore_files(self, ws_names):
         self._data_workspaces.add_from_names_dict(ws_names)
@@ -524,8 +523,10 @@ class FittingDataModel(object):
                 bg_line.set_ydata(data_line.get_ydata() - bgsub_line.get_ydata())
                 event.canvas.draw_idle()
             else:
-                logger.warning("Inspect background figure will be closed because it doesn't have the correct curves.")
-                close(event.canvas.figure.number)  # figure.close method doesn't exist - use plt.close
+                # would like to close the figure at this point but this interferes with the mantid ADS observers when
+                # any of the tracked workspaces are deleted and causes mantid to hard crash - so just print warning
+                logger.warning(f"Inspect background figure {event.canvas.figure.number} has been invalidated - the "
+                               f"background curve will no longer be updated.")
 
         ws = self._data_workspaces[ws_name].loaded_ws
         ws_bgsub = self._data_workspaces[ws_name].bgsub_ws

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/data_handling/data_model.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/data_handling/data_model.py
@@ -537,8 +537,8 @@ class FittingDataModel(object):
             ax[0].plot(ws, 'x')
             ax[1].plot(ws_bgsub, 'x', label='background subtracted data')
             ax[0].plot(bg, '-r', label='background')
-            ax[0].legend(fontsize=8.0).set_draggable(True).legend
-            ax[1].legend(fontsize=8.0).set_draggable(True).legend
+            ax[0].legend(fontsize=8.0)
+            ax[1].legend(fontsize=8.0)
             fig.canvas.mpl_connect("draw_event", on_draw)
             fig.show()
 


### PR DESCRIPTION
**Description of work.**

The background estimated for a spectrum is not tracked in the ADS, this did meant that when the background estimation parameters (passed to `EnggEstimateFocusedBackground`) were changed the background curve in the Inspect Background plot wasn't updated (the background subtracted data however were updated on the plot).

This problem could have been fixed by storing the bg in the ADS with a  unique name, however I think it is good to limit the number of workspaces present in the ADS (though it could always be hidden) and not add another set of workspaces to keep track of when workspaces are renamed/deleted etc. 

This change adds in a function that updates the background data when the figure is redrawn. I have also added a check that there is a tracked and untracked workspace present (data and background curve respectively) before trying to update the data on the background curve, I could add more checks (e.g. same number of data points, correct labels etc.) but I think it's overkill as it's an external plot that can always be regenerated with one click if the user gets it into an unusable state.

Have also added a legend to make it clearer which curve is which (fixes #33247).

**To test:**

(1) Follow instructions in issue
(2) Load two spectra and open the Inspect background figure for each, check the correct plot is updated when a bg param is changed
(3) Try to remove the data or background curve from one of the figures (cog > Curves > Remove) it should print a warning to the log `Inspect background figure 1 has been invalidated - the background curve will no longer be updated.`
(4) Update the bg params in the table (e.g. Niter=1) - the background curve should not update (the same warning will also be printed)
(5) Delete the bgsub workspace corresponding to the data on the remaining figure, it should print the same warning.

Fixes #33246
Fixes #33247

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
