### PR TITLE
Cannot open slice viewer bug

### DIFF
--- a/Testing/SystemTests/tests/qt/SliceViewerIntegrationTest.py
+++ b/Testing/SystemTests/tests/qt/SliceViewerIntegrationTest.py
@@ -31,7 +31,7 @@ from numpy.testing import assert_allclose
 
 
 class MockConfig(object):
-    def get(self, name):
+    def get(self, name, type=None):
         if name == SCALENORM:
             return "Log"
 

--- a/docs/source/release/v6.5.0/Workbench/SliceViewer/Bugfixes/34282.rst
+++ b/docs/source/release/v6.5.0/Workbench/SliceViewer/Bugfixes/34282.rst
@@ -1,0 +1,1 @@
+- Bug fix with SCALENORM and POWERNORM attributes not having type `str` set which prevented sliceviwer from opening

--- a/docs/source/release/v6.5.0/Workbench/SliceViewer/Bugfixes/34282.rst
+++ b/docs/source/release/v6.5.0/Workbench/SliceViewer/Bugfixes/34282.rst
@@ -1,1 +1,0 @@
-- Bug fix with SCALENORM and POWERNORM attributes not having type `str` set which prevented sliceviwer from opening

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_sliceviewer_dataview.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_sliceviewer_dataview.py
@@ -256,6 +256,18 @@ class SliceviewerDataViewTest(unittest.TestCase):
         self.view._line_plots.plotter.delete_line_plot_lines.assert_not_called()
         self.view._line_plots.plotter.update_line_plot_labels.assert_not_called()
 
+    def test_get_default_scale_norm_conf_none(self):
+        self.view.conf = None
+        scale = self.view.get_default_scale_norm()
+        self.assertEqual(scale, 'Linear')
+
+    def test_get_default_scale_norm_scalenorm(self):
+        self.view.conf = mock.Mock()
+        self.view.conf.has = mock.Mock(return_value=True)
+        self.view.conf.get = mock.Mock(return_value='Log')
+        scale = self.view.get_default_scale_norm()
+        self.assertEqual(scale, 'SymmetricLog10')
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/views/dataview.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/views/dataview.py
@@ -553,7 +553,7 @@ class SliceViewerDataView(QWidget):
             return scale
 
         if self.conf.has(SCALENORM):
-            scale = self.conf.get(SCALENORM)
+            scale = self.conf.get(SCALENORM, type=str)
 
         if scale == 'Power' and self.conf.has(POWERSCALE):
             exponent = self.conf.get(POWERSCALE)

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/views/dataview.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/views/dataview.py
@@ -556,7 +556,7 @@ class SliceViewerDataView(QWidget):
             scale = self.conf.get(SCALENORM, type=str)
 
         if scale == 'Power' and self.conf.has(POWERSCALE):
-            exponent = self.conf.get(POWERSCALE)
+            exponent = self.conf.get(POWERSCALE, type=str)
             scale = (scale, exponent)
 
         scale = "SymmetricLog10" if scale == 'Log' else scale


### PR DESCRIPTION
**Description of work.**

There is an issue where slice viewer cannot be opened due to `SCALENORM` type not being specified where the data view throws an exception when getting this attribute from the configuration. The fix is: 

```python
 scale = self.conf.get(SCALENORM, type=str)
```

This was not an issue in the initial release of v6.4.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**

Run this script before and after the fix. In the current version of main, sliceviewer cannot be opened.

```python
# import mantid algorithms, numpy and matplotlib
from mantid.simpleapi import *
import matplotlib.pyplot as plt
import numpy as np

signal = np.linspace(0,1,1000)
error = np.sqrt(signal)

signal -= 0.5

signal[signal>0.25] = np.nan

ws = CreateMDHistoWorkspace(Dimensionality=3,
                            Extents='-3,3,-10,10,-5,5',
                            SignalInput=signal,
                            ErrorInput=error,
                            NumberOfBins='10,10,10',
                            Names='[H,0,0],[0,K,0],[0,0,L]',
                            Units='r.l.u.,r.l.u.,r.l.u.',
                            Frames='HKL,HKL,HKL')
```
<!-- Instructions for testing. -->


*There is no associated issue.*


*This does not require release notes* because it was introduced in this iteration.

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
