### PR TITLE
Remove RectangularDetector monitor and use normal monitor

### DIFF
--- a/Framework/Algorithms/src/CreateSampleWorkspace.cpp
+++ b/Framework/Algorithms/src/CreateSampleWorkspace.cpp
@@ -533,22 +533,15 @@ Instrument_sptr CreateSampleWorkspace::createTestInstrumentRectangular(
       createCappedCylinder(0.1, 0.1, V3D(0.0, -cylHeight / 2.0, 0.0), V3D(0., 1.0, 0.), "monitor-shape");
 
   for (int monitorNumber = monitorsStart; monitorNumber < monitorsStart + numMonitors; monitorNumber++) {
-    // Make a new bank
-    std::ostringstream monitorName;
-    monitorName << "monitor" << monitorNumber - monitorsStart + 1;
+    std::string monitorName = "monitor" + std::to_string(monitorNumber - monitorsStart + 1);
 
-    RectangularDetector *bank = new RectangularDetector(monitorName.str());
-    bank->initialize(monitorShape, 1, 0.0, pixelSpacing, 1, 0.0, pixelSpacing, monitorNumber, true, 1);
+    Detector *detector = new Detector(monitorName, monitorNumber, monitorShape, testInst.get());
+    // Mark it as a monitor (add to the instrument cache)
+    testInst->markAsMonitor(detector);
 
-    std::shared_ptr<Detector> detector = bank->getAtXY(0, 0);
-    if (detector) {
-      // Mark it as a monitor (add to the instrument cache)
-      testInst->markAsMonitor(detector.get());
-    }
-
-    testInst->add(bank);
+    testInst->add(detector);
     // Set the bank along the z-axis of the instrument, between the detectors.
-    bank->setPos(V3D(0.0, 0.0, bankDistanceFromSample * (monitorNumber - monitorsStart + 0.5)));
+    detector->setPos(V3D(0.0, 0.0, bankDistanceFromSample * (monitorNumber - monitorsStart + 0.5)));
   }
 
   // Define a source component

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/ReflectometryISISSumBanksTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/ReflectometryISISSumBanksTest.py
@@ -95,18 +95,19 @@ class ReflectometryISISSumBanksTest(unittest.TestCase):
         self.assertNotEqual(test_ws, summed_ws)
         self.assertTrue(numpy.allclose(num_banks_included * test_ws.readY(0), summed_ws.readY(0)))
 
-    def test_monitors_are_included(self):
+    def test_monitors_are_prepended(self):
         num_banks = 3
         num_monitors = 2
         test_ws = CreateSampleWorkspace(StoreInADS=False, NumBanks=1, BankPixelWidth=num_banks, NumMonitors=num_monitors)
 
         summed_ws = ReflectometryISISSumBanks().sum_banks(test_ws)
+        prepended_ws = ReflectometryISISSumBanks()._prepend_monitors(test_ws, summed_ws)
 
-        self.assertEqual(num_banks + num_monitors, summed_ws.getNumberHistograms())
-        for idx in range(summed_ws.getNumberHistograms()):
-            # The monitors are at the end
-            expected_monitor = idx >= num_banks
-            self.assertEqual(expected_monitor, summed_ws.getDetector(idx).isMonitor())
+        self.assertEqual(num_banks + num_monitors, prepended_ws.getNumberHistograms())
+        for idx in range(prepended_ws.getNumberHistograms()):
+            # The monitors are at the start
+            expected_monitor = idx < num_monitors
+            self.assertEqual(expected_monitor, prepended_ws.getDetector(idx).isMonitor())
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
**Description of work.**
We have made a minor change to the `CreateSampleWorkspace` algorithm to create a normal `Detector` monitor instead of a `RectangularDetector` monitor. This has been done because we were experiencing a few bugs as mentioned in Gemma's comments below. We also felt it didn't make sense to use a `RectangularDetector` monitor which only has one pixel (as this seems equivalent to just a single ordinary Detector), and whether a RectangularDetector monitor is a true-to-life situation is doubtful.

**To test:**
Code review and make sure the tests pass.

Run Gemma's script below.

*There is no associated issue.*

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
