### PR TITLE
Save workspace name in workspacedisplay.model and allow renaming

### DIFF
--- a/qt/python/mantidqt/mantidqt/widgets/workspacedisplay/matrix/model.py
+++ b/qt/python/mantidqt/mantidqt/widgets/workspacedisplay/matrix/model.py
@@ -38,9 +38,13 @@ class MatrixWorkspaceDisplayModel(object):
         """
         self.supports(ws)
         self._ws = ws
+        self._workspace_name = self.get_name()
 
     def get_name(self):
         return self._ws.name()
+
+    def set_name(self, workspace_name):
+        self._workspace_name = workspace_name
 
     def get_item_model(self):
         return (MatrixWorkspaceTableViewModel(self._ws, MatrixWorkspaceTableViewModelType.x),
@@ -49,4 +53,4 @@ class MatrixWorkspaceDisplayModel(object):
                 MatrixWorkspaceTableViewModel(self._ws, MatrixWorkspaceTableViewModelType.dx))
 
     def workspace_equals(self, workspace_name):
-        return workspace_name == self._ws.name()
+        return workspace_name == self._workspace_name

--- a/qt/python/mantidqt/mantidqt/widgets/workspacedisplay/matrix/presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/workspacedisplay/matrix/presenter.py
@@ -63,6 +63,7 @@ class MatrixWorkspaceDisplay(ObservingPresenter, DataCopier):
 
         # connect to replace_signal signal to handle replacement of the workspace
         self.container.replace_signal.connect(self.action_replace_workspace)
+        self.container.rename_signal.connect(self.action_rename_workspace)
 
     def show_view(self):
         self.container.show()
@@ -71,6 +72,9 @@ class MatrixWorkspaceDisplay(ObservingPresenter, DataCopier):
         if self.model.workspace_equals(workspace_name):
             self.model = MatrixWorkspaceDisplayModel(workspace)
             self.setup_tables()
+
+    def action_rename_workspace(self, workspace_name):
+        self.model.set_name(workspace_name)
 
     @classmethod
     def supports(cls, ws):


### PR DESCRIPTION
**Description of work.**

Save the current workspace name in the Show Data (workspacedisplay) model. Since weak pointers were implemented (https://github.com/mantidproject/mantid/commit/5a8567449036e7c9253be45821a246444e8d9946) the workspace is invalidated by the time we were asking for the name. Now it is stored and updated when renamed.
**To test:**

- Load any workspace
- Right click -> show data
- Load the same workspace with the same name to overwrite the data

- Try the above but Load > Live Data
- Try some other things including RenameWorkspace and SumSpectra with the ShowData dialog open

Fixes #33885

*This does not require release notes* because **fixing a regression since the last release**


<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
