### PR TITLE
Apply ROI Detector IDs to experiment settings

### DIFF
--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/SumBanksAlgorithm.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/SumBanksAlgorithm.cpp
@@ -26,11 +26,11 @@ using MantidQt::API::IConfiguredAlgorithm_sptr;
 
 namespace {
 void updateInputProperties(MantidQt::API::IAlgorithmRuntimeProps &properties, MatrixWorkspace_sptr const &workspace,
-                           std::vector<Mantid::detid_t> const &detIDs) {
+                           boost::optional<ProcessingInstructions> const &detIDsStr) {
   properties.setProperty("InputWorkspace", workspace);
-
-  auto detIDsStr = Mantid::Kernel::Strings::simpleJoin(detIDs.cbegin(), detIDs.cend(), ",");
-  AlgorithmProperties::update("ROIDetectorIDs", detIDsStr, properties);
+  if (detIDsStr) {
+    AlgorithmProperties::update("ROIDetectorIDs", *detIDsStr, properties);
+  }
 }
 } // namespace
 

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/ExperimentPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/ExperimentPresenter.cpp
@@ -108,6 +108,8 @@ void ExperimentPresenter::notifyPreviewApplyRequested(PreviewRow const &previewR
   if (auto const foundRow = m_model.findLookupRow(previewRow, m_thetaTolerance)) {
     auto lookupRowCopy = *foundRow;
 
+    lookupRowCopy.setRoiDetectorIDs(std::move(previewRow.getSelectedBanks()));
+
     updateLookupRowProcessingInstructions(previewRow, lookupRowCopy, ROIType::Signal);
     updateLookupRowProcessingInstructions(previewRow, lookupRowCopy, ROIType::Background);
     updateLookupRowProcessingInstructions(previewRow, lookupRowCopy, ROIType::Transmission);
@@ -123,7 +125,7 @@ void ExperimentPresenter::notifyPreviewApplyRequested(PreviewRow const &previewR
 void ExperimentPresenter::updateLookupRowProcessingInstructions(PreviewRow const &previewRow, LookupRow &lookupRow,
                                                                 ROIType regionType) {
   auto const instructions = previewRow.getProcessingInstructions(regionType);
-  lookupRow.setProcessingInstructions(regionType, instructions);
+  lookupRow.setProcessingInstructions(regionType, std::move(instructions));
 }
 
 void ExperimentPresenter::restoreDefaults() {

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/ExperimentPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/ExperimentPresenter.cpp
@@ -108,7 +108,7 @@ void ExperimentPresenter::notifyPreviewApplyRequested(PreviewRow const &previewR
   if (auto const foundRow = m_model.findLookupRow(previewRow, m_thetaTolerance)) {
     auto lookupRowCopy = *foundRow;
 
-    lookupRowCopy.setRoiDetectorIDs(std::move(previewRow.getSelectedBanks()));
+    lookupRowCopy.setRoiDetectorIDs(previewRow.getSelectedBanks());
 
     updateLookupRowProcessingInstructions(previewRow, lookupRowCopy, ROIType::Signal);
     updateLookupRowProcessingInstructions(previewRow, lookupRowCopy, ROIType::Background);

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/IPreviewModel.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/IPreviewModel.h
@@ -33,7 +33,7 @@ public:
   virtual void reduceAsync(IJobManager &jobManager) = 0;
 
   virtual Mantid::API::MatrixWorkspace_sptr getLoadedWs() const = 0;
-  virtual std::vector<Mantid::detid_t> getSelectedBanks() const = 0;
+  virtual boost::optional<ProcessingInstructions> getSelectedBanks() const = 0;
   virtual Mantid::API::MatrixWorkspace_sptr getSummedWs() const = 0;
   virtual Mantid::API::MatrixWorkspace_sptr getReducedWs() const = 0;
   virtual boost::optional<ProcessingInstructions> getProcessingInstructions(ROIType regionType) const = 0;
@@ -44,7 +44,7 @@ public:
 
   virtual void setTheta(double theta) = 0;
 
-  virtual void setSelectedBanks(std::vector<Mantid::detid_t> selectedBanks) = 0;
+  virtual void setSelectedBanks(boost::optional<ProcessingInstructions> selectedBanks) = 0;
   virtual void setSelectedRegion(ROIType regionType, Selection const &selection) = 0;
 
   virtual void exportSummedWsToAds() const = 0;

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewModel.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewModel.cpp
@@ -95,14 +95,16 @@ std::optional<double> PreviewModel::getDefaultTheta() const {
 
 PreviewRow const &PreviewModel::getPreviewRow() const { return *m_runDetails; }
 
-std::vector<Mantid::detid_t> PreviewModel::getSelectedBanks() const { return m_runDetails->getSelectedBanks(); }
+boost::optional<ProcessingInstructions> PreviewModel::getSelectedBanks() const {
+  return m_runDetails->getSelectedBanks();
+}
 
 void PreviewModel::setLoadedWs(Mantid::API::MatrixWorkspace_sptr workspace) { m_runDetails->setLoadedWs(workspace); }
 
 void PreviewModel::setSummedWs(Mantid::API::MatrixWorkspace_sptr workspace) { m_runDetails->setSummedWs(workspace); }
 
 void PreviewModel::setTheta(double theta) { m_runDetails->setTheta(theta); }
-void PreviewModel::setSelectedBanks(std::vector<Mantid::detid_t> selectedBanks) {
+void PreviewModel::setSelectedBanks(boost::optional<ProcessingInstructions> selectedBanks) {
   m_runDetails->setSelectedBanks(std::move(selectedBanks));
 }
 

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewModel.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewModel.h
@@ -36,7 +36,7 @@ public:
   void reduceAsync(IJobManager &jobManager) override;
 
   Mantid::API::MatrixWorkspace_sptr getLoadedWs() const override;
-  std::vector<Mantid::detid_t> getSelectedBanks() const override;
+  boost::optional<ProcessingInstructions> getSelectedBanks() const override;
   Mantid::API::MatrixWorkspace_sptr getSummedWs() const override;
   boost::optional<ProcessingInstructions> getProcessingInstructions(ROIType regionType) const override;
   Mantid::API::MatrixWorkspace_sptr getReducedWs() const override;
@@ -46,7 +46,7 @@ public:
   void setLoadedWs(Mantid::API::MatrixWorkspace_sptr workspace);
   void setSummedWs(Mantid::API::MatrixWorkspace_sptr workspace) override;
   void setTheta(double theta) override;
-  void setSelectedBanks(std::vector<Mantid::detid_t> selectedBanks) override;
+  void setSelectedBanks(boost::optional<ProcessingInstructions> selectedBanks) override;
   void setSelectedRegion(ROIType regionType, Selection const &selection) override;
 
   void exportSummedWsToAds() const override;

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.cpp
@@ -9,6 +9,7 @@
 #include "Common/Detector.h"
 #include "GUI/Batch/IBatchPresenter.h"
 #include "MantidAPI/MatrixWorkspace.h"
+#include "MantidKernel/Strings.h"
 #include "MantidQtWidgets/Plotting/AxisID.h"
 #include "MantidQtWidgets/RegionSelector/IRegionSelector.h"
 #include "MantidQtWidgets/RegionSelector/RegionSelector.h"

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.cpp
@@ -168,7 +168,8 @@ void PreviewPresenter::notifyInstViewShapeChanged() {
   notifyInstViewEditRequested();
   // Get the masked workspace indices
   auto indices = m_instViewModel->detIndicesToDetIDs(m_view->getSelectedDetectors());
-  m_model->setSelectedBanks(indices);
+  auto detIDsStr = Mantid::Kernel::Strings::simpleJoin(indices.cbegin(), indices.cend(), ",");
+  m_model->setSelectedBanks(ProcessingInstructions{detIDsStr});
   // Execute summing the selected banks
   runSumBanks();
 }

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/LookupRow.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/LookupRow.cpp
@@ -52,6 +52,10 @@ boost::optional<ProcessingInstructions> LookupRow::backgroundProcessingInstructi
 
 boost::optional<ProcessingInstructions> LookupRow::roiDetectorIDs() const { return m_roiDetectorIDs; }
 
+void LookupRow::setRoiDetectorIDs(boost::optional<ProcessingInstructions> selectedBanks) {
+  m_roiDetectorIDs = std::move(selectedBanks);
+}
+
 void LookupRow::setProcessingInstructions(ROIType regionType,
                                           boost::optional<ProcessingInstructions> processingInstructions) {
   switch (regionType) {

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/LookupRow.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/LookupRow.h
@@ -64,6 +64,7 @@ public:
   boost::optional<ProcessingInstructions> processingInstructions() const;
   boost::optional<ProcessingInstructions> backgroundProcessingInstructions() const;
   boost::optional<ProcessingInstructions> roiDetectorIDs() const;
+  void setRoiDetectorIDs(boost::optional<ProcessingInstructions> selectedBanks);
   void setProcessingInstructions(ROIType regionType, boost::optional<ProcessingInstructions> processingInstructions);
   bool hasEqualThetaAndTitle(LookupRow const &lookupRow, double tolerance) const;
 

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/PreviewRow.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/PreviewRow.cpp
@@ -42,9 +42,9 @@ void PreviewRow::setLoadedWs(Mantid::API::MatrixWorkspace_sptr ws) noexcept { m_
 void PreviewRow::setSummedWs(Mantid::API::MatrixWorkspace_sptr ws) noexcept { m_summedWs = std::move(ws); }
 void PreviewRow::setReducedWs(Mantid::API::MatrixWorkspace_sptr ws) noexcept { m_reducedWs = std::move(ws); }
 
-std::vector<Mantid::detid_t> PreviewRow::getSelectedBanks() const noexcept { return m_selectedBanks; }
+boost::optional<ProcessingInstructions> PreviewRow::getSelectedBanks() const noexcept { return m_selectedBanks; }
 
-void PreviewRow::setSelectedBanks(std::vector<Mantid::detid_t> selectedBanks) noexcept {
+void PreviewRow::setSelectedBanks(boost::optional<ProcessingInstructions> selectedBanks) noexcept {
   m_selectedBanks = std::move(selectedBanks);
 }
 

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/PreviewRow.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/PreviewRow.h
@@ -46,13 +46,13 @@ public:
   Mantid::API::MatrixWorkspace_sptr getLoadedWs() const noexcept;
   Mantid::API::MatrixWorkspace_sptr getSummedWs() const noexcept;
   Mantid::API::MatrixWorkspace_sptr getReducedWs() const noexcept;
-  std::vector<Mantid::detid_t> getSelectedBanks() const noexcept;
+  boost::optional<ProcessingInstructions> getSelectedBanks() const noexcept;
   boost::optional<ProcessingInstructions> getProcessingInstructions(ROIType regionType) const;
 
   void setLoadedWs(Mantid::API::MatrixWorkspace_sptr ws) noexcept;
   void setSummedWs(Mantid::API::MatrixWorkspace_sptr ws) noexcept;
   void setReducedWs(Mantid::API::MatrixWorkspace_sptr ws) noexcept;
-  void setSelectedBanks(std::vector<Mantid::detid_t> selectedBanks) noexcept;
+  void setSelectedBanks(boost::optional<ProcessingInstructions> selectedBanks) noexcept;
   void setProcessingInstructions(ROIType regionType, boost::optional<ProcessingInstructions> processingInstructions);
 
   friend bool operator==(const PreviewRow &lhs, const PreviewRow &rhs) {
@@ -64,7 +64,7 @@ public:
 private:
   std::vector<std::string> m_runNumbers;
   double m_theta;
-  std::vector<Mantid::detid_t> m_selectedBanks;
+  boost::optional<ProcessingInstructions> m_selectedBanks{boost::none};
   boost::optional<ProcessingInstructions> m_processingInstructions{boost::none};
   boost::optional<ProcessingInstructions> m_backgroundProcessingInstructions{boost::none};
   boost::optional<ProcessingInstructions> m_transmissionProcessingInstructions{boost::none};

--- a/qt/scientific_interfaces/ISISReflectometry/test/Batch/SumBanksAlgorithmTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Batch/SumBanksAlgorithmTest.h
@@ -52,10 +52,10 @@ public:
     auto batch = MockBatch();
     const bool isHistogram = true;
     Mantid::API::MatrixWorkspace_sptr mockWs = WorkspaceCreationHelper::create1DWorkspaceRand(1, isHistogram);
-    auto detIDs = std::vector<Mantid::detid_t>{2, 3};
+    auto detIDsStr = ProcessingInstructions{"2,3"};
     auto row = PreviewRow({});
     row.setLoadedWs(mockWs);
-    row.setSelectedBanks(detIDs);
+    row.setSelectedBanks(detIDsStr);
     auto mockAlg = std::make_shared<StubbedPreProcess>();
 
     const std::string inputPropName = "InputWorkspace";

--- a/qt/scientific_interfaces/ISISReflectometry/test/Experiment/ExperimentPresenterTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Experiment/ExperimentPresenterTest.h
@@ -17,10 +17,13 @@
 #include "MockExperimentOptionDefaults.h"
 #include "MockExperimentView.h"
 
+#include <string>
+
 #include <cxxtest/TestSuite.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+using namespace std::string_literals;
 using namespace MantidQt::CustomInterfaces::ISISReflectometry;
 using namespace MantidQt::CustomInterfaces::ISISReflectometry::ModelCreationHelper;
 using testing::_;
@@ -682,14 +685,16 @@ public:
     // makeExperiment will create a model Experiment with two lookup rows and a wildcard row
     auto presenter = makePresenter(makeDefaults(), makeExperiment());
     auto previewRow = PreviewRow({"1234"});
-    previewRow.setProcessingInstructions(ROIType::Signal, std::string{"10"});
-    previewRow.setProcessingInstructions(ROIType::Background, std::string{"11"});
-    previewRow.setProcessingInstructions(ROIType::Transmission, std::string{"12"});
+    previewRow.setSelectedBanks("9"s);
+    previewRow.setProcessingInstructions(ROIType::Signal, "10"s);
+    previewRow.setProcessingInstructions(ROIType::Background, "11"s);
+    previewRow.setProcessingInstructions(ROIType::Transmission, "12"s);
     previewRow.setTheta(2.3);
 
     presenter.notifyPreviewApplyRequested(previewRow);
     // Row with angle 2.3 is the last row in the look-up table
     auto row = presenter.experiment().lookupTableRows().back();
+    TS_ASSERT_EQUALS(row.roiDetectorIDs().get(), "9");
     TS_ASSERT_EQUALS(row.processingInstructions().get(), "10");
     TS_ASSERT_EQUALS(row.backgroundProcessingInstructions().get(), "11");
     TS_ASSERT_EQUALS(row.transmissionProcessingInstructions().get(), "12");
@@ -704,6 +709,7 @@ public:
     presenter.notifyPreviewApplyRequested(previewRow);
     // Row with angle 2.3 is the last row in the look-up table
     auto row = presenter.experiment().lookupTableRows().back();
+    TS_ASSERT(!row.roiDetectorIDs());
     TS_ASSERT(!row.processingInstructions());
     TS_ASSERT(!row.backgroundProcessingInstructions());
     TS_ASSERT(!row.transmissionProcessingInstructions());

--- a/qt/scientific_interfaces/ISISReflectometry/test/Preview/MockPreviewModel.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Preview/MockPreviewModel.h
@@ -29,14 +29,14 @@ public:
   MOCK_METHOD(MatrixWorkspace_sptr, getLoadedWs, (), (const, override));
   MOCK_METHOD(MatrixWorkspace_sptr, getSummedWs, (), (const, override));
   MOCK_METHOD(MatrixWorkspace_sptr, getReducedWs, (), (const, override));
-  MOCK_METHOD(std::vector<Mantid::detid_t>, getSelectedBanks, (), (const, override));
+  MOCK_METHOD(boost::optional<ProcessingInstructions>, getSelectedBanks, (), (const, override));
   MOCK_METHOD(boost::optional<ProcessingInstructions>, getProcessingInstructions, (ROIType), (const, override));
   MOCK_METHOD(std::optional<double>, getDefaultTheta, (), (const, override));
   MOCK_METHOD(PreviewRow const &, getPreviewRow, (), (const, override));
 
   MOCK_METHOD(void, setSummedWs, (MatrixWorkspace_sptr), (override));
   MOCK_METHOD(void, setTheta, (double), (override));
-  MOCK_METHOD(void, setSelectedBanks, (std::vector<Mantid::detid_t>), (override));
+  MOCK_METHOD(void, setSelectedBanks, (boost::optional<ProcessingInstructions>), (override));
   MOCK_METHOD(void, setSelectedRegion, (ROIType, Selection const &), (override));
 
   MOCK_METHOD(void, sumBanksAsync, (IJobManager &), (override));

--- a/qt/scientific_interfaces/ISISReflectometry/test/Preview/PreviewModelTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Preview/PreviewModelTest.h
@@ -78,9 +78,9 @@ public:
 
   void test_set_and_get_selected_banks() {
     PreviewModel model;
-    const std::vector<Mantid::detid_t> inputRoi{56, 57, 58, 59};
-    model.setSelectedBanks(inputRoi);
-    TS_ASSERT_EQUALS(inputRoi, model.getSelectedBanks())
+    const ProcessingInstructions inputRoi{"56,57,58,59"};
+    model.setSelectedBanks(std::move(inputRoi));
+    TS_ASSERT_EQUALS(inputRoi, *model.getSelectedBanks())
   }
 
   void test_set_selected_signal_region_converts_to_processing_instructions_string() {

--- a/qt/scientific_interfaces/ISISReflectometry/test/Preview/PreviewPresenterTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Preview/PreviewPresenterTest.h
@@ -527,10 +527,10 @@ private:
                                                MockInstViewModel &mockInstViewModel, MockJobManager &mockJobManager) {
     auto detIndices = std::vector<size_t>{44, 45, 46};
     auto detIDs = std::vector<Mantid::detid_t>{2, 3, 4};
-    auto detIDsStr = std::string{"2, 3, 4"};
+    auto detIDsStr = ProcessingInstructions{"2,3,4"};
     EXPECT_CALL(mockView, getSelectedDetectors()).Times(1).WillOnce(Return(detIndices));
     EXPECT_CALL(mockInstViewModel, detIndicesToDetIDs(Eq(detIndices))).Times(1).WillOnce(Return(detIDs));
-    EXPECT_CALL(mockModel, setSelectedBanks(detIDs)).Times(1);
+    EXPECT_CALL(mockModel, setSelectedBanks(Eq(detIDsStr))).Times(1);
     EXPECT_CALL(mockModel, sumBanksAsync(Ref(mockJobManager))).Times(1);
   }
 

--- a/qt/scientific_interfaces/ISISReflectometry/test/Reduction/ValidateLookupRowTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Reduction/ValidateLookupRowTest.h
@@ -187,4 +187,20 @@ public:
     TS_ASSERT(result.isError());
     TS_ASSERT_EQUALS(result.assertError(), errorCells);
   }
+
+  void testParseROIDetectorIDs() {
+    LookupRowValidator validator;
+    auto result = validator({"", "", "", "", "", "", "", "", "", "", "", "4-7"});
+    TS_ASSERT(result.isValid());
+    TS_ASSERT(result.assertValid().roiDetectorIDs().is_initialized());
+    TS_ASSERT_EQUALS(result.assertValid().roiDetectorIDs().get(), "4-7");
+  }
+
+  void testParseROIDetectorIDsError() {
+    LookupRowValidator validator;
+    auto result = validator({"", "", "", "", "", "", "", "", "", "", "", "bad"});
+    std::unordered_set<int> errorCells = {LookupRow::Column::ROI_DETECTOR_IDS};
+    TS_ASSERT(result.isError());
+    TS_ASSERT_EQUALS(result.assertError(), errorCells);
+  }
 };


### PR DESCRIPTION
**Description of work.**
This PR will set the ROI Detector IDs in the lookup table in the experiment settings table whenever the apply button is clicked on the preview tab.

**Questions**
- [ ] Something to check: does the full-detector range get added to the lookup table if no region is selected in the instrument view, and Apply is clicked?
- [ ] Do we want to show detector ids as a range rather than a list separated by commas?

**To test:**

- Open the ISIS Reflectometry interface and go to the Preview tab
- Load the test dataset INTER45455_inst and set angle to `1.0`
- Before setting any ranges, click the Apply button and check the Experiment Settings tab - the ROI Detector IDs field in the table should be empty
- Now select a range on the instrument view on the Preview tab and repeat - the ROI Detector IDs should be set to the detectors selected 

Fixes #34110 

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
