### PR TITLE
Clear plots if processing fails in preview tab

### DIFF
--- a/qt/python/mantidqt/mantidqt/widgets/regionselector/presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/regionselector/presenter.py
@@ -110,6 +110,11 @@ class RegionSelector(ObservingPresenter, SliceViewerBasePresenter):
     def nonorthogonal_axes(self, state: bool) -> None:
         pass
 
+    def clear_workspace(self):
+        self._selectors = []
+        self.model.ws = None
+        self.view.clear_figure()
+
     def update_workspace(self, workspace) -> None:
         if WorkspaceInfo.get_ws_type(workspace) != WS_TYPE.MATRIX:
             raise NotImplementedError("Only Matrix Workspaces are currently supported by the region selector.")

--- a/qt/python/mantidqt/mantidqt/widgets/regionselector/test/test_regionselector_presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/regionselector/test/test_regionselector_presenter.py
@@ -87,6 +87,27 @@ class RegionSelectorTest(unittest.TestCase):
         self.assertFalse(region_selector._selectors[0].active)
         self.assertTrue(region_selector._selectors[1].active)
 
+    def test_clear_workspace_will_clear_all_the_selectors_and_model_workspace(self):
+        region_selector = RegionSelector(view=Mock())
+        mock_ws = Mock()
+
+        region_selector.update_workspace(mock_ws)
+        region_selector.add_rectangular_region("test", "black")
+        region_selector.add_rectangular_region("test", "black")
+
+        region_selector.clear_workspace()
+
+        self.assertEqual(0, len(region_selector._selectors))
+        self.assertEqual(None, region_selector.model.ws)
+
+    def test_clear_workspace_will_clear_the_figure_in_the_view(self):
+        mock_view = Mock()
+        region_selector = RegionSelector(view=mock_view)
+
+        region_selector.clear_workspace()
+
+        mock_view.clear_figure.assert_called_once_with()
+
     def test_get_region_with_two_signal_regions(self):
         region_selector, selector_one, selector_two = self._mock_selectors()
 

--- a/qt/python/mantidqt/mantidqt/widgets/regionselector/view.py
+++ b/qt/python/mantidqt/mantidqt/widgets/regionselector/view.py
@@ -36,6 +36,10 @@ class RegionSelectorView(QWidget):
     def create_axes_orthogonal(self, redraw_on_zoom):
         self._data_view.create_axes_orthogonal(redraw_on_zoom=redraw_on_zoom)
 
+    def clear_figure(self):
+        self._data_view.clear_figure()
+        self._data_view.canvas.draw()
+
     @staticmethod
     def set_override_cursor(override: bool, override_cursor: Qt.CursorShape = Qt.SizeAllCursor) -> None:
         """

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Common/IJobManager.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Common/IJobManager.h
@@ -20,6 +20,7 @@ public:
   virtual void notifySumBanksCompleted() = 0;
   virtual void notifyReductionCompleted() = 0;
 
+  virtual void notifySumBanksAlgorithmError() = 0;
   virtual void notifyReductionAlgorithmError() = 0;
 };
 

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Common/IJobManager.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Common/IJobManager.h
@@ -19,6 +19,8 @@ public:
   virtual void notifyLoadWorkspaceCompleted() = 0;
   virtual void notifySumBanksCompleted() = 0;
   virtual void notifyReductionCompleted() = 0;
+
+  virtual void notifyReductionAlgorithmError() = 0;
 };
 
 class MANTIDQT_ISISREFLECTOMETRY_DLL IJobManager {

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewJobManager.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewJobManager.cpp
@@ -96,6 +96,7 @@ void PreviewJobManager::notifyAlgorithmError(API::IConfiguredAlgorithm_sptr algo
     break;
   case AlgorithmType::SUM_BANKS:
     g_log.error(std::string("Error summing banks: ") + message);
+    m_notifyee->notifySumBanksAlgorithmError();
     break;
   case AlgorithmType::REDUCTION:
     g_log.error(std::string("Error performing reduction: ") + message);

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewJobManager.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewJobManager.cpp
@@ -99,6 +99,7 @@ void PreviewJobManager::notifyAlgorithmError(API::IConfiguredAlgorithm_sptr algo
     break;
   case AlgorithmType::REDUCTION:
     g_log.error(std::string("Error performing reduction: ") + message);
+    m_notifyee->notifyReductionAlgorithmError();
     break;
   };
 }

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.cpp
@@ -127,6 +127,12 @@ void PreviewPresenter::notifyReductionCompleted() {
   plotLinePlot();
 }
 
+void PreviewPresenter::notifyReductionAlgorithmError() {
+  // Clear the final plot if there is an error
+  m_plotPresenter->clearModel();
+  m_plotPresenter->plot();
+}
+
 void PreviewPresenter::notifyInstViewSelectRectRequested() {
   m_view->setInstViewZoomState(false);
   m_view->setInstViewEditState(false);

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.cpp
@@ -127,11 +127,12 @@ void PreviewPresenter::notifyReductionCompleted() {
   plotLinePlot();
 }
 
-void PreviewPresenter::notifyReductionAlgorithmError() {
-  // Clear the final plot if there is an error
-  m_plotPresenter->clearModel();
-  m_plotPresenter->plot();
+void PreviewPresenter::notifySumBanksAlgorithmError() {
+  clearRegionSelector();
+  clearReductionPlot();
 }
+
+void PreviewPresenter::notifyReductionAlgorithmError() { clearReductionPlot(); }
 
 void PreviewPresenter::notifyInstViewSelectRectRequested() {
   m_view->setInstViewZoomState(false);
@@ -223,4 +224,13 @@ void PreviewPresenter::runReduction() {
   m_model->reduceAsync(*m_jobManager);
 }
 
+void PreviewPresenter::clearRegionSelector() {
+  m_regionSelector->clearWorkspace();
+  m_view->setRegionSelectorToolbarEnabled(false);
+}
+
+void PreviewPresenter::clearReductionPlot() {
+  m_plotPresenter->clearModel();
+  m_plotPresenter->plot();
+}
 } // namespace MantidQt::CustomInterfaces::ISISReflectometry

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.cpp
@@ -185,12 +185,6 @@ void PreviewPresenter::notifyRegionChanged() {
   m_view->setRectangularROIState(false);
   m_view->setEditROIState(true);
 
-  // Set the selection from the view
-  m_model->setSelectedRegion(ROIType::Signal, m_regionSelector->getRegion(roiTypeToString(ROIType::Signal)));
-  m_model->setSelectedRegion(ROIType::Background, m_regionSelector->getRegion(roiTypeToString(ROIType::Background)));
-  m_model->setSelectedRegion(ROIType::Transmission,
-                             m_regionSelector->getRegion(roiTypeToString(ROIType::Transmission)));
-
   runReduction();
 }
 
@@ -220,6 +214,8 @@ void PreviewPresenter::runReduction() {
   m_view->setUpdateAngleButtonEnabled(false);
   // Ensure the angle is up to date
   m_model->setTheta(m_view->getAngle());
+  // Ensure the selected regions are up to date. Required when Loading new data because an empty run details is created.
+  updateSelectedRegionInModelFromView();
   // Perform the reduction
   m_model->reduceAsync(*m_jobManager);
 }
@@ -233,4 +229,12 @@ void PreviewPresenter::clearReductionPlot() {
   m_plotPresenter->clearModel();
   m_plotPresenter->plot();
 }
+
+void PreviewPresenter::updateSelectedRegionInModelFromView() {
+  m_model->setSelectedRegion(ROIType::Signal, m_regionSelector->getRegion(roiTypeToString(ROIType::Signal)));
+  m_model->setSelectedRegion(ROIType::Background, m_regionSelector->getRegion(roiTypeToString(ROIType::Background)));
+  m_model->setSelectedRegion(ROIType::Transmission,
+                             m_regionSelector->getRegion(roiTypeToString(ROIType::Transmission)));
+}
+
 } // namespace MantidQt::CustomInterfaces::ISISReflectometry

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.h
@@ -98,6 +98,7 @@ private:
   std::shared_ptr<StubRegionObserver> m_stubRegionObserver;
 
   void updateWidgetEnabledState();
+  void updateSelectedRegionInModelFromView();
 
   void plotInstView();
   void plotRegionSelector();

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.h
@@ -81,6 +81,8 @@ public:
   void notifySumBanksCompleted() override;
   void notifyReductionCompleted() override;
 
+  void notifyReductionAlgorithmError() override;
+
   // RegionSelectionObserver overrides
   void notifyRegionChanged() override;
 

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.h
@@ -81,6 +81,7 @@ public:
   void notifySumBanksCompleted() override;
   void notifyReductionCompleted() override;
 
+  void notifySumBanksAlgorithmError() override;
   void notifyReductionAlgorithmError() override;
 
   // RegionSelectionObserver overrides
@@ -103,5 +104,7 @@ private:
   void plotLinePlot();
   void runSumBanks();
   void runReduction();
+  void clearRegionSelector();
+  void clearReductionPlot();
 };
 } // namespace MantidQt::CustomInterfaces::ISISReflectometry

--- a/qt/scientific_interfaces/ISISReflectometry/test/Preview/MockPlotPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Preview/MockPlotPresenter.h
@@ -16,6 +16,7 @@ class MockPlotPresenter : public PlotPresenter {
 public:
   MockPlotPresenter() : PlotPresenter(nullptr){};
 
+  MOCK_METHOD(void, clearModel, (), (override));
   MOCK_METHOD(void, setSpectrum, (const Mantid::API::MatrixWorkspace_sptr &, const size_t), (override));
   MOCK_METHOD(void, setScaleLinear, (const AxisID), (override));
   MOCK_METHOD(void, setScaleLog, (const AxisID), (override));

--- a/qt/scientific_interfaces/ISISReflectometry/test/Preview/PreviewJobManagerTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Preview/PreviewJobManagerTest.h
@@ -180,6 +180,34 @@ public:
     TS_ASSERT_THROWS(jobManager.notifyAlgorithmError(configuredAlgRef, ""), std::logic_error const &);
   }
 
+  void test_notify_algorithm_error_will_notify_when_sum_banks_algorithm_error_occurs() {
+    auto mockJobRunner = makeJobRunner();
+    auto mockSubscriber = MockJobManagerSubscriber();
+    auto previewRow = makePreviewRow();
+    auto sumBanksAlg = makeConfiguredSumBanksAlg(previewRow);
+
+    auto jobManager = makeJobManager(std::move(mockJobRunner), mockSubscriber);
+    auto configuredAlgRef = std::static_pointer_cast<IConfiguredAlgorithm>(sumBanksAlg);
+
+    EXPECT_CALL(mockSubscriber, notifySumBanksAlgorithmError).Times(1);
+
+    jobManager.notifyAlgorithmError(configuredAlgRef, "");
+  }
+
+  void test_notify_algorithm_error_will_notify_when_reduction_algorithm_error_occurs() {
+    auto mockJobRunner = makeJobRunner();
+    auto mockSubscriber = MockJobManagerSubscriber();
+    auto previewRow = makePreviewRow();
+    auto sumBanksAlg = makeConfiguredReductionAlg(previewRow);
+
+    auto jobManager = makeJobManager(std::move(mockJobRunner), mockSubscriber);
+    auto configuredAlgRef = std::static_pointer_cast<IConfiguredAlgorithm>(sumBanksAlg);
+
+    EXPECT_CALL(mockSubscriber, notifyReductionAlgorithmError).Times(1);
+
+    jobManager.notifyAlgorithmError(configuredAlgRef, "");
+  }
+
   void test_notify_algorithm_complete_catches_runtime_errors() {
     auto mockJobRunner = makeJobRunner();
     auto mockSubscriber = MockJobManagerSubscriber();

--- a/qt/scientific_interfaces/ISISReflectometry/test/ReflMockObjects.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/ReflMockObjects.h
@@ -303,6 +303,8 @@ public:
   MOCK_METHOD0(notifyLoadWorkspaceCompleted, void());
   MOCK_METHOD0(notifySumBanksCompleted, void());
   MOCK_METHOD0(notifyReductionCompleted, void());
+  MOCK_METHOD0(notifySumBanksAlgorithmError, void());
+  MOCK_METHOD0(notifyReductionAlgorithmError, void());
 };
 
 class MockEncoder : public IEncoder {

--- a/qt/widgets/plotting/inc/MantidQtWidgets/Plotting/PlotWidget/PlotModel.h
+++ b/qt/widgets/plotting/inc/MantidQtWidgets/Plotting/PlotWidget/PlotModel.h
@@ -19,6 +19,8 @@ public:
   virtual std::vector<Mantid::API::MatrixWorkspace_sptr> getWorkspaces() const;
   virtual std::vector<int> getWorkspaceIndices() const;
 
+  virtual void clear() noexcept;
+
   virtual void setSpectrum(const Mantid::API::MatrixWorkspace_sptr &ws, const size_t wsIndex);
 
   virtual bool getPlotErrorBars() const { return m_plotErrorBars; }

--- a/qt/widgets/plotting/inc/MantidQtWidgets/Plotting/PlotWidget/PlotPresenter.h
+++ b/qt/widgets/plotting/inc/MantidQtWidgets/Plotting/PlotWidget/PlotPresenter.h
@@ -18,6 +18,8 @@ public:
   PlotPresenter(IPlotView *view, std::unique_ptr<PlotModel> model = nullptr);
   virtual ~PlotPresenter() = default;
 
+  virtual void clearModel();
+
   virtual void setSpectrum(const Mantid::API::MatrixWorkspace_sptr &ws, const size_t wsIndex);
 
   virtual void setScaleLinear(const AxisID axisID);

--- a/qt/widgets/plotting/src/PlotWidget/PlotModel.cpp
+++ b/qt/widgets/plotting/src/PlotWidget/PlotModel.cpp
@@ -17,6 +17,11 @@ std::vector<Mantid::API::MatrixWorkspace_sptr> PlotModel::getWorkspaces() const 
 
 std::vector<int> PlotModel::getWorkspaceIndices() const { return m_workspaceIndices; }
 
+void PlotModel::clear() noexcept {
+  m_workspaces.clear();
+  m_workspaceIndices.clear();
+}
+
 void PlotModel::setSpectrum(const Mantid::API::MatrixWorkspace_sptr &ws, const size_t wsIndex) {
   m_workspaces = std::vector<MatrixWorkspace_sptr>{ws};
   m_workspaceIndices = std::vector<int>{static_cast<int>(wsIndex)};

--- a/qt/widgets/plotting/src/PlotWidget/PlotPresenter.cpp
+++ b/qt/widgets/plotting/src/PlotWidget/PlotPresenter.cpp
@@ -17,6 +17,8 @@ PlotPresenter::PlotPresenter(IPlotView *view, std::unique_ptr<PlotModel> model)
   }
 }
 
+void PlotPresenter::clearModel() { m_model->clear(); }
+
 void PlotPresenter::setSpectrum(const Mantid::API::MatrixWorkspace_sptr &ws, const size_t wsIndex) {
   m_model->setSpectrum(ws, wsIndex);
 }

--- a/qt/widgets/plotting/test/PlotWidget/PlotModelTest.h
+++ b/qt/widgets/plotting/test/PlotWidget/PlotModelTest.h
@@ -43,6 +43,18 @@ public:
     TS_ASSERT_EQUALS(model.getWorkspaces(), expectedWorkspaces);
   }
 
+  void test_clear_will_clear_the_model() {
+    auto model = PlotModel();
+    auto ws = createMatrixWorkspace(3);
+
+    model.setSpectrum(ws, 1);
+
+    model.clear();
+
+    TS_ASSERT(model.getWorkspaceIndices().empty());
+    TS_ASSERT(model.getWorkspaces().empty());
+  }
+
   void test_set_get_plot_error_bars() {
     auto model = PlotModel();
     model.setPlotErrorBars(true);

--- a/qt/widgets/regionselector/inc/MantidQtWidgets/RegionSelector/IRegionSelector.h
+++ b/qt/widgets/regionselector/inc/MantidQtWidgets/RegionSelector/IRegionSelector.h
@@ -20,6 +20,7 @@ public:
   using Selection = std::vector<double>;
   virtual ~IRegionSelector() = default;
   virtual void subscribe(std::shared_ptr<Mantid::API::RegionSelectorObserver> const &notifyee) = 0;
+  virtual void clearWorkspace() = 0;
   virtual void updateWorkspace(Mantid::API::Workspace_sptr const &workspace) = 0;
   virtual void addRectangularRegion(const std::string &regionType, const std::string &color) = 0;
   virtual Selection getRegion(const std::string &regionType) = 0;

--- a/qt/widgets/regionselector/inc/MantidQtWidgets/RegionSelector/RegionSelector.h
+++ b/qt/widgets/regionselector/inc/MantidQtWidgets/RegionSelector/RegionSelector.h
@@ -24,6 +24,7 @@ public:
   RegionSelector &operator=(RegionSelector &&);
 
   void subscribe(std::shared_ptr<Mantid::API::RegionSelectorObserver> const &notifyee) override;
+  void clearWorkspace() override;
   void updateWorkspace(Mantid::API::Workspace_sptr const &workspace) override;
   void addRectangularRegion(const std::string &regionType, const std::string &color) override;
   Selection getRegion(const std::string &regionType) override;

--- a/qt/widgets/regionselector/src/RegionSelector.cpp
+++ b/qt/widgets/regionselector/src/RegionSelector.cpp
@@ -73,6 +73,11 @@ void RegionSelector::subscribe(std::shared_ptr<Mantid::API::RegionSelectorObserv
   pyobj().attr("subscribe")(*boost::python::tuple(), **kwargs);
 }
 
+void RegionSelector::clearWorkspace() {
+  GlobalInterpreterLock lock;
+  pyobj().attr("clear_workspace")();
+}
+
 void RegionSelector::updateWorkspace(Workspace_sptr const &workspace) {
   GlobalInterpreterLock lock;
   boost::python::dict kwargs;

--- a/qt/widgets/regionselector/test/MockRegionSelector.h
+++ b/qt/widgets/regionselector/test/MockRegionSelector.h
@@ -13,6 +13,7 @@ namespace MantidQt::Widgets {
 class MockRegionSelector : public IRegionSelector {
 public:
   MOCK_METHOD(void, subscribe, (std::shared_ptr<Mantid::API::RegionSelectorObserver> const &), (override));
+  MOCK_METHOD(void, clearWorkspace, (), (override));
   MOCK_METHOD(void, updateWorkspace, (Mantid::API::Workspace_sptr const &workspace), (override));
   MOCK_METHOD(void, addRectangularRegion, (const std::string &regionType, const std::string &color), (override));
   MOCK_METHOD(Selection, getRegion, (const std::string &regionType), (override));


### PR DESCRIPTION
**Description of work.**
This PR ensures the reduction plot and region selector plot gets cleared when there is an error.

Two things we noted while working on this:
- The cursor info doesn't get cleared if you move your cursor out of the region selector plot fast
- The clearing of the reduction plot does not clear the axis limits or remove the legend handle

We thought we'd let the reviewer decide if these need to be fixed.

**To test:**
1. Open `ISIS Reflectometry` interface
2. Go to the Preview tab and load `INTER45455_inst`
3. Set a non-zero angle such as `1.0` and click `Update`
4. Drag a Signal region of interest. Draw a second region of interest with overlapping y. This should cause the reduction to fail and the reduction plot will clear

Part of #34220

*This does not require release notes* because **it is still being developed**

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
