### PR TITLE
Fix failing python api start on debug ubuntu

### DIFF
--- a/qt/scientific_interfaces/ISISReflectometry/test/Common/CoderCommonTester.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Common/CoderCommonTester.h
@@ -275,6 +275,60 @@ private:
   }
 };
 
+/**
+ * This fake version of the LoadAndProcess exists so we don't have to import the
+ * python API, which was causing some issues on Ubuntu when running the tests.
+ *
+ * It is only used to set the tooltips in the views from the algorithm.
+ */
+class ReflectometryISISLoadAndProcess : public Mantid::API::Algorithm {
+public:
+  ReflectometryISISLoadAndProcess() : Algorithm() {}
+  ~ReflectometryISISLoadAndProcess() override = default;
+  const std::string name() const override { return "ReflectometryISISLoadAndProcess"; }
+  int version() const override { return 1; }
+  const std::string summary() const override { return "ReflectometryISISLoadAndProcess"; }
+
+  void init() override {
+    declareProperty("FirstTransmissionRunList", "");
+    declareProperty("SecondTransmissionRunList", "");
+    declareProperty("MomentumTransferMin", "");
+    declareProperty("MomentumTransferStep", "");
+    declareProperty("MomentumTransferMax", "");
+    declareProperty("TransmissionProcessingInstructions", "");
+    declareProperty("ScaleFactor", "");
+    declareProperty("ProcessingInstructions", "");
+    declareProperty("BackgroundProcessingInstructions", "");
+    declareProperty("AnalysisMode", "");
+    declareProperty("StartOverlap", "");
+    declareProperty("EndOverlap", "");
+    declareProperty("Params", "");
+    declareProperty("ScaleRHSWorkspace", "");
+    declareProperty("PolarizationAnalysis", "");
+    declareProperty("ReductionType", "");
+    declareProperty("SummationType", "");
+    declareProperty("IncludePartialBins", "");
+    declareProperty("FloodCorrection", "");
+    declareProperty("FloodWorkspace", "");
+    declareProperty("Debug", "");
+    declareProperty("SubtractBackground", "");
+    declareProperty("BackgroundCalculationMethod", "");
+    declareProperty("DegreeOfPolynomial", "");
+    declareProperty("CostFunction", "");
+    declareProperty("NormalizeByIntegratedMonitors", "");
+    declareProperty("MonitorIntegrationWavelengthMin", "");
+    declareProperty("MonitorIntegrationWavelengthMax", "");
+    declareProperty("MonitorBackgroundWavelengthMin", "");
+    declareProperty("MonitorBackgroundWavelengthMax", "");
+    declareProperty("WavelengthMin", "");
+    declareProperty("WavelengthMax", "");
+    declareProperty("I0MonitorIndex", "");
+    declareProperty("DetectorCorrectionType", "");
+    declareProperty("CorrectDetectors", "");
+  }
+  void exec() override {}
+};
+
 } // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt

--- a/qt/scientific_interfaces/ISISReflectometry/test/Common/DecoderTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Common/DecoderTest.h
@@ -41,9 +41,10 @@ public:
   static DecoderTest *createSuite() { return new DecoderTest(); }
   static void destroySuite(DecoderTest *suite) { delete suite; }
 
-  DecoderTest() {
-    PyRun_SimpleString("import mantid.api as api\n"
-                       "api.FrameworkManager.Instance()");
+  void setUp() override { Mantid::API::AlgorithmFactory::Instance().subscribe<ReflectometryISISLoadAndProcess>(); }
+
+  void tearDown() override {
+    Mantid::API::AlgorithmFactory::Instance().unsubscribe("ReflectometryISISLoadAndProcess", 1);
   }
 
   void test_decodeMainWindow() {

--- a/qt/scientific_interfaces/ISISReflectometry/test/Common/EncoderTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Common/EncoderTest.h
@@ -25,9 +25,10 @@ public:
   static EncoderTest *createSuite() { return new EncoderTest(); }
   static void destroySuite(EncoderTest *suite) { delete suite; }
 
-  EncoderTest() {
-    PyRun_SimpleString("import mantid.api as api\n"
-                       "api.FrameworkManager.Instance()");
+  void setUp() override { Mantid::API::AlgorithmFactory::Instance().subscribe<ReflectometryISISLoadAndProcess>(); }
+
+  void tearDown() override {
+    Mantid::API::AlgorithmFactory::Instance().unsubscribe("ReflectometryISISLoadAndProcess", 1);
   }
 
   void test_encoder() {
@@ -57,6 +58,7 @@ public:
     TS_ASSERT_EQUALS(expectedVersion, map[QString("version")].toString().toStdString())
   }
 };
+
 } // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt


### PR DESCRIPTION
**Description of work.**

Attempting to initialize the framework manager from the python API (like
is done in the reflectometry Encoder and Decoder tests) was causing a
segfault due to some undefinfed behaviour as a result of certain
variables dropping out of scope between the python and C++ layer.

Importing the whole python API for a test is just silly, and is needlessly expensive. Instead, a fake algorithm is created, subscribed, and removed each time the tests run. 

**To test:**
1. Check all unit tests pass properly. 


*There is no associated issue.*

*This does not require release notes* because **the change only affects unit tests.**


<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
