### PR TITLE
Clear second transmission run if only the first is overridden

### DIFF
--- a/docs/source/release/v6.5.0/Reflectometry/New_features/34313.rst
+++ b/docs/source/release/v6.5.0/Reflectometry/New_features/34313.rst
@@ -1,0 +1,1 @@
+- If both transmission runs are set on the Experiment Settings tab, there was previously no way to override this to only use a single transmission run. This has been changed so that if you specify only the first transmission run on the Runs table, and leave the second blank, then only the first will be used.

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/RowProcessingAlgorithm.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/RowProcessingAlgorithm.cpp
@@ -36,8 +36,12 @@ void updateInputWorkspacesProperties(AlgorithmRuntimeProps &properties,
 
 void updateTransmissionWorkspaceProperties(AlgorithmRuntimeProps &properties,
                                            TransmissionRunPair const &transmissionRuns) {
-  AlgorithmProperties::update("FirstTransmissionRunList", transmissionRuns.firstRunList(), properties);
-  AlgorithmProperties::update("SecondTransmissionRunList", transmissionRuns.secondRunList(), properties);
+  // Transmission runs come as a pair: if the first is set, use both; else use neither
+  if (transmissionRuns.firstRunList().empty()) {
+    return;
+  }
+  properties.setPropertyValue("FirstTransmissionRunList", transmissionRuns.firstRunList());
+  properties.setPropertyValue("SecondTransmissionRunList", transmissionRuns.secondRunList());
 }
 
 void updateMomentumTransferProperties(AlgorithmRuntimeProps &properties, RangeInQ const &rangeInQ) {

--- a/qt/scientific_interfaces/ISISReflectometry/test/Batch/RowProcessingAlgorithmTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Batch/RowProcessingAlgorithmTest.h
@@ -214,6 +214,18 @@ public:
     assertProperty(*result, "ScaleFactor", 2.2);
   }
 
+  void testSecondTransmissionRunClearedIfFirstTransmissionSet() {
+    auto model = Batch(m_experiment, m_instrument, m_runsTable, m_slicing);
+    // Use an angle that will match per-theta defaults. They should be
+    // overridden by the cell values. Set first transmission run only.
+    auto row = Row({"12345", "12346"}, 2.3, TransmissionRunPair("92345", ""), RangeInQ(0.1, 0.09, 0.91), 2.2,
+                   ReductionOptionsMap(), ReductionWorkspaces({"12345", "12346"}, TransmissionRunPair("92345", "")));
+    auto result = RowProcessing::createAlgorithmRuntimeProps(model, row);
+
+    TS_ASSERT_EQUALS(result->getPropertyValue("FirstTransmissionRunList"), "92345");
+    TS_ASSERT_EQUALS(result->getPropertyValue("SecondTransmissionRunList"), "");
+  }
+
   void testAddingPropertyViaOptionsCell() {
     // This tests adding a property via the options cell on a row, for a
     // property that does not get set anywhere else on the GUI


### PR DESCRIPTION
Fix a problem where the second transmission run could not be cleared if only the first is required to be set. 

**Description of work.**

**Report to:** Becky at ISIS

**To test:**

- Open the ISIS reflectometry GUI. Set instrument to `INTER`
- In the Experiment Settings tab lookup table, enter transmission runs `13463` and `13464`
- In the Runs tab, in the row in the first group, enter run `13460`, angle `0.5` and first trans run `13464`. Leave second trans run blank.
- Click Process. The row should turn green and some workspaces should appear in workbench.
- View the history for `IvsQ_binned_13460`. Check that the `FirstTransmissionRun` property was set as `13464` and `SecondTransmissionRun` is blank.

*There is no associated issue.*


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
