### PR TITLE
Make Indirect Moments MVP friendly

### DIFF
--- a/qt/scientific_interfaces/Indirect/CMakeLists.txt
+++ b/qt/scientific_interfaces/Indirect/CMakeLists.txt
@@ -67,6 +67,7 @@ set(SRC_FILES
     IndirectLoadILL.cpp
     IndirectMolDyn.cpp
     IndirectMoments.cpp
+    IndirectMomentsModel.cpp
     IndirectPlotOptionsModel.cpp
     IndirectPlotOptionsPresenter.cpp
     IndirectPlotOptionsView.cpp
@@ -147,6 +148,7 @@ set(MOC_FILES
     IndirectLoadILL.h
     IndirectMolDyn.h
     IndirectMoments.h
+    IndirectMomentsModel.h
     IndirectPlotOptionsPresenter.h
     IndirectPlotOptionsView.h
     IndirectSassena.h

--- a/qt/scientific_interfaces/Indirect/CMakeLists.txt
+++ b/qt/scientific_interfaces/Indirect/CMakeLists.txt
@@ -68,6 +68,7 @@ set(SRC_FILES
     IndirectMolDyn.cpp
     IndirectMoments.cpp
     IndirectMomentsModel.cpp
+    IndirectMomentsView.cpp
     IndirectPlotOptionsModel.cpp
     IndirectPlotOptionsPresenter.cpp
     IndirectPlotOptionsView.cpp
@@ -149,6 +150,7 @@ set(MOC_FILES
     IndirectMolDyn.h
     IndirectMoments.h
     IndirectMomentsModel.h
+    IndirectMomentsView.h
     IndirectPlotOptionsPresenter.h
     IndirectPlotOptionsView.h
     IndirectSassena.h

--- a/qt/scientific_interfaces/Indirect/IndirectMoments.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectMoments.cpp
@@ -28,8 +28,6 @@ IndirectMoments::IndirectMoments(IndirectDataReduction *idrUI, QWidget *parent)
   setOutputPlotOptionsPresenter(
       std::make_unique<IndirectPlotOptionsPresenter>(m_view->getPlotOptions(), PlotWidget::Spectra, "0,2,4"));
 
-  const unsigned int NUM_DECIMALS = 6;
-
   m_view->setupProperties();
 
   connect(m_view.get(), SIGNAL(dataReady(QString const &)), this, SLOT(handleDataReady(const QString &)));

--- a/qt/scientific_interfaces/Indirect/IndirectMoments.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectMoments.cpp
@@ -32,7 +32,7 @@ IndirectMoments::IndirectMoments(IndirectDataReduction *idrUI, QWidget *parent)
 
   connect(m_view.get(), SIGNAL(dataReady(QString const &)), this, SLOT(handleDataReady(const QString &)));
   connect(m_view.get(), SIGNAL(valueChanged(QtProperty *, double)), this, SLOT(updateProperties(QtProperty *, double)));
-  connect(m_view.get(), SIGNAL(scaleChanged(bool)), this, SLOT(handleScaleChanged(bool)));
+  connect(m_view.get(), SIGNAL(scaleChanged(int)), this, SLOT(handleScaleChanged(int)));
   connect(m_view.get(), SIGNAL(scaleValueChanged(double)), this, SLOT(handleScaleValueChanged(double)));
   connect(m_view.get(), SIGNAL(runClicked()), this, SLOT(runClicked()));
   connect(m_view.get(), SIGNAL(saveClicked()), this, SLOT(saveClicked()));
@@ -62,7 +62,7 @@ void IndirectMoments::handleDataReady(QString const &dataName) {
 /**
  * Handles the scale checkbox being changed.
  */
-void IndirectMoments::handleScaleChanged(bool scale) { m_model->setScale(scale); }
+void IndirectMoments::handleScaleChanged(int state) { m_model->setScale(state == Qt::Checked); }
 
 /**
  * Handles the scale value being changed.

--- a/qt/scientific_interfaces/Indirect/IndirectMoments.h
+++ b/qt/scientific_interfaces/Indirect/IndirectMoments.h
@@ -46,7 +46,7 @@ protected slots:
 
 private slots:
   void handleDataReady(QString const &dataName) override;
-  void handleScaleChanged(bool scale);
+  void handleScaleChanged(int state);
   void handleScaleValueChanged(double value);
 
 private:

--- a/qt/scientific_interfaces/Indirect/IndirectMoments.h
+++ b/qt/scientific_interfaces/Indirect/IndirectMoments.h
@@ -8,6 +8,7 @@
 
 #include "IndirectDataReductionTab.h"
 #include "IndirectMomentsModel.h"
+#include "IndirectMomentsView.h"
 
 #include "MantidKernel/System.h"
 #include "ui_IndirectMoments.h"
@@ -28,15 +29,13 @@ class DLLExport IndirectMoments : public IndirectDataReductionTab {
 
 public:
   IndirectMoments(IndirectDataReduction *idrUI, QWidget *parent = nullptr);
-  ~IndirectMoments() override;
+  ~IndirectMoments() = default;
 
   void setup() override;
   void run() override;
   bool validate() override;
 
 protected slots:
-  /// Slot for when the range selector changes
-  void rangeChanged(double min, double max);
   /// Slot to update the guides when the range properties change
   void updateProperties(QtProperty *prop, double val);
   /// Called when the algorithm completes to update preview plot
@@ -44,11 +43,6 @@ protected slots:
   /// Slots for plot and save
   void runClicked();
   void saveClicked();
-
-  void setRunEnabled(bool enabled);
-  void setSaveEnabled(bool enabled);
-  void updateRunButton(bool enabled = true, std::string const &enableOutputButtons = "unchanged",
-                       QString const &message = "Run", QString const &tooltip = "");
 
 private slots:
   void handleDataReady(QString const &dataName) override;
@@ -58,9 +52,9 @@ private slots:
 private:
   void plotNewData(QString const &filename);
   void setFileExtensionsByName(bool filter) override;
-
   Ui::IndirectMoments m_uiForm;
-  IndirectMomentsModel m_model;
+  std::unique_ptr<IndirectMomentsModel> m_model;
+  std::unique_ptr<IndirectMomentsView> m_view;
 };
 } // namespace CustomInterfaces
 } // namespace MantidQt

--- a/qt/scientific_interfaces/Indirect/IndirectMoments.h
+++ b/qt/scientific_interfaces/Indirect/IndirectMoments.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include "IndirectDataReductionTab.h"
+#include "IndirectMomentsModel.h"
 
 #include "MantidKernel/System.h"
 #include "ui_IndirectMoments.h"
@@ -51,12 +52,15 @@ protected slots:
 
 private slots:
   void handleDataReady(QString const &dataName) override;
+  void handleScaleChanged(bool scale);
+  void handleScaleValueChanged(double value);
 
 private:
   void plotNewData(QString const &filename);
   void setFileExtensionsByName(bool filter) override;
 
   Ui::IndirectMoments m_uiForm;
+  IndirectMomentsModel m_model;
 };
 } // namespace CustomInterfaces
 } // namespace MantidQt

--- a/qt/scientific_interfaces/Indirect/IndirectMomentsModel.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectMomentsModel.cpp
@@ -23,7 +23,7 @@ namespace MantidQt::CustomInterfaces {
 //----------------------------------------------------------------------------------------------
 /** Constructor
  */
-IndirectMomentsModel::IndirectMomentsModel() {}
+IndirectMomentsModel::IndirectMomentsModel() { m_scale = false; }
 
 IAlgorithm_sptr IndirectMomentsModel::setupAlgorithm() {
   IAlgorithm_sptr momentsAlg = AlgorithmManager::Instance().create("SofQWMoments", -1);
@@ -33,8 +33,11 @@ IAlgorithm_sptr IndirectMomentsModel::setupAlgorithm() {
   momentsAlg->setProperty("EnergyMax", m_eMax);
   momentsAlg->setProperty("OutputWorkspace", m_outputWorkspaceName);
 
-  if (m_scale)
+  if (m_scale) {
     momentsAlg->setProperty("Scale", m_scaleValue);
+  } else {
+    momentsAlg->setProperty("Scale", 1.0);
+  }
 
   return momentsAlg;
 }

--- a/qt/scientific_interfaces/Indirect/IndirectMomentsModel.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectMomentsModel.cpp
@@ -39,7 +39,7 @@ IAlgorithm_sptr IndirectMomentsModel::setupAlgorithm() {
   return momentsAlg;
 }
 
-void IndirectMomentsModel::setInputWorkspace(std::string workspace) {
+void IndirectMomentsModel::setInputWorkspace(const std::string &workspace) {
   m_inputWorkspace = workspace;
   m_outputWorkspaceName = m_inputWorkspace.substr(0, m_inputWorkspace.length() - 4) + "_Moments";
 }

--- a/qt/scientific_interfaces/Indirect/IndirectMomentsModel.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectMomentsModel.cpp
@@ -1,6 +1,6 @@
 // Mantid Repository : https://github.com/mantidproject/mantid
 //
-// Copyright &copy; 2018 ISIS Rutherford Appleton Laboratory UKRI,
+// Copyright &copy; 2022 ISIS Rutherford Appleton Laboratory UKRI,
 //   NScD Oak Ridge National Laboratory, European Spallation Source,
 //   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 // SPDX - License - Identifier: GPL - 3.0 +
@@ -53,5 +53,7 @@ void IndirectMomentsModel::setScale(bool scale) { m_scale = scale; }
 void IndirectMomentsModel::setScaleValue(double scaleValue) { m_scaleValue = scaleValue; }
 
 std::string IndirectMomentsModel::getOutputWorkspace() { return m_outputWorkspaceName; }
+
+QMap<QString, QtProperty *> IndirectMomentsModel::getProperties() { return m_properties; }
 
 } // namespace MantidQt::CustomInterfaces

--- a/qt/scientific_interfaces/Indirect/IndirectMomentsModel.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectMomentsModel.cpp
@@ -54,6 +54,4 @@ void IndirectMomentsModel::setScaleValue(double scaleValue) { m_scaleValue = sca
 
 std::string IndirectMomentsModel::getOutputWorkspace() { return m_outputWorkspaceName; }
 
-QMap<QString, QtProperty *> IndirectMomentsModel::getProperties() { return m_properties; }
-
 } // namespace MantidQt::CustomInterfaces

--- a/qt/scientific_interfaces/Indirect/IndirectMomentsModel.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectMomentsModel.cpp
@@ -1,0 +1,57 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2018 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#include "IndirectMomentsModel.h"
+#include "IndirectDataValidationHelper.h"
+
+#include "MantidAPI/AlgorithmManager.h"
+#include "MantidAPI/MatrixWorkspace.h"
+#include "MantidAPI/WorkspaceGroup.h"
+#include "MantidQtWidgets/Common/UserInputValidator.h"
+
+#include <QDoubleValidator>
+#include <QFileInfo>
+
+using namespace IndirectDataValidationHelper;
+using namespace Mantid::API;
+
+namespace MantidQt::CustomInterfaces {
+
+//----------------------------------------------------------------------------------------------
+/** Constructor
+ */
+IndirectMomentsModel::IndirectMomentsModel() {}
+
+IAlgorithm_sptr IndirectMomentsModel::setupAlgorithm() {
+  IAlgorithm_sptr momentsAlg = AlgorithmManager::Instance().create("SofQWMoments", -1);
+  momentsAlg->initialize();
+  momentsAlg->setProperty("InputWorkspace", m_inputWorkspace);
+  momentsAlg->setProperty("EnergyMin", m_eMin);
+  momentsAlg->setProperty("EnergyMax", m_eMax);
+  momentsAlg->setProperty("OutputWorkspace", m_outputWorkspaceName);
+
+  if (m_scale)
+    momentsAlg->setProperty("Scale", m_scaleValue);
+
+  return momentsAlg;
+}
+
+void IndirectMomentsModel::setInputWorkspace(std::string workspace) {
+  m_inputWorkspace = workspace;
+  m_outputWorkspaceName = m_inputWorkspace.substr(0, m_inputWorkspace.length() - 4) + "_Moments";
+}
+
+void IndirectMomentsModel::setEMin(double eMin) { m_eMin = eMin; }
+
+void IndirectMomentsModel::setEMax(double eMax) { m_eMax = eMax; }
+
+void IndirectMomentsModel::setScale(bool scale) { m_scale = scale; }
+
+void IndirectMomentsModel::setScaleValue(double scaleValue) { m_scaleValue = scaleValue; }
+
+std::string IndirectMomentsModel::getOutputWorkspace() { return m_outputWorkspaceName; }
+
+} // namespace MantidQt::CustomInterfaces

--- a/qt/scientific_interfaces/Indirect/IndirectMomentsModel.h
+++ b/qt/scientific_interfaces/Indirect/IndirectMomentsModel.h
@@ -22,7 +22,7 @@ public:
   IndirectMomentsModel();
   ~IndirectMomentsModel() = default;
   IAlgorithm_sptr setupAlgorithm();
-  void setInputWorkspace(std::string workspace);
+  void setInputWorkspace(const std::string &workspace);
   void setEMin(double eMin);
   void setEMax(double eMax);
   void setScale(bool scale);

--- a/qt/scientific_interfaces/Indirect/IndirectMomentsModel.h
+++ b/qt/scientific_interfaces/Indirect/IndirectMomentsModel.h
@@ -1,0 +1,40 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2013 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#pragma once
+
+#include "DllConfig.h"
+#include "IndirectDataValidationHelper.h"
+#include <typeinfo>
+
+using namespace Mantid::API;
+
+namespace MantidQt {
+namespace CustomInterfaces {
+
+class MANTIDQT_INDIRECT_DLL IndirectMomentsModel {
+
+public:
+  IndirectMomentsModel();
+  ~IndirectMomentsModel() = default;
+  IAlgorithm_sptr setupAlgorithm();
+  void setInputWorkspace(std::string workspace);
+  void setEMin(double eMin);
+  void setEMax(double eMax);
+  void setScale(bool scale);
+  void setScaleValue(double scaleValue);
+  std::string getOutputWorkspace();
+
+private:
+  std::string m_inputWorkspace;
+  std::string m_outputWorkspaceName;
+  double m_eMin;
+  double m_eMax;
+  double m_scaleValue;
+  bool m_scale;
+};
+} // namespace CustomInterfaces
+} // namespace MantidQt

--- a/qt/scientific_interfaces/Indirect/IndirectMomentsModel.h
+++ b/qt/scientific_interfaces/Indirect/IndirectMomentsModel.h
@@ -28,12 +28,10 @@ public:
   void setScale(bool scale);
   void setScaleValue(double scaleValue);
   std::string getOutputWorkspace();
-  QMap<QString, QtProperty *> getProperties();
 
 private:
   std::string m_inputWorkspace;
   std::string m_outputWorkspaceName;
-  QMap<QString, QtProperty *> m_properties;
   double m_eMin;
   double m_eMax;
   double m_scaleValue;

--- a/qt/scientific_interfaces/Indirect/IndirectMomentsModel.h
+++ b/qt/scientific_interfaces/Indirect/IndirectMomentsModel.h
@@ -1,6 +1,6 @@
 // Mantid Repository : https://github.com/mantidproject/mantid
 //
-// Copyright &copy; 2013 ISIS Rutherford Appleton Laboratory UKRI,
+// Copyright &copy; 2022 ISIS Rutherford Appleton Laboratory UKRI,
 //   NScD Oak Ridge National Laboratory, European Spallation Source,
 //   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 // SPDX - License - Identifier: GPL - 3.0 +
@@ -8,6 +8,7 @@
 
 #include "DllConfig.h"
 #include "IndirectDataValidationHelper.h"
+#include "MantidQtWidgets/Common/QtPropertyBrowser/QtTreePropertyBrowser"
 #include <typeinfo>
 
 using namespace Mantid::API;
@@ -27,10 +28,12 @@ public:
   void setScale(bool scale);
   void setScaleValue(double scaleValue);
   std::string getOutputWorkspace();
+  QMap<QString, QtProperty *> getProperties();
 
 private:
   std::string m_inputWorkspace;
   std::string m_outputWorkspaceName;
+  QMap<QString, QtProperty *> m_properties;
   double m_eMin;
   double m_eMax;
   double m_scaleValue;

--- a/qt/scientific_interfaces/Indirect/IndirectMomentsView.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectMomentsView.cpp
@@ -35,7 +35,7 @@ IndirectMomentsView::IndirectMomentsView(QWidget *parent) {
   connect(xRangeSelector, SIGNAL(selectionChanged(double, double)), this, SLOT(rangeChanged(double, double)));
 
   connect(m_uiForm.dsInput, SIGNAL(dataReady(QString const &)), this, SIGNAL(dataReady(const QString &)));
-  connect(m_uiForm.ckScale, SIGNAL(stateChanged(bool)), this, SIGNAL(scaleChanged(bool)));
+  connect(m_uiForm.ckScale, SIGNAL(stateChanged(int)), this, SIGNAL(scaleChanged(int)));
   connect(m_uiForm.spScale, SIGNAL(valueChanged(double)), this, SIGNAL(scaleValueChanged(double)));
   connect(m_uiForm.pbRun, SIGNAL(clicked()), this, SIGNAL(runClicked()));
   connect(m_uiForm.pbSave, SIGNAL(clicked()), this, SIGNAL(saveClicked()));

--- a/qt/scientific_interfaces/Indirect/IndirectMomentsView.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectMomentsView.cpp
@@ -1,0 +1,225 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2022 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#include "IndirectMomentsView.h"
+#include "IndirectDataValidationHelper.h"
+
+#include "MantidAPI/AlgorithmManager.h"
+#include "MantidAPI/MatrixWorkspace.h"
+#include "MantidAPI/WorkspaceGroup.h"
+#include "MantidQtWidgets/Common/UserInputValidator.h"
+
+#include <QDoubleValidator>
+#include <QFileInfo>
+
+using namespace IndirectDataValidationHelper;
+using namespace Mantid::API;
+
+namespace MantidQt::CustomInterfaces {
+
+//----------------------------------------------------------------------------------------------
+/** Constructor
+ */
+IndirectMomentsView::IndirectMomentsView(QWidget *parent) {
+  m_uiForm.setupUi(parent);
+  m_dblManager = new QtDoublePropertyManager();
+  m_dblEdFac = new DoubleEditorFactory(this);
+
+  m_uiForm.ppRawPlot->setCanvasColour(QColor(240, 240, 240));
+  m_uiForm.ppMomentsPreview->setCanvasColour(QColor(240, 240, 240));
+
+  MantidWidgets::RangeSelector *xRangeSelector = m_uiForm.ppRawPlot->addRangeSelector("XRange");
+  connect(xRangeSelector, SIGNAL(selectionChanged(double, double)), this, SLOT(rangeChanged(double, double)));
+
+  connect(m_uiForm.dsInput, SIGNAL(dataReady(QString const &)), this, SIGNAL(dataReady(const QString &)));
+  connect(m_uiForm.ckScale, SIGNAL(stateChanged(bool)), this, SIGNAL(scaleChanged(bool)));
+  connect(m_uiForm.spScale, SIGNAL(valueChanged(double)), this, SIGNAL(scaleValueChanged(double)));
+  connect(m_uiForm.pbRun, SIGNAL(clicked()), this, SIGNAL(runClicked()));
+  connect(m_uiForm.pbSave, SIGNAL(clicked()), this, SIGNAL(saveClicked()));
+
+  connect(m_dblManager, SIGNAL(valueChanged(QtProperty *, double)), this, SIGNAL(valueChanged(QtProperty *, double)));
+
+  // Allows empty workspace selector when initially selected
+  m_uiForm.dsInput->isOptional(true);
+
+  // Disables searching for run files in the data archive
+  m_uiForm.dsInput->isForRunFiles(false);
+}
+
+//----------------------------------------------------------------------------------------------
+/** Destructor
+ */
+IndirectMomentsView::~IndirectMomentsView() { m_propTrees["MomentsPropTree"]->unsetFactoryForManager(m_dblManager); }
+
+/**
+ * Updates the property manager when the range selector is moved.
+ *
+ * @param min :: The new value of the lower guide
+ * @param max :: The new value of the upper guide
+ */
+void IndirectMomentsView::rangeChanged(double min, double max) {
+  m_dblManager->setValue(m_properties["EMin"], min);
+  m_dblManager->setValue(m_properties["EMax"], max);
+}
+
+void IndirectMomentsView::setupProperties() {
+
+  const unsigned int NUM_DECIMALS = 6;
+  // PROPERTY TREE
+  m_propTrees["MomentsPropTree"] = new QtTreePropertyBrowser();
+  m_propTrees["MomentsPropTree"]->setFactoryForManager(m_dblManager, m_dblEdFac);
+  m_uiForm.properties->addWidget(m_propTrees["MomentsPropTree"]);
+  m_properties["EMin"] = m_dblManager->addProperty("EMin");
+  m_propTrees["MomentsPropTree"]->addProperty(m_properties["EMin"]);
+  m_dblManager->setDecimals(m_properties["EMin"], NUM_DECIMALS);
+
+  m_properties["EMax"] = m_dblManager->addProperty("EMax");
+  m_propTrees["MomentsPropTree"]->addProperty(m_properties["EMax"]);
+  m_dblManager->setDecimals(m_properties["EMax"], NUM_DECIMALS);
+}
+
+IndirectPlotOptionsView *IndirectMomentsView::getPlotOptions() { return m_uiForm.ipoPlotOptions; }
+
+std::string IndirectMomentsView::getDataName() { return m_uiForm.dsInput->getCurrentDataName().toStdString(); }
+
+bool IndirectMomentsView::validate() {
+  UserInputValidator uiv;
+  validateDataIsOfType(uiv, m_uiForm.dsInput, "Sample", DataType::Sqw);
+
+  auto const errorMessage = uiv.generateErrorMessage();
+  if (!errorMessage.isEmpty())
+    showMessageBox(errorMessage);
+  return errorMessage.isEmpty();
+}
+
+/**
+ * Clears previous plot data (in both preview and raw plot) and sets the new
+ * range bars
+ */
+void IndirectMomentsView::plotNewData(QString const &filename) {
+  disconnect(m_dblManager, SIGNAL(valueChanged(QtProperty *, double)), this,
+             SLOT(updateProperties(QtProperty *, double)));
+  // Clears previous plotted data
+  m_uiForm.ppRawPlot->clear();
+  m_uiForm.ppMomentsPreview->clear();
+
+  // Update plot and change data in interface
+  m_uiForm.ppRawPlot->addSpectrum("Raw", filename, 0);
+
+  connect(m_dblManager, SIGNAL(valueChanged(QtProperty *, double)), this, SLOT(updateProperties(QtProperty *, double)));
+}
+
+/**
+ * Sets the edge bounds of plot to prevent the user inputting invalid values
+ * Also sets limits for range selector movement
+ *
+ * @param min :: The lower bound property in the property browser
+ * @param max :: The upper bound property in the property browser
+ * @param bounds :: The upper and lower bounds to be set
+ */
+void IndirectMomentsView::setPlotPropertyRange(const QPair<double, double> &bounds) {
+  disconnect(m_dblManager, SIGNAL(valueChanged(QtProperty *, double)), this,
+             SLOT(updateProperties(QtProperty *, double)));
+  m_dblManager->setMinimum(m_properties["EMin"], bounds.first);
+  m_dblManager->setMaximum(m_properties["EMin"], bounds.second);
+  m_dblManager->setMinimum(m_properties["EMax"], bounds.first);
+  m_dblManager->setMaximum(m_properties["EMax"], bounds.second);
+  auto xRangeSelector = m_uiForm.ppRawPlot->getRangeSelector("XRange");
+  xRangeSelector->setBounds(bounds.first, bounds.second);
+  connect(m_dblManager, SIGNAL(valueChanged(QtProperty *, double)), this, SLOT(updateProperties(QtProperty *, double)));
+}
+
+/**
+ * Set the position of the range selectors on the mini plot
+ *
+ * @param lower :: The lower bound property in the property browser
+ * @param upper :: The upper bound property in the property browser
+ * @param bounds :: The upper and lower bounds to be set
+ * @param range :: The range to set the range selector to.
+ */
+void IndirectMomentsView::setRangeSelector(const QPair<double, double> &bounds,
+                                           const boost::optional<QPair<double, double>> &range) {
+  disconnect(m_dblManager, SIGNAL(valueChanged(QtProperty *, double)), this,
+             SLOT(updateProperties(QtProperty *, double)));
+  m_dblManager->setValue(m_properties["EMin"], bounds.first);
+  m_dblManager->setValue(m_properties["EMax"], bounds.second);
+  auto xRangeSelector = m_uiForm.ppRawPlot->getRangeSelector("XRange");
+  if (range) {
+    xRangeSelector->setMinimum(range.get().first);
+    xRangeSelector->setMaximum(range.get().second);
+    // clamp the bounds of the selector
+    xRangeSelector->setRange(range.get().first, range.get().second);
+  } else {
+    xRangeSelector->setMinimum(bounds.first);
+    xRangeSelector->setMaximum(bounds.second);
+  }
+  connect(m_dblManager, SIGNAL(valueChanged(QtProperty *, double)), this, SLOT(updateProperties(QtProperty *, double)));
+}
+
+/**
+ * Set the minimum of a range selector if it is less than the maximum value.
+ * To be used when changing the min or max via the Property table
+ *
+ * @param minProperty :: The property managing the minimum of the range
+ * @param maxProperty :: The property managing the maximum of the range
+ * @param rangeSelector :: The range selector
+ * @param newValue :: The new value for the minimum
+ */
+void IndirectMomentsView::setRangeSelectorMin(double newValue) {
+  if (newValue <= m_properties["EMax"]->valueText().toDouble())
+    getRangeSelector()->setMinimum(newValue);
+  else
+    m_dblManager->setValue(m_properties["EMin"], getRangeSelector()->getMinimum());
+}
+
+/**
+ * Set the maximum of a range selector if it is greater than the minimum value
+ * To be used when changing the min or max via the Property table
+ *
+ * @param minProperty :: The property managing the minimum of the range
+ * @param maxProperty :: The property managing the maximum of the range
+ * @param rangeSelector :: The range selector
+ * @param newValue :: The new value for the maximum
+ */
+void IndirectMomentsView::setRangeSelectorMax(double newValue) {
+  if (newValue >= m_properties["EMin"]->valueText().toDouble())
+    getRangeSelector()->setMaximum(newValue);
+  else
+    m_dblManager->setValue(m_properties["EMax"], getRangeSelector()->getMaximum());
+}
+
+void IndirectMomentsView::replot() { m_uiForm.ppRawPlot->replot(); }
+
+MantidWidgets::RangeSelector *IndirectMomentsView::getRangeSelector() {
+  return m_uiForm.ppRawPlot->getRangeSelector("XRange");
+}
+
+void IndirectMomentsView::plotOutput(QString outputWorkspace) {
+  // Plot each spectrum
+  m_uiForm.ppMomentsPreview->clear();
+  m_uiForm.ppMomentsPreview->addSpectrum("M0", outputWorkspace, 0, Qt::green);
+  m_uiForm.ppMomentsPreview->addSpectrum("M1", outputWorkspace, 1, Qt::black);
+  m_uiForm.ppMomentsPreview->addSpectrum("M2", outputWorkspace, 2, Qt::red);
+  m_uiForm.ppMomentsPreview->resizeX();
+
+  // Enable plot and save buttons
+  m_uiForm.pbSave->setEnabled(true);
+}
+
+void IndirectMomentsView::setFBSuffixes(QStringList const suffix) { m_uiForm.dsInput->setFBSuffixes(suffix); }
+
+void IndirectMomentsView::setWSSuffixes(QStringList const suffix) { m_uiForm.dsInput->setWSSuffixes(suffix); }
+
+void IndirectMomentsView::updateRunButton(bool enabled, std::string const &enableOutputButtons, QString const &message,
+                                          QString const &tooltip) {
+  m_uiForm.pbRun->setEnabled(enabled);
+  m_uiForm.pbRun->setText(message);
+  m_uiForm.pbRun->setToolTip(tooltip);
+  if (enableOutputButtons != "unchanged")
+    m_uiForm.pbSave->setEnabled(enabled);
+}
+
+} // namespace MantidQt::CustomInterfaces

--- a/qt/scientific_interfaces/Indirect/IndirectMomentsView.h
+++ b/qt/scientific_interfaces/Indirect/IndirectMomentsView.h
@@ -1,0 +1,70 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2022 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#pragma once
+
+#include "MantidQtWidgets/Common/QtPropertyBrowser/DoubleEditorFactory.h"
+#include "MantidQtWidgets/Common/QtPropertyBrowser/QtTreePropertyBrowser"
+#include "MantidQtWidgets/Common/QtPropertyBrowser/qtpropertymanager.h"
+#include "MantidQtWidgets/Plotting/RangeSelector.h"
+#include "ui_IndirectMoments.h"
+
+namespace MantidQt {
+namespace CustomInterfaces {
+
+class MANTIDQT_INDIRECT_DLL IndirectMomentsView : public QWidget {
+  Q_OBJECT
+
+public:
+  IndirectMomentsView(QWidget *perent = nullptr);
+  ~IndirectMomentsView();
+
+  void setupProperties();
+  IndirectPlotOptionsView *getPlotOptions();
+  std::string getDataName();
+  bool validate();
+  void plotNewData(QString const &filename);
+  /// Function to set the range limits of the plot
+  void setPlotPropertyRange(const QPair<double, double> &bounds);
+  /// Function to set the range selector on the mini plot
+  void setRangeSelector(const QPair<double, double> &bounds,
+                        const boost::optional<QPair<double, double>> &range = boost::none);
+  /// Sets the min of the range selector if it is less than the max
+  void setRangeSelectorMin(double newValue);
+  /// Sets the max of the range selector if it is more than the min
+  void setRangeSelectorMax(double newValue);
+  void replot();
+  void plotOutput(QString outputWorkspace);
+  void setFBSuffixes(QStringList const suffix);
+  void setWSSuffixes(QStringList const suffix);
+
+signals:
+  void valueChanged(QtProperty *, double);
+  void dataReady(QString const &);
+  void scaleChanged(bool);
+  void scaleValueChanged(double);
+  void runClicked();
+  void saveClicked();
+  void showMessageBox(const QString &message);
+
+public slots:
+  void rangeChanged(double min, double max);
+  void updateRunButton(bool enabled, std::string const &enableOutputButtons, QString const &message,
+                       QString const &tooltip);
+
+private:
+  MantidWidgets::RangeSelector *getRangeSelector();
+  Ui::IndirectMoments m_uiForm;
+
+  /// Tree of the properties
+  std::map<QString, QtTreePropertyBrowser *> m_propTrees;
+  /// Internal list of the properties
+  QMap<QString, QtProperty *> m_properties;
+  DoubleEditorFactory *m_dblEdFac;
+  QtDoublePropertyManager *m_dblManager;
+};
+} // namespace CustomInterfaces
+} // namespace MantidQt

--- a/qt/scientific_interfaces/Indirect/IndirectMomentsView.h
+++ b/qt/scientific_interfaces/Indirect/IndirectMomentsView.h
@@ -44,7 +44,7 @@ public:
 signals:
   void valueChanged(QtProperty *, double);
   void dataReady(QString const &);
-  void scaleChanged(bool);
+  void scaleChanged(int);
   void scaleValueChanged(double);
   void runClicked();
   void saveClicked();

--- a/qt/scientific_interfaces/Indirect/test/CMakeLists.txt
+++ b/qt/scientific_interfaces/Indirect/test/CMakeLists.txt
@@ -18,6 +18,7 @@ set(TEST_FILES
     IndirectFitPlotPresenterTest.h
     IndirectFitPropertyBrowserTest.h
     IndirectFittingModelTest.h
+    IndirectMomentsModelTest.h
     IndirectPlotOptionsModelTest.h
     IndirectPlotOptionsPresenterTest.h
     IndirectSettingsModelTest.h

--- a/qt/scientific_interfaces/Indirect/test/IndirectMomentsModelTest.h
+++ b/qt/scientific_interfaces/Indirect/test/IndirectMomentsModelTest.h
@@ -23,16 +23,13 @@ public:
   void setUp() override { m_model = std::make_unique<IndirectMomentsModel>(); }
 
   void test_algorrithm_set_up() {
-
+    // The Moments algorithm is a python algorithm and so can not be called in
     m_workspace = WorkspaceCreationHelper::create2DWorkspace(5, 4);
     Mantid::API::AnalysisDataService::Instance().addOrReplace("Workspace_name_sqw", m_workspace);
     m_model->setInputWorkspace("Workspace_name");
     m_model->setEMin(-0.4);
     m_model->setEMax(0.4);
     m_model->setScale(false);
-    // auto alg = m_model->setupAlgorithm();
-    // auto properties = alg->getProperties();
-    int foo = 1;
   }
 
   void test_output_workspace() {

--- a/qt/scientific_interfaces/Indirect/test/IndirectMomentsModelTest.h
+++ b/qt/scientific_interfaces/Indirect/test/IndirectMomentsModelTest.h
@@ -1,0 +1,47 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2019 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#pragma once
+
+#include "IndirectDataValidationHelper.h"
+#include "IndirectMomentsModel.h"
+#include "MantidAPI/AnalysisDataService.h"
+#include "MantidFrameworkTestHelpers/WorkspaceCreationHelper.h"
+#include <cxxtest/TestSuite.h>
+#include <gmock/gmock.h>
+
+using namespace MantidQt::CustomInterfaces;
+
+class IndirectMomentsModelTest : public CxxTest::TestSuite {
+public:
+  /// Needed to make sure everything is initialized
+  IndirectMomentsModelTest() = default;
+
+  void setUp() override { m_model = std::make_unique<IndirectMomentsModel>(); }
+
+  void test_algorrithm_set_up() {
+
+    m_workspace = WorkspaceCreationHelper::create2DWorkspace(5, 4);
+    Mantid::API::AnalysisDataService::Instance().addOrReplace("Workspace_name_sqw", m_workspace);
+    m_model->setInputWorkspace("Workspace_name");
+    m_model->setEMin(-0.4);
+    m_model->setEMax(0.4);
+    m_model->setScale(false);
+    // auto alg = m_model->setupAlgorithm();
+    // auto properties = alg->getProperties();
+    int foo = 1;
+  }
+
+  void test_output_workspace() {
+    m_model->setInputWorkspace("Workspace_name_sqw");
+    auto outputWorkspaceName = m_model->getOutputWorkspace();
+    TS_ASSERT(outputWorkspaceName == "Workspace_name_Moments");
+  }
+
+private:
+  MatrixWorkspace_sptr m_workspace;
+  std::unique_ptr<IndirectMomentsModel> m_model;
+};


### PR DESCRIPTION
**Description of work.**

This PR is to make the Indirect Moments tab MVP compliant. currently as it is part of the IndirectDataReduction interface It is required to inherit from the IndirectDataReductionTab object, this means that the algorithm running is still being done in the presenter, and tests for the presenter can not be written.

**To test:**

1. open the indirect data reduction interface.
2. go to the Moments tab. 
3. Load sqw data.
4. check that the preview plot has worked and the range boundary markers are platted
5. move the range markers and check that the values in the table change with it.
6. Click the run button.
7. Check the moments workspace generated and check that the parameters in it's fistoery are the same as in the interface.
8. run these same steps in the version built on master or the nightly and check that the output is the same.

Fixes #33679

*This does not require release notes* because It is all internal chagnes, it should not be noticed by users.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
