### PR TITLE
BUGFIX: DensityOfStates .phonon import

### DIFF
--- a/docs/source/release/v6.4.0/Indirect/Bugfixes/33918.rst
+++ b/docs/source/release/v6.4.0/Indirect/Bugfixes/33918.rst
@@ -1,0 +1,2 @@
+- A bug has been fixed in the CASTEP .phonon file import for the Indirect/Simulation/DensityOfStates interface and SimulatedDensityOfStates algorithm.
+  The bug was causing some q-points to be misidentified as duplicate Gamma-points and removed.

--- a/scripts/Inelastic/dos/load_helper.py
+++ b/scripts/Inelastic/dos/load_helper.py
@@ -4,6 +4,8 @@
 #   NScD Oak Ridge National Laboratory, European Spallation Source,
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
+import numpy as np
+
 ###=============General Regex strings===============###
 
 FLOAT_REGEX = r'\-?(?:\d+\.?\d*|\d*\.?\d+)'
@@ -45,6 +47,6 @@ def _parse_block_header(header_match, block_count):
     # Found header block at start of frequencies
     q1, q2, q3, weight = [float(x) for x in header_match.groups()[:4]]
     q_vector = [q1, q2, q3]
-    if block_count > 1 and sum(q_vector) == 0:
+    if block_count > 1 and np.allclose(q_vector, [0, 0, 0]):
         weight = 0.0
     return weight, q_vector


### PR DESCRIPTION
**Description of work.**

This resolves a nasty bug in the CASTEP .phonon file importer used by the SimulatedDensityOfStates Algorithm and Indirect/Simulation/DensityOfStates interface.

There is some ambiguity in CASTEP .phonon files when data includes
LO-TO splitting. This introduces a discontinuity at the "Gamma point" (q = [0, 0, 0]) which is sometimes addresed by computing values in several directions. A CASTEP .phonon file from such a calculation will include entries for each of these, and they will each be given the full "weight" value of Gamma. If those are naively used, this will lead to over-weighting of the Gamma-point compared to other q-points.

The _intended_ strategy of this .phonon reader is to only take the first Gamma point provided and reject others. It does this by

- allowing the first q-point regardless of its q-vector, assuming that in such LO-TO meshes any such Gamma-point will be first in the list.

- determining if any other q-point is Gamma by checking `sum(q_vector) == 0`, and weighting to zero if so.

The first assumption will hold in typical user scenarios (i.e. Monkhorst-Pack mesh generated within CASTEP) but is not actually a safe assumption. See https://github.com/mantidproject/mantid/pull/33761 where a similar assumption can lead to a much worse failure case.

The second assumption, that Gamma-points can by identified with `sum(q_vector) == 0`, is deeply flawed.

- It fails to identify (1, 1, 1) as also being Gamma due to periodicity
- It incorrectly identifies e.g. (-0.25, 0, 0.25) as being Gamma.

In practice this leads to a small set of q-points being discarded from the calculation arbitrarily. The worst-case scenario would be a calculation that follows e.g. the (0, 0, 0) -> (0.5, 0.5, 0) high symmetry line, where all those points would be removed. (This would not be a good DOS sampling even if implemented correctly, but maybe the user has their own reasons and knows what they are doing. It would be a valid file input.)

Although the qualitative damage is small in practice, this should be treated quite seriously as the Phonon DOS may well be used as an input to further calculations that are sensitive to this error.

**Report to:** Matthew Krzystyniak, Sanghamitra Mukhopadhyay

**To test:**

The existing unit test for DensityOfStates still passes, because it does not cover this scenario. The bug is very sensitive to the q-point sampling of the underlying calculation.

One good file to test with is https://github.com/pace-neutrons/Euphonic/blob/master/tests_and_analysis/test/data/castep_files/quartz/quartz-777-grid.phonon

This should give a more complete sampling with the fixed implementation, and a slightly more intense DOS if comparing workspaces generated with SimulatedDensityOfStates before and after the changes.

To see the difference in result between the parsers, try

```python
import numpy as np
import dos.load_phonon
data = dos.load_phonon.parse_phonon_file('/path/to/quartz-777-grid.phonon', True)
weights = data[0]['weights'].reshape(len(data[0]['q_vectors']), -1)[:, 0]

print("q-point weights:")
print(weights)

print("zero-weight q-points:")
print(np.array(data[0]['q_vectors'])[weights == 0.])
```

With _main_ I get
```
[[-0.142857,  0.285714, -0.142857],
[ 0.      , -0.428571,  0.428571],
[ 0.      , -0.285714,  0.285714],
[ 0.      , -0.142857,  0.142857],
[ 0.      ,  0.      ,  0.      ]]
```
showing that several "innocent" q-points have been zeroed out.

With this branch I get
```
[[0. 0. 0.]]
```
which is better... Except that there is no LO-TO splitting going on and really Gamma should also have been left in! Still, that could be a smaller issue to resolve separately.

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
