### PR TITLE
Change default mechanics for scaling in IndirectCalibration

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/IndirectCalibration.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/IndirectCalibration.py
@@ -48,6 +48,9 @@ class IndirectCalibration(DataProcessorAlgorithm):
                                                 validator=FloatArrayMandatoryValidator()),
                              doc='Time of flight range over the background.')
 
+        self.declareProperty(name='ScaleByFactor', defaultValue=False,
+                             doc='Set to True to enable Scaling, if false output will be normalised to 1.')
+
         self.declareProperty(name='ScaleFactor', defaultValue=1.0,
                              doc='Factor by which to scale the result.')
 
@@ -182,9 +185,9 @@ class IndirectCalibration(DataProcessorAlgorithm):
         self._peak_range = self.getProperty('PeakRange').value
         self._back_range = self.getProperty('BackgroundRange').value
         self._spec_range = self.getProperty('DetectorRange').value
-
+        self._scale_by_factor = self.getProperty('ScaleByFactor').value
         self._intensity_scale = self.getProperty('ScaleFactor').value
-        if self._intensity_scale == 1.0:
+        if not self._scale_by_factor:
             self._intensity_scale = None
 
     def _add_logs(self):

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/IndirectCalibrationTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/IndirectCalibrationTest.py
@@ -10,28 +10,51 @@ from mantid.simpleapi import IndirectCalibration
 
 
 class IndirectCalibrationTest(unittest.TestCase):
-
-    def test_simple(self):
-        cal_ws = IndirectCalibration(InputFiles='IRS38633.raw',
-                                            DetectorRange=[3,53],
-                                            PeakRange=[62000,65000],
-                                            BackgroundRange=[59000,61000])
-
-        self.assertEqual(cal_ws.getNumberHistograms(), 51)
-        self.assertEqual(cal_ws.blocksize(), 1)
-
-
     def test_logs(self):
         cal_ws = IndirectCalibration(InputFiles='IRS38633.raw',
-                                            DetectorRange=[3,53],
-                                            PeakRange=[62000,65000],
-                                            BackgroundRange=[59000,61000],
-                                            LoadLogFiles=True)
+                                     DetectorRange=[3, 53],
+                                     PeakRange=[62000, 65000],
+                                     BackgroundRange=[59000, 61000],
+                                     LoadLogFiles=True)
 
         self.assertEqual(cal_ws.getNumberHistograms(), 51)
         self.assertEqual(cal_ws.blocksize(), 1)
 
         self.assertEqual(cal_ws.run().getProperty('current_period').value, 1)
 
+    def test_scale_by_factor_does_not_normalise(self):
+        cal_ws = IndirectCalibration(InputFiles='IRS38633.raw',
+                                     DetectorRange=[3, 53],
+                                     PeakRange=[62000, 65000],
+                                     BackgroundRange=[59000, 61000],
+                                     LoadLogFiles=True)
+        cal_ws_scaled = IndirectCalibration(InputFiles='IRS38633.raw',
+                                            DetectorRange=[3, 53],
+                                            PeakRange=[62000, 65000],
+                                            BackgroundRange=[59000, 61000],
+                                            LoadLogFiles=True,
+                                            ScaleByFactor=True)
+
+        self.assertNotEqual(cal_ws_scaled.dataY(0)/cal_ws.dataY(0), 1.0)
+
+    def test_scale_by_factor_uses_factor(self):
+        cal_ws_1_0 = IndirectCalibration(InputFiles='IRS38633.raw',
+                                         DetectorRange=[3, 53],
+                                         PeakRange=[62000, 65000],
+                                         BackgroundRange=[59000, 61000],
+                                         LoadLogFiles=True,
+                                         ScaleByFactor=True,
+                                         ScaleFactor=1.0)
+        cal_ws_0_9 = IndirectCalibration(InputFiles='IRS38633.raw',
+                                         DetectorRange=[3, 53],
+                                         PeakRange=[62000, 65000],
+                                         BackgroundRange=[59000, 61000],
+                                         LoadLogFiles=True,
+                                         ScaleByFactor=True,
+                                         ScaleFactor=0.9)
+
+        self.assertEqual(cal_ws_0_9.dataY(0)/cal_ws_1_0.dataY(0), 0.9)
+
+
 if __name__ == "__main__":
-	unittest.main()
+    unittest.main()

--- a/docs/source/release/v6.3.0/33212_indirect_geometry.rst
+++ b/docs/source/release/v6.3.0/33212_indirect_geometry.rst
@@ -1,0 +1,4 @@
+Bugfixes
+########
+
+- Fixed a bug that caused ISIS calibration to ignore `Scale by factor` if set to 1.0

--- a/docs/source/release/v6.3.0/indirect_geometry.rst
+++ b/docs/source/release/v6.3.0/indirect_geometry.rst
@@ -26,5 +26,6 @@ Bugfixes
 - Contour workspaces are now saved when saving in ``Bayes stretch``.
 - Fixed a bug which prevented workspaces being loaded into the :ref:`Elwin Tab <Elwin-iqt-ref>` .
 - Fixed a bug which caused :ref:`VesuvioAnalysis <algm-VesuvioAnalysis>` to crash when run with a single element.
+- Fixed a bug that caused ISIS calibration to ignore `Scale by factor` if set to 1.0
 
 :ref:`Release 6.3.0 <v6.3.0>`

--- a/docs/source/release/v6.3.0/indirect_geometry.rst
+++ b/docs/source/release/v6.3.0/indirect_geometry.rst
@@ -26,6 +26,5 @@ Bugfixes
 - Contour workspaces are now saved when saving in ``Bayes stretch``.
 - Fixed a bug which prevented workspaces being loaded into the :ref:`Elwin Tab <Elwin-iqt-ref>` .
 - Fixed a bug which caused :ref:`VesuvioAnalysis <algm-VesuvioAnalysis>` to crash when run with a single element.
-- Fixed a bug that caused ISIS calibration to ignore `Scale by factor` if set to 1.0
 
 :ref:`Release 6.3.0 <v6.3.0>`

--- a/qt/scientific_interfaces/Indirect/ISISCalibration.cpp
+++ b/qt/scientific_interfaces/Indirect/ISISCalibration.cpp
@@ -670,8 +670,8 @@ IAlgorithm_sptr ISISCalibration::calibrationAlgorithm(const QString &inputFiles)
   calibrationAlg->setProperty("BackgroundRange", backgroundRangeString().toStdString());
   calibrationAlg->setProperty("LoadLogFiles", m_uiForm.ckLoadLogFiles->isChecked());
 
-  if (m_uiForm.ckScale->isChecked())
-    calibrationAlg->setProperty("ScaleFactor", m_uiForm.spScale->value());
+  calibrationAlg->setProperty("ScaleByFactor", m_uiForm.ckScale->isChecked());
+  calibrationAlg->setProperty("ScaleFactor", m_uiForm.spScale->value());
   return calibrationAlg;
 }
 


### PR DESCRIPTION
**Description of work.**

This PR fixes an issue in Indirectcalibration where if `ScaleFactor` was set to 1.0 (the default) it would normalise the output to 1.0, but if it was set to any other value it would not normalise and instead scale the total by whatever the factor was. this made it impossible to get the output as it's total value without also having it scaled. it now implements a `ScaleByFactor` property that  if set to true will use the `ScaleFactor` even if it is 1.0 without normalising it.

**To test:**

See associated issue for setup. when `Scale by factor` is checked it should not normalise the output `_calib` workspace even if the factor is set to 1.0

Fixes #33212

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
