### PR TITLE
String logs appear as strings on Model Analysis plots

### DIFF
--- a/docs/source/release/v6.5.0/Muon/MA_FDA/Bugfixes/33012.rst
+++ b/docs/source/release/v6.5.0/Muon/MA_FDA/Bugfixes/33012.rst
@@ -1,0 +1,1 @@
+- Fixed a bug in Model Analysis where string logs were not being displayed correctly.

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/fitting_widgets/model_fitting/model_fitting_model.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/fitting_widgets/model_fitting/model_fitting_model.py
@@ -313,5 +313,5 @@ class ModelFittingModel(BasicFittingModel):
         """Returns a list of tick labels to use as override labels if the parameter values are strings."""
         if parameter_name in parameters:
             parameter_values = parameters[parameter_name]
-            return parameter_values if type(parameter_values[0]) == str else []
+            return parameter_values[0] if all(isinstance(n, str) for n in parameter_values[0]) else []
         return []


### PR DESCRIPTION
**Description of work.**
The string logs were not appearing on the axis correctly of model analysis plot. This is because it was looking for a string and getting a list of strings and so the override would not kick in.


**To test:**
1. Make sure you have Feature Flags set for Model Analysis - https://docs.mantidproject.org/nightly/interfaces/muon/feature_flags.html#muon-feature-flags-ref
2. Open Muon Analysis GUI
3. Load EMU runs 96116-8
4. Go to fitting and add a function (DynamicToyabeKuobo works well)
5. Go to sequential fitting tab and click fit all button
6. Go to the Results tab and select the analysis group name from the list of logs
7. Create a results table
8. Go to model analysis and set the x axis and the y axis as parameters that are likely to be strings e.g. workspace names
9. The plot should show strings rather than numbers (as seen on the issue)

Fixes #33012

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
