### PR TITLE
Added alternative option for gofit installation to CEF docs

### DIFF
--- a/docs/source/interfaces/direct/Crystal Field Python Interface.rst
+++ b/docs/source/interfaces/direct/Crystal Field Python Interface.rst
@@ -427,8 +427,17 @@ optimization of parameters using a non-linear least squares cost function. For m
 The GOFit package contains `three optimization algorithms <https://github.com/ralna/GOFit/blob/master/docs/algorithms.md>`_ called ``regularisation``, ``multistart`` and
 ``alternating``. Please note that the fitting process for ``multistart`` and ``alternating`` can be slow due to the residuals being evaluated in python.
 
-Before you can use the GOFit package in Mantid, you will need to ``pip install gofit`` into your environment because it is an external dependency. Once installed,
-it should be possible to import the package and perform a fit using the ``regularisation`` algorithm by passing a GOFit callable into the Crystal Field API::
+Before you can use the GOFit package in Mantid, you will need to ``pip install gofit`` into your environment because it is an external dependency. Alternatively, run the
+following code in the Mantid workbench script window::
+
+    import subprocess, sys
+    rv = subprocess.run([sys.executable, '-m', 'pip', 'install', '--user', 'gofit'], capture_output=True)
+    print(rv.stdout.decode())
+    print(rv.stderr.decode())
+
+Mantid has to be restarted for the changes to take effect. Please note that the script above requires Python 3.7 or higher.
+
+Once installed, it should be possible to import the package and perform a fit using the ``regularisation`` algorithm by passing a GOFit callable into the Crystal Field API::
 
     import gofit
     fit.gofit(algorithm_callable=gofit.regularisation, jacobian=True, maxit=500)


### PR DESCRIPTION
**Description of work.**

To run gofit fitting in the CEF interface gofit has to be installed first. One option is to use pip install directly. This update describes an alternative option for the necessary gofit installation.

**To test:**

Read the instructions and check for spelling errors and grammar mistake. Follow the instructions to check whether they make sense.

Fixes #34242

*This does not require release notes* because it is a small change in the documentation for a new feature.

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
