### PR TITLE
muon instrument changed warning

### DIFF
--- a/docs/source/release/v6.3.0/33365_muon.rst
+++ b/docs/source/release/v6.3.0/33365_muon.rst
@@ -1,0 +1,7 @@
+Muon Analysis and Frequency Domain Analysis
+-------------------------------------------
+
+Improvements
+############
+
+- When using browse to load data from a different instrument, a warning is now shown saying that the data has not been loaded.

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/load_file_widget/presenter.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/load_file_widget/presenter.py
@@ -150,6 +150,10 @@ class BrowseFileWidgetPresenter(object):
             run_list = [self._model.get_data(filename=filename)['run'] for filename in file_list]
 
         self.set_file_edit(file_list)
+        if file_list==[]:
+            self._view.warning_popup("This data is for a different instrument and has not been loaded."
+                                     "The instrument selection on the home tab has been updated."
+                                     "Please reload your data.")
         self._model.current_runs = run_list
 
         self._view.notify_loading_finished()

--- a/qt/python/mantidqtinterfaces/test/Muon/load_file_widget/loadfile_presenter_single_file_test.py
+++ b/qt/python/mantidqtinterfaces/test/Muon/load_file_widget/loadfile_presenter_single_file_test.py
@@ -244,6 +244,40 @@ class LoadFileWidgetPresenterTest(unittest.TestCase):
 
         self.assertEqual(self.view.reset_edit_to_cached_value.call_count, 1)
 
+    def test_on_loading_finished(self):
+        self.model.get_instrument_from_latest_run = mock.Mock(return_value="MUSR")
+        self.presenter._multiple_files = False
+        self.presenter.filenames = ["unit test"]
+        self.model._loaded_data_store.get_data = mock.Mock(return_value= True)
+        self.model.get_data = mock.Mock(return_value={'run':1})
+        self.presenter.enable_loading = mock.Mock()
+        self.presenter.set_file_edit = mock.Mock()
+        self.view.notify_loading_finished = mock.Mock()
+
+        self.presenter.on_loading_finished()
+
+        self.presenter.enable_loading.assert_called_once_with()
+        self.presenter.set_file_edit.assert_called_once_with(["unit test"])
+        self.view.notify_loading_finished.assert_called_once_with()
+        self.view.warning_popup.assert_not_called()
+
+    def test_on_loading_finished_fail(self):
+        self.model.get_instrument_from_latest_run = mock.Mock(return_value="MUSR")
+        self.presenter._multiple_files = False
+        self.presenter.filenames = ["unit test"]
+        self.model._loaded_data_store.get_data = mock.Mock(return_value= False)
+        self.model.get_data = mock.Mock(return_value={})
+        self.presenter.enable_loading = mock.Mock()
+        self.presenter.set_file_edit = mock.Mock()
+        self.view.notify_loading_finished = mock.Mock()
+
+        self.presenter.on_loading_finished()
+
+        self.presenter.enable_loading.assert_called_once_with()
+        self.presenter.set_file_edit.assert_called_once_with([])
+        self.view.notify_loading_finished.assert_called_once_with()
+        self.view.warning_popup.assert_called_once()
+
 
 if __name__ == '__main__':
     unittest.main(buffer=False, verbosity=2)


### PR DESCRIPTION
In the muon GUI if you set the instrument (e.g. EMU), then use the browse button to load data from a different instrument (e.g. HIFI) then the data does not load into the interface.

This is caused by a check to see if the instrument has changed, which it has. It then updates the instrument selection. When the instrument selection changes the GUI is cleared, removing the data the user just tried to load. This behaviour is a consequence of ensuring that the run from the new instrument is loaded correctly (e.g. the correct number of detectors).

This just adds a simple warning that the data has not been loaded.

**To test:**
Get some muon data on your local machine from 2 different instruments
Open muon analysis
Set the instrument to be different to your data
Use the browse button to load the data (from a different instrument)
A warning will pop up
Use browse to reload the data 
The data will load successfully 

Use the browse button to load data from the other instrument you downloaded
A warning will appear
Use browse to reload the data 
The data will load successfully 



Fixes #33365. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->

In release notes

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
