### PR TITLE
Added clarification in VesuvioAnalysis doc

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/VesuvioAnalysis.py
+++ b/Framework/PythonInterface/plugins/algorithms/VesuvioAnalysis.py
@@ -95,7 +95,10 @@ class VesuvioAnalysis(PythonAlgorithm):
                              validator=IntListValidator([0,1,2,3,4]))
         self.declareProperty("OutputName", "polyethylene",doc="The base name for the outputs." )
         self.declareProperty("Runs", "38898-38906", doc="List of Vesuvio run numbers (e.g. 20934-20937, 30924)")
-        self.declareProperty(IntArrayProperty("Spectra",[135,182]), doc="Range of spectra to be analysed (first, last).")
+        self.declareProperty(IntArrayProperty("Spectra",[135,182]), doc="Range of spectra to be analysed (first, last). Please note that "
+                                                                         "spectra with a number lower than 135 are treated as back "
+                                                                         "scattering spectra and are therefore not considered valid input "
+                                                                         "as this algorithm is only for forward scattering data.")
         self.declareProperty(FloatArrayProperty("TOFRangeVector", [110.,1.5,460.]),
                              doc="In micro seconds (lower bound, binning, upper bound).")
         self.declareProperty(


### PR DESCRIPTION
Added a short explanation to the Spectra property of VesuvioAnalysis to clarify that the algorithm only covers forward scattering data.

**To Test**

Please check spelling and grammar of the new comment.

There is no additional release note necessary as disabling backscattering for VesuvioAnalysis is already mentioned.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
