### PR TITLE
Fix a bug saving add files for multi period data

### DIFF
--- a/scripts/SANS/SANSadd2.py
+++ b/scripts/SANS/SANSadd2.py
@@ -137,13 +137,11 @@ def add_runs(runs,  # noqa: C901
 
         lastFile = os.path.splitext(lastFile)[0]
         # Now save the added file
-        outFile = lastFile + '-add.' + 'nxs' if outFile is None else outFile
-        outFile_monitors = lastFile + '-add_monitors.' + 'nxs' if outFile_monitors is None else outFile_monitors
-        if save_directory is not None:
-            # In ISIS SANS gui, an output directory can be specified.
-            # If one has, add it to filepath here
-            outFile = save_directory + outFile
-            outFile_monitors = save_directory + outFile_monitors
+        prefix = save_directory if save_directory else ''
+        if outFile is None:
+            outFile = prefix + lastFile + '-add.' + 'nxs'
+        if outFile_monitors is None:
+            outFile_monitors = prefix + lastFile + '-add_monitors.' + 'nxs'
         sanslog.notice("Writing file: {}".format(outFile))
 
         if period == 1 or period == _NO_INDIVIDUAL_PERIODS:


### PR DESCRIPTION
**Report to:** @smk78 @dehoni

This PR fixes a bug in the SANS GUI where summed files for multi-period data were not being saved correctly.
- There was a bug setting the filename for subsequent periods after the first one, where the save path was being pre-pended too many times. This meant that only the first period was saved; monitors were also not being saved.

Fixes #33965

**Description of work.**

**To test:**

- Find a LARMOR user file - here is a minimal version which you can save as e.g. `MaskFile.toml`. 
```
toml_file_version = 1

[instrument]
  name = "LARMOR"

[detector.configuration]
  selected_detector = "All"

[binning]
  wavelength = {start = 2.2, step=0.035, stop=10.0, type = "Log"}
```
- Ensure you have a default save directory set
- Open the ISIS SANS interface
- Select the `Sum Runs` tab on the left
- In Runs To Sum enter `63550, 63552` and click `Add`
- At the bottom click `Sum`
- Check the filename in the Save File text box (this should be `LARMOR00063552-add` by default) - a file should have been created in the save directory with this name.
- Load the saved file into Mantid and check that it is a workspace group containing two event workspaces for the data for each period, and two Workspace2Ds for the monitors:
![image](https://user-images.githubusercontent.com/12895056/171393643-b06c7e7d-1574-4285-863e-0cc753dac4dd.png)
- Click Remove All in the GUI to reset and ensure the save filename is empty.
- Repeat the test using runs `63551,63552`. These are histo workspaces. The output should contain two Workspace2Ds, one for each period. Note that the monitor workspaces are deliberately not included:
![image](https://user-images.githubusercontent.com/12895056/171393724-5b264d5d-5f8b-4936-83af-e5b49492a775.png)

Release notes to follow

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
