### PR TITLE
Fix Tiny About Workbench Comboboxes on macOS

### DIFF
--- a/docs/source/release/v6.3.0/33265_mantidworkbench.rst
+++ b/docs/source/release/v6.3.0/33265_mantidworkbench.rst
@@ -1,0 +1,3 @@
+Bugfixes
+--------
+- The instrument and facility combo-boxes are now always appropriately sized on the About Mantid Workbench page on macOS.

--- a/qt/applications/workbench/workbench/widgets/about/view.py
+++ b/qt/applications/workbench/workbench/widgets/about/view.py
@@ -259,6 +259,7 @@ font: {self.rescale_w(12)}px;
         lbl_personal_setup.setAlignment(Qt.AlignHCenter)
         grp_personal_setup_layout.addWidget(lbl_personal_setup)
         personal_setup_form_layout = QFormLayout()
+        personal_setup_form_layout.setFieldGrowthPolicy(QFormLayout.AllNonFixedFieldsGrow)
         personal_setup_form_layout.setHorizontalSpacing(self.rescale_w(5))
         personal_setup_form_layout.setVerticalSpacing(self.rescale_h(5))
         personal_setup_form_layout.setLabelAlignment(Qt.AlignRight)


### PR DESCRIPTION
**Description of work.**
Qt has some defaults for QMacStyle such as [`FieldGrowthPolicy`](https://doc.qt.io/qt-5/qformlayout.html#FieldGrowthPolicy-enum) which was causing the boxes to shrink to their smallest size. 

**To test:**
1. Open Workbench
2. Open the About Mantid Workbench menu (Under the workbench/python menu)
3. Switch the Facility to none
4. Close and reopen the About window
5. Set the facility and instrument and check both can be read clearly.

Fixes #33265 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
