### PR TITLE
Fix deadlock with GIL and logger

### DIFF
--- a/Framework/PythonInterface/mantid/kernel/src/Exports/Logger.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Exports/Logger.cpp
@@ -5,6 +5,7 @@
 //   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 // SPDX - License - Identifier: GPL - 3.0 +
 #include "MantidKernel/Logger.h"
+#include "MantidPythonInterface/core/ReleaseGlobalInterpreterLock.h"
 #include <boost/python/class.hpp>
 #include <boost/python/make_constructor.hpp>
 #include <boost/python/reference_existing_object.hpp>
@@ -12,6 +13,7 @@
 #include <memory>
 
 using Mantid::Kernel::Logger;
+using Mantid::PythonInterface::ReleaseGlobalInterpreterLock;
 using namespace boost::python;
 using LoggerMsgFunction = void (Logger::*)(const std::string &);
 using LoggerFlushFunction = void (Logger::*)();
@@ -29,6 +31,37 @@ std::shared_ptr<Logger> getLogger(const std::string &name) {
 }
 
 std::shared_ptr<Logger> create(const std::string &name) { return std::make_shared<Logger>(name); }
+
+void fatal(Logger *self, const std::string &message) {
+  ReleaseGlobalInterpreterLock releaseGIL;
+  self->fatal(message);
+}
+
+void error(Logger *self, const std::string &message) {
+  ReleaseGlobalInterpreterLock releaseGIL;
+  self->error(message);
+}
+
+void warning(Logger *self, const std::string &message) {
+  ReleaseGlobalInterpreterLock releaseGIL;
+  self->warning(message);
+}
+
+void notice(Logger *self, const std::string &message) {
+  ReleaseGlobalInterpreterLock releaseGIL;
+  self->notice(message);
+}
+
+void information(Logger *self, const std::string &message) {
+  ReleaseGlobalInterpreterLock releaseGIL;
+  self->information(message);
+}
+
+void debug(Logger *self, const std::string &message) {
+  ReleaseGlobalInterpreterLock releaseGIL;
+  self->debug(message);
+}
+
 } // namespace
 
 void export_Logger() {
@@ -36,27 +69,27 @@ void export_Logger() {
 
   class_<Logger, boost::noncopyable>("Logger", init<std::string>((arg("self"), arg("name"))))
       .def("__init__", make_constructor(&create, default_call_policies(), args("name")))
-      .def("fatal", (LoggerMsgFunction)&Logger::fatal, (arg("self"), arg("message")),
+      .def("fatal", fatal, (arg("self"), arg("message")),
            "Send a message at fatal priority: "
            "An unrecoverable error has occured and the application will "
            "terminate")
-      .def("error", (LoggerMsgFunction)&Logger::error, (arg("self"), arg("message")),
+      .def("error", error, (arg("self"), arg("message")),
            "Send a message at error priority: "
            "An error has occured but the framework is able to handle it and "
            "continue")
-      .def("warning", (LoggerMsgFunction)&Logger::warning, (arg("self"), arg("message")),
+      .def("warning", warning, (arg("self"), arg("message")),
            "Send a message at warning priority: "
            "Something was wrong but the framework was able to continue despite "
            "the problem.")
-      .def("notice", (LoggerMsgFunction)&Logger::notice, (arg("self"), arg("message")),
+      .def("notice", notice, (arg("self"), arg("message")),
            "Sends a message at notice priority: "
            "Really important information that should be displayed to the user, "
            "this should be minimal. The default logging level is set here "
            "unless it is altered.")
-      .def("information", (LoggerMsgFunction)&Logger::information, (arg("self"), arg("message")),
+      .def("information", information, (arg("self"), arg("message")),
            "Send a message at information priority: "
            "Useful but not vital information to be relayed back to the user.")
-      .def("debug", (LoggerMsgFunction)&Logger::debug, (arg("self"), arg("message")),
+      .def("debug", debug, (arg("self"), arg("message")),
            "Send a message at debug priority:"
            ". Anything that may be useful to understand what the code has been "
            "doing for debugging purposes.")


### PR DESCRIPTION
Ensure we release the GIL in the logger python exports. This avoids a possibility of deadlock where a python thread can have the GIL locked but get stuck waiting on a Poco mutex to issue a log message, which another thread has locked but is waiting on the GIL in order to update the GUI with the python log message.

Fixes #33938

**To test:**

See the instructions in the linked issue

*This does not require release notes* because **it is already covered by release notes to fix another deadlock**


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
