### PR TITLE
Allow writing the same value in WorkspaceIndex and Workspace Index fields

### DIFF
--- a/docs/source/release/v6.4.0/Framework/Fit_Functions/Bugfixes/33788.rst
+++ b/docs/source/release/v6.4.0/Framework/Fit_Functions/Bugfixes/33788.rst
@@ -1,0 +1,2 @@
+- Allow the user to put the same values in the `WorkspaceIndex` and `Workspace Index` fields
+when creating a composite function in the fitting browser.

--- a/qt/widgets/common/src/FitPropertyBrowser.cpp
+++ b/qt/widgets/common/src/FitPropertyBrowser.cpp
@@ -1305,14 +1305,16 @@ void FitPropertyBrowser::intChanged(QtProperty *prop) {
     }
     m_oldWorkspaceIndex = allowedIndex;
   } else if (prop->propertyName() == "Workspace Index") {
+    // Property field from Settings. Note the white space.
     PropertyHandler *h = getHandler()->findHandler(prop);
     if (!h)
       return;
     h->setFunctionWorkspace();
   } else if (prop->propertyName() == "WorkspaceIndex") {
+    // Property field from functions. In a word.
     PropertyHandler *h = getHandler()->findHandler(prop);
     auto const index = prop->valueText().toInt();
-    if (h && index != workspaceIndex()) {
+    if (h) {
       h->setAttribute(prop);
       setWorkspaceIndex(index);
       emit workspaceIndexChanged(index);


### PR DESCRIPTION
**Description of work.**
This PR allows the user to select the same index for the `WorkspaceIndex` and `Workspace Index` fields in the fit browser, which was not possible previously, leading to some very confusing behaviors as the value input was silently ignored by the function when fitting.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**
   - Create a sample workspace with multiple spectra
   - Open a 1D plot, with more than the first workspace - for example spectra 4
   - Open the fit window
   - Set the fitting to a convolution function, based on a delta function and more importantly, on a Resolution function
   - For the resolution function, set the value of the `WorkspaceIndex` field **to the same value as the `Workspace Index`** field from `Settings`, with a value different from 0.
   - Set the logs to `Debug` and fit the function
   - The result is hard to see with the actual fitting, but fortunately the logs help us. You should see there, in the function parameters, the composite function used and its arguments (it is at the information level but is not spelled out if the level is not set to debug) in the form : 
   ```
Name: Function, Value: composite=Convolution,NumDeriv=true,FixResolution=true;Name=DeltaFunction,Height=1,Centre=0,ties=(Height=1,Centre=0);name=Resolution,Workspace=out,**WorkspaceIndex=4**,X=(),Y=(), Default?: No, Direction: InOut 
```
   -  Check that the value of `WorkspaceIndex` there is not 0, but indeed the value of the field (here, 4).
  
Fixes #33787 . 
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
