### PR TITLE
Add checkbox to include row outputs in autosave

### DIFF
--- a/docs/source/release/v6.5.0/Reflectometry/New_features/34289.rst
+++ b/docs/source/release/v6.5.0/Reflectometry/New_features/34289.rst
@@ -1,0 +1,1 @@
+- The Save ASCII tab now has a checkbox to allow individual row outputs to be included as well as group outputs when autosave is selected.

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchJobManager.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchJobManager.cpp
@@ -264,20 +264,32 @@ boost::optional<Item &> BatchJobManager::getRunsTableItem(IConfiguredAlgorithm_s
   return *item;
 }
 
-std::vector<std::string> BatchJobManager::algorithmOutputWorkspacesToSave(IConfiguredAlgorithm_sptr algorithm) const {
+std::vector<std::string> BatchJobManager::algorithmOutputWorkspacesToSave(IConfiguredAlgorithm_sptr algorithm,
+                                                                          bool includeGrpRows) const {
   auto jobAlgorithm = std::dynamic_pointer_cast<IBatchJobAlgorithm>(algorithm);
   auto item = jobAlgorithm->item();
 
   if (item->isGroup())
-    return getWorkspacesToSave(dynamic_cast<Group &>(*item));
+    return getWorkspacesToSave(dynamic_cast<Group &>(*item), includeGrpRows);
   else
     return getWorkspacesToSave(dynamic_cast<Row &>(*item));
 
   return std::vector<std::string>();
 }
 
-std::vector<std::string> BatchJobManager::getWorkspacesToSave(Group const &group) const {
-  return std::vector<std::string>{group.postprocessedWorkspaceName()};
+std::vector<std::string> BatchJobManager::getWorkspacesToSave(Group const &group, bool includeRows) const {
+  auto workspaces = std::vector<std::string>{group.postprocessedWorkspaceName()};
+
+  if (includeRows) {
+    auto const &rows = group.rows();
+    for (auto &row : rows) {
+      if (row) {
+        workspaces.emplace_back(row.get().reducedWorkspaceNames().iVsQBinned());
+      }
+    }
+  }
+
+  return workspaces;
 }
 
 std::vector<std::string> BatchJobManager::getWorkspacesToSave(Row const &row) const {

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchJobManager.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchJobManager.h
@@ -49,8 +49,8 @@ public:
   void algorithmComplete(MantidQt::API::IConfiguredAlgorithm_sptr algorithm) override;
   void algorithmError(MantidQt::API::IConfiguredAlgorithm_sptr algorithm, std::string const &message) override;
 
-  std::vector<std::string>
-  algorithmOutputWorkspacesToSave(MantidQt::API::IConfiguredAlgorithm_sptr algorithm) const override;
+  std::vector<std::string> algorithmOutputWorkspacesToSave(MantidQt::API::IConfiguredAlgorithm_sptr algorithm,
+                                                           bool includeGrpRows) const override;
 
   boost::optional<Item const &> notifyWorkspaceDeleted(std::string const &wsName) override;
   boost::optional<Item const &> notifyWorkspaceRenamed(std::string const &oldName, std::string const &newName) override;
@@ -75,7 +75,7 @@ protected:
 private:
   int itemsInSelection(Item::ItemCountFunction countFunction) const;
 
-  std::vector<std::string> getWorkspacesToSave(Group const &group) const;
+  std::vector<std::string> getWorkspacesToSave(Group const &group, bool includeRows) const;
   std::vector<std::string> getWorkspacesToSave(Row const &row) const;
   size_t getNumberOfInitialisedRowsInGroup(const int groupIndex) const;
   template <typename T> bool isSelected(T const &item);

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchPresenter.cpp
@@ -136,7 +136,8 @@ void BatchPresenter::notifyAlgorithmComplete(IConfiguredAlgorithm_sptr &algorith
   /// TODO Longer term it would probably be better if algorithms took care
   /// of saving their outputs so we could remove this callback
   if (m_savePresenter->shouldAutosave()) {
-    auto const workspaces = m_jobManager->algorithmOutputWorkspacesToSave(algorithm);
+    auto const workspaces =
+        m_jobManager->algorithmOutputWorkspacesToSave(algorithm, m_savePresenter->shouldAutosaveGroupRows());
     m_savePresenter->saveWorkspaces(workspaces);
   }
 }

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/IBatchJobManager.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/IBatchJobManager.h
@@ -37,8 +37,8 @@ public:
   virtual void algorithmStarted(MantidQt::API::IConfiguredAlgorithm_sptr algorithm) = 0;
   virtual void algorithmComplete(MantidQt::API::IConfiguredAlgorithm_sptr algorithm) = 0;
   virtual void algorithmError(MantidQt::API::IConfiguredAlgorithm_sptr algorithm, std::string const &message) = 0;
-  virtual std::vector<std::string>
-  algorithmOutputWorkspacesToSave(MantidQt::API::IConfiguredAlgorithm_sptr algorithm) const = 0;
+  virtual std::vector<std::string> algorithmOutputWorkspacesToSave(MantidQt::API::IConfiguredAlgorithm_sptr algorithm,
+                                                                   bool includeGrpRows) const = 0;
   virtual boost::optional<Item const &> notifyWorkspaceDeleted(std::string const &wsName) = 0;
   virtual boost::optional<Item const &> notifyWorkspaceRenamed(std::string const &oldName,
                                                                std::string const &newName) = 0;

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Save/ISavePresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Save/ISavePresenter.h
@@ -24,6 +24,7 @@ public:
   virtual void acceptMainPresenter(IBatchPresenter *mainPresenter) = 0;
   virtual void saveWorkspaces(std::vector<std::string> const &workspaceNames) = 0;
   virtual bool shouldAutosave() const = 0;
+  virtual bool shouldAutosaveGroupRows() const = 0;
 
   /// Tell the presenter something happened
   virtual void notifyReductionPaused() = 0;

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Save/ISaveView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Save/ISaveView.h
@@ -76,6 +76,8 @@ public:
   virtual void disableQResolutionCheckBox() = 0;
   virtual void enableSeparatorButtonGroup() = 0;
   virtual void disableSeparatorButtonGroup() = 0;
+  virtual void enableSaveIndividualRowsCheckbox() = 0;
+  virtual void disableSaveIndividualRowsCheckbox() = 0;
 
   virtual void showFilterEditValid() = 0;
   virtual void showFilterEditInvalid() = 0;

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Save/ISaveView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Save/ISaveView.h
@@ -23,6 +23,8 @@ public:
   virtual void notifySaveSelectedWorkspaces() = 0;
   virtual void notifyAutosaveDisabled() = 0;
   virtual void notifyAutosaveEnabled() = 0;
+  virtual void notifySaveIndividualRowsEnabled() = 0;
+  virtual void notifySaveIndividualRowsDisabled() = 0;
   virtual void notifySavePathChanged() = 0;
 };
 

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Save/QtSaveView.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Save/QtSaveView.cpp
@@ -63,6 +63,7 @@ void QtSaveView::connectSaveSettingsWidgets() {
   connectSettingsChange(*m_ui.filterEdit);
   connectSettingsChange(*m_ui.regexCheckBox);
   connectSettingsChange(*m_ui.saveReductionResultsCheckBox);
+  connectSettingsChange(*m_ui.saveIndividualRowsCheckBox);
   connectSettingsChange(*m_ui.headerCheckBox);
   connectSettingsChange(*m_ui.qResolutionCheckBox);
   connectSettingsChange(*m_ui.commaRadioButton);

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Save/QtSaveView.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Save/QtSaveView.cpp
@@ -142,6 +142,10 @@ void QtSaveView::disableSeparatorButtonGroup() {
   m_ui.tabRadioButton->setEnabled(false);
 }
 
+void QtSaveView::enableSaveIndividualRowsCheckbox() { m_ui.saveIndividualRowsCheckBox->setEnabled(true); }
+
+void QtSaveView::disableSaveIndividualRowsCheckbox() { m_ui.saveIndividualRowsCheckBox->setEnabled(false); }
+
 /** Returns the save path
  * @return :: The save path
  */

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Save/QtSaveView.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Save/QtSaveView.cpp
@@ -34,6 +34,7 @@ void QtSaveView::initLayout() {
   connect(m_ui.filterEdit, SIGNAL(textChanged(const QString &)), this, SLOT(filterWorkspaceList()));
   connect(m_ui.listOfWorkspaces, SIGNAL(itemDoubleClicked(QListWidgetItem *)), this, SLOT(requestWorkspaceParams()));
   connect(m_ui.saveReductionResultsCheckBox, SIGNAL(stateChanged(int)), this, SLOT(onAutosaveChanged(int)));
+  connect(m_ui.saveIndividualRowsCheckBox, SIGNAL(stateChanged(int)), this, SLOT(onSaveIndividualRowsChanged(int)));
   connect(m_ui.savePathEdit, SIGNAL(editingFinished()), this, SLOT(onSavePathChanged()));
   connect(m_ui.savePathBrowseButton, SIGNAL(clicked()), this, SLOT(browseToSaveDirectory()));
 }
@@ -93,6 +94,14 @@ void QtSaveView::onAutosaveChanged(int state) {
     Mantid::Kernel::UsageService::Instance().registerFeatureUsage(
         Mantid::Kernel::FeatureType::Feature, {"ISIS Reflectometry", "SaveTab", "DisableAutosave"}, false);
     m_notifyee->notifyAutosaveDisabled();
+  }
+}
+
+void QtSaveView::onSaveIndividualRowsChanged(int state) {
+  if (state == Qt::CheckState::Checked) {
+    m_notifyee->notifySaveIndividualRowsEnabled();
+  } else {
+    m_notifyee->notifySaveIndividualRowsDisabled();
   }
 }
 

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Save/QtSaveView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Save/QtSaveView.h
@@ -83,6 +83,8 @@ public:
   void disableQResolutionCheckBox() override;
   void enableSeparatorButtonGroup() override;
   void disableSeparatorButtonGroup() override;
+  void enableSaveIndividualRowsCheckbox() override;
+  void disableSaveIndividualRowsCheckbox() override;
 
   void error(const std::string &title, const std::string &prompt);
   void warning(const std::string &title, const std::string &prompt);

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Save/QtSaveView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Save/QtSaveView.h
@@ -108,6 +108,7 @@ public slots:
 
   void onSavePathChanged();
   void onAutosaveChanged(int state);
+  void onSaveIndividualRowsChanged(int state);
 
 private slots:
   void onSettingsChanged();

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Save/SavePresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Save/SavePresenter.cpp
@@ -125,6 +125,7 @@ void SavePresenter::notifyAutoreductionResumed() { updateWidgetEnabledState(); }
 void SavePresenter::enableAutosave() {
   if (isValidSaveDirectory(m_view->getSavePath())) {
     m_shouldAutosave = true;
+    m_view->enableSaveIndividualRowsCheckbox();
   } else {
     m_shouldAutosave = false;
     m_view->disallowAutosave();
@@ -132,7 +133,10 @@ void SavePresenter::enableAutosave() {
   }
 }
 
-void SavePresenter::disableAutosave() { m_shouldAutosave = false; }
+void SavePresenter::disableAutosave() {
+  m_shouldAutosave = false;
+  m_view->disableSaveIndividualRowsCheckbox();
+}
 
 void SavePresenter::notifySaveIndividualRowsEnabled() { m_shouldSaveIndividualRows = true; }
 

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Save/SavePresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Save/SavePresenter.cpp
@@ -28,7 +28,8 @@ using namespace Mantid::API;
  * @param view :: The view we are handling
  */
 SavePresenter::SavePresenter(ISaveView *view, std::unique_ptr<IAsciiSaver> saver)
-    : m_mainPresenter(nullptr), m_view(view), m_saver(std::move(saver)), m_shouldAutosave(false) {
+    : m_mainPresenter(nullptr), m_view(view), m_saver(std::move(saver)), m_shouldAutosave(false),
+      m_shouldSaveIndividualRows(false) {
 
   m_view->subscribe(this);
   populateWorkspaceList();
@@ -133,12 +134,18 @@ void SavePresenter::enableAutosave() {
 
 void SavePresenter::disableAutosave() { m_shouldAutosave = false; }
 
+void SavePresenter::notifySaveIndividualRowsEnabled() { m_shouldSaveIndividualRows = true; }
+
+void SavePresenter::notifySaveIndividualRowsDisabled() { m_shouldSaveIndividualRows = false; }
+
 void SavePresenter::onSavePathChanged() {
   if (shouldAutosave() && !isValidSaveDirectory(m_view->getSavePath()))
     warnInvalidSaveDirectory();
 }
 
 bool SavePresenter::shouldAutosave() const { return m_shouldAutosave; }
+
+bool SavePresenter::shouldAutosaveGroupRows() const { return m_shouldSaveIndividualRows; }
 
 /** Fills the 'List of Workspaces' widget with the names of all available
  * workspaces

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Save/SavePresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Save/SavePresenter.h
@@ -33,6 +33,7 @@ public:
   void acceptMainPresenter(IBatchPresenter *mainPresenter) override;
   void saveWorkspaces(std::vector<std::string> const &workspaceNames) override;
   bool shouldAutosave() const override;
+  bool shouldAutosaveGroupRows() const override;
   void notifyReductionPaused() override;
   void notifyReductionResumed() override;
   void notifyAutoreductionPaused() override;
@@ -46,6 +47,8 @@ public:
   void notifySaveSelectedWorkspaces() override;
   void notifyAutosaveDisabled() override;
   void notifyAutosaveEnabled() override;
+  void notifySaveIndividualRowsEnabled() override;
+  void notifySaveIndividualRowsDisabled() override;
   void notifySavePathChanged() override;
 
 private:
@@ -83,6 +86,7 @@ private:
   ISaveView *m_view;
   std::unique_ptr<IAsciiSaver> m_saver;
   bool m_shouldAutosave;
+  bool m_shouldSaveIndividualRows;
 };
 } // namespace ISISReflectometry
 } // namespace CustomInterfaces

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Save/SaveWidget.ui
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Save/SaveWidget.ui
@@ -155,6 +155,16 @@
             </property>
            </widget>
           </item>
+          <item>
+           <widget class="QCheckBox" name="saveIndividualRowsCheckBox">
+            <property name="enabled">
+             <bool>true</bool>
+            </property>
+            <property name="text">
+             <string>Include individual row outputs for groups</string>
+            </property>
+           </widget>
+          </item>
          </layout>
         </widget>
        </item>

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Save/SaveWidget.ui
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Save/SaveWidget.ui
@@ -158,7 +158,7 @@
           <item>
            <widget class="QCheckBox" name="saveIndividualRowsCheckBox">
             <property name="enabled">
-             <bool>true</bool>
+             <bool>false</bool>
             </property>
             <property name="text">
              <string>Include individual row outputs for groups</string>

--- a/qt/scientific_interfaces/ISISReflectometry/test/Batch/BatchJobManagerWorkspacesTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Batch/BatchJobManagerWorkspacesTest.h
@@ -23,7 +23,7 @@ public:
     EXPECT_CALL(*m_jobAlgorithm, item()).Times(AtLeast(1)).WillRepeatedly(Return(row));
 
     // For a single row, we save the binned workspace for the row
-    auto workspacesToSave = jobManager.algorithmOutputWorkspacesToSave(m_jobAlgorithm);
+    auto workspacesToSave = jobManager.algorithmOutputWorkspacesToSave(m_jobAlgorithm, false);
     TS_ASSERT_EQUALS(workspacesToSave, std::vector<std::string>{"IvsQBin"});
 
     verifyAndClear();
@@ -37,13 +37,13 @@ public:
     EXPECT_CALL(*m_jobAlgorithm, item()).Times(AtLeast(1)).WillRepeatedly(Return(row));
 
     // For multiple rows, we don't save any workspaces
-    auto workspacesToSave = jobManager.algorithmOutputWorkspacesToSave(m_jobAlgorithm);
+    auto workspacesToSave = jobManager.algorithmOutputWorkspacesToSave(m_jobAlgorithm, false);
     TS_ASSERT_EQUALS(workspacesToSave, std::vector<std::string>{});
 
     verifyAndClear();
   }
 
-  void testGetWorkspacesToSaveForGroup() {
+  void testGetWorkspacesToSaveForGroupWithoutIncludeRows() {
     auto jobManager = makeJobManager(oneGroupWithTwoRowsModel());
     auto &group = getGroup(jobManager, 0);
     group.setOutputNames({
@@ -52,7 +52,56 @@ public:
 
     EXPECT_CALL(*m_jobAlgorithm, item()).Times(AtLeast(1)).WillRepeatedly(Return(&group));
 
-    auto workspacesToSave = jobManager.algorithmOutputWorkspacesToSave(m_jobAlgorithm);
+    auto workspacesToSave = jobManager.algorithmOutputWorkspacesToSave(m_jobAlgorithm, false);
+    TS_ASSERT_EQUALS(workspacesToSave, std::vector<std::string>{"stitched_test"});
+
+    verifyAndClear();
+  }
+
+  void testGetWorkspacesToSaveForGroupWithIncludeRows() {
+    auto jobManager = makeJobManager(oneGroupWithTwoRowsModel());
+    auto &group = getGroup(jobManager, 0);
+    group.setOutputNames({
+        "stitched_test",
+    });
+    auto *row1 = getRow(jobManager, 0, 0);
+    row1->setOutputNames({"", "test1", "row_bin_test01"});
+    auto *row2 = getRow(jobManager, 0, 1);
+    row2->setOutputNames({"", "test2", "row_bin_test02"});
+
+    EXPECT_CALL(*m_jobAlgorithm, item()).Times(AtLeast(1)).WillRepeatedly(Return(&group));
+
+    auto workspacesToSave = jobManager.algorithmOutputWorkspacesToSave(m_jobAlgorithm, true);
+    TS_ASSERT_EQUALS(workspacesToSave, std::vector<std::string>({"stitched_test", "row_bin_test01", "row_bin_test02"}));
+
+    verifyAndClear();
+  }
+
+  void testGetWorkspacesToSaveForGroupHasNoRowsWithIncludeRows() {
+    auto jobManager = makeJobManager(oneEmptyGroupModel());
+    auto &group = getGroup(jobManager, 0);
+    group.setOutputNames({
+        "stitched_test",
+    });
+
+    EXPECT_CALL(*m_jobAlgorithm, item()).Times(AtLeast(1)).WillRepeatedly(Return(&group));
+
+    auto workspacesToSave = jobManager.algorithmOutputWorkspacesToSave(m_jobAlgorithm, true);
+    TS_ASSERT_EQUALS(workspacesToSave, std::vector<std::string>{"stitched_test"});
+
+    verifyAndClear();
+  }
+
+  void testGetWorkspacesToSaveForGroupHasInvalidRowWithIncludeRows() {
+    auto jobManager = makeJobManager(oneGroupWithAnInvalidRowModel());
+    auto &group = getGroup(jobManager, 0);
+    group.setOutputNames({
+        "stitched_test",
+    });
+
+    EXPECT_CALL(*m_jobAlgorithm, item()).Times(AtLeast(1)).WillRepeatedly(Return(&group));
+
+    auto workspacesToSave = jobManager.algorithmOutputWorkspacesToSave(m_jobAlgorithm, true);
     TS_ASSERT_EQUALS(workspacesToSave, std::vector<std::string>{"stitched_test"});
 
     verifyAndClear();

--- a/qt/scientific_interfaces/ISISReflectometry/test/Batch/BatchPresenterTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Batch/BatchPresenterTest.h
@@ -382,11 +382,27 @@ public:
     auto presenter = makePresenter(makeModel());
     IConfiguredAlgorithm_sptr algorithm = std::make_shared<MockBatchJobAlgorithm>();
     EXPECT_CALL(*m_savePresenter, shouldAutosave()).Times(1).WillOnce(Return(true));
+    EXPECT_CALL(*m_savePresenter, shouldAutosaveGroupRows()).Times(1).WillOnce(Return(false));
     auto const workspaces = std::vector<std::string>{"test1", "test2"};
     auto row = makeRow();
     EXPECT_CALL(*m_jobManager, getRunsTableItem(algorithm)).Times(1).WillOnce(Return(row));
     EXPECT_CALL(*m_jobManager, algorithmComplete(algorithm)).Times(1);
-    EXPECT_CALL(*m_jobManager, algorithmOutputWorkspacesToSave(algorithm)).Times(1).WillOnce(Return(workspaces));
+    EXPECT_CALL(*m_jobManager, algorithmOutputWorkspacesToSave(algorithm, false)).Times(1).WillOnce(Return(workspaces));
+    EXPECT_CALL(*m_savePresenter, saveWorkspaces(workspaces)).Times(1);
+    presenter->notifyAlgorithmComplete(algorithm);
+    verifyAndClear();
+  }
+
+  void testOutputWorkspacesSavedOnAlgorithmCompleteWithAutosaveGroupRows() {
+    auto presenter = makePresenter(makeModel());
+    IConfiguredAlgorithm_sptr algorithm = std::make_shared<MockBatchJobAlgorithm>();
+    EXPECT_CALL(*m_savePresenter, shouldAutosave()).Times(1).WillOnce(Return(true));
+    EXPECT_CALL(*m_savePresenter, shouldAutosaveGroupRows()).Times(1).WillOnce(Return(true));
+    auto const workspaces = std::vector<std::string>{"test1", "test2"};
+    auto row = makeRow();
+    EXPECT_CALL(*m_jobManager, getRunsTableItem(algorithm)).Times(1).WillOnce(Return(row));
+    EXPECT_CALL(*m_jobManager, algorithmComplete(algorithm)).Times(1);
+    EXPECT_CALL(*m_jobManager, algorithmOutputWorkspacesToSave(algorithm, true)).Times(1).WillOnce(Return(workspaces));
     EXPECT_CALL(*m_savePresenter, saveWorkspaces(workspaces)).Times(1);
     presenter->notifyAlgorithmComplete(algorithm);
     verifyAndClear();
@@ -399,7 +415,7 @@ public:
     auto row = makeRow();
     EXPECT_CALL(*m_jobManager, getRunsTableItem(algorithm)).Times(1).WillOnce(Return(row));
     EXPECT_CALL(*m_jobManager, algorithmComplete(algorithm)).Times(1);
-    EXPECT_CALL(*m_jobManager, algorithmOutputWorkspacesToSave(_)).Times(0);
+    EXPECT_CALL(*m_jobManager, algorithmOutputWorkspacesToSave(_, _)).Times(0);
     EXPECT_CALL(*m_savePresenter, saveWorkspaces(_)).Times(0);
     presenter->notifyAlgorithmComplete(algorithm);
     verifyAndClear();

--- a/qt/scientific_interfaces/ISISReflectometry/test/ReflMockObjects.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/ReflMockObjects.h
@@ -192,6 +192,7 @@ public:
   MOCK_METHOD1(acceptMainPresenter, void(IBatchPresenter *));
   MOCK_METHOD1(saveWorkspaces, void(std::vector<std::string> const &));
   MOCK_CONST_METHOD0(shouldAutosave, bool());
+  MOCK_CONST_METHOD0(shouldAutosaveGroupRows, bool());
   MOCK_METHOD0(notifyReductionPaused, void());
   MOCK_METHOD0(notifyReductionResumed, void());
   MOCK_METHOD0(notifyAutoreductionPaused, void());

--- a/qt/scientific_interfaces/ISISReflectometry/test/ReflMockObjects.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/ReflMockObjects.h
@@ -355,8 +355,8 @@ public:
   MOCK_METHOD1(algorithmStarted, void(MantidQt::API::IConfiguredAlgorithm_sptr));
   MOCK_METHOD1(algorithmComplete, void(MantidQt::API::IConfiguredAlgorithm_sptr));
   MOCK_METHOD2(algorithmError, void(MantidQt::API::IConfiguredAlgorithm_sptr, std::string const &));
-  MOCK_CONST_METHOD1(algorithmOutputWorkspacesToSave,
-                     std::vector<std::string>(MantidQt::API::IConfiguredAlgorithm_sptr));
+  MOCK_CONST_METHOD2(algorithmOutputWorkspacesToSave,
+                     std::vector<std::string>(MantidQt::API::IConfiguredAlgorithm_sptr, bool));
   MOCK_METHOD1(notifyWorkspaceDeleted, boost::optional<Item const &>(std::string const &));
   MOCK_METHOD2(notifyWorkspaceRenamed, boost::optional<Item const &>(std::string const &, std::string const &));
   MOCK_METHOD0(notifyAllWorkspacesDeleted, void());

--- a/qt/scientific_interfaces/ISISReflectometry/test/Save/MockSaveView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Save/MockSaveView.h
@@ -55,6 +55,8 @@ public:
   MOCK_METHOD0(disableQResolutionCheckBox, void());
   MOCK_METHOD0(enableSeparatorButtonGroup, void());
   MOCK_METHOD0(disableSeparatorButtonGroup, void());
+  MOCK_METHOD0(enableSaveIndividualRowsCheckbox, void());
+  MOCK_METHOD0(disableSaveIndividualRowsCheckbox, void());
 
   MOCK_METHOD0(showFilterEditValid, void());
   MOCK_METHOD0(showFilterEditInvalid, void());

--- a/qt/scientific_interfaces/ISISReflectometry/test/Save/SavePresenterTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Save/SavePresenterTest.h
@@ -197,6 +197,43 @@ public:
     verifyAndClear();
   }
 
+  void testNotifySaveIndividualRowsEnabled() {
+    auto presenter = makePresenter();
+    // There are no calls to the view
+    presenter.notifySaveIndividualRowsEnabled();
+    verifyAndClear();
+  }
+
+  void testNotifySaveIndividualRowsDisabled() {
+    auto presenter = makePresenter();
+    // There are no calls to the view
+    presenter.notifySaveIndividualRowsDisabled();
+    verifyAndClear();
+  }
+
+  void testShouldAutosaveGroupRowsFalseByDefault() {
+    auto presenter = makePresenter();
+    bool saveRows = presenter.shouldAutosaveGroupRows();
+    TS_ASSERT(!saveRows);
+    verifyAndClear();
+  }
+
+  void testShouldAutosaveGroupRowsWhenSaveIndividualRowsIsEnabled() {
+    auto presenter = makePresenter();
+    presenter.notifySaveIndividualRowsEnabled();
+    bool saveRows = presenter.shouldAutosaveGroupRows();
+    TS_ASSERT(saveRows);
+    verifyAndClear();
+  }
+
+  void testShouldAutosaveGroupRowsWhenSaveIndividualRowsIsDisabled() {
+    auto presenter = makePresenter();
+    presenter.notifySaveIndividualRowsDisabled();
+    bool saveRows = presenter.shouldAutosaveGroupRows();
+    TS_ASSERT(!saveRows);
+    verifyAndClear();
+  }
+
   void testNotifySavePathChangedWithAutosaveOn() {
     auto presenter = makePresenter();
     enableAutosave(presenter);

--- a/qt/scientific_interfaces/ISISReflectometry/test/Save/SavePresenterTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Save/SavePresenterTest.h
@@ -177,6 +177,7 @@ public:
   void testNotifyAutosaveDisabled() {
     auto presenter = makePresenter();
     // There are no calls to the view
+    EXPECT_CALL(m_view, disableSaveIndividualRowsCheckbox()).Times(1);
     presenter.notifyAutosaveDisabled();
     verifyAndClear();
   }
@@ -184,6 +185,7 @@ public:
   void testNotifyAutosaveEnabled() {
     auto presenter = makePresenter();
     expectGetValidSaveDirectory();
+    EXPECT_CALL(m_view, enableSaveIndividualRowsCheckbox()).Times(1);
     presenter.notifyAutosaveEnabled();
     verifyAndClear();
   }
@@ -191,6 +193,7 @@ public:
   void testNotifyAutosaveEnabledWithInvalidPath() {
     auto presenter = makePresenter();
     expectGetInvalidSaveDirectory();
+    EXPECT_CALL(m_view, enableSaveIndividualRowsCheckbox()).Times(0);
     EXPECT_CALL(m_view, disallowAutosave()).Times(1);
     EXPECT_CALL(m_view, errorInvalidSaveDirectory()).Times(1);
     presenter.notifyAutosaveEnabled();


### PR DESCRIPTION
**Description of work.**

Adds a checkbox to the Autosave section on the Save ACII tab to allow users to choose whether to include individual rows as well as stitched groups in the saved outputs. The new checkbox should only be enabled (i.e. not greyed out) when the user has selected the autosave checkbox.

**To test:**

- Open the Reflectometry interface
- Open the Save ASCII tab and confirm that the `Save as ASCII on completion` checkbox is enabled but unticked and the `Include individual row outputs for groups` checkbox is disabled and unticked.
- Select a Save Path (create a convenient directory on your machine to hold the saved output) and then select the checkbox labelled `Save as ASCII on completion`. Check that the `Include individual row outputs for groups` checkbox is enabled. Select the checkbox.
- On the Runs tab enter instrument `INTER`, investigation id `1120015` and cycle `11_3` and click Search. Highlight 4 or 5 rows from the table (make sure at least one group with multiple rows is included) and click the Transfer button to move them into the right hand panel.
- Click the Process button. Check the save directory you specified and confirm that files have been output for both the groups and rows.
- Also test the following:
   - individual rows are not output if the checkbox is not selected.
   - nothing is output if the individual rows checkbox has been selected and then autosave has been deselected

Fixes #34130. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
