### PR TITLE
Fix for Alf view not loading data bug

### DIFF
--- a/qt/widgets/instrumentview/src/InstrumentWidget.cpp
+++ b/qt/widgets/instrumentview/src/InstrumentWidget.cpp
@@ -763,6 +763,10 @@ void InstrumentWidget::updateIntegrationWidget(bool init) {
     } else {
       m_xIntegration->setRange(0, 0);
     }
+  } else {
+    if (minRange > 0 || maxRange > 0) {
+      m_xIntegration->setWholeRange();
+    }
   }
 
   m_xIntegration->setUnits(QString::fromStdString(ws->getAxis(0)->unit()->caption()));


### PR DESCRIPTION
**Description of work.**
Update the maximum range of the integration widget when initializing after data was loaded successfully. This ensures that the instrument image is updated after loading data as it would otherwise remain empty.

**To test:**
Follow steps from original issue and check that the instrument image is updated as soon as the d-spacing bar is displayed (usually takes a few seconds).

Fixes #34085 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
