### PR TITLE
Fix crash on colorfill plot when more than one image sharing a color bar

### DIFF
--- a/docs/source/release/v6.4.0/Workbench/Bugfixes/33990 FixErrorOnSavingPropertiesOnImagePlots.rst
+++ b/docs/source/release/v6.4.0/Workbench/Bugfixes/33990 FixErrorOnSavingPropertiesOnImagePlots.rst
@@ -1,0 +1,1 @@
+- Workbench no longer generates an error when you save the Figure Options on a colour fill plot containing two images of different types (eg QuadMesh and Image)

--- a/qt/python/mantidqt/mantidqt/widgets/plotconfigdialog/imagestabwidget/presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/plotconfigdialog/imagestabwidget/presenter.py
@@ -44,7 +44,7 @@ class ImagesTabWidgetPresenter:
                 image.colorbar.set_label(props.label)
 
             image.set_cmap(props.colormap)
-            if props.interpolation and (not isinstance(image, QuadMesh) or not isinstance(image, Poly3DCollection)):
+            if props.interpolation and not (isinstance(image, QuadMesh) or isinstance(image, Poly3DCollection)):
                 image.set_interpolation(props.interpolation)
 
             update_colorbar_scale(self.fig, image, SCALES[props.scale], props.vmin, props.vmax)


### PR DESCRIPTION
**Description of work.**

Fix crash on hitting OK\Apply in the Figure Options screen of a colorfill plot containing images of different type (eg Image and QuadMesh). The two images need to share a color bar. Caused by logic error in if statement protecting the call to set_interpolation

This problem showed up in some anonymous error reports in the Slack error-reports channel. Since it's a small change I thought I'd fix it now

**To test:**

Run this script to create a colorfill plot. It's a slightly modified version of a script in the API documentation. It creates two images of different types via the calls to the matplotlib imshow and pcolormesh functions.

Once the plot is displayed open up the Figure Options, go to the Images tab and hit Apply or OK:
```
# import mantid algorithms, numpy and matplotlib
from mantid.simpleapi import *
import matplotlib.pyplot as plt
import numpy as np

import matplotlib.pyplot as plt
from mantid.plots.utility import MantidAxType
from mantid.api import AnalysisDataService as ADS
LoadEventNexus(Filename='CNCS_7860_event.nxs', OutputWorkspace='CNCS_7860_event')
ConvertUnits(InputWorkspace='CNCS_7860_event', OutputWorkspace='CNCS_7860_event', Target='DeltaE', EMode='Direct', EFixed=3)
Rebin(InputWorkspace='CNCS_7860_event', OutputWorkspace='CNCS_7860_event', Params='-3,0.05,3')
SofQW(InputWorkspace='CNCS_7860_event', OutputWorkspace='CNCS_7860_sqw', QAxisBinning='0,0.05,3', EMode='Direct', EFixed=3)
Transpose(InputWorkspace='CNCS_7860_sqw',  OutputWorkspace='CNCS_7860_sqw')

CNCS_7860_sqw = ADS.retrieve('CNCS_7860_sqw')

fig, axes = plt.subplots(nrows=1, ncols=2,edgecolor='#ffffff', figsize=[8.0, 6.9718], 
                         num='CNCS_7860_sqw-1', subplot_kw={'projection': 'mantid'})
cfill = axes[0].imshow(CNCS_7860_sqw, aspect='auto', cmap='viridis', distribution=False, 
                       label='_image0', origin='lower')
cfill = axes[1].pcolormesh(CNCS_7860_sqw)
cbar = fig.colorbar(cfill, ax=[axes], pad=0.06)

plt.show()
```

Fixes #33979.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
