### PR TITLE
Update LookupRow Indexes in Model when Settings Change

### DIFF
--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchJobManager.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchJobManager.cpp
@@ -38,7 +38,7 @@ int countItemsForLocation(ReductionJobs const &jobs, MantidWidgets::Batch::RowLo
 
 using API::IConfiguredAlgorithm_sptr;
 
-BatchJobManager::BatchJobManager(Batch &batch, std::unique_ptr<IReflAlgorithmFactory> algFactory)
+BatchJobManager::BatchJobManager(IBatch &batch, std::unique_ptr<IReflAlgorithmFactory> algFactory)
     : m_batch(batch), m_algFactory(std::move(algFactory)), m_isProcessing(false), m_isAutoreducing(false),
       m_reprocessFailed(false), m_processAll(false), m_processPartial(false) {
   // TODO Pass IJobRunner into this class and move job execution here instead of in the presenter

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchJobManager.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchJobManager.h
@@ -30,7 +30,7 @@ class PreviewRow;
  */
 class MANTIDQT_ISISREFLECTOMETRY_DLL BatchJobManager : public IBatchJobManager {
 public:
-  BatchJobManager(Batch &batch, std::unique_ptr<IReflAlgorithmFactory> algFactory = nullptr);
+  BatchJobManager(IBatch &batch, std::unique_ptr<IReflAlgorithmFactory> algFactory = nullptr);
 
   bool isProcessing() const override;
   bool isAutoreducing() const override;
@@ -63,8 +63,7 @@ public:
   bool getProcessAll() const override;
 
 protected:
-  Batch &m_batch;
-  // TODO use algFactory to wrap and test calls to createConfiguredAlgorithm
+  IBatch &m_batch;
   std::unique_ptr<IReflAlgorithmFactory> m_algFactory;
   bool m_isProcessing;
   bool m_isAutoreducing;

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchPresenter.cpp
@@ -277,6 +277,8 @@ void BatchPresenter::notifyBatchLoaded() { m_runsPresenter->notifyBatchLoaded();
 
 void BatchPresenter::notifyRowContentChanged(Row &changedRow) { m_model->updateLookupIndex(changedRow); }
 
+void BatchPresenter::notifyGroupNameChanged(Group &changedGroup) {}
+
 Mantid::Geometry::Instrument_const_sptr BatchPresenter::instrument() const { return m_mainPresenter->instrument(); }
 
 std::string BatchPresenter::instrumentName() const { return m_mainPresenter->instrumentName(); }

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchPresenter.cpp
@@ -281,6 +281,7 @@ std::string BatchPresenter::instrumentName() const { return m_mainPresenter->ins
 
 void BatchPresenter::settingsChanged() {
   setBatchUnsaved();
+  m_model->updateLookupIndexesOfTable();
   m_runsPresenter->settingsChanged();
 }
 

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchPresenter.cpp
@@ -275,6 +275,8 @@ void BatchPresenter::notifyAnyBatchAutoreductionPaused() { m_runsPresenter->noti
 
 void BatchPresenter::notifyBatchLoaded() { m_runsPresenter->notifyBatchLoaded(); }
 
+void BatchPresenter::notifyRowContentChanged(Row &changedRow) {}
+
 Mantid::Geometry::Instrument_const_sptr BatchPresenter::instrument() const { return m_mainPresenter->instrument(); }
 
 std::string BatchPresenter::instrumentName() const { return m_mainPresenter->instrumentName(); }

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchPresenter.cpp
@@ -33,7 +33,7 @@ using API::IConfiguredAlgorithm_sptr;
  * presenter
  * @param savePresenter :: [input] A pointer to the 'Save ASCII' tab presenter
  */
-BatchPresenter::BatchPresenter(IBatchView *view, std::unique_ptr<Batch> model, IJobRunner *jobRunner,
+BatchPresenter::BatchPresenter(IBatchView *view, std::unique_ptr<IBatch> model, IJobRunner *jobRunner,
                                std::unique_ptr<IRunsPresenter> runsPresenter,
                                std::unique_ptr<IEventPresenter> eventPresenter,
                                std::unique_ptr<IExperimentPresenter> experimentPresenter,

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchPresenter.cpp
@@ -275,7 +275,7 @@ void BatchPresenter::notifyAnyBatchAutoreductionPaused() { m_runsPresenter->noti
 
 void BatchPresenter::notifyBatchLoaded() { m_runsPresenter->notifyBatchLoaded(); }
 
-void BatchPresenter::notifyRowContentChanged(Row &changedRow) {}
+void BatchPresenter::notifyRowContentChanged(Row &changedRow) { m_model->updateLookupIndex(changedRow); }
 
 Mantid::Geometry::Instrument_const_sptr BatchPresenter::instrument() const { return m_mainPresenter->instrument(); }
 

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchPresenter.cpp
@@ -277,7 +277,7 @@ void BatchPresenter::notifyBatchLoaded() { m_runsPresenter->notifyBatchLoaded();
 
 void BatchPresenter::notifyRowContentChanged(Row &changedRow) { m_model->updateLookupIndex(changedRow); }
 
-void BatchPresenter::notifyGroupNameChanged(Group &changedGroup) {}
+void BatchPresenter::notifyGroupNameChanged(Group &changedGroup) { m_model->updateLookupIndexesOfGroup(changedGroup); }
 
 Mantid::Geometry::Instrument_const_sptr BatchPresenter::instrument() const { return m_mainPresenter->instrument(); }
 

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchPresenter.h
@@ -37,7 +37,7 @@ class MANTIDQT_ISISREFLECTOMETRY_DLL BatchPresenter : public IBatchPresenter,
                                                       public MantidQt::API::WorkspaceObserver {
 public:
   /// Constructor
-  BatchPresenter(IBatchView *view, std::unique_ptr<Batch> model, IJobRunner *jobRunner,
+  BatchPresenter(IBatchView *view, std::unique_ptr<IBatch> model, IJobRunner *jobRunner,
                  std::unique_ptr<IRunsPresenter> runsPresenter, std::unique_ptr<IEventPresenter> eventPresenter,
                  std::unique_ptr<IExperimentPresenter> experimentPresenter,
                  std::unique_ptr<IInstrumentPresenter> instrumentPresenter,
@@ -108,7 +108,7 @@ private:
   void settingsChanged();
 
   IBatchView *m_view;
-  std::unique_ptr<Batch> m_model;
+  std::unique_ptr<IBatch> m_model;
   IMainWindowPresenter *m_mainPresenter;
   std::unique_ptr<IRunsPresenter> m_runsPresenter;
   std::unique_ptr<IEventPresenter> m_eventPresenter;

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchPresenter.h
@@ -76,6 +76,7 @@ public:
   void notifyReductionPaused() override;
   void notifyBatchLoaded() override;
   void notifyRowContentChanged(Row &changedRow) override;
+  void notifyGroupNameChanged(Group &changedGroup) override;
   bool requestClose() const override;
   bool isProcessing() const override;
   bool isAutoreducing() const override;

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchPresenter.h
@@ -75,6 +75,7 @@ public:
   void notifyAnyBatchAutoreductionPaused() override;
   void notifyReductionPaused() override;
   void notifyBatchLoaded() override;
+  void notifyRowContentChanged(Row &changedRow) override;
   bool requestClose() const override;
   bool isProcessing() const override;
   bool isAutoreducing() const override;

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/IBatchPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/IBatchPresenter.h
@@ -50,6 +50,7 @@ public:
   virtual void notifyAnyBatchAutoreductionPaused() = 0;
   virtual void notifyReductionPaused() = 0;
   virtual void notifyBatchLoaded() = 0;
+  virtual void notifyRowContentChanged(Row &changedRow) = 0;
 
   /// Data processing check for all groups
   virtual bool isProcessing() const = 0;

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/IBatchPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/IBatchPresenter.h
@@ -9,6 +9,7 @@
 #include "GUI/Batch/RowProcessingAlgorithm.h"
 #include "MantidGeometry/Instrument_fwd.h"
 #include "MantidQtWidgets/Common/IAlgorithmRuntimeProps.h"
+#include "Reduction/Group.h"
 
 #include <memory>
 #include <string>
@@ -51,6 +52,7 @@ public:
   virtual void notifyReductionPaused() = 0;
   virtual void notifyBatchLoaded() = 0;
   virtual void notifyRowContentChanged(Row &changedRow) = 0;
+  virtual void notifyGroupNameChanged(Group &changedGroup) = 0;
 
   /// Data processing check for all groups
   virtual bool isProcessing() const = 0;

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/IRunsPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/IRunsPresenter.h
@@ -49,6 +49,7 @@ public:
   virtual void notifyAnyBatchAutoreductionPaused() = 0;
   virtual void notifyInstrumentChanged(std::string const &instrumentName) = 0;
   virtual void notifyTableChanged() = 0;
+  virtual void notifyRowContentChanged(Row &changedRowLocation) = 0;
   virtual void settingsChanged() = 0;
   virtual void notifyChangesSaved() = 0;
   virtual bool hasUnsavedChanges() const = 0;

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/IRunsPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/IRunsPresenter.h
@@ -49,7 +49,8 @@ public:
   virtual void notifyAnyBatchAutoreductionPaused() = 0;
   virtual void notifyInstrumentChanged(std::string const &instrumentName) = 0;
   virtual void notifyTableChanged() = 0;
-  virtual void notifyRowContentChanged(Row &changedRowLocation) = 0;
+  virtual void notifyRowContentChanged(Row &changedRow) = 0;
+  virtual void notifyGroupNameChanged(Group &changedGroup) = 0;
   virtual void settingsChanged() = 0;
   virtual void notifyChangesSaved() = 0;
   virtual bool hasUnsavedChanges() const = 0;

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/RunsPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/RunsPresenter.cpp
@@ -286,6 +286,8 @@ void RunsPresenter::notifyTableChanged() { m_tableUnsaved = true; }
 
 void RunsPresenter::notifyRowContentChanged(Row &changedRow) { m_mainPresenter->notifyRowContentChanged(changedRow); }
 
+void RunsPresenter::notifyGroupNameChanged(Group &changedGroup) {}
+
 void RunsPresenter::settingsChanged() { tablePresenter()->settingsChanged(); }
 
 void RunsPresenter::notifyChangesSaved() {

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/RunsPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/RunsPresenter.cpp
@@ -284,7 +284,7 @@ std::string RunsPresenter::instrumentName() const { return m_mainPresenter->inst
 
 void RunsPresenter::notifyTableChanged() { m_tableUnsaved = true; }
 
-void RunsPresenter::notifyRowContentChanged(Row &changedRow) {}
+void RunsPresenter::notifyRowContentChanged(Row &changedRow) { m_mainPresenter->notifyRowContentChanged(changedRow); }
 
 void RunsPresenter::settingsChanged() { tablePresenter()->settingsChanged(); }
 

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/RunsPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/RunsPresenter.cpp
@@ -286,7 +286,9 @@ void RunsPresenter::notifyTableChanged() { m_tableUnsaved = true; }
 
 void RunsPresenter::notifyRowContentChanged(Row &changedRow) { m_mainPresenter->notifyRowContentChanged(changedRow); }
 
-void RunsPresenter::notifyGroupNameChanged(Group &changedGroup) {}
+void RunsPresenter::notifyGroupNameChanged(Group &changedGroup) {
+  m_mainPresenter->notifyGroupNameChanged(changedGroup);
+}
 
 void RunsPresenter::settingsChanged() { tablePresenter()->settingsChanged(); }
 

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/RunsPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/RunsPresenter.cpp
@@ -284,6 +284,8 @@ std::string RunsPresenter::instrumentName() const { return m_mainPresenter->inst
 
 void RunsPresenter::notifyTableChanged() { m_tableUnsaved = true; }
 
+void RunsPresenter::notifyRowContentChanged(Row &changedRow) {}
+
 void RunsPresenter::settingsChanged() { tablePresenter()->settingsChanged(); }
 
 void RunsPresenter::notifyChangesSaved() {

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/RunsPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/RunsPresenter.h
@@ -96,6 +96,7 @@ public:
   void notifyAnyBatchAutoreductionPaused() override;
   void notifyInstrumentChanged(std::string const &instrumentName) override;
   void notifyTableChanged() override;
+  void notifyRowContentChanged(Row &changedRow) override;
   void settingsChanged() override;
   void notifyChangesSaved() override;
   bool hasUnsavedChanges() const override;

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/RunsPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/RunsPresenter.h
@@ -97,6 +97,7 @@ public:
   void notifyInstrumentChanged(std::string const &instrumentName) override;
   void notifyTableChanged() override;
   void notifyRowContentChanged(Row &changedRow) override;
+  void notifyGroupNameChanged(Group &changedGroup) override;
   void settingsChanged() override;
   void notifyChangesSaved() override;
   bool hasUnsavedChanges() const override;

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/RunsTable/RunsTablePresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/RunsTable/RunsTablePresenter.cpp
@@ -452,7 +452,7 @@ void RunsTablePresenter::updateGroupName(MantidWidgets::Batch::RowLocation const
     cell.setContentText(oldValue);
     m_view->jobs().setCellAt(itemIndex, column, cell);
   }
-  m_mainPresenter->notifyGroupNameChanged(m_model.mutableReductionJobs().mutableGroups()[0]);
+  m_mainPresenter->notifyGroupNameChanged(m_model.mutableReductionJobs().mutableGroups()[groupIndex]);
 }
 
 void RunsTablePresenter::updateRowField(MantidWidgets::Batch::RowLocation const &itemIndex, int column,
@@ -469,7 +469,8 @@ void RunsTablePresenter::updateRowField(MantidWidgets::Batch::RowLocation const 
   updateRow(m_model.mutableReductionJobs(), groupIndex, rowIndex, rowValidationResult.validElseNone());
   if (rowValidationResult.isValid()) {
     showAllCellsOnRowAsValid(itemIndex);
-    m_mainPresenter->notifyRowContentChanged(m_model.mutableReductionJobs().mutableGroups()[0].mutableRows()[0].get());
+    m_mainPresenter->notifyRowContentChanged(
+        m_model.mutableReductionJobs().mutableGroups()[groupIndex].mutableRows()[rowIndex].get());
   } else {
     showCellsAsInvalidInView(itemIndex, rowValidationResult.assertError());
   }

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/RunsTable/RunsTablePresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/RunsTable/RunsTablePresenter.cpp
@@ -468,6 +468,7 @@ void RunsTablePresenter::updateRowField(MantidWidgets::Batch::RowLocation const 
   updateRow(m_model.mutableReductionJobs(), groupIndex, rowIndex, rowValidationResult.validElseNone());
   if (rowValidationResult.isValid()) {
     showAllCellsOnRowAsValid(itemIndex);
+    m_mainPresenter->notifyRowContentChanged(m_model.mutableReductionJobs().mutableGroups()[0].mutableRows()[0].get());
   } else {
     showCellsAsInvalidInView(itemIndex, rowValidationResult.assertError());
   }

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/RunsTable/RunsTablePresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/RunsTable/RunsTablePresenter.cpp
@@ -452,6 +452,7 @@ void RunsTablePresenter::updateGroupName(MantidWidgets::Batch::RowLocation const
     cell.setContentText(oldValue);
     m_view->jobs().setCellAt(itemIndex, column, cell);
   }
+  m_mainPresenter->notifyGroupNameChanged(m_model.mutableReductionJobs().mutableGroups()[0]);
 }
 
 void RunsTablePresenter::updateRowField(MantidWidgets::Batch::RowLocation const &itemIndex, int column,

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Save/SavePresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Save/SavePresenter.cpp
@@ -244,12 +244,12 @@ void SavePresenter::saveWorkspaces(std::vector<std::string> const &workspaceName
 /** Saves selected workspaces */
 void SavePresenter::saveSelectedWorkspaces() {
   // Check that at least one workspace has been selected for saving
-  auto workspaceNames = m_view->getSelectedWorkspaces();
-  if (workspaceNames.empty()) {
+  auto wkspNames = m_view->getSelectedWorkspaces();
+  if (wkspNames.empty()) {
     m_view->noWorkspacesSelected();
   } else {
     try {
-      saveWorkspaces(workspaceNames);
+      saveWorkspaces(wkspNames);
     } catch (std::exception &e) {
       m_view->cannotSaveWorkspaces(e.what());
     } catch (...) {

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/Batch.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/Batch.cpp
@@ -63,4 +63,18 @@ void Batch::updateLookupIndexesOfTable() {
   }
 }
 
+bool Batch::isInSelection(const Item &item,
+                          const std::vector<MantidWidgets::Batch::RowLocation> &selectedRowLocations) {
+  return m_runsTable.isInSelection(item, selectedRowLocations);
+}
+
+bool Batch::isInSelection(const Row &item, const std::vector<MantidWidgets::Batch::RowLocation> &selectedRowLocations) {
+  return m_runsTable.isInSelection(item, selectedRowLocations);
+}
+
+bool Batch::isInSelection(const Group &item,
+                          const std::vector<MantidWidgets::Batch::RowLocation> &selectedRowLocations) {
+  return m_runsTable.isInSelection(item, selectedRowLocations);
+}
+
 } // namespace MantidQt::CustomInterfaces::ISISReflectometry

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/Batch.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/Batch.h
@@ -32,18 +32,22 @@ public:
 
   Experiment const &experiment() const override;
   Instrument const &instrument() const override;
-  RunsTable const &runsTable() const;
-  RunsTable &mutableRunsTable();
+  RunsTable const &runsTable() const override;
+  RunsTable &mutableRunsTable() override;
   Slicing const &slicing() const override;
 
-  std::vector<MantidWidgets::Batch::RowLocation> selectedRowLocations() const;
-  template <typename T>
-  bool isInSelection(T const &item, std::vector<MantidWidgets::Batch::RowLocation> const &selectedRowLocations) const;
+  std::vector<MantidWidgets::Batch::RowLocation> selectedRowLocations() const override;
+  bool isInSelection(const Item &item,
+                     const std::vector<MantidWidgets::Batch::RowLocation> &selectedRowLocations) override;
+  bool isInSelection(const Row &item,
+                     const std::vector<MantidWidgets::Batch::RowLocation> &selectedRowLocations) override;
+  bool isInSelection(const Group &item,
+                     const std::vector<MantidWidgets::Batch::RowLocation> &selectedRowLocations) override;
   boost::optional<LookupRow> findLookupRow(Row const &row) const override;
   boost::optional<LookupRow> findWildcardLookupRow() const override;
-  void resetState();
-  void resetSkippedItems();
-  boost::optional<Item &> getItemWithOutputWorkspaceOrNone(std::string const &wsName);
+  void resetState() override;
+  void resetSkippedItems() override;
+  boost::optional<Item &> getItemWithOutputWorkspaceOrNone(std::string const &wsName) override;
 
   void updateLookupIndex(Row &row);
   void updateLookupIndexesOfGroup(Group &group);
@@ -56,11 +60,6 @@ private:
   Slicing const &m_slicing;
 };
 
-template <typename T>
-bool Batch::isInSelection(T const &item,
-                          std::vector<MantidWidgets::Batch::RowLocation> const &selectedRowLocations) const {
-  return m_runsTable.isInSelection(item, selectedRowLocations);
-}
 } // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/Batch.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/Batch.h
@@ -49,9 +49,9 @@ public:
   void resetSkippedItems() override;
   boost::optional<Item &> getItemWithOutputWorkspaceOrNone(std::string const &wsName) override;
 
-  void updateLookupIndex(Row &row);
-  void updateLookupIndexesOfGroup(Group &group);
-  void updateLookupIndexesOfTable();
+  void updateLookupIndex(Row &row) override;
+  void updateLookupIndexesOfGroup(Group &group) override;
+  void updateLookupIndexesOfTable() override;
 
 private:
   Experiment const &m_experiment;

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/IBatch.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/IBatch.h
@@ -44,5 +44,8 @@ public:
   virtual void resetSkippedItems() = 0;
   virtual void resetState() = 0;
   virtual std::vector<MantidWidgets::Batch::RowLocation> selectedRowLocations() const = 0;
+  virtual void updateLookupIndex(Row &row) = 0;
+  virtual void updateLookupIndexesOfGroup(Group &group) = 0;
+  virtual void updateLookupIndexesOfTable() = 0;
 };
 } // namespace MantidQt::CustomInterfaces::ISISReflectometry

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/IBatch.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/IBatch.h
@@ -7,15 +7,20 @@
 #pragma once
 
 #include "LookupRow.h"
+#include "Reduction/RowLocation.h"
 #include "Slicing.h"
 
 #include <boost/optional.hpp>
+#include <vector>
 
 namespace MantidQt::CustomInterfaces::ISISReflectometry {
 
 class Experiment;
 class Instrument;
 class Row;
+class Group;
+class Item;
+class RunsTable;
 
 class IBatch {
 public:
@@ -23,9 +28,21 @@ public:
 
   virtual Experiment const &experiment() const = 0;
   virtual Instrument const &instrument() const = 0;
+  virtual RunsTable &mutableRunsTable() = 0;
+  virtual RunsTable const &runsTable() const = 0;
   virtual Slicing const &slicing() const = 0;
 
-  virtual boost::optional<LookupRow> findWildcardLookupRow() const = 0;
   virtual boost::optional<LookupRow> findLookupRow(Row const &row) const = 0;
+  virtual boost::optional<LookupRow> findWildcardLookupRow() const = 0;
+  virtual boost::optional<Item &> getItemWithOutputWorkspaceOrNone(std::string const &wsName) = 0;
+  virtual bool isInSelection(const Item &item,
+                             const std::vector<MantidWidgets::Batch::RowLocation> &selectedRowLocations) = 0;
+  virtual bool isInSelection(const Row &item,
+                             const std::vector<MantidWidgets::Batch::RowLocation> &selectedRowLocations) = 0;
+  virtual bool isInSelection(const Group &item,
+                             const std::vector<MantidWidgets::Batch::RowLocation> &selectedRowLocations) = 0;
+  virtual void resetSkippedItems() = 0;
+  virtual void resetState() = 0;
+  virtual std::vector<MantidWidgets::Batch::RowLocation> selectedRowLocations() const = 0;
 };
 } // namespace MantidQt::CustomInterfaces::ISISReflectometry

--- a/qt/scientific_interfaces/ISISReflectometry/test/Batch/BatchPresenterTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Batch/BatchPresenterTest.h
@@ -528,6 +528,14 @@ public:
     presenter->notifySettingsChanged();
   }
 
+  void testSingleRowUpdatedWhenRowContentChanged() {
+    auto mock = makeMockModel();
+    auto row = makeRow(0.7);
+    EXPECT_CALL(*mock, updateLookupIndex(row)).Times(1);
+    auto presenter = makePresenter(std::move(mock));
+    presenter->notifyRowContentChanged(row);
+  }
+
 private:
   NiceMock<MockBatchView> m_view;
   NiceMock<MockBatchJobManager> *m_jobManager;

--- a/qt/scientific_interfaces/ISISReflectometry/test/Batch/BatchPresenterTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Batch/BatchPresenterTest.h
@@ -9,10 +9,11 @@
 #include "../../../ISISReflectometry/GUI/Batch/BatchPresenter.h"
 #include "../../../ISISReflectometry/TestHelpers/ModelCreationHelper.h"
 #include "../MainWindow/MockMainWindowPresenter.h"
+#include "../Preview/MockPreviewPresenter.h"
+#include "../Reduction/MockBatch.h"
 #include "../ReflMockObjects.h"
 #include "MantidAPI/FrameworkManager.h"
 #include "MockBatchView.h"
-#include "MockPreviewPresenter.h"
 
 #include <cxxtest/TestSuite.h>
 #include <gmock/gmock.h>
@@ -46,19 +47,19 @@ public:
 
   void testPresenterSubscribesToJobRunner() {
     EXPECT_CALL(m_jobRunner, subscribe(_)).Times(1);
-    auto presenter = makePresenter();
+    auto presenter = makePresenter(makeModel());
     verifyAndClear();
   }
 
   void testInitInstrumentListUpdatesRunsPresenter() {
-    auto presenter = makePresenter();
+    auto presenter = makePresenter(makeModel());
     EXPECT_CALL(*m_runsPresenter, initInstrumentList()).Times(1);
     presenter->initInstrumentList();
     verifyAndClear();
   }
 
   void testMainPresenterUpdatedWhenChangeInstrumentRequested() {
-    auto presenter = makePresenter();
+    auto presenter = makePresenter(makeModel());
     auto const instrument = std::string("POLREF");
     EXPECT_CALL(m_mainPresenter, notifyChangeInstrumentRequested(instrument)).Times(1);
     presenter->notifyChangeInstrumentRequested(instrument);
@@ -66,7 +67,7 @@ public:
   }
 
   void testChildPresentersAreUpdatedWhenInstrumentChanged() {
-    auto presenter = makePresenter();
+    auto presenter = makePresenter(makeModel());
     auto const instrument = std::string("POLREF");
     EXPECT_CALL(*m_runsPresenter, notifyInstrumentChanged(instrument)).Times(1);
     EXPECT_CALL(*m_experimentPresenter, notifyInstrumentChanged(instrument)).Times(1);
@@ -76,7 +77,7 @@ public:
   }
 
   void testMainPresenterUpdatedWhenUpdateInstrumentRequested() {
-    auto presenter = makePresenter();
+    auto presenter = makePresenter(makeModel());
     auto const instrument = std::string("POLREF");
     EXPECT_CALL(m_mainPresenter, notifyUpdateInstrumentRequested()).Times(1);
     presenter->notifyUpdateInstrumentRequested();
@@ -84,35 +85,35 @@ public:
   }
 
   void testChildPresentersUpdatedWhenSettingsChanged() {
-    auto presenter = makePresenter();
+    auto presenter = makePresenter(makeModel());
     EXPECT_CALL(*m_runsPresenter, settingsChanged()).Times(1);
     presenter->notifySettingsChanged();
     verifyAndClear();
   }
 
   void testModelUpdatedWhenReductionResumed() {
-    auto presenter = makePresenter();
+    auto presenter = makePresenter(makeModel());
     EXPECT_CALL(*m_jobManager, notifyReductionResumed()).Times(1);
     presenter->notifyResumeReductionRequested();
     verifyAndClear();
   }
 
   void testBatchIsExecutedWhenReductionResumed() {
-    auto presenter = makePresenter();
+    auto presenter = makePresenter(makeModel());
     expectBatchIsExecuted();
     presenter->notifyResumeReductionRequested();
     verifyAndClear();
   }
 
   void testOtherPresentersUpdatedWhenReductionResumed() {
-    auto presenter = makePresenter();
+    auto presenter = makePresenter(makeModel());
     expectReductionResumed();
     presenter->notifyResumeReductionRequested();
     verifyAndClear();
   }
 
   void testJobManagerGetProcessAll() {
-    auto presenter = makePresenter();
+    auto presenter = makePresenter(makeModel());
     TS_ASSERT_EQUALS(m_jobManager->getProcessAll(), false);
     expectReductionResumed();
     presenter->notifyResumeReductionRequested();
@@ -120,7 +121,7 @@ public:
   }
 
   void testJobManagerGetProcessPartial() {
-    auto presenter = makePresenter();
+    auto presenter = makePresenter(makeModel());
     TS_ASSERT_EQUALS(m_jobManager->getProcessPartial(), false);
     expectReductionResumed();
     presenter->notifyResumeReductionRequested();
@@ -128,7 +129,7 @@ public:
   }
 
   void testWarnProcessAllWhenReductionResumedOptionChecked() {
-    auto presenter = makePresenter();
+    auto presenter = makePresenter(makeModel());
     EXPECT_CALL(*m_jobManager, getProcessAll()).Times(1).WillOnce(Return(true));
     EXPECT_CALL(*m_jobManager, notifyReductionResumed()).Times(1);
     EXPECT_CALL(m_mainPresenter, isProcessAllPrevented()).Times(1).WillOnce(Return(true));
@@ -137,7 +138,7 @@ public:
   }
 
   void testNoWarnProcessAllWhenReductionResumedOptionUnchecked() {
-    auto presenter = makePresenter();
+    auto presenter = makePresenter(makeModel());
     EXPECT_CALL(*m_jobManager, getProcessAll()).Times(1).WillOnce(Return(true));
     EXPECT_CALL(*m_jobManager, notifyReductionResumed()).Times(1);
     EXPECT_CALL(m_mainPresenter, isProcessAllPrevented()).Times(1).WillOnce(Return(false));
@@ -146,7 +147,7 @@ public:
   }
 
   void testWarnProcessPartialGroupWhenReductionResumedOptionChecked() {
-    auto presenter = makePresenter();
+    auto presenter = makePresenter(makeModel());
     EXPECT_CALL(*m_jobManager, getProcessPartial()).Times(1).WillOnce(Return(true));
     EXPECT_CALL(*m_jobManager, notifyReductionResumed()).Times(1);
     EXPECT_CALL(m_mainPresenter, isProcessPartialGroupPrevented()).Times(1).WillOnce(Return(true));
@@ -155,7 +156,7 @@ public:
   }
 
   void testNoWarnProcessPartialGroupWhenReductionResumedOptionUnchecked() {
-    auto presenter = makePresenter();
+    auto presenter = makePresenter(makeModel());
     EXPECT_CALL(*m_jobManager, getProcessPartial()).Times(1).WillOnce(Return(true));
     EXPECT_CALL(*m_jobManager, notifyReductionResumed()).Times(1);
     EXPECT_CALL(m_mainPresenter, isProcessPartialGroupPrevented()).Times(1).WillOnce(Return(false));
@@ -164,35 +165,35 @@ public:
   }
 
   void testChildPresentersUpdatedWhenAnyBatchReductionResumed() {
-    auto presenter = makePresenter();
+    auto presenter = makePresenter(makeModel());
     EXPECT_CALL(*m_runsPresenter, notifyAnyBatchReductionResumed()).Times(1);
     presenter->notifyAnyBatchReductionResumed();
     verifyAndClear();
   }
 
   void testChildPresentersUpdatedWhenAnyBatchReductionPaused() {
-    auto presenter = makePresenter();
+    auto presenter = makePresenter(makeModel());
     EXPECT_CALL(*m_runsPresenter, notifyAnyBatchReductionPaused()).Times(1);
     presenter->notifyAnyBatchReductionPaused();
     verifyAndClear();
   }
 
   void testChildPresentersUpdatedWhenAnyBatchAutoreductionResumed() {
-    auto presenter = makePresenter();
+    auto presenter = makePresenter(makeModel());
     EXPECT_CALL(*m_runsPresenter, notifyAnyBatchAutoreductionResumed()).Times(1);
     presenter->notifyAnyBatchAutoreductionResumed();
     verifyAndClear();
   }
 
   void testChildPresentersUpdatedWhenAnyBatchAutoreductionPaused() {
-    auto presenter = makePresenter();
+    auto presenter = makePresenter(makeModel());
     EXPECT_CALL(*m_runsPresenter, notifyAnyBatchAutoreductionPaused()).Times(1);
     presenter->notifyAnyBatchAutoreductionPaused();
     verifyAndClear();
   }
 
   void testMainPresenterQueriedWhenCheckingAnyBatchProcessing() {
-    auto presenter = makePresenter();
+    auto presenter = makePresenter(makeModel());
     EXPECT_CALL(m_mainPresenter, isAnyBatchProcessing()).Times(1).WillOnce(Return(true));
     auto result = presenter->isAnyBatchProcessing();
     TS_ASSERT_EQUALS(result, true);
@@ -200,7 +201,7 @@ public:
   }
 
   void testMainPresenterQueriedWhenCheckingAnyBatchAutoreducing() {
-    auto presenter = makePresenter();
+    auto presenter = makePresenter(makeModel());
     EXPECT_CALL(m_mainPresenter, isAnyBatchAutoreducing()).Times(1).WillOnce(Return(true));
     auto result = presenter->isAnyBatchAutoreducing();
     TS_ASSERT_EQUALS(result, true);
@@ -208,7 +209,7 @@ public:
   }
 
   void testAutoreductionCompletedWhenReductionResumedWithNoRemainingJobs() {
-    auto presenter = makePresenter();
+    auto presenter = makePresenter(makeModel());
     EXPECT_CALL(*m_jobManager, getAlgorithms()).Times(1).WillOnce(Return(std::deque<IConfiguredAlgorithm_sptr>()));
     EXPECT_CALL(*m_jobManager, isAutoreducing()).Times(AtLeast(1)).WillRepeatedly(Return(true));
     EXPECT_CALL(*m_runsPresenter, autoreductionCompleted()).Times(1);
@@ -217,28 +218,28 @@ public:
   }
 
   void testAutoreductionNotCompletedWhenReductionResumedWithRemainingJobs() {
-    auto presenter = makePresenter();
+    auto presenter = makePresenter(makeModel());
     EXPECT_CALL(*m_runsPresenter, autoreductionCompleted()).Times(0);
     presenter->notifyResumeReductionRequested();
     verifyAndClear();
   }
 
   void testBatchIsCancelledWhenReductionPaused() {
-    auto presenter = makePresenter();
+    auto presenter = makePresenter(makeModel());
     EXPECT_CALL(m_jobRunner, cancelAlgorithmQueue()).Times(1);
     presenter->notifyPauseReductionRequested();
     verifyAndClear();
   }
 
   void testModelUpdatedWhenBatchCancelled() {
-    auto presenter = makePresenter();
+    auto presenter = makePresenter(makeModel());
     EXPECT_CALL(*m_jobManager, notifyReductionPaused()).Times(1);
     presenter->notifyBatchCancelled();
     verifyAndClear();
   }
 
   void testChildPresentersUpdatedWhenBatchCancelled() {
-    auto presenter = makePresenter();
+    auto presenter = makePresenter(makeModel());
     expectReductionPaused();
     expectAutoreductionPaused();
     presenter->notifyBatchCancelled();
@@ -246,7 +247,7 @@ public:
   }
 
   void testModelUpdatedWhenAutoreductionResumed() {
-    auto presenter = makePresenter();
+    auto presenter = makePresenter(makeModel());
     EXPECT_CALL(*m_jobManager, notifyAutoreductionResumed()).Times(1);
     EXPECT_CALL(*m_jobManager, notifyAutoreductionPaused()).Times(0);
     presenter->notifyResumeAutoreductionRequested();
@@ -254,14 +255,14 @@ public:
   }
 
   void testRunsPresenterCalledWhenAutoreductionResumed() {
-    auto presenter = makePresenter();
+    auto presenter = makePresenter(makeModel());
     EXPECT_CALL(*m_runsPresenter, resumeAutoreduction()).Times(1);
     presenter->notifyResumeAutoreductionRequested();
     verifyAndClear();
   }
 
   void testModelResetWhenAutoreductionCancelled() {
-    auto presenter = makePresenter();
+    auto presenter = makePresenter(makeModel());
     EXPECT_CALL(*m_runsPresenter, resumeAutoreduction()).Times(1).WillOnce(Return(false));
     EXPECT_CALL(*m_jobManager, notifyAutoreductionPaused()).Times(1);
     presenter->notifyResumeAutoreductionRequested();
@@ -269,14 +270,14 @@ public:
   }
 
   void testOtherPresentersUpdatedWhenAutoreductionResumed() {
-    auto presenter = makePresenter();
+    auto presenter = makePresenter(makeModel());
     expectAutoreductionResumed();
     presenter->notifyResumeAutoreductionRequested();
     verifyAndClear();
   }
 
   void testChildPresentersNotUpdatedWhenAutoreductionCanelled() {
-    auto presenter = makePresenter();
+    auto presenter = makePresenter(makeModel());
     EXPECT_CALL(*m_runsPresenter, resumeAutoreduction()).Times(1).WillOnce(Return(false));
     EXPECT_CALL(*m_savePresenter, notifyAutoreductionResumed()).Times(0);
     EXPECT_CALL(*m_eventPresenter, notifyAutoreductionResumed()).Times(0);
@@ -288,28 +289,28 @@ public:
   }
 
   void testModelUpdatedWhenAutoreductionPaused() {
-    auto presenter = makePresenter();
+    auto presenter = makePresenter(makeModel());
     EXPECT_CALL(*m_jobManager, notifyAutoreductionPaused()).Times(1);
     presenter->notifyPauseAutoreductionRequested();
     verifyAndClear();
   }
 
   void testBatchIsCancelledWhenAutoreductionPaused() {
-    auto presenter = makePresenter();
+    auto presenter = makePresenter(makeModel());
     EXPECT_CALL(m_jobRunner, cancelAlgorithmQueue()).Times(1);
     presenter->notifyPauseAutoreductionRequested();
     verifyAndClear();
   }
 
   void testOtherPresentersUpdatedWhenAutoreductionPaused() {
-    auto presenter = makePresenter();
+    auto presenter = makePresenter(makeModel());
     expectAutoreductionPaused();
     presenter->notifyPauseAutoreductionRequested();
     verifyAndClear();
   }
 
   void testAutoreductionComplete() {
-    auto presenter = makePresenter();
+    auto presenter = makePresenter(makeModel());
     EXPECT_CALL(*m_runsPresenter, autoreductionCompleted()).Times(1);
     EXPECT_CALL(*m_runsPresenter, notifyRowStateChanged()).Times(1);
     presenter->notifyAutoreductionCompleted();
@@ -317,14 +318,14 @@ public:
   }
 
   void testNextBatchIsStartedWhenBatchFinished() {
-    auto presenter = makePresenter();
+    auto presenter = makePresenter(makeModel());
     expectBatchIsExecuted();
     presenter->notifyBatchComplete(false);
     verifyAndClear();
   }
 
   void testChildPresentersUpdatedWhenBatchFinishedAndNothingLeftToProcess() {
-    auto presenter = makePresenter();
+    auto presenter = makePresenter(makeModel());
     EXPECT_CALL(*m_jobManager, getAlgorithms()).Times(1).WillOnce(Return(std::deque<IConfiguredAlgorithm_sptr>()));
     expectReductionPaused();
     presenter->notifyBatchComplete(false);
@@ -332,7 +333,7 @@ public:
   }
 
   void testNotifyAlgorithmStarted() {
-    auto presenter = makePresenter();
+    auto presenter = makePresenter(makeModel());
     IConfiguredAlgorithm_sptr algorithm = std::make_shared<MockBatchJobAlgorithm>();
     auto row = makeRow();
     EXPECT_CALL(*m_jobManager, getRunsTableItem(algorithm)).Times(1).WillOnce(Return(row));
@@ -344,7 +345,7 @@ public:
   }
 
   void testNotifyAlgorithmComplete() {
-    auto presenter = makePresenter();
+    auto presenter = makePresenter(makeModel());
     IConfiguredAlgorithm_sptr algorithm = std::make_shared<MockBatchJobAlgorithm>();
     auto row = makeRow();
     EXPECT_CALL(*m_jobManager, getRunsTableItem(algorithm)).Times(1).WillOnce(Return(row));
@@ -356,7 +357,7 @@ public:
   }
 
   void testNotifyAlgorithmStartedSkipsNonItems() {
-    auto presenter = makePresenter();
+    auto presenter = makePresenter(makeModel());
     IConfiguredAlgorithm_sptr algorithm = std::make_shared<MockBatchJobAlgorithm>();
     EXPECT_CALL(*m_jobManager, getRunsTableItem(algorithm)).Times(1).WillOnce(Return(boost::none));
     EXPECT_CALL(*m_jobManager, algorithmStarted(_)).Times(0);
@@ -367,7 +368,7 @@ public:
   }
 
   void testNotifyAlgorithmCompleteSkipsNonItems() {
-    auto presenter = makePresenter();
+    auto presenter = makePresenter(makeModel());
     IConfiguredAlgorithm_sptr algorithm = std::make_shared<MockBatchJobAlgorithm>();
     EXPECT_CALL(*m_jobManager, getRunsTableItem(algorithm)).Times(1).WillOnce(Return(boost::none));
     EXPECT_CALL(*m_jobManager, algorithmComplete(_)).Times(0);
@@ -378,7 +379,7 @@ public:
   }
 
   void testNotifyAlgorithmErrorSkipsNonItems() {
-    auto presenter = makePresenter();
+    auto presenter = makePresenter(makeModel());
     IConfiguredAlgorithm_sptr algorithm = std::make_shared<MockBatchJobAlgorithm>();
     EXPECT_CALL(*m_jobManager, getRunsTableItem(algorithm)).Times(1).WillOnce(Return(boost::none));
     EXPECT_CALL(*m_jobManager, algorithmError(_, _)).Times(0);
@@ -389,7 +390,7 @@ public:
   }
 
   void testOutputWorkspacesSavedOnAlgorithmComplete() {
-    auto presenter = makePresenter();
+    auto presenter = makePresenter(makeModel());
     IConfiguredAlgorithm_sptr algorithm = std::make_shared<MockBatchJobAlgorithm>();
     EXPECT_CALL(*m_savePresenter, shouldAutosave()).Times(1).WillOnce(Return(true));
     auto const workspaces = std::vector<std::string>{"test1", "test2"};
@@ -403,7 +404,7 @@ public:
   }
 
   void testOutputWorkspacesNotSavedIfAutosaveDisabled() {
-    auto presenter = makePresenter();
+    auto presenter = makePresenter(makeModel());
     IConfiguredAlgorithm_sptr algorithm = std::make_shared<MockBatchJobAlgorithm>();
     EXPECT_CALL(*m_savePresenter, shouldAutosave()).Times(1).WillOnce(Return(false));
     auto row = makeRow();
@@ -416,7 +417,7 @@ public:
   }
 
   void testNotifyAlgorithmError() {
-    auto presenter = makePresenter();
+    auto presenter = makePresenter(makeModel());
     IConfiguredAlgorithm_sptr algorithm = std::make_shared<MockBatchJobAlgorithm>();
     auto const errorMessage = std::string("test error");
     auto row = makeRow();
@@ -429,7 +430,7 @@ public:
   }
 
   void testModelUpdatedWhenWorkspaceDeleted() {
-    auto presenter = makePresenter();
+    auto presenter = makePresenter(makeModel());
     auto name = std::string("test_workspace");
     EXPECT_CALL(*m_jobManager, notifyWorkspaceDeleted(name)).Times(1);
     presenter->postDeleteHandle(name);
@@ -437,7 +438,7 @@ public:
   }
 
   void testRowStateUpdatedWhenWorkspaceDeleted() {
-    auto presenter = makePresenter();
+    auto presenter = makePresenter(makeModel());
     EXPECT_CALL(*m_runsPresenter, notifyRowOutputsChanged(_)).Times(1);
     EXPECT_CALL(*m_runsPresenter, notifyRowStateChanged(_)).Times(1);
     presenter->postDeleteHandle("");
@@ -445,7 +446,7 @@ public:
   }
 
   void testModelUpdatedWhenWorkspaceRenamed() {
-    auto presenter = makePresenter();
+    auto presenter = makePresenter(makeModel());
     auto oldName = std::string("test_workspace1");
     auto newName = std::string("test_workspace2");
     EXPECT_CALL(*m_jobManager, notifyWorkspaceRenamed(oldName, newName)).Times(1);
@@ -454,7 +455,7 @@ public:
   }
 
   void testRowStateUpdatedWhenWorkspaceRenamed() {
-    auto presenter = makePresenter();
+    auto presenter = makePresenter(makeModel());
     EXPECT_CALL(*m_runsPresenter, notifyRowOutputsChanged(_)).Times(1);
     EXPECT_CALL(*m_runsPresenter, notifyRowStateChanged(_)).Times(1);
     presenter->renameHandle("", "");
@@ -462,14 +463,14 @@ public:
   }
 
   void testModelUpdatedWhenWorkspacesCleared() {
-    auto presenter = makePresenter();
+    auto presenter = makePresenter(makeModel());
     EXPECT_CALL(*m_jobManager, notifyAllWorkspacesDeleted()).Times(1);
     presenter->clearADSHandle();
     verifyAndClear();
   }
 
   void testRowStateUpdatedWhenWorkspacesCleared() {
-    auto presenter = makePresenter();
+    auto presenter = makePresenter(makeModel());
     EXPECT_CALL(*m_runsPresenter, notifyRowOutputsChanged()).Times(1);
     EXPECT_CALL(*m_runsPresenter, notifyRowStateChanged()).Times(1);
     presenter->clearADSHandle();
@@ -477,7 +478,7 @@ public:
   }
 
   void testPercentCompleteIsRequestedFromJobManager() {
-    auto presenter = makePresenter();
+    auto presenter = makePresenter(makeModel());
     auto progress = 33;
     EXPECT_CALL(*m_jobManager, percentComplete()).Times(1).WillOnce(Return(progress));
     TS_ASSERT_EQUALS(presenter->percentComplete(), progress);
@@ -485,7 +486,7 @@ public:
   }
 
   void testRunsPresenterNotifiesSetRoundPrecision() {
-    auto presenter = makePresenter();
+    auto presenter = makePresenter(makeModel());
     auto prec = 2;
     EXPECT_CALL(*m_runsPresenter, setRoundPrecision(prec));
     presenter->notifySetRoundPrecision(prec);
@@ -493,28 +494,28 @@ public:
   }
 
   void testRunsPresenterNotifiesResetRoundPrecision() {
-    auto presenter = makePresenter();
+    auto presenter = makePresenter(makeModel());
     EXPECT_CALL(*m_runsPresenter, resetRoundPrecision());
     presenter->notifyResetRoundPrecision();
     verifyAndClear();
   }
 
   void testNotifyBatchLoaded() {
-    auto presenter = makePresenter();
+    auto presenter = makePresenter(makeModel());
     EXPECT_CALL(*m_runsPresenter, notifyBatchLoaded());
     presenter->notifyBatchLoaded();
     verifyAndClear();
   }
 
   void testWarningShownOnResumeWhenExperimentSettingsInvalid() {
-    auto presenter = makePresenter();
+    auto presenter = makePresenter(makeModel());
     EXPECT_CALL(*m_experimentPresenter, hasValidSettings()).Times(1).WillOnce(Return(false));
     EXPECT_CALL(m_messageHandler, giveUserCritical(_, _)).Times(1);
     presenter->notifyResumeReductionRequested();
   }
 
   void testWarningShownOnAutoreduceWhenExperimentSettingsInvalid() {
-    auto presenter = makePresenter();
+    auto presenter = makePresenter(makeModel());
     EXPECT_CALL(*m_experimentPresenter, hasValidSettings()).Times(1).WillOnce(Return(false));
     EXPECT_CALL(m_messageHandler, giveUserCritical(_, _)).Times(1);
     presenter->notifyResumeAutoreductionRequested();
@@ -544,7 +545,7 @@ private:
     friend class BatchPresenterTest;
 
   public:
-    BatchPresenterFriend(IBatchView *view, std::unique_ptr<Batch> model, IJobRunner *jobRunner,
+    BatchPresenterFriend(IBatchView *view, std::unique_ptr<IBatch> model, IJobRunner *jobRunner,
                          std::unique_ptr<IRunsPresenter> runsPresenter, std::unique_ptr<IEventPresenter> eventPresenter,
                          std::unique_ptr<IExperimentPresenter> experimentPresenter,
                          std::unique_ptr<IInstrumentPresenter> instrumentPresenter,
@@ -558,11 +559,13 @@ private:
 
   RunsTable makeRunsTable() { return RunsTable(m_instruments, m_tolerance, ReductionJobs()); }
 
-  std::unique_ptr<Batch> makeModel() {
+  std::unique_ptr<IBatch> makeModel() {
     return std::make_unique<Batch>(m_experiment, m_instrument, m_runsTable, m_slicing);
   }
 
-  std::unique_ptr<BatchPresenterFriend> makePresenter() {
+  std::unique_ptr<IBatch> makeMockModel() { return std::make_unique<MockBatch>(); }
+
+  std::unique_ptr<BatchPresenterFriend> makePresenter(std::unique_ptr<IBatch> batchModel) {
     // Create pointers to the child presenters and pass them into the batch
     auto runsPresenter = std::make_unique<NiceMock<MockRunsPresenter>>();
     auto eventPresenter = std::make_unique<NiceMock<MockEventPresenter>>();
@@ -578,7 +581,7 @@ private:
     m_previewPresenter = previewPresenter.get();
     // Create the batch presenter
     auto presenter = std::make_unique<BatchPresenterFriend>(
-        &m_view, makeModel(), &m_jobRunner, std::move(runsPresenter), std::move(eventPresenter),
+        &m_view, std::move(batchModel), &m_jobRunner, std::move(runsPresenter), std::move(eventPresenter),
         std::move(experimentPresenter), std::move(instrumentPresenter), std::move(savePresenter),
         std::move(previewPresenter), &m_messageHandler);
     presenter->acceptMainPresenter(&m_mainPresenter);

--- a/qt/scientific_interfaces/ISISReflectometry/test/Batch/BatchPresenterTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Batch/BatchPresenterTest.h
@@ -536,6 +536,14 @@ public:
     presenter->notifyRowContentChanged(row);
   }
 
+  void testModelInformedWhenGroupNameChanged() {
+    auto mock = makeMockModel();
+    auto group = makeGroupWithOneRow();
+    EXPECT_CALL(*mock, updateLookupIndexesOfGroup(group)).Times(1);
+    auto presenter = makePresenter(std::move(mock));
+    presenter->notifyGroupNameChanged(group);
+  }
+
 private:
   NiceMock<MockBatchView> m_view;
   NiceMock<MockBatchJobManager> *m_jobManager;

--- a/qt/scientific_interfaces/ISISReflectometry/test/Batch/BatchPresenterTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Batch/BatchPresenterTest.h
@@ -521,6 +521,13 @@ public:
     presenter->notifyResumeAutoreductionRequested();
   }
 
+  void testAllIndexesUpdatedWhenSettingsChanged() {
+    auto mock = makeMockModel();
+    EXPECT_CALL(*mock, updateLookupIndexesOfTable()).Times(1);
+    auto presenter = makePresenter(std::move(mock));
+    presenter->notifySettingsChanged();
+  }
+
 private:
   NiceMock<MockBatchView> m_view;
   NiceMock<MockBatchJobManager> *m_jobManager;
@@ -563,7 +570,7 @@ private:
     return std::make_unique<Batch>(m_experiment, m_instrument, m_runsTable, m_slicing);
   }
 
-  std::unique_ptr<IBatch> makeMockModel() { return std::make_unique<MockBatch>(); }
+  std::unique_ptr<MockBatch> makeMockModel() { return std::make_unique<MockBatch>(); }
 
   std::unique_ptr<BatchPresenterFriend> makePresenter(std::unique_ptr<IBatch> batchModel) {
     // Create pointers to the child presenters and pass them into the batch

--- a/qt/scientific_interfaces/ISISReflectometry/test/Reduction/MockBatch.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Reduction/MockBatch.h
@@ -34,5 +34,8 @@ public:
   MOCK_METHOD(void, resetSkippedItems, (), (override));
   MOCK_METHOD(void, resetState, (), (override));
   MOCK_METHOD(std::vector<MantidWidgets::Batch::RowLocation>, selectedRowLocations, (), (const, override));
+  MOCK_METHOD(void, updateLookupIndex, (Row &), (override));
+  MOCK_METHOD(void, updateLookupIndexesOfGroup, (Group &), (override));
+  MOCK_METHOD(void, updateLookupIndexesOfTable, (), (override));
 };
 } // namespace MantidQt::CustomInterfaces::ISISReflectometry

--- a/qt/scientific_interfaces/ISISReflectometry/test/Reduction/MockBatch.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Reduction/MockBatch.h
@@ -10,6 +10,7 @@
 #include "../../Reduction/IBatch.h"
 #include "../../Reduction/Instrument.h"
 #include "../../Reduction/LookupRow.h"
+#include "../../Reduction/RunsTable.h"
 #include "MantidFrameworkTestHelpers/FallbackBoostOptionalIO.h"
 
 #include <gmock/gmock.h>
@@ -20,8 +21,18 @@ public:
   virtual ~MockBatch() = default;
   MOCK_METHOD(Experiment const &, experiment, (), (const, override));
   MOCK_METHOD(Instrument const &, instrument, (), (const, override));
+  MOCK_METHOD(RunsTable &, mutableRunsTable, (), (override));
+  MOCK_METHOD(RunsTable const &, runsTable, (), (const, override));
   MOCK_METHOD(Slicing const &, slicing, (), (const, override));
-  MOCK_METHOD(boost::optional<LookupRow>, findWildcardLookupRow, (), (const, override));
+
   MOCK_METHOD(boost::optional<LookupRow>, findLookupRow, (Row const &), (const, override));
+  MOCK_METHOD(boost::optional<LookupRow>, findWildcardLookupRow, (), (const, override));
+  MOCK_METHOD(boost::optional<Item &>, getItemWithOutputWorkspaceOrNone, (std::string const &), (override));
+  MOCK_METHOD(bool, isInSelection, (const Item &, const std::vector<MantidWidgets::Batch::RowLocation> &), (override));
+  MOCK_METHOD(bool, isInSelection, (const Row &, const std::vector<MantidWidgets::Batch::RowLocation> &), (override));
+  MOCK_METHOD(bool, isInSelection, (const Group &, const std::vector<MantidWidgets::Batch::RowLocation> &), (override));
+  MOCK_METHOD(void, resetSkippedItems, (), (override));
+  MOCK_METHOD(void, resetState, (), (override));
+  MOCK_METHOD(std::vector<MantidWidgets::Batch::RowLocation>, selectedRowLocations, (), (const, override));
 };
 } // namespace MantidQt::CustomInterfaces::ISISReflectometry

--- a/qt/scientific_interfaces/ISISReflectometry/test/ReflMockObjects.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/ReflMockObjects.h
@@ -37,6 +37,7 @@
 #include "MantidKernel/ICatalogInfo.h"
 #include "MantidKernel/ProgressBase.h"
 #include "MantidKernel/WarningSuppressions.h"
+#include "MantidQtWidgets/Common/Batch/RowLocation.h"
 #include "MantidQtWidgets/Common/BatchAlgorithmRunner.h"
 #include "MantidQtWidgets/Common/Hint.h"
 #include "Reduction/PreviewRow.h"
@@ -127,6 +128,7 @@ public:
   MOCK_METHOD0(notifyAnyBatchAutoreductionResumed, void());
   MOCK_METHOD1(notifyInstrumentChanged, void(std::string const &));
   MOCK_METHOD0(notifyTableChanged, void());
+  MOCK_METHOD1(notifyRowContentChanged, void(Row &));
   MOCK_METHOD0(settingsChanged, void());
   MOCK_METHOD0(notifyChangesSaved, void());
   MOCK_METHOD0(notifyBatchLoaded, void());

--- a/qt/scientific_interfaces/ISISReflectometry/test/ReflMockObjects.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/ReflMockObjects.h
@@ -86,6 +86,7 @@ public:
   MOCK_METHOD0(notifyResetRoundPrecision, void());
   MOCK_METHOD0(notifyBatchLoaded, void());
   MOCK_METHOD1(notifyRowContentChanged, void(Row &));
+  MOCK_METHOD1(notifyGroupNameChanged, void(Group &));
 
   MOCK_CONST_METHOD0(isProcessing, bool());
   MOCK_CONST_METHOD0(isAutoreducing, bool());

--- a/qt/scientific_interfaces/ISISReflectometry/test/ReflMockObjects.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/ReflMockObjects.h
@@ -85,6 +85,8 @@ public:
   MOCK_METHOD1(notifySetRoundPrecision, void(int &));
   MOCK_METHOD0(notifyResetRoundPrecision, void());
   MOCK_METHOD0(notifyBatchLoaded, void());
+  MOCK_METHOD1(notifyRowContentChanged, void(Row &));
+
   MOCK_CONST_METHOD0(isProcessing, bool());
   MOCK_CONST_METHOD0(isAutoreducing, bool());
   MOCK_CONST_METHOD0(isAnyBatchProcessing, bool());

--- a/qt/scientific_interfaces/ISISReflectometry/test/ReflMockObjects.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/ReflMockObjects.h
@@ -131,6 +131,7 @@ public:
   MOCK_METHOD1(notifyInstrumentChanged, void(std::string const &));
   MOCK_METHOD0(notifyTableChanged, void());
   MOCK_METHOD1(notifyRowContentChanged, void(Row &));
+  MOCK_METHOD1(notifyGroupNameChanged, void(Group &));
   MOCK_METHOD0(settingsChanged, void());
   MOCK_METHOD0(notifyChangesSaved, void());
   MOCK_METHOD0(notifyBatchLoaded, void());

--- a/qt/scientific_interfaces/ISISReflectometry/test/Runs/RunsPresenterTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Runs/RunsPresenterTest.h
@@ -791,6 +791,14 @@ public:
     verifyAndClear();
   }
 
+  void testNotifyRowContentChanged() {
+    auto presenter = makePresenter();
+    auto row = makeRow(0.5);
+    EXPECT_CALL(m_mainPresenter, notifyRowContentChanged(row));
+    presenter.notifyRowContentChanged(row);
+    verifyAndClear();
+  }
+
 private:
   class RunsPresenterFriend : public RunsPresenter {
     friend class RunsPresenterTest;

--- a/qt/scientific_interfaces/ISISReflectometry/test/Runs/RunsPresenterTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Runs/RunsPresenterTest.h
@@ -799,6 +799,14 @@ public:
     verifyAndClear();
   }
 
+  void testNotifyGroupNameChanged() {
+    auto presenter = makePresenter();
+    auto group = makeGroupWithOneRow();
+    EXPECT_CALL(m_mainPresenter, notifyGroupNameChanged(group));
+    presenter.notifyGroupNameChanged(group);
+    verifyAndClear();
+  }
+
 private:
   class RunsPresenterFriend : public RunsPresenter {
     friend class RunsPresenterTest;

--- a/qt/scientific_interfaces/ISISReflectometry/test/RunsTable/RunsTablePresenterDisplayTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/RunsTable/RunsTablePresenterDisplayTest.h
@@ -246,12 +246,23 @@ public:
   }
 
   void testNotifyBatchRowCellChanged() {
+    auto constexpr groupIndex = 1;
+    auto constexpr rowIndex = 1;
+    auto constexpr cellIndex = 1;
     auto reductionJobs = twoGroupsWithMixedRowsModel();
     auto presenter = makePresenter(m_view, reductionJobs);
-    auto const rowLocation = location(0, 0);
-    ON_CALL(m_jobs, cellAt(rowLocation, 0)).WillByDefault(Return(Cell("")));
-    EXPECT_CALL(m_mainPresenter, notifyRowContentChanged(_)).Times(1);
-    presenter.notifyCellTextChanged(rowLocation, 0, "", "");
+    auto const rowLocation = location(groupIndex, rowIndex);
+    ON_CALL(m_jobs, cellAt(rowLocation, cellIndex)).WillByDefault(Return(Cell("")));
+    // This extra call is needed to sort out some row states that get changed by calls to Update Row. That's not what
+    // we're testing here, so just get the state in line before checking notify is called correctly.
+    presenter.notifyCellTextChanged(rowLocation, cellIndex, "", "");
+    EXPECT_CALL(m_mainPresenter, notifyRowContentChanged(presenter.mutableRunsTable()
+                                                             .mutableReductionJobs()
+                                                             .mutableGroups()[groupIndex]
+                                                             .mutableRows()[rowIndex]
+                                                             .get()))
+        .Times(1);
+    presenter.notifyCellTextChanged(rowLocation, cellIndex, "", "");
     verifyAndClearExpectations();
   }
 

--- a/qt/scientific_interfaces/ISISReflectometry/test/RunsTable/RunsTablePresenterDisplayTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/RunsTable/RunsTablePresenterDisplayTest.h
@@ -245,6 +245,16 @@ public:
     verifyAndClearExpectations();
   }
 
+  void testNotifyBatchRowCellChanged() {
+    auto reductionJobs = twoGroupsWithMixedRowsModel();
+    auto presenter = makePresenter(m_view, reductionJobs);
+    auto const rowLocation = location(0, 0);
+    ON_CALL(m_jobs, cellAt(rowLocation, 0)).WillByDefault(Return(Cell("")));
+    EXPECT_CALL(m_mainPresenter, notifyRowContentChanged(_)).Times(1);
+    presenter.notifyCellTextChanged(rowLocation, 0, "", "");
+    verifyAndClearExpectations();
+  }
+
 private:
   ReductionJobs oneGroupWithTwoRowsWithSrcAndDestTransRuns() {
     auto reductionJobs = ReductionJobs();

--- a/qt/scientific_interfaces/ISISReflectometry/test/RunsTable/RunsTablePresenterDisplayTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/RunsTable/RunsTablePresenterDisplayTest.h
@@ -255,6 +255,16 @@ public:
     verifyAndClearExpectations();
   }
 
+  void testMainPresenterBatchThatGroupNameChanged() {
+    auto reductionJobs = twoGroupsWithMixedRowsModel();
+    auto presenter = makePresenter(m_view, reductionJobs);
+    auto const groupLocation = location(0);
+    ON_CALL(m_jobs, cellAt(groupLocation, 0)).WillByDefault(Return(Cell("")));
+    EXPECT_CALL(m_mainPresenter, notifyGroupNameChanged(_)).Times(1);
+    presenter.notifyCellTextChanged(groupLocation, 0, "old", "new");
+    verifyAndClearExpectations();
+  }
+
 private:
   ReductionJobs oneGroupWithTwoRowsWithSrcAndDestTransRuns() {
     auto reductionJobs = ReductionJobs();


### PR DESCRIPTION
**Description of work.**
Adds calls through the gui's presenter layers to inform the model that it needs to update rows. 
When:
- Exp Settings are changed, update all rows in the runs table
- a Group name is changed, update all rows in the group
- a Row's cell is changed, update that row

**To test:**
1. Load a batch, (ask me on slack for a file with some values already filled in, it's much easier than filling it all in yourself)
2. Take note of what matches should occur, (E.g: The run with an angle of 0.7 and a group name containing MAB should take the dQ/Q value from that row in the experiements settings tab)
3. Hit process on the runs tab
4. Check the right values were used. 

Fixes #33625 

*This does not require release notes* because **there are not yet any user facing changes.**


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
