### PR TITLE
Exclude FrameworkTestHelpers from all target

### DIFF
--- a/Framework/TestHelpers/CMakeLists.txt
+++ b/Framework/TestHelpers/CMakeLists.txt
@@ -68,7 +68,7 @@ endif()
 # We use an object lib to avoid the problems with static libs and dynamic factories. As the linker will only pull in the
 # static init if the symbol is used in the executable. A DLL could be used but it requires each helper to be labelled
 # with DLL export and complexity one CMake file < DLL exports in every test helper header
-add_library(FrameworkTestHelpers OBJECT ${SRC_FILES} ${INC_FILES})
+add_library(FrameworkTestHelpers OBJECT EXCLUDE_FROM_ALL ${SRC_FILES} ${INC_FILES})
 add_library(FrameWorkTestHelpersHeaders INTERFACE)
 
 add_library(Mantid::FrameworkTestHelpers ALIAS FrameworkTestHelpers)


### PR DESCRIPTION
**Description of work.**
Update the FrameworkTestHelpers target to not build with all targets.
It should only be built with test targets instead, and this was
noticed when gtest errors appeared (for unrelated reasons) building main.

**To test:**
- On Linux or OSX (this makes testing easier)
- Manually run CMake
- Run the following, check the output is empty. This shows what files will be built by the all target:
`ninja -n -v | grep -i gtest`

There is no associated issue. Noticed by another developer

*This does not require release notes* because it's an internal change

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
