### PR TITLE
Hide warning about seperate thread in matplotlib 3.5.1

### DIFF
--- a/docs/source/release/v6.4.0/Workbench/Bugfixes/33561.rst
+++ b/docs/source/release/v6.4.0/Workbench/Bugfixes/33561.rst
@@ -1,0 +1,1 @@
+- Suppressed a spurious warning where matplotlib warns about creating a figure outside of the main thread when using the script window.

--- a/docs/source/release/v6.4.0/mantidworkbench.rst
+++ b/docs/source/release/v6.4.0/mantidworkbench.rst
@@ -19,7 +19,6 @@ Bugfixes
 - Fixed where matplotlib 3.5 caused any 3D plot to raise an exception when opened.
 - Fixed where matplotlib 3.5 caused a crash when closing workbench with a plot open.
 - Fixed where matplotlib 3.5 caused a project to be unable to save and load plots.
-- Suppressed a spurious warning where matplotlib warns about creating a figure outside of the main thread when using the script window.
 
 Sliceviewer
 -----------

--- a/docs/source/release/v6.4.0/mantidworkbench.rst
+++ b/docs/source/release/v6.4.0/mantidworkbench.rst
@@ -19,6 +19,7 @@ Bugfixes
 - Fixed where matplotlib 3.5 caused any 3D plot to raise an exception when opened.
 - Fixed where matplotlib 3.5 caused a crash when closing workbench with a plot open.
 - Fixed where matplotlib 3.5 caused a project to be unable to save and load plots.
+- Suppressed a spurious warning where matplotlib warns about creating a figure outside of the main thread when using the script window.
 
 Sliceviewer
 -----------

--- a/qt/applications/workbench/workbench/plotting/config.py
+++ b/qt/applications/workbench/workbench/plotting/config.py
@@ -10,6 +10,8 @@
 # system imports
 
 # 3rd-party imports
+import warnings
+
 import matplotlib as mpl
 import matplotlib._pylab_helpers as _pylab_helpers
 from qtpy.QtWidgets import QApplication
@@ -37,6 +39,8 @@ def initialize_matplotlib():
     reset_rcparams_to_default()
     # Set figure DPI scaling to monitor DPI
     mpl.rcParams['figure.dpi'] = QApplication.instance().desktop().physicalDpiX()
+    # Hide warning made by matplotlib before checking our backend.
+    warnings.filterwarnings("ignore", message="Starting a Matplotlib GUI outside of the main thread will likely fail.")
 
 
 def init_mpl_gcf():

--- a/qt/python/mantidqt/mantidqt/widgets/codeeditor/execution.py
+++ b/qt/python/mantidqt/mantidqt/widgets/codeeditor/execution.py
@@ -9,7 +9,6 @@
 #
 import __future__
 import ast
-import warnings
 
 try:
     import builtins
@@ -141,15 +140,7 @@ class PythonCodeExecution(QObject):
         flags = get_future_import_compiler_flags(code_str)
         with AddedToSysPath([os.path.dirname(filename)]):
             executor = CodeExecution(self._editor)
-            with warnings.catch_warnings() as warnings_list:
-                # Hide matplotlib warning about threading as we handle this manually on the backend, but this happens
-                # before our code is executed.
-                warnings.filterwarnings("ignore", message="Starting a Matplotlib GUI outside of the main thread will "
-                                                          "likely fail.")
-                executor.execute(code_str, filename, flags, self.globals_ns, line_offset)
-                if warnings_list is list:
-                    for warning in warnings_list:
-                        print(warning)
+            executor.execute(code_str, filename, flags, self.globals_ns, line_offset)
 
     def reset_context(self):
         # create new context for execution

--- a/qt/python/mantidqt/mantidqt/widgets/codeeditor/execution.py
+++ b/qt/python/mantidqt/mantidqt/widgets/codeeditor/execution.py
@@ -75,6 +75,11 @@ def get_future_import_compiler_flags(code_str):
     return flags
 
 
+def hide_warnings_in_script_editor():
+    warnings.filterwarnings("ignore", message="Starting a Matplotlib GUI outside of the main thread will "
+                                              "likely fail.")
+
+
 class PythonCodeExecution(QObject):
     """Provides the ability to execute arbitrary
     strings of Python code. It supports
@@ -141,15 +146,8 @@ class PythonCodeExecution(QObject):
         flags = get_future_import_compiler_flags(code_str)
         with AddedToSysPath([os.path.dirname(filename)]):
             executor = CodeExecution(self._editor)
-            with warnings.catch_warnings() as warnings_list:
-                # Hide matplotlib warning about threading as we handle this manually on the backend, but this happens
-                # before our code is executed.
-                warnings.filterwarnings("ignore", message="Starting a Matplotlib GUI outside of the main thread will "
-                                                          "likely fail.")
-                executor.execute(code_str, filename, flags, self.globals_ns, line_offset)
-                if warnings_list is list:
-                    for warning in warnings_list:
-                        print(warning)
+            hide_warnings_in_script_editor()
+            executor.execute(code_str, filename, flags, self.globals_ns, line_offset)
 
     def reset_context(self):
         # create new context for execution


### PR DESCRIPTION
**Description of work.**
Hide a warning that matplotlib throws out, that is not useful in the context of mantid for executing matplotlib creation on separate threads. We handle this on the backend so we are suppressing this warning.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**
- Using an up to date matplotlib (3.5.1 and up)
- Run `plt.figure()` in a script window and ensure there is no error message.

<!-- Instructions for testing. -->

*There is no associated issue.* Discovered, and fixed during work on #33540 but decided to split out due to it's potentially volatile nature

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
