### PR TITLE
Expose `getNumberDetectors` to python

### DIFF
--- a/Framework/PythonInterface/mantid/geometry/src/Exports/Instrument.cpp
+++ b/Framework/PythonInterface/mantid/geometry/src/Exports/Instrument.cpp
@@ -10,6 +10,7 @@
 #include "MantidPythonInterface/core/Policies/RemoveConst.h"
 
 #include <boost/python/class.hpp>
+#include <boost/python/overloads.hpp>
 #include <boost/python/register_ptr_to_python.hpp>
 
 using namespace Mantid::Geometry;
@@ -18,6 +19,12 @@ using namespace boost::python;
 using Mantid::PythonInterface::Policies::RemoveConstSharedPtr;
 
 GET_POINTER_SPECIALIZATION(Instrument)
+
+namespace {
+
+BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(Instrument_getNumberDetectors, Instrument::getNumberDetectors, 0, 1)
+
+} // namespace
 
 void export_Instrument() {
   register_ptr_to_python<std::shared_ptr<Instrument>>();
@@ -39,6 +46,9 @@ void export_Instrument() {
       .def("getDetector",
            (std::shared_ptr<const IDetector>(Instrument::*)(const detid_t &) const) & Instrument::getDetector,
            (arg("self"), arg("detector_id")), "Returns the :class:`~mantid.geometry.Detector` with the given ID")
+
+      .def("getNumberDetectors", &Instrument::getNumberDetectors,
+           Instrument_getNumberDetectors((arg("self"), arg("skipMonitors") = false)))
 
       .def("getReferenceFrame",
            (std::shared_ptr<const ReferenceFrame>(Instrument::*)()) & Instrument::getReferenceFrame, arg("self"),

--- a/Framework/PythonInterface/mantid/geometry/src/Exports/Instrument.cpp
+++ b/Framework/PythonInterface/mantid/geometry/src/Exports/Instrument.cpp
@@ -6,6 +6,7 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 #include "MantidGeometry/Instrument.h"
 #include "MantidGeometry/Instrument/ReferenceFrame.h"
+#include "MantidKernel/WarningSuppressions.h"
 #include "MantidPythonInterface/core/GetPointer.h"
 #include "MantidPythonInterface/core/Policies/RemoveConst.h"
 
@@ -22,7 +23,13 @@ GET_POINTER_SPECIALIZATION(Instrument)
 
 namespace {
 
+// Ignore -Wconversion warnings coming from boost::python
+// Seen with GCC 7.1.1 and Boost 1.63.0
+GNU_DIAG_OFF("conversion")
+
 BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(Instrument_getNumberDetectors, Instrument::getNumberDetectors, 0, 1)
+
+GNU_DIAG_ON("conversion")
 
 } // namespace
 

--- a/Framework/PythonInterface/test/python/mantid/geometry/InstrumentTest.py
+++ b/Framework/PythonInterface/test/python/mantid/geometry/InstrumentTest.py
@@ -38,6 +38,10 @@ class InstrumentTest(unittest.TestCase):
         comp = self.__testws.getInstrument().getDetector(1)
         self.assertTrue(isinstance(comp, Detector))
 
+    def test_getNumberDetectors(self):
+        num_detectors = self.__testws.getInstrument().getNumberDetectors()
+        self.assertEqual(num_detectors, 1)
+
     def test_getReferenceFrame(self):
         frame = self.__testws.getInstrument().getReferenceFrame()
         self.assertTrue(isinstance(frame, ReferenceFrame))

--- a/docs/source/release/v6.4.0/Framework/Python/New_features/33981.rst
+++ b/docs/source/release/v6.4.0/Framework/Python/New_features/33981.rst
@@ -1,0 +1,1 @@
+- `getNumberDetectors` from the Instrument class is now exposed to the Python API


### PR DESCRIPTION
**Description of work.**
This PR exposes the `Instrument::getNumberDetectors` function to the python API. This function needs to be exposed before I can fix an issue in the MSlice repo https://github.com/mantidproject/mslice/issues/754

**To test:**
1. Open Workbench and load the following data
[OSIRIS00144076.zip](https://github.com/mantidproject/mantid/files/8771838/OSIRIS00144076.zip)

3. Run this python script. It should print 1004
```
# import mantid algorithms, numpy and matplotlib
from mantid.simpleapi import *
import matplotlib.pyplot as plt
import numpy as np

ws = AnalysisDataService.retrieve('OSIRIS00144076')
print(ws.getInstrument().getNumberDetectors())
```


*There is no associated issue.*

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
