### PR TITLE
Fix problems starting up workbench for developers

### DIFF
--- a/mantid-developer-linux.yml
+++ b/mantid-developer-linux.yml
@@ -38,7 +38,7 @@ dependencies:
   - qtpy>=1.9.0
   - requests>=2.25.1
   - scipy>=1.6.2
-  - setuptools=48.0.0 # Pinned purposefully due to incompatibility with later versions
+  - setuptools=47.0.0 # Pinned purposefully due to incompatibility with later versions
   - sphinx >= 4.5.*
   - sphinx_bootstrap_theme<=0.7.1
   - tbb-devel=2020.2.*

--- a/mantid-developer-osx.yml
+++ b/mantid-developer-osx.yml
@@ -38,7 +38,7 @@ dependencies:
   - qtpy>=1.9.0
   - requests>=2.25.1
   - scipy>=1.6.2
-  - setuptools=48.0.0 # Pinned purposefully due to incompatibility with later versions
+  - setuptools=47.0.0 # Pinned purposefully due to incompatibility with later versions
   - sphinx >= 4.5.*
   - sphinx_bootstrap_theme<=0.7.1
   - tbb-devel=2020.2.*

--- a/mantid-developer-win.yml
+++ b/mantid-developer-win.yml
@@ -14,6 +14,7 @@ dependencies:
   - gsl=2.6 # Keep gsl a specific version to reduce changes in our fitting
   - h5py>=2.10.0,<3 # Pinned back due to api differences
   - hdf5=1.10.*
+  - ipykernel<6 # Added as hard dependency only to deal with an issue with ipykernel v6 and incompatibility with qtconsole/workbench, was previously a soft dependency that was allowed to update to v6 by qtconsole, at present it stops workbench from loading.
   - jsoncpp>=1.9.4,<2
   - librdkafka>=1.6.0
   - lib3mf # windows only
@@ -38,7 +39,7 @@ dependencies:
   - qtpy>=1.9.0
   - requests>=2.25.1
   - scipy>=1.6.2
-  - setuptools=48.0.0 # Pinned purposefully due to incompatibility with later versions
+  - setuptools=47.0.0 # Pinned purposefully due to incompatibility with later versions
   - sphinx >= 4.5.*
   - sphinx_bootstrap_theme<=0.7.1
   - tbb-devel=2020.2.*


### PR DESCRIPTION
**Description of work.**

Fixes a couple of problems starting up workbench when using a Conda set up:
- Align pin of ipykernel on Windows with other platforms. This removes `incompatible copy of pydevd already imported` error (followed by long list of files) when starting workbench using PyCharm debug configuration. I think this pin was added to linux\OSX before the Windows .yml file existed and never got replicated in the Windows one
- Pin setuptools at v47.0.0 so that shim files such as workbench-script.pyw use pkgresources instead of importlib - which means that .egg-link files are still read. This resolves a `importlib.metadata.PackageNotFoundError: MantidWorkbench` error when starting workbench using PyCharm run configuration or when running the shim from a command prompt

Note - at some point we probably will want to move setuptools beyond v47.0.0. Since the .egg-link files are deprecated we'll need to rely on the site.py and .pth file mechanism. I think this is probably possible by creating a sitecustomize.py file a bit like I was looking at in this closed PR: https://github.com/mantidproject/mantid/pull/33541 but felt like this needed a bit more time than I have right now

**To test:**

First fix is Windows only. Would be nice to test the second fix on the 3 platforms if possible so feel free to test on one at least and then unassign yourself:

1. update conda environment with the .yml files in this PR by running: `conda env update --file mantid-developer-XXX.yml --prune`
2. Check the setuptools version is 47.0.0 and ipykernel version is <6 by running `conda list`
3. Delete the shim files created by setup tools from your bin directory. On Windows these are workbench.exe and workbench-script.pyw. On Linux there's just a single file called workbench. Regenerate them by building the workbench target
4. (Assuming your Debug configuration in PyCharm uses one of these shim files) Start up Mantid from PyCharm using a Debug configuration and check there are no errors in the Workbench messages log
5. Start up Mantid from PyCharm using a Run configuration and check it starts up OK
6. Run Mantid using the shim file(s) from a command prompt with the conda environment activated

*There is no associated issue.*

*This does not require release notes* because **it fixes problems when running Mantid as a developer from a source code folder set up**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
