### PR TITLE
Add all variations of TOML to file filter

### DIFF
--- a/docs/source/release/v6.4.0/SANS/Bugfixes/33284_ext.rst
+++ b/docs/source/release/v6.4.0/SANS/Bugfixes/33284_ext.rst
@@ -1,0 +1,1 @@
+- The ISIS SANS Interface now will correctly find "txt", "Txt", "TXT", "toml", "Toml", and "TOML" extensions on case sensitive platforms

--- a/scripts/Interface/ui/sans_isis/sans_data_processor_gui.py
+++ b/scripts/Interface/ui/sans_isis/sans_data_processor_gui.py
@@ -575,7 +575,7 @@ class SANSDataProcessorGui(QMainWindow,
         Load the user file
         """
         # Load the user file
-        load_file(self.user_file_line_edit, "TOML Files (*.toml, *.TOML);; Text Files (*.txt)",
+        load_file(self.user_file_line_edit, "TOML Files (*.toml *.Toml *.TOML);; Text Files (*.txt *.Txt *.TXT)",
                   self.__generic_settings, self.__path_key, self.get_user_file_path)
 
         # Set full user file path for default loading


### PR DESCRIPTION
**Description of work.**

This is particularly important on POSIX platforms where case matters.
Since we've seen all three forms and the comma is incorrect fix both at
once for TOML and apply the same change for .txt

**To test:**
Create empty files with the extensions:
- txt
- Txt
- TXT
- toml
- Toml
- TOML

Open the ISIS SANS interface
Go to user file, ensure all of them appear in the file filter dialog.

Part of #33284 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
