### PR TITLE
Activate conda environment when opening command prompt

### DIFF
--- a/buildconfig/windows/command-prompt.bat.in
+++ b/buildconfig/windows/command-prompt.bat.in
@@ -3,8 +3,7 @@
 :: Sets up the environment configured for Mantid by CMake and
 :: starts the appropriate version of Visual Studio
 
-call %~dp0thirdpartypaths.bat
 set VCVARS=@MSVC_VAR_LOCATION@
 set UseEnv=true
 :: Start command line
-%COMSPEC% /k ""%VCVARS%\vcvarsall.bat"" amd64
+%COMSPEC% /k "conda activate %CONDA_BASE_DIR% && "%VCVARS%\vcvarsall.bat" amd64"


### PR DESCRIPTION
**Description of work.**
This PR fixes a problem where you cannot activate a conda environment after opening the `command_prompt.bat` on windows. Also, when you open the `command_prompt.bat` it will now automatically activate your conda environment for you which saves some effort.

**To test:**
1. Build mantid and make sure a new `command_prompt.bat` is created.
1. Open the `command_prompt.bat` in your build folder
2. It should open and activate the correct conda environment

Fixes #34045

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
