### PR TITLE
Fix a crash with reflectometry live data and sliceviewer

### DIFF
--- a/Framework/PythonInterface/test/python/plugins/algorithms/ReflectometryReductionOneLiveDataTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/ReflectometryReductionOneLiveDataTest.py
@@ -154,10 +154,14 @@ class ReflectometryReductionOneLiveDataTest(unittest.TestCase):
             assert False, "The following child properties are not implemented in the parent algorithm:\n" \
             + str(child_props.difference(actual_props))
 
-    def test_instrument_was_set_on_input_and_output_workspace(self):
+    def test_instrument_was_set_on_output_workspace(self):
         workspace = self._run_algorithm_with_defaults()
-        self.assertEqual(self.__class__._input_ws.getInstrument().getName(), self._instrument_name)
         self.assertEqual(workspace.getInstrument().getName(), self._instrument_name)
+
+    def test_instrument_was_not_set_on_input_workspace(self):
+        workspace = self._run_algorithm_with_defaults()
+        # The input workspace should be unchanged
+        self.assertEqual(self.__class__._input_ws.getInstrument().getName(), "")
 
     def test_sample_log_values_were_set_on_output_workspace(self):
         workspace = self._run_algorithm_with_defaults()

--- a/docs/source/release/v6.4.0/Reflectometry/Bugfixes/33613.rst
+++ b/docs/source/release/v6.4.0/Reflectometry/Bugfixes/33613.rst
@@ -1,0 +1,1 @@
+- Fixed a potential crash running live data reduction when SliceViewer is open on the live data workspace.


### PR DESCRIPTION
A crash was happening related to the fact that the ReflectometryReductionOneLiveData algorithm updates the input workspace. If sliceviewer is open on the workspace while this happens it is possible that it will cause mantid to crash. While the sliceviewer issue still needs resolving, the algorithm does not need to (and therefore should not) modify the input workspace anyway. This PR therefore removes this modification, which fixes the crash.

Refs #33610

**To test:**

Follow the instructions in the linked issue and ensure the crash is fixed.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
