### PR TITLE
Set default Rebin in Energy in the sqw tab of Indirect Data Reduction

### DIFF
--- a/qt/scientific_interfaces/Indirect/IndirectSqwModel.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectSqwModel.cpp
@@ -47,7 +47,7 @@ namespace MantidQt::CustomInterfaces {
 //----------------------------------------------------------------------------------------------
 /** Constructor
  */
-IndirectSqwModel::IndirectSqwModel() {}
+IndirectSqwModel::IndirectSqwModel() { m_rebinInEnergy = false; }
 
 void IndirectSqwModel::setupRebinAlgorithm(MantidQt::API::BatchAlgorithmRunner *batchAlgoRunner) {
   if (m_rebinInEnergy) {

--- a/qt/scientific_interfaces/Indirect/test/IndirectSqwModelTest.h
+++ b/qt/scientific_interfaces/Indirect/test/IndirectSqwModelTest.h
@@ -74,7 +74,6 @@ public:
     m_model->setQWidth(0.05);
     m_model->setQMax(1.8);
     m_model->setEFixed("0.4");
-    m_model->setRebinInEnergy(false);
 
     m_model->setupRebinAlgorithm(&batch);
     m_model->setupSofQWAlgorithm(&batch);


### PR DESCRIPTION
**Description of work.**

This PR sets the default bool of Rebin in energy in the model of indirect Sqw to false, this fixed a bug that caused a chance that the rebin would happen when the tab was ran if the user did not explicitly set the value to false.

**To test:**
contact me for reduced data if you don't have it.

1. open indirect data reduction and go to the sqw tab.
2. load data
3. click run.
4. there should be no `_r` output.
5. check the rebin by energy box and run again. there should be an `_r` output.
6. remove the _r output and close the interface.
7. repeate these steps to make sure it does not output a rebinned unless specified.

*There is no associated issue.*

*This does not require release notes* because It is a bug that was introduced this release.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
