### PR TITLE
Allow wavlength ranges in WavRangeReduction

### DIFF
--- a/Testing/SystemTests/tests/framework/ISIS/SANS/ZOOM/ZOOMWavLoopsTest.py
+++ b/Testing/SystemTests/tests/framework/ISIS/SANS/ZOOM/ZOOMWavLoopsTest.py
@@ -9,6 +9,7 @@ from sans.command_interface.ISISCommandInterface import (ZOOM, MaskFile, Set1D, 
                                                          UseCompatibilityMode, WavRangeReduction)
 from sans.common.enums import SANSInstrument
 from systemtesting import MantidSystemTest
+import unittest
 
 
 @ISISSansSystemTest(SANSInstrument.ZOOM)
@@ -25,3 +26,53 @@ class ZOOMWavLoopsTest(MantidSystemTest):
     def validate(self):
         self.disableChecking.append('Instrument')
         return '16182_rear_1D_1.75_16.5', 'ZOOM_16182_Userfile.nxs'
+
+
+@ISISSansSystemTest(SANSInstrument.ZOOM)
+class ZOOMWavRangeReductionLoopsTest(MantidSystemTest):
+    """This test uses a user file without multiple wavelength ranges, but sets multiple wavelength ranges in the call
+    to WavRangeReduction"""
+    def runTest(self):
+        UseCompatibilityMode()
+        ZOOM()
+        MaskFile("16812_Userfile.toml")
+        Set1D()
+
+        AssignSample('16182')
+        WavRangeReduction([1.75, 6.5, 10.75], [6.5, 10.75, 16.5])
+
+    def validate(self):
+        self.disableChecking.append('Instrument')
+        return '16182_rear_1D_1.75_16.5', 'ZOOM_16182_Userfile.nxs'
+
+
+@ISISSansSystemTest(SANSInstrument.ZOOM)
+class ZOOMWavRangeReductionValidation(unittest.TestCase):
+    """These tests check the validation in WavRangeReduction fails as expected"""
+    def setUp(self):
+        UseCompatibilityMode()
+        ZOOM()
+        MaskFile("16812_Userfile.toml")
+        Set1D()
+
+        AssignSample('16182')
+
+    def test_throws_if_first_input_is_list_and_other_is_not_set(self):
+        start = [1.75, 6.5, 10.75]
+        end = [6.5, 10.75, 16.5]
+        self.assertRaises(RuntimeError, WavRangeReduction, start, end)
+
+    def test_throws_if_second_input_is_list_and_other_is_not_set(self):
+        start = None
+        end = [6.5, 10.75, 16.5]
+        self.assertRaises(RuntimeError, WavRangeReduction, start, end)
+
+    def test_throws_if_first_input_is_list_and_other_is_not(self):
+        start = [1.75, 6.5, 10.75]
+        end = 16.5
+        self.assertRaises(RuntimeError, WavRangeReduction, start, end)
+
+    def test_throws_if_second_input_is_list_and_other_is_not(self):
+        start = 1.75
+        end = [6.5, 10.75, 16.5]
+        self.assertRaises(RuntimeError, WavRangeReduction, start, end)

--- a/docs/source/release/v6.5.0/SANS/New_features/34335.rst
+++ b/docs/source/release/v6.5.0/SANS/New_features/34335.rst
@@ -1,0 +1,1 @@
+- Multiple wavelength ranges can now be processed in a single call to ``WavRangeReduction``. This is more efficient than calling the function separately for each range. To do this, pass the start/end values as lists, e.g. for ranges "1-2, 3-4, 5-6" pass ``wav_start=[1, 3, 5]`` and ``wav_end=[2, 4, 6]``.

--- a/scripts/SANS/sans/command_interface/ISISCommandInterface.py
+++ b/scripts/SANS/sans/command_interface/ISISCommandInterface.py
@@ -713,6 +713,34 @@ def SetDetectorOffsets(bank, x, y, z, rot, radius, side, xtilt=0.0, ytilt=0.0):
     director.add_command(detector_offsets)
 
 
+def _validate_wavrange_types(start, end):
+    def is_set(val):
+        return val is not None
+
+    def is_list(val):
+        return is_set(val) and isinstance(val, list)
+
+    # If one input is a list, they must both be lists of the same length
+    if is_list(start) != is_list(end):
+        raise RuntimeError("WavRangeReduction: The wav_start and wav_end inputs must both be the same type (got"
+                           " a mixture of single value and list)")
+    if is_list(start) and is_list(end) and len(start) != len(end):
+        raise RuntimeError("WavRangeReduction: the wav_start and wav_end inputs must contain the same number of values")
+
+    # Ensure values are stored as floats
+    if is_list(start):
+        start = [float(wav) for wav in start]
+    elif is_set(start):
+        start = float(start)
+
+    if is_list(end):
+        end = [float(wav) for wav in end]
+    elif is_set(end):
+        end = float(end)
+
+    return start, end
+
+
 # --------------------------------------------
 # Commands which actually kick off a reduction
 # --------------------------------------------
@@ -768,11 +796,7 @@ def WavRangeReduction(wav_start=None, wav_end=None, full_trans_wav=None, name_su
         raise RuntimeError("WavRangeReduction: The combineDet input parameter was given a value of {0}. rear, front,"
                            " both, merged and no input are allowed".format(combineDet))
 
-    if wav_start is not None:
-        wav_start = float(wav_start)
-
-    if wav_end is not None:
-        wav_end = float(wav_end)
+    wav_start, wav_end = _validate_wavrange_types(wav_start, wav_end)
 
     wavelength_command = NParameterCommand(command_id=NParameterCommandId.WAV_RANGE_SETTINGS,
                                            values=[wav_start, wav_end, full_trans_wav, reduction_mode])

--- a/scripts/SANS/sans/state/StateObjects/StateWavelength.py
+++ b/scripts/SANS/sans/state/StateObjects/StateWavelength.py
@@ -33,6 +33,16 @@ class StateWavelength(metaclass=JsonSerializable):
             RangeStepType.NOT_SET
         return result
 
+    @property
+    def wavelength_step_type_range(self):
+        # Return the wavelength step type, converting LIN/LOG to
+        # RANGE_LIN/RANGE_LOG.
+        value = self.wavelength_step_type
+        result = RangeStepType.RANGE_LIN if value in [RangeStepType.LIN, RangeStepType.RANGE_LIN] else \
+            RangeStepType.RANGE_LOG if value in [RangeStepType.LOG, RangeStepType.RANGE_LOG] else \
+            RangeStepType.NOT_SET
+        return result
+
     def validate(self):
         is_invalid = dict()
         if one_is_none([self.wavelength_interval]):

--- a/scripts/test/SANS/state/wavelength_test.py
+++ b/scripts/test/SANS/state/wavelength_test.py
@@ -46,6 +46,26 @@ class StateWavelengthTest(unittest.TestCase):
         state.wavelength_step_type = RangeStepType.NOT_SET
         self.assertEqual(state.wavelength_step_type_lin_log,  RangeStepType.NOT_SET)
 
+    def test_convert_step_type_from_LIN_to_RANGE_LIN(self):
+        state = StateWavelength()
+        state.wavelength_step_type = RangeStepType.LIN
+        self.assertEqual(state.wavelength_step_type_range,  RangeStepType.RANGE_LIN)
+
+    def test_convert_step_type_from_LOG_to_RANGE_LOG(self):
+        state = StateWavelength()
+        state.wavelength_step_type = RangeStepType.LOG
+        self.assertEqual(state.wavelength_step_type_range,  RangeStepType.RANGE_LOG)
+
+    def test_convert_step_type_does_not_change_RANGE_LIN(self):
+        state = StateWavelength()
+        state.wavelength_step_type = RangeStepType.RANGE_LIN
+        self.assertEqual(state.wavelength_step_type_range,  RangeStepType.RANGE_LIN)
+
+    def test_convert_step_type_does_not_change_RANGE_LOG(self):
+        state = StateWavelength()
+        state.wavelength_step_type = RangeStepType.RANGE_LOG
+        self.assertEqual(state.wavelength_step_type_range,  RangeStepType.RANGE_LOG)
+
 
 # ----------------------------------------------------------------------------------------------------------------------
 # Builder


### PR DESCRIPTION
**Report to:** @rmdalgliesh 

This allows the user to specify a list of start/end wavelength values in WavRangeReduction so that the wavelengths ranges will be processed more efficiently than calling this function separately for each range. There is a modification to the command interface to accept these lists and set the relevant state (which already supports multiple ranges)

Fixes #34202

**To test:**

- Ensure the ISIS archive is enabled in Mantid
- Ensure you have the archive mounted on your machine
- Save this file; if you are not on Windows, change the hard-coded paths to where the archive is mounted on your machine
- Run the following two scripts and compare the output to see how long each took.
  - You'll need to save these toml files and update the scripts with the relevant paths: [toml_files.zip](https://github.com/mantidproject/mantid/files/9536630/toml_files.zip)
  - **Delete the outputs after the first one before running the second.**
  - The second one should be around 2 or 3 times quicker. They should both produce 4 workspaces - one for each of the 3 ranges plus one for the overall range (they will be ungrouped in the separate reductions but grouped in the multi-range reduction):
![image](https://user-images.githubusercontent.com/12895056/189871984-e5d138ea-0584-48ba-85c9-5e6e6a5d575d.png)
  - The third script is an equivalent reduction to the multi-ranges one done via setting the ranges in the user file. This should run in a similar time to the list reduction.

```
from sans.command_interface.ISISCommandInterface import (ZOOM, MaskFile, Set1D, AssignSample, UseCompatibilityMode, WavRangeReduction)
import time

# Set up
UseCompatibilityMode()
ZOOM()
MaskFile("C:/Users/mhb52947/work/data/mantid/16812_Userfile.toml")
Set1D()
AssignSample('16182')

# Define some wavelength ranges
wavelength_list = [1.75, 6.5, 10.75, 16.5]

# Run each range separately in a loop
t1 = time.time()
print("STARTING SEPARATE REDUCTIONS")
for i in range(len(wavelength_list)-1):
    WavRangeReduction(wavelength_list[i], wavelength_list[i+1])

# Also need to run for the overall range
WavRangeReduction(wavelength_list[0], wavelength_list[-1])

t2 = time.time()
print("SEPARATE REDUCTIONS TOOK:", t2 - t1, "SECONDS")
```

```
from sans.command_interface.ISISCommandInterface import (ZOOM, MaskFile, Set1D, AssignSample, UseCompatibilityMode, WavRangeReduction)
import time

# Set up
UseCompatibilityMode()
ZOOM()
MaskFile("C:/Users/mhb52947/work/data/mantid/16812_Userfile.toml")
Set1D()
AssignSample('16182')

# Define some wavelength ranges
wavelength_list = [1.75, 6.5, 10.75, 16.5]

# Run in one go with list inputs
wav_start = []
wav_end = []
for i in range(len(wavelength_list)-1):
    wav_start.append(wavelength_list[i])
    wav_end.append(wavelength_list[i+1])

t1 = time.time()
print("STARTING LIST REDUCTION")
WavRangeReduction(wav_start, wav_end)
t2 = time.time()
print("LIST REDUCTION TOOK:", t2 - t1, "SECONDS")
```

```
from sans.command_interface.ISISCommandInterface import (ZOOM, MaskFile, Set1D, AssignSample, UseCompatibilityMode, WavRangeReduction)
import time

# Set up
UseCompatibilityMode()
ZOOM()
MaskFile("C:/Users/mhb52947/work/data/mantid/16812_Userfile_wav_loops.toml")
Set1D()
AssignSample('16182')

t1 = time.time()
print("STARTING USERFILE REDUCTION")
WavRangeReduction()
t2 = time.time()
print("USERFILE REDUCTION TOOK:", t2 - t1, "SECONDS")
```

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
