### PR TITLE
Check for zero proton charge before performing time slicing

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/ReflectometrySliceEventWorkspace.py
+++ b/Framework/PythonInterface/plugins/algorithms/ReflectometrySliceEventWorkspace.py
@@ -38,6 +38,16 @@ class ReflectometrySliceEventWorkspace(DataProcessorAlgorithm):
                              doc='Group name for the output workspace(s).')
         self.declareProperty("UseNewFilterAlgorithm", True, doc='If true, use the new FilterEvents algorithm instead of FilterByTime.')
 
+    def validateInputs(self):
+        issues = {}
+        workspace = self.getProperty("InputWorkspace").value
+        # Skip check for workspace groups
+        if not workspace:
+            return issues
+        if workspace.run().getProtonCharge() < 1e-9:
+            issues["InputWorkspace"] = "Cannot slice workspace with zero proton charge"
+        return issues
+
     def PyExec(self):
         self._input_ws = self.getProperty("InputWorkspace").value
         self._output_ws_group_name = self.getPropertyValue("OutputWorkspace")

--- a/Framework/PythonInterface/test/python/plugins/algorithms/ReflectometrySliceEventWorkspaceTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/ReflectometrySliceEventWorkspaceTest.py
@@ -9,6 +9,7 @@ import unittest
 from mantid.kernel import *
 from mantid.api import *
 from mantid.simpleapi import *
+from mantid.dataobjects import Workspace2D
 from testhelpers import (assertRaisesNothing, create_algorithm)
 
 
@@ -334,6 +335,12 @@ class ReflectometrySliceEventWorkspaceTest(unittest.TestCase):
         args['MonitorWorkspace'] = 'test_monitor_ws_group'
         self._assert_run_algorithm_fails(args)
         mtd.remove('test_monitor_ws_group')
+
+    def test_validation_fails_when_workspace_has_zero_counts(self):
+        input_ws = Workspace2D()
+        args = self._default_args
+        args['InputWorkspace'] = input_ws
+        self._assert_run_algorithm_throws(args)
 
     def _create_test_workspace(self):
         input_ws = CreateSampleWorkspace("Event",BankPixelWidth=1, BinWidth=20000)

--- a/docs/source/release/v6.5.0/Reflectometry/Bugfixes/34312.rst
+++ b/docs/source/release/v6.5.0/Reflectometry/Bugfixes/34312.rst
@@ -1,0 +1,1 @@
+- Fix a potential crash when performing time slicing if the workspace contains zero counts; you should now get a sensible error message instead.


### PR DESCRIPTION
When performing time slicing in ReflectometrySliceEventWorkspace (and the reflectometry GUI), add a check that the workspace contains proton charge. This catches the error early and avoids a divide-by-zero which can cause a confusing error or crash.

**Report to:** Becky at ISIS

**To test:**

Run this script and check you get a sensible error message in the log:
```
ws=CreateWorkspace([0,1], [0,0])
mon=CreateWorkspace([0,1], [0,0])
out=ReflectometrySliceEventWorkspace(ws, mon)
```
- Open the ISIS Reflectometry interface
- In the first row in the group in the table enter run `66718` and angle `0.5`
- On the Event Handling tab select the first option under Uniform Slicing
- Back on the Runs tab, click process
- The row should turn blue - hover over it and you should see a sensible error message

*There is no associated issue.*


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
