### PR TITLE
Move facility in drill test

### DIFF
--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/drill/test/DrillTest.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/drill/test/DrillTest.py
@@ -138,6 +138,11 @@ class DrillTest(unittest.TestCase):
     ###########################################################################
 
     def setUp(self):
+        self.facility = config['default.facility']
+        self.instrument = config['default.instrument']
+        config['default.facility'] = "ILL"
+        config['default.instrument'] = "D11"
+
         # avoid popup messages
         patch = mock.patch('mantidqtinterfaces.drill.view.DrillView.QMessageBox')
         self.mMessageBox = patch.start()
@@ -167,11 +172,6 @@ class DrillTest(unittest.TestCase):
         # shown window
         self.view.isHidden = mock.Mock()
         self.view.isHidden.return_value = False
-
-        self.facility = config['default.facility']
-        self.instrument = config['default.instrument']
-        config['default.facility'] = "ILL"
-        config['default.instrument'] = "D11"
 
     def tearDown(self):
         config['default.facility'] = self.facility


### PR DESCRIPTION
**Description of work.**

This PR is a attempt to fix the intermittent failure of DrILLTest.

I move the configuration of the facility/instrument to the very beginning of the test.

**To test:**

* code review
* tests should pass

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
