### PR TITLE
Extension of exported files in DrILL

### DIFF
--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/drill/model/DrillExportModel.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/drill/model/DrillExportModel.py
@@ -219,7 +219,7 @@ class DrillExportModel:
             return
 
         tasks = list()
-        for algo,active in self._exportAlgorithms.items():
+        for (algo, ext), active in self._exportAlgorithms.items():
             if not active:
                 continue
             if not self._validCriteria(outputWs, algo):
@@ -233,8 +233,7 @@ class DrillExportModel:
                     continue
 
                 filename = os.path.join(
-                        exportPath,
-                        wsName + RundexSettings.EXPORT_ALGO_EXTENSION[algo])
+                        exportPath, wsName + ext)
                 name = wsName + ":" + filename
                 if wsName not in self._exports:
                     self._exports[wsName] = set()

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/drill/model/DrillExportModel.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/drill/model/DrillExportModel.py
@@ -59,10 +59,7 @@ class DrillExportModel:
         self._exportAlgorithms = {k: v for k, v in RundexSettings.EXPORT_ALGORITHMS[acquisitionMode].items()}
         self._exportExtensions = dict()
         self._exportDocs = dict()
-        for a in self._exportAlgorithms.keys():
-            if a in RundexSettings.EXPORT_ALGO_EXTENSION:
-                self._exportExtensions[a] = \
-                    RundexSettings.EXPORT_ALGO_EXTENSION[a]
+        for (a, _) in self._exportAlgorithms.keys():
             try:
                 alg = AlgorithmManager.createUnmanaged(a)
                 self._exportDocs[a] = alg.summary()
@@ -79,7 +76,7 @@ class DrillExportModel:
         Returns:
             list(str): names of algorithms
         """
-        return [algo for algo in self._exportAlgorithms.keys()]
+        return [algo for (algo, _) in self._exportAlgorithms.keys()]
 
     def getAlgorithmExtentions(self):
         """
@@ -88,7 +85,7 @@ class DrillExportModel:
         Returns:
             dict(str:str): dictionnary algo:extension
         """
-        return {k:v for k,v in self._exportExtensions.items()}
+        return {algo:ext for (algo,ext) in self._exportAlgorithms.keys()}
 
     def getAlgorithmDocs(self):
         """
@@ -106,8 +103,9 @@ class DrillExportModel:
         Args:
             algorithm: name of the algo
         """
-        if algorithm in self._exportAlgorithms:
-            return self._exportAlgorithms[algorithm]
+        extension = ""
+        if (algorithm, extension) in self._exportAlgorithms:
+            return self._exportAlgorithms[(algorithm, extension)]
         else:
             return False
 
@@ -118,8 +116,9 @@ class DrillExportModel:
         Args:
             algorithm (str): name of the algo
         """
-        if algorithm in self._exportAlgorithms:
-            self._exportAlgorithms[algorithm] = True
+        extension = ""
+        if (algorithm, extension) in self._exportAlgorithms:
+            self._exportAlgorithms[(algorithm, extension)] = True
 
     def inactivateAlgorithm(self, algorithm):
         """
@@ -128,8 +127,9 @@ class DrillExportModel:
         Args:
             algorithm (str): name of the algo
         """
-        if algorithm in self._exportAlgorithms:
-            self._exportAlgorithms[algorithm] = False
+        extension = ""
+        if (algorithm, extension) in self._exportAlgorithms:
+            self._exportAlgorithms[(algorithm, extension)] = False
 
     def _validCriteria(self, ws, algo):
         """

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/drill/model/DrillExportModel.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/drill/model/DrillExportModel.py
@@ -92,11 +92,10 @@ class DrillExportModel:
         Get the state of a specific algorithm.
 
         Args:
-            algorithm: name of the algo
+            algorithm (str, str): name of the algo and output file extension
         """
-        extension = ""
-        if (algorithm, extension) in self._exportAlgorithms:
-            return self._exportAlgorithms[(algorithm, extension)]
+        if algorithm in self._exportAlgorithms:
+            return self._exportAlgorithms[algorithm]
         else:
             return False
 
@@ -105,22 +104,20 @@ class DrillExportModel:
         Activate a spefific algorithm.
 
         Args:
-            algorithm (str): name of the algo
+            algorithm (str, str)): name of the algo and output file extension
         """
-        extension = ""
-        if (algorithm, extension) in self._exportAlgorithms:
-            self._exportAlgorithms[(algorithm, extension)] = True
+        if algorithm in self._exportAlgorithms:
+            self._exportAlgorithms[algorithm] = True
 
     def inactivateAlgorithm(self, algorithm):
         """
         Inactivate a specific algorithm.
 
         Args:
-            algorithm (str): name of the algo
+            algorithm (str, str): name of the algo and output file extension
         """
-        extension = ""
-        if (algorithm, extension) in self._exportAlgorithms:
-            self._exportAlgorithms[(algorithm, extension)] = False
+        if algorithm in self._exportAlgorithms:
+            self._exportAlgorithms[algorithm] = False
 
     def _validCriteria(self, ws, algo):
         """

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/drill/model/DrillExportModel.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/drill/model/DrillExportModel.py
@@ -25,11 +25,6 @@ class DrillExportModel:
     _exportAlgorithms = None
 
     """
-    Dictionnary of export file extensions.
-    """
-    _exportExtensions = None
-
-    """
     Dictionnary of export algorithm short doc.
     """
     _exportDocs = None
@@ -57,7 +52,6 @@ class DrillExportModel:
             acquisitionMode (str): acquisition mode
         """
         self._exportAlgorithms = {k: v for k, v in RundexSettings.EXPORT_ALGORITHMS[acquisitionMode].items()}
-        self._exportExtensions = dict()
         self._exportDocs = dict()
         for (a, _) in self._exportAlgorithms.keys():
             try:

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/drill/model/DrillExportModel.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/drill/model/DrillExportModel.py
@@ -20,7 +20,8 @@ import os
 class DrillExportModel:
 
     """
-    Dictionnary containing algorithms and activation state.
+    Dictionnary containing algorithm (name, extension) tuples and activation
+    state.
     """
     _exportAlgorithms = None
 

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/drill/model/DrillExportModel.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/drill/model/DrillExportModel.py
@@ -76,16 +76,7 @@ class DrillExportModel:
         Returns:
             list(str): names of algorithms
         """
-        return [algo for (algo, _) in self._exportAlgorithms.keys()]
-
-    def getAlgorithmExtentions(self):
-        """
-        Get the extension used for the output file of each export algorithm.
-
-        Returns:
-            dict(str:str): dictionnary algo:extension
-        """
-        return {algo:ext for (algo,ext) in self._exportAlgorithms.keys()}
+        return [(algo, ext) for (algo, ext) in self._exportAlgorithms.keys()]
 
     def getAlgorithmDocs(self):
         """

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/drill/model/configurations.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/drill/model/configurations.py
@@ -240,57 +240,47 @@ class RundexSettings(object):
     # it as activated or not
     EXPORT_ALGORITHMS = {
             SANS_ACQ: {
-                "SaveNexusProcessed": False,
-                "SaveAscii": False,
-                "SaveCanSAS1D": True,
-                "SaveNISTDAT": True
+                ("SaveNexusProcessed", ".nxs"): False,
+                ("SaveAscii", ".txt"): False,
+                ("SaveCanSAS1D", ".xml"): True,
+                ("SaveNISTDAT", ".dat"): True
                 },
             SANS_MULTI: {
-                "SaveNexusProcessed": False,
-                "SaveAscii": False,
-                "SaveCanSAS1D": True,
-                "SaveNISTDAT": True
+                ("SaveNexusProcessed", ".nxs"): False,
+                ("SaveAscii", ".txt"): False,
+                ("SaveCanSAS1D", "xml"): True,
+                ("SaveNISTDAT", ".dat"): True
                 },
             REFL_POL: {
-                "SaveNexusProcessed": False,
-                "SaveAscii": False,
-                "SaveReflectometryAscii": True
+                ("SaveNexusProcessed", ".nxs"): False,
+                ("SaveAscii", ".txt"): False,
+                ("SaveReflectometryAscii", ".mft"): True
                 },
             REFL_NPOL: {
-                "SaveNexusProcessed": False,
-                "SaveAscii": False,
-                "SaveReflectometryAscii": True
+                ("SaveNexusProcessed", ".nxs"): False,
+                ("SaveAscii", ".txt"): False,
+                ("SaveReflectometryAscii", ".mft"): True
                 },
             POWDER_DSCAN: {
-                "SaveNexusProcessed": False,
-                "SaveAscii": False,
-                "SaveFocusedXYE": True
+                ("SaveNexusProcessed", ".nxs"): False,
+                ("SaveAscii", ".txt"): False,
+                ("SaveFocusedXYE", ".dat"): True
                 },
             POWDER_PSCAN: {
-                "SaveNexusProcessed": False,
-                "SaveAscii": False,
-                "SaveFocussedXYE": True
+                ("SaveNexusProcessed", ".nxs"): False,
+                ("SaveAscii", ".txt"): False,
+                ("SaveFocussedXYE", ".dat"): True
                 },
             DIRECT_TOF: {
-                "SaveNexusProcessed": True,
-                "SaveAscii": False,
-                "SaveNXSPE": False
+                ("SaveNexusProcessed", ".nxs"): True,
+                ("SaveAscii", ".txt"): False,
+                ("SaveNXSPE", ".nxspe"): False
                 }
             }
 
     EXPORT_ALGO_CRITERIA = {
             "SaveCanSAS1D": "%OutputType% == 'I(Q)'",
             "SaveNISTDAT": "%OutputType% == 'I(Qx,Qy)'",
-            }
-
-    EXPORT_ALGO_EXTENSION = {
-            "SaveNexusProcessed": ".nxs",
-            "SaveAscii": ".txt",
-            "SaveCanSAS1D": ".xml",
-            "SaveNISTDAT": ".dat",
-            "SaveReflectometryAscii": ".mft",
-            "SaveFocussedXYE": ".dat",
-            "SaveNXSPE": ".nxspe"
             }
 
     # ideal number of threads for each acquisition mode (optional)

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/drill/presenter/DrillExportPresenter.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/drill/presenter/DrillExportPresenter.py
@@ -30,9 +30,8 @@ class DrillExportPresenter:
         self._model = model
         self._view.setPresenter(self)
         algorithms = self._model.getAlgorithms()
-        extensions = self._model.getAlgorithmExtentions()
         tooltips = self._model.getAlgorithmDocs()
-        self._view.setAlgorithms(algorithms, extensions, tooltips)
+        self._view.setAlgorithms(algorithms, tooltips)
         states = dict()
         for a in algorithms:
             states[a] = self._model.isAlgorithmActivated(a)

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/drill/test/DrillExportModelTest.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/drill/test/DrillExportModelTest.py
@@ -14,18 +14,13 @@ from mantidqtinterfaces.drill.model.DrillExportModel import DrillExportModel
 class DrillExportModelTest(unittest.TestCase):
 
     EXPORT_ALGORITHMS = {
-            "a1": {"ea1": True, "ea2": False},
-            "a2": {"ea2": True}
+            "a1": {("ea1", ".txt"): True, ("ea2", ".xml"): False},
+            "a2": {("ea2", ".xml"): True}
             }
 
     EXPORT_ALGO_CRITERIA = {
             "ea1": "%param% == 'test'",
             "ea2": "%param% != 'test'"
-            }
-
-    EXPORT_ALGO_EXTENSION = {
-            "ea1": ".txt",
-            "ea2": ".xml"
             }
 
     def setUp(self):
@@ -53,12 +48,6 @@ class DrillExportModelTest(unittest.TestCase):
         self.mAlgoCriteria = patch.start()
         self.addCleanup(patch.stop)
 
-        patch = mock.patch.dict("mantidqtinterfaces.drill.model.DrillExportModel"
-                                ".RundexSettings.EXPORT_ALGO_EXTENSION",
-                                self.EXPORT_ALGO_EXTENSION, clear=True)
-        self.mAlgoExtension = patch.start()
-        self.addCleanup(patch.stop)
-
         patch = mock.patch("mantidqtinterfaces.drill.model.DrillExportModel"
                            ".DrillAlgorithmPool")
         self.mTasksPool = patch.start()
@@ -83,28 +72,39 @@ class DrillExportModelTest(unittest.TestCase):
         self.assertEqual(algs, [a for a in self.EXPORT_ALGORITHMS["a1"]])
 
     def test_isAlgorithmActivated(self):
-        self.assertEqual(self.exportModel._exportAlgorithms["ea1"], True)
-        self.assertEqual(self.exportModel.isAlgorithmActivated("ea1"), True)
-        self.exportModel._exportAlgorithms["ea1"] = False
-        self.assertEqual(self.exportModel.isAlgorithmActivated("ea1"), False)
-        self.assertEqual(self.exportModel._exportAlgorithms["ea2"], False)
-        self.assertEqual(self.exportModel.isAlgorithmActivated("ea2"), False)
+        self.assertEqual(
+                self.exportModel._exportAlgorithms[("ea1", ".txt")], True)
+        self.assertEqual(
+                self.exportModel.isAlgorithmActivated(("ea1", ".txt")), True)
+        self.exportModel._exportAlgorithms[("ea1", ".txt")] = False
+        self.assertEqual(
+                self.exportModel.isAlgorithmActivated(("ea1", ".txt")), False)
+        self.assertEqual(
+                self.exportModel._exportAlgorithms[("ea2", ".xml")], False)
+        self.assertEqual(
+                self.exportModel.isAlgorithmActivated(("ea2", ".xml")), False)
 
     def test_activateAlgorithm(self):
-        self.assertEqual(self.exportModel._exportAlgorithms["ea2"], False)
-        self.exportModel.activateAlgorithm("ea2")
-        self.assertEqual(self.exportModel._exportAlgorithms["ea2"], True)
-        self.exportModel.activateAlgorithm("ea2")
-        self.assertEqual(self.exportModel._exportAlgorithms["ea2"], True)
-        self.exportModel.activateAlgorithm("ea3")
+        self.assertEqual(
+                self.exportModel._exportAlgorithms[("ea2",".xml")], False)
+        self.exportModel.activateAlgorithm(("ea2", ".xml"))
+        self.assertEqual(
+                self.exportModel._exportAlgorithms[("ea2"), (".xml")], True)
+        self.exportModel.activateAlgorithm(("ea2", ".xml"))
+        self.assertEqual(
+                self.exportModel._exportAlgorithms[("ea2", ".xml")], True)
+        self.exportModel.activateAlgorithm(("ea3", ".data"))
 
     def test_inactivateAlgorithm(self):
-        self.assertEqual(self.exportModel._exportAlgorithms["ea1"], True)
-        self.exportModel.inactivateAlgorithm("ea1")
-        self.assertEqual(self.exportModel._exportAlgorithms["ea1"], False)
-        self.exportModel.inactivateAlgorithm("ea1")
-        self.assertEqual(self.exportModel._exportAlgorithms["ea1"], False)
-        self.exportModel.inactivateAlgorithm("ea3")
+        self.assertEqual(
+                self.exportModel._exportAlgorithms[("ea1", ".txt")], True)
+        self.exportModel.inactivateAlgorithm(("ea1", ".txt"))
+        self.assertEqual(
+                self.exportModel._exportAlgorithms[("ea1", ".txt")], False)
+        self.exportModel.inactivateAlgorithm(("ea1", ".txt"))
+        self.assertEqual(
+                self.exportModel._exportAlgorithms[("ea1", ".txt")], False)
+        self.exportModel.inactivateAlgorithm(("ea3", ".data"))
 
     def test_valid_Criteria(self):
         mHist = self.mMtd.__getitem__.return_value.getHistory.return_value

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/drill/view/DrillExportDialog.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/drill/view/DrillExportDialog.py
@@ -25,7 +25,8 @@ class DrillExportDialog(QDialog):
     _presenter = None
 
     """
-    Dictionnary of algorithm names and their corresponding QCheckBox.
+    Dictionnary of algorithm (names, ext) tuples and their corresponding
+    QCheckBox.
     """
     _widgets = None
 

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/drill/view/DrillExportDialog.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/drill/view/DrillExportDialog.py
@@ -87,8 +87,8 @@ class DrillExportDialog(QDialog):
         Set the check state of algorithm.
 
         Args:
-            sates (dict(str:bool)): for each algorithm name, a bool to set its
-                                    check state
+            sates (dict((str, str): bool)): activation state for each algorithm
+                                            (name, ext) tuple
         """
         for a,s in states.items():
             if a in self._widgets:
@@ -99,7 +99,7 @@ class DrillExportDialog(QDialog):
         Get the check state of algorithms.
 
         Returns:
-            dict(str:bool): for each algorithm name, a bool to set its check
-                            state
+            dict((str, str): bool): activation state for each algorithm
+                                    (name, ext) tuple
         """
         return {a:w.isChecked() for a,w in self._widgets.items()}

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/drill/view/DrillExportDialog.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/drill/view/DrillExportDialog.py
@@ -56,34 +56,31 @@ class DrillExportDialog(QDialog):
         """
         self._presenter = presenter
 
-    def setAlgorithms(self, algorithms, extensions, tooltips):
+    def setAlgorithms(self, algorithms, tooltips):
         """
         Set the algorithms displayed on the dialog.
 
         Args:
-            algorithms (list(str)): list of algorithms
-            extensions (dict(str:str)): extension used by each algorithm
+            algorithms (list((str, ext))): list of algorithms and extensions
             tooltips (dict(str:str)): short doc of each algorithm
         """
-        for i in range(len(algorithms)):
-            algo = algorithms[i]
-            if algo in extensions:
-                text = algo + " (" + extensions[algo] + ")"
-            else:
-                text = algo
+        i = 0
+        for (name, ext) in algorithms:
+            text = name + " (" + ext + ")"
             widget = QCheckBox(text, self)
-            if algo in tooltips:
-                widget.setToolTip(tooltips[algo])
-            self._widgets[algorithms[i]] = widget
+            if name in tooltips:
+                widget.setToolTip(tooltips[name])
+            self._widgets[(name, ext)] = widget
             self.algoList.addWidget(widget, i, 0, Qt.AlignLeft)
             helpButton = QToolButton(self)
             helpButton.setText('...')
             helpButton.setIcon(icons.get_icon("mdi.help"))
             helpButton.clicked.connect(
-                    lambda _, a=algorithms[i]: InterfaceManager().showHelpPage(
+                    lambda _, a=name: InterfaceManager().showHelpPage(
                         "qthelp://org.mantidproject/doc/algorithms/{}.html"
                         .format(a)))
             self.algoList.addWidget(helpButton, i, 1, Qt.AlignRight)
+            i += 1
 
     def setAlgorithmCheckStates(self, states):
         """


### PR DESCRIPTION
**Description of work.**

This PR slightly changes the export mechanism on DrILL. This comes from a need expressed by one of our scientists to be able to select two different extensions for one algorithm.

With this PR, the export algorithms are now identified by their name and the extension. Adding a second extension can be done by adding a new tuple `(algorithm, extension)` in the configuration of DrILL.

**To test:**

* code review
* unit tests

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
