### PR TITLE
load pelican data with larger eos bin event file (no ticket)

### DIFF
--- a/Framework/DataHandling/inc/MantidDataHandling/LoadPLN.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadPLN.h
@@ -96,7 +96,7 @@ protected:
 
   // shared member variables
   DataObjects::EventWorkspace_sptr m_localWorkspace;
-  int32_t m_datasetIndex;
+  int32_t m_datasetIndex{0};
   std::string m_startRun;
   std::vector<double> m_detectorL2;
 };

--- a/Framework/DataHandling/inc/MantidDataHandling/LoadPLN.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadPLN.h
@@ -92,7 +92,7 @@ protected:
                            std::vector<EventVector_pt> &eventVectors);
 
   // set up the detector masks
-  void setupDetectorMasks(std::vector<bool> &roi);
+  void setupDetectorMasks(const std::vector<bool> &roi);
 
   // shared member variables
   DataObjects::EventWorkspace_sptr m_localWorkspace;

--- a/Framework/DataHandling/src/LoadPLN.cpp
+++ b/Framework/DataHandling/src/LoadPLN.cpp
@@ -77,7 +77,7 @@ void AddSinglePointTimeSeriesProperty(API::LogManager &logManager, const std::st
 // Utility functions for loading values with defaults
 // Single value properties only support int, double, string and bool
 template <typename Type>
-Type GetNeXusValue(NeXus::NXEntry &entry, const std::string &path, const Type &defval, int32_t index) {
+Type GetNeXusValue(const NeXus::NXEntry &entry, const std::string &path, const Type &defval, int32_t index) {
   try {
     NeXus::NXDataSetTyped<Type> dataSet = entry.openNXDataSet<Type>(path);
     dataSet.load();
@@ -90,7 +90,8 @@ Type GetNeXusValue(NeXus::NXEntry &entry, const std::string &path, const Type &d
 
 // string and double are special cases
 template <>
-double GetNeXusValue<double>(NeXus::NXEntry &entry, const std::string &path, const double &defval, int32_t index) {
+double GetNeXusValue<double>(const NeXus::NXEntry &entry, const std::string &path, const double &defval,
+                             int32_t index) {
   try {
     NeXus::NXDataSetTyped<float> dataSet = entry.openNXDataSet<float>(path);
     dataSet.load();
@@ -102,7 +103,7 @@ double GetNeXusValue<double>(NeXus::NXEntry &entry, const std::string &path, con
 }
 
 template <>
-std::string GetNeXusValue<std::string>(NeXus::NXEntry &entry, const std::string &path, const std::string &defval,
+std::string GetNeXusValue<std::string>(const NeXus::NXEntry &entry, const std::string &path, const std::string &defval,
                                        int32_t /*unused*/) {
 
   try {
@@ -116,8 +117,8 @@ std::string GetNeXusValue<std::string>(NeXus::NXEntry &entry, const std::string 
 }
 
 template <typename T>
-void MapNeXusToProperty(NeXus::NXEntry &entry, const std::string &path, const T &defval, API::LogManager &logManager,
-                        const std::string &name, const T &factor, int32_t index) {
+void MapNeXusToProperty(const NeXus::NXEntry &entry, const std::string &path, const T &defval,
+                        API::LogManager &logManager, const std::string &name, const T &factor, int32_t index) {
 
   T value = GetNeXusValue<T>(entry, path, defval, index);
   logManager.addProperty<T>(name, value * factor);
@@ -125,7 +126,7 @@ void MapNeXusToProperty(NeXus::NXEntry &entry, const std::string &path, const T 
 
 // sting is a special case
 template <>
-void MapNeXusToProperty<std::string>(NeXus::NXEntry &entry, const std::string &path, const std::string &defval,
+void MapNeXusToProperty<std::string>(const NeXus::NXEntry &entry, const std::string &path, const std::string &defval,
                                      API::LogManager &logManager, const std::string &name,
                                      const std::string & /*unused*/, int32_t index) {
 
@@ -134,8 +135,9 @@ void MapNeXusToProperty<std::string>(NeXus::NXEntry &entry, const std::string &p
 }
 
 template <typename T>
-void MapNeXusToSeries(NeXus::NXEntry &entry, const std::string &path, const T &defval, API::LogManager &logManager,
-                      const std::string &time, const std::string &name, const T &factor, int32_t index) {
+void MapNeXusToSeries(const NeXus::NXEntry &entry, const std::string &path, const T &defval,
+                      API::LogManager &logManager, const std::string &time, const std::string &name, const T &factor,
+                      int32_t index) {
 
   auto value = GetNeXusValue<T>(entry, path, defval, index);
   AddSinglePointTimeSeriesProperty<T>(logManager, time, name, value * factor);

--- a/Framework/DataHandling/src/LoadPLN.cpp
+++ b/Framework/DataHandling/src/LoadPLN.cpp
@@ -319,10 +319,6 @@ public:
     // map the raw detector index to the physical model
     size_t xid = m_mapIndex[x];
 
-    // take the modules of the tof time to account for the
-    // longer background chopper rate
-    double mtof = tof < 0.0 ? fmod(tof + m_gatePeriod, m_gatePeriod) : fmod(tof, m_gatePeriod);
-
     size_t id = xid < DETECTOR_TUBES ? PIXELS_PER_TUBE * xid + y : DETECTOR_SPECTRA + xid;
     if (id >= m_roi.size())
       return;
@@ -333,6 +329,10 @@ public:
 
     // finally pass to specific handler
     if (m_maxEvents == 0 || m_processedEvents < m_maxEvents) {
+      // take the modulus of the tof time to account for the
+      // longer background chopper rate
+      double mtof = tof < 0.0 ? fmod(tof + m_gatePeriod, m_gatePeriod) : fmod(tof, m_gatePeriod);
+
       addEventImpl(id, xid, y, mtof);
       m_processedEvents++;
     } else {
@@ -652,7 +652,7 @@ void LoadPLN::loadDetectorL2Values() {
 }
 
 /// Set up the detector masks to the region of interest \p roi.
-void LoadPLN::setupDetectorMasks(std::vector<bool> &roi) {
+void LoadPLN::setupDetectorMasks(const std::vector<bool> &roi) {
 
   // count total number of masked bins
   size_t maskedBins = 0;

--- a/Framework/DataHandling/src/LoadPLN.cpp
+++ b/Framework/DataHandling/src/LoadPLN.cpp
@@ -124,7 +124,7 @@ void MapNeXusToProperty(const NeXus::NXEntry &entry, const std::string &path, co
   logManager.addProperty<T>(name, value * factor);
 }
 
-// sting is a special case
+// string is a special case
 template <>
 void MapNeXusToProperty<std::string>(const NeXus::NXEntry &entry, const std::string &path, const std::string &defval,
                                      API::LogManager &logManager, const std::string &name,

--- a/Framework/DataHandling/src/LoadPLN.cpp
+++ b/Framework/DataHandling/src/LoadPLN.cpp
@@ -193,7 +193,7 @@ public:
 
   bool read(char *s, std::streamsize n) { return static_cast<bool>(_ifs.read(s, n)); }
 
-  size_t size() { return _size; }
+  size_t size() const { return _size; }
 
   size_t position() { return _ifs.tellg(); }
 
@@ -270,8 +270,8 @@ public:
   EventProcessor(const std::vector<bool> &roi, const std::vector<size_t> &mapIndex, const double framePeriod,
                  const double gatePeriod, const TimeLimits &timeBoundary, size_t maxEvents)
       : m_roi(roi), m_mapIndex(mapIndex), m_framePeriod(framePeriod), m_gatePeriod(gatePeriod), m_frames(0),
-        m_framesValid(0), m_timeBoundary(timeBoundary), m_maxEvents(maxEvents), m_processedEvents(0),
-        m_droppedEvents(0) {}
+        m_framesValid(0), m_maxEvents(maxEvents), m_processedEvents(0), m_droppedEvents(0),
+        m_timeBoundary(timeBoundary) {}
 
   void newFrame() {
     if (m_maxEvents == 0 || m_processedEvents < m_maxEvents) {
@@ -641,7 +641,7 @@ void LoadPLN::exec(const std::string &hdfFile, const std::string &eventFile) {
 /// Recovers the L2 neutronic distance for each detector.
 void LoadPLN::loadDetectorL2Values() {
 
-  m_detectorL2 = std::vector<double>(HISTOGRAMS);
+  m_detectorL2.resize(HISTOGRAMS, 0.0);
   const auto &detectorInfo = m_localWorkspace->detectorInfo();
   auto detIDs = detectorInfo.detectorIDs();
   for (const auto detID : detIDs) {
@@ -757,7 +757,7 @@ void LoadPLN::loadParameters(const std::string &hdfFile, API::LogManager &logm) 
     auto nthTime = GetNeXusValue<int32_t>(entry, "instrument/detector/start_time", 0, m_datasetIndex);
 
     Types::Core::time_duration duration =
-        boost::posix_time::microseconds(static_cast<boost::int64_t>((nthTime - baseTime) * 1.0e6));
+        boost::posix_time::microseconds((static_cast<int64_t>(nthTime) - static_cast<int64_t>(baseTime)) * 1'000'000);
     Types::Core::DateAndTime startDataset(startTime + duration);
     m_startRun = startDataset.toISO8601String();
   } else {

--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -320,9 +320,6 @@ containerOutOfBounds:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/LoadPSIMuonB
 containerOutOfBounds:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/LoadPSIMuonBin.cpp:855
 useStlAlgorithm:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/LoadPSIMuonBin.cpp:206
 useStlAlgorithm:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/LoadPSIMuonBin.cpp:233
-constParameter:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/LoadPLN.cpp:93
-constParameter:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/LoadPLN.cpp:105
-constParameter:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/LoadPLN.cpp:643
 integerOverflowCond:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/LoadRaw/byte_rel_comp.cpp:59
 objectIndex:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/LoadRaw/isisraw.cpp:592
 objectIndex:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/LoadRaw/isisraw.cpp:593

--- a/docs/source/release/v6.4.0/Direct_Geometry/General/New_features/33722.rst
+++ b/docs/source/release/v6.4.0/Direct_Geometry/General/New_features/33722.rst
@@ -1,0 +1,1 @@
+- :ref:`LoadPLN <algm-LoadPLN>` now supports loading ANSTO PELICAN data during event capture mid experiment as a cross check for long experiments.


### PR DESCRIPTION
Pelican instrument data at ANSTO comprises a hdf file and related binary event file. The scientists can save a hdf file during an experiment but the event file is continually being updated. This change allows the scientist to load the hdf file with the portion of the event data that is relevent to ensure consistency. It is only used as a simple cross check that the experiment is proceeding as expected. The result is not used for any normal processing and the user is alerted to the unexpected difference in recorded events between the files.

**To test:**
This change does not change the results of any processing and the existing tests are still valid.

<!-- Instructions for testing. -->


There are no release notes as there is no functional change to the processing.


#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
