### PR TITLE
Removes the brief documentation functionality from the Property class

### DIFF
--- a/Framework/Kernel/inc/MantidKernel/Property.h
+++ b/Framework/Kernel/inc/MantidKernel/Property.h
@@ -101,7 +101,6 @@ public:
   // Getters
   const std::string &name() const;
   const std::string &documentation() const;
-  const std::string &briefDocumentation() const;
   const std::type_info *type_info() const;
   const std::string type() const;
 
@@ -124,7 +123,6 @@ public:
   void setRemember(bool);
 
   void setDocumentation(const std::string &documentation);
-  void setBriefDocumentation(const std::string &documentation);
 
   virtual void saveProperty(::NeXus::File * /*file*/) {
     throw std::invalid_argument("Property::saveProperty - Cannot save '" + this->name() +
@@ -215,8 +213,6 @@ private:
 
   /// Longer, optional description of property
   std::string m_documentation;
-  /// Brief description of property
-  std::string m_shortDoc;
   /// The type of the property
   const std::type_info *m_typeinfo;
   /// Whether the property is used as input, output or both to an algorithm

--- a/Framework/Kernel/src/Property.cpp
+++ b/Framework/Kernel/src/Property.cpp
@@ -64,11 +64,6 @@ const std::string &Property::name() const { return m_name; }
  */
 const std::string &Property::documentation() const { return m_documentation; }
 
-/** Get the property's short documentation string
- *  @return The documentation string
- */
-const std::string &Property::briefDocumentation() const { return m_shortDoc; }
-
 /** Get the property type_info
  *  @return The type of the property
  */
@@ -136,19 +131,7 @@ std::string Property::valueAsPrettyStr(const size_t maxLength, const bool collap
  *  (or the entire string if no period is found).
  *  @param documentation The string containing the descriptive comment
  */
-void Property::setDocumentation(const std::string &documentation) {
-  m_documentation = documentation;
-
-  if (m_shortDoc.empty()) {
-    auto period = documentation.find_first_of('.');
-    setBriefDocumentation(documentation.substr(0, period));
-  }
-}
-
-/** Sets the
- *
- */
-void Property::setBriefDocumentation(const std::string &documentation) { m_shortDoc = documentation; }
+void Property::setDocumentation(const std::string &documentation) { m_documentation = documentation; }
 
 /** Returns the set of valid values for this property, if such a set exists.
  *  If not, it returns an empty set.

--- a/Framework/Kernel/test/PropertyTest.h
+++ b/Framework/Kernel/test/PropertyTest.h
@@ -44,7 +44,6 @@ public:
   void testDocumentation() {
     auto pp = std::make_unique<PropertyHelper>();
     TS_ASSERT(pp->documentation().empty());
-    TS_ASSERT(pp->briefDocumentation().empty());
   }
 
   void testType_info() { TS_ASSERT(typeid(int) == *p->type_info()); }
@@ -59,25 +58,15 @@ public:
     const std::string str("Doc comment. This property does something.");
     p->setDocumentation(str);
     TS_ASSERT_EQUALS(p->documentation(), str);
-    TS_ASSERT_EQUALS(p->briefDocumentation(), "Doc comment");
 
     const std::string str2("A string with no period to be seen");
     // Brief documentation not changed if it's not empty
     p->setDocumentation(str2);
     TS_ASSERT_EQUALS(p->documentation(), str2);
-    TS_ASSERT_EQUALS(p->briefDocumentation(), "Doc comment");
 
     // Make it empty and see that it will now be changed via setDocumentation()
-    p->setBriefDocumentation("");
-    TS_ASSERT(p->briefDocumentation().empty());
     p->setDocumentation(str2);
     TS_ASSERT_EQUALS(p->documentation(), str2);
-    TS_ASSERT_EQUALS(p->briefDocumentation(), str2);
-
-    // Set just the brief documentation
-    p->setBriefDocumentation("Brief");
-    TS_ASSERT_EQUALS(p->documentation(), str2);
-    TS_ASSERT_EQUALS(p->briefDocumentation(), "Brief");
   }
 
   void testIsValueSerializable() { TS_ASSERT(p->isValueSerializable()) }

--- a/docs/source/release/v6.6.0/Workbench/Bugfixes/34472.rst
+++ b/docs/source/release/v6.6.0/Workbench/Bugfixes/34472.rst
@@ -1,0 +1,1 @@
+- The tooltips of properties in an algorithm dialog will now provide the full description of a property.

--- a/qt/widgets/common/src/AlgorithmDialog.cpp
+++ b/qt/widgets/common/src/AlgorithmDialog.cpp
@@ -500,7 +500,7 @@ QWidget *AlgorithmDialog::tie(QWidget *widget, const QString &property, QLayout 
 
   Mantid::Kernel::Property *prop = getAlgorithmProperty(property);
   if (prop) { // Set a few things on the widget
-    widget->setToolTip(QString::fromStdString(prop->briefDocumentation()));
+    widget->setToolTip(QString::fromStdString(prop->documentation()));
   }
   widget->setEnabled(isWidgetEnabled(property));
 

--- a/qt/widgets/common/src/PropertyWidget.cpp
+++ b/qt/widgets/common/src/PropertyWidget.cpp
@@ -237,7 +237,7 @@ PropertyWidget::PropertyWidget(Mantid::Kernel::Property *prop, QWidget *parent, 
   connect(m_icons[RESTORE], SIGNAL(clicked()), this, SLOT(toggleUseHistory()));
 
   /// Save the documentation tooltip
-  m_doc = QString::fromStdString(prop->briefDocumentation());
+  m_doc = QString::fromStdString(prop->documentation());
 
   if (!isOptionalProperty(prop)) {
     if (!m_doc.isEmpty())

--- a/qt/widgets/plugins/algorithm_dialogs/src/LoadDialog.cpp
+++ b/qt/widgets/plugins/algorithm_dialogs/src/LoadDialog.cpp
@@ -330,7 +330,7 @@ int LoadDialog::createWidgetsForProperty(const Mantid::Kernel::Property *prop, Q
     propertyLayout->addWidget(inputWidget);
   } else {
     QLabel *nameLbl = new QLabel(propName, parent);
-    nameLbl->setToolTip(QString::fromStdString(prop->briefDocumentation()));
+    nameLbl->setToolTip(QString::fromStdString(prop->documentation()));
     if (dynamic_cast<const PropertyWithValue<bool> *>(prop)) {
       auto *checkBox = new QCheckBox(parent);
       inputWidget = checkBox;


### PR DESCRIPTION
**Description of work.**
This PR ensures the full description of a property is used in the algorithm dialog rather than a shorter version which only shows the first sentence.

**To test:**
Open the algorithm dialog of multiple different algorithms
Check that the tooltip of the properties displays the full documentation and not just the first sentence of the documentation

Fixes #34462 

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
