### PR TITLE
Avoid direct access to constants.codata - deprecated in recent Scipy

### DIFF
--- a/scripts/abins/constants.py
+++ b/scripts/abins/constants.py
@@ -41,15 +41,15 @@ ALL_SYMBOLS = ["Ac", "Ag", "Al", "Am", "Ar", "As", "At", "Au", "B", "Ba", "Be", 
 
 SMALL_K = 1.0e-1  # norm of k vector below this value is considered zero
 
-K_2_HARTREE = constants.codata.value("kelvin-hartree relationship")  # K * K_2_HARTREE =  Hartree
+K_2_HARTREE = constants.value("kelvin-hartree relationship")  # K * K_2_HARTREE =  Hartree
 
 # here we have to multiply by 100 because frequency is expressed in cm^-1
-CM1_2_HARTREE = constants.codata.value("inverse meter-hartree relationship") * 100.0  # cm-1 * CM1_2_HARTREE =  Hartree
+CM1_2_HARTREE = constants.value("inverse meter-hartree relationship") * 100.0  # cm-1 * CM1_2_HARTREE =  Hartree
 
-ATOMIC_LENGTH_2_ANGSTROM = constants.codata.value(
+ATOMIC_LENGTH_2_ANGSTROM = constants.value(
     "atomic unit of length") / constants.angstrom  # 1 a.u. = 0.52917721067 Angstrom
 
-M_2_HARTREE = constants.codata.value("atomic mass unit-hartree relationship")  # amu * m2_hartree =  Hartree
+M_2_HARTREE = constants.value("atomic mass unit-hartree relationship")  # amu * m2_hartree =  Hartree
 
 # ALL_SAMPLE_FORMS = ["SingleCrystal", "Powder"]  # valid forms of samples
 ALL_SAMPLE_FORMS = ["Powder"]  # valid forms of samples
@@ -90,7 +90,7 @@ S_LAST_INDEX = 1
 # construction of aCLIMAX constant which is used to evaluate mean square displacement (u)
 with warnings.catch_warnings(record=True) as warning_list:
     warnings.simplefilter("always")
-    H_BAR = constants.codata.value("Planck constant over 2 pi")  # H_BAR =  1.0545718e-34 [J s] = [kg m^2 / s ]
+    H_BAR = constants.value("Planck constant over 2 pi")  # H_BAR =  1.0545718e-34 [J s] = [kg m^2 / s ]
     if len(warning_list) >= 1 and isinstance(warning_list[0].message, ConstantWarning):
         H_BAR = constants.hbar  # H_BAR =  1.0545718e-34 [J s] = [kg m^2 / s ]
 
@@ -99,11 +99,11 @@ H_BAR_DECOMPOSITION = math.frexp(H_BAR)
 M2_TO_ANGSTROM2 = 1.0 / constants.angstrom ** 2  # m^2 = 10^20 A^2
 M2_TO_ANGSTROM2_DECOMPOSITION = math.frexp(M2_TO_ANGSTROM2)
 
-KG2AMU = constants.codata.value("kilogram-atomic mass unit relationship")  # kg = 6.022140857e+26 amu
+KG2AMU = constants.value("kilogram-atomic mass unit relationship")  # kg = 6.022140857e+26 amu
 KG2AMU_DECOMPOSITION = math.frexp(KG2AMU)
 
 # here we divide by 100 because we need relation between hertz and inverse cm
-HZ2INV_CM = constants.codata.value("hertz-inverse meter relationship") / 100  # Hz [s^1] = 3.33564095198152e-11 [cm^-1]
+HZ2INV_CM = constants.value("hertz-inverse meter relationship") / 100  # Hz [s^1] = 3.33564095198152e-11 [cm^-1]
 HZ2INV_CM_DECOMPOSITION = math.frexp(HZ2INV_CM)
 
 # Conversion factor from VASP internal units


### PR DESCRIPTION
Deprecation warnings have been reported from `abins.constants` when used with very recent versions of SciPy.

It looks like constants.value() was always the preferred way of accessing this data, and constants.codata is a nominally-private data namespace that is due to be renamed to constants._codata.

**Description of work.**

**To test:**

The changed lines are called as soon as `abins.constants` is imported, so standard unit testing should ensure no harm is done. The interesting part will be to see if the deprecation warnings go away for Ubuntu 22.04 users.

*This does not require release notes* because it is entirely uninteresting to users.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
