### PR TITLE
Release GIL before posting ADS notifications

### DIFF
--- a/Framework/PythonInterface/mantid/api/src/Exports/MultipleExperimentInfos.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/MultipleExperimentInfos.cpp
@@ -6,11 +6,29 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 #include "MantidAPI/MultipleExperimentInfos.h"
 #include "MantidAPI/ExperimentInfo.h"
+#include "MantidAPI/Workspace.h"
+#include "MantidPythonInterface/core/ExtractSharedPtr.h"
 #include <boost/python/class.hpp>
 
+using Mantid::API::ExperimentInfo;
 using Mantid::API::ExperimentInfo_sptr;
 using Mantid::API::MultipleExperimentInfos;
+using Mantid::API::Workspace;
+using Mantid::PythonInterface::ExtractSharedPtr;
 using namespace boost::python;
+
+namespace {
+void addExperimentInfo(MultipleExperimentInfos &self, const boost::python::object &item) {
+  auto workspaceExtractor = ExtractSharedPtr<Workspace>(item);
+  if (!workspaceExtractor.check())
+    throw std::invalid_argument("Incorrect type. Expected a workspace.");
+
+  if (auto exptInfo = std::dynamic_pointer_cast<ExperimentInfo>(workspaceExtractor()))
+    self.addExperimentInfo(exptInfo);
+  else
+    throw std::invalid_argument("Incorrect type. Expected a workspace type derived from ExperimentInfo.");
+}
+} // namespace
 
 void export_MultipleExperimentInfos() {
   class_<MultipleExperimentInfos, boost::noncopyable>("MultipleExperimentInfos", no_init)
@@ -18,7 +36,7 @@ void export_MultipleExperimentInfos() {
            (ExperimentInfo_sptr(MultipleExperimentInfos::*)(const uint16_t)) &
                MultipleExperimentInfos::getExperimentInfo,
            (arg("self"), arg("expInfoIndex")), "Return the experiment info at the given index.")
-      .def("addExperimentInfo", &MultipleExperimentInfos::addExperimentInfo, (arg("self"), arg("ExperimentalInfo")),
+      .def("addExperimentInfo", addExperimentInfo, (arg("self"), arg("ExperimentalInfo")),
            "Add a new :class:`~mantid.api.ExperimentInfo` to this "
            ":class:`~mantid.api.IMDWorkspace`")
       .def("getNumExperimentInfo", &MultipleExperimentInfos::getNumExperimentInfo, arg("self"),

--- a/Framework/PythonInterface/test/python/mantid/api/MultipleExperimentInfos.py
+++ b/Framework/PythonInterface/test/python/mantid/api/MultipleExperimentInfos.py
@@ -6,10 +6,14 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 import unittest
 from testhelpers import WorkspaceCreationHelper
-from mantid.api import ExperimentInfo
+from mantid.api import AnalysisDataService, ExperimentInfo
+from mantid.simpleapi import CreateSampleWorkspace, CreateMDWorkspace
 
 
 class MultipleExperimentInfoTest(unittest.TestCase):
+
+    def tearDown(self):
+        AnalysisDataService.clear()
 
     def test_information_access(self):
         signal = 2.0
@@ -18,5 +22,10 @@ class MultipleExperimentInfoTest(unittest.TestCase):
         expinfo = expt_ws.getExperimentInfo(0)
         self.assertTrue(isinstance(expinfo, ExperimentInfo))
         self.assertEqual(1, expt_ws.getNumExperimentInfo())
+
+    def test_add_experiment_info(self):
+        ws1 = CreateSampleWorkspace()
+        md = CreateMDWorkspace(Dimensions=1, Extents='-1,1', Names='A', Units='U')
+        md.addExperimentInfo(ws1)
 
 if __name__ == '__main__': unittest.main()

--- a/docs/source/release/v6.4.0/Framework/Python/Bugfixes/33664.rst
+++ b/docs/source/release/v6.4.0/Framework/Python/Bugfixes/33664.rst
@@ -1,0 +1,1 @@
+- Fix a bug where Mantid could hang when performing ADS updates from multiple python algorithms at the same time.

--- a/docs/source/release/v6.4.0/Reflectometry/Bugfixes/33664.rst
+++ b/docs/source/release/v6.4.0/Reflectometry/Bugfixes/33664.rst
@@ -1,0 +1,1 @@
+- Fix a bug where Mantid could hang when running multiple python algorithms simultaneously, e.g. when running live data and processing a batch at the same time.


### PR DESCRIPTION
**Report to:** Max at ISIS

This PR fixes a bug where Mantid could hang due to a deadlock between the GIL and a poco lock that is set when posting notifications about ADS updates.

If an ADS function such as addOrRemove is called from a python algorithm (which has the GIL locked) then the poco notification attempts to take its own lock. However, the poco lock could already be locked by another  notification, and it could be possible for the other notification to call into python, hence requiring the GIL and hence ending up in deadlock.

This PR changes the python exports to ensure we release the GIL in any ADS calls that cause poco notifications.

Fixes #33664

**To test:**

Try to reproduce the bug in the linked issue. Mantid should no longer hang. 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
