### PR TITLE
Preventing a memory leak using weak pointers in ADS.

### DIFF
--- a/Framework/PythonInterface/mantid/api/src/Exports/AnalysisDataService.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/AnalysisDataService.cpp
@@ -10,8 +10,10 @@
 #include "MantidPythonInterface/core/Converters/ToPyList.h"
 #include "MantidPythonInterface/core/DataServiceExporter.h"
 #include "MantidPythonInterface/core/GetPointer.h"
+#include "MantidPythonInterface/core/WeakPtr.h"
 
 #include <boost/python/enum.hpp>
+
 #include <boost/python/list.hpp>
 #include <boost/python/overloads.hpp>
 #include <boost/python/return_value_policy.hpp>
@@ -49,6 +51,17 @@ AnalysisDataServiceImpl &instance() {
  * @param unrollGroups If true unroll the workspace groups
  * @return a python list of the workspaces in the ADS
  */
+
+// list retrieveWorkspaces(AnalysisDataServiceImpl const *const self, const list &names, bool unrollGroups = false) {
+//  using WeakPtr = std::weak_ptr<Workspace>;
+//  const auto wsSharedPtrs =
+//      self->retrieveWorkspaces(Converters::PySequenceToVector<std::string>(names)(), unrollGroups);
+//      std::vector<WeakPtr> wsWeakPtrs;
+//  std::transform(wsSharedPtrs.begin(), wsSharedPtrs.end(), std::back_inserter(wsWeakPtrs),
+//                     [](const Workspace_sptr wksp) -> WeakPtr { return WeakPtr(wksp); });
+//      return Converters::ToPyList<WeakPtr>()(wsWeakPtrs);
+//}
+
 list retrieveWorkspaces(AnalysisDataServiceImpl const *const self, const list &names, bool unrollGroups = false) {
   return Converters::ToPyList<Workspace_sptr>()(
       self->retrieveWorkspaces(Converters::PySequenceToVector<std::string>(names)(), unrollGroups));

--- a/Framework/PythonInterface/mantid/api/src/Exports/AnalysisDataService.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/AnalysisDataService.cpp
@@ -57,7 +57,8 @@ list retrieveWorkspaces(AnalysisDataServiceImpl const *const self, const list &n
   const auto wsSharedPtrs =
       self->retrieveWorkspaces(Converters::PySequenceToVector<std::string>(names)(), unrollGroups);
   std::vector<WeakPtr> wsWeakPtrs;
-  std::transform(wsSharedPtrs.begin(), wsSharedPtrs.end(), std::back_inserter(wsWeakPtrs),
+  wsWeakPtrs.reserve(wsSharedPtrs.size());
+  std::transform(wsSharedPtrs.cbegin(), wsSharedPtrs.cend(), std::back_inserter(wsWeakPtrs),
                  [](const Workspace_sptr &wksp) -> WeakPtr { return WeakPtr(wksp); });
   return Converters::ToPyList<WeakPtr>()(wsWeakPtrs);
 }

--- a/Framework/PythonInterface/mantid/api/src/Exports/AnalysisDataService.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/AnalysisDataService.cpp
@@ -52,19 +52,14 @@ AnalysisDataServiceImpl &instance() {
  * @return a python list of the workspaces in the ADS
  */
 
-// list retrieveWorkspaces(AnalysisDataServiceImpl const *const self, const list &names, bool unrollGroups = false) {
-//  using WeakPtr = std::weak_ptr<Workspace>;
-//  const auto wsSharedPtrs =
-//      self->retrieveWorkspaces(Converters::PySequenceToVector<std::string>(names)(), unrollGroups);
-//      std::vector<WeakPtr> wsWeakPtrs;
-//  std::transform(wsSharedPtrs.begin(), wsSharedPtrs.end(), std::back_inserter(wsWeakPtrs),
-//                     [](const Workspace_sptr wksp) -> WeakPtr { return WeakPtr(wksp); });
-//      return Converters::ToPyList<WeakPtr>()(wsWeakPtrs);
-//}
-
 list retrieveWorkspaces(AnalysisDataServiceImpl const *const self, const list &names, bool unrollGroups = false) {
-  return Converters::ToPyList<Workspace_sptr>()(
-      self->retrieveWorkspaces(Converters::PySequenceToVector<std::string>(names)(), unrollGroups));
+  using WeakPtr = std::weak_ptr<Workspace>;
+  const auto wsSharedPtrs =
+      self->retrieveWorkspaces(Converters::PySequenceToVector<std::string>(names)(), unrollGroups);
+  std::vector<WeakPtr> wsWeakPtrs;
+  std::transform(wsSharedPtrs.begin(), wsSharedPtrs.end(), std::back_inserter(wsWeakPtrs),
+                 [](const Workspace_sptr &wksp) -> WeakPtr { return WeakPtr(wksp); });
+  return Converters::ToPyList<WeakPtr>()(wsWeakPtrs);
 }
 
 GNU_DIAG_OFF("unused-local-typedef")

--- a/Framework/PythonInterface/test/python/mantid/api/AnalysisDataServiceTest.py
+++ b/Framework/PythonInterface/test/python/mantid/api/AnalysisDataServiceTest.py
@@ -38,8 +38,8 @@ class AnalysisDataServiceTest(unittest.TestCase):
         """
             Run create workspace storing the output in the named workspace
         """
-        data = [1.0,2.0,3.0]
-        alg = run_algorithm('CreateWorkspace',DataX=data,DataY=data,NSpec=1,UnitX='Wavelength', child=True)
+        data = [1.0, 2.0, 3.0]
+        alg = run_algorithm('CreateWorkspace', DataX=data, DataY=data, NSpec=1, UnitX='Wavelength', child=True)
         AnalysisDataService.addOrReplace(wsname, alg.getProperty("OutputWorkspace").value)
 
     def test_contains(self):
@@ -66,16 +66,16 @@ class AnalysisDataServiceTest(unittest.TestCase):
         self.assertEqual(len(AnalysisDataService), current_len - 1)
 
     def test_add_raises_error_if_name_exists(self):
-        data = [1.0,2.0,3.0]
-        alg = run_algorithm('CreateWorkspace',DataX=data,DataY=data,NSpec=1,UnitX='Wavelength', child=True)
+        data = [1.0, 2.0, 3.0]
+        alg = run_algorithm('CreateWorkspace', DataX=data, DataY=data, NSpec=1, UnitX='Wavelength', child=True)
         name = "testws"
         ws = alg.getProperty("OutputWorkspace").value
         AnalysisDataService.addOrReplace(name, ws)
         self.assertRaises(RuntimeError, AnalysisDataService.add, name, ws)
 
     def test_addOrReplace_replaces_workspace_with_existing_name(self):
-        data = [1.0,2.0,3.0]
-        alg = run_algorithm('CreateWorkspace',DataX=data,DataY=data,NSpec=1,UnitX='Wavelength', child=True)
+        data = [1.0, 2.0, 3.0]
+        alg = run_algorithm('CreateWorkspace', DataX=data, DataY=data, NSpec=1, UnitX='Wavelength', child=True)
         name = "testws"
         ws = alg.getProperty("OutputWorkspace").value
         AnalysisDataService.add(name, ws)
@@ -136,7 +136,7 @@ class AnalysisDataServiceTest(unittest.TestCase):
         ws_handle = AnalysisDataService[wsname]
         succeeded = False
         try:
-            ws_handle.id() # Should be okay
+            ws_handle.id()  # Should be okay
             succeeded = True
         except RuntimeError:
             pass
@@ -200,6 +200,24 @@ class AnalysisDataServiceTest(unittest.TestCase):
 
         self.assertEqual(group.size(), 2)
         self.assertCountEqual(group.getNames(), ["ws1", "ws2"])
+
+    def test_retrieve_workspaces_uses_weak_ptrs(self):
+        ws_names = ["test_retrieve_workspaces_1", "test_retrieve_workspaces_2"]
+        for name in ws_names:
+            self._run_createws(name)
+        workspaces = AnalysisDataService.retrieveWorkspaces(ws_names)
+        self.assertEqual(len(workspaces), 2)
+
+        AnalysisDataService.remove(ws_names[0])
+        # even though workspace has been deleted this should not affect workspaces size
+        self.assertEqual(len(workspaces), 2)
+
+        # check that the second workspace pointer in workspaces exists and can be used
+        str(workspaces[1])
+
+        # if a weak pointer has been used we expect a RuntimeError. Any other pointer will result in a different error
+        with self.assertRaises(RuntimeError):
+            str(workspaces[0])
 
 
 if __name__ == '__main__':

--- a/docs/source/release/v6.4.0/Workbench/Bugfixes/33802.rst
+++ b/docs/source/release/v6.4.0/Workbench/Bugfixes/33802.rst
@@ -1,0 +1,1 @@
+- Fixed a memory leak whereby copies of workspaces were being retained even though the workspace had been deleted.


### PR DESCRIPTION
**Description of work.**
Part of the work to try and stop a memory leak. This was initially noted using SliceViewer but further investigation showed problems with plotting and other actions. This PR changes the retrieveal of workspaces method to produce a list of weak pointers to ensure copies of workspaces are not left after deleting them from the ADS.

**To test:**

1. By checking the new unit test passes
2. By checking the memory (see below)

On the main branch (not this PR branch):
1. Open Mantid and load a dataset of your choice.
2. Make a plot from the resulting workspace via the right click menu (do not do this as a script!)
3. Close the plot and delete the workspace (use the button not a script)
4. repeat steps 2 and 3 with another two different datasets to the one previously used
5. Find out how much memory is being used by the python executable before closing Mantid

On this PR branch
Repeat steps 1-5 of the above - making sure you use the same files and do the same plots. The memory usage should be smaller than when doing this on the main branch.

Fixes #33662 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
