### PR TITLE
Extend workbench system test process timeout

### DIFF
--- a/Testing/SystemTests/tests/qt/WorkbenchStartupTest.py
+++ b/Testing/SystemTests/tests/qt/WorkbenchStartupTest.py
@@ -15,7 +15,7 @@ from tempfile import NamedTemporaryFile
 
 TEST_MESSAGE = "Hello Mantid!"
 EXECUTABLE_SWITCHER = {"linux": ["launch_mantidworkbench.sh", "mantidworkbench"], "darwin": ["workbench"], "win32": ["workbench.exe"]}
-SUBPROCESS_TIMEOUT_SECS = 30
+SUBPROCESS_TIMEOUT_SECS = 300
 
 
 def get_mantid_executables_for_platform(platform):


### PR DESCRIPTION
**Description of work.**

Some older machines take a touch over 30 seconds to properly
load and run the workbench script. Increasing the timeout ensures
that if it is hit then it is a definite hang.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**

* System tests for Workbench should pass on Windows. See #34266 for instructions. 

*This does not require release notes* because **it is an internal testing change**

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
