### PR TITLE
Handle OSError exceptions when trying to remove recovery checkpoints

### DIFF
--- a/docs/source/release/v6.3.0/33335_mantidworkbench.rst
+++ b/docs/source/release/v6.3.0/33335_mantidworkbench.rst
@@ -1,0 +1,5 @@
+Bugfixes
+--------
+
+* A bug in project recovery attempting to remove non-empty directories and
+  raising the error reporter has been fixed.

--- a/qt/applications/workbench/workbench/app/mainwindow.py
+++ b/qt/applications/workbench/workbench/app/mainwindow.py
@@ -600,7 +600,6 @@ class MainWindow(QMainWindow):
             if self.project_recovery is not None:
                 self.project_recovery.stop_recovery_thread()
                 self.project_recovery.closing_workbench = True
-                self.project_recovery.remove_current_pid_folder()
 
             # Cancel memory widget thread
             if self.memorywidget is not None:
@@ -611,6 +610,18 @@ class MainWindow(QMainWindow):
 
             if self.workspacecalculator is not None:
                 self.workspacecalculator.view.closeEvent(event)
+
+            if self.project_recovery is not None:
+                # Do not merge this block with the above block that
+                # starts with the same check.
+                # We deliberately split the call to stop the recovery
+                # thread and removal of the checkpoints folder to
+                # allow for the maximum amount of time for the recovery
+                # thread to finish. Any errors here are ignored as exceptions
+                # on shutdown cannot be handled in a meaningful way.
+                # Future runs of project recovery will clean any stale points
+                # after a month
+                self.project_recovery.remove_current_pid_folder(ignore_errors=True)
 
             event.accept()
         else:

--- a/qt/applications/workbench/workbench/projectrecovery/projectrecovery.py
+++ b/qt/applications/workbench/workbench/projectrecovery/projectrecovery.py
@@ -107,38 +107,33 @@ class ProjectRecovery(object):
         """
         self.saver.stop_recovery_thread()
 
-    def _remove_empty_folders_from_dir(self, directory):
+    def _remove_empty_folders_from_dir(self, directory: str):
         """
-        Will remove all empty directories in the passed directory
+        Will remove all empty directories in the given directory
         :param directory: String; A path to a directory
         """
         folders = glob(os.path.join(directory, "*", ""))
         for folder in folders:
-            try:
-                if len(os.listdir(folder)) == 0:
-                    self._remove_directory_and_directory_trees(folder)
-            except OSError:
-                # Fail silently as expected for all folders
-                pass
+            if len(os.listdir(folder)) == 0:
+                self._remove_directory_and_directory_trees(folder, ignore_errors=True)
 
-    def _remove_directory_and_directory_trees(self, directory):
+    def _remove_directory_and_directory_trees(self, directory: str, *, ignore_errors: bool = False):
         """
         Will remove the file/directory passed as directory if somewhere below the self.recovery_directory directory
         :param directory: String; A path to a directory/file
-        :return:
+        :param ignore_errors: If True all OSErrors raised are swallowed, else the exceptions are propagated to the
+        caller
+        :return: None
         """
         if directory is None or not os.path.exists(directory):
             return
 
         # Only allow deleting in subdirectories of workbench-recovery
         if self.recovery_directory not in directory:
-            raise RuntimeError("Project Recovery: Only allowed to delete trees in the recovery directory")
-
-        try:
-            shutil.rmtree(directory)
-        except FileNotFoundError:
-            # Doesn't matter if the file is deleted by another process as we are trying to do that anyway
+            logger.warning("Project Recovery: Only allowed to delete trees in the recovery directory")
             return
+
+        shutil.rmtree(directory, ignore_errors)
 
     @staticmethod
     def sort_by_last_modified(paths):
@@ -192,11 +187,13 @@ class ProjectRecovery(object):
         except OSError:
             return []
 
-    def remove_current_pid_folder(self):
+    def remove_current_pid_folder(self, ignore_errors=False):
         """
         Removes the current open PID folder
+        :param ignore_errors: If true then all errors are swallowed, else OSErrors
+        will be raised
         """
-        self._remove_directory_and_directory_trees(self.recovery_directory_pid)
+        self._remove_directory_and_directory_trees(self.recovery_directory_pid, ignore_errors=ignore_errors)
 
     ######################################################
     #  Saving
@@ -290,7 +287,7 @@ class ProjectRecovery(object):
 
     def remove_oldest_checkpoints(self):
         """
-        Removes the oldest checkpoint in the currently running programs directory if it has hit the max number of
+        Removes the oldest checkpoint in the currently running programs' directory if it has hit the max number of
         checkpoints
         """
         paths = self.listdir_fullpath(self.recovery_directory_pid)
@@ -299,7 +296,10 @@ class ProjectRecovery(object):
             # Order paths in reverse and remove the last folder
             paths.sort(reverse=True)
             for ii in range(self.maximum_num_checkpoints, len(paths)):
-                self._remove_directory_and_directory_trees(paths[ii])
+                try:
+                    self._remove_directory_and_directory_trees(paths[ii])
+                except OSError as exc:
+                    logger.warning(f"Unable to remove project recovery checkpoint '{paths[ii]}': {str(exc)}")
 
     def clear_all_unused_checkpoints(self, pid_dir=None):
         """
@@ -318,14 +318,7 @@ class ProjectRecovery(object):
         else:
             path = pid_dir
         if os.path.exists(path):
-            try:
-                self._remove_directory_and_directory_trees(path)
-            except Exception as e:
-                if isinstance(e, KeyboardInterrupt):
-                    raise
-                else:
-                    # Fail silently because it is just over diligent calls to clear checkpoints
-                    pass
+            self._remove_directory_and_directory_trees(path, ignore_errors=True)
 
     def repair_checkpoints(self):
         """
@@ -339,7 +332,7 @@ class ProjectRecovery(object):
         dirs_to_delete += self._find_checkpoints_which_are_locked(pid_dirs)
 
         for directory in dirs_to_delete:
-            self._remove_directory_and_directory_trees(directory)
+            self._remove_directory_and_directory_trees(directory, ignore_errors=True)
 
         # Now the checkpoints have been deleted we may have PID directories with no checkpoints present so delete them
         self._remove_empty_folders_from_dir(self.recovery_directory_hostname)

--- a/qt/applications/workbench/workbench/projectrecovery/test/test_projectrecovery.py
+++ b/qt/applications/workbench/workbench/projectrecovery/test/test_projectrecovery.py
@@ -107,12 +107,18 @@ class ProjectRecoveryTest(unittest.TestCase):
 
         self.assertTrue(not os.path.exists(empty))
 
-    def test_remove_empty_dir_throws_outside_of_workbench_directory(self):
+    @mock.patch('workbench.projectrecovery.projectrecovery.logger')
+    def test_remove_empty_dir_logs_outside_of_workbench_directory(self, logger_mock):
         os.mkdir(os.path.join(self.working_directory, "temp"))
-        self.assertRaises(RuntimeError, self.pr._remove_empty_folders_from_dir, self.working_directory)
+        self.pr._remove_empty_folders_from_dir(self.working_directory)
 
-    def test_remove_all_folders_from_dir_raises_outside_of_mantid_dir(self):
-        self.assertRaises(RuntimeError, self.pr._remove_directory_and_directory_trees, self.working_directory)
+        logger_mock.warning.assert_called_once()
+
+    @mock.patch('workbench.projectrecovery.projectrecovery.logger')
+    def test_remove_all_folders_from_dir_outside_of_mantid_dir_logs_warning(self, logger_mock):
+        self.pr._remove_directory_and_directory_trees(self.working_directory)
+
+        logger_mock.warning.assert_called_once()
 
     def test_remove_all_folders_from_dir_doesnt_raise_inside_of_mantid_dir(self):
         temp_dir = os.path.join(self.pr.recovery_directory, "tempDir")
@@ -189,7 +195,7 @@ class ProjectRecoveryTest(unittest.TestCase):
 
         self.assertTrue(self.pr.check_for_recover_checkpoint())
 
-    def test_remove_oldest_checkpoints(self):
+    def test_remove_oldest_checkpoints_when_no_errors_present(self):
         self.pr._recovery_directory_pid = self.working_directory
         self.pr._remove_directory_and_directory_trees = mock.MagicMock()
 
@@ -202,13 +208,29 @@ class ProjectRecoveryTest(unittest.TestCase):
         # Now should have had a call made to delete working_directory + dir0
         self.pr._remove_directory_and_directory_trees.assert_called_with(os.path.join(self.working_directory, "dir0"))
 
+    @mock.patch('workbench.projectrecovery.projectrecovery.logger')
+    def test_remove_oldest_checkpoints_logs_when_directory_not_removable(self, logger_mock):
+        self.pr._recovery_directory_pid = self.working_directory
+        self.pr._remove_directory_and_directory_trees = mock.MagicMock(side_effect=OSError("Error removing directory"))
+
+        for ii in range(0, self.pr.maximum_num_checkpoints+1):
+            os.mkdir(os.path.join(self.working_directory, "dir"+str(ii)))
+            time.sleep(0.01)
+
+        self.pr.remove_oldest_checkpoints()
+
+        # Now should have had a call made to delete working_directory + dir0
+        self.pr._remove_directory_and_directory_trees.assert_called_with(os.path.join(self.working_directory, "dir0"))
+        logger_mock.warning.assert_called_once()
+
     def test_clear_all_unused_checkpoints_called_with_none_and_only_one_user(self):
         self.pr._remove_directory_and_directory_trees = mock.MagicMock()
         os.makedirs(self.pr.recovery_directory_hostname)
 
         self.pr.clear_all_unused_checkpoints()
 
-        self.pr._remove_directory_and_directory_trees.assert_called_with(self.pr.recovery_directory_hostname)
+        self.pr._remove_directory_and_directory_trees.assert_called_with(self.pr.recovery_directory_hostname,
+                                                                         ignore_errors=True)
 
     def test_clear_all_unused_checkpoints_called_with_none_and_multiple_users(self):
         self.pr._remove_directory_and_directory_trees = mock.MagicMock()
@@ -220,7 +242,8 @@ class ProjectRecoveryTest(unittest.TestCase):
 
         self.pr.clear_all_unused_checkpoints()
 
-        self.pr._remove_directory_and_directory_trees.assert_called_with(self.pr.recovery_directory_hostname)
+        self.pr._remove_directory_and_directory_trees.assert_called_with(self.pr.recovery_directory_hostname,
+                                                                         ignore_errors=True)
 
     def test_clear_all_unused_checkpoints_called_with_not_none(self):
         self.pr._remove_directory_and_directory_trees = mock.MagicMock()
@@ -228,7 +251,8 @@ class ProjectRecoveryTest(unittest.TestCase):
 
         self.pr.clear_all_unused_checkpoints(pid_dir=self.pr.recovery_directory_hostname)
 
-        self.pr._remove_directory_and_directory_trees.assert_called_with(self.pr.recovery_directory_hostname)
+        self.pr._remove_directory_and_directory_trees.assert_called_with(self.pr.recovery_directory_hostname,
+                                                                         ignore_errors=True)
 
     def _repair_checkpoint_checkpoints_setup(self, checkpoint1, checkpoint2, pid, pid2):
         if os.path.exists(pid):

--- a/qt/applications/workbench/workbench/projectrecovery/test/test_projectrecovery.py
+++ b/qt/applications/workbench/workbench/projectrecovery/test/test_projectrecovery.py
@@ -272,8 +272,10 @@ class ProjectRecoveryTest(unittest.TestCase):
 
     def _repair_checkpoints_assertions(self, checkpoint1, checkpoint2, pid, pid2):
         # None of the checkpoints should exist after the call. Thus the PID folder should be deleted and thus ignored.
-        directory_removal_calls = [mock.call(os.path.join(self.pr.recovery_directory_hostname, '200000')),
-                                   mock.call(os.path.join(self.pr.recovery_directory_hostname, "1000000", "check1"))]
+        directory_removal_calls = [mock.call(os.path.join(self.pr.recovery_directory_hostname, '200000'),
+                                             ignore_errors=True),
+                                   mock.call(os.path.join(self.pr.recovery_directory_hostname, "1000000", "check1"),
+                                             ignore_errors=True)]
 
         self.pr._remove_directory_and_directory_trees.assert_has_calls(directory_removal_calls)
 

--- a/qt/applications/workbench/workbench/test/test_mainwindow.py
+++ b/qt/applications/workbench/workbench/test/test_mainwindow.py
@@ -271,7 +271,8 @@ class MainWindowTest(unittest.TestCase):
         self.main_window.writeSettings.assert_called()
         mock_plt_close.assert_called_with('all')
         mock_QApplication.instance().closeAllWindows.assert_called()
-        self.main_window.project_recovery.assert_has_calls([call.stop_recovery_thread(), call.remove_current_pid_folder()])
+        self.main_window.project_recovery.assert_has_calls([call.stop_recovery_thread(),
+                                                            call.remove_current_pid_folder(ignore_errors=True)])
         self.assertTrue(self.main_window.project_recovery.closing_workbench)
         self.main_window.interface_manager.closeHelpWindow.assert_called()
         mock_event.accept.assert_called()


### PR DESCRIPTION
**Description of work.**

We now trap errors that would have caused the error reporter to be raised. A user can do nothing about
the errors and recovery cleans up after itself in future runs so the risk is minimal. See the commit messages
for more details.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**

* Please pay close attention to code changes amd review them throughly to check the logic.
* Run through the [project recovery manual tests](https://developer.mantidproject.org/Testing/ErrorReporter-ProjectRecovery/ProjectRecoveryTesting.html)

Fixes #32065 

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
