### PR TITLE
Delete old GitHub nightly packages

### DIFF
--- a/buildconfig/Jenkins/Conda/nightly_build_and_deploy.jenkinsfile
+++ b/buildconfig/Jenkins/Conda/nightly_build_and_deploy.jenkinsfile
@@ -212,7 +212,7 @@ pipeline {
           selector: specific('${BUILD_NUMBER}'),
           target: 'standalone-packages',
           flatten: true
-        sh '${WORKSPACE}/buildconfig/Jenkins/Conda/publish-to-github ${WORKSPACE} ${GITHUB_TOKEN} ${GITHUB_RELEASES_REPO} ${GITHUB_RELEASES_TAG} ${WORKSPACE}/standalone-packages/*'
+        sh '${WORKSPACE}/buildconfig/Jenkins/Conda/publish-to-github ${WORKSPACE} ${GITHUB_TOKEN} ${GITHUB_RELEASES_REPO} ${GITHUB_RELEASES_TAG} ${GIT_COMMIT} ${WORKSPACE}/standalone-packages/*'
       }
     }
     stage ('Delete old Conda nightly packages from Anaconda') {

--- a/buildconfig/Jenkins/Conda/publish-to-github
+++ b/buildconfig/Jenkins/Conda/publish-to-github
@@ -51,18 +51,31 @@ conda activate $CONDA_ENV_NAME
 
 # Export token for use by gh to authenticate
 export GITHUB_TOKEN
-# We want to provide a custom label that is a fixed string that both
-#   - better describes which package users should select
-#   - automatically handles deleting old packages
+# We want to provide a custom label that is a fixed string that
+# better describes which package users should select
 for asset in "$@"; do
     if [[ $asset == *.exe ]]; then
       label=MantidWorkbench-Windows
+      asset_query=".*\\\\.exe"
     elif [[ $asset == *.dmg ]]; then
       label=MantidWorkbench-macOS
+      asset_query=".*\\\\.dmg"
     elif [[ $asset == *.tar.xz ]]; then
       label=MantidWorkbench-Linux
-    else
-      echo "Unknown asset type found. Uploading as unlabelled asset."
+      asset_query=".*\\\\.tar.xz"
+      else
+      echo "Unknown asset type found \"${asset}\" Skipping upload."
+      continue
     fi
-    gh release -R $RELEASES_REPO upload --clobber $RELEASES_TAG "$asset#$label"
+
+    # grab name of current uploaded asset so it can be deleted later
+    old_uploaded_asset=$(gh release --repo $RELEASES_REPO view $RELEASES_TAG --json assets --jq ".assets[] | select(.name|test(\"${asset_query}\")) | .name")
+    echo "Uploading $asset, labelled as $asset#$label, to $RELEASES_TAG tag under $RELEASES_REPO"
+    gh release --repo $RELEASES_REPO upload --clobber $RELEASES_TAG "$asset#$label"
+
+    # remove old asset iff the current one uploaded
+    if [[ -n "$old_uploaded_asset" ]]  && [[ $? -eq 0 ]]; then
+      echo "Removing $old_uploaded_asset from $RELEASES_TAG tag under $RELEASES_REPO"
+      gh release --repo $RELEASES_REPO delete-asset --yes $RELEASES_TAG "$old_uploaded_asset"
+    fi
 done

--- a/buildconfig/Jenkins/Conda/publish-to-github
+++ b/buildconfig/Jenkins/Conda/publish-to-github
@@ -1,25 +1,21 @@
 #!/bin/bash -ex
-# This script expects
-#
 # Expected args:
 #   1. WORKSPACE: path to the workspace/source code that this should run inside
 #                 (mantid repo). Windows Caveat: Only use / for this argument do
 #                 not use \\ or \ in the path.
 #   2. TOKEN: Token for uploading to github.com
 #   3. RELEASES_REPO: Name, in owner/reponame format, of repository to publish to
-#   4. RELEASES_TAG GitHub tag to store assets
+#   4. RELEASES_TAG_NAME_NAME GitHub tag name. Creates a release with a tag of this name
+#   5. RELEASES_TAG_SHA Git tag target SHA.
 #   Remainder PACKAGES: A list of args that will be uploaded to github release cloud.
 #
-
 # Parse arguments
 WORKSPACE=$1
-shift
-GITHUB_TOKEN=$1
-shift
-RELEASES_REPO=$1
-shift
-RELEASES_TAG=$1
-shift
+GITHUB_TOKEN=$2
+RELEASES_REPO=$3
+RELEASES_TAG_NAME=$4
+RELEASES_TAG_SHA=$5
+shift 5
 
 # The remaining arguments should be the packages to upload - is there anything?
 if [ $# -eq 0 ]; then
@@ -27,6 +23,13 @@ if [ $# -eq 0 ]; then
     exit 1
 fi
 
+# Shorthand to always set the --repo command for "gh release"
+# All other arguments are passed to the command
+github_release_cmd() {
+  gh release --repo $RELEASES_REPO "$@"
+}
+
+# Setup conda environment for github cli tool
 EXPECTED_MAMBAFORGE_PATH=$WORKSPACE/mambaforge # Install into the WORKSPACE_DIR
 if [[ $OSTYPE == "msys" ]]; then
     EXPECTED_CONDA_PATH=$EXPECTED_MAMBAFORGE_PATH/condabin/mamba.bat
@@ -35,47 +38,63 @@ else
 fi
 CONDA_ENV_NAME=mantid-github-upload
 SCRIPT_DIR=$WORKSPACE/buildconfig/Jenkins/Conda/
-
-# Setup Mambaforge if not already installed
 $SCRIPT_DIR/download-and-install-mambaforge $EXPECTED_MAMBAFORGE_PATH $EXPECTED_CONDA_PATH false
-
-# Remove conda env if it exists
 $EXPECTED_CONDA_PATH env remove -n $CONDA_ENV_NAME
-
-# Create env with the gh github client installed
 $EXPECTED_CONDA_PATH create -n $CONDA_ENV_NAME gh -y
-
-# Activate Conda environment
 . $WORKSPACE/mambaforge/etc/profile.d/conda.sh
 conda activate $CONDA_ENV_NAME
 
-# Export token for use by gh to authenticate
+# Create a release and attach the given assets.
+# The workflow here is attempting ensure there is always something on GitHub. As
+# tags cannot be overwritten we have to delete and recreate the release/tag. If
+# we delete the existing tag/release first and then uploading the new one fails
+# we will be left with nothing on GitHub. For nightly releases we are better atleast
+# leaving the previous nightly in place. The workflow is:
+#  - create new draft release with the suffix -staged
+#  - upload new assets to staged release
+#  - if above is successful delete old release
+#  - rename staged to correct tag/release name
 export GITHUB_TOKEN
-# We want to provide a custom label that is a fixed string that
-# better describes which package users should select
+if [ "$RELEASES_TAG_NAME" == "nightly" ]; then
+  title="Nightly Builds"
+  notes="Use with caution. Not recommended for production use."
+  options="--draft=true --prerelease"
+else
+  title="Release $RELEASES_TAG_NAME"
+  notes=$title
+  options="--draft=true"
+fi
+staged_tag_name=$RELEASES_TAG_NAME-staged
+echo "Creating draft release $staged_tag_name"
+github_release_cmd create $staged_tag_name --title "$title" --notes "$notes" --target $RELEASES_TAG_SHA $options
+# there is a minor lag in creating the release - wait before we upload
+sleep 1
+
+# Provide a custom label that is a fixed string to better describe
+# which package users should select
 for asset in "$@"; do
     if [[ $asset == *.exe ]]; then
       label=MantidWorkbench-Windows
-      asset_query=".*\\\\.exe"
     elif [[ $asset == *.dmg ]]; then
       label=MantidWorkbench-macOS
-      asset_query=".*\\\\.dmg"
     elif [[ $asset == *.tar.xz ]]; then
       label=MantidWorkbench-Linux
-      asset_query=".*\\\\.tar.xz"
       else
       echo "Unknown asset type found \"${asset}\" Skipping upload."
       continue
     fi
-
-    # grab name of current uploaded asset so it can be deleted later
-    old_uploaded_asset=$(gh release --repo $RELEASES_REPO view $RELEASES_TAG --json assets --jq ".assets[] | select(.name|test(\"${asset_query}\")) | .name")
-    echo "Uploading $asset, labelled as $asset#$label, to $RELEASES_TAG tag under $RELEASES_REPO"
-    gh release --repo $RELEASES_REPO upload --clobber $RELEASES_TAG "$asset#$label"
-
-    # remove old asset iff the current one uploaded
-    if [[ -n "$old_uploaded_asset" ]]  && [[ $? -eq 0 ]]; then
-      echo "Removing $old_uploaded_asset from $RELEASES_TAG tag under $RELEASES_REPO"
-      gh release --repo $RELEASES_REPO delete-asset --yes $RELEASES_TAG "$old_uploaded_asset"
-    fi
+    echo "Uploading $asset, labelled as $asset#$label, to $staged_tag_name tag under $RELEASES_REPO"
+    github_release_cmd upload --clobber $staged_tag_name "$asset#$label"
 done
+
+if github_release_cmd view $RELEASES_TAG_NAME >/dev/null; then
+    echo "Removing old tag & release $RELEASES_TAG_NAME"
+    curl -X DELETE -H "Accept: application/vnd.github+json" -H "Authorization: token $GITHUB_TOKEN" https://api.github.com/repos/$RELEASES_REPO/git/refs/tags/$RELEASES_TAG_NAME
+    github_release_cmd delete $RELEASES_TAG_NAME --yes
+fi
+
+echo "Renaming staged release to final $RELEASES_TAG_NAME name"
+if [ "$RELEASES_TAG_NAME" == "nightly" ]; then
+  options="--draft=false"
+fi
+github_release_cmd edit $staged_tag_name --tag $RELEASES_TAG_NAME $options


### PR DESCRIPTION
**Description of work.**

This work ensures that the releases, including nightly, published to GitHub have only one set of assets attached to them.

Previously the script upload would just added to a fixed tag it assumed had been created. In order to also update the tag, mainly for avoiding confusion, we must delete the old tag/release and recreate them as GitHub does not allow editing the tag using the API. The workflow described in the file attempts to ensure a failure of upload does not result in there being nothing left on GitHub.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**

*Please note that this will not work on Windows.*

It is best to test this in an isolated repository to avoid affecting the main nightly build. My tests happened at [martyngigg/sandbox](https://github.com/martyngigg/sandbox). If you do not have a repository then you can create one yourself on GitHub for testing - it does not need to be a mantid one. Add at least two commits to this repository. You will also need a [GitHub access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token). 

* First create some testing assets to upload. We create two sets to first upload one set and test the overwriting with the second. I simply used plain text files to speed up the uploading and changed the date of the filename:
```
mkdir /tmp/packages-old
for name in MantidWorkbenchNightly-6.4.20220727.1203.dmg MantidWorkbenchNightly-6.4.20220727.1203.exe mantidworkbenchnightly-6.4.20220727.1203.tar.xz; do echo $name > /tmp/packages-old/$name; done
mkdir /tmp/packages-new
for name in MantidWorkbenchNightly-6.4.20220728.1203.dmg MantidWorkbenchNightly-6.4.20220728.1203.exe mantidworkbenchnightly-6.4.20220728.1203.tar.xz; do echo $name > /tmp/packages-new/$name; done
```
* Make a note of the two commit most recent commit SHA from the repository
* Upload the "old" packages
```
GITHUB_TOKEN=paste-github-token-in-terminal-here
buildconfig/Jenkins/Conda/publish-to-github $PWD $GITHUB_TOKEN your-username/your-repo-name nightly OLDER_COMMIT_SHA /tmp/packages-old/*
```
* Visit the repository on GitHub and see a new nightly pre-release has been made with the 3 assets you uploaded - check the dates are as you expect. Check the tag corresponds to the SHA you provided.
* Now we pretend a new nightly is to be published and run the scripts on the second set of files we created above
```
buildconfig/Jenkins/Conda/publish-to-github $PWD $GITHUB_TOKEN your-username/your-repo-name nightly NEWER_COMMIT_SHA /tmp/packages-new/*
```
* Again, visit the repository releases and see that there is still only one nightly release but it has the updated assets and updated commit SHA

*There is no associated issue.*

*This does not require release notes* because **it is an internal change.**

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
