### PR TITLE
Validate Sample and Corrections provided in ApplyAbsorptionCorrections

### DIFF
--- a/docs/source/release/v6.5.0/Indirect/Bugfixes/34117.rst
+++ b/docs/source/release/v6.5.0/Indirect/Bugfixes/34117.rst
@@ -1,1 +1,2 @@
 - Fixed a bug where clicking 'Run' on the :ref:`Apply Absorption Corrections Tab<indirect_apply_absorp_correct>` in the :ref:`Corrections GUI<interface-indirect-corrections>` with no Sample or Corrections would close mantid.
+- Fixed a bug where if the Corrections Workspace name entered on the :ref:`Apply Absorption Corrections Tab<indirect_apply_absorp_correct>` does not match an exisiting workspace Mantid would close.

--- a/docs/source/release/v6.5.0/Indirect/Bugfixes/34117.rst
+++ b/docs/source/release/v6.5.0/Indirect/Bugfixes/34117.rst
@@ -1,0 +1,1 @@
+- Fixed a bug where clicking 'Run' on the :ref:`Apply Absorption Corrections Tab<indirect_apply_absorp_correct>` in the :ref:`Corrections GUI<interface-indirect-corrections>` with no Sample or Corrections would close mantid.

--- a/qt/scientific_interfaces/Indirect/ApplyAbsorptionCorrections.cpp
+++ b/qt/scientific_interfaces/Indirect/ApplyAbsorptionCorrections.cpp
@@ -440,17 +440,20 @@ bool ApplyAbsorptionCorrections::validate() {
 
     // Check sample has the same number of Histograms as each of the workspaces in the corrections group
     m_correctionsGroupName = m_uiForm.dsCorrections->getCurrentDataName().toStdString();
-    m_ppCorrectionsGp = getADSWorkspace<WorkspaceGroup>(m_correctionsGroupName);
+    if (AnalysisDataService::Instance().doesExist(m_correctionsGroupName)) {
+      m_ppCorrectionsGp = getADSWorkspace<WorkspaceGroup>(m_correctionsGroupName);
+      for (std::size_t i = 0; i < m_ppCorrectionsGp->size(); i++) {
+        MatrixWorkspace_sptr factorWs = std::dynamic_pointer_cast<MatrixWorkspace>(m_ppCorrectionsGp->getItem(i));
 
-    for (std::size_t i = 0; i < m_ppCorrectionsGp->size(); i++) {
-      MatrixWorkspace_sptr factorWs = std::dynamic_pointer_cast<MatrixWorkspace>(m_ppCorrectionsGp->getItem(i));
+        const size_t sampleHist = m_ppSampleWS->getNumberHistograms();
+        const size_t containerHist = factorWs->getNumberHistograms();
 
-      const size_t sampleHist = m_ppSampleWS->getNumberHistograms();
-      const size_t containerHist = factorWs->getNumberHistograms();
-
-      if (sampleHist != containerHist) {
-        uiv.addErrorMessage(" Sample and Container do not have a matching number of Histograms.");
+        if (sampleHist != containerHist) {
+          uiv.addErrorMessage(" Sample and Container do not have a matching number of Histograms.");
+        }
       }
+    } else {
+      uiv.addErrorMessage("Please check the Corrections Workspace that has been selected.");
     }
   }
 

--- a/qt/scientific_interfaces/Indirect/ApplyAbsorptionCorrections.cpp
+++ b/qt/scientific_interfaces/Indirect/ApplyAbsorptionCorrections.cpp
@@ -15,6 +15,7 @@
 #include "MantidAPI/WorkspaceGroup.h"
 #include "MantidQtWidgets/Common/AlgorithmRuntimeProps.h"
 #include "MantidQtWidgets/Common/SignalBlocker.h"
+#include "MantidQtWidgets/Common/UserInputValidator.h"
 
 #include <QStringList>
 #include <utility>
@@ -422,30 +423,37 @@ void ApplyAbsorptionCorrections::postProcessComplete(bool error) {
 bool ApplyAbsorptionCorrections::validate() {
   UserInputValidator uiv;
 
-  // Validate the sample workspace
-  validateDataIsOneOf(uiv, m_uiForm.dsSample, "Sample", DataType::Red, {DataType::Sqw});
+  // Check input not empty
+  uiv.checkDataSelectorIsValid("Sample", m_uiForm.dsSample);
+  uiv.checkDataSelectorIsValid("Corrections", m_uiForm.dsCorrections);
 
-  // Validate the container workspace
-  if (m_uiForm.ckUseCan->isChecked())
-    validateDataIsOneOf(uiv, m_uiForm.dsContainer, "Container", DataType::Red, {DataType::Sqw});
+  if (uiv.isAllInputValid()) {
+    // Validate the sample workspace
+    validateDataIsOneOf(uiv, m_uiForm.dsSample, "Sample", DataType::Red, {DataType::Sqw});
 
-  // Validate the corrections workspace
-  validateDataIsOfType(uiv, m_uiForm.dsCorrections, "Corrections", DataType::Corrections);
+    // Validate the container workspace
+    if (m_uiForm.ckUseCan->isChecked())
+      validateDataIsOneOf(uiv, m_uiForm.dsContainer, "Container", DataType::Red, {DataType::Sqw});
 
-  // Check sample has the same number of Histograms as each of the workspaces in the corrections group
-  m_correctionsGroupName = m_uiForm.dsCorrections->getCurrentDataName().toStdString();
-  m_ppCorrectionsGp = getADSWorkspace<WorkspaceGroup>(m_correctionsGroupName);
+    // Validate the corrections workspace
+    validateDataIsOfType(uiv, m_uiForm.dsCorrections, "Corrections", DataType::Corrections);
 
-  for (std::size_t i = 0; i < m_ppCorrectionsGp->size(); i++) {
-    MatrixWorkspace_sptr factorWs = std::dynamic_pointer_cast<MatrixWorkspace>(m_ppCorrectionsGp->getItem(i));
+    // Check sample has the same number of Histograms as each of the workspaces in the corrections group
+    m_correctionsGroupName = m_uiForm.dsCorrections->getCurrentDataName().toStdString();
+    m_ppCorrectionsGp = getADSWorkspace<WorkspaceGroup>(m_correctionsGroupName);
 
-    const size_t sampleHist = m_ppSampleWS->getNumberHistograms();
-    const size_t containerHist = factorWs->getNumberHistograms();
+    for (std::size_t i = 0; i < m_ppCorrectionsGp->size(); i++) {
+      MatrixWorkspace_sptr factorWs = std::dynamic_pointer_cast<MatrixWorkspace>(m_ppCorrectionsGp->getItem(i));
 
-    if (sampleHist != containerHist) {
-      uiv.addErrorMessage(" Sample and Container do not have a matching number of Histograms.");
+      const size_t sampleHist = m_ppSampleWS->getNumberHistograms();
+      const size_t containerHist = factorWs->getNumberHistograms();
+
+      if (sampleHist != containerHist) {
+        uiv.addErrorMessage(" Sample and Container do not have a matching number of Histograms.");
+      }
     }
   }
+
   // Show errors if there are any
   if (!uiv.isAllInputValid())
     emit showMessageBox(uiv.generateErrorMessage());


### PR DESCRIPTION
**Description of work.**
When testing the ApplyAbsorptionCorrections tab during smoke testing Mantid would close if both Sample and Corrections were not provided. Looking at the other tabs there is validation in place to prevent 'Run' from working and provides the user with an explanation if nothing has been uploaded. This PR provides validation for the Apply Absorption Corrections tab in line with the other Indirect Corrections tabs.

**To test:**
1. Go to `Indirection->Corrections` GUI
2. Select the `Apply Absorption Corrections` tab
3. Scroll down and press `Run`. You should get a pop up explaining no data was uploaded .

Fixes #34117

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
