### PR TITLE
Fix the width of the plotting status bar for Conda builds

### DIFF
--- a/docs/source/release/v6.4.0/Workbench/Bugfixes/33732.rst
+++ b/docs/source/release/v6.4.0/Workbench/Bugfixes/33732.rst
@@ -1,1 +1,1 @@
-- Fixed a bug with the plotting status bar in Conda builds. The status bar has a fixed size so that there is no flicerking behaviour as users move over the plot image or the z axis image.
+- Fixed a bug with the plotting status bar in Conda builds. The status bar has a fixed size so that there is no flickering behaviour as users move over the plot image or the z axis image.

--- a/docs/source/release/v6.4.0/Workbench/Bugfixes/33732.rst
+++ b/docs/source/release/v6.4.0/Workbench/Bugfixes/33732.rst
@@ -1,1 +1,1 @@
-- Fixed a bug with the plotting status bar in Conda builds. The status bar has a fixed size so that there is no flickering behaviour as users move over the plot image or the z axis image.
+- Fixed a bug with the plotting status bar in Conda builds. The status bar no longer flickers when users move over the plot image or the z axis image.

--- a/docs/source/release/v6.4.0/Workbench/Bugfixes/33732.rst
+++ b/docs/source/release/v6.4.0/Workbench/Bugfixes/33732.rst
@@ -1,0 +1,1 @@
+- Fixed a bug with the plotting status bar in Conda builds. The status bar has a fixed size so that there is no flicerking behaviour as users move over the plot image or the z axis image.

--- a/qt/applications/workbench/workbench/plotting/figuremanager.py
+++ b/qt/applications/workbench/workbench/plotting/figuremanager.py
@@ -46,6 +46,9 @@ from workbench.plotting.toolbar import WorkbenchNavigationToolbar, ToolbarStateM
 from workbench.plotting.plothelppages import PlotHelpPages
 
 
+STATUS_BAR_HEIGHT = 45
+
+
 def _replace_workspace_name_in_string(old_name, new_name, string):
     return re.sub(rf'\b{old_name}\b', new_name, string)
 
@@ -240,11 +243,17 @@ class FigureManagerWorkbench(FigureManagerBase, QObject):
         # resize the main window so it will display the canvas with the
         # requested size:
         cs = canvas.sizeHint()
-        sbs = self.window.statusBar().sizeHint()
-        self._status_and_tool_height = tbs_height + sbs.height()
+
+        # for matplot lib v3.5 and higher status bar height needs to be fixed
+        if LooseVersion(matplotlib.__version__) >= LooseVersion("3.5.0"):
+            self.window.statusBar().setFixedHeight(STATUS_BAR_HEIGHT)
+            self._status_and_tool_height = tbs_height + STATUS_BAR_HEIGHT
+        else:
+            sbs = self.window.statusBar().sizeHint()
+            self._status_and_tool_height = tbs_height + sbs.height()
+
         height = cs.height() + self._status_and_tool_height
         self.window.resize(cs.width(), height)
-
         self.fit_browser = FitPropertyBrowser(canvas, ToolbarStateManager(self.toolbar))
         self.fit_browser.closing.connect(self.handle_fit_browser_close)
         self.window.setCentralWidget(canvas)

--- a/qt/applications/workbench/workbench/plotting/figuremanager.py
+++ b/qt/applications/workbench/workbench/plotting/figuremanager.py
@@ -46,9 +46,6 @@ from workbench.plotting.toolbar import WorkbenchNavigationToolbar, ToolbarStateM
 from workbench.plotting.plothelppages import PlotHelpPages
 
 
-STATUS_BAR_HEIGHT = 45
-
-
 def _replace_workspace_name_in_string(old_name, new_name, string):
     return re.sub(rf'\b{old_name}\b', new_name, string)
 
@@ -243,14 +240,8 @@ class FigureManagerWorkbench(FigureManagerBase, QObject):
         # resize the main window so it will display the canvas with the
         # requested size:
         cs = canvas.sizeHint()
-
-        # for matplot lib v3.5 and higher status bar height needs to be fixed
-        if LooseVersion(matplotlib.__version__) >= LooseVersion("3.5.0"):
-            self.window.statusBar().setFixedHeight(STATUS_BAR_HEIGHT)
-            self._status_and_tool_height = tbs_height + STATUS_BAR_HEIGHT
-        else:
-            sbs = self.window.statusBar().sizeHint()
-            self._status_and_tool_height = tbs_height + sbs.height()
+        sbs = self.window.statusBar().sizeHint()
+        self._status_and_tool_height = tbs_height + sbs.height()
 
         height = cs.height() + self._status_and_tool_height
         self.window.resize(cs.width(), height)

--- a/qt/applications/workbench/workbench/plotting/figuremanager.py
+++ b/qt/applications/workbench/workbench/plotting/figuremanager.py
@@ -242,9 +242,9 @@ class FigureManagerWorkbench(FigureManagerBase, QObject):
         cs = canvas.sizeHint()
         sbs = self.window.statusBar().sizeHint()
         self._status_and_tool_height = tbs_height + sbs.height()
-
         height = cs.height() + self._status_and_tool_height
         self.window.resize(cs.width(), height)
+
         self.fit_browser = FitPropertyBrowser(canvas, ToolbarStateManager(self.toolbar))
         self.fit_browser.closing.connect(self.handle_fit_browser_close)
         self.window.setCentralWidget(canvas)

--- a/qt/python/mantidqt/mantidqt/plotting/mantid_navigation_toolbar.py
+++ b/qt/python/mantidqt/mantidqt/plotting/mantid_navigation_toolbar.py
@@ -125,9 +125,9 @@ class MantidNavigationToolbar(NavigationToolbar2, QToolBar):
         pass
 
     def set_message(self, s):
-        self.message.emit(s)
+        self.message.emit(s.replace("\n", ""))
         if self.coordinates:
-            self.locLabel.setText(s)
+            self.locLabel.setText(s.replace("\n", ""))
 
     def set_cursor(self, cursor):
         self.canvas.setCursor(cursord[cursor])


### PR DESCRIPTION
**Description of work.**
Conda builds use version 3.5 of matplotlib or higher. This version changes how the x and y coords are shown on the status bar of plots. Unfotunately it is not possible to get the information to show on a single line (this seems to be something specific with matplotlib). Instead the status bar width has now been fixed for those using matplotlib 3.5 or higher to prevent the constant resizing of the bar as you move on and off the plot image or the z axis bar.

**To test:**
Using a Conda installation:

1. Load a workspace, e.g. MAR11060 from the training course data.
2. Open a colorfill plot by right clicking and selecting Plot->Colorfill.
3. Move the mouse over the plot image and off again. The GUI no longer moves around because the status bar height is static.


Fixes #33732 . 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
