### PR TITLE
Use CFBundleShortVersionString and not CFBundleLongVersionString

### DIFF
--- a/installers/conda/osx/create_bundle.sh
+++ b/installers/conda/osx/create_bundle.sh
@@ -111,7 +111,7 @@ function create_plist() {
   add_string_to_plist "$bundle_plist" CFBundleName "$bundle_name"
   add_string_to_plist "$bundle_plist" CFBundleIconFile "$(basename $bundle_icon)"
   add_string_to_plist "$bundle_plist" CFBundleVersion "$version"
-  add_string_to_plist "$bundle_plist" CFBundleLongVersionString "$version"
+  add_string_to_plist "$bundle_plist" CFBundleShortVersionString "$version"
 }
 
 # Add a key string-value pair to a plist


### PR DESCRIPTION
**Description of work.**

Use CFBundleShortVersionString and not CFBundleLongVersionString.

The latter is obselete and no longer supported/documented by apple.
The short version is required for the version to be displayed in Finder/Spotlight.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**

See associated issue and try the reproduction steps and you should see the version in Spotlight now. I have built a package at https://builds.mantidproject.org/job/build_packages_from_branch/21/ to help test this.

Fixes #34026 

*This does not require release notes* because **it fixes a regression**

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
