### PR TITLE
Compute final package options in jenkinsfile

### DIFF
--- a/buildconfig/Jenkins/Conda/nightly_build_and_deploy.jenkinsfile
+++ b/buildconfig/Jenkins/Conda/nightly_build_and_deploy.jenkinsfile
@@ -22,14 +22,23 @@ def publish_test_reports() {
 }
 
 def conda_build_unix(arch) {
-  sh "${WORKSPACE}/buildconfig/Jenkins/Conda/package ${WORKSPACE} --build-mantid --build-qt --build-workbench ${PACKAGE_OPTIONS}"
+  sh "${WORKSPACE}/buildconfig/Jenkins/Conda/package ${WORKSPACE} --build-mantid --build-qt --build-workbench ${package_options()}"
   archive_conda_build(arch)
 }
 
 def conda_build_win(arch) {
-  bat "\"${WIN_BASH}\" -ex -c \"${WORKSPACE_UNIX_PATH}/buildconfig/Jenkins/Conda/package ${WORKSPACE_UNIX_PATH} --build-mantid --build-qt --build-workbench ${PACKAGE_OPTIONS}\""
+  bat "\"${WIN_BASH}\" -ex -c \"${WORKSPACE_UNIX_PATH}/buildconfig/Jenkins/Conda/package ${WORKSPACE_UNIX_PATH} --build-mantid --build-qt --build-workbench ${package_options()}\""
   archive_conda_build(arch)
 }
+
+def package_options() {
+    package_options="${PACKAGE_OPTIONS.trim()}"
+    if(PACKAGE_SUFFIX.trim() != '') {
+        package_options += " --package-suffix ${PACKAGE_SUFFIX}"
+    }
+    return package_options.trim()
+}
+
 
 def archive_conda_build(arch) {
   archiveArtifacts artifacts: "**/conda-bld/${arch}/*.tar.bz2",

--- a/buildconfig/Jenkins/Conda/package
+++ b/buildconfig/Jenkins/Conda/package
@@ -63,8 +63,7 @@ ENABLE_BUILD_WORKBENCH=false
 BUILD_CURRENT_BRANCH=false
 CLOBBER_FILE=
 RECIPES_TAG=main
-# defaults to unstable to avoid accidentally producing a release package with no suffix
-STANDALONE_PACKAGE_SUFFIX=Unstable
+STANDALONE_PACKAGE_SUFFIX=
 
 # Handle flag inputs
 while [ ! $# -eq 0 ]
@@ -154,7 +153,10 @@ fi
 cd $WORKSPACE
 # Set our local conda channel to find our locally build mantidworkbench package.
 LOCAL_CHANNEL=file://$CONDA_BLD_PATH
-PACKAGING_ARGS="-c ${LOCAL_CHANNEL} -s ${STANDALONE_PACKAGE_SUFFIX}"
+PACKAGING_ARGS="-c ${LOCAL_CHANNEL}"
+if [ -n "${STANDALONE_PACKAGE_SUFFIX}" ]; then
+    PACKAGING_ARGS="${PACKAGING_ARGS} -s ${STANDALONE_PACKAGE_SUFFIX}"
+fi
 if [[ $OSTYPE == 'msys'* ]]; then
     rm -fr *.exe
     ${WORKSPACE}/installers/conda/win/create_package.sh $PACKAGING_ARGS


### PR DESCRIPTION
**Description of work.**

The PACKAGE_SUFFIX can be empty for a release build
and in this case it is far simpler to set the default
to empty in the package script and pass through
the suffix argument from the Jenkinsfile if it is set

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**

I created a [test job](https://builds.mantidproject.org/job/testing-pipeline/) with the same package_options function in it. It seems to work as expected.

I have kicked off two builds on the branch build pipeline:
 - ~~https://builds.mantidproject.org/job/build_packages_from_branch/33: This has an empty suffix~~. This failed
 - https://builds.mantidproject.org/job/build_packages_from_branch/35/: This has an empty suffix
 - https://builds.mantidproject.org/job/build_packages_from_branch/34: This has a Nightly suffix

*There is no associated issue.*

*This does not require release notes* because **it is an internal change.**

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
