### PR TITLE
Disable processing if lookup table invalid

### DIFF
--- a/docs/source/release/v6.4.0/reflectometry.rst
+++ b/docs/source/release/v6.4.0/reflectometry.rst
@@ -14,4 +14,6 @@ Improvements
 
 - Groups are now highlighted to show that all subtasks are completed.
 
+- Processing is disabled if there are errors on the Experiment Setting table.
+
 :ref:`Release 6.4.0 <v6.4.0>`

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchPresenter.cpp
@@ -163,7 +163,9 @@ bool BatchPresenter::startBatch(std::deque<IConfiguredAlgorithm_sptr> algorithms
 
 void BatchPresenter::resumeReduction() {
   if (!m_experimentPresenter->hasValidSettings()) {
-    m_messageHandler->giveUserCritical("One or more of the experiment settings is incorrect", "Processing Error");
+    m_messageHandler->giveUserCritical(
+        "One or more of the experiment settings is invalid. Please check the Experiment Settings tab.",
+        "Processing Error");
     return;
   }
   // Update the model
@@ -209,7 +211,9 @@ void BatchPresenter::notifyReductionPaused() {
 
 void BatchPresenter::resumeAutoreduction() {
   if (!m_experimentPresenter->hasValidSettings()) {
-    m_messageHandler->giveUserCritical("One or more of the experiment settings is incorrect", "Processing Error");
+    m_messageHandler->giveUserCritical(
+        "One or more of the experiment settings is invalid. Please check the Experiment Settings tab.",
+        "Processing Error");
     return;
   }
   // Update the model first to ensure the autoprocessing flag is set

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchPresenter.cpp
@@ -14,6 +14,7 @@
 #include "GUI/Save/ISavePresenter.h"
 #include "IBatchView.h"
 #include "MantidQtWidgets/Common/HelpWindow.h"
+#include "MantidQtWidgets/Common/IMessageHandler.h"
 #include <memory>
 
 namespace MantidQt::CustomInterfaces::ISISReflectometry {
@@ -38,12 +39,13 @@ BatchPresenter::BatchPresenter(IBatchView *view, std::unique_ptr<Batch> model, I
                                std::unique_ptr<IExperimentPresenter> experimentPresenter,
                                std::unique_ptr<IInstrumentPresenter> instrumentPresenter,
                                std::unique_ptr<ISavePresenter> savePresenter,
-                               std::unique_ptr<IPreviewPresenter> previewPresenter)
+                               std::unique_ptr<IPreviewPresenter> previewPresenter,
+                               MantidQt::MantidWidgets::IMessageHandler *messageHandler)
     : m_view(view), m_model(std::move(model)), m_mainPresenter(), m_runsPresenter(std::move(runsPresenter)),
       m_eventPresenter(std::move(eventPresenter)), m_experimentPresenter(std::move(experimentPresenter)),
       m_instrumentPresenter(std::move(instrumentPresenter)), m_savePresenter(std::move(savePresenter)),
       m_previewPresenter(std::move(previewPresenter)), m_unsavedBatchFlag(false), m_jobRunner(jobRunner),
-      m_jobManager(new BatchJobManager(*m_model)) {
+      m_messageHandler(messageHandler), m_jobManager(new BatchJobManager(*m_model)) {
 
   m_jobRunner->subscribe(this);
 
@@ -160,6 +162,10 @@ bool BatchPresenter::startBatch(std::deque<IConfiguredAlgorithm_sptr> algorithms
 }
 
 void BatchPresenter::resumeReduction() {
+  if (!m_experimentPresenter->hasValidSettings()) {
+    m_messageHandler->giveUserCritical("One or more of the experiment settings is incorrect", "Processing Error");
+    return;
+  }
   // Update the model
   m_jobManager->notifyReductionResumed();
   // Get the algorithms to process
@@ -202,6 +208,10 @@ void BatchPresenter::notifyReductionPaused() {
 }
 
 void BatchPresenter::resumeAutoreduction() {
+  if (!m_experimentPresenter->hasValidSettings()) {
+    m_messageHandler->giveUserCritical("One or more of the experiment settings is incorrect", "Processing Error");
+    return;
+  }
   // Update the model first to ensure the autoprocessing flag is set
   m_jobManager->notifyAutoreductionResumed();
   // The runs presenter starts autoreduction. This sets off a search to find

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchPresenter.h
@@ -19,9 +19,11 @@
 #include "MantidQtWidgets/Common/WorkspaceObserver.h"
 #include <memory>
 
-namespace MantidQt {
-namespace CustomInterfaces {
-namespace ISISReflectometry {
+namespace MantidQt::MantidWidgets {
+class IMessageHandler;
+}
+
+namespace MantidQt::CustomInterfaces::ISISReflectometry {
 
 class IBatchView;
 
@@ -39,7 +41,8 @@ public:
                  std::unique_ptr<IRunsPresenter> runsPresenter, std::unique_ptr<IEventPresenter> eventPresenter,
                  std::unique_ptr<IExperimentPresenter> experimentPresenter,
                  std::unique_ptr<IInstrumentPresenter> instrumentPresenter,
-                 std::unique_ptr<ISavePresenter> savePresenter, std::unique_ptr<IPreviewPresenter> previewPresenter);
+                 std::unique_ptr<ISavePresenter> savePresenter, std::unique_ptr<IPreviewPresenter> previewPresenter,
+                 MantidQt::MantidWidgets::IMessageHandler *messageHandler);
   BatchPresenter(BatchPresenter const &rhs) = delete;
   BatchPresenter(BatchPresenter &&rhs) = delete;
   BatchPresenter const &operator=(BatchPresenter const &rhs) = delete;
@@ -115,6 +118,7 @@ private:
   std::unique_ptr<IPreviewPresenter> m_previewPresenter;
   bool m_unsavedBatchFlag;
   IJobRunner *m_jobRunner;
+  MantidQt::MantidWidgets::IMessageHandler *m_messageHandler;
 
   friend class Encoder;
   friend class Decoder;
@@ -123,6 +127,4 @@ private:
 protected:
   std::unique_ptr<IBatchJobManager> m_jobManager;
 };
-} // namespace ISISReflectometry
-} // namespace CustomInterfaces
-} // namespace MantidQt
+} // namespace MantidQt::CustomInterfaces::ISISReflectometry

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchPresenterFactory.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchPresenterFactory.h
@@ -19,9 +19,11 @@
 #include "ReflAlgorithmFactory.h"
 #include <memory>
 
-namespace MantidQt {
-namespace CustomInterfaces {
-namespace ISISReflectometry {
+namespace MantidQt::MantidWidgets {
+class IMessageHandler;
+}
+
+namespace MantidQt::CustomInterfaces::ISISReflectometry {
 
 class BatchPresenterFactory : public IBatchPresenterFactory {
 public:
@@ -29,13 +31,14 @@ public:
 
       RunsPresenterFactory runsPresenterFactory, EventPresenterFactory eventPresenterFactory,
       ExperimentPresenterFactory experimentPresenterFactory, InstrumentPresenterFactory instrumentPresenterFactory,
-      PreviewPresenterFactory previewPresenterFactory, SavePresenterFactory savePresenterFactory)
+      PreviewPresenterFactory previewPresenterFactory, SavePresenterFactory savePresenterFactory,
+      MantidQt::MantidWidgets::IMessageHandler *messageHandler)
       : m_runsPresenterFactory(std::move(runsPresenterFactory)),
         m_eventPresenterFactory(std::move(eventPresenterFactory)),
         m_experimentPresenterFactory(std::move(experimentPresenterFactory)),
         m_instrumentPresenterFactory(std::move(instrumentPresenterFactory)),
         m_previewPresenterFactory(std::move(previewPresenterFactory)),
-        m_savePresenterFactory(std::move(savePresenterFactory)) {}
+        m_savePresenterFactory(std::move(savePresenterFactory)), m_messageHandler(messageHandler) {}
 
   std::unique_ptr<IBatchPresenter> make(IBatchView *view) override {
     auto runsPresenter = m_runsPresenterFactory.make(view->runs());
@@ -52,7 +55,7 @@ public:
     return std::make_unique<BatchPresenter>(view, std::move(batchModel), view, std::move(runsPresenter),
                                             std::move(eventPresenter), std::move(experimentPresenter),
                                             std::move(instrumentPresenter), std::move(savePresenter),
-                                            std::move(previewPresenter));
+                                            std::move(previewPresenter), m_messageHandler);
   }
 
 private:
@@ -62,7 +65,6 @@ private:
   InstrumentPresenterFactory m_instrumentPresenterFactory;
   PreviewPresenterFactory m_previewPresenterFactory;
   SavePresenterFactory m_savePresenterFactory;
+  MantidQt::MantidWidgets::IMessageHandler *m_messageHandler;
 };
-} // namespace ISISReflectometry
-} // namespace CustomInterfaces
-} // namespace MantidQt
+} // namespace MantidQt::CustomInterfaces::ISISReflectometry

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/ExperimentPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/ExperimentPresenter.cpp
@@ -21,7 +21,7 @@ Mantid::Kernel::Logger g_log("Reflectometry GUI");
 ExperimentPresenter::ExperimentPresenter(IExperimentView *view, Experiment experiment, double defaultsThetaTolerance,
                                          std::unique_ptr<IExperimentOptionDefaults> experimentDefaults)
     : m_experimentDefaults(std::move(experimentDefaults)), m_view(view), m_model(std::move(experiment)),
-      m_validationResult(m_model), m_thetaTolerance(defaultsThetaTolerance) {
+      m_thetaTolerance(defaultsThetaTolerance), m_validationResult(m_model) {
   m_view->subscribe(this);
 }
 

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/ExperimentPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/ExperimentPresenter.cpp
@@ -21,7 +21,7 @@ Mantid::Kernel::Logger g_log("Reflectometry GUI");
 ExperimentPresenter::ExperimentPresenter(IExperimentView *view, Experiment experiment, double defaultsThetaTolerance,
                                          std::unique_ptr<IExperimentOptionDefaults> experimentDefaults)
     : m_experimentDefaults(std::move(experimentDefaults)), m_view(view), m_model(std::move(experiment)),
-      m_thetaTolerance(defaultsThetaTolerance) {
+      m_validationResult(m_model), m_thetaTolerance(defaultsThetaTolerance) {
   m_view->subscribe(this);
 }
 
@@ -30,8 +30,8 @@ void ExperimentPresenter::acceptMainPresenter(IBatchPresenter *mainPresenter) { 
 Experiment const &ExperimentPresenter::experiment() const { return m_model; }
 
 void ExperimentPresenter::notifySettingsChanged() {
-  auto validationResult = updateModelFromView();
-  showValidationResult(validationResult);
+  updateModelFromView();
+  showValidationResult();
   m_mainPresenter->notifySettingsChanged();
 }
 
@@ -64,10 +64,10 @@ void ExperimentPresenter::notifyRemoveLookupRowRequested(int index) {
 }
 
 void ExperimentPresenter::notifyLookupRowChanged(int, int column) {
-  auto validationResult = updateModelFromView();
-  showValidationResult(validationResult);
-  if (column == 0 && !validationResult.isValid() &&
-      validationResult.assertError().lookupTableValidationErrors().fullTableError() ==
+  updateModelFromView();
+  showValidationResult();
+  if (column == 0 && !m_validationResult.isValid() &&
+      m_validationResult.assertError().lookupTableValidationErrors().fullTableError() ==
           ThetaValuesValidationError::NonUniqueTheta)
     m_view->showLookupRowsNotUnique(m_thetaTolerance);
   m_mainPresenter->notifySettingsChanged();
@@ -234,6 +234,8 @@ std::map<std::string, std::string> ExperimentPresenter::stitchParametersFromView
   return std::map<std::string, std::string>();
 }
 
+bool ExperimentPresenter::hasValidSettings() const noexcept { return m_validationResult.isValid(); }
+
 ExperimentValidationResult ExperimentPresenter::validateExperimentFromView() {
   auto validate = LookupTableValidator();
   auto lookupTableValidationResult = validate(m_view->getLookupTable(), m_thetaTolerance);
@@ -257,13 +259,12 @@ ExperimentValidationResult ExperimentPresenter::validateExperimentFromView() {
   }
 }
 
-ExperimentValidationResult ExperimentPresenter::updateModelFromView() {
-  auto validationResult = validateExperimentFromView();
-  if (validationResult.isValid()) {
-    m_model = validationResult.assertValid();
+void ExperimentPresenter::updateModelFromView() {
+  m_validationResult = validateExperimentFromView();
+  if (m_validationResult.isValid()) {
+    m_model = m_validationResult.assertValid();
     updateWidgetEnabledState();
   }
-  return validationResult;
 }
 
 void ExperimentPresenter::showLookupTableErrors(LookupTableValidationError const &errors) {
@@ -274,11 +275,11 @@ void ExperimentPresenter::showLookupTableErrors(LookupTableValidationError const
   }
 }
 
-void ExperimentPresenter::showValidationResult(ExperimentValidationResult const &result) {
-  if (result.isValid()) {
+void ExperimentPresenter::showValidationResult() {
+  if (m_validationResult.isValid()) {
     m_view->showAllLookupRowsAsValid();
   } else {
-    auto errors = result.assertError();
+    auto errors = m_validationResult.assertError();
     showLookupTableErrors(errors.lookupTableValidationErrors());
   }
 }

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/ExperimentPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/ExperimentPresenter.h
@@ -63,6 +63,8 @@ public:
   void notifyInstrumentChanged(std::string const &instrumentName) override;
   void restoreDefaults() override;
 
+  bool hasValidSettings() const noexcept;
+
 protected:
   std::unique_ptr<IExperimentOptionDefaults> m_experimentDefaults;
 
@@ -79,10 +81,10 @@ private:
 
   std::map<std::string, std::string> stitchParametersFromView();
 
-  ExperimentValidationResult updateModelFromView();
+  void updateModelFromView();
   void updateViewFromModel();
 
-  void showValidationResult(ExperimentValidationResult const &result);
+  void showValidationResult();
   void showLookupTableErrors(LookupTableValidationError const &errors);
 
   void updateWidgetEnabledState();
@@ -94,9 +96,10 @@ private:
   bool isProcessing() const;
   bool isAutoreducing() const;
 
-  IExperimentView *m_view;
+  IExperimentView *m_view = nullptr;
   Experiment m_model;
-  double m_thetaTolerance;
+  double m_thetaTolerance = 0;
+  ExperimentValidationResult m_validationResult;
 };
 } // namespace ISISReflectometry
 } // namespace CustomInterfaces

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/ExperimentPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/ExperimentPresenter.h
@@ -63,7 +63,7 @@ public:
   void notifyInstrumentChanged(std::string const &instrumentName) override;
   void restoreDefaults() override;
 
-  bool hasValidSettings() const noexcept;
+  bool hasValidSettings() const noexcept override;
 
 protected:
   std::unique_ptr<IExperimentOptionDefaults> m_experimentDefaults;

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/IExperimentPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/IExperimentPresenter.h
@@ -28,6 +28,7 @@ public:
   virtual void notifyAutoreductionResumed() = 0;
   virtual void notifyInstrumentChanged(std::string const &instrumentName) = 0;
   virtual void restoreDefaults() = 0;
+  virtual bool hasValidSettings() const noexcept = 0;
 };
 } // namespace ISISReflectometry
 } // namespace CustomInterfaces

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/MainWindow/QtMainWindowView.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/MainWindow/QtMainWindowView.cpp
@@ -90,9 +90,9 @@ void QtMainWindowView::initLayout() {
   auto makeInstrumentPresenter = InstrumentPresenterFactory();
   auto makePreviewPresenter = PreviewPresenterFactory();
 
-  auto makeBatchPresenter =
-      std::make_unique<BatchPresenterFactory>(std::move(makeRunsPresenter), makeEventPresenter, makeExperimentPresenter,
-                                              makeInstrumentPresenter, makePreviewPresenter, makeSaveSettingsPresenter);
+  auto makeBatchPresenter = std::make_unique<BatchPresenterFactory>(
+      std::move(makeRunsPresenter), makeEventPresenter, makeExperimentPresenter, makeInstrumentPresenter,
+      makePreviewPresenter, makeSaveSettingsPresenter, messageHandler);
 
   // Create the presenter
   auto slitCalculator = std::make_unique<SlitCalculator>(this);

--- a/qt/scientific_interfaces/ISISReflectometry/test/Experiment/ExperimentPresenterTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Experiment/ExperimentPresenterTest.h
@@ -891,6 +891,7 @@ private:
     for (auto row : rows)
       EXPECT_CALL(m_view, showLookupRowAsInvalid(row, column)).Times(1);
     presenter.notifyLookupRowChanged(1, 1);
+    TS_ASSERT(!presenter.hasValidSettings());
     verifyAndClear();
   }
 
@@ -899,6 +900,7 @@ private:
     EXPECT_CALL(m_view, getLookupTable()).WillOnce(Return(optionsTable));
     EXPECT_CALL(m_view, showLookupRowAsInvalid(row, column)).Times(1);
     presenter.notifyLookupRowChanged(1, 1);
+    TS_ASSERT(!presenter.hasValidSettings());
     verifyAndClear();
   }
 

--- a/qt/scientific_interfaces/ISISReflectometry/test/ReflMockObjects.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/ReflMockObjects.h
@@ -164,6 +164,7 @@ public:
   MOCK_METHOD0(notifyAutoreductionResumed, void());
   MOCK_METHOD1(notifyInstrumentChanged, void(std::string const &));
   MOCK_METHOD0(restoreDefaults, void());
+  MOCK_METHOD(bool, hasValidSettings, (), (const, noexcept, override));
 };
 
 class MockInstrumentPresenter : public IInstrumentPresenter {


### PR DESCRIPTION
**Description of work.**

This PR disables processing on the ISIS Reflectometry GUI if the lookup table on the Experiment Settings tab contains invalid settings. Previously, processing was allowed anyway, meaning that it was unclear which settings would be used.

**To test:**

- Open the ISIS Reflectometry interface
- Set the instrument to INTER, enter a run number in the first row in the group in the table as `13460` and angle `0.5`
- Click Process and check that the row process (it will turn green on success)
- Go to the Experiment Settings tab and click Add Row under the table. This will result in two duplicate (empty) rows, which is an error, and the angle fields will be highlighted in red.
- Back on the Runs tab, click Process. You should now get an error message
- Back on the Experiement Settings tab, enter 0.5 in one of the angle fields and 0.01 in the same row for dq/q
- Re-process and it should work and pick up the dq/q value you entered

Fixes #33554 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
