### PR TITLE
Use .tar.xz as suffix for manylinux bundle

### DIFF
--- a/buildconfig/Jenkins/Conda/conda-build-recipes
+++ b/buildconfig/Jenkins/Conda/conda-build-recipes
@@ -149,6 +149,6 @@ elif [[ $OSTYPE == 'darwin'* ]]; then
     rm -fr *.dmg
     ${WORKSPACE}/installers/conda/osx/create_bundle.sh -c "${LOCAL_CHANNEL}" -s ${PACKAGE_SUFFIX}
 else
-    rm -fr *.xz
+    rm -fr *.tar.xz
     ${WORKSPACE}/installers/conda/linux/create_tarball.sh -c "${LOCAL_CHANNEL}" -s ${PACKAGE_SUFFIX}
 fi

--- a/buildconfig/Jenkins/Conda/nightly_build_and_deploy.jenkinsfile
+++ b/buildconfig/Jenkins/Conda/nightly_build_and_deploy.jenkinsfile
@@ -38,7 +38,7 @@ def archive_conda_build(arch) {
 }
 
 def create_standalone_package_linux() {
-  archiveArtifacts artifacts: "*.xz",
+  archiveArtifacts artifacts: "*.tar.xz",
     allowEmptyArchive: false,
     fingerprint: true,
     onlyIfSuccessful: true
@@ -162,7 +162,7 @@ pipeline {
         sh '${WORKSPACE}/buildconfig/Jenkins/Conda/publish-to-anaconda ${WORKSPACE} ${ANACONDA_TOKEN} ${ANACONDA_CHANNEL} ${ANACONDA_CHANNEL_LABEL} ${WORKSPACE}/conda-packages/*.tar.bz2'
         // Standalone packages next
         sh 'rm -fr ${WORKSPACE}/standalone-packages'
-        copyArtifacts filter: '*.exe, *.dmg, *.xz',
+        copyArtifacts filter: '*.exe, *.dmg, *.tar.xz',
           fingerprintArtifacts: true,
           projectName: '${JOB_NAME}',
           selector: specific('${BUILD_NUMBER}'),

--- a/installers/conda/linux/create_tarball.sh
+++ b/installers/conda/linux/create_tarball.sh
@@ -19,6 +19,7 @@ BUILD_DIR=_bundle_build
 CONDA_EXE=mamba
 CONDA_PACKAGE=mantidworkbench
 BUNDLE_PREFIX=mantidworkbench
+BUNDLE_EXTENSION=.tar.xz
 ICON_DIR="$HERE/../../../images"
 
 # Common routines
@@ -50,10 +51,10 @@ function fixup_bundle() {
 #  $1 - Name of the final file (without the suffix)
 #  $2 - Bundle name
 function create_tarball() {
-  local version_name=$1
+  local version_filename=$1$BUNDLE_EXTENSION
   local bundle_name=$2
-  echo "Creating tarball '$version_name.xz'"
-  tar --directory "$BUILD_DIR" --create --file "$version_name.xz" --xz "$bundle_name"
+  echo "Creating tarball '$version_filename'"
+  tar --directory "$BUILD_DIR" --create --file "$version_filename" --xz "$bundle_name"
 }
 
 # Print usage and exit
@@ -62,7 +63,7 @@ function usage() {
   echo "Usage: $0 [options]"
   echo
   echo "Create a tarball bundle out of a Conda package. The package is built in $BUILD_DIR."
-  echo "The final name will be '${BUNDLE_PREFIX}{suffix}.xz'"
+  echo "The final name will be '${BUNDLE_PREFIX}{suffix}${BUNDLE_EXTENSION}'"
   echo "This directory will be created if it does not exist or purged if it already exists."
   echo "The final .dmg will be created in the current working directory."
   echo "Options:"


### PR DESCRIPTION
**Description of work.**

The produced bundle is a tarball compressed with xz
and now the suffix reflects this correctly.

**To test:**

Use the "Package Build" instructions from #33819 to create a package.
This time a `.tar.xz` file should be created and not just `.xz`. Test it can be extracted and started using the same `tar` command just replacing the filename with the one generated here.

Fixes #34003

*This does not require release notes* because **this is not a released feature**

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
