### PR TITLE
Add G_k(r) type to PDFFourierTransform2

### DIFF
--- a/Framework/Algorithms/inc/MantidAlgorithms/PDFFourierTransform2.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/PDFFourierTransform2.h
@@ -33,6 +33,9 @@ public:
   const std::string category() const override;
   /// @copydoc Algorithm::validateInputs()
   std::map<std::string, std::string> validateInputs() override;
+  void convertToLittleGRMinus1(std::vector<double> &FOfR, const std::vector<double> &R, std::vector<double> &DFOfR,
+                               const std::vector<double> &DR, const std::string &PDFType, const std::double_t &rho0,
+                               const std::double_t &cohScatLen);
 
 protected:
   size_t determineMinIndex(double min, const std::vector<double> &X, const std::vector<double> &Y);
@@ -47,12 +50,11 @@ private:
   double determineRho0();
   void convertToSQMinus1(std::vector<double> &FOfQ, std::vector<double> &Q, std::vector<double> &DFOfQ,
                          const std::vector<double> &DQ);
-  void convertToLittleGRMinus1(std::vector<double> &FOfR, const std::vector<double> &R, std::vector<double> &DFOfR,
-                               const std::vector<double> &DR);
   void convertFromSQMinus1(HistogramData::HistogramY &FOfQ, const HistogramData::HistogramX &Q,
                            HistogramData::HistogramE &DFOfQ);
   void convertFromLittleGRMinus1(HistogramData::HistogramY &FOfR, const HistogramData::HistogramX &R,
-                                 HistogramData::HistogramE &DFOfR);
+                                 HistogramData::HistogramE &DFOfR, const std::string &PDFType,
+                                 const std::double_t &rho0, const std::double_t &cohScatLen);
 };
 
 } // namespace Algorithms

--- a/Framework/Algorithms/inc/MantidAlgorithms/PDFFourierTransform2.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/PDFFourierTransform2.h
@@ -34,8 +34,8 @@ public:
   /// @copydoc Algorithm::validateInputs()
   std::map<std::string, std::string> validateInputs() override;
   void convertToLittleGRMinus1(std::vector<double> &FOfR, const std::vector<double> &R, std::vector<double> &DFOfR,
-                               const std::vector<double> &DR, const std::string &PDFType, const std::double_t &rho0,
-                               const std::double_t &cohScatLen);
+                               const std::vector<double> &DR, const std::string &PDFType, const double &rho0,
+                               const double &cohScatLen);
 
 protected:
   size_t determineMinIndex(double min, const std::vector<double> &X, const std::vector<double> &Y);
@@ -53,8 +53,8 @@ private:
   void convertFromSQMinus1(HistogramData::HistogramY &FOfQ, const HistogramData::HistogramX &Q,
                            HistogramData::HistogramE &DFOfQ);
   void convertFromLittleGRMinus1(HistogramData::HistogramY &FOfR, const HistogramData::HistogramX &R,
-                                 HistogramData::HistogramE &DFOfR, const std::string &PDFType,
-                                 const std::double_t &rho0, const std::double_t &cohScatLen);
+                                 HistogramData::HistogramE &DFOfR, const std::string &PDFType, const double &rho0,
+                                 const double &cohScatLen);
 };
 
 } // namespace Algorithms

--- a/Framework/Algorithms/src/PDFFourierTransform2.cpp
+++ b/Framework/Algorithms/src/PDFFourierTransform2.cpp
@@ -44,6 +44,8 @@ const string BIG_G_OF_R("G(r)");
 const string LITTLE_G_OF_R("g(r)");
 /// Radial distribution function
 const string RDF_OF_R("RDF(r)");
+/// Total radial distribution function
+const string G_K_OF_R("G_k(r)");
 
 /// Normalized intensity
 const string S_OF_Q("S(Q)");
@@ -110,6 +112,7 @@ void PDFFourierTransform2::init() {
   pdfTypes.emplace_back(BIG_G_OF_R);
   pdfTypes.emplace_back(LITTLE_G_OF_R);
   pdfTypes.emplace_back(RDF_OF_R);
+  pdfTypes.emplace_back(G_K_OF_R);
   declareProperty("PDFType", BIG_G_OF_R, std::make_shared<StringListValidator>(pdfTypes),
                   "Type of output PDF including G(r)");
 
@@ -343,6 +346,16 @@ void PDFFourierTransform2::convertFromLittleGRMinus1(HistogramData::HistogramY &
       DFOfR[i] = DFOfR[i] * R[i];
       // transform the data
       FOfR[i] = (FOfR[i] + 1.0) * factor * R[i] * R[i];
+    }
+  } else if (outputType == G_K_OF_R) {
+    API::MatrixWorkspace_const_sptr inputWS = getProperty("InputWorkspace");
+    const Kernel::Material &material = inputWS->sample().getMaterial();
+    double sigma = material.cohScatterXSection();
+    const double factor = sigma / (4. * M_PI);
+
+    for (size_t i = 0; i < FOfR.size(); ++i) {
+      // transform the data
+      FOfR[i] = FOfR[i] * factor;
     }
   }
   return;

--- a/Framework/Algorithms/src/PDFFourierTransform2.cpp
+++ b/Framework/Algorithms/src/PDFFourierTransform2.cpp
@@ -296,8 +296,7 @@ void PDFFourierTransform2::convertToLittleGRMinus1(std::vector<double> &FOfR, co
   } else if (PDFType == G_K_OF_R) {
     API::MatrixWorkspace_const_sptr inputWS = getProperty("InputWorkspace");
     const Kernel::Material &material = inputWS->sample().getMaterial();
-    double sigma = material.cohScatterXSection();
-    const double factor = sigma / (4. * M_PI);
+    const double factor = 0.001 * pow(material.cohScatterLength(), 2);
 
     for (size_t i = 0; i < FOfR.size(); ++i) {
       // error propagation - assuming uncertainty in r = 0
@@ -362,8 +361,7 @@ void PDFFourierTransform2::convertFromLittleGRMinus1(HistogramData::HistogramY &
   } else if (outputType == G_K_OF_R) {
     API::MatrixWorkspace_const_sptr inputWS = getProperty("InputWorkspace");
     const Kernel::Material &material = inputWS->sample().getMaterial();
-    double sigma = material.cohScatterXSection();
-    const double factor = sigma / (4. * M_PI);
+    const double factor = 0.001 * pow(material.cohScatterLength(), 2);
 
     for (size_t i = 0; i < FOfR.size(); ++i) {
       // error propagation - assuming uncertainty in r = 0

--- a/Framework/Algorithms/src/PDFFourierTransform2.cpp
+++ b/Framework/Algorithms/src/PDFFourierTransform2.cpp
@@ -419,15 +419,23 @@ void PDFFourierTransform2::exec() {
     */
   }
 
+  const std::string PDFType = getProperty("PDFType");
   double rho0 = determineRho0();
   const Kernel::Material &material = inputWS->sample().getMaterial();
   const auto cohScatLen = material.cohScatterLength();
+
+  // A material needs to be provided in order to calculate G_K(r)
+  if (PDFType == "G_k(r)" && cohScatLen == 0.0) {
+    std::stringstream msg;
+    msg << "Coherent Scattering Length is zero. Please check a sample material has been specified";
+    throw std::runtime_error(msg.str());
+  }
 
   // convert to S(Q)-1 or g(R)+1
   if (direction == FORWARD) {
     convertToSQMinus1(inputY, inputX, inputDY, inputDX);
   } else if (direction == BACKWARD) {
-    convertToLittleGRMinus1(inputY, inputX, inputDY, inputDX, getProperty("PDFType"), rho0, cohScatLen);
+    convertToLittleGRMinus1(inputY, inputX, inputDY, inputDX, PDFType, rho0, cohScatLen);
   }
 
   double inMin, inMax, outDelta, outMax;
@@ -519,7 +527,7 @@ void PDFFourierTransform2::exec() {
   }
 
   if (direction == FORWARD) {
-    convertFromLittleGRMinus1(outputY, outputX, outputE, getProperty("PDFType"), rho0, cohScatLen);
+    convertFromLittleGRMinus1(outputY, outputX, outputE, PDFType, rho0, cohScatLen);
   } else if (direction == BACKWARD) {
     convertFromSQMinus1(outputY, outputX, outputE);
   }

--- a/Framework/Algorithms/src/PDFFourierTransform2.cpp
+++ b/Framework/Algorithms/src/PDFFourierTransform2.cpp
@@ -300,6 +300,8 @@ void PDFFourierTransform2::convertToLittleGRMinus1(std::vector<double> &FOfR, co
     const double factor = sigma / (4. * M_PI);
 
     for (size_t i = 0; i < FOfR.size(); ++i) {
+      // error propagation - assuming uncertainty in r = 0
+      DFOfR[i] = DFOfR[i] / factor;
       // transform the data
       FOfR[i] = FOfR[i] / factor;
     }
@@ -364,6 +366,8 @@ void PDFFourierTransform2::convertFromLittleGRMinus1(HistogramData::HistogramY &
     const double factor = sigma / (4. * M_PI);
 
     for (size_t i = 0; i < FOfR.size(); ++i) {
+      // error propagation - assuming uncertainty in r = 0
+      DFOfR[i] = DFOfR[i] * factor;
       // transform the data
       FOfR[i] = FOfR[i] * factor;
     }

--- a/Framework/Algorithms/src/PDFFourierTransform2.cpp
+++ b/Framework/Algorithms/src/PDFFourierTransform2.cpp
@@ -293,6 +293,16 @@ void PDFFourierTransform2::convertToLittleGRMinus1(std::vector<double> &FOfR, co
       // transform the data
       FOfR[i] = FOfR[i] / (factor * R[i] * R[i]) - 1.0;
     }
+  } else if (PDFType == G_K_OF_R) {
+    API::MatrixWorkspace_const_sptr inputWS = getProperty("InputWorkspace");
+    const Kernel::Material &material = inputWS->sample().getMaterial();
+    double sigma = material.cohScatterXSection();
+    const double factor = sigma / (4. * M_PI);
+
+    for (size_t i = 0; i < FOfR.size(); ++i) {
+      // transform the data
+      FOfR[i] = FOfR[i] / factor;
+    }
   }
   return;
 }

--- a/Framework/Algorithms/src/PDFFourierTransform2.cpp
+++ b/Framework/Algorithms/src/PDFFourierTransform2.cpp
@@ -270,9 +270,8 @@ void PDFFourierTransform2::convertToSQMinus1(std::vector<double> &FOfQ, std::vec
 
 void PDFFourierTransform2::convertToLittleGRMinus1(std::vector<double> &FOfR, const std::vector<double> &R,
                                                    std::vector<double> &DFOfR, const std::vector<double> &DR,
-                                                   const std::string &PDFType, const std::double_t &rho0,
-                                                   const std::double_t &cohScatLen) {
-  // string PDFType = getProperty("PDFType");
+                                                   const std::string &PDFType, const double &rho0,
+                                                   const double &cohScatLen) {
   if (PDFType == LITTLE_G_OF_R) {
     for (size_t i = 0; i < FOfR.size(); ++i) {
       // transform the data
@@ -295,7 +294,7 @@ void PDFFourierTransform2::convertToLittleGRMinus1(std::vector<double> &FOfR, co
       FOfR[i] = FOfR[i] / (factor * R[i] * R[i]) - 1.0;
     }
   } else if (PDFType == G_K_OF_R) {
-    const double factor = 0.001 * pow(cohScatLen, 2);
+    const double factor = 0.01 * pow(cohScatLen, 2);
 
     for (size_t i = 0; i < FOfR.size(); ++i) {
       // error propagation - assuming uncertainty in r = 0
@@ -333,7 +332,7 @@ void PDFFourierTransform2::convertFromSQMinus1(HistogramData::HistogramY &FOfQ, 
 void PDFFourierTransform2::convertFromLittleGRMinus1(HistogramData::HistogramY &FOfR,
                                                      const HistogramData::HistogramX &R,
                                                      HistogramData::HistogramE &DFOfR, const std::string &PDFType,
-                                                     const std::double_t &rho0, const std::double_t &cohScatLen) {
+                                                     const double &rho0, const double &cohScatLen) {
   // convert to the correct form of PDF
   if (PDFType == LITTLE_G_OF_R) {
     for (size_t i = 0; i < FOfR.size(); ++i) {
@@ -357,7 +356,7 @@ void PDFFourierTransform2::convertFromLittleGRMinus1(HistogramData::HistogramY &
       FOfR[i] = (FOfR[i] + 1.0) * factor * R[i] * R[i];
     }
   } else if (PDFType == G_K_OF_R) {
-    const double factor = 0.001 * pow(cohScatLen, 2);
+    const double factor = 0.01 * pow(cohScatLen, 2);
 
     for (size_t i = 0; i < FOfR.size(); ++i) {
       // error propagation - assuming uncertainty in r = 0

--- a/Framework/Algorithms/test/PDFFourierTransform2Test.h
+++ b/Framework/Algorithms/test/PDFFourierTransform2Test.h
@@ -354,7 +354,7 @@ public:
     const double factor1 = 4. * M_PI * rho0;
 
     // set up initial y values
-    std::vector<double> y(2, 5.0);
+    std::vector<double> y_initial(2, 5.0);
 
     // Algorithm destructor crashes without workspace properties initialised
     PDFFourierTransform2 pdfft;
@@ -364,31 +364,35 @@ public:
 
     // test g(r)
     const std::string LITTLE_G_OF_R("g(r)");
-    pdfft.convertToLittleGRMinus1(y, x, dy, dx, LITTLE_G_OF_R, rho0, cohScatLen);
+    auto y_gr = y_initial;
+    pdfft.convertToLittleGRMinus1(y_gr, x, dy, dx, LITTLE_G_OF_R, rho0, cohScatLen);
     const auto exp_gr = 4.0;
-    const auto actual_gr = y[0];
+    const auto actual_gr = y_gr[0];
     TS_ASSERT_DELTA(actual_gr, exp_gr, 1e-8);
 
     // test G(r) - note that y values have been changed by previous call to convertToLittleGRMinus1
     const std::string BIG_G_OF_R("G(r)");
-    pdfft.convertToLittleGRMinus1(y, x, dy, dx, BIG_G_OF_R, rho0, cohScatLen);
-    const auto exp_big_gr = exp_gr / (factor1 * single_x);
-    const auto actual_big_gr = y[0];
-    TS_ASSERT_DELTA(actual_big_gr, exp_big_gr, 1e-8);
+    auto y_gr_minus_one = y_initial;
+    pdfft.convertToLittleGRMinus1(y_gr_minus_one, x, dy, dx, BIG_G_OF_R, rho0, cohScatLen);
+    const auto exp_little_gr_minus_one = y_initial[0] / (factor1 * single_x);
+    const auto actual_little_gr_minus_one = y_gr_minus_one[0];
+    TS_ASSERT_DELTA(actual_little_gr_minus_one, exp_little_gr_minus_one, 1e-8);
 
     //// test RDF(r) - note that y values have been changed by previous call to convertToLittleGRMinus1
     const std::string RDF_OF_R("RDF(r)");
-    pdfft.convertToLittleGRMinus1(y, x, dy, dx, RDF_OF_R, rho0, cohScatLen);
-    const auto exp_rdf_r = exp_big_gr / (factor1 * single_x * single_x) - 1.0;
-    const auto actual_rdf_r = y[0];
+    auto y_rdf_r = y_initial;
+    pdfft.convertToLittleGRMinus1(y_rdf_r, x, dy, dx, RDF_OF_R, rho0, cohScatLen);
+    const auto exp_rdf_r = y_initial[0] / (factor1 * single_x * single_x) - 1.0;
+    const auto actual_rdf_r = y_rdf_r[0];
     TS_ASSERT_DELTA(actual_rdf_r, exp_rdf_r, 1e-8);
 
     //// test G_k(r) - note that y values have been changed by previous call to convertToLittleGRMinus1
     const std::string G_K_OF_R("G_k(r)");
-    pdfft.convertToLittleGRMinus1(y, x, dy, dx, G_K_OF_R, rho0, cohScatLen);
+    auto y_gkr = y_initial;
+    pdfft.convertToLittleGRMinus1(y_gkr, x, dy, dx, G_K_OF_R, rho0, cohScatLen);
     const double factor2 = 0.01 * pow(cohScatLen, 2);
-    const auto exp_gkr = exp_rdf_r / factor2;
-    const auto actual_gkr = y[0];
+    const auto exp_gkr = y_initial[0] / factor2;
+    const auto actual_gkr = y_gkr[0];
     TS_ASSERT_DELTA(actual_gkr, exp_gkr, 1e-8);
   }
 

--- a/Framework/Algorithms/test/PDFFourierTransform2Test.h
+++ b/Framework/Algorithms/test/PDFFourierTransform2Test.h
@@ -345,16 +345,16 @@ public:
     API::MatrixWorkspace_sptr ws = createWS(20, 0.1, "CheckResult3", "AtomicDistance");
 
     // shared values for tests
-    std::vector<double> x(2, 2.0);
+    const double single_x = 2.0;
+    std::vector<double> x(2, single_x);
     std::vector<double> dy(2, 0.0);
     std::vector<double> dx(2, 0.0);
     const double rho0 = 1.0;
     const double cohScatLen = 1.0;
     const double factor1 = 4. * M_PI * rho0;
-    const double single_x = 2.0;
 
     // set up initial y values
-    std::vector<double> y(single_x, 5.0);
+    std::vector<double> y(2, 5.0);
 
     // Algorithm destructor crashes without workspace properties initialised
     PDFFourierTransform2 pdfft;

--- a/docs/source/algorithms/PDFFourierTransform-v2.rst
+++ b/docs/source/algorithms/PDFFourierTransform-v2.rst
@@ -112,6 +112,19 @@ otherwise
 
    </center>
 
+**G_k(r)**
+##########
+
+.. raw:: html
+
+   <center>
+
+:math:`G_k(r) = \frac{\sigma_s G(r)}{(4 \pi)^2 \rho_0 r} = \frac{\sigma_s}{4 \pi} [g(r)-1]`
+
+.. raw:: html
+
+   </center>
+
 **Note:** All output forms are calculated by transforming :math:`g(r)-1`.
 
 Usage

--- a/docs/source/algorithms/PDFFourierTransform-v2.rst
+++ b/docs/source/algorithms/PDFFourierTransform-v2.rst
@@ -119,7 +119,7 @@ otherwise
 
    <center>
 
-:math:`G_k(r) = \frac{\sigma_s G(r)}{(4 \pi)^2 \rho_0 r} = \frac{\sigma_s}{4 \pi} [g(r)-1]`
+:math:`G_k(r) = \frac{0.01 * \langle b_{coh} \rangle ^2 G^{PDF}(r)}{(4 \pi)^2 \rho_0 r} = 0.01 * \langle b_{coh} \rangle ^2 [g(r)-1]`
 
 .. raw:: html
 

--- a/docs/source/algorithms/PDFFourierTransform-v2.rst
+++ b/docs/source/algorithms/PDFFourierTransform-v2.rst
@@ -13,8 +13,8 @@ The algorithm transforms a single spectrum workspace containing
 spectral density :math:`S(Q)`, :math:`S(Q)-1`, or :math:`Q[S(Q)-1]`
 (as a function of **MomentumTransfer** or **dSpacing** :ref:`units <Unit Factory>`) to a PDF
 (pair distribution function) as described below and also the reverse. The available PDF types are the
-reduced pair distribution function :math:`G(r)`, the pair distribution function :math:`g(r)`, and the
-radial distribution function :math:`RDF(r)`.
+reduced pair distribution function :math:`G(r)`, the pair distribution function :math:`g(r)`, the
+radial distribution function :math:`RDF(r)`, and the total radial distribution function :math:`G_k(r)`.
 
 The output from this algorithm will have an x-range between 0.0 and the maximum parameter of the output,
 i.e. if converting from `g(r)` to `S(Q)` the output will be between 0.0 and `Qmax`.

--- a/docs/source/release/v6.5.0/Diffraction/Powder/New_features/34014.rst
+++ b/docs/source/release/v6.5.0/Diffraction/Powder/New_features/34014.rst
@@ -1,0 +1,1 @@
+- Added Total radial distribution function (G_k(r)) option to :ref:`PDFFourierTransform v2 <algm-PDFFourierTransform-v2>` .

--- a/scripts/Diffraction/isis_powder/polaris.py
+++ b/scripts/Diffraction/isis_powder/polaris.py
@@ -51,7 +51,7 @@ class Polaris(AbstractInst):
         return vanadium_d
 
     def create_total_scattering_pdf(self, **kwargs):
-        if 'pdf_type' not in kwargs or kwargs['pdf_type'] not in ['G(r)', 'g(r)', 'RDF(r)']:
+        if 'pdf_type' not in kwargs or kwargs['pdf_type'] not in ['G(r)', 'g(r)', 'RDF(r)', 'G_k(r)']:
             kwargs['pdf_type'] = 'G(r)'
             logger.warning('PDF type not specified or is invalid, defaulting to G(r)')
         self._inst_settings.update_attributes(kwargs=kwargs)


### PR DESCRIPTION
**Description of work.**
Added a new PDF type of G_k(r) to the PDFFourierTransform (v2) algorithm. Further discussions identified that the formula provided in the issue was incorrect and it has now been revised to the following:

$$
G_k(r) = \frac{0.01 * \langle b_{coh} \rangle ^2 G^{PDF}(r)}{(4 \pi)^2 \rho_0 r} = 0.01 * \langle b_{coh} \rangle ^2 [g(r)-1]
$$

This PR adds the functionality required to use the new PDF Type, documentation and relevant tests.

**To test:**

Unzip this zip file somewhere: 
[POLARISPowderDiffractionFolderSmall.zip](https://github.com/mantidproject/mantid/files/9103459/POLARISPowderDiffractionFolderSmall.zip)

Update the paths in the file polaris_config_example.yaml so they match where you unzipped the file and also update config_file_path in the script below

Run the following script in workbench and check it completes. In addition plot the PDF workspace and check that it is non-zero:

```
# import mantid algorithms, numpy and matplotlib
from mantid.simpleapi import *
import matplotlib.pyplot as plt
import numpy as np

from isis_powder import polaris, SampleDetails

config_file_path = r"C:\Total Scattering\polaris_config_example.yaml"
polaris = polaris.Polaris(config_file=config_file_path, user_name="test", mode="PDF")

sample_details = SampleDetails(height=4.0, radius=0.2985, center=[0, 0, 0], shape='cylinder')
sample_details.set_material(chemical_formula='Si', packing_fraction=0.6)
polaris.set_sample_details(sample=sample_details)

polaris.create_vanadium(first_cycle_run_no="98532", multiple_scattering=False)

polaris.focus(run_number="98533", input_mode='Summed')

q_lim = [[2.5, 3, 4, 6, 7], [3.5, 5, 7, 11, 40]]

polaris.create_total_scattering_pdf(run_number="98533", merge_banks=True,q_lims=q_lim, 
                                    freq_params=[1.4], pdf_type="G_k(r)", debug=True)
```

Fixes #34014 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
