### PR TITLE
Fix Waterfall Plot's Reverse Order Button

### DIFF
--- a/qt/applications/workbench/workbench/plotting/figuremanager.py
+++ b/qt/applications/workbench/workbench/plotting/figuremanager.py
@@ -507,14 +507,15 @@ class FigureManagerWorkbench(FigureManagerBase, QObject):
 
         errorbar_cap_lines = datafunctions.remove_and_return_errorbar_cap_lines(ax)
 
-        # TODO: ax.lines is deprecated in matplotlib v3.5, and will be gone from v3.7. This will need re-writing.
         # The built-in reverse method can't be used here as the double assignment doesn't work.
-        n = len(ax.lines)
-        for i in range(n//2):
-            line_1 = ax.lines.pop(i)
-            line_2 = ax.lines.pop(n-i-2)
-            ax.lines.insert(i, line_2)
-            ax.lines.insert(n-i-1, line_1)
+        lines = []
+        num_lines = len(ax.get_lines())
+        for i in range(num_lines):
+            line = ax.get_lines()[num_lines - i - 1]
+            lines.append(line)
+        for line in lines:
+            line.remove()
+            ax.add_line(line)
 
         for cap in errorbar_cap_lines:
             ax.add_line(cap)

--- a/qt/applications/workbench/workbench/plotting/figuremanager.py
+++ b/qt/applications/workbench/workbench/plotting/figuremanager.py
@@ -507,7 +507,15 @@ class FigureManagerWorkbench(FigureManagerBase, QObject):
 
         errorbar_cap_lines = datafunctions.remove_and_return_errorbar_cap_lines(ax)
 
-        ax.lines.reverse()
+        # TODO: ax.lines is deprecated in matplotlib v3.5, and will be gone from v3.7. This will need re-writing.
+        # The built-in reverse method can't be used here as the double assignment doesn't work.
+        n = len(ax.lines)
+        for i in range(n//2):
+            line_1 = ax.lines.pop(i)
+            line_2 = ax.lines.pop(n-i-2)
+            ax.lines.insert(i, line_2)
+            ax.lines.insert(n-i-1, line_1)
+
         for cap in errorbar_cap_lines:
             ax.add_line(cap)
         if LooseVersion("3.7") > LooseVersion(matplotlib.__version__) >= LooseVersion("3.2"):

--- a/qt/applications/workbench/workbench/plotting/figuremanager.py
+++ b/qt/applications/workbench/workbench/plotting/figuremanager.py
@@ -507,15 +507,7 @@ class FigureManagerWorkbench(FigureManagerBase, QObject):
 
         errorbar_cap_lines = datafunctions.remove_and_return_errorbar_cap_lines(ax)
 
-        # The built-in reverse method can't be used here as the double assignment doesn't work.
-        lines = []
-        num_lines = len(ax.get_lines())
-        for i in range(num_lines):
-            line = ax.get_lines()[num_lines - i - 1]
-            lines.append(line)
-        for line in lines:
-            line.remove()
-            ax.add_line(line)
+        self._reverse_axis_lines(ax)
 
         for cap in errorbar_cap_lines:
             ax.add_line(cap)
@@ -553,6 +545,18 @@ class FigureManagerWorkbench(FigureManagerBase, QObject):
                 col.set_color(colour.name())
 
         self.canvas.draw()
+
+    @staticmethod
+    def _reverse_axis_lines(ax):
+        # The built-in reverse method can't be used here as the double assignment doesn't work.
+        lines = []
+        num_lines = len(ax.get_lines())
+        for i in range(num_lines):
+            line = ax.get_lines()[num_lines - i - 1]
+            lines.append(line)
+        for line in lines:
+            line.remove()
+            ax.add_line(line)
 
 
 # -----------------------------------------------------------------------------

--- a/qt/applications/workbench/workbench/plotting/test/test_figuremanager.py
+++ b/qt/applications/workbench/workbench/plotting/test/test_figuremanager.py
@@ -6,14 +6,32 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 #  This file is part of the mantid workbench.
 import unittest
+import matplotlib.pyplot as plt
 
 from unittest.mock import MagicMock, patch
+from mantid.simpleapi import CreateWorkspace, DeleteWorkspace
 from mantidqt.utils.qt.testing import start_qapplication
 from workbench.plotting.figuremanager import MantidFigureCanvas, FigureManagerWorkbench
 
 
 @start_qapplication
 class FigureManagerWorkbenchTest(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.ws2d_histo = CreateWorkspace(DataX=[10, 20, 30, 10, 20, 30, 10, 20, 30],
+                                         DataY=[2, 3, 4, 5, 3, 5],
+                                         DataE=[1, 2, 3, 4, 1, 1],
+                                         NSpec=3,
+                                         Distribution=True,
+                                         UnitX='Wavelength',
+                                         VerticalAxisUnit='DeltaE',
+                                         VerticalAxisValues=[4, 6, 8],
+                                         OutputWorkspace='ws2d_histo')
+
+    @classmethod
+    def tearDownClass(cls):
+        DeleteWorkspace('ws2d_histo')
 
     @patch("workbench.plotting.figuremanager.QAppThreadCall")
     def test_construction(self, mock_qappthread):
@@ -32,6 +50,19 @@ class FigureManagerWorkbenchTest(unittest.TestCase):
         canvas = MantidFigureCanvas(fig)
         fig_mgr = FigureManagerWorkbench(canvas, 1)
         self.assertEqual(fig_mgr.get_window_title(), "Figure 1")
+
+    def test_reverse_axes_lines(self):
+        fig, ax = plt.subplots(subplot_kw={'projection': 'mantid'})
+        spec2 = ax.plot(self.ws2d_histo, 'rs', specNum=2, linewidth=6)
+        spec3 = ax.plot(self.ws2d_histo, 'rs', specNum=3, linewidth=6)
+        spec1 = ax.plot(self.ws2d_histo, 'rs', specNum=1, linewidth=6)
+        self.assertEqual(ax.get_lines()[0], spec2[0])
+        self.assertEqual(ax.get_lines()[1], spec3[0])
+        self.assertEqual(ax.get_lines()[2], spec1[0])
+        FigureManagerWorkbench._reverse_axis_lines(ax)
+        self.assertEqual(ax.get_lines()[0], spec1[0])
+        self.assertEqual(ax.get_lines()[1], spec3[0])
+        self.assertEqual(ax.get_lines()[2], spec2[0])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
**Description of work.**
Stops the waterfall plot's reverse order button from shuffling the lines around. This seems to be because the 3.5 upgrade stops the `ax.lines` property from working with the built-in `reverse()` method.

**To test:**
1. Plot something with a few lines
2. Make it a waterfall plot (right click -> plot type)
3. Reverse the order. 

Fixes #34006 

*This does not require release notes* because **it fixes a regression introduced this release.**


<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
