### PR TITLE
Use `ipython.exe` in `mantidpython.bat`

### DIFF
--- a/buildconfig/CMake/MSVCSetup.cmake
+++ b/buildconfig/CMake/MSVCSetup.cmake
@@ -162,8 +162,6 @@ endif()
 # Configure Mantid startup scripts
 # ######################################################################################################################
 set(PACKAGING_DIR ${PROJECT_SOURCE_DIR}/buildconfig/CMake/Packaging)
-# build version
-set(MANTIDPYTHON_PREAMBLE "set PYTHONHOME=${MSVC_PYTHON_EXECUTABLE_DIR}\nset PATH=%_BIN_DIR%;%PATH%")
 
 configure_file(${PACKAGING_DIR}/mantidpython.bat.in ${PROJECT_BINARY_DIR}/mantidpython.bat.in @ONLY)
 # place it in the appropriate directory
@@ -172,8 +170,6 @@ file(
   OUTPUT ${MSVC_BIN_DIR}/mantidpython.bat
   INPUT ${PROJECT_BINARY_DIR}/mantidpython.bat.in
 )
-# install version
-set(MANTIDPYTHON_PREAMBLE "set PYTHONHOME=%_BIN_DIR%\nset PATH=%_BIN_DIR%;%_BIN_DIR%\\..\\plugins;%PATH%")
 
 configure_file(${PACKAGING_DIR}/mantidpython.bat.in ${PROJECT_BINARY_DIR}/mantidpython.bat.install @ONLY)
 

--- a/buildconfig/CMake/Packaging/mantidpython.bat.in
+++ b/buildconfig/CMake/Packaging/mantidpython.bat.in
@@ -22,7 +22,7 @@ set PYTHONPATH=%_BIN_DIR%;%_sip_dir%;%PYTHONPATH%
 
 :: Python drivers
 set _PYTHON_EXE=%PYTHONHOME%\python.exe
-set _IPYTHON_CMD=%PYTHONHOME%\Scripts\ipython.cmd
+set _IPYTHON_EXE=%PYTHONHOME%\Scripts\ipython.exe
 
 :: QtPy should use Qt5 by unless specified
 if "%QT_API%"=="" (
@@ -47,7 +47,7 @@ if "%1"=="--classic" (
 )
 
 :: Start ipython and pass through all arguments to it
-start "Mantid Python" /B /WAIT %_IPYTHON_CMD% %*
+start "Mantid Python" /B /WAIT %_IPYTHON_EXE% %*
 if %ERRORLEVEL% NEQ 0 exit /B %ERRORLEVEL%
 goto TheEnd
 

--- a/buildconfig/CMake/Packaging/mantidpython.bat.in
+++ b/buildconfig/CMake/Packaging/mantidpython.bat.in
@@ -12,17 +12,14 @@ set _SCRIPT_DIR=%~dp0
 set _BIN_DIR=%_SCRIPT_DIR:~,-1%
 
 :: Set paths for dependencies, including Python
-@MANTIDPYTHON_PREAMBLE@
+set PATH=%_BIN_DIR%;%PATH%
+set PYTHONPATH=%_BIN_DIR%;%PYTHONPATH%
 
-if exist "%PYTHONHOME%\Lib\site-packages\PyQt4\sip.pyd" (
-  set _sip_dir=%PYTHONHOME%\Lib\site-packages\PyQt4
-)
-
-set PYTHONPATH=%_BIN_DIR%;%_sip_dir%;%PYTHONPATH%
+set CONDA_BASE=@CONDA_BASE_DIR@
 
 :: Python drivers
-set _PYTHON_EXE=%PYTHONHOME%\python.exe
-set _IPYTHON_EXE=%PYTHONHOME%\Scripts\ipython.exe
+set _PYTHON_EXE=%CONDA_BASE%\python.exe
+set _IPYTHON_EXE=%CONDA_BASE%\Scripts\ipython.exe
 
 :: QtPy should use Qt5 by unless specified
 if "%QT_API%"=="" (


### PR DESCRIPTION
**Description of work.**
This PR switches the use of `ipython.cmd` for `ipython.exe` as the `ipython.cmd` doesn't seem to be in the expected location.

**To test:**

1. Build this branch starting from an empty build folder
2. Create a test script which has a mantid import
3. Run this script with 
```
bin\\Debug\\mantidpython.bat --classic <full_path_to>/test_script.py
```
4. There shouldn't be an error about a missing file called `ipython.cmd`

*This does not require release notes* because **only affects developers**

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
