### PR TITLE
Remove change to histogram in IqtFit

### DIFF
--- a/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/ConvolutionFit.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/ConvolutionFit.h
@@ -32,10 +32,8 @@ protected:
 
 private:
   std::map<std::string, std::string> validateInputs() override;
-
-  bool throwIfElasticQConversionFails() const override;
   bool isFitParameter(const std::string &name) const override;
-
+  bool throwIfElasticQConversionFails() const override;
   bool m_deltaUsed;
 };
 

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/IqtFit.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/IqtFit.h
@@ -22,9 +22,6 @@ public:
   const std::vector<std::string> seeAlso() const override;
 
 private:
-  double getStartX(std::size_t index) const;
-  double getEndX(std::size_t index) const;
-
   std::map<std::string, std::string> validateInputs() override;
   bool isFitParameter(const std::string &name) const override;
   bool throwIfElasticQConversionFails() const override;

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/IqtFit.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Algorithms/IqtFit.h
@@ -21,9 +21,6 @@ public:
   const std::string summary() const override;
   const std::vector<std::string> seeAlso() const override;
 
-protected:
-  std::vector<API::MatrixWorkspace_sptr> getWorkspaces() const override;
-
 private:
   double getStartX(std::size_t index) const;
   double getEndX(std::size_t index) const;

--- a/Framework/CurveFitting/src/Algorithms/ConvolutionFit.cpp
+++ b/Framework/CurveFitting/src/Algorithms/ConvolutionFit.cpp
@@ -282,12 +282,12 @@ template <typename Base> std::map<std::string, std::string> ConvolutionFit<Base>
   return errors;
 }
 
-template <typename Base> bool ConvolutionFit<Base>::throwIfElasticQConversionFails() const { return true; }
-
 template <typename Base> bool ConvolutionFit<Base>::isFitParameter(const std::string &name) const {
   bool isBackgroundParameter = name.rfind("A0") != std::string::npos || name.rfind("A1") != std::string::npos;
   return name.rfind("Centre") == std::string::npos && !isBackgroundParameter;
 }
+
+template <typename Base> bool ConvolutionFit<Base>::throwIfElasticQConversionFails() const { return true; }
 
 template <typename Base>
 ITableWorkspace_sptr ConvolutionFit<Base>::processParameterTable(ITableWorkspace_sptr parameterTable) {

--- a/Framework/CurveFitting/src/Algorithms/IqtFit.cpp
+++ b/Framework/CurveFitting/src/Algorithms/IqtFit.cpp
@@ -16,8 +16,6 @@ using namespace Mantid::API;
 
 namespace {
 Mantid::Kernel::Logger g_log("IqtFit");
-
-std::string getPropertySuffix(std::size_t index) { return index == 0 ? "" : "_" + std::to_string(index); }
 } // namespace
 
 namespace Mantid::CurveFitting::Algorithms {

--- a/Framework/CurveFitting/src/Algorithms/IqtFit.cpp
+++ b/Framework/CurveFitting/src/Algorithms/IqtFit.cpp
@@ -17,46 +17,6 @@ using namespace Mantid::API;
 namespace {
 Mantid::Kernel::Logger g_log("IqtFit");
 
-MatrixWorkspace_sptr cropWorkspace(const MatrixWorkspace_sptr &workspace, double startX, double endX) {
-  auto cropper = AlgorithmManager::Instance().create("CropWorkspace");
-  cropper->setLogging(false);
-  cropper->setAlwaysStoreInADS(false);
-  cropper->setProperty("InputWorkspace", workspace);
-  cropper->setProperty("OutputWorkspace", "__cropped");
-  cropper->setProperty("XMin", startX);
-  cropper->setProperty("XMax", endX);
-  cropper->execute();
-  return cropper->getProperty("OutputWorkspace");
-}
-
-MatrixWorkspace_sptr convertToHistogram(const MatrixWorkspace_sptr &workspace) {
-  auto converter = AlgorithmManager::Instance().create("ConvertToHistogram");
-  converter->setLogging(false);
-  converter->setAlwaysStoreInADS(false);
-  converter->setProperty("InputWorkspace", workspace);
-  converter->setProperty("OutputWorkspace", "__converted");
-  converter->execute();
-  return converter->getProperty("OutputWorkspace");
-}
-
-struct HistogramConverter {
-  explicit HistogramConverter() : m_converted() {}
-
-  MatrixWorkspace_sptr operator()(const MatrixWorkspace_sptr &workspace, double startX, double endX) const {
-    auto it = m_converted.find(workspace.get());
-    if (it != m_converted.end())
-      return it->second;
-    else {
-      auto histogram = convertToHistogram(cropWorkspace(workspace, startX, endX));
-      m_converted[workspace.get()] = histogram;
-      return histogram;
-    }
-  }
-
-private:
-  mutable std::unordered_map<MatrixWorkspace *, MatrixWorkspace_sptr> m_converted;
-};
-
 std::string getPropertySuffix(std::size_t index) { return index == 0 ? "" : "_" + std::to_string(index); }
 } // namespace
 
@@ -120,15 +80,6 @@ template <typename Base> bool IqtFit<Base>::isFitParameter(const std::string &na
 }
 
 template <typename Base> bool IqtFit<Base>::throwIfElasticQConversionFails() const { return true; }
-
-template <typename Base> std::vector<API::MatrixWorkspace_sptr> IqtFit<Base>::getWorkspaces() const {
-  auto workspaces = Base::getWorkspaces();
-  HistogramConverter convert;
-
-  for (std::size_t i = 0; i < workspaces.size(); ++i)
-    workspaces[i] = convert(workspaces[i], getStartX(i), getEndX(i));
-  return workspaces;
-}
 
 template <> double IqtFit<QENSFitSimultaneous>::getStartX(std::size_t index) const {
   return QENSFitSimultaneous::getProperty("StartX" + getPropertySuffix(index));

--- a/Framework/CurveFitting/src/Algorithms/IqtFit.cpp
+++ b/Framework/CurveFitting/src/Algorithms/IqtFit.cpp
@@ -81,32 +81,6 @@ template <typename Base> bool IqtFit<Base>::isFitParameter(const std::string &na
 
 template <typename Base> bool IqtFit<Base>::throwIfElasticQConversionFails() const { return true; }
 
-template <> double IqtFit<QENSFitSimultaneous>::getStartX(std::size_t index) const {
-  return QENSFitSimultaneous::getProperty("StartX" + getPropertySuffix(index));
-}
-
-template <> double IqtFit<QENSFitSequential>::getStartX(std::size_t i) const {
-  std::vector<double> startX = QENSFitSequential::getProperty("StartX");
-  if (startX.size() == 1) {
-    return startX[0];
-  } else {
-    return startX[i];
-  }
-}
-
-template <> double IqtFit<QENSFitSimultaneous>::getEndX(std::size_t index) const {
-  return QENSFitSimultaneous::getProperty("EndX" + getPropertySuffix(index));
-}
-
-template <> double IqtFit<QENSFitSequential>::getEndX(std::size_t i) const {
-  std::vector<double> endX = QENSFitSequential::getProperty("EndX");
-  if (endX.size() == 1) {
-    return endX[0];
-  } else {
-    return endX[i];
-  }
-}
-
 // Register the algorithms into the AlgorithmFactory
 template class IqtFit<QENSFitSequential>;
 template class IqtFit<QENSFitSimultaneous>;

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/IqtFitSequentialTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/IqtFitSequentialTest.py
@@ -124,16 +124,16 @@ class IqtFitSequentialTest(unittest.TestCase):
         sub_ws = groupWS.getItem(0)
         # Check Data
         data = sub_ws.readY(0)
-        self.assertEqual(round(data[0], 6), 0.797069)
-        self.assertEqual(round(data[-1],6), 0.039044)
+        self.assertEqual(round(data[0], 6), 1.0)
+        self.assertEqual(round(data[-1], 6), 0.039044)
         # Check Calc
         calc = sub_ws.readY(1)
-        self.assertEqual(round(calc[0], 6), 0.870524)
-        self.assertEqual(round(calc[-1],6), 0.033886)
+        self.assertEqual(round(calc[0], 6), 1.0)
+        self.assertEqual(round(calc[-1], 6), 0.033886)
         # Check Diff
         diff = sub_ws.readY(2)
-        self.assertEqual(round(diff[0], 6),-0.073455)
-        self.assertEqual(round(diff[-1],6), 0.005157)
+        self.assertEqual(round(diff[0], 6), 0.0)
+        self.assertEqual(round(diff[-1], 6), 0.005157)
 
     def _validate_sample_log_values(self, matrixWS):
         run = matrixWS.getRun()

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/IqtFitSequentialTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/IqtFitSequentialTest.py
@@ -77,7 +77,7 @@ class IqtFitSequentialTest(unittest.TestCase):
         sub_ws = groupWS.getItem(0)
         nbins = sub_ws.blocksize()
         nhists = sub_ws.getNumberHistograms()
-        self.assertEqual(nbins, 58)
+        self.assertEqual(nbins, 59)
         self.assertEqual(nhists, 3)
 
         # Check histogram names

--- a/docs/source/release/v6.4.0/indirect_geometry.rst
+++ b/docs/source/release/v6.4.0/indirect_geometry.rst
@@ -16,3 +16,8 @@ Changes
 #######
 
 - In Indirect Data analysis the button for fitting the currently plotted spectra has been renamed and rescaled to fit the interface.
+
+Bugfixes
+########
+
+- A bug has been fixed in IqtFit where the first value would be ignored when a fit was performed.

--- a/docs/source/release/v6.4.0/indirect_geometry.rst
+++ b/docs/source/release/v6.4.0/indirect_geometry.rst
@@ -20,4 +20,4 @@ Changes
 Bugfixes
 ########
 
-- A bug has been fixed in IqtFit where the first value would be ignored when a fit was performed.
+- A bug has been fixed in Indirect Data Analysis where the first value would be ignored when a fit was performed.

--- a/qt/scientific_interfaces/Indirect/IndirectFittingModel.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFittingModel.cpp
@@ -525,8 +525,8 @@ IAlgorithm_sptr IndirectFittingModel::createSequentialFit(const IFunction_sptr f
   std::stringstream endX;
   for (size_t i = 0; i < m_fitDataModel->getNumberOfDomains(); i++) {
     const auto range = m_fitDataModel->getFittingRange(FitDomainIndex(i));
-    startX << range.first << ",";
-    endX << range.second << ",";
+    startX << std::setprecision(6) << std::floor(range.first * 1E6) / 1E6 << ",";
+    endX << std::setprecision(6) << std::ceil(range.second * 1E6) / 1E6 << ",";
   }
   fitAlgorithm->setProperty("StartX", startX.str());
   fitAlgorithm->setProperty("EndX", endX.str());


### PR DESCRIPTION
**Description of work.**
This commit removes the conversion to histogram in IqtFit. It is not clear why this is done as all it ends up doing is stopping the fit from using the first value.
It also adds rounding to the ranges given to QENSFitSequential in IDA to stop the same issue in other tabs

**Report to:** @SpencerHowells

**To test:**

1. open Indirect Data Analysis Iqtfit tab
2. Load irs26176_graphite002_iqt spectra 0
3. set Exponentials to 1 and endX to 0.20
4. click run
5. show data on workspace `irs26176_graphite002_iqt_IQt_seq_1E_0_0_Workspace`
6. check that the first X value is the same as on workspace `irs26176_graphite002_iqt`

As well as this, in the other fit tabs, load data and attempt to fit using the default ranges, check that it includes the first and last data points.

Fixes #32478

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
