### PR TITLE
Fix Cannot Set Axes to Log from Double-Clicking Axes

### DIFF
--- a/qt/applications/workbench/workbench/plotting/propertiesdialog.py
+++ b/qt/applications/workbench/workbench/plotting/propertiesdialog.py
@@ -9,12 +9,15 @@
 #
 
 # 3rdparty imports
+from distutils.version import LooseVersion
+
 from mantid.plots.datafunctions import update_colorbar_scale, get_images_from_figure
 from mantidqt.plotting.figuretype import FigureType, figure_type
 from mantidqt.utils.qt import load_ui
 
 from matplotlib.colors import LogNorm, Normalize
 from matplotlib.ticker import ScalarFormatter, LogFormatterSciNotation
+from matplotlib import __version__ as matplotlib_version
 from mpl_toolkits.mplot3d.axes3d import Axes3D
 from qtpy.QtGui import QDoubleValidator, QIcon
 from qtpy.QtWidgets import QDialog, QWidget
@@ -169,7 +172,12 @@ class AxisEditor(PropertiesEditorBase):
             self.lim_setter = getattr(axes, 'set_{}lim'.format(axis_id))
 
         self.scale_setter = getattr(axes, 'set_{}scale'.format(axis_id))
-        self.nonposkw = 'nonpos' + axis_id
+
+        if LooseVersion(matplotlib_version) < LooseVersion("3.3.1"):
+            self.nonposkw = 'nonpos' + axis_id
+        else:
+            self.nonposkw = 'nonpositive'
+
         # Store the axis for attributes that can't be directly accessed
         # from axes object (e.g. grid and tick parameters).
         self.axis = getattr(axes, '{}axis'.format(axis_id))

--- a/qt/applications/workbench/workbench/plotting/propertiesdialog.py
+++ b/qt/applications/workbench/workbench/plotting/propertiesdialog.py
@@ -172,11 +172,7 @@ class AxisEditor(PropertiesEditorBase):
             self.lim_setter = getattr(axes, 'set_{}lim'.format(axis_id))
 
         self.scale_setter = getattr(axes, 'set_{}scale'.format(axis_id))
-
-        if LooseVersion(matplotlib_version) < LooseVersion("3.3.1"):
-            self.nonposkw = 'nonpos' + axis_id
-        else:
-            self.nonposkw = 'nonpositive'
+        self.nonposkw = 'nonpos' + axis_id if LooseVersion(matplotlib_version) < LooseVersion("3.3.1") else 'nonpositive'
 
         # Store the axis for attributes that can't be directly accessed
         # from axes object (e.g. grid and tick parameters).


### PR DESCRIPTION
REF#33910

**Description of work.**

Add condition to use `nonposx/y` or `nonpositive` depending upon matplotlib version. The former has been deprecated.

**To test:**
1. Load a workspace and plot a spectrum
2. Double click the numbers on an axis to bring up the Edit axis dialog
3. Check the log checkbox (make sure both min and max are positive)
4. Click ok, observe no error.

Fixes #33910

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
