### PR TITLE
Fixed delta function and elastic* functions not interacting with the fitting GUI

### DIFF
--- a/Framework/CurveFitting/inc/MantidCurveFitting/Functions/DeltaFunction.h
+++ b/Framework/CurveFitting/inc/MantidCurveFitting/Functions/DeltaFunction.h
@@ -30,10 +30,10 @@ public:
   DeltaFunction();
 
   /// overwrite IPeakFunction base class methods
-  double centre() const override { return 0; }
+  double centre() const override { return getParameter("Centre"); }
   double height() const override { return getParameter("Height"); }
   double fwhm() const override { return 0; }
-  void setCentre(const double c) override { UNUSED_ARG(c); }
+  void setCentre(const double c) override { setParameter("Centre", c); }
   void setHeight(const double h) override { setParameter("Height", h); }
   void setFwhm(const double w) override { UNUSED_ARG(w); }
   virtual double HeightPrefactor() const { return 1.0; } // modulates the Height of the Delta function

--- a/docs/source/release/v6.6.0/Workbench/Bugfixes/31547.rst
+++ b/docs/source/release/v6.6.0/Workbench/Bugfixes/31547.rst
@@ -1,0 +1,1 @@
+- Fixed bug where Delta and Elastic function peaks were not connected to the fitting window GUI.


### PR DESCRIPTION
**Description of work.**

Added implementations of `centre()` and `setCentre()` to `DeltaFunction.h`.

**To test:**

- Load data
- Open a plot and click the 'Fit' button
- Right click and 'Select peak type'
- Choose 'DeltaFunction' and add to the plot somewhere
- Check that the marker is added where you clicked
- Check then when you drag the marker left and right that the Centre value changes (on the left hand side)
- Repeat this for 'ElasticDiffRotDiscreteCircle', 'ElasticDiffSphere', and 'ElasticIsoRocDiff'

Fixes #31547 #31550

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
