### PR TITLE
Add tooltips to Lookup Table Errors

### DIFF
--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -665,7 +665,6 @@ useStlAlgorithm:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/Muon/ALCInterface.c
 useStlAlgorithm:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/ISISReflectometry/Common/Clipboard.cpp:91
 constParameter:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchJobManager.cpp:58
 useStlAlgorithm:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchJobManager.cpp:152
-useStlAlgorithm:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/QtExperimentView.cpp:593
 constParameter:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/ISISReflectometry/GUI/Instrument/InstrumentPresenter.cpp:18
 useStlAlgorithm:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/ISISReflectometry/GUI/MainWindow/MainWindowPresenter.cpp:153
 useStlAlgorithm:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/Indirect/DensityOfStates.cpp:121

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/ExperimentPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/ExperimentPresenter.cpp
@@ -268,14 +268,18 @@ void ExperimentPresenter::showLookupTableErrors(LookupTableValidationError const
   for (auto const &validationError : errors.errors()) {
     for (auto const &column : validationError.invalidColumns()) {
       if (errors.fullTableError()) {
-        if (errors.fullTableError() == LookupCriteriaError::NonUniqueSearchCriteria)
-          m_view->setTooltip(validationError.row(), column, "Error: Duplicated search criteria.");
-        if (errors.fullTableError() == LookupCriteriaError::MultipleWildcards)
-          m_view->setTooltip(validationError.row(), column, "Error: Multiple wildcards.");
+        showFullTableError(errors.fullTableError().get(), validationError.row(), column);
       }
       m_view->showLookupRowAsInvalid(validationError.row(), column);
     }
   }
+}
+
+void ExperimentPresenter::showFullTableError(LookupCriteriaError const &tableError, int row, int column) {
+  if (tableError == LookupCriteriaError::NonUniqueSearchCriteria)
+    m_view->setTooltip(row, column, "Error: Duplicated search criteria.");
+  if (tableError == LookupCriteriaError::MultipleWildcards)
+    m_view->setTooltip(row, column, "Error: Multiple wildcards.");
 }
 
 void ExperimentPresenter::showValidationResult() {

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/ExperimentPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/ExperimentPresenter.cpp
@@ -63,13 +63,9 @@ void ExperimentPresenter::notifyRemoveLookupRowRequested(int index) {
   notifySettingsChanged();
 }
 
-void ExperimentPresenter::notifyLookupRowChanged(int, int column) {
+void ExperimentPresenter::notifyLookupRowChanged(int /*row*/, int /*column*/) {
   updateModelFromView();
   showValidationResult();
-  if (column == 0 && !m_validationResult.isValid() &&
-      m_validationResult.assertError().lookupTableValidationErrors().fullTableError() ==
-          LookupCriteriaError::NonUniqueSearchCriteria)
-    m_view->showLookupRowsNotUnique(m_thetaTolerance);
   m_mainPresenter->notifySettingsChanged();
 }
 

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/ExperimentPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/ExperimentPresenter.cpp
@@ -266,8 +266,15 @@ void ExperimentPresenter::updateModelFromView() {
 void ExperimentPresenter::showLookupTableErrors(LookupTableValidationError const &errors) {
   m_view->showAllLookupRowsAsValid();
   for (auto const &validationError : errors.errors()) {
-    for (auto const &column : validationError.invalidColumns())
+    for (auto const &column : validationError.invalidColumns()) {
+      if (errors.fullTableError()) {
+        if (errors.fullTableError() == LookupCriteriaError::NonUniqueSearchCriteria)
+          m_view->setTooltip(validationError.row(), column, "Error: Duplicated search criteria.");
+        if (errors.fullTableError() == LookupCriteriaError::MultipleWildcards)
+          m_view->setTooltip(validationError.row(), column, "Error: Multiple wildcards.");
+      }
       m_view->showLookupRowAsInvalid(validationError.row(), column);
+    }
   }
 }
 

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/ExperimentPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/ExperimentPresenter.cpp
@@ -277,9 +277,12 @@ void ExperimentPresenter::showLookupTableErrors(LookupTableValidationError const
 
 void ExperimentPresenter::showFullTableError(LookupCriteriaError const &tableError, int row, int column) {
   if (tableError == LookupCriteriaError::NonUniqueSearchCriteria)
-    m_view->setTooltip(row, column, "Error: Duplicated search criteria.");
+    m_view->setTooltip(row, column,
+                       "Error: Duplicated search criteria. No more than one row may have the same angle and title.");
   if (tableError == LookupCriteriaError::MultipleWildcards)
-    m_view->setTooltip(row, column, "Error: Multiple wildcards.");
+    m_view->setTooltip(
+        row, column,
+        "Error: Multiple wildcard rows. Only a single row in the table may have a blank angle and title cell.");
 }
 
 void ExperimentPresenter::showValidationResult() {

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/ExperimentPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/ExperimentPresenter.h
@@ -86,6 +86,7 @@ private:
 
   void showValidationResult();
   void showLookupTableErrors(LookupTableValidationError const &errors);
+  void showFullTableError(LookupCriteriaError const &tableError, int row, int column);
 
   void updateWidgetEnabledState();
   void updateSummationTypeEnabledState();

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/IExperimentView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/IExperimentView.h
@@ -123,6 +123,9 @@ public:
   virtual void addLookupRow() = 0;
   virtual void removeLookupRow(int rowIndex) = 0;
 
+  virtual void setTooltip(int row, int column, std::string text) = 0;
+  virtual void resetTooltip(int row, int column) = 0;
+
   virtual ~IExperimentView() = default;
 };
 } // namespace ISISReflectometry

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/IExperimentView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/IExperimentView.h
@@ -123,8 +123,6 @@ public:
   virtual void addLookupRow() = 0;
   virtual void removeLookupRow(int rowIndex) = 0;
 
-  virtual void showLookupRowsNotUnique(double tolerance) = 0;
-
   virtual ~IExperimentView() = default;
 };
 } // namespace ISISReflectometry

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/IExperimentView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/IExperimentView.h
@@ -124,7 +124,6 @@ public:
   virtual void removeLookupRow(int rowIndex) = 0;
 
   virtual void setTooltip(int row, int column, std::string text) = 0;
-  virtual void resetTooltip(int row, int column) = 0;
 
   virtual ~IExperimentView() = default;
 };

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/IExperimentView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/IExperimentView.h
@@ -123,7 +123,7 @@ public:
   virtual void addLookupRow() = 0;
   virtual void removeLookupRow(int rowIndex) = 0;
 
-  virtual void setTooltip(int row, int column, std::string text) = 0;
+  virtual void setTooltip(int row, int column, std::string const &text) = 0;
 
   virtual ~IExperimentView() = default;
 };

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/LookupTableValidator.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/LookupTableValidator.cpp
@@ -29,9 +29,9 @@ auto LookupTableValidator::operator()(ContentType const &lookupTableContent, dou
   auto validationErrors = std::vector<InvalidLookupRowCells>();
   validateAllLookupRows(lookupTableContent, lookupTable, validationErrors);
   // Now cross-check search criteria across all rows against each other (in case of duplicates etc.)
-  auto thetaValidationResult = validateSearchCriteria(lookupTable, thetaTolerance);
+  auto searchCriteriaValidationResult = validateSearchCriteria(lookupTable, thetaTolerance);
 
-  if (thetaValidationResult.isValid()) {
+  if (searchCriteriaValidationResult.isValid()) {
     if (validationErrors.empty()) {
       // No errors - return the valid table
       return ResultType(std::move(lookupTable));
@@ -42,7 +42,8 @@ auto LookupTableValidator::operator()(ContentType const &lookupTableContent, dou
   } else {
     // Mark all rows with the search criteria errors, then return both row and table errors
     appendSearchCriteriaErrorForAllRows(validationErrors, lookupTableContent.size());
-    return ResultType(LookupTableValidationError(std::move(validationErrors), thetaValidationResult.assertError()));
+    return ResultType(
+        LookupTableValidationError(std::move(validationErrors), searchCriteriaValidationResult.assertError()));
   }
 }
 

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/QtExperimentView.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/QtExperimentView.cpp
@@ -81,12 +81,6 @@ void QtExperimentView::showAllLookupRowsAsValid() {
     showLookupRowAsValid(row);
 }
 
-void QtExperimentView::showLookupRowsNotUnique(double tolerance) {
-  QMessageBox::critical(this, "Invalid lookup criteria combination!",
-                        "Cannot have multiple defaults with theta values less than " + QString::number(tolerance) +
-                            " apart.");
-}
-
 void QtExperimentView::showStitchParametersValid() { showAsValid(stitchOptionsLineEdit()); }
 
 void QtExperimentView::showStitchParametersInvalid() { showAsInvalid(stitchOptionsLineEdit()); }

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/QtExperimentView.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/QtExperimentView.cpp
@@ -79,9 +79,6 @@ void QtExperimentView::onRemoveLookupRowRequested() {
 void QtExperimentView::showAllLookupRowsAsValid() {
   for (auto row = 0; row < m_ui.optionsTable->rowCount(); ++row) {
     showLookupRowAsValid(row);
-    for (auto column = 0; column < m_ui.optionsTable->columnCount(); ++column) {
-      resetTooltip(row, column);
-    }
   }
 }
 
@@ -152,12 +149,6 @@ void QtExperimentView::setTooltipFromAlgorithm(int column, std::unordered_map<in
 void QtExperimentView::setTooltip(int row, int column, std::string text) {
   m_ui.optionsTable->blockSignals(true);
   m_ui.optionsTable->item(row, column)->setToolTip(QString::fromStdString(text));
-  m_ui.optionsTable->blockSignals(false);
-}
-
-void QtExperimentView::resetTooltip(int row, int column) {
-  m_ui.optionsTable->blockSignals(true);
-  m_ui.optionsTable->item(row, column)->setToolTip(m_columnToolTips[column]);
   m_ui.optionsTable->blockSignals(false);
 }
 
@@ -703,8 +694,10 @@ void QtExperimentView::showLookupRowAsInvalid(int row, int column) {
 
 void QtExperimentView::showLookupRowAsValid(int row) {
   m_ui.optionsTable->blockSignals(true);
-  for (auto column = 0; column < m_ui.optionsTable->columnCount(); ++column)
+  for (auto column = 0; column < m_ui.optionsTable->columnCount(); ++column) {
     m_ui.optionsTable->item(row, column)->setBackground(QBrush(Qt::transparent));
+    m_ui.optionsTable->item(row, column)->setToolTip(m_columnToolTips[column]);
+  }
   m_ui.optionsTable->blockSignals(false);
 }
 

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/QtExperimentView.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/QtExperimentView.cpp
@@ -590,8 +590,8 @@ void QtExperimentView::showOptionLoadErrors(std::vector<InstrumentParameterTypeM
   if (!missingValues.empty())
     message += messageFor(missingValues);
 
-  for (auto &typeError : typeErrors)
-    message += messageFor(typeError);
+  std::accumulate(typeErrors.cbegin(), typeErrors.cend(), message,
+                  [this](auto &msg, auto const &section) { return msg += messageFor(section); });
 
   QMessageBox::warning(this, "Failed to load one or more defaults from parameter file", message);
 }

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/QtExperimentView.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/QtExperimentView.cpp
@@ -146,7 +146,7 @@ void QtExperimentView::setTooltipFromAlgorithm(int column, std::unordered_map<in
   m_columnToolTips[column] = toolTip;
 }
 
-void QtExperimentView::setTooltip(int row, int column, std::string text) {
+void QtExperimentView::setTooltip(int row, int column, std::string const &text) {
   m_ui.optionsTable->blockSignals(true);
   m_ui.optionsTable->item(row, column)->setToolTip(QString::fromStdString(text));
   m_ui.optionsTable->blockSignals(false);

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/QtExperimentView.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/QtExperimentView.cpp
@@ -77,8 +77,12 @@ void QtExperimentView::onRemoveLookupRowRequested() {
 }
 
 void QtExperimentView::showAllLookupRowsAsValid() {
-  for (auto row = 0; row < m_ui.optionsTable->rowCount(); ++row)
+  for (auto row = 0; row < m_ui.optionsTable->rowCount(); ++row) {
     showLookupRowAsValid(row);
+    for (auto column = 0; column < m_ui.optionsTable->columnCount(); ++column) {
+      resetTooltip(row, column);
+    }
+  }
 }
 
 void QtExperimentView::showStitchParametersValid() { showAsValid(stitchOptionsLineEdit()); }
@@ -143,6 +147,18 @@ void QtExperimentView::setTooltipFromAlgorithm(int column, std::unordered_map<in
   // on the table cells instead. They are created dynamically, so for now
   // just cache the tooltip.
   m_columnToolTips[column] = toolTip;
+}
+
+void QtExperimentView::setTooltip(int row, int column, std::string text) {
+  m_ui.optionsTable->blockSignals(true);
+  m_ui.optionsTable->item(row, column)->setToolTip(QString::fromStdString(text));
+  m_ui.optionsTable->blockSignals(false);
+}
+
+void QtExperimentView::resetTooltip(int row, int column) {
+  m_ui.optionsTable->blockSignals(true);
+  m_ui.optionsTable->item(row, column)->setToolTip(m_columnToolTips[column]);
+  m_ui.optionsTable->blockSignals(false);
 }
 
 void QtExperimentView::initializeTableColumns(QTableWidget &table,

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/QtExperimentView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/QtExperimentView.h
@@ -117,7 +117,6 @@ public:
   void removeLookupRow(int rowIndex) override;
 
   void setTooltip(int row, int column, std::string text) override;
-  void resetTooltip(int row, int column) override;
 
 public slots:
   /// Adds another row to the per-angle options table

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/QtExperimentView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/QtExperimentView.h
@@ -116,7 +116,7 @@ public:
   void addLookupRow() override;
   void removeLookupRow(int rowIndex) override;
 
-  void setTooltip(int row, int column, std::string text) override;
+  void setTooltip(int row, int column, std::string const &text) override;
 
 public slots:
   /// Adds another row to the per-angle options table

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/QtExperimentView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/QtExperimentView.h
@@ -116,6 +116,9 @@ public:
   void addLookupRow() override;
   void removeLookupRow(int rowIndex) override;
 
+  void setTooltip(int row, int column, std::string text) override;
+  void resetTooltip(int row, int column) override;
+
 public slots:
   /// Adds another row to the per-angle options table
   void onRestoreDefaultsRequested();

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/QtExperimentView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/QtExperimentView.h
@@ -54,7 +54,6 @@ public:
   void setLookupTable(std::vector<LookupRow::ValueArray> rows) override;
   void showLookupRowAsInvalid(int row, int column) override;
   void showLookupRowAsValid(int row) override;
-  void showLookupRowsNotUnique(double thetaTolerance) override;
   void showStitchParametersValid() override;
   void showStitchParametersInvalid() override;
 

--- a/qt/scientific_interfaces/ISISReflectometry/test/Experiment/ExperimentPresenterTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Experiment/ExperimentPresenterTest.h
@@ -393,7 +393,12 @@ public:
     OptionsTable const optionsTable = {optionsRowWithWildcard(), optionsRowWithWildcard()};
     for (auto row = 0; row < 2; ++row) {
       for (auto col = 0; col < 2; ++col) {
-        EXPECT_CALL(m_view, setTooltip(row, col, "Error: Multiple wildcards.")).Times(1);
+        EXPECT_CALL(
+            m_view,
+            setTooltip(
+                row, col,
+                "Error: Multiple wildcard rows. Only a single row in the table may have a blank angle and title cell."))
+            .Times(1);
       }
     }
     runTestForInvalidOptionsTable(optionsTable, {0, 1}, {LookupRow::Column::THETA, LookupRow::Column::TITLE});
@@ -916,7 +921,11 @@ private:
     for (auto row = 0; row < 2; ++row) {
       for (auto col = 0; col < 2; ++col) {
         EXPECT_CALL(m_view, showLookupRowAsInvalid(row, col)).Times(1);
-        EXPECT_CALL(m_view, setTooltip(row, col, "Error: Duplicated search criteria.")).Times(1);
+        EXPECT_CALL(
+            m_view,
+            setTooltip(row, col,
+                       "Error: Duplicated search criteria. No more than one row may have the same angle and title."))
+            .Times(1);
       }
     }
     presenter.notifyLookupRowChanged(0, 0);

--- a/qt/scientific_interfaces/ISISReflectometry/test/Experiment/ExperimentPresenterTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Experiment/ExperimentPresenterTest.h
@@ -908,7 +908,10 @@ private:
   void runTestForNonUniqueAngles(OptionsTable const &optionsTable) {
     auto presenter = makePresenter();
     EXPECT_CALL(m_view, getLookupTable()).WillOnce(Return(optionsTable));
-    EXPECT_CALL(m_view, showLookupRowsNotUnique(m_thetaTolerance)).Times(1);
+    EXPECT_CALL(m_view, showLookupRowAsInvalid(0, 1)).Times(1);
+    EXPECT_CALL(m_view, showLookupRowAsInvalid(0, 0)).Times(1);
+    EXPECT_CALL(m_view, showLookupRowAsInvalid(1, 1)).Times(1);
+    EXPECT_CALL(m_view, showLookupRowAsInvalid(1, 0)).Times(1);
     presenter.notifyLookupRowChanged(0, 0);
     verifyAndClear();
   }

--- a/qt/scientific_interfaces/ISISReflectometry/test/Experiment/ExperimentPresenterTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Experiment/ExperimentPresenterTest.h
@@ -391,6 +391,11 @@ public:
 
   void testMultipleWildcardRowsAreInvalid() {
     OptionsTable const optionsTable = {optionsRowWithWildcard(), optionsRowWithWildcard()};
+    for (auto row = 0; row < 2; ++row) {
+      for (auto col = 0; col < 2; ++col) {
+        EXPECT_CALL(m_view, setTooltip(row, col, "Error: Multiple wildcards.")).Times(1);
+      }
+    }
     runTestForInvalidOptionsTable(optionsTable, {0, 1}, {LookupRow::Column::THETA, LookupRow::Column::TITLE});
   }
 
@@ -908,10 +913,12 @@ private:
   void runTestForNonUniqueAngles(OptionsTable const &optionsTable) {
     auto presenter = makePresenter();
     EXPECT_CALL(m_view, getLookupTable()).WillOnce(Return(optionsTable));
-    EXPECT_CALL(m_view, showLookupRowAsInvalid(0, 1)).Times(1);
-    EXPECT_CALL(m_view, showLookupRowAsInvalid(0, 0)).Times(1);
-    EXPECT_CALL(m_view, showLookupRowAsInvalid(1, 1)).Times(1);
-    EXPECT_CALL(m_view, showLookupRowAsInvalid(1, 0)).Times(1);
+    for (auto row = 0; row < 2; ++row) {
+      for (auto col = 0; col < 2; ++col) {
+        EXPECT_CALL(m_view, showLookupRowAsInvalid(row, col)).Times(1);
+        EXPECT_CALL(m_view, setTooltip(row, col, "Error: Duplicated search criteria.")).Times(1);
+      }
+    }
     presenter.notifyLookupRowChanged(0, 0);
     verifyAndClear();
   }

--- a/qt/scientific_interfaces/ISISReflectometry/test/Experiment/MockExperimentView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Experiment/MockExperimentView.h
@@ -99,6 +99,7 @@ public:
   MOCK_METHOD0(addLookupRow, void());
   MOCK_METHOD1(removeLookupRow, void(int));
   MOCK_METHOD1(showLookupRowsNotUnique, void(double));
+  MOCK_METHOD3(setTooltip, void(int, int, std::string const &));
 };
 } // namespace ISISReflectometry
 } // namespace CustomInterfaces


### PR DESCRIPTION
**Description of work.**
Added help message tooltips to the table when errors are detected. Rather than the description of what the column is for, when there is a lookup criteria error the tooltip is changed to indicate what the problem is and how to fix it. 

**To test:**
1. Open the Refl GUI
2. Click the Experiment Settings tab
3. On the table, check that the tooltips on the cells in the Angle and Title columns contain a description of what those cells are for.
4. Add an additional row, those columns should now be highlighted red
5. Check the tooltips now contain an "multiple wildcards" error message and details. 
6. Change one of the angles
7. Check the tooltip has been reverted
8. Change the other to the same angle as in step 6
9. Check the tooltip has a "duplicate search criteria" error.
10. Change one of the titles
11. Check the tooltip is reverted

Fixes #33587 

*This does not require release notes* because **it is part of the larger piece of work to add title lookup to the GUI**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
