### PR TITLE
Fix SHELX format in SaveReflections

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/SaveReflections.py
+++ b/Framework/PythonInterface/plugins/algorithms/SaveReflections.py
@@ -117,7 +117,9 @@ class SaveReflections(PythonAlgorithm):
         # find the max intensity so fits in column with format 12.2f in Fullprof and Jana, 8.2f in SaveHKL (SHELX, GSAS)
         max_intens = max(workspace.column('Intens'))
         max_exponent = 8 if output_format in [ReflectionFormat.Fullprof, ReflectionFormat.Jana] else 4
-        scale = 1 if max_intens < 10**max_exponent else 10**(-(int(np.log10(max_intens))-max_exponent+1))
+        min_exponent = -2  # 2 decimal points in SHELX, FullProf, Jana2006 and GSAS-II
+        # find scale factor to scale intensity to largest value in the available width (e.g. 9999.99 for SHELX)
+        scale = 1 if max_intens < 10 ** max_exponent else ((10 ** max_exponent) - 10 ** min_exponent) / max_intens
         FORMAT_MAP[output_format]()(file_name, workspace, split_files, scale)
 
 

--- a/Framework/PythonInterface/plugins/algorithms/SaveReflections.py
+++ b/Framework/PythonInterface/plugins/algorithms/SaveReflections.py
@@ -385,6 +385,53 @@ class JanaFormat(object):
 # ------------------------------------------------------------------------------------------------------
 
 
+class SHELXFormat(object):
+    """Writes a PeaksWorkspace to an ASCII file in the format required
+    by the SHELX crystallographic refinement program.
+    For constant wavelength workspaces this is an ASCII file
+    consisting of 4 columns: H, K, L, intensity, sigma.
+    For TOF Laue there are two extra columns: scaleID and wavelength.
+    """
+
+    def __call__(self, file_name, workspace, split_files, scale):
+        """
+        Write a PeaksWorkspace to an ASCII file using this formatter.
+        :param file_name: the file name to output data to.
+        :param workspace: the PeaksWorkspace to write to file.
+        :param scale: scale peaks to fit in column width
+        """
+        if has_modulated_indexing(workspace):
+            raise RuntimeError(
+                "Cannot currently save modulated structures to GSAS or SHELX formats")
+
+        with open(file_name, 'w') as f_handle:
+            self.write_peaks(f_handle, workspace, scale)
+
+    def write_peaks(self, f_handle, workspace, scale):
+        """Write all the peaks in the workspace to file.
+
+        :param f_handle: handle to the file to write to.
+        :param workspace: the PeaksWorkspace to save to file.
+        """
+        col_format = "{:>4.0f}{:>4.0f}{:>4.0f}{:>8.2f}{:>8.2f}"  # H, K, L, Intens, Sig
+        is_CW = np.std([pk.getWavelength() for pk in workspace]) < 0.01  # constant wavelength
+        if not is_CW:
+            col_format += "{:>4.0f}{:>8.4f}"  # scaleID, wavelength
+        col_format += "\n"
+        for i, peak in enumerate(workspace):
+            hkl, _ = get_intHKLM(peak, workspace)  # no mnp as not modulated
+            data = hkl + [peak.getIntensity() * scale, peak.getSigmaIntensity() * scale]
+            if not is_CW:
+                data.extend([1, peak.getWavelength()])  # hard code scaleID=1
+            line = col_format.format(*data)
+            f_handle.write(line)
+        # write row of zeros to end file
+        f_handle.write(col_format.format(*len(data)*[0.0]))
+
+
+# ------------------------------------------------------------------------------------------------------
+
+
 class SaveHKLFormat(object):
     """Writes a PeaksWorkspace to an ASCII file in the format output from
     the SaveHKL algorithm.
@@ -419,7 +466,7 @@ FORMAT_MAP = {
     ReflectionFormat.Fullprof: FullprofFormat,
     ReflectionFormat.GSAS: SaveHKLFormat,
     ReflectionFormat.Jana: JanaFormat,
-    ReflectionFormat.SHELX: SaveHKLFormat
+    ReflectionFormat.SHELX: SHELXFormat
 }
 
 AlgorithmFactory.subscribe(SaveReflections)

--- a/Framework/PythonInterface/test/python/plugins/algorithms/SaveReflectionsTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/SaveReflectionsTest.py
@@ -109,7 +109,7 @@ class SaveReflectionsTest(unittest.TestCase):
         file_name = os.path.join(self._test_dir, "test_fullprof_scaled.hkl")
         lines = self._test_helper_scale_large_intensities(output_format="Fullprof", file_name=file_name)
         intensity = float(lines[-1].split()[3])  # last line (only peak)
-        self.assertEqual(intensity, 2.5E7)
+        self.assertEqual(intensity, 99999999.99)
 
     def test_save_fullprof_format_constant_wavelength(self):
         # Arrange
@@ -158,7 +158,7 @@ class SaveReflectionsTest(unittest.TestCase):
         file_name = os.path.join(self._test_dir, "test_jana_scaled.hkl")
         lines = self._test_helper_scale_large_intensities(output_format="Jana", file_name=file_name)
         intensity = float(lines[-1].split()[3])  # last line (only peak)
-        self.assertEqual(intensity, 2.5E7)
+        self.assertEqual(intensity, 99999999.99)
 
     def test_save_jana_format_modulated_single_file(self):
         # Arrange
@@ -221,7 +221,7 @@ class SaveReflectionsTest(unittest.TestCase):
         file_name = os.path.join(self._test_dir, "test_gsas_scaled.hkl")
         lines = self._test_helper_scale_large_intensities(output_format="GSAS", file_name=file_name)
         intensity = float(lines[0].split()[3])  # first line (no header)
-        self.assertEqual(intensity, 2.5E3)
+        self.assertEqual(intensity, 9999.99)
 
     def test_save_GSAS_format_modulated(self):
         # Arrange
@@ -252,7 +252,7 @@ class SaveReflectionsTest(unittest.TestCase):
         file_name = os.path.join(self._test_dir, "test_shelx_scaled.hkl")
         lines = self._test_helper_scale_large_intensities(output_format="SHELX", file_name=file_name)
         intensity = float(lines[0].split()[3])  # first line (no header)
-        self.assertEqual(intensity, 2.5E3)
+        self.assertEqual(intensity, 9999.99)
 
     def test_save_SHELX_format_modulated(self):
         # Arrange

--- a/Testing/Data/UnitTest/shelx_format.hkl.md5
+++ b/Testing/Data/UnitTest/shelx_format.hkl.md5
@@ -1,1 +1,1 @@
-7ede934a5f184b2da1a07b213ff18e82
+c5ca6d83ab4af5ef67adb08bcb39f4cc


### PR DESCRIPTION
**Description of work.**
SaveReflections calls `SaveHKL` for GSAS and SHELX formats, but `SaveHKL` is using the spec for GSAS-II input file. In this PR I add another writer class to `SaveReflections` to produce `SHELX` files.

For constant wavelength data this will produce a file with the following columns:
`H    K    L    Intens    Sig`
For TOF Laue it will have extra columns
`H    K    L    Intens    Sig   ScaleID    wavelength`

`ScaleID` tells SHELX which peak intensities should be scaled by a given scale factor in the refinement - here I set set this to be the same for all peaks in the table (i.e. all peaks have the same scale factor). However the previous behaviour in `SaveHKL` (which has a similar column) had one index per run - i.e. different runs would have a different scale factor. I believe the correct behaviour would be to use a different scale factor for different samples or different crystallites in the same sample, but that the same scale factor should be used for different orientations of the same sample - and that a peak table with multiple runs is more likely to be the latter scenario.

**Report to:** Nick Funnell

**To test:**
(1) Run this script
```
ws = LoadEmptyInstrument(InstrumentName='SXD', OutputWorkspace='empty_SXD')
peaks = CreatePeaksWorkspace(InstrumentWorkspace=ws, NumberOfPeaks=0)
SetUB(peaks, UB=np.diag([1.0 / 3.9, 0.25, 0.1]))
for ii in range(1,3):
    pk = peaks.createPeakHKL(3*[ii])
    pk.setIntensity(100.0)
    pk.setSigmaIntensity(10.0)
    peaks.addPeak(pk)
SaveReflections(peaks, Filename=r"C:\Users\xhg73778\Desktop\peaks.hkl", Format='SHELX')
```
 - Check that the last row comprises of 0s
 - Compare the format of the output file to the example in the issue

(2) Remove the last peak and save the file again (this should have removed the last two columns - i.e. it is taken to be constant wavelength)

Fixes #34274 

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
