### PR TITLE
Publish nightly packages from conda pipeline

### DIFF
--- a/buildconfig/Jenkins/Conda/nightly_build_and_deploy.jenkinsfile
+++ b/buildconfig/Jenkins/Conda/nightly_build_and_deploy.jenkinsfile
@@ -64,7 +64,7 @@ pipeline {
     WIN_BASH = "C:\\Program Files\\git\\bin\\bash.exe"
   }
   stages {
-/*     stage('Build and test') {
+    stage('Build and test') {
       parallel {
         stage('platform: linux') {
           agent { label 'conda-build-linux' }
@@ -104,7 +104,7 @@ pipeline {
           }
         }
       }
-    } */
+    }
     stage('Update conda-recipes repository') {
       agent { label 'conda-build-linux' }
       environment { GITHUB_TOKEN = credentials("${GITHUB_TOKEN_CREDENTIAL_ID}") }

--- a/buildconfig/Jenkins/Conda/nightly_build_and_deploy.jenkinsfile
+++ b/buildconfig/Jenkins/Conda/nightly_build_and_deploy.jenkinsfile
@@ -168,7 +168,7 @@ pipeline {
           selector: specific('${BUILD_NUMBER}',
           target: 'standalone-packages',
           flatten: true)
-        sh '${WORKSPACE}/buildconfig/Jenkins/Conda/publish-to-github ${WORKSPACE} ${GITHUB_TOKEN} ${GITHUB_RELEASES_REPO} ${GITHUB_RELEASES_TAG} ${WORKSPACE}/standalone-packages/*.tar.bz2'
+        sh '${WORKSPACE}/buildconfig/Jenkins/Conda/publish-to-github ${WORKSPACE} ${GITHUB_TOKEN} ${GITHUB_RELEASES_REPO} ${GITHUB_RELEASES_TAG} ${WORKSPACE}/standalone-packages/*'
       }
     }
     stage ('Delete old Conda nightly packages from Anaconda') {

--- a/buildconfig/Jenkins/Conda/nightly_build_and_deploy.jenkinsfile
+++ b/buildconfig/Jenkins/Conda/nightly_build_and_deploy.jenkinsfile
@@ -107,9 +107,9 @@ pipeline {
     }
     stage('Update conda-recipes repository') {
       agent { label 'conda-build-linux' }
-      environment { GITHUB_ACCESS_TOKEN = credentials("${GITHUB_TOKEN_CREDENTIAL_ID}") }
+      environment { GITHUB_TOKEN = credentials("${GITHUB_TOKEN_CREDENTIAL_ID}") }
       steps {
-        sh '${WORKSPACE}/buildconfig/Jenkins/Conda/update-conda-recipes.sh $GITHUB_ACCESS_TOKEN $GITHUB_USER_NAME $GITHUB_USER_EMAIL'
+        sh '${WORKSPACE}/buildconfig/Jenkins/Conda/update-conda-recipes.sh $GITHUB_TOKEN $GITHUB_USER_NAME $GITHUB_USER_EMAIL'
       }
     }
     stage('Packaging') {
@@ -143,17 +143,32 @@ pipeline {
         }
       }
     }
-    stage ('Publish Conda packages to Anaconda') {
+    stage ('Publishing') {
       agent { label 'conda-build-linux' } // Use linux for simplicity with shell scripts
       options { timestamps () }
-      environment { ANACONDA_TOKEN = credentials("${ANACONDA_TOKEN_CREDENTIAL_ID}") }
-      steps{
-        // Copy all artifacts into ${WORKSPACE} from the current job, using ${JOB_NAME} and the current ${BUILD_NUMBER}
+      environment {
+        ANACONDA_TOKEN = credentials("${ANACONDA_TOKEN_CREDENTIAL_ID}")
+        GITHUB_TOKEN = credentials("${GITHUB_TOKEN_CREDENTIAL_ID}")
+      }
+      steps {
+        // Conda first
+        sh 'rm -fr ${WORKSPACE}/conda-packages'
         copyArtifacts filter: '**/conda-bld/**/*.tar.bz2',
           fingerprintArtifacts: true,
           projectName: '${JOB_NAME}',
-          selector: specific('${BUILD_NUMBER}')
-        sh '${WORKSPACE}/buildconfig/Jenkins/Conda/publish-to-anaconda ${WORKSPACE} $ANACONDA_TOKEN $ANACONDA_CHANNEL $ANACONDA_CHANNEL_LABEL ${WORKSPACE}/conda-bld/linux-64/mantid-*.tar.bz2 ${WORKSPACE}/conda-bld/linux-64/mantidqt-*.tar.bz2 ${WORKSPACE}/conda-bld/linux-64/mantidworkbench-*.tar.bz2 ${WORKSPACE}/conda-bld/osx-64/mantid-*.tar.bz2 ${WORKSPACE}/conda-bld/osx-64/mantidqt-*.tar.bz2 ${WORKSPACE}/conda-bld/osx-64/mantidworkbench-*.tar.bz2 ${WORKSPACE}/conda-bld/win-64/mantid-*.tar.bz2 ${WORKSPACE}/conda-bld/win-64/mantidqt-*.tar.bz2 ${WORKSPACE}/conda-bld/win-64/mantidworkbench-*.tar.bz2'
+          selector: specific('${BUILD_NUMBER}',
+          target: 'conda-packages',
+          flatten: true)
+        sh '${WORKSPACE}/buildconfig/Jenkins/Conda/publish-to-anaconda ${WORKSPACE} ${ANACONDA_TOKEN} ${ANACONDA_CHANNEL} ${ANACONDA_CHANNEL_LABEL} ${WORKSPACE}/conda-packages/*.tar.bz2'
+        // Standalone packages next
+        sh 'rm -fr ${WORKSPACE}/standalone-packages'
+        copyArtifacts filter: '*.exe, *.dmg, *.xz',
+          fingerprintArtifacts: true,
+          projectName: '${JOB_NAME}',
+          selector: specific('${BUILD_NUMBER}',
+          target: 'standalone-packages',
+          flatten: true)
+        sh '${WORKSPACE}/buildconfig/Jenkins/Conda/publish-to-github ${WORKSPACE} ${GITHUB_TOKEN} ${GITHUB_RELEASES_REPO} ${GITHUB_RELEASES_TAG} ${WORKSPACE}/standalone-packages/*.tar.bz2'
       }
     }
     stage ('Delete old Conda nightly packages from Anaconda') {

--- a/buildconfig/Jenkins/Conda/nightly_build_and_deploy.jenkinsfile
+++ b/buildconfig/Jenkins/Conda/nightly_build_and_deploy.jenkinsfile
@@ -64,7 +64,7 @@ pipeline {
     WIN_BASH = "C:\\Program Files\\git\\bin\\bash.exe"
   }
   stages {
-    stage('Build and test') {
+/*     stage('Build and test') {
       parallel {
         stage('platform: linux') {
           agent { label 'conda-build-linux' }
@@ -104,7 +104,7 @@ pipeline {
           }
         }
       }
-    }
+    } */
     stage('Update conda-recipes repository') {
       agent { label 'conda-build-linux' }
       environment { GITHUB_TOKEN = credentials("${GITHUB_TOKEN_CREDENTIAL_ID}") }

--- a/buildconfig/Jenkins/Conda/nightly_build_and_deploy.jenkinsfile
+++ b/buildconfig/Jenkins/Conda/nightly_build_and_deploy.jenkinsfile
@@ -156,18 +156,18 @@ pipeline {
         copyArtifacts filter: '**/conda-bld/**/*.tar.bz2',
           fingerprintArtifacts: true,
           projectName: '${JOB_NAME}',
-          selector: specific('${BUILD_NUMBER}',
+          selector: specific('${BUILD_NUMBER}'),
           target: 'conda-packages',
-          flatten: true)
+          flatten: true
         sh '${WORKSPACE}/buildconfig/Jenkins/Conda/publish-to-anaconda ${WORKSPACE} ${ANACONDA_TOKEN} ${ANACONDA_CHANNEL} ${ANACONDA_CHANNEL_LABEL} ${WORKSPACE}/conda-packages/*.tar.bz2'
         // Standalone packages next
         sh 'rm -fr ${WORKSPACE}/standalone-packages'
         copyArtifacts filter: '*.exe, *.dmg, *.xz',
           fingerprintArtifacts: true,
           projectName: '${JOB_NAME}',
-          selector: specific('${BUILD_NUMBER}',
+          selector: specific('${BUILD_NUMBER}'),
           target: 'standalone-packages',
-          flatten: true)
+          flatten: true
         sh '${WORKSPACE}/buildconfig/Jenkins/Conda/publish-to-github ${WORKSPACE} ${GITHUB_TOKEN} ${GITHUB_RELEASES_REPO} ${GITHUB_RELEASES_TAG} ${WORKSPACE}/standalone-packages/*'
       }
     }

--- a/buildconfig/Jenkins/Conda/publish-to-github
+++ b/buildconfig/Jenkins/Conda/publish-to-github
@@ -1,0 +1,48 @@
+#!/bin/bash -ex
+# This script expects
+#
+# Expected args:
+#   1. WORKSPACE: path to the workspace/source code that this should run inside
+#                 (mantid repo). Windows Caveat: Only use / for this argument do
+#                 not use \\ or \ in the path.
+#   2. TOKEN: Token for uploading to github.com
+#   3. RELEASES_REPO: Name, in owner/reponame format, of repository to publish to
+#   4. RELEASES_TAG GitHub tag to store assets
+#   Remainder PACKAGES: A list of args that will be uploaded to github release cloud.
+#
+
+# Parse arguments
+WORKSPACE=$1
+shift
+GITHUB_TOKEN=$1
+shift
+RELEASES_REPO=$1
+shift
+RELEASES_TAG=$1
+shift
+
+EXPECTED_MAMBAFORGE_PATH=$WORKSPACE/mambaforge # Install into the WORKSPACE_DIR
+if [[ $OSTYPE == "msys" ]]; then
+    EXPECTED_CONDA_PATH=$EXPECTED_MAMBAFORGE_PATH/condabin/mamba.bat
+else
+    EXPECTED_CONDA_PATH=$EXPECTED_MAMBAFORGE_PATH/bin/mamba
+fi
+CONDA_ENV_NAME=mantid-github-upload
+SCRIPT_DIR=$WORKSPACE/buildconfig/Jenkins/Conda/
+
+# Setup Mambaforge if not already installed
+$SCRIPT_DIR/download-and-install-mambaforge $EXPECTED_MAMBAFORGE_PATH $EXPECTED_CONDA_PATH false
+
+# Remove conda env if it exists
+$EXPECTED_CONDA_PATH env remove -n $CONDA_ENV_NAME
+
+# Create env with the gh github client installed
+$EXPECTED_CONDA_PATH create -n $CONDA_ENV_NAME gh -y
+
+# Activate Conda environment
+. $WORKSPACE/mambaforge/etc/profile.d/conda.sh
+conda activate $CONDA_ENV_NAME
+
+# Export token for use by gh to authenticate
+export GITHUB_TOKEN
+gh release -R $RELEASES_REPO upload $RELEASES_TAG "$@"


### PR DESCRIPTION
**Description of work.**
Publish nightly packages from the conda-based Jenkins nightly pipeline to a github nightly builds release tag.

**To test:**
Verfiy that this Jenkins build succeeded in publishing to anaconda and to github:

https://builds.mantidproject.org/view/Nightly%20Pipelines/job/main_nightly_deployment_prototype/345/

i.e. the assets from that job match the ones that were deployed here:

https://anaconda.org/mantid/mantidworkbench/files
https://github.com/mantidproject/mantid/releases/tag/nightly

*There is no associated issue.*


*This does not require release notes* because it is not a functional change to the mantid software


<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
