### PR TITLE
DIRECTILL: Fix PANTHER experiment identifier logbook entry

### DIFF
--- a/instrument/PANTHER_Parameters.xml
+++ b/instrument/PANTHER_Parameters.xml
@@ -121,7 +121,7 @@
 			      cps:/entry0/instrument/Detector/detsum//entry0/actual_time:f,
 			      Treg:/entry0/sample/regulation_temperature:f,
 			      Tsamp:/entry0/sample/temperature:f,
-			      subtitle:/entry0/experiment_identifier:f" />
+			      subtitle:/entry0/experiment_identifier:s" />
 		</parameter>
 		<parameter name="logbook_optional_parameters" type="string" visible="false">
 		  <value val="lambda:/entry0/wavelength:f,


### PR DESCRIPTION
**Description of work.**

The experiment identifier has been wrongly marked in the IPF as a float instead of a string, leading to nans instead of useful subtitle when a logbook is generated from data. More fixes are present in a separate PR #33727, which on its own requires user's feedback.

**To test:**

1. Run generate logbook on a directory containing PANTHER data
2. The column titled 'subtitle' should contain meaningful information
<!-- Instructions for testing. -->

*There is no associated issue.*


<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
