### PR TITLE
Enable the refl gui preview tab

### DIFF
--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/QtBatchView.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/QtBatchView.cpp
@@ -48,10 +48,6 @@ void QtBatchView::initLayout() {
 
   m_preview = std::make_unique<QtPreviewView>(this);
   m_ui.batchTabs->addTab(m_preview.get(), "Reduction Preview");
-#ifdef NDEBUG
-  // Preview disabled in Release mode to prevent users "finding" it in the nightly
-  m_ui.batchTabs->removeTab(m_ui.batchTabs->indexOf(m_preview.get()));
-#endif // NDEBUG
 
   m_save = createSaveTab();
   m_ui.batchTabs->addTab(m_save.get(), "Save ASCII");


### PR DESCRIPTION
**Experimental - not to be merged** 

This PR enables the Preview tab on the reflectometry interface so that it can be tested by scientists. This is still experimental work and is not yet ready to be merged.

**To test:**

<!-- Instructions for testing. -->

Fixes #xxxx. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
