### PR TITLE
Fix Jenkins pipeline stage for updating conda-recipes

### DIFF
--- a/buildconfig/Jenkins/Conda/nightly_build_and_deploy.jenkinsfile
+++ b/buildconfig/Jenkins/Conda/nightly_build_and_deploy.jenkinsfile
@@ -42,7 +42,7 @@ def package_options() {
 def recipe_update_options() {
   recipe_options=""
   if(PACKAGE_SUFFIX.trim() == '') {
-    recipe_options+=" --release_version"
+    recipe_options+=" --release-version"
   }
   return recipe_options
 }

--- a/buildconfig/Jenkins/Conda/nightly_build_and_deploy.jenkinsfile
+++ b/buildconfig/Jenkins/Conda/nightly_build_and_deploy.jenkinsfile
@@ -132,9 +132,12 @@ pipeline {
         environment name: 'PUBLISH_PACKAGES', value: 'true'
       }
       agent { label 'conda-build-linux' }
-      environment { GITHUB_TOKEN = credentials("${GITHUB_TOKEN_CREDENTIAL_ID}") }
+      environment {
+        GITHUB_TOKEN = credentials("${GITHUB_TOKEN_CREDENTIAL_ID}")
+        RECIPE_UPDATE_OPTIONS = recipe_update_options()
+      }
       steps {
-        sh '${WORKSPACE}/buildconfig/Jenkins/Conda/update-conda-recipes.sh $GITHUB_TOKEN $GITHUB_USER_NAME $GITHUB_USER_EMAIL ${recipe_update_options()}'
+        sh '${WORKSPACE}/buildconfig/Jenkins/Conda/update-conda-recipes.sh $GITHUB_TOKEN $GITHUB_USER_NAME $GITHUB_USER_EMAIL $RECIPE_UPDATE_OPTIONS'
       }
     }
     stage('Packaging') {


### PR DESCRIPTION
**Description of work.**

A syntax error meant that the Jenkins nightly pipeline stage for updating our conda-recipes repository was broken. This has now been fixed.

**To test:**

Verify that the `Update conda-recipes repository` stage ran successfully and set the correct version numbers for the following two pipeline builds
- This one was built with the `Nightly` suffix and should have a nightly-like version number (it's echoed in the output)
https://builds.mantidproject.org/view/Nightly%20Pipelines/job/main_nightly_deployment_prototype/377/pipeline-graph/
- This one was built with no suffix and should have a release-like version number (it's echoed in the output)
https://builds.mantidproject.org/view/Nightly%20Pipelines/job/main_nightly_deployment_prototype/378/pipeline-graph/


*There is no associated issue.*

*This does not require release notes* because it is a fix to a jenkins pipeline that is invisible to the end-user.

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
