### PR TITLE
Disabled script and color line options for contour plots

### DIFF
--- a/docs/source/release/v6.4.0/mantidworkbench.rst
+++ b/docs/source/release/v6.4.0/mantidworkbench.rst
@@ -37,6 +37,7 @@ Bugfixes
 - Fixed a bug where trying to save a large project would cause Mantid to crash.
 - Workbench no longer generates an error when you save the ``Figure Options`` on a colour fill plot containing two images of different types (e.g. QuadMesh and Image).
 - Users are now prevented from overwriting previous versions of Mantid if the uninstaller is not present. Some antivirus software deletes the uninstaller. Installing over older versions without the uninstaller can cause Mantid not to function properly and for users to lose data.
+- Removed Line Colour option from the toolbar in Contour Plots as it no longer works.
 
 Instrument Viewer
 -----------------

--- a/qt/applications/workbench/workbench/plotting/toolbar.py
+++ b/qt/applications/workbench/workbench/plotting/toolbar.py
@@ -236,7 +236,8 @@ class WorkbenchNavigationToolbar(MantidNavigationToolbar):
 
         # For contour and wireframe plots, add a toolbar option to change the colour of the lines.
         if figure_type(fig) in [FigureType.Wireframe, FigureType.Contour]:
-            self.set_up_color_selector_toolbar_button(fig)
+            if any(isinstance(col, LineCollection) for col in fig.get_axes()[0].collections):
+                self.set_up_color_selector_toolbar_button(fig)
 
         if figure_type(fig) in [FigureType.Surface, FigureType.Wireframe, FigureType.Mesh]:
             self.adjust_for_3d_plots()

--- a/qt/python/mantidqt/mantidqt/plotting/figuretype.py
+++ b/qt/python/mantidqt/mantidqt/plotting/figuretype.py
@@ -13,7 +13,7 @@ Provides facilities to check plot types
 # third party
 from enum import Enum
 from matplotlib.axes import Axes
-from matplotlib.collections import LineCollection
+from matplotlib.collections import LineCollection, PathCollection
 from matplotlib.container import ErrorbarContainer
 from mpl_toolkits.mplot3d.axes3d import Axes3D
 from mpl_toolkits.mplot3d.art3d import Line3DCollection, Poly3DCollection
@@ -75,6 +75,8 @@ def axes_type(ax):
             axtype = FigureType.Wireframe
     elif len(ax.images) > 0 or len(ax.collections) > 0:
         if any(isinstance(col, LineCollection) for col in ax.collections):
+            axtype = FigureType.Contour
+        elif any(isinstance(col, PathCollection) for col in ax.collections):
             axtype = FigureType.Contour
         else:
             axtype = FigureType.Image

--- a/qt/python/mantidqt/mantidqt/plotting/test/test_figuretype.py
+++ b/qt/python/mantidqt/mantidqt/plotting/test/test_figuretype.py
@@ -10,7 +10,6 @@
 from __future__  import absolute_import
 
 # std imports
-from distutils.version import LooseVersion
 from unittest import TestCase, main
 
 # thirdparty imports
@@ -64,10 +63,7 @@ class FigureTypeTest(TestCase):
         ax = plt.subplot(111)
         ax.imshow([[1], [1]])
         ax.contour([[1, 1], [1, 1]])
-        if LooseVersion("3.5") <= LooseVersion(matplotlib.__version__):
-            self.assertEqual(FigureType.Image, figure_type(ax.figure))
-        else:
-            self.assertEqual(FigureType.Contour, figure_type(ax.figure))
+        self.assertEqual(FigureType.Contour, figure_type(ax.figure))
 
     def test_mesh_plot_returns_mesh(self):
         a = np.array([[[1, 1, 1], [2, 2, 2], [3, 3, 3]]])


### PR DESCRIPTION
**Description of work.**
Contour Plots no longer have LineCollections - instead these have changed to PathCollections. The Script button in the toolbar has not been disabled for Contour plots which fixes the hard crash notes in #34080. However, the line colour selection tool does not work with PathCollections and so it is necessary to disable this toolbar also.

**To test:**

1. Open Mantid
2. Load MAR11060
3. Right click on the Workspace in the ADS and click `Plot->3D->Contour`
4. The plot should load with no error messages and neither the script button nor the line colour button should be available in the toolbar.

Fixes #34080 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
