### PR TITLE
Refactor LookupRowFinder to take row instead of row properties

### DIFF
--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -749,7 +749,7 @@ shadowFunction:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/ISISReflectometry/GU
 shadowFunction:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/ISISReflectometry/GUI/Common/Encoder.cpp:261
 shadowFunction:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/ISISReflectometry/GUI/Common/Encoder.cpp:284
 shadowFunction:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/ISISReflectometry/GUI/Common/Encoder.cpp:311
-useStlAlgorithm:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/ISISReflectometry/Reduction/Experiment.cpp:62
+useStlAlgorithm:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/ISISReflectometry/Reduction/Experiment.cpp:63
 useStlAlgorithm:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/Indirect/DensityOfStates.cpp:121
 unreadVariable:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/Indirect/IndirectCorrections.cpp:80
 unreadVariable:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/Indirect/IndirectDataAnalysis.cpp:91

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/GroupProcessingAlgorithm.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/GroupProcessingAlgorithm.cpp
@@ -130,7 +130,7 @@ std::unique_ptr<MantidQt::API::IAlgorithmRuntimeProps> createAlgorithmRuntimePro
   auto properties = std::make_unique<MantidQt::API::AlgorithmRuntimeProps>();
   updateWorkspaceProperties(*properties, group);
   // Set the rebin Params from the lookup row resolution, if given
-  updateLookupRowProperties(*properties, model.findLookupRow());
+  updateLookupRowProperties(*properties, model.findWildcardLookupRow());
   // Override the lookup row with the group's rows' resolution,
   // if given
   updateGroupProperties(*properties, group);

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/GroupProcessingAlgorithm.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/GroupProcessingAlgorithm.cpp
@@ -70,7 +70,7 @@ void updateParamsFromResolution(AlgorithmRuntimeProps &properties, boost::option
   AlgorithmProperties::update("Params", -(resolution.get()), properties);
 }
 
-void updateLookupRowProperties(AlgorithmRuntimeProps &properties, LookupRow const *lookupRow) {
+void updateLookupRowProperties(AlgorithmRuntimeProps &properties, boost::optional<LookupRow> lookupRow) {
   if (!lookupRow)
     return;
 

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/RowProcessingAlgorithm.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/RowProcessingAlgorithm.cpp
@@ -102,7 +102,7 @@ void updateExperimentProperties(AlgorithmRuntimeProps &properties, Experiment co
   updateFloodCorrectionProperties(properties, experiment.floodCorrections());
 }
 
-void updateLookupRowProperties(AlgorithmRuntimeProps &properties, LookupRow const *lookupRow) {
+void updateLookupRowProperties(AlgorithmRuntimeProps &properties, boost::optional<LookupRow> lookupRow) {
   if (!lookupRow)
     return;
 

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/RowProcessingAlgorithm.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/RowProcessingAlgorithm.cpp
@@ -237,7 +237,7 @@ std::unique_ptr<MantidQt::API::IAlgorithmRuntimeProps> createAlgorithmRuntimePro
   auto properties = createAlgorithmRuntimeProps(model);
   // Update properties specific to this row - the per-angle options based on
   // the known angle, and the values in the table cells in the row
-  updateLookupRowProperties(*properties, model.findLookupRow(row.theta()));
+  updateLookupRowProperties(*properties, model.findLookupRow(row));
   updateRowProperties(*properties, row);
   return properties;
 }
@@ -250,7 +250,7 @@ std::unique_ptr<MantidQt::API::IAlgorithmRuntimeProps> createAlgorithmRuntimePro
   updateExperimentProperties(*properties, model.experiment());
   updateInstrumentProperties(*properties, model.instrument());
   // Update properties from the wildcard row in the lookup table
-  updateLookupRowProperties(*properties, model.findLookupRow());
+  updateLookupRowProperties(*properties, model.findWildcardLookupRow());
   return properties;
 }
 } // namespace MantidQt::CustomInterfaces::ISISReflectometry

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/Batch.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/Batch.cpp
@@ -27,9 +27,11 @@ std::vector<MantidWidgets::Batch::RowLocation> Batch::selectedRowLocations() con
   return m_runsTable.selectedRowLocations();
 }
 
-boost::optional<LookupRow> Batch::findLookupRow(boost::optional<double> thetaAngle) const {
-  return experiment().findLookupRow(thetaAngle, runsTable().thetaTolerance());
+boost::optional<LookupRow> Batch::findLookupRow(Row const &row) const {
+  return experiment().findLookupRow(row, runsTable().thetaTolerance());
 }
+
+boost::optional<LookupRow> Batch::findWildcardLookupRow() const { return experiment().findWildcardLookupRow(); }
 
 void Batch::resetState() { m_runsTable.resetState(); }
 

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/Batch.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/Batch.cpp
@@ -27,7 +27,7 @@ std::vector<MantidWidgets::Batch::RowLocation> Batch::selectedRowLocations() con
   return m_runsTable.selectedRowLocations();
 }
 
-LookupRow const *Batch::findLookupRow(boost::optional<double> thetaAngle) const {
+boost::optional<LookupRow> Batch::findLookupRow(boost::optional<double> thetaAngle) const {
   return experiment().findLookupRow(thetaAngle, runsTable().thetaTolerance());
 }
 

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/Batch.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/Batch.h
@@ -38,7 +38,8 @@ public:
   std::vector<MantidWidgets::Batch::RowLocation> selectedRowLocations() const;
   template <typename T>
   bool isInSelection(T const &item, std::vector<MantidWidgets::Batch::RowLocation> const &selectedRowLocations) const;
-  boost::optional<LookupRow> findLookupRow(boost::optional<double> thetaAngle = boost::none) const;
+  boost::optional<LookupRow> findLookupRow(Row const &row) const;
+  boost::optional<LookupRow> findWildcardLookupRow() const;
   void resetState();
   void resetSkippedItems();
   boost::optional<Item &> getItemWithOutputWorkspaceOrNone(std::string const &wsName);

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/Batch.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/Batch.h
@@ -38,7 +38,7 @@ public:
   std::vector<MantidWidgets::Batch::RowLocation> selectedRowLocations() const;
   template <typename T>
   bool isInSelection(T const &item, std::vector<MantidWidgets::Batch::RowLocation> const &selectedRowLocations) const;
-  LookupRow const *findLookupRow(boost::optional<double> thetaAngle = boost::none) const;
+  boost::optional<LookupRow> findLookupRow(boost::optional<double> thetaAngle = boost::none) const;
   void resetState();
   void resetSkippedItems();
   boost::optional<Item &> getItemWithOutputWorkspaceOrNone(std::string const &wsName);

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/Experiment.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/Experiment.cpp
@@ -7,6 +7,7 @@
 #include "Experiment.h"
 #include "LookupRowFinder.h"
 #include "MantidQtWidgets/Common/ParseKeyValueString.h"
+#include <boost/optional.hpp>
 #include <cmath>
 
 namespace MantidQt::CustomInterfaces::ISISReflectometry {
@@ -63,7 +64,8 @@ std::vector<LookupRow::ValueArray> Experiment::lookupTableToArray() const {
   return result;
 }
 
-LookupRow const *Experiment::findLookupRow(const boost::optional<double> &thetaAngle, double tolerance) const {
+boost::optional<LookupRow> Experiment::findLookupRow(const boost::optional<double> &thetaAngle,
+                                                     double tolerance) const {
   LookupRowFinder findLookupRow(m_lookupTable);
   return findLookupRow(thetaAngle, tolerance);
 }

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/Experiment.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/Experiment.cpp
@@ -64,10 +64,14 @@ std::vector<LookupRow::ValueArray> Experiment::lookupTableToArray() const {
   return result;
 }
 
-boost::optional<LookupRow> Experiment::findLookupRow(const boost::optional<double> &thetaAngle,
-                                                     double tolerance) const {
+boost::optional<LookupRow> Experiment::findLookupRow(Row const &row, double tolerance) const {
   LookupRowFinder findLookupRow(m_lookupTable);
-  return findLookupRow(thetaAngle, tolerance);
+  return findLookupRow(row, tolerance);
+}
+
+boost::optional<LookupRow> Experiment::findWildcardLookupRow() const {
+  LookupRowFinder finder(m_lookupTable);
+  return finder.findWildcardLookupRow();
 }
 
 bool operator!=(Experiment const &lhs, Experiment const &rhs) { return !(lhs == rhs); }

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/Experiment.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/Experiment.cpp
@@ -18,8 +18,8 @@ Experiment::Experiment()
       m_polarizationCorrections(PolarizationCorrections(PolarizationCorrectionType::None)),
       m_floodCorrections(FloodCorrections(FloodCorrectionType::Workspace)), m_transmissionStitchOptions(),
       m_stitchParameters(std::map<std::string, std::string>()),
-      m_lookupTable(LookupTable({LookupRow(boost::none, TransmissionRunPair(), boost::none, RangeInQ(), boost::none,
-                                           ProcessingInstructions(), boost::none)})) {}
+      m_lookupTable(LookupTable({LookupRow(boost::none, boost::none, TransmissionRunPair(), boost::none, RangeInQ(),
+                                           boost::none, ProcessingInstructions(), boost::none)})) {}
 
 Experiment::Experiment(AnalysisMode analysisMode, ReductionType reductionType, SummationType summationType,
                        bool includePartialBins, bool debug, BackgroundSubtraction backgroundSubtraction,

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/Experiment.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/Experiment.h
@@ -15,6 +15,7 @@
 #include "ReductionType.h"
 #include "SummationType.h"
 #include "TransmissionStitchOptions.h"
+#include <boost/optional.hpp>
 #include <map>
 #include <string>
 #include <vector>
@@ -51,7 +52,7 @@ public:
   LookupTable const &lookupTable() const;
   std::vector<LookupRow::ValueArray> lookupTableToArray() const;
 
-  LookupRow const *findLookupRow(const boost::optional<double> &thetaAngle, double tolerance) const;
+  boost::optional<LookupRow> findLookupRow(const boost::optional<double> &thetaAngle, double tolerance) const;
 
 private:
   AnalysisMode m_analysisMode;

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/Experiment.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/Experiment.h
@@ -24,6 +24,8 @@ namespace MantidQt {
 namespace CustomInterfaces {
 namespace ISISReflectometry {
 
+class Row;
+
 /** @class Experiment
 
     The Experiment model holds all settings relating to the Experiment Settings
@@ -52,7 +54,8 @@ public:
   LookupTable const &lookupTable() const;
   std::vector<LookupRow::ValueArray> lookupTableToArray() const;
 
-  boost::optional<LookupRow> findLookupRow(const boost::optional<double> &thetaAngle, double tolerance) const;
+  boost::optional<LookupRow> findLookupRow(Row const &row, double tolerance) const;
+  boost::optional<LookupRow> findWildcardLookupRow() const;
 
 private:
   AnalysisMode m_analysisMode;

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/LookupRow.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/LookupRow.cpp
@@ -44,8 +44,8 @@ boost::optional<ProcessingInstructions> LookupRow::backgroundProcessingInstructi
 }
 
 bool operator==(LookupRow const &lhs, LookupRow const &rhs) {
-  return lhs.thetaOrWildcard() == rhs.thetaOrWildcard() && lhs.qRange() == rhs.qRange() &&
-         lhs.scaleFactor() == rhs.scaleFactor() &&
+  return lhs.thetaOrWildcard() == rhs.thetaOrWildcard() && lhs.titleMatcher() == rhs.titleMatcher() &&
+         lhs.qRange() == rhs.qRange() && lhs.scaleFactor() == rhs.scaleFactor() &&
          lhs.transmissionProcessingInstructions() == rhs.transmissionProcessingInstructions() &&
          lhs.processingInstructions() == rhs.processingInstructions() &&
          lhs.backgroundProcessingInstructions() == rhs.backgroundProcessingInstructions();

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/LookupRow.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/LookupRow.cpp
@@ -8,14 +8,14 @@
 
 namespace MantidQt::CustomInterfaces::ISISReflectometry {
 
-LookupRow::LookupRow(boost::optional<double> theta,
-
+LookupRow::LookupRow(boost::optional<double> theta, boost::optional<boost::regex> titleMatcher,
                      TransmissionRunPair transmissionRuns,
                      boost::optional<ProcessingInstructions> transmissionProcessingInstructions, RangeInQ qRange,
                      boost::optional<double> scaleFactor,
                      boost::optional<ProcessingInstructions> processingInstructions,
                      boost::optional<ProcessingInstructions> backgroundProcessingInstructions)
-    : m_theta(std::move(theta)), m_transmissionRuns(std::move(transmissionRuns)), m_qRange(std::move(qRange)),
+    : m_theta(std::move(theta)), m_titleMatcher(std::move(titleMatcher)),
+      m_transmissionRuns(std::move(transmissionRuns)), m_qRange(std::move(qRange)),
       m_scaleFactor(std::move(scaleFactor)),
       m_transmissionProcessingInstructions(std::move(transmissionProcessingInstructions)),
       m_processingInstructions(std::move(processingInstructions)),
@@ -26,6 +26,8 @@ TransmissionRunPair const &LookupRow::transmissionWorkspaceNames() const { retur
 bool LookupRow::isWildcard() const { return !m_theta.is_initialized(); }
 
 boost::optional<double> LookupRow::thetaOrWildcard() const { return m_theta; }
+
+boost::optional<boost::regex> LookupRow::titleMatcher() const { return m_titleMatcher; }
 
 RangeInQ const &LookupRow::qRange() const { return m_qRange; }
 

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/LookupRow.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/LookupRow.h
@@ -11,6 +11,7 @@
 #include "TransmissionRunPair.h"
 #include <array>
 #include <boost/optional.hpp>
+#include <boost/regex.hpp>
 #include <string>
 namespace MantidQt {
 namespace CustomInterfaces {
@@ -55,7 +56,8 @@ public:
                                                            "ProcessingInstructions",
                                                            "BackgroundProcessingInstructions"};
 
-  LookupRow(boost::optional<double> theta, TransmissionRunPair tranmissionRuns,
+  LookupRow(boost::optional<double> theta, boost::optional<boost::regex> titleMatcher,
+            TransmissionRunPair tranmissionRuns,
             boost::optional<ProcessingInstructions> transmissionProcessingInstructions, RangeInQ qRange,
             boost::optional<double> scaleFactor, boost::optional<ProcessingInstructions> processingInstructions,
             boost::optional<ProcessingInstructions> backgroundProcessingInstructions);
@@ -63,6 +65,7 @@ public:
   TransmissionRunPair const &transmissionWorkspaceNames() const;
   bool isWildcard() const;
   boost::optional<double> thetaOrWildcard() const;
+  boost::optional<boost::regex> titleMatcher() const;
   RangeInQ const &qRange() const;
   boost::optional<double> scaleFactor() const;
   boost::optional<ProcessingInstructions> transmissionProcessingInstructions() const;
@@ -71,6 +74,7 @@ public:
 
 private:
   boost::optional<double> m_theta;
+  boost::optional<boost::regex> m_titleMatcher;
   TransmissionRunPair m_transmissionRuns;
   RangeInQ m_qRange;
   boost::optional<double> m_scaleFactor;

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/LookupRowFinder.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/LookupRowFinder.cpp
@@ -6,7 +6,10 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 
 #include "LookupRowFinder.h"
+#include <boost/optional.hpp>
+#include <boost/regex.hpp>
 #include <cmath>
+#include <vector>
 
 namespace {
 constexpr double EPSILON = std::numeric_limits<double>::epsilon();
@@ -18,11 +21,13 @@ bool equalWithinTolerance(double val1, double val2, double tolerance) {
 
 namespace MantidQt::CustomInterfaces::ISISReflectometry {
 
-LookupRowFinder::LookupRowFinder(const LookupTable &table) : m_lookupTable(table) {}
+LookupRowFinder::LookupRowFinder(LookupTable const &table) : m_lookupTable(table) {}
 
-LookupRow const *LookupRowFinder::operator()(const boost::optional<double> &thetaAngle, double tolerance) const {
+// TODO pass in row rather than unpacking at call-site
+boost::optional<LookupRow> LookupRowFinder::operator()(boost::optional<double> const &thetaAngle, double tolerance,
+                                                       std::string const &title) const {
   if (thetaAngle) {
-    if (const auto *found = searchByTheta(thetaAngle, tolerance)) {
+    if (auto found = searchByTheta(thetaAngle, tolerance)) {
       return found;
     }
   }
@@ -30,18 +35,34 @@ LookupRow const *LookupRowFinder::operator()(const boost::optional<double> &thet
   return searchForWildcard();
 }
 
-LookupRow const *LookupRowFinder::searchByTheta(const boost::optional<double> &thetaAngle, double tolerance) const {
+boost::optional<LookupRow> LookupRowFinder::searchByTheta(boost::optional<double> const &thetaAngle,
+                                                          double tolerance) const {
   auto match = std::find_if(
       m_lookupTable.cbegin(), m_lookupTable.cend(), [thetaAngle, tolerance](LookupRow const &candiate) -> bool {
         return !candiate.isWildcard() && equalWithinTolerance(*thetaAngle, candiate.thetaOrWildcard().get(), tolerance);
       });
-  return match == m_lookupTable.cend() ? nullptr : &(*match);
+  if (match == m_lookupTable.cend())
+    return boost::none;
+  else
+    return *match;
 }
 
-LookupRow const *LookupRowFinder::searchForWildcard() const {
+std::vector<LookupRow> LookupRowFinder::searchByTitle(std::string_view title) const {
+  auto results = std::vector<LookupRow>();
+  std::copy_if(
+      m_lookupTable.cbegin(), m_lookupTable.cend(), std::back_inserter(results), [&title](auto const &candidate) {
+        return candidate.titleMatcher().has_value() && boost::regex_search("test", candidate.titleMatcher().get());
+      });
+  return results;
+}
+
+boost::optional<LookupRow> LookupRowFinder::searchForWildcard() const {
   auto match = std::find_if(m_lookupTable.cbegin(), m_lookupTable.cend(),
                             [](LookupRow const &candidate) -> bool { return candidate.isWildcard(); });
-  return match == m_lookupTable.cend() ? nullptr : &(*match);
+  if (match == m_lookupTable.cend())
+    return boost::none;
+  else
+    return *match;
 }
 
 } // namespace MantidQt::CustomInterfaces::ISISReflectometry

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/LookupRowFinder.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/LookupRowFinder.cpp
@@ -55,17 +55,17 @@ boost::optional<LookupRow> LookupRowFinder::searchByTheta(std::vector<LookupRow>
 
 std::vector<LookupRow> LookupRowFinder::findMatchingRegexes(std::string const &title) const {
   auto results = std::vector<LookupRow>();
-  std::copy_if(
-      m_lookupTable.cbegin(), m_lookupTable.cend(), std::back_inserter(results), [&title](auto const &candidate) {
-        return candidate.titleMatcher().has_value() && boost::regex_search(title, candidate.titleMatcher().get());
-      });
+  std::copy_if(m_lookupTable.cbegin(), m_lookupTable.cend(), std::back_inserter(results),
+               [&title](auto const &candidate) {
+                 return candidate.titleMatcher() && boost::regex_search(title, candidate.titleMatcher().get());
+               });
   return results;
 }
 
 std::vector<LookupRow> LookupRowFinder::findEmptyRegexes() const {
   auto results = std::vector<LookupRow>();
   std::copy_if(m_lookupTable.cbegin(), m_lookupTable.cend(), std::back_inserter(results),
-               [](auto const &candidate) { return !candidate.titleMatcher().has_value(); });
+               [](auto const &candidate) { return !candidate.titleMatcher(); });
   return results;
 }
 

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/LookupRowFinder.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/LookupRowFinder.h
@@ -29,6 +29,8 @@ private:
                                            double) const;
   std::vector<LookupRow> searchByTitle(std::string const &title) const;
   boost::optional<LookupRow> searchForWildcard() const;
+  std::vector<LookupRow> findMatchingRegexes(std::string const &title) const;
+  std::vector<LookupRow> findEmptyRegexes() const;
 };
 
 } // namespace MantidQt::CustomInterfaces::ISISReflectometry

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/LookupRowFinder.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/LookupRowFinder.h
@@ -14,21 +14,21 @@
 #include <vector>
 
 namespace MantidQt::CustomInterfaces::ISISReflectometry {
+class Row;
 
 class MANTIDQT_ISISREFLECTOMETRY_DLL LookupRowFinder {
 public:
   LookupRowFinder(LookupTable const &);
 
-  boost::optional<LookupRow> operator()(boost::optional<double> const &thetaAngle, double tolerance,
-                                        std::string const & = "") const;
+  boost::optional<LookupRow> operator()(Row const &row, double tolerance) const;
+  boost::optional<LookupRow> findWildcardLookupRow() const;
 
 private:
   LookupTable const &m_lookupTable;
 
   boost::optional<LookupRow> searchByTheta(std::vector<LookupRow> lookupRows, boost::optional<double> const &,
                                            double) const;
-  std::vector<LookupRow> searchByTitle(std::string const &title) const;
-  boost::optional<LookupRow> searchForWildcard() const;
+  std::vector<LookupRow> searchByTitle(Row const &row) const;
   std::vector<LookupRow> findMatchingRegexes(std::string const &title) const;
   std::vector<LookupRow> findEmptyRegexes() const;
 };

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/LookupRowFinder.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/LookupRowFinder.h
@@ -25,8 +25,9 @@ public:
 private:
   LookupTable const &m_lookupTable;
 
-  boost::optional<LookupRow> searchByTheta(boost::optional<double> const &, double) const;
-  std::vector<LookupRow> searchByTitle(std::string_view title) const;
+  boost::optional<LookupRow> searchByTheta(std::vector<LookupRow> lookupRows, boost::optional<double> const &,
+                                           double) const;
+  std::vector<LookupRow> searchByTitle(std::string const &title) const;
   boost::optional<LookupRow> searchForWildcard() const;
 };
 

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/LookupRowFinder.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/LookupRowFinder.h
@@ -9,6 +9,9 @@
 
 #include "Common/DllConfig.h"
 #include "LookupRow.h"
+#include <boost/optional.hpp>
+#include <boost/regex.hpp>
+#include <vector>
 
 namespace MantidQt::CustomInterfaces::ISISReflectometry {
 
@@ -16,13 +19,15 @@ class MANTIDQT_ISISREFLECTOMETRY_DLL LookupRowFinder {
 public:
   LookupRowFinder(LookupTable const &);
 
-  LookupRow const *operator()(const boost::optional<double> &thetaAngle, double tolerance) const;
+  boost::optional<LookupRow> operator()(boost::optional<double> const &thetaAngle, double tolerance,
+                                        std::string const & = "") const;
 
 private:
   LookupTable const &m_lookupTable;
 
-  LookupRow const *searchByTheta(const boost::optional<double> &thetaAngle, double tolerance) const;
-  LookupRow const *searchForWildcard() const;
+  boost::optional<LookupRow> searchByTheta(boost::optional<double> const &, double) const;
+  std::vector<LookupRow> searchByTitle(std::string_view title) const;
+  boost::optional<LookupRow> searchForWildcard() const;
 };
 
 } // namespace MantidQt::CustomInterfaces::ISISReflectometry

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/ValidateLookupRow.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/ValidateLookupRow.cpp
@@ -104,7 +104,9 @@ LookupRowValidator::parseBackgroundProcessingInstructions(CellText const &cellTe
 ValidationResult<LookupRow, std::vector<int>> LookupRowValidator::operator()(CellText const &cellText) {
   auto maybeTheta = parseThetaOrWhitespace(cellText);
   // TODO implement parsing function for the title matcher when it is added to the view
-  auto maybeTitleMatcher = boost::optional<boost::regex>("");
+  // Note that the contained value is already an optional so we wrap it in another optional to indicate whether
+  // parsing succeeded or not.
+  auto maybeTitleMatcher = boost::optional<boost::optional<boost::regex>>(boost::optional<boost::regex>(boost::none));
   auto maybeTransmissionRuns = parseTransmissionRuns(cellText);
   auto maybeTransmissionProcessingInstructions = parseTransmissionProcessingInstructions(cellText);
   auto maybeQRange = parseQRange(cellText);

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/ValidateLookupRow.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/ValidateLookupRow.cpp
@@ -103,6 +103,8 @@ LookupRowValidator::parseBackgroundProcessingInstructions(CellText const &cellTe
 
 ValidationResult<LookupRow, std::vector<int>> LookupRowValidator::operator()(CellText const &cellText) {
   auto maybeTheta = parseThetaOrWhitespace(cellText);
+  // TODO implement parsing function for the title matcher when it is added to the view
+  auto maybeTitleMatcher = boost::optional<boost::regex>("");
   auto maybeTransmissionRuns = parseTransmissionRuns(cellText);
   auto maybeTransmissionProcessingInstructions = parseTransmissionProcessingInstructions(cellText);
   auto maybeQRange = parseQRange(cellText);
@@ -110,8 +112,8 @@ ValidationResult<LookupRow, std::vector<int>> LookupRowValidator::operator()(Cel
   auto maybeProcessingInstructions = parseProcessingInstructions(cellText);
   auto maybeBackgroundProcessingInstructions = parseBackgroundProcessingInstructions(cellText);
   auto maybeDefaults = makeIfAllInitialized<LookupRow>(
-      maybeTheta, maybeTransmissionRuns, maybeTransmissionProcessingInstructions, maybeQRange, maybeScaleFactor,
-      maybeProcessingInstructions, maybeBackgroundProcessingInstructions);
+      maybeTheta, maybeTitleMatcher, maybeTransmissionRuns, maybeTransmissionProcessingInstructions, maybeQRange,
+      maybeScaleFactor, maybeProcessingInstructions, maybeBackgroundProcessingInstructions);
 
   if (maybeDefaults.is_initialized())
     return ValidationResult<LookupRow, std::vector<int>>(maybeDefaults.get());

--- a/qt/scientific_interfaces/ISISReflectometry/TestHelpers/ModelCreationHelper.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/TestHelpers/ModelCreationHelper.cpp
@@ -349,6 +349,8 @@ LookupRow makeLookupRow(boost::optional<double> angle, boost::optional<boost::re
       ProcessingInstructions("2-3,7-8"));
 }
 
+LookupRow makeWildcardLookupRow() { return makeLookupRow(boost::none, boost::none); }
+
 LookupTable makeEmptyLookupTable() { return LookupTable{}; }
 
 LookupTable makeLookupTable() {

--- a/qt/scientific_interfaces/ISISReflectometry/TestHelpers/ModelCreationHelper.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/TestHelpers/ModelCreationHelper.cpp
@@ -341,6 +341,14 @@ ReductionJobs oneGroupWithTwoRowsWithOutputNamesModel() {
 
 /* Experiment */
 
+LookupRow makeLookupRow(boost::optional<double> angle, boost::optional<boost::regex> titleMatcher) {
+  return LookupRow(
+      std::move(angle), std::move(titleMatcher),
+      TransmissionRunPair(std::vector<std::string>{"22348", "22349"}, std::vector<std::string>{"22358", "22359"}),
+      ProcessingInstructions("4"), RangeInQ(0.009, 0.03, 1.3), 0.9, ProcessingInstructions("4-6"),
+      ProcessingInstructions("2-3,7-8"));
+}
+
 LookupTable makeEmptyLookupTable() { return LookupTable{}; }
 
 LookupTable makeLookupTable() {
@@ -350,14 +358,9 @@ LookupTable makeLookupTable() {
 }
 
 LookupTable makeLookupTableWithTwoAngles() {
-  return LookupTable{// two angle rows
-                     LookupRow(0.5, boost::none, TransmissionRunPair("22347", ""), boost::none,
+  return LookupTable{LookupRow(0.5, boost::none, TransmissionRunPair("22347", ""), boost::none,
                                RangeInQ(0.008, 0.02, 1.2), 0.8, ProcessingInstructions("2-3"), boost::none),
-                     LookupRow(2.3, boost::none,
-                               TransmissionRunPair(std::vector<std::string>{"22348", "22349"},
-                                                   std::vector<std::string>{"22358", "22359"}),
-                               ProcessingInstructions("4"), RangeInQ(0.009, 0.03, 1.3), 0.9,
-                               ProcessingInstructions("4-6"), ProcessingInstructions("2-3,7-8"))};
+                     makeLookupRow(2.3)};
 }
 
 LookupTable makeLookupTableWithTwoAnglesAndWildcard() {
@@ -368,11 +371,7 @@ LookupTable makeLookupTableWithTwoAnglesAndWildcard() {
       // two angle rows
       LookupRow(0.5, boost::none, TransmissionRunPair("22347", ""), boost::none, RangeInQ(0.008, 0.02, 1.2), 0.8,
                 ProcessingInstructions("2-3"), boost::none),
-      LookupRow(
-          2.3, boost::none,
-          TransmissionRunPair(std::vector<std::string>{"22348", "22349"}, std::vector<std::string>{"22358", "22359"}),
-          ProcessingInstructions("4"), RangeInQ(0.009, 0.03, 1.3), 0.9, ProcessingInstructions("4-6"),
-          ProcessingInstructions("2-3,7-8"))};
+      LookupRow(makeLookupRow(2.3))};
 }
 
 std::map<std::string, std::string> makeStitchOptions() {

--- a/qt/scientific_interfaces/ISISReflectometry/TestHelpers/ModelCreationHelper.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/TestHelpers/ModelCreationHelper.cpp
@@ -344,16 +344,16 @@ ReductionJobs oneGroupWithTwoRowsWithOutputNamesModel() {
 LookupTable makeEmptyLookupTable() { return LookupTable{}; }
 
 LookupTable makeLookupTable() {
-  auto lookupRow = LookupRow(boost::none, TransmissionRunPair(), boost::none,
+  auto lookupRow = LookupRow(boost::none, boost::none, TransmissionRunPair(), boost::none,
                              RangeInQ(boost::none, boost::none, boost::none), boost::none, boost::none, boost::none);
   return LookupTable{std::move(lookupRow)};
 }
 
 LookupTable makeLookupTableWithTwoAngles() {
   return LookupTable{// two angle rows
-                     LookupRow(0.5, TransmissionRunPair("22347", ""), boost::none, RangeInQ(0.008, 0.02, 1.2), 0.8,
-                               ProcessingInstructions("2-3"), boost::none),
-                     LookupRow(2.3,
+                     LookupRow(0.5, boost::none, TransmissionRunPair("22347", ""), boost::none,
+                               RangeInQ(0.008, 0.02, 1.2), 0.8, ProcessingInstructions("2-3"), boost::none),
+                     LookupRow(2.3, boost::none,
                                TransmissionRunPair(std::vector<std::string>{"22348", "22349"},
                                                    std::vector<std::string>{"22358", "22359"}),
                                ProcessingInstructions("4"), RangeInQ(0.009, 0.03, 1.3), 0.9,
@@ -363,13 +363,13 @@ LookupTable makeLookupTableWithTwoAngles() {
 LookupTable makeLookupTableWithTwoAnglesAndWildcard() {
   return LookupTable{
       // wildcard row with no angle
-      LookupRow(boost::none, TransmissionRunPair("22345", "22346"), ProcessingInstructions("5-6"),
+      LookupRow(boost::none, boost::none, TransmissionRunPair("22345", "22346"), ProcessingInstructions("5-6"),
                 RangeInQ(0.007, 0.01, 1.1), 0.7, ProcessingInstructions("1"), ProcessingInstructions("3,7")),
       // two angle rows
-      LookupRow(0.5, TransmissionRunPair("22347", ""), boost::none, RangeInQ(0.008, 0.02, 1.2), 0.8,
+      LookupRow(0.5, boost::none, TransmissionRunPair("22347", ""), boost::none, RangeInQ(0.008, 0.02, 1.2), 0.8,
                 ProcessingInstructions("2-3"), boost::none),
       LookupRow(
-          2.3,
+          2.3, boost::none,
           TransmissionRunPair(std::vector<std::string>{"22348", "22349"}, std::vector<std::string>{"22358", "22359"}),
           ProcessingInstructions("4"), RangeInQ(0.009, 0.03, 1.3), 0.9, ProcessingInstructions("4-6"),
           ProcessingInstructions("2-3,7-8"))};

--- a/qt/scientific_interfaces/ISISReflectometry/TestHelpers/ModelCreationHelper.h
+++ b/qt/scientific_interfaces/ISISReflectometry/TestHelpers/ModelCreationHelper.h
@@ -71,6 +71,8 @@ MANTIDQT_ISISREFLECTOMETRY_DLL
 ReductionJobs oneGroupWithTwoRowsWithOutputNamesModel();
 
 /* Experiment */
+MANTIDQT_ISISREFLECTOMETRY_DLL LookupRow makeLookupRow(boost::optional<double> angle,
+                                                       boost::optional<boost::regex> titleMatcher = boost::none);
 MANTIDQT_ISISREFLECTOMETRY_DLL LookupTable makeEmptyLookupTable();
 MANTIDQT_ISISREFLECTOMETRY_DLL LookupTable makeLookupTable();
 MANTIDQT_ISISREFLECTOMETRY_DLL LookupTable makeLookupTableWithTwoAngles();

--- a/qt/scientific_interfaces/ISISReflectometry/TestHelpers/ModelCreationHelper.h
+++ b/qt/scientific_interfaces/ISISReflectometry/TestHelpers/ModelCreationHelper.h
@@ -71,6 +71,7 @@ MANTIDQT_ISISREFLECTOMETRY_DLL
 ReductionJobs oneGroupWithTwoRowsWithOutputNamesModel();
 
 /* Experiment */
+MANTIDQT_ISISREFLECTOMETRY_DLL LookupRow makeWildcardLookupRow();
 MANTIDQT_ISISREFLECTOMETRY_DLL LookupRow makeLookupRow(boost::optional<double> angle,
                                                        boost::optional<boost::regex> titleMatcher = boost::none);
 MANTIDQT_ISISREFLECTOMETRY_DLL LookupTable makeEmptyLookupTable();

--- a/qt/scientific_interfaces/ISISReflectometry/test/Experiment/ExperimentOptionDefaultsTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Experiment/ExperimentOptionDefaultsTest.h
@@ -72,7 +72,7 @@ public:
 
   void testDefaultLookupRowOptions() {
     auto result = getDefaults();
-    auto expected = LookupRow(boost::none, TransmissionRunPair(), boost::none,
+    auto expected = LookupRow(boost::none, boost::none, TransmissionRunPair(), boost::none,
                               RangeInQ(boost::none, boost::none, boost::none), boost::none, boost::none, boost::none);
     TS_ASSERT_EQUALS(result.lookupTable().size(), 1);
     TS_ASSERT_EQUALS(result.lookupTable().front(), expected);
@@ -80,8 +80,8 @@ public:
 
   void testValidLookupRowOptionsFromParamsFile() {
     auto result = getDefaultsFromParamsFile("Experiment");
-    auto expected = LookupRow(boost::none, TransmissionRunPair(), boost::none, RangeInQ(0.01, 0.03, 0.2), 0.7,
-                              std::string("390-415"), std::string("370-389,416-430"));
+    auto expected = LookupRow(boost::none, boost::none, TransmissionRunPair(), boost::none, RangeInQ(0.01, 0.03, 0.2),
+                              0.7, std::string("390-415"), std::string("370-389,416-430"));
     TS_ASSERT_EQUALS(result.lookupTable().size(), 1);
     TS_ASSERT_EQUALS(result.lookupTable().front(), expected);
   }

--- a/qt/scientific_interfaces/ISISReflectometry/test/Experiment/ExperimentPresenterTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Experiment/ExperimentPresenterTest.h
@@ -557,8 +557,8 @@ public:
   }
 
   void testInstrumentChangedUpdatesLookupRowInView() {
-    auto lookupRow = LookupRow(boost::none, TransmissionRunPair(), boost::none, RangeInQ(0.01, 0.03, 0.2), 0.7,
-                               std::string("390-415"), std::string("370-389,416-430"));
+    auto lookupRow = LookupRow(boost::none, boost::none, TransmissionRunPair(), boost::none, RangeInQ(0.01, 0.03, 0.2),
+                               0.7, std::string("390-415"), std::string("370-389,416-430"));
     auto model = makeModelWithLookupRow(std::move(lookupRow));
     auto defaultOptions = expectDefaults(model);
     auto presenter = makePresenter(std::move(defaultOptions));
@@ -570,14 +570,14 @@ public:
   }
 
   void testInstrumentChangedUpdatesLookupRowInModel() {
-    auto model =
-        makeModelWithLookupRow(LookupRow(boost::none, TransmissionRunPair(), boost::none, RangeInQ(0.01, 0.03, 0.2),
-                                         0.7, std::string("390-415"), std::string("370-389,416-430")));
+    auto model = makeModelWithLookupRow(LookupRow(boost::none, boost::none, TransmissionRunPair(), boost::none,
+                                                  RangeInQ(0.01, 0.03, 0.2), 0.7, std::string("390-415"),
+                                                  std::string("370-389,416-430")));
     auto defaultOptions = expectDefaults(model);
     auto presenter = makePresenter(std::move(defaultOptions));
     presenter.notifyInstrumentChanged("POLREF");
-    auto expected = LookupRow(boost::none, TransmissionRunPair(), boost::none, RangeInQ(0.01, 0.03, 0.2), 0.7,
-                              std::string("390-415"), std::string("370-389,416-430"));
+    auto expected = LookupRow(boost::none, boost::none, TransmissionRunPair(), boost::none, RangeInQ(0.01, 0.03, 0.2),
+                              0.7, std::string("390-415"), std::string("370-389,416-430"));
     TS_ASSERT_EQUALS(presenter.experiment().lookupTable().size(), 1);
     TS_ASSERT_EQUALS(presenter.experiment().lookupTable().front(), expected);
     verifyAndClear();
@@ -843,14 +843,14 @@ private:
   // either as an input array of strings or an output model
   OptionsRow optionsRowWithFirstAngle() { return {"0.5", "13463", ""}; }
   LookupRow defaultsWithFirstAngle() {
-    return LookupRow(0.5, TransmissionRunPair("13463", ""), boost::none, RangeInQ(), boost::none, boost::none,
-                     boost::none);
+    return LookupRow(0.5, boost::none, TransmissionRunPair("13463", ""), boost::none, RangeInQ(), boost::none,
+                     boost::none, boost::none);
   }
 
   OptionsRow optionsRowWithSecondAngle() { return {"2.3", "13463", "13464"}; }
   LookupRow defaultsWithSecondAngle() {
-    return LookupRow(2.3, TransmissionRunPair("13463", "13464"), boost::none, RangeInQ(), boost::none, boost::none,
-                     boost::none);
+    return LookupRow(2.3, boost::none, TransmissionRunPair("13463", "13464"), boost::none, RangeInQ(), boost::none,
+                     boost::none, boost::none);
   }
   OptionsRow optionsRowWithWildcard() { return {"", "13463", "13464"}; }
   OptionsRow optionsRowWithFirstTransmissionRun() { return {"", "13463"}; }

--- a/qt/scientific_interfaces/ISISReflectometry/test/Reduction/LookupRowFinderTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Reduction/LookupRowFinderTest.h
@@ -22,9 +22,11 @@ public:
     for (const auto angle : {0.5, 2.3}) {
       const auto lookupRow = findLookupRow(angle, m_exactMatchTolerance);
       TS_ASSERT(lookupRow)
-      const auto foundAngle = lookupRow->thetaOrWildcard();
-      TS_ASSERT(foundAngle)
-      TS_ASSERT_DELTA(*foundAngle, angle, m_exactMatchTolerance)
+      if (lookupRow) {
+        const auto foundAngle = lookupRow->thetaOrWildcard();
+        TS_ASSERT(foundAngle)
+        TS_ASSERT_DELTA(*foundAngle, angle, m_exactMatchTolerance)
+      }
     }
   }
 
@@ -36,10 +38,12 @@ public:
     for (const auto angle : {(0.5 - matchTolerance), (2.3 + matchTolerance)}) {
       const auto lookupRow = findLookupRow(angle, matchTolerance);
       TS_ASSERT(lookupRow)
-      const auto foundAngle = lookupRow->thetaOrWildcard();
-      TS_ASSERT(foundAngle)
-      if (foundAngle)
-        TS_ASSERT_DELTA(*foundAngle, angle, matchTolerance)
+      if (lookupRow) {
+        const auto foundAngle = lookupRow->thetaOrWildcard();
+        TS_ASSERT(foundAngle)
+        if (foundAngle)
+          TS_ASSERT_DELTA(*foundAngle, angle, matchTolerance)
+      }
     }
   }
 
@@ -50,9 +54,11 @@ public:
     for (const auto angle : {1.2, 3.4}) {
       const auto lookupRow = findLookupRow(angle, m_exactMatchTolerance);
       TS_ASSERT(lookupRow)
-      const auto foundAngle = lookupRow->thetaOrWildcard();
-      TS_ASSERT(!foundAngle)
-      TS_ASSERT(lookupRow->isWildcard())
+      if (lookupRow) {
+        const auto foundAngle = lookupRow->thetaOrWildcard();
+        TS_ASSERT(!foundAngle)
+        TS_ASSERT(lookupRow->isWildcard())
+      }
     }
   }
 
@@ -82,9 +88,87 @@ public:
     LookupRowFinder findLookupRow(table);
     const auto foundLookupRow = findLookupRow(angle, m_exactMatchTolerance, "El Em En Oh");
     TS_ASSERT(foundLookupRow)
-    TS_ASSERT_EQUALS(*foundLookupRow, table[1])
+    if (foundLookupRow)
+      TS_ASSERT_EQUALS(*foundLookupRow, table[1])
   }
 
+  void test_searching_by_theta_and_title_found_with_wildcard_present() {
+    auto constexpr angle = 2.3;
+    auto table = LookupTable{ModelCreationHelper::makeLookupRow(angle, boost::regex("Ay")),
+                             ModelCreationHelper::makeLookupRow(angle, boost::regex("El")),
+                             ModelCreationHelper::makeWildcardLookupRow()};
+
+    LookupRowFinder findLookupRow(table);
+    const auto foundLookupRow = findLookupRow(angle, m_exactMatchTolerance, "El Em En Oh");
+    TS_ASSERT(foundLookupRow)
+    if (foundLookupRow)
+      TS_ASSERT_EQUALS(*foundLookupRow, table[1])
+  }
+
+  void test_searching_by_theta_found_but_title_not_found_returns_none() {
+    auto constexpr angle = 2.3;
+    auto table = LookupTable{ModelCreationHelper::makeLookupRow(angle, boost::regex("Ay")),
+                             ModelCreationHelper::makeLookupRow(angle, boost::regex("El"))};
+
+    LookupRowFinder findLookupRow(table);
+    const auto foundLookupRow = findLookupRow(angle, m_exactMatchTolerance, "En Oh");
+    TS_ASSERT(!foundLookupRow.has_value())
+  }
+
+  void test_searching_by_title_found_but_theta_not_found_returns_none() {
+    auto constexpr angle = 2.3;
+    auto table = LookupTable{ModelCreationHelper::makeLookupRow(angle, boost::regex("Ay")),
+                             ModelCreationHelper::makeLookupRow(angle, boost::regex("El"))};
+
+    LookupRowFinder findLookupRow(table);
+    const auto foundLookupRow = findLookupRow(0.5, m_exactMatchTolerance, "En Oh");
+    TS_ASSERT(!foundLookupRow.has_value())
+  }
+
+  void test_searching_by_theta_found_but_title_not_found_returns_wildcard() {
+    auto constexpr angle = 2.3;
+    auto wildcardRow = ModelCreationHelper::makeWildcardLookupRow();
+    auto table = LookupTable{ModelCreationHelper::makeLookupRow(angle, boost::regex("Ay")),
+                             ModelCreationHelper::makeLookupRow(angle, boost::regex("El")), wildcardRow};
+
+    LookupRowFinder findLookupRow(table);
+    const auto foundLookupRow = findLookupRow(angle, m_exactMatchTolerance, "En Oh");
+    TS_ASSERT(foundLookupRow.has_value())
+    TS_ASSERT_EQUALS(wildcardRow, foundLookupRow)
+  }
+
+  void test_searching_by_title_found_but_theta_not_found_returns_wildcard() {
+    auto constexpr angle = 2.3;
+    auto wildcardRow = ModelCreationHelper::makeWildcardLookupRow();
+    auto table = LookupTable{ModelCreationHelper::makeLookupRow(angle, boost::regex("Ay")),
+                             ModelCreationHelper::makeLookupRow(angle, boost::regex("El")), wildcardRow};
+
+    LookupRowFinder findLookupRow(table);
+    const auto foundLookupRow = findLookupRow(0.5, m_exactMatchTolerance, "En Oh");
+    TS_ASSERT(foundLookupRow.has_value())
+    TS_ASSERT_EQUALS(wildcardRow, foundLookupRow)
+  }
+
+  void test_searching_by_title_matches_regex_over_wildcard() {
+    auto constexpr angle = 2.3;
+    auto wildcardRow = ModelCreationHelper::makeWildcardLookupRow();
+    auto regexRow = ModelCreationHelper::makeLookupRow(angle, boost::regex(".*"));
+    auto table = LookupTable{wildcardRow, regexRow};
+
+    LookupRowFinder findLookupRow(table);
+    const auto foundLookupRow = findLookupRow(angle, m_exactMatchTolerance, "En Oh");
+    TS_ASSERT(foundLookupRow.has_value())
+    TS_ASSERT_EQUALS(regexRow, foundLookupRow)
+  }
+
+  // void test_searching_by_title_when_no_regex
+
+  // error cases:
+  // lookup title specified but theta is not
+  // multiple wildcard rows
+  // duplicate criteria
+  // matches multiple non-empty titles with same theta
+  // whitespace
 private:
   const double m_exactMatchTolerance = 1e-6;
 };

--- a/qt/scientific_interfaces/ISISReflectometry/test/Reduction/LookupRowFinderTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Reduction/LookupRowFinderTest.h
@@ -112,7 +112,7 @@ public:
 
     LookupRowFinder findLookupRow(table);
     const auto foundLookupRow = findLookupRow(angle, m_exactMatchTolerance, "En Oh");
-    TS_ASSERT(!foundLookupRow.has_value())
+    TS_ASSERT(!foundLookupRow)
   }
 
   void test_searching_by_title_found_but_theta_not_found_returns_none() {
@@ -122,7 +122,7 @@ public:
 
     LookupRowFinder findLookupRow(table);
     const auto foundLookupRow = findLookupRow(0.5, m_exactMatchTolerance, "En Oh");
-    TS_ASSERT(!foundLookupRow.has_value())
+    TS_ASSERT(!foundLookupRow)
   }
 
   void test_searching_by_theta_found_but_title_not_found_returns_wildcard() {
@@ -133,7 +133,7 @@ public:
 
     LookupRowFinder findLookupRow(table);
     const auto foundLookupRow = findLookupRow(angle, m_exactMatchTolerance, "En Oh");
-    TS_ASSERT(foundLookupRow.has_value())
+    TS_ASSERT(foundLookupRow)
     TS_ASSERT_EQUALS(wildcardRow, foundLookupRow)
   }
 
@@ -145,7 +145,7 @@ public:
 
     LookupRowFinder findLookupRow(table);
     const auto foundLookupRow = findLookupRow(0.5, m_exactMatchTolerance, "En Oh");
-    TS_ASSERT(foundLookupRow.has_value())
+    TS_ASSERT(foundLookupRow)
     TS_ASSERT_EQUALS(wildcardRow, foundLookupRow)
   }
 
@@ -157,7 +157,7 @@ public:
 
     LookupRowFinder findLookupRow(table);
     const auto foundLookupRow = findLookupRow(angle, m_exactMatchTolerance, "En Oh");
-    TS_ASSERT(foundLookupRow.has_value())
+    TS_ASSERT(foundLookupRow)
     TS_ASSERT_EQUALS(regexRow, foundLookupRow)
   }
 
@@ -168,7 +168,7 @@ public:
 
     LookupRowFinder findLookupRow(table);
     const auto foundLookupRow = findLookupRow(angle, m_exactMatchTolerance, "En Oh");
-    TS_ASSERT(foundLookupRow.has_value())
+    TS_ASSERT(foundLookupRow)
     TS_ASSERT_EQUALS(emptyRegexRow, foundLookupRow)
   }
 

--- a/qt/scientific_interfaces/ISISReflectometry/test/Reduction/LookupRowFinderTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Reduction/LookupRowFinderTest.h
@@ -20,13 +20,12 @@ public:
 
     LookupRowFinder findLookupRow(table);
     for (const auto angle : {0.5, 2.3}) {
-      const auto lookupRow = findLookupRow(angle, m_exactMatchTolerance);
+      auto row = ModelCreationHelper::makeRow(angle);
+      const auto lookupRow = findLookupRow(row, m_exactMatchTolerance);
       TS_ASSERT(lookupRow)
-      if (lookupRow) {
-        const auto foundAngle = lookupRow->thetaOrWildcard();
-        TS_ASSERT(foundAngle)
-        TS_ASSERT_DELTA(*foundAngle, angle, m_exactMatchTolerance)
-      }
+      const auto foundAngle = lookupRow->thetaOrWildcard();
+      TS_ASSERT(foundAngle)
+      TS_ASSERT_DELTA(*foundAngle, angle, m_exactMatchTolerance)
     }
   }
 
@@ -36,13 +35,13 @@ public:
     LookupRowFinder findLookupRow(table);
     const double matchTolerance = 0.01;
     for (const auto angle : {(0.5 - matchTolerance), (2.3 + matchTolerance)}) {
-      const auto lookupRow = findLookupRow(angle, matchTolerance);
+      auto row = ModelCreationHelper::makeRow(angle);
+      const auto lookupRow = findLookupRow(row, matchTolerance);
       TS_ASSERT(lookupRow)
-      if (lookupRow) {
-        const auto foundAngle = lookupRow->thetaOrWildcard();
-        TS_ASSERT(foundAngle)
-        if (foundAngle)
-          TS_ASSERT_DELTA(*foundAngle, angle, matchTolerance)
+      const auto foundAngle = lookupRow->thetaOrWildcard();
+      TS_ASSERT(foundAngle)
+      if (foundAngle) {
+        TS_ASSERT_DELTA(*foundAngle, angle, matchTolerance)
       }
     }
   }
@@ -52,31 +51,32 @@ public:
 
     LookupRowFinder findLookupRow(table);
     for (const auto angle : {1.2, 3.4}) {
-      const auto lookupRow = findLookupRow(angle, m_exactMatchTolerance);
+      auto row = ModelCreationHelper::makeRow(angle);
+      const auto lookupRow = findLookupRow(row, m_exactMatchTolerance);
       TS_ASSERT(lookupRow)
-      if (lookupRow) {
-        const auto foundAngle = lookupRow->thetaOrWildcard();
-        TS_ASSERT(!foundAngle)
-        TS_ASSERT(lookupRow->isWildcard())
-      }
+      const auto foundAngle = lookupRow->thetaOrWildcard();
+      TS_ASSERT(!foundAngle)
+      TS_ASSERT(lookupRow->isWildcard());
     }
   }
 
-  void test_searching_by_theta_not_found_returns_nullptr() {
+  void test_searching_by_theta_not_found_returns_none() {
     LookupTable table = ModelCreationHelper::makeLookupTableWithTwoAngles();
 
     LookupRowFinder findLookupRow(table);
     constexpr double notThere = 999;
-    const auto lookupRow = findLookupRow(notThere, m_exactMatchTolerance);
+    auto row = ModelCreationHelper::makeRow(notThere);
+    const auto lookupRow = findLookupRow(row, m_exactMatchTolerance);
     TS_ASSERT(!lookupRow)
   }
 
-  void test_searching_empty_table_returns_nullptr() {
+  void test_searching_empty_table_returns_none() {
     LookupTable table = ModelCreationHelper::makeEmptyLookupTable();
 
     LookupRowFinder findLookupRow(table);
     constexpr double notThere = 0.5;
-    const auto lookupRow = findLookupRow(notThere, m_exactMatchTolerance);
+    auto row = ModelCreationHelper::makeRow(notThere);
+    const auto lookupRow = findLookupRow(row, m_exactMatchTolerance);
     TS_ASSERT(!lookupRow)
   }
 
@@ -86,7 +86,8 @@ public:
                              ModelCreationHelper::makeLookupRow(angle, boost::regex("El"))};
 
     LookupRowFinder findLookupRow(table);
-    const auto foundLookupRow = findLookupRow(angle, m_exactMatchTolerance, "El Em En Oh");
+    auto group = Group("El Em En Oh", {ModelCreationHelper::makeRow(angle)});
+    const auto foundLookupRow = findLookupRow(*group[0], m_exactMatchTolerance);
     TS_ASSERT(foundLookupRow)
     if (foundLookupRow)
       TS_ASSERT_EQUALS(*foundLookupRow, table[1])
@@ -99,7 +100,8 @@ public:
                              ModelCreationHelper::makeWildcardLookupRow()};
 
     LookupRowFinder findLookupRow(table);
-    const auto foundLookupRow = findLookupRow(angle, m_exactMatchTolerance, "El Em En Oh");
+    auto group = Group("El Em En Oh", {ModelCreationHelper::makeRow(angle)});
+    const auto foundLookupRow = findLookupRow(*group[0], m_exactMatchTolerance);
     TS_ASSERT(foundLookupRow)
     if (foundLookupRow)
       TS_ASSERT_EQUALS(*foundLookupRow, table[1])
@@ -111,7 +113,8 @@ public:
                              ModelCreationHelper::makeLookupRow(angle, boost::regex("El"))};
 
     LookupRowFinder findLookupRow(table);
-    const auto foundLookupRow = findLookupRow(angle, m_exactMatchTolerance, "En Oh");
+    auto group = Group("En Oh", {ModelCreationHelper::makeRow(angle)});
+    const auto foundLookupRow = findLookupRow(*group[0], m_exactMatchTolerance);
     TS_ASSERT(!foundLookupRow)
   }
 
@@ -121,7 +124,8 @@ public:
                              ModelCreationHelper::makeLookupRow(angle, boost::regex("El"))};
 
     LookupRowFinder findLookupRow(table);
-    const auto foundLookupRow = findLookupRow(0.5, m_exactMatchTolerance, "En Oh");
+    auto group = Group("En Oh", {ModelCreationHelper::makeRow(angle)});
+    const auto foundLookupRow = findLookupRow(*group[0], m_exactMatchTolerance);
     TS_ASSERT(!foundLookupRow)
   }
 
@@ -132,7 +136,8 @@ public:
                              ModelCreationHelper::makeLookupRow(angle, boost::regex("El")), wildcardRow};
 
     LookupRowFinder findLookupRow(table);
-    const auto foundLookupRow = findLookupRow(angle, m_exactMatchTolerance, "En Oh");
+    auto group = Group("En Oh", {ModelCreationHelper::makeRow(angle)});
+    const auto foundLookupRow = findLookupRow(*group[0], m_exactMatchTolerance);
     TS_ASSERT(foundLookupRow)
     TS_ASSERT_EQUALS(wildcardRow, foundLookupRow)
   }
@@ -144,7 +149,8 @@ public:
                              ModelCreationHelper::makeLookupRow(angle, boost::regex("El")), wildcardRow};
 
     LookupRowFinder findLookupRow(table);
-    const auto foundLookupRow = findLookupRow(0.5, m_exactMatchTolerance, "En Oh");
+    auto group = Group("En Oh", {ModelCreationHelper::makeRow(angle)});
+    const auto foundLookupRow = findLookupRow(*group[0], m_exactMatchTolerance);
     TS_ASSERT(foundLookupRow)
     TS_ASSERT_EQUALS(wildcardRow, foundLookupRow)
   }
@@ -156,7 +162,8 @@ public:
     auto table = LookupTable{wildcardRow, regexRow};
 
     LookupRowFinder findLookupRow(table);
-    const auto foundLookupRow = findLookupRow(angle, m_exactMatchTolerance, "En Oh");
+    auto group = Group("En Oh", {ModelCreationHelper::makeRow(angle)});
+    const auto foundLookupRow = findLookupRow(*group[0], m_exactMatchTolerance);
     TS_ASSERT(foundLookupRow)
     TS_ASSERT_EQUALS(regexRow, foundLookupRow)
   }
@@ -167,9 +174,32 @@ public:
     auto table = LookupTable{emptyRegexRow};
 
     LookupRowFinder findLookupRow(table);
-    const auto foundLookupRow = findLookupRow(angle, m_exactMatchTolerance, "En Oh");
+    auto group = Group("En Oh", {ModelCreationHelper::makeRow(angle)});
+    const auto foundLookupRow = findLookupRow(*group[0], m_exactMatchTolerance);
     TS_ASSERT(foundLookupRow)
     TS_ASSERT_EQUALS(emptyRegexRow, foundLookupRow)
+  }
+
+  void test_get_wildcard_row_returns_wildcard_row() {
+    auto constexpr angle = 2.3;
+    auto wildcardRow = ModelCreationHelper::makeWildcardLookupRow();
+    auto table = LookupTable{ModelCreationHelper::makeLookupRow(angle, boost::regex("Ay")),
+                             ModelCreationHelper::makeLookupRow(angle, boost::regex("El")), wildcardRow};
+
+    LookupRowFinder finder(table);
+    const auto foundLookupRow = finder.findWildcardLookupRow();
+    TS_ASSERT(foundLookupRow)
+    TS_ASSERT_EQUALS(wildcardRow, foundLookupRow)
+  }
+
+  void test_get_wildcard_row_returns_none() {
+    auto constexpr angle = 2.3;
+    auto table = LookupTable{ModelCreationHelper::makeLookupRow(angle, boost::regex("Ay")),
+                             ModelCreationHelper::makeLookupRow(angle, boost::regex("El"))};
+
+    LookupRowFinder finder(table);
+    const auto foundLookupRow = finder.findWildcardLookupRow();
+    TS_ASSERT(!foundLookupRow)
   }
 
   // error cases:

--- a/qt/scientific_interfaces/ISISReflectometry/test/Reduction/LookupRowFinderTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Reduction/LookupRowFinderTest.h
@@ -20,7 +20,7 @@ public:
 
     LookupRowFinder findLookupRow(table);
     for (const auto angle : {0.5, 2.3}) {
-      const auto *lookupRow = findLookupRow(angle, m_exactMatchTolerance);
+      const auto lookupRow = findLookupRow(angle, m_exactMatchTolerance);
       TS_ASSERT(lookupRow)
       const auto foundAngle = lookupRow->thetaOrWildcard();
       TS_ASSERT(foundAngle)
@@ -34,7 +34,7 @@ public:
     LookupRowFinder findLookupRow(table);
     const double matchTolerance = 0.01;
     for (const auto angle : {(0.5 - matchTolerance), (2.3 + matchTolerance)}) {
-      const auto *lookupRow = findLookupRow(angle, matchTolerance);
+      const auto lookupRow = findLookupRow(angle, matchTolerance);
       TS_ASSERT(lookupRow)
       const auto foundAngle = lookupRow->thetaOrWildcard();
       TS_ASSERT(foundAngle)
@@ -48,7 +48,7 @@ public:
 
     LookupRowFinder findLookupRow(table);
     for (const auto angle : {1.2, 3.4}) {
-      const auto *lookupRow = findLookupRow(angle, m_exactMatchTolerance);
+      const auto lookupRow = findLookupRow(angle, m_exactMatchTolerance);
       TS_ASSERT(lookupRow)
       const auto foundAngle = lookupRow->thetaOrWildcard();
       TS_ASSERT(!foundAngle)
@@ -61,7 +61,7 @@ public:
 
     LookupRowFinder findLookupRow(table);
     constexpr double notThere = 999;
-    const auto *lookupRow = findLookupRow(notThere, m_exactMatchTolerance);
+    const auto lookupRow = findLookupRow(notThere, m_exactMatchTolerance);
     TS_ASSERT(!lookupRow)
   }
 
@@ -70,8 +70,19 @@ public:
 
     LookupRowFinder findLookupRow(table);
     constexpr double notThere = 0.5;
-    const auto *lookupRow = findLookupRow(notThere, m_exactMatchTolerance);
+    const auto lookupRow = findLookupRow(notThere, m_exactMatchTolerance);
     TS_ASSERT(!lookupRow)
+  }
+
+  void test_searching_by_theta_and_title_found() {
+    auto constexpr angle = 2.3;
+    auto table = LookupTable{ModelCreationHelper::makeLookupRow(angle, boost::regex("Ay")),
+                             ModelCreationHelper::makeLookupRow(angle, boost::regex("El"))};
+
+    LookupRowFinder findLookupRow(table);
+    const auto foundLookupRow = findLookupRow(angle, m_exactMatchTolerance, "El Em En Oh");
+    TS_ASSERT(foundLookupRow)
+    TS_ASSERT_EQUALS(*foundLookupRow, table[1])
   }
 
 private:

--- a/qt/scientific_interfaces/ISISReflectometry/test/Reduction/LookupRowFinderTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Reduction/LookupRowFinderTest.h
@@ -161,7 +161,16 @@ public:
     TS_ASSERT_EQUALS(regexRow, foundLookupRow)
   }
 
-  // void test_searching_by_title_when_no_regex
+  void test_searching_by_title_matches_empty_regex() {
+    auto constexpr angle = 2.3;
+    auto emptyRegexRow = ModelCreationHelper::makeLookupRow(angle, boost::none);
+    auto table = LookupTable{emptyRegexRow};
+
+    LookupRowFinder findLookupRow(table);
+    const auto foundLookupRow = findLookupRow(angle, m_exactMatchTolerance, "En Oh");
+    TS_ASSERT(foundLookupRow.has_value())
+    TS_ASSERT_EQUALS(emptyRegexRow, foundLookupRow)
+  }
 
   // error cases:
   // lookup title specified but theta is not


### PR DESCRIPTION
**Description of work.**

Refactor `LookupRowFinder` to take a `Row` rather than individual row members. This means removing the default `boost::none` value that was on theta in the calling functions in Batch and Experiment. Previously this was used to search for wildcard rows so we've now added an explicit method to do that instead.

**To test:**

Follow the instructions on #33535 to ensure existing functionality isn't broken.

Refs #33512

*This does not require release notes* because **it concerns under the hood work**

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
