### PR TITLE
Remove as many `QT_VERSION_CHECK`'s as possible

### DIFF
--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -523,8 +523,6 @@ useStlAlgorithm:${CMAKE_SOURCE_DIR}/qt/widgets/common/src/UserInputValidator.cpp
 shadowFunction:${CMAKE_SOURCE_DIR}/qt/widgets/common/src/Batch/JobTreeView.cpp:434
 unknownMacro:${CMAKE_SOURCE_DIR}/qt/widgets/common/src/QtPropertyBrowser/qtpropertybrowser.cpp:1142
 unknownMacro:${CMAKE_SOURCE_DIR}/qt/widgets/common/src/QtPropertyBrowser/qteditorfactory.cpp:1546
-redundantInitialization:${CMAKE_SOURCE_DIR}/qt/widgets/common/src/QtPropertyBrowser/qttreepropertybrowser.cpp:585
-shadowVariable:${CMAKE_SOURCE_DIR}/qt/widgets/common/src/QtPropertyBrowser/qttreepropertybrowser.cpp:340
 unknownMacro:${CMAKE_SOURCE_DIR}/qt/widgets/common/src/QtPropertyBrowser/qtpropertymanager.cpp:276
 unknownMacro:${CMAKE_SOURCE_DIR}/qt/widgets/common/src/QtPropertyBrowser/qtvariantproperty.cpp:114
 unreadVariable:${CMAKE_SOURCE_DIR}/qt/widgets/plotting/src/Mpl/ContourPreviewPlot.cpp:83
@@ -532,10 +530,10 @@ unreadVariable:${CMAKE_SOURCE_DIR}/qt/widgets/plotting/src/Mpl/PreviewPlot.cpp:6
 useStlAlgorithm:${CMAKE_SOURCE_DIR}/qt/widgets/instrumentview/src/BankRenderingHelpers.cpp:172
 constParameter:${CMAKE_SOURCE_DIR}/qt/widgets/common/inc/MantidQtWidgets/Common/ObserverPattern.h:65
 useStlAlgorithm:${CMAKE_SOURCE_DIR}/qt/widgets/instrumentview/src/InstrumentWidgetDecoder.cpp:186
-knownConditionTrueFalse:${CMAKE_SOURCE_DIR}/qt/widgets/instrumentview/src/InstrumentWidgetPickTab.cpp:1638
-knownConditionTrueFalse:${CMAKE_SOURCE_DIR}/qt/widgets/instrumentview/src/InstrumentWidgetPickTab.cpp:1671
+knownConditionTrueFalse:${CMAKE_SOURCE_DIR}/qt/widgets/instrumentview/src/InstrumentWidgetPickTab.cpp:1597
+knownConditionTrueFalse:${CMAKE_SOURCE_DIR}/qt/widgets/instrumentview/src/InstrumentWidgetPickTab.cpp:1630
 useStlAlgorithm:${CMAKE_SOURCE_DIR}/qt/widgets/instrumentview/src/PanelsSurface.cpp:178
-knownConditionTrueFalse:${CMAKE_SOURCE_DIR}/qt/widgets/instrumentview/src/Projection3D.cpp:248
+knownConditionTrueFalse:${CMAKE_SOURCE_DIR}/qt/widgets/instrumentview/src/Projection3D.cpp:244
 unreadVariable:${CMAKE_SOURCE_DIR}/qt/widgets/plugins/algorithm_dialogs/src/LoadDialog.cpp:137
 unsafeClassCanLeak:${CMAKE_SOURCE_DIR}/qt/widgets/plugins/algorithm_dialogs/inc/MantidQtWidgets/Plugins/AlgorithmDialogs/FitDialog.h:201
 unsafeClassCanLeak:${CMAKE_SOURCE_DIR}/qt/widgets/plugins/algorithm_dialogs/inc/MantidQtWidgets/Plugins/AlgorithmDialogs/SampleShapeHelpers.h:178
@@ -550,9 +548,8 @@ unsafeClassCanLeak:${CMAKE_SOURCE_DIR}/qt/widgets/plugins/algorithm_dialogs/inc/
 unsafeClassCanLeak:${CMAKE_SOURCE_DIR}/qt/widgets/plugins/algorithm_dialogs/inc/MantidQtWidgets/Plugins/AlgorithmDialogs/SampleShapeHelpers.h:292
 unsafeClassCanLeak:${CMAKE_SOURCE_DIR}/qt/widgets/plugins/algorithm_dialogs/inc/MantidQtWidgets/Plugins/AlgorithmDialogs/SampleShapeHelpers.h:321
 shadowVariable:${CMAKE_SOURCE_DIR}/qt/widgets/plugins/algorithm_dialogs/src/PlotAsymmetryByLogValueDialog.cpp:160
-unreadVariable:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/General/StepScan.cpp:608
-unreadVariable:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/General/StepScan.cpp:610
-unreadVariable:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/General/StepScan.cpp:697
+unreadVariable:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/General/StepScan.cpp:599
+unreadVariable:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/General/StepScan.cpp:601
 useStlAlgorithm:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/Muon/ALCBaselineModellingModel.cpp:115
 useStlAlgorithm:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/Muon/ALCDataLoadingView.cpp:343
 unreadVariable:${CMAKE_SOURCE_DIR}/qt/scientific_interfaces/Muon/ALCDataLoadingView.cpp:168

--- a/qt/icons/inc/MantidQtIcons/CharIconEngine.h
+++ b/qt/icons/inc/MantidQtIcons/CharIconEngine.h
@@ -37,11 +37,7 @@ public:
   CharIconEngine(IconicFont *iconic, CharIconPainter *painter, const QList<QHash<QString, QVariant>> &options);
   void paint(QPainter *painter, const QRect &rect, QIcon::Mode mode, QIcon::State state) override;
   QPixmap pixmap(const QSize &size, QIcon::Mode mode, QIcon::State state) override;
-#if (QT_VERSION < QT_VERSION_CHECK(5, 0, 0))
-  QIconEngine *clone() const;
-#else
   QIconEngine *clone() const override;
-#endif
 
 private:
   IconicFont *m_iconic;

--- a/qt/icons/src/Icon.cpp
+++ b/qt/icons/src/Icon.cpp
@@ -8,14 +8,9 @@
 
 #include <QFile>
 #include <QFontDatabase>
-
-#if (QT_VERSION < QT_VERSION_CHECK(5, 0, 0))
-#include <QtScript/QScriptEngine>
-#include <QtScript/QScriptValueIterator>
-#else
 #include <QJsonDocument>
 #include <QJsonObject>
-#endif
+
 #include <stdexcept>
 
 namespace {
@@ -23,42 +18,7 @@ MantidQt::Icons::IconicFont &iconFontInstance() {
   static MantidQt::Icons::IconicFont iconicFont;
   return iconicFont;
 }
-#if (QT_VERSION < QT_VERSION_CHECK(5, 0, 0))
-// In Qt4 there is no access to QJsonDocument and a method for reading JSON in
-// the QT standard library so the Qt4 method must be used.
 
-// This code for decode and decodeInner was inspired and
-// taken from:
-// https://stackoverflow.com/questions/4169988/easiest-way-to-parse-json-in-qt-4-7
-// specifically in the answer by user2243820 on April 4th 2013 at 8:10
-
-QHash<QString, QVariant> decodeInner(const QScriptValue &object) {
-  QHash<QString, QVariant> map;
-  QScriptValueIterator it(object);
-  while (it.hasNext()) {
-    it.next();
-    if (it.value().isString())
-      map.insert(it.name(), QVariant(it.value().toString()));
-    else
-      throw std::runtime_error("Decoding JSON file not successful as some values are not strings.");
-  }
-  return map;
-}
-
-QHash<QString, QVariant> decode(const QString &jsonStr) {
-  QScriptValue object;
-  QScriptEngine engine;
-  object = engine.evaluate("(" + jsonStr + ")");
-  return decodeInner(object);
-}
-
-QHash<QString, QVariant> loadJsonFile(const QString &charmapFileName) {
-  QFile jsonFile(charmapFileName);
-  jsonFile.open(QFile::ReadOnly);
-  return decode(jsonFile.readAll());
-}
-
-#else
 QHash<QString, QVariant> loadJsonFile(const QString &charmapFileName) {
   QFile jsonFile(charmapFileName);
   jsonFile.open(QFile::ReadOnly);
@@ -67,7 +27,7 @@ QHash<QString, QVariant> loadJsonFile(const QString &charmapFileName) {
   // VariantHash = QHash<QString, QVariant> in this case QVaraint = QString
   return jsonObject.toVariantHash();
 }
-#endif
+
 } // namespace
 
 QIcon MantidQt::Icons::getIcon(const QString &iconName, const QString &color, const double &scaleFactor) {

--- a/qt/scientific_interfaces/General/StepScan.cpp
+++ b/qt/scientific_interfaces/General/StepScan.cpp
@@ -625,7 +625,7 @@ auto get_fig_ax(boost::optional<int> fignum) {
   } else {
     main_namespace["fig_num"] = Python::Object();
   }
-  auto ignored = boost::python::exec(pyCode.c_str(), main_namespace);
+  boost::python::exec(pyCode.c_str(), main_namespace);
   auto fig = Figure(boost::python::extract<Python::Object>(main_namespace["fig"]));
   auto ax = MantidAxes(boost::python::extract<Python::Object>(main_namespace["ax"]));
   return std::make_tuple(fig, ax);
@@ -659,7 +659,7 @@ void StepScan::plotCurve() {
   QHash<QString, QVariant> hash;
   hash.insert("linestyle", "");
   hash.insert("marker", ".");
-  auto line = ax.plot(ws, 0, "black", "", hash);
+  ax.plot(ws, 0, "black", "", hash);
   ax.setXLabel(xAxisTitle.c_str());
   ax.setYLabel(yAxisTitle.c_str());
   fig.show();

--- a/qt/scientific_interfaces/General/StepScan.h
+++ b/qt/scientific_interfaces/General/StepScan.h
@@ -79,9 +79,7 @@ private:
   API::AlgorithmRunner *m_algRunner; ///< Object for running algorithms asynchronously
   Poco::NObserver<StepScan, Mantid::API::WorkspaceAddNotification> m_addObserver;
   Poco::NObserver<StepScan, Mantid::API::WorkspaceAfterReplaceNotification> m_replObserver;
-#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
   boost::optional<int> m_fignum;
-#endif
   bool m_replaceObserverAdded;
 };
 

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Common/Plotter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Common/Plotter.cpp
@@ -6,9 +6,6 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 #include "Plotter.h"
 
-#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
-#include "../Common/IPythonRunner.h"
-#else
 #include "MantidAPI/AnalysisDataService.h"
 #include "MantidAPI/MatrixWorkspace.h"
 #include "MantidAPI/WorkspaceGroup.h"
@@ -18,28 +15,10 @@
 #include <QString>
 #include <QVariant>
 using namespace MantidQt::Widgets::MplCpp;
-#endif
 
 namespace MantidQt::CustomInterfaces::ISISReflectometry {
 
-#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
-Plotter::Plotter(IPythonRunner *pythonRunner) : m_pythonRunner(pythonRunner) {}
-#endif
-
 void Plotter::reflectometryPlot(const std::vector<std::string> &workspaces) const {
-#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
-  if (!workspaces.empty()) {
-    std::string pythonSrc;
-    pythonSrc += "base_graph = None\n";
-    for (const auto &workspace : workspaces)
-      pythonSrc += "base_graph = plotSpectrum(\"" + workspace + "\", 0, True, window = base_graph)\n";
-
-    pythonSrc += "base_graph.activeLayer().logLogAxes()\n";
-
-    this->runPython(pythonSrc);
-  }
-#else
-  // Workbench Plotting
   QHash<QString, QVariant> ax_properties;
   ax_properties[QString("yscale")] = QVariant("log");
   ax_properties[QString("xscale")] = QVariant("log");
@@ -70,13 +49,6 @@ void Plotter::reflectometryPlot(const std::vector<std::string> &workspaces) cons
 
   plot(actualWorkspaces, boost::none, wksp_indices, boost::none, boost::none, ax_properties, window_title,
        plotErrorBars, false);
-#endif
 }
-
-// This should never be implemented for Qt 5 or above because that is
-// workbench.
-#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
-void Plotter::runPython(const std::string &pythonCode) const { m_pythonRunner->runPythonAlgorithm(pythonCode); }
-#endif
 
 } // namespace MantidQt::CustomInterfaces::ISISReflectometry

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Common/Plotter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Common/Plotter.h
@@ -15,24 +15,10 @@
 namespace MantidQt {
 namespace CustomInterfaces {
 namespace ISISReflectometry {
-#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
-class IPythonRunner;
-#endif
 
 class MANTIDQT_ISISREFLECTOMETRY_DLL Plotter : public IPlotter {
 public:
-#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
-  Plotter(IPythonRunner *pythonRunner);
-  void runPython(const std::string &pythonCode) const;
-#endif
   void reflectometryPlot(const std::vector<std::string> &workspaces) const override;
-
-private:
-#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
-  // Object only needed for MantidPlot implementation as it requires Python
-  // execution
-  IPythonRunner *m_pythonRunner;
-#endif
 };
 
 } // namespace ISISReflectometry

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/MainWindow/QtMainWindowView.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/MainWindow/QtMainWindowView.cpp
@@ -72,11 +72,8 @@ void QtMainWindowView::initLayout() {
   auto instruments = std::vector<std::string>({{"INTER", "SURF", "CRISP", "POLREF", "OFFSPEC"}});
 
   auto thetaTolerance = 0.01;
-#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
-  Plotter plotter(this);
-#else
   Plotter plotter;
-#endif
+
   auto makeRunsTablePresenter = RunsTablePresenterFactory(instruments, thetaTolerance, std::move(plotter));
 
   auto messageHandler = this;

--- a/qt/scientific_interfaces/ISISReflectometry/test/Runs/RunsPresenterTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Runs/RunsPresenterTest.h
@@ -819,12 +819,8 @@ private:
   };
 
   RunsPresenterFriend makePresenter() {
-#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
-    IPythonRunner *pythonRunner = new MockPythonRunner();
-    Plotter plotter(pythonRunner);
-#else
     Plotter plotter;
-#endif
+
     auto makeRunsTablePresenter = RunsTablePresenterFactory(m_instruments, m_thetaTolerance, std::move(plotter));
     auto presenter = RunsPresenterFriend(&m_view, &m_progressView, makeRunsTablePresenter, m_thetaTolerance,
                                          m_instruments, &m_messageHandler);

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/ManageUserDirectories.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/ManageUserDirectories.h
@@ -7,13 +7,9 @@
 #pragma once
 
 #include "DllOption.h"
+#include <QDialog>
 #include <QtGlobal>
 
-#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
-#include "MantidQtWidgets/Common/MantidDialog.h"
-#else
-#include <QDialog>
-#endif
 #include "ui_ManageUserDirectories.h"
 
 namespace MantidQt {
@@ -23,15 +19,8 @@ namespace API {
  * Access and update the user directory settings within the
  * Mantid config service
  */
-class EXPORT_OPT_MANTIDQT_COMMON ManageUserDirectories
-#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
-    : public MantidQt::API::MantidDialog {
-  using BaseClass = MantidQt::API::MantidDialog;
-#else
-    : public QDialog {
+class EXPORT_OPT_MANTIDQT_COMMON ManageUserDirectories : public QDialog {
   using BaseClass = QDialog;
-#endif
-
   Q_OBJECT
 
 public:

--- a/qt/widgets/common/src/CheckboxHeader.cpp
+++ b/qt/widgets/common/src/CheckboxHeader.cpp
@@ -17,11 +17,7 @@ namespace MantidWidgets {
 CheckboxHeader::CheckboxHeader(Qt::Orientation orientation, QWidget *parent)
     : QHeaderView(orientation, parent), m_checked(false) {
   show();
-#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
-  setClickable(true);
-#else
   setSectionsClickable(true);
-#endif
 }
 
 /**

--- a/qt/widgets/common/src/DataProcessorUI/QDataProcessorWidget.cpp
+++ b/qt/widgets/common/src/DataProcessorUI/QDataProcessorWidget.cpp
@@ -117,13 +117,9 @@ void QDataProcessorWidget::createTable() {
   auto *header = new QHeaderView(Qt::Horizontal);
   header->setStretchLastSection(true);
   header->setStyleSheet("QHeaderView {font-size:11pt;}");
-#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
-  header->setMovable(true);
-  header->setResizeMode(QHeaderView::ResizeToContents);
-#else
   header->setSectionsMovable(true);
   header->setSectionResizeMode(QHeaderView::ResizeToContents);
-#endif
+
   ui.viewTable->setHeader(header);
 
   // Re-emit a signal when the instrument changes

--- a/qt/widgets/common/src/ImageInfoWidget.cpp
+++ b/qt/widgets/common/src/ImageInfoWidget.cpp
@@ -20,9 +20,7 @@ namespace MantidQt::MantidWidgets {
  */
 ImageInfoWidget::ImageInfoWidget(QWidget *parent)
     : IImageInfoWidget(parent), m_presenter(std::make_unique<ImageInfoPresenter>(this)) {
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 0, 0))
   setSizeAdjustPolicy(QAbstractScrollArea::AdjustToContents);
-#endif
   setSizePolicy(QSizePolicy::Maximum, QSizePolicy::Maximum);
   horizontalHeader()->hide();
   verticalHeader()->hide();

--- a/qt/widgets/common/src/MantidHelpWindow.cpp
+++ b/qt/widgets/common/src/MantidHelpWindow.cpp
@@ -21,16 +21,14 @@
 #include <QLatin1Char>
 #include <QLatin1String>
 #include <QResource>
-#include <boost/lexical_cast.hpp>
-#include <memory>
-#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
 #include <QStandardPaths>
-#endif
 #include <QString>
 #include <QTemporaryFile>
 #include <QTextStream>
 #include <QUrl>
 #include <QWidget>
+#include <boost/lexical_cast.hpp>
+#include <memory>
 #include <stdexcept>
 
 namespace MantidQt::MantidWidgets {
@@ -443,11 +441,8 @@ void MantidHelpWindow::determineFileLocs() {
 
   // determine cache file location
   m_cacheFile = COLLECTION_FILE.toStdString();
-#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
-  QString dataLoc = QDesktopServices::storageLocation(QDesktopServices::DataLocation);
-#else
+
   QString dataLoc = QStandardPaths::writableLocation(QStandardPaths::GenericDataLocation) + "/data";
-#endif
 
   if (dataLoc.endsWith("mantidproject")) {
     Poco::Path path(dataLoc.toStdString(), m_cacheFile);

--- a/qt/widgets/common/src/MessageDisplay.cpp
+++ b/qt/widgets/common/src/MessageDisplay.cpp
@@ -11,9 +11,7 @@
 
 #include "MantidKernel/ConfigService.h"
 #include "MantidKernel/Logger.h"
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 0, 0))
 #include "MantidQtWidgets/Common/NotificationService.h"
-#endif
 
 #include <QAction>
 #include <QActionGroup>
@@ -232,12 +230,10 @@ void MessageDisplay::append(const Message &msg) {
     moveCursorToEnd();
 
     if (msg.priority() <= Message::Priority::PRIO_ERROR) {
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 0, 0))
       NotificationService::showMessage(parentWidget() ? parentWidget()->windowTitle() : "Mantid",
                                        "Sorry, there was an error, please look at the message display for "
                                        "details.",
                                        NotificationService::MessageIcon::Critical);
-#endif
       emit errorReceived(msg.text());
     }
     if (msg.priority() <= Message::Priority::PRIO_WARNING)

--- a/qt/widgets/common/src/PluginLibraries.cpp
+++ b/qt/widgets/common/src/PluginLibraries.cpp
@@ -47,13 +47,9 @@ int loadPluginsFromCfgPath(const std::string &key) { return loadPluginsFromPath(
  * @return The number of libraries successfully loaded
  */
 int loadPluginsFromPath(const std::string &path) {
-// We must *NOT* load plugins compiled against a different version of Qt
-// so we set exclude flags by Qt version.
-#if (QT_VERSION < QT_VERSION_CHECK(5, 0, 0))
-  static std::vector<std::string> excludes{"Qt5"};
-#else
+  // We must *NOT* load plugins compiled against a different version of Qt
+  // so we set exclude flags by Qt version.
   static std::vector<std::string> excludes{"Qt4"};
-#endif
   return LibraryManager::Instance().openLibraries(path, LibraryManagerImpl::NonRecursive, excludes);
 }
 } // namespace MantidQt::API

--- a/qt/widgets/common/src/Python/Sip.cpp
+++ b/qt/widgets/common/src/Python/Sip.cpp
@@ -18,9 +18,7 @@ const sipAPIDef *sipAPI() {
     return sip_API;
 
     // Some configs have a private sip module inside PyQt. Try this first
-#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
-  sip_API = (const sipAPIDef *)PyCapsule_Import("PyQt4.sip._C_API", 0);
-#elif QT_VERSION >= QT_VERSION_CHECK(5, 0, 0) && QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0) && QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
   sip_API = (const sipAPIDef *)PyCapsule_Import("PyQt5.sip._C_API", 0);
 #else
 #error "Unknown sip module for Qt >= 6"

--- a/qt/widgets/common/src/Python/Sip.cpp
+++ b/qt/widgets/common/src/Python/Sip.cpp
@@ -18,7 +18,7 @@ const sipAPIDef *sipAPI() {
     return sip_API;
 
     // Some configs have a private sip module inside PyQt. Try this first
-#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0) && QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
   sip_API = (const sipAPIDef *)PyCapsule_Import("PyQt5.sip._C_API", 0);
 #else
 #error "Unknown sip module for Qt >= 6"

--- a/qt/widgets/common/src/QtJSONUtils.cpp
+++ b/qt/widgets/common/src/QtJSONUtils.cpp
@@ -7,108 +7,13 @@
 #include "MantidQtWidgets/Common/QtJSONUtils.h"
 
 #include <QFile>
-#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
-#include <QScriptEngine>
-#include <QScriptValue>
-#include <QScriptValueIterator>
-#else
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QTextStream>
-#endif
+
 #include <stdexcept>
 
 namespace {
-#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
-// Code in anonymous namespace taken from stack overflow
-// https://stackoverflow.com/questions/4169988/easiest-way-to-parse-json-in-qt-4-7
-// from user2243820 on 1st August 2019
-
-class JSON {
-public:
-  QScriptValue encodeInner(const QMap<QString, QVariant> &map, QScriptEngine *engine) {
-    QScriptValue obj = engine->newObject();
-    QMapIterator<QString, QVariant> i(map);
-    while (i.hasNext()) {
-      i.next();
-      if (i.value().type() == QVariant::String)
-        obj.setProperty(i.key(), i.value().toString());
-      else if (i.value().type() == QVariant::Int)
-        obj.setProperty(i.key(), i.value().toInt());
-      else if (i.value().type() == QVariant::Double)
-        obj.setProperty(i.key(), i.value().toDouble());
-      else if (i.value().type() == QVariant::Bool)
-        obj.setProperty(i.key(), i.value().toBool());
-      else if (i.value().type() == QVariant::List)
-        obj.setProperty(i.key(), qScriptValueFromSequence(engine, i.value().toList()));
-      else if (i.value().type() == QVariant::Map)
-        obj.setProperty(i.key(), encodeInner(i.value().toMap(), engine));
-    }
-    return obj;
-  }
-
-  QString encode(const QMap<QString, QVariant> &map) {
-    QScriptEngine engine;
-    engine.evaluate("function toString() { return JSON.stringify(this, null, 4) }");
-
-    QScriptValue toString = engine.globalObject().property("toString");
-    QScriptValue obj = encodeInner(map, &engine);
-    return toString.call(obj).toString();
-  }
-
-  QMap<QString, QVariant> decodeInner(const QScriptValue &object) {
-    QMap<QString, QVariant> map;
-    QScriptValueIterator it(object);
-    while (it.hasNext()) {
-      it.next();
-      if (it.value().isArray())
-        map.insert(it.name(), QVariant(decodeInnerToList(it.value())));
-      else if (it.value().isNumber())
-        map.insert(it.name(), QVariant(it.value().toNumber()));
-      else if (it.value().isString())
-        map.insert(it.name(), QVariant(it.value().toString()));
-      else if (it.value().isNull())
-        map.insert(it.name(), QVariant());
-      else if (it.value().isObject())
-        map.insert(it.name(), QVariant(decodeInner(it.value())));
-      else if (it.value().isBool())
-        map.insert(it.name(), QVariant(it.value().toBool()));
-    }
-    return map;
-  }
-
-  QList<QVariant> decodeInnerToList(const QScriptValue &arrayValue) {
-    QList<QVariant> list;
-    QScriptValueIterator it(arrayValue);
-    while (it.hasNext()) {
-      it.next();
-      if (it.name() == "length")
-        continue;
-
-      if (it.value().isArray())
-        list.append(QVariant(decodeInnerToList(it.value())));
-      else if (it.value().isNumber())
-        list.append(QVariant(it.value().toNumber()));
-      else if (it.value().isString())
-        list.append(QVariant(it.value().toString()));
-      else if (it.value().isBool())
-        list.append(QVariant(it.value().toBool()));
-      else if (it.value().isNull())
-        list.append(QVariant());
-      else if (it.value().isObject())
-        list.append(QVariant(decodeInner(it.value())));
-    }
-    return list;
-  }
-
-  QMap<QString, QVariant> decode(const QString &jsonStr) {
-    QScriptValue object;
-    QScriptEngine engine;
-    object = engine.evaluate("(" + jsonStr + ")");
-    return decodeInner(object);
-  }
-};
-#endif
 
 void writeData(const QString &filename, const QByteArray &data) {
   QFile jsonFile(filename);
@@ -130,27 +35,12 @@ void saveJSONToFile(QString &filename, const QMap<QString, QVariant> &map) {
       filenameString.substr(filenameString.find_last_of(".") + 1) != std::string("json")) {
     filename += ".json";
   }
-#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
-  JSON JSON;
-  auto jsonString = JSON.encode(map);
 
-  QByteArray jsonByteArray;
-  writeData(filename, jsonByteArray.append(jsonString));
-#else
   QJsonDocument jsonDocument(QJsonObject::fromVariantMap(map));
   writeData(filename, jsonDocument.toJson());
-#endif
 }
 
 QMap<QString, QVariant> loadJSONFromFile(const QString &filename) {
-#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
-  QFile jsonFile(filename);
-  if (!jsonFile.open(QFile::ReadOnly)) {
-    throw std::invalid_argument("Cannot open file at: " + filename.toStdString());
-  }
-  QString jsonString(jsonFile.readAll());
-  return loadJSONFromString(jsonString);
-#else
   /* https://stackoverflow.com/questions/19822211/qt-parsing-json-using-qjsondocument-qjsonobject-qjsonarray
    * is the source for a large portion of the source code for the Qt5
    * implementation of this function, from user alanwsx and edited by BSMP.
@@ -167,15 +57,9 @@ QMap<QString, QVariant> loadJSONFromFile(const QString &filename) {
   file.close();
 
   return loadJSONFromString(jsonString);
-
-#endif
 }
 
 QMap<QString, QVariant> loadJSONFromString(const QString &jsonString) {
-#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
-  JSON JSON;
-  return JSON.decode(jsonString);
-#else
   QByteArray jsonByteArray = jsonString.toLocal8Bit();
 
   auto jsonDoc = QJsonDocument::fromJson(jsonByteArray);
@@ -192,7 +76,6 @@ QMap<QString, QVariant> loadJSONFromString(const QString &jsonString) {
   }
 
   return jsonObj.toVariantMap();
-#endif
 }
 
 } // namespace MantidQt::API

--- a/qt/widgets/common/src/QtPropertyBrowser/qtpropertybrowserutils.cpp
+++ b/qt/widgets/common/src/QtPropertyBrowser/qtpropertybrowserutils.cpp
@@ -95,13 +95,9 @@
 #include <QPainter>
 
 namespace {
-// Translation function for Qt4/Qt5. Qt5 has no encoding option
+// Translation function for Qt5
 QString translateUtf8Encoded(const char *context, const char *key, const char *disambiguation = nullptr, int n = -1) {
-#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
-  return QApplication::translate(context, key, disambiguation, QApplication::UnicodeUTF8, n);
-#else
   return QApplication::translate(context, key, disambiguation, n);
-#endif
 }
 } // namespace
 

--- a/qt/widgets/common/src/QtPropertyBrowser/qttreepropertybrowser.cpp
+++ b/qt/widgets/common/src/QtPropertyBrowser/qttreepropertybrowser.cpp
@@ -325,12 +325,12 @@ void QtPropertyEditorDelegate::paint(QPainter *painter, const QStyleOptionViewIt
     }
     QString optionName = m_editorPrivate->options()[optionIndex];
     if (property->hasOption(optionName)) {
-      QStyleOptionButton opt;
+      QStyleOptionButton optButton;
       auto state = property->checkOption(optionName) ? QStyle::State_On : QStyle::State_Off;
-      opt.state |= state;
-      opt.rect = option.rect;
-      opt.rect.setWidth(opt.rect.height());
-      QApplication::style()->drawPrimitive(QStyle::PE_IndicatorCheckBox, &opt, painter);
+      optButton.state |= state;
+      optButton.rect = option.rect;
+      optButton.rect.setWidth(optButton.rect.height());
+      QApplication::style()->drawPrimitive(QStyle::PE_IndicatorCheckBox, &optButton, painter);
     }
   }
 }
@@ -562,16 +562,8 @@ void QtTreePropertyBrowserPrivate::updateItem(QTreeWidgetItem *item) {
   item->setWhatsThis(0, property->whatsThis());
   item->setText(0, property->propertyName());
   bool wasEnabled = item->flags() & Qt::ItemIsEnabled;
-  bool isEnabled = wasEnabled;
-  if (property->isEnabled()) {
-    QTreeWidgetItem *parent = item->parent();
-    if (!parent || (parent->flags() & Qt::ItemIsEnabled))
-      isEnabled = true;
-    else
-      isEnabled = false;
-  } else {
-    isEnabled = false;
-  }
+  bool isEnabled = property->isEnabled() ? !item->parent() || (item->parent()->flags() & Qt::ItemIsEnabled) : false;
+
   if (wasEnabled != isEnabled) {
     if (isEnabled)
       enableItem(item);

--- a/qt/widgets/common/src/QtPropertyBrowser/qttreepropertybrowser.cpp
+++ b/qt/widgets/common/src/QtPropertyBrowser/qttreepropertybrowser.cpp
@@ -101,7 +101,7 @@
 #include <QTreeWidget>
 
 namespace {
-// Translation function for Qt5 which has no encoding option
+// Translation function for Qt5
 QString translateUtf8Encoded(const char *context, const char *key, const char *disambiguation = nullptr, int n = -1) {
   return QApplication::translate(context, key, disambiguation, n);
 }

--- a/qt/widgets/common/src/QtPropertyBrowser/qttreepropertybrowser.cpp
+++ b/qt/widgets/common/src/QtPropertyBrowser/qttreepropertybrowser.cpp
@@ -101,13 +101,9 @@
 #include <QTreeWidget>
 
 namespace {
-// Translation function for Qt4/Qt5. Qt5 has no encoding option
+// Translation function for Qt5 which has no encoding option
 QString translateUtf8Encoded(const char *context, const char *key, const char *disambiguation = nullptr, int n = -1) {
-#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
-  return QApplication::translate(context, key, disambiguation, QApplication::UnicodeUTF8, n);
-#else
   return QApplication::translate(context, key, disambiguation, n);
-#endif
 }
 } // namespace
 
@@ -126,11 +122,7 @@ QtPropertyEditorView::QtPropertyEditorView(QWidget *parent, bool darkTopLevel)
 
 void QtPropertyEditorView::drawRow(QPainter *painter, const QStyleOptionViewItem &option,
                                    const QModelIndex &index) const {
-#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
-  QStyleOptionViewItemV3 opt = option;
-#else
   QStyleOptionViewItem opt = option;
-#endif
 
   bool hasValue = true;
   if (m_editorPrivate) {
@@ -294,11 +286,7 @@ void QtPropertyEditorDelegate::paint(QPainter *painter, const QStyleOptionViewIt
       hasValue = property->hasValue();
   }
 
-#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
-  QStyleOptionViewItemV3 opt = option;
-#else
   QStyleOptionViewItem opt = option;
-#endif
   if ((m_editorPrivate && index.column() == 0) || !hasValue) {
     QtProperty *property = m_editorPrivate->indexToProperty(index);
     if (property && property->isModified()) {
@@ -420,13 +408,9 @@ void QtTreePropertyBrowserPrivate::init(QWidget *parent, const QStringList &opti
   QObject::connect(m_delegate, SIGNAL(optionChanged(QtProperty *, const QString &, bool)), parent,
                    SIGNAL(optionChanged(QtProperty *, const QString &, bool)));
   m_treeWidget->setItemDelegate(m_delegate);
-#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
-  m_treeWidget->header()->setMovable(false);
-  m_treeWidget->header()->setResizeMode(QHeaderView::Stretch);
-#else
   m_treeWidget->header()->setSectionsMovable(false);
   m_treeWidget->header()->setSectionResizeMode(QHeaderView::Stretch);
-#endif
+
   m_expandIcon = drawIndicatorIcon(q_ptr->palette(), q_ptr->style());
 
   QObject::connect(m_treeWidget, SIGNAL(collapsed(const QModelIndex &)), q_ptr,
@@ -661,11 +645,7 @@ void QtTreePropertyBrowserPrivate::disableItem(QtBrowserItem *browserItem) {
 }
 
 void QtTreePropertyBrowserPrivate::setColumnSizes(int s0, int s1, int s2) {
-#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
-  m_treeWidget->header()->setResizeMode(QHeaderView::Interactive);
-#else
   m_treeWidget->header()->setSectionResizeMode(QHeaderView::Interactive);
-#endif
   m_treeWidget->header()->setStretchLastSection(false);
   m_treeWidget->header()->resizeSection(0, s0);
   m_treeWidget->header()->resizeSection(1, s1);
@@ -853,11 +833,7 @@ void QtTreePropertyBrowser::setResizeMode(QtTreePropertyBrowser::ResizeMode mode
     m = QHeaderView::Stretch;
     break;
   }
-#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
-  d_ptr->m_treeWidget->header()->setResizeMode(m);
-#else
   d_ptr->m_treeWidget->header()->setSectionResizeMode(m);
-#endif
 }
 
 /**

--- a/qt/widgets/common/src/RepoModel.cpp
+++ b/qt/widgets/common/src/RepoModel.cpp
@@ -255,35 +255,6 @@ QVariant RepoModel::data(const QModelIndex &index, int role) const {
     if (role == Qt::DecorationRole) {
       if (index.column() == 0) {
         inf = repo_ptr->fileInfo(path.toStdString());
-#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
-        if (inf.directory) {
-          status = repo_ptr->fileStatus(path.toStdString());
-          if (status == Mantid::API::REMOTE_ONLY)
-            return QIcon::fromTheme("folder-remote", QIcon(QPixmap(":/win/folder-remote")));
-          else
-            return QIcon::fromTheme("folder", QIcon(QPixmap(":/win/folder")));
-        } else {
-          int pos = QString(path).lastIndexOf('.');
-          if (pos < 0)
-            return QIcon::fromTheme("unknown", QIcon(QPixmap(":/win/unknown")));
-          if (path.contains("readme", Qt::CaseInsensitive))
-            return QIcon::fromTheme("text-x-readme", QIcon(QPixmap(":/win/txt_file.png")));
-
-          QString extension = QString(path).remove(0, pos);
-          if (extension == ".cpp" || extension == ".CPP" || extension == ".c" || extension == ".C")
-            return QIcon::fromTheme("text-x-c++", QIcon(QPixmap(":/win/unknown")));
-          else if (extension == ".py" || extension == ".PY")
-            return QIcon::fromTheme("text-x-python", QIcon(QPixmap(":/win/text-x-python")));
-          else if (extension == ".ui")
-            return QIcon::fromTheme("document", QIcon(QPixmap(":/win/document")));
-          else if (extension == ".docx" || extension == ".doc" || extension == ".odf")
-            return QIcon::fromTheme("x-office-document", QIcon(QPixmap(":/win/office-document")));
-          else if (extension == ".pdf")
-            return QIcon::fromTheme("application-pdf", QIcon(QPixmap(":/win/file_pdf")));
-          else
-            return QIcon::fromTheme("unknown", QIcon(QPixmap(":/win/unknown")));
-        }
-#else
         if (inf.directory) {
           status = repo_ptr->fileStatus(path.toStdString());
           if (status == Mantid::API::REMOTE_ONLY) {
@@ -309,7 +280,6 @@ QVariant RepoModel::data(const QModelIndex &index, int role) const {
           else
             return Icons::getIcon("mdi.file-question", "black", 1.2);
         }
-#endif
       }
     } // end decorationRole
 

--- a/qt/widgets/common/src/ScriptRepositoryView.cpp
+++ b/qt/widgets/common/src/ScriptRepositoryView.cpp
@@ -333,19 +333,6 @@ void ScriptRepositoryView::RepoDelegate::paint(QPainter *painter, const QStyleOp
 
 QIcon ScriptRepositoryView::RepoDelegate::getIcon(const QString &state) const {
   QIcon icon;
-#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
-  if (state == RepoModel::remoteOnlySt())
-    icon = QIcon::fromTheme("system-software-install", QIcon(QPixmap(":/win/download")));
-  else if (state == RepoModel::remoteChangedSt() || state == RepoModel::bothChangedSt())
-    icon = QIcon::fromTheme("bottom", QIcon(QPixmap(":win/system-software-update")));
-  else if (state == RepoModel::updatedSt())
-    icon = QIcon::fromTheme("dialog-ok", QIcon(QPixmap(":/win/dialog-ok")));
-  else if (state == RepoModel::localOnlySt() || state == RepoModel::localChangedSt())
-    icon = QIcon::fromTheme("add-files-to-archive", QIcon(QPixmap(":win/upload")));
-  else if (state == RepoModel::downloadSt() || state == RepoModel::uploadSt())
-    icon = QIcon(QPixmap(":win/running_process"));
-  return icon;
-#else
   if (state == RepoModel::remoteOnlySt())
     icon = Icons::getIcon("mdi.download");
   else if (state == RepoModel::remoteChangedSt() || state == RepoModel::bothChangedSt()) {
@@ -359,7 +346,6 @@ QIcon ScriptRepositoryView::RepoDelegate::getIcon(const QString &state) const {
   else if (state == RepoModel::uploadSt())
     icon = Icons::getIcon("mdi.progress-upload");
   return icon;
-#endif
 }
 
 /** Reacts to the iteraction with the user when he clicks on the buttons
@@ -442,11 +428,7 @@ void ScriptRepositoryView::CheckBoxDelegate::paint(QPainter *painter, const QSty
   if (painter->device() == nullptr)
     return;
 
-#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
-  QStyleOptionViewItemV4 modifiedOption(option);
-#else
   QStyleOptionViewItem modifiedOption(option);
-#endif
 
   QPoint p = modifiedOption.rect.center();
   QSize curr = modifiedOption.rect.size();
@@ -535,12 +517,8 @@ void ScriptRepositoryView::RemoveEntryDelegate::paint(QPainter *painter, const Q
 
   if (entry_type == "protected")
     return;
-#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
-  icon = QIcon::fromTheme("emptytrash", QIcon(QPixmap(":/win/emptytrash")));
-#else
+
   icon = Icons::getIcon("mdi.trash-can");
-  ;
-#endif
 
   // define the region to draw the icon
   QRect buttonRect(option.rect);

--- a/qt/widgets/common/src/SelectFunctionDialog.cpp
+++ b/qt/widgets/common/src/SelectFunctionDialog.cpp
@@ -66,9 +66,8 @@ SelectFunctionDialog::SelectFunctionDialog(QWidget *parent, const std::vector<st
 
   // Set up the search box
   m_form->searchBox->completer()->setCompletionMode(QCompleter::PopupCompletion);
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 0, 0))
   m_form->searchBox->completer()->setFilterMode(Qt::MatchContains);
-#endif
+
   connect(m_form->searchBox, SIGNAL(editTextChanged(const QString &)), this, SLOT(searchBoxChanged(const QString &)));
 
   // Construct the QTreeWidget based on the map information of categories and

--- a/qt/widgets/common/src/WorkspacePresenter/WorkspaceTreeWidget.cpp
+++ b/qt/widgets/common/src/WorkspacePresenter/WorkspaceTreeWidget.cpp
@@ -293,14 +293,8 @@ void WorkspaceTreeWidget::enableDeletePrompt(bool enable) { m_promptDelete = ena
 bool WorkspaceTreeWidget::isPromptDelete() const { return m_promptDelete; }
 
 bool WorkspaceTreeWidget::deleteConfirmation() const {
-  std::string message = "Are you sure you want to delete the selected Workspaces?";
-#if QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
-  message += "\n\nThis prompt can be disabled from:\nFile->Settings->General";
-#else
-  message += "\n\nThis prompt can be disabled "
-             "from:\nPreferences->General->Confirmations";
-#endif
-  return askUserYesNo("Delete Workspaces", message);
+  return askUserYesNo("Delete Workspaces", "Are you sure you want to delete the selected Workspaces?\n\nThis prompt "
+                                           "can be disabled from:\nFile->Settings->General");
 }
 
 void WorkspaceTreeWidget::deleteWorkspaces(const StringList &wsNames) {

--- a/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/ColorBar.h
+++ b/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/ColorBar.h
@@ -8,18 +8,10 @@
 
 #include <QtGlobal>
 
-#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
-#include "MantidQtWidgets/Plotting/Qwt/DraggableColorBarWidget.h"
-#elif QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
 #include "MantidQtWidgets/MplCpp/ColorbarWidget.h"
-#endif
 
 namespace MantidQt {
 namespace MantidWidgets {
-#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
-using ColorBar = DraggableColorBarWidget;
-#elif QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
 using ColorBar = MantidQt::Widgets::MplCpp::ColorbarWidget;
-#endif
 } // namespace MantidWidgets
 } // namespace MantidQt

--- a/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/ColorMap.h
+++ b/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/ColorMap.h
@@ -8,18 +8,10 @@
 
 #include <QtGlobal>
 
-#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
-#include "MantidQtWidgets/Plotting/Qwt/MantidColorMap.h"
-#elif QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
 #include "MantidQtWidgets/MplCpp/MantidColorMap.h"
-#endif
 
 namespace MantidQt {
 namespace MantidWidgets {
-#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
-using ColorMap = MantidColorMap;
-#elif QT_VERSION >= QT_VERSION_CHECK(5, 0, 0)
 using ColorMap = MantidQt::Widgets::MplCpp::MantidColorMap;
-#endif
 } // namespace MantidWidgets
 } // namespace MantidQt

--- a/qt/widgets/instrumentview/src/InstrumentActor.cpp
+++ b/qt/widgets/instrumentview/src/InstrumentActor.cpp
@@ -1150,18 +1150,7 @@ std::vector<std::string> InstrumentActor::getStringParameter(const std::string &
  * @return string representing the current state of the instrumet actor.
  */
 std::string InstrumentActor::saveToProject() const {
-#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
-  API::TSVSerialiser tsv;
-  const std::string currentColorMap = getCurrentColorMap().toStdString();
-
-  if (!currentColorMap.empty())
-    tsv.writeLine("FileName") << currentColorMap;
-
-  tsv.writeSection("binmasks", m_maskBinsData.saveToProject());
-  return tsv.outputLines();
-#else
   throw std::runtime_error("InstrumentActor::saveToProject() not implemented for Qt >= 5");
-#endif
 }
 
 /**
@@ -1169,23 +1158,8 @@ std::string InstrumentActor::saveToProject() const {
  * @param lines :: string representing the current state of the instrumet actor.
  */
 void InstrumentActor::loadFromProject(const std::string &lines) {
-#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
-  API::TSVSerialiser tsv(lines);
-  if (tsv.selectLine("FileName")) {
-    QString filename;
-    tsv >> filename;
-    loadColorMap(filename);
-  }
-
-  if (tsv.selectSection("binmasks")) {
-    std::string binMaskLines;
-    tsv >> binMaskLines;
-    m_maskBinsData.loadFromProject(binMaskLines);
-  }
-#else
   Q_UNUSED(lines);
   throw std::runtime_error("InstrumentActor::saveToProject() not implemented for Qt >= 5");
-#endif
 }
 
 bool InstrumentActor::hasGridBank() const { return m_hasGrid; }

--- a/qt/widgets/instrumentview/src/InstrumentWidgetMaskTab.cpp
+++ b/qt/widgets/instrumentview/src/InstrumentWidgetMaskTab.cpp
@@ -5,9 +5,6 @@
 //   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 // SPDX - License - Identifier: GPL - 3.0 +
 #include "MantidQtWidgets/InstrumentView/InstrumentWidgetMaskTab.h"
-#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
-#include "MantidQtWidgets/Common/TSVSerialiser.h"
-#endif
 #include "MantidQtWidgets/InstrumentView/DetXMLFile.h"
 #include "MantidQtWidgets/InstrumentView/InstrumentActor.h"
 #include "MantidQtWidgets/InstrumentView/InstrumentWidget.h"
@@ -1256,46 +1253,8 @@ void InstrumentWidgetMaskTab::changedIntegrationRange(double /*unused*/, double 
  * @param lines :: lines from the project file to load state from
  */
 void InstrumentWidgetMaskTab::loadFromProject(const std::string &lines) {
-#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
-  API::TSVSerialiser tsv(lines);
-
-  if (!tsv.selectSection("masktab"))
-    return;
-
-  std::string tabLines;
-  tsv >> tabLines;
-  API::TSVSerialiser tab(tabLines);
-
-  std::vector<QPushButton *> buttons{m_move,         m_pointer,        m_ellipse,  m_rectangle,
-                                     m_ring_ellipse, m_ring_rectangle, m_free_draw};
-
-  tab.selectLine("ActiveTools");
-  for (auto button : buttons) {
-    bool value;
-    tab >> value;
-    button->setChecked(value);
-  }
-
-  std::vector<QRadioButton *> typeButtons{m_masking_on, m_grouping_on, m_roi_on};
-
-  tab.selectLine("ActiveType");
-  for (auto type : typeButtons) {
-    bool value;
-    tab >> value;
-    type->setChecked(value);
-  }
-
-  if (tab.selectLine("MaskViewWorkspace")) {
-    // the view was masked. We should load reapply this from a cached
-    // workspace in the project folder
-    std::string maskWSName;
-    tab >> maskWSName;
-    loadMaskViewFromProject(maskWSName);
-  }
-#else
   Q_UNUSED(lines);
   throw std::runtime_error("InstrumentWidgetMaskTab::loadFromProject() not implemented for Qt >= 5");
-#endif
 }
 
 /** Load a mask workspace applied to the instrument actor from the project
@@ -1369,36 +1328,7 @@ Mantid::API::MatrixWorkspace_sptr InstrumentWidgetMaskTab::loadMask(const std::s
  * @return a string representing the state of the mask tab
  */
 std::string InstrumentWidgetMaskTab::saveToProject() const {
-#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
-  API::TSVSerialiser tsv;
-  API::TSVSerialiser tab;
-
-  std::vector<QPushButton *> buttons{m_move,         m_pointer,        m_ellipse,  m_rectangle,
-                                     m_ring_ellipse, m_ring_rectangle, m_free_draw};
-
-  tab.writeLine("ActiveTools");
-  for (auto button : buttons) {
-    tab << button->isChecked();
-  }
-
-  std::vector<QRadioButton *> typeButtons{m_masking_on, m_grouping_on, m_roi_on};
-
-  tab.writeLine("ActiveType");
-  for (auto type : typeButtons) {
-    tab << type->isChecked();
-  }
-
-  // Save the masks applied to view but not saved to a workspace
-  auto wsName = m_instrWidget->getWorkspaceName().toStdString() + "MaskView.xml";
-  bool success = saveMaskViewToProject(wsName);
-  if (success)
-    tab.writeLine("MaskViewWorkspace") << wsName;
-
-  tsv.writeSection("masktab", tab.outputLines());
-  return tsv.outputLines();
-#else
   throw std::runtime_error("InstrumentWidgetMaskTab::saveToProject() not implemented for Qt >= 5");
-#endif
 }
 
 /** Save a mask workspace containing masks applied to the instrument view

--- a/qt/widgets/instrumentview/src/InstrumentWidgetPickTab.cpp
+++ b/qt/widgets/instrumentview/src/InstrumentWidgetPickTab.cpp
@@ -5,9 +5,6 @@
 //   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 // SPDX - License - Identifier: GPL - 3.0 +
 #include "MantidQtWidgets/InstrumentView/InstrumentWidgetPickTab.h"
-#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
-#include "MantidQtWidgets/Common/TSVSerialiser.h"
-#endif
 #include "MantidQtWidgets/InstrumentView/CollapsiblePanel.h"
 #include "MantidQtWidgets/InstrumentView/InstrumentActor.h"
 #include "MantidQtWidgets/InstrumentView/InstrumentWidget.h"
@@ -865,53 +862,15 @@ void InstrumentWidgetPickTab::savePlotToWorkspace() { m_plotController->savePlot
  * @param lines :: lines from the project file to load state from
  */
 void InstrumentWidgetPickTab::loadFromProject(const std::string &lines) {
-#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
-  API::TSVSerialiser tsv(lines);
-
-  if (!tsv.selectSection("picktab"))
-    return;
-
-  std::string tabLines;
-  tsv >> tabLines;
-  API::TSVSerialiser tab(tabLines);
-
-  // load active push button
-  std::vector<QPushButton *> buttons{m_zoom,      m_edit, m_ellipse, m_rectangle, m_ring_ellipse, m_ring_rectangle,
-                                     m_free_draw, m_one,  m_tube,    m_peakAdd,   m_peakErase};
-
-  tab.selectLine("ActiveTools");
-  for (auto button : buttons) {
-    bool value;
-    tab >> value;
-    button->setChecked(value);
-  }
-#else
   Q_UNUSED(lines);
   throw std::runtime_error("MaskBinsData::loadFromProject() not implemented for Qt >= 5");
-#endif
 }
 
 /** Save the state of the pick tab to a Mantid project file
  * @return a string representing the state of the pick tab
  */
 std::string InstrumentWidgetPickTab::saveToProject() const {
-#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
-  API::TSVSerialiser tsv, tab;
-
-  // save active push button
-  std::vector<QPushButton *> buttons{m_zoom,      m_edit, m_ellipse, m_rectangle, m_ring_ellipse, m_ring_rectangle,
-                                     m_free_draw, m_one,  m_tube,    m_peakAdd,   m_peakErase};
-
-  tab.writeLine("ActiveTools");
-  for (auto button : buttons) {
-    tab << button->isChecked();
-  }
-
-  tsv.writeSection("picktab", tab.outputLines());
-  return tsv.outputLines();
-#else
   throw std::runtime_error("MaskBinsData::saveToProject() not implemented for Qt >= 5");
-#endif
 }
 
 //=====================================================================================//
@@ -1751,18 +1710,6 @@ QString DetectorPlotController::getTubeXUnitsName() const {
  * Return symbolic name of units of current TubeXUnit.
  */
 QString DetectorPlotController::getTubeXUnitsUnits() const {
-#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
-  switch (m_tubeXUnits) {
-  case LENGTH:
-    return "(m)";
-  case PHI:
-    return "(radians)";
-  case OUT_OF_PLANE_ANGLE:
-    return "(radians)";
-  default:
-    return "";
-  }
-#else
   switch (m_tubeXUnits) {
   case LENGTH:
     return "m";
@@ -1773,15 +1720,9 @@ QString DetectorPlotController::getTubeXUnitsUnits() const {
   default:
     return "";
   }
-#endif
 }
 
-void DetectorPlotController::setTubeXUnits(TubeXUnits units) {
-  m_tubeXUnits = units;
-#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
-  m_plot->setXLabel(getTubeXUnitsName() + " " + getTubeXUnitsUnits());
-#endif
-}
+void DetectorPlotController::setTubeXUnits(TubeXUnits units) { m_tubeXUnits = units; }
 
 /**
  * Get the plot caption for the current plot type.
@@ -1883,11 +1824,6 @@ void DetectorPlotController::addPeak(double x, double y) {
 /**
  * Zoom out back to the natural home of the mini plot
  */
-void DetectorPlotController::zoomOutOnPlot() {
-#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
-// Do nothing if in Qt4 or below.
-#else
-  m_plot->zoomOutOnPlot();
-#endif
-}
+void DetectorPlotController::zoomOutOnPlot() { m_plot->zoomOutOnPlot(); }
+
 } // namespace MantidQt::MantidWidgets

--- a/qt/widgets/instrumentview/src/InstrumentWidgetRenderTab.cpp
+++ b/qt/widgets/instrumentview/src/InstrumentWidgetRenderTab.cpp
@@ -12,10 +12,6 @@
 #include "MantidQtWidgets/InstrumentView/UCorrectionDialog.h"
 #include "MantidQtWidgets/InstrumentView/UnwrappedSurface.h"
 
-#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
-#include "MantidQtWidgets/Common/TSVSerialiser.h"
-#endif
-
 #include <QAction>
 #include <QActionGroup>
 #include <QCheckBox>
@@ -846,116 +842,15 @@ QPointF InstrumentWidgetRenderTab::getUCorrection() const {
  * Save widget render tab to a project file.
  * @return string representing the current state of the project file.
  */
-std::string MantidQt::MantidWidgets::InstrumentWidgetRenderTab::saveToProject() const {
-#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
-
-  API::TSVSerialiser tab;
-
-  tab.writeLine("AxesView") << mAxisCombo->currentIndex();
-  tab.writeLine("AutoScaling") << m_autoscaling->isChecked();
-  tab.writeLine("DisplayAxes") << m_displayAxes->isChecked();
-  tab.writeLine("FlipView") << m_flipCheckBox->isChecked();
-  tab.writeLine("DisplayDetectorsOnly") << m_displayDetectorsOnly->isChecked();
-  tab.writeLine("DisplayWireframe") << m_wireframe->isChecked();
-  tab.writeLine("DisplayLighting") << m_lighting->isChecked();
-  tab.writeLine("UseOpenGL") << m_GLView->isChecked();
-  tab.writeLine("UseUCorrection") << m_UCorrection->isChecked();
-
-  // peak options
-  auto surface = getSurface();
-  tab.writeLine("ShowLabels") << surface->getShowPeakLabelsFlag();
-  tab.writeLine("ShowRows") << surface->getShowPeakRowsFlag();
-  tab.writeLine("LabelPrecision") << surface->getPeakLabelPrecision();
-  tab.writeLine("ShowRelativeIntensity");
-  tab << surface->getShowPeakRelativeIntensityFlag();
-
-  const auto colorMap = m_colorBarWidget->saveToProject();
-  tab.writeSection("colormap", colorMap);
-
-  API::TSVSerialiser tsv;
-  tsv.writeSection("rendertab", tab.outputLines());
-  return tsv.outputLines();
-#else
-  return "";
-#endif
-}
+std::string MantidQt::MantidWidgets::InstrumentWidgetRenderTab::saveToProject() const { return ""; }
 
 /**
  * Load the state of the render tab from a project file.
  * @param lines :: lines defining the state of the render tab
  */
 void InstrumentWidgetRenderTab::loadFromProject(const std::string &lines) {
-#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
-  API::TSVSerialiser tsv(lines);
-
-  if (!tsv.selectSection("rendertab"))
-    return;
-
-  std::string tabLines;
-  tsv >> tabLines;
-  API::TSVSerialiser tab(tabLines);
-
-  bool autoScaling, displayAxes, flipView, displayDetectorsOnly, displayWireframe, displayLighting, useOpenGL,
-      useUCorrection;
-  int axesView;
-
-  tab.selectLine("AxesView");
-  tab >> axesView;
-  tab.selectLine("AutoScaling");
-  tab >> autoScaling;
-  tab.selectLine("DisplayAxes");
-  tab >> displayAxes;
-  tab.selectLine("FlipView");
-  tab >> flipView;
-  tab.selectLine("DisplayDetectorsOnly");
-  tab >> displayDetectorsOnly;
-  tab.selectLine("DisplayWireframe");
-  tab >> displayWireframe;
-  tab.selectLine("DisplayLighting");
-  tab >> displayLighting;
-  tab.selectLine("UseOpenGL");
-  tab >> useOpenGL;
-  tab.selectLine("UseUCorrection");
-  tab >> useUCorrection;
-
-  mAxisCombo->setCurrentIndex(axesView);
-  m_autoscaling->setChecked(autoScaling);
-  m_displayAxes->setChecked(displayAxes);
-  m_flipCheckBox->setChecked(flipView);
-  m_displayDetectorsOnly->setChecked(displayDetectorsOnly);
-  m_wireframe->setChecked(displayWireframe);
-  m_lighting->setChecked(displayLighting);
-  m_GLView->setChecked(useOpenGL);
-  m_UCorrection->setChecked(useUCorrection);
-
-  // peak options
-  auto surface = getSurface();
-  bool showLabels, showRows, showRelativeIntensity;
-  int labelPrecision;
-
-  tab.selectLine("ShowLabels");
-  tab >> showLabels;
-  tab.selectLine("ShowRows");
-  tab >> showRows;
-  tab.selectLine("LabelPrecision");
-  tab >> labelPrecision;
-  tab.selectLine("ShowRelativeIntensity");
-  tab >> showRelativeIntensity;
-
-  surface->setShowPeakLabelsFlag(showLabels);
-  surface->setShowPeakRowsFlag(showRows);
-  surface->setPeakLabelPrecision(labelPrecision);
-  surface->setShowPeakRelativeIntensityFlag(showRelativeIntensity);
-
-  if (tab.selectSection("colormap")) {
-    std::string colorMapLines;
-    tab >> colorMapLines;
-    m_colorBarWidget->loadFromProject(colorMapLines);
-  }
-#else
   Q_UNUSED(lines);
   throw std::runtime_error("InstrumentActor::saveToProject() not implemented for Qt >= 5");
-#endif
 }
 
 } // namespace MantidQt::MantidWidgets

--- a/qt/widgets/instrumentview/src/InstrumentWidgetTreeTab.cpp
+++ b/qt/widgets/instrumentview/src/InstrumentWidgetTreeTab.cpp
@@ -5,9 +5,6 @@
 //   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 // SPDX - License - Identifier: GPL - 3.0 +
 #include "MantidQtWidgets/InstrumentView/InstrumentWidgetTreeTab.h"
-#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
-#include "MantidQtWidgets/Common/TSVSerialiser.h"
-#endif
 #include "MantidQtWidgets/InstrumentView/InstrumentActor.h"
 #include "MantidQtWidgets/InstrumentView/InstrumentTreeWidget.h"
 #include "MantidQtWidgets/InstrumentView/InstrumentWidget.h"
@@ -63,63 +60,15 @@ void InstrumentWidgetTreeTab::showEvent(QShowEvent * /*unused*/) {
  * @param lines :: lines from the project file to load state from
  */
 void InstrumentWidgetTreeTab::loadFromProject(const std::string &lines) {
-#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
-  API::TSVSerialiser tsv(lines);
-
-  if (!tsv.selectSection("treetab"))
-    return;
-
-  std::string tabLines;
-  tsv >> tabLines;
-  API::TSVSerialiser tab(tabLines);
-
-  if (tab.selectLine("SelectedComponent")) {
-    std::string componentName;
-    tab >> componentName;
-    selectComponentByName(QString::fromStdString(componentName));
-  }
-
-  if (tab.selectLine("ExpandedItems")) {
-    auto names = tab.values("ExpandedItems");
-    for (auto &name : names) {
-      auto qName = QString::fromStdString(name);
-      auto index = m_instrumentTree->findComponentByName(qName);
-      m_instrumentTree->setExpanded(index, true);
-    }
-  }
-#else
   Q_UNUSED(lines);
   throw std::runtime_error("InstrumentWidgetTreeTab::loadFromProject() not implemented for Qt >= 5");
-#endif
 }
 
 /** Save the state of the tree tab to a Mantid project file
  * @return a string representing the state of the tree tab
  */
 std::string InstrumentWidgetTreeTab::saveToProject() const {
-#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
-  API::TSVSerialiser tsv, tab;
-
-  auto index = m_instrumentTree->currentIndex();
-  auto model = index.model();
-
-  if (model) {
-    auto item = model->data(index);
-    auto name = item.value<QString>();
-    tab.writeLine("SelectedComponent") << name;
-  }
-
-  auto names = m_instrumentTree->findExpandedComponents();
-  tab.writeLine("ExpandedItems");
-  for (const auto &name : names) {
-    tab << name;
-  }
-
-  tsv.writeSection("treetab", tab.outputLines());
-  return tsv.outputLines();
-#else
   throw std::runtime_error("InstrumentWidgetTreeTab::saveToProject() not implemented for Qt >= 5");
-#endif
 }
 
 } // namespace MantidQt::MantidWidgets

--- a/qt/widgets/instrumentview/src/MaskBinsData.cpp
+++ b/qt/widgets/instrumentview/src/MaskBinsData.cpp
@@ -8,10 +8,6 @@
 #include "MantidAPI/AlgorithmManager.h"
 #include "MantidAPI/MatrixWorkspace.h"
 
-#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
-#include "MantidQtWidgets/Common/TSVSerialiser.h"
-#endif
-
 #include <vector>
 
 namespace MantidQt::MantidWidgets {
@@ -70,49 +66,15 @@ void MaskBinsData::clear() { m_masks.clear(); }
  * @param lines :: lines from the project file to load state from
  */
 void MaskBinsData::loadFromProject(const std::string &lines) {
-#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
-  API::TSVSerialiser tsv(lines);
-  for (auto &maskLines : tsv.sections("Mask")) {
-    API::TSVSerialiser mask(maskLines);
-    mask.selectLine("Range");
-    double start, end;
-    mask >> start >> end;
-
-    std::vector<size_t> spectra;
-    const size_t numSpectra = mask.values("Spectra").size();
-    for (size_t i = 0; i < numSpectra; ++i) {
-      size_t spectrum;
-      mask >> spectrum;
-      spectra.emplace_back(spectrum);
-    }
-
-    addXRange(start, end, spectra);
-  }
-#else
   Q_UNUSED(lines);
   throw std::runtime_error("MaskBinsData::loadFromProject() not implemented for Qt >= 5");
-#endif
 }
 
 /** Save the state of the mask bins to a Mantid project file
  * @return a string representing the state of the mask bins
  */
 std::string MaskBinsData::saveToProject() const {
-#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
-  API::TSVSerialiser tsv;
-  for (const auto &binMask : m_masks) {
-    API::TSVSerialiser mask;
-    mask.writeLine("Range") << binMask.start << binMask.end;
-    mask.writeLine("Spectra");
-    for (auto spectrum : binMask.spectra) {
-      mask << spectrum;
-    }
-    tsv.writeSection("Mask", mask.outputLines());
-  }
-  return tsv.outputLines();
-#else
   throw std::runtime_error("MaskBinsData::saveToProject() not implemented for Qt >= 5");
-#endif
 }
 
 } // namespace MantidQt::MantidWidgets

--- a/qt/widgets/instrumentview/src/Projection3D.cpp
+++ b/qt/widgets/instrumentview/src/Projection3D.cpp
@@ -20,10 +20,6 @@
 #include "MantidGeometry/Objects/CSGObject.h"
 #include "MantidQtWidgets/Common/InputController.h"
 
-#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
-#include "MantidQtWidgets/Common/TSVSerialiser.h"
-#endif
-
 #include <memory>
 
 #include <QApplication>
@@ -449,33 +445,15 @@ void Projection3D::setLightingModel(bool picking) const {
  * @param lines :: lines from the project file to load state from
  */
 void Projection3D::loadFromProject(const std::string &lines) {
-#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
-  ProjectionSurface::loadFromProject(lines);
-  API::TSVSerialiser tsv(lines);
-
-  if (tsv.selectSection("Viewport")) {
-    std::string viewportLines;
-    tsv >> viewportLines;
-    m_viewport.loadFromProject(viewportLines);
-  }
-#else
   Q_UNUSED(lines);
   throw std::runtime_error("Projection3D::loadFromProject not implemented for Qt >= 5");
-#endif
 }
 
 /** Save the state of the 3D projection to a Mantid project file
  * @return a string representing the state of the 3D projection
  */
 std::string Projection3D::saveToProject() const {
-#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
-  API::TSVSerialiser tsv;
-  tsv.writeRaw(ProjectionSurface::saveToProject());
-  tsv.writeSection("Viewport", m_viewport.saveToProject());
-  return tsv.outputLines();
-#else
   throw std::runtime_error("Projection3D::saveToProject not implemented for Qt >= 5");
-#endif
 }
 
 void Projection3D::saveShapesToTableWorkspace() {

--- a/qt/widgets/instrumentview/src/Shape2DCollection.cpp
+++ b/qt/widgets/instrumentview/src/Shape2DCollection.cpp
@@ -5,9 +5,6 @@
 //   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 // SPDX - License - Identifier: GPL - 3.0 +
 #include "MantidQtWidgets/InstrumentView/Shape2DCollection.h"
-#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
-#include "MantidQtWidgets/Common/TSVSerialiser.h"
-#endif
 #include "MantidAPI/AnalysisDataService.h"
 #include "MantidAPI/ITableWorkspace.h"
 #include "MantidAPI/TableRow.h"
@@ -793,32 +790,15 @@ void Shape2DCollection::eraseFree(const QPolygonF &polygon) {
  * @param lines :: lines from the project file to load state from
  */
 void Shape2DCollection::loadFromProject(const std::string &lines) {
-#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
-  API::TSVSerialiser tsv(lines);
-  for (const auto &shapeLines : tsv.sections("shape")) {
-    Shape2D *shape = Shape2D::loadFromProject(shapeLines);
-    m_shapes.push_back(shape);
-    emit shapeCreated();
-  }
-#else
   Q_UNUSED(lines);
   throw std::runtime_error("Shape2DCollection::loadFromProject() not implemented for Qt >= 5");
-#endif
 }
 
 /** Save the state of the shape 2D collection to a Mantid project file
  * @return a string representing the state of the shape 2D collection
  */
 std::string Shape2DCollection::saveToProject() const {
-#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
-  API::TSVSerialiser tsv;
-  for (auto shape : m_shapes) {
-    tsv.writeSection("shape", shape->saveToProject());
-  }
-  return tsv.outputLines();
-#else
   throw std::runtime_error("Shape2DCollection::saveToProject() not implemented for Qt >= 5");
-#endif
 }
 
 } // namespace MantidQt::MantidWidgets

--- a/qt/widgets/instrumentview/src/UnwrappedSurface.cpp
+++ b/qt/widgets/instrumentview/src/UnwrappedSurface.cpp
@@ -17,9 +17,6 @@
 #include "MantidGeometry/Instrument/DetectorInfo.h"
 #include "MantidGeometry/Objects/CSGObject.h"
 #include "MantidQtWidgets/Common/InputController.h"
-#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
-#include "MantidQtWidgets/Common/TSVSerialiser.h"
-#endif
 
 #include <QApplication>
 #include <QMenu>
@@ -634,35 +631,8 @@ void UnwrappedSurface::calcSize(UnwrappedDetector &udet) {
  * @param lines :: lines from the project file to load state from
  */
 void UnwrappedSurface::loadFromProject(const std::string &lines) {
-#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
-  ProjectionSurface::loadFromProject(lines);
-  API::TSVSerialiser tsv(lines);
-
-  if (tsv.selectLine("Zoom")) {
-    double x0, y0, x1, y1;
-    tsv >> x0 >> y0 >> x1 >> y1;
-    RectF bounds(QPointF(x0, y0), QPointF(x1, y1));
-
-    m_zoomStack.push(m_viewRect);
-    m_viewRect = bounds;
-    updateView();
-    emit updateInfoText();
-  }
-
-  if (tsv.selectLine("PeaksWorkspaces")) {
-    size_t workspaceCount = tsv.values("PeaksWorkspaces").size();
-    for (size_t i = 0; i < workspaceCount; ++i) {
-      std::string name;
-      tsv >> name;
-      auto ws = retrievePeaksWorkspace(name);
-      if (ws)
-        setPeaksWorkspace(ws);
-    }
-  }
-#else
   Q_UNUSED(lines);
   throw std::runtime_error("UnwrappedSurface::loadFromProject() not implemented for Qt >= 5");
-#endif
 }
 
 /**
@@ -689,23 +659,7 @@ Mantid::API::IPeaksWorkspace_sptr UnwrappedSurface::retrievePeaksWorkspace(const
  * @return a string representing the state of the surface
  */
 std::string UnwrappedSurface::saveToProject() const {
-#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
-  API::TSVSerialiser tsv;
-  tsv.writeRaw(ProjectionSurface::saveToProject());
-
-  tsv.writeLine("Zoom");
-  tsv << m_viewRect.x0() << m_viewRect.y0();
-  tsv << m_viewRect.x1() << m_viewRect.y1();
-
-  tsv.writeLine("PeaksWorkspaces");
-  for (auto overlay : m_peakShapes) {
-    tsv << overlay->getPeaksWorkspace()->getName();
-  }
-
-  return tsv.outputLines();
-#else
   throw std::runtime_error("UnwrappedSurface::saveToProject() not implemented for Qt >= 5");
-#endif
 }
 
 } // namespace MantidQt::MantidWidgets

--- a/qt/widgets/instrumentview/src/Viewport.cpp
+++ b/qt/widgets/instrumentview/src/Viewport.cpp
@@ -496,29 +496,8 @@ void Viewport::transform(Mantid::Kernel::V3D &pos) const {
 }
 
 void Viewport::loadFromProject(const std::string &lines) {
-#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
-  reset();
-  API::TSVSerialiser tsv(lines);
-
-  tsv.selectLine("Translation");
-  double xTrans, yTrans;
-  tsv >> xTrans >> yTrans;
-  setTranslation(xTrans, yTrans);
-
-  tsv.selectLine("Zoom");
-  double zoom;
-  tsv >> zoom;
-  setZoom(zoom);
-
-  tsv.selectLine("Rotation");
-  double w, a, b, c;
-  tsv >> w >> a >> b >> c;
-  Mantid::Kernel::Quat quat(w, a, b, c);
-  setRotation(quat);
-#else
   Q_UNUSED(lines);
   throw std::runtime_error("Viewport::loadFromProject not implemented for Qt >= 5");
-#endif
 }
 
 std::string Viewport::saveToProject() const {

--- a/qt/widgets/mplcpp/inc/MantidQtWidgets/MplCpp/BackendQt.h
+++ b/qt/widgets/mplcpp/inc/MantidQtWidgets/MplCpp/BackendQt.h
@@ -14,9 +14,7 @@
  * Defines constants relating to the matplotlib backend
  */
 
-#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
-#error "Qt >= 5 required"
-#elif QT_VERSION >= QT_VERSION_CHECK(5, 0, 0) && QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
 
 /// Define PyQt version that matches the matplotlib backend
 constexpr static const char *PYQT_MODULE = "PyQt5";

--- a/qt/widgets/plotting/inc/MantidQtWidgets/Plotting/PeakPicker.h
+++ b/qt/widgets/plotting/inc/MantidQtWidgets/Plotting/PeakPicker.h
@@ -8,8 +8,4 @@
 
 #include <QtGlobal>
 
-#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
-#include "MantidQtWidgets/Plotting/Qwt/PeakPicker.h"
-#else
 #include "MantidQtWidgets/Plotting/Mpl/PeakPicker.h"
-#endif

--- a/qt/widgets/plotting/inc/MantidQtWidgets/Plotting/PreviewPlot.h
+++ b/qt/widgets/plotting/inc/MantidQtWidgets/Plotting/PreviewPlot.h
@@ -8,8 +8,4 @@
 
 #include <QtGlobal>
 
-#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
-#include "MantidQtWidgets/Plotting/Qwt/PreviewPlot.h"
-#else
 #include "MantidQtWidgets/Plotting/Mpl/PreviewPlot.h"
-#endif

--- a/qt/widgets/plotting/inc/MantidQtWidgets/Plotting/RangeSelector.h
+++ b/qt/widgets/plotting/inc/MantidQtWidgets/Plotting/RangeSelector.h
@@ -8,8 +8,4 @@
 
 #include <QtGlobal>
 
-#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
-#include "MantidQtWidgets/Plotting/Qwt/RangeSelector.h"
-#else
 #include "MantidQtWidgets/Plotting/Mpl/RangeSelector.h"
-#endif

--- a/qt/widgets/plotting/inc/MantidQtWidgets/Plotting/SingleSelector.h
+++ b/qt/widgets/plotting/inc/MantidQtWidgets/Plotting/SingleSelector.h
@@ -8,8 +8,4 @@
 
 #include <QtGlobal>
 
-#if QT_VERSION < QT_VERSION_CHECK(5, 0, 0)
-#include "MantidQtWidgets/Plotting/Qwt/SingleSelector.h"
-#else
 #include "MantidQtWidgets/Plotting/Mpl/SingleSelector.h"
-#endif


### PR DESCRIPTION
**Description of work.**
This PR removes as many `QT_VERSION_CHECK`'s for qt4 as possible.

**To test:**
1. Code review
2. grep for `QT_VERSION_CHECK` and check that all that can be removed, has been removed
3. Ensure all Qt4 code in pqHelpWindow.h and pqHelpWindow.cxx is removed.

Part of #30268

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
