### PR TITLE
Disabled vesuvio backscattering to avoid problems in VesuvioAnalysis

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/VesuvioAnalysis.py
+++ b/Framework/PythonInterface/plugins/algorithms/VesuvioAnalysis.py
@@ -179,6 +179,9 @@ class VesuvioAnalysis(PythonAlgorithm):
         spectra = self.getProperty("Spectra").value
         if len(spectra) != 2:
             issues["Spectra"] = "Spectra should be of the form [first, last]"
+        # exclude backscattering spectra for now
+        if spectra[0] < 135 or spectra[1] < 135:
+            issues["Spectra"] = "Analysis not available for backscattering spectra at the moment."
 
         run_string = self.getProperty("Runs").value
         for ch in run_string:

--- a/Framework/PythonInterface/test/python/plugins/algorithms/VesuvioAnalysisTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/VesuvioAnalysisTest.py
@@ -208,7 +208,16 @@ class VesuvioAnalysisTest(unittest.TestCase):
             self.assertEquals(len(errors),1)
             self.assertTrue("Runs" in errors)
 
-    def test_masked_sapectra_correct(self):
+    def test_spectra_incorrect(self):
+        table = self.generate_table()
+        alg = self.set_up_alg()
+        alg.setProperty('ComptonProfile', table)
+        alg.setProperty('Spectra', [3, 134])
+        errors = alg.validateInputs()
+        self.assertEquals(len(errors),1)
+        self.assertTrue("Spectra" in errors)
+
+    def test_masked_spectra_correct(self):
         table = self.generate_table()
         alg = self.set_up_alg()
         alg.setProperty('ComptonProfile', table)

--- a/docs/source/release/v6.3.0/33417_indirect_geometry.rst
+++ b/docs/source/release/v6.3.0/33417_indirect_geometry.rst
@@ -1,0 +1,3 @@
+Improvements
+------------
+- :ref:`VesuvioAnalysis <algm-VesuvioAnalysis>` excludes back scattering spectra for now to avoid problems with the analysis.


### PR DESCRIPTION
**Description of work.**

On request of the scientists back scattering spectra are not enabled in VesuvioAnalysis anymore as this leads to problems (there are updates to VesuvioAnalysis planned for the next release that will fix this).

**To test:**

Run the following script

```python
# import mantid algorithms, numpy and matplotlib
from mantid.simpleapi import *
import matplotlib.pyplot as plt
import numpy as np

table = CreateEmptyTableWorkspace() 
table.addColumn(type="str",name="Symbol")
table.addColumn(type="double",name="Mass (a.u.)")
table.addColumn(type="double",name="Intensity lower limit")
table.addColumn(type="double",name="Intensity value")
table.addColumn(type="double",name="Intensity upper limit")
table.addColumn(type="double",name="Width lower limit")
table.addColumn(type="double",name="Width value")
table.addColumn(type="double",name="Width upper limit")
table.addColumn(type="double",name="Centre lower limit")
table.addColumn(type="double",name="Centre value")
table.addColumn(type="double",name="Centre upper limit")
#table.addRow(['H',1.0079,0.,1.,9.9e9,3.,4.5,6.,-1.5,0.,0.5])
table.addRow(['C',12.0,0.,1.,9.9e9,10.,15.5,30.,-1.5,0.,0.5])
table.addRow(['O',16.0,0.,1.,9.9e9,6.,8.,15.,-1.5,0.,0.5])
table.addRow(['Al',27.0,0.,1.,9.9e9,12.,14.,16.,-1.5,0.,0.5])

constraints = CreateEmptyTableWorkspace()
constraints.addColumn(type="int", name="LHS element")
constraints.addColumn(type="int", name="RHS element")
constraints.addColumn(type="str", name="ScatteringCrossSection")
constraints.addColumn(type="str", name="State")
constraints.addRow([0, 1, "2.*82.03/5.551", "eq"])
#constraints.addRow([1, 2, "2.*82.03/5.551", "eq"])

#VesuvioAnalysis(IPFile = "ip2018.par", 
        #ComptonProfile = table, AnalysisMode = "LoadReduce", NumberOfIterations = 2, OutputName = "polyethylene", 
        #Runs = "38898-38906", TOFRangeVector = [110.,1.5,460.], Spectra = [3,134], MonteCarloEvents = 1e3, 
        #ConstraintsProfileNumbers = [0,1], ConstraintsProfileScatteringCrossSection = "2.*82.03/5.51", 
        #SpectraToBeMasked = [173,174,181], SubtractResonancesFunction = None, YSpaceFitFunctionTies = '(c6=0.,c4=0.)')
        #TransmissionGuess=0.92, SpectraToBeMasked = [18,34,42,62])

VesuvioAnalysis(IPFile = "ip2018.par", ComptonProfile = table, AnalysisMode = "LoadReduce", 
        NumberOfIterations = 2, OutputName = "starch_80", Runs = "43066-43076", TOFRangeVector = [110.,1.5,460.], 
        Spectra = [3,134], MonteCarloEvents = 1e3, SpectraToBeMasked = [18,34,42,43,59,60,62,118,119,133], 
        #SubtractResonancesFunction = 'name=Voigt,LorentzAmp=1.,LorentzPos=284.131,LorentzFWHM=2,GaussianFWHM=3;', 
        #YSpaceFitFunctionTies = '(c6=0.,c4=0.)')
        TransmissionGuess=0.8537, ConstraintsProfile = constraints)

fit_results = mtd["polyethylene_H_JoY_sym_Parameters"]

print("variable", "value")
for row in range(fit_results.rowCount()):
    print(fit_results.column(0)[row],"{:.3f}".format(fit_results.column(1)[row]))
```

It will abort with an error message and also mention that backscattering spectra are not available at the moment.

Fixes #33417.


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
