### PR TITLE
Remove Typo From Multithreading.h

### DIFF
--- a/Framework/Algorithms/inc/MantidAlgorithms/SpectrumAlgorithm.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/SpectrumAlgorithm.h
@@ -73,14 +73,14 @@ private:
 
     PARALLEL_FOR_IF(Kernel::threadSafe(workspace))
     for (int64_t i = 0; i < size; ++i) {
-      PARALLEL_START_INTERUPT_REGION
+      PARALLEL_START_INTERRUPT_REGION
       // Note the small but for now negligible overhead from the IndexSet access
       // in the case where it is not used.
       operation(std::get<S>(getters)(workspace, indexSet[i])...);
       progress.report(name());
-      PARALLEL_END_INTERUPT_REGION
+      PARALLEL_END_INTERRUPT_REGION
     }
-    PARALLEL_CHECK_INTERUPT_REGION
+    PARALLEL_CHECK_INTERRUPT_REGION
 
     ifEventWorkspaceClearMRU(workspace);
   }

--- a/Framework/Algorithms/src/AbsorptionCorrection.cpp
+++ b/Framework/Algorithms/src/AbsorptionCorrection.cpp
@@ -199,7 +199,7 @@ void AbsorptionCorrection::exec() {
   // Loop over the spectra
   PARALLEL_FOR_IF(Kernel::threadSafe(*m_inputWS, *correctionFactors))
   for (int64_t i = 0; i < int64_t(numHists); ++i) {
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
     // Copy over bins
     correctionFactors->setSharedX(i, m_inputWS->sharedX(i));
 
@@ -263,9 +263,9 @@ void AbsorptionCorrection::exec() {
 
     prog.report();
 
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   }
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
 
   g_log.information() << "Total number of elements in the integration was " << m_L1s.size() << '\n';
   setProperty("OutputWorkspace", correctionFactors);

--- a/Framework/Algorithms/src/AddAbsorptionWeightedPathLengths.cpp
+++ b/Framework/Algorithms/src/AddAbsorptionWeightedPathLengths.cpp
@@ -117,7 +117,7 @@ void AddAbsorptionWeightedPathLengths::exec() {
 
   PARALLEL_FOR_IF(Kernel::threadSafe(*inputWS))
   for (int i = 0; i < npeaks; ++i) {
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
     Peak &peak = inputWS->getPeak(i);
     auto peakWavelength = peak.getWavelength();
 
@@ -157,9 +157,9 @@ void AddAbsorptionWeightedPathLengths::exec() {
     peak.setAbsorptionWeightedPathLength(absWeightedPathLength * 100);                  // cm
 
     prog.report(reportMsg);
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   }
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
 }
 
 /**

--- a/Framework/Algorithms/src/AlignDetectors.cpp
+++ b/Framework/Algorithms/src/AlignDetectors.cpp
@@ -266,7 +266,7 @@ void AlignDetectors::align(const ConversionFactors &converter, Progress &progres
   auto eventW = std::dynamic_pointer_cast<EventWorkspace>(outputWS);
   PARALLEL_FOR_IF(Kernel::threadSafe(*outputWS))
   for (int64_t i = 0; i < m_numberOfSpectra; ++i) {
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
     try {
       // Get the input spectrum number at this workspace index
       auto &spec = outputWS->getSpectrum(size_t(i));
@@ -294,9 +294,9 @@ void AlignDetectors::align(const ConversionFactors &converter, Progress &progres
       }
     }
     progress.report();
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   }
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
   if (eventW) {
     if (eventW->getTofMin() < 0.) {
       std::stringstream msg;

--- a/Framework/Algorithms/src/ApplyTransmissionCorrection.cpp
+++ b/Framework/Algorithms/src/ApplyTransmissionCorrection.cpp
@@ -124,7 +124,7 @@ void ApplyTransmissionCorrection::exec() {
     // Loop through the spectra and apply correction
     PARALLEL_FOR_IF(Kernel::threadSafe(*inputWS, *corrWS))
     for (int i = 0; i < numHists; i++) {
-      PARALLEL_START_INTERUPT_REGION
+      PARALLEL_START_INTERRUPT_REGION
 
       if (!spectrumInfo.hasDetectors(i)) {
         g_log.warning() << "Workspace index " << i << " has no detector assigned to it - discarding'\n";
@@ -149,9 +149,9 @@ void ApplyTransmissionCorrection::exec() {
       }
 
       progress.report("Calculating transmission correction");
-      PARALLEL_END_INTERUPT_REGION
+      PARALLEL_END_INTERRUPT_REGION
     }
-    PARALLEL_CHECK_INTERUPT_REGION
+    PARALLEL_CHECK_INTERRUPT_REGION
 
     // apply the correction
     MatrixWorkspace_sptr outputWS = inputWS * corrWS;

--- a/Framework/Algorithms/src/Bin2DPowderDiffraction.cpp
+++ b/Framework/Algorithms/src/Bin2DPowderDiffraction.cpp
@@ -209,7 +209,7 @@ MatrixWorkspace_sptr Bin2DPowderDiffraction::createOutputWorkspace() {
 
   PARALLEL_FOR_IF(Kernel::threadSafe(*m_inputWS, *outputWS))
   for (int64_t snum = 0; snum < numSpectra; ++snum) {
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
     if (!spectrumInfo.isMasked(snum)) {
       double theta = 0.5 * spectrumInfo.twoTheta(snum);
       double sin_theta = sin(theta);
@@ -249,9 +249,9 @@ MatrixWorkspace_sptr Bin2DPowderDiffraction::createOutputWorkspace() {
       }
     }
     prog.report("Binning event data...");
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   }
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
   size_t idx = 0;
   for (const auto &yVec : newYValues) {
     outputWS->setCounts(idx, yVec);

--- a/Framework/Algorithms/src/BinaryOperation.cpp
+++ b/Framework/Algorithms/src/BinaryOperation.cpp
@@ -450,18 +450,18 @@ void BinaryOperation::doSingleValue() {
     // ---- The output is an EventWorkspace ------
     PARALLEL_FOR_IF(Kernel::threadSafe(*m_lhs, *m_rhs, *m_out))
     for (int64_t i = 0; i < numHists; ++i) {
-      PARALLEL_START_INTERUPT_REGION
+      PARALLEL_START_INTERRUPT_REGION
       m_out->setSharedX(i, m_lhs->sharedX(i));
       performEventBinaryOperation(m_eout->getSpectrum(i), rhsY, rhsE);
       m_progress->report(this->name());
-      PARALLEL_END_INTERUPT_REGION
+      PARALLEL_END_INTERRUPT_REGION
     }
-    PARALLEL_CHECK_INTERUPT_REGION
+    PARALLEL_CHECK_INTERRUPT_REGION
   } else {
     // ---- Histogram Output -----
     PARALLEL_FOR_IF(Kernel::threadSafe(*m_lhs, *m_rhs, *m_out))
     for (int64_t i = 0; i < numHists; ++i) {
-      PARALLEL_START_INTERUPT_REGION
+      PARALLEL_START_INTERRUPT_REGION
       m_out->setSharedX(i, m_lhs->sharedX(i));
       // Get reference to output vectors here to break any sharing outside the
       // function call below
@@ -471,9 +471,9 @@ void BinaryOperation::doSingleValue() {
       HistogramData::HistogramE &outE = m_out->mutableE(i);
       performBinaryOperation(m_lhs->histogram(i), rhsY, rhsE, outY, outE);
       m_progress->report(this->name());
-      PARALLEL_END_INTERUPT_REGION
+      PARALLEL_END_INTERRUPT_REGION
     }
-    PARALLEL_CHECK_INTERUPT_REGION
+    PARALLEL_CHECK_INTERRUPT_REGION
   }
 }
 
@@ -496,21 +496,21 @@ void BinaryOperation::doSingleColumn() {
     // ---- The output is an EventWorkspace ------
     PARALLEL_FOR_IF(Kernel::threadSafe(*m_lhs, *m_rhs, *m_out))
     for (int64_t i = 0; i < numHists; ++i) {
-      PARALLEL_START_INTERUPT_REGION
+      PARALLEL_START_INTERRUPT_REGION
       const double rhsY = m_rhs->y(i)[0];
       const double rhsE = m_rhs->e(i)[0];
       if (propagateSpectraMask(lhsSpectrumInfo, rhsSpectrumInfo, i, *m_out, outSpectrumInfo)) {
         performEventBinaryOperation(m_eout->getSpectrum(i), rhsY, rhsE);
       }
       m_progress->report(this->name());
-      PARALLEL_END_INTERUPT_REGION
+      PARALLEL_END_INTERRUPT_REGION
     }
-    PARALLEL_CHECK_INTERUPT_REGION
+    PARALLEL_CHECK_INTERRUPT_REGION
   } else {
     // ---- Histogram Output -----
     PARALLEL_FOR_IF(Kernel::threadSafe(*m_lhs, *m_rhs, *m_out))
     for (int64_t i = 0; i < numHists; ++i) {
-      PARALLEL_START_INTERUPT_REGION
+      PARALLEL_START_INTERRUPT_REGION
       const double rhsY = m_rhs->y(i)[0];
       const double rhsE = m_rhs->e(i)[0];
 
@@ -525,9 +525,9 @@ void BinaryOperation::doSingleColumn() {
         performBinaryOperation(m_lhs->histogram(i), rhsY, rhsE, outY, outE);
       }
       m_progress->report(this->name());
-      PARALLEL_END_INTERUPT_REGION
+      PARALLEL_END_INTERRUPT_REGION
     }
-    PARALLEL_CHECK_INTERUPT_REGION
+    PARALLEL_CHECK_INTERRUPT_REGION
   }
 }
 
@@ -554,13 +554,13 @@ void BinaryOperation::doSingleSpectrum() {
       const int64_t numHists = m_lhs->getNumberHistograms();
       PARALLEL_FOR_IF(Kernel::threadSafe(*m_lhs, *m_rhs, *m_out))
       for (int64_t i = 0; i < numHists; ++i) {
-        PARALLEL_START_INTERUPT_REGION
+        PARALLEL_START_INTERRUPT_REGION
         // Perform the operation on the event list on the output (== lhs)
         performEventBinaryOperation(m_eout->getSpectrum(i), rhs_spectrum);
         m_progress->report(this->name());
-        PARALLEL_END_INTERUPT_REGION
+        PARALLEL_END_INTERRUPT_REGION
       }
-      PARALLEL_CHECK_INTERUPT_REGION
+      PARALLEL_CHECK_INTERRUPT_REGION
     } else {
       // -------- The rhs is a histogram ---------
       // Pull m_out the m_rhs spectrum
@@ -574,13 +574,13 @@ void BinaryOperation::doSingleSpectrum() {
 
       PARALLEL_FOR_IF(Kernel::threadSafe(*m_lhs, *m_rhs, *m_out))
       for (int64_t i = 0; i < numHists; ++i) {
-        PARALLEL_START_INTERUPT_REGION
+        PARALLEL_START_INTERRUPT_REGION
         // Perform the operation on the event list on the output (== lhs)
         performEventBinaryOperation(m_eout->getSpectrum(i), rhsX, rhsY, rhsE);
         m_progress->report(this->name());
-        PARALLEL_END_INTERUPT_REGION
+        PARALLEL_END_INTERRUPT_REGION
       }
-      PARALLEL_CHECK_INTERUPT_REGION
+      PARALLEL_CHECK_INTERRUPT_REGION
     }
 
   } else {
@@ -597,7 +597,7 @@ void BinaryOperation::doSingleSpectrum() {
 
     PARALLEL_FOR_IF(Kernel::threadSafe(*m_lhs, *m_rhs, *m_out))
     for (int64_t i = 0; i < numHists; ++i) {
-      PARALLEL_START_INTERUPT_REGION
+      PARALLEL_START_INTERRUPT_REGION
       m_out->setSharedX(i, m_lhs->sharedX(i));
       // Get reference to output vectors here to break any sharing outside the
       // function call below
@@ -607,9 +607,9 @@ void BinaryOperation::doSingleSpectrum() {
       HistogramData::HistogramE &outE = m_out->mutableE(i);
       performBinaryOperation(m_lhs->histogram(i), rhs, outY, outE);
       m_progress->report(this->name());
-      PARALLEL_END_INTERUPT_REGION
+      PARALLEL_END_INTERRUPT_REGION
     }
-    PARALLEL_CHECK_INTERUPT_REGION
+    PARALLEL_CHECK_INTERRUPT_REGION
   }
 }
 
@@ -644,7 +644,7 @@ void BinaryOperation::do2D(bool mismatchedSpectra) {
       const int64_t numHists = m_lhs->getNumberHistograms();
       PARALLEL_FOR_IF(Kernel::threadSafe(*m_lhs, *m_rhs, *m_out))
       for (int64_t i = 0; i < numHists; ++i) {
-        PARALLEL_START_INTERUPT_REGION
+        PARALLEL_START_INTERRUPT_REGION
         m_progress->report(this->name());
 
         int64_t rhs_wi = i;
@@ -664,9 +664,9 @@ void BinaryOperation::do2D(bool mismatchedSpectra) {
         // Free up memory on the RHS if that is possible
         if (m_ClearRHSWorkspace)
           const_cast<EventList &>(m_erhs->getSpectrum(rhs_wi)).clear();
-        PARALLEL_END_INTERUPT_REGION
+        PARALLEL_END_INTERRUPT_REGION
       }
-      PARALLEL_CHECK_INTERUPT_REGION
+      PARALLEL_CHECK_INTERRUPT_REGION
     } else {
       // -------- The rhs is a histogram, or we want to use the histogram
       // representation of it ---------
@@ -676,7 +676,7 @@ void BinaryOperation::do2D(bool mismatchedSpectra) {
 
       PARALLEL_FOR_IF(Kernel::threadSafe(*m_lhs, *m_rhs, *m_out))
       for (int64_t i = 0; i < numHists; ++i) {
-        PARALLEL_START_INTERUPT_REGION
+        PARALLEL_START_INTERRUPT_REGION
         m_progress->report(this->name());
         int64_t rhs_wi = i;
         if (mismatchedSpectra && table) {
@@ -697,9 +697,9 @@ void BinaryOperation::do2D(bool mismatchedSpectra) {
         if (m_ClearRHSWorkspace)
           const_cast<EventList &>(m_erhs->getSpectrum(rhs_wi)).clear();
 
-        PARALLEL_END_INTERUPT_REGION
+        PARALLEL_END_INTERRUPT_REGION
       }
-      PARALLEL_CHECK_INTERUPT_REGION
+      PARALLEL_CHECK_INTERRUPT_REGION
     }
 
   } else {
@@ -712,7 +712,7 @@ void BinaryOperation::do2D(bool mismatchedSpectra) {
 
     PARALLEL_FOR_IF(Kernel::threadSafe(*m_lhs, *m_rhs, *m_out))
     for (int64_t i = 0; i < numHists; ++i) {
-      PARALLEL_START_INTERUPT_REGION
+      PARALLEL_START_INTERRUPT_REGION
       m_progress->report(this->name());
       m_out->setSharedX(i, m_lhs->sharedX(i));
       int64_t rhs_wi = i;
@@ -738,9 +738,9 @@ void BinaryOperation::do2D(bool mismatchedSpectra) {
       if (m_ClearRHSWorkspace)
         const_cast<EventList &>(m_erhs->getSpectrum(rhs_wi)).clear();
 
-      PARALLEL_END_INTERUPT_REGION
+      PARALLEL_END_INTERRUPT_REGION
     }
-    PARALLEL_CHECK_INTERUPT_REGION
+    PARALLEL_CHECK_INTERRUPT_REGION
   }
   // Make sure we don't use outdated MRU
   if (m_ClearRHSWorkspace)

--- a/Framework/Algorithms/src/CalculateCarpenterSampleCorrection.cpp
+++ b/Framework/Algorithms/src/CalculateCarpenterSampleCorrection.cpp
@@ -169,7 +169,7 @@ void CalculateCarpenterSampleCorrection::exec() {
   const auto &spectrumInfo = inputWksp->spectrumInfo();
   PARALLEL_FOR_IF(Kernel::threadSafe(*absWksp, *msWksp))
   for (int64_t index = 0; index < NUM_HIST; ++index) {
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
     if (!spectrumInfo.hasDetectors(index))
       throw std::runtime_error("Failed to find detector");
     if (spectrumInfo.isMasked(index))
@@ -193,9 +193,9 @@ void CalculateCarpenterSampleCorrection::exec() {
     }
 
     prog.report();
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   }
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
 
   absWksp->setDistribution(true);
   absWksp->setYUnit("");

--- a/Framework/Algorithms/src/CalculateCountRate.cpp
+++ b/Framework/Algorithms/src/CalculateCountRate.cpp
@@ -215,7 +215,7 @@ void CalculateCountRate::calcRateLog(DataObjects::EventWorkspace_sptr &InputWork
 #pragma omp for
     for (int64_t i = 0; i < nHist; ++i) {
       const auto loopThread = PARALLEL_THREAD_NUMBER;
-      PARALLEL_START_INTERUPT_REGION
+      PARALLEL_START_INTERRUPT_REGION
 
       // Get a const event list reference. eventInputWS->dataY() doesn't work.
       const DataObjects::EventList &el = InputWorkspace->getSpectrum(i);
@@ -226,9 +226,9 @@ void CalculateCountRate::calcRateLog(DataObjects::EventWorkspace_sptr &InputWork
 
       // Report progress
       prog.report(name());
-      PARALLEL_END_INTERUPT_REGION
+      PARALLEL_END_INTERRUPT_REGION
     }
-    PARALLEL_CHECK_INTERUPT_REGION
+    PARALLEL_CHECK_INTERRUPT_REGION
 // calculate final sums
 #pragma omp for
     for (int64_t j = 0; j < m_numLogSteps; j++) {

--- a/Framework/Algorithms/src/CalculateFlatBackground.cpp
+++ b/Framework/Algorithms/src/CalculateFlatBackground.cpp
@@ -167,7 +167,7 @@ void CalculateFlatBackground::exec() {
 
   PARALLEL_FOR_IF(Kernel::threadSafe(*inputWS, *outputWS))
   for (int64_t i = 0; i < static_cast<int64_t>(numHists); ++i) {
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
     // Extract a histogram from inputWS, work on it and, finally, put it to
     // outputWS.
     auto histogram = inputWS->histogram(i);
@@ -259,9 +259,9 @@ void CalculateFlatBackground::exec() {
     }
     outputWS->setHistogram(i, outHistogram);
     m_progress->report();
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   }
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
 
   g_log.debug() << calculationCount << " spectra corrected\n";
   g_log.information() << "The mean background was " << backgroundTotal / static_cast<double>(calculationCount) << ".\n";

--- a/Framework/Algorithms/src/CalculateIqt.cpp
+++ b/Framework/Algorithms/src/CalculateIqt.cpp
@@ -164,13 +164,13 @@ MatrixWorkspace_sptr CalculateIqt::monteCarloErrorCalculation(const MatrixWorksp
     PARALLEL_FOR_IF(Kernel::threadSafe(*sample, *resolution))
     for (auto i = 0; i < nIterations - 1; ++i) {
       errorCalculationProg.report("Calculating Monte Carlo errors...");
-      PARALLEL_START_INTERUPT_REGION
+      PARALLEL_START_INTERRUPT_REGION
       auto simulated = doSimulation(sample->clone(), resolution, rebinParams, mTwister);
       PARALLEL_CRITICAL(emplace_back)
       simulatedWorkspaces.emplace_back(simulated);
-      PARALLEL_END_INTERUPT_REGION
+      PARALLEL_END_INTERRUPT_REGION
     }
-    PARALLEL_CHECK_INTERUPT_REGION
+    PARALLEL_CHECK_INTERRUPT_REGION
     return setErrorsToStandardDeviation(simulatedWorkspaces);
   }
   return setErrorsToZero(simulatedWorkspaces);
@@ -286,11 +286,11 @@ CalculateIqt::setErrorsToStandardDeviation(const std::vector<MatrixWorkspace_spt
   auto outputWorkspace = simulatedWorkspaces.front();
   PARALLEL_FOR_IF(Mantid::Kernel::threadSafe(*outputWorkspace))
   for (auto i = 0; i < getWorkspaceNumberOfHistograms(outputWorkspace); ++i) {
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
     outputWorkspace->mutableE(i) = standardDeviationArray(allYValuesAtIndex(simulatedWorkspaces, i));
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   }
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
   return outputWorkspace;
 }
 
@@ -298,11 +298,11 @@ MatrixWorkspace_sptr CalculateIqt::setErrorsToZero(const std::vector<MatrixWorks
   auto outputWorkspace = simulatedWorkspaces.front();
   PARALLEL_FOR_IF(Mantid::Kernel::threadSafe(*outputWorkspace))
   for (auto i = 0; i < getWorkspaceNumberOfHistograms(outputWorkspace); ++i) {
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
     outputWorkspace->mutableE(i) = 0;
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   }
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
   return outputWorkspace;
 }
 

--- a/Framework/Algorithms/src/CalculatePlaczek.cpp
+++ b/Framework/Algorithms/src/CalculatePlaczek.cpp
@@ -303,7 +303,7 @@ void CalculatePlaczek::exec() {
   const int64_t numHist = specInfo.size();
   PARALLEL_FOR_IF(Kernel::threadSafe(*outputWS))
   for (int64_t specIndex = 0; specIndex < numHist; specIndex++) {
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
     auto &y = outputWS->mutableY(specIndex); // x-axis is directly copied from incident flux
     // only perform calculation for components that
     // - is monitor
@@ -367,9 +367,9 @@ void CalculatePlaczek::exec() {
         y[xIndex] = 0;
       }
     }
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   }
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
 
   // consolidate output to workspace
   outputWS->setDistribution(false);

--- a/Framework/Algorithms/src/CalculatePolynomialBackground.cpp
+++ b/Framework/Algorithms/src/CalculatePolynomialBackground.cpp
@@ -326,15 +326,15 @@ void CalculatePolynomialBackground::exec() {
   API::Progress progress(this, 0, 1.0, nHistograms);
   PARALLEL_FOR_IF(Kernel::threadSafe(*inWS, *outWS))
   for (int64_t i = 0; i < nHistograms; ++i) {
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
     const bool logging{false};
     auto fit = createChildAlgorithm("Fit", 0, 0, logging);
     const auto parameters = executeFit(*fit, fitFunction, inWS, i, inputRanges, costFunction, minimizer);
     evaluateInPlace(name, parameters, *outWS, i);
     progress.report();
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   }
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
 
   setProperty(Prop::OUTPUT_WS, outWS);
 }

--- a/Framework/Algorithms/src/CarpenterSampleCorrection.cpp
+++ b/Framework/Algorithms/src/CarpenterSampleCorrection.cpp
@@ -77,14 +77,14 @@ void CarpenterSampleCorrection::exec() {
   const auto NUM_HIST = static_cast<int64_t>(inputWksp->getNumberHistograms());
   PARALLEL_FOR_IF(Kernel::threadSafe(*absWksp))
   for (int64_t i = 0; i < NUM_HIST; ++i) {
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
     auto &y = absWksp->mutableY(i);
     for (size_t j = 0; j < y.size(); j++) {
       y[j] = 1.0 / y[j];
     }
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   }
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
 
   // Compute the overall correction (= 1/A - MS ) to multiply by
   auto correctionWksp = minus(absWksp, msWksp);

--- a/Framework/Algorithms/src/ChopData.cpp
+++ b/Framework/Algorithms/src/ChopData.cpp
@@ -135,7 +135,7 @@ void ChopData::exec() {
 
       auto edges = inputWS->binEdges(j);
 
-      PARALLEL_START_INTERUPT_REGION;
+      PARALLEL_START_INTERRUPT_REGION;
 
       workspace->mutableX(j).assign(edges.cbegin() + indexLow, edges.cbegin() + indexLow + nbins + 1);
 
@@ -144,9 +144,9 @@ void ChopData::exec() {
       workspace->mutableY(j).assign(inputWS->y(j).cbegin() + indexLow, inputWS->y(j).cbegin() + indexLow + nbins);
 
       workspace->mutableE(j).assign(inputWS->e(j).cbegin() + indexLow, inputWS->e(j).cbegin() + indexLow + nbins);
-      PARALLEL_END_INTERUPT_REGION;
+      PARALLEL_END_INTERRUPT_REGION;
     }
-    PARALLEL_CHECK_INTERUPT_REGION;
+    PARALLEL_CHECK_INTERRUPT_REGION;
 
     // add the workspace to the AnalysisDataService
     std::stringstream name;

--- a/Framework/Algorithms/src/CompareWorkspaces.cpp
+++ b/Framework/Algorithms/src/CompareWorkspaces.cpp
@@ -485,7 +485,7 @@ bool CompareWorkspaces::compareEventWorkspaces(const DataObjects::EventWorkspace
   std::vector<int> vec_mismatchedwsindex;
   PARALLEL_FOR_IF(m_parallelComparison && ews1.threadSafe() && ews2.threadSafe())
   for (int i = 0; i < static_cast<int>(ews1.getNumberHistograms()); ++i) {
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
     m_progress->report("EventLists");
     if (!mismatchedEvent || checkallspectra) // This guard will avoid checking unnecessarily
     {
@@ -534,9 +534,9 @@ bool CompareWorkspaces::compareEventWorkspaces(const DataObjects::EventWorkspace
 
       } // If elist 1 is not equal to elist 2
     }
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   }
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
 
   bool wsmatch;
   if (mismatchedEvent) {
@@ -610,7 +610,7 @@ bool CompareWorkspaces::checkData(const API::MatrixWorkspace_const_sptr &ws1,
   // Now check the data itself
   PARALLEL_FOR_IF(m_parallelComparison && ws1->threadSafe() && ws2->threadSafe())
   for (long i = 0; i < static_cast<long>(numHists); ++i) {
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
     m_progress->report("Histograms");
 
     if (resultBool || checkAllData) // Avoid checking unnecessarily
@@ -650,9 +650,9 @@ bool CompareWorkspaces::checkData(const API::MatrixWorkspace_const_sptr &ws1,
         resultBool = false;
       }
     }
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   }
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
 
   if (!resultBool)
     recordMismatch("Data mismatch");

--- a/Framework/Algorithms/src/ConjoinXRuns.cpp
+++ b/Framework/Algorithms/src/ConjoinXRuns.cpp
@@ -396,12 +396,12 @@ void ConjoinXRuns::exec() {
   // Now loop in parallel over all the spectra and join the data
   PARALLEL_FOR_IF(threadSafe(*m_outWS))
   for (int64_t index = 0; index < static_cast<int64_t>(numSpec); ++index) {
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
     joinSpectrum(index);
     m_progress->report();
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   }
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
 
   if (!m_logEntry.empty()) {
     std::string unit = first->run().getLogData(m_logEntry)->units();

--- a/Framework/Algorithms/src/ConvertAxesToRealSpace.cpp
+++ b/Framework/Algorithms/src/ConvertAxesToRealSpace.cpp
@@ -111,7 +111,7 @@ void ConvertAxesToRealSpace::exec() {
   // for each spectra
   PARALLEL_FOR_IF(Kernel::threadSafe(*summedWs, *outputWs))
   for (int i = 0; i < nHist; ++i) {
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
     try {
       V3D pos = spectrumInfo.position(i);
       double r, theta, phi;
@@ -160,7 +160,7 @@ void ConvertAxesToRealSpace::exec() {
       dataVector[i].horizontalValue = std::numeric_limits<double>::min();
       dataVector[i].verticalValue = std::numeric_limits<double>::min();
     }
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
 
     // take the values from the integrated data
     dataVector[i].intensity = summedWs->y(i)[0];
@@ -168,7 +168,7 @@ void ConvertAxesToRealSpace::exec() {
 
     progress.report("Calculating new coords");
   }
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
 
   g_log.warning() << "Could not find detector for " << failedCount << " spectra, see the debug log for more details.\n";
 

--- a/Framework/Algorithms/src/ConvertAxisByFormula.cpp
+++ b/Framework/Algorithms/src/ConvertAxisByFormula.cpp
@@ -194,12 +194,12 @@ void ConvertAxisByFormula::exec() {
       Progress prog(this, 0.6, 1.0, numberOfSpectra_i);
       PARALLEL_FOR_IF(Kernel::threadSafe(*outputWs))
       for (int64_t j = 1; j < numberOfSpectra_i; ++j) {
-        PARALLEL_START_INTERUPT_REGION
+        PARALLEL_START_INTERRUPT_REGION
         outputWs->setX(j, xVals);
         prog.report();
-        PARALLEL_END_INTERUPT_REGION
+        PARALLEL_END_INTERRUPT_REGION
       }
-      PARALLEL_CHECK_INTERUPT_REGION
+      PARALLEL_CHECK_INTERRUPT_REGION
     }
   } else {
     size_t axisLength = axisPtr->length();

--- a/Framework/Algorithms/src/ConvertToConstantL2.cpp
+++ b/Framework/Algorithms/src/ConvertToConstantL2.cpp
@@ -90,7 +90,7 @@ void ConvertToConstantL2::exec() {
   // Loop over the histograms (detector spectra)
   PARALLEL_FOR_IF(Kernel::threadSafe(*m_inputWS, *m_outputWS))
   for (int64_t i = 0; i < numberOfSpectra_i; ++i) {
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
     m_outputWS->setHistogram(i, m_inputWS->histogram(i));
 
     // Should not move the monitors
@@ -124,9 +124,9 @@ void ConvertToConstantL2::exec() {
     m_outputWS->mutableX(i) -= deltaTOF;
 
     prog.report("Aligning elastic line...");
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   } // end for i
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
 
   this->setProperty("OutputWorkspace", this->m_outputWS);
 }

--- a/Framework/Algorithms/src/ConvertToEventWorkspace.cpp
+++ b/Framework/Algorithms/src/ConvertToEventWorkspace.cpp
@@ -55,7 +55,7 @@ void ConvertToEventWorkspace::exec() {
   Progress prog(this, 0.0, 1.0, inWS->getNumberHistograms());
   PARALLEL_FOR_IF(Kernel::threadSafe(*inWS))
   for (int iwi = 0; iwi < int(inWS->getNumberHistograms()); iwi++) {
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
     auto wi = size_t(iwi);
 
     // The input spectrum (a histogram)
@@ -68,9 +68,9 @@ void ConvertToEventWorkspace::exec() {
     el.createFromHistogram(&inSpec, GenerateZeros, GenerateMultipleEvents, MaxEventsPerBin);
 
     prog.report("Converting");
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   }
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
 
   // Set the output
   setProperty("OutputWorkspace", std::move(outWS));

--- a/Framework/Algorithms/src/ConvertToMatrixWorkspace.cpp
+++ b/Framework/Algorithms/src/ConvertToMatrixWorkspace.cpp
@@ -53,7 +53,7 @@ void ConvertToMatrixWorkspace::exec() {
     // ...but not the data, so do that here.
     PARALLEL_FOR_IF(Kernel::threadSafe(*inputWorkspace, *outputWorkspace))
     for (int64_t i = 0; i < static_cast<int64_t>(numHists); ++i) {
-      PARALLEL_START_INTERUPT_REGION
+      PARALLEL_START_INTERRUPT_REGION
       const auto &inSpec = inputWorkspace->getSpectrum(i);
       auto &outSpec = outputWorkspace->getSpectrum(i);
 
@@ -62,9 +62,9 @@ void ConvertToMatrixWorkspace::exec() {
 
       prog.report("Binning");
 
-      PARALLEL_END_INTERUPT_REGION
+      PARALLEL_END_INTERRUPT_REGION
     }
-    PARALLEL_CHECK_INTERUPT_REGION
+    PARALLEL_CHECK_INTERRUPT_REGION
   } else {
     outputWorkspace = getProperty("OutputWorkspace");
     if (inputWorkspace == outputWorkspace) {

--- a/Framework/Algorithms/src/ConvertUnits.cpp
+++ b/Framework/Algorithms/src/ConvertUnits.cpp
@@ -268,7 +268,7 @@ API::MatrixWorkspace_sptr ConvertUnits::setupOutputWorkspace(const API::MatrixWo
     Progress prog(this, 0.0, 0.2, m_numberOfSpectra);
     PARALLEL_FOR_IF(Kernel::threadSafe(*outputWS))
     for (int64_t i = 0; i < static_cast<int64_t>(m_numberOfSpectra); ++i) {
-      PARALLEL_START_INTERUPT_REGION
+      PARALLEL_START_INTERRUPT_REGION
       // Take the bin width dependency out of the Y & E data
       const auto &X = outputWS->x(i);
       auto &Y = outputWS->mutableY(i);
@@ -280,9 +280,9 @@ API::MatrixWorkspace_sptr ConvertUnits::setupOutputWorkspace(const API::MatrixWo
       }
 
       prog.report("Convert to " + m_outputUnit->unitID());
-      PARALLEL_END_INTERUPT_REGION
+      PARALLEL_END_INTERRUPT_REGION
     }
-    PARALLEL_CHECK_INTERUPT_REGION
+    PARALLEL_CHECK_INTERRUPT_REGION
   }
 
   // Set the final unit that our output workspace will have
@@ -326,12 +326,12 @@ MatrixWorkspace_sptr ConvertUnits::convertQuickly(const API::MatrixWorkspace_con
 
     PARALLEL_FOR_IF(Kernel::threadSafe(*outputWS))
     for (int64_t j = 1; j < numberOfSpectra_i; ++j) {
-      PARALLEL_START_INTERUPT_REGION
+      PARALLEL_START_INTERRUPT_REGION
       outputWS->setX(j, xVals);
       prog.report("Convert to " + m_outputUnit->unitID());
-      PARALLEL_END_INTERUPT_REGION
+      PARALLEL_END_INTERRUPT_REGION
     }
-    PARALLEL_CHECK_INTERUPT_REGION
+    PARALLEL_CHECK_INTERRUPT_REGION
     if (!m_inputEvents) // if in event mode the work is done
       return outputWS;
   }
@@ -344,7 +344,7 @@ MatrixWorkspace_sptr ConvertUnits::convertQuickly(const API::MatrixWorkspace_con
   // Loop over the histograms (detector spectra)
   PARALLEL_FOR_IF(Kernel::threadSafe(*outputWS))
   for (int64_t k = 0; k < numberOfSpectra_i; ++k) {
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
     if (!commonBoundaries) {
       for (auto &x : outputWS->mutableX(k)) {
         x = factor * std::pow(x, power);
@@ -355,9 +355,9 @@ MatrixWorkspace_sptr ConvertUnits::convertQuickly(const API::MatrixWorkspace_con
       eventWS->getSpectrum(k).convertUnitsQuickly(factor, power);
     }
     prog.report("Convert to " + m_outputUnit->unitID());
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   }
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
 
   if (m_inputEvents)
     eventWS->clearMRU();
@@ -436,7 +436,7 @@ MatrixWorkspace_sptr ConvertUnits::convertViaTOF(Kernel::Unit_const_sptr fromUni
   // Loop over the histograms (detector spectra)
   PARALLEL_FOR_IF(Kernel::threadSafe(*outputWS))
   for (int64_t i = 0; i < numberOfSpectra_i; ++i) {
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
     double efixed = efixedProp;
 
     // Now get the detector object for this histogram
@@ -475,9 +475,9 @@ MatrixWorkspace_sptr ConvertUnits::convertViaTOF(Kernel::Unit_const_sptr fromUni
     }
 
     prog.report("Convert to " + m_outputUnit->unitID());
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   } // loop over spectra
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
 
   if (failedDetectorCount != 0) {
     g_log.information() << "Unable to calculate sample-detector distance for " << failedDetectorCount
@@ -560,7 +560,7 @@ void ConvertUnits::reverse(const API::MatrixWorkspace_sptr &WS) {
     auto numberOfSpectra_i = static_cast<int>(numberOfSpectra);
     PARALLEL_FOR_IF(Kernel::threadSafe(*WS))
     for (int j = 0; j < numberOfSpectra_i; ++j) {
-      PARALLEL_START_INTERUPT_REGION
+      PARALLEL_START_INTERRUPT_REGION
       if (isInputEvents) {
         eventWS->getSpectrum(j).reverse();
       } else {
@@ -568,9 +568,9 @@ void ConvertUnits::reverse(const API::MatrixWorkspace_sptr &WS) {
         std::reverse(WS->mutableY(j).begin(), WS->mutableY(j).end());
         std::reverse(WS->mutableE(j).begin(), WS->mutableE(j).end());
       }
-      PARALLEL_END_INTERUPT_REGION
+      PARALLEL_END_INTERRUPT_REGION
     }
-    PARALLEL_CHECK_INTERUPT_REGION
+    PARALLEL_CHECK_INTERRUPT_REGION
   }
 }
 

--- a/Framework/Algorithms/src/CorelliCrossCorrelate.cpp
+++ b/Framework/Algorithms/src/CorelliCrossCorrelate.cpp
@@ -176,7 +176,7 @@ void CorelliCrossCorrelate::exec() {
   const auto &spectrumInfo = inputWS->spectrumInfo();
   PARALLEL_FOR_IF(Kernel::threadSafe(*outputWS))
   for (int64_t i = 0; i < numHistograms; ++i) {
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
 
     auto &evlist = outputWS->getSpectrum(i);
 
@@ -234,9 +234,9 @@ void CorelliCrossCorrelate::exec() {
       g_log.warning("Events occurred long after last TDC.");
 
     prog.report();
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   }
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
   setProperty("OutputWorkspace", outputWS);
 }
 

--- a/Framework/Algorithms/src/CorrectKiKf.cpp
+++ b/Framework/Algorithms/src/CorrectKiKf.cpp
@@ -99,7 +99,7 @@ void CorrectKiKf::exec() {
 
   PARALLEL_FOR_IF(Kernel::threadSafe(*inputWS, *outputWS))
   for (int64_t i = 0; i < int64_t(numberOfSpectra); ++i) {
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
     double Efi = 0;
     // Now get the detector object for this histogram to check if monitor
     // or to get Ef for indirect geometry
@@ -151,9 +151,9 @@ void CorrectKiKf::exec() {
       eOut[j] = eIn[j] * kioverkf;
     }
     prog.report();
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   } // end for i
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
 
   if (negativeEnergyWarning)
     g_log.information() << "Ef <= 0 or Ei <= 0 in at least one spectrum!!!!\n";
@@ -209,7 +209,7 @@ void CorrectKiKf::execEvent() {
   API::Progress prog = API::Progress(this, 0.0, 1.0, numHistograms);
   PARALLEL_FOR_IF(Kernel::threadSafe(*outputWS))
   for (int64_t i = 0; i < numHistograms; ++i) {
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
     // Now get the detector object for this histogram to check if monitor
     // or to get Ef for indirect geometry
     if (emodeStr == "Indirect") {
@@ -247,9 +247,9 @@ void CorrectKiKf::execEvent() {
     }
 
     prog.report();
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   }
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
 
   outputWS->clearMRU();
   if (inputWS->getNumberEvents() != outputWS->getNumberEvents()) {

--- a/Framework/Algorithms/src/CorrectTOFAxis.cpp
+++ b/Framework/Algorithms/src/CorrectTOFAxis.cpp
@@ -311,11 +311,11 @@ void CorrectTOFAxis::useReferenceWorkspace(const API::MatrixWorkspace_sptr &outp
   const auto histogramCount = static_cast<int64_t>(m_referenceWs->getNumberHistograms());
   PARALLEL_FOR_IF(threadSafe(*m_referenceWs, *outputWs))
   for (int64_t i = 0; i < histogramCount; ++i) {
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
     std::copy(m_referenceWs->x(i).cbegin(), m_referenceWs->x(i).cend(), outputWs->mutableX(i).begin());
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   }
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
   if (outputWs->run().hasProperty(SampleLog::INCIDENT_ENERGY)) {
     outputWs->mutableRun()
         .getProperty(SampleLog::INCIDENT_ENERGY)
@@ -366,11 +366,11 @@ void CorrectTOFAxis::correctManually(const API::MatrixWorkspace_sptr &outputWs) 
   const auto histogramCount = static_cast<int64_t>(m_inputWs->getNumberHistograms());
   PARALLEL_FOR_IF(threadSafe(*m_inputWs, *outputWs))
   for (int64_t i = 0; i < histogramCount; ++i) {
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
     outputWs->mutableX(i) += shift;
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   }
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
 }
 
 /** Calculates the average L2 distance between the sample and given
@@ -391,7 +391,7 @@ void CorrectTOFAxis::averageL2AndEPP(const API::SpectrumInfo &spectrumInfo, doub
   PRAGMA_OMP(parallel for if (m_eppTable->threadSafe())
              reduction(+: n, l2Sum, eppSum))
   for (int64_t i = 0; i < indexCount; ++i) {
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
     const size_t index = m_workspaceIndices[i];
     interruption_point();
     if (fitStatusColumn->cell<std::string>(index) == EPPTableLiterals::FIT_STATUS_SUCCESS) {
@@ -408,9 +408,9 @@ void CorrectTOFAxis::averageL2AndEPP(const API::SpectrumInfo &spectrumInfo, doub
     } else {
       g_log.debug() << "Excluding detector with unsuccessful fit at workspace index " << index << ".\n";
     }
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   }
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
   if (n == 0) {
     throw std::runtime_error("No successful detector fits found in " + PropertyNames::EPP_TABLE);
   }
@@ -426,7 +426,7 @@ double CorrectTOFAxis::averageL2(const API::SpectrumInfo &spectrumInfo) {
   const auto indexCount = static_cast<int64_t>(m_workspaceIndices.size());
   PRAGMA_OMP(parallel for reduction(+: n, l2Sum))
   for (int64_t i = 0; i < indexCount; ++i) {
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
     const size_t index = m_workspaceIndices[i];
     interruption_point();
     if (!spectrumInfo.isMasked(index)) {
@@ -436,9 +436,9 @@ double CorrectTOFAxis::averageL2(const API::SpectrumInfo &spectrumInfo) {
     } else {
       g_log.debug() << "Excluding masked workspace index " << index << ".\n";
     }
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   }
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
   if (n == 0) {
     throw std::runtime_error("No unmasked detectors found in " + PropertyNames::REFERENCE_SPECTRA);
   }

--- a/Framework/Algorithms/src/CreateFloodWorkspace.cpp
+++ b/Framework/Algorithms/src/CreateFloodWorkspace.cpp
@@ -193,7 +193,7 @@ API::MatrixWorkspace_sptr CreateFloodWorkspace::removeBackground(API::MatrixWork
   auto const nHisto = static_cast<int>(ws->getNumberHistograms());
   PARALLEL_FOR_IF(Kernel::threadSafe(*ws, *bkgWS))
   for (int i = 0; i < nHisto; ++i) {
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
     auto const xVal = x[i];
     if (isExcludedSpectrum(xVal)) {
       ws->mutableY(i)[0] = VERY_BIG_VALUE;
@@ -210,9 +210,9 @@ API::MatrixWorkspace_sptr CreateFloodWorkspace::removeBackground(API::MatrixWork
       ws->mutableY(i)[0] = 1.0;
       ws->mutableE(i)[0] = 0.0;
     }
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   }
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
 
   // Remove the logs
   ws->setSharedRun(make_cow<Run>());
@@ -240,7 +240,7 @@ MatrixWorkspace_sptr CreateFloodWorkspace::scaleToCentralPixel(MatrixWorkspace_s
   double const endX = isDefault(Prop::END_X) ? sa->getMax() : getProperty(Prop::END_X);
   PARALLEL_FOR_IF(Kernel::threadSafe(*ws))
   for (int i = 0; i < nHisto; ++i) {
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
     auto const spec = ws->getSpectrum(i).getSpectrumNo();
     if (isExcludedSpectrum(spec)) {
       ws->mutableY(i)[0] = VERY_BIG_VALUE;
@@ -252,9 +252,9 @@ MatrixWorkspace_sptr CreateFloodWorkspace::scaleToCentralPixel(MatrixWorkspace_s
       ws->mutableY(i)[0] = 1.0;
       ws->mutableE(i)[0] = 0.0;
     }
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   }
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
   return ws;
 }
 

--- a/Framework/Algorithms/src/CreateGroupingWorkspace.cpp
+++ b/Framework/Algorithms/src/CreateGroupingWorkspace.cpp
@@ -619,16 +619,16 @@ void CreateGroupingWorkspace::exec() {
 
           PRAGMA_OMP(parallel for schedule(dynamic, 1) )
           for (int num = 0; num < 300; ++num) {
-            PARALLEL_START_INTERUPT_REGION
+            PARALLEL_START_INTERRUPT_REGION
             std::ostringstream mess;
             mess << grouping << num;
             IComponent_const_sptr comp = inst->getComponentByName(mess.str(), maxRecurseDepth);
             PARALLEL_CRITICAL(GroupNames)
             if (comp)
               GroupNames += mess.str() + ",";
-            PARALLEL_END_INTERUPT_REGION
+            PARALLEL_END_INTERRUPT_REGION
           }
-          PARALLEL_CHECK_INTERUPT_REGION
+          PARALLEL_CHECK_INTERRUPT_REGION
     }
   }
 

--- a/Framework/Algorithms/src/CreatePSDBleedMask.cpp
+++ b/Framework/Algorithms/src/CreatePSDBleedMask.cpp
@@ -147,7 +147,7 @@ void CreatePSDBleedMask::exec() {
 
   PARALLEL_FOR_IF(Kernel::threadSafe(*inputWorkspace, *outputWorkspace))
   for (int i = 0; i < numTubes; ++i) {
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
     auto current = std::next(tubeMap.begin(), i);
     const TubeIndex::mapped_type tubeIndices = current->second;
     bool mask = performBleedTest(tubeIndices, inputWorkspace, maxRate, numIgnoredPixels);
@@ -161,9 +161,9 @@ void CreatePSDBleedMask::exec() {
 
     progress.report("Performing Bleed Test");
 
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   }
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
 
   g_log.information() << numTubesMasked << " tube(s) failed the bleed tests.";
   if (numTubesMasked > 0) {

--- a/Framework/Algorithms/src/CreateWorkspace.cpp
+++ b/Framework/Algorithms/src/CreateWorkspace.cpp
@@ -186,7 +186,7 @@ void CreateWorkspace::exec() {
 
   PARALLEL_FOR_IF(Kernel::threadSafe(*outputWS))
   for (int i = 0; i < nSpec; i++) {
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
 
     // In an MPI run the global index i is not necessarily on this rank, i.e.,
     // there might not be a corrsponding workspace index.
@@ -214,9 +214,9 @@ void CreateWorkspace::exec() {
       outputWS->mutableDx(local_i).assign(dX.begin() + yStart, dX.begin() + yEnd);
 
     progress.report();
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   }
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
 
   // Set the Unit of the X Axis
   try {

--- a/Framework/Algorithms/src/CropWorkspaceRagged.cpp
+++ b/Framework/Algorithms/src/CropWorkspaceRagged.cpp
@@ -118,7 +118,7 @@ void CropWorkspaceRagged::exec() {
   }
   PARALLEL_FOR_IF(Kernel::threadSafe(*tmp, *outputWS))
   for (int64_t i = 0; i < int64_t(numSpectra); ++i) {
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
     auto points = tmp->points(i);
     auto &dataX = outputWS->dataX(i);
     auto &dataY = outputWS->dataY(i);
@@ -150,9 +150,9 @@ void CropWorkspaceRagged::exec() {
     outputWS->mutableX(i) = newX;
     outputWS->mutableY(i) = newY;
     outputWS->mutableE(i) = newE;
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   }
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
 
   setProperty("OutputWorkspace", outputWS);
 }

--- a/Framework/Algorithms/src/CrossCorrelate.cpp
+++ b/Framework/Algorithms/src/CrossCorrelate.cpp
@@ -199,7 +199,7 @@ void CrossCorrelate::exec() {
   PARALLEL_FOR_IF(Kernel::threadSafe(*inputWS, *out))
   for (int currentSpecIndex = 0; currentSpecIndex < numSpectra; ++currentSpecIndex) // Now loop on all spectra
   {
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
     size_t wsIndex = indexes[currentSpecIndex]; // Get the ws index from the table
     // Copy spectra info from input Workspace
     out->getSpectrum(currentSpecIndex).copyInfoFrom(inputWS->getSpectrum(wsIndex));
@@ -251,9 +251,9 @@ void CrossCorrelate::exec() {
     }
     // Update progress information
     m_progress->report();
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   }
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
 
   out->getAxis(0)->unit() = UnitFactory::Instance().create("Label");
   Unit_sptr unit = out->getAxis(0)->unit();

--- a/Framework/Algorithms/src/DeadTimeCorrection.cpp
+++ b/Framework/Algorithms/src/DeadTimeCorrection.cpp
@@ -116,7 +116,7 @@ void DeadTimeCorrection::exec() {
   Progress progress(this, 0.0, 1.0, grouped->getNumberHistograms());
   PARALLEL_FOR_IF(Kernel::threadSafe(*outputWorkspace))
   for (int index = 0; index < static_cast<int>(grouped->getNumberHistograms()); ++index) {
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
     progress.report("Performing the correction for the group at index " + std::to_string(index));
     auto correction = grouped->readY(index);
     for (size_t bin = 0; bin < correction.size(); bin++) {
@@ -143,9 +143,9 @@ void DeadTimeCorrection::exec() {
         errors *= correction;
       }
     }
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   }
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
   setProperty("OutputWorkspace", outputWorkspace);
 }
 

--- a/Framework/Algorithms/src/DetectorDiagnostic.cpp
+++ b/Framework/Algorithms/src/DetectorDiagnostic.cpp
@@ -570,7 +570,7 @@ std::vector<double> DetectorDiagnostic::calculateMedian(const API::MatrixWorkspa
 
     PARALLEL_FOR_IF(Kernel::threadSafe(input))
     for (int i = 0; i < nhists; ++i) { // NOLINT
-      PARALLEL_START_INTERUPT_REGION
+      PARALLEL_START_INTERRUPT_REGION
 
       if (checkForMask && spectrumInfo.hasDetectors(hists[i])) {
         if (spectrumInfo.isMasked(hists[i]) || spectrumInfo.isMonitor(hists[i]))
@@ -589,9 +589,9 @@ std::vector<double> DetectorDiagnostic::calculateMedian(const API::MatrixWorkspa
       // Now we have a good value
       PARALLEL_CRITICAL(DetectorDiagnostic_median_d) { medianInput.emplace_back(yValue); }
 
-      PARALLEL_END_INTERUPT_REGION
+      PARALLEL_END_INTERRUPT_REGION
     }
-    PARALLEL_CHECK_INTERUPT_REGION
+    PARALLEL_CHECK_INTERRUPT_REGION
 
     if (medianInput.empty()) {
       g_log.information("some group has no valid histograms. Will use 0 for median.");

--- a/Framework/Algorithms/src/DetectorEfficiencyCor.cpp
+++ b/Framework/Algorithms/src/DetectorEfficiencyCor.cpp
@@ -127,7 +127,7 @@ void DetectorEfficiencyCor::exec() {
 
   PARALLEL_FOR_IF(Kernel::threadSafe(*m_inputWS, *m_outputWS))
   for (int64_t i = 0; i < numHists; ++i) {
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
 
     m_outputWS->setSharedX(i, m_inputWS->sharedX(i));
     try {
@@ -145,9 +145,9 @@ void DetectorEfficiencyCor::exec() {
       interruption_point();
     }
 
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   }
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
 
   logErrors(numHists);
   setProperty("OutputWorkspace", m_outputWS);

--- a/Framework/Algorithms/src/DetectorEfficiencyCorUser.cpp
+++ b/Framework/Algorithms/src/DetectorEfficiencyCorUser.cpp
@@ -69,7 +69,7 @@ void DetectorEfficiencyCorUser::exec() {
   // Loop over the histograms (detector spectra)
   PARALLEL_FOR_IF(Kernel::threadSafe(*m_outputWS, *m_inputWS))
   for (int64_t i = 0; i < numberOfSpectra_i; ++i) {
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
     const auto effFormula = retrieveFormula(i);
     // Calculate Efficiency for E = Ei
     double e;
@@ -80,9 +80,9 @@ void DetectorEfficiencyCorUser::exec() {
 
     prog.report("Detector Efficiency correction...");
 
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   } // end for i
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
 
   this->setProperty("OutputWorkspace", this->m_outputWS);
 }

--- a/Framework/Algorithms/src/DetectorEfficiencyVariation.cpp
+++ b/Framework/Algorithms/src/DetectorEfficiencyVariation.cpp
@@ -196,7 +196,7 @@ int DetectorEfficiencyVariation::doDetectorTests(const API::MatrixWorkspace_cons
   const auto &spectrumInfo = counts1->spectrumInfo();
   PARALLEL_FOR_IF(Kernel::threadSafe(*counts1, *counts2, *maskWS))
   for (int i = 0; i < numSpec; ++i) {
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
     // move progress bar
     if (i % progStep == 0) {
       advanceProgress(progStep * static_cast<double>(RTMarkDetects) / numSpec);
@@ -233,9 +233,9 @@ int DetectorEfficiencyVariation::doDetectorTests(const API::MatrixWorkspace_cons
       ++numFailed;
     }
 
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   }
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
 
   // Register the results with the ADS
   setProperty("OutputWorkspace", maskWS);

--- a/Framework/Algorithms/src/DiffractionFocussing2.cpp
+++ b/Framework/Algorithms/src/DiffractionFocussing2.cpp
@@ -177,7 +177,7 @@ void DiffractionFocussing2::exec() {
 
   PARALLEL_FOR_IF(Kernel::threadSafe(*m_matrixInputW, *out))
   for (int outWorkspaceIndex = 0; outWorkspaceIndex < static_cast<int>(m_validGroups.size()); outWorkspaceIndex++) {
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
     auto group = static_cast<int>(m_validGroups[outWorkspaceIndex]);
 
     // Get the group
@@ -300,9 +300,9 @@ void DiffractionFocussing2::exec() {
     std::for_each(Eout.begin(), Eout.end(), [groupSize](double &val) { val *= static_cast<double>(groupSize); });
 
     prog.report();
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   } // end of loop for groups
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
 
   setProperty("OutputWorkspace", out);
 
@@ -374,7 +374,7 @@ void DiffractionFocussing2::execEvent() {
 
     PRAGMA_OMP(parallel for schedule(dynamic, 1) )
     for (int wiChunk = 0; wiChunk < end; wiChunk++) {
-      PARALLEL_START_INTERUPT_REGION
+      PARALLEL_START_INTERRUPT_REGION
 
       // Perform in chunks for more efficiency
       int max = (wiChunk + 1) * chunkSize;
@@ -396,16 +396,16 @@ void DiffractionFocussing2::execEvent() {
       // Rejoin the chunk with the rest.
       PARALLEL_CRITICAL(DiffractionFocussing2_JoinChunks) { groupEL += chunkEL; }
 
-      PARALLEL_END_INTERUPT_REGION
+      PARALLEL_END_INTERRUPT_REGION
     }
-    PARALLEL_CHECK_INTERUPT_REGION
+    PARALLEL_CHECK_INTERRUPT_REGION
   } else {
     // ------ PARALLELIZE BY GROUPS -------------------------
 
     auto nValidGroups = static_cast<int>(this->m_validGroups.size());
     PARALLEL_FOR_IF(Kernel::threadSafe(*m_eventW))
     for (int iGroup = 0; iGroup < nValidGroups; iGroup++) {
-      PARALLEL_START_INTERUPT_REGION
+      PARALLEL_START_INTERRUPT_REGION
       const std::vector<size_t> &indices = this->m_wsIndices[iGroup];
       for (auto wi : indices) {
         // In workspace index iGroup, put what was in the OLD workspace index wi
@@ -419,9 +419,9 @@ void DiffractionFocussing2::execEvent() {
           std::const_pointer_cast<EventWorkspace>(m_eventW)->getSpectrum(wi).clear();
         }
       }
-      PARALLEL_END_INTERUPT_REGION
+      PARALLEL_END_INTERRUPT_REGION
     }
-    PARALLEL_CHECK_INTERUPT_REGION
+    PARALLEL_CHECK_INTERRUPT_REGION
   } // (done with parallel by groups)
 
   // Now that the data is cleaned up, go through it and set the X vectors to the

--- a/Framework/Algorithms/src/DirectILLTubeBackground.cpp
+++ b/Framework/Algorithms/src/DirectILLTubeBackground.cpp
@@ -275,7 +275,7 @@ void DirectILLTubeBackground::exec() {
   API::Progress progress(this, 0.0, 1.0, componentNames.size());
   PARALLEL_FOR_IF(Kernel::threadSafe(*ws))
   for (int64_t i = 0; i < static_cast<int64_t>(componentNames.size()); ++i) {
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
     auto const &componentName = componentNames[static_cast<size_t>(i)];
     progress.report("Processing " + componentName);
     checkComponentExists(componentName, *instrument);
@@ -290,9 +290,9 @@ void DirectILLTubeBackground::exec() {
     auto averageWS = peakExcludingAverage(*componentWS, bounds.peakStarts, bounds.peakEnds);
     auto fittedComponentBkg = fitComponentBackground(averageWS, bkgRanges);
     writeComponentBackgroundToOutput(*fittedComponentBkg, *bkgWS, wsIndexRange.first);
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   }
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
   if (!ws->isDistribution()) {
     for (size_t i = 0; i < bkgWS->getNumberHistograms(); ++i) {
       bkgWS->convertToCounts(i);

--- a/Framework/Algorithms/src/DiscusMultipleScatteringCorrection.cpp
+++ b/Framework/Algorithms/src/DiscusMultipleScatteringCorrection.cpp
@@ -269,7 +269,7 @@ void DiscusMultipleScatteringCorrection::exec() {
 
   PARALLEL_FOR_IF(enableParallelFor)
   for (int64_t i = 0; i < nhists; ++i) {
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
     auto &spectrum = instrumentWS.getSpectrum(i);
     Mantid::specnum_t specNo = spectrum.getSpectrumNo();
     MersenneTwister rng(seed + specNo);
@@ -334,9 +334,9 @@ void DiscusMultipleScatteringCorrection::exec() {
       }
     }
 
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   }
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
 
   if (useSparseInstrument) {
     Poco::Thread::sleep(200); // to ensure prog message changes
@@ -867,7 +867,7 @@ void DiscusMultipleScatteringCorrection::interpolateFromSparse(
   const auto refFrame = targetWS.getInstrument()->getReferenceFrame();
   PARALLEL_FOR_IF(Kernel::threadSafe(targetWS, sparseWS))
   for (int64_t i = 0; i < static_cast<decltype(i)>(spectrumInfo.size()); ++i) {
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
     if (spectrumInfo.hasDetectors(i) && !spectrumInfo.isMonitor(i)) {
       double lat, lon;
       std::tie(lat, lon) = spectrumInfo.geographicalAngles(i);
@@ -880,9 +880,9 @@ void DiscusMultipleScatteringCorrection::interpolateFromSparse(
         targetWS.mutableY(i) = spatiallyInterpHisto.y().front();
       }
     }
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   }
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
 }
 
 void DiscusMultipleScatteringCorrection::correctForWorkspaceNameClash(std::string &wsName) {

--- a/Framework/Algorithms/src/EQSANSCorrectFrame.cpp
+++ b/Framework/Algorithms/src/EQSANSCorrectFrame.cpp
@@ -103,7 +103,7 @@ void EQSANSCorrectFrame::exec() {
   // Loop through the spectra and apply correction
   PARALLEL_FOR_IF(Kernel::threadSafe(*inputWS))
   for (int64_t ispec = 0; ispec < int64_t(numHists); ++ispec) {
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
     if (!spectrumInfo.hasDetectors(ispec)) {
       g_log.warning() << "Workspace index " << ispec << " has no detector assigned to it - discarding\n";
       continue;
@@ -122,9 +122,9 @@ void EQSANSCorrectFrame::exec() {
 
     evlist.convertTof(tofCorrector);
     progress.report("Correct TOF frame");
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   }
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
   // Set bin boundaries to absolute minimum and maximum
   inputWS->resetAllXToSingleBin();
 }

--- a/Framework/Algorithms/src/EQSANSTofStructure.cpp
+++ b/Framework/Algorithms/src/EQSANSTofStructure.cpp
@@ -119,7 +119,7 @@ void EQSANSTofStructure::execEvent(const Mantid::DataObjects::EventWorkspace_spt
   // Loop through the spectra and apply correction
   PARALLEL_FOR_IF(Kernel::threadSafe(*inputWS))
   for (int64_t ispec = 0; ispec < int64_t(numHists); ++ispec) {
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
 
     if (!spectrumInfo.hasDetectors(ispec)) {
       g_log.warning() << "Workspace index " << ispec << " has no detector assigned to it - discarding\n";
@@ -161,9 +161,9 @@ void EQSANSTofStructure::execEvent(const Mantid::DataObjects::EventWorkspace_spt
     }
 
     progress.report("TOF structure");
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   }
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
 }
 
 double EQSANSTofStructure::getTofOffset(const EventWorkspace_const_sptr &inputWS, bool frame_skipping) {

--- a/Framework/Algorithms/src/ExtractFFTSpectrum.cpp
+++ b/Framework/Algorithms/src/ExtractFFTSpectrum.cpp
@@ -64,7 +64,7 @@ void ExtractFFTSpectrum::exec() {
   Mantid::Kernel::Unit_sptr unit; // must retrieve this from the child FFT
   PARALLEL_FOR_IF(Kernel::threadSafe(*outputWS))
   for (int i = 0; i < numHists; i++) {
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
 
     auto childFFT = createChildAlgorithm("FFT");
     childFFT->setProperty<MatrixWorkspace_sptr>("InputWorkspace", inputWS);
@@ -83,9 +83,9 @@ void ExtractFFTSpectrum::exec() {
 
     prog.report();
 
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   }
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
 
   outputWS->getAxis(0)->unit() = unit;
 

--- a/Framework/Algorithms/src/ExtractMask.cpp
+++ b/Framework/Algorithms/src/ExtractMask.cpp
@@ -71,7 +71,7 @@ void ExtractMask::exec() {
 
   PARALLEL_FOR_IF(Kernel::threadSafe(*inputWS, *maskWS))
   for (int64_t i = 0; i < nHist; ++i) {
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
     bool inputIsMasked(false);
     if (spectrumInfo.hasDetectors(i)) {
       // special workspaces can mysteriously have the mask bit set
@@ -79,9 +79,9 @@ void ExtractMask::exec() {
     }
     maskWS->setMaskedIndex(i, inputIsMasked);
     prog.report();
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   }
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
 
   g_log.information() << maskWS->getNumberMasked() << " spectra are masked\n";
   g_log.information() << detectorList.size() << " detectors are masked\n";

--- a/Framework/Algorithms/src/ExtractSpectra.cpp
+++ b/Framework/Algorithms/src/ExtractSpectra.cpp
@@ -202,7 +202,7 @@ void ExtractSpectra::execEvent() {
   Progress prog(this, 0.0, 1.0, eventW->getNumberHistograms());
   PARALLEL_FOR_IF(Kernel::threadSafe(*eventW))
   for (int i = 0; i < static_cast<int>(eventW->getNumberHistograms()); ++i) {
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
     EventList &el = eventW->getSpectrum(i);
 
     switch (el.getEventType()) {
@@ -231,9 +231,9 @@ void ExtractSpectra::execEvent() {
     }
     propagateBinMasking(*eventW, i);
     prog.report();
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   }
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
 }
 
 /// Propagate bin masking if there is any.

--- a/Framework/Algorithms/src/FilterByLogValue.cpp
+++ b/Framework/Algorithms/src/FilterByLogValue.cpp
@@ -168,7 +168,7 @@ void FilterByLogValue::exec() {
     // -------------------------------------------------------------
     PARALLEL_FOR_NO_WSP_CHECK()
     for (int64_t i = 0; i < int64_t(numberOfSpectra); ++i) {
-      PARALLEL_START_INTERUPT_REGION
+      PARALLEL_START_INTERRUPT_REGION
 
       // this is the input event list
       EventList &input_el = inputWS->getSpectrum(i);
@@ -177,9 +177,9 @@ void FilterByLogValue::exec() {
       input_el.filterInPlace(splitter);
 
       prog.report();
-      PARALLEL_END_INTERUPT_REGION
+      PARALLEL_END_INTERRUPT_REGION
     }
-    PARALLEL_CHECK_INTERUPT_REGION
+    PARALLEL_CHECK_INTERRUPT_REGION
 
     // To split/filter the runs, first you make a vector with just the one
     // output run
@@ -199,7 +199,7 @@ void FilterByLogValue::exec() {
     // Loop over the histograms (detector spectra)
     PARALLEL_FOR_NO_WSP_CHECK()
     for (int64_t i = 0; i < int64_t(numberOfSpectra); ++i) {
-      PARALLEL_START_INTERUPT_REGION
+      PARALLEL_START_INTERRUPT_REGION
 
       // Get the output event list (should be empty)
       std::vector<EventList *> outputs{&outputWS->getSpectrum(i)};
@@ -212,9 +212,9 @@ void FilterByLogValue::exec() {
       input_el.splitByTime(splitter, outputs);
 
       prog.report();
-      PARALLEL_END_INTERUPT_REGION
+      PARALLEL_END_INTERRUPT_REGION
     }
-    PARALLEL_CHECK_INTERUPT_REGION
+    PARALLEL_CHECK_INTERRUPT_REGION
 
     // To split/filter the runs, first you make a vector with just the one
     // output run

--- a/Framework/Algorithms/src/FilterByTime.cpp
+++ b/Framework/Algorithms/src/FilterByTime.cpp
@@ -111,7 +111,7 @@ void FilterByTime::exec() {
   // Loop over the histograms (detector spectra)
   PARALLEL_FOR_NO_WSP_CHECK()
   for (int64_t i = 0; i < int64_t(numberOfSpectra); ++i) {
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
 
     // Get the output event list (should be empty)
     EventList &output_el = outputWS->getSpectrum(i);
@@ -122,9 +122,9 @@ void FilterByTime::exec() {
     input_el.filterByPulseTime(start, stop, output_el);
 
     prog.report();
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   }
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
 
   // Now filter out the run, using the DateAndTime type.
   outputWS->mutableRun().filterByTime(start, stop);

--- a/Framework/Algorithms/src/FilterByXValue.cpp
+++ b/Framework/Algorithms/src/FilterByXValue.cpp
@@ -89,7 +89,7 @@ void FilterByXValue::exec() {
   // Loop over the workspace, removing the events that don't pass the filter
   PARALLEL_FOR_IF(Kernel::threadSafe(*outputWS))
   for (int spec = 0; spec < numSpec; ++spec) {
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
 
     EventList &events = outputWS->getSpectrum(spec);
     // Sort to make getting the tof min/max faster (& since maskTof will sort
@@ -111,9 +111,9 @@ void FilterByXValue::exec() {
     }
 
     prog.report();
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   }
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
 }
 
 } // namespace Mantid::Algorithms

--- a/Framework/Algorithms/src/FilterEvents.cpp
+++ b/Framework/Algorithms/src/FilterEvents.cpp
@@ -1617,7 +1617,7 @@ void FilterEvents::filterEventsBySplitters(double progressamount) {
   // FIXME - Turn on parallel:
   PARALLEL_FOR_NO_WSP_CHECK()
   for (int64_t iws = 0; iws < int64_t(numberOfSpectra); ++iws) {
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
 
     // Filter the non-skipped
     if (!m_vecSkip[iws]) {
@@ -1644,9 +1644,9 @@ void FilterEvents::filterEventsBySplitters(double progressamount) {
       }
     }
 
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   } // END FOR i = 0
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
 
   // Split the sample logs in each target workspace.
   progress(0.1 + progressamount, "Splitting logs");
@@ -1687,7 +1687,7 @@ void FilterEvents::filterEventsByVectorSplitters(double progressamount) {
 
   PARALLEL_FOR_NO_WSP_CHECK()
   for (int64_t iws = 0; iws < int64_t(numberOfSpectra); ++iws) {
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
 
     // Filter the non-skipped spectrum
     if (!m_vecSkip[iws]) {
@@ -1723,9 +1723,9 @@ void FilterEvents::filterEventsByVectorSplitters(double progressamount) {
         g_log.notice(logmessage);
     }
 
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   } // END FOR i = 0
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
 
   // Finish (1) adding events and splitting the sample logs in each target
   // workspace.

--- a/Framework/Algorithms/src/FindEPP.cpp
+++ b/Framework/Algorithms/src/FindEPP.cpp
@@ -60,11 +60,11 @@ void FindEPP::exec() {
   // Loop over spectra
   PARALLEL_FOR_IF(threadSafe(*m_inWS, *m_outWS))
   for (int64_t index = 0; index < numberspectra; ++index) {
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
     fitGaussian(index);
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   }
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
 
   setProperty("OutputWorkspace", m_outWS);
 }

--- a/Framework/Algorithms/src/FitPeaks.cpp
+++ b/Framework/Algorithms/src/FitPeaks.cpp
@@ -852,7 +852,7 @@ std::vector<std::shared_ptr<FitPeaksAlgorithm::PeakFitResult>> FitPeaks::fitPeak
 
   PRAGMA_OMP(parallel for schedule(dynamic, 1) )
   for (int ithread = 0; ithread < nThreads; ithread++) {
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
     auto iws_begin = m_startWorkspaceIndex + chunkSize * static_cast<size_t>(ithread);
     auto iws_end = (ithread == nThreads - 1) ? m_stopWorkspaceIndex + 1 : iws_begin + chunkSize;
 
@@ -877,9 +877,9 @@ std::vector<std::shared_ptr<FitPeaksAlgorithm::PeakFitResult>> FitPeaks::fitPeak
       }
       prog.report();
     }
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   }
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
 
   return fit_result_vector;
 }
@@ -1280,7 +1280,7 @@ void FitPeaks::calculateFittedPeaks(std::vector<std::shared_ptr<FitPeaksAlgorith
   PARALLEL_FOR_IF(Kernel::threadSafe(*m_fittedPeakWS))
   for (auto iws = static_cast<int64_t>(m_startWorkspaceIndex); iws <= static_cast<int64_t>(m_stopWorkspaceIndex);
        ++iws) {
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
     // get a copy of peak function and background function
     IPeakFunction_sptr peak_function = std::dynamic_pointer_cast<IPeakFunction>(m_peakFunction->clone());
     IBackgroundFunction_sptr bkgd_function = std::dynamic_pointer_cast<IBackgroundFunction>(m_bkgdFunction->clone());
@@ -1323,9 +1323,9 @@ void FitPeaks::calculateFittedPeaks(std::vector<std::shared_ptr<FitPeaksAlgorith
         m_fittedPeakWS->dataY(static_cast<size_t>(iws))[yindex] = values.getCalculated(yindex - istart);
       }
     } // END-FOR (ipeak)
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   } // END-FOR (iws)
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
 
   return;
 }

--- a/Framework/Algorithms/src/GenerateEventsFilter.cpp
+++ b/Framework/Algorithms/src/GenerateEventsFilter.cpp
@@ -1078,7 +1078,7 @@ void GenerateEventsFilter::makeMultipleFiltersByValuesParallel(const map<size_t,
 
     PRAGMA_OMP(parallel for schedule(dynamic, 1) )
     for (int i = 0; i < numThreads; ++i) {
-      PARALLEL_START_INTERUPT_REGION
+      PARALLEL_START_INTERRUPT_REGION
 
       int istart = vecStart[i];
       int iend = vecEnd[i];
@@ -1086,9 +1086,9 @@ void GenerateEventsFilter::makeMultipleFiltersByValuesParallel(const map<size_t,
       makeMultipleFiltersByValuesPartialLog(istart, iend, m_vecSplitterTimeSet[i], m_vecGroupIndexSet[i],
                                             indexwsindexmap, logvalueranges, tol, filterIncrease, filterDecrease,
                                             startTime, stopTime);
-      PARALLEL_END_INTERUPT_REGION
+      PARALLEL_END_INTERRUPT_REGION
     }
-    PARALLEL_CHECK_INTERUPT_REGION
+    PARALLEL_CHECK_INTERRUPT_REGION
 
     // Concatenate splitters on different threads together
     for (int i = 1; i < numThreads; ++i) {

--- a/Framework/Algorithms/src/GetDetectorOffsets.cpp
+++ b/Framework/Algorithms/src/GetDetectorOffsets.cpp
@@ -132,7 +132,7 @@ void GetDetectorOffsets::exec() {
   auto &spectrumInfo = maskWS->mutableSpectrumInfo();
   PARALLEL_FOR_IF(Kernel::threadSafe(*inputW))
   for (int64_t wi = 0; wi < nspec; ++wi) {
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
     // Fit the peak
     double offset = fitSpectra(wi);
     double mask = 0.0;
@@ -166,9 +166,9 @@ void GetDetectorOffsets::exec() {
       }
     }
     prog.report();
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   }
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
 
   // Return the output
   setProperty("OutputWorkspace", outputW);

--- a/Framework/Algorithms/src/He3TubeEfficiency.cpp
+++ b/Framework/Algorithms/src/He3TubeEfficiency.cpp
@@ -114,7 +114,7 @@ void He3TubeEfficiency::exec() {
 
   PARALLEL_FOR_IF(Kernel::threadSafe(*m_inputWS, *m_outputWS))
   for (int i = 0; i < static_cast<int>(numHists); ++i) {
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
 
     m_outputWS->setSharedX(i, m_inputWS->sharedX(i));
     try {
@@ -133,9 +133,9 @@ void He3TubeEfficiency::exec() {
       interruption_point();
     }
 
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   }
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
 
   this->logErrors();
   this->setProperty("OutputWorkspace", m_outputWS);
@@ -378,7 +378,7 @@ void He3TubeEfficiency::execEvent() {
 
   PARALLEL_FOR_IF(Kernel::threadSafe(*m_outputWS))
   for (int i = 0; i < static_cast<int>(numHistograms); ++i) {
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
 
     const auto &det = spectrumInfo.detector(i);
     if (spectrumInfo.isMonitor(i) || spectrumInfo.isMasked(i)) {
@@ -419,9 +419,9 @@ void He3TubeEfficiency::execEvent() {
       interruption_point();
     }
 
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   }
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
 
   m_outputWS->clearMRU();
 

--- a/Framework/Algorithms/src/HyspecScharpfCorrection.cpp
+++ b/Framework/Algorithms/src/HyspecScharpfCorrection.cpp
@@ -109,7 +109,7 @@ void HyspecScharpfCorrection::exec() {
   API::Progress prog(this, 0.0, 1.0, numberOfSpectra);
   PARALLEL_FOR_IF(Kernel::threadSafe(*m_inputWS, *m_outputWS))
   for (int64_t i = 0; i < numberOfSpectra; ++i) {
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
     auto &yOut = m_outputWS->mutableY(i);
     auto &eOut = m_outputWS->mutableE(i);
 
@@ -138,9 +138,9 @@ void HyspecScharpfCorrection::exec() {
       yOut[j] = yIn[j] * factor;
       eOut[j] = eIn[j] * factor;
     }
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   } // end for i
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
   this->setProperty("OutputWorkspace", m_outputWS);
 }
 
@@ -168,7 +168,7 @@ void HyspecScharpfCorrection::execEvent() {
   API::Progress prog(this, 0.0, 1.0, numberOfSpectra);
   PARALLEL_FOR_IF(Kernel::threadSafe(*m_inputWS, *m_outputWS))
   for (int64_t i = 0; i < numberOfSpectra; ++i) {
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
     prog.report();
     // continue if no detectors, if monitor, or is masked
     if ((!spectrumInfo.hasDetectors(i)) || spectrumInfo.isMonitor(i) || spectrumInfo.isMasked(i)) {
@@ -194,9 +194,9 @@ void HyspecScharpfCorrection::execEvent() {
       ScharpfEventHelper(evlist.getWeightedEventsNoTime(), thPlane);
       break;
     }
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   } // end for i
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
 }
 
 template <class T> void HyspecScharpfCorrection::ScharpfEventHelper(std::vector<T> &wevector, double thPlane) {

--- a/Framework/Algorithms/src/IntegrateByComponent.cpp
+++ b/Framework/Algorithms/src/IntegrateByComponent.cpp
@@ -80,7 +80,7 @@ void IntegrateByComponent::exec() {
 
       PARALLEL_FOR_IF(Kernel::threadSafe(*integratedWS))
       for (int i = 0; i < static_cast<int>(hists.size()); ++i) { // NOLINT
-        PARALLEL_START_INTERUPT_REGION
+        PARALLEL_START_INTERRUPT_REGION
 
         if (spectrumInfo.isMonitor(hists[i]))
           continue;
@@ -99,9 +99,9 @@ void IntegrateByComponent::exec() {
           averageEInput.emplace_back(eValue * eValue);
         }
 
-        PARALLEL_END_INTERUPT_REGION
+        PARALLEL_END_INTERRUPT_REGION
       }
-      PARALLEL_CHECK_INTERUPT_REGION
+      PARALLEL_CHECK_INTERRUPT_REGION
 
       double averageY, averageE;
       if (averageYInput.empty()) {
@@ -115,7 +115,7 @@ void IntegrateByComponent::exec() {
 
       PARALLEL_FOR_IF(Kernel::threadSafe(*integratedWS))
       for (int i = 0; i < static_cast<int>(hists.size()); ++i) { // NOLINT
-        PARALLEL_START_INTERUPT_REGION
+        PARALLEL_START_INTERRUPT_REGION
         if (spectrumInfo.isMonitor(hists[i]))
           continue;
         if (spectrumInfo.isMasked(hists[i]))
@@ -132,9 +132,9 @@ void IntegrateByComponent::exec() {
           integratedWS->dataE(hists[i])[0] = averageE;
         }
 
-        PARALLEL_END_INTERUPT_REGION
+        PARALLEL_END_INTERRUPT_REGION
       }
-      PARALLEL_CHECK_INTERUPT_REGION
+      PARALLEL_CHECK_INTERRUPT_REGION
     }
   }
   // Assign it to the output workspace property

--- a/Framework/Algorithms/src/Integration.cpp
+++ b/Framework/Algorithms/src/Integration.cpp
@@ -155,7 +155,7 @@ void Integration::exec() {
   // Loop over spectra
   PARALLEL_FOR_IF(Kernel::threadSafe(*localworkspace, *outputWorkspace))
   for (int i = minWsIndex; i <= maxWsIndex; ++i) {
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
     // Workspace index on the output
     const int outWI = i - minWsIndex;
 
@@ -200,9 +200,9 @@ void Integration::exec() {
     integrateSpectrum(inSpec, outSpec, Fin, Fout, lowerLimit, upperLimit, incPartBins);
 
     progress.report();
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   }
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
 
   if (rebinned_output) {
     rebinned_output->finalize(false);

--- a/Framework/Algorithms/src/LorentzCorrection.cpp
+++ b/Framework/Algorithms/src/LorentzCorrection.cpp
@@ -125,7 +125,7 @@ void LorentzCorrection::processTOF_SCD(MatrixWorkspace_sptr &wksp, Progress &pro
 
   PARALLEL_FOR_IF(Kernel::threadSafe(*wksp))
   for (int64_t i = 0; i < numHistos; ++i) {
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
 
     if (!spectrumInfo.hasDetectors(i))
       continue;
@@ -151,9 +151,9 @@ void LorentzCorrection::processTOF_SCD(MatrixWorkspace_sptr &wksp, Progress &pro
 
     prog.report();
 
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   }
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
 }
 
 void LorentzCorrection::processTOF_PD(MatrixWorkspace_sptr &wksp, Progress &prog) {
@@ -165,7 +165,7 @@ void LorentzCorrection::processTOF_PD(MatrixWorkspace_sptr &wksp, Progress &prog
 
   PARALLEL_FOR_IF(Kernel::threadSafe(*wksp))
   for (int64_t i = 0; i < numHistos; ++i) {
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
 
     if (!spectrumInfo.hasDetectors(i))
       continue;
@@ -189,9 +189,9 @@ void LorentzCorrection::processTOF_PD(MatrixWorkspace_sptr &wksp, Progress &prog
 
     prog.report();
 
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   }
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
 }
 
 } // namespace Mantid::Algorithms

--- a/Framework/Algorithms/src/MaskBins.cpp
+++ b/Framework/Algorithms/src/MaskBins.cpp
@@ -125,12 +125,12 @@ void MaskBins::execEvent() {
   PARALLEL_FOR_IF(Kernel::threadSafe(*outputWS))
   for (int i = 0; i < static_cast<int>(indexSet.size()); // NOLINT
        ++i) {
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
     outputWS->getSpectrum(indexSet[i]).maskTof(m_startX, m_endX);
     progress.report();
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   }
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
 
   outputWS->clearMRU();
 }

--- a/Framework/Algorithms/src/MaskBinsIf.cpp
+++ b/Framework/Algorithms/src/MaskBinsIf.cpp
@@ -96,7 +96,7 @@ void MaskBinsIf::exec() {
   auto progress = std::make_unique<Progress>(this, 0., 1., numberHistograms);
   PARALLEL_FOR_IF(Mantid::Kernel::threadSafe(*outputWorkspace))
   for (int64_t index = 0; index < numberHistograms; ++index) {
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
     double y, e, x, dx;
     double s = spectrumOrNumeric ? verticalAxis->getValue(index) : 0.;
     mu::Parser parser = makeParser(y, e, x, dx, s, criterion);
@@ -113,9 +113,9 @@ void MaskBinsIf::exec() {
       }
     }
     progress->report();
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   }
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
   setProperty("OutputWorkspace", outputWorkspace);
 }
 

--- a/Framework/Algorithms/src/MaxMin.cpp
+++ b/Framework/Algorithms/src/MaxMin.cpp
@@ -93,7 +93,7 @@ void MaxMin::exec() {
   PARALLEL_FOR_IF(Kernel::threadSafe(*localworkspace, *outputWorkspace))
   // Loop over spectra
   for (int i = MinSpec; i <= MaxSpec; ++i) {
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
     int newindex = i - MinSpec;
     // Copy over spectrum and detector number info
     outputWorkspace->getSpectrum(newindex).copyInfoFrom(localworkspace->getSpectrum(i));
@@ -139,9 +139,9 @@ void MaxMin::exec() {
     outputWorkspace->mutableX(newindex)[1] = *(X.begin() + d + 1); // This is safe since X is of dimension Y+1
     outputWorkspace->mutableY(newindex)[0] = *maxY;
     progress.report();
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   }
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
 
   // Assign it to the output workspace property
   setProperty("OutputWorkspace", outputWorkspace);

--- a/Framework/Algorithms/src/MedianDetectorTest.cpp
+++ b/Framework/Algorithms/src/MedianDetectorTest.cpp
@@ -259,7 +259,7 @@ int MedianDetectorTest::maskOutliers(const std::vector<double> &medianvec, const
         }
       }
     }
-    PARALLEL_CHECK_INTERUPT_REGION
+    PARALLEL_CHECK_INTERRUPT_REGION
   }
 
   return numFailed;
@@ -309,7 +309,7 @@ int MedianDetectorTest::doDetectorTests(const API::MatrixWorkspace_sptr &countsW
     g_log.debug() << "new component with " << nhist << " spectra.\n";
     for (size_t i = 0; i < nhist; ++i) {
       g_log.debug() << "Counts workspace index=" << i << ", Mask workspace index=" << hists.at(i) << '\n';
-      PARALLEL_START_INTERUPT_REGION
+      PARALLEL_START_INTERRUPT_REGION
       ++steps;
       // update the progressbar information
       if (steps % progStep == 0) {
@@ -346,9 +346,9 @@ int MedianDetectorTest::doDetectorTests(const API::MatrixWorkspace_sptr &countsW
         ++numFailed;
       }
 
-      PARALLEL_END_INTERUPT_REGION
+      PARALLEL_END_INTERRUPT_REGION
     }
-    PARALLEL_CHECK_INTERUPT_REGION
+    PARALLEL_CHECK_INTERRUPT_REGION
 
     // Log finds
     g_log.information() << numFailed << " spectra failed the median tests.\n";

--- a/Framework/Algorithms/src/ModeratorTzero.cpp
+++ b/Framework/Algorithms/src/ModeratorTzero.cpp
@@ -117,7 +117,7 @@ void ModeratorTzero::exec() {
   PARALLEL_FOR_IF(Kernel::threadSafe(*inputWS, *outputWS))
   // iterate over the spectra
   for (int i = 0; i < static_cast<int>(numHists); ++i) {
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
     outputWS->setHistogram(i, inputWS->histogram(i));
 
     // One parser for each parallel processor needed (except Edirect mode)
@@ -189,9 +189,9 @@ void ModeratorTzero::exec() {
     }   // end of if(L2 >= 0)
 
     prog.report();
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   } // end of for (int i = 0; i < static_cast<int>(numHists); ++i)
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
 
   // Copy units
   if (inputWS->getAxis(0)->unit().get()) {
@@ -239,7 +239,7 @@ void ModeratorTzero::execEvent(const std::string &emode) {
   Progress prog(this, 0.0, 1.0, numHists); // report progress of algorithm
   PARALLEL_FOR_IF(Kernel::threadSafe(*outputWS))
   for (int i = 0; i < static_cast<int>(numHists); ++i) {
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
     auto wsIndex = static_cast<size_t>(i);
     EventList &evlist = outputWS->getSpectrum(wsIndex);
     if (evlist.getNumberEvents() > 0) // don't bother with empty lists
@@ -344,9 +344,9 @@ void ModeratorTzero::execEvent(const std::string &emode) {
       }   // end of if(L2 >= 0)
     }     // end of if (evlist.getNumberEvents() > 0)
     prog.report();
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   } // end of for (int i = 0; i < static_cast<int>(numHists); ++i)
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
   outputWS->clearMRU(); // Clears the Most Recent Used lists */
 } // end of void ModeratorTzero::execEvent()
 

--- a/Framework/Algorithms/src/ModeratorTzeroLinear.cpp
+++ b/Framework/Algorithms/src/ModeratorTzeroLinear.cpp
@@ -146,7 +146,7 @@ void ModeratorTzeroLinear::exec() {
   Progress prog(this, 0.0, 1.0, numHists); // report progress of algorithm
   PARALLEL_FOR_IF(Kernel::threadSafe(*inputWS, *outputWS))
   for (int i = 0; i < static_cast<int>(numHists); ++i) {
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
     double t_f, L_i;
     auto wsIndex = static_cast<size_t>(i);
     calculateTfLi(spectrumInfo, wsIndex, t_f, L_i);
@@ -162,9 +162,9 @@ void ModeratorTzeroLinear::exec() {
       outbins += offset;
     }
     prog.report();
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   }
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
 
   // Copy units
   if (inputWS->getAxis(0)->unit()) {
@@ -202,7 +202,7 @@ void ModeratorTzeroLinear::execEvent() {
   PARALLEL_FOR_IF(Kernel::threadSafe(*outputWS))
   for (int i = 0; i < static_cast<int>(numHists); ++i) {
     auto wsIndex = static_cast<size_t>(i);
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
     EventList &evlist = outputWS->getSpectrum(wsIndex);
     if (evlist.getNumberEvents() > 0) // don't bother with empty lists
     {
@@ -217,9 +217,9 @@ void ModeratorTzeroLinear::execEvent() {
       }
     }
     prog.report();
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   }
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
   outputWS->clearMRU(); // Clears the Most Recent Used lists */
 } // end of void ModeratorTzeroLinear::execEvent()
 

--- a/Framework/Algorithms/src/MonitorEfficiencyCorUser.cpp
+++ b/Framework/Algorithms/src/MonitorEfficiencyCorUser.cpp
@@ -80,13 +80,13 @@ void MonitorEfficiencyCorUser::exec() {
   double factor = 1 / eff0;
   PARALLEL_FOR_IF(Kernel::threadSafe(*m_outputWS, *m_inputWS))
   for (int64_t i = 0; i < numberOfSpectra_i; ++i) {
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
     m_outputWS->setHistogram(i, m_inputWS->histogram(i) * factor);
 
     prog.report("Detector Efficiency correction...");
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   } // end for i
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
 
   setProperty("OutputWorkspace", m_outputWS);
 }

--- a/Framework/Algorithms/src/MonteCarloAbsorption.cpp
+++ b/Framework/Algorithms/src/MonteCarloAbsorption.cpp
@@ -323,7 +323,7 @@ MatrixWorkspace_uptr MonteCarloAbsorption::doSimulation(const MatrixWorkspace &i
 
   PARALLEL_FOR_IF(Kernel::threadSafe(simulationWS))
   for (int64_t i = 0; i < nhists; ++i) {
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
 
     auto &outE = simulationWS.mutableE(i);
     // The input was cloned so clear the errors out
@@ -386,9 +386,9 @@ MatrixWorkspace_uptr MonteCarloAbsorption::doSimulation(const MatrixWorkspace &i
 
     prog.report(reportMsg);
 
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   }
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
 
   if (useSparseInstrument) {
     interpolateFromSparse(*outputWS, *sparseWS, interpolateOpt);
@@ -448,7 +448,7 @@ void MonteCarloAbsorption::interpolateFromSparse(MatrixWorkspace &targetWS, cons
   const auto refFrame = targetWS.getInstrument()->getReferenceFrame();
   PARALLEL_FOR_IF(Kernel::threadSafe(targetWS, sparseWS))
   for (int64_t i = 0; i < static_cast<decltype(i)>(spectrumInfo.size()); ++i) {
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
     if (spectrumInfo.hasDetectors(i)) {
       double lat, lon;
       std::tie(lat, lon) = spectrumInfo.geographicalAngles(i);
@@ -461,8 +461,8 @@ void MonteCarloAbsorption::interpolateFromSparse(MatrixWorkspace &targetWS, cons
         targetWS.mutableY(i) = spatiallyInterpHisto.y().front();
       }
     }
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   }
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
 }
 } // namespace Mantid::Algorithms

--- a/Framework/Algorithms/src/MultipleScatteringCorrection.cpp
+++ b/Framework/Algorithms/src/MultipleScatteringCorrection.cpp
@@ -296,7 +296,7 @@ void MultipleScatteringCorrection::calculateSingleComponent(const API::MatrixWor
   // -- loop over the spectra/detectors
   PARALLEL_FOR_IF(Kernel::threadSafe(*m_inputWS, *outws))
   for (int64_t workspaceIndex = 0; workspaceIndex < numHists; ++workspaceIndex) {
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
     // locate the spectrum and its detector
     if (!spectrumInfo.hasDetectors(workspaceIndex)) {
       g_log.information() << "Spectrum " << workspaceIndex << " does not have a detector defined for it\n";
@@ -352,9 +352,9 @@ void MultipleScatteringCorrection::calculateSingleComponent(const API::MatrixWor
 
     prog.report();
 
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   }
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
 
   g_log.notice() << "finished integration.\n";
 }
@@ -472,7 +472,7 @@ void MultipleScatteringCorrection::calculateSampleAndContainer(const API::Matrix
   // -- loop over the spectra/detectors
   PARALLEL_FOR_IF(Kernel::threadSafe(*m_inputWS, *outws))
   for (int64_t workspaceIndex = 0; workspaceIndex < numHists; ++workspaceIndex) {
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
     // locate the spectrum and its detector
     if (!spectrumInfo.hasDetectors(workspaceIndex)) {
       g_log.information() << "Spectrum " << workspaceIndex << " does not have a detector defined for it\n";
@@ -538,9 +538,9 @@ void MultipleScatteringCorrection::calculateSampleAndContainer(const API::Matrix
       outws->setHistogram(workspaceIndex, histNew);
     }
     prog.report();
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   }
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
   g_log.notice() << "finished integration.\n";
 }
 
@@ -641,7 +641,7 @@ void MultipleScatteringCorrection::calculateL12s(const MultipleScatteringCorrect
 
   PARALLEL_FOR_IF(Kernel::threadSafe(*m_inputWS))
   for (int64_t indexTo = 0; indexTo < numVolumeElements; ++indexTo) {
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
 
     const auto posTo = distGraber.m_elementPositions[indexTo];
     Track track(posTo, V3D{0, 0, 1}); // take object creation out of the loop
@@ -670,9 +670,9 @@ void MultipleScatteringCorrection::calculateL12s(const MultipleScatteringCorrect
       L12s[idx] = checkzero(rayLengthOne1 - rayLengthOne2);
     }
 
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   }
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
 }
 
 void MultipleScatteringCorrection::calculateL12s(const MultipleScatteringCorrectionDistGraber &distGraberContainer, //
@@ -700,7 +700,7 @@ void MultipleScatteringCorrection::calculateL12s(const MultipleScatteringCorrect
 
   PARALLEL_FOR_IF(Kernel::threadSafe(*m_inputWS))
   for (int64_t indexTo = 0; indexTo < numVolumeElements; ++indexTo) {
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
     // find the position of first scattering element (container or sample)
     const auto posTo = indexTo < numVolumeElementsContainer
                            ? distGraberContainer.m_elementPositions[indexTo]
@@ -732,9 +732,9 @@ void MultipleScatteringCorrection::calculateL12s(const MultipleScatteringCorrect
       L12sContainer[idx] = checkzero(rayLen1_container - rayLen2_container);
       L12sSample[idx] = checkzero(rayLen1_sample - rayLen2_sample);
     }
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   }
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
 }
 
 /**

--- a/Framework/Algorithms/src/MultiplyRange.cpp
+++ b/Framework/Algorithms/src/MultiplyRange.cpp
@@ -79,7 +79,7 @@ void MultiplyRange::exec() {
   // Loop over spectra
   PARALLEL_FOR_IF(Kernel::threadSafe(*inputWS, *outputWS))
   for (int i = 0; i < histogramCount; ++i) {
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
     outputWS->setHistogram(i, inputWS->histogram(i));
     auto &newY = outputWS->mutableY(i);
     auto &newE = outputWS->mutableE(i);
@@ -92,9 +92,9 @@ void MultiplyRange::exec() {
                    std::bind(std::multiplies<double>(), _1, factor));
 
     progress.report();
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   }
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
 }
 
 } // namespace Mantid::Algorithms

--- a/Framework/Algorithms/src/NormaliseByDetector.cpp
+++ b/Framework/Algorithms/src/NormaliseByDetector.cpp
@@ -165,11 +165,11 @@ MatrixWorkspace_sptr NormaliseByDetector::processHistograms(const MatrixWorkspac
   if (m_parallelExecution) {
     PARALLEL_FOR_IF(Kernel::threadSafe(*inWS, *denominatorWS))
     for (int wsIndex = 0; wsIndex < static_cast<int>(nHistograms); ++wsIndex) {
-      PARALLEL_START_INTERUPT_REGION
+      PARALLEL_START_INTERRUPT_REGION
       this->processHistogram(wsIndex, inWS, denominatorWS, prog);
-      PARALLEL_END_INTERUPT_REGION
+      PARALLEL_END_INTERRUPT_REGION
     }
-    PARALLEL_CHECK_INTERUPT_REGION
+    PARALLEL_CHECK_INTERRUPT_REGION
   } else {
     for (size_t wsIndex = 0; wsIndex < nHistograms; ++wsIndex) {
       this->processHistogram(wsIndex, inWS, denominatorWS, prog);

--- a/Framework/Algorithms/src/NormaliseToMonitor.cpp
+++ b/Framework/Algorithms/src/NormaliseToMonitor.cpp
@@ -591,7 +591,7 @@ void NormaliseToMonitor::performHistogramDivision(const MatrixWorkspace_sptr &in
 
     PARALLEL_FOR_IF(Kernel::threadSafe(*outputWorkspace))
     for (int64_t i = 0; i < int64_t(outputWorkspace->getNumberHistograms()); ++i) {
-      PARALLEL_START_INTERUPT_REGION
+      PARALLEL_START_INTERRUPT_REGION
       const auto &specDef = specInfo.spectrumDefinition(i);
 
       if (!spectrumDefinitionsMatchTimeIndex(specDef, timeIndex))
@@ -607,9 +607,9 @@ void NormaliseToMonitor::performHistogramDivision(const MatrixWorkspace_sptr &in
       }
 
       outputWorkspace->setHistogram(i, hist);
-      PARALLEL_END_INTERUPT_REGION
+      PARALLEL_END_INTERRUPT_REGION
     }
-    PARALLEL_CHECK_INTERUPT_REGION
+    PARALLEL_CHECK_INTERRUPT_REGION
   }
 }
 
@@ -654,7 +654,7 @@ void NormaliseToMonitor::normaliseBinByBin(const MatrixWorkspace_sptr &inputWork
     // Loop over spectra
     PARALLEL_FOR_IF(Kernel::threadSafe(*inputWorkspace, *outputWorkspace, *m_monitor))
     for (int64_t i = 0; i < int64_t(numHists); ++i) {
-      PARALLEL_START_INTERUPT_REGION
+      PARALLEL_START_INTERRUPT_REGION
       prog.report();
 
       const auto &specDef = inputSpecInfo.spectrumDefinition(i);
@@ -720,9 +720,9 @@ void NormaliseToMonitor::normaliseBinByBin(const MatrixWorkspace_sptr &inputWork
         } // end Workspace2D case
       }   // end loop over current spectrum
 
-      PARALLEL_END_INTERUPT_REGION
+      PARALLEL_END_INTERRUPT_REGION
     } // end loop over spectra
-    PARALLEL_CHECK_INTERUPT_REGION
+    PARALLEL_CHECK_INTERRUPT_REGION
 
     if (hasZeroDivision) {
       g_log.warning() << "Division by zero in some of the bins.\n";

--- a/Framework/Algorithms/src/PDCalibration.cpp
+++ b/Framework/Algorithms/src/PDCalibration.cpp
@@ -546,7 +546,7 @@ void PDCalibration::exec() {
 
    PRAGMA_OMP(parallel for schedule(dynamic, 1))
    for (int wkspIndex = 0; wkspIndex < NUMHIST; ++wkspIndex) {
-     PARALLEL_START_INTERUPT_REGION
+     PARALLEL_START_INTERRUPT_REGION
      if ((isEvent && uncalibratedEWS->getSpectrum(wkspIndex).empty()) || !spectrumInfo.hasDetectors(wkspIndex) ||
          spectrumInfo.isMonitor(wkspIndex)) {
        prog.report();
@@ -687,9 +687,9 @@ void PDCalibration::exec() {
      }
      prog.report();
 
-     PARALLEL_END_INTERUPT_REGION
+     PARALLEL_END_INTERRUPT_REGION
    }
-   PARALLEL_CHECK_INTERUPT_REGION
+   PARALLEL_CHECK_INTERRUPT_REGION
 
    // sort the calibration tables by increasing detector ID
    m_calibrationTable = sortTableWorkspace(m_calibrationTable);
@@ -1357,7 +1357,7 @@ PDCalibration::createTOFPeakCenterFitWindowWorkspaces(const API::MatrixWorkspace
 
   PRAGMA_OMP(parallel for schedule(dynamic, 1) )
   for (int64_t iws = 0; iws < static_cast<int64_t>(NUM_HIST); ++iws) {
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
     // calculatePositionWindowInTOF
     PDCalibration::FittedPeaks peaks(dataws, static_cast<size_t>(iws));
     // toTof is a function that converts from d-spacing to TOF for a particular
@@ -1369,9 +1369,9 @@ PDCalibration::createTOFPeakCenterFitWindowWorkspaces(const API::MatrixWorkspace
     peak_window_ws->setPoints(iws, peaks.inTofWindows);
     prog.report();
 
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   }
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
 
   return std::make_pair(peak_pos_ws, peak_window_ws);
 }

--- a/Framework/Algorithms/src/PaalmanPingsAbsorptionCorrection.cpp
+++ b/Framework/Algorithms/src/PaalmanPingsAbsorptionCorrection.cpp
@@ -163,7 +163,7 @@ void PaalmanPingsAbsorptionCorrection::exec() {
   // Loop over the spectra
   PARALLEL_FOR_IF(Kernel::threadSafe(*m_inputWS, *ass, *assc, *acc, *acsc))
   for (int64_t i = 0; i < int64_t(numHists); ++i) {
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
     // Copy over bins
     ass->setSharedX(i, m_inputWS->sharedX(i));
     assc->setSharedX(i, m_inputWS->sharedX(i));
@@ -247,9 +247,9 @@ void PaalmanPingsAbsorptionCorrection::exec() {
 
     prog.report();
 
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   }
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
 
   g_log.information() << "Total number of elements in the integration was " << m_sampleL1s.size() << '\n';
 

--- a/Framework/Algorithms/src/PaddingAndApodization.cpp
+++ b/Framework/Algorithms/src/PaddingAndApodization.cpp
@@ -92,7 +92,7 @@ void PaddingAndApodization::exec() {
     // Copy all the Y and E data
     PARALLEL_FOR_IF(Kernel::threadSafe(*inputWS, *outputWS))
     for (int64_t i = 0; i < int64_t(numSpectra); ++i) {
-      PARALLEL_START_INTERUPT_REGION
+      PARALLEL_START_INTERRUPT_REGION
 
       if (std::find(spectra.begin(), spectra.end(), i) != spectra.end()) {
         const auto index = static_cast<size_t>(i);
@@ -100,9 +100,9 @@ void PaddingAndApodization::exec() {
         outputWS->setSharedE(index, inputWS->sharedE(index));
       }
       prog.report();
-      PARALLEL_END_INTERUPT_REGION
+      PARALLEL_END_INTERRUPT_REGION
     }
-    PARALLEL_CHECK_INTERUPT_REGION
+    PARALLEL_CHECK_INTERRUPT_REGION
   }
   const std::string method = getProperty("ApodizationFunction");
   const double decayConstant = getProperty("DecayConstant");
@@ -112,7 +112,7 @@ void PaddingAndApodization::exec() {
   auto specLength = static_cast<int>(spectra.size());
   PARALLEL_FOR_IF(Kernel::threadSafe(*inputWS, *outputWS))
   for (int i = 0; i < specLength; ++i) {
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
     const auto specNum = static_cast<size_t>(spectra[i]);
 
     if (spectra[i] > static_cast<int>(numSpectra)) {
@@ -123,9 +123,9 @@ void PaddingAndApodization::exec() {
     outputWS->setHistogram(specNum, applyApodizationFunction(addPadding(inputWS->histogram(specNum), padding),
                                                              decayConstant, apodizationFunction));
     prog.report();
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   }
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
   setProperty("OutputWorkspace", outputWS);
 }
 

--- a/Framework/Algorithms/src/PointByPointVCorrection.cpp
+++ b/Framework/Algorithms/src/PointByPointVCorrection.cpp
@@ -59,7 +59,7 @@ void PointByPointVCorrection::exec() {
   PARALLEL_FOR_IF(Kernel::threadSafe(*inputWS1, *inputWS2, *outputWS))
   for (int i = 0; i < nHist; i++) // Looping on all histograms
   {
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
 
     outputWS->setSharedX(i, inputWS1->sharedX(i));
 
@@ -131,9 +131,9 @@ void PointByPointVCorrection::exec() {
     check_masks(inputWS1, inputWS2, i);
 
     prog.report();
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   }
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
 
   outputWS->setYUnitLabel("Counts normalised to a vanadium");
   outputWS->setDistribution(false);

--- a/Framework/Algorithms/src/Q1D2.cpp
+++ b/Framework/Algorithms/src/Q1D2.cpp
@@ -155,7 +155,7 @@ void Q1D2::exec() {
   const auto &spectrumInfo = m_dataWS->spectrumInfo();
   PARALLEL_FOR_IF(Kernel::threadSafe(*m_dataWS, *outputWS, pixelAdj.get()))
   for (int i = 0; i < numSpec; ++i) {
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
     if (!spectrumInfo.hasDetectors(i)) {
       g_log.warning() << "Workspace index " << i << " (SpectrumIndex = " << m_dataWS->getSpectrum(i).getSpectrumNo()
                       << ") has no detector assigned to it - discarding\n";
@@ -251,9 +251,9 @@ void Q1D2::exec() {
       outSpec.addDetectorIDs(inSpec.getDetectorIDs());
     }
 
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   }
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
 
   if (communicator().size() > 1) {
     int tag = 0;

--- a/Framework/Algorithms/src/Q1DWeighted.cpp
+++ b/Framework/Algorithms/src/Q1DWeighted.cpp
@@ -368,7 +368,7 @@ void Q1DWeighted::calculate(const MatrixWorkspace_const_sptr &inputWS) {
   PARALLEL_FOR_IF(Kernel::threadSafe(*inputWS))
   // first we loop over spectra
   for (int index = 0; index < static_cast<int>(m_nSpec); ++index) {
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
     const auto i = static_cast<size_t>(index);
     // skip spectra with no detectors, monitors or masked spectra
     if (!spectrumInfo.hasDetectors(i) || spectrumInfo.isMonitor(i) || spectrumInfo.isMasked(i)) {
@@ -483,9 +483,9 @@ void Q1DWeighted::calculate(const MatrixWorkspace_const_sptr &inputWS) {
       }
       progress.report("Computing I(Q)");
     }
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   }
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
 }
 
 /**
@@ -544,15 +544,15 @@ void Q1DWeighted::fillMonochromaticOutput(MatrixWorkspace_sptr &outputWS, const 
 
     PARALLEL_FOR_IF(Kernel::threadSafe(*outputWS))
     for (int iq = 0; iq < static_cast<int>(m_nQ); ++iq) {
-      PARALLEL_START_INTERUPT_REGION
+      PARALLEL_START_INTERRUPT_REGION
       const double norm = m_normalisation[iout][iSample][iq];
       if (norm != 0.) {
         YOut[iq] = m_intensities[iout][iSample][iq] / norm;
         EOut[iq] = m_errors[iout][iSample][iq] / (norm * norm);
       }
-      PARALLEL_END_INTERUPT_REGION
+      PARALLEL_END_INTERRUPT_REGION
     }
-    PARALLEL_CHECK_INTERUPT_REGION
+    PARALLEL_CHECK_INTERRUPT_REGION
   }
 }
 
@@ -571,16 +571,16 @@ void Q1DWeighted::fillTOFOutput(MatrixWorkspace_sptr &outputWS, const size_t iou
   for (size_t il = 0; il < m_nBins; ++il) {
     PARALLEL_FOR_IF(Kernel::threadSafe(*outputWS))
     for (int iq = 0; iq < static_cast<int>(m_nQ); ++iq) {
-      PARALLEL_START_INTERUPT_REGION
+      PARALLEL_START_INTERRUPT_REGION
       const double norm = m_normalisation[iout][il][iq];
       if (norm != 0.) {
         YOut[iq] += m_intensities[iout][il][iq] / norm;
         EOut[iq] += m_errors[iout][il][iq] / (norm * norm);
         normLambda[iq] += 1.;
       }
-      PARALLEL_END_INTERUPT_REGION
+      PARALLEL_END_INTERRUPT_REGION
     }
-    PARALLEL_CHECK_INTERUPT_REGION
+    PARALLEL_CHECK_INTERRUPT_REGION
   }
 
   for (size_t i = 0; i < m_nQ; ++i) {

--- a/Framework/Algorithms/src/Rebin.cpp
+++ b/Framework/Algorithms/src/Rebin.cpp
@@ -223,7 +223,7 @@ void Rebin::exec() {
       // Go through all the histograms and set the data
       PARALLEL_FOR_IF(Kernel::threadSafe(*inputWS, *outputWS))
       for (int i = 0; i < histnumber; ++i) {
-        PARALLEL_START_INTERUPT_REGION
+        PARALLEL_START_INTERRUPT_REGION
         // Get a const event list reference. eventInputWS->dataY() doesn't work.
         const EventList &el = eventInputWS->getSpectrum(i);
         MantidVec y_data, e_data;
@@ -236,9 +236,9 @@ void Rebin::exec() {
 
         // Report progress
         prog.report(name());
-        PARALLEL_END_INTERUPT_REGION
+        PARALLEL_END_INTERRUPT_REGION
       }
-      PARALLEL_CHECK_INTERUPT_REGION
+      PARALLEL_CHECK_INTERRUPT_REGION
 
       // Copy all the axes
       for (int i = 1; i < inputWS->axes(); i++) {
@@ -283,7 +283,7 @@ void Rebin::exec() {
     Progress prog(this, 0.0, 1.0, histnumber);
     PARALLEL_FOR_IF(Kernel::threadSafe(*inputWS, *outputWS))
     for (int hist = 0; hist < histnumber; ++hist) {
-      PARALLEL_START_INTERUPT_REGION
+      PARALLEL_START_INTERRUPT_REGION
 
       try {
         outputWS->setHistogram(hist, HistogramData::rebin(inputWS->histogram(hist), XValues_new));
@@ -294,9 +294,9 @@ void Rebin::exec() {
           throw;
       }
       prog.report(name());
-      PARALLEL_END_INTERUPT_REGION
+      PARALLEL_END_INTERRUPT_REGION
     }
-    PARALLEL_CHECK_INTERUPT_REGION
+    PARALLEL_CHECK_INTERRUPT_REGION
     outputWS->setDistribution(dist);
 
     // Now propagate any masking correctly to the output workspace

--- a/Framework/Algorithms/src/Rebin2D.cpp
+++ b/Framework/Algorithms/src/Rebin2D.cpp
@@ -115,7 +115,7 @@ void Rebin2D::exec() {
 
   PARALLEL_FOR_IF(Kernel::threadSafe(*inputWS, *outputWS))
   for (int64_t i = 0; i < static_cast<int64_t>(numYBins); ++i) {
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
 
     m_progress->report("Computing polygon intersections");
     const double vlo = oldYEdges[i];
@@ -133,9 +133,9 @@ void Rebin2D::exec() {
       }
     }
 
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   }
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
   if (useFractionalArea) {
     FractionalRebinning::finalizeFractionalRebin(*outputRB);
     outputRB->finalize(true);

--- a/Framework/Algorithms/src/RebinByPulseTimes.cpp
+++ b/Framework/Algorithms/src/RebinByPulseTimes.cpp
@@ -50,7 +50,7 @@ void RebinByPulseTimes::doHistogramming(IEventWorkspace_sptr inWS, MatrixWorkspa
 
   PARALLEL_FOR_IF(Kernel::threadSafe(*inWS, *outputWS))
   for (int i = 0; i < histnumber; ++i) {
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
 
     const auto &el = inWS->getSpectrum(i);
     MantidVec y_data, e_data;
@@ -66,9 +66,9 @@ void RebinByPulseTimes::doHistogramming(IEventWorkspace_sptr inWS, MatrixWorkspa
 
     // Report progress
     prog.report(name());
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   }
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
 }
 
 /**

--- a/Framework/Algorithms/src/RebinByTimeAtSample.cpp
+++ b/Framework/Algorithms/src/RebinByTimeAtSample.cpp
@@ -64,7 +64,7 @@ void RebinByTimeAtSample::doHistogramming(IEventWorkspace_sptr inWS, MatrixWorks
   // Go through all the histograms and set the data
   PARALLEL_FOR_IF(Kernel::threadSafe(*inWS, *outputWS))
   for (int i = 0; i < histnumber; ++i) {
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
 
     Correction correction = strategy.calculate(i);
 
@@ -84,9 +84,9 @@ void RebinByTimeAtSample::doHistogramming(IEventWorkspace_sptr inWS, MatrixWorks
 
     // Report progress
     prog.report(name());
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   }
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
 }
 
 /**

--- a/Framework/Algorithms/src/RebinToWorkspace.cpp
+++ b/Framework/Algorithms/src/RebinToWorkspace.cpp
@@ -124,7 +124,7 @@ void RebinToWorkspace::rebin(MatrixWorkspace_sptr &toRebin, MatrixWorkspace_sptr
   // rebin
   PARALLEL_FOR_IF(Kernel::threadSafe(*toMatch, *outputWS))
   for (int i = 0; i < numHist; ++i) {
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
     const auto &edges = matchingX ? toMatch->histogram(0).binEdges() : toMatch->histogram(i).binEdges();
     if (m_isEvents) {
       outputWSEvents->getSpectrum(i).setHistogram(edges);
@@ -132,9 +132,9 @@ void RebinToWorkspace::rebin(MatrixWorkspace_sptr &toRebin, MatrixWorkspace_sptr
       outputWS->setHistogram(i, HistogramData::rebin(toRebin->histogram(i), edges));
     }
     prog.report();
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   }
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
 
   setProperty("OutputWorkspace", outputWS);
 }
@@ -153,7 +153,7 @@ void RebinToWorkspace::histogram(API::MatrixWorkspace_sptr &toRebin, API::Matrix
   // histogram
   PARALLEL_FOR_IF(Kernel::threadSafe(*toMatch, *outputWS))
   for (int i = 0; i < numHist; ++i) {
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
     const auto &edges = matchingX ? toMatch->histogram(0).binEdges() : toMatch->histogram(i).binEdges();
 
     // TODO this should be in HistogramData/Rebin
@@ -163,9 +163,9 @@ void RebinToWorkspace::histogram(API::MatrixWorkspace_sptr &toRebin, API::Matrix
 
     outputWS->setHistogram(i, edges, Counts(std::move(y_data)), CountStandardDeviations(std::move(e_data)));
     prog.report();
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   }
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
 
   setProperty("OutputWorkspace", std::move(outputWS));
 }

--- a/Framework/Algorithms/src/Rebunch.cpp
+++ b/Framework/Algorithms/src/Rebunch.cpp
@@ -84,7 +84,7 @@ void Rebunch::exec() {
     progress_step = 1;
   PARALLEL_FOR_IF(Kernel::threadSafe(*inputW, *outputW))
   for (int hist = 0; hist < histnumber; hist++) {
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
     // output data arrays are implicitly filled by function
     if (point) {
       rebunch_point(inputW->x(hist), inputW->y(hist), inputW->e(hist), outputW->mutableX(hist), outputW->mutableY(hist),
@@ -101,9 +101,9 @@ void Rebunch::exec() {
       progress(double(hist) / histnumber);
       interruption_point();
     }
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   }
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
   outputW->setDistribution(dist);
 
   // Copy units

--- a/Framework/Algorithms/src/RemoveBackground.cpp
+++ b/Framework/Algorithms/src/RemoveBackground.cpp
@@ -120,7 +120,7 @@ void RemoveBackground::exec() {
   Progress prog(this, 0.0, 1.0, histnumber);
   PARALLEL_FOR_IF(Kernel::threadSafe(*inputWS, *outputWS))
   for (int hist = 0; hist < histnumber; ++hist) {
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
     // get references to output Workspace X-arrays.
     auto &XValues = outputWS->mutableX(hist);
     // get references to output workspace data and error. If it is new
@@ -133,9 +133,9 @@ void RemoveBackground::exec() {
     m_BackgroundHelper.removeBackground(hist, XValues, YValues, YErrors, id);
 
     prog.report(name());
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   }
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
   // Assign it to the output workspace property
   setProperty("OutputWorkspace", outputWS);
 }

--- a/Framework/Algorithms/src/ResampleX.cpp
+++ b/Framework/Algorithms/src/ResampleX.cpp
@@ -338,16 +338,16 @@ void ResampleX::exec() {
         // do the rebinning
         PARALLEL_FOR_IF(Kernel::threadSafe(*inputEventWS, *outputWS))
         for (int wkspIndex = 0; wkspIndex < numSpectra; ++wkspIndex) {
-          PARALLEL_START_INTERUPT_REGION
+          PARALLEL_START_INTERRUPT_REGION
           BinEdges xValues(0);
           const double delta = this->determineBinning(xValues.mutableRawData(), xmins[wkspIndex], xmaxs[wkspIndex]);
           g_log.debug() << "delta[wkspindex=" << wkspIndex << "] = " << delta << " xmin=" << xmins[wkspIndex]
                         << " xmax=" << xmaxs[wkspIndex] << "\n";
           outputEventWS->setHistogram(wkspIndex, xValues);
           prog.report(name()); // Report progress
-          PARALLEL_END_INTERUPT_REGION
+          PARALLEL_END_INTERRUPT_REGION
         }
-        PARALLEL_CHECK_INTERUPT_REGION
+        PARALLEL_CHECK_INTERRUPT_REGION
       }
     }    // end if (m_preserveEvents)
     else // event workspace -> matrix workspace
@@ -362,7 +362,7 @@ void ResampleX::exec() {
       // Go through all the histograms and set the data
       PARALLEL_FOR_IF(Kernel::threadSafe(*inputEventWS, *outputWS))
       for (int wkspIndex = 0; wkspIndex < numSpectra; ++wkspIndex) {
-        PARALLEL_START_INTERUPT_REGION
+        PARALLEL_START_INTERRUPT_REGION
 
         // Set the X axis for each output histogram
         MantidVec xValues;
@@ -382,9 +382,9 @@ void ResampleX::exec() {
 
         // Report progress
         prog.report(name());
-        PARALLEL_END_INTERUPT_REGION
+        PARALLEL_END_INTERRUPT_REGION
       }
-      PARALLEL_CHECK_INTERUPT_REGION
+      PARALLEL_CHECK_INTERRUPT_REGION
 
       // Copy all the axes
       for (int i = 1; i < inputWS->axes(); i++) {
@@ -425,7 +425,7 @@ void ResampleX::exec() {
     Progress prog(this, 0.0, 1.0, numSpectra);
     PARALLEL_FOR_IF(Kernel::threadSafe(*inputWS, *outputWS))
     for (int wkspIndex = 0; wkspIndex < numSpectra; ++wkspIndex) {
-      PARALLEL_START_INTERUPT_REGION
+      PARALLEL_START_INTERRUPT_REGION
       // get const references to input Workspace arrays (no copying)
       // TODO: replace with HistogramX/Y/E when VectorHelper::rebin is updated
       const MantidVec &XValues = inputWS->readX(wkspIndex);
@@ -454,9 +454,9 @@ void ResampleX::exec() {
       outputWS->setBinEdges(wkspIndex, XValues_new);
 
       prog.report(name());
-      PARALLEL_END_INTERUPT_REGION
+      PARALLEL_END_INTERRUPT_REGION
     }
-    PARALLEL_CHECK_INTERUPT_REGION
+    PARALLEL_CHECK_INTERRUPT_REGION
     outputWS->setDistribution(m_isDistribution);
 
     // Now propagate any masking correctly to the output workspace

--- a/Framework/Algorithms/src/ResetNegatives.cpp
+++ b/Framework/Algorithms/src/ResetNegatives.cpp
@@ -89,13 +89,13 @@ void ResetNegatives::exec() {
   outputWS = API::WorkspaceFactory::Instance().create(inputWS);
   PARALLEL_FOR_IF(Kernel::threadSafe(*inputWS, *outputWS))
   for (int64_t i = 0; i < nHist; i++) {
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
     const auto index = static_cast<size_t>(i);
     outputWS->setHistogram(index, inputWS->histogram(index));
     prog.report();
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   }
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
 
   // do the actual work
   if (this->getProperty("AddMinimum")) {
@@ -133,7 +133,7 @@ void ResetNegatives::pushMinimum(const MatrixWorkspace_const_sptr &minWS, const 
   int64_t nHist = minWS->getNumberHistograms();
   PARALLEL_FOR_IF(Kernel::threadSafe(*wksp, *minWS))
   for (int64_t i = 0; i < nHist; i++) {
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
     double minValue = minWS->y(i)[0];
     if (minValue <= 0) {
       minValue *= -1.;
@@ -141,9 +141,9 @@ void ResetNegatives::pushMinimum(const MatrixWorkspace_const_sptr &minWS, const 
       std::transform(y.begin(), y.end(), y.begin(), [minValue](double value) { return fixZero(value + minValue); });
     }
     prog.report();
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   }
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
 }
 
 /**
@@ -161,7 +161,7 @@ void ResetNegatives::changeNegatives(const MatrixWorkspace_const_sptr &minWS, co
   int64_t nHist = wksp->getNumberHistograms();
   PARALLEL_FOR_IF(Kernel::threadSafe(*minWS, *wksp))
   for (int64_t i = 0; i < nHist; i++) {
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
     if (minWS->y(i)[0] <= 0.) // quick check to see if there is a reason to bother
     {
       auto &y = wksp->mutableY(i);
@@ -173,9 +173,9 @@ void ResetNegatives::changeNegatives(const MatrixWorkspace_const_sptr &minWS, co
       }
     }
     prog.report();
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   }
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
 }
 
 } // namespace Mantid::Algorithms

--- a/Framework/Algorithms/src/SampleCorrections/MayersSampleCorrection.cpp
+++ b/Framework/Algorithms/src/SampleCorrections/MayersSampleCorrection.cpp
@@ -114,7 +114,7 @@ void MayersSampleCorrection::exec() {
 
   PARALLEL_FOR_IF(Kernel::threadSafe(*inputWS, *outputWS))
   for (int64_t i = 0; i < static_cast<int64_t>(nhist); ++i) {
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
 
     if (!spectrumInfo.hasDetectors(i) || spectrumInfo.isMonitor(i) || spectrumInfo.isMasked(i) ||
         spectrumInfo.l2(i) == 0) {
@@ -146,9 +146,9 @@ void MayersSampleCorrection::exec() {
     outputWS->setHistogram(i, correction.getCorrectedHisto());
     prog.report();
 
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   }
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
 
   setProperty("OutputWorkspace", outputWS);
 }

--- a/Framework/Algorithms/src/ScaleX.cpp
+++ b/Framework/Algorithms/src/ScaleX.cpp
@@ -122,7 +122,7 @@ void ScaleX::exec() {
   // do the shift in X
   PARALLEL_FOR_IF(Kernel::threadSafe(*inputW, *outputW))
   for (int i = 0; i < histnumber; ++i) {
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
 
     // Copy y and e data
     outputW->setHistogram(i, inputW->histogram(i));
@@ -148,9 +148,9 @@ void ScaleX::exec() {
 
     m_progress->report("Scaling X");
 
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   }
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
 
   // Copy units
   if (outputW->getAxis(0)->unit().get())
@@ -180,7 +180,7 @@ void ScaleX::execEvent() {
   auto numHistograms = static_cast<int>(outputWS->getNumberHistograms());
   PARALLEL_FOR_IF(Kernel::threadSafe(*outputWS))
   for (int i = 0; i < numHistograms; ++i) {
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
     // Do the offsetting
     if ((i >= m_wi_min) && (i <= m_wi_max)) {
       auto factor = getScaleFactor(outputWS, i);
@@ -194,9 +194,9 @@ void ScaleX::execEvent() {
       }
     }
     m_progress->report("Scaling X");
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   }
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
   outputWS->clearMRU();
 }
 

--- a/Framework/Algorithms/src/SetUncertainties.cpp
+++ b/Framework/Algorithms/src/SetUncertainties.cpp
@@ -129,14 +129,14 @@ void SetUncertainties::exec() {
     outputWorkspace = WorkspaceFactory::Instance().create(inputWorkspace);
     PARALLEL_FOR_IF(Kernel::threadSafe(*inputWorkspace, *outputWorkspace))
     for (int64_t i = 0; i < numHists; ++i) {
-      PARALLEL_START_INTERUPT_REGION
+      PARALLEL_START_INTERRUPT_REGION
       // copy  X/Y/E
       outputWorkspace->setSharedX(i, inputWorkspace->sharedX(i));
       outputWorkspace->setSharedY(i, inputWorkspace->sharedY(i));
       outputWorkspace->setSharedE(i, inputWorkspace->sharedE(i));
-      PARALLEL_END_INTERUPT_REGION
+      PARALLEL_END_INTERRUPT_REGION
     }
-    PARALLEL_CHECK_INTERUPT_REGION
+    PARALLEL_CHECK_INTERRUPT_REGION
   } else if (inputWorkspace != outputWorkspace) {
     outputWorkspace = inputWorkspace->clone();
   }
@@ -145,7 +145,7 @@ void SetUncertainties::exec() {
   Progress prog(this, 0.0, 1.0, numHists);
   PARALLEL_FOR_IF(Kernel::threadSafe(*inputWorkspace, *outputWorkspace))
   for (int64_t i = 0; i < numHists; ++i) {
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
     // copy the E or set to zero depending on the mode
     if (errorType == ONE_IF_ZERO || customError) {
     } else {
@@ -162,9 +162,9 @@ void SetUncertainties::exec() {
       }
     }
     prog.report();
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   }
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
   setProperty("OutputWorkspace", outputWorkspace);
 }
 

--- a/Framework/Algorithms/src/SmoothData.cpp
+++ b/Framework/Algorithms/src/SmoothData.cpp
@@ -58,7 +58,7 @@ void SmoothData::exec() {
   Progress progress(this, 0.0, 1.0, inputWorkspace->getNumberHistograms());
   PARALLEL_FOR_IF(Kernel::threadSafe(*inputWorkspace, *outputWorkspace))
   for (int i = 0; i < static_cast<int>(inputWorkspace->getNumberHistograms()); ++i) {
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
     int npts = nptsGroup[0];
     if (groupWS) {
       const int group = validateSpectrumInGroup(static_cast<size_t>(i));
@@ -86,9 +86,9 @@ void SmoothData::exec() {
     outputWorkspace->setHistogram(i, smooth(inputWorkspace->histogram(i), npts));
 
     progress.report();
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   } // Loop over spectra
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
 
   // Set the output workspace to its property
   setProperty("OutputWorkspace", outputWorkspace);

--- a/Framework/Algorithms/src/SmoothNeighbours.cpp
+++ b/Framework/Algorithms/src/SmoothNeighbours.cpp
@@ -565,7 +565,7 @@ void SmoothNeighbours::execWorkspace2D() {
   // Go through all the output workspace
   PARALLEL_FOR_IF(Kernel::threadSafe(*inWS, *outWS))
   for (int outWIi = 0; outWIi < int(numberOfSpectra); outWIi++) {
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
 
     auto &outSpec = outWS->getSpectrum(outWIi);
     // Reset the Y and E vectors
@@ -615,9 +615,9 @@ void SmoothNeighbours::execWorkspace2D() {
     // outSpec->copyInfoFrom(*inWS->getSpectrum(outWIi));
 
     m_progress->report("Summing");
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   }
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
   if (expandSumAllPixels)
     spreadPixels(outWS);
 }
@@ -712,7 +712,7 @@ void SmoothNeighbours::execEvent(Mantid::DataObjects::EventWorkspace_sptr &ws) {
   // Go through all the output workspace
   PARALLEL_FOR_IF(Kernel::threadSafe(*ws, *outWS))
   for (int outWIi = 0; outWIi < int(numberOfSpectra); outWIi++) {
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
 
     // Create the output event list (empty)
     EventList &outEL = outWS->getSpectrum(outWIi);
@@ -737,9 +737,9 @@ void SmoothNeighbours::execEvent(Mantid::DataObjects::EventWorkspace_sptr &ws) {
     // if (!sum) outEL.copyInfoFrom(*ws->getSpectrum(outWIi));
 
     m_progress->report("Summing");
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   }
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
 
   // Give the 0-th X bins to all the output spectra.
   outWS->setAllX(inWS->binEdges(0));

--- a/Framework/Algorithms/src/SofQWNormalisedPolygon.cpp
+++ b/Framework/Algorithms/src/SofQWNormalisedPolygon.cpp
@@ -355,7 +355,7 @@ void SofQWNormalisedPolygon::exec() {
 
   PARALLEL_FOR_IF(Kernel::threadSafe(*inputWS, *outputWS))
   for (int64_t i = 0; i < static_cast<int64_t>(nHistos); ++i) {
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
 
     if (spectrumInfo.isMasked(i) || spectrumInfo.isMonitor(i)) {
       continue;
@@ -405,9 +405,9 @@ void SofQWNormalisedPolygon::exec() {
       g_log.debug(logStream.str());
     }
 
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   }
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
 
   FractionalRebinning::finalizeFractionalRebin(*outputWS);
   outputWS->finalize();

--- a/Framework/Algorithms/src/SofQWPolygon.cpp
+++ b/Framework/Algorithms/src/SofQWPolygon.cpp
@@ -62,7 +62,7 @@ void SofQWPolygon::exec() {
   PARALLEL_FOR_IF(Kernel::threadSafe(*inputWS, *outputWS))
   for (int64_t i = 0; i < static_cast<int64_t>(nTheta); ++i) // signed for openmp
   {
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
 
     const double theta = m_thetaPts[i];
     if (theta < 0.0) // One to skip
@@ -106,9 +106,9 @@ void SofQWPolygon::exec() {
       }
     }
 
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   }
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
 
   DataObjects::FractionalRebinning::normaliseOutput(outputWS, inputWS, m_progress.get());
 

--- a/Framework/Algorithms/src/SolidAngle.cpp
+++ b/Framework/Algorithms/src/SolidAngle.cpp
@@ -246,7 +246,7 @@ void SolidAngle::exec() {
   // Loop over the histograms (detector spectra)
   PARALLEL_FOR_IF(Kernel::threadSafe(*outputWS, *inputWS))
   for (int j = m_MinSpec; j <= m_MaxSpec; ++j) {
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
     initSpectrum(*inputWS, *outputWS, j);
     if (spectrumInfo.hasDetectors(j)) {
       double solidAngle = 0.0;
@@ -261,9 +261,9 @@ void SolidAngle::exec() {
       ++failCount;
     }
     prog.report();
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   } // loop over spectra
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
   g_log.warning() << "min max total" << m_MinSpec << " " << m_MaxSpec << " " << numberOfSpectra;
 
   auto &outputSpectrumInfo = outputWS->mutableSpectrumInfo();

--- a/Framework/Algorithms/src/SortXAxis.cpp
+++ b/Framework/Algorithms/src/SortXAxis.cpp
@@ -59,15 +59,15 @@ void SortXAxis::exec() {
 
   PARALLEL_FOR_IF(Kernel::threadSafe(*inputWorkspace, *outputWorkspace))
   for (int specNum = 0u; specNum < (int)inputWorkspace->getNumberHistograms(); specNum++) {
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
     auto workspaceIndices = createIndexes(sizeOfX);
 
     sortIndicesByX(workspaceIndices, getProperty("Ordering"), *inputWorkspace, specNum);
 
     copyToOutputWorkspace(workspaceIndices, *inputWorkspace, *outputWorkspace, specNum, isAProperHistogram);
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   }
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
 
   setProperty("OutputWorkspace", outputWorkspace);
 }

--- a/Framework/Algorithms/src/Stitch1D.cpp
+++ b/Framework/Algorithms/src/Stitch1D.cpp
@@ -63,7 +63,7 @@ MatrixWorkspace_sptr Stitch1D::maskAllBut(int a1, int a2, MatrixWorkspace_sptr &
   const auto histogramCount = static_cast<int>(source->getNumberHistograms());
   PARALLEL_FOR_IF(Kernel::threadSafe(*source, *product))
   for (int i = 0; i < histogramCount; ++i) {
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
     // Copy over the bin boundaries
     product->setSharedX(i, source->sharedX(i));
     // Copy over the data
@@ -81,9 +81,9 @@ MatrixWorkspace_sptr Stitch1D::maskAllBut(int a1, int a2, MatrixWorkspace_sptr &
     std::copy(sourceY.begin() + a1 + 1, sourceY.begin() + a2, newY.begin() + a1 + 1);
     std::copy(sourceE.begin() + a1 + 1, sourceE.begin() + a2, newE.begin() + a1 + 1);
 
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   }
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
   return product;
 }
 
@@ -98,7 +98,7 @@ void Stitch1D::maskInPlace(int a1, int a2, MatrixWorkspace_sptr &source) {
   const auto histogramCount = static_cast<int>(source->getNumberHistograms());
   PARALLEL_FOR_IF(Kernel::threadSafe(*source))
   for (int i = 0; i < histogramCount; ++i) {
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
     // Copy over the data
     auto &sourceY = source->mutableY(i);
     auto &sourceE = source->mutableE(i);
@@ -107,9 +107,9 @@ void Stitch1D::maskInPlace(int a1, int a2, MatrixWorkspace_sptr &source) {
       sourceE[binIndex] = 0;
     }
 
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   }
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
 }
 
 //----------------------------------------------------------------------------------------------
@@ -303,7 +303,7 @@ MatrixWorkspace_sptr Stitch1D::rebin(MatrixWorkspace_sptr &input, const std::vec
   // remembered and then replaced post processing.
   PARALLEL_FOR_IF(Kernel::threadSafe(*outWS))
   for (int i = 0; i < histogramCount; ++i) {
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
     std::vector<size_t> &nanEIndexes = m_nanEIndexes[i];
     std::vector<size_t> &nanYIndexes = m_nanYIndexes[i];
     std::vector<size_t> &infEIndexes = m_infEIndexes[i];
@@ -332,9 +332,9 @@ MatrixWorkspace_sptr Stitch1D::rebin(MatrixWorkspace_sptr &input, const std::vec
       }
     }
 
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   }
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
 
   return outWS;
 }
@@ -418,7 +418,7 @@ bool Stitch1D::hasNonzeroErrors(MatrixWorkspace_sptr &ws) {
   bool hasNonZeroErrors = false;
   PARALLEL_FOR_IF(Kernel::threadSafe(*ws))
   for (int64_t i = 0; i < ws_size; ++i) {
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
     if (!hasNonZeroErrors) // Keep checking
     {
       const auto &e = ws->e(i);
@@ -429,9 +429,9 @@ bool Stitch1D::hasNonzeroErrors(MatrixWorkspace_sptr &ws) {
         }
       }
     }
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   }
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
 
   return hasNonZeroErrors;
 }
@@ -588,7 +588,7 @@ void Stitch1D::reinsertSpecialValues(const MatrixWorkspace_sptr &ws) {
   auto histogramCount = static_cast<int>(ws->getNumberHistograms());
   PARALLEL_FOR_IF(Kernel::threadSafe(*ws))
   for (int i = 0; i < histogramCount; ++i) {
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
     // Copy over the data
     auto &sourceY = ws->mutableY(i);
 
@@ -608,9 +608,9 @@ void Stitch1D::reinsertSpecialValues(const MatrixWorkspace_sptr &ws) {
       sourceY[j] = std::numeric_limits<double>::infinity();
     }
 
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   }
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
 }
 
 } // namespace Mantid::Algorithms

--- a/Framework/Algorithms/src/SumEventsByLogValue.cpp
+++ b/Framework/Algorithms/src/SumEventsByLogValue.cpp
@@ -142,13 +142,13 @@ void SumEventsByLogValue::createTableOutput(const Kernel::TimeSeriesProperty<int
   Progress prog(this, 0.0, 1.0, numSpec + xLength);
   PARALLEL_FOR_IF(Kernel::threadSafe(*m_inputWorkspace))
   for (int spec = 0; spec < numSpec; ++spec) {
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
     const IEventList &eventList = m_inputWorkspace->getSpectrum(spec);
     filterEventList(eventList, minVal, maxVal, log, Y);
     prog.report();
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   }
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
 
   // Create a table workspace to hold the sum.
   ITableWorkspace_sptr outputWorkspace = WorkspaceFactory::Instance().createTable();
@@ -392,7 +392,7 @@ template <typename T> void SumEventsByLogValue::createBinnedOutput(const Kernel:
   Progress prog(this, 0.0, 1.0, numSpec);
   PARALLEL_FOR_IF(Kernel::threadSafe(*m_inputWorkspace))
   for (int spec = 0; spec < numSpec; ++spec) {
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
     const IEventList &eventList = m_inputWorkspace->getSpectrum(spec);
     const auto pulseTimes = eventList.getPulseTimes();
     for (auto pulseTime : pulseTimes) {
@@ -405,9 +405,9 @@ template <typename T> void SumEventsByLogValue::createBinnedOutput(const Kernel:
     }
 
     prog.report();
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   }
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
 
   // The errors are the sqrt of the counts so long as we don't deal with
   // weighted events.

--- a/Framework/Algorithms/src/SumOverlappingTubes.cpp
+++ b/Framework/Algorithms/src/SumOverlappingTubes.cpp
@@ -261,7 +261,7 @@ std::vector<std::vector<double>> SumOverlappingTubes::performBinning(MatrixWorks
     const auto &specInfo = ws->spectrumInfo();
     PARALLEL_FOR_IF(Kernel::threadSafe(*ws, *outputWS))
     for (int i = 0; i < static_cast<int>(specInfo.size()); ++i) {
-      PARALLEL_START_INTERUPT_REGION
+      PARALLEL_START_INTERRUPT_REGION
       if (specInfo.isMonitor(i) || specInfo.isMasked(i))
         continue;
 
@@ -331,9 +331,9 @@ std::vector<std::vector<double>> SumOverlappingTubes::performBinning(MatrixWorks
           normalisation[heightIndex][angleIndex]++;
         }
       }
-      PARALLEL_END_INTERUPT_REGION
+      PARALLEL_END_INTERRUPT_REGION
     }
-    PARALLEL_CHECK_INTERUPT_REGION
+    PARALLEL_CHECK_INTERRUPT_REGION
   }
 
   return normalisation;

--- a/Framework/Algorithms/src/TOFSANSResolution.cpp
+++ b/Framework/Algorithms/src/TOFSANSResolution.cpp
@@ -125,7 +125,7 @@ void TOFSANSResolution::exec() {
 
   PARALLEL_FOR_IF(Kernel::threadSafe(*reducedWS, *iqWS))
   for (int i = 0; i < numberOfSpectra; i++) {
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
     if (!spectrumInfo.hasDetectors(i)) {
       g_log.warning() << "Workspace index " << i << " has no detector assigned to it - discarding\n";
       continue;
@@ -204,9 +204,9 @@ void TOFSANSResolution::exec() {
     }
 
     progress.report("Computing Q resolution");
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   }
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
 
   // Normalize according to the chosen weighting scheme
   // Note: we are looping over bins, therefore the xLength-1.

--- a/Framework/Algorithms/src/Transpose.cpp
+++ b/Framework/Algorithms/src/Transpose.cpp
@@ -55,7 +55,7 @@ void Transpose::exec() {
   progress.report("Swapping data values");
   PARALLEL_FOR_IF(Kernel::threadSafe(*inputWorkspace, *outputWorkspace))
   for (int64_t i = 0; i < static_cast<int64_t>(newNhist); ++i) {
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
 
     outputWorkspace->setSharedX(i, newXVector);
 
@@ -82,9 +82,9 @@ void Transpose::exec() {
       outRebinWorkspace->setF(i, F);
     }
 
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   }
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
 }
 
 /**

--- a/Framework/Algorithms/src/UnaryOperation.cpp
+++ b/Framework/Algorithms/src/UnaryOperation.cpp
@@ -67,7 +67,7 @@ void UnaryOperation::exec() {
   // function
   PARALLEL_FOR_IF(Kernel::threadSafe(*in_work, *out_work))
   for (int64_t i = 0; i < int64_t(numSpec); ++i) {
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
     // Copy the X values over
     out_work->setSharedX(i, in_work->sharedX(i));
     // Get references to the data
@@ -85,9 +85,9 @@ void UnaryOperation::exec() {
     }
 
     progress.report();
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   }
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
 }
 
 /// Executes the algorithm for events
@@ -111,7 +111,7 @@ void UnaryOperation::execEvent() {
   API::Progress prog = API::Progress(this, 0.0, 1.0, numHistograms);
   PARALLEL_FOR_IF(Kernel::threadSafe(*outputWS))
   for (int64_t i = 0; i < numHistograms; ++i) {
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
     // switch to weighted events if needed, and use the appropriate helper
     // function
     auto &evlist = outputWS->getSpectrum(i);
@@ -132,9 +132,9 @@ void UnaryOperation::execEvent() {
     }
 
     prog.report();
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   }
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
 
   outputWS->clearMRU();
   auto inputWS = std::dynamic_pointer_cast<EventWorkspace>(matrixOutputWS);

--- a/Framework/Algorithms/src/UnwrapSNS.cpp
+++ b/Framework/Algorithms/src/UnwrapSNS.cpp
@@ -117,7 +117,7 @@ void UnwrapSNS::exec() {
 
   PARALLEL_FOR_IF(Kernel::threadSafe(*m_inputWS, *outputWS))
   for (int workspaceIndex = 0; workspaceIndex < m_numberOfSpectra; workspaceIndex++) {
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
     if (!spectrumInfo.hasDetectors(workspaceIndex)) {
       // If the detector flightpath is missing, zero the data
       g_log.debug() << "Detector information for workspace index " << workspaceIndex << " is not available.\n";
@@ -150,9 +150,9 @@ void UnwrapSNS::exec() {
       std::copy(eIn.begin(), eIn.begin() + pivot, eOut.begin() + lengthFirstPartE);
     }
     m_progress->report();
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   }
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
 
   m_inputWS.reset();
   this->runMaskDetectors();

--- a/Framework/Algorithms/src/WorkspaceJoiners.cpp
+++ b/Framework/Algorithms/src/WorkspaceJoiners.cpp
@@ -46,7 +46,7 @@ MatrixWorkspace_sptr WorkspaceJoiners::execWS2D(const MatrixWorkspace &ws1, cons
   const int64_t &nhist1 = ws1.getNumberHistograms();
   PARALLEL_FOR_IF(Kernel::threadSafe(ws1, *output))
   for (int64_t i = 0; i < nhist1; ++i) {
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
     auto &outSpec = output->getSpectrum(i);
     const auto &inSpec = ws1.getSpectrum(i);
 
@@ -62,9 +62,9 @@ MatrixWorkspace_sptr WorkspaceJoiners::execWS2D(const MatrixWorkspace &ws1, cons
     }
 
     m_progress->report();
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   }
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
 
   // For second loop we use the offset from the first
   const int64_t &nhist2 = ws2.getNumberHistograms();
@@ -72,7 +72,7 @@ MatrixWorkspace_sptr WorkspaceJoiners::execWS2D(const MatrixWorkspace &ws1, cons
   auto &outSpectrumInfo = output->mutableSpectrumInfo();
   PARALLEL_FOR_IF(Kernel::threadSafe(ws2, *output))
   for (int64_t j = 0; j < nhist2; ++j) {
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
     // The spectrum in the output workspace
     auto &outSpec = output->getSpectrum(nhist1 + j);
     // Spectrum in the second workspace
@@ -95,9 +95,9 @@ MatrixWorkspace_sptr WorkspaceJoiners::execWS2D(const MatrixWorkspace &ws1, cons
     }
 
     m_progress->report();
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   }
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
 
   fixSpectrumNumbers(ws1, ws2, *output);
 

--- a/Framework/Algorithms/src/XDataConverter.cpp
+++ b/Framework/Algorithms/src/XDataConverter.cpp
@@ -64,7 +64,7 @@ void XDataConverter::exec() {
   Progress prog(this, 0.0, 1.0, numSpectra);
   PARALLEL_FOR_IF(Kernel::threadSafe(*inputWS, *outputWS))
   for (int i = 0; i < int(numSpectra); ++i) {
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
 
     // Copy over the Y and E data
     outputWS->setSharedY(i, inputWS->sharedY(i));
@@ -75,9 +75,9 @@ void XDataConverter::exec() {
     }
     prog.report();
 
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   }
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
 
   // Store the output
   setProperty("OutputWorkspace", outputWS);

--- a/Framework/Crystal/src/AnvredCorrection.cpp
+++ b/Framework/Crystal/src/AnvredCorrection.cpp
@@ -188,7 +188,7 @@ void AnvredCorrection::exec() {
   // Loop over the spectra
   PARALLEL_FOR_IF(Kernel::threadSafe(*m_inputWS, *correctionFactors))
   for (int64_t i = 0; i < int64_t(numHists); ++i) {
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
 
     // If no detector is found, skip onto the next spectrum
     if (!spectrumInfo.hasDetectors(i) || spectrumInfo.isMonitor(i))
@@ -252,9 +252,9 @@ void AnvredCorrection::exec() {
 
     prog.report();
 
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   }
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
 
   // set the absorption correction values in the run parameters
   API::Run &run = correctionFactors->mutableRun();
@@ -289,7 +289,7 @@ void AnvredCorrection::execEvent() {
   // Loop over the spectra
   PARALLEL_FOR_IF(Kernel::threadSafe(*eventW, *correctionFactors))
   for (int64_t i = 0; i < int64_t(numHists); ++i) {
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
 
     // share bin boundaries, and leave Y and E nullptr
     correctionFactors->setHistogram(i, eventW->binEdges(i));
@@ -350,9 +350,9 @@ void AnvredCorrection::execEvent() {
 
     prog.report();
 
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   }
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
 
   // set the absorption correction values in the run parameters
   API::Run &run = correctionFactors->mutableRun();

--- a/Framework/Crystal/src/CentroidPeaks.cpp
+++ b/Framework/Crystal/src/CentroidPeaks.cpp
@@ -90,7 +90,7 @@ void CentroidPeaks::integrate() {
   Progress prog(this, MinPeaks, 1.0, MaxPeaks);
   PARALLEL_FOR_IF(Kernel::threadSafe(*inWS, *peakWS))
   for (int i = MinPeaks; i <= MaxPeaks; ++i) {
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
     // Get a direct ref to that peak.
     auto &peak = peakWS->getPeak(i);
     int col = peak.getCol();
@@ -163,9 +163,9 @@ void CentroidPeaks::integrate() {
       peak.setWavelength(lambda);
       peak.setBinCount(inWS->y(workspaceIndex)[chan]);
     }
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   }
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
   removeEdgePeaks(*peakWS);
 
   // Save the output
@@ -212,7 +212,7 @@ void CentroidPeaks::integrateEvent() {
   Progress prog(this, MinPeaks, 1.0, MaxPeaks);
   PARALLEL_FOR_IF(Kernel::threadSafe(*inWS, *peakWS))
   for (int i = MinPeaks; i <= MaxPeaks; ++i) {
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
     // Get a direct ref to that peak.
     auto &peak = peakWS->getPeak(i);
     int col = peak.getCol();
@@ -281,9 +281,9 @@ void CentroidPeaks::integrateEvent() {
       peak.setWavelength(lambda);
       peak.setBinCount(intensity);
     }
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   }
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
   removeEdgePeaks(*peakWS);
 
   // Save the output

--- a/Framework/Crystal/src/FindClusterFaces.cpp
+++ b/Framework/Crystal/src/FindClusterFaces.cpp
@@ -310,7 +310,7 @@ void FindClusterFaces::exec() {
   Progress progress(this, 0.0, 1.0, nSteps);
   PARALLEL_FOR_NO_WSP_CHECK()
   for (int it = 0; it < nIterators; ++it) {
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
     ClusterFaces &localClusterFaces = clusterFaces[it];
     auto mdIterator = mdIterators[it].get();
 
@@ -320,9 +320,9 @@ void FindClusterFaces::exec() {
     } else {
       executeUnFiltered(mdIterator, localClusterFaces, progress, clusterImage, imageShape);
     }
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   }
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
 
   const bool limitRows = getProperty("LimitRows");
   const int maxRows = getProperty("MaximumRows");

--- a/Framework/Crystal/src/FindSXPeaks.cpp
+++ b/Framework/Crystal/src/FindSXPeaks.cpp
@@ -262,7 +262,7 @@ void FindSXPeaks::exec() {
   // Count the peaks so that we can resize the peak vector at the end.
   PARALLEL_FOR_IF(Kernel::threadSafe(*localworkspace))
   for (auto wsIndex = static_cast<int>(m_MinWsIndex); wsIndex <= static_cast<int>(m_MaxWsIndex); ++wsIndex) {
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
 
     // If no detector found / monitor, skip onto the next spectrum
     const auto wsIndexSize_t = static_cast<size_t>(wsIndex);
@@ -282,9 +282,9 @@ void FindSXPeaks::exec() {
 
     PARALLEL_CRITICAL(entries) { std::copy(foundPeaks->cbegin(), foundPeaks->cend(), std::back_inserter(entries)); }
     progress.report();
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   }
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
 
   // Now reduce the list with duplicate entries
   reducePeakList(entries, progress);

--- a/Framework/Crystal/src/IntegratePeaksHybrid.cpp
+++ b/Framework/Crystal/src/IntegratePeaksHybrid.cpp
@@ -169,7 +169,7 @@ void IntegratePeaksHybrid::exec() {
   PARALLEL_FOR_IF(Kernel::threadSafe(*peakWS))
   for (int i = 0; i < peakWS->getNumberPeaks(); ++i) {
 
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
     Geometry::IPeak &peak = peakWS->getPeak(i);
     const V3D center = projection.peakCenter(peak);
 
@@ -236,9 +236,9 @@ void IntegratePeaksHybrid::exec() {
       peak.setSigmaIntensity(std::sqrt(integratedValues.get<1>()));
     }
     progress.report();
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   }
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
 
   setProperty("OutputWorkspace", peakWS);
   setProperty("OutputWorkspaces", outImageResults);

--- a/Framework/Crystal/src/IntegratePeaksUsingClusters.cpp
+++ b/Framework/Crystal/src/IntegratePeaksUsingClusters.cpp
@@ -141,7 +141,7 @@ void IntegratePeaksUsingClusters::exec() {
   progress.resetNumSteps(peakWS->getNumberPeaks(), 0.9, 1);
   PARALLEL_FOR_IF(Kernel::threadSafe(*peakWS))
   for (int i = 0; i < peakWS->getNumberPeaks(); ++i) {
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
     Geometry::IPeak &peak = peakWS->getPeak(i);
     const Mantid::signal_t signalValue =
         projection.signalAtPeakCenter(peak); // No normalization when extracting label ids!
@@ -169,9 +169,9 @@ void IntegratePeaksUsingClusters::exec() {
       }
       progress.report();
     }
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   }
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
 
   setProperty("OutputWorkspace", peakWS);
   setProperty("OutputWorkspaceMD", outHistoWS);

--- a/Framework/Crystal/src/MaskPeaksWorkspace.cpp
+++ b/Framework/Crystal/src/MaskPeaksWorkspace.cpp
@@ -85,7 +85,7 @@ void MaskPeaksWorkspace::exec() {
   const std::vector<Peak> &peaks = peaksW->getPeaks();
   PARALLEL_FOR_IF(Kernel::threadSafe(*m_inputW, *peaksW, *tablews))
   for (int i = 0; i < static_cast<int>(peaks.size()); i++) { // NOLINT
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
     const Peak &peak = peaks[i];
     // get the peak location on the detector
     double col = peak.getCol();
@@ -144,9 +144,9 @@ void MaskPeaksWorkspace::exec() {
         API::TableRow newrow = tablews->appendRow();
         newrow << x0 << xf << Kernel::Strings::toString(spectra);
       }
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   } // end loop over peaks
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
 
   // Mask bins
   auto maskbinstb = createChildAlgorithm("MaskBinsFromTable", 0.5, 1.0, true);

--- a/Framework/Crystal/src/NormaliseVanadium.cpp
+++ b/Framework/Crystal/src/NormaliseVanadium.cpp
@@ -65,7 +65,7 @@ void NormaliseVanadium::exec() {
   // Loop over the spectra
   PARALLEL_FOR_IF(Kernel::threadSafe(*m_inputWS, *correctionFactors))
   for (int64_t i = 0; i < int64_t(numHists); ++i) {
-    //    PARALLEL_START_INTERUPT_REGION //FIXME: Restore
+    //    PARALLEL_START_INTERRUPT_REGION //FIXME: Restore
 
     // Get a reference to the Y's in the output WS for storing the factors
     auto &Y = correctionFactors->mutableY(i);
@@ -112,9 +112,9 @@ void NormaliseVanadium::exec() {
 
     prog.report();
 
-    //    PARALLEL_END_INTERUPT_REGION
+    //    PARALLEL_END_INTERRUPT_REGION
   }
-  //  PARALLEL_CHECK_INTERUPT_REGION
+  //  PARALLEL_CHECK_INTERRUPT_REGION
 
   setProperty("OutputWorkspace", correctionFactors);
 }

--- a/Framework/Crystal/src/PeakIntegration.cpp
+++ b/Framework/Crystal/src/PeakIntegration.cpp
@@ -127,7 +127,7 @@ void PeakIntegration::exec() {
   PARALLEL_FOR_IF(Kernel::threadSafe(*inputW, *peaksW, *outputW))
   for (int i = MinPeaks; i < NumberPeaks; i++) {
 
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
 
     // Direct ref to that peak
     Peak &peak = peaksW->getPeaks()[i];
@@ -262,10 +262,10 @@ void PeakIntegration::exec() {
     peak.setSigmaIntensity(sigI);
 
     prog.report();
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   }
 
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
 
   // Save the output
   setProperty("OutPeaksWorkspace", peaksW);

--- a/Framework/Crystal/src/PeaksIntersection.cpp
+++ b/Framework/Crystal/src/PeaksIntersection.cpp
@@ -125,7 +125,7 @@ void PeaksIntersection::executePeaksIntersection(const bool checkPeakExtents) {
 
   PARALLEL_FOR_IF(Kernel::threadSafe(*ws, *outputWorkspace))
   for (int i = 0; i < nPeaks; ++i) {
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
     Peak *peak = dynamic_cast<Peak *>(ws->getPeakPtr(i));
     V3D peakCenter = coordFrameFunc(peak);
 
@@ -164,9 +164,9 @@ void PeaksIntersection::executePeaksIntersection(const bool checkPeakExtents) {
 
     TableRow row = outputWorkspace->getRow(i);
     row << i << doesIntersect << distance;
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   }
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
 
   setProperty("OutputWorkspace", outputWorkspace);
 }

--- a/Framework/Crystal/src/SCDCalibratePanels.cpp
+++ b/Framework/Crystal/src/SCDCalibratePanels.cpp
@@ -85,16 +85,16 @@ void SCDCalibratePanels::exec() {
 
     PRAGMA_OMP(parallel for schedule(dynamic, 1) )
     for (int num = 1; num < 64; ++num) {
-      PARALLEL_START_INTERUPT_REGION
+      PARALLEL_START_INTERRUPT_REGION
       std::ostringstream mess;
       mess << "bank" << num;
       IComponent_const_sptr comp = inst->getComponentByName(mess.str(), maxRecurseDepth);
       PARALLEL_CRITICAL(MyBankNames)
       if (comp)
         MyBankNames.insert(mess.str());
-      PARALLEL_END_INTERUPT_REGION
+      PARALLEL_END_INTERRUPT_REGION
     }
-    PARALLEL_CHECK_INTERUPT_REGION
+    PARALLEL_CHECK_INTERRUPT_REGION
   } else {
     for (int i = 0; i < nPeaks; ++i) {
       std::string name = peaksWs->getPeak(i).getBankName();
@@ -170,16 +170,16 @@ void SCDCalibratePanels::exec() {
   Geometry::OrientedLattice lattice0 = peaksWs->mutableSample().getOrientedLattice();
   PARALLEL_FOR_IF(Kernel::threadSafe(*peaksWs))
   for (int i = 0; i < nPeaks; i++) {
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
     DataObjects::Peak &peak = peaksWs->getPeak(i);
     try {
       peak.setInstrument(inst2);
     } catch (const std::exception &exc) {
       g_log.notice() << "Problem in applying calibration to peak " << i << " : " << exc.what() << "\n";
     }
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   }
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
 
   // Find U again for optimized geometry and index peaks
   findU(peaksWs);
@@ -211,7 +211,7 @@ void SCDCalibratePanels::exec() {
   peaksWs->sort(criteria);
   PARALLEL_FOR_IF(Kernel::threadSafe(*ColWksp, *RowWksp, *TofWksp))
   for (int i = 0; i < static_cast<int>(MyBankNames.size()); ++i) {
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
     const std::string &bankName = *std::next(MyBankNames.begin(), i);
     size_t k = bankName.find_last_not_of("0123456789");
     int bank = 0;
@@ -245,9 +245,9 @@ void SCDCalibratePanels::exec() {
         icount++;
       }
     }
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   }
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
 
   string colFilename = getProperty("ColFilename");
   string rowFilename = getProperty("RowFilename");
@@ -580,7 +580,7 @@ void SCDCalibratePanels::findL2(boost::container::flat_set<string> MyBankNames,
 
   PARALLEL_FOR_IF(Kernel::threadSafe(*peaksWs))
   for (int bankIndex = 0; bankIndex < static_cast<int>(MyBankNames.size()); ++bankIndex) {
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
     const std::string &iBank = *std::next(MyBankNames.begin(), bankIndex);
     const std::string bankName = "__PWS_" + iBank;
     PeaksWorkspace_sptr local = peaksWs->clone();
@@ -701,8 +701,8 @@ void SCDCalibratePanels::findL2(boost::container::flat_set<string> MyBankNames,
     AnalysisDataService::Instance().remove(bankName);
     SCDPanelErrors det;
     det.moveDetector(xShift, yShift, zShift, xRotate, yRotate, zRotate, scaleWidth, scaleHeight, iBank, peaksWs);
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   }
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
 }
 } // namespace Mantid::Crystal

--- a/Framework/Crystal/src/SCDCalibratePanels2.cpp
+++ b/Framework/Crystal/src/SCDCalibratePanels2.cpp
@@ -528,7 +528,7 @@ void SCDCalibratePanels2::optimizeBanks(IPeaksWorkspace_sptr pws, const IPeaksWo
 
   PARALLEL_FOR_IF(Kernel::threadSafe(*pws))
   for (int i = 0; i < static_cast<int>(m_BankNames.size()); ++i) {
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
     // prepare local copies to work with
     const std::string bankname = *std::next(m_BankNames.begin(), i);
     const std::string pwsBankiName = "_pws_" + bankname;
@@ -710,9 +710,9 @@ void SCDCalibratePanels2::optimizeBanks(IPeaksWorkspace_sptr pws, const IPeaksWo
     g_log.notice() << calilog.str();
 
     // -- cleanup
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   }
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
 }
 
 /**
@@ -1491,7 +1491,7 @@ void SCDCalibratePanels2::profileBanks(Mantid::API::IPeaksWorkspace_sptr &pws,
   // Use OPENMP to speed up the profiling
   PARALLEL_FOR_IF(Kernel::threadSafe(*pws))
   for (int bankIndex = 0; bankIndex < static_cast<int>(m_BankNames.size()); ++bankIndex) {
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
     // prepare local copies to work with
     const std::string bankname = *std::next(m_BankNames.begin(), bankIndex);
     const std::string pwsBankiName = "_pws_" + bankname;
@@ -1595,9 +1595,9 @@ void SCDCalibratePanels2::profileBanks(Mantid::API::IPeaksWorkspace_sptr &pws,
         << filenamebase << "\n"
         << "END of profiling objective func for " << bankname << "\n";
     g_log.notice() << msg.str();
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   }
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
 }
 
 /**

--- a/Framework/CurveFitting/src/Algorithms/ConvertToYSpace.cpp
+++ b/Framework/CurveFitting/src/Algorithms/ConvertToYSpace.cpp
@@ -181,7 +181,7 @@ void ConvertToYSpace::exec() {
 
   PARALLEL_FOR_IF(Kernel::threadSafe(*m_inputWS, *m_outputWS))
   for (int64_t i = 0; i < nhist; ++i) {
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
 
     if (!convert(i)) {
       g_log.warning("No detector defined for index=" + std::to_string(i) + ". Zeroing spectrum.");
@@ -195,9 +195,9 @@ void ConvertToYSpace::exec() {
       }
     }
     progress->report();
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   }
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
 
   setProperty("OutputWorkspace", m_outputWS);
 

--- a/Framework/CurveFitting/src/Algorithms/ConvolveWorkspaces.cpp
+++ b/Framework/CurveFitting/src/Algorithms/ConvolveWorkspaces.cpp
@@ -58,7 +58,7 @@ void ConvolveWorkspaces::exec() {
   // Now convolve the histograms
   PARALLEL_FOR_IF(Kernel::threadSafe(*ws1, *ws2, *outputWS))
   for (int i = 0; i < static_cast<int>(numHists); ++i) {
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
     m_progress->report();
     outputWS->setSharedX(i, ws1->sharedX(i));
     auto &Yout = outputWS->mutableY(i);
@@ -84,9 +84,9 @@ void ConvolveWorkspaces::exec() {
     for (size_t j = 0; j < N; j++) {
       Yout[j] = out.getCalculated(j);
     }
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   }
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
   // Assign it to the output workspace property
   setProperty("OutputWorkspace", outputWS);
 }

--- a/Framework/CurveFitting/src/Algorithms/VesuvioCalculateGammaBackground.cpp
+++ b/Framework/CurveFitting/src/Algorithms/VesuvioCalculateGammaBackground.cpp
@@ -110,7 +110,7 @@ void VesuvioCalculateGammaBackground::exec() {
 
   PARALLEL_FOR_IF(Kernel::threadSafe(*m_inputWS, *m_correctedWS, *m_backgroundWS))
   for (int64_t i = 0; i < nhist; ++i) {
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
     const size_t outputIndex = i;
     auto indexIter = m_indices.cbegin();
     std::advance(indexIter, i);
@@ -120,9 +120,9 @@ void VesuvioCalculateGammaBackground::exec() {
       g_log.information("No detector defined for index=" + std::to_string(inputIndex) + ". Skipping correction.");
     }
 
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   }
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
 
   setProperty("BackgroundWorkspace", m_backgroundWS);
   setProperty("CorrectedWorkspace", m_correctedWS);

--- a/Framework/CurveFitting/src/Algorithms/VesuvioCalculateMS.cpp
+++ b/Framework/CurveFitting/src/Algorithms/VesuvioCalculateMS.cpp
@@ -125,7 +125,7 @@ void VesuvioCalculateMS::exec() {
 
   PARALLEL_FOR_IF(Kernel::threadSafe(*m_inputWS))
   for (int64_t i = 0; i < static_cast<int64_t>(nhist); ++i) {
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
 
     // set common X-values
     totalsc->setSharedX(i, m_inputWS->sharedX(i));
@@ -147,9 +147,9 @@ void VesuvioCalculateMS::exec() {
     // the output spectrum objects have references to where the data will be
     // stored
     calculateMS(rng, i, totalsc->getSpectrum(i), multsc->getSpectrum(i));
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   }
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
 
   setProperty("TotalScatteringWS", totalsc);
   setProperty("MultipleScatteringWS", multsc);

--- a/Framework/CurveFitting/src/Functions/ThermalNeutronBk2BkExpConvPVoigt.cpp
+++ b/Framework/CurveFitting/src/Functions/ThermalNeutronBk2BkExpConvPVoigt.cpp
@@ -334,7 +334,7 @@ void ThermalNeutronBk2BkExpConvPVoigt::functionLocal(double *out, const double *
   // PARALLEL_SET_NUM_THREADS(8);
   // PARALLEL_FOR_NO_WSP_CHECK()
   for (size_t id = 0; id < nData; ++id) {
-    // PARALLEL_START_INTERUPT_REGION
+    // PARALLEL_START_INTERRUPT_REGION
 
     // a) Caclualte peak intensity
     double dT = xValues[id] - m_centre;
@@ -369,9 +369,9 @@ void ThermalNeutronBk2BkExpConvPVoigt::functionLocal(double *out, const double *
     }
     */
 
-    // PARALLEL_END_INTERUPT_REGION
+    // PARALLEL_END_INTERRUPT_REGION
   } // ENDFOR data points
-  // PARALLEL_CHECK_INTERUPT_REGION
+  // PARALLEL_CHECK_INTERRUPT_REGION
 }
 
 //----------------------------------------------------------------------------------------------

--- a/Framework/DataHandling/src/CreateChunkingFromInstrument.cpp
+++ b/Framework/DataHandling/src/CreateChunkingFromInstrument.cpp
@@ -380,7 +380,7 @@ void CreateChunkingFromInstrument::exec() {
 
     PRAGMA_OMP(parallel for schedule(dynamic, 1) )
     for (int num = 0; num < maxBankNum; ++num) {
-      PARALLEL_START_INTERUPT_REGION
+      PARALLEL_START_INTERRUPT_REGION
       ostringstream mess;
       mess << "bank" << num;
       IComponent_const_sptr comp = inst->getComponentByName(mess.str(), maxRecurseDepth);
@@ -403,9 +403,9 @@ void CreateChunkingFromInstrument::exec() {
         }
       }
       progress.report();
-      PARALLEL_END_INTERUPT_REGION
+      PARALLEL_END_INTERRUPT_REGION
     }
-    PARALLEL_CHECK_INTERUPT_REGION
+    PARALLEL_CHECK_INTERRUPT_REGION
 
     // check to see that something happened
     if (grouping.empty())

--- a/Framework/DataHandling/src/FilterEventsByLogValuePreNexus.cpp
+++ b/Framework/DataHandling/src/FilterEventsByLogValuePreNexus.cpp
@@ -383,11 +383,11 @@ void FilterEventsByLogValuePreNexus::exec() {
     const int64_t numberOfSpectra = m_localWorkspace->getNumberHistograms();
     PARALLEL_FOR_NO_WSP_CHECK()
     for (int64_t i = 0; i < numberOfSpectra; i++) {
-      PARALLEL_START_INTERUPT_REGION
+      PARALLEL_START_INTERRUPT_REGION
       m_localWorkspace->getSpectrum(i).setSortOrder(DataObjects::PULSETIME_SORT);
-      PARALLEL_END_INTERUPT_REGION
+      PARALLEL_END_INTERRUPT_REGION
     }
-    PARALLEL_CHECK_INTERUPT_REGION
+    PARALLEL_CHECK_INTERRUPT_REGION
   }
 
   // Save output
@@ -911,7 +911,7 @@ void FilterEventsByLogValuePreNexus::procEvents(DataObjects::EventWorkspace_sptr
     //--------------------------------------------------------------------
     PRAGMA_OMP( parallel for schedule(dynamic, 1) if (m_parallelProcessing) )
     for (int blockNum = 0; blockNum < int(numBlocks); blockNum++) {
-      PARALLEL_START_INTERUPT_REGION
+      PARALLEL_START_INTERRUPT_REGION
 
       // Find the workspace for this particular thread
       EventWorkspace_sptr ws;
@@ -945,9 +945,9 @@ void FilterEventsByLogValuePreNexus::procEvents(DataObjects::EventWorkspace_sptr
       // Report progress
       m_progress->report("Load Event PreNeXus");
 
-      PARALLEL_END_INTERUPT_REGION
+      PARALLEL_END_INTERRUPT_REGION
     }
-    PARALLEL_CHECK_INTERUPT_REGION
+    PARALLEL_CHECK_INTERRUPT_REGION
 
     g_log.information() << tim << " to load the data.\n";
 
@@ -955,7 +955,7 @@ void FilterEventsByLogValuePreNexus::procEvents(DataObjects::EventWorkspace_sptr
     // MERGE WORKSPACES BACK TOGETHER
     //--------------------------------------------------------------------
     if (m_parallelProcessing) {
-      PARALLEL_START_INTERUPT_REGION
+      PARALLEL_START_INTERRUPT_REGION
       m_progress->resetNumSteps(workspace->getNumberHistograms(), 0.8, 0.95);
 
       // Merge all workspaces, index by index.
@@ -985,9 +985,9 @@ void FilterEventsByLogValuePreNexus::procEvents(DataObjects::EventWorkspace_sptr
       }
 
       g_log.debug() << tim << " to merge workspaces together.\n";
-      PARALLEL_END_INTERUPT_REGION
+      PARALLEL_END_INTERRUPT_REGION
     }
-    PARALLEL_CHECK_INTERUPT_REGION
+    PARALLEL_CHECK_INTERRUPT_REGION
 
     // Delete the buffers for each thread.
     for (size_t i = 0; i < numThreads; i++) {
@@ -1298,16 +1298,16 @@ void FilterEventsByLogValuePreNexus::unmaskVetoEventIndexes() {
     PRAGMA_OMP(parallel for schedule(dynamic, 1) )
     for (int i = 0; i < static_cast<int>(m_vecEventIndex.size()); // NOLINT
          ++i) {
-      PARALLEL_START_INTERUPT_REGION
+      PARALLEL_START_INTERRUPT_REGION
 
       uint64_t eventindex = m_vecEventIndex[i];
       if (eventindex > static_cast<uint64_t>(m_numEvents)) {
         uint64_t realeventindex = eventindex & VETOFLAG;
         m_vecEventIndex[i] = realeventindex;
       }
-      PARALLEL_END_INTERUPT_REGION
+      PARALLEL_END_INTERRUPT_REGION
     }
-    PARALLEL_CHECK_INTERUPT_REGION
+    PARALLEL_CHECK_INTERRUPT_REGION
 
 #if 0
         // Examine whether it is a veto
@@ -1344,15 +1344,15 @@ void FilterEventsByLogValuePreNexus::unmaskVetoEventIndexes() {
           }
         }
       } // END
-      PARALLEL_END_INTERUPT_REGION
+      PARALLEL_END_INTERRUPT_REGION
     }
-    PARALLEL_CHECK_INTERUPT_REGION
+    PARALLEL_CHECK_INTERRUPT_REGION
 #endif
 
     // Check
     PRAGMA_OMP(parallel for schedule(dynamic, 1) )
     for (int i = 0; i < static_cast<int>(m_vecEventIndex.size()); ++i) {
-      PARALLEL_START_INTERUPT_REGION
+      PARALLEL_START_INTERRUPT_REGION
 
       uint64_t eventindex = m_vecEventIndex[i];
       if (eventindex > static_cast<uint64_t>(m_numEvents)) {
@@ -1361,9 +1361,9 @@ void FilterEventsByLogValuePreNexus::unmaskVetoEventIndexes() {
         }
       }
 
-      PARALLEL_END_INTERUPT_REGION
+      PARALLEL_END_INTERRUPT_REGION
     }
-    PARALLEL_CHECK_INTERUPT_REGION
+    PARALLEL_CHECK_INTERRUPT_REGION
 
     g_log.notice() << "Number of veto pulses = " << numveto << ", Number of error-event-index pulses = " << numerror
                    << "\n";
@@ -1484,7 +1484,7 @@ void FilterEventsByLogValuePreNexus::filterEvents() {
     //--------------------------------------------------------------------
     PRAGMA_OMP( parallel for schedule(dynamic, 1) if (m_parallelProcessing) )
     for (int blockNum = 0; blockNum < int(numBlocks); blockNum++) {
-      PARALLEL_START_INTERUPT_REGION
+      PARALLEL_START_INTERRUPT_REGION
 
       // Find the workspace for this particular thread
       EventWorkspace_sptr ws;
@@ -1518,9 +1518,9 @@ void FilterEventsByLogValuePreNexus::filterEvents() {
       // Report progress
       m_progress->report("Load Event PreNeXus");
 
-      PARALLEL_END_INTERUPT_REGION
+      PARALLEL_END_INTERRUPT_REGION
     }
-    PARALLEL_CHECK_INTERUPT_REGION
+    PARALLEL_CHECK_INTERRUPT_REGION
 
     g_log.information() << tim << " to load the data.\n";
 
@@ -1528,7 +1528,7 @@ void FilterEventsByLogValuePreNexus::filterEvents() {
     // MERGE WORKSPACES BACK TOGETHER
     //--------------------------------------------------------------------
     if (m_parallelProcessing) {
-      PARALLEL_START_INTERUPT_REGION
+      PARALLEL_START_INTERRUPT_REGION
       m_progress->resetNumSteps(m_localWorkspace->getNumberHistograms(), 0.8, 0.95);
 
       // Merge all workspaces, index by index.
@@ -1558,9 +1558,9 @@ void FilterEventsByLogValuePreNexus::filterEvents() {
       }
 
       g_log.debug() << tim << " to merge workspaces together.\n";
-      PARALLEL_END_INTERUPT_REGION
+      PARALLEL_END_INTERRUPT_REGION
     }
-    PARALLEL_CHECK_INTERUPT_REGION
+    PARALLEL_CHECK_INTERRUPT_REGION
 
     // Delete the buffers for each thread.
     for (size_t i = 0; i < numThreads; i++) {

--- a/Framework/DataHandling/src/FindDetectorsPar.cpp
+++ b/Framework/DataHandling/src/FindDetectorsPar.cpp
@@ -101,7 +101,7 @@ void FindDetectorsPar::exec() {
   // Loop over the spectra
   PARALLEL_FOR_NO_WSP_CHECK()
   for (int64_t i = 0; i < nHist; i++) {
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
     // Check that we aren't writing a monitor...
     if (!spectrumInfo.hasDetectors(i) || spectrumInfo.isMonitor(i))
       continue;
@@ -117,9 +117,9 @@ void FindDetectorsPar::exec() {
     if (i % progStep == 0) {
       progress.report();
     }
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   }
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
 
   this->extractAndLinearize(Detectors);
   // if necessary set up table workspace with detectors parameters.

--- a/Framework/DataHandling/src/LoadDNSEvent.cpp
+++ b/Framework/DataHandling/src/LoadDNSEvent.cpp
@@ -151,7 +151,7 @@ void LoadDNSEvent::populate_EventWorkspace(EventWorkspace_sptr &eventWS, EventAc
     auto chopperIt = finalEventAccumulator.triggerEvents.cbegin();
 
     auto &spectrum = eventWS->getSpectrum(wsIndex);
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
 
     uint64_t numProcessed = 0;
     for (const auto &event : eventList) {
@@ -176,11 +176,11 @@ void LoadDNSEvent::populate_EventWorkspace(EventWorkspace_sptr &eventWS, EventAc
       spectrum.addEventQuickly(Types::Event::TofEvent(double(event.timestamp - chopperTimestamp) / 10.0));
     }
 
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
     oversizedChanelIndexCounterA += oversizedChanelIndexCounter;
     oversizedPosCounterA += oversizedPosCounter;
   }
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
 
   if (oversizedChanelIndexCounterA > 0) {
     g_log.warning() << "Bad chanel indices: " << oversizedChanelIndexCounterA << std::endl;

--- a/Framework/DataHandling/src/LoadEventNexus.cpp
+++ b/Framework/DataHandling/src/LoadEventNexus.cpp
@@ -1183,12 +1183,12 @@ void LoadEventNexus::loadEvents(API::Progress *const prog, const bool monitors) 
         auto numHistograms = static_cast<int64_t>(m_ws->getNumberHistograms());
         PARALLEL_FOR_IF(Kernel::threadSafe(*m_ws))
         for (int64_t i = 0; i < numHistograms; ++i) {
-          PARALLEL_START_INTERUPT_REGION
+          PARALLEL_START_INTERRUPT_REGION
           // Do the offsetting
           m_ws->getSpectrum(i).addTof(mT0);
-          PARALLEL_END_INTERUPT_REGION
+          PARALLEL_END_INTERRUPT_REGION
         }
-        PARALLEL_CHECK_INTERUPT_REGION
+        PARALLEL_CHECK_INTERRUPT_REGION
         // set T0 in the run parameters
         API::Run &run = m_ws->mutableRun();
         run.addProperty<double>("T0", mT0, true);

--- a/Framework/DataHandling/src/LoadEventPreNexus2.cpp
+++ b/Framework/DataHandling/src/LoadEventPreNexus2.cpp
@@ -444,7 +444,7 @@ void LoadEventPreNexus2::unmaskVetoEventIndex() {
 
   PARALLEL_FOR_NO_WSP_CHECK()
   for (int i = 0; i < static_cast<int>(event_indices.size()); ++i) {
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
 
     uint64_t eventindex = event_indices[i];
     if (eventindex > static_cast<uint64_t>(max_events)) {
@@ -458,9 +458,9 @@ void LoadEventPreNexus2::unmaskVetoEventIndex() {
     if (eventindexcheck > static_cast<uint64_t>(max_events)) {
       g_log.information() << "Check: Pulse " << i << ": unphysical event index = " << eventindexcheck << "\n";
     }
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   }
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
 }
 
 //------------------------------------------------------------------------------------------------
@@ -762,7 +762,7 @@ void LoadEventPreNexus2::procEvents(DataObjects::EventWorkspace_sptr &workspace)
 
     PRAGMA_OMP( parallel for schedule(dynamic, 1) if (parallelProcessing) )
     for (int blockNum = 0; blockNum < int(numBlocks); blockNum++) {
-      PARALLEL_START_INTERUPT_REGION
+      PARALLEL_START_INTERRUPT_REGION
 
       // Find the workspace for this particular thread
       EventWorkspace_sptr ws;
@@ -797,9 +797,9 @@ void LoadEventPreNexus2::procEvents(DataObjects::EventWorkspace_sptr &workspace)
       // Report progress
       prog->report("Load Event PreNeXus");
 
-      PARALLEL_END_INTERUPT_REGION
+      PARALLEL_END_INTERRUPT_REGION
     }
-    PARALLEL_CHECK_INTERUPT_REGION
+    PARALLEL_CHECK_INTERRUPT_REGION
 
     g_log.debug() << tim << " to load the data.\n";
 
@@ -807,7 +807,7 @@ void LoadEventPreNexus2::procEvents(DataObjects::EventWorkspace_sptr &workspace)
     // MERGE WORKSPACES BACK TOGETHER
     //-------------------------------------------------------------------------
     if (parallelProcessing) {
-      PARALLEL_START_INTERUPT_REGION
+      PARALLEL_START_INTERRUPT_REGION
       prog->resetNumSteps(workspace->getNumberHistograms(), 0.8, 0.95);
 
       // Merge all workspaces, index by index.
@@ -836,9 +836,9 @@ void LoadEventPreNexus2::procEvents(DataObjects::EventWorkspace_sptr &workspace)
         prog->report("Merging Workspaces");
       }
       g_log.debug() << tim << " to merge workspaces together.\n";
-      PARALLEL_END_INTERUPT_REGION
+      PARALLEL_END_INTERRUPT_REGION
     }
-    PARALLEL_CHECK_INTERUPT_REGION
+    PARALLEL_CHECK_INTERRUPT_REGION
 
     //-------------------------------------------------------------------------
     // Clean memory

--- a/Framework/DataHandling/src/LoadILLPolarizationFactors.cpp
+++ b/Framework/DataHandling/src/LoadILLPolarizationFactors.cpp
@@ -282,7 +282,7 @@ void LoadILLPolarizationFactors::exec() {
   const auto factorTags = factor_list();
   PARALLEL_FOR_IF(Kernel::threadSafe(*refWS))
   for (int i = 0; i < static_cast<int>(factorTags.size()); ++i) {
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
     const auto tag = factorTags[i];
     const auto &fDef = fittingData.at(tag);
     auto source = make_histogram(fDef.limits, maxWavelength);
@@ -295,9 +295,9 @@ void LoadILLPolarizationFactors::exec() {
     outH.setSharedE(target.sharedE());
     outWS->setHistogram(i, outH);
     outVertAxis->setLabel(i, to_string(tag));
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   }
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
   outWS->replaceAxis(1, std::move(outVertAxis));
   setUnits(*outWS);
   outWS->setTitle("Polarization efficiency factors");

--- a/Framework/DataHandling/src/LoadNexusProcessed.cpp
+++ b/Framework/DataHandling/src/LoadNexusProcessed.cpp
@@ -697,7 +697,7 @@ API::MatrixWorkspace_sptr LoadNexusProcessed::loadEventEntry(NXData &wksp_cls, N
   Progress progress(this, progressStart, progressStart + progressRange, max);
   PARALLEL_FOR_NO_WSP_CHECK()
   for (int64_t j = 0; j < max; ++j) {
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
     size_t wi = m_filtered_spec_idxs[j] - 1;
     int64_t index_start = indices[wi];
     int64_t index_end = indices[wi + 1];
@@ -736,9 +736,9 @@ API::MatrixWorkspace_sptr LoadNexusProcessed::loadEventEntry(NXData &wksp_cls, N
       }
     }
     progress.report();
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   }
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
 
   return ws;
 }

--- a/Framework/DataHandling/src/SaveGSS.cpp
+++ b/Framework/DataHandling/src/SaveGSS.cpp
@@ -719,7 +719,7 @@ void SaveGSS::writeBufferToFile(size_t numOutFiles, size_t numSpectra) {
 
   PARALLEL_FOR_NO_WSP_CHECK()
   for (int64_t fileIndex = 0; fileIndex < numOutFilesInt64; fileIndex++) {
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
 
     // Open each file when there are multiple
     std::ofstream fileStream;
@@ -738,9 +738,9 @@ void SaveGSS::writeBufferToFile(size_t numOutFiles, size_t numSpectra) {
       throw std::runtime_error("Failed to close the file at " + m_outFileNames[fileIndex] +
                                " - this file may be empty, corrupted or incorrect.");
     }
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   }
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
 }
 
 void SaveGSS::writeRALFHeader(std::stringstream &out, int bank, const HistogramData::Histogram &histo) const {

--- a/Framework/DataHandling/src/SaveNexusProcessed.cpp
+++ b/Framework/DataHandling/src/SaveNexusProcessed.cpp
@@ -464,7 +464,7 @@ void SaveNexusProcessed::execEvent(Mantid::NeXus::NexusFileIO *nexusFile, const 
   // --- Fill in the combined event arrays ----
   PARALLEL_FOR_NO_WSP_CHECK()
   for (int wi = 0; wi < static_cast<int>(m_eventWorkspace->getNumberHistograms()); wi++) {
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
     const DataObjects::EventList &el = m_eventWorkspace->getSpectrum(wi);
 
     // This is where it will land in the output array.
@@ -484,9 +484,9 @@ void SaveNexusProcessed::execEvent(Mantid::NeXus::NexusFileIO *nexusFile, const 
     }
     m_progress->reportIncrement(el.getNumberEvents(), "Copying EventList");
 
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   }
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
 
   /*Default = DONT compress - much faster*/
   bool CompressNexus = getProperty("CompressNexus");

--- a/Framework/DataHandling/src/SaveToSNSHistogramNexus.cpp
+++ b/Framework/DataHandling/src/SaveToSNSHistogramNexus.cpp
@@ -279,7 +279,7 @@ int SaveToSNSHistogramNexus::WriteOutDataOrErrors(const Geometry::RectangularDet
 
     PARALLEL_FOR_IF(Kernel::threadSafe(*m_inputWorkspace))
     for (int y = 0; y < ypixels; y++) {
-      PARALLEL_START_INTERUPT_REGION
+      PARALLEL_START_INTERRUPT_REGION
       // Get the workspace index for the detector ID at this spot
       size_t wi = 0;
       try {
@@ -306,9 +306,9 @@ int SaveToSNSHistogramNexus::WriteOutDataOrErrors(const Geometry::RectangularDet
         }
       }
 
-      PARALLEL_END_INTERUPT_REGION
+      PARALLEL_END_INTERRUPT_REGION
     }
-    PARALLEL_CHECK_INTERUPT_REGION
+    PARALLEL_CHECK_INTERRUPT_REGION
 
     fillTime += tim1.elapsed();
 

--- a/Framework/Kernel/inc/MantidKernel/MultiThreaded.h
+++ b/Framework/Kernel/inc/MantidKernel/MultiThreaded.h
@@ -89,18 +89,18 @@ template <typename T, typename BinaryOp> void AtomicOp(std::atomic<T> &f, T d, B
 
 /** Begins a block to skip processing is the algorithm has been interupted
  * Note the end of the block if not defined that must be added by including
- * PARALLEL_END_INTERUPT_REGION at the end of the loop
+ * PARALLEL_END_INTERRUPT_REGION at the end of the loop
  */
-#define PARALLEL_START_INTERUPT_REGION                                                                                 \
+#define PARALLEL_START_INTERRUPT_REGION                                                                                \
   if (!m_parallelException && !m_cancel) {                                                                             \
     try {
 
 /** Ends a block to skip processing is the algorithm has been interupted
  * Note the start of the block if not defined that must be added by including
- * PARALLEL_START_INTERUPT_REGION at the start of the loop
+ * PARALLEL_START_INTERRUPT_REGION at the start of the loop
  */
-#define PARALLEL_END_INTERUPT_REGION                                                                                   \
-  } /* End of try block in PARALLEL_START_INTERUPT_REGION */                                                           \
+#define PARALLEL_END_INTERRUPT_REGION                                                                                  \
+  } /* End of try block in PARALLEL_START_INTERRUPT_REGION */                                                          \
   catch (std::exception & ex) {                                                                                        \
     if (!m_parallelException) {                                                                                        \
       m_parallelException = true;                                                                                      \
@@ -110,11 +110,11 @@ template <typename T, typename BinaryOp> void AtomicOp(std::atomic<T> &f, T d, B
   catch (...) {                                                                                                        \
     m_parallelException = true;                                                                                        \
   }                                                                                                                    \
-  } // End of if block in PARALLEL_START_INTERUPT_REGION
+  } // End of if block in PARALLEL_START_INTERRUPT_REGION
 
 /** Adds a check after a Parallel region to see if it was interupted
  */
-#define PARALLEL_CHECK_INTERUPT_REGION                                                                                 \
+#define PARALLEL_CHECK_INTERRUPT_REGION                                                                                \
   if (m_parallelException) {                                                                                           \
     g_log.debug("Exception thrown in parallel region");                                                                \
     throw std::runtime_error(this->name() + ": error (see log)");                                                      \

--- a/Framework/MDAlgorithms/src/ApplyDetailedBalanceMD.cpp
+++ b/Framework/MDAlgorithms/src/ApplyDetailedBalanceMD.cpp
@@ -193,7 +193,7 @@ void ApplyDetailedBalanceMD::applyDetailedBalance(typename Mantid::DataObjects::
 
   PRAGMA_OMP( parallel for if (!ws->isFileBacked()))
   for (int i = 0; i < numBoxes; ++i) {
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
     auto *box = dynamic_cast<MDBox<MDE, nd> *>(boxes[i]);
     if (box && !box->getIsMasked()) {
       // get the MEEvents from box
@@ -221,9 +221,9 @@ void ApplyDetailedBalanceMD::applyDetailedBalance(typename Mantid::DataObjects::
       }
     }
     box->releaseEvents();
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   }
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
 
   return;
 }

--- a/Framework/MDAlgorithms/src/BinMD.cpp
+++ b/Framework/MDAlgorithms/src/BinMD.cpp
@@ -273,7 +273,7 @@ template <typename MDE, size_t nd> void BinMD::binByIterating(typename MDEventWo
 
     PRAGMA_OMP( parallel for schedule(dynamic,1) if (doParallel) )
     for (int chunk = 0; chunk < int(m_binDimensions[chunkDimension]->getNBins()); chunk += chunkNumBins) {
-      PARALLEL_START_INTERUPT_REGION
+      PARALLEL_START_INTERRUPT_REGION
       // Region of interest for this chunk.
       std::vector<size_t> chunkMin(m_outD);
       std::vector<size_t> chunkMax(m_outD);
@@ -326,9 +326,9 @@ template <typename MDE, size_t nd> void BinMD::binByIterating(typename MDEventWo
         if (this->m_cancel)
           break;
       } // for each box in the vector
-      PARALLEL_END_INTERUPT_REGION
+      PARALLEL_END_INTERRUPT_REGION
     } // for each chunk in parallel
-    PARALLEL_CHECK_INTERUPT_REGION
+    PARALLEL_CHECK_INTERRUPT_REGION
 
     // Now the implicit function
     if (implicitFunction) {

--- a/Framework/MDAlgorithms/src/CalculateCoverageDGS.cpp
+++ b/Framework/MDAlgorithms/src/CalculateCoverageDGS.cpp
@@ -388,7 +388,7 @@ void CalculateCoverageDGS::exec() {
 
   PARALLEL_FOR_IF(Kernel::threadSafe(*inputWS))
   for (int64_t i = 0; i < ndets; i++) {
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
     auto intersections = calculateIntersections(tt[i], phi[i]);
     if (intersections.empty())
       continue;
@@ -413,9 +413,9 @@ void CalculateCoverageDGS::exec() {
         continue;
       PARALLEL_CRITICAL(updateMD) { m_normWS->setSignalAt(linIndex, 1.); }
     }
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   }
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
 }
 
 /**

--- a/Framework/MDAlgorithms/src/CompareMDWorkspaces.cpp
+++ b/Framework/MDAlgorithms/src/CompareMDWorkspaces.cpp
@@ -299,7 +299,7 @@ void CompareMDWorkspaces::compareMDEventWorkspaces(typename MDEventWorkspace<MDE
 
   PRAGMA_OMP( parallel for if (!filebacked))
   for (int ibox = 0; ibox < num_boxes; ibox++) {
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
     // No need to compare because the boxes are not same already
     if (!boxes_same) {
       continue;
@@ -327,9 +327,9 @@ void CompareMDWorkspaces::compareMDEventWorkspaces(typename MDEventWorkspace<MDE
       }
     }
 
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   } // for box
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
 
   // throw altogether
   if (!boxes_same) {

--- a/Framework/MDAlgorithms/src/ConvertToDiffractionMDWorkspace.cpp
+++ b/Framework/MDAlgorithms/src/ConvertToDiffractionMDWorkspace.cpp
@@ -493,11 +493,11 @@ void ConvertToDiffractionMDWorkspace::exec() {
     // 2. Process next chunk of spectra (threaded)
     PARALLEL_FOR_IF(Kernel::threadSafe(*m_inWS))
     for (int i = start; i < static_cast<int>(wi); ++i) {
-      PARALLEL_START_INTERUPT_REGION
+      PARALLEL_START_INTERRUPT_REGION
       this->convertSpectrum(specInfo, static_cast<int>(i));
-      PARALLEL_END_INTERUPT_REGION
+      PARALLEL_END_INTERRUPT_REGION
     }
-    PARALLEL_CHECK_INTERUPT_REGION
+    PARALLEL_CHECK_INTERRUPT_REGION
 
     // 3. Split boxes
     if (DODEBUG) {

--- a/Framework/MDAlgorithms/src/DgsScatteredTransmissionCorrectionMD.cpp
+++ b/Framework/MDAlgorithms/src/DgsScatteredTransmissionCorrectionMD.cpp
@@ -147,7 +147,7 @@ void DgsScatteredTransmissionCorrectionMD::correctForTransmission(typename MDEve
 
   PRAGMA_OMP( parallel for if (!ws->isFileBacked()))
   for (int i = 0; i < numBoxes; ++i) {
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
     auto *box = dynamic_cast<MDBox<MDE, nd> *>(boxes[i]);
     if (box && !box->getIsMasked()) {
       std::vector<MDE> &events = box->getEvents();
@@ -161,9 +161,9 @@ void DgsScatteredTransmissionCorrectionMD::correctForTransmission(typename MDEve
       }
     }
     box->releaseEvents();
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   }
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
 }
 
 //---------------------------------------------------------------------------------------------------------

--- a/Framework/MDAlgorithms/src/IntegrateEllipsoids.cpp
+++ b/Framework/MDAlgorithms/src/IntegrateEllipsoids.cpp
@@ -55,7 +55,7 @@ void IntegrateEllipsoids::qListFromEventWS(IntegrateQLabEvents &integrator, Prog
   auto numSpectra = static_cast<int>(wksp->getNumberHistograms());
   PARALLEL_FOR_IF(Kernel::threadSafe(*wksp))
   for (int i = 0; i < numSpectra; ++i) {
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
 
     // units conversion helper
     UnitsConversionHelper unitConverter;
@@ -100,9 +100,9 @@ void IntegrateEllipsoids::qListFromEventWS(IntegrateQLabEvents &integrator, Prog
     PARALLEL_CRITICAL(addEvents) { integrator.addEvents(qList); }
 
     prog.report();
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   } // end of loop over spectra
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
   integrator.populateCellsWithPeaks();
 }
 
@@ -110,7 +110,7 @@ void IntegrateEllipsoids::qListFromHistoWS(IntegrateQLabEvents &integrator, Prog
   auto numSpectra = static_cast<int>(wksp->getNumberHistograms());
   PARALLEL_FOR_IF(Kernel::threadSafe(*wksp))
   for (int i = 0; i < numSpectra; ++i) {
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
 
     // units conversion helper
     UnitsConversionHelper unitConverter;
@@ -158,9 +158,9 @@ void IntegrateEllipsoids::qListFromHistoWS(IntegrateQLabEvents &integrator, Prog
     }
     PARALLEL_CRITICAL(addHisto) { integrator.addEvents(qList); }
     prog.report();
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   } // end of loop over spectra
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
   integrator.populateCellsWithPeaks();
 }
 

--- a/Framework/MDAlgorithms/src/IntegrateEllipsoidsTwoStep.cpp
+++ b/Framework/MDAlgorithms/src/IntegrateEllipsoidsTwoStep.cpp
@@ -338,7 +338,7 @@ void IntegrateEllipsoidsTwoStep::qListFromEventWS(Integrate3DEvents &integrator,
   auto numSpectra = static_cast<int>(wksp->getNumberHistograms());
   PARALLEL_FOR_IF(Kernel::threadSafe(*wksp))
   for (int i = 0; i < numSpectra; ++i) {
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
 
     // units conversion helper
     UnitsConversionHelper unitConverter;
@@ -385,9 +385,9 @@ void IntegrateEllipsoidsTwoStep::qListFromEventWS(Integrate3DEvents &integrator,
     PARALLEL_CRITICAL(addEvents) { integrator.addEvents(qList, hkl_integ); }
 
     prog.report();
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   } // end of loop over spectra
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
 }
 
 /**
@@ -428,7 +428,7 @@ void IntegrateEllipsoidsTwoStep::qListFromHistoWS(Integrate3DEvents &integrator,
   auto numSpectra = static_cast<int>(wksp->getNumberHistograms());
   PARALLEL_FOR_IF(Kernel::threadSafe(*wksp))
   for (int i = 0; i < numSpectra; ++i) {
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
 
     // units conversion helper
     UnitsConversionHelper unitConverter;
@@ -474,9 +474,9 @@ void IntegrateEllipsoidsTwoStep::qListFromHistoWS(Integrate3DEvents &integrator,
     }
     PARALLEL_CRITICAL(addHisto) { integrator.addEvents(qList, hkl_integ); }
     prog.report();
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   } // end of loop over spectra
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
 }
 
 /*

--- a/Framework/MDAlgorithms/src/IntegrateMDHistoWorkspace.cpp
+++ b/Framework/MDAlgorithms/src/IntegrateMDHistoWorkspace.cpp
@@ -326,7 +326,7 @@ void IntegrateMDHistoWorkspace::exec() {
 
     PARALLEL_FOR_NO_WSP_CHECK()
     for (int i = 0; i < int(outIterators.size()); ++i) { // NOLINT
-      PARALLEL_START_INTERUPT_REGION
+      PARALLEL_START_INTERRUPT_REGION
       auto outIterator = dynamic_cast<MDHistoWorkspaceIterator *>(outIterators[i].get());
       if (!outIterator) {
         throw std::logic_error("Failed to cast iterator to MDHistoWorkspaceIterator");
@@ -384,9 +384,9 @@ void IntegrateMDHistoWorkspace::exec() {
 
         progress.report();
       } while (outIterator->next());
-      PARALLEL_END_INTERUPT_REGION
+      PARALLEL_END_INTERRUPT_REGION
     }
-    PARALLEL_CHECK_INTERUPT_REGION
+    PARALLEL_CHECK_INTERRUPT_REGION
     outWS->setDisplayNormalization(inWS->displayNormalizationHisto());
     this->setProperty("OutputWorkspace", outWS);
   }

--- a/Framework/MDAlgorithms/src/IntegratePeaksMDHKL.cpp
+++ b/Framework/MDAlgorithms/src/IntegratePeaksMDHKL.cpp
@@ -112,7 +112,7 @@ void IntegratePeaksMDHKL::exec() {
   auto prog = std::make_unique<Progress>(this, 0.3, 1.0, npeaks);
   PARALLEL_FOR_IF(Kernel::threadSafe(*peakWS))
   for (int i = 0; i < npeaks; i++) {
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
 
     IPeak &p = peakWS->getPeak(i);
     // round to integer
@@ -133,9 +133,9 @@ void IntegratePeaksMDHKL::exec() {
     p.setIntensity(intensity);
     p.setSigmaIntensity(sqrt(errorSquared));
     prog->report();
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   }
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
   // Save the output
   setProperty("OutputWorkspace", peakWS);
 }

--- a/Framework/MDAlgorithms/src/LoadDNSSCD.cpp
+++ b/Framework/MDAlgorithms/src/LoadDNSSCD.cpp
@@ -525,7 +525,7 @@ void LoadDNSSCD::fillOutputWorkspace(double wavelength) {
       if ((theta > theta_min) && (theta < theta_max)) {
         PARALLEL_FOR_IF(Kernel::threadSafe(*m_OutWS, *normWS))
         for (int64_t channel = 0; channel < nchannels; channel++) {
-          PARALLEL_START_INTERUPT_REGION
+          PARALLEL_START_INTERRUPT_REGION
           double signal = ds.signal[i][channel];
           signal_t error = std::sqrt(signal);
           double tof2 = static_cast<double>(channel) * ds.chwidth + 0.5 * ds.chwidth; // bin centers
@@ -556,9 +556,9 @@ void LoadDNSSCD::fillOutputWorkspace(double wavelength) {
                                           static_cast<uint16_t>(expInfoIndex), 0, detid, millerindex.data());
             }
           }
-          PARALLEL_END_INTERUPT_REGION
+          PARALLEL_END_INTERRUPT_REGION
         }
-        PARALLEL_CHECK_INTERUPT_REGION
+        PARALLEL_CHECK_INTERRUPT_REGION
       }
     }
   }
@@ -678,7 +678,7 @@ void LoadDNSSCD::fillOutputWorkspaceRaw(double wavelength) {
       if ((theta > theta_min) && (theta < theta_max)) {
         PARALLEL_FOR_IF(Kernel::threadSafe(*m_OutWS, *normWS))
         for (int64_t channel = 0; channel < nchannels; channel++) {
-          PARALLEL_START_INTERUPT_REGION
+          PARALLEL_START_INTERRUPT_REGION
           double signal = ds.signal[i][channel];
           signal_t error = std::sqrt(signal);
           double tof2(tof2_elastic);
@@ -698,9 +698,9 @@ void LoadDNSSCD::fillOutputWorkspaceRaw(double wavelength) {
             norm_inserter.insertMDEvent(static_cast<float>(norm_signal), static_cast<float>(norm_error * norm_error),
                                         static_cast<uint16_t>(expInfoIndex), 0, detid, datapoint.data());
           }
-          PARALLEL_END_INTERUPT_REGION
+          PARALLEL_END_INTERRUPT_REGION
         }
-        PARALLEL_CHECK_INTERUPT_REGION
+        PARALLEL_CHECK_INTERRUPT_REGION
       }
     }
   }

--- a/Framework/MDAlgorithms/src/MDNorm.cpp
+++ b/Framework/MDAlgorithms/src/MDNorm.cpp
@@ -1525,7 +1525,7 @@ void MDNorm::calculateNormalization(const std::vector<coord_t> &otherValues, con
 
 PRAGMA_OMP(parallel for private(intersections, xValues, yValues, pos, posNew) if (safe))
 for (int64_t i = 0; i < ndets; i++) {
-  PARALLEL_START_INTERUPT_REGION
+  PARALLEL_START_INTERRUPT_REGION
 
   // Skip: non-existing detector, monitor and masked detector
   if (!spectrumInfo.hasDetectors(i) || spectrumInfo.isMonitor(i) || spectrumInfo.isMasked(i)) {
@@ -1583,9 +1583,9 @@ for (int64_t i = 0; i < ndets; i++) {
 
   prog->report();
 
-  PARALLEL_END_INTERUPT_REGION
+  PARALLEL_END_INTERRUPT_REGION
 }
-PARALLEL_CHECK_INTERUPT_REGION
+PARALLEL_CHECK_INTERRUPT_REGION
 if (m_accumulate) {
   std::transform(signalArray.cbegin(), signalArray.cend(), m_normWS->getSignalArray(), m_normWS->mutableSignalArray(),
                  [](const std::atomic<signal_t> &a, const signal_t &b) { return a + b; });

--- a/Framework/MDAlgorithms/src/MDNormDirectSC.cpp
+++ b/Framework/MDAlgorithms/src/MDNormDirectSC.cpp
@@ -465,7 +465,7 @@ void MDNormDirectSC::calculateNormalization(const std::vector<coord_t> &otherVal
 
 PRAGMA_OMP(parallel for private(intersections, pos, posNew))
 for (int64_t i = 0; i < ndets; i++) {
-  PARALLEL_START_INTERUPT_REGION
+  PARALLEL_START_INTERRUPT_REGION
 
   if (!spectrumInfo.hasDetectors(i) || spectrumInfo.isMonitor(i) || spectrumInfo.isMasked(i)) {
     continue;
@@ -518,9 +518,9 @@ for (int64_t i = 0; i < ndets; i++) {
   }
   prog->report();
 
-  PARALLEL_END_INTERUPT_REGION
+  PARALLEL_END_INTERRUPT_REGION
 }
-PARALLEL_CHECK_INTERUPT_REGION
+PARALLEL_CHECK_INTERRUPT_REGION
 if (m_accumulate) {
   std::transform(signalArray.cbegin(), signalArray.cend(), m_normWS->getSignalArray(), m_normWS->mutableSignalArray(),
                  [](const std::atomic<signal_t> &a, const signal_t &b) { return a + b; });

--- a/Framework/MDAlgorithms/src/MDNormSCD.cpp
+++ b/Framework/MDAlgorithms/src/MDNormSCD.cpp
@@ -414,7 +414,7 @@ void MDNormSCD::calculateNormalization(const std::vector<coord_t> &otherValues,
 
 PRAGMA_OMP(parallel for private(intersections, xValues, yValues, pos, posNew) if (Kernel::threadSafe(*integrFlux)))
 for (int64_t i = 0; i < ndets; i++) {
-  PARALLEL_START_INTERUPT_REGION
+  PARALLEL_START_INTERRUPT_REGION
 
   if (!spectrumInfo.hasDetectors(i) || spectrumInfo.isMonitor(i) || spectrumInfo.isMasked(i)) {
     continue;
@@ -480,9 +480,9 @@ for (int64_t i = 0; i < ndets; i++) {
   }
   prog->report();
 
-  PARALLEL_END_INTERUPT_REGION
+  PARALLEL_END_INTERRUPT_REGION
 }
-PARALLEL_CHECK_INTERUPT_REGION
+PARALLEL_CHECK_INTERRUPT_REGION
 if (m_accumulate) {
   std::transform(signalArray.cbegin(), signalArray.cend(), m_normWS->getSignalArray(), m_normWS->mutableSignalArray(),
                  [](const std::atomic<signal_t> &a, const signal_t &b) { return a + b; });

--- a/Framework/MDAlgorithms/src/MergeMD.cpp
+++ b/Framework/MDAlgorithms/src/MergeMD.cpp
@@ -215,7 +215,7 @@ template <typename MDE, size_t nd> void MergeMD::doPlus(typename MDEventWorkspac
 
     PRAGMA_OMP( parallel for if (!ws2->isFileBacked()) )
     for (int i = 0; i < numBoxes; i++) {
-      PARALLEL_START_INTERUPT_REGION
+      PARALLEL_START_INTERRUPT_REGION
       auto *box = dynamic_cast<MDBox<MDE, nd> *>(boxes[i]);
       if (box && !box->getIsMasked()) {
         // Copy the events from WS2 and add them into WS1
@@ -235,9 +235,9 @@ template <typename MDE, size_t nd> void MergeMD::doPlus(typename MDEventWorkspac
         else
           box->releaseEvents();
       }
-      PARALLEL_END_INTERUPT_REGION
+      PARALLEL_END_INTERRUPT_REGION
     }
-    PARALLEL_CHECK_INTERUPT_REGION
+    PARALLEL_CHECK_INTERRUPT_REGION
 
     // Progress * prog2 = new Progress(this, 0.4, 0.9, 100);
     Progress *prog2 = nullptr;

--- a/Framework/MDAlgorithms/src/PolarizationAngleCorrectionMD.cpp
+++ b/Framework/MDAlgorithms/src/PolarizationAngleCorrectionMD.cpp
@@ -155,7 +155,7 @@ void PolarizationAngleCorrectionMD::applyPolarizationAngleCorrection(
 
   PRAGMA_OMP( parallel for if (!ws->isFileBacked()))
   for (int i = 0; i < numBoxes; ++i) {
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
     auto *box = dynamic_cast<MDBox<MDE, nd> *>(boxes[i]);
     if (box && !box->getIsMasked()) {
       // get the MEEvents from box
@@ -201,9 +201,9 @@ void PolarizationAngleCorrectionMD::applyPolarizationAngleCorrection(
       }
     }
     box->releaseEvents();
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   }
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
 
   return;
 }

--- a/Framework/MDAlgorithms/src/ReplicateMD.cpp
+++ b/Framework/MDAlgorithms/src/ReplicateMD.cpp
@@ -325,7 +325,7 @@ void ReplicateMD::exec() {
   PARALLEL_FOR_NO_WSP_CHECK()
   for (int it = 0; it < int(iterators.size()); ++it) { // NOLINT
 
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
     auto outIt = dynamic_cast<MDHistoWorkspaceIterator *>(iterators[it].get());
 
     // Iterate over the output workspace
@@ -347,9 +347,9 @@ void ReplicateMD::exec() {
 
     } while (outIt->next());
 
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   }
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
 
   this->setProperty("OutputWorkspace", outputWS);
 }

--- a/Framework/MDAlgorithms/src/SmoothMD.cpp
+++ b/Framework/MDAlgorithms/src/SmoothMD.cpp
@@ -177,7 +177,7 @@ IMDHistoWorkspace_sptr SmoothMD::hatSmooth(const IMDHistoWorkspace_const_sptr &t
   PARALLEL_FOR_NO_WSP_CHECK()
   for (int it = 0; it < int(iterators.size()); ++it) { // NOLINT
 
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
     auto iterator = dynamic_cast<MDHistoWorkspaceIterator *>(iterators[it].get());
 
     if (!iterator) {
@@ -234,9 +234,9 @@ IMDHistoWorkspace_sptr SmoothMD::hatSmooth(const IMDHistoWorkspace_const_sptr &t
       progress.report();
 
     } while (iterator->next());
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   }
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
 
   return outWS;
 }
@@ -292,7 +292,7 @@ IMDHistoWorkspace_sptr SmoothMD::gaussianSmooth(const IMDHistoWorkspace_const_sp
     PARALLEL_FOR_NO_WSP_CHECK()
     for (int it = 0; it < int(iterators.size()); ++it) { // NOLINT
 
-      PARALLEL_START_INTERUPT_REGION
+      PARALLEL_START_INTERRUPT_REGION
       auto iterator = dynamic_cast<MDHistoWorkspaceIterator *>(iterators[it].get());
       if (!iterator) {
         throw std::logic_error("Failed to cast IMDIterator to MDHistoWorkspaceIterator");
@@ -338,9 +338,9 @@ IMDHistoWorkspace_sptr SmoothMD::gaussianSmooth(const IMDHistoWorkspace_const_sp
         progress.report();
 
       } while (iterator->next());
-      PARALLEL_END_INTERUPT_REGION
+      PARALLEL_END_INTERRUPT_REGION
     }
-    PARALLEL_CHECK_INTERUPT_REGION
+    PARALLEL_CHECK_INTERRUPT_REGION
   }
 
   return write_ws;

--- a/Framework/MDAlgorithms/src/ThresholdMD.cpp
+++ b/Framework/MDAlgorithms/src/ThresholdMD.cpp
@@ -108,7 +108,7 @@ void ThresholdMD::exec() {
 
   PARALLEL_FOR_IF(Kernel::threadSafe(*inputWS, *outWS))
   for (int64_t i = 0; i < nPoints; ++i) {
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
     const double signalAt = inputWS->getSignalAt(i);
     if (comparitor(signalAt)) {
       outWS->setSignalAt(i, customOverwriteValue);
@@ -116,9 +116,9 @@ void ThresholdMD::exec() {
     if (i % frequency == 0) {
       prog.report();
     }
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   }
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
 
   setProperty("OutputWorkspace", outWS);
 }

--- a/Framework/MDAlgorithms/src/TransformMD.cpp
+++ b/Framework/MDAlgorithms/src/TransformMD.cpp
@@ -74,14 +74,14 @@ void TransformMD::doTransform(typename Mantid::DataObjects::MDEventWorkspace<MDE
 
   PARALLEL_FOR_IF(!ws->isFileBacked())
   for (int i = 0; i < static_cast<int>(boxes.size()); i++) { // NOLINT
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
     auto *box = dynamic_cast<MDBoxBase<MDE, nd> *>(boxes[i]);
     if (box) {
       box->transformDimensions(m_scaling, m_offset);
     }
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   }
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
 }
 
 //----------------------------------------------------------------------------------------------

--- a/Framework/MDAlgorithms/src/TransposeMD.cpp
+++ b/Framework/MDAlgorithms/src/TransposeMD.cpp
@@ -122,7 +122,7 @@ void TransposeMD::exec() {
   PARALLEL_FOR_NO_WSP_CHECK()
   for (int it = 0; it < int(iterators.size()); ++it) { // NOLINT
 
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
     auto inIterator = iterators[it].get();
     do {
       auto center = inIterator->getCenter();
@@ -138,9 +138,9 @@ void TransposeMD::exec() {
       outWS->setMDMaskAt(index, inIterator->getIsMasked());
       progress.report();
     } while (inIterator->next());
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   }
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
 
   this->setProperty("OutputWorkspace", outWS);
 }

--- a/Framework/Muon/src/EstimateMuonAsymmetryFromCounts.cpp
+++ b/Framework/Muon/src/EstimateMuonAsymmetryFromCounts.cpp
@@ -137,14 +137,14 @@ void EstimateMuonAsymmetryFromCounts::exec() {
     // Copy all the Y and E data
     PARALLEL_FOR_IF(Kernel::threadSafe(*inputWS, *outputWS))
     for (int64_t i = 0; i < int64_t(numSpectra); ++i) {
-      PARALLEL_START_INTERUPT_REGION
+      PARALLEL_START_INTERRUPT_REGION
       const auto index = static_cast<size_t>(i);
       outputWS->setSharedY(index, inputWS->sharedY(index));
       outputWS->setSharedE(index, inputWS->sharedE(index));
       prog.report();
-      PARALLEL_END_INTERUPT_REGION
+      PARALLEL_END_INTERRUPT_REGION
     }
-    PARALLEL_CHECK_INTERUPT_REGION
+    PARALLEL_CHECK_INTERRUPT_REGION
   }
 
   // Do the specified spectra only
@@ -160,7 +160,7 @@ void EstimateMuonAsymmetryFromCounts::exec() {
 
   PARALLEL_FOR_IF(Kernel::threadSafe(*inputWS, *outputWS))
   for (int i = 0; i < specLength; ++i) {
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
     const auto specNum = static_cast<size_t>(spectra[i]);
 
     if (spectra[i] > static_cast<int>(numSpectra)) {
@@ -188,9 +188,9 @@ void EstimateMuonAsymmetryFromCounts::exec() {
     outputWS->mutableE(specNum) /= normConst;
     norm[i] = normConst;
     prog.report();
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   }
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
   if (extraData) {
     unnormWS->setYUnit("Asymmetry");
     setProperty("OutputUnNormWorkspace", unnormWS);

--- a/Framework/Muon/src/RemoveExpDecay.cpp
+++ b/Framework/Muon/src/RemoveExpDecay.cpp
@@ -82,21 +82,21 @@ void MuonRemoveExpDecay::exec() {
     // Copy all the Y and E data
     PARALLEL_FOR_IF(Kernel::threadSafe(*inputWS, *outputWS))
     for (int64_t i = 0; i < int64_t(numSpectra); ++i) {
-      PARALLEL_START_INTERUPT_REGION
+      PARALLEL_START_INTERRUPT_REGION
       const auto index = static_cast<size_t>(i);
       outputWS->setSharedY(index, inputWS->sharedY(index));
       outputWS->setSharedE(index, inputWS->sharedE(index));
       prog.report();
-      PARALLEL_END_INTERUPT_REGION
+      PARALLEL_END_INTERRUPT_REGION
     }
-    PARALLEL_CHECK_INTERUPT_REGION
+    PARALLEL_CHECK_INTERRUPT_REGION
   }
 
   // Do the specified spectra only
   auto specLength = static_cast<int>(spectra.size());
   PARALLEL_FOR_IF(Kernel::threadSafe(*inputWS, *outputWS))
   for (int i = 0; i < specLength; ++i) {
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
     const auto specNum = static_cast<size_t>(spectra[i]);
     if (spectra[i] > numSpectra) {
       g_log.error("Spectra size greater than the number of spectra!");
@@ -120,9 +120,9 @@ void MuonRemoveExpDecay::exec() {
     }
 
     prog.report();
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   }
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
 
   // Update Y axis units
   outputWS->setYUnit("Asymmetry");

--- a/Framework/WorkflowAlgorithms/src/SANSSolidAngleCorrection.cpp
+++ b/Framework/WorkflowAlgorithms/src/SANSSolidAngleCorrection.cpp
@@ -108,7 +108,7 @@ void SANSSolidAngleCorrection::exec() {
   const auto &spectrumInfo = inputWS->spectrumInfo();
   PARALLEL_FOR_IF(Kernel::threadSafe(*outputWS, *inputWS))
   for (int i = 0; i < numHists; ++i) {
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
     outputWS->setSharedX(i, inputWS->sharedX(i));
 
     if (!spectrumInfo.hasDetectors(i)) {
@@ -151,9 +151,9 @@ void SANSSolidAngleCorrection::exec() {
       EOut[j] = fabs(EIn[j] * corr);
     }
     progress.report("Solid Angle Correction");
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   }
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
   setProperty("OutputMessage", "Solid angle correction applied");
 }
 
@@ -175,7 +175,7 @@ void SANSSolidAngleCorrection::execEvent() {
   const auto &spectrumInfo = outputEventWS->spectrumInfo();
   PARALLEL_FOR_IF(Kernel::threadSafe(*outputEventWS))
   for (int i = 0; i < numberOfSpectra; i++) {
-    PARALLEL_START_INTERUPT_REGION
+    PARALLEL_START_INTERRUPT_REGION
 
     if (!spectrumInfo.hasDetectors(i)) {
       g_log.warning() << "Workspace index " << i << " has no detector assigned to it - discarding\n";
@@ -201,9 +201,9 @@ void SANSSolidAngleCorrection::execEvent() {
     EventList &el = outputEventWS->getSpectrum(i);
     el *= corr;
     progress.report("Solid Angle Correction");
-    PARALLEL_END_INTERUPT_REGION
+    PARALLEL_END_INTERRUPT_REGION
   }
-  PARALLEL_CHECK_INTERUPT_REGION
+  PARALLEL_CHECK_INTERRUPT_REGION
 
   setProperty("OutputMessage", "Solid angle correction applied");
 }

--- a/dev-docs/source/MultiThreadingInMantid.rst
+++ b/dev-docs/source/MultiThreadingInMantid.rst
@@ -23,13 +23,13 @@ one over the spectra in a workspace) is as follows:
      PARALLEL_FOR_IF(Kernel::threadSafe(*inputWS, *outputWS))
      for (int i = 0; i < numSpec; ++i)
      {
-       PARALLEL_START_INTERUPT_REGION
+       PARALLEL_START_INTERRUPT_REGION
 
        // .... algorithm code ....
 
-       PARALLEL_END_INTERUPT_REGION
+       PARALLEL_END_INTERRUPT_REGION
      }
-     PARALLEL_CHECK_INTERUPT_REGION
+     PARALLEL_CHECK_INTERRUPT_REGION
 
 
 The main work is in the first statement, which contains the


### PR DESCRIPTION
**Description of work.**
Simply removes a mispelling from the Interrupt macros in `Multithreading.h`. Seemed worth doing given how frequently they are used in algorithms and the like. 

**To test:**
Try a few algorithms to check they work as expected. Should be mostly covered by the unit tests. Any errors would stop the build. 


*There is no associated issue.*


*This does not require release notes* because **it is a maintenance fix with no user facing effects**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
