### PR TITLE
Fix Time Slicing Settings Being Incorrect After Loading a Batch

### DIFF
--- a/docs/source/release/v6.5.0/Reflectometry/Bugfixes/34128_time_slicing.rst
+++ b/docs/source/release/v6.5.0/Reflectometry/Bugfixes/34128_time_slicing.rst
@@ -1,0 +1,1 @@
+- The settings from the ``Event Handling`` tab are now correctly applied after loading a batch.

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Common/Decoder.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Common/Decoder.cpp
@@ -452,12 +452,12 @@ void Decoder::decodeSave(const QtSaveView *gui, const QMap<QString, QVariant> &m
 void Decoder::decodeEvent(const QtEventView *gui, const QMap<QString, QVariant> &map) {
   gui->m_ui.disabledSlicingButton->setChecked(map[QString("disabledSlicingButton")].toBool());
   gui->m_ui.uniformEvenButton->setChecked(map[QString("uniformEvenButton")].toBool());
-  gui->m_ui.uniformEvenEdit->setValue(static_cast<int>(map[QString("uniformEvenEdit")].toDouble()));
   gui->m_ui.uniformButton->setChecked(map[QString("uniformButton")].toBool());
-  gui->m_ui.uniformEdit->setValue(map[QString("uniformEdit")].toDouble());
   gui->m_ui.customButton->setChecked(map[QString("customButton")].toBool());
-  gui->m_ui.customEdit->setText(map[QString("customEdit")].toString());
   gui->m_ui.logValueButton->setChecked(map[QString("logValueButton")].toBool());
+  gui->m_ui.uniformEvenEdit->setValue(static_cast<int>(map[QString("uniformEvenEdit")].toDouble()));
+  gui->m_ui.uniformEdit->setValue(map[QString("uniformEdit")].toDouble());
+  gui->m_ui.customEdit->setText(map[QString("customEdit")].toString());
   gui->m_ui.logValueEdit->setText(map[QString("logValueEdit")].toString());
   gui->m_ui.logValueTypeEdit->setText(map[QString("logValueTypeEdit")].toString());
 }

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Event/EventPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Event/EventPresenter.cpp
@@ -25,28 +25,38 @@ void EventPresenter::acceptMainPresenter(IBatchPresenter *mainPresenter) { m_mai
 Slicing const &EventPresenter::slicing() const { return m_slicing; }
 
 void EventPresenter::notifyUniformSliceCountChanged(int) {
-  setUniformSlicingByNumberOfSlicesFromView();
-  m_mainPresenter->notifySettingsChanged();
+  if (m_sliceType == SliceType::UniformEven) {
+    setUniformSlicingByNumberOfSlicesFromView();
+    m_mainPresenter->notifySettingsChanged();
+  }
 }
 
 void EventPresenter::notifyUniformSecondsChanged(double) {
-  setUniformSlicingByTimeFromView();
-  m_mainPresenter->notifySettingsChanged();
+  if (m_sliceType == SliceType::Uniform) {
+    setUniformSlicingByTimeFromView();
+    m_mainPresenter->notifySettingsChanged();
+  }
 }
 
 void EventPresenter::notifyCustomSliceValuesChanged(std::string) {
-  setCustomSlicingFromView();
-  m_mainPresenter->notifySettingsChanged();
+  if (m_sliceType == SliceType::Custom) {
+    setCustomSlicingFromView();
+    m_mainPresenter->notifySettingsChanged();
+  }
 }
 
 void EventPresenter::notifyLogSliceBreakpointsChanged(std::string) {
-  setLogValueSlicingFromView();
-  m_mainPresenter->notifySettingsChanged();
+  if (m_sliceType == SliceType::LogValue) {
+    setLogValueSlicingFromView();
+    m_mainPresenter->notifySettingsChanged();
+  }
 }
 
 void EventPresenter::notifyLogBlockNameChanged(std::string) {
-  setLogValueSlicingFromView();
-  m_mainPresenter->notifySettingsChanged();
+  if (m_sliceType == SliceType::LogValue) {
+    setLogValueSlicingFromView();
+    m_mainPresenter->notifySettingsChanged();
+  }
 }
 
 void EventPresenter::notifySliceTypeChanged(SliceType newSliceType) {

--- a/qt/scientific_interfaces/ISISReflectometry/test/Event/EventPresenterTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Event/EventPresenterTest.h
@@ -186,6 +186,7 @@ public:
 
   void testChangingSliceCountNotifiesMainPresenter() {
     auto presenter = makePresenter();
+    presenter.notifySliceTypeChanged(SliceType::UniformEven);
     EXPECT_CALL(m_mainPresenter, notifySettingsChanged()).Times(AtLeast(1));
     presenter.notifyUniformSliceCountChanged(1);
     verifyAndClear();
@@ -195,6 +196,20 @@ public:
     auto presenter = makePresenter();
     EXPECT_CALL(m_mainPresenter, notifySettingsChanged()).Times(AtLeast(1));
     presenter.notifyCustomSliceValuesChanged("");
+    verifyAndClear();
+  }
+
+  void testNoSlicingOccursWhenSliceTypeIsNone() {
+    auto presenter = makePresenter();
+    presenter.notifySliceTypeChanged(SliceType::None);
+
+    EXPECT_CALL(m_mainPresenter, notifySettingsChanged()).Times(0);
+    presenter.notifyUniformSliceCountChanged(2);
+    presenter.notifyUniformSecondsChanged(2);
+    presenter.notifyCustomSliceValuesChanged("string");
+    presenter.notifyLogSliceBreakpointsChanged("");
+    presenter.notifyLogBlockNameChanged("");
+
     verifyAndClear();
   }
 


### PR DESCRIPTION
**Description of work.**
Adds some checks to make sure that the time slicing settings are only applied after the correct radio button has been selected. This is to handle to behaviour that should not occur when the GUI is used (but can occur when a batch is loaded), where the settings for an unselected radio button are edited. 

**To test:**

1. Open the ISIS reflectometry GUI
2. In the runs table enter run 13460 and angle 0.5
3. In the Event Handling tab, select Uniform Slicing and set the value to 2
4. Back on the runs tab click process. This results in some output workspace groups containing 2 slices:
 ![image](https://user-images.githubusercontent.com/12895056/174631055-c5ee0383-15d1-44e0-ba92-e198fac255d9.png)
6. On the Event Handling tab, select Disable Slicing
7. Go to Batch->Save and specify a filename to save to
8. Close and re-open the GUI
9. Go to Batch->Load and select your file. 
10. Check the Event Handling tab - the slicing is seemingly still disabled
11. On the Runs tab, click process. You should now get a single `IvsQ_binned_13460` workspace output instead of a group.

Fixes #34128 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
