### PR TITLE
WIP: Explore issues with SmoothNeighbours not releasing memory

### DIFF
--- a/Framework/Algorithms/src/SmoothNeighbours.cpp
+++ b/Framework/Algorithms/src/SmoothNeighbours.cpp
@@ -326,11 +326,7 @@ void SmoothNeighbours::findNeighboursUbiqutious() {
   outWI = 0;
   int sum = getProperty("SumNumberOfNeighbours");
   std::shared_ptr<const Geometry::IComponent> parent, neighbParent, grandparent, neighbGParent;
-  auto used = new bool[inWS->getNumberHistograms()];
-  if (sum > 1) {
-    for (size_t wi = 0; wi < inWS->getNumberHistograms(); wi++)
-      used[wi] = false;
-  }
+  std::vector<bool> used(inWS->getNumberHistograms(), false);
   const auto &detectorInfo = inWS->detectorInfo();
   for (size_t wi = 0; wi < inWS->getNumberHistograms(); wi++) {
     if (sum > 1)
@@ -419,8 +415,6 @@ void SmoothNeighbours::findNeighboursUbiqutious() {
 
     m_progress->report("Finding Neighbours");
   } // each workspace index
-
-  delete[] used;
 }
 
 /**
@@ -523,17 +517,13 @@ void SmoothNeighbours::exec() {
   else
     findNeighboursUbiqutious();
 
-  EventWorkspace_sptr wsEvent = std::dynamic_pointer_cast<EventWorkspace>(inWS);
+  auto wsEvent = std::dynamic_pointer_cast<EventWorkspace>(inWS);
   if (wsEvent)
     wsEvent->sortAll(TOF_SORT, m_progress.get());
-
-  if (!wsEvent || !PreserveEvents)
-    this->execWorkspace2D();
-  else if (wsEvent)
+  if (wsEvent && PreserveEvents)
     this->execEvent(wsEvent);
   else
-    throw std::runtime_error("This algorithm requires a Workspace2D or "
-                             "EventWorkspace as its input.");
+    this->execWorkspace2D();
 }
 
 //--------------------------------------------------------------------------------------------

--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -167,7 +167,6 @@ useStlAlgorithm:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/CreateFloodWorkspac
 knownConditionTrueFalse:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/ResetNegatives.cpp:115
 knownConditionTrueFalse:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/ResizeRectangularDetector.cpp:74
 useStlAlgorithm:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/SampleCorrections/MCInteractionStatistics.cpp:77
-knownConditionTrueFalse:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/SmoothNeighbours.cpp:532
 nullPointerRedundantCheck:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/SmoothNeighbours.cpp:256
 unreadVariable:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/VesuvioL1ThetaResolution.cpp:241
 useStlAlgorithm:${CMAKE_SOURCE_DIR}/Framework/API/src/Algorithm.cpp:369


### PR DESCRIPTION
**Description of work.**


Avoids managing memory by hand,ensuring
all paths out of the function will delete
it

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**

<!-- Instructions for testing. -->

Fixes #xxxx. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
