### PR TITLE
Fix crash when opening Interface Help Documentation

### DIFF
--- a/Framework/Geometry/inc/MantidGeometry/Instrument/Parameter.h
+++ b/Framework/Geometry/inc/MantidGeometry/Instrument/Parameter.h
@@ -18,7 +18,7 @@
 namespace Mantid {
 
 namespace Kernel {
-template <class C, class Base> class Instantiator;
+template <class C, class Base, typename... Args> class Instantiator;
 }
 
 namespace Geometry {

--- a/Framework/Kernel/inc/MantidKernel/Instantiator.h
+++ b/Framework/Kernel/inc/MantidKernel/Instantiator.h
@@ -19,7 +19,7 @@ namespace Kernel {
     @author Nick Draper, Tessella Support Services plc
     @date 10/10/2007
 */
-template <class Base>
+template <class Base, typename... Args>
 class DLLExport AbstractInstantiator
 /// The base class for instantiators
 {
@@ -31,11 +31,11 @@ public:
   virtual ~AbstractInstantiator() = default;
 
   /// Creates an instance of a concrete subclass of Base.
-  virtual std::shared_ptr<Base> createInstance() const = 0;
+  virtual std::shared_ptr<Base> createInstance(Args... args) const = 0;
 
   /// Creates an instance of a concrete subclass of Base, which is
   /// not wrapped in a shared_ptr
-  virtual Base *createUnwrappedInstance() const = 0;
+  virtual Base *createUnwrappedInstance(Args... args) const = 0;
 
 private:
   /// Private copy constructor
@@ -50,7 +50,8 @@ private:
 // For the Instantiator to work, the class of which
 // instances are to be instantiated must have a no-argument
 // constructor.
-template <class C, class Base> class DLLExport Instantiator : public AbstractInstantiator<Base> {
+template <class C, class Base, typename... Args>
+class DLLExport Instantiator : public AbstractInstantiator<Base, Args...> {
 public:
   /// Creates the Instantiator.
   Instantiator() = default;
@@ -58,13 +59,13 @@ public:
   /** Creates an instance of a concrete subclass of Base.
    *  @return A pointer to the base type
    */
-  std::shared_ptr<Base> createInstance() const override { return std::make_shared<C>(); }
+  std::shared_ptr<Base> createInstance(Args... args) const override { return std::make_shared<C>(args...); }
 
   /** Creates an instance of a concrete subclass of Base that is not wrapped in
    * a shared_ptr.
    *  @return A bare pointer to the base type
    */
-  Base *createUnwrappedInstance() const override { return static_cast<Base *>(new C()); }
+  Base *createUnwrappedInstance(Args... args) const override { return static_cast<Base *>(new C(args...)); }
 };
 
 } // namespace Kernel

--- a/docs/source/release/v6.5.0/Workbench/Bugfixes/34116.rst
+++ b/docs/source/release/v6.5.0/Workbench/Bugfixes/34116.rst
@@ -1,0 +1,1 @@
+- It is no longer possible to crash mantid when opening an interface's help documentation for the second time.

--- a/qt/applications/workbench/CMakeLists.txt
+++ b/qt/applications/workbench/CMakeLists.txt
@@ -34,6 +34,13 @@ endif()
 # Resource files
 set(_images_qrc_file ${CMAKE_CURRENT_LIST_DIR}/resources.qrc)
 if(WIN32)
+  get_property(_is_multi_config GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
+  if(_is_multi_config)
+    set(WIN_BIN_DIR ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/$<CONFIG>)
+  else()
+    set(WIN_BIN_DIR ${CMAKE_LIBRARY_OUTPUT_DIRECTORY})
+  endif()
+
   function(CREATE_QRC_FILE_TEMPLATE BUILD_TYPE)
     # Set path and file content variables
     set(_paths_qrc_file ${CMAKE_CURRENT_BINARY_DIR}/resources.qrc.${BUILD_TYPE})
@@ -49,6 +56,11 @@ if(WIN32)
     # Write qt.conf.BUILD_TYPE file and get resources file name
     if(${BUILD_TYPE} STREQUAL "build")
       file(WRITE ${_qt_conf_file} "[Paths]\nPrefix = ${_qt5_dir}\n\n[Platforms]\nWindowsArguments = dpiawareness=1\n")
+      file(
+        GENERATE
+        OUTPUT ${WIN_BIN_DIR}/qt.conf
+        INPUT ${_qt_conf_file}
+      )
       set(_output_res_py ${CMAKE_CURRENT_LIST_DIR}/workbench/app/resources.py)
     elseif(${BUILD_TYPE} STREQUAL "install")
       file(WRITE ${_qt_conf_file} "[Paths]\nPrefix = ../lib/qt5\n\n[Platforms]\nWindowsArguments = dpiawareness=1\n")

--- a/qt/scientific_interfaces/General/MantidEV.cpp
+++ b/qt/scientific_interfaces/General/MantidEV.cpp
@@ -420,7 +420,7 @@ void MantidEV::setDefaultState_slot() {
  * Go to MantidEV help page when help menu item is chosen
  */
 void MantidEV::help_slot() {
-  MantidQt::API::HelpWindow::showCustomInterface(nullptr, QString("SCD Event Data Reduction"), QString("diffraction"));
+  MantidQt::API::HelpWindow::showCustomInterface(QString("SCD Event Data Reduction"), QString("diffraction"));
 }
 
 /**

--- a/qt/scientific_interfaces/General/SampleTransmission.cpp
+++ b/qt/scientific_interfaces/General/SampleTransmission.cpp
@@ -53,8 +53,7 @@ void SampleTransmission::initLayout() {
  * Opens the Qt help page for the interface.
  */
 void SampleTransmission::showHelp() {
-  MantidQt::API::HelpWindow::showCustomInterface(nullptr, QString("Sample Transmission Calculator"),
-                                                 QString("general"));
+  MantidQt::API::HelpWindow::showCustomInterface(QString("Sample Transmission Calculator"), QString("general"));
 }
 
 /**

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/MainWindow/MainWindowPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/MainWindow/MainWindowPresenter.cpp
@@ -286,8 +286,7 @@ void MainWindowPresenter::initNewBatch(IBatchPresenter *batchPresenter, std::str
 }
 
 void MainWindowPresenter::showHelp() {
-  MantidQt::API::HelpWindow::showCustomInterface(nullptr, std::string("ISIS Reflectometry"),
-                                                 std::string("reflectometry"));
+  MantidQt::API::HelpWindow::showCustomInterface(std::string("ISIS Reflectometry"), std::string("reflectometry"));
 }
 
 void MainWindowPresenter::notifySaveBatchRequested(int tabIndex) {

--- a/qt/scientific_interfaces/Indirect/IndirectInterface.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectInterface.cpp
@@ -21,7 +21,7 @@ IndirectInterface::IndirectInterface(QWidget *parent)
 }
 
 void IndirectInterface::help() {
-  HelpWindow::showCustomInterface(nullptr, QString::fromStdString(documentationPage()), QString("indirect"));
+  HelpWindow::showCustomInterface(QString::fromStdString(documentationPage()), QString("indirect"));
 }
 
 void IndirectInterface::settings() {

--- a/qt/scientific_interfaces/Indirect/IndirectSettingsView.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectSettingsView.cpp
@@ -28,7 +28,7 @@ void IndirectSettingsView::emitApplyClicked() { emit applyClicked(); }
 void IndirectSettingsView::emitCancelClicked() { emit cancelClicked(); }
 
 void IndirectSettingsView::openHelp() {
-  MantidQt::API::HelpWindow::showCustomInterface(nullptr, QString("Indirect Settings"), QString("indirect"));
+  MantidQt::API::HelpWindow::showCustomInterface(QString("Indirect Settings"), QString("indirect"));
 }
 
 void IndirectSettingsView::setSelectedFacility(QString const &text) {

--- a/qt/scientific_interfaces/Muon/ALCBaselineModellingView.cpp
+++ b/qt/scientific_interfaces/Muon/ALCBaselineModellingView.cpp
@@ -199,7 +199,7 @@ void ALCBaselineModellingView::setSelectorValues(RangeSelector *selector,
 }
 
 void ALCBaselineModellingView::help() {
-  MantidQt::API::HelpWindow::showCustomInterface(nullptr, QString("Muon ALC"), QString("muon"));
+  MantidQt::API::HelpWindow::showCustomInterface(QString("Muon ALC"), QString("muon"));
 }
 
 void ALCBaselineModellingView::emitFitRequested() { emit fitRequested(); }

--- a/qt/scientific_interfaces/Muon/ALCDataLoadingView.cpp
+++ b/qt/scientific_interfaces/Muon/ALCDataLoadingView.cpp
@@ -290,7 +290,7 @@ void ALCDataLoadingView::setTimeRange(double tMin, double tMax) {
 }
 
 void ALCDataLoadingView::help() {
-  MantidQt::API::HelpWindow::showCustomInterface(nullptr, QString("Muon ALC"), QString("muon"));
+  MantidQt::API::HelpWindow::showCustomInterface(QString("Muon ALC"), QString("muon"));
 }
 
 void ALCDataLoadingView::disableAll() {

--- a/qt/scientific_interfaces/Muon/ALCPeakFittingView.cpp
+++ b/qt/scientific_interfaces/Muon/ALCPeakFittingView.cpp
@@ -111,7 +111,7 @@ void ALCPeakFittingView::setPeakPicker(const IPeakFunction_const_sptr &peak) {
 }
 
 void ALCPeakFittingView::help() {
-  MantidQt::API::HelpWindow::showCustomInterface(nullptr, QString("Muon ALC"), QString("muon"));
+  MantidQt::API::HelpWindow::showCustomInterface(QString("Muon ALC"), QString("muon"));
 }
 
 void ALCPeakFittingView::displayError(const QString &message) { QMessageBox::critical(m_widget, "Error", message); }

--- a/qt/widgets/common/CMakeLists.txt
+++ b/qt/widgets/common/CMakeLists.txt
@@ -817,6 +817,7 @@ set(QT5_TEST_FILES
     test/ImageInfoPresenterTest.h
     test/InterfaceManagerTest.h
     test/ManageUserDirectoriesTest.h
+    test/MantidHelpWindowTest.h
     test/MuonPeriodInfoTest.h
     test/QtJSONUtilsTest.h
     test/RepoModelTest.h

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/HelpWindow.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/HelpWindow.h
@@ -12,25 +12,24 @@
 
 // forward declarations
 class QUrl;
-class QWidget;
 
 namespace MantidQt {
 namespace API {
 
 class EXPORT_OPT_MANTIDQT_COMMON HelpWindow {
 public:
-  static void showPage(QWidget *parent, const std::string &url = std::string());
-  static void showPage(QWidget *parent, const QString &url);
-  static void showPage(QWidget *parent, const QUrl &url);
-  static void showAlgorithm(QWidget *parent, const std::string &name = std::string(), const int version = -1);
-  static void showAlgorithm(QWidget *parent, const QString &name, const int version = -1);
-  static void showConcept(QWidget *parent, const std::string &name = std::string());
-  static void showConcept(QWidget *parent, const QString &name);
-  static void showFitFunction(QWidget *parent, const std::string &name = std::string());
-  static void showCustomInterface(QWidget *parent, const QString &name, const QString &area = QString(),
+  static void showPage(const std::string &url = std::string());
+  static void showPage(const QString &url);
+  static void showPage(const QUrl &url);
+  static void showAlgorithm(const std::string &name = std::string(), const int version = -1);
+  static void showAlgorithm(const QString &name, const int version = -1);
+  static void showConcept(const std::string &name = std::string());
+  static void showConcept(const QString &name);
+  static void showFitFunction(const std::string &name = std::string());
+  static void showCustomInterface(const QString &name, const QString &area = QString(),
                                   const QString &section = QString());
-  static void showCustomInterface(QWidget *parent, const std::string &name = std::string(),
-                                  const std::string &area = std::string(), const std::string &section = std::string());
+  static void showCustomInterface(const std::string &name = std::string(), const std::string &area = std::string(),
+                                  const std::string &section = std::string());
 };
 } // namespace API
 } // namespace MantidQt

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/MantidHelpWindow.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/MantidHelpWindow.h
@@ -8,6 +8,7 @@
 
 #include "DllOption.h"
 #include "MantidQtWidgets/Common/MantidHelpInterface.h"
+#include <QPointer>
 #include <QWidget>
 #include <string>
 
@@ -24,10 +25,9 @@ class EXPORT_OPT_MANTIDQT_COMMON MantidHelpWindow : public API::MantidHelpInterf
   Q_OBJECT
 
 public:
-  static bool helpWindowExists() { return g_helpWindow != nullptr; }
+  static bool helpWindowExists() { return !g_helpWindow.isNull(); }
 
   MantidHelpWindow(QWidget *parent = nullptr, const Qt::WindowFlags &flags = nullptr);
-  ~MantidHelpWindow() override;
 
   void showPage(const std::string &url = std::string()) override;
   void showPage(const QString &url) override;
@@ -55,7 +55,7 @@ private:
       determined this is an empty string. */
   std::string m_cacheFile;
   /// The window that renders the help information
-  static pqHelpWindow *g_helpWindow;
+  static QPointer<pqHelpWindow> g_helpWindow;
 
   /// Whether this is the very first startup of the helpwindow.
   bool m_firstRun;

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/MantidHelpWindow.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/MantidHelpWindow.h
@@ -27,7 +27,7 @@ class EXPORT_OPT_MANTIDQT_COMMON MantidHelpWindow : public API::MantidHelpInterf
 public:
   static bool helpWindowExists() { return !g_helpWindow.isNull(); }
 
-  MantidHelpWindow(QWidget *parent = nullptr, const Qt::WindowFlags &flags = nullptr);
+  MantidHelpWindow(const Qt::WindowFlags &flags = nullptr);
 
   void showPage(const std::string &url = std::string()) override;
   void showPage(const QString &url) override;

--- a/qt/widgets/common/src/AlgorithmDialog.cpp
+++ b/qt/widgets/common/src/AlgorithmDialog.cpp
@@ -712,7 +712,7 @@ void AlgorithmDialog::helpClicked() {
     version = m_algorithm->version();
 
   // bring up the help window
-  HelpWindow::showAlgorithm(this->nativeParentWidget(), m_algName, version);
+  HelpWindow::showAlgorithm(m_algName, version);
 }
 
 //-------------------------------------------------------------------------------------------------

--- a/qt/widgets/common/src/FitPropertyBrowser.cpp
+++ b/qt/widgets/common/src/FitPropertyBrowser.cpp
@@ -3161,7 +3161,7 @@ std::string FitPropertyBrowser::getFitAlgorithmOutputStatus() const { return m_f
 void FitPropertyBrowser::functionHelp() {
   PropertyHandler *handler = currentHandler();
   if (handler) {
-    MantidQt::API::HelpWindow::showFitFunction(nullptr, handler->ifun()->name());
+    MantidQt::API::HelpWindow::showFitFunction(handler->ifun()->name());
   }
 }
 

--- a/qt/widgets/common/src/FitScriptGeneratorView.cpp
+++ b/qt/widgets/common/src/FitScriptGeneratorView.cpp
@@ -314,7 +314,7 @@ void FitScriptGeneratorView::onGenerateScriptToClipboardClicked() {
 }
 
 void FitScriptGeneratorView::onHelpClicked() {
-  MantidQt::API::HelpWindow::showCustomInterface(this, "Fit Script Generator", QString("general"));
+  MantidQt::API::HelpWindow::showCustomInterface("Fit Script Generator", QString("general"));
 }
 
 std::string FitScriptGeneratorView::workspaceName(FitDomainIndex index) const {

--- a/qt/widgets/common/src/HelpWindow.cpp
+++ b/qt/widgets/common/src/HelpWindow.cpp
@@ -21,20 +21,6 @@ namespace {
 /// static logger
 Mantid::Kernel::Logger g_log("HelpWindow");
 
-/**
- * Attach the parent to the gui and connect the shutdown signal
- *
- * @param gui The help window that will render the url.
- * @param parent The parent widget.
- */
-void connectParent(MantidHelpInterface *gui, QWidget *parent) {
-  if (parent) {
-    if (parent->metaObject()->indexOfSignal("shutting_down") > 0) {
-      QObject::connect(parent, SIGNAL(shutting_down()), gui, SLOT(shutdown()));
-    }
-    gui->setParent(parent);
-  }
-}
 } // namespace
 
 using std::string;
@@ -45,7 +31,6 @@ void HelpWindow::showPage(QWidget *parent, const QString &url) {
   InterfaceManager interfaceManager;
   MantidHelpInterface *gui = interfaceManager.createHelpWindow();
   if (gui) {
-    connectParent(gui, parent);
     gui->showPage(url);
   } else {
     g_log.error() << "Failed to launch help for page " << url.toStdString() << "\n";
@@ -56,7 +41,6 @@ void HelpWindow::showPage(QWidget *parent, const QUrl &url) {
   InterfaceManager interfaceManager;
   MantidHelpInterface *gui = interfaceManager.createHelpWindow();
   if (gui) {
-    connectParent(gui, parent);
     gui->showPage(url);
   } else {
     g_log.error() << "Failed to launch help for page " << url.toString().toStdString() << "\n";
@@ -71,7 +55,6 @@ void HelpWindow::showAlgorithm(QWidget *parent, const QString &name, const int v
   InterfaceManager interfaceManager;
   MantidHelpInterface *gui = interfaceManager.createHelpWindow();
   if (gui) {
-    connectParent(gui, parent);
     gui->showAlgorithm(name, version);
   } else {
     // Open online help
@@ -88,7 +71,6 @@ void HelpWindow::showConcept(QWidget *parent, const QString &name) {
   InterfaceManager interfaceManager;
   MantidHelpInterface *gui = interfaceManager.createHelpWindow();
   if (gui) {
-    connectParent(gui, parent);
     gui->showConcept(name);
   } else {
     g_log.error() << "Failed to launch help for concept " << name.toStdString() << "\n";
@@ -99,7 +81,6 @@ void HelpWindow::showFitFunction(QWidget *parent, const std::string &name) {
   InterfaceManager interfaceManager;
   MantidHelpInterface *gui = interfaceManager.createHelpWindow();
   if (gui) {
-    connectParent(gui, parent);
     gui->showFitFunction(name);
   } else {
     g_log.error() << "Failed to launch help for fit function " << name << "\n";
@@ -117,7 +98,6 @@ void HelpWindow::showCustomInterface(QWidget *parent, const QString &name, const
   InterfaceManager interfaceManager;
   MantidHelpInterface *gui = interfaceManager.createHelpWindow();
   if (gui) {
-    connectParent(gui, parent);
     gui->showCustomInterface(name, area, section);
   } else {
     // Open online help

--- a/qt/widgets/common/src/HelpWindow.cpp
+++ b/qt/widgets/common/src/HelpWindow.cpp
@@ -25,9 +25,9 @@ Mantid::Kernel::Logger g_log("HelpWindow");
 
 using std::string;
 
-void HelpWindow::showPage(QWidget *parent, const std::string &url) { showPage(parent, QString(url.c_str())); }
+void HelpWindow::showPage(const std::string &url) { showPage(QString(url.c_str())); }
 
-void HelpWindow::showPage(QWidget *parent, const QString &url) {
+void HelpWindow::showPage(const QString &url) {
   InterfaceManager interfaceManager;
   MantidHelpInterface *gui = interfaceManager.createHelpWindow();
   if (gui) {
@@ -37,7 +37,7 @@ void HelpWindow::showPage(QWidget *parent, const QString &url) {
   }
 }
 
-void HelpWindow::showPage(QWidget *parent, const QUrl &url) {
+void HelpWindow::showPage(const QUrl &url) {
   InterfaceManager interfaceManager;
   MantidHelpInterface *gui = interfaceManager.createHelpWindow();
   if (gui) {
@@ -47,11 +47,11 @@ void HelpWindow::showPage(QWidget *parent, const QUrl &url) {
   }
 }
 
-void HelpWindow::showAlgorithm(QWidget *parent, const std::string &name, const int version) {
-  showAlgorithm(parent, QString(name.c_str()), version);
+void HelpWindow::showAlgorithm(const std::string &name, const int version) {
+  showAlgorithm(QString(name.c_str()), version);
 }
 
-void HelpWindow::showAlgorithm(QWidget *parent, const QString &name, const int version) {
+void HelpWindow::showAlgorithm(const QString &name, const int version) {
   InterfaceManager interfaceManager;
   MantidHelpInterface *gui = interfaceManager.createHelpWindow();
   if (gui) {
@@ -65,9 +65,9 @@ void HelpWindow::showAlgorithm(QWidget *parent, const QString &name, const int v
   }
 }
 
-void HelpWindow::showConcept(QWidget *parent, const std::string &name) { showConcept(parent, QString(name.c_str())); }
+void HelpWindow::showConcept(const std::string &name) { showConcept(QString(name.c_str())); }
 
-void HelpWindow::showConcept(QWidget *parent, const QString &name) {
+void HelpWindow::showConcept(const QString &name) {
   InterfaceManager interfaceManager;
   MantidHelpInterface *gui = interfaceManager.createHelpWindow();
   if (gui) {
@@ -77,7 +77,7 @@ void HelpWindow::showConcept(QWidget *parent, const QString &name) {
   }
 }
 
-void HelpWindow::showFitFunction(QWidget *parent, const std::string &name) {
+void HelpWindow::showFitFunction(const std::string &name) {
   InterfaceManager interfaceManager;
   MantidHelpInterface *gui = interfaceManager.createHelpWindow();
   if (gui) {
@@ -87,14 +87,11 @@ void HelpWindow::showFitFunction(QWidget *parent, const std::string &name) {
   }
 }
 
-void HelpWindow::showCustomInterface(QWidget *parent, const std::string &name, const std::string &area,
-                                     const std::string &section) {
-  showCustomInterface(parent, QString::fromStdString(name), QString::fromStdString(area),
-                      QString::fromStdString(section));
+void HelpWindow::showCustomInterface(const std::string &name, const std::string &area, const std::string &section) {
+  showCustomInterface(QString::fromStdString(name), QString::fromStdString(area), QString::fromStdString(section));
 }
 
-void HelpWindow::showCustomInterface(QWidget *parent, const QString &name, const QString &area,
-                                     const QString &section) {
+void HelpWindow::showCustomInterface(const QString &name, const QString &area, const QString &section) {
   InterfaceManager interfaceManager;
   MantidHelpInterface *gui = interfaceManager.createHelpWindow();
   if (gui) {

--- a/qt/widgets/common/src/ManageUserDirectories.cpp
+++ b/qt/widgets/common/src/ManageUserDirectories.cpp
@@ -215,7 +215,7 @@ QListWidget *ManageUserDirectories::listWidget(QObject *sender) {
 }
 
 /// Show the help for ManageUserDirectories
-void ManageUserDirectories::helpClicked() { HelpWindow::showCustomInterface(nullptr, HELP_ID, "framework"); }
+void ManageUserDirectories::helpClicked() { HelpWindow::showCustomInterface(HELP_ID, "framework"); }
 
 /// Close the dialog without saving the configuration
 void ManageUserDirectories::cancelClicked() { this->close(); }

--- a/qt/widgets/common/src/MantidHelpWindow.cpp
+++ b/qt/widgets/common/src/MantidHelpWindow.cpp
@@ -44,7 +44,7 @@ Mantid::Kernel::Logger g_log("MantidHelpWindow");
 } // namespace
 
 // initialise the help window
-pqHelpWindow *MantidHelpWindow::g_helpWindow = nullptr;
+QPointer<pqHelpWindow> MantidHelpWindow::g_helpWindow;
 
 /// Base url for all of the files in the project.
 const QString BASE_URL("qthelp://org.mantidproject/doc/");
@@ -65,7 +65,7 @@ const QString COLLECTION_FILE("MantidProject.qhc");
 MantidHelpWindow::MantidHelpWindow(QWidget *parent, const Qt::WindowFlags &flags)
     : MantidHelpInterface(), m_collectionFile(""), m_cacheFile(""), m_firstRun(true) {
   // find the collection and delete the cache file if this is the first run
-  if (!bool(g_helpWindow)) {
+  if (!helpWindowExists()) {
     this->determineFileLocs();
 
     // see if chache file exists and remove it - shouldn't be necessary, but it
@@ -85,7 +85,7 @@ MantidHelpWindow::MantidHelpWindow(QWidget *parent, const Qt::WindowFlags &flags
 
     // create the help engine with the found location
     g_log.debug() << "Loading " << m_collectionFile << "\n";
-    auto helpEngine = new QHelpEngine(QString(m_collectionFile.c_str()), parent);
+    auto helpEngine = new QHelpEngine(QString(m_collectionFile.c_str()));
     QObject::connect(helpEngine, SIGNAL(warning(QString)), this, SLOT(warning(QString)));
     g_log.debug() << "Making local cache copy for saving information at " << m_cacheFile << "\n";
 
@@ -98,7 +98,7 @@ MantidHelpWindow::MantidHelpWindow(QWidget *parent, const Qt::WindowFlags &flags
     g_log.debug() << "helpengine.setupData() returned " << helpEngine->setupData() << "\n";
 
     // create a new help window
-    g_helpWindow = new pqHelpWindow(helpEngine, parent, flags);
+    g_helpWindow = new pqHelpWindow(helpEngine, this, flags);
     g_helpWindow->setWindowTitle(QString("Mantid - Help"));
     g_helpWindow->setWindowIcon(QIcon(":/images/MantidIcon.ico"));
 
@@ -111,9 +111,6 @@ MantidHelpWindow::MantidHelpWindow(QWidget *parent, const Qt::WindowFlags &flags
     g_helpWindow->raise();
   }
 }
-
-/// Destructor does nothing.
-MantidHelpWindow::~MantidHelpWindow() { this->shutdown(); }
 
 void MantidHelpWindow::showHelp(const QString &url) {
   g_log.debug() << "open help window for \"" << url.toStdString() << "\"\n";
@@ -133,7 +130,7 @@ void MantidHelpWindow::openWebpage(const QUrl &url) {
 void MantidHelpWindow::showPage(const QString &url) { this->showPage(QUrl(url)); }
 
 void MantidHelpWindow::showPage(const QUrl &url) {
-  if (bool(g_helpWindow)) {
+  if (helpWindowExists()) {
     if (url.isEmpty())
       this->showHelp(DEFAULT_URL);
     else
@@ -191,7 +188,7 @@ void MantidHelpWindow::showAlgorithm(const string &name, const int version) {
     auto alg = Mantid::API::AlgorithmManager::Instance().createUnmanaged(name);
     help_url = QString::fromStdString(alg->helpURL());
   }
-  if (bool(g_helpWindow)) {
+  if (helpWindowExists()) {
     if (help_url.isEmpty()) {
       QString url(BASE_URL);
       url += "algorithms/";
@@ -237,7 +234,7 @@ void MantidHelpWindow::showAlgorithm(const QString &name, const int version) {
  * the concept index.
  */
 void MantidHelpWindow::showConcept(const string &name) {
-  if (bool(g_helpWindow)) {
+  if (helpWindowExists()) {
     QString url(BASE_URL);
     url += "concepts/";
     if (name.empty())
@@ -270,7 +267,7 @@ void MantidHelpWindow::showConcept(const QString &name) { this->showConcept(name
  * the fit function index.
  */
 void MantidHelpWindow::showFitFunction(const std::string &name) {
-  if (bool(g_helpWindow)) {
+  if (helpWindowExists()) {
     QString url(BASE_URL);
     url += "fitting/fitfunctions/";
     auto functionUrl = url + QString(name.c_str()) + ".html";
@@ -318,7 +315,7 @@ void MantidHelpWindow::showCustomInterface(const QString &name, const QString &a
  */
 void MantidHelpWindow::showCustomInterface(const std::string &name, const std::string &area,
                                            const std::string &section) {
-  if (bool(g_helpWindow)) {
+  if (helpWindowExists()) {
     QString url(BASE_URL);
     url += "interfaces/";
     if (!area.empty()) {

--- a/qt/widgets/common/src/MantidHelpWindow.cpp
+++ b/qt/widgets/common/src/MantidHelpWindow.cpp
@@ -62,7 +62,7 @@ const QString COLLECTION_FILE("MantidProject.qhc");
 /**
  * Default constructor shows the @link DEFAULT_URL @endlink.
  */
-MantidHelpWindow::MantidHelpWindow(QWidget *parent, const Qt::WindowFlags &flags)
+MantidHelpWindow::MantidHelpWindow(const Qt::WindowFlags &flags)
     : MantidHelpInterface(), m_collectionFile(""), m_cacheFile(""), m_firstRun(true) {
   // find the collection and delete the cache file if this is the first run
   if (!helpWindowExists()) {

--- a/qt/widgets/common/src/SelectFunctionDialog.cpp
+++ b/qt/widgets/common/src/SelectFunctionDialog.cpp
@@ -236,9 +236,9 @@ void SelectFunctionDialog::rejectFunction() {
 void SelectFunctionDialog::helpClicked() const {
   auto function = getFunction();
   if (!function.isEmpty()) {
-    MantidQt::API::HelpWindow::showFitFunction(nullptr, function.toStdString());
+    MantidQt::API::HelpWindow::showFitFunction(function.toStdString());
   } else { // No function selected open fit function index
-    MantidQt::API::HelpWindow::showFitFunction(nullptr, "");
+    MantidQt::API::HelpWindow::showFitFunction("");
   }
 }
 

--- a/qt/widgets/common/src/pqHelpWindow.cxx
+++ b/qt/widgets/common/src/pqHelpWindow.cxx
@@ -36,7 +36,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <QBuffer>
 #include <QFileInfo>
 #include <QHash>
-#include <QHelpContentWidget>
 #include <QHelpEngine>
 #include <QHelpIndexWidget>
 #include <QHelpSearchQueryWidget>
@@ -289,7 +288,6 @@ pqHelpWindow::pqHelpWindow(QHelpEngine *engine, QWidget *parentObject, const Qt:
   connect(this->m_helpEngine->searchEngine()->queryWidget(), SIGNAL(search()), this, SLOT(search()));
 
   // connect the index page to the content pane
-  connect(m_helpEngine->contentWidget(), SIGNAL(linkActivated(QUrl)), this, SLOT(showPage(QUrl)));
   connect(this->m_helpEngine->indexWidget(), SIGNAL(linkActivated(QUrl, QString)), this, SLOT(showPage(QUrl)));
 
 // setup the content pane
@@ -305,7 +303,7 @@ pqHelpWindow::pqHelpWindow(QHelpEngine *engine, QWidget *parentObject, const Qt:
   connect(m_browser->page(), SIGNAL(linkHovered(QString, QString, QString)), this,
           SLOT(linkHovered(QString, QString, QString)));
 #else
-  QWebEngineProfile::defaultProfile()->installUrlSchemeHandler(QTHELP_SCHEME, new QtHelpUrlHandler(engine));
+  QWebEngineProfile::defaultProfile()->installUrlSchemeHandler(QTHELP_SCHEME, new QtHelpUrlHandler(engine, this));
   m_browser = new QWebEngineView(this);
   m_browser->setPage(new DelegatingWebPage(m_browser));
   connect(m_browser->page(), SIGNAL(linkClicked(QUrl)), this, SLOT(showLinkedPage(QUrl)));

--- a/qt/widgets/common/test/MantidHelpWindowTest.h
+++ b/qt/widgets/common/test/MantidHelpWindowTest.h
@@ -62,10 +62,15 @@ private:
   void assertWidgetCreated() { TS_ASSERT_LESS_THAN(0, QApplication::topLevelWidgets().size()); }
 
   void assertNoTopLevelWidgets() {
+    // The 'QtWebEngineWidgetUI::MessageBubbleWidget' widget is an internal web engine widget which sometimes sticks
+    // around after closing the Help Window on a Windows machine. It was decided to ignore it as it's not causing any
+    // problems, and we expect the MantidHelpWindow code is near end-of-life.
     for (auto const &widget : QApplication::topLevelWidgets()) {
-      std::cout << widget->metaObject()->className() << std::endl;
+      auto const widgetClass = std::string(widget->metaObject()->className());
+      if (widgetClass != "QtWebEngineWidgetUI::MessageBubbleWidget") {
+        TS_FAIL("Found a widget of type " + widgetClass);
+      }
     }
-    TS_ASSERT_EQUALS(0, QApplication::topLevelWidgets().size());
   }
 
   std::size_t m_openAttempts{5u};

--- a/qt/widgets/common/test/MantidHelpWindowTest.h
+++ b/qt/widgets/common/test/MantidHelpWindowTest.h
@@ -1,0 +1,100 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2022 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#pragma once
+
+#include "MantidAPI/FrameworkManager.h"
+#include "MantidKernel/Instantiator.h"
+#include "MantidQtWidgets/Common/InterfaceManager.h"
+#include "MantidQtWidgets/Common/MantidHelpInterface.h"
+#include "MantidQtWidgets/Common/MantidHelpWindow.h"
+
+#include <QApplication>
+#include <QObject>
+#include <QTimer>
+#include <QWidget>
+
+#include <cxxtest/TestSuite.h>
+
+using namespace Mantid::API;
+using namespace MantidQt::API;
+using namespace MantidQt::MantidWidgets;
+using namespace testing;
+
+class MantidHelpWindowTest : public CxxTest::TestSuite {
+
+public:
+  MantidHelpWindowTest() { FrameworkManager::Instance(); }
+
+  static MantidHelpWindowTest *createSuite() { return new MantidHelpWindowTest; }
+  static void destroySuite(MantidHelpWindowTest *suite) { delete suite; }
+
+  void setUp() override { assertNoTopLevelWidgets(); }
+
+  void tearDown() override { assertNoTopLevelWidgets(); }
+
+  void test_the_mantid_help_window_can_be_opened_and_closed_once_without_a_parent_widget() {
+    openHelpInterfaceWithoutParent();
+  }
+
+  // void test_the_mantid_help_window_can_be_opened_and_closed_once_with_a_parent_widget() {
+  //  openHelpInterfaceWithParent();
+  //}
+
+  void test_the_mantid_help_window_can_be_opened_and_closed_multiple_times_without_a_parent_widget() {
+    for (auto i = 0u; i < m_openAttempts; ++i) {
+      openHelpInterfaceWithoutParent();
+    }
+  }
+
+  // void test_the_mantid_help_window_can_be_opened_and_closed_multiple_times_with_a_parent_widget() {
+  //  for (auto i = 0u; i < m_openAttempts; ++i) {
+  //    openHelpInterfaceWithParent();
+  //  }
+  //}
+
+private:
+  void openHelpInterfaceWithoutParent() {
+    // Assert widget is created
+    auto helpInterface = new MantidHelpWindow();
+    helpInterface->setAttribute(Qt::WA_DeleteOnClose);
+    helpInterface->showPage(m_url);
+    assertWidgetCreated();
+
+    // Assert widget is closed
+    QTimer::singleShot(0, helpInterface, &QWidget::close);
+    QApplication::sendPostedEvents();
+    QApplication::sendPostedEvents();
+
+    assertNoTopLevelWidgets();
+  }
+
+  // void openHelpInterfaceWithParent() {
+  //  const auto factory = new Mantid::Kernel::Instantiator<MantidHelpWindow, MantidHelpInterface, QWidget *>();
+
+  //  QWidget *parent = new QWidget();
+  //  parent->setAttribute(Qt::WA_DeleteOnClose);
+
+  //  // Assert widget is created
+  //  auto helpInterface = factory->createUnwrappedInstance(parent);
+  //  helpInterface->showPage(m_url);
+  //  assertWidgetCreated();
+
+  //  // Assert widget is closed
+  //  QTimer::singleShot(0, parent, &QWidget::close);
+  //  QApplication::sendPostedEvents();
+  //  QApplication::sendPostedEvents();
+
+  //  assertNoTopLevelWidgets();
+  //}
+
+  void assertWidgetCreated() { TS_ASSERT_LESS_THAN(0, QApplication::topLevelWidgets().size()); }
+
+  void assertNoTopLevelWidgets() { TS_ASSERT_EQUALS(0, QApplication::topLevelWidgets().size()); }
+
+  std::size_t m_openAttempts{1000u};
+  std::string m_url{"qthelp://org.mantidproject/doc/interfaces/direct/MSlice.html"};
+};

--- a/qt/widgets/common/test/MantidHelpWindowTest.h
+++ b/qt/widgets/common/test/MantidHelpWindowTest.h
@@ -7,13 +7,9 @@
 #pragma once
 
 #include "MantidAPI/FrameworkManager.h"
-#include "MantidKernel/Instantiator.h"
-#include "MantidQtWidgets/Common/InterfaceManager.h"
-#include "MantidQtWidgets/Common/MantidHelpInterface.h"
 #include "MantidQtWidgets/Common/MantidHelpWindow.h"
 
 #include <QApplication>
-#include <QObject>
 #include <QTimer>
 #include <QWidget>
 
@@ -36,28 +32,16 @@ public:
 
   void tearDown() override { assertNoTopLevelWidgets(); }
 
-  void test_the_mantid_help_window_can_be_opened_and_closed_once_without_a_parent_widget() {
-    openHelpInterfaceWithoutParent();
-  }
+  void test_the_mantid_help_window_can_be_opened_and_closed_once() { openHelpInterface(); }
 
-  // void test_the_mantid_help_window_can_be_opened_and_closed_once_with_a_parent_widget() {
-  //  openHelpInterfaceWithParent();
-  //}
-
-  void test_the_mantid_help_window_can_be_opened_and_closed_multiple_times_without_a_parent_widget() {
+  void test_the_mantid_help_window_can_be_opened_and_closed_multiple_times() {
     for (auto i = 0u; i < m_openAttempts; ++i) {
-      openHelpInterfaceWithoutParent();
+      openHelpInterface();
     }
   }
 
-  // void test_the_mantid_help_window_can_be_opened_and_closed_multiple_times_with_a_parent_widget() {
-  //  for (auto i = 0u; i < m_openAttempts; ++i) {
-  //    openHelpInterfaceWithParent();
-  //  }
-  //}
-
 private:
-  void openHelpInterfaceWithoutParent() {
+  void openHelpInterface() {
     // Assert widget is created
     auto helpInterface = new MantidHelpWindow();
     helpInterface->setAttribute(Qt::WA_DeleteOnClose);
@@ -72,29 +56,10 @@ private:
     assertNoTopLevelWidgets();
   }
 
-  // void openHelpInterfaceWithParent() {
-  //  const auto factory = new Mantid::Kernel::Instantiator<MantidHelpWindow, MantidHelpInterface, QWidget *>();
-
-  //  QWidget *parent = new QWidget();
-  //  parent->setAttribute(Qt::WA_DeleteOnClose);
-
-  //  // Assert widget is created
-  //  auto helpInterface = factory->createUnwrappedInstance(parent);
-  //  helpInterface->showPage(m_url);
-  //  assertWidgetCreated();
-
-  //  // Assert widget is closed
-  //  QTimer::singleShot(0, parent, &QWidget::close);
-  //  QApplication::sendPostedEvents();
-  //  QApplication::sendPostedEvents();
-
-  //  assertNoTopLevelWidgets();
-  //}
-
   void assertWidgetCreated() { TS_ASSERT_LESS_THAN(0, QApplication::topLevelWidgets().size()); }
 
   void assertNoTopLevelWidgets() { TS_ASSERT_EQUALS(0, QApplication::topLevelWidgets().size()); }
 
-  std::size_t m_openAttempts{1000u};
+  std::size_t m_openAttempts{5u};
   std::string m_url{"qthelp://org.mantidproject/doc/interfaces/direct/MSlice.html"};
 };

--- a/qt/widgets/common/test/MantidHelpWindowTest.h
+++ b/qt/widgets/common/test/MantidHelpWindowTest.h
@@ -49,16 +49,24 @@ private:
     assertWidgetCreated();
 
     // Assert widget is closed
+    // We don't understand why sendPostedEvents doesn't work, why it needs to be a singleShot,
+    // and why processEvents needs to be called twice. Requires more investigation into the
+    // Qt code.
     QTimer::singleShot(0, helpInterface, &QWidget::close);
-    QApplication::sendPostedEvents();
-    QApplication::sendPostedEvents();
+    QApplication::instance()->processEvents();
+    QApplication::instance()->processEvents();
 
     assertNoTopLevelWidgets();
   }
 
   void assertWidgetCreated() { TS_ASSERT_LESS_THAN(0, QApplication::topLevelWidgets().size()); }
 
-  void assertNoTopLevelWidgets() { TS_ASSERT_EQUALS(0, QApplication::topLevelWidgets().size()); }
+  void assertNoTopLevelWidgets() {
+    for (auto const &widget : QApplication::topLevelWidgets()) {
+      std::cout << widget->metaObject()->className() << std::endl;
+    }
+    TS_ASSERT_EQUALS(0, QApplication::topLevelWidgets().size());
+  }
 
   std::size_t m_openAttempts{5u};
   std::string m_url{"qthelp://org.mantidproject/doc/interfaces/direct/MSlice.html"};

--- a/qt/widgets/instrumentview/src/BaseCustomInstrumentView.cpp
+++ b/qt/widgets/instrumentview/src/BaseCustomInstrumentView.cpp
@@ -75,7 +75,7 @@ void BaseCustomInstrumentView::openHelp() {
   if (m_helpPage == "") {
     return;
   }
-  MantidQt::API::HelpWindow::showCustomInterface(nullptr, QString::fromStdString(m_helpPage));
+  MantidQt::API::HelpWindow::showCustomInterface(QString::fromStdString(m_helpPage));
 }
 
 std::string BaseCustomInstrumentView::getFile() {

--- a/qt/widgets/instrumentview/src/InstrumentWidget.cpp
+++ b/qt/widgets/instrumentview/src/InstrumentWidget.cpp
@@ -1024,7 +1024,7 @@ void InstrumentWidget::saveSettings() {
 }
 
 void InstrumentWidget::helpClicked() {
-  HelpWindow::showPage(nullptr, std::string("qthelp://org.mantidproject/doc/workbench/instrumentviewer.html"));
+  HelpWindow::showPage(std::string("qthelp://org.mantidproject/doc/workbench/instrumentviewer.html"));
 }
 
 void InstrumentWidget::set3DAxesState(bool on) {

--- a/qt/widgets/plugins/algorithm_dialogs/src/LoadDialog.cpp
+++ b/qt/widgets/plugins/algorithm_dialogs/src/LoadDialog.cpp
@@ -86,7 +86,7 @@ void LoadDialog::createDynamicWidgets() {
 void LoadDialog::helpClicked() {
   const auto loaderName = getAlgorithm()->getPropertyValue("LoaderName");
   QString helpPage = (loaderName.empty()) ? QString("Load") : QString::fromStdString(loaderName);
-  MantidQt::API::HelpWindow::showAlgorithm(this->nativeParentWidget(), helpPage);
+  MantidQt::API::HelpWindow::showAlgorithm(helpPage);
 }
 
 /**


### PR DESCRIPTION
**Description of work.**
This PR fixes a crash when passing a parent widget to the help window.

The ability to pass a parent widget has been removed for a couple of reasons:
- It is unused elsewhere in the codebase (including for the LoadDialog and AlgorithmDialog which just passes a nullptr)
- The crash would require implementing a better design for the help documentation code, which would be timely. This is not ideal seeing as we will be replacing the current documentation mechanism in Mantid in the near future.

**To test:**
In Release mode, and with the documentation targets built, do the following:
1. Open the `Fit Script Generator` interface
2. Click on the `Help` button and the documentation should appear.
3. Close the interface, and then open the FSG again and click `Help` again. There should be no crash

Fixes #34116

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
