### PR TITLE
Avoid DrILL processing test to hang forever

### DIFF
--- a/Testing/SystemTests/tests/framework/DrillProcessTest.py
+++ b/Testing/SystemTests/tests/framework/DrillProcessTest.py
@@ -123,6 +123,15 @@ class DrillProcessSANSTest(systemtesting.MantidSystemTest):
                            "CalculateResolution": "MildnerCarpenter",
                            "TransmissionBeamRadius": "0.2"})
 
+        # remove all exports
+        QTest.mouseClick(self.drill.export, Qt.LeftButton)
+        ew = self.drill.children()[-1]
+        for i in range(ew.algoList.rowCount()):
+            widget = ew.algoList.itemAtPosition(i,0).widget()
+            if isinstance(widget, QCheckBox) and widget.isChecked():
+                QTest.mouseClick(widget, Qt.LeftButton)
+        QTest.mouseClick(ew.okButton, Qt.LeftButton)
+
         self.editCell(0, "SampleRuns", sampleRuns[0])
         self.editCell(0, "SampleTransmissionRuns", sampleTransmissionRuns[0])
         self.editCell(0, "BeamRuns", beamRuns)


### PR DESCRIPTION
**Description of work.**

Sometimes, the DrILL processing test was hanging forever. This seems to be due to a deadlock occurring between the processing algorithm and the export algorithms (called after the processing in DrILL). This problem was never reproduced outside of the `systemtest` framework.

Because the export files are not needed for the test, I decided to disable them.

**To test:**

Tests should pass. You can locally insist on `DrillProcessSANSTest` to check if it properly ends.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
