### PR TITLE
Prevent Mantid from installing if uninstaller missing

### DIFF
--- a/docs/source/release/v6.4.0/Workbench/Bugfixes/33940.rst
+++ b/docs/source/release/v6.4.0/Workbench/Bugfixes/33940.rst
@@ -1,0 +1,1 @@
+- Users are now prevented from overwriting previous versions of Mantid if the uninstaller is not present. Some antivirus software deletes the uninstaller. Installing over older versions without the uninstaller can cause Mantid not to function properly and for users to lose data.

--- a/installers/conda/win/project.nsi
+++ b/installers/conda/win/project.nsi
@@ -90,9 +90,23 @@ FunctionEnd
 # Add functions needed for install and uninstall with the modern UI
 
 # On clicking install, uninstall any instance of mantid that exists in the target directory.
+# Some anti-virus software will remove the uninstaller. If this happens we check whether pythonw.exe, which is needed
+# to run Mantid, exists. If it does we stop the installation otherwise the installer attempts to overwrite any
+# exisiting files and users may lose data and their user proprties settings. In some instances this overwrite will
+# result in a version of Mantid that will not open at all.
 Function in.uninstallIfExistsInTargetDirectory
-    IfFileExists $INSTDIR\uninstall.exe 0 +2 ;If there is an uninstall.exe run it
-    ExecWait '"$INSTDIR\uninstall.exe" /UIS _?=$INSTDIR'
+    IfFileExists $INSTDIR\uninstall.exe uninstall_exists no_uninstall
+    uninstall_exists: ;If there is an uninstall.exe run it
+        ExecWait '"$INSTDIR\uninstall.exe" /UIS _?=$INSTDIR'
+    no_uninstall: ;If there is no uninstaller
+        IfFileExists $INSTDIR\bin\pythonw.exe 0 +3
+        !define msgLine1 "It looks like a previous version is installed in this location but the uninstaller has been deleted (possibly by antivirus) $\r$\n$\r$\n"
+        !define msgLine2 "In order to continue please either: $\r$\n"
+        !define msgLine3 "- backup the installation folder by renaming it or $\r$\n"
+        !define msgLine4 "- delete the installation folder if you are certain you do not need anything in it. $\r$\n $\r$\n "
+        !define msgLine5 "If you rename your installation folder you can restore your settings in the new version by copying bin\Mantid.user.properties from the renamed folder to new installation."
+        MessageBox MB_OK "${msgLine1}${msgLine2}${msgLine3}${msgLine4}${msgLine5}"
+        Quit
 FunctionEnd
 
 # Give the option to uninstall the currently installed version of the same package.


### PR DESCRIPTION
**Description of work.**
As described in the issue some antivirus software can delete the Mantid uninstaller on Windows. If users then try to install a newer version of Mantid into the same folder files will be overwritten, settings and potentially data lost. In some instances Mantid would no longer open.

In order to prevent issues this fix will stop installation in this circumstance and advise the user on what to do before trying to install again. This is done by checking if uninstall.exe is present and if not checks whether pythonw.exe is present as this file is required for Mantid to operate. If pythonw.exe is present then the install will stop with a pop up warning.

**To test:**

<!-- Instructions for testing. -->

1. Check out this branch
2. Follow the Part 1 instructions for creating an installer in PR #33742. You must make sure that you use the repo you checked this branch out into otherwise it won't have the correct project.nsi file. It may take a while.
3. Use the installer to Install Mantid but change install location so as not to cause problems with your own Nightly version
4. Delete the uninstall.exe file from this new folder.
5. Attempt to use the installer again to install the package into this folder. After confirming the file location you should get a warning advising you to rename or delete the folder before trying again. Check that the instructions make sense!
6. Follow the instructions (either will do) and attempt to install again - should be successful this time.

Fixes #33940 . 


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
