### PR TITLE
indirect calibration resolution selection fix

### DIFF
--- a/docs/source/release/v6.4.0/Indirect/Bugfixes/no_issue_cal_fix.rst
+++ b/docs/source/release/v6.4.0/Indirect/Bugfixes/no_issue_cal_fix.rst
@@ -1,0 +1,1 @@
+A bug has been fixed that sometimes caused a bad energy range selection for the resolution data in ISISCalibration (IndirectData Reduction).

--- a/qt/scientific_interfaces/Indirect/ISISCalibration.cpp
+++ b/qt/scientific_interfaces/Indirect/ISISCalibration.cpp
@@ -540,14 +540,29 @@ void ISISCalibration::calSetDefaultResolution(const MatrixWorkspace_const_sptr &
 
       const auto energyRange = getXRangeFromWorkspace(ws);
       // Set default rebinning bounds
+      double minScaleFactor = 10.0;
+      double maxScaleFactor = 10.0;
       const auto energyRangeMid = (energyRange.second + energyRange.first) / 2.0;
-      QPair<double, double> peakERange(-res * 10 + energyRangeMid, res * 10 + energyRangeMid);
+      double offset = energyRangeMid;
+      if (-res * minScaleFactor > energyRange.first && res * maxScaleFactor < energyRange.second) {
+        offset = 0.0;
+      }
+      QPair<double, double> peakERange(-res * minScaleFactor + offset, res * maxScaleFactor + offset);
       auto resPeak = m_uiForm.ppResolution->getRangeSelector("ResPeak");
       setPlotPropertyRange(resPeak, m_properties["ResELow"], m_properties["ResEHigh"], energyRange);
       setRangeSelector(resPeak, m_properties["ResELow"], m_properties["ResEHigh"], peakERange);
 
       // Set default background bounds
-      QPair<double, double> backgroundERange(-res * 20 + energyRangeMid, -res * 15 + energyRangeMid);
+      minScaleFactor = 9.0;
+      maxScaleFactor = 8.0;
+      if (-res * minScaleFactor > energyRange.first && -res * maxScaleFactor < energyRange.second) {
+        offset = 0.0;
+      } else {
+        minScaleFactor = 20.;
+        maxScaleFactor = 15.;
+        offset = (energyRange.second + energyRange.first) / 2.0;
+      }
+      QPair<double, double> backgroundERange(-res * minScaleFactor + offset, -res * maxScaleFactor + offset);
       auto resBackground = m_uiForm.ppResolution->getRangeSelector("ResBackground");
       setRangeSelector(resBackground, m_properties["ResStart"], m_properties["ResEnd"], backgroundERange);
     }


### PR DESCRIPTION
**Description of work.**

In the ISIS indirect calibration GUI the auto selection for the resolution file was not correct (a bug introduced in 6.2). However, this bug was introduced fixing another bug https://github.com/mantidproject/mantid/pull/33378

I have added some basic checks for which range selectors to use. 

**To test:**

<!-- Instructions for testing. -->
Open indirect data reduction
Go to calibration
Select Osiris
Load runs 145242-3
Tick the create res file option
Press run
It should produce a workspace with a nice single peak (it was giving a mess)

Also check that it passes the functional test from https://github.com/mantidproject/mantid/pull/33378


*There is no associated issue.*

Added a release note.

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
