### PR TITLE
Fix WISHProcessVanadiumforNormalisationTest

### DIFF
--- a/Testing/SystemTests/tests/framework/ISIS_WISHSingleCrystalReduction.py
+++ b/Testing/SystemTests/tests/framework/ISIS_WISHSingleCrystalReduction.py
@@ -162,7 +162,7 @@ class WISHProcessVanadiumForNormalisationTest(MantidSystemTest):
         # correct Vanadium run for absorption
         van = Divide(LHSWorkspace=van, RHSWorkspace=abs_cor, OutputWorkspace=van)
         # smooth data
-        SmoothNeighbours(InputWorkspace=van, OutputWorkspace=van, Radius=3, NumberOfNeighbours=6)
+        van = SmoothNeighbours(InputWorkspace=van, OutputWorkspace=van, Radius=3, NumberOfNeighbours=6)
         SmoothData(InputWorkspace=van, OutputWorkspace=van, NPoints=300)
 
     def validate(self):


### PR DESCRIPTION
**Description of work.**
Recent changes to SmoothNeighbours algorithm (see #33790) exposed an issue with the WISHProcessVanadiumForNormalisationTest that made use of the memory leak for the test to work. By making a small change (assigning the output to a variable) this has fixed the test.

High priority as blocking nightly builds.

**To test:**

Tests should pass.

*There is no associated issue.*

This does not require release notes because it is _an update to a system test and therefore not user facing_.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
