### PR TITLE
Adjust Fourier Filter used in ISIS total scattering reduction

### DIFF
--- a/Framework/Algorithms/src/PDFFourierTransform2.cpp
+++ b/Framework/Algorithms/src/PDFFourierTransform2.cpp
@@ -399,6 +399,13 @@ void PDFFourierTransform2::exec() {
     */
   }
 
+  // convert to S(Q)-1 or g(R)+1
+  if (direction == FORWARD) {
+    convertToSQMinus1(inputY, inputX, inputDY, inputDX);
+  } else if (direction == BACKWARD) {
+    convertToLittleGRMinus1(inputY, inputX, inputDY, inputDX);
+  }
+
   double inMin, inMax, outDelta, outMax;
   inMin = getProperty("Qmin");
   inMax = getProperty("Qmax");
@@ -422,18 +429,6 @@ void PDFFourierTransform2::exec() {
   size_t Xmax_index = determineMaxIndex(inMax, inputX, inputY);
   g_log.notice() << "Adjusting to data: input min = " << inputX[Xmin_index] << " input max = " << inputX[Xmax_index]
                  << "\n";
-  for (size_t i = 0; i < Xmin_index; ++i)
-    inputY[i] = 0.;
-  for (size_t i = Xmax_index; i < inputY.size(); ++i)
-    // for points ws this will set the y[Xmax_index]=0
-    // This is OK since the integration is based on y value at LH edge of each segment
-    inputY[i] = 0.;
-  // convert to S(Q)-1 or g(R)+1
-  if (direction == FORWARD) {
-    convertToSQMinus1(inputY, inputX, inputDY, inputDX);
-  } else if (direction == BACKWARD) {
-    convertToLittleGRMinus1(inputY, inputX, inputDY, inputDX);
-  }
   // determine r axis for result
   if (isEmpty(outDelta))
     outDelta = M_PI / inputX[Xmax_index];
@@ -478,7 +473,7 @@ void PDFFourierTransform2::exec() {
 
     double fs = 0;
     double error = 0;
-    for (size_t inXIndex = 0; inXIndex < inputX.size() - 1; inXIndex++) {
+    for (size_t inXIndex = Xmin_index; inXIndex < Xmax_index; inXIndex++) {
       const double inX1 = inputX[inXIndex];
       const double inX2 = inputX[inXIndex + 1];
       const double sinx1 = sin(inX1 * outX) - inX1 * outX * cos(inX1 * outX);
@@ -487,7 +482,7 @@ void PDFFourierTransform2::exec() {
 
       // multiply by filter function sin(q*pi/qmax)/(q*pi/qmax)
       if (filter && inX1 != 0) {
-        const double lorchKernel = inX1 * M_PI / inputX.back();
+        const double lorchKernel = inX1 * M_PI / inputX[Xmax_index];
         sinus *= sin(lorchKernel) / lorchKernel;
       }
       fs += sinus * inputY[inXIndex];

--- a/Framework/Algorithms/src/PDFFourierTransform2.cpp
+++ b/Framework/Algorithms/src/PDFFourierTransform2.cpp
@@ -173,8 +173,7 @@ size_t PDFFourierTransform2::determineMinIndex(double min, const std::vector<dou
 
   // get index for the min from the X-range, tightening the range if a partial x bin value is provided
   auto iter = std::lower_bound(X.begin(), X.end(), min);
-  // size_t min_index = std::distance(X.begin(), iter);
-  size_t min_index = 0;
+  size_t min_index = std::distance(X.begin(), iter);
 
   // go to first non-nan value
   auto iter_first_normal =
@@ -199,8 +198,7 @@ size_t PDFFourierTransform2::determineMaxIndex(double max, const std::vector<dou
 
   // get index for the max from the X-range, tightening the range if a partial x bin value is provided
   auto iter = std::upper_bound(X.begin(), X.end(), max) - 1;
-  // size_t max_index = std::distance(X.begin(), iter);
-  size_t max_index = X.size() - 1;
+  size_t max_index = std::distance(X.begin(), iter);
 
   // go to first non-nan value. This works for both histogram (bin edge) data and
   // point data, as the integration proceeds by calculating rectangles between pairs of X values.
@@ -419,33 +417,23 @@ void PDFFourierTransform2::exec() {
     }
   }
 
-  for (size_t i = 0; i < inputX.size(); ++i) {
-    if (inputWS->histogram(0).xMode() == HistogramData::Histogram::XMode::Points) {
-      if ((inputX[i] < inMin) || (inputX[i] > inMax))
-        inputY[i] = 0.;
-    } else {
-      // since the integration is based on LH segment edge we could in theory use this "edge"
-      // logic for points as well but perhaps better to be more verbose here
-      if ((inputX[i] < inMin) && (i < inputY.size()))
-        inputY[i] = 0.;
-      if (inputX[i] > inMax)
-        inputY[i - 1] = 0.;
-    }
-  }
-
+  // determine input-range
+  size_t Xmin_index = determineMinIndex(inMin, inputX, inputY);
+  size_t Xmax_index = determineMaxIndex(inMax, inputX, inputY);
+  g_log.notice() << "Adjusting to data: input min = " << inputX[Xmin_index] << " input max = " << inputX[Xmax_index]
+                 << "\n";
+  for (size_t i = 0; i < Xmin_index; ++i)
+    inputY[i] = 0.;
+  for (size_t i = Xmax_index; i < inputY.size(); ++i)
+    // for points ws this will set the y[Xmax_index]=0
+    // This is OK since the integration is based on y value at LH edge of each segment
+    inputY[i] = 0.;
   // convert to S(Q)-1 or g(R)+1
   if (direction == FORWARD) {
     convertToSQMinus1(inputY, inputX, inputDY, inputDX);
   } else if (direction == BACKWARD) {
     convertToLittleGRMinus1(inputY, inputX, inputDY, inputDX);
   }
-
-  // determine input-range
-  size_t Xmin_index = determineMinIndex(inMin, inputX, inputY);
-  size_t Xmax_index = determineMaxIndex(inMax, inputX, inputY);
-  g_log.notice() << "Adjusting to data: input min = " << inputX[Xmin_index] << " input max = " << inputX[Xmax_index]
-                 << "\n";
-
   // determine r axis for result
   if (isEmpty(outDelta))
     outDelta = M_PI / inputX[Xmax_index];
@@ -490,7 +478,7 @@ void PDFFourierTransform2::exec() {
 
     double fs = 0;
     double error = 0;
-    for (size_t inXIndex = Xmin_index; inXIndex < Xmax_index; inXIndex++) {
+    for (size_t inXIndex = 0; inXIndex < inputX.size() - 1; inXIndex++) {
       const double inX1 = inputX[inXIndex];
       const double inX2 = inputX[inXIndex + 1];
       const double sinx1 = sin(inX1 * outX) - inX1 * outX * cos(inX1 * outX);

--- a/Testing/SystemTests/tests/framework/ISIS_PowderPolarisTest.py
+++ b/Testing/SystemTests/tests/framework/ISIS_PowderPolarisTest.py
@@ -246,22 +246,28 @@ class TotalScatteringPdfTypeTest(systemtesting.MantidSystemTest):
         self.assertAlmostEqual(self.pdf_output.dataY(0)[37], 1.0207, places=3)
 
 
-class TotalScatteringFilterTest(systemtesting.MantidSystemTest):
+class TotalScatteringFourierFilterTest(systemtesting.MantidSystemTest):
 
     pdf_output = None
+    r_min = 1.0
 
     def runTest(self):
         setup_mantid_paths()
         # Load Focused ws
         mantid.LoadNexus(Filename=total_scattering_input_file, OutputWorkspace='98533-ResultTOF')
         q_lims = np.array([2.5, 3, 4, 6, 7, 3.5, 5, 7, 11, 40]).reshape((2, 5))
-        self.pdf_output = run_total_scattering('98533', True, q_lims=q_lims, freq_params=[1])
+        self.pdf_output = run_total_scattering('98533', True, q_lims=q_lims, pdf_type="g(r)", freq_params=[self.r_min])
 
     def validate(self):
         # Whilst total scattering is in development, the validation will avoid using reference files as they will have
         # to be updated very frequently. In the meantime, the expected peak in the PDF at ~3.9 Angstrom will be checked.
         # After rebin this is at X index 37
-        self.assertAlmostEqual(self.pdf_output.dataY(0)[37], 0.90692, places=3)
+        x_data = self.pdf_output.dataX(0)
+        y_data = self.pdf_output.dataY(0)
+        idx_to_check_filter = 5
+        self.assertTrue(x_data[idx_to_check_filter] < self.r_min)
+        self.assertAlmostEqual(y_data[idx_to_check_filter], 0.0, places=1)
+        self.assertAlmostEqual(y_data[37], 1.0187, places=3)
 
 
 class TotalScatteringLorchFilterTest(systemtesting.MantidSystemTest):

--- a/docs/source/release/v6.5.0/Diffraction/Powder/Bugfixes/32920_FixProblemWithFourierFilter.rst
+++ b/docs/source/release/v6.5.0/Diffraction/Powder/Bugfixes/32920_FixProblemWithFourierFilter.rst
@@ -1,0 +1,1 @@
+- Change Fourier Filter applied during ISIS total scattering reduction so that g(r)=0 instead of g(r)-1=0

--- a/scripts/Diffraction/isis_powder/polaris_routines/polaris_algs.py
+++ b/scripts/Diffraction/isis_powder/polaris_routines/polaris_algs.py
@@ -113,13 +113,13 @@ def generate_ts_pdf(run_number, focus_file_path, merge_banks=False, q_lims=None,
         q_min, q_max = _load_qlims(q_lims)
         merged_ws = mantid.MatchAndMergeWorkspaces(InputWorkspaces=focused_ws, XMin=q_min, XMax=q_max,
                                                    CalculateScale=False)
-        fast_fourier_filter(merged_ws, freq_params=freq_params)
+        fast_fourier_filter(merged_ws, rho0=sample_details.material_object.crystal_density, freq_params=freq_params)
         pdf_output = mantid.PDFFourierTransform(Inputworkspace="merged_ws", InputSofQType="S(Q)-1", PDFType=pdf_type,
                                                 Filter=lorch_filter, DeltaR=delta_r,
                                                 rho0=sample_details.material_object.crystal_density)
     else:
         for ws in focused_ws:
-            fast_fourier_filter(ws, freq_params=freq_params)
+            fast_fourier_filter(ws, rho0=sample_details.material_object.crystal_density, freq_params=freq_params)
         pdf_output = mantid.PDFFourierTransform(Inputworkspace='focused_ws', InputSofQType="S(Q)-1", PDFType=pdf_type,
                                                 Filter=lorch_filter, DeltaR=delta_r,
                                                 rho0=sample_details.material_object.crystal_density)
@@ -208,11 +208,11 @@ def _determine_chopper_mode(ws):
         raise ValueError("Chopper frequency not in log data. Please specify a chopper mode")
 
 
-def fast_fourier_filter(ws, freq_params=None):
+def fast_fourier_filter(ws, rho0, freq_params=None):
     if freq_params:
-        x_range = ws.dataX(0)
-        q_max = x_range[-1]
-        q_delta = (x_range[1] - x_range[0])
+        q_data = ws.dataX(0)
+        q_max = q_data[-1]
+        q_delta = (q_data[1] - q_data[0])
         r_min = freq_params[0]
         # If no maximum r is given a high r_max prevents loss of detail on the output.
         if len(freq_params) > 1:
@@ -220,8 +220,15 @@ def fast_fourier_filter(ws, freq_params=None):
         else:
             r_max = 1000
         ws_name = str(ws)
-        mantid.PDFFourierTransform(Inputworkspace=ws_name, OutputWorkspace=ws_name, SofQType="S(Q)-1", PDFType="G(r)",
-                                   Filter=True, DeltaR=0.01, Rmax=r_max, Direction='Forward')
-        mantid.PDFFourierTransform(Inputworkspace=ws_name, OutputWorkspace=ws_name, SofQType="S(Q)-1", PDFType="G(r)",
-                                   Filter=True, Qmax=q_max, deltaQ=q_delta, Rmin=r_min, Rmax=r_max,
-                                   Direction='Backward')
+        mantid.PDFFourierTransform(Inputworkspace=ws_name, OutputWorkspace=ws_name, SofQType="S(Q)-1", PDFType="g(r)",
+                                   Filter=True, DeltaR=0.01, Rmax=r_max, Direction='Forward', rho0=rho0)
+        # apply filter so that g(r)=0 for r < rmin => RDF(r)=0, G(r)~-r
+        ws = mantid.mtd[ws_name]
+        r_data = ws.dataX(0)
+        y_data = ws.dataY(0)
+        for i in range(len(r_data)):
+            if r_data[i] < r_min and i < len(y_data): # ws will be points but cope if it's bin edges
+                y_data[i] = 0.
+        mantid.PDFFourierTransform(Inputworkspace=ws_name, OutputWorkspace=ws_name, SofQType="S(Q)-1", PDFType="g(r)",
+                                   Filter=True, Qmax=q_max, deltaQ=q_delta, Rmax=r_max,
+                                   Direction='Backward', rho0=rho0)


### PR DESCRIPTION
**Description of work.**

Problem raised by Helen Playford. The action of the Fourier Filter option in the POLARIS total scattering scripts has been changed so that it sets g(r)=0 in the low r region instead of setting g(r)-1=0. To achieve this the filter no longer relies on the Rmin property of the PDFFourierTransform algorithm and it is instead implemented in the POLARIS python script.

A problem has also been fixed where a custom crystal density caused the filter to malfunction (it was using the default crystal density in all cases)

**To test:**

Unzip these files somewhere and update the script below with the path. Also update the paths in the file polaris_config_example.yaml
[PR34144Files.zip](https://github.com/mantidproject/mantid/files/8968124/PR34144Files.zip)
Run the following script and observe that the spectrum in the workspace 98533_pdf_R is approximately zero in the region r<1.0. You'll need to have access to the ISIS data archive:
```
# import mantid algorithms, numpy and matplotlib
from mantid.simpleapi import *
import matplotlib.pyplot as plt
import numpy as np

from isis_powder import polaris, SampleDetails

config_file_path = r"C:\Total Scattering\polaris_config_example.yaml"
polaris = polaris.Polaris(config_file=config_file_path, user_name="test", mode="PDF")

sample_details = SampleDetails(height=4.0, radius=0.2985, center=[0, 0, 0], shape='cylinder')
sample_details.set_material(chemical_formula='Si', number_density=2.0, crystal_density=1.0)
polaris.set_sample_details(sample=sample_details)

polaris.create_vanadium(first_cycle_run_no="98532", multiple_scattering=False)
polaris.focus(run_number="98533", input_mode='Summed')

# q_lim from script on https://github.com/mantidproject/mantid/pull/28447
q_lim = [[2.5, 3, 4, 6, 7], [3.5, 5, 7, 11, 40]]
polaris.create_total_scattering_pdf(run_number="98533", merge_banks=True,q_lims=q_lim, 
                                    freq_params=[1.0], pdf_type="g(r)")
```

Change pdf_type to G(r) (ie capital G) in the final line. The low r region should now be downward sloping.

Fixes #32920.



---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
