### PR TITLE
Correct sample orientation on Discus inelastic usage example

### DIFF
--- a/Framework/Algorithms/test/DiscusMultipleScatteringCorrectionTest.h
+++ b/Framework/Algorithms/test/DiscusMultipleScatteringCorrectionTest.h
@@ -596,14 +596,17 @@ public:
     SofQWorkspace->getAxis(0)->unit() = UnitFactory::Instance().create("DeltaE");
     SofQWorkspace->getAxis(1)->unit() = UnitFactory::Instance().create("MomentumTransfer");
 
-    std::vector<double> two_thetas = {20.0, 40.0, 60.0, 90.0};
     const double THICKNESS = 0.00065; // metres
 
+    // Discus calc was done at 20, 40, 60 and 90 degrees. Do it at every 10 degrees here so have access to the 4 Discus
+    // results
     const int NTHETA = 18;
     const double ang_inc = 180.0 / NTHETA;
     const double EInitial = 5.1;
+    // sample occupies +y,-z and -y,+z regions ie \ when looking along positive x direction
+    // the detectors are in a ring in the yz plane in positive y. All 4 Discus angles are on the same side of the sample
     auto inputWorkspace = SetupFlatPlateWorkspace(NTHETA, 1, ang_inc, nwpts, wmin - 0.5 * wwidth, wwidth, 0.05, 0.05,
-                                                  THICKNESS, 45.0, {1.0, 0.0, 0.0}, emode, EInitial);
+                                                  THICKNESS, -45.0, {1.0, 0.0, 0.0}, emode, EInitial);
     auto alg = std::make_shared<Mantid::Algorithms::DiscusMultipleScatteringCorrection>();
 
     // override the material
@@ -663,12 +666,12 @@ public:
 
   void test_indirect_on_realistic_structure_factor_without_importance_sampling() {
     // results are not vastly different to the direct geometry
-    run_test_inelastic_on_realistic_structure_factor(DeltaEMode::Indirect, 1000, false, false, -1, 0.00022, 0.00021);
+    run_test_inelastic_on_realistic_structure_factor(DeltaEMode::Indirect, 1000, false, false, -1, 0.00027, 0.00022);
   }
 
   void test_indirect_on_realistic_structure_factor_with_deltaE_interpolation() {
     // only run simulation on half of the deltaE bins (even indices) and interpolate the rest (odd indices)
-    run_test_inelastic_on_realistic_structure_factor(DeltaEMode::Indirect, 1000, false, false, 40, 0.00023, 0.00021);
+    run_test_inelastic_on_realistic_structure_factor(DeltaEMode::Indirect, 1000, false, false, 40, 0.00027, 0.00022);
   }
 
   void test_getxminmax() {

--- a/Framework/Kernel/src/V3D.cpp
+++ b/Framework/Kernel/src/V3D.cpp
@@ -52,7 +52,7 @@ namespace Mantid::Kernel {
   @param theta :: The theta value (in degrees) = the polar angle away from the
   +Z axis.
   @param phi :: The phi value (in degrees) = the azimuthal angle, where 0 points
-  along +X and rotates counter-clockwise in the XY plane
+  along +X and rotates clockwise in the XY plane
 */
 void V3D::spherical(const double R, const double theta, const double phi) noexcept {
   constexpr double deg2rad = M_PI / 180.0;
@@ -65,7 +65,7 @@ void V3D::spherical(const double R, const double theta, const double phi) noexce
   @param R :: The R value (distance)
   @param polar :: the polar angle (in radians) away from the +Z axis.
   @param azimuth :: the azimuthal angle (in radians), where 0 points along +X
-  and rotates counter-clockwise in the XY plane
+  and rotates clockwise in the XY plane
 */
 void V3D::spherical_rad(const double R, const double polar, const double azimuth) noexcept {
   m_pt[2] = R * cos(polar);

--- a/docs/source/algorithms/DiscusMultipleScatteringCorrection-v1.rst
+++ b/docs/source/algorithms/DiscusMultipleScatteringCorrection-v1.rst
@@ -196,8 +196,7 @@ Usage
        SpectrumIDs=ids,
        L2=[2.0] * len(two_thetas),
        Polar=two_thetas,
-       #azimuthal angle=phi, phi=0 along x axis and increases as move towards vertical y axis
-       Azimuthal=[-90.0] * len(two_thetas),
+       Azimuthal=[90.0] * len(two_thetas),
        DetectorIDs=ids,
        InstrumentName="testinst")
 
@@ -303,7 +302,8 @@ The double scatter profile shows a similar shape to the analytic result calculat
        SpectrumIDs=ids,
        L2=[2.0] * len(two_thetas),
        Polar=two_thetas,
-       Azimuthal=[90.0] * len(two_thetas),
+       #azimuthal angle=phi, phi=0 along x axis and increases as move towards vertical y axis
+       Azimuthal=[-90.0] * len(two_thetas),
        DetectorIDs=ids,
        InstrumentName="testinst")
 

--- a/docs/source/algorithms/DiscusMultipleScatteringCorrection-v1.rst
+++ b/docs/source/algorithms/DiscusMultipleScatteringCorrection-v1.rst
@@ -196,7 +196,8 @@ Usage
        SpectrumIDs=ids,
        L2=[2.0] * len(two_thetas),
        Polar=two_thetas,
-       Azimuthal=[90.0] * len(two_thetas),
+       #azimuthal angle=phi, phi=0 along x axis and increases as move towards vertical y axis
+       Azimuthal=[-90.0] * len(two_thetas),
        DetectorIDs=ids,
        InstrumentName="testinst")
 


### PR DESCRIPTION
**Description of work.**

The second usage examples on the DiscusMultipleScatteringCorrection is taken from the original Discus MS paper. The four scattering angles at 20, 40, 60 and 90 degrees should all be on the same side of the flat plate sample. This is the diagram from the original paper:

![image](https://user-images.githubusercontent.com/56295817/172438493-260ed92d-5db1-4d4d-9472-899f1e4fae02.png)

Due to misleading comment in V3D::spherical function I'd got the detectors on wrong side of the sample. The original comment possibly originated from an assumption that the XYZ coordinate system was left handed but it's actually right handed

Changes in summary:
- correct the usage example by moving the ring of detectors so they're in positions with negative z ie under the beam
- An equivalent unit test also had the same mistake so that's corrected. This resulted in a couple of reference values needing an update as well
- corrected the misleading comment in V3D::spherical which (mis)defined the positive direction for phi

**To test:**

Run the inelastic usage example (this is the second one in the DiscusMultipleScatteringCorrection algorithm documentation) with the final mtd.clear statement removed and check it works. The plots should look like the right hand plot:

![image](https://user-images.githubusercontent.com/56295817/172564316-e4b42fc3-4a76-4e75-915d-7204ed1b2fd4.png)

The change to the sample orientation mainly affects the results for the detector at 2theta=40 degrees (orange solid line and brown dashed line). This was close to being in line with the long dimension of the flat plate sample which is tilted at 45 degrees. This meant that paths reaching this detector were going through a lot of sample and being suppressed a bit. The scattered intensity for 1 and 2 scatters for this detector is bigger in the new result where the detector at 40 degrees is 85 degrees away from the face of the sample.

*There is no associated issue.*

*This does not require release notes* because **the usage example and the unit test were added during this release. Only changes are to tests and a comment in V3D.cpp**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
