### PR TITLE
Fix CMake option call to set expected initial values

### DIFF
--- a/buildconfig/CMake/Eigen.cmake
+++ b/buildconfig/CMake/Eigen.cmake
@@ -12,11 +12,11 @@ else()
     GIT_PROGRESS TRUE
   )
 
-  option(EIGEN_BUILD_DOC OFF)
-  option(BUILD_TESTING OFF)
-  option(EIGEN_LEAVE_TEST_IN_ALL_TARGET OFF)
-  option(EIGEN_BUILD_PKGCONFIG OFF)
-  option(EIGEN_TEST_NOQT ON) # Only used in demos and tests
+  option(EIGEN_BUILD_DOC "" OFF)
+  option(BUILD_TESTING "" OFF)
+  option(EIGEN_LEAVE_TEST_IN_ALL_TARGET "" OFF)
+  option(EIGEN_BUILD_PKGCONFIG "" OFF)
+  option(EIGEN_TEST_NOQT "" ON) # Only used in demos and tests
 
   # Preserve shared attrs
   set(CMAKE_INSTALL_PREFIX_OLD ${CMAKE_INSTALL_PREFIX})


### PR DESCRIPTION
**Description of work.**

See commit message for details.

**To test:**

This will require either an empty build directory or removing the CMakeCache.txt and only applies to non-conda builds.

* Run CMake as you would an observe there are not longer warnings related the Qt4.

*There is no associated issue.*

*This does not require release notes* because **it is not a user-facing change.**

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
