### PR TITLE
Fix initial parameter setting for the Iqt fit model

### DIFF
--- a/qt/scientific_interfaces/Indirect/IndirectFunctionBrowser/IqtFunctionModel.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFunctionBrowser/IqtFunctionModel.cpp
@@ -557,7 +557,7 @@ void IqtFunctionModel::estimateExpParameters() {
     auto const &x = m_estimationData[i].x;
     auto const &y = m_estimationData[i].y;
     auto lifeTime = (x[1] - x[0]) / (log(y[0]) - log(y[1]));
-    if (lifeTime <= 0)
+    if (lifeTime <= 0 || isnan(lifeTime))
       lifeTime = 1.0;
     auto const height = y[0] * exp(x[0] / lifeTime);
     setLocalParameterValue(*heightName1, i, height);

--- a/qt/scientific_interfaces/Indirect/IndirectFunctionBrowser/IqtFunctionModel.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFunctionBrowser/IqtFunctionModel.cpp
@@ -557,7 +557,7 @@ void IqtFunctionModel::estimateExpParameters() {
     auto const &x = m_estimationData[i].x;
     auto const &y = m_estimationData[i].y;
     auto lifeTime = (x[1] - x[0]) / (log(y[0]) - log(y[1]));
-    if (lifeTime <= 0 || isnan(lifeTime))
+    if (!(lifeTime > 0))
       lifeTime = 1.0;
     auto const height = y[0] * exp(x[0] / lifeTime);
     setLocalParameterValue(*heightName1, i, height);


### PR DESCRIPTION
In case of a wrong function the lifetime and height parameter estimation
may create a NaN value. This will now omitted by setting the lifetime to
1 in this case.

**Description of work.**

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**

<!-- Instructions for testing. -->

 <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or master)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---
