### PR TITLE
Workaround boost 1.77 on clang 13

### DIFF
--- a/qt/applications/workbench/CMakeLists.txt
+++ b/qt/applications/workbench/CMakeLists.txt
@@ -55,6 +55,8 @@ if(APPLE OR WIN32)
     set(_qt_plugins_standalone "../PlugIns")
     # appears in the unified menu bar and helps distiguish from other packages
     set(PACKAGE_EXECUTABLE MantidWorkbench${CPACK_PACKAGE_SUFFIX_CAMELCASE})
+    target_compile_definitions(MantidWorkbench PRIVATE -DBOOST_ASIO_DISABLE_STD_ALIGNED_ALLOC)
+    target_compile_definitions(MantidWorkbenchInstalled PRIVATE -DBOOST_ASIO_DISABLE_STD_ALIGNED_ALLOC)
   endif()
   set_target_properties(
     MantidWorkbenchInstalled PROPERTIES OUTPUT_NAME ${PACKAGE_EXECUTABLE} RUNTIME_OUTPUT_DIRECTORY


### PR DESCRIPTION
**Description of work.**

Workarond boost 1.77 compilation failure on clang 13: https://github.com/msys2/MINGW-packages/issues/9827

**To test:**

All builds pass.

*This does not require release notes* because **it is an internal change.**

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
