### PR TITLE
Fix Sliceviewer Autoscaling not respected

### DIFF
--- a/docs/source/release/v6.5.0/Workbench/SliceViewer/Bugfixes/34225.rst
+++ b/docs/source/release/v6.5.0/Workbench/SliceViewer/Bugfixes/34225.rst
@@ -1,0 +1,1 @@
+- The colorbar now remains autoscaled when switching between the different normalisation options.

--- a/qt/python/mantidqt/mantidqt/widgets/colorbar/colorbar.py
+++ b/qt/python/mantidqt/mantidqt/widgets/colorbar/colorbar.py
@@ -210,6 +210,7 @@ class ColorbarWidget(QWidget):
         self.colorbar.mappable.set_norm(self.get_norm())
         self.set_mappable(self.colorbar.mappable)
         self.update_clim_validator()
+        self.update_clim()
         self.scaleNormChanged.emit()
 
     def get_norm(self):

--- a/qt/python/mantidqt/mantidqt/widgets/colorbar/test/test_colorbar.py
+++ b/qt/python/mantidqt/mantidqt/widgets/colorbar/test/test_colorbar.py
@@ -10,7 +10,7 @@ import numpy as np
 from unittest import TestCase
 
 from mantidqt.utils.qt.testing import start_qapplication
-from mantidqt.widgets.colorbar.colorbar import ColorbarWidget
+from mantidqt.widgets.colorbar.colorbar import ColorbarWidget, NORM_OPTS
 from matplotlib.colors import LogNorm, Normalize, SymLogNorm
 
 
@@ -39,25 +39,37 @@ class ColorbarWidgetTest(TestCase):
         self.widget.set_mappable(image)
 
     def test_that_masked_data_in_log_mode_will_cause_a_switch_back_to_linear_normalisation(self):
-        normalisation_index = 1  # Log
         image = plt.imshow(self.data, cmap="plasma", norm=LogNorm(vmin=0.01, vmax=1.0))
         masked_image = plt.imshow(self.masked_data, cmap="plasma", norm=LogNorm(vmin=0.01, vmax=1.0))
 
         self.widget.set_mappable(image)
-        self.widget.norm.setCurrentIndex(normalisation_index)
+        self.widget.norm.setCurrentIndex(NORM_OPTS.index("Log"))
         self.widget.set_mappable(masked_image)
 
-        self.assertEqual(self.widget.norm.currentIndex(), 0)  # Linear
+        self.assertEqual(self.widget.norm.currentIndex(), NORM_OPTS.index("Linear"))
         self.assertTrue(isinstance(masked_image.norm, Normalize))
 
     def test_that_masked_data_in_symmetric_log_mode_will_cause_a_switch_back_to_linear_normalisation(self):
-        normalisation_index = 2  # SymmetricLog10
         image = plt.imshow(self.data, cmap="plasma", norm=SymLogNorm(1e-8, vmin=0.01, vmax=1.0))
         masked_image = plt.imshow(self.masked_data, cmap="plasma", norm=SymLogNorm(1e-8, vmin=0.01, vmax=1.0))
 
         self.widget.set_mappable(image)
-        self.widget.norm.setCurrentIndex(normalisation_index)
+        self.widget.norm.setCurrentIndex(NORM_OPTS.index("SymmetricLog10"))
         self.widget.set_mappable(masked_image)
 
-        self.assertEqual(self.widget.norm.currentIndex(), 0)  # Linear
+        self.assertEqual(self.widget.norm.currentIndex(), NORM_OPTS.index("Linear"))
         self.assertTrue(isinstance(masked_image.norm, Normalize))
+
+    def test_that_switching_normalisation_will_autoscale_the_colorbar_limits_appropriately(self):
+        image = plt.imshow(self.data, cmap="plasma", norm=SymLogNorm(1e-8, vmin=None, vmax=None))
+
+        self.widget.set_mappable(image)
+        self.widget.autoscale.setChecked(True)
+        c_min, c_max = self.widget._calculate_clim()
+
+        for normalisation_index in range(len(NORM_OPTS)):
+            self.widget.norm.setCurrentIndex(normalisation_index)
+            expected_c_min = c_min if normalisation_index != NORM_OPTS.index("Log") else max(c_min, 1)
+
+            self.assertEqual(self.widget.cmin_value, expected_c_min)
+            self.assertEqual(self.widget.cmax_value, c_max)


### PR DESCRIPTION
**Description of work.**
This PR fixes a bug in the sliceviewer where switching between normalisations (with autoscale turned on) would reset the colorbar limits to be from 0 to 1, but we want it to be autoscaled.

The solution was to ensure the colorbar limits got updated after the normalisation was changed.

Confirmed this bug appeared due to the upgrade from matplotlib 3.1.2 --> 3.5.2 

**To test:**
See the instructions in the issue

Fixes #34223 

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
