### PR TITLE
Change to horizontal cursor while hovering over fit plot markers

### DIFF
--- a/docs/source/release/v6.6.0/Workbench/New_features/31319.rst
+++ b/docs/source/release/v6.6.0/Workbench/New_features/31319.rst
@@ -1,0 +1,1 @@
+- Mouse cursor now changes to a horizontal double arrow when hovering over peak and range markers in the fitting tool, indicating they can be dragged left and right.

--- a/qt/applications/workbench/workbench/plotting/figureinteraction.py
+++ b/qt/applications/workbench/workbench/plotting/figureinteraction.py
@@ -680,11 +680,12 @@ class FigureInteraction(object):
         If the cursor is above multiple markers (eg. an intersection) make it into a cross.
         Otherwise set it to the default one.
         :param x_pos: cursor x position
-        :param y_pos: cursor y position
+        :param y_pos: cursor y position(
         """
         if x_pos is None or y_pos is None:
             QApplication.restoreOverrideCursor()
             return
+
         is_moving = any([marker.is_marker_moving() for marker in self.markers])
         hovering_over = sum([1 for marker in self.markers if marker.is_above(x_pos, y_pos)])
         if not is_moving:

--- a/qt/applications/workbench/workbench/plotting/figureinteraction.py
+++ b/qt/applications/workbench/workbench/plotting/figureinteraction.py
@@ -680,7 +680,7 @@ class FigureInteraction(object):
         If the cursor is above multiple markers (eg. an intersection) make it into a cross.
         Otherwise set it to the default one.
         :param x_pos: cursor x position
-        :param y_pos: cursor y position(
+        :param y_pos: cursor y position
         """
         if x_pos is None or y_pos is None:
             QApplication.restoreOverrideCursor()

--- a/qt/applications/workbench/workbench/plotting/figureinteraction.py
+++ b/qt/applications/workbench/workbench/plotting/figureinteraction.py
@@ -685,19 +685,11 @@ class FigureInteraction(object):
         if x_pos is None or y_pos is None:
             QApplication.restoreOverrideCursor()
             return
-
         is_moving = any([marker.is_marker_moving() for marker in self.markers])
-        above_markers = [marker for marker in self.markers if marker.is_above(x_pos, y_pos)]
-        hovering_over = len(above_markers)
-        # hovering_over = sum([1 for marker in self.markers if marker.is_above(x_pos, y_pos)])
+        hovering_over = sum([1 for marker in self.markers if marker.is_above(x_pos, y_pos)])
         if not is_moving:
             if hovering_over == 1:
-                m = above_markers[0]
-                print(m.marker_type)
-                if m.marker_type == 'XSingle':
-                    QApplication.setOverrideCursor(Qt.SizeHorCursor)
-                else:
-                    QApplication.setOverrideCursor(Qt.PointingHandCursor)
+                QApplication.setOverrideCursor(Qt.PointingHandCursor)
             elif hovering_over > 1:
                 QApplication.setOverrideCursor(Qt.CrossCursor)
             else:

--- a/qt/applications/workbench/workbench/plotting/figureinteraction.py
+++ b/qt/applications/workbench/workbench/plotting/figureinteraction.py
@@ -687,10 +687,17 @@ class FigureInteraction(object):
             return
 
         is_moving = any([marker.is_marker_moving() for marker in self.markers])
-        hovering_over = sum([1 for marker in self.markers if marker.is_above(x_pos, y_pos)])
+        above_markers = [marker for marker in self.markers if marker.is_above(x_pos, y_pos)]
+        hovering_over = len(above_markers)
+        # hovering_over = sum([1 for marker in self.markers if marker.is_above(x_pos, y_pos)])
         if not is_moving:
             if hovering_over == 1:
-                QApplication.setOverrideCursor(Qt.PointingHandCursor)
+                m = above_markers[0]
+                print(m.marker_type)
+                if m.marker_type == 'XSingle':
+                    QApplication.setOverrideCursor(Qt.SizeHorCursor)
+                else:
+                    QApplication.setOverrideCursor(Qt.PointingHandCursor)
             elif hovering_over > 1:
                 QApplication.setOverrideCursor(Qt.CrossCursor)
             else:

--- a/qt/python/mantidqt/CMakeLists.txt
+++ b/qt/python/mantidqt/CMakeLists.txt
@@ -112,6 +112,7 @@ set(PYTHON_WIDGET_QT5_ONLY_TESTS
     mantidqt/widgets/colorbar/test/test_colorbar.py
     mantidqt/widgets/fitpropertybrowser/addfunctiondialog/test/test_addfunctiondialogpresenter.py
     mantidqt/widgets/fitpropertybrowser/addfunctiondialog/test/test_addfunctiondialogview.py
+    mantidqt/widgets/fitpropertybrowser/test/test_interactive_tool.py
     mantidqt/widgets/instrumentview/test/test_instrumentview_io.py
     mantidqt/widgets/instrumentview/test/test_instrumentview_presenter.py
     mantidqt/widgets/instrumentview/test/test_instrumentview_view.py

--- a/qt/python/mantidqt/mantidqt/widgets/fitpropertybrowser/interactive_tool.py
+++ b/qt/python/mantidqt/mantidqt/widgets/fitpropertybrowser/interactive_tool.py
@@ -139,11 +139,12 @@ class FitInteractiveTool(QObject):
         if should_redraw:
             self.canvas.draw()
 
-    def update_cursor(self, event):
+    def update_hover_cursor(self, event):
         """
-        Change cursor to horizontal arrows when hovering over peak marker components.
+        Change cursor to horizontal arrows when hovering over markers.
         :param event: A MPL mouse event.
         """
+        # when clicking and dragging, the marker class controls the cursor
         if event.button is not None:
             return
 

--- a/qt/python/mantidqt/mantidqt/widgets/fitpropertybrowser/interactive_tool.py
+++ b/qt/python/mantidqt/mantidqt/widgets/fitpropertybrowser/interactive_tool.py
@@ -4,7 +4,8 @@
 #   NScD Oak Ridge National Laboratory, European Spallation Source,
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
-from qtpy.QtCore import QObject, Signal, Slot
+from qtpy.QtCore import QObject, Signal, Slot, Qt
+from qtpy.QtWidgets import QApplication
 
 from mantid import ConfigService
 from mantidqt.plotting.markers import PeakMarker, RangeMarker
@@ -137,6 +138,29 @@ class FitInteractiveTool(QObject):
             should_redraw = pm.mouse_move(x, y) or should_redraw
         if should_redraw:
             self.canvas.draw()
+
+    def update_cursor(self, event):
+        """
+        Change cursor to horizontal arrows when hovering over peak marker components.
+        :param event: A MPL mouse event.
+        """
+        if event.button is not None:
+            return
+
+        x, y = event.xdata, event.ydata
+        if x is None or y is None:
+            return
+
+        if self.fit_range.min_marker.is_above(x, y) or self.fit_range.max_marker.is_above(x, y):
+            QApplication.setOverrideCursor(Qt.SizeHorCursor)
+            return
+
+        for pm in self.peak_markers:
+            if pm.left_width.is_above(x, y) or pm.right_width.is_above(x, y) or pm.centre_marker.is_above(x, y):
+                QApplication.setOverrideCursor(Qt.SizeHorCursor)
+                return
+
+        QApplication.restoreOverrideCursor()
 
     def start_move_markers(self, event):
         """

--- a/qt/python/mantidqt/mantidqt/widgets/fitpropertybrowser/mouse_state_machine.py
+++ b/qt/python/mantidqt/mantidqt/widgets/fitpropertybrowser/mouse_state_machine.py
@@ -75,7 +75,7 @@ class MoveMarkersState(object):
 
     def motion_notify_callback(self, event):
         """Override base class method"""
-        self.tool.update_cursor(event)
+        self.tool.update_hover_cursor(event)
         self.tool.move_markers(event)
 
     def button_release_callback(self, event):

--- a/qt/python/mantidqt/mantidqt/widgets/fitpropertybrowser/mouse_state_machine.py
+++ b/qt/python/mantidqt/mantidqt/widgets/fitpropertybrowser/mouse_state_machine.py
@@ -75,6 +75,7 @@ class MoveMarkersState(object):
 
     def motion_notify_callback(self, event):
         """Override base class method"""
+        self.tool.update_cursor(event)
         self.tool.move_markers(event)
 
     def button_release_callback(self, event):

--- a/qt/python/mantidqt/mantidqt/widgets/fitpropertybrowser/test/__init__.py
+++ b/qt/python/mantidqt/mantidqt/widgets/fitpropertybrowser/test/__init__.py
@@ -1,0 +1,9 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2022 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+#  This file is part of the mantidqt package
+#
+#

--- a/qt/python/mantidqt/mantidqt/widgets/fitpropertybrowser/test/test_interactive_tool.py
+++ b/qt/python/mantidqt/mantidqt/widgets/fitpropertybrowser/test/test_interactive_tool.py
@@ -1,0 +1,20 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2022 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+#  This file is part of the mantid workbench.
+#
+import unittest
+from mantidqt.mantidqt.widgets.fitpropertybrowser.interactive_tool import FitInteractiveTool
+from unittest.mock import MagicMock
+
+
+class FitInteractiveToolTest(unittest.TestCase):
+
+    def setUp(self) -> None:
+        canvas = MagicMock()
+        toolbar_manager = MagicMock()
+        current_peak_type = MagicMock()
+        self.interactor = FitInteractiveTool(canvas, toolbar_manager, current_peak_type)

--- a/qt/python/mantidqt/mantidqt/widgets/fitpropertybrowser/test/test_interactive_tool.py
+++ b/qt/python/mantidqt/mantidqt/widgets/fitpropertybrowser/test/test_interactive_tool.py
@@ -6,15 +6,54 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 #  This file is part of the mantid workbench.
 #
+
+
 import unittest
-from mantidqt.mantidqt.widgets.fitpropertybrowser.interactive_tool import FitInteractiveTool
-from unittest.mock import MagicMock
+from mantidqt.widgets.fitpropertybrowser.interactive_tool import FitInteractiveTool
+from mantidqt.utils.qt.testing import start_qapplication
+from unittest.mock import MagicMock, patch
+from qtpy.QtWidgets import QApplication
+from qtpy.QtCore import Qt
 
 
+@start_qapplication
 class FitInteractiveToolTest(unittest.TestCase):
 
-    def setUp(self) -> None:
+    @patch('mantidqt.plotting.markers.VerticalMarker')
+    def setUp(self, mock_v_marker) -> None:
+        mock_v_marker._get_y0_y1 = MagicMock(return_value=(0, 1))
         canvas = MagicMock()
         toolbar_manager = MagicMock()
         current_peak_type = MagicMock()
         self.interactor = FitInteractiveTool(canvas, toolbar_manager, current_peak_type)
+
+    def tearDown(self) -> None:
+        del self.interactor
+
+    def cursor_hover_over_marker_test_helper(self, above, expected_cursor):
+        with patch('mantidqt.plotting.markers.SingleMarker.is_inside_bounds', return_value=(True, 1)):
+            with patch('mantidqt.plotting.markers.RangeMarker.get_range', return_value=[0, 10]):
+                # set is_above to return True, simulating cursor hovering over a marker
+                with patch('mantidqt.plotting.markers.SingleMarker.is_above', return_value=above):
+                    event = MagicMock()
+                    event.xdata = 1
+                    event.ydata = 2
+                    event.button = None
+
+                    self.interactor.toolbar_manager.is_tool_active = MagicMock(return_value=False)
+                    self.interactor.motion_notify_callback(event)
+
+                    self.assertEqual(expected_cursor, QApplication.overrideCursor())
+
+    def test_hover_over_marker_sets_override_cursor(self):
+        expected_cursor = Qt.SizeHorCursor
+        self.cursor_hover_over_marker_test_helper(True, expected_cursor)
+
+    def test_not_hover_over_marker_restores_override_cursor(self):
+        expected_cursor = Qt.ArrowCursor
+
+        # set twice since restoreOverrideCursor returns the previous cursor set
+        QApplication.setOverrideCursor(expected_cursor)
+        QApplication.setOverrideCursor(expected_cursor)
+
+        self.cursor_hover_over_marker_test_helper(False, expected_cursor)

--- a/qt/python/mantidqt/mantidqt/widgets/fitpropertybrowser/test/test_interactive_tool.py
+++ b/qt/python/mantidqt/mantidqt/widgets/fitpropertybrowser/test/test_interactive_tool.py
@@ -9,11 +9,13 @@
 
 
 import unittest
-from mantidqt.widgets.fitpropertybrowser.interactive_tool import FitInteractiveTool
-from mantidqt.utils.qt.testing import start_qapplication
 from unittest.mock import MagicMock, patch
-from qtpy.QtWidgets import QApplication
+
 from qtpy.QtCore import Qt
+from qtpy.QtWidgets import QApplication
+
+from mantidqt.utils.qt.testing import start_qapplication
+from mantidqt.widgets.fitpropertybrowser.interactive_tool import FitInteractiveTool
 
 
 @start_qapplication
@@ -33,7 +35,8 @@ class FitInteractiveToolTest(unittest.TestCase):
     def cursor_hover_over_marker_test_helper(self, above, expected_cursor):
         with patch('mantidqt.plotting.markers.SingleMarker.is_inside_bounds', return_value=(True, 1)):
             with patch('mantidqt.plotting.markers.RangeMarker.get_range', return_value=[0, 10]):
-                # set is_above to return True, simulating cursor hovering over a marker
+                # is_above = True -> cursor is hovering over a marker
+                # is_above = False -> cursor is not hovering ove a marker
                 with patch('mantidqt.plotting.markers.SingleMarker.is_above', return_value=above):
                     event = MagicMock()
                     event.xdata = 1

--- a/qt/python/mantidqt/mantidqt/widgets/fitpropertybrowser/test/test_interactive_tool.py
+++ b/qt/python/mantidqt/mantidqt/widgets/fitpropertybrowser/test/test_interactive_tool.py
@@ -46,7 +46,7 @@ class FitInteractiveToolTest(unittest.TestCase):
                     self.interactor.toolbar_manager.is_tool_active = MagicMock(return_value=False)
                     self.interactor.motion_notify_callback(event)
 
-                    self.assertEqual(expected_cursor, QApplication.overrideCursor())
+                    self.assertEqual(expected_cursor, QApplication.overrideCursor().shape())
 
     def test_hover_over_marker_sets_override_cursor(self):
         expected_cursor = Qt.SizeHorCursor


### PR DESCRIPTION
**Description of work.**

When hovering over a peak or range marker in the fitting tool, the mouse cursor now changes to a horizontal double arrow to indicate that the markers can be dragged left and right.

- added `update_hover_cursor` to `fitpropertybrowser/interactive_tool.py` to handel cursor change logic
- added `update_hover_cursor` call to `motion_notify_callback` so it is run when the house is moved on the matplotlib canvas
- added tests

**To test:**

- Load `SXD23767.raw` (or really any data)
- Double-click the workspace to open a plot
- Click 'Fit' to open the fitting tool
- Right-click and add a peak
- Hover the mouse over the green range markers and check it changes to a horizontal double arrow
- Hover over the three markers that make up the peak marker and check it changes to a horizontal double arrow
- Click and drag the different markers to move them around

Fixes #31319

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
