### PR TITLE
Force mambaforge version on ci

### DIFF
--- a/buildconfig/Jenkins/Conda/download-and-install-mambaforge
+++ b/buildconfig/Jenkins/Conda/download-and-install-mambaforge
@@ -12,6 +12,10 @@ EXPECTED_CONDA_PATH=$2
 CLEAN_BUILD=$3
 MAMBAFORGE_VERSION=4.11.0-0
 
+LINUX_SHA256="49268ee30d4418be4de852dda3aa4387f8c95b55a76f43fb1af68dcbf8b205c3  ./Mambaforge-4.11.0-0-Linux-x86_64.sh"
+MAC_SHA256="2039f744e272d47878f0bc2ae372f03c7f07881f39a93d693d5445744f36f19d  ./Mambaforge-4.11.0-0-MacOSX-x86_64.sh"
+WINDOWS_SHA256="70e8cb24f329f867155a81bb90b48d9f6d105ca1414e8382cac4f4fd7a1c6529  *./Mambaforge-4.11.0-0-Windows-x86_64.exe"
+
 # Only supporting x86_64 at this time for the build process
 if [[ $OSTYPE == 'msys'* ]]; then
     MAMBAFORGE_SCRIPT_NAME=Mambaforge-$MAMBAFORGE_VERSION-Windows-x86_64.exe
@@ -40,6 +44,14 @@ if [[ ! -f $EXPECTED_CONDA_PATH ]]; then
             exit 1
         fi
     fi
+
+    # Compare the sha256 of the downloaded file to the expected sha256
+    SHA256_DOWNLOADED=$(sha256sum $MAMBAFORGE_SCRIPT_NAME)
+    if [[ $SHA256_DOWNLOADED != $LINUX_SHA256 && $SHA256_DOWNLOADED != $MAC_SHA256 && $SHA256_DOWNLOADED != $WINDOWS_SHA256 ]]; then
+        echo "sha256 of downloaded file does not match expected sha256, failing..."
+        exit 1
+    fi
+
     if [[ $OSTYPE == 'msys'* ]]; then
         # Replace all / with \ for windows batch support before passing in $EXPECTED_MAMBAFORGE_PATH
         cmd.exe /C "START /wait "" $MAMBAFORGE_SCRIPT_NAME /InstallationType=JustMe /RegisterPython=0 /S /D=${EXPECTED_MAMBAFORGE_PATH////\\}"

--- a/buildconfig/Jenkins/Conda/download-and-install-mambaforge
+++ b/buildconfig/Jenkins/Conda/download-and-install-mambaforge
@@ -10,12 +10,13 @@
 EXPECTED_MAMBAFORGE_PATH=$1
 EXPECTED_CONDA_PATH=$2
 CLEAN_BUILD=$3
+MAMBAFORGE_VERSION=4.11.0-0
 
 # Only supporting x86_64 at this time for the build process
 if [[ $OSTYPE == 'msys'* ]]; then
-    MAMBAFORGE_SCRIPT_NAME=Mambaforge-Windows-x86_64.exe
+    MAMBAFORGE_SCRIPT_NAME=Mambaforge-$MAMBAFORGE_VERSION-Windows-x86_64.exe
 else
-    MAMBAFORGE_SCRIPT_NAME=Mambaforge-$(uname)-x86_64.sh
+    MAMBAFORGE_SCRIPT_NAME=Mambaforge-$MAMBAFORGE_VERSION-$(uname)-x86_64.sh
 fi
 URL=https://github.com/conda-forge/miniforge/releases/latest/download/$MAMBAFORGE_SCRIPT_NAME
 

--- a/buildconfig/Jenkins/Conda/download-and-install-mambaforge
+++ b/buildconfig/Jenkins/Conda/download-and-install-mambaforge
@@ -12,9 +12,9 @@ EXPECTED_CONDA_PATH=$2
 CLEAN_BUILD=$3
 MAMBAFORGE_VERSION=4.11.0-0
 
-LINUX_SHA256="49268ee30d4418be4de852dda3aa4387f8c95b55a76f43fb1af68dcbf8b205c3  ./Mambaforge-4.11.0-0-Linux-x86_64.sh"
-MAC_SHA256="2039f744e272d47878f0bc2ae372f03c7f07881f39a93d693d5445744f36f19d  ./Mambaforge-4.11.0-0-MacOSX-x86_64.sh"
-WINDOWS_SHA256="70e8cb24f329f867155a81bb90b48d9f6d105ca1414e8382cac4f4fd7a1c6529  *./Mambaforge-4.11.0-0-Windows-x86_64.exe"
+LINUX_SHA256="49268ee30d4418be4de852dda3aa4387f8c95b55a76f43fb1af68dcbf8b205c3  Mambaforge-4.11.0-0-Linux-x86_64.sh"
+MAC_SHA256="2039f744e272d47878f0bc2ae372f03c7f07881f39a93d693d5445744f36f19d  Mambaforge-4.11.0-0-MacOSX-x86_64.sh"
+WINDOWS_SHA256="70e8cb24f329f867155a81bb90b48d9f6d105ca1414e8382cac4f4fd7a1c6529  Mambaforge-4.11.0-0-Windows-x86_64.exe"
 
 # Only supporting x86_64 at this time for the build process
 if [[ $OSTYPE == 'msys'* ]]; then

--- a/buildconfig/Jenkins/Conda/download-and-install-mambaforge
+++ b/buildconfig/Jenkins/Conda/download-and-install-mambaforge
@@ -46,7 +46,12 @@ if [[ ! -f $EXPECTED_CONDA_PATH ]]; then
     fi
 
     # Compare the sha256 of the downloaded file to the expected sha256
-    SHA256_DOWNLOADED=$(sha256sum $MAMBAFORGE_SCRIPT_NAME)
+    if [[ $OSTYPE == 'darwin'* ]]; then
+        SHA256_DOWNLOADED=$(shasum -a 256 $MAMBAFORGE_SCRIPT_NAME)
+    else
+        SHA256_DOWNLOADED=$(sha256sum $MAMBAFORGE_SCRIPT_NAME)
+    fi
+
     if [[ $SHA256_DOWNLOADED != $LINUX_SHA256 && $SHA256_DOWNLOADED != $MAC_SHA256 && $SHA256_DOWNLOADED != $WINDOWS_SHA256 ]]; then
         echo "sha256 of downloaded file does not match expected sha256, failing..."
         exit 1


### PR DESCRIPTION
**Description of work.**
With regards to ensuring security, we want to make sure that the packages we are downloading and running on CI servers don't change from underneath us. This fixes the version and checks the checksum so we are less vulnerable to malicious attacks, and corrupted downloads.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**
- Code review or run the main buildscript, but as this correctly runs the file and is the most common use case for this change.

<!-- Instructions for testing. -->

Fixes #33447  <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->

*This does not require release notes* because **Not user facing**

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
