### PR TITLE
move cppcheck suppression to source for false positive

### DIFF
--- a/Framework/DataObjects/src/AffineMatrixParameter.cpp
+++ b/Framework/DataObjects/src/AffineMatrixParameter.cpp
@@ -118,6 +118,7 @@ bool AffineMatrixParameter::isValid() const { return m_isValid; }
  * @param other : another affine matrix to assign from.
  * @return ref to assigned object
  */
+// cppcheck-suppress operatorEqVarError
 AffineMatrixParameter &AffineMatrixParameter::operator=(const AffineMatrixParameter &other) {
   if ((other.m_affineMatrix.numCols() != this->m_affineMatrix.numCols()) ||
       (other.m_affineMatrix.numRows() != this->m_affineMatrix.numRows())) {

--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -119,7 +119,6 @@ knownConditionTrueFalse:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/SaveRKH.c
 knownConditionTrueFalse:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/SaveSPE.cpp:149
 knownConditionTrueFalse:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/SaveSPE.cpp:159
 wrongPrintfScanfArgNum:${CMAKE_SOURCE_DIR}/Framework/DataHandling/src/SaveSPE.cpp:54
-operatorEqVarError:${CMAKE_SOURCE_DIR}/Framework/DataObjects/src/AffineMatrixParameter.cpp:121
 knownConditionTrueFalse:${CMAKE_SOURCE_DIR}/Framework/DataObjects/inc/MantidDataObjects/MortonIndex/WideIntImpl.h:145
 funcArgOrderDifferent:${CMAKE_SOURCE_DIR}/Framework/DataObjects/inc/MantidDataObjects/MortonIndex/WideIntImpl.h:1090
 funcArgOrderDifferent:${CMAKE_SOURCE_DIR}/Framework/DataObjects/inc/MantidDataObjects/MortonIndex/WideIntImpl.h:1100

--- a/qt/scientific_interfaces/Indirect/CMakeLists.txt
+++ b/qt/scientific_interfaces/Indirect/CMakeLists.txt
@@ -159,7 +159,6 @@ set(MOC_FILES
     IndirectSimulation.h
     IndirectSimulationTab.h
     IndirectSqw.h
-    IndirectSqwModel.h
     IndirectSqwView.h
     IndirectSymmetrise.h
     IndirectTab.h
@@ -194,6 +193,7 @@ set(INC_FILES
     IndirectMomentsModel.h
     IndirectPlotOptionsModel.h
     IndirectSettingsHelper.h
+    IndirectSqwModel.h
     IqtFitModel.h
     MSDFitModel.h
     Notifier.h


### PR DESCRIPTION
**Description of work.**
This cppcheck defect is a false positive - fixing the defect results in a memory leak (see comment on #34195). Suppression has been moved from the suppressions file to the source to help avoid someone mistakingly resolving the defect in the future.

I've also made a minor adjustment to a CMakeLists file to avoid a wanring from Qt (it shouldn't have been in the MOC_FILES list).

**To test:**
Ensure cppcheck job passes.

*There is no associated issue.*

*This does not require release notes* because it's not user facing.

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
