### PR TITLE
Modify some variables names to clarify summed empty instrument

### DIFF
--- a/scripts/Diffraction/isis_powder/gem_routines/gem_algs.py
+++ b/scripts/Diffraction/isis_powder/gem_routines/gem_algs.py
@@ -32,13 +32,13 @@ def get_run_details(run_number_string, inst_settings, is_vanadium_run):
     grouping_file_name = inst_settings.grouping_file_name
     if inst_settings.texture_mode:
         return create_run_details_object(run_number_string=run_number_string, inst_settings=inst_settings,
-                                         is_vanadium_run=is_vanadium_run, empty_run_number=empty_runs,
+                                         is_vanadium_run=is_vanadium_run, empty_inst_run_number=empty_runs,
                                          grouping_file_name=grouping_file_name, vanadium_string=vanadium_runs,
                                          splined_name_list=["texture_mode"])
 
     return create_run_details_object(run_number_string=run_number_string, inst_settings=inst_settings,
 
-                                     is_vanadium_run=is_vanadium_run, empty_run_number=empty_runs,
+                                     is_vanadium_run=is_vanadium_run, empty_inst_run_number=empty_runs,
                                      grouping_file_name=grouping_file_name, vanadium_string=vanadium_runs)
 
 

--- a/scripts/Diffraction/isis_powder/hrpd_routines/hrpd_algs.py
+++ b/scripts/Diffraction/isis_powder/hrpd_routines/hrpd_algs.py
@@ -95,7 +95,7 @@ def get_run_details(run_number_string, inst_settings, is_vanadium):
     grouping_file_name = inst_settings.grouping_file_name
 
     return create_run_details_object(run_number_string=run_number_string, inst_settings=inst_settings,
-                                     is_vanadium_run=is_vanadium, empty_run_number=empty_run,
+                                     is_vanadium_run=is_vanadium, empty_inst_run_number=empty_run,
                                      vanadium_string=vanadium_run, grouping_file_name=grouping_file_name)
 
 

--- a/scripts/Diffraction/isis_powder/pearl_routines/pearl_algs.py
+++ b/scripts/Diffraction/isis_powder/pearl_routines/pearl_algs.py
@@ -123,7 +123,7 @@ def get_run_details(run_number_string, inst_settings, is_vanadium_run):
 
     return create_run_details_object(run_number_string=run_number_string, inst_settings=inst_settings,
                                      is_vanadium_run=is_vanadium_run, splined_name_list=spline_identifier,
-                                     grouping_file_name=grouping_file_name, empty_run_number=empty_runs,
+                                     grouping_file_name=grouping_file_name, empty_inst_run_number=empty_runs,
                                      vanadium_string=vanadium_runs, van_abs_file_name=inst_settings.van_absorb_file)
 
 

--- a/scripts/Diffraction/isis_powder/polaris_routines/polaris_algs.py
+++ b/scripts/Diffraction/isis_powder/polaris_routines/polaris_algs.py
@@ -58,7 +58,7 @@ def get_run_details(run_number_string, inst_settings, is_vanadium_run):
     grouping_file_name = inst_settings.grouping_file_name
 
     return create_run_details_object(run_number_string=run_number_string, inst_settings=inst_settings,
-                                     is_vanadium_run=is_vanadium_run, empty_run_number=empty_runs,
+                                     is_vanadium_run=is_vanadium_run, empty_inst_run_number=empty_runs,
                                      vanadium_string=vanadium_runs, grouping_file_name=grouping_file_name)
 
 

--- a/scripts/Diffraction/isis_powder/routines/calibrate.py
+++ b/scripts/Diffraction/isis_powder/routines/calibrate.py
@@ -27,11 +27,11 @@ def create_van(instrument, run_details, absorb):
 
     instrument.create_solid_angle_corrections(input_van_ws, run_details)
 
-    if not (run_details.empty_runs is None):
-        summed_empty = common.generate_summed_runs(empty_sample_ws_string=run_details.empty_runs,
-                                                   instrument=instrument)
-        mantid.SaveNexus(Filename=run_details.summed_empty_file_path, InputWorkspace=summed_empty)
-        corrected_van_ws = common.subtract_summed_runs(ws_to_correct=input_van_ws, empty_sample=summed_empty)
+    if not (run_details.empty_inst_runs is None):
+        summed_empty_inst = common.generate_summed_runs(empty_sample_ws_string=run_details.empty_inst_runs,
+                                                        instrument=instrument)
+        mantid.SaveNexus(Filename=run_details.summed_empty_inst_file_path, InputWorkspace=summed_empty_inst)
+        corrected_van_ws = common.subtract_summed_runs(ws_to_correct=input_van_ws, empty_sample=summed_empty_inst)
 
     # Crop the tail end of the data on PEARL if they are not capturing slow neutrons
     corrected_van_ws = instrument._crop_raw_to_expected_tof_range(ws_to_crop=corrected_van_ws)

--- a/scripts/Diffraction/isis_powder/routines/focus.py
+++ b/scripts/Diffraction/isis_powder/routines/focus.py
@@ -34,17 +34,17 @@ def _focus_one_ws(input_workspace, run_number, instrument, perform_vanadium_norm
 
     # Subtract empty instrument runs, as long as this run isn't an empty, user hasn't turned empty subtraction off, or
     # The user has not supplied a sample empty
-    is_run_empty = common.runs_overlap(run_number, run_details.empty_runs)
+    is_run_empty = common.runs_overlap(run_number, run_details.empty_inst_runs)
     summed_empty = None
     if not is_run_empty and instrument.should_subtract_empty_inst() and not run_details.sample_empty:
-        if os.path.isfile(run_details.summed_empty_file_path):
-            logger.warning('Pre-summed empty instrument workspace found at ' + run_details.summed_empty_file_path)
-            summed_empty = mantid.LoadNexus(Filename=run_details.summed_empty_file_path)
+        if os.path.isfile(run_details.summed_empty_inst_file_path):
+            logger.warning('Pre-summed empty instrument workspace found at ' + run_details.summed_empty_inst_file_path)
+            summed_empty = mantid.LoadNexus(Filename=run_details.summed_empty_inst_file_path)
         else:
-            summed_empty = common.generate_summed_runs(empty_sample_ws_string=run_details.empty_runs,
+            summed_empty = common.generate_summed_runs(empty_sample_ws_string=run_details.empty_inst_runs,
                                                        instrument=instrument)
     elif run_details.sample_empty:
-        # Subtract a sample empty if specified
+        # Subtract a sample empty if specified ie empty can
         summed_empty = common.generate_summed_runs(empty_sample_ws_string=run_details.sample_empty,
                                                    instrument=instrument,
                                                    scale_factor=instrument._inst_settings.sample_empty_scale)

--- a/scripts/Diffraction/isis_powder/routines/run_details.py
+++ b/scripts/Diffraction/isis_powder/routines/run_details.py
@@ -8,7 +8,7 @@ from isis_powder.routines import common, yaml_parser
 import os
 
 
-def create_run_details_object(run_number_string, inst_settings, is_vanadium_run, empty_run_number,
+def create_run_details_object(run_number_string, inst_settings, is_vanadium_run, empty_inst_run_number,
                               grouping_file_name, vanadium_string, splined_name_list=None, van_abs_file_name=None):
     """
     Creates and returns a run details object which holds various
@@ -16,7 +16,7 @@ def create_run_details_object(run_number_string, inst_settings, is_vanadium_run,
     :param run_number_string: The user string for the current run
     :param inst_settings: The current instrument object
     :param is_vanadium_run: Boolean of if the current run is a vanadium run
-    :param empty_run_number: Empty run number(s) from mapping file
+    :param empty_inst_run_number: Empty instrument run number(s) from mapping file
     :param grouping_file_name: Filename of the grouping file found in the calibration folder
     :param vanadium_string: Vanadium run number(s) from mapping file
     :param splined_name_list: (Optional) List of unique properties to generate a splined vanadium name from
@@ -40,7 +40,7 @@ def create_run_details_object(run_number_string, inst_settings, is_vanadium_run,
     splined_van_name = common.generate_splined_name(vanadium_string, new_splined_list)
     unsplined_van_name = common.generate_unsplined_name(vanadium_string, new_splined_list)
 
-    summed_empty_name = common.generate_summed_empty_name(empty_run_number, new_splined_list)
+    summed_empty_inst_name = common.generate_summed_empty_name(empty_inst_run_number, new_splined_list)
 
     if is_vanadium_run:
         # The run number should be the vanadium number in this case
@@ -72,15 +72,15 @@ def create_run_details_object(run_number_string, inst_settings, is_vanadium_run,
     splined_van_path = os.path.join(van_paths, splined_van_name)
     unsplined_van_path = os.path.join(van_paths, unsplined_van_name)
     van_absorb_path = os.path.join(calibration_dir, van_abs_file_name) if van_abs_file_name else None
-    summed_empty_path = os.path.join(van_paths, summed_empty_name)
+    summed_empty_inst_path = os.path.join(van_paths, summed_empty_inst_name)
 
-    return _RunDetails(empty_run_number=empty_run_number, file_extension=file_extension,
+    return _RunDetails(empty_inst_run_number=empty_inst_run_number, file_extension=file_extension,
                        run_number=run_number, output_run_string=output_run_string, label=label,
                        offset_file_path=offset_file_path, grouping_file_path=grouping_file_path,
                        splined_vanadium_path=splined_van_path, vanadium_run_number=vanadium_string,
                        sample_empty=sample_empty, vanadium_abs_path=van_absorb_path,
                        unsplined_vanadium_path=unsplined_van_path, output_suffix=suffix,van_paths=van_paths,
-                       summed_empty_path=summed_empty_path)
+                       summed_empty_inst_path=summed_empty_inst_path)
 
 
 def get_cal_mapping_dict(run_number_string, cal_mapping_path):
@@ -96,13 +96,13 @@ class _RunDetails(object):
     This class holds the full file paths associated with each run and various other useful attributes
     """
 
-    def __init__(self, empty_run_number, file_extension, run_number, output_run_string, label,
+    def __init__(self, empty_inst_run_number, file_extension, run_number, output_run_string, label,
                  offset_file_path, grouping_file_path, splined_vanadium_path, vanadium_run_number,
                  sample_empty, vanadium_abs_path, unsplined_vanadium_path, output_suffix,van_paths,
-                 summed_empty_path):
+                 summed_empty_inst_path):
 
         # Essential attribute
-        self.empty_runs = empty_run_number
+        self.empty_inst_runs = empty_inst_run_number
         self.run_number = run_number
         self.output_run_string = output_run_string
 
@@ -113,7 +113,7 @@ class _RunDetails(object):
 
         self.splined_vanadium_file_path = splined_vanadium_path
         self.unsplined_vanadium_file_path = unsplined_vanadium_path
-        self.summed_empty_file_path = summed_empty_path
+        self.summed_empty_inst_file_path = summed_empty_inst_path
         self.vanadium_run_numbers = vanadium_run_number
 
         # Optional

--- a/scripts/Diffraction/isis_powder/test/ISISPowderAbstractInstrumentTest.py
+++ b/scripts/Diffraction/isis_powder/test/ISISPowderAbstractInstrumentTest.py
@@ -187,7 +187,7 @@ class ISISPowderAbstractInstrumentTest(unittest.TestCase):
             inst_settings=mock_inst._inst_settings,
             is_vanadium_run=False,
             grouping_file_name=grouping_filename,
-            empty_run_number=empty_runs,
+            empty_inst_run_number=empty_runs,
             vanadium_string=vanadium_runs)
 
         return mock_inst, run_details_obj, out_dir

--- a/scripts/Diffraction/isis_powder/test/ISISPowderRunDetailsTest.py
+++ b/scripts/Diffraction/isis_powder/test/ISISPowderRunDetailsTest.py
@@ -54,9 +54,9 @@ class ISISPowderInstrumentRunDetailsTest(unittest.TestCase):
 
         output_obj = run_details.create_run_details_object(run_number_string=run_number_string, inst_settings=mock_inst,
                                                            is_vanadium_run=False, grouping_file_name=grouping_filename,
-                                                           empty_run_number=empty_runs, vanadium_string=vanadium_runs)
+                                                           empty_inst_run_number=empty_runs, vanadium_string=vanadium_runs)
 
-        self.assertEqual(output_obj.empty_runs, expected_empty_runs)
+        self.assertEqual(output_obj.empty_inst_runs, expected_empty_runs)
         self.assertEqual(output_obj.grouping_file_path,
                          os.path.join(mock_inst.calibration_dir, mock_inst.grouping_file_name))
         expected_file_ext = mock_inst.file_extension
@@ -68,7 +68,7 @@ class ISISPowderInstrumentRunDetailsTest(unittest.TestCase):
         self.assertEqual(output_obj.output_run_string, run_number_string)
         self.assertEqual(output_obj.run_number, 17)
         self.assertEqual(output_obj.vanadium_run_numbers, expected_vanadium_runs)
-        self.assertEqual(output_obj.summed_empty_file_path,
+        self.assertEqual(output_obj.summed_empty_inst_file_path,
                          os.path.join(mock_inst.calibration_dir, expected_label,
                                       common.generate_summed_empty_name(expected_empty_runs,
                                                                         expected_offset_file_name)))
@@ -89,7 +89,7 @@ class ISISPowderInstrumentRunDetailsTest(unittest.TestCase):
 
         output_obj = run_details.create_run_details_object(run_number_string=run_number_string, inst_settings=mock_inst,
                                                            is_vanadium_run=True, grouping_file_name=grouping_filename,
-                                                           empty_run_number=empty_runs, vanadium_string=vanadium_runs)
+                                                           empty_inst_run_number=empty_runs, vanadium_string=vanadium_runs)
 
         self.assertEqual(expected_vanadium_runs, output_obj.run_number)
         self.assertEqual(output_obj.vanadium_run_numbers, output_obj.run_number)
@@ -111,7 +111,7 @@ class ISISPowderInstrumentRunDetailsTest(unittest.TestCase):
         output_obj = run_details.create_run_details_object(run_number_string, inst_settings=mock_inst,
                                                            is_vanadium_run=False, splined_name_list=splined_name_list,
                                                            grouping_file_name=grouping_filename,
-                                                           empty_run_number=empty_runs, vanadium_string=vanadium_runs)
+                                                           empty_inst_run_number=empty_runs, vanadium_string=vanadium_runs)
 
         expected_splined_out_str = ''.join('_' + val for val in splined_name_list)
         expected_output_name = "VanSplined_" + expected_vanadium_runs + expected_splined_out_str


### PR DESCRIPTION
**Description of work.**

The ISIS Powder scripts handle runs which are measurements taken with an empty instrument (no sample, no can) and other runs which are measurements taken with an empty can. The variable naming didn't make it very clear which was which

I've added an "inst" string to some variable names to make this more clear. There should be no functional change

**To test:**

Code review only. The automated tests will ensure I've not broken anything

*There is no associated issue.*

*This does not require release notes* because **there's no change in functionality**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
