### PR TITLE
SHA update for MSlice interface and release notes

### DIFF
--- a/docs/source/release/v6.4.0/Direct_Geometry/MSlice/Bugfixes/34035.rst
+++ b/docs/source/release/v6.4.0/Direct_Geometry/MSlice/Bugfixes/34035.rst
@@ -1,0 +1,7 @@
+- Fixed bug that caused an error when changing the scale to logarithmic for cut plots with Bragg peaks.
+- Prevent strings for max and min axes values.
+- Dialogue boxes for quick options and plot options now stay on top of the plot window.
+- Fixed bug causing error messages when loading OSIRIS data.
+- Fixed problem with deletion of overplotted lines.
+- Fix for duplicated Bragg peaks when overplotting cut plots.
+- Fixed scaling of Bragg peaks on plots with logarithmic scales.

--- a/scripts/ExternalInterfaces/CMakeLists.txt
+++ b/scripts/ExternalInterfaces/CMakeLists.txt
@@ -7,7 +7,7 @@ externalproject_add(
   mslice
   PREFIX ${_mslice_external_root}
   GIT_REPOSITORY "https://github.com/mantidproject/mslice.git"
-  GIT_TAG e0613ab266f4a43c9f7aeee60679675c0efd14c6
+  GIT_TAG 93f0b276fdb0f4bb303768ed34943e0e612f400a
   EXCLUDE_FROM_ALL 1
   CONFIGURE_COMMAND ""
   BUILD_COMMAND ""


### PR DESCRIPTION
**Description of work.**

Replaced MSlice SHA for Mantid with SHA of current MSlice release-next branch.

Added release notes for all changes since the last SHA update.

**To test:**

Double-check SHA with SHA of current MSlice release-next branch.

There is no associated issue.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
