### PR TITLE
Remove instant fail in update conda repo, fix environment issues in pipeline

### DIFF
--- a/buildconfig/Jenkins/Conda/nightly_build_and_deploy.jenkinsfile
+++ b/buildconfig/Jenkins/Conda/nightly_build_and_deploy.jenkinsfile
@@ -89,18 +89,27 @@ pipeline {
             parallel {
                 stage('conda-build Linux') {
                     agent { label 'conda-build-linux' }
+                    environment {
+                        CONDA_BLD_PATH = "${WORKSPACE}/conda-bld"
+                    }
                     steps {
                         conda_build_linux()
                     }
                 }
                 stage('conda-build Windows') {
                     agent { label 'conda-build-win' }
+                    environment {
+                        CONDA_BLD_PATH = "${WORKSPACE}/conda-bld"
+                    }
                     steps {
                         conda_build_win()
                     }
                 }
                 stage('conda-build MacOSX') {
                     agent { label 'conda-build-osx' }
+                    environment {
+                        CONDA_BLD_PATH = "${WORKSPACE}/conda-bld"
+                    }
                     steps {
                         conda_build_macos()
                     }

--- a/buildconfig/Jenkins/Conda/update-conda-recipes.sh
+++ b/buildconfig/Jenkins/Conda/update-conda-recipes.sh
@@ -75,3 +75,9 @@ if [ $? -ne 0 ]; then
 else
     echo "No changes to commit"
 fi
+
+# Cleanup cloned repository
+cd ..
+rm -rf conda-recipes
+
+exit 0

--- a/buildconfig/Jenkins/Conda/update-conda-recipes.sh
+++ b/buildconfig/Jenkins/Conda/update-conda-recipes.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -ex
+#!/bin/bash -x
 
 # Update the https://github.com/mantidproject/conda-recipes repository with the latest changes from the currently
 # checked out branch.


### PR DESCRIPTION
**Description of work.**
Changes:
1. Removed a case of instant fail, on command fail in the script that updates the conda-recipes repository. This is necessary as we use the exit code of git diff --exit-code to determine how to proceed.
2. Add some cleanup to remove the conda-recipes repo after push has been completed
3. Change how the pipeline is using/defining environment variables for conda build
<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**
Code review
<!-- Instructions for testing. -->

*There is no associated issue.*

*This does not require release notes* because **Developer Facing**


<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
