### PR TITLE
Fix Crash when Using Invalid Files on ConvertAxesToRealSpace

### DIFF
--- a/Framework/Algorithms/src/ConvertAxesToRealSpace.cpp
+++ b/Framework/Algorithms/src/ConvertAxesToRealSpace.cpp
@@ -111,6 +111,7 @@ void ConvertAxesToRealSpace::exec() {
   // for each spectra
   PARALLEL_FOR_IF(Kernel::threadSafe(*summedWs, *outputWs))
   for (int i = 0; i < nHist; ++i) {
+    PARALLEL_START_INTERUPT_REGION
     try {
       V3D pos = spectrumInfo.position(i);
       double r, theta, phi;
@@ -159,6 +160,7 @@ void ConvertAxesToRealSpace::exec() {
       dataVector[i].horizontalValue = std::numeric_limits<double>::min();
       dataVector[i].verticalValue = std::numeric_limits<double>::min();
     }
+    PARALLEL_END_INTERUPT_REGION
 
     // take the values from the integrated data
     dataVector[i].intensity = summedWs->y(i)[0];
@@ -166,6 +168,7 @@ void ConvertAxesToRealSpace::exec() {
 
     progress.report("Calculating new coords");
   }
+  PARALLEL_CHECK_INTERUPT_REGION
 
   g_log.warning() << "Could not find detector for " << failedCount << " spectra, see the debug log for more details.\n";
 

--- a/Framework/Algorithms/test/ConvertAxesToRealSpaceTest.h
+++ b/Framework/Algorithms/test/ConvertAxesToRealSpaceTest.h
@@ -96,4 +96,31 @@ public:
 
     return ws;
   }
+
+  void test_exec_invalid_ws() {
+    std::string baseWSName = "ConvertAxesToRealSpaceTest_exec_invalid_monitors";
+    std::string inWSName(baseWSName + "_InputWS");
+    std::string outWSName(baseWSName + "_OutputWS");
+    std::string verticalAxis = "y";
+    std::string horizontalAxis = "2theta";
+    int nVBins = 100;
+    int nHBins = 200;
+    auto testWS = WorkspaceCreationHelper::create2DWorkspaceWithFullInstrument(3, 2, true);
+    AnalysisDataService::Instance().addOrReplace(inWSName, testWS);
+
+    Mantid::Algorithms::ConvertAxesToRealSpace conv;
+
+    conv.initialize();
+
+    TS_ASSERT_THROWS_NOTHING(conv.setPropertyValue("InputWorkspace", inWSName));
+    TS_ASSERT_THROWS_NOTHING(conv.setPropertyValue("OutputWorkspace", outWSName));
+    TS_ASSERT_THROWS_NOTHING(conv.setPropertyValue("VerticalAxis", verticalAxis));
+    TS_ASSERT_THROWS_NOTHING(conv.setPropertyValue("HorizontalAxis", horizontalAxis));
+    TS_ASSERT_THROWS_NOTHING(conv.setProperty("NumberVerticalBins", nVBins));
+    TS_ASSERT_THROWS_NOTHING(conv.setProperty("NumberHorizontalBins", nHBins));
+
+    auto success = conv.execute();
+    TS_ASSERT(!conv.isExecuted());
+    TS_ASSERT(!success);
+  }
 };

--- a/docs/source/release/v6.3.0/32434_framework.rst
+++ b/docs/source/release/v6.3.0/32434_framework.rst
@@ -1,0 +1,6 @@
+Algorithms
+----------
+
+Bug Fixes
+#########
+- ConvertAxesToRealSpace no longer crashes mantid if using an invalid file.


### PR DESCRIPTION
**Description of work.**
Errors thrown within the PARALLEL block were causing unhandled qt exceptions. Adds a check for errors in the loop and then throws afterwards to ensure they are thrown in the GUI thread as required by Qt. 

**To test:**

1. Load a monochromatic file like `./ExternalData/Testing/Data/SystemTest/ILL/D16/003682.nxs`.
2. Run `ConvertAxesToRealSpace` on this. 
3. It should fail gracefully, presenting a relevant error message. 

Fixes #32434 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
