### PR TITLE
Log a warning when using default settings for live data

### DIFF
--- a/docs/source/release/v6.4.0/Reflectometry/New_features/33651.rst
+++ b/docs/source/release/v6.4.0/Reflectometry/New_features/33651.rst
@@ -1,0 +1,1 @@
+- The ISIS Reflectometry interface now log a warning if starting live data will use potentially unexpected settings

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/RowProcessingAlgorithm.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/RowProcessingAlgorithm.cpp
@@ -210,6 +210,37 @@ void updateRowFromOutputProperties(const IAlgorithm_sptr &algorithm, Item &item)
                          getDouble(algorithm, "MomentumTransferMax"));
   row.setOutputQRange(qRange);
 }
+
+// Get the lookup row from the model. Because using a wildcard row or algorithm defaults
+// can be confusing this function also logs warnings about what is happening.
+boost::optional<LookupRow> findLookupRow(Row const &row, IBatch const &model) {
+  auto lookupRow = model.findLookupRow(row);
+  if (!lookupRow) {
+    g_log.warning(
+        "No matching experiment settings found for " + boost::algorithm::join(row.runNumbers(), ", ") +
+        ". Using algorithm default settings instead. You may wish to check that all lookup criteria on the Experiment "
+        "Settings table are correct.");
+  } else if (lookupRow->isWildcard()) {
+    g_log.warning(
+        "No matching experiment settings found for " + boost::algorithm::join(row.runNumbers(), ", ") +
+        ". Using wildcard row settings instead. You may wish to check that all lookup criteria on the Experiment "
+        "Settings table are correct.");
+  }
+  return lookupRow;
+}
+
+// Get the wildcard lookup row from the model. Because using a wildcard row or algorithm defaults
+// can be confusing this function also logs warnings about what is happening.
+boost::optional<LookupRow> findWildcardLookupRow(IBatch const &model) {
+  auto lookupRow = model.findWildcardLookupRow();
+  if (lookupRow) {
+    g_log.warning("Using experiment settings from the wildcard row.");
+  } else {
+    g_log.warning("No experiment settings found; using algorithm defaults. You may wish to specify a wildcard"
+                  " row in the Experiment Settings table to override them.");
+  }
+  return lookupRow;
+}
 } // unnamed namespace
 
 /** Create a configured algorithm for processing a row. The algorithm
@@ -232,33 +263,30 @@ IConfiguredAlgorithm_sptr createConfiguredAlgorithm(IBatch const &model, Row &ro
   return jobAlgorithm;
 }
 
+/** This function gets the canonical set of properties for performing the reduction, either using defaults for all runs
+ * or for a specific run if that run's Row is passed. It starts with the most generic set of defaults, overrides them
+ * from the lookup table if a match is found there, and then finally overrides them with the specific run's settings if
+ * the user has specified them on the Runs table.
+ *
+ * @param model : the Batch model containing all of the default settings and the lookup table
+ * @param row : optional run details from the Runs table
+ * @returns : a custom PropertyManager class with all of the algorithm properties set
+ */
 std::unique_ptr<MantidQt::API::IAlgorithmRuntimeProps> createAlgorithmRuntimeProps(IBatch const &model,
-                                                                                   Row const &row) {
-  // Create properties for the model
-  auto properties = createAlgorithmRuntimeProps(model);
-  // Update properties specific to this row - the per-angle options based on
-  // the known angle, and the values in the table cells in the row
-  if (auto lookupRow = model.findLookupRow(row)) {
-    updateLookupRowProperties(*properties, *lookupRow);
-  }
-  updateRowProperties(*properties, row);
-  return properties;
-}
-
-std::unique_ptr<MantidQt::API::IAlgorithmRuntimeProps> createAlgorithmRuntimeProps(IBatch const &model) {
+                                                                                   boost::optional<Row const &> row) {
   auto properties = std::make_unique<MantidQt::API::AlgorithmRuntimeProps>();
-  // Update properties from settings in the event, experiment and instrument
-  // tabs
+  // Update properties from settings in the event, experiment and instrument tabs
   updateEventProperties(*properties, model.slicing());
   updateExperimentProperties(*properties, model.experiment());
   updateInstrumentProperties(*properties, model.instrument());
-  // Update properties from the wildcard row in the lookup table
-  if (auto lookupRow = model.findWildcardLookupRow()) {
-    g_log.warning("Using experiment settings from the wildcard row.");
+  // Look up properties for this run on the lookup table (or use wildcard defaults if no run is given)
+  auto lookupRow = row ? findLookupRow(*row, model) : findWildcardLookupRow(model);
+  if (lookupRow) {
     updateLookupRowProperties(*properties, *lookupRow);
-  } else {
-    g_log.warning("No experiment settings found; using algorithm defaults. You may wish to specify a wildcard"
-                  " row in the Experiment Settings table to override them.");
+  }
+  // Update properties the user has specifically set for this run
+  if (row) {
+    updateRowProperties(*properties, *row);
   }
   return properties;
 }

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/RowProcessingAlgorithm.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/RowProcessingAlgorithm.h
@@ -27,7 +27,5 @@ namespace MantidQt::CustomInterfaces::ISISReflectometry::RowProcessing {
 MANTIDQT_ISISREFLECTOMETRY_DLL MantidQt::API::IConfiguredAlgorithm_sptr createConfiguredAlgorithm(IBatch const &model,
                                                                                                   Row &row);
 MANTIDQT_ISISREFLECTOMETRY_DLL std::unique_ptr<MantidQt::API::IAlgorithmRuntimeProps>
-createAlgorithmRuntimeProps(IBatch const &model, Row const &row);
-MANTIDQT_ISISREFLECTOMETRY_DLL std::unique_ptr<MantidQt::API::IAlgorithmRuntimeProps>
-createAlgorithmRuntimeProps(IBatch const &model);
+createAlgorithmRuntimeProps(IBatch const &model, boost::optional<Row const &> row = boost::none);
 } // namespace MantidQt::CustomInterfaces::ISISReflectometry::RowProcessing

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/RunsPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/RunsPresenter.cpp
@@ -12,14 +12,12 @@
 #include "GUI/RunsTable/RunsTablePresenter.h"
 #include "IRunsView.h"
 #include "MantidAPI/AlgorithmManager.h"
+#include "MantidKernel/Logger.h"
 #include "MantidQtWidgets/Common/AlgorithmRunner.h"
 #include "MantidQtWidgets/Common/ProgressPresenter.h"
 #include "QtCatalogSearcher.h"
 
 #include <algorithm>
-#include <fstream>
-#include <iterator>
-#include <sstream>
 #include <utility>
 #include <vector>
 
@@ -28,6 +26,10 @@
 using namespace Mantid::API;
 using namespace Mantid::Kernel;
 using namespace MantidQt::MantidWidgets;
+
+namespace {
+Mantid::Kernel::Logger g_log("Reflectometry RunsPresenter");
+} // namespace
 
 namespace MantidQt::CustomInterfaces::ISISReflectometry {
 
@@ -474,6 +476,7 @@ std::string RunsPresenter::liveDataReductionAlgorithm() { return "ReflectometryR
 
 std::string RunsPresenter::liveDataReductionOptions(const std::string &inputWorkspace, const std::string &instrument) {
   // Get the properties for the reduction algorithm from the settings tabs
+  g_log.warning("Note that lookup of experiment settings by angle/title is not supported for live data.");
   auto options = m_mainPresenter->rowProcessingProperties();
   // Add other required input properties to the live data reduction algorithnm
   options->setPropertyValue("InputWorkspace", inputWorkspace);

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/LookupTable.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/LookupTable.cpp
@@ -7,7 +7,6 @@
 
 #include "LookupTable.h"
 #include "IGroup.h"
-#include "MantidKernel/Logger.h"
 #include "Row.h"
 #include <boost/optional.hpp>
 #include <boost/regex.hpp>
@@ -20,8 +19,6 @@ constexpr double EPSILON = std::numeric_limits<double>::epsilon();
 bool equalWithinTolerance(double val1, double val2, double tolerance) {
   return std::abs(val1 - val2) <= (tolerance + EPSILON);
 }
-
-Mantid::Kernel::Logger g_log("Reflectometry Lookup Table");
 } // namespace
 
 namespace MantidQt::CustomInterfaces::ISISReflectometry {
@@ -48,17 +45,6 @@ boost::optional<LookupRow> LookupTable::findLookupRow(Row const &row, double tol
   // If we didn't find a lookup row where theta matches, then we allow the user to specify a "wildcard" row
   // which will be used for everything where a specific match is not found
   auto result = findWildcardLookupRow();
-  if (result) {
-    g_log.warning(
-        "No matching experiment settings found for " + boost::algorithm::join(row.runNumbers(), ", ") +
-        ". Using wildcard row settings instead. You may wish to check that all lookup criteria on the Experiment "
-        "Settings table are correct.");
-    return result;
-  }
-  g_log.warning(
-      "No matching experiment settings found for " + boost::algorithm::join(row.runNumbers(), ", ") +
-      ". Using algorithm default settings instead. You may wish to check that all lookup criteria on the Experiment "
-      "Settings table are correct.");
   return result;
 }
 


### PR DESCRIPTION
**Report to:** Max at ISIS

**Description of work.**

This PR adds warnings if potentially unexpected settings are used when running the live data monitor from the ISIS Reflectometry interface.

I've added warnings both in the RunsPresenter when requesting the defaults, as well as in createAlgorithmRuntimeProps when it searches for the wildcard row. The former allows us to warn specifically about live data, and the latter to say specifically which defaults are used. Although this is slight duplication I think it is better to be over-informative here because it is very confusing if unexpected defaults get used. The latter function is not used anywhere else at the moment but the warnings will still make sense if it is in the future.

The warnings will appear consecutively and are written such that they make sense together and look like a single message:
![image](https://user-images.githubusercontent.com/12895056/157718158-0585a940-de47-4f35-83ba-6ebe8ac43c0a.png)

**To test:**

*Live data*

- Open the ISIS Reflectometry interface
- Click Start Monitor
- This warning about using a wildcard row should appear in the log:
```
Note that lookup of experiment settings by angle/title is not supported for live data.
Using experiment settings from the wildcard row.
```
- On the Experiment Settings tab, click on the empty row and press Delete. The table should now be empty
- Back on the Runs tab click Stop Monitor (if necessary) and then Start Monitor again.
- You should now get this warning:
```
Note that lookup of experiment settings by angle/title is not supported for live data.
No experiment settings found; using algorithm defaults. You may wish to specify a wildcard row in the Experiment Settings table to override them.
```

*Normal reduction*

- Set instrument to INTER and in the table enter run `13460` and angle `0.5`
- On the Experiment Settings tab make sure there is one wildcard row (i.e. angle and title are empty)
- Back on the Runs tab, click Process. You should get a warning about using a wildcard row.
- On the lookup table, change the angle to `0.5` and re-process. There should be no warning.
- On the lookup table, delete the row so the table is empty, and re-process. There should be a warning about using algorithm defaults.

Fixes #33649

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
