### PR TITLE
Reduce precision on FitIncidentSpectrum test so passes on all platforms

### DIFF
--- a/Framework/PythonInterface/test/python/plugins/algorithms/FitIncidentSpectrumTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/FitIncidentSpectrumTest.py
@@ -109,9 +109,9 @@ class FitIncidentSpectrumTest(unittest.TestCase):
         self.assertTrue(alg_test.isExecuted())
         fit_wksp = AnalysisDataService.retrieve("fit_wksp")
         # check values at peak at wavelength~1.0 A
-        self.assertEqual(fit_wksp.readY(0)[8], 43064.085162668904)
-        self.assertEqual(fit_wksp.readY(1)[8], -9772.88981292931)
-        self.assertEqual(fit_wksp.readY(2)[8], -494934.7687858478)
+        self.assertAlmostEqual(fit_wksp.readY(0)[8], 43064.09, 2)
+        self.assertAlmostEqual(fit_wksp.readY(1)[8], -9772.89, 2)
+        self.assertAlmostEqual(fit_wksp.readY(2)[8], -494934.77, 2)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
**Description of work.**

The test FitIncidentSpectrumTest.test_fit_cubic_spline_both_derivatives wasn't passing on certain Jenkins pipelines and some local linux machines (but not all). Reduced the precision on the asserts so that the test is more reasonable

**To test:**

Code review and check Jenkins jobs all succeed

*There is no associated issue.*

*This does not require release notes* because **affects tests only and no functional change for user**

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
