### PR TITLE
Catch error thrown when overlay peaks side-by-side view in instrument view

### DIFF
--- a/docs/source/release/v6.5.0/Workbench/InstrumentViewer/Bugfixes/34460.rst
+++ b/docs/source/release/v6.5.0/Workbench/InstrumentViewer/Bugfixes/34460.rst
@@ -1,0 +1,1 @@
+- Fix crash when overlaying peaks in side-by-side view of instrument viewer which is not supported.

--- a/qt/widgets/instrumentview/src/PeakOverlay.cpp
+++ b/qt/widgets/instrumentview/src/PeakOverlay.cpp
@@ -245,13 +245,18 @@ void PeakOverlay::createMarkers(const PeakMarker2D::Style &style) {
       return;
     }
     // Project the peak (detector) position onto u,v coords
-    double u, v, uscale, vscale;
-    m_surface->project(pos, u, v, uscale, vscale);
-
-    // Create a peak marker at this position
-    PeakMarker2D *r = new PeakMarker2D(*this, u, v, m_peakIntensityScale->getScaledMarker(peak.getIntensity(), style));
-    r->setPeak(peak, i);
-    addMarker(r);
+    try {
+      double u, v, uscale, vscale;
+      m_surface->project(pos, u, v, uscale, vscale);
+      // Create a peak marker at this position
+      PeakMarker2D *r =
+          new PeakMarker2D(*this, u, v, m_peakIntensityScale->getScaledMarker(peak.getIntensity(), style));
+      r->setPeak(peak, i);
+      addMarker(r);
+    } catch (const std::runtime_error &ex) {
+      g_log.error(ex.what());
+      return;
+    }
   }
 
   deselectAll();


### PR DESCRIPTION
**Description of work.**
 Small fix to catch error thrown when overlay peaks side-by-side view in instrument view

To-Do
- Add test if possible

**To test:**
(1) Follow instructions on issue - it should now print an error to the log rather than crash

Fixes #34365 
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
