### PR TITLE
Conda-buildscript shanum fixes for mambaforge download

### DIFF
--- a/buildconfig/Jenkins/Conda/download-and-install-mambaforge
+++ b/buildconfig/Jenkins/Conda/download-and-install-mambaforge
@@ -19,6 +19,8 @@ WINDOWS_SHA256="70e8cb24f329f867155a81bb90b48d9f6d105ca1414e8382cac4f4fd7a1c6529
 # Only supporting x86_64 at this time for the build process
 if [[ $OSTYPE == 'msys'* ]]; then
     MAMBAFORGE_SCRIPT_NAME=Mambaforge-$MAMBAFORGE_VERSION-Windows-x86_64.exe
+elif [[ $OSTYPE == 'darwin'* ]]; then
+    MAMBAFORGE_SCRIPT_NAME=Mambaforge-$MAMBAFORGE_VERSION-MacOSX-x86_64.sh
 else
     MAMBAFORGE_SCRIPT_NAME=Mambaforge-$MAMBAFORGE_VERSION-$(uname)-x86_64.sh
 fi

--- a/buildconfig/Jenkins/Conda/download-and-install-mambaforge
+++ b/buildconfig/Jenkins/Conda/download-and-install-mambaforge
@@ -22,7 +22,7 @@ if [[ $OSTYPE == 'msys'* ]]; then
 else
     MAMBAFORGE_SCRIPT_NAME=Mambaforge-$MAMBAFORGE_VERSION-$(uname)-x86_64.sh
 fi
-URL=https://github.com/conda-forge/miniforge/releases/latest/download/$MAMBAFORGE_SCRIPT_NAME
+URL=https://github.com/conda-forge/miniforge/releases/download/$MAMBAFORGE_VERSION/$MAMBAFORGE_SCRIPT_NAME
 
 if [[ $CLEAN_BUILD  == true ]]; then
     rm -rf $EXPECTED_MAMBAFORGE_PATH


### PR DESCRIPTION
**Description of work.**
After mambaforge's version progressed beyond 4.11.0 it exposed an issue with our URL for downloading.

**To test:**
Run the conda-buildscript on one OS locally using the correct script for your os:

- `mantid_source/buildconfig/Jenkins/Conda/conda-buildscript ~/work_dir linux-ci`
- `mantid_source/buildconfig/Jenkins/Conda/conda-buildscript ~/work_dir osx`
- `mantid_source/buildconfig/Jenkins/Conda/conda-buildscript ~/work_dir win`

If it runs for 1 minute then you cancel it and it should be fine.
<!-- Instructions for testing. -->

*There is no associated issue.*

*This does not require release notes* because **Not user-facing**

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
