### PR TITLE
table WS now sends a replaced signal

### DIFF
--- a/qt/python/mantidqt/mantidqt/widgets/workspacedisplay/table/model.py
+++ b/qt/python/mantidqt/mantidqt/widgets/workspacedisplay/table/model.py
@@ -10,6 +10,7 @@ from mantid.api import IPeaksWorkspace, ITableWorkspace
 from mantid.kernel import V3D
 from mantidqt.widgets.workspacedisplay.table.error_column import ErrorColumn
 from mantidqt.widgets.workspacedisplay.table.marked_columns import MarkedColumns
+from contextlib import contextmanager
 
 
 class TableWorkspaceColumnTypeMapping(object):
@@ -26,6 +27,13 @@ class TableWorkspaceColumnTypeMapping(object):
     XERR = 4
     YERR = 5
     LABEL = 6
+
+
+@contextmanager
+def table_ws_context_manager(model):
+    model.edit_flag = True
+    yield
+    model.edit_flag = False
 
 
 class TableWorkspaceDisplayModel:
@@ -58,7 +66,7 @@ class TableWorkspaceDisplayModel:
         self.ws_num_cols = self.ws.columnCount()
         self.marked_columns = MarkedColumns()
         self._original_column_headers = self.get_column_headers()
-
+        self.edit_flag = False
         # loads the types of the columns
         for col in range(self.ws_num_cols):
             plot_type = self.ws.getPlotType(col)
@@ -135,7 +143,8 @@ class TableWorkspaceDisplayModel:
             # at the same time as we are trying to locally update the data in the
             # item object itself, which causes a Qt exception that the object has
             # already been deleted and a crash
-            self.ws.setCell(row, col, data, notify_replace=False)
+            with table_ws_context_manager(self):
+                self.ws.setCell(row, col, data)
 
     def workspace_equals(self, workspace_name):
         return self.ws.name() == workspace_name

--- a/qt/python/mantidqt/mantidqt/widgets/workspacedisplay/table/model.py
+++ b/qt/python/mantidqt/mantidqt/widgets/workspacedisplay/table/model.py
@@ -30,10 +30,10 @@ class TableWorkspaceColumnTypeMapping(object):
 
 
 @contextmanager
-def table_ws_context_manager(model):
-    model.edit_flag = True
+def block_model_replacement(model):
+    model.block_model_replace = True
     yield
-    model.edit_flag = False
+    model.block_model_replace = False
 
 
 class TableWorkspaceDisplayModel:
@@ -66,7 +66,7 @@ class TableWorkspaceDisplayModel:
         self.ws_num_cols = self.ws.columnCount()
         self.marked_columns = MarkedColumns()
         self._original_column_headers = self.get_column_headers()
-        self.edit_flag = False
+        self.block_model_replace = False
         # loads the types of the columns
         for col in range(self.ws_num_cols):
             plot_type = self.ws.getPlotType(col)
@@ -143,7 +143,7 @@ class TableWorkspaceDisplayModel:
             # at the same time as we are trying to locally update the data in the
             # item object itself, which causes a Qt exception that the object has
             # already been deleted and a crash
-            with table_ws_context_manager(self):
+            with block_model_replacement(self):
                 self.ws.setCell(row, col, data)
 
     def workspace_equals(self, workspace_name):

--- a/qt/python/mantidqt/mantidqt/widgets/workspacedisplay/table/presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/workspacedisplay/table/presenter.py
@@ -6,7 +6,6 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 #  This file is part of mantidqt package.
 from functools import partial
-
 from qtpy.QtCore import Qt
 
 from mantid.kernel import logger
@@ -133,15 +132,9 @@ class TableWorkspaceDisplay(ObservingPresenter, DataCopier):
         return TableWorkspaceDisplayModel.supports(ws)
 
     def replace_workspace(self, workspace_name, workspace):
-        if self.presenter.model.workspace_equals(workspace_name):
-            # stops triggering itemChanged signal while the data is being reloaded
-            self.presenter.view.blockSignals(True)
-
+        if self.presenter.model.workspace_equals(workspace_name) and self.presenter.model.edit_flag:
             self.presenter.model = TableWorkspaceDisplayModel(workspace)
             self.presenter.load_data(self.presenter.view)
-            self.presenter.view.blockSignals(False)
-
-            self.presenter.view.emit_repaint()
 
     def action_copy_cells(self):
         self.copy_cells(self.presenter.view)

--- a/qt/python/mantidqt/mantidqt/widgets/workspacedisplay/table/presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/workspacedisplay/table/presenter.py
@@ -132,7 +132,7 @@ class TableWorkspaceDisplay(ObservingPresenter, DataCopier):
         return TableWorkspaceDisplayModel.supports(ws)
 
     def replace_workspace(self, workspace_name, workspace):
-        if self.presenter.model.workspace_equals(workspace_name) and self.presenter.model.block_model_replace:
+        if self.presenter.model.workspace_equals(workspace_name) and not self.presenter.model.block_model_replace:
             self.presenter.view.blockSignals(True)
             self.presenter.model = TableWorkspaceDisplayModel(workspace)
             self.presenter.load_data(self.presenter.view)

--- a/qt/python/mantidqt/mantidqt/widgets/workspacedisplay/table/presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/workspacedisplay/table/presenter.py
@@ -132,9 +132,11 @@ class TableWorkspaceDisplay(ObservingPresenter, DataCopier):
         return TableWorkspaceDisplayModel.supports(ws)
 
     def replace_workspace(self, workspace_name, workspace):
-        if self.presenter.model.workspace_equals(workspace_name) and self.presenter.model.edit_flag:
+        if self.presenter.model.workspace_equals(workspace_name) and self.presenter.model.block_model_replace:
+            self.presenter.view.blockSignals(True)
             self.presenter.model = TableWorkspaceDisplayModel(workspace)
             self.presenter.load_data(self.presenter.view)
+            self.presenter.view.blockSignals(False)
 
     def action_copy_cells(self):
         self.copy_cells(self.presenter.view)

--- a/qt/python/mantidqt/mantidqt/widgets/workspacedisplay/table/test/test_tableworkspacedisplay_model.py
+++ b/qt/python/mantidqt/mantidqt/widgets/workspacedisplay/table/test/test_tableworkspacedisplay_model.py
@@ -66,11 +66,11 @@ class TableWorkspaceDisplayModelTest(unittest.TestCase):
         expected_col = 1111
         expected_row = 1
 
-        model.set_cell_data(expected_row, expected_col, test_data, False)
+        model.set_cell_data(expected_row, expected_col, test_data)
 
         # check that the correct conversion function was retrieved
         # -> the one for the column for which the data is being set
-        model.ws.setCell.assert_called_once_with(expected_row, expected_col, test_data, notify_replace=False)
+        model.ws.setCell.assert_called_once_with(expected_row, expected_col, test_data)
 
     @with_mock_workspace
     def test_set_cell_data_v3d(self, model):

--- a/qt/python/mantidqt/mantidqt/widgets/workspacedisplay/table/test/test_tableworkspacedisplay_model.py
+++ b/qt/python/mantidqt/mantidqt/widgets/workspacedisplay/table/test/test_tableworkspacedisplay_model.py
@@ -66,7 +66,7 @@ class TableWorkspaceDisplayModelTest(unittest.TestCase):
         expected_col = 1111
         expected_row = 1
 
-        model.set_cell_data(expected_row, expected_col, test_data, True)
+        model.set_cell_data(expected_row, expected_col, test_data, False)
 
         # check that the correct conversion function was retrieved
         # -> the one for the column for which the data is being set
@@ -86,7 +86,7 @@ class TableWorkspaceDisplayModelTest(unittest.TestCase):
 
         # check that the correct conversion function was retrieved
         # -> the one for the column for which the data is being set
-        model.ws.setCell.assert_called_once_with(expected_row, expected_col, V3D(1, 2, 3), notify_replace=False)
+        model.ws.setCell.assert_called_once_with(expected_row, expected_col, V3D(1, 2, 3))
 
     @with_mock_workspace
     def test_set_cell_data_hkl(self, model):

--- a/qt/python/mantidqt/mantidqt/widgets/workspacedisplay/table/test/test_tableworkspacedisplay_model.py
+++ b/qt/python/mantidqt/mantidqt/widgets/workspacedisplay/table/test/test_tableworkspacedisplay_model.py
@@ -66,7 +66,7 @@ class TableWorkspaceDisplayModelTest(unittest.TestCase):
         expected_col = 1111
         expected_row = 1
 
-        model.set_cell_data(expected_row, expected_col, test_data)
+        model.set_cell_data(expected_row, expected_col, test_data, True)
 
         # check that the correct conversion function was retrieved
         # -> the one for the column for which the data is being set

--- a/qt/python/mantidqt/mantidqt/widgets/workspacedisplay/table/test/test_tableworkspacedisplay_presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/workspacedisplay/table/test/test_tableworkspacedisplay_presenter.py
@@ -814,7 +814,6 @@ class TableWorkspaceDisplayPresenterTest(unittest.TestCase):
         ) as mock_load_data:
             presenter.replace_workspace(ws.TEST_NAME, ws)
             mock_load_data.assert_called_once_with(view)
-            view.emit_repaint.assert_called_once_with()
 
 
 if __name__ == '__main__':

--- a/qt/python/mantidqt/mantidqt/widgets/workspacedisplay/table/test/test_tableworkspacedisplay_presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/workspacedisplay/table/test/test_tableworkspacedisplay_presenter.py
@@ -808,7 +808,7 @@ class TableWorkspaceDisplayPresenterTest(unittest.TestCase):
     def test_replace(self, ws, view, presenter):
         # patch this out after the constructor of the presenter has finished,
         # so that we reset any calls it might have made
-        presenter.model.edit_flag = True
+        presenter.model.block_model_replace = True
         with patch(
                 'mantidqt.widgets.workspacedisplay.table.presenter.TableWorkspaceDataPresenterStandard.load_data'
         ) as mock_load_data:

--- a/qt/python/mantidqt/mantidqt/widgets/workspacedisplay/table/test/test_tableworkspacedisplay_presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/workspacedisplay/table/test/test_tableworkspacedisplay_presenter.py
@@ -808,6 +808,7 @@ class TableWorkspaceDisplayPresenterTest(unittest.TestCase):
     def test_replace(self, ws, view, presenter):
         # patch this out after the constructor of the presenter has finished,
         # so that we reset any calls it might have made
+        presenter.model.edit_flag = True
         with patch(
                 'mantidqt.widgets.workspacedisplay.table.presenter.TableWorkspaceDataPresenterStandard.load_data'
         ) as mock_load_data:

--- a/qt/python/mantidqt/mantidqt/widgets/workspacedisplay/table/test/test_tableworkspacedisplay_presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/workspacedisplay/table/test/test_tableworkspacedisplay_presenter.py
@@ -808,7 +808,7 @@ class TableWorkspaceDisplayPresenterTest(unittest.TestCase):
     def test_replace(self, ws, view, presenter):
         # patch this out after the constructor of the presenter has finished,
         # so that we reset any calls it might have made
-        presenter.model.block_model_replace = True
+        presenter.model.block_model_replace = False
         with patch(
                 'mantidqt.widgets.workspacedisplay.table.presenter.TableWorkspaceDataPresenterStandard.load_data'
         ) as mock_load_data:

--- a/qt/python/mantidqt/mantidqt/widgets/workspacedisplay/table/test/test_tableworkspacedisplay_view.py
+++ b/qt/python/mantidqt/mantidqt/widgets/workspacedisplay/table/test/test_tableworkspacedisplay_view.py
@@ -54,7 +54,7 @@ class TableWorkspaceDisplayViewTest(unittest.TestCase):
         ws.addColumn("double", "test_col")
 
         presenter = TableWorkspaceDisplay(ws, batch=False)
-        presenter.model.edit_flag = True
+        presenter.model.block_model_replace = True
         current_rows = presenter.view.rowCount()
         ws.addRow({'test_col': 1.0})
 
@@ -66,7 +66,7 @@ class TableWorkspaceDisplayViewTest(unittest.TestCase):
         ws.addColumn("double", "l")
 
         presenter = TableWorkspaceDisplay(ws, batch=False)
-        presenter.model.edit_flag = True
+        presenter.model.block_model_replace = True
         current_rows = presenter.view.rowCount()
         ws.addRow([1.0])
 
@@ -78,7 +78,7 @@ class TableWorkspaceDisplayViewTest(unittest.TestCase):
         ws.addColumn("double", "test_col")
 
         presenter = TableWorkspaceDisplay(ws, batch=True)
-        presenter.model.edit_flag = True
+        presenter.model.block_model_replace = True
         ws.removeColumn('test_col')
 
         self.assertEqual(0, presenter.view.columnCount())
@@ -89,7 +89,7 @@ class TableWorkspaceDisplayViewTest(unittest.TestCase):
         ws.addColumn("double", "test_col")
 
         presenter = TableWorkspaceDisplay(ws, batch=True)
-        presenter.model.edit_flag = True
+        presenter.model.block_model_replace = True
         current_rows = presenter.view.rowCount()
         ws.addRow({'test_col': 1.0})
 

--- a/qt/python/mantidqt/mantidqt/widgets/workspacedisplay/table/test/test_tableworkspacedisplay_view.py
+++ b/qt/python/mantidqt/mantidqt/widgets/workspacedisplay/table/test/test_tableworkspacedisplay_view.py
@@ -54,6 +54,7 @@ class TableWorkspaceDisplayViewTest(unittest.TestCase):
         ws.addColumn("double", "test_col")
 
         presenter = TableWorkspaceDisplay(ws, batch=False)
+        presenter.model.edit_flag = True
         current_rows = presenter.view.rowCount()
         ws.addRow({'test_col': 1.0})
 
@@ -65,6 +66,7 @@ class TableWorkspaceDisplayViewTest(unittest.TestCase):
         ws.addColumn("double", "l")
 
         presenter = TableWorkspaceDisplay(ws, batch=False)
+        presenter.model.edit_flag = True
         current_rows = presenter.view.rowCount()
         ws.addRow([1.0])
 
@@ -76,6 +78,7 @@ class TableWorkspaceDisplayViewTest(unittest.TestCase):
         ws.addColumn("double", "test_col")
 
         presenter = TableWorkspaceDisplay(ws, batch=True)
+        presenter.model.edit_flag = True
         ws.removeColumn('test_col')
 
         self.assertEqual(0, presenter.view.columnCount())
@@ -86,6 +89,7 @@ class TableWorkspaceDisplayViewTest(unittest.TestCase):
         ws.addColumn("double", "test_col")
 
         presenter = TableWorkspaceDisplay(ws, batch=True)
+        presenter.model.edit_flag = True
         current_rows = presenter.view.rowCount()
         ws.addRow({'test_col': 1.0})
 

--- a/qt/python/mantidqt/mantidqt/widgets/workspacedisplay/table/test/test_tableworkspacedisplay_view.py
+++ b/qt/python/mantidqt/mantidqt/widgets/workspacedisplay/table/test/test_tableworkspacedisplay_view.py
@@ -54,7 +54,7 @@ class TableWorkspaceDisplayViewTest(unittest.TestCase):
         ws.addColumn("double", "test_col")
 
         presenter = TableWorkspaceDisplay(ws, batch=False)
-        presenter.model.block_model_replace = True
+        presenter.model.block_model_replace = False
         current_rows = presenter.view.rowCount()
         ws.addRow({'test_col': 1.0})
 
@@ -66,7 +66,7 @@ class TableWorkspaceDisplayViewTest(unittest.TestCase):
         ws.addColumn("double", "l")
 
         presenter = TableWorkspaceDisplay(ws, batch=False)
-        presenter.model.block_model_replace = True
+        presenter.model.block_model_replace = False
         current_rows = presenter.view.rowCount()
         ws.addRow([1.0])
 
@@ -78,7 +78,7 @@ class TableWorkspaceDisplayViewTest(unittest.TestCase):
         ws.addColumn("double", "test_col")
 
         presenter = TableWorkspaceDisplay(ws, batch=True)
-        presenter.model.block_model_replace = True
+        presenter.model.block_model_replace = False
         ws.removeColumn('test_col')
 
         self.assertEqual(0, presenter.view.columnCount())
@@ -89,7 +89,7 @@ class TableWorkspaceDisplayViewTest(unittest.TestCase):
         ws.addColumn("double", "test_col")
 
         presenter = TableWorkspaceDisplay(ws, batch=True)
-        presenter.model.block_model_replace = True
+        presenter.model.block_model_replace = False
         current_rows = presenter.view.rowCount()
         ws.addRow({'test_col': 1.0})
 


### PR DESCRIPTION
**Description of work.**

We wanted to know when a table ws has been edited for the muon GUI. This change makes it possible.

**To test:**
Before starting Mantid go to https://github.com/mantidproject/mantid/blob/bb76b55b25b0bea63c170d071858014005f69589/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/contexts/muon_context_ADS_observer.py#L78 and add `print(workspace.name())` this will then allow us to know if it worked.

Start Mantid
Open Muon Analysis
Load some data (e.g. MUSR 62260)
Go to the fitting tab and do a fit (doesn't matter which)
Go to the results table tab
Select the "run number" and press create at the bottom of the tab
Clear the ADS
Open the table workspace from the ADS
Change a value -> originally this just updated the table. Now it will be picked up by the replace signal (will print name) and it will flash briefly. 

*There is no associated issue.*

This is a developer only improvement so does not need a release note

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
