### PR TITLE
Fix Symmetrise failing on workspaces with different bin width

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/Symmetrise.py
+++ b/Framework/PythonInterface/plugins/algorithms/Symmetrise.py
@@ -243,7 +243,7 @@ class Symmetrise(PythonAlgorithm):
         """
         # Find array index of the first negative XMin
         negative_min_diff = sample_x + self._x_min
-        self._negative_min_index = np.where(negative_min_diff < 0)[0][-1]
+        self._negative_min_index = np.where(negative_min_diff > 0)[0][0]
         self._check_bounds(self._negative_min_index, sample_array_len, label='Negative')
 
         # Find array index of the first positive XMin, that is smaller than the required

--- a/Framework/PythonInterface/plugins/algorithms/Symmetrise.py
+++ b/Framework/PythonInterface/plugins/algorithms/Symmetrise.py
@@ -242,14 +242,13 @@ class Symmetrise(PythonAlgorithm):
         @param sample_array_len - Length of data array for sample data
         """
         # Find array index of the first negative XMin
-        delta_x = sample_x[1] - sample_x[0]
-        negative_min_diff = np.absolute(sample_x + self._x_min)
-        self._negative_min_index = np.where(negative_min_diff < delta_x)[0][-1]
+        negative_min_diff = sample_x + self._x_min
+        self._negative_min_index = np.where(negative_min_diff < 0)[0][-1]
         self._check_bounds(self._negative_min_index, sample_array_len, label='Negative')
 
         # Find array index of the first positive XMin, that is smaller than the required
-        positive_min_diff = np.absolute(sample_x + sample_x[self._negative_min_index])
-        self._positive_min_index = np.where(positive_min_diff < delta_x)[0][-1]
+        positive_min_diff = sample_x + sample_x[self._negative_min_index]
+        self._positive_min_index = np.where(positive_min_diff > 0)[0][0]
         self._check_bounds(self._positive_min_index, sample_array_len, label='Positive')
 
         # Find array index of the first positive XMax, that is smaller than the required

--- a/Framework/PythonInterface/test/python/plugins/algorithms/SymmetriseTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/SymmetriseTest.py
@@ -17,14 +17,15 @@ def _rayleigh(x, sigma):
 
 
 def _generate_sample_ws(ws_name):
-    data_x = np.arange(0, 10, 0.01)
+    data_x = np.append(np.arange(0, 2.5, 0.001), np.arange(2.501, 7.5, 0.01))
+    data_x = np.append(data_x, np.arange(7.51, 10, 0.001))
     data_y = _rayleigh(data_x, 1)
 
     # Create the workspace and give it some units
     CreateWorkspace(OutputWorkspace=ws_name, DataX=data_x, DataY=data_y, \
                     UnitX='MomentumTransfer', VerticalAxisUnit='QSquared', VerticalAxisValues='0.2')
     # Centre the peak over 0
-    ScaleX(InputWorkspace=ws_name, Factor=-1, Operation="Add", OutputWorkspace=ws_name)
+    ScaleX(InputWorkspace=ws_name, Factor=-5, Operation="Add", OutputWorkspace=ws_name)
 
     return mtd[ws_name]
 
@@ -60,12 +61,6 @@ class SymmetriseTest(unittest.TestCase):
         @param workspace Workspace to check
         """
         tolerance = 1e-15
-
-        # Test that each pair of points moving inwards are equal
-        data_x = workspace.dataX(0)
-        for idx in range(0, int(len(data_x) / 2)):
-            delta = abs(data_x[idx]) - abs(data_x[-(idx + 1)])
-            self.assertLess(abs(delta), tolerance)
 
         # Test that the axis and values were preserved
         sample_x_axis = self._sample_ws.getAxis(0)
@@ -175,6 +170,16 @@ class SymmetriseTest(unittest.TestCase):
                           OutputWOrkspace='__Symmetrise_TestWS',
                           XMin=0.05, XMax=0.2,
                           SpectraRange=[1, 2])
+
+    def test_handle_different_bin_width_in_sample_ws(self):
+        """
+        Tests validation on entering a maximum spectra number higher then that of the workspace.
+        """
+        symm_test_out_ws = Symmetrise(InputWorkspace=self._sample_ws,
+                                      XMin=2.1, XMax=3.3,
+                                      SpectraRange=[1, 1])
+
+        self._validate_workspace(symm_test_out_ws)
 
 
 if __name__ == '__main__':

--- a/docs/source/release/v6.3.0/33339_indirect_geometry.rst
+++ b/docs/source/release/v6.3.0/33339_indirect_geometry.rst
@@ -1,0 +1,4 @@
+Bugfixes
+--------
+
+- Fixed a bug in the Symmetrise algorithm where workspaces in different bin widths would sometimes cause exceptions.

--- a/docs/source/release/v6.3.0/indirect_geometry.rst
+++ b/docs/source/release/v6.3.0/indirect_geometry.rst
@@ -26,6 +26,5 @@ Bugfixes
 - Contour workspaces are now saved when saving in ``Bayes stretch``.
 - Fixed a bug which prevented workspaces being loaded into the :ref:`Elwin Tab <Elwin-iqt-ref>` .
 - Fixed a bug which caused :ref:`VesuvioAnalysis <algm-VesuvioAnalysis>` to crash when run with a single element.
-- Fixed a bug in the Symmetrise algorithm where workspaces in different bin widths would sometimes cause exceptions.
 
 :ref:`Release 6.3.0 <v6.3.0>`

--- a/docs/source/release/v6.3.0/indirect_geometry.rst
+++ b/docs/source/release/v6.3.0/indirect_geometry.rst
@@ -18,7 +18,7 @@ Improvements
   from CASTEP or Phonopy calculations, then sample an appropriate q-point mesh on-the-fly to create a phonon DOS. This feature requires the Euphonic library to be installed. This library is
   included in the Windows package, but for other platforms an installer is provided in the Script Repository.
 - In Inelastic Data Analysis the :ref:`Elwin Tab <Elwin-iqt-ref>` has had its UI updated to be more user friendly.
-- Updated documentation for :ref:`VesuvioAnalysis <algm-VesuvioAnalysis>`.
+- Updated documentation for :ref:`VesuvioAnalysis <algm-VesuvioAnalysis>` .
 
 Bugfixes
 --------

--- a/docs/source/release/v6.3.0/indirect_geometry.rst
+++ b/docs/source/release/v6.3.0/indirect_geometry.rst
@@ -18,7 +18,7 @@ Improvements
   from CASTEP or Phonopy calculations, then sample an appropriate q-point mesh on-the-fly to create a phonon DOS. This feature requires the Euphonic library to be installed. This library is
   included in the Windows package, but for other platforms an installer is provided in the Script Repository.
 - In Inelastic Data Analysis the :ref:`Elwin Tab <Elwin-iqt-ref>` has had its UI updated to be more user friendly.
-- Updated documentation for :ref:`VesuvioAnalysis <algm-VesuvioAnalysis>` .
+- Updated documentation for :ref:`VesuvioAnalysis <algm-VesuvioAnalysis>`.
 
 Bugfixes
 --------
@@ -26,5 +26,6 @@ Bugfixes
 - Contour workspaces are now saved when saving in ``Bayes stretch``.
 - Fixed a bug which prevented workspaces being loaded into the :ref:`Elwin Tab <Elwin-iqt-ref>` .
 - Fixed a bug which caused :ref:`VesuvioAnalysis <algm-VesuvioAnalysis>` to crash when run with a single element.
+- Fixed a bug in the Symmetrise algorithm where workspaces in different bin widths would sometimes cause exceptions.
 
 :ref:`Release 6.3.0 <v6.3.0>`


### PR DESCRIPTION
**Description of work.**

This PR fixes a bug in Symmetrise where if a workspace had different bin widths it would sometimes be unable to find the correct minimum values.

**To test:**

See associated issue, following the steps should not rsult in an unhandled exception, and the algoithm should run correctly.

Fixes #33339

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
