### PR TITLE
Ignored OutputCompositeMembers fix

### DIFF
--- a/Framework/CurveFitting/src/Algorithms/Fit.cpp
+++ b/Framework/CurveFitting/src/Algorithms/Fit.cpp
@@ -114,6 +114,12 @@ void Fit::readProperties() {
 /// Initialize the minimizer for this fit.
 /// @param maxIterations :: Maximum number of iterations.
 void Fit::initializeMinimizer(size_t maxIterations) {
+  const bool unrollComposites = getProperty("OutputCompositeMembers");
+  bool convolveMembers = existsProperty("ConvolveMembers");
+  if (convolveMembers) {
+    convolveMembers = getProperty("ConvolveMembers");
+  }
+  m_domainCreator->separateCompositeMembersInOutput(unrollComposites, convolveMembers);
   m_costFunction = getCostFunctionInitialized();
   std::string minimizerName = getPropertyValue("Minimizer");
   m_minimizer = API::FuncMinimizerFactory::Instance().createMinimizer(minimizerName);
@@ -204,7 +210,7 @@ void Fit::finalizeMinimizer(size_t nIterations) {
   }
 }
 
-/// Create algorithm output worksapces.
+/// Create algorithm output workspaces.
 void Fit::createOutput() {
 
   // degrees of freedom
@@ -337,12 +343,6 @@ void Fit::createOutput() {
     bool outputParametersOnly = getProperty("OutputParametersOnly");
 
     if (!outputParametersOnly) {
-      const bool unrollComposites = getProperty("OutputCompositeMembers");
-      bool convolveMembers = existsProperty("ConvolveMembers");
-      if (convolveMembers) {
-        convolveMembers = getProperty("ConvolveMembers");
-      }
-      m_domainCreator->separateCompositeMembersInOutput(unrollComposites, convolveMembers);
       m_domainCreator->createOutputWorkspace(baseName, m_function, m_costFunction->getDomain(),
                                              m_costFunction->getValues());
     }

--- a/Framework/CurveFitting/src/MultiDomainCreator.cpp
+++ b/Framework/CurveFitting/src/MultiDomainCreator.cpp
@@ -71,15 +71,6 @@ void MultiDomainCreator::initFunction(API::IFunction_sptr function) {
       // get domain indices for this function
       mdFunction->getDomainIndices(iFun, m_creators.size(), domainIndices);
       if (!domainIndices.empty()) {
-        /*
-        if ( domainIndices.size() != 1 )
-        {
-          std::stringstream msg;
-          msg << "Function #" << iFun << " applies to multiple domains.\n"
-              << "Only one of the domains is used to set workspace.";
-          g_log.warning(msg.str());
-        }
-        */
         size_t index = domainIndices[0];
         if (index >= m_creators.size()) {
           std::stringstream msg;

--- a/Framework/CurveFitting/src/MultiDomainCreator.cpp
+++ b/Framework/CurveFitting/src/MultiDomainCreator.cpp
@@ -51,6 +51,7 @@ void MultiDomainCreator::createDomain(std::shared_ptr<API::FunctionDomain> &doma
     }
     API::FunctionDomain_sptr dom;
     creator->createDomain(dom, values, i0);
+    creator->separateCompositeMembersInOutput(m_outputCompositeMembers, m_convolutionCompositeMembers);
     jointDomain->addDomain(dom);
     i0 += dom->size();
   }

--- a/Framework/CurveFitting/test/MultiDomainCreatorTest.h
+++ b/Framework/CurveFitting/test/MultiDomainCreatorTest.h
@@ -285,10 +285,122 @@ public:
     TS_ASSERT_EQUALS(f3->m_workspace, ws3);
   }
 
-private:
-  void doTestOutputSpectrum(const MatrixWorkspace_sptr &ws, size_t index) {
+  void test_output_composite_members() {
+    MultiDomainCreatorTest_Manager manager;
+    manager.declareProperty(std::make_unique<WorkspaceProperty<Workspace>>("WS1", "", Direction::Input));
+    manager.declareProperty(std::make_unique<WorkspaceProperty<Workspace>>("WS2", "", Direction::Input));
+    manager.declareProperty(std::make_unique<WorkspaceProperty<Workspace>>("WS3", "", Direction::Input));
+
+    std::vector<std::string> propNames{"WS1", "WS2", "WS3"};
+    MultiDomainCreator multi(&manager, propNames);
+
+    manager.setProperty("WS1", ws1);
+    manager.setProperty("WS2", ws2);
+    manager.setProperty("WS3", ws3);
+
+    FitMW *creator = new FitMW(&manager, "WS1");
+    creator->declareDatasetProperties("1");
+    creator->separateCompositeMembersInOutput(true, false);
+    multi.setCreator(0, creator);
+    creator = new FitMW(&manager, "WS2");
+    creator->declareDatasetProperties("2");
+    creator->separateCompositeMembersInOutput(true, false);
+    multi.setCreator(1, creator);
+    creator = new FitMW(&manager, "WS3");
+    creator->separateCompositeMembersInOutput(true, false);
+    creator->declareDatasetProperties("3");
+    multi.setCreator(2, creator);
+
+    manager.setProperty("WorkspaceIndex1", 0);
+    manager.setProperty("WorkspaceIndex2", 0);
+    manager.setProperty("WorkspaceIndex3", 0);
+
+    FunctionDomain_sptr domain;
+    FunctionValues_sptr values;
+
+    auto mdfun = std::make_shared<MultiDomainFunction>();
+
+    std::shared_ptr<CompositeFunction> mfun = std::make_shared<CompositeFunction>();
+
+    std::shared_ptr<UserFunction> fun1 = std::make_shared<UserFunction>();
+    fun1->setAttributeValue("Formula", "a + b*x");
+    fun1->setParameter("a", 0.55);
+    fun1->setParameter("b", 0.00);
+
+    std::shared_ptr<UserFunction> fun2 = std::make_shared<UserFunction>();
+    fun2->setAttributeValue("Formula", "c*x + d");
+    fun2->setParameter("c", 0.00);
+    fun2->setParameter("d", 0.55);
+
+    mfun->addFunction(fun1);
+    mfun->addFunction(fun2);
+
+    mdfun->addFunction(mfun);
+    mdfun->setDomainIndex(0, 0);
+
+    fun1 = std::make_shared<UserFunction>();
+    fun1->setAttributeValue("Formula", "a + b*x");
+    fun1->setParameter("a", 1.05);
+    fun1->setParameter("b", 0.00);
+
+    fun2 = std::make_shared<UserFunction>();
+    fun2->setAttributeValue("Formula", "c*x + b");
+    fun2->setParameter("c", 0.00);
+    fun2->setParameter("b", 1.05);
+
+    std::shared_ptr<CompositeFunction> mfun2 = std::make_shared<CompositeFunction>();
+    mfun2->addFunction(fun1);
+    mfun2->addFunction(fun2);
+
+    mdfun->addFunction(mfun2);
+    mdfun->setDomainIndex(1, 1);
+
+    fun1 = std::make_shared<UserFunction>();
+    fun1->setAttributeValue("Formula", "a + b*x");
+    fun1->setParameter("a", 1.55);
+    fun1->setParameter("b", 0.00);
+
+    fun2 = std::make_shared<UserFunction>();
+    fun2->setAttributeValue("Formula", "c*x + b");
+    fun2->setParameter("c", 0.00);
+    fun2->setParameter("b", 1.55);
+
+    std::shared_ptr<CompositeFunction> mfun3 = std::make_shared<CompositeFunction>();
+    mfun3->addFunction(fun1);
+    mfun3->addFunction(fun2);
+
+    mdfun->addFunction(mfun3);
+    mdfun->setDomainIndex(2, 2);
+
+    auto ws = multi.createOutputWorkspace("out_", mdfun, FunctionDomain_sptr(), FunctionValues_sptr(), "OUT_WS");
     TS_ASSERT(ws);
-    TS_ASSERT_EQUALS(ws->getNumberHistograms(), 3);
+
+    auto group = std::dynamic_pointer_cast<WorkspaceGroup>(ws);
+    TS_ASSERT(group);
+
+    TS_ASSERT_EQUALS(group->size(), 3);
+
+    auto ows1 = std::dynamic_pointer_cast<MatrixWorkspace>(group->getItem(0));
+    doTestOutputSpectrum(ows1, 0, 5);
+    auto ows2 = std::dynamic_pointer_cast<MatrixWorkspace>(group->getItem(1));
+    doTestOutputSpectrum(ows2, 1, 5);
+    auto ows3 = std::dynamic_pointer_cast<MatrixWorkspace>(group->getItem(2));
+    doTestOutputSpectrum(ows3, 2, 5);
+
+    WorkspaceGroup_sptr outWS = manager.getProperty("OUT_WS");
+    TS_ASSERT(outWS);
+    TS_ASSERT_EQUALS(outWS->getItem(0)->getName(), "out_Workspace_0");
+    TS_ASSERT_EQUALS(outWS->getItem(1)->getName(), "out_Workspace_1");
+    TS_ASSERT_EQUALS(outWS->getItem(2)->getName(), "out_Workspace_2");
+    manager.store("OUT_WS");
+    TS_ASSERT_EQUALS(outWS->getName(), "out_Workspaces");
+    AnalysisDataService::Instance().clear();
+  }
+
+private:
+  void doTestOutputSpectrum(const MatrixWorkspace_sptr &ws, size_t index, size_t nHistograms = 3) {
+    TS_ASSERT(ws);
+    TS_ASSERT_EQUALS(ws->getNumberHistograms(), nHistograms);
     auto &data = ws->readY(0);
     auto &calc = ws->readY(1);
     auto &diff = ws->readY(2);

--- a/Framework/CurveFitting/test/MultiDomainCreatorTest.h
+++ b/Framework/CurveFitting/test/MultiDomainCreatorTest.h
@@ -315,9 +315,6 @@ public:
     manager.setProperty("WorkspaceIndex2", 0);
     manager.setProperty("WorkspaceIndex3", 0);
 
-    FunctionDomain_sptr domain;
-    FunctionValues_sptr values;
-
     auto mdfun = std::make_shared<MultiDomainFunction>();
 
     std::shared_ptr<CompositeFunction> mfun = std::make_shared<CompositeFunction>();

--- a/docs/source/release/v6.4.0/Framework/Fit_Functions/Bugfixes/33737.rst
+++ b/docs/source/release/v6.4.0/Framework/Fit_Functions/Bugfixes/33737.rst
@@ -1,0 +1,1 @@
+- Fixed bug that prevented seeing individual members of composite multi-domain fit functions


### PR DESCRIPTION
**Description of work.**

This PR fixes the spotted issue when fitting composite multi-domain functions, it is not possible to see individual members in the output workspace, as it is the case for fitting regular composite functions. The property `OutputCompositeMembers` is always ignored in this case. The proposed solution moves the setting of flags responsible for separating composite (and convolute) members to much earlier in the `Fit` algorithm, from creating output to initialising minimizer, and forwarding the user's choice to sub-domains created in `MultiDomainCreator`.

**To test:**

1. Run the composite MultiDomain function example from documentation but with OutputCompositeMembers set to True:

```
from mantid.simpleapi import *
import numpy as np

# Create workspaces
x_values = np.linspace(start=1.0,stop=10.0,num=22)
y_values1 = [2.0*x + 10.0 for x in x_values]
y_values2 = [5.0/x + 10.0 for x in x_values]

input_workspace1 = CreateWorkspace(x_values, y_values1)
input_workspace2 = CreateWorkspace(x_values, y_values2)

# Create MultiDomainFunction where datasets have different fitting functions
multi_domain_function = FunctionFactory.createInitializedMultiDomainFunction('name=CompositeFunction', 2)

flat_background = FunctionFactory.createInitialized("name=FlatBackground")
linear_background = FunctionFactory.createInitialized("name=LinearBackground")
exp_decay = FunctionFactory.createInitialized("name=ExpDecay")

composite1 = multi_domain_function.getFunction(0)
composite1.add(flat_background)
composite1.add(linear_background)

composite2 = multi_domain_function.getFunction(1)
composite2.add(flat_background)
composite2.add(exp_decay)

# Tie the FlatBackground which is common for both datasets
function_string = str(multi_domain_function)
function_string += ";ties=(f1.f0.A0=f0.f0.A0)"

# Perform the fit
fit_output = Fit(Function=function_string,
                 InputWorkspace=input_workspace1, WorkspaceIndex=0, StartX = 1.0, EndX=10.0,
                 InputWorkspace_1=input_workspace2, WorkspaceIndex_1=0, StartX_1 = 1.0, EndX_1=10.0,
                 Output='fit', OutputCompositeMembers=True)

```

2. Individual composite members, a flat background and a Gaussian function, should be present in 'fit_Workspace' workspaces. You can verify that using 'Show data' or by plotting the workspace.

Fixes #33737 . 

Release note added.

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
