### PR TITLE
Fix generation of doc source links on windows

### DIFF
--- a/docs/sphinxext/mantiddoc/directives/sourcelink.py
+++ b/docs/sphinxext/mantiddoc/directives/sourcelink.py
@@ -91,9 +91,9 @@ class SourceLinkDirective(AlgorithmBaseDirective):
                 # prepend the base framework directory
                 fname = os.path.join(self.source_root, file_paths[extension])
                 file_paths[extension] = fname
-                if not os.path.exists(file_paths[extension][0]):
+                if not os.path.exists(file_paths[extension]):
                     error_string += "Cannot find {} file at {}\n".format(
-                        extension, file_paths[extension][0])
+                        extension, file_paths[extension])
 
         # throw accumulated errors now if you have any
         if error_string != "":


### PR DESCRIPTION
**Description of work.**

Docs build currently failing on Windows due to problem with generating source links where an explicit file path has been provided in the .rst file (eg CatalogSearch-v1.rst). The source links were recently changed in https://github.com/mantidproject/mantid/pull/33350

**To test:**

Build docs on Windows

*There is no associated issue.*

*This does not require release notes* because **not visible to users**

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
