### PR TITLE
Use re compile for regex strings in CrystalField

### DIFF
--- a/scripts/Inelastic/CrystalField/CrystalFieldMultiSite.py
+++ b/scripts/Inelastic/CrystalField/CrystalFieldMultiSite.py
@@ -33,7 +33,7 @@ def makeWorkspace(xArray, yArray, child=True, ws_name='dummy'):
 
 def get_parameters_for_add(cf, new_ion_index):
     """get params from crystalField object to append"""
-    ion_prefix = 'ion{}.'.format(new_ion_index)
+    ion_prefix = f'ion{new_ion_index}.'
     return get_parameters(cf, ion_prefix, '')
 
 
@@ -41,8 +41,8 @@ def get_parameters_for_add_from_multisite(cfms, new_ion_index):
     """get params from crystalFieldMultiSite object to append"""
     params = {}
     for i in range(len(cfms.Ions)):
-        ion_prefix = 'ion{}.'.format(new_ion_index + i)
-        existing_prefix = 'ion{}.'.format(i) if cfms._isMultiSite() else ''
+        ion_prefix = f'ion{new_ion_index + i}.'
+        existing_prefix = f'ion{i}.' if cfms._isMultiSite() else ''
         params.update(get_parameters(cfms, ion_prefix, existing_prefix))
     return params
 
@@ -143,14 +143,14 @@ class CrystalFieldMultiSite(object):
             ws = arg2
             ws_index = 0
             if self.Temperatures[i] < 0:
-                raise RuntimeError('You must first define a valid temperature for spectrum {}'.format(i))
+                raise RuntimeError(f'You must first define a valid temperature for spectrum {i}')
         elif isinstance(arg2, int):
             i = 0
             ws = arg1
             ws_index = arg2
         else:
-            raise TypeError('expected int for one argument in GetSpectrum, got {0} and {1}'.format(
-                arg1.__class__.__name__, arg2.__class__.__name__))
+            raise TypeError(f'expected int for one argument in GetSpectrum, got {arg1.__class__.__name__} and '
+                            f'{arg2.__class__.__name__}')
 
         if isinstance(ws, list) or isinstance(ws, np.ndarray):
             ws = self._convertToWS(ws)
@@ -162,7 +162,7 @@ class CrystalFieldMultiSite(object):
         for idx in range(len(self.Ions)):
             blm = {}
             for bparam in CrystalField.CrystalField.field_parameter_names:
-                blm[bparam] = self.function.getParameterValue('ion{}.'.format(idx) + bparam)
+                blm[bparam] = self.function.getParameterValue(f'ion{idx}.' + bparam)
             _cft = CrystalField.CrystalField(self.Ions[idx], 'C1', Temperature=self.Temperatures[i], **blm)
             peaks = np.append(peaks, _cft.getPeakList()[0])
         return np.min(peaks), np.max(peaks)
@@ -250,7 +250,7 @@ class CrystalFieldMultiSite(object):
         """Create dict for ion intensity scalings"""
         if abundances is not None:
             for ion_index in range(len(self.Ions)):
-                self._abundances['ion{}'.format(ion_index)]  = abundances[ion_index]
+                self._abundances[f'ion{ion_index}']  = abundances[ion_index]
             max_ion = max(self._abundances, key=lambda key: self._abundances[key])
             ties = {}
             for ion in self._abundances.keys():
@@ -262,7 +262,7 @@ class CrystalFieldMultiSite(object):
             self.ties(ties)
         else:
             for ion_index in range(len(self.Ions)):
-                self._abundances['ion{}'.format(ion_index)]  = 1.0
+                self._abundances[f'ion{ion_index}']  = 1.0
 
     def update(self, func):
         """
@@ -302,12 +302,12 @@ class CrystalFieldMultiSite(object):
 
     def plot(self, *args):
         """Plot a spectrum. Parameters are the same as in getSpectrum(...) with additional name argument"""
-        ws_name = args[3] if len(args) == 4 else 'CrystalFieldMultiSite_{}'.format(self.Ions)
+        ws_name = args[3] if len(args) == 4 else f'CrystalFieldMultiSite_{self.Ions}'
         xArray, yArray = self.getSpectrum(*args)
         if len(args) > 0:
-            ws_name += '_{}'.format(args[0])
+            ws_name += f'_{args[0]}'
             if isinstance(args[0], int):
-                ws_name += '_{}'.format(args[1])
+                ws_name += f'_{args[1]}'
         makeWorkspace(xArray, yArray, child=False, ws_name=ws_name)
         plotSpectrum(ws_name, 0)
 
@@ -342,7 +342,7 @@ class CrystalFieldMultiSite(object):
             else:
                 raise RuntimeError('_setBackground expects peak or background arguments only')
         else:
-            raise RuntimeError('_setBackground takes 1 or 2 arguments, got {}'.format(len(kwargs)))
+            raise RuntimeError(f'_setBackground takes 1 or 2 arguments, got {len(kwargs)}')
 
     def _setSingleBackground(self, background, property_name):
         if isinstance(background, str):
@@ -352,8 +352,8 @@ class CrystalFieldMultiSite(object):
                 peak, background = str(background).split(';')
                 self._setCompositeBackground(peak, background)
             else:
-                raise ValueError("composite function passed to background must have "
-                                 "exactly 2 functions, got {}".format(len(background)))
+                raise ValueError(f"composite function passed to background must have "
+                                 f"exactly 2 functions, got {len(background)}")
         elif isinstance(background, FunctionWrapper):
             setattr(self._background, property_name, CrystalField.Function(self.function, prefix='bg.'))
             self.function.setAttributeValue('Background', str(background))
@@ -363,7 +363,7 @@ class CrystalFieldMultiSite(object):
     def _setCompositeBackground(self, peak, background):
         self._background.peak = CrystalField.Function(self.function, prefix='bg.f0.')
         self._background.background = CrystalField.Function(self.function, prefix='bg.f1.')
-        self.function.setAttributeValue('Background', '{0};{1}'.format(peak, background))
+        self.function.setAttributeValue('Background', f'{peak};{background}')
 
     def _setBackgroundUsingString(self, background, property_name):
         number_of_functions = background.count(';') + 1
@@ -374,8 +374,8 @@ class CrystalFieldMultiSite(object):
             setattr(self._background, property_name, CrystalField.Function(self.function, prefix='bg.'))
             self.function.setAttributeValue('Background', background)
         else:
-            raise ValueError("string passed to background must have exactly 1 or 2 functions, got {}".format(
-                number_of_functions))
+            raise ValueError(f"string passed to background must have exactly 1 or 2 functions, got "
+                             f"{number_of_functions}")
 
     def _combine_multisite(self, other):
         """Used to add two CrystalFieldMultiSite"""
@@ -405,8 +405,7 @@ class CrystalFieldMultiSite(object):
         elif isinstance(other, CrystalFieldMultiSite):
             return self._combine_multisite(other)
         if not isinstance(other, CrystalField.CrystalField):
-            raise TypeError('Unsupported operand type(s) for +: '
-                            'CrystalFieldMultiSite and {}'.format(other.__class__.__name__))
+            raise TypeError(f'Unsupported operand type(s) for +: CrystalFieldMultiSite and {other.__class__.__name__}')
         ions = self.Ions + [other.Ion]
         symmetries = self.Symmetries + [other.Symmetry]
         abundances = list(self._abundances.values()) + [scale_factor]
@@ -422,8 +421,7 @@ class CrystalFieldMultiSite(object):
             scale_factor = other.abundance
             other = other.crystalField
         if not isinstance(other, CrystalField.CrystalField):
-            raise TypeError('Unsupported operand type(s) for +: '
-                            'CrystalFieldMultiSite and {}'.format(other.__class__.__name__))
+            raise TypeError(f'Unsupported operand type(s) for +: CrystalFieldMultiSite and {other.__class__.__name__}')
         ions = [other.Ion] + self.Ions
         symmetries = [other.Symmetry] + self.Symmetries
         abundances = [scale_factor] + list(self._abundances.values())

--- a/scripts/Inelastic/CrystalField/fitting.py
+++ b/scripts/Inelastic/CrystalField/fitting.py
@@ -1564,7 +1564,7 @@ class CrystalFieldFit(object):
             ws_kwargs['InputWorkspace'] = self._input_workspace[0]
             i = 1
             for workspace in self._input_workspace[1:]:
-                ws_kwargs['InputWorkspace_{}'.format(i)] = workspace
+                ws_kwargs[f'InputWorkspace_{i}'] = workspace
                 i += 1
             # clean up multispectrum function to prevent problems during evaluation
             # e.g. remove FWHMX0/FWHMY0 and FWHMX1/FWHMY1

--- a/scripts/Inelastic/CrystalField/fitting.py
+++ b/scripts/Inelastic/CrystalField/fitting.py
@@ -22,6 +22,12 @@ FN_PATTERN = re.compile('f(\\d+)\\.(.+)')
 # RegEx pattern matching a composite function parameter name, eg f2.Sigma. Multi-spectrum case.
 FN_MS_PATTERN = re.compile('f(\\d+)\\.f(\\d+)\\.(.+)')
 
+CONSTRAINTS_PATTERN = re.compile(r'constraints=\((.*?)\)')
+FWHM_PATTERN = re.compile(r'FWHM[X|Y]\d+=\(\),')
+PHYSICAL_PROPERTIES_PATTERN = re.compile(r'(name=.*?,)(.*?)(PhysicalProperties=\(.*?\),)')
+TEMPERATURES_PATTERN = re.compile(r'(name=.*?,)(.*?)(Temperatures=\(.*?\),)')
+TIES_PATTERN = re.compile(r',ties=\((.*?)\)')
+
 
 def makeWorkspace(xArray, yArray):
     """Create a workspace that doesn't appear in the ADS"""
@@ -336,9 +342,9 @@ class CrystalField(object):
         return out
 
     def makeMultiSpectrumFunction(self):
-        fun = re.sub(r'FWHM[X|Y]\d+=\(\),', '', str(self.function))
-        fun = re.sub(r'(name=.*?,)(.*?)(Temperatures=\(.*?\),)',r'\1\3\2', fun)
-        fun = re.sub(r'(name=.*?,)(.*?)(PhysicalProperties=\(.*?\),)',r'\1\3\2', fun)
+        fun = re.sub(FWHM_PATTERN, '', str(self.function))
+        fun = re.sub(TEMPERATURES_PATTERN, r'\1\3\2', fun)
+        fun = re.sub(PHYSICAL_PROPERTIES_PATTERN, r'\1\3\2', fun)
         return fun
 
     @property
@@ -1072,11 +1078,11 @@ class CrystalField(object):
         return params
 
     def _getFieldTies(self):
-        ties = re.search(r',ties=\((.*?)\)', str(self.crystalFieldFunction))
+        ties = re.search(TIES_PATTERN, str(self.crystalFieldFunction))
         return re.sub(FN_PATTERN, '', ties.group(1)).rstrip(',') if ties else ''
 
     def _getFieldConstraints(self):
-        constraints = re.search(r'constraints=\((.*?)\)', str(self.crystalFieldFunction))
+        constraints = re.search(CONSTRAINTS_PATTERN, str(self.crystalFieldFunction))
         return constraints.group(1) if constraints else ''
 
     def _getPhysProp(self, ppobj, workspace, ws_index):
@@ -1433,7 +1439,7 @@ class CrystalFieldFit(object):
         if 'CrystalFieldMultiSpectrum' in fun:
             # Hack to ensure that 'PhysicalProperties' attribute is first
             # otherwise it won't set up other attributes properly
-            fun = re.sub(r'(name=.*?,)(.*?)(PhysicalProperties=\(.*?\),)',r'\1\3\2', fun)
+            fun = re.sub(PHYSICAL_PROPERTIES_PATTERN, r'\1\3\2', fun)
         alg = AlgorithmManager.createUnmanaged('EstimateFitParameters')
         alg.initialize()
         alg.setProperty('Function', fun)
@@ -1482,7 +1488,7 @@ class CrystalFieldFit(object):
             else:
                 fun = str(self._function)
         if 'CrystalFieldMultiSpectrum' in fun:
-            fun = re.sub(r'(name=.*?,)(.*?)(PhysicalProperties=\(.*?\),)',r'\1\3\2', fun)
+            fun = re.sub(PHYSICAL_PROPERTIES_PATTERN, r'\1\3\2', fun)
         alg = AlgorithmManager.createUnmanaged('Fit')
         alg.initialize()
         alg.setProperty('Function', fun)
@@ -1562,10 +1568,10 @@ class CrystalFieldFit(object):
                 i += 1
             # clean up multispectrum function to prevent problems during evaluation
             # e.g. remove FWHMX0/FWHMY0 and FWHMX1/FWHMY1
-            fun_str = re.sub(r'FWHM[X|Y]\d+=\(\),', '', str(fun))
+            fun_str = re.sub(FWHM_PATTERN, '', str(fun))
             # move Temperature and PhysicalProperties settings to front
-            fun_str = re.sub(r'(name=.*?,)(.*?)(Temperatures=\(.*?\),)',r'\1\3\2', fun_str)
-            fun_str = re.sub(r'(name=.*?,)(.*?)(PhysicalProperties=\(.*?\),)',r'\1\3\2', fun_str)
+            fun_str = re.sub(TEMPERATURES_PATTERN, r'\1\3\2', fun_str)
+            fun_str = re.sub(PHYSICAL_PROPERTIES_PATTERN, r'\1\3\2', fun_str)
             # remove peaks above MaxPeakCount
             fun_str = re.sub(r'f[0-9]+\.f(['+str(fun.getAttributeValue("MaxPeakCount"))+r'-9]|[1-9][0-9])\.\w+=.*?,','', fun_str)
             return CalculateChiSquared(fun_str, **ws_kwargs)[1]

--- a/scripts/Inelastic/CrystalField/function.py
+++ b/scripts/Inelastic/CrystalField/function.py
@@ -7,7 +7,7 @@
 import re
 from mantid import logger
 
-parNamePattern = re.compile(r'([a-zA-Z][\w.]+)')
+PARAMETER_NAME_PATTERN = re.compile(r'([a-zA-Z][\w.]+)')
 
 
 class FunctionParameters(object):
@@ -141,7 +141,7 @@ class Function(object):
                 constraints('A0 > 0', '0.1 < A1 < 0.9')
         """
         for arg in args:
-            constraint = re.sub(parNamePattern, '%s\\1' % self.prefix, arg)
+            constraint = re.sub(PARAMETER_NAME_PATTERN, '%s\\1' % self.prefix, arg)
             self.function.addConstraints(constraint)
 
     def toString(self):
@@ -208,7 +208,7 @@ class CompositeProperties(object):
                 tie({'A0': 0.1, 'A1': '2*A0'})
         """
         for param, tie in ties_dict.items():
-            tie = re.sub(parNamePattern, '%s\\1' % self.prefix, tie)
+            tie = re.sub(PARAMETER_NAME_PATTERN, '%s\\1' % self.prefix, tie)
             self.function.tie(self.prefix + param, tie)
 
     def constraints(self, *args):
@@ -219,7 +219,7 @@ class CompositeProperties(object):
                 constraints('A0 > 0', '0.1 < A1 < 0.9')
         """
         for arg in args:
-            constraint = re.sub(parNamePattern, '%s\\1' % self.prefix, arg)
+            constraint = re.sub(PARAMETER_NAME_PATTERN, '%s\\1' % self.prefix, arg)
             self.function.addConstraints(constraint)
 
 
@@ -317,7 +317,7 @@ class PeaksFunction(object):
             start = self._params.first_index
             end = iFirstN + self._params.first_index
 
-        pattern = re.sub(parNamePattern, 'f%s.\\1', constraint)
+        pattern = re.sub(PARAMETER_NAME_PATTERN, 'f%s.\\1', constraint)
         self.constraints(*[pattern % i for i in range(start, end)])
 
 

--- a/scripts/Inelastic/CrystalField/normalisation.py
+++ b/scripts/Inelastic/CrystalField/normalisation.py
@@ -8,6 +8,8 @@ import numpy as np
 import re
 from CrystalField.energies import energies as CFEnergy
 
+ION_NAME_PATTERN = re.compile(r'[SJsj]([0-9\.]+)')
+
 
 def ionname2Nre(ionname):
     ion_nre_map = {'Ce': 1, 'Pr': 2, 'Nd': 3, 'Pm': 4, 'Sm': 5, 'Eu': 6, 'Gd': 7,
@@ -15,7 +17,7 @@ def ionname2Nre(ionname):
     if ionname not in ion_nre_map.keys():
         msg = 'Value %s is not allowed for attribute Ion.\nList of allowed values: %s' % \
               (ionname, ', '.join(list(ion_nre_map.keys())))
-        arbitraryJ = re.match(r'[SJsj]([0-9\.]+)', ionname)
+        arbitraryJ = re.match(ION_NAME_PATTERN, ionname)
         if arbitraryJ and (float(arbitraryJ.group(1)) % 0.5) == 0:
             nre = int(-float(arbitraryJ.group(1)) * 2.)
             if nre < -99:

--- a/scripts/Inelastic/CrystalField/pointcharge.py
+++ b/scripts/Inelastic/CrystalField/pointcharge.py
@@ -6,7 +6,10 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 import numpy as np
 from scipy import constants
+import re
 import warnings
+
+CHARGES_PATTERN = re.compile(r'^[A-z]+')
 
 
 class PointCharge(object):
@@ -364,9 +367,8 @@ class PointCharge(object):
         for name, coords in self._atoms.items():
             pos[name] = [c for c in sg.getEquivalentPositions(coords)]
             if name not in self._charges.keys():
-                import re
                 try:
-                    charges[name] = self._charges[re.match('^[A-z]+', name).group(0)]
+                    charges[name] = self._charges[re.match(CHARGES_PATTERN, name).group(0)]
                 except (KeyError, AttributeError):
                     warnstr = 'Atom type ''%s'' in structure not in list of charges. Assuming q=0' % (name)
                     warnings.warn(warnstr, RuntimeWarning)


### PR DESCRIPTION
**Description of work.**
This PR updates the CrystalField scripts to us re-compile for the regex strings so they are only compiled once. It also replaces the format method with using f-strings.

**To test:**
Code review and make sure the tests are passing.

Fixes #33158

*This does not require release notes* because **it is a behind-the-scenes change.**

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
