### PR TITLE
Use "defaultsave.directory" for load and save in DrILL

### DIFF
--- a/docs/source/release/v6.4.0/Workbench/Improvements/33708.rst
+++ b/docs/source/release/v6.4.0/Workbench/Improvements/33708.rst
@@ -1,0 +1,1 @@
+- In DrILL, the working directory of save and load dialogs is set to the default save directory

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/drill/presenter/DrillPresenter.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/drill/presenter/DrillPresenter.py
@@ -332,7 +332,9 @@ class DrillPresenter:
         Triggered when the user want to load a file. This methods start a
         QDialog to get the file path from the user.
         """
-        filename = QFileDialog.getOpenFileName(self.view, 'Load rundex', '.',
+        defaultSaveDirectory = config["defaultsave.directory"]
+        filename = QFileDialog.getOpenFileName(self.view, 'Load rundex',
+                                               defaultSaveDirectory,
                                                "Rundex (*.mrd);;All (*)")
         if not filename[0]:
             return
@@ -362,8 +364,9 @@ class DrillPresenter:
         will open a dialog to select the file even if one has previously been
         used.
         """
+        defaultSaveDirectory = config["defaultsave.directory"]
         filename = QFileDialog.getSaveFileName(self.view, 'Save rundex',
-                                               './*.mrd',
+                                               defaultSaveDirectory + '/*.mrd',
                                                "Rundex (*.mrd);;All (*)")
         if not filename[0]:
             return

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/drill/presenter/DrillPresenter.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/drill/presenter/DrillPresenter.py
@@ -333,6 +333,8 @@ class DrillPresenter:
         QDialog to get the file path from the user.
         """
         defaultSaveDirectory = config["defaultsave.directory"]
+        if not defaultSaveDirectory:
+            defaultSaveDirectory = "."
         filename = QFileDialog.getOpenFileName(self.view, 'Load rundex',
                                                defaultSaveDirectory,
                                                "Rundex (*.mrd);;All (*)")
@@ -365,6 +367,8 @@ class DrillPresenter:
         used.
         """
         defaultSaveDirectory = config["defaultsave.directory"]
+        if not defaultSaveDirectory:
+            defaultSaveDirectory = "."
         filename = QFileDialog.getSaveFileName(self.view, 'Save rundex',
                                                defaultSaveDirectory + '/*.mrd',
                                                "Rundex (*.mrd);;All (*)")


### PR DESCRIPTION
**Description of work.**

This PR changes the working directory of the save and load dialogs to the current "default save directory".

**To test:**

Open DrILL (Interfaces -> ILL -> DrILL). Open the save (File -> Save rundex as) and load (File -> Load rundex) dialogs and check that the working directory corresponds to your default save directory.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
