### PR TITLE
Fix a bug where unsupported toml files stop GUI opening

### DIFF
--- a/scripts/SANS/sans/gui_logic/models/file_loading.py
+++ b/scripts/SANS/sans/gui_logic/models/file_loading.py
@@ -32,7 +32,7 @@ class FileLoading:
             return parser.parse_toml_file(file_path, file_information=file_information)
         except KeyError as e:
             raise UserFileLoadException(f"The following key is missing: {e}")
-        except ValueError as e:
+        except (NotImplementedError, ValueError) as e:
             raise UserFileLoadException(e)
 
     @staticmethod

--- a/scripts/test/SANS/gui_logic/models/test_file_loading.py
+++ b/scripts/test/SANS/gui_logic/models/test_file_loading.py
@@ -22,7 +22,7 @@ class FileLoadingTest(unittest.TestCase):
             self.assertEquals(result, mocked_parser.parse_toml_file.return_value)
 
     def test_wraps_exceptions_toml(self):
-        expected_wrapped = [KeyError(), ValueError()]
+        expected_wrapped = [KeyError(), NotImplementedError(), ValueError()]
 
         for known_exception in expected_wrapped:
             with mock.patch("sans.gui_logic.models.file_loading.TomlParser") as mocked_module:


### PR DESCRIPTION
The SANS GUI remembers previously-opened user files. If you had previously opened a v0 toml file in a version of Mantid that supported v0, the SANS GUI will attempt to reload it. This will now fail because v0 is no longer supported. This is expected; however, there was a bug where this was causing an unhandled exception which was stopping the GUI opening at all. This commit wraps the exception in the same way as other expected exceptions meaning that it is now handled correctly.

Fixes #33718

**To test:**

Follow the instructions in the linked issue. You should now get a pop up warning about the unsupported file. On clicking OK the SANS GUI should open successfully. The user file should be empty. You should only get the warning once - if you close and reopen the GUI the warning should not reappear.

![image](https://user-images.githubusercontent.com/12895056/161110899-a1be81b1-f46c-4473-96a7-3b1a357f4ff3.png)

*This does not require release notes* because **it fixes a regression in development**


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
