### PR TITLE
Stop de-referencing of a null pointer in FindSXPeaks for NaN data

### DIFF
--- a/Framework/Crystal/src/FindSXPeaksHelper.cpp
+++ b/Framework/Crystal/src/FindSXPeaksHelper.cpp
@@ -446,7 +446,8 @@ AllPeaksStrategy::getAllPeaks(const HistogramData::HistogramX &x, const Histogra
     // 4. Recording + above threshold => continue recording
     if (!isRecording && !isAboveThreshold) {
       continue;
-    } else if (!isRecording && isAboveThreshold) {
+    } else if (!isRecording && isAboveThreshold && std::isfinite(signal)) {
+      // only start recording if is finite as NaN values will be found to be above threshold
       currentPeak = std::make_unique<PeakContainer>(y);
       currentPeak->startRecord(it);
       isRecording = true;
@@ -456,6 +457,7 @@ AllPeaksStrategy::getAllPeaks(const HistogramData::HistogramX &x, const Histogra
       currentPeak = nullptr;
       isRecording = false;
     } else {
+      // this will continue to record NaN if previous point was above the background
       currentPeak->record(it);
     }
   }
@@ -654,8 +656,11 @@ std::vector<SXPeak> FindMaxReduceStrategy::getFinalPeaks(const std::vector<std::
       }
     }
 
-    // Add the max peak
-    peaks.emplace_back(*maxPeak);
+    // Add the max peak if valid
+    if (maxPeak) {
+      // check not null as is case when intensity is NaN (though this shouldn't occur now)
+      peaks.emplace_back(*maxPeak);
+    }
   }
   return peaks;
 }

--- a/Framework/Crystal/src/FindSXPeaksHelper.cpp
+++ b/Framework/Crystal/src/FindSXPeaksHelper.cpp
@@ -444,7 +444,7 @@ AllPeaksStrategy::getAllPeaks(const HistogramData::HistogramX &x, const Histogra
     // 2. Not recording + above treshold => start recording
     // 3. Recording + below threshold => stop recording
     // 4. Recording + above threshold => continue recording
-    if (!isRecording && !isAboveThreshold) {
+    if (!isRecording && (!std::isfinite(signal) || !isAboveThreshold)) {
       continue;
     } else if (!isRecording && isAboveThreshold && std::isfinite(signal)) {
       // only start recording if is finite as NaN values will be found to be above threshold

--- a/docs/source/release/v6.5.0/Diffraction/Single_Crystal/Bugfixes/34466.rst
+++ b/docs/source/release/v6.5.0/Diffraction/Single_Crystal/Bugfixes/34466.rst
@@ -1,0 +1,1 @@
+- Fix bug in :ref:`FindSXPeaks <algm-FindSXPeaks>` which caused a crash for non-finite data (e.g. NaN after dividing intensity in a bin by 0).


### PR DESCRIPTION
**Description of work.**

NaN data led to a de-referencing of a null pointer as any logical comparison including a NaN returns false - in this case  NaN > min(). So to be on the safe side I have added a check for a nullptr before appending to the vector of peaks.

However it is not ideal that to record NaN data as a peak so I have also stopped the initial peak search starting to record a peak for NaN data -  although the current behaviour of treating a NaN value as above the threshold is maintained so that if there is a bin with NaN between bins with intensities above the threshold then there will only be a single peak created. A peak including bins with naN is not an issue as the intensity returned by `element->getIntensity() ` is actually the maximum intensity observed within the peak range (the calculation of which is not affected by NaN).


**To test:**

(1) Run this script (should not throw an exception or crash mantid)
```
ws = CreateSampleWorkspace("Histogram", "Flat background", NumBanks=1, BankPixelWidth=1)
MoveInstrumentComponent(Workspace='ws', ComponentName='bank1', X=5, Y=-0.1, Z=0.1, RelativePosition=False)  # so peak isn't at Q=0
y = ws.dataY(0)
y[10:20] = np.nan
y[49] = 2
FindSXPeaks(InputWorkspace='ws', PeakFindingStrategy='AllPeaks', AbsoluteBackground=0, ResolutionStrategy='AbsoluteResolution', XResolution=400, PhiResolution=3, TwoThetaResolution=3, OutputWorkspace='peaks')
```
(2) There should be a single peak in `peaks` at TOF = 9900


Fixes #34464 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
