### PR TITLE
Add method for getting lookup row index

### DIFF
--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/LookupTable.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/LookupTable.cpp
@@ -117,6 +117,14 @@ boost::optional<LookupRow> LookupTable::findWildcardLookupRow() const {
     return *match;
 }
 
+ptrdiff_t LookupTable::getIndex(const LookupRow &lookupRow) const noexcept {
+  if (auto found = std::find(m_lookupRows.cbegin(), m_lookupRows.cend(), lookupRow); found != m_lookupRows.cend()) {
+    return std::distance(m_lookupRows.cbegin(), found);
+  }
+  // TODO: Think of a proper return when we find nothing
+  return -1;
+}
+
 std::vector<LookupRow::ValueArray> LookupTable::toValueArray() const {
   auto result = std::vector<LookupRow::ValueArray>();
   std::transform(m_lookupRows.cbegin(), m_lookupRows.cend(), std::back_inserter(result),

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/LookupTable.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/LookupTable.cpp
@@ -117,12 +117,11 @@ boost::optional<LookupRow> LookupTable::findWildcardLookupRow() const {
     return *match;
 }
 
-ptrdiff_t LookupTable::getIndex(const LookupRow &lookupRow) const noexcept {
+ptrdiff_t LookupTable::getIndex(const LookupRow &lookupRow) const {
   if (auto found = std::find(m_lookupRows.cbegin(), m_lookupRows.cend(), lookupRow); found != m_lookupRows.cend()) {
     return std::distance(m_lookupRows.cbegin(), found);
   }
-  // TODO: Think of a proper return when we find nothing
-  return -1;
+  throw std::out_of_range("Lookup row not found.");
 }
 
 std::vector<LookupRow::ValueArray> LookupTable::toValueArray() const {

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/LookupTable.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/LookupTable.cpp
@@ -117,9 +117,11 @@ boost::optional<LookupRow> LookupTable::findWildcardLookupRow() const {
     return *match;
 }
 
-ptrdiff_t LookupTable::getIndex(const LookupRow &lookupRow) const {
+size_t LookupTable::getIndex(const LookupRow &lookupRow) const {
   if (auto found = std::find(m_lookupRows.cbegin(), m_lookupRows.cend(), lookupRow); found != m_lookupRows.cend()) {
-    return std::distance(m_lookupRows.cbegin(), found);
+    auto index = std::distance(m_lookupRows.cbegin(), found);
+    assert(index >= 0);
+    return static_cast<size_t>(index);
   }
   throw std::out_of_range("Lookup row not found.");
 }

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/LookupTable.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/LookupTable.h
@@ -28,9 +28,10 @@ public:
   LookupTable(std::vector<LookupRow> rowsIn);
   LookupTable(std::initializer_list<LookupRow> rowsIn);
 
-  std::vector<LookupRow> const &rows() const;
   boost::optional<LookupRow> findLookupRow(Row const &row, double tolerance) const;
   boost::optional<LookupRow> findWildcardLookupRow() const;
+  ptrdiff_t getIndex(LookupRow const &) const noexcept;
+  std::vector<LookupRow> const &rows() const;
   std::vector<LookupRow::ValueArray> toValueArray() const;
 
   friend bool operator==(LookupTable const &lhs, LookupTable const &rhs);

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/LookupTable.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/LookupTable.h
@@ -30,7 +30,7 @@ public:
 
   boost::optional<LookupRow> findLookupRow(Row const &row, double tolerance) const;
   boost::optional<LookupRow> findWildcardLookupRow() const;
-  ptrdiff_t getIndex(LookupRow const &) const;
+  size_t getIndex(LookupRow const &) const;
   std::vector<LookupRow> const &rows() const;
   std::vector<LookupRow::ValueArray> toValueArray() const;
 

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/LookupTable.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/LookupTable.h
@@ -30,7 +30,7 @@ public:
 
   boost::optional<LookupRow> findLookupRow(Row const &row, double tolerance) const;
   boost::optional<LookupRow> findWildcardLookupRow() const;
-  ptrdiff_t getIndex(LookupRow const &) const noexcept;
+  ptrdiff_t getIndex(LookupRow const &) const;
   std::vector<LookupRow> const &rows() const;
   std::vector<LookupRow::ValueArray> toValueArray() const;
 

--- a/qt/scientific_interfaces/ISISReflectometry/test/Reduction/LookupTableTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Reduction/LookupTableTest.h
@@ -216,7 +216,13 @@ public:
     TS_ASSERT_EQUALS(table.getIndex(lookupRow), 1);
   }
 
-  // TODO handle a missing lookup row
+  void test_get_index_for_missing_lookup_row() {
+    auto constexpr angle = 2.3;
+    auto const lookupRow = ModelCreationHelper::makeLookupRow(angle, boost::regex("A.*"));
+    auto table = LookupTable{ModelCreationHelper::makeLookupRow(angle, boost::regex(".*")),
+                             ModelCreationHelper::makeLookupRow(angle, boost::regex("AA.*"))};
+    TS_ASSERT_THROWS(table.getIndex(lookupRow), std::out_of_range const &);
+  }
 
 private:
   const double m_exactMatchTolerance = 1e-6;

--- a/qt/scientific_interfaces/ISISReflectometry/test/Reduction/LookupTableTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Reduction/LookupTableTest.h
@@ -208,6 +208,16 @@ public:
     TS_ASSERT_THROWS(table.findLookupRow(*group[0], m_exactMatchTolerance), MultipleRowsFoundException const &)
   }
 
+  void test_get_index_for_lookup_row() {
+    auto constexpr angle = 2.3;
+    auto const lookupRow = ModelCreationHelper::makeLookupRow(angle, boost::regex("A.*"));
+    auto table = LookupTable{ModelCreationHelper::makeLookupRow(angle, boost::regex(".*")), lookupRow,
+                             ModelCreationHelper::makeLookupRow(angle, boost::regex("AA.*"))};
+    TS_ASSERT_EQUALS(table.getIndex(lookupRow), 1);
+  }
+
+  // TODO handle a missing lookup row
+
 private:
   const double m_exactMatchTolerance = 1e-6;
 };


### PR DESCRIPTION
**Description of work.**
This will be useful for including a way to see which of the lookup rows was used for a given run. 

**To test:**

<!-- Instructions for testing. -->

1. not yet implemented, so check unit tests pass

Fixes #33623 


*This does not require release notes* because **changes not user facing**


<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
