### PR TITLE
Check for conflicts on push to likely target branches

### DIFF
--- a/.github/workflows/label_merge_conflicts.yml
+++ b/.github/workflows/label_merge_conflicts.yml
@@ -1,5 +1,10 @@
 name: 'Check for merge conflicts'
 on:
+  push:
+    branches:
+      - 'main'
+      - 'release-next'
+      - 'ornl**'
   pull_request:
     types: [opened, synchronize, reopened]
 

--- a/.github/workflows/label_merge_conflicts.yml
+++ b/.github/workflows/label_merge_conflicts.yml
@@ -4,7 +4,7 @@ on:
     branches:
       - 'main'
       - 'release-next'
-      - 'ornl**'
+      - 'ornl-next'
   pull_request:
     types: [opened, synchronize, reopened]
 


### PR DESCRIPTION
**Description of work.**

Our conflict label checker was only running on changes to
branches for open pull requests so it missed if a push to, e.g. main,
generates a conflict. 

Checking every push is overkill but checking on push
to branches that most people use as a target will
pick up more conflicts sooner.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**

Code review.

*There is no associated issue.*

*This does not require release notes* because **it is an internal change.**

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
