### PR TITLE
make bin/title units less ambiguous

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ElasticWindowMultiple.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ElasticWindowMultiple.py
@@ -207,7 +207,7 @@ class ElasticWindowMultiple(DataProcessorAlgorithm):
                 return float(sample_param[index])
         else:
             logger.information('Vertical axis is in run number')
-            unit = ('Run No', 'last 3 digits')
+            unit = ('Run No', ' last 3 digits')
 
             def axis_value(index):
                 return float(run_numbers[index][-3:])

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/IndirectDiffScan.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/IndirectDiffScan.py
@@ -137,7 +137,7 @@ class IndirectDiffScan(DataProcessorAlgorithm):
             unit = ('Temperature', 'K')
         else:
             logger.notice('Vertical axis is in run number')
-            unit = ('Run No', '_last 3 digits')
+            unit = ('Run No', ' last 3 digits')
 
         # Create a new vertical axis for the workspaces
         y_ws_axis = NumericAxis.create(len(run_numbers))

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/IndirectQuickRun.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/IndirectQuickRun.py
@@ -352,7 +352,7 @@ class IndirectQuickRun(DataProcessorAlgorithm):
     def _create_and_format_diffusion_workspace(x_data, y_data, e_data, output_name, x_axis_is_temperature):
         create_workspace(x_data, y_data, e_data, 1, 'Diffusion', output_name)
 
-        unit = ('Temperature', 'K') if x_axis_is_temperature else ('Run No', 'last 3 digits')
+        unit = ('Temperature', 'K') if x_axis_is_temperature else ('Run No', ' last 3 digits')
         x_axis = mtd[output_name].getAxis(0).setUnit("Label")
         x_axis.setLabel(unit[0], unit[1])
 

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SofQWMomentsScan.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SofQWMomentsScan.py
@@ -281,7 +281,7 @@ class SofQWMomentsScan(DataProcessorAlgorithm):
             unit = ('Temperature', 'K')
         else:
             logger.information('X axis is in run number')
-            unit = ('Run No', 'last 3 digits')
+            unit = ('Run No', ' last 3 digits')
 
         xdat = list()
         ydat = list()


### PR DESCRIPTION
**Description of work.**

In several algorithms, if the an axis contains run numbers the unit label `last 3 digits` was assigned. ~~This is label is fairly ambiguous, so have changed the label to '_Run No'. Otherwise could remove the label all together, open to suggestions.~~
It has been decided to keep this label. It has been present in the relevant algorithms for a long time, and makes sense in the context of a plot (see images below from @SpencerHowells). I have added a space to the label to separate it from the number in the bin title and have made this consistent across algorithms.

**To test:**
- Follow instructions set out in #34416 
- Plot a graph of the bin, observe the `Run No (last3digits)` axis title is unaffected by this change.

Fixes #34416

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
