### PR TITLE
Fixing colorbar

### DIFF
--- a/docs/source/release/v6.5.0/Workbench/SliceViewer/Bugfixes/34214.rst
+++ b/docs/source/release/v6.5.0/Workbench/SliceViewer/Bugfixes/34214.rst
@@ -1,0 +1,1 @@
+* Fix for colorbar when using log scale that causes slice viewer to throw exception with all masked slice.

--- a/qt/python/mantidqt/mantidqt/widgets/colorbar/colorbar.py
+++ b/qt/python/mantidqt/mantidqt/widgets/colorbar/colorbar.py
@@ -306,7 +306,10 @@ class ColorbarWidget(QWidget):
     def _calculate_clim(self) -> tuple:
         """Calculate the colorbar limits to use when autoscale is turned on."""
         axes = self.colorbar.mappable
-        data = axes.get_array_clipped_to_bounds() if hasattr(axes, "get_array_clipped_to_bounds") else axes.get_array()
+        try:
+            data = axes.get_array_clipped_to_bounds()
+        except AttributeError:
+            data = axes.get_array()
 
         log_normalisation = NORM_OPTS[self.norm.currentIndex()] == "Log"
         try:
@@ -317,7 +320,7 @@ class ColorbarWidget(QWidget):
                 # If any dimension is zero then we have no data in the display area
                 data_is_empty = any(map(lambda dim: dim == 0, masked_data.shape))
 
-                return (0.0, 0.0) if data_is_empty else (masked_data.min(), masked_data.max())
+                return (0.1, 1.0) if data_is_empty else (masked_data.min(), masked_data.max())
             except (AttributeError, IndexError):
                 data = data[np.nonzero(data)] if log_normalisation else data
                 return np.nanmin(data), np.nanmax(data)


### PR DESCRIPTION
**Description of work.**

Fixing an annoying bug that causes sliceviewer to throw an exception when using log-scale and there are empty slices with invalid data

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**

Run this script. Open the workspace in slice viewer and change to log scale. Slice through the data and transpose to make sure no exception is thrown.

```python
# import mantid algorithms, numpy and matplotlib
from mantid.simpleapi import *
import matplotlib.pyplot as plt
import numpy as np

signal = np.linspace(0,1,1000)
error = np.sqrt(signal)

signal -= 0.5

signal[signal>0.25] = np.nan

ws = CreateMDHistoWorkspace(Dimensionality=3,
                            Extents='-3,3,-10,10,-5,5',
                            SignalInput=signal,
                            ErrorInput=error,
                            NumberOfBins='10,10,10',
                            Names='Dim1,Dim2,Dim3',
                            Units='Uni1,Uni2,Uni3')
```


<!-- Instructions for testing. -->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
