### PR TITLE
Improve Handling of Empty Group Titles

### DIFF
--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/LookupTable.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/LookupTable.cpp
@@ -98,9 +98,8 @@ std::vector<LookupRow> LookupTable::findEmptyRegexes() const {
 }
 
 std::vector<LookupRow> LookupTable::searchByTitle(Row const &row) const {
-  if (!row.getParent() || row.getParent()->name().empty()) {
-    // No titles for us to check against, so skip filtering
-    return m_lookupRows;
+  if (!row.getParent()) {
+    return findMatchingRegexes("");
   }
 
   auto const &title = row.getParent()->name();

--- a/qt/scientific_interfaces/ISISReflectometry/test/Reduction/LookupTableTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Reduction/LookupTableTest.h
@@ -167,6 +167,18 @@ public:
     TS_ASSERT_EQUALS(emptyRegexRow, foundLookupRow)
   }
 
+  void test_empty_title_matches_only_empty_regex() {
+    auto constexpr angle = 2.3;
+    auto emptyRegexRow = ModelCreationHelper::makeLookupRow(angle, boost::none);
+    auto regexRow = ModelCreationHelper::makeLookupRow(angle, boost::regex("Ay"));
+    auto table = LookupTable{emptyRegexRow, regexRow};
+
+    auto group = Group("", {ModelCreationHelper::makeRow(angle)});
+    const auto foundLookupRow = table.findLookupRow(*group[0], m_exactMatchTolerance);
+    TS_ASSERT(foundLookupRow);
+    TS_ASSERT_EQUALS(emptyRegexRow, foundLookupRow);
+  }
+
   void test_get_wildcard_row_returns_wildcard_row() {
     auto constexpr angle = 2.3;
     auto wildcardRow = ModelCreationHelper::makeWildcardLookupRow();


### PR DESCRIPTION
**Description of work.**

Empty titles now match only empty regexes, rather than the previous
confusing behaviour of matching all title matcher regexes.

**To test:**
1. Load up the reflectometry interface
2. Load a batch from the sample data
3. Remove the title from one of the groups to make it blank (the cells with the drop-down arrows)
4. Switch to the Experiment settings tab
5. With two rows (you may need to add one) set one to have an angle of 2.3 and leave the title blank, set the other to 2.3 and set the title to any non-empty string
6. Set the d/q values to two different numbers, such a 0.01 (you will use this for checking)
7. Return to the runs tab and click process
8. Check that the empty group took the value from the row with the empty title matcher

Fixes #33584 


*This does not require release notes* because **it is part of new functionality.**


<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
