### PR TITLE
Fix documentation build warnings

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -262,10 +262,10 @@ intersphinx_mapping = {
     'mantid-dev': ('https://developer.mantidproject.org/', None)
 }
 
-# Temporarily suppress build warnings of the type:
+# Suppress build warnings of the type:
 # "WARNING: document isn't included in any toctree"
-# while new release notes system is under development.
+# for individual release notes files.
 exclude_patterns = [
-    'release/v6.4.0/**/Bugfixes/**/*.rst',
-    'release/v6.4.0/**/New_features/**/*.rst'
+    'release/v6.4.0/**/Bugfixes/*.rst',
+    'release/v6.4.0/**/New_features/*.rst'
 ]

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -266,6 +266,6 @@ intersphinx_mapping = {
 # "WARNING: document isn't included in any toctree"
 # while new release notes system is under development.
 exclude_patterns = [
-    'release/v6.4.0/**/Bugfixes/Bugfixes.rst',
-    'release/v6.4.0/**/New_features/New_features.rst'
+    'release/v6.4.0/**/Bugfixes/**/*.rst',
+    'release/v6.4.0/**/New_features/**/*.rst'
 ]


### PR DESCRIPTION
**Description of work.**
Exclude new `.rst` files that will be added whenever new release notes are added, which cause build warnings when building the documentation.

**To test:**

Check that the Windows job built the package without build warnings.

*There is no associated issue.*

*This does not require release notes* because it is a fix for docs builds.

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
