### PR TITLE
SliceViewer: Fix a bug when workspaces are replaced from an algorithm with more than 1 output

### DIFF
--- a/docs/source/release/v6.5.0/Workbench/SliceViewer/Bugfixes/34337.rst
+++ b/docs/source/release/v6.5.0/Workbench/SliceViewer/Bugfixes/34337.rst
@@ -1,0 +1,2 @@
+- Fixes a bug in the SliceViewer where a workspace is replaced by an algorithm
+  with more than one output workspace.

--- a/qt/python/mantidqt/mantidqt/utils/qt/qappthreadcall.py
+++ b/qt/python/mantidqt/mantidqt/utils/qt/qappthreadcall.py
@@ -7,9 +7,12 @@
 import functools
 import inspect
 import sys
+from typing import Any, Callable, Optional, Sequence
 
 from qtpy.QtCore import Qt, QMetaObject, QObject, QThread, Slot
 from qtpy.QtWidgets import QApplication
+
+from mantid.py36compat import dataclass
 
 
 class QAppThreadCall(QObject):
@@ -18,25 +21,42 @@ class QAppThreadCall(QObject):
     on the same thread as the qApp object. If QApplication does not yet exist
     at the point of call then a direct call is made
     """
-    __slots__ = ["callee", "_args", "_kwargs", "_result", "_exc_info", "_moved_to_app"]
+
+    @dataclass
+    class CallArgs:
+        """Encapsulate the arguments to a callable"""
+        args: list
+
+    @dataclass
+    class CallResult:
+        """Encapsulate the result of a object call"""
+        result: Any
+        exc_info: Optional[tuple]
 
     @staticmethod
-    def is_qapp_thread():
+    def is_qapp_thread() -> bool:
         """Returns True iff a QApplication instance exists and the current
         thread matches the thread the QApplication was created in
         """
         qapp = QApplication.instance()
         return qapp is None or (QThread.currentThread() == qapp.thread())
 
-    def __init__(self, callee, blocking=True):
-        QObject.__init__(self)
-        self.callee = callee
-        self.blocking = blocking
-        functools.update_wrapper(self.__call__.__func__, callee)
-        self._moved_to_app = False
-        self._store_function_args(None, None)
+    __slots__ = ["_callable", "_blocking", "_moved_to_app", "_pending_calls", "_completed_calls"]
 
-    def __call__(self, *args, **kwargs):
+    def __init__(self, callable: Callable, blocking: bool = True):
+        """
+        :param callable: A callable that should be executed on the QApplication thread
+        :param blocking: If True, the asynchronous call will block until completed
+        """
+        super().__init__()
+        functools.update_wrapper(self.__call__.__func__, callable)
+
+        self._callable = callable
+        self._blocking = blocking
+        self._moved_to_app = False
+        self._pending_calls, self._completed_calls = [], []
+
+    def __call__(self, *args: Sequence) -> Any:
         """
         If the current thread is the qApp thread then this
         performs a straight call to the wrapped callable_obj. Otherwise
@@ -44,26 +64,49 @@ class QAppThreadCall(QObject):
         BlockingQueuedConnection.
         """
         if self.is_qapp_thread():
-            return self.callee(*args, **kwargs)
+            return self._callable(*args)
         else:
             self._ensure_self_on_qapp_thread()
-            self._store_function_args(args, kwargs)
-            connection_type = Qt.BlockingQueuedConnection if self.blocking else Qt.AutoConnection
-            QMetaObject.invokeMethod(self, "on_call", connection_type)
-            if self._exc_info is not None:
-                raise self._exc_info[1].with_traceback(self._exc_info[2])
-            return self._result
+            connection_type = Qt.BlockingQueuedConnection if self._blocking else Qt.AutoConnection
+
+            # A given object wraps a single callable. If calls are non-blocking
+            # then a second call can enter this method before the previous has
+            # had time to perform _on_call. Queue up the arguments to ensure
+            # they are processed in the correct order. This method and _on_call
+            # are very closely tied together. We append arguments to the end of a pending list
+            # and pop results from the front of a results list. _on_call must understand
+            # this ordering too.
+            self._pending_calls.append(QAppThreadCall.CallArgs(args))
+            QMetaObject.invokeMethod(self, "_on_call", connection_type)
+
+            # Only return/re-raise exceptions in the blocking case or else the
+            # user has moved on
+            if self._blocking:
+                call_result = self._completed_calls.pop(0)
+                if call_result.exc_info is not None:
+                    raise call_result.exc_info[1].with_traceback(call_result.exc_info[2])
+                else:
+                    return call_result.result
+            else:
+                # It makes little sense to return anything from a non-blocking call
+                # as the client cannot have waited for it
+                return None
 
     @Slot()
-    def on_call(self):
+    def _on_call(self) -> None:
         """Perform a call to a GUI function across a
-        thread and return the result
+        thread. All exceptions are caught internally and stored to be propagated
         """
+        # Changes to this method will very likely require changes to the __call__
+        # method, especially w.r.t how the arguments and results are queued.
+        result, exc_info = None, None
         try:
-            self._result = \
-                self.callee(*self._args, **self._kwargs)
+            call_info = self._pending_calls.pop(0)
+            result = self._callable(*call_info.args)
         except Exception:  # pylint: disable=broad-except
-            self._exc_info = sys.exc_info()
+            exc_info = sys.exc_info()
+
+        self._completed_calls.append(QAppThreadCall.CallResult(result, exc_info))
 
     # private api
     def _ensure_self_on_qapp_thread(self):
@@ -74,14 +117,6 @@ class QAppThreadCall(QObject):
 
         self.moveToThread(QApplication.instance().thread())
         self._moved_to_app = True
-
-    def _store_function_args(self, args, kwargs):
-        """
-        Store arguments for future function call and reset result/exception info
-        from previous call
-        """
-        self._args, self._kwargs = args, kwargs
-        self._result, self._exc_info = None, None
 
 
 def force_method_calls_to_qapp_thread(instance, *, all_methods=False):

--- a/qt/python/mantidqt/mantidqt/utils/qt/test/test_qappthreadcall.py
+++ b/qt/python/mantidqt/mantidqt/utils/qt/test/test_qappthreadcall.py
@@ -6,7 +6,6 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 #  This file is part of the mantid workbench.
 #
-#
 import unittest
 
 from qtpy.QtWidgets import QApplication
@@ -16,14 +15,59 @@ from mantidqt.utils.qt.qappthreadcall import QAppThreadCall, force_method_calls_
 from mantidqt.utils.qt.testing import start_qapplication
 
 
+# Helper functions for various task scenarios
 class CustomException(Exception):
     pass
 
 
+def raises_exception():
+    raise CustomException()
+
+
 @start_qapplication
 class QAppThreadCallTest(unittest.TestCase):
+
+    def test_successive_non_blocking_calls_receive_expected_arguments(self):
+        self.do_successive_call_with_expected_args_test(blocking=True)
+
+    def test_successive_blocking_calls_receive_expected_arguments(self):
+        self.do_successive_call_with_expected_args_test(blocking=False)
+
+    def do_successive_call_with_expected_args_test(self, blocking: bool):
+        # scenario: Test calling a callable from a separate thread with successive arguments
+        # Simple add function taking successive pairs of arguments.
+        input_args = ((1, 2), (4, 3))
+        called_args = []
+
+        def add(lhs, rhs):
+            called_args.append((lhs, rhs))
+            return lhs + rhs
+
+        # Wrap the callable with our wrapper
+        wrapped_add = QAppThreadCall(add, blocking=blocking)
+
+        # Define an outer function that is the entrypoint for the new thread
+        def add_inputs():
+            for arg in input_args:
+                wrapped_add(*arg)
+
+        # Start async task to do the addition and simulate
+        thread = AsyncTask(add_inputs, error_cb=lambda x: self.fail(msg=str(x.exc_value)))
+        thread.start()
+        while thread.is_alive():
+            QApplication.sendPostedEvents()
+        thread.join()
+        QApplication.sendPostedEvents()
+
+        # Assert correct ordering
+        self.assertEqual(len(called_args),
+                         len(input_args),
+                         msg="Number of called arguments does not match the expected number of input arguments")
+        for input_arg, called_arg in zip(input_args, called_args):
+            self.assertEqual(input_arg, called_arg)
+
     def test_correct_exception_is_raised_when_called_on_main_thread(self):
-        qappthread_wrap = QAppThreadCall(self.raises_exception)
+        qappthread_wrap = QAppThreadCall(raises_exception)
 
         self.assertRaises(CustomException, qappthread_wrap)
 
@@ -34,23 +78,23 @@ class QAppThreadCallTest(unittest.TestCase):
         def collect_error(e):
             self.exc = e
 
-        thread = AsyncTask(self.task, error_cb=collect_error)
+        def raise_an_error_on_qapp_thread():
+            qappthread_wrap = QAppThreadCall(raises_exception)
+            qappthread_wrap()
+
+        thread = AsyncTask(raise_an_error_on_qapp_thread, error_cb=collect_error)
         thread.start()
         while thread.is_alive():
             QApplication.sendPostedEvents()
         thread.join(0.5)
-        self.assertTrue(isinstance(self.exc.exc_value, CustomException))
+
         self.assertEqual(TaskExitCode.ERROR, thread.exit_code)
-
-    def raises_exception(self):
-        raise CustomException()
-
-    def task(self):
-        qappthread_wrap = QAppThreadCall(self.raises_exception)
-        qappthread_wrap()
+        self.assertTrue(isinstance(self.exc.exc_value, CustomException), msg=f"Expected CustomException, found {self.exc.exc_value}")
 
     def test_force_method_calls_to_qapp_thread(self):
+
         class Impl:
+
             def public(self):
                 pass
 
@@ -64,3 +108,7 @@ class QAppThreadCallTest(unittest.TestCase):
         all_methods = force_method_calls_to_qapp_thread(Impl(), all_methods=True)
         self.assertTrue(isinstance(all_methods.public, QAppThreadCall))
         self.assertTrue(isinstance(all_methods._private, QAppThreadCall))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
**Description of work.**

Fix a bug with the ordering of arguments when a method call was made from a no-gui to the gui thread.

See the first commit details for a fuller description.

**To test:**

See the original issue and the problem should be fixed.
Examine the unit test to confirm it covers the case.
Try the case in #31367 to confirm the bug has not reemerged.

Fixes #34125

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
