### PR TITLE
Add troubleshooting section to UserSupport for broken Qt Help display

### DIFF
--- a/dev-docs/source/UserSupport.rst
+++ b/dev-docs/source/UserSupport.rst
@@ -128,7 +128,7 @@ For a full release, ``C:\MantidInstall\`` is likely the correct install path. Ta
 .. _Trouble_Linux:
 
 Linux
-======
+=====
 
 For a full release, ``/opt/Mantid/`` is likely the correct install path. Take care to readjust this to ``/opt/mantidnightly/`` if you are diagnosing a nightly version.
 
@@ -205,6 +205,24 @@ For a full release, ``/opt/Mantid/`` is likely the correct install path. Take ca
 
 11. Further diagnosis for process monitoring: `strace <https://strace.io/>`_.
 
+Built-in Help Not Displaying
+----------------------------
+
+It has been observed that the built-in help window can display empty content
+under some circumstances.
+If another package has created a directory in the path ``$HOME/.local/share/mime``
+along with a file ``$HOME/.local/share/mime/packages/user-extension-html.xml``
+then that package has registered that it will handle all ``.html`` files,
+causing Mantid help to display a blank page.
+
+The Mantid help can be restored by renaming the ``mime`` directory:
+
+.. code-block:: shell
+
+   mv ~/.local/share/mime .local/share/mime.orig
+
+It is unclear what might break in other applications but nothing as yet has
+been observed.
 
 .. _Trouble_MacOS:
 


### PR DESCRIPTION
**Description of work.**

Add knowledge gained from recent debugging attempt when the Qt Help documentation would not
display due to a custom mime handler being
installed for all html files

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**

* Build the dev docs and check the new section makes sense.
 
*There is no associated issue.*

*This does not require release notes* because **it is developer oriented.**

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
