### PR TITLE
Add C++ SipTest disabled on Apple

### DIFF
--- a/qt/widgets/common/CMakeLists.txt
+++ b/qt/widgets/common/CMakeLists.txt
@@ -821,6 +821,7 @@ set(QT5_TEST_FILES
     test/QtJSONUtilsTest.h
     test/RepoModelTest.h
     test/ParseKeyValueStringTest.h
+    test/Python/SipTest.h
     test/Batch/BuildSubtreeItemsTest.h
     test/Batch/ExtractSubtreesTest.h
     test/Batch/FindSubtreeRootsTest.h
@@ -831,10 +832,6 @@ set(QT5_TEST_FILES
     test/WorkspacePresenter/ADSAdapterTest.h
     test/WorkspacePresenter/WorkspacePresenterTest.h
 )
-
-if(NOT APPLE)
-  list(APPEND QT5_TEST_FILES test/Python/SipTest.h)
-endif()
 
 if(MANTID_FRAMEWORK_LIB STREQUAL "BUILD")
   mtd_add_qt_tests(


### PR DESCRIPTION
**Description of work.**

The test passes under Conda so we should keep it.

It also fixes the [Conda tests](https://builds.mantidproject.org/job/main_nightly_deployment_prototype/310/testReport/projectroot.qt.widgets/common/Build_and_test___platform__macos___MantidQtWidgetsCommonTestQt5_ExtractSubtreesTest/) on macOS. Once re-enabled the pipeline spotted that the tests did not run due to a symbol error. The library is linked to boost::python but our code made no use of Python API directly so the linker dropped the symbols. Enabling this causes the compiler to spot that we are now using Python so keeps the link to the Python dylib.

**To test:**

* In a conda environment on macOS run any MantidQtWidgetsCommon test:

```ctest -R MantidQtWidgetsCommon```

and they should pass.

*There is no associated issue.*

*This does not require release notes* because **it is an internal change.**

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
