### PR TITLE
Remove assumption that workspace exists in ADS

### DIFF
--- a/qt/widgets/instrumentview/src/MaskBinsData.cpp
+++ b/qt/widgets/instrumentview/src/MaskBinsData.cpp
@@ -29,7 +29,8 @@ void MaskBinsData::mask(std::shared_ptr<Mantid::API::MatrixWorkspace> &workspace
                    [](const size_t spec) -> int { return static_cast<int>(spec); });
     auto alg = Mantid::API::AlgorithmManager::Instance().create("MaskBins", -1);
     alg->setProperty("InputWorkspace", workspace);
-    alg->setPropertyValue("OutputWorkspace", workspace->getName());
+    alg->getPointerToProperty("OutputWorkspace")->createTemporaryValue();
+    alg->setProperty("OutputWorkspace", workspace);
     alg->setProperty("InputWorkspaceIndexSet", spectraList);
     alg->setProperty("XMin", mask.start);
     alg->setProperty("XMax", mask.end);


### PR DESCRIPTION
When masking bins in instrument viewer, remove an assumption that the workspace exists in the ADS. This may not be the case going forward when instrument viewer is embedded in other widgets. There was a bug described in issue #34094 where this assumption was previously removed, but the output workspace pointer was being set without a name, which caused a crash because it is assumed to have a name by the algorithm. This PR gets around this by setting a temporary name value instead, similarly to the pattern used in the [instrument actor](https://github.com/mantidproject/mantid/blob/main/qt/widgets/instrumentview/src/InstrumentActor.cpp#L277).

Refs #34094

**To test:**

Follow the instructions in the original fix for the crash bug, in PR #34099, and ensure that masking still works.

*This does not require release notes* because **it is an under the hood change**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
