### PR TITLE
Extend FitPropertyBrowser for attributes with validators

### DIFF
--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -595,7 +595,7 @@ knownConditionTrueFalse:${CMAKE_SOURCE_DIR}/qt/widgets/common/src/FitPropertyBro
 shadowVariable:${CMAKE_SOURCE_DIR}/qt/widgets/common/src/FitPropertyBrowser.cpp:512
 shadowVariable:${CMAKE_SOURCE_DIR}/qt/widgets/common/src/FitPropertyBrowser.cpp:1801
 constParameter:${CMAKE_SOURCE_DIR}/qt/widgets/common/inc/MantidQtWidgets/Common/PropertyHandler.h:194
-useStlAlgorithm:${CMAKE_SOURCE_DIR}/qt/widgets/common/src/FitPropertyBrowser.cpp:3283
+useStlAlgorithm:${CMAKE_SOURCE_DIR}/qt/widgets/common/src/FitPropertyBrowser.cpp:3281
 useStlAlgorithm:${CMAKE_SOURCE_DIR}/qt/widgets/common/src/FitScriptGeneratorDataTable.cpp:200
 unsignedLessThanZero:${CMAKE_SOURCE_DIR}/qt/widgets/common/src/FitScriptGeneratorModel.cpp:611
 knownConditionTrueFalse:${CMAKE_SOURCE_DIR}/qt/widgets/common/src/FlowLayout.cpp:131

--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -591,11 +591,11 @@ templateRecursion:${CMAKE_SOURCE_DIR}/Framework/MDAlgorithms/src/SliceMD.cpp:300
 useStlAlgorithm:${CMAKE_SOURCE_DIR}/qt/widgets/common/src/FitDomain.cpp:97
 unreadVariable:${CMAKE_SOURCE_DIR}/qt/widgets/common/src/FitDomain.cpp:125
 knownConditionTrueFalse:${CMAKE_SOURCE_DIR}/qt/widgets/common/src/FitPropertyBrowser.cpp:862
-knownConditionTrueFalse:${CMAKE_SOURCE_DIR}/qt/widgets/common/src/FitPropertyBrowser.cpp:1634
+knownConditionTrueFalse:${CMAKE_SOURCE_DIR}/qt/widgets/common/src/FitPropertyBrowser.cpp:1644
 shadowVariable:${CMAKE_SOURCE_DIR}/qt/widgets/common/src/FitPropertyBrowser.cpp:512
-shadowVariable:${CMAKE_SOURCE_DIR}/qt/widgets/common/src/FitPropertyBrowser.cpp:1791
+shadowVariable:${CMAKE_SOURCE_DIR}/qt/widgets/common/src/FitPropertyBrowser.cpp:1801
 constParameter:${CMAKE_SOURCE_DIR}/qt/widgets/common/inc/MantidQtWidgets/Common/PropertyHandler.h:194
-useStlAlgorithm:${CMAKE_SOURCE_DIR}/qt/widgets/common/src/FitPropertyBrowser.cpp:3251
+useStlAlgorithm:${CMAKE_SOURCE_DIR}/qt/widgets/common/src/FitPropertyBrowser.cpp:3283
 useStlAlgorithm:${CMAKE_SOURCE_DIR}/qt/widgets/common/src/FitScriptGeneratorDataTable.cpp:200
 unsignedLessThanZero:${CMAKE_SOURCE_DIR}/qt/widgets/common/src/FitScriptGeneratorModel.cpp:611
 knownConditionTrueFalse:${CMAKE_SOURCE_DIR}/qt/widgets/common/src/FlowLayout.cpp:131

--- a/docs/source/release/v6.4.0/Framework/Fit_Functions/New_features/33691.rst
+++ b/docs/source/release/v6.4.0/Framework/Fit_Functions/New_features/33691.rst
@@ -1,0 +1,5 @@
+- New feature: Functions have been extended to allow for Function Attribute Validators. This feature further extends to the FitPropertyBrowser.
+  This allows the value of attributes to be restricted in numerous ways, using validators already available in the Mantid Kernel. Examples of validation include (but are not limited to):
+    - A numeric value being bound by a numeric min/max.
+    - A string value having to be be selected from a list of possible values.
+    - A string value being required to contain specific sub-strings.

--- a/docs/source/release/v6.4.0/Workbench/New_features/33691.rst
+++ b/docs/source/release/v6.4.0/Workbench/New_features/33691.rst
@@ -1,0 +1,2 @@
+- New feature: `FitPropertyBrowser` has been extended to allow for Function Attribute Validators.
+  This allows the value of attributes to be restricted in numerous ways such as being bounded by a numeric min/max value or to be selected from a list of values using a drop box.

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FitPropertyBrowser.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FitPropertyBrowser.h
@@ -387,6 +387,8 @@ protected slots:
 
   virtual void doubleChanged(QtProperty *prop);
 
+  void enactAttributeChange(QtProperty *prop, PropertyHandler *h);
+
 private slots:
   /// Called when one of the parameter values gets changed
   void parameterChanged(QtProperty *prop);
@@ -583,6 +585,8 @@ private:
   QtProperty *addStringProperty(const QString &name) const;
   void setStringPropertyValue(QtProperty *prop, const QString &value) const;
   QString getStringPropertyValue(QtProperty *prop) const;
+  /// Create a string list property
+  QtProperty *addStringListProperty(const QString &name, const std::vector<std::string> &allowed_values) const;
   /// Check that the properties match the function
   void checkFunction();
   /// Return the nearest allowed workspace index.

--- a/qt/widgets/common/src/FitPropertyBrowser.cpp
+++ b/qt/widgets/common/src/FitPropertyBrowser.cpp
@@ -1381,7 +1381,7 @@ void FitPropertyBrowser::doubleChanged(QtProperty *prop) {
 void FitPropertyBrowser::enactAttributeChange(QtProperty *prop, PropertyHandler *h) {
   try {
     h->setAttribute(prop);
-  } catch (IFunction::validationException &ve) {
+  } catch (IFunction::ValidationException &ve) {
     std::stringstream err_str;
     err_str << prop->propertyName().toStdString() << " - " << ve.what();
     g_log.warning(err_str.str());

--- a/qt/widgets/common/src/FitPropertyBrowser.cpp
+++ b/qt/widgets/common/src/FitPropertyBrowser.cpp
@@ -2428,10 +2428,8 @@ QtProperty *FitPropertyBrowser::addStringProperty(const QString &name) const {
  */
 QtProperty *FitPropertyBrowser::addStringListProperty(const QString &name,
                                                       const std::vector<std::string> &allowed_values) const {
-  QtProperty *prop;
   QStringList qAllowedValues;
-
-  prop = m_enumManager->addProperty(name);
+  QtProperty *prop = m_enumManager->addProperty(name);
 
   for (const auto &values : allowed_values) {
     qAllowedValues << QString::fromStdString(values);

--- a/qt/widgets/common/src/PropertyHandler.cpp
+++ b/qt/widgets/common/src/PropertyHandler.cpp
@@ -133,7 +133,7 @@ void PropertyHandler::init() {
 class CreateAttributeProperty : public Mantid::API::IFunction::ConstAttributeVisitor<QtProperty *> {
 public:
   CreateAttributeProperty(FitPropertyBrowser *browser, PropertyHandler *handler, QString name,
-                          Mantid::Kernel::IValidator_sptr validator = Mantid::Kernel::IValidator_sptr())
+                          Mantid::Kernel::IValidator_sptr validator = nullptr)
       : m_browser(browser), m_handler(handler), m_name(std::move(name)) {
     m_validator = validator;
   }

--- a/qt/widgets/common/src/PropertyHandler.cpp
+++ b/qt/widgets/common/src/PropertyHandler.cpp
@@ -21,6 +21,8 @@
 #include "MantidAPI/ParameterReference.h"
 #include "MantidAPI/ParameterTie.h"
 
+#include "MantidKernel/ListValidator.h"
+
 #include "MantidQtWidgets/Common/QtPropertyBrowser/ParameterPropertyManager.h"
 #include "MantidQtWidgets/Common/QtPropertyBrowser/qtpropertymanager.h"
 #include "MantidQtWidgets/Common/QtPropertyBrowser/qttreepropertybrowser.h"
@@ -130,13 +132,24 @@ void PropertyHandler::init() {
  */
 class CreateAttributeProperty : public Mantid::API::IFunction::ConstAttributeVisitor<QtProperty *> {
 public:
-  CreateAttributeProperty(FitPropertyBrowser *browser, PropertyHandler *handler, QString name)
-      : m_browser(browser), m_handler(handler), m_name(std::move(name)) {}
+  CreateAttributeProperty(FitPropertyBrowser *browser, PropertyHandler *handler, QString name,
+                          Mantid::Kernel::IValidator_sptr validator = Mantid::Kernel::IValidator_sptr())
+      : m_browser(browser), m_handler(handler), m_name(std::move(name)) {
+    m_validator = validator;
+  }
 
 protected:
   /// Create string property
   QtProperty *apply(const std::string &str) const override {
-    QtProperty *prop = m_browser->addStringProperty(m_name);
+    QtProperty *prop;
+
+    // if validator is string list validator, create string list property
+    if (dynamic_cast<Mantid::Kernel::StringListValidator *>(m_validator.get()) != nullptr) {
+      prop = m_browser->addStringListProperty(m_name, m_validator->allowedValues());
+    } else {
+      prop = m_browser->addStringProperty(m_name);
+    }
+
     m_browser->setStringPropertyValue(prop, QString::fromStdString(str));
     return prop;
   }
@@ -219,7 +232,7 @@ void PropertyHandler::initAttributes() {
       continue;
     QString aName = QString::fromStdString(attName);
     Mantid::API::IFunction::Attribute att = function()->getAttribute(attName);
-    CreateAttributeProperty tmp(m_browser, this, aName);
+    CreateAttributeProperty tmp(m_browser, this, aName, att.getValidator());
     QtProperty *prop = att.apply(tmp);
     m_item->property()->addSubProperty(prop);
     m_attributes << prop;
@@ -650,17 +663,41 @@ bool PropertyHandler::setParameter(QtProperty *prop) {
  */
 class SetAttribute : public Mantid::API::IFunction::AttributeVisitor<> {
 public:
-  SetAttribute(FitPropertyBrowser *browser, QtProperty *prop) : m_browser(browser), m_prop(prop) {}
+  SetAttribute(FitPropertyBrowser *browser, QtProperty *prop,
+               Mantid::Kernel::IValidator_sptr validator = Mantid::Kernel::IValidator_sptr())
+      : m_browser(browser), m_prop(prop) {
+    m_validator = validator;
+  }
 
 protected:
   /// Create string property
-  void apply(std::string &str) const override { str = m_browser->getStringPropertyValue(m_prop).toStdString(); }
+  void apply(std::string &str) const override {
+    std::string propValue = m_browser->getStringPropertyValue(m_prop).toStdString();
+
+    evaluateValidator(propValue);
+    str = propValue;
+  }
   /// Create double property
-  void apply(double &d) const override { d = m_browser->m_doubleManager->value(m_prop); }
+  void apply(double &d) const override {
+    double propValue = m_browser->m_doubleManager->value(m_prop);
+
+    evaluateValidator(propValue);
+    d = propValue;
+  }
   /// Create int property
-  void apply(int &i) const override { i = m_browser->m_intManager->value(m_prop); }
+  void apply(int &i) const override {
+    int propValue = m_browser->m_intManager->value(m_prop);
+
+    evaluateValidator(propValue);
+    i = propValue;
+  }
   /// Create bool property
-  void apply(bool &b) const override { b = m_browser->m_boolManager->value(m_prop); }
+  void apply(bool &b) const override {
+    bool propValue = m_browser->m_boolManager->value(m_prop);
+
+    evaluateValidator(propValue);
+    b = propValue;
+  }
   /// Create vector property
   void apply(std::vector<double> &v) const override {
     QList<QtProperty *> members = m_prop->subProperties();
@@ -668,12 +705,25 @@ protected:
       v.clear();
       return;
     }
+
     int newSize = m_browser->m_vectorSizeManager->value(members[0]);
-    v.resize(newSize);
     int vectorSize = members.size() - 1;
     if (vectorSize > newSize) {
       vectorSize = newSize;
     }
+
+    // if there is a validator, construct new vector for validator evaluation
+    if (m_validator != Mantid::Kernel::IValidator_sptr()) {
+      std::vector<double> newVec(newSize);
+      for (int i = 1; i < vectorSize + 1; ++i) {
+        newVec[i - 1] = m_browser->m_vectorDoubleManager->value(members[i]);
+      }
+
+      evaluateValidator(newVec);
+    }
+
+    v.resize(newSize);
+
     for (int i = 1; i < vectorSize + 1; ++i) {
       v[i - 1] = m_browser->m_vectorDoubleManager->value(members[i]);
     }
@@ -742,7 +792,7 @@ bool PropertyHandler::setAttribute(QtProperty *prop, bool resetProperties) {
     QString attName = prop->propertyName();
     try {
       Mantid::API::IFunction::Attribute att = m_fun->getAttribute(attName.toStdString());
-      SetAttribute tmp(m_browser, prop);
+      SetAttribute tmp(m_browser, prop, att.getValidator());
       att.apply(tmp);
       m_fun->setAttribute(attName.toStdString(), att);
       m_browser->compositeFunction()->checkFunction();
@@ -753,6 +803,12 @@ bool PropertyHandler::setAttribute(QtProperty *prop, bool resetProperties) {
       if (this == m_browser->m_autoBackground) {
         fit();
       }
+    } catch (Mantid::API::IFunction::validationException &ve) { // catch attribute validation error
+      initAttributes();
+      initParameters();
+
+      throw Mantid::API::IFunction::validationException(
+          ve.what()); // rethrow validation exception so it can be recaught by Fit Property Browser.
     } catch (std::exception &e) {
       initAttributes();
       initParameters();

--- a/qt/widgets/common/src/PropertyHandler.cpp
+++ b/qt/widgets/common/src/PropertyHandler.cpp
@@ -803,11 +803,11 @@ bool PropertyHandler::setAttribute(QtProperty *prop, bool resetProperties) {
       if (this == m_browser->m_autoBackground) {
         fit();
       }
-    } catch (Mantid::API::IFunction::validationException &ve) { // catch attribute validation error
+    } catch (Mantid::API::IFunction::ValidationException &ve) { // catch attribute validation error
       initAttributes();
       initParameters();
 
-      throw Mantid::API::IFunction::validationException(
+      throw Mantid::API::IFunction::ValidationException(
           ve.what()); // rethrow validation exception so it can be recaught by Fit Property Browser.
     } catch (std::exception &e) {
       initAttributes();


### PR DESCRIPTION
**Description of work.**
The `FitPropertyBrowser` has been extended to allow for Function Attribute Validators which have already been added to the `Framework` and `PythonInterface` in previous PRs.

This PR ensures that:
- Error messages thrown by the validators are printed onto the `workbench` console, providing feedback to the user.
- Any attributes validating using a `StringListValidator` can be selected by the user through the use of a combo box. This ensures only valid arguments can be input.

If other validators require the `FitFitPropertyBrowser` to handle them in a custom manner, this can be subsequently developed.

**To test:**

1.  Replace the code in `mantid\Framework\CurveFitting\inc\MantidCurveFitting\Functions\DiffRotDiscreteCircle.h` and `mantid\Framework\CurveFitting\src\Functions\DiffRotDiscreteCircle.cpp` with the respective files below.
[DiffRotDiscreteCircleH.txt](https://github.com/mantidproject/mantid/files/8333265/DiffRotDiscreteCircleH.txt)
[DiffRotDiscreteCircleCPP.txt](https://github.com/mantidproject/mantid/files/8333264/DiffRotDiscreteCircleCPP.txt)

2. Using workbench, load sample data (HRP39182) used.
3. Plot any spectrum from this sample
4. Click `Fit` to open the `FitPropertyBrowser`.
5. Right click on a peak, select `Add other function`.
6. From the combo box, select `DiffRotDiscreteCircle` and select ok (expect several function specific errors, which are not a regression).
7. Confirm that the `E` attribute can be selected using a combo box.
8. Confirm that the `Q` attribute is bound between the values of 0 and 1. Observe that appropriate error messages are printed to the console if values outside of this range are input.

Resolves #33122 and #33123.


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
