### PR TITLE
Fix error when copying spectrum from ragged workspace

### DIFF
--- a/docs/source/release/v6.4.0/Workbench/Bugfixes/33905.rst
+++ b/docs/source/release/v6.4.0/Workbench/Bugfixes/33905.rst
@@ -1,0 +1,1 @@
+Copying a spectrum in a MatrixWorkspace is now supported for ragged workspaces.

--- a/qt/python/mantidqt/mantidqt/widgets/workspacedisplay/matrix/presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/workspacedisplay/matrix/presenter.py
@@ -101,10 +101,10 @@ class MatrixWorkspaceDisplay(ObservingPresenter, DataCopier):
             return
         ws = table.model().ws
         table_ws = CreateEmptyTableWorkspace(OutputWorkspace=ws.name() + "_spectra")
-        num_rows = ws.blocksize()
-        table_ws.setRowCount(num_rows)
+        row_sizes = [ws.getNumberBins(row) for row in selected_rows]
+        table_ws.setRowCount(max(row_sizes))
         num_col = 4 if self.hasDx else 3
-        for i, row in enumerate(selected_rows):
+        for i, (row, row_size) in enumerate(zip(selected_rows, row_sizes)):
             table_ws.addColumn("double", "XS" + str(row))
             table_ws.addColumn("double", "YS" + str(row))
             table_ws.addColumn("double", "ES" + str(row))
@@ -117,7 +117,7 @@ class MatrixWorkspaceDisplay(ObservingPresenter, DataCopier):
             data_x = ws.readX(row)
             data_e = ws.readE(row)
 
-            for j in range(num_rows):
+            for j in range(row_size):
                 table_ws.setCell(j, col_x, data_x[j])
                 table_ws.setCell(j, col_y, data_y[j])
                 table_ws.setCell(j, col_e, data_e[j])
@@ -127,7 +127,7 @@ class MatrixWorkspaceDisplay(ObservingPresenter, DataCopier):
                 table_ws.addColumn("double", "DXS" + str(row))
                 col_dx = num_col * i + 3
                 data_dx = ws.readDx(row)
-                for j in range(num_rows):
+                for j in range(row_size):
                     table_ws.setCell(j, col_dx, data_dx[j])
 
     def action_copy_bin_to_table(self, table):

--- a/qt/python/mantidqt/mantidqt/widgets/workspacedisplay/matrix/test/test_matrixworkspacedisplay_presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/workspacedisplay/matrix/test/test_matrixworkspacedisplay_presenter.py
@@ -429,7 +429,7 @@ class MatrixWorkspaceDisplayPresenterTest(unittest.TestCase):
         mock_create_table.return_value = mock_table_ws
         mock_input_ws = Mock()
         mock_input_ws.name.return_value = "mock_ws"
-        mock_input_ws.blocksize.return_value = 2
+        mock_input_ws.getNumberBins.return_value = 2
         mock_input_ws.readX.return_value = [3, 3]
         mock_input_ws.readY.return_value = [2, 2]
         mock_input_ws.readE.return_value = [1, 1]

--- a/qt/python/mantidqt/mantidqt/widgets/workspacedisplay/test/test_workspacedisplay_view.py
+++ b/qt/python/mantidqt/mantidqt/widgets/workspacedisplay/test/test_workspacedisplay_view.py
@@ -6,6 +6,7 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 #  This file is part of the mantid workbench.
 import unittest
+from unittest import mock
 
 from mantid.api import AnalysisDataService
 from mantid.simpleapi import ConjoinWorkspaces, CreateWorkspace
@@ -14,6 +15,10 @@ from mantidqt.utils.qt.testing.qt_widget_finder import QtWidgetFinder
 from mantidqt.widgets.workspacedisplay.matrix.presenter import MatrixWorkspaceDisplay
 
 from qtpy.QtWidgets import QApplication
+# Import sip after Qt. Modern versions of PyQt ship an internal sip module
+# located at PyQt5X.sip. Importing PyQt first sets a shim sip module to point
+# to the correct place
+import sip
 
 
 def create_test_workspace(workspace_name, ragged=False):
@@ -31,34 +36,59 @@ def create_test_workspace(workspace_name, ragged=False):
 class WorkspaceDisplayViewTest(unittest.TestCase, QtWidgetFinder):
     @classmethod
     def setUpClass(cls):
-        cls.non_ragged_workspace = create_test_workspace("non-ragged")
+        cls.workspace = create_test_workspace("non-ragged")
         cls.ragged_workspace = create_test_workspace("ragged", ragged=True)
 
     @classmethod
     def tearDownClass(cls):
         AnalysisDataService.clear()
 
+    def tearDown(self):
+        if not sip.isdeleted(self.presenter.container):
+            self.presenter.container.close()
+            QApplication.sendPostedEvents()
+
     def test_that_the_workspace_display_opens_and_closes_ok_with_a_non_ragged_workspace(self):
-        presenter = MatrixWorkspaceDisplay(self.non_ragged_workspace)
-        presenter.show_view()
+        self.presenter = MatrixWorkspaceDisplay(self.workspace)
+        self.presenter.show_view()
+
         self.assert_widget_created()
 
-        presenter.container.close()
-
+        self.presenter.container.close()
         QApplication.sendPostedEvents()
 
         self.assert_no_toplevel_widgets()
 
     def test_that_the_workspace_display_opens_and_closes_ok_with_a_ragged_workspace(self):
-        presenter = MatrixWorkspaceDisplay(self.ragged_workspace)
-        presenter.show_view()
+        self.presenter = MatrixWorkspaceDisplay(self.ragged_workspace)
+        self.presenter.show_view()
+
         self.assert_widget_created()
 
-        presenter.container.close()
-
+        self.presenter.container.close()
         QApplication.sendPostedEvents()
 
         self.assert_no_toplevel_widgets()
+
+    def test_that_copy_spectrum_to_table_does_not_cause_an_error_with_a_non_ragged_workspace(self):
+        with mock.patch('qtpy.QtCore.QItemSelectionModel.selectedRows') as patch:
+            self.presenter = MatrixWorkspaceDisplay(self.workspace)
+            self.presenter.show_view()
+            table = self.presenter.view.currentWidget()
+
+            patch.return_value = [table.model().index(0, 0)]
+
+            self.presenter.action_copy_spectrum_to_table(table)
+
+    def test_that_copy_spectrum_to_table_does_not_cause_an_error_with_a_ragged_workspace(self):
+        with mock.patch('qtpy.QtCore.QItemSelectionModel.selectedRows') as patch:
+            self.presenter = MatrixWorkspaceDisplay(self.ragged_workspace)
+            self.presenter.show_view()
+            table = self.presenter.view.currentWidget()
+
+            patch.return_value = [table.model().index(0, 0), table.model().index(1, 0), table.model().index(2, 0)]
+
+            self.presenter.action_copy_spectrum_to_table(table)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
**Description of work.**
This PR fixes a bug causing an error when copying a spectrum from a ragged workspace.

**To test:**

1. Follow the instructions in the related issue
2. After copying the spectrum, a TableWorkspace should appear in the ADS containing the ragged spectrum. There should be no error

Fixes #33905

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
