### PR TITLE
Stop using ScaleRHSWorkspace parameter in Stitch1DMany in favour of IndexOfReference parameter

### DIFF
--- a/Framework/Algorithms/inc/MantidAlgorithms/Stitch1DMany.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/Stitch1DMany.h
@@ -59,7 +59,7 @@ private:
   bool m_scaleRHSWorkspace = true;
   bool m_useManualScaleFactors = false;
   size_t m_scaleFactorFromPeriod = 1;
-  size_t m_indexOfReference = 0;
+  int m_indexOfReference = 0;
 };
 
 } // namespace Algorithms

--- a/Framework/Algorithms/inc/MantidAlgorithms/Stitch1DMany.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/Stitch1DMany.h
@@ -56,7 +56,6 @@ private:
   std::vector<double> m_manualScaleFactors;
   API::Workspace_sptr m_outputWorkspace;
 
-  bool m_scaleRHSWorkspace = true;
   bool m_useManualScaleFactors = false;
   size_t m_scaleFactorFromPeriod = 1;
   int m_indexOfReference = 0;

--- a/Framework/Algorithms/src/Stitch1DMany.cpp
+++ b/Framework/Algorithms/src/Stitch1DMany.cpp
@@ -15,6 +15,7 @@
 #include "MantidKernel/OptionalBool.h"
 #include "MantidKernel/RebinParamsValidator.h"
 #include "MantidKernel/VisibleWhenProperty.h"
+#include <MantidKernel/InvisibleProperty.h>
 #include <memory>
 
 using namespace Mantid::Kernel;
@@ -49,6 +50,8 @@ void Stitch1DMany::init() {
       "Scaling either with respect to first (first hand side, LHS) "
       "or second (right hand side, RHS) workspace. "
       "This property no longer has an effect, please use the IndexOfReference property instead.");
+  // Hide this property from the GUI as it now has no effect and will eventually be removed
+  setPropertySettings("ScaleRHSWorkspace", std::make_unique<InvisibleProperty>());
 
   declareProperty(std::make_unique<PropertyWithValue<bool>>("UseManualScaleFactors", false, Direction::Input),
                   "True to use provided values for the scale factor.");

--- a/Framework/Algorithms/src/Stitch1DMany.cpp
+++ b/Framework/Algorithms/src/Stitch1DMany.cpp
@@ -124,8 +124,8 @@ std::map<std::string, std::string> Stitch1DMany::validateInputs() {
       }
       if (!isDefault("IndexOfReference")) {
         m_indexOfReference = static_cast<int>(this->getProperty("IndexOfReference"));
-        if (m_indexOfReference > -1 && m_indexOfReference >= column.size() &&
-            m_indexOfReference >= m_inputWSMatrix.size()) {
+        if (m_indexOfReference > -1 && static_cast<size_t>(m_indexOfReference) >= column.size() &&
+            static_cast<size_t>(m_indexOfReference) >= m_inputWSMatrix.size()) {
           issues["IndexOfReference"] = "The index of reference workspace is larger than the number of "
                                        "provided workspaces.";
         }
@@ -235,7 +235,7 @@ void Stitch1DMany::exec() {
 
         outName = groupName;
         std::vector<double> scaleFactors;
-        doStitch1DMany(i, m_useManualScaleFactors, outName, scaleFactors, static_cast<int>(m_indexOfReference));
+        doStitch1DMany(i, m_useManualScaleFactors, outName, scaleFactors, m_indexOfReference);
 
         // Add the resulting workspace to the list to be grouped together
         toGroup.emplace_back(outName);
@@ -249,8 +249,7 @@ void Stitch1DMany::exec() {
       std::vector<double> periodScaleFactors;
       constexpr bool storeInADS = false;
 
-      doStitch1DMany(m_scaleFactorFromPeriod, false, tempOutName, periodScaleFactors,
-                     static_cast<int>(m_indexOfReference), storeInADS);
+      doStitch1DMany(m_scaleFactorFromPeriod, false, tempOutName, periodScaleFactors, m_indexOfReference, storeInADS);
 
       // Iterate over each period
       for (size_t i = 0; i < m_inputWSMatrix.front().size(); ++i) {

--- a/Framework/Algorithms/test/Stitch1DManyTest.h
+++ b/Framework/Algorithms/test/Stitch1DManyTest.h
@@ -1525,4 +1525,246 @@ public:
     TS_ASSERT_EQUALS(wsInADS.size(), 2)
     Mantid::API::AnalysisDataService::Instance().clear();
   }
+
+  void test_two_workspaces_scale_left() {
+    // Two matrix workspaces with two spectra each
+    createUniformWorkspace(0.1, 0.1, 1., 2., "ws1");
+    createUniformWorkspace(0.8, 0.1, 1.1, 2.1, "ws2");
+    Stitch1DMany alg;
+    alg.setChild(true);
+    alg.initialize();
+    alg.setProperty("InputWorkspaces", "ws1, ws2");
+    alg.setProperty("Params", "0.1, 0.1, 1.8");
+    alg.setProperty("StartOverlaps", "0.8");
+    alg.setProperty("EndOverlaps", "1.1");
+    alg.setProperty("ScaleRHSWorkspace", "0");
+    alg.setProperty("IndexOfReference", "-1");
+    alg.setProperty("OutputWorkspace", "outws");
+    alg.execute();
+    TS_ASSERT(alg.isExecuted());
+
+    // Test output ws
+    Workspace_sptr outws = alg.getProperty("OutputWorkspace");
+    TS_ASSERT(outws);
+    auto stitched = std::dynamic_pointer_cast<MatrixWorkspace>(outws);
+    TS_ASSERT_EQUALS(stitched->getNumberHistograms(), 2);
+    TS_ASSERT_EQUALS(stitched->blocksize(), 17);
+    TS_ASSERT_DELTA(stitched->y(0)[0], 1.1, 0.00001);
+    TS_ASSERT_DELTA(stitched->y(0)[9], 1.1, 0.00001);
+    TS_ASSERT_DELTA(stitched->y(0)[16], 1.1, 0.00001);
+    TS_ASSERT_DELTA(stitched->y(1)[0], 2.1, 0.00001);
+    TS_ASSERT_DELTA(stitched->y(1)[9], 2.1, 0.00001);
+    TS_ASSERT_DELTA(stitched->y(1)[16], 2.1, 0.00001);
+    TS_ASSERT_DELTA(stitched->e(0)[0], 1.40712, 0.00001);
+    TS_ASSERT_DELTA(stitched->e(0)[9], 0.84091, 0.00001);
+    TS_ASSERT_DELTA(stitched->e(0)[16], 1.04880, 0.00001);
+    TS_ASSERT_DELTA(stitched->e(1)[0], 1.90787, 0.00001);
+    TS_ASSERT_DELTA(stitched->e(1)[9], 1.15399, 0.00001);
+    TS_ASSERT_DELTA(stitched->e(1)[16], 1.44913, 0.00001);
+    // Test out scale factors
+    std::vector<double> scales = alg.getProperty("OutScaleFactors");
+    TS_ASSERT_EQUALS(scales.size(), 1);
+    // Only scale factor for first spectrum is returned
+    TS_ASSERT_DELTA(scales.front(), 1.09999, 0.00001);
+
+    // Cross-check that the result of using Stitch1DMany with two workspaces
+    // is the same as using Stitch1D
+    Mantid::Algorithms::Stitch1D alg2;
+    alg2.setChild(true);
+    alg2.initialize();
+    alg2.setProperty("LHSWorkspace", "ws1");
+    alg2.setProperty("RHSWorkspace", "ws2");
+    alg2.setProperty("Params", "0.1, 0.1, 1.8");
+    alg2.setProperty("StartOverlap", "0.8");
+    alg2.setProperty("EndOverlap", "1.1");
+    alg2.setProperty("ScaleRHSWorkspace", "0");
+    alg2.setProperty("OutputWorkspace", "outws");
+    alg2.execute();
+    MatrixWorkspace_sptr stitched2 = alg2.getProperty("OutputWorkspace");
+
+    TS_ASSERT_EQUALS(stitched->x(0).rawData(), stitched2->x(0).rawData());
+    TS_ASSERT_EQUALS(stitched->y(0).rawData(), stitched2->y(0).rawData());
+    TS_ASSERT_EQUALS(stitched->e(0).rawData(), stitched2->e(0).rawData());
+
+    // Check workspaces in ADS
+    auto wsInADS = AnalysisDataService::Instance().getObjectNames();
+    // In ADS: ws1, ws2
+    TS_ASSERT_EQUALS(wsInADS.size(), 2)
+    // Remove workspaces from ADS
+    AnalysisDataService::Instance().clear();
+  }
+
+  void test_three_workspaces_scale_left() {
+    // Three matrix workspaces with two spectra each,
+    // Scale the stitched output to the RHS workspace.
+
+    createUniformWorkspace(0.1, 0.1, 1., 2., "ws1");
+    createUniformWorkspace(0.8, 0.1, 1.1, 2.1, "ws2");
+    createUniformWorkspace(1.6, 0.1, 1.5, 2.5, "ws3");
+
+    Stitch1DMany alg;
+    alg.setChild(true);
+    alg.initialize();
+    alg.setProperty("InputWorkspaces", "ws1, ws2, ws3");
+    alg.setProperty("Params", "0.1, 0.1, 2.6");
+    alg.setProperty("StartOverlaps", "0.8, 1.6");
+    alg.setProperty("EndOverlaps", "1.1, 1.8");
+    alg.setProperty("OutputWorkspace", "outws");
+    alg.setProperty("ScaleRHSWorkspace", "0");
+    alg.setProperty("IndexOfReference", "-1");
+    alg.execute();
+    TS_ASSERT(alg.isExecuted());
+
+    // Test output ws
+    Workspace_sptr outws = alg.getProperty("OutputWorkspace");
+    TS_ASSERT(outws);
+    const auto stitched = std::dynamic_pointer_cast<MatrixWorkspace>(outws);
+
+    TS_ASSERT_EQUALS(stitched->getNumberHistograms(), 2);
+    TS_ASSERT_EQUALS(stitched->blocksize(), 25);
+    // First spectrum, Y values
+    TS_ASSERT_DELTA(stitched->y(0)[0], 1.50, 0.01);
+    TS_ASSERT_DELTA(stitched->y(0)[10], 1.50, 0.01);
+    TS_ASSERT_DELTA(stitched->y(0)[18], 1.50, 0.01);
+    // Second spectrum, Y values
+    TS_ASSERT_DELTA(stitched->y(1)[0], 2.50, 0.01);
+    TS_ASSERT_DELTA(stitched->y(1)[10], 2.50, 0.01);
+    TS_ASSERT_DELTA(stitched->y(1)[18], 2.50, 0.01);
+    // First spectrum, E values
+    TS_ASSERT_DELTA(stitched->e(0)[0], 2.33, 0.01);
+    TS_ASSERT_DELTA(stitched->e(0)[10], 1.95, 0.01);
+    TS_ASSERT_DELTA(stitched->e(0)[18], 1.22, 0.01);
+    // Second spectrum, E values
+    TS_ASSERT_DELTA(stitched->e(1)[0], 2.81, 0.01);
+    TS_ASSERT_DELTA(stitched->e(1)[10], 2.39, 0.01);
+    TS_ASSERT_DELTA(stitched->e(1)[18], 1.58, 0.01);
+
+    // Check workspaces in ADS
+    auto wsInADS = AnalysisDataService::Instance().getObjectNames();
+    // In ADS: ws1, ws2, ws3
+    TS_ASSERT_EQUALS(wsInADS.size(), 3)
+    // Remove workspaces from ADS
+    AnalysisDataService::Instance().clear();
+  }
+
+  void test_two_workspaces_scale_left_with_ScaleRHSWorkspace_true() {
+    // Two matrix workspaces with two spectra each
+    createUniformWorkspace(0.1, 0.1, 1., 2., "ws1");
+    createUniformWorkspace(0.8, 0.1, 1.1, 2.1, "ws2");
+    Stitch1DMany alg;
+    alg.setChild(true);
+    alg.initialize();
+    alg.setProperty("InputWorkspaces", "ws1, ws2");
+    alg.setProperty("Params", "0.1, 0.1, 1.8");
+    alg.setProperty("StartOverlaps", "0.8");
+    alg.setProperty("EndOverlaps", "1.1");
+    alg.setProperty("ScaleRHSWorkspace", "1");
+    alg.setProperty("IndexOfReference", "-1");
+    alg.setProperty("OutputWorkspace", "outws");
+    alg.execute();
+    TS_ASSERT(alg.isExecuted());
+
+    // Test output ws
+    Workspace_sptr outws = alg.getProperty("OutputWorkspace");
+    TS_ASSERT(outws);
+    auto stitched = std::dynamic_pointer_cast<MatrixWorkspace>(outws);
+    TS_ASSERT_EQUALS(stitched->getNumberHistograms(), 2);
+    TS_ASSERT_EQUALS(stitched->blocksize(), 17);
+    TS_ASSERT_DELTA(stitched->y(0)[0], 1.1, 0.00001);
+    TS_ASSERT_DELTA(stitched->y(0)[9], 1.1, 0.00001);
+    TS_ASSERT_DELTA(stitched->y(0)[16], 1.1, 0.00001);
+    TS_ASSERT_DELTA(stitched->y(1)[0], 2.1, 0.00001);
+    TS_ASSERT_DELTA(stitched->y(1)[9], 2.1, 0.00001);
+    TS_ASSERT_DELTA(stitched->y(1)[16], 2.1, 0.00001);
+    TS_ASSERT_DELTA(stitched->e(0)[0], 1.40712, 0.00001);
+    TS_ASSERT_DELTA(stitched->e(0)[9], 0.84091, 0.00001);
+    TS_ASSERT_DELTA(stitched->e(0)[16], 1.04880, 0.00001);
+    TS_ASSERT_DELTA(stitched->e(1)[0], 1.90787, 0.00001);
+    TS_ASSERT_DELTA(stitched->e(1)[9], 1.15399, 0.00001);
+    TS_ASSERT_DELTA(stitched->e(1)[16], 1.44913, 0.00001);
+    // Test out scale factors
+    std::vector<double> scales = alg.getProperty("OutScaleFactors");
+    TS_ASSERT_EQUALS(scales.size(), 1);
+    // Only scale factor for first spectrum is returned
+    TS_ASSERT_DELTA(scales.front(), 1.09999, 0.00001);
+
+    // Cross-check that the result of using Stitch1DMany with two workspaces
+    // is the same as using Stitch1D
+    Mantid::Algorithms::Stitch1D alg2;
+    alg2.setChild(true);
+    alg2.initialize();
+    alg2.setProperty("LHSWorkspace", "ws1");
+    alg2.setProperty("RHSWorkspace", "ws2");
+    alg2.setProperty("Params", "0.1, 0.1, 1.8");
+    alg2.setProperty("StartOverlap", "0.8");
+    alg2.setProperty("EndOverlap", "1.1");
+    alg2.setProperty("ScaleRHSWorkspace", "0");
+    alg2.setProperty("OutputWorkspace", "outws");
+    alg2.execute();
+    MatrixWorkspace_sptr stitched2 = alg2.getProperty("OutputWorkspace");
+
+    TS_ASSERT_EQUALS(stitched->x(0).rawData(), stitched2->x(0).rawData());
+    TS_ASSERT_EQUALS(stitched->y(0).rawData(), stitched2->y(0).rawData());
+    TS_ASSERT_EQUALS(stitched->e(0).rawData(), stitched2->e(0).rawData());
+
+    // Check workspaces in ADS
+    auto wsInADS = AnalysisDataService::Instance().getObjectNames();
+    // In ADS: ws1, ws2
+    TS_ASSERT_EQUALS(wsInADS.size(), 2)
+    // Remove workspaces from ADS
+    AnalysisDataService::Instance().clear();
+  }
+
+  void test_three_workspaces_scale_left_with_ScaleRHSWorkspace_true() {
+    // Three matrix workspaces with two spectra each,
+    // Scale the stitched output to the RHS workspace.
+
+    createUniformWorkspace(0.1, 0.1, 1., 2., "ws1");
+    createUniformWorkspace(0.8, 0.1, 1.1, 2.1, "ws2");
+    createUniformWorkspace(1.6, 0.1, 1.5, 2.5, "ws3");
+
+    Stitch1DMany alg;
+    alg.setChild(true);
+    alg.initialize();
+    alg.setProperty("InputWorkspaces", "ws1, ws2, ws3");
+    alg.setProperty("Params", "0.1, 0.1, 2.6");
+    alg.setProperty("StartOverlaps", "0.8, 1.6");
+    alg.setProperty("EndOverlaps", "1.1, 1.8");
+    alg.setProperty("OutputWorkspace", "outws");
+    alg.setProperty("ScaleRHSWorkspace", "1");
+    alg.setProperty("IndexOfReference", "-1");
+    alg.execute();
+    TS_ASSERT(alg.isExecuted());
+
+    // Test output ws
+    Workspace_sptr outws = alg.getProperty("OutputWorkspace");
+    TS_ASSERT(outws);
+    const auto stitched = std::dynamic_pointer_cast<MatrixWorkspace>(outws);
+
+    TS_ASSERT_EQUALS(stitched->getNumberHistograms(), 2);
+    TS_ASSERT_EQUALS(stitched->blocksize(), 25);
+    // First spectrum, Y values
+    TS_ASSERT_DELTA(stitched->y(0)[0], 1.50, 0.01);
+    TS_ASSERT_DELTA(stitched->y(0)[10], 1.50, 0.01);
+    TS_ASSERT_DELTA(stitched->y(0)[18], 1.50, 0.01);
+    // Second spectrum, Y values
+    TS_ASSERT_DELTA(stitched->y(1)[0], 2.50, 0.01);
+    TS_ASSERT_DELTA(stitched->y(1)[10], 2.50, 0.01);
+    TS_ASSERT_DELTA(stitched->y(1)[18], 2.50, 0.01);
+    // First spectrum, E values
+    TS_ASSERT_DELTA(stitched->e(0)[0], 2.33, 0.01);
+    TS_ASSERT_DELTA(stitched->e(0)[10], 1.95, 0.01);
+    TS_ASSERT_DELTA(stitched->e(0)[18], 1.22, 0.01);
+    // Second spectrum, E values
+    TS_ASSERT_DELTA(stitched->e(1)[0], 2.81, 0.01);
+    TS_ASSERT_DELTA(stitched->e(1)[10], 2.39, 0.01);
+    TS_ASSERT_DELTA(stitched->e(1)[18], 1.58, 0.01);
+
+    // Check workspaces in ADS
+    auto wsInADS = AnalysisDataService::Instance().getObjectNames();
+    // In ADS: ws1, ws2, ws3
+    TS_ASSERT_EQUALS(wsInADS.size(), 3)
+    // Remove workspaces from ADS
+    AnalysisDataService::Instance().clear();
+  }
 };

--- a/Framework/Algorithms/test/Stitch1DManyTest.h
+++ b/Framework/Algorithms/test/Stitch1DManyTest.h
@@ -1526,7 +1526,7 @@ public:
     Mantid::API::AnalysisDataService::Instance().clear();
   }
 
-  void test_two_workspaces_scale_left() {
+  void test_two_workspaces_scale_to_last_ws() {
     // Two matrix workspaces with two spectra each
     createUniformWorkspace(0.1, 0.1, 1., 2., "ws1");
     createUniformWorkspace(0.8, 0.1, 1.1, 2.1, "ws2");
@@ -1537,7 +1537,6 @@ public:
     alg.setProperty("Params", "0.1, 0.1, 1.8");
     alg.setProperty("StartOverlaps", "0.8");
     alg.setProperty("EndOverlaps", "1.1");
-    alg.setProperty("ScaleRHSWorkspace", "0");
     alg.setProperty("IndexOfReference", "-1");
     alg.setProperty("OutputWorkspace", "outws");
     alg.execute();
@@ -1594,10 +1593,8 @@ public:
     AnalysisDataService::Instance().clear();
   }
 
-  void test_three_workspaces_scale_left() {
+  void test_three_workspaces_scale_to_last_ws() {
     // Three matrix workspaces with two spectra each,
-    // Scale the stitched output to the RHS workspace.
-
     createUniformWorkspace(0.1, 0.1, 1., 2., "ws1");
     createUniformWorkspace(0.8, 0.1, 1.1, 2.1, "ws2");
     createUniformWorkspace(1.6, 0.1, 1.5, 2.5, "ws3");
@@ -1610,128 +1607,6 @@ public:
     alg.setProperty("StartOverlaps", "0.8, 1.6");
     alg.setProperty("EndOverlaps", "1.1, 1.8");
     alg.setProperty("OutputWorkspace", "outws");
-    alg.setProperty("ScaleRHSWorkspace", "0");
-    alg.setProperty("IndexOfReference", "-1");
-    alg.execute();
-    TS_ASSERT(alg.isExecuted());
-
-    // Test output ws
-    Workspace_sptr outws = alg.getProperty("OutputWorkspace");
-    TS_ASSERT(outws);
-    const auto stitched = std::dynamic_pointer_cast<MatrixWorkspace>(outws);
-
-    TS_ASSERT_EQUALS(stitched->getNumberHistograms(), 2);
-    TS_ASSERT_EQUALS(stitched->blocksize(), 25);
-    // First spectrum, Y values
-    TS_ASSERT_DELTA(stitched->y(0)[0], 1.50, 0.01);
-    TS_ASSERT_DELTA(stitched->y(0)[10], 1.50, 0.01);
-    TS_ASSERT_DELTA(stitched->y(0)[18], 1.50, 0.01);
-    // Second spectrum, Y values
-    TS_ASSERT_DELTA(stitched->y(1)[0], 2.50, 0.01);
-    TS_ASSERT_DELTA(stitched->y(1)[10], 2.50, 0.01);
-    TS_ASSERT_DELTA(stitched->y(1)[18], 2.50, 0.01);
-    // First spectrum, E values
-    TS_ASSERT_DELTA(stitched->e(0)[0], 2.33, 0.01);
-    TS_ASSERT_DELTA(stitched->e(0)[10], 1.95, 0.01);
-    TS_ASSERT_DELTA(stitched->e(0)[18], 1.22, 0.01);
-    // Second spectrum, E values
-    TS_ASSERT_DELTA(stitched->e(1)[0], 2.81, 0.01);
-    TS_ASSERT_DELTA(stitched->e(1)[10], 2.39, 0.01);
-    TS_ASSERT_DELTA(stitched->e(1)[18], 1.58, 0.01);
-
-    // Check workspaces in ADS
-    auto wsInADS = AnalysisDataService::Instance().getObjectNames();
-    // In ADS: ws1, ws2, ws3
-    TS_ASSERT_EQUALS(wsInADS.size(), 3)
-    // Remove workspaces from ADS
-    AnalysisDataService::Instance().clear();
-  }
-
-  void test_two_workspaces_scale_left_with_ScaleRHSWorkspace_true() {
-    // Two matrix workspaces with two spectra each
-    createUniformWorkspace(0.1, 0.1, 1., 2., "ws1");
-    createUniformWorkspace(0.8, 0.1, 1.1, 2.1, "ws2");
-    Stitch1DMany alg;
-    alg.setChild(true);
-    alg.initialize();
-    alg.setProperty("InputWorkspaces", "ws1, ws2");
-    alg.setProperty("Params", "0.1, 0.1, 1.8");
-    alg.setProperty("StartOverlaps", "0.8");
-    alg.setProperty("EndOverlaps", "1.1");
-    alg.setProperty("ScaleRHSWorkspace", "1");
-    alg.setProperty("IndexOfReference", "-1");
-    alg.setProperty("OutputWorkspace", "outws");
-    alg.execute();
-    TS_ASSERT(alg.isExecuted());
-
-    // Test output ws
-    Workspace_sptr outws = alg.getProperty("OutputWorkspace");
-    TS_ASSERT(outws);
-    auto stitched = std::dynamic_pointer_cast<MatrixWorkspace>(outws);
-    TS_ASSERT_EQUALS(stitched->getNumberHistograms(), 2);
-    TS_ASSERT_EQUALS(stitched->blocksize(), 17);
-    TS_ASSERT_DELTA(stitched->y(0)[0], 1.1, 0.00001);
-    TS_ASSERT_DELTA(stitched->y(0)[9], 1.1, 0.00001);
-    TS_ASSERT_DELTA(stitched->y(0)[16], 1.1, 0.00001);
-    TS_ASSERT_DELTA(stitched->y(1)[0], 2.1, 0.00001);
-    TS_ASSERT_DELTA(stitched->y(1)[9], 2.1, 0.00001);
-    TS_ASSERT_DELTA(stitched->y(1)[16], 2.1, 0.00001);
-    TS_ASSERT_DELTA(stitched->e(0)[0], 1.40712, 0.00001);
-    TS_ASSERT_DELTA(stitched->e(0)[9], 0.84091, 0.00001);
-    TS_ASSERT_DELTA(stitched->e(0)[16], 1.04880, 0.00001);
-    TS_ASSERT_DELTA(stitched->e(1)[0], 1.90787, 0.00001);
-    TS_ASSERT_DELTA(stitched->e(1)[9], 1.15399, 0.00001);
-    TS_ASSERT_DELTA(stitched->e(1)[16], 1.44913, 0.00001);
-    // Test out scale factors
-    std::vector<double> scales = alg.getProperty("OutScaleFactors");
-    TS_ASSERT_EQUALS(scales.size(), 1);
-    // Only scale factor for first spectrum is returned
-    TS_ASSERT_DELTA(scales.front(), 1.09999, 0.00001);
-
-    // Cross-check that the result of using Stitch1DMany with two workspaces
-    // is the same as using Stitch1D
-    Mantid::Algorithms::Stitch1D alg2;
-    alg2.setChild(true);
-    alg2.initialize();
-    alg2.setProperty("LHSWorkspace", "ws1");
-    alg2.setProperty("RHSWorkspace", "ws2");
-    alg2.setProperty("Params", "0.1, 0.1, 1.8");
-    alg2.setProperty("StartOverlap", "0.8");
-    alg2.setProperty("EndOverlap", "1.1");
-    alg2.setProperty("ScaleRHSWorkspace", "0");
-    alg2.setProperty("OutputWorkspace", "outws");
-    alg2.execute();
-    MatrixWorkspace_sptr stitched2 = alg2.getProperty("OutputWorkspace");
-
-    TS_ASSERT_EQUALS(stitched->x(0).rawData(), stitched2->x(0).rawData());
-    TS_ASSERT_EQUALS(stitched->y(0).rawData(), stitched2->y(0).rawData());
-    TS_ASSERT_EQUALS(stitched->e(0).rawData(), stitched2->e(0).rawData());
-
-    // Check workspaces in ADS
-    auto wsInADS = AnalysisDataService::Instance().getObjectNames();
-    // In ADS: ws1, ws2
-    TS_ASSERT_EQUALS(wsInADS.size(), 2)
-    // Remove workspaces from ADS
-    AnalysisDataService::Instance().clear();
-  }
-
-  void test_three_workspaces_scale_left_with_ScaleRHSWorkspace_true() {
-    // Three matrix workspaces with two spectra each,
-    // Scale the stitched output to the RHS workspace.
-
-    createUniformWorkspace(0.1, 0.1, 1., 2., "ws1");
-    createUniformWorkspace(0.8, 0.1, 1.1, 2.1, "ws2");
-    createUniformWorkspace(1.6, 0.1, 1.5, 2.5, "ws3");
-
-    Stitch1DMany alg;
-    alg.setChild(true);
-    alg.initialize();
-    alg.setProperty("InputWorkspaces", "ws1, ws2, ws3");
-    alg.setProperty("Params", "0.1, 0.1, 2.6");
-    alg.setProperty("StartOverlaps", "0.8, 1.6");
-    alg.setProperty("EndOverlaps", "1.1, 1.8");
-    alg.setProperty("OutputWorkspace", "outws");
-    alg.setProperty("ScaleRHSWorkspace", "1");
     alg.setProperty("IndexOfReference", "-1");
     alg.execute();
     TS_ASSERT(alg.isExecuted());

--- a/Framework/Kernel/inc/MantidKernel/OptionalBool.h
+++ b/Framework/Kernel/inc/MantidKernel/OptionalBool.h
@@ -37,6 +37,7 @@ public:
   OptionalBool(Value arg);
   virtual ~OptionalBool() = default;
   bool operator==(const OptionalBool &other) const;
+  bool operator!=(const OptionalBool &other) const;
   Value getValue() const;
 
 private:

--- a/Framework/Kernel/src/OptionalBool.cpp
+++ b/Framework/Kernel/src/OptionalBool.cpp
@@ -25,6 +25,8 @@ OptionalBool::OptionalBool(Value arg) : m_arg(arg) {}
 
 bool OptionalBool::operator==(const OptionalBool &other) const { return m_arg == other.getValue(); }
 
+bool OptionalBool::operator!=(const OptionalBool &other) const { return m_arg != other.getValue(); }
+
 OptionalBool::Value OptionalBool::getValue() const { return m_arg; }
 
 std::ostream &operator<<(std::ostream &os, OptionalBool const &object) {

--- a/Testing/SystemTests/tests/framework/INTERReductionTest.py
+++ b/Testing/SystemTests/tests/framework/INTERReductionTest.py
@@ -150,7 +150,7 @@ def quickRef(run_numbers=[], trans_workspace_names=[], angles=[]):
     first_run_name=str(run_numbers[0])
     dqq = NRCalculateSlitResolution(Workspace=first_run_name+'_IvsQ')
     stitched_name=stitchedWorkspaceName(run_numbers[0], run_numbers[-1])
-    Stitch1DMany(InputWorkspaces=reduced_runs, OutputWorkspace=stitched_name, Params='-'+str(dqq), ScaleRHSWorkspace=1)
+    Stitch1DMany(InputWorkspaces=reduced_runs, OutputWorkspace=stitched_name, Params='-'+str(dqq), IndexOfReference=0)
 
 
 def twoAngleFit(workspace_name, scalefactor, expected_fit_params, expected_fit_covariance):

--- a/docs/source/algorithms/Stitch1DMany-v1.rst
+++ b/docs/source/algorithms/Stitch1DMany-v1.rst
@@ -32,8 +32,7 @@ same number of workspaces. The algorithm will stitch together the workspaces
 in the first group before stitching workspaces from the next group on top
 of the previous ones.
 
-When stitching the workspaces, either the RHS or LHS workspaces can be scaled.
-We can specify manual scale factors to use by setting
+When stitching the workspaces, we can specify manual scale factors to use by setting
 :literal:`UseManualScaleFactors` true and passing values to
 :literal:`ManualScaleFactors`. For group workspaces, we can also use
 :literal:`ScaleFactorFromPeriod` to select a period which will obtain a vector
@@ -43,7 +42,8 @@ to all other periods when stitching.
 The workspace that provides the scale for stitching output can be chosen by
 specifying the desired index through :literal:`IndexOfReference` property.
 The reference workspace will not be scaled, and the other workspaces will be scaled
-to match the reference.
+to match the reference. Note that this property should be used instead of
+:literal:`ScaleRHSWorkspace`, which no longer has any effect and will eventually be removed.
 
 Workflow
 --------
@@ -54,10 +54,10 @@ The algorithm workflow is as follows:
    workspaces or not. The algorithm handles matrix workspaces differently from
    group workspaces.
 #. If matrix workspaces are supplied, the algorithm simply iterates over each
-   workspace and calls the :literal:`Stitch1D` algorithm. This stitches each RHS
-   workspace to the LHS workspace to form a single stitched workspace (LHS to
-   RHS if ScaleRHSWorkspace is set to false). The resultant workspace and its
-   scale factor are outputted.
+   workspace and calls the :literal:`Stitch1D` algorithm. This stitches each pair
+   of workspaces together, with either the RHS or LHS workspace being scaled
+   depending on the chosen reference workspace (given by :literal:`IndexOfReference`).
+   The resultant workspace and its scale factor are outputted.
 #. If group workspaces are supplied, the algorithm checks whether or not to
    scale workspaces using scale factors from a specific period (given by
    :literal:`ScaleFactorFromPeriod`). This is done only if

--- a/docs/source/release/v6.6.0/Reflectometry/Bugfixes/34470.rst
+++ b/docs/source/release/v6.6.0/Reflectometry/Bugfixes/34470.rst
@@ -1,0 +1,1 @@
+- Stop using the value of the ScaleRHSWorkspace parameter of Stitch1DMany in favour of the IndexOfReference parameter.

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/QtExperimentView.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/QtExperimentView.cpp
@@ -98,7 +98,7 @@ void QtExperimentView::initLayout(const Mantid::API::IAlgorithm_sptr &algorithmF
   initOptionsTable(algorithmForTooltips);
   initFloodControls();
 
-  auto blacklist = std::vector<std::string>({"InputWorkspaces", "OutputWorkspace"});
+  auto blacklist = std::vector<std::string>({"InputWorkspaces", "OutputWorkspace", "ScaleRHSWorkspace"});
   MantidWidgets::AlgorithmHintStrategy strategy("Stitch1DMany", blacklist);
   createStitchHints(strategy.createHints());
 


### PR DESCRIPTION
**Description of work.**

**Report to:** Max at ISIS

See details on the issue that describe the underlying problem.

This PR makes the following changes to the Stitch1DMany algorithm:

- The `IndexOfReference` parameter will now accept a value of `-1`, which will set the last workspace in the list to be the reference.
- The value passed in to `ScaleRHSWorkspace` is no longer used. The `IndexOfReference` parameter can now be used to replicate the behaviour that this parameter used to provide, making it obsolete. The parameter will eventually be removed altogether.
- A warning has been added if users set a value for `ScaleRHSWorkspace` to let them know it will have no effect and to use `IndexOfReference` instead. Relevant documentation has been updated.
- The `ScaleRHSWorkspace` input is no longer visible in the algorithm dialog or in the hints for the `Output Stitch Properties` field in the Reflectometry interface.

There were just a couple of things I wanted to double check with the reviewer:

1) The warning that I've added to the algorithm doesn't appear when `Stitch1DMany` is being run as a postprocessing algorithm for a Reflectometry reduction and `ScaleRHSWorkspace` has been passed in via the `Output Stitch Properties` field of the ISIS Reflectometry interface. Is this something to do with it being run as a child algorithm and is this expected behaviour, or does something need looking at here?

2) I've noticed that there's a screenshot of the `Stitch1DMany` dialog on the top right of the documentation for the algorithm. This image would need updating as the ScaleRHSWorkspace checkbox will no longer be there. I couldn't find the image anywhere to update manually, are these generated automatically somehow?

**To test:**

1) Check that the `ScaleRHSWorkspace` checkbox no longer appears in the `Stitch1DMany` algorithm dialog.
2) Open the ISIS Reflectometry interface. On the Experiment Settings tab, there should no longer be a hint for the `ScaleRHSWorkspace` parameter in the `Output Stitch Properties` field.
3) Replace the final line in the Python script given in the Stitch1DMany documentation [here](https://docs.mantidproject.org/nightly/algorithms/Stitch1DMany-v1.html#usage) with:

```stitched, scale = Stitch1DMany(InputWorkspaces=workspaces, IndexOfReference=-1)```

4) Run the script in workbench. The algorithm should complete successfully with no errors or warnings. Plot the stitched output over a plot of the input workspaces and check that when the `IndexOfReference` is changed between `0` and `-1` the stitched curve scales appropriately (i.e. when the index is 0 the right hand side of the curve should move up to be in line with the first/left-most workspace, and vice versa).
5) Add in parameter `ScaleRHSWorkspace=1` and run the algorithm again. Check that the algorithm completes but that a warning message is printed to the GUI.
 
Fixes #34440. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
