### PR TITLE
Fix Style Issues on macOS (Also requires non-macOS testing)

### DIFF
--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -682,8 +682,6 @@ unsafeClassCanLeak:${CMAKE_SOURCE_DIR}/qt/widgets/common/inc/MantidQtWidgets/Com
 unsafeClassCanLeak:${CMAKE_SOURCE_DIR}/qt/widgets/common/inc/MantidQtWidgets/Common/WidgetScrollbarDecorator.h:105
 unsafeClassCanLeak:${CMAKE_SOURCE_DIR}/qt/widgets/common/inc/MantidQtWidgets/Common/WidgetScrollbarDecorator.h:106
 useStlAlgorithm:${CMAKE_SOURCE_DIR}/qt/widgets/common/src/UserInputValidator.cpp:40
-useStlAlgorithm:${CMAKE_SOURCE_DIR}/qt/widgets/common/src/WorkspacePresenter/WorkspaceTreeWidget.cpp:200
-unreadVariable:${CMAKE_SOURCE_DIR}/qt/widgets/common/src/WorkspacePresenter/WorkspaceTreeWidget.cpp:487
 unreadVariable:${CMAKE_SOURCE_DIR}/qt/widgets/common/src/WorkspacePresenter/WorkspaceTreeWidgetSimple.cpp:222
 unreadVariable:${CMAKE_SOURCE_DIR}/qt/widgets/common/src/WorkspacePresenter/WorkspaceTreeWidgetSimple.cpp:225
 unreadVariable:${CMAKE_SOURCE_DIR}/qt/widgets/common/src/WorkspacePresenter/WorkspaceTreeWidgetSimple.cpp:261

--- a/docs/source/release/v6.4.0/mantidworkbench.rst
+++ b/docs/source/release/v6.4.0/mantidworkbench.rst
@@ -12,5 +12,6 @@ New and Improved
 Bugfixes
 --------
 - In DrILL interface, scrolling down in the settings dialog no longer affects the comboxes
+- Cleaned up the appearance of the main window and the Indirect, Reflectometry, and Engineering GUIs on macOS.
 
 :ref:`Release 6.4.0 <v6.4.0>`

--- a/qt/applications/workbench/workbench/app/mainwindow.py
+++ b/qt/applications/workbench/workbench/app/mainwindow.py
@@ -24,7 +24,7 @@ from workbench.widgets.settings.presenter import SettingsPresenter
 # -----------------------------------------------------------------------------
 # Qt
 # -----------------------------------------------------------------------------
-from qtpy.QtCore import (QEventLoop, Qt, QPoint, QSize)  # noqa
+from qtpy.QtCore import (QEventLoop, Qt, QPoint, QSize, QCoreApplication)  # noqa
 from qtpy.QtGui import (QColor, QFontDatabase, QGuiApplication, QIcon, QPixmap)  # noqa
 from qtpy.QtWidgets import (QApplication, QDesktopWidget, QFileDialog, QMainWindow,
                             QSplashScreen, QMessageBox)  # noqa
@@ -223,6 +223,9 @@ class MainWindow(QMainWindow):
         self.config_updated()
 
         self.override_python_input()
+
+        # Ensure windows created after the main window have their own menu bars (on mac)
+        QCoreApplication.setAttribute(Qt.AA_DontUseNativeMenuBar, True)
 
     def post_mantid_init(self):
         """Run any setup that requires mantid

--- a/qt/applications/workbench/workbench/widgets/plotselector/view.py
+++ b/qt/applications/workbench/workbench/widgets/plotselector/view.py
@@ -75,7 +75,6 @@ class PlotSelectorView(QWidget):
         self.table_widget.customContextMenuRequested.connect(self.context_menu_opened)
 
         buttons_layout = FlowLayout()
-        buttons_layout.setSpacing(1)
         buttons_layout.addWidget(self.show_button)
         buttons_layout.addWidget(self.hide_button)
         buttons_layout.addWidget(self.close_button)
@@ -87,6 +86,7 @@ class PlotSelectorView(QWidget):
         filter_layout.addWidget(self.filter_box)
 
         layout = QVBoxLayout()
+        layout.setContentsMargins(0,0,0,0)
         layout.addLayout(buttons_layout)
         layout.addLayout(filter_layout)
         layout.addWidget(self.table_widget)

--- a/qt/python/mantidqt/mantidqt/widgets/codeeditor/tab_widget/codeeditor_tab_view.py
+++ b/qt/python/mantidqt/mantidqt/widgets/codeeditor/tab_widget/codeeditor_tab_view.py
@@ -32,6 +32,7 @@ class CodeEditorTabWidget(QTabWidget):
         self.setAttribute(Qt.WA_DeleteOnClose, True)
         self.setContextMenuPolicy(Qt.ActionsContextMenu)
         self.setMovable(True)
+        self.setUsesScrollButtons(True)
         self.setTabsClosable(True)
         self.setDocumentMode(True)
 

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/main_window.ui
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/main_window.ui
@@ -82,8 +82,8 @@
         </property>
         <property name="maximumSize">
          <size>
-          <width>25</width>
-          <height>25</height>
+          <width>30</width>
+          <height>16777215</height>
          </size>
         </property>
         <property name="text">

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/MainWindow/QtMainWindowView.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/MainWindow/QtMainWindowView.cpp
@@ -59,6 +59,8 @@ Initialise the Interface
 void QtMainWindowView::initLayout() {
   m_ui.setupUi(this);
 
+  m_ui.mainTabs->setUsesScrollButtons(true);
+
   connect(m_ui.helpButton, SIGNAL(clicked()), this, SLOT(helpPressed()));
   connect(m_ui.mainTabs, SIGNAL(tabCloseRequested(int)), this, SLOT(onTabCloseRequested(int)));
   connect(m_ui.newBatch, SIGNAL(triggered(bool)), this, SLOT(onNewBatchRequested(bool)));

--- a/qt/scientific_interfaces/Indirect/IndirectBayes.ui
+++ b/qt/scientific_interfaces/Indirect/IndirectBayes.ui
@@ -43,8 +43,8 @@
        <widget class="QPushButton" name="pbSettings">
         <property name="maximumSize">
          <size>
-          <width>25</width>
-          <height>25</height>
+          <width>16777215</width>
+          <height>16777215</height>
          </size>
         </property>
        </widget>
@@ -62,8 +62,8 @@
         </property>
         <property name="maximumSize">
          <size>
-          <width>25</width>
-          <height>25</height>
+          <width>16777215</width>
+          <height>16777215</height>
          </size>
         </property>
         <property name="text">

--- a/qt/scientific_interfaces/Indirect/IndirectCorrections.ui
+++ b/qt/scientific_interfaces/Indirect/IndirectCorrections.ui
@@ -54,8 +54,8 @@
        <widget class="QPushButton" name="pbSettings">
         <property name="maximumSize">
          <size>
-          <width>25</width>
-          <height>25</height>
+          <width>16777215</width>
+          <height>16777215</height>
          </size>
         </property>
         <property name="text">
@@ -76,8 +76,8 @@
         </property>
         <property name="maximumSize">
          <size>
-          <width>25</width>
-          <height>25</height>
+          <width>16777215</width>
+          <height>16777215</height>
          </size>
         </property>
         <property name="toolTip">
@@ -101,8 +101,8 @@
         </property>
         <property name="maximumSize">
          <size>
-          <width>30</width>
-          <height>25</height>
+          <width>16777215</width>
+          <height>16777215</height>
          </size>
         </property>
         <property name="toolTip">

--- a/qt/scientific_interfaces/Indirect/IndirectDataAnalysis.ui
+++ b/qt/scientific_interfaces/Indirect/IndirectDataAnalysis.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>1100</width>
-    <height>1100</height>
+    <height>1027</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -92,10 +92,22 @@
      <layout class="QHBoxLayout" name="layout_bottom">
       <item>
        <widget class="QPushButton" name="pbSettings">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>0</width>
+          <height>0</height>
+         </size>
+        </property>
         <property name="maximumSize">
          <size>
-          <width>25</width>
-          <height>25</height>
+          <width>16777215</width>
+          <height>16777215</height>
          </size>
         </property>
        </widget>
@@ -113,8 +125,8 @@
         </property>
         <property name="maximumSize">
          <size>
-          <width>25</width>
-          <height>25</height>
+          <width>16777215</width>
+          <height>16777215</height>
          </size>
         </property>
         <property name="toolTip">
@@ -138,8 +150,8 @@
         </property>
         <property name="maximumSize">
          <size>
-          <width>30</width>
-          <height>25</height>
+          <width>16777215</width>
+          <height>16777215</height>
          </size>
         </property>
         <property name="toolTip">

--- a/qt/scientific_interfaces/Indirect/IndirectDataReduction.ui
+++ b/qt/scientific_interfaces/Indirect/IndirectDataReduction.ui
@@ -83,8 +83,8 @@
        <widget class="QPushButton" name="pbSettings">
         <property name="maximumSize">
          <size>
-          <width>25</width>
-          <height>25</height>
+          <width>16777215</width>
+          <height>16777215</height>
          </size>
         </property>
         <property name="text">
@@ -102,8 +102,8 @@
         </property>
         <property name="maximumSize">
          <size>
-          <width>25</width>
-          <height>25</height>
+          <width>16777215</width>
+          <height>16777215</height>
          </size>
         </property>
         <property name="toolTip">
@@ -124,8 +124,8 @@
         </property>
         <property name="maximumSize">
          <size>
-          <width>25</width>
-          <height>40</height>
+          <width>16777215</width>
+          <height>16777215</height>
          </size>
         </property>
         <property name="toolTip">

--- a/qt/scientific_interfaces/Indirect/IndirectDiffractionReduction.ui
+++ b/qt/scientific_interfaces/Indirect/IndirectDiffractionReduction.ui
@@ -40,8 +40,8 @@
         <rect>
          <x>0</x>
          <y>0</y>
-         <width>530</width>
-         <height>592</height>
+         <width>547</width>
+         <height>663</height>
         </rect>
        </property>
        <layout class="QVBoxLayout" name="verticalLayout">
@@ -834,8 +834,8 @@
        <widget class="QPushButton" name="pbSettings">
         <property name="maximumSize">
          <size>
-          <width>25</width>
-          <height>25</height>
+          <width>6567567</width>
+          <height>16777215</height>
          </size>
         </property>
         <property name="text">
@@ -856,8 +856,8 @@
         </property>
         <property name="maximumSize">
          <size>
-          <width>25</width>
-          <height>25</height>
+          <width>6567567</width>
+          <height>16777215</height>
          </size>
         </property>
         <property name="text">
@@ -892,9 +892,10 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>MantidQt::API::FileFinderWidget</class>
+   <class>MantidQt::CustomInterfaces::IndirectPlotOptionsView</class>
    <extends>QWidget</extends>
-   <header>MantidQtWidgets/Common/FileFinderWidget.h</header>
+   <header>IndirectPlotOptionsView.h</header>
+   <container>1</container>
   </customwidget>
   <customwidget>
    <class>MantidQt::MantidWidgets::IndirectInstrumentConfig</class>
@@ -902,10 +903,9 @@
    <header>IndirectInstrumentConfig.h</header>
   </customwidget>
   <customwidget>
-   <class>MantidQt::CustomInterfaces::IndirectPlotOptionsView</class>
+   <class>MantidQt::API::FileFinderWidget</class>
    <extends>QWidget</extends>
-   <header>IndirectPlotOptionsView.h</header>
-   <container>1</container>
+   <header>MantidQtWidgets/Common/FileFinderWidget.h</header>
   </customwidget>
  </customwidgets>
  <tabstops>

--- a/qt/scientific_interfaces/Indirect/IndirectInterfaceSettings.ui
+++ b/qt/scientific_interfaces/Indirect/IndirectInterfaceSettings.ui
@@ -136,8 +136,8 @@
         </property>
         <property name="maximumSize">
          <size>
-          <width>25</width>
-          <height>25</height>
+          <width>16777215</width>
+          <height>16777215</height>
          </size>
         </property>
         <property name="text">

--- a/qt/scientific_interfaces/Indirect/IndirectSimulation.ui
+++ b/qt/scientific_interfaces/Indirect/IndirectSimulation.ui
@@ -49,8 +49,8 @@
        <widget class="QPushButton" name="pbSettings">
         <property name="maximumSize">
          <size>
-          <width>25</width>
-          <height>25</height>
+          <width>16777215</width>
+          <height>16777215</height>
          </size>
         </property>
         <property name="text">
@@ -71,8 +71,8 @@
         </property>
         <property name="maximumSize">
          <size>
-          <width>25</width>
-          <height>25</height>
+          <width>16777215</width>
+          <height>16777215</height>
          </size>
         </property>
         <property name="text">

--- a/qt/scientific_interfaces/Indirect/IndirectTools.ui
+++ b/qt/scientific_interfaces/Indirect/IndirectTools.ui
@@ -44,8 +44,8 @@
        <widget class="QPushButton" name="pbSettings">
         <property name="maximumSize">
          <size>
-          <width>25</width>
-          <height>25</height>
+          <width>16777215</width>
+          <height>16777215</height>
          </size>
         </property>
         <property name="text">
@@ -66,8 +66,8 @@
         </property>
         <property name="maximumSize">
          <size>
-          <width>25</width>
-          <height>25</height>
+          <width>16777215</width>
+          <height>16777215</height>
          </size>
         </property>
         <property name="text">

--- a/qt/widgets/common/src/WorkspacePresenter/WorkspaceTreeWidget.cpp
+++ b/qt/widgets/common/src/WorkspacePresenter/WorkspaceTreeWidget.cpp
@@ -136,7 +136,6 @@ void WorkspaceTreeWidget::setupWidgetLayout() {
   m_workspaceFilter->setToolTip("Type here to filter the workspaces");
 
   auto *layout = new QVBoxLayout();
-  layout->setSpacing(0);
   layout->setMargin(0);
   layout->addLayout(buttonLayout);
   layout->addWidget(m_workspaceFilter);

--- a/qt/widgets/common/src/WorkspacePresenter/WorkspaceTreeWidget.cpp
+++ b/qt/widgets/common/src/WorkspacePresenter/WorkspaceTreeWidget.cpp
@@ -195,8 +195,8 @@ StringList WorkspaceTreeWidget::getSelectedWorkspaceNames() const {
   auto items = m_tree->selectedItems();
   StringList names;
   names.reserve(static_cast<size_t>(items.size()));
-  for (auto &item : items)
-    names.emplace_back(item->text(0).toStdString());
+  std::transform(items.cbegin(), items.cend(), std::back_inserter(names),
+                 [](auto const &item) { return item->text(0).toStdString(); });
 
   return names;
 }
@@ -483,7 +483,7 @@ void WorkspaceTreeWidget::filterWorkspaces(const std::string &filterText) {
           // I am a workspace
           if (item->text(0).contains(filterRegEx)) {
             // my name does match the filter
-            if (auto group = std::dynamic_pointer_cast<WorkspaceGroup>(workspace)) {
+            if (workspace->isGroup()) {
               // I am a group, I will want my children to be visible
               // but I cannot do that until this iterator has finished
               // store this pointer in a list for processing later


### PR DESCRIPTION
**Description of work.**
Fix some strange looking parts of workbench of macOS. Tends to just be changes to GUIs and layouts. 

**To test:**
In an ideal world, this would be tested on Mac and (at least) one of the other OSs to make sure nothing is broken. 

- Check that menu bar items can be accessed in the Refl and Elemental Analysis GUIs. 
- Add a bunch of editor tabs and check that they can all be switched to. Do the same with the batches in the Refl GUI
- Check all of the indirect interfaces have reasonably sized buttons

Fixes #33361 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
