### PR TITLE
Fixes to remove Sphinx pinning

### DIFF
--- a/Framework/PythonInterface/mantid/plots/datafunctions.py
+++ b/Framework/PythonInterface/mantid/plots/datafunctions.py
@@ -446,7 +446,7 @@ def get_md_data2d_bin_centers(workspace, normalization, indices=None, transpose=
 
 
 def boundaries_from_points(input_array):
-    """"
+    """
     The function tries to guess bin boundaries from bin centers
 
     :param input_array: a :class:`numpy.ndarray` of bin centers

--- a/Framework/PythonInterface/mantid/plots/mantidaxes.py
+++ b/Framework/PythonInterface/mantid/plots/mantidaxes.py
@@ -8,6 +8,7 @@
 from collections.abc import Iterable
 import copy
 from distutils.version import LooseVersion
+from functools import wraps
 
 import matplotlib
 import numpy as np
@@ -41,6 +42,7 @@ WATERFALL_XOFFSET_DEFAULT, WATERFALL_YOFFSET_DEFAULT = 10, 20
 
 
 def plot_decorator(func):
+    @wraps(func)
     def wrapper(self, *args, **kwargs):
         func_value = func(self, *args, **kwargs)
         func_name = func.__name__

--- a/docs/source/api/python/mantid/plots/index.rst
+++ b/docs/source/api/python/mantid/plots/index.rst
@@ -229,16 +229,30 @@ When using ``mantid`` projection
 --------------------------------
 
 .. autoclass:: mantid.plots.MantidAxes
-   :members: plot, errorbar, scatter, contour,
-             contourf, pcolor, pcolorfast, pcolormesh, tripcolor,
-             tricontour, tricontourf
+
+   .. automethod:: contour
+   .. automethod:: contourf
+   .. automethod:: errorbar
+   .. automethod:: pcolor
+   .. automethod:: pcolorfast
+   .. automethod:: pcolormesh
+   .. automethod:: plot
+   .. automethod:: scatter
+   .. automethod:: tripcolor
+   .. automethod:: tricontour
+   .. automethod:: tricontourf
 
 When using ``mantid3d`` projection
 ----------------------------------
 
 .. autoclass:: mantid.plots.MantidAxes3D
-   :members: plot, scatter, plot_wireframe, plot_surface, contour,
-             contourf
+
+   .. automethod:: contour
+   .. automethod:: contourf
+   .. automethod:: plot
+   .. automethod:: plot_surface
+   .. automethod:: plot_wireframe
+   .. automethod:: scatter
 
 Functions to use when **mantid** projection is not available
 ------------------------------------------------------------
@@ -246,7 +260,6 @@ Functions to use when **mantid** projection is not available
 .. automodule:: mantid.plots.axesfunctions
    :members: plot, errorbar, scatter, contour, contourf, pcolor,
              pcolorfast, pcolormesh, tripcolor, tricontour, tricontourf
-
 
 Functions to use when **mantid3d** projection is not available
 --------------------------------------------------------------
@@ -264,5 +277,3 @@ Helper functions
              get_md_data2d_bin_bounds, get_md_data2d_bin_centers,
              get_spectrum, get_matrix_2d_data,get_uneven_data,
              get_sample_log, get_axes_labels
-
-

--- a/mantid-developer-linux.yml
+++ b/mantid-developer-linux.yml
@@ -39,6 +39,7 @@ dependencies:
   - requests>=2.25.1
   - scipy>=1.6.2
   - setuptools=48.0.0 # Pinned purposefully due to incompatibility with later versions
+  - sphinx >= 4.5.*
   - sphinx_bootstrap_theme<=0.7.1
   - tbb-devel=2020.2.*
   - tbb=2020.2.*

--- a/mantid-developer-linux.yml
+++ b/mantid-developer-linux.yml
@@ -39,7 +39,6 @@ dependencies:
   - requests>=2.25.1
   - scipy>=1.6.2
   - setuptools=48.0.0 # Pinned purposefully due to incompatibility with later versions
-  - sphinx<=3.5.4 # Pinned at 3.5.4 and below due to styling changes in 4.0, and 4.3 has a bug fix which imports a lot of matplotlib code (probably correctly, based on what we have in the api/python/mantid/plots/index.html file) and fails the doctests.
   - sphinx_bootstrap_theme<=0.7.1
   - tbb-devel=2020.2.*
   - tbb=2020.2.*

--- a/mantid-developer-osx.yml
+++ b/mantid-developer-osx.yml
@@ -39,6 +39,7 @@ dependencies:
   - requests>=2.25.1
   - scipy>=1.6.2
   - setuptools=48.0.0 # Pinned purposefully due to incompatibility with later versions
+  - sphinx >= 4.5.*
   - sphinx_bootstrap_theme<=0.7.1
   - tbb-devel=2020.2.*
   - tbb=2020.2.*

--- a/mantid-developer-osx.yml
+++ b/mantid-developer-osx.yml
@@ -39,7 +39,6 @@ dependencies:
   - requests>=2.25.1
   - scipy>=1.6.2
   - setuptools=48.0.0 # Pinned purposefully due to incompatibility with later versions
-  - sphinx<=3.5.4 # Pinned at 3.5.4 and below due to styling changes in 4.0, and 4.3 has a bug fix which imports a lot of matplotlib code (probably correctly, based on what we have in the api/python/mantid/plots/index.html file) and fails the doctests.
   - sphinx_bootstrap_theme<=0.7.1
   - tbb-devel=2020.2.*
   - tbb=2020.2.*

--- a/mantid-developer-win.yml
+++ b/mantid-developer-win.yml
@@ -39,6 +39,7 @@ dependencies:
   - requests>=2.25.1
   - scipy>=1.6.2
   - setuptools=48.0.0 # Pinned purposefully due to incompatibility with later versions
+  - sphinx >= 4.5.*
   - sphinx_bootstrap_theme<=0.7.1
   - tbb-devel=2020.2.*
   - tbb=2020.2.*

--- a/mantid-developer-win.yml
+++ b/mantid-developer-win.yml
@@ -39,7 +39,6 @@ dependencies:
   - requests>=2.25.1
   - scipy>=1.6.2
   - setuptools=48.0.0 # Pinned purposefully due to incompatibility with later versions
-  - sphinx<=3.5.4 # Pinned at 3.5.4 and below due to styling changes in 4.0, and 4.3 has a bug fix which imports a lot of matplotlib code (probably correctly, based on what we have in the api/python/mantid/plots/index.html file) and fails the doctests.
   - sphinx_bootstrap_theme<=0.7.1
   - tbb-devel=2020.2.*
   - tbb=2020.2.*


### PR DESCRIPTION
**Description of work.**
In order to remove the pinning of the Sphinx library in mantid-developer .yml files we needed to fix an issue with the mantid.plots page. For some reason the Sphinx directives were no longer working as they previously did and instead of using the docstring of mantid methods referred to it was trying to pull in the documentation from matplotlib. As the matplotlib documentation was not written to be pulled into our website it was causing alsorts of failures.

Note: Once this is merged in no changes need to be made to the Conda Recipes as it does not have a pin for Sphinx (see https://github.com/mantidproject/conda-recipes/blob/main/recipes/mantid/meta.yaml) 

**To test:**

On a Conda environment

- update your mantid-developer environment (to do this activate your conda environment on the pr branch and then run `conda env update -f mantid-developer-win.yml` if using Windows. For other OS use the relevant .yml file instead).
- Run `conda list` and check that the version of Sphinx is 4.5.0 
- remove `build/docs/doctrees`
- build the documents again and check there are no warnings
- open `build/docs/html/api/python/mantid/plots/index.html` and scroll down to _Available Functions_ . The descriptions should be taken from mantid code base, particularly the docstrings for methods in `Framework/PythonInterface/mantid/plots/mantidaxes.py` . Make sure this is the case. If should not pull from the matplotlib documentation (e.g. errorbars - https://matplotlib.org/stable/api/_as_gen/matplotlib.pyplot.errorbar.html),

*There is no associated issue.*

*This does not require release notes* because **it is a library issue that has been caused by the conda packaging for this release**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
