### PR TITLE
Move Muon Model Fitting release notes to v6.4

### DIFF
--- a/docs/source/release/v6.4.0/muon.rst
+++ b/docs/source/release/v6.4.0/muon.rst
@@ -10,3 +10,18 @@ MuSR Changes
     improvements, followed by bug fixes.
 
 :ref:`Release 6.4.0 <v6.4.0>`
+
+
+..
+  Model Fitting
+  -------------
+
+  BugFixes
+  ########
+  - A bug has been fixed that caused Model fitting to not update it's results table list.
+  - Plotting in Model Fitting now features a greater number of units for parameters and sample logs.
+  - The dates and times for relevant parameters in Model Fitting have been formatted so that they can be plotted with relative spacing.
+  - On the Model Fitting Tab, the fit range will now update when the x axis is changed.
+  - The Model Fitting tab no longer resets when the instrument is changed.
+  - When a new results table is created the Model Fitting tab selects the default parameters to plot based on log values or parameters in the results table.
+  - Fixed a bug that prevented the Model Fitting plot showing when data was binned.


### PR DESCRIPTION
**Description of work.**
The Model Fitting Tab in the Muon GUIs is not yet finished and available to users. Work undertaken on this during v6.3 has been noted in a hidden section of the V6.3 release notes. These notes now need to move to v6.4 as they are not relevant to v6.3. The notes will be removed from V6.3 in a separate PR to avoid merge conflicts as this PR must be based on main, not release-next.  No editing of the release notes has been undertaken.

**To test:**

- build the documents and check there are no warnings.
- Check that the notes do not appear when opening the muon.html file in the V6.4 release notes.
- Check the code to ensure the release notes copied into muon.rst V6.4 file match those in the V6.3 file.

*There is no associated issue.*


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
