### PR TITLE
Move release notes to separate files

### DIFF
--- a/docs/source/release/v6.4.0/Diffraction/Engineering/Bugfixes/33593.rst
+++ b/docs/source/release/v6.4.0/Diffraction/Engineering/Bugfixes/33593.rst
@@ -1,0 +1,1 @@
+- Add a parent to an instance of the engineering diffraction interface created by loading a project so that it's a child of the main window. This also resolves an occasional crash when loading a project containing a workspace that was plotted on the Fitting tab

--- a/docs/source/release/v6.4.0/Diffraction/Powder/New_features/33593.rst
+++ b/docs/source/release/v6.4.0/Diffraction/Powder/New_features/33593.rst
@@ -1,0 +1,1 @@
+- The NOMAD instrument IDF was updated

--- a/docs/source/release/v6.4.0/Direct_Geometry/Algorithms/New_features/33593.rst
+++ b/docs/source/release/v6.4.0/Direct_Geometry/Algorithms/New_features/33593.rst
@@ -1,0 +1,2 @@
+- :ref:`DirectILLAutoProcess <algm-DirectILLAutoProcess>` performs full data reduction treatment for ILL direct geometry instruments for empty container, vanadium, and sample, both single crystal and powder.
+- :ref:`DirectILLCollectData <algm-DirectILLCollectData>` has two new properties: `GroupDetHorizontallyBy` and `GroupDetVerticallyBy` which allow for averaging pixel counts between the tubes and inside them, respectively, of for flat background calculation

--- a/docs/source/release/v6.4.0/Direct_Geometry/General/New_features/33593.rst
+++ b/docs/source/release/v6.4.0/Direct_Geometry/General/New_features/33593.rst
@@ -1,0 +1,5 @@
+- :ref:`CorrectTOFAxis <algm-CorrectTOFAxis>` can now accept fractional bin indices for more precise calculation of the elastic peak position calibration
+- :ref:`DirectILLCollectData <algm-DirectILLCollectData>` will now accept fractional elastic peak reference bin as well as forward fractional elastic
+  peak index to the :ref:`CorrectTOFAxis <algm-CorrectTOFAxis>`
+- :ref:`DirectILLApplySelfShielding <algm-DirectILLApplySelfShielding>` now ensures that the subtracted container and self-attenuation correction workspaces
+  have consistent binning with the provided sample to be corrected by rebinning to the sample

--- a/docs/source/release/v6.4.0/Framework/Algorithms/New_features/33593.rst
+++ b/docs/source/release/v6.4.0/Framework/Algorithms/New_features/33593.rst
@@ -1,0 +1,4 @@
+- :ref:`LoadAndMerge <algm-LoadAndMerge>` will now offer a possibility to have a joined workspace as output instead of a workspace group.
+- :ref:`ConjoinXRuns <algm-ConjoinXRuns>` will now have a possibility to set a linear integer range as the axis of the output joined workspace.
+- :ref:`CalculateFlux <algm-CalculateFlux>` will now work also on workspaces with dimensionless x-axis.
+- Performance of :ref:`DiscusMultipleScatteringCorrection <algm-DiscusMultipleScatteringCorrection>` improved when running with ImportanceSampling=True

--- a/docs/source/release/v6.4.0/Framework/Python/New_features/33593.rst
+++ b/docs/source/release/v6.4.0/Framework/Python/New_features/33593.rst
@@ -1,0 +1,1 @@
+- Added possibility to forward log messages to Python, see :ref:`mantid.utils.logging.log_to_python`.

--- a/docs/source/release/v6.4.0/Indirect/Bugfixes/33593.rst
+++ b/docs/source/release/v6.4.0/Indirect/Bugfixes/33593.rst
@@ -1,0 +1,1 @@
+- A bug has been fixed in Indirect Data Analysis where the first value would be ignored when a fit was performed.

--- a/docs/source/release/v6.4.0/Indirect/New_features/33593.rst
+++ b/docs/source/release/v6.4.0/Indirect/New_features/33593.rst
@@ -1,0 +1,2 @@
+- In Indirect Data analysis the button for fitting the currently plotted spectra has been renamed and rescaled to fit the interface.
+- :ref:`IndirectILLReductionQENS <algm-IndirectILLReductionQENS>` and :ref:`IndirectILLReductionFWS <algm-IndirectILLReductionFWS>` now offer a possibility to switch off the detector grouping.

--- a/docs/source/release/v6.4.0/Reflectometry/New_features/33593.rst
+++ b/docs/source/release/v6.4.0/Reflectometry/New_features/33593.rst
@@ -1,0 +1,5 @@
+- On the ISIS Reflectometry interface, you can now specify default experiment settings on a per-sample basis as well as a per-angle basis. The new ``Title`` field in the lookup table allows you to specify a regular expression. Any runs whose title matches this expression will use those settings by default.
+- Groups are now highlighted to show that all subtasks are completed.
+- Processing is disabled if there are errors on the Experiment Setting table.
+- Removed the automated template generation from the `LRAutoReduction` algorithm, which was never used.
+- Removed the so-called "primary fraction correction" from the `LRAutoReduction` algorithm. This correction is no longer in use.

--- a/docs/source/release/v6.4.0/SANS/Bugfixes/33593.rst
+++ b/docs/source/release/v6.4.0/SANS/Bugfixes/33593.rst
@@ -1,0 +1,1 @@
+- The ISIS SANS row copy, cut and paste has been overhauled fixing numerous edge-cases. These include: the paste order being reversed, unexpected rows appearing or clearing whilst pasting and blank rows appearing randomly.

--- a/docs/source/release/v6.4.0/SANS/New_features/33593.rst
+++ b/docs/source/release/v6.4.0/SANS/New_features/33593.rst
@@ -1,0 +1,4 @@
+- ILL SANS reduction suite has been refactored, providing up to 2 orders of magnitude of speed-up for kinetic monochromatic measurements. The new algorithm :ref:`SANSILLMultiProcess <algm-SANSILLMultiProcess>` steers the reduction of the whole experiment, using the new version of the :ref:`SANSILLReduction-v2 <algm-SANSILLReduction-v2>`.
+- :ref:`CalculateDynamicRange <algm-CalculateDynamicRange>` will now work also for workspaces where the x-axis unit is not wavelength, provided that the wavelength is present in the sample logs.
+- :ref:`ParallaxCorrection <algm-ParallaxCorrection>` will now accept optional angle offsets per detector bank, to be subtracted from the scattering angles before evaluating the formulae.
+- :ref:`ApplyTransmissionCorrection <algm-ApplyTransmissionCorrection>` no longer requires the input workspace to be histogram data in wavelengths.

--- a/docs/source/release/v6.4.0/Workbench/Bugfixes/33593.rst
+++ b/docs/source/release/v6.4.0/Workbench/Bugfixes/33593.rst
@@ -1,0 +1,8 @@
+- In DrILL interface, scrolling down in the settings dialog no longer affects the comboxes
+- Cleaned up the appearance of the main window and the Indirect, Reflectometry, and Engineering GUIs on macOS.
+- Fixed where matplotlib 3.5 caused 3D plots to throw a warning in multiple places.
+- Fixed where matplotlib 3.5 caused a plot to raise an exception when right clicked, or showing the context menu.
+- Fixed where matplotlib 3.5 caused a warning when opening plots.
+- Fixed where matplotlib 3.5 caused any 3D plot to raise an exception when opened.
+- Fixed where matplotlib 3.5 caused a crash when closing workbench with a plot open.
+- Fixed where matplotlib 3.5 caused a project to be unable to save and load plots.

--- a/docs/source/release/v6.4.0/Workbench/InstrumentViewer/New_features/33593.rst
+++ b/docs/source/release/v6.4.0/Workbench/InstrumentViewer/New_features/33593.rst
@@ -1,0 +1,1 @@
+- It is now possible to replace the workspace and save the image of the instrument viewer using its python API.

--- a/docs/source/release/v6.4.0/Workbench/New_features/33593.rst
+++ b/docs/source/release/v6.4.0/Workbench/New_features/33593.rst
@@ -1,0 +1,1 @@
+- New general setting: `Provide auto-completion suggestions in the script editor` for making auto-completion optional in the script editor

--- a/docs/source/release/v6.4.0/Workbench/SliceViewer/Bugfixes/33593.rst
+++ b/docs/source/release/v6.4.0/Workbench/SliceViewer/Bugfixes/33593.rst
@@ -1,0 +1,1 @@
+- Color limit autoscaling now works for MDHisto workspaces in non-orthogonal view in sliceviewer.

--- a/docs/source/release/v6.4.0/diffraction.rst
+++ b/docs/source/release/v6.4.0/diffraction.rst
@@ -12,12 +12,10 @@ Diffraction Changes
 Powder Diffraction
 ------------------
 
-- The NOMAD instrument IDF was updated
 
 Engineering Diffraction
 -----------------------
 
-Add a parent to an instance of the engineering diffraction interface created by loading a project so that it's a child of the main window. This also resolves an occasional crash when loading a project containing a workspace that was plotted on the Fitting tab
 
 Single Crystal Diffraction
 --------------------------

--- a/docs/source/release/v6.4.0/direct_geometry.rst
+++ b/docs/source/release/v6.4.0/direct_geometry.rst
@@ -5,33 +5,19 @@ Direct Geometry Changes
 .. contents:: Table of Contents
    :local:
 
-Direct Geometry
----------------
+General
+-------
 
-Improvements
+New Features
 ############
 
-- :ref:`CorrectTOFAxis <algm-CorrectTOFAxis>` can now accept fractional bin indices for more precise calculation of the elastic peak position calibration
-- :ref:`DirectILLCollectData <algm-DirectILLCollectData>` will now accept fractional elastic peak reference bin as well as forward fractional elastic
-  peak index to the :ref:`CorrectTOFAxis <algm-CorrectTOFAxis>`
-- :ref:`DirectILLApplySelfShielding <algm-DirectILLApplySelfShielding>` now ensures that the subtracted container and self-attenuation correction workspaces
-  have consistent binning with the provided sample to be corrected by rebinning to the sample
 
-.. warning:: **Developers:** Sort changes under appropriate heading
-    putting new features at the top of the section, followed by
-    improvements, followed by bug fixes.
+Algorithms
+----------
 
-Direct Geometry
----------------
-
-New Algorithms
-##############
-
-:ref:`DirectILLAutoProcess <algm-DirectILLAutoProcess>` performs full data reduction treatment for ILL direct geometry instruments for empty container, vanadium, and sample, both single crystal and powder.
-
-Improvements
+New Features
 ############
 
-:ref:`DirectILLCollectData <algm-DirectILLCollectData>` has two new properties: `GroupDetHorizontallyBy` and `GroupDetVerticallyBy` which allow for averaging pixel counts between the tubes and inside them, respectively, of for flat background calculation
+
 
 :ref:`Release 6.4.0 <v6.4.0>`

--- a/docs/source/release/v6.4.0/framework.rst
+++ b/docs/source/release/v6.4.0/framework.rst
@@ -15,10 +15,8 @@ Concepts
 Algorithms
 ----------
 
-- :ref:`LoadAndMerge <algm-LoadAndMerge>` will now offer a possibility to have a joined workspace as output instead of a workspace group.
-- :ref:`ConjoinXRuns <algm-ConjoinXRuns>` will now have a possibility to set a linear integer range as the axis of the output joined workspace.
-- :ref:`CalculateFlux <algm-CalculateFlux>` will now work also on workspaces with dimensionless x-axis.
-- Performance of :ref:`DiscusMultipleScatteringCorrection <algm-DiscusMultipleScatteringCorrection>` improved when running with ImportanceSampling=True
+New Features
+############
 
 Data Objects
 ------------
@@ -26,7 +24,8 @@ Data Objects
 Python
 ------
 
-- Added possibility to forward log messages to Python, see :ref:`mantid.utils.logging.log_to_python`.
+New Features
+############
 
 Installation
 ------------
@@ -36,13 +35,5 @@ MantidWorkbench
 
 See :doc:`mantidworkbench`.
 
-SliceViewer
------------
-
-Improvements
-############
-
-Bugfixes
-########
 
 :ref:`Release 6.4.0 <v6.4.0>`

--- a/docs/source/release/v6.4.0/indirect_geometry.rst
+++ b/docs/source/release/v6.4.0/indirect_geometry.rst
@@ -5,22 +5,13 @@ Indirect Geometry Changes
 .. contents:: Table of Contents
    :local:
 
-.. warning:: **Developers:** Sort changes under appropriate heading
-    putting new features at the top of the section, followed by
-    improvements, followed by bug fixes.
 
-:ref:`Release 6.4.0 <v6.4.0>`
-
-
-Changes
-#######
-
-- In Indirect Data analysis the button for fitting the currently plotted spectra has been renamed and rescaled to fit the interface.
-- :ref:`IndirectILLReductionQENS <algm-IndirectILLReductionQENS>` and :ref:`IndirectILLReductionFWS <algm-IndirectILLReductionFWS>` now offer a possibility to switch off the detector grouping.
+New Features
+------------
 
 
 Bugfixes
-########
+--------
 
-- A bug has been fixed in Indirect Data Analysis where the first value would be ignored when a fit was performed.
 
+:ref:`Release 6.4.0 <v6.4.0>`

--- a/docs/source/release/v6.4.0/mantidworkbench.rst
+++ b/docs/source/release/v6.4.0/mantidworkbench.rst
@@ -5,31 +5,26 @@ Mantid Workbench Changes
 .. contents:: Table of Contents
    :local:
 
-New and Improved
-----------------
-- New general setting: `Provide auto-completion suggestions in the script editor` for making auto-completion optional in the script editor
+New Features
+------------
+
 
 Bugfixes
 --------
-- In DrILL interface, scrolling down in the settings dialog no longer affects the comboxes
-- Cleaned up the appearance of the main window and the Indirect, Reflectometry, and Engineering GUIs on macOS.
-- Fixed where matplotlib 3.5 caused 3D plots to throw a warning in multiple places.
-- Fixed where matplotlib 3.5 caused a plot to raise an exception when right clicked, or showing the context menu.
-- Fixed where matplotlib 3.5 caused a warning when opening plots.
-- Fixed where matplotlib 3.5 caused any 3D plot to raise an exception when opened.
-- Fixed where matplotlib 3.5 caused a crash when closing workbench with a plot open.
-- Fixed where matplotlib 3.5 caused a project to be unable to save and load plots.
+
+Instrument Viewer
+-----------------
+
+New Features
+############
+
 
 Sliceviewer
 -----------
 
 Bugfixes
 ########
-- Color limit autoscaling now works for MDHisto workspaces in non-orthogonal view in sliceviewer.
 
-Instrument Viewer
------------------
 
-- It is now possible to replace the workspace and save the image of the instrument viewer using its python API.
 
 :ref:`Release 6.4.0 <v6.4.0>`

--- a/docs/source/release/v6.4.0/reflectometry.rst
+++ b/docs/source/release/v6.4.0/reflectometry.rst
@@ -5,21 +5,9 @@ Reflectometry Changes
 .. contents:: Table of Contents
    :local:
 
-.. warning:: **Developers:** Sort changes under appropriate heading
-    putting new features at the top of the section, followed by
-    improvements, followed by bug fixes.
 
 New features
 ------------
 
-- On the ISIS Reflectometry interface, you can now specify default experiment settings on a per-sample basis as well as a per-angle basis. The new ``Title`` field in the lookup table allows you to specify a regular expression. Any runs whose title matches this expression will use those settings by default.
-
-Improvements
-------------
-
-- Groups are now highlighted to show that all subtasks are completed.
-- Processing is disabled if there are errors on the Experiment Setting table.
-- Removed the automated template generation from the `LRAutoReduction` algorithm, which was never used.
-- Removed the so-called "primary fraction correction" from the `LRAutoReduction` algorithm. This correction is no longer in use.
 
 :ref:`Release 6.4.0 <v6.4.0>`

--- a/docs/source/release/v6.4.0/sans.rst
+++ b/docs/source/release/v6.4.0/sans.rst
@@ -5,22 +5,12 @@ SANS Changes
 .. contents:: Table of Contents
    :local:
 
-.. warning:: **Developers:** Sort changes under appropriate heading
-    putting new features at the top of the section, followed by
-    improvements, followed by bug fixes.
-
-New
----
-
-- ILL SANS reduction suite has been refactored, providing up to 2 orders of magnitude of speed-up for kinetic monochromatic measurements. The new algorithm :ref:`SANSILLMultiProcess <algm-SANSILLMultiProcess>` steers the reduction of the whole experiment, using the new version of the :ref:`SANSILLReduction-v2 <algm-SANSILLReduction-v2>`.
-- :ref:`CalculateDynamicRange <algm-CalculateDynamicRange>` will now work also for workspaces where the x-axis unit is not wavelength, provided that the wavelength is present in the sample logs.
-- :ref:`ParallaxCorrection <algm-ParallaxCorrection>` will now accept optional angle offsets per detector bank, to be subtracted from the scattering angles before evaluating the formulae.
-- :ref:`ApplyTransmissionCorrection <algm-ApplyTransmissionCorrection>` no longer requires the input workspace to be histogram data in wavelengths.
+New Features
+------------
 
 Bugfixes
 --------
 
-- The ISIS SANS row copy, cut and paste has been overhauled fixing numerous edge-cases. These include: the paste order being reversed, unexpected rows appearing or clearing whilst pasting and blank rows appearing randomly.
 
 
 :ref:`Release 6.4.0 <v6.4.0>`


### PR DESCRIPTION
**Description of work.**

As part of the move towards separate release notes (see #33593) we need to move release notes previously merged in for v6.4.0 to new, separate files. 

Please note - Muon release notes have not been included in this PR as they need to be addressed separately.

**To test:**
- check that tests pass
- check that there are no release notes in the upper level .rst files for v6.4.0 (e.g. `docs/release/v6.4.0/diffraction.rst`)
- check that all the release notes previously in upper files have moved to 

Part of the prs for #33593. 

This does not require release notes because it is a functional, under the hood change that does not affect users.


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
