### PR TITLE
Update boost for developers to 1.77

### DIFF
--- a/Framework/Algorithms/src/CorelliCalibrationApply.cpp
+++ b/Framework/Algorithms/src/CorelliCalibrationApply.cpp
@@ -159,7 +159,7 @@ void CorelliCalibrationApply::exec() {
   rotateAlg->initialize();
   rotateAlg->setProperty("Workspace", wsName);
   for (size_t row_num = 0; row_num < calTable->rowCount(); row_num++) {
-    if (abs(rotangs->cell<double>(row_num)) < 1e-8) {
+    if (std::abs(rotangs->cell<double>(row_num)) < 1e-8) {
       continue;
     }
     rotateAlg->setProperty("ComponentName", componentNames->cell<std::string>(row_num));

--- a/Framework/Algorithms/test/MaskDetectorsIfTest.h
+++ b/Framework/Algorithms/test/MaskDetectorsIfTest.h
@@ -181,7 +181,7 @@ public:
 
   void testMaskWorkspaceSelectIfNotFinite() {
     auto correctMasking = [](MatrixWorkspace const &ws, const size_t wsIndex) {
-      return !isfinite(ws.y(wsIndex).front());
+      return !std::isfinite(ws.y(wsIndex).front());
     };
     MaskDetectorsIf alg;
     MatrixWorkspace_sptr inWS = makeFakeWorkspace();

--- a/Framework/Algorithms/test/SparseWorkspaceTest.h
+++ b/Framework/Algorithms/test/SparseWorkspaceTest.h
@@ -339,18 +339,15 @@ public:
     double lon = (grid.longitudeAt(3) + grid.longitudeAt(2)) / 2.0;
     size_t nearestLatIndex, nearestLonIndex;
     std::tie(nearestLatIndex, nearestLonIndex) = sparseWS->grid().getNearestVertex(lat, lon);
-    double val = static_cast<double>(sparseWS->grid().getDetectorIndex(nearestLatIndex, nearestLonIndex) +
-                                     sparseWS->grid().getDetectorIndex(nearestLatIndex + 1, nearestLonIndex) +
-                                     sparseWS->grid().getDetectorIndex(nearestLatIndex, nearestLonIndex + 1) +
-                                     sparseWS->grid().getDetectorIndex(nearestLatIndex + 1, nearestLonIndex + 1)) /
-                 4.0;
+    double indexSum = static_cast<double>(sparseWS->grid().getDetectorIndex(nearestLatIndex, nearestLonIndex) +
+                                          sparseWS->grid().getDetectorIndex(nearestLatIndex + 1, nearestLonIndex) +
+                                          sparseWS->grid().getDetectorIndex(nearestLatIndex, nearestLonIndex + 1) +
+                                          sparseWS->grid().getDetectorIndex(nearestLatIndex + 1, nearestLonIndex + 1));
+    double val = indexSum / 4.0;
     // second derivative is zero here so error will be from propagating
     // the original errors on points only
-    double err = sqrt(sparseWS->grid().getDetectorIndex(nearestLatIndex, nearestLonIndex) +
-                      sparseWS->grid().getDetectorIndex(nearestLatIndex + 1, nearestLonIndex) +
-                      sparseWS->grid().getDetectorIndex(nearestLatIndex, nearestLonIndex + 1) +
-                      sparseWS->grid().getDetectorIndex(nearestLatIndex + 1, nearestLonIndex + 1)) /
-                 4.0;
+    double err = sqrt(indexSum) / 4.0;
+
     auto h = sparseWS->bilinearInterpolateFromDetectorGrid(lat, lon);
     TS_ASSERT_EQUALS(h.size(), wavelengths)
     for (size_t i = 0; i < h.size(); ++i) {
@@ -371,7 +368,7 @@ public:
       for (size_t col = 0; col < sparseCols; col++) {
         auto &ys = sparseWS->mutableY(row + col * sparseRows);
         for (size_t j = 0; j < ys.size(); ++j) {
-          ys[j] = pow(col, 2);
+          ys[j] = std::pow(col, 2);
         }
       }
     }
@@ -398,7 +395,7 @@ public:
       for (size_t col = 0; col < sparseCols; col++) {
         auto &ys = sparseWS->mutableY(row + col * sparseRows);
         for (size_t j = 0; j < ys.size(); ++j) {
-          ys[j] = pow(col, 2);
+          ys[j] = std::pow(col, 2);
         }
       }
     }
@@ -422,7 +419,7 @@ public:
       for (size_t col = 0; col < sparseCols; col++) {
         auto &ys = sparseWS->mutableY(row + col * sparseRows);
         for (size_t j = 0; j < ys.size(); ++j) {
-          ys[j] = pow(sparseCols - 1, 2) - pow(sparseCols - col - 1, 2);
+          ys[j] = std::pow(sparseCols - 1, 2) - std::pow(sparseCols - col - 1, 2);
         }
       }
     }

--- a/Framework/CurveFitting/test/Functions/PowerLawTest.h
+++ b/Framework/CurveFitting/test/Functions/PowerLawTest.h
@@ -54,7 +54,7 @@ public:
     pl.function1D(yValues.data(), xValues.data(), numPoints);
 
     for (size_t i = 0; i < numPoints; i++) {
-      TS_ASSERT_DELTA(yValues[i], constant + magnitude * pow(i, exponent), 1e-12);
+      TS_ASSERT_DELTA(yValues[i], constant + magnitude * std::pow(i, exponent), 1e-12);
     }
   }
 };

--- a/Framework/DataHandling/src/LoadNXSPE.cpp
+++ b/Framework/DataHandling/src/LoadNXSPE.cpp
@@ -284,7 +284,7 @@ void LoadNXSPE::exec() {
     Kernel::V3D pos;
     pos.spherical(r, polar.at(i), azimuthal.at(i));
     // Define the size of the detector using the minimum of the polar or azimuthal width
-    double rr = r * sin(std::min(abs(polar_width.at(i)), abs(azimuthal_width.at(i))) * deg2rad / 2);
+    double rr = r * sin(std::min(std::abs(polar_width.at(i)), std::abs(azimuthal_width.at(i))) * deg2rad / 2);
     const auto shape = Geometry::ShapeFactory().createSphere(V3D(0, 0, 0), std::max(rr, 0.01));
 
     Geometry::Detector *det = new Geometry::Detector("pixel", static_cast<int>(i + 1), sample);

--- a/Framework/Kernel/src/Matrix.cpp
+++ b/Framework/Kernel/src/Matrix.cpp
@@ -998,7 +998,7 @@ yes invert the matrix using analytic formula. If not then use standard Invert
         auto iMinusj = static_cast<T>(i) - static_cast<T>(j);
         auto iPlusj = static_cast<T>(i) + static_cast<T>(j);
         if (D >= 2) {
-          m_rawData[i][j] = static_cast<T>(pow(-1.0, i + j));
+          m_rawData[i][j] = static_cast<T>(pow(-1.0, static_cast<double>(i + j)));
           lambda = static_cast<T>(acosh(D / 2));
         } else if ((D > -2) && (D < 2)) {
           m_rawData[i][j] = 1;                   // use +1 here instead of the -1 in the paper

--- a/Framework/MDAlgorithms/src/ConvertHFIRSCDtoMDE.cpp
+++ b/Framework/MDAlgorithms/src/ConvertHFIRSCDtoMDE.cpp
@@ -215,8 +215,8 @@ void ConvertHFIRSCDtoMDE::exec() {
   for (size_t m = 0; m < azimuthal.size(); ++m) {
     auto twotheta_f = static_cast<float>(twotheta[m]);
     auto azimuthal_f = static_cast<float>(azimuthal[m]);
-    q_lab_pre.push_back({-sin(twotheta_f) * cos(azimuthal_f) * k, -sin(twotheta_f) * sin(azimuthal_f) * k * coeff,
-                         (1.f - cos(twotheta_f)) * k});
+    q_lab_pre.push_back({-std::sin(twotheta_f) * std::cos(azimuthal_f) * k,
+                         -std::sin(twotheta_f) * std::sin(azimuthal_f) * k * coeff, (1.f - std::cos(twotheta_f)) * k});
   }
   const auto run = inputWS->getExperimentInfo(0)->run();
   for (size_t n = 0; n < inputWS->getDimension(2)->getNBins(); n++) {

--- a/mantid-developer-linux.yml
+++ b/mantid-developer-linux.yml
@@ -5,7 +5,7 @@ channels:
 
 dependencies:
   # Common packages
-  - boost=1.75.* # Also pulls in boost-cpp
+  - boost=1.77.* # Also pulls in boost-cpp. 1.78 clashes with icu version from Qt
   - cmake=3.19.*|>=3.21.0 # Avoid bug in 3.20.* with updating external projects
   - doxygen>=1.9.*
   - eigen=3.4.*

--- a/mantid-developer-osx.yml
+++ b/mantid-developer-osx.yml
@@ -4,7 +4,7 @@ channels:
   - conda-forge
 
 dependencies:
-  - boost=1.75.* # Also pulls in boost-cpp
+  - boost=1.77.* # Also pulls in boost-cpp. 1.78 clashes with icu version from Qt
   - cmake=3.19.*|>=3.21.0 # Avoid bug in 3.20.* with updating external projects
   - doxygen>=1.9.*
   - eigen=3.4.*

--- a/mantid-developer-win.yml
+++ b/mantid-developer-win.yml
@@ -4,7 +4,7 @@ channels:
   - conda-forge
 
 dependencies:
-  - boost=1.75.* # Also pulls in boost-cpp
+  - boost=1.77.* # Also pulls in boost-cpp. 1.78 clashes with icu version from Qt
   - cmake=3.19.*|>=3.21.0 # Avoid bug in 3.20.* with updating external projects
   - conda-wrappers
   - doxygen>=1.9.*


### PR DESCRIPTION
**Description of work.**

Boost-cpp builds with `zstd` and the `zstd` conda package contains a run export to pin to what was used at build time: https://github.com/conda-forge/zstd-feedstock/blob/main/recipe/meta.yaml#L24. Using boost 1.75 keeps ztsd from moving forward so lets try updating boost.

**To test:**

* Conda pull request checks should pass


*This does not require release notes* because **not a significant outward-facing change.**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).


<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

**Note**: Once merged the `conda-recipes` pin needs to be updated by merging

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
