### PR TITLE
Stop sliceviewer rebinning original MDEvent workspace if MDhisto workspace altered

### DIFF
--- a/docs/source/release/v6.3.0/33362_mantidworkbench.rst
+++ b/docs/source/release/v6.3.0/33362_mantidworkbench.rst
@@ -1,0 +1,6 @@
+Sliceviewer
+###########
+
+Bugfixes
+--------
+- Sliceviewer will no longer dynamically rebin when viewing an MDHisto workspace that has been modified by a binary operation (e.g. MinusMD).

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/model.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/model.py
@@ -121,13 +121,23 @@ class SliceViewerModel:
 
         return False
 
+    def can_rebin_original_workspace(self):
+        if self.get_ws_type() == WS_TYPE.MDH and self._get_ws().hasOriginalWorkspace(0):
+            has_same_dims = self._get_ws().getOriginalWorkspace(0).getNumDims() == self._get_ws().getNumDims()
+            # check if mdhisto altered (e.g. scaled) since original ws BinMD - then not valid to rebin original
+            run = self._get_ws().getExperimentInfo(0).run()
+            mdhisto_has_been_altered = False if not run.hasProperty("mdhisto_was_modified") else bool(
+                int(run.get("mdhisto_was_modified").value))
+            return has_same_dims and not mdhisto_has_been_altered
+        else:
+            return False
+
     def can_support_dynamic_rebinning(self) -> bool:
         """
         Check if the given workspace can multiple BinMD calls.
         """
         ws_type = self.get_ws_type()
-        return ws_type == WS_TYPE.MDE or (ws_type == WS_TYPE.MDH and self._get_ws().hasOriginalWorkspace(
-            0) and self._get_ws().getOriginalWorkspace(0).getNumDims() == self._get_ws().getNumDims())
+        return ws_type == WS_TYPE.MDE or (ws_type == WS_TYPE.MDH and self.can_rebin_original_workspace())
 
     def set_ws_name(self, new_name):
         self._ws_name = new_name

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/model.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/model.py
@@ -122,12 +122,13 @@ class SliceViewerModel:
         return False
 
     def can_rebin_original_workspace(self):
+        ws = self._get_ws()
         if self.get_ws_type() == WS_TYPE.MDH and self._get_ws().hasOriginalWorkspace(0):
-            has_same_dims = self._get_ws().getOriginalWorkspace(0).getNumDims() == self._get_ws().getNumDims()
-            # check if mdhisto altered (e.g. scaled) since original ws BinMD - then not valid to rebin original
-            run = self._get_ws().getExperimentInfo(0).run()
-            mdhisto_has_been_altered = False if not run.hasProperty("mdhisto_was_modified") else bool(
-                int(run.get("mdhisto_was_modified").value))
+            has_same_dims = ws.getOriginalWorkspace(0).getNumDims() == ws.getNumDims()
+            # check if mdhisto altered since original ws BinMD - then not valid to rebin original
+            mdhisto_has_been_altered = False
+            if ws.getNumExperimentInfo() > 0 and ws.getExperimentInfo(0).run().hasProperty("mdhisto_was_modified"):
+                mdhisto_has_been_altered = bool(int(ws.getExperimentInfo(0).run().get("mdhisto_was_modified").value))
             return has_same_dims and not mdhisto_has_been_altered
         else:
             return False


### PR DESCRIPTION
**Description of work.**

Stop sliceviewer rebinning original MDEvent workspace if MDhisto workspace altered - in this instance it is no longer valid to dynamically rebin using the original workspace - for example you subtract a background from an MDHisto workspace, zoom in and zoom out to get back to the same place and they background will no longer be subtracted from the slice shown.

After the release it might be worth considering whether to remove the original workspace at the point the `ws_histo_modified` is altered.
https://github.com/mantidproject/mantid/blob/8615240d7f70485fead62824beab95c9a050572e/Framework/MDAlgorithms/src/BinaryOperationMD.cpp#L178

**To test:**

(1) Create an MDHisto workspace with same num dimensions as the original MDEvent
```
ws = CreateMDWorkspace(Dimensions='3', Extents='-3,3,-3,3,-3,3',
                       Names='H,K,L', Units='r.l.u.,r.l.u.,r.l.u.',
                       Frames='HKL,HKL,HKL',
                       SplitInto='2', SplitThreshold='10')
ws_histo = BinMD(InputWorkspace='ws', AxisAligned=False, 
    BasisVector0='H,r.l.u.,1.0,0.0,0.0', 
    BasisVector1='K,r.l.u.,0.0,1.0,0.0', 
    BasisVector2='L,r.l.u.,0.0,0.0,1.0', 
    OutputExtents='-3,3,-3,3,-3,3', OutputBins='30,30,30', 
    NormalizeBasisVectors=False, OutputWorkspace='ws_histo')
```

(2) Open `ws_histo` in sliceviewer
It should look like this - i.e. it should be dynamically rebinnable with box for integration width and nbins etc.
![image](https://user-images.githubusercontent.com/55979119/150536333-14a8a99e-1093-49ab-ad81-705328871505.png)

(3) Scale `ws_histo` by a constant
`ws_histo *= 2`
This should close sliceviewer with this message
`Closing Sliceviewer as the underlying workspace was changed: The property supports_dynamic_rebinning is different on the new workspace.`

(3) Open `ws_histo` in the sliceviewer again - it should now look like this - i.e. it should not be dynamically rebinnable
![image](https://user-images.githubusercontent.com/55979119/150536368-683568fa-7280-4ef5-8a46-b4be19abeaae.png)

(4) Zoom in - it should not cause an errors

(5) Can also try with real data following instructions in original issue - note both `ws2 `and `ws3` should not be dynamically rebinnable

Fixes #33104 
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
