### PR TITLE
Support sphere in SetSample

### DIFF
--- a/Framework/DataHandling/inc/MantidDataHandling/SetSample.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/SetSample.h
@@ -56,6 +56,7 @@ private:
                                             const Geometry::ReferenceFrame &refFrame) const;
   std::string createCylinderLikeXML(const Kernel::PropertyManager &args, const Geometry::ReferenceFrame &refFrame,
                                     bool hollow, const std::string &id = "sample-shape") const;
+  std::string createSphereXML(const Kernel::PropertyManager &args, const Geometry::ReferenceFrame &refFrame) const;
   void validateGeometry(std::map<std::string, std::string> &errors, const Kernel::PropertyManager &args,
                         const std::string &flavour);
   void validateMaterial(std::map<std::string, std::string> &errors, const Kernel::PropertyManager &inputArgs,

--- a/Framework/DataHandling/inc/MantidDataHandling/SetSample.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/SetSample.h
@@ -56,7 +56,7 @@ private:
                                             const Geometry::ReferenceFrame &refFrame) const;
   std::string createCylinderLikeXML(const Kernel::PropertyManager &args, const Geometry::ReferenceFrame &refFrame,
                                     bool hollow, const std::string &id = "sample-shape") const;
-  std::string createSphereXML(const Kernel::PropertyManager &args, const Geometry::ReferenceFrame &refFrame) const;
+  std::string createSphereXML(const Kernel::PropertyManager &args) const;
   void validateGeometry(std::map<std::string, std::string> &errors, const Kernel::PropertyManager &args,
                         const std::string &flavour);
   void validateMaterial(std::map<std::string, std::string> &errors, const Kernel::PropertyManager &inputArgs,

--- a/Framework/DataHandling/src/SetSample.cpp
+++ b/Framework/DataHandling/src/SetSample.cpp
@@ -1061,8 +1061,7 @@ std::string SetSample::createCylinderLikeXML(const Kernel::PropertyManager &args
 std::string SetSample::createSphereXML(const Kernel::PropertyManager &args,
                                        const Geometry::ReferenceFrame &refFrame) const {
   const double radius = static_cast<double>(args.getProperty(ShapeArgs::RADIUS)) * 0.01;
-  std::vector<double> center = {0., 0., 0.};
-  center = getPropertyAsVectorDouble(args, ShapeArgs::CENTER);
+  std::vector<double> center = getPropertyAsVectorDouble(args, ShapeArgs::CENTER);
   std::transform(center.begin(), center.end(), center.begin(), [](double val) { return val *= 0.01; });
 
   std::ostringstream xmlShapeStream;

--- a/Framework/DataHandling/src/SetSample.cpp
+++ b/Framework/DataHandling/src/SetSample.cpp
@@ -829,7 +829,7 @@ std::string SetSample::tryCreateXMLFromArgsOnly(const Kernel::PropertyManager &a
   } else if (boost::algorithm::ends_with(shape, ShapeArgs::HOLLOW_CYLINDER_HOLDER)) {
     result = createHollowCylinderHolderXML(args, refFrame);
   } else if (boost::algorithm::ends_with(shape, ShapeArgs::SPHERE)) {
-    result = createSphereXML(args, refFrame);
+    result = createSphereXML(args);
   } else {
     std::stringstream msg;
     msg << "Unknown 'Shape' argument '" << shape << "' provided in 'Geometry' property. Allowed values are "
@@ -1055,11 +1055,9 @@ std::string SetSample::createCylinderLikeXML(const Kernel::PropertyManager &args
 /**
  * Create the XML required to define a sphere from the given args
  * @param args A user-supplied dict of args
- * @param refFrame Defines the reference frame for the shape
  * @return The XML definition string
  */
-std::string SetSample::createSphereXML(const Kernel::PropertyManager &args,
-                                       const Geometry::ReferenceFrame &refFrame) const {
+std::string SetSample::createSphereXML(const Kernel::PropertyManager &args) const {
   const double radius = static_cast<double>(args.getProperty(ShapeArgs::RADIUS)) * 0.01;
   std::vector<double> center = getPropertyAsVectorDouble(args, ShapeArgs::CENTER);
   std::transform(center.begin(), center.end(), center.begin(), [](double val) { return val *= 0.01; });

--- a/Framework/DataHandling/src/SetSample.cpp
+++ b/Framework/DataHandling/src/SetSample.cpp
@@ -31,7 +31,6 @@
 #include <Poco/Path.h>
 #include <boost/algorithm/string/case_conv.hpp>
 #include <boost/algorithm/string/predicate.hpp>
-#include <boost/range/algorithm/transform.hpp>
 
 namespace Mantid::DataHandling {
 

--- a/Framework/DataHandling/test/SetSampleTest.h
+++ b/Framework/DataHandling/test/SetSampleTest.h
@@ -818,6 +818,29 @@ public:
     TS_ASSERT_DELTA(1.25, material.numberDensityEffective(), 1e-04);
   }
 
+  void test_run_Geometry_As_Sphere() {
+    using Mantid::Kernel::V3D;
+    auto inputWS = WorkspaceCreationHelper::create2DWorkspaceBinned(1, 1);
+    setTestReferenceFrame(inputWS);
+
+    auto alg = createAlgorithm(inputWS);
+    alg->setProperty("Geometry", createSphereGeometryProps());
+    TS_ASSERT_THROWS_NOTHING(alg->execute());
+    TS_ASSERT(alg->isExecuted());
+
+    // New shape
+    const auto &sampleShape = inputWS->sample().getShape();
+    TS_ASSERT(sampleShape.hasValidShape());
+
+    // Check some random points inside sphere
+    // Check boundary
+    TS_ASSERT_EQUALS(true, sampleShape.isValid(V3D(0.049, 0., 0.)));
+    TS_ASSERT_EQUALS(true, sampleShape.isValid(V3D(0., 0.049, 0.)));
+    TS_ASSERT_EQUALS(true, sampleShape.isValid(V3D(0., 0., 0.049)));
+    // Check outside boundary
+    TS_ASSERT_EQUALS(false, sampleShape.isValid(V3D(0., 0., 0.06)));
+  }
+
   //----------------------------------------------------------------------------
   // Failure tests
   //----------------------------------------------------------------------------
@@ -1202,6 +1225,21 @@ private:
     props->declareProperty(std::make_unique<DoubleProperty>("OuterRadius", 0.4), "");
     props->declareProperty(std::make_unique<DoubleArrayProperty>("Center", center), "");
     props->declareProperty(std::make_unique<DoubleArrayProperty>("Axis", axis), "");
+    return props;
+  }
+
+  Mantid::Kernel::PropertyManager_sptr createSphereGeometryProps() {
+    using namespace Mantid::Kernel;
+    using DoubleArrayProperty = ArrayProperty<double>;
+    using DoubleProperty = PropertyWithValue<double>;
+    using StringProperty = PropertyWithValue<std::string>;
+
+    auto props = std::make_shared<PropertyManager>();
+    props->declareProperty(std::make_unique<StringProperty>("Shape", "Sphere"), "");
+    props->declareProperty(std::make_unique<DoubleProperty>("Radius", 5), "");
+    std::vector<double> center{0, 0, 1};
+    props->declareProperty(std::make_unique<DoubleArrayProperty>("Center", center), "");
+
     return props;
   }
 

--- a/docs/source/algorithms/SetSample-v1.rst
+++ b/docs/source/algorithms/SetSample-v1.rst
@@ -45,6 +45,7 @@ be in centimeters):
 - ``HollowCylinder``: Height, InnerRadius, OuterRadius, Center
 - ``FlatPlateHolder``: Width, Height, Thick, Center, Angle, FrontThick, BackThick. This is a CSG union of 2 FlatPlates tightly wrapping a FlatPlate sample. To be used for the ContainerGeometry.
 - ``HollowCylinderHolder``: Height, InnerRadius, InnerOuterRadius, OuterInnerRadius, OuterRadius, Center. This is a CSG union of 2 HollowCylinders tightly wrapping a HollowCylinder sample. To be used for the ContainerGeometry.
+- ``Sphere``: Center, Radius
 - ``CSG``: Value is a string containing any generic shape as detailed in :ref:`HowToDefineGeometricShape`
 
 The ``Center`` key is expected to be a list of three values indicating the :python:`[X,Y,Z]`
@@ -190,22 +191,16 @@ used for the dictionary parameters.
              Material={'ChemicalFormula': '(Li7)2-C-H4-N-Cl6',
                        'NumberDensity': 0.1})
 
-**Example - Specify shape using CSG object**
+**Example - Use sphere sample geometry**
 
 .. testcode:: Ex4
 
    # A fake host workspace, replace this with your real one.
    ws = CreateSampleWorkspace()
-   # Specify a Sphere geometry using CSG
-   sphere_xml = " \
-   <sphere id='some-sphere'> \
-       <centre x='0.0'  y='0.0' z='0.0' /> \
-       <radius val='0.5' /> \
-   </sphere> \
-   <algebra val='some-sphere' /> \
-   "
-   # Set sample geometry of workspace to this CSG object Sphere
-   SetSample(ws, Geometry={'Shape': 'CSG', 'Value': sphere_xml})
+
+   # Set sample geometry of workspace to a Sphere
+   SetSample(ws, Geometry={'Shape': 'Sphere',
+                 'Radius': 2.0, 'Center': [0.,0.,0.]})
 
 **Example - Flat plate sample in a flat plate holder container**
 
@@ -258,6 +253,24 @@ used for the dictionary parameters.
                     'Center': [0.,0.,0.]},
           ContainerMaterial={'ChemicalFormula': 'Al',
                     'NumberDensity': 0.01})
+
+**Example - Specify shape using CSG object**
+
+.. testcode:: Ex8
+
+   # A fake host workspace, replace this with your real one.
+   ws = CreateSampleWorkspace()
+   # Specify an Infinite Cylinder geometry using CSG
+   infinite_cylinder_xml = " \
+   <infinite-cylinder id='some-cylinder'> \
+       <centre x='0.0'  y='0.2' z='0' /> \
+	   <axis x='0.0'  y='0.2' z='0' /> \
+       <radius val='1' /> \
+   </infinite-cylinder> \
+   <algebra val='some-cylinder' /> \
+   "
+   # Set sample geometry of workspace to this CSG object Sphere
+   SetSample(ws, Geometry={'Shape': 'CSG', 'Value': infinite_cylinder_xml})
 
 **Example - SetGoniometer to apply automatic rotation to Sample Shape.**
 

--- a/docs/source/algorithms/SetSample-v1.rst
+++ b/docs/source/algorithms/SetSample-v1.rst
@@ -41,8 +41,8 @@ expected along with additional keys specifying the values (all values are assume
 be in centimeters):
 
 - ``FlatPlate``: Width, Height, Thick, Center, Angle
-- ``Cylinder``: Height, Radius, Center
-- ``HollowCylinder``: Height, InnerRadius, OuterRadius, Center
+- ``Cylinder``: Height, Radius, Center, Axis
+- ``HollowCylinder``: Height, InnerRadius, OuterRadius, Center, Axis
 - ``FlatPlateHolder``: Width, Height, Thick, Center, Angle, FrontThick, BackThick. This is a CSG union of 2 FlatPlates tightly wrapping a FlatPlate sample. To be used for the ContainerGeometry.
 - ``HollowCylinderHolder``: Height, InnerRadius, InnerOuterRadius, OuterInnerRadius, OuterRadius, Center. This is a CSG union of 2 HollowCylinders tightly wrapping a HollowCylinder sample. To be used for the ContainerGeometry.
 - ``Sphere``: Center, Radius

--- a/docs/source/release/v6.5.0/Framework/Algorithms/New_features/32892.rst
+++ b/docs/source/release/v6.5.0/Framework/Algorithms/New_features/32892.rst
@@ -1,0 +1,1 @@
+- Added Sphere to the preset shapes supplied in :ref:`SetSample <algm-SetSample>`.


### PR DESCRIPTION
**Description of work.**
Previously anyone wanting to use a sphere in  SetSample would have to do so using an xml string. This PR adds sphere to the preset shapes available.

**To test:**

1. Build Mantid
2. Run the following code and it shouldn't crash
```
ws = CreateSampleWorkspace()
SetSample(ws,
        Geometry={'Shape': 'Sphere',
                  'Radius': 2.0, 'Center': [0.,0.,0.]})
```
3. Code review

Fixes #32892 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
