### PR TITLE
Stop SliceViewer stacking delayed refreshes

### DIFF
--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/presenters/presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/presenters/presenter.py
@@ -384,6 +384,8 @@ class SliceViewer(ObservingPresenter, SliceViewerBasePresenter):
         if not self.view:
             return
 
+        self.view.refresh_queued = False
+
         # we don't want to use model.get_ws for the image info widget as this needs
         # extra arguments depending on workspace type.
         ws = self.model.ws

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_sliceviewer_presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_sliceviewer_presenter.py
@@ -482,6 +482,18 @@ class SliceViewerTest(unittest.TestCase):
         self.view.setWindowTitle.assert_called_with(self.model.get_title())
         presenter.new_plot.assert_called_once()
 
+    def test_refresh_queued_flag_reset_upon_refresh_view(self):
+        presenter, _ = _create_presenter(self.model,
+                                         self.view,
+                                         mock.MagicMock(),
+                                         enable_nonortho_axes=False,
+                                         supports_nonortho=False)
+        presenter.new_plot = mock.Mock()
+        presenter.view.refresh_queued = True
+
+        presenter.refresh_view()
+        self.assertFalse(presenter.view.refresh_queued)
+
     def test_clear_observer_peaks_presenter_not_none(self):
         presenter, _ = _create_presenter(self.model,
                                          self.view,

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/views/view.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/views/view.py
@@ -57,6 +57,7 @@ class SliceViewerView(QWidget, ObservingView):
         layout.setContentsMargins(0, 0, 0, 0)
         layout.addWidget(self._splitter)
         self.setLayout(layout)
+        self.refresh_queued = False
 
         # connect up additional peaks signals
         self.data_view.mpl_toolbar.peaksOverlayClicked.connect(self.peaks_overlay_clicked)
@@ -114,7 +115,9 @@ class SliceViewerView(QWidget, ObservingView):
     def delayed_refresh(self):
         """Post an event to the event loop that causes the view to
         update on the next cycle"""
-        QTimer.singleShot(0, self.presenter.refresh_view)
+        if not self.refresh_queued:
+            self.refresh_queued = True
+            QTimer.singleShot(0, self.presenter.refresh_view)
 
     def close(self):
         self.presenter.notify_close()


### PR DESCRIPTION
**Description of work.**
SliceViewer currently utilises a delayed refresh. If a workspace with SliceViewer open is changed multiple times in quick succession these delayed refreshes stack and cause workbench to hang whilst they are processed.

This PR adds a simple flag to the delayed refresh to limit the amount of refreshes which can be queued.

**To test:**

1.  Run `ws = CreateSampleWorkspace()`
2.  Right click the created workspace and open sliceviewr.
3. Run:
```
for i in range(50):
    print(i)
    ws = ws*10
```
4. Observe minimal delay after execution of calculations.

*There is no associated issue.*

*This does not require release notes* because it fixes an issue caused by a recent commit.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
