### PR TITLE
Correctly autoscale axes limits on workspace update non-axis cut viewer in sliceviewer

### DIFF
--- a/docs/source/release/v6.5.0/Workbench/SliceViewer/Bugfixes/34395.rst
+++ b/docs/source/release/v6.5.0/Workbench/SliceViewer/Bugfixes/34395.rst
@@ -1,0 +1,1 @@
+* Fix bug with axes limits of 1D cut viewer plot not autoscaling on cut update after the user had zoomed or panned

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/cutviewer/view.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/cutviewer/view.py
@@ -25,6 +25,7 @@ class CutViewerView(QWidget):
     """Displays a table view of the PeaksWorkspace along with controls
     to interact with the peaks.
     """
+
     def __init__(self, presenter, canvas, frame, parent=None):
         """
         :param painter: An object responsible for drawing the representation of the cut
@@ -94,7 +95,7 @@ class CutViewerView(QWidget):
 
     def update_step(self, irow):
         _, extents, nbins = self.get_bin_params()
-        self.set_step(irow, (extents[1, irow]-extents[0, irow])/nbins[irow])
+        self.set_step(irow, (extents[1, irow] - extents[0, irow]) / nbins[irow])
 
     def set_nbin(self, irow, nbin):
         self.table.item(irow, 5).setData(Qt.EditRole, int(nbin))
@@ -112,7 +113,7 @@ class CutViewerView(QWidget):
 
     def set_slicepoint(self, slicept, width):
         self.table.blockSignals(True)
-        self.set_extent(2, slicept - width/2, slicept + width/2)
+        self.set_extent(2, slicept - width / 2, slicept + width / 2)
         self.set_step(2, width)
         self.table.blockSignals(False)
 
@@ -155,7 +156,8 @@ class CutViewerView(QWidget):
         col_headers = ['a*', 'b*', 'c*'] if self.frame == SpecialCoordinateSystem.HKL else ['Qx', 'Qy', 'Qz']
         col_headers.extend(['start', 'stop', 'nbins', 'step'])
         table_widget.setHorizontalHeaderLabels(col_headers)
-        table_widget.setFixedHeight(table_widget.verticalHeader().defaultSectionSize()*(table_widget.rowCount()+1))  # +1 to include headers
+        table_widget.setFixedHeight(
+            table_widget.verticalHeader().defaultSectionSize() * (table_widget.rowCount() + 1))  # +1 to include headers
         for icol in range(table_widget.columnCount()):
             table_widget.setColumnWidth(icol, 50)
         table_widget.horizontalHeader().setSectionResizeMode(QHeaderView.Stretch)
@@ -166,7 +168,6 @@ class CutViewerView(QWidget):
 
     def _setup_figure_widget(self):
         fig, _, _, _ = create_subplots(1)
-        fig.axes[0].autoscale(enable=True, tight=False)
         self.figure = fig
         self.figure.canvas = FigureCanvas(self.figure)
         toolbar = MantidNavigationToolbar(self.figure.canvas, self)
@@ -183,7 +184,7 @@ class CutViewerView(QWidget):
                     item.setData(Qt.EditRole, int(1))
                 else:
                     item.setData(Qt.EditRole, float(1))
-                if irow == self.table.rowCount()-1:
+                if irow == self.table.rowCount() - 1:
                     item.setFlags(item.flags() ^ Qt.ItemIsEditable)  # disable editing in last row (out of plane dim)
                     item.setBackground(QColor(250, 250, 250))
                 else:
@@ -192,7 +193,7 @@ class CutViewerView(QWidget):
 
     def _format_cut_figure(self):
         self.figure.axes[0].ignore_existing_data_limits = True
-        self.figure.axes[0].autoscale_view()
+        self.figure.axes[0].autoscale(axis='both', tight=False)
         self._format_cut_xlabel()
         for textobj in self.figure.findobj(text.Text):
             textobj.set_fontsize(8)


### PR DESCRIPTION
**Description of work.**

If an artist is updated the ax.autoscale_view() doesn't work without a call to ax.relim() - but that doesn't support containers (such as errorbars) so doesn't get the right limits.

Here I use another autoscale method, ax.autoscale() - but without for it to work on update we have to set ignore_existing_data_limits = True

Note  `ax.autoscale()`  gets set to False if the axes limits are set (e.g. by panning or zooming) - so this needs to be called on every update (not on axes creation as previously).

**To test:**
(1) Follow instructions on issue

Fixes #34382 
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
