### PR TITLE
Sync muon frequency plots

### DIFF
--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/FrequencyDomainAnalysis/plot_widget/dual_plot_maxent_pane/dual_plot_maxent_pane_presenter.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/FrequencyDomainAnalysis/plot_widget/dual_plot_maxent_pane/dual_plot_maxent_pane_presenter.py
@@ -108,4 +108,5 @@ class DualPlotMaxentPanePresenter(BasePanePresenter):
         else:
             self._view.set_plot_type(FREQ_X_LABEL)
         self._figure_presenter.set_plot_range(self.context.frequency_context.range())
-        self.handle_maxent_data_updated(self.context._frequency_context.switch_units_in_name(self._maxent_ws_name))
+        new_ws_name = self.context._frequency_context.switch_units_in_name(self._maxent_ws_name)
+        self.handle_maxent_data_updated(new_ws_name)

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/FrequencyDomainAnalysis/plot_widget/dual_plot_maxent_pane/dual_plot_maxent_pane_presenter.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/FrequencyDomainAnalysis/plot_widget/dual_plot_maxent_pane/dual_plot_maxent_pane_presenter.py
@@ -9,12 +9,16 @@ from mantidqt.utils.observer_pattern import GenericObserverWithArgPassing, Gener
 from mantidqtinterfaces.Muon.GUI.FrequencyDomainAnalysis.frequency_context import FREQ, FIELD, GAUSS, MHz
 
 
+FREQ_X_LABEL = f'Maxent ({MHz}) and Counts'
+FIELD_X_LABEL =  f'Maxent ({GAUSS}) and Counts'
+
+
 class DualPlotMaxentPanePresenter(BasePanePresenter):
 
     def __init__(self, view, model, context, figure_presenter):
         super().__init__(view, model, context, figure_presenter)
         # view set up
-        self._data_type = [f'Maxent ({MHz}) and Counts', f'Maxent ({GAUSS}) and Counts']
+        self._data_type = [FREQ_X_LABEL, FIELD_X_LABEL]
         self._sort_by = ["Maxent + Groups/detectors"]
         self.update_view()
         self._view.enable_plot_type_combo()
@@ -37,6 +41,7 @@ class DualPlotMaxentPanePresenter(BasePanePresenter):
             self.handle_reconstructed_data_updated)
         self.instrument_observer = GenericObserver(self.clear)
         self.update_freq_units = GenericObservable()
+        self.update_x_label_observer = GenericObserver(self._update_pane)
 
     def change_time_plot(self, method):
         self._model.set_if_groups(method=="Groups")
@@ -96,3 +101,11 @@ class DualPlotMaxentPanePresenter(BasePanePresenter):
         # update plot -> will update range too
         self.handle_maxent_data_updated(self.context._frequency_context.switch_units_in_name(self._maxent_ws_name))
         self.update_freq_units.notify_subscribers()
+
+    def _update_pane(self):
+        if self.context.frequency_context.unit() == GAUSS:
+            self._view.set_plot_type(FIELD_X_LABEL)
+        else:
+            self._view.set_plot_type(FREQ_X_LABEL)
+        self._figure_presenter.set_plot_range(self.context.frequency_context.range())
+        self.handle_maxent_data_updated(self.context._frequency_context.switch_units_in_name(self._maxent_ws_name))

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/FrequencyDomainAnalysis/plot_widget/frequency_analysis_plot_widget.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/FrequencyDomainAnalysis/plot_widget/frequency_analysis_plot_widget.py
@@ -98,6 +98,7 @@ class FrequencyAnalysisPlotWidget(MuonAnalysisPlotWidget):
                                                          self.plotting_canvas_widgets[name].presenter)
         self._panes.append(self.modes[MAXENT])
         self.maxent_mode.update_freq_units.add_subscriber(self.fit_mode.update_fit_pane_observer)
+        self.fit_mode.update_maxent_plot.add_subscriber(self.maxent_mode.update_x_label_observer)
 
     @property
     def maxent_index(self):

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/FrequencyDomainAnalysis/plot_widget/plot_freq_fit_pane_presenter.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/FrequencyDomainAnalysis/plot_widget/plot_freq_fit_pane_presenter.py
@@ -19,6 +19,7 @@ class PlotFreqFitPanePresenter(PlotFitPanePresenter):
         self._view.hide_plot_raw()
         self._view.hide_tiled_by()
         self.update_freq_units = GenericObservable()
+        self.update_maxent_plot = GenericObservable()
         self.update_fit_pane_observer = GenericObserver(self._update_fit_pane)
 
     def handle_data_type_changed(self):
@@ -26,10 +27,13 @@ class PlotFreqFitPanePresenter(PlotFitPanePresenter):
         Handles the data type being changed in the view by plotting the workspaces corresponding to the new data type
         """
         self.context.frequency_context.x_label = self._view.get_plot_type()
-        self.update_freq_units.notify_subscribers()
         self._figure_presenter.set_plot_range(self.context.frequency_context.range())
+        # need to add observable for switching units cannot reuse it as it causes a loop
+        self.update_maxent_plot.notify_subscribers()
+
         # need to send signal out to update stuff => dont undate here
         # the slot will update the plot when the fit list updates
+        self.update_freq_units.notify_subscribers()
 
     def handle_rebin_options_changed(self):
         # there is no way to rebin the data -> do nothing
@@ -40,4 +44,5 @@ class PlotFreqFitPanePresenter(PlotFitPanePresenter):
             self._view.set_plot_type(FIELD)
         else:
             self._view.set_plot_type(FREQ)
-        self.handle_data_type_changed()
+        self._figure_presenter.set_plot_range(self.context.frequency_context.range())
+        self.update_freq_units.notify_subscribers()

--- a/qt/python/mantidqtinterfaces/test/Muon/dual_plot_maxent_pane/dual_plot_maxent_pane_presenter_test.py
+++ b/qt/python/mantidqtinterfaces/test/Muon/dual_plot_maxent_pane/dual_plot_maxent_pane_presenter_test.py
@@ -8,7 +8,8 @@ from mantid import AnalysisDataService
 from mantidqtinterfaces.Muon.GUI.Common.plot_widget.plotting_canvas.plotting_canvas_presenter_interface import \
     PlottingCanvasPresenterInterface
 from mantidqtinterfaces.Muon.GUI.FrequencyDomainAnalysis.\
-    plot_widget.dual_plot_maxent_pane.dual_plot_maxent_pane_presenter import DualPlotMaxentPanePresenter
+    plot_widget.dual_plot_maxent_pane.dual_plot_maxent_pane_presenter import DualPlotMaxentPanePresenter, \
+    FREQ_X_LABEL, FIELD_X_LABEL
 from mantidqtinterfaces.Muon.GUI.FrequencyDomainAnalysis. \
     plot_widget.dual_plot_maxent_pane.dual_plot_maxent_pane_model import DualPlotMaxentPaneModel
 from mantidqtinterfaces.Muon.GUI.FrequencyDomainAnalysis. \
@@ -147,11 +148,11 @@ class DualPlotMaxentPanePresenterTest(unittest.TestCase):
         self.presenter.clear_subplots.assert_called_once_with()
 
     def test_get_plot_type_MHz(self):
-        self.view.get_plot_type.return_value = "Maxent (MHz) and counts"
+        self.view.get_plot_type.return_value = FREQ_X_LABEL
         self.assertEqual("Frequency", self.presenter.get_plot_type())
 
     def test_get_plot_type_Gauss(self):
-        self.view.get_plot_type.return_value = "Maxent (Gauss) and counts"
+        self.view.get_plot_type.return_value = FIELD_X_LABEL
         self.assertEqual("Field", self.presenter.get_plot_type())
 
     def test_handle_data_changed(self):
@@ -165,6 +166,34 @@ class DualPlotMaxentPanePresenterTest(unittest.TestCase):
         self.presenter.handle_data_type_changed()
         self.presenter.handle_maxent_data_updated.assert_called_once_with("unit test")
         self.presenter.update_freq_units.notify_subscribers.assert_called_once_with()
+
+    def test_update_pane_freq(self):
+        self.context.frequency_context.unit = mock.Mock(return_value="MHz")
+        self.context.frequency_context.range = mock.MagicMock(return_value=[1,3])
+        self.context._frequency_context.switch_units_in_name = mock.Mock(return_value="unit test")
+        self.presenter._maxent_ws_name = "maxent"
+        self.presenter.handle_maxent_data_updated = mock.Mock()
+
+        self.presenter._update_pane()
+
+        self.context._frequency_context.switch_units_in_name.assert_called_once_with("maxent")
+        self.figure_presenter.set_plot_range.assert_called_once_with([1, 3])
+        self.view.set_plot_type.assert_called_once_with(FREQ_X_LABEL)
+        self.presenter.handle_maxent_data_updated.assert_called_once_with("unit test")
+
+    def test_update_pane_field(self):
+        self.context.frequency_context.unit = mock.Mock(return_value="Gauss")
+        self.context.frequency_context.range = mock.MagicMock(return_value=[1,3])
+        self.context._frequency_context.switch_units_in_name = mock.Mock(return_value="unit test")
+        self.presenter._maxent_ws_name = "maxent"
+        self.presenter.handle_maxent_data_updated = mock.Mock()
+
+        self.presenter._update_pane()
+
+        self.context._frequency_context.switch_units_in_name.assert_called_once_with("maxent")
+        self.figure_presenter.set_plot_range.assert_called_once_with([1, 3])
+        self.view.set_plot_type.assert_called_once_with(FIELD_X_LABEL)
+        self.presenter.handle_maxent_data_updated.assert_called_once_with("unit test")
 
 
 if __name__ == '__main__':

--- a/qt/python/mantidqtinterfaces/test/Muon/plot_fit_panes/plot_freq_fit_pane_presenter_test.py
+++ b/qt/python/mantidqtinterfaces/test/Muon/plot_fit_panes/plot_freq_fit_pane_presenter_test.py
@@ -39,27 +39,39 @@ class PlotFreqFitPanePresenterTest(unittest.TestCase):
         self.view.get_plot_type = mock.Mock(return_value="Frequency")
         self.presenter.update_freq_units = mock.Mock()
         self.presenter.update_freq_units.notify_subscribers = mock.Mock()
+        self.presenter.update_maxent_plot = mock.Mock()
+        self.presenter.update_maxent_plot.notify_subscribers = mock.Mock()
         self.context.frequency_context.range = mock.MagicMock(return_value=[1,3])
 
         self.presenter.handle_data_type_changed()
         self.presenter.update_freq_units.notify_subscribers.assert_called_once_with()
+        self.presenter.update_maxent_plot.notify_subscribers.assert_called_once_with()
         self.figure_presenter.set_plot_range.assert_called_once_with([1, 3])
         self.assertEqual(self.context.frequency_context.x_label, "Frequency")
 
     def test_update_fit_pane_freq(self):
         self.context.frequency_context.unit = mock.Mock(return_value="MHz")
-        self.presenter.handle_data_type_changed = mock.Mock()
+        self.context.frequency_context.range = mock.MagicMock(return_value=[1,3])
+        self.presenter.update_freq_units = mock.Mock()
+        self.presenter.update_freq_units.notify_subscribers = mock.Mock()
+
         self.presenter._update_fit_pane()
 
-        self.presenter.handle_data_type_changed.assert_called_once_with()
+        self.figure_presenter.set_plot_range.assert_called_once_with([1, 3])
+        self.presenter.update_freq_units.notify_subscribers.assert_called_once_with()
+
         self.view.set_plot_type.assert_called_once_with("Frequency")
 
     def test_update_fit_pane_field(self):
         self.context.frequency_context.unit = mock.Mock(return_value="Gauss")
-        self.presenter.handle_data_type_changed = mock.Mock()
+        self.context.frequency_context.range = mock.MagicMock(return_value=[1,3])
+        self.presenter.update_freq_units = mock.Mock()
+        self.presenter.update_freq_units.notify_subscribers = mock.Mock()
+
         self.presenter._update_fit_pane()
 
-        self.presenter.handle_data_type_changed.assert_called_once_with()
+        self.figure_presenter.set_plot_range.assert_called_once_with([1, 3])
+        self.presenter.update_freq_units.notify_subscribers.assert_called_once_with()
         self.view.set_plot_type.assert_called_once_with("Field")
 
 

--- a/qt/python/mantidqtinterfaces/test/Muon/plot_widget/frequency_analysis_plot_widget_test.py
+++ b/qt/python/mantidqtinterfaces/test/Muon/plot_widget/frequency_analysis_plot_widget_test.py
@@ -119,9 +119,7 @@ class FrequencyAnalysisPlotWidgetTest(unittest.TestCase):
 
         self.context.update_plots_notifier.add_subscriber = mock.Mock()
         self.context.deleted_plots_notifier.add_subscriber = mock.Mock()
-
         self.widget.insert_plot_panes()
-
         self.context.update_plots_notifier.add_subscriber.assert_any_call("data 1")
         self.context.update_plots_notifier.add_subscriber.assert_any_call("fit 2")
         self.context.update_plots_notifier.add_subscriber.assert_any_call("maxent 3")


### PR DESCRIPTION
**Description of work.**

In the frequency domain analysis (muon) GUI it is possible to select the units of the transforms (field or frequency). If the user changed the units on the maxent dual pane, then the frequency pane would automatically update to keep the units in sync. However, they could get out of sync as there was no feedback from the frequency pane to the maxent pane. This PR fixes that.

**To test:**

Open frequency domain analysis
Load some muon data (e.g. MUSR 62260 - the results  are rubbish for this data but thats ok)
Go to the transform tab
At the top of the tab, change from FFT to Maxent
Tick the "output reconstructed data" option in the top table
Press calculate maxent - this will take a while

A plot will appear with units of frequency (data will go from about 0 to 30 MHz)
Just above the plot change the unit from frequency to field 
The plot will update (new x range will be 0 to 1000 Gauss)
Change it back to frequency 

Towards the top of of the plotting window, change it from "Frequency data" to "maxent dual plot"
The top left plot should have an x label of frequency, a range of 0 to 30, but the data will end at about 15
Change the label as before (the names of the labels are slightly different) 
The top left plot should have an x label of field, a range of 0 to 1000

Towards the top of of the plotting window, change it from  "maxent dual plot" to "Frequency data"
The x label should be field and the range 0 to 15
Just above the plot change the unit from field to frequency
This all worked before, the next bit fixes the issue 

Towards the top of of the plotting window, change it from "Frequency data" to "maxent dual plot"
The top left plot should have an x label of field, a range of 0 to 1000. Previously this plot was not updating the label or the range


Fixes #33333. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

Not in release notes as it fixes a bug that we introduced this release.
---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
