### PR TITLE
Adjust the sha calculations for windows to account for differences

### DIFF
--- a/buildconfig/Jenkins/Conda/download-and-install-mambaforge
+++ b/buildconfig/Jenkins/Conda/download-and-install-mambaforge
@@ -14,7 +14,7 @@ MAMBAFORGE_VERSION=4.11.0-0
 
 LINUX_SHA256="49268ee30d4418be4de852dda3aa4387f8c95b55a76f43fb1af68dcbf8b205c3  Mambaforge-4.11.0-0-Linux-x86_64.sh"
 MAC_SHA256="2039f744e272d47878f0bc2ae372f03c7f07881f39a93d693d5445744f36f19d  Mambaforge-4.11.0-0-MacOSX-x86_64.sh"
-WINDOWS_SHA256="70e8cb24f329f867155a81bb90b48d9f6d105ca1414e8382cac4f4fd7a1c6529  Mambaforge-4.11.0-0-Windows-x86_64.exe"
+WINDOWS_SHA256="70e8cb24f329f867155a81bb90b48d9f6d105ca1414e8382cac4f4fd7a1c6529 *Mambaforge-4.11.0-0-Windows-x86_64.exe"
 
 # Only supporting x86_64 at this time for the build process
 if [[ $OSTYPE == 'msys'* ]]; then


### PR DESCRIPTION
**Description of work.**
Change the sha comparison for windows in the CI

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**
Check that this script works on Windows:
`mantid_source/buildconfig/Jenkins/Conda/conda-buildscript ~/work_dir win`

<!-- Instructions for testing. -->

*There is no associated issue.*

*This does not require release notes* because **not user facing**

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
