### PR TITLE
Add check to see if the rectangular detector ids are in the workspace

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ReflectometryISISLoadAndProcess.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ReflectometryISISLoadAndProcess.py
@@ -247,8 +247,7 @@ class ReflectometryISISLoadAndProcess(DataProcessorAlgorithm):
                 alg.execute()
         return output_workspace_names
 
-    @staticmethod
-    def _has_single_2D_rectangular_detector(workspace) -> bool:
+    def _has_single_2D_rectangular_detector(self, workspace) -> bool:
         """Returns true if workspace has a single 2D rectangular detector, and is not a group workspace."""
         is_group = isinstance(workspace, WorkspaceGroup)
         if is_group:
@@ -271,7 +270,23 @@ class ReflectometryISISLoadAndProcess(DataProcessorAlgorithm):
         if is_group:
             raise NotImplementedError("Not implemented for a WorkspaceGroup containing 2D detectors.")
 
+        if not self._spectra_refer_to_rectangular_detector(workspace, rect_detectors[0]):
+            return False
+
         return True
+
+    @staticmethod
+    def _spectra_refer_to_rectangular_detector(workspace, rectangular_detector) -> bool:
+        """Returns true if the detectors in a rectangular bank are found in a workspace."""
+        def _safe_get_id(ws_index):
+            try:
+                return workspace.getDetector(ws_index).getID()
+            except Exception:
+                return None
+
+        workspace_det_ids = [_safe_get_id(i) for i in range(workspace.getNumberHistograms())]
+        return all(det_id in workspace_det_ids for det_id in [rectangular_detector.minDetectorID(),
+                                                              rectangular_detector.maxDetectorID()])
 
     def _prefixedName(self, name, isTrans):
         """Add a prefix for TOF workspaces onto the given name"""


### PR DESCRIPTION
**Description of work.**
This PR adds a check to see if the rectangular detector IDs are referred to in the spectra of the workspace. This is required as `SURF136500` contains a single rectangular detector, and multiple point detectors, but the rectangular detector is unused.

**To test:**
1. Open the ISISReflectometry GUI
2. Select `SURF` as the instrument
3. Create a new row with run `SURF136500` and angle 0.5
4. Click process. It should process fine and the row turns green
5. Repeat for `INTER45455_inst` and an OFFSPEC run

*This does not require release notes* because **the bug was not in the previous mantid version**

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
