### PR TITLE
Ensure that all spectrum in Indirect Detector Table start at 1

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ISISIndirectEnergyTransfer.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ISISIndirectEnergyTransfer.py
@@ -292,7 +292,7 @@ class ISISIndirectEnergyTransfer(DataProcessorAlgorithm):
                                          OutputWorkspace=self._output_ws)
 
         # The spectrum numbers need to start at 1 not 0 if spectra are grouped
-        if self.output_ws.getNumberOfEntries() == 1 and self.getProperty('GroupingMethod').value == 'Custom':
+        if self.output_ws.getNumberOfEntries() == 1:
             for i in range(len(self.output_ws.getItem(0).getSpectrumNumbers())):
                 self.output_ws.getItem(0).getSpectrum(i).setSpectrumNo(i+1)
 

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/ISISIndirectEnergyTransferTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/ISISIndirectEnergyTransferTest.py
@@ -370,6 +370,22 @@ class ISISIndirectEnergyTransferTest(unittest.TestCase):
         red_ws = reduced_workspace.getItem(0)
         self.assertEqual(red_ws.getSpectrum(0).getSpectrumNo(), 1)
 
+    def test_change_spectra_for_individual(self):
+        """Check that the spectra are changed for a custom grouping"""
+
+        wks = ISISIndirectEnergyTransfer(InputFiles=['IRS26176.RAW'],
+                                         Instrument='IRIS',
+                                         Analyser='graphite',
+                                         Reflection='002',
+                                         SpectraRange=[3, 53],
+                                         GroupingMethod='Individual')
+
+        self.assertTrue(isinstance(wks, WorkspaceGroup), 'Result workspace should be a workspace group.')
+        self.assertEqual(wks.getNames()[0], 'iris26176_graphite002_red')
+
+        red_ws = wks.getItem(0)
+        self.assertEqual(red_ws.getSpectrum(0).getSpectrumNo(), 1)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/docs/source/release/v6.5.0/Indirect/Bugfixes/34183.rst
+++ b/docs/source/release/v6.5.0/Indirect/Bugfixes/34183.rst
@@ -1,1 +1,1 @@
-- Fixed a bug in Indirect Data Reduction where the spectra in the detector table after grouping started at 0. The spectra now start at 1.
+- Fixed a bug in Indirect Data Reduction where the spectra in the detector table started at 0. The spectra now start at 1.


### PR DESCRIPTION
**Description of work.**
This extends the work undertaken in #34199 to cover indidivual as well as groupings in the Data Reduction GUI. 

**Report to:** Spencer Howells


**To test:**
Test A
1. Open Indirect -> Data Reduction GUI
2. Type run 96141
3. In the detector grouping section, set the value to "groups" and then set the number of groups to 5
4. Press the Run button (you may need to scroll down)
5. Right click on the resulting workspace in the ADS and select 'Show Detectors'
6. The first row will have 0 for the index and 1 for the spectrum number.

Test B
Follow steps 1 and 2 from Test A and then do as follows for step 3
3.  In the detector grouping section, set the value to "individual"
Now follow steps 4-6 from Test A.

This is associated with #34199 

Release notes from previous PR have been updated.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
