### PR TITLE
Fix crash when group workspace is validated by ReflectometryBackgroundSubtraction

### DIFF
--- a/Framework/Reflectometry/src/ReflectometryBackgroundSubtraction.cpp
+++ b/Framework/Reflectometry/src/ReflectometryBackgroundSubtraction.cpp
@@ -293,7 +293,7 @@ std::map<std::string, std::string> ReflectometryBackgroundSubtraction::validateI
   Indexing::SpectrumIndexSet indexSet;
   try {
     indexSet = *indexProp;
-  } catch (std::runtime_error &e) {
+  } catch (std::runtime_error const &e) {
     // This can except unhandled when the input workspace is the wrong type. So just add an error instead.
     errors["InputWorkspace"] = e.what();
   }

--- a/Framework/Reflectometry/src/ReflectometryBackgroundSubtraction.cpp
+++ b/Framework/Reflectometry/src/ReflectometryBackgroundSubtraction.cpp
@@ -290,7 +290,13 @@ std::map<std::string, std::string> ReflectometryBackgroundSubtraction::validateI
 
   MatrixWorkspace_const_sptr inputWS = getProperty("InputWorkspace");
   auto indexProp = dynamic_cast<IndexProperty *>(getPointerToProperty("ProcessingInstructions"));
-  Indexing::SpectrumIndexSet indexSet = *indexProp;
+  Indexing::SpectrumIndexSet indexSet;
+  try {
+    indexSet = *indexProp;
+  } catch (std::runtime_error &e) {
+    // This can except unhandled when the input workspace is the wrong type. So just add an error instead.
+    errors["InputWorkspace"] = e.what();
+  }
   const std::string backgroundType = getProperty("BackgroundCalculationMethod");
 
   if (inputWS) {

--- a/Framework/Reflectometry/test/ReflectometryBackgroundSubtractionTest.py
+++ b/Framework/Reflectometry/test/ReflectometryBackgroundSubtractionTest.py
@@ -152,6 +152,18 @@ class ReflectometryBackgroundSubtractionTest(unittest.TestCase):
                 'OutputWorkspace': 'output'}
         self._assert_run_algorithm_throws(args)
 
+    def test_validateInputs(self):
+        group = mantid.api.WorkspaceGroup()
+        mtd['group'] = group
+        args = {'InputWorkspace' : 'group',
+                'BackgroundCalculationMethod' : 'PerDetectorAverage',
+                'OutputWorkspace': 'output'}
+        alg = create_algorithm('ReflectometryBackgroundSubtraction', **args)
+        error_map = alg.validateInputs()
+        self.assertEqual(len(error_map), 1)
+        self.assertEqual(error_map['InputWorkspace'], "Invalid workspace type provided to IndexProperty. "
+                                                      "Must be convertible to MatrixWorkspace.")
+
     def _assert_run_algorithm_succeeds(self, args):
         """ Run the algorithm with the given args and check it succeeds """
         alg = create_algorithm('ReflectometryBackgroundSubtraction', **args)

--- a/docs/source/release/v6.4.0/Reflectometry/Bugfixes/33627.rst
+++ b/docs/source/release/v6.4.0/Reflectometry/Bugfixes/33627.rst
@@ -1,0 +1,1 @@
+- Workbench will no longer crash if ReflectometryBackgroundSubtraction is run with a group workspace when using the Algorithm dialog.


### PR DESCRIPTION
**Description of work.**
When validating inputs the conversion of the index property to an index
set was causing unhandled exceptions that could crash mantid if run and
would interfere with the doc tests if not. This adds a catch for that
behaviour and also warns the user that they may not use a group
workspace for this algorithm (in the dialogue anyway, running from a script automatically converts group workspaces to re-run the algorithm for each member, so gets around the issue. This should probably be remedied at some point to have consistent behaviour, but is outside the scope of this PR and certainly not this close to release).

**To test:**

1. Put an empty group workspace in the ADS:
```
from mantid import api
groupws = api.WorkspaceGroup()
mtd['group'] = groupws
```
2. Open the ReflectometryBackgroundSubtraction dialogue 
3. It should open cleanly
4. Hit run with the group selected as the input workspace
5. The InputWorkspace property should be highlighted with an error

Fixes #33627 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
