### PR TITLE
Fix peak overlay and add peak action for 4D workspace in sliceviewer

### DIFF
--- a/docs/source/release/v6.4.0/Workbench/SliceViewer/Bugfixes/33931.rst
+++ b/docs/source/release/v6.4.0/Workbench/SliceViewer/Bugfixes/33931.rst
@@ -1,0 +1,3 @@
+- Fixed a bug with peak selection causing crash for 4D MD workspaces
+- Peak addition now correctly assigns new peak HKL in nonorthogonal view
+- Peak overlay disabled when non-Q axis viewed (peak object does not have a position defined for non Q dimension)

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/models/sliceinfo.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/models/sliceinfo.py
@@ -89,10 +89,6 @@ class SliceInfo:
         and Z is the out of place coordinate
         :param point: A 3D point in the slice frame
         """
-        print("self._display_x, self._display_y, self._display_z", self._display_x, self._display_y, self._display_z)
-        print('adjusted', self.adjust_index_for_preceding_nonq_dims(self._display_x),
-              self.adjust_index_for_preceding_nonq_dims(self._display_y),
-              self.adjust_index_for_preceding_nonq_dims(self._display_z))
         px = point[self.adjust_index_for_preceding_nonq_dims(self._display_x)]
         py = point[self.adjust_index_for_preceding_nonq_dims(self._display_y)]
         pz = point[self.adjust_index_for_preceding_nonq_dims(self._display_z)]
@@ -104,13 +100,13 @@ class SliceInfo:
 
         :param point: A 3D point in the slice frame
         """
-        transform = np.zeros((3, 3))
-        transform[0][self._display_x] = 1
-        transform[1][self._display_y] = 1
-        transform[2][self._display_z] = 1
-        inv_trans = np.linalg.inv(transform)
-        point = np.dot(inv_trans, point)
-        return np.array((*self._transform.inv_tr(point[0], point[1]), point[2]))
+        x, y = self._transform.inv_tr(point[0], point[1])
+
+        data_point = np.zeros(3)
+        data_point[self.adjust_index_for_preceding_nonq_dims(self._display_x)] = x
+        data_point[self.adjust_index_for_preceding_nonq_dims(self._display_y)] = y
+        data_point[self.adjust_index_for_preceding_nonq_dims(self._display_z)] = point[2]
+        return data_point
 
     # private api
     def _init_display_indices(self, transpose: bool, qflags: Sequence[bool]):

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/peaksviewer/model.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/peaksviewer/model.py
@@ -122,7 +122,8 @@ class PeaksViewerModel(TableWorkspaceDisplayModel):
         frame_to_slice_fn = self._frame_to_slice_fn(frame)
         peak = self.ws.getPeak(selected_index)
         slicepoint = slice_info.slicepoint
-        slicepoint[slice_info.z_index] = getattr(peak, frame_to_slice_fn)()[slice_info.z_index]
+        iz_peak = slice_info.adjust_index_for_preceding_nonq_dims(slice_info.z_index)
+        slicepoint[slice_info.z_index] = getattr(peak, frame_to_slice_fn)()[iz_peak]
 
         return slicepoint
 

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/peaksviewer/presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/peaksviewer/presenter.py
@@ -127,7 +127,7 @@ class PeaksViewerPresenter:
         Respond to the selection change of a peak in the list
         """
         selected_index = self._view.selected_index
-        if selected_index is None:
+        if selected_index is None or not self.model.has_representations_drawn():
             return
 
         # Two step:

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/peaksviewer/test/test_peaksviewer_model.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/peaksviewer/test/test_peaksviewer_model.py
@@ -80,6 +80,7 @@ class PeaksViewerModelTest(unittest.TestCase):
         slice_info = MagicMock()
         slice_info.slicepoint = [0.5, None, None]
         slice_info.z_index = 0
+        slice_info.adjust_index_for_preceding_nonq_dims.side_effect = lambda index: index
 
         slicepoint = model.slicepoint(0, slice_info, SpecialCoordinateSystem.QSample)
 

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/peaksviewer/test/test_peaksviewer_presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/peaksviewer/test/test_peaksviewer_presenter.py
@@ -108,6 +108,7 @@ class PeaksViewerPresenterTest(unittest.TestCase):
     def test_single_peak_selection(self, mock_peaks_list_presenter):
         name = 'ws1'
         mock_model = create_mock_model(name)
+        mock_model.has_representations_drawn.return_value = True
         viewlimits = (-1, 1), (-2, 2)
         mock_model.viewlimits.return_value = viewlimits
         self.mock_view.selected_index = 0
@@ -117,6 +118,19 @@ class PeaksViewerPresenterTest(unittest.TestCase):
 
         mock_model.viewlimits.assert_called_once_with(0)
         self.mock_view.set_axes_limits.assert_called_once_with(*viewlimits, auto_transform=False)
+
+    def test_single_peak_selection_if_peaks_not_drawn(self, mock_peaks_list_presenter):
+        # peaks not drawn if one fo viewing axes non-Q
+        name = 'ws1'
+        mock_model = create_mock_model(name)
+        mock_model.has_representations_drawn.return_value = False
+        self.mock_view.selected_index = 0
+        presenter = PeaksViewerPresenter(mock_model, self.mock_view)
+
+        presenter.notify(PeaksViewerPresenter.Event.PeakSelected)
+
+        mock_model.viewlimits.assert_not_called()
+        self.mock_view.set_axes_limits.assert_not_called()
 
     def test_add_delete_peaks(self, mock_peaks_list_presenter):
         name = 'ws1'

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/presenters/presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/presenters/presenter.py
@@ -414,9 +414,9 @@ class SliceViewer(ObservingPresenter, SliceViewerBasePresenter):
             self._peaks_presenter.clear_observer()
 
     def canvas_clicked(self, event):
-        if self._peaks_presenter is not None:
-            if event.inaxes:
-                sliceinfo = self.get_sliceinfo()
+        if self._peaks_presenter is not None and event.inaxes:
+            sliceinfo = self.get_sliceinfo()
+            if sliceinfo.can_support_peak_overlay():
                 self._logger.debug(f"Coordinates selected x={event.xdata} y={event.ydata} z={sliceinfo.z_value}")
                 pos = sliceinfo.inverse_transform([event.xdata, event.ydata, sliceinfo.z_value])
                 self._logger.debug(f"Coordinates transformed into {self.get_frame()} frame, pos={pos}")


### PR DESCRIPTION
**Description of work.**
Fixed:
-  Disabled drawing of peak representations if viewing a non Q dimension along one of the slice axes (e.g. energy transfer or temperature) - as the peak position is not defined for a non Q dimension. This previously caused an out-of-range error when a fourth dimension (typically E) was viewed as it tries to transform a 3 vector corresponding to the peak centre (e.g. Qx,Qy,Qz or HKL) to the slice frame. 
- Transform (HKL -> slice) applied correctly on peak selection when a non Q dimension is present
- Inverse  transform applied correctly for peak add action (this was also broke for 3D workspaces)
- Stop add action when a non Q dimension is one of the viewed axes (not enough info to populate peak position)

A lot of logic regarding peaks in sliceviewer assumes 3 Q dimensions (e.g. when adding/removing peaks, when drawing ellipsoids) - indeed peak overlay is completely disabled in 2D workspaces. In this PR a 4D workspace will have the same functionality wrt peak overlay as a 3D workspace when the 2 slice axes are Q dimensions.


**To test:**
(1) Make workspaces
```
# import mantid algorithms, numpy and matplotlib
from mantid.simpleapi import *
import matplotlib.pyplot as plt
ws_4D = CreateMDWorkspace(Dimensions=4, Extents=[-4, 4, -5, 5, -6, 6, -1, 1], Names="E,H,K,L",
                              Frames='General Frame,HKL,HKL,HKL', Units='meV,r.l.u.,r.l.u.,r.l.u.')
expt_info_4D = CreateSampleWorkspace()
ws_4D.addExperimentInfo(expt_info_4D)
SetUB(ws_4D, 1, 1, 2, 90, 90, 120)
CreatePeaksWorkspace(InstrumentWorkspace='ws_4D', NumberOfPeaks=0, OutputWorkspace='peaks')
CopySample(InputWorkspace='ws_4D', OutputWorkspace='peaks', CopyName=False, CopyMaterial=False, CopyEnvironment=False, CopyShape=False)
AddPeakHKL(Workspace='peaks', HKL='1,2,3')

ws_4D_normal_order = CreateMDWorkspace(Dimensions=4, Extents=[-1, 1, -1, 1, -1, 1, -1, 1], Names="H,K,L,E",
                              Frames='HKL,HKL,HKL,General Frame', Units='r.l.u.,r.l.u.,r.l.u.,meV')

```
With both `ws_4D` and `ws_4D_normal_order`
(2) Open workspace in sliceviewer
(3) Overlay `peaks`
(4) Select a peak in the table - peaks should be drawn if (X,Y) correspond to Q axes (i.e. not E)
(5) Transpose and swap axes - confirm again that peaks are drawn only when (X,Y) correspond to Q axes
(6) Switch to (X,Y) = (H,K) and turn on non-orthog view (if looking at `ws_4D`)
(7) Repeat steps (4-5)
(8) In orthog and non-orthog view (if looking at `ws_4D`) add peaks (Add button above table on RHS)
(9) Check that you can only add peaks when (X,Y) are Q dims
(10) Check the peak added has the correct position (H,K,L) in the table in ortho and non-ortho view (if looking at `ws_4D`)

Fixes #33873

<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
