### PR TITLE
Add clang and LLVM openmp to macOS conda environment

### DIFF
--- a/mantid-developer-osx.yml
+++ b/mantid-developer-osx.yml
@@ -49,3 +49,9 @@ dependencies:
   # Needed only for development
   - cppcheck==2.5
   - pre-commit>=2.12.0
+
+  # Use conda version of clang to get matching CXXFLAGS.
+  # Pinned to same version as conda forge: https://github.com/conda-forge/conda-forge-pinning-feedstock/blob/main/recipe/conda_build_config.yaml#L23
+  - clang_osx-64=12
+  - clangxx_osx-64=12
+  - llvm-openmp=12


### PR DESCRIPTION
We need to use the same compiler flags to compile mantid that conda-forge uses for its packages.
The best way is to use the same compilers.

**Description of work.**

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**

* Either create a [new conda environment](https://developer.mantidproject.org/GettingStarted/GettingStartedCondaOSX.html#gettingstartedcondaosx) or
* activate your existing `mantid-developer` environment and update it `mamba env update -f mantid-developer-osx.yml`
* In a clean directory, build the code
* Follow the issue instructions and there should be no segfault.

Fixes #33273 

*This does not require release notes* because **no bug actually existed it was to do with how we built the code.**

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
