### PR TITLE
Prevent instrument viewer hang when replacing workspace

### DIFF
--- a/docs/source/release/v6.3.0/33357_mantidworkbench.rst
+++ b/docs/source/release/v6.3.0/33357_mantidworkbench.rst
@@ -1,0 +1,4 @@
+Bugfixes
+--------
+
+- Opening the :ref:`InstrumentViewer` while a workspace is being reloaded will no longer cause a crash.

--- a/qt/python/mantidqt/mantidqt/widgets/instrumentview/presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/instrumentview/presenter.py
@@ -29,8 +29,10 @@ class InstrumentViewPresenter(ObservingPresenter):
 
         self.container = view
         if not self.container:
+            ws.readLock()
             self.container = InstrumentView(parent=parent, presenter=self,
                                             name=self.ws_name, window_flags=window_flags)
+            ws.unlock()
 
         if ads_observer:
             self.ads_observer = ads_observer

--- a/qt/python/mantidqt/mantidqt/widgets/instrumentview/presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/instrumentview/presenter.py
@@ -35,9 +35,11 @@ class InstrumentViewPresenter(ObservingPresenter):
         if not self.container:
             workspace = AnalysisDataService.retrieve(self.ws_name)
             workspace.readLock()
-            self.container = InstrumentView(parent=parent, presenter=self,
-                                            name=self.ws_name, window_flags=window_flags)
-            workspace.unlock()
+            try:
+                self.container = InstrumentView(parent=parent, presenter=self,
+                                                name=self.ws_name, window_flags=window_flags)
+            finally:
+                workspace.unlock()
 
         if ads_observer:
             self.ads_observer = ads_observer

--- a/qt/python/mantidqt/mantidqt/widgets/instrumentview/presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/instrumentview/presenter.py
@@ -12,6 +12,7 @@ Contains the presenter for displaying the InstrumentWidget
 """
 from qtpy.QtCore import Qt
 
+from mantid.api import AnalysisDataService
 from mantidqt.widgets.observers.ads_observer import WorkspaceDisplayADSObserver
 from mantidqt.widgets.observers.observing_presenter import ObservingPresenter
 from .view import InstrumentView
@@ -23,16 +24,20 @@ class InstrumentViewPresenter(ObservingPresenter):
     It has no model as its an old widget written in C++ with out MVP
     """
 
+    """
+    @param ws : The workspace object OR workspace name.
+    """
     def __init__(self, ws, parent=None, window_flags=Qt.Window, ads_observer=None, view: InstrumentView=None):
         super(InstrumentViewPresenter, self).__init__()
         self.ws_name = str(ws)
 
         self.container = view
         if not self.container:
-            ws.readLock()
+            workspace = AnalysisDataService.retrieve(self.ws_name)
+            workspace.readLock()
             self.container = InstrumentView(parent=parent, presenter=self,
                                             name=self.ws_name, window_flags=window_flags)
-            ws.unlock()
+            workspace.unlock()
 
         if ads_observer:
             self.ads_observer = ads_observer

--- a/qt/python/mantidqt/mantidqt/widgets/instrumentview/test/test_instrumentview_presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/instrumentview/test/test_instrumentview_presenter.py
@@ -10,6 +10,7 @@ import unittest
 from unittest import mock
 
 from mantidqt.widgets.instrumentview.presenter import InstrumentViewPresenter
+from testhelpers import assertRaisesNothing
 
 
 class InstrumentViewPresenterTest(unittest.TestCase):
@@ -20,13 +21,29 @@ class InstrumentViewPresenterTest(unittest.TestCase):
         self.ws = mock.NonCallableMock()
         self.presenter = InstrumentViewPresenter(ws=self.ws, view=self.mock_view)
 
+    @mock.patch("mantidqt.widgets.instrumentview.presenter.AnalysisDataService")
     @mock.patch("mantidqt.widgets.instrumentview.presenter.InstrumentView")
-    def test_ws_name_passed_in_constructor(self, mock_view):
+    def test_ws_name_passed_in_constructor(self, mock_view, mock_ads):
+        mock_ads.retrieve.return_value = mock.NonCallableMock()
+
         ws = mock.NonCallableMock()
         presenter = InstrumentViewPresenter(ws)
 
         mock_view.assert_called_once_with(parent=mock.ANY, presenter=presenter,
                                           name=str(ws), window_flags=mock.ANY)
+
+    @mock.patch("mantidqt.widgets.instrumentview.presenter.AnalysisDataService")
+    @mock.patch("mantidqt.widgets.instrumentview.presenter.InstrumentView")
+    def test_constructor_works_with_ws_name(self, mock_view, mock_ads):
+        """
+        Check that the InstrumentViewPresenter constructs correctly when passing the name
+        of the workspace rather than the workspace object.
+        """
+        mock_ads.retrieve.return_value = mock.NonCallableMock()
+        ws_name = "my_workspace"
+        presenter = assertRaisesNothing(self, InstrumentViewPresenter, ws_name)
+        mock_view.assert_called_once_with(parent=mock.ANY, presenter=presenter,
+                                          name=ws_name, window_flags=mock.ANY)
 
     @mock.patch("mantidqt.widgets.instrumentview.presenter.InstrumentViewManager")
     def test_constructor_registers_with_inst_view_manager(self, mock_manager):

--- a/qt/python/mantidqt/mantidqt/widgets/instrumentview/test/test_instrumentview_presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/instrumentview/test/test_instrumentview_presenter.py
@@ -57,6 +57,18 @@ class InstrumentViewPresenterTest(unittest.TestCase):
         ws.readLock.assert_called_once()
         ws.unlock.assert_called_once()
 
+    @mock.patch("mantidqt.widgets.instrumentview.presenter.AnalysisDataService")
+    @mock.patch("mantidqt.widgets.instrumentview.presenter.InstrumentView")
+    def test_ws_unlocks_if_instrument_view_throws_exception(self, mock_view, mock_ads):
+        ws = mock.NonCallableMock()
+        mock_ads.retrieve.return_value = ws
+        # Get our mock InstrumentView to throw an exception.
+        mock_view.side_effect = KeyError('instrument view threw an exception')
+        with self.assertRaises(KeyError):
+            InstrumentViewPresenter(ws)
+        # Make sure workspace is unlocked if exception is thrown.
+        ws.unlock.assert_called_once()
+
     @mock.patch("mantidqt.widgets.instrumentview.presenter.InstrumentViewManager")
     def test_constructor_registers_with_inst_view_manager(self, mock_manager):
         ws = mock.NonCallableMock()


### PR DESCRIPTION
**Description of work.**

Prevents Mantid from crashing or hanging indefinitely when opening the instrument view on a workspace that is being overwritten.

**To test:**

1. Load a big workspace that takes a while to open.
2. When it's finished loading, load it again.
3. QUICKLY, while it's loading, open the instrument view by right clicking the workspace and selecting "Show Instrument"
Mantid may appear to hang, but if you give it time it will eventually display the isntrument view and replace the workspace (depending on the size of your workspace).

Fixes #32433 

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
