### PR TITLE
Change GroupBySampleChangerPosition to give no text for no samp_posn

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/GroupBySampleChangerPosition.py
+++ b/Framework/PythonInterface/plugins/algorithms/GroupBySampleChangerPosition.py
@@ -9,10 +9,10 @@ from mantid.simpleapi import GroupWorkspaces
 from mantid.api import (Algorithm, AlgorithmFactory, WorkspaceGroupProperty)
 from mantid.kernel import (Direction, StringArrayProperty)
 
-SAMP_POSITION = {6.0: "btm",
-                 85.5: "mid",
-                 165.0: "top",
-                 "None": "None"}
+SAMP_POSITION = {6.0: "btm_",
+                 85.5: "mid_",
+                 165.0: "top_",
+                 "None": ""}
 
 
 class GroupBySampleChangerPosition(Algorithm):
@@ -48,7 +48,7 @@ class GroupBySampleChangerPosition(Algorithm):
         sample_sorted_lists = self._sort_runs_by_sample()
         output_ws_name = []
         for sample in sample_sorted_lists:
-            group_ws_name = self._output_prefix + "_" + SAMP_POSITION[sample] + "_" + self._output_suffix
+            group_ws_name = self._output_prefix + "_" + SAMP_POSITION[sample] + self._output_suffix
             GroupWorkspaces(InputWorkspaces=sample_sorted_lists[sample], OutputWorkspace=group_ws_name)
             output_ws_name.append(group_ws_name)
         self.setProperty('OutputWorkspaceList', output_ws_name)

--- a/Framework/PythonInterface/test/python/plugins/algorithms/GroupBySampleChangerPositionTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/GroupBySampleChangerPositionTest.py
@@ -26,8 +26,8 @@ class GroupBySampleChangerPositionTest(unittest.TestCase):
         self.assertFalse(ads.doesExist("Prefix_btm_Suffix"))
         self.assertFalse(ads.doesExist("Prefix_mid_Suffix"))
         self.assertFalse(ads.doesExist("Prefix_top_Suffix"))
-        self.assertTrue(ads.doesExist("Prefix_none_Suffix"))
-        ads.remove("Prefix_none_Suffix")
+        self.assertTrue(ads.doesExist("Prefix_Suffix"))
+        ads.remove("Prefix_Suffix")
 
     def test_group_with_sample_position(self):
         """
@@ -44,7 +44,7 @@ class GroupBySampleChangerPositionTest(unittest.TestCase):
         self.assertTrue(ads.doesExist("Prefix_btm_Suffix"))
         self.assertTrue(ads.doesExist("Prefix_mid_Suffix"))
         self.assertTrue(ads.doesExist("Prefix_top_Suffix"))
-        self.assertFalse(ads.doesExist("Prefix_none_Suffix"))
+        self.assertFalse(ads.doesExist("Prefix_Suffix"))
         ads.remove("Prefix_btm_Suffix")
         ads.remove("Prefix_mid_Suffix")
         ads.remove("Prefix_top_Suffix")


### PR DESCRIPTION
**Description of work.**

This commit changes GroupBySampleChangerPosition so that if a workspace has no SAMP_POSN it does not give any extra text for the output group. this also means that if ISIS energy transfer is used with group by sample selected on worksapces with no SAMP_POSN in their sample logs it ungroups these workspaces

**To test:**

1. Open Indirect Data reduction
2. Load Runs 94297-94312
3. Under output options select Group by Sample
4. Click run
5. check that outputs are grouped into 3 group workspaces each labeled as either top, mid or btm
6. Select one of the workspaces in the groups and show sample logs,
7. the SAMP_POS log should be 6.0 for btm workspaces, 85.5 for mid and 165.0 for top
8. repeat for runs 32500-32510
9. These should not be grouped together, and workspaces should not have SAMP_POS in their logs.

Fixes #33954

*This does not require release notes* because **It is a change to a new feature in this release**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
