### PR TITLE
Fix container history check in SNSPowderReduction

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/SNSPowderReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/SNSPowderReduction.py
@@ -512,7 +512,7 @@ class SNSPowderReduction(DistributedDataProcessorAlgorithm):
             if can_run_ws_name in mtd:
                 hstry = mtd[can_run_ws_name].getHistory()
                 if not hstry.empty():
-                    alg = hstry.getAlgorithm(0)
+                    alg = hstry.getAlgorithmHistory(0)
                     if alg.name() == "SNSPowderReduction":
                         if alg.getPropertyValue("TypeOfCorrection") != self._absMethod:
                             self.log().information(

--- a/docs/source/release/v6.4.0/Diffraction/Powder/Bugfixes/33646.rst
+++ b/docs/source/release/v6.4.0/Diffraction/Powder/Bugfixes/33646.rst
@@ -1,0 +1,1 @@
+- Fixed an issue in :ref:`SNSPowderReduction <algm-SNSPowderReduction>` causing a failure if a reduction was repeated twice.


### PR DESCRIPTION
**Description of work.**

Fixes an issue in `SNSPowderReduction` where running a reduction twice would fail when retrieving the history of the existing container workspace. This changes the history check to use `getAlgorithmHistory()`.


<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**

<!-- Instructions for testing. -->

Run the Powder Diffraction Reduction with [snspowderreduction.xml.txt](https://github.com/mantidproject/mantid/files/8224800/snspowderreduction.xml.txt). Run the reduction again, this should no longer throw an exception when running.

Fixes [PD411](https://code.ornl.gov/sns-hfir-scse/diffraction/powder/powder-diffraction/-/issues/411)


<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

Version into `ornl-next`: #33647 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
