### PR TITLE
Replot resolution data in ISIS calibration when instrument changed

### DIFF
--- a/docs/source/release/v6.4.0/Indirect/Bugfixes/33872.rst
+++ b/docs/source/release/v6.4.0/Indirect/Bugfixes/33872.rst
@@ -1,0 +1,1 @@
+A bug has been fixed that caused the resolution data to not be updated when the reflection was changed in ISISCalibration in IndirectData Reduction

--- a/qt/scientific_interfaces/Indirect/ISISCalibration.cpp
+++ b/qt/scientific_interfaces/Indirect/ISISCalibration.cpp
@@ -366,8 +366,17 @@ void ISISCalibration::setDefaultInstDetails(QMap<QString, QString> const &instru
   // Set peak and background ranges
   const auto ranges = getRangesFromInstrument();
 
-  QFileInfo fi(m_lastCalPlotFilename);
+  QString filename = m_uiForm.leRunNo->getFirstFilename();
+  if (filename.isEmpty())
+    return;
+  QFileInfo fi(filename);
   QString wsname = fi.baseName();
+  if (!loadFile(filename, wsname, spectraMin, spectraMax)) {
+    emit showMessageBox("Unable to load file.\nCheck whether your file exists "
+                        "and matches the selected instrument in the Energy "
+                        "Transfer tab.");
+    return;
+  }
 
   if (Mantid::API::AnalysisDataService::Instance().doesExist(wsname.toStdString())) {
     const auto input =
@@ -390,6 +399,9 @@ void ISISCalibration::setDefaultInstDetails(QMap<QString, QString> const &instru
   m_uiForm.ckCreateResolution->setEnabled(hasResolution);
   if (!hasResolution)
     m_uiForm.ckCreateResolution->setChecked(false);
+
+  // plot energy to correctly set the res plot
+  calPlotEnergy();
 }
 
 /**

--- a/qt/scientific_interfaces/Indirect/ISISCalibration.cpp
+++ b/qt/scientific_interfaces/Indirect/ISISCalibration.cpp
@@ -354,8 +354,8 @@ void ISISCalibration::setDefaultInstDetails() {
 
 void ISISCalibration::setDefaultInstDetails(QMap<QString, QString> const &instrumentDetails) {
   auto const instrument = getInstrumentDetail(instrumentDetails, "instrument");
-  auto const spectraMin = getInstrumentDetail(instrumentDetails, "spectra-min").toDouble();
-  auto const spectraMax = getInstrumentDetail(instrumentDetails, "spectra-max").toDouble();
+  auto const spectraMin = getInstrumentDetail(instrumentDetails, "spectra-min").toInt();
+  auto const spectraMax = getInstrumentDetail(instrumentDetails, "spectra-max").toInt();
 
   // Set the search instrument for runs
   m_uiForm.leRunNo->setInstrumentOverride(instrument);

--- a/qt/scientific_interfaces/Indirect/ISISCalibration.cpp
+++ b/qt/scientific_interfaces/Indirect/ISISCalibration.cpp
@@ -371,25 +371,16 @@ void ISISCalibration::setDefaultInstDetails(QMap<QString, QString> const &instru
     return;
   QFileInfo fi(filename);
   QString wsname = fi.baseName();
-  if (!loadFile(filename, wsname, spectraMin, spectraMax)) {
-    emit showMessageBox("Unable to load file.\nCheck whether your file exists "
-                        "and matches the selected instrument in the Energy "
-                        "Transfer tab.");
-    return;
+  if (!Mantid::API::AnalysisDataService::Instance().doesExist(wsname.toStdString())) {
+    loadFile(filename, wsname, spectraMin, spectraMax);
   }
-
-  if (Mantid::API::AnalysisDataService::Instance().doesExist(wsname.toStdString())) {
-    const auto input =
-        std::dynamic_pointer_cast<MatrixWorkspace>(AnalysisDataService::Instance().retrieve(wsname.toStdString()));
-    const auto &dataX = input->x(0);
-    if (dataX.back() <= getValueOr(ranges, "peak-end-tof", 0.0) ||
-        dataX.front() >= getValueOr(ranges, "peak-start-tof", 0.0)) {
-      setPeakRange((3.0 * dataX.front() + dataX.back()) / 4.0, (dataX.front() + 3.0 * dataX.back()) / 4.0);
-      setBackgroundRange(dataX.front(), (7.0 * dataX.front() + dataX.back()) / 8.0);
-    } else {
-      setPeakRange(getValueOr(ranges, "peak-start-tof", 0.0), getValueOr(ranges, "peak-end-tof", 0.0));
-      setBackgroundRange(getValueOr(ranges, "back-start-tof", 0.0), getValueOr(ranges, "back-end-tof", 0.0));
-    }
+  const auto input =
+      std::dynamic_pointer_cast<MatrixWorkspace>(AnalysisDataService::Instance().retrieve(wsname.toStdString()));
+  const auto &dataX = input->x(0);
+  if (dataX.back() <= getValueOr(ranges, "peak-end-tof", 0.0) ||
+      dataX.front() >= getValueOr(ranges, "peak-start-tof", 0.0)) {
+    setPeakRange((3.0 * dataX.front() + dataX.back()) / 4.0, (dataX.front() + 3.0 * dataX.back()) / 4.0);
+    setBackgroundRange(dataX.front(), (7.0 * dataX.front() + dataX.back()) / 8.0);
   } else {
     setPeakRange(getValueOr(ranges, "peak-start-tof", 0.0), getValueOr(ranges, "peak-end-tof", 0.0));
     setBackgroundRange(getValueOr(ranges, "back-start-tof", 0.0), getValueOr(ranges, "back-end-tof", 0.0));

--- a/qt/scientific_interfaces/Indirect/ISISCalibration.cpp
+++ b/qt/scientific_interfaces/Indirect/ISISCalibration.cpp
@@ -620,8 +620,7 @@ void ISISCalibration::calUpdateRS(QtProperty *prop, double val) {
   auto resPeak = m_uiForm.ppResolution->getRangeSelector("ResPeak");
   auto resBackground = m_uiForm.ppResolution->getRangeSelector("ResBackground");
 
-  disconnect(m_dblManager, SIGNAL(valueChanged(QtProperty *, double)), this, SLOT(calUpdateRS(QtProperty *, double)));
-
+  disconnectRangeSelectors();
   if (prop == m_properties["CalPeakMin"]) {
     setRangeSelectorMin(m_properties["CalPeakMin"], m_properties["CalPeakMax"], calPeak, val);
   } else if (prop == m_properties["CalPeakMax"]) {
@@ -639,8 +638,7 @@ void ISISCalibration::calUpdateRS(QtProperty *prop, double val) {
   } else if (prop == m_properties["ResEHigh"]) {
     setRangeSelectorMax(m_properties["ResELow"], m_properties["ResEHigh"], resPeak, val);
   }
-
-  connect(m_dblManager, SIGNAL(valueChanged(QtProperty *, double)), this, SLOT(calUpdateRS(QtProperty *, double)));
+  connectRangeSelectors();
 }
 
 /**

--- a/qt/scientific_interfaces/Indirect/ISISCalibration.cpp
+++ b/qt/scientific_interfaces/Indirect/ISISCalibration.cpp
@@ -133,15 +133,7 @@ ISISCalibration::ISISCalibration(IndirectDataReduction *idrUI, QWidget *parent)
   connect(this, SIGNAL(newInstrumentConfiguration()), this, SLOT(setDefaultInstDetails()));
 
   // Update property map when a range selector is moved
-  connect(calPeak, SIGNAL(minValueChanged(double)), this, SLOT(calMinChanged(double)));
-  connect(calPeak, SIGNAL(maxValueChanged(double)), this, SLOT(calMaxChanged(double)));
-  connect(calBackground, SIGNAL(minValueChanged(double)), this, SLOT(calMinChanged(double)));
-  connect(calBackground, SIGNAL(maxValueChanged(double)), this, SLOT(calMaxChanged(double)));
-  connect(resPeak, SIGNAL(minValueChanged(double)), this, SLOT(calMinChanged(double)));
-  connect(resPeak, SIGNAL(maxValueChanged(double)), this, SLOT(calMaxChanged(double)));
-  connect(resBackground, SIGNAL(minValueChanged(double)), this, SLOT(calMinChanged(double)));
-  connect(resBackground, SIGNAL(maxValueChanged(double)), this, SLOT(calMaxChanged(double)));
-
+  connectRangeSelectors();
   // Update range selector positions when a value in the double manager changes
   connect(m_dblManager, SIGNAL(valueChanged(QtProperty *, double)), this, SLOT(calUpdateRS(QtProperty *, double)));
   // Plot miniplots after a file has loaded
@@ -173,6 +165,44 @@ ISISCalibration::ISISCalibration(IndirectDataReduction *idrUI, QWidget *parent)
 ISISCalibration::~ISISCalibration() {
   m_propTrees["CalPropTree"]->unsetFactoryForManager(m_dblManager);
   m_propTrees["ResPropTree"]->unsetFactoryForManager(m_dblManager);
+}
+
+void ISISCalibration::connectRangeSelectors() {
+  connect(m_uiForm.ppCalibration->getRangeSelector("CalPeak"), SIGNAL(minValueChanged(double)), this,
+          SLOT(calMinChanged(double)));
+  connect(m_uiForm.ppCalibration->getRangeSelector("CalPeak"), SIGNAL(maxValueChanged(double)), this,
+          SLOT(calMaxChanged(double)));
+  connect(m_uiForm.ppCalibration->getRangeSelector("CalBackground"), SIGNAL(minValueChanged(double)), this,
+          SLOT(calMinChanged(double)));
+  connect(m_uiForm.ppCalibration->getRangeSelector("CalBackground"), SIGNAL(maxValueChanged(double)), this,
+          SLOT(calMaxChanged(double)));
+  connect(m_uiForm.ppResolution->getRangeSelector("ResPeak"), SIGNAL(minValueChanged(double)), this,
+          SLOT(calMinChanged(double)));
+  connect(m_uiForm.ppResolution->getRangeSelector("ResPeak"), SIGNAL(maxValueChanged(double)), this,
+          SLOT(calMaxChanged(double)));
+  connect(m_uiForm.ppResolution->getRangeSelector("ResBackground"), SIGNAL(minValueChanged(double)), this,
+          SLOT(calMinChanged(double)));
+  connect(m_uiForm.ppResolution->getRangeSelector("ResBackground"), SIGNAL(maxValueChanged(double)), this,
+          SLOT(calMaxChanged(double)));
+}
+
+void ISISCalibration::disconnectRangeSelectors() {
+  disconnect(m_uiForm.ppCalibration->getRangeSelector("CalPeak"), SIGNAL(minValueChanged(double)), this,
+             SLOT(calMinChanged(double)));
+  disconnect(m_uiForm.ppCalibration->getRangeSelector("CalPeak"), SIGNAL(maxValueChanged(double)), this,
+             SLOT(calMaxChanged(double)));
+  disconnect(m_uiForm.ppCalibration->getRangeSelector("CalBackground"), SIGNAL(minValueChanged(double)), this,
+             SLOT(calMinChanged(double)));
+  disconnect(m_uiForm.ppCalibration->getRangeSelector("CalBackground"), SIGNAL(maxValueChanged(double)), this,
+             SLOT(calMaxChanged(double)));
+  disconnect(m_uiForm.ppResolution->getRangeSelector("ResPeak"), SIGNAL(minValueChanged(double)), this,
+             SLOT(calMinChanged(double)));
+  disconnect(m_uiForm.ppResolution->getRangeSelector("ResPeak"), SIGNAL(maxValueChanged(double)), this,
+             SLOT(calMaxChanged(double)));
+  disconnect(m_uiForm.ppResolution->getRangeSelector("ResBackground"), SIGNAL(minValueChanged(double)), this,
+             SLOT(calMinChanged(double)));
+  disconnect(m_uiForm.ppResolution->getRangeSelector("ResBackground"), SIGNAL(maxValueChanged(double)), this,
+             SLOT(calMaxChanged(double)));
 }
 
 std::pair<double, double> ISISCalibration::peakRange() const {
@@ -377,6 +407,9 @@ void ISISCalibration::setDefaultInstDetails(QMap<QString, QString> const &instru
   const auto input =
       std::dynamic_pointer_cast<MatrixWorkspace>(AnalysisDataService::Instance().retrieve(wsname.toStdString()));
   const auto &dataX = input->x(0);
+
+  disconnect(m_dblManager, SIGNAL(valueChanged(QtProperty *, double)), this, SLOT(calUpdateRS(QtProperty *, double)));
+  disconnectRangeSelectors();
   if (dataX.back() <= getValueOr(ranges, "peak-end-tof", 0.0) ||
       dataX.front() >= getValueOr(ranges, "peak-start-tof", 0.0)) {
     setPeakRange((3.0 * dataX.front() + dataX.back()) / 4.0, (dataX.front() + 3.0 * dataX.back()) / 4.0);
@@ -391,6 +424,8 @@ void ISISCalibration::setDefaultInstDetails(QMap<QString, QString> const &instru
   if (!hasResolution)
     m_uiForm.ckCreateResolution->setChecked(false);
 
+  connect(m_dblManager, SIGNAL(valueChanged(QtProperty *, double)), this, SLOT(calUpdateRS(QtProperty *, double)));
+  connectRangeSelectors();
   // plot energy to correctly set the res plot
   calPlotEnergy();
 }

--- a/qt/scientific_interfaces/Indirect/ISISCalibration.h
+++ b/qt/scientific_interfaces/Indirect/ISISCalibration.h
@@ -74,6 +74,8 @@ private slots:
 
 private:
   void setDefaultInstDetails(QMap<QString, QString> const &instrumentDetails);
+  void connectRangeSelectors();
+  void disconnectRangeSelectors();
   void createRESfile(const QString &file);
   void addRuntimeSmoothing(const QString &workspaceName);
   void setRangeLimits(MantidWidgets::RangeSelector *rangeSelector, const double &minimum, const double &maximum,

--- a/qt/scientific_interfaces/Indirect/IndirectTab.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectTab.cpp
@@ -350,10 +350,8 @@ QString IndirectTab::getWorkspaceBasename(const QString &wsName) {
  */
 void IndirectTab::setPlotPropertyRange(RangeSelector *rs, QtProperty *min, QtProperty *max,
                                        const QPair<double, double> &bounds) {
-  m_dblManager->setMinimum(min, bounds.first);
-  m_dblManager->setMaximum(min, bounds.second);
-  m_dblManager->setMinimum(max, bounds.first);
-  m_dblManager->setMaximum(max, bounds.second);
+  m_dblManager->setRange(min, bounds.first, bounds.second);
+  m_dblManager->setRange(max, bounds.first, bounds.second);
   rs->setBounds(bounds.first, bounds.second);
 }
 
@@ -367,18 +365,14 @@ void IndirectTab::setPlotPropertyRange(RangeSelector *rs, QtProperty *min, QtPro
  * @param range :: The range to set the range selector to.
  */
 void IndirectTab::setRangeSelector(RangeSelector *rs, QtProperty *lower, QtProperty *upper,
-                                   const QPair<double, double> &bounds,
-                                   const boost::optional<QPair<double, double>> &range) {
-  m_dblManager->setValue(lower, bounds.first);
-  m_dblManager->setValue(upper, bounds.second);
-  if (range) {
-    rs->setMinimum(range.get().first);
-    rs->setMaximum(range.get().second);
+                                   const QPair<double, double> &range,
+                                   const boost::optional<QPair<double, double>> &bounds) {
+  m_dblManager->setValue(lower, range.first);
+  m_dblManager->setValue(upper, range.second);
+  rs->setRange(range.first, range.second);
+  if (bounds) {
     // clamp the bounds of the selector
-    rs->setRange(range.get().first, range.get().second);
-  } else {
-    rs->setMinimum(bounds.first);
-    rs->setMaximum(bounds.second);
+    rs->setBounds(bounds.get().first, bounds.get().second);
   }
 }
 

--- a/qt/scientific_interfaces/Indirect/IndirectTab.h
+++ b/qt/scientific_interfaces/Indirect/IndirectTab.h
@@ -107,8 +107,8 @@ protected:
                             const QPair<double, double> &bounds);
   /// Function to set the range selector on the mini plot
   void setRangeSelector(MantidWidgets::RangeSelector *rs, QtProperty *lower, QtProperty *upper,
-                        const QPair<double, double> &bounds,
-                        const boost::optional<QPair<double, double>> &range = boost::none);
+                        const QPair<double, double> &range,
+                        const boost::optional<QPair<double, double>> &bounds = boost::none);
   /// Sets the min of the range selector if it is less than the max
   void setRangeSelectorMin(QtProperty *minProperty, QtProperty *maxProperty,
                            MantidWidgets::RangeSelector *rangeSelector, double newValue);


### PR DESCRIPTION
**Description of work.**

This PR fixes a bug in ISISCalibration that causes the resolution data to not be updated when the instrument is changed.
It also correctly sets the defaults for the background and peak ranges when the instrument is changed.

**To test:**

1. open Indirect Data Reduction
2. Go to ISISCalibration
3. in run numbers enter `59057-59059`
4. click run there should be no error
5. Change reflection to 004
6. check that the resolution plot has been updated and the defaults are cahnged to the correct range.
7. click run there should be no error.

re: #33872

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
