### PR TITLE
Add support for $CONDA_BLD_PATH for different conda-build paths to Jenkins

### DIFF
--- a/buildconfig/Jenkins/Conda/nightly_build_and_deploy.jenkinsfile
+++ b/buildconfig/Jenkins/Conda/nightly_build_and_deploy.jenkinsfile
@@ -82,9 +82,7 @@ pipeline {
                 GITHUB_ACCESS_TOKEN = credentials("${GITHUB_TOKEN_CREDENTIAL_ID}")
             }
             steps {
-                catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
-                    sh '$WORKSPACE/buildconfig/Jenkins/Conda/update-conda-recipes.sh $GITHUB_ACCESS_TOKEN $GITHUB_USER_NAME'
-                }
+               sh '$WORKSPACE/buildconfig/Jenkins/Conda/update-conda-recipes.sh $GITHUB_ACCESS_TOKEN $GITHUB_USER_NAME'
             }
         }
         stage('Package and Test') {

--- a/buildconfig/Jenkins/Conda/nightly_build_and_deploy.jenkinsfile
+++ b/buildconfig/Jenkins/Conda/nightly_build_and_deploy.jenkinsfile
@@ -2,6 +2,7 @@
 // GITHUB_TOKEN_CREDENTIAL_ID - The name of the credentials token in Jenkins that you want to use for cloning and pushing to the conda-recipes repo
 // ANACONDA_TOKEN_CREDENTIAL_ID - The name of the credentials token in Jenkins that you want to use for publishing conda packages
 // ANACONDA_CHANNEL - The channel to publish to on Anaconda.org
+// CONDA_BLD_PATH - The path to where conda-build will construct the packages, needed for windows due to path length.
 
 def build_and_test_linux() {
     sh "$WORKSPACE/buildconfig/Jenkins/Conda/conda-buildscript $WORKSPACE linux-ci --enable-systemtests --enable-doctests --clean-build --clean-external-projects"
@@ -21,20 +22,27 @@ def conda_build_UNIX(){
 
 def conda_build_linux() {
     conda_build_UNIX()
-    archive:
-        includes: "mambaforge/envs/mantid-conda-build-env/conda-bld/linux-64/*.tar.bz2"
+    archive_conda_build("linux-64")
 }
 
 def conda_build_macos() {
     conda_build_UNIX()
-    archive:
-        includes: "mambaforge/envs/mantid-conda-build-env/conda-bld/osx-64/*.tar.bz2"
+    archive_conda_build("osx-64")
 }
 
 def conda_build_win(){
     bat "\"C:\\Program Files\\git\\bin\\bash.exe\" -c \"C:/Jenkins/workspace/$JOB_NAME/buildconfig/Jenkins/Conda/conda-build-recipes C:/Jenkins/workspace/$JOB_NAME --build-mantid --build-qt --build-workbench\""
-    archive:
-        includes: "mambaforge/envs/mantid-conda-build-env/conda-bld/win-64/*.tar.bz2"
+    archive_conda_build("win-64")
+}
+
+def archive_conda_build(build_name) {
+    if (env.CONDA_BLD_PATH != null) {
+        archive:
+            includes: "$CONDA_BLD_PATH/$build_name/*.tar.bz2"
+    } else {
+        archive:
+            includes: "mambaforge/envs/mantid-conda-build-env/conda-bld/$build_name/*.tar.bz2"
+    }
 }
 
 pipeline {
@@ -42,7 +50,7 @@ pipeline {
     stages {
         stage('Build and Test'){
             parallel {
-                stage('Build and Test on Ubuntu'){
+                stage('Build and Test on Ubuntu') {
                     agent { label 'ubuntu-18.04-build' }
                     steps {
                         build_and_test_linux()
@@ -74,7 +82,9 @@ pipeline {
                 GITHUB_ACCESS_TOKEN = credentials("${GITHUB_TOKEN_CREDENTIAL_ID}")
             }
             steps {
-                sh '$WORKSPACE/buildconfig/Jenkins/Conda/update-conda-recipes.sh $GITHUB_ACCESS_TOKEN $GITHUB_USER_NAME'
+                catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
+                    sh '$WORKSPACE/buildconfig/Jenkins/Conda/update-conda-recipes.sh $GITHUB_ACCESS_TOKEN $GITHUB_USER_NAME'
+                }
             }
         }
         stage('Package and Test') {

--- a/buildconfig/Jenkins/Conda/run-tests
+++ b/buildconfig/Jenkins/Conda/run-tests
@@ -59,7 +59,6 @@ function onexit {
 if [[ $OSTYPE == "msys"* ]]; then
     userconfig_dir=$WORKSPACE/build/bin/Release
     rm -rf $userconfig_dir/Mantid.user.properties
-    rm -rf $userconfig_dir/Mantid.properties
 else
     userconfig_dir=$HOME/.mantid
     rm -fr $userconfig_dir

--- a/buildconfig/Jenkins/Conda/run-tests
+++ b/buildconfig/Jenkins/Conda/run-tests
@@ -103,7 +103,6 @@ fi
 if [[ $ENABLE_SYSTEM_TESTS == true ]]; then
     if [[ $OSTYPE == "msys"* ]]; then
         rm -rf $userconfig_dir/Mantid.user.properties
-        rm -rf $userconfig_dir/Mantid.properties
     else
         rm -fr $userconfig_dir
     fi

--- a/buildconfig/Jenkins/Conda/run-tests
+++ b/buildconfig/Jenkins/Conda/run-tests
@@ -56,13 +56,19 @@ function onexit {
 
 # Clean up prior to testing
 # Prevent race conditions when creating the user config directory
-userconfig_dir=$HOME/.mantid
-rm -fr $userconfig_dir
+if [[ $OSTYPE == "msys"* ]]; then
+    userconfig_dir=$WORKSPACE/build/bin/Release
+    rm -rf $userconfig_dir/Mantid.user.properties
+    rm -rf $userconfig_dir/Mantid.properties
+else
+    userconfig_dir=$HOME/.mantid
+    rm -fr $userconfig_dir
+    mkdir -p $userconfig_dir
+fi
 
 # Remove GUI qsettings files
 rm -f ~/.config/mantidproject/mantidworkbench.ini
 
-mkdir -p $userconfig_dir
 # use a fixed number of openmp threads to avoid overloading the system
 echo MultiThreaded.MaxCores=2 > $userconfig_dir/Mantid.user.properties
 
@@ -95,7 +101,12 @@ if [[ $ENABLE_DOCS == true && $ENABLE_DOC_TESTS == true ]]; then
 fi
 
 if [[ $ENABLE_SYSTEM_TESTS == true ]]; then
-    rm -fr $userconfig_dir
+    if [[ $OSTYPE == "msys"* ]]; then
+        rm -rf $userconfig_dir/Mantid.user.properties
+        rm -rf $userconfig_dir/Mantid.properties
+    else
+        rm -fr $userconfig_dir
+    fi
     rm -f ~/.config/mantidproject/mantidworkbench.ini
 
     # Turn off any auto updating on startup

--- a/buildconfig/Jenkins/Conda/run-tests
+++ b/buildconfig/Jenkins/Conda/run-tests
@@ -57,19 +57,24 @@ function onexit {
 # Clean up prior to testing
 # Prevent race conditions when creating the user config directory
 if [[ $OSTYPE == "msys"* ]]; then
-    userconfig_dir=$WORKSPACE/build/bin/Release
-    rm -rf $userconfig_dir/Mantid.user.properties
+    userconfig_dir=$APPDATA/mantidproject/mantid
+    userprops=$WORKSPACE/build/bin/Release/Mantid.user.properties
+    workbench_ini=$APPDATA/mantidproject/mantidworkbench.ini
 else
     userconfig_dir=$HOME/.mantid
-    rm -fr $userconfig_dir
-    mkdir -p $userconfig_dir
+    userprops=$userconfig_dir/Mantid.user.properties
+    workbench_ini=~/.config/mantidproject/mantidworkbench.ini
 fi
 
+rm -fr $userconfig_dir
+rm -fr $userprops
+mkdir -p $userconfig_dir
+
 # Remove GUI qsettings files
-rm -f ~/.config/mantidproject/mantidworkbench.ini
+rm -f $workbench_ini
 
 # use a fixed number of openmp threads to avoid overloading the system
-echo MultiThreaded.MaxCores=2 > $userconfig_dir/Mantid.user.properties
+echo MultiThreaded.MaxCores=2 > $userprops
 
 # Setup core dumping
 trap onexit INT TERM EXIT
@@ -100,16 +105,11 @@ if [[ $ENABLE_DOCS == true && $ENABLE_DOC_TESTS == true ]]; then
 fi
 
 if [[ $ENABLE_SYSTEM_TESTS == true ]]; then
-    if [[ $OSTYPE == "msys"* ]]; then
-        rm -rf $userconfig_dir/Mantid.user.properties
-    else
-        rm -fr $userconfig_dir
-    fi
-    rm -f ~/.config/mantidproject/mantidworkbench.ini
+    rm -fr $userconfig_dir
+    rm -f $workbench_ini
 
     # Turn off any auto updating on startup
     mkdir -p $userconfig_dir
-    userprops=$userconfig_dir/Mantid.user.properties
     echo "UpdateInstrumentDefinitions.OnStartup = 0" > $userprops
     echo "usagereports.enabled = 0" >> $userprops
     echo "CheckMantidVersion.OnStartup = 0" >> $userprops

--- a/buildconfig/Jenkins/Conda/update-conda-recipes.sh
+++ b/buildconfig/Jenkins/Conda/update-conda-recipes.sh
@@ -64,10 +64,14 @@ input_data recipes/mantid/meta.yaml
 input_data recipes/mantidqt/meta.yaml
 input_data recipes/mantidworkbench/meta.yaml
 
-git config user.name ${GITHUB_USER_NAME}
-git config user.email ${GITHUB_USER_NAME}@mantidproject.org
-git add recipes/*/meta.yaml
-git commit -m "Update version and git sha" --no-verify --signoff
-git pull --ff
-
-git push
+git diff --exit-code
+if [ $? -ne 0 ]; then
+    git config user.name ${GITHUB_USER_NAME}
+    git config user.email ${GITHUB_USER_NAME}@mantidproject.org
+    git add recipes/*/meta.yaml
+    git commit -m "Update version and git sha" --no-verify --signoff
+    git pull --ff
+    git push
+else
+    echo "No changes to commit"
+fi


### PR DESCRIPTION
**Description of work.**
Made some changes to the Jenkins pipeline for the conda nightly pipeline:
1. Add support for changing $CONDA_BLD_PATH which allows you to set the where conda build will build the source code, by supporting different archive locations
2. If `update conda-recipes repository` step fails then continue anyway, as we still want to try these conda-builds in most circumstances even if they don't publish
3. Improve the script by reducing duplication of code.
<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**
Code review and wait for build 214 to pass or not on this pipeline: https://builds.mantidproject.org/job/main_nightly_deployment_prototype/
<!-- Instructions for testing. -->

*There is no associated issue.*

*This does not require release notes* because **Developer facing**


<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
