### PR TITLE
Parameterise Jenkins pipeline to allow individual stages to be run

### DIFF
--- a/buildconfig/Jenkins/Conda/conda-build-recipes
+++ b/buildconfig/Jenkins/Conda/conda-build-recipes
@@ -149,13 +149,13 @@ cd $WORKSPACE
 # Set our local conda channel to find our locally build mantidworkbench package.
 LOCAL_CHANNEL=file://$CONDA_BLD_PATH
 
-#if [[ $OSTYPE == 'msys'* ]]; then
-#    rm -fr *.exe
-#    ${WORKSPACE}/installers/conda/win/create_package.sh -c "${LOCAL_CHANNEL}" -s ${PACKAGE_SUFFIX}
-#elif [[ $OSTYPE == 'darwin'* ]]; then
-#    rm -fr *.dmg
-#    ${WORKSPACE}/installers/conda/osx/create_bundle.sh -c "${LOCAL_CHANNEL}" -s ${PACKAGE_SUFFIX}
-#else
-#    rm -fr *.tar.xz
-#    ${WORKSPACE}/installers/conda/linux/create_tarball.sh -c "${LOCAL_CHANNEL}" -s ${PACKAGE_SUFFIX}
-#fi
+if [[ $OSTYPE == 'msys'* ]]; then
+    rm -fr *.exe
+    ${WORKSPACE}/installers/conda/win/create_package.sh -c "${LOCAL_CHANNEL}" -s ${PACKAGE_SUFFIX}
+elif [[ $OSTYPE == 'darwin'* ]]; then
+    rm -fr *.dmg
+    ${WORKSPACE}/installers/conda/osx/create_bundle.sh -c "${LOCAL_CHANNEL}" -s ${PACKAGE_SUFFIX}
+else
+    rm -fr *.tar.xz
+    ${WORKSPACE}/installers/conda/linux/create_tarball.sh -c "${LOCAL_CHANNEL}" -s ${PACKAGE_SUFFIX}
+fi

--- a/buildconfig/Jenkins/Conda/conda-build-recipes
+++ b/buildconfig/Jenkins/Conda/conda-build-recipes
@@ -24,7 +24,7 @@
 # Possible parameters:
 #   --clobber-yml: clobber the meta yaml files of each package build with conda-build, provide an absolute path to the uteyml file
 #   --recipes-tag: a branch or tag that should be used for cloning the recipes from conda-build-recipes
-#
+#   --build-current-branch: build the packages from the latest commit in the currently checkout out branch
 
 # Setup expected variables
 WORKSPACE=$1
@@ -59,6 +59,7 @@ SCRIPT_DIR=$WORKSPACE/buildconfig/Jenkins/Conda/
 ENABLE_BUILD_MANTID=false
 ENABLE_BUILD_QT=false
 ENABLE_BUILD_WORKBENCH=false
+BUILD_CURRENT_BRANCH=false
 RECIPES_TAG=main
 
 # Handle flag inputs
@@ -68,6 +69,7 @@ do
         --build-mantid) ENABLE_BUILD_MANTID=true ;;
         --build-qt) ENABLE_BUILD_QT=true ;;
         --build-workbench) ENABLE_BUILD_WORKBENCH=true ;;
+        --build-current-branch) BUILD_CURRENT_BRANCH=true ;;
         --clobber-yml)
             CLOBBER_FILE="--clobber-file $2"
             shift ;;
@@ -111,6 +113,11 @@ if [[ -d conda-recipes ]]; then
     rm -rf conda-recipes
 fi
 git clone https://github.com/mantidproject/conda-recipes.git --depth=1 -b $RECIPES_TAG
+
+# Update the git sha and version number when building packages from the current branch.
+if [[ BUILD_CURRENT_BRANCH == true ]]; then
+    $SCRIPT_DIR/update-conda-recipes.sh dummy_token dummy_name dummy_email --local-only
+fi
 
 # Run conda build. Use shortest path possible for Windows
 export CONDA_BLD_PATH=$WORKSPACE/conda-bld

--- a/buildconfig/Jenkins/Conda/conda-build-recipes
+++ b/buildconfig/Jenkins/Conda/conda-build-recipes
@@ -115,7 +115,7 @@ fi
 git clone https://github.com/mantidproject/conda-recipes.git --depth=1 -b $RECIPES_TAG
 
 # Update the git sha and version number when building packages from the current branch.
-if [[ BUILD_CURRENT_BRANCH == true ]]; then
+if [[ $BUILD_CURRENT_BRANCH == true ]]; then
     $SCRIPT_DIR/update-conda-recipes.sh dummy_token dummy_name dummy_email --local-only
 fi
 

--- a/buildconfig/Jenkins/Conda/conda-build-recipes
+++ b/buildconfig/Jenkins/Conda/conda-build-recipes
@@ -149,13 +149,13 @@ cd $WORKSPACE
 # Set our local conda channel to find our locally build mantidworkbench package.
 LOCAL_CHANNEL=file://$CONDA_BLD_PATH
 
-if [[ $OSTYPE == 'msys'* ]]; then
-    rm -fr *.exe
-    ${WORKSPACE}/installers/conda/win/create_package.sh -c "${LOCAL_CHANNEL}" -s ${PACKAGE_SUFFIX}
-elif [[ $OSTYPE == 'darwin'* ]]; then
-    rm -fr *.dmg
-    ${WORKSPACE}/installers/conda/osx/create_bundle.sh -c "${LOCAL_CHANNEL}" -s ${PACKAGE_SUFFIX}
-else
-    rm -fr *.tar.xz
-    ${WORKSPACE}/installers/conda/linux/create_tarball.sh -c "${LOCAL_CHANNEL}" -s ${PACKAGE_SUFFIX}
-fi
+#if [[ $OSTYPE == 'msys'* ]]; then
+#    rm -fr *.exe
+#    ${WORKSPACE}/installers/conda/win/create_package.sh -c "${LOCAL_CHANNEL}" -s ${PACKAGE_SUFFIX}
+#elif [[ $OSTYPE == 'darwin'* ]]; then
+#    rm -fr *.dmg
+#    ${WORKSPACE}/installers/conda/osx/create_bundle.sh -c "${LOCAL_CHANNEL}" -s ${PACKAGE_SUFFIX}
+#else
+#    rm -fr *.tar.xz
+#    ${WORKSPACE}/installers/conda/linux/create_tarball.sh -c "${LOCAL_CHANNEL}" -s ${PACKAGE_SUFFIX}
+#fi

--- a/buildconfig/Jenkins/Conda/nightly_build_and_deploy.jenkinsfile
+++ b/buildconfig/Jenkins/Conda/nightly_build_and_deploy.jenkinsfile
@@ -65,7 +65,7 @@ pipeline {
   environment {
     WIN_BASH = "C:\\Program Files\\git\\bin\\bash.exe"
   }
-//   stages {
+  stages {
 //     stage('Build and test') {
 //       parallel {
 //         stage('platform: linux') {

--- a/buildconfig/Jenkins/Conda/nightly_build_and_deploy.jenkinsfile
+++ b/buildconfig/Jenkins/Conda/nightly_build_and_deploy.jenkinsfile
@@ -66,6 +66,10 @@ pipeline {
   }
   stages {
     stage('Build and test') {
+      when {
+        beforeAgent true
+        environment name: 'BUILD_AND_TEST', value: 'true'
+      }
       parallel {
         stage('platform: linux') {
           agent { label 'conda-build-linux' }
@@ -107,6 +111,10 @@ pipeline {
       }
     }
     stage('Update conda-recipes repository') {
+      when {
+        beforeAgent true
+        environment name: 'PUBLISH_PACKAGES', value: 'true'
+      }
       agent { label 'conda-build-linux' }
       environment { GITHUB_TOKEN = credentials("${GITHUB_TOKEN_CREDENTIAL_ID}") }
       steps {
@@ -116,6 +124,10 @@ pipeline {
     stage('Packaging') {
       parallel {
         stage('platform: linux-64') {
+          when {
+            beforeAgent true
+            environment name: 'BUILD_PACKAGE_LINUX', value: 'true'
+          }
           agent { label 'conda-build-linux' }
           options { timestamps () }
           steps {
@@ -124,6 +136,10 @@ pipeline {
           }
         }
         stage('platform: win-64') {
+          when {
+            beforeAgent true
+            environment name: 'BUILD_PACKAGE_WIN', value: 'true'
+          }
           agent { label 'conda-build-win' }
           options { timestamps () }
           steps {
@@ -135,6 +151,10 @@ pipeline {
           }
         }
         stage('platform: osx-64') {
+          when {
+            beforeAgent true
+            environment name: 'BUILD_PACKAGE_OSX', value: 'true'
+          }
           agent { label 'conda-build-osx' }
           options { timestamps () }
           steps {
@@ -145,6 +165,10 @@ pipeline {
       }
     }
     stage ('Publishing') {
+      when {
+        beforeAgent true
+        environment name: 'PUBLISH_PACKAGES', value: 'true'
+      }
       agent { label 'conda-build-linux' } // Use linux for simplicity with shell scripts
       options { timestamps () }
       environment {
@@ -173,6 +197,10 @@ pipeline {
       }
     }
     stage ('Delete old Conda nightly packages from Anaconda') {
+      when {
+        beforeAgent true
+        environment name: 'PUBLISH_PACKAGES', value: 'true'
+      }
       agent { label 'conda-build-linux' } // Use linux for simplicity with shell scripts
       options { timestamps () }
       environment { ANACONDA_TOKEN = credentials("${ANACONDA_TOKEN_CREDENTIAL_ID}") }

--- a/buildconfig/Jenkins/Conda/nightly_build_and_deploy.jenkinsfile
+++ b/buildconfig/Jenkins/Conda/nightly_build_and_deploy.jenkinsfile
@@ -5,6 +5,7 @@
 // ANACONDA_TOKEN_CREDENTIAL_ID - The name of the credentials token in Jenkins that you want to use for publishing conda packages
 // ANACONDA_CHANNEL - The channel to publish to on Anaconda.org
 // ANACONDA_CHANNEL_LABEL - This will be used as the label for the channel, otherwise no label will be set.
+// PACKAGE_OPTIONS - additional options to pass to the packaging step.
 
 def build_and_test_unix(cmake_preset) {
   sh "${WORKSPACE}/buildconfig/Jenkins/Conda/conda-buildscript ${WORKSPACE} ${cmake_preset} --enable-systemtests --enable-doctests --clean-build --clean-external-projects"
@@ -21,14 +22,12 @@ def publish_test_reports() {
 }
 
 def conda_build_unix(arch) {
-//   sh "${WORKSPACE}/buildconfig/Jenkins/Conda/conda-build-recipes ${WORKSPACE} --build-mantid --build-qt --build-workbench"
-  sh "${WORKSPACE}/buildconfig/Jenkins/Conda/conda-build-recipes ${WORKSPACE} --build-current-branch"
+  sh "${WORKSPACE}/buildconfig/Jenkins/Conda/conda-build-recipes ${WORKSPACE} --build-mantid --build-qt --build-workbench ${PACKAGE_OPTIONS}"
   archive_conda_build(arch)
 }
 
 def conda_build_win(arch) {
-//   bat "\"${WIN_BASH}\" -ex -c \"${WORKSPACE_UNIX_PATH}/buildconfig/Jenkins/Conda/conda-build-recipes ${WORKSPACE_UNIX_PATH} --build-mantid --build-qt --build-workbench\""
-  bat "\"${WIN_BASH}\" -ex -c \"${WORKSPACE_UNIX_PATH}/buildconfig/Jenkins/Conda/conda-build-recipes ${WORKSPACE_UNIX_PATH} --build-current-branch\""
+  bat "\"${WIN_BASH}\" -ex -c \"${WORKSPACE_UNIX_PATH}/buildconfig/Jenkins/Conda/conda-build-recipes ${WORKSPACE_UNIX_PATH} --build-mantid --build-qt --build-workbench ${PACKAGE_OPTIONS}\""
   archive_conda_build(arch)
 }
 

--- a/buildconfig/Jenkins/Conda/nightly_build_and_deploy.jenkinsfile
+++ b/buildconfig/Jenkins/Conda/nightly_build_and_deploy.jenkinsfile
@@ -65,54 +65,54 @@ pipeline {
     WIN_BASH = "C:\\Program Files\\git\\bin\\bash.exe"
   }
   stages {
-//     stage('Build and test') {
-//       parallel {
-//         stage('platform: linux') {
-//           agent { label 'conda-build-linux' }
-//           options { timestamps () }
-//           steps {
-//             build_and_test_unix("linux-ci")
-//           }
-//           post {
-//             always {
-//               publish_test_reports()
-//             }
-//           }
-//         }
-//         stage('platform: windows') {
-//           agent { label 'conda-build-win' }
-//           options { timestamps () }
-//           steps {
-//             script { WORKSPACE_UNIX_PATH = "${WORKSPACE}".replaceAll("\\\\", "/") }
-//             build_and_test_win("win")
-//           }
-//           post {
-//             always {
-//               publish_test_reports()
-//             }
-//           }
-//         }
-//         stage('platform: macos') {
-//           agent { label 'conda-build-osx' }
-//           options { timestamps () }
-//           steps {
-//             build_and_test_unix("osx-ci")
-//           }
-//           post {
-//             always {
-//               publish_test_reports()
-//             }
-//           }
-//         }
-//       }
-//     }
-//     stage('Update conda-recipes repository') {
-//       agent { label 'conda-build-linux' }
-//       environment { GITHUB_TOKEN = credentials("${GITHUB_TOKEN_CREDENTIAL_ID}") }
-//       steps {
-//         sh '${WORKSPACE}/buildconfig/Jenkins/Conda/update-conda-recipes.sh $GITHUB_TOKEN $GITHUB_USER_NAME $GITHUB_USER_EMAIL'
-//       }
-//     }
+    stage('Build and test') {
+      parallel {
+        stage('platform: linux') {
+          agent { label 'conda-build-linux' }
+          options { timestamps () }
+          steps {
+            build_and_test_unix("linux-ci")
+          }
+          post {
+            always {
+              publish_test_reports()
+            }
+          }
+        }
+        stage('platform: windows') {
+          agent { label 'conda-build-win' }
+          options { timestamps () }
+          steps {
+            script { WORKSPACE_UNIX_PATH = "${WORKSPACE}".replaceAll("\\\\", "/") }
+            build_and_test_win("win")
+          }
+          post {
+            always {
+              publish_test_reports()
+            }
+          }
+        }
+        stage('platform: macos') {
+          agent { label 'conda-build-osx' }
+          options { timestamps () }
+          steps {
+            build_and_test_unix("osx-ci")
+          }
+          post {
+            always {
+              publish_test_reports()
+            }
+          }
+        }
+      }
+    }
+    stage('Update conda-recipes repository') {
+      agent { label 'conda-build-linux' }
+      environment { GITHUB_TOKEN = credentials("${GITHUB_TOKEN_CREDENTIAL_ID}") }
+      steps {
+        sh '${WORKSPACE}/buildconfig/Jenkins/Conda/update-conda-recipes.sh $GITHUB_TOKEN $GITHUB_USER_NAME $GITHUB_USER_EMAIL'
+      }
+    }
     stage('Packaging') {
       parallel {
         stage('platform: linux-64') {
@@ -144,43 +144,43 @@ pipeline {
         }
       }
     }
-//     stage ('Publishing') {
-//       agent { label 'conda-build-linux' } // Use linux for simplicity with shell scripts
-//       options { timestamps () }
-//       environment {
-//         ANACONDA_TOKEN = credentials("${ANACONDA_TOKEN_CREDENTIAL_ID}")
-//         GITHUB_TOKEN = credentials("${GITHUB_TOKEN_CREDENTIAL_ID}")
-//       }
-//       steps {
-//         // Conda first
-//         sh 'rm -fr ${WORKSPACE}/conda-packages'
-//         copyArtifacts filter: '**/conda-bld/**/*.tar.bz2',
-//           fingerprintArtifacts: true,
-//           projectName: '${JOB_NAME}',
-//           selector: specific('${BUILD_NUMBER}'),
-//           target: 'conda-packages',
-//           flatten: true
-//         sh '${WORKSPACE}/buildconfig/Jenkins/Conda/publish-to-anaconda ${WORKSPACE} ${ANACONDA_TOKEN} ${ANACONDA_CHANNEL} ${ANACONDA_CHANNEL_LABEL} ${WORKSPACE}/conda-packages/*.tar.bz2'
-//         // Standalone packages next
-//         sh 'rm -fr ${WORKSPACE}/standalone-packages'
-//         copyArtifacts filter: '*.exe, *.dmg, *.tar.xz',
-//           fingerprintArtifacts: true,
-//           projectName: '${JOB_NAME}',
-//           selector: specific('${BUILD_NUMBER}'),
-//           target: 'standalone-packages',
-//           flatten: true
-//         sh '${WORKSPACE}/buildconfig/Jenkins/Conda/publish-to-github ${WORKSPACE} ${GITHUB_TOKEN} ${GITHUB_RELEASES_REPO} ${GITHUB_RELEASES_TAG} ${WORKSPACE}/standalone-packages/*'
-//       }
-//     }
-//     stage ('Delete old Conda nightly packages from Anaconda') {
-//       agent { label 'conda-build-linux' } // Use linux for simplicity with shell scripts
-//       options { timestamps () }
-//       environment { ANACONDA_TOKEN = credentials("${ANACONDA_TOKEN_CREDENTIAL_ID}") }
-//       steps {
-//         sh '${WORKSPACE}/buildconfig/Jenkins/Conda/delete-old-nightlies.sh ${WORKSPACE} $ANACONDA_TOKEN --channel mantid --package mantid --label nightly'
-//         sh '${WORKSPACE}/buildconfig/Jenkins/Conda/delete-old-nightlies.sh ${WORKSPACE} $ANACONDA_TOKEN --channel mantid --package mantidqt --label nightly'
-//         sh '${WORKSPACE}/buildconfig/Jenkins/Conda/delete-old-nightlies.sh ${WORKSPACE} $ANACONDA_TOKEN --channel mantid --package mantidworkbench --label nightly'
-//       }
-//     }
+    stage ('Publishing') {
+      agent { label 'conda-build-linux' } // Use linux for simplicity with shell scripts
+      options { timestamps () }
+      environment {
+        ANACONDA_TOKEN = credentials("${ANACONDA_TOKEN_CREDENTIAL_ID}")
+        GITHUB_TOKEN = credentials("${GITHUB_TOKEN_CREDENTIAL_ID}")
+      }
+      steps {
+        // Conda first
+        sh 'rm -fr ${WORKSPACE}/conda-packages'
+        copyArtifacts filter: '**/conda-bld/**/*.tar.bz2',
+          fingerprintArtifacts: true,
+          projectName: '${JOB_NAME}',
+          selector: specific('${BUILD_NUMBER}'),
+          target: 'conda-packages',
+          flatten: true
+        sh '${WORKSPACE}/buildconfig/Jenkins/Conda/publish-to-anaconda ${WORKSPACE} ${ANACONDA_TOKEN} ${ANACONDA_CHANNEL} ${ANACONDA_CHANNEL_LABEL} ${WORKSPACE}/conda-packages/*.tar.bz2'
+        // Standalone packages next
+        sh 'rm -fr ${WORKSPACE}/standalone-packages'
+        copyArtifacts filter: '*.exe, *.dmg, *.tar.xz',
+          fingerprintArtifacts: true,
+          projectName: '${JOB_NAME}',
+          selector: specific('${BUILD_NUMBER}'),
+          target: 'standalone-packages',
+          flatten: true
+        sh '${WORKSPACE}/buildconfig/Jenkins/Conda/publish-to-github ${WORKSPACE} ${GITHUB_TOKEN} ${GITHUB_RELEASES_REPO} ${GITHUB_RELEASES_TAG} ${WORKSPACE}/standalone-packages/*'
+      }
+    }
+    stage ('Delete old Conda nightly packages from Anaconda') {
+      agent { label 'conda-build-linux' } // Use linux for simplicity with shell scripts
+      options { timestamps () }
+      environment { ANACONDA_TOKEN = credentials("${ANACONDA_TOKEN_CREDENTIAL_ID}") }
+      steps {
+        sh '${WORKSPACE}/buildconfig/Jenkins/Conda/delete-old-nightlies.sh ${WORKSPACE} $ANACONDA_TOKEN --channel mantid --package mantid --label nightly'
+        sh '${WORKSPACE}/buildconfig/Jenkins/Conda/delete-old-nightlies.sh ${WORKSPACE} $ANACONDA_TOKEN --channel mantid --package mantidqt --label nightly'
+        sh '${WORKSPACE}/buildconfig/Jenkins/Conda/delete-old-nightlies.sh ${WORKSPACE} $ANACONDA_TOKEN --channel mantid --package mantidworkbench --label nightly'
+      }
+    }
   }
 }

--- a/buildconfig/Jenkins/Conda/nightly_build_and_deploy.jenkinsfile
+++ b/buildconfig/Jenkins/Conda/nightly_build_and_deploy.jenkinsfile
@@ -21,12 +21,14 @@ def publish_test_reports() {
 }
 
 def conda_build_unix(arch) {
-  sh "${WORKSPACE}/buildconfig/Jenkins/Conda/conda-build-recipes ${WORKSPACE} --build-mantid --build-qt --build-workbench"
+//   sh "${WORKSPACE}/buildconfig/Jenkins/Conda/conda-build-recipes ${WORKSPACE} --build-mantid --build-qt --build-workbench"
+  sh "${WORKSPACE}/buildconfig/Jenkins/Conda/conda-build-recipes ${WORKSPACE} --build-current-branch"
   archive_conda_build(arch)
 }
 
 def conda_build_win(arch) {
-  bat "\"${WIN_BASH}\" -ex -c \"${WORKSPACE_UNIX_PATH}/buildconfig/Jenkins/Conda/conda-build-recipes ${WORKSPACE_UNIX_PATH} --build-mantid --build-qt --build-workbench\""
+//   bat "\"${WIN_BASH}\" -ex -c \"${WORKSPACE_UNIX_PATH}/buildconfig/Jenkins/Conda/conda-build-recipes ${WORKSPACE_UNIX_PATH} --build-mantid --build-qt --build-workbench\""
+  bat "\"${WIN_BASH}\" -ex -c \"${WORKSPACE_UNIX_PATH}/buildconfig/Jenkins/Conda/conda-build-recipes ${WORKSPACE_UNIX_PATH} --build-current-branch\""
   archive_conda_build(arch)
 }
 
@@ -63,55 +65,55 @@ pipeline {
   environment {
     WIN_BASH = "C:\\Program Files\\git\\bin\\bash.exe"
   }
-  stages {
-    stage('Build and test') {
-      parallel {
-        stage('platform: linux') {
-          agent { label 'conda-build-linux' }
-          options { timestamps () }
-          steps {
-            build_and_test_unix("linux-ci")
-          }
-          post {
-            always {
-              publish_test_reports()
-            }
-          }
-        }
-        stage('platform: windows') {
-          agent { label 'conda-build-win' }
-          options { timestamps () }
-          steps {
-            script { WORKSPACE_UNIX_PATH = "${WORKSPACE}".replaceAll("\\\\", "/") }
-            build_and_test_win("win")
-          }
-          post {
-            always {
-              publish_test_reports()
-            }
-          }
-        }
-        stage('platform: macos') {
-          agent { label 'conda-build-osx' }
-          options { timestamps () }
-          steps {
-            build_and_test_unix("osx-ci")
-          }
-          post {
-            always {
-              publish_test_reports()
-            }
-          }
-        }
-      }
-    }
-    stage('Update conda-recipes repository') {
-      agent { label 'conda-build-linux' }
-      environment { GITHUB_TOKEN = credentials("${GITHUB_TOKEN_CREDENTIAL_ID}") }
-      steps {
-        sh '${WORKSPACE}/buildconfig/Jenkins/Conda/update-conda-recipes.sh $GITHUB_TOKEN $GITHUB_USER_NAME $GITHUB_USER_EMAIL'
-      }
-    }
+//   stages {
+//     stage('Build and test') {
+//       parallel {
+//         stage('platform: linux') {
+//           agent { label 'conda-build-linux' }
+//           options { timestamps () }
+//           steps {
+//             build_and_test_unix("linux-ci")
+//           }
+//           post {
+//             always {
+//               publish_test_reports()
+//             }
+//           }
+//         }
+//         stage('platform: windows') {
+//           agent { label 'conda-build-win' }
+//           options { timestamps () }
+//           steps {
+//             script { WORKSPACE_UNIX_PATH = "${WORKSPACE}".replaceAll("\\\\", "/") }
+//             build_and_test_win("win")
+//           }
+//           post {
+//             always {
+//               publish_test_reports()
+//             }
+//           }
+//         }
+//         stage('platform: macos') {
+//           agent { label 'conda-build-osx' }
+//           options { timestamps () }
+//           steps {
+//             build_and_test_unix("osx-ci")
+//           }
+//           post {
+//             always {
+//               publish_test_reports()
+//             }
+//           }
+//         }
+//       }
+//     }
+//     stage('Update conda-recipes repository') {
+//       agent { label 'conda-build-linux' }
+//       environment { GITHUB_TOKEN = credentials("${GITHUB_TOKEN_CREDENTIAL_ID}") }
+//       steps {
+//         sh '${WORKSPACE}/buildconfig/Jenkins/Conda/update-conda-recipes.sh $GITHUB_TOKEN $GITHUB_USER_NAME $GITHUB_USER_EMAIL'
+//       }
+//     }
     stage('Packaging') {
       parallel {
         stage('platform: linux-64') {
@@ -143,43 +145,43 @@ pipeline {
         }
       }
     }
-    stage ('Publishing') {
-      agent { label 'conda-build-linux' } // Use linux for simplicity with shell scripts
-      options { timestamps () }
-      environment {
-        ANACONDA_TOKEN = credentials("${ANACONDA_TOKEN_CREDENTIAL_ID}")
-        GITHUB_TOKEN = credentials("${GITHUB_TOKEN_CREDENTIAL_ID}")
-      }
-      steps {
-        // Conda first
-        sh 'rm -fr ${WORKSPACE}/conda-packages'
-        copyArtifacts filter: '**/conda-bld/**/*.tar.bz2',
-          fingerprintArtifacts: true,
-          projectName: '${JOB_NAME}',
-          selector: specific('${BUILD_NUMBER}'),
-          target: 'conda-packages',
-          flatten: true
-        sh '${WORKSPACE}/buildconfig/Jenkins/Conda/publish-to-anaconda ${WORKSPACE} ${ANACONDA_TOKEN} ${ANACONDA_CHANNEL} ${ANACONDA_CHANNEL_LABEL} ${WORKSPACE}/conda-packages/*.tar.bz2'
-        // Standalone packages next
-        sh 'rm -fr ${WORKSPACE}/standalone-packages'
-        copyArtifacts filter: '*.exe, *.dmg, *.tar.xz',
-          fingerprintArtifacts: true,
-          projectName: '${JOB_NAME}',
-          selector: specific('${BUILD_NUMBER}'),
-          target: 'standalone-packages',
-          flatten: true
-        sh '${WORKSPACE}/buildconfig/Jenkins/Conda/publish-to-github ${WORKSPACE} ${GITHUB_TOKEN} ${GITHUB_RELEASES_REPO} ${GITHUB_RELEASES_TAG} ${WORKSPACE}/standalone-packages/*'
-      }
-    }
-    stage ('Delete old Conda nightly packages from Anaconda') {
-      agent { label 'conda-build-linux' } // Use linux for simplicity with shell scripts
-      options { timestamps () }
-      environment { ANACONDA_TOKEN = credentials("${ANACONDA_TOKEN_CREDENTIAL_ID}") }
-      steps {
-        sh '${WORKSPACE}/buildconfig/Jenkins/Conda/delete-old-nightlies.sh ${WORKSPACE} $ANACONDA_TOKEN --channel mantid --package mantid --label nightly'
-        sh '${WORKSPACE}/buildconfig/Jenkins/Conda/delete-old-nightlies.sh ${WORKSPACE} $ANACONDA_TOKEN --channel mantid --package mantidqt --label nightly'
-        sh '${WORKSPACE}/buildconfig/Jenkins/Conda/delete-old-nightlies.sh ${WORKSPACE} $ANACONDA_TOKEN --channel mantid --package mantidworkbench --label nightly'
-      }
-    }
+//     stage ('Publishing') {
+//       agent { label 'conda-build-linux' } // Use linux for simplicity with shell scripts
+//       options { timestamps () }
+//       environment {
+//         ANACONDA_TOKEN = credentials("${ANACONDA_TOKEN_CREDENTIAL_ID}")
+//         GITHUB_TOKEN = credentials("${GITHUB_TOKEN_CREDENTIAL_ID}")
+//       }
+//       steps {
+//         // Conda first
+//         sh 'rm -fr ${WORKSPACE}/conda-packages'
+//         copyArtifacts filter: '**/conda-bld/**/*.tar.bz2',
+//           fingerprintArtifacts: true,
+//           projectName: '${JOB_NAME}',
+//           selector: specific('${BUILD_NUMBER}'),
+//           target: 'conda-packages',
+//           flatten: true
+//         sh '${WORKSPACE}/buildconfig/Jenkins/Conda/publish-to-anaconda ${WORKSPACE} ${ANACONDA_TOKEN} ${ANACONDA_CHANNEL} ${ANACONDA_CHANNEL_LABEL} ${WORKSPACE}/conda-packages/*.tar.bz2'
+//         // Standalone packages next
+//         sh 'rm -fr ${WORKSPACE}/standalone-packages'
+//         copyArtifacts filter: '*.exe, *.dmg, *.tar.xz',
+//           fingerprintArtifacts: true,
+//           projectName: '${JOB_NAME}',
+//           selector: specific('${BUILD_NUMBER}'),
+//           target: 'standalone-packages',
+//           flatten: true
+//         sh '${WORKSPACE}/buildconfig/Jenkins/Conda/publish-to-github ${WORKSPACE} ${GITHUB_TOKEN} ${GITHUB_RELEASES_REPO} ${GITHUB_RELEASES_TAG} ${WORKSPACE}/standalone-packages/*'
+//       }
+//     }
+//     stage ('Delete old Conda nightly packages from Anaconda') {
+//       agent { label 'conda-build-linux' } // Use linux for simplicity with shell scripts
+//       options { timestamps () }
+//       environment { ANACONDA_TOKEN = credentials("${ANACONDA_TOKEN_CREDENTIAL_ID}") }
+//       steps {
+//         sh '${WORKSPACE}/buildconfig/Jenkins/Conda/delete-old-nightlies.sh ${WORKSPACE} $ANACONDA_TOKEN --channel mantid --package mantid --label nightly'
+//         sh '${WORKSPACE}/buildconfig/Jenkins/Conda/delete-old-nightlies.sh ${WORKSPACE} $ANACONDA_TOKEN --channel mantid --package mantidqt --label nightly'
+//         sh '${WORKSPACE}/buildconfig/Jenkins/Conda/delete-old-nightlies.sh ${WORKSPACE} $ANACONDA_TOKEN --channel mantid --package mantidworkbench --label nightly'
+//       }
+//     }
   }
 }

--- a/buildconfig/Jenkins/Conda/update-conda-recipes.sh
+++ b/buildconfig/Jenkins/Conda/update-conda-recipes.sh
@@ -82,9 +82,9 @@ fi
 cd conda-recipes
 
 function replace_version_data() {
-    sed -i '/{% set git_commit =/c\{% set git_commit = "'$LATEST_GIT_SHA'" %}' $1
-    sed -i '/{% set version =/c\{% set version = "'$VERSION'" %}' $1
-    sed -i '/  sha256: /c\  sha256: '$SHA256'' $1
+    sed -ie 's/{% set git_commit =.*/{% set git_commit = "'$LATEST_GIT_SHA'" %}/' $1
+    sed -ie 's/{% set version =.*/{% set version = "'$VERSION'" %}/' $1
+    sed -ie 's/  sha256: .*/  sha256: '$SHA256'/' $1
 }
 
 replace_version_data recipes/mantid/meta.yaml

--- a/buildconfig/Jenkins/Conda/update-conda-recipes.sh
+++ b/buildconfig/Jenkins/Conda/update-conda-recipes.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -ex
 
 # Update the https://github.com/mantidproject/conda-recipes repository with the latest changes from the currently
-# checked out branch.
+# checked out branch of mantid.
 #
 # Expected args:
 #   1. GITHUB_ACCESS_TOKEN: The token required to push to a https cloned mantidproject/conda-recipes repository
@@ -9,7 +9,8 @@
 #   3. GITHUB_USER_EMAIL: The email address associated with the user
 #
 # Possible flags:
-#   --local-only: update a local copy of the repository only, and do not push the changes to github
+#   --local-only: update a local copy of the conda-recipes repository only without cloning, and do not push the changes
+#     to github.
 
 GITHUB_ACCESS_TOKEN=$1
 shift


### PR DESCRIPTION
**Description of work.**
- Added `when` directives to pipeline stages so that they can be turned on if the following variables are set to true in the jenkins build:
  - `BUILD_AND_TEST` - run the parallel build and test stages
  - `PUBLISH_PACKAGES` - update conda-recipes, publish the packages to Anaconda and github, and delete old nightlies from Anaconda
  - `BUILD_PACKAGE_{LINUX,WIN,OSX}` - individually specify whether to build packages for each OS.

- Added the ability to build conda packages, and the subsequent standalone packages, from the curently checked out branch, rather than just taking the commit that is set within the conda-recipes repository at the time of performing the conda-build. This can be utilised by setting an environment variable `PACKAGE_OPTIONS=--build-current-branch` in a Jenkins job.

**To test:**

A Jenkins pipeline job has been created that has all except the packaging stages turned off, and which has`PACKAGE_OPTIONS=--build-current-branch` set. The packages can be built by specifying boolean parameters when the job is built. One must also specify the branch to build in the job. Currently it will only function correctly when using this PR's branch.

To check functionality, ensure that this job built and archived all three packages with the file names corresponding to the date of the latest commit in this branch (Tue May 31 16:05:33 2022):
https://builds.mantidproject.org/job/parameterised_pipeline_test/13/

*This does not require release notes* because it is a change to internal build mechanisms.

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
