### PR TITLE
Fix workbench startup test after removing custom MantidWorkbench targets

### DIFF
--- a/Testing/SystemTests/tests/qt/WorkbenchStartupTest.py
+++ b/Testing/SystemTests/tests/qt/WorkbenchStartupTest.py
@@ -5,6 +5,7 @@
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
 import os
+import psutil
 import subprocess
 import sys
 import systemtesting
@@ -12,12 +13,9 @@ import systemtesting
 from mantid.kernel import ConfigService
 from tempfile import NamedTemporaryFile
 
-
 TEST_MESSAGE = "Hello Mantid!"
-
-EXECUTABLE_SWITCHER = {"linux": ["launch_mantidworkbench.sh", "mantidworkbench"],
-                       "darwin": ["MantidWorkbench", "MantidWorkbenchNightly", "MantidWorkbenchUnstable"],
-                       "win32": ["MantidWorkbench.exe"]}
+EXECUTABLE_SWITCHER = {"linux": ["launch_mantidworkbench.sh", "mantidworkbench"], "darwin": ["workbench"], "win32": ["workbench.exe"]}
+SUBPROCESS_TIMEOUT_SECS = 30
 
 
 def get_mantid_executables_for_platform(platform):
@@ -33,7 +31,29 @@ def get_mantid_executable_path(platform):
         workbench_exe = os.path.join(directory, executable)
         if os.path.exists(workbench_exe):
             return workbench_exe
-    raise RuntimeError(f"Could not find path to {workbench_exe}.")
+    raise RuntimeError(f"Could not find path to {workbench_exe}. Tried {get_mantid_executables_for_platform(platform)}")
+
+
+def start_and_wait_for_completion(args_list):
+    pids_before_open = set(psutil.pids())
+    process = subprocess.Popen(args_list,
+                               stdout=subprocess.PIPE,
+                               stderr=subprocess.PIPE)
+    exitcode = process.wait(timeout=SUBPROCESS_TIMEOUT_SECS)
+    if sys.platform == 'win32':
+        # The setuptools generated .exe starts a new process using 'pythonw workbench-script.pyw'
+        # but this outer process does not wait for the child to finish so completes leaving workbench
+        # to continue. We attempt to find the python child process by looking at the created pids
+        # and we wait on that. A timeout is set just in case we pick the wrong process and we wait forever
+        pids_after_open = set(psutil.pids())
+        new_pids_created = pids_after_open - pids_before_open
+        for pid in new_pids_created:
+            proc = psutil.Process(pid)
+            if 'python' in proc.exe():
+                print(f"Found Python subprocess {proc.exe()}. Pid={pid}. Waiting for completion...")
+                proc.wait(timeout=SUBPROCESS_TIMEOUT_SECS)
+
+    return exitcode
 
 
 def write_test_script(test_script, test_file):
@@ -54,25 +74,23 @@ class WorkbenchStartupTest(systemtesting.MantidSystemTest):
     """
     A system test for testing that Mantid Workbench opens ok for Linux, MacOS and Windows.
     """
+
     def __init__(self):
         super(WorkbenchStartupTest, self).__init__()
 
         self._test_file = NamedTemporaryFile(suffix=".txt", delete=False).name.replace('\\', '/')
         self._test_script = NamedTemporaryFile(suffix=".py", delete=False).name.replace('\\', '/')
-
+        self._executable = get_mantid_executable_path(sys.platform)
         write_test_script(self._test_script, self._test_file)
 
-        self._executable = get_mantid_executable_path(sys.platform)
-
     def runTest(self):
-        process = subprocess.Popen([self._executable, "--execute", self._test_script, "--quit"],
-                                   stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        exitcode = start_and_wait_for_completion([self._executable, "--execute", self._test_script, "--quit"])
 
-        # Wait for the process to finish execution, and assert it was successfully
-        self.assertTrue(process.wait() == 0)
+        # Was the process successful
+        self.assertEqual(0, exitcode)
         # Assert that the test script runs successfully by writing to a .txt file
         with open(self._test_file, "r") as file:
-            self.assertTrue(file.readline() == TEST_MESSAGE)
+            self.assertEqual(TEST_MESSAGE, file.readline())
 
     def cleanup(self):
         remove_file(self._test_script)


### PR DESCRIPTION
**Description of work.**

The legacy MantidWorkbench targets on macOS/Windows
were removed in favour of the setuptools generated ones but the startup test was not updated.

This adds handling for the Windows case where the outer process does not wait for the child to complete.

**To test:**

* Checkout the PR & build
* Run the system test
  * Windows: `systemtest -C Release -R WorkbenchStartup`
  * Linux/macOS: `systemtest -R WorkbenchStartup`

*There is no associated issue.*

*This does not require release notes* because **it fixes an internal error**

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
