### PR TITLE
Fix incorrect error reporter test instructions

### DIFF
--- a/dev-docs/source/Testing/ErrorReporter-ProjectRecovery/ErrorReporterTesting.rst
+++ b/dev-docs/source/Testing/ErrorReporter-ProjectRecovery/ErrorReporterTesting.rst
@@ -38,7 +38,7 @@ Error Reporter test
 - Input some additional information into the main textbox. Try to include characters that need to be escaped such as ``"``
 - Tick the `Remember Me` checkbox
 - Click the `Don't share any information` button
-- Check with the database admin that an error report was sent **without** a name, email or stacktrace.
+- Check with the database admin that an error report was **not** sent.
 
 ---------------
 
@@ -68,7 +68,7 @@ Error Reporter test
 - Make sure the `Continue` radio button is checked
 - Click the `Don't share any information` button
 - You should be returned to the main Mantid window
-- Check with the database admin that an error report was sent **without** a name, email, stacktrace or textbox.
+- Check with the database admin that an error report was **not** sent.
 
 ---------------
 


### PR DESCRIPTION
The instructions said that an error report should be sent when the user chooses not to share any information; this is incorrect. An error report should not be sent.

**To test:**

Check the instructions read ok.
*There is no associated issue.*

*This does not require release notes* because **it is developer documentation**


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
