### PR TITLE
Fix problems with LoadAllLogs feature in LoadEventNexus

### DIFF
--- a/Framework/DataHandling/inc/MantidDataHandling/LoadHelper.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/LoadHelper.h
@@ -32,7 +32,8 @@ public:
   double calculateEnergy(double);
   double calculateTOF(double, double);
   double getInstrumentProperty(const API::MatrixWorkspace_sptr &, const std::string &);
-  void addNexusFieldsToWsRun(NXhandle nxfileID, API::Run &runDetails, const std::string &entryName = "");
+  void addNexusFieldsToWsRun(NXhandle nxfileID, API::Run &runDetails, const std::string &entryName = "",
+                             bool useFullPath = false);
   void dumpNexusAttributes(NXhandle nxfileID);
   std::string dateTimeInIsoFormat(const std::string &);
 
@@ -42,7 +43,7 @@ public:
 
 private:
   void recurseAndAddNexusFieldsToWsRun(NXhandle nxfileID, API::Run &runDetails, std::string &parent_name,
-                                       std::string &parent_class, int level);
+                                       std::string &parent_class, int level, bool useFullPath);
 };
 } // namespace DataHandling
 // namespace DataHandling

--- a/Framework/DataHandling/src/LoadEventNexus.cpp
+++ b/Framework/DataHandling/src/LoadEventNexus.cpp
@@ -886,7 +886,7 @@ void LoadEventNexus::loadEvents(API::Progress *const prog, const bool monitors) 
 
       if (nxStat != NX_ERROR) {
         LoadHelper loadHelper;
-        loadHelper.addNexusFieldsToWsRun(nxHandle, m_ws->mutableRun());
+        loadHelper.addNexusFieldsToWsRun(nxHandle, m_ws->mutableRun(), "", true);
         NXclose(&nxHandle);
       }
     }

--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -161,7 +161,6 @@ constParameter:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/LoadEMU.cpp:729
 constParameter:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/LoadFITS.cpp:951
 constParameter:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/LoadFITS.cpp:951
 knownConditionTrueFalse:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/LoadGSASInstrumentFile.cpp:106
-unreadVariable:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/LoadHelper.cpp:168
 constParameter:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/LoadILLReflectometry.cpp:238
 constParameter:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/LoadILLReflectometry.cpp:365
 constParameter:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/LoadILLReflectometry.cpp:652

--- a/docs/source/release/v6.5.0/Framework/Algorithms/Bugfixes/34025_FixErrorOnUsingLoadAllLogs.rst
+++ b/docs/source/release/v6.5.0/Framework/Algorithms/Bugfixes/34025_FixErrorOnUsingLoadAllLogs.rst
@@ -1,0 +1,1 @@
+- If an event nexus file is loaded using :ref:`LoadEventNexus <algm-LoadEventNexus>` with LoadAllLogs=True any duplicate log entries no longer give an error. Log entries that are nested lower than two levels down are also properly distinguished


### PR DESCRIPTION
**Description of work.**

Log entries nested lower than 2 levels weren't properly distinguished because the log entry name in Mantid only contains the bottom two levels ie \<parent\>.\<bottom level entry\>. I've added a boolean switch to the function that sets up the log entry names that allows the full path to be used instead. This is used by the LoadAllLogs feature in LoadEventNexus. The old behaviour is retained for other load algorithms. In particular the LoadILLXXX family of algorithms use the old behaviour because the instrument name is included in the Nexus path in the ILL Nexus files and paths below this are used in the code on the assumption that only a two part name is sufficient to identify a log entry.

Duplicate log entries generated error and stopped load in some cases

**To test:**

1. Load file LARMOR00064041 in workbench and set LoadAllLogs to true. Check it loads
2. Load same file in HDFView on IDAaaS
3. Compare the log entries and check all are shown in workbench (right click on LARMOR00064041 in workbench and select Show Sample Logs). There are some repeated log entries such as "time" and "value" within the selog folder and these should be properly distinguished with a full dot separated path in workbench now:

![image](https://user-images.githubusercontent.com/56295817/172589246-d7920969-60bd-4269-a51a-93f3d1bdcfaf.png)

![image](https://user-images.githubusercontent.com/56295817/172589858-d4f077b0-7215-42e8-974e-d46fdf3d4d9b.png)


Fixes #34025.


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
