### PR TITLE
Add Sliceviewer link to Workbench Docs

### DIFF
--- a/docs/source/workbench/index.rst
+++ b/docs/source/workbench/index.rst
@@ -28,24 +28,24 @@ completed much faster than they were in MantidPlot.
       shortcuts.
 
 **Workbench Features**
-    * :ref:`WorkbenchMainWindowMenu` Overview of the top-level menus.
-    * :ref:`WorkbenchSettings` The control panel for settings in workbench.
-    * :ref:`WorkbenchWorkspaceToolbox` The area in which all workspaces currently loaded into Workbench can be accessed
+    * :ref:`WorkbenchMainWindowMenu`: Overview of the top-level menus.
+    * :ref:`WorkbenchSettings`: The control panel for settings in workbench.
+    * :ref:`WorkbenchWorkspaceToolbox`: The area in which all workspaces currently loaded into Workbench can be accessed
       and edited from.
-    * :ref:`WorkbenchAlgorithmToolbox` shows a list is all of the algorithms available to users to run on workspaces loaded into
+    * :ref:`WorkbenchAlgorithmToolbox`: Shows a list of all of the algorithms available to users to run on the workspaces loaded into
       the Workspace Toolbox.
-    * :ref:`WorkbenchScriptWindow` provides the ability to edit and execute Python scripts.
-    * :ref:`WorkbenchMessagesWindow` Display mantid log messages and Python output.
-    * :ref:`WorkbenchPlotsToolbox` A way of controlling all available plots.
-    * :ref:`WorkbenchIPythonConsole` provides an IPython console allowing the immeidate execution of Python commands
-    * :ref:`WorkbenchPlotWindow` The new way that plots are created and manipulated in Workbench, includes plot options
+    * :ref:`WorkbenchScriptWindow`: Provides the ability to edit and execute Python scripts.
+    * :ref:`WorkbenchMessagesWindow`: Displays mantid log messages and Python output.
+    * :ref:`WorkbenchPlotsToolbox`: A way of controlling all available plots.
+    * :ref:`WorkbenchIPythonConsole`: Provides an IPython console allowing the immediate execution of Python commands.
+    * :ref:`WorkbenchPlotWindow`: The way that plots are created and manipulated in Workbench, includes plot options
       and fitting.
-    * *Workspace data views*: Display data from ``MatrixWorkspace`` / ``TableWorkspace`` and edit ``TableWorkspace``
-    * :ref:`InstrumentViewer`: Visualize an instrument attached to a workspace
-    * :ref:`SliceViewer`: View 2D slices of multi-dimensional workspaces
-    * *Sample log viewer*: Display information, plots and statistics about the sample logs in a workspace
-    * :ref:`WorkbenchWorkspaceHistoryWindow` displays the algorithms that have been applied to a workspace
-    * :ref:`Plotting <plotting>` describes how mantid workspaces have been integrated with the matplotlib framework and
+    * *Workspace data views*: Display data from a :ref:`MatrixWorkspace <MatrixWorkspace>` or :ref:`TableWorkspace <Table Workspaces>` and edit :ref:`TableWorkspaces <Table Workspaces>`.
+    * :ref:`InstrumentViewer`: Visualize an instrument attached to a workspace.
+    * :ref:`SliceViewer`: View 2D slices of multi-dimensional workspaces.
+    * *Sample log viewer*: Display information, plots and statistics about the sample logs in a workspace.
+    * :ref:`WorkbenchWorkspaceHistoryWindow`: Displays the algorithms that have been applied to a workspace.
+    * :ref:`Plotting <plotting>`: Describes how mantid workspaces have been integrated with the matplotlib framework and
       how to create these plots via scripts.
-    * :ref:`WorkbenchWorkspaceCalculator` describes briefly the workspace calculator plugin.
+    * :ref:`WorkbenchWorkspaceCalculator`: Describes, briefly, the workspace calculator plugin.
     * :ref:`WorkbenchSuperplot`: Decorator widget of the plot window that provides tools to overplot data.

--- a/docs/source/workbench/index.rst
+++ b/docs/source/workbench/index.rst
@@ -45,7 +45,7 @@ completed much faster than they were in MantidPlot.
     * :ref:`SliceViewer`: View 2D slices of multi-dimensional workspaces.
     * *Sample log viewer*: Display information, plots and statistics about the sample logs in a workspace.
     * :ref:`WorkbenchWorkspaceHistoryWindow`: Displays the algorithms that have been applied to a workspace.
-    * :ref:`Plotting <plotting>`: Describes how mantid workspaces have been integrated with the matplotlib framework and
+    * :ref:`Plotting <plotting>`: Describes how Mantid workspaces have been integrated with the matplotlib framework and
       how to create these plots via scripts.
     * :ref:`WorkbenchWorkspaceCalculator`: Describes, briefly, the workspace calculator plugin.
     * :ref:`WorkbenchSuperplot`: Decorator widget of the plot window that provides tools to overplot data.

--- a/docs/source/workbench/index.rst
+++ b/docs/source/workbench/index.rst
@@ -42,6 +42,7 @@ completed much faster than they were in MantidPlot.
       and fitting.
     * *Workspace data views*: Display data from ``MatrixWorkspace`` / ``TableWorkspace`` and edit ``TableWorkspace``
     * :ref:`InstrumentViewer`: Visualize an instrument attached to a workspace
+    * :ref:`SliceViewer`: View 2D slices of multi-dimensional workspaces
     * *Sample log viewer*: Display information, plots and statistics about the sample logs in a workspace
     * :ref:`WorkbenchWorkspaceHistoryWindow` displays the algorithms that have been applied to a workspace
     * :ref:`Plotting <plotting>` describes how mantid workspaces have been integrated with the matplotlib framework and


### PR DESCRIPTION
**Description of work.**
While looking for the sliceviewer docs I noticed that the only links to them appear to come from the release notes. This just adds a link to the list of workbench features, and also does some tidying to make the list look consistent. 

**To test:**
1. Delete doc-trees
2. Build the docs
3. Check links work and grammar is good. 

*There is no associated issue.*


*This does not require release notes* because **it only concerns documentation.**

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
