### PR TITLE
Improve Instrumentview startup speed

### DIFF
--- a/docs/source/release/v6.5.0/Workbench/InstrumentViewer/Bugfixes/34172.rst
+++ b/docs/source/release/v6.5.0/Workbench/InstrumentViewer/Bugfixes/34172.rst
@@ -1,0 +1,3 @@
+- The instrument view startup time has been improved by avoid checking for masking
+  if it is not present.
+

--- a/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/InstrumentActor.h
+++ b/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/InstrumentActor.h
@@ -84,7 +84,6 @@ public:
   /// Check if any child is visible
   bool hasChildVisible() const;
   /// Get the underlying instrument
-  std::vector<size_t> getMonitors() const;
   std::shared_ptr<const Mantid::Geometry::Instrument> getInstrument() const;
   /// Get the associated data workspace
   std::shared_ptr<const Mantid::API::MatrixWorkspace> getWorkspace() const;
@@ -256,7 +255,7 @@ private:
   mutable MaskBinsData m_maskBinsData;
   QString m_currentCMap;
   /// integrated spectra
-  std::vector<double> m_specIntegrs;
+  std::vector<double> m_integratedSignal;
   /// The workspace data and bin range limits
   double m_WkspBinMinValue, m_WkspBinMaxValue;
   // The user requested data and bin ranges

--- a/qt/widgets/instrumentview/src/InstrumentActor.cpp
+++ b/qt/widgets/instrumentview/src/InstrumentActor.cpp
@@ -1031,7 +1031,7 @@ void InstrumentActor::setDataIntegrationRange(const double &xmin, const double &
     m_DataMaxValue = -DBL_MAX;
 
     const auto &spectrumInfo = workspace->spectrumInfo();
-    auto maskWksp = getMaskWorkspace();
+    auto maskWksp = getMaskWorkspaceIfExists();
 
     // Ignore monitors if multiple detectors aren't grouped.
     for (size_t i = 0; i < m_integratedSignal.size(); i++) {

--- a/qt/widgets/instrumentview/src/InstrumentActor.cpp
+++ b/qt/widgets/instrumentview/src/InstrumentActor.cpp
@@ -355,8 +355,6 @@ void InstrumentActor::clearMasks() {
   }
 }
 
-std::vector<size_t> InstrumentActor::getMonitors() const { return m_monitors; }
-
 Instrument_const_sptr InstrumentActor::getInstrument() const {
   auto sharedWorkspace = getWorkspace();
   Mantid::Kernel::ReadLock _lock(*sharedWorkspace);
@@ -438,7 +436,7 @@ double InstrumentActor::getIntegratedCounts(size_t index) const {
   auto i = getWorkspaceIndex(index);
   if (i == INVALID_INDEX)
     return InstrumentActor::INVALID_VALUE;
-  return m_specIntegrs.at(i);
+  return m_integratedSignal.at(i);
 }
 
 /**
@@ -622,7 +620,7 @@ void InstrumentActor::sumDetectorsRagged(const std::vector<size_t> &dets, std::v
 
 /**
  * Recalculate the detector colors based on the integrated values in
- * m_specIntegrs and
+ * m_integratedSignal and
  * the masking information in ....
  */
 void InstrumentActor::resetColors() {
@@ -994,13 +992,13 @@ void InstrumentActor::setDataMinMaxRange(double vmin, double vmax) {
 
 void InstrumentActor::calculateIntegratedSpectra(const Mantid::API::MatrixWorkspace &workspace) {
   // Use the workspace function to get the integrated spectra
-  workspace.getIntegratedSpectra(m_specIntegrs, m_BinMinValue, m_BinMaxValue, wholeRange());
+  workspace.getIntegratedSpectra(m_integratedSignal, m_BinMinValue, m_BinMaxValue, wholeRange());
   // replace any values that are not finite
   std::replace_if(
-      m_specIntegrs.begin(), m_specIntegrs.end(), [](double x) { return !std::isfinite(x); },
+      m_integratedSignal.begin(), m_integratedSignal.end(), [](double x) { return !std::isfinite(x); },
       InstrumentActor::INVALID_VALUE);
 
-  m_maskBinsData.subtractIntegratedSpectra(workspace, m_specIntegrs);
+  m_maskBinsData.subtractIntegratedSpectra(workspace, m_integratedSignal);
 }
 
 void InstrumentActor::setDataIntegrationRange(const double &xmin, const double &xmax) {
@@ -1018,12 +1016,12 @@ void InstrumentActor::setDataIntegrationRange(const double &xmin, const double &
     monitorIndices.emplace(index);
   }
   // check that there is at least 1 non-monitor spectrum
-  if (monitorIndices.size() == m_specIntegrs.size()) {
+  if (monitorIndices.size() == m_integratedSignal.size()) {
     // there are only monitors - cannot skip them
     monitorIndices.clear();
   }
 
-  if (m_specIntegrs.empty()) {
+  if (m_integratedSignal.empty()) {
     // in case there are no spectra set some arbitrary values
     m_DataMinValue = 1.0;
     m_DataMaxValue = 10.0;
@@ -1036,7 +1034,7 @@ void InstrumentActor::setDataIntegrationRange(const double &xmin, const double &
     auto maskWksp = getMaskWorkspace();
 
     // Ignore monitors if multiple detectors aren't grouped.
-    for (size_t i = 0; i < m_specIntegrs.size(); i++) {
+    for (size_t i = 0; i < m_integratedSignal.size(); i++) {
       const auto &spectrumDefinition = spectrumInfo.spectrumDefinition(i);
       // Ignore monitors if they are masked on the view
       if (spectrumDefinition.size() == 1 &&
@@ -1044,7 +1042,7 @@ void InstrumentActor::setDataIntegrationRange(const double &xmin, const double &
            (maskWksp && maskWksp->isMasked(static_cast<int>(i)))))
         continue;
 
-      auto sum = m_specIntegrs[i];
+      auto sum = m_integratedSignal[i];
 
       if (sum == InstrumentActor::INVALID_VALUE)
         continue;


### PR DESCRIPTION
**Description of work.**

Speeds up the instrument view rendering when no masking is present on the view.

Some code cleanup has also been applied. The second commit contains the key changes.

**To test:**

In a debug build this was much slower and nearly unusable before this fix.

* Run `LoadEmptyInstrument` with `InstrumentName` `MAPS`
* Show the instrument and it should be created within a second or 2. Previously you could wait ~5-10s and in a debug build possible more.
* Try a variety of other instruments.

Fixes #34166 

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
