### PR TITLE
Allow Multiple ROI types in Reflectometry

### DIFF
--- a/qt/python/mantidqt/mantidqt/widgets/regionselector/presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/regionselector/presenter.py
@@ -18,6 +18,15 @@ import matplotlib
 from matplotlib.widgets import RectangleSelector
 
 
+class Selector(RectangleSelector):
+    def __init__(self, region_type, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._region_type = region_type
+
+    def region_type(self):
+        return self._region_type
+
+
 class RegionSelector(ObservingPresenter, SliceViewerBasePresenter):
     def __init__(self, ws=None, parent=None, view=None):
         if ws and WorkspaceInfo.get_ws_type(ws) != WS_TYPE.MATRIX:
@@ -26,7 +35,7 @@ class RegionSelector(ObservingPresenter, SliceViewerBasePresenter):
         self.notifyee = None
         self.view = view if view else RegionSelectorView(self, parent)
         super().__init__(ws, self.view._data_view)
-        self._selectors: list[RectangleSelector] = []
+        self._selectors: list[Selector] = []
         self._drawing_region = False
 
         if ws:
@@ -82,7 +91,7 @@ class RegionSelector(ObservingPresenter, SliceViewerBasePresenter):
             self._selectors.pop()
             self._drawing_region = False
 
-    def add_rectangular_region(self):
+    def add_rectangular_region(self, region_type):
         """
         Add a rectangular region selection tool.
         """
@@ -99,16 +108,17 @@ class RegionSelector(ObservingPresenter, SliceViewerBasePresenter):
             selector_kwargs["drag_from_anywhere"] = True
             selector_kwargs["ignore_event_outside"] = True
 
-        self._selectors.append(RectangleSelector(self.view._data_view.ax, self._on_rectangle_selected,
+        self._selectors.append(Selector(region_type, self.view._data_view.ax, self._on_rectangle_selected,
                                                  **selector_kwargs))
 
         self._drawing_region = True
 
-    def get_region(self):
+    def get_region(self, region_type):
         # extents contains x1, x2, y1, y2. Just store y (spectra) for now
         result = []
         for selector in self._selectors:
-            result.extend([selector.extents[2], selector.extents[3]])
+            if selector.region_type() == region_type:
+                result.extend([selector.extents[2], selector.extents[3]])
         return result
 
     def _initialise_dimensions(self, workspace):

--- a/qt/python/mantidqt/mantidqt/widgets/regionselector/presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/regionselector/presenter.py
@@ -26,11 +26,8 @@ class Selector(RectangleSelector):
                        "spancoords": "pixels",
                        "interactive": True}
 
-    REGION_COLOURS = { "Signal": "green", "Background": "magenta", "Transmission": "blue" }
-
-    def __init__(self, region_type, *args):
-        self.selector_kwargs["props"] = dict(facecolor='white', edgecolor=self.REGION_COLOURS.get(region_type),
-                                             alpha=0.2, linewidth=2, fill=True)
+    def __init__(self, region_type, color, *args):
+        self.selector_kwargs["props"] = dict(facecolor='white', edgecolor=color, alpha=0.2, linewidth=2, fill=True)
         if LooseVersion(matplotlib.__version__) >= LooseVersion("3.5.0"):
             self.selector_kwargs["drag_from_anywhere"] = True
             self.selector_kwargs["ignore_event_outside"] = True
@@ -106,14 +103,14 @@ class RegionSelector(ObservingPresenter, SliceViewerBasePresenter):
             self._selectors.pop()
             self._drawing_region = False
 
-    def add_rectangular_region(self, region_type):
+    def add_rectangular_region(self, region_type, color):
         """
         Add a rectangular region selection tool.
         """
         for selector in self._selectors:
             selector.set_active(False)
 
-        self._selectors.append(Selector(region_type, self.view._data_view.ax, self._on_rectangle_selected))
+        self._selectors.append(Selector(region_type, color, self.view._data_view.ax, self._on_rectangle_selected))
 
         self._drawing_region = True
 

--- a/qt/python/mantidqt/mantidqt/widgets/regionselector/presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/regionselector/presenter.py
@@ -19,20 +19,21 @@ from matplotlib.widgets import RectangleSelector
 
 
 class Selector(RectangleSelector):
-    selector_kwargs = {"useblit": False,  # rectangle persists on button release
-                       "button": [1],
-                       "minspanx": 5,
-                       "minspany": 5,
-                       "spancoords": "pixels",
-                       "interactive": True}
+    kwargs = {"useblit": False,  # rectangle persists on button release
+              "button": [1],
+              "minspanx": 5,
+              "minspany": 5,
+              "spancoords": "pixels",
+              "interactive": True,
+              "props": dict(facecolor="white", alpha=0.2, linewidth=2, fill=True)}
 
-    def __init__(self, region_type, color, *args):
-        self.selector_kwargs["props"] = dict(facecolor='white', edgecolor=color, alpha=0.2, linewidth=2, fill=True)
+    def __init__(self, region_type: str, color: str, *args):
+        self.kwargs["props"]["edgecolor"] = color
         if LooseVersion(matplotlib.__version__) >= LooseVersion("3.5.0"):
-            self.selector_kwargs["drag_from_anywhere"] = True
-            self.selector_kwargs["ignore_event_outside"] = True
+            self.kwargs["drag_from_anywhere"] = True
+            self.kwargs["ignore_event_outside"] = True
 
-        super().__init__(*args, **self.selector_kwargs)
+        super().__init__(*args, **self.kwargs)
         self._region_type = region_type
 
     def region_type(self):

--- a/qt/python/mantidqt/mantidqt/widgets/regionselector/presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/regionselector/presenter.py
@@ -19,8 +19,23 @@ from matplotlib.widgets import RectangleSelector
 
 
 class Selector(RectangleSelector):
-    def __init__(self, region_type, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+    selector_kwargs = {"useblit": False,  # rectangle persists on button release
+                       "button": [1],
+                       "minspanx": 5,
+                       "minspany": 5,
+                       "spancoords": "pixels",
+                       "interactive": True}
+
+    REGION_COLOURS = { "Signal": "green", "Background": "magenta", "Transmission": "blue" }
+
+    def __init__(self, region_type, *args):
+        self.selector_kwargs["props"] = dict(facecolor='white', edgecolor=self.REGION_COLOURS.get(region_type),
+                                             alpha=0.2, linewidth=2, fill=True)
+        if LooseVersion(matplotlib.__version__) >= LooseVersion("3.5.0"):
+            self.selector_kwargs["drag_from_anywhere"] = True
+            self.selector_kwargs["ignore_event_outside"] = True
+
+        super().__init__(*args, **self.selector_kwargs)
         self._region_type = region_type
 
     def region_type(self):
@@ -98,18 +113,7 @@ class RegionSelector(ObservingPresenter, SliceViewerBasePresenter):
         for selector in self._selectors:
             selector.set_active(False)
 
-        selector_kwargs = {"useblit": False,  # rectangle persists on button release
-                           "button": [1],
-                           "minspanx": 5,
-                           "minspany": 5,
-                           "spancoords": "pixels",
-                           "interactive": True}
-        if LooseVersion(matplotlib.__version__) >= LooseVersion("3.5.0"):
-            selector_kwargs["drag_from_anywhere"] = True
-            selector_kwargs["ignore_event_outside"] = True
-
-        self._selectors.append(Selector(region_type, self.view._data_view.ax, self._on_rectangle_selected,
-                                                 **selector_kwargs))
+        self._selectors.append(Selector(region_type, self.view._data_view.ax, self._on_rectangle_selected))
 
         self._drawing_region = True
 

--- a/qt/python/mantidqt/mantidqt/widgets/regionselector/presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/regionselector/presenter.py
@@ -24,12 +24,11 @@ class Selector(RectangleSelector):
               "minspanx": 5,
               "minspany": 5,
               "spancoords": "pixels",
-              "interactive": True,
-              "props": dict(facecolor="white", alpha=0.2, linewidth=2, fill=True)}
+              "interactive": True}
 
     def __init__(self, region_type: str, color: str, *args):
-        self.kwargs["props"]["edgecolor"] = color
         if LooseVersion(matplotlib.__version__) >= LooseVersion("3.5.0"):
+            self.kwargs["props"] = dict(facecolor="white", edgecolor=color, alpha=0.2, linewidth=2, fill=True)
             self.kwargs["drag_from_anywhere"] = True
             self.kwargs["ignore_event_outside"] = True
 

--- a/qt/python/mantidqt/mantidqt/widgets/regionselector/test/test_regionselector_presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/regionselector/test/test_regionselector_presenter.py
@@ -70,7 +70,7 @@ class RegionSelectorTest(unittest.TestCase):
     def test_add_rectangular_region_creates_selector(self):
         region_selector = RegionSelector(ws=Mock(), view=Mock())
 
-        region_selector.add_rectangular_region("test")
+        region_selector.add_rectangular_region("test", "black")
 
         self.assertEqual(1, len(region_selector._selectors))
         self.assertTrue(region_selector._selectors[0].active)
@@ -79,8 +79,8 @@ class RegionSelectorTest(unittest.TestCase):
     def test_add_second_rectangular_region_deactivates_first_selector(self):
         region_selector = RegionSelector(ws=Mock(), view=Mock())
 
-        region_selector.add_rectangular_region("test")
-        region_selector.add_rectangular_region("test")
+        region_selector.add_rectangular_region("test", "black")
+        region_selector.add_rectangular_region("test", "black")
 
         self.assertEqual(2, len(region_selector._selectors))
 
@@ -149,14 +149,14 @@ class RegionSelectorTest(unittest.TestCase):
         mock_observer = Mock()
         region_selector.subscribe(mock_observer)
 
-        region_selector.add_rectangular_region("test")
+        region_selector.add_rectangular_region("test", "black")
         region_selector._on_rectangle_selected(Mock(), Mock())
 
         mock_observer.notifyRegionChanged.assert_called_once()
 
     def test_cancel_drawing_region_will_remove_last_selector(self):
         region_selector = RegionSelector(ws=Mock(), view=Mock())
-        region_selector.add_rectangular_region("test")
+        region_selector.add_rectangular_region("test", "black")
         self.assertEqual(1, len(region_selector._selectors))
         region_selector.cancel_drawing_region()
         self.assertEqual(0, len(region_selector._selectors))

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/RowProcessingAlgorithm.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/RowProcessingAlgorithm.cpp
@@ -46,6 +46,15 @@ void updateMomentumTransferProperties(AlgorithmRuntimeProps &properties, RangeIn
   AlgorithmProperties::update("MomentumTransferStep", rangeInQ.step(), properties);
 }
 
+void updateProcessingInstructionsProperties(AlgorithmRuntimeProps &properties, PreviewRow const &previewRow) {
+  AlgorithmProperties::update("ProcessingInstructions", previewRow.getProcessingInstructions(ROIType::Signal),
+                              properties);
+  AlgorithmProperties::update("BackgroundProcessingInstructions",
+                              previewRow.getProcessingInstructions(ROIType::Background), properties);
+  AlgorithmProperties::update("TransmissionProcessingInstructions",
+                              previewRow.getProcessingInstructions(ROIType::Transmission), properties);
+}
+
 void updateRowProperties(AlgorithmRuntimeProps &properties, Row const &row) {
   updateInputWorkspacesProperties(properties, row.reducedWorkspaceNames().inputRunNumbers());
   updateTransmissionWorkspaceProperties(properties, row.reducedWorkspaceNames().transmissionRuns());
@@ -300,12 +309,8 @@ std::unique_ptr<MantidQt::API::IAlgorithmRuntimeProps> createAlgorithmRuntimePro
   }
   // Update properties from the preview tab
   properties->setProperty("InputWorkspace", previewRow.getSummedWs());
-  properties->setProperty("ProcessingInstructions", previewRow.getProcessingInstructions(ROIType::Signal));
-  properties->setProperty("BackgroundProcessingInstructions",
-                          previewRow.getProcessingInstructions(ROIType::Background));
-  properties->setProperty("TransmissionProcessingInstructions",
-                          previewRow.getProcessingInstructions(ROIType::Transmission));
   properties->setProperty("ThetaIn", previewRow.theta());
+  updateProcessingInstructionsProperties(*properties, previewRow);
   return properties;
 }
 

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/RowProcessingAlgorithm.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/RowProcessingAlgorithm.cpp
@@ -5,6 +5,7 @@
 //   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 // SPDX - License - Identifier: GPL - 3.0 +
 #include "RowProcessingAlgorithm.h"
+#include "../../GUI/Preview/ROIType.h"
 #include "../../Reduction/Batch.h"
 #include "../../Reduction/PreviewRow.h"
 #include "AlgorithmProperties.h"
@@ -299,7 +300,11 @@ std::unique_ptr<MantidQt::API::IAlgorithmRuntimeProps> createAlgorithmRuntimePro
   }
   // Update properties from the preview tab
   properties->setProperty("InputWorkspace", previewRow.getSummedWs());
-  properties->setProperty("ProcessingInstructions", previewRow.getProcessingInstructions());
+  properties->setProperty("ProcessingInstructions", previewRow.getProcessingInstructions(ROIType::Signal));
+  properties->setProperty("BackgroundProcessingInstructions",
+                          previewRow.getProcessingInstructions(ROIType::Background));
+  properties->setProperty("TransmissionProcessingInstructions",
+                          previewRow.getProcessingInstructions(ROIType::Transmission));
   properties->setProperty("ThetaIn", previewRow.theta());
   return properties;
 }

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/CMakeLists.txt
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/CMakeLists.txt
@@ -12,6 +12,7 @@ set(PREVIEW_INC_FILES
     PreviewPresenterFactory.h
     PreviewPresenter.h
     IPreviewView.h
+    ROIType.h
     QtPreviewView.h
 )
 

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/IPreviewModel.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/IPreviewModel.h
@@ -11,6 +11,8 @@
 #include "ROIType.h"
 #include "Reduction/ProcessingInstructions.h"
 
+#include <boost/optional.hpp>
+
 #include <optional>
 #include <string>
 #include <vector>
@@ -33,7 +35,7 @@ public:
   virtual std::vector<Mantid::detid_t> getSelectedBanks() const = 0;
   virtual Mantid::API::MatrixWorkspace_sptr getSummedWs() const = 0;
   virtual Mantid::API::MatrixWorkspace_sptr getReducedWs() const = 0;
-  virtual ProcessingInstructions getProcessingInstructions(ROIType regionType) const = 0;
+  virtual boost::optional<ProcessingInstructions> getProcessingInstructions(ROIType regionType) const = 0;
   virtual std::optional<double> getDefaultTheta() const = 0;
 
   virtual void setTheta(double theta) = 0;

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/IPreviewModel.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/IPreviewModel.h
@@ -8,6 +8,7 @@
 
 #include "MantidAPI/MatrixWorkspace_fwd.h"
 #include "MantidGeometry/IDTypes.h"
+#include "ROIType.h"
 #include "Reduction/ProcessingInstructions.h"
 
 #include <optional>
@@ -32,13 +33,13 @@ public:
   virtual std::vector<Mantid::detid_t> getSelectedBanks() const = 0;
   virtual Mantid::API::MatrixWorkspace_sptr getSummedWs() const = 0;
   virtual Mantid::API::MatrixWorkspace_sptr getReducedWs() const = 0;
-  virtual ProcessingInstructions getProcessingInstructions() const = 0;
+  virtual ProcessingInstructions getProcessingInstructions(ROIType regionType) const = 0;
   virtual std::optional<double> getDefaultTheta() const = 0;
 
   virtual void setTheta(double theta) = 0;
 
   virtual void setSelectedBanks(std::vector<Mantid::detid_t> selectedBanks) = 0;
-  virtual void setSelectedRegion(Selection const &selection) = 0;
+  virtual void setSelectedRegion(ROIType regionType, Selection const &selection) = 0;
 
   virtual void exportSummedWsToAds() const = 0;
   virtual void exportReducedWsToAds() const = 0;

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/IPreviewView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/IPreviewView.h
@@ -32,7 +32,7 @@ public:
   virtual void notifyLinePlotExportAdsRequested() = 0;
 
   virtual void notifyEditROIModeRequested() = 0;
-  virtual void notifyRectangularROIModeRequested(const std::string &regionType) = 0;
+  virtual void notifyRectangularROIModeRequested() = 0;
 };
 
 class IPreviewView {
@@ -59,6 +59,7 @@ public:
   virtual void setRectangularROIState(bool state) = 0;
 
   virtual std::vector<size_t> getSelectedDetectors() const = 0;
+  virtual std::string getRegionType() const = 0;
 
   virtual QLayout *getRegionSelectorLayout() const = 0;
   virtual MantidQt::MantidWidgets::IPlotView *getLinePlotView() const = 0;

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/IPreviewView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/IPreviewView.h
@@ -32,7 +32,7 @@ public:
   virtual void notifyLinePlotExportAdsRequested() = 0;
 
   virtual void notifyEditROIModeRequested() = 0;
-  virtual void notifyRectangularROIModeRequested() = 0;
+  virtual void notifyRectangularROIModeRequested(const std::string &regionType) = 0;
 };
 
 class IPreviewView {

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewModel.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewModel.cpp
@@ -16,6 +16,7 @@
 #include "MantidKernel/Strings.h"
 #include "MantidKernel/TimeSeriesProperty.h"
 #include "MantidKernel/Tolerance.h"
+#include "ROIType.h"
 
 #include <boost/utility/in_place_factory.hpp>
 
@@ -100,11 +101,11 @@ void PreviewModel::setSelectedBanks(std::vector<Mantid::detid_t> selectedBanks) 
   m_runDetails->setSelectedBanks(std::move(selectedBanks));
 }
 
-ProcessingInstructions PreviewModel::getProcessingInstructions() const {
-  return m_runDetails->getProcessingInstructions();
+ProcessingInstructions PreviewModel::getProcessingInstructions(ROIType regionType) const {
+  return m_runDetails->getProcessingInstructions(regionType);
 }
 
-void PreviewModel::setSelectedRegion(Selection const &selection) {
+void PreviewModel::setSelectedRegion(ROIType regionType, Selection const &selection) {
   // TODO We will need to allow for more complex selections, but for now the selection just consists two y indices per
   // TODO rectangle selection
   if (selection.size() % 2 != 0) {
@@ -121,7 +122,7 @@ void PreviewModel::setSelectedRegion(Selection const &selection) {
     }
     processingInstructions += std::to_string(start) + "-" + std::to_string(end);
   }
-  m_runDetails->setProcessingInstructions(std::move(processingInstructions));
+  m_runDetails->setProcessingInstructions(regionType, std::move(processingInstructions));
 }
 
 void PreviewModel::createRunDetails(const std::string &workspaceName) {

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewModel.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewModel.cpp
@@ -18,6 +18,7 @@
 #include "MantidKernel/Tolerance.h"
 #include "ROIType.h"
 
+#include <boost/optional.hpp>
 #include <boost/utility/in_place_factory.hpp>
 
 #include <optional>
@@ -101,7 +102,7 @@ void PreviewModel::setSelectedBanks(std::vector<Mantid::detid_t> selectedBanks) 
   m_runDetails->setSelectedBanks(std::move(selectedBanks));
 }
 
-ProcessingInstructions PreviewModel::getProcessingInstructions(ROIType regionType) const {
+boost::optional<ProcessingInstructions> PreviewModel::getProcessingInstructions(ROIType regionType) const {
   return m_runDetails->getProcessingInstructions(regionType);
 }
 

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewModel.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewModel.h
@@ -14,6 +14,8 @@
 #include "ROIType.h"
 #include "Reduction/PreviewRow.h"
 
+#include <boost/optional.hpp>
+
 #include <cstddef>
 #include <memory>
 #include <optional>
@@ -36,7 +38,7 @@ public:
   Mantid::API::MatrixWorkspace_sptr getLoadedWs() const override;
   std::vector<Mantid::detid_t> getSelectedBanks() const override;
   Mantid::API::MatrixWorkspace_sptr getSummedWs() const override;
-  ProcessingInstructions getProcessingInstructions(ROIType regionType) const override;
+  boost::optional<ProcessingInstructions> getProcessingInstructions(ROIType regionType) const override;
   Mantid::API::MatrixWorkspace_sptr getReducedWs() const override;
   std::optional<double> getDefaultTheta() const override;
 

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewModel.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewModel.h
@@ -11,6 +11,7 @@
 #include "IPreviewModel.h"
 #include "MantidAPI/MatrixWorkspace_fwd.h"
 #include "MantidGeometry/IDTypes.h"
+#include "ROIType.h"
 #include "Reduction/PreviewRow.h"
 
 #include <cstddef>
@@ -35,14 +36,14 @@ public:
   Mantid::API::MatrixWorkspace_sptr getLoadedWs() const override;
   std::vector<Mantid::detid_t> getSelectedBanks() const override;
   Mantid::API::MatrixWorkspace_sptr getSummedWs() const override;
-  ProcessingInstructions getProcessingInstructions() const override;
+  ProcessingInstructions getProcessingInstructions(ROIType regionType) const override;
   Mantid::API::MatrixWorkspace_sptr getReducedWs() const override;
   std::optional<double> getDefaultTheta() const override;
 
   void setLoadedWs(Mantid::API::MatrixWorkspace_sptr workspace);
   void setTheta(double theta) override;
   void setSelectedBanks(std::vector<Mantid::detid_t> selectedBanks) override;
-  void setSelectedRegion(Selection const &selection) override;
+  void setSelectedRegion(ROIType regionType, Selection const &selection) override;
 
   void exportSummedWsToAds() const override;
   void exportReducedWsToAds() const override;
@@ -56,5 +57,7 @@ private:
   void createRunDetails(std::string const &workspaceName);
 
   std::optional<double> getThetaFromLogs(std::string const &logName) const;
+
+  void setProcessingInstructions(ROIType regionType, ProcessingInstructions processingInstructions);
 };
 } // namespace MantidQt::CustomInterfaces::ISISReflectometry

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.cpp
@@ -162,9 +162,11 @@ void PreviewPresenter::notifyRegionChanged() {
   m_view->setEditROIState(true);
 
   // Set the selection from the view
-  // TODO make use of background and transmission regions. Move hard coded strings to somewhere central as an enum
-  auto roi = m_regionSelector->getRegion(roiTypeToString(ROIType::Signal));
-  m_model->setSelectedRegion(ROIType::Signal, roi);
+  m_model->setSelectedRegion(ROIType::Signal, m_regionSelector->getRegion(roiTypeToString(ROIType::Signal)));
+  m_model->setSelectedRegion(ROIType::Background, m_regionSelector->getRegion(roiTypeToString(ROIType::Background)));
+  m_model->setSelectedRegion(ROIType::Transmission,
+                             m_regionSelector->getRegion(roiTypeToString(ROIType::Transmission)));
+
   runReduction();
 }
 

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.cpp
@@ -150,9 +150,10 @@ void PreviewPresenter::notifyEditROIModeRequested() {
 }
 
 void PreviewPresenter::notifyRectangularROIModeRequested(const std::string &regionType) {
+  auto const roiType = roiTypeFromString(regionType);
   m_view->setEditROIState(false);
   m_view->setRectangularROIState(true);
-  m_regionSelector->addRectangularRegion(regionType);
+  m_regionSelector->addRectangularRegion(regionType, roiTypeToColor(roiType));
 }
 
 void PreviewPresenter::notifyRegionChanged() {

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.cpp
@@ -163,7 +163,7 @@ void PreviewPresenter::notifyRegionChanged() {
   // Set the selection from the view
   // TODO make use of background and transmission regions. Move hard coded strings to somewhere central as an enum
   auto roi = m_regionSelector->getRegion(roiTypeToString(ROIType::Signal));
-  m_model->setSelectedRegion(roi);
+  m_model->setSelectedRegion(ROIType::Signal, roi);
   runReduction();
 }
 

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.cpp
@@ -148,10 +148,10 @@ void PreviewPresenter::notifyEditROIModeRequested() {
   m_regionSelector->cancelDrawingRegion();
 }
 
-void PreviewPresenter::notifyRectangularROIModeRequested() {
+void PreviewPresenter::notifyRectangularROIModeRequested(const std::string &regionType) {
   m_view->setEditROIState(false);
   m_view->setRectangularROIState(true);
-  m_regionSelector->addRectangularRegion();
+  m_regionSelector->addRectangularRegion(regionType);
 }
 
 void PreviewPresenter::notifyRegionChanged() {
@@ -159,7 +159,8 @@ void PreviewPresenter::notifyRegionChanged() {
   m_view->setEditROIState(true);
 
   // Set the selection from the view
-  auto roi = m_regionSelector->getRegion();
+  // TODO make use of background and transmission regions. Move hard coded strings to somewhere central as an enum
+  auto roi = m_regionSelector->getRegion("Signal");
   m_model->setSelectedRegion(roi);
   runReduction();
 }

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.cpp
@@ -11,6 +11,7 @@
 #include "MantidQtWidgets/Plotting/AxisID.h"
 #include "MantidQtWidgets/RegionSelector/IRegionSelector.h"
 #include "MantidQtWidgets/RegionSelector/RegionSelector.h"
+#include "ROIType.h"
 #include <memory>
 
 using Mantid::API::MatrixWorkspace_sptr;
@@ -160,7 +161,7 @@ void PreviewPresenter::notifyRegionChanged() {
 
   // Set the selection from the view
   // TODO make use of background and transmission regions. Move hard coded strings to somewhere central as an enum
-  auto roi = m_regionSelector->getRegion("Signal");
+  auto roi = m_regionSelector->getRegion(roiTypeToString(ROIType::Signal));
   m_model->setSelectedRegion(roi);
   runReduction();
 }

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.cpp
@@ -149,7 +149,8 @@ void PreviewPresenter::notifyEditROIModeRequested() {
   m_regionSelector->cancelDrawingRegion();
 }
 
-void PreviewPresenter::notifyRectangularROIModeRequested(const std::string &regionType) {
+void PreviewPresenter::notifyRectangularROIModeRequested() {
+  auto const regionType = m_view->getRegionType();
   auto const roiType = roiTypeFromString(regionType);
   m_view->setEditROIState(false);
   m_view->setRectangularROIState(true);

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.h
@@ -65,7 +65,7 @@ public:
   void notifyLinePlotExportAdsRequested() override;
 
   void notifyEditROIModeRequested() override;
-  void notifyRectangularROIModeRequested() override;
+  void notifyRectangularROIModeRequested(const std::string &regionType) override;
 
   // JobManagerSubscriber overrides
   void notifyLoadWorkspaceCompleted() override;

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.h
@@ -65,7 +65,7 @@ public:
   void notifyLinePlotExportAdsRequested() override;
 
   void notifyEditROIModeRequested() override;
-  void notifyRectangularROIModeRequested(const std::string &regionType) override;
+  void notifyRectangularROIModeRequested() override;
 
   // JobManagerSubscriber overrides
   void notifyLoadWorkspaceCompleted() override;

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewWidget.ui
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewWidget.ui
@@ -185,7 +185,13 @@
              <string>Select a rectangular region of interest</string>
             </property>
             <property name="text">
-             <string>Rectangular ROI</string>
+             <string/>
+            </property>
+            <property name="popupMode">
+             <enum>QToolButton::MenuButtonPopup</enum>
+            </property>
+            <property name="toolButtonStyle">
+             <enum>Qt::ToolButtonTextBesideIcon</enum>
             </property>
            </widget>
           </item>

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/QtPreviewView.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/QtPreviewView.cpp
@@ -11,6 +11,7 @@
 #include "MantidQtWidgets/InstrumentView/ProjectionSurface.h"
 #include "MantidQtWidgets/InstrumentView/UnwrappedCylinder.h"
 #include "MantidQtWidgets/Plotting/PreviewPlot.h"
+#include "ROIType.h"
 
 #include <QAction>
 #include <QMenu>
@@ -20,12 +21,6 @@
 using namespace Mantid::Kernel;
 using MantidQt::MantidWidgets::IPlotView;
 using MantidQt::MantidWidgets::ProjectionSurface;
-
-namespace {
-static constexpr char *BACKGROUND_REGION = "Background";
-static constexpr char *SIGNAL_REGION = "Signal";
-static constexpr char *TRANSMISSION_REGION = "Transmission";
-} // namespace
 
 namespace MantidQt::CustomInterfaces::ISISReflectometry {
 QtPreviewView::QtPreviewView(QWidget *parent) : QWidget(parent) {
@@ -48,10 +43,15 @@ void QtPreviewView::loadToolbarIcons() {
 
 void QtPreviewView::setupSelectRegionTypes() {
   QMenu *menu = new QMenu();
-  QAction *signalAction = new QAction(MantidQt::Icons::getIcon("mdi.selection", "green", 1.3), SIGNAL_REGION);
-  QAction *backgroundAction = new QAction(MantidQt::Icons::getIcon("mdi.selection", "magenta", 1.3), BACKGROUND_REGION);
-  QAction *transmissionAction =
-      new QAction(MantidQt::Icons::getIcon("mdi.selection", "blue", 1.3), TRANSMISSION_REGION);
+  QAction *signalAction = new QAction(
+      MantidQt::Icons::getIcon("mdi.selection", QString::fromStdString(roiTypeToColor(ROIType::Signal)), 1.3),
+      QString::fromStdString(roiTypeToString(ROIType::Signal)));
+  QAction *backgroundAction = new QAction(
+      MantidQt::Icons::getIcon("mdi.selection", QString::fromStdString(roiTypeToColor(ROIType::Background)), 1.3),
+      QString::fromStdString(roiTypeToString(ROIType::Background)));
+  QAction *transmissionAction = new QAction(
+      MantidQt::Icons::getIcon("mdi.selection", QString::fromStdString(roiTypeToColor(ROIType::Transmission)), 1.3),
+      QString::fromStdString(roiTypeToString(ROIType::Transmission)));
 
   signalAction->setToolTip("Add rectangular signal region");
   backgroundAction->setToolTip("Add rectangular background region");

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/QtPreviewView.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/QtPreviewView.cpp
@@ -96,7 +96,7 @@ void QtPreviewView::onEditROIClicked() const { m_notifyee->notifyEditROIModeRequ
 
 void QtPreviewView::onAddRectangularROIClicked(QAction *regionType) const {
   m_ui.rs_rect_select_button->setDefaultAction(regionType);
-  m_notifyee->notifyRectangularROIModeRequested(regionType->text().toStdString());
+  m_notifyee->notifyRectangularROIModeRequested();
 }
 
 void QtPreviewView::onLinePlotExportToAdsClicked() const { m_notifyee->notifyLinePlotExportAdsRequested(); }
@@ -160,5 +160,9 @@ std::vector<size_t> QtPreviewView::getSelectedDetectors() const {
   // (although weather it's treated as a mask or not is up to the caller)
   m_instDisplay->getSurface()->getMaskedDetectors(result);
   return result;
+}
+
+std::string QtPreviewView::getRegionType() const {
+  return m_ui.rs_rect_select_button->defaultAction()->text().toStdString();
 }
 } // namespace MantidQt::CustomInterfaces::ISISReflectometry

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/QtPreviewView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/QtPreviewView.h
@@ -56,6 +56,7 @@ public:
   void setRectangularROIState(bool state) override;
 
   std::vector<size_t> getSelectedDetectors() const override;
+  std::string getRegionType() const override;
 
   QLayout *getRegionSelectorLayout() const override;
   MantidQt::MantidWidgets::IPlotView *getLinePlotView() const override;

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/QtPreviewView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/QtPreviewView.h
@@ -67,6 +67,7 @@ private:
 
   void connectSignals() const;
   void loadToolbarIcons();
+  void setupSelectRegionTypes();
 
 private slots:
   void onLoadWorkspaceRequested() const;
@@ -77,6 +78,6 @@ private slots:
   void onRegionSelectorExportToAdsClicked() const;
   void onLinePlotExportToAdsClicked() const;
   void onEditROIClicked() const;
-  void onAddRectangularROIClicked() const;
+  void onAddRectangularROIClicked(QAction *regionType) const;
 };
 } // namespace MantidQt::CustomInterfaces::ISISReflectometry

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/ROIType.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/ROIType.h
@@ -1,0 +1,53 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2022 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#pragma once
+
+#include <stdexcept>
+#include <string>
+
+namespace MantidQt {
+namespace CustomInterfaces {
+namespace ISISReflectometry {
+enum class ROIType { Signal, Background, Transmission };
+
+inline ROIType roiTypeFromString(std::string const &roiType) {
+  if (roiType == "Signal")
+    return ROIType::Signal;
+  if (roiType == "Background")
+    return ROIType::Background;
+  if (roiType == "Transmission")
+    return ROIType::Transmission;
+  throw std::invalid_argument("Unexpected ROI type");
+}
+
+inline std::string roiTypeToString(ROIType roiType) {
+  switch (roiType) {
+  case ROIType::Signal:
+    return "Signal";
+  case ROIType::Background:
+    return "Background";
+  case ROIType::Transmission:
+    return "Transmission";
+  }
+  throw std::invalid_argument("Unexpected ROI type");
+}
+
+inline std::string roiTypeToColor(ROIType roiType) {
+  switch (roiType) {
+  case ROIType::Signal:
+    return "green";
+  case ROIType::Background:
+    return "magenta";
+  case ROIType::Transmission:
+    return "blue";
+  }
+  throw std::invalid_argument("Unexpected ROI type");
+}
+
+} // namespace ISISReflectometry
+} // namespace CustomInterfaces
+} // namespace MantidQt

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/PreviewRow.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/PreviewRow.cpp
@@ -5,6 +5,7 @@
 //   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 // SPDX - License - Identifier: GPL - 3.0 +
 #include "PreviewRow.h"
+#include "GUI/Preview/ROIType.h"
 #include "MantidAPI/MatrixWorkspace.h"
 #include "MantidGeometry/IDTypes.h"
 
@@ -45,9 +46,30 @@ void PreviewRow::setSelectedBanks(std::vector<Mantid::detid_t> selectedBanks) no
   m_selectedBanks = std::move(selectedBanks);
 }
 
-ProcessingInstructions PreviewRow::getProcessingInstructions() const noexcept { return m_processingInstructions; }
+ProcessingInstructions PreviewRow::getProcessingInstructions(ROIType regionType) const {
+  switch (regionType) {
+  case ROIType::Signal:
+    return m_processingInstructions;
+  case ROIType::Background:
+    return m_backgroundProcessingInstructions;
+  case ROIType::Transmission:
+    return m_transmissionProcessingInstructions;
+  }
+  throw std::invalid_argument("Unexpected ROIType provided");
+}
 
-void PreviewRow::setProcessingInstructions(ProcessingInstructions processingInstructions) noexcept {
-  m_processingInstructions = std::move(processingInstructions);
+void PreviewRow::setProcessingInstructions(ROIType regionType, ProcessingInstructions processingInstructions) {
+  switch (regionType) {
+  case ROIType::Signal:
+    m_processingInstructions = std::move(processingInstructions);
+    return;
+  case ROIType::Background:
+    m_backgroundProcessingInstructions = std::move(processingInstructions);
+    return;
+  case ROIType::Transmission:
+    m_transmissionProcessingInstructions = std::move(processingInstructions);
+    return;
+  }
+  throw std::invalid_argument("Unexpected ROIType provided");
 }
 } // namespace MantidQt::CustomInterfaces::ISISReflectometry

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/PreviewRow.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/PreviewRow.cpp
@@ -9,6 +9,8 @@
 #include "MantidAPI/MatrixWorkspace.h"
 #include "MantidGeometry/IDTypes.h"
 
+#include <boost/optional.hpp>
+
 #include <string>
 #include <vector>
 
@@ -46,7 +48,7 @@ void PreviewRow::setSelectedBanks(std::vector<Mantid::detid_t> selectedBanks) no
   m_selectedBanks = std::move(selectedBanks);
 }
 
-ProcessingInstructions PreviewRow::getProcessingInstructions(ROIType regionType) const {
+boost::optional<ProcessingInstructions> PreviewRow::getProcessingInstructions(ROIType regionType) const {
   switch (regionType) {
   case ROIType::Signal:
     return m_processingInstructions;

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/PreviewRow.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/PreviewRow.h
@@ -12,6 +12,8 @@
 #include "MantidGeometry/IDTypes.h"
 #include "Reduction/ProcessingInstructions.h"
 
+#include <boost/optional.hpp>
+
 #include <string>
 #include <vector>
 
@@ -45,7 +47,7 @@ public:
   Mantid::API::MatrixWorkspace_sptr getSummedWs() const noexcept;
   Mantid::API::MatrixWorkspace_sptr getReducedWs() const noexcept;
   std::vector<Mantid::detid_t> getSelectedBanks() const noexcept;
-  ProcessingInstructions getProcessingInstructions(ROIType regionType) const;
+  boost::optional<ProcessingInstructions> getProcessingInstructions(ROIType regionType) const;
 
   void setLoadedWs(Mantid::API::MatrixWorkspace_sptr ws) noexcept;
   void setSummedWs(Mantid::API::MatrixWorkspace_sptr ws) noexcept;
@@ -63,9 +65,9 @@ private:
   std::vector<std::string> m_runNumbers;
   double m_theta;
   std::vector<Mantid::detid_t> m_selectedBanks;
-  ProcessingInstructions m_processingInstructions;
-  ProcessingInstructions m_backgroundProcessingInstructions;
-  ProcessingInstructions m_transmissionProcessingInstructions;
+  boost::optional<ProcessingInstructions> m_processingInstructions{boost::none};
+  boost::optional<ProcessingInstructions> m_backgroundProcessingInstructions{boost::none};
+  boost::optional<ProcessingInstructions> m_transmissionProcessingInstructions{boost::none};
   Mantid::API::MatrixWorkspace_sptr m_loadedWs;
   Mantid::API::MatrixWorkspace_sptr m_summedWs;
   Mantid::API::MatrixWorkspace_sptr m_reducedWs;

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/PreviewRow.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/PreviewRow.h
@@ -6,6 +6,7 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 #pragma once
 #include "Common/DllConfig.h"
+#include "GUI/Preview/ROIType.h"
 #include "Item.h"
 #include "MantidAPI/MatrixWorkspace_fwd.h"
 #include "MantidGeometry/IDTypes.h"
@@ -44,13 +45,13 @@ public:
   Mantid::API::MatrixWorkspace_sptr getSummedWs() const noexcept;
   Mantid::API::MatrixWorkspace_sptr getReducedWs() const noexcept;
   std::vector<Mantid::detid_t> getSelectedBanks() const noexcept;
-  ProcessingInstructions getProcessingInstructions() const noexcept;
+  ProcessingInstructions getProcessingInstructions(ROIType regionType) const;
 
   void setLoadedWs(Mantid::API::MatrixWorkspace_sptr ws) noexcept;
   void setSummedWs(Mantid::API::MatrixWorkspace_sptr ws) noexcept;
   void setReducedWs(Mantid::API::MatrixWorkspace_sptr ws) noexcept;
   void setSelectedBanks(std::vector<Mantid::detid_t> selectedBanks) noexcept;
-  void setProcessingInstructions(ProcessingInstructions processingInstructions) noexcept;
+  void setProcessingInstructions(ROIType regionType, ProcessingInstructions processingInstructions);
 
   friend bool operator==(const PreviewRow &lhs, const PreviewRow &rhs) {
     // Note: This does not consider if the underlying item is equal currently
@@ -63,6 +64,8 @@ private:
   double m_theta;
   std::vector<Mantid::detid_t> m_selectedBanks;
   ProcessingInstructions m_processingInstructions;
+  ProcessingInstructions m_backgroundProcessingInstructions;
+  ProcessingInstructions m_transmissionProcessingInstructions;
   Mantid::API::MatrixWorkspace_sptr m_loadedWs;
   Mantid::API::MatrixWorkspace_sptr m_summedWs;
   Mantid::API::MatrixWorkspace_sptr m_reducedWs;

--- a/qt/scientific_interfaces/ISISReflectometry/test/Batch/RowProcessingAlgorithmTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Batch/RowProcessingAlgorithmTest.h
@@ -52,13 +52,15 @@ public:
   void testExperimentSettingsWithPreviewRow() {
     auto model = Batch(m_experiment, m_instrument, m_runsTable, m_slicing);
     auto theta = 0.7;
-    auto previewRow = makePreviewRow(theta, "2-3");
+    auto previewRow = makePreviewRow(theta, "2-3", "4-5", "6-7");
     auto result = Reduction::createAlgorithmRuntimeProps(model, previewRow);
 
     // Check results from the experiment settings tab
     checkExperimentSettings(*result);
     // Check the settings from the PreviewRow model
     TS_ASSERT_EQUALS(result->getPropertyValue("ProcessingInstructions"), "2-3");
+    TS_ASSERT_EQUALS(result->getPropertyValue("BackgroundProcessingInstructions"), "4-5");
+    TS_ASSERT_EQUALS(result->getPropertyValue("TransmissionProcessingInstructions"), "6-7");
     assertProperty(*result, "ThetaIn", theta);
   }
 
@@ -225,9 +227,14 @@ public:
     auto model = Batch(m_experiment, m_instrument, m_runsTable, m_slicing);
     // Use an angle that will match per-theta defaults. They should be
     // overridden by the cell values
-    auto row = makeRowWithOptionsCellFilled(2.3, ReductionOptionsMap{{"ProcessingInstructions", "390-410"}});
+    auto row =
+        makeRowWithOptionsCellFilled(2.3, ReductionOptionsMap{{"ProcessingInstructions", "390-410"},
+                                                              {"BackgroundProcessingInstructions", "410-430"},
+                                                              {"TransmissionProcessingInstructions", "430-450"}});
     auto result = RowProcessing::createAlgorithmRuntimeProps(model, row);
     TS_ASSERT_EQUALS(result->getPropertyValue("ProcessingInstructions"), "390-410");
+    TS_ASSERT_EQUALS(result->getPropertyValue("BackgroundProcessingInstructions"), "410-430");
+    TS_ASSERT_EQUALS(result->getPropertyValue("TransmissionProcessingInstructions"), "430-450");
   }
 
   void testOptionsCellOverridesInstrumentSettings() {
@@ -291,10 +298,16 @@ private:
     const std::string m_propName = "OutputWorkspace";
   };
 
-  PreviewRow makePreviewRow(double theta = 0.1, const std::string &processingInstructions = "10-11") {
+  PreviewRow makePreviewRow(double theta = 0.1, const std::string &processingInstructions = "10-11",
+                            const std::string &backgroundProcessingInstructions = "",
+                            const std::string &transmissionProcessingInstructions = "") {
     auto previewRow = PreviewRow({"12345"});
     previewRow.setTheta(theta);
     previewRow.setProcessingInstructions(ROIType::Signal, processingInstructions);
+    if (!backgroundProcessingInstructions.empty())
+      previewRow.setProcessingInstructions(ROIType::Background, backgroundProcessingInstructions);
+    if (!transmissionProcessingInstructions.empty())
+      previewRow.setProcessingInstructions(ROIType::Transmission, transmissionProcessingInstructions);
     return previewRow;
   }
 

--- a/qt/scientific_interfaces/ISISReflectometry/test/Batch/RowProcessingAlgorithmTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Batch/RowProcessingAlgorithmTest.h
@@ -6,6 +6,7 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 #pragma once
 #include "../../../ISISReflectometry/GUI/Batch/RowProcessingAlgorithm.h"
+#include "../../../ISISReflectometry/GUI/Preview/ROIType.h"
 #include "../../../ISISReflectometry/Reduction/Batch.h"
 #include "../../../ISISReflectometry/Reduction/PreviewRow.h"
 #include "../../../ISISReflectometry/TestHelpers/ModelCreationHelper.h"
@@ -293,7 +294,7 @@ private:
   PreviewRow makePreviewRow(double theta = 0.1, const std::string &processingInstructions = "10-11") {
     auto previewRow = PreviewRow({"12345"});
     previewRow.setTheta(theta);
-    previewRow.setProcessingInstructions(processingInstructions);
+    previewRow.setProcessingInstructions(ROIType::Signal, processingInstructions);
     return previewRow;
   }
 

--- a/qt/scientific_interfaces/ISISReflectometry/test/Preview/MockPreviewModel.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Preview/MockPreviewModel.h
@@ -12,6 +12,7 @@
 #include "MantidGeometry/IDTypes.h"
 #include "ROIType.h"
 
+#include <boost/optional.hpp>
 #include <gmock/gmock.h>
 
 #include <string>
@@ -28,7 +29,7 @@ public:
   MOCK_METHOD(MatrixWorkspace_sptr, getSummedWs, (), (const, override));
   MOCK_METHOD(MatrixWorkspace_sptr, getReducedWs, (), (const, override));
   MOCK_METHOD(std::vector<Mantid::detid_t>, getSelectedBanks, (), (const, override));
-  MOCK_METHOD(ProcessingInstructions, getProcessingInstructions, (ROIType), (const, override));
+  MOCK_METHOD(boost::optional<ProcessingInstructions>, getProcessingInstructions, (ROIType), (const, override));
   MOCK_METHOD(std::optional<double>, getDefaultTheta, (), (const, override));
 
   MOCK_METHOD(void, setTheta, (double), (override));

--- a/qt/scientific_interfaces/ISISReflectometry/test/Preview/MockPreviewModel.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Preview/MockPreviewModel.h
@@ -10,6 +10,7 @@
 #include "IPreviewModel.h"
 #include "MantidAPI/MatrixWorkspace_fwd.h"
 #include "MantidGeometry/IDTypes.h"
+#include "ROIType.h"
 
 #include <gmock/gmock.h>
 
@@ -27,12 +28,12 @@ public:
   MOCK_METHOD(MatrixWorkspace_sptr, getSummedWs, (), (const, override));
   MOCK_METHOD(MatrixWorkspace_sptr, getReducedWs, (), (const, override));
   MOCK_METHOD(std::vector<Mantid::detid_t>, getSelectedBanks, (), (const, override));
-  MOCK_METHOD(ProcessingInstructions, getProcessingInstructions, (), (const, override));
+  MOCK_METHOD(ProcessingInstructions, getProcessingInstructions, (ROIType), (const, override));
   MOCK_METHOD(std::optional<double>, getDefaultTheta, (), (const, override));
 
   MOCK_METHOD(void, setTheta, (double), (override));
   MOCK_METHOD(void, setSelectedBanks, (std::vector<Mantid::detid_t>), (override));
-  MOCK_METHOD(void, setSelectedRegion, (Selection const &), (override));
+  MOCK_METHOD(void, setSelectedRegion, (ROIType, Selection const &), (override));
 
   MOCK_METHOD(void, sumBanksAsync, (IJobManager &), (override));
   MOCK_METHOD(void, reduceAsync, (IJobManager &), (override));

--- a/qt/scientific_interfaces/ISISReflectometry/test/Preview/MockPreviewView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Preview/MockPreviewView.h
@@ -35,6 +35,7 @@ public:
   MOCK_METHOD(void, setEditROIState, (bool), (override));
   MOCK_METHOD(void, setAngle, (double), (override));
   MOCK_METHOD(std::vector<size_t>, getSelectedDetectors, (), (const, override));
+  MOCK_METHOD(std::string, getRegionType, (), (const, override));
   MOCK_METHOD(QLayout *, getRegionSelectorLayout, (), (const, override));
   MOCK_METHOD(MantidQt::MantidWidgets::IPlotView *, getLinePlotView, (), (const, override));
 };

--- a/qt/scientific_interfaces/ISISReflectometry/test/Preview/PreviewModelTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Preview/PreviewModelTest.h
@@ -11,6 +11,7 @@
 #include "MantidAPI/WorkspaceGroup.h"
 #include "MantidFrameworkTestHelpers/WorkspaceCreationHelper.h"
 #include "PreviewModel.h"
+#include "ROIType.h"
 #include "test/ReflMockObjects.h"
 
 #include <cxxtest/TestSuite.h>
@@ -82,12 +83,28 @@ public:
     TS_ASSERT_EQUALS(inputRoi, model.getSelectedBanks())
   }
 
-  void test_set_selected_region_converts_to_processing_instructions_string() {
+  void test_set_selected_signal_region_converts_to_processing_instructions_string() {
     PreviewModel model;
     const IPreviewModel::Selection inputRoi{3.6, 11.4};
-    model.setSelectedRegion(inputRoi);
+    model.setSelectedRegion(ROIType::Signal, inputRoi);
     // Start and end are rounded to nearest integer and converted to a string
-    TS_ASSERT_EQUALS(ProcessingInstructions{"4-11"}, model.getProcessingInstructions())
+    TS_ASSERT_EQUALS(ProcessingInstructions{"4-11"}, model.getProcessingInstructions(ROIType::Signal))
+  }
+
+  void test_set_selected_background_region_converts_to_processing_instructions_string() {
+    PreviewModel model;
+    const IPreviewModel::Selection inputRoi{3.6, 11.4};
+    model.setSelectedRegion(ROIType::Background, inputRoi);
+    // Start and end are rounded to nearest integer and converted to a string
+    TS_ASSERT_EQUALS(ProcessingInstructions{"4-11"}, model.getProcessingInstructions(ROIType::Background))
+  }
+
+  void test_set_selected_transmission_region_converts_to_processing_instructions_string() {
+    PreviewModel model;
+    const IPreviewModel::Selection inputRoi{3.6, 11.4};
+    model.setSelectedRegion(ROIType::Transmission, inputRoi);
+    // Start and end are rounded to nearest integer and converted to a string
+    TS_ASSERT_EQUALS(ProcessingInstructions{"4-11"}, model.getProcessingInstructions(ROIType::Transmission))
   }
 
   void test_sum_banks() {

--- a/qt/scientific_interfaces/ISISReflectometry/test/Preview/PreviewPresenterTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Preview/PreviewPresenterTest.h
@@ -230,12 +230,13 @@ public:
     const std::string regionType = roiTypeToString(ROIType::Signal);
     const std::string color = roiTypeToColor(ROIType::Signal);
 
+    EXPECT_CALL(*mockView, getRegionType()).Times(1).WillOnce(Return(regionType));
     expectRectangularROIMode(*mockView);
     EXPECT_CALL(*mockRegionSelector, addRectangularRegion(regionType, color)).Times(1);
     auto presenter = PreviewPresenter(packDeps(mockView.get(), makeModel(), makeJobManager(), makeInstViewModel(),
                                                std::move(mockRegionSelector_uptr)));
 
-    presenter.notifyRectangularROIModeRequested(regionType);
+    presenter.notifyRectangularROIModeRequested();
   }
 
   void test_edit_roi_mode_requested() {

--- a/qt/scientific_interfaces/ISISReflectometry/test/Preview/PreviewPresenterTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Preview/PreviewPresenterTest.h
@@ -424,7 +424,7 @@ private:
     // Check ROI is set
     auto roi = IRegionSelector::Selection{3.5, 11.23};
     EXPECT_CALL(mockRegionSelector, getRegion("Signal")).Times(1).WillOnce(Return(roi));
-    EXPECT_CALL(mockModel, setSelectedRegion(roi)).Times(1);
+    EXPECT_CALL(mockModel, setSelectedRegion(ROIType::Signal, roi)).Times(1);
     // Check theta is set
     auto theta = 0.3;
     EXPECT_CALL(mockView, getAngle()).Times(1).WillOnce(Return(theta));

--- a/qt/scientific_interfaces/ISISReflectometry/test/Preview/PreviewPresenterTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Preview/PreviewPresenterTest.h
@@ -424,8 +424,12 @@ private:
                                                MockJobManager &mockJobManager, MockRegionSelector &mockRegionSelector) {
     // Check ROI is set
     auto roi = IRegionSelector::Selection{3.5, 11.23};
-    EXPECT_CALL(mockRegionSelector, getRegion("Signal")).Times(1).WillOnce(Return(roi));
+    EXPECT_CALL(mockRegionSelector, getRegion(roiTypeToString(ROIType::Signal))).Times(1).WillOnce(Return(roi));
+    EXPECT_CALL(mockRegionSelector, getRegion(roiTypeToString(ROIType::Background))).Times(1).WillOnce(Return(roi));
+    EXPECT_CALL(mockRegionSelector, getRegion(roiTypeToString(ROIType::Transmission))).Times(1).WillOnce(Return(roi));
     EXPECT_CALL(mockModel, setSelectedRegion(ROIType::Signal, roi)).Times(1);
+    EXPECT_CALL(mockModel, setSelectedRegion(ROIType::Background, roi)).Times(1);
+    EXPECT_CALL(mockModel, setSelectedRegion(ROIType::Transmission, roi)).Times(1);
     // Check theta is set
     auto theta = 0.3;
     EXPECT_CALL(mockView, getAngle()).Times(1).WillOnce(Return(theta));

--- a/qt/scientific_interfaces/ISISReflectometry/test/Preview/PreviewPresenterTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Preview/PreviewPresenterTest.h
@@ -17,6 +17,7 @@
 #include "MockPreviewModel.h"
 #include "MockPreviewView.h"
 #include "PreviewPresenter.h"
+#include "ROIType.h"
 #include "TestHelpers/ModelCreationHelper.h"
 
 #include <cxxtest/TestSuite.h>
@@ -226,10 +227,11 @@ public:
     auto mockView = makeView();
     auto mockRegionSelector_uptr = makeRegionSelector();
     auto mockRegionSelector = mockRegionSelector_uptr.get();
-    const std::string regionType = "Test";
+    const std::string regionType = roiTypeToString(ROIType::Signal);
+    const std::string color = roiTypeToColor(ROIType::Signal);
 
     expectRectangularROIMode(*mockView);
-    EXPECT_CALL(*mockRegionSelector, addRectangularRegion(regionType)).Times(1);
+    EXPECT_CALL(*mockRegionSelector, addRectangularRegion(regionType, color)).Times(1);
     auto presenter = PreviewPresenter(packDeps(mockView.get(), makeModel(), makeJobManager(), makeInstViewModel(),
                                                std::move(mockRegionSelector_uptr)));
 

--- a/qt/scientific_interfaces/ISISReflectometry/test/Preview/PreviewPresenterTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Preview/PreviewPresenterTest.h
@@ -226,13 +226,14 @@ public:
     auto mockView = makeView();
     auto mockRegionSelector_uptr = makeRegionSelector();
     auto mockRegionSelector = mockRegionSelector_uptr.get();
+    const std::string regionType = "Test";
 
     expectRectangularROIMode(*mockView);
-    EXPECT_CALL(*mockRegionSelector, addRectangularRegion()).Times(1);
+    EXPECT_CALL(*mockRegionSelector, addRectangularRegion(regionType)).Times(1);
     auto presenter = PreviewPresenter(packDeps(mockView.get(), makeModel(), makeJobManager(), makeInstViewModel(),
                                                std::move(mockRegionSelector_uptr)));
 
-    presenter.notifyRectangularROIModeRequested();
+    presenter.notifyRectangularROIModeRequested(regionType);
   }
 
   void test_edit_roi_mode_requested() {
@@ -420,7 +421,7 @@ private:
                                                MockJobManager &mockJobManager, MockRegionSelector &mockRegionSelector) {
     // Check ROI is set
     auto roi = IRegionSelector::Selection{3.5, 11.23};
-    EXPECT_CALL(mockRegionSelector, getRegion()).Times(1).WillOnce(Return(roi));
+    EXPECT_CALL(mockRegionSelector, getRegion("Signal")).Times(1).WillOnce(Return(roi));
     EXPECT_CALL(mockModel, setSelectedRegion(roi)).Times(1);
     // Check theta is set
     auto theta = 0.3;

--- a/qt/widgets/regionselector/inc/MantidQtWidgets/RegionSelector/IRegionSelector.h
+++ b/qt/widgets/regionselector/inc/MantidQtWidgets/RegionSelector/IRegionSelector.h
@@ -21,7 +21,7 @@ public:
   virtual ~IRegionSelector() = default;
   virtual void subscribe(std::shared_ptr<Mantid::API::RegionSelectorObserver> const &notifyee) = 0;
   virtual void updateWorkspace(Mantid::API::Workspace_sptr const &workspace) = 0;
-  virtual void addRectangularRegion(const std::string &regionType) = 0;
+  virtual void addRectangularRegion(const std::string &regionType, const std::string &color) = 0;
   virtual Selection getRegion(const std::string &regionType) = 0;
   virtual void cancelDrawingRegion() = 0;
 };

--- a/qt/widgets/regionselector/inc/MantidQtWidgets/RegionSelector/IRegionSelector.h
+++ b/qt/widgets/regionselector/inc/MantidQtWidgets/RegionSelector/IRegionSelector.h
@@ -21,8 +21,8 @@ public:
   virtual ~IRegionSelector() = default;
   virtual void subscribe(std::shared_ptr<Mantid::API::RegionSelectorObserver> const &notifyee) = 0;
   virtual void updateWorkspace(Mantid::API::Workspace_sptr const &workspace) = 0;
-  virtual void addRectangularRegion() = 0;
-  virtual Selection getRegion() = 0;
+  virtual void addRectangularRegion(const std::string &regionType) = 0;
+  virtual Selection getRegion(const std::string &regionType) = 0;
   virtual void cancelDrawingRegion() = 0;
 };
 } // namespace MantidQt::Widgets

--- a/qt/widgets/regionselector/inc/MantidQtWidgets/RegionSelector/RegionSelector.h
+++ b/qt/widgets/regionselector/inc/MantidQtWidgets/RegionSelector/RegionSelector.h
@@ -25,7 +25,7 @@ public:
 
   void subscribe(std::shared_ptr<Mantid::API::RegionSelectorObserver> const &notifyee) override;
   void updateWorkspace(Mantid::API::Workspace_sptr const &workspace) override;
-  void addRectangularRegion(const std::string &regionType) override;
+  void addRectangularRegion(const std::string &regionType, const std::string &color) override;
   Selection getRegion(const std::string &regionType) override;
   void cancelDrawingRegion() override;
 

--- a/qt/widgets/regionselector/inc/MantidQtWidgets/RegionSelector/RegionSelector.h
+++ b/qt/widgets/regionselector/inc/MantidQtWidgets/RegionSelector/RegionSelector.h
@@ -25,8 +25,8 @@ public:
 
   void subscribe(std::shared_ptr<Mantid::API::RegionSelectorObserver> const &notifyee) override;
   void updateWorkspace(Mantid::API::Workspace_sptr const &workspace) override;
-  void addRectangularRegion() override;
-  Selection getRegion() override;
+  void addRectangularRegion(const std::string &regionType) override;
+  Selection getRegion(const std::string &regionType) override;
   void cancelDrawingRegion() override;
 
 private:

--- a/qt/widgets/regionselector/src/RegionSelector.cpp
+++ b/qt/widgets/regionselector/src/RegionSelector.cpp
@@ -80,9 +80,9 @@ void RegionSelector::updateWorkspace(Workspace_sptr const &workspace) {
   pyobj().attr("update_workspace")(*boost::python::tuple(), **kwargs);
 }
 
-void RegionSelector::addRectangularRegion() {
+void RegionSelector::addRectangularRegion(const std::string &regionType) {
   GlobalInterpreterLock lock;
-  pyobj().attr("add_rectangular_region")();
+  pyobj().attr("add_rectangular_region")(regionType);
 }
 
 void RegionSelector::cancelDrawingRegion() {
@@ -90,9 +90,9 @@ void RegionSelector::cancelDrawingRegion() {
   pyobj().attr("cancel_drawing_region")();
 }
 
-auto RegionSelector::getRegion() -> Selection {
+auto RegionSelector::getRegion(const std::string &regionType) -> Selection {
   GlobalInterpreterLock lock;
-  auto pyValues = pyobj().attr("get_region")();
+  auto pyValues = pyobj().attr("get_region")(regionType);
   auto result = Selection();
   for (int i = 0; i < len(pyValues); ++i) {
     result.push_back(boost::python::extract<double>(pyValues[i]));

--- a/qt/widgets/regionselector/src/RegionSelector.cpp
+++ b/qt/widgets/regionselector/src/RegionSelector.cpp
@@ -80,9 +80,9 @@ void RegionSelector::updateWorkspace(Workspace_sptr const &workspace) {
   pyobj().attr("update_workspace")(*boost::python::tuple(), **kwargs);
 }
 
-void RegionSelector::addRectangularRegion(const std::string &regionType) {
+void RegionSelector::addRectangularRegion(const std::string &regionType, const std::string &color) {
   GlobalInterpreterLock lock;
-  pyobj().attr("add_rectangular_region")(regionType);
+  pyobj().attr("add_rectangular_region")(regionType, color);
 }
 
 void RegionSelector::cancelDrawingRegion() {

--- a/qt/widgets/regionselector/test/MockRegionSelector.h
+++ b/qt/widgets/regionselector/test/MockRegionSelector.h
@@ -14,7 +14,7 @@ class MockRegionSelector : public IRegionSelector {
 public:
   MOCK_METHOD(void, subscribe, (std::shared_ptr<Mantid::API::RegionSelectorObserver> const &), (override));
   MOCK_METHOD(void, updateWorkspace, (Mantid::API::Workspace_sptr const &workspace), (override));
-  MOCK_METHOD(void, addRectangularRegion, (const std::string &regionType), (override));
+  MOCK_METHOD(void, addRectangularRegion, (const std::string &regionType, const std::string &color), (override));
   MOCK_METHOD(Selection, getRegion, (const std::string &regionType), (override));
   MOCK_METHOD(void, cancelDrawingRegion, (), (override));
 };

--- a/qt/widgets/regionselector/test/MockRegionSelector.h
+++ b/qt/widgets/regionselector/test/MockRegionSelector.h
@@ -14,8 +14,8 @@ class MockRegionSelector : public IRegionSelector {
 public:
   MOCK_METHOD(void, subscribe, (std::shared_ptr<Mantid::API::RegionSelectorObserver> const &), (override));
   MOCK_METHOD(void, updateWorkspace, (Mantid::API::Workspace_sptr const &workspace), (override));
-  MOCK_METHOD(void, addRectangularRegion, (), (override));
-  MOCK_METHOD(Selection, getRegion, (), (override));
+  MOCK_METHOD(void, addRectangularRegion, (const std::string &regionType), (override));
+  MOCK_METHOD(Selection, getRegion, (const std::string &regionType), (override));
   MOCK_METHOD(void, cancelDrawingRegion, (), (override));
 };
 } // namespace MantidQt::Widgets


### PR DESCRIPTION
**Description of work.**
This PR makes it possible to add three different types of ROI: Signal, Background and Transmission. This is done using a QToolButton with a QMenu set. The PR also stores the ProcessingInstructions for each of these regions in the PreviewRow, and passes them through to the RowProcessingAlgorithm.

**To test:**
1. Open ISIS Reflectometry interface
2. Load `INTER45455_inst` in the Preview tab
3. Have a go out creating different types of ROI

Fixes #34175

*This does not require release notes* because **this part of the refl gui is still under development**


<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
