### PR TITLE
Quietly ignore failing import

### DIFF
--- a/scripts/Inelastic/IndirectImport.py
+++ b/scripts/Inelastic/IndirectImport.py
@@ -11,7 +11,12 @@ the Indirect scripts depending on platform and numpy package version.
 We also deal with importing the mantidplot module outside of MantidPlot here.
 """
 from contextlib import contextmanager
-import numpy.core.setup_common as numpy_cfg
+try:
+    from numpy.core.setup_common import C_ABI_VERSION
+except (ImportError, FileNotFoundError):
+    # the import doesn't work in particular linux python environments
+    # this doesn't match with anything
+    C_ABI_VERSION = None
 import platform
 import os
 import importlib
@@ -80,7 +85,7 @@ def _numpy_abi_ver():
 
     @return The C ABI version
     """
-    return numpy_cfg.C_ABI_VERSION
+    return C_ABI_VERSION
 
 
 def unsupported_message():


### PR DESCRIPTION
For some reason this import fails on linux inside of conda. This will make the module not exist on those systems.

**Report to:** @Kvieta1990 

The full startup message
```
FrameworkManager-[Notice] Welcome to Mantid 6.3.20220520.1730
FrameworkManager-[Notice] Please cite: http://dx.doi.org/10.1016/j.nima.2014.07.029 and this release: http://dx.doi.org/10.5286/Software/Mantid
DownloadInstrument-[Notice] All instrument definitions up to date
Python-[Warning] Failed to load plugin /SNS/users/y8z/miniconda/envs/addie_testing_zyp_3/plugins/python/algorithms/WorkflowAlgorithms/BayesQuasi.py.
Error: Traceback (most recent call last):
  File "/SNS/users/y8z/miniconda/envs/addie_testing_zyp_3/lib/python3.8/site-packages/mantid/kernel/plugins.py", line 184, in load_from_file
    name, module = load_plugin(filepath)
  File "/SNS/users/y8z/miniconda/envs/addie_testing_zyp_3/lib/python3.8/site-packages/mantid/kernel/plugins.py", line 204, in load_plugin
    module = loader.run()
  File "/SNS/users/y8z/miniconda/envs/addie_testing_zyp_3/lib/python3.8/site-packages/mantid/kernel/plugins.py", line 49, in run
    return SourceFileLoader(name, pathname).load_module()
  File "<frozen importlib._bootstrap_external>", line 522, in _check_name_wrapper
  File "<frozen importlib._bootstrap_external>", line 1022, in load_module
  File "<frozen importlib._bootstrap_external>", line 847, in load_module
  File "<frozen importlib._bootstrap>", line 265, in _load_module_shim
  File "<frozen importlib._bootstrap>", line 702, in _load
  File "<frozen importlib._bootstrap>", line 671, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 843, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "/SNS/users/y8z/miniconda/envs/addie_testing_zyp_3/plugins/python/algorithms/WorkflowAlgorithms/BayesQuasi.py", line 12, in <module>
    from IndirectImport import *
  File "/SNS/users/y8z/miniconda/envs/addie_testing_zyp_3/scripts/Inelastic/IndirectImport.py", line 14, in <module>
    import numpy.core.setup_common as numpy_cfg
  File "/SNS/users/y8z/miniconda/envs/addie_testing_zyp_3/lib/python3.8/site-packages/numpy/core/setup_common.py", line 123, in <module>
    with open(pathlib.Path(__file__).parent / file) as f:
FileNotFoundError: [Errno 2] No such file or directory: '/SNS/users/y8z/miniconda/envs/addie_testing_zyp_3/lib/python3.8/site-packages/numpy/core/feature_detection_locale.h'

Python-[Warning] Failed to load plugin /SNS/users/y8z/miniconda/envs/addie_testing_zyp_3/plugins/python/algorithms/WorkflowAlgorithms/BayesStretch.py.
Error: Traceback (most recent call last):
  File "/SNS/users/y8z/miniconda/envs/addie_testing_zyp_3/lib/python3.8/site-packages/mantid/kernel/plugins.py", line 184, in load_from_file
    name, module = load_plugin(filepath)
  File "/SNS/users/y8z/miniconda/envs/addie_testing_zyp_3/lib/python3.8/site-packages/mantid/kernel/plugins.py", line 204, in load_plugin
    module = loader.run()
  File "/SNS/users/y8z/miniconda/envs/addie_testing_zyp_3/lib/python3.8/site-packages/mantid/kernel/plugins.py", line 49, in run
    return SourceFileLoader(name, pathname).load_module()
  File "<frozen importlib._bootstrap_external>", line 522, in _check_name_wrapper
  File "<frozen importlib._bootstrap_external>", line 1022, in load_module
  File "<frozen importlib._bootstrap_external>", line 847, in load_module
  File "<frozen importlib._bootstrap>", line 265, in _load_module_shim
  File "<frozen importlib._bootstrap>", line 702, in _load
  File "<frozen importlib._bootstrap>", line 671, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 843, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "/SNS/users/y8z/miniconda/envs/addie_testing_zyp_3/plugins/python/algorithms/WorkflowAlgorithms/BayesStretch.py", line 8, in <module>
    from IndirectImport import *
  File "/SNS/users/y8z/miniconda/envs/addie_testing_zyp_3/scripts/Inelastic/IndirectImport.py", line 14, in <module>
    import numpy.core.setup_common as numpy_cfg
  File "/SNS/users/y8z/miniconda/envs/addie_testing_zyp_3/lib/python3.8/site-packages/numpy/core/setup_common.py", line 123, in <module>
    with open(pathlib.Path(__file__).parent / file) as f:
FileNotFoundError: [Errno 2] No such file or directory: '/SNS/users/y8z/miniconda/envs/addie_testing_zyp_3/lib/python3.8/site-packages/numpy/core/feature_detection_locale.h'
```

**To test:**

Unfortunately, you have to build a conda package use it from [addie](https://github.com/neutrons/addie).

*There is no associated issue.*

*This does not require release notes* because it should only affect the warnings printed on startup in addie.

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
