### PR TITLE
Fix autoscale color axis for nonortho view of MD(Event)Workspaces in sliceviewer

### DIFF
--- a/qt/python/mantidqt/mantidqt/widgets/colorbar/colorbar.py
+++ b/qt/python/mantidqt/mantidqt/widgets/colorbar/colorbar.py
@@ -295,7 +295,12 @@ class ColorbarWidget(QWidget):
     def _autoscale_clim(self):
         """Update stored colorbar limits
         The new limits are found from the colobar data """
-        data = self.colorbar.mappable.get_array_clipped_to_bounds()
+        if hasattr(self.colorbar.mappable, "get_array_clipped_to_bounds"):
+            data = self.colorbar.mappable.get_array_clipped_to_bounds()
+        else:
+            # in nonorthog view get passed a QuadMesh that doesn't have the above method
+            # however the data from get_array for MDEvent ws is already clipped (not for MDHisto)
+            data = self.colorbar.mappable.get_array()
         norm = NORM_OPTS[self.norm.currentIndex()]
         try:
             try:


### PR DESCRIPTION
**Description of work.**
This fixes color axis autoscaling for MDEvent workspaces in nonortho mode - but for MDHisto the data array is not clipped to the axes limits (as it is not rebinned to axes limits).

The reason the nonorthogonal view behaves differently is that it is plotted using `pcolormesh` which returns a `QuadMesh` which doesn't have the `get_array_clipped_to_bounds` method that was introduced in #33336 for `ModestImage` (and `SamplingImage` for Workspace2D) which is produced with an adapted version of` imshow`.

To fix the issue for MDHisto we could add a pcolormesh function in `MantidAxes` that returns a `MantidQuadMesh`-like class with an additional `get_array_clipped_to_bounds` method?
Or make nonortho plots with `imshow` producing a `ModestImage` - it does seem to support transforms in the code.

**To test:**

(1) Create MDEventWorkspace
```
md_3D = CreateMDWorkspace(Dimensions=3, Extents=[-0.5,0.5,-1,1,-2,2], 
    Names="H,K,L", Frames='HKL,HKL,HKL',Units='r.l.u.,r.l.u.,r.l.u.')
expt_info = CreateSampleWorkspace()
md_3D.addExperimentInfo(expt_info)
SetUB(Workspace=md_3D, c=2, gamma=120)
FakeMDEventData(md_3D, EllipsoidParams='1e+04,0,0,0,1,0,0,0,1,0,0,0,1,0.02,0.06,1,1', RandomSeed='3873875')
```
(2) Open sliceviewer
(3) Turn on non-ortho view - should be no error
(4) Zoom and pan - autoscale should work
(5) Close sliceviewer and delete the `md_3D `workspace
(6) open `md_3D_svrebinned`  - an MDHistoWorkspace - in sliceviewer
(7) Zoom - no error but clim won't update

Fixes #33389

*This does not require release notes* because **it is covered by the release note of #33336 **


<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
