### PR TITLE
Fix crash on opening Discus algorithm dialog

### DIFF
--- a/Framework/Algorithms/src/DiscusMultipleScatteringCorrection.cpp
+++ b/Framework/Algorithms/src/DiscusMultipleScatteringCorrection.cpp
@@ -163,8 +163,14 @@ void DiscusMultipleScatteringCorrection::init() {
  * @return a map where keys are property names and values the found issues
  */
 std::map<std::string, std::string> DiscusMultipleScatteringCorrection::validateInputs() {
-  MatrixWorkspace_sptr inputWS = getProperty("InputWorkspace");
   std::map<std::string, std::string> issues;
+  MatrixWorkspace_sptr inputWS = getProperty("InputWorkspace");
+  if (inputWS == nullptr) {
+    // Mainly aimed at groups. Group ws pass the property validation on MatrixWorkspace type if all members are
+    // MatrixWorkspaces. We output a WorkspaceGroup for a single input workspace so can't manage input groups
+    issues["InputWorkspace"] = "Input workspace must be a matrix workspace";
+    return issues;
+  }
   Geometry::IComponent_const_sptr sample = inputWS->getInstrument()->getSample();
   if (!sample) {
     issues["InputWorkspace"] = "Input workspace does not have a Sample";

--- a/docs/source/release/v6.4.0/Framework/Algorithms/Bugfixes/33973_FixCrashOnOpeningDiscusAlgDialog.rst
+++ b/docs/source/release/v6.4.0/Framework/Algorithms/Bugfixes/33973_FixCrashOnOpeningDiscusAlgDialog.rst
@@ -1,1 +1,1 @@
-- fix crash when opening the algorithm dialog for :ref:`DiscusMultipleScatteringCorrection <algm-DiscusMultipleScatteringCorrection>` if a group workspace is present in the Analysis Data Service
+- Workbench will no longer crash if the algorithm dialog for :ref:`DiscusMultipleScatteringCorrection <algm-DiscusMultipleScatteringCorrection>` is opened while a group workspace is present in the Workspaces list.

--- a/docs/source/release/v6.4.0/Framework/Algorithms/Bugfixes/33973_FixCrashOnOpeningDiscusAlgDialog.rst
+++ b/docs/source/release/v6.4.0/Framework/Algorithms/Bugfixes/33973_FixCrashOnOpeningDiscusAlgDialog.rst
@@ -1,0 +1,1 @@
+- fix crash when opening the algorithm dialog for :ref:`DiscusMultipleScatteringCorrection <algm-DiscusMultipleScatteringCorrection>` if a group workspace is present in the Analysis Data Service


### PR DESCRIPTION
**Description of work.**

Fix crash on opening the algorithm dialog for DiscusMultipleScatteringCorrection. Crash happened when there was a workspace group in the ADS that was picked up as default value for the InputWorkspace property. If the OutputWorkspace property had a value from a previous run the crash happened on opening up the algorithm dialog. If OutputWorkspace was empty then the dialog opened up OK but populating it followed by pressing "Run" in the dialog caused the crash

This conditions for the crash are likely to happen with the DiscusMultipleScatteringCorrection algorithm because it outputs a workspace group so successive runs can create this situation.

Note - There are some general features in the algorithm base classes to take workspace groups as input and loop through the group members running the algorithm on each workspace. This can't work for DiscusMultipleScatteringCorrection. When run with a normal workspace as input this algorithm outputs a workspace group containing various results relating to the input. It's therefore not possible for the algorithm to work successfully with an input workspace group because it would require a group of groups as output

Also note - the InputWorkspace property is set up as a `WorkspaceProperty<MatrixWorkspace>`. When I originally wrote the algorithm I expected the "per parameter" validation to block a workspace group value so that the code in validateInputs could assume it was a MatrixWorkspace. The functionality I mentioned in the previous point about algorithms in general accepting workspace groups side steps this validation though. If each member of the workspace group is a MatrixWorkspace then it's treated as a valid input by the "per parameter" validation and validateInputs does get called with the InputWorkspace parameter holding a group.

**To test:**

Best to do this on a release build so it runs quickly:

1. Copy one of the usage examples from the algorithm's documentation into the workbench script editor and remove the final mtd.clear() statement
2. Run the script. This should create some workspaces including a workspace group
3. Open up the DiscusMultipleScatteringCorrection algorithm dialog
4. Check it doesn't crash and also check that the workspace group has been entered into the InputWorkspace as the default value
5. Fill in the OutputWorkspace property with any string if it's blank then Press run
6. Check it doesn't crash. The algorithm shouldn't run because it's not valid to have a workspace group as the InputWorkspace value. That property should be flagged as invalid

*There is no associated issue.*

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
