### PR TITLE
Add Breadcrumb to user docs

### DIFF
--- a/docs/source/_templates/navbar.html
+++ b/docs/source/_templates/navbar.html
@@ -2,6 +2,27 @@
 {#   Remove search box when in embedded mode (qthelp etc) #}
 {#   Point the main logo anchor to www.mantidproject.org in standard mode and the master document in embedded mode #}
 
+{%- macro relbar() %}
+    <div class="related" role="navigation" aria-label="related navigation">
+      <h3>{{ _('Navigation') }}</h3>
+      <ul>
+        {%- block rootrellink %}
+        <li class="nav-item nav-item-0"><a href="{{ pathto(master_doc) }}">{{ "Documentation" }}</a>{{ reldelim1 }}</li>
+        {%- endblock %}
+        {% if master_doc != pagename %}
+          {%- for parent in parents %}
+            <li class="nav-item nav-item-{{ loop.index }}"><a href="{{ parent.link|e }}" {% if loop.last %}{{ accesskey("U") }}{% endif %}>{{ parent.title }}</a>{{ reldelim1 }}</li>
+          {% endfor %}
+        {% endif %}
+        {% if title != "Mantid" %}
+          {% block relbaritems %}
+            <li class="nav-item nav-item-this"><a href="{{ link|e }}">{{ title }}</a></li>
+          {% endblock %}
+        {% endif %}
+      </ul>
+    </div>
+{%- endmacro %}
+
   <div id="navbar" class="{{ theme_navbar_class }} navbar-default {% if theme_navbar_fixed_top == 'true' -%} navbar-fixed-top{%- endif -%}">
     <div class="container">
       <div class="navbar-header">
@@ -55,4 +76,5 @@
           {%- endif -%}
         </div>
     </div>
+    <p> {%- block relbar %}{{ relbar() }}{% endblock %} </p>
   </div>

--- a/docs/source/conf-qthelp.py
+++ b/docs/source/conf-qthelp.py
@@ -53,7 +53,7 @@ qthelp_theme_options = {
     # Remove the local TOC from the nav bar
     'navbar_pagenav': False,
     # Hide the next/previous in the nav bar.
-    'navbar_sidebarrel': False,
+    'navbar_sidebarrel': True,
     # Use the latest version.
     'bootstrap_version': "3",
     # Ensure the nav bar always stays on top of page.


### PR DESCRIPTION
**Description of work.**

**To test:**

- Build the docs-html target
- check that the breadcrumb (just below the top navbar) can help you navigate the docs More quickly. The root (master_doc) page is labelled as Documentation (is there a better name???). The current page is in the breadcrumb, with a clickable link. 
- Any comments on its formatting?? Ive added it to the nav bar at the top but this is a design choice that I could easily change!
- Ive not tested what this looks like in the built in qthelp docs, but we should check it works there too!

*This does not require release notes* because **documentation update**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
