### PR TITLE
Directories and initial files to enable separate release notes

### DIFF
--- a/docs/source/release/templates/diffraction.rst
+++ b/docs/source/release/templates/diffraction.rst
@@ -1,0 +1,53 @@
+===================
+Diffraction Changes
+===================
+
+.. contents:: Table of Contents
+   :local:
+
+Powder Diffraction
+------------------
+
+New features
+############
+.. include:: Diffraction/Powder/New_features/New_features.rst
+
+Improvements
+############
+.. include:: Diffraction/Powder/Improvements/Improvements.rst
+
+Bugfixes
+############
+.. include:: Diffraction/Powder/Bugfixes/Bugfixes.rst
+
+
+Engineering Diffraction
+-----------------------
+
+New features
+############
+.. include:: Diffraction/Engineering/New_features/New_features.rst
+
+Improvements
+############
+.. include:: Diffraction/Engineering/Improvements/Improvements.rst
+
+Bugfixes
+############
+.. include:: Diffraction/Engineering/Bugfixes/Bugfixes.rst
+
+
+Single Crystal Diffraction
+--------------------------
+
+New features
+############
+.. include:: Diffraction/Single_Crystal/New_features/New_features.rst
+
+Improvements
+############
+.. include:: Diffraction/Single_Crystal/Improvements/Improvements.rst
+
+Bugfixes
+############
+.. include:: Diffraction/Single_Crystal/Bugfixes/Bugfixes.rst

--- a/docs/source/release/templates/direct_geometry.rst
+++ b/docs/source/release/templates/direct_geometry.rst
@@ -1,0 +1,54 @@
+=======================
+Direct Geometry Changes
+=======================
+
+.. contents:: Table of Contents
+   :local:
+
+General
+-------
+
+New features
+############
+.. include:: Direct_Geometry/General/New_features/New_features.rst
+
+Improvements
+############
+.. include:: Direct_Geometry/General/Improvements.rst
+
+Bugfixes
+############
+.. include:: Direct_Geometry/General/Bugfixes/Bugfixes.rst
+
+
+CrystalField
+-------------
+
+New features
+############
+.. include:: Direct_Geometry/CrystalField/New_features/New_features.rst
+
+Improvements
+############
+.. include:: Direct_Geometry/CrystalField/Improvements/Improvements.rst
+
+Bugfixes
+############
+.. include:: Direct_Geometry/CrystalField/Bugfixes/Bugfixes.rst
+
+
+MSlice
+------
+
+New features
+############
+.. include:: Direct_Geometry/MSlice/New_features/New_features.rst
+
+Improvements
+############
+.. include:: Direct_Geometry/MSlice/Improvements/Improvements.rst
+
+Bugfixes
+############
+.. include:: Direct_Geometry/MSlice/Bugfixes/Bugfixes.rst
+

--- a/docs/source/release/templates/direct_geometry.rst
+++ b/docs/source/release/templates/direct_geometry.rst
@@ -14,7 +14,7 @@ New features
 
 Improvements
 ############
-.. include:: Direct_Geometry/General/Improvements.rst
+.. include:: Direct_Geometry/General/Improvements/Improvements.rst
 
 Bugfixes
 ############

--- a/docs/source/release/templates/framework.rst
+++ b/docs/source/release/templates/framework.rst
@@ -1,0 +1,68 @@
+=================
+Framework Changes
+=================
+
+.. contents:: Table of Contents
+   :local:
+
+Algorithms
+----------
+
+New features
+############
+.. include:: Framework/Algorithms/New_features/New_features.rst
+
+Improvements
+############
+.. include:: Framework/Algorithms/Improvements/Improvements.rst
+
+Bugfixes
+############
+.. include:: Framework/Algorithms/Bugfixes/Bugfixes.rst
+
+Fit Functions
+-------------
+
+New features
+############
+.. include:: Framework/Fit_Functions/New_features/New_features.rst
+
+Improvements
+############
+.. include:: Framework/Fit_Functions/Improvements/Improvements.rst
+
+Bugfixes
+############
+.. include:: Framework/Fit_Functions/Bugfixes/Bugfixes.rst
+
+
+Data Objects
+------------
+
+New features
+############
+.. include:: Framework/Data_Objects/New_features/New_features.rst
+
+Improvements
+############
+.. include:: Framework/Data_Objects/Improvements/Improvements.rst
+
+Bugfixes
+############
+.. include:: Framework/Data_Objects/Bugfixes/Bugfixes.rst
+
+
+Python
+------
+
+New features
+############
+.. include:: Framework/Python/New_features/New_features.rst
+
+Improvements
+############
+.. include:: Framework/Python/Improvements/Improvements.rst
+
+Bugfixes
+############
+.. include:: Framework/Python/Bugfixes/Bugfixes.rst

--- a/docs/source/release/templates/indirect_geometry.rst
+++ b/docs/source/release/templates/indirect_geometry.rst
@@ -1,0 +1,36 @@
+=========================
+Indirect Geometry Changes
+=========================
+
+.. contents:: Table of Contents
+   :local:
+
+New Features
+------------
+.. include:: Indirect/New_features/New_features.rst
+
+
+Improvements
+------------
+.. include:: Indirect/Improvements/Improvements.rst
+
+
+Bugfixes
+--------
+.. include:: Indirect/Bugfixes/Bugfixes.rst
+
+
+Algorithms
+----------
+
+New features
+############
+.. include:: Indirect/Algorithms/New_features/New_features.rst
+
+Improvements
+############
+.. include:: Indirect/Algorithms/Improvements/Improvements.rst
+
+Bugfixes
+############
+.. include:: Indirect/Algorithms/Bugfixes/Bugfixes.rst

--- a/docs/source/release/templates/mantidworkbench.rst
+++ b/docs/source/release/templates/mantidworkbench.rst
@@ -1,0 +1,53 @@
+========================
+Mantid Workbench Changes
+========================
+
+.. contents:: Table of Contents
+   :local:
+
+New Features
+------------
+.. include:: Workbench/New_features/New_features.rst
+
+
+Improvements
+------------
+.. include:: Workbench/Improvements/Improvements.rst
+
+
+Bugfixes
+--------
+.. include:: Workbench/Bugfixes/Bugfixes.rst
+
+
+InstrumentViewer
+----------------
+
+New features
+############
+.. include:: Workbench/InstrumentViewer/New_features/New_features.rst
+
+Improvements
+############
+.. include:: Workbench/InstrumentViewer/Improvements/Improvements.rst
+
+Bugfixes
+############
+.. include:: Workbench/InstrumentViewer/Bugfixes/Bugfixes.rst
+
+
+SliceViewer
+-----------
+
+New features
+############
+.. include:: Workbench/SliceViewer/New_features/New_features.rst
+
+Improvements
+############
+.. include:: Workbench/SliceViewer/Improvements/Improvements.rst
+
+Bugfixes
+############
+.. include:: Workbench/SliceViewer/Bugfixes/Bugfixes.rst
+

--- a/docs/source/release/templates/muon.rst
+++ b/docs/source/release/templates/muon.rst
@@ -1,0 +1,103 @@
+============
+Muon Changes
+============
+
+.. contents:: Table of Contents
+   :local:
+
+
+Frequency Domain Analysis
+-------------------------
+
+New features
+############
+.. include:: Muon/FDA/New_features/New_features.rst
+
+Improvements
+############
+.. include:: Muon/FDA/Improvements/Improvements.rst
+
+Bugfixes
+############
+.. include:: Muon/FDA/Bugfixes/Bugfixes.rst
+
+
+Muon Analysis
+-------------
+
+New features
+############
+.. include:: Muon/Muon_Analysis/New_features/New_features.rst
+
+Improvements
+############
+.. include:: Muon/Muon_Analysis/Improvements/Improvements.rst
+
+Bugfixes
+############
+.. include:: Muon/Muon_Analysis/Bugfixes/Bugfixes.rst
+
+
+
+Muon Analysis and Frequency Domain Analysis
+-------------------------------------------
+
+New features
+############
+.. include:: Muon/MA_FDA/New_features/New_features.rst
+
+Improvements
+############
+.. include:: Muon/MA_FDA/Improvements/Improvements.rst
+
+Bugfixes
+############
+.. include:: Muon/MA_FDA/Bugfixes/Bugfixes.rst
+
+
+ALC
+---
+
+New features
+############
+.. include:: Muon/ALC/New_features/New_features.rst
+
+Improvements
+############
+.. include:: Muon/ALC/Improvements/Improvements.rst
+
+Bugfixes
+############
+.. include:: Muon/ALC/Bugfixes/Bugfixes.rst
+
+
+Elemental Analysis
+------------------
+
+New features
+############
+.. include:: Muon/Elemental_Analysis/New_features/New_features.rst
+
+Improvements
+############
+.. include:: Muon/Elemental_Analysis/Improvements/Improvements.rst
+
+Bugfixes
+############
+.. include:: Muon/Elemental_Analysis/Bugfixes/Bugfixes.rst
+
+
+Algorithms
+----------
+
+New features
+############
+.. include:: Muon/Algorithms/New_features/New_features.rst
+
+Improvements
+############
+.. include:: Muon/Algorithms/Improvements/Improvements.rst
+
+Bugfixes
+############
+.. include:: Muon/Algorithms/Bugfixes/Bugfixes.rst

--- a/docs/source/release/templates/reflectometry.rst
+++ b/docs/source/release/templates/reflectometry.rst
@@ -1,0 +1,20 @@
+=====================
+Reflectometry Changes
+=====================
+
+.. contents:: Table of Contents
+   :local:
+
+New Features
+------------
+.. include:: Reflectometry/New_features/New_features.rst
+
+
+Improvements
+------------
+.. include:: Reflectometry/Improvements/Improvements.rst
+
+
+Bugfixes
+--------
+.. include:: Reflectometry/Bugfixes/Bugfixes.rst

--- a/docs/source/release/templates/sans.rst
+++ b/docs/source/release/templates/sans.rst
@@ -1,0 +1,20 @@
+============
+SANS Changes
+============
+
+.. contents:: Table of Contents
+   :local:
+
+New Features
+------------
+.. include:: SANS/New_features/New_features.rst
+
+
+Improvements
+------------
+.. include:: SANS/Improvements/Improvements.rst
+
+
+Bugfixes
+--------
+.. include:: SANS/Bugfixes/Bugfixes.rst

--- a/tools/ReleaseNoteProject/InitialSetup.py
+++ b/tools/ReleaseNoteProject/InitialSetup.py
@@ -1,0 +1,91 @@
+import os
+import shutil
+import sys
+
+level1 = ['/Diffraction', '/Muon', '/Direct_Geometry', '/Framework']
+#For upper level folders that will require Bugfixes, Improvements and New features as sub directories
+level1Upper = ['/Workbench', '/Reflectometry', '/SANS', '/Indirect']
+
+diffraction = ['/Powder', '/Single_Crystal', '/Engineering']
+framework = ['/Algorithms', '/Data_Objects', '/Fit_Functions', '/Python']
+workbench = ['/InstrumentViewer', '/SliceViewer']
+direct = ['/General', '/CrystalField', '/MSlice']
+indirect = ['/Algorithms']
+muon = ['/FDA', '/Muon_Analysis', '/MA_FDA', '/ALC', '/Elemental_Analysis', '/Algorithms']
+
+subfolders = ['/Bugfixes', '/New_features', '/Improvements']
+
+
+def getReleaseRoot():
+    script_dir = os.path.split(sys.argv[0])[0]
+    return os.path.abspath(os.path.join(script_dir, '../../docs/source/release/'))
+
+
+def getReleaseTemplateRoot():
+    script_dir = os.path.split(sys.argv[0])[0]
+    return os.path.abspath(os.path.join(script_dir, '../../docs/source/release/templates'))
+
+
+def createFileLocation():
+    release_root = getReleaseRoot()
+    release_root = release_root + '/Test'
+    return release_root
+
+
+HigherLevel = createFileLocation()
+
+
+def makeReleaseNoteDirectories():
+    for directory in level1:
+        os.makedirs(HigherLevel+directory, exist_ok=True)
+    for directory in level1Upper:
+        os.makedirs(HigherLevel + directory, exist_ok=True)
+        makeReleaseNoteSubfolders(directory)
+    makeSubDirectoriesFromList(diffraction, '/Diffraction')
+    makeSubDirectoriesFromList(framework, '/Framework')
+    makeSubDirectoriesFromList(workbench, '/Workbench')
+    makeSubDirectoriesFromList(direct, '/Direct_Geometry')
+    makeSubDirectoriesFromList(indirect, '/Indirect')
+    makeSubDirectoriesFromList(muon, '/Muon')
+
+
+def makeSubDirectoriesFromList(directoryList, upperDirectory):
+    for directory in directoryList:
+        combinedDirectory = upperDirectory + directory
+        os.makedirs(HigherLevel + combinedDirectory, exist_ok=True)
+        makeReleaseNoteSubfolders(combinedDirectory)
+
+
+def makeReleaseNoteSubfolders(directory):
+    for folder in subfolders:
+        os.makedirs(HigherLevel + directory + folder, exist_ok=True)
+        makeEmptyRST(folder, directory)
+
+
+def makeEmptyRST(folder, directory):
+    filename = folder + '.rst'
+    fullPath = HigherLevel + directory + folder + filename
+    open(fullPath, 'a').close()
+
+
+def textToAppend():
+    release_link = '\n:ref:`Release {0} <{1}>`'.format("Test", "Test" )
+    return release_link
+
+
+def makeMainReleaseNoteFiles():
+    templateLocation = getReleaseTemplateRoot()
+    for file in os.listdir(templateLocation):
+        templateFile = templateLocation + '/' + file
+        newFile = HigherLevel + '/' + file
+        shutil.copyfile(templateFile, newFile)
+        with open(newFile, "a") as file_to_ammend:
+            file_to_ammend.write(textToAppend())
+
+
+def createNewRelease():
+    makeReleaseNoteDirectories()
+    makeMainReleaseNoteFiles()
+
+
+createNewRelease()

--- a/tools/ReleaseNoteProject/compilationScript.py
+++ b/tools/ReleaseNoteProject/compilationScript.py
@@ -1,0 +1,58 @@
+import os
+import sys
+
+
+def getReleaseRoot():
+    script_dir = os.path.split(sys.argv[0])[0]
+    return os.path.abspath(os.path.join(script_dir, '../../docs/source/release/'))
+
+
+def createFileLocation():
+    release_root = getReleaseRoot()
+    release_root = release_root + '/Test'
+    return release_root
+
+
+def getReleaseNoteDirectories(path, directoryList):
+    #return nothing if path is a file
+    if os.path.isfile(path):
+        return ()
+
+    #add dir to directorylist if it contains .rst files
+    if len([f for f in os.listdir(path) if f.endswith('.rst')])>0:
+        directoryList.append(path)
+
+    for d in os.listdir(path):
+        new_path = os.path.join(path, d)
+        if os.path.isdir(new_path):
+            getReleaseNoteDirectories(new_path, directoryList)
+
+    return directoryList
+
+
+def checkContainsReleaseNote(path):
+    releaseNoteList = []
+    getReleaseNoteDirectories(path, releaseNoteList)
+    releaseNoteList.remove(path)
+    return releaseNoteList
+
+
+pathToCheck = createFileLocation()
+
+listofDirectories = checkContainsReleaseNote(pathToCheck)
+
+excludedFileList = ["Bugfixes.rst", "New_features.rst", "Improvements.rst"]
+
+for path in listofDirectories:
+    combinedRst = ""
+    filesScanned = []
+    for file in os.listdir(path):
+        if file.endswith(".rst") and file not in excludedFileList:
+            filesScanned.append(file)
+            with open(path + '/' + file) as f:
+                contents = f.read()
+                combinedRst = combinedRst + "\n" + contents
+    for file in os.listdir(path):
+        if file.endswith(".rst") and file in excludedFileList:
+            with open(path + '/' + file, 'w') as handle:
+                handle.write(combinedRst)

--- a/tools/ReleaseNoteProject/startOfRelease.py
+++ b/tools/ReleaseNoteProject/startOfRelease.py
@@ -1,0 +1,93 @@
+import os
+import sys
+import shutil
+
+
+def getReleaseRoot():
+    script_dir = os.path.split(sys.argv[0])[0]
+    return os.path.abspath(os.path.join(script_dir, '../../docs/source/release/'))
+
+
+def createFileLocation():
+    release_root = getReleaseRoot()
+    release_root = release_root + '/Test'
+    return release_root
+
+
+mainDirectory = createFileLocation()
+includeStatement = ".. include:: "
+
+
+def updateFile(originalFile, fileToAdd, textToReplace):
+    mainRST = open(originalFile, 'r')
+    rstToRead = mainRST.read()
+    mainRST.close()
+
+    releaseNoteFile = open(fileToAdd)
+    replaceText = releaseNoteFile.read()
+    releaseNoteFile.close()
+
+    newdata = rstToRead.replace(textToReplace, replaceText)
+
+    mainRST = open(originalFile, 'w')
+    mainRST.write(newdata)
+    mainRST.close()
+
+
+def createFileName(fileName, mainDirectory, includeStatement):
+    newFileName = fileName.replace(includeStatement, "")
+    newFileName = newFileName.replace("\n", "")
+    newFileName = mainDirectory + '/' + newFileName
+    return newFileName
+
+
+def addReleaseNotesToMain(mainDirectory):
+    for file in os.listdir(mainDirectory):
+        if file.endswith(".rst"):
+            with open(mainDirectory + '/' + file) as fileToEdit:
+                for line in fileToEdit:
+                    if line.startswith(includeStatement):
+                        fileName = createFileName(line, mainDirectory, includeStatement)
+                        originalFile = mainDirectory + '/' + file
+                        updateFile(originalFile, fileName, line)
+
+
+def getReleaseNoteDirectories(path, directoryList):
+    #return nothing if path is a file
+    if os.path.isfile(path):
+        return ()
+
+    #add dir to directorylist if it contains .rst files
+    if len([f for f in os.listdir(path) if f.endswith('.rst')])>0:
+        directoryList.append(path)
+
+    for d in os.listdir(path):
+        new_path = os.path.join(path, d)
+        if os.path.isdir(new_path):
+            getReleaseNoteDirectories(new_path, directoryList)
+
+    return directoryList
+
+
+def checkContainsReleaseNote(path):
+    releaseNoteList = []
+    getReleaseNoteDirectories(path, releaseNoteList)
+    releaseNoteList.remove(path)
+    return releaseNoteList
+
+
+def moveFiles(mainDirectory):
+    listofDirectories = checkContainsReleaseNote(mainDirectory)
+    for path in listofDirectories:
+        print("the path is ", path)
+        os.makedirs(path + '/' + 'Used')
+        for file in os.listdir(path):
+            print("the file is ", file)
+            if file.endswith(".rst"):
+                currentFileLocation = path + '/' + file
+                newFileLocation = path + '/Used/' + file
+                shutil.move(currentFileLocation, newFileLocation)
+
+
+addReleaseNotesToMain(mainDirectory)
+moveFiles(mainDirectory)


### PR DESCRIPTION
**Description of work.**
In order to move to doing release notes as separate files (to reduce merge conflicts) we need to put in place the file directories to enable this. This PR adds all the necessary directories to the v6.4.0 release notes folder. It also adds the templates for creating the main release notes in future and the files needed for the compilation script to enable the release notes to appear on the website.

A separate PR will contain the developer documentation to support the move to seperate release notes

**To test:**
Review the new directory names.

*There is no associated issue.*

*This does not require release notes* because **this will have no impact on users**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
