### PR TITLE
Updated SHA for MSlice and also release note

### DIFF
--- a/docs/source/release/v6.3.0/mslice_direct_geometry.rst
+++ b/docs/source/release/v6.3.0/mslice_direct_geometry.rst
@@ -5,3 +5,4 @@ BugFixes
 - Updated misleading cut algorithm names and made selection of cut algorithms available on cut tab.
 - Fixed 'Save to Workspace' button on cut tabs and renamed it to 'Save to Workbench' to avoid confusion.
 - Prevented non-Mslice plots to be displayed as an MSlice plot as most buttons and menu items can not work in this case.
+- Added check for deprecated hold feature in pyplot.py.

--- a/docs/source/release/v6.3.0/mslice_direct_geometry.rst
+++ b/docs/source/release/v6.3.0/mslice_direct_geometry.rst
@@ -1,0 +1,7 @@
+MSlice
+------
+BugFixes
+########
+- Updated misleading cut algorithm names and made selection of cut algorithms available on cut tab.
+- Fixed 'Save to Workspace' button on cut tabs and renamed it to 'Save to Workbench' to avoid confusion.
+- Prevented non-Mslice plots to be displayed as an MSlice plot as most buttons and menu items can not work in this case.

--- a/scripts/ExternalInterfaces/CMakeLists.txt
+++ b/scripts/ExternalInterfaces/CMakeLists.txt
@@ -7,7 +7,7 @@ externalproject_add(
   mslice
   PREFIX ${_mslice_external_root}
   GIT_REPOSITORY "https://github.com/mantidproject/mslice.git"
-  GIT_TAG e2b4c07e4398db1cbd52902b2ff5d800d5fc0062
+  GIT_TAG 831a829c213bbdc8b14db876805a68a8ac929259
   EXCLUDE_FROM_ALL 1
   CONFIGURE_COMMAND ""
   BUILD_COMMAND ""

--- a/scripts/ExternalInterfaces/CMakeLists.txt
+++ b/scripts/ExternalInterfaces/CMakeLists.txt
@@ -7,7 +7,7 @@ externalproject_add(
   mslice
   PREFIX ${_mslice_external_root}
   GIT_REPOSITORY "https://github.com/mantidproject/mslice.git"
-  GIT_TAG 831a829c213bbdc8b14db876805a68a8ac929259
+  GIT_TAG 74998f7ccd45f1b3d803e01009a8d6acb135c792
   EXCLUDE_FROM_ALL 1
   CONFIGURE_COMMAND ""
   BUILD_COMMAND ""


### PR DESCRIPTION
Description of work.

Replaced MSlice SHA for Mantid with SHA of current MSlice release-next branch.

Added release note in mslice_direct_geometry.rst with all changes in MSlice since last MSlice SHA update in Mantid.

To test:

Double-check SHA with SHA of current MSlice release-next branch.

There is no associated issue.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
