### PR TITLE
Parallelize more of CI pipeline

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,172 +1,182 @@
 {
-    "version": 1,
-    "cmakeMinimumRequired": {
-        "major": 3,
-        "minor": 19,
-        "patch": 0
+  "version": 1,
+  "cmakeMinimumRequired": {
+    "major": 3,
+    "minor": 19,
+    "patch": 0
+  },
+  "configurePresets": [
+    {
+      "name": "osx",
+      "displayName": "osx",
+      "description": "Default build options for an OSX conda build",
+      "generator": "Ninja",
+      "binaryDir": "${sourceDir}/build",
+      "cacheVariables": {
+        "CMAKE_FIND_FRAMEWORK": "LAST",
+        "USE_PYTHON_DYNAMIC_LIB": "OFF",
+        "Qt5_DIR": "$env{CONDA_PREFIX}/lib/cmake/qt5",
+        "HDF5_ROOT": "$env{CONDA_PREFIX}",
+        "OpenSSL_ROOT": "$env{CONDA_PREFIX}",
+        "CMAKE_CXX_FLAGS_DEBUG": "-g -O0",
+        "CONDA_ENV": true,
+        "CMAKE_BUILD_TYPE": "Debug"
+      }
     },
-    "configurePresets": [
-        {
-            "name": "osx",
-            "displayName": "osx",
-            "description": "Default build options for an OSX conda build",
-            "generator": "Ninja",
-            "binaryDir": "${sourceDir}/build",
-            "cacheVariables": {
-                "CMAKE_FIND_FRAMEWORK": "LAST",
-                "CMAKE_PREFIX_PATH": "$env{CONDA_PREFIX}",
-                "USE_PYTHON_DYNAMIC_LIB": "OFF",
-                "Qt5_DIR": "$env{CONDA_PREFIX}/lib/cmake/qt5",
-                "HDF5_ROOT": "$env{CONDA_PREFIX}",
-                "OpenSSL_ROOT": "$env{CONDA_PREFIX}",
-                "CMAKE_CXX_FLAGS_DEBUG": "-g -O0",
-                "CONDA_ENV": true,
-                "CMAKE_BUILD_TYPE": "Debug"
-            }
-        },
-        {
-            "name": "osx-ci",
-            "displayName": "osx-ci",
-            "description": "To be used in the CI environment only",
-            "generator": "Ninja",
-            "binaryDir": "${sourceDir}/build",
-            "cacheVariables": {
-                "CMAKE_FIND_FRAMEWORK": "LAST",
-                "CMAKE_PREFIX_PATH": "$env{CONDA_PREFIX}",
-                "USE_PYTHON_DYNAMIC_LIB": "OFF",
-                "Qt5_DIR": "$env{CONDA_PREFIX}/lib/cmake/qt5",
-                "HDF5_ROOT": "$env{CONDA_PREFIX}",
-                "OpenSSL_ROOT": "$env{CONDA_PREFIX}",
-                "CONDA_ENV": true,
-                "CMAKE_BUILD_TYPE": "Release"
-            }
-        },
-        {
-            "name": "win",
-            "displayName": "win",
-            "description": "Default build options for a windows conda build",
-            "binaryDir": "${sourceDir}/build",
-            "generator": "Visual Studio 16 2019",
-            "cacheVariables": {
-                "CMAKE_PREFIX_PATH": "$env{CONDA_PREFIX}",
-                "CONDA_ENV": true
-            }
-        },
-        {
-            "name": "linux",
-            "displayName": "linux",
-            "description": "Default build options for a linux conda build",
-            "binaryDir": "${sourceDir}/build",
-            "generator": "Ninja",
-            "cacheVariables": {
-                "CMAKE_PREFIX_PATH": "$env{CONDA_PREFIX}",
-                "CONDA_ENV": true,
-                "CMAKE_FIND_USE_SYSTEM_ENVIRONMENT_PATH": "FALSE",
-                "CMAKE_FIND_USE_CMAKE_ENVIRONMENT_PATH": "FALSE",
-                "CMAKE_BUILD_TYPE": "Debug",
-                "CMAKE_CXX_FLAGS_DEBUG": "-g -O0"
-            }
-        },
-        {
-            "name": "linux-ci",
-            "displayName": "linux-ci",
-            "description": "To be used in the CI environment only",
-            "binaryDir": "${sourceDir}/build",
-            "generator": "Ninja",
-            "cacheVariables": {
-                "CMAKE_PREFIX_PATH": "$env{CONDA_PREFIX}",
-                "CONDA_ENV": true,
-                "CMAKE_FIND_USE_SYSTEM_ENVIRONMENT_PATH": "FALSE",
-                "CMAKE_FIND_USE_CMAKE_ENVIRONMENT_PATH": "FALSE",
-                "CMAKE_BUILD_TYPE": "Release",
-                "ENABLE_PRECOMMIT": "OFF",
-                "ENABLE_CPACK": "ON",
-                "DOCS_HTML": "ON",
-                "ENABLE_CONDA": "ON",
-                "COLORED_COMPILER_OUTPUT": "OFF"
-            }
-        },
-        {
-            "name": "linux-ci-address-sanitiser",
-            "displayName": "linux-ci-address-sanitiser",
-            "description": "To be used for the CI environment",
-            "binaryDir": "${sourceDir}/build",
-            "generator": "Ninja",
-            "cacheVariables": {
-                "CMAKE_PREFIX_PATH": "$env{CONDA_PREFIX}",
-                "CONDA_ENV": true,
-                "CMAKE_FIND_USE_SYSTEM_ENVIRONMENT_PATH": "FALSE",
-                "CMAKE_FIND_USE_CMAKE_ENVIRONMENT_PATH": "FALSE",
-                "CMAKE_BUILD_TYPE": "RelWithDebInfo",
-                "ENABLE_PRECOMMIT": "OFF",
-                "ENABLE_CPACK": "ON",
-                "DOCS_HTML": "ON",
-                "ENABLE_CONDA": "ON",
-                "COLORED_COMPILER_OUTPUT": "OFF",
-                "USE_SANITIZER": "Address"
-            }
-        },
-        {
-            "name": "linux-ci-memory-sanitiser",
-            "displayName": "linux-ci-memory-sanitiser",
-            "description": "To be used for the CI environment",
-            "binaryDir": "${sourceDir}/build",
-            "generator": "Ninja",
-            "cacheVariables": {
-                "CMAKE_PREFIX_PATH": "$env{CONDA_PREFIX}",
-                "CONDA_ENV": true,
-                "CMAKE_FIND_USE_SYSTEM_ENVIRONMENT_PATH": "FALSE",
-                "CMAKE_FIND_USE_CMAKE_ENVIRONMENT_PATH": "FALSE",
-                "CMAKE_BUILD_TYPE": "RelWithDebInfo",
-                "ENABLE_PRECOMMIT": "OFF",
-                "ENABLE_CPACK": "ON",
-                "DOCS_HTML": "ON",
-                "ENABLE_CONDA": "ON",
-                "COLORED_COMPILER_OUTPUT": "OFF",
-                "USE_SANITIZER": "memory"
-            }
-        },
-        {
-            "name": "linux-ci-thread-sanitiser",
-            "displayName": "linux-ci-thread-sanitiser",
-            "description": "To be used for the CI environment",
-            "binaryDir": "${sourceDir}/build",
-            "generator": "Ninja",
-            "cacheVariables": {
-                "CMAKE_PREFIX_PATH": "$env{CONDA_PREFIX}",
-                "CONDA_ENV": true,
-                "CMAKE_FIND_USE_SYSTEM_ENVIRONMENT_PATH": "FALSE",
-                "CMAKE_FIND_USE_CMAKE_ENVIRONMENT_PATH": "FALSE",
-                "CMAKE_BUILD_TYPE": "RelWithDebInfo",
-                "ENABLE_PRECOMMIT": "OFF",
-                "ENABLE_CPACK": "ON",
-                "DOCS_HTML": "ON",
-                "ENABLE_CONDA": "ON",
-                "COLORED_COMPILER_OUTPUT": "OFF",
-                "USE_SANITIZER": "thread"
-            }
-        },
-        {
-            "name": "linux-ci-coverage",
-            "displayName": "linux-ci-coverage",
-            "description": "To be used in the CI environment only",
-            "binaryDir": "${sourceDir}/build",
-            "generator": "Ninja",
-            "cacheVariables": {
-                "CMAKE_PREFIX_PATH": "$env{CONDA_PREFIX}",
-                "CONDA_ENV": true,
-                "CMAKE_FIND_USE_SYSTEM_ENVIRONMENT_PATH": "FALSE",
-                "CMAKE_FIND_USE_CMAKE_ENVIRONMENT_PATH": "FALSE",
-                "CMAKE_BUILD_TYPE": "Debug",
-                "ENABLE_PRECOMMIT": "OFF",
-                "ENABLE_CPACK": "ON",
-                "DOCS_HTML": "ON",
-                "ENABLE_CONDA": "ON",
-                "COLORED_COMPILER_OUTPUT": "OFF",
-                "COVERAGE": "OFF",
-                "TESTING_TIMEOUT": "1200",
-                "CMAKE_CXX_FLAGS_DEBUG": "-g -O0"
-            }
-        }
-    ]
+    {
+      "name": "osx-64-ci",
+      "displayName": "osx-64-ci",
+      "description": "To be used in the CI environment only",
+      "generator": "Ninja",
+      "binaryDir": "${sourceDir}/build",
+      "cacheVariables": {
+        "CMAKE_FIND_FRAMEWORK": "LAST",
+        "CMAKE_PREFIX_PATH": "$env{CONDA_PREFIX}",
+        "USE_PYTHON_DYNAMIC_LIB": "OFF",
+        "Qt5_DIR": "$env{CONDA_PREFIX}/lib/cmake/qt5",
+        "HDF5_ROOT": "$env{CONDA_PREFIX}",
+        "OpenSSL_ROOT": "$env{CONDA_PREFIX}",
+        "CONDA_ENV": true,
+        "CMAKE_BUILD_TYPE": "Release"
+      }
+    },
+    {
+      "name": "win",
+      "displayName": "win",
+      "description": "Default build options for a windows conda build",
+      "binaryDir": "${sourceDir}/build",
+      "generator": "Visual Studio 16 2019",
+      "cacheVariables": {
+        "CMAKE_PREFIX_PATH": "$env{CONDA_PREFIX}",
+        "CONDA_ENV": true
+      }
+    },
+    {
+      "name": "win-64-ci",
+      "displayName": "win",
+      "description": "Default build options for a windows conda build",
+      "binaryDir": "${sourceDir}/build",
+      "generator": "Visual Studio 16 2019",
+      "cacheVariables": {
+        "CMAKE_PREFIX_PATH": "$env{CONDA_PREFIX}",
+        "CONDA_ENV": true
+      }
+    },
+    {
+      "name": "linux",
+      "displayName": "linux",
+      "description": "Default build options for a linux conda build",
+      "binaryDir": "${sourceDir}/build",
+      "generator": "Ninja",
+      "cacheVariables": {
+        "CMAKE_PREFIX_PATH": "$env{CONDA_PREFIX}",
+        "CONDA_ENV": true,
+        "CMAKE_FIND_USE_SYSTEM_ENVIRONMENT_PATH": "FALSE",
+        "CMAKE_FIND_USE_CMAKE_ENVIRONMENT_PATH": "FALSE",
+        "CMAKE_BUILD_TYPE": "Debug",
+        "CMAKE_CXX_FLAGS_DEBUG": "-g -O0"
+      }
+    },
+    {
+      "name": "linux-64-ci",
+      "displayName": "linux-64-ci",
+      "description": "To be used in the CI environment only",
+      "binaryDir": "${sourceDir}/build",
+      "generator": "Ninja",
+      "cacheVariables": {
+        "CMAKE_PREFIX_PATH": "$env{CONDA_PREFIX}",
+        "CONDA_ENV": true,
+        "CMAKE_FIND_USE_SYSTEM_ENVIRONMENT_PATH": "FALSE",
+        "CMAKE_FIND_USE_CMAKE_ENVIRONMENT_PATH": "FALSE",
+        "CMAKE_BUILD_TYPE": "Release",
+        "ENABLE_PRECOMMIT": "OFF",
+        "ENABLE_CPACK": "ON",
+        "DOCS_HTML": "ON",
+        "ENABLE_CONDA": "ON",
+        "COLORED_COMPILER_OUTPUT": "OFF"
+      }
+    },
+    {
+      "name": "linux-64-ci-address-sanitiser",
+      "displayName": "linux-64-ci-address-sanitiser",
+      "description": "To be used for the CI environment",
+      "binaryDir": "${sourceDir}/build",
+      "generator": "Ninja",
+      "cacheVariables": {
+        "CMAKE_PREFIX_PATH": "$env{CONDA_PREFIX}",
+        "CONDA_ENV": true,
+        "CMAKE_FIND_USE_SYSTEM_ENVIRONMENT_PATH": "FALSE",
+        "CMAKE_FIND_USE_CMAKE_ENVIRONMENT_PATH": "FALSE",
+        "CMAKE_BUILD_TYPE": "RelWithDebInfo",
+        "ENABLE_PRECOMMIT": "OFF",
+        "ENABLE_CPACK": "ON",
+        "DOCS_HTML": "ON",
+        "ENABLE_CONDA": "ON",
+        "COLORED_COMPILER_OUTPUT": "OFF",
+        "USE_SANITIZER": "Address"
+      }
+    },
+    {
+      "name": "linux-64-ci-memory-sanitiser",
+      "displayName": "linux-64-ci-memory-sanitiser",
+      "description": "To be used for the CI environment",
+      "binaryDir": "${sourceDir}/build",
+      "generator": "Ninja",
+      "cacheVariables": {
+        "CMAKE_PREFIX_PATH": "$env{CONDA_PREFIX}",
+        "CONDA_ENV": true,
+        "CMAKE_FIND_USE_SYSTEM_ENVIRONMENT_PATH": "FALSE",
+        "CMAKE_FIND_USE_CMAKE_ENVIRONMENT_PATH": "FALSE",
+        "CMAKE_BUILD_TYPE": "RelWithDebInfo",
+        "ENABLE_PRECOMMIT": "OFF",
+        "ENABLE_CPACK": "ON",
+        "DOCS_HTML": "ON",
+        "ENABLE_CONDA": "ON",
+        "COLORED_COMPILER_OUTPUT": "OFF",
+        "USE_SANITIZER": "memory"
+      }
+    },
+    {
+      "name": "linux-64-ci-thread-sanitiser",
+      "displayName": "linux-64-ci-thread-sanitiser",
+      "description": "To be used for the CI environment",
+      "binaryDir": "${sourceDir}/build",
+      "generator": "Ninja",
+      "cacheVariables": {
+        "CMAKE_PREFIX_PATH": "$env{CONDA_PREFIX}",
+        "CONDA_ENV": true,
+        "CMAKE_FIND_USE_SYSTEM_ENVIRONMENT_PATH": "FALSE",
+        "CMAKE_FIND_USE_CMAKE_ENVIRONMENT_PATH": "FALSE",
+        "CMAKE_BUILD_TYPE": "RelWithDebInfo",
+        "ENABLE_PRECOMMIT": "OFF",
+        "ENABLE_CPACK": "ON",
+        "DOCS_HTML": "ON",
+        "ENABLE_CONDA": "ON",
+        "COLORED_COMPILER_OUTPUT": "OFF",
+        "USE_SANITIZER": "thread"
+      }
+    },
+    {
+      "name": "linux-64-ci-coverage",
+      "displayName": "linux-64-ci-coverage",
+      "description": "To be used in the CI environment only",
+      "binaryDir": "${sourceDir}/build",
+      "generator": "Ninja",
+      "cacheVariables": {
+        "CMAKE_PREFIX_PATH": "$env{CONDA_PREFIX}",
+        "CONDA_ENV": true,
+        "CMAKE_FIND_USE_SYSTEM_ENVIRONMENT_PATH": "FALSE",
+        "CMAKE_FIND_USE_CMAKE_ENVIRONMENT_PATH": "FALSE",
+        "CMAKE_BUILD_TYPE": "Debug",
+        "ENABLE_PRECOMMIT": "OFF",
+        "ENABLE_CPACK": "ON",
+        "DOCS_HTML": "ON",
+        "ENABLE_CONDA": "ON",
+        "COLORED_COMPILER_OUTPUT": "OFF",
+        "COVERAGE": "OFF",
+        "TESTING_TIMEOUT": "1200",
+        "CMAKE_CXX_FLAGS_DEBUG": "-g -O0"
+      }
+    }
+  ]
 }

--- a/buildconfig/CMake/FindSIP.cmake
+++ b/buildconfig/CMake/FindSIP.cmake
@@ -44,12 +44,8 @@ Directory holding the SIP C++ header file.
 #]=======================================================================]
 include(FindPackageHandleStandardArgs)
 
-if(EXISTS "$ENV{CONDA_PREFIX}")
-  set(_path_opt NO_DEFAULT_PATH)
-endif()
-
 # First look for sip-build, indicating the newer v6 build system
-find_program(SIP_BUILD_EXECUTABLE sip-build ${_path_opt})
+find_program(SIP_BUILD_EXECUTABLE NAMES sip-build)
 
 if(SIP_BUILD_EXECUTABLE)
 
@@ -61,7 +57,7 @@ if(SIP_BUILD_EXECUTABLE)
   )
 
   # module generator
-  find_program(SIP_MODULE_EXECUTABLE sip-module)
+  find_program(SIP_MODULE_EXECUTABLE NAMES sip-module)
 
   # pyproject.toml template
   find_file(SIP_PYPROJECT_TOML_TEMPLATE NAME pyproject.toml.in PATHS ${CMAKE_MODULE_PATH}/sip-build)

--- a/buildconfig/Jenkins/Conda/nightly_build_and_deploy.jenkinsfile
+++ b/buildconfig/Jenkins/Conda/nightly_build_and_deploy.jenkinsfile
@@ -22,17 +22,21 @@ def publish_test_reports() {
 }
 
 def conda_build_unix(arch) {
-  sh "${WORKSPACE}/buildconfig/Jenkins/Conda/package ${WORKSPACE} --build-mantid --build-qt --build-workbench ${package_options()}"
+  sh "${WORKSPACE}/buildconfig/Jenkins/Conda/package ${WORKSPACE} ${package_options(arch)}"
   archive_conda_build(arch)
 }
 
 def conda_build_win(arch) {
-  bat "\"${WIN_BASH}\" -ex -c \"${WORKSPACE_UNIX_PATH}/buildconfig/Jenkins/Conda/package ${WORKSPACE_UNIX_PATH} --build-mantid --build-qt --build-workbench ${package_options()}\""
+  bat "\"${WIN_BASH}\" -ex -c \"${WORKSPACE_UNIX_PATH}/buildconfig/Jenkins/Conda/package ${WORKSPACE_UNIX_PATH} ${package_options(arch)}\""
   archive_conda_build(arch)
 }
 
-def package_options() {
-  package_options="${PACKAGE_OPTIONS.trim()}"
+def package_options(arch) {
+  build_docs = ""
+  if(arch == "linux-64") {
+    build_docs="--build-docs"
+  }
+  package_options="--build-mantid --build-qt --build-workbench ${build_docs} ${PACKAGE_OPTIONS.trim()}"
   if(PACKAGE_SUFFIX.trim() != '') {
       package_options += " --package-suffix ${PACKAGE_SUFFIX}"
   }

--- a/buildconfig/Jenkins/Conda/nightly_build_and_deploy.jenkinsfile
+++ b/buildconfig/Jenkins/Conda/nightly_build_and_deploy.jenkinsfile
@@ -206,7 +206,7 @@ pipeline {
           ${WORKSPACE} ${GITHUB_TOKEN} ${GITHUB_RELEASES_REPO} ${GITHUB_RELEASES_TAG} ${GIT_COMMIT} ${WORKSPACE}/standalone-packages/*'
       }
     }
-    stage ('Delete old Conda nightly packages from Anaconda') {
+    stage ('Delete old non-main packages from Anaconda') {
       when {
         beforeAgent true
         beforeOptions true
@@ -219,10 +219,8 @@ pipeline {
       options { timestamps () }
       environment { ANACONDA_TOKEN = credentials("${ANACONDA_TOKEN_CREDENTIAL_ID}") }
       steps {
-        sh '${WORKSPACE}/buildconfig/Jenkins/Conda/delete-old-nightlies.sh ${WORKSPACE} ${ANACONDA_TOKEN} --channel mantid --package mantid --label ${ANACONDA_CHANNEL_LABEL}'
-        sh '${WORKSPACE}/buildconfig/Jenkins/Conda/delete-old-nightlies.sh ${WORKSPACE} ${ANACONDA_TOKEN} --channel mantid --package mantidqt --label ${ANACONDA_CHANNEL_LABEL}'
-        sh '${WORKSPACE}/buildconfig/Jenkins/Conda/delete-old-nightlies.sh ${WORKSPACE} ${ANACONDA_TOKEN} --channel mantid --package mantiddocs --label ${ANACONDA_CHANNEL_LABEL}'
-        sh '${WORKSPACE}/buildconfig/Jenkins/Conda/delete-old-nightlies.sh ${WORKSPACE} ${ANACONDA_TOKEN} --channel mantid --package mantidworkbench --label ${ANACONDA_CHANNEL_LABEL}'
+        sh '${WORKSPACE}/buildconfig/Jenkins/Conda/delete-old-packages.sh\
+         ${WORKSPACE} ${ANACONDA_TOKEN} --channel mantid --label ${ANACONDA_CHANNEL_LABEL} mantid mantidqt mantiddocs mantidworkbench'
       }
     }
     stage('Update conda-recipes') {

--- a/buildconfig/Jenkins/Conda/nightly_build_and_deploy.jenkinsfile
+++ b/buildconfig/Jenkins/Conda/nightly_build_and_deploy.jenkinsfile
@@ -3,196 +3,181 @@
 // GITHUB_USER_EMAIL - The email of the user, being used with pushing/pulling from conda-recipes
 // GITHUB_TOKEN_CREDENTIAL_ID - The name of the credentials token in Jenkins that you want to use for cloning and pushing to the conda-recipes repo
 // ANACONDA_TOKEN_CREDENTIAL_ID - The name of the credentials token in Jenkins that you want to use for publishing conda packages
-// ANACONDA_CHANNEL - The channel to publish to on Anaconda.org
-// ANACONDA_CHANNEL_LABEL - This will be used as the label for the channel, otherwise no label will be set.
-// PACKAGE_OPTIONS - additional options to pass to the packaging step.
 
-def build_and_test_unix(cmake_preset) {
-  sh "${WORKSPACE}/buildconfig/Jenkins/Conda/conda-buildscript ${WORKSPACE} ${cmake_preset} --enable-systemtests --enable-doctests --clean-build --clean-external-projects"
-}
-
-def build_and_test_win(cmake_preset) {
-  bat "\"${WIN_BASH}\" -ex -c \"${WORKSPACE_UNIX_PATH}/buildconfig/Jenkins/Conda/conda-buildscript ${WORKSPACE_UNIX_PATH} ${cmake_preset} --enable-systemtests --clean-build --clean-external-projects\""
-}
-
-def publish_test_reports() {
-  xunit thresholds: [failed(failureThreshold: '0')],
-  tools: [CTest(excludesPattern: '', pattern: 'build/Testing/**/*.xml', stopProcessingIfError: true)]
-  junit "build/Testing/SystemTests/scripts/TEST-*.xml"
-}
-
-def conda_build_unix(arch) {
-  sh "${WORKSPACE}/buildconfig/Jenkins/Conda/package ${WORKSPACE} ${package_options(arch)}"
-  archive_conda_build(arch)
-}
-
-def conda_build_win(arch) {
-  bat "\"${WIN_BASH}\" -ex -c \"${WORKSPACE_UNIX_PATH}/buildconfig/Jenkins/Conda/package ${WORKSPACE_UNIX_PATH} ${package_options(arch)}\""
-  archive_conda_build(arch)
-}
-
-def package_options(arch) {
-  build_docs = ""
-  if(arch == "linux-64") {
-    build_docs="--build-docs"
-  }
-  package_options="--build-mantid --build-qt --build-workbench ${build_docs} ${PACKAGE_OPTIONS.trim()}"
-  if(PACKAGE_SUFFIX.trim() != '') {
-      package_options += " --package-suffix ${PACKAGE_SUFFIX}"
-  }
-  return package_options.trim()
-}
-
-def recipe_update_options() {
-  recipe_options=""
-  if(PACKAGE_SUFFIX.trim() == '') {
-    recipe_options+=" --release-version"
-  }
-  return recipe_options
-}
-
-def archive_conda_build(arch) {
-  archiveArtifacts artifacts: "**/conda-bld/${arch}/*.tar.bz2",
-    allowEmptyArchive: false,
-    fingerprint: true,
-    onlyIfSuccessful: true
-}
-
-def create_standalone_package_linux() {
-  archiveArtifacts artifacts: "*.tar.xz",
-    allowEmptyArchive: false,
-    fingerprint: true,
-    onlyIfSuccessful: true
-}
-
-def create_standalone_package_osx() {
-  archiveArtifacts artifacts: "*.dmg",
-    allowEmptyArchive: false,
-    fingerprint: true,
-    onlyIfSuccessful: true
-}
-
-def create_standalone_package_win() {
-  archiveArtifacts artifacts: "*.exe",
-    allowEmptyArchive: false,
-    fingerprint: true,
-    onlyIfSuccessful: true
+// Determine default values of parameters. Some are based on the branch.
+ANACONDA_CHANNEL_DEFAULT = 'mantid'
+GITHUB_RELEASES_REPO_DEFAULT = 'mantidproject/mantid'
+CONDA_RECIPES_BRANCH_NAME_DEFAULT = 'main'
+GIT_BRANCH = git_branch_name()
+switch(GIT_BRANCH) {
+  case ['main', 'release-next']:
+    PUBLISH_PACKAGES_DEFAULT = true
+    PACKAGE_SUFFIX_DEFAULT = 'Nightly'
+    ANACONDA_CHANNEL_LABEL_DEFAULT = 'nightly'
+    GITHUB_RELEASES_TAG_DEFAULT = 'nightly'
+    PLATFORM_CHOICES = ['all']
+    break
+  default:
+    PUBLISH_PACKAGES_DEFAULT = false
+    PACKAGE_SUFFIX_DEFAULT = 'Unstable'
+    ANACONDA_CHANNEL_LABEL_DEFAULT = 'unstable'
+    GITHUB_RELEASES_TAG_DEFAULT = 'unstable'
+    PLATFORM_CHOICES = ['none', 'all', 'linux-64', 'win-64', 'osx-64']
+    break
 }
 
 pipeline {
   agent none
+  parameters {
+      // Check these match the PLATFORM matrix values below (without all).
+      choice(name: 'BUILD_DEVEL', choices: PLATFORM_CHOICES,
+              description: 'Choose a platform to build & test the developer configuration.')
+      choice(name: 'BUILD_PACKAGE', choices: PLATFORM_CHOICES,
+              description: 'Choose a platform to build just this standalone package')
+      string(name: 'CONDA_RECIPES_BRANCH_NAME', defaultValue: CONDA_RECIPES_BRANCH_NAME_DEFAULT,
+             description: 'The name of the conda-recipes branch to build')
+      string(name: 'PACKAGE_SUFFIX', defaultValue: PACKAGE_SUFFIX_DEFAULT,
+             description: 'A string to append to the standalone package name')
+      booleanParam(name: 'PUBLISH_PACKAGES', defaultValue: PUBLISH_PACKAGES_DEFAULT,
+                   description: 'If true, publish the packages to Anaconda channel & GitHub')
+      string(name: 'ANACONDA_CHANNEL', defaultValue: ANACONDA_CHANNEL_DEFAULT,
+             description: 'The Anaconda channel to accept the package')
+      string(name: 'ANACONDA_CHANNEL_LABEL', defaultValue: ANACONDA_CHANNEL_LABEL_DEFAULT,
+             description: 'The label attached to package in the Anaconda channel')
+      string(name: 'GITHUB_RELEASES_REPO', defaultValue: GITHUB_RELEASES_REPO_DEFAULT,
+             description: 'The repository to house the release')
+      string(name: 'GITHUB_RELEASES_TAG', defaultValue: GITHUB_RELEASES_TAG_DEFAULT,
+             description: 'The name of the tag for the release')
+  }
   environment {
     WIN_BASH = "C:\\Program Files\\git\\bin\\bash.exe"
   }
   stages {
-    stage('Build and test') {
-      when {
-        beforeAgent true
-        environment name: 'BUILD_AND_TEST', value: 'true'
-      }
-      parallel {
-        stage('platform: linux') {
-          agent { label 'conda-build-linux' }
-          options { timestamps () }
-          steps {
-            build_and_test_unix("linux-ci")
+    // Verify developer environment build/test while also building conda packages
+    // in parallel. Running both steps in parallel reduces the overall pipeline
+    // time, however if either part breaks then no publishing occurs.
+    stage('Build/Test: Development, Package: Conda') {
+      matrix {
+        axes {
+          // See the agent label above when changing these. They will need to
+          // match labels on the agents
+          axis {
+            name 'PLATFORM'
+            values 'linux-64', 'win-64', 'osx-64'
           }
-          post {
-            always {
-              publish_test_reports()
-            }
-          }
-        }
-        stage('platform: windows') {
-          agent { label 'conda-build-win' }
-          options { timestamps () }
-          steps {
-            script { WORKSPACE_UNIX_PATH = "${WORKSPACE}".replaceAll("\\\\", "/") }
-            build_and_test_win("win")
-          }
-          post {
-            always {
-              publish_test_reports()
-            }
+          axis {
+            name 'BUILD_TYPE'
+            values 'conda-devel', 'conda-release'
           }
         }
-        stage('platform: macos') {
-          agent { label 'conda-build-osx' }
-          options { timestamps () }
-          steps {
-            build_and_test_unix("osx-ci")
+        stages {
+          stage('build and test') {
+            when {
+              beforeAgent true
+              beforeOptions true
+              allOf {
+                expression { env.BUILD_TYPE == 'conda-devel' }
+                anyOf {
+                  expression { env.BUILD_DEVEL == 'all' }
+                  expression { env.BUILD_DEVEL == "${PLATFORM}" }
+                }
+              }
+            }
+            agent { label "${PLATFORM}" }
+            options { timestamps () }
+            steps {
+              build_and_test("${PLATFORM}")
+            }
+            post {
+              always {
+                publish_test_reports()
+              }
+            }
           }
-          post {
-            always {
-              publish_test_reports()
+          stage('package conda') {
+            when {
+              beforeAgent true
+              beforeOptions true
+              allOf {
+                environment name: 'BUILD_TYPE', value: 'conda-release'
+                // Messy part of the pipeline. We build mantiddocs (noarch) on
+                // Linux but this is needed to package up mantidworkbench version so
+                // we pick the simple option of always building the linux one
+                anyOf {
+                  expression { env.PLATFORM.startsWith('linux') }
+                  expression { env.BUILD_PACKAGE == "${PLATFORM}" }
+                  expression { env.BUILD_PACKAGE == 'all' }
+                }
+              }
+            }
+            agent { label "${PLATFORM}" }
+            options { timestamps () }
+            steps {
+              // Clean up conda-bld before we start to avoid any
+              // confusion with old packages
+               dir('conda-bld') {
+                 deleteDir()
+               }
+              // Build the base set of packages (ones not required for mantidworkbench)
+              // in parallel
+              package_conda("${PLATFORM}", "base")
+              archive_conda_packages("${PLATFORM}", false)
+              archive_conda_packages("noarch", true)
             }
           }
         }
       }
     }
-    stage('Update conda-recipes repository') {
-      when {
-        beforeAgent true
-        environment name: 'PUBLISH_PACKAGES', value: 'true'
-      }
-      agent { label 'conda-build-linux' }
-      environment {
-        GITHUB_TOKEN = credentials("${GITHUB_TOKEN_CREDENTIAL_ID}")
-        RECIPE_UPDATE_OPTIONS = recipe_update_options()
-      }
-      steps {
-        sh '${WORKSPACE}/buildconfig/Jenkins/Conda/update-conda-recipes.sh $GITHUB_TOKEN $GITHUB_USER_NAME $GITHUB_USER_EMAIL $RECIPE_UPDATE_OPTIONS'
-      }
-    }
-    stage('Packaging') {
-      parallel {
-        stage('platform: linux-64') {
-          when {
-            beforeAgent true
-            environment name: 'BUILD_PACKAGE_LINUX', value: 'true'
-          }
-          agent { label 'conda-build-linux' }
-          options { timestamps () }
-          steps {
-            conda_build_unix("linux-64")
-            create_standalone_package_linux()
+    stage('Package: Workbench') {
+      matrix {
+        axes {
+          axis {
+            name 'PLATFORM'
+            values 'linux-64', 'win-64', 'osx-64'
           }
         }
-        stage('platform: win-64') {
-          when {
-            beforeAgent true
-            environment name: 'BUILD_PACKAGE_WIN', value: 'true'
-          }
-          agent { label 'conda-build-win' }
-          options { timestamps () }
-          steps {
-            script {
-              WORKSPACE_UNIX_PATH = "${WORKSPACE}".replaceAll("\\\\", "/")
+        stages {
+          stage('') {
+            when {
+              beforeAgent true
+              beforeOptions true
+              anyOf {
+                  expression { env.BUILD_PACKAGE == "${PLATFORM}" }
+                  expression { env.BUILD_PACKAGE == 'all' }
+               }
             }
-            conda_build_win("win-64")
-            create_standalone_package_win()
-          }
-        }
-        stage('platform: osx-64') {
-          when {
-            beforeAgent true
-            environment name: 'BUILD_PACKAGE_OSX', value: 'true'
-          }
-          agent { label 'conda-build-osx' }
-          options { timestamps () }
-          steps {
-            conda_build_unix("osx-64")
-            create_standalone_package_osx()
+            agent { label "${PLATFORM}" }
+            options { timestamps() }
+            steps {
+              // Clean up conda-bld before we start to avoid any
+              // confusion with old packages
+              dir('conda-bld') {
+                deleteDir()
+              }
+              // Copy base packages to build workbench
+              copyArtifacts filter: "**/conda-bld/noarch/*.tar.bz2, **/conda-bld/${PLATFORM}/*.tar.bz2",
+                fingerprintArtifacts: true,
+                projectName: '${JOB_NAME}',
+                selector: specific('${BUILD_NUMBER}'),
+                target: './',
+                flatten: false
+              package_conda("${PLATFORM}", "workbench")
+              archive_conda_packages("${PLATFORM}", false)
+              package_standalone("${PLATFORM}")
+              archive_standalone_package("${PLATFORM}")
+            }
           }
         }
       }
     }
+
     stage ('Publishing') {
       when {
         beforeAgent true
-        environment name: 'PUBLISH_PACKAGES', value: 'true'
+        beforeOptions true
+        expression { env.PUBLISH_PACKAGES == 'true' }
       }
-      agent { label 'conda-build-linux' } // Use linux for simplicity with shell scripts
+      agent { label 'linux-64' } // Use linux for simplicity with shell scripts
       options { timestamps () }
       environment {
         ANACONDA_TOKEN = credentials("${ANACONDA_TOKEN_CREDENTIAL_ID}")
@@ -207,7 +192,8 @@ pipeline {
           selector: specific('${BUILD_NUMBER}'),
           target: 'conda-packages',
           flatten: true
-        sh '${WORKSPACE}/buildconfig/Jenkins/Conda/publish-to-anaconda ${WORKSPACE} ${ANACONDA_TOKEN} ${ANACONDA_CHANNEL} ${ANACONDA_CHANNEL_LABEL} ${WORKSPACE}/conda-packages/*.tar.bz2'
+        sh '${WORKSPACE}/buildconfig/Jenkins/Conda/publish-to-anaconda\
+          ${WORKSPACE} ${ANACONDA_TOKEN} ${ANACONDA_CHANNEL} ${ANACONDA_CHANNEL_LABEL} ${WORKSPACE}/conda-packages/*.tar.bz2'
         // Standalone packages next
         sh 'rm -fr ${WORKSPACE}/standalone-packages'
         copyArtifacts filter: '*.exe, *.dmg, *.tar.xz',
@@ -216,22 +202,164 @@ pipeline {
           selector: specific('${BUILD_NUMBER}'),
           target: 'standalone-packages',
           flatten: true
-        sh '${WORKSPACE}/buildconfig/Jenkins/Conda/publish-to-github ${WORKSPACE} ${GITHUB_TOKEN} ${GITHUB_RELEASES_REPO} ${GITHUB_RELEASES_TAG} ${GIT_COMMIT} ${WORKSPACE}/standalone-packages/*'
+        sh '${WORKSPACE}/buildconfig/Jenkins/Conda/publish-to-github\
+          ${WORKSPACE} ${GITHUB_TOKEN} ${GITHUB_RELEASES_REPO} ${GITHUB_RELEASES_TAG} ${GIT_COMMIT} ${WORKSPACE}/standalone-packages/*'
       }
     }
     stage ('Delete old Conda nightly packages from Anaconda') {
       when {
         beforeAgent true
-        environment name: 'PUBLISH_PACKAGES', value: 'true'
+        beforeOptions true
+        allOf {
+            expression { env.PUBLISH_PACKAGES == 'true' }
+            expression { env.ANACONDA_CHANNEL_LABEL != '' }
+        }
       }
-      agent { label 'conda-build-linux' } // Use linux for simplicity with shell scripts
+      agent { label 'linux-64' } // Use linux for simplicity with shell scripts
       options { timestamps () }
       environment { ANACONDA_TOKEN = credentials("${ANACONDA_TOKEN_CREDENTIAL_ID}") }
       steps {
-        sh '${WORKSPACE}/buildconfig/Jenkins/Conda/delete-old-nightlies.sh ${WORKSPACE} $ANACONDA_TOKEN --channel mantid --package mantid --label nightly'
-        sh '${WORKSPACE}/buildconfig/Jenkins/Conda/delete-old-nightlies.sh ${WORKSPACE} $ANACONDA_TOKEN --channel mantid --package mantidqt --label nightly'
-        sh '${WORKSPACE}/buildconfig/Jenkins/Conda/delete-old-nightlies.sh ${WORKSPACE} $ANACONDA_TOKEN --channel mantid --package mantidworkbench --label nightly'
+        sh '${WORKSPACE}/buildconfig/Jenkins/Conda/delete-old-nightlies.sh ${WORKSPACE} ${ANACONDA_TOKEN} --channel mantid --package mantid --label ${ANACONDA_CHANNEL_LABEL}'
+        sh '${WORKSPACE}/buildconfig/Jenkins/Conda/delete-old-nightlies.sh ${WORKSPACE} ${ANACONDA_TOKEN} --channel mantid --package mantidqt --label ${ANACONDA_CHANNEL_LABEL}'
+        sh '${WORKSPACE}/buildconfig/Jenkins/Conda/delete-old-nightlies.sh ${WORKSPACE} ${ANACONDA_TOKEN} --channel mantid --package mantiddocs --label ${ANACONDA_CHANNEL_LABEL}'
+        sh '${WORKSPACE}/buildconfig/Jenkins/Conda/delete-old-nightlies.sh ${WORKSPACE} ${ANACONDA_TOKEN} --channel mantid --package mantidworkbench --label ${ANACONDA_CHANNEL_LABEL}'
+      }
+    }
+    stage('Update conda-recipes') {
+      when {
+        beforeAgent true
+        beforeOptions true
+        expression { env.PUBLISH_PACKAGES == 'true' }
+      }
+      agent { label 'linux-64' }
+      environment {
+        GITHUB_TOKEN = credentials("${GITHUB_TOKEN_CREDENTIAL_ID}")
+        RECIPE_UPDATE_OPTIONS = recipe_update_options()
+      }
+      steps {
+        sh '${WORKSPACE}/buildconfig/Jenkins/Conda/update-conda-recipes.sh ${GITHUB_TOKEN} ${GITHUB_USER_NAME} ${GITHUB_USER_EMAIL} ${RECIPE_UPDATE_OPTIONS}'
       }
     }
   }
+}
+
+// ------------------- Functions -------------------
+
+def git_branch_name() {
+  name = scm.branches[0].name
+  if (name.contains("*/")) {
+    name = name.split("\\*/")[1]
+  }
+  return name
+}
+
+def toUnixStylePath(path) {
+  return path.replaceAll("\\\\", "/")
+}
+
+def build_and_test(platform) {
+  buildscript_path = 'buildconfig/Jenkins/Conda/conda-buildscript'
+  common_args = '--clean-build --clean-external-projects --enable-systemtests'
+  cmake_preset = "${platform}-ci"
+  if(platform.startsWith('win')) {
+    workspace_unix_style = toUnixStylePath("${WORKSPACE}")
+    bat "\"${WIN_BASH}\" -ex -c \"${workspace_unix_style}/${buildscript_path}\
+      ${workspace_unix_style} ${cmake_preset} ${common_args}\""
+  } else {
+    sh "${WORKSPACE}/${buildscript_path} ${WORKSPACE} ${cmake_preset} ${common_args} --enable-doctests"
+  }
+}
+
+def publish_test_reports() {
+  xunit thresholds: [failed(failureThreshold: '0')],
+  tools: [CTest(excludesPattern: '', pattern: 'build/Testing/**/*.xml', stopProcessingIfError: true)]
+  junit 'build/Testing/SystemTests/scripts/TEST-*.xml'
+}
+
+def package_conda(platform, base_or_workbench) {
+  packagescript_path = 'buildconfig/Jenkins/Conda/package-conda'
+  if(platform.startsWith('win')) {
+    workspace_unix_style = toUnixStylePath("${WORKSPACE}")
+    bat "\"${WIN_BASH}\" -ex -c \"${workspace_unix_style}/${packagescript_path}\
+      ${workspace_unix_style} ${package_conda_options(platform, base_or_workbench)}\""
+  } else {
+    sh "${WORKSPACE}/${packagescript_path}\
+      ${WORKSPACE} ${package_conda_options(platform, base_or_workbench)}"
+  }
+}
+
+def package_conda_options(platform, base_or_workbench) {
+  package_flags = ""
+  if(base_or_workbench == 'base') {
+    docs_flags = ""
+    if(platform.startsWith('linux')) {
+      docs_flags = '--build-docs'
+    }
+    package_flags = "--build-mantid --build-qt ${docs_flags}"
+  }
+  else if(base_or_workbench == 'workbench') {
+    package_flags = "--build-workbench"
+  }
+
+  release_version = ""
+  if(PACKAGE_SUFFIX.trim() == '') {
+    release_version = ' --release-version'
+  }
+  package_options = "${package_flags} ${release_version} \
+    --build-current-branch --recipes-tag ${CONDA_RECIPES_BRANCH_NAME}"
+  return package_options.trim()
+}
+
+def package_standalone(platform) {
+  packagescript_path = 'buildconfig/Jenkins/Conda/package-standalone'
+  if(platform.startsWith('win')) {
+    workspace_unix_style = toUnixStylePath("${WORKSPACE}")
+    bat "\"${WIN_BASH}\" -ex -c \"${workspace_unix_style}/${packagescript_path} ${workspace_unix_style}\
+      ${package_standalone_options(platform)}\""
+  } else {
+    sh "${WORKSPACE}/buildconfig/Jenkins/Conda/package-standalone ${WORKSPACE} ${package_standalone_options(platform)}"
+  }
+}
+
+def package_standalone_options(platform) {
+  package_options = ""
+  if(PACKAGE_SUFFIX.trim() != '') {
+      package_options += " --package-suffix ${PACKAGE_SUFFIX}"
+  }
+  return package_options.trim()
+}
+
+def archive_conda_packages(platform, allowEmpty) {
+  archiveArtifacts artifacts: "**/conda-bld/${platform}/*.tar.bz2",
+    allowEmptyArchive: allowEmpty,
+    fingerprint: true,
+    onlyIfSuccessful: true
+}
+
+def archive_standalone_package(platform) {
+  pattern = ""
+  if(platform.startsWith('linux')) {
+    pattern = '*.tar.xz'
+  } else if(platform.startsWith('win')) {
+    pattern = '*.exe'
+  } else if(platform.startsWith('osx')) {
+    pattern = '*.dmg'
+  }
+
+  if(pattern != '') {
+    archiveArtifacts artifacts: "${pattern}",
+      allowEmptyArchive: false,
+      fingerprint: true,
+      onlyIfSuccessful: true
+  } else {
+    unstable("Unknown platform (${platform}) detected while archving standalone package. Archiving skipped.")
+  }
+}
+
+def recipe_update_options() {
+  recipe_options = "--recipes-tag ${CONDA_RECIPES_BRANCH_NAME}"
+  if(PACKAGE_SUFFIX.trim() == '') {
+    recipe_options += ' --release-version'
+  }
+  return recipe_options
 }

--- a/buildconfig/Jenkins/Conda/package
+++ b/buildconfig/Jenkins/Conda/package
@@ -60,6 +60,7 @@ SCRIPT_DIR=$WORKSPACE/buildconfig/Jenkins/Conda/
 ENABLE_BUILD_MANTID=false
 ENABLE_BUILD_QT=false
 ENABLE_BUILD_WORKBENCH=false
+ENABLE_BUILD_DOCS=false
 BUILD_CURRENT_BRANCH=false
 CLOBBER_FILE=
 RECIPES_TAG=main
@@ -72,6 +73,7 @@ do
         --build-mantid) ENABLE_BUILD_MANTID=true ;;
         --build-qt) ENABLE_BUILD_QT=true ;;
         --build-workbench) ENABLE_BUILD_WORKBENCH=true ;;
+        --build-docs) ENABLE_BUILD_DOCS=true ;;
         --build-current-branch) BUILD_CURRENT_BRANCH=true ;;
         --clobber-yml)
             CLOBBER_FILE="--clobber-file $2"
@@ -95,7 +97,12 @@ if [[ $ENABLE_BUILD_QT  == true ]]; then
     ENABLE_BUILD_MANTID=true
 fi
 
-if [[ $ENABLE_WORKBENCH  == true ]]; then
+if [[ $ENABLE_BUILD_WORKBENCH  == true ]]; then
+    ENABLE_BUILD_MANTID=true
+    ENABLE_BUILD_QT=true
+fi
+
+if [[ $ENABLE_BUILD_DOCS  == true ]]; then
     ENABLE_BUILD_MANTID=true
     ENABLE_BUILD_QT=true
 fi
@@ -144,11 +151,12 @@ fi
 if [[ $ENABLE_BUILD_MANTID == true ]]; then
     conda mambabuild ./mantid/ $CLOBBER_FILE $WINDOWS_BUILD_OPTIONS
 fi
-
 if [[ $ENABLE_BUILD_QT == true ]]; then
     conda mambabuild ./mantidqt/ $CLOBBER_FILE $WINDOWS_BUILD_OPTIONS
 fi
-
+if [[ $ENABLE_BUILD_DOCS == true ]]; then
+    conda mambabuild ./mantiddocs/ $CLOBBER_FILE $WINDOWS_BUILD_OPTIONS
+fi
 if [[ $ENABLE_BUILD_WORKBENCH == true ]]; then
     conda mambabuild ./mantidworkbench/ $CLOBBER_FILE $WINDOWS_BUILD_OPTIONS
 fi

--- a/buildconfig/Jenkins/Conda/package-conda
+++ b/buildconfig/Jenkins/Conda/package-conda
@@ -6,10 +6,10 @@
 # package dependent on a different one it will build and produce that package too.
 #
 # Script usage:
-# conda-build-recipes WORKSPACE [options]
+# package-conda WORKSPACE [options]
 #
 # Example command to build all of the packages:
-# conda-build-recipes $WORKSPACE --build-mantid --build-qt --build-workbench
+# conda-build-recipes $WORKSPACE --build-mantid --build-qt --build-docs --build-workbench
 #
 # Expected args:
 #   1. WORKSPACE: path to the workspace/source code that this should run inside
@@ -19,13 +19,14 @@
 # Possible flags:
 #   --build-mantid: build the mantid package using conda-build
 #   --build-qt: build the qt package using conda-build (this will implicitly build mantid)
+#   --build-docs: build the HTML/Qthelp documentation
 #   --build-workbench: build the workbench package using conda-build (this will implicitly build qt and mantid)
+#   --build-current-branch: build the packages from the latest commit in the currently checkout out branch
+#   --release-version: indicate that this is a build for a stable release
 #
 # Possible parameters:
 #   --clobber-yml: clobber the meta yaml files of each package build with conda-build, provide an absolute path to the yml file
 #   --recipes-tag: a branch or tag that should be used for cloning the recipes
-#   --build-current-branch: build the packages from the latest commit in the currently checkout out branch
-#   --package-suffix: An optional suffix to pass to the standalone package step.
 
 # Setup expected variables
 WORKSPACE=$1
@@ -62,9 +63,9 @@ ENABLE_BUILD_QT=false
 ENABLE_BUILD_WORKBENCH=false
 ENABLE_BUILD_DOCS=false
 BUILD_CURRENT_BRANCH=false
+RELEASE_VERSION=false
 CLOBBER_FILE=
 RECIPES_TAG=main
-STANDALONE_PACKAGE_SUFFIX=
 
 # Handle flag inputs
 while [ ! $# -eq 0 ]
@@ -75,14 +76,12 @@ do
         --build-workbench) ENABLE_BUILD_WORKBENCH=true ;;
         --build-docs) ENABLE_BUILD_DOCS=true ;;
         --build-current-branch) BUILD_CURRENT_BRANCH=true ;;
+        --release-version) RELEASE_VERSION=true ;;
         --clobber-yml)
             CLOBBER_FILE="--clobber-file $2"
             shift ;;
         --recipes-tag)
             RECIPES_TAG="$2"
-            shift ;;
-        --package-suffix)
-            STANDALONE_PACKAGE_SUFFIX="$2"
             shift ;;
         *)
             echo "Argument not accepted: $1"
@@ -91,21 +90,6 @@ do
   esac
   shift
 done
-
-# Build dependencies for requested packages
-if [[ $ENABLE_BUILD_QT  == true ]]; then
-    ENABLE_BUILD_MANTID=true
-fi
-
-if [[ $ENABLE_BUILD_WORKBENCH  == true ]]; then
-    ENABLE_BUILD_MANTID=true
-    ENABLE_BUILD_QT=true
-fi
-
-if [[ $ENABLE_BUILD_DOCS  == true ]]; then
-    ENABLE_BUILD_MANTID=true
-    ENABLE_BUILD_QT=true
-fi
 
 # Setup Mambaforge
 $SCRIPT_DIR/download-and-install-mambaforge $EXPECTED_MAMBAFORGE_PATH $EXPECTED_CONDA_PATH true
@@ -131,16 +115,17 @@ git clone https://github.com/mantidproject/conda-recipes.git --depth=1 -b $RECIP
 if [[ $BUILD_CURRENT_BRANCH == true ]]; then
     RECIPE_UPDATE_ARGS="dummy_token dummy_name dummy_email --local-only"
     #If it's a release version, pass an extra argument to use the patch version number
-    if [[ -z "${STANDALONE_PACKAGE_SUFFIX}" ]]; then
+    if [[ $RELEASE_VERSION == true ]]; then
         RECIPE_UPDATE_ARGS="${RECIPE_UPDATE_ARGS} --release-version"
     fi
     $SCRIPT_DIR/update-conda-recipes.sh $RECIPE_UPDATE_ARGS
 fi
 
-# Run conda build. Use shortest path possible for Windows
+# Run conda build. Use a known path so packages built in other steps can be
+# copied to a known location and reused
 export CONDA_BLD_PATH=$WORKSPACE/conda-bld
 if [[ -d $CONDA_BLD_PATH ]]; then
-    rm -rf $CONDA_BLD_PATH
+    conda index $CONDA_BLD_PATH
 fi
 cd $RECIPES_DIR/recipes/
 
@@ -159,24 +144,4 @@ if [[ $ENABLE_BUILD_DOCS == true ]]; then
 fi
 if [[ $ENABLE_BUILD_WORKBENCH == true ]]; then
     conda mambabuild ./mantidworkbench/ $CLOBBER_FILE $WINDOWS_BUILD_OPTIONS
-fi
-
-# Build the standalone packages, currently only for Windows and macOS
-# Jenkins Pipeline expects packages in the root workspace directory
-cd $WORKSPACE
-# Set our local conda channel to find our locally build mantidworkbench package.
-LOCAL_CHANNEL=file://$CONDA_BLD_PATH
-PACKAGING_ARGS="-c ${LOCAL_CHANNEL}"
-if [ -n "${STANDALONE_PACKAGE_SUFFIX}" ]; then
-    PACKAGING_ARGS="${PACKAGING_ARGS} -s ${STANDALONE_PACKAGE_SUFFIX}"
-fi
-if [[ $OSTYPE == 'msys'* ]]; then
-    rm -fr *.exe
-    ${WORKSPACE}/installers/conda/win/create_package.sh $PACKAGING_ARGS
-elif [[ $OSTYPE == 'darwin'* ]]; then
-    rm -fr *.dmg
-    ${WORKSPACE}/installers/conda/osx/create_bundle.sh $PACKAGING_ARGS
-else
-    rm -fr *.tar.xz
-    ${WORKSPACE}/installers/conda/linux/create_tarball.sh $PACKAGING_ARGS
 fi

--- a/buildconfig/Jenkins/Conda/package-standalone
+++ b/buildconfig/Jenkins/Conda/package-standalone
@@ -1,0 +1,96 @@
+#!/bin/bash -ex
+
+# This script expects to be in a POSIX environment, the script clones the conda-recipes
+# repo and then runs conda builds based on passed args. By default it only clones the
+# source, you need to pass a flag to actually build something useful. If building a
+# package dependent on a different one it will build and produce that package too.
+#
+# Script usage:
+# package-standalone WORKSPACE [options]
+#
+# Example command to build all of the packages:
+# package-standalone $WORKSPACE --package-suffix Nightly
+#
+# Expected args:
+#   1. WORKSPACE: path to the workspace/source code that this should run inside
+#                 (mantid repo). Windows Caveat: Only use / for this argument do
+#                 not use \\ or \ in the path.
+#
+# Possible parameters:
+#   --package-suffix: An optional suffix to pass to the standalone package step.
+
+# Setup expected variables
+WORKSPACE=$1
+if [[ -z "$WORKSPACE" ]]; then
+    echo "A workspace argument is required"
+    exit 1
+fi
+shift
+if [[ $OSTYPE == "msys"* ]]; then
+    if [[ "$WORKSPACE" == *'\'* ]]; then
+        echo "You have \ or \\ in your Workspace path, this is not supported on Windows."
+        exit 1
+    fi
+    WORKSPACE=${WORKSPACE////\\} # Replace // with \
+    # Require git settings so that paths can be checked out with longer file names than 260 characters
+    if [[ ! $(git config --system --get core.longpaths) == true ]]; then
+        echo "This windows machine is does not have longpaths enabled for git, please run this command: git config --system core.longpaths true"
+        exit 1
+    fi
+fi
+EXPECTED_MAMBAFORGE_PATH=$WORKSPACE/mambaforge # Install into the WORKSPACE_DIR
+if [[ $OSTYPE == "msys" ]]; then
+    EXPECTED_CONDA_PATH=$EXPECTED_MAMBAFORGE_PATH/condabin/mamba.bat
+else
+    EXPECTED_CONDA_PATH=$EXPECTED_MAMBAFORGE_PATH/bin/mamba
+fi
+
+# Parse options
+STANDALONE_PACKAGE_SUFFIX=
+while [ ! $# -eq 0 ]
+do
+    case "$1" in
+        --package-suffix)
+            STANDALONE_PACKAGE_SUFFIX="$2"
+            shift ;;
+        *)
+            echo "Argument not accepted: $1"
+            exit 1
+            ;;
+  esac
+  shift
+done
+
+# Setup Mambaforge & environment if it is not already there
+$WORKSPACE/buildconfig/Jenkins/Conda/download-and-install-mambaforge $EXPECTED_MAMBAFORGE_PATH $EXPECTED_CONDA_PATH true
+CONDA_ENV_NAME=standalone-package-env
+$EXPECTED_CONDA_PATH env remove -n $CONDA_ENV_NAME
+# Create env with conda-build so we can build a local channel
+$EXPECTED_CONDA_PATH create -n $CONDA_ENV_NAME conda-build mamba -y
+. $WORKSPACE/mambaforge/etc/profile.d/conda.sh
+conda activate $CONDA_ENV_NAME
+
+# Build packages
+# Setup a local conda channel to find our locally built packages package. It is
+# assumed the raw .bz2 artefacts have been copied into the directory below
+LOCAL_CHANNEL_PATH=$WORKSPACE/conda-bld
+conda index $LOCAL_CHANNEL_PATH
+
+# Jenkins Pipeline expects packages in the root workspace directory
+cd $WORKSPACE
+PACKAGING_SCRIPTS_DIR=$WORKSPACE/installers/conda
+LOCAL_CHANNEL=file://$LOCAL_CHANNEL_PATH
+PACKAGING_ARGS="-c ${LOCAL_CHANNEL}"
+if [ -n "${STANDALONE_PACKAGE_SUFFIX}" ]; then
+    PACKAGING_ARGS="${PACKAGING_ARGS} -s ${STANDALONE_PACKAGE_SUFFIX}"
+fi
+if [[ $OSTYPE == 'msys'* ]]; then
+    rm -fr *.exe
+    ${PACKAGING_SCRIPTS_DIR}/win/create_package.sh $PACKAGING_ARGS
+elif [[ $OSTYPE == 'darwin'* ]]; then
+    rm -fr *.dmg
+    ${PACKAGING_SCRIPTS_DIR}/osx/create_bundle.sh $PACKAGING_ARGS
+else
+    rm -fr *.tar.xz
+    ${PACKAGING_SCRIPTS_DIR}/linux/create_tarball.sh $PACKAGING_ARGS
+fi

--- a/buildconfig/Jenkins/Conda/update-conda-recipes.sh
+++ b/buildconfig/Jenkins/Conda/update-conda-recipes.sh
@@ -98,6 +98,7 @@ function replace_version_data() {
 
 replace_version_data recipes/mantid/meta.yaml
 replace_version_data recipes/mantidqt/meta.yaml
+replace_version_data recipes/mantiddocs/meta.yaml
 replace_version_data recipes/mantidworkbench/meta.yaml
 
 if [[ $LOCAL_ONLY  == false ]]; then

--- a/buildconfig/Jenkins/Conda/update-conda-recipes.sh
+++ b/buildconfig/Jenkins/Conda/update-conda-recipes.sh
@@ -23,6 +23,7 @@ shift
 # Optional flag to update a local repo without pushing the changes
 LOCAL_ONLY=false
 RELEASE_VERSION=false
+RECIPES_TAG=main
 
 # Handle flag inputs
 while [ ! $# -eq 0 ]
@@ -30,6 +31,9 @@ do
     case "$1" in
         --local-only) LOCAL_ONLY=true ;;
         --release-version) RELEASE_VERSION=true ;;
+        --recipes-tag)
+            RECIPES_TAG="$2"
+            shift ;;
         *)
             echo "Argument not accepted: $1"
             exit 1
@@ -85,7 +89,7 @@ rm -rf $SOURCE_FILE
 # Clone conda-recipes
 if [[ $LOCAL_ONLY  == false ]]; then
     if [ -d "conda-recipes" ]; then rm -rf conda-recipes; fi
-    git clone https://${GITHUB_USER_NAME}:${GITHUB_ACCESS_TOKEN}@github.com/mantidproject/conda-recipes.git
+    git clone https://${GITHUB_USER_NAME}:${GITHUB_ACCESS_TOKEN}@github.com/mantidproject/conda-recipes.git -b $RECIPES_TAG
 fi
 
 cd conda-recipes

--- a/installers/conda/linux/create_tarball.sh
+++ b/installers/conda/linux/create_tarball.sh
@@ -17,7 +17,6 @@ set -e
 HERE="$(dirname "$0")"
 BUILD_DIR=_bundle_build
 CONDA_EXE=mamba
-CONDA_PACKAGE=mantidworkbench
 BUNDLE_PREFIX=mantidworkbench
 BUNDLE_EXTENSION=.tar.xz
 ICON_DIR="$HERE/../../../images"
@@ -133,10 +132,10 @@ mkdir -p "$bundle_contents"
 # Create conda environment internally. --copy ensures no symlinks are used
 bundle_conda_prefix="$bundle_contents"
 
-echo "Creating Conda environment in '$bundle_conda_prefix' from '$CONDA_PACKAGE'"
+echo "Creating Conda environment in '$bundle_conda_prefix'"
 "$CONDA_EXE" create --quiet --prefix "$bundle_conda_prefix" --copy \
   --channel "$conda_channel" --channel conda-forge --yes \
-  "$CONDA_PACKAGE" \
+  mantidworkbench \
   jq  # used for processing the version string
 echo
 

--- a/installers/conda/osx/create_bundle.sh
+++ b/installers/conda/osx/create_bundle.sh
@@ -21,7 +21,6 @@ TEMP_OSA_SCPT=/tmp/dmg_setup.scpt
 DETACH_MAX_TRIES=5
 DETACH_WAIT_SECS=60
 CONDA_EXE=mamba
-CONDA_PACKAGE=mantidworkbench
 BUNDLE_PREFIX=MantidWorkbench
 ICON_DIR="$HERE/../../../images"
 
@@ -228,10 +227,10 @@ mkdir -p "$bundle_contents"/{Resources,MacOS}
 # Create conda environment internally. --copy ensures no symlinks are used
 bundle_conda_prefix="$bundle_contents"/Resources
 
-echo "Creating Conda environment in '$bundle_conda_prefix' from '$CONDA_PACKAGE'"
+echo "Creating Conda environment in '$bundle_conda_prefix'"
 "$CONDA_EXE" create --quiet --prefix "$bundle_conda_prefix" --copy \
   --channel "$conda_channel" --channel conda-forge --yes \
-  "$CONDA_PACKAGE" \
+  mantidworkbench \
   jq  # used for processing the version string
 echo
 

--- a/installers/conda/win/create_package.sh
+++ b/installers/conda/win/create_package.sh
@@ -73,7 +73,11 @@ rm -rf $CONDA_ENV_PATH
 mkdir $COPY_DIR
 
 echo "Creating conda env from mantidworkbench and jq"
-"$CONDA_EXE" create --prefix $CONDA_ENV_PATH mantidworkbench m2w64-jq notebook --copy -c $CONDA_CHANNEL -c conda-forge -y
+"$CONDA_EXE" create --prefix $CONDA_ENV_PATH \
+  --copy --channel $CONDA_CHANNEL --channel conda-forge -y \
+  mantidworkbench \
+  notebook \
+  m2w64-jq
 echo "Conda env created"
 
 # Determine version information

--- a/installers/conda/win/create_package.sh
+++ b/installers/conda/win/create_package.sh
@@ -139,7 +139,8 @@ echo "Copy scripts into the package"
 mv $CONDA_ENV_PATH/Library/scripts $COPY_DIR/
 
 echo "Copy share files (includes mantid docs) to the package"
-mv $CONDA_ENV_PATH/Library/share/doc $COPY_DIR/share/
+mkdir $COPY_DIR/share
+mv $CONDA_ENV_PATH/share/doc/* $COPY_DIR/share/
 
 echo "Copy executable launcher"
 # MantidWorkbench-script.pyw is created by project.nsi on creation of the package


### PR DESCRIPTION
**Description of work.**

**mantidproject/conda-recipes#77 must be merged at the same time**

Creating a new mantiddocs package, mantidproject/conda-recipes#77, required that the pipeline be rearranged. This has the advantage of parallelizing more of it. This work has aimed to reduce the duplication of the original by introducing a matrix over platforms and hiding details in the implementation functions.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**

See full completed [test job](https://builds.mantidproject.org/job/build_packages_from_branch_parallel/27/)

<!-- alternative
*There is no associated issue.*
-->

*This does not require release notes* because **it is an internal developer change**

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
