### PR TITLE
Pinned version of numpy

### DIFF
--- a/mantid-developer-linux.yml
+++ b/mantid-developer-linux.yml
@@ -22,7 +22,7 @@ dependencies:
   - muparser>=2.3.2
   - nexus=4.4.*
   - ninja>=1.10.2
-  - numpy>=1.20.2
+  - numpy>=1.20.2, <1.22.4
   - occt>=7.4.0
   - pip>=21.0.1
   - poco=1.10.*

--- a/mantid-developer-osx.yml
+++ b/mantid-developer-osx.yml
@@ -21,7 +21,7 @@ dependencies:
   - matplotlib=3.5.*
   - nexus=4.4.*
   - ninja>=1.10.2
-  - numpy>=1.20.2
+  - numpy>=1.20.2, <1.22.4
   - occt
   - pip>=21.0.1
   - poco=1.10.*

--- a/mantid-developer-win.yml
+++ b/mantid-developer-win.yml
@@ -21,7 +21,7 @@ dependencies:
   - matplotlib=3.5.*
   - nexus=4.4.*
   - ninja>=1.10.2
-  - numpy=1.20.2, <1.22.4
+  - numpy>=1.20.2, <1.22.4
   - occt>=7.4.0
   - conda-wrappers
   - pip>=21.0.1

--- a/mantid-developer-win.yml
+++ b/mantid-developer-win.yml
@@ -21,7 +21,7 @@ dependencies:
   - matplotlib=3.5.*
   - nexus=4.4.*
   - ninja>=1.10.2
-  - numpy>=1.20.2
+  - numpy=1.20.2, <1.22.4
   - occt>=7.4.0
   - conda-wrappers
   - pip>=21.0.1


### PR DESCRIPTION
**Description of work.**
A new version of numpy (1.22.4) was released this weekend. However it was not compatible for us so we need to pin it to v 1.22.3 for the time being.

**To test:**
This job should pass without error:
https://builds.mantidproject.org/job/pull_requests-conda-linux/469
as well as all the ones from this commit:
https://github.com/mantidproject/mantid/pull/33974/commits/836befe1633d4690f78d453f9f494ed82f3396e6
(the second commit will have no affect on any of the PR checks, so as long as the first commit passes we are fine)

*There is no associated issue.*

*This does not require release notes* because **this is not user facing**


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
