### PR TITLE
DirectILL: TOF axis channel width sign change

### DIFF
--- a/Framework/DataHandling/src/LoadILLTOF2.cpp
+++ b/Framework/DataHandling/src/LoadILLTOF2.cpp
@@ -351,8 +351,8 @@ void LoadILLTOF2::loadDataIntoTheWorkSpace(NeXus::NXEntry &entry, const std::vec
   if (moni.containsDataSet("time_of_flight")) {
     if (convertToTOF) {
       for (size_t i = 0; i < m_numberOfChannels + 1; ++i) {
-        X0[i] = m_timeOfFlightDelay + m_channelWidth * static_cast<double>(i) -
-                m_channelWidth / 2; // to make sure the bin centre is correct
+        X0[i] = m_timeOfFlightDelay + m_channelWidth * static_cast<double>(i) +
+                m_channelWidth / 2; // to make sure the bin centre is positive
       }
     } else {
       for (size_t i = 0; i < m_numberOfChannels + 1; ++i) {

--- a/Framework/DataHandling/test/LoadILLTOF2Test.h
+++ b/Framework/DataHandling/test/LoadILLTOF2Test.h
@@ -81,7 +81,7 @@ public:
       const auto &xs = histogram.x();
       if (convertToTOF) {
         for (size_t channelIndex = 0; channelIndex != xs.size(); ++channelIndex) {
-          const double binEdge = tofDelay + static_cast<double>(channelIndex) * tofChannelWidth - tofChannelWidth / 2;
+          const double binEdge = tofDelay + static_cast<double>(channelIndex) * tofChannelWidth + tofChannelWidth / 2;
           TS_ASSERT_DELTA(xs[channelIndex], binEdge, 1e-3)
         }
       } else {

--- a/Testing/SystemTests/tests/framework/ILLDirectGeometryReductionTest.py
+++ b/Testing/SystemTests/tests/framework/ILLDirectGeometryReductionTest.py
@@ -86,9 +86,6 @@ class IN4(systemtesting.MantidSystemTest):
         self.disableChecking = ['Instrument', 'Sample']
         self.tolerance_is_rel_err = True
         self.tolerance = 1e-4
-        # NOTE: a new reference file is added to the standard system test file location
-        #       as I cannot figure out how to properly replace the existing file for ILL
-        #       standard.  Please consider moving/adjust the reference file as you see fit.
         return ['cropped', 'ILL_IN4_SofQW.nxs']
 
 

--- a/docs/source/algorithms/DirectILLCollectData-v1.rst
+++ b/docs/source/algorithms/DirectILLCollectData-v1.rst
@@ -161,7 +161,7 @@ Output:
 
     Number of histograms in 'raw': 397, and in 'preprocessed': 396
     Wavelength from sample logs: 3.06A
-    'raw' wavelength at channel 150: 1.63A (incorrect!)
+    'raw' wavelength at channel 150: 1.64A (incorrect!)
     'preprocessed' wavelength at channel 150: 3.04A
 
 .. categories::

--- a/docs/source/release/v6.4.0/Direct_Geometry/General/Bugfixes/33618.rst
+++ b/docs/source/release/v6.4.0/Direct_Geometry/General/Bugfixes/33618.rst
@@ -1,0 +1,1 @@
+- :ref:`LoadILLTOF <algm-LoadILLTOF>` the sign of the half-channel width has been changed from negative to positive to ensure TOF axis is always positive.


### PR DESCRIPTION
Direct geometry scientists have agreed that the sign of the channel width should be changed in the calculation of the TOF axis. 
Previously it was deducted, placing the bin centre at TOF value lower than the time-of-flight delay. However, it would be preferable if the bin centre was placed at a TOF value later than the delay. This PR implements this minor change and updates unit tests.

**Description of work.**

**To test:**
1. Tests should be passing.

*There is no associated issue.*

Release note updated.

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
