### PR TITLE
Suppress Documentation warnings

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -267,7 +267,7 @@ intersphinx_mapping = {
 # "WARNING: document isn't included in any toctree"
 # for individual release notes files.
 exclude_patterns = [
-    'release/templates/*.rst'
+    'release/templates/*.rst',
     'release/v6.4.0/**/Bugfixes/*.rst',
     'release/v6.4.0/**/New_features/*.rst'
 ]


### PR DESCRIPTION
**Description of work.**

In order for the new style of release notes to function without causing build failures certain files need to be excluded from TOC Tree building. The recent addition of templates (see #33671) caused problems with the TOC Tree exclusions and caused the latest Windows build to be unstable. This PR fixes this.

**To test:**
Check that the Windows build has built a package and passed the build checks.

This does not require release notes because it a temporary fix for release notes.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
