### PR TITLE
Set default angle on preview tab

### DIFF
--- a/Framework/Reflectometry/inc/MantidReflectometry/ReflectometryWorkflowBase2.h
+++ b/Framework/Reflectometry/inc/MantidReflectometry/ReflectometryWorkflowBase2.h
@@ -77,7 +77,7 @@ protected:
   /// Populate transmission properties
   bool populateTransmissionProperties(const Mantid::API::IAlgorithm_sptr &alg) const;
   /// Find theta from a named log value
-  double getThetaFromLogs(const Mantid::API::MatrixWorkspace_sptr &inputWs, const std::string &logName);
+  double getThetaFromLogs(const Mantid::API::MatrixWorkspace_sptr &inputWs, const std::string &logName) const;
   // Retrieve the run number from the logs of the input workspace.
   std::string getRunNumber(Mantid::API::MatrixWorkspace const &ws) const;
 

--- a/Framework/Reflectometry/src/ReflectometryWorkflowBase2.cpp
+++ b/Framework/Reflectometry/src/ReflectometryWorkflowBase2.cpp
@@ -786,7 +786,8 @@ bool ReflectometryWorkflowBase2::populateTransmissionProperties(const IAlgorithm
  * @return :: the value of theta found from the logs
  * @throw :: NotFoundError if the log value was not found
  */
-double ReflectometryWorkflowBase2::getThetaFromLogs(const MatrixWorkspace_sptr &inputWs, const std::string &logName) {
+double ReflectometryWorkflowBase2::getThetaFromLogs(const MatrixWorkspace_sptr &inputWs,
+                                                    const std::string &logName) const {
   double theta = -1.;
   const Mantid::API::Run &run = inputWs->run();
   Property *logData = run.getLogData(logName);

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/IPreviewModel.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/IPreviewModel.h
@@ -9,6 +9,8 @@
 #include "MantidAPI/MatrixWorkspace_fwd.h"
 #include "MantidGeometry/IDTypes.h"
 #include "Reduction/ProcessingInstructions.h"
+
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -31,7 +33,7 @@ public:
   virtual Mantid::API::MatrixWorkspace_sptr getSummedWs() const = 0;
   virtual Mantid::API::MatrixWorkspace_sptr getReducedWs() const = 0;
   virtual ProcessingInstructions getProcessingInstructions() const = 0;
-  virtual double getDefaultTheta() const = 0;
+  virtual std::optional<double> getDefaultTheta() const = 0;
 
   virtual void setTheta(double theta) = 0;
 

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/IPreviewModel.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/IPreviewModel.h
@@ -31,6 +31,7 @@ public:
   virtual Mantid::API::MatrixWorkspace_sptr getSummedWs() const = 0;
   virtual Mantid::API::MatrixWorkspace_sptr getReducedWs() const = 0;
   virtual ProcessingInstructions getProcessingInstructions() const = 0;
+  virtual double getDefaultTheta() const = 0;
 
   virtual void setTheta(double theta) = 0;
 

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/IPreviewView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/IPreviewView.h
@@ -54,6 +54,7 @@ public:
   virtual void setInstViewEditMode() = 0;
   virtual void setInstViewSelectRectMode() = 0;
   virtual void setInstViewToolbarEnabled(bool enable) = 0;
+  virtual void setAngle(double angle) = 0;
   // Region selector toolbar
   // TODO implement edit ROI button
   // virtual void setEditROIState(bool on) = 0;

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewModel.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewModel.cpp
@@ -9,16 +9,19 @@
 #include "GUI/Common/IJobManager.h"
 #include "MantidAPI/AnalysisDataService.h"
 #include "MantidAPI/MatrixWorkspace.h"
+#include "MantidAPI/Run.h"
 #include "MantidGeometry/IDTypes.h"
 #include "MantidGeometry/Instrument/DetectorInfo.h"
 #include "MantidKernel/Logger.h"
 #include "MantidKernel/Strings.h"
+#include "MantidKernel/TimeSeriesProperty.h"
 
 #include <boost/utility/in_place_factory.hpp>
 
 #include <string>
 
 using namespace Mantid::API;
+using namespace Mantid::Kernel;
 
 namespace {
 Mantid::Kernel::Logger g_log("Reflectometry Preview Model");
@@ -78,7 +81,11 @@ MatrixWorkspace_sptr PreviewModel::getLoadedWs() const { return m_runDetails->ge
 MatrixWorkspace_sptr PreviewModel::getSummedWs() const { return m_runDetails->getSummedWs(); }
 MatrixWorkspace_sptr PreviewModel::getReducedWs() const { return m_runDetails->getReducedWs(); }
 
+double PreviewModel::getDefaultTheta() const { return getThetaFromLogs("Theta"); }
+
 std::vector<Mantid::detid_t> PreviewModel::getSelectedBanks() const { return m_runDetails->getSelectedBanks(); }
+
+void PreviewModel::setLoadedWs(Mantid::API::MatrixWorkspace_sptr workspace) { m_runDetails->setLoadedWs(workspace); }
 
 void PreviewModel::setTheta(double theta) { m_runDetails->setTheta(theta); }
 void PreviewModel::setSelectedBanks(std::vector<Mantid::detid_t> selectedBanks) {
@@ -122,4 +129,22 @@ void PreviewModel::exportReducedWsToAds() const {
         "Could not export reduced WS. No selection has been made on the instrument viewer and/or region selector.");
   }
 }
+
+double PreviewModel::getThetaFromLogs(const std::string &logName) const {
+  double theta = -1.;
+  const Mantid::API::Run &run = getLoadedWs()->run();
+  Property *logData = run.getLogData(logName);
+  auto logPWV = dynamic_cast<const PropertyWithValue<double> *>(logData);
+  auto logTSP = dynamic_cast<const TimeSeriesProperty<double> *>(logData);
+
+  if (logPWV) {
+    theta = *logPWV;
+  } else if (logTSP && logTSP->realSize() > 0) {
+    theta = logTSP->lastValue();
+  } else {
+    throw Exception::NotFoundError("Theta", "Log value not found");
+  }
+  return theta;
+}
+
 } // namespace MantidQt::CustomInterfaces::ISISReflectometry

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewModel.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewModel.h
@@ -36,7 +36,9 @@ public:
   Mantid::API::MatrixWorkspace_sptr getSummedWs() const override;
   ProcessingInstructions getProcessingInstructions() const override;
   Mantid::API::MatrixWorkspace_sptr getReducedWs() const override;
+  double getDefaultTheta() const override;
 
+  void setLoadedWs(Mantid::API::MatrixWorkspace_sptr workspace);
   void setTheta(double theta) override;
   void setSelectedBanks(std::vector<Mantid::detid_t> selectedBanks) override;
   void setSelectedRegion(Selection const &selection) override;
@@ -51,5 +53,7 @@ private:
   std::unique_ptr<PreviewRow> m_runDetails{nullptr};
 
   void createRunDetails(std::string const &workspaceName);
+
+  double getThetaFromLogs(std::string const &logName) const;
 };
 } // namespace MantidQt::CustomInterfaces::ISISReflectometry

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewModel.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewModel.h
@@ -15,6 +15,7 @@
 
 #include <cstddef>
 #include <memory>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -36,7 +37,7 @@ public:
   Mantid::API::MatrixWorkspace_sptr getSummedWs() const override;
   ProcessingInstructions getProcessingInstructions() const override;
   Mantid::API::MatrixWorkspace_sptr getReducedWs() const override;
-  double getDefaultTheta() const override;
+  std::optional<double> getDefaultTheta() const override;
 
   void setLoadedWs(Mantid::API::MatrixWorkspace_sptr workspace);
   void setTheta(double theta) override;
@@ -54,6 +55,6 @@ private:
 
   void createRunDetails(std::string const &workspaceName);
 
-  double getThetaFromLogs(std::string const &logName) const;
+  std::optional<double> getThetaFromLogs(std::string const &logName) const;
 };
 } // namespace MantidQt::CustomInterfaces::ISISReflectometry

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.cpp
@@ -7,6 +7,7 @@
 
 #include "PreviewPresenter.h"
 #include "MantidAPI/MatrixWorkspace.h"
+#include "MantidKernel/Tolerance.h"
 #include "MantidQtWidgets/Plotting/AxisID.h"
 #include "MantidQtWidgets/RegionSelector/IRegionSelector.h"
 #include "MantidQtWidgets/RegionSelector/RegionSelector.h"
@@ -77,9 +78,12 @@ void PreviewPresenter::notifyLoadWorkspaceCompleted() {
   auto ws = m_model->getLoadedWs();
   assert(ws);
 
-  // Set the angle so that it has a non-zero value when the reduction is run
-  if (auto const theta = m_model->getDefaultTheta()) {
-    m_view->setAngle(*theta);
+  // Only set the angle to the default if the user hasn't already set it manually
+  if (m_view->getAngle() < Mantid::Kernel::Tolerance) {
+    // Set the angle so that it has a non-zero value when the reduction is run
+    if (auto const theta = m_model->getDefaultTheta()) {
+      m_view->setAngle(*theta);
+    }
   }
 
   // Notify the instrument view model that the workspace has changed before we get the surface

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.cpp
@@ -77,6 +77,9 @@ void PreviewPresenter::notifyLoadWorkspaceCompleted() {
   auto ws = m_model->getLoadedWs();
   assert(ws);
 
+  // Set the angle so that it has a non-zero value when the reduction is run
+  m_view->setAngle(m_model->getDefaultTheta());
+
   // Notify the instrument view model that the workspace has changed before we get the surface
   m_instViewModel->updateWorkspace(ws);
   plotInstView();

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.cpp
@@ -78,7 +78,9 @@ void PreviewPresenter::notifyLoadWorkspaceCompleted() {
   assert(ws);
 
   // Set the angle so that it has a non-zero value when the reduction is run
-  m_view->setAngle(m_model->getDefaultTheta());
+  if (auto const theta = m_model->getDefaultTheta()) {
+    m_view->setAngle(*theta);
+  }
 
   // Notify the instrument view model that the workspace has changed before we get the surface
   m_instViewModel->updateWorkspace(ws);

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/QtPreviewView.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/QtPreviewView.cpp
@@ -106,6 +106,8 @@ void QtPreviewView::setInstViewToolbarEnabled(bool enable) {
   m_ui.iv_rect_select_button->setEnabled(enable);
 }
 
+void QtPreviewView::setAngle(double angle) { m_ui.angle_spin_box->setValue(angle); }
+
 void QtPreviewView::setRectangularROIState(bool enable) { m_ui.rs_rect_select_button->setEnabled(enable); }
 
 std::vector<size_t> QtPreviewView::getSelectedDetectors() const {

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/QtPreviewView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/QtPreviewView.h
@@ -49,6 +49,7 @@ public:
   void setInstViewEditMode() override;
   void setInstViewSelectRectMode() override;
   void setInstViewToolbarEnabled(bool enable) override;
+  void setAngle(double angle) override;
   // Region selector toolbar
   void setRectangularROIState(bool enable) override;
 

--- a/qt/scientific_interfaces/ISISReflectometry/test/Preview/MockPreviewModel.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Preview/MockPreviewModel.h
@@ -28,7 +28,7 @@ public:
   MOCK_METHOD(MatrixWorkspace_sptr, getReducedWs, (), (const, override));
   MOCK_METHOD(std::vector<Mantid::detid_t>, getSelectedBanks, (), (const, override));
   MOCK_METHOD(ProcessingInstructions, getProcessingInstructions, (), (const, override));
-  MOCK_METHOD(double, getDefaultTheta, (), (const, override));
+  MOCK_METHOD(std::optional<double>, getDefaultTheta, (), (const, override));
 
   MOCK_METHOD(void, setTheta, (double), (override));
   MOCK_METHOD(void, setSelectedBanks, (std::vector<Mantid::detid_t>), (override));

--- a/qt/scientific_interfaces/ISISReflectometry/test/Preview/MockPreviewModel.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Preview/MockPreviewModel.h
@@ -28,6 +28,7 @@ public:
   MOCK_METHOD(MatrixWorkspace_sptr, getReducedWs, (), (const, override));
   MOCK_METHOD(std::vector<Mantid::detid_t>, getSelectedBanks, (), (const, override));
   MOCK_METHOD(ProcessingInstructions, getProcessingInstructions, (), (const, override));
+  MOCK_METHOD(double, getDefaultTheta, (), (const, override));
 
   MOCK_METHOD(void, setTheta, (double), (override));
   MOCK_METHOD(void, setSelectedBanks, (std::vector<Mantid::detid_t>), (override));

--- a/qt/scientific_interfaces/ISISReflectometry/test/Preview/MockPreviewView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Preview/MockPreviewView.h
@@ -31,6 +31,7 @@ public:
   MOCK_METHOD(void, setInstViewZoomMode, (), (override));
   MOCK_METHOD(void, setInstViewEditMode, (), (override));
   MOCK_METHOD(void, setRectangularROIState, (bool), (override));
+  MOCK_METHOD(void, setAngle, (double), (override));
   MOCK_METHOD(std::vector<size_t>, getSelectedDetectors, (), (const, override));
   MOCK_METHOD(QLayout *, getRegionSelectorLayout, (), (const, override));
   MOCK_METHOD(MantidQt::MantidWidgets::IPlotView *, getLinePlotView, (), (const, override));

--- a/qt/scientific_interfaces/ISISReflectometry/test/Preview/PreviewModelTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Preview/PreviewModelTest.h
@@ -158,6 +158,24 @@ public:
     model.exportReducedWsToAds();
   }
 
+  void test_get_set_loaded_workspace() {
+    PreviewModel model;
+    auto ws = createWorkspace();
+    model.setLoadedWs(ws);
+
+    TS_ASSERT_EQUALS(model.getLoadedWs(), ws);
+  }
+
+  void test_get_theta_from_workspace() {
+    PreviewModel model;
+    auto theta = 2.3;
+    auto ws = createWorkspace();
+    ws->mutableRun().addProperty("Theta", theta, true);
+    model.setLoadedWs(ws);
+
+    TS_ASSERT_DELTA(model.getDefaultTheta(), theta, 1e-6);
+  }
+
 private:
   MatrixWorkspace_sptr generateSummedWs(MockJobManager &mockJobManager, PreviewModel &model) {
     auto expectedWs = createWorkspace();

--- a/qt/scientific_interfaces/ISISReflectometry/test/Preview/PreviewModelTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Preview/PreviewModelTest.h
@@ -173,7 +173,28 @@ public:
     ws->mutableRun().addProperty("Theta", theta, true);
     model.setLoadedWs(ws);
 
-    TS_ASSERT_DELTA(model.getDefaultTheta(), theta, 1e-6);
+    TS_ASSERT(model.getDefaultTheta());
+    TS_ASSERT_DELTA(*model.getDefaultTheta(), theta, 1e-6);
+  }
+
+  void test_get_theta_from_workspace_not_found() {
+    PreviewModel model;
+    auto ws = createWorkspace();
+    model.setLoadedWs(ws);
+
+    TS_ASSERT(!model.getDefaultTheta());
+  }
+
+  void test_get_theta_from_workspace_is_invalid() {
+    PreviewModel model;
+    auto thetas = std::vector<double>{0.0, -1.2, 0.00000000008};
+    for (auto theta : thetas) {
+      auto ws = createWorkspace();
+      ws->mutableRun().addProperty("Theta", theta, true);
+      model.setLoadedWs(ws);
+
+      TS_ASSERT(!model.getDefaultTheta());
+    }
   }
 
 private:

--- a/qt/scientific_interfaces/ISISReflectometry/test/Preview/PreviewPresenterTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Preview/PreviewPresenterTest.h
@@ -77,7 +77,8 @@ public:
     EXPECT_CALL(*mockView, getWorkspaceName()).Times(1).WillOnce(Return(workspaceName));
     EXPECT_CALL(*mockModel, loadWorkspaceFromAds(workspaceName)).Times(1).WillOnce(Return(true));
     EXPECT_CALL(*mockModel, loadAndPreprocessWorkspaceAsync(_, _)).Times(0);
-    expectLoadWorkspaceCompleted(*mockView, *mockModel, *mockInstViewModel);
+    expectLoadWorkspaceCompletedUpdatesInstrumentView(*mockView, *mockModel, *mockInstViewModel);
+    expectLoadWorkspaceCompletedUpdatesAngle(*mockView, *mockModel);
 
     auto presenter = PreviewPresenter(
         packDeps(mockView.get(), std::move(mockModel), std::move(mockJobManager), std::move(mockInstViewModel)));
@@ -119,7 +120,8 @@ public:
     auto mockJobManager = makeJobManager();
     auto mockInstViewModel = makeInstViewModel();
 
-    expectLoadWorkspaceCompleted(*mockView, *mockModel, *mockInstViewModel);
+    expectLoadWorkspaceCompletedUpdatesInstrumentView(*mockView, *mockModel, *mockInstViewModel);
+    expectLoadWorkspaceCompletedUpdatesAngle(*mockView, *mockModel);
 
     auto deps = packDeps(mockView.get(), std::move(mockModel), std::move(mockJobManager), std::move(mockInstViewModel));
     auto presenter = PreviewPresenter(std::move(deps));
@@ -282,18 +284,24 @@ private:
     EXPECT_CALL(linePlot, setPlotErrorBars(true)).Times(1);
   }
 
-  void expectLoadWorkspaceCompleted(MockPreviewView &mockView, MockPreviewModel &mockModel,
-                                    MockInstViewModel &mockInstViewModel) {
+  void expectLoadWorkspaceCompletedUpdatesInstrumentView(MockPreviewView &mockView, MockPreviewModel &mockModel,
+                                                         MockInstViewModel &mockInstViewModel) {
     expectInstViewModelUpdatedWithLoadedWorkspace(mockModel, mockInstViewModel);
     expectPlotInstView(mockView, mockInstViewModel);
     expectInstViewToolbarEnabled(mockView);
     expectInstViewSetToZoomMode(mockView);
   }
 
+  void expectLoadWorkspaceCompletedUpdatesAngle(MockPreviewView &mockView, MockPreviewModel &mockModel) {
+    auto angle = 2.3;
+    EXPECT_CALL(mockModel, getDefaultTheta()).Times(1).WillOnce(Return(angle));
+    EXPECT_CALL(mockView, setAngle(angle)).Times(1);
+  }
+
   void expectInstViewModelUpdatedWithLoadedWorkspace(MockPreviewModel &mockModel,
                                                      MockInstViewModel &mockInstViewModel) {
     auto ws = WorkspaceCreationHelper::create2DWorkspace(1, 1);
-    EXPECT_CALL(mockModel, getLoadedWs).Times(1).WillOnce(Return(ws));
+    EXPECT_CALL(mockModel, getLoadedWs()).Times(1).WillOnce(Return(ws));
     EXPECT_CALL(mockInstViewModel, updateWorkspace(Eq(ws))).Times(1);
   }
 


### PR DESCRIPTION
This work was pair programmed with: @rbauststfc @robertapplin @gemmaguest 

**Description of work.**

This PR sets a default angle on the Preview tab in the ISIS Reflectometry interface. The angle is taken from the sample logs for a run when the workspace is loaded, if it exists and is valid (i.e. positive non-zero). This will provide a sensible default that will enable a full reduction to be run when the user loads a file. 

Note that the value is only updated if the current value is zero. This is so that a user-entered value is not overwritten; however it does mean that on changing to a different run, the value is not changed for the new run. This will be fixed by improvements to the UX in future PRs.

**To test:**

Must be run in a Debug build.

- Ensure the ISIS data archive is enabled in your user directories settings.
- Open the ISIS reflectometry GUI
- Set instrument to INTER
- On the Preview tab, enter run number 43583 and click Load
- The value in the Angle box should change from zero to `1.3`
- Note that you will now get an error because the processing will fail (this is expected for this run because it is a detector type that is not supported yet).
- Change the angle to `1.0` and click Load again. The angle should not change.

Fixes #34212.

*This does not require release notes* because **it relates to functionality that is not exposed in the release yet**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
