### PR TITLE
Fix F(q) fit tab crash when no data selected on parameter change.

### DIFF
--- a/docs/source/release/v6.5.0/Indirect/Bugfixes/34348.rst
+++ b/docs/source/release/v6.5.0/Indirect/Bugfixes/34348.rst
@@ -1,0 +1,1 @@
+Fixed a bug in Indirect Data Analysis F(Q) fit tab where when adding data to the interface if the parameter type was changed when no data was selected it would crash Mantid.

--- a/docs/source/release/v6.5.0/Indirect/Bugfixes/34348.rst
+++ b/docs/source/release/v6.5.0/Indirect/Bugfixes/34348.rst
@@ -1,1 +1,2 @@
+Fixed a bug in Indirect Data Analysis F(Q) fit tab where when loading a file in the workspace selector if the parameter type was changed before the workspace was finished loading it would crash Mantid.
 Fixed a bug in Indirect Data Analysis F(Q) fit tab where when adding data to the interface if the parameter type was changed when no data was selected it would crash Mantid.

--- a/qt/scientific_interfaces/Indirect/FqFitDataPresenter.cpp
+++ b/qt/scientific_interfaces/Indirect/FqFitDataPresenter.cpp
@@ -253,7 +253,7 @@ void FqFitDataPresenter::setDialogParameterNames(FqFitAddWorkspaceDialog *dialog
 
 void FqFitDataPresenter::dialogParameterTypeUpdated(FqFitAddWorkspaceDialog *dialog, const std::string &type) {
   const auto workspaceName = dialog->workspaceName();
-  if (!workspaceName.empty()) {
+  if (!workspaceName.empty() && m_adsInstance.doesExist(workspaceName)) {
     auto workspace = m_adsInstance.retrieveWS<MatrixWorkspace>(workspaceName);
     const FqFitParameters parameter = createFqFitParameters(workspace);
     setActiveParameterType(type);

--- a/qt/scientific_interfaces/Indirect/FqFitDataPresenter.cpp
+++ b/qt/scientific_interfaces/Indirect/FqFitDataPresenter.cpp
@@ -253,10 +253,12 @@ void FqFitDataPresenter::setDialogParameterNames(FqFitAddWorkspaceDialog *dialog
 
 void FqFitDataPresenter::dialogParameterTypeUpdated(FqFitAddWorkspaceDialog *dialog, const std::string &type) {
   const auto workspaceName = dialog->workspaceName();
-  auto workspace = m_adsInstance.retrieveWS<MatrixWorkspace>(workspaceName);
-  const FqFitParameters parameter = createFqFitParameters(workspace);
-  setActiveParameterType(type);
-  updateParameterOptions(dialog, parameter);
+  if (!workspaceName.empty()) {
+    auto workspace = m_adsInstance.retrieveWS<MatrixWorkspace>(workspaceName);
+    const FqFitParameters parameter = createFqFitParameters(workspace);
+    setActiveParameterType(type);
+    updateParameterOptions(dialog, parameter);
+  }
 }
 
 void FqFitDataPresenter::updateParameterOptions(FqFitAddWorkspaceDialog *dialog, const FqFitParameters &parameter) {


### PR DESCRIPTION
This fixes a bug in indirect data Analysis when adding data to the Fqfit Tab. If there is nothing in the file text box when you change parameter type it crashes mantid.

To Test:
1. open Indirect Data Analysis and go to the FqFit tab.
2. open the add workspace dialogue.
3. with the file box empty change the parameter type from width to EISF.
4. This should not crash now.

Fixes #34392

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
