### PR TITLE
Fix slice viewer bug caused by switching to `Log` or `SymmetricLog` on masked data

### DIFF
--- a/docs/source/release/v6.4.0/Workbench/SliceViewer/Bugfixes/33310.rst
+++ b/docs/source/release/v6.4.0/Workbench/SliceViewer/Bugfixes/33310.rst
@@ -1,0 +1,1 @@
+- Using the Region of Interest tool when the colorscale is set to Power will no longer cause a position related error.

--- a/docs/source/release/v6.4.0/Workbench/SliceViewer/Bugfixes/33883.rst
+++ b/docs/source/release/v6.4.0/Workbench/SliceViewer/Bugfixes/33883.rst
@@ -1,0 +1,1 @@
+- Using the Log or SymmetricLog10 colorbar normalisation options on masked data is now disabled to prevent an error.

--- a/qt/python/mantidqt/CMakeLists.txt
+++ b/qt/python/mantidqt/CMakeLists.txt
@@ -109,6 +109,7 @@ set(PYTHON_WIDGET_QT5_ONLY_TESTS
     mantidqt/widgets/codeeditor/test/test_scriptcompatibility.py
     mantidqt/widgets/codeeditor/tab_widget/test/test_codeeditor_tab_presenter.py
     mantidqt/widgets/codeeditor/tab_widget/test/test_codeeditor_tab_view.py
+    mantidqt/widgets/colorbar/test/test_colorbar.py
     mantidqt/widgets/fitpropertybrowser/addfunctiondialog/test/test_addfunctiondialogpresenter.py
     mantidqt/widgets/fitpropertybrowser/addfunctiondialog/test/test_addfunctiondialogview.py
     mantidqt/widgets/instrumentview/test/test_instrumentview_io.py

--- a/qt/python/mantidqt/mantidqt/widgets/colorbar/colorbar.py
+++ b/qt/python/mantidqt/mantidqt/widgets/colorbar/colorbar.py
@@ -276,8 +276,8 @@ class ColorbarWidget(QWidget):
         """
         Update displayed limit values based on stored ones
         """
-        self.cmin.setText("{:.4}".format(self.cmin_value))
-        self.cmax.setText("{:.4}".format(self.cmax_value))
+        self.cmin.setText(f"{float(self.cmin_value):.4}")
+        self.cmax.setText(f"{float(self.cmax_value):.4}")
 
     def redraw(self):
         """

--- a/qt/python/mantidqt/mantidqt/widgets/colorbar/colorbar.py
+++ b/qt/python/mantidqt/mantidqt/widgets/colorbar/colorbar.py
@@ -351,7 +351,7 @@ class ColorbarWidget(QWidget):
         """Disable the Log option if no positive value can be found from given data (image)"""
         index = NORM_OPTS.index("Log")
         if mappable.get_array() is not None:
-            if np.all(mappable.get_array() <= 0):
+            if np.all(mappable.get_array() <= 0) or mappable.get_array().all() is np.ma.masked:
                 self.norm.model().item(index, 0).setEnabled(False)
                 self.norm.setItemData(index, "Log scale is disabled for non-positive data",
                                       Qt.ToolTipRole)

--- a/qt/python/mantidqt/mantidqt/widgets/colorbar/test/__init__.py
+++ b/qt/python/mantidqt/mantidqt/widgets/colorbar/test/__init__.py
@@ -1,0 +1,6 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2022 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +

--- a/qt/python/mantidqt/mantidqt/widgets/colorbar/test/test_colorbar.py
+++ b/qt/python/mantidqt/mantidqt/widgets/colorbar/test/test_colorbar.py
@@ -1,0 +1,55 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2022 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+import matplotlib.pyplot as plt
+import numpy as np
+
+from unittest import mock, TestCase
+
+from mantidqt.utils.qt.testing import start_qapplication
+from mantidqt.widgets.colorbar.colorbar import ColorbarWidget
+
+
+@start_qapplication
+class ColorbarWidgetTest(TestCase):
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.data = np.arange(100.0).reshape((10, 10))
+        cls.masked_data = np.ma.masked_array(cls.data, mask=[list(range(1, 11))]*10)
+
+    def setUp(self) -> None:
+        self.fig = plt.figure(figsize=(1, 1))
+        self.image = plt.imshow(self.data, cmap="plasma")
+        self.masked_image = plt.imshow(self.masked_data, cmap="plasma")
+
+        self.widget = ColorbarWidget()
+        self.widget.cmin_value = 0
+        self.widget.set_mappable(self.image)
+
+    def tearDown(self) -> None:
+        plt.close('all')
+        self.fig, self.image, self.masked_image = None, None, None
+        self.widget = None
+
+    def test_that_masked_data_will_not_allow_negative_cmin_for_log_normalisation(self):
+        normalisation_index = 1  # Log
+
+        self.widget.norm.setCurrentIndex(normalisation_index)
+        self.widget.set_mappable(self.masked_image)
+
+        self.assertGreaterEqual(self.widget.cmin_value, 0.0)
+
+    def test_that_masked_data_will_not_cause_error_when_switching_to_symmetric_log_normalisation(self):
+        normalisation_index = 2  # SymmetricLog10
+
+        self.widget.norm.setCurrentIndex(normalisation_index)
+        self.widget.set_mappable(self.masked_image)
+
+        with mock.patch('qtpy.QtWidgets.QComboBox.currentIndex') as patch:
+            patch.return_value = normalisation_index
+
+            self.widget.norm_changed()

--- a/qt/python/mantidqt/mantidqt/widgets/colorbar/test/test_colorbar.py
+++ b/qt/python/mantidqt/mantidqt/widgets/colorbar/test/test_colorbar.py
@@ -32,10 +32,16 @@ class ColorbarWidgetTest(TestCase):
         plt.close('all')
         self.fig, self.widget = None, None
 
+    def test_that_an_integer_vmax_will_not_cause_an_error_when_the_clim_gets_updated(self):
+        image = plt.imshow(self.data, cmap="plasma", norm=LogNorm(vmin=0.01, vmax=1))
+
+        # The clim gets updated here
+        self.widget.set_mappable(image)
+
     def test_that_masked_data_in_log_mode_will_cause_a_switch_back_to_linear_normalisation(self):
         normalisation_index = 1  # Log
-        image = plt.imshow(self.data, cmap="plasma", norm=LogNorm(vmin=0.01, vmax=1))
-        masked_image = plt.imshow(self.masked_data, cmap="plasma", norm=LogNorm(vmin=0.01, vmax=1))
+        image = plt.imshow(self.data, cmap="plasma", norm=LogNorm(vmin=0.01, vmax=1.0))
+        masked_image = plt.imshow(self.masked_data, cmap="plasma", norm=LogNorm(vmin=0.01, vmax=1.0))
 
         self.widget.set_mappable(image)
         self.widget.norm.setCurrentIndex(normalisation_index)
@@ -46,8 +52,8 @@ class ColorbarWidgetTest(TestCase):
 
     def test_that_masked_data_in_symmetric_log_mode_will_cause_a_switch_back_to_linear_normalisation(self):
         normalisation_index = 2  # SymmetricLog10
-        image = plt.imshow(self.data, cmap="plasma", norm=SymLogNorm(1e-8, vmin=0.01, vmax=1))
-        masked_image = plt.imshow(self.masked_data, cmap="plasma", norm=SymLogNorm(1e-8, vmin=0.01, vmax=1))
+        image = plt.imshow(self.data, cmap="plasma", norm=SymLogNorm(1e-8, vmin=0.01, vmax=1.0))
+        masked_image = plt.imshow(self.masked_data, cmap="plasma", norm=SymLogNorm(1e-8, vmin=0.01, vmax=1.0))
 
         self.widget.set_mappable(image)
         self.widget.norm.setCurrentIndex(normalisation_index)


### PR DESCRIPTION
**Description of work.**
This PR fixes a bug on the sliceviewer caused by zooming in to data which is all masked and then changing the normalisation to `Log` or `SymmetricLog10`.
It also fixes a similar bug (reproducible only on a conda build) causing an error when switching to `Log` after zooming in to a region with barely any data.

**To test:**
From a conda environment:

1. Load in `CNCS_7860_event.nxs` from `<build_dir>/ExternalData/Testing/Data/SystemTest/` folder
2. Zoom out, and then zoom into a region with no data.
3. The `Log` and `SymmetricLog10` colorscale options should be disabled and have a useful tooltip
4. Click the Home button, and these options should now be enabled and with no tooltip
5. Zoom into a region that contains almost zero bins (where only one small line can be seen on the plot)
6. Change colorscale to log, and there should be no error message. There might be a warning but this is ok

Fixes #33883

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
