### PR TITLE
Fix plot options error for inset axes

### DIFF
--- a/Framework/PythonInterface/mantid/plots/utility.py
+++ b/Framework/PythonInterface/mantid/plots/utility.py
@@ -132,7 +132,8 @@ def row_num(ax):
     if LooseVersion(mpl_version_str) >= LooseVersion("3.2.0"):
         return ax.get_subplotspec().rowspan.start
     else:
-        return ax.rowNum
+        # An 'inset' axes does not have a rowNum, so return None
+        return ax.rowNum if hasattr(ax, 'rowNum') else None
 
 
 def col_num(ax):
@@ -143,7 +144,8 @@ def col_num(ax):
     if LooseVersion(mpl_version_str) >= LooseVersion("3.2.0"):
         return ax.get_subplotspec().colspan.start
     else:
-        return ax.colNum
+        # An 'inset' axes does not have a colNum, so return None
+        return ax.colNum if hasattr(ax, 'colNum') else None
 
 
 def zoom_axis(ax, coord, x_or_y, factor):

--- a/Framework/PythonInterface/mantid/plots/utility.py
+++ b/Framework/PythonInterface/mantid/plots/utility.py
@@ -130,7 +130,8 @@ def row_num(ax):
     Version check to avoid calling depreciated method in matplotlib > 3.2
     """
     if LooseVersion(mpl_version_str) >= LooseVersion("3.2.0"):
-        return ax.get_subplotspec().rowspan.start
+        # An 'inset' axes does not have a subplotspec, so return None
+        return ax.get_subplotspec().rowspan.start if hasattr(ax, 'get_subplotspec') else None
     else:
         # An 'inset' axes does not have a rowNum, so return None
         return ax.rowNum if hasattr(ax, 'rowNum') else None
@@ -142,7 +143,8 @@ def col_num(ax):
     Version check to avoid calling depreciated method in matplotlib > 3.2
     """
     if LooseVersion(mpl_version_str) >= LooseVersion("3.2.0"):
-        return ax.get_subplotspec().colspan.start
+        # An 'inset' axes does not have a subplotspec, so return None
+        return ax.get_subplotspec().colspan.start if hasattr(ax, 'get_subplotspec') else None
     else:
         # An 'inset' axes does not have a colNum, so return None
         return ax.colNum if hasattr(ax, 'colNum') else None

--- a/Framework/PythonInterface/test/python/mantid/plots/UtilityTest.py
+++ b/Framework/PythonInterface/test/python/mantid/plots/UtilityTest.py
@@ -12,13 +12,41 @@
 #     & Institut Laue - Langevin
 # SPDX - License - Identifier: GPL - 3.0 +
 import unittest
+import matplotlib.pyplot as plt
 
-from mantid.plots.utility import legend_set_draggable
-from unittest.mock import create_autospec
+from mantid.api import AnalysisDataService
+from mantid.simpleapi import CreateSampleWorkspace
+from mantid.plots.utility import col_num, legend_set_draggable, row_num
 from matplotlib.legend import Legend
+from unittest.mock import create_autospec
 
 
 class UtilityTest(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.workspace = CreateSampleWorkspace(Function='User Defined',
+                                              UserDefinedFunction='name=ExpDecay,Lifetime = 20,Height = 200;'
+                                                                  'name=Gaussian,PeakCentre=50, Height=10, Sigma=3',
+                                              XMax=100, BinWidth=2, OutputWorkspace="__temp")
+
+    @classmethod
+    def tearDownClass(cls):
+        AnalysisDataService.clear()
+
+    def setUp(self):
+        self.fig, self.axes = plt.subplots(ncols=2, nrows=1, subplot_kw={'projection': 'mantid'})
+
+        self.axes[0].plot(self.workspace, specNum=1)
+        self.axes[1].errorbar(self.workspace, specNum=1, capsize=2.0)
+
+        # Add an inset axes, which is a good edge case to test
+        inset = self.fig.add_axes([0.77, 0.70, 0.18, 0.18], projection='mantid')
+        inset.plot(self.workspace, specNum=5, color='blue', label='Log Peak', marker='.')
+
+    def tearDown(self):
+        plt.close('all')
+        self.fig, self.axes = None, None
 
     def test_legend_set_draggable(self):
         legend = create_autospec(Legend)
@@ -29,6 +57,16 @@ class UtilityTest(unittest.TestCase):
             legend.set_draggable.assert_called_with(*args)
         else:
             legend.draggable.assert_called_with(*args)
+
+    def test_row_num_for_a_figure_with_an_inset_axis(self):
+        expected_row_nums = [0, 0, None]
+        for axis, row_number in zip(self.fig.get_axes(), expected_row_nums):
+            self.assertEqual(row_num(axis), row_number)
+
+    def test_col_num_for_a_figure_with_an_inset_axis(self):
+        expected_col_nums = [0, 1, None]
+        for axis, col_number in zip(self.fig.get_axes(), expected_col_nums):
+            self.assertEqual(col_num(axis), col_number)
 
 
 if __name__ == '__main__':

--- a/docs/source/release/v6.4.0/Workbench/Bugfixes/33915.rst
+++ b/docs/source/release/v6.4.0/Workbench/Bugfixes/33915.rst
@@ -1,0 +1,1 @@
+- Opening the plot options for a figure containing an 'inset' axes will no longer cause an error.


### PR DESCRIPTION
**Description of work.**
This PR fixes an error caused when opening the plot options on a figure containing an inset axes. An inset axes does not have a rowNum or colNum, and so this was causing an error when attempting to retrieve a name for the axes in the plot options. I think it makes sense to just return None if it doesn't have these attributes.

**To test:**
It would be great if we could test this on a conda build (matplotlib >= 3.2) and optionally on a non-conda build (with matplotlib < 3.2)

1. Run the following script in mantid
```
from mantid.simpleapi import *
import matplotlib.pyplot as plt
from matplotlib.ticker import (MultipleLocator, AutoMinorLocator)

#Example data
exp_decay = CreateSampleWorkspace(Function='User Defined',
                                  UserDefinedFunction='\
                                  name=ExpDecay,Lifetime = 20,Height = 200;name=Gaussian,\
                                  PeakCentre=50, Height=10, Sigma=3',
                                  XMax=100, BinWidth=2)

#Create figure and axes
fig, axes = plt.subplots(ncols=2,nrows=1,subplot_kw={'projection': 'mantid'})

# Plot with errorbars on the left set of axes
axes[0].plot(exp_decay, specNum=1, color='red', label='400 K', linewidth=1.0, drawstyle='steps')
axes[0].set_title('Steps and Grids')
axes[0].xaxis.set_minor_locator(AutoMinorLocator())
axes[0].grid(True, which = 'both', axis = 'both') # major/minor, x/y

# Add an inset, use trial and error to find the right location
inset = fig.add_axes([0.77, 0.70, 0.18, 0.18],projection='mantid') #[left, bottom, width, height]
inset.plot(exp_decay, specNum=5, color='blue', label='Log Peak', marker ='.')
plt.yscale('log') #only affects the most recently called axes
inset.set_xlim(40, 60), inset.set_ylim(5, 20)
inset.xaxis.set_minor_locator(AutoMinorLocator()) #inserts 5 minor b/w each major
inset.tick_params(which='minor', width = 0.5, length=4, color='b', direction='in', top='on')
inset.set_title('Inset')

#Plot on the right set of axes
axes[1].errorbar(exp_decay, specNum=1, capsize=2.0, errorevery=5, color='green', label='spec 1', linestyle='--')
axes[1].set_xlabel('Time-of-flight ($\mu s$)', fontsize = 12, fontstyle = 'italic', fontweight = 'bold')
axes[1].set_ylabel('Counts ($\mu s$)$^{-1}$')
axes[1].set_title('Errorbars')

#Use tight layout for subplots and create a legend
plt.tight_layout()
fig.legend(loc='center right')

fig.show()
```
3. Click on the cog (plot options)
4. The plot options should open without the error seen in the attached issue.
5. If you look at the axes in the combobox, the bottom axes is named `Inset: (None, None)`
6.  Mess around with the options for this inset axis. In general, they should work as expected.

Fixes #33915 


#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
