### PR TITLE
Fix container history check in SNSPowderReduction ornl-next

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/SNSPowderReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/SNSPowderReduction.py
@@ -512,7 +512,7 @@ class SNSPowderReduction(DistributedDataProcessorAlgorithm):
             if can_run_ws_name in mtd:
                 hstry = mtd[can_run_ws_name].getHistory()
                 if not hstry.empty():
-                    alg = hstry.getAlgorithm(0)
+                    alg = hstry.getAlgorithmHistory(0)
                     if alg.name() == "SNSPowderReduction":
                         if alg.getPropertyValue("TypeOfCorrection") != self._absMethod:
                             self.log().information(

--- a/docs/source/release/v6.4.0/Diffraction/Powder/Bugfixes/33646.rst
+++ b/docs/source/release/v6.4.0/Diffraction/Powder/Bugfixes/33646.rst
@@ -1,0 +1,1 @@
+- Fixed an issue in :ref:`SNSPowderReduction <algm-SNSPowderReduction>` causing a failure if a reduction was repeated twice.


### PR DESCRIPTION
Version of #33646 into `ornl-next`.

Refer to [PD411](https://code.ornl.gov/sns-hfir-scse/diffraction/powder/powder-diffraction/-/issues/411).