### PR TITLE
Add inelastic discus workflow algorithm

### DIFF
--- a/Framework/PythonInterface/plugins/CMakeLists.txt
+++ b/Framework/PythonInterface/plugins/CMakeLists.txt
@@ -307,6 +307,7 @@ set(PYTHON_PLUGINS
     algorithms/WorkflowAlgorithms/SANSStitch.py
     algorithms/WorkflowAlgorithms/SavePlot1D.py
     algorithms/WorkflowAlgorithms/SaveVulcanGSS.py
+    algorithms/WorkflowAlgorithms/SimpleShapeDiscusInelastic.py
     algorithms/WorkflowAlgorithms/SimpleShapeMonteCarloAbsorption.py
     algorithms/WorkflowAlgorithms/SimulatedDensityOfStates.py
     algorithms/WorkflowAlgorithms/SingleCrystalDiffuseReduction.py

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SimpleShapeDiscusInelastic.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SimpleShapeDiscusInelastic.py
@@ -1,0 +1,228 @@
+#pylint: disable=no-init
+from mantid.api import (PythonAlgorithm, AlgorithmFactory, MatrixWorkspaceProperty)
+from mantid.kernel import (VisibleWhenProperty, PropertyCriterion,
+                           StringListValidator, IntBoundedValidator, FloatBoundedValidator, Direction)
+from mantid.simpleapi import *
+
+
+class SimpleShapeDiscusInelastic(PythonAlgorithm):
+    # basic sample variables
+    _chemical_formula = None
+    _mass_density = None
+    _shape = None
+    _height = None
+
+    # MC variables
+    _single_paths = None
+    _multiple_paths = None
+    _scatterings = None
+    _output_ws = None
+
+    # flat plate variables
+    _width = None
+    _thickness = None
+    _angle = None
+
+    # cylinder variables
+    _radius = None
+
+    # annulus variables
+    _inner_radius = None
+    _outer_radius = None
+
+    def category(self):
+        return "Workflow\\MIDAS"
+
+    def PyInit(self):
+        self.declareProperty(MatrixWorkspaceProperty('ReducedWorkspace', '',
+                                                     direction=Direction.Input),
+                             doc='Reduced Workspace')
+        self.declareProperty(MatrixWorkspaceProperty('SqwWorkspace', '',
+                                                     direction=Direction.Input),
+                             doc='S(Q,w) Workspace')
+        self.declareProperty(name='OutputWorkspace', defaultValue='MuscatResults',
+                             doc='Name for results workspaces')
+
+        self.declareProperty(name='SampleMassDensity', defaultValue=1.0,
+                             validator=FloatBoundedValidator(0.0),
+                             doc='Sample mass density. Default=1.0')
+
+        self.declareProperty(name='SampleChemicalFormula', defaultValue='',
+                             doc='Sample Chemical formula')
+
+        self.declareProperty(name='Height', defaultValue=1.0,
+                             validator=FloatBoundedValidator(0.0),
+                             doc='Height of the sample environment (cm)')
+
+        # set up shape options
+
+        self.declareProperty(name='Shape', defaultValue='FlatPlate',
+                             validator=StringListValidator(['FlatPlate', 'Cylinder', 'Annulus']),
+                             doc='Geometry of sample environment. Options are: FlatPlate, Cylinder, Annulus')
+
+        flat_plate_condition = VisibleWhenProperty('Shape', PropertyCriterion.IsEqualTo, 'FlatPlate')
+        cylinder_condition = VisibleWhenProperty('Shape', PropertyCriterion.IsEqualTo, 'Cylinder')
+        annulus_condition = VisibleWhenProperty('Shape', PropertyCriterion.IsEqualTo, 'Annulus')
+
+        # flat plate options
+
+        self.declareProperty(name='Width', defaultValue=1.0,
+                             validator=FloatBoundedValidator(0.0),
+                             doc='Width of the FlatPlate sample environment (cm)')
+        self.setPropertySettings('Width', flat_plate_condition)
+
+        self.declareProperty(name='Thickness', defaultValue=0.1,
+                             validator=FloatBoundedValidator(0.0),
+                             doc='Thickness of the FlatPlate sample environment (cm)')
+        self.setPropertySettings('Thickness', flat_plate_condition)
+
+        self.declareProperty(name='Angle', defaultValue=0.0,
+                             validator=FloatBoundedValidator(0.0),
+                             doc='Angle of the FlatPlate sample environment with respect to the beam (degrees)')
+        self.setPropertySettings('Angle', flat_plate_condition)
+
+        # cylinder options
+
+        self.declareProperty(name='SampleRadius', defaultValue=0.5,
+                             validator=FloatBoundedValidator(0.0),
+                             doc='Sample radius (cm). Default=0.5')
+        self.setPropertySettings('SampleRadius', cylinder_condition)
+
+        # annulus options
+
+        self.declareProperty(name='SampleInnerRadius', defaultValue=0.5,
+                             validator=FloatBoundedValidator(0.0),
+                             doc='Sample inner radius (cm). Default=0.5')
+        self.setPropertySettings('SampleInnerRadius', annulus_condition)
+
+        self.declareProperty(name='SampleOuterRadius', defaultValue=0.6,
+                             validator=FloatBoundedValidator(0.0),
+                             doc='Sample outer radius (cm). Default=0.6')
+        self.setPropertySettings('SampleOuterRadius', annulus_condition)
+
+        # MC options
+
+        self.declareProperty(name='NeutronPathsSingle', defaultValue=1000,
+                             validator=IntBoundedValidator(1),
+                             doc='Number of paths for single scattering. Default=1000')
+        self.declareProperty(name='NeutronPathsMultiple', defaultValue=1000,
+                             validator=IntBoundedValidator(1),
+                             doc='Number of paths for multiple scattering. Default=1000')
+        self.declareProperty(name='NumberScatterings', defaultValue=1,
+                             validator=IntBoundedValidator(1),
+                             doc='Number of scatterings. Default=1')
+
+    def PyExec(self):
+        reduced_ws = self.getProperty('ReducedWorkspace').value
+        sqw_ws = self.getProperty('SqwWorkspace').value
+
+        if self._shape == 'FlatPlate':
+            width = self.getProperty('Width').value
+            thick = self.getProperty('Thickness').value
+            angle = self.getProperty('Angle').value
+
+            SetSample(reduced_ws,
+                      Geometry={"Shape": 'FlatPlate', "Height": self._height,"Width": width, "Angle": angle,
+                                "Center": [0.,0.,0.], "Thick": thick},
+                      Material={"ChemicalFormula": self._chemical_formula, "MassDensity": self._mass_density})
+
+        if self._shape == 'Cylinder':
+            sample_radius = self.getProperty('SampleRadius').value
+
+            SetSample(reduced_ws,
+                      Geometry={"Shape": "Cylinder", "Height": self._height,"Radius": sample_radius, "Center": [0.,0.,0.]},
+                      Material={"ChemicalFormula": self._chemical_formula, "MassDensity": self._mass_density})
+
+        if self._shape == 'Annulus':
+            sample_inner = self.getProperty('SampleInnerRadius').value
+            sample_outer = self.getProperty('SampleOuterRadius').value
+
+            SetSample(reduced_ws,
+                      Geometry={"Shape": "HollowCylinder", "Height": self._height,
+                                "InnerRadius": sample_inner, "OuterRadius": sample_outer, "Center": [0.,0.,0.]},
+                      Material={"ChemicalFormula": self._chemical_formula, "MassDensity": self._mass_density})
+
+        DiscusMultipleScatteringCorrection(InputWorkspace=reduced_ws, StructureFactorWorkspace=sqw_ws,
+                                           OutputWorkspace=self._output_ws,
+                                           NeutronPathsSingle=self._single_paths,
+                                           NeutronPathsMultiple=self._multiple_paths,
+                                           NumberScatterings=self._scatterings)
+
+    def _setup(self):
+
+        self._chemical_formula = self.getPropertyValue('SampleChemicalFormula')
+        self._mass_density = self.getProperty('SampleMassDensity').value
+
+        # shape options
+        self._shape = self.getProperty('Shape').value
+
+        self._height = self.getProperty('Height').value
+
+        # flat plate
+        self._width = self.getProperty('Width').value
+        self._thickness = self.getProperty('Thickness').value
+        self._angle = self.getProperty('Angle').value
+
+        # cylinder
+        self._radius = self.getProperty('SampleRadius').value
+
+        # annulus
+        self._inner_radius = self.getProperty('SampleInnerRadius').value
+        self._outer_radius = self.getProperty('SampleOuterRadius').value
+
+        # MC parameters
+        self._single_paths = self.getProperty('NeutronPathsSingle').value
+        self._multiple_paths = self.getProperty('NeutronPathsMultiple').value
+        self._scatterings = self.getProperty('NumberScatterings').value
+
+        # output
+        self._output_ws = self.getPropertyValue('OutputWorkspace')
+
+    def validateInputs(self):
+
+        self._setup()
+        issues = dict()
+
+        if not self._mass_density:
+            issues['SampleMassDensity'] = 'Please enter a non-zero number for sample mass density'
+
+#        if self._chemical_formula:
+#            issues['SampleChemicalFormula'] = 'Please enter a chemical formula or cross sections.'
+
+        if not self._height:
+            issues['Height'] = 'Please enter a non-zero number for height'
+
+        if self._shape == 'FlatPlate':
+            if not self._width:
+                issues['Width'] = 'Please enter a non-zero number for width'
+            if not self._thickness:
+                issues['Thickness'] = 'Please enter a non-zero number for thickness'
+
+        if self._shape == 'Cylinder':
+            if not self._radius:
+                issues['Radius'] = 'Please enter a non-zero number for radius'
+
+        if self._shape == 'Annulus':
+            if not self._inner_radius:
+                issues['InnerRadius'] = 'Please enter a non-zero number for inner radius'
+            if not self._outer_radius:
+                issues['OuterRadius'] = 'Please enter a non-zero number for outer radius'
+
+            # Geometry validation: outer radius > inner radius
+            if not self._outer_radius > self._inner_radius:
+                issues['OuterRadius'] = 'Must be greater than InnerRadius'
+
+        if not self._single_paths:
+            issues['NeutronPathsSingle'] = 'Please enter a non-zero number for neutron paths single'
+
+        if not self._multiple_paths:
+            issues['NeutronPathsMultiple'] = 'Please enter a non-zero number for neutron paths multiple'
+
+        if not self._scatterings:
+            issues['NumberScatterings'] = 'Please enter a non-zero number for neutron scatterings'
+
+        return issues
+
+
+# Register algorithm with Mantid
+AlgorithmFactory.subscribe(SimpleShapeDiscusInelastic)

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SimpleShapeDiscusInelastic.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SimpleShapeDiscusInelastic.py
@@ -157,7 +157,9 @@ class SimpleShapeDiscusInelastic(PythonAlgorithm):
                                                               OutputWorkspace=self._output_ws,
                                                               NeutronPathsSingle=self._single_paths,
                                                               NeutronPathsMultiple=self._multiple_paths,
-                                                              NumberScatterings=self._scatterings)
+                                                              NumberScatterings=self._scatterings,
+                                                              startProgress=0.,
+                                                              endProgress=1.)
 
         self.setProperty('OutputWorkspace', results_group_ws)
 

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SimpleShapeDiscusInelastic.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SimpleShapeDiscusInelastic.py
@@ -1,4 +1,9 @@
-#pylint: disable=no-init
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2022 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
 from mantid.api import (PythonAlgorithm, AlgorithmFactory, MatrixWorkspaceProperty,
                         WorkspaceGroupProperty, PropertyMode)
 from mantid.kernel import (VisibleWhenProperty, PropertyCriterion,

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SimpleShapeDiscusInelastic.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SimpleShapeDiscusInelastic.py
@@ -199,8 +199,8 @@ class SimpleShapeDiscusInelastic(PythonAlgorithm):
         if not self._mass_density:
             issues['SampleMassDensity'] = 'Please enter a non-zero number for sample mass density'
 
-#        if self._chemical_formula:
-#            issues['SampleChemicalFormula'] = 'Please enter a chemical formula or cross sections.'
+        if not self._chemical_formula:
+            issues['SampleChemicalFormula'] = 'Please enter a chemical formula.'
 
         if not self._height:
             issues['Height'] = 'Please enter a non-zero number for height'

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/CMakeLists.txt
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/CMakeLists.txt
@@ -77,6 +77,7 @@ set(TEST_PY_FILES
     SANSStitchTest.py
     SavePlot1DTest.py
     SaveVulcanGSSTest.py
+    SimpleShapeDiscusInelasticTest.py
     SimpleShapeMonteCarloAbsorptionTest.py
     SimulatedDensityOfStatesTest.py
     SofQWMomentsTest.py

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/SimpleShapeDiscusInelasticTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/SimpleShapeDiscusInelasticTest.py
@@ -1,0 +1,155 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2022 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+from mantid.simpleapi import (SimpleShapeDiscusInelastic, Load, ConvertUnits,
+                              DeleteWorkspace)
+import unittest
+
+
+class SimpleShapeDiscusInelasticTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(self):
+        red_ws = Load('irs26176_graphite002_red.nxs')
+        red_ws.run().addProperty("deltaE-mode", "Indirect", True);
+        red_ws.run().addProperty("Ei", 1.845, True);
+
+        self._red_ws = red_ws
+
+        sqw_ws = Load('iris26176_graphite002_sqw.nxs')
+        self._sqw_ws = sqw_ws
+
+        self._arguments = {'SampleChemicalFormula': 'H2-O',
+                           'SampleMassDensity': 1.0,
+                           'NeutronPathsSingle': 50,
+                           'NeutronPathsMultiple': 50,
+                           'Height': 2.0,
+                           'NumberScatterings': 2}
+
+        self._annulus_arguments = self._arguments.copy()
+        self._annulus_arguments.update({
+            'Shape': 'Annulus',
+            'SampleOuterRadius': 2.0
+        })
+
+    @classmethod
+    def tearDownClass(self):
+        DeleteWorkspace(self._red_ws)
+        DeleteWorkspace(self._sqw_ws)
+
+    def _test_corrections_workspace(self, corr_ws_grp):
+        number_ws = corr_ws_grp.getNumberOfEntries()
+        # Scatter_1, Scatter_1_NoAbs, Scatter_2, Scatter_2_2_Summed
+        self.assertEqual(number_ws,4)
+
+        for i in range(number_ws):
+            x_unit = corr_ws_grp[i].getAxis(0).getUnit().unitID()
+            self.assertEqual(x_unit, 'DeltaE')
+
+            y_unit = corr_ws_grp[i].YUnitLabel()
+            self.assertEqual(y_unit, 'Scattered Weight')
+
+            num_hists = corr_ws_grp[i].getNumberHistograms()
+            self.assertEqual(num_hists, 10)
+
+            blocksize = corr_ws_grp[i].blocksize()
+            self.assertEqual(blocksize, 1905)
+
+    def test_flat_plate(self):
+        # Test flat plate shape
+
+        kwargs = self._arguments
+        results = SimpleShapeDiscusInelastic(ReducedWorkspace=self._red_ws,
+                                             SqwWorkspace=self._sqw_ws,
+                                             Shape='FlatPlate',
+                                             Width=2.0,
+                                             Thickness=2.0,
+                                             **kwargs)
+
+        self._test_corrections_workspace(results)
+
+    def test_cylinder(self):
+        # Test cylinder shape
+
+        kwargs = self._arguments
+        results = SimpleShapeDiscusInelastic(ReducedWorkspace=self._red_ws,
+                                             SqwWorkspace=self._sqw_ws,
+                                             Shape='Cylinder',
+                                             SampleRadius=2.0,
+                                             **kwargs)
+
+        self._test_corrections_workspace(results)
+
+    def test_annulus(self):
+        # Test annulus shape
+
+        kwargs = self._annulus_arguments
+        results = SimpleShapeDiscusInelastic(ReducedWorkspace=self._red_ws,
+                                             SqwWorkspace=self._sqw_ws,
+                                             SampleInnerRadius=1.0,
+                                             **kwargs)
+
+        self._test_corrections_workspace(results)
+
+
+    # ------------------------------------- Failure Cases --------------------
+
+    def test_no_chemical_formula_or_cross_sections_causes_an_error(self):
+        kwargs = {'ReducedWorkspace': self._red_ws,
+                  'SqwWorkspace' :self._sqw_ws,
+                  'SampleMassDensity': 1.0,
+                  'NeutronPathsSingle': 50,
+                  'NeutronPathsMultiple': 50,
+                  'Height': 2.0,
+                  'Shape': 'FlatPlate',
+                  'Width': 1.4,
+                  'Thickness': 2.1}
+
+        with self.assertRaises(RuntimeError):
+            SimpleShapeDiscusInelastic(**kwargs)
+
+    def test_flat_plate_no_params(self):
+        # If the shape is flat plate but the relevant parameters haven't been entered this should throw
+        # relevant params are Height, Width, Thickness
+
+        kwargs = {'ReducedWorkspace': self._red_ws,
+                  'SqwWorkspace': self._sqw_ws,
+                  'ChemicalFormula': 'H2-O',
+                  'SampleMassDensity': 1.0,
+                  'NeutronPathsSingle': 50,
+                  'NeutronPathsMultiple': 50,
+                  'Shape': 'FlatPlate'}
+
+        with self.assertRaises(RuntimeError):
+            SimpleShapeDiscusInelastic(**kwargs)
+
+    def test_not_in_deltaE(self):
+        red_ws_not_deltaE = Load('irs26176_graphite002_red.nxs')
+
+        red_ws_not_deltaE = ConvertUnits(
+            InputWorkspace=self._red_ws,
+            Target='Wavelength',
+            EMode='Indirect',
+            EFixed=1.845)
+
+        kwargs = {'ReducedWorkspace': red_ws_not_deltaE,
+                  'SqwWorkspace': self._sqw_ws,
+                  'ChemicalFormula': 'H2-O',
+                  'SampleMassDensity': 1.0,
+                  'NeutronPathsSingle': 50,
+                  'NeutronPathsMultiple': 50,
+                  'Height': 2.0,
+                  'Shape': 'FlatPlate',
+                  'Width': 1.4,
+                  'Thickness': 2.1}
+
+        with self.assertRaises(RuntimeError):
+            SimpleShapeDiscusInelastic(**kwargs)
+
+        DeleteWorkspace(red_ws_not_deltaE)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/source/algorithms/DiscusMultipleScatteringCorrection-v1.rst
+++ b/docs/source/algorithms/DiscusMultipleScatteringCorrection-v1.rst
@@ -209,9 +209,10 @@ Usage
              Material={'NumberDensity': 0.02, 'AttenuationXSection': 0.0,
                        'CoherentXSection': 0.0, 'IncoherentXSection': 0.0, 'ScatteringXSection': 80.0})
 
-   DiscusMultipleScatteringCorrection(InputWorkspace=ws, StructureFactorWorkspace=Sofq,
-                                      OutputWorkspace="MuscatResults", NeutronPathsSingle=1000,
-                                      NeutronPathsMultiple=10000, ImportanceSampling=True)
+   results_group = DiscusMultipleScatteringCorrection(InputWorkspace=ws, StructureFactorWorkspace=Sofq,
+                                                      OutputWorkspace="MuscatResults", NeutronPathsSingle=1000,
+                                                      NeutronPathsMultiple=10000, ImportanceSampling=True)
+   # Can't index into workspace group by name (yet) so just get the members from the ADS instead
    Scatter_1_DeltaFunction = CloneWorkspace('Scatter_1')
    Scatter_2_DeltaFunction = CloneWorkspace('Scatter_2')
    DeleteWorkspace('MuscatResults')

--- a/docs/source/algorithms/SimpleShapeDiscusInelastic-v1.rst
+++ b/docs/source/algorithms/SimpleShapeDiscusInelastic-v1.rst
@@ -1,0 +1,27 @@
+
+.. algorithm::
+
+.. summary::
+
+.. relatedalgorithms::
+
+.. properties::
+
+Description
+-----------
+
+Sets up a sample shape, along with the required material properties, and runs
+the :ref:`DiscusMultipleScatteringCorrection <algm-DiscusMultipleScatteringCorrection-v1>` algorithm. This algorithm merely
+serves as a simpler interface to define the shape & material of the sample without having
+to resort to the more complex :ref:`SetSample <algm-SetSample-v1>` algorithm.
+The computational part is all taken care of by :ref:`DiscusMultipleScatteringCorrection <algm-DiscusMultipleScatteringCorrection-v1>`. Please see that
+documentation for more details.
+Currently the shape geometries supported are:
+
+* Flat Plate
+* Cylinder
+* Annulus
+
+.. categories::
+
+.. sourcelink::

--- a/docs/source/release/v6.4.0/Indirect/Algorithms/New_features/33752_NewSimpleShapeDiscusInelasticAlgorithm.rst
+++ b/docs/source/release/v6.4.0/Indirect/Algorithms/New_features/33752_NewSimpleShapeDiscusInelasticAlgorithm.rst
@@ -1,0 +1,1 @@
+- Add new workflow algorithm called :ref:`SimpleShapeDiscusInelastic <algm-SimpleShapeDiscusInelastic>` that calls :ref:`DiscusMultipleScatteringCorrection <algm-DiscusMultipleScatteringCorrection>` with options for some simple shape types


### PR DESCRIPTION
**Description of work.**

Add workflow algorithm called SimpleShapeDiscusInelastic created by Spencer Howells. The new algorithm calls DiscusMultipleScatteringCorrection for some simple sample shapes. I've added a documentation page and a unit test suite

**To test:**

1) Load these two files which are part of the Mantid unit test data files:
- irs26176_graphite002_red.nxs
- iris26176_graphite002_sqw.nxs
2) Open up the SimpleShapeDiscusInelastic algorithm dialog and run with the following parameters:

![image](https://user-images.githubusercontent.com/56295817/162746501-8694f795-e007-4d61-9a6a-c912ee52fa18.png)

The algorithm should complete successfully and generate a workspace group called "MuscatResults"

Fixes #33723.


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
