### PR TITLE
Fix muon change instrument crash

### DIFF
--- a/docs/source/release/v6.4.0/Muon/MA_FDA/Bugfixes/33890.rst
+++ b/docs/source/release/v6.4.0/Muon/MA_FDA/Bugfixes/33890.rst
@@ -1,0 +1,1 @@
+- The Muon Analysis and Frequency Domain Analysis GUI's have had a bug fixed that caused a crash when changing instrument.

--- a/docs/source/release/v6.4.0/Muon/MA_FDA/Bugfixes/33890.rst
+++ b/docs/source/release/v6.4.0/Muon/MA_FDA/Bugfixes/33890.rst
@@ -1,2 +1,2 @@
 - The Muon Analysis and Frequency Domain Analysis GUI's have had a bug fixed that caused a crash when changing instrument.
- - The Muon Analysis and Frequency Domain Analysis GUI's have had a bug fixed that caused a crash when undoing a fit.
+- The Muon Analysis and Frequency Domain Analysis GUI's have had a bug fixed that caused a crash when undoing a fit.

--- a/docs/source/release/v6.4.0/Muon/MA_FDA/Bugfixes/33890.rst
+++ b/docs/source/release/v6.4.0/Muon/MA_FDA/Bugfixes/33890.rst
@@ -1,1 +1,2 @@
 - The Muon Analysis and Frequency Domain Analysis GUI's have had a bug fixed that caused a crash when changing instrument.
+ - The Muon Analysis and Frequency Domain Analysis GUI's have had a bug fixed that caused a crash when undoing a fit.

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/results_tab_widget/results_tab_presenter.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/results_tab_widget/results_tab_presenter.py
@@ -55,7 +55,12 @@ class ResultsTabPresenter(QObject):
         # view lives on. This avoids errors from painting on non-gui threads.
 
         new_fit_name = ";"
-        if fit_info:
+        if fit_info and isinstance(fit_info, list):
+            if len(fit_info)>0:
+                new_fit_list = fit_info[0].output_workspace_names()
+                if new_fit_list and len(new_fit_list)>0:
+                    new_fit_name = new_fit_list[0]
+        elif fit_info:
             new_fit_list = fit_info.output_workspace_names()
             if new_fit_list and len(new_fit_list)>0:
                 new_fit_name = new_fit_list[0]

--- a/qt/python/mantidqtinterfaces/test/Muon/results_tab_widget/results_tab_presenter_test.py
+++ b/qt/python/mantidqtinterfaces/test/Muon/results_tab_widget/results_tab_presenter_test.py
@@ -128,6 +128,40 @@ class ResultsTabPresenterTest(unittest.TestCase):
         self.mock_view.set_output_results_button_enabled.assert_called_once_with(
             True)
 
+    def test_adding_new_fit_via_list_works(
+            self):
+        ws1 = "ws1; parameters"
+        ws2 = "ws2; parameters"
+        fit_ws = "ws3; workspaces"
+        ws3 = "ws3; parameters"
+
+        # list is [row number, ticked, enabled] -> first selected, second is not
+        orig_ws_list_state = {ws1: [0, True, True], ws2: [1, False, True]}
+        final_ws_list_state = [ws1, ws2, ws3]
+        test_functions = ['func1', 'func2']
+        self.mock_model.fit_functions.return_value = test_functions
+        self.mock_model.fit_selection.return_value = final_ws_list_state
+        self.mock_view.fit_result_workspaces.return_value = orig_ws_list_state
+
+        presenter = ResultsTabPresenter(self.mock_view, self.mock_model)
+        presenter._get_workspace_list = mock.MagicMock(return_value=([ws1, ws2, ws3], "func1"))
+        # previous test verifies this is correct on construction
+        self.mock_view.set_output_results_button_enabled.reset_mock()
+        # add a new fit_ws
+        fit_info = [mock_fit_info(fit_ws)]
+
+        presenter.on_new_fit_performed(fit_info)
+
+        self.mock_model.fit_functions.assert_called_once_with()
+        # only the first ws and the new one are selected
+        self.mock_model.fit_selection.assert_called_once_with([ws1, ws3])
+        self.mock_view.set_fit_function_names.assert_called_once_with(
+            test_functions)
+        self.mock_view.set_fit_result_workspaces.assert_called_once_with(
+            final_ws_list_state)
+        self.mock_view.set_output_results_button_enabled.assert_called_once_with(
+            True)
+
     def test_redoing_fit_to_updates_selections(
             self):
         ws1 = "ws1; parameters"


### PR DESCRIPTION
Description of work.
When changing instrument in muon analysis after doing a fit a crash would happen (it was getting a list instead of a fit info object). This PR fixes it.

This (by accident) also fixes another bug caused by using undo fit.

To test:

Test 1
Open muon analysis
Load some data (e.g. MUSR 62260)
Go to the fitting tab
Do a fit (the actual fit is irrelevant)
Go to the home tab
Change the instrument to something else -> it should no longer crash

Test 2
Open muon analysis
Load some data (e.g. MUSR 62260)
Go to the fitting tab
Do a fit (the actual fit is irrelevant)
Press undo fit -> it should no longer crash

Fixes https://github.com/mantidproject/mantid/issues/33890 and https://github.com/mantidproject/mantid/issues/33893.

Added to release notes

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
