### PR TITLE
Update muon ADS observers

### DIFF
--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/fitting_widgets/model_fitting/model_fitting_presenter.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/fitting_widgets/model_fitting/model_fitting_presenter.py
@@ -36,7 +36,7 @@ class ModelFittingPresenter(BasicFittingPresenter):
         self.view.set_slot_for_selected_x_changed(self.handle_selected_x_changed)
         self.view.set_slot_for_selected_y_changed(self.handle_selected_y_changed)
 
-        self.clear_observer = GenericObserverWithArgPassing(self.clear)
+        self.clear_observer = GenericObserver(self.clear)
         self.remove_observer = GenericObserverWithArgPassing(self.remove)
         self.replace_observer = GenericObserverWithArgPassing(self.replaced)
 


### PR DESCRIPTION
The muon observers were throwing errors when the user cleared the ADS while the GUI was open.

**To test:**

<!-- Instructions for testing. -->
Follow the instructions for the crashes in https://github.com/mantidproject/mantid/pull/33902


Fixes #33947. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

There is no release note as this is due to something we added this release. 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
