### PR TITLE
Fix Misleading Cell State Checking Tests

### DIFF
--- a/qt/scientific_interfaces/ISISReflectometry/test/RunsTable/RunsTablePresenterProcessingTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/RunsTable/RunsTablePresenterProcessingTest.h
@@ -19,9 +19,18 @@ using namespace MantidQt::CustomInterfaces::ISISReflectometry;
 using MantidQt::MantidWidgets::Batch::Cell;
 using MantidQt::MantidWidgets::Batch::RowLocation;
 using MantidQt::MantidWidgets::Batch::RowPath;
+using testing::AllOf;
 using testing::Mock;
 using testing::NiceMock;
 using testing::Return;
+
+namespace {
+MATCHER_P(AreAllColour, colour, "Colour checker for vectors of Cells") {
+  auto const col = colour;
+  return std::all_of(arg.cbegin(), arg.cend(),
+                     [col](auto const &cell) { return strcmp(cell.backgroundColor().c_str(), col) == 0; });
+}
+} // namespace
 
 class RunsTablePresenterProcessingTest : public CxxTest::TestSuite, RunsTablePresenterTest {
 public:
@@ -170,7 +179,7 @@ public:
   void testRowStateChangedForCompleteRow() {
     auto presenter = makePresenter(m_view, oneGroupWithARowModel());
     getRow(presenter, 0, 0)->setSuccess();
-    expectGroupStateCleared();
+    expectGroupState(Colour::CHILDREN_SUCCESS);
     expectRowState(Colour::SUCCESS);
     presenter.notifyRowStateChanged();
     verifyAndClearExpectations();
@@ -196,8 +205,8 @@ public:
 
   void testRowStateChangedForCompleteGroup() {
     auto presenter = makePresenter(m_view, oneGroupWithARowModel());
-    getGroup(presenter, 0).setSuccess();
     getRow(presenter, 0, 0)->setSuccess();
+    getGroup(presenter, 0).setSuccess();
     expectGroupState(Colour::SUCCESS);
     expectRowState(Colour::SUCCESS);
     presenter.notifyRowStateChanged();
@@ -206,8 +215,8 @@ public:
 
   void testRowStateChangedForErrorGroup() {
     auto presenter = makePresenter(m_view, oneGroupWithARowModel());
-    getGroup(presenter, 0).setError("error message");
     getRow(presenter, 0, 0)->setSuccess();
+    getGroup(presenter, 0).setError("error message");
     expectGroupState(Colour::FAILURE);
     expectRowState(Colour::SUCCESS);
     presenter.notifyRowStateChanged();
@@ -270,11 +279,14 @@ private:
   }
 
   void expectGroupStateCleared() {
-    EXPECT_CALL(m_jobs, setCellsAt(RowLocation({0}), rowCells(Colour::DEFAULT))).Times(AtLeast(1));
+    EXPECT_CALL(m_jobs, setCellsAt(RowLocation({0}), AllOf(rowCells(Colour::DEFAULT), AreAllColour(Colour::DEFAULT))))
+        .Times(AtLeast(1));
   }
 
   void expectRowStateCleared() {
-    EXPECT_CALL(m_jobs, setCellsAt(RowLocation({0, 0}), rowCells(Colour::DEFAULT))).Times(AtLeast(1));
+    EXPECT_CALL(m_jobs,
+                setCellsAt(RowLocation({0, 0}), AllOf(rowCells(Colour::DEFAULT), AreAllColour(Colour::DEFAULT))))
+        .Times(AtLeast(1));
   }
 
   void expectRowStateInvalid() {
@@ -283,15 +295,15 @@ private:
       cell.setToolTip("Row will not be processed: it either contains invalid cell values, "
                       "or duplicates a reduction in another row");
 
-    EXPECT_CALL(m_jobs, setCellsAt(RowLocation({0, 0}), cells)).Times(1);
+    EXPECT_CALL(m_jobs, setCellsAt(RowLocation({0, 0}), AllOf(cells, AreAllColour(Colour::INVALID)))).Times(1);
   }
 
   void expectGroupState(const char *colour) {
-    EXPECT_CALL(m_jobs, setCellsAt(RowLocation({0}), rowCells(colour))).Times(1);
+    EXPECT_CALL(m_jobs, setCellsAt(RowLocation({0}), AllOf(rowCells(colour), AreAllColour(colour)))).Times(1);
   }
 
   void expectRowState(const char *colour) {
-    EXPECT_CALL(m_jobs, setCellsAt(RowLocation({0, 0}), rowCells(colour))).Times(1);
+    EXPECT_CALL(m_jobs, setCellsAt(RowLocation({0, 0}), AllOf(rowCells(colour), AreAllColour(colour)))).Times(1);
   }
 
   void expectUpdateProgressBar() {


### PR DESCRIPTION
**Description of work.**

Cell comparison does not take the colour into account. This is for ease
elsewhere. This adds a custom matcher to ensure that the colours are
also checked, as they represent the state. Also moves the setting of the
group state after the setting of the row state. Rows update their
parents when their state is updated so need to have their states set
last.

**To test:**
1. Only changes tests, so just make sure they run correctly. 

Fixes #33474 

*This does not require release notes* because **it only affects the unit tests.**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
