### PR TITLE
Fix waterfall for log axes in plots

### DIFF
--- a/Framework/PythonInterface/mantid/plots/datafunctions.py
+++ b/Framework/PythonInterface/mantid/plots/datafunctions.py
@@ -1138,7 +1138,10 @@ def waterfall_create_fill(ax):
     errorbar_cap_lines = remove_and_return_errorbar_cap_lines(ax)
 
     for i, line in enumerate(ax.get_lines()):
-        bottom_line = [min(line.get_ydata()) - ((i * ax.height) / 100)] * len(line.get_ydata())
+        if ax.get_yscale() == "log":
+            bottom_line = [min(line.get_ydata())] * len(line.get_ydata())
+        else:
+            bottom_line = [min(line.get_ydata()) - ((i * ax.height) / 100)] * len(line.get_ydata())
         fill = ax.fill_between(line.get_xdata(), line.get_ydata(), bottom_line)
         fill.set_zorder((len(ax.get_lines()) - i) + 1)
         set_waterfall_fill_visible(ax, i)

--- a/Framework/PythonInterface/mantid/plots/datafunctions.py
+++ b/Framework/PythonInterface/mantid/plots/datafunctions.py
@@ -1047,11 +1047,13 @@ def apply_waterfall_offset_to_errorbars(ax, line, amount_to_move_x, amount_to_mo
             # Shift the errorbars
             for bar_line_col in container[2]:
                 segments = bar_line_col.get_segments()
+                i = 0
                 for point in segments:
                     for row in range(2):
-                        point[row][1] += amount_to_move_y
+                        point[row][1] += amount_to_move_y[i]
                     for column in range(2):
-                        point[column][0] += amount_to_move_x
+                        point[column][0] += amount_to_move_x[i]
+                    i+=1
                 bar_line_col.set_segments(segments)
             bar_line_col.set_zorder((len(ax.get_lines()) - index) + 1)
             break
@@ -1059,12 +1061,20 @@ def apply_waterfall_offset_to_errorbars(ax, line, amount_to_move_x, amount_to_mo
 
 def convert_single_line_to_waterfall(ax, index, x=None, y=None, need_to_update_fill=False):
     line = ax.get_lines()[index]
-
-    amount_to_move_x = index * ax.width * (ax.waterfall_x_offset / 500) if x is None else \
-        index * ax.width * ((x - ax.waterfall_x_offset) / 500)
-
-    amount_to_move_y = index * ax.height * (ax.waterfall_y_offset / 500) if y is None else \
-        index * ax.height * ((y - ax.waterfall_y_offset) / 500)
+    x_data = line.get_xdata()
+    y_data = line.get_ydata()
+    if ax.get_xscale() == "log":
+        amount_to_move_x = x_data * ((1 + ax.waterfall_x_offset / 100) ** index - 1) if x is None else \
+            x_data * (((1 + x / 100)/(1 + ax.waterfall_x_offset / 100)) ** index - 1)
+    else:
+        amount_to_move_x = np.zeros(x_data.size) + index * ax.width * (ax.waterfall_x_offset / 500) if x is None else \
+            np.zeros(x_data.size) + index * ax.width * ((x - ax.waterfall_x_offset) / 500)
+    if ax.get_yscale() == "log":
+        amount_to_move_y = y_data * ((1 + ax.waterfall_y_offset / 100) ** index - 1) if y is None else \
+            y_data * (((1 + y / 100)/(1 + ax.waterfall_y_offset / 100)) ** index - 1)
+    else:
+        amount_to_move_y = np.zeros(y_data.size) + index * ax.height * (ax.waterfall_y_offset / 500) if y is None else \
+            np.zeros(y_data.size) + index * ax.height * ((y - ax.waterfall_y_offset) / 500)
 
     if line.get_label() == "_nolegend_":
         apply_waterfall_offset_to_errorbars(ax, line, amount_to_move_x, amount_to_move_y, index)

--- a/Framework/PythonInterface/mantid/plots/mantidaxes.py
+++ b/Framework/PythonInterface/mantid/plots/mantidaxes.py
@@ -1214,6 +1214,9 @@ class MantidAxes(Axes):
             datafunctions.waterfall_remove_fill(self)
 
     def set_xscale(self, *args, **kwargs):
+        is_waterfall = self.is_waterfall()
+        if is_waterfall:
+            self.set_waterfall(False)
         has_minor_ticks = not isinstance(self.xaxis.minor.locator, NullLocator)
 
         super().set_xscale(*args, **kwargs)
@@ -1222,8 +1225,13 @@ class MantidAxes(Axes):
             self.minorticks_on()
         else:
             self.minorticks_off()
+        if is_waterfall:
+            self.set_waterfall(True)
 
     def set_yscale(self, *args, **kwargs):
+        is_waterfall = self.is_waterfall()
+        if is_waterfall:
+            self.set_waterfall(False)
         has_minor_ticks = not isinstance(self.yaxis.minor.locator, NullLocator)
 
         super().set_yscale(*args, **kwargs)
@@ -1232,6 +1240,8 @@ class MantidAxes(Axes):
             self.minorticks_on()
         else:
             self.minorticks_off()
+        if is_waterfall:
+            self.set_waterfall(True)
 
     def grid_on(self):
         return self.xaxis._major_tick_kw.get('gridOn', False) and self.yaxis._major_tick_kw.get('gridOn', False)

--- a/Framework/PythonInterface/mantid/plots/mantidaxes.py
+++ b/Framework/PythonInterface/mantid/plots/mantidaxes.py
@@ -1216,6 +1216,8 @@ class MantidAxes(Axes):
     def set_xscale(self, *args, **kwargs):
         is_waterfall = self.is_waterfall()
         if is_waterfall:
+            # The waterfall must be turned off before the log can be changed or the offset will not scale correctly
+            fill = self.waterfall_has_fill()
             x_offset = self.waterfall_x_offset
             y_offset = self.waterfall_y_offset
             self.set_waterfall(False)
@@ -1228,11 +1230,12 @@ class MantidAxes(Axes):
         else:
             self.minorticks_off()
         if is_waterfall:
-            self.set_waterfall(True, x_offset=x_offset, y_offset=y_offset)
+            self.set_waterfall(True, x_offset=x_offset, y_offset=y_offset, fill=fill)
 
     def set_yscale(self, *args, **kwargs):
         is_waterfall = self.is_waterfall()
         if is_waterfall:
+            fill = self.waterfall_has_fill()
             x_offset = self.waterfall_x_offset
             y_offset = self.waterfall_y_offset
             self.set_waterfall(False)
@@ -1245,7 +1248,7 @@ class MantidAxes(Axes):
         else:
             self.minorticks_off()
         if is_waterfall:
-            self.set_waterfall(True, x_offset=x_offset, y_offset=y_offset)
+            self.set_waterfall(True, x_offset=x_offset, y_offset=y_offset, fill=fill)
 
     def grid_on(self):
         return self.xaxis._major_tick_kw.get('gridOn', False) and self.yaxis._major_tick_kw.get('gridOn', False)

--- a/Framework/PythonInterface/mantid/plots/mantidaxes.py
+++ b/Framework/PythonInterface/mantid/plots/mantidaxes.py
@@ -1216,6 +1216,8 @@ class MantidAxes(Axes):
     def set_xscale(self, *args, **kwargs):
         is_waterfall = self.is_waterfall()
         if is_waterfall:
+            x_offset = self.waterfall_x_offset
+            y_offset = self.waterfall_y_offset
             self.set_waterfall(False)
         has_minor_ticks = not isinstance(self.xaxis.minor.locator, NullLocator)
 
@@ -1226,11 +1228,13 @@ class MantidAxes(Axes):
         else:
             self.minorticks_off()
         if is_waterfall:
-            self.set_waterfall(True)
+            self.set_waterfall(True, x_offset=x_offset, y_offset=y_offset)
 
     def set_yscale(self, *args, **kwargs):
         is_waterfall = self.is_waterfall()
         if is_waterfall:
+            x_offset = self.waterfall_x_offset
+            y_offset = self.waterfall_y_offset
             self.set_waterfall(False)
         has_minor_ticks = not isinstance(self.yaxis.minor.locator, NullLocator)
 
@@ -1241,7 +1245,7 @@ class MantidAxes(Axes):
         else:
             self.minorticks_off()
         if is_waterfall:
-            self.set_waterfall(True)
+            self.set_waterfall(True, x_offset=x_offset, y_offset=y_offset)
 
     def grid_on(self):
         return self.xaxis._major_tick_kw.get('gridOn', False) and self.yaxis._major_tick_kw.get('gridOn', False)

--- a/Framework/PythonInterface/test/python/mantid/plots/mantidaxesTest.py
+++ b/Framework/PythonInterface/test/python/mantid/plots/mantidaxesTest.py
@@ -634,6 +634,34 @@ class MantidAxesTest(unittest.TestCase):
         self.assertEqual(ax.get_lines()[0].get_xdata()[0], ax.get_lines()[1].get_xdata()[0])
         self.assertEqual(ax.get_lines()[0].get_ydata()[0], ax.get_lines()[1].get_ydata()[0])
 
+    def test_converting_waterfall_plot_scale(self):
+        fig, ax = plt.subplots(subplot_kw={'projection': 'mantid'})
+        # Plot the same line twice.
+        ax.plot([0, 1], [0, 1])
+        ax.plot([0, 1], [0, 1])
+
+        # Make a waterfall plot.
+        ax.set_waterfall(True)
+        x_lin_1 = ax.get_lines()[1].get_xdata()[0]
+        y_lin_1 = ax.get_lines()[1].get_ydata()[0]
+
+        ax.set_xscale("log")
+        ax.set_yscale("log")
+        x_log = ax.get_lines()[1].get_xdata()[0]
+        y_log = ax.get_lines()[1].get_ydata()[0]
+
+        ax.set_xscale("linear")
+        ax.set_yscale("linear")
+        x_lin_2 = ax.get_lines()[1].get_xdata()[0]
+        y_lin_2 = ax.get_lines()[1].get_ydata()[0]
+
+        self.assertTrue(ax.is_waterfall())
+        # Check the lines' data are different now that it is a log scale waterfall plot.
+        self.assertNotEqual(x_lin_1, x_log)
+        self.assertNotEqual(y_lin_1, y_log)
+        self.assertEqual(x_lin_1, x_lin_2)
+        self.assertEqual(y_lin_1, y_lin_2)
+
     def test_create_fill_creates_fills_for_waterfall_plot(self):
         fig, ax = plt.subplots(subplot_kw={'projection': 'mantid'})
         ax.plot([0, 1], [0, 1])

--- a/docs/source/release/v6.5.0/Workbench/Bugfixes/33980.rst
+++ b/docs/source/release/v6.5.0/Workbench/Bugfixes/33980.rst
@@ -1,0 +1,1 @@
+- Scaling for waterfall plots has been fixed for scaling in log scale plots


### PR DESCRIPTION
**Description of work.**

This PR changes the offset for waterfall plots when using log scales so that they are equally distrebuted in log space

**To test:**

Run the following script to make a test workspace.
```
# import mantid algorithms, numpy and matplotlib
from mantid.simpleapi import *
import matplotlib.pyplot as plt
import numpy as np

x = np.arange(1,101)
e = 2*np.ones(500)
y1 = 2*x+2
y2 = 3*x+3
y3 = 4*x+4
y4 = 5*x+5
y5 = 6*x+6
y0 = np.append(y1,y2)
y0 = np.append(y0,y3)
y0 = np.append(y0,y4)
y0 = np.append(y0,y5)
ws0 = CreateWorkspace(DataX=x, DataY=y0, DataE=e, NSpec=5)
```
1. plot all spectra in this workspace as a waterfall plot.
2. while on a linear scale chack that all lines are equally distrebuted.
3. change the offset and check that they all move together
4. cahnge the axes to log scale and cehck that the lines are still evenly offset
5. change the offset values and check that the lines moves corectly.
6. change the scale back to linear and cahgne that the lines are back to the same linear offset.
7. turn on error bars and repeat these steps.


Fixes #33980

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
