### PR TITLE
Check for valid x/y before passing event to add_peak

### DIFF
--- a/docs/source/release/v6.3.0/33352_mantidworkbench.rst
+++ b/docs/source/release/v6.3.0/33352_mantidworkbench.rst
@@ -1,0 +1,5 @@
+Bugfixes
+########
+- Users no longer able to add a peak to the fit browser by clicking with the interactive tool outside of the axes (would cause an error).
+
+:ref:`Release 6.3.0 <v6.3.0>`

--- a/qt/python/mantidqt/mantidqt/widgets/fitpropertybrowser/mouse_state_machine.py
+++ b/qt/python/mantidqt/mantidqt/widgets/fitpropertybrowser/mouse_state_machine.py
@@ -38,10 +38,13 @@ class StateMachine(object):
         """
         Respond to mouse release event.
         """
-        if self.tool.toolbar_manager.is_tool_active():
-            return
-        self.state.button_release_callback(event)
-        self.state = self.state.transition()
+        if not self.tool.toolbar_manager.is_tool_active():
+            if (event.xdata is None or event.ydata is None) and isinstance(self.state, AddPeakState):
+                # cursor off the axes - reset cursor state to behave as if just clicked Add Peak when cursor next moved
+                self.state.reset_cursor()
+                return
+            self.state.button_release_callback(event)
+            self.state = self.state.transition()
 
     def transition_to(self, state_name):
         """
@@ -94,6 +97,9 @@ class AddPeakState(object):
     def __init__(self, machine):
         self.machine = machine
         self.tool = machine.tool
+        self.cursor = None
+
+    def reset_cursor(self):
         self.cursor = None
 
     def button_press_callback(self, event):


### PR DESCRIPTION
**Description of work.**

On mouse release check for valid x/y (i.e. None if cursor outside axes) before passing event to add_peak - it is important for non-peak adding (e.g. slider moving) events to call `button_release_callback` and `self.state.transition()` so as to not get the mouse clicked/non-clicked behaviour out of sync - the valid x/y are handled correctly for case of moving sliders (i.e. ignored).

In the case of adding a peak the cursor is reset so that when next moved it behaves as if Add Peak just clicked.

**To test:**

(1) make a workspace
```
ws = CreateSampleWorkspace(Function="User Defined", UserDefinedFunction="name=LinearBackground, A0=1;name=Gaussian, PeakCentre=5, Height=10, Sigma=0.7", NumBanks=1, BankPixelWidth=1, XMin=0, XMax=10, BinWidth=0.4, WorkspaceType="Histogram")
```
(2) Plot and open fit browser
(3) Right-click on axes > Add Peak
(4) Move cursor off the axes and add a peak
 - There should be no error, it should not add a peak and the Add Peak cursor should remain enabled when you move the cursor
 
(5) Add a peak on the axes
(6) Move a FWHM slider off the axes and release the mouse button 
- when you move the cursor back onto the axes the sliders should not move (i.e. it has correctly registered the mouse release).

Fixes #33304 


<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
