### PR TITLE
check for num events before retrieval of pulsetime, dont if 0 events

### DIFF
--- a/Framework/DataHandling/src/LoadEventNexus.cpp
+++ b/Framework/DataHandling/src/LoadEventNexus.cpp
@@ -979,7 +979,14 @@ void LoadEventNexus::loadEvents(API::Progress *const prog, const bool monitors) 
 
         m_file->openGroup(entry_name, classType);
 
-        if (takeTimesFromEvents) {
+        // get the number of events
+        const std::string prefix = "/" + m_top_entry_name + "/" + entry_name;
+        bool hasTotalCounts = true;
+        std::size_t num = numEvents(*m_file, hasTotalCounts, oldNeXusFileNames, prefix, *descriptor);
+        bankNames.emplace_back(entry_name);
+        bankNumEvents.emplace_back(num);
+
+        if (takeTimesFromEvents && num > 0) {
           /* If we are here, we are loading logs, but have failed to establish
            * the run_start from the proton_charge log. We are going to get this
            * from our event_time_zero instead
@@ -987,12 +994,6 @@ void LoadEventNexus::loadEvents(API::Progress *const prog, const bool monitors) 
           auto localFirstLast = firstLastPulseTimes(*m_file, this->g_log);
           firstPulseT = std::min(firstPulseT, localFirstLast.first);
         }
-        // get the number of events
-        const std::string prefix = "/" + m_top_entry_name + "/" + entry_name;
-        bool hasTotalCounts = true;
-        std::size_t num = numEvents(*m_file, hasTotalCounts, oldNeXusFileNames, prefix, *descriptor);
-        bankNames.emplace_back(entry_name);
-        bankNumEvents.emplace_back(num);
 
         // Look for weights in simulated file
         const std::string absoluteEventWeightName = prefix + "/event_weight";

--- a/Framework/DataHandling/test/LoadEventNexusTest.h
+++ b/Framework/DataHandling/test/LoadEventNexusTest.h
@@ -1066,18 +1066,6 @@ public:
     TS_ASSERT_THROWS(loader.execute(), const InvalidLogPeriods &);
   }
 
-  void test_load_fails_on_empty_pulse_times() {
-    // Some ISIS runs can contain no pulse times.
-    // LoadEventNexus should not cause a crash in these cases; for now just fail to load.
-    LoadEventNexus loader;
-
-    loader.setChild(true);
-    loader.initialize();
-    loader.setPropertyValue("OutputWorkspace", "dummy");
-    loader.setPropertyValue("Filename", "LARMOR00067436.nxs");
-    TS_ASSERT_THROWS(loader.execute(), const std::invalid_argument &);
-  }
-
   void test_load_ILL_no_triggers() {
     // ILL runs don't have any pulses, so in event mode, they are replaced in the event nexus by trigger signals.
     // But some of these nexuses don't have any triggers either, so they are modified to be allowed to be loaded.

--- a/docs/source/release/v6.5.0/SANS/Bugfixes/34433.rst
+++ b/docs/source/release/v6.5.0/SANS/Bugfixes/34433.rst
@@ -1,0 +1,1 @@
+- Changes :ref:`algm-LoadEventNexus` to skip pulsetime lookup on 0 event sections, preventing the crash of legacy files.

--- a/docs/source/release/v6.5.0/sans.rst
+++ b/docs/source/release/v6.5.0/sans.rst
@@ -12,6 +12,5 @@ New Features
 
 Bugfixes
 --------
-- Changes :ref:`algm-LoadEventNexus` to skip pulsetime lookup on 0 event sections, preventing the crash of legacy files.
 
 :ref:`Release 6.5.0 <v6.5.0>`

--- a/docs/source/release/v6.5.0/sans.rst
+++ b/docs/source/release/v6.5.0/sans.rst
@@ -12,6 +12,6 @@ New Features
 
 Bugfixes
 --------
-
+- Changes :ref:`algm-LoadEventNexus` to skip pulsetime lookup on 0 event sections, preventing the crash of legacy files.
 
 :ref:`Release 6.5.0 <v6.5.0>`


### PR DESCRIPTION
**Description of work.**

Legacy sensitivity file loading causes Mantid to crash with out clear error message, this has be found to be caused by attempting to read pulse information from a section that has no events.

The fix implemented was to skip pulse info on event-less sections.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**

<!-- Instructions for testing. -->
Attempt to use LoadEventNexus on a legacy file that has sections with no events and observe that mantid doesnt crash, and it loads the file.

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
