### PR TITLE
Fix Save Project after opening multiple mantid instances

### DIFF
--- a/docs/source/release/v6.5.0/Workbench/Bugfixes/34089.rst
+++ b/docs/source/release/v6.5.0/Workbench/Bugfixes/34089.rst
@@ -1,0 +1,1 @@
+- Opening multiple instances of Mantid in quick succession will no longer cause errors in the shared settings.

--- a/qt/applications/workbench/workbench/app/mainwindow.py
+++ b/qt/applications/workbench/workbench/app/mainwindow.py
@@ -24,7 +24,7 @@ from workbench.widgets.settings.presenter import SettingsPresenter
 # -----------------------------------------------------------------------------
 # Qt
 # -----------------------------------------------------------------------------
-from qtpy.QtCore import (QEventLoop, Qt, QPoint, QSize, QCoreApplication)  # noqa
+from qtpy.QtCore import (QByteArray, QEventLoop, Qt, QPoint, QSize, QCoreApplication)  # noqa
 from qtpy.QtGui import (QColor, QFontDatabase, QGuiApplication, QIcon, QPixmap)  # noqa
 from qtpy.QtWidgets import (QApplication, QDesktopWidget, QFileDialog, QMainWindow,
                             QSplashScreen, QMessageBox)  # noqa
@@ -780,7 +780,7 @@ class MainWindow(QMainWindow):
 
         # restore window state
         if settings.has('MainWindow/state'):
-            if not self.restoreState(settings.get('MainWindow/state'), SAVE_STATE_VERSION):
+            if not self.restoreState(settings.get('MainWindow/state', type=QByteArray), SAVE_STATE_VERSION):
                 logger.warning(
                     "The previous layout of workbench is not compatible with this version, reverting to default layout."
                 )

--- a/qt/applications/workbench/workbench/app/mainwindow.py
+++ b/qt/applications/workbench/workbench/app/mainwindow.py
@@ -187,8 +187,8 @@ class MainWindow(QMainWindow):
         from workbench.plugins.workspacewidget import WorkspaceWidget
         self.workspacewidget = WorkspaceWidget(self)
         self.workspacewidget.register_plugin()
-        prompt = CONF.get('project/prompt_on_deleting_workspace')
-        self.workspacewidget.workspacewidget.enableDeletePrompt(bool(prompt))
+        prompt = CONF.get('project/prompt_on_deleting_workspace', type=bool)
+        self.workspacewidget.workspacewidget.enableDeletePrompt(prompt)
         self.widgets.append(self.workspacewidget)
 
         self.set_splash("Loading memory widget")
@@ -473,8 +473,8 @@ class MainWindow(QMainWindow):
     def populate_layout_menu(self):
         self.view_menu_layouts.clear()
         try:
-            layout_dict = CONF.get("MainWindow/user_layouts")
-        except KeyError:
+            layout_dict = CONF.get("MainWindow/user_layouts", type=dict)
+        except (KeyError, TypeError):
             layout_dict = {}
         layout_keys = sorted(layout_dict.keys())
         layout_options = []
@@ -743,14 +743,10 @@ class MainWindow(QMainWindow):
         qapp = QApplication.instance()
 
         # get the saved window geometry
-        window_size = settings.get('MainWindow/size')
-        if not isinstance(window_size, QSize):
-            window_size = QSize(*window_size)
-        window_pos = settings.get('MainWindow/position')
-        if not isinstance(window_pos, QPoint):
-            window_pos = QPoint(*window_pos)
+        window_size = settings.get('MainWindow/size', type=QSize)
+        window_pos = settings.get('MainWindow/position', type=QPoint)
         if settings.has('MainWindow/font'):
-            font_string = settings.get('MainWindow/font').split(',')
+            font_string = settings.get('MainWindow/font', type=str).split(',')
             font = QFontDatabase().font(font_string[0], font_string[-1], int(font_string[1]))
             qapp.setFont(font)
 

--- a/qt/applications/workbench/workbench/config/test/test_user.py
+++ b/qt/applications/workbench/workbench/config/test/test_user.py
@@ -83,17 +83,17 @@ class ConfigUserTest(TestCase):
 
     def test_stored_value_not_in_defaults_is_retrieved(self):
         self.cfg.set('main', 'key1', 1)
-        self.assertEqual(1, self.cfg.get('main', 'key1'))
+        self.assertEqual(1, self.cfg.get('main', 'key1', type=int))
 
     def test_value_not_in_settings_retrieves_default_if_it_exists(self):
-        self.assertEqual(100, self.cfg.get('main', 'a_default_key'))
-        self.assertEqual(100, self.cfg.get('main/a_default_key'))
+        self.assertEqual(100, self.cfg.get('main', 'a_default_key', type=int))
+        self.assertEqual(100, self.cfg.get('main/a_default_key', type=int))
 
     def test_boolean_with_default_false_can_be_retrieved(self):
-        self.assertEqual(False, self.cfg.get('main', 'bool_option'))
-        self.assertEqual(False, self.cfg.get('main/bool_option'))
+        self.assertEqual(False, self.cfg.get('main', 'bool_option', type=bool))
+        self.assertEqual(False, self.cfg.get('main/bool_option', type=bool))
 
-        self.assertEqual(True, self.cfg.get('main/bool_option2'))
+        self.assertEqual(True, self.cfg.get('main/bool_option2', type=bool))
 
     def test_has_keys(self):
         self.assertTrue(self.cfg.has('main', 'a_default_key'))
@@ -116,8 +116,8 @@ class ConfigUserTest(TestCase):
             },
         }
         with ConfigUserManager("lowercase", defaults) as cfg:
-            self.assertFalse(cfg.get('main/lowercase_bool_option'))
-            self.assertTrue(cfg.get('main/lowercase_bool_option2'))
+            self.assertFalse(cfg.get('main/lowercase_bool_option', type=bool))
+            self.assertTrue(cfg.get('main/lowercase_bool_option2', type=bool))
 
     def test_all_keys_with_specified_group(self):
         with ConfigUserManager("allkeys") as cfg:
@@ -135,10 +135,10 @@ class ConfigUserTest(TestCase):
     # ----------------------------------------------
 
     def test_get_raises_error_with_invalid_section_type(self):
-        self.assertRaises(TypeError, self.cfg.get, 1, 'key1')
+        self.assertRaises(TypeError, self.cfg.get, 1, 'key1', type=int)
 
     def test_get_raises_error_with_invalid_option_type(self):
-        self.assertRaises(TypeError, self.cfg.get, 'section', 1)
+        self.assertRaises(TypeError, self.cfg.get, 'section', 1, type=int)
 
     def test_get_raises_error_with_missing_key_when_type_provided(self):
         self.assertRaises(KeyError, self.cfg.get, 'not_a_key', type=bool)
@@ -147,8 +147,8 @@ class ConfigUserTest(TestCase):
         self.assertRaises(TypeError, self.cfg.get, 'main', 'bool_option', type='QStringList')
 
     def test_get_raises_keyerror_with_no_saved_setting_or_default(self):
-        self.assertRaises(KeyError, self.cfg.get, 'main', 'missing-key')
-        self.assertRaises(KeyError, self.cfg.get, 'main/missing-key')
+        self.assertRaises(KeyError, self.cfg.get, 'main', 'missing-key', type=str)
+        self.assertRaises(KeyError, self.cfg.get, 'main/missing-key', type=str)
 
     def test_set_raises_error_with_invalid_section_type(self):
         self.assertRaises(TypeError, self.cfg.set, 1, 'key1', 1)

--- a/qt/applications/workbench/workbench/config/user.py
+++ b/qt/applications/workbench/workbench/config/user.py
@@ -75,7 +75,7 @@ class UserConfig(object):
             return self._get_setting(option, second, type)
         except TypeError:
             # The 'PyQt_PyObject' (1024) type is sometimes used for settings which have an unknown type.
-            value = self._get_setting(option, type=QVariant.typeToName(1024))
+            value = self._get_setting(option, second, type=QVariant.typeToName(1024))
             return value if isinstance(value, type) else type(*value)
 
     def has(self, option, second=None):

--- a/qt/applications/workbench/workbench/plugins/editor.py
+++ b/qt/applications/workbench/workbench/plugins/editor.py
@@ -44,7 +44,7 @@ class MultiFileEditor(PluginWidget):
 
         completion_enabled = True
         if CONF.has(ENABLE_COMPLETION_KEY):
-            completion_enabled = CONF.get(ENABLE_COMPLETION_KEY)
+            completion_enabled = CONF.get(ENABLE_COMPLETION_KEY, type=bool)
 
         # layout
         self.editors = MultiPythonFileInterpreter(font=font,
@@ -118,12 +118,12 @@ class MultiFileEditor(PluginWidget):
 
     def readSettings(self, settings):
         try:
-            prev_session_tabs = settings.get(TAB_SETTINGS_KEY)
-            zoom_level = settings.get(ZOOM_LEVEL_KEY)
-        except KeyError:
+            prev_session_tabs = settings.get(TAB_SETTINGS_KEY, type=list)
+            zoom_level = settings.get(ZOOM_LEVEL_KEY, type=int)
+        except (KeyError, TypeError):
             return
         self.restore_session_tabs(prev_session_tabs)
-        self.editors.current_editor().editor.zoomTo(int(zoom_level))
+        self.editors.current_editor().editor.zoomTo(zoom_level)
 
     def writeSettings(self, settings):
         settings.set(ZOOM_LEVEL_KEY, self.editors_zoom_level)

--- a/qt/applications/workbench/workbench/utils/recentlyclosedscriptsmenu.py
+++ b/qt/applications/workbench/workbench/utils/recentlyclosedscriptsmenu.py
@@ -86,7 +86,7 @@ class RecentlyClosedScriptsMenu(QMenu):
     def _get_scripts_from_settings():
         scripts = []
         try:
-            scripts = CONF.get(RECENT_SCRIPTS_KEY)
+            scripts = CONF.get(RECENT_SCRIPTS_KEY, type=list)
         except KeyError:
             # Happens quite often and should fail silently.
             pass

--- a/qt/applications/workbench/workbench/widgets/about/presenter.py
+++ b/qt/applications/workbench/workbench/widgets/about/presenter.py
@@ -51,7 +51,7 @@ class AboutPresenter(object):
         # set do not show
         qSettings = QSettings()
         qSettings.beginGroup(self.DO_NOT_SHOW_GROUP)
-        doNotShowUntilNextRelease = int(qSettings.value(self.DO_NOT_SHOW, "0"))
+        doNotShowUntilNextRelease = qSettings.value(self.DO_NOT_SHOW, 0, type=int)
         qSettings.endGroup()
         about_widget.chk_do_not_show_until_next_release.setChecked(doNotShowUntilNextRelease)
         about_widget.chk_do_not_show_until_next_release.stateChanged.connect(self.action_do_not_show_until_next_release)
@@ -81,8 +81,8 @@ class AboutPresenter(object):
 
         settings = QSettings()
         settings.beginGroup(AboutPresenter.DO_NOT_SHOW_GROUP)
-        doNotShowUntilNextRelease = int(settings.value(AboutPresenter.DO_NOT_SHOW, '0'))
-        lastVersion = settings.value(AboutPresenter.PREVIOUS_VERSION, "")
+        doNotShowUntilNextRelease = settings.value(AboutPresenter.DO_NOT_SHOW, 0, type=int)
+        lastVersion = settings.value(AboutPresenter.PREVIOUS_VERSION, "", type=str)
         current_version = version().major + "." + version().minor
         settings.endGroup()
 

--- a/qt/applications/workbench/workbench/widgets/settings/general/presenter.py
+++ b/qt/applications/workbench/workbench/widgets/settings/general/presenter.py
@@ -93,7 +93,7 @@ class GeneralSettings(object):
 
     def setup_general_group(self):
         self.view.window_behaviour.addItems(self.WINDOW_BEHAVIOUR)
-        window_behaviour = CONF.get(GeneralProperties.WINDOW_BEHAVIOUR.value)
+        window_behaviour = CONF.get(GeneralProperties.WINDOW_BEHAVIOUR.value, type=str)
         if window_behaviour in self.WINDOW_BEHAVIOUR:
             self.view.window_behaviour.setCurrentIndex(self.view.window_behaviour.findText(window_behaviour))
 
@@ -104,7 +104,7 @@ class GeneralSettings(object):
     def action_main_font_button_clicked(self):
         font = None
         if CONF.has(GeneralProperties.FONT.value):
-            font_string = CONF.get(GeneralProperties.FONT.value).split(',')
+            font_string = CONF.get(GeneralProperties.FONT.value, type=str).split(',')
             if len(font_string) > 2:
                 font = QFontDatabase().font(font_string[0], font_string[-1], int(font_string[1]))
         font_dialog = self.view.create_font_dialog(self.parent, font)
@@ -113,7 +113,7 @@ class GeneralSettings(object):
     def action_font_selected(self, font):
         font_string = ""
         if CONF.has(GeneralProperties.FONT.value):
-            font_string = CONF.get(GeneralProperties.FONT.value)
+            font_string = CONF.get(GeneralProperties.FONT.value, type=str)
         if font_string != font.toString():
             CONF.set(GeneralProperties.FONT.value, font.toString())
             if self.settings_presenter is not None:
@@ -231,8 +231,8 @@ class GeneralSettings(object):
 
     def get_layout_dict(self):
         try:
-            layout_list = CONF.get(GeneralProperties.USER_LAYOUT.value)
-        except KeyError:
+            layout_list = CONF.get(GeneralProperties.USER_LAYOUT.value, type=dict)
+        except (KeyError, TypeError):
             layout_list = {}
         return layout_list
 

--- a/qt/applications/workbench/workbench/widgets/settings/general/test/test_general_settings.py
+++ b/qt/applications/workbench/workbench/widgets/settings/general/test/test_general_settings.py
@@ -369,7 +369,8 @@ class GeneralSettingsTest(unittest.TestCase):
 
         presenter.save_layout()
 
-        calls = [call(GeneralProperties.USER_LAYOUT.value), call(GeneralProperties.USER_LAYOUT.value)]
+        calls = [call(GeneralProperties.USER_LAYOUT.value, type=dict),
+                 call(GeneralProperties.USER_LAYOUT.value, type=dict)]
         mock_CONF.get.assert_has_calls(calls)
         mock_parent.saveState.assert_called_once_with(SAVE_STATE_VERSION)
         mock_parent.populate_layout_menu.assert_called_once_with()
@@ -390,7 +391,7 @@ class GeneralSettingsTest(unittest.TestCase):
 
         presenter.load_layout()
 
-        mock_CONF.get.assert_called_once_with(GeneralProperties.USER_LAYOUT.value)
+        mock_CONF.get.assert_called_once_with(GeneralProperties.USER_LAYOUT.value, type=dict)
         mock_parent.restoreState.assert_called_once_with(test_dict['a'], SAVE_STATE_VERSION)
 
     @patch(WORKBENCH_CONF_CLASSPATH)
@@ -409,7 +410,8 @@ class GeneralSettingsTest(unittest.TestCase):
 
         presenter.delete_layout()
 
-        calls = [call(GeneralProperties.USER_LAYOUT.value), call(GeneralProperties.USER_LAYOUT.value)]
+        calls = [call(GeneralProperties.USER_LAYOUT.value, type=dict),
+                 call(GeneralProperties.USER_LAYOUT.value, type=dict)]
         mock_CONF.get.assert_has_calls(calls)
         mock_CONF.set.assert_called_once_with(GeneralProperties.USER_LAYOUT.value, {})
         mock_parent.populate_layout_menu.assert_called_once_with()

--- a/qt/applications/workbench/workbench/widgets/settings/model.py
+++ b/qt/applications/workbench/workbench/widgets/settings/model.py
@@ -20,7 +20,7 @@ class SettingsModel:
             for setting in settings:
                 if CONF.has(setting):
                     if setting != GeneralProperties.USER_LAYOUT.value:
-                        value = CONF.get(setting)
+                        value = CONF.get(setting, type=str)
                 else:
                     value = ConfigService.getString(setting)
                 file.write(setting + '=' + str(value) + '\n')

--- a/qt/applications/workbench/workbench/widgets/settings/test/test_settings_model.py
+++ b/qt/applications/workbench/workbench/widgets/settings/test/test_settings_model.py
@@ -32,7 +32,7 @@ class MockCONF(object):
 
     def __init__(self):
         self.set = MagicMock()
-        self.get = MagicMock(side_effect=lambda x: test_CONF_settings[x])
+        self.get = MagicMock(side_effect=lambda x, type: test_CONF_settings[x])
         self.has = MagicMock(side_effect=lambda x: x in test_CONF_settings)
 
 

--- a/qt/python/mantidqt/mantidqt/dialogs/errorreports/report.py
+++ b/qt/python/mantidqt/mantidqt/dialogs/errorreports/report.py
@@ -85,8 +85,8 @@ class CrashReportPage(ErrorReportUIBase, ErrorReportUI):
         # Prefill name and email saved in QSettings
         qSettings = QSettings()
         qSettings.beginGroup(self.CONTACT_INFO)
-        self.saved_name = str(qSettings.value(self.NAME, ""))
-        self.saved_email = str(qSettings.value(self.EMAIL, ""))
+        self.saved_name = qSettings.value(self.NAME, "", type=str)
+        self.saved_email = qSettings.value(self.EMAIL, "", type=str)
         qSettings.endGroup()
         if self.saved_name or self.saved_email:
             self.input_name_line_edit.setText(self.saved_name)

--- a/qt/python/mantidqt/mantidqt/project/project.py
+++ b/qt/python/mantidqt/mantidqt/project/project.py
@@ -55,8 +55,8 @@ class Project(AnalysisDataServiceObserver):
         self.prompt_save_on_close = True
 
     def load_settings_from_config(self, config):
-        self.prompt_save_on_close = config.get('project', 'prompt_save_on_close')
-        self.save_altered_workspaces_only = config.get('project', 'save_altered_workspaces_only')
+        self.prompt_save_on_close = config.get('project', 'prompt_save_on_close', type=bool)
+        self.save_altered_workspaces_only = config.get('project', 'save_altered_workspaces_only', type=bool)
 
     @property
     def saved(self):

--- a/qt/python/mantidqt/mantidqt/widgets/codeeditor/multifileinterpreter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/codeeditor/multifileinterpreter.py
@@ -92,8 +92,8 @@ class MultiPythonFileInterpreter(QWidget):
         super(MultiPythonFileInterpreter, self).closeEvent(event)
 
     def load_settings_from_config(self, config):
-        self.confirm_on_save = config.get('project', 'prompt_save_editor_modified')
-        self.completion_enabled = config.get('Editors', 'completion_enabled')
+        self.confirm_on_save = config.get('project', 'prompt_save_editor_modified', type=bool)
+        self.completion_enabled = config.get('Editors', 'completion_enabled', type=bool)
         self.on_completion_change()
 
     @property

--- a/qt/python/mantidqt/mantidqt/widgets/messagedisplay.py
+++ b/qt/python/mantidqt/mantidqt/widgets/messagedisplay.py
@@ -46,7 +46,7 @@ class MessageDisplay(MessageDisplay_cpp):
         self.setShowActiveScriptOutput(self.ReadSettingSafely(qsettings, SHOW_ACTIVE_SCRIPT_OUTPUT_KEY, True, bool))
         self.setShowAllScriptOutput(self.ReadSettingSafely(qsettings, SHOW_ALL_SCRIPT_OUTPUT_KEY, False, bool))
 
-    def ReadSettingSafely(self,qsettings,key,default,type):
+    def ReadSettingSafely(self, qsettings, key, default, type):
         """
         Reads a value from qsettings, returning the default if the value is missing or the type is wrong
         :param qsettings: the qsettings object
@@ -56,8 +56,7 @@ class MessageDisplay(MessageDisplay_cpp):
         :return: The value from qsettings, or default if the value is missing or the type is wrong
         """
         try:
-            settingValue = qsettings.value(key, default)
-            return settingValue if isinstance(settingValue, type) else default
+            return qsettings.value(key, default, type=type)
         except TypeError:
             return default
 

--- a/qt/python/mantidqt/mantidqt/widgets/messagedisplay.py
+++ b/qt/python/mantidqt/mantidqt/widgets/messagedisplay.py
@@ -57,7 +57,7 @@ class MessageDisplay(MessageDisplay_cpp):
         """
         try:
             return qsettings.value(key, default, type=type)
-        except TypeError:
+        except (KeyError, TypeError):
             return default
 
     def writeSettings(self, qsettings):

--- a/qt/python/mantidqt/mantidqt/widgets/saveprojectdialog/test/test_saveprojectdialog.py
+++ b/qt/python/mantidqt/mantidqt/widgets/saveprojectdialog/test/test_saveprojectdialog.py
@@ -44,4 +44,4 @@ class SaveProjectDialogTest(unittest.TestCase):
 
         self.presenter.save_as()
 
-        self.assertEqual(self.mock_conf.get('project/save_altered_workspaces_only'), True)
+        self.assertEqual(self.mock_conf.get('project/save_altered_workspaces_only', type=bool), True)

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/HFIR_4Circle_Reduction/reduce4circleGUI.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/HFIR_4Circle_Reduction/reduce4circleGUI.py
@@ -3847,9 +3847,9 @@ class MainWindow(QMainWindow):
 
         # directories
         try:
-            spice_dir = settings.value('local_spice_dir', '')
+            spice_dir = settings.value('local_spice_dir', '', type=str)
             self.ui.lineEdit_localSpiceDir.setText(str(spice_dir))
-            work_dir = settings.value('work_dir')
+            work_dir = settings.value('work_dir', type=str)
             self.ui.lineEdit_workDir.setText(str(work_dir))
 
             # experiment number
@@ -3857,40 +3857,40 @@ class MainWindow(QMainWindow):
             self.ui.lineEdit_exp.setText(str(exp_num))
 
             # lattice parameters
-            lattice_a = settings.value('a')
+            lattice_a = settings.value('a', type=str)
             self.ui.lineEdit_a.setText(str(lattice_a))
-            lattice_b = settings.value('b')
+            lattice_b = settings.value('b', type=str)
             self.ui.lineEdit_b.setText(str(lattice_b))
-            lattice_c = settings.value('c')
+            lattice_c = settings.value('c', type=str)
             self.ui.lineEdit_c.setText(str(lattice_c))
-            lattice_alpha = settings.value('alpha')
+            lattice_alpha = settings.value('alpha', type=str)
             self.ui.lineEdit_alpha.setText(str(lattice_alpha))
-            lattice_beta = settings.value('beta')
+            lattice_beta = settings.value('beta', type=str)
             self.ui.lineEdit_beta.setText(str(lattice_beta))
-            lattice_gamma = settings.value('gamma')
+            lattice_gamma = settings.value('gamma', type=str)
             self.ui.lineEdit_gamma.setText(str(lattice_gamma))
 
             # last project
-            last_1_project_path = str(settings.value('last1path'))
+            last_1_project_path = settings.value('last1path', type=str)
             self.ui.label_last1Path.setText(last_1_project_path)
 
             # calibrated instrument configurations
-            user_wave_length = settings.value('wave_length')
+            user_wave_length = settings.value('wave_length', type=str)
             self.ui.lineEdit_userWaveLength.setText(user_wave_length)
 
-            det_row_center = settings.value('row_center')
+            det_row_center = settings.value('row_center', type=str)
             self.ui.lineEdit_detCenterPixHorizontal.setText(det_row_center)
 
-            det_col_center = settings.value('col_center')
+            det_col_center = settings.value('col_center', type=str)
             self.ui.lineEdit_detCenterPixVertical.setText(det_col_center)
 
-            det_sample_distance = settings.value('det_sample_distance')
+            det_sample_distance = settings.value('det_sample_distance', type=str)
             self.ui.lineEdit_userDetSampleDistance.setText(det_sample_distance)
 
             # survey
-            survey_start = str(settings.value('survey_start_scan'))
+            survey_start = settings.value('survey_start_scan', type=str)
             self.ui.lineEdit_surveyStartPt.setText(survey_start)
-            survey_stop = str(settings.value('survey_stop_scan'))
+            survey_stop = settings.value('survey_stop_scan', type=str)
             self.ui.lineEdit_surveyEndPt.setText(survey_stop)
 
         except TypeError as err:

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/reduction_application.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/reduction_application.py
@@ -84,6 +84,8 @@ class ReductionGUI(QMainWindow):
 
         # Recent files
         self._recent_files = settings.value("recent_files", [], type=list)
+        if self._recent_files is None:  # An empty list saved to QSettings comes back as 'None'
+            self._recent_files = []
 
         # Folder to open files in
         self._last_directory = settings.value("last_directory", '.', type=unicode)

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/reduction_application.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/reduction_application.py
@@ -69,7 +69,7 @@ class ReductionGUI(QMainWindow):
 
         # Name handle for the instrument
         if instrument is None:
-            instrument = unicode(settings.value("instrument_name", ''))
+            instrument = settings.value("instrument_name", '', type=unicode)
             if instrument_list is not None and instrument not in instrument_list:
                 instrument = None
 
@@ -83,13 +83,11 @@ class ReductionGUI(QMainWindow):
         self._interface = None
 
         # Recent files
-        self._recent_files = settings.value("recent_files", [])
-        if self._recent_files is None:  # An empty list saved to QSettings comes back as 'None'
-            self._recent_files = []
+        self._recent_files = settings.value("recent_files", [], type=list)
 
         # Folder to open files in
-        self._last_directory = unicode(settings.value("last_directory", '.'))
-        self._last_export_directory = unicode(settings.value("last_export_directory", '.'))
+        self._last_directory = settings.value("last_directory", '.', type=unicode)
+        self._last_export_directory = settings.value("last_export_directory", '.', type=unicode)
 
         # Current file name
         self._filename = None

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/reduction_gui/settings/application_settings.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/reduction_gui/settings/application_settings.py
@@ -66,7 +66,7 @@ class GeneralSettings(QObject):
 
     @property
     def data_path(self):
-        self._data_path = unicode(self._settings.value("general_data_path", '.'))
+        self._data_path = self._settings.value("general_data_path", '.', type=unicode)
         return self._data_path
 
     @data_path.setter
@@ -77,7 +77,7 @@ class GeneralSettings(QObject):
 
     @property
     def debug(self):
-        self._debug = unicode(self._settings.value("debug_mode", 'false')).lower()=='true'
+        self._debug = self._settings.value("debug_mode", False, type=bool)
         return self._debug
 
     @debug.setter
@@ -88,7 +88,7 @@ class GeneralSettings(QObject):
 
     @property
     def advanced(self):
-        self._advanced = unicode(self._settings.value("advanced_mode", 'true')).lower()=='true'
+        self._advanced = self._settings.value("advanced_mode", True, type=bool)
         return self._advanced
 
     @advanced.setter
@@ -102,8 +102,8 @@ class GeneralSettings(QObject):
         """ Get instrument name
         :return: instrument name or False
         """
-        self._instrument_name = unicode(self._settings.value("instrument_name", 'true'))
-        if self._instrument_name.lower() == 'true':
+        self._instrument_name = self._settings.value("instrument_name", "", type=unicode)
+        if self._instrument_name == "":
             self._instrument_name = False
         return self._instrument_name
 
@@ -115,8 +115,8 @@ class GeneralSettings(QObject):
 
     @property
     def facility_name(self):
-        self._facility_name = unicode(self._settings.value("facility_name", 'true'))
-        if self._facility_name.lower() == 'true':
+        self._facility_name = self._settings.value("facility_name", "", type=unicode)
+        if self._facility_name == "":
             self._facility_name = False
         return self._facility_name
 
@@ -128,7 +128,7 @@ class GeneralSettings(QObject):
 
     @property
     def data_output_dir(self):
-        self._data_output_dir = unicode(self._settings.value("data_output_dir", 'true')).lower()=='true'
+        self._data_output_dir = self._settings.value("data_output_dir", True, type=bool)
         return self._data_output_dir
 
     @data_output_dir.setter
@@ -139,7 +139,7 @@ class GeneralSettings(QObject):
 
     @property
     def catalog_data_path(self):
-        self._catalog_data_path = unicode(self._settings.value("catalog_data_path", self.data_path ))
+        self._catalog_data_path = self._settings.value("catalog_data_path", self.data_path, type=unicode)
         return self._catalog_data_path
 
     @catalog_data_path.setter

--- a/scripts/Interface/ui/sans_isis/run_selector_widget.py
+++ b/scripts/Interface/ui/sans_isis/run_selector_widget.py
@@ -46,7 +46,7 @@ class RunSelectorWidget(QtWidgets.QWidget, Ui_RunSelectorWidget):
         return previous_directories
 
     def _previous_or_default_directory(self, settings, default):
-        return settings.value("InPath", default)
+        return settings.value("InPath", default, type=type(default))
 
     def _store_previous_directory(self, settings, path):
         previous_file = QFileInfo(path)


### PR DESCRIPTION
**Description of work.**
This PR fixes an error when attempting to save a project when multiple mantid instances have been opened in quick succession.

A similar error was fixed in #34020 and seems to have done the job.

**To test:**
1. Use the instructions [here](https://developer.mantidproject.org/BuildingWithCMake.html#building-the-installer-package) to create a package for this branch. Install this package locally on your system
1. Open Mantid twice in quick succession (Quadruple click)
2. Go to File -> Save Project in both Mantids
3. There should not be any errors in either of the Mantids.
4. Repeat this process, but this time open File -> Settings.
5. Mess around with other mantid features that involve reading/writing to the QSettings

Fixes #34088

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
