### PR TITLE
Avoid scrolling down in comboboxes of the DrILL settings

### DIFF
--- a/docs/source/release/v6.4.0/mantidworkbench.rst
+++ b/docs/source/release/v6.4.0/mantidworkbench.rst
@@ -11,5 +11,6 @@ New and Improved
 
 Bugfixes
 --------
+- In DrILL interface, scrolling down in the settings dialog no longer affects the comboxes
 
 :ref:`Release 6.4.0 <v6.4.0>`

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/drill/view/DrillSettingsDialog.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/drill/view/DrillSettingsDialog.py
@@ -6,7 +6,7 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 
 import os
-from qtpy.QtCore import QObject, Signal
+from qtpy.QtCore import QObject, Signal, QEvent
 
 from qtpy.QtWidgets import QDialog, QComboBox, QCheckBox, QLineEdit, QLabel
 
@@ -14,6 +14,22 @@ from qtpy import uic
 
 from mantidqt.widgets.filefinderwidget import FileFinderWidget
 from mantidqt.widgets.workspaceselector import WorkspaceSelector
+
+
+class MouseScrollEater(QObject):
+    """
+    Event filter to eat the scroll event. This is used on comboboxes that appear
+    in potential scroll area to avoid scrolling the combobox while scrolling in
+    the dialog.
+    """
+    def __init__(self):
+        super(MouseScrollEater, self).__init__()
+
+    def eventFilter(self, obj, event):
+        if event.type() == QEvent.Wheel:
+            return True
+        else:
+            return False
 
 
 class DrillSetting(QObject):
@@ -64,6 +80,8 @@ class DrillSetting(QObject):
 
         elif (settingType == "combobox"):
             self._widget = QComboBox()
+            self._widgetEventFilter = MouseScrollEater()
+            self._widget.installEventFilter(self._widgetEventFilter)
             self._widget.addItems(values)
             self._widget.currentTextChanged.connect(
                     lambda t : self.valueChanged.emit(name)

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/drill/view/DrillSettingsDialog.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/drill/view/DrillSettingsDialog.py
@@ -26,6 +26,13 @@ class MouseScrollEventFilter(QObject):
         super(MouseScrollEventFilter, self).__init__()
 
     def eventFilter(self, obj, event):
+        """
+        Override QObject::eventFilter
+
+        Args:
+            obj (QObject): object on which the event is called
+            event (QEvent): event received
+        """
         return event.type() == QEvent.Wheel
 
 

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/drill/view/DrillSettingsDialog.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/drill/view/DrillSettingsDialog.py
@@ -16,14 +16,14 @@ from mantidqt.widgets.filefinderwidget import FileFinderWidget
 from mantidqt.widgets.workspaceselector import WorkspaceSelector
 
 
-class MouseScrollEater(QObject):
+class MouseScrollEventFilter(QObject):
     """
     Event filter to eat the scroll event. This is used on comboboxes that appear
     in potential scroll area to avoid scrolling the combobox while scrolling in
     the dialog.
     """
     def __init__(self):
-        super(MouseScrollEater, self).__init__()
+        super(MouseScrollEventFilter, self).__init__()
 
     def eventFilter(self, obj, event):
         if event.type() == QEvent.Wheel:
@@ -80,7 +80,7 @@ class DrillSetting(QObject):
 
         elif (settingType == "combobox"):
             self._widget = QComboBox()
-            self._widgetEventFilter = MouseScrollEater()
+            self._widgetEventFilter = MouseScrollEventFilter()
             self._widget.installEventFilter(self._widgetEventFilter)
             self._widget.addItems(values)
             self._widget.currentTextChanged.connect(

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/drill/view/DrillSettingsDialog.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/drill/view/DrillSettingsDialog.py
@@ -26,10 +26,7 @@ class MouseScrollEventFilter(QObject):
         super(MouseScrollEventFilter, self).__init__()
 
     def eventFilter(self, obj, event):
-        if event.type() == QEvent.Wheel:
-            return True
-        else:
-            return False
+        return event.type() == QEvent.Wheel
 
 
 class DrillSetting(QObject):


### PR DESCRIPTION
**Description of work.**

This PR disables the scroll event on comboboxes of the DrILL settings dialog.

Because the settings dialog contains a scroll area, the scroll event is used to navigate through the dialog. Annoyingly, if the mouse was going over a combobox during the scrolling, the event was caught and the combobox selection was changed.

**To test:**

* open DrILL (Interfaces -> ILL -> DrILL)
* open the settings dialog (gear icon of the toolbar)
* try to scroll down on the dialog and on the comboboxes of the dialog
* the scroll event should not be caught by comboboxes

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
