### PR TITLE
Include save rows checkbox in Save Batch output

### DIFF
--- a/Testing/Data/UnitTest/ISISReflectometry/batch_with_save_rows_box.json.md5
+++ b/Testing/Data/UnitTest/ISISReflectometry/batch_with_save_rows_box.json.md5
@@ -1,0 +1,1 @@
+e3f8dfdb052fa6ecb38f243cfd535f04

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Common/Decoder.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Common/Decoder.cpp
@@ -447,6 +447,7 @@ void Decoder::decodeSave(const QtSaveView *gui, const QMap<QString, QVariant> &m
   gui->m_ui.filterEdit->setText(map[QString("filterEdit")].toString());
   gui->m_ui.regexCheckBox->setChecked(map[QString("regexCheckBox")].toBool());
   gui->m_ui.saveReductionResultsCheckBox->setChecked(map[QString("saveReductionResultsCheckBox")].toBool());
+  gui->m_ui.saveIndividualRowsCheckBox->setChecked(map[QString("saveIndividualRowsCheckBox")].toBool());
 }
 
 void Decoder::decodeEvent(const QtEventView *gui, const QMap<QString, QVariant> &map) {

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Common/Encoder.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Common/Encoder.cpp
@@ -330,6 +330,7 @@ QMap<QString, QVariant> Encoder::encodeSave(const QtSaveView *gui) {
   saveMap.insert(QString("regexCheckBox"), QVariant(gui->m_ui.regexCheckBox->isChecked()));
   saveMap.insert(QString("saveReductionResultsCheckBox"),
                  QVariant(gui->m_ui.saveReductionResultsCheckBox->isChecked()));
+  saveMap.insert(QString("saveIndividualRowsCheckBox"), QVariant(gui->m_ui.saveIndividualRowsCheckBox->isChecked()));
   return saveMap;
 }
 } // namespace MantidQt::CustomInterfaces::ISISReflectometry

--- a/qt/scientific_interfaces/ISISReflectometry/test/Common/CoderCommonTester.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Common/CoderCommonTester.h
@@ -259,6 +259,8 @@ private:
     TS_ASSERT_EQUALS(gui->m_ui.regexCheckBox->isChecked(), map[QString("regexCheckBox")].toBool())
     TS_ASSERT_EQUALS(gui->m_ui.saveReductionResultsCheckBox->isChecked(),
                      map[QString("saveReductionResultsCheckBox")].toBool())
+    TS_ASSERT_EQUALS(gui->m_ui.saveIndividualRowsCheckBox->isChecked(),
+                     map[QString("saveIndividualRowsCheckBox")].toBool())
   }
 
   void testEvent(const QtEventView *gui, const QMap<QString, QVariant> &map) {

--- a/qt/scientific_interfaces/ISISReflectometry/test/Common/DecoderTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Common/DecoderTest.h
@@ -24,7 +24,8 @@ namespace {
 const std::string DIR_PATH = "ISISReflectometry/";
 auto &fileFinder = FileFinder::Instance();
 const auto MAINWINDOW_FILE = fileFinder.getFullPath(DIR_PATH + "mainwindow.json");
-const auto BATCH_FILE = fileFinder.getFullPath(DIR_PATH + "batch.json");
+const auto BATCH_FILE_PREVIOUS = fileFinder.getFullPath(DIR_PATH + "batch.json");
+const auto BATCH_FILE_CURRENT = fileFinder.getFullPath(DIR_PATH + "batch_with_save_rows_box.json");
 const auto EMPTY_BATCH_FILE = fileFinder.getFullPath(DIR_PATH + "empty_batch.json");
 const auto TWO_ROW_EXP_BATCH_FILE = fileFinder.getFullPath(DIR_PATH + "batch_2_exp_rows.json");
 const auto EIGHT_COL_BATCH_FILE = fileFinder.getFullPath(DIR_PATH + "8_col_batch.json");
@@ -69,7 +70,20 @@ public:
 
   void test_decodePopulatedBatch() {
     CoderCommonTester tester;
-    auto map = MantidQt::API::loadJSONFromFile(QString::fromStdString(BATCH_FILE));
+    auto map = MantidQt::API::loadJSONFromFile(QString::fromStdString(BATCH_FILE_CURRENT));
+    QtMainWindowView mwv;
+    mwv.initLayout();
+    auto gui = dynamic_cast<QtBatchView *>(mwv.batches()[0]);
+    Decoder decoder;
+    decoder.decodeBatch(&mwv, 0, map);
+
+    tester.testBatch(gui, &mwv, map);
+  }
+
+  void test_decodeOldPopulatedBatchFile() {
+    // Check we maintain backwards compatibility when controls are added or changed
+    CoderCommonTester tester;
+    auto map = MantidQt::API::loadJSONFromFile(QString::fromStdString(BATCH_FILE_PREVIOUS));
     QtMainWindowView mwv;
     mwv.initLayout();
     auto gui = dynamic_cast<QtBatchView *>(mwv.batches()[0]);
@@ -94,7 +108,7 @@ public:
 
   void test_decodeBatchWhenInstrumentChanged() {
     CoderCommonTester tester;
-    auto map = MantidQt::API::loadJSONFromFile(QString::fromStdString(BATCH_FILE));
+    auto map = MantidQt::API::loadJSONFromFile(QString::fromStdString(BATCH_FILE_CURRENT));
     QtMainWindowView mwv;
     mwv.initLayout();
     auto gui = dynamic_cast<QtBatchView *>(mwv.batches()[0]);
@@ -150,7 +164,7 @@ public:
   }
 
   void test_decodeVersionOneFiles() {
-    auto map = MantidQt::API::loadJSONFromFile(QString::fromStdString(BATCH_FILE));
+    auto map = MantidQt::API::loadJSONFromFile(QString::fromStdString(BATCH_FILE_CURRENT));
     Decoder decoder;
     auto constexpr expectedVersion = 1;
     TS_ASSERT_EQUALS(expectedVersion, decoder.decodeVersion(map));


### PR DESCRIPTION
**Description of work.**

Adds the new `Include individual group rows` checkbox on the Save ASCII tab to the JSON file that is created when a user saves their batch settings. Also updates loading of these files so that the saved setting for this checkbox is set correctly on load.

The unit tests have been updated, including adding a test to check that it's still possible to load old batch settings files that don't include the new checkbox. I've set up this backwards compatibility test assuming that we will only test one previous and one current version of the file, rather than continuing to build up new test data files each time a control has been changed.

**To test:**

1) Open the ISIS Reflectometry GUI
1) Open the Batch menu and click Save
1) Check the output JSON file and confirm that there is an entry for `saveIndividualRowsCheckBox`
1) Check re-loading the file
1) Go through the above a few times checking that different settings for the new checkbox (can be found on the Save ASCII tab) are saved out and re-loaded correctly
1) Check that a JSON file without an entry for `saveIndividualRowsCheckBox` still loads correctly, to confirm the changes are backward compatible.

Fixes #34298. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

*This does not require release notes* because these changes are covered by the release notes added on PR #34289.

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
