### PR TITLE
Correct EigenJacobian and remove GSL from JacobianImpl1

### DIFF
--- a/Framework/CurveFitting/CMakeLists.txt
+++ b/Framework/CurveFitting/CMakeLists.txt
@@ -409,6 +409,7 @@ set(TEST_FILES
     EigenComplexVectorTest.h
     EigenFortranMatrixTest.h
     EigenFortranVectorTest.h
+    EigenJacobianTest.h
     EigenMatrixTest.h
     EigenToGSLTest.h
     EigenVectorTest.h

--- a/Framework/CurveFitting/inc/MantidCurveFitting/EigenJacobian.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/EigenJacobian.h
@@ -127,13 +127,13 @@ public:
     }
     int j = m_index[iP];
     if (j >= 0)
-      m_J->mutator().data()[iY * m_J->size2() + j] = value;
+      m_J->mutator().data()[j * m_J->size1() + iY] = value;
   }
   /// overwrite base method
   double get(size_t iY, size_t iP) override {
     int j = m_index[iP];
     if (j >= 0)
-      return m_J->inspector().data()[iY * m_J->size2() + j];
+      return m_J->inspector().data()[j * m_J->size1() + iY];
     return 0.0;
   }
   /// overwrite base method

--- a/Framework/CurveFitting/inc/MantidCurveFitting/EigenJacobian.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/EigenJacobian.h
@@ -10,7 +10,6 @@
 #include "MantidAPI/Jacobian.h"
 #include "MantidCurveFitting/EigenMatrix.h"
 
-#include <iostream>
 #include <stdexcept>
 #include <vector>
 
@@ -56,7 +55,7 @@ public:
   void addNumberToColumn(const double &value, const size_t &iActiveP) override {
     if (iActiveP < m_J.size2()) {
       // add penalty to first and last point and every 10th point in between
-      m_J.mutator().data()[iActiveP] += value;
+      m_J.mutator().data()[iActiveP * m_J.size1()] += value;
       m_J.mutator().data()[(iActiveP + 1) * m_J.size1() - 1] += value;
       for (size_t iY = 9; iY < m_J.size1() - 1; iY += 10)
         m_J.mutator().data()[iActiveP * m_J.size1() + iY] += value;
@@ -101,10 +100,10 @@ public:
   void addNumberToColumn(const double &value, const size_t &iActiveP) override {
     if (iActiveP < m_J->size2()) {
       // add penalty to first and last point and every 10th point in between
-      m_J->mutator().data()[iActiveP] += value;
-      m_J->mutator().data()[(iActiveP + 1) * m_J.size1() - 1] += value;
+      m_J->mutator().data()[iActiveP * m_J->size1()] += value;
+      m_J->mutator().data()[(iActiveP + 1) * m_J->size1() - 1] += value;
       for (size_t iY = 9; iY < m_J->size1() - 1; iY += 10)
-        m_J->mutator().data()[iActiveP * m_J.size1() + iY] += value;
+        m_J->mutator().data()[iActiveP * m_J->size1() + iY] += value;
     } else {
       throw std::runtime_error("Try to add number to column of Jacobian matrix "
                                "which does not exist.");

--- a/Framework/CurveFitting/inc/MantidCurveFitting/EigenJacobian.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/EigenJacobian.h
@@ -10,6 +10,7 @@
 #include "MantidAPI/Jacobian.h"
 #include "MantidCurveFitting/EigenMatrix.h"
 
+#include <iostream>
 #include <stdexcept>
 #include <vector>
 
@@ -35,8 +36,9 @@ public:
     size_t np = 0; // number of active parameters
     for (size_t i = 0; i < fun.nParams(); ++i) {
       m_index[i] = static_cast<int>(np);
-      if (fun.isActive(i))
+      if (fun.isActive(i)) {
         ++np;
+      }
     }
     m_J.resize(ny, np);
   }
@@ -55,9 +57,9 @@ public:
     if (iActiveP < m_J.size2()) {
       // add penalty to first and last point and every 10th point in between
       m_J.mutator().data()[iActiveP] += value;
-      m_J.mutator().data()[(m_J.size1() - 1) * m_J.size2() + iActiveP] += value;
+      m_J.mutator().data()[(iActiveP + 1) * m_J.size1() - 1] += value;
       for (size_t iY = 9; iY < m_J.size1() - 1; iY += 10)
-        m_J.mutator().data()[iY * m_J.size2() + iActiveP] += value;
+        m_J.mutator().data()[iActiveP * m_J.size1() + iY] += value;
     } else {
       throw std::runtime_error("Try to add number to column of Jacobian matrix "
                                "which does not exist.");
@@ -100,9 +102,9 @@ public:
     if (iActiveP < m_J->size2()) {
       // add penalty to first and last point and every 10th point in between
       m_J->mutator().data()[iActiveP] += value;
-      m_J->mutator().data()[(m_J->size1() - 1) * m_J->size2() + iActiveP] += value;
+      m_J->mutator().data()[(iActiveP + 1) * m_J.size1() - 1] += value;
       for (size_t iY = 9; iY < m_J->size1() - 1; iY += 10)
-        m_J->mutator().data()[iY * m_J->size2() + iActiveP] += value;
+        m_J->mutator().data()[iActiveP * m_J.size1() + iY] += value;
     } else {
       throw std::runtime_error("Try to add number to column of Jacobian matrix "
                                "which does not exist.");

--- a/Framework/CurveFitting/inc/MantidCurveFitting/EigenJacobian.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/EigenJacobian.h
@@ -10,8 +10,6 @@
 #include "MantidAPI/Jacobian.h"
 #include "MantidCurveFitting/EigenMatrix.h"
 
-#include <gsl/gsl_matrix.h>
-
 #include <stdexcept>
 #include <vector>
 
@@ -19,13 +17,11 @@ namespace Mantid {
 namespace CurveFitting {
 /**
 Two implementations of Jacobian.
--The first (EigenJacobian) using Eigen::Matrix.
-- The second (JacobianImpl1) using gsl_matrix.
 @author Anders Markvardsen, ISIS, RAL
 @date 14/05/2010
 */
 class EigenJacobian : public API::Jacobian {
-  /// The pointer to the the internal jacobian matrix
+  /// The internal jacobian matrix
   EigenMatrix m_J;
   /// Maps declared indeces to active. For fixed (tied) parameters holds -1
   std::vector<int> m_index;
@@ -47,7 +43,7 @@ public:
 
   EigenMatrix &matrix() { return m_J; }
 
-  /// Get the pointer to the GSL's jacobian
+  /// Get the map to the jacobian
   map_type &getJ() { return m_J.mutator(); }
 
   /// overwrite base method
@@ -85,15 +81,15 @@ public:
 };
 
 /// The implementation of Jacobian
-class JacobianImpl1 : public API::Jacobian {
+template <class T> class JacobianImpl1 : public API::Jacobian {
 public:
-  /// The pointer to the GSL's internal jacobian matrix
-  gsl_matrix *m_J;
-  /// Maps declared indeces to active. For fixed (tied) parameters holds -1
+  /// The internal jacobian matrix
+  T *m_J;
+  /// Maps declared indices to active. For fixed (tied) parameters holds -1
   std::vector<int> m_index;
 
-  /// Set the pointer to the GSL's jacobian
-  void setJ(gsl_matrix *J) { m_J = J; }
+  /// Set the pointer to the jacobian
+  void setJ(T *J) { m_J = J; }
 
   /// overwrite base method
   /// @param value :: the value
@@ -101,12 +97,12 @@ public:
   ///  @throw runtime_error Thrown if column of Jacobian to add number to does
   ///  not exist
   void addNumberToColumn(const double &value, const size_t &iActiveP) override {
-    if (iActiveP < m_J->size2) {
+    if (iActiveP < m_J->size2()) {
       // add penalty to first and last point and every 10th point in between
-      m_J->data[iActiveP] += value;
-      m_J->data[(m_J->size1 - 1) * m_J->size2 + iActiveP] += value;
-      for (size_t iY = 9; iY < m_J->size1 - 1; iY += 10)
-        m_J->data[iY * m_J->size2 + iActiveP] += value;
+      m_J->mutator().data()[iActiveP] += value;
+      m_J->mutator().data()[(m_J->size1() - 1) * m_J->size2() + iActiveP] += value;
+      for (size_t iY = 9; iY < m_J->size1() - 1; iY += 10)
+        m_J->mutator().data()[iY * m_J->size2() + iActiveP] += value;
     } else {
       throw std::runtime_error("Try to add number to column of Jacobian matrix "
                                "which does not exist.");
@@ -131,17 +127,17 @@ public:
     }
     int j = m_index[iP];
     if (j >= 0)
-      gsl_matrix_set(m_J, iY, j, value);
+      m_J->mutator().data()[iY * m_J->size2() + j] = value;
   }
   /// overwrite base method
   double get(size_t iY, size_t iP) override {
     int j = m_index[iP];
     if (j >= 0)
-      return gsl_matrix_get(m_J, iY, j);
+      return m_J->inspector().data()[iY * m_J->size2() + j];
     return 0.0;
   }
   /// overwrite base method
-  void zero() override { gsl_matrix_set_zero(m_J); }
+  void zero() override { m_J->zero(); }
 };
 
 } // namespace CurveFitting

--- a/Framework/CurveFitting/inc/MantidCurveFitting/FuncMinimizers/TrustRegionMinimizer.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/FuncMinimizers/TrustRegionMinimizer.h
@@ -54,7 +54,7 @@ private:
   /// Fitting parameters
   DoubleFortranVector m_x;
   /// The Jacobian
-  mutable JacobianImpl1 m_J;
+  mutable JacobianImpl1<DoubleFortranMatrix> m_J;
   /// Options
   NLLS::nlls_options m_options;
   /// Information about the fitting

--- a/Framework/CurveFitting/inc/MantidCurveFitting/GSLFunctions.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/GSLFunctions.h
@@ -40,7 +40,7 @@ struct GSL_FitData {
   /// Initial function parameters
   gsl_vector *initFuncParams;
   /// Jacobi matrix interface
-  JacobianImpl1 J;
+  JacobianImpl1<EigenMatrix> J;
 
   // this is presently commented out in the implementation
   // gsl_matrix *holdCalculatedJacobian; ///< cache of the calculated jacobian

--- a/Framework/CurveFitting/src/FuncMinimizers/TrustRegionMinimizer.cpp
+++ b/Framework/CurveFitting/src/FuncMinimizers/TrustRegionMinimizer.cpp
@@ -18,6 +18,8 @@
 
 #include <gsl/gsl_blas.h>
 
+#include <iostream>
+
 namespace Mantid::CurveFitting::FuncMinimisers {
 
 // clang-format off
@@ -101,11 +103,8 @@ void TrustRegionMinimizer::evalJ(const DoubleFortranVector &x, DoubleFortranMatr
     J.allocate(m, n);
   }
 
-  DoubleFortranMatrix J_tr(J.transpose());
-  gsl_matrix_view J_tr_gsl = getGSLMatrixView(J_tr.mutator());
-  m_J.setJ(&J_tr_gsl.matrix);
+  m_J.setJ(&J);
   m_function->functionDeriv(domain, m_J);
-  J = J_tr.tr();
 
   for (int i = 1; i <= m; ++i) {
     double w = values.getFitWeight(i - 1);

--- a/Framework/CurveFitting/src/GSLFunctions.cpp
+++ b/Framework/CurveFitting/src/GSLFunctions.cpp
@@ -10,6 +10,7 @@
 #include "MantidCurveFitting/GSLFunctions.h"
 #include "MantidAPI/IConstraint.h"
 #include "MantidAPI/ICostFunction.h"
+#include <iostream>
 
 namespace Mantid::CurveFitting {
 
@@ -80,13 +81,28 @@ int gsl_f(const gsl_vector *x, void *params, gsl_vector *f) {
  * @param J :: Output derivatives
  * @return A GSL status information
  */
+
+void print_gsl_matrix(const gsl_matrix *J) {
+  for (int j = 0; j < J->size1; j++) {   // rows
+    for (int i = 0; i < J->size2; i++) { // cols
+      std::cout << gsl_matrix_get(J, j, i) << " ";
+    }
+    std::cout << std::endl;
+  }
+  std::cout << std::endl;
+}
+
 int gsl_df(const gsl_vector *x, void *params, gsl_matrix *J) {
 
   auto *p = reinterpret_cast<struct GSL_FitData *>(params);
+  print_gsl_matrix(J); // TEMP
   gsl_matrix *J_tr = gsl_matrix_calloc(J->size2, J->size1);
+  // print_gsl_matrix(J_tr); // TEMP
   gsl_matrix_transpose_memcpy(J_tr, J);
-  EigenMatrix m(J_tr->size1, J_tr->size2);
-  std::copy(&m.mutator().data()[0], &m.mutator().data()[J_tr->size1 * J_tr->size2], &J_tr->data[0]);
+  // print_gsl_matrix(J_tr); // TEMP
+  EigenMatrix m(J_tr->size2, J_tr->size1);
+  // std::copy(&J_tr->data[0], &J_tr->data[J_tr->size1 * J_tr->size2], &m.mutator().data()[0]); // TEMP
+  // std::cout << m << std::endl;
   p->J.setJ(&m);
 
   // update function parameters
@@ -140,6 +156,13 @@ int gsl_df(const gsl_vector *x, void *params, gsl_matrix *J) {
     for (size_t iP = 0; iP < p->p; iP++) {
       J->data[iY * p->p + iP] *= values->getFitWeight(iY);
     }
+
+  // std::cout << m << std::endl;  //TEMP
+  EigenMatrix m_tr = m.tr();
+  // std::cout << m_tr << std::endl;  //TEMP
+  // print_gsl_matrix(J);            // TEMP
+  std::copy(&m_tr.mutator().data()[0], &m_tr.mutator().data()[J_tr->size1 * J_tr->size2], &J->data[0]);
+  print_gsl_matrix(J); // TEMP
 
   return GSL_SUCCESS;
 }

--- a/Framework/CurveFitting/src/GSLFunctions.cpp
+++ b/Framework/CurveFitting/src/GSLFunctions.cpp
@@ -83,8 +83,11 @@ int gsl_f(const gsl_vector *x, void *params, gsl_vector *f) {
 int gsl_df(const gsl_vector *x, void *params, gsl_matrix *J) {
 
   auto *p = reinterpret_cast<struct GSL_FitData *>(params);
-
-  p->J.setJ(J);
+  gsl_matrix *J_tr = gsl_matrix_calloc(J->size2, J->size1);
+  gsl_matrix_transpose_memcpy(J_tr, J);
+  EigenMatrix m(J_tr->size1, J_tr->size2);
+  std::copy(&m.mutator().data()[0], &m.mutator().data()[J_tr->size1 * J_tr->size2], &J_tr->data[0]);
+  p->J.setJ(&m);
 
   // update function parameters
   if (x->data) {

--- a/Framework/CurveFitting/test/EigenJacobianTest.h
+++ b/Framework/CurveFitting/test/EigenJacobianTest.h
@@ -76,7 +76,7 @@ public:
     JacobianImpl1<EigenMatrix> J;
 
     J.m_index.reserve(n_params);
-    for (size_t i = 0; i < n_params; ++i) {
+    for (int i = 0; i < n_params; ++i) {
       J.m_index.emplace_back(i);
     }
 

--- a/Framework/CurveFitting/test/EigenJacobianTest.h
+++ b/Framework/CurveFitting/test/EigenJacobianTest.h
@@ -99,7 +99,7 @@ public:
     JacobianImpl1<EigenMatrix> J;
 
     J.m_index.reserve(n_params);
-    for (size_t i = 0; i < n_params; ++i) {
+    for (int i = 0; i < n_params; ++i) {
       J.m_index.emplace_back(i);
     }
 

--- a/Framework/CurveFitting/test/EigenJacobianTest.h
+++ b/Framework/CurveFitting/test/EigenJacobianTest.h
@@ -1,0 +1,124 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2022 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#pragma once
+
+#include "MantidCurveFitting/EigenJacobian.h"
+#include "MantidCurveFitting/EigenMatrix.h"
+#include "MantidCurveFitting/Functions/Gaussian.h"
+#include "MantidCurveFitting/GSLFunctions.h"
+#include <cxxtest/TestSuite.h>
+
+using namespace Mantid::API;
+using namespace Mantid::CurveFitting;
+
+class EigenToGSLTest : public CxxTest::TestSuite {
+public:
+  std::shared_ptr<Functions::Gaussian> generate_tst_fn() {
+    std::shared_ptr<Functions::Gaussian> fn = std::make_shared<Functions::Gaussian>();
+    fn->initialize();
+    fn->setParameter("PeakCentre", 79440.0);
+    fn->setParameter("Height", 200.0);
+    fn->setParameter("Sigma", 30.0);
+    return fn;
+  }
+
+  void test_EigenJacobian_initialise() {
+    auto test_fn = generate_tst_fn();
+    int size = 10;
+
+    EigenJacobian J(*test_fn, size);
+    TS_ASSERT_EQUALS(J.matrix().size1(), size);
+    TS_ASSERT_EQUALS(J.matrix().size2(), test_fn->nParams());
+  }
+
+  void test_EigenJacobian_get_and_set() {
+    auto test_fn = generate_tst_fn();
+    int size = 10;
+    int val = 5;
+
+    EigenJacobian J(*test_fn, size);
+
+    J.set(5, 1, val);
+    J.set(9, 2, val * 3);
+    TS_ASSERT_EQUALS(J.get(5, 1), val);
+    TS_ASSERT_EQUALS(J.get(9, 2), val * 3);
+  }
+
+  void test_EigenJacobian_add_number_to_column() {
+    auto test_fn = generate_tst_fn();
+    int size = 35;
+    int val = 5;
+
+    EigenJacobian J(*test_fn, size);
+    J.addNumberToColumn(val, 0);
+    TS_ASSERT_EQUALS(J.get(0, 0), val);
+    TS_ASSERT_EQUALS(J.get(9, 0), val);
+    TS_ASSERT_EQUALS(J.get(19, 0), val);
+    TS_ASSERT_EQUALS(J.get(29, 0), val);
+    TS_ASSERT_EQUALS(J.get(size - 1, 0), val);
+
+    J.addNumberToColumn(val + 5, 1);
+    TS_ASSERT_EQUALS(J.get(0, 1), val + 5);
+    TS_ASSERT_EQUALS(J.get(9, 1), val + 5);
+    TS_ASSERT_EQUALS(J.get(19, 1), val + 5);
+    TS_ASSERT_EQUALS(J.get(29, 1), val + 5);
+    TS_ASSERT_EQUALS(J.get(size - 1, 1), val + 5);
+  }
+
+  void test_EigenJacobian_Impl1_test_get_and_set() {
+    int size = 10;
+    int val = 5;
+    int n_params = 3;
+
+    JacobianImpl1<EigenMatrix> J;
+
+    J.m_index.reserve(n_params);
+    for (size_t i = 0; i < n_params; ++i) {
+      J.m_index.emplace_back(i);
+    }
+
+    EigenMatrix m(size, n_params);
+    J.setJ(&m);
+
+    J.set(5, 1, val);
+    J.set(9, 2, val * 3);
+    TS_ASSERT_EQUALS(J.get(5, 1), val);
+    TS_ASSERT_EQUALS(J.get(9, 2), val * 3);
+    TS_ASSERT_EQUALS(m(5, 1), val);
+    TS_ASSERT_EQUALS(m(9, 2), val * 3);
+  }
+
+  void test_EigenJacobian_Impl1_test_add_number_to_column() {
+    int size = 35;
+    int val = 5;
+    int n_params = 3;
+
+    JacobianImpl1<EigenMatrix> J;
+
+    J.m_index.reserve(n_params);
+    for (size_t i = 0; i < n_params; ++i) {
+      J.m_index.emplace_back(i);
+    }
+
+    EigenMatrix m(size, n_params);
+    J.setJ(&m);
+
+    J.addNumberToColumn(val, 0);
+    TS_ASSERT_EQUALS(J.get(0, 0), val);
+    TS_ASSERT_EQUALS(J.get(9, 0), val);
+    TS_ASSERT_EQUALS(J.get(19, 0), val);
+    TS_ASSERT_EQUALS(J.get(29, 0), val);
+    TS_ASSERT_EQUALS(J.get(size - 1, 0), val);
+
+    J.addNumberToColumn(val + 5, 1);
+    TS_ASSERT_EQUALS(J.get(0, 1), val + 5);
+    TS_ASSERT_EQUALS(J.get(9, 1), val + 5);
+    TS_ASSERT_EQUALS(J.get(19, 1), val + 5);
+    TS_ASSERT_EQUALS(J.get(29, 1), val + 5);
+    TS_ASSERT_EQUALS(J.get(size - 1, 1), val + 5);
+  }
+};

--- a/Framework/CurveFitting/test/EigenJacobianTest.h
+++ b/Framework/CurveFitting/test/EigenJacobianTest.h
@@ -37,7 +37,7 @@ public:
   void test_EigenJacobian_get_and_set() {
     auto test_fn = generate_tst_fn();
     int size = 10;
-    int val = 5;
+    double val = 5;
 
     EigenJacobian J(*test_fn, size);
 
@@ -49,8 +49,8 @@ public:
 
   void test_EigenJacobian_add_number_to_column() {
     auto test_fn = generate_tst_fn();
-    int size = 35;
-    int val = 5;
+    double size = 35;
+    double val = 5;
 
     EigenJacobian J(*test_fn, size);
     J.addNumberToColumn(val, 0);
@@ -60,17 +60,17 @@ public:
     TS_ASSERT_EQUALS(J.get(29, 0), val);
     TS_ASSERT_EQUALS(J.get(size - 1, 0), val);
 
-    J.addNumberToColumn(val + 5, 1);
+    J.addNumberToColumn((size_t)val + 5, 1);
     TS_ASSERT_EQUALS(J.get(0, 1), val + 5);
     TS_ASSERT_EQUALS(J.get(9, 1), val + 5);
     TS_ASSERT_EQUALS(J.get(19, 1), val + 5);
     TS_ASSERT_EQUALS(J.get(29, 1), val + 5);
-    TS_ASSERT_EQUALS(J.get(size - 1, 1), val + 5);
+    TS_ASSERT_EQUALS(J.get((size_t)size - 1, 1), (size_t)val + 5);
   }
 
   void test_EigenJacobian_Impl1_test_get_and_set() {
     int size = 10;
-    int val = 5;
+    double val = 5;
     int n_params = 3;
 
     JacobianImpl1<EigenMatrix> J;
@@ -92,8 +92,8 @@ public:
   }
 
   void test_EigenJacobian_Impl1_test_add_number_to_column() {
-    int size = 35;
-    int val = 5;
+    double size = 35;
+    double val = 5;
     int n_params = 3;
 
     JacobianImpl1<EigenMatrix> J;

--- a/Framework/CurveFitting/test/EigenJacobianTest.h
+++ b/Framework/CurveFitting/test/EigenJacobianTest.h
@@ -9,7 +9,6 @@
 #include "MantidCurveFitting/EigenJacobian.h"
 #include "MantidCurveFitting/EigenMatrix.h"
 #include "MantidCurveFitting/Functions/Gaussian.h"
-#include "MantidCurveFitting/GSLFunctions.h"
 #include <cxxtest/TestSuite.h>
 
 using namespace Mantid::API;

--- a/Framework/CurveFitting/test/EigenJacobianTest.h
+++ b/Framework/CurveFitting/test/EigenJacobianTest.h
@@ -14,7 +14,7 @@
 using namespace Mantid::API;
 using namespace Mantid::CurveFitting;
 
-class EigenToGSLTest : public CxxTest::TestSuite {
+class EigenJacobianTest : public CxxTest::TestSuite {
 public:
   std::shared_ptr<Functions::Gaussian> generate_tst_fn() {
     std::shared_ptr<Functions::Gaussian> fn = std::make_shared<Functions::Gaussian>();
@@ -36,8 +36,8 @@ public:
 
   void test_EigenJacobian_get_and_set() {
     auto test_fn = generate_tst_fn();
-    int size = 10;
-    double val = 5;
+    const size_t size = 10;
+    const double val = 5;
 
     EigenJacobian J(*test_fn, size);
 
@@ -49,8 +49,8 @@ public:
 
   void test_EigenJacobian_add_number_to_column() {
     auto test_fn = generate_tst_fn();
-    double size = 35;
-    double val = 5;
+    const size_t size = 35;
+    const double val = 5;
 
     EigenJacobian J(*test_fn, size);
     J.addNumberToColumn(val, 0);
@@ -60,7 +60,7 @@ public:
     TS_ASSERT_EQUALS(J.get(29, 0), val);
     TS_ASSERT_EQUALS(J.get(size - 1, 0), val);
 
-    J.addNumberToColumn((size_t)val + 5, 1);
+    J.addNumberToColumn(val + 5, 1);
     TS_ASSERT_EQUALS(J.get(0, 1), val + 5);
     TS_ASSERT_EQUALS(J.get(9, 1), val + 5);
     TS_ASSERT_EQUALS(J.get(19, 1), val + 5);
@@ -68,7 +68,7 @@ public:
     TS_ASSERT_EQUALS(J.get((size_t)size - 1, 1), (size_t)val + 5);
   }
 
-  void test_EigenJacobian_Impl1_test_get_and_set() {
+  void test_JacobianImpl1_get_and_set() {
     int size = 10;
     double val = 5;
     int n_params = 3;
@@ -91,10 +91,10 @@ public:
     TS_ASSERT_EQUALS(m(9, 2), val * 3);
   }
 
-  void test_EigenJacobian_Impl1_test_add_number_to_column() {
-    double size = 35;
-    double val = 5;
-    int n_params = 3;
+  void test_JacobianImpl1_add_number_to_column() {
+    const size_t size = 35;
+    const double val = 5;
+    const int n_params = 3;
 
     JacobianImpl1<EigenMatrix> J;
 

--- a/Framework/CurveFitting/test/EigenToGSLTest.h
+++ b/Framework/CurveFitting/test/EigenToGSLTest.h
@@ -13,9 +13,6 @@
 #include <MantidCurveFitting/GSLFunctions.h>
 #include <gsl/gsl_blas.h>
 
-// JACOBIAN TEST INCLUDES
-#include "MantidCurveFitting/Functions/Gaussian.h"
-
 using namespace Mantid::API;
 using namespace Mantid::CurveFitting;
 
@@ -110,108 +107,5 @@ public:
     for (size_t i = 0; i < v.size(); i++) {
       TS_ASSERT_EQUALS(gsl_vector_get(&v_gsl.vector, i), v[i]);
     }
-  }
-
-  std::shared_ptr<Functions::Gaussian> generate_tst_fn() {
-    std::shared_ptr<Functions::Gaussian> fn = std::make_shared<Functions::Gaussian>();
-    fn->initialize();
-    fn->setParameter("PeakCentre", 79440.0);
-    fn->setParameter("Height", 200.0);
-    fn->setParameter("Sigma", 30.0);
-    return fn;
-  }
-
-  void test_EigenJacobian_initialise() {
-    auto test_fn = generate_tst_fn();
-    int size = 10;
-
-    EigenJacobian J(*test_fn, size);
-    TS_ASSERT_EQUALS(J.matrix().size1(), size);
-    TS_ASSERT_EQUALS(J.matrix().size2(), test_fn->nParams());
-  }
-
-  void test_EigenJacobian_get_and_set() {
-    auto test_fn = generate_tst_fn();
-    int size = 10;
-    int val = 5;
-
-    EigenJacobian J(*test_fn, size);
-
-    J.set(5, 1, val);
-    J.set(9, 2, val * 3);
-    TS_ASSERT_EQUALS(J.get(5, 1), val);
-    TS_ASSERT_EQUALS(J.get(9, 2), val * 3);
-  }
-
-  void test_EigenJacobian_add_number_to_column() {
-    auto test_fn = generate_tst_fn();
-    int size = 35;
-    int val = 5;
-
-    EigenJacobian J(*test_fn, size);
-    J.addNumberToColumn(val, 0);
-    TS_ASSERT_EQUALS(J.get(0, 0), val);
-    TS_ASSERT_EQUALS(J.get(9, 0), val);
-    TS_ASSERT_EQUALS(J.get(19, 0), val);
-    TS_ASSERT_EQUALS(J.get(29, 0), val);
-    TS_ASSERT_EQUALS(J.get(size - 1, 0), val);
-
-    J.addNumberToColumn(val + 5, 1);
-    TS_ASSERT_EQUALS(J.get(0, 1), val + 5);
-    TS_ASSERT_EQUALS(J.get(9, 1), val + 5);
-    TS_ASSERT_EQUALS(J.get(19, 1), val + 5);
-    TS_ASSERT_EQUALS(J.get(29, 1), val + 5);
-    TS_ASSERT_EQUALS(J.get(size - 1, 1), val + 5);
-  }
-
-  void test_EigenJacobian_Impl1_test_get_and_set() {
-    int size = 10;
-    int val = 5;
-    int n_params = 3;
-
-    JacobianImpl1<EigenMatrix> J;
-
-    for (size_t i = 0; i < n_params; ++i) {
-      J.m_index.emplace_back(i);
-    }
-
-    EigenMatrix m(size, n_params);
-    J.setJ(&m);
-
-    J.set(5, 1, val);
-    J.set(9, 2, val * 3);
-    TS_ASSERT_EQUALS(J.get(5, 1), val);
-    TS_ASSERT_EQUALS(J.get(9, 2), val * 3);
-    TS_ASSERT_EQUALS(m(5, 1), val);
-    TS_ASSERT_EQUALS(m(9, 2), val * 3);
-  }
-
-  void test_EigenJacobian_Impl1_test_add_number_to_column() {
-    int size = 35;
-    int val = 5;
-    int n_params = 3;
-
-    JacobianImpl1<EigenMatrix> J;
-
-    for (size_t i = 0; i < n_params; ++i) {
-      J.m_index.emplace_back(i);
-    }
-
-    EigenMatrix m(size, n_params);
-    J.setJ(&m);
-
-    J.addNumberToColumn(val, 0);
-    TS_ASSERT_EQUALS(J.get(0, 0), val);
-    TS_ASSERT_EQUALS(J.get(9, 0), val);
-    TS_ASSERT_EQUALS(J.get(19, 0), val);
-    TS_ASSERT_EQUALS(J.get(29, 0), val);
-    TS_ASSERT_EQUALS(J.get(size - 1, 0), val);
-
-    J.addNumberToColumn(val + 5, 1);
-    TS_ASSERT_EQUALS(J.get(0, 1), val + 5);
-    TS_ASSERT_EQUALS(J.get(9, 1), val + 5);
-    TS_ASSERT_EQUALS(J.get(19, 1), val + 5);
-    TS_ASSERT_EQUALS(J.get(29, 1), val + 5);
-    TS_ASSERT_EQUALS(J.get(size - 1, 1), val + 5);
   }
 };

--- a/Framework/CurveFitting/test/EigenToGSLTest.h
+++ b/Framework/CurveFitting/test/EigenToGSLTest.h
@@ -13,7 +13,6 @@
 #include <MantidCurveFitting/GSLFunctions.h>
 #include <gsl/gsl_blas.h>
 
-using namespace Mantid::API;
 using namespace Mantid::CurveFitting;
 
 namespace {

--- a/Framework/CurveFitting/test/EigenToGSLTest.h
+++ b/Framework/CurveFitting/test/EigenToGSLTest.h
@@ -163,4 +163,55 @@ public:
     TS_ASSERT_EQUALS(J.get(29, 1), val + 5);
     TS_ASSERT_EQUALS(J.get(size - 1, 1), val + 5);
   }
+
+  void test_EigenJacobian_Impl1_test_get_and_set() {
+    int size = 10;
+    int val = 5;
+    int n_params = 3;
+
+    JacobianImpl1<EigenMatrix> J;
+
+    for (size_t i = 0; i < n_params; ++i) {
+      J.m_index.emplace_back(i);
+    }
+
+    EigenMatrix m(size, n_params);
+    J.setJ(&m);
+
+    J.set(5, 1, val);
+    J.set(9, 2, val * 3);
+    TS_ASSERT_EQUALS(J.get(5, 1), val);
+    TS_ASSERT_EQUALS(J.get(9, 2), val * 3);
+    TS_ASSERT_EQUALS(m(5, 1), val);
+    TS_ASSERT_EQUALS(m(9, 2), val * 3);
+  }
+
+  void test_EigenJacobian_Impl1_test_add_number_to_column() {
+    int size = 35;
+    int val = 5;
+    int n_params = 3;
+
+    JacobianImpl1<EigenMatrix> J;
+
+    for (size_t i = 0; i < n_params; ++i) {
+      J.m_index.emplace_back(i);
+    }
+
+    EigenMatrix m(size, n_params);
+    J.setJ(&m);
+
+    J.addNumberToColumn(val, 0);
+    TS_ASSERT_EQUALS(J.get(0, 0), val);
+    TS_ASSERT_EQUALS(J.get(9, 0), val);
+    TS_ASSERT_EQUALS(J.get(19, 0), val);
+    TS_ASSERT_EQUALS(J.get(29, 0), val);
+    TS_ASSERT_EQUALS(J.get(size - 1, 0), val);
+
+    J.addNumberToColumn(val + 5, 1);
+    TS_ASSERT_EQUALS(J.get(0, 1), val + 5);
+    TS_ASSERT_EQUALS(J.get(9, 1), val + 5);
+    TS_ASSERT_EQUALS(J.get(19, 1), val + 5);
+    TS_ASSERT_EQUALS(J.get(29, 1), val + 5);
+    TS_ASSERT_EQUALS(J.get(size - 1, 1), val + 5);
+  }
 };

--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -118,7 +118,7 @@ knownConditionTrueFalse:${CMAKE_SOURCE_DIR}/Framework/CurveFitting/src/Algorithm
 unreadVariable:${CMAKE_SOURCE_DIR}/Framework/CurveFitting/src/Algorithms/ProfileChiSquared1D.cpp:306
 unreadVariable:${CMAKE_SOURCE_DIR}/Framework/CurveFitting/src/Algorithms/ProfileChiSquared1D.cpp:307
 knownConditionTrueFalse:${CMAKE_SOURCE_DIR}/Framework/CurveFitting/src/CostFunctions/CostFuncFitting.cpp:381
-constParameter:${CMAKE_SOURCE_DIR}/Framework/CurveFitting/src/FuncMinimizers/TrustRegionMinimizer.cpp:815
+constParameter:${CMAKE_SOURCE_DIR}/Framework/CurveFitting/src/FuncMinimizers/TrustRegionMinimizer.cpp:814
 uninitDerivedMemberVar:${CMAKE_SOURCE_DIR}/Framework/CurveFitting/src/Functions/BivariateNormal.cpp:65
 unreadVariable:${CMAKE_SOURCE_DIR}/Framework/CurveFitting/src/Functions/Convolution.cpp:224
 constParameter:${CMAKE_SOURCE_DIR}/Framework/CurveFitting/src/Functions/CrystalElectricField.cpp:449


### PR DESCRIPTION
**Description of work.**

This PR removes the GSL library from `JacobianImpl1` and corrects a logic error with regards to method of matrix storage in memory in the `EigenJacobian` function `addNumberToColumn`.

**To test:**

1.  Observe the `EigenJacobianTest` unit tests pass
2.  Observe all other unit tests pass.