### PR TITLE
TabulatedFunction: no segfault with WorkspaceGroup

### DIFF
--- a/Framework/CurveFitting/src/Functions/TabulatedFunction.cpp
+++ b/Framework/CurveFitting/src/Functions/TabulatedFunction.cpp
@@ -275,6 +275,9 @@ void TabulatedFunction::load(const std::string &fname) {
 void TabulatedFunction::loadWorkspace(const std::string &wsName) const {
   auto ws = AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(wsName);
   loadWorkspace(ws);
+  if (!m_workspace) {
+    throw std::runtime_error("Unable to set " + wsName + " as workspace attribute. Incorrect workspace type?");
+  }
 }
 
 /**

--- a/Framework/CurveFitting/src/Functions/TabulatedFunction.cpp
+++ b/Framework/CurveFitting/src/Functions/TabulatedFunction.cpp
@@ -276,7 +276,7 @@ void TabulatedFunction::loadWorkspace(const std::string &wsName) const {
   auto ws = AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(wsName);
   loadWorkspace(ws);
   if (!m_workspace) {
-    throw std::runtime_error("Unable to set " + wsName + " as workspace attribute. Incorrect workspace type?");
+    throw std::runtime_error("Unable to set " + wsName + " as workspace attribute. Expected a MatrixWorkspace.");
   }
 }
 

--- a/Framework/CurveFitting/test/Functions/TabulatedFunctionTest.h
+++ b/Framework/CurveFitting/test/Functions/TabulatedFunctionTest.h
@@ -185,6 +185,13 @@ public:
                      const Mantid::Kernel::Exception::NotFoundError &);
   }
 
+  void test_loadWorkspaceGroup() {
+    auto ws = WorkspaceCreationHelper::createWorkspaceGroup(3, 3, 3, "group");
+    TabulatedFunction fun;
+    TS_ASSERT_THROWS(fun.setAttributeValue("Workspace", "group"), const std::runtime_error &);
+    AnalysisDataService::Instance().clear();
+  }
+
   void test_Derivatives() {
     auto ws = WorkspaceCreationHelper::create2DWorkspaceFromFunction(Fun(), 1, -5.0, 5.0, 0.1, false);
     AnalysisDataService::Instance().add("TABULATEDFUNCTIONTEST_WS", ws);

--- a/docs/source/release/v6.4.0/Framework/Fit_Functions/Bugfixes/33782.rst
+++ b/docs/source/release/v6.4.0/Framework/Fit_Functions/Bugfixes/33782.rst
@@ -1,0 +1,1 @@
+- Fix for hard crash when user attempts to use WorkspaceGroup as Workspace in TabulatedFunction. Now, a runtime_error exception is thrown with information that the attribute cannot be assigned.


### PR DESCRIPTION
**Description of work.**

A hard crash has been observed by one of our users when they were trying to forward output from one algorithm to the `Workspace` attribute of the `TabulatedFunction` which was of `WorkspaceGroup` type. To remedy the segfault, a` runtime_error `is now thrown in case the dynamic cast returns a `nullptr` after an attempt to retrieve desired workspace from the ADS.

**To test:**


1. Run the example script:

```
# import mantid algorithms, numpy and matplotlib
from mantid.simpleapi import *

CreateSampleWorkspace(OutputWorkspace='test')
GroupWorkspaces(InputWorkspaces='test', OutputWorkspace='group')
F = TabulatedFunction(Workspace='group', WorkspaceIndex=1)
x=np.linspace(-0.01,0.01,30)
y = F(x)
```

2. Instead of a hard crash, a runtime error should appear. 

Fixes #33782 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
