### PR TITLE
Reflectometry Preview tab Edit ROI

### DIFF
--- a/qt/python/mantidqt/mantidqt/widgets/regionselector/presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/regionselector/presenter.py
@@ -93,7 +93,10 @@ class RegionSelector(ObservingPresenter, SliceViewerBasePresenter):
 
     def get_region(self):
         # extents contains x1, x2, y1, y2. Just store y (spectra) for now
-        return [self._selectors[0].extents[2], self._selectors[0].extents[3]]
+        result = []
+        for selector in self._selectors:
+            result.extend([selector.extents[2], selector.extents[3]])
+        return result
 
     def _initialise_dimensions(self, workspace):
         self.view.create_dimensions(dims_info=Dimensions.get_dimensions_info(workspace))

--- a/qt/python/mantidqt/mantidqt/widgets/regionselector/presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/regionselector/presenter.py
@@ -48,6 +48,7 @@ class RegionSelector(ObservingPresenter, SliceViewerBasePresenter):
 
         for selector in self._selectors:
             if self._contains_point(selector.extents, event.xdata, event.ydata):
+                # Ensure only one selector is active to avoid confusing matplotlib behaviour
                 selector.set_active(True)
                 return
 
@@ -69,6 +70,14 @@ class RegionSelector(ObservingPresenter, SliceViewerBasePresenter):
             self._initialise_dimensions(workspace)
 
         self._set_workspace(workspace)
+
+    def cancel_drawing_region(self):
+        """
+        Cancel drawing a region if a different toolbar option is pressed.
+        """
+        if self._drawing_region:
+            self._selectors.pop()
+            self._drawing_region = False
 
     def add_rectangular_region(self):
         """
@@ -119,5 +128,6 @@ class RegionSelector(ObservingPresenter, SliceViewerBasePresenter):
         if self.notifyee:
             self.notifyee.notifyRegionChanged()
 
-    def _contains_point(self, extents, x, y):
+    @staticmethod
+    def _contains_point(extents, x, y):
         return extents[0] <= x <= extents[1] and extents[2] <= y <= extents[3]

--- a/qt/python/mantidqt/mantidqt/widgets/regionselector/presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/regionselector/presenter.py
@@ -4,6 +4,8 @@
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
 #  This file is part of the mantid workbench.
+from distutils.version import LooseVersion
+
 from .view import RegionSelectorView
 from ..observers.observing_presenter import ObservingPresenter
 from ..sliceviewer.models.dimensions import Dimensions
@@ -12,6 +14,7 @@ from ..sliceviewer.presenters.base_presenter import SliceViewerBasePresenter
 from mantid.api import RegionSelectorObserver
 
 # 3rd party imports
+import matplotlib
 from matplotlib.widgets import RectangleSelector
 
 
@@ -86,17 +89,18 @@ class RegionSelector(ObservingPresenter, SliceViewerBasePresenter):
         for selector in self._selectors:
             selector.set_active(False)
 
-        self._selectors.append(RectangleSelector(
-            self.view._data_view.ax,
-            self._on_rectangle_selected,
-            useblit=False,  # rectangle persists on button release
-            button=[1],
-            minspanx=5,
-            minspany=5,
-            spancoords='pixels',
-            interactive=True,
-            ignore_event_outside=True,
-            drag_from_anywhere=True))
+        selector_kwargs = {"useblit": False,  # rectangle persists on button release
+                           "button": [1],
+                           "minspanx": 5,
+                           "minspany": 5,
+                           "spancoords": "pixels",
+                           "interactive": True}
+        if LooseVersion(matplotlib.__version__) >= LooseVersion("3.5.0"):
+            selector_kwargs["drag_from_anywhere"] = True
+            selector_kwargs["ignore_event_outside"] = True
+
+        self._selectors.append(RectangleSelector(self.view._data_view.ax, self._on_rectangle_selected,
+                                                 **selector_kwargs))
 
         self._drawing_region = True
 

--- a/qt/python/mantidqt/mantidqt/widgets/regionselector/test/test_regionselector_presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/regionselector/test/test_regionselector_presenter.py
@@ -87,20 +87,12 @@ class RegionSelectorTest(unittest.TestCase):
         self.assertTrue(region_selector._selectors[1].active)
 
     def test_get_region(self):
-        x1, x2, x3, x4, y1, y2, y3, y4 = 1.0, 2.0, 5.0, 6.0, 3.0, 4.0, 7.0, 8.0
-
-        selector_one = Mock()
-        selector_one.extents = [x1, x2, y1, y2]
-        selector_two = Mock()
-        selector_two.extents = [x3, x4, y3, y4]
-
-        region_selector = RegionSelector(ws=Mock(), view=Mock())
-        region_selector._selectors.append(selector_one)
-        region_selector._selectors.append(selector_two)
+        region_selector, selector_one, selector_two = self._mock_selectors()
 
         region = region_selector.get_region()
         self.assertEqual(4, len(region))
-        self.assertEqual([y1, y2, y3, y4], region)
+        self.assertEqual([selector_one.extents[2], selector_one.extents[3], selector_two.extents[2],
+                          selector_two.extents[3]], region)
 
     def test_canvas_clicked_does_nothing_when_redrawing_region(self):
         region_selector, selector_one, selector_two = self._mock_selectors()

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/IPreviewView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/IPreviewView.h
@@ -54,6 +54,7 @@ public:
   virtual void setInstViewEditMode() = 0;
   virtual void setInstViewSelectRectMode() = 0;
   virtual void setInstViewToolbarEnabled(bool enable) = 0;
+  virtual void setRegionSelectorToolbarEnabled(bool enable) = 0;
   virtual void setAngle(double angle) = 0;
   // Region selector toolbar
   // TODO implement edit ROI button

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/IPreviewView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/IPreviewView.h
@@ -31,9 +31,7 @@ public:
   virtual void notifyRegionSelectorExportAdsRequested() = 0;
   virtual void notifyLinePlotExportAdsRequested() = 0;
 
-  // TODO implement edit ROI button and ROI-changed callback
-  // virtual void notifyEditROIRequested() = 0;
-  // virtual void notifyROIChanged() = 0;
+  virtual void notifyEditROIModeRequested() = 0;
   virtual void notifyRectangularROIModeRequested() = 0;
 };
 
@@ -57,10 +55,8 @@ public:
   virtual void setRegionSelectorToolbarEnabled(bool enable) = 0;
   virtual void setAngle(double angle) = 0;
   // Region selector toolbar
-  // TODO implement edit ROI button
-  // virtual void setEditROIState(bool on) = 0;
-  // virtual void activateEditROIMode() = 0;
-  virtual void setRectangularROIState(bool on) = 0;
+  virtual void setEditROIState(bool state) = 0;
+  virtual void setAddRectangularROIState(bool state) = 0;
 
   virtual std::vector<size_t> getSelectedDetectors() const = 0;
 

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/IPreviewView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/IPreviewView.h
@@ -56,7 +56,7 @@ public:
   virtual void setAngle(double angle) = 0;
   // Region selector toolbar
   virtual void setEditROIState(bool state) = 0;
-  virtual void setAddRectangularROIState(bool state) = 0;
+  virtual void setRectangularROIState(bool state) = 0;
 
   virtual std::vector<size_t> getSelectedDetectors() const = 0;
 

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewModel.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewModel.cpp
@@ -106,14 +106,20 @@ ProcessingInstructions PreviewModel::getProcessingInstructions() const {
 
 void PreviewModel::setSelectedRegion(Selection const &selection) {
   // TODO We will need to allow for more complex selections, but for now the selection just consists two y indices
-  if (selection.size() != 2) {
-    throw std::runtime_error("Program error: unexpected selection size; expected 2, got " +
+  if (selection.size() % 2 != 0) {
+    throw std::runtime_error("Program error: unexpected selection size; must be multiple of 2; got " +
                              std::to_string(selection.size()));
   }
   // For now we just support a y axis of spectrum number so round to the nearest integer
-  auto const start = static_cast<int>(std::round(selection[0]));
-  auto const end = static_cast<int>(std::round(selection[1]));
-  auto processingInstructions = ProcessingInstructions(std::to_string(start) + "-" + std::to_string(end));
+  auto processingInstructions = ProcessingInstructions{};
+  for (size_t i = 0; i < selection.size(); i += 2) {
+    auto const start = static_cast<int>(std::round(selection[i]));
+    auto const end = static_cast<int>(std::round(selection[i + 1]));
+    if (!processingInstructions.empty()) {
+      processingInstructions += ",";
+    }
+    processingInstructions += std::to_string(start) + "-" + std::to_string(end);
+  }
   m_runDetails->setProcessingInstructions(std::move(processingInstructions));
 }
 

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewModel.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewModel.cpp
@@ -105,7 +105,8 @@ ProcessingInstructions PreviewModel::getProcessingInstructions() const {
 }
 
 void PreviewModel::setSelectedRegion(Selection const &selection) {
-  // TODO We will need to allow for more complex selections, but for now the selection just consists two y indices
+  // TODO We will need to allow for more complex selections, but for now the selection just consists two y indices per
+  // TODO rectangle selection
   if (selection.size() % 2 != 0) {
     throw std::runtime_error("Program error: unexpected selection size; must be multiple of 2; got " +
                              std::to_string(selection.size()));

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.cpp
@@ -142,12 +142,21 @@ void PreviewPresenter::notifyInstViewShapeChanged() {
 
 void PreviewPresenter::notifyRegionSelectorExportAdsRequested() { m_model->exportSummedWsToAds(); }
 
+void PreviewPresenter::notifyEditROIModeRequested() {
+  m_view->setAddRectangularROIState(false);
+  m_view->setEditROIState(true);
+}
+
 void PreviewPresenter::notifyRectangularROIModeRequested() {
-  m_view->setRectangularROIState(true);
+  m_view->setEditROIState(false);
+  m_view->setAddRectangularROIState(true);
   m_regionSelector->addRectangularRegion();
 }
 
 void PreviewPresenter::notifyRegionChanged() {
+  m_view->setAddRectangularROIState(false);
+  m_view->setEditROIState(true);
+
   // Set the selection from the view
   auto roi = m_regionSelector->getRegion();
   m_model->setSelectedRegion(roi);

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.cpp
@@ -143,18 +143,19 @@ void PreviewPresenter::notifyInstViewShapeChanged() {
 void PreviewPresenter::notifyRegionSelectorExportAdsRequested() { m_model->exportSummedWsToAds(); }
 
 void PreviewPresenter::notifyEditROIModeRequested() {
-  m_view->setAddRectangularROIState(false);
+  m_view->setRectangularROIState(false);
   m_view->setEditROIState(true);
+  m_regionSelector->cancelDrawingRegion();
 }
 
 void PreviewPresenter::notifyRectangularROIModeRequested() {
   m_view->setEditROIState(false);
-  m_view->setAddRectangularROIState(true);
+  m_view->setRectangularROIState(true);
   m_regionSelector->addRectangularRegion();
 }
 
 void PreviewPresenter::notifyRegionChanged() {
-  m_view->setAddRectangularROIState(false);
+  m_view->setRectangularROIState(false);
   m_view->setEditROIState(true);
 
   // Set the selection from the view

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.cpp
@@ -47,6 +47,7 @@ PreviewPresenter::PreviewPresenter(Dependencies dependencies)
   m_jobManager->subscribe(this);
 
   m_view->setInstViewToolbarEnabled(false);
+  m_view->setRegionSelectorToolbarEnabled(false);
 
   m_plotPresenter->setScaleLog(AxisID::YLeft);
   m_plotPresenter->setScaleLog(AxisID::XBottom);
@@ -98,6 +99,7 @@ void PreviewPresenter::notifyLoadWorkspaceCompleted() {
 
 void PreviewPresenter::notifySumBanksCompleted() {
   plotRegionSelector();
+  m_view->setRegionSelectorToolbarEnabled(true);
   // Perform reduction to update the next plot, if possible
   runReduction();
 }

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.h
@@ -64,6 +64,7 @@ public:
   void notifyRegionSelectorExportAdsRequested() override;
   void notifyLinePlotExportAdsRequested() override;
 
+  void notifyEditROIModeRequested() override;
   void notifyRectangularROIModeRequested() override;
 
   // JobManagerSubscriber overrides

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewWidget.ui
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewWidget.ui
@@ -170,6 +170,16 @@
            </widget>
           </item>
           <item>
+           <widget class="QToolButton" name="rs_edit_button">
+            <property name="toolTip">
+             <string>Edit a rectangular region of interest</string>
+            </property>
+            <property name="text">
+             <string>Edit ROI</string>
+            </property>
+           </widget>
+          </item>
+          <item>
            <widget class="QToolButton" name="rs_rect_select_button">
             <property name="toolTip">
              <string>Select a rectangular region of interest</string>
@@ -245,13 +255,6 @@
    </item>
   </layout>
  </widget>
- <tabstops>
-  <tabstop>workspace_line_edit</tabstop>
-  <tabstop>rs_ads_export_button</tabstop>
-  <tabstop>lp_ads_export_button</tabstop>
-  <tabstop>tableWidget_2</tabstop>
-  <tabstop>pushButton_3</tabstop>
- </tabstops>
  <customwidgets>
   <customwidget>
    <class>MantidQt::MantidWidgets::QtPlotView</class>
@@ -260,6 +263,13 @@
    <container>1</container>
   </customwidget>
  </customwidgets>
+ <tabstops>
+  <tabstop>workspace_line_edit</tabstop>
+  <tabstop>rs_ads_export_button</tabstop>
+  <tabstop>lp_ads_export_button</tabstop>
+  <tabstop>tableWidget_2</tabstop>
+  <tabstop>pushButton_3</tabstop>
+ </tabstops>
  <resources>
   <include location="../../../../icons/resources/icons.qrc"/>
  </resources>

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/QtPreviewView.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/QtPreviewView.cpp
@@ -120,7 +120,7 @@ void QtPreviewView::setAngle(double angle) { m_ui.angle_spin_box->setValue(angle
 
 void QtPreviewView::setEditROIState(bool state) { m_ui.rs_edit_button->setDown(state); }
 
-void QtPreviewView::setAddRectangularROIState(bool state) { m_ui.rs_rect_select_button->setDown(state); }
+void QtPreviewView::setRectangularROIState(bool state) { m_ui.rs_rect_select_button->setDown(state); }
 
 std::vector<size_t> QtPreviewView::getSelectedDetectors() const {
   std::vector<size_t> result;

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/QtPreviewView.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/QtPreviewView.cpp
@@ -48,7 +48,8 @@ void QtPreviewView::connectSignals() const {
   connect(m_ui.iv_rect_select_button, SIGNAL(clicked()), this, SLOT(onInstViewSelectRectClicked()));
   // Region selector toolbar
   connect(m_ui.rs_ads_export_button, SIGNAL(clicked()), this, SLOT(onRegionSelectorExportToAdsClicked()));
-  connect(m_ui.rs_rect_select_button, SIGNAL(clicked()), this, SLOT(onSelectRectangularROIClicked()));
+  connect(m_ui.rs_edit_button, SIGNAL(clicked()), this, SLOT(onEditROIClicked()));
+  connect(m_ui.rs_rect_select_button, SIGNAL(clicked()), this, SLOT(onAddRectangularROIClicked()));
   // Line plot toolbar
   connect(m_ui.lp_ads_export_button, SIGNAL(clicked()), this, SLOT(onLinePlotExportToAdsClicked()));
 }
@@ -62,7 +63,9 @@ void QtPreviewView::onInstViewShapeChanged() const { m_notifyee->notifyInstViewS
 
 void QtPreviewView::onRegionSelectorExportToAdsClicked() const { m_notifyee->notifyRegionSelectorExportAdsRequested(); }
 
-void QtPreviewView::onSelectRectangularROIClicked() const { m_notifyee->notifyRectangularROIModeRequested(); }
+void QtPreviewView::onEditROIClicked() const { m_notifyee->notifyEditROIModeRequested(); }
+
+void QtPreviewView::onAddRectangularROIClicked() const { m_notifyee->notifyRectangularROIModeRequested(); }
 
 void QtPreviewView::onLinePlotExportToAdsClicked() const { m_notifyee->notifyLinePlotExportAdsRequested(); }
 
@@ -115,7 +118,9 @@ void QtPreviewView::setRegionSelectorToolbarEnabled(bool enable) {
 
 void QtPreviewView::setAngle(double angle) { m_ui.angle_spin_box->setValue(angle); }
 
-void QtPreviewView::setRectangularROIState(bool enable) { m_ui.rs_rect_select_button->setEnabled(enable); }
+void QtPreviewView::setEditROIState(bool state) { m_ui.rs_edit_button->setDown(state); }
+
+void QtPreviewView::setAddRectangularROIState(bool state) { m_ui.rs_rect_select_button->setDown(state); }
 
 std::vector<size_t> QtPreviewView::getSelectedDetectors() const {
   std::vector<size_t> result;

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/QtPreviewView.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/QtPreviewView.cpp
@@ -32,6 +32,7 @@ void QtPreviewView::loadToolbarIcons() {
   m_ui.iv_edit_button->setIcon(MantidQt::Icons::getIcon("mdi.pencil", "black", 1.3));
   m_ui.iv_rect_select_button->setIcon(MantidQt::Icons::getIcon("mdi.selection", "black", 1.3));
   m_ui.rs_ads_export_button->setIcon(MantidQt::Icons::getIcon("mdi.file-export", "black", 1.3));
+  m_ui.rs_edit_button->setIcon(MantidQt::Icons::getIcon("mdi.pencil", "black", 1.3));
   m_ui.rs_rect_select_button->setIcon(MantidQt::Icons::getIcon("mdi.selection", "black", 1.3));
   m_ui.lp_ads_export_button->setIcon(MantidQt::Icons::getIcon("mdi.file-export", "black", 1.3));
 }

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/QtPreviewView.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/QtPreviewView.cpp
@@ -107,6 +107,12 @@ void QtPreviewView::setInstViewToolbarEnabled(bool enable) {
   m_ui.iv_rect_select_button->setEnabled(enable);
 }
 
+void QtPreviewView::setRegionSelectorToolbarEnabled(bool enable) {
+  m_ui.rs_ads_export_button->setEnabled(enable);
+  m_ui.rs_edit_button->setEnabled(enable);
+  m_ui.rs_rect_select_button->setEnabled(enable);
+}
+
 void QtPreviewView::setAngle(double angle) { m_ui.angle_spin_box->setValue(angle); }
 
 void QtPreviewView::setRectangularROIState(bool enable) { m_ui.rs_rect_select_button->setEnabled(enable); }

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/QtPreviewView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/QtPreviewView.h
@@ -52,7 +52,8 @@ public:
   void setRegionSelectorToolbarEnabled(bool enable) override;
   void setAngle(double angle) override;
   // Region selector toolbar
-  void setRectangularROIState(bool enable) override;
+  void setEditROIState(bool state) override;
+  void setAddRectangularROIState(bool state) override;
 
   std::vector<size_t> getSelectedDetectors() const override;
 
@@ -75,6 +76,7 @@ private slots:
   void onInstViewShapeChanged() const;
   void onRegionSelectorExportToAdsClicked() const;
   void onLinePlotExportToAdsClicked() const;
-  void onSelectRectangularROIClicked() const;
+  void onEditROIClicked() const;
+  void onAddRectangularROIClicked() const;
 };
 } // namespace MantidQt::CustomInterfaces::ISISReflectometry

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/QtPreviewView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/QtPreviewView.h
@@ -53,7 +53,7 @@ public:
   void setAngle(double angle) override;
   // Region selector toolbar
   void setEditROIState(bool state) override;
-  void setAddRectangularROIState(bool state) override;
+  void setRectangularROIState(bool state) override;
 
   std::vector<size_t> getSelectedDetectors() const override;
 

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/QtPreviewView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/QtPreviewView.h
@@ -49,6 +49,7 @@ public:
   void setInstViewEditMode() override;
   void setInstViewSelectRectMode() override;
   void setInstViewToolbarEnabled(bool enable) override;
+  void setRegionSelectorToolbarEnabled(bool enable) override;
   void setAngle(double angle) override;
   // Region selector toolbar
   void setRectangularROIState(bool enable) override;

--- a/qt/scientific_interfaces/ISISReflectometry/test/Preview/MockPreviewView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Preview/MockPreviewView.h
@@ -28,6 +28,7 @@ public:
   MOCK_METHOD(void, setInstViewSelectRectState, (bool), (override));
   MOCK_METHOD(void, setInstViewSelectRectMode, (), (override));
   MOCK_METHOD(void, setInstViewToolbarEnabled, (bool), (override));
+  MOCK_METHOD(void, setRegionSelectorToolbarEnabled, (bool), (override));
   MOCK_METHOD(void, setInstViewZoomMode, (), (override));
   MOCK_METHOD(void, setInstViewEditMode, (), (override));
   MOCK_METHOD(void, setRectangularROIState, (bool), (override));

--- a/qt/scientific_interfaces/ISISReflectometry/test/Preview/MockPreviewView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Preview/MockPreviewView.h
@@ -32,6 +32,7 @@ public:
   MOCK_METHOD(void, setInstViewZoomMode, (), (override));
   MOCK_METHOD(void, setInstViewEditMode, (), (override));
   MOCK_METHOD(void, setRectangularROIState, (bool), (override));
+  MOCK_METHOD(void, setEditROIState, (bool), (override));
   MOCK_METHOD(void, setAngle, (double), (override));
   MOCK_METHOD(std::vector<size_t>, getSelectedDetectors, (), (const, override));
   MOCK_METHOD(QLayout *, getRegionSelectorLayout, (), (const, override));

--- a/qt/scientific_interfaces/ISISReflectometry/test/Preview/PreviewPresenterTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Preview/PreviewPresenterTest.h
@@ -222,16 +222,30 @@ public:
     presenter.notifySumBanksCompleted();
   }
 
-  void test_rectangular_roi_requested_updates_view() {
+  void test_rectangular_roi_requested() {
     auto mockView = makeView();
     auto mockRegionSelector_uptr = makeRegionSelector();
     auto mockRegionSelector = mockRegionSelector_uptr.get();
 
-    expectActivateRectangularROIMode(*mockView, *mockRegionSelector);
+    expectRectangularROIMode(*mockView, *mockRegionSelector);
+    EXPECT_CALL(*mockRegionSelector, addRectangularRegion()).Times(1);
     auto presenter = PreviewPresenter(packDeps(mockView.get(), makeModel(), makeJobManager(), makeInstViewModel(),
                                                std::move(mockRegionSelector_uptr)));
 
     presenter.notifyRectangularROIModeRequested();
+  }
+
+  void test_edit_roi_mode_requested() {
+    auto mockView = makeView();
+    auto mockRegionSelector_uptr = makeRegionSelector();
+    auto mockRegionSelector = mockRegionSelector_uptr.get();
+
+    expectEditROIMode(*mockView, *mockRegionSelector);
+    EXPECT_CALL(*mockRegionSelector, cancelDrawingRegion()).Times(1);
+    auto presenter = PreviewPresenter(packDeps(mockView.get(), makeModel(), makeJobManager(), makeInstViewModel(),
+                                               std::move(mockRegionSelector_uptr)));
+
+    presenter.notifyEditROIModeRequested();
   }
 
   void test_notify_region_changed_starts_reduction() {
@@ -241,8 +255,7 @@ public:
     auto mockRegionSelector_uptr = makeRegionSelector();
     auto mockRegionSelector = mockRegionSelector_uptr.get();
 
-    // TODO reset edit mode after region is selected
-    // expectRegionSelectorSetToEditMode(*mockView);
+    expectEditROIMode(*mockView, *mockRegionSelector);
     expectReduceAsyncCalledOnSelectedRegion(*mockView, *mockModel, *mockJobManager, *mockRegionSelector);
 
     auto presenter = PreviewPresenter(packDeps(mockView.get(), std::move(mockModel), std::move(mockJobManager),
@@ -393,11 +406,14 @@ private:
     EXPECT_CALL(mockView, setInstViewSelectRectMode()).Times(1);
   }
 
-  void expectActivateRectangularROIMode(MockPreviewView &mockView, MockRegionSelector &mockRegionSelector) {
-    // TODO Disable edit button when implemented
-    // EXPECT_CALL(mockView, setEditROIState(Eq(false))).Times(1);
+  void expectRectangularROIMode(MockPreviewView &mockView, MockRegionSelector &mockRegionSelector) {
+    EXPECT_CALL(mockView, setEditROIState(Eq(false))).Times(1);
     EXPECT_CALL(mockView, setRectangularROIState(Eq(true))).Times(1);
-    EXPECT_CALL(mockRegionSelector, addRectangularRegion()).Times(1);
+  }
+
+  void expectEditROIMode(MockPreviewView &mockView, MockRegionSelector &mockRegionSelector) {
+    EXPECT_CALL(mockView, setEditROIState(Eq(true))).Times(1);
+    EXPECT_CALL(mockView, setRectangularROIState(Eq(false))).Times(1);
   }
 
   void expectReduceAsyncCalledOnSelectedRegion(MockPreviewView &mockView, MockPreviewModel &mockModel,

--- a/qt/scientific_interfaces/ISISReflectometry/test/Preview/PreviewPresenterTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Preview/PreviewPresenterTest.h
@@ -212,8 +212,12 @@ public:
     auto ws = WorkspaceCreationHelper::create2DWorkspace(1, 1);
     EXPECT_CALL(*mockModel, getSummedWs).Times(1).WillOnce(Return(ws));
     EXPECT_CALL(*mockRegionSelector, updateWorkspace(Eq(ws))).Times(1);
+    expectRegionSelectorToolbarEnabled(*mockView, false);
+
     auto presenter = PreviewPresenter(packDeps(mockView.get(), std::move(mockModel), makeJobManager(),
                                                makeInstViewModel(), std::move(mockRegionSelector_uptr)));
+
+    expectRegionSelectorToolbarEnabled(*mockView, true);
 
     presenter.notifySumBanksCompleted();
   }
@@ -362,6 +366,10 @@ private:
 
   void expectInstViewToolbarEnabled(MockPreviewView &mockView) {
     EXPECT_CALL(mockView, setInstViewToolbarEnabled(Eq(true))).Times(1);
+  }
+
+  void expectRegionSelectorToolbarEnabled(MockPreviewView &mockView, bool enable) {
+    EXPECT_CALL(mockView, setRegionSelectorToolbarEnabled(Eq(enable))).Times(1);
   }
 
   void expectInstViewSetToZoomMode(MockPreviewView &mockView) {

--- a/qt/scientific_interfaces/ISISReflectometry/test/Preview/PreviewPresenterTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Preview/PreviewPresenterTest.h
@@ -227,7 +227,7 @@ public:
     auto mockRegionSelector_uptr = makeRegionSelector();
     auto mockRegionSelector = mockRegionSelector_uptr.get();
 
-    expectRectangularROIMode(*mockView, *mockRegionSelector);
+    expectRectangularROIMode(*mockView);
     EXPECT_CALL(*mockRegionSelector, addRectangularRegion()).Times(1);
     auto presenter = PreviewPresenter(packDeps(mockView.get(), makeModel(), makeJobManager(), makeInstViewModel(),
                                                std::move(mockRegionSelector_uptr)));
@@ -240,7 +240,7 @@ public:
     auto mockRegionSelector_uptr = makeRegionSelector();
     auto mockRegionSelector = mockRegionSelector_uptr.get();
 
-    expectEditROIMode(*mockView, *mockRegionSelector);
+    expectEditROIMode(*mockView);
     EXPECT_CALL(*mockRegionSelector, cancelDrawingRegion()).Times(1);
     auto presenter = PreviewPresenter(packDeps(mockView.get(), makeModel(), makeJobManager(), makeInstViewModel(),
                                                std::move(mockRegionSelector_uptr)));
@@ -255,7 +255,7 @@ public:
     auto mockRegionSelector_uptr = makeRegionSelector();
     auto mockRegionSelector = mockRegionSelector_uptr.get();
 
-    expectEditROIMode(*mockView, *mockRegionSelector);
+    expectEditROIMode(*mockView);
     expectReduceAsyncCalledOnSelectedRegion(*mockView, *mockModel, *mockJobManager, *mockRegionSelector);
 
     auto presenter = PreviewPresenter(packDeps(mockView.get(), std::move(mockModel), std::move(mockJobManager),
@@ -406,12 +406,12 @@ private:
     EXPECT_CALL(mockView, setInstViewSelectRectMode()).Times(1);
   }
 
-  void expectRectangularROIMode(MockPreviewView &mockView, MockRegionSelector &mockRegionSelector) {
+  void expectRectangularROIMode(MockPreviewView &mockView) {
     EXPECT_CALL(mockView, setEditROIState(Eq(false))).Times(1);
     EXPECT_CALL(mockView, setRectangularROIState(Eq(true))).Times(1);
   }
 
-  void expectEditROIMode(MockPreviewView &mockView, MockRegionSelector &mockRegionSelector) {
+  void expectEditROIMode(MockPreviewView &mockView) {
     EXPECT_CALL(mockView, setEditROIState(Eq(true))).Times(1);
     EXPECT_CALL(mockView, setRectangularROIState(Eq(false))).Times(1);
   }

--- a/qt/widgets/regionselector/inc/MantidQtWidgets/RegionSelector/IRegionSelector.h
+++ b/qt/widgets/regionselector/inc/MantidQtWidgets/RegionSelector/IRegionSelector.h
@@ -23,5 +23,6 @@ public:
   virtual void updateWorkspace(Mantid::API::Workspace_sptr const &workspace) = 0;
   virtual void addRectangularRegion() = 0;
   virtual Selection getRegion() = 0;
+  virtual void cancelDrawingRegion() = 0;
 };
 } // namespace MantidQt::Widgets

--- a/qt/widgets/regionselector/inc/MantidQtWidgets/RegionSelector/RegionSelector.h
+++ b/qt/widgets/regionselector/inc/MantidQtWidgets/RegionSelector/RegionSelector.h
@@ -27,6 +27,7 @@ public:
   void updateWorkspace(Mantid::API::Workspace_sptr const &workspace) override;
   void addRectangularRegion() override;
   Selection getRegion() override;
+  void cancelDrawingRegion() override;
 
 private:
   Common::Python::Object getView() const;

--- a/qt/widgets/regionselector/src/RegionSelector.cpp
+++ b/qt/widgets/regionselector/src/RegionSelector.cpp
@@ -85,6 +85,11 @@ void RegionSelector::addRectangularRegion() {
   pyobj().attr("add_rectangular_region")();
 }
 
+void RegionSelector::cancelDrawingRegion() {
+  GlobalInterpreterLock lock;
+  pyobj().attr("cancel_drawing_region")();
+}
+
 auto RegionSelector::getRegion() -> Selection {
   GlobalInterpreterLock lock;
   auto pyValues = pyobj().attr("get_region")();

--- a/qt/widgets/regionselector/test/MockRegionSelector.h
+++ b/qt/widgets/regionselector/test/MockRegionSelector.h
@@ -16,5 +16,6 @@ public:
   MOCK_METHOD(void, updateWorkspace, (Mantid::API::Workspace_sptr const &workspace), (override));
   MOCK_METHOD(void, addRectangularRegion, (), (override));
   MOCK_METHOD(Selection, getRegion, (), (override));
+  MOCK_METHOD(void, cancelDrawingRegion, (), (override));
 };
 } // namespace MantidQt::Widgets


### PR DESCRIPTION
**Description of work.**
This PR makes it possible to edit multiple different rectangle ROI's when the toolbar Edit button is selected. It also connects up the toolbar to give a visual indication for which tool you have selected.

**To test:**
1. Open ISIS Reflectometry interface
2. Load `INTER45455_inst`, and change angle to 1.00
3. Mess around with the toolbar and try edit/draw regions of interests. Make sure the behaviour is the same as seen on the inst view.

Refs #34174

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
