### PR TITLE
Avoid reloading user file when editing the table

### DIFF
--- a/scripts/SANS/sans/common/file_information.py
+++ b/scripts/SANS/sans/common/file_information.py
@@ -724,9 +724,14 @@ class SANSFileInformation(metaclass=ABCMeta):
         self._run_number = self._init_run_number()
 
     def __eq__(self, other):
-        if type(other) is type(self):
-            return self.__dict__ == other.__dict__
-        return False
+        if not type(other) is type(self):
+            return False
+
+        return self.get_instrument() == other.get_instrument() and \
+            self.get_facility() == other.get_facility() and \
+            self.get_type() == other.get_type() and \
+            self.is_event_mode() == other.is_event_mode() and \
+            self.is_added_data() == other.is_added_data()
 
     @abstractmethod
     def get_file_name(self):

--- a/scripts/SANS/sans/gui_logic/presenter/presenter_common.py
+++ b/scripts/SANS/sans/gui_logic/presenter/presenter_common.py
@@ -56,4 +56,6 @@ class PresenterCommon(metaclass=ABCMeta):
             return
         if decimal_places:
             attribute = round(attribute,decimal_places)
-        setattr(view, attribute_name, attribute)
+        old_attribute = getattr(view, attribute_name)
+        if attribute != old_attribute:
+            setattr(view, attribute_name, attribute)

--- a/scripts/SANS/sans/gui_logic/presenter/run_tab_presenter.py
+++ b/scripts/SANS/sans/gui_logic/presenter/run_tab_presenter.py
@@ -483,7 +483,8 @@ class RunTabPresenter(PresenterCommon):
         for row in self._table_model.get_non_empty_rows():
             try:
                 file_info = row.file_information
-            except (ValueError, RuntimeError, OSError):
+                break
+            except (ValueError, RuntimeError):
                 pass
 
         if self._file_information != file_info:


### PR DESCRIPTION
Experimental fix - still need to check if this works properly.

This PR fixes a bug where the SANS interface settings were being reset when editing the runs table. See the commit messages for explanation.

Fixes #30306

**To test:**

Follow the instructions in the linked issue and ensure the settings are _not_ reset when editing the table.

Release notes to follow

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
