### PR TITLE
Updated MSlice SHA and release notes

### DIFF
--- a/docs/source/release/v6.4.0/Direct_Geometry/MSlice/Bugfixes/33822.rst
+++ b/docs/source/release/v6.4.0/Direct_Geometry/MSlice/Bugfixes/33822.rst
@@ -1,0 +1,2 @@
+Fix for bug that left the menu for Default Energy Unit empty
+Fix for permanently enabled 'Show Legend' check boxes

--- a/docs/source/release/v6.4.0/Direct_Geometry/MSlice/New_features/33822.rst
+++ b/docs/source/release/v6.4.0/Direct_Geometry/MSlice/New_features/33822.rst
@@ -1,0 +1,5 @@
+Various documentation updates
+MSlice now available as a noarch conda package
+Update to matplotlib 3.5
+Add ability to change slice plot font sizes using quick options
+Changed default cut algorithm to Integration

--- a/scripts/ExternalInterfaces/CMakeLists.txt
+++ b/scripts/ExternalInterfaces/CMakeLists.txt
@@ -7,7 +7,7 @@ externalproject_add(
   mslice
   PREFIX ${_mslice_external_root}
   GIT_REPOSITORY "https://github.com/mantidproject/mslice.git"
-  GIT_TAG 7444a0122d3e3395c09e34c7da6ffc2c0d991fea
+  GIT_TAG 44470f2612345fc347a5e25387585ac749dd33fb
   EXCLUDE_FROM_ALL 1
   CONFIGURE_COMMAND ""
   BUILD_COMMAND ""


### PR DESCRIPTION
**Description of work.**

Replaced MSlice SHA for Mantid with SHA of current MSlice main branch.

Added release notes in Direct_Geometry\MSlice folder with all changes in MSlice since last MSlice SHA update in Mantid.

**To test:**

Double-check SHA with SHA of current MSlice main branch.

There is no associated issue.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
