### PR TITLE
Muon reselect fits in results tab

### DIFF
--- a/docs/source/release/v6.3.0/33315_muon.rst
+++ b/docs/source/release/v6.3.0/33315_muon.rst
@@ -1,0 +1,10 @@
+Muon Analysis and Frequency Domain Analysis
+-------------------------------------------
+
+New Features
+############
+
+Improvements
+############
+
+- The :ref:`Results Tab <muon_results_tab-ref>` will now preserve the workspace selection after a fit. However, it will reselect a fit that has been recalculated.

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/results_tab_widget/results_tab_presenter.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/results_tab_widget/results_tab_presenter.py
@@ -45,7 +45,7 @@ class ResultsTabPresenter(QObject):
         else:
             self.view.set_output_results_button_no_warning()
 
-    def on_new_fit_performed(self, fit_info):
+    def on_new_fit_performed(self, fit_info=None):
         """React to a new fit created in the fitting tab"""
         # It's possible that this call can come in on a thread that
         # is different to the one that the view lives on.
@@ -53,11 +53,13 @@ class ResultsTabPresenter(QObject):
         # that 'self' lives on the same thread as the view and Qt forces
         # the call to the chose method to be done on the thread the
         # view lives on. This avoids errors from painting on non-gui threads.
-        new_fit_name = fit_info.output_workspace_names()
-        if new_fit_name and len(new_fit_name)>0:
-            QMetaObject.invokeMethod(self, "_on_new_fit_performed_impl", Q_ARG(str, new_fit_name[0]))
-        else:
-            QMetaObject.invokeMethod(self, "_on_new_fit_performed_impl")
+
+        new_fit_name = ";"
+        if fit_info:
+            new_fit_list = fit_info.output_workspace_names()
+            if new_fit_list and len(new_fit_list)>0:
+                new_fit_name = new_fit_list[0]
+        QMetaObject.invokeMethod(self, "_on_new_fit_performed_impl", Q_ARG(str, new_fit_name))
 
     def on_output_results_request(self):
         """React to the output results table request"""


### PR DESCRIPTION
**Description of work.**

In the muon GUI the user will do several fits. Then generate a results table. The user can select the data to put into the table on the results tab. When a user updated the selection to remove a fit and then recalculated it, the fit was not reselected. This PR fixes this.

**To test:**

<!-- Instructions for testing. -->
Open muon analysis
Load MUSR 62260
Go to fitting and add a fit function (doesnt matter which)
Go to sequential fitting and press "fit all"
Go to the results tab
In the bottom table untick all of the options
Go back to fitting
Check which data set is selected (should have the word "top" in the name displayed in the combo box)
Press fit
Go back to the results tab
Check that the bottom table has one item selected (should match the thing you just fitted, i.e. top)
Untick it again
Go to the sequential tab
Highlight a row and make a note of the group name
Press fit selected
Go back to the results tab 
Check that the bottom table has one item selected (should include the group yo just fitted to in the name)

Fixes #33315. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

In release notes (I couldnt see it in the original)

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
