### PR TITLE
Always add API import to top of file

### DIFF
--- a/docs/source/release/v6.6.0/Workbench/Bugfixes/34386.rst
+++ b/docs/source/release/v6.6.0/Workbench/Bugfixes/34386.rst
@@ -1,0 +1,2 @@
+- When a file with mantid algorithms is loaded, and the user accepts workbench adding the mantid API import line,
+  the new import is always added to the top of the file

--- a/qt/python/mantidqt/mantidqt/widgets/codeeditor/scriptcompatibility.py
+++ b/qt/python/mantidqt/mantidqt/widgets/codeeditor/scriptcompatibility.py
@@ -23,9 +23,8 @@ API_IMPORT = ("# import mantid algorithms\n"
 
 
 def add_mantid_api_import(editor, content):
-    future_imported_line_no = check_future_import(content)
-    if future_imported_line_no:
-        editor.setCursorPosition(future_imported_line_no, 0)
+    # Always put import at top of file
+    editor.setCursorPosition(0, 0)
     editor.insert(API_IMPORT)
 
 
@@ -37,19 +36,9 @@ def attr_called(attr, content):
     return bool(re.search(r'(^|\s)+' + attr + r'\(.*\)', content))
 
 
-def check_future_import(content):
-    """Return line number of __future__ import in content, if present"""
-    match = re.search(r'(import .*__future__|from __future__  *import)',
-                      content)
-    if match:
-        line_no = len(re.findall(r'(\r\n|\n|\r)', content[:match.end()])) + 1
-        return line_no
-    return False
-
-
 def mantid_algorithm_used_without_import(content):
     for attr in dir(simpleapi):
-        if (not attr.startswith('_') and attr == attr.title()
+        if (not attr.startswith('_') and attr[0].isupper()
                 and attr_called(attr, content)
                 and not attr_imported(attr, content)):
             return True

--- a/qt/python/mantidqt/mantidqt/widgets/codeeditor/test/test_multifileinterpreter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/codeeditor/test/test_multifileinterpreter.py
@@ -33,7 +33,7 @@ class MultiPythonFileInterpreterTest(unittest.TestCase, QtWidgetFinder):
         self.assertEqual(2, widget.editor_count)
 
     def test_open_file_in_new_tab_import_added(self):
-        test_string = "Test file\nLoad()"
+        test_string = "Test file\nConvertUnits()"
         widget = MultiPythonFileInterpreter()
         mock_open_func = mock.mock_open(read_data=test_string)
         with mock.patch(widget.__module__ + '.open', mock_open_func, create=True):


### PR DESCRIPTION
**Description of work.**
Set the cursor position to top of file to add API import
Also remove check for import from __future__ as Python2 not supported

**To test:**

save a python file locally with some text in the first few lines:
```
Rebin()
Load()
Rebin(again)
```

- open this file in the scripteditor in MantidWorkbench. 
- Previously the import was added to the end (Or first empty line) but check it is now added to the top of the file.

Fixes #https://github.com/mantidproject/mantid/issues/34386

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
