### PR TITLE
Suppress documentation build warnings

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -261,3 +261,11 @@ intersphinx_mapping = {
     'pystog': ('https://pystog.readthedocs.io/en/latest/', None),
     'mantid-dev': ('https://developer.mantidproject.org/', None)
 }
+
+# Temporarily suppress build warnings of the type:
+# "WARNING: document isn't included in any toctree"
+# while new release notes system is under development.
+exclude_patterns = [
+    'release/v6.4.0/**/Bugfixes/Bugfixes.rst',
+    'release/v6.4.0/**/New_features/New_features.rst'
+]


### PR DESCRIPTION
**Description of work.**
Currently Windows PR builds will be marked as failed if the BUILD_PACKAGE option is switched on because of warnings from the documentation build. Also the main Windows builds are marked as unstable (see [here](https://builds.mantidproject.org/job/main_clean-windows/1808/msbuild/new/)). The new .rst files have been temporarily excluded while the new release notes system is a WIP, which should stop the warnings.

**To test:**
Check that the Windows build has built a package and passed the build checks.

<!-- alternative
*There is no associated issue.*
-->

*This does not require release notes* because it a temporary fix for release notes.

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
