### PR TITLE
Added check for ties in free parameter detection in the CEF two step fitting

### DIFF
--- a/docs/source/release/v6.5.0/Direct_Geometry/CrystalField/Bugfixes/34244.rst
+++ b/docs/source/release/v6.5.0/Direct_Geometry/CrystalField/Bugfixes/34244.rst
@@ -1,0 +1,1 @@
+- Fix for bug that caused runtime errors when trying to fix a tied parameter in the two step fitting process.

--- a/scripts/Inelastic/CrystalField/fitting.py
+++ b/scripts/Inelastic/CrystalField/fitting.py
@@ -1497,7 +1497,7 @@ class CrystalFieldFit(object):
             fun = self._function
         for par_id in [id for id in range(fun.nParams()) if not fun.isFixed(id)]:
             parName = fun.getParamName(par_id)
-            if parName in CrystalField.field_parameter_names or "IntensityScaling" in parName:
+            if (parName in CrystalField.field_parameter_names or "IntensityScaling" in parName) and parName not in fun.getTies():
                 self._free_cef_parameters.append(par_id)
 
     def estimate_parameters(self, EnergySplitting, Parameters, **kwargs):


### PR DESCRIPTION
**Description of work.**

Added an extra check for ties when determining free CEF parameters. For ties between two parameters it was possible to falsely detect one as free before. This leads to runtime errors when trying to fix a tied parameter during two step fitting.

**To test:**

Run script from https://github.com/mantidproject/mantid/issues/34243

Fixes #34243 

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
