### PR TITLE
Fix windows packaging

### DIFF
--- a/installers/conda/win/create_package.sh
+++ b/installers/conda/win/create_package.sh
@@ -88,54 +88,54 @@ $CONDA_ENV_PATH/python.exe -m pip install quasielasticbayes
 
 echo "Copying root packages of env files (Python, DLLs, Lib, Scripts, ucrt, and msvc files) to package/bin"
 mkdir $COPY_DIR/bin
-cp $CONDA_ENV_PATH/DLLs $COPY_DIR/bin/ -r
-cp $CONDA_ENV_PATH/Lib $COPY_DIR/bin/ -r
-cp $CONDA_ENV_PATH/Scripts $COPY_DIR/bin/ -r
-cp $CONDA_ENV_PATH/tcl $COPY_DIR/bin/ -r
-cp $CONDA_ENV_PATH/python*.* $COPY_DIR/bin/
-cp $CONDA_ENV_PATH/msvc*.* $COPY_DIR/bin/
-cp $CONDA_ENV_PATH/ucrt*.* $COPY_DIR/bin/
+mv $CONDA_ENV_PATH/DLLs $COPY_DIR/bin/
+mv $CONDA_ENV_PATH/Lib $COPY_DIR/bin/
+mv $CONDA_ENV_PATH/Scripts $COPY_DIR/bin/
+mv $CONDA_ENV_PATH/tcl $COPY_DIR/bin/
+mv $CONDA_ENV_PATH/python*.* $COPY_DIR/bin/
+mv $CONDA_ENV_PATH/msvc*.* $COPY_DIR/bin/
+mv $CONDA_ENV_PATH/ucrt*.* $COPY_DIR/bin/
 
 echo "Copy all DLLs from env/Library/bin to package/bin"
-cp $CONDA_ENV_PATH/Library/bin/*.dll $COPY_DIR/bin/
+mv $CONDA_ENV_PATH/Library/bin/*.dll $COPY_DIR/bin/
 
 echo "Copy Mantid specific files from env/Library/bin to package/bin"
-cp $CONDA_ENV_PATH/Library/bin/Mantid.properties $COPY_DIR/bin/
-cp $CONDA_ENV_PATH/Library/bin/MantidNexusParallelLoader.exe $COPY_DIR/bin/
-cp $CONDA_ENV_PATH/Library/bin/mantid-scripts.pth $COPY_DIR/bin/
+mv $CONDA_ENV_PATH/Library/bin/Mantid.properties $COPY_DIR/bin/
+mv $CONDA_ENV_PATH/Library/bin/MantidNexusParallelLoader.exe $COPY_DIR/bin/
+mv $CONDA_ENV_PATH/Library/bin/mantid-scripts.pth $COPY_DIR/bin/
 
 echo "Copy Mantid icon files from source to package/bin"
 cp $THIS_SCRIPT_DIR/../../../images/mantid_workbench$LOWER_CASE_SUFFIX.ico $COPY_DIR/bin/mantid_workbench.ico
 cp $THIS_SCRIPT_DIR/../../../images/mantid_notebook$LOWER_CASE_SUFFIX.ico $COPY_DIR/bin/mantid_notebook.ico
 
 echo "Copy Instrument details to the package"
-cp $CONDA_ENV_PATH/Library/instrument $COPY_DIR/ -r
+mv $CONDA_ENV_PATH/Library/instrument $COPY_DIR/
 
 echo "Constructing package/lib/qt5"
 mkdir -p $COPY_DIR/lib/qt5/bin
-cp $CONDA_ENV_PATH/Library/bin/QtWebEngineProcess.exe $COPY_DIR/lib/qt5/bin
+mv $CONDA_ENV_PATH/Library/bin/QtWebEngineProcess.exe $COPY_DIR/lib/qt5/bin
 cp $THIS_SCRIPT_DIR/../common/qt.conf $COPY_DIR/lib/qt5/bin
-cp $CONDA_ENV_PATH/Library/resources $COPY_DIR/lib/qt5/ -r
+mv $CONDA_ENV_PATH/Library/resources $COPY_DIR/lib/qt5/
 mkdir -p $COPY_DIR/lib/qt5/translations/qtwebengine_locales
-cp $CONDA_ENV_PATH/Library/translations/qtwebengine_locales/en*.pak $COPY_DIR/lib/qt5/translations/qtwebengine_locales/
+mv $CONDA_ENV_PATH/Library/translations/qtwebengine_locales/en*.pak $COPY_DIR/lib/qt5/translations/qtwebengine_locales/
 
 echo "Copy plugins to the package"
 mkdir $COPY_DIR/plugins
 mkdir $COPY_DIR/plugins/qt5
-cp $CONDA_ENV_PATH/Library/plugins/platforms $COPY_DIR/plugins/qt5/ -r
-cp $CONDA_ENV_PATH/Library/plugins/imageformats $COPY_DIR/plugins/qt5/ -r
-cp $CONDA_ENV_PATH/Library/plugins/printsupport $COPY_DIR/plugins/qt5/ -r
-cp $CONDA_ENV_PATH/Library/plugins/sqldrivers $COPY_DIR/plugins/qt5/ -r
-cp $CONDA_ENV_PATH/Library/plugins/styles $COPY_DIR/plugins/qt5/ -r
-cp $CONDA_ENV_PATH/Library/plugins/qt5/*.dll $COPY_DIR/plugins/qt5
-cp $CONDA_ENV_PATH/Library/plugins/*.dll $COPY_DIR/plugins/
-cp $CONDA_ENV_PATH/Library/plugins/python $COPY_DIR/plugins/ -r
+mv $CONDA_ENV_PATH/Library/plugins/platforms $COPY_DIR/plugins/qt5/
+mv $CONDA_ENV_PATH/Library/plugins/imageformats $COPY_DIR/plugins/qt5/
+mv $CONDA_ENV_PATH/Library/plugins/printsupport $COPY_DIR/plugins/qt5/
+mv $CONDA_ENV_PATH/Library/plugins/sqldrivers $COPY_DIR/plugins/qt5/
+mv $CONDA_ENV_PATH/Library/plugins/styles $COPY_DIR/plugins/qt5/
+mv $CONDA_ENV_PATH/Library/plugins/qt5/*.dll $COPY_DIR/plugins/qt5
+mv $CONDA_ENV_PATH/Library/plugins/*.dll $COPY_DIR/plugins/
+mv $CONDA_ENV_PATH/Library/plugins/python $COPY_DIR/plugins/
 
 echo "Copy scripts into the package"
-cp $CONDA_ENV_PATH/Library/scripts $COPY_DIR/ -r
+mv $CONDA_ENV_PATH/Library/scripts $COPY_DIR/
 
 echo "Copy share files (includes mantid docs) to the package"
-cp $CONDA_ENV_PATH/Library/share/doc $COPY_DIR/share/ -r
+mv $CONDA_ENV_PATH/Library/share/doc $COPY_DIR/share/
 
 echo "Copy executable launcher"
 # MantidWorkbench-script.pyw is created by project.nsi on creation of the package


### PR DESCRIPTION
**Description of work.**
A conda package (pint) has been added somewhere in our dependency chain, which adds the files {pint-convert, pint-convert.exe}. When copying files from the conda environment that we create for packaging into our temporary packaging directory it fails to copy pint-convert, because pint-convert.exe exists already inside that directory. Windows does not allow this sort of behaviour from within bash. Moving the files rather than copying them avoids this issue.


**To test:**
Check that this package built:
https://builds.mantidproject.org/job/build_packages_from_branch/84/
You could download and install it too and check that it works.

*There is no associated issue.*

*This does not require release notes* because it's a new packaging problem that users don't need to be aware of.


<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
