### PR TITLE
Tweak version in conda

### DIFF
--- a/Framework/CMakeLists.txt
+++ b/Framework/CMakeLists.txt
@@ -170,7 +170,7 @@ if(CONDA_ENV)
 
   write_basic_package_version_file(
     ${CMAKE_CURRENT_BINARY_DIR}/MantidFrameworkConfigVersion.cmake
-    VERSION ${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}
+    VERSION ${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}${VERSION_TWEAK}
     COMPATIBILITY SameMajorVersion
   )
 

--- a/buildconfig/CMake/PythonPackageTargetFunctions.cmake
+++ b/buildconfig/CMake/PythonPackageTargetFunctions.cmake
@@ -50,7 +50,7 @@ function(add_python_package pkg_name)
 
   # create the developer setup which just creates a pth file rather than copying things over
   set(_outputs ${_egg_link} ${_startup_script} ${_startup_exe})
-  set(_version_str ${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}${VERSION_TWEAK_PY})
+  set(_version_str ${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}${VERSION_TWEAK})
   add_custom_command(
     OUTPUT ${_outputs}
     COMMAND ${CMAKE_COMMAND} -E env PYTHONPATH=${_egg_link_dir} MANTID_VERSION_STR=${_version_str} ${Python_EXECUTABLE}

--- a/buildconfig/CMake/VersionNumber.cmake
+++ b/buildconfig/CMake/VersionNumber.cmake
@@ -1,37 +1,51 @@
-# Set the version number here for MantidVersion and the package filenames This follows Semantic Versioning
-# https://semver.org
+# Set the version number here for MantidVersion and the package filenames. This roughly follows Semantic Versioning
+# https://semver.org, but will adhere to PEP440 https://peps.python.org/pep-0440/
+#
+# The version number will be of the form
+#
+# major.minor.patch(tweak(rcN))
+#
+# where tweak version and rcN number are optional. This assumes the rc value will not exist without a tweak version.
+# Examples: `6.5.0`, `6.4.20220915.1529`, `6.4.0.1`, and `6.4.0.1rc2`.
+
 if(CONDA_BUILD)
-  # If inside of conda-build assume the version number is set by the version number in the recipe. The conda recipe
-  # version number is set either manually in https://github.com/mantidproject/conda-recipes.git and Automatically set by
-  # the nightly pipeline that handles conda-build.
+  # If inside of conda-build assume the version number is set by the version number in the recipe and brough in by the
+  # PKG_VERSION environment variable that conda sets
+  # https://conda.io/projects/conda-build/en/latest/user-guide/environment-variables.html. The conda recipe version
+  # number is set either manually in https://github.com/mantidproject/conda-recipes.git and Automatically set by the
+  # nightly pipeline that handles conda-build.
   set(_conda_package_version $ENV{PKG_VERSION})
+  # convert the `.` into `;` so cmake treats it as a list
   string(REPLACE "." ";" _conda_package_version ${_conda_package_version})
   set(_conda_package_list ${_conda_package_version})
 
+  # the length of the list declares whether there is a tweak version
+  list(LENGTH _conda_package_version _number_version_level)
+
+  # unpack the list into major.minor.patch(tweak)
   list(GET _conda_package_version 0 VERSION_MAJOR)
   list(GET _conda_package_version 1 VERSION_MINOR)
-  list(SUBLIST _conda_package_list 2 2 _version_patch_list)
-  set(VERSION_PATCH)
-  string(REPLACE ";" "." VERSION_PATCH "${_version_patch_list}")
-  message(STATUS "Version: ${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}")
+  list(GET _conda_package_version 2 VERSION_PATCH)
+  if(_number_version_level GREATER 3)
+    list(GET _conda_package_version 3 VERSION_TWEAK)
+    # The version number in template files (e.g. MantidVersion.cpp.in) assumes that the `.` is included in the tweak
+    # number
+    set(VERSION_TWEAK ".${VERSION_TWEAK}")
+  endif()
+
 else()
   set(VERSION_MAJOR 6)
   set(VERSION_MINOR 4)
+
+  # UNCOMMENT the next 'set' line to 'force' the patch version number to a value (instead of using the count coming out
+  # of 'git describe') DO NOT COMMIT THIS TO MASTER UNCOMMENTED, ONLY TO A RELEASE BRANCH
+
+  # set(VERSION_PATCH 0)
+
+  # The tweak is mean to keep in line with the pre-release numbering. https://semver.org/ examples: First release
+  # cadidate for tweak 1 is ".1rc1" Second release cadidate for tweak 1 is ".1rc2" Actual tweak release is ".1"
+
+  # set(VERSION_TWEAK ".2rc1")
+
 endif()
-
-# UNCOMMENT the next 'set' line to 'force' the patch version number to a value (instead of using the count coming out of
-# 'git describe') DO NOT COMMIT THIS TO MASTER UNCOMMENTED, ONLY TO A RELEASE BRANCH
-
-# set(VERSION_PATCH 0)
-
-# The tweak is mean to keep in line with the pre-release numbering. https://semver.org/ examples: First release cadidate
-# for tweak 1 is "-1-rc.1" Second release cadidate for tweak 1 is "-1-rc.2" Actual tweak release is "-1"
-
-# set(VERSION_TWEAK "-2-rc.1")
-
-# pep440 is incompatible with semantic versioning https://www.python.org/dev/peps/pep-0440/ example: First release
-# cadidate for tweak 1 is ".1rc.1"
-if(VERSION_TWEAK)
-  string(REPLACE "-rc." "rc" VERSION_TWEAK_PY ${VERSION_TWEAK})
-  string(REPLACE "-" "." VERSION_TWEAK_PY ${VERSION_TWEAK_PY})
-endif()
+message(STATUS "Version: ${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}${VERSION_TWEAK}")


### PR DESCRIPTION
This allows for the tweak version to be set via conda as well as coded into cmake directly. There is also some minor cleanup as the tweak version is now more universally applied.

**To test:**

Run cmake with different values of `PKG_VERSION` injected and `CONDA_BUILD` turned on. The examples in the comment of `VersionNumber.cmake` are a good set as they cover all the options. Example:

```sh
PKG_VERSION="6.4.20220915.1529" cmake -D CONDA_BUILD=True .
```
will print `Version: 6.4.20220915.1529` in the cmake configuration logs and look at the values in the templated file `Framework/Kernel/src/MantidVersion.cpp` that they are accurate.

*There is no associated issue.*

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
