### PR TITLE
Disallow PyQt5 >=5.15

### DIFF
--- a/mantid-developer-linux.yml
+++ b/mantid-developer-linux.yml
@@ -28,7 +28,7 @@ dependencies:
   - poco=1.10.*
   - psutil>=5.8.0
   - pycifrw==4.4.1 # Force to 4.4.1 as later versions cause issues with loading CIF files
-  - pyqt>=5.12.3,<6
+  - pyqt>=5.12.3,<5.15
   - python-dateutil>=2.8.1
   - python=3.8.*
   - pyyaml>=5.4.1

--- a/mantid-developer-osx.yml
+++ b/mantid-developer-osx.yml
@@ -27,7 +27,7 @@ dependencies:
   - poco=1.10.*
   - psutil>=5.8.0
   - pycifrw==4.4.1 # Force to 4.4.1 as later versions cause issues with loading CIF files
-  - pyqt>=5.12.3,<6
+  - pyqt>=5.12,<5.15
   - python-dateutil>=2.8.1
   - python=3.8.*
   - python.app

--- a/mantid-developer-win.yml
+++ b/mantid-developer-win.yml
@@ -28,7 +28,7 @@ dependencies:
   - poco=1.10.*
   - psutil>=5.8.0
   - pycifrw==4.4.1 # Force to 4.4.1 as later versions cause issues with loading CIF files
-  - pyqt>=5.12.3,<6
+  - pyqt>=5.12.3,<5.15
   - python-dateutil>=2.8.1
   - python=3.8.*
   - pyyaml>=5.4.1


### PR DESCRIPTION
**Description of work.**

Our cmake configure no longer finds sip or the PyQt5 sip files with 5.15.
Until this is fixed use 5.12

See [this build](https://builds.mantidproject.org/job/pull_requests-conda-linux/628/console)

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**

* Check the conda build passes

*There is no associated issue.*

*This does not require release notes* because **it is a developer change.**

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
