### PR TITLE
Fix copy bin to table bug

### DIFF
--- a/qt/python/mantidqt/mantidqt/widgets/workspacedisplay/matrix/presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/workspacedisplay/matrix/presenter.py
@@ -153,7 +153,7 @@ class MatrixWorkspaceDisplay(ObservingPresenter, DataCopier):
             return
         ws = table.model().ws
         num_rows = ws.getNumberHistograms()
-        table_ws = _create_empty_table_workspace(name=ws.name() + "_bins", row_count=num_rows)
+        table_ws = _create_empty_table_workspace(name=ws.name() + "_bins", num_rows=num_rows)
         table_ws.addColumn("double", "X")
         num_cols = 3 if self.hasDx else 2
         for i, col in enumerate(selected_cols):

--- a/qt/python/mantidqt/mantidqt/widgets/workspacedisplay/matrix/test/test_matrixworkspacedisplay_presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/workspacedisplay/matrix/test/test_matrixworkspacedisplay_presenter.py
@@ -399,6 +399,21 @@ class MatrixWorkspaceDisplayPresenterTest(unittest.TestCase):
         # (2 Selected Bins * 2 Spectra * 3 Cols per bin) + 2 spectra names
         self.assertEqual(mock_table_ws.setCell.call_count, 14)
 
+    def test_action_copy_bin_to_table_will_create_an_empty_table_without_error(self):
+        _, mock_table, _, presenter = self.common_setup_action_plot(table_has_selection=False)
+        self.setup_mock_selection(mock_table, num_selected_cols=2, num_selected_rows=None)
+        mock_input_ws = Mock()
+        mock_input_ws.name.return_value = "mock_ws"
+        mock_input_ws.getNumberHistograms.return_value = 2
+        mock_input_ws.axes.return_value = 1
+        mock_input_ws.readY.return_value = [2, 2]
+        mock_input_ws.readE.return_value = [1, 1]
+        mock_input_ws.readDx.return_value = [3, 3]
+
+        mock_table.model().ws = mock_input_ws
+
+        presenter.action_copy_bin_to_table(mock_table)
+
     @patch("mantidqt.widgets.workspacedisplay.matrix.presenter.MatrixWorkspaceDisplay.notify_no_selection_to_copy")
     def test_action_copy_spectrum_to_table_no_selection(self, mock_notify):
         _, mock_table, _, presenter = self.common_setup_action_plot(table_has_selection=False)


### PR DESCRIPTION
**Description of work.**
This PR fixes the `Copy bin to table` functionality in matrix workspace displays, and adds a test to cover the bug.

**To test:**
Open MantidWorkbench
Run the algorithm CreateSampleWorkspace
on the output workspace, right-click and select Show Data
Select one bin by clicking at the top of a column
Right-click and select Copy bin to table.
There should be no error and a new table workspace created

Fixes #34375

*This does not require release notes* because **the bug doesn't exist in the previous version**

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
