### PR TITLE
fixed missing unsubscribe in muon GUI's

### DIFF
--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/FrequencyDomainAnalysis/frequency_domain_analysis.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/FrequencyDomainAnalysis/frequency_domain_analysis.py
@@ -518,4 +518,5 @@ class FrequencyAnalysisGui(QtWidgets.QMainWindow):
         self.tabs.closeEvent(event)
         self.context.ads_observer.unsubscribe()
         self.grouping_tab_widget.group_tab_presenter.closePeriodInfoWidget()
+        self.results_context.ADS_observer.unsubscribe()
         super(FrequencyAnalysisGui, self).closeEvent(event)

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/MuonAnalysis/muon_analysis_2.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/MuonAnalysis/muon_analysis_2.py
@@ -483,4 +483,5 @@ class MuonAnalysisGui(QtWidgets.QMainWindow):
         self.tabs.closeEvent(event)
         self.context.ads_observer.unsubscribe()
         self.grouping_tab_widget.group_tab_presenter.closePeriodInfoWidget()
+        self.results_context.ADS_observer.unsubscribe()
         super(MuonAnalysisGui, self).closeEvent(event)


### PR DESCRIPTION
**Description of work.**

When I added the results table ADS observer for this release, I forgot to include the unsubscribe methods. This PR fixes it.

**To test:**

<!-- Instructions for testing. -->
You will need to do this twice (once with model analysis active and once with it off) see https://github.com/mantidproject/mantid/blob/main/docs/source/interfaces/muon/feature_flags.rst

Open Muon Analysis
Load some data
Do a fit
Close the GUI
Clear the ADS -> this used to cause a crash

Open Frequency Domain Analysis
Go to the transform tab and press calculate at the bottom of the tab
Close the GUI
Clear the ADS -> this used to cause a crash

*There is no associated issue.*

There is no release note as this is covered by https://github.com/mantidproject/mantid/pull/33763

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
