### PR TITLE
Add Controlling of Row's LookupRowIndex Values to Batch

### DIFF
--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/Batch.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/Batch.cpp
@@ -45,4 +45,12 @@ void Batch::updateLookupIndex(Row &row) {
   row.setLookupIndex(experiment().getLookupRowIndexFromRow(row, runsTable().thetaTolerance()));
 }
 
+void Batch::updateLookupIndexesOfGroup(Group &group) {
+  for (auto &row : group.mutableRows()) {
+    if (row.is_initialized()) {
+      updateLookupIndex(row.get());
+    }
+  }
+}
+
 } // namespace MantidQt::CustomInterfaces::ISISReflectometry

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/Batch.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/Batch.cpp
@@ -42,7 +42,11 @@ boost::optional<Item &> Batch::getItemWithOutputWorkspaceOrNone(std::string cons
 }
 
 void Batch::updateLookupIndex(Row &row) {
-  row.setLookupIndex(experiment().getLookupRowIndexFromRow(row, runsTable().thetaTolerance()));
+  try {
+    row.setLookupIndex(experiment().getLookupRowIndexFromRow(row, runsTable().thetaTolerance()));
+  } catch (MultipleRowsFoundException &e) {
+    row.setError(e.what());
+  }
 }
 
 void Batch::updateLookupIndexesOfGroup(Group &group) {

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/Batch.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/Batch.cpp
@@ -40,4 +40,9 @@ void Batch::resetSkippedItems() { m_runsTable.resetSkippedItems(); }
 boost::optional<Item &> Batch::getItemWithOutputWorkspaceOrNone(std::string const &wsName) {
   return m_runsTable.getItemWithOutputWorkspaceOrNone(wsName);
 }
+
+void Batch::updateLookupIndex(Row &row) {
+  row.setLookupIndex(experiment().getLookupRowIndexFromRow(row, runsTable().thetaTolerance()));
+}
+
 } // namespace MantidQt::CustomInterfaces::ISISReflectometry

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/Batch.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/Batch.cpp
@@ -53,4 +53,10 @@ void Batch::updateLookupIndexesOfGroup(Group &group) {
   }
 }
 
+void Batch::updateLookupIndexesOfTable() {
+  for (auto &group : m_runsTable.mutableReductionJobs().mutableGroups()) {
+    updateLookupIndexesOfGroup(group);
+  }
+}
+
 } // namespace MantidQt::CustomInterfaces::ISISReflectometry

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/Batch.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/Batch.h
@@ -45,6 +45,8 @@ public:
   void resetSkippedItems();
   boost::optional<Item &> getItemWithOutputWorkspaceOrNone(std::string const &wsName);
 
+  void updateLookupIndex(Row &row);
+
 private:
   Experiment const &m_experiment;
   Instrument const &m_instrument;

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/Batch.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/Batch.h
@@ -47,6 +47,7 @@ public:
 
   void updateLookupIndex(Row &row);
   void updateLookupIndexesOfGroup(Group &group);
+  void updateLookupIndexesOfTable();
 
 private:
   Experiment const &m_experiment;

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/Batch.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/Batch.h
@@ -46,6 +46,7 @@ public:
   boost::optional<Item &> getItemWithOutputWorkspaceOrNone(std::string const &wsName);
 
   void updateLookupIndex(Row &row);
+  void updateLookupIndexesOfGroup(Group &group);
 
 private:
   Experiment const &m_experiment;

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/Experiment.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/Experiment.cpp
@@ -65,6 +65,13 @@ boost::optional<LookupRow> Experiment::findLookupRow(Row const &row, double tole
 
 boost::optional<LookupRow> Experiment::findWildcardLookupRow() const { return m_lookupTable.findWildcardLookupRow(); }
 
+boost::optional<size_t> Experiment::getLookupRowIndexFromRow(Row const &row, double tolerance) const {
+  if (auto const lookupRow = m_lookupTable.findLookupRow(row, tolerance)) {
+    return m_lookupTable.getIndex(lookupRow.get());
+  }
+  return boost::none;
+}
+
 bool operator!=(Experiment const &lhs, Experiment const &rhs) { return !operator==(lhs, rhs); }
 
 bool operator==(Experiment const &lhs, Experiment const &rhs) {

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/Experiment.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/Experiment.h
@@ -58,6 +58,8 @@ public:
   boost::optional<LookupRow> findLookupRow(Row const &row, double tolerance) const;
   boost::optional<LookupRow> findWildcardLookupRow() const;
 
+  boost::optional<size_t> getLookupRowIndexFromRow(Row const &row, double tolerance) const;
+
 private:
   AnalysisMode m_analysisMode;
   ReductionType m_reductionType;

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/Row.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/Row.cpp
@@ -21,7 +21,7 @@ Row::Row(std::vector<std::string> runNumbers, double theta,
     : Item(), m_runNumbers(std::move(runNumbers)), m_theta(theta), m_qRange(std::move(qRange)), m_qRangeOutput(),
       m_scaleFactor(std::move(scaleFactor)), m_transmissionRuns(std::move(transmissionRuns)),
       m_reducedWorkspaceNames(std::move(reducedWorkspaceNames)), m_reductionOptions(std::move(reductionOptions)),
-      m_parent(nullptr) {
+      m_lookupIndex(boost::none), m_parent(nullptr) {
   std::sort(m_runNumbers.begin(), m_runNumbers.end());
 }
 

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/Row.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/Row.cpp
@@ -45,6 +45,8 @@ ReductionOptionsMap const &Row::reductionOptions() const { return m_reductionOpt
 
 ReductionWorkspaces const &Row::reducedWorkspaceNames() const { return m_reducedWorkspaceNames; }
 
+boost::optional<size_t> const &Row::lookupIndex() const { return m_lookupIndex; }
+
 void Row::setOutputNames(std::vector<std::string> const &outputNames) {
   if (outputNames.size() != 3)
     throw std::runtime_error("Invalid number of output workspaces for row");
@@ -53,6 +55,8 @@ void Row::setOutputNames(std::vector<std::string> const &outputNames) {
 }
 
 void Row::setOutputQRange(RangeInQ qRange) { m_qRangeOutput = std::move(qRange); }
+
+void Row::setLookupIndex(boost::optional<size_t> lookupIndex) { m_lookupIndex = std::move(lookupIndex); }
 
 void Row::resetOutputs() {
   m_reducedWorkspaceNames.resetOutputNames();

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/Row.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/Row.h
@@ -43,9 +43,11 @@ public:
   boost::optional<double> scaleFactor() const;
   ReductionOptionsMap const &reductionOptions() const;
   ReductionWorkspaces const &reducedWorkspaceNames() const;
+  boost::optional<size_t> const &lookupIndex() const;
 
   void setOutputNames(std::vector<std::string> const &outputNames) override;
   void setOutputQRange(RangeInQ qRange);
+  void setLookupIndex(boost::optional<size_t> lookupIndex);
   void resetOutputs() override;
   bool hasOutputWorkspace(std::string const &wsName) const;
   void renameOutputWorkspace(std::string const &oldName, std::string const &newName) override;
@@ -73,6 +75,7 @@ private:
   TransmissionRunPair m_transmissionRuns;
   ReductionWorkspaces m_reducedWorkspaceNames;
   ReductionOptionsMap m_reductionOptions;
+  boost::optional<size_t> m_lookupIndex;
   mutable IGroup *m_parent;
   friend class Encoder;
 

--- a/qt/scientific_interfaces/ISISReflectometry/TestHelpers/ModelCreationHelper.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/TestHelpers/ModelCreationHelper.cpp
@@ -376,6 +376,10 @@ LookupTable makeLookupTableWithTwoAnglesAndWildcard() {
       LookupRow(makeLookupRow(2.3))};
 }
 
+LookupTable makeLookupTableWithTwoValidDuplicateCriteria() {
+  return LookupTable{makeLookupRow(0.5, boost::regex(".*")), makeLookupRow(0.5, boost::regex("g.*"))};
+}
+
 std::map<std::string, std::string> makeStitchOptions() {
   return std::map<std::string, std::string>{{"key1", "value1"}, {"key2", "value2"}};
 }
@@ -420,6 +424,13 @@ Experiment makeEmptyExperiment() {
                     makeEmptyBackgroundSubtraction(), PolarizationCorrections(PolarizationCorrectionType::None),
                     FloodCorrections(FloodCorrectionType::Workspace), TransmissionStitchOptions(),
                     std::map<std::string, std::string>(), LookupTable());
+}
+
+Experiment makeExperimentWithValidDuplicateCriteria() {
+  return Experiment(AnalysisMode::MultiDetector, ReductionType::NonFlatSample, SummationType::SumInQ, true, true,
+                    makeBackgroundSubtraction(), makePolarizationCorrections(), makeFloodCorrections(),
+                    makeTransmissionStitchOptions(), makeStitchOptions(),
+                    makeLookupTableWithTwoValidDuplicateCriteria());
 }
 
 /* Instrument */

--- a/qt/scientific_interfaces/ISISReflectometry/TestHelpers/ModelCreationHelper.h
+++ b/qt/scientific_interfaces/ISISReflectometry/TestHelpers/ModelCreationHelper.h
@@ -78,6 +78,7 @@ MANTIDQT_ISISREFLECTOMETRY_DLL LookupTable makeEmptyLookupTable();
 MANTIDQT_ISISREFLECTOMETRY_DLL LookupTable makeLookupTable();
 MANTIDQT_ISISREFLECTOMETRY_DLL LookupTable makeLookupTableWithTwoAngles();
 MANTIDQT_ISISREFLECTOMETRY_DLL LookupTable makeLookupTableWithTwoAnglesAndWildcard();
+MANTIDQT_ISISREFLECTOMETRY_DLL LookupTable makeLookupTableWithTwoValidDuplicateCriteria();
 MANTIDQT_ISISREFLECTOMETRY_DLL std::map<std::string, std::string> makeStitchOptions();
 MANTIDQT_ISISREFLECTOMETRY_DLL std::map<std::string, std::string> makeEmptyStitchOptions();
 MANTIDQT_ISISREFLECTOMETRY_DLL BackgroundSubtraction makeBackgroundSubtraction();
@@ -89,6 +90,7 @@ MANTIDQT_ISISREFLECTOMETRY_DLL RangeInLambda makeTransmissionRunRange();
 MANTIDQT_ISISREFLECTOMETRY_DLL TransmissionStitchOptions makeEmptyTransmissionStitchOptions();
 MANTIDQT_ISISREFLECTOMETRY_DLL Experiment makeExperiment();
 MANTIDQT_ISISREFLECTOMETRY_DLL Experiment makeEmptyExperiment();
+MANTIDQT_ISISREFLECTOMETRY_DLL Experiment makeExperimentWithValidDuplicateCriteria();
 
 /* Instrument */
 MANTIDQT_ISISREFLECTOMETRY_DLL RangeInLambda makeWavelengthRange();

--- a/qt/scientific_interfaces/ISISReflectometry/test/CMakeLists.txt
+++ b/qt/scientific_interfaces/ISISReflectometry/test/CMakeLists.txt
@@ -32,6 +32,7 @@ set(TEST_FILES
     Experiment/ExperimentPresenterTest.h
     Experiment/LookupTableValidatorTest.h
     Experiment/ExperimentOptionDefaultsTest.h
+    Reduction/BatchLookupIndexTest.h
     Reduction/LookupTableTest.h
     Reduction/ReductionJobsMergeTest.h
     Reduction/RowTest.h

--- a/qt/scientific_interfaces/ISISReflectometry/test/Reduction/BatchLookupIndexTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Reduction/BatchLookupIndexTest.h
@@ -1,0 +1,63 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2022 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#pragma once
+
+#include "../../../ISISReflectometry/Reduction/Batch.h"
+#include "../../../ISISReflectometry/TestHelpers/ModelCreationHelper.h"
+#include <cxxtest/TestSuite.h>
+#include <unordered_set>
+
+using namespace MantidQt::CustomInterfaces::ISISReflectometry;
+
+class BatchLookupIndexTest : public CxxTest::TestSuite {
+public:
+  static BatchLookupIndexTest *createSuite() { return new BatchLookupIndexTest(); }
+  static void destroySuite(BatchLookupIndexTest *suite) { delete suite; }
+
+  BatchLookupIndexTest()
+      : m_instruments{"INTER", "OFFSPEC", "POLREF", "SURF", "CRISP"}, m_thetaTolerance(0.01),
+        m_experiment(ModelCreationHelper::makeExperiment()), m_instrument(ModelCreationHelper::makeInstrument()),
+        m_runsTable(m_instruments, m_thetaTolerance, ReductionJobs()), m_slicing() {}
+
+  void test_update_lookup_index_single_row_match() {
+    constexpr auto angle = 0.5;
+    auto row = ModelCreationHelper::makeRow(angle);
+    auto model = Batch(m_experiment, m_instrument, m_runsTable, m_slicing);
+    TS_ASSERT_EQUALS(row.lookupIndex(), boost::none);
+    model.updateLookupIndex(row);
+    TS_ASSERT(row.lookupIndex().is_initialized());
+    TS_ASSERT_EQUALS(row.lookupIndex().get(), size_t(1));
+  }
+
+  void test_update_lookup_index_single_row_wildcard() {
+    constexpr auto angle = 0.1;
+    auto row = ModelCreationHelper::makeRow(angle);
+    auto model = Batch(m_experiment, m_instrument, m_runsTable, m_slicing);
+    TS_ASSERT_EQUALS(row.lookupIndex(), boost::none);
+    model.updateLookupIndex(row);
+    TS_ASSERT(row.lookupIndex().is_initialized());
+    TS_ASSERT_EQUALS(row.lookupIndex().get(), size_t(0));
+  }
+
+  void test_update_lookup_index_single_row_no_match() {
+    constexpr auto angle = 0.1;
+    auto row = ModelCreationHelper::makeRow(angle);
+    auto model = Batch(ModelCreationHelper::makeEmptyExperiment(), m_instrument, m_runsTable, m_slicing);
+    TS_ASSERT_EQUALS(row.lookupIndex(), boost::none);
+    model.updateLookupIndex(row);
+    TS_ASSERT(!row.lookupIndex().is_initialized());
+    TS_ASSERT_EQUALS(row.lookupIndex(), boost::none);
+  }
+
+private:
+  std::vector<std::string> m_instruments;
+  double m_thetaTolerance;
+  Experiment m_experiment;
+  Instrument m_instrument;
+  RunsTable m_runsTable;
+  Slicing m_slicing;
+};

--- a/qt/scientific_interfaces/ISISReflectometry/test/Reduction/BatchLookupIndexTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Reduction/BatchLookupIndexTest.h
@@ -100,6 +100,23 @@ public:
     }
   }
 
+  void test_error_message_set_if_lookup_throws() {
+    constexpr auto angle = 0.5;
+    auto row = ModelCreationHelper::makeRow(angle);
+    auto group = Group("groupName");
+    group.appendRow(std::move(row));
+
+    auto exp = ModelCreationHelper::makeExperimentWithValidDuplicateCriteria();
+
+    auto model = Batch(exp, m_instrument, m_runsTable, m_slicing);
+
+    TS_ASSERT_EQUALS(group.rows()[0].get().lookupIndex(), boost::none);
+    model.updateLookupIndex(group.mutableRows()[0].get());
+    TS_ASSERT(!group.rows()[0].get().lookupIndex().is_initialized());
+    TS_ASSERT_EQUALS(group.rows()[0].get().state(), State::ITEM_ERROR);
+    TS_ASSERT_EQUALS(group.rows()[0].get().message(), "Multiple matching Experiment Setting rows")
+  }
+
 private:
   std::vector<std::string> m_instruments;
   double m_thetaTolerance;

--- a/qt/scientific_interfaces/ISISReflectometry/test/Reduction/BatchLookupIndexTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Reduction/BatchLookupIndexTest.h
@@ -53,6 +53,29 @@ public:
     TS_ASSERT_EQUALS(row.lookupIndex(), boost::none);
   }
 
+  void test_update_lookup_index_group_updates_all_rows() {
+    auto rowA = ModelCreationHelper::makeRow(0.5);
+    auto rowB = ModelCreationHelper::makeRow(2.3);
+    auto rowW = ModelCreationHelper::makeRow(1.8);
+    auto group = Group("groupName");
+    group.appendRow(std::move(rowA));
+    group.appendRow(std::move(rowB));
+    group.appendRow(std::move(rowW));
+    auto model = Batch(m_experiment, m_instrument, m_runsTable, m_slicing);
+    TS_ASSERT_EQUALS(group.mutableRows()[0].get().lookupIndex(), boost::none);
+    TS_ASSERT_EQUALS(group.mutableRows()[1].get().lookupIndex(), boost::none);
+    TS_ASSERT_EQUALS(group.mutableRows()[2].get().lookupIndex(), boost::none);
+
+    model.updateLookupIndexesOfGroup(group);
+
+    TS_ASSERT(group.mutableRows()[0].get().lookupIndex().is_initialized());
+    TS_ASSERT_EQUALS(group.mutableRows()[0].get().lookupIndex().get(), size_t(1));
+    TS_ASSERT(group.mutableRows()[1].get().lookupIndex().is_initialized());
+    TS_ASSERT_EQUALS(group.mutableRows()[1].get().lookupIndex().get(), size_t(2));
+    TS_ASSERT(group.mutableRows()[2].get().lookupIndex().is_initialized());
+    TS_ASSERT_EQUALS(group.mutableRows()[2].get().lookupIndex().get(), size_t(0));
+  }
+
 private:
   std::vector<std::string> m_instruments;
   double m_thetaTolerance;

--- a/qt/scientific_interfaces/ISISReflectometry/test/Reduction/RowTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Reduction/RowTest.h
@@ -74,4 +74,20 @@ public:
 
     row.resetState();
   }
+
+  void test_set_get_lookup_row_index() {
+    auto row = makeEmptyRow();
+    auto index = boost::optional<size_t>{1};
+    row.setLookupIndex(index);
+    TS_ASSERT(row.lookupIndex().is_initialized());
+    TS_ASSERT_EQUALS(row.lookupIndex().get(), index.get());
+  }
+
+  void test_set_get_no_lookup_row_index() {
+    auto row = makeEmptyRow();
+    auto index = boost::none;
+    row.setLookupIndex(index);
+    TS_ASSERT(!row.lookupIndex().is_initialized());
+    TS_ASSERT_EQUALS(row.lookupIndex(), boost::none);
+  }
 };


### PR DESCRIPTION
**Description of work.**

Adds some methods to batch that allow it to control which of the Rows in the runs table are updated. Details of when each method will be called are in the commit messages. 

This is part of the work to visualse which of the lookup rows will be used on each of the rows in the runs table. 

**To test:**
There are not any user facing GUI elements yet, and these methods are not called. So a simple check that the existing behaviour works is adequate. 
1. Load a batch from the ISIS sample data into the Refl gui (there is an example 
2. Add some matching criteria to the lookup table
3. Check that those rows were used when process is pressed

Fixes #33624 

*This does not require release notes* because **it is not yet user facing and is part of a larger peice of work.**


<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
