### PR TITLE
Delete Workbench workspace QMenu after use

### DIFF
--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -606,9 +606,6 @@ unsafeClassCanLeak:${CMAKE_SOURCE_DIR}/qt/widgets/common/inc/MantidQtWidgets/Com
 unsafeClassCanLeak:${CMAKE_SOURCE_DIR}/qt/widgets/common/inc/MantidQtWidgets/Common/WidgetScrollbarDecorator.h:105
 unsafeClassCanLeak:${CMAKE_SOURCE_DIR}/qt/widgets/common/inc/MantidQtWidgets/Common/WidgetScrollbarDecorator.h:106
 useStlAlgorithm:${CMAKE_SOURCE_DIR}/qt/widgets/common/src/UserInputValidator.cpp:40
-unreadVariable:${CMAKE_SOURCE_DIR}/qt/widgets/common/src/WorkspacePresenter/WorkspaceTreeWidgetSimple.cpp:222
-unreadVariable:${CMAKE_SOURCE_DIR}/qt/widgets/common/src/WorkspacePresenter/WorkspaceTreeWidgetSimple.cpp:225
-unreadVariable:${CMAKE_SOURCE_DIR}/qt/widgets/common/src/WorkspacePresenter/WorkspaceTreeWidgetSimple.cpp:261
 shadowFunction:${CMAKE_SOURCE_DIR}/qt/widgets/common/src/Batch/JobTreeView.cpp:434
 unknownMacro:${CMAKE_SOURCE_DIR}/qt/widgets/common/src/QtPropertyBrowser/qtpropertybrowser.cpp:1142
 unknownMacro:${CMAKE_SOURCE_DIR}/qt/widgets/common/src/QtPropertyBrowser/qteditorfactory.cpp:1546

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/WorkspacePresenter/WorkspaceTreeWidgetSimple.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/WorkspacePresenter/WorkspaceTreeWidgetSimple.h
@@ -9,16 +9,17 @@
 #include "MantidQtWidgets/Common/DllOption.h"
 #include "MantidQtWidgets/Common/WorkspacePresenter/WorkspaceTreeWidget.h"
 
-#include "MantidAPI/MatrixWorkspace_fwd.h"
-
 #include <QMenu>
 #include <QWidget>
 
 class QTreeWidgetItem;
 class QSignalMapper;
 
-namespace MantidQt {
-namespace MantidWidgets {
+namespace Mantid::API {
+class Workspace;
+}
+
+namespace MantidQt::MantidWidgets {
 class MantidDisplayBase;
 class MantidTreeWidget;
 
@@ -26,9 +27,6 @@ class MantidTreeWidget;
 \class  WorkspaceTreeWidgetSimple
 \brief  WorkspaceTreeWidget implementation for the Workbench - required for some
 function overides
-\author Elliot Oram
-\date   16-01-2018
-\version 1.0
 */
 class EXPORT_OPT_MANTIDQT_COMMON WorkspaceTreeWidgetSimple : public WorkspaceTreeWidget {
   Q_OBJECT
@@ -101,11 +99,20 @@ private slots:
   void onSuperplotBinsWithErrsClicked();
 
 private:
+  QMenu *createWorkspaceContextMenu(const Mantid::API::Workspace &workspace);
+
+  void addMatrixWorkspaceActions(QMenu *menu, const Mantid::API::MatrixWorkspace &workspace);
+  void addTableWorkspaceActions(QMenu *menu, const Mantid::API::ITableWorkspace &workspace);
+  void addMDWorkspaceActions(QMenu *menu, const Mantid::API::IMDWorkspace &workspace);
+  void addWorkspaceGroupActions(QMenu *menu, const Mantid::API::WorkspaceGroup &workspace);
+  void addGeneralWorkspaceActions(QMenu *menu) const;
+
+  QMenu *createMatrixWorkspacePlotMenu(QWidget *parent, bool hasMultipleBins);
+
   QAction *m_plotSpectrum, *m_plotBin, *m_overplotSpectrum, *m_plotSpectrumWithErrs, *m_overplotSpectrumWithErrs,
       *m_plotColorfill, *m_sampleLogs, *m_sliceViewer, *m_showInstrument, *m_showData, *m_showAlgorithmHistory,
       *m_showDetectors, *m_plotAdvanced, *m_plotSurface, *m_plotWireframe, *m_plotContour, *m_plotMDHisto1D,
       *m_overplotMDHisto1D, *m_plotMDHisto1DWithErrs, *m_overplotMDHisto1DWithErrs, *m_sampleMaterial, *m_superplot,
       *m_superplotWithErrs, *m_superplotBins, *m_superplotBinsWithErrs;
 };
-} // namespace MantidWidgets
-} // namespace MantidQt
+} // namespace MantidQt::MantidWidgets

--- a/qt/widgets/common/src/WorkspacePresenter/WorkspaceTreeWidgetSimple.cpp
+++ b/qt/widgets/common/src/WorkspacePresenter/WorkspaceTreeWidgetSimple.cpp
@@ -26,7 +26,20 @@ using namespace Mantid::API;
 using namespace Mantid::Kernel;
 
 namespace {
-bool singleValued(const MatrixWorkspace &ws) { return (ws.getNumberHistograms() == 1 && ws.blocksize() == 1); }
+bool hasSingleValue(const MatrixWorkspace &ws) { return (ws.getNumberHistograms() == 1 && ws.blocksize() == 1); }
+bool hasMultipleBins(const MatrixWorkspace &ws) {
+  try {
+    return (ws.blocksize() > 1);
+  } catch (...) {
+    const size_t numHist = ws.getNumberHistograms();
+    for (size_t i = 0; i < numHist; ++i) {
+      if (ws.y(i).size() > 1) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
 } // namespace
 
 namespace MantidQt::MantidWidgets {
@@ -100,16 +113,10 @@ void WorkspaceTreeWidgetSimple::popupContextMenu() {
     m_tree->selectionModel()->clear();
 
   QMenu *menu(nullptr);
-
-  // If no workspace is here then have load items
-  if (selectedWsName.isEmpty())
+  if (selectedWsName.isEmpty()) {
+    // If no workspace is here then have load items
     menu = m_loadMenu;
-  else {
-    menu = new QMenu(this);
-    menu->setAttribute(Qt::WA_DeleteOnClose, true);
-    menu->setObjectName("WorkspaceContextMenu");
-
-    // plot submenu first for MatrixWorkspace.
+  } else {
     // Check is defensive just in case the workspace has disappeared
     Workspace_sptr workspace;
     try {
@@ -117,159 +124,7 @@ void WorkspaceTreeWidgetSimple::popupContextMenu() {
     } catch (Exception::NotFoundError &) {
       return;
     }
-    if (auto matrixWS = std::dynamic_pointer_cast<MatrixWorkspace>(workspace)) {
-      QMenu *plotSubMenu(new QMenu("Plot", menu));
-      // Don't plot 1D spectra if only one X value
-      bool multipleBins = false;
-      try {
-        multipleBins = (matrixWS->blocksize() > 1);
-      } catch (...) {
-        const size_t numHist = matrixWS->getNumberHistograms();
-        for (size_t i = 0; i < numHist; ++i) {
-          if (matrixWS->y(i).size() > 1) {
-            multipleBins = true;
-            break;
-          }
-        }
-      }
-      if (multipleBins) {
-        plotSubMenu->addAction(m_plotSpectrum);
-        plotSubMenu->addAction(m_overplotSpectrum);
-        plotSubMenu->addAction(m_plotSpectrumWithErrs);
-        plotSubMenu->addAction(m_overplotSpectrumWithErrs);
-        plotSubMenu->addAction(m_plotAdvanced);
-        plotSubMenu->addAction(m_superplot);
-        plotSubMenu->addAction(m_superplotWithErrs);
-      } else {
-        plotSubMenu->addAction(m_plotBin);
-        plotSubMenu->addAction(m_superplotBins);
-        plotSubMenu->addAction(m_superplotBinsWithErrs);
-      }
-      plotSubMenu->addSeparator();
-      plotSubMenu->addAction(m_plotColorfill);
-
-      if (multipleBins) {
-        QMenu *plot3DSubMenu(new QMenu("3D", menu));
-        plot3DSubMenu->addAction(m_plotSurface);
-        plot3DSubMenu->addAction(m_plotWireframe);
-        plot3DSubMenu->addAction(m_plotContour);
-
-        plotSubMenu->addMenu(plot3DSubMenu);
-      }
-      if (!singleValued(*matrixWS)) {
-        // regular matrix workspace
-        menu->addMenu(plotSubMenu);
-        menu->addSeparator();
-        menu->addAction(m_showData);
-        menu->addAction(m_showAlgorithmHistory);
-        menu->addAction(m_showInstrument);
-        m_showInstrument->setEnabled(matrixWS->getInstrument() && !matrixWS->getInstrument()->getName().empty() &&
-                                     matrixWS->getAxis(1)->isSpectra());
-        menu->addAction(m_sampleLogs);
-        menu->addAction(m_sliceViewer);
-        menu->addAction(m_showDetectors);
-      } else {
-        menu->addAction(m_showData);
-      }
-
-    } else if (std::dynamic_pointer_cast<ITableWorkspace>(workspace)) {
-      menu->addAction(m_showData);
-      menu->addAction(m_showAlgorithmHistory);
-      if (std::dynamic_pointer_cast<IPeaksWorkspace>(workspace)) {
-        menu->addAction(m_showDetectors);
-      }
-    } else if (auto md_ws = std::dynamic_pointer_cast<IMDWorkspace>(workspace)) {
-      menu->addAction(m_showAlgorithmHistory);
-      menu->addAction(m_sampleLogs);
-
-      // launch slice viewer or plot spectrum conditionally
-      bool add_slice_viewer = false;
-      bool add_1d_plot = false;
-
-      if (md_ws->isMDHistoWorkspace()) {
-        // if the number of non-integral  if the number of non-integrated
-        // dimensions is 1.
-        auto num_dims = md_ws->getNumNonIntegratedDims();
-        if (num_dims == 1) {
-          // number of non-integral dimension is 1: show menu item to plot
-          // spectrum
-          add_1d_plot = true;
-        } else if (num_dims > 1) {
-          // number of non-integral dimension is larger than 1: show menu item
-          // to launch slice view
-          add_slice_viewer = true;
-        }
-      } else if (md_ws->getNumDims() > 1) {
-        add_slice_viewer = true;
-      }
-
-      if (add_slice_viewer) {
-        menu->addAction(m_sliceViewer);
-      } else if (add_1d_plot) {
-        QMenu *plotSubMenu(new QMenu("Plot", menu));
-        plotSubMenu->addAction(m_plotMDHisto1D);
-        plotSubMenu->addAction(m_overplotMDHisto1D);
-        plotSubMenu->addAction(m_plotMDHisto1DWithErrs);
-        plotSubMenu->addAction(m_overplotMDHisto1DWithErrs);
-        menu->addMenu(plotSubMenu);
-      }
-
-    } else if (auto wsGroup = std::dynamic_pointer_cast<WorkspaceGroup>(workspace)) {
-      auto workspaces = wsGroup->getAllItems();
-      bool containsMatrixWorkspace{false};
-      bool containsPeaksWorkspace{false};
-
-      for (const auto &ws : workspaces) {
-        if (std::dynamic_pointer_cast<MatrixWorkspace>(ws)) {
-          containsMatrixWorkspace = true;
-          break;
-        } else if (std::dynamic_pointer_cast<IPeaksWorkspace>(ws)) {
-          containsPeaksWorkspace = true;
-        }
-      }
-
-      // Add plotting options if the group contains at least one matrix
-      // workspace.
-      if (containsMatrixWorkspace) {
-        QMenu *plotSubMenu(new QMenu("Plot", menu));
-
-        plotSubMenu->addAction(m_plotSpectrum);
-        plotSubMenu->addAction(m_overplotSpectrum);
-        plotSubMenu->addAction(m_plotSpectrumWithErrs);
-        plotSubMenu->addAction(m_overplotSpectrumWithErrs);
-        plotSubMenu->addAction(m_plotAdvanced);
-        plotSubMenu->addAction(m_superplot);
-        plotSubMenu->addAction(m_superplotWithErrs);
-
-        plotSubMenu->addSeparator();
-        plotSubMenu->addAction(m_plotColorfill);
-        menu->addMenu(plotSubMenu);
-
-        menu->addSeparator();
-      }
-
-      if (containsMatrixWorkspace || containsPeaksWorkspace) {
-        menu->addAction(m_showDetectors);
-      }
-    }
-
-    // Only show sample material action if we have a single workspace
-    // selected.
-    if (m_tree->selectedItems().size() == 1) {
-      // SetSampleMaterial algorithm requires that the workspace
-      // inherits from ExperimentInfo, so check that it does
-      // before adding the action to the context menu.
-      if (std::dynamic_pointer_cast<ExperimentInfo>(workspace)) {
-        menu->addAction(m_sampleMaterial);
-      }
-    }
-
-    menu->addSeparator();
-    menu->addAction(m_rename);
-    menu->addAction(m_saveNexus);
-
-    menu->addSeparator();
-    menu->addAction(m_delete);
+    menu = createWorkspaceContextMenu(*workspace);
   }
 
   // Show the menu at the cursor's current position
@@ -361,6 +216,160 @@ void WorkspaceTreeWidgetSimple::onSuperplotBinsClicked() {
 
 void WorkspaceTreeWidgetSimple::onSuperplotBinsWithErrsClicked() {
   emit superplotBinsWithErrsClicked(getSelectedWorkspaceNamesAsQList());
+}
+
+/**
+ * Create a new QMenu object filled with appropriate items for the given workspace
+ * The created object has this as its parent and WA_DeleteOnClose set
+ */
+QMenu *WorkspaceTreeWidgetSimple::createWorkspaceContextMenu(const Mantid::API::Workspace &workspace) {
+  auto menu = new QMenu(this);
+  menu->setAttribute(Qt::WA_DeleteOnClose, true);
+  menu->setObjectName("WorkspaceContextMenu");
+
+  if (auto matrixWS = dynamic_cast<const MatrixWorkspace *>(&workspace))
+    addMatrixWorkspaceActions(menu, *matrixWS);
+  else if (auto tableWS = dynamic_cast<const ITableWorkspace *>(&workspace))
+    addTableWorkspaceActions(menu, *tableWS);
+  else if (auto mdWS = dynamic_cast<const IMDWorkspace *>(&workspace))
+    addMDWorkspaceActions(menu, *mdWS);
+  else if (auto wsGroup = dynamic_cast<const WorkspaceGroup *>(&workspace))
+    addWorkspaceGroupActions(menu, *wsGroup);
+
+  // Add for all types
+  addGeneralWorkspaceActions(menu);
+
+  return menu;
+}
+
+void WorkspaceTreeWidgetSimple::addMatrixWorkspaceActions(QMenu *menu, const Mantid::API::MatrixWorkspace &workspace) {
+  // Show just data for a single value.
+  if (hasSingleValue(workspace)) {
+    menu->addAction(m_showData);
+    return;
+  }
+
+  menu->addMenu(createMatrixWorkspacePlotMenu(menu, hasMultipleBins(workspace)));
+  menu->addSeparator();
+  menu->addAction(m_showData);
+  menu->addAction(m_showAlgorithmHistory);
+  menu->addAction(m_showInstrument);
+  m_showInstrument->setEnabled(workspace.getInstrument() && !workspace.getInstrument()->getName().empty() &&
+                               workspace.getAxis(1)->isSpectra());
+  menu->addAction(m_sampleLogs);
+  menu->addAction(m_sliceViewer);
+  menu->addAction(m_showDetectors);
+  if (m_tree->selectedItems().size() == 1) {
+    menu->addAction(m_sampleMaterial);
+  }
+}
+
+void WorkspaceTreeWidgetSimple::addTableWorkspaceActions(QMenu *menu, const Mantid::API::ITableWorkspace &workspace) {
+  menu->addAction(m_showData);
+  menu->addAction(m_showAlgorithmHistory);
+  if (dynamic_cast<const IPeaksWorkspace *>(&workspace)) {
+    menu->addAction(m_showDetectors);
+  }
+}
+
+void WorkspaceTreeWidgetSimple::addMDWorkspaceActions(QMenu *menu, const Mantid::API::IMDWorkspace &workspace) {
+  menu->addAction(m_showAlgorithmHistory);
+  menu->addAction(m_sampleLogs);
+
+  // launch slice viewer or plot spectrum conditionally
+  bool addSliceViewer = false;
+  bool add1DPlot = false;
+
+  if (workspace.isMDHistoWorkspace()) {
+    // if the number of non-integral  if the number of non-integrated
+    // dimensions is 1.
+    auto num_dims = workspace.getNumNonIntegratedDims();
+    if (num_dims == 1) {
+      // number of non-integral dimension is 1: show menu item to plot
+      // spectrum
+      add1DPlot = true;
+    } else if (num_dims > 1) {
+      // number of non-integral dimension is larger than 1: show menu item
+      // to launch slice view
+      addSliceViewer = true;
+    }
+  } else if (workspace.getNumDims() > 1) {
+    addSliceViewer = true;
+  }
+
+  if (addSliceViewer) {
+    menu->addAction(m_sliceViewer);
+  } else if (add1DPlot) {
+    auto *plotSubMenu = new QMenu("Plot", menu);
+    plotSubMenu->addAction(m_plotMDHisto1D);
+    plotSubMenu->addAction(m_overplotMDHisto1D);
+    plotSubMenu->addAction(m_plotMDHisto1DWithErrs);
+    plotSubMenu->addAction(m_overplotMDHisto1DWithErrs);
+    menu->addMenu(plotSubMenu);
+  }
+}
+
+void WorkspaceTreeWidgetSimple::addWorkspaceGroupActions(QMenu *menu, const Mantid::API::WorkspaceGroup &workspace) {
+  auto workspaces = workspace.getAllItems();
+  bool containsMatrixWorkspace{false};
+  bool containsPeaksWorkspace{false};
+  for (const auto &ws : workspaces) {
+    if (std::dynamic_pointer_cast<MatrixWorkspace>(ws)) {
+      containsMatrixWorkspace = true;
+      break;
+    } else if (std::dynamic_pointer_cast<IPeaksWorkspace>(ws)) {
+      containsPeaksWorkspace = true;
+    }
+  }
+
+  // Add plotting options if the group contains at least one matrix
+  // workspace.
+  if (containsMatrixWorkspace) {
+    menu->addMenu(createMatrixWorkspacePlotMenu(menu, true));
+    menu->addSeparator();
+  }
+
+  if (containsMatrixWorkspace || containsPeaksWorkspace) {
+    menu->addAction(m_showDetectors);
+  }
+}
+
+void WorkspaceTreeWidgetSimple::addGeneralWorkspaceActions(QMenu *menu) const {
+  menu->addSeparator();
+  menu->addAction(m_rename);
+  menu->addAction(m_saveNexus);
+  menu->addSeparator();
+  menu->addAction(m_delete);
+}
+
+QMenu *WorkspaceTreeWidgetSimple::createMatrixWorkspacePlotMenu(QWidget *parent, bool hasMultipleBins) {
+  auto *plotSubMenu = new QMenu("Plot", parent);
+  if (hasMultipleBins) {
+    plotSubMenu->addAction(m_plotSpectrum);
+    plotSubMenu->addAction(m_overplotSpectrum);
+    plotSubMenu->addAction(m_plotSpectrumWithErrs);
+    plotSubMenu->addAction(m_overplotSpectrumWithErrs);
+    plotSubMenu->addAction(m_plotAdvanced);
+    plotSubMenu->addAction(m_superplot);
+    plotSubMenu->addAction(m_superplotWithErrs);
+    plotSubMenu->addSeparator();
+    plotSubMenu->addAction(m_plotColorfill);
+    // 3D
+    auto *plot3DSubMenu = new QMenu("3D", plotSubMenu);
+    plot3DSubMenu->addAction(m_plotSurface);
+    plot3DSubMenu->addAction(m_plotWireframe);
+    plot3DSubMenu->addAction(m_plotContour);
+    plotSubMenu->addMenu(plot3DSubMenu);
+
+  } else {
+    plotSubMenu->addAction(m_plotBin);
+    plotSubMenu->addAction(m_superplotBins);
+    plotSubMenu->addAction(m_superplotBinsWithErrs);
+    plotSubMenu->addSeparator();
+    plotSubMenu->addAction(m_plotColorfill);
+  }
+
+  return plotSubMenu;
 }
 
 } // namespace MantidQt::MantidWidgets

--- a/qt/widgets/common/src/WorkspacePresenter/WorkspaceTreeWidgetSimple.cpp
+++ b/qt/widgets/common/src/WorkspacePresenter/WorkspaceTreeWidgetSimple.cpp
@@ -106,6 +106,7 @@ void WorkspaceTreeWidgetSimple::popupContextMenu() {
     menu = m_loadMenu;
   else {
     menu = new QMenu(this);
+    menu->setAttribute(Qt::WA_DeleteOnClose, true);
     menu->setObjectName("WorkspaceContextMenu");
 
     // plot submenu first for MatrixWorkspace.

--- a/qt/widgets/common/src/WorkspacePresenter/WorkspaceTreeWidgetSimple.cpp
+++ b/qt/widgets/common/src/WorkspacePresenter/WorkspaceTreeWidgetSimple.cpp
@@ -219,11 +219,11 @@ void WorkspaceTreeWidgetSimple::popupContextMenu() {
       bool containsMatrixWorkspace{false};
       bool containsPeaksWorkspace{false};
 
-      for (auto ws : workspaces) {
-        if (auto matrixWS = std::dynamic_pointer_cast<MatrixWorkspace>(ws)) {
+      for (const auto &ws : workspaces) {
+        if (std::dynamic_pointer_cast<MatrixWorkspace>(ws)) {
           containsMatrixWorkspace = true;
           break;
-        } else if (auto peaksWS = std::dynamic_pointer_cast<IPeaksWorkspace>(ws)) {
+        } else if (std::dynamic_pointer_cast<IPeaksWorkspace>(ws)) {
           containsPeaksWorkspace = true;
         }
       }
@@ -259,7 +259,7 @@ void WorkspaceTreeWidgetSimple::popupContextMenu() {
       // SetSampleMaterial algorithm requires that the workspace
       // inherits from ExperimentInfo, so check that it does
       // before adding the action to the context menu.
-      if (auto experimentInfoWS = std::dynamic_pointer_cast<ExperimentInfo>(workspace)) {
+      if (std::dynamic_pointer_cast<ExperimentInfo>(workspace)) {
         menu->addAction(m_sampleMaterial);
       }
     }


### PR DESCRIPTION
**Description of work.**

This is not a large leak but it can cause
confusion when trying to decide with methods
like `QApplication.topLevelWindows()` whether
everything that was to be deleted has been.

**To test:**

To check you understand the problem run the instructions before merging and then after:

* Start workbench
* Run `CreateSampleWorkspace`
* Right-click on the workspace
* In the script editor run:
```python
from qtpy.QtWidgets import QApplication
import pprint

pprint.pprint([w.objectName() for w in QApplication.topLevelWindows()])
```

The list should not contain any references to `WorkspaceContextMenu` after the fix.

*There is no associated issue. It was disocvered while debugging #33662*

*This does not require release notes* because **a complete summary once #33662 and #33661 is fixed will be included.**

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
