### PR TITLE
Read EngDiff save location at runtime

### DIFF
--- a/docs/source/release/v6.4.0/Diffraction/Engineering/Bugfixes/33877.rst
+++ b/docs/source/release/v6.4.0/Diffraction/Engineering/Bugfixes/33877.rst
@@ -1,0 +1,2 @@
+- On first time start up of the Engineering Diffraction interface, the default save location is now utilised for
+  calibration and focus files

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/calibration/model.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/calibration/model.py
@@ -13,7 +13,9 @@ from mantidqtinterfaces.Engineering.gui.engineering_diffraction.settings.setting
 class CalibrationModel(object):
     # model shares code with the EnginX auto reduction script - code is kept in EnggUtils.py
     @staticmethod
-    def create_new_calibration(calibration, rb_num, plot_output, save_dir=output_settings.get_output_path()):
+    def create_new_calibration(calibration, rb_num, plot_output, save_dir=None):
+        if save_dir is None:
+            save_dir = output_settings.get_output_path()
         full_calib = load_full_instrument_calibration()
         EnggUtils.create_new_calibration(calibration, rb_num, plot_output, save_dir, full_calib)
 

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/focus/model.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/focus/model.py
@@ -22,7 +22,9 @@ class FocusModel(object):
         return self._last_focused_files
 
     def focus_run(self, sample_paths: list, vanadium_path: str, plot_output: bool, rb_num: str,
-                  calibration: CalibrationInfo, save_dir: Optional[str] = output_settings.get_output_path()) -> None:
+                  calibration: CalibrationInfo, save_dir: Optional[str] = None) -> None:
+        if save_dir is None:
+            save_dir = output_settings.get_output_path()
         full_calib = load_full_instrument_calibration()
         focused_files = EnggUtils.focus_run(sample_paths, vanadium_path, plot_output, rb_num, calibration, save_dir,
                                             full_calib)

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/focus/test/test_focus_model.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/focus/test/test_focus_model.py
@@ -9,10 +9,15 @@ import tempfile
 import shutil
 from os import path
 
+from unittest import mock
 from unittest.mock import patch, MagicMock, call, create_autospec
 from Engineering.EnggUtils import GROUP
 from mantidqtinterfaces.Engineering.gui.engineering_diffraction.tabs.focus import model
 from Engineering.common.calibration_info import CalibrationInfo
+from mantidqtinterfaces.Engineering.gui.engineering_diffraction.settings import settings_model, \
+    settings_view, settings_presenter
+from qtpy.QtCore import QCoreApplication
+from workbench.config import APPNAME
 
 file_path = "mantidqtinterfaces.Engineering.gui.engineering_diffraction.tabs.focus.model"
 enggutils_path = "Engineering.EnggUtils"
@@ -64,6 +69,41 @@ class FocusModelTest(unittest.TestCase):
         self.model.focus_run(["305761"], "fake/van/path", plot_output=False, rb_num=None, calibration=self.calibration)
 
         mock_plot.assert_not_called()
+
+    @patch(file_path + '.output_settings.get_output_path')
+    @patch(enggutils_path + '.focus_run')
+    @patch(file_path + ".load_full_instrument_calibration")
+    def test_first_time_focus_uses_correct_default_save_directory(self, mock_load_cal,
+                                                                  mock_enggutils_focus_run, mock_get_output_path):
+
+        default_save_location = path.join(path.expanduser("~"), "Engineering_Mantid")
+        QCoreApplication.setApplicationName("Engineering_Diffraction_test_calib_model")
+        presenter = settings_presenter.SettingsPresenter(mock.create_autospec(settings_model.SettingsModel),
+                                                         mock.create_autospec(settings_view.SettingsView))
+        presenter.settings = {  # "save_location" is not defined
+                              "full_calibration": "cal",
+                              "logs": "some,logs",
+                              "primary_log": "some",
+                              "sort_ascending": True,
+                              "default_peak": "BackToBackExponential"
+                              }
+        presenter._validate_settings()  # save_location now set to the default value at runtime
+        self.assertEqual(presenter.settings['save_location'], default_save_location)
+
+        # this is the runtime return from output_settings.get_output_path()
+        # if called at define time in a default parameter value then this value is not used
+        mock_get_output_path.return_value = default_save_location
+
+        mock_load_cal.return_value = "full_calibration"
+        self.calibration.group = GROUP.BOTH
+
+        self.model.focus_run(["305761"], "fake/van/path", plot_output=False, rb_num=None,
+                             calibration=self.calibration)  # save_dir not given
+
+        mock_enggutils_focus_run.assert_called_once_with(["305761"], "fake/van/path", False, None, self.calibration,
+                                                         default_save_location, "full_calibration")
+        # sample_paths, vanadium_path, plot_output, rb_num, calibration, save_dir, full_calib
+        QCoreApplication.setApplicationName(APPNAME)  # reset to 'mantidworkbench' in case required by other tests
 
     @patch(enggutils_path + '.mantid.DeleteWorkspace')
     @patch(enggutils_path + '.mantid.ConvertUnits')


### PR DESCRIPTION
**Description of work.**

The default value for the `save_dir` parameter in the calibration model was set at compile time (when the 
function was defined) not at runtime. Now instead of setting the default parameter to a function return value:
`def create_new_calibration(... save_dir=output_settings.get_output_path()`
the default parameter is set to None, so the `output_settings.get_output_path()` function runs at runtime.

Also fixed this bug in the focus model.

Had to read this article for inspiration: https://medium.com/techtofreedom/mind-the-default-arguments-in-python-functions-8b00d6f532e3

**To test:**

- Rename your mantidworkbench.ini file, see the steps for [**Config Files** in the relevant section for Windows, Linux and MacOS ](https://developer.mantidproject.org/UserSupport.html).
- Open MantidWorkbench
- Open the Engineering Diffraction interface
- Create a new calibration with the file /archive/ndxenginx/Instrument/data/cycle_19_1/ENGINX00305738.nxs (path on the archive may be different on Windows)
- The calibration should complete successfully, with no errors and should save calibration files somewhere in an `Engineering_Mantid` folder. Check where this is by looking in the Engineering Diffraction settings (gear icon bottom left of interface) and check some files are added to this directory in a file browser.

Fixes #33877

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
