### PR TITLE
Missing ws type in superplot

### DIFF
--- a/docs/source/release/v6.4.0/Workbench/Bugfixes/33866.rst
+++ b/docs/source/release/v6.4.0/Workbench/Bugfixes/33866.rst
@@ -1,0 +1,1 @@
+- RebinnedOutput workspaces are now supported in the Superplot

--- a/qt/python/mantidqt/mantidqt/widgets/superplot/view.py
+++ b/qt/python/mantidqt/mantidqt/widgets/superplot/view.py
@@ -161,7 +161,8 @@ class SuperplotViewSide(QDockWidget):
         ws_list.setMinimumSize(QSize(size0 + size1, 0))
         self.workspaceSelector.setWorkspaceTypes(["Workspace2D",
                                                   "WorkspaceGroup",
-                                                  "EventWorkspace"])
+                                                  "EventWorkspace",
+                                                  "RebinnedOutput"])
         self.setAcceptDrops(True)
 
     def dragEnterEvent(self, event):


### PR DESCRIPTION
**Description of work.**

This PR adds support for RebinnedOutput workspaces in the Superplot.

Our users requested this feature to be able to plot results of `DirectILLReduction`.

**To test:**

With data from `ExternalData/Testing/Data/UnitTest/ILL/IN5/`

* Run the following script:
```python
from mantid.simpleapi import DirectILLCollectData, DirectILLReduction

DirectILLCollectData(
    Run='104007.nxs',                                           
    OutputWorkspace='sample'
    )

DirectILLReduction(
    InputWorkspace='sample',
    OutputWorkspace='out'
    )
```
* Open the superplot on any workspace
* Observe the workspace selection combobox in the superplot dialog. It should contain the "out" workspace.


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
