### PR TITLE
Eliminate indirect qt warnings when opening interfaces

### DIFF
--- a/qt/scientific_interfaces/Indirect/FitStatusWidget.cpp
+++ b/qt/scientific_interfaces/Indirect/FitStatusWidget.cpp
@@ -36,19 +36,19 @@ QPalette getFitStatusColor(const std::string &status) {
 namespace MantidQt::CustomInterfaces::IDA {
 
 FitStatusWidget::FitStatusWidget(QWidget *parent) : QWidget(parent) {
-  auto fitInformationLayout = new QVBoxLayout(this);
+  auto fitInformationLayout = new QVBoxLayout();
 
-  auto fitStatusLayout = new QHBoxLayout(this);
-  auto fitStatusLabel = new QLabel(this);
+  auto fitStatusLayout = new QHBoxLayout();
+  auto fitStatusLabel = new QLabel();
   fitStatusLabel->setText(QString::fromStdString("Status:"));
-  m_fitStatus = new QLabel(this);
+  m_fitStatus = new QLabel();
   fitStatusLayout->addWidget(fitStatusLabel);
   fitStatusLayout->addWidget(m_fitStatus);
 
-  auto fitChiSquaredLayout = new QHBoxLayout(this);
-  auto fitChiSquaredLabel = new QLabel(this);
+  auto fitChiSquaredLayout = new QHBoxLayout();
+  auto fitChiSquaredLabel = new QLabel();
   fitChiSquaredLabel->setText(QString::fromStdString("Chi squared:"));
-  m_fitChiSquared = new QLabel(this);
+  m_fitChiSquared = new QLabel();
   fitChiSquaredLayout->addWidget(fitChiSquaredLabel);
   fitChiSquaredLayout->addWidget(m_fitChiSquared);
 

--- a/qt/scientific_interfaces/Indirect/IndirectBayes.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectBayes.cpp
@@ -32,8 +32,6 @@ void IndirectBayes::initLayout() {
   // Connect each tab to the actions available in this GUI
   std::map<unsigned int, IndirectBayesTab *>::iterator iter;
   for (iter = m_bayesTabs.begin(); iter != m_bayesTabs.end(); ++iter) {
-    connect(iter->second, SIGNAL(runAsPythonScript(const QString &, bool)), this,
-            SIGNAL(runAsPythonScript(const QString &, bool)));
     connect(iter->second, SIGNAL(showMessageBox(const QString &)), this, SLOT(showMessageBox(const QString &)));
   }
 

--- a/qt/scientific_interfaces/Indirect/IndirectCorrections.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectCorrections.cpp
@@ -57,8 +57,6 @@ void IndirectCorrections::initLayout() {
   // Set up all tabs
   for (auto &tab : m_tabs) {
     tab.second->setupTab();
-    connect(tab.second, SIGNAL(runAsPythonScript(const QString &, bool)), this,
-            SIGNAL(runAsPythonScript(const QString &, bool)));
     connect(tab.second, SIGNAL(showMessageBox(const QString &)), this, SLOT(showMessageBox(const QString &)));
   }
 

--- a/qt/scientific_interfaces/Indirect/IndirectDataAnalysisElwinTab.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectDataAnalysisElwinTab.cpp
@@ -154,13 +154,6 @@ IndirectDataAnalysisElwinTab::IndirectDataAnalysisElwinTab(QWidget *parent)
   m_uiForm.setupUi(parent);
   setOutputPlotOptionsPresenter(
       std::make_unique<IndirectPlotOptionsPresenter>(m_uiForm.ipoPlotOptions, PlotWidget::Spectra));
-  connect(m_uiForm.inputChoice, SIGNAL(currentIndexChanged(int)), this, SLOT(handleViewChanged(int)));
-
-  // data selected changes
-  connect(m_uiForm.file, SIGNAL(filesFoundChanged()), this, SLOT(handleFileInput()));
-
-  connect(m_uiForm.workspace, SIGNAL(currentIndexChanged(int)), this, SLOT(handleWorkspaceInput()));
-
   connect(m_uiForm.wkspAdd, SIGNAL(clicked()), this, SLOT(showAddWorkspaceDialog()));
   connect(m_uiForm.wkspRemove, SIGNAL(clicked()), this, SLOT(removeSelectedData()));
   connect(m_uiForm.wkspRemove, SIGNAL(clicked()), this, SIGNAL(dataRemoved()));
@@ -172,8 +165,6 @@ IndirectDataAnalysisElwinTab::IndirectDataAnalysisElwinTab(QWidget *parent)
   setHorizontalHeaders(headers);
   m_dataTable->setItemDelegateForColumn(headers.size() - 1, std::make_unique<ExcludeRegionDelegate>().release());
   m_dataTable->verticalHeader()->setVisible(false);
-
-  connect(m_dataTable, SIGNAL(cellChanged(int, int)), this, SLOT(handleCellChanged(int, int)));
 }
 
 IndirectDataAnalysisElwinTab::~IndirectDataAnalysisElwinTab() {

--- a/qt/scientific_interfaces/Indirect/IndirectDataReduction.h
+++ b/qt/scientific_interfaces/Indirect/IndirectDataReduction.h
@@ -119,8 +119,6 @@ private:
     tabIDRContent->setupTab();
     tabContent->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
 
-    connect(tabIDRContent, SIGNAL(runAsPythonScript(const QString &, bool)), this,
-            SIGNAL(runAsPythonScript(const QString &, bool)));
     connect(tabIDRContent, SIGNAL(showMessageBox(const QString &)), this, SLOT(showMessageBox(const QString &)));
 
     // Add to the cache

--- a/qt/scientific_interfaces/Indirect/IndirectSimulation.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectSimulation.cpp
@@ -36,8 +36,6 @@ void IndirectSimulation::initLayout() {
   // Connect each tab to the actions available in this GUI
   std::map<unsigned int, IndirectSimulationTab *>::iterator iter;
   for (iter = m_simulationTabs.begin(); iter != m_simulationTabs.end(); ++iter) {
-    connect(iter->second, SIGNAL(runAsPythonScript(const QString &, bool)), this,
-            SIGNAL(runAsPythonScript(const QString &, bool)));
     connect(iter->second, SIGNAL(showMessageBox(const QString &)), this, SLOT(showMessageBox(const QString &)));
   }
 


### PR DESCRIPTION
**Description of work.**
This PR eliminates a number of qt warnings seen in the command prompt when opening the indirect interfaces. These warnings have been around for a long time, and so its nice to finally get around to fixing them.

**To test:**
1. Open visual studio, and run mantid. There should be a command prompt that appears along with the mantid window
2. Open each of the Indirect interfaces, and check the command prompt for any qt-based warnings after opening each one. There should be none.
3. Test that loading data on the Elwin tab of Indirect Data Analysis still works as expected

*This PR doesn't need release notes because the warnings are not visible to users, they only appear in the VS command prompt*

Fixes #33966

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
