### PR TITLE
Masked bins flag needs checking after cropping

### DIFF
--- a/Framework/API/inc/MantidAPI/MatrixWorkspace.h
+++ b/Framework/API/inc/MantidAPI/MatrixWorkspace.h
@@ -352,7 +352,7 @@ public:
   const MaskList &maskedBins(const size_t &workspaceIndex) const;
   std::vector<size_t> maskedBinsIndices(const size_t &workspaceIndex) const;
   void setMaskedBins(const size_t workspaceIndex, const MaskList &maskedBins);
-  void setUnmaskedIndex(const size_t workspaceIndex);
+  void setUnmaskedBins(const size_t workspaceIndex);
 
   // Methods handling the internal monitor workspace
   virtual void setMonitorWorkspace(const std::shared_ptr<MatrixWorkspace> &monitorWS);

--- a/Framework/API/inc/MantidAPI/MatrixWorkspace.h
+++ b/Framework/API/inc/MantidAPI/MatrixWorkspace.h
@@ -352,6 +352,7 @@ public:
   const MaskList &maskedBins(const size_t &workspaceIndex) const;
   std::vector<size_t> maskedBinsIndices(const size_t &workspaceIndex) const;
   void setMaskedBins(const size_t workspaceIndex, const MaskList &maskedBins);
+  void setUnmaskedIndex(const size_t workspaceIndex);
 
   // Methods handling the internal monitor workspace
   virtual void setMonitorWorkspace(const std::shared_ptr<MatrixWorkspace> &monitorWS);

--- a/Framework/API/src/MatrixWorkspace.cpp
+++ b/Framework/API/src/MatrixWorkspace.cpp
@@ -1242,7 +1242,7 @@ void MatrixWorkspace::setMaskedBins(const size_t workspaceIndex, const MaskList 
  *
  * @param workspaceIndex workspace index to be unmasked
  */
-void MatrixWorkspace::setUnmaskedIndex(const size_t workspaceIndex) { m_masks.erase(workspaceIndex); }
+void MatrixWorkspace::setUnmaskedBins(const size_t workspaceIndex) { m_masks.erase(workspaceIndex); }
 
 /** Sets the internal monitor workspace to the provided workspace.
  *  This method is intended for use by data-loading algorithms.

--- a/Framework/API/src/MatrixWorkspace.cpp
+++ b/Framework/API/src/MatrixWorkspace.cpp
@@ -1237,6 +1237,13 @@ void MatrixWorkspace::setMaskedBins(const size_t workspaceIndex, const MaskList 
   m_masks[workspaceIndex] = maskedBins;
 }
 
+/**
+ * Removes the mask from an index. Not thread safe.
+ *
+ * @param workspaceIndex workspace index to be unmasked
+ */
+void MatrixWorkspace::setUnmaskedIndex(const size_t workspaceIndex) { m_masks.erase(workspaceIndex); }
+
 /** Sets the internal monitor workspace to the provided workspace.
  *  This method is intended for use by data-loading algorithms.
  *  Note that no checking is performed as to whether this workspace actually

--- a/Framework/Algorithms/src/ExtractSpectra.cpp
+++ b/Framework/Algorithms/src/ExtractSpectra.cpp
@@ -248,7 +248,7 @@ void ExtractSpectra::propagateBinMasking(MatrixWorkspace &workspace, const int i
     if (filteredMask.size() > 0)
       workspace.setMaskedBins(i, filteredMask);
     else
-      workspace.setUnmaskedIndex(i);
+      workspace.setUnmaskedBins(i);
   }
 }
 

--- a/Framework/Algorithms/src/ExtractSpectra.cpp
+++ b/Framework/Algorithms/src/ExtractSpectra.cpp
@@ -245,7 +245,10 @@ void ExtractSpectra::propagateBinMasking(MatrixWorkspace &workspace, const int i
       if (maskIndex >= m_minX && maskIndex < m_maxX - m_histogram)
         filteredMask[maskIndex - m_minX] = mask.second;
     }
-    workspace.setMaskedBins(i, filteredMask);
+    if (filteredMask.size() > 0)
+      workspace.setMaskedBins(i, filteredMask);
+    else
+      workspace.setUnmaskedIndex(i);
   }
 }
 

--- a/docs/source/release/v6.5.0/Framework/Algorithms/Bugfixes/33556.rst
+++ b/docs/source/release/v6.5.0/Framework/Algorithms/Bugfixes/33556.rst
@@ -1,0 +1,1 @@
+- :ref:`ExtractSpectra <algm-ExtractSpectra>` now checks if the bins flagged as masked are still there after processing, and if they are not, the masking flag is unchecked for that spectrum.


### PR DESCRIPTION
**Description of work.**

This PR implements a proposed fix to the issue related to masked bins flag never being reset, even if masked bins were cropped away from the workspace. A new function of the `MatrixWorkspace`, `setUnmaskedIndex`, allows removing a key related to a workspace index one wants to 'unflag' as masked. The issue with cropping out the masked bins is fixed by better controlling propagation of the mask flags: they are assigned only if the length of the list of remaining masked bins in a particular spectrum is non-zero, otherwise, the masked flag is removed.  

**To test:**
1. Run the example from the linked issue:

```
# import mantid algorithms, numpy and matplotlib
from mantid.simpleapi import *
import matplotlib.pyplot as plt
import numpy as np

ws = CreateSampleWorkspace(NumBanks=1,BankPixelWidth=1)
wsmasked = MaskBins(ws, 0, 1000)

print(wsmasked.hasMaskedBins(0))
print(wsmasked.maskedBinsIndices(0))

wscropped = CropWorkspace(wsmasked, XMin=1100)

print(wscropped.hasMaskedBins(0))
try:
    print(wscropped.maskedBinsIndices(0)) 
except RuntimeError:
    print("No masked bin indices in the cropped workspace.")

# Executing this will no longer block
test = Rebin(wscropped, Params=1000)
```

2. The has masked bins flag for the cropped workspace should return false, and thus a `RuntimeError` should be raised when calling `maskedBinsIndices(workspace_index)`.
3. Rebinning should execute without an issue.

Fixes #33556 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->


Release note added.

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
