### PR TITLE
Convert QSetting properties to boolean if a boolean is expected

### DIFF
--- a/qt/applications/workbench/workbench/widgets/settings/general/presenter.py
+++ b/qt/applications/workbench/workbench/widgets/settings/general/presenter.py
@@ -167,9 +167,11 @@ class GeneralSettings(object):
         ConfigService.setString(GeneralProperties.USE_NOTIFICATIONS.value, "On" if bool(state) else "Off")
 
     def load_current_setting_values(self):
-        self.view.prompt_save_on_close.setChecked(bool(CONF.get(GeneralProperties.PROMPT_SAVE_ON_CLOSE.value)))
-        self.view.prompt_save_editor_modified.setChecked(bool(CONF.get(GeneralProperties.PROMPT_SAVE_EDITOR_MODIFIED.value)))
-        self.view.prompt_deleting_workspaces.setChecked(bool(CONF.get(GeneralProperties.PROMPT_ON_DELETING_WORKSPACE.value)))
+        self.view.prompt_save_on_close.setChecked(CONF.get(GeneralProperties.PROMPT_SAVE_ON_CLOSE.value, type=bool))
+        self.view.prompt_save_editor_modified.setChecked(CONF.get(GeneralProperties.PROMPT_SAVE_EDITOR_MODIFIED.value,
+                                                                  type=bool))
+        self.view.prompt_deleting_workspaces.setChecked(CONF.get(GeneralProperties.PROMPT_ON_DELETING_WORKSPACE.value,
+                                                                 type=bool))
 
         # compare lower-case, because MantidPlot will save it as lower case,
         # but Python will have the bool's first letter capitalised
@@ -180,7 +182,7 @@ class GeneralSettings(object):
         crystallography_convention = ("Crystallography" == ConfigService.getString(GeneralProperties.CRYSTALLOGRAPY_CONV.value))
         use_open_gl = ("on" == ConfigService.getString(GeneralProperties.OPENGL.value).lower())
         invisible_workspaces = ("true" == ConfigService.getString(GeneralProperties.SHOW_INVISIBLE_WORKSPACES.value).lower())
-        completion_enabled = CONF.get(GeneralProperties.COMPLETION_ENABLED.value)
+        completion_enabled = CONF.get(GeneralProperties.COMPLETION_ENABLED.value, type=bool)
 
         self.view.project_recovery_enabled.setChecked(pr_enabled)
         self.view.time_between_recovery.setValue(pr_time_between_recovery)

--- a/qt/applications/workbench/workbench/widgets/settings/general/test/test_general_settings.py
+++ b/qt/applications/workbench/workbench/widgets/settings/general/test/test_general_settings.py
@@ -184,14 +184,11 @@ class GeneralSettingsTest(unittest.TestCase):
         # load current setting is called automatically in the constructor
         GeneralSettings(None)
 
-        # calls().__bool__() are the calls to bool() on the retrieved value from ConfigService.getString
-        mock_CONF.get.assert_has_calls([call(GeneralProperties.PROMPT_SAVE_ON_CLOSE.value),
-                                        call().__bool__(),
-                                        call(GeneralProperties.PROMPT_SAVE_EDITOR_MODIFIED.value),
-                                        call().__bool__(),
-                                        call(GeneralProperties.PROMPT_ON_DELETING_WORKSPACE.value),
-                                        call().__bool__(),
-                                        call(GeneralProperties.COMPLETION_ENABLED.value)])
+        # 'any_order' is used to avoid having to assert call().__index__ is called due to 'get' returning a mock object
+        mock_CONF.get.assert_has_calls([call(GeneralProperties.PROMPT_SAVE_ON_CLOSE.value, type=bool),
+                                        call(GeneralProperties.PROMPT_SAVE_EDITOR_MODIFIED.value, type=bool),
+                                        call(GeneralProperties.PROMPT_ON_DELETING_WORKSPACE.value, type=bool),
+                                        call(GeneralProperties.COMPLETION_ENABLED.value, type=bool)], any_order=True)
 
         mock_ConfigService.getString.assert_has_calls([call(GeneralProperties.PR_RECOVERY_ENABLED.value),
                                                        call(GeneralProperties.PR_TIME_BETWEEN_RECOVERY.value),


### PR DESCRIPTION
**Description of work.**
When opening multiple Mantids in quick succession, there is sometimes a race condition between the syncing of the QSettings, and the 'fixup' of the booleans values such as changing 'true' to True. The syncing can be triggered by the event loop, and if this is triggered at the correct time, the converted booleans can be overwritten back to their original string form for a specific mantid instance. When this happens, there are errors.

The solution I have gone for is to ~~use Pyside2 to~~ specify the type of the QVariant being retrieved. This seems to correctly handle the conversion of  `'false': str` to `False: bool` and `'true': str` to `True: bool`. 

**To test:**

1. Use the instructions [here](https://developer.mantidproject.org/BuildingWithCMake.html#building-the-installer-package) to create a package for this branch. Install this package locally on your system
1. Open Mantid twice in quick succession (Quadruple click)
2. Go to File -> Settings in both Mantids
3. There should not be any errors in either of the Mantids. The settings should function as normal.

*No release notes because this problem is a regression since v6.3*

Fixes #33900

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
