### PR TITLE
Notify region changed when region is deleted

### DIFF
--- a/qt/python/mantidqt/mantidqt/widgets/regionselector/presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/regionselector/presenter.py
@@ -178,6 +178,9 @@ class RegionSelector(ObservingPresenter, SliceViewerBasePresenter):
         selector.update()
         self._selectors.remove(selector)
 
+        if self.notifyee:
+            self.notifyee.notifyRegionChanged()
+
     def _find_selector_if(self, predicate: Callable) -> Selector:
         """
         Find the first selector which agrees with a predicate. Return None if no selector is found

--- a/qt/python/mantidqt/mantidqt/widgets/regionselector/test/test_regionselector_presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/regionselector/test/test_regionselector_presenter.py
@@ -182,6 +182,20 @@ class RegionSelectorTest(unittest.TestCase):
         selector_two.set_active.assert_called_once_with(False)
         selector_two.update.assert_called_once_with()
 
+    def test_delete_key_pressed_will_notify_region_changed(self):
+        region_selector, selector_one, selector_two = self._mock_selectors()
+        selector_one.active, selector_two.active = False, True
+        selector_two.artists = []
+        mock_observer = Mock()
+        region_selector.subscribe(mock_observer)
+
+        event = Mock()
+        event.key = "delete"
+
+        region_selector.key_pressed(event)
+
+        mock_observer.notifyRegionChanged.assert_called_once()
+
     def test_mouse_moved_will_not_set_override_cursor_if_no_selectors_exist(self):
         region_selector = RegionSelector(ws=Mock(), view=Mock())
         region_selector.view.set_override_cursor = Mock()


### PR DESCRIPTION
**Description of work.**
This PR ensures the Preview Presenter is notified whenever a region is deleted.

**To test:**
1. Open `ISIS Reflectometry` interface
2. Load `INTER45455_inst` on the Preview tab
3. Select a signal region on the Region selector plot. See that the reduction plot changes
4. Select the signal region and press the delete key.
5. The reduction plot should update to its original plot before a region was drawn

*This does not require release notes* because **the preview tab is still under development**


#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
