### PR TITLE
Pin back pre-commit due to incompatibilities on windows

### DIFF
--- a/mantid-developer-win.yml
+++ b/mantid-developer-win.yml
@@ -47,4 +47,4 @@ dependencies:
   - zlib>=1.2.11
   # Needed only for development
   - cppcheck==2.5
-  - pre-commit>=2.12.0
+  - pre-commit==2.15 # Had to pin back to 2.15 as we can't handle changes made here (https://github.com/pre-commit/pre-commit/pull/2065 added in 2.16) on windows yet.


### PR DESCRIPTION
**Description of work.**
ad to pin back to 2.15 as we can't handle changes made here (https://github.com/pre-commit/pre-commit/pull/2065 added in 2.16) on windows yet. Longer term we should change how we handle windows pre-commit, but we have no reason to put in the work yet.

**To test:**
- Create a fresh conda environment in windows
- Using a fresh clone of the mantid source configure cmake
- Change some code and try to commit these changes
- Pre-commit should run

<!-- Instructions for testing. -->
*There is no associated issue.*

*This does not require release notes* because **Not user facing**



<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
