### PR TITLE
Split elemental analysis test classes into separate modules

### DIFF
--- a/qt/python/mantidqtinterfaces/test/Muon/CMakeLists.txt
+++ b/qt/python/mantidqtinterfaces/test/Muon/CMakeLists.txt
@@ -34,6 +34,8 @@ set(TEST_PY_FILES
     elemental_analysis/PeriodicTableModel_test.py
     elemental_analysis/PeriodicTablePresenter_test.py
     elemental_analysis_2/elemental_analysis_context_test.py
+    elemental_analysis_2/elemental_analysis_data_context_test.py
+    elemental_analysis_2/elemental_analysis_eagroup_context_test.py
     elemental_analysis_2/elemental_analysis_main_GUI_test.py
     elemental_analysis_2/EA_loading_tab/elemental_analysis_loadutils_test.py
     elemental_analysis_2/EA_loading_tab/elemental_analysis_load_model_test.py

--- a/qt/python/mantidqtinterfaces/test/Muon/elemental_analysis_2/elemental_analysis_context_test.py
+++ b/qt/python/mantidqtinterfaces/test/Muon/elemental_analysis_2/elemental_analysis_context_test.py
@@ -7,13 +7,11 @@
 import unittest
 import numpy as np
 from unittest import mock
-from mantid.api import WorkspaceGroup
-from mantid.simpleapi import CreateSampleWorkspace, CreateWorkspace
+from mantid.simpleapi import CreateWorkspace
 from mantidqtinterfaces.Muon.GUI.ElementalAnalysis2.context.context import ElementalAnalysisContext, REBINNED_VARIABLE_WS_SUFFIX
 from mantidqtinterfaces.Muon.GUI.ElementalAnalysis2.context.data_context import DataContext
 from mantidqtinterfaces.Muon.GUI.ElementalAnalysis2.context.ea_group_context import EAGroupContext
 from mantidqtinterfaces.Muon.GUI.Common.contexts.muon_gui_context import MuonGuiContext
-from mantidqtinterfaces.Muon.GUI.Common.muon_load_data import MuonLoadData
 from mantidqtinterfaces.Muon.GUI.ElementalAnalysis2.ea_group import EAGroup
 from mantidqtinterfaces.Muon.GUI.Common.ADSHandler.ADS_calls import retrieve_ws, remove_ws_if_present
 
@@ -174,151 +172,6 @@ class ElementalAnalysisContextTest(unittest.TestCase):
         # assert statement
         self.context.group_context.add_new_group.assert_called_once_with(self.context.group_context.groups,
                                                                          self.context.data_context._loaded_data)
-
-
-class DataContextTest(unittest.TestCase):
-    def setUp(self):
-        self.context = DataContext()
-
-    def assert_data_context_empty(self):
-        self.assertEqual(self.context.current_runs, [])
-        self.assertEqual(self.context.run_info, [])
-
-    # ------------------------------------------------------------------------------------------------------------------
-    # TESTS
-    # ------------------------------------------------------------------------------------------------------------------
-
-    def test_add_run_object_to_run_info(self):
-        self.assert_data_context_empty()
-        new_run_object = mock.Mock(run_number=1234)
-        self.context.run_info_update(new_run_object)
-        self.assertEqual(len(self.context.run_info), 1)
-        self.assertEqual(self.context.run_info[0].run_number, 1234)
-
-    def test_clear_run_info(self):
-        self.assert_data_context_empty()
-        new_run_object = mock.Mock()
-        self.context.run_info_update(new_run_object)
-        self.assertEqual(len(self.context.run_info), 1)
-
-        self.context.clear_run_info()
-        self.assert_data_context_empty()
-
-
-class EAGroupContextTest(unittest.TestCase):
-    def setUp(self):
-        self.context = EAGroupContext()
-        self.loadedData = MuonLoadData()
-
-    def create_group_workspace_and_load(self):
-        grpws = WorkspaceGroup()
-        ws_detector1 = '9999; Detector 1'
-        grpws.addWorkspace(CreateSampleWorkspace(OutputWorkspace=ws_detector1))
-        ws_detector2 = '9999; Detector 2'
-        grpws.addWorkspace(CreateSampleWorkspace(OutputWorkspace=ws_detector2))
-        run = 9999
-        self.loadedData.add_data(run=[run], workspace=grpws)
-
-    # ------------------------------------------------------------------------------------------------------------------
-    # TESTS
-    # ------------------------------------------------------------------------------------------------------------------
-
-    def test_add_new_group(self):
-        self.loadedData.clear()
-        self.create_group_workspace_and_load()
-        empty_group = []
-        new_group = self.context.add_new_group(empty_group, self.loadedData)
-        self.assertEqual(len(new_group), 2)
-
-    def test_remove_group(self):
-        self.loadedData.clear()
-        self.create_group_workspace_and_load()
-        self.context.reset_group_to_default(self.loadedData)
-        self.assertEqual(len(self.context.groups), 2)
-        group_name1 = '9999; Detector 1'
-        self.assertTrue(group_name1 in self.context.group_names)
-
-        self.context.remove_group(group_name1)
-        self.assertFalse(group_name1 in self.context.group_names)
-
-    def test_reset_group_to_default(self):
-        self.loadedData.clear()
-        self.assertEqual(self.loadedData.num_items(), 0)
-        self.create_group_workspace_and_load()
-        self.context.reset_group_to_default(self.loadedData)
-        self.assertEqual(len(self.context.groups), 2)
-
-    def test_clear(self):
-        self.loadedData.clear()
-        self.create_group_workspace_and_load()
-        self.context.reset_group_to_default(self.loadedData)
-        self.assertEqual(len(self.context.groups), 2)
-
-        self.context.clear()
-        self.assertEqual(len(self.context.groups), 0)
-
-    @mock.patch("mantidqtinterfaces.Muon.GUI.ElementalAnalysis2.ea_group.EAGroup.remove_rebinned_workspace")
-    @mock.patch("mantidqtinterfaces.Muon.GUI.ElementalAnalysis2.ea_group.EAGroup.remove_peak_table")
-    @mock.patch("mantidqtinterfaces.Muon.GUI.ElementalAnalysis2.ea_group.EAGroup.remove_matches_group")
-    def test_remove_rebinned_workspace_from_group(self, mock_remove_matches, mock_remove_peak, mock_remove_rebinned):
-        mock_group = EAGroup("9999; Detector 1", "detector 1", "9999")
-        self.context.add_group(mock_group)
-        self.context.remove_workspace_from_group('9999; Detector 1_EA_Rebinned_Fixed')
-        mock_remove_rebinned.assert_called_once()
-        mock_remove_peak.assert_not_called()
-        mock_remove_matches.assert_not_called()
-
-    @mock.patch("mantidqtinterfaces.Muon.GUI.ElementalAnalysis2.ea_group.EAGroup.remove_rebinned_workspace")
-    @mock.patch("mantidqtinterfaces.Muon.GUI.ElementalAnalysis2.ea_group.EAGroup.remove_peak_table")
-    @mock.patch("mantidqtinterfaces.Muon.GUI.ElementalAnalysis2.ea_group.EAGroup.remove_matches_group")
-    def test_remove_peak_table_from_group(self, mock_remove_matches, mock_remove_peak, mock_remove_rebinned):
-        mock_group = EAGroup("9999; Detector 1", "detector 1", "9999")
-        self.context.add_group(mock_group)
-        self.context.remove_workspace_from_group('9999; Detector 1_EA_peak_table')
-        mock_remove_rebinned.assert_not_called()
-        mock_remove_peak.aassert_called_once()
-        mock_remove_matches.assert_not_called()
-
-    @mock.patch("mantidqtinterfaces.Muon.GUI.ElementalAnalysis2.ea_group.EAGroup.remove_rebinned_workspace")
-    @mock.patch("mantidqtinterfaces.Muon.GUI.ElementalAnalysis2.ea_group.EAGroup.remove_peak_table")
-    @mock.patch("mantidqtinterfaces.Muon.GUI.ElementalAnalysis2.ea_group.EAGroup.remove_matches_group")
-    def test_remove_matches_table_from_group(self, mock_remove_matches, mock_remove_peak, mock_remove_rebinned):
-        mock_group = EAGroup("9999; Detector 1", "detector 1", "9999")
-        self.context.add_group(mock_group)
-        self.context.remove_workspace_from_group('9999; Detector 1_EA_matches')
-        mock_remove_rebinned.assert_not_called()
-        mock_remove_peak.aassert_not_called()
-        mock_remove_matches.assert_called_once()
-
-    @mock.patch("mantidqtinterfaces.Muon.GUI.ElementalAnalysis2.ea_group.EAGroup.remove_rebinned_workspace")
-    @mock.patch("mantidqtinterfaces.Muon.GUI.ElementalAnalysis2.ea_group.EAGroup.remove_peak_table")
-    @mock.patch("mantidqtinterfaces.Muon.GUI.ElementalAnalysis2.ea_group.EAGroup.remove_matches_group")
-    def test_remove_workspace_from_group_when_not_in_group(self, mock_remove_matches, mock_remove_peak,
-                                                           mock_remove_rebinned):
-        mock_group = EAGroup("9999; Detector 1", "detector 1", "9999")
-        self.context.add_group(mock_group)
-        self.context.remove_workspace_from_group('mock_workspace')
-        mock_remove_rebinned.assert_not_called()
-        mock_remove_peak.aassert_not_called()
-        mock_remove_matches.assert_not_called()
-
-    @mock.patch("mantidqtinterfaces.Muon.GUI.ElementalAnalysis2.ea_group.remove_ws_if_present")
-    def test_error_raised_when_deleting_EAGroup(self, mock_remove_ws):
-        self.loadedData.clear()
-        self.create_group_workspace_and_load()
-        self.context.reset_group_to_default(self.loadedData)
-        self.assertEqual(len(self.context.groups), 2)
-        group_name1 = '9999; Detector 1'
-        self.assertTrue(group_name1 in self.context.group_names)
-        mock_remove_ws.side_effect = ValueError("mock error")
-        error_notifier_mock = mock.Mock()
-        self.context[group_name1].error_notifier = error_notifier_mock
-
-        self.context.remove_group(group_name1)
-        self.assertFalse(group_name1 in self.context.group_names)
-        mock_remove_ws.assert_called_once_with(group_name1)
-        error_notifier_mock.notify_subscribers.assert_called_once_with(f"Unexpected error occurred when"
-                                                                       f" deleting group {group_name1}: mock error")
 
 
 if __name__ == '__main__':

--- a/qt/python/mantidqtinterfaces/test/Muon/elemental_analysis_2/elemental_analysis_data_context_test.py
+++ b/qt/python/mantidqtinterfaces/test/Muon/elemental_analysis_2/elemental_analysis_data_context_test.py
@@ -1,0 +1,42 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2018 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+import unittest
+from unittest import mock
+from mantidqtinterfaces.Muon.GUI.ElementalAnalysis2.context.data_context import DataContext
+
+
+class DataContextTest(unittest.TestCase):
+    def setUp(self):
+        self.context = DataContext()
+
+    def assert_data_context_empty(self):
+        self.assertEqual(self.context.current_runs, [])
+        self.assertEqual(self.context.run_info, [])
+
+    # ------------------------------------------------------------------------------------------------------------------
+    # TESTS
+    # ------------------------------------------------------------------------------------------------------------------
+
+    def test_add_run_object_to_run_info(self):
+        self.assert_data_context_empty()
+        new_run_object = mock.Mock(run_number=1234)
+        self.context.run_info_update(new_run_object)
+        self.assertEqual(len(self.context.run_info), 1)
+        self.assertEqual(self.context.run_info[0].run_number, 1234)
+
+    def test_clear_run_info(self):
+        self.assert_data_context_empty()
+        new_run_object = mock.Mock()
+        self.context.run_info_update(new_run_object)
+        self.assertEqual(len(self.context.run_info), 1)
+
+        self.context.clear_run_info()
+        self.assert_data_context_empty()
+
+
+if __name__ == '__main__':
+    unittest.main(buffer=False, verbosity=2)

--- a/qt/python/mantidqtinterfaces/test/Muon/elemental_analysis_2/elemental_analysis_eagroup_context_test.py
+++ b/qt/python/mantidqtinterfaces/test/Muon/elemental_analysis_2/elemental_analysis_eagroup_context_test.py
@@ -1,0 +1,133 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2018 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+import unittest
+from unittest import mock
+from mantid.api import WorkspaceGroup
+from mantid.simpleapi import CreateSampleWorkspace
+from mantidqtinterfaces.Muon.GUI.ElementalAnalysis2.context.ea_group_context import EAGroupContext
+from mantidqtinterfaces.Muon.GUI.Common.muon_load_data import MuonLoadData
+from mantidqtinterfaces.Muon.GUI.ElementalAnalysis2.ea_group import EAGroup
+
+
+class EAGroupContextTest(unittest.TestCase):
+    def setUp(self):
+        self.context = EAGroupContext()
+        self.loadedData = MuonLoadData()
+
+    def create_group_workspace_and_load(self):
+        grpws = WorkspaceGroup()
+        ws_detector1 = '9999; Detector 1'
+        grpws.addWorkspace(CreateSampleWorkspace(OutputWorkspace=ws_detector1))
+        ws_detector2 = '9999; Detector 2'
+        grpws.addWorkspace(CreateSampleWorkspace(OutputWorkspace=ws_detector2))
+        run = 9999
+        self.loadedData.add_data(run=[run], workspace=grpws)
+
+    # ------------------------------------------------------------------------------------------------------------------
+    # TESTS
+    # ------------------------------------------------------------------------------------------------------------------
+
+    def test_add_new_group(self):
+        self.loadedData.clear()
+        self.create_group_workspace_and_load()
+        empty_group = []
+        new_group = self.context.add_new_group(empty_group, self.loadedData)
+        self.assertEqual(len(new_group), 2)
+
+    def test_remove_group(self):
+        self.loadedData.clear()
+        self.create_group_workspace_and_load()
+        self.context.reset_group_to_default(self.loadedData)
+        self.assertEqual(len(self.context.groups), 2)
+        group_name1 = '9999; Detector 1'
+        self.assertTrue(group_name1 in self.context.group_names)
+
+        self.context.remove_group(group_name1)
+        self.assertFalse(group_name1 in self.context.group_names)
+
+    def test_reset_group_to_default(self):
+        self.loadedData.clear()
+        self.assertEqual(self.loadedData.num_items(), 0)
+        self.create_group_workspace_and_load()
+        self.context.reset_group_to_default(self.loadedData)
+        self.assertEqual(len(self.context.groups), 2)
+
+    def test_clear(self):
+        self.loadedData.clear()
+        self.create_group_workspace_and_load()
+        self.context.reset_group_to_default(self.loadedData)
+        self.assertEqual(len(self.context.groups), 2)
+
+        self.context.clear()
+        self.assertEqual(len(self.context.groups), 0)
+
+    @mock.patch("mantidqtinterfaces.Muon.GUI.ElementalAnalysis2.ea_group.EAGroup.remove_rebinned_workspace")
+    @mock.patch("mantidqtinterfaces.Muon.GUI.ElementalAnalysis2.ea_group.EAGroup.remove_peak_table")
+    @mock.patch("mantidqtinterfaces.Muon.GUI.ElementalAnalysis2.ea_group.EAGroup.remove_matches_group")
+    def test_remove_rebinned_workspace_from_group(self, mock_remove_matches, mock_remove_peak, mock_remove_rebinned):
+        mock_group = EAGroup("9999; Detector 1", "detector 1", "9999")
+        self.context.add_group(mock_group)
+        self.context.remove_workspace_from_group('9999; Detector 1_EA_Rebinned_Fixed')
+        mock_remove_rebinned.assert_called_once()
+        mock_remove_peak.assert_not_called()
+        mock_remove_matches.assert_not_called()
+
+    @mock.patch("mantidqtinterfaces.Muon.GUI.ElementalAnalysis2.ea_group.EAGroup.remove_rebinned_workspace")
+    @mock.patch("mantidqtinterfaces.Muon.GUI.ElementalAnalysis2.ea_group.EAGroup.remove_peak_table")
+    @mock.patch("mantidqtinterfaces.Muon.GUI.ElementalAnalysis2.ea_group.EAGroup.remove_matches_group")
+    def test_remove_peak_table_from_group(self, mock_remove_matches, mock_remove_peak, mock_remove_rebinned):
+        mock_group = EAGroup("9999; Detector 1", "detector 1", "9999")
+        self.context.add_group(mock_group)
+        self.context.remove_workspace_from_group('9999; Detector 1_EA_peak_table')
+        mock_remove_rebinned.assert_not_called()
+        mock_remove_peak.aassert_called_once()
+        mock_remove_matches.assert_not_called()
+
+    @mock.patch("mantidqtinterfaces.Muon.GUI.ElementalAnalysis2.ea_group.EAGroup.remove_rebinned_workspace")
+    @mock.patch("mantidqtinterfaces.Muon.GUI.ElementalAnalysis2.ea_group.EAGroup.remove_peak_table")
+    @mock.patch("mantidqtinterfaces.Muon.GUI.ElementalAnalysis2.ea_group.EAGroup.remove_matches_group")
+    def test_remove_matches_table_from_group(self, mock_remove_matches, mock_remove_peak, mock_remove_rebinned):
+        mock_group = EAGroup("9999; Detector 1", "detector 1", "9999")
+        self.context.add_group(mock_group)
+        self.context.remove_workspace_from_group('9999; Detector 1_EA_matches')
+        mock_remove_rebinned.assert_not_called()
+        mock_remove_peak.aassert_not_called()
+        mock_remove_matches.assert_called_once()
+
+    @mock.patch("mantidqtinterfaces.Muon.GUI.ElementalAnalysis2.ea_group.EAGroup.remove_rebinned_workspace")
+    @mock.patch("mantidqtinterfaces.Muon.GUI.ElementalAnalysis2.ea_group.EAGroup.remove_peak_table")
+    @mock.patch("mantidqtinterfaces.Muon.GUI.ElementalAnalysis2.ea_group.EAGroup.remove_matches_group")
+    def test_remove_workspace_from_group_when_not_in_group(self, mock_remove_matches, mock_remove_peak,
+                                                           mock_remove_rebinned):
+        mock_group = EAGroup("9999; Detector 1", "detector 1", "9999")
+        self.context.add_group(mock_group)
+        self.context.remove_workspace_from_group('mock_workspace')
+        mock_remove_rebinned.assert_not_called()
+        mock_remove_peak.aassert_not_called()
+        mock_remove_matches.assert_not_called()
+
+    @mock.patch("mantidqtinterfaces.Muon.GUI.ElementalAnalysis2.ea_group.remove_ws_if_present")
+    def test_error_raised_when_deleting_EAGroup(self, mock_remove_ws):
+        self.loadedData.clear()
+        self.create_group_workspace_and_load()
+        self.context.reset_group_to_default(self.loadedData)
+        self.assertEqual(len(self.context.groups), 2)
+        group_name1 = '9999; Detector 1'
+        self.assertTrue(group_name1 in self.context.group_names)
+        mock_remove_ws.side_effect = ValueError("mock error")
+        error_notifier_mock = mock.Mock()
+        self.context[group_name1].error_notifier = error_notifier_mock
+
+        self.context.remove_group(group_name1)
+        self.assertFalse(group_name1 in self.context.group_names)
+        mock_remove_ws.assert_called_once_with(group_name1)
+        error_notifier_mock.notify_subscribers.assert_called_once_with(f"Unexpected error occurred when"
+                                                                       f" deleting group {group_name1}: mock error")
+
+
+if __name__ == '__main__':
+    unittest.main(buffer=False, verbosity=2)


### PR DESCRIPTION
**Description of work.**

Splits elemental analysis test classes into separate modules

This allows them to run in parallel (at the process level) within ctest.
It also avoids some strange interplay that was seen by the
tests on Windows running methods overlapping
with each other.

**To test:**

* Checkout and build the branch in a conda build
* Run all elemental analysis tests: `ctest -C Release -R elemental_analaysis -j8` (you do not need the "-C Release" on Linux/mac)
* All tests should pass.

Fixes #34015

*This does not require release notes* because **it is an internal change.**

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
