### PR TITLE
Fix sliceviewer colorbar autoscale

### DIFF
--- a/Framework/PythonInterface/mantid/plots/modest_image/modest_image.py
+++ b/Framework/PythonInterface/mantid/plots/modest_image/modest_image.py
@@ -87,6 +87,25 @@ class ModestImage(MantidImage):
         """Override to return the full-resolution array"""
         return self._full_res
 
+    def get_array_clipped_to_bounds(self):
+        # Get the extents of the axes and transform to pixel coordinates
+        xlim, ylim = self.axes.get_xlim(), self.axes.get_ylim()
+        transform=self._world2pixel
+        ind0 = transform.transform([min(xlim), min(ylim)])
+        ind1 = transform.transform([max(xlim), max(ylim)])
+
+        # Add 0.5 to get the edge of the pixel. Also add 1 to the max values which need to be one past the end
+        # for when we slice.
+        y0 = max(int(np.floor(ind0[1] + 0.5)), 0)
+        y1 = max(int(np.floor(ind1[1] + 0.5)) + 1, 0)
+        x0 = max(int(np.floor(ind0[0] + 0.5)), 0)
+        x1 = max(int(np.floor(ind1[0] + 0.5)) + 1, 0)
+
+        # Clip the data to the extents
+        data = self._full_res[y0:y1:1, x0:x1:1]
+        data = cbook.safe_masked_invalid(data)
+        return data
+
     @property
     def _pixel2world(self):
 

--- a/Framework/PythonInterface/mantid/plots/modest_image/modest_image.py
+++ b/Framework/PythonInterface/mantid/plots/modest_image/modest_image.py
@@ -102,7 +102,7 @@ class ModestImage(MantidImage):
         x1 = max(int(np.floor(ind1[0] + 0.5)) + 1, 0)
 
         # Clip the data to the extents
-        data = self._full_res[y0:y1:1, x0:x1:1]
+        data = self._full_res[y0:y1, x0:x1]
         data = cbook.safe_masked_invalid(data)
         return data
 

--- a/Framework/PythonInterface/mantid/plots/resampling_image/samplingimage.py
+++ b/Framework/PythonInterface/mantid/plots/resampling_image/samplingimage.py
@@ -143,6 +143,9 @@ class SamplingImage(MantidImage):
     def get_full_extent(self):
         return self._full_extent
 
+    def get_array_clipped_to_bounds(self):
+        return self.get_array()
+
     def _update_maxpooling_option(self):
         """
         Updates the maxpooling option, used when the image is downsampled

--- a/docs/source/release/v6.3.0/33336_mantidworkbench.rst
+++ b/docs/source/release/v6.3.0/33336_mantidworkbench.rst
@@ -1,0 +1,15 @@
+========================
+Mantid Workbench Changes
+========================
+
+.. contents:: Table of Contents
+   :local:
+
+SliceViewer
+-----------
+
+Bugfixes
+########
+- Fixed issues with the colorbar autoscale not updating correctly on zoom
+
+:ref:`Release 6.3.0 <v6.3.0>`

--- a/qt/python/mantidqt/mantidqt/widgets/colorbar/colorbar.py
+++ b/qt/python/mantidqt/mantidqt/widgets/colorbar/colorbar.py
@@ -295,7 +295,15 @@ class ColorbarWidget(QWidget):
     def _autoscale_clim(self):
         """Update stored colorbar limits
         The new limits are found from the colobar data """
-        data = self.colorbar.mappable.get_array()
+        data = self.colorbar.mappable.get_array_clipped_to_bounds()
+
+        # If any dimension is zero then we have no data in the display area
+        if any(map(lambda dim: dim == 0, data.shape)):
+            self.cmin_value = 0.
+            self.cmax_value = 0.
+            self.update_clim_text()
+            return
+
         norm = NORM_OPTS[self.norm.currentIndex()]
         try:
             try:

--- a/qt/python/mantidqt/mantidqt/widgets/colorbar/colorbar.py
+++ b/qt/python/mantidqt/mantidqt/widgets/colorbar/colorbar.py
@@ -296,14 +296,6 @@ class ColorbarWidget(QWidget):
         """Update stored colorbar limits
         The new limits are found from the colobar data """
         data = self.colorbar.mappable.get_array_clipped_to_bounds()
-
-        # If any dimension is zero then we have no data in the display area
-        if any(map(lambda dim: dim == 0, data.shape)):
-            self.cmin_value = 0.
-            self.cmax_value = 0.
-            self.update_clim_text()
-            return
-
         norm = NORM_OPTS[self.norm.currentIndex()]
         try:
             try:
@@ -311,8 +303,12 @@ class ColorbarWidget(QWidget):
                 # use the smallest positive value as vmin when using log scale,
                 # matplotlib will take care of the data skipping part.
                 masked_data = masked_data[masked_data > 0] if norm == "Log" else masked_data
-                self.cmin_value = masked_data.min()
-                self.cmax_value = masked_data.max()
+
+                # If any dimension is zero then we have no data in the display area
+                data_is_empty = any(map(lambda dim: dim == 0, masked_data.shape))
+
+                self.cmin_value = 0. if data_is_empty else masked_data.min()
+                self.cmax_value = 0. if data_is_empty else masked_data.max()
             except (AttributeError, IndexError):
                 data = data[np.nonzero(data)] if norm == "Log" else data
                 self.cmin_value = np.nanmin(data)

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_sliceviewer_dataview.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_sliceviewer_dataview.py
@@ -194,6 +194,68 @@ class SliceviewerDataViewTest(unittest.TestCase):
                                                     norm=self.view.colorbar.get_norm(),
                                                     extent=original_image.get_extent())
 
+    def test_draw_plot_clears_title(self):
+        self.view.ax = mock.Mock()
+
+        self.view.draw_plot()
+
+        self.view.ax.set_title.assert_called_once_with('')
+
+    def test_draw_plot_draws_canvas(self):
+        self.view.ax = mock.Mock()
+        self.view.canvas = mock.Mock()
+
+        self.view.draw_plot()
+
+        self.view.canvas.draw.assert_called_once()
+
+    def test_draw_plot_updates_toolbar(self):
+        self.view.ax = mock.Mock()
+
+        self.view.draw_plot()
+
+        self.view.mpl_toolbar.update.assert_called_once()
+
+    def test_draw_plot_updates_colorbar(self):
+        self.view.ax = mock.Mock()
+        self.view.image = mock.NonCallableMock()
+
+        self.view.draw_plot()
+
+        self.view.colorbar.set_mappable.assert_called_once_with(self.view.image)
+        self.view.colorbar.update_clim.assert_called_once()
+
+    def test_draw_plot_does_not_update_colorbar_if_image_is_none(self):
+        self.view.ax = mock.Mock()
+        self.view.image = None
+
+        self.view.draw_plot()
+
+        self.view.colorbar.set_mappable.assert_not_called()
+        self.view.colorbar.update_clim.assert_not_called()
+
+    def test_draw_plot_updates_line_plots_if_active(self):
+        self.view.ax = mock.Mock()
+        self.view.image = mock.NonCallableMock()
+        self.view._line_plots = mock.Mock()
+        self.view.line_plots_active = True
+
+        self.view.draw_plot()
+
+        self.view._line_plots.plotter.delete_line_plot_lines.assert_called_once()
+        self.view._line_plots.plotter.update_line_plot_labels.assert_called_once()
+
+    def test_draw_plot_does_not_update_line_plots_if_inactive(self):
+        self.view.ax = mock.Mock()
+        self.view.image = mock.NonCallableMock()
+        self.view._line_plots = mock.Mock()
+        self.view.line_plots_active = False
+
+        self.view.draw_plot()
+
+        self.view._line_plots.plotter.delete_line_plot_lines.assert_not_called()
+        self.view._line_plots.plotter.update_line_plot_labels.assert_not_called()
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/view.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/view.py
@@ -346,6 +346,7 @@ class SliceViewerDataView(QWidget):
 
     def draw_plot(self):
         self.ax.set_title('')
+        self.canvas.draw()
         if self.image:
             self.colorbar.set_mappable(self.image)
             self.colorbar.update_clim()
@@ -353,8 +354,6 @@ class SliceViewerDataView(QWidget):
         if self.line_plots_active:
             self._line_plots.plotter.delete_line_plot_lines()
             self._line_plots.plotter.update_line_plot_labels()
-
-        self.canvas.draw()
 
     def export_region(self, limits, cut):
         """


### PR DESCRIPTION
This PR fixes two issues that are causing autoscale to fail for the sliceviewer colorbar:

- Move the `canvas.draw` to before calculating the colorbar limits, because the limits are based on the image data. For Workspace2D this is not recalculated before we redraw.
- For MD workspaces, add a new function to get the image data clipped to the axes extents (because the default `get_array` function always returns the full extent). Note that this works regardless of where the draw is done with the previous fix.

Fixes #33214, fixes #32359

**To test:**

See the instructions in the comment by Richard in the linked issue. Check that autoscaling now works as expected when you zoom in and out. 

Release notes to follow


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
