### PR TITLE
Exclude banks from Total scattering merge banks

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/MatchAndMergeWorkspaces.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/MatchAndMergeWorkspaces.py
@@ -151,8 +151,12 @@ class MatchAndMergeWorkspaces(DataProcessorAlgorithm):
     def exclude_banks(flat_list, x_min, x_max):
         index_to_remove = []
         for i in range(x_min.size):
-            if x_min[i] and x_max[i] == -1:
-                index_to_remove.append(i)
+            if x_min[i] == -1:
+                if x_max[i] == -1:
+                    index_to_remove.append(i)
+                else:
+                    raise RuntimeError("The banks to be excluded in q_lims do not match. Please check "
+                                       "that -1 has been added in the correct place on both lists.")
         revised_wslist = np.delete(flat_list, index_to_remove)
         x_min = np.delete(x_min, index_to_remove)
         x_max = np.delete(x_max, index_to_remove)

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/MatchAndMergeWorkspaces.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/MatchAndMergeWorkspaces.py
@@ -77,6 +77,8 @@ class MatchAndMergeWorkspaces(DataProcessorAlgorithm):
         scale_bool = self.getProperty('CalculateScale').value
         offset_bool = self.getProperty('CalculateOffset').value
         flattened_list = self.unwrap_groups(ws_list)
+        # If some banks are to be excluded this line removes them from flattened_list, x_min and x_max
+        flattened_list, x_min, x_max = self.exclude_banks(flattened_list, x_min, x_max)
         largest_range_spectrum, rebin_param = self.get_common_bin_range_and_largest_spectra(flattened_list)
         CloneWorkspace(InputWorkspace=flattened_list[0], OutputWorkspace='ws_conjoined')
         Rebin(InputWorkspace='ws_conjoined', OutputWorkspace='ws_conjoined', Params=rebin_param)
@@ -144,6 +146,17 @@ class MatchAndMergeWorkspaces(DataProcessorAlgorithm):
         if x_min.any() == -np.inf or x_min.any() == np.inf:
             raise AttributeError("Limits contains an infinite value.")
         return x_min, x_max, bin_width
+
+    @staticmethod
+    def exclude_banks(flat_list, x_min, x_max):
+        index_to_remove = []
+        for i in range(x_min.size):
+            if x_min[i] and x_max[i] == -1:
+                index_to_remove.append(i)
+        revised_wslist = np.delete(flat_list, index_to_remove)
+        x_min = np.delete(x_min, index_to_remove)
+        x_max = np.delete(x_max, index_to_remove)
+        return revised_wslist, x_min, x_max
 
 
 # Register algorithm with Mantid

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/MatchAndMergeWorkspaces.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/MatchAndMergeWorkspaces.py
@@ -151,10 +151,10 @@ class MatchAndMergeWorkspaces(DataProcessorAlgorithm):
     def exclude_banks(flat_list, x_min, x_max):
         index_to_remove = []
         for i in range(x_min.size):
-            if x_min[i] == -1:
-                if x_max[i] == -1:
-                    index_to_remove.append(i)
-                else:
+            if x_min[i] == -1 and x_max[i] == -1:
+                index_to_remove.append(i)
+            else:
+                if x_min[i] == -1 or x_max[i] == -1:
                     raise RuntimeError("The banks to be excluded in q_lims do not match. Please check "
                                        "that -1 has been added in the correct place on both lists.")
         revised_wslist = np.delete(flat_list, index_to_remove)

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/MatchAndMergeWorkspaces.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/MatchAndMergeWorkspaces.py
@@ -160,6 +160,8 @@ class MatchAndMergeWorkspaces(DataProcessorAlgorithm):
         revised_wslist = np.delete(flat_list, index_to_remove)
         x_min = np.delete(x_min, index_to_remove)
         x_max = np.delete(x_max, index_to_remove)
+        if len(x_min) < 1 or len(x_max) < 1:
+            raise RuntimeError("You have excluded all banks. Merging requires at least one bank.")
         return revised_wslist, x_min, x_max
 
 

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/MatchAndMergeWorkspacesTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/MatchAndMergeWorkspacesTest.py
@@ -87,6 +87,11 @@ class MatchAndMergeWorkspacesTest(unittest.TestCase):
         x_max = np.array([0, 5, 10, 15, 20])
         self.assertRaises(ValueError, MatchAndMergeWorkspaces, InputWorkspaces='fake_group', XMin=x_min, XMax=x_max)
 
+    def test_excluding_banks_fails_with_wrong_input(self):
+        x_min = np.array([2, -1, 10, -1, 20])
+        x_max = np.array([10, 20, 30, -1, 45])
+        self.assertRaises(RuntimeError, MatchAndMergeWorkspaces, InputWorkspaces='ws_group', XMin=x_min, XMax=x_max)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/MatchAndMergeWorkspacesTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/MatchAndMergeWorkspacesTest.py
@@ -120,6 +120,10 @@ class MatchAndMergeWorkspacesTest(unittest.TestCase):
         x_max = np.array([10, 20, 30, -1, 45])
         self.assertRaises(RuntimeError, MatchAndMergeWorkspaces, InputWorkspaces='ws_group', XMin=x_min, XMax=x_max)
 
+        x_min = np.array([2, 5, 10, -1, 20])
+        x_max = np.array([10, -1, 30, -1, 45])
+        self.assertRaises(RuntimeError, MatchAndMergeWorkspaces, InputWorkspaces='ws_group', XMin=x_min, XMax=x_max)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/MatchAndMergeWorkspacesTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/MatchAndMergeWorkspacesTest.py
@@ -24,6 +24,19 @@ class MatchAndMergeWorkspacesTest(unittest.TestCase):
             ws_list.append(ws_name)
         GroupWorkspaces(InputWorkspaces=ws_list, OutputWorkspace='ws_group')
 
+    def create_larger_group(self):
+        ws_list = []
+        for i in range(5):
+            ws_name = 'ws_' + str(i + 1)
+            data_x = np.arange(i, (i + 1) * 10 + 0.1, 0.1)
+            data_y = np.arange(i, (i + 1) * 10, 0.1)
+            data_e = np.arange(i, (i + 1) * 10, 0.1)
+            new_ws = CreateWorkspace(OutputWorkspace=ws_name, DataX=data_x, DataY=data_y, DataE=data_e)
+            if i == 0:
+                new_ws *= 100
+            ws_list.append(new_ws)
+        GroupWorkspaces(InputWorkspaces=ws_list, OutputWorkspace='ws_group_large')
+
     def test_MatchAndMergeWorkspaces_executes(self):
         x_min = np.array([0, 5, 10, 15, 20])
         x_max = np.array([10, 20, 30, 40, 50])
@@ -86,6 +99,21 @@ class MatchAndMergeWorkspacesTest(unittest.TestCase):
         x_min = np.array([10, 20, 30, 40, 50])
         x_max = np.array([0, 5, 10, 15, 20])
         self.assertRaises(ValueError, MatchAndMergeWorkspaces, InputWorkspaces='fake_group', XMin=x_min, XMax=x_max)
+
+    def test_exclude_banks(self):
+        self.create_larger_group()
+
+        x_min = np.array([2, 5, 10, 15, 20])
+        x_max = np.array([10, 20, 30, 40, 45])
+        ws_group_large = AnalysisDataService.retrieve('ws_group_large')
+        ws_merged = MatchAndMergeWorkspaces(InputWorkspaces=ws_group_large, XMin=x_min, XMax=x_max)
+        self.assertEqual(ws_merged.getNumberHistograms(), 1)
+
+        x_min_ex = np.array([-1, 5, 10, 15, 20])
+        x_max_ex = np.array([-1, 20, 30, 40, 45])
+        ws_merged_ex = MatchAndMergeWorkspaces(InputWorkspaces=ws_group_large, XMin=x_min_ex, XMax=x_max_ex)
+        self.assertEqual(ws_merged_ex.getNumberHistograms(), 1)
+        self.assertNotEqual(ws_merged.dataX(0)[0], ws_merged_ex.dataX(0)[0])
 
     def test_excluding_banks_fails_with_wrong_input(self):
         x_min = np.array([2, -1, 10, -1, 20])

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/MatchAndMergeWorkspacesTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/MatchAndMergeWorkspacesTest.py
@@ -124,6 +124,11 @@ class MatchAndMergeWorkspacesTest(unittest.TestCase):
         x_max = np.array([10, -1, 30, -1, 45])
         self.assertRaises(RuntimeError, MatchAndMergeWorkspaces, InputWorkspaces='ws_group', XMin=x_min, XMax=x_max)
 
+    def test_excluding_all_banks_fails_with_wrong_input(self):
+        x_min = np.array([-1, -1, -1, -1, -1])
+        x_max = np.array([-1, -1, -1, -1, -1])
+        self.assertRaises(RuntimeError, MatchAndMergeWorkspaces, InputWorkspaces='ws_group', XMin=x_min, XMax=x_max)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/docs/source/release/v6.5.0/Diffraction/Powder/New_features/33830.rst
+++ b/docs/source/release/v6.5.0/Diffraction/Powder/New_features/33830.rst
@@ -1,0 +1,1 @@
+- It is now possible to exclude specific banks from the total scattering merge banks for Polaris using -1 in the q_lims. For more details see :ref:`create_total_scattering_pdf<create_total_scattering_pdf_polaris-isis-powder-ref>`.

--- a/docs/source/techniques/ISISPowder-Polaris-v1.rst
+++ b/docs/source/techniques/ISISPowder-Polaris-v1.rst
@@ -189,8 +189,8 @@ The output PDF can be customized with the following parameters:
   `g(r)`, `RDF(r)` (defaults to `G(r)`).
 - By calling with `merge_banks=True` a PDF will be generated based on the weighted sum of the detector
   banks performed using supplied Q limits `q_lims=q_limits`, q_limits can be in the form of an array or
-  with shape (2, x) where x is the number of detectors, or a string containing the directory
-  of an appropriately formatted `.lim` file. To exclude any of the banks use -1 as the value for that detector in each list.
+  with shape (2, x) where x is the number of banks, or a string containing the directory
+  of an appropriately formatted `.lim` file. To exclude any of the banks use -1 as the value for that bank in each list.
   By default or specifically called with `merge_banks=False` a PDF will be generated for each bank within the focused_workspace.
 - By calling with `delta_q` which will calculate the PDF after rebinning the Q workspace to have bin width `delta_r`.
 - By calling with `delta_r` which will calculate the PDF with bin width of `delta_q`.

--- a/docs/source/techniques/ISISPowder-Polaris-v1.rst
+++ b/docs/source/techniques/ISISPowder-Polaris-v1.rst
@@ -190,8 +190,8 @@ The output PDF can be customized with the following parameters:
 - By calling with `merge_banks=True` a PDF will be generated based on the weighted sum of the detector
   banks performed using supplied Q limits `q_lims=q_limits`, q_limits can be in the form of an array or
   with shape (2, x) where x is the number of detectors, or a string containing the directory
-  of an appropriately formatted `.lim` file. By default or specifically called with `merge_banks=False`
-  a PDF will be generated for each bank within the focused_workspace.
+  of an appropriately formatted `.lim` file. To exclude any of the banks use -1 as the value for that detector in each list.
+  By default or specifically called with `merge_banks=False` a PDF will be generated for each bank within the focused_workspace.
 - By calling with `delta_q` which will calculate the PDF after rebinning the Q workspace to have bin width `delta_r`.
 - By calling with `delta_r` which will calculate the PDF with bin width of `delta_q`.
 - By calling with `lorch_filter` will calculate the PDF with a Lorth Filter if set to `True`
@@ -207,9 +207,18 @@ Example
 
 ..  code-block:: python
 
+  # Include all the banks
   polaris_example.create_total_scattering_pdf(run_number='12345',
                                               merge_banks=True,
                                               q_lims=[[2.5, 3, 4, 6, 7], [3.5, 5, 7, 11, 40]],
+                                              output_binning=[0,0.1,20],
+                                              pdf_type='G(r)',
+                                              freq_params=[1])
+
+  # Exclude the 2nd and 4th banks
+  polaris_example.create_total_scattering_pdf(run_number='12345',
+                                              merge_banks=True,
+                                              q_lims=[[2.5, -1, 4, -1, 7], [3.5, -1, 7, -1, 40]],
                                               output_binning=[0,0.1,20],
                                               pdf_type='G(r)',
                                               freq_params=[1])


### PR DESCRIPTION
**Description of work.**
Users are now able to exclude specific banks from the merge banks option in total scattering by setting x-min and x-max for that bank to -1. X is positive so this is a good way of denoting they need to be excluded.

This PR adds this functionality, including a check that the exclusion is in the same place on x-min and x-max. Documentation has been added (including an example) to show how this functionality works. Tests have been added too.

**To test:**
1. Unzip this zip file somewhere:
[POLARISPowderDiffractionFolderSmall.zip](https://github.com/mantidproject/mantid/files/9103459/POLARISPowderDiffractionFolderSmall.zip)

2. Update the paths in the file polaris_config_example.yaml so they match where you unzipped the file and also update config_file_path in the script below

3. Run the following script in workbench and check it completes.
```
# import mantid algorithms, numpy and matplotlib
from mantid.simpleapi import *
import matplotlib.pyplot as plt
import numpy as np

from isis_powder import polaris, SampleDetails

config_file_path = r"C:\mantid-development\POLARISPowderDiffraction\polaris_config_example.yaml"
polaris = polaris.Polaris(config_file=config_file_path, user_name="test", mode="PDF")

sample_details = SampleDetails(height=4.0, radius=0.2985, center=[0, 0, 0], shape='cylinder')
sample_details.set_material(chemical_formula='Si')
polaris.set_sample_details(sample=sample_details)

polaris.create_vanadium(first_cycle_run_no="98532", multiple_scattering=False)

polaris.focus(run_number="98533", input_mode='Summed')

q_lim = [[2.5, 3, 4, 6, 7], [3.5, 5, 7, 11, 40]]

ws = mtd['98533-ResultTOF_2']
ws *= 100

polaris.create_total_scattering_pdf(run_number="98533", merge_banks=True,q_lims=q_lim, 
                                    freq_params=[1.4], pdf_type="g(r)")
```

4. Rename the pdf workspace so that it won't be overwritten when you re-run the code above.
5. Change the qlim line in the code above to the line below and then re-run it
```q_lim = [[2.5, -1, 4, 6, 7], [3.5, -1, 7, 11, 40]]```
<!-- Instructions for testing. -->

6. Plot the spectrum in both of the pdf workspaces (the new one and the one renamed in step 4). They should be different.


Fixes #33830 


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
