### PR TITLE
Fix UnEx and Deprecation Warning in Waterfall Plots

### DIFF
--- a/Framework/PythonInterface/mantid/plots/datafunctions.py
+++ b/Framework/PythonInterface/mantid/plots/datafunctions.py
@@ -979,7 +979,8 @@ def remove_and_return_errorbar_cap_lines(ax):
                         break
 
             if line_is_errorbar_cap:
-                errorbar_cap_lines.append(ax.lines.pop(ax.lines.index(line)))
+                errorbar_cap_lines.append(line)
+                line.remove()
 
     return errorbar_cap_lines
 

--- a/Framework/PythonInterface/mantid/plots/mantidaxes.py
+++ b/Framework/PythonInterface/mantid/plots/mantidaxes.py
@@ -1127,7 +1127,7 @@ class MantidAxes(Axes):
         self.waterfall_y_offset = y_offset
 
         for cap in errorbar_cap_lines:
-            self.lines.add_line(cap)
+            self.add_line(cap)
 
         datafunctions.set_waterfall_toolbar_options_enabled(self)
         self.get_figure().canvas.draw()

--- a/docs/source/release/v6.4.0/Workbench/Bugfixes/33913.rst
+++ b/docs/source/release/v6.4.0/Workbench/Bugfixes/33913.rst
@@ -1,2 +1,1 @@
 - Workbench will no longer throw on plots with error bar caps when the offset of a waterfall plot is adjusted.
-- The fill must now be manually re-enabled after changing settings on waterfall plots. This is due to deprecated methods in new versions of matplotlib.

--- a/docs/source/release/v6.4.0/Workbench/Bugfixes/33913.rst
+++ b/docs/source/release/v6.4.0/Workbench/Bugfixes/33913.rst
@@ -1,0 +1,2 @@
+- Workbench will no longer throw on plots with error bar caps when the offset of a waterfall plot is adjusted.
+- The fill must now be manually re-enabled after changing settings on waterfall plots. This is due to deprecated methods in new versions of matplotlib.

--- a/qt/python/mantidqt/mantidqt/widgets/plotconfigdialog/curvestabwidget/presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/plotconfigdialog/curvestabwidget/presenter.py
@@ -70,12 +70,6 @@ class CurvesTabWidgetPresenter:
         if view_props == self.current_view_properties:
             return
 
-        if isinstance(ax, MantidAxes):
-            was_waterfall = ax.is_waterfall()
-            if was_waterfall:
-                x_offset, y_offset = ax.waterfall_x_offset, ax.waterfall_y_offset
-                ax.set_waterfall(False)
-
         plot_kwargs = view_props.get_plot_kwargs()
         # Re-plot curve
         self._replot_current_curve(plot_kwargs)
@@ -84,10 +78,6 @@ class CurvesTabWidgetPresenter:
         self.set_new_curve_name_in_dict_and_list(curve, view_props.label)
         FigureErrorsManager.toggle_errors(curve, view_props)
         self.current_view_properties = view_props
-
-        if isinstance(ax, MantidAxes):
-            if was_waterfall:
-                ax.set_waterfall(True, x_offset, y_offset)
 
         FigureErrorsManager.update_limits_and_legend(ax, self.legend_props)
 
@@ -129,6 +119,12 @@ class CurvesTabWidgetPresenter:
         """Replot the selected curve with the given plot kwargs"""
         ax = self.get_selected_ax()
         curve = self.get_current_curve()
+
+        if isinstance(ax, MantidAxes):
+            was_waterfall = ax.is_waterfall()
+            if was_waterfall:
+                x_offset, y_offset = ax.waterfall_x_offset, ax.waterfall_y_offset
+                ax.set_waterfall(False)
 
         waterfall = False
         if isinstance(ax, MantidAxes):
@@ -182,6 +178,10 @@ class CurvesTabWidgetPresenter:
 
         for cap in errorbar_cap_lines:
             ax.add_line(cap)
+
+        if isinstance(ax, MantidAxes):
+            if was_waterfall:
+                ax.set_waterfall(True, x_offset, y_offset)
 
     def populate_select_axes_combo_box(self):
         """

--- a/qt/python/mantidqt/mantidqt/widgets/plotconfigdialog/curvestabwidget/presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/plotconfigdialog/curvestabwidget/presenter.py
@@ -69,6 +69,13 @@ class CurvesTabWidgetPresenter:
         view_props = self.get_view_properties()
         if view_props == self.current_view_properties:
             return
+
+        if isinstance(ax, MantidAxes):
+            was_waterfall = ax.is_waterfall()
+            if was_waterfall:
+                x_offset, y_offset = ax.waterfall_x_offset, ax.waterfall_y_offset
+                ax.set_waterfall(False)
+
         plot_kwargs = view_props.get_plot_kwargs()
         # Re-plot curve
         self._replot_current_curve(plot_kwargs)
@@ -77,6 +84,10 @@ class CurvesTabWidgetPresenter:
         self.set_new_curve_name_in_dict_and_list(curve, view_props.label)
         FigureErrorsManager.toggle_errors(curve, view_props)
         self.current_view_properties = view_props
+
+        if isinstance(ax, MantidAxes):
+            if was_waterfall:
+                ax.set_waterfall(True, x_offset, y_offset)
 
         FigureErrorsManager.update_limits_and_legend(ax, self.legend_props)
 
@@ -151,11 +162,6 @@ class CurvesTabWidgetPresenter:
             errorbar_cap_lines = datafunctions.remove_and_return_errorbar_cap_lines(ax)
         else:
             errorbar_cap_lines = []
-
-        # When a curve is redrawn it is moved to the back of the list of curves so here it is moved back to its previous
-        # position. This is so that the correct offset is applied to the curve if the plot is a waterfall plot, but it
-        # also just makes sense for the curve order to remain unchanged.
-        ax.lines.insert(curve_index, ax.lines.pop())
 
         if waterfall:
             # Set the waterfall offsets to what they were previously.

--- a/qt/python/mantidqt/mantidqt/widgets/plotconfigdialog/curvestabwidget/test/test_curvestabwidgetpresenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/plotconfigdialog/curvestabwidget/test/test_curvestabwidgetpresenter.py
@@ -15,8 +15,7 @@ from matplotlib.pyplot import figure, subplots
 from numpy import array_equal
 
 from mantid.simpleapi import CreateWorkspace
-from mantid.plots import datafunctions
-from mantid.plots.utility import convert_color_to_hex, MantidAxType
+from mantid.plots.utility import MantidAxType
 from unittest.mock import Mock, patch, call
 from mantidqt.widgets.plotconfigdialog.curvestabwidget import CurveProperties
 from mantidqt.widgets.plotconfigdialog.curvestabwidget.presenter import (
@@ -325,46 +324,6 @@ class CurvesTabWidgetPresenterTest(unittest.TestCase):
         self.assertEqual(presenter.view.errorbars.set_cap_thickness.call_count, 0)
         self.assertEqual(presenter.view.errorbars.set_error_every.call_count, 0)
         self.assertEqual(mock_apply_properties.call_count, 3)
-
-    def test_hiding_a_curve_on_a_waterfall_plot_also_hides_its_filled_area(self):
-        fig = self.make_figure_with_multiple_curves()
-
-        mock_view = Mock(get_selected_ax_name=lambda: "Axes 0: (0, 0)",
-                         get_current_curve_name=lambda: "Workspace")
-
-        ax = fig.get_axes()[0]
-        ax.set_waterfall(True)
-        ax.set_waterfall_fill(True)
-
-        presenter = self._generate_presenter(fig=fig, mock_view=mock_view)
-
-        new_plot_kwargs = {'visible': False}
-        presenter._replot_current_curve(new_plot_kwargs)
-
-        self.assertEqual(datafunctions.get_waterfall_fill_for_curve(ax, 0).get_visible(), False)
-
-    def test_changing_line_colour_on_a_waterfall_plot_with_filled_areas_changes_fill_colour_to_match(self):
-        fig = self.make_figure_with_multiple_curves()
-
-        mock_view = Mock(get_selected_ax_name=lambda: "Axes 0: (0, 0)",
-                         get_current_curve_name=lambda: "Workspace")
-
-        ax = fig.get_axes()[0]
-        ax.lines[0].set_color('#ff9900')
-        ax.lines[1].set_color('#008fff')
-        ax.lines[2].set_color('#42ff00')
-
-        # Create waterfall plot and add filled areas.
-        ax.set_waterfall(True)
-        ax.set_waterfall_fill(True)
-
-        presenter = self._generate_presenter(fig=fig, mock_view=mock_view)
-        # Change the colour of one of the lines.
-        new_plot_kwargs = {'color': '#ffff00'}
-        presenter._replot_current_curve(new_plot_kwargs)
-
-        # The fill for that line should be the new colour.
-        self.assertEqual(convert_color_to_hex(ax.collections[0].get_facecolor()[0]), ax.lines[0].get_color())
 
     def test_adding_errorbars_to_waterfall_plot_maintains_waterfall(self):
         fig = self.make_figure_with_multiple_curves()


### PR DESCRIPTION
**Description of work.**
Fixed an unhandled exception in waterfall plots and a deprecation warning. 

This has been a nightmare. There isn't a clean way to control the order of the lines in a plot without using a (now) deprecated accessor. ~~As a result, these changes result in some regressions in the way that waterfall plots function. Whether these are worth the fix is worth discussing.~~

1. ~~The fill on waterfall plots is no longer maintained when changes are made to the figure options. This will need to be re-set each time.~~
2. ~~The order of the lines in the plot is no longer maintained. This makes the "reverse order" button act a bit more like a shuffle.~~
~~(The tests related to these have, as a result, been removed)~~

We are now simply suppressing the warning. The shuffling of the reverse button is actually a separate issue that was introduced from the 3.5 upgrade rather than any of these changes. Here: #34006

**To test:**
1. Plot a graph of a workspace
2. Right click the figure and change the plot type to waterfall. 
4. Change the offset using the |<>| toolbar button
5. May as well set a fill as well to show that behaviour
6. Open the figure options (cog)
7. Switch to the curves tab and then the inner errorbars tab
8. Unhide the errorbars and set a capsize
9. Apply to all
10. Click okay
11. Adjust the offset again
12. No exception should be seen

Fixes #33913 

Also fixes #33950 


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
