### PR TITLE
Fix failing system test on conda builds

### DIFF
--- a/Testing/SystemTests/tests/framework/ISIS/SANS/SANS2D/SANS2D_GDW20_4m_cycle_22_02.py
+++ b/Testing/SystemTests/tests/framework/ISIS/SANS/SANS2D/SANS2D_GDW20_4m_cycle_22_02.py
@@ -50,6 +50,7 @@ class SANS2D_GDW20_4m_22_02_2D_M4(systemtesting.MantidSystemTest):
         self.returned = WavRangeReduction()
 
     def validate(self):
+        self.tolerance = 7e-5  # Tolerance added to handle conda float rounding differences.
         self.disableChecking.append('Axes')
         self.disableChecking.append('Instrument')
         self.disableChecking.append('SpectraMap')


### PR DESCRIPTION

**Description of work.**

Builds on conda have slightly different float rounding in certain
situations. This should fix the failing test by adding a small
tolerance to account for the rounding.

**To test:**

1. Check system tests still pass. 

*There is no associated issue.*


*This does not require release notes* because **there are no user facing changes. This only edits a system test.**


<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
