### PR TITLE
Fix Algorithm Dialog Crashes

### DIFF
--- a/Framework/Algorithms/src/CalculateDynamicRange.cpp
+++ b/Framework/Algorithms/src/CalculateDynamicRange.cpp
@@ -54,7 +54,9 @@ const std::string CalculateDynamicRange::summary() const {
 std::map<std::string, std::string> CalculateDynamicRange::validateInputs() {
   std::map<std::string, std::string> issues;
   API::MatrixWorkspace_sptr workspace = getProperty("Workspace");
-  if (workspace->getAxis(0)->unit()->unitID() != "Wavelength" && !workspace->run().hasProperty("wavelength")) {
+  if (!workspace) {
+    issues["InputWorkspace"] = "The InputWorkspace must be a MatrixWorkspace.";
+  } else if (workspace->getAxis(0)->unit()->unitID() != "Wavelength" && !workspace->run().hasProperty("wavelength")) {
     issues["InputWorkspace"] = "If the workspace is not in units of wavelength it must have a sample log wavelength.";
   }
   return issues;

--- a/Framework/Algorithms/src/CopyDataRange.cpp
+++ b/Framework/Algorithms/src/CopyDataRange.cpp
@@ -113,6 +113,16 @@ std::map<std::string, std::string> CopyDataRange::validateInputs() {
   int const yInsertionIndex = getProperty("InsertionYIndex");
   int const xInsertionIndex = getProperty("InsertionXIndex");
 
+  if (!inputWorkspace) {
+    errors["InputWorkspace"] = "The InputWorkspace must be a MatrixWorkspace.";
+  }
+  if (!destWorkspace) {
+    errors["DestWorkspace"] = "The DestWorkspace must be a MatrixWorkspace.";
+  }
+  if (!errors.empty()) {
+    return errors;
+  }
+
   try {
     auto const xMinIndex = inputWorkspace->yIndexOfX(xMin, 0, 0.000001);
     auto const xMaxIndex = inputWorkspace->yIndexOfX(xMax, 0, 0.000001);

--- a/Framework/Algorithms/src/CreateEPP.cpp
+++ b/Framework/Algorithms/src/CreateEPP.cpp
@@ -145,7 +145,9 @@ void CreateEPP::exec() {
 std::map<std::string, std::string> CreateEPP::validateInputs(void) {
   std::map<std::string, std::string> issues;
   API::MatrixWorkspace_sptr inputWS = getProperty(PropertyNames::INPUT_WORKSPACE);
-  if (!inputWS->run().hasProperty("Ei")) {
+  if (!inputWS) {
+    issues[PropertyNames::INPUT_WORKSPACE] = "The InputWorkspace must be a MatrixWorkspace.";
+  } else if (!inputWS->run().hasProperty("Ei")) {
     issues[PropertyNames::INPUT_WORKSPACE] = "Workspace is missing the 'Ei' sample log.";
   }
   return issues;

--- a/Framework/Algorithms/src/CropToComponent.cpp
+++ b/Framework/Algorithms/src/CropToComponent.cpp
@@ -98,6 +98,12 @@ void CropToComponent::exec() {
 std::map<std::string, std::string> CropToComponent::validateInputs() {
   std::map<std::string, std::string> result;
   Mantid::API::MatrixWorkspace_sptr inputWorkspace = getProperty("InputWorkspace");
+
+  if (!inputWorkspace) {
+    result["InputWorkspace"] = "The InputWorkspace must be a MatrixWorkspace.";
+    return result;
+  }
+
   std::vector<std::string> componentNames = getProperty("ComponentNames");
 
   // Make sure that the component exists on the input workspace

--- a/Framework/Algorithms/src/GetDetectorOffsets.cpp
+++ b/Framework/Algorithms/src/GetDetectorOffsets.cpp
@@ -9,6 +9,7 @@
 #include "MantidAPI/FileProperty.h"
 #include "MantidAPI/FunctionFactory.h"
 #include "MantidAPI/IPeakFunction.h"
+#include "MantidAPI/MatrixWorkspace.h"
 #include "MantidAPI/NumericAxis.h"
 #include "MantidAPI/SpectraAxis.h"
 #include "MantidAPI/SpectrumInfo.h"
@@ -36,7 +37,7 @@ using namespace DataObjects;
  */
 void GetDetectorOffsets::init() {
 
-  declareProperty(std::make_unique<WorkspaceProperty<>>("InputWorkspace", "", Direction::Input),
+  declareProperty(std::make_unique<WorkspaceProperty<MatrixWorkspace>>("InputWorkspace", "", Direction::Input),
 
                   "A 2D workspace with X values of d-spacing");
 
@@ -77,6 +78,10 @@ std::map<std::string, std::string> GetDetectorOffsets::validateInputs() {
   std::map<std::string, std::string> result;
 
   MatrixWorkspace_const_sptr inputWS = getProperty("InputWorkspace");
+  if (!inputWS) {
+    result["InputWorkspace"] = "The InputWorkspace must be a MatrixWorkspace.";
+    return result;
+  }
   const auto unit = inputWS->getAxis(0)->unit()->caption();
   const auto unitErrorMsg =
       "GetDetectorOffsets only supports input workspaces with units 'Bins of Shift' or 'd-Spacing', your unit was : " +

--- a/Framework/Algorithms/src/GetDetectorOffsets.cpp
+++ b/Framework/Algorithms/src/GetDetectorOffsets.cpp
@@ -9,7 +9,6 @@
 #include "MantidAPI/FileProperty.h"
 #include "MantidAPI/FunctionFactory.h"
 #include "MantidAPI/IPeakFunction.h"
-#include "MantidAPI/MatrixWorkspace.h"
 #include "MantidAPI/NumericAxis.h"
 #include "MantidAPI/SpectraAxis.h"
 #include "MantidAPI/SpectrumInfo.h"
@@ -37,7 +36,7 @@ using namespace DataObjects;
  */
 void GetDetectorOffsets::init() {
 
-  declareProperty(std::make_unique<WorkspaceProperty<MatrixWorkspace>>("InputWorkspace", "", Direction::Input),
+  declareProperty(std::make_unique<WorkspaceProperty<>>("InputWorkspace", "", Direction::Input),
 
                   "A 2D workspace with X values of d-spacing");
 

--- a/Framework/Algorithms/src/LorentzCorrection.cpp
+++ b/Framework/Algorithms/src/LorentzCorrection.cpp
@@ -78,6 +78,10 @@ std::map<std::string, std::string> LorentzCorrection::validateInputs() {
   // check units if the SCD option is selected
   if (processingType == TOF_SCD) {
     MatrixWorkspace_const_sptr wksp = this->getProperty(PropertyNames::INPUT_WKSP);
+    if (!wksp) {
+      result[PropertyNames::INPUT_WKSP] = "The workspace must be a MatrixWorkspace.";
+      return result;
+    }
     // code is a variant of private method from WorkspaceUnitValidator
     const auto unit = wksp->getAxis(0)->unit();
     if ((!unit) || (unit->unitID().compare("Wavelength"))) {

--- a/Framework/Algorithms/src/MaskBinsIf.cpp
+++ b/Framework/Algorithms/src/MaskBinsIf.cpp
@@ -66,12 +66,18 @@ void MaskBinsIf::init() {
 std::map<std::string, std::string> MaskBinsIf::validateInputs() {
   std::map<std::string, std::string> issues;
   double y = 0., e = 0., x = 0., dx = 0., s = 0.;
-  mu::Parser parser = makeParser(y, e, x, dx, s, getPropertyValue("Criterion"));
-  try {
-    parser.Eval();
-  } catch (mu::Parser::exception_type &exception) {
-    issues["Criterion"] = "Invalid expression given: " + exception.GetMsg();
+  const std::string criterion = getPropertyValue("Criterion");
+  if (criterion.empty()) {
+    issues["Criterion"] = "The criterion expression provided is empty";
+  } else {
+    mu::Parser parser = makeParser(y, e, x, dx, s, criterion);
+    try {
+      parser.Eval();
+    } catch (mu::Parser::exception_type &exception) {
+      issues["Criterion"] = "Invalid expression given: " + exception.GetMsg();
+    }
   }
+
   return issues;
 }
 

--- a/Framework/Algorithms/src/MaskBinsIf.cpp
+++ b/Framework/Algorithms/src/MaskBinsIf.cpp
@@ -65,11 +65,11 @@ void MaskBinsIf::init() {
  */
 std::map<std::string, std::string> MaskBinsIf::validateInputs() {
   std::map<std::string, std::string> issues;
-  double y = 0., e = 0., x = 0., dx = 0., s = 0.;
   const std::string criterion = getPropertyValue("Criterion");
   if (criterion.empty()) {
     issues["Criterion"] = "The criterion expression provided is empty";
   } else {
+    double y = 0., e = 0., x = 0., dx = 0., s = 0.;
     mu::Parser parser = makeParser(y, e, x, dx, s, criterion);
     try {
       parser.Eval();

--- a/Framework/Algorithms/src/MaskNonOverlappingBins.cpp
+++ b/Framework/Algorithms/src/MaskNonOverlappingBins.cpp
@@ -131,6 +131,14 @@ std::map<std::string, std::string> MaskNonOverlappingBins::validateInputs() {
   std::map<std::string, std::string> issues;
   API::MatrixWorkspace_const_sptr inputWS = getProperty(Prop::INPUT_WS);
   API::MatrixWorkspace_const_sptr comparisonWS = getProperty(Prop::COMPARISON_WS);
+  if (!inputWS) {
+    issues[Prop::INPUT_WS] = "The " + Prop::INPUT_WS + " must be a MatrixWorkspace.";
+    return issues;
+  }
+  if (!comparisonWS) {
+    issues[Prop::COMPARISON_WS] = "The " + Prop::COMPARISON_WS + " must be a MatrixWorkspace.";
+    return issues;
+  }
   if (inputWS->getNumberHistograms() != comparisonWS->getNumberHistograms()) {
     issues[Prop::COMPARISON_WS] = "The number of histogams mismatches with " + Prop::INPUT_WS;
   }

--- a/Framework/Algorithms/src/MaskNonOverlappingBins.cpp
+++ b/Framework/Algorithms/src/MaskNonOverlappingBins.cpp
@@ -133,10 +133,11 @@ std::map<std::string, std::string> MaskNonOverlappingBins::validateInputs() {
   API::MatrixWorkspace_const_sptr comparisonWS = getProperty(Prop::COMPARISON_WS);
   if (!inputWS) {
     issues[Prop::INPUT_WS] = "The " + Prop::INPUT_WS + " must be a MatrixWorkspace.";
-    return issues;
   }
   if (!comparisonWS) {
     issues[Prop::COMPARISON_WS] = "The " + Prop::COMPARISON_WS + " must be a MatrixWorkspace.";
+  }
+  if (!issues.empty()) {
     return issues;
   }
   if (inputWS->getNumberHistograms() != comparisonWS->getNumberHistograms()) {

--- a/Framework/Algorithms/src/Stitch1D.cpp
+++ b/Framework/Algorithms/src/Stitch1D.cpp
@@ -153,10 +153,14 @@ std::map<std::string, std::string> Stitch1D::validateInputs(void) {
   std::map<std::string, std::string> issues;
   MatrixWorkspace_sptr lhs = getProperty("LHSWorkspace");
   MatrixWorkspace_sptr rhs = getProperty("RHSWorkspace");
-  if (!lhs)
-    issues["LHSWorkspace"] = "Cannot retrieve workspace";
-  if (!rhs)
-    issues["RHSWorkspace"] = "Cannot retrieve workspace";
+  if (!lhs) {
+    issues["LHSWorkspace"] = "The LHSWorkspace must be a MatrixWorkspace.";
+    return issues;
+  }
+  if (!rhs) {
+    issues["RHSWorkspace"] = "The RHSWorkspace must be a MatrixWorkspace.";
+    return issues;
+  }
   RunCombinationHelper combHelper;
   combHelper.setReferenceProperties(lhs);
   std::string compatible = combHelper.checkCompatibility(rhs, true);

--- a/Framework/Algorithms/src/Stitch1D.cpp
+++ b/Framework/Algorithms/src/Stitch1D.cpp
@@ -155,10 +155,11 @@ std::map<std::string, std::string> Stitch1D::validateInputs(void) {
   MatrixWorkspace_sptr rhs = getProperty("RHSWorkspace");
   if (!lhs) {
     issues["LHSWorkspace"] = "The LHSWorkspace must be a MatrixWorkspace.";
-    return issues;
   }
   if (!rhs) {
     issues["RHSWorkspace"] = "The RHSWorkspace must be a MatrixWorkspace.";
+  }
+  if (!issues.empty()) {
     return issues;
   }
   RunCombinationHelper combHelper;

--- a/Framework/Algorithms/src/XrayAbsorptionCorrection.cpp
+++ b/Framework/Algorithms/src/XrayAbsorptionCorrection.cpp
@@ -66,6 +66,15 @@ std::map<std::string, std::string> XrayAbsorptionCorrection::validateInputs() {
   MatrixWorkspace_sptr inputWS = getProperty("InputWorkspace");
   MatrixWorkspace_sptr muonProfile = getProperty("MuonImplantationProfile");
   std::map<std::string, std::string> issues;
+  if (!inputWS) {
+    issues["InputWorkspace"] = "The InputWorkspace must be a MatrixWorkspace.";
+  }
+  if (!muonProfile) {
+    issues["MuonImplantationProfile"] = "The MuonImplantationProfile must be a MatrixWorkspace.";
+  }
+  if (!issues.empty()) {
+    return issues;
+  }
   if (!inputWS->sample().getShape().hasValidShape()) {
     issues["InputWorkspace"] = "Input workspace does not have a Sample";
   }

--- a/Framework/Crystal/src/AnvredCorrection.cpp
+++ b/Framework/Crystal/src/AnvredCorrection.cpp
@@ -80,8 +80,9 @@ void AnvredCorrection::init() {
   // The input workspace must have an instrument and units of wavelength
   auto wsValidator = std::make_shared<InstrumentValidator>();
 
-  declareProperty(std::make_unique<WorkspaceProperty<MatrixWorkspace>>("InputWorkspace", "", Direction::Input),
-                  "The X values for the input workspace must be in units of wavelength or TOF");
+  declareProperty(
+      std::make_unique<WorkspaceProperty<MatrixWorkspace>>("InputWorkspace", "", Direction::Input, wsValidator),
+      "The X values for the input workspace must be in units of wavelength or TOF");
   declareProperty(std::make_unique<WorkspaceProperty<>>("OutputWorkspace", "", Direction::Output),
                   "Output workspace name");
 

--- a/Framework/Crystal/src/AnvredCorrection.cpp
+++ b/Framework/Crystal/src/AnvredCorrection.cpp
@@ -80,9 +80,8 @@ void AnvredCorrection::init() {
   // The input workspace must have an instrument and units of wavelength
   auto wsValidator = std::make_shared<InstrumentValidator>();
 
-  declareProperty(std::make_unique<WorkspaceProperty<>>("InputWorkspace", "", Direction::Input, wsValidator),
-                  "The X values for the input workspace must be in units of "
-                  "wavelength or TOF");
+  declareProperty(std::make_unique<WorkspaceProperty<MatrixWorkspace>>("InputWorkspace", "", Direction::Input),
+                  "The X values for the input workspace must be in units of wavelength or TOF");
   declareProperty(std::make_unique<WorkspaceProperty<>>("OutputWorkspace", "", Direction::Output),
                   "Output workspace name");
 
@@ -125,8 +124,13 @@ std::map<std::string, std::string> AnvredCorrection::validateInputs() {
   const double radius = getProperty("Radius");
   if (radius == EMPTY_DBL()) {
     // check that if radius isn't supplied that the radius can be accessed from the sample
-    m_inputWS = getProperty("InputWorkspace");
-    const auto &sampleShape = m_inputWS->sample().getShape();
+    Mantid::API::MatrixWorkspace_sptr inputWorkspace = this->getProperty("InputWorkspace");
+    if (!inputWorkspace) {
+      result["InputWorkspace"] = "The InputWorkspace must be a MatrixWorkspace.";
+      return result;
+    }
+
+    const auto &sampleShape = inputWorkspace->sample().getShape();
     if (!sampleShape.hasValidShape() ||
         sampleShape.shapeInfo().shape() != Geometry::detail::ShapeInfo::GeometryShape::SPHERE) {
       result["Radius"] = "Please supply a radius or provide a workspace with a spherical sample set.";

--- a/Framework/MDAlgorithms/src/SetMDFrame.cpp
+++ b/Framework/MDAlgorithms/src/SetMDFrame.cpp
@@ -132,6 +132,7 @@ std::map<std::string, std::string> SetMDFrame::validateInputs() {
       !std::dynamic_pointer_cast<Mantid::API::IMDHistoWorkspace>(ws)) {
     invalidProperties.insert(std::make_pair("InputWorkspace", "The input workspace has to be either "
                                                               "an MDEvent or MDHisto Workspace."));
+    return invalidProperties;
   }
 
   std::vector<int> axesInts = this->getProperty("Axes");

--- a/Framework/Muon/src/MuonPairingAsymmetry.cpp
+++ b/Framework/Muon/src/MuonPairingAsymmetry.cpp
@@ -119,12 +119,12 @@ void MuonPairingAsymmetry::init() {
 
   // Select groups via workspaces
 
-  declareProperty(std::make_unique<WorkspaceProperty<WorkspaceGroup>>("InputWorkspace1", emptyString, Direction::Input,
-                                                                      PropertyMode::Optional),
+  declareProperty(std::make_unique<WorkspaceProperty<Workspace>>("InputWorkspace1", emptyString, Direction::Input,
+                                                                 PropertyMode::Optional),
                   "Input workspace containing data from grouped detectors.");
 
-  declareProperty(std::make_unique<WorkspaceProperty<WorkspaceGroup>>("InputWorkspace2", emptyString, Direction::Input,
-                                                                      PropertyMode::Optional),
+  declareProperty(std::make_unique<WorkspaceProperty<Workspace>>("InputWorkspace2", emptyString, Direction::Input,
+                                                                 PropertyMode::Optional),
                   "Input workspace containing data from grouped detectors.");
 
   setPropertySettings("InputWorkspace1",
@@ -221,8 +221,7 @@ void MuonPairingAsymmetry::validateManualGroups(std::map<std::string, std::strin
     errors["Group1"] = "The two groups must be different.";
   }
 
-  Workspace_sptr inputWS = this->getProperty("InputWorkspace");
-  if (const auto workspaceGroup = std::dynamic_pointer_cast<WorkspaceGroup>(inputWS)) {
+  if (WorkspaceGroup_sptr workspaceGroup = this->getProperty("InputWorkspace")) {
     validatePeriods(workspaceGroup, errors);
   } else {
     errors["InputWorkspace"] = "The InputWorkspace must be a WorkspaceGroup.";
@@ -230,14 +229,14 @@ void MuonPairingAsymmetry::validateManualGroups(std::map<std::string, std::strin
 }
 
 void MuonPairingAsymmetry::validateGroupsWorkspaces(std::map<std::string, std::string> &errors) {
-  WorkspaceGroup_sptr ws1 = this->getProperty("InputWorkspace1");
-  WorkspaceGroup_sptr ws2 = this->getProperty("InputWorkspace2");
+  Workspace_sptr ws1 = this->getProperty("InputWorkspace1");
+  Workspace_sptr ws2 = this->getProperty("InputWorkspace2");
   if (!ws1) {
-    errors["InputWorkspace1"] = "The InputWorkspace1 must be a WorkspaceGroup.";
+    errors["InputWorkspace1"] = "The InputWorkspace1 must be a Workspace.";
     return;
   }
   if (!ws2) {
-    errors["InputWorkspace2"] = "The InputWorkspace2 must be a WorkspaceGroup.";
+    errors["InputWorkspace2"] = "The InputWorkspace2 must be a Workspace.";
     return;
   }
   if (ws1->isGroup() && !ws2->isGroup()) {

--- a/Framework/Muon/src/MuonPairingAsymmetry.cpp
+++ b/Framework/Muon/src/MuonPairingAsymmetry.cpp
@@ -233,10 +233,11 @@ void MuonPairingAsymmetry::validateGroupsWorkspaces(std::map<std::string, std::s
   Workspace_sptr ws2 = this->getProperty("InputWorkspace2");
   if (!ws1) {
     errors["InputWorkspace1"] = "The InputWorkspace1 must be a Workspace.";
-    return;
   }
   if (!ws2) {
     errors["InputWorkspace2"] = "The InputWorkspace2 must be a Workspace.";
+  }
+  if (errors.count("InputWorkspace1") == 1 || errors.count("InputWorkspace2") == 1) {
     return;
   }
   if (ws1->isGroup() && !ws2->isGroup()) {

--- a/Framework/Muon/src/MuonPairingAsymmetry.cpp
+++ b/Framework/Muon/src/MuonPairingAsymmetry.cpp
@@ -119,12 +119,12 @@ void MuonPairingAsymmetry::init() {
 
   // Select groups via workspaces
 
-  declareProperty(std::make_unique<WorkspaceProperty<Workspace>>("InputWorkspace1", emptyString, Direction::Input,
-                                                                 PropertyMode::Optional),
+  declareProperty(std::make_unique<WorkspaceProperty<WorkspaceGroup>>("InputWorkspace1", emptyString, Direction::Input,
+                                                                      PropertyMode::Optional),
                   "Input workspace containing data from grouped detectors.");
 
-  declareProperty(std::make_unique<WorkspaceProperty<Workspace>>("InputWorkspace2", emptyString, Direction::Input,
-                                                                 PropertyMode::Optional),
+  declareProperty(std::make_unique<WorkspaceProperty<WorkspaceGroup>>("InputWorkspace2", emptyString, Direction::Input,
+                                                                      PropertyMode::Optional),
                   "Input workspace containing data from grouped detectors.");
 
   setPropertySettings("InputWorkspace1",
@@ -221,13 +221,25 @@ void MuonPairingAsymmetry::validateManualGroups(std::map<std::string, std::strin
     errors["Group1"] = "The two groups must be different.";
   }
 
-  WorkspaceGroup_sptr inputWS = this->getProperty("InputWorkspace");
-  validatePeriods(inputWS, errors);
+  Workspace_sptr inputWS = this->getProperty("InputWorkspace");
+  if (const auto workspaceGroup = std::dynamic_pointer_cast<WorkspaceGroup>(inputWS)) {
+    validatePeriods(workspaceGroup, errors);
+  } else {
+    errors["InputWorkspace"] = "The InputWorkspace must be a WorkspaceGroup.";
+  }
 }
 
 void MuonPairingAsymmetry::validateGroupsWorkspaces(std::map<std::string, std::string> &errors) {
-  Workspace_sptr ws1 = this->getProperty("InputWorkspace1");
-  Workspace_sptr ws2 = this->getProperty("InputWorkspace2");
+  WorkspaceGroup_sptr ws1 = this->getProperty("InputWorkspace1");
+  WorkspaceGroup_sptr ws2 = this->getProperty("InputWorkspace2");
+  if (!ws1) {
+    errors["InputWorkspace1"] = "The InputWorkspace1 must be a WorkspaceGroup.";
+    return;
+  }
+  if (!ws2) {
+    errors["InputWorkspace2"] = "The InputWorkspace2 must be a WorkspaceGroup.";
+    return;
+  }
   if (ws1->isGroup() && !ws2->isGroup()) {
     errors["InputWorkspace1"] = "InputWorkspace2 should be multi period to match InputWorkspace1";
   }

--- a/Framework/PythonInterface/plugins/algorithms/CylinderPaalmanPingsCorrection2.py
+++ b/Framework/PythonInterface/plugins/algorithms/CylinderPaalmanPingsCorrection2.py
@@ -8,7 +8,7 @@
 import math
 import numpy as np
 from mantid.simpleapi import *
-from mantid.api import (PythonAlgorithm, AlgorithmFactory, PropertyMode, MatrixWorkspaceProperty,
+from mantid.api import (PythonAlgorithm, AlgorithmFactory, PropertyMode, MatrixWorkspace, MatrixWorkspaceProperty,
                         WorkspaceGroupProperty, InstrumentValidator, Progress)
 from mantid.kernel import (StringListValidator, IntBoundedValidator, FloatBoundedValidator, Direction, logger)
 
@@ -223,12 +223,17 @@ class CylinderPaalmanPingsCorrection(PythonAlgorithm):
         logger.information('Sample : ms = %i ' % self._ms)
 
         if self._emode != 'Efixed':
-            # require both sample and can ws have wavelength as x-axis
-            if mtd[sample_ws_name].getAxis(0).getUnit().unitID() != 'Wavelength':
-                issues['SampleWorkspace'] = 'Workspace must have units of wavelength.'
+            if not isinstance(mtd[sample_ws_name], MatrixWorkspace):
+                issues['SampleWorkspace'] = "The SampleWorkspace must be a MatrixWorkspace."
+            elif mtd[sample_ws_name].getAxis(0).getUnit().unitID() != 'Wavelength':
+                # require both sample and can ws have wavelength as x-axis
+                issues['SampleWorkspace'] = 'The SampleWorkspace must have units of wavelength.'
 
-            if self._use_can and mtd[can_ws_name].getAxis(0).getUnit().unitID() != 'Wavelength':
-                issues['CanWorkspace'] = 'Workspace must have units of wavelength.'
+            if self._use_can:
+                if not isinstance(mtd[can_ws_name], MatrixWorkspace):
+                    issues['CanWorkspace'] = "The CanWorkspace must be a MatrixWorkspace."
+                elif mtd[can_ws_name].getAxis(0).getUnit().unitID() != 'Wavelength':
+                    issues['CanWorkspace'] = 'The CanWorkspace must have units of wavelength.'
 
         return issues
 

--- a/Framework/PythonInterface/plugins/algorithms/EnggEstimateFocussedBackground.py
+++ b/Framework/PythonInterface/plugins/algorithms/EnggEstimateFocussedBackground.py
@@ -4,7 +4,7 @@
 #   NScD Oak Ridge National Laboratory, European Spallation Source,
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
-from mantid.api import AlgorithmFactory, MatrixWorkspaceProperty, PythonAlgorithm, Progress
+from mantid.api import AlgorithmFactory, MatrixWorkspace, MatrixWorkspaceProperty, PythonAlgorithm, Progress
 from mantid.kernel import Direction, IntBoundedValidator, FloatBoundedValidator
 import numpy as np
 from scipy.signal import savgol_filter
@@ -59,7 +59,9 @@ class EnggEstimateFocussedBackground(PythonAlgorithm):
         issues = dict()
         # check there are more than three points in a workspace
         inws = self.getProperty("InputWorkspace").value
-        if inws.blocksize() < self.MIN_WINDOW_SIZE:
+        if not isinstance(inws, MatrixWorkspace):
+            issues['InputWorkspace'] = "The InputWorkspace must be a MatrixWorkspace."
+        elif inws.blocksize() < self.MIN_WINDOW_SIZE:
             issues['InputWorkspace'] = "At least three points needed in each spectra"
         return issues
 

--- a/Framework/PythonInterface/plugins/algorithms/HB2AReduce.py
+++ b/Framework/PythonInterface/plugins/algorithms/HB2AReduce.py
@@ -146,12 +146,11 @@ class HB2AReduce(PythonAlgorithm):
                     if os.path.isdir(directory):
                         if self.getProperty("Exp").value == Property.EMPTY_INT:
                             exp = int([e for e in os.listdir(directory) if 'exp' in e][0].replace('exp', ''))
+                        filenames = [f"{directory}/exp{exp}/Datafiles/HB2A_exp{exp:04}_scan{scan:04}.dat"
+                                     for scan in self.getProperty("ScanNumbers").value]
                     else:
                         issues["IPTS"] = f"Failed to find the directory: {directory}"
-                    filenames = [
-                        '/HFIR/HB2A/IPTS-{0}/exp{1}/Datafiles/HB2A_exp{1:04}_scan{2:04}.dat'.format(
-                            ipts, exp, scan) for scan in self.getProperty("ScanNumbers").value
-                    ]
+
                 filenames = filenames if isinstance(filenames, list) else [filenames]
                 _target = "# def_x = 2theta"
                 for fn in filenames:

--- a/Framework/PythonInterface/plugins/algorithms/HB2AReduce.py
+++ b/Framework/PythonInterface/plugins/algorithms/HB2AReduce.py
@@ -118,14 +118,15 @@ class HB2AReduce(PythonAlgorithm):
             if ((ipts == Property.EMPTY_INT) or len(self.getProperty("ScanNumbers").value) == 0):
                 issues["Filename"] = 'Must specify either Filename or IPTS AND ScanNumbers'
 
+            directory = f'/HFIR/HB2A/IPTS-{ipts}'
             if self.getProperty("Exp").value == Property.EMPTY_INT:
-                exp_list = sorted(e for e in os.listdir('/HFIR/HB2A/IPTS-{0}'.format(ipts))
-                                  if 'exp' in e)
-                if len(exp_list) > 1:
-                    exps = ','.join(e.replace('exp', '') for e in exp_list)
-                    issues[
-                        "Exp"] = 'Multiple experiments found in IPTS-{}. You must set Exp to one of {}'.format(
-                            ipts, exps)
+                if os.path.isdir(directory):
+                    exp_list = sorted(e for e in os.listdir(directory) if 'exp' in e)
+                    if len(exp_list) > 1:
+                        exps = ','.join(e.replace('exp', '') for e in exp_list)
+                        issues["Exp"] = f'Multiple experiments found in IPTS-{ipts}. You must set Exp to one of {exps}'
+            else:
+                issues["Exp"] = f"Failed to find the directory: {directory}"
 
         # validate output format options
         # Def_x    GSAS    XYE
@@ -142,9 +143,11 @@ class HB2AReduce(PythonAlgorithm):
                     ipts = self.getProperty("IPTS").value
                     exp = self.getProperty("Exp").value
                     if self.getProperty("Exp").value == Property.EMPTY_INT:
-                        exp = int([
-                            e for e in os.listdir('/HFIR/HB2A/IPTS-{0}'.format(ipts)) if 'exp' in e
-                        ][0].replace('exp', ''))
+                        directory = f'/HFIR/HB2A/IPTS-{ipts}'
+                        if os.path.isdir(directory):
+                            exp = int([e for e in os.listdir(directory) if 'exp' in e][0].replace('exp', ''))
+                        else:
+                            issues["Exp"] = f"Failed to find the directory: {directory}"
                     filenames = [
                         '/HFIR/HB2A/IPTS-{0}/exp{1}/Datafiles/HB2A_exp{1:04}_scan{2:04}.dat'.format(
                             ipts, exp, scan) for scan in self.getProperty("ScanNumbers").value

--- a/Framework/PythonInterface/plugins/algorithms/HB2AReduce.py
+++ b/Framework/PythonInterface/plugins/algorithms/HB2AReduce.py
@@ -119,14 +119,14 @@ class HB2AReduce(PythonAlgorithm):
                 issues["Filename"] = 'Must specify either Filename or IPTS AND ScanNumbers'
 
             directory = f'/HFIR/HB2A/IPTS-{ipts}'
-            if self.getProperty("Exp").value == Property.EMPTY_INT:
-                if os.path.isdir(directory):
+            if os.path.isdir(directory):
+                if self.getProperty("Exp").value == Property.EMPTY_INT:
                     exp_list = sorted(e for e in os.listdir(directory) if 'exp' in e)
                     if len(exp_list) > 1:
                         exps = ','.join(e.replace('exp', '') for e in exp_list)
                         issues["Exp"] = f'Multiple experiments found in IPTS-{ipts}. You must set Exp to one of {exps}'
             else:
-                issues["Exp"] = f"Failed to find the directory: {directory}"
+                issues["IPTS"] = f"Failed to find the directory: {directory}"
 
         # validate output format options
         # Def_x    GSAS    XYE
@@ -142,12 +142,12 @@ class HB2AReduce(PythonAlgorithm):
                 if not filenames:
                     ipts = self.getProperty("IPTS").value
                     exp = self.getProperty("Exp").value
-                    if self.getProperty("Exp").value == Property.EMPTY_INT:
-                        directory = f'/HFIR/HB2A/IPTS-{ipts}'
-                        if os.path.isdir(directory):
+                    directory = f'/HFIR/HB2A/IPTS-{ipts}'
+                    if os.path.isdir(directory):
+                        if self.getProperty("Exp").value == Property.EMPTY_INT:
                             exp = int([e for e in os.listdir(directory) if 'exp' in e][0].replace('exp', ''))
-                        else:
-                            issues["Exp"] = f"Failed to find the directory: {directory}"
+                    else:
+                        issues["IPTS"] = f"Failed to find the directory: {directory}"
                     filenames = [
                         '/HFIR/HB2A/IPTS-{0}/exp{1}/Datafiles/HB2A_exp{1:04}_scan{2:04}.dat'.format(
                             ipts, exp, scan) for scan in self.getProperty("ScanNumbers").value

--- a/Framework/PythonInterface/plugins/algorithms/HB3APredictPeaks.py
+++ b/Framework/PythonInterface/plugins/algorithms/HB3APredictPeaks.py
@@ -4,7 +4,8 @@
 #   NScD Oak Ridge National Laboratory, European Spallation Source,
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
-from mantid.api import AlgorithmFactory, IMDWorkspaceProperty, IPeaksWorkspaceProperty, PythonAlgorithm, PropertyMode
+from mantid.api import (AlgorithmFactory, IMDWorkspace, IMDWorkspaceProperty, IPeaksWorkspaceProperty, PythonAlgorithm,
+                        PropertyMode)
 from mantid.kernel import Direction, FloatPropertyWithValue, StringListValidator, EnabledWhenProperty, PropertyCriterion
 from mantid.simpleapi import (PredictPeaks, CloneMDWorkspace,
                               CopySample, DeleteWorkspace, PredictSatellitePeaks,
@@ -79,7 +80,10 @@ class HB3APredictPeaks(PythonAlgorithm):
         issues = dict()
 
         input_ws = self.getProperty("InputWorkspace").value
-        if input_ws.getSpecialCoordinateSystem().name != "QSample":
+
+        if not isinstance(input_ws, IMDWorkspace):
+            issues['InputWorkspace'] = "The InputWorkspace must be an IMDWorkspace."
+        elif input_ws.getSpecialCoordinateSystem().name != "QSample":
             issues["InputWorkspace"] = "Input workspace expected to be in QSample, " \
                 "workspace is in '{}'".format(input_ws.getSpecialCoordinateSystem().name)
         elif input_ws.getNumDims() != 3:

--- a/Framework/PythonInterface/plugins/algorithms/MaskAngle.py
+++ b/Framework/PythonInterface/plugins/algorithms/MaskAngle.py
@@ -54,11 +54,14 @@ class MaskAngle(mantid.api.PythonAlgorithm):
         issues = dict()
         ws = self.getProperty("Workspace").value
         hasInstrument = True
-        if type(ws).__name__ == "WorkspaceGroup" and len(ws) > 0:
+        if isinstance(ws, mantid.api.WorkspaceGroup) and len(ws) > 0:
             for item in ws:
                 hasInstrument = hasInstrument and len(item.componentInfo()) > 0
-        else:
+        elif isinstance(ws, mantid.api.MatrixWorkspace):
             hasInstrument = len(ws.componentInfo()) > 0
+        else:
+            issues["Workspace"] = "Workspace must be a WorkspaceGroup or MatrixWorkspace."
+            return issues
 
         if not hasInstrument:
             issues["Workspace"] = "Workspace must have an associated instrument."

--- a/Framework/PythonInterface/plugins/algorithms/MaskAngle.py
+++ b/Framework/PythonInterface/plugins/algorithms/MaskAngle.py
@@ -60,10 +60,10 @@ class MaskAngle(mantid.api.PythonAlgorithm):
         elif isinstance(ws, mantid.api.MatrixWorkspace):
             hasInstrument = len(ws.componentInfo()) > 0
         else:
+            hasInstrument = False
             issues["Workspace"] = "Workspace must be a WorkspaceGroup or MatrixWorkspace."
-            return issues
 
-        if not hasInstrument:
+        if not hasInstrument and "Workspace" not in issues:
             issues["Workspace"] = "Workspace must have an associated instrument."
 
         angleMin = self.getProperty('MinAngle').value

--- a/Framework/PythonInterface/plugins/algorithms/PDConvertRealSpace.py
+++ b/Framework/PythonInterface/plugins/algorithms/PDConvertRealSpace.py
@@ -5,9 +5,8 @@
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
 # pylint: disable=no-init,invalid-name
-from mantid.api import (PythonAlgorithm, AlgorithmFactory,
-                        MatrixWorkspaceProperty,
-                        WorkspaceProperty, WorkspaceFactory)
+from mantid.api import (PythonAlgorithm, AlgorithmFactory, MatrixWorkspace, MatrixWorkspaceProperty, WorkspaceProperty,
+                        WorkspaceFactory)
 from mantid.kernel import (Direction, StringListValidator, logger)
 
 from pystog.converter import Converter
@@ -58,7 +57,9 @@ class PDConvertRealSpace(PythonAlgorithm):
     def validateInputs(self):
         result = dict()
         input_ws = self.getProperty('InputWorkspace').value
-        if input_ws.sample().getMaterial():
+        if not isinstance(input_ws, MatrixWorkspace):
+            result['InputWorkspace'] = "The InputWorkspace must be a MatrixWorkspace."
+        elif input_ws.sample().getMaterial():
             if input_ws.sample().getMaterial().cohScatterLengthSqrd() == 0.:
                 from_quantity = self.getProperty('From').value
                 to_quantity = self.getProperty('To').value

--- a/Framework/PythonInterface/plugins/algorithms/RebinRagged.py
+++ b/Framework/PythonInterface/plugins/algorithms/RebinRagged.py
@@ -44,24 +44,13 @@ class RebinRagged(PythonAlgorithm):
         errors = {}
 
         inputWS = self.getProperty("InputWorkspace").value
-
-        if not isinstance(inputWS, MatrixWorkspace):
-            errors['InputWorkspace'] = "The InputWorkspace must be a MatrixWorkspace."
-            return errors
-
         xmins = self.getProperty("XMin").value
         xmaxs = self.getProperty("XMax").value
         deltas = self.getProperty("Delta").value
 
-        numSpec = inputWS.getNumberHistograms()
         numMin = len(xmins)
         numMax = len(xmaxs)
         numDelta = len(deltas)
-
-        if numDelta == 0:
-            errors["Delta"] = "Must specify binning"
-        elif not (numDelta == 1 or numDelta == numSpec):
-            errors["Delta"] = "Must specify for each spetra ({}!={})".format(numDelta, numSpec)
 
         if np.any(np.invert(np.isfinite(xmins))):
             errors["Delta"] = "All must be finite"
@@ -72,11 +61,21 @@ class RebinRagged(PythonAlgorithm):
             errors["XMin"] = "Must specify minimums or maximums"
             errors["XMax"] = "Must specify minimums or maximums"
 
-        if numMin > 1 and numMin != numSpec:
-            errors["XMin"] = "Must specify min for each spectra ({}!={})".format(numMin, numSpec)
+        if isinstance(inputWS, MatrixWorkspace):
+            numSpec = inputWS.getNumberHistograms()
 
-        if numMax > 1 and numMax != numSpec:
-            errors["XMax"] = "Must specify max for each spectra ({}!={})".format(numMax, numSpec)
+            if numDelta == 0:
+                errors["Delta"] = "Must specify binning"
+            elif not (numDelta == 1 or numDelta == numSpec):
+                errors["Delta"] = "Must specify for each spetra ({}!={})".format(numDelta, numSpec)
+
+            if numMin > 1 and numMin != numSpec:
+                errors["XMin"] = "Must specify min for each spectra ({}!={})".format(numMin, numSpec)
+
+            if numMax > 1 and numMax != numSpec:
+                errors["XMax"] = "Must specify max for each spectra ({}!={})".format(numMax, numSpec)
+        else:
+            errors['InputWorkspace'] = "The InputWorkspace must be a MatrixWorkspace."
 
         return errors
 

--- a/Framework/PythonInterface/plugins/algorithms/RebinRagged.py
+++ b/Framework/PythonInterface/plugins/algorithms/RebinRagged.py
@@ -41,7 +41,14 @@ class RebinRagged(PythonAlgorithm):
         self.declareProperty("PreserveEvents", True, "False converts event workspaces to histograms")
 
     def validateInputs(self):
+        errors = {}
+
         inputWS = self.getProperty("InputWorkspace").value
+
+        if not isinstance(inputWS, MatrixWorkspace):
+            errors['InputWorkspace'] = "The InputWorkspace must be a MatrixWorkspace."
+            return errors
+
         xmins = self.getProperty("XMin").value
         xmaxs = self.getProperty("XMax").value
         deltas = self.getProperty("Delta").value
@@ -50,8 +57,6 @@ class RebinRagged(PythonAlgorithm):
         numMin = len(xmins)
         numMax = len(xmaxs)
         numDelta = len(deltas)
-
-        errors = {}
 
         if numDelta == 0:
             errors["Delta"] = "Must specify binning"

--- a/Framework/PythonInterface/plugins/algorithms/Symmetrise.py
+++ b/Framework/PythonInterface/plugins/algorithms/Symmetrise.py
@@ -10,7 +10,7 @@ import numpy as np
 
 import mantid.simpleapi as ms
 from mantid import logger, mtd
-from mantid.api import (PythonAlgorithm, AlgorithmFactory, MatrixWorkspaceProperty,
+from mantid.api import (PythonAlgorithm, AlgorithmFactory, MatrixWorkspace, MatrixWorkspaceProperty,
                         ITableWorkspaceProperty, PropertyMode, WorkspaceFactory, Progress)
 from mantid.kernel import Direction, IntArrayProperty
 
@@ -158,7 +158,10 @@ class Symmetrise(PythonAlgorithm):
         from IndirectCommon import CheckHistZero
         issues = dict()
 
-        input_workspace_name = self.getPropertyValue('InputWorkspace')
+        input_workspace = self.getProperty('InputWorkspace').value
+        if not isinstance(input_workspace, MatrixWorkspace):
+            issues['InputWorkspace'] = "The InputWorkspace must be a MatrixWorkspace."
+            return issues
 
         # Validate spectra range
         spectra_range = self.getProperty('SpectraRange').value
@@ -169,9 +172,9 @@ class Symmetrise(PythonAlgorithm):
             spec_min = spectra_range[0]
             spec_max = spectra_range[1]
 
-            num_sample_spectra, _ = CheckHistZero(input_workspace_name)
-            min_spectra_number = mtd[input_workspace_name].getSpectrum(0).getSpectrumNo()
-            max_spectra_number = mtd[input_workspace_name].getSpectrum(num_sample_spectra - 1).getSpectrumNo()
+            num_sample_spectra, _ = CheckHistZero(input_workspace.name())
+            min_spectra_number = input_workspace.getSpectrum(0).getSpectrumNo()
+            max_spectra_number = input_workspace.getSpectrum(num_sample_spectra - 1).getSpectrumNo()
 
             if spec_min < min_spectra_number:
                 issues['SpectraRange'] = 'Minimum spectra must be greater than or equal to %d' % min_spectra_number
@@ -200,7 +203,7 @@ class Symmetrise(PythonAlgorithm):
             issues['XMax'] = 'XMax must be greater than XMin'
 
         # Valudate X range against workspace X range
-        sample_x = mtd[input_workspace_name].readX(0)
+        sample_x = input_workspace.readX(0)
         sample_x_min = sample_x.min()
         sample_x_max = sample_x.max()
 

--- a/Framework/PythonInterface/plugins/algorithms/TOFTOFCropWorkspace.py
+++ b/Framework/PythonInterface/plugins/algorithms/TOFTOFCropWorkspace.py
@@ -4,7 +4,7 @@
 #   NScD Oak Ridge National Laboratory, European Spallation Source,
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
-from mantid.api import PythonAlgorithm, AlgorithmFactory, WorkspaceProperty    # , WorkspaceUnitValidator
+from mantid.api import AlgorithmFactory, MatrixWorkspace, MatrixWorkspaceProperty, PythonAlgorithm
 from mantid.kernel import Direction
 import mantid.simpleapi as api
 
@@ -22,7 +22,7 @@ class TOFTOFCropWorkspace(PythonAlgorithm):
         return "Workflow\\MLZ\\TOFTOF;Transforms\\Splitting"
 
     def seeAlso(self):
-        return [ "TOFTOFMergeRuns","CorrectTOF" ]
+        return ["TOFTOFMergeRuns", "CorrectTOF"]
 
     def name(self):
         """ Return summary
@@ -35,19 +35,18 @@ class TOFTOFCropWorkspace(PythonAlgorithm):
     def PyInit(self):
         """ Declare properties
         """
-        # better would be to use the validator, but it fails if WorkspaceGroup is given as an input
-        # self.declareProperty(WorkspaceProperty("InputWorkspace", "", direction=Direction.Input,
-        #                                       validator=WorkspaceUnitValidator('TOF')),
-        #                     doc="Input workspace.")
-        self.declareProperty(WorkspaceProperty("InputWorkspace", "", direction=Direction.Input),
+        self.declareProperty(MatrixWorkspaceProperty("InputWorkspace", "", direction=Direction.Input),
                              doc="Input workspace.")
-        self.declareProperty(WorkspaceProperty("OutputWorkspace", "", direction=Direction.Output),
+        self.declareProperty(MatrixWorkspaceProperty("OutputWorkspace", "", direction=Direction.Output),
                              doc="Name of the workspace that will contain the results")
-        return
 
     def validateInputs(self):
         issues = dict()
         input_workspace = self.getProperty("InputWorkspace").value
+
+        if not isinstance(input_workspace, MatrixWorkspace):
+            issues['InputWorkspace'] = "The InputWorkspace must be a MatrixWorkspace. "
+            return issues
 
         xunit = input_workspace.getAxis(0).getUnit().unitID()
         if xunit != 'TOF':

--- a/Framework/PythonInterface/plugins/algorithms/TOFTOFCropWorkspace.py
+++ b/Framework/PythonInterface/plugins/algorithms/TOFTOFCropWorkspace.py
@@ -4,7 +4,7 @@
 #   NScD Oak Ridge National Laboratory, European Spallation Source,
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
-from mantid.api import AlgorithmFactory, MatrixWorkspace, MatrixWorkspaceProperty, PythonAlgorithm
+from mantid.api import AlgorithmFactory, MatrixWorkspace, WorkspaceProperty, PythonAlgorithm
 from mantid.kernel import Direction
 import mantid.simpleapi as api
 
@@ -35,9 +35,9 @@ class TOFTOFCropWorkspace(PythonAlgorithm):
     def PyInit(self):
         """ Declare properties
         """
-        self.declareProperty(MatrixWorkspaceProperty("InputWorkspace", "", direction=Direction.Input),
+        self.declareProperty(WorkspaceProperty("InputWorkspace", "", direction=Direction.Input),
                              doc="Input workspace.")
-        self.declareProperty(MatrixWorkspaceProperty("OutputWorkspace", "", direction=Direction.Output),
+        self.declareProperty(WorkspaceProperty("OutputWorkspace", "", direction=Direction.Output),
                              doc="Name of the workspace that will contain the results")
 
     def validateInputs(self):
@@ -45,7 +45,7 @@ class TOFTOFCropWorkspace(PythonAlgorithm):
         input_workspace = self.getProperty("InputWorkspace").value
 
         if not isinstance(input_workspace, MatrixWorkspace):
-            issues['InputWorkspace'] = "The InputWorkspace must be a MatrixWorkspace. "
+            issues['InputWorkspace'] = "The InputWorkspace must be a MatrixWorkspace."
             return issues
 
         xunit = input_workspace.getAxis(0).getUnit().unitID()

--- a/Framework/PythonInterface/plugins/algorithms/VesuvioResolution.py
+++ b/Framework/PythonInterface/plugins/algorithms/VesuvioResolution.py
@@ -22,10 +22,10 @@ class VesuvioResolution(VesuvioBase):
         return 'Calculates the resolution function for VESUVIO'
 
     def PyInit(self):
-        self.declareProperty(WorkspaceProperty(name='Workspace',
-                                               defaultValue='',
-                                               direction=Direction.Input),
-                             doc='Sample workspace')
+        self.declareProperty(MatrixWorkspaceProperty(name='Workspace',
+                                                     defaultValue='',
+                                                     direction=Direction.Input),
+                             doc='Sample matrix workspace')
 
         self.declareProperty(name='WorkspaceIndex', defaultValue=0,
                              doc='Workspace index to use for resolution')
@@ -55,7 +55,9 @@ class VesuvioResolution(VesuvioBase):
         sample_ws = self.getProperty('Workspace').value
         workspace_index = self.getProperty('WorkspaceIndex').value
 
-        if workspace_index > sample_ws.getNumberHistograms() - 1:
+        if not isinstance(sample_ws, MatrixWorkspace):
+            issues['Workspace'] = 'The Workspace must be a MatrixWorkspace'
+        elif workspace_index > sample_ws.getNumberHistograms() - 1:
             issues['WorkspaceIndex'] = 'Workspace index is out of range'
 
         out_ws_tof = self.getPropertyValue('OutputWorkspaceTOF')

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/FlatPlatePaalmanPingsCorrection.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/FlatPlatePaalmanPingsCorrection.py
@@ -10,7 +10,7 @@ import math
 
 import numpy as np
 from mantid.simpleapi import *
-from mantid.api import (PythonAlgorithm, AlgorithmFactory, PropertyMode, MatrixWorkspaceProperty,
+from mantid.api import (PythonAlgorithm, AlgorithmFactory, PropertyMode, MatrixWorkspace, MatrixWorkspaceProperty,
                         WorkspaceGroupProperty, InstrumentValidator, Progress)
 from mantid.kernel import (StringListValidator, IntBoundedValidator, FloatBoundedValidator, Direction, logger)
 
@@ -199,12 +199,17 @@ class FlatPlatePaalmanPingsCorrection(PythonAlgorithm):
         self._efixed = self.getProperty('Efixed').value
 
         if self._emode != 'Efixed':
-            # require both sample and can ws have wavelenght as x-axis
-            if mtd[sample_ws_name].getAxis(0).getUnit().unitID() != 'Wavelength':
-                issues['SampleWorkspace'] = 'Workspace must have units of wavelength.'
+            if not isinstance(mtd[sample_ws_name], MatrixWorkspace):
+                issues['SampleWorkspace'] = "The SampleWorkspace must be a MatrixWorkspace."
+            elif mtd[sample_ws_name].getAxis(0).getUnit().unitID() != 'Wavelength':
+                # require both sample and can ws have wavelenght as x-axis
+                issues['SampleWorkspace'] = 'The SampleWorkspace must have units of wavelength.'
 
-            if use_can and mtd[can_ws_name].getAxis(0).getUnit().unitID() != 'Wavelength':
-                issues['CanWorkspace'] = 'Workspace must have units of wavelength.'
+            if use_can:
+                if not isinstance(mtd[can_ws_name], MatrixWorkspace):
+                    issues['CanWorkspace'] = "The CanWorkspace must be a MatrixWorkspace."
+                elif mtd[can_ws_name].getAxis(0).getUnit().unitID() != 'Wavelength':
+                    issues['CanWorkspace'] = 'The CanWorkspace must have units of wavelength.'
 
         return issues
 

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/FlatPlatePaalmanPingsCorrection.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/FlatPlatePaalmanPingsCorrection.py
@@ -180,7 +180,7 @@ class FlatPlatePaalmanPingsCorrection(PythonAlgorithm):
     def validateInputs(self):
         issues = dict()
 
-        sample_ws_name = self.getPropertyValue('SampleWorkspace')
+        sample_ws = self.getProperty('SampleWorkspace').value
         can_ws_name = self.getPropertyValue('CanWorkspace')
         use_can = can_ws_name != ''
 
@@ -199,9 +199,9 @@ class FlatPlatePaalmanPingsCorrection(PythonAlgorithm):
         self._efixed = self.getProperty('Efixed').value
 
         if self._emode != 'Efixed':
-            if not isinstance(mtd[sample_ws_name], MatrixWorkspace):
+            if not isinstance(sample_ws, MatrixWorkspace):
                 issues['SampleWorkspace'] = "The SampleWorkspace must be a MatrixWorkspace."
-            elif mtd[sample_ws_name].getAxis(0).getUnit().unitID() != 'Wavelength':
+            elif sample_ws.getAxis(0).getUnit().unitID() != 'Wavelength':
                 # require both sample and can ws have wavelenght as x-axis
                 issues['SampleWorkspace'] = 'The SampleWorkspace must have units of wavelength.'
 

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/MSDFit.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/MSDFit.py
@@ -60,6 +60,9 @@ class MSDFit(DataProcessorAlgorithm):
         issues = dict()
 
         workspace = self.getProperty('InputWorkspace').value
+        if not isinstance(workspace, MatrixWorkspace):
+            issues['InputWorkspace'] = "The InputWorkspace must be a MatrixWorkspace."
+            return issues
         x_data = workspace.readX(0)
 
         # Validate X axis fitting range

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/MSDFit.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/MSDFit.py
@@ -60,35 +60,31 @@ class MSDFit(DataProcessorAlgorithm):
         issues = dict()
 
         workspace = self.getProperty('InputWorkspace').value
-        if not isinstance(workspace, MatrixWorkspace):
-            issues['InputWorkspace'] = "The InputWorkspace must be a MatrixWorkspace."
-            return issues
-        x_data = workspace.readX(0)
-
-        # Validate X axis fitting range
         x_min = self.getProperty('XStart').value
         x_max = self.getProperty('XEnd').value
+        spec_min = self.getProperty('SpecMin').value
+        spec_max = self.getProperty('SpecMax').value
+
+        if isinstance(workspace, MatrixWorkspace):
+            x_data = workspace.readX(0)
+            if x_min < x_data[0]:
+                issues['XStart'] = 'Must be greater than minimum X value in workspace'
+
+            if x_max > x_data[-1]:
+                issues['XEnd'] = 'Must be less than maximum X value in workspace'
+
+            if spec_max > workspace.getNumberHistograms():
+                issues['SpecMax'] = 'Maximum spectrum number must be less than number of spectra in workspace'
+        else:
+            issues['InputWorkspace'] = "The InputWorkspace must be a MatrixWorkspace."
 
         if x_min > x_max:
             msg = 'XStart must be less then XEnd'
             issues['XStart'] = msg
             issues['XEnd'] = msg
 
-        if x_min < x_data[0]:
-            issues['XStart'] = 'Must be greater than minimum X value in workspace'
-
-        if x_max > x_data[-1]:
-            issues['XEnd'] = 'Must be less than maximum X value in workspace'
-
-        # Validate spectra fitting range
-        spec_min = self.getProperty('SpecMin').value
-        spec_max = self.getProperty('SpecMax').value
-
         if spec_min < 0:
             issues['SpecMin'] = 'Minimum spectrum number must be greater than or equal to 0'
-
-        if spec_max > workspace.getNumberHistograms():
-            issues['SpecMax'] = 'Maximum spectrum number must be less than number of spectra in workspace'
 
         if spec_min > spec_max:
             msg = 'SpecMin must be less then SpecMax'

--- a/Testing/SystemTests/tests/qt/AlgorithmDialogsMDWorkspaceStartupTest.py
+++ b/Testing/SystemTests/tests/qt/AlgorithmDialogsMDWorkspaceStartupTest.py
@@ -16,9 +16,6 @@ class AlgorithmDialogsMDWorkspaceStartupTest(AlgorithmDialogsStartupTestBase):
 
     def _setup_test(self) -> None:
         self._workspace_type = "MDWorkspace"
-        # These algorithms currently fail to open when the given workspace type is auto-selected from the ADS
-        self._exclude_algorithms = ["HB2AReduce", "MaskAngle", "MuonPairingAsymmetry", "TOFTOFCropWorkspace",
-                                    "VesuvioResolution"]
 
         CreateMDWorkspace(Dimensions="3", EventType="MDEvent", Extents='-10,10,-5,5,-1,1',
                           Names="Q_lab_x,Q_lab_y,Q_lab_z", Units="1\\A,1\\A,1\\A", OutputWorkspace="ws")

--- a/Testing/SystemTests/tests/qt/AlgorithmDialogsMatrixWorkspaceStartupTest.py
+++ b/Testing/SystemTests/tests/qt/AlgorithmDialogsMatrixWorkspaceStartupTest.py
@@ -16,7 +16,5 @@ class AlgorithmDialogsMatrixWorkspaceStartupTest(AlgorithmDialogsStartupTestBase
 
     def _setup_test(self) -> None:
         self._workspace_type = "MatrixWorkspace"
-        # These algorithms currently fail to open when the given workspace type is auto-selected from the ADS
-        self._exclude_algorithms = ["HB2AReduce", "MaskBinsIf", "MuonPairingAsymmetry"]
 
         CreateSampleWorkspace(OutputWorkspace="ws")

--- a/Testing/SystemTests/tests/qt/AlgorithmDialogsStartupTestBase.py
+++ b/Testing/SystemTests/tests/qt/AlgorithmDialogsStartupTestBase.py
@@ -45,12 +45,10 @@ class AlgorithmDialogsStartupTestBase(MantidSystemTest, metaclass=ABCMeta):
             self.fail("Failed to find any of the Algorithms.")
 
         print(f"Running the AlgorithmDialog{self._workspace_type}StartupTest with a {self._workspace_type} in the ADS")
-        print(f"Excluding the following algorithms from the test: {str(self._exclude_algorithms)}")
 
         for algorithm_name in self._unique_algorithm_names:
-            if algorithm_name not in self._exclude_algorithms:
-                # print(algorithm_name)  # Useful for debugging when an algorithm dialog crashes
-                self._attempt_to_open_algorithm_dialog(self._workspace_type, algorithm_name)
+            # print(algorithm_name)  # Useful for debugging when an algorithm dialog crashes
+            self._attempt_to_open_algorithm_dialog(self._workspace_type, algorithm_name)
 
     def _attempt_to_open_algorithm_dialog(self, workspace_type: str, algorithm_name: str) -> None:
         """Attempt to open the most recent version of the algorithm provided."""

--- a/Testing/SystemTests/tests/qt/AlgorithmDialogsTableWorkspaceStartupTest.py
+++ b/Testing/SystemTests/tests/qt/AlgorithmDialogsTableWorkspaceStartupTest.py
@@ -16,8 +16,5 @@ class AlgorithmDialogsTableWorkspaceStartupTest(AlgorithmDialogsStartupTestBase)
 
     def _setup_test(self) -> None:
         self._workspace_type = "TableWorkspace"
-        # These algorithms currently fail to open when the given workspace type is auto-selected from the ADS
-        self._exclude_algorithms = ["HB2AReduce", "MaskAngle", "MuonPairingAsymmetry", "TOFTOFCropWorkspace",
-                                    "VesuvioResolution"]
 
         CreateEmptyTableWorkspace(OutputWorkspace="ws")

--- a/Testing/SystemTests/tests/qt/AlgorithmDialogsWorkspaceGroupStartupTest.py
+++ b/Testing/SystemTests/tests/qt/AlgorithmDialogsWorkspaceGroupStartupTest.py
@@ -16,13 +16,6 @@ class AlgorithmDialogsWorkspaceGroupStartupTest(AlgorithmDialogsStartupTestBase)
 
     def _setup_test(self) -> None:
         self._workspace_type = "WorkspaceGroup"
-        # These algorithms currently fail to open when the given workspace type is auto-selected from the ADS
-        self._exclude_algorithms = ["CylinderPaalmanPingsCorrection",
-                                    "EnggEstimateFocussedBackground", "FlatPlatePaalmanPingsCorrection",
-                                    "GetDetectorOffsets", "HB2AReduce", "HB3APredictPeaks", "LorentzCorrection",
-                                    "MaskBinsIf", "MaskNonOverlappingBins", "MSDFit", "MuonPairingAsymmetry",
-                                    "PDConvertRealSpace", "RebinRagged", "SetMDFrame", "Stitch1D", "Symmetrise",
-                                    "TOFTOFCropWorkspace", "VesuvioResolution", "XrayAbsorptionCorrection"]
 
         ws1 = CreateSampleWorkspace()
         ws2 = CreateSampleWorkspace()

--- a/Testing/SystemTests/tests/qt/AlgorithmDialogsWorkspaceGroupStartupTest.py
+++ b/Testing/SystemTests/tests/qt/AlgorithmDialogsWorkspaceGroupStartupTest.py
@@ -17,8 +17,7 @@ class AlgorithmDialogsWorkspaceGroupStartupTest(AlgorithmDialogsStartupTestBase)
     def _setup_test(self) -> None:
         self._workspace_type = "WorkspaceGroup"
         # These algorithms currently fail to open when the given workspace type is auto-selected from the ADS
-        self._exclude_algorithms = ["AnvredCorrection", "CalculateDynamicRange", "CopyDataRange", "CreateEPP",
-                                    "CropToComponent", "CylinderPaalmanPingsCorrection",
+        self._exclude_algorithms = ["CylinderPaalmanPingsCorrection",
                                     "EnggEstimateFocussedBackground", "FlatPlatePaalmanPingsCorrection",
                                     "GetDetectorOffsets", "HB2AReduce", "HB3APredictPeaks", "LorentzCorrection",
                                     "MaskBinsIf", "MaskNonOverlappingBins", "MSDFit", "MuonPairingAsymmetry",

--- a/docs/source/release/v6.5.0/Workbench/Bugfixes/34114.rst
+++ b/docs/source/release/v6.5.0/Workbench/Bugfixes/34114.rst
@@ -1,0 +1,1 @@
+- A large number of crashes have been fixed caused by opening an Algorithm Dialog and populating it with a WorkspaceGroup.


### PR DESCRIPTION
**Description of work.**
This PR fixes a large number of crashes caused when opening an algorithm dialog and auto-populating a variable such as an InputWorkspace with a WorkspaceGroup (or other types of workspace which are not compatible with the `validateInputs` method of a specific algorithm).

Most of the problems could be fixed by checking that the correct workspace type had been provided before performing any further checks on the data.

**To test:**
Code review, and make sure the `AlgorithmDialogStartupTests` all pass.

Fixes #34114

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
