### PR TITLE
Add Lookup Row Index to Refl View 

### DIFF
--- a/docs/source/release/v6.4.0/Reflectometry/New_features/33626.rst
+++ b/docs/source/release/v6.4.0/Reflectometry/New_features/33626.rst
@@ -1,0 +1,1 @@
+- The Runs Tab of the ISIS Reflectometry Interface now contains a Lookup Index column to indicate which of the rows from the Experiment Settings tab was used.

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchPresenter.cpp
@@ -123,7 +123,6 @@ void BatchPresenter::notifyAlgorithmStarted(IConfiguredAlgorithm_sptr &algorithm
   }
   m_jobManager->algorithmStarted(algorithm);
   m_runsPresenter->notifyRowModelChanged(item.value());
-  m_runsPresenter->notifyRowStateChanged(item.value());
 }
 
 void BatchPresenter::notifyAlgorithmComplete(IConfiguredAlgorithm_sptr &algorithm) {
@@ -133,7 +132,6 @@ void BatchPresenter::notifyAlgorithmComplete(IConfiguredAlgorithm_sptr &algorith
   }
   m_jobManager->algorithmComplete(algorithm);
   m_runsPresenter->notifyRowModelChanged(item.value());
-  m_runsPresenter->notifyRowStateChanged(item.value());
   /// TODO Longer term it would probably be better if algorithms took care
   /// of saving their outputs so we could remove this callback
   if (m_savePresenter->shouldAutosave()) {
@@ -149,7 +147,6 @@ void BatchPresenter::notifyAlgorithmError(IConfiguredAlgorithm_sptr algorithm, s
   }
   m_jobManager->algorithmError(algorithm, message);
   m_runsPresenter->notifyRowModelChanged(item.value());
-  m_runsPresenter->notifyRowStateChanged(item.value());
 }
 
 /** Start processing the next batch of algorithms.
@@ -348,18 +345,15 @@ std::unique_ptr<MantidQt::API::IAlgorithmRuntimeProps> BatchPresenter::rowProces
 void BatchPresenter::postDeleteHandle(const std::string &wsName) {
   auto const item = m_jobManager->notifyWorkspaceDeleted(wsName);
   m_runsPresenter->notifyRowModelChanged(item);
-  m_runsPresenter->notifyRowStateChanged(item);
 }
 
 void BatchPresenter::renameHandle(const std::string &oldName, const std::string &newName) {
   auto const item = m_jobManager->notifyWorkspaceRenamed(oldName, newName);
   m_runsPresenter->notifyRowModelChanged(item);
-  m_runsPresenter->notifyRowStateChanged(item);
 }
 
 void BatchPresenter::clearADSHandle() {
   m_jobManager->notifyAllWorkspacesDeleted();
   m_runsPresenter->notifyRowModelChanged();
-  m_runsPresenter->notifyRowStateChanged();
 }
 } // namespace MantidQt::CustomInterfaces::ISISReflectometry

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchPresenter.cpp
@@ -122,7 +122,7 @@ void BatchPresenter::notifyAlgorithmStarted(IConfiguredAlgorithm_sptr &algorithm
     return;
   }
   m_jobManager->algorithmStarted(algorithm);
-  m_runsPresenter->notifyRowOutputsChanged(item.value());
+  m_runsPresenter->notifyRowModelChanged(item.value());
   m_runsPresenter->notifyRowStateChanged(item.value());
 }
 
@@ -132,7 +132,7 @@ void BatchPresenter::notifyAlgorithmComplete(IConfiguredAlgorithm_sptr &algorith
     return;
   }
   m_jobManager->algorithmComplete(algorithm);
-  m_runsPresenter->notifyRowOutputsChanged(item.value());
+  m_runsPresenter->notifyRowModelChanged(item.value());
   m_runsPresenter->notifyRowStateChanged(item.value());
   /// TODO Longer term it would probably be better if algorithms took care
   /// of saving their outputs so we could remove this callback
@@ -148,7 +148,7 @@ void BatchPresenter::notifyAlgorithmError(IConfiguredAlgorithm_sptr algorithm, s
     return;
   }
   m_jobManager->algorithmError(algorithm, message);
-  m_runsPresenter->notifyRowOutputsChanged(item.value());
+  m_runsPresenter->notifyRowModelChanged(item.value());
   m_runsPresenter->notifyRowStateChanged(item.value());
 }
 
@@ -347,19 +347,19 @@ std::unique_ptr<MantidQt::API::IAlgorithmRuntimeProps> BatchPresenter::rowProces
 
 void BatchPresenter::postDeleteHandle(const std::string &wsName) {
   auto const item = m_jobManager->notifyWorkspaceDeleted(wsName);
-  m_runsPresenter->notifyRowOutputsChanged(item);
+  m_runsPresenter->notifyRowModelChanged(item);
   m_runsPresenter->notifyRowStateChanged(item);
 }
 
 void BatchPresenter::renameHandle(const std::string &oldName, const std::string &newName) {
   auto const item = m_jobManager->notifyWorkspaceRenamed(oldName, newName);
-  m_runsPresenter->notifyRowOutputsChanged(item);
+  m_runsPresenter->notifyRowModelChanged(item);
   m_runsPresenter->notifyRowStateChanged(item);
 }
 
 void BatchPresenter::clearADSHandle() {
   m_jobManager->notifyAllWorkspacesDeleted();
-  m_runsPresenter->notifyRowOutputsChanged();
+  m_runsPresenter->notifyRowModelChanged();
   m_runsPresenter->notifyRowStateChanged();
 }
 } // namespace MantidQt::CustomInterfaces::ISISReflectometry

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Common/Decoder.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Common/Decoder.cpp
@@ -287,7 +287,7 @@ void Decoder::decodeRunsTable(QtRunsTableView *gui, ReductionJobs *redJobs, Runs
 
   if (m_projectSave) {
     // Apply styling and restore completed state for output range values
-    presenter->notifyRowOutputsChanged();
+    presenter->notifyRowModelChanged();
     presenter->notifyRowStateChanged();
   }
   gui->m_ui.filterBox->setText(map[QString("filterBox")].toString());

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Common/Decoder.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Common/Decoder.cpp
@@ -221,7 +221,8 @@ std::vector<MantidQt::MantidWidgets::Batch::Cell> cellsFromRow(Row const &row, c
        qRangeCellOrDefault(row.qRange(), row.qRangeOutput(), &RangeInQ::max, precision),
        qRangeCellOrDefault(row.qRange(), row.qRangeOutput(), &RangeInQ::step, precision),
        MantidQt::MantidWidgets::Batch::Cell(optionalToString(row.scaleFactor(), precision)),
-       MantidQt::MantidWidgets::Batch::Cell(MantidWidgets::optionsToString(row.reductionOptions()))});
+       MantidQt::MantidWidgets::Batch::Cell(MantidWidgets::optionsToString(row.reductionOptions())),
+       MantidQt::MantidWidgets::Batch::Cell(optionalToString(row.lookupIndex(), precision))});
 }
 } // namespace
 

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/IRunsPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/IRunsPresenter.h
@@ -33,8 +33,8 @@ public:
   virtual void notifyPauseReductionRequested() = 0;
   virtual void notifyRowStateChanged() = 0;
   virtual void notifyRowStateChanged(boost::optional<Item const &> item) = 0;
-  virtual void notifyRowOutputsChanged(boost::optional<Item const &> item) = 0;
-  virtual void notifyRowOutputsChanged() = 0;
+  virtual void notifyRowModelChanged(boost::optional<Item const &> item) = 0;
+  virtual void notifyRowModelChanged() = 0;
   virtual void notifyBatchLoaded() = 0;
 
   virtual void notifyReductionPaused() = 0;

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/RunsPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/RunsPresenter.cpp
@@ -165,10 +165,10 @@ void RunsPresenter::notifyRowStateChanged(boost::optional<Item const &> item) {
   tablePresenter()->notifyRowStateChanged(item);
 }
 
-void RunsPresenter::notifyRowOutputsChanged() { tablePresenter()->notifyRowOutputsChanged(); }
+void RunsPresenter::notifyRowModelChanged() { tablePresenter()->notifyRowModelChanged(); }
 
-void RunsPresenter::notifyRowOutputsChanged(boost::optional<Item const &> item) {
-  tablePresenter()->notifyRowOutputsChanged(item);
+void RunsPresenter::notifyRowModelChanged(boost::optional<Item const &> item) {
+  tablePresenter()->notifyRowModelChanged(item);
 }
 
 void RunsPresenter::notifyBatchLoaded() { m_tablePresenter->notifyBatchLoaded(); }

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/RunsPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/RunsPresenter.cpp
@@ -165,10 +165,14 @@ void RunsPresenter::notifyRowStateChanged(boost::optional<Item const &> item) {
   tablePresenter()->notifyRowStateChanged(item);
 }
 
-void RunsPresenter::notifyRowModelChanged() { tablePresenter()->notifyRowModelChanged(); }
+void RunsPresenter::notifyRowModelChanged() {
+  tablePresenter()->notifyRowModelChanged();
+  tablePresenter()->notifyRowStateChanged();
+}
 
 void RunsPresenter::notifyRowModelChanged(boost::optional<Item const &> item) {
   tablePresenter()->notifyRowModelChanged(item);
+  tablePresenter()->notifyRowStateChanged(item);
 }
 
 void RunsPresenter::notifyBatchLoaded() { m_tablePresenter->notifyBatchLoaded(); }

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/RunsPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/RunsPresenter.h
@@ -80,8 +80,8 @@ public:
   void notifyPauseReductionRequested() override;
   void notifyRowStateChanged() override;
   void notifyRowStateChanged(boost::optional<Item const &> item) override;
-  void notifyRowOutputsChanged() override;
-  void notifyRowOutputsChanged(boost::optional<Item const &> item) override;
+  void notifyRowModelChanged() override;
+  void notifyRowModelChanged(boost::optional<Item const &> item) override;
   void notifyBatchLoaded() override;
 
   void notifyReductionPaused() override;

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/RunsTable/IRunsTablePresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/RunsTable/IRunsTablePresenter.h
@@ -32,8 +32,8 @@ public:
   virtual void notifyRowStateChanged() = 0;
   virtual void notifyRowStateChanged(boost::optional<Item const &> item) = 0;
 
-  virtual void notifyRowOutputsChanged() = 0;
-  virtual void notifyRowOutputsChanged(boost::optional<Item const &> item) = 0;
+  virtual void notifyRowModelChanged() = 0;
+  virtual void notifyRowModelChanged(boost::optional<Item const &> item) = 0;
   virtual void notifyRemoveAllRowsAndGroupsRequested() = 0;
 
   virtual void mergeAdditionalJobs(ReductionJobs const &jobs) = 0;

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/RunsTable/JobsViewUpdater.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/RunsTable/JobsViewUpdater.cpp
@@ -35,7 +35,18 @@ MantidWidgets::Batch::Cell qRangeCellOrDefault(RangeInQ const &qRangeInput, Rang
   return result;
 }
 
+boost::optional<size_t> incrementIndex(const Row &row) {
+  auto lookupIndex = row.lookupIndex();
+  if (lookupIndex.is_initialized()) {
+    lookupIndex = lookupIndex.get() + 1;
+  } else {
+    lookupIndex = boost::none;
+  }
+  return lookupIndex;
+}
+
 std::vector<MantidQt::MantidWidgets::Batch::Cell> cellsFromRow(Row const &row, boost::optional<int> precision) {
+  auto lookupIndex = incrementIndex(row);
   return std::vector<MantidQt::MantidWidgets::Batch::Cell>(
       {MantidQt::MantidWidgets::Batch::Cell(boost::join(row.runNumbers(), "+")),
        MantidQt::MantidWidgets::Batch::Cell(valueToString(row.theta(), precision)),
@@ -45,7 +56,8 @@ std::vector<MantidQt::MantidWidgets::Batch::Cell> cellsFromRow(Row const &row, b
        qRangeCellOrDefault(row.qRange(), row.qRangeOutput(), &RangeInQ::max, precision),
        qRangeCellOrDefault(row.qRange(), row.qRangeOutput(), &RangeInQ::step, precision),
        MantidQt::MantidWidgets::Batch::Cell(optionalToString(row.scaleFactor(), precision)),
-       MantidQt::MantidWidgets::Batch::Cell(MantidWidgets::optionsToString(row.reductionOptions()))});
+       MantidQt::MantidWidgets::Batch::Cell(MantidWidgets::optionsToString(row.reductionOptions())),
+       MantidQt::MantidWidgets::Batch::Cell(optionalToString(lookupIndex, precision))});
 }
 } // namespace
 

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/RunsTable/JobsViewUpdater.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/RunsTable/JobsViewUpdater.cpp
@@ -37,12 +37,7 @@ MantidWidgets::Batch::Cell qRangeCellOrDefault(RangeInQ const &qRangeInput, Rang
 
 boost::optional<size_t> incrementIndex(const Row &row) {
   auto lookupIndex = row.lookupIndex();
-  if (lookupIndex.is_initialized()) {
-    lookupIndex = lookupIndex.get() + 1;
-  } else {
-    lookupIndex = boost::none;
-  }
-  return lookupIndex;
+  return lookupIndex.is_initialized() ? boost::optional<size_t>(lookupIndex.get() + 1) : boost::none;
 }
 
 std::vector<MantidQt::MantidWidgets::Batch::Cell> cellsFromRow(Row const &row, boost::optional<int> precision) {

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/RunsTable/JobsViewUpdater.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/RunsTable/JobsViewUpdater.h
@@ -33,8 +33,6 @@ public:
 private:
   MantidQt::MantidWidgets::Batch::IJobTreeView &m_view;
   boost::optional<int> m_precision;
-
-  boost::optional<size_t> incrementIndex(const Row &row);
 };
 } // namespace ISISReflectometry
 } // namespace CustomInterfaces

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/RunsTable/JobsViewUpdater.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/RunsTable/JobsViewUpdater.h
@@ -33,6 +33,8 @@ public:
 private:
   MantidQt::MantidWidgets::Batch::IJobTreeView &m_view;
   boost::optional<int> m_precision;
+
+  boost::optional<size_t> incrementIndex(const Row &row);
 };
 } // namespace ISISReflectometry
 } // namespace CustomInterfaces

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/RunsTable/QtRunsTableView.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/RunsTable/QtRunsTableView.cpp
@@ -20,8 +20,8 @@ QtRunsTableView::QtRunsTableView(std::vector<std::string> instruments)
   m_ui.setupUi(this);
   m_ui.progressBar->setRange(0, 100);
   m_jobs = std::make_unique<MantidQt::MantidWidgets::Batch::JobTreeView>(
-      QStringList(
-          {"Run(s)", "Angle", "1st Trans Run(s)", "2nd Trans Run(s)", "Q min", "Q max", "dQ/Q", "Scale", "Options"}),
+      QStringList({"Run(s)", "Angle", "1st Trans Run(s)", "2nd Trans Run(s)", "Q min", "Q max", "dQ/Q", "Scale",
+                   "Options", "Lookup Index"}),
       MantidQt::MantidWidgets::Batch::Cell(""), this);
   constexpr double runColScaleFactor = 1.5;
   m_jobs->setColumnWidth(0, int(m_jobs->columnWidth(0) * runColScaleFactor));

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/RunsTable/RunsTablePresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/RunsTable/RunsTablePresenter.cpp
@@ -280,6 +280,7 @@ void RunsTablePresenter::resetTablePrecision() { m_jobViewUpdater.resetPrecision
 void RunsTablePresenter::settingsChanged() {
   m_model.resetState();
   notifyRowStateChanged();
+  notifyRowOutputsChanged();
 }
 
 void RunsTablePresenter::appendRowsToGroupsInView(std::vector<int> const &groupIndices) {
@@ -453,6 +454,7 @@ void RunsTablePresenter::updateGroupName(MantidWidgets::Batch::RowLocation const
     m_view->jobs().setCellAt(itemIndex, column, cell);
   }
   m_mainPresenter->notifyGroupNameChanged(m_model.mutableReductionJobs().mutableGroups()[groupIndex]);
+  notifyRowOutputsChanged();
 }
 
 void RunsTablePresenter::updateRowField(MantidWidgets::Batch::RowLocation const &itemIndex, int column,
@@ -471,6 +473,7 @@ void RunsTablePresenter::updateRowField(MantidWidgets::Batch::RowLocation const 
     showAllCellsOnRowAsValid(itemIndex);
     m_mainPresenter->notifyRowContentChanged(
         m_model.mutableReductionJobs().mutableGroups()[groupIndex].mutableRows()[rowIndex].get());
+    notifyRowOutputsChanged(m_model.reductionJobs().groups()[groupIndex].rows()[rowIndex].get());
   } else {
     showCellsAsInvalidInView(itemIndex, rowValidationResult.assertError());
   }

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/RunsTable/RunsTablePresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/RunsTable/RunsTablePresenter.cpp
@@ -280,7 +280,7 @@ void RunsTablePresenter::resetTablePrecision() { m_jobViewUpdater.resetPrecision
 void RunsTablePresenter::settingsChanged() {
   m_model.resetState();
   notifyRowStateChanged();
-  notifyRowOutputsChanged();
+  notifyRowModelChanged();
 }
 
 void RunsTablePresenter::appendRowsToGroupsInView(std::vector<int> const &groupIndices) {
@@ -454,7 +454,7 @@ void RunsTablePresenter::updateGroupName(MantidWidgets::Batch::RowLocation const
     m_view->jobs().setCellAt(itemIndex, column, cell);
   }
   m_mainPresenter->notifyGroupNameChanged(m_model.mutableReductionJobs().mutableGroups()[groupIndex]);
-  notifyRowOutputsChanged();
+  notifyRowModelChanged();
 }
 
 void RunsTablePresenter::updateRowField(MantidWidgets::Batch::RowLocation const &itemIndex, int column,
@@ -473,7 +473,7 @@ void RunsTablePresenter::updateRowField(MantidWidgets::Batch::RowLocation const 
     showAllCellsOnRowAsValid(itemIndex);
     m_mainPresenter->notifyRowContentChanged(
         m_model.mutableReductionJobs().mutableGroups()[groupIndex].mutableRows()[rowIndex].get());
-    notifyRowOutputsChanged(m_model.reductionJobs().groups()[groupIndex].rows()[rowIndex].get());
+    notifyRowModelChanged(m_model.reductionJobs().groups()[groupIndex].rows()[rowIndex].get());
   } else {
     showCellsAsInvalidInView(itemIndex, rowValidationResult.assertError());
   }
@@ -780,7 +780,7 @@ void RunsTablePresenter::notifyRowStateChanged(boost::optional<Item const &> ite
   applyStylingToParent(row);
 }
 
-void RunsTablePresenter::notifyRowOutputsChanged() {
+void RunsTablePresenter::notifyRowModelChanged() {
   int groupIndex = 0;
   for (auto &group : m_model.reductionJobs().groups()) {
     auto groupLocation = MantidWidgets::Batch::RowLocation({groupIndex});
@@ -796,7 +796,7 @@ void RunsTablePresenter::notifyRowOutputsChanged() {
   }
 }
 
-void RunsTablePresenter::notifyRowOutputsChanged(boost::optional<Item const &> item) {
+void RunsTablePresenter::notifyRowModelChanged(boost::optional<Item const &> item) {
   if (!item.is_initialized() || item->isGroup())
     return;
 

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/RunsTable/RunsTablePresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/RunsTable/RunsTablePresenter.h
@@ -87,8 +87,8 @@ public:
   void notifyFilterReset() override;
   void notifyRowStateChanged() override;
   void notifyRowStateChanged(boost::optional<Item const &> item) override;
-  void notifyRowOutputsChanged() override;
-  void notifyRowOutputsChanged(boost::optional<Item const &> item) override;
+  void notifyRowModelChanged() override;
+  void notifyRowModelChanged(boost::optional<Item const &> item) override;
 
 private:
   void applyGroupStylingToRow(MantidWidgets::Batch::RowLocation const &location);

--- a/qt/scientific_interfaces/ISISReflectometry/test/Batch/BatchPresenterTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Batch/BatchPresenterTest.h
@@ -339,7 +339,6 @@ public:
     EXPECT_CALL(*m_jobManager, getRunsTableItem(algorithm)).Times(1).WillOnce(Return(row));
     EXPECT_CALL(*m_jobManager, algorithmStarted(algorithm)).Times(1);
     EXPECT_CALL(*m_runsPresenter, notifyRowModelChanged(_)).Times(1);
-    EXPECT_CALL(*m_runsPresenter, notifyRowStateChanged(_)).Times(1);
     presenter->notifyAlgorithmStarted(algorithm);
     verifyAndClear();
   }
@@ -351,7 +350,6 @@ public:
     EXPECT_CALL(*m_jobManager, getRunsTableItem(algorithm)).Times(1).WillOnce(Return(row));
     EXPECT_CALL(*m_jobManager, algorithmComplete(algorithm)).Times(1);
     EXPECT_CALL(*m_runsPresenter, notifyRowModelChanged(_)).Times(1);
-    EXPECT_CALL(*m_runsPresenter, notifyRowStateChanged(_)).Times(1);
     presenter->notifyAlgorithmComplete(algorithm);
     verifyAndClear();
   }
@@ -362,7 +360,6 @@ public:
     EXPECT_CALL(*m_jobManager, getRunsTableItem(algorithm)).Times(1).WillOnce(Return(boost::none));
     EXPECT_CALL(*m_jobManager, algorithmStarted(_)).Times(0);
     EXPECT_CALL(*m_runsPresenter, notifyRowModelChanged(_)).Times(0);
-    EXPECT_CALL(*m_runsPresenter, notifyRowStateChanged(_)).Times(0);
     presenter->notifyAlgorithmStarted(algorithm);
     verifyAndClear();
   }
@@ -373,7 +370,6 @@ public:
     EXPECT_CALL(*m_jobManager, getRunsTableItem(algorithm)).Times(1).WillOnce(Return(boost::none));
     EXPECT_CALL(*m_jobManager, algorithmComplete(_)).Times(0);
     EXPECT_CALL(*m_runsPresenter, notifyRowModelChanged(_)).Times(0);
-    EXPECT_CALL(*m_runsPresenter, notifyRowStateChanged(_)).Times(0);
     presenter->notifyAlgorithmComplete(algorithm);
     verifyAndClear();
   }
@@ -384,7 +380,6 @@ public:
     EXPECT_CALL(*m_jobManager, getRunsTableItem(algorithm)).Times(1).WillOnce(Return(boost::none));
     EXPECT_CALL(*m_jobManager, algorithmError(_, _)).Times(0);
     EXPECT_CALL(*m_runsPresenter, notifyRowModelChanged(_)).Times(0);
-    EXPECT_CALL(*m_runsPresenter, notifyRowStateChanged(_)).Times(0);
     presenter->notifyAlgorithmError(algorithm, "");
     verifyAndClear();
   }
@@ -423,7 +418,6 @@ public:
     auto row = makeRow();
     EXPECT_CALL(*m_jobManager, getRunsTableItem(algorithm)).Times(1).WillOnce(Return(row));
     EXPECT_CALL(*m_jobManager, algorithmError(algorithm, errorMessage)).Times(1);
-    EXPECT_CALL(*m_runsPresenter, notifyRowStateChanged(_)).Times(1);
     EXPECT_CALL(*m_runsPresenter, notifyRowModelChanged(_)).Times(1);
     presenter->notifyAlgorithmError(algorithm, errorMessage);
     verifyAndClear();
@@ -440,7 +434,6 @@ public:
   void testRowStateUpdatedWhenWorkspaceDeleted() {
     auto presenter = makePresenter(makeModel());
     EXPECT_CALL(*m_runsPresenter, notifyRowModelChanged(_)).Times(1);
-    EXPECT_CALL(*m_runsPresenter, notifyRowStateChanged(_)).Times(1);
     presenter->postDeleteHandle("");
     verifyAndClear();
   }
@@ -457,7 +450,6 @@ public:
   void testRowStateUpdatedWhenWorkspaceRenamed() {
     auto presenter = makePresenter(makeModel());
     EXPECT_CALL(*m_runsPresenter, notifyRowModelChanged(_)).Times(1);
-    EXPECT_CALL(*m_runsPresenter, notifyRowStateChanged(_)).Times(1);
     presenter->renameHandle("", "");
     verifyAndClear();
   }
@@ -472,7 +464,6 @@ public:
   void testRowStateUpdatedWhenWorkspacesCleared() {
     auto presenter = makePresenter(makeModel());
     EXPECT_CALL(*m_runsPresenter, notifyRowModelChanged()).Times(1);
-    EXPECT_CALL(*m_runsPresenter, notifyRowStateChanged()).Times(1);
     presenter->clearADSHandle();
     verifyAndClear();
   }

--- a/qt/scientific_interfaces/ISISReflectometry/test/Batch/BatchPresenterTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Batch/BatchPresenterTest.h
@@ -338,7 +338,7 @@ public:
     auto row = makeRow();
     EXPECT_CALL(*m_jobManager, getRunsTableItem(algorithm)).Times(1).WillOnce(Return(row));
     EXPECT_CALL(*m_jobManager, algorithmStarted(algorithm)).Times(1);
-    EXPECT_CALL(*m_runsPresenter, notifyRowOutputsChanged(_)).Times(1);
+    EXPECT_CALL(*m_runsPresenter, notifyRowModelChanged(_)).Times(1);
     EXPECT_CALL(*m_runsPresenter, notifyRowStateChanged(_)).Times(1);
     presenter->notifyAlgorithmStarted(algorithm);
     verifyAndClear();
@@ -350,7 +350,7 @@ public:
     auto row = makeRow();
     EXPECT_CALL(*m_jobManager, getRunsTableItem(algorithm)).Times(1).WillOnce(Return(row));
     EXPECT_CALL(*m_jobManager, algorithmComplete(algorithm)).Times(1);
-    EXPECT_CALL(*m_runsPresenter, notifyRowOutputsChanged(_)).Times(1);
+    EXPECT_CALL(*m_runsPresenter, notifyRowModelChanged(_)).Times(1);
     EXPECT_CALL(*m_runsPresenter, notifyRowStateChanged(_)).Times(1);
     presenter->notifyAlgorithmComplete(algorithm);
     verifyAndClear();
@@ -361,7 +361,7 @@ public:
     IConfiguredAlgorithm_sptr algorithm = std::make_shared<MockBatchJobAlgorithm>();
     EXPECT_CALL(*m_jobManager, getRunsTableItem(algorithm)).Times(1).WillOnce(Return(boost::none));
     EXPECT_CALL(*m_jobManager, algorithmStarted(_)).Times(0);
-    EXPECT_CALL(*m_runsPresenter, notifyRowOutputsChanged(_)).Times(0);
+    EXPECT_CALL(*m_runsPresenter, notifyRowModelChanged(_)).Times(0);
     EXPECT_CALL(*m_runsPresenter, notifyRowStateChanged(_)).Times(0);
     presenter->notifyAlgorithmStarted(algorithm);
     verifyAndClear();
@@ -372,7 +372,7 @@ public:
     IConfiguredAlgorithm_sptr algorithm = std::make_shared<MockBatchJobAlgorithm>();
     EXPECT_CALL(*m_jobManager, getRunsTableItem(algorithm)).Times(1).WillOnce(Return(boost::none));
     EXPECT_CALL(*m_jobManager, algorithmComplete(_)).Times(0);
-    EXPECT_CALL(*m_runsPresenter, notifyRowOutputsChanged(_)).Times(0);
+    EXPECT_CALL(*m_runsPresenter, notifyRowModelChanged(_)).Times(0);
     EXPECT_CALL(*m_runsPresenter, notifyRowStateChanged(_)).Times(0);
     presenter->notifyAlgorithmComplete(algorithm);
     verifyAndClear();
@@ -383,7 +383,7 @@ public:
     IConfiguredAlgorithm_sptr algorithm = std::make_shared<MockBatchJobAlgorithm>();
     EXPECT_CALL(*m_jobManager, getRunsTableItem(algorithm)).Times(1).WillOnce(Return(boost::none));
     EXPECT_CALL(*m_jobManager, algorithmError(_, _)).Times(0);
-    EXPECT_CALL(*m_runsPresenter, notifyRowOutputsChanged(_)).Times(0);
+    EXPECT_CALL(*m_runsPresenter, notifyRowModelChanged(_)).Times(0);
     EXPECT_CALL(*m_runsPresenter, notifyRowStateChanged(_)).Times(0);
     presenter->notifyAlgorithmError(algorithm, "");
     verifyAndClear();
@@ -424,7 +424,7 @@ public:
     EXPECT_CALL(*m_jobManager, getRunsTableItem(algorithm)).Times(1).WillOnce(Return(row));
     EXPECT_CALL(*m_jobManager, algorithmError(algorithm, errorMessage)).Times(1);
     EXPECT_CALL(*m_runsPresenter, notifyRowStateChanged(_)).Times(1);
-    EXPECT_CALL(*m_runsPresenter, notifyRowOutputsChanged(_)).Times(1);
+    EXPECT_CALL(*m_runsPresenter, notifyRowModelChanged(_)).Times(1);
     presenter->notifyAlgorithmError(algorithm, errorMessage);
     verifyAndClear();
   }
@@ -439,7 +439,7 @@ public:
 
   void testRowStateUpdatedWhenWorkspaceDeleted() {
     auto presenter = makePresenter(makeModel());
-    EXPECT_CALL(*m_runsPresenter, notifyRowOutputsChanged(_)).Times(1);
+    EXPECT_CALL(*m_runsPresenter, notifyRowModelChanged(_)).Times(1);
     EXPECT_CALL(*m_runsPresenter, notifyRowStateChanged(_)).Times(1);
     presenter->postDeleteHandle("");
     verifyAndClear();
@@ -456,7 +456,7 @@ public:
 
   void testRowStateUpdatedWhenWorkspaceRenamed() {
     auto presenter = makePresenter(makeModel());
-    EXPECT_CALL(*m_runsPresenter, notifyRowOutputsChanged(_)).Times(1);
+    EXPECT_CALL(*m_runsPresenter, notifyRowModelChanged(_)).Times(1);
     EXPECT_CALL(*m_runsPresenter, notifyRowStateChanged(_)).Times(1);
     presenter->renameHandle("", "");
     verifyAndClear();
@@ -471,7 +471,7 @@ public:
 
   void testRowStateUpdatedWhenWorkspacesCleared() {
     auto presenter = makePresenter(makeModel());
-    EXPECT_CALL(*m_runsPresenter, notifyRowOutputsChanged()).Times(1);
+    EXPECT_CALL(*m_runsPresenter, notifyRowModelChanged()).Times(1);
     EXPECT_CALL(*m_runsPresenter, notifyRowStateChanged()).Times(1);
     presenter->clearADSHandle();
     verifyAndClear();

--- a/qt/scientific_interfaces/ISISReflectometry/test/ReflMockObjects.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/ReflMockObjects.h
@@ -117,8 +117,8 @@ public:
   MOCK_METHOD0(notifyPauseReductionRequested, void());
   MOCK_METHOD0(notifyRowStateChanged, void());
   MOCK_METHOD1(notifyRowStateChanged, void(boost::optional<Item const &>));
-  MOCK_METHOD0(notifyRowOutputsChanged, void());
-  MOCK_METHOD1(notifyRowOutputsChanged, void(boost::optional<Item const &>));
+  MOCK_METHOD0(notifyRowModelChanged, void());
+  MOCK_METHOD1(notifyRowModelChanged, void(boost::optional<Item const &>));
   MOCK_METHOD0(notifyReductionPaused, void());
   MOCK_METHOD0(notifyReductionResumed, void());
   MOCK_METHOD0(resumeAutoreduction, bool());

--- a/qt/scientific_interfaces/ISISReflectometry/test/Runs/RunsPresenterTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Runs/RunsPresenterTest.h
@@ -664,18 +664,18 @@ public:
     verifyAndClear();
   }
 
-  void testNotifyRowOutputsChanged() {
+  void testNotifyRowModelChanged() {
     auto presenter = makePresenter();
-    EXPECT_CALL(*m_runsTablePresenter, notifyRowOutputsChanged()).Times(1);
-    presenter.notifyRowOutputsChanged();
+    EXPECT_CALL(*m_runsTablePresenter, notifyRowModelChanged()).Times(1);
+    presenter.notifyRowModelChanged();
     verifyAndClear();
   }
 
-  void testNotifyRowOutputsChangedItem() {
+  void testNotifyRowModelChangedItem() {
     auto presenter = makePresenter();
     auto row = makeRow();
-    EXPECT_CALL(*m_runsTablePresenter, notifyRowOutputsChanged(_)).Times(1);
-    presenter.notifyRowOutputsChanged(row);
+    EXPECT_CALL(*m_runsTablePresenter, notifyRowModelChanged(_)).Times(1);
+    presenter.notifyRowModelChanged(row);
     verifyAndClear();
   }
 

--- a/qt/scientific_interfaces/ISISReflectometry/test/RunsTable/MockRunsTablePresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/RunsTable/MockRunsTablePresenter.h
@@ -24,8 +24,8 @@ public:
   MOCK_METHOD0(mutableRunsTable, RunsTable &());
   MOCK_METHOD0(notifyRowStateChanged, void());
   MOCK_METHOD1(notifyRowStateChanged, void(boost::optional<Item const &>));
-  MOCK_METHOD0(notifyRowOutputsChanged, void());
-  MOCK_METHOD1(notifyRowOutputsChanged, void(boost::optional<Item const &>));
+  MOCK_METHOD0(notifyRowModelChanged, void());
+  MOCK_METHOD1(notifyRowModelChanged, void(boost::optional<Item const &>));
   MOCK_METHOD0(notifyRemoveAllRowsAndGroupsRequested, void());
   MOCK_METHOD1(mergeAdditionalJobs, void(ReductionJobs const &));
   MOCK_METHOD0(notifyReductionPaused, void());

--- a/qt/scientific_interfaces/ISISReflectometry/test/RunsTable/RunsTablePresenterDisplayTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/RunsTable/RunsTablePresenterDisplayTest.h
@@ -231,7 +231,8 @@ public:
          MantidQt::MantidWidgets::Batch::Cell("Trans A"), MantidQt::MantidWidgets::Batch::Cell("Trans B"),
          MantidQt::MantidWidgets::Batch::Cell("0.56"), MantidQt::MantidWidgets::Batch::Cell("0.90"),
          MantidQt::MantidWidgets::Batch::Cell("0.01"), MantidQt::MantidWidgets::Batch::Cell(""),
-         MantidQt::MantidWidgets::Batch::Cell(MantidQt::MantidWidgets::optionsToString(ReductionOptionsMap()))});
+         MantidQt::MantidWidgets::Batch::Cell(MantidQt::MantidWidgets::optionsToString(ReductionOptionsMap())),
+         MantidQt::MantidWidgets::Batch::Cell("")});
     EXPECT_CALL(m_jobs, setCellsAt(rowLocation, roundedCells)).Times(1);
     presenter.notifyRowOutputsChanged();
 

--- a/qt/scientific_interfaces/ISISReflectometry/test/RunsTable/RunsTablePresenterDisplayTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/RunsTable/RunsTablePresenterDisplayTest.h
@@ -220,7 +220,7 @@ public:
     verifyAndClearExpectations();
   }
 
-  void testNotifyRowOutputsChangedRounding() {
+  void testNotifyRowModelChangedRounding() {
     auto presenter = makePresenter(m_view, oneGroupWithARowWithInputQRangeModelMixedPrecision());
     auto precision = 2;
     presenter.setTablePrecision(precision);
@@ -234,7 +234,7 @@ public:
          MantidQt::MantidWidgets::Batch::Cell(MantidQt::MantidWidgets::optionsToString(ReductionOptionsMap())),
          MantidQt::MantidWidgets::Batch::Cell("")});
     EXPECT_CALL(m_jobs, setCellsAt(rowLocation, roundedCells)).Times(1);
-    presenter.notifyRowOutputsChanged();
+    presenter.notifyRowModelChanged();
 
     verifyAndClearExpectations();
   }

--- a/qt/scientific_interfaces/ISISReflectometry/test/RunsTable/RunsTablePresenterProcessingTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/RunsTable/RunsTablePresenterProcessingTest.h
@@ -126,8 +126,9 @@ public:
 
   void testSettingsChangedResetsStateInView() {
     auto presenter = makePresenter(m_view, oneGroupWithARowModel());
-    expectGroupStateCleared();
-    expectRowStateCleared();
+    EXPECT_CALL(m_jobs, setCellsAt(RowLocation({0, 0}), rowCells(Colour::DEFAULT))).Times(1);
+    EXPECT_CALL(m_jobs, setCellsAt(RowLocation({0}), rowCells(Colour::DEFAULT))).Times(1);
+    EXPECT_CALL(m_jobs, setCellsAt(RowLocation({0, 0}), rowCellsWithSomeValues())).Times(1);
     presenter.settingsChanged();
     verifyAndClearExpectations();
   }
@@ -247,8 +248,8 @@ public:
 
 private:
   std::vector<Cell> rowCells(const char *colour) {
-    auto cells =
-        std::vector<Cell>{Cell(""), Cell(""), Cell(""), Cell(""), Cell(""), Cell(""), Cell(""), Cell(""), Cell("")};
+    auto cells = std::vector<Cell>{Cell(""), Cell(""), Cell(""), Cell(""), Cell(""),
+                                   Cell(""), Cell(""), Cell(""), Cell(""), Cell("")};
     for (auto &cell : cells)
       cell.setBackgroundColor(colour);
     return cells;
@@ -257,18 +258,23 @@ private:
   std::vector<Cell> rowCellsWithValues(const char *colour) {
     auto cells =
         std::vector<Cell>{Cell("12345"),    Cell("0.500000"), Cell("Trans A"), Cell("Trans B"), Cell("0.500000"),
-                          Cell("0.900000"), Cell("0.010000"), Cell(""),        Cell("")};
+                          Cell("0.900000"), Cell("0.010000"), Cell(""),        Cell(""),        Cell("")};
     for (auto &cell : cells)
       cell.setBackgroundColor(colour);
     return cells;
   }
 
+  std::vector<Cell> rowCellsWithSomeValues() {
+    return std::vector<Cell>{Cell("12345"), Cell("0.500000"), Cell("Trans A"), Cell("Trans B"), Cell(""),
+                             Cell(""),      Cell(""),         Cell(""),        Cell(""),        Cell("")};
+  }
+
   void expectGroupStateCleared() {
-    EXPECT_CALL(m_jobs, setCellsAt(RowLocation({0}), rowCells(Colour::DEFAULT))).Times(1);
+    EXPECT_CALL(m_jobs, setCellsAt(RowLocation({0}), rowCells(Colour::DEFAULT))).Times(AtLeast(1));
   }
 
   void expectRowStateCleared() {
-    EXPECT_CALL(m_jobs, setCellsAt(RowLocation({0, 0}), rowCells(Colour::DEFAULT))).Times(1);
+    EXPECT_CALL(m_jobs, setCellsAt(RowLocation({0, 0}), rowCells(Colour::DEFAULT))).Times(AtLeast(1));
   }
 
   void expectRowStateInvalid() {

--- a/qt/scientific_interfaces/ISISReflectometry/test/RunsTable/RunsTablePresenterProcessingTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/RunsTable/RunsTablePresenterProcessingTest.h
@@ -214,21 +214,21 @@ public:
     verifyAndClearExpectations();
   }
 
-  void testNotifyRowOutputsChangedForInputQRange() {
+  void testNotifyRowModelChangedForInputQRange() {
     auto presenter = makePresenter(m_view, oneGroupWithARowWithInputQRangeModel());
     EXPECT_CALL(m_jobs, setCellsAt(RowLocation({0, 0}), rowCellsWithValues(Colour::DEFAULT))).Times(1);
-    presenter.notifyRowOutputsChanged();
+    presenter.notifyRowModelChanged();
     verifyAndClearExpectations();
   }
 
-  void testNotifyRowOutputsChangedForOutputQRange() {
+  void testNotifyRowModelChangedForOutputQRange() {
     auto presenter = makePresenter(m_view, oneGroupWithARowWithOutputQRangeModel());
     auto cells = rowCellsWithValues(Colour::DEFAULT);
     cells[4].setOutput();
     cells[5].setOutput();
     cells[6].setOutput();
     EXPECT_CALL(m_jobs, setCellsAt(RowLocation({0, 0}), cells)).Times(1);
-    presenter.notifyRowOutputsChanged();
+    presenter.notifyRowModelChanged();
     verifyAndClearExpectations();
   }
 

--- a/qt/scientific_interfaces/ISISReflectometry/test/RunsTable/RunsTablePresenterTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/RunsTable/RunsTablePresenterTest.h
@@ -89,13 +89,13 @@ public:
   }
 
   std::vector<Cell> emptyCellsArray() {
-    return std::vector<MantidQt::MantidWidgets::Batch::Cell>(9, MantidQt::MantidWidgets::Batch::Cell(""));
+    return std::vector<MantidQt::MantidWidgets::Batch::Cell>(10, MantidQt::MantidWidgets::Batch::Cell(""));
   }
 
   std::vector<Cell> cellsArray(std::string const &run = "12345", std::string const &theta = "0.5",
                                std::string const &trans1 = "", std::string const &trans2 = "") {
     return std::vector<Cell>{Cell(run), Cell(theta), Cell(trans1), Cell(trans2), Cell(""),
-                             Cell(""),  Cell(""),    Cell(""),     Cell("")};
+                             Cell(""),  Cell(""),    Cell(""),     Cell(""),     Cell("")};
   }
 
   void expectIsProcessing() {


### PR DESCRIPTION
**Description of work.**

The reflectometry scientists wanted a way to see which of the "per-angle defaults" (probably needs renaming now it takes the title of the group into account too) were used for each of the runs in the runs table. 
This is the final element of that work, adding the functionality to the view so that the user can see what's going on under the hood. 
When the user has a number of rows in the runs table and some matching rows in the experiment lookup table, the user should be able to see which of the rows in the lookup table were used by looking at the final column on the runs table. 

**To test:**

1. Open the reflectometry GUI
2. Open the "Batch" menu and load the `.json` file that appears in the ISIS Sample Data. 
3. Click the arrows next to the loaded groups to open the drop-downs
4. Check the names of the groups and the angles for each of the rows.
5. Expand the GUI, you should see a column called Lookup Index that says "1" for each row (We're using 1 based indexes. I don't like it either, but it's better for the users)
6. Navigate to the Experiment Settings Tab
7. The 1 refers to the single, empty line currently present in the "Per-angle Defaults" table
8. The line being empty in the Angle and Title columns means that this is a Wildcard Row, and will match anything. 
9. Add a row or two to match some of the runs on the runs table. (Note: Matches happen from most to least specific; Matching title & angle -> Matching angle -> wildcard)
10. You'll need to see if the processing is working, so put in values like 0.01, 0.02, etc. into the dQ/Q column. 
11. Navigate back to the runs table
12. The "Lookup Index" column should now contain the index of the row you expect it to match in the experiment settings tab
13. Change group names and angles and check that the lookup index column is updated correctly. 
14. Click process and check that the correct dQ/Q values were taken from the experiment settings tab

Fixes #33626 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
