### PR TITLE
Fixed typo in external plotting

### DIFF
--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/plot_widget/external_plotting/external_plotting_view.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/plot_widget/external_plotting/external_plotting_view.py
@@ -74,7 +74,7 @@ class ExternalPlottingView(object):
         external_axes = fig_window.axes
         for plot_info in data:
             external_axis = external_axes[plot_info.axis]
-            external_axis.plot(plot_info.workspace, specNum=plot_info.specNume, distribution=not plot_info.normalised)
+            external_axis.plot(plot_info.workspace, specNum=plot_info.specNum, distribution=not plot_info.normalised)
             legend_set_draggable(external_axis.legend(), True)
         fig_window.show()
 


### PR DESCRIPTION
**Description of work.**
We introduced a typo into the external plotting code for muons. This PR fixes it.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**

<!-- Instructions for testing. -->
Open muon analysis
Load some data
Press the external plot button - it wont crash
A plot will appear

Fixes #33892. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->

This does not have a release note as it was due to a typo added in March (so has not been in a release)

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
