### PR TITLE
Fix links in Osiris script docs.

### DIFF
--- a/docs/source/techniques/ISISPowder-OSIRIS-v1.rst
+++ b/docs/source/techniques/ISISPowder-OSIRIS-v1.rst
@@ -16,7 +16,7 @@ This method assumes you are familiar with :ref:`intro_to_objects-isis-powder-dif
 To create a OSIRIS object the following parameters are required:
 
 - :ref:`calibration_directory_osiris_isis-powder-diffraction-ref`
-- output_directory
+- :ref:`output_directory_osiris_isis-powder-diffraction-ref`
 - :ref:`user_name_osiris_isis-powder-diffraction-ref`
 
 Optionally a configuration file may be specified if one exists
@@ -63,7 +63,7 @@ the user enables.
 On OSIRIS the following parameters are required when executing *create_vanadium*:
 
 - :ref:`calibration_mapping_file_osiris_isis-powder-diffraction-ref`
-- vanadium_normalisation
+- :ref:`do_van_normalisation_osiris_isis-powder-diffraction-ref`
 - :ref:`subtract_empty_can_osiris_isis-powder-diffraction-ref`
 - :ref:`merge_drange_osiris_isis-powder-diffraction-ref`
 
@@ -239,6 +239,26 @@ Example Input:
 ..  code-block:: python
 
   osiris_example = Osiris(merge_drange=True, ...)
+
+.. _output_directory_osiris_isis-powder-diffraction-ref:
+
+output_directory
+^^^^^^^^^^^^^^^^
+Specifies the path to the output directory to save resulting files
+into. The script will automatically create a folder
+with the label determined from the
+:ref:`calibration_mapping_file_polaris_isis-powder-diffraction-ref`
+and within that create another folder for the current
+:ref:`user_name_polaris_isis-powder-diffraction-ref`.
+
+Within this folder processed data will be saved out in
+several formats.
+
+Example Input:
+
+..  code-block:: python
+
+  osiris_example = Osiris(output_directory=r"C:\path\to\output_dir", ...)
 
 .. _run_number_osiris_isis-powder-diffraction-ref:
 


### PR DESCRIPTION
This PR adds section references in the OSIRIS powder scripts documentation.

**To test:**

build the docs and check ISISPowder-OSIRIS. check that all links are valid and any reference to a parameter is linked to the correct subheading.

Fixes #34441

*This does not require release notes* because the OSIRIS scripts are new for this release.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
