### PR TITLE
fix issue in load wand data caused by deprecated h5py syntax

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/LoadWANDSCD.py
+++ b/Framework/PythonInterface/plugins/algorithms/LoadWANDSCD.py
@@ -225,10 +225,10 @@ class LoadWANDSCD(PythonAlgorithm):
                          bc[3::4, 1::4] + bc[::4, 2::4] + bc[1::4, 2::4] + bc[2::4, 2::4] + bc[3::4, 2::4] + bc[::4, 3::4] + \
                          bc[1::4, 3::4] + bc[2::4, 3::4] + bc[3::4, 3::4]
                 data_array[n] = bc
-                s1_array.append(f['/entry/DASlogs/HB2C:Mot:s1.RBV/average_value'][()][0])
-                duration_array.append(float(f['/entry/duration'][()][0]))
-                run_number_array.append(float(f['/entry/run_number'][()][0]))
-                monitor_count_array.append(float(f['/entry/monitor1/total_counts'][()][0]))
+                s1_array.append(f['/entry/DASlogs/HB2C:Mot:s1.RBV/average_value'][0])
+                duration_array.append(float(f['/entry/duration'][0]))
+                run_number_array.append(float(f['/entry/run_number'][0]))
+                monitor_count_array.append(float(f['/entry/monitor1/total_counts'][0]))
 
         progress.report('Creating MDHistoWorkspace')
         createWS_alg = self.createChildAlgorithm("CreateMDHistoWorkspace", enableLogging=False)

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/LoadWAND.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/LoadWAND.py
@@ -58,11 +58,11 @@ class LoadWAND(DataProcessorAlgorithm):
         for i, run in enumerate(runs):
             data = np.zeros((512 * 480 * 8), dtype=np.int64)
             with h5py.File(run, 'r') as f:
-                monitor_count = f['/entry/monitor1/total_counts'].value[0]
-                duration = f['/entry/duration'].value[0]
-                run_number = f['/entry/run_number'].value[0]
+                monitor_count = f['/entry/monitor1/total_counts'][()][0]
+                duration = f['/entry/duration'][()][0]
+                run_number = f['/entry/run_number'][()][0]
                 for b in range(8):
-                    data += np.bincount(f['/entry/bank' + str(b + 1) + '_events/event_id'].value, minlength=512 * 480 * 8)
+                    data += np.bincount(f['/entry/bank' + str(b + 1) + '_events/event_id'][()], minlength=512 * 480 * 8)
             data = data.reshape((480 * 8, 512))
             if grouping == 2:
                 data = data[::2, ::2] + data[1::2, ::2] + data[::2, 1::2] + data[1::2, 1::2]

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/LoadWAND.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/LoadWAND.py
@@ -58,9 +58,9 @@ class LoadWAND(DataProcessorAlgorithm):
         for i, run in enumerate(runs):
             data = np.zeros((512 * 480 * 8), dtype=np.int64)
             with h5py.File(run, 'r') as f:
-                monitor_count = f['/entry/monitor1/total_counts'][()][0]
-                duration = f['/entry/duration'][()][0]
-                run_number = f['/entry/run_number'][()][0]
+                monitor_count = f['/entry/monitor1/total_counts'][0]
+                duration = f['/entry/duration'][0]
+                run_number = f['/entry/run_number'][0]
                 for b in range(8):
                     data += np.bincount(f['/entry/bank' + str(b + 1) + '_events/event_id'][()], minlength=512 * 480 * 8)
             data = data.reshape((480 * 8, 512))

--- a/docs/source/release/v6.5.0/Diffraction/Powder/Bugfixes/34434.rst
+++ b/docs/source/release/v6.5.0/Diffraction/Powder/Bugfixes/34434.rst
@@ -1,0 +1,1 @@
+* Fixed deprecated syntax in :ref:`LoadWAND <algm-LoadWAND>` that gives h5py warnings.


### PR DESCRIPTION
**Description of work.**

Fixing deprecation warnings in `LoadWAND`  from h5py syntax `.value` and replace with `[()]`.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

Run this test. Ensure that no `.value` warnings are printed. Test on Python 3.11.`
**To test:**
```python
silicon = LoadWAND(IPTS=7776,RunNumbers='26506,26507') # silicon
```

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
