### PR TITLE
Look up preview reduction settings by angle

### DIFF
--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/RowProcessingAlgorithm.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/RowProcessingAlgorithm.cpp
@@ -293,8 +293,7 @@ std::unique_ptr<MantidQt::API::IAlgorithmRuntimeProps> createAlgorithmRuntimePro
   auto properties = std::make_unique<MantidQt::API::AlgorithmRuntimeProps>();
   updatePropertiesFromBatchModel(*properties, model);
   // Look up properties for this run on the lookup table (or use wildcard defaults if no run is given)
-  // TODO need to find row by angle/title; for now it just uses the wildcard row
-  auto lookupRow = findWildcardLookupRow(model);
+  auto lookupRow = model.findLookupRow(previewRow);
   if (lookupRow) {
     updateLookupRowProperties(*properties, *lookupRow);
   }

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/Batch.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/Batch.cpp
@@ -31,6 +31,10 @@ boost::optional<LookupRow> Batch::findLookupRow(Row const &row) const {
   return experiment().findLookupRow(row, runsTable().thetaTolerance());
 }
 
+boost::optional<LookupRow> Batch::findLookupRow(PreviewRow const &previewRow) const {
+  return experiment().findLookupRow(previewRow, runsTable().thetaTolerance());
+}
+
 boost::optional<LookupRow> Batch::findWildcardLookupRow() const { return experiment().findWildcardLookupRow(); }
 
 void Batch::resetState() { m_runsTable.resetState(); }

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/Batch.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/Batch.h
@@ -44,6 +44,7 @@ public:
   bool isInSelection(const Group &item,
                      const std::vector<MantidWidgets::Batch::RowLocation> &selectedRowLocations) override;
   boost::optional<LookupRow> findLookupRow(Row const &row) const override;
+  boost::optional<LookupRow> findLookupRow(PreviewRow const &previewRow) const override;
   boost::optional<LookupRow> findWildcardLookupRow() const override;
   void resetState() override;
   void resetSkippedItems() override;

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/Experiment.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/Experiment.cpp
@@ -63,6 +63,10 @@ boost::optional<LookupRow> Experiment::findLookupRow(Row const &row, double tole
   return m_lookupTable.findLookupRow(row, tolerance);
 }
 
+boost::optional<LookupRow> Experiment::findLookupRow(PreviewRow const &previewRow, double tolerance) const {
+  return m_lookupTable.findLookupRow(previewRow, tolerance);
+}
+
 boost::optional<LookupRow> Experiment::findWildcardLookupRow() const { return m_lookupTable.findWildcardLookupRow(); }
 
 boost::optional<size_t> Experiment::getLookupRowIndexFromRow(Row const &row, double tolerance) const {

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/Experiment.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/Experiment.h
@@ -26,6 +26,7 @@ namespace CustomInterfaces {
 namespace ISISReflectometry {
 
 class Row;
+class PreviewRow;
 
 /** @class Experiment
 
@@ -56,6 +57,7 @@ public:
   std::vector<LookupRow::ValueArray> lookupTableToArray() const;
 
   boost::optional<LookupRow> findLookupRow(Row const &row, double tolerance) const;
+  boost::optional<LookupRow> findLookupRow(PreviewRow const &previewRow, double tolerance) const;
   boost::optional<LookupRow> findWildcardLookupRow() const;
 
   boost::optional<size_t> getLookupRowIndexFromRow(Row const &row, double tolerance) const;

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/IBatch.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/IBatch.h
@@ -17,6 +17,7 @@ namespace MantidQt::CustomInterfaces::ISISReflectometry {
 
 class Experiment;
 class Instrument;
+class PreviewRow;
 class Row;
 class Group;
 class Item;
@@ -33,6 +34,7 @@ public:
   virtual Slicing const &slicing() const = 0;
 
   virtual boost::optional<LookupRow> findLookupRow(Row const &row) const = 0;
+  virtual boost::optional<LookupRow> findLookupRow(PreviewRow const &previewRow) const = 0;
   virtual boost::optional<LookupRow> findWildcardLookupRow() const = 0;
   virtual boost::optional<Item &> getItemWithOutputWorkspaceOrNone(std::string const &wsName) = 0;
   virtual bool isInSelection(const Item &item,

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/LookupTable.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/LookupTable.cpp
@@ -7,6 +7,7 @@
 
 #include "LookupTable.h"
 #include "IGroup.h"
+#include "PreviewRow.h"
 #include "Row.h"
 #include <boost/optional.hpp>
 #include <boost/regex.hpp>
@@ -40,6 +41,16 @@ boost::optional<LookupRow> LookupTable::findLookupRow(Row const &row, double tol
   lookupRows = findEmptyRegexes();
   // Now filter by angle; it should be unique
   if (auto found = searchByTheta(lookupRows, row.theta(), tolerance)) {
+    return found;
+  }
+  // If we didn't find a lookup row where theta matches, then we allow the user to specify a "wildcard" row
+  // which will be used for everything where a specific match is not found
+  auto result = findWildcardLookupRow();
+  return result;
+}
+
+boost::optional<LookupRow> LookupTable::findLookupRow(PreviewRow const &previewRow, double tolerance) const {
+  if (auto found = searchByTheta(m_lookupRows, previewRow.theta(), tolerance)) {
     return found;
   }
   // If we didn't find a lookup row where theta matches, then we allow the user to specify a "wildcard" row

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/LookupTable.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/LookupTable.h
@@ -16,6 +16,7 @@
 
 namespace MantidQt::CustomInterfaces::ISISReflectometry {
 class Row;
+class PreviewRow;
 
 struct MultipleRowsFoundException : public std::length_error {
 public:
@@ -29,6 +30,7 @@ public:
   LookupTable(std::initializer_list<LookupRow> rowsIn);
 
   boost::optional<LookupRow> findLookupRow(Row const &row, double tolerance) const;
+  boost::optional<LookupRow> findLookupRow(PreviewRow const &previewRow, double tolerance) const;
   boost::optional<LookupRow> findWildcardLookupRow() const;
   size_t getIndex(LookupRow const &) const;
   std::vector<LookupRow> const &rows() const;

--- a/qt/scientific_interfaces/ISISReflectometry/test/Reduction/MockBatch.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Reduction/MockBatch.h
@@ -26,6 +26,7 @@ public:
   MOCK_METHOD(Slicing const &, slicing, (), (const, override));
 
   MOCK_METHOD(boost::optional<LookupRow>, findLookupRow, (Row const &), (const, override));
+  MOCK_METHOD(boost::optional<LookupRow>, findLookupRow, (PreviewRow const &), (const, override));
   MOCK_METHOD(boost::optional<LookupRow>, findWildcardLookupRow, (), (const, override));
   MOCK_METHOD(boost::optional<Item &>, getItemWithOutputWorkspaceOrNone, (std::string const &), (override));
   MOCK_METHOD(bool, isInSelection, (const Item &, const std::vector<MantidWidgets::Batch::RowLocation> &), (override));


### PR DESCRIPTION
This PR adds lookup of experiment settings by angle when performing a preview reduction on the ISIS reflectometry interface. It replaces the previous lookup, which just used the wildcard row, to a lookup based on the angle provided on the preview tab.

Fixes #34210

**To test:**

Must be tested in a debug build

- Ensure this workspace is loaded or is in your load path: [INTER45455_inst.zip](https://github.com/mantidproject/mantid/files/7504266/INTER45455_inst.zip)
- Open the ISIS Reflectometry GUI
- Select the Experiment Settings tab and in the lookup table enter an angle of 1 and a Scale of 0.9.
- Select the Preview tab.
- Type in `INTER45455_inst`, set the angle to `1`, and click Load. The instrument view plot should display the data. Click the rectangle-select button above it and select a region. The segments will be summed and the result plotted on the second plot.
- Click the rectangle-selection button on the second plot and select a region. A reduction will now be performed on the selected spectra and the result plotted on the 1D plot. 
- Click the Export button above the 1D plot. This should export the workspace `preview_reduced_ws` to the ADS.
  - Right-click it and view the history.
  - Select the algorithm ReflectometryReductionOneAuto
  - Check that the properties were taken from the correct row in the lookup table i.e. ScaleFactor is set to `0.9` or whatever you entered in the lookup table.
- Change the angle on the Preview tab to something outside the tolerance of 0.01, e.g. `1.02`. Re-draw the second ROI so that the final plot updates. Re-export it and re-open the history. The scale factor should have reverted to the default of `1`.
- Change the angle to within tolerance e.g. `1.01` and re-try. It should now match again and report `0.9`.
- Edit the Lookup Table and clear the Angle field - this is a wildcard row and should match everything. Try again and it should match and report `0.9`.
- Select the row in the Lookup Table and press Del to delete it. Try again and it should not find a match, so revert to scale of `1`

*This does not require release notes* because **it is part of work that is not exposed in the release build yet**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
