### PR TITLE
Expand range for scale factor in ISISCalibration

### DIFF
--- a/qt/scientific_interfaces/Indirect/ISISCalibration.cpp
+++ b/qt/scientific_interfaces/Indirect/ISISCalibration.cpp
@@ -14,6 +14,7 @@
 
 #include <QDebug>
 #include <QFileInfo>
+#include <QRegExpValidator>
 #include <stdexcept>
 
 using namespace Mantid::API;
@@ -50,7 +51,8 @@ ISISCalibration::ISISCalibration(IndirectDataReduction *idrUI, QWidget *parent)
   m_uiForm.ppResolution->setCanvasColour(QColor(240, 240, 240));
   m_uiForm.ppCalibration->watchADS(false);
   m_uiForm.ppResolution->watchADS(false);
-
+  m_uiForm.leScale->setValidator(new QRegExpValidator(QRegExp("\\d+(\\.\\d*)?")));
+  m_uiForm.leResolutionScale->setValidator(new QRegExpValidator(QRegExp("\\d+(\\.\\d*)?")));
   auto *doubleEditorFactory = new DoubleEditorFactory();
 
   // CAL PROPERTY TREE
@@ -130,10 +132,6 @@ ISISCalibration::ISISCalibration(IndirectDataReduction *idrUI, QWidget *parent)
   // SIGNAL/SLOT CONNECTIONS
   // Update instrument information when a new instrument config is selected
   connect(this, SIGNAL(newInstrumentConfiguration()), this, SLOT(setDefaultInstDetails()));
-
-#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
-  connect(resPeak, SIGNAL(rangeChanged(double, double)), resBackground, SLOT(setRange(double, double)));
-#endif
 
   // Update property map when a range selector is moved
   connect(calPeak, SIGNAL(minValueChanged(double)), this, SLOT(calMinChanged(double)));
@@ -690,7 +688,7 @@ IAlgorithm_sptr ISISCalibration::calibrationAlgorithm(const QString &inputFiles)
   calibrationAlg->setProperty("LoadLogFiles", m_uiForm.ckLoadLogFiles->isChecked());
 
   calibrationAlg->setProperty("ScaleByFactor", m_uiForm.ckScale->isChecked());
-  calibrationAlg->setProperty("ScaleFactor", m_uiForm.spScale->value());
+  calibrationAlg->setProperty("ScaleFactor", m_uiForm.leScale->text().toDouble());
   return calibrationAlg;
 }
 
@@ -707,7 +705,7 @@ IAlgorithm_sptr ISISCalibration::resolutionAlgorithm(const QString &inputFiles) 
   resAlg->setProperty("LoadLogFiles", m_uiForm.ckLoadLogFiles->isChecked());
 
   if (m_uiForm.ckResolutionScale->isChecked())
-    resAlg->setProperty("ScaleFactor", m_uiForm.spScale->value());
+    resAlg->setProperty("ScaleFactor", m_uiForm.leResolutionScale->text().toDouble());
 
   if (m_uiForm.ckSmoothResolution->isChecked())
     resAlg->setProperty("OutputWorkspace", m_outputResolutionName.toStdString() + "_pre_smooth");

--- a/qt/scientific_interfaces/Indirect/ISISCalibration.ui
+++ b/qt/scientific_interfaces/Indirect/ISISCalibration.ui
@@ -74,21 +74,9 @@
          </widget>
         </item>
         <item>
-         <widget class="QDoubleSpinBox" name="spScale">
-          <property name="enabled">
-           <bool>false</bool>
-          </property>
-          <property name="decimals">
-           <number>5</number>
-          </property>
-          <property name="maximum">
-           <double>999.990000000000009</double>
-          </property>
-          <property name="singleStep">
-           <double>0.100000000000000</double>
-          </property>
-          <property name="value">
-           <double>1.000000000000000</double>
+         <widget class="QLineEdit" name="leScale">
+          <property name="text">
+           <string>1.0</string>
           </property>
          </widget>
         </item>
@@ -263,21 +251,9 @@
               </widget>
              </item>
              <item row="2" column="1">
-              <widget class="QDoubleSpinBox" name="spResolutionScale">
-               <property name="enabled">
-                <bool>false</bool>
-               </property>
-               <property name="decimals">
-                <number>5</number>
-               </property>
-               <property name="maximum">
-                <double>999.990000000000009</double>
-               </property>
-               <property name="singleStep">
-                <double>0.100000000000000</double>
-               </property>
-               <property name="value">
-                <double>1.000000000000000</double>
+              <widget class="QLineEdit" name="leResolutionScale">
+               <property name="text">
+                <string>1.0</string>
                </property>
               </widget>
              </item>
@@ -438,38 +414,5 @@
   </customwidget>
  </customwidgets>
  <resources/>
- <connections>
-  <connection>
-   <sender>ckResolutionScale</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>spResolutionScale</receiver>
-   <slot>setEnabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>69</x>
-     <y>252</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>169</x>
-     <y>253</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>ckScale</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>spScale</receiver>
-   <slot>setEnabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>81</x>
-     <y>80</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>180</x>
-     <y>81</y>
-    </hint>
-   </hints>
-  </connection>
- </connections>
+ <connections/>
 </ui>


### PR DESCRIPTION
**Description of work.**

This PR replaces the spion box for ScaleFactor in ISIS calibration with line edits, this removes the limiting range on the scale factor.

**To test:**

1. Go to Indirect Data Reduction ISIS Calibration
2. Input 26173
3. Enable `Scale by factor`
4. Enter a value in the line edit and run.
7. click Create RES File
8. check Scale RES and enter a value
9. click run and check algorithm runs.

Fixes #33413 

*This does not require release notes* because **This release already has a note regarding fixing the scale factor**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
