### PR TITLE
Draft: LoadEventNexusCrash

### DIFF
--- a/Framework/DataHandling/src/LoadEventNexus.cpp
+++ b/Framework/DataHandling/src/LoadEventNexus.cpp
@@ -466,6 +466,10 @@ std::pair<DateAndTime, DateAndTime> firstLastPulseTimes(::NeXus::File &file, Ker
   auto pulse_times = Mantid::NeXus::NeXusIOHelper::readNexusVector<double>(file, "event_time_zero");
   // Remember to close the entry
   file.closeData();
+  // deal with no events
+  if (pulse_times.empty()) {
+    return std::make_pair(DateAndTime(0.0, 0.0), DateAndTime(0.0, 0.0));
+  }
   // Convert to seconds
   auto conv = Kernel::Units::timeConversionValue(units, "s");
   return std::make_pair(DateAndTime(pulse_times.front() * conv, 0.0) + offset.totalNanoseconds(),
@@ -982,7 +986,9 @@ void LoadEventNexus::loadEvents(API::Progress *const prog, const bool monitors) 
            * from our event_time_zero instead
            */
           auto localFirstLast = firstLastPulseTimes(*m_file, this->g_log);
-          firstPulseT = std::min(firstPulseT, localFirstLast.first);
+          if (localFirstLast.first != DateAndTime(0.0, 0.0)) {
+            firstPulseT = std::min(firstPulseT, localFirstLast.first);
+          }
         }
         // get the number of events
         const std::string prefix = "/" + m_top_entry_name + "/" + entry_name;

--- a/docs/source/release/v6.5.0/Framework/Algorithms/Bugfixes/34141.rst
+++ b/docs/source/release/v6.5.0/Framework/Algorithms/Bugfixes/34141.rst
@@ -1,0 +1,1 @@
+* Fixed bug in :ref:`LoadEventNexus <algm-LoadEventNexus>` that causes Mantid to crash in some limited cases.


### PR DESCRIPTION
**Description of work.**

In some cases, when there are logs in the NeXus files, but no proton charge, LoadEventNexus will try to get the start time by looking at the time of the first event in each bank. This caused a crash if no events were found in a particular bank.  This is ORNL issue https://code.ornl.gov/sns-hfir-scse/sans/sans-backend/-/issues/907

**To test:**

<!-- Instructions for testing. -->
Try to load `/HFIR/CG3/IPTS-18679/shared/Exp440/s6v/All/ConvertedXML/CG3_044000120003.nxs.h5`

*There is no associated issue.*
<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
