### PR TITLE
Add export button for the reduced workspace on the Preview tab

### DIFF
--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/RowProcessingAlgorithm.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/RowProcessingAlgorithm.cpp
@@ -259,10 +259,15 @@ namespace MantidQt::CustomInterfaces::ISISReflectometry::Reduction {
  * @param model : the reduction configuration model
  * @param row : the row from the preview tab
  */
-IConfiguredAlgorithm_sptr createConfiguredAlgorithm(IBatch const &model, PreviewRow &row) {
+IConfiguredAlgorithm_sptr createConfiguredAlgorithm(IBatch const &model, PreviewRow &row,
+                                                    Mantid::API::IAlgorithm_sptr alg) {
   // Create the algorithm
-  auto alg = Mantid::API::AlgorithmManager::Instance().create("ReflectometryReductionOneAuto");
+  if (!alg) {
+    alg = Mantid::API::AlgorithmManager::Instance().create("ReflectometryReductionOneAuto");
+  }
   alg->setRethrows(true);
+  alg->setAlwaysStoreInADS(false);
+  alg->getPointerToProperty("OutputWorkspace")->createTemporaryValue();
 
   // Set the algorithm properties from the model
   auto properties = createAlgorithmRuntimeProps(model, row);

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/RowProcessingAlgorithm.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/RowProcessingAlgorithm.cpp
@@ -17,6 +17,7 @@
 
 using namespace MantidQt::CustomInterfaces::ISISReflectometry;
 using Mantid::API::IAlgorithm_sptr;
+using Mantid::API::MatrixWorkspace_sptr;
 using MantidQt::API::AlgorithmRuntimeProps;
 using MantidQt::API::IConfiguredAlgorithm_sptr;
 
@@ -274,7 +275,7 @@ IConfiguredAlgorithm_sptr createConfiguredAlgorithm(IBatch const &model, Preview
 
   // Return the configured algorithm
   auto jobAlgorithm =
-      std::make_shared<BatchJobAlgorithm>(std::move(alg), std::move(properties), updateRowFromOutputProperties, &row);
+      std::make_shared<BatchJobAlgorithm>(std::move(alg), std::move(properties), updateRowOnAlgorithmComplete, &row);
   return jobAlgorithm;
 }
 
@@ -300,9 +301,15 @@ std::unique_ptr<MantidQt::API::IAlgorithmRuntimeProps> createAlgorithmRuntimePro
   // Update properties from the preview tab
   properties->setProperty("InputWorkspace", previewRow.getSummedWs());
   properties->setProperty("ProcessingInstructions", previewRow.getProcessingInstructions());
-  // TODO add theta once it is in the previewRow
-  // AlgorithmProperties::update("ThetaIn", previewRow.theta(), properties);
+  // TODO add the real theta once it is implemented in the previewRow
+  properties->setProperty("ThetaIn", 0.5);
   return properties;
+}
+
+void updateRowOnAlgorithmComplete(const IAlgorithm_sptr &algorithm, Item &item) {
+  auto &row = dynamic_cast<PreviewRow &>(item);
+  MatrixWorkspace_sptr outputWs = algorithm->getProperty("OutputWorkspace");
+  row.setReducedWs(outputWs);
 }
 } // namespace MantidQt::CustomInterfaces::ISISReflectometry::Reduction
 

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/RowProcessingAlgorithm.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/RowProcessingAlgorithm.cpp
@@ -301,8 +301,7 @@ std::unique_ptr<MantidQt::API::IAlgorithmRuntimeProps> createAlgorithmRuntimePro
   // Update properties from the preview tab
   properties->setProperty("InputWorkspace", previewRow.getSummedWs());
   properties->setProperty("ProcessingInstructions", previewRow.getProcessingInstructions());
-  // TODO add the real theta once it is implemented in the previewRow
-  properties->setProperty("ThetaIn", 0.5);
+  properties->setProperty("ThetaIn", previewRow.theta());
   return properties;
 }
 

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/RowProcessingAlgorithm.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/RowProcessingAlgorithm.cpp
@@ -299,6 +299,7 @@ std::unique_ptr<MantidQt::API::IAlgorithmRuntimeProps> createAlgorithmRuntimePro
   }
   // Update properties from the preview tab
   properties->setProperty("InputWorkspace", previewRow.getSummedWs());
+  properties->setProperty("ProcessingInstructions", previewRow.getProcessingInstructions());
   // TODO add theta once it is in the previewRow
   // AlgorithmProperties::update("ThetaIn", previewRow.theta(), properties);
   return properties;

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/RowProcessingAlgorithm.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/RowProcessingAlgorithm.h
@@ -10,6 +10,7 @@
 #include "MantidAPI/IAlgorithm_fwd.h"
 #include "MantidQtWidgets/Common/IAlgorithmRuntimeProps.h"
 #include "MantidQtWidgets/Common/IConfiguredAlgorithm.h"
+#include "Reduction/Item.h"
 #include <boost/optional.hpp>
 
 #include <map>
@@ -30,6 +31,8 @@ MANTIDQT_ISISREFLECTOMETRY_DLL MantidQt::API::IConfiguredAlgorithm_sptr
 createConfiguredAlgorithm(IBatch const &model, PreviewRow &row, Mantid::API::IAlgorithm_sptr alg = nullptr);
 MANTIDQT_ISISREFLECTOMETRY_DLL std::unique_ptr<MantidQt::API::IAlgorithmRuntimeProps>
 createAlgorithmRuntimeProps(IBatch const &model, PreviewRow const &row);
+MANTIDQT_ISISREFLECTOMETRY_DLL void updateRowOnAlgorithmComplete(const Mantid::API::IAlgorithm_sptr &algorithm,
+                                                                 Item &item);
 } // namespace MantidQt::CustomInterfaces::ISISReflectometry::Reduction
 
 namespace MantidQt::CustomInterfaces::ISISReflectometry::RowProcessing {

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/RowProcessingAlgorithm.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/RowProcessingAlgorithm.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include "Common/DllConfig.h"
+#include "MantidAPI/IAlgorithm_fwd.h"
 #include "MantidQtWidgets/Common/IAlgorithmRuntimeProps.h"
 #include "MantidQtWidgets/Common/IConfiguredAlgorithm.h"
 #include <boost/optional.hpp>
@@ -25,8 +26,8 @@ class Row;
 namespace MantidQt::CustomInterfaces::ISISReflectometry::Reduction {
 // These functions concern reduction of a workspace using ReflectometryReductionOneAuto. This is used to perform
 // just the reduction step on its own when performing on-the-fly reduction on the Preview tab
-MANTIDQT_ISISREFLECTOMETRY_DLL MantidQt::API::IConfiguredAlgorithm_sptr createConfiguredAlgorithm(IBatch const &model,
-                                                                                                  PreviewRow &row);
+MANTIDQT_ISISREFLECTOMETRY_DLL MantidQt::API::IConfiguredAlgorithm_sptr
+createConfiguredAlgorithm(IBatch const &model, PreviewRow &row, Mantid::API::IAlgorithm_sptr alg = nullptr);
 MANTIDQT_ISISREFLECTOMETRY_DLL std::unique_ptr<MantidQt::API::IAlgorithmRuntimeProps>
 createAlgorithmRuntimeProps(IBatch const &model, PreviewRow const &row);
 } // namespace MantidQt::CustomInterfaces::ISISReflectometry::Reduction

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Common/IJobManager.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Common/IJobManager.h
@@ -18,6 +18,7 @@ public:
 
   virtual void notifyLoadWorkspaceCompleted() = 0;
   virtual void notifySumBanksCompleted() = 0;
+  virtual void notifyReductionCompleted() = 0;
 };
 
 class MANTIDQT_ISISREFLECTOMETRY_DLL IJobManager {

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Common/IJobManager.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Common/IJobManager.h
@@ -27,5 +27,6 @@ public:
   virtual void subscribe(JobManagerSubscriber *notifyee) = 0;
   virtual void startPreprocessing(PreviewRow &row) = 0;
   virtual void startSumBanks(PreviewRow &row) = 0;
+  virtual void startReduction(PreviewRow &row) = 0;
 };
 } // namespace MantidQt::CustomInterfaces::ISISReflectometry

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/IPreviewModel.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/IPreviewModel.h
@@ -28,6 +28,8 @@ public:
   virtual Mantid::API::MatrixWorkspace_sptr getLoadedWs() const = 0;
   virtual std::vector<Mantid::detid_t> getSelectedBanks() const = 0;
   virtual Mantid::API::MatrixWorkspace_sptr getSummedWs() const = 0;
+  virtual Mantid::API::MatrixWorkspace_sptr getReducedWs() const = 0;
+  virtual Selection getSelectedRegion() const = 0;
 
   virtual void setSelectedBanks(std::vector<Mantid::detid_t> selectedBanks) = 0;
   virtual void setSelectedRegion(Selection const &selection) = 0;

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/IPreviewModel.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/IPreviewModel.h
@@ -16,17 +16,21 @@ class IJobManager;
 
 class IPreviewModel {
 public:
+  using Selection = std::vector<double>;
+
   IPreviewModel() = default;
   virtual ~IPreviewModel() = default;
   virtual bool loadWorkspaceFromAds(std::string const &workspaceName) = 0;
   virtual void loadAndPreprocessWorkspaceAsync(std::string const &workspaceName, IJobManager &jobManager) = 0;
   virtual void sumBanksAsync(IJobManager &jobManager) = 0;
+  virtual void reduceAsync(IJobManager &jobManager) = 0;
 
   virtual Mantid::API::MatrixWorkspace_sptr getLoadedWs() const = 0;
   virtual std::vector<Mantid::detid_t> getSelectedBanks() const = 0;
   virtual Mantid::API::MatrixWorkspace_sptr getSummedWs() const = 0;
 
   virtual void setSelectedBanks(std::vector<Mantid::detid_t> selectedBanks) = 0;
+  virtual void setSelectedRegion(Selection const &selection) = 0;
 
   virtual std::string detIDsToString(std::vector<Mantid::detid_t> const &indices) const = 0;
   virtual void exportSummedWsToAds() const = 0;

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/IPreviewModel.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/IPreviewModel.h
@@ -8,6 +8,7 @@
 
 #include "MantidAPI/MatrixWorkspace_fwd.h"
 #include "MantidGeometry/IDTypes.h"
+#include "Reduction/ProcessingInstructions.h"
 #include <string>
 #include <vector>
 
@@ -29,7 +30,7 @@ public:
   virtual std::vector<Mantid::detid_t> getSelectedBanks() const = 0;
   virtual Mantid::API::MatrixWorkspace_sptr getSummedWs() const = 0;
   virtual Mantid::API::MatrixWorkspace_sptr getReducedWs() const = 0;
-  virtual Selection getSelectedRegion() const = 0;
+  virtual ProcessingInstructions getProcessingInstructions() const = 0;
 
   virtual void setSelectedBanks(std::vector<Mantid::detid_t> selectedBanks) = 0;
   virtual void setSelectedRegion(Selection const &selection) = 0;

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/IPreviewModel.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/IPreviewModel.h
@@ -39,5 +39,6 @@ public:
 
   virtual std::string detIDsToString(std::vector<Mantid::detid_t> const &indices) const = 0;
   virtual void exportSummedWsToAds() const = 0;
+  virtual void exportReducedWsToAds() const = 0;
 };
 } // namespace MantidQt::CustomInterfaces::ISISReflectometry

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/IPreviewModel.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/IPreviewModel.h
@@ -32,6 +32,8 @@ public:
   virtual Mantid::API::MatrixWorkspace_sptr getReducedWs() const = 0;
   virtual ProcessingInstructions getProcessingInstructions() const = 0;
 
+  virtual void setTheta(double theta) = 0;
+
   virtual void setSelectedBanks(std::vector<Mantid::detid_t> selectedBanks) = 0;
   virtual void setSelectedRegion(Selection const &selection) = 0;
 

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/IPreviewView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/IPreviewView.h
@@ -25,6 +25,7 @@ public:
   virtual void notifyInstViewShapeChanged() = 0;
 
   virtual void notifyRegionSelectorExportAdsRequested() = 0;
+  virtual void notify1DPlotExportAdsRequested() = 0;
 
   // TODO implement edit ROI button and ROI-changed callback
   // virtual void notifyEditROIRequested() = 0;

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/IPreviewView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/IPreviewView.h
@@ -37,6 +37,7 @@ public:
   virtual ~IPreviewView() = default;
   virtual void subscribe(PreviewViewSubscriber *notifyee) noexcept = 0;
   virtual std::string getWorkspaceName() const = 0;
+  virtual double getAngle() const = 0;
   // Plotting
   virtual void plotInstView(MantidWidgets::InstrumentActor *instActor, Mantid::Kernel::V3D const &samplePos,
                             Mantid::Kernel::V3D const &axis) = 0;

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewJobManager.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewJobManager.cpp
@@ -99,6 +99,8 @@ void PreviewJobManager::startPreprocessing(PreviewRow &row) {
 
 void PreviewJobManager::startSumBanks(PreviewRow &row) { executeAlg(m_algFactory->makeSumBanksAlgorithm(row)); }
 
+void PreviewJobManager::startReduction(PreviewRow &row) { executeAlg(m_algFactory->makeReductionAlgorithm(row)); }
+
 void PreviewJobManager::executeAlg(IConfiguredAlgorithm_sptr alg) {
   m_jobRunner->clearAlgorithmQueue();
   m_jobRunner->setAlgorithmQueue(std::deque<IConfiguredAlgorithm_sptr>{std::move(alg)});

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewJobManager.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewJobManager.cpp
@@ -20,8 +20,9 @@ Mantid::Kernel::Logger g_log("Reflectometry Preview Job Manager");
 
 constexpr auto PREPROCESS_ALG_NAME = "ReflectometryISISPreprocess";
 constexpr auto SUM_BANKS_ALG_NAME = "ReflectometryISISSumBanks";
+constexpr auto REDUCTION_ALG_NAME = "ReflectometryReductionOneAuto";
 
-enum class AlgorithmType { PREPROCESS, SUM_BANKS };
+enum class AlgorithmType { PREPROCESS, SUM_BANKS, REDUCTION };
 
 AlgorithmType algorithmType(MantidQt::API::IConfiguredAlgorithm_sptr &configuredAlg) {
   auto const &name = configuredAlg->algorithm()->name();
@@ -29,6 +30,8 @@ AlgorithmType algorithmType(MantidQt::API::IConfiguredAlgorithm_sptr &configured
     return AlgorithmType::PREPROCESS;
   } else if (name == SUM_BANKS_ALG_NAME) {
     return AlgorithmType::SUM_BANKS;
+  } else if (name == REDUCTION_ALG_NAME) {
+    return AlgorithmType::REDUCTION;
   } else {
     throw std::logic_error(std::string("Preview tab error: callback from invalid algorithm ") + name);
   }
@@ -72,6 +75,9 @@ void PreviewJobManager::notifyAlgorithmComplete(API::IConfiguredAlgorithm_sptr &
   case AlgorithmType::SUM_BANKS:
     m_notifyee->notifySumBanksCompleted();
     break;
+  case AlgorithmType::REDUCTION:
+    m_notifyee->notifyReductionCompleted();
+    break;
   };
 }
 
@@ -89,6 +95,9 @@ void PreviewJobManager::notifyAlgorithmError(API::IConfiguredAlgorithm_sptr algo
     break;
   case AlgorithmType::SUM_BANKS:
     g_log.error(std::string("Error summing banks: ") + message);
+    break;
+  case AlgorithmType::REDUCTION:
+    g_log.error(std::string("Error performing reduction: ") + message);
     break;
   };
 }

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewJobManager.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewJobManager.h
@@ -22,6 +22,7 @@ public:
   void subscribe(JobManagerSubscriber *notifyee) override;
   void startPreprocessing(PreviewRow &row) override;
   void startSumBanks(PreviewRow &row) override;
+  void startReduction(PreviewRow &row) override;
 
   // JobRunnerSubscriber overrides
   void notifyBatchComplete(bool) override;

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewModel.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewModel.cpp
@@ -72,6 +72,11 @@ void PreviewModel::loadAndPreprocessWorkspaceAsync(std::string const &workspaceN
  */
 void PreviewModel::sumBanksAsync(IJobManager &jobManager) { jobManager.startSumBanks(*m_runDetails); }
 
+void PreviewModel::reduceAsync(IJobManager &jobManager) {
+  // TODO implement
+  // jobManager.startReduction(*m_runDetails);
+}
+
 MatrixWorkspace_sptr PreviewModel::getLoadedWs() const { return m_runDetails->getLoadedWs(); }
 MatrixWorkspace_sptr PreviewModel::getSummedWs() const { return m_runDetails->getSummedWs(); }
 
@@ -79,6 +84,10 @@ std::vector<Mantid::detid_t> PreviewModel::getSelectedBanks() const { return m_r
 
 void PreviewModel::setSelectedBanks(std::vector<Mantid::detid_t> selectedBanks) {
   m_runDetails->setSelectedBanks(std::move(selectedBanks));
+}
+
+void PreviewModel::setSelectedRegion(Selection const &selection) {
+  // TODO implement
 }
 
 void PreviewModel::createRunDetails(const std::string &workspaceName) {

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewModel.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewModel.cpp
@@ -80,6 +80,7 @@ MatrixWorkspace_sptr PreviewModel::getReducedWs() const { return m_runDetails->g
 
 std::vector<Mantid::detid_t> PreviewModel::getSelectedBanks() const { return m_runDetails->getSelectedBanks(); }
 
+void PreviewModel::setTheta(double theta) { m_runDetails->setTheta(theta); }
 void PreviewModel::setSelectedBanks(std::vector<Mantid::detid_t> selectedBanks) {
   m_runDetails->setSelectedBanks(std::move(selectedBanks));
 }

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewModel.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewModel.cpp
@@ -117,4 +117,13 @@ void PreviewModel::exportSummedWsToAds() const {
     g_log.error("Could not export summed WS. No rectangular selection has been made on the instrument viewer.");
   }
 }
+
+void PreviewModel::exportReducedWsToAds() const {
+  if (auto reducedWs = m_runDetails->getReducedWs()) {
+    AnalysisDataService::Instance().addOrReplace("preview_reduced_ws", reducedWs);
+  } else {
+    g_log.error(
+        "Could not export reduced WS. No selection has been made on the instrument viewer and/or region selector.");
+  }
+}
 } // namespace MantidQt::CustomInterfaces::ISISReflectometry

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewModel.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewModel.cpp
@@ -84,9 +84,22 @@ void PreviewModel::setSelectedBanks(std::vector<Mantid::detid_t> selectedBanks) 
   m_runDetails->setSelectedBanks(std::move(selectedBanks));
 }
 
-auto PreviewModel::getSelectedRegion() const -> Selection { return m_runDetails->getSelectedRegion(); }
+ProcessingInstructions PreviewModel::getProcessingInstructions() const {
+  return m_runDetails->getProcessingInstructions();
+}
 
-void PreviewModel::setSelectedRegion(Selection const &selection) { m_runDetails->setSelectedRegion(selection); }
+void PreviewModel::setSelectedRegion(Selection const &selection) {
+  // TODO We will need to allow for more complex selections, but for now the selection just consists two y indices
+  if (selection.size() != 2) {
+    throw std::runtime_error("Program error: unexpected selection size; expected 2, got " +
+                             std::to_string(selection.size()));
+  }
+  // For now we just support a y axis of spectrum number so round to the nearest integer
+  auto const start = static_cast<int>(std::round(selection[0]));
+  auto const end = static_cast<int>(std::round(selection[1]));
+  auto processingInstructions = ProcessingInstructions(std::to_string(start) + "-" + std::to_string(end));
+  m_runDetails->setProcessingInstructions(std::move(processingInstructions));
+}
 
 void PreviewModel::createRunDetails(const std::string &workspaceName) {
   m_runDetails = std::make_unique<PreviewRow>(std::vector<std::string>{workspaceName});

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewModel.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewModel.cpp
@@ -72,13 +72,11 @@ void PreviewModel::loadAndPreprocessWorkspaceAsync(std::string const &workspaceN
  */
 void PreviewModel::sumBanksAsync(IJobManager &jobManager) { jobManager.startSumBanks(*m_runDetails); }
 
-void PreviewModel::reduceAsync(IJobManager &jobManager) {
-  // TODO implement
-  // jobManager.startReduction(*m_runDetails);
-}
+void PreviewModel::reduceAsync(IJobManager &jobManager) { jobManager.startReduction(*m_runDetails); }
 
 MatrixWorkspace_sptr PreviewModel::getLoadedWs() const { return m_runDetails->getLoadedWs(); }
 MatrixWorkspace_sptr PreviewModel::getSummedWs() const { return m_runDetails->getSummedWs(); }
+MatrixWorkspace_sptr PreviewModel::getReducedWs() const { return m_runDetails->getReducedWs(); }
 
 std::vector<Mantid::detid_t> PreviewModel::getSelectedBanks() const { return m_runDetails->getSelectedBanks(); }
 
@@ -86,9 +84,9 @@ void PreviewModel::setSelectedBanks(std::vector<Mantid::detid_t> selectedBanks) 
   m_runDetails->setSelectedBanks(std::move(selectedBanks));
 }
 
-void PreviewModel::setSelectedRegion(Selection const &selection) {
-  // TODO implement
-}
+auto PreviewModel::getSelectedRegion() const -> Selection { return m_runDetails->getSelectedRegion(); }
+
+void PreviewModel::setSelectedRegion(Selection const &selection) { m_runDetails->setSelectedRegion(selection); }
 
 void PreviewModel::createRunDetails(const std::string &workspaceName) {
   m_runDetails = std::make_unique<PreviewRow>(std::vector<std::string>{workspaceName});

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewModel.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewModel.h
@@ -44,6 +44,7 @@ public:
   void setSelectedRegion(Selection const &selection) override;
 
   void exportSummedWsToAds() const override;
+  void exportReducedWsToAds() const override;
 
 private:
   // This should be an optional instead of a point, but we have issues reassigning it because boost::optional doesn't

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewModel.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewModel.h
@@ -29,6 +29,7 @@ public:
   bool loadWorkspaceFromAds(std::string const &workspaceName) override;
   void loadAndPreprocessWorkspaceAsync(std::string const &workspaceName, IJobManager &jobManager) override;
   void sumBanksAsync(IJobManager &jobManager) override;
+  void reduceAsync(IJobManager &jobManager) override;
 
   std::string detIDsToString(std::vector<Mantid::detid_t> const &indices) const override;
 
@@ -37,6 +38,8 @@ public:
   Mantid::API::MatrixWorkspace_sptr getSummedWs() const override;
 
   void setSelectedBanks(std::vector<Mantid::detid_t> selectedBanks) override;
+  void setSelectedRegion(Selection const &selection) override;
+
   void exportSummedWsToAds() const override;
 
 private:

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewModel.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewModel.h
@@ -39,6 +39,7 @@ public:
   ProcessingInstructions getProcessingInstructions() const override;
   Mantid::API::MatrixWorkspace_sptr getReducedWs() const override;
 
+  void setTheta(double theta) override;
   void setSelectedBanks(std::vector<Mantid::detid_t> selectedBanks) override;
   void setSelectedRegion(Selection const &selection) override;
 

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewModel.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewModel.h
@@ -36,6 +36,8 @@ public:
   Mantid::API::MatrixWorkspace_sptr getLoadedWs() const override;
   std::vector<Mantid::detid_t> getSelectedBanks() const override;
   Mantid::API::MatrixWorkspace_sptr getSummedWs() const override;
+  Selection getSelectedRegion() const override;
+  Mantid::API::MatrixWorkspace_sptr getReducedWs() const override;
 
   void setSelectedBanks(std::vector<Mantid::detid_t> selectedBanks) override;
   void setSelectedRegion(Selection const &selection) override;

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewModel.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewModel.h
@@ -36,7 +36,7 @@ public:
   Mantid::API::MatrixWorkspace_sptr getLoadedWs() const override;
   std::vector<Mantid::detid_t> getSelectedBanks() const override;
   Mantid::API::MatrixWorkspace_sptr getSummedWs() const override;
-  Selection getSelectedRegion() const override;
+  ProcessingInstructions getProcessingInstructions() const override;
   Mantid::API::MatrixWorkspace_sptr getReducedWs() const override;
 
   void setSelectedBanks(std::vector<Mantid::detid_t> selectedBanks) override;

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.cpp
@@ -124,10 +124,9 @@ void PreviewPresenter::notifyRectangularROIModeRequested() {
 }
 
 void PreviewPresenter::notifyRegionChanged() {
-  // TODO Get ROI from m_regionSelector and perform the reduction
   auto roi = m_regionSelector->getRegion();
-  g_log.notice("Region of interest was changed: " + std::to_string(roi[0]) + " to " + std::to_string(roi[1]));
   m_model->setSelectedRegion(roi);
+  g_log.notice("Running reduction on ROI: " + m_model->getProcessingInstructions());
   m_model->reduceAsync(*m_jobManager);
 }
 } // namespace MantidQt::CustomInterfaces::ISISReflectometry

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.cpp
@@ -78,6 +78,11 @@ void PreviewPresenter::notifyLoadWorkspaceCompleted() {
 
 void PreviewPresenter::notifySumBanksCompleted() { m_regionSelector->updateWorkspace(m_model->getSummedWs()); }
 
+void PreviewPresenter::notifyReductionCompleted() {
+  // TODO plot reduced workspace
+  g_log.notice("Reduction completed");
+}
+
 void PreviewPresenter::notifyInstViewSelectRectRequested() {
   m_view->setInstViewZoomState(false);
   m_view->setInstViewEditState(false);

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.cpp
@@ -124,9 +124,13 @@ void PreviewPresenter::notifyRectangularROIModeRequested() {
 }
 
 void PreviewPresenter::notifyRegionChanged() {
+  // Set the selection from the view
   auto roi = m_regionSelector->getRegion();
   m_model->setSelectedRegion(roi);
   g_log.notice("Running reduction on ROI: " + m_model->getProcessingInstructions());
+  // Ensure the angle is up to date
+  m_model->setTheta(m_view->getAngle());
+  // Perform the reduction
   m_model->reduceAsync(*m_jobManager);
 }
 } // namespace MantidQt::CustomInterfaces::ISISReflectometry

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.cpp
@@ -127,5 +127,7 @@ void PreviewPresenter::notifyRegionChanged() {
   // TODO Get ROI from m_regionSelector and perform the reduction
   auto roi = m_regionSelector->getRegion();
   g_log.notice("Region of interest was changed: " + std::to_string(roi[0]) + " to " + std::to_string(roi[1]));
+  m_model->setSelectedRegion(roi);
+  m_model->reduceAsync(*m_jobManager);
 }
 } // namespace MantidQt::CustomInterfaces::ISISReflectometry

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.cpp
@@ -133,4 +133,6 @@ void PreviewPresenter::notifyRegionChanged() {
   // Perform the reduction
   m_model->reduceAsync(*m_jobManager);
 }
+
+void PreviewPresenter::notify1DPlotExportAdsRequested() { m_model->exportReducedWsToAds(); }
 } // namespace MantidQt::CustomInterfaces::ISISReflectometry

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.h
@@ -61,6 +61,7 @@ public:
   void notifyInstViewShapeChanged() override;
 
   void notifyRegionSelectorExportAdsRequested() override;
+  void notify1DPlotExportAdsRequested() override;
 
   void notifyRectangularROIModeRequested() override;
 

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.h
@@ -67,6 +67,7 @@ public:
   // JobManagerSubscriber overrides
   void notifyLoadWorkspaceCompleted() override;
   void notifySumBanksCompleted() override;
+  void notifyReductionCompleted() override;
 
   // RegionSelectionObserver overrides
   void notifyRegionChanged() override;

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewWidget.ui
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewWidget.ui
@@ -162,10 +162,10 @@
           <item>
            <widget class="QToolButton" name="rs_ads_export_button">
             <property name="toolTip">
-             <string>Export the summed workspace to the ADS</string>
+             <string>Export the summed workspace to the workspaces list</string>
             </property>
             <property name="text">
-             <string>ADS Export</string>
+             <string>Export summed workspace</string>
             </property>
            </widget>
           </item>
@@ -202,9 +202,12 @@
       <widget class="QWidget" name="linePlotLayoutWidget">
        <layout class="QVBoxLayout" name="line_plot_layout">
         <item>
-         <widget class="QPushButton" name="plot_1d_toolbar_placeholder">
+         <widget class="QToolButton" name="plot_ads_export_button">
+          <property name="toolTip">
+           <string>Export the reduced workspace to the workspaces list</string>
+          </property>
           <property name="text">
-           <string>Toolbar 1d</string>
+           <string>Export reduced workspace</string>
           </property>
          </widget>
         </item>
@@ -237,7 +240,7 @@
  </widget>
  <tabstops>
   <tabstop>workspace_line_edit</tabstop>
-  <tabstop>plot_1d_toolbar_placeholder</tabstop>
+  <tabstop>plot_ads_export_button</tabstop>
   <tabstop>treeView</tabstop>
   <tabstop>tableWidget_2</tabstop>
   <tabstop>pushButton_3</tabstop>

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/QtPreviewView.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/QtPreviewView.cpp
@@ -58,6 +58,8 @@ void QtPreviewView::onSelectRectangularROIClicked() const { m_notifyee->notifyRe
 
 std::string QtPreviewView::getWorkspaceName() const { return m_ui.workspace_line_edit->text().toStdString(); }
 
+double QtPreviewView::getAngle() const { return m_ui.angle_spin_box->value(); }
+
 void QtPreviewView::plotInstView(MantidWidgets::InstrumentActor *instActor, V3D const &samplePos, V3D const &axis) {
   // We need to recreate the surface so disconnect any existing signals first
   if (m_instDisplay->getSurface()) {

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/QtPreviewView.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/QtPreviewView.cpp
@@ -29,6 +29,7 @@ void QtPreviewView::loadToolbarIcons() {
   m_ui.iv_rect_select_button->setIcon(MantidQt::Icons::getIcon("mdi.selection", "black", 1.3));
   m_ui.rs_ads_export_button->setIcon(MantidQt::Icons::getIcon("mdi.file-export", "black", 1.3));
   m_ui.rs_rect_select_button->setIcon(MantidQt::Icons::getIcon("mdi.selection", "black", 1.3));
+  m_ui.plot_ads_export_button->setIcon(MantidQt::Icons::getIcon("mdi.file-export", "black", 1.3));
 }
 
 void QtPreviewView::subscribe(PreviewViewSubscriber *notifyee) noexcept { m_notifyee = notifyee; }
@@ -43,6 +44,7 @@ void QtPreviewView::connectSignals() const {
   // Region selector toolbar
   connect(m_ui.rs_ads_export_button, SIGNAL(clicked()), this, SLOT(onRegionSelectorExportToAdsClicked()));
   connect(m_ui.rs_rect_select_button, SIGNAL(clicked()), this, SLOT(onSelectRectangularROIClicked()));
+  connect(m_ui.plot_ads_export_button, SIGNAL(clicked()), this, SLOT(on1DPlotExportToAdsClicked()));
 }
 
 void QtPreviewView::onLoadWorkspaceRequested() const { m_notifyee->notifyLoadWorkspaceRequested(); }
@@ -55,6 +57,8 @@ void QtPreviewView::onInstViewShapeChanged() const { m_notifyee->notifyInstViewS
 void QtPreviewView::onRegionSelectorExportToAdsClicked() const { m_notifyee->notifyRegionSelectorExportAdsRequested(); }
 
 void QtPreviewView::onSelectRectangularROIClicked() const { m_notifyee->notifyRectangularROIModeRequested(); }
+
+void QtPreviewView::on1DPlotExportToAdsClicked() const { m_notifyee->notify1DPlotExportAdsRequested(); }
 
 std::string QtPreviewView::getWorkspaceName() const { return m_ui.workspace_line_edit->text().toStdString(); }
 

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/QtPreviewView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/QtPreviewView.h
@@ -33,6 +33,7 @@ public:
   void subscribe(PreviewViewSubscriber *notifyee) noexcept override;
 
   std::string getWorkspaceName() const override;
+  double getAngle() const override;
   // Plotting
   void plotInstView(MantidWidgets::InstrumentActor *instActor, Mantid::Kernel::V3D const &samplePos,
                     Mantid::Kernel::V3D const &axis) override;

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/QtPreviewView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/QtPreviewView.h
@@ -56,7 +56,6 @@ private:
   Ui::PreviewWidget m_ui;
   PreviewViewSubscriber *m_notifyee{nullptr};
   std::unique_ptr<MantidQt::MantidWidgets::InstrumentDisplay> m_instDisplay{nullptr};
-  std::unique_ptr<MantidQt::Widgets::RegionSelector> m_regionSelector{nullptr};
 
   void connectSignals() const;
   void loadToolbarIcons();

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/QtPreviewView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/QtPreviewView.h
@@ -68,6 +68,7 @@ private slots:
   void onInstViewEditClicked() const;
   void onInstViewShapeChanged() const;
   void onRegionSelectorExportToAdsClicked() const;
+  void on1DPlotExportToAdsClicked() const;
   void onSelectRectangularROIClicked() const;
 };
 } // namespace MantidQt::CustomInterfaces::ISISReflectometry

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/PreviewRow.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/PreviewRow.cpp
@@ -12,11 +12,16 @@
 #include <vector>
 
 namespace MantidQt::CustomInterfaces::ISISReflectometry {
-PreviewRow::PreviewRow(const std::vector<std::string> &runNumbers) : Item(), m_runNumbers(std::move(runNumbers)) {
+PreviewRow::PreviewRow(const std::vector<std::string> &runNumbers)
+    : Item(), m_runNumbers(std::move(runNumbers)), m_theta{0.0} {
   std::sort(m_runNumbers.begin(), m_runNumbers.end());
 }
 
 std::vector<std::string> const &PreviewRow::runNumbers() const { return m_runNumbers; }
+
+double PreviewRow::theta() const { return m_theta; }
+
+void PreviewRow::setTheta(double theta) { m_theta = theta; }
 
 bool PreviewRow::isGroup() const { return false; }
 

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/PreviewRow.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/PreviewRow.cpp
@@ -40,9 +40,9 @@ void PreviewRow::setSelectedBanks(std::vector<Mantid::detid_t> selectedBanks) no
   m_selectedBanks = std::move(selectedBanks);
 }
 
-std::vector<double> PreviewRow::getSelectedRegion() const noexcept { return m_selectedRegion; }
+ProcessingInstructions PreviewRow::getProcessingInstructions() const noexcept { return m_processingInstructions; }
 
-void PreviewRow::setSelectedRegion(std::vector<double> selectedRegion) noexcept {
-  m_selectedRegion = std::move(selectedRegion);
+void PreviewRow::setProcessingInstructions(ProcessingInstructions processingInstructions) noexcept {
+  m_processingInstructions = std::move(processingInstructions);
 }
 } // namespace MantidQt::CustomInterfaces::ISISReflectometry

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/PreviewRow.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/PreviewRow.cpp
@@ -28,13 +28,21 @@ int PreviewRow::completedItems() const { return 1; }
 
 Mantid::API::MatrixWorkspace_sptr PreviewRow::getLoadedWs() const noexcept { return m_loadedWs; }
 Mantid::API::MatrixWorkspace_sptr PreviewRow::getSummedWs() const noexcept { return m_summedWs; }
+Mantid::API::MatrixWorkspace_sptr PreviewRow::getReducedWs() const noexcept { return m_reducedWs; }
 
 void PreviewRow::setLoadedWs(Mantid::API::MatrixWorkspace_sptr ws) noexcept { m_loadedWs = std::move(ws); }
 void PreviewRow::setSummedWs(Mantid::API::MatrixWorkspace_sptr ws) noexcept { m_summedWs = std::move(ws); }
+void PreviewRow::setReducedWs(Mantid::API::MatrixWorkspace_sptr ws) noexcept { m_reducedWs = std::move(ws); }
 
 std::vector<Mantid::detid_t> PreviewRow::getSelectedBanks() const noexcept { return m_selectedBanks; }
 
 void PreviewRow::setSelectedBanks(std::vector<Mantid::detid_t> selectedBanks) noexcept {
   m_selectedBanks = std::move(selectedBanks);
+}
+
+std::vector<double> PreviewRow::getSelectedRegion() const noexcept { return m_selectedRegion; }
+
+void PreviewRow::setSelectedRegion(std::vector<double> selectedRegion) noexcept {
+  m_selectedRegion = std::move(selectedRegion);
 }
 } // namespace MantidQt::CustomInterfaces::ISISReflectometry

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/PreviewRow.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/PreviewRow.h
@@ -29,6 +29,8 @@ public:
   PreviewRow &operator=(PreviewRow &&) = default;
 
   std::vector<std::string> const &runNumbers() const;
+  double theta() const;
+  void setTheta(double theta);
 
   bool isGroup() const override;
   bool isPreview() const override;
@@ -58,6 +60,7 @@ public:
 
 private:
   std::vector<std::string> m_runNumbers;
+  double m_theta;
   std::vector<Mantid::detid_t> m_selectedBanks;
   ProcessingInstructions m_processingInstructions;
   Mantid::API::MatrixWorkspace_sptr m_loadedWs;

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/PreviewRow.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/PreviewRow.h
@@ -39,11 +39,15 @@ public:
 
   Mantid::API::MatrixWorkspace_sptr getLoadedWs() const noexcept;
   Mantid::API::MatrixWorkspace_sptr getSummedWs() const noexcept;
+  Mantid::API::MatrixWorkspace_sptr getReducedWs() const noexcept;
   std::vector<Mantid::detid_t> getSelectedBanks() const noexcept;
+  std::vector<double> getSelectedRegion() const noexcept;
 
   void setLoadedWs(Mantid::API::MatrixWorkspace_sptr ws) noexcept;
   void setSummedWs(Mantid::API::MatrixWorkspace_sptr ws) noexcept;
+  void setReducedWs(Mantid::API::MatrixWorkspace_sptr ws) noexcept;
   void setSelectedBanks(std::vector<Mantid::detid_t> selectedBanks) noexcept;
+  void setSelectedRegion(std::vector<double> selectedRegion) noexcept;
 
   friend bool operator==(const PreviewRow &lhs, const PreviewRow &rhs) {
     // Note: This does not consider if the underlying item is equal currently
@@ -54,8 +58,10 @@ public:
 private:
   std::vector<std::string> m_runNumbers;
   std::vector<Mantid::detid_t> m_selectedBanks;
+  std::vector<double> m_selectedRegion;
   Mantid::API::MatrixWorkspace_sptr m_loadedWs;
   Mantid::API::MatrixWorkspace_sptr m_summedWs;
+  Mantid::API::MatrixWorkspace_sptr m_reducedWs;
 };
 
 } // namespace MantidQt::CustomInterfaces::ISISReflectometry

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/PreviewRow.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/PreviewRow.h
@@ -9,6 +9,7 @@
 #include "Item.h"
 #include "MantidAPI/MatrixWorkspace_fwd.h"
 #include "MantidGeometry/IDTypes.h"
+#include "Reduction/ProcessingInstructions.h"
 
 #include <string>
 #include <vector>
@@ -41,13 +42,13 @@ public:
   Mantid::API::MatrixWorkspace_sptr getSummedWs() const noexcept;
   Mantid::API::MatrixWorkspace_sptr getReducedWs() const noexcept;
   std::vector<Mantid::detid_t> getSelectedBanks() const noexcept;
-  std::vector<double> getSelectedRegion() const noexcept;
+  ProcessingInstructions getProcessingInstructions() const noexcept;
 
   void setLoadedWs(Mantid::API::MatrixWorkspace_sptr ws) noexcept;
   void setSummedWs(Mantid::API::MatrixWorkspace_sptr ws) noexcept;
   void setReducedWs(Mantid::API::MatrixWorkspace_sptr ws) noexcept;
   void setSelectedBanks(std::vector<Mantid::detid_t> selectedBanks) noexcept;
-  void setSelectedRegion(std::vector<double> selectedRegion) noexcept;
+  void setProcessingInstructions(ProcessingInstructions processingInstructions) noexcept;
 
   friend bool operator==(const PreviewRow &lhs, const PreviewRow &rhs) {
     // Note: This does not consider if the underlying item is equal currently
@@ -58,7 +59,7 @@ public:
 private:
   std::vector<std::string> m_runNumbers;
   std::vector<Mantid::detid_t> m_selectedBanks;
-  std::vector<double> m_selectedRegion;
+  ProcessingInstructions m_processingInstructions;
   Mantid::API::MatrixWorkspace_sptr m_loadedWs;
   Mantid::API::MatrixWorkspace_sptr m_summedWs;
   Mantid::API::MatrixWorkspace_sptr m_reducedWs;

--- a/qt/scientific_interfaces/ISISReflectometry/test/Batch/RowProcessingAlgorithmTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Batch/RowProcessingAlgorithmTest.h
@@ -49,8 +49,16 @@ public:
 
   void testExperimentSettingsWithPreviewRow() {
     auto model = Batch(m_experiment, m_instrument, m_runsTable, m_slicing);
-    auto result = Reduction::createAlgorithmRuntimeProps(model, makePreviewRow());
+    auto previewRow = makePreviewRow();
+    auto processingInstructions = std::string("2-3");
+    previewRow.setProcessingInstructions(processingInstructions);
+
+    auto result = Reduction::createAlgorithmRuntimeProps(model, previewRow);
+
+    // Check results from the experiment settings tab
     checkExperimentSettings(*result);
+    // Check the settings from the PreviewRow model
+    TS_ASSERT_EQUALS(result->getPropertyValue("ProcessingInstructions"), processingInstructions);
   }
 
   void testLookupRowWithAngleLookup() {

--- a/qt/scientific_interfaces/ISISReflectometry/test/Batch/RowProcessingAlgorithmTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Batch/RowProcessingAlgorithmTest.h
@@ -53,6 +53,8 @@ public:
     auto previewRow = makePreviewRow();
     auto processingInstructions = std::string("2-3");
     previewRow.setProcessingInstructions(processingInstructions);
+    auto theta = 0.7;
+    previewRow.setTheta(theta);
 
     auto result = Reduction::createAlgorithmRuntimeProps(model, previewRow);
 
@@ -60,6 +62,7 @@ public:
     checkExperimentSettings(*result);
     // Check the settings from the PreviewRow model
     TS_ASSERT_EQUALS(result->getPropertyValue("ProcessingInstructions"), processingInstructions);
+    assertProperty(*result, "ThetaIn", theta);
   }
 
   void testLookupRowWithAngleLookup() {

--- a/qt/scientific_interfaces/ISISReflectometry/test/Batch/RowProcessingAlgorithmTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Batch/RowProcessingAlgorithmTest.h
@@ -9,6 +9,7 @@
 #include "../../../ISISReflectometry/Reduction/Batch.h"
 #include "../../../ISISReflectometry/Reduction/PreviewRow.h"
 #include "../../../ISISReflectometry/TestHelpers/ModelCreationHelper.h"
+#include "MantidFrameworkTestHelpers/WorkspaceCreationHelper.h"
 
 #include <cxxtest/TestSuite.h>
 
@@ -253,6 +254,20 @@ public:
     TS_ASSERT_EQUALS(result->getPropertyValue("CostFunction"), "Unweighted least squares");
   }
 
+  void test_row_is_updated_on_reduction_algorithm_complete() {
+    auto mockAlg = std::make_shared<StubbedReduction>();
+    const bool isHistogram = true;
+    Mantid::API::MatrixWorkspace_sptr mockWs = WorkspaceCreationHelper::create1DWorkspaceRand(1, isHistogram);
+    mockAlg->addOutputWorkspace(mockWs);
+
+    auto runNumbers = std::vector<std::string>{};
+    auto row = PreviewRow(runNumbers);
+
+    Reduction::updateRowOnAlgorithmComplete(mockAlg, row);
+
+    TS_ASSERT_EQUALS(row.getReducedWs(), mockWs);
+  }
+
 private:
   std::vector<std::string> m_instruments;
   double m_thetaTolerance;
@@ -260,6 +275,21 @@ private:
   Instrument m_instrument;
   RunsTable m_runsTable;
   Slicing m_slicing;
+
+  class StubbedReduction : public WorkspaceCreationHelper::StubAlgorithm {
+  public:
+    StubbedReduction() {
+      this->setChild(true);
+      auto prop = std::make_unique<Mantid::API::WorkspaceProperty<>>(m_propName, "", Mantid::Kernel::Direction::Output);
+      declareProperty(std::move(prop));
+    }
+
+    void addOutputWorkspace(Mantid::API::MatrixWorkspace_sptr &ws) {
+      this->getPointerToProperty("OutputWorkspace")->createTemporaryValue();
+      setProperty(m_propName, ws);
+    }
+    const std::string m_propName = "OutputWorkspace";
+  };
 
   PreviewRow makePreviewRow() { return PreviewRow({"12345"}); }
 

--- a/qt/scientific_interfaces/ISISReflectometry/test/Preview/MockPreviewModel.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Preview/MockPreviewModel.h
@@ -37,5 +37,6 @@ public:
   MOCK_METHOD(void, reduceAsync, (IJobManager &), (override));
   MOCK_METHOD(std::string, detIDsToString, (std::vector<Mantid::detid_t> const &), (const, override));
   MOCK_METHOD(void, exportSummedWsToAds, (), (const, override));
+  MOCK_METHOD(void, exportReducedWsToAds, (), (const, override));
 };
 } // namespace MantidQt::CustomInterfaces::ISISReflectometry

--- a/qt/scientific_interfaces/ISISReflectometry/test/Preview/MockPreviewModel.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Preview/MockPreviewModel.h
@@ -29,6 +29,7 @@ public:
   MOCK_METHOD(std::vector<Mantid::detid_t>, getSelectedBanks, (), (const, override));
   MOCK_METHOD(ProcessingInstructions, getProcessingInstructions, (), (const, override));
 
+  MOCK_METHOD(void, setTheta, (double), (override));
   MOCK_METHOD(void, setSelectedBanks, (std::vector<Mantid::detid_t>), (override));
   MOCK_METHOD(void, setSelectedRegion, (Selection const &), (override));
 

--- a/qt/scientific_interfaces/ISISReflectometry/test/Preview/MockPreviewModel.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Preview/MockPreviewModel.h
@@ -25,7 +25,9 @@ public:
   MOCK_METHOD(void, loadAndPreprocessWorkspaceAsync, (std::string const &, IJobManager &), (override));
   MOCK_METHOD(MatrixWorkspace_sptr, getLoadedWs, (), (const, override));
   MOCK_METHOD(MatrixWorkspace_sptr, getSummedWs, (), (const, override));
+  MOCK_METHOD(MatrixWorkspace_sptr, getReducedWs, (), (const, override));
   MOCK_METHOD(std::vector<Mantid::detid_t>, getSelectedBanks, (), (const, override));
+  MOCK_METHOD(Selection, getSelectedRegion, (), (const, override));
 
   MOCK_METHOD(void, setSelectedBanks, (std::vector<Mantid::detid_t>), (override));
   MOCK_METHOD(void, setSelectedRegion, (Selection const &), (override));

--- a/qt/scientific_interfaces/ISISReflectometry/test/Preview/MockPreviewModel.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Preview/MockPreviewModel.h
@@ -27,7 +27,7 @@ public:
   MOCK_METHOD(MatrixWorkspace_sptr, getSummedWs, (), (const, override));
   MOCK_METHOD(MatrixWorkspace_sptr, getReducedWs, (), (const, override));
   MOCK_METHOD(std::vector<Mantid::detid_t>, getSelectedBanks, (), (const, override));
-  MOCK_METHOD(Selection, getSelectedRegion, (), (const, override));
+  MOCK_METHOD(ProcessingInstructions, getProcessingInstructions, (), (const, override));
 
   MOCK_METHOD(void, setSelectedBanks, (std::vector<Mantid::detid_t>), (override));
   MOCK_METHOD(void, setSelectedRegion, (Selection const &), (override));

--- a/qt/scientific_interfaces/ISISReflectometry/test/Preview/MockPreviewModel.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Preview/MockPreviewModel.h
@@ -28,8 +28,10 @@ public:
   MOCK_METHOD(std::vector<Mantid::detid_t>, getSelectedBanks, (), (const, override));
 
   MOCK_METHOD(void, setSelectedBanks, (std::vector<Mantid::detid_t>), (override));
+  MOCK_METHOD(void, setSelectedRegion, (Selection const &), (override));
 
   MOCK_METHOD(void, sumBanksAsync, (IJobManager &), (override));
+  MOCK_METHOD(void, reduceAsync, (IJobManager &), (override));
   MOCK_METHOD(std::string, detIDsToString, (std::vector<Mantid::detid_t> const &), (const, override));
   MOCK_METHOD(void, exportSummedWsToAds, (), (const, override));
 };

--- a/qt/scientific_interfaces/ISISReflectometry/test/Preview/MockPreviewView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Preview/MockPreviewView.h
@@ -20,6 +20,7 @@ class MockPreviewView : public IPreviewView {
 public:
   MOCK_METHOD(void, subscribe, (PreviewViewSubscriber *), (noexcept, override));
   MOCK_METHOD(std::string, getWorkspaceName, (), (const, override));
+  MOCK_METHOD(double, getAngle, (), (const, override));
   MOCK_METHOD(void, plotInstView,
               (MantidWidgets::InstrumentActor *, Mantid::Kernel::V3D const &, Mantid::Kernel::V3D const &), (override));
   MOCK_METHOD(void, setInstViewZoomState, (bool), (override));

--- a/qt/scientific_interfaces/ISISReflectometry/test/Preview/PreviewJobManagerTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Preview/PreviewJobManagerTest.h
@@ -111,6 +111,19 @@ public:
     jobManager.startSumBanks(previewRow);
   }
 
+  void test_start_reduction() {
+    auto mockAlgFactory = std::make_unique<MockReflAlgorithmFactory>();
+    auto mockJobRunner = MockJobRunner();
+    auto previewRow = makePreviewRow();
+    auto stubAlg = makeConfiguredAlg();
+
+    expectReductionAlgorithmCreated(*mockAlgFactory, previewRow, stubAlg);
+    expectAlgorithmExecuted(stubAlg, mockJobRunner);
+
+    auto jobManager = makeJobManager(&mockJobRunner, std::move(mockAlgFactory));
+    jobManager.startReduction(previewRow);
+  }
+
   void test_notify_sum_banks_algorithm_complete_notifies_subscriber() {
     auto mockJobRunner = MockJobRunner();
     auto mockSubscriber = MockJobManagerSubscriber();
@@ -238,6 +251,11 @@ private:
   void expectSumBanksAlgorithmCreated(MockReflAlgorithmFactory &mockAlgFactory, PreviewRow &previewRow,
                                       IConfiguredAlgorithm_sptr const &alg) {
     EXPECT_CALL(mockAlgFactory, makeSumBanksAlgorithm(Eq(ByRef(previewRow)))).Times(1).WillOnce(Return(alg));
+  }
+
+  void expectReductionAlgorithmCreated(MockReflAlgorithmFactory &mockAlgFactory, PreviewRow &previewRow,
+                                       IConfiguredAlgorithm_sptr const &alg) {
+    EXPECT_CALL(mockAlgFactory, makeReductionAlgorithm(Eq(ByRef(previewRow)))).Times(1).WillOnce(Return(alg));
   }
 
   void expectAlgorithmExecuted(IConfiguredAlgorithm_sptr const &alg, MockJobRunner &mockJobRunner) {

--- a/qt/scientific_interfaces/ISISReflectometry/test/Preview/PreviewJobManagerTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Preview/PreviewJobManagerTest.h
@@ -140,6 +140,22 @@ public:
     assertUpdateItemCallbackWasCalled();
   }
 
+  void test_notify_reduction_algorithm_complete_notifies_subscriber() {
+    auto mockJobRunner = MockJobRunner();
+    auto mockSubscriber = MockJobManagerSubscriber();
+
+    auto previewRow = makePreviewRow();
+    auto stubAlg = makeConfiguredReductionAlg(previewRow);
+
+    EXPECT_CALL(mockSubscriber, notifyReductionCompleted).Times(1);
+
+    auto jobManager = makeJobManager(&mockJobRunner, mockSubscriber);
+    auto stubAlgRef = std::static_pointer_cast<IConfiguredAlgorithm>(stubAlg);
+    jobManager.notifyAlgorithmComplete(stubAlgRef);
+
+    assertUpdateItemCallbackWasCalled();
+  }
+
   void test_notify_algorithm_complete_throws_with_unknown_algorithm() {
     auto mockJobRunner = MockJobRunner();
     auto mockSubscriber = MockJobManagerSubscriber();
@@ -199,6 +215,11 @@ private:
     const std::string name() const override { return "ReflectometryISISSumBanks"; }
   };
 
+  class StubAlgReduction : public StubAlgorithm {
+  public:
+    const std::string name() const override { return "ReflectometryReductionOneAuto"; }
+  };
+
   PreviewJobManager
   makeJobManager(MockJobRunner *mockJobRunner,
                  std::unique_ptr<IReflAlgorithmFactory> algFactory = std::make_unique<MockReflAlgorithmFactory>()) {
@@ -241,6 +262,10 @@ private:
 
   std::shared_ptr<ConfiguredAlgorithm> makeConfiguredSumBanksAlg(Item &item) {
     return makeConfiguredAlg(item, std::make_shared<StubAlgSumBanks>());
+  }
+
+  std::shared_ptr<ConfiguredAlgorithm> makeConfiguredReductionAlg(Item &item) {
+    return makeConfiguredAlg(item, std::make_shared<StubAlgReduction>());
   }
 
   void expectPreprocessingAlgCreated(MockReflAlgorithmFactory &mockAlgFactory, PreviewRow &previewRow,

--- a/qt/scientific_interfaces/ISISReflectometry/test/Preview/PreviewModelTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Preview/PreviewModelTest.h
@@ -82,6 +82,13 @@ public:
     TS_ASSERT_EQUALS(inputRoi, model.getSelectedBanks())
   }
 
+  void test_set_and_get_selected_region() {
+    PreviewModel model;
+    const IPreviewModel::Selection inputRoi{3.6, 11.4};
+    model.setSelectedRegion(inputRoi);
+    TS_ASSERT_EQUALS(inputRoi, model.getSelectedRegion())
+  }
+
   void test_sum_banks() {
     auto mockJobManager = MockJobManager();
     auto expectedWs = createWorkspace();
@@ -96,19 +103,19 @@ public:
     TS_ASSERT_EQUALS(workspace, expectedWs);
   }
 
-  //  void test_reduce() {
-  //    auto mockJobManager = MockJobManager();
-  //    auto expectedWs = createWorkspace();
-  //    EXPECT_CALL(mockJobManager, startReduction(_)).Times(1).WillOnce(Invoke(wsReductionEffect));
-  //    auto wsReductionEffect = [&expectedWs](PreviewRow &row) { row.setReducedWs(expectedWs); };
-  //
-  //    PreviewModel model;
-  //    model.reduceAsync(mockJobManager, selection);
-  //
-  //    auto workspace = model.getReducedWs();
-  //    TS_ASSERT(workspace);
-  //    TS_ASSERT_EQUALS(workspace, expectedWs);
-  //  }
+  void test_reduce() {
+    auto mockJobManager = MockJobManager();
+    auto expectedWs = createWorkspace();
+    auto wsReductionEffect = [&expectedWs](PreviewRow &row) { row.setReducedWs(expectedWs); };
+    EXPECT_CALL(mockJobManager, startReduction(_)).Times(1).WillOnce(Invoke(wsReductionEffect));
+
+    PreviewModel model;
+    model.reduceAsync(mockJobManager);
+
+    auto workspace = model.getReducedWs();
+    TS_ASSERT(workspace);
+    TS_ASSERT_EQUALS(workspace, expectedWs);
+  }
 
   void test_convert_detIDs_to_string() {
     PreviewModel model;

--- a/qt/scientific_interfaces/ISISReflectometry/test/Preview/PreviewModelTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Preview/PreviewModelTest.h
@@ -82,11 +82,12 @@ public:
     TS_ASSERT_EQUALS(inputRoi, model.getSelectedBanks())
   }
 
-  void test_set_and_get_selected_region() {
+  void test_set_selected_region_converts_to_processing_instructions_string() {
     PreviewModel model;
     const IPreviewModel::Selection inputRoi{3.6, 11.4};
     model.setSelectedRegion(inputRoi);
-    TS_ASSERT_EQUALS(inputRoi, model.getSelectedRegion())
+    // Start and end are rounded to nearest integer and converted to a string
+    TS_ASSERT_EQUALS(ProcessingInstructions{"4-11"}, model.getProcessingInstructions())
   }
 
   void test_sum_banks() {

--- a/qt/scientific_interfaces/ISISReflectometry/test/Preview/PreviewModelTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Preview/PreviewModelTest.h
@@ -96,6 +96,20 @@ public:
     TS_ASSERT_EQUALS(workspace, expectedWs);
   }
 
+  //  void test_reduce() {
+  //    auto mockJobManager = MockJobManager();
+  //    auto expectedWs = createWorkspace();
+  //    EXPECT_CALL(mockJobManager, startReduction(_)).Times(1).WillOnce(Invoke(wsReductionEffect));
+  //    auto wsReductionEffect = [&expectedWs](PreviewRow &row) { row.setReducedWs(expectedWs); };
+  //
+  //    PreviewModel model;
+  //    model.reduceAsync(mockJobManager, selection);
+  //
+  //    auto workspace = model.getReducedWs();
+  //    TS_ASSERT(workspace);
+  //    TS_ASSERT_EQUALS(workspace, expectedWs);
+  //  }
+
   void test_convert_detIDs_to_string() {
     PreviewModel model;
     auto const indices = std::vector<Mantid::detid_t>{99, 4, 5};

--- a/qt/scientific_interfaces/ISISReflectometry/test/Preview/PreviewPresenterTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Preview/PreviewPresenterTest.h
@@ -164,6 +164,16 @@ public:
     presenter.notifyRegionSelectorExportAdsRequested();
   }
 
+  void test_notify_1D_plot_export_to_ads_requested() {
+    auto mockView = makeView();
+    auto mockModel = makeModel();
+
+    EXPECT_CALL(*mockModel, exportReducedWsToAds()).Times(1);
+    auto presenter = PreviewPresenter(packDeps(mockView.get(), std::move(mockModel)));
+
+    presenter.notify1DPlotExportAdsRequested();
+  }
+
   void test_sum_banks_completed_plots_region_selector() {
     auto mockView = makeView();
     auto mockModel = makeModel();

--- a/qt/scientific_interfaces/ISISReflectometry/test/Preview/PreviewPresenterTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Preview/PreviewPresenterTest.h
@@ -191,6 +191,20 @@ public:
     presenter.notifyRectangularROIModeRequested();
   }
 
+  void test_notify_region_changed_starts_reduction() {
+    auto mockView = makeView();
+    auto mockModel = makeModel();
+    auto mockJobManager = makeJobManager();
+    auto mockRegionSelector_uptr = makeRegionSelector();
+    auto mockRegionSelector = mockRegionSelector_uptr.get();
+    // TODO reset edit mode after region is selected
+    // expectRegionSelectorSetToEditMode(*mockView);
+    expectReduceAsyncCalledOnSelectedRegion(*mockModel, *mockJobManager, *mockRegionSelector);
+    auto presenter = PreviewPresenter(packDeps(mockView.get(), std::move(mockModel), std::move(mockJobManager),
+                                               makeInstViewModel(), std::move(mockRegionSelector_uptr)));
+    presenter.notifyRegionChanged();
+  }
+
 private:
   MockViewT makeView() {
     auto mockView = std::make_unique<MockPreviewView>();
@@ -287,5 +301,13 @@ private:
     // EXPECT_CALL(mockView, setEditROIState(Eq(false))).Times(1);
     EXPECT_CALL(mockView, setRectangularROIState(Eq(true))).Times(1);
     EXPECT_CALL(mockRegionSelector, addRectangularRegion()).Times(1);
+  }
+
+  void expectReduceAsyncCalledOnSelectedRegion(MockPreviewModel &mockModel, MockJobManager &mockJobManager,
+                                               MockRegionSelector &mockRegionSelector) {
+    auto roi = IRegionSelector::Selection{3.5, 11.23};
+    EXPECT_CALL(mockRegionSelector, getRegion()).Times(1).WillOnce(Return(roi));
+    EXPECT_CALL(mockModel, setSelectedRegion(roi)).Times(1);
+    EXPECT_CALL(mockModel, reduceAsync(Ref(mockJobManager))).Times(1);
   }
 };

--- a/qt/scientific_interfaces/ISISReflectometry/test/ReflMockObjects.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/ReflMockObjects.h
@@ -302,6 +302,7 @@ class MockJobManagerSubscriber : public JobManagerSubscriber {
 public:
   MOCK_METHOD0(notifyLoadWorkspaceCompleted, void());
   MOCK_METHOD0(notifySumBanksCompleted, void());
+  MOCK_METHOD0(notifyReductionCompleted, void());
 };
 
 class MockEncoder : public IEncoder {

--- a/qt/scientific_interfaces/ISISReflectometry/test/ReflMockObjects.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/ReflMockObjects.h
@@ -295,6 +295,7 @@ public:
   MOCK_METHOD1(subscribe, void(JobManagerSubscriber *notifyee));
   MOCK_METHOD1(startPreprocessing, void(PreviewRow &row));
   MOCK_METHOD1(startSumBanks, void(PreviewRow &row));
+  MOCK_METHOD1(startReduction, void(PreviewRow &row));
 };
 
 class MockJobManagerSubscriber : public JobManagerSubscriber {

--- a/qt/widgets/regionselector/inc/MantidQtWidgets/RegionSelector/IRegionSelector.h
+++ b/qt/widgets/regionselector/inc/MantidQtWidgets/RegionSelector/IRegionSelector.h
@@ -10,15 +10,18 @@
 #include "MantidAPI/Workspace_fwd.h"
 #include "MantidQtWidgets/RegionSelector/DllConfig.h"
 
+#include <vector>
+
 class QLayout;
 
 namespace MantidQt::Widgets {
 class MANTID_REGIONSELECTOR_DLL IRegionSelector {
 public:
+  using Selection = std::vector<double>;
   virtual ~IRegionSelector() = default;
   virtual void subscribe(std::shared_ptr<Mantid::API::RegionSelectorObserver> const &notifyee) = 0;
   virtual void updateWorkspace(Mantid::API::Workspace_sptr const &workspace) = 0;
   virtual void addRectangularRegion() = 0;
-  virtual std::vector<double> getRegion() = 0;
+  virtual Selection getRegion() = 0;
 };
 } // namespace MantidQt::Widgets

--- a/qt/widgets/regionselector/inc/MantidQtWidgets/RegionSelector/RegionSelector.h
+++ b/qt/widgets/regionselector/inc/MantidQtWidgets/RegionSelector/RegionSelector.h
@@ -26,7 +26,7 @@ public:
   void subscribe(std::shared_ptr<Mantid::API::RegionSelectorObserver> const &notifyee) override;
   void updateWorkspace(Mantid::API::Workspace_sptr const &workspace) override;
   void addRectangularRegion() override;
-  std::vector<double> getRegion() override;
+  Selection getRegion() override;
 
 private:
   Common::Python::Object getView() const;

--- a/qt/widgets/regionselector/src/RegionSelector.cpp
+++ b/qt/widgets/regionselector/src/RegionSelector.cpp
@@ -85,10 +85,10 @@ void RegionSelector::addRectangularRegion() {
   pyobj().attr("add_rectangular_region")();
 }
 
-std::vector<double> RegionSelector::getRegion() {
+auto RegionSelector::getRegion() -> Selection {
   GlobalInterpreterLock lock;
   auto pyValues = pyobj().attr("get_region")();
-  auto result = std::vector<double>();
+  auto result = Selection();
   for (int i = 0; i < len(pyValues); ++i) {
     result.push_back(boost::python::extract<double>(pyValues[i]));
   }

--- a/qt/widgets/regionselector/test/MockRegionSelector.h
+++ b/qt/widgets/regionselector/test/MockRegionSelector.h
@@ -15,6 +15,6 @@ public:
   MOCK_METHOD(void, subscribe, (std::shared_ptr<Mantid::API::RegionSelectorObserver> const &), (override));
   MOCK_METHOD(void, updateWorkspace, (Mantid::API::Workspace_sptr const &workspace), (override));
   MOCK_METHOD(void, addRectangularRegion, (), (override));
-  MOCK_METHOD(std::vector<double>, getRegion, (), (override));
+  MOCK_METHOD(Selection, getRegion, (), (override));
 };
 } // namespace MantidQt::Widgets


### PR DESCRIPTION
**Depends on PR #34186.** To review, view the comparison with [that branch](https://github.com/gemmaguest/mantid/compare/34106_perform_reduction_on_roi_changed...34106_export_button_for_reduced_ws)

This PR adds a toolbar button to export the reduced workspace on the reflectometry GUI Preview tab to the ADS.

**To test:**

This must be run in a development build.

Note that this is work in progress on a hidden GUI component so is very rough and ready at the moment. The look and usability of these features is currently very poor so you do not need to test that side thoroughly; just ensure it performs as expected in the happy path case and does not crash etc.

- Ensure this workspace is loaded or is in your load path: [INTER45455_inst.zip](https://github.com/mantidproject/mantid/files/7504266/INTER45455_inst.zip)
- Open the ISIS Reflectometry GUI
- Select the Preview tab.
- Type in `INTER45455_inst`, set the angle to `0.5`, and click Load. The instrument view plot should now display data. Click the rectangle-select button above it and select a region. The second plot will now be updated. 
- Click the rectangle-selection button on the second plot and select a region. A reduction will now be performed on the selected spectra and a log message `Reduction completed` should be displayed.
  - You can see the counts better on the second plot if you set the color scale to SymmetricLog10, although there's a bug with autoscaling (un-tick and re-tick to get it to work).
  - Note that the reduction is quite picky and may fail; if so you will get a warning in the log. It's best to select a region around spectra 20-30.
- Click the Export button _below_ the second plot. This should export the workspace `preview_reduced_ws` to the ADS. Double click it and you should get a 1D plot. View its history and it should have run ReflectometryReductionOneAuto with the settings on the GUI. These will be taken from the Experiment and Instrument settings tab apart from ProcessingInstructions and Angle which are taken from the Preview tab.

![image](https://user-images.githubusercontent.com/12895056/177527512-dc895fba-ebee-4ef3-99af-d5fb7f198e3a.png)

Part of #34106 

*This does not require release notes* because **it only affects functionality that is not yet available in the release build**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
