### PR TITLE
New popup warning for missing periods in MA & FDA

### DIFF
--- a/docs/source/release/v6.4.0/Muon/MA_FDA/New_features/32794.rst
+++ b/docs/source/release/v6.4.0/Muon/MA_FDA/New_features/32794.rst
@@ -1,0 +1,1 @@
+- Users will now receive a warning if they load a run with missing period information.

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/grouping_table_widget/grouping_table_widget_presenter.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/grouping_table_widget/grouping_table_widget_presenter.py
@@ -220,9 +220,13 @@ class GroupingTablePresenter(object):
 
         self._remove_groups_with_invalid_detectors()
 
+        groupWarning = False
+
         for group in self._model.groups:
             to_analyse = True if group.name in self._model.selected_groups else False
             display_period_warning = self._model.validate_periods_list(group.periods)
+            if display_period_warning != RowValid.valid_for_all_runs:
+                groupWarning = True
             color = row_colors[display_period_warning]
             tool_tip = row_tooltips[display_period_warning]
             self.add_group_to_view(group, to_analyse, color, tool_tip)
@@ -232,6 +236,9 @@ class GroupingTablePresenter(object):
 
         if self._view.group_range_use_first_good_data.isChecked():
             self._view.group_range_min.setText(str(self._model.get_first_good_data_from_file()))
+
+        if groupWarning:
+            self._view.warning_popup("Warning: Please check the grouping tab. \n Some periods are unavailable.")
 
         self._view.enable_updates()
 


### PR DESCRIPTION
**Description of work.**
Users will now get a warning if they try to switch from a run with multiple periods to a run with a single period.

**To test:**
1. Open Muon Analysis GUI
2. Load run ```HIFI84447```
3. Click on Grouping tab and check there are several groups/periods
4. Load run ```HIFI83447```
5. A pop up box with a warning should appear alerting the user to a problem with the periods
6. Close the Muon Analysis GUI
7. Open the Frequency Domain Analysis GUI
8. Repeat steps 2 to 5 in this GUI.

Fixes #32794 



---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
