### PR TITLE
Prevent setting readLock on a workspace already locked

### DIFF
--- a/docs/source/release/v6.4.0/Workbench/SliceViewer/Bugfixes/33882.rst
+++ b/docs/source/release/v6.4.0/Workbench/SliceViewer/Bugfixes/33882.rst
@@ -1,0 +1,1 @@
+- Automatic refresh now works when a binary operation is applied to the underlying workspace.

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/presenters/presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/presenters/presenter.py
@@ -371,7 +371,7 @@ class SliceViewer(ObservingPresenter, SliceViewerBasePresenter):
             # New model is OK, proceed with updating Slice Viewer
             self.model = candidate_model
             self.new_plot, self.update_plot_data = self._decide_plot_update_methods()
-            self.refresh_view()
+            self.view.delayed_refresh()
         except ValueError as err:
             self._close_view_with_message(
                 f"Closing Sliceviewer as the underlying workspace was changed: {str(err)}")

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_sliceviewer_presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_sliceviewer_presenter.py
@@ -464,7 +464,7 @@ class SliceViewerTest(unittest.TestCase):
             presenter.replace_workspace('workspace', workspace)
 
             presenter.view.emit_close.assert_not_called()
-            presenter.view.data_view.plot_MDH.assert_called_once()
+            presenter.view.delayed_refresh.assert_called_once()  # leave it to QTimer to call refresh_view()
 
     def test_refresh_view(self):
         presenter, _ = _create_presenter(self.model,

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/views/view.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/views/view.py
@@ -10,7 +10,7 @@
 # 3rd party imports
 
 import mantid.api
-from qtpy.QtCore import Qt, Signal
+from qtpy.QtCore import Qt, QTimer, Signal
 from qtpy.QtWidgets import (QHBoxLayout, QSplitter, QWidget)
 
 # local imports
@@ -110,6 +110,11 @@ class SliceViewerView(QWidget, ObservingView):
         :return: The PeaksViewerCollectionView
         """
         self.peaks_view.set_visible(on)
+
+    def delayed_refresh(self):
+        """Post an event to the event loop that causes the view to
+        update on the next cycle"""
+        QTimer.singleShot(0, self.presenter.refresh_view)
 
     def close(self):
         self.presenter.notify_close()


### PR DESCRIPTION
**Description of work.**

A small fix to stop setting a readLock on a workspace that is already locked. I am not very familiar with readLocking workspaces but the new behaviour seems to work. It should be checked that most basic sliceviewer features (especially ones that include refreshing the plot) aren't broken by this change.

**To test:**

PLEASE TEST ON A CONDA BUILD, as I could only reproduce the bug there.

- Open the IPython toolbox
- Paste this script  and run it to create data:
``` python
from mantid.simpleapi import *

md_4D = CreateMDWorkspace(Dimensions=4, Extents=[-2,2,-1,1,-1.5,1.5,-0.25,0.25], Names="H,K,L,E", Frames='HKL,HKL,HKL,General Frame',Units='r.l.u.,r.l.u.,r.l.u.,meV')
FakeMDEventData(InputWorkspace=md_4D, UniformParams='5e5') # 4D data
tmp = CreateMDWorkspace(Dimensions=4, Extents=[-0.5,0.5,-1,-0.5,-1.5,-1, -0.25,0], Names="H,K,L,E", Frames='HKL,HKL,HKL,General Frame',Units='r.l.u.,r.l.u.,r.l.u.,meV')
FakeMDEventData(InputWorkspace=tmp, UniformParams='1e5') # 4D data
md_4D += tmp
DeleteWorkspace(tmp)

# Add a non-orthogonal UB
expt_info = CreateSampleWorkspace()
md_4D.addExperimentInfo(expt_info)
SetUB(Workspace='md_4D', c=2, gamma=120)

# make a 3D MDEvent workspace by integrating over all E
md_3D = SliceMD(InputWorkspace='md_4D', AlignedDim0='H,-2,2,100', AlignedDim1='K,-1,1,100', AlignedDim2='L,-1.5,1.5,100')

# Create a peaks workspace and fake data in 3D MD
CreatePeaksWorkspace(InstrumentWorkspace='md_3D', NumberOfPeaks=0, OutputWorkspace='peaks')
CopySample(InputWorkspace='md_3D', OutputWorkspace='peaks', CopyName=False, CopyMaterial=False, CopyEnvironment=False, CopyShape=False)
AddPeakHKL(Workspace='peaks', HKL='1,0,1')
AddPeakHKL(Workspace='peaks', HKL='1,0,0')
```

- Right-click on the ``md_3D`` workspace and open sliceviewer
- still in the IPython: run `mtd['md_3D'] *= 2`
- you should get no errors in the IPython widget or elsewhere and the colorbar max value should double (from ~ 35 to ~70 for me)

- still in the IPython: run `md_3D = mtd['md_3D'] * 2`
- again you should get no errors in the IPython widget or elsewhere and the colorbar max value should double (from ~ 70 to ~140 for me)
A simpler example:
``` python
from mantid.simpleapi import *
ws = CreateSampleWorkspace()
two = CreateSingleValuedWorkspace(2)

'''OPEN SLICEVIEWER'''
''' RUN THIS LINE IN IPYTHON'''
ws = Multiply('ws', 'two')
```

- finally try other things from here to see if this change breaks expected behaviour: https://developer.mantidproject.org/Testing/SliceViewer/SliceViewer.html

Fixes #33882

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
