### PR TITLE
Fix Lookup Index Being Blank when Transferring From Search Results

### DIFF
--- a/docs/source/release/v6.5.0/Reflectometry/Bugfixes/34127.rst
+++ b/docs/source/release/v6.5.0/Reflectometry/Bugfixes/34127.rst
@@ -1,0 +1,1 @@
+- The lookup index is now set correctly on the ``Runs`` table when transferring from the search results.

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchPresenter.cpp
@@ -276,6 +276,11 @@ void BatchPresenter::notifyRowContentChanged(Row &changedRow) { m_model->updateL
 
 void BatchPresenter::notifyGroupNameChanged(Group &changedGroup) { m_model->updateLookupIndexesOfGroup(changedGroup); }
 
+void BatchPresenter::notifyRunsTransferred() {
+  m_model->updateLookupIndexesOfTable();
+  m_runsPresenter->notifyRowModelChanged();
+}
+
 Mantid::Geometry::Instrument_const_sptr BatchPresenter::instrument() const { return m_mainPresenter->instrument(); }
 
 std::string BatchPresenter::instrumentName() const { return m_mainPresenter->instrumentName(); }

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchPresenter.h
@@ -77,6 +77,7 @@ public:
   void notifyBatchLoaded() override;
   void notifyRowContentChanged(Row &changedRow) override;
   void notifyGroupNameChanged(Group &changedGroup) override;
+  void notifyRunsTransferred() override;
   bool requestClose() const override;
   bool isProcessing() const override;
   bool isAutoreducing() const override;

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/IBatchPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/IBatchPresenter.h
@@ -53,6 +53,7 @@ public:
   virtual void notifyBatchLoaded() = 0;
   virtual void notifyRowContentChanged(Row &changedRow) = 0;
   virtual void notifyGroupNameChanged(Group &changedGroup) = 0;
+  virtual void notifyRunsTransferred() = 0;
 
   /// Data processing check for all groups
   virtual bool isProcessing() const = 0;

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/RunsPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/RunsPresenter.cpp
@@ -118,10 +118,7 @@ void RunsPresenter::notifySearchFailed() {
   }
 }
 
-void RunsPresenter::notifyTransfer() {
-  transfer(m_view->getSelectedSearchRows(), TransferMatch::Any);
-  notifyRowStateChanged();
-}
+void RunsPresenter::notifyTransfer() { transfer(m_view->getSelectedSearchRows(), TransferMatch::Any); }
 
 // Notification from our own view that the instrument should be changed
 void RunsPresenter::notifyChangeInstrumentRequested() {
@@ -456,8 +453,7 @@ void RunsPresenter::transfer(const std::set<int> &rowsToTransfer, const Transfer
     }
 
     tablePresenter()->mergeAdditionalJobs(jobs);
-    m_mainPresenter->notifySettingsChanged();
-    notifyRowModelChanged();
+    m_mainPresenter->notifyRunsTransferred();
   }
 }
 

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/RunsPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/RunsPresenter.cpp
@@ -456,6 +456,8 @@ void RunsPresenter::transfer(const std::set<int> &rowsToTransfer, const Transfer
     }
 
     tablePresenter()->mergeAdditionalJobs(jobs);
+    m_mainPresenter->notifySettingsChanged();
+    notifyRowModelChanged();
   }
 }
 

--- a/qt/scientific_interfaces/ISISReflectometry/test/Batch/BatchPresenterTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Batch/BatchPresenterTest.h
@@ -535,6 +535,14 @@ public:
     presenter->notifyGroupNameChanged(group);
   }
 
+  void testIndexesUpdatedWhenRowsTransferred() {
+    auto mock = makeMockModel();
+    EXPECT_CALL(*mock, updateLookupIndexesOfTable()).Times(1);
+    auto presenter = makePresenter(std::move(mock));
+    EXPECT_CALL(*m_runsPresenter, notifyRowModelChanged()).Times(1);
+    presenter->notifyRunsTransferred();
+  }
+
 private:
   NiceMock<MockBatchView> m_view;
   NiceMock<MockBatchJobManager> *m_jobManager;

--- a/qt/scientific_interfaces/ISISReflectometry/test/ReflMockObjects.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/ReflMockObjects.h
@@ -87,6 +87,7 @@ public:
   MOCK_METHOD0(notifyBatchLoaded, void());
   MOCK_METHOD1(notifyRowContentChanged, void(Row &));
   MOCK_METHOD1(notifyGroupNameChanged, void(Group &));
+  MOCK_METHOD0(notifyRunsTransferred, void());
 
   MOCK_CONST_METHOD0(isProcessing, bool());
   MOCK_CONST_METHOD0(isAutoreducing, bool());

--- a/qt/scientific_interfaces/ISISReflectometry/test/Runs/RunsPresenterTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Runs/RunsPresenterTest.h
@@ -503,6 +503,15 @@ public:
     verifyAndClear();
   }
 
+  void testTransferUpdatesLookupIndexes() {
+    auto presenter = makePresenter();
+    auto expectedJobs = expectGetValidSearchResult();
+    EXPECT_CALL(*m_runsTablePresenter, notifyRowModelChanged()).Times(1);
+    EXPECT_CALL(m_mainPresenter, notifySettingsChanged()).Times(1);
+    presenter.notifyTransfer();
+    verifyAndClear();
+  }
+
   void testChangeInstrumentOnViewNotifiesMainPresenter() {
     auto presenter = makePresenter();
     auto const instrument = std::string("TEST-instrumnet");

--- a/qt/scientific_interfaces/ISISReflectometry/test/Runs/RunsPresenterTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Runs/RunsPresenterTest.h
@@ -506,8 +506,7 @@ public:
   void testTransferUpdatesLookupIndexes() {
     auto presenter = makePresenter();
     auto expectedJobs = expectGetValidSearchResult();
-    EXPECT_CALL(*m_runsTablePresenter, notifyRowModelChanged()).Times(1);
-    EXPECT_CALL(m_mainPresenter, notifySettingsChanged()).Times(1);
+    EXPECT_CALL(m_mainPresenter, notifyRunsTransferred()).Times(1);
     presenter.notifyTransfer();
     verifyAndClear();
   }


### PR DESCRIPTION
**Description of work.**
Tell the GUI to update the model and the view when runs are loaded from the search results. 

**To test:**
1. Boot workbench and load the ISIS Reflectometry interface. 
2. Switch to the experiment settings tab and set up 3 rows, one with an angle of 2.3, one with 0.7 and a title of MAB, and one blank
3. Return to the Runs tab
4. Type 1120015 into the experiment bar and 11_3 in the cycle number
5. select a bunch of runs and click transfer
6. Check that the Lookup Index column of the runs table (at the end) is set appropriately. 

Fixes #34127 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
