### PR TITLE
Check workspace supports non axis cuts before enabling on toggle nonortho view off in sliceviewer

### DIFF
--- a/docs/source/release/v6.5.0/Workbench/SliceViewer/Bugfixes/34400.rst
+++ b/docs/source/release/v6.5.0/Workbench/SliceViewer/Bugfixes/34400.rst
@@ -1,0 +1,1 @@
+* Added check on toggling non-orthogonal view off that ensures the non axis cutting tool is not enabled if the workspace does not support non axis cuts (e.g. is 4D)

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/presenters/presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/presenters/presenter.py
@@ -303,7 +303,8 @@ class SliceViewer(ObservingPresenter, SliceViewerBasePresenter):
             data_view.create_axes_orthogonal()
             data_view.enable_tool_button(ToolItemText.LINEPLOTS)
             data_view.enable_tool_button(ToolItemText.REGIONSELECTION)
-            data_view.enable_tool_button(ToolItemText.NONAXISALIGNEDCUTS)
+            if self.model.can_support_non_axis_cuts():
+                data_view.enable_tool_button(ToolItemText.NONAXISALIGNEDCUTS)
 
         self.new_plot()
 

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_sliceviewer_presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_sliceviewer_presenter.py
@@ -244,6 +244,7 @@ class SliceViewerTest(unittest.TestCase):
     @mock.patch("mantidqt.widgets.sliceviewer.presenters.presenter.SliceInfo")
     def test_non_orthogonal_axes_toggled_off(self, mock_sliceinfo_cls):
         self.patched_deps["WorkspaceInfo"].get_ws_type.return_value = WS_TYPE.MDE
+        self.model.can_support_non_axis_cuts.return_value = True
         presenter, data_view_mock = _create_presenter(self.model,
                                                       self.view,
                                                       mock_sliceinfo_cls,
@@ -263,7 +264,26 @@ class SliceViewerTest(unittest.TestCase):
         data_view_mock.create_axes_nonorthogonal.assert_not_called()
         data_view_mock.plot_MDH.assert_called_once()
         data_view_mock.enable_tool_button.assert_has_calls(
-            (mock.call(ToolItemText.LINEPLOTS), mock.call(ToolItemText.REGIONSELECTION)))
+            (mock.call(ToolItemText.LINEPLOTS),
+             mock.call(ToolItemText.REGIONSELECTION),
+             mock.call(ToolItemText.NONAXISALIGNEDCUTS)))
+
+    @mock.patch("mantidqt.widgets.sliceviewer.presenters.presenter.SliceInfo")
+    def test_non_orthogonal_axes_toggled_off_not_enable_non_axis_cuts_if_not_supported(self, mock_sliceinfo_cls):
+        self.patched_deps["WorkspaceInfo"].get_ws_type.return_value = WS_TYPE.MDE
+        self.model.can_support_non_axis_cuts.return_value = False
+        presenter, data_view_mock = _create_presenter(self.model,
+                                                      self.view,
+                                                      mock_sliceinfo_cls,
+                                                      enable_nonortho_axes=True,
+                                                      supports_nonortho=True)
+
+        data_view_mock.enable_tool_button.reset_mock()
+
+        presenter.nonorthogonal_axes(False)
+
+        self.assertTrue(mock.call(ToolItemText.NONAXISALIGNEDCUTS) not in
+                        data_view_mock.enable_tool_button.call_args_list)
 
     def test_cut_view_button_disabled_if_model_cannot_support_it(self):
         self.patched_deps["WorkspaceInfo"].get_ws_type.return_value = WS_TYPE.MATRIX


### PR DESCRIPTION
**Description of work.**

One-line fix to check workspace supports non axis cuts before enabling on toggle nonortho view off in sliceviewer

**To test:**

(1) Follow instructions in issue

Fixes #34379 

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
