### PR TITLE
Activate the mantid developer conda environment

### DIFF
--- a/buildconfig/windows/command-prompt.bat.in
+++ b/buildconfig/windows/command-prompt.bat.in
@@ -3,7 +3,8 @@
 :: Sets up the environment configured for Mantid by CMake and
 :: starts the appropriate version of Visual Studio
 
+set CONDA_ENV_DIR=@CONDA_BASE_DIR@
 set VCVARS=@MSVC_VAR_LOCATION@
 set UseEnv=true
 :: Start command line
-%COMSPEC% /k "conda activate %CONDA_BASE_DIR% && "%VCVARS%\vcvarsall.bat" amd64"
+%COMSPEC% /k "conda activate %CONDA_ENV_DIR% && "%VCVARS%\vcvarsall.bat" amd64"

--- a/buildconfig/windows/command-prompt.bat.in
+++ b/buildconfig/windows/command-prompt.bat.in
@@ -6,6 +6,7 @@ set UseEnv=true
 
 setlocal
 set CONDA_ENV_DIR=@CONDA_BASE_DIR@
+set PYTHONPATH=@CMAKE_LIBRARY_OUTPUT_DIRECTORY@
 set VCVARS=@MSVC_VAR_LOCATION@
 
 :: Start command line

--- a/buildconfig/windows/command-prompt.bat.in
+++ b/buildconfig/windows/command-prompt.bat.in
@@ -2,9 +2,12 @@
 ::
 :: Sets up the environment configured for Mantid by CMake and
 :: starts the appropriate version of Visual Studio
+set UseEnv=true
 
+setlocal
 set CONDA_ENV_DIR=@CONDA_BASE_DIR@
 set VCVARS=@MSVC_VAR_LOCATION@
-set UseEnv=true
+
 :: Start command line
 %COMSPEC% /k "conda activate %CONDA_ENV_DIR% && "%VCVARS%\vcvarsall.bat" amd64"
+endlocal


### PR DESCRIPTION
**Description of work.**
This PR ensures the mantid developer conda environment (not the base environment) gets activated when opening the `command_prompt.bat` file.

It also sets the `PYTHONPATH` environment variable to a more reasonable value rather than a blank string. This `PYTHONPATH` should work fine for Ninja-generated builds as it is set to the bin directory, however it will not work for Visual Studio generated builds because they require a configuration on the end of the bin directory. This change still makes it easier to set the correct `PYTHONPATH` for VS builds as you can just do `set PYTHONPATH=%PYTHONPATH%/<config>` rather than having to specify a full path.

**To test:**
Open the `command_prompt.bat` file and make sure the relevant 'mantid developer' conda environment is activated.

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
