### PR TITLE
Fix SliceViewer zoom tool crash

### DIFF
--- a/docs/source/release/v6.4.0/Workbench/SliceViewer/Bugfixes/33733.rst
+++ b/docs/source/release/v6.4.0/Workbench/SliceViewer/Bugfixes/33733.rst
@@ -1,0 +1,1 @@
+- Fixed a bug caused by moving to matplotlib 3.5 that prevented users from zooming in on a plot in SliceViewer.

--- a/qt/applications/workbench/CMakeLists.txt
+++ b/qt/applications/workbench/CMakeLists.txt
@@ -231,6 +231,7 @@ set(TEST_FILES
     workbench/plotting/test/test_figuremanager.py
     workbench/plotting/test/test_figurewindow.py
     workbench/plotting/test/test_globalfiguremanager.py
+    workbench/plotting/test/test_mantidfigurecanvas.py
     workbench/plotting/test/test_propertiesdialog.py
     workbench/plotting/test/test_plothelppages.py
     workbench/plotting/test/test_toolbar.py

--- a/qt/applications/workbench/workbench/plotting/mantidfigurecanvas.py
+++ b/qt/applications/workbench/workbench/plotting/mantidfigurecanvas.py
@@ -20,7 +20,8 @@ class MantidFigureCanvas(FigureCanvasQTAgg):
         super().__init__(figure=figure)
         self._pen_color = Qt.black
         self._pen_thickness = 1.5
-        self._dpi_ratio = self.devicePixelRatio() or 1
+        if LooseVersion(matplotlib.__version__) >= LooseVersion("3.5.0"):
+            self._dpi_ratio = self.devicePixelRatio() or 1
 
     # options controlling the pen used by tools that manipulate the graph - e.g the zoom box
     @property

--- a/qt/applications/workbench/workbench/plotting/mantidfigurecanvas.py
+++ b/qt/applications/workbench/workbench/plotting/mantidfigurecanvas.py
@@ -8,6 +8,7 @@
 """
 Qt-based matplotlib canvas
 """
+from distutils.version import LooseVersion
 from qtpy.QtCore import Qt
 from qtpy.QtGui import QPen
 from matplotlib.backends.backend_qt5agg import (  # noqa: F401

--- a/qt/applications/workbench/workbench/plotting/mantidfigurecanvas.py
+++ b/qt/applications/workbench/workbench/plotting/mantidfigurecanvas.py
@@ -11,6 +11,7 @@ Qt-based matplotlib canvas
 from distutils.version import LooseVersion
 from qtpy.QtCore import Qt
 from qtpy.QtGui import QPen
+import matplotlib
 from matplotlib.backends.backend_qt5agg import (  # noqa: F401
     FigureCanvasQTAgg, draw_if_interactive, show)
 from mantid.plots.mantidimage import MantidImage, ImageIntensity

--- a/qt/applications/workbench/workbench/plotting/mantidfigurecanvas.py
+++ b/qt/applications/workbench/workbench/plotting/mantidfigurecanvas.py
@@ -20,6 +20,7 @@ class MantidFigureCanvas(FigureCanvasQTAgg):
         super().__init__(figure=figure)
         self._pen_color = Qt.black
         self._pen_thickness = 1.5
+        self._dpi_ratio = self.devicePixelRatio() or 1
 
     # options controlling the pen used by tools that manipulate the graph - e.g the zoom box
     @property

--- a/qt/applications/workbench/workbench/plotting/test/test_mantidfigurecanvas.py
+++ b/qt/applications/workbench/workbench/plotting/test/test_mantidfigurecanvas.py
@@ -1,0 +1,24 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2022 ISIS Rutherford Appleton Laboratory UKRI,
+# NScD Oak Ridge National Laboratory, European Spallation Source,
+# Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+
+import unittest
+from unittest.mock import MagicMock
+from workbench.plotting.mantidfigurecanvas import MantidFigureCanvas
+
+
+class MantidFigureCanvasTest(unittest.TestCase):
+
+    def test_dpi_attribute_exists(self):
+        fig = MagicMock()
+        fig.bbox.max = [1, 1]
+        canvas = MantidFigureCanvas(fig)
+
+        self.assertTrue(hasattr(canvas, '_dpi_ratio'))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**Description of work.**
Upgrading to matplotlib 3.5 seems to have broken access to the ```dpi_ratio```. To fix the variable has been added to the MantidFigureCanvas so it no longer relies on this functionality from matplotlib.

**To test:**
Using a Conda installation:

Load a workspace, e.g. MAR11060 from the training course data.
Open SliceViewer by right clicking on the workspace name and selecting ```Show Slice Viewer```
Make sure the Magnifying Glass button on the toolbar has been selected
Draw a rectangle somewhere on the plot. The plot should zoom to that point without any error messages.

Fixes #33733 and #33687

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
