### PR TITLE
Remove mantidqt && mantidworkbench packages from Conda release

### DIFF
--- a/docs/source/release/v6.3.0/index.rst
+++ b/docs/source/release/v6.3.0/index.rst
@@ -43,16 +43,10 @@ Conda
 We are excited to announce the release of brand-new packages built for the `Conda package manager <https://docs.conda.io/en/latest/>`__.
 Up until this release only a single ``mantid-framework`` package has been available for Linux but
 this release sees full support for our standard platforms (Linux, Windows, macOS).
-Furthermore, the traditional monolithic package has been split into 3 packages in the Conda world:
+We have also renamed the package from ``mantid-framework`` to ``mantid`` to align with the package name used in scripts.
 
-- ``mantid``: Access to the algorithms and workspace from Python (no GUI components).
-
-- ``mantidqt``: Access to custom-made Qt widgets built on top of Mantid functionality,
-  e.g. InstrumentViewer, SliceViewer.
-
-- ``mantidworkbench``: A package shippping the traditional Workbench application.
-
-For instructions on how to access these packages please see the `Conda installation instructions <https://download.mantidproject.org/conda.html>`__.
+For instructions on how to access the packages please see
+the `Conda installation instructions <https://download.mantidproject.org/conda.html>`__.
 
 Future Packaging Changes
 ------------------------


### PR DESCRIPTION
**Description of work.**

A bug in `mantidqt`/`mantidworkbench` Conda packages has been found so we are not releasing them. We will instead just release `mantid`. This reworks the release note.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**

Review the wording.

*There is no associated issue.*


<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
