### PR TITLE
Fix MS Build Warning in QtExperimentView

### DIFF
--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/IExperimentView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/IExperimentView.h
@@ -114,9 +114,6 @@ public:
   virtual std::string getStitchOptions() const = 0;
   virtual void setStitchOptions(std::string const &stitchOptions) = 0;
 
-  virtual void showOptionLoadErrors(std::vector<InstrumentParameterTypeMissmatch> const &typeErrors,
-                                    std::vector<MissingInstrumentParameterValue> const &missingValues) = 0;
-
   virtual void disableAll() = 0;
   virtual void enableAll() = 0;
 

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/QtExperimentView.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/QtExperimentView.cpp
@@ -583,19 +583,6 @@ QString QtExperimentView::messageFor(std::vector<MissingInstrumentParameterValue
          " not set in the instrument parameter file but should be.\n";
 }
 
-void QtExperimentView::showOptionLoadErrors(std::vector<InstrumentParameterTypeMissmatch> const &typeErrors,
-                                            std::vector<MissingInstrumentParameterValue> const &missingValues) {
-  auto message = QString("Unable to retrieve default values for the following parameters:\n");
-
-  if (!missingValues.empty())
-    message += messageFor(missingValues);
-
-  std::accumulate(typeErrors.cbegin(), typeErrors.cend(), message,
-                  [this](auto &msg, auto const &section) { return msg += messageFor(section); });
-
-  QMessageBox::warning(this, "Failed to load one or more defaults from parameter file", message);
-}
-
 QLineEdit &QtExperimentView::stitchOptionsLineEdit() const { return *static_cast<QLineEdit *>(m_stitchEdit); }
 
 /** Creates hints for 'Stitch1DMany'
@@ -744,8 +731,5 @@ std::string QtExperimentView::getStitchOptions() const { return getText(stitchOp
 void QtExperimentView::setStitchOptions(std::string const &stitchOptions) {
   setText(stitchOptionsLineEdit(), stitchOptions);
 }
-
-void showOptionLoadErrors(std::vector<InstrumentParameterTypeMissmatch> const &typeErrors,
-                          std::vector<MissingInstrumentParameterValue> const &missingValues);
 
 } // namespace MantidQt::CustomInterfaces::ISISReflectometry

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/QtExperimentView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/QtExperimentView.h
@@ -81,9 +81,6 @@ public:
   std::string getStitchOptions() const override;
   void setStitchOptions(std::string const &stitchOptions) override;
 
-  void showOptionLoadErrors(std::vector<InstrumentParameterTypeMissmatch> const &typeErrors,
-                            std::vector<MissingInstrumentParameterValue> const &missingValues) override;
-
   void showAllLookupRowsAsValid() override;
 
   void disableAll() override;

--- a/qt/scientific_interfaces/ISISReflectometry/test/Experiment/MockExperimentView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Experiment/MockExperimentView.h
@@ -92,8 +92,6 @@ public:
   MOCK_METHOD1(setFloodWorkspace, void(std::string const &));
   MOCK_CONST_METHOD0(getStitchOptions, std::string());
   MOCK_METHOD1(setStitchOptions, void(std::string const &));
-  MOCK_METHOD2(showOptionLoadErrors, void(std::vector<InstrumentParameterTypeMissmatch> const &,
-                                          std::vector<MissingInstrumentParameterValue> const &));
   MOCK_METHOD0(disableAll, void());
   MOCK_METHOD0(enableAll, void());
   MOCK_METHOD0(addLookupRow, void());


### PR DESCRIPTION
**Description of work.**
Removes dead code containing a bug missed by me and the CI in #33608 which is causing the nightly to be unstable. 

**To test:**
Build success. 

*There is no associated issue.*

*This does not require release notes* because **changes are not user facing.**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
