### PR TITLE
Update muon plots for new matplotlib

### DIFF
--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/plot_widget/plotting_canvas/plot_toolbar.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/plot_widget/plotting_canvas/plot_toolbar.py
@@ -77,79 +77,24 @@ class PlotToolbar(MantidNavigationToolbar):
         self.is_minor_grid_on = False
         self.is_major_grid_on = False
 
-    def zoom(self, *args):
-        """Activate zoom to rect mode."""
-        if self._active == 'ZOOM':
-            self._active = None
+    def _update_buttons_checked(self):
+        # sync button checkstates to match active mode
+        pan_or_zoom_checked = False
+        if 'pan' in self._actions:
+            self._actions['pan'].setChecked(self._get_mode() == 'PAN' or self._get_mode() == 'pan/zoom'  )
+        if 'zoom' in self._actions:
+            self._actions['zoom'].setChecked(self._get_mode()  == 'ZOOM' or self._get_mode() == 'zoom rect' )
+        pan_or_zoom_checked = self._actions['pan'].isChecked() or self._actions['zoom'].isChecked()
+        self._send_notifiers(pan_or_zoom_checked)
+
+    def _send_notifiers(self, is_checked):
+        print(is_checked)
+        if is_checked:
+            self.disable_autoscale_notifier.notify_subscribers()
+            self.uncheck_autoscale_notifier.notify_subscribers()
+        else:
             self.enable_autoscale_notifier.notify_subscribers()
             self.range_changed_notifier.notify_subscribers()
-
-        else:
-            self.uncheck_autoscale_notifier.notify_subscribers()
-            self.disable_autoscale_notifier.notify_subscribers()
-            self._active = 'ZOOM'
-
-        if self._idPress is not None:
-            self._idPress = self.canvas.mpl_disconnect(self._idPress)
-            self.mode = ''
-
-        if self._idRelease is not None:
-            self._idRelease = self.canvas.mpl_disconnect(self._idRelease)
-            self.mode = ''
-
-        if self._active:
-            self._idPress = self.canvas.mpl_connect('button_press_event',
-                                                    self.press_zoom)
-            self._idRelease = self.canvas.mpl_connect('button_release_event',
-                                                      self.release_zoom)
-            self.mode = 'zoom rect'
-            self.canvas.widgetlock(self)
-        else:
-            self.canvas.widgetlock.release(self)
-
-        for axes in self.canvas.figure.get_axes():
-            axes.set_navigate_mode(self._active)
-
-        self._update_buttons_checked()
-        self.set_message(self.mode)
-
-    def pan(self, *args):
-        """Activate the pan/zoom tool. pan with left button, zoom with right"""
-        # set the pointer icon and button press funcs to the
-        # appropriate callbacks
-
-        if self._active == 'PAN':
-            self._active = None
-            self.enable_autoscale_notifier.notify_subscribers()
-            self.range_changed_notifier.notify_subscribers()
-
-        else:
-            self.uncheck_autoscale_notifier.notify_subscribers()
-            self.disable_autoscale_notifier.notify_subscribers()
-            self._active = 'PAN'
-        if self._idPress is not None:
-            self._idPress = self.canvas.mpl_disconnect(self._idPress)
-            self.mode = ''
-
-        if self._idRelease is not None:
-            self._idRelease = self.canvas.mpl_disconnect(self._idRelease)
-            self.mode = ''
-
-        if self._active:
-            self._idPress = self.canvas.mpl_connect(
-                'button_press_event', self.press_pan)
-            self._idRelease = self.canvas.mpl_connect(
-                'button_release_event', self.release_pan)
-            self.mode = 'pan/zoom'
-            self.canvas.widgetlock(self)
-        else:
-            self.canvas.widgetlock.release(self)
-
-        for axes in self.canvas.figure.get_axes():
-            axes.set_navigate_mode(self._active)
-
-        self._update_buttons_checked()
-        self.set_message(self.mode)
 
     def home(self, *args):
         """Restore the original view."""

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/plot_widget/plotting_canvas/plot_toolbar.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/plot_widget/plotting_canvas/plot_toolbar.py
@@ -88,7 +88,6 @@ class PlotToolbar(MantidNavigationToolbar):
         self._send_notifiers(pan_or_zoom_checked)
 
     def _send_notifiers(self, is_checked):
-        print(is_checked)
         if is_checked:
             self.disable_autoscale_notifier.notify_subscribers()
             self.uncheck_autoscale_notifier.notify_subscribers()


### PR DESCRIPTION
**Description of work.**

Matplotlib implementation changed in 3.3 so the self._active variable no longer exists. This causes the muon plotting zoom and pan buttons to no longer work. This fixes that.

**To test:**

<!-- Instructions for testing. -->
Open muon analysis
Load some data (which is irrelevant)
Press the zoom button on the toolbar
Check that autoscale is unchecked and unselectable
select a zoom region on the plot
Press the zoom button
The x and y values under stated under the plot should match what is shown
The autoscale checkbox should be selectable

Repeat the above, but press pan instead of zoom.

Fixes #32895. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->

There is no release note as this does not alter any user functionality. 

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
