### PR TITLE
Fix bug in the Jenkins prototype nightly pipeline

### DIFF
--- a/buildconfig/Jenkins/Conda/nightly_build_and_deploy.jenkinsfile
+++ b/buildconfig/Jenkins/Conda/nightly_build_and_deploy.jenkinsfile
@@ -19,7 +19,7 @@ def build_and_test_win(){
 }
 
 def update_conda_recipes(){
-    sh "$WORKSPACE/buildconfig/Jenkins/Conda/update-conda-recipes.sh $GITHUB_ACCESS_TOKEN mantid-builder"
+    sh "$WORKSPACE/buildconfig/Jenkins/Conda/update-conda-recipes.sh $GITHUB_ACCESS_TOKEN $GITHUB_USER_NAME"
 }
 
 def conda_build_UNIX(){

--- a/buildconfig/Jenkins/Conda/nightly_build_and_deploy.jenkinsfile
+++ b/buildconfig/Jenkins/Conda/nightly_build_and_deploy.jenkinsfile
@@ -19,7 +19,7 @@ def build_and_test_win(){
 }
 
 def update_conda_recipes(){
-    sh "$WORKSPACE/buildconfig/Jenkins/Conda/update-conda-recipes.sh $GITHUB_ACCESS_TOKEN"
+    sh "$WORKSPACE/buildconfig/Jenkins/Conda/update-conda-recipes.sh $GITHUB_ACCESS_TOKEN mantid-builder"
 }
 
 def conda_build_UNIX(){


### PR DESCRIPTION
**Description of work.**
After the last PR I forgot to add a username to the jenkins pipeline script after adding it as an argument to the new shell scripts conda_update_recipes, which causes the nightly pipeline to fall over.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**
Code-review

<!-- Instructions for testing. -->

*There is no associated issue.*

*This does not require release notes* because **Developer Facing**


<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
