### PR TITLE
Add a recipes tag parameter to the conda-build-recipes script

### DIFF
--- a/buildconfig/Jenkins/Conda/conda-build-recipes
+++ b/buildconfig/Jenkins/Conda/conda-build-recipes
@@ -23,6 +23,7 @@
 #
 # Possible parameters:
 #   --clobber-yml: clobber the meta yaml files of each package build with conda-build, provide an absolute path to the uteyml file
+#   --recipes-tag: a branch, sha, or tag that should be used for cloning the recipes from conda-build-recipes
 #
 
 # Setup expected variables
@@ -58,6 +59,7 @@ SCRIPT_DIR=$WORKSPACE/buildconfig/Jenkins/Conda/
 ENABLE_BUILD_MANTID=false
 ENABLE_BUILD_QT=false
 ENABLE_BUILD_WORKBENCH=false
+RECIPES_TAG=main
 
 # Handle flag inputs
 while [ ! $# -eq 0 ]
@@ -68,6 +70,9 @@ do
         --build-workbench) ENABLE_BUILD_WORKBENCH=true ;;
         --clobber-yml)
             CLOBBER_FILE="--clobber-file $2"
+            shift ;;
+        --recipes-tag)
+            RECIPES_TAG="$2"
             shift ;;
         *)
             echo "Argument not accepted: $1"
@@ -105,7 +110,7 @@ cd $WORKSPACE
 if [[ -d conda-recipes ]]; then
     rm -rf conda-recipes
 fi
-git clone https://github.com/mantidproject/conda-recipes.git --depth=1
+git clone https://github.com/mantidproject/conda-recipes.git --depth=1 -b $RECIPES_TAG
 
 # Run conda build on framework
 cd $RECIPES_DIR/recipes/

--- a/buildconfig/Jenkins/Conda/conda-build-recipes
+++ b/buildconfig/Jenkins/Conda/conda-build-recipes
@@ -23,7 +23,7 @@
 #
 # Possible parameters:
 #   --clobber-yml: clobber the meta yaml files of each package build with conda-build, provide an absolute path to the uteyml file
-#   --recipes-tag: a branch, sha, or tag that should be used for cloning the recipes from conda-build-recipes
+#   --recipes-tag: a branch or tag that should be used for cloning the recipes from conda-build-recipes
 #
 
 # Setup expected variables


### PR DESCRIPTION
**Description of work.**
Add a recipes tag parameter to the conda-build-recipes script, this is necessary to allow a Jenkins job or anything really, to pick a specific conda recipe to clone and thus build.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**
Run the script (if it starts building mantid it did fine):
`conda-build-recipes ~/new_workspace_folder --build-mantid --recipes-tag 6.3.0` 
(The git sha is just a previous commit)

*There is no associated issue.*

*This does not require release notes* because **Developer Facing**


<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
