### PR TITLE
Bug in montecarlo absorption

### DIFF
--- a/Framework/Algorithms/src/MonteCarloAbsorption.cpp
+++ b/Framework/Algorithms/src/MonteCarloAbsorption.cpp
@@ -463,12 +463,12 @@ void MonteCarloAbsorption::interpolateFromSparse(MatrixWorkspace &targetWS, cons
       double lat, lon;
       std::tie(lat, lon) = spectrumInfo.geographicalAngles(i);
       const auto spatiallyInterpHisto = sparseWS.bilinearInterpolateFromDetectorGrid(lat, lon);
-      if (spatiallyInterpHisto.size() > 1) {
+      if ((spatiallyInterpHisto.size() > 1) && (spatiallyInterpHisto.size() != targetWS.getNumberBins(i))) {
         auto targetHisto = targetWS.histogram(i);
         interpOpt.applyInPlace(spatiallyInterpHisto, targetHisto);
         targetWS.setHistogram(i, targetHisto);
       } else {
-        targetWS.mutableY(i) = spatiallyInterpHisto.y().front();
+        targetWS.mutableY(i) = spatiallyInterpHisto.y();
       }
     }
     PARALLEL_END_INTERRUPT_REGION

--- a/Framework/Algorithms/src/MonteCarloAbsorption.cpp
+++ b/Framework/Algorithms/src/MonteCarloAbsorption.cpp
@@ -469,6 +469,7 @@ void MonteCarloAbsorption::interpolateFromSparse(MatrixWorkspace &targetWS, cons
         targetWS.setHistogram(i, targetHisto);
       } else {
         targetWS.mutableY(i) = spatiallyInterpHisto.y();
+        targetWS.mutableE(i) = spatiallyInterpHisto.e();
       }
     }
     PARALLEL_END_INTERRUPT_REGION


### PR DESCRIPTION
**Description of work.**

This PR fixes a bug in MonteCarloAbsorption where the Y axis is always interpolated when the sparse instrument is used, even if it is not needed.

**To test:**

* Code review
* Use this script. Here the Monte Carlo simulation is done on sparse instrument but the number of bins is by default the same as the input. The interpolation is not needed. The script takes ~4min on main, less that 2 seconds with this PR (and ws1 and ws2 have same number of bins)

```python
from mantid.simpleapi import CreateSampleWorkspace, MonteCarloAbsorption

CreateSampleWorkspace(OutputWorkspace="ws1", XMin=0, XMax=5000, BinWidth=1, XUnit="Wavelength")
MonteCarloAbsorption(
    InputWorkspace="ws1",
    OutputWorkspace="ws2",
    SparseInstrument=True,
    Interpolation='CSpline',
    EventsPerPoint=1
    )
```

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
