### PR TITLE
Fix crash in Frequency Domain Analysis caused by changing units

### DIFF
--- a/docs/source/release/v6.4.0/Muon/FDA/Bugfixes/33891.rst
+++ b/docs/source/release/v6.4.0/Muon/FDA/Bugfixes/33891.rst
@@ -1,0 +1,1 @@
+- Changing the units on the frequency plot no longer causes a crash.

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/FrequencyDomainAnalysis/frequency_context.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/FrequencyDomainAnalysis/frequency_context.py
@@ -120,6 +120,8 @@ class FrequencyContext(object):
         return int(run) == int(fft_run) and (fft_group_or_pair in group or fft_group_or_pair in pair)
 
     def switch_units_in_name(self, name):
+        if name is None:
+            return None
         if MHz in name:
             return name.replace(MHz, GAUSS)
         elif GAUSS in name:

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/FrequencyDomainAnalysis/plot_widget/dual_plot_maxent_pane/dual_plot_maxent_pane_presenter.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/FrequencyDomainAnalysis/plot_widget/dual_plot_maxent_pane/dual_plot_maxent_pane_presenter.py
@@ -108,5 +108,7 @@ class DualPlotMaxentPanePresenter(BasePanePresenter):
         else:
             self._view.set_plot_type(FREQ_X_LABEL)
         self._figure_presenter.set_plot_range(self.context.frequency_context.range())
+        if self._maxent_ws_name is None:
+            return
         new_ws_name = self.context._frequency_context.switch_units_in_name(self._maxent_ws_name)
         self.handle_maxent_data_updated(new_ws_name)

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/FrequencyDomainAnalysis/plot_widget/dual_plot_maxent_pane/dual_plot_maxent_pane_presenter.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/FrequencyDomainAnalysis/plot_widget/dual_plot_maxent_pane/dual_plot_maxent_pane_presenter.py
@@ -51,6 +51,8 @@ class DualPlotMaxentPanePresenter(BasePanePresenter):
         self._model.set_period(period)
 
     def handle_maxent_data_updated(self, name):
+        if name is None:
+            return
         self._maxent_ws_name = name
         self._model.set_run_from_name(name)
         self.add_data_to_plots()

--- a/qt/python/mantidqtinterfaces/test/Muon/dual_plot_maxent_pane/dual_plot_maxent_pane_presenter_test.py
+++ b/qt/python/mantidqtinterfaces/test/Muon/dual_plot_maxent_pane/dual_plot_maxent_pane_presenter_test.py
@@ -195,6 +195,20 @@ class DualPlotMaxentPanePresenterTest(unittest.TestCase):
         self.view.set_plot_type.assert_called_once_with(FIELD_X_LABEL)
         self.presenter.handle_maxent_data_updated.assert_called_once_with("unit test")
 
+    def test_update_pane_none(self):
+        self.context.frequency_context.unit = mock.Mock(return_value="Gauss")
+        self.context.frequency_context.range = mock.MagicMock(return_value=[1,3])
+        self.context._frequency_context.switch_units_in_name = mock.Mock(return_value="unit test")
+        self.presenter._maxent_ws_name = None
+        self.presenter.handle_maxent_data_updated = mock.Mock()
+
+        self.presenter._update_pane()
+
+        self.context._frequency_context.switch_units_in_name.assert_not_called()
+        self.figure_presenter.set_plot_range.assert_called_once_with([1, 3])
+        self.view.set_plot_type.assert_called_once_with(FIELD_X_LABEL)
+        self.presenter.handle_maxent_data_updated.assert_not_called()
+
 
 if __name__ == '__main__':
     unittest.main(buffer=False, verbosity=2)

--- a/qt/python/mantidqtinterfaces/test/Muon/dual_plot_maxent_pane/dual_plot_maxent_pane_presenter_test.py
+++ b/qt/python/mantidqtinterfaces/test/Muon/dual_plot_maxent_pane/dual_plot_maxent_pane_presenter_test.py
@@ -61,6 +61,15 @@ class DualPlotMaxentPanePresenterTest(unittest.TestCase):
         self.model.set_run_from_name.assert_called_once_with(name)
         self.presenter.add_data_to_plots.assert_called_once_with()
 
+    def test_handle_maxent_data_updated_None(self):
+        self.presenter.add_data_to_plots = mock.Mock()
+        name = None
+
+        self.presenter.handle_maxent_data_updated(name)
+        self.assertEqual(self.presenter._maxent_ws_name, name)
+        self.model.set_run_from_name.assert_not_called()
+        self.presenter.add_data_to_plots.assert_not_called()
+
     def test_add_data_to_plots(self):
         ws = ["unit", "test"]
         indices = [1,3]

--- a/qt/python/mantidqtinterfaces/test/Muon/frequency_domain_context_test.py
+++ b/qt/python/mantidqtinterfaces/test/Muon/frequency_domain_context_test.py
@@ -298,6 +298,9 @@ class MuonFreqContextTest(unittest.TestCase):
     def test_switch_units_in_name_field_to_freq(self):
         self.assertEqual(self.context.switch_units_in_name(f"unit {GAUSS} test"), f"unit {MHz} test")
 
+    def test_switch_units_in_name_with_None(self):
+        self.assertEqual(self.context.switch_units_in_name(None), None)
+
     def test_range(self):
         self.context.x_label = FIELD
         self.assertEqual(self.context.range(), [0.0, 1000.0])


### PR DESCRIPTION
**Description of work.**

When the user would change the frequency units in the frequency domain analysis GUI Mantid would crash.

**To test:**

Open frequency domain analysis
Load MUSR 62260
Go to the transform tab
Click "calculate" at the bottom of the tab
A line will appear in the plot showing a peak. 
Just above the plot change the unit from "frequency" to "field" -> it will not crash
Notice that the x axis is now different.

Fixes #33891  <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->

In release notes

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
