### PR TITLE
Release Editor Script

### DIFF
--- a/dev-docs/source/ReleaseChecklist.rst
+++ b/dev-docs/source/ReleaseChecklist.rst
@@ -141,7 +141,7 @@ Wednesday, 2 weeks & 3 days
 *  Switch to manual handling of release notes by running the release_editor.py script using the
    `release editor helper tool
    <https://github.com/mantidproject/mantid/blob/main/tools/ReleaseNotes/release_editor.py>`_
-   and open a pull request to put them on ``release``. The script copies all of the separate release notes under the correct heading of their upper level file, e.g. framework.rst, and moves
+   and open a pull request to put them on ``release-next``. The script copies all of the separate release notes under the correct heading of their upper level file, e.g. framework.rst, and moves
    the original release notes into a 'Used' folder. This makes it easier for the Release Editor to see which notes have been copied over and which haven't and prevents losing notes or merge conflicts.
 
 .. code-block:: bash
@@ -159,10 +159,10 @@ Tuesday, 4 days
 
 *  Review the complete set of release notes to make sure there are no glaring mistakes.
 
-After Release
--------------
+Just before release
+-------------------
 
-* Remove all separate release note files and sub-file structure to leave just the upper level release notes e.g. diffraction.rst, index.rst, framework.rst etc.
+* As one of the final steps in preparing to tag the release, remove all separate release note files and sub-file structure to leave just the upper level release notes e.g. diffraction.rst, index.rst, framework.rst etc.
 
 .. _release-manager-checklist:
 

--- a/dev-docs/source/ReleaseChecklist.rst
+++ b/dev-docs/source/ReleaseChecklist.rst
@@ -138,7 +138,18 @@ language, layout, and collecting images.
 Wednesday, 2 weeks & 3 days
 ---------------------------
 
-*  Create issues for people to neaten up the release notes and add images etc.
+*  Switch to manual handling of release notes by running the release_editor.py script using the
+   `release editor helper tool
+   <https://github.com/mantidproject/mantid/blob/main/tools/ReleaseNotes/release_editor.py>`_
+   and open a pull request to put them on ``release``. The script copies all of separate release notes under the correct heading of their upper level file, e.g. framework.rst, and moves
+   the original release notes into a 'Used' folder. This makes it easier for the Release Editor to see which notes have been copied over and which haven't and prevents losing notes or merge conflicts.
+
+.. code-block:: bash
+
+    python release_editor.py --release 6.4.0
+
+*  Neaten up the release notes and add images etc.
+*  Copy over new release notes into main files and move separate release notes into 'Used' folder when done to avoid confusion.
 *  Ensure an image for the release is found to highlight the main changes for this
    release. This can be a collage of images if there is not a big 'headline' feature
    or change.
@@ -147,6 +158,11 @@ Tuesday, 4 days
 ---------------
 
 *  Review the complete set of release notes to make sure there are no glaring mistakes.
+
+After Release
+-------------
+
+* Remove all separate release note files and sub-file structure to leave just the upper level release notes e.g. diffraction.rst, index.rst, framework.rst etc.
 
 .. _release-manager-checklist:
 

--- a/dev-docs/source/ReleaseChecklist.rst
+++ b/dev-docs/source/ReleaseChecklist.rst
@@ -141,7 +141,7 @@ Wednesday, 2 weeks & 3 days
 *  Switch to manual handling of release notes by running the release_editor.py script using the
    `release editor helper tool
    <https://github.com/mantidproject/mantid/blob/main/tools/ReleaseNotes/release_editor.py>`_
-   and open a pull request to put them on ``release``. The script copies all of separate release notes under the correct heading of their upper level file, e.g. framework.rst, and moves
+   and open a pull request to put them on ``release``. The script copies all of the separate release notes under the correct heading of their upper level file, e.g. framework.rst, and moves
    the original release notes into a 'Used' folder. This makes it easier for the Release Editor to see which notes have been copied over and which haven't and prevents losing notes or merge conflicts.
 
 .. code-block:: bash

--- a/tools/ReleaseNotes/release_editor.py
+++ b/tools/ReleaseNotes/release_editor.py
@@ -6,15 +6,17 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 
 import os
+import pathlib
 import sys
-import shutil
+
 
 DIRECTIVE = ".. amalgamate:: "
 
 
-def getReleaseRoot():
-    script_dir = os.path.split(sys.argv[0])[0]
-    return os.path.abspath(os.path.join(script_dir, '../../docs/source/release/'))
+def getReleaseRoot() -> pathlib.Path:
+    program_path = pathlib.Path((sys.argv[0])[0])
+    script_dir = program_path / '../../../docs/source/release/'
+    return script_dir.resolve()
 
 
 def fixReleaseName(name):
@@ -23,47 +25,43 @@ def fixReleaseName(name):
     return name
 
 
-def createFileLocation(releaseNo):
-    release_root = getReleaseRoot()
-    release_root = release_root + '/' + releaseNo
-    return release_root
+def createFileLocation(releaseNo) -> pathlib.Path:
+    return getReleaseRoot() / releaseNo
 
 
 def updateFile(originalFile, replaceText, textToReplace):
     # opens the upper level release note e.g. diffraction.rst
-    mainRST = open(originalFile, 'r')
-    rstToRead = mainRST.read()
-    mainRST.close()
+    with open(originalFile, mode='r') as mainRST:
+        rstToRead = mainRST.read()
+        mainRST.close()
 
     # replaces the amalgamate directive with the notes compiled for that heading
     newdata = rstToRead.replace(textToReplace, replaceText)
 
-    mainRST = open(originalFile, 'w')
-    mainRST.write(newdata)
-    mainRST.close()
+    with open(originalFile, mode='w') as mainRST:
+        mainRST.write(newdata)
+        mainRST.close()
 
 
-def createFileName(fileName, pathDirectory, includeStatement):
+def createFileName(fileName, pathDirectory, includeStatement) -> pathlib.Path:
     newFileName = fileName.replace(includeStatement, "")
     newFileName = newFileName.replace("\n", "")
-    newFileName = pathDirectory + '/' + newFileName
-    return os.path.normpath(newFileName)
+    newFileName = pathDirectory / newFileName
+    return newFileName
 
 
 def addReleaseNotesToMain(pathDirectory):
     # iterates through files in a directory
-    for file in os.listdir(pathDirectory):
-        # only copy from .rst files
-        if file.endswith(".rst"):
-            with open(mainDirectory + '/' + file) as fileToEdit:
-                # iterate through each line in the upper level release note file e.g. diffraction.rst
-                for line in fileToEdit:
-                    # finds the amalgamate directive to replace
-                    if line.startswith(DIRECTIVE):
-                        fileName = createFileName(line, pathDirectory, DIRECTIVE)
-                        releaseNotes = collateNotes(fileName)
-                        originalFile = mainDirectory + '/' + file
-                        updateFile(originalFile, releaseNotes, line)
+    for file in pathDirectory.glob('*.rst'):
+        with open(file) as fileToEdit:
+            # iterate through each line in the upper level release note file e.g. diffraction.rst
+            for line in fileToEdit:
+                # finds the amalgamate directive to replace
+                if line.startswith(DIRECTIVE):
+                    fileName = createFileName(line, pathDirectory, DIRECTIVE)
+                    releaseNotes = collateNotes(fileName)
+                    originalFile = mainDirectory / file
+                    updateFile(originalFile, releaseNotes, line)
 
 
 def getReleaseNoteDirectories(path, directoryList):
@@ -73,7 +71,8 @@ def getReleaseNoteDirectories(path, directoryList):
 
     # add dir to directorylist if it contains .rst files
     if len([f for f in os.listdir(path) if f.endswith('.rst')]) > 0:
-        directoryList.append(os.path.normpath(path))
+        path = pathlib.Path(path)
+        directoryList.append(path)
 
     for d in os.listdir(path):
         new_path = os.path.join(path, d)
@@ -86,7 +85,7 @@ def getReleaseNoteDirectories(path, directoryList):
 def checkContainsReleaseNote(path):
     releaseNoteList = []
     getReleaseNoteDirectories(path, releaseNoteList)
-    releaseNoteList.remove(path)
+    releaseNoteList.pop(0)
     return releaseNoteList
 
 
@@ -94,12 +93,11 @@ def checkContainsReleaseNote(path):
 def collateNotes(path):
     combinedRst = ""
     filesScanned = []
-    for file in os.listdir(path):
-        if file.endswith(".rst"):
-            filesScanned.append(file)
-            with open(path + '/' + file) as f:
-                contents = f.read().rstrip()
-                combinedRst = combinedRst + "\n" + contents
+    for file in path.glob('*.rst'):
+        filesScanned.append(file)
+        with open(file) as f:
+            contents = f.read().rstrip()
+            combinedRst = combinedRst + "\n" + contents
     combinedRst = combinedRst.strip() + "\n"
     return combinedRst
 
@@ -107,12 +105,11 @@ def collateNotes(path):
 # Moves the release note files that have been copied to top level file into 'Used' folders
 def moveFiles(listOfDirectories):
     for path in listOfDirectories:
-        os.makedirs(path + '/' + 'Used')
-        for file in os.listdir(path):
-            if file.endswith(".rst"):
-                currentFileLocation = path + '/' + file
-                newFileLocation = path + '/Used/' + file
-                shutil.move(currentFileLocation, newFileLocation)
+        usedDir = path / 'Used'
+        usedDir.mkdir(parents=True, exist_ok=True)
+        for file in path.glob('*.rst'):
+            used_folder = 'Used'
+            file.rename(path / used_folder / file.name)
 
 
 if __name__ == '__main__':
@@ -122,7 +119,7 @@ if __name__ == '__main__':
     args = parser.parse_args()
 
     args.release = fixReleaseName(args.release)
-    mainDirectory = os.path.normpath(createFileLocation(args.release))
+    mainDirectory = createFileLocation(args.release)
     directoriesUsed = checkContainsReleaseNote(mainDirectory)
 
     addReleaseNotesToMain(mainDirectory)

--- a/tools/ReleaseNotes/release_editor.py
+++ b/tools/ReleaseNotes/release_editor.py
@@ -48,17 +48,18 @@ def createFileName(fileName, pathDirectory, includeStatement):
     return os.path.normpath(newFileName)
 
 
-def addReleaseNotesToMain(pathDirectory, listOfDirectories):
+def addReleaseNotesToMain(pathDirectory):
+    # iterates through files in a directory
     for file in os.listdir(pathDirectory):
+        # only copy from .rst files
         if file.endswith(".rst"):
             with open(mainDirectory + '/' + file) as fileToEdit:
+                # iterate through each line in the upper level release note file e.g. diffraction.rst
                 for line in fileToEdit:
+                    # finds the amalgamate directive to replace
                     if line.startswith(directive):
                         fileName = createFileName(line, pathDirectory, directive)
-                        if fileName in listOfDirectories:
-                            releaseNotes = collateNotes(fileName)
-                        else:
-                            releaseNotes = ""
+                        releaseNotes = collateNotes(fileName)
                         originalFile = mainDirectory + '/' + file
                         updateFile(originalFile, releaseNotes, line)
 
@@ -123,5 +124,5 @@ if __name__ == '__main__':
     directive = ".. amalgamate:: "
     directoriesUsed = checkContainsReleaseNote(mainDirectory)
 
-    addReleaseNotesToMain(mainDirectory, directoriesUsed)
+    addReleaseNotesToMain(mainDirectory)
     moveFiles(directoriesUsed)

--- a/tools/ReleaseNotes/release_editor.py
+++ b/tools/ReleaseNotes/release_editor.py
@@ -95,8 +95,9 @@ def collateNotes(path):
         if file.endswith(".rst"):
             filesScanned.append(file)
             with open(path + '/' + file) as f:
-                contents = f.read()
+                contents = f.read().rstrip()
                 combinedRst = combinedRst + "\n" + contents
+    combinedRst = combinedRst.strip() + "\n"
     return combinedRst
 
 

--- a/tools/ReleaseNotes/release_editor.py
+++ b/tools/ReleaseNotes/release_editor.py
@@ -7,14 +7,13 @@
 
 import os
 import pathlib
-import sys
 
 
 DIRECTIVE = ".. amalgamate:: "
 
 
 def getReleaseRoot() -> pathlib.Path:
-    program_path = pathlib.Path((sys.argv[0])[0])
+    program_path = pathlib.Path(__file__).resolve()
     script_dir = program_path / '../../../docs/source/release/'
     return script_dir.resolve()
 

--- a/tools/ReleaseNotes/release_editor.py
+++ b/tools/ReleaseNotes/release_editor.py
@@ -9,6 +9,8 @@ import os
 import sys
 import shutil
 
+DIRECTIVE = ".. amalgamate:: "
+
 
 def getReleaseRoot():
     script_dir = os.path.split(sys.argv[0])[0]
@@ -57,8 +59,8 @@ def addReleaseNotesToMain(pathDirectory):
                 # iterate through each line in the upper level release note file e.g. diffraction.rst
                 for line in fileToEdit:
                     # finds the amalgamate directive to replace
-                    if line.startswith(directive):
-                        fileName = createFileName(line, pathDirectory, directive)
+                    if line.startswith(DIRECTIVE):
+                        fileName = createFileName(line, pathDirectory, DIRECTIVE)
                         releaseNotes = collateNotes(fileName)
                         originalFile = mainDirectory + '/' + file
                         updateFile(originalFile, releaseNotes, line)
@@ -121,7 +123,6 @@ if __name__ == '__main__':
 
     args.release = fixReleaseName(args.release)
     mainDirectory = os.path.normpath(createFileLocation(args.release))
-    directive = ".. amalgamate:: "
     directoriesUsed = checkContainsReleaseNote(mainDirectory)
 
     addReleaseNotesToMain(mainDirectory)

--- a/tools/ReleaseNotes/release_editor.py
+++ b/tools/ReleaseNotes/release_editor.py
@@ -1,6 +1,6 @@
 # Mantid Repository : https://github.com/mantidproject/mantid
 #
-# Copyright &copy; 2021 ISIS Rutherford Appleton Laboratory UKRI,
+# Copyright &copy; 2022 ISIS Rutherford Appleton Laboratory UKRI,
 #   NScD Oak Ridge National Laboratory, European Spallation Source,
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
@@ -45,17 +45,20 @@ def createFileName(fileName, pathDirectory, includeStatement):
     newFileName = fileName.replace(includeStatement, "")
     newFileName = newFileName.replace("\n", "")
     newFileName = pathDirectory + '/' + newFileName
-    return newFileName
+    return os.path.normpath(newFileName)
 
 
-def addReleaseNotesToMain(pathDirectory):
+def addReleaseNotesToMain(pathDirectory, listOfDirectories):
     for file in os.listdir(pathDirectory):
         if file.endswith(".rst"):
             with open(mainDirectory + '/' + file) as fileToEdit:
                 for line in fileToEdit:
                     if line.startswith(directive):
                         fileName = createFileName(line, pathDirectory, directive)
-                        releaseNotes = collateNotes(fileName)
+                        if fileName in listOfDirectories:
+                            releaseNotes = collateNotes(fileName)
+                        else:
+                            releaseNotes = ""
                         originalFile = mainDirectory + '/' + file
                         updateFile(originalFile, releaseNotes, line)
 
@@ -67,7 +70,7 @@ def getReleaseNoteDirectories(path, directoryList):
 
     # add dir to directorylist if it contains .rst files
     if len([f for f in os.listdir(path) if f.endswith('.rst')]) > 0:
-        directoryList.append(path)
+        directoryList.append(os.path.normpath(path))
 
     for d in os.listdir(path):
         new_path = os.path.join(path, d)
@@ -115,9 +118,9 @@ if __name__ == '__main__':
     args = parser.parse_args()
 
     args.release = fixReleaseName(args.release)
-    mainDirectory = createFileLocation(args.release)
+    mainDirectory = os.path.normpath(createFileLocation(args.release))
     directive = ".. amalgamate:: "
     directoriesUsed = checkContainsReleaseNote(mainDirectory)
 
-    addReleaseNotesToMain(mainDirectory)
+    addReleaseNotesToMain(mainDirectory, directoriesUsed)
     moveFiles(directoriesUsed)

--- a/tools/ReleaseNotes/release_editor.py
+++ b/tools/ReleaseNotes/release_editor.py
@@ -1,0 +1,123 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2021 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+
+import os
+import sys
+import shutil
+
+
+def getReleaseRoot():
+    script_dir = os.path.split(sys.argv[0])[0]
+    return os.path.abspath(os.path.join(script_dir, '../../docs/source/release/'))
+
+
+def fixReleaseName(name):
+    if not name.startswith('v'):
+        name = 'v' + name
+    return name
+
+
+def createFileLocation(releaseNo):
+    release_root = getReleaseRoot()
+    release_root = release_root + '/' + releaseNo
+    return release_root
+
+
+def updateFile(originalFile, replaceText, textToReplace):
+    # opens the upper level release note e.g. diffraction.rst
+    mainRST = open(originalFile, 'r')
+    rstToRead = mainRST.read()
+    mainRST.close()
+
+    # replaces the amalgamate directive with the notes compiled for that heading
+    newdata = rstToRead.replace(textToReplace, replaceText)
+
+    mainRST = open(originalFile, 'w')
+    mainRST.write(newdata)
+    mainRST.close()
+
+
+def createFileName(fileName, pathDirectory, includeStatement):
+    newFileName = fileName.replace(includeStatement, "")
+    newFileName = newFileName.replace("\n", "")
+    newFileName = pathDirectory + '/' + newFileName
+    return newFileName
+
+
+def addReleaseNotesToMain(pathDirectory):
+    for file in os.listdir(pathDirectory):
+        if file.endswith(".rst"):
+            with open(mainDirectory + '/' + file) as fileToEdit:
+                for line in fileToEdit:
+                    if line.startswith(directive):
+                        fileName = createFileName(line, pathDirectory, directive)
+                        releaseNotes = collateNotes(fileName)
+                        originalFile = mainDirectory + '/' + file
+                        updateFile(originalFile, releaseNotes, line)
+
+
+def getReleaseNoteDirectories(path, directoryList):
+    # return nothing if path is a file
+    if os.path.isfile(path):
+        return ()
+
+    # add dir to directorylist if it contains .rst files
+    if len([f for f in os.listdir(path) if f.endswith('.rst')]) > 0:
+        directoryList.append(path)
+
+    for d in os.listdir(path):
+        new_path = os.path.join(path, d)
+        if os.path.isdir(new_path):
+            getReleaseNoteDirectories(new_path, directoryList)
+
+    return directoryList
+
+
+def checkContainsReleaseNote(path):
+    releaseNoteList = []
+    getReleaseNoteDirectories(path, releaseNoteList)
+    releaseNoteList.remove(path)
+    return releaseNoteList
+
+
+# This is the method for iterating through release notes in a folder and collating the notes into one object
+def collateNotes(path):
+    combinedRst = ""
+    filesScanned = []
+    for file in os.listdir(path):
+        if file.endswith(".rst"):
+            filesScanned.append(file)
+            with open(path + '/' + file) as f:
+                contents = f.read()
+                combinedRst = combinedRst + "\n" + contents
+    return combinedRst
+
+
+# Moves the release note files that have been copied to top level file into 'Used' folders
+def moveFiles(listOfDirectories):
+    for path in listOfDirectories:
+        os.makedirs(path + '/' + 'Used')
+        for file in os.listdir(path):
+            if file.endswith(".rst"):
+                currentFileLocation = path + '/' + file
+                newFileLocation = path + '/Used/' + file
+                shutil.move(currentFileLocation, newFileLocation)
+
+
+if __name__ == '__main__':
+    from argparse import ArgumentParser
+    parser = ArgumentParser(description="Generate generic release pages")
+    parser.add_argument('--release', required=True)
+    args = parser.parse_args()
+
+    args.release = fixReleaseName(args.release)
+    mainDirectory = createFileLocation(args.release)
+    directive = ".. amalgamate:: "
+    directoriesUsed = checkContainsReleaseNote(mainDirectory)
+
+    addReleaseNotesToMain(mainDirectory)
+    moveFiles(directoriesUsed)


### PR DESCRIPTION
**Description of work.**
During release the separate release notes need to be copied over to the final files. This script does that and moves the separate release notes that have been copied to 'Used' folders to denote they have been copied over. This kick starts the move to manual release notes during release and should give the Release Editor the ability to clean and edit release notes whilst developers continue to add separate release notes as normal.

**To test:**
1. Take a look at the upper level release notes files for v6.4.0 e.g. diffraction.rst. Check that under each heading is a sphinx directive for '''amalgamate'''
2. Check that you have separate release notes in the sub-folders for v.6.4.0 release. None of these folders should contain a folder entitled 'Used'.
3. Navigate to the ../tools/ReleaseNotes folder in your command line
4. Run ```python release_editor.py --release 6.4.0```
5. Check that the upper level release notes file (see 1 above) have either release notes or empty lines instead of the ```amalgamate``` directives
6. Check that the separate release notes (see 2 above) are now in new sub folders called 'Used'
7. Read through the new guidance for release editors and check that the instructions make sense.

Part of #33593 

*This does not require release notes* because **it is a script for developer use only**


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
