### PR TITLE
Allow ISISCalibration to set defaults for range from workspaces if date is outside of instrument range.

### DIFF
--- a/docs/source/release/v6.3.0/33267_indirect_geometry.rst
+++ b/docs/source/release/v6.3.0/33267_indirect_geometry.rst
@@ -1,0 +1,4 @@
+Bugfixes
+########
+
+- Fixed a bug that caused ISIS calibration would not set valid defaults for certain runs.

--- a/qt/scientific_interfaces/Indirect/ISISCalibration.cpp
+++ b/qt/scientific_interfaces/Indirect/ISISCalibration.cpp
@@ -505,15 +505,14 @@ void ISISCalibration::calSetDefaultResolution(const MatrixWorkspace_const_sptr &
 
       const auto energyRange = getXRangeFromWorkspace(ws);
       // Set default rebinning bounds
-      QPair<double, double> peakERange(-res * 10 + (energyRange.second + energyRange.first) / 2.0,
-                                       res * 10 + (energyRange.second + energyRange.first) / 2.0);
+      const auto energyRangeMid = (energyRange.second + energyRange.first) / 2.0;
+      QPair<double, double> peakERange(-res * 10 + energyRangeMid, res * 10 + energyRangeMid);
       auto resPeak = m_uiForm.ppResolution->getRangeSelector("ResPeak");
       setPlotPropertyRange(resPeak, m_properties["ResELow"], m_properties["ResEHigh"], energyRange);
       setRangeSelector(resPeak, m_properties["ResELow"], m_properties["ResEHigh"], peakERange);
 
       // Set default background bounds
-      QPair<double, double> backgroundERange(-res * 20 + (energyRange.second + energyRange.first) / 2.0,
-                                             -res * 15 + (energyRange.second + energyRange.first) / 2.0);
+      QPair<double, double> backgroundERange(-res * 20 + energyRangeMid, -res * 15 + energyRangeMid);
       auto resBackground = m_uiForm.ppResolution->getRangeSelector("ResBackground");
       setRangeSelector(resBackground, m_properties["ResStart"], m_properties["ResEnd"], backgroundERange);
     }


### PR DESCRIPTION
**Description of work.**

This PR changes how ISISCalibation chooses default values for peak and background ranges. Instead of using the instrument every time it compares the range from the instrument to the data in the workspace. This makes it better suited to certain runs where the instrument defaults can cause failures.

**Report to:** Sanghamitra Mukhopadhyay

**To test:**

1. open Indirect Data Reduction
2. go to ISIS Calibration
3. In Input runs load 55878-55879, the range markers should align somewhat closely to the peak and the background
4. check `Create RES File` the range markers on the RES plot should be within the data range
4. click run
5. change the loaded runs to 59057-59059, the range markers are not aligned to the peak as closely, but should be within the range
6. The range markers on the RES plot should be within the data range.

Fixes #33267

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
