### PR TITLE
Fix Mantid crash on saving big project

### DIFF
--- a/docs/source/release/v6.4.0/Workbench/Bugfixes/33944.rst
+++ b/docs/source/release/v6.4.0/Workbench/Bugfixes/33944.rst
@@ -1,0 +1,1 @@
+- Fix a bug where trying to save a large project would cause Mantid to crash.

--- a/qt/python/mantidqt/mantidqt/project/project.py
+++ b/qt/python/mantidqt/mantidqt/project/project.py
@@ -18,6 +18,7 @@ from mantidqt.project.projectloader import ProjectLoader
 from mantidqt.project.projectsaver import ProjectSaver
 from mantidqt.utils.asynchronous import BlockingAsyncTaskWithCallback
 from mantidqt.widgets.saveprojectdialog.presenter import ProjectSaveDialogPresenter
+from mantidqt.utils.qt.qappthreadcall import QAppThreadCall
 
 
 class Project(AnalysisDataServiceObserver):
@@ -138,7 +139,9 @@ class Project(AnalysisDataServiceObserver):
             # If a project is > the value in the properties file, question the user if they want to continue.
             result = None
             if project_size > warning_size:
-                result = self._offer_large_size_confirmation()
+                # we have to create the message box in the main thread
+                result = QAppThreadCall(self._offer_large_size_confirmation)()
+
             if result is None or result != QMessageBox.Cancel:
                 plots_to_save = self.plot_gfm.figs
 


### PR DESCRIPTION
**Description of work.**
This fixes Mantid crashing when trying to save a big project, by moving the popup asking the user if they are sure they want to do that to the main thread, where it belongs.

**To test:**
If possible, try those steps on the main branch before, to be sure you have the bug in the first place - it does not appear on every machine.

- Run this script. Take note of the previous value of projectSaving.warningSize if you want to reset it after testing.
```
from mantid.simpleapi import *

# old value if we want to reset it afterwards
print("Previous warning size was", int(ConfigService.getString("projectSaving.warningSize")))

# set the warning value lower so we are not forced to create 10 GB of junk data
ConfigService.setString("projectSaving.warningSize", "10000000")

# create a workspace bigger than the limit
ws = CreateSampleWorkspace(BankPixelWidth=100)
```
- Save the project as. 
- A popup asking you to confirm because the project is very large should appear, without Mantid crashing.

Fixes #33943 .

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
