### PR TITLE
GroupToXResolution documentation figures fix

### DIFF
--- a/docs/source/algorithms/GroupToXResolution-v1.rst
+++ b/docs/source/algorithms/GroupToXResolution-v1.rst
@@ -48,9 +48,9 @@ Usage
    grouped = GroupToXResolution(original)
    # Plot side-by-side comparison.
    fig, (left, right) = plt.subplots(ncols=2, subplot_kw={'projection':'mantid'})
-   left.errorbar(original, linestyle='None')
+   left.errorbar(original, linestyle='-')
    left.set_title('Original')
-   right.errorbar(grouped, linestyle='None')
+   right.errorbar(grouped, linestyle='-')
    right.set_title('Grouped')
    # Uncomment the next line to show the plot window.
    #fig.show()

--- a/docs/source/release/v6.5.0/Framework/Algorithms/Bugfixes/34273.rst
+++ b/docs/source/release/v6.5.0/Framework/Algorithms/Bugfixes/34273.rst
@@ -1,0 +1,1 @@
+- Fixed bug in documentation of :ref:`GroupToXResolution <algm-GroupToXResolution>` where the figures showing the algorithm output were all blank.


### PR DESCRIPTION
**Description of work.**

The line style was in the figure generation script in the documentation of `GroupToXResolution` algorithm was set to None, which resulted in blank figures. I propose it is changed to continuous line for better visibility.

I also checked other algorithms in the documentation that contain plots and they seem all to be fine.

**To test:**
1. Build documentation
2. Check if figures are not blank in the documentation of GroupToXResolution 

Fixes #34273 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

Release note added, not sure if it was necessary to start with.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
