### PR TITLE
tweaked UI and addnl diagnostic files (no ticket)

### DIFF
--- a/Testing/SystemTests/tests/framework/PelicanReductionTest.py
+++ b/Testing/SystemTests/tests/framework/PelicanReductionTest.py
@@ -4,7 +4,10 @@
 #   NScD Oak Ridge National Laboratory, European Spallation Source,
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
+
 import systemtesting
+from mantid.simpleapi import *
+from mantid.api import IEventWorkspace
 from PelicanReduction import PelicanReduction
 
 
@@ -34,3 +37,39 @@ class PelicanReductionNXSPETest(systemtesting.MantidSystemTest):
     def validate(self):
         self.disableChecking.append('Instrument')
         return 'test_spe_2D', 'PelicanReductionExampleNXSPE.nxs'
+
+
+class PelicanReductionAutoQTest(systemtesting.MantidSystemTest):
+    def __init__(self):
+        systemtesting.MantidSystemTest.__init__(self)
+        self.tolerance = 1e-6
+
+    def runTest(self):
+        PelicanReduction('44464', OutputWorkspace='test', EnergyTransfer='-2,0.05,2',
+                         Processing='SOFQW1-Centre', ConfigurationFile='pelican_doctest.ini')
+        self.assertTrue('test_qw1_2D' in mtd, "Expected output workspace in ADS")
+        ws = mtd['test_qw1_2D']
+        xv = ws.dataX[0]
+        self.assertDelta( xv[0], 0.0, 0.01, "Unexpected minimum Q value")
+        self.assertDelta( xv[-1], 2.7, 0.01, "Unexpected maximum Q value")
+
+    def validate(self):
+        return True
+
+
+class PelicanReductionDebugFilesTest(systemtesting.MantidSystemTest):
+    def __init__(self):
+        systemtesting.MantidSystemTest.__init__(self)
+        self.tolerance = 1e-6
+
+    def runTest(self):
+        PelicanReduction('44464', OutputWorkspace='test', EnergyTransfer='-2,0.05,2',
+                         Processing='SOFQW1-Centre', KeepIntermediateWorkspaces=True,
+                         ConfigurationFile='pelican_doctest.ini')
+        self.assertTrue('intermediate' in mtd, "Expected intermediate workgroup in ADS")
+        self.assertTrue('_sample_merged' in mtd, "Expected merged workspace in ADS")
+        ws = mtd['_sample_merged']
+        self.assertTrue(isinstance(ws, IEventWorkspace), "Expected the merged sample is an EventWorkspace")
+
+    def validate(self):
+        return True

--- a/Testing/SystemTests/tests/framework/PelicanReductionTest.py
+++ b/Testing/SystemTests/tests/framework/PelicanReductionTest.py
@@ -47,9 +47,11 @@ class PelicanReductionAutoQTest(systemtesting.MantidSystemTest):
     def runTest(self):
         PelicanReduction('44464', OutputWorkspace='test', EnergyTransfer='-2,0.05,2',
                          Processing='SOFQW1-Centre', ConfigurationFile='pelican_doctest.ini')
-        self.assertTrue('test_qw1_2D' in mtd, "Expected output workspace in ADS")
-        ws = mtd['test_qw1_2D']
-        xv = ws.dataX[0]
+        self.assertTrue('test_qw1' in mtd, "Expected output workspace group in ADS")
+        wg = mtd['test_qw1']
+        index = dict([(tag, i) for i, tag in enumerate(wg.getNames())])
+        ws = wg.getItem(index['test_qw1_2D'])
+        xv = ws.dataX(0)
         self.assertDelta( xv[0], 0.0, 0.01, "Unexpected minimum Q value")
         self.assertDelta( xv[-1], 2.7, 0.01, "Unexpected maximum Q value")
 

--- a/docs/source/release/v6.4.0/Direct_Geometry/Algorithms/New_features/33791.rst
+++ b/docs/source/release/v6.4.0/Direct_Geometry/Algorithms/New_features/33791.rst
@@ -1,0 +1,1 @@
+- :ref:`PelicanReduction <algm-PelicanReduction>` add autoscaling the Q range to match the energy transfer as default in the UI.


### PR DESCRIPTION
Changed the Pelican reduction UI to autoscale the Q range to match the energy transfer limits as default, exposed the frameoverlap to the UI and added additional diagnostic files for analysing results.

Updated the system tests to cover autoQ and the addnl diagnostic files. Did not add a system test for the frameoverlap check as it would require a new data file to be added to the repository and the functionality was not changed other than exposing the parameter to the UI rather than a config file overriding the default.  


<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
