### PR TITLE
Fixed crash in Absorption Corrections Tab in Indirect

### DIFF
--- a/qt/scientific_interfaces/Indirect/ApplyAbsorptionCorrections.cpp
+++ b/qt/scientific_interfaces/Indirect/ApplyAbsorptionCorrections.cpp
@@ -180,13 +180,13 @@ void ApplyAbsorptionCorrections::run() {
   setRunIsRunning(true);
 
   // Create / Initialize algorithm
-  auto absCorProps = std::unique_ptr<MantidQt::API::AlgorithmRuntimeProps>();
+  auto absCorProps = std::make_unique<MantidQt::API::AlgorithmRuntimeProps>();
   IAlgorithm_sptr applyCorrAlg = AlgorithmManager::Instance().create("ApplyPaalmanPingsCorrection");
   applyCorrAlg->initialize();
 
   // get Sample Workspace
   auto const sampleWs = getADSWorkspace(m_sampleWorkspaceName);
-  absCorProps->setPropertyValue("SampleWorkspace", m_sampleWorkspaceName);
+  absCorProps->setProperty("SampleWorkspace", sampleWs);
 
   const bool useCan = m_uiForm.ckUseCan->isChecked();
   // Get Can and Clone


### PR DESCRIPTION
**Description of work.**
This PR fixes the specific issue of Mantid closing without error in Windows or a seg fault occuring in Ubuntu when using the Apply Absorptions Corrections Tab. This fix does not include checking histograms as dicsussed in #33384. This will be dealt with in a separate PR as this isn't the cause of the specific crash that is occurring.

**Report to:** Spencer Howells


**To test:**

1. Open Indirect -> Corrections
2. Open the Apply Absorptions Corrections Tab
3. Load a sample file (ask for file if you don't have anything suitable)
4. Load a corrections file(ask for file if you don't have anything suitable)
5. Press Run. It should complete successfully

Needs testing on both Windows and Ubuntu

Partially Fixes #33384


*This does not require release notes* because **it is a bug introduced by work undertaken for this release**


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
