### PR TITLE
Use PROJ_MATRIX_LOG_NAME for MDH

### DIFF
--- a/Testing/SystemTests/tests/qt/SliceViewerIntegrationTest.py
+++ b/Testing/SystemTests/tests/qt/SliceViewerIntegrationTest.py
@@ -488,31 +488,6 @@ class SliceViewerTestAxesLimitsRespectNonorthogonalTransform(systemtesting.Manti
         pres.view.close()
 
 
-class SliceViewerTestAxesLimitsWithLogMatrixTransform(systemtesting.MantidSystemTest, HelperTestingClass):
-    def runTest(self):
-        HelperTestingClass.__init__(self)
-        limits = (-10.0, 10.0, -9.0, 9.0)
-        ws_nonrotho = CreateMDHistoWorkspace(Dimensionality=3,
-                                             Extents=','.join([str(lim) for lim in limits]) + ',-8,8',
-                                             NumberOfBins='6,7,8',
-                                             SignalInput=range(6*7*8),
-                                             ErrorInput=range(6*7*8),
-                                             Names='A,B,C',
-                                             Units='r.l.u.,r.l.u.,r.l.u.',
-                                             Frames='HKL,HKL,HKL')
-        expt_info_nonortho = CreateSampleWorkspace()
-        ws_nonrotho.addExperimentInfo(expt_info_nonortho)
-        SetUB(ws_nonrotho, 1, 1, 2, 90, 90, 120)
-        W_MATRIX = [1,1,0,-1,1,0,0,0,1]
-        ws_nonrotho.getExperimentInfo(0).run().addProperty('W_MATRIX', W_MATRIX, True)
-        pres = SliceViewer(ws_nonrotho)
-
-        W = pres.model.get_proj_matrix()
-        assert_allclose(W.flatten(), W_MATRIX)
-
-        pres.view.close()
-
-
 # private helper functions
 def toolbar_actions(presenter, text_labels):
     """

--- a/Testing/SystemTests/tests/qt/SliceViewerIntegrationTest.py
+++ b/Testing/SystemTests/tests/qt/SliceViewerIntegrationTest.py
@@ -492,11 +492,14 @@ class SliceViewerTestAxesLimitsWithLogMatrixTransform(systemtesting.MantidSystem
     def runTest(self):
         HelperTestingClass.__init__(self)
         limits = (-10.0, 10.0, -9.0, 9.0)
-        ws_nonrotho = CreateMDWorkspace(Dimensions=3,
-                                        Extents=','.join([str(lim) for lim in limits]) + ',-8,8',
-                                        Names='A,B,C',
-                                        Units='r.l.u.,r.l.u.,r.l.u.',
-                                        Frames='HKL,HKL,HKL')
+        ws_nonrotho = CreateMDHistoWorkspace(Dimensionality=3,
+                                             Extents=','.join([str(lim) for lim in limits]) + ',-8,8',
+                                             NumberOfBins='6,7,8',
+                                             SignalInput=range(6*7*8),
+                                             ErrorInput=range(6*7*8),
+                                             Names='A,B,C',
+                                             Units='r.l.u.,r.l.u.,r.l.u.',
+                                             Frames='HKL,HKL,HKL')
         expt_info_nonortho = CreateSampleWorkspace()
         ws_nonrotho.addExperimentInfo(expt_info_nonortho)
         SetUB(ws_nonrotho, 1, 1, 2, 90, 90, 120)
@@ -504,8 +507,6 @@ class SliceViewerTestAxesLimitsWithLogMatrixTransform(systemtesting.MantidSystem
         ws_nonrotho.getExperimentInfo(0).run().addProperty('W_MATRIX', W_MATRIX, True)
         pres = SliceViewer(ws_nonrotho)
 
-        # set nonorthog view and retrieve new limits
-        pres.nonorthogonal_axes(True)
         W = pres.model.get_proj_matrix()
         assert_allclose(W.flatten(), W_MATRIX)
 

--- a/Testing/SystemTests/tests/qt/SliceViewerIntegrationTest.py
+++ b/Testing/SystemTests/tests/qt/SliceViewerIntegrationTest.py
@@ -488,6 +488,30 @@ class SliceViewerTestAxesLimitsRespectNonorthogonalTransform(systemtesting.Manti
         pres.view.close()
 
 
+class SliceViewerTestAxesLimitsWithLogMatrixTransform(systemtesting.MantidSystemTest, HelperTestingClass):
+    def runTest(self):
+        HelperTestingClass.__init__(self)
+        limits = (-10.0, 10.0, -9.0, 9.0)
+        ws_nonrotho = CreateMDWorkspace(Dimensions=3,
+                                        Extents=','.join([str(lim) for lim in limits]) + ',-8,8',
+                                        Names='A,B,C',
+                                        Units='r.l.u.,r.l.u.,r.l.u.',
+                                        Frames='HKL,HKL,HKL')
+        expt_info_nonortho = CreateSampleWorkspace()
+        ws_nonrotho.addExperimentInfo(expt_info_nonortho)
+        SetUB(ws_nonrotho, 1, 1, 2, 90, 90, 120)
+        W_MATRIX = [1,1,0,-1,1,0,0,0,1]
+        ws_nonrotho.getExperimentInfo(0).run().addProperty('W_MATRIX', W_MATRIX, True)
+        pres = SliceViewer(ws_nonrotho)
+
+        # set nonorthog view and retrieve new limits
+        pres.nonorthogonal_axes(True)
+        W = pres.model.get_proj_matrix()
+        assert_allclose(W.flatten(), W_MATRIX)
+
+        pres.view.close()
+
+
 # private helper functions
 def toolbar_actions(presenter, text_labels):
     """

--- a/docs/source/release/v6.5.0/Workbench/SliceViewer/Bugfixes/34285.rst
+++ b/docs/source/release/v6.5.0/Workbench/SliceViewer/Bugfixes/34285.rst
@@ -1,0 +1,1 @@
+- SliceViewer will now support `W_MATRIX` log for nonorthogonal axes with MDHistoWorkspaces. This prevents a bug related where basis vectors are used to calculate the projection.

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/models/model.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/models/model.py
@@ -480,12 +480,17 @@ class SliceViewerModel(SliceViewerBaseModel):
         if not ws_type == WS_TYPE.MATRIX:
             proj_matrix = np.eye(3)  # needs to be 3x3 even if 2D ws as columns passed to recAngle when calc axes angles
             if ws_type == WS_TYPE.MDH:
-                ndims = ws.getNumDims()
-                i_qdims = [idim for idim in range(ndims) if ws.getDimension(idim).getMDFrame().isQ()]
-                irow_end = min(3, len(i_qdims))  # note for 2D the last col/row of proj_matrix is 0,0,1 - i.e. L
-                for icol, idim in enumerate(i_qdims):
-                    # copy first irow_end components of basis vec are always Q
-                    proj_matrix[0:irow_end, icol] = list(ws.getBasisVector(idim))[0:irow_end]
+                # for histo try to find axes from log
+                try:
+                    expt_info = ws.getExperimentInfo(0)
+                    proj_matrix = np.array(expt_info.run().get(PROJ_MATRIX_LOG_NAME).value, dtype=float).reshape(3, 3)
+                except:
+                    ndims = ws.getNumDims()
+                    i_qdims = [idim for idim in range(ndims) if ws.getDimension(idim).getMDFrame().isQ()]
+                    irow_end = min(3, len(i_qdims))  # note for 2D the last col/row of proj_matrix is 0,0,1 - i.e. L
+                    for icol, idim in enumerate(i_qdims):
+                        # copy first irow_end components of basis vec are always Q
+                        proj_matrix[0:irow_end, icol] = list(ws.getBasisVector(idim))[0:irow_end]
             else:
                 # for event try to find axes from log
                 try:

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/models/model.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/models/model.py
@@ -480,17 +480,20 @@ class SliceViewerModel(SliceViewerBaseModel):
         if not ws_type == WS_TYPE.MATRIX:
             proj_matrix = np.eye(3)  # needs to be 3x3 even if 2D ws as columns passed to recAngle when calc axes angles
             if ws_type == WS_TYPE.MDH:
-                # for histo try to find axes from log
-                try:
-                    expt_info = ws.getExperimentInfo(0)
-                    proj_matrix = np.array(expt_info.run().get(PROJ_MATRIX_LOG_NAME).value, dtype=float).reshape(3, 3)
-                except:
-                    ndims = ws.getNumDims()
-                    i_qdims = [idim for idim in range(ndims) if ws.getDimension(idim).getMDFrame().isQ()]
-                    irow_end = min(3, len(i_qdims))  # note for 2D the last col/row of proj_matrix is 0,0,1 - i.e. L
-                    for icol, idim in enumerate(i_qdims):
-                        # copy first irow_end components of basis vec are always Q
-                        proj_matrix[0:irow_end, icol] = list(ws.getBasisVector(idim))[0:irow_end]
+                ndims = ws.getNumDims()
+                i_qdims = [idim for idim in range(ndims) if ws.getDimension(idim).getMDFrame().isQ()]
+                irow_end = min(3, len(i_qdims))  # note for 2D the last col/row of proj_matrix is 0,0,1 - i.e. L
+                for icol, idim in enumerate(i_qdims):
+                    # copy first irow_end components of basis vec are always Q
+                    proj_matrix[0:irow_end, icol] = list(ws.getBasisVector(idim))[0:irow_end]
+                # if determinant is zero, try to get the info from log or revert back to identity matrix
+                if np.isclose(np.linalg.det(proj_matrix),0):
+                    # for histo try to find axes from log
+                    try:
+                        expt_info = ws.getExperimentInfo(0)
+                        proj_matrix = np.array(expt_info.run().get(PROJ_MATRIX_LOG_NAME).value, dtype=float).reshape(3, 3)
+                    except:
+                        proj_matrix = np.eye(3)
             else:
                 # for event try to find axes from log
                 try:

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/models/model.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/models/model.py
@@ -491,7 +491,13 @@ class SliceViewerModel(SliceViewerBaseModel):
                     # for histo try to find axes from log
                     try:
                         expt_info = ws.getExperimentInfo(0)
-                        proj_matrix = np.array(expt_info.run().get(PROJ_MATRIX_LOG_NAME).value, dtype=float).reshape(3, 3)
+                        trans_matrix = np.array(expt_info.run().get(PROJ_MATRIX_LOG_NAME).value, dtype=float).reshape(3, 3)
+                        ndims = ws.getNumDims()
+                        i_qdims = [idim for idim in range(ndims) if ws.getDimension(idim).getMDFrame().isQ()]
+                        irow_end = min(3, len(i_qdims))
+                        for icol, idim in enumerate(i_qdims):
+                            # copy first irow_end components of basis vec are always Q
+                            proj_matrix[0:irow_end, icol] = trans_matrix[0:irow_end, icol]
                     except (AttributeError, KeyError, ValueError):
                         # revert back to orthogonal projection
                         proj_matrix = np.eye(3)

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/models/model.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/models/model.py
@@ -492,7 +492,8 @@ class SliceViewerModel(SliceViewerBaseModel):
                     try:
                         expt_info = ws.getExperimentInfo(0)
                         proj_matrix = np.array(expt_info.run().get(PROJ_MATRIX_LOG_NAME).value, dtype=float).reshape(3, 3)
-                    except:
+                    except (AttributeError, KeyError, ValueError):
+                        # revert back to orthogonal projection
                         proj_matrix = np.eye(3)
             else:
                 # for event try to find axes from log

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/models/model.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/models/model.py
@@ -491,13 +491,7 @@ class SliceViewerModel(SliceViewerBaseModel):
                     # for histo try to find axes from log
                     try:
                         expt_info = ws.getExperimentInfo(0)
-                        trans_matrix = np.array(expt_info.run().get(PROJ_MATRIX_LOG_NAME).value, dtype=float).reshape(3, 3)
-                        ndims = ws.getNumDims()
-                        i_qdims = [idim for idim in range(ndims) if ws.getDimension(idim).getMDFrame().isQ()]
-                        irow_end = min(3, len(i_qdims))
-                        for icol, idim in enumerate(i_qdims):
-                            # copy first irow_end components of basis vec are always Q
-                            proj_matrix[0:irow_end, icol] = trans_matrix[0:irow_end, icol]
+                        proj_matrix = np.array(expt_info.run().get(PROJ_MATRIX_LOG_NAME).value, dtype=float).reshape(3, 3)
                     except (AttributeError, KeyError, ValueError):
                         # revert back to orthogonal projection
                         proj_matrix = np.eye(3)

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_sliceviewer_model.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_sliceviewer_model.py
@@ -551,6 +551,24 @@ class SliceViewerModelTest(unittest.TestCase):
         for iy in range(1, 3):
             self.assertAlmostEqual(axes_angles[0, iy], np.pi / 2, delta=1e-10)
 
+    def test_calculate_axes_angles_uses_W_if_basis_vectors_unavailable_and_W_available_MDHisto(self):
+        #test MD histo
+        ws = _create_mock_workspace(IMDHistoWorkspace,
+                                    SpecialCoordinateSystem.HKL,
+                                    has_oriented_lattice=True,
+                                    ndims=3)
+        ws.getBasisVector.side_effect = lambda x: [0.0]
+        ws.getExperimentInfo().run().get().value = [0, 1, 1, 0, 0, 1, 1, 0, 0]
+        model = SliceViewerModel(ws)
+
+        axes_angles = model.get_axes_angles()
+        self.assertAlmostEqual(axes_angles[1, 2], np.pi / 4, delta=1e-10)
+        for iy in range(1, 3):
+            self.assertAlmostEqual(axes_angles[0, iy], np.pi / 2, delta=1e-10)
+        # test force_orthog works
+        axes_angles = model.get_axes_angles(force_orthogonal=True)
+        self.assertAlmostEqual(axes_angles[1, 2], np.pi / 2, delta=1e-10)
+
     @patch.multiple('mantidqt.widgets.sliceviewer.models.roi',
                     ExtractSpectra=DEFAULT,
                     Rebin=DEFAULT,

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_sliceviewer_model.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_sliceviewer_model.py
@@ -495,7 +495,7 @@ class SliceViewerModelTest(unittest.TestCase):
 
         self.assertIsNone(model.get_axes_angles())
 
-    def test_calculate_axes_angles_uses_W_if_available(self):
+    def test_calculate_axes_angles_uses_W_if_available_MDEvent(self):
         # test MD event
         ws = _create_mock_workspace(IMDEventWorkspace,
                                     SpecialCoordinateSystem.HKL,
@@ -511,6 +511,7 @@ class SliceViewerModelTest(unittest.TestCase):
         axes_angles = model.get_axes_angles(force_orthogonal=True)
         self.assertAlmostEqual(axes_angles[1, 2], np.pi / 2, delta=1e-10)
 
+    def test_calculate_axes_angles_uses_W_if_available_MDHisto(self):
         #test MD histo
         ws = _create_mock_workspace(IMDHistoWorkspace,
                                     SpecialCoordinateSystem.HKL,
@@ -524,7 +525,7 @@ class SliceViewerModelTest(unittest.TestCase):
         for iy in range(1, 3):
             self.assertAlmostEqual(axes_angles[0, iy], np.pi / 2, delta=1e-10)
 
-    def test_calculate_axes_angles_uses_identity_if_W_unavailable(self):
+    def test_calculate_axes_angles_uses_identity_if_W_unavailable_MDEvent(self):
         # test MD event
         ws = _create_mock_workspace(IMDEventWorkspace,
                                     SpecialCoordinateSystem.HKL,
@@ -537,6 +538,7 @@ class SliceViewerModelTest(unittest.TestCase):
         for iy in range(1, 3):
             self.assertAlmostEqual(axes_angles[0, iy], np.pi / 2, delta=1e-10)
 
+    def test_calculate_axes_angles_uses_identity_if_W_unavailable_MDHisto(self):
         #test MD histo
         ws = _create_mock_workspace(IMDHistoWorkspace,
                                     SpecialCoordinateSystem.HKL,

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_sliceviewer_model.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_sliceviewer_model.py
@@ -511,7 +511,7 @@ class SliceViewerModelTest(unittest.TestCase):
         axes_angles = model.get_axes_angles(force_orthogonal=True)
         self.assertAlmostEqual(axes_angles[1, 2], np.pi / 2, delta=1e-10)
 
-    def test_calculate_axes_angles_uses_W_if_available_MDHisto(self):
+    def test_calculate_axes_angles_uses_basis_vectors_even_if_WMatrix_log_available_MDHisto(self):
         #test MD histo
         ws = _create_mock_workspace(IMDHistoWorkspace,
                                     SpecialCoordinateSystem.HKL,


### PR DESCRIPTION
**Description of work.**

In SliceViewer `model.py`, MDHisto workspaces rely solely on the embedded basis vectors to calculate non orthogonal axes which can only be set with `MDNorm` or `BinMD`. This makes it impossible to use nonorthogonal view with other algorithms that create MDHisto workspaces like `ConvertWandSCDToQ`.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**

Run this script. Run it with the main build, open SliceViewer, and choose no orthogonal view. An exception will be thrown. Now try it with these changes. The hexagonal axes should be viewable.

```python
# import mantid algorithms, numpy and matplotlib
from mantid.simpleapi import *
import matplotlib.pyplot as plt
import numpy as np

signal = np.linspace(0,1,1000)
error = np.sqrt(signal)

signal -= 0.5

signal[signal>0.25] = np.nan

ws = CreateMDHistoWorkspace(Dimensionality=3,
                            Extents='-3,3,-10,10,-5,5',
                            SignalInput=signal,
                            ErrorInput=error,
                            NumberOfBins='10,10,10',
                            Names='[H,0,0],[0,K,0],[0,0,L]',
                            Units='r.l.u.,r.l.u.,r.l.u.',
                            Frames='HKL,HKL,HKL')

SetMDFrame('ws', MDFrame='HKL', Axes=[0,1,2])

AddSampleLog('ws', LogName='sample')
ws.getExperimentInfo(0).run().addProperty('W_MATRIX', list(np.eye(3).flatten()), True)

SetUB('ws', a=5, b=5, c=7, alpha=90, beta=90, gamma=120)
```

<!-- Instructions for testing. -->

<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
