### PR TITLE
Highlight title matcher when lookup errors occur

### DIFF
--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/LookupTableValidator.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/LookupTableValidator.cpp
@@ -128,6 +128,6 @@ void LookupTableValidator::sortInPlaceByThetaThenTitleMatcher(LookupTableRows &l
 void LookupTableValidator::appendSearchCriteriaErrorForAllRows(std::vector<InvalidLookupRowCells> &validationErrors,
                                                                std::size_t rowCount) const {
   for (auto row = 0u; row < rowCount; ++row)
-    validationErrors.emplace_back(row, std::unordered_set<int>({LookupRow::Column::THETA}));
+    validationErrors.emplace_back(row, std::unordered_set<int>({LookupRow::Column::THETA, LookupRow::Column::TITLE}));
 }
 } // namespace MantidQt::CustomInterfaces::ISISReflectometry

--- a/qt/scientific_interfaces/ISISReflectometry/test/Experiment/ExperimentPresenterTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Experiment/ExperimentPresenterTest.h
@@ -391,7 +391,7 @@ public:
 
   void testMultipleWildcardRowsAreInvalid() {
     OptionsTable const optionsTable = {optionsRowWithWildcard(), optionsRowWithWildcard()};
-    runTestForInvalidOptionsTable(optionsTable, {0, 1}, LookupRow::Column::THETA);
+    runTestForInvalidOptionsTable(optionsTable, {0, 1}, {LookupRow::Column::THETA, LookupRow::Column::TITLE});
   }
 
   void testSetFirstTransmissionRun() {
@@ -401,7 +401,7 @@ public:
 
   void testSetSecondTransmissionRun() {
     OptionsTable const optionsTable = {optionsRowWithSecondTransmissionRun()};
-    runTestForInvalidOptionsTable(optionsTable, 0, LookupRow::Column::FIRST_TRANS);
+    runTestForInvalidOptionsTable(optionsTable, 0, {LookupRow::Column::FIRST_TRANS});
   }
 
   void testSetBothTransmissionRuns() {
@@ -416,7 +416,7 @@ public:
 
   void testSetTransmissionProcessingInstructionsInvalid() {
     OptionsTable const optionsTable = {optionsRowWithTransProcessingInstructionsInvalid()};
-    runTestForInvalidOptionsTable(optionsTable, 0, LookupRow::Column::TRANS_SPECTRA);
+    runTestForInvalidOptionsTable(optionsTable, 0, {LookupRow::Column::TRANS_SPECTRA});
   }
 
   void testSetQMin() {
@@ -426,7 +426,7 @@ public:
 
   void testSetQMinInvalid() {
     OptionsTable const optionsTable = {optionsRowWithQMinInvalid()};
-    runTestForInvalidOptionsTable(optionsTable, 0, LookupRow::Column::QMIN);
+    runTestForInvalidOptionsTable(optionsTable, 0, {LookupRow::Column::QMIN});
   }
 
   void testSetQMax() {
@@ -436,7 +436,7 @@ public:
 
   void testSetQMaxInvalid() {
     OptionsTable const optionsTable = {optionsRowWithQMaxInvalid()};
-    runTestForInvalidOptionsTable(optionsTable, 0, LookupRow::Column::QMAX);
+    runTestForInvalidOptionsTable(optionsTable, 0, {LookupRow::Column::QMAX});
   }
 
   void testSetQStep() {
@@ -446,7 +446,7 @@ public:
 
   void testSetQStepInvalid() {
     OptionsTable const optionsTable = {optionsRowWithQStepInvalid()};
-    runTestForInvalidOptionsTable(optionsTable, 0, LookupRow::Column::QSTEP);
+    runTestForInvalidOptionsTable(optionsTable, 0, {LookupRow::Column::QSTEP});
   }
 
   void testSetScale() {
@@ -456,7 +456,7 @@ public:
 
   void testSetScaleInvalid() {
     OptionsTable const optionsTable = {optionsRowWithScaleInvalid()};
-    runTestForInvalidOptionsTable(optionsTable, 0, LookupRow::Column::SCALE);
+    runTestForInvalidOptionsTable(optionsTable, 0, {LookupRow::Column::SCALE});
   }
 
   void testSetProcessingInstructions() {
@@ -466,7 +466,7 @@ public:
 
   void testSetProcessingInstructionsInvalid() {
     OptionsTable const optionsTable = {optionsRowWithProcessingInstructionsInvalid()};
-    runTestForInvalidOptionsTable(optionsTable, 0, LookupRow::Column::RUN_SPECTRA);
+    runTestForInvalidOptionsTable(optionsTable, 0, {LookupRow::Column::RUN_SPECTRA});
   }
 
   void testSetBackgroundProcessingInstructionsValid() {
@@ -476,7 +476,7 @@ public:
 
   void testSetBackgroundProcessingInstructionsInvalid() {
     OptionsTable const optionsTable = {optionsRowWithBackgroundProcessingInstructionsInvalid()};
-    runTestForInvalidOptionsTable(optionsTable, 0, LookupRow::Column::BACKGROUND_SPECTRA);
+    runTestForInvalidOptionsTable(optionsTable, 0, {LookupRow::Column::BACKGROUND_SPECTRA});
   }
 
   void testChangingSettingsNotifiesMainPresenter() {
@@ -887,23 +887,22 @@ private:
     verifyAndClear();
   }
 
-  void runTestForInvalidOptionsTable(OptionsTable const &optionsTable, const std::vector<int> &rows, int column) {
+  void runTestForInvalidOptionsTable(OptionsTable const &optionsTable, const std::vector<int> &rows,
+                                     std::vector<int> columns) {
     auto presenter = makePresenter();
     EXPECT_CALL(m_view, getLookupTable()).WillOnce(Return(optionsTable));
-    for (auto row : rows)
-      EXPECT_CALL(m_view, showLookupRowAsInvalid(row, column)).Times(1);
+    for (auto row : rows) {
+      for (auto col : columns) {
+        EXPECT_CALL(m_view, showLookupRowAsInvalid(row, col)).Times(1);
+      }
+    }
     presenter.notifyLookupRowChanged(1, 1);
     TS_ASSERT(!presenter.hasValidSettings());
     verifyAndClear();
   }
 
-  void runTestForInvalidOptionsTable(OptionsTable const &optionsTable, int row, int column) {
-    auto presenter = makePresenter();
-    EXPECT_CALL(m_view, getLookupTable()).WillOnce(Return(optionsTable));
-    EXPECT_CALL(m_view, showLookupRowAsInvalid(row, column)).Times(1);
-    presenter.notifyLookupRowChanged(1, 1);
-    TS_ASSERT(!presenter.hasValidSettings());
-    verifyAndClear();
+  void runTestForInvalidOptionsTable(OptionsTable const &optionsTable, int row, std::vector<int> columns) {
+    runTestForInvalidOptionsTable(optionsTable, std::vector<int>{row}, columns);
   }
 
   void runTestForNonUniqueAngles(OptionsTable const &optionsTable) {

--- a/qt/scientific_interfaces/ISISReflectometry/test/Experiment/LookupTableValidatorTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Experiment/LookupTableValidatorTest.h
@@ -36,7 +36,7 @@ public:
   void testTwoWildcardRowsIsInvalid() {
     auto table = Table({emptyRow(), emptyRow()});
     runTestInvalidThetas(table, LookupCriteriaError::MultipleWildcards,
-                         expectedErrors({0, 1}, {LookupRow::Column::THETA}));
+                         expectedErrors({0, 1}, {LookupRow::Column::THETA, LookupRow::Column::TITLE}));
   }
 
   void testOneAngleRow() {
@@ -60,7 +60,7 @@ public:
   void testTwoNonUniqueAngleRowsIsInvalid() {
     auto table = Table({Cells({"0.5"}), Cells({"0.5"})});
     runTestInvalidThetas(table, LookupCriteriaError::NonUniqueSearchCriteria,
-                         expectedErrors({0, 1}, {LookupRow::Column::THETA}));
+                         expectedErrors({0, 1}, {LookupRow::Column::THETA, LookupRow::Column::TITLE}));
   }
 
   void testMatchingAngleRowsWithDifferentTitleMatchersAreUnique() {
@@ -81,7 +81,7 @@ public:
   void testDuplicateAnglesAndTitleMatchersAreInvalid() {
     auto table = Table({Cells({"0.5", "title"}), Cells({"0.5", "title"})});
     runTestInvalidThetas(table, LookupCriteriaError::NonUniqueSearchCriteria,
-                         expectedErrors({0, 1}, {LookupRow::Column::THETA}));
+                         expectedErrors({0, 1}, {LookupRow::Column::THETA, LookupRow::Column::TITLE}));
   }
 
   void testInvalidAngle() {
@@ -181,7 +181,7 @@ public:
   void testAnglesThatDifferByLessThanTolerance() {
     auto table = Table({Cells({"0.5"}), Cells({"0.5009"})});
     runTestInvalidThetas(table, LookupCriteriaError::NonUniqueSearchCriteria,
-                         expectedErrors({0, 1}, {LookupRow::Column::THETA}));
+                         expectedErrors({0, 1}, {LookupRow::Column::THETA, LookupRow::Column::TITLE}));
   }
 
   void testCorrectRowMarkedAsInvalidInMultiRowTable() {


### PR DESCRIPTION
**Description of work.**

Originally only highlighted the theta angle. As duplication occurs when
both the title and angle match, both should be highlighted.

Now both columns are higlighted to induicate that both seach criteria should be checked for duplicates. 

**To test:**
1. Open the Refl interface
2. Experiment tab
3. Add two blank rows
4. Both the theta and title options should be highlighed red
5. Fill both rows in with duplicate title and angle
6. As of point 4

Fixes #33586

*This does not require release notes* because **this is minor functionality expanding on work already new for this release.**


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
