### PR TITLE
Fix deadlock with AlgorithmManager Python exports

### DIFF
--- a/Framework/PythonInterface/mantid/api/src/Exports/AlgorithmManager.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/AlgorithmManager.cpp
@@ -46,7 +46,10 @@ IAlgorithm_sptr create(AlgorithmManagerImpl *self, const std::string &algName, c
 }
 
 void clear(AlgorithmManagerImpl *self) {
-  ReleaseGlobalInterpreterLock releaseGIL;
+  /// TODO We should release the GIL here otherwise we risk deadlock (see issue #33895). However, doing so causes
+  /// test failures because it exposes an unreleated bug to do with the way we handle shared_ptrs to Python objects
+  /// (see #33924). Fixing that is not trivial, so I am reverting this change until it can be resolved properly.
+  // ReleaseGlobalInterpreterLock releaseGIL;
   return self->clear();
 }
 


### PR DESCRIPTION
**Report to:** Max at ISIS

**Description of work.**
This PR fixes a race condition that could result in deadlock. It ensures that the AlgorithmManager Python exports always release the GIL before calling into C++ functions that require a mutex. See the commit messages for more details.

Fixes #33894

**To test:**

See the linked issue and ensure you can no longer reproduce the hang.

*This does not require release notes* because **it is already covered by the release notes in #33756**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
