### PR TITLE
Fixed not being able to select peak markers after creating others

### DIFF
--- a/docs/source/release/v6.6.0/Workbench/Bugfixes/31315.rst
+++ b/docs/source/release/v6.6.0/Workbench/Bugfixes/31315.rst
@@ -1,0 +1,1 @@
+- Fixed a bug where the user couldn't reselect a peak in the fitting tool after adding another

--- a/qt/python/mantidqt/mantidqt/widgets/fitpropertybrowser/interactive_tool.py
+++ b/qt/python/mantidqt/mantidqt/widgets/fitpropertybrowser/interactive_tool.py
@@ -151,7 +151,7 @@ class FitInteractiveTool(QObject):
         selected_peak = None
         for pm in self.peak_markers:
             pm.mouse_move_start(x, y)
-            if pm.is_moving:
+            if pm.is_moving():
                 selected_peak = pm
         if selected_peak is not None:
             self.select_peak(selected_peak)


### PR DESCRIPTION
**Description of work.**

Fixed a function call in `interactive_tool.py` so if statement is not always true

**To test:**

- Load data and open plot
- Click the 'Fit' button
- Add multiple peaks
- Check that clicking on any peak now changes it's colour to red and shows it's width markers

Fixes #31315

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
