### PR TITLE
Muon plots with fits on top of data

### DIFF
--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/plot_widget/plotting_canvas/plotting_canvas_view.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/plot_widget/plotting_canvas/plotting_canvas_view.py
@@ -440,6 +440,16 @@ class PlottingCanvasView(QtWidgets.QWidget, PlottingCanvasViewInterface):
         plot_kwargs = {'distribution': True, 'autoscale_on_update': False, 'label': label}
         plot_kwargs["marker"] = self._settings.get_marker(workspace_info.workspace_name)
         plot_kwargs["linestyle"] = self._settings.get_linestyle(workspace_info.workspace_name)
+        if isinstance(workspace_info.index, int):
+            """
+            Attempts at replotting the fit line do not work,
+            this is because replot_artist currently only does anything
+            if the data has changed (it has not in our case).
+            So lets manually set the fit lines to be on top
+            (they will always have an index of either 1 or 3 and data
+            will always have an index of 0).
+            """
+            plot_kwargs["zorder"] = workspace_info.index
         return plot_kwargs
 
     def _get_y_axis_autoscale_limits(self, axis):


### PR DESCRIPTION
**Description of work.**

During this release we changed the way the muon GUI handles errors on the fit line (we dont plot error bars anymore). Since the fit "line" was not changing (by adding error bars) it was not getting replotted as expected (I assume this is to prevent unnecessary drawing). However, it meant that the fit line would fall behind the data. I have fixed this by explicitly setting the order of the layers in the plot. This method does use the follwing facts about muon data:

1. All experimental data has a ws index of 0 (except for raw plots)
2. All fits have an index of 1 or 3 (TF Asymmetry fit)
3. The raw plots are always plotted as tiles
4. The only time a line is plotted with raw plots is the reconstructed data in the dual plot pane and for this pane errors are never plotted

**To test:**

<!-- Instructions for testing. -->
Open muon analysis
Load MUSR 62260
Go to fitting
Tick simultaneous
Add a GausOsc
Set Frequency and Sigma to global
Give Frequency a value of 1.3
Press fit
Zoom in so you can see the peaks in detail (you can do all 4 groups at once) and check that the fit is on top
Turn on the errors (below the plot)
Check that the fit is still on top
Turn off the errors
Check that the fit is still on top
Close muon analysis

Open Frequency domain analysis
Load MUSR 62261
Go to the phase tab
Calculate a phase table (name does not matter)
Go to the transform tab
Change from FFT to Maxent
Set calculate by to all detectors
Set the phase table to the one you made
Tick Output reconstructed data
Click calculate maxent - it takes a while
When its done above the plot change from "frequency data" to dual plot
Check that the reconstructed data is on top
Turn on the errors
Check that the reconstructed data is on top
Note that no errors appear on the data either. This is intentional 

Fixes #33331. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

Not in release notes as we added this bug in this release

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
