### PR TITLE
Fix issues with windows in jenkins deployment pipeline

### DIFF
--- a/buildconfig/Jenkins/Conda/nightly_build_and_deploy.jenkinsfile
+++ b/buildconfig/Jenkins/Conda/nightly_build_and_deploy.jenkinsfile
@@ -99,7 +99,7 @@ pipeline {
                 stage('conda-build Windows') {
                     agent { label 'conda-build-win' }
                     environment {
-                        CONDA_BLD_PATH = "${WORKSPACE}/conda-bld"
+                        CONDA_BLD_PATH = "${WORKSPACE}\\conda-bld"
                     }
                     steps {
                         conda_build_win()

--- a/buildconfig/Jenkins/Conda/nightly_build_and_deploy.jenkinsfile
+++ b/buildconfig/Jenkins/Conda/nightly_build_and_deploy.jenkinsfile
@@ -1,8 +1,8 @@
 // This script expects the following environment variables to be set by the Jenkins job:
+// GITHUB_USER_NAME - The name of the user, being used with pushing/pulling from conda-recipes whilst updating it.
 // GITHUB_TOKEN_CREDENTIAL_ID - The name of the credentials token in Jenkins that you want to use for cloning and pushing to the conda-recipes repo
 // ANACONDA_TOKEN_CREDENTIAL_ID - The name of the credentials token in Jenkins that you want to use for publishing conda packages
 // ANACONDA_CHANNEL - The channel to publish to on Anaconda.org
-// CONDA_BLD_PATH - The path to where conda-build will construct the packages, needed for windows due to path length. Must be inside the Workspace ending with conda-bld, equivelant to $WORKSPACE/conda-bld. Due to limitations with jenkins archiving of artifacts.
 // ANACONDA_CHANNEL_LABEL - This will be used as the label for the channel, otherwise no label will be set.
 
 def build_and_test_linux() {


### PR DESCRIPTION
**Description of work.**
If $WORKSPACE/conda-bld folder does exist, RMDIR and thus DEL will fall over as it uses a / in one part of the path currently, this replaces the / with a \\.

**To test:**
Code-review

*There is no associated issue.*

*This does not require release notes* because **Dev facing**


<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
