### PR TITLE
Fix row/column highlighting in matrix workspacedisplay view

### DIFF
--- a/qt/python/mantidqt/mantidqt/widgets/workspacedisplay/matrix/delegate.py
+++ b/qt/python/mantidqt/mantidqt/widgets/workspacedisplay/matrix/delegate.py
@@ -7,8 +7,8 @@
 from typing import Optional
 
 from qtpy.QtCore import Qt, QObject, QModelIndex
-from qtpy.QtGui import QPainter
-from qtpy.QtWidgets import (QStyledItemDelegate, QStyleOptionViewItem)
+from qtpy.QtGui import QPainter, QColor
+from qtpy.QtWidgets import (QStyledItemDelegate, QStyleOptionViewItem, QStyle)
 
 
 class CustomTextElidingDelegate(QStyledItemDelegate):
@@ -44,10 +44,17 @@ class CustomTextElidingDelegate(QStyledItemDelegate):
         try:
             painter.setClipRect(opt.rect)
             foreground_colour, background_colour = index.data(Qt.ForegroundRole), index.data(Qt.BackgroundRole)
-            if foreground_colour is not None:
+            state_selected = option.state & QStyle.State_Selected
+            if state_selected:
+                painter.setPen(QColor("white"))
+            elif foreground_colour is not None:
                 painter.setPen(foreground_colour)
-            if background_colour is not None:
+
+            if state_selected:
+                painter.fillRect(option.rect, option.palette.highlight())
+            elif background_colour is not None:
                 painter.fillRect(option.rect, background_colour)
+
             padding = self._padding
             opt.rect = option.rect.adjusted(padding, padding, -padding, -padding)
             painter.drawText(opt.rect, int(Qt.AlignLeft | Qt.AlignVCenter),

--- a/qt/python/mantidqt/mantidqt/widgets/workspacedisplay/matrix/delegate.py
+++ b/qt/python/mantidqt/mantidqt/widgets/workspacedisplay/matrix/delegate.py
@@ -47,13 +47,12 @@ class CustomTextElidingDelegate(QStyledItemDelegate):
             state_selected = option.state & QStyle.State_Selected
             if state_selected:
                 painter.setPen(QColor("white"))
-            elif foreground_colour is not None:
-                painter.setPen(foreground_colour)
-
-            if state_selected:
                 painter.fillRect(option.rect, option.palette.highlight())
-            elif background_colour is not None:
-                painter.fillRect(option.rect, background_colour)
+            else:
+                if foreground_colour is not None:
+                    painter.setPen(foreground_colour)
+                if background_colour is not None:
+                    painter.fillRect(option.rect, background_colour)
 
             padding = self._padding
             opt.rect = option.rect.adjusted(padding, padding, -padding, -padding)


### PR DESCRIPTION
**Description of work.**

[#34260](https://github.com/mantidproject/mantid/pull/34260) introduces a bug which caused table cells to not be highlighted when selected.

This is because the `paint` method of the respective delegate was reimplemented with statements to retain the original foreground and background colour. This logic did not consider the foreground and background colour changing upon being selected.

Associated unit test added.

**To test:**

- Confirm associated unit test is adequate and passes.
- Confirm issue #34383 has been resolved.

Fixes #34383.

No release note as introduced in 6.5 and not reported by user.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
