### PR TITLE
Disable failing MantidHelpWindowTest temporarily

### DIFF
--- a/qt/widgets/common/CMakeLists.txt
+++ b/qt/widgets/common/CMakeLists.txt
@@ -817,7 +817,7 @@ set(QT5_TEST_FILES
     test/ImageInfoPresenterTest.h
     test/InterfaceManagerTest.h
     test/ManageUserDirectoriesTest.h
-    test/MantidHelpWindowTest.h
+    # test/MantidHelpWindowTest.h - disabled while the failure is investigated
     test/MuonPeriodInfoTest.h
     test/QtJSONUtilsTest.h
     test/RepoModelTest.h


### PR DESCRIPTION
**Description of work.**
This PR temporarily disables the MantidHelpWindowTest while we investigate why it is failing.

It is failing on the main nightly deployment pipeline https://builds.mantidproject.org/view/Nightly%20Pipelines/job/main_nightly_deployment_prototype/424/ .

**To test:**
Make sure MantidHelpWindowTest is not run in the tests.

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
