### PR TITLE
Link preview and batch presenters in refl GUI

### DIFF
--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchPresenter.cpp
@@ -55,6 +55,7 @@ BatchPresenter::BatchPresenter(IBatchView *view, std::unique_ptr<IBatch> model, 
   m_experimentPresenter->acceptMainPresenter(this);
   m_instrumentPresenter->acceptMainPresenter(this);
   m_runsPresenter->acceptMainPresenter(this);
+  m_previewPresenter->acceptMainPresenter(this);
 
   m_unsavedBatchFlag = false;
 
@@ -182,6 +183,7 @@ void BatchPresenter::resumeReduction() {
 
 void BatchPresenter::notifyReductionResumed() {
   // Notify child presenters
+  m_previewPresenter->notifyReductionResumed();
   m_savePresenter->notifyReductionResumed();
   m_eventPresenter->notifyReductionResumed();
   m_experimentPresenter->notifyReductionResumed();
@@ -196,6 +198,7 @@ void BatchPresenter::notifyReductionPaused() {
   // Update the model
   m_jobManager->notifyReductionPaused();
   // Notify child presenters
+  m_previewPresenter->notifyReductionPaused();
   m_savePresenter->notifyReductionPaused();
   m_eventPresenter->notifyReductionPaused();
   m_experimentPresenter->notifyReductionPaused();
@@ -227,6 +230,7 @@ void BatchPresenter::resumeAutoreduction() {
 
 void BatchPresenter::notifyAutoreductionResumed() {
   // Notify child presenters
+  m_previewPresenter->notifyAutoreductionResumed();
   m_savePresenter->notifyAutoreductionResumed();
   m_eventPresenter->notifyAutoreductionResumed();
   m_experimentPresenter->notifyAutoreductionResumed();
@@ -248,6 +252,7 @@ void BatchPresenter::pauseAutoreduction() {
 
 void BatchPresenter::notifyAutoreductionPaused() {
   // Notify child presenters
+  m_previewPresenter->notifyAutoreductionPaused();
   m_savePresenter->notifyAutoreductionPaused();
   m_eventPresenter->notifyAutoreductionPaused();
   m_experimentPresenter->notifyAutoreductionPaused();

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/IPreviewPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/IPreviewPresenter.h
@@ -7,8 +7,16 @@
 #pragma once
 
 namespace MantidQt::CustomInterfaces::ISISReflectometry {
+class IBatchPresenter;
+
 class IPreviewPresenter {
 public:
   virtual ~IPreviewPresenter() = default;
+
+  virtual void acceptMainPresenter(IBatchPresenter *mainPresenter) = 0;
+  virtual void notifyReductionResumed() = 0;
+  virtual void notifyReductionPaused() = 0;
+  virtual void notifyAutoreductionResumed() = 0;
+  virtual void notifyAutoreductionPaused() = 0;
 };
 } // namespace MantidQt::CustomInterfaces::ISISReflectometry

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/IPreviewView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/IPreviewView.h
@@ -18,9 +18,14 @@ class IPlotView;
 }
 
 namespace MantidQt::CustomInterfaces::ISISReflectometry {
+class IBatchPresenter;
+
 class PreviewViewSubscriber {
 public:
   virtual ~PreviewViewSubscriber() = default;
+
+  virtual void acceptMainPresenter(IBatchPresenter *mainPresenter) = 0;
+
   virtual void notifyLoadWorkspaceRequested() = 0;
 
   virtual void notifyInstViewZoomRequested() = 0;
@@ -39,6 +44,9 @@ class IPreviewView {
 public:
   virtual ~IPreviewView() = default;
   virtual void subscribe(PreviewViewSubscriber *notifyee) noexcept = 0;
+  virtual void enableApplyButton() = 0;
+  virtual void disableApplyButton() = 0;
+
   virtual std::string getWorkspaceName() const = 0;
   virtual double getAngle() const = 0;
   // Plotting

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.cpp
@@ -6,6 +6,7 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 
 #include "PreviewPresenter.h"
+#include "GUI/Batch/IBatchPresenter.h"
 #include "MantidAPI/MatrixWorkspace.h"
 #include "MantidKernel/Tolerance.h"
 #include "MantidQtWidgets/Plotting/AxisID.h"
@@ -53,6 +54,24 @@ PreviewPresenter::PreviewPresenter(Dependencies dependencies)
   m_plotPresenter->setScaleLog(AxisID::YLeft);
   m_plotPresenter->setScaleLog(AxisID::XBottom);
   m_plotPresenter->setPlotErrorBars(true);
+}
+
+void PreviewPresenter::acceptMainPresenter(IBatchPresenter *mainPresenter) { m_mainPresenter = mainPresenter; }
+
+void PreviewPresenter::notifyReductionResumed() { updateWidgetEnabledState(); }
+
+void PreviewPresenter::notifyReductionPaused() { updateWidgetEnabledState(); }
+
+void PreviewPresenter::notifyAutoreductionResumed() { updateWidgetEnabledState(); }
+
+void PreviewPresenter::notifyAutoreductionPaused() { updateWidgetEnabledState(); }
+
+void PreviewPresenter::updateWidgetEnabledState() {
+  if (m_mainPresenter->isProcessing() || m_mainPresenter->isAutoreducing()) {
+    m_view->disableApplyButton();
+  } else {
+    m_view->enableApplyButton();
+  }
 }
 
 /** Notification received when the user has requested to load a workspace. If it already exists in the ADS

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.h
@@ -22,6 +22,7 @@ class IRegionSelector;
 }
 
 namespace MantidQt::CustomInterfaces::ISISReflectometry {
+class IBatchPresenter;
 
 class MANTIDQT_ISISREFLECTOMETRY_DLL PreviewPresenter : public IPreviewPresenter,
                                                         public PreviewViewSubscriber,
@@ -53,6 +54,13 @@ public:
   PreviewPresenter(Dependencies dependencies);
   virtual ~PreviewPresenter() = default;
 
+  // IPreviewPresenter overrides
+  void acceptMainPresenter(IBatchPresenter *mainPresenter) override;
+  void notifyReductionResumed() override;
+  void notifyReductionPaused() override;
+  void notifyAutoreductionResumed() override;
+  void notifyAutoreductionPaused() override;
+
   // PreviewViewSubscriber overrides
   void notifyLoadWorkspaceRequested() override;
 
@@ -77,12 +85,15 @@ public:
 
 private:
   IPreviewView *m_view{nullptr};
+  IBatchPresenter *m_mainPresenter{nullptr};
   std::unique_ptr<IPreviewModel> m_model;
   std::unique_ptr<IJobManager> m_jobManager;
   std::unique_ptr<IInstViewModel> m_instViewModel;
   std::unique_ptr<MantidQt::Widgets::IRegionSelector> m_regionSelector;
   std::unique_ptr<MantidQt::MantidWidgets::PlotPresenter> m_plotPresenter;
   std::shared_ptr<StubRegionObserver> m_stubRegionObserver;
+
+  void updateWidgetEnabledState();
 
   void plotInstView();
   void plotRegionSelector();

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/QtPreviewView.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/QtPreviewView.cpp
@@ -69,6 +69,10 @@ void QtPreviewView::setupSelectRegionTypes() {
 
 void QtPreviewView::subscribe(PreviewViewSubscriber *notifyee) noexcept { m_notifyee = notifyee; }
 
+void QtPreviewView::enableApplyButton() { m_ui.pushButton_3->setEnabled(true); }
+
+void QtPreviewView::disableApplyButton() { m_ui.pushButton_3->setEnabled(false); }
+
 void QtPreviewView::connectSignals() const {
   // Loading section
   connect(m_ui.load_button, SIGNAL(clicked()), this, SLOT(onLoadWorkspaceRequested()));

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/QtPreviewView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/QtPreviewView.h
@@ -35,6 +35,8 @@ public:
   QtPreviewView(QWidget *parent = nullptr);
 
   void subscribe(PreviewViewSubscriber *notifyee) noexcept override;
+  void enableApplyButton() override;
+  void disableApplyButton() override;
 
   std::string getWorkspaceName() const override;
   double getAngle() const override;

--- a/qt/scientific_interfaces/ISISReflectometry/test/Batch/BatchPresenterTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Batch/BatchPresenterTest.h
@@ -632,6 +632,7 @@ private:
   }
 
   void expectReductionResumed() {
+    EXPECT_CALL(*m_previewPresenter, notifyReductionResumed()).Times(1);
     EXPECT_CALL(*m_savePresenter, notifyReductionResumed()).Times(1);
     EXPECT_CALL(*m_eventPresenter, notifyReductionResumed()).Times(1);
     EXPECT_CALL(*m_experimentPresenter, notifyReductionResumed()).Times(1);
@@ -641,6 +642,7 @@ private:
   }
 
   void expectReductionPaused() {
+    EXPECT_CALL(*m_previewPresenter, notifyReductionPaused()).Times(1);
     EXPECT_CALL(*m_savePresenter, notifyReductionPaused()).Times(1);
     EXPECT_CALL(*m_eventPresenter, notifyReductionPaused()).Times(1);
     EXPECT_CALL(*m_experimentPresenter, notifyReductionPaused()).Times(1);
@@ -649,6 +651,7 @@ private:
   }
 
   void expectAutoreductionResumed() {
+    EXPECT_CALL(*m_previewPresenter, notifyAutoreductionResumed()).Times(1);
     EXPECT_CALL(*m_savePresenter, notifyAutoreductionResumed()).Times(1);
     EXPECT_CALL(*m_eventPresenter, notifyAutoreductionResumed()).Times(1);
     EXPECT_CALL(*m_experimentPresenter, notifyAutoreductionResumed()).Times(1);
@@ -659,6 +662,7 @@ private:
   }
 
   void expectAutoreductionPaused() {
+    EXPECT_CALL(*m_previewPresenter, notifyAutoreductionPaused()).Times(1);
     EXPECT_CALL(*m_savePresenter, notifyAutoreductionPaused()).Times(1);
     EXPECT_CALL(*m_eventPresenter, notifyAutoreductionPaused()).Times(1);
     EXPECT_CALL(*m_experimentPresenter, notifyAutoreductionPaused()).Times(1);

--- a/qt/scientific_interfaces/ISISReflectometry/test/Preview/MockPreviewPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Preview/MockPreviewPresenter.h
@@ -12,5 +12,12 @@
 
 namespace MantidQt::CustomInterfaces::ISISReflectometry {
 
-class MockPreviewPresenter : public IPreviewPresenter {};
+class MockPreviewPresenter : public IPreviewPresenter {
+public:
+  MOCK_METHOD(void, acceptMainPresenter, (IBatchPresenter *), (override));
+  MOCK_METHOD(void, notifyReductionResumed, (), (override));
+  MOCK_METHOD(void, notifyReductionPaused, (), (override));
+  MOCK_METHOD(void, notifyAutoreductionResumed, (), (override));
+  MOCK_METHOD(void, notifyAutoreductionPaused, (), (override));
+};
 } // namespace MantidQt::CustomInterfaces::ISISReflectometry

--- a/qt/scientific_interfaces/ISISReflectometry/test/Preview/MockPreviewView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Preview/MockPreviewView.h
@@ -19,6 +19,8 @@ namespace MantidQt::CustomInterfaces::ISISReflectometry {
 class MockPreviewView : public IPreviewView {
 public:
   MOCK_METHOD(void, subscribe, (PreviewViewSubscriber *), (noexcept, override));
+  MOCK_METHOD(void, enableApplyButton, (), (override));
+  MOCK_METHOD(void, disableApplyButton, (), (override));
   MOCK_METHOD(std::string, getWorkspaceName, (), (const, override));
   MOCK_METHOD(double, getAngle, (), (const, override));
   MOCK_METHOD(void, plotInstView,

--- a/qt/scientific_interfaces/ISISReflectometry/test/Preview/PreviewPresenterTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Preview/PreviewPresenterTest.h
@@ -36,6 +36,7 @@ using MantidQt::MantidWidgets::AxisID;
 using MantidQt::MantidWidgets::MockPlotPresenter;
 
 using ::testing::_;
+using ::testing::AtLeast;
 using ::testing::ByRef;
 using ::testing::Eq;
 using ::testing::NiceMock;
@@ -284,6 +285,54 @@ public:
     presenter.notifyReductionCompleted();
   }
 
+  void test_notify_reduction_resumed_disables_view() {
+    auto mockView = makeView();
+    auto mainPresenter = MockBatchPresenter();
+
+    expectProcessingEnabled(mainPresenter);
+    expectApplyButtonDisabled(*mockView);
+
+    auto presenter = PreviewPresenter(packDeps(mockView.get()));
+    presenter.acceptMainPresenter(&mainPresenter);
+    presenter.notifyReductionResumed();
+  }
+
+  void test_notify_reduction_paused_enables_view() {
+    auto mockView = makeView();
+    auto mainPresenter = MockBatchPresenter();
+
+    expectProcessingDisabled(mainPresenter);
+    expectApplyButtonEnabled(*mockView);
+
+    auto presenter = PreviewPresenter(packDeps(mockView.get()));
+    presenter.acceptMainPresenter(&mainPresenter);
+    presenter.notifyReductionPaused();
+  }
+
+  void test_notify_autoreduction_resumed_disables_view() {
+    auto mockView = makeView();
+    auto mainPresenter = MockBatchPresenter();
+
+    expectAutoreducingEnabled(mainPresenter);
+    expectApplyButtonDisabled(*mockView);
+
+    auto presenter = PreviewPresenter(packDeps(mockView.get()));
+    presenter.acceptMainPresenter(&mainPresenter);
+    presenter.notifyAutoreductionResumed();
+  }
+
+  void test_notify_autoreduction_paused_enables_view() {
+    auto mockView = makeView();
+    auto mainPresenter = MockBatchPresenter();
+
+    expectAutoreducingDisabled(mainPresenter);
+    expectApplyButtonEnabled(*mockView);
+
+    auto presenter = PreviewPresenter(packDeps(mockView.get()));
+    presenter.acceptMainPresenter(&mainPresenter);
+    presenter.notifyAutoreductionPaused();
+  }
+
 private:
   MockViewT makeView() {
     auto mockView = std::make_unique<MockPreviewView>();
@@ -436,5 +485,25 @@ private:
     EXPECT_CALL(mockModel, setTheta(theta)).Times(1);
     // Check reduction is executed
     EXPECT_CALL(mockModel, reduceAsync(Ref(mockJobManager))).Times(1);
+  }
+
+  void expectApplyButtonDisabled(MockPreviewView &mockView) { EXPECT_CALL(mockView, disableApplyButton()).Times(1); }
+
+  void expectApplyButtonEnabled(MockPreviewView &mockView) { EXPECT_CALL(mockView, enableApplyButton()).Times(1); }
+
+  void expectProcessingEnabled(MockBatchPresenter &mainPresenter) {
+    EXPECT_CALL(mainPresenter, isProcessing()).Times(AtLeast(1)).WillRepeatedly(Return(true));
+  }
+
+  void expectProcessingDisabled(MockBatchPresenter &mainPresenter) {
+    EXPECT_CALL(mainPresenter, isProcessing()).Times(AtLeast(1)).WillRepeatedly(Return(false));
+  }
+
+  void expectAutoreducingEnabled(MockBatchPresenter &mainPresenter) {
+    EXPECT_CALL(mainPresenter, isAutoreducing()).Times(AtLeast(1)).WillRepeatedly(Return(true));
+  }
+
+  void expectAutoreducingDisabled(MockBatchPresenter &mainPresenter) {
+    EXPECT_CALL(mainPresenter, isAutoreducing()).Times(AtLeast(1)).WillRepeatedly(Return(false));
   }
 };


### PR DESCRIPTION
This PR adds a pointer to the main (batch) presenter from the preview presenter using a subscriber pattern, similarly to the other tabs in the GUI.

This is part of work in progress for #31069, and in future PRs this mechanism will be used to send a notification to the preview presenter when the Apply button is clicked.

Notifications have been added from the batch to the preview presenter when processing is started/paused so that the Apply button can be disabled. This will be necessary (when the Apply button is implemented) to ensure experiment settings are not changed during processing.

Part of #34240

**To test:**

Must be tested in a debug build and have the ISIS archive enabled.

- Ensure this workspace is loaded or is in your load path: [INTER45455_inst.zip](https://github.com/mantidproject/mantid/files/7504266/INTER45455_inst.zip)
- Open the ISIS Reflectometry GUI
- Set instrument to `INTER`, investigation ID to `1120015` and cycle to `11_3` and click Autoprocess - the table should be populated and start processing (there may be some lag while it's loading runs).
- Select the Preview tab. The Apply button should be greyed out.
- Type in `INTER45455_inst`, set the angle to `1`, and click Load. The instrument view plot should display the data. This is just to check that the rest of this tab is still usable.
- Back on the Runs tab click Pause. The Apply button on the Preview tab should be enabled.
- On the Runs tab click Process - now it should be disabled again; and again click Pause and it should be enabled.

*This does not require release notes* because **the Preview tab is work in progress and is not exposed in the release build**


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
