### PR TITLE
Reflectometry Update Angle button

### DIFF
--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/IPreviewView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/IPreviewView.h
@@ -22,6 +22,7 @@ class PreviewViewSubscriber {
 public:
   virtual ~PreviewViewSubscriber() = default;
   virtual void notifyLoadWorkspaceRequested() = 0;
+  virtual void notifyUpdateAngle() = 0;
 
   virtual void notifyInstViewZoomRequested() = 0;
   virtual void notifyInstViewEditRequested() = 0;
@@ -54,6 +55,7 @@ public:
   virtual void setInstViewToolbarEnabled(bool enable) = 0;
   virtual void setRegionSelectorToolbarEnabled(bool enable) = 0;
   virtual void setAngle(double angle) = 0;
+  virtual void setUpdateAngleButtonEnabled(bool enabled) = 0;
   // Region selector toolbar
   virtual void setEditROIState(bool state) = 0;
   virtual void setRectangularROIState(bool state) = 0;

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.cpp
@@ -94,6 +94,8 @@ void PreviewPresenter::notifyLoadWorkspaceCompleted() {
   runSumBanks();
 }
 
+void PreviewPresenter::notifyUpdateAngle() { runReduction(); }
+
 void PreviewPresenter::notifySumBanksCompleted() {
   plotRegionSelector();
   m_view->setRegionSelectorToolbarEnabled(true);
@@ -189,6 +191,7 @@ void PreviewPresenter::plotLinePlot() {
 void PreviewPresenter::runSumBanks() { m_model->sumBanksAsync(*m_jobManager); }
 
 void PreviewPresenter::runReduction() {
+  m_view->setUpdateAngleButtonEnabled(false);
   // Ensure the angle is up to date
   m_model->setTheta(m_view->getAngle());
   // Perform the reduction

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.cpp
@@ -7,7 +7,6 @@
 
 #include "PreviewPresenter.h"
 #include "MantidAPI/MatrixWorkspace.h"
-#include "MantidKernel/Tolerance.h"
 #include "MantidQtWidgets/Plotting/AxisID.h"
 #include "MantidQtWidgets/RegionSelector/IRegionSelector.h"
 #include "MantidQtWidgets/RegionSelector/RegionSelector.h"
@@ -80,12 +79,9 @@ void PreviewPresenter::notifyLoadWorkspaceCompleted() {
   auto ws = m_model->getLoadedWs();
   assert(ws);
 
-  // Only set the angle to the default if the user hasn't already set it manually
-  if (m_view->getAngle() < Mantid::Kernel::Tolerance) {
-    // Set the angle so that it has a non-zero value when the reduction is run
-    if (auto const theta = m_model->getDefaultTheta()) {
-      m_view->setAngle(*theta);
-    }
+  // Set the angle so that it has a non-zero value when the reduction is run
+  if (auto const theta = m_model->getDefaultTheta()) {
+    m_view->setAngle(*theta);
   }
 
   // Notify the instrument view model that the workspace has changed before we get the surface

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.h
@@ -55,6 +55,7 @@ public:
 
   // PreviewViewSubscriber overrides
   void notifyLoadWorkspaceRequested() override;
+  void notifyUpdateAngle() override;
 
   void notifyInstViewZoomRequested() override;
   void notifyInstViewEditRequested() override;

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewWidget.ui
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewWidget.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>1000</width>
-    <height>870</height>
+    <height>873</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -44,6 +44,13 @@
       <widget class="QLineEdit" name="workspace_line_edit"/>
      </item>
      <item>
+      <widget class="QPushButton" name="load_button">
+       <property name="text">
+        <string>Load</string>
+       </property>
+      </widget>
+     </item>
+     <item>
       <widget class="QLabel" name="angle_label">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
@@ -65,9 +72,12 @@
       <widget class="QDoubleSpinBox" name="angle_spin_box"/>
      </item>
      <item>
-      <widget class="QPushButton" name="load_button">
+      <widget class="QPushButton" name="update_button">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
        <property name="text">
-        <string>Load</string>
+        <string>Update</string>
        </property>
       </widget>
      </item>

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/QtPreviewView.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/QtPreviewView.cpp
@@ -72,6 +72,8 @@ void QtPreviewView::subscribe(PreviewViewSubscriber *notifyee) noexcept { m_noti
 void QtPreviewView::connectSignals() const {
   // Loading section
   connect(m_ui.load_button, SIGNAL(clicked()), this, SLOT(onLoadWorkspaceRequested()));
+  connect(m_ui.update_button, SIGNAL(clicked()), this, SLOT(onUpdateClicked()));
+  connect(m_ui.angle_spin_box, SIGNAL(valueChanged(double)), this, SLOT(onAngleEdited()));
   // Instrument viewer toolbar
   connect(m_ui.iv_zoom_button, SIGNAL(clicked()), this, SLOT(onInstViewZoomClicked()));
   connect(m_ui.iv_edit_button, SIGNAL(clicked()), this, SLOT(onInstViewEditClicked()));
@@ -84,6 +86,7 @@ void QtPreviewView::connectSignals() const {
 }
 
 void QtPreviewView::onLoadWorkspaceRequested() const { m_notifyee->notifyLoadWorkspaceRequested(); }
+void QtPreviewView::onUpdateClicked() const { m_notifyee->notifyUpdateAngle(); }
 
 void QtPreviewView::onInstViewZoomClicked() const { m_notifyee->notifyInstViewZoomRequested(); }
 void QtPreviewView::onInstViewEditClicked() const { m_notifyee->notifyInstViewEditRequested(); }
@@ -100,6 +103,8 @@ void QtPreviewView::onAddRectangularROIClicked(QAction *regionType) const {
 }
 
 void QtPreviewView::onLinePlotExportToAdsClicked() const { m_notifyee->notifyLinePlotExportAdsRequested(); }
+
+void QtPreviewView::onAngleEdited() { m_ui.update_button->setEnabled(true); }
 
 std::string QtPreviewView::getWorkspaceName() const { return m_ui.workspace_line_edit->text().toStdString(); }
 
@@ -148,7 +153,13 @@ void QtPreviewView::setRegionSelectorToolbarEnabled(bool enable) {
   m_ui.rs_rect_select_button->setEnabled(enable);
 }
 
-void QtPreviewView::setAngle(double angle) { m_ui.angle_spin_box->setValue(angle); }
+void QtPreviewView::setAngle(double angle) {
+  m_ui.angle_spin_box->blockSignals(true);
+  m_ui.angle_spin_box->setValue(angle);
+  m_ui.angle_spin_box->blockSignals(false);
+}
+
+void QtPreviewView::setUpdateAngleButtonEnabled(bool enabled) { m_ui.update_button->setEnabled(enabled); }
 
 void QtPreviewView::setEditROIState(bool state) { m_ui.rs_edit_button->setDown(state); }
 

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/QtPreviewView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/QtPreviewView.h
@@ -51,6 +51,7 @@ public:
   void setInstViewToolbarEnabled(bool enable) override;
   void setRegionSelectorToolbarEnabled(bool enable) override;
   void setAngle(double angle) override;
+  void setUpdateAngleButtonEnabled(bool enable) override;
   // Region selector toolbar
   void setEditROIState(bool state) override;
   void setRectangularROIState(bool state) override;
@@ -72,6 +73,7 @@ private:
 
 private slots:
   void onLoadWorkspaceRequested() const;
+  void onUpdateClicked() const;
   void onInstViewSelectRectClicked() const;
   void onInstViewZoomClicked() const;
   void onInstViewEditClicked() const;
@@ -80,5 +82,6 @@ private slots:
   void onLinePlotExportToAdsClicked() const;
   void onEditROIClicked() const;
   void onAddRectangularROIClicked(QAction *regionType) const;
+  void onAngleEdited();
 };
 } // namespace MantidQt::CustomInterfaces::ISISReflectometry

--- a/qt/scientific_interfaces/ISISReflectometry/test/Preview/MockPreviewView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Preview/MockPreviewView.h
@@ -34,6 +34,7 @@ public:
   MOCK_METHOD(void, setRectangularROIState, (bool), (override));
   MOCK_METHOD(void, setEditROIState, (bool), (override));
   MOCK_METHOD(void, setAngle, (double), (override));
+  MOCK_METHOD(void, setUpdateAngleButtonEnabled, (bool), (override));
   MOCK_METHOD(std::vector<size_t>, getSelectedDetectors, (), (const, override));
   MOCK_METHOD(std::string, getRegionType, (), (const, override));
   MOCK_METHOD(QLayout *, getRegionSelectorLayout, (), (const, override));

--- a/qt/scientific_interfaces/ISISReflectometry/test/Preview/PreviewPresenterTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Preview/PreviewPresenterTest.h
@@ -128,22 +128,11 @@ public:
     presenter.notifyLoadWorkspaceCompleted();
   }
 
-  void test_angle_is_set_if_it_equals_zero() {
+  void test_angle_is_set_when_workspace_loaded() {
     auto mockModel = makeModel();
     auto mockView = std::make_unique<MockPreviewView>();
 
     expectLoadWorkspaceCompletedUpdatesAngle(*mockView, *mockModel);
-
-    auto deps = packDeps(mockView.get(), std::move(mockModel));
-    auto presenter = PreviewPresenter(std::move(deps));
-    presenter.notifyLoadWorkspaceCompleted();
-  }
-
-  void test_angle_is_not_set_if_already_set_manually() {
-    auto mockModel = makeModel();
-    auto mockView = std::make_unique<MockPreviewView>();
-
-    expectLoadWorkspaceCompletedDoesNotUpdateAngle(*mockView, *mockModel);
 
     auto deps = packDeps(mockView.get(), std::move(mockModel));
     auto presenter = PreviewPresenter(std::move(deps));
@@ -339,19 +328,8 @@ private:
     auto angle = 2.3;
 
     EXPECT_CALL(mockModel, getLoadedWs()).Times(1).WillOnce(Return(ws));
-    EXPECT_CALL(mockView, getAngle()).Times(1).WillOnce(Return(0.0));
     EXPECT_CALL(mockModel, getDefaultTheta()).Times(1).WillOnce(Return(angle));
     EXPECT_CALL(mockView, setAngle(angle)).Times(1);
-  }
-
-  void expectLoadWorkspaceCompletedDoesNotUpdateAngle(MockPreviewView &mockView, MockPreviewModel &mockModel) {
-    auto ws = WorkspaceCreationHelper::create2DWorkspace(1, 1);
-    auto angle = 2.3;
-
-    EXPECT_CALL(mockModel, getLoadedWs()).Times(1).WillOnce(Return(ws));
-    EXPECT_CALL(mockView, getAngle()).Times(1).WillOnce(Return(angle));
-    EXPECT_CALL(mockModel, getDefaultTheta()).Times(0);
-    EXPECT_CALL(mockView, setAngle(_)).Times(0);
   }
 
   void expectInstViewModelUpdatedWithLoadedWorkspace(MockPreviewModel &mockModel,


### PR DESCRIPTION
**Description of work.**
This PR adds an Update button to the Refl preview tab which runs a reduction. The button is only enabled after the user manually changes the angle. It will be disabled if there is no need to run another reduction.

**To test:**

<!-- Instructions for testing. -->

Part of #34220

*This does not require release notes* because **fill in an explanation of why**

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
