### PR TITLE
Fix LoadNXSPE incorrect detector size

### DIFF
--- a/Framework/DataHandling/src/LoadNXSPE.cpp
+++ b/Framework/DataHandling/src/LoadNXSPE.cpp
@@ -273,7 +273,7 @@ void LoadNXSPE::exec() {
   instrument->add(sample);
   instrument->markAsSamplePos(sample);
 
-  const auto shape = Geometry::ShapeFactory().createSphere(V3D(0, 0, 0), 0.01);
+  constexpr double deg2rad = M_PI / 180.0;
 
   for (std::size_t i = 0; i < numSpectra; ++i) {
     double r = 1.0;
@@ -283,6 +283,9 @@ void LoadNXSPE::exec() {
 
     Kernel::V3D pos;
     pos.spherical(r, polar.at(i), azimuthal.at(i));
+    // Define the size of the detector using the minimum of the polar or azimuthal width
+    double rr = r * sin(std::min(polar_width.at(i), azimuthal_width.at(i)) * deg2rad / 2);
+    const auto shape = Geometry::ShapeFactory().createSphere(V3D(0, 0, 0), rr);
 
     Geometry::Detector *det = new Geometry::Detector("pixel", static_cast<int>(i + 1), sample);
     det->setPos(pos);

--- a/Framework/DataHandling/src/LoadNXSPE.cpp
+++ b/Framework/DataHandling/src/LoadNXSPE.cpp
@@ -284,8 +284,8 @@ void LoadNXSPE::exec() {
     Kernel::V3D pos;
     pos.spherical(r, polar.at(i), azimuthal.at(i));
     // Define the size of the detector using the minimum of the polar or azimuthal width
-    double rr = r * sin(std::min(polar_width.at(i), azimuthal_width.at(i)) * deg2rad / 2);
-    const auto shape = Geometry::ShapeFactory().createSphere(V3D(0, 0, 0), rr);
+    double rr = r * sin(std::min(abs(polar_width.at(i)), abs(azimuthal_width.at(i))) * deg2rad / 2);
+    const auto shape = Geometry::ShapeFactory().createSphere(V3D(0, 0, 0), std::max(rr, 0.01));
 
     Geometry::Detector *det = new Geometry::Detector("pixel", static_cast<int>(i + 1), sample);
     det->setPos(pos);

--- a/docs/source/release/v6.3.0/33373_direct_geometry.rst
+++ b/docs/source/release/v6.3.0/33373_direct_geometry.rst
@@ -1,0 +1,3 @@
+Bugfixes
+########
+- :ref:`LoadNXSPE <algm-LoadNXSPE>` now creates workspaces with the correct detector sizes, which was previously causing aliasing issues in `SofQWNormalisePolygon <algm-SofQWNormalisePolygon` for small q-bin sizes.

--- a/docs/source/release/v6.3.0/direct_geometry.rst
+++ b/docs/source/release/v6.3.0/direct_geometry.rst
@@ -18,7 +18,6 @@ Improvements
 Bugfixes
 ########
 - Updated instrument created by :ref:`LoadNXSPE <algm-LoadNXSPE>` is viewable in instrument 3D view.
-- :ref:`LoadNXSPE <algm-LoadNXSPE>` now creates workspaces with the correct detector sizes, which was previously causing aliasing issues in `SofQWNormalisePolygon <algm-SofQWNormalisePolygon` for small q-bin sizes.
 
 Interfaces
 ----------

--- a/docs/source/release/v6.3.0/direct_geometry.rst
+++ b/docs/source/release/v6.3.0/direct_geometry.rst
@@ -18,6 +18,7 @@ Improvements
 Bugfixes
 ########
 - Updated instrument created by :ref:`LoadNXSPE <algm-LoadNXSPE>` is viewable in instrument 3D view.
+- :ref:`LoadNXSPE <algm-LoadNXSPE>` now creates workspaces with the correct detector sizes, which was previously causing aliasing issues in `SofQWNormalisePolygon <algm-SofQWNormalisePolygon` for small q-bin sizes.
 
 Interfaces
 ----------


### PR DESCRIPTION
**Description of work.**

The `.nxspe` files define the detector positions using `polar` and `azimuth` angles in a spherical coordinate system, and the detector extents using a `polar_width` and `azimuth_width`. Whilst the `*_width` quantities are read in by the `LoadNXSPE` algorithm they are *not* used to generate the detectors in the generated workspace. Instead, the detectors are set uniformly to be spheres of radius 1 cm.

As described in issue #33370 this leads to problems when using the `SofQWNormalisedPolygon` on these workspaces because the 1 cm radius sphere is *smaller* than the true detector size and causes aliasing when rebinned into Q-space. 

This PR still keeps the detectors as spheres but sets their radius to be equal to the chord subtending the smaller of either the `polar_width` or `azimuthal_width` angles. In the particular datafiles which are the subject of issue #33370 this is ok because the data is actually the product of a `GroupDetectors` over rings of constant `2theta` so there is really only a single independent angle (the `polar` angle - the `azimuthal` angle is irrelevant for these data). For the other commonly used `.nxspe` data (a "1-to-1" mapping) the detectors are approximately square so the `polar_width` and `azimuthal_width` is approximately the same, so this fudge of using spherical detectors should also work. (In future it might be worthwhile to implement a "bannana" shaped detectors, but probably a better long term solution is to deprecate the `.nxspe` format in favour of the processed/reduced NeXus files).

**Report to:** R. Stewart / ISIS

**To test:**

Run the script in the issue #33370 and check you get this result:

![mantid_sqw_nxspe_alias_bug_fixed](https://user-images.githubusercontent.com/14106963/150813270-b47581c1-700d-4feb-b228-4ebca5a8b7db.png)

Additionally, you can also set the logging level to `Debug` and look at the start of the output of `SofQWNormalisePolygons` (`SofQW3`). This prints the calculated 2theta extents of the detectors. The values for the `.nxs` and `.nxspe` workspaces should now be similar (2theta widths of approximately 1 degree); previously the `.nxs` files had 2theta widths of ~1 deg, whilst the `.nxspe` files had widths of ~0.3deg

Fixes #33370. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
