### PR TITLE
Crystal Field GOFit fitting

### DIFF
--- a/Framework/PythonInterface/mantid/fitfunctions.py
+++ b/Framework/PythonInterface/mantid/fitfunctions.py
@@ -23,7 +23,7 @@ class FunctionWrapper(object):
                 return wrapper(fun, *args, **kwargs)
         return FunctionWrapper(fun, **kwargs)
 
-    def __init__(self, name, **kwargs):
+    def __init__(self, name, params_to_optimize=None, **kwargs):
         """
         Called when creating an instance
 
@@ -37,6 +37,9 @@ class FunctionWrapper(object):
         else:
             self.fun = FunctionFactory.createFunction(name)
         self.init_paramgeters_and_attributes(**kwargs)
+
+        self.params_to_optimize = params_to_optimize if params_to_optimize is not None else \
+            [self.fun.parameterName(i) for i in range(self.fun.nParams())]
 
     def init_paramgeters_and_attributes(self, **kwargs):
         # Deal with attributes first
@@ -175,9 +178,8 @@ class FunctionWrapper(object):
         else:
             x_list = [x]
 
-        for i in range(len(params)):
-            if not self.fun.isFixed(i):
-                self.fun.setParameter(i, params[i])
+        for i, param_name in enumerate(self.params_to_optimize):
+            self.fun.setParameter(param_name, params[i])
         y = x_list[:]
         ws = self._execute_algorithm('CreateWorkspace', DataX=x_list, DataY=y)
         out = self._execute_algorithm('EvaluateFunction', Function=self.fun, InputWorkspace=ws)

--- a/Framework/PythonInterface/mantid/fitfunctions.py
+++ b/Framework/PythonInterface/mantid/fitfunctions.py
@@ -176,7 +176,8 @@ class FunctionWrapper(object):
             x_list = [x]
 
         for i in range(len(params)):
-            self.fun.setParameter(i, params[i])
+            if not self.fun.isFixed(i):
+                self.fun.setParameter(i, params[i])
         y = x_list[:]
         ws = self._execute_algorithm('CreateWorkspace', DataX=x_list, DataY=y)
         out = self._execute_algorithm('EvaluateFunction', Function=self.fun, InputWorkspace=ws)

--- a/docs/source/interfaces/direct/Crystal Field Python Interface.rst
+++ b/docs/source/interfaces/direct/Crystal Field Python Interface.rst
@@ -443,7 +443,7 @@ The ``multistart`` algorithm requires you to pass in parameter_bounds and the nu
 
 The ``alternating`` algorithm also requires you to pass in parameter_bounds and the number of samples::
 
-    fit.gofit(algorithm_callable=gofit.alternating,, parameter_bounds=parameter_bounds, samples=100, maxit=500)
+    fit.gofit(algorithm_callable=gofit.alternating, parameter_bounds=parameter_bounds, samples=100, maxit=500)
 
 A full list of possible arguments for these algorithm can be found `here <https://github.com/ralna/GOFit/blob/master/docs/algorithms.md>`_. The output from these fits
 should be a matrix workspace containing the fitted data, and a table workspace containing the fitted parameters.

--- a/docs/source/interfaces/direct/Crystal Field Python Interface.rst
+++ b/docs/source/interfaces/direct/Crystal Field Python Interface.rst
@@ -418,6 +418,35 @@ A complete list of minimizers available for ``scipy.optimize.minimize`` can be f
 
 If the minimizer is not overwritten, 'L-BFGS-B' is set as a default for ``scipy.optimize.minimize`` and 'Levenberg-Marquardt' for Mantid fitting.
 
+GOFit fitting
+~~~~~~~~~~~~~
+The algorithms contained within the `GOFit package <https://github.com/ralna/GOFit>`_ can also be used from the Crystal Field API. This package is designed for the global
+optimization of parameters using a non-linear least squares cost function. For more information about the algorithms used in this implementation, please see the related
+`RAL Technical Report <https://epubs.stfc.ac.uk/work/51662496>`_.
+
+The GOFit package contains `three optimization algorithms <https://github.com/ralna/GOFit/blob/master/docs/algorithms.md>`_ called ``regularisation``, ``multistart`` and
+``alternating``. Please note that the fitting process for ``multistart`` and ``alternating`` can be slow due to the residuals being evaluated in python.
+
+Before you can use the GOFit package in Mantid, you will need to ``pip install gofit`` into your environment because it is an external dependency. Once installed,
+it should be possible to import the package and perform a fit using the ``regularisation`` algorithm by passing a GOFit callable into the Crystal Field API::
+
+    import gofit
+    fit.gofit(algorithm_callable=gofit.regularisation, jacobian=True, maxit=500)
+
+The ``multistart`` algorithm requires you to pass in parameter_bounds and the number of samples::
+
+    parameter_bounds = {'B20': (-0.3013,0.3013), 'B22': (-0.5219,0.5219), 'B40': (-0.004624,0.004624), 'B42': (-0.02068,0.02068), 'B44': (-0.02736,0.02736),
+                        'B60': (-0.0001604,0.0001604), 'B62': (-0.001162,0.001162), 'B64': (-0.001273,0.001273), 'B66': (-0.001724,0.001724),
+                        'IntensityScaling': (0.,10.), 'f0.FWHM': (0.1,5.0), 'f1.FWHM': (0.1,5.0), 'f2.FWHM': (0.1,5.0), 'f3.FWHM': (0.1,5.0), 'f4.FWHM': (0.1,7.0)}
+
+    fit.gofit(algorithm_callable=gofit.multistart, parameter_bounds=parameter_bounds, samples=100, jacobian=True, maxit=500, scaling=True)
+
+The ``alternating`` algorithm also requires you to pass in parameter_bounds and the number of samples::
+
+    fit.gofit(algorithm_callable=gofit.alternating,, parameter_bounds=parameter_bounds, samples=100, maxit=500)
+
+A full list of possible arguments for these algorithm can be found `here <https://github.com/ralna/GOFit/blob/master/docs/algorithms.md>`_. The output from these fits
+should be a matrix workspace containing the fitted data, and a table workspace containing the fitted parameters.
 
 Multiple Ions
 -------------

--- a/docs/source/release/v6.5.0/Direct_Geometry/CrystalField/New_features/33864.rst
+++ b/docs/source/release/v6.5.0/Direct_Geometry/CrystalField/New_features/33864.rst
@@ -1,0 +1,1 @@
+- It is now possible to use the algorithms from the GOFit optimization package directly with the `Crystal Field API <https://docs.mantidproject.org/nightly/interfaces/direct/Crystal%20Field%20Python%20Interface.html#gofit-fitting>`_.

--- a/scripts/Inelastic/CrystalField/fitting.py
+++ b/scripts/Inelastic/CrystalField/fitting.py
@@ -1328,6 +1328,7 @@ class CrystalFieldFit(object):
         except TypeError as ex:
             logger.error(str(ex))
         else:
+            print(f"GOFit exited with status code {status}.")
             self._process_gofit_output(all_parameters, params, "_" + algorithm_name)
 
     def _get_algorithm_args(self, algorithm_name: str, all_parameters: List[str], b_parameters: List[str],

--- a/scripts/Inelastic/CrystalField/fitting.py
+++ b/scripts/Inelastic/CrystalField/fitting.py
@@ -6,7 +6,8 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 from mantid.api import IFunction, AlgorithmManager, mtd
 from mantid.kernel import logger
-from mantid.simpleapi import CalculateChiSquared, EvaluateFunction, FunctionFactory, FunctionWrapper, plotSpectrum
+from mantid.simpleapi import (CalculateChiSquared, CreateEmptyTableWorkspace, EvaluateFunction, FunctionFactory,
+                              FunctionWrapper, plotSpectrum)
 from .function import PeaksFunction, PhysicalProperties, ResolutionModel, Background, Function
 from .energies import energies
 from .normalisation import split2range, ionname2Nre
@@ -1382,6 +1383,16 @@ class CrystalFieldFit(object):
         EvaluateFunction(Function=str(self.model.function),
                          InputWorkspace=self._input_workspace,
                          OutputWorkspace=output_name + suffix)
+        self._create_parameter_table(output_name, suffix)
+
+    def _create_parameter_table(self, output_name: str, suffix: str) -> None:
+        """Creates a table workspace to display the output parameters from a GOFit."""
+        parameter_table = CreateEmptyTableWorkspace(OutputWorkspace=output_name + suffix + "_parameters")
+        parameter_table.setTitle("Fit Parameters")
+        parameter_table.addColumn("str", "Parameter")
+        parameter_table.addColumn("float", "Value")
+        for i in range(self.model.function.nParams()):
+            parameter_table.addRow([self.model.function.parameterName(i), self.model.function.getParameterValue(i)])
 
     def two_step_fit(self, OverwriteMaxIterations: list = None, OverwriteMinimizers: list = None, Iterations: int = 20) -> None:
         logger.warning("Please note that this is a first experimental version of the two_step_fit algorithm.")

--- a/scripts/Inelastic/CrystalField/fitting.py
+++ b/scripts/Inelastic/CrystalField/fitting.py
@@ -1278,6 +1278,38 @@ class CrystalFieldFit(object):
             self._monte_carlo_single(**kwargs)
         self.model.FixAllPeaks = fix_all_peaks
 
+    def fit_with_gofit(self):
+        from gofit import regularisation
+
+        data = np.loadtxt('C:\\Users\\mlc47243\\Documents\\mantid-data\\cubic.txt')
+
+        def fun(p, x):
+            return p[0] + p[1] * x + p[2] * x ** 2 + p[3] * x ** 3
+
+        def eval_res(p):
+            x = data[:, 0]
+            y = data[:, 1]
+            return y - fun(p, x)
+
+        def eval_jac(p):
+            x = data[:, 0]
+            ones = np.ones(len(x))
+            return -1 * np.transpose([ones, x, x ** 2, x ** 3])
+
+        m = data.shape[0]
+        n = 4
+        p0 = np.array([8, 2.98, 4, 1.02])
+
+        # Parameters
+        maxit = 200
+
+        p, status = regularisation(m, n, p0, eval_res, jac=eval_jac, maxit=maxit)
+
+        print("Status:")
+        print(status)
+        print("p*:")
+        print(p)
+
     def two_step_fit(self, OverwriteMaxIterations: list = None, OverwriteMinimizers: list = None, Iterations: int = 20) -> None:
         logger.warning("Please note that this is a first experimental version of the two_step_fit algorithm.")
         fix_all_peaks = self.model.FixAllPeaks


### PR DESCRIPTION
**Description of work.**
This PR adds the ability to perform a fit from the Crystal Field API which uses the GOFit python package. There are three GOFit
algorithms you can use: `regularisation`, `multistart` and `alternating`. The `alternating` algorithm is said to give very good results, even starting from initial parameters which are less than optimal.

I decided it would be neat to pass the gofit algorithm callable into the API so that we do not have a gofit import statement inside of mantid. I think this is a good idea because gofit will not be packaged with the mantid conda environment, so it makes sense for a user to import it and pass it in.

**To test:**
1. Make sure you have gofit pip installed in your environment `pip install gofit`
1. Open a script editor in mantid
2. Run the script below, and wait until it finishes.
```py
# import mantid algorithms, numpy and matplotlib
from mantid.simpleapi import *
import matplotlib.pyplot as plt
import numpy as np
from CrystalField import CrystalField, CrystalFieldFit
import os
import gofit

minimizers = ['Nelder-Mead', 'BFGS']
iterations = [5, 10]

data_ws1 = Load(os.path.join(os.path.dirname(__file__), 'NdOs2Al10_5K35meV_Ecut_0to3ang_bp15V1.xye'))

np.random.RandomState(np.random.MT19937(np.random.SeedSequence(int(np.random.rand()*1e6))))

refpars = {'B20':0.19, 'B22':0.11, 'B40':-0.0004, 'B42':-0.002, 'B44':-0.012, 'B60':5.e-05, 'B62':0.00054, 'B64':-0.0006, 'B66':0.0008}
init_pars = {pn:refpars[pn]*((np.random.rand()-0.5)/2+1) for pn in refpars.keys()}

parameter_bounds = {'B20': (-0.3013,0.3013), 'B22': (-0.5219,0.5219), 'B40': (-0.004624,0.004624), 'B42': (-0.02068,0.02068), 'B44': (-0.02736,0.02736), 'B60': (-0.0001604,0.0001604), 'B62': (-0.001162,0.001162), 'B64': (-0.001273,0.001273), 'B66': (-0.001724,0.001724), 'IntensityScaling': (0.,10.), 'f0.FWHM': (0.1,5.0), 'f1.FWHM': (0.1,5.0), 'f2.FWHM': (0.1,5.0), 'f3.FWHM': (0.1,5.0), 'f4.FWHM': (0.1,7.0)}

cf = CrystalField('Nd', 'C2v', Temperature=5, FWHM=1, **init_pars)

fit2 = CrystalFieldFit(Model=cf, InputWorkspace=data_ws1, MaxIterations=50, Output='fit_gofit')
EvaluateFunction(Function=str(fit2.model.function), InputWorkspace=data_ws1, OutputWorkspace="guess")

fit2.gofit(algorithm_callable=gofit.regularisation, jacobian=True, maxit=3000)
#fit2.gofit(algorithm_callable=gofit.multistart,  jacobian=True, parameter_bounds=parameter_bounds, samples=100, maxit=3000, scaling=True)
#fit2.gofit(algorithm_callable=gofit.alternating,, parameter_bounds=parameter_bounds, samples=100, maxit=3000)

# Plots the data and print fitted parameters
l=plotSpectrum('fit_gofit_regularisation',[0,1,2],error_bars=False)
```
3. See that you get the following plot. Note that you might get a result which is not as good as this when running the `regularisation` and `multistart` algorithms, because the initial parameters are being randomized slightly.
![image](https://user-images.githubusercontent.com/40830825/179258397-a3f1f571-55ca-4010-b354-d110be99bf44.png)

5. Repeat this, but for the `multistart` and `alternating` algorithms

6. Now try testing the `alternating` algorithm with more difficult starting parameters:

```py
# import mantid algorithms, numpy and matplotlib
from mantid.simpleapi import *
import matplotlib.pyplot as plt
import numpy as np
from CrystalField import CrystalField, CrystalFieldFit
import os
import gofit

#fully_random = True     # Use fully random starting pars
fully_random = False    # Just slightly randomize good pars
#fully_random = "MC"     # Use the Monte Carlo parameter estimation routine to refine fully random initial pars.
do_plot = True

minimizers = ['Nelder-Mead', 'BFGS']
iterations = [5, 10]

dir = os.path.dirname(__file__)
data_ws1 = Load(os.path.join(dir, 'NdOs2Al10_5K35meV_Ecut_0to3ang_bp15V1.xye'))

np.random.RandomState(np.random.MT19937(np.random.SeedSequence(int(np.random.rand()*1e6))))

if fully_random:
    parnames = ['B20', 'B22', 'B40', 'B42', 'B44', 'B60', 'B62', 'B64', 'B66']
    init_pars = {pn:(np.random.rand()-0.5)*2 for pn in parnames}
    
    if isinstance(fully_random, str) and fully_random.lower() == 'mc':
    # Use the "Monte Carlo" estimation routine to refine the random parameters a bit
        cf = CrystalField('Nd', 'C2v', Temperature=5, FWHM=1, **init_pars)
        cf.PeakShape = 'Lorentzian'
        cf.IntensityScaling = 2   # Scale factor if data is not in absolute units (mbarn/sr/f.u./meV), will be fitted.
        fit = CrystalFieldFit(Model=cf, InputWorkspace=data_ws1,MaxIterations=200)
        fit.estimate_parameters(EnergySplitting=20,
                                Parameters=parnames,
                                NSamples=1000)
        fit.select_estimated_parameters(1)
        init_pars = {pn:fit.model[pn] for pn in parnames}
else:
    # Just slightly randomize reference parameters
    parnames = ['B20', 'B22', 'B40', 'B42', 'B44', 'B60', 'B62', 'B64', 'B66']
    refpars = {'B20':0.19, 'B22':0.11, 'B40':-0.0004, 'B42':-0.002, 'B44':-0.012, 'B60':5.e-05, 'B62':0.00054, 'B64':-0.0006, 'B66':0.0008}
    init_pars = {pn:refpars[pn]*((np.random.rand()-0.5)/2+1) for pn in parnames}

cf = CrystalField('Nd', 'C2v', Temperature=5, FWHM=1, **init_pars)

fit = CrystalFieldFit(Model=cf, InputWorkspace=data_ws1, MaxIterations=50)
fit.gofit(algorithm_callable=gofit.alternating,, parameter_bounds=parameter_bounds, samples=100, maxit=3000)
```

Fixes #33864

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
