### PR TITLE
Fix excessive text elision workbench data view

### DIFF
--- a/docs/source/release/v6.5.0/Workbench/Bugfixes/34260.rst
+++ b/docs/source/release/v6.5.0/Workbench/Bugfixes/34260.rst
@@ -1,0 +1,3 @@
+- Fix a change in behaviour after upgrading Qt where floating point numbers in
+  the matrix data view were not displayed unless the column was wide enough to show
+  all digits.

--- a/qt/python/mantidqt/CMakeLists.txt
+++ b/qt/python/mantidqt/CMakeLists.txt
@@ -166,6 +166,7 @@ set(PYTHON_WIDGET_QT5_ONLY_TESTS
     mantidqt/widgets/workspacedisplay/test/test_data_copier.py
     mantidqt/widgets/workspacedisplay/test/test_workspacedisplay_view.py
     mantidqt/widgets/workspacedisplay/test/test_user_notifier.py
+    mantidqt/widgets/workspacedisplay/matrix/test/test_matrixworkspacedisplay_delegate.py
     mantidqt/widgets/workspacedisplay/matrix/test/test_matrixworkspacedisplay_model.py
     mantidqt/widgets/workspacedisplay/matrix/test/test_matrixworkspacedisplay_presenter.py
     mantidqt/widgets/workspacedisplay/matrix/test/test_matrixworkspacedisplay_table_view_model.py

--- a/qt/python/mantidqt/mantidqt/widgets/workspacedisplay/matrix/delegate.py
+++ b/qt/python/mantidqt/mantidqt/widgets/workspacedisplay/matrix/delegate.py
@@ -1,0 +1,56 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2022 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+from typing import Optional
+
+from qtpy.QtCore import Qt, QObject, QModelIndex
+from qtpy.QtGui import QPainter
+from qtpy.QtWidgets import (QStyledItemDelegate, QStyleOptionViewItem)
+
+
+class CustomTextElidingDelegate(QStyledItemDelegate):
+    """Supports setting a custom padding for text string elision in a table"""
+
+    def __init__(self, padding: int, parent: Optional[QObject] = None) -> None:
+        """Initialize an object with a padding and optional parent
+
+        :param padding: An integer specifying the number of characters
+                        to display as elision dots at the end
+        :param parent: An optional parent object, defaults to None
+        """
+        super().__init__(parent)
+        self._padding = padding
+
+    def paint(self, painter: QPainter, option: QStyleOptionViewItem, index: QModelIndex):
+        """Renders the delegate using the given painter and style option for the item specified by index.
+
+        :param painter: A QPainter object to draw
+        :param option: Options to describe what should be drawn
+        :param index: _description_
+        """
+        if not index.isValid():
+            return
+
+        # Initialize the style options. This is not very Pythonic as it uses C++
+        # references under the hood so opt is affected by the second call
+        opt = QStyleOptionViewItem(option)
+        self.initStyleOption(opt, index)
+
+        # Standard setup, paint, restore operation
+        painter.save()
+        try:
+            painter.setClipRect(opt.rect)
+            foreground_colour, background_colour = index.data(Qt.ForegroundRole), index.data(Qt.BackgroundRole)
+            if foreground_colour is not None:
+                painter.setPen(foreground_colour)
+            if background_colour is not None:
+                painter.fillRect(option.rect, background_colour)
+            padding = self._padding
+            opt.rect = option.rect.adjusted(padding, padding, -padding, -padding)
+            painter.drawText(opt.rect, int(Qt.AlignLeft | Qt.AlignVCenter),
+                             opt.fontMetrics.elidedText(opt.text, Qt.ElideRight, opt.rect.width()))
+        finally:
+            painter.restore()

--- a/qt/python/mantidqt/mantidqt/widgets/workspacedisplay/matrix/presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/workspacedisplay/matrix/presenter.py
@@ -9,6 +9,7 @@
 #
 from qtpy.QtCore import Qt
 
+from mantid.api import ITableWorkspace
 from mantid.plots.utility import MantidAxType
 from mantidqt.widgets.observers.ads_observer import WorkspaceDisplayADSObserver
 from mantidqt.widgets.workspacedisplay.data_copier import DataCopier
@@ -17,15 +18,25 @@ from mantidqt.widgets.observers.observing_presenter import ObservingPresenter
 from mantidqt.widgets.workspacedisplay.status_bar_view import StatusBarView
 from .model import MatrixWorkspaceDisplayModel
 from .view import MatrixWorkspaceDisplayView
-from mantid.simpleapi import CreateEmptyTableWorkspace
+# import of CreateEmptyTableWorkspace is inside method where it is used to avoid
+# starting the mantid framework in unit tests when this module is imported
 
 
 class MatrixWorkspaceDisplay(ObservingPresenter, DataCopier):
     A_LOT_OF_THINGS_TO_PLOT_MESSAGE = "You selected {} spectra to plot. Are you sure you want to plot that many?"
     NUM_SELECTED_FOR_CONFIRMATION = 10
 
-    def __init__(self, ws, plot=None, parent=None, window_flags=Qt.Window, model=None, view=None, ads_observer=None, container=None,
-                 window_width=600, window_height=400):
+    def __init__(self,
+                 ws,
+                 plot=None,
+                 parent=None,
+                 window_flags=Qt.Window,
+                 model=None,
+                 view=None,
+                 ads_observer=None,
+                 container=None,
+                 window_width=600,
+                 window_height=400):
         """
         Creates a display for the provided workspace.
 
@@ -42,7 +53,9 @@ class MatrixWorkspaceDisplay(ObservingPresenter, DataCopier):
         # Create model and view, or accept mocked versions
         self.model = model if model else MatrixWorkspaceDisplayModel(ws)
         self.view = view if view else MatrixWorkspaceDisplayView(self, parent, window_flags)
-        self.container = container if container else StatusBarView(parent, self.view, self.model.get_name(),
+        self.container = container if container else StatusBarView(parent,
+                                                                   self.view,
+                                                                   self.model.get_name(),
                                                                    window_width=window_width,
                                                                    window_height=window_height,
                                                                    presenter=self,
@@ -104,9 +117,8 @@ class MatrixWorkspaceDisplay(ObservingPresenter, DataCopier):
             self.notify_no_selection_to_copy()
             return
         ws = table.model().ws
-        table_ws = CreateEmptyTableWorkspace(OutputWorkspace=ws.name() + "_spectra")
         row_sizes = [ws.getNumberBins(row) for row in selected_rows]
-        table_ws.setRowCount(max(row_sizes))
+        table_ws = _create_empty_table_workspace(name=ws.name() + "_spectra", num_rows=max(row_sizes))
         num_col = 4 if self.hasDx else 3
         for i, (row, row_size) in enumerate(zip(selected_rows, row_sizes)):
             table_ws.addColumn("double", "XS" + str(row))
@@ -140,17 +152,16 @@ class MatrixWorkspaceDisplay(ObservingPresenter, DataCopier):
             self.notify_no_selection_to_copy()
             return
         ws = table.model().ws
-        table_ws = CreateEmptyTableWorkspace(OutputWorkspace=ws.name() + "_bins")
         num_rows = ws.getNumberHistograms()
-        table_ws.setRowCount(num_rows)
+        table_ws = _create_empty_table_workspace(name=ws.name() + "_bins", row_count=num_rows)
         table_ws.addColumn("double", "X")
-        num_col = 3 if self.hasDx else 2
+        num_cols = 3 if self.hasDx else 2
         for i, col in enumerate(selected_cols):
             table_ws.addColumn("double", "YB" + str(col))
             table_ws.addColumn("double", "YE" + str(col))
 
-            col_y = num_col * i + 1
-            col_e = num_col * i + 2
+            col_y = num_cols * i + 1
+            col_e = num_cols * i + 2
 
             for j in range(num_rows):
                 data_y = ws.readY(j)
@@ -166,7 +177,7 @@ class MatrixWorkspaceDisplay(ObservingPresenter, DataCopier):
 
             if self.hasDx:
                 table_ws.addColumn("double", "XE" + str(col))
-                col_dx = num_col * i + 3
+                col_dx = num_cols * i + 3
                 for j in range(num_rows):
                     data_dx = ws.readDx(j)
                     table_ws.setCell(j, col_dx, data_dx[col])
@@ -195,8 +206,11 @@ class MatrixWorkspaceDisplay(ObservingPresenter, DataCopier):
         plot_kwargs["axis"] = axis
 
         ws_list = [self.model._ws]
-        self.plot(ws_list, wksp_indices=[get_index(index) for index in selected], errors=plot_errors,
-                  overplot=overplot, plot_kwargs=plot_kwargs)
+        self.plot(ws_list,
+                  wksp_indices=[get_index(index) for index in selected],
+                  errors=plot_errors,
+                  overplot=overplot,
+                  plot_kwargs=plot_kwargs)
 
     def action_plot_spectrum(self, table):
         self._do_action_plot(table, MantidAxType.SPECTRUM, lambda index: index.row())
@@ -205,12 +219,10 @@ class MatrixWorkspaceDisplay(ObservingPresenter, DataCopier):
         self._do_action_plot(table, MantidAxType.SPECTRUM, lambda index: index.row(), plot_errors=True)
 
     def action_overplot_spectrum(self, table):
-        self._do_action_plot(table, MantidAxType.SPECTRUM, lambda index: index.row(),
-                             plot_errors=False, overplot=True)
+        self._do_action_plot(table, MantidAxType.SPECTRUM, lambda index: index.row(), plot_errors=False, overplot=True)
 
     def action_overplot_spectrum_with_errors(self, table):
-        self._do_action_plot(table, MantidAxType.SPECTRUM, lambda index: index.row(),
-                             plot_errors=True, overplot=True)
+        self._do_action_plot(table, MantidAxType.SPECTRUM, lambda index: index.row(), plot_errors=True, overplot=True)
 
     def action_plot_bin(self, table):
         self._do_action_plot(table, MantidAxType.BIN, lambda index: index.column())
@@ -248,3 +260,18 @@ class MatrixWorkspaceDisplay(ObservingPresenter, DataCopier):
             return self.model._ws.readDx
         else:
             raise ValueError("Unknown TableViewModel type {}".format(type))
+
+
+# utility functions
+def _create_empty_table_workspace(name: str, num_rows: int) -> ITableWorkspace:
+    """Create and empty table with the given number of rows
+
+    :param name: The name of the workspace in the ADS
+    :param num_rows: Number of rows for the new table
+    :return: A new tableworkspace
+    """
+    # keep import here to avoid framework initialization in tests
+    from mantid.simpleapi import CreateEmptyTableWorkspace
+    table = CreateEmptyTableWorkspace(OutputWorkspace=name)
+    table.setRowCount(num_rows)
+    return table

--- a/qt/python/mantidqt/mantidqt/widgets/workspacedisplay/matrix/test/test_matrixworkspacedisplay_delegate.py
+++ b/qt/python/mantidqt/mantidqt/widgets/workspacedisplay/matrix/test/test_matrixworkspacedisplay_delegate.py
@@ -1,0 +1,98 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2012 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+#  This file is part of the mantid workbench.
+import math
+import unittest
+from unittest import mock
+
+from qtpy.QtCore import QModelIndex, Qt, QRect
+from qtpy.QtGui import QColor, QStandardItemModel, QPainter
+from qtpy.QtWidgets import QStyleOptionViewItem
+from mantidqt.widgets.workspacedisplay.matrix.delegate import CustomTextElidingDelegate
+from mantidqt.utils.qt.testing import start_qapplication
+
+
+@start_qapplication
+class CustomTextElidingDelegateTest(unittest.TestCase):
+
+    def test_custom_eliding_delegate_does_nothing_for_invalid_indices(self):
+        delegate = CustomTextElidingDelegate(padding=5)
+        painter = mock.MagicMock(spec=QPainter)
+        # we cannot mock the style &index as they are passed to a C++ type that expects real types
+        style, invalid_index = QStyleOptionViewItem(), QModelIndex()
+
+        delegate.paint(painter, style, invalid_index)
+
+        painter.save.assert_not_called()
+        painter.drawText.assert_not_called()
+        painter.restore.assert_not_called()
+
+    def test_custom_eliding_delegate_respects_padding(self):
+        padding = 3
+        delegate = CustomTextElidingDelegate(padding)
+        painter = mock.MagicMock(spec=QPainter)
+        # we cannot mock the style & index as they are passed to a C++ type that expects real types
+        style, model = QStyleOptionViewItem(), QStandardItemModel(1, 1)
+        style.rect = QRect(0, 0, 99, 29)  # give a non-zero sized rectangle to paint in
+        text = str(math.pi)
+        model.setData(model.index(0, 0), text, Qt.DisplayRole)
+
+        delegate.paint(painter, style, model.index(0, 0))
+
+        painter.save.assert_called_once()
+        painter.setPen.assert_not_called()
+        painter.fillRect.assert_not_called()
+        painter.drawText.assert_called_once()
+        painter.restore.assert_called_once()
+
+        # first call and second argument is the text that will be painted
+        # the exact text depends on the font metric so we have a looser requirement
+        # for matching
+        drawn_text = painter.drawText.call_args[0][2]
+        self.assertTrue(drawn_text.startswith("3.141592"))
+        # Qt uses the 'horizontal ellipsis' unicode symbol for ellision.
+        # To avoid confusion with it look like 3 separate '.' characters in code
+        # we use the unicode codepoint directly
+        self.assertTrue(drawn_text.endswith(b"\xe2\x80\xa6".decode("utf-8")))
+
+    def test_custom_eliding_delegate_respects_forgeround_color(self):
+        padding = 3
+        delegate = CustomTextElidingDelegate(padding)
+        painter = mock.MagicMock(spec=QPainter)
+        # we cannot mock the style & index as they are passed to a C++ type that expects real types
+        style, model = QStyleOptionViewItem(), QStandardItemModel(1, 1)
+        style.rect = QRect(0, 0, 99, 29)  # give a non-zero sized rectangle to paint in
+        text, foreground = str(math.pi), QColor(10, 10, 10)
+        model.setData(model.index(0, 0), text, Qt.DisplayRole)
+        model.setData(model.index(0, 0), foreground, Qt.ForegroundRole)
+
+        delegate.paint(painter, style, model.index(0, 0))
+
+        painter.setPen.assert_called_once_with(foreground)
+        painter.fillRect.assert_not_called()
+
+    def test_custom_eliding_delegate_respects_background_color(self):
+        padding = 3
+        delegate = CustomTextElidingDelegate(padding)
+        painter = mock.MagicMock(spec=QPainter)
+        # we cannot mock the style & index as they are passed to a C++ type that expects real types
+        style, model = QStyleOptionViewItem(), QStandardItemModel(1, 1)
+        style.rect = QRect(0, 0, 99, 29)  # give a non-zero sized rectangle to paint in
+        text, background = str(math.pi), QColor(5, 5, 5)
+        model.setData(model.index(0, 0), text, Qt.DisplayRole)
+        model.setData(model.index(0, 0), background, Qt.BackgroundRole)
+
+        delegate.paint(painter, style, model.index(0, 0))
+
+        painter.setPen.assert_not_called()
+        painter.fillRect.assert_called_once()
+        # the background color object seems different but we only care about value equality
+        self.assertEqual(background, painter.fillRect.call_args[0][1])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/qt/python/mantidqt/mantidqt/widgets/workspacedisplay/matrix/test/test_matrixworkspacedisplay_presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/workspacedisplay/matrix/test/test_matrixworkspacedisplay_presenter.py
@@ -378,7 +378,7 @@ class MatrixWorkspaceDisplayPresenterTest(unittest.TestCase):
         self.assertEqual(mock_notify.call_count, 1)
         self.assertEqual(mock_table.model.call_count, 0)
 
-    @patch("mantidqt.widgets.workspacedisplay.matrix.presenter.CreateEmptyTableWorkspace")
+    @patch("mantidqt.widgets.workspacedisplay.matrix.presenter._create_empty_table_workspace")
     def test_action_copy_bin_to_table(self, mock_create_table):
         _, mock_table, _, presenter = self.common_setup_action_plot(table_has_selection=False)
         self.setup_mock_selection(mock_table, num_selected_cols=2, num_selected_rows=None)
@@ -421,7 +421,7 @@ class MatrixWorkspaceDisplayPresenterTest(unittest.TestCase):
         self.assertEqual(mock_notify.call_count, 1)
         self.assertEqual(mock_table.model.call_count, 0)
 
-    @patch("mantidqt.widgets.workspacedisplay.matrix.presenter.CreateEmptyTableWorkspace")
+    @patch("mantidqt.widgets.workspacedisplay.matrix.presenter._create_empty_table_workspace")
     def test_action_copy_spectrum_to_table(self, mock_create_table):
         _, mock_table, _, presenter = self.common_setup_action_plot(table_has_selection=False)
         self.setup_mock_selection(mock_table, num_selected_cols=None, num_selected_rows=2)

--- a/qt/python/mantidqt/mantidqt/widgets/workspacedisplay/matrix/view.py
+++ b/qt/python/mantidqt/mantidqt/widgets/workspacedisplay/matrix/view.py
@@ -12,20 +12,27 @@ from functools import partial
 from qtpy import QtGui
 from qtpy.QtCore import Qt
 from qtpy.QtGui import QKeySequence
-from qtpy.QtWidgets import (QAbstractItemView, QAction, QHeaderView, QMessageBox, QTabWidget, QTableView, QMenu)
+from qtpy.QtWidgets import (QAbstractItemView, QAction, QHeaderView, QMenu, QMessageBox, QTabWidget, QTableView)
 
 import mantidqt.icons
+from mantidqt.widgets.workspacedisplay.matrix.delegate import CustomTextElidingDelegate
 from mantidqt.widgets.workspacedisplay.matrix.table_view_model import MatrixWorkspaceTableViewModelType
 from mantidqt.plotting.functions import can_overplot
 
+# Constants
+ELIDE_NCHARS_RIGHT = 3
+
 
 class MatrixWorkspaceTableView(QTableView):
+
     def __init__(self, parent):
         super(MatrixWorkspaceTableView, self).__init__(parent)
         self.setSelectionBehavior(QAbstractItemView.SelectItems)
 
         header = self.horizontalHeader()
         header.sectionDoubleClicked.connect(self.handle_double_click)
+
+        self.setItemDelegate(CustomTextElidingDelegate(ELIDE_NCHARS_RIGHT))
 
     def resizeEvent(self, event):
         super(MatrixWorkspaceTableView, self).resizeEvent(event)
@@ -184,33 +191,33 @@ class MatrixWorkspaceDisplayView(QTabWidget):
         overplot_bin_action = QAction(self.GRAPH_ICON, "Overplot bin (values only)", self)
         overplot_bin_action.triggered.connect(partial(self.presenter.action_overplot_bin, table))
         overplot_bin_with_errors_action = QAction(self.GRAPH_ICON, "Overplot bin (values + errors)", self)
-        overplot_bin_with_errors_action.triggered.connect(partial(self.presenter.action_overplot_bin_with_errors,
-                                                                  table))
+        overplot_bin_with_errors_action.triggered.connect(partial(self.presenter.action_overplot_bin_with_errors, table))
         overplot_bin_action.setEnabled(can_overplot())
         overplot_bin_with_errors_action.setEnabled(can_overplot())
         separator = QAction(self)
         separator.setSeparator(True)
-        list(map(context_menu.addAction, [plot_bin_action, plot_bin_with_errors_action, separator,
-                                          overplot_bin_action, overplot_bin_with_errors_action]))
+        list(
+            map(context_menu.addAction,
+                [plot_bin_action, plot_bin_with_errors_action, separator, overplot_bin_action, overplot_bin_with_errors_action]))
 
     def setup_plot_spectrum_actions(self, context_menu, table):
         plot_spectrum_action = QAction(self.GRAPH_ICON, "Plot spectrum (values only)", self)
         plot_spectrum_action.triggered.connect(partial(self.presenter.action_plot_spectrum, table))
-        plot_spectrum_with_errors_action = QAction(self.GRAPH_ICON, "Plot spectrum (values + errors)",
-                                                   self)
-        plot_spectrum_with_errors_action.triggered.connect(
-            partial(self.presenter.action_plot_spectrum_with_errors, table))
+        plot_spectrum_with_errors_action = QAction(self.GRAPH_ICON, "Plot spectrum (values + errors)", self)
+        plot_spectrum_with_errors_action.triggered.connect(partial(self.presenter.action_plot_spectrum_with_errors, table))
         overplot_spectrum_action = QAction(self.GRAPH_ICON, "Overplot spectrum (values only)", self)
         overplot_spectrum_action.triggered.connect(partial(self.presenter.action_overplot_spectrum, table))
         overplot_spectrum_with_errors_action = QAction(self.GRAPH_ICON, "Overplot spectrum (values + errors)", self)
-        overplot_spectrum_with_errors_action.triggered.connect(partial(
-            self.presenter.action_overplot_spectrum_with_errors, table))
+        overplot_spectrum_with_errors_action.triggered.connect(partial(self.presenter.action_overplot_spectrum_with_errors, table))
         overplot_spectrum_action.setEnabled(can_overplot())
         overplot_spectrum_with_errors_action.setEnabled(can_overplot())
         separator = QAction(self)
         separator.setSeparator(True)
-        list(map(context_menu.addAction, [plot_spectrum_action, plot_spectrum_with_errors_action, separator,
-                                          overplot_spectrum_action, overplot_spectrum_with_errors_action]))
+        list(
+            map(context_menu.addAction, [
+                plot_spectrum_action, plot_spectrum_with_errors_action, separator, overplot_spectrum_action,
+                overplot_spectrum_with_errors_action
+            ]))
 
     def setup_copy_bin_actions(self, context_menu, table):
         copy_bin_values = QAction(self.COPY_ICON, "Copy", self)
@@ -223,8 +230,7 @@ class MatrixWorkspaceDisplayView(QTabWidget):
 
     def setup_copy_spectrum_actions(self, context_menu, table):
         copy_spectrum_values = QAction(self.COPY_ICON, "Copy", self)
-        copy_spectrum_values.triggered.connect(
-            partial(self.presenter.action_copy_spectrum_values, table))
+        copy_spectrum_values.triggered.connect(partial(self.presenter.action_copy_spectrum_values, table))
         copy_spectrum_to_table = QAction(self.TABLE_ICON, "Copy spectrum to table", self)
         copy_spectrum_to_table.triggered.connect(partial(self.presenter.action_copy_spectrum_to_table, table))
         separator = QAction(self)


### PR DESCRIPTION
**Description of work.**

This work addresses the issues with excessive text elision in the matrixworkspace data view after upgrading to Qt 5.12. See the screenshot in the linked issue for a comparison where the old version is on Qt 5.9.

It is not clear that this is a bug in Qt, just a change in behaviour. Here we introduce a delegate to control the amount of elision of the string that occurs.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**

* Open workbench
* Load any data file
* Show the data and most digits after the decimal point should be shown. Widen the column to show everything.
* Also check the background colours are respected. Run `MaskDetectors` and mask out several rows.
  Open the data view again and see the masked rows have a grey background color
* Check the monitor background is colored yellow. Run `LoadEmptyInstrument` with `InstrumentName=IRIS`. The first two rows in the data view should have a yellow background

Fixes #34101

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
