### PR TITLE
Visual Indication for selected ROI and implement delete key

### DIFF
--- a/qt/python/mantidqt/mantidqt/widgets/regionselector/presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/regionselector/presenter.py
@@ -19,6 +19,7 @@ from matplotlib.widgets import RectangleSelector
 
 
 class Selector(RectangleSelector):
+    active_handle_alpha = 0.5
     kwargs = {"useblit": False,  # rectangle persists on button release
               "button": [1],
               "minspanx": 5,
@@ -37,6 +38,11 @@ class Selector(RectangleSelector):
 
     def region_type(self):
         return self._region_type
+
+    def set_active(self, active: bool) -> None:
+        """Hide the handles of a selector if it is not active."""
+        self.set_handle_props(alpha=self.active_handle_alpha if active else 0)
+        super().set_active(active)
 
 
 class RegionSelector(ObservingPresenter, SliceViewerBasePresenter):

--- a/qt/python/mantidqt/mantidqt/widgets/regionselector/presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/regionselector/presenter.py
@@ -31,6 +31,7 @@ class Selector(RectangleSelector):
     def __init__(self, region_type: str, color: str, *args):
         if LooseVersion(matplotlib.__version__) >= LooseVersion("3.5.0"):
             self.kwargs["props"] = dict(facecolor="white", edgecolor=color, alpha=0.2, linewidth=2, fill=True)
+            self.kwargs["handle_props"] = dict(markersize=4)
             self.kwargs["drag_from_anywhere"] = True
             self.kwargs["ignore_event_outside"] = True
 

--- a/qt/python/mantidqt/mantidqt/widgets/regionselector/presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/regionselector/presenter.py
@@ -43,7 +43,8 @@ class Selector(RectangleSelector):
 
     def set_active(self, active: bool) -> None:
         """Hide the handles of a selector if it is not active."""
-        self.set_handle_props(alpha=self.active_handle_alpha if active else 0)
+        if LooseVersion(matplotlib.__version__) >= LooseVersion("3.5.0"):
+            self.set_handle_props(alpha=self.active_handle_alpha if active else 0)
         super().set_active(active)
 
 

--- a/qt/python/mantidqt/mantidqt/widgets/regionselector/test/test_regionselector_presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/regionselector/test/test_regionselector_presenter.py
@@ -144,6 +144,44 @@ class RegionSelectorTest(unittest.TestCase):
         selector_one.set_active.assert_has_calls([call(False), call(True)])
         selector_two.set_active.assert_called_once_with(False)
 
+    def test_delete_key_pressed_will_do_nothing_if_no_selectors_exist(self):
+        region_selector = RegionSelector(ws=Mock(), view=Mock())
+
+        event = Mock()
+        event.key = "delete"
+
+        self.assertEqual(0, len(region_selector._selectors))
+        region_selector.key_pressed(event)
+        self.assertEqual(0, len(region_selector._selectors))
+
+    def test_delete_key_pressed_will_do_nothing_if_no_selectors_are_active(self):
+        region_selector, selector_one, selector_two = self._mock_selectors()
+        selector_one.active = False
+        selector_two.active = False
+
+        event = Mock()
+        event.key = "delete"
+
+        self.assertEqual(2, len(region_selector._selectors))
+        region_selector.key_pressed(event)
+        self.assertEqual(2, len(region_selector._selectors))
+
+    def test_delete_key_pressed_will_remove_the_active_selector(self):
+        region_selector, selector_one, selector_two = self._mock_selectors()
+        selector_one.active = False
+        selector_two.active = True
+        selector_two.artists = []
+
+        event = Mock()
+        event.key = "delete"
+
+        self.assertEqual(2, len(region_selector._selectors))
+        region_selector.key_pressed(event)
+        self.assertEqual(1, len(region_selector._selectors))
+
+        selector_two.set_active.assert_called_once_with(False)
+        selector_two.update.assert_called_once_with()
+
     def test_on_rectangle_selected_notifies_observer(self):
         region_selector = RegionSelector(ws=Mock(), view=Mock())
         mock_observer = Mock()

--- a/qt/python/mantidqt/mantidqt/widgets/regionselector/test/test_regionselector_presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/regionselector/test/test_regionselector_presenter.py
@@ -182,6 +182,53 @@ class RegionSelectorTest(unittest.TestCase):
         selector_two.set_active.assert_called_once_with(False)
         selector_two.update.assert_called_once_with()
 
+    def test_mouse_moved_will_not_set_override_cursor_if_no_selectors_exist(self):
+        region_selector = RegionSelector(ws=Mock(), view=Mock())
+        region_selector.view.set_override_cursor = Mock()
+
+        event = Mock()
+        event.xdata, event.ydata = 1.0, 2.0
+
+        region_selector.mouse_moved(event)
+
+        region_selector.view.set_override_cursor.assert_called_once_with(False)
+
+    def test_mouse_moved_will_not_set_override_cursor_if_no_selectors_are_active(self):
+        region_selector, selector_one, selector_two = self._mock_selectors()
+        selector_one.active = False
+        selector_two.active = False
+
+        event = Mock()
+        event.xdata, event.ydata = 5.5, 7.5
+
+        region_selector.mouse_moved(event)
+
+        region_selector.view.set_override_cursor.assert_called_once_with(False)
+
+    def test_mouse_moved_will_not_set_override_cursor_if_not_hovering_over_selector(self):
+        region_selector, selector_one, selector_two = self._mock_selectors()
+        selector_one.active = False
+        selector_two.active = True
+
+        event = Mock()
+        event.xdata, event.ydata = 1.5, 3.5
+
+        region_selector.mouse_moved(event)
+
+        region_selector.view.set_override_cursor.assert_called_once_with(False)
+
+    def test_mouse_moved_will_set_override_cursor_if_hovering_over_active_selector(self):
+        region_selector, selector_one, selector_two = self._mock_selectors()
+        selector_one.active = False
+        selector_two.active = True
+
+        event = Mock()
+        event.xdata, event.ydata = 5.5, 7.5
+
+        region_selector.mouse_moved(event)
+
+        region_selector.view.set_override_cursor.assert_called_once_with(True)
+
     def test_on_rectangle_selected_notifies_observer(self):
         region_selector = RegionSelector(ws=Mock(), view=Mock())
         mock_observer = Mock()

--- a/qt/python/mantidqt/mantidqt/widgets/regionselector/view.py
+++ b/qt/python/mantidqt/mantidqt/widgets/regionselector/view.py
@@ -5,8 +5,9 @@
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
 #  This file is part of the mantid workbench.
-from qtpy.QtWidgets import (QWidget, QHBoxLayout)
 from qtpy.QtCore import Qt
+from qtpy.QtGui import QCursor
+from qtpy.QtWidgets import QApplication, QHBoxLayout, QWidget
 
 from mantidqt.widgets.sliceviewer.views.dataview import SliceViewerDataView
 
@@ -34,3 +35,16 @@ class RegionSelectorView(QWidget):
 
     def create_axes_orthogonal(self, redraw_on_zoom):
         self._data_view.create_axes_orthogonal(redraw_on_zoom=redraw_on_zoom)
+
+    @staticmethod
+    def set_override_cursor(override: bool, override_cursor: Qt.CursorShape = Qt.SizeAllCursor) -> None:
+        """
+        Sets the override cursor if an override cursor doesn't exist. Otherwise, restores the override cursor
+        :param override: A boolean for whether to set the override cursor or not
+        :param override_cursor: The override cursor to use if the override parameter is true
+        """
+        cursor = QApplication.overrideCursor()
+        if override and cursor is None:
+            QApplication.setOverrideCursor(QCursor(override_cursor))
+        elif not override and cursor is not None:
+            QApplication.restoreOverrideCursor()

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/presenters/presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/presenters/presenter.py
@@ -425,6 +425,12 @@ class SliceViewer(ObservingPresenter, SliceViewerBasePresenter):
                 self._peaks_presenter.add_delete_peak(pos)
                 self.view.data_view.canvas.draw_idle()
 
+    def key_pressed(self, event) -> None:
+        pass
+
+    def mouse_moved(self, event) -> None:
+        pass
+
     def deactivate_zoom_pan(self):
         self.view.data_view.deactivate_zoom_pan()
 

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_base_presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_base_presenter.py
@@ -28,6 +28,12 @@ class SliceViewerBasePresenterShim(SliceViewerBasePresenter):
     def canvas_clicked(self, event) -> None:
         pass
 
+    def key_pressed(self, event) -> None:
+        pass
+
+    def mouse_moved(self, event) -> None:
+        pass
+
     def zoom_pan_clicked(self, active) -> None:
         pass
 

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/views/dataview.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/views/dataview.py
@@ -93,6 +93,7 @@ class SliceViewerDataView(QWidget):
         self.canvas.mpl_connect('button_release_event', self.mouse_release)
         self.canvas.mpl_connect('button_press_event', self.presenter.canvas_clicked)
         self.canvas.mpl_connect('key_press_event', self.presenter.key_pressed)
+        self.canvas.mpl_connect('motion_notify_event', self.presenter.mouse_moved)
 
         self.colorbar_label = QLabel("Colormap")
         self.colorbar_layout.addWidget(self.colorbar_label)

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/views/dataview.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/views/dataview.py
@@ -92,6 +92,7 @@ class SliceViewerDataView(QWidget):
         self.canvas = SliceViewerCanvas(self.fig)
         self.canvas.mpl_connect('button_release_event', self.mouse_release)
         self.canvas.mpl_connect('button_press_event', self.presenter.canvas_clicked)
+        self.canvas.mpl_connect('key_press_event', self.presenter.key_pressed)
 
         self.colorbar_label = QLabel("Colormap")
         self.colorbar_layout.addWidget(self.colorbar_label)

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/views/dataviewsubscriber.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/views/dataviewsubscriber.py
@@ -14,6 +14,10 @@ class IDataViewSubscriber(ABC):
         pass
 
     @abstractmethod
+    def key_pressed(self, event) -> None:
+        pass
+
+    @abstractmethod
     def data_limits_changed(self):
         pass
 

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/views/dataviewsubscriber.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/views/dataviewsubscriber.py
@@ -18,6 +18,10 @@ class IDataViewSubscriber(ABC):
         pass
 
     @abstractmethod
+    def mouse_moved(self, event) -> None:
+        pass
+
+    @abstractmethod
     def data_limits_changed(self):
         pass
 


### PR DESCRIPTION
This branch is based off `34175-multiple-roi-types` , so should be merged after #34233
---------------------

**Description of work.**
This PR makes a couple of small improvements:
- There is now a visual indication which ROI is selected. (The handles of a region are made transparent if it is not active)
- The 'Delete' key on the keyboard will delete the currently selected ROI
- The handles on the ROI's have been made smaller in an attempt to help with the resizing of ROI's
- When you hover over a selected ROI, the cursor will change

**To test:**

<!-- Instructions for testing. -->

Fixes #34174

*This does not require release notes* because **this part of the refl gui is still under development**

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
