### PR TITLE
Fix windows conversion warnings between int and size_t

### DIFF
--- a/qt/widgets/common/src/FunctionModel.cpp
+++ b/qt/widgets/common/src/FunctionModel.cpp
@@ -498,8 +498,9 @@ void FunctionModel::checkNumberOfDomains(const QList<FunctionModelDataset> &data
 }
 
 int FunctionModel::numberOfDomains(const QList<FunctionModelDataset> &datasets) const {
-  return std::accumulate(datasets.cbegin(), datasets.cend(), 0,
-                         [](size_t lhs, const auto &dataset) { return lhs + dataset.numberOfSpectra(); });
+  return std::accumulate(datasets.cbegin(), datasets.cend(), 0, [](int lhs, const auto &dataset) {
+    return lhs + static_cast<int>(dataset.numberOfSpectra());
+  });
 }
 
 /// Check a domain/function index to be in range.

--- a/qt/widgets/instrumentview/src/PanelsSurface.cpp
+++ b/qt/widgets/instrumentview/src/PanelsSurface.cpp
@@ -174,9 +174,9 @@ void setBankVisited(const ComponentInfo &componentInfo, size_t bankIndex, std::v
 }
 
 size_t findNumDetectors(const ComponentInfo &componentInfo, const std::vector<size_t> &components) {
-  return std::accumulate(components.cbegin(), components.cend(), 0, [&componentInfo](size_t lhs, const auto &comp) {
-    return componentInfo.isDetector(comp) ? lhs + 1 : lhs;
-  });
+  return std::accumulate(
+      components.cbegin(), components.cend(), std::size_t{0u},
+      [&componentInfo](size_t lhs, const auto &comp) { return componentInfo.isDetector(comp) ? lhs + 1u : lhs; });
 }
 
 void initialisePolygonWithTransformedBoundingBoxPoints(QPolygonF &panelPolygon, const ComponentInfo &componentInfo,


### PR DESCRIPTION
**Description of work.**
Fixes a conversion warning seen on recent windows builds. These warnings are preventing the windows builds from passing, so I've marked this as high priority.

**To test:**
Code review and make sure the windows job passes.

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
