### PR TITLE
Change interface documentation category for Fit Script Generator

### DIFF
--- a/docs/source/interfaces/general/Fit Script Generator.rst
+++ b/docs/source/interfaces/general/Fit Script Generator.rst
@@ -201,4 +201,4 @@ make sure you have access to the data archive. This will add a background to the
    :align: center
    :height: 300px
 
-.. categories:: Interfaces
+.. categories:: Interfaces General

--- a/qt/widgets/common/src/FitScriptGeneratorView.cpp
+++ b/qt/widgets/common/src/FitScriptGeneratorView.cpp
@@ -314,7 +314,7 @@ void FitScriptGeneratorView::onGenerateScriptToClipboardClicked() {
 }
 
 void FitScriptGeneratorView::onHelpClicked() {
-  MantidQt::API::HelpWindow::showCustomInterface(this, "Fit Script Generator", QString("utility"));
+  MantidQt::API::HelpWindow::showCustomInterface(this, "Fit Script Generator", QString("general"));
 }
 
 std::string FitScriptGeneratorView::workspaceName(FitDomainIndex index) const {


### PR DESCRIPTION
**Description of work.**
This PR fixes a problem where the documentation for the Fit Script Generator would not open because the wrong category was being used in the code.

**To test:**
Code review and follow the instructions in the issue

Fixes #34084 

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
