### PR TITLE
Stop rectangle ROI using x/y data from event outside colorfill axes when ROI resized/moved

### DIFF
--- a/docs/source/release/v6.3.0/33346_mantidworkbench.rst
+++ b/docs/source/release/v6.3.0/33346_mantidworkbench.rst
@@ -1,0 +1,8 @@
+SliceViewer
+-----------
+
+Bugfixes
+########
+- Stop ROI rectangle selection extents jumping discontinuously when the user tries to resize beyond the extent of the colorfill axes towards the line plot axes.
+
+:ref:`Release 6.3.0 <v6.3.0>`

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/lineplots.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/lineplots.py
@@ -316,7 +316,7 @@ class RectangleSelectorMtd(RectangleSelector):
     def onmove(self, event):
         """
         Only process event if inside the axes with which the selector was init
-        This fixes bug #33264 where the x/y of the event originated form the line plot axes not the colorfill axes
+        This fixes bug where the x/y of the event originated from the line plot axes not the colorfill axes
         """
         if event.inaxes is None or self.ax == event.inaxes.axes:
             super(RectangleSelectorMtd, self).onmove(event)

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/lineplots.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/lineplots.py
@@ -312,6 +312,16 @@ class PixelLinePlot(CursorTracker, KeyHandler):
             self.exporter.export_pixel_cut(self._cursor_pos, key)
 
 
+class RectangleSelectorMtd(RectangleSelector):
+    def onmove(self, event):
+        """
+        Only process event if inside the axes with which the selector was init
+        This fixes bug #33264 where the x/y of the event originated form the line plot axes not the colorfill axes
+        """
+        if event.inaxes is None or self.ax == event.inaxes.axes:
+            super(RectangleSelectorMtd, self).onmove(event)
+
+
 class RectangleSelectionLinePlot(KeyHandler):
     """
     Draws X/Y line plots from a rectangular selection by summing across
@@ -328,7 +338,7 @@ class RectangleSelectionLinePlot(KeyHandler):
         super().__init__(plotter, exporter)
 
         ax = plotter.image_axes
-        self._selector = RectangleSelector(
+        self._selector = RectangleSelectorMtd(
             ax,
             self._on_rectangle_selected,
             drawtype='box',


### PR DESCRIPTION
**Description of work.**

Stop rectangle ROI using x/y data from event outside colorfill axes when ROI resized/moved - this involved overriding one method, `onmove`, of a matplotlib widget `RectangleSelector`.

**To test:**

(1) Follow instructions on original issue - the box shouldn't jump to the ylimit of the line-plot 
(2) Try dragging ROI off the colorfill axes - the ROI limits should not change discontinuously, it will look like the ROI box is getting shrunk as the box is moved to the edge of the axes.

Fixes #33264 

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
