### PR TITLE
Set the qt5_dir when conda environment is active for windows

### DIFF
--- a/qt/applications/workbench/CMakeLists.txt
+++ b/qt/applications/workbench/CMakeLists.txt
@@ -95,7 +95,7 @@ if(WIN32)
     set(_qrc_file_contents
         "<!DOCTYPE RCC><RCC version=\"1.0\">\n<qresource prefix=\"/qt/etc\">\n<file alias=\"qt.conf\">qt.conf.${BUILD_TYPE}</file>\n</qresource>\n</RCC>\n"
     )
-    if(CONDA_BUILD)
+    if(CONDA_BUILD OR CONDA_ENV)
       file(TO_CMAKE_PATH $ENV{CONDA_PREFIX}/Library _qt5_dir)
     else()
       set(_qt5_dir ${THIRD_PARTY_DIR}/lib/qt5)


### PR DESCRIPTION
**Description of work.**
This PR fixes an issue where the qt help documentation wouldn't open even after building the `docs-qtassistant` and `docs-qthelp` targets on windows. The problem was that the `qt.conf` file was not being copied into the expected location because the `_qt5_dir` variable is not set correctly when `CONDA_BUILD=False` but `CONDA_ENV=True`.

**To test:**
1. On windows, build the `docs-qtassistant` and `docs-qthelp` targets
2. Open mantid and attempt to open the interface documentation pages via `?`

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
