### PR TITLE
Ignore reduction type when not applicable

### DIFF
--- a/docs/source/release/v6.5.0/Reflectometry/Bugfixes/34288.rst
+++ b/docs/source/release/v6.5.0/Reflectometry/Bugfixes/34288.rst
@@ -1,0 +1,1 @@
+- The reduction type from the Experiment Settings tab is now ignored when SumInLambda is selected

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/RowProcessingAlgorithm.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/RowProcessingAlgorithm.cpp
@@ -108,8 +108,12 @@ void updateFloodCorrectionProperties(AlgorithmRuntimeProps &properties, FloodCor
 void updateExperimentProperties(AlgorithmRuntimeProps &properties, Experiment const &experiment) {
   AlgorithmProperties::update("AnalysisMode", analysisModeToString(experiment.analysisMode()), properties);
   AlgorithmProperties::update("Debug", experiment.debug(), properties);
-  AlgorithmProperties::update("SummationType", summationTypeToString(experiment.summationType()), properties);
-  AlgorithmProperties::update("ReductionType", reductionTypeToString(experiment.reductionType()), properties);
+  SummationType summationType = experiment.summationType();
+  AlgorithmProperties::update("SummationType", summationTypeToString(summationType), properties);
+  // The ReductionType value is only relevant when the SummationType is SumInQ
+  ReductionType reductionType =
+      (summationType == SummationType::SumInQ) ? experiment.reductionType() : ReductionType::Normal;
+  AlgorithmProperties::update("ReductionType", reductionTypeToString(reductionType), properties);
   AlgorithmProperties::update("IncludePartialBins", experiment.includePartialBins(), properties);
   updateTransmissionStitchProperties(properties, experiment.transmissionStitchOptions());
   updateBackgroundSubtractionProperties(properties, experiment.backgroundSubtraction());

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/ExperimentWidget.ui
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/ExperimentWidget.ui
@@ -442,7 +442,7 @@
        </property>
        <item>
         <property name="text">
-         <string>Normal</string>
+         <string/>
         </property>
        </item>
        <item>

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/ReductionType.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/ReductionType.h
@@ -16,7 +16,7 @@ namespace ISISReflectometry {
 enum class ReductionType { DivergentBeam, NonFlatSample, Normal };
 
 inline ReductionType reductionTypeFromString(std::string const &reductionType) {
-  if (reductionType == "Normal")
+  if (reductionType.empty() || reductionType == "Normal")
     return ReductionType::Normal;
   else if (reductionType == "DivergentBeam")
     return ReductionType::DivergentBeam;

--- a/qt/scientific_interfaces/ISISReflectometry/TestHelpers/ModelCreationHelper.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/TestHelpers/ModelCreationHelper.cpp
@@ -433,6 +433,12 @@ Experiment makeExperimentWithValidDuplicateCriteria() {
                     makeLookupTableWithTwoValidDuplicateCriteria());
 }
 
+Experiment makeExperimentWithReductionTypeSetForSumInLambda() {
+  return Experiment(AnalysisMode::MultiDetector, ReductionType::NonFlatSample, SummationType::SumInLambda, true, true,
+                    makeBackgroundSubtraction(), makePolarizationCorrections(), makeFloodCorrections(),
+                    makeTransmissionStitchOptions(), makeStitchOptions(), makeLookupTableWithTwoAnglesAndWildcard());
+}
+
 /* Instrument */
 
 RangeInLambda makeWavelengthRange() { return RangeInLambda(2.3, 14.4); }

--- a/qt/scientific_interfaces/ISISReflectometry/TestHelpers/ModelCreationHelper.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/TestHelpers/ModelCreationHelper.cpp
@@ -434,9 +434,10 @@ Experiment makeExperimentWithValidDuplicateCriteria() {
 }
 
 Experiment makeExperimentWithReductionTypeSetForSumInLambda() {
-  return Experiment(AnalysisMode::MultiDetector, ReductionType::NonFlatSample, SummationType::SumInLambda, true, true,
-                    makeBackgroundSubtraction(), makePolarizationCorrections(), makeFloodCorrections(),
-                    makeTransmissionStitchOptions(), makeStitchOptions(), makeLookupTableWithTwoAnglesAndWildcard());
+  return Experiment(AnalysisMode::PointDetector, ReductionType::NonFlatSample, SummationType::SumInLambda, false, false,
+                    makeEmptyBackgroundSubtraction(), PolarizationCorrections(PolarizationCorrectionType::None),
+                    FloodCorrections(FloodCorrectionType::Workspace), TransmissionStitchOptions(),
+                    std::map<std::string, std::string>(), LookupTable());
 }
 
 /* Instrument */

--- a/qt/scientific_interfaces/ISISReflectometry/TestHelpers/ModelCreationHelper.h
+++ b/qt/scientific_interfaces/ISISReflectometry/TestHelpers/ModelCreationHelper.h
@@ -91,6 +91,7 @@ MANTIDQT_ISISREFLECTOMETRY_DLL TransmissionStitchOptions makeEmptyTransmissionSt
 MANTIDQT_ISISREFLECTOMETRY_DLL Experiment makeExperiment();
 MANTIDQT_ISISREFLECTOMETRY_DLL Experiment makeEmptyExperiment();
 MANTIDQT_ISISREFLECTOMETRY_DLL Experiment makeExperimentWithValidDuplicateCriteria();
+MANTIDQT_ISISREFLECTOMETRY_DLL Experiment makeExperimentWithReductionTypeSetForSumInLambda();
 
 /* Instrument */
 MANTIDQT_ISISREFLECTOMETRY_DLL RangeInLambda makeWavelengthRange();

--- a/qt/scientific_interfaces/ISISReflectometry/test/Batch/RowProcessingAlgorithmTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Batch/RowProcessingAlgorithmTest.h
@@ -49,6 +49,14 @@ public:
     checkExperimentSettings(*result);
   }
 
+  void testExperimentSettingsReductionTypeSetToNormalForSumInLambda() {
+    auto model = Batch(makeExperimentWithReductionTypeSetForSumInLambda(), m_instrument, m_runsTable, m_slicing);
+    auto row = makeEmptyRow();
+    auto result = RowProcessing::createAlgorithmRuntimeProps(model, row);
+    TS_ASSERT_EQUALS(result->getPropertyValue("ReductionType"), "Normal");
+    TS_ASSERT_EQUALS(result->getPropertyValue("SummationType"), "SumInLambda");
+  }
+
   void testExperimentSettingsWithPreviewRow() {
     auto model = Batch(m_experiment, m_instrument, m_runsTable, m_slicing);
     auto theta = 0.7;

--- a/qt/scientific_interfaces/ISISReflectometry/test/Batch/RowProcessingAlgorithmTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Batch/RowProcessingAlgorithmTest.h
@@ -50,7 +50,8 @@ public:
   }
 
   void testExperimentSettingsReductionTypeSetToNormalForSumInLambda() {
-    auto model = Batch(makeExperimentWithReductionTypeSetForSumInLambda(), m_instrument, m_runsTable, m_slicing);
+    auto experiment = makeExperimentWithReductionTypeSetForSumInLambda();
+    auto model = Batch(experiment, m_instrument, m_runsTable, m_slicing);
     auto row = makeEmptyRow();
     auto result = RowProcessing::createAlgorithmRuntimeProps(model, row);
     TS_ASSERT_EQUALS(result->getPropertyValue("ReductionType"), "Normal");


### PR DESCRIPTION
**Description of work.**

The ReductionType selected on the Experiment Settings tab is now ignored and a value of `Normal` is always used when the SummationType is SumInLambda.

Looking through the code, it seems that we're using `Normal` to represent that no ReductionType has been selected. Changing this to be a blank string throughout the code base would be ideal, but I think it would be an extensive change as it's used in lots of places. Instead I have changed the ReductionType dropdown to display a blank value rather than `Normal` to make it clear to the user that a value hasn't been set. Internally the code then converts the blank string to `Normal`.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**

- Open the ISIS Reflectometry interface
- In the table enter run 13460 and angle 0.5
- On the Experiment Settings tab, set the Summation Type to SumInQ.
- Set ReductionType to DivergentBeam
- Set SummationType back to SumInLambda
- Back on the Runs tab, click Process. The reduction should complete successfully.
- Also test that the reduction completes successfully when SummationType is set to SumInLambda and ReductionType is left blank

Fixes #33717. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
