### PR TITLE
remove unnecessary analyzer checks in IqtTab

### DIFF
--- a/qt/scientific_interfaces/Indirect/IndirectDataAnalysisIqtTab.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectDataAnalysisIqtTab.cpp
@@ -23,27 +23,6 @@ using namespace MantidQt::CustomInterfaces;
 namespace {
 Mantid::Kernel::Logger g_log("Iqt");
 
-MatrixWorkspace_sptr getADSMatrixWorkspace(std::string const &workspaceName) {
-  return AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(workspaceName);
-}
-
-std::string checkInstrumentParametersMatch(const Instrument_const_sptr &sampleInstrument,
-                                           const Instrument_const_sptr &resolutionInstrument,
-                                           std::string const &parameter) {
-  if (!sampleInstrument->hasParameter(parameter))
-    return "Could not find the " + parameter + " for the sample workspace.";
-  if (!resolutionInstrument->hasParameter(parameter))
-    return "Could not find the " + parameter + " for the resolution workspaces.";
-  if (sampleInstrument->getStringParameter(parameter)[0] != resolutionInstrument->getStringParameter(parameter)[0])
-    return "The sample and resolution must have matching " + parameter + "s.";
-  return "";
-}
-
-void addErrorMessage(UserInputValidator &uiv, std::string const &message) {
-  if (!message.empty())
-    uiv.addErrorMessage(QString::fromStdString(message) + "\n");
-}
-
 /**
  * Calculate the number of bins in the sample & resolution workspaces
  * @param wsName The sample workspace name

--- a/qt/scientific_interfaces/Indirect/IndirectDataAnalysisIqtTab.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectDataAnalysisIqtTab.cpp
@@ -39,52 +39,9 @@ std::string checkInstrumentParametersMatch(const Instrument_const_sptr &sampleIn
   return "";
 }
 
-std::string checkParametersMatch(const MatrixWorkspace_const_sptr &sampleWorkspace,
-                                 const MatrixWorkspace_const_sptr &resolutionWorkspace, std::string const &parameter) {
-  auto const sampleInstrument = sampleWorkspace->getInstrument();
-  auto const resolutionInstrument = resolutionWorkspace->getInstrument();
-  return checkInstrumentParametersMatch(sampleInstrument, resolutionInstrument, parameter);
-}
-
-std::string checkParametersMatch(std::string const &sampleName, std::string const &resolutionName,
-                                 std::string const &parameter) {
-  auto const sampleWorkspace = getADSMatrixWorkspace(sampleName);
-  auto const resolutionWorkspace = getADSMatrixWorkspace(resolutionName);
-  return checkParametersMatch(sampleWorkspace, resolutionWorkspace, parameter);
-}
-
-std::string checkInstrumentsMatch(const MatrixWorkspace_const_sptr &sampleWorkspace,
-                                  const MatrixWorkspace_const_sptr &resolutionWorkspace) {
-  auto const sampleInstrument = sampleWorkspace->getInstrument();
-  auto const resolutionInstrument = resolutionWorkspace->getInstrument();
-  if (sampleInstrument->getName() != resolutionInstrument->getName())
-    return "The sample and resolution must have matching instruments.";
-  return "";
-}
-
-std::string validateNumberOfHistograms(const MatrixWorkspace_const_sptr &sampleWorkspace,
-                                       const MatrixWorkspace_const_sptr &resolutionWorkspace) {
-  auto const sampleSize = sampleWorkspace->getNumberHistograms();
-  auto const resolutionSize = resolutionWorkspace->getNumberHistograms();
-  if (resolutionSize > 1 && sampleSize != resolutionSize)
-    return "Resolution must have either one or as many spectra as the sample.";
-  return "";
-}
-
 void addErrorMessage(UserInputValidator &uiv, std::string const &message) {
   if (!message.empty())
     uiv.addErrorMessage(QString::fromStdString(message) + "\n");
-}
-
-bool isTechniqueDirect(const MatrixWorkspace_const_sptr &sampleWorkspace,
-                       const MatrixWorkspace_const_sptr &resWorkspace) {
-  try {
-    auto const logValue1 = sampleWorkspace->getLog("deltaE-mode")->value();
-    auto const logValue2 = resWorkspace->getLog("deltaE-mode")->value();
-    return (logValue1 == "Direct") && (logValue2 == "Direct");
-  } catch (std::exception const &) {
-    return false;
-  }
 }
 
 /**
@@ -299,23 +256,6 @@ bool IndirectDataAnalysisIqtTab::validate() {
   if (eLow >= eHigh)
     uiv.addErrorMessage("ELow must be less than EHigh.\n");
 
-  auto const sampleName = m_uiForm.dsInput->getCurrentDataName().toStdString();
-  auto const resolutionName = m_uiForm.dsResolution->getCurrentDataName().toStdString();
-
-  auto &ads = AnalysisDataService::Instance();
-  if (ads.doesExist(sampleName) && ads.doesExist(resolutionName)) {
-    auto const sampleWorkspace = getADSMatrixWorkspace(sampleName);
-    auto const resWorkspace = getADSMatrixWorkspace(resolutionName);
-
-    addErrorMessage(uiv, checkInstrumentsMatch(sampleWorkspace, resWorkspace));
-    addErrorMessage(uiv, validateNumberOfHistograms(sampleWorkspace, resWorkspace));
-
-    if (!isTechniqueDirect(sampleWorkspace, resWorkspace)) {
-      addErrorMessage(uiv, checkParametersMatch(sampleWorkspace, resWorkspace, "analyser"));
-      addErrorMessage(uiv, checkParametersMatch(sampleWorkspace, resWorkspace, "reflection"));
-    }
-  }
-
   auto const message = uiv.generateErrorMessage();
   showMessageBox(message);
 
@@ -332,12 +272,6 @@ void IndirectDataAnalysisIqtTab::updateDisplayedBinParameters() {
   auto &ads = AnalysisDataService::Instance();
   if (!ads.doesExist(sampleName) || !ads.doesExist(resolutionName))
     return;
-
-  if (!isTechniqueDirect(getADSMatrixWorkspace(sampleName), getADSMatrixWorkspace(resolutionName))) {
-    if (!checkParametersMatch(sampleName, resolutionName, "analyser").empty() ||
-        !checkParametersMatch(sampleName, resolutionName, "reflection").empty())
-      return;
-  }
 
   double energyMin = m_dblManager->value(m_properties["ELow"]);
   double energyMax = m_dblManager->value(m_properties["EHigh"]);


### PR DESCRIPTION
This PR removes validation of the analyser and resolution in iqt tab. This is note required as part off loading data utalizes the more accurate validation of the TransformToIqt algorithm. When iqt tab loads data it runs a dry run of TransformToIqt so the validation is well covered.
This also fixes a previous attempt of making direct data runable in the tab.

Fixes: #34204

**To test:**

Contact me for the test data

1. Open Indirect Data Analaysis and go to Iqt
2. set the sample worksapce as FOCUS2374_sam_sqw
3. set the resolution workspace as FOCUS2388_res_sqw
4. a warning should pop up informing you that the resolution is insufficent
5. set sample binning to 3
6. click run, again ignore the pop up.
7. an iqw workspace should have been produced.


*This does not require release notes* because it fixes bug that already has release notes describing the fix

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
