### PR TITLE
Update SimpleShapeDiscusInelastic with container functionality

### DIFF
--- a/Framework/Algorithms/inc/MantidAlgorithms/DiscusMultipleScatteringCorrection.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/DiscusMultipleScatteringCorrection.h
@@ -76,7 +76,7 @@ protected:
   std::tuple<double, int> sampleQW(const API::MatrixWorkspace_sptr &CumulativeProb, double x);
   double interpolateSquareRoot(const API::ISpectrum &histToInterpolate, double x);
   double interpolateGaussian(const API::ISpectrum &histToInterpolate, double x);
-  double Interpolate2D(const ComponentWorkspaceMapping &SQWSMapping, double w, double q);
+  double Interpolate2D(const ComponentWorkspaceMapping &SQWSMapping, double q, double w);
   void updateTrackDirection(Geometry::Track &track, const double cosT, const double phi);
   void integrateCumulative(const API::ISpectrum &h, const double xmin, const double xmax, std::vector<double> &resultX,
                            std::vector<double> &resultY, const bool returnCumulative);

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SimpleShapeDiscusInelastic.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SimpleShapeDiscusInelastic.py
@@ -6,7 +6,7 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 from mantid.api import (PythonAlgorithm, AlgorithmFactory, MatrixWorkspaceProperty,
                         WorkspaceGroupProperty, PropertyMode, Sample)
-from mantid.kernel import (VisibleWhenProperty, PropertyCriterion, LogicOperator,
+from mantid.kernel import (VisibleWhenProperty, Property, PropertyCriterion, LogicOperator,
                            StringListValidator, IntBoundedValidator, FloatBoundedValidator, Direction)
 from mantid.simpleapi import *
 
@@ -32,14 +32,14 @@ class SimpleShapeDiscusInelastic(PythonAlgorithm):
         self.declareProperty(name='Container', defaultValue=False,
                              doc='Enable input of container data')
 
-        self.declareProperty(name='SampleMassDensity', defaultValue=1.0,
-                             doc='Sample mass density. Default=1.0')
+        self.declareProperty(name='SampleMassDensity', defaultValue=Property.EMPTY_DBL,
+                             validator=FloatBoundedValidator(0.0), doc='Sample mass density')
         self.declareProperty(name='SampleChemicalFormula', defaultValue='',
                              doc='Sample Chemical formula')
 
         container_condition = VisibleWhenProperty('Container', PropertyCriterion.IsEqualTo, '1')
-        self.declareProperty(name='ContainerMassDensity', defaultValue=6.1,
-                             doc='Container number density. Default=6.1')
+        self.declareProperty(name='ContainerMassDensity', defaultValue=Property.EMPTY_DBL,
+                             validator=FloatBoundedValidator(0.0), doc='Container number density')
         self.setPropertySettings('ContainerMassDensity', container_condition)
         self.declareProperty(name='ContainerChemicalFormula', defaultValue='V',
                              doc='Container Chemical formula')

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SimpleShapeDiscusInelastic.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SimpleShapeDiscusInelastic.py
@@ -6,7 +6,7 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 from mantid.api import (PythonAlgorithm, AlgorithmFactory, MatrixWorkspaceProperty,
                         WorkspaceGroupProperty, PropertyMode, Sample)
-from mantid.kernel import (VisibleWhenProperty, PropertyCriterion,
+from mantid.kernel import (VisibleWhenProperty, PropertyCriterion, LogicOperator,
                            StringListValidator, IntBoundedValidator, FloatBoundedValidator, Direction)
 from mantid.simpleapi import *
 
@@ -37,10 +37,13 @@ class SimpleShapeDiscusInelastic(PythonAlgorithm):
         self.declareProperty(name='SampleChemicalFormula', defaultValue='',
                              doc='Sample Chemical formula')
 
+        container_condition = VisibleWhenProperty('Container', PropertyCriterion.IsEqualTo, '1')
         self.declareProperty(name='ContainerMassDensity', defaultValue=6.1,
                              doc='Container number density. Default=6.1')
+        self.setPropertySettings('ContainerMassDensity', container_condition)
         self.declareProperty(name='ContainerChemicalFormula', defaultValue='V',
                              doc='Container Chemical formula')
+        self.setPropertySettings('ContainerChemicalFormula', container_condition)
 
         # set up shape options
 
@@ -51,6 +54,13 @@ class SimpleShapeDiscusInelastic(PythonAlgorithm):
         flat_plate_condition = VisibleWhenProperty('Shape', PropertyCriterion.IsEqualTo, 'FlatPlate')
         cylinder_condition = VisibleWhenProperty('Shape', PropertyCriterion.IsEqualTo, 'Cylinder')
         annulus_condition = VisibleWhenProperty('Shape', PropertyCriterion.IsEqualTo, 'Annulus')
+
+        container_flat_plate_condition = VisibleWhenProperty(container_condition, flat_plate_condition,
+                                                             LogicOperator.And)
+        container_cylinder_condition = VisibleWhenProperty(container_condition, cylinder_condition,
+                                                           LogicOperator.And)
+        container_annulus_condition = VisibleWhenProperty(container_condition, annulus_condition,
+                                                          LogicOperator.And)
 
         # height is common to all options
 
@@ -78,12 +88,12 @@ class SimpleShapeDiscusInelastic(PythonAlgorithm):
         self.declareProperty(name='Front', defaultValue=0.1,
                              validator=FloatBoundedValidator(0.0),
                              doc='Thickness of the FlatPlate front (cm)')
-        self.setPropertySettings('Front', flat_plate_condition)
+        self.setPropertySettings('Front', container_flat_plate_condition)
 
         self.declareProperty(name='Back', defaultValue=0.1,
                              validator=FloatBoundedValidator(0.0),
                              doc='Thickness of the FlatPlate back (cm)')
-        self.setPropertySettings('Back', flat_plate_condition)
+        self.setPropertySettings('Back', container_flat_plate_condition)
 
         # cylinder options
 
@@ -94,7 +104,7 @@ class SimpleShapeDiscusInelastic(PythonAlgorithm):
 
         self.declareProperty(name='ContainerOuterRadius', defaultValue=0.6,
                              doc='Container outer radius. Default=0.6')
-        self.setPropertySettings('ContainerOuterRadius', cylinder_condition)
+        self.setPropertySettings('ContainerOuterRadius', container_cylinder_condition)
 
         # annulus options
 
@@ -111,22 +121,22 @@ class SimpleShapeDiscusInelastic(PythonAlgorithm):
         self.declareProperty(name='CanInnerRadius', defaultValue=0.45,
                              validator=FloatBoundedValidator(0.0),
                              doc='Container inner radius. Default=0.5')
-        self.setPropertySettings('CanInnerRadius', annulus_condition)
+        self.setPropertySettings('CanInnerRadius', container_annulus_condition)
 
         self.declareProperty(name='CanInnerOuterRadius', defaultValue=0.5,
                              validator=FloatBoundedValidator(0.0),
                              doc='Container inner radius. Default=0.5')
-        self.setPropertySettings('CanInnerOuterRadius', annulus_condition)
+        self.setPropertySettings('CanInnerOuterRadius', container_annulus_condition)
 
         self.declareProperty(name='CanOuterInnerRadius', defaultValue=0.6,
                              validator=FloatBoundedValidator(0.0),
                              doc='Container outer inner radius. Default=0.6')
-        self.setPropertySettings('CanOuterInnerRadius', annulus_condition)
+        self.setPropertySettings('CanOuterInnerRadius', container_annulus_condition)
 
         self.declareProperty(name='CanOuterRadius', defaultValue=0.65,
                              validator=FloatBoundedValidator(0.0),
                              doc='Container outer radius. Default=0.65')
-        self.setPropertySettings('CanOuterRadius', annulus_condition)
+        self.setPropertySettings('CanOuterRadius', container_annulus_condition)
 
         # MC options
 

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SimpleShapeDiscusInelastic.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SimpleShapeDiscusInelastic.py
@@ -22,7 +22,7 @@ class SimpleShapeDiscusInelastic(PythonAlgorithm):
                              doc='Reduced Workspace')
         self.declareProperty(MatrixWorkspaceProperty('SqwWorkspace', '',
                                                      direction=Direction.Input),
-                             doc='S(Q,w) Workspace')
+                             doc='S(Q,w) Workspace for the sample')
         self.declareProperty(WorkspaceGroupProperty(name='OutputWorkspace',
                                                     defaultValue='MuscatResults',
                                                     direction=Direction.Output,
@@ -103,7 +103,7 @@ class SimpleShapeDiscusInelastic(PythonAlgorithm):
         self.setPropertySettings('SampleRadius', cylinder_condition)
 
         self.declareProperty(name='CanRadius', defaultValue=0.6,
-                             doc='Container outer radius. Default=0.6')
+                             doc='Container outer radius (cm). Default=0.6')
         self.setPropertySettings('CanRadius', container_cylinder_condition)
 
         # annulus options
@@ -120,12 +120,12 @@ class SimpleShapeDiscusInelastic(PythonAlgorithm):
 
         self.declareProperty(name='CanInnerRadius', defaultValue=0.45,
                              validator=FloatBoundedValidator(0.0),
-                             doc='Container inner radius. Default=0.5')
+                             doc='Container inner radius (cm). Default=0.5')
         self.setPropertySettings('CanInnerRadius', container_annulus_condition)
 
         self.declareProperty(name='CanOuterRadius', defaultValue=0.65,
                              validator=FloatBoundedValidator(0.0),
-                             doc='Container outer radius. Default=0.65')
+                             doc='Container outer radius (cm). Default=0.65')
         self.setPropertySettings('CanOuterRadius', container_annulus_condition)
 
         # MC options

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/SimpleShapeDiscusInelasticTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/SimpleShapeDiscusInelasticTest.py
@@ -95,6 +95,19 @@ class SimpleShapeDiscusInelasticTest(unittest.TestCase):
 
         self._test_corrections_workspace(results)
 
+    def test_annulus_with_container(self):
+
+        kwargs = self._annulus_arguments
+        results = SimpleShapeDiscusInelastic(ReducedWorkspace=self._red_ws,
+                                             SqwWorkspace=self._sqw_ws,
+                                             SampleInnerRadius=1.0,
+                                             CanInnerRadius=0.9,
+                                             CanOuterRadius=2.1,
+                                             Container=True,
+                                             **kwargs)
+
+        self._test_corrections_workspace(results)
+
 
     # ------------------------------------- Failure Cases --------------------
 

--- a/docs/source/algorithms/SimpleShapeDiscusInelastic-v1.rst
+++ b/docs/source/algorithms/SimpleShapeDiscusInelastic-v1.rst
@@ -10,9 +10,9 @@
 Description
 -----------
 
-Sets up a sample shape, along with the required material properties, and runs
+Sets up a sample shape and optionally a container shape, along with the required material properties, and runs
 the :ref:`DiscusMultipleScatteringCorrection <algm-DiscusMultipleScatteringCorrection-v1>` algorithm. This algorithm merely
-serves as a simpler interface to define the shape & material of the sample without having
+serves as a simpler interface to define the shape & material of the sample\\container without having
 to resort to the more complex :ref:`SetSample <algm-SetSample-v1>` algorithm.
 The computational part is all taken care of by :ref:`DiscusMultipleScatteringCorrection <algm-DiscusMultipleScatteringCorrection-v1>`. Please see that
 documentation for more details.
@@ -21,6 +21,34 @@ Currently the shape geometries supported are:
 * Flat Plate
 * Cylinder
 * Annulus
+
+Below are the properties applicable to each specific shape:
+
+FlatPlate
+#########
+
+- *Height*
+- *Width*
+- *Thickness*
+- *Angle*
+- *Front*
+- *Back*
+
+Cylinder
+########
+
+- *Height*
+- *SampleRadius*
+- *CanRadius* stands for the outer radius of the annular container, inner radius of which is the same as the radius of the sample.
+
+Annulus
+#######
+
+- *Height*
+- *CanInnerRadius*
+- *SampleInnerRadius*
+- *SampleOuterRadius*
+- *CanOuterRadius*
 
 .. categories::
 

--- a/docs/source/release/v6.5.0/Indirect/New_features/34315 Add Container Support to Discus Wrapper Alg.rst
+++ b/docs/source/release/v6.5.0/Indirect/New_features/34315 Add Container Support to Discus Wrapper Alg.rst
@@ -1,0 +1,1 @@
+- Updated :ref:`SimpleShapeDiscusInelastic <algm-SimpleShapeDiscusInelastic>` workflow algorithm to add support for containers in line with the enhancements made to :ref:`DiscusMultipleScatteringCorrection <algm-DiscusMultipleScatteringCorrection>`


### PR DESCRIPTION
**Description of work.**

Update the SimpleShapeDiscusInelastic workflow algorithm with some extra fields to support scattering from the container as well as the sample. The new fields reflect the additional functionality added into the underlying DiscusMultipleScatteringCorrection algorithm in https://github.com/mantidproject/mantid/pull/34203. The algorithm has been created by Spencer Howells and I've added the tests and documentation around it.

I have also included a couple of minor tidy ups to the DiscusMultipleScatteringCorrection algorithm itself eg a validation to ensure equal size q bins that is needed to ensure some of the interpolation is valid

**To test:**

Run this script. You'll need to have access the ISIS archive and check it completes and generates a workspace group called MuscatResults. It should also plot the sample and container shape - the sample is a hollow cylinder:

```
# import mantid algorithms, numpy and matplotlib
from mantid.simpleapi import *
import matplotlib.pyplot as plt
import numpy as np
import math
from mpl_toolkits.mplot3d.art3d import Poly3DCollection

# the InputFiles property of ISISIndirectEnergyTransfer is set up as StringArray which gets
# in the way of some of the features of the Load algorithm's File property. 
# This means you have to repeat the instrument prefix
e_fixed = 1.845
inputWSGrouped=ISISIndirectEnergyTransferWrapper(InputFiles='OSIRIS126197,OSIRIS126198,OSIRIS126199,OSIRIS126200,OSIRIS126201.nxs', 
                                                 SumFiles=True, Instrument='OSIRIS', 
                                                 Analyser='graphite', Reflection='002', 
                                                 Efixed=e_fixed, SpectraRange='963,1004', # load 42 spectra only at phi=180
                                                 FoldMultipleFrames=False, GroupingMethod='Individual', 
                                                 OutputWorkspace='osiris_graphite002_Reduced')
inputWS = inputWSGrouped[0]
UnGroupWorkspace(inputWSGrouped)

# default cylinder axis is "up" ie y
container_thickness = 0.05 #cm. Know outer wall thickness is 0.5mm. Assume inner wall thickness the same
inner_sample_diameter = 2.3 #cm
outer_sample_diameter = 2.4 #cm
inner_sample_radius = inner_sample_diameter / 2
outer_sample_radius = outer_sample_diameter / 2
container_inner_layer_inner_radius = inner_sample_radius - container_thickness
container_outer_layer_outer_radius = outer_sample_radius + container_thickness

inputWS = ConvertUnits(inputWS, Target="DeltaE", EMode="Indirect", EFixed=e_fixed)

sqw = SofQW(InputWorkspace=inputWS, QAxisBinning='0.2,0.05,1.75', 
            EMode='Indirect', EFixed=1.845, ReplaceNaNs=True, Method='NormalisedPolygon')
AddSampleLog(Workspace=sqw, LogName='rebin_type', LogText='NormalisedPolygon')

SimpleShapeDiscusInelastic(ReducedWorkspace=inputWS, SqwWorkspace=sqw, Container=True,
                           SampleMassDensity=1.0, SampleChemicalFormula='H2-O',
                           Shape='Annulus', Height=3.0, SampleInnerRadius=inner_sample_radius,
                           SampleOuterRadius=outer_sample_radius, NeutronPathsSingle=100,
                           NeutronPathsMultiple=100, NumberScatterings=2,
                           ContainerChemicalFormula='Al', CanInnerRadius=container_inner_layer_inner_radius,
                           CanOuterRadius=container_outer_layer_outer_radius)

sample = inputWS.sample()
shape = sample.getShape()
mesh = shape.getMesh()
environment = sample.getEnvironment()

mesh_polygon = Poly3DCollection(mesh, facecolors = ['g'], edgecolors = ['b'], alpha = 0.5, linewidths=0.1)

'''getMesh() to plot the Container Shape'''
container_mesh = environment.getContainer().getShape().getMesh()
container_mesh_polygon = Poly3DCollection(container_mesh, facecolors = ['r'], edgecolors = ['b'], alpha = 0.5, linewidths=0.1)

fig, axes = plt.subplots(subplot_kw={'projection':'mantid3d', 'proj_type':'ortho'})
#fig, axes = plt.subplots(subplot_kw={'projection':'mantid3d'})
axes.add_collection3d(mesh_polygon)
axes.add_collection3d(container_mesh_polygon)

axes.set_mesh_axes_equal(mesh)
axes.set_title('OSIRIS annular cell')
axes.set_xlabel('X / m')
axes.set_ylabel('Y / m')
axes.set_zlabel('Z / m')

plt.show()
```

Fixes #34315.


<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
