### PR TITLE
Results table observer for muons

### DIFF
--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/ADSHandler/muon_ADS_observer.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/ADSHandler/muon_ADS_observer.py
@@ -26,9 +26,9 @@ def _catch_exceptions(func):
     return wrapper
 
 
-class MuonContextADSObserver(AnalysisDataServiceObserver):
+class MuonADSObserver(AnalysisDataServiceObserver):
     def __init__(self, delete_callback, clear_callback, replace_callback, delete_group_callback=None):
-        super(MuonContextADSObserver, self).__init__()
+        super(MuonADSObserver, self).__init__()
         self.delete_callback = delete_callback
         self.clear_callback = clear_callback
         self.replace_callback = replace_callback

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/contexts/muon_context.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/contexts/muon_context.py
@@ -537,7 +537,7 @@ class MuonContext(object):
         # required as the renameHandler returns a name instead of a workspace.
         if isinstance(workspace, str):
             workspace_name = workspace
-        if isinstance(workspace, TableWorkspace):
+        elif isinstance(workspace, TableWorkspace):
             # if its a table ws do nothing in the main part of the GUI
             return
         else:

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/contexts/muon_context.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/contexts/muon_context.py
@@ -27,6 +27,7 @@ from mantidqtinterfaces.Muon.GUI.Common.muon_base import MuonRun
 from mantidqtinterfaces.Muon.GUI.Common.muon_pair import MuonPair
 from mantidqtinterfaces.Muon.GUI.Common.muon_diff import MuonDiff
 from typing import List
+from mantid.dataobjects import TableWorkspace
 
 
 class MuonContext(object):
@@ -536,6 +537,9 @@ class MuonContext(object):
         # required as the renameHandler returns a name instead of a workspace.
         if isinstance(workspace, str):
             workspace_name = workspace
+        if isinstance(workspace, TableWorkspace):
+            # if its a table ws do nothing in the main part of the GUI
+            return
         else:
             workspace_name = workspace.name()
 
@@ -543,7 +547,6 @@ class MuonContext(object):
         self.group_pair_context.remove_workspace_by_name(workspace_name)
         self.phase_context.remove_workspace_by_name(workspace_name)
         self.fitting_context.remove_workspace_by_name(workspace_name)
-        self.results_context.remove_workspace_by_name(workspace_name)
         self.update_view_from_model_notifier.notify_subscribers(workspace_name)
         self.deleted_plots_notifier.notify_subscribers(workspace)
 

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/contexts/muon_context.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/contexts/muon_context.py
@@ -20,7 +20,7 @@ import mantidqtinterfaces.Muon.GUI.Common.ADSHandler.workspace_naming as wsName
 from mantidqtinterfaces.Muon.GUI.Common.ADSHandler.ADS_calls import retrieve_ws, delete_ws
 from mantidqtinterfaces.Muon.GUI.Common.ADSHandler.workspace_group_definition import add_to_group
 from mantidqtinterfaces.Muon.GUI.Common.contexts.muon_group_pair_context import get_default_grouping
-from mantidqtinterfaces.Muon.GUI.Common.contexts.muon_context_ADS_observer import MuonContextADSObserver
+from mantidqtinterfaces.Muon.GUI.Common.ADSHandler.muon_ADS_observer import MuonADSObserver
 from mantidqtinterfaces.Muon.GUI.Common.ADSHandler.muon_workspace_wrapper import MuonWorkspaceWrapper
 from mantidqt.utils.observer_pattern import Observable
 from mantidqtinterfaces.Muon.GUI.Common.muon_base import MuonRun
@@ -45,7 +45,7 @@ class MuonContext(object):
         self.base_directory = base_directory
         self.workspace_suffix = workspace_suffix
         self._plot_panes_context = plot_panes_context
-        self.ads_observer = MuonContextADSObserver(
+        self.ads_observer = MuonADSObserver(
             self.remove_workspace,
             self.clear_context,
             self.workspace_replaced)

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/contexts/results_context.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/contexts/results_context.py
@@ -5,12 +5,30 @@
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
 from mantidqtinterfaces.Muon.GUI.Common.ADSHandler.ADS_calls import check_if_workspace_exist
+from mantidqtinterfaces.Muon.GUI.Common.ADSHandler.muon_ADS_observer import MuonADSObserver
+from mantidqt.utils.observer_pattern import GenericObservable
 
 
 class ResultsContext:
 
     def __init__(self):
         self._result_table_names: list = []
+
+        self.ADS_observer = MuonADSObserver(self.remove,
+                                            self.clear,
+                                             self.replaced) # need to add unsubscribe to a close method in the widget
+        self.remove_observable = GenericObservable()
+        self.clear_observable = GenericObservable()
+        self.replace_observable = GenericObservable()
+
+    def remove(self, workspace):
+        self.remove_observable.notify_subscribers(workspace)
+
+    def clear(self):
+        self.clear_observable.notify_subscribers()
+
+    def replaced(self, workspace):
+        self.replace_observable.notify_subscribers(workspace)
 
     @property
     def result_table_names(self) -> list:

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/contexts/results_context.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/contexts/results_context.py
@@ -16,7 +16,7 @@ class ResultsContext:
 
         self.ADS_observer = MuonADSObserver(self.remove,
                                             self.clear,
-                                             self.replaced) # need to add unsubscribe to a close method in the widget
+                                            self.replaced)
         self.remove_observable = GenericObservable()
         self.clear_observable = GenericObservable()
         self.replace_observable = GenericObservable()

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/fitting_widgets/model_fitting/model_fitting_presenter.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/fitting_widgets/model_fitting/model_fitting_presenter.py
@@ -6,7 +6,7 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 from mantidqt.utils.observer_pattern import GenericObservable, GenericObserverWithArgPassing, GenericObserver
 from mantidqtinterfaces.Muon.GUI.Common.ADSHandler.ADS_calls import check_if_workspace_exist
-from mantidqtinterfaces.Muon.GUI.Common.ADSHandler.muon_ADS_observer import MuonADSObserver
+
 from mantidqtinterfaces.Muon.GUI.Common.fitting_widgets.basic_fitting.basic_fitting_presenter import BasicFittingPresenter
 from mantidqtinterfaces.Muon.GUI.Common.fitting_widgets.model_fitting.model_fitting_model import ModelFittingModel
 from mantidqtinterfaces.Muon.GUI.Common.fitting_widgets.model_fitting.model_fitting_view import ModelFittingView
@@ -36,24 +36,30 @@ class ModelFittingPresenter(BasicFittingPresenter):
         self.view.set_slot_for_selected_x_changed(self.handle_selected_x_changed)
         self.view.set_slot_for_selected_y_changed(self.handle_selected_y_changed)
 
-        self.ADS_observer = MuonADSObserver(self.remove,
-                                            self.clear,
-                                             self.replaced) # need to add unsubscribe to a close method in the widget
+        self.clear_observer = GenericObserverWithArgPassing(self.clear)
+        self.remove_observer = GenericObserverWithArgPassing(self.remove)
+        self.replace_observer = GenericObserverWithArgPassing(self.replaced)
 
-    def remove(self, ws):
-        if workspace.name() in self.model.result_table_names:
-            return
-            #names = self.model.result_table_names
-            #names.pop(ws.name())
-            #self.model.result_table_names = names
-            #self.view.update_result_table_names(names)
-            #self.handle_results_table_changed()
+    def remove(self, workspace):
+        if isinstance(workspace, str):
+            workspace_name = workspace
+        else:
+            workspace_name = workspace.name()
+        if workspace_name in self.model.result_table_names:
+            names = self.model.result_table_names
+            names.remove(workspace_name)
+            print("mooo remove", names)
+            self.view.update_result_table_names(names)
+            self.model.result_table_names = names
+            self.handle_results_table_changed()
 
     def clear(self):
+        print("mooo clear")
         self.model.result_table_names = []
         self.view.update_result_table_names([])
 
     def replaced(self, workspace):
+        print("mooo replace")
         if workspace.name() in self.model.result_table_names:
             self.handle_results_table_changed()
 

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/fitting_widgets/model_fitting/model_fitting_presenter.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/fitting_widgets/model_fitting/model_fitting_presenter.py
@@ -6,6 +6,7 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 from mantidqt.utils.observer_pattern import GenericObservable, GenericObserverWithArgPassing, GenericObserver
 from mantidqtinterfaces.Muon.GUI.Common.ADSHandler.ADS_calls import check_if_workspace_exist
+from mantidqtinterfaces.Muon.GUI.Common.ADSHandler.muon_ADS_observer import MuonADSObserver
 from mantidqtinterfaces.Muon.GUI.Common.fitting_widgets.basic_fitting.basic_fitting_presenter import BasicFittingPresenter
 from mantidqtinterfaces.Muon.GUI.Common.fitting_widgets.model_fitting.model_fitting_model import ModelFittingModel
 from mantidqtinterfaces.Muon.GUI.Common.fitting_widgets.model_fitting.model_fitting_view import ModelFittingView
@@ -34,6 +35,27 @@ class ModelFittingPresenter(BasicFittingPresenter):
         self.view.set_slot_for_results_table_changed(self.handle_results_table_changed)
         self.view.set_slot_for_selected_x_changed(self.handle_selected_x_changed)
         self.view.set_slot_for_selected_y_changed(self.handle_selected_y_changed)
+
+        self.ADS_observer = MuonADSObserver(self.remove,
+                                            self.clear,
+                                             self.replaced) # need to add unsubscribe to a close method in the widget
+
+    def remove(self, ws):
+        if workspace.name() in self.model.result_table_names:
+            return
+            #names = self.model.result_table_names
+            #names.pop(ws.name())
+            #self.model.result_table_names = names
+            #self.view.update_result_table_names(names)
+            #self.handle_results_table_changed()
+
+    def clear(self):
+        self.model.result_table_names = []
+        self.view.update_result_table_names([])
+
+    def replaced(self, workspace):
+        if workspace.name() in self.model.result_table_names:
+            self.handle_results_table_changed()
 
     def handle_new_results_table_created(self, new_results_table_name: str) -> None:
         """Handles when a new results table is created and added to the results context."""

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/fitting_widgets/model_fitting/model_fitting_presenter.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/fitting_widgets/model_fitting/model_fitting_presenter.py
@@ -48,18 +48,15 @@ class ModelFittingPresenter(BasicFittingPresenter):
         if workspace_name in self.model.result_table_names:
             names = self.model.result_table_names
             names.remove(workspace_name)
-            print("mooo remove", names)
             self.view.update_result_table_names(names)
             self.model.result_table_names = names
             self.handle_results_table_changed()
 
     def clear(self):
-        print("mooo clear")
         self.model.result_table_names = []
         self.view.update_result_table_names([])
 
     def replaced(self, workspace):
-        print("mooo replace")
         if workspace.name() in self.model.result_table_names:
             self.handle_results_table_changed()
 

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/model_fitting_tab_widget/model_fitting_tab_widget.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/model_fitting_tab_widget/model_fitting_tab_widget.py
@@ -25,3 +25,7 @@ class ModelFittingTabWidget(object):
 
         context.update_view_from_model_notifier.add_subscriber(
             self.model_fitting_tab_presenter.update_view_from_model_observer)
+
+        context.results_context.clear_observable.add_subscriber(self.model_fitting_tab_presenter.clear_observer)
+        context.results_context.remove_observable.add_subscriber(self.model_fitting_tab_presenter.remove_observer)
+        context.results_context.replace_observable.add_subscriber(self.model_fitting_tab_presenter.replace_observer)

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/ElementalAnalysis2/context/context.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/ElementalAnalysis2/context/context.py
@@ -10,7 +10,7 @@ from mantidqtinterfaces.Muon.GUI.Common import thread_model
 from mantid.simpleapi import CloneWorkspace
 from mantidqtinterfaces.Muon.GUI.Common.ADSHandler.ADS_calls import retrieve_ws, remove_ws_if_present
 from mantidqtinterfaces.Muon.GUI.Common.utilities.algorithm_utils import rebin_ws
-from mantidqtinterfaces.Muon.GUI.Common.contexts.muon_context_ADS_observer import MuonContextADSObserver
+from mantidqtinterfaces.Muon.GUI.Common.ADSHandler.muon_ADS_observer import MuonADSObserver
 
 REBINNED_FIXED_WS_SUFFIX = "_EA_Rebinned_Fixed"
 REBINNED_VARIABLE_WS_SUFFIX = "_EA_Rebinned_Variable"
@@ -26,7 +26,7 @@ class ElementalAnalysisContext(object):
         self._group_context = ea_group_context
         self._plot_panes_context = plot_panes_context
         self.workspace_suffix = workspace_suffix
-        self.ads_observer = MuonContextADSObserver(delete_callback=self.remove_workspace,
+        self.ads_observer = MuonADSObserver(delete_callback=self.remove_workspace,
                                                    clear_callback=self.clear_context,
                                                    replace_callback=self.workspace_replaced,
                                                    delete_group_callback=self.remove_workspace)

--- a/qt/python/mantidqtinterfaces/test/Muon/muon_context_test.py
+++ b/qt/python/mantidqtinterfaces/test/Muon/muon_context_test.py
@@ -10,6 +10,9 @@ from collections import Counter
 
 from mantid.api import AnalysisDataService, FileFinder
 from mantid import ConfigService
+
+from mantidqtinterfaces.Muon.GUI.Common.ADSHandler.ADS_calls import retrieve_ws
+from mantidqtinterfaces.Muon.GUI.Common.utilities.algorithm_utils import create_empty_table, run_create_workspace
 from mantidqt.utils.qt.testing import start_qapplication
 from mantidqtinterfaces.Muon.GUI.Common.calculate_pair_and_group import run_pre_processing
 from mantidqtinterfaces.Muon.GUI.Common.utilities.load_utils import load_workspace_from_filename
@@ -660,6 +663,63 @@ class MuonContextTest(unittest.TestCase):
     def test_do_grouping(self, group_mock):
         self.context.do_grouping()
         group_mock.assert_called_once_with(self.data_context.instrument, self.context.workspace_suffix)
+
+    def test_remove_workspace_str(self):
+        self.context.data_context.remove_workspace_by_name = mock.Mock()
+        self.context.group_pair_context.remove_workspace_by_name = mock.Mock()
+        self.context.phase_context.remove_workspace_by_name = mock.Mock()
+        self.context.fitting_context.remove_workspace_by_name = mock.Mock()
+        self.context.update_view_from_model_notifier.notify_subscribers = mock.Mock()
+        self.context.deleted_plots_notifier.notify_subscribers = mock.Mock()
+        name = "test"
+
+        self.context.remove_workspace(name)
+
+        self.context.data_context.remove_workspace_by_name.assert_called_once_with(name)
+        self.context.group_pair_context.remove_workspace_by_name.assert_called_once_with(name)
+        self.context.phase_context.remove_workspace_by_name.assert_called_once_with(name)
+        self.context.fitting_context.remove_workspace_by_name.assert_called_once_with(name)
+        self.context.update_view_from_model_notifier.notify_subscribers.assert_called_once_with(name)
+        self.context.deleted_plots_notifier.notify_subscribers.assert_called_once_with(name)
+
+    def test_remove_workspace_ws(self):
+        self.context.data_context.remove_workspace_by_name = mock.Mock()
+        self.context.group_pair_context.remove_workspace_by_name = mock.Mock()
+        self.context.phase_context.remove_workspace_by_name = mock.Mock()
+        self.context.fitting_context.remove_workspace_by_name = mock.Mock()
+        self.context.update_view_from_model_notifier.notify_subscribers = mock.Mock()
+        self.context.deleted_plots_notifier.notify_subscribers = mock.Mock()
+
+        name = run_create_workspace([0,1], [0,1], "test")
+        ws = retrieve_ws("test")
+
+        self.context.remove_workspace(ws)
+
+        self.context.data_context.remove_workspace_by_name.assert_called_once_with(name)
+        self.context.group_pair_context.remove_workspace_by_name.assert_called_once_with(name)
+        self.context.phase_context.remove_workspace_by_name.assert_called_once_with(name)
+        self.context.fitting_context.remove_workspace_by_name.assert_called_once_with(name)
+        self.context.update_view_from_model_notifier.notify_subscribers.assert_called_once_with(name)
+        self.context.deleted_plots_notifier.notify_subscribers.assert_called_once_with(ws)
+
+    def test_remove_workspace_table(self):
+        self.context.data_context.remove_workspace_by_name = mock.Mock()
+        self.context.group_pair_context.remove_workspace_by_name = mock.Mock()
+        self.context.phase_context.remove_workspace_by_name = mock.Mock()
+        self.context.fitting_context.remove_workspace_by_name = mock.Mock()
+        self.context.update_view_from_model_notifier.notify_subscribers = mock.Mock()
+        self.context.deleted_plots_notifier.notify_subscribers = mock.Mock()
+
+        ws = create_empty_table("test")
+
+        self.context.remove_workspace(ws)
+
+        self.context.data_context.remove_workspace_by_name.assert_not_called()
+        self.context.group_pair_context.remove_workspace_by_name.assert_not_called()
+        self.context.phase_context.remove_workspace_by_name.assert_not_called()
+        self.context.fitting_context.remove_workspace_by_name.assert_not_called()
+        self.context.update_view_from_model_notifier.notify_subscribers.assert_not_called()
+        self.context.deleted_plots_notifier.notify_subscribers.assert_not_called()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
**Description of work.**

**Merge after https://github.com/mantidproject/mantid/pull/33743**

Users wanted to be able to change the values in a results table and for the values to automatically be updated in the GUI. 

**To test:**

<!-- Instructions for testing. -->
Before opening Mantid turn on the model analysis and plotting (option 2) feature flag as described in https://github.com/mantidproject/mantid/pull/33712

Open mantid
Open muon analysis
Load MUSR 62260
Go to the fitting tab and add a function (doesnt matter which)
Go to sequential fitting tab and press fit all
Go to the results table tab
Select run number in the top table, then click the "output results" button 
Change the table name to "run" and press "output results"
Change the table name to "new" and press "output results"
Go to the model fitting tab
Notice that the plot is just bunch of markers in a vertical line
Open the "new" table from the ADS
Change one of the run numbers to 62249
Notice that the plot updates
Deleting "run" from the ADS will update the results table combo box so it will only contain "new" and "ResultsTable"


Fixes #33763. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

There is no release note for this as it is part of the new "model analysis" 

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
