### PR TITLE
Fix Deprecation Warnings from matplotlib

### DIFF
--- a/qt/python/mantidqt/mantidqt/widgets/fitpropertybrowser/fitpropertybrowser.py
+++ b/qt/python/mantidqt/mantidqt/widgets/fitpropertybrowser/fitpropertybrowser.py
@@ -229,7 +229,7 @@ class FitPropertyBrowser(FitPropertyBrowserBase):
         """
         Change the output name if more than one plot of the same workspace
         """
-        window_title = self.canvas.get_window_title()
+        window_title = self.canvas.manager.get_window_title()
         workspace_name = window_title.rsplit('-', 1)[0]
         for open_figures in plt.get_figlabels():
             if open_figures != window_title and open_figures.rsplit('-', 1)[0] == workspace_name:

--- a/qt/python/mantidqt/mantidqt/widgets/plotconfigdialog/axestabwidget/presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/plotconfigdialog/axestabwidget/presenter.py
@@ -93,7 +93,7 @@ class AxesTabWidgetPresenter:
 
         if "xlabel" in self.current_view_props:
             ax.set_xlabel(self.current_view_props['xlabel'])
-            ax.set_xscale(self.current_view_props['xscale'])
+            ax.set_xscale(self.current_view_props['xscale'].lower())  # As of mpl 3.5 scale settings must be lowercase
 
             if self.current_view_props['xautoscale']:
                 if ax.images:
@@ -108,7 +108,7 @@ class AxesTabWidgetPresenter:
 
         if "ylabel" in self.current_view_props:
             ax.set_ylabel(self.current_view_props['ylabel'])
-            ax.set_yscale(self.current_view_props['yscale'])
+            ax.set_yscale(self.current_view_props['yscale'].lower())
 
             if self.current_view_props['yautoscale']:
                 if ax.images:

--- a/qt/python/mantidqt/mantidqt/widgets/plotconfigdialog/axestabwidget/test/test_axestabwidgetpresenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/plotconfigdialog/axestabwidget/test/test_axestabwidgetpresenter.py
@@ -70,13 +70,13 @@ class AxesTabWidgetPresenterTest(unittest.TestCase):
                     ax_mock.set_xlabel.assert_called_once_with(
                         presenter.current_view_props.xlabel)
                     ax_mock.set_xscale.assert_called_once_with(
-                        presenter.current_view_props.xscale)
+                        presenter.current_view_props.xscale.lower())
                     ax_mock.set_ylim.assert_called_once_with(
                         presenter.current_view_props.ylim)
                     ax_mock.set_ylabel.assert_called_once_with(
                         presenter.current_view_props.ylabel)
                     ax_mock.set_yscale.assert_called_once_with(
-                        presenter.current_view_props.yscale)
+                        presenter.current_view_props.yscale.lower())
                     ax_mock.minorticks_on.assert_called_once()
                     ax_mock.set_facecolor.assert_called_once_with(
                         presenter.current_view_props.canvas_color)
@@ -101,13 +101,13 @@ class AxesTabWidgetPresenterTest(unittest.TestCase):
                     ax_mock.set_xlabel.assert_called_once_with(
                         presenter.current_view_props.xlabel)
                     ax_mock.set_xscale.assert_called_once_with(
-                        presenter.current_view_props.xscale)
+                        presenter.current_view_props.xscale.lower())
                     ax_mock.autoscale.assert_has_calls(
                         [mock.call(True, axis="y")])
                     ax_mock.set_ylabel.assert_called_once_with(
                         presenter.current_view_props.ylabel)
                     ax_mock.set_yscale.assert_called_once_with(
-                        presenter.current_view_props.yscale)
+                        presenter.current_view_props.yscale.lower())
                     ax_mock.minorticks_on.assert_called_once()
                     ax_mock.set_facecolor.assert_called_once_with(
                         presenter.current_view_props.canvas_color)
@@ -137,13 +137,13 @@ class AxesTabWidgetPresenterTest(unittest.TestCase):
                         ax_mock.set_xlabel.assert_called_once_with(
                             presenter.current_view_props.xlabel)
                         ax_mock.set_xscale.assert_called_once_with(
-                            presenter.current_view_props.xscale)
+                            presenter.current_view_props.xscale.lower())
                         ax_mock.set_ylim.assert_called_once_with(
                             presenter.current_view_props.ylim)
                         ax_mock.set_ylabel.assert_called_once_with(
                             presenter.current_view_props.ylabel)
                         ax_mock.set_yscale.assert_called_once_with(
-                            presenter.current_view_props.yscale)
+                            presenter.current_view_props.yscale.lower())
                         ax_mock.set_facecolor.assert_called_once_with(
                             presenter.current_view_props.canvas_color)
 
@@ -168,13 +168,13 @@ class AxesTabWidgetPresenterTest(unittest.TestCase):
                         ax_mock.set_xlabel.assert_called_once_with(
                             presenter.current_view_props.xlabel)
                         ax_mock.set_xscale.assert_called_once_with(
-                            presenter.current_view_props.xscale)
+                            presenter.current_view_props.xscale.lower())
                         ax_mock.autoscale.assert_has_calls(
                             [mock.call(True, axis="y")])
                         ax_mock.set_ylabel.assert_called_once_with(
                             presenter.current_view_props.ylabel)
                         ax_mock.set_yscale.assert_called_once_with(
-                            presenter.current_view_props.yscale)
+                            presenter.current_view_props.yscale.lower())
                         ax_mock.set_facecolor.assert_called_once_with(
                             presenter.current_view_props.canvas_color)
                         ax_mock.set_xlim.assert_not_called()

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/presenters/lineplots.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/presenters/lineplots.py
@@ -342,7 +342,6 @@ class RectangleSelectionLinePlot(KeyHandler):
         self._selector = RectangleSelectorMtd(
             ax,
             self._on_rectangle_selected,
-            drawtype='box',
             useblit=False,  # rectangle persists on button release
             button=[1],
             minspanx=5,

--- a/qt/python/mantidqt/mantidqt/widgets/test/test_fitpropertybrowser.py
+++ b/qt/python/mantidqt/mantidqt/widgets/test/test_fitpropertybrowser.py
@@ -199,7 +199,7 @@ class FitPropertyBrowserTest(unittest.TestCase):
         # plot it twice
         for i in [0, 1]:
             fig = plot([ws], spectrum_nums=[1])
-            fig.canvas.get_window_title = Mock(return_value=ws_window_names[i])
+            fig.canvas.manager.get_window_title = Mock(return_value=ws_window_names[i])
             browser = self._create_widget(canvas=fig.canvas)
             # don't want the widget to actually show in test
             QDockWidget.show = Mock()


### PR DESCRIPTION
**Description of work.**
Found and fixed some of the depreaction warnings caused by the matplotlib 3.5 upgrade. 

**To test:**
1. Plot something
2. Switch the scales to log (you may have to do this from the figure options (cog) if another issue hasn't been fixed yet)
3. Open the sliceviewer and draw a box on the plot (the button of a rectangle with squares in the corners)
4. Open the fit property browser

None of these things should come up with deprecation warnings. 

Fixes #33886 

*This does not require release notes* because **these issues have only come about since the mpl 3.5 upgrade. **

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
