### PR TITLE
Remove the last of the Python 2 Code from the Project

### DIFF
--- a/Framework/PythonInterface/mantid/api/src/Exports/ITableWorkspace.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/ITableWorkspace.cpp
@@ -51,18 +51,12 @@ GET_POINTER_SPECIALIZATION(ITableWorkspace)
 namespace {
 
 // Numpy PyArray_IsIntegerScalar is broken for Python 3 for numpy < 1.11
-#if PY_MAJOR_VERSION >= 3
 #define TO_LONG PyLong_AsLong
 #define STR_CHECK PyUnicode_Check
 #if NPY_API_VERSION < 0x0000000a //(1.11)
 #define IS_ARRAY_INTEGER(obj) (PyLong_Check(obj) || PyArray_IsScalar((obj), Integer))
 #else
 #define IS_ARRAY_INTEGER PyArray_IsIntegerScalar
-#endif
-#else // Python 2
-#define IS_ARRAY_INTEGER PyArray_IsIntegerScalar
-#define TO_LONG PyInt_AsLong
-#define STR_CHECK PyString_Check
 #endif
 
 /// Boost macro for "looping" over builtin types

--- a/Framework/PythonInterface/mantid/api/src/PythonAlgorithm/AlgorithmAdapter.cpp
+++ b/Framework/PythonInterface/mantid/api/src/PythonAlgorithm/AlgorithmAdapter.cpp
@@ -166,13 +166,7 @@ template <typename BaseAlgorithm> bool AlgorithmAdapter<BaseAlgorithm>::isRunnin
     if (PyErr_Occurred())
       throw PythonException();
     if (PyBool_Check(result)) {
-
-#if PY_MAJOR_VERSION >= 3
       return static_cast<bool>(PyLong_AsLong(result));
-#else
-      return static_cast<bool>(PyInt_AsLong(result));
-#endif
-
     } else
       throw std::runtime_error("Algorithm.isRunning - Expected bool return type.");
   }

--- a/Framework/PythonInterface/mantid/kernel/src/Exports/IPropertyManager.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Exports/IPropertyManager.cpp
@@ -53,12 +53,8 @@ void setProperty(IPropertyManager &self, const std::string &name, const boost::p
 }
 
 void setProperties(IPropertyManager &self, const boost::python::dict &kwargs) {
-#if PY_MAJOR_VERSION >= 3
   const object view = kwargs.attr("items")();
   const object objectItems(handle<>(PyObject_GetIter(view.ptr())));
-#else
-  const object objectItems = kwargs.iteritems();
-#endif
   auto begin = stl_input_iterator<object>(objectItems);
   auto end = stl_input_iterator<object>();
   for (auto it = begin; it != end; ++it) {

--- a/Framework/PythonInterface/mantid/kernel/src/Exports/Material.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Exports/Material.cpp
@@ -74,11 +74,7 @@ void export_Material() {
       .add_property("temperature", make_function(&Material::temperature), "Temperature")
       .add_property("pressure", make_function(&Material::pressure), "Pressure")
       .add_property("totalAtoms", make_function(&Material::totalAtoms), "Total number of atoms")
-#if PY_MAJOR_VERSION >= 3
       .def("__bool__", &toBool, "Returns True if any of the scattering values are non-zero")
-#else
-      .def("__nonzero__", &toBool, "Returns True if any of the scattering values are non-zero")
-#endif
       .def("cohScatterXSection", (double (Material::*)() const)(&Material::cohScatterXSection), (arg("self")),
            "Coherent Scattering Cross-Section for the given wavelength in "
            "barns")

--- a/Framework/PythonInterface/mantid/kernel/src/Exports/UnitLabel.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Exports/UnitLabel.cpp
@@ -23,15 +23,9 @@ namespace {
 std::shared_ptr<UnitLabel> createLabel(const object &ascii, const object &utf8, const object &latex) {
   using Utf8Char = UnitLabel::Utf8String::value_type;
   if (PyUnicode_Check(utf8.ptr())) {
-#if PY_MAJOR_VERSION >= 3
     auto length = PyUnicode_GetLength(utf8.ptr());
     boost::scoped_array<Utf8Char> buffer(new Utf8Char[length]);
     PyUnicode_AsWideChar(utf8.ptr(), buffer.get(), length);
-#else
-    auto length = PyUnicode_GetSize(utf8.ptr());
-    boost::scoped_array<Utf8Char> buffer(new Utf8Char[length]);
-    PyUnicode_AsWideChar(reinterpret_cast<PyUnicodeObject *>(utf8.ptr()), buffer.get(), length);
-#endif
     return std::make_shared<UnitLabel>(extract<std::string>(ascii)(),
                                        UnitLabel::Utf8String(buffer.get(), buffer.get() + length),
                                        extract<std::string>(latex)());

--- a/Framework/PythonInterface/mantid/kernel/src/Registry/PropertyManagerFactory.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Registry/PropertyManagerFactory.cpp
@@ -27,12 +27,8 @@ namespace PythonInterface::Registry {
  */
 std::shared_ptr<Kernel::PropertyManager> createPropertyManager(const boost::python::dict &mapping) {
   auto pmgr = std::make_shared<PropertyManager>();
-#if PY_MAJOR_VERSION >= 3
   object view(mapping.attr("items")());
   object itemIter(handle<>(PyObject_GetIter(view.ptr())));
-#else
-  object itemIter(mapping.attr("iteritems")());
-#endif
   auto length = len(mapping);
   for (ssize_t i = 0; i < length; ++i) {
     const object keyValue(handle<>(PyIter_Next(itemIter.ptr())));

--- a/Framework/PythonInterface/mantid/kernel/src/Registry/PropertyWithValueFactory.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Registry/PropertyWithValueFactory.cpp
@@ -59,15 +59,6 @@ void initTypeLookup(PyTypeIndex &index) {
   using AsciiStrHandler = TypedPropertyValueHandler<std::string>;
   // Both versions have unicode objects
   index.emplace(&PyUnicode_Type, std::make_shared<AsciiStrHandler>());
-
-#if PY_MAJOR_VERSION < 3
-  // Version < 3 had separate fixed-precision long and arbitrary precision
-  // long objects. Handle these too
-  index.emplace(&PyInt_Type, std::make_shared<IntHandler>());
-  // Version 2 also has the PyString_Type
-  index.emplace(&PyString_Type, std::make_shared<AsciiStrHandler>());
-#endif
-
   // Handle a dictionary type
   index.emplace(&PyDict_Type, std::make_shared<MappingTypeHandler>());
 }
@@ -100,12 +91,6 @@ void initArrayLookup(PyArrayIndex &index) {
 
   using LongIntArrayHandler = SequenceTypeHandler<std::vector<long>>;
   index.emplace("LongIntArray", std::make_shared<LongIntArrayHandler>());
-
-#if PY_MAJOR_VERSION < 3
-  // Backwards compatible behaviour
-  using IntArrayHandler = SequenceTypeHandler<std::vector<int>>;
-  index.emplace("IntArray", std::make_shared<IntArrayHandler>());
-#endif
 }
 
 /**
@@ -240,21 +225,12 @@ const std::string PropertyWithValueFactory::isArray(PyObject *const object) {
       return std::string("LongIntArray");
     }
     GNU_DIAG_ON("parentheses-equality")
-
-#if PY_MAJOR_VERSION < 3
-    // In python 2 ints & longs are separate
-    if (PyInt_Check(item)) {
-      return std::string("IntArray");
-    }
-#endif
     if (PyFloat_Check(item)) {
       return std::string("FloatArray");
     }
-#if PY_MAJOR_VERSION >= 3
     if (PyUnicode_Check(item)) {
       return std::string("StringArray");
     }
-#endif
     if (PyBytes_Check(item)) {
       return std::string("StringArray");
     }

--- a/Framework/PythonInterface/test/cpp/PropertyWithValueFactoryTest.h
+++ b/Framework/PythonInterface/test/cpp/PropertyWithValueFactoryTest.h
@@ -33,13 +33,8 @@ public:
   static PropertyWithValueFactoryTest *createSuite() { return new PropertyWithValueFactoryTest(); }
   static void destroySuite(PropertyWithValueFactoryTest *suite) { delete suite; }
 
-#if PY_MAJOR_VERSION >= 3
 #define FROM_INT PyLong_FromLong
 #define FROM_CSTRING PyUnicode_FromString
-#else
-#define FROM_INT PyInt_FromLong
-#define FROM_CSTRING PyString_FromString
-#endif
 
 #define CREATE_PROPERTY_TEST_BODY(CType, PythonCall)                                                                   \
                                                                                                                        \
@@ -76,11 +71,7 @@ public:
   }
 
   void test_builtin_type_create_int_array_from_list_type_property() {
-#if PY_MAJOR_VERSION < 3
-    testCreateArrayProperty<int>(Py_BuildValue("[ii]", -10, 4));
-#else
     testCreateArrayProperty<long>(Py_BuildValue("[ii]", -10, 4));
-#endif
   }
 
 private:

--- a/Testing/PerformanceTests/analysis.py
+++ b/Testing/PerformanceTests/analysis.py
@@ -468,7 +468,7 @@ def generate_html_subproject_report(path, last_num, x_field='revision', starts_w
 
     # -------- Report for each test ------------------------
     for name in test_names:
-        print "Plotting", name
+        print("Plotting", name)
         html += """<hr><h2>%s</h2>\n""" % name
         overview_html += """<hr><h2>%s</h2>\n""" % name
 
@@ -575,7 +575,7 @@ def generate_html_report(path, last_num, x_field='revision'):
     f.write(overview_html)
     f.close()
 
-    print "Report complete!"
+    print("Report complete!")
 
 
 # ============================================================================================

--- a/Testing/PerformanceTests/check_performance.py
+++ b/Testing/PerformanceTests/check_performance.py
@@ -35,12 +35,12 @@ import secureemail
 #====================================================================================
 def run(args):
     """ Execute the program """
-    print
-    print "=============== Checking For Performance Loss ====================="
+    print()
+    print("=============== Checking For Performance Loss =====================")
     dbfile = args.db[0]
 
     if not os.path.exists(dbfile):
-        print "Database file %s not found."
+        print("Database file %s not found.")
         sys.exit(1)
 
     # Set the database to the one given
@@ -51,7 +51,7 @@ def run(args):
     tol = float(args.tol)
     rev = sqlresults.get_latest_revison()
 
-    print "Comparing the average of the %d revisions before rev. %d. Tolerance of %g %%." % (avg, rev, tol)
+    print("Comparing the average of the %d revisions before rev. %d. Tolerance of %g %%." % (avg, rev, tol))
     if args.verbose: print
 
     # For limiting the results
@@ -59,7 +59,7 @@ def run(args):
 
     names = sqlresults.get_all_test_names("revision = %d" % rev)
     if len(names) == 0:
-        print "Error! No tests found at revision number %d.\n" % rev
+        print("Error! No tests found at revision number %d.\n" % rev)
         sys.exit(1)
 
     bad_results = ""

--- a/Testing/PerformanceTests/make_report.py
+++ b/Testing/PerformanceTests/make_report.py
@@ -30,7 +30,7 @@ def join_databases(dbfiles):
     all_results = []
     # Get the results of each file
     for dbfile in dbfiles:
-        print "Reading", dbfile
+        print("Reading", dbfile)
         sqlresults.set_database_filename(dbfile)
         these_results = sqlresults.get_results("")
         all_results += these_results
@@ -85,7 +85,7 @@ if __name__ == "__main__":
         dbfile = args.dbfile[0]
 
     if not os.path.exists(dbfile):
-        print "Error! Could not find", dbfile
+        print("Error! Could not find", dbfile)
         sys.exit(1)
 
     # This is where we look for the DB file

--- a/Testing/PerformanceTests/reporters.py
+++ b/Testing/PerformanceTests/reporters.py
@@ -41,14 +41,14 @@ class TextResultReporter(ResultReporter):
         Print the results to standard out
         '''
         nstars = 30
-        print '*' * nstars
+        print('*' * nstars)
         for (name, val) in result.data.items():
             str_val = str(val)
             str_val = str_val.replace("\n", " ")
             if len(str_val) > 50:
                 str_val = str_val[:50] + " . . . "
-            print '    ' + name.ljust(15) + '->  ', str_val
-        print '*' * nstars
+            print('    ' + name.ljust(15) + '->  ', str_val)
+        print('*' * nstars)
 
 
 #########################################################################

--- a/Testing/PerformanceTests/xunit_to_sql.py
+++ b/Testing/PerformanceTests/xunit_to_sql.py
@@ -74,7 +74,7 @@ def handle_suite(suite):
 def convert_xml(filename):
     """Convert a single XML file to SQL db"""
     # Parse the xml
-    print "Reading", filename
+    print("Reading", filename)
     doc = parse(filename)
     suites = doc.getElementsByTagName("testsuite")
     for suite in suites:

--- a/Testing/SystemTests/lib/systemtests/algorithm_decorator.py
+++ b/Testing/SystemTests/lib/systemtests/algorithm_decorator.py
@@ -33,9 +33,9 @@ def make_decorator(algorithm_to_decorate):
 
         def execute(self, additional=None, verbose=False):
             if verbose:
-                print "Algorithm Parameters:"
-                print self.__parameters__
-                print
+                print("Algorithm Parameters:")
+                print(self.__parameters__)
+                print()
             out = self.__alg_subject(**self.__parameters__)
             return out
 

--- a/Testing/SystemTests/scripts/performance/make_report.py
+++ b/Testing/SystemTests/scripts/performance/make_report.py
@@ -31,7 +31,7 @@ def join_databases(dbfiles):
     all_results = []
     # Get the results of each file
     for dbfile in dbfiles:
-        print "Reading", dbfile
+        print("Reading", dbfile)
         sqlresults.set_database_filename(dbfile)
         these_results = sqlresults.get_results("")
         all_results += these_results
@@ -79,7 +79,7 @@ if __name__ == "__main__":
 
 
     if not os.path.exists(dbfile):
-        print "Error! Could not find", dbfile
+        print("Error! Could not find", dbfile)
         sys.exit(1)
 
     # This is where we look for the DB file

--- a/Testing/SystemTests/scripts/performance/reporters.py
+++ b/Testing/SystemTests/scripts/performance/reporters.py
@@ -41,14 +41,14 @@ class TextResultReporter(ResultReporter):
         Print the results to standard out
         '''
         nstars = 30
-        print '*' * nstars
+        print('*' * nstars)
         for (name, val) in result.data.items():
             str_val = str(val)
             str_val = str_val.replace("\n", " ")
             if len(str_val) > 50:
                 str_val = str_val[:50] + " . . . "
-            print '    ' + name.ljust(15) + '->  ', str_val
-        print '*' * nstars
+            print('    ' + name.ljust(15) + '->  ', str_val)
+        print('*' * nstars)
 
 
 #########################################################################

--- a/Testing/SystemTests/scripts/performance/xunit_to_sql.py
+++ b/Testing/SystemTests/scripts/performance/xunit_to_sql.py
@@ -83,7 +83,7 @@ def handle_suite(suite):
 def convert_xml(filename):
     """Convert a single XML file to SQL db"""
     # Parse the xml
-    print "Reading", filename
+    print("Reading", filename)
     doc = parse(filename)
     suites = doc.getElementsByTagName("testsuite")
     for suite in suites:


### PR DESCRIPTION
**Description of work.**
This PR should cover the removal of the last little bits of python 2 that were left from before, mainly removing if statements to check the py version in the C++ code and from the report generation scripts. 

**To test:**
There's a few different elements changed but nothing should be affected, mainly checking that TableWorkspaces can still be generated from scripts, that algorithms still work, and that unit labels can be changed from python. 

Fixes #27722 

*This does not require release notes* because **it is an internal change.**

**Note:** The parts of jenkins responsible for report generation may need updating after this is merged. 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
