### PR TITLE
Fix bug when loading batch over existing lookup rows

### DIFF
--- a/Testing/Data/UnitTest/ISISReflectometry/batch_2_exp_rows.json.md5
+++ b/Testing/Data/UnitTest/ISISReflectometry/batch_2_exp_rows.json.md5
@@ -1,0 +1,1 @@
+3a32fccfc8c08be8404ebe7362e8aa92

--- a/docs/source/release/v6.4.0/Reflectometry/Bugfixes/33585_batch_loading.rst
+++ b/docs/source/release/v6.4.0/Reflectometry/Bugfixes/33585_batch_loading.rst
@@ -1,0 +1,1 @@
+- Loading a batch now completely clears the Experiment Settings tab's lookup table before re-populating it.

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Common/Decoder.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Common/Decoder.cpp
@@ -110,9 +110,7 @@ void Decoder::decodeExperiment(QtExperimentView *gui, const QMap<QString, QVaria
 
 void Decoder::decodePerAngleDefaults(QTableWidget *tab, const QMap<QString, QVariant> &map) {
   // Clear the rows
-  for (auto rowIndex = 0; rowIndex < tab->rowCount(); ++rowIndex) {
-    tab->removeRow(rowIndex);
-  }
+  tab->setRowCount(0);
   const int rowsNum = map[QString("rowsNum")].toInt();
   const int columnsNum = map[QString("columnsNum")].toInt();
 

--- a/qt/scientific_interfaces/ISISReflectometry/test/Common/DecoderTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Common/DecoderTest.h
@@ -26,6 +26,7 @@ auto &fileFinder = FileFinder::Instance();
 const auto MAINWINDOW_FILE = fileFinder.getFullPath(DIR_PATH + "mainwindow.json");
 const auto BATCH_FILE = fileFinder.getFullPath(DIR_PATH + "batch.json");
 const auto EMPTY_BATCH_FILE = fileFinder.getFullPath(DIR_PATH + "empty_batch.json");
+const auto TWO_ROW_EXP_BATCH_FILE = fileFinder.getFullPath(DIR_PATH + "batch_2_exp_rows.json");
 const auto EIGHT_COL_BATCH_FILE = fileFinder.getFullPath(DIR_PATH + "8_col_batch.json");
 const auto NINE_COL_BATCH_FILE = fileFinder.getFullPath(DIR_PATH + "9_col_batch.json");
 const auto TEN_COL_BATCH_FILE = fileFinder.getFullPath(DIR_PATH + "10_col_batch.json");
@@ -72,6 +73,19 @@ public:
     mwv.initLayout();
     auto gui = dynamic_cast<QtBatchView *>(mwv.batches()[0]);
     Decoder decoder;
+    decoder.decodeBatch(&mwv, 0, map);
+
+    tester.testBatch(gui, &mwv, map);
+  }
+
+  void test_decodePopulatedBatchWithPopulatedGUI() {
+    CoderCommonTester tester;
+    auto map = MantidQt::API::loadJSONFromFile(QString::fromStdString(TWO_ROW_EXP_BATCH_FILE));
+    QtMainWindowView mwv;
+    mwv.initLayout();
+    auto gui = dynamic_cast<QtBatchView *>(mwv.batches()[0]);
+    Decoder decoder;
+    decoder.decodeBatch(&mwv, 0, map);
     decoder.decodeBatch(&mwv, 0, map);
 
     tester.testBatch(gui, &mwv, map);


### PR DESCRIPTION
**Description of work.**

If the lookup table already contained a number of lookup rows the
loading of a batch resulted in some of the rows that had been there
before sticking around due to an indexing error. This simply sets the
number of rows to 0 before loading, which gracefully handles the
clearing of the table under the hood.

**To test:**
1. Load/make a batch with a few rows in the experiment tab of the refl gui
2. Save this batch
3. load the batch into the same window as the previous one
4. The batch should load the same way it was saved, with no duplicated rows or rows from the old batch. 

Fixes #33585 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
