### PR TITLE
Prevent Mantid crash when fitting Gaussian peaks for a CrystalFieldFunction

### DIFF
--- a/Framework/API/inc/MantidAPI/IFunction.h
+++ b/Framework/API/inc/MantidAPI/IFunction.h
@@ -555,7 +555,7 @@ public:
   /// Get the tie of i-th parameter
   virtual ParameterTie *getTie(size_t i) const;
   /// Ignore a tie
-  virtual bool ignoreTie(const ParameterTie &tie) const { return false; }
+  virtual bool ignoreTie(const ParameterTie &) const { return false; }
   /// Put all ties in order in which they will be applied correctly.
   void sortTies();
   /// Write a parameter tie to a string

--- a/Framework/API/inc/MantidAPI/IFunction.h
+++ b/Framework/API/inc/MantidAPI/IFunction.h
@@ -554,6 +554,8 @@ public:
   virtual bool removeTie(size_t i);
   /// Get the tie of i-th parameter
   virtual ParameterTie *getTie(size_t i) const;
+  /// Ignore a tie
+  virtual bool ignoreTie(const ParameterTie &tie) const { return false; }
   /// Put all ties in order in which they will be applied correctly.
   void sortTies();
   /// Write a parameter tie to a string

--- a/Framework/API/src/IFunction.cpp
+++ b/Framework/API/src/IFunction.cpp
@@ -1581,12 +1581,7 @@ void IFunction::sortTies() {
   std::list<TieNode> orderedTieNodes;
   for (size_t i = 0; i < nParams(); ++i) {
     auto const tie = getTie(i);
-    if (!tie) {
-      continue;
-    }
-    // Ignore height ties for Gaussian peaks as component of a CrystalFieldFunction
-    if (this->name() == "CrystalFieldFunction" && tie->ownerFunction()->name() == "Gaussian" &&
-        tie->parameterName() == "Height" && tie->asString().find("/Sigma") != std::string::npos) {
+    if (!tie || ignoreTie(*tie)) {
       continue;
     }
 

--- a/Framework/API/src/IFunction.cpp
+++ b/Framework/API/src/IFunction.cpp
@@ -1584,6 +1584,12 @@ void IFunction::sortTies() {
     if (!tie) {
       continue;
     }
+    // Ignore height ties for Gaussian peaks as component of a CrystalFieldFunction
+    if (this->name() == "CrystalFieldFunction" && tie->ownerFunction()->name() == "Gaussian" &&
+        tie->parameterName() == "Height" && tie->asString().find("/Sigma") != std::string::npos) {
+      continue;
+    }
+
     TieNode newNode;
     newNode.left = getParameterIndex(*tie);
     auto const rhsParameters = tie->getRHSParameters();

--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/CrystalFieldFunction.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/CrystalFieldFunction.h
@@ -70,6 +70,8 @@ public:
   void setUpForFit() override;
   /// Get the tie for i-th parameter
   API::ParameterTie *getTie(size_t i) const override;
+  /// Checks if whether tie should be ignored
+  bool ignoreTie(const API::ParameterTie &tie) const override;
   /// Get the i-th constraint
   API::IConstraint *getConstraint(size_t i) const override;
   //@}

--- a/Framework/CurveFitting/src/Functions/CrystalFieldFunction.cpp
+++ b/Framework/CurveFitting/src/Functions/CrystalFieldFunction.cpp
@@ -576,6 +576,13 @@ ParameterTie *CrystalFieldFunction::getTie(size_t i) const {
   return tie;
 }
 
+/// Checks if whether tie should be ignored
+bool CrystalFieldFunction::ignoreTie(const ParameterTie &tie) const {
+  // Ignore height ties for Gaussian peaks as component of a CrystalFieldFunction to avoid problems during tie sorting
+  return tie.ownerFunction()->name() == "Gaussian" && tie.parameterName() == "Height" &&
+         tie.asString().find("/Sigma") != std::string::npos;
+}
+
 /// Get the i-th constraint
 IConstraint *CrystalFieldFunction::getConstraint(size_t i) const {
   checkSourceFunction();

--- a/Framework/CurveFitting/test/Functions/CrystalFieldFunctionTest.h
+++ b/Framework/CurveFitting/test/Functions/CrystalFieldFunctionTest.h
@@ -11,10 +11,12 @@
 #include "MantidAPI/AlgorithmFactory.h"
 #include "MantidAPI/AnalysisDataService.h"
 #include "MantidAPI/FunctionFactory.h"
+#include "MantidAPI/ParameterTie.h"
 #include "MantidAPI/WorkspaceGroup.h"
 #include "MantidCurveFitting/Algorithms/EvaluateFunction.h"
 #include "MantidCurveFitting/Algorithms/Fit.h"
 #include "MantidCurveFitting/Functions/CrystalFieldFunction.h"
+#include "MantidCurveFitting/Functions/Gaussian.h"
 #include "MantidFrameworkTestHelpers/WorkspaceCreationHelper.h"
 
 using namespace Mantid;
@@ -682,6 +684,18 @@ public:
     cf.setAttributeValue("PeakShape", "Lorentzian");
     TS_ASSERT_EQUALS(cf.getParameter("ion0.B20"), 1.0);
     TS_ASSERT_EQUALS(cf.getParameter("ion1.B20"), 2.0);
+  }
+
+  void test_ignore_height_tie_for_gaussian_peaks() {
+    CrystalFieldFunction cf;
+    Gaussian gaussian;
+    gaussian.initialize();
+    ParameterTie tie1(&gaussian, "Height", "2.0/Sigma");
+    ParameterTie tie2(&gaussian, "PeakCentre", "2.0/Sigma");
+    ParameterTie tie3(&gaussian, "Height", "2.0");
+    TS_ASSERT(cf.ignoreTie(tie1));
+    TS_ASSERT(!cf.ignoreTie(tie2));
+    TS_ASSERT(!cf.ignoreTie(tie3));
   }
 
 private:

--- a/docs/source/release/v6.5.0/Direct_Geometry/CrystalField/Bugfixes/34283.rst
+++ b/docs/source/release/v6.5.0/Direct_Geometry/CrystalField/Bugfixes/34283.rst
@@ -1,0 +1,1 @@
+- Fix for sortTies to prevent Mantid crash when fitting CrystalField multisite objects with Gaussian peaks.

--- a/scripts/test/CrystalFieldMultiSiteTest.py
+++ b/scripts/test/CrystalFieldMultiSiteTest.py
@@ -599,6 +599,26 @@ class CrystalFieldMultiSiteTests(unittest.TestCase):
         self.assertTrue(cf.function.isFixed(cf.function.getParameterIndex("ion1.B66")))
         self.assertTrue(cf.function.isFixed(cf.function.getParameterIndex("ion1.IB62")))
 
+    def test_fit_gaussian_peaks(self):
+        origin = CrystalField('Ce', 'C2v', B20=0.37737, B22=3.9770, B40=-0.031787, B42=-0.11611, B44=-0.12544, Temperature=44.0, FWHM=1.1)
+        x, y = origin.getSpectrum()
+        ws = makeWorkspace(x, y)
+
+        params = {'B20': 0.37737, 'B22': 3.9770, 'B40': -0.031787, 'B42': -0.11611, 'B44': -0.12544,
+                  'Temperature': 44.0, 'FWHM': 1.1}
+        cf1 = CrystalField.CrystalField('Ce', 'C2v', **params)
+        cf2 = CrystalField.CrystalField('Pr', 'C2v', **params)
+        cf = cf1 + cf2
+        cf.PeakShape = 'Gaussian'
+
+        chi2 = CalculateChiSquared(cf.makeSpectrumFunction(), InputWorkspace=ws)[1]
+
+        fit = CrystalFieldFit(Model=cf, InputWorkspace=ws,MaxIterations=10)
+        fit.fit()
+
+        self.assertGreater(cf.chi2, 0.0)
+        self.assertLess(cf.chi2, chi2)
+
     def test_two_step_fit_multi_ion_single_spectrum(self):
         params = {'B20': 0.37737, 'B22': 3.9770, 'B40': -0.031787, 'B42': -0.11611, 'B44': -0.12544,
                   'Temperature': 44.0, 'FWHM': 1.1}

--- a/scripts/test/CrystalFieldMultiSiteTest.py
+++ b/scripts/test/CrystalFieldMultiSiteTest.py
@@ -600,7 +600,8 @@ class CrystalFieldMultiSiteTests(unittest.TestCase):
         self.assertTrue(cf.function.isFixed(cf.function.getParameterIndex("ion1.IB62")))
 
     def test_fit_gaussian_peaks(self):
-        origin = CrystalField('Ce', 'C2v', B20=0.37737, B22=3.9770, B40=-0.031787, B42=-0.11611, B44=-0.12544, Temperature=44.0, FWHM=1.1)
+        origin = CrystalField.CrystalField('Ce', 'C2v', B20=0.37737, B22=3.9770, B40=-0.031787, B42=-0.11611, B44=-0.12544,
+                                           Temperature=44.0, FWHM=1.1)
         x, y = origin.getSpectrum()
         ws = makeWorkspace(x, y)
 

--- a/scripts/test/CrystalFieldMultiSiteTest.py
+++ b/scripts/test/CrystalFieldMultiSiteTest.py
@@ -603,7 +603,7 @@ class CrystalFieldMultiSiteTests(unittest.TestCase):
         origin = CrystalField.CrystalField('Ce', 'C2v', B20=0.37737, B22=3.9770, B40=-0.031787, B42=-0.11611, B44=-0.12544,
                                            Temperature=44.0, FWHM=1.1)
         x, y = origin.getSpectrum()
-        ws = makeWorkspace(x, y)
+        ws = CrystalField.fitting.makeWorkspace(x, y)
 
         params = {'B20': 0.37737, 'B22': 3.9770, 'B40': -0.031787, 'B42': -0.11611, 'B44': -0.12544,
                   'Temperature': 44.0, 'FWHM': 1.1}
@@ -614,7 +614,7 @@ class CrystalFieldMultiSiteTests(unittest.TestCase):
 
         chi2 = CalculateChiSquared(cf.makeSpectrumFunction(), InputWorkspace=ws)[1]
 
-        fit = CrystalFieldFit(Model=cf, InputWorkspace=ws,MaxIterations=10)
+        fit = CrystalField.CrystalFieldFit(Model=cf, InputWorkspace=ws,MaxIterations=10)
         fit.fit()
 
         self.assertGreater(cf.chi2, 0.0)


### PR DESCRIPTION
**Description of work.**

Added check for height ties based on sigma for Gaussian peaks within a CrystalFieldFunction to void IFunction::sortTies(). In this case the tie is not sorted but still applied as usual for its respective peak function. The sortTies function does not differentiate between ties applied to individual peaks separately and ties that can potentially influence each other. This caused Mantid crashes for multisite CrystalField objects with Gaussian peaks as Gaussian peaks automatically have a tie based on sigma for its height.

**To test:**

Run the script from the original issue [34245](https://github.com/mantidproject/mantid/issues/34245) and check it works.

Fixes #34245 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
