### PR TITLE
Support non-orthog view for 2D MDHisto workspaces in sliceviewer

### DIFF
--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_sliceviewer_model.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_sliceviewer_model.py
@@ -122,6 +122,8 @@ def _create_mock_workspace(ws_type,
             ws.isMDHistoWorkspace.return_value = True
             ws.getNonIntegratedDimensions.return_value = [MagicMock(), MagicMock()]
             ws.hasOriginalWorkspace.return_value = False
+            basis_mat = np.eye(ndims)
+            ws.getBasisVector.side_effect = lambda idim: basis_mat[:, idim]
         else:
             ws.isMDHistoWorkspace.return_value = False
 


### PR DESCRIPTION
**Description of work.**
Support non-orthog view in 2D MDHisto workspaces by forcing basis vector of third dim to be orthogonal in` proj_matrix`
Note this assumes the first and second Q-axes are H and K (as is always the case H,K,L are assumed to be in that order - sliceviewer does not infer them from the axes labels).
Also refactored to explicitly check if dim is Q rather than infer from basis vector

**To test:**
Follow instructions on issue - it should be possible to enable non-ortho view

Fixes #33463


<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
