### PR TITLE
Auto restart live data monitor from refl gui

### DIFF
--- a/docs/source/release/v6.5.0/Reflectometry/Bugfixes/34132.rst
+++ b/docs/source/release/v6.5.0/Reflectometry/Bugfixes/34132.rst
@@ -1,0 +1,1 @@
+- Fix a bug with starting the live data monitor from the ISIS Reflectometry interface where there was a delay in updating the processed (IvsQ) workspace.

--- a/docs/source/release/v6.5.0/Reflectometry/New_features/34132.rst
+++ b/docs/source/release/v6.5.0/Reflectometry/New_features/34132.rst
@@ -1,0 +1,1 @@
+- When running the live data monitor from the ISIS Reflectometry interface, it will now be automatically restarted if it stops unexpectedly.

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/RunsPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/RunsPresenter.cpp
@@ -610,6 +610,8 @@ void RunsPresenter::finishHandle(const IAlgorithm *alg) {
   stopObserving(m_monitorAlg);
   m_monitorAlg.reset();
   updateViewWhenMonitorStopped();
+  g_log.warning("Live data monitor stopped; re-starting the monitor.");
+  startMonitor();
 }
 
 /** Handler called when the monitor algorithm errors
@@ -620,5 +622,9 @@ void RunsPresenter::errorHandle(const IAlgorithm *alg, const std::string &what) 
   stopObserving(m_monitorAlg);
   m_monitorAlg.reset();
   updateViewWhenMonitorStopped();
+  if (what != "Algorithm terminated") {
+    g_log.warning("Live data error: " + what + "; re-starting the monitor.");
+    startMonitor();
+  }
 }
 } // namespace MantidQt::CustomInterfaces::ISISReflectometry

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/RunsPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/RunsPresenter.cpp
@@ -495,26 +495,11 @@ std::string RunsPresenter::liveDataReductionOptions(const std::string &inputWork
 }
 
 IAlgorithm_sptr RunsPresenter::setupLiveDataMonitorAlgorithm() {
-  auto instrument = m_view->getSearchInstrument();
-
-#ifndef NDEBUG
-  // Debug version to allow testing with a fake instrument
-  bool useFakeInstrument = false;
-  auto &config = Mantid::Kernel::ConfigService::Instance();
-  auto facility = config.getString("default.facility");
-  if (facility == "TEST_LIVE") {
-    // If the developer has set the facility to TEST_LIVE, use the default instrument
-    // Note that you must set the facility _after_ opening the interface, and also
-    // run the FakeISISHistoDAE or similar for it to work
-    useFakeInstrument = true;
-    instrument = config.getString("default.instrument");
-  }
-#endif
-
   auto alg = AlgorithmManager::Instance().create("StartLiveData");
   alg->initialize();
   alg->setChild(false);
   alg->setLogging(false);
+  auto const instrument = m_view->getSearchInstrument();
   auto const inputWorkspace = "TOF_live";
   auto const updateInterval = m_view->getLiveDataUpdateInterval();
   alg->setProperty("Instrument", instrument);
@@ -522,15 +507,8 @@ IAlgorithm_sptr RunsPresenter::setupLiveDataMonitorAlgorithm() {
   alg->setProperty("AccumulationWorkspace", inputWorkspace);
   alg->setProperty("AccumulationMethod", "Replace");
   alg->setProperty("UpdateEvery", static_cast<double>(updateInterval));
-#ifndef NDEBUG
-  if (!useFakeInstrument) {
-    alg->setProperty("PostProcessingAlgorithm", liveDataReductionAlgorithm());
-    alg->setProperty("PostProcessingProperties", liveDataReductionOptions(inputWorkspace, instrument));
-  }
-#else
   alg->setProperty("PostProcessingAlgorithm", liveDataReductionAlgorithm());
   alg->setProperty("PostProcessingProperties", liveDataReductionOptions(inputWorkspace, instrument));
-#endif
   alg->setProperty("RunTransitionBehavior", "Restart");
   auto errorMap = alg->validateInputs();
   if (!errorMap.empty()) {

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/RunsPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/RunsPresenter.cpp
@@ -513,7 +513,7 @@ IAlgorithm_sptr RunsPresenter::setupLiveDataMonitorAlgorithm() {
 
   auto alg = AlgorithmManager::Instance().create("StartLiveData");
   alg->initialize();
-  alg->setChild(true);
+  alg->setChild(false);
   alg->setLogging(false);
   auto const inputWorkspace = "TOF_live";
   auto const updateInterval = m_view->getLiveDataUpdateInterval();


### PR DESCRIPTION
**Report to:** Max at ISIS

This PR ensures that live data is automatically restarted if it was run from the ISIS Reflectometry GUI and drops out for an unexpected reason.  It also adds a fix where live data was slow to start.

**To test:**

Ideally needs to be tested ISIS when cycle is running:
- Open the ISIS reflectometry GUI and click the Start Monitor button. Two workspaces should appear in the workspaces list: TOF_live and IvsQ_binned_live.
- Open sliceviewer on the TOF workspace and a line plot on the second workspace (IvsQ should contain only one spectrum).
- Leave the monitor running during an experiment and keep an eye on the log. At some point the monitor is likely to drop out; you should see a warning when this happens and a message that it was automatically re-started.
- Ensure the monitor can be stopped from the Stop Monitor button or by cancelling it on the algorithm progress dialog.

If cycle is not running unfortunately there is not much we can test:
- Open the ISIS reflectometry GUI
- Click Start Monitor. It should grey out both Start Monitor and Stop Monitor buttons while it is attempting to start. It will probably take a while (say 20 seconds) but eventually time out and give an error in the log.

Fixes #34132 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
