### PR TITLE
Add warning when using wildcard row

### DIFF
--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/LookupTable.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/LookupTable.cpp
@@ -47,9 +47,15 @@ boost::optional<LookupRow> LookupTable::findLookupRow(Row const &row, double tol
   }
   // If we didn't find a lookup row where theta matches, then we allow the user to specify a "wildcard" row
   // which will be used for everything where a specific match is not found
-  g_log.warning("Used wildcard row for " + boost::algorithm::join(row.runNumbers(), ", ") +
+  auto result = findWildcardLookupRow();
+  if (result) {
+    g_log.warning("Used wildcard row for " + boost::algorithm::join(row.runNumbers(), ", ") +
+                  ". You may wish to check that all lookup criteria are correct.");
+    return result;
+  }
+  g_log.warning("Used algorithm defaults for " + boost::algorithm::join(row.runNumbers(), ", ") +
                 ". You may wish to check that all lookup criteria are correct.");
-  return findWildcardLookupRow();
+  return result;
 }
 
 boost::optional<LookupRow> LookupTable::searchByTheta(std::vector<LookupRow> lookupRows,

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/LookupTable.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/LookupTable.cpp
@@ -7,6 +7,7 @@
 
 #include "LookupTable.h"
 #include "IGroup.h"
+#include "MantidKernel/Logger.h"
 #include "Row.h"
 #include <boost/optional.hpp>
 #include <boost/regex.hpp>
@@ -19,6 +20,8 @@ constexpr double EPSILON = std::numeric_limits<double>::epsilon();
 bool equalWithinTolerance(double val1, double val2, double tolerance) {
   return std::abs(val1 - val2) <= (tolerance + EPSILON);
 }
+
+Mantid::Kernel::Logger g_log("Reflectometry Lookup Table");
 } // namespace
 
 namespace MantidQt::CustomInterfaces::ISISReflectometry {
@@ -44,6 +47,8 @@ boost::optional<LookupRow> LookupTable::findLookupRow(Row const &row, double tol
   }
   // If we didn't find a lookup row where theta matches, then we allow the user to specify a "wildcard" row
   // which will be used for everything where a specific match is not found
+  g_log.warning("Used wildcard row for " + boost::algorithm::join(row.runNumbers(), ", ") +
+                ". You may wish to check that all lookup criteria are correct.");
   return findWildcardLookupRow();
 }
 

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/LookupTable.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/LookupTable.cpp
@@ -49,12 +49,16 @@ boost::optional<LookupRow> LookupTable::findLookupRow(Row const &row, double tol
   // which will be used for everything where a specific match is not found
   auto result = findWildcardLookupRow();
   if (result) {
-    g_log.warning("Used wildcard row for " + boost::algorithm::join(row.runNumbers(), ", ") +
-                  ". You may wish to check that all lookup criteria are correct.");
+    g_log.warning(
+        "No matching experiment settings found for " + boost::algorithm::join(row.runNumbers(), ", ") +
+        ". Using wildcard row settings instead. You may wish to check that all lookup criteria on the Experiment "
+        "Settings table are correct.");
     return result;
   }
-  g_log.warning("Used algorithm defaults for " + boost::algorithm::join(row.runNumbers(), ", ") +
-                ". You may wish to check that all lookup criteria are correct.");
+  g_log.warning(
+      "No matching experiment settings found for " + boost::algorithm::join(row.runNumbers(), ", ") +
+      ". Using algorithm default settings instead. You may wish to check that all lookup criteria on the Experiment "
+      "Settings table are correct.");
   return result;
 }
 


### PR DESCRIPTION
**Description of work.**

With the added complexity of having two lookup rows, it could be
beneficial to warn the user when the run does not match any of the rows
in the experiment tab and so has hit the wildcard row. This should
reduce the effects of typos in the title field.

**To test:**
1. Open the Refl GUI
2. Load a few runs or a batch

Fixes #33515

*This does not require release notes* because **it is a part of a larger peice of work**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
