### PR TITLE
Add a Historgram validation check to Indirect Absorption Corrections

### DIFF
--- a/docs/source/interfaces/indirect/Indirect Corrections.rst
+++ b/docs/source/interfaces/indirect/Indirect Corrections.rst
@@ -414,6 +414,8 @@ Container Radius
 Sample Height
   Height of the sample in :math:`cm`.
 
+.. _indirect_apply_absorp_correct:
+
 Apply Absorption Corrections
 ----------------------------
 

--- a/docs/source/release/v6.3.0/33403_indirect_geometry.rst
+++ b/docs/source/release/v6.3.0/33403_indirect_geometry.rst
@@ -1,0 +1,3 @@
+Improvements
+------------
+- Added a validation check to the :ref:`Apply Absorption Corrections Tab<indirect_apply_absorp_correct>` in the ref:`Corrections GUI <interface-indirect-corrections>' that makes sure the sample workspace and corrections workspaces all have the same number of histograms.

--- a/qt/scientific_interfaces/Indirect/ApplyAbsorptionCorrections.cpp
+++ b/qt/scientific_interfaces/Indirect/ApplyAbsorptionCorrections.cpp
@@ -180,13 +180,13 @@ void ApplyAbsorptionCorrections::run() {
   setRunIsRunning(true);
 
   // Create / Initialize algorithm
-  auto absCorProps = std::unique_ptr<MantidQt::API::AlgorithmRuntimeProps>();
+  auto absCorProps = std::make_unique<MantidQt::API::AlgorithmRuntimeProps>();
   IAlgorithm_sptr applyCorrAlg = AlgorithmManager::Instance().create("ApplyPaalmanPingsCorrection");
   applyCorrAlg->initialize();
 
   // get Sample Workspace
   auto const sampleWs = getADSWorkspace(m_sampleWorkspaceName);
-  absCorProps->setPropertyValue("SampleWorkspace", m_sampleWorkspaceName);
+  absCorProps->setProperty("SampleWorkspace", sampleWs);
 
   const bool useCan = m_uiForm.ckUseCan->isChecked();
   // Get Can and Clone
@@ -239,10 +239,9 @@ void ApplyAbsorptionCorrections::run() {
 
   QString correctionsWsName = m_uiForm.dsCorrections->getCurrentDataName();
 
-  auto const corrections = getADSWorkspace<WorkspaceGroup>(correctionsWsName.toStdString());
   bool interpolateAll = false;
-  for (std::size_t i = 0; i < corrections->size(); i++) {
-    MatrixWorkspace_sptr factorWs = std::dynamic_pointer_cast<MatrixWorkspace>(corrections->getItem(i));
+  for (std::size_t i = 0; i < m_ppCorrectionsGp->size(); i++) {
+    MatrixWorkspace_sptr factorWs = std::dynamic_pointer_cast<MatrixWorkspace>(m_ppCorrectionsGp->getItem(i));
 
     // Check for matching binning
     const auto factorBlocksize = factorWs->blocksize();
@@ -275,8 +274,7 @@ void ApplyAbsorptionCorrections::run() {
         return;
       }
     }
-
-    applyCorrAlg->setProperty("CorrectionsWorkspace", correctionsWsName.toStdString());
+    applyCorrAlg->setProperty("CorrectionsWorkspace", m_correctionsGroupName);
   }
 
   // Generate output workspace name
@@ -434,6 +432,20 @@ bool ApplyAbsorptionCorrections::validate() {
   // Validate the corrections workspace
   validateDataIsOfType(uiv, m_uiForm.dsCorrections, "Corrections", DataType::Corrections);
 
+  // Check sample has the same number of Histograms as each of the workspaces in the corrections group
+  m_correctionsGroupName = m_uiForm.dsCorrections->getCurrentDataName().toStdString();
+  m_ppCorrectionsGp = getADSWorkspace<WorkspaceGroup>(m_correctionsGroupName);
+
+  for (std::size_t i = 0; i < m_ppCorrectionsGp->size(); i++) {
+    MatrixWorkspace_sptr factorWs = std::dynamic_pointer_cast<MatrixWorkspace>(m_ppCorrectionsGp->getItem(i));
+
+    const size_t sampleHist = m_ppSampleWS->getNumberHistograms();
+    const size_t containerHist = factorWs->getNumberHistograms();
+
+    if (sampleHist != containerHist) {
+      uiv.addErrorMessage(" Sample and Container do not have a matching number of Histograms.");
+    }
+  }
   // Show errors if there are any
   if (!uiv.isAllInputValid())
     emit showMessageBox(uiv.generateErrorMessage());

--- a/qt/scientific_interfaces/Indirect/ApplyAbsorptionCorrections.cpp
+++ b/qt/scientific_interfaces/Indirect/ApplyAbsorptionCorrections.cpp
@@ -180,13 +180,13 @@ void ApplyAbsorptionCorrections::run() {
   setRunIsRunning(true);
 
   // Create / Initialize algorithm
-  auto absCorProps = std::make_unique<MantidQt::API::AlgorithmRuntimeProps>();
+  auto absCorProps = std::unique_ptr<MantidQt::API::AlgorithmRuntimeProps>();
   IAlgorithm_sptr applyCorrAlg = AlgorithmManager::Instance().create("ApplyPaalmanPingsCorrection");
   applyCorrAlg->initialize();
 
   // get Sample Workspace
   auto const sampleWs = getADSWorkspace(m_sampleWorkspaceName);
-  absCorProps->setProperty("SampleWorkspace", sampleWs);
+  absCorProps->setPropertyValue("SampleWorkspace", m_sampleWorkspaceName);
 
   const bool useCan = m_uiForm.ckUseCan->isChecked();
   // Get Can and Clone

--- a/qt/scientific_interfaces/Indirect/ApplyAbsorptionCorrections.h
+++ b/qt/scientific_interfaces/Indirect/ApplyAbsorptionCorrections.h
@@ -61,9 +61,11 @@ private:
 
   std::string m_sampleWorkspaceName;
   std::string m_containerWorkspaceName;
+  std::string m_correctionsGroupName;
   /// Loaded workspaces
   Mantid::API::MatrixWorkspace_sptr m_ppSampleWS;
   Mantid::API::MatrixWorkspace_sptr m_ppContainerWS;
+  Mantid::API::WorkspaceGroup_sptr m_ppCorrectionsGp;
 
   size_t m_spectra;
 };


### PR DESCRIPTION
**Description of work.**
In the process of trying to fix #33384 it was suggested that this might be resolved by adding a check to the number of histograms in the sample and corrections workspaces (they need to be the same). This check is already used in other tabs in the Indirect Corrections GUI.

Whilst this did not fix the fault that occurred the addition of this check is sensible and has been done using this PR.

**Report to:** Spencer Howells

**To test:**
1. Using #33395 make changes to lines 183 and 189 of the ApplyAbsorptionCorrections.cpp file (otherwise you cannot load any files without it crashing).
1. Open Indirect -> Corrections
2. Open the Apply Absorptions Corrections Tab
3. Load a sample file (ask for file if you don't have anything suitable)
4. Load a corrections file with the same number of histograms (ask for file if you don't have anything suitable)
5. Press Run. It should complete successfully
6. Change the corrections file to one with a different number of histograms (ask if you don't have anything suitable)
7. Press run. You should get a pop up explaining the number of histograms doesn't match and it will not proceed with applying the corrections.

Partially Fixes #33384 


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
