### PR TITLE
Add Warning of Restart Requirement to Project Recovery Settings

### DIFF
--- a/docs/source/release/v6.3.0/33272_mantidworkbench.rst
+++ b/docs/source/release/v6.3.0/33272_mantidworkbench.rst
@@ -1,0 +1,3 @@
+Improvements
+------------
+- There is now a warning in the settings to say that changes project recovery settings are only applied after restarting workbench.

--- a/qt/applications/workbench/workbench/widgets/settings/general/section_general.ui
+++ b/qt/applications/workbench/workbench/widgets/settings/general/section_general.ui
@@ -33,8 +33,8 @@
        <rect>
         <x>0</x>
         <y>0</y>
-        <width>728</width>
-        <height>656</height>
+        <width>739</width>
+        <height>747</height>
        </rect>
       </property>
       <property name="sizePolicy">
@@ -350,6 +350,16 @@
                </widget>
               </item>
              </layout>
+            </item>
+            <item>
+             <widget class="QLabel" name="restart_warning_label">
+              <property name="styleSheet">
+               <string notr="true">color : #CC0000</string>
+              </property>
+              <property name="text">
+               <string>(Workbench must be restarted for any changes to Project Recovery settings to take effect!)</string>
+              </property>
+             </widget>
             </item>
            </layout>
           </widget>


### PR DESCRIPTION
**Description of work.**
Added a warning to users that their changes to the project recovery settings are only applied after restarting workbench. This used to be sent as a log message, but it seems to be of a high enough importance to me that having a label next to those settings is worth it. 

**To test:**
1. Open the preferences and scroll to the project recovery settings. 
2. Check warning


Fixes #33272 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
