### PR TITLE
Updated call to file location in release script

### DIFF
--- a/tools/release_generator/release.py
+++ b/tools/release_generator/release.py
@@ -8,7 +8,6 @@
 
 import os
 import pathlib
-import sys
 
 DOCS = {
     'index.rst': '''.. _v{version}:
@@ -134,13 +133,13 @@ def getTemplate(technique):
 
 
 def getReleaseRoot() -> pathlib.Path:
-    program_path = pathlib.Path((sys.argv[0])[0])
+    program_path = pathlib.Path(__file__).resolve()
     release_path = program_path / '../../../docs/source/release/'
     return release_path.resolve()
 
 
 def getTemplateRoot() -> pathlib.Path:
-    program_path = pathlib.Path((sys.argv[0])[0])
+    program_path = pathlib.Path(__file__).resolve()
     template_path = program_path / '../../../docs/source/release/templates/'
     return template_path.resolve()
 


### PR DESCRIPTION
**Description of work.**

After testing the new Release Editor script (#33700) for the release period it because clear that using ```sys.argv``` call as the starting point for relative paths could cause the script to fail. This is because we were assuming the current directory and the location of the script were one and the same and sometimes it isn't. A relatively simple fix was to switch to the location of the script file instead.

**To test:**

1. Navigate to the ../tools/release_generator folder in your command line
2. run ```python release.py --release 6.5.0 --milestone "Release 6.5"```
3. Check that v6.5.0 release notes have been created, including subfolders containing .gitkeep files

*There is no associated issue.*

*This does not require release notes* because **this is a minor change to a developer script**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
