### PR TITLE
bugfix: Abins TOSCA detector banks mislabelled

### DIFF
--- a/docs/source/release/v6.4.0/Indirect/Bugfixes/33681.rst
+++ b/docs/source/release/v6.4.0/Indirect/Bugfixes/33681.rst
@@ -1,0 +1,6 @@
+An error is fixed in Abins. This relates to the assignment of
+"Forward" and "Backward" detector settings for TOSCA, which were
+reversed from their conventional definition. The default behaviour has
+not changed: results will only be affected for calculations which
+explicitly selected the "Forward (TOSCA)" or "Backward (TOSCA)"
+options.

--- a/scripts/abins/parameters.py
+++ b/scripts/abins/parameters.py
@@ -27,10 +27,10 @@ instruments = {
         'final_neutron_energy': 32.0,  # Final energy on the crystal analyser in cm-1
         'cos_scattering_angle': math.cos(2.356),  # Angle of the crystal analyser radians (NO LONGER USED)
         # The forward detector angle is rather specific as test-data was based on truncated value in radians
-        'settings': {'Forward (TOSCA)': {'angles': [134.98885653282196]},
-                     'Backward (TOSCA)': {'angles': [45.]},
+        'settings': {'Backward (TOSCA)': {'angles': [134.98885653282196]},
+                     'Forward (TOSCA)': {'angles': [45.]},
                      'All detectors (TOSCA)': {'angles': [45., 134.98885653282196]}},
-        'settings_default': 'Forward (TOSCA)',
+        'settings_default': 'Backward (TOSCA)',
         # TOSCA parameters for resolution function
         # sigma = tosca_a * omega * omega + tosca_b * omega + tosca_c
         # where sigma is width of Gaussian function

--- a/scripts/test/Abins/AbinsCalculateQToscaTest.py
+++ b/scripts/test/Abins/AbinsCalculateQToscaTest.py
@@ -51,7 +51,7 @@ class CalculateQToscaTest(unittest.TestCase):
 
         q2 = self._tosca_instrument.calculate_q_powder(
             input_data=freq,
-            angle=tosca_params['settings']['Forward (TOSCA)']['angles'][0])
+            angle=tosca_params['settings']['Backward (TOSCA)']['angles'][0])
 
         # noinspection PyTypeChecker
         self.assertEqual(True, np.allclose(correct_q_data, q2))


### PR DESCRIPTION
"Forward" and "Backward" are the wrong way around. The default
behaviour is unchanged, but should have been labelled "Backward".

**Description of work.**

Hopefully this will fix a discrepancy identified by Matthew Krzystyniak

**To test:**

This should mostly be covered by unit tests and system tests. To verify change from old version, run Abins with the TOSCA instrument and compare results from "Forward" and "Backward" settings.

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
