### PR TITLE
Set cppcheck version to 2.5 in conda developer environment files

### DIFF
--- a/mantid-developer-linux.yml
+++ b/mantid-developer-linux.yml
@@ -64,7 +64,7 @@ dependencies:
   - xorg-libxtst>=1.2.3
 
   # Development tooling
-  - cppcheck>=2.4.1
+  - cppcheck==2.5
   - gcovr>=4.2
   - pre-commit>=2.12.0
   - pip:

--- a/mantid-developer-osx.yml
+++ b/mantid-developer-osx.yml
@@ -45,7 +45,7 @@ dependencies:
   - toml>=0.10.2
   - zlib>=1.2.11
   # Needed only for development
-  - cppcheck>=2.4.1
+  - cppcheck==2.5
   - pre-commit>=2.12.0
   - pip:
       - matplotlib==3.1.3 # Pip used for package compatibility (Conda seems to have a broken dependancy list), otherwise a high version number is needed (for use on conda) which doesn't work right now for workbench. Pinned at 3.1.3 as is highest/currently used and compatible with Workbench.

--- a/mantid-developer-win.yml
+++ b/mantid-developer-win.yml
@@ -44,7 +44,7 @@ dependencies:
   - toml>=0.10.2
   - zlib>=1.2.11
   # Needed only for development
-  - cppcheck>=2.4.1
+  - cppcheck==2.5
   - pre-commit>=2.12.0
   - pip:
       - matplotlib==3.1.3 # Pip used for package compatibility (Conda seems to have a broken dependancy list), otherwise a high version number is needed (for use on conda) which doesn't work right now for workbench. Pinned at 3.1.3 as is highest/currently used and compatible with Workbench.


### PR DESCRIPTION
**Description of work.**
Set cppcheck version in conda environment files to v2.5 so that it's consistent with the build servers.

**To test:**
Create a new environment using the mantid-developer-<OS>.yml file and verify that cppcheck is at version 2.5, e.g on linux:
1. `conda env create -f mantid-developer-linux.yml`
2. `conda activate mantid-developer`
3. `cppcheck --version`

*There is no associated issue.*

*This does not require release notes* because it is not user facing.

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
