### PR TITLE
Fix problem on plots zooming out when plotting guess

### DIFF
--- a/Framework/PythonInterface/mantid/plots/__init__.py
+++ b/Framework/PythonInterface/mantid/plots/__init__.py
@@ -22,7 +22,7 @@ from mantid.plots.legend import LegendProperties  # noqa: F401
 from mantid.plots.datafunctions import get_normalize_by_bin_width  # noqa: F401
 from mantid.plots.scales import PowerScale, SquareScale  # noqa: F401
 from mantid.plots.mantidaxes import MantidAxes, MantidAxes3D, WATERFALL_XOFFSET_DEFAULT, WATERFALL_YOFFSET_DEFAULT  # noqa: F401
-from mantid.plots.utility import artists_hidden, convert_color_to_hex, legend_set_draggable, MantidAxType  # noqa: F401
+from mantid.plots.utility import artists_hidden, autoscale_on_update, convert_color_to_hex, legend_set_draggable, MantidAxType  # noqa: F401
 
 register_projection(MantidAxes)
 register_projection(MantidAxes3D)

--- a/Framework/PythonInterface/mantid/plots/mantidaxes.py
+++ b/Framework/PythonInterface/mantid/plots/mantidaxes.py
@@ -30,7 +30,7 @@ from mantid.api import AnalysisDataService as ads
 from mantid.plots import datafunctions, axesfunctions, axesfunctions3D
 from mantid.plots.legend import LegendProperties
 from mantid.plots.datafunctions import get_normalize_by_bin_width
-from mantid.plots.utility import (artists_hidden, legend_set_draggable, MantidAxType)
+from mantid.plots.utility import (artists_hidden, autoscale_on_update, legend_set_draggable, MantidAxType)
 
 
 WATERFALL_XOFFSET_DEFAULT, WATERFALL_YOFFSET_DEFAULT = 10, 20
@@ -630,6 +630,8 @@ class MantidAxes(Axes):
         if datafunctions.validate_args(*args,**kwargs):
             logger.debug('using plotfunctions')
 
+            autoscale_on = kwargs.pop("autoscale_on_update", self.get_autoscale_on())
+
             def _data_update(artists, workspace, new_kwargs=None):
                 # It's only possible to plot 1 line at a time from a workspace
                 try:
@@ -653,6 +655,14 @@ class MantidAxes(Axes):
                     if (not self.is_empty(self)) and self.legend_ is not None:
                         legend_set_draggable(self.legend(), True)
 
+                if new_kwargs:
+                    _autoscale_on = new_kwargs.pop("autoscale_on_update", self.get_autoscale_on())
+                else:
+                    _autoscale_on = self.get_autoscale_on()
+
+                if _autoscale_on:
+                    self.relim()
+                    self.autoscale()
                 return artists
 
             workspace = args[0]
@@ -660,17 +670,23 @@ class MantidAxes(Axes):
             normalize_by_bin_width, kwargs = get_normalize_by_bin_width(workspace, self, **kwargs)
             is_normalized = normalize_by_bin_width or \
                             (hasattr(workspace, 'isDistribution') and workspace.isDistribution())
-            artist = self.track_workspace_artist(workspace,
-                                                 axesfunctions.plot(self, normalize_by_bin_width=is_normalized,
-                                                                    *args, **kwargs),
-                                                 _data_update, spec_num, is_normalized,
-                                                 MantidAxes.is_axis_of_type(MantidAxType.SPECTRUM, kwargs),
-                                                 kwargs.get('LogName', None),
-                                                 kwargs.get('Filtered', None),
-                                                 kwargs.get('ExperimentInfo', None))
+            with autoscale_on_update(self, autoscale_on):
+                artist = self.track_workspace_artist(workspace,
+                                                     axesfunctions.plot(self, normalize_by_bin_width=is_normalized,
+                                                                        *args, **kwargs),
+                                                     _data_update, spec_num, is_normalized,
+                                                     MantidAxes.is_axis_of_type(MantidAxType.SPECTRUM, kwargs),
+                                                     kwargs.get('LogName', None),
+                                                     kwargs.get('Filtered', None),
+                                                     kwargs.get('ExperimentInfo', None))
             return artist
         else:
-            return Axes.plot(self, *args, **kwargs)
+            lines = Axes.plot(self, *args, **kwargs)
+            # matplotlib 3.5.0 operates a lazy process for updating the view limits where they get updated
+            # on call to ax.draw instead of ax.plot. This doesn't work nicely with the Mantid requirement
+            # to toggle autoscale on and off so access the view limits here to update immediately
+            self.viewLim
+            return lines
 
     @plot_decorator
     def scatter(self, *args, **kwargs):
@@ -720,7 +736,13 @@ class MantidAxes(Axes):
         if datafunctions.validate_args(*args):
             logger.debug('using plotfunctions')
 
+            autoscale_on = kwargs.pop("autoscale_on_update", self.get_autoscale_on())
+
             def _data_update(artists, workspace, new_kwargs=None):
+                if new_kwargs:
+                    _autoscale_on = new_kwargs.pop("autoscale_on_update", self.get_autoscale_on())
+                else:
+                    _autoscale_on = self.get_autoscale_on()
                 # errorbar with workspaces can only return a single container
                 container_orig = artists[0]
                 # It is not possible to simply reset the error bars so
@@ -735,10 +757,11 @@ class MantidAxes(Axes):
                     pass
                 # this gets pushed back onto the containers list
                 try:
-                    if new_kwargs:
-                        container_new = axesfunctions.errorbar(self, workspace, **new_kwargs)
-                    else:
-                        container_new = axesfunctions.errorbar(self, workspace, **kwargs)
+                    with autoscale_on_update(self, _autoscale_on):
+                        if new_kwargs:
+                            container_new = axesfunctions.errorbar(self, workspace, **new_kwargs)
+                        else:
+                            container_new = axesfunctions.errorbar(self, workspace, **kwargs)
 
                     self.containers.insert(orig_idx, container_new)
                     self.containers.pop()
@@ -770,14 +793,20 @@ class MantidAxes(Axes):
             normalize_by_bin_width, kwargs = get_normalize_by_bin_width(workspace, self, **kwargs)
             is_normalized = normalize_by_bin_width or (hasattr(workspace, 'isDistribution')
                                                        and workspace.isDistribution())
-            artist = self.track_workspace_artist(workspace,
-                                                 axesfunctions.errorbar(self, normalize_by_bin_width=is_normalized,
-                                                                        *args, **kwargs),
-                                                 _data_update, spec_num, is_normalized,
-                                                 MantidAxes.is_axis_of_type(MantidAxType.SPECTRUM, kwargs))
+            with autoscale_on_update(self, autoscale_on):
+                artist = self.track_workspace_artist(workspace,
+                                                     axesfunctions.errorbar(self, normalize_by_bin_width=is_normalized,
+                                                                            *args, **kwargs),
+                                                     _data_update, spec_num, is_normalized,
+                                                     MantidAxes.is_axis_of_type(MantidAxType.SPECTRUM, kwargs))
             return artist
         else:
-            return Axes.errorbar(self, *args, **kwargs)
+            errorbar_container =  Axes.errorbar(self, *args, **kwargs)
+            # matplotlib 3.5.0 operates a lazy process for updating the view limits where they get updated
+            # on call to ax.draw instead of ax.errorbar. This doesn't work nicely with the Mantid requirement
+            # to toggle autoscale on and off so access the view limits here to update immediately
+            self.viewLim
+            return errorbar_container
 
     @plot_decorator
     def axhline(self, *args, **kwargs):

--- a/Framework/PythonInterface/mantid/plots/utility.py
+++ b/Framework/PythonInterface/mantid/plots/utility.py
@@ -62,6 +62,40 @@ def artists_hidden(artists):
             artist.set_visible(True)
 
 
+@contextmanager
+def autoscale_on_update(ax, state, axis='both'):
+    """
+    Context manager to temporarily change value of autoscale_on_update
+    :param matplotlib.axes.Axes ax: The axes to disable autoscale on
+    :param bool state: True turns auto-scaling on, False off
+    :param str axis: {'both', 'x', 'y'} The axis to set the scaling on
+    """
+    original_state = ax.get_autoscale_on()
+    try:
+        # If we are making the first plot on an axes object
+        # i.e. ax.lines is empty, axes has default ylim values.
+        # Therefore we need to autoscale regardless of state parameter.
+        if ax.lines:
+            if axis == 'both':
+                original_state = ax.get_autoscale_on()
+                ax.set_autoscale_on(state)
+            elif axis == 'x':
+                original_state = ax.get_autoscalex_on()
+                ax.set_autoscalex_on(state)
+            elif axis == 'y':
+                original_state = ax.get_autoscaley_on()
+                ax.set_autoscaley_on(state)
+        yield
+    finally:
+        if ax.lines:
+            if axis == 'both':
+                ax.set_autoscale_on(original_state)
+            elif axis == 'x':
+                ax.set_autoscalex_on(original_state)
+            elif axis == 'y':
+                ax.set_autoscaley_on(original_state)
+
+
 def find_errorbar_container(line, containers):
     """
     Finds the ErrorbarContainer associated with the plot line.

--- a/Framework/PythonInterface/test/python/mantid/plots/mantidaxesTest.py
+++ b/Framework/PythonInterface/test/python/mantid/plots/mantidaxesTest.py
@@ -508,8 +508,7 @@ class MantidAxesTest(unittest.TestCase):
         autoscale if the workspace changes
         """
         ws = CreateWorkspace(DataX=[10, 20], DataY=[10, 20], OutputWorkspace="ws")
-        self.ax.autoscale(enable=False, axis='both')
-        self.ax.plot(ws)
+        self.ax.plot(ws, autoscale_on_update=False)
         CreateWorkspace(DataX=[10, 20], DataY=[10, 5000], OutputWorkspace="ws")
         self.assertLess(self.ax.get_ylim()[1], 5000)
 
@@ -518,8 +517,7 @@ class MantidAxesTest(unittest.TestCase):
         ws = CreateWorkspace(DataX=[10, 20], DataY=[10, 20])
         self.ax.plot(ws)
         ws2 = CreateWorkspace(DataX=[10, 20], DataY=[10, 5000])
-        self.ax.autoscale(enable=False, axis='both')
-        self.ax.plot(ws2)
+        self.ax.plot(ws2, autoscale_on_update=False)
         self.assertLess(self.ax.get_ylim()[1], 5000)
 
     def test_that_plot_autoscales_by_default(self):
@@ -540,16 +538,14 @@ class MantidAxesTest(unittest.TestCase):
         ws = CreateWorkspace(DataX=[10, 20], DataY=[10, 20])
         self.ax.errorbar(ws)
         ws2 = CreateWorkspace(DataX=[10, 20], DataY=[10, 5000])
-        self.ax.autoscale(enable=False, axis='both')
-        self.ax.errorbar(ws2)
+        self.ax.errorbar(ws2, autoscale_on_update=False)
         self.assertLess(self.ax.get_ylim()[1], 5000)
 
     def test_that_errorbar_autoscaling_can_be_turned_off(self):
         ws = CreateWorkspace(DataX=[10, 20], DataY=[10, 20], DataE=[1, 2], OutputWorkspace="ws")
         self.ax.errorbar(ws)
         ws2 = CreateWorkspace(DataX=[10, 20], DataY=[10, 5000], DataE=[1, 1], OutputWorkspace="ws2")
-        self.ax.autoscale(enable=False, axis='both')
-        self.ax.errorbar(ws2)
+        self.ax.errorbar(ws2, autoscale_on_update=False)
         self.assertLess(self.ax.get_ylim()[1], 5000)
 
     def test_that_plotting_ws_without_giving_spec_num_sets_spec_num_if_ws_has_1_histogram(self):

--- a/qt/applications/workbench/workbench/plotting/figureinteraction.py
+++ b/qt/applications/workbench/workbench/plotting/figureinteraction.py
@@ -814,7 +814,7 @@ class FigureInteraction(object):
                 arg_set_copy = copy(arg_set)
                 [
                     arg_set_copy.pop(key)
-                    for key in ['function', 'workspaces', 'norm']
+                    for key in ['function', 'workspaces', 'autoscale_on_update', 'norm']
                     if key in arg_set_copy.keys()
                 ]
                 if 'specNum' not in arg_set:

--- a/qt/applications/workbench/workbench/plotting/test/test_figureinteraction.py
+++ b/qt/applications/workbench/workbench/plotting/test/test_figureinteraction.py
@@ -225,12 +225,12 @@ class FigureInteractionTest(unittest.TestCase):
     def test_normalization_toggle_with_no_autoscale_on_update_no_errors(self):
         self.ax.autoscale(enable=False, axis='both')
         self._test_toggle_normalization(errorbars_on=False,
-                                        plot_kwargs={'distribution': True})
+                                        plot_kwargs={'distribution': True, 'autoscale_on_update': False})
 
     def test_normalization_toggle_with_no_autoscale_on_update_with_errors(self):
         self.ax.autoscale(enable=False, axis='both')
         self._test_toggle_normalization(errorbars_on=True,
-                                        plot_kwargs={'distribution': True})
+                                        plot_kwargs={'distribution': True, 'autoscale_on_update': False})
 
     def test_add_error_bars_menu(self):
         self.ax.errorbar([0, 15000], [0, 14000], yerr=[10, 10000], label='MyLabel 2')

--- a/qt/python/mantidqt/mantidqt/widgets/fitpropertybrowser/fitpropertybrowser.py
+++ b/qt/python/mantidqt/mantidqt/widgets/fitpropertybrowser/fitpropertybrowser.py
@@ -220,9 +220,6 @@ class FitPropertyBrowser(FitPropertyBrowserBase):
         self.setPeakToolOn(True)
         self.canvas.draw()
         self.set_output_window_names()
-        # Turn off autoscaling in the future
-        for axes in self.canvas.figure.get_axes():
-            axes.autoscale(enable=False)
 
     def set_output_window_names(self):
         import matplotlib.pyplot as plt  # unfortunately need to import again
@@ -384,10 +381,9 @@ class FitPropertyBrowser(FitPropertyBrowserBase):
         # Keep local copy of the original lines
         original_lines = self.get_lines()
 
-        ax.autoscale(enable=False, axis='both')
-        ax.plot(ws, wkspIndex=1, **plot_kwargs)
+        ax.plot(ws, wkspIndex=1, autoscale_on_update=False, **plot_kwargs)
         if plot_diff:
-            ax.plot(ws, wkspIndex=2, **plot_kwargs)
+            ax.plot(ws, wkspIndex=2, autoscale_on_update=False, **plot_kwargs)
 
         self.addFitResultWorkspacesToTableWidget()
         # Add properties back to the lines

--- a/qt/python/mantidqt/mantidqt/widgets/fitpropertybrowser/fitpropertybrowserplotinteraction.py
+++ b/qt/python/mantidqt/mantidqt/widgets/fitpropertybrowser/fitpropertybrowserplotinteraction.py
@@ -276,10 +276,8 @@ class FitPropertyBrowserPlotInteraction(QObject):
         legend = ax.get_legend()
 
         # Setting distribution=True prevents the guess being normalised
-        ax.autoscale(enable=False, axis='both')
-        line = ax.plot(out_ws, wkspIndex=1, label=output_workspace_name, distribution=True, update_axes_labels=False,
-                       **plotkwargs)[0]
-        ax.autoscale(enable=True, axis='both')
+        line = ax.plot(out_ws, wkspIndex=1, label=output_workspace_name, distribution=True,
+                       update_axes_labels=False, autoscale_on_update=False, **plotkwargs)[0]
         if legend:
             ax.make_legend()
 

--- a/qt/python/mantidqt/mantidqt/widgets/test/test_fitpropertybrowser.py
+++ b/qt/python/mantidqt/mantidqt/widgets/test/test_fitpropertybrowser.py
@@ -24,7 +24,7 @@ from mantidqt.utils.qt.testing import start_qapplication
 from mantidqt.utils.testing.strict_mock import StrictMock
 from mantidqt.widgets.fitpropertybrowser.fitpropertybrowser import FitPropertyBrowser
 from workbench.plotting.figuremanager import FigureManagerADSObserver
-from mantid.plots.utility import MantidAxType
+from mantid.plots.utility import MantidAxType, zoom
 
 from qtpy.QtWidgets import QDockWidget
 
@@ -178,13 +178,35 @@ class FitPropertyBrowserTest(unittest.TestCase):
         wsList = property_browser.getWorkspaceList()
         self.assertEqual(1, len(wsList))
 
-    def test_plot_limits_are_not_changed_when_plotting_fit_lines(self):
+    def test_plot_limits_are_not_changed_when_plotting_fit_lines_autoscale_true(self):
         fig, canvas, _ = self._create_and_plot_matrix_workspace()
         ax_limits = fig.get_axes()[0].axis()
         canvas.draw()
         widget = self._create_widget(canvas=canvas)
         fit_ws_name = "fit_ws"
         CreateSampleWorkspace(OutputWorkspace=fit_ws_name)
+        widget.fitting_done_slot(fit_ws_name)
+        self.assertEqual(ax_limits, fig.get_axes()[0].axis())
+
+    def test_plot_limits_are_not_changed_when_plotting_fit_lines_autoscale_false(self):
+        fig, canvas, ws = self._create_and_plot_matrix_workspace()
+        ax = fig.get_axes()[0]
+        full_ax_limits = ax.axis()
+        # zoom in x2 based on the central x and y values and recapture limits
+        # note, zoom turns autoscale off
+        zoom(ax, 0.5*(full_ax_limits[0]+full_ax_limits[1]), 0.5*(full_ax_limits[2]+full_ax_limits[3]), 2)
+        ax_limits = ax.axis()
+        canvas.draw()
+        widget = self._create_widget(canvas=canvas)
+        fit_ws_name = "fit_ws"
+        # create fit workspace containing 3 spectra (data\calc\diff)
+        CreateWorkspace(OutputWorkspace=fit_ws_name, DataX=[ax_limits[0], ax_limits[1]], DataY=[1]*6,
+                        NSpec=3, Distribution=False)
+        widget.fitting_done_slot(fit_ws_name)
+        self.assertEqual(ax_limits, fig.get_axes()[0].axis())
+        # user picks x range bigger than current zoom (but still within ws data range). Plot limits still don't change
+        CreateWorkspace(OutputWorkspace=fit_ws_name, DataX=[full_ax_limits[0], full_ax_limits[1]], DataY=[1]*6,
+                        NSpec=3, Distribution=False)
         widget.fitting_done_slot(fit_ws_name)
         self.assertEqual(ax_limits, fig.get_axes()[0].axis())
 

--- a/qt/python/mantidqt/mantidqt/widgets/test/test_fitpropertybrowserplotinteraction.py
+++ b/qt/python/mantidqt/mantidqt/widgets/test/test_fitpropertybrowserplotinteraction.py
@@ -75,6 +75,7 @@ class FitPropertyBrowserPlotInteractionTest(unittest.TestCase):
         self.canvas = MagicMock()
         self.figure = MagicMock()
         self.axes = MagicMock(spec=MantidAxes)
+        self.axes.get_autoscale_on.return_value=False
         self.figure.get_axes.return_value = [self.axes]
         self.canvas.figure = self.figure
         self.browser_plot_interaction = FitPropertyBrowserPlotInteraction(self.fit_browser, self.canvas)
@@ -101,7 +102,7 @@ class FitPropertyBrowserPlotInteractionTest(unittest.TestCase):
         self.figure.get_axes.assert_called_once()
         self.axes.plot.assert_called_once_with(ANY, wkspIndex=1, label=workspace_name + '_guess',
                                                distribution=True,
-                                               update_axes_labels=False)
+                                               update_axes_labels=False, autoscale_on_update=False)
 
     def test_plot_current_guess_evaluates_correct_function(self):
         workspace_name = "test_workspace"
@@ -124,7 +125,19 @@ class FitPropertyBrowserPlotInteractionTest(unittest.TestCase):
         self.figure.get_axes.assert_called_once()
         self.axes.plot.assert_called_once_with(ANY, wkspIndex=1, label=prefix + '.' + FUNCTION_2.name(),
                                                distribution=True,
-                                               update_axes_labels=False)
+                                               update_axes_labels=False, autoscale_on_update=False)
+
+    def test_plot_guess_doesnt_alter_autoscale(self):
+        workspace_name = "test_workspace"
+        prefix = 'f1'
+        self.setup_mock_fit_browser(self.create_workspace2D, workspace_name, FUNCTION_2, prefix)
+
+        ax = self.figure.get_axes()[0]
+        orig_autoscale = ax.get_autoscale_on()
+        self.browser_plot_interaction.plot_current_guess()
+        set_autoscale_call_count = ax.autoscale.call_count
+        if set_autoscale_call_count > 0:
+            ax.autoscale.assert_called_with(orig_autoscale, ANY) # checks most recent call
 
     def test_plot_guess_all_plots_for_table_workspaces(self):
         table_name = "table_name"
@@ -136,7 +149,7 @@ class FitPropertyBrowserPlotInteractionTest(unittest.TestCase):
         self.figure.get_axes.assert_called_once()
         self.axes.plot.assert_called_once_with(ANY, wkspIndex=1, label=table_name + '_guess',
                                                distribution=True,
-                                               update_axes_labels=False)
+                                               update_axes_labels=False, autoscale_on_update=False)
 
     def test_remove_function_correctly_updates_stored_prefixed_functions(self):
         workspace_name = "test_workspace"
@@ -183,7 +196,7 @@ class FitPropertyBrowserPlotInteractionTest(unittest.TestCase):
         old_line.remove.assert_called_once()
         self.axes.plot.assert_called_once_with(ANY, wkspIndex=1, label=workspace_name + '_guess',
                                                distribution=True,
-                                               update_axes_labels=False,
+                                               update_axes_labels=False, autoscale_on_update=False,
                                                color=old_line.get_color())
 
     def test_changing_parameters_refreshes_guess_all(self):
@@ -198,7 +211,7 @@ class FitPropertyBrowserPlotInteractionTest(unittest.TestCase):
         old_line.remove.assert_called_once()
         self.axes.plot.assert_called_once_with(ANY, wkspIndex=1, label=workspace_name + '_guess',
                                                distribution=True,
-                                               update_axes_labels=False,
+                                               update_axes_labels=False, autoscale_on_update=False,
                                                color=old_line.get_color())
 
     def test_changing_parameters_refreshes_current_guess(self):
@@ -212,7 +225,7 @@ class FitPropertyBrowserPlotInteractionTest(unittest.TestCase):
         line_2.remove.assert_called_once()
         self.axes.plot.assert_called_once_with(ANY, wkspIndex=1, label=prefix + '.' + FUNCTION_2.name(),
                                                distribution=True,
-                                               update_axes_labels=False,
+                                               update_axes_labels=False, autoscale_on_update=False,
                                                color=line_2.get_color())
 
 

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/plot_widget/external_plotting/external_plotting_view.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/plot_widget/external_plotting/external_plotting_view.py
@@ -74,7 +74,8 @@ class ExternalPlottingView(object):
         external_axes = fig_window.axes
         for plot_info in data:
             external_axis = external_axes[plot_info.axis]
-            external_axis.plot(plot_info.workspace, specNum=plot_info.specNum, distribution=not plot_info.normalised)
+            external_axis.plot(plot_info.workspace, specNum=plot_info.specNum, autoscale_on_update=True,
+                               distribution=not plot_info.normalised)
             legend_set_draggable(external_axis.legend(), True)
         fig_window.show()
 

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/plot_widget/plotting_canvas/plotting_canvas_view.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/plot_widget/plotting_canvas/plotting_canvas_view.py
@@ -437,7 +437,7 @@ class PlottingCanvasView(QtWidgets.QWidget, PlottingCanvasViewInterface):
 
     def _get_plot_kwargs(self, workspace_info: WorkspacePlotInformation):
         label = workspace_info.label
-        plot_kwargs = {'distribution': True, 'label': label}
+        plot_kwargs = {'distribution': True, 'autoscale_on_update': False, 'label': label}
         plot_kwargs["marker"] = self._settings.get_marker(workspace_info.workspace_name)
         plot_kwargs["linestyle"] = self._settings.get_linestyle(workspace_info.workspace_name)
         if isinstance(workspace_info.index, int):


### PR DESCRIPTION
**Description of work.**

Fix for problem found during manual testing for the 6.4 release. Mantid was automatically zooming out when you plotted a guess if you'd previously zoomed into a peak to add a peak function (see linked issue)


Problem was introduced during the work to upgrade to matplotlib 3.5 (in 053b57df23abdafe0fa56e6b6b54cdf886f10f0c specifically) when the autoscale_on_update decorator was removed. This was done to work around a new "lazy" approach to updating axes view limits in matplotlib 3.5 (see new function `_unstale_viewLim` in matplotlib/axes/_base.py). The view limits get updated on the call to ax.draw instead of ax.plot which doesn't interact very nicely with the Mantid autoscale_on_update feature. The original Mantid workaround was to replace the decorator with pairs of calls to ax.autoscale() wherever the autoscale_on_update setting had been used but some of these weren't working properly - see fitpropertybrowser.py and fitpropertybrowserplotinteraction.py.

These changes revert commit 053b57df23abdafe0fa56e6b6b54cdf886f10f0c and reintroduce the autoscale_on_update decorator. I've effectively stopped the lazy viewLim update by accessing the view limits as soon as plot has been called (see changes in mantidaxes.py):
```
            lines = Axes.plot(self, *args, **kwargs)
            # matplotlib 3.5.0 operates a lazy process for updating the view limits where they get updated
            # on call to ax.draw instead of ax.plot. This doesn't work nicely with the Mantid requirement
            # to toggle autoscale on and off so access the view limits here to update immediately
            self.viewLim
            return lines
```
I've also reverted f7077fd1f94bb0691fde46f83774dcea44054150 which fixed a similar zooming out problem on opening the fit property browser because this is covered by reinstating the autoscale_on_update decorator

**To test:**

Run steps on linked issue
Also test that opening the fit property browser on a plot that's zoomed in doesn't change the zoom level
Would be good to test on pre-Conda (which is matplotlib 3.1.2 on Windows) and Conda (matplotlib 3.5) just to be sure this all works in both cases


Fixes #33909.

*This does not require release notes* because **fixes an issue created during this release cycle**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
