### PR TITLE
Remove legacy macOS startup executable

### DIFF
--- a/dev-docs/source/UserSupport.rst
+++ b/dev-docs/source/UserSupport.rst
@@ -223,31 +223,29 @@ MacOS
 
 .. code-block:: shell
 
-	/Applications/MantidWorkbench.app/Contents/MacOS/MantidWorkbench
+   open --stdout=workbench_bundle.log --stderr=workbench_bundle.log /Applications/MantidWorkbench.app
 
 If this does not work, try launching with:
 
 .. code-block:: shell
 
-	cd /Applications/MantidWorkbench.app/Contents/MacOS
-	export QT_PLUGIN_PATH=$PWD/../PlugIns/
-	export PYTHONPATH=$PWD:$PYTHONPATH
-	python3 -m workbench.app.main
+   cd /Applications/MantidWorkbench.app/Contents/MacOS
+   ../Resources/python -m workbench.app.main
 
 
-4. Does **Qt** import correctly?
+1. Does **Qt** import correctly?
 
 .. code-block:: shell
 
-    /Applications/MantidWorkbench.app/Contents/MacOS/mantidpython --classic
-    import qtpy.QtCore
+   /Applications/MantidWorkbench.app/Contents/Resources/python
+   import qtpy.QtCore
 
 
 5. Do **Mantid Algorithms** import correctly?
 
 .. code-block:: shell
 
-    /Applications/MantidWorkbench.app/Contents/MacOS/mantidpython --classic
+    /Applications/MantidWorkbench.app/Contents/Resources/python
     import mantid.simpleapi
 
 
@@ -281,7 +279,7 @@ Advanced Options:
 
 .. code-block:: shell
 
-    cd /Applications/MantidWorkbench.app/Contents/MacOS/
+    cd /Applications/MantidWorkbench.app/Contents/Resources/
     python -c "import sys; import os; import pprint; pprint.pprint(sys.path); pprint.pprint(os.environ)"
 
 

--- a/installers/conda/common/common.sh
+++ b/installers/conda/common/common.sh
@@ -20,10 +20,10 @@ function trim_conda() {
   cp "$bundle_conda_prefix"/bin_tmp/python* "$bundle_conda_prefix"/bin/
   cp "$bundle_conda_prefix"/bin_tmp/Mantid.properties "$bundle_conda_prefix"/bin/
   cp "$bundle_conda_prefix"/bin_tmp/mantid-scripts.pth "$bundle_conda_prefix"/bin/
-  if [[ $OSTYPE == 'darwin'* ]]; then
-    cp "$bundle_conda_prefix"/bin_tmp/MantidWorkbench "$bundle_conda_prefix"/bin/
-  elif [[ $OSTYPE == 'linux'*  ]]; then
-    cp "$bundle_conda_prefix"/bin_tmp/workbench "$bundle_conda_prefix"/bin/
+  cp "$bundle_conda_prefix"/bin_tmp/workbench "$bundle_conda_prefix"/bin/
+  if [ -f "$bundle_conda_prefix"/bin_tmp/mantidworkbench ]; then
+    # keep handwritten startup script used on Linux and created by cmake if it exists.
+    # todo: Can it be amalgamated with osx/BundleExecutable somehow?
     cp "$bundle_conda_prefix"/bin_tmp/mantidworkbench "$bundle_conda_prefix"/bin/
   fi
   # Heavily cut down share

--- a/installers/conda/osx/BundleExecutable
+++ b/installers/conda/osx/BundleExecutable
@@ -21,4 +21,4 @@ echo "Using bundled conda-environment in '$PREFIX'"
 echo "Using Python: '$(which python)'"
 
 # Start
-"$PREFIX/bin/MantidWorkbench" "$@"
+python "$PREFIX/bin/workbench" "$@"


### PR DESCRIPTION
**Description of work.**

The legacy wrapper executable was deleted but the reference to it in the macOS bundle was not removed.

Remove it and use python directly as in the Linux startup

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**

* Build a standalone package locally:
`installers/conda/osx/create_bundle.sh -c mantid/label/nightly -s Nightly | tee package.log`
* Install the generated .dmg file
* Make sure usage reports are enabled
* Run workbench
* In a terminal run `ps -aux | grep spawn_main` and note the process ID
* Kill the process: using `kill <process_id>`
* The error reporter should pop up 

*This does not require release notes* because **it fixes an internal issue**

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
