### PR TITLE
Create view and model for indirect Sqw

### DIFF
--- a/qt/scientific_interfaces/Indirect/CMakeLists.txt
+++ b/qt/scientific_interfaces/Indirect/CMakeLists.txt
@@ -80,6 +80,8 @@ set(SRC_FILES
     IndirectSimulation.cpp
     IndirectSimulationTab.cpp
     IndirectSqw.cpp
+    IndirectSqwModel.cpp
+    IndirectSqwView.cpp
     IndirectSymmetrise.cpp
     IndirectTab.cpp
     IndirectTools.cpp
@@ -157,6 +159,8 @@ set(MOC_FILES
     IndirectSimulation.h
     IndirectSimulationTab.h
     IndirectSqw.h
+    IndirectSqwModel.h
+    IndirectSqwView.h
     IndirectSymmetrise.h
     IndirectTab.h
     IndirectTools.h

--- a/qt/scientific_interfaces/Indirect/IndirectMoments.h
+++ b/qt/scientific_interfaces/Indirect/IndirectMoments.h
@@ -52,7 +52,6 @@ private slots:
 private:
   void plotNewData(QString const &filename);
   void setFileExtensionsByName(bool filter) override;
-  Ui::IndirectMoments m_uiForm;
   std::unique_ptr<IndirectMomentsModel> m_model;
   std::unique_ptr<IndirectMomentsView> m_view;
 };

--- a/qt/scientific_interfaces/Indirect/IndirectSqw.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectSqw.cpp
@@ -22,58 +22,18 @@ using MantidQt::API::BatchAlgorithmRunner;
 namespace {
 Mantid::Kernel::Logger g_log("S(Q,w)");
 
-MatrixWorkspace_sptr getADSMatrixWorkspace(std::string const &workspaceName) {
-  return AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(workspaceName);
-}
-
-double roundToPrecision(double value, double precision) { return value - std::remainder(value, precision); }
-
-std::pair<double, double> roundToWidth(std::tuple<double, double> const &axisRange, double width) {
-  return std::make_pair(roundToPrecision(std::get<0>(axisRange), width) + width,
-                        roundToPrecision(std::get<1>(axisRange), width) - width);
-}
-
-void convertToSpectrumAxis(std::string const &inputName, std::string const &outputName) {
-  auto converter = AlgorithmManager::Instance().create("ConvertSpectrumAxis");
-  converter->initialize();
-  converter->setProperty("InputWorkspace", inputName);
-  converter->setProperty("OutputWorkspace", outputName);
-  converter->setProperty("Target", "ElasticQ");
-  converter->setProperty("EMode", "Indirect");
-  converter->execute();
-}
-
-std::pair<double, double> convertTupleToPair(std::tuple<double, double> const &tuple) {
-  return std::make_pair(std::get<0>(tuple), std::get<1>(tuple));
-}
-
 } // namespace
 
 namespace MantidQt::CustomInterfaces {
 //----------------------------------------------------------------------------------------------
 /** Constructor
  */
-IndirectSqw::IndirectSqw(IndirectDataReduction *idrUI, QWidget *parent) : IndirectDataReductionTab(idrUI, parent) {
-  m_uiForm.setupUi(parent);
+IndirectSqw::IndirectSqw(IndirectDataReduction *idrUI, QWidget *parent)
+    : IndirectDataReductionTab(idrUI, parent), m_model(std::make_unique<IndirectSqwModel>()),
+      m_view(std::make_unique<IndirectSqwView>(parent)) {
   setOutputPlotOptionsPresenter(
-      std::make_unique<IndirectPlotOptionsPresenter>(m_uiForm.ipoPlotOptions, PlotWidget::SpectraContour));
-
-  connect(m_uiForm.dsSampleInput, SIGNAL(dataReady(QString const &)), this, SLOT(handleDataReady(QString const &)));
-  connect(m_batchAlgoRunner, SIGNAL(batchComplete(bool)), this, SLOT(sqwAlgDone(bool)));
-
-  connect(m_uiForm.pbRun, SIGNAL(clicked()), this, SLOT(runClicked()));
-  connect(m_uiForm.pbSave, SIGNAL(clicked()), this, SLOT(saveClicked()));
-
-  connect(this, SIGNAL(updateRunButton(bool, std::string const &, QString const &, QString const &)), this,
-          SLOT(updateRunButton(bool, std::string const &, QString const &, QString const &)));
-
-  m_uiForm.rqwPlot2D->setCanvasColour(QColor(240, 240, 240));
-
-  // Allows empty workspace selector when initially selected
-  m_uiForm.dsSampleInput->isOptional(true);
-
-  // Disables searching for run files in the data archive
-  m_uiForm.dsSampleInput->isForRunFiles(false);
+      std::make_unique<IndirectPlotOptionsPresenter>(m_view->getPlotOptions(), PlotWidget::SpectraContour));
+  connectSignals();
 }
 
 IndirectSqw::~IndirectSqw() = default;
@@ -81,119 +41,60 @@ IndirectSqw::~IndirectSqw() = default;
 void IndirectSqw::setup() {}
 
 /**
+ * Connects the signals in the interface.
+ *
+ */
+
+void IndirectSqw::connectSignals() {
+  connect(m_batchAlgoRunner, SIGNAL(batchComplete(bool)), this, SLOT(sqwAlgDone(bool)));
+
+  connect(m_view.get(), SIGNAL(dataReady(QString const &)), this, SLOT(handleDataReady(QString const &)));
+  connect(m_view.get(), SIGNAL(qLowChanged(double)), this, SLOT(qLowChanged(double)));
+  connect(m_view.get(), SIGNAL(qWidthChanged(double)), this, SLOT(qWidthChanged(double)));
+  connect(m_view.get(), SIGNAL(qHighChanged(double)), this, SLOT(qHighChanged(double)));
+  connect(m_view.get(), SIGNAL(eLowChanged(double)), this, SLOT(eLowChanged(double)));
+  connect(m_view.get(), SIGNAL(eWidthChanged(double)), this, SLOT(eWidthChanged(double)));
+  connect(m_view.get(), SIGNAL(eHighChanged(double)), this, SLOT(eHighChanged(double)));
+  connect(m_view.get(), SIGNAL(rebinEChanged(int)), this, SLOT(rebinEChanged(int)));
+
+  connect(m_view.get(), SIGNAL(runClicked()), this, SLOT(runClicked()));
+  connect(m_view.get(), SIGNAL(saveClicked()), this, SLOT(saveClicked()));
+
+  connect(m_view.get(), SIGNAL(showMessageBox(const QString &)), this, SIGNAL(showMessageBox(const QString &)));
+
+  connect(this, SIGNAL(updateRunButton(bool, std::string const &, QString const &, QString const &)), m_view.get(),
+          SLOT(updateRunButton(bool, std::string const &, QString const &, QString const &)));
+}
+
+/**
  * Handles the event of data being loaded. Validates the loaded data.
  *
  */
 void IndirectSqw::handleDataReady(QString const &dataName) {
-  UserInputValidator uiv;
-  validateDataIsOfType(uiv, m_uiForm.dsSampleInput, "Sample", DataType::Red);
-
-  auto const errorMessage = uiv.generateErrorMessage();
-  if (!errorMessage.isEmpty()) {
-    showMessageBox(errorMessage);
-  } else {
+  if (m_view->validate()) {
+    m_model->setInputWorkspace(dataName.toStdString());
+    m_model->setEFixed(getInstrumentDetail("Efixed").toStdString());
     plotRqwContour(dataName.toStdString());
-    setDefaultQAndEnergy();
+    m_view->setDefaultQAndEnergy();
   }
 }
 
 bool IndirectSqw::validate() {
-  double const tolerance = 1e-10;
-  double const qLow = m_uiForm.spQLow->value();
-  double const qWidth = m_uiForm.spQWidth->value();
-  double const qHigh = m_uiForm.spQHigh->value();
-  auto const qRange = m_uiForm.rqwPlot2D->getAxisRange(MantidWidgets::AxisID::YLeft);
-
-  UserInputValidator uiv;
-
-  // Validate the sample
-  validateDataIsOfType(uiv, m_uiForm.dsSampleInput, "Sample", DataType::Red);
-
-  // Validate Q binning
-  uiv.checkBins(qLow, qWidth, qHigh, tolerance);
-  uiv.checkRangeIsEnclosed("The contour plots Q axis", convertTupleToPair(qRange), "the Q range provided",
-                           std::make_pair(qLow, qHigh));
-
-  // If selected, validate energy binning
-  if (m_uiForm.ckRebinInEnergy->isChecked()) {
-    double const eLow = m_uiForm.spELow->value();
-    double const eWidth = m_uiForm.spEWidth->value();
-    double const eHigh = m_uiForm.spEHigh->value();
-    auto const eRange = m_uiForm.rqwPlot2D->getAxisRange(MantidWidgets::AxisID::XBottom);
-
-    uiv.checkBins(eLow, eWidth, eHigh, tolerance);
-    uiv.checkRangeIsEnclosed("The contour plots Energy axis", convertTupleToPair(eRange), "the E range provided",
-                             std::make_pair(eLow, eHigh));
-  }
-
+  UserInputValidator uiv = m_model->validate(m_view->getQRangeFromPlot(), m_view->getERangeFromPlot());
   auto const errorMessage = uiv.generateErrorMessage();
-
   // Show an error message if needed
   if (!errorMessage.isEmpty())
     emit showMessageBox(errorMessage);
-
   return errorMessage.isEmpty();
 }
 
 void IndirectSqw::run() {
-  auto const sampleWsName = m_uiForm.dsSampleInput->getCurrentDataName();
-  auto const sqwWsName = sampleWsName.left(sampleWsName.length() - 4) + "_sqw";
-  auto const eRebinWsName = sampleWsName.left(sampleWsName.length() - 4) + "_r";
-
-  auto const rebinString = m_uiForm.spQLow->text() + "," + m_uiForm.spQWidth->text() + "," + m_uiForm.spQHigh->text();
-
-  // Rebin in energy
-  bool const rebinInEnergy = m_uiForm.ckRebinInEnergy->isChecked();
-  if (rebinInEnergy) {
-    auto const eRebinString =
-        m_uiForm.spELow->text() + "," + m_uiForm.spEWidth->text() + "," + m_uiForm.spEHigh->text();
-
-    auto energyRebinAlg = AlgorithmManager::Instance().create("Rebin");
-    energyRebinAlg->initialize();
-    energyRebinAlg->setProperty("InputWorkspace", sampleWsName.toStdString());
-    energyRebinAlg->setProperty("OutputWorkspace", eRebinWsName.toStdString());
-    energyRebinAlg->setProperty("Params", eRebinString.toStdString());
-
-    m_batchAlgoRunner->addAlgorithm(energyRebinAlg);
-  }
-
-  auto const eFixed = getInstrumentDetail("Efixed").toStdString();
-
-  auto sqwAlg = AlgorithmManager::Instance().create("SofQW");
-  sqwAlg->initialize();
-  sqwAlg->setProperty("OutputWorkspace", sqwWsName.toStdString());
-  sqwAlg->setProperty("QAxisBinning", rebinString.toStdString());
-  sqwAlg->setProperty("EMode", "Indirect");
-  sqwAlg->setProperty("EFixed", eFixed);
-  sqwAlg->setProperty("Method", "NormalisedPolygon");
-  sqwAlg->setProperty("ReplaceNaNs", true);
-
-  auto sqwInputProps = std::make_unique<MantidQt::API::AlgorithmRuntimeProps>();
-  sqwInputProps->setPropertyValue("InputWorkspace",
-                                  rebinInEnergy ? eRebinWsName.toStdString() : sampleWsName.toStdString());
-
-  m_batchAlgoRunner->addAlgorithm(sqwAlg, std::move(sqwInputProps));
-
-  // Add sample log for S(Q, w) algorithm used
-  auto sampleLogAlg = AlgorithmManager::Instance().create("AddSampleLog");
-  sampleLogAlg->initialize();
-  sampleLogAlg->setProperty("LogName", "rebin_type");
-  sampleLogAlg->setProperty("LogType", "String");
-  sampleLogAlg->setProperty("LogText", "NormalisedPolygon");
-
-  auto inputToAddSampleLogProps = std::make_unique<MantidQt::API::AlgorithmRuntimeProps>();
-  inputToAddSampleLogProps->setPropertyValue("Workspace", sqwWsName.toStdString());
-
-  m_batchAlgoRunner->addAlgorithm(sampleLogAlg, std::move(inputToAddSampleLogProps));
-
-  // Set the name of the result workspace for Python export
-  m_pythonExportWsName = sqwWsName.toStdString();
+  // m_model->setupAlgorithm();
+  m_model->setupRebinAlgorithm(m_batchAlgoRunner);
+  m_model->setupSofQWAlgorithm(m_batchAlgoRunner);
+  m_model->setupAddSampleLogAlgorithm(m_batchAlgoRunner);
 
   m_batchAlgoRunner->executeBatch();
-}
-
-std::size_t IndirectSqw::getOutWsNumberOfSpectra() const {
-  return getADSMatrixWorkspace(m_pythonExportWsName)->getNumberHistograms();
 }
 
 /**
@@ -203,8 +104,8 @@ std::size_t IndirectSqw::getOutWsNumberOfSpectra() const {
  */
 void IndirectSqw::sqwAlgDone(bool error) {
   if (!error) {
-    setOutputPlotOptionsWorkspaces({m_pythonExportWsName});
-    setSaveEnabled(true);
+    setOutputPlotOptionsWorkspaces({m_model->getOutputWorkspace()});
+    m_view->setSaveEnabled(true);
   }
 }
 
@@ -214,64 +115,42 @@ void IndirectSqw::sqwAlgDone(bool error) {
  * Creates a colour 2D plot of the data
  */
 void IndirectSqw::plotRqwContour(std::string const &sampleName) {
-  auto const outputName = sampleName.substr(0, sampleName.size() - 4) + "_rqw";
-
   try {
-    convertToSpectrumAxis(sampleName, outputName);
-    if (AnalysisDataService::Instance().doesExist(outputName)) {
-      auto const rqwWorkspace = getADSMatrixWorkspace(outputName);
-      if (rqwWorkspace)
-        m_uiForm.rqwPlot2D->setWorkspace(rqwWorkspace);
-    }
+    auto const rqwWorkspace = m_model->getRqwWorkspace();
+    if (rqwWorkspace)
+      m_view->plotRqwContour(rqwWorkspace);
   } catch (std::exception const &ex) {
     g_log.warning(ex.what());
     showMessageBox("Invalid file. Please load a valid reduced workspace.");
   }
 }
 
-void IndirectSqw::setDefaultQAndEnergy() {
-  setQRange(m_uiForm.rqwPlot2D->getAxisRange(MantidWidgets::AxisID::YLeft));
-  setEnergyRange(m_uiForm.rqwPlot2D->getAxisRange(MantidWidgets::AxisID::XBottom));
-}
-
-void IndirectSqw::setQRange(std::tuple<double, double> const &axisRange) {
-  auto const qRange = roundToWidth(axisRange, m_uiForm.spQWidth->value());
-  m_uiForm.spQLow->setValue(qRange.first);
-  m_uiForm.spQHigh->setValue(qRange.second);
-}
-
-void IndirectSqw::setEnergyRange(std::tuple<double, double> const &axisRange) {
-  auto const energyRange = roundToWidth(axisRange, m_uiForm.spEWidth->value());
-  m_uiForm.spELow->setValue(energyRange.first);
-  m_uiForm.spEHigh->setValue(energyRange.second);
-}
-
 void IndirectSqw::setFileExtensionsByName(bool filter) {
   QStringList const noSuffixes{""};
   auto const tabName("Sqw");
-  m_uiForm.dsSampleInput->setFBSuffixes(filter ? getSampleFBSuffixes(tabName) : getExtensions(tabName));
-  m_uiForm.dsSampleInput->setWSSuffixes(filter ? getSampleWSSuffixes(tabName) : noSuffixes);
+  m_view->setFBSuffixes(filter ? getSampleFBSuffixes(tabName) : getExtensions(tabName));
+  m_view->setWSSuffixes(filter ? getSampleWSSuffixes(tabName) : noSuffixes);
 }
 
 void IndirectSqw::runClicked() { runTab(); }
 
 void IndirectSqw::saveClicked() {
-  if (checkADSForPlotSaveWorkspace(m_pythonExportWsName, false))
-    addSaveWorkspaceToQueue(QString::fromStdString(m_pythonExportWsName));
+  if (checkADSForPlotSaveWorkspace(m_model->getOutputWorkspace(), false))
+    addSaveWorkspaceToQueue(QString::fromStdString(m_model->getOutputWorkspace()));
   m_batchAlgoRunner->executeBatch();
 }
 
-void IndirectSqw::setRunEnabled(bool enabled) { m_uiForm.pbRun->setEnabled(enabled); }
+void IndirectSqw::qLowChanged(double value) { m_model->setQMin(value); }
 
-void IndirectSqw::setSaveEnabled(bool enabled) { m_uiForm.pbSave->setEnabled(enabled); }
+void IndirectSqw::qWidthChanged(double value) { m_model->setQWidth(value); }
 
-void IndirectSqw::updateRunButton(bool enabled, std::string const &enableOutputButtons, QString const &message,
-                                  QString const &tooltip) {
-  setRunEnabled(enabled);
-  m_uiForm.pbRun->setText(message);
-  m_uiForm.pbRun->setToolTip(tooltip);
-  if (enableOutputButtons != "unchanged")
-    setSaveEnabled(enableOutputButtons == "enable");
-}
+void IndirectSqw::qHighChanged(double value) { m_model->setQMax(value); }
 
+void IndirectSqw::eLowChanged(double value) { m_model->setEMin(value); }
+
+void IndirectSqw::eWidthChanged(double value) { m_model->setEWidth(value); }
+
+void IndirectSqw::eHighChanged(double value) { m_model->setEMax(value); }
+
+void IndirectSqw::rebinEChanged(int value) { m_model->setRebinInEnergy(value != 0); }
 } // namespace MantidQt::CustomInterfaces

--- a/qt/scientific_interfaces/Indirect/IndirectSqw.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectSqw.cpp
@@ -36,8 +36,6 @@ IndirectSqw::IndirectSqw(IndirectDataReduction *idrUI, QWidget *parent)
   connectSignals();
 }
 
-IndirectSqw::~IndirectSqw() = default;
-
 void IndirectSqw::setup() {}
 
 /**
@@ -89,7 +87,6 @@ bool IndirectSqw::validate() {
 }
 
 void IndirectSqw::run() {
-  // m_model->setupAlgorithm();
   m_model->setupRebinAlgorithm(m_batchAlgoRunner);
   m_model->setupSofQWAlgorithm(m_batchAlgoRunner);
   m_model->setupAddSampleLogAlgorithm(m_batchAlgoRunner);

--- a/qt/scientific_interfaces/Indirect/IndirectSqw.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectSqw.cpp
@@ -74,7 +74,7 @@ void IndirectSqw::handleDataReady(QString const &dataName) {
   if (m_view->validate()) {
     m_model->setInputWorkspace(dataName.toStdString());
     m_model->setEFixed(getInstrumentDetail("Efixed").toStdString());
-    plotRqwContour(dataName.toStdString());
+    plotRqwContour();
     m_view->setDefaultQAndEnergy();
   }
 }
@@ -114,7 +114,7 @@ void IndirectSqw::sqwAlgDone(bool error) {
  *
  * Creates a colour 2D plot of the data
  */
-void IndirectSqw::plotRqwContour(std::string const &sampleName) {
+void IndirectSqw::plotRqwContour() {
   try {
     auto const rqwWorkspace = m_model->getRqwWorkspace();
     if (rqwWorkspace)

--- a/qt/scientific_interfaces/Indirect/IndirectSqw.h
+++ b/qt/scientific_interfaces/Indirect/IndirectSqw.h
@@ -48,7 +48,7 @@ private slots:
 
 private:
   void connectSignals();
-  void plotRqwContour(std::string const &sampleName);
+  void plotRqwContour();
   void setFileExtensionsByName(bool filter) override;
 
   std::unique_ptr<IndirectSqwModel> m_model;

--- a/qt/scientific_interfaces/Indirect/IndirectSqw.h
+++ b/qt/scientific_interfaces/Indirect/IndirectSqw.h
@@ -7,6 +7,8 @@
 #pragma once
 
 #include "IndirectDataReductionTab.h"
+#include "IndirectSqwModel.h"
+#include "IndirectSqwView.h"
 
 #include "MantidKernel/System.h"
 #include "ui_IndirectSqw.h"
@@ -36,22 +38,21 @@ private slots:
   void runClicked();
   void saveClicked();
 
-  void updateRunButton(bool enabled = true, std::string const &enableOutputButtons = "unchanged",
-                       QString const &message = "Run", QString const &tooltip = "");
+  void qLowChanged(double value);
+  void qWidthChanged(double value);
+  void qHighChanged(double value);
+  void eLowChanged(double value);
+  void eWidthChanged(double value);
+  void eHighChanged(double value);
+  void rebinEChanged(int value);
 
 private:
+  void connectSignals();
   void plotRqwContour(std::string const &sampleName);
-  void setDefaultQAndEnergy();
-  void setQRange(std::tuple<double, double> const &axisRange);
-  void setEnergyRange(std::tuple<double, double> const &axisRange);
   void setFileExtensionsByName(bool filter) override;
 
-  std::size_t getOutWsNumberOfSpectra() const;
-
-  void setRunEnabled(bool enabled);
-  void setSaveEnabled(bool enabled);
-
-  Ui::IndirectSqw m_uiForm;
+  std::unique_ptr<IndirectSqwModel> m_model;
+  std::unique_ptr<IndirectSqwView> m_view;
 };
 } // namespace CustomInterfaces
 } // namespace MantidQt

--- a/qt/scientific_interfaces/Indirect/IndirectSqw.h
+++ b/qt/scientific_interfaces/Indirect/IndirectSqw.h
@@ -25,7 +25,7 @@ class DLLExport IndirectSqw : public IndirectDataReductionTab {
 
 public:
   IndirectSqw(IndirectDataReduction *idrUI, QWidget *parent = nullptr);
-  ~IndirectSqw() override;
+  ~IndirectSqw() = default;
 
   void setup() override;
   void run() override;

--- a/qt/scientific_interfaces/Indirect/IndirectSqw.ui
+++ b/qt/scientific_interfaces/Indirect/IndirectSqw.ui
@@ -33,7 +33,7 @@
      </property>
      <layout class="QVBoxLayout" name="verticalLayout_12">
       <item>
-       <widget class="MantidQt::MantidWidgets::DataSelector" name="dsSampleInput" native="true">
+       <widget class="MantidQt::MantidWidgets::DataSelector" name="dsInput" native="true">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
           <horstretch>0</horstretch>

--- a/qt/scientific_interfaces/Indirect/IndirectSqwModel.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectSqwModel.cpp
@@ -1,0 +1,157 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2022 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#include "IndirectSqwModel.h"
+#include "IndirectDataValidationHelper.h"
+
+#include "MantidAPI/AlgorithmManager.h"
+#include "MantidAPI/MatrixWorkspace.h"
+#include "MantidAPI/WorkspaceGroup.h"
+#include "MantidQtWidgets/Common/AlgorithmRuntimeProps.h"
+#include "MantidQtWidgets/Common/UserInputValidator.h"
+
+#include <QDoubleValidator>
+#include <QFileInfo>
+
+using namespace IndirectDataValidationHelper;
+using namespace Mantid::API;
+
+namespace {
+
+MatrixWorkspace_sptr getADSMatrixWorkspace(std::string const &workspaceName) {
+  return AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(workspaceName);
+}
+
+std::pair<double, double> convertTupleToPair(std::tuple<double, double> const &tuple) {
+  return std::make_pair(std::get<0>(tuple), std::get<1>(tuple));
+}
+
+double roundToPrecision(double value, double precision) { return value - std::remainder(value, precision); }
+
+void convertToSpectrumAxis(std::string const &inputName, std::string const &outputName) {
+  auto converter = AlgorithmManager::Instance().create("ConvertSpectrumAxis");
+  converter->initialize();
+  converter->setProperty("InputWorkspace", inputName);
+  converter->setProperty("OutputWorkspace", outputName);
+  converter->setProperty("Target", "ElasticQ");
+  converter->setProperty("EMode", "Indirect");
+  converter->execute();
+}
+} // namespace
+
+namespace MantidQt::CustomInterfaces {
+
+//----------------------------------------------------------------------------------------------
+/** Constructor
+ */
+IndirectSqwModel::IndirectSqwModel() {}
+
+void IndirectSqwModel::setupRebinAlgorithm(MantidQt::API::BatchAlgorithmRunner *batchAlgoRunner) {
+  if (m_rebinInEnergy) {
+    std::string eRebinString = std::to_string(m_eLow) + "," + std::to_string(m_eWidth) + "," + std::to_string(m_eHigh);
+    auto const eRebinWsName = m_inputWorkspace.substr(0, m_inputWorkspace.length() - 4) + "_r";
+    auto energyRebinAlg = AlgorithmManager::Instance().create("Rebin");
+    energyRebinAlg->initialize();
+    energyRebinAlg->setProperty("InputWorkspace", m_inputWorkspace);
+    energyRebinAlg->setProperty("OutputWorkspace", eRebinWsName);
+    energyRebinAlg->setProperty("Params", eRebinString);
+    batchAlgoRunner->addAlgorithm(energyRebinAlg);
+  }
+}
+
+void IndirectSqwModel::setupSofQWAlgorithm(MantidQt::API::BatchAlgorithmRunner *batchAlgoRunner) {
+  std::string qRebinString = std::to_string(m_qLow) + "," + std::to_string(m_qWidth) + "," + std::to_string(m_qHigh);
+
+  auto const sqwWsName = m_inputWorkspace.substr(0, m_inputWorkspace.length() - 4) + "_sqw";
+  auto const eRebinWsName = m_inputWorkspace.substr(0, m_inputWorkspace.length() - 4) + "_r";
+
+  auto sqwAlg = AlgorithmManager::Instance().create("SofQW");
+  sqwAlg->initialize();
+  sqwAlg->setProperty("OutputWorkspace", sqwWsName);
+  sqwAlg->setProperty("QAxisBinning", qRebinString);
+  sqwAlg->setProperty("EMode", "Indirect");
+  sqwAlg->setProperty("EFixed", m_eFixed);
+  sqwAlg->setProperty("Method", "NormalisedPolygon");
+  sqwAlg->setProperty("ReplaceNaNs", true);
+
+  auto sqwInputProps = std::make_unique<MantidQt::API::AlgorithmRuntimeProps>();
+  sqwInputProps->setPropertyValue("InputWorkspace", m_rebinInEnergy ? eRebinWsName : m_inputWorkspace);
+
+  batchAlgoRunner->addAlgorithm(sqwAlg, std::move(sqwInputProps));
+}
+
+void IndirectSqwModel::setupAddSampleLogAlgorithm(MantidQt::API::BatchAlgorithmRunner *batchAlgoRunner) {
+  auto const sqwWsName = m_inputWorkspace.substr(0, m_inputWorkspace.length() - 4) + "_sqw";
+  // Add sample log for S(Q, w) algorithm used
+  auto sampleLogAlg = AlgorithmManager::Instance().create("AddSampleLog");
+  sampleLogAlg->initialize();
+  sampleLogAlg->setProperty("LogName", "rebin_type");
+  sampleLogAlg->setProperty("LogType", "String");
+  sampleLogAlg->setProperty("LogText", "NormalisedPolygon");
+
+  auto inputToAddSampleLogProps = std::make_unique<MantidQt::API::AlgorithmRuntimeProps>();
+  inputToAddSampleLogProps->setPropertyValue("Workspace", sqwWsName);
+
+  batchAlgoRunner->addAlgorithm(sampleLogAlg, std::move(inputToAddSampleLogProps));
+}
+
+void IndirectSqwModel::setInputWorkspace(const std::string &workspace) {
+  m_inputWorkspace = workspace;
+  m_outputWorkspaceName = m_inputWorkspace.substr(0, m_inputWorkspace.length() - 4) + "_sqw";
+}
+
+void IndirectSqwModel::setQMin(double qMin) { m_qLow = qMin; }
+
+void IndirectSqwModel::setQWidth(double qWidth) { m_qWidth = qWidth; }
+
+void IndirectSqwModel::setQMax(double qMax) { m_qHigh = qMax; }
+
+void IndirectSqwModel::setEMin(double eMin) { m_eLow = eMin; }
+
+void IndirectSqwModel::setEWidth(double eWidth) { m_eWidth = eWidth; }
+
+void IndirectSqwModel::setEMax(double eMax) { m_eHigh = eMax; }
+
+void IndirectSqwModel::setEFixed(std::string eFixed) { m_eFixed = eFixed; }
+
+void IndirectSqwModel::setRebinInEnergy(bool scale) { m_rebinInEnergy = scale; }
+
+std::string IndirectSqwModel::getOutputWorkspace() { return m_outputWorkspaceName; }
+
+MatrixWorkspace_sptr IndirectSqwModel::getRqwWorkspace() {
+  auto const outputName = m_inputWorkspace.substr(0, m_inputWorkspace.size() - 4) + "_rqw";
+  convertToSpectrumAxis(m_inputWorkspace, outputName);
+  return getADSMatrixWorkspace(outputName);
+}
+
+UserInputValidator IndirectSqwModel::validate(std::tuple<double, double> const qRange,
+                                              std::tuple<double, double> const eRange) {
+
+  double const tolerance = 1e-10;
+
+  UserInputValidator uiv;
+
+  // Validate Q binning
+  uiv.checkBins(m_qLow, m_qWidth, m_qHigh, tolerance);
+  uiv.checkRangeIsEnclosed("The contour plots Q axis", convertTupleToPair(qRange), "the Q range provided",
+                           std::make_pair(m_qLow, m_qHigh));
+
+  // If selected, validate energy binning
+  if (m_rebinInEnergy) {
+
+    uiv.checkBins(m_eLow, m_eWidth, m_eHigh, tolerance);
+    uiv.checkRangeIsEnclosed("The contour plots Energy axis", convertTupleToPair(eRange), "the E range provided",
+                             std::make_pair(m_eLow, m_eHigh));
+  }
+  return uiv;
+}
+
+std::pair<double, double> IndirectSqwModel::roundToWidth(std::tuple<double, double> const &axisRange, double width) {
+  return std::make_pair(roundToPrecision(std::get<0>(axisRange), width) + width,
+                        roundToPrecision(std::get<1>(axisRange), width) - width);
+}
+
+} // namespace MantidQt::CustomInterfaces

--- a/qt/scientific_interfaces/Indirect/IndirectSqwModel.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectSqwModel.cpp
@@ -115,7 +115,7 @@ void IndirectSqwModel::setEWidth(double eWidth) { m_eWidth = eWidth; }
 
 void IndirectSqwModel::setEMax(double eMax) { m_eHigh = eMax; }
 
-void IndirectSqwModel::setEFixed(std::string eFixed) { m_eFixed = eFixed; }
+void IndirectSqwModel::setEFixed(const std::string &eFixed) { m_eFixed = eFixed; }
 
 void IndirectSqwModel::setRebinInEnergy(bool scale) { m_rebinInEnergy = scale; }
 

--- a/qt/scientific_interfaces/Indirect/IndirectSqwModel.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectSqwModel.cpp
@@ -52,7 +52,7 @@ IndirectSqwModel::IndirectSqwModel() {}
 void IndirectSqwModel::setupRebinAlgorithm(MantidQt::API::BatchAlgorithmRunner *batchAlgoRunner) {
   if (m_rebinInEnergy) {
     std::string eRebinString = std::to_string(m_eLow) + "," + std::to_string(m_eWidth) + "," + std::to_string(m_eHigh);
-    auto const eRebinWsName = m_inputWorkspace.substr(0, m_inputWorkspace.length() - 4) + "_r";
+    auto const eRebinWsName = m_baseName + "_r";
     auto energyRebinAlg = AlgorithmManager::Instance().create("Rebin");
     energyRebinAlg->initialize();
     energyRebinAlg->setProperty("InputWorkspace", m_inputWorkspace);
@@ -65,8 +65,8 @@ void IndirectSqwModel::setupRebinAlgorithm(MantidQt::API::BatchAlgorithmRunner *
 void IndirectSqwModel::setupSofQWAlgorithm(MantidQt::API::BatchAlgorithmRunner *batchAlgoRunner) {
   std::string qRebinString = std::to_string(m_qLow) + "," + std::to_string(m_qWidth) + "," + std::to_string(m_qHigh);
 
-  auto const sqwWsName = m_inputWorkspace.substr(0, m_inputWorkspace.length() - 4) + "_sqw";
-  auto const eRebinWsName = m_inputWorkspace.substr(0, m_inputWorkspace.length() - 4) + "_r";
+  auto const sqwWsName = getOutputWorkspace();
+  auto const eRebinWsName = m_baseName + "_r";
 
   auto sqwAlg = AlgorithmManager::Instance().create("SofQW");
   sqwAlg->initialize();
@@ -84,7 +84,7 @@ void IndirectSqwModel::setupSofQWAlgorithm(MantidQt::API::BatchAlgorithmRunner *
 }
 
 void IndirectSqwModel::setupAddSampleLogAlgorithm(MantidQt::API::BatchAlgorithmRunner *batchAlgoRunner) {
-  auto const sqwWsName = m_inputWorkspace.substr(0, m_inputWorkspace.length() - 4) + "_sqw";
+  auto const sqwWsName = getOutputWorkspace();
   // Add sample log for S(Q, w) algorithm used
   auto sampleLogAlg = AlgorithmManager::Instance().create("AddSampleLog");
   sampleLogAlg->initialize();
@@ -100,7 +100,8 @@ void IndirectSqwModel::setupAddSampleLogAlgorithm(MantidQt::API::BatchAlgorithmR
 
 void IndirectSqwModel::setInputWorkspace(const std::string &workspace) {
   m_inputWorkspace = workspace;
-  m_outputWorkspaceName = m_inputWorkspace.substr(0, m_inputWorkspace.length() - 4) + "_sqw";
+  // remove _red suffix from inpur workspace for outputs
+  m_baseName = m_inputWorkspace.substr(0, m_inputWorkspace.find("_red", m_inputWorkspace.length() - 4));
 }
 
 void IndirectSqwModel::setQMin(double qMin) { m_qLow = qMin; }
@@ -119,7 +120,7 @@ void IndirectSqwModel::setEFixed(const std::string &eFixed) { m_eFixed = eFixed;
 
 void IndirectSqwModel::setRebinInEnergy(bool scale) { m_rebinInEnergy = scale; }
 
-std::string IndirectSqwModel::getOutputWorkspace() { return m_outputWorkspaceName; }
+std::string IndirectSqwModel::getOutputWorkspace() { return m_baseName + "_sqw"; }
 
 MatrixWorkspace_sptr IndirectSqwModel::getRqwWorkspace() {
   auto const outputName = m_inputWorkspace.substr(0, m_inputWorkspace.size() - 4) + "_rqw";

--- a/qt/scientific_interfaces/Indirect/IndirectSqwModel.h
+++ b/qt/scientific_interfaces/Indirect/IndirectSqwModel.h
@@ -32,7 +32,7 @@ public:
   void setEMin(double eMin);
   void setEWidth(double eWidth);
   void setEMax(double eMax);
-  void setEFixed(std::string eFixed);
+  void setEFixed(const std::string &eFixed);
   void setRebinInEnergy(bool scale);
   std::string getOutputWorkspace();
   MatrixWorkspace_sptr getRqwWorkspace();

--- a/qt/scientific_interfaces/Indirect/IndirectSqwModel.h
+++ b/qt/scientific_interfaces/Indirect/IndirectSqwModel.h
@@ -41,7 +41,7 @@ public:
 
 private:
   std::string m_inputWorkspace;
-  std::string m_outputWorkspaceName;
+  std::string m_baseName;
   std::string m_eFixed;
   double m_scaleValue;
   double m_qLow;

--- a/qt/scientific_interfaces/Indirect/IndirectSqwModel.h
+++ b/qt/scientific_interfaces/Indirect/IndirectSqwModel.h
@@ -1,0 +1,56 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2022 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#pragma once
+
+#include "DllConfig.h"
+#include "IndirectDataValidationHelper.h"
+#include "MantidQtWidgets/Common/BatchAlgorithmRunner.h"
+#include "MantidQtWidgets/Common/QtPropertyBrowser/QtTreePropertyBrowser"
+#include <typeinfo>
+
+using namespace Mantid::API;
+
+namespace MantidQt {
+namespace CustomInterfaces {
+
+class MANTIDQT_INDIRECT_DLL IndirectSqwModel {
+
+public:
+  IndirectSqwModel();
+  ~IndirectSqwModel() = default;
+  void setupRebinAlgorithm(MantidQt::API::BatchAlgorithmRunner *batchAlgoRunner);
+  void setupSofQWAlgorithm(MantidQt::API::BatchAlgorithmRunner *batchAlgoRunner);
+  void setupAddSampleLogAlgorithm(MantidQt::API::BatchAlgorithmRunner *batchAlgoRunner);
+  void setInputWorkspace(const std::string &workspace);
+  void setQMin(double qMin);
+  void setQWidth(double qWidth);
+  void setQMax(double qMax);
+  void setEMin(double eMin);
+  void setEWidth(double eWidth);
+  void setEMax(double eMax);
+  void setEFixed(std::string eFixed);
+  void setRebinInEnergy(bool scale);
+  std::string getOutputWorkspace();
+  MatrixWorkspace_sptr getRqwWorkspace();
+  UserInputValidator validate(std::tuple<double, double> const qRange, std::tuple<double, double> const eRange);
+  std::pair<double, double> roundToWidth(std::tuple<double, double> const &axisRange, double width);
+
+private:
+  std::string m_inputWorkspace;
+  std::string m_outputWorkspaceName;
+  std::string m_eFixed;
+  double m_scaleValue;
+  double m_qLow;
+  double m_qWidth = 0.05;
+  double m_qHigh;
+  double m_eLow;
+  double m_eWidth = 0.005;
+  double m_eHigh;
+  bool m_rebinInEnergy;
+};
+} // namespace CustomInterfaces
+} // namespace MantidQt

--- a/qt/scientific_interfaces/Indirect/IndirectSqwModel.h
+++ b/qt/scientific_interfaces/Indirect/IndirectSqwModel.h
@@ -43,7 +43,6 @@ private:
   std::string m_inputWorkspace;
   std::string m_baseName;
   std::string m_eFixed;
-  double m_scaleValue;
   double m_qLow;
   double m_qWidth = 0.05;
   double m_qHigh;

--- a/qt/scientific_interfaces/Indirect/IndirectSqwView.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectSqwView.cpp
@@ -1,0 +1,126 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2022 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#include "IndirectSqwView.h"
+#include "IndirectDataValidationHelper.h"
+
+#include "MantidAPI/AlgorithmManager.h"
+#include "MantidAPI/MatrixWorkspace.h"
+#include "MantidAPI/WorkspaceGroup.h"
+#include "MantidQtWidgets/Common/UserInputValidator.h"
+
+#include <QDoubleValidator>
+#include <QFileInfo>
+
+using namespace IndirectDataValidationHelper;
+using namespace Mantid::API;
+
+namespace {
+double roundToPrecision(double value, double precision) { return value - std::remainder(value, precision); }
+
+std::pair<double, double> roundToWidth(std::tuple<double, double> const &axisRange, double width) {
+  return std::make_pair(roundToPrecision(std::get<0>(axisRange), width) + width,
+                        roundToPrecision(std::get<1>(axisRange), width) - width);
+}
+} // namespace
+
+namespace MantidQt::CustomInterfaces {
+
+//----------------------------------------------------------------------------------------------
+/** Constructor
+ */
+IndirectSqwView::IndirectSqwView(QWidget *parent) {
+  m_uiForm.setupUi(parent);
+  m_dblManager = new QtDoublePropertyManager();
+  m_dblEdFac = new DoubleEditorFactory(this);
+
+  m_uiForm.rqwPlot2D->setCanvasColour(QColor(240, 240, 240));
+
+  connect(m_uiForm.dsInput, SIGNAL(dataReady(QString const &)), this, SIGNAL(dataReady(QString const &)));
+  connect(m_uiForm.spQLow, SIGNAL(valueChanged(double)), this, SIGNAL(qLowChanged(double)));
+  connect(m_uiForm.spQWidth, SIGNAL(valueChanged(double)), this, SIGNAL(qWidthChanged(double)));
+  connect(m_uiForm.spQHigh, SIGNAL(valueChanged(double)), this, SIGNAL(qHighChanged(double)));
+  connect(m_uiForm.spELow, SIGNAL(valueChanged(double)), this, SIGNAL(eLowChanged(double)));
+  connect(m_uiForm.spEWidth, SIGNAL(valueChanged(double)), this, SIGNAL(eWidthChanged(double)));
+  connect(m_uiForm.spEHigh, SIGNAL(valueChanged(double)), this, SIGNAL(eHighChanged(double)));
+  connect(m_uiForm.ckRebinInEnergy, SIGNAL(stateChanged(int)), this, SIGNAL(rebinEChanged(int)));
+
+  connect(m_uiForm.pbRun, SIGNAL(clicked()), this, SIGNAL(runClicked()));
+  connect(m_uiForm.pbSave, SIGNAL(clicked()), this, SIGNAL(saveClicked()));
+
+  // Allows empty workspace selector when initially selected
+  m_uiForm.dsInput->isOptional(true);
+
+  // Disables searching for run files in the data archive
+  m_uiForm.dsInput->isForRunFiles(false);
+}
+
+//----------------------------------------------------------------------------------------------
+/** Destructor
+ */
+IndirectSqwView::~IndirectSqwView() {}
+
+IndirectPlotOptionsView *IndirectSqwView::getPlotOptions() { return m_uiForm.ipoPlotOptions; }
+
+std::string IndirectSqwView::getDataName() { return m_uiForm.dsInput->getCurrentDataName().toStdString(); }
+
+void IndirectSqwView::setFBSuffixes(QStringList suffix) { m_uiForm.dsInput->setFBSuffixes(suffix); }
+
+void IndirectSqwView::setWSSuffixes(QStringList suffix) { m_uiForm.dsInput->setWSSuffixes(suffix); }
+
+bool IndirectSqwView::validate() {
+  UserInputValidator uiv;
+  validateDataIsOfType(uiv, m_uiForm.dsInput, "Sample", DataType::Red);
+
+  auto const errorMessage = uiv.generateErrorMessage();
+  if (!errorMessage.isEmpty())
+    showMessageBox(errorMessage);
+  return errorMessage.isEmpty();
+}
+
+void IndirectSqwView::updateRunButton(bool enabled, std::string const &enableOutputButtons, QString const &message,
+                                      QString const &tooltip) {
+  setRunEnabled(enabled);
+  m_uiForm.pbRun->setText(message);
+  m_uiForm.pbRun->setToolTip(tooltip);
+  if (enableOutputButtons != "unchanged")
+    setSaveEnabled(enableOutputButtons == "enable");
+}
+
+void IndirectSqwView::setRunEnabled(bool enabled) { m_uiForm.pbRun->setEnabled(enabled); }
+
+void IndirectSqwView::setSaveEnabled(bool enabled) { m_uiForm.pbSave->setEnabled(enabled); }
+
+void IndirectSqwView::plotRqwContour(MatrixWorkspace_sptr rqwWorkspace) {
+  m_uiForm.rqwPlot2D->setWorkspace(rqwWorkspace);
+}
+
+void IndirectSqwView::setDefaultQAndEnergy() {
+  setQRange(m_uiForm.rqwPlot2D->getAxisRange(MantidWidgets::AxisID::YLeft));
+  setEnergyRange(m_uiForm.rqwPlot2D->getAxisRange(MantidWidgets::AxisID::XBottom));
+}
+
+void IndirectSqwView::setQRange(std::tuple<double, double> const &axisRange) {
+  auto const qRange = roundToWidth(axisRange, m_uiForm.spQWidth->value());
+  m_uiForm.spQLow->setValue(qRange.first);
+  m_uiForm.spQHigh->setValue(qRange.second);
+}
+
+void IndirectSqwView::setEnergyRange(std::tuple<double, double> const &axisRange) {
+  auto const energyRange = roundToWidth(axisRange, m_uiForm.spEWidth->value());
+  m_uiForm.spELow->setValue(energyRange.first);
+  m_uiForm.spEHigh->setValue(energyRange.second);
+}
+
+std::tuple<double, double> IndirectSqwView::getQRangeFromPlot() {
+  return m_uiForm.rqwPlot2D->getAxisRange(MantidWidgets::AxisID::YLeft);
+}
+
+std::tuple<double, double> IndirectSqwView::getERangeFromPlot() {
+  return m_uiForm.rqwPlot2D->getAxisRange(MantidWidgets::AxisID::XBottom);
+}
+
+} // namespace MantidQt::CustomInterfaces

--- a/qt/scientific_interfaces/Indirect/IndirectSqwView.h
+++ b/qt/scientific_interfaces/Indirect/IndirectSqwView.h
@@ -1,0 +1,70 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2022 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#pragma once
+
+#include "MantidAPI/MatrixWorkspace.h"
+#include "MantidQtWidgets/Common/QtPropertyBrowser/DoubleEditorFactory.h"
+#include "MantidQtWidgets/Common/QtPropertyBrowser/QtTreePropertyBrowser"
+#include "MantidQtWidgets/Common/QtPropertyBrowser/qtpropertymanager.h"
+#include "MantidQtWidgets/Plotting/RangeSelector.h"
+#include "ui_IndirectSqw.h"
+
+namespace MantidQt {
+namespace CustomInterfaces {
+
+class MANTIDQT_INDIRECT_DLL IndirectSqwView : public QWidget {
+  Q_OBJECT
+
+public:
+  IndirectSqwView(QWidget *perent = nullptr);
+  ~IndirectSqwView();
+
+  IndirectPlotOptionsView *getPlotOptions();
+  void setFBSuffixes(QStringList suffix);
+  void setWSSuffixes(QStringList suffix);
+  std::tuple<double, double> getQRangeFromPlot();
+  std::tuple<double, double> getERangeFromPlot();
+  std::string getDataName();
+  void plotRqwContour(Mantid::API::MatrixWorkspace_sptr rqwWorkspace);
+  void setDefaultQAndEnergy();
+  void setSaveEnabled(bool enabled);
+  bool validate();
+
+signals:
+  void valueChanged(QtProperty *, double);
+  void dataReady(QString const &);
+  void qLowChanged(double);
+  void qWidthChanged(double);
+  void qHighChanged(double);
+  void eLowChanged(double);
+  void eWidthChanged(double);
+  void eHighChanged(double);
+  void rebinEChanged(int);
+  void runClicked();
+  void saveClicked();
+  void showMessageBox(const QString &message);
+
+public slots:
+  void updateRunButton(bool enabled, std::string const &enableOutputButtons, QString const &message,
+                       QString const &tooltip);
+
+private:
+  void setQRange(std::tuple<double, double> const &axisRange);
+  void setEnergyRange(std::tuple<double, double> const &axisRange);
+
+  void setRunEnabled(bool enabled);
+  Ui::IndirectSqw m_uiForm;
+
+  /// Tree of the properties
+  std::map<QString, QtTreePropertyBrowser *> m_propTrees;
+  /// Internal list of the properties
+  QMap<QString, QtProperty *> m_properties;
+  DoubleEditorFactory *m_dblEdFac;
+  QtDoublePropertyManager *m_dblManager;
+};
+} // namespace CustomInterfaces
+} // namespace MantidQt

--- a/qt/scientific_interfaces/Indirect/test/CMakeLists.txt
+++ b/qt/scientific_interfaces/Indirect/test/CMakeLists.txt
@@ -23,6 +23,7 @@ set(TEST_FILES
     IndirectPlotOptionsPresenterTest.h
     IndirectSettingsModelTest.h
     IndirectSettingsPresenterTest.h
+    IndirectSqwModelTest.h
     IqtFitModelTest.h
 )
 

--- a/qt/scientific_interfaces/Indirect/test/IndirectMomentsModelTest.h
+++ b/qt/scientific_interfaces/Indirect/test/IndirectMomentsModelTest.h
@@ -26,7 +26,7 @@ public:
     // The Moments algorithm is a python algorithm and so can not be called in
     m_workspace = WorkspaceCreationHelper::create2DWorkspace(5, 4);
     Mantid::API::AnalysisDataService::Instance().addOrReplace("Workspace_name_sqw", m_workspace);
-    m_model->setInputWorkspace("Workspace_name");
+    m_model->setInputWorkspace("Workspace_name_sqw");
     m_model->setEMin(-0.4);
     m_model->setEMax(0.4);
     m_model->setScale(false);

--- a/qt/scientific_interfaces/Indirect/test/IndirectSqwModelTest.h
+++ b/qt/scientific_interfaces/Indirect/test/IndirectSqwModelTest.h
@@ -1,0 +1,89 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2019 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#pragma once
+
+#include "IndirectDataValidationHelper.h"
+#include "IndirectSqwModel.h"
+#include "MantidAPI/AnalysisDataService.h"
+#include "MantidFrameworkTestHelpers/WorkspaceCreationHelper.h"
+#include <cxxtest/TestSuite.h>
+#include <gmock/gmock.h>
+
+using namespace MantidQt::CustomInterfaces;
+
+class IndirectSqwModelTest : public CxxTest::TestSuite {
+public:
+  /// Needed to make sure everything is initialized
+  IndirectSqwModelTest() = default;
+
+  void setUp() override { m_model = std::make_unique<IndirectSqwModel>(); }
+
+  void test_algorrithm_set_up() {
+    // The Moments algorithm is a python algorithm and so can not be called in
+    m_workspace = WorkspaceCreationHelper::create2DWorkspace(5, 4);
+    Mantid::API::AnalysisDataService::Instance().addOrReplace("Workspace_name_red", m_workspace);
+    m_model->setInputWorkspace("Workspace_name_red");
+    m_model->setEMin(-0.4);
+    m_model->setEWidth(0.005);
+    m_model->setEMax(0.4);
+    m_model->setQMin(0.8);
+    m_model->setQWidth(0.05);
+    m_model->setQMax(1.8);
+    m_model->setEFixed("0.4");
+    m_model->setRebinInEnergy(true);
+  }
+
+  void test_output_workspace() {
+    m_model->setInputWorkspace("Workspace_name_red");
+    auto outputWorkspaceName = m_model->getOutputWorkspace();
+    TS_ASSERT(outputWorkspaceName == "Workspace_name_sqw");
+  }
+
+  void test_setupRebinAlgorithm() {
+    MantidQt::API::BatchAlgorithmRunner batch;
+    m_model->setInputWorkspace("Workspace_name_red");
+    m_model->setEMin(-0.4);
+    m_model->setEWidth(0.005);
+    m_model->setEMax(0.4);
+    m_model->setRebinInEnergy(true);
+    m_model->setupRebinAlgorithm(&batch);
+    batch.executeBatch();
+  }
+
+  void test_setupRebinAlgorithmFalse() {
+    MantidQt::API::BatchAlgorithmRunner batch;
+    m_model->setInputWorkspace("Workspace_name_red");
+    m_model->setEMin(-0.4);
+    m_model->setEWidth(0.005);
+    m_model->setEMax(0.4);
+    m_model->setRebinInEnergy(false);
+    m_model->setupRebinAlgorithm(&batch);
+    batch.executeBatch();
+  }
+
+  void test_setupSofQWAlgorithm() {
+    MantidQt::API::BatchAlgorithmRunner batch;
+    m_model->setInputWorkspace("Workspace_name_red");
+    m_model->setQMin(0.8);
+    m_model->setQWidth(0.05);
+    m_model->setQMax(1.8);
+    m_model->setEFixed("0.4");
+    m_model->setupSofQWAlgorithm(&batch);
+    batch.executeBatch();
+  }
+
+  void test_setupAddSampleLogAlgorithm() {
+    MantidQt::API::BatchAlgorithmRunner batch;
+    m_model->setInputWorkspace("Workspace_name_red");
+    m_model->setupAddSampleLogAlgorithm(&batch);
+    batch.executeBatch();
+  }
+
+private:
+  MatrixWorkspace_sptr m_workspace;
+  std::unique_ptr<IndirectSqwModel> m_model;
+};


### PR DESCRIPTION
**Description of work.**

This PR is to make the Indirect S(Q, omega) tab MVP compliant. currently as it is part of the IndirectDataReduction interface It is required to inherit from the IndirectDataReductionTab object, this means that the algorithm running is still being done in the presenter, and tests for the presenter can not be written.

**To test:**

1. open the indirect data reduction interface.
2. go to the Sqw tab. 
3. Load _red data.
4. check that the preview plot has worked and ranges for Q and E are set to the range of the data.
8. check rebin in energy and change the Q and E ranges to be smaller that the data ranges.
6. Click the run button.
7. Check the sqw workspace generated and check that the data range is the same as set in the interface.
8. uncheck rebin in energy and run again. check the energy range in the output has not been rebinned.

Fixes #33678

*This does not require release notes* because It is all internal chagnes, it should not be noticed by users.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
