### PR TITLE
Fix crash on adding user function to a plot with guess present

### DIFF
--- a/Framework/CurveFitting/src/Functions/UserFunction.cpp
+++ b/Framework/CurveFitting/src/Functions/UserFunction.cpp
@@ -103,12 +103,16 @@ void UserFunction::setAttribute(const std::string &attName, const Attribute &val
  *  @param nData :: The size of the fitted data.
  */
 void UserFunction::function1D(double *out, const double *xValues, const size_t nData) const {
+  if (m_formula.empty()) {
+    throw std::invalid_argument("Empty formula supplied for user function");
+  }
   for (size_t i = 0; i < nData; i++) {
     m_x = xValues[i];
     try {
       out[i] = m_parser->Eval();
     } catch (mu::Parser::exception_type &e) {
-      throw std::invalid_argument("Error evaluating function: " + e.GetMsg());
+      throw std::invalid_argument("Error evaluating function \"" + m_formula + "\" for x=" + std::to_string(m_x) +
+                                  ": " + e.GetMsg());
     }
   }
 }

--- a/docs/source/release/v6.4.0/Workbench/Bugfixes/33925.rst
+++ b/docs/source/release/v6.4.0/Workbench/Bugfixes/33925.rst
@@ -1,0 +1,1 @@
+- Fix crash on adding a user function to a plot that already has a guess plotted

--- a/qt/python/mantidqt/mantidqt/widgets/fitpropertybrowser/fitpropertybrowserplotinteraction.py
+++ b/qt/python/mantidqt/mantidqt/widgets/fitpropertybrowser/fitpropertybrowserplotinteraction.py
@@ -269,7 +269,7 @@ class FitPropertyBrowserPlotInteraction(QObject):
         """
         try:
             out_ws = self.evaluate_function(workspace_name, function, output_workspace_name)
-        except RuntimeError:
+        except (ValueError, RuntimeError):
             return
 
         ax = self.get_axes()

--- a/qt/python/mantidqt/mantidqt/widgets/fitpropertybrowser/fitpropertybrowserplotinteraction.py
+++ b/qt/python/mantidqt/mantidqt/widgets/fitpropertybrowser/fitpropertybrowserplotinteraction.py
@@ -232,7 +232,8 @@ class FitPropertyBrowserPlotInteraction(QObject):
             pass
 
         line = self._plot_guess_workspace(ws_name, fun, out_ws_name, color=color)
-        self.guess_all_line = line
+        if line is not None:
+            self.guess_all_line = line
 
     def update_legend(self):
         """

--- a/qt/python/mantidqt/mantidqt/widgets/test/test_fitpropertybrowserplotinteraction.py
+++ b/qt/python/mantidqt/mantidqt/widgets/test/test_fitpropertybrowserplotinteraction.py
@@ -114,6 +114,16 @@ class FitPropertyBrowserPlotInteractionTest(unittest.TestCase):
         self.browser_plot_interaction.evaluate_function.assert_called_once_with(workspace_name, FUNCTION_2,
                                                                                 prefix + '.' + FUNCTION_2.name())
 
+    def test_plot_current_guess_handles_invalid_function(self):
+        workspace_name = "test_workspace"
+        prefix = 'f1'
+        self.setup_mock_fit_browser(self.create_workspace2D, workspace_name, FUNCTION_2, prefix)
+        self.browser_plot_interaction.evaluate_function = Mock()
+        self.browser_plot_interaction.evaluate_function.side_effect = ValueError()
+
+        self.browser_plot_interaction.plot_current_guess()
+        self.axes.plot.assert_not_called()
+
     def test_plot_current_guess_correctly_calls_plot(self):
         workspace_name = "test_workspace"
         prefix = 'f1'


### PR DESCRIPTION
**Description of work.**

Fix crash on adding user function to a plot with guess present. The algorithm EvaluateFunction returns a ValueError and not a RunTimeError if the function is invalid

**To test:**

See attached issue

Fixes #33925. 


<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
