### PR TITLE
Correction to Indirect spectrum numbers in Data Reduction when grouped

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ISISIndirectEnergyTransfer.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ISISIndirectEnergyTransfer.py
@@ -134,6 +134,8 @@ class ISISIndirectEnergyTransfer(DataProcessorAlgorithm):
 
     #pylint: disable=too-many-locals
     def PyExec(self):
+        #import pydevd_pycharm
+        #pydevd_pycharm.settrace('localhost', port=8080, stdoutToServer=True, stderrToServer=True)
         from IndirectReductionCommon import (load_files,
                                              get_multi_frame_rebin,
                                              get_detectors_to_mask,
@@ -288,8 +290,13 @@ class ISISIndirectEnergyTransfer(DataProcessorAlgorithm):
 
         # Group result workspaces
         summary_prog.report('grouping workspaces')
-        GroupWorkspaces(InputWorkspaces=output_workspace_names,
-                        OutputWorkspace=self._output_ws)
+        self.output_ws = GroupWorkspaces(InputWorkspaces=output_workspace_names,
+                                         OutputWorkspace=self._output_ws)
+
+        # The spectrum numbers need to start at 1 not 0 if spectra are grouped
+        if self.output_ws.getNumberOfEntries() == 1 and self.getProperty('GroupingMethod').value == 'Custom':
+            for i in range(len(self.output_ws.getItem(0).getSpectrumNumbers())):
+                self.output_ws.getItem(0).getSpectrum(i).setSpectrumNo(i+1)
 
         self.setProperty('OutputWorkspace', mtd[self._output_ws])
 

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ISISIndirectEnergyTransfer.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ISISIndirectEnergyTransfer.py
@@ -134,8 +134,6 @@ class ISISIndirectEnergyTransfer(DataProcessorAlgorithm):
 
     #pylint: disable=too-many-locals
     def PyExec(self):
-        #import pydevd_pycharm
-        #pydevd_pycharm.settrace('localhost', port=8080, stdoutToServer=True, stderrToServer=True)
         from IndirectReductionCommon import (load_files,
                                              get_multi_frame_rebin,
                                              get_detectors_to_mask,

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/ISISIndirectEnergyTransferTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/ISISIndirectEnergyTransferTest.py
@@ -358,6 +358,18 @@ class ISISIndirectEnergyTransferTest(unittest.TestCase):
         red_ws = wks.getItem(0)
         self.assertEqual(red_ws.getNumberHistograms(), 51)
 
+    def test_change_spectra_for_groups(self):
+        """Check that the spectra are changed for a custom grouping"""
+
+        custom_grouping_strings = {"3:53": 51, "3:25,27:53": 50, "3-53": 1, "3-25,26:53": 29, "3+5+7,8-40,41:53": 15}
+
+        for custom_string, expected_size in custom_grouping_strings.items():
+            reduced_workspace = ISISIndirectEnergyTransfer(InputFiles=['IRS26176.RAW'], Instrument='IRIS',
+                                                           Analyser='graphite', Reflection='002', SpectraRange=[3, 53],
+                                                           GroupingMethod='Custom', GroupingString=custom_string)
+        red_ws = reduced_workspace.getItem(0)
+        self.assertEqual(red_ws.getSpectrum(0).getSpectrumNo(), 1)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/docs/source/release/v6.5.0/Indirect/Bugfixes/34183.rst
+++ b/docs/source/release/v6.5.0/Indirect/Bugfixes/34183.rst
@@ -1,0 +1,1 @@
+- Fixed a bug in Indirect Data Reduction where the spectra in the detector table after grouping started at 0. The spectra now start at 1.


### PR DESCRIPTION
**Description of work.**

This piece of works reverts the numbering of the spectrum in Indirect Data Reduction when spectra are grouped to how the numbering worked in v3.11. The spectra numbers need to start at 1 rather than 0.

**To test:**
- Open Indirect -> Data Reduction GUI
- Type run 96141
- In the detector grouping section, set the value to "groups" and then set the number of groups to 5
- Press the Run button (you may need to scroll down)
- Right click on the resulting workspace in the ADS and select 'Show Detectors'
- The first row will have 0 for the index and 1 for the spectrum number. 
 
Fixes #34183 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
