### PR TITLE
Fix Sliceviewer grids cannot be enabled with lineplots

### DIFF
--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/presenters/lineplots.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/presenters/lineplots.py
@@ -161,8 +161,8 @@ class LinePlots:
         # Create a new GridSpec and reposition the existing image Axes
         gs = GridSpec(2, 2, width_ratios=[1, 4], height_ratios=[4, 1], wspace=0.0, hspace=0.0)
         image_axes.set_position(gs[1].get_position(self._fig))
-        image_axes.get_xaxis().set_visible(False)
-        image_axes.get_yaxis().set_visible(False)
+        image_axes.tick_params(labelleft=False, labelbottom=False)
+        image_axes.xaxis.get_label().set_visible(False)
         self._axx = self._fig.add_subplot(gs[3], sharex=image_axes)
         self._axx.yaxis.tick_right()
         self._axy = self._fig.add_subplot(gs[0], sharey=image_axes)
@@ -188,10 +188,8 @@ class LinePlots:
 
         gs = GridSpec(1, 1)
         image_axes.set_position(gs[0].get_position(self._fig))
-        image_axes.get_xaxis().set_visible(True)
-        image_axes.get_yaxis().set_visible(True)
-        image_axes.xaxis.tick_bottom()
-        image_axes.yaxis.tick_left()
+        image_axes.tick_params(labelleft=True, labelbottom=True)
+        image_axes.xaxis.get_label().set_visible(True)
         self._axx, self._axy = None, None
 
         # self.mpl_toolbar.update()  # sync list of axes in navstack

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/presenters/lineplots.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/presenters/lineplots.py
@@ -163,6 +163,7 @@ class LinePlots:
         image_axes.set_position(gs[1].get_position(self._fig))
         image_axes.tick_params(labelleft=False, labelbottom=False)
         image_axes.xaxis.get_label().set_visible(False)
+        image_axes.yaxis.get_label().set_visible(False)
         self._axx = self._fig.add_subplot(gs[3], sharex=image_axes)
         self._axx.yaxis.tick_right()
         self._axy = self._fig.add_subplot(gs[0], sharey=image_axes)
@@ -190,6 +191,7 @@ class LinePlots:
         image_axes.set_position(gs[0].get_position(self._fig))
         image_axes.tick_params(labelleft=True, labelbottom=True)
         image_axes.xaxis.get_label().set_visible(True)
+        image_axes.yaxis.get_label().set_visible(True)
         self._axx, self._axy = None, None
 
         # self.mpl_toolbar.update()  # sync list of axes in navstack

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_sliceviewer_lineplots.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_sliceviewer_lineplots.py
@@ -35,8 +35,9 @@ class LinePlotsTest(unittest.TestCase):
         # check has removed third and second axes in that order
         expected_calls = [call(2), call().remove(), call(1), call().remove()]
         self.image_axes.figure.axes.__getitem__.assert_has_calls(expected_calls, any_order=False)
-        for mock_axis in [self.image_axes.get_xaxis(), self.image_axes.get_yaxis()]:
-            mock_axis.set_visible.assert_called_with(True)
+
+        self.image_axes.xaxis.get_label().set_visible.assert_called_with(True)
+        self.image_axes.tick_params.assert_called_with(labelleft=True, labelbottom=True)
 
     @patch('mantidqt.widgets.sliceviewer.presenters.lineplots.GridSpec')
     def test_construction_adds_line_plots_to_axes(self, mock_gridspec):
@@ -51,8 +52,9 @@ class LinePlotsTest(unittest.TestCase):
         gs.__getitem__.assert_has_calls((call(0), call(1), call(3)), any_order=True)
         self.assertTrue('sharey' in fig.add_subplot.call_args_list[0][1] or 'sharey' in fig.add_subplot.call_args_list[1][1])
         self.assertTrue('sharex' in fig.add_subplot.call_args_list[0][1] or 'sharex' in fig.add_subplot.call_args_list[1][1])
-        for mock_axis in [self.image_axes.get_xaxis(), self.image_axes.get_yaxis()]:
-            mock_axis.set_visible.assert_called_once_with(False)
+
+        self.image_axes.xaxis.get_label().set_visible.assert_called_with(False)
+        self.image_axes.tick_params.assert_called_with(labelleft=False, labelbottom=False)
 
     def test_delete_plot_lines_handles_empty_plots(self):
         plotter = LinePlots(self.image_axes, self.mock_colorbar)
@@ -162,8 +164,9 @@ def _create_mock_axes():
     image_axes.get_ylim.return_value = (-3, 3)
     image_axes.get_xlabel.return_value = 'x'
     image_axes.get_ylabel.return_value = 'y'
-    image_axes.get_xaxis.return_value = MagicMock()
-    image_axes.get_yaxis.return_value = MagicMock()
+    image_axes.xaxis.get_label().set_visible.return_value = MagicMock()
+    image_axes.tick_params.return_value = MagicMock()
+
     return image_axes
 
 

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_sliceviewer_lineplots.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_sliceviewer_lineplots.py
@@ -37,6 +37,7 @@ class LinePlotsTest(unittest.TestCase):
         self.image_axes.figure.axes.__getitem__.assert_has_calls(expected_calls, any_order=False)
 
         self.image_axes.xaxis.get_label().set_visible.assert_called_with(True)
+        self.image_axes.yaxis.get_label().set_visible.assert_called_with(True)
         self.image_axes.tick_params.assert_called_with(labelleft=True, labelbottom=True)
 
     @patch('mantidqt.widgets.sliceviewer.presenters.lineplots.GridSpec')
@@ -53,6 +54,7 @@ class LinePlotsTest(unittest.TestCase):
         self.assertTrue('sharey' in fig.add_subplot.call_args_list[0][1] or 'sharey' in fig.add_subplot.call_args_list[1][1])
         self.assertTrue('sharex' in fig.add_subplot.call_args_list[0][1] or 'sharex' in fig.add_subplot.call_args_list[1][1])
 
+        self.image_axes.xaxis.get_label().set_visible.assert_called_with(False)
         self.image_axes.xaxis.get_label().set_visible.assert_called_with(False)
         self.image_axes.tick_params.assert_called_with(labelleft=False, labelbottom=False)
 
@@ -165,6 +167,7 @@ def _create_mock_axes():
     image_axes.get_xlabel.return_value = 'x'
     image_axes.get_ylabel.return_value = 'y'
     image_axes.xaxis.get_label().set_visible.return_value = MagicMock()
+    image_axes.yaxis.get_label().set_visible.return_value = MagicMock()
     image_axes.tick_params.return_value = MagicMock()
 
     return image_axes


### PR DESCRIPTION
**Description of work.**
As part of a previous PR a regression was introduced that prevented grid lines from showing when line plots were active on SliceViewer.

This was caused by the image axes x and y axis being set `visible = False` entirely. For grid lines to show, the relevant tick markers must be active.

This PR individually hides axis and marker labels, leaving the ticks visible (though in reality obscured by the line plots as intended). 


<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**

Follow the test instructions on the following Issue and PR:
https://github.com/mantidproject/mantid/issues/34083
https://github.com/mantidproject/mantid/pull/33363

Fixes #34083

*This does not require release notes* because its a regression identified in smoke testing not by a user.

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
