### PR TITLE
Euphonic systemtest: pin installed version

### DIFF
--- a/Testing/SystemTests/tests/framework/SimulatedDensityOfStatesEuphonicPackaging.py
+++ b/Testing/SystemTests/tests/framework/SimulatedDensityOfStatesEuphonicPackaging.py
@@ -114,7 +114,7 @@ class SimulatedDensityOfStatesEuphonicTest(MantidSystemTest):
 
         process = subprocess.run([sys.executable, "-m", "pip", "install",
                                   "--prefix", tmp_prefix,
-                                  "euphonic[phonopy_reader]"],
+                                  "euphonic[phonopy_reader]==0.6.5"],
                                  stdout=subprocess.PIPE,
                                  stderr=subprocess.STDOUT,
                                  env=env)


### PR DESCRIPTION
Euphonic 1.0 has API changes that are not yet supported. The version has already been pinned to pre-v1 in Script Repository installer and Conda recipes; this systemtest was overlooked.

**To test:**

This addresses a CI problem, so we just need to check the CI passes

*This does not require release notes* because it's a testing fix and doesn't really affect users.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
