### PR TITLE
Fixing logic for V1/V2 versions of IntegrateEllipsoids

### DIFF
--- a/Framework/MDAlgorithms/src/IntegrateEllipsoids.cpp
+++ b/Framework/MDAlgorithms/src/IntegrateEllipsoids.cpp
@@ -60,13 +60,14 @@ void IntegrateEllipsoids::exec() {
   Algorithm_sptr alg;
 
   // detect which algo to run
-  if ((isIntegrateInHKL || isGetUBFromPeaksWorkspace) && indexCount != 0 && !shareBackground) {
+  if ((isIntegrateInHKL || isGetUBFromPeaksWorkspace) || (indexCount != 0 && !shareBackground)) {
     // v1
     alg = std::dynamic_pointer_cast<Algorithm>(createChildAlgorithm("IntegrateEllipsoids", -1., -1., true, 1));
   } else {
     // v2
     alg = std::dynamic_pointer_cast<Algorithm>(createChildAlgorithm("IntegrateEllipsoids", -1., -1., true, 2));
   }
+
   // forward properties to algo
   alg->copyPropertiesFrom(*this);
   // run correct algo and return results

--- a/Framework/MDAlgorithms/src/IntegrateEllipsoids.cpp
+++ b/Framework/MDAlgorithms/src/IntegrateEllipsoids.cpp
@@ -60,7 +60,7 @@ void IntegrateEllipsoids::exec() {
   Algorithm_sptr alg;
 
   // detect which algo to run
-  if ((isIntegrateInHKL || isGetUBFromPeaksWorkspace) && indexCount > 0 && !shareBackground) {
+  if ((isIntegrateInHKL || isGetUBFromPeaksWorkspace) && indexCount != 0 && !shareBackground) {
     // v1
     alg = std::dynamic_pointer_cast<Algorithm>(createChildAlgorithm("IntegrateEllipsoids", -1., -1., true, 1));
   } else {

--- a/Framework/MDAlgorithms/src/IntegrateEllipsoids.cpp
+++ b/Framework/MDAlgorithms/src/IntegrateEllipsoids.cpp
@@ -42,7 +42,7 @@ int getIndexCount(PeaksWorkspace_sptr peakWorkspace) {
   const int numPeaks = peakWorkspace->getNumberPeaks();
   for (int i = 0; i < numPeaks; ++i) {
     const auto peak = peakWorkspace->getPeak(i);
-    if (peak.getHKL().norm2() > 0)
+    if (peak.getIntHKL().norm2() > 0 || peak.getIntMNP().norm2() > 0)
       indexCount += 1;
   }
   return indexCount;
@@ -60,7 +60,7 @@ void IntegrateEllipsoids::exec() {
   Algorithm_sptr alg;
 
   // detect which algo to run
-  if ((isIntegrateInHKL || isGetUBFromPeaksWorkspace) || (indexCount != 0 && !shareBackground)) {
+  if (isIntegrateInHKL || isGetUBFromPeaksWorkspace || (indexCount > 0 && !shareBackground)) {
     // v1
     alg = std::dynamic_pointer_cast<Algorithm>(createChildAlgorithm("IntegrateEllipsoids", -1., -1., true, 1));
   } else {

--- a/Framework/MDAlgorithms/src/IntegrateEllipsoids.cpp
+++ b/Framework/MDAlgorithms/src/IntegrateEllipsoids.cpp
@@ -42,7 +42,18 @@ int getIndexCount(PeaksWorkspace_sptr peakWorkspace) {
   const int numPeaks = peakWorkspace->getNumberPeaks();
   for (int i = 0; i < numPeaks; ++i) {
     const auto peak = peakWorkspace->getPeak(i);
-    if (peak.getIntHKL().norm2() > 0 || peak.getIntMNP().norm2() > 0)
+    if (peak.getIntHKL().norm2() > 0)
+      indexCount += 1;
+  }
+  return indexCount;
+}
+
+int getSatelliteIndexCount(PeaksWorkspace_sptr peakWorkspace) {
+  int indexCount = 0;
+  const int numPeaks = peakWorkspace->getNumberPeaks();
+  for (int i = 0; i < numPeaks; ++i) {
+    const auto peak = peakWorkspace->getPeak(i);
+    if (peak.getIntMNP().norm2() > 0)
       indexCount += 1;
   }
   return indexCount;
@@ -56,11 +67,13 @@ void IntegrateEllipsoids::exec() {
   const PeaksWorkspace_sptr peakWorkspace = getProperty("PeaksWorkspace");
 
   const int indexCount = getIndexCount(peakWorkspace);
+  const int satelliteIndexCount = getSatelliteIndexCount(peakWorkspace);
 
   Algorithm_sptr alg;
 
   // detect which algo to run
-  if (isIntegrateInHKL || isGetUBFromPeaksWorkspace || (indexCount > 0 && !shareBackground)) {
+  if (isIntegrateInHKL || isGetUBFromPeaksWorkspace ||
+      (indexCount > 0 && satelliteIndexCount == 0 && !shareBackground)) {
     // v1
     alg = std::dynamic_pointer_cast<Algorithm>(createChildAlgorithm("IntegrateEllipsoids", -1., -1., true, 1));
   } else {

--- a/Framework/MDAlgorithms/src/IntegrateEllipsoidsV2.cpp
+++ b/Framework/MDAlgorithms/src/IntegrateEllipsoidsV2.cpp
@@ -327,7 +327,15 @@ void IntegrateEllipsoidsV2::exec() {
   std::vector<Peak> &peaks = peak_ws->getPeaks();
   size_t n_peaks = peak_ws->getNumberPeaks();
   SlimEvents qList;
-  // Note: we skip un-indexed peaks
+
+  // get the index count
+  int indexCount = 0;
+  for (size_t i = 0; i < n_peaks; ++i) {
+    if (peaks[i].getHKL().norm2() > 0)
+      indexCount += 1;
+  }
+
+  // Note: we skip un-indexed peaks if index count greater than zero
   for (size_t i = 0; i < n_peaks; i++) {
     // check if peak is satellite peak
     const bool isSatellitePeak = (peaks[i].getIntMNP().norm2() > 0);
@@ -340,7 +348,7 @@ void IntegrateEllipsoidsV2::exec() {
     // add peak Q to list
     V3D hkl(peaks[i].getIntHKL());
     // use tolerance == 1 to just check for (0,0,0,0,0,0)
-    if (Geometry::IndexingUtils::ValidIndex(hkl, 1.0)) {
+    if (Geometry::IndexingUtils::ValidIndex(hkl, 1.0) || indexCount == 0) {
       qList.emplace_back(std::pair<double, double>(1., 1.), peak_q);
     }
   }

--- a/Framework/MDAlgorithms/src/IntegrateEllipsoidsV2.cpp
+++ b/Framework/MDAlgorithms/src/IntegrateEllipsoidsV2.cpp
@@ -328,13 +328,6 @@ void IntegrateEllipsoidsV2::exec() {
   size_t n_peaks = peak_ws->getNumberPeaks();
   SlimEvents qList;
 
-  // get the index count
-  int indexCount = 0;
-  for (size_t i = 0; i < n_peaks; ++i) {
-    if (peaks[i].getHKL().norm2() > 0)
-      indexCount += 1;
-  }
-
   // Note: we skip un-indexed peaks if index count greater than zero
   for (size_t i = 0; i < n_peaks; i++) {
     // check if peak is satellite peak
@@ -346,11 +339,7 @@ void IntegrateEllipsoidsV2::exec() {
       continue; // skip this peak
     }
     // add peak Q to list
-    V3D hkl(peaks[i].getIntHKL());
-    // use tolerance == 1 to just check for (0,0,0,0,0,0)
-    if (Geometry::IndexingUtils::ValidIndex(hkl, 1.0) || indexCount == 0) {
-      qList.emplace_back(std::pair<double, double>(1., 1.), peak_q);
-    }
+    qList.emplace_back(std::pair<double, double>(1., 1.), peak_q);
   }
 
   // Peak vectors

--- a/Framework/MDAlgorithms/test/IntegrateEllipsoidsTest.h
+++ b/Framework/MDAlgorithms/test/IntegrateEllipsoidsTest.h
@@ -669,13 +669,13 @@ public:
     AnalysisDataService::Instance().remove(peaksWS->getName());
   }
 
-  void test_execution_V1_Path() {
+  void test_execution_V1_Path_integrate_HKL() {
 
     const std::vector<V3D> peaksHKL = {V3D(0.15, 1.85, -1.0), V3D(1.0, 4.0, -3.0), V3D(1.0, 5.0, -3.0)};
 
     // creates the peak workspace, sets UB, and indexes them
     PeaksWorkspace_sptr peaksWS = createPeaksForSatelliteTests(peaksHKL);
-    // integrate with sharing background region to satellite peaks
+
     IntegrateEllipsoids alg;
     TS_ASSERT_THROWS_NOTHING(alg.initialize());
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("InputWorkspace", m_satelliteEventWS));
@@ -687,6 +687,8 @@ public:
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("BackgroundOuterSize", 0.26));
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("AdaptiveQMultiplier", 0.01));
     TS_ASSERT_THROWS_NOTHING(alg.setProperty("AdaptiveQBackground", true));
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("GetUBFromPeaksWorkspace", true));
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("IntegrateInHKL", true));
 
     TS_ASSERT_THROWS_NOTHING(alg.execute());
     TS_ASSERT_THROWS_NOTHING(alg.isExecuted());

--- a/Testing/SystemTests/tests/framework/IntegrateEllipsoidsTest.py
+++ b/Testing/SystemTests/tests/framework/IntegrateEllipsoidsTest.py
@@ -7,7 +7,7 @@ from numpy.testing import assert_allclose
 from systemtesting import MantidSystemTest
 from mantid.api import mtd
 from mantid.kernel import V3D
-from mantid.simpleapi import (LoadNexus, IndexPeaks, IntegrateEllipsoids)
+from mantid.simpleapi import (LoadNexus, IntegrateEllipsoids)
 
 
 class IntegrateEllipsoidsTest(MantidSystemTest):
@@ -40,7 +40,9 @@ class IntegrateEllipsoidsTest(MantidSystemTest):
         # intensities for the first two peaks
         assert_allclose(table.column('Intens')[0:2], [938, 13936], atol=1.0)
 
-        IndexPeaks(PeaksWorkspace='peaks_output', Tolerance=0.0)
+        for pk in range(mtd['peaks_input'].getNumberPeaks()):
+            mtd['peaks_input'].getPeak(pk).setHKL(0,0,0)
+
         IntegrateEllipsoids(InputWorkspace='events',
                             PeaksWorkspace='peaks_input',
                             OutputWorkspace='peaks_output',

--- a/Testing/SystemTests/tests/framework/IntegrateEllipsoidsTest.py
+++ b/Testing/SystemTests/tests/framework/IntegrateEllipsoidsTest.py
@@ -6,6 +6,7 @@ from numpy.testing import assert_allclose
 
 from systemtesting import MantidSystemTest
 from mantid.api import mtd
+from mantid.kernel import V3D
 from mantid.simpleapi import (LoadNexus, IntegrateEllipsoids)
 
 
@@ -20,6 +21,7 @@ class IntegrateEllipsoidsTest(MantidSystemTest):
         table corresponds to satellite peak HKL=(1.5, 1.5,0) and main peak (1,1,0)"""
         LoadNexus(Filename='TOPAZ_39037_bank29.nxs', OutputWorkspace='events')
         LoadNexus(Filename='TOPAZ_39037_peaks_short.nxs', OutputWorkspace='peaks_input')
+        mtd['peaks_input'].getPeak(0).setIntMNP(V3D(1,0,0))
         IntegrateEllipsoids(InputWorkspace='events',
                             PeaksWorkspace='peaks_input',
                             OutputWorkspace='peaks_output',

--- a/docs/source/release/v6.5.0/Diffraction/Single_Crystal/Bugfixes/34147.rst
+++ b/docs/source/release/v6.5.0/Diffraction/Single_Crystal/Bugfixes/34147.rst
@@ -1,0 +1,2 @@
+* Fixed logic issues in :ref:`IntegrateEllipsoids <algm-IntegrateEllipsoids>` that prevents the integration of satellite peaks.
+


### PR DESCRIPTION
**Description of work.**

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

Fix a logic test where V1 of the algorithm `IntegrateEllipsoids` was not being run in some cases. Two new unit tests are added to cover the logic of V1 and V2. In the past, this test would execute V2 and also not integrate certain unindexed peaks.

**To test:**

1. Run the following script
2. Check that V1/V2 of `IntegrateEllipsoids` is run by looking at the algorithm history for each corresponding workspace

```python
# import mantid algorithms, numpy and matplotlib
from mantid.simpleapi import *
import matplotlib.pyplot as plt
import numpy as np

Load(Filename='/SNS/TOPAZ/IPTS-23996/nexus/TOPAZ_36079.nxs.h5', OutputWorkspace='TOPAZ_36079.nxs_event', FilterByTofMin=500, FilterByTofMax=16666)
FilterBadPulses(InputWorkspace='TOPAZ_36079.nxs_event', OutputWorkspace='TOPAZ_36079.nxs_event', LowerCutoff=25)
LoadIsawDetCal(InputWorkspace='TOPAZ_36079.nxs_event', Filename='/SNS/TOPAZ/IPTS-23996/shared/calibration/TOPAZ_2020A.DetCal')
ConvertToMD(InputWorkspace='TOPAZ_36079.nxs_event', QDimensions='Q3D', dEAnalysisMode='Elastic', Q3DFrames='Q_sample', LorentzCorrection=True, OutputWorkspace='TOPAZ_36079.nxs_md', MinValues='-12,-12,-12', MaxValues='12,12,12', SplitInto='2', SplitThreshold=50, MaxRecursionDepth=13, MinRecursionDepth=7)

# Find peaks
FindPeaksMD(InputWorkspace='TOPAZ_36079.nxs_md', 
    PeakDistanceThreshold=0.12025531914893617, 
    MaxPeaks=1200, 
    DensityThresholdFactor=100,
    EdgePixels=19,
    OutputWorkspace='TOPAZ_36079.nxs_peaks')
FindUBUsingFFT(PeaksWorkspace='TOPAZ_36079.nxs_peaks', MinD=3, MaxD=7, Tolerance=0.12)
IndexPeaks(PeaksWorkspace='TOPAZ_36079.nxs_peaks', Tolerance=0.12, RoundHKLs=False)
ShowPossibleCells(PeaksWorkspace='TOPAZ_36079.nxs_peaks', MaxScalarError=0.5, BestOnly=False, AllowPermutations=False)
SelectCellOfType(PeaksWorkspace='TOPAZ_36079.nxs_peaks', CellType='Hexagonal', Apply=True, TransformationMatrix='0,1,0,0,0,1,1,0,0')
OptimizeLatticeForCellType(PeaksWorkspace='TOPAZ_36079.nxs_peaks', CellType='Hexagonal', Apply=True, Tolerance=0.06, EdgePixels=19, OutputDirectory='/SNS/TOPAZ/shared/test/Integrate_satellite_peaks')

# Integrate all peaks first
IndexPeaks(PeaksWorkspace='TOPAZ_36079.nxs_peaks', Tolerance=1, RoundHKLs=False)

CopySample(InputWorkspace='TOPAZ_36079.nxs_peaks',
           OutputWorkspace='TOPAZ_36079.nxs_event',
           CopyName=False, CopyMaterial=False,
           CopyEnvironment=False,
           CopyShape=False)

IndexPeaks(PeaksWorkspace='TOPAZ_36079.nxs_peaks', Tolerance=0.06, ToleranceForSatellite=0.05, 
    RoundHKLs=False, 
    ModVector1='0.125,0,0', 
    ModVector2='0,0.125,0', 
    ModVector3='-0.125,0.125,0', 
    MaxOrder=1, 
    CrossTerms=False, 
    SaveModulationInfo=True)

FindUBUsingIndexedPeaks(PeaksWorkspace='TOPAZ_36079.nxs_peaks', 
                        Tolerance=0.05,
                        ToleranceForSatellite=0.05)

CopySample(InputWorkspace='TOPAZ_36079.nxs_peaks', 
           OutputWorkspace='TOPAZ_36079.nxs_event',
           CopyName=False, CopyMaterial=False,
           CopyEnvironment=False,
           CopyShape=False)

IntegrateEllipsoids(InputWorkspace='TOPAZ_36079.nxs_event', PeaksWorkspace='TOPAZ_36079.nxs_peaks', 
    RegionRadius=0.3, SpecifySize=True, 
    PeakSize=0.085, BackgroundInnerSize=0.086, 
    BackgroundOuterSize=0.11, 
    OutputWorkspace='TOPAZ_36079.nxs_peaks_v1', CutoffIsigI=5, 
    UseOnePercentBackgroundCorrection=False, 
    SatelliteRegionRadius=0.10, 
    SatellitePeakSize=0.065, 
    ShareBackground=False,
    GetUBFromPeaksWorkspace=True,
    SatelliteBackgroundInnerSize=0.08, 
    SatelliteBackgroundOuterSize=0.10)
    
IntegrateEllipsoids(InputWorkspace='TOPAZ_36079.nxs_event', PeaksWorkspace='TOPAZ_36079.nxs_peaks', 
    RegionRadius=0.3, SpecifySize=True, 
    PeakSize=0.085, BackgroundInnerSize=0.086, 
    BackgroundOuterSize=0.11, 
    OutputWorkspace='TOPAZ_36079.nxs_peaks_v2', CutoffIsigI=5, 
    UseOnePercentBackgroundCorrection=False, 
    SatelliteRegionRadius=0.10, 
    SatellitePeakSize=0.065, 
    ShareBackground=False,
    GetUBFromPeaksWorkspace=False,
    SatelliteBackgroundInnerSize=0.08, 
    SatelliteBackgroundOuterSize=0.10)
```

<!-- Instructions for testing. -->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
