### PR TITLE
Remove rns term from Mayers multiple scattering correction

### DIFF
--- a/Framework/Algorithms/src/SampleCorrections/MayersSampleCorrectionStrategy.cpp
+++ b/Framework/Algorithms/src/SampleCorrections/MayersSampleCorrectionStrategy.cpp
@@ -142,10 +142,6 @@ Mantid::HistogramData::Histogram MayersSampleCorrectionStrategy::getCorrectedHis
   // corrections to input
   const double muMin(xmur.front()), muMax(xmur.back()), flightPath(m_pars.l1 + m_pars.l2),
       vol(M_PI * m_pars.cylHeight * pow(m_pars.cylRadius, 2));
-  //  Oct 2003 discussion with Jerry Mayers:
-  //  1E-22 factor in formula for RNS was introduced by Jerry to keep
-  //   multiple scattering correction close to 1
-  const double rns = (vol * 1e6) * (m_pars.rho * 1e24) * 1e-22;
   ChebyshevSeries chebyPoly(N_POLY_ORDER);
 
   auto outputHistogram = m_histogram;
@@ -168,7 +164,7 @@ Mantid::HistogramData::Histogram MayersSampleCorrectionStrategy::getCorrectedHis
     if (m_pars.mscat) {
       const double msVal = chebyPoly(msCoeffs, xcap);
       const double beta = m_pars.sigmaSc * msVal / sigt;
-      corrfact *= (1.0 - (beta / rns));
+      corrfact *= (1.0 - beta);
     }
     // apply correction
 

--- a/Framework/Algorithms/src/SampleCorrections/MayersSampleCorrectionStrategy.cpp
+++ b/Framework/Algorithms/src/SampleCorrections/MayersSampleCorrectionStrategy.cpp
@@ -140,8 +140,7 @@ Mantid::HistogramData::Histogram MayersSampleCorrectionStrategy::getCorrectedHis
     msCoeffs = polyfit(xmur, yms, wms);
 
   // corrections to input
-  const double muMin(xmur.front()), muMax(xmur.back()), flightPath(m_pars.l1 + m_pars.l2),
-      vol(M_PI * m_pars.cylHeight * pow(m_pars.cylRadius, 2));
+  const double muMin(xmur.front()), muMax(xmur.back()), flightPath(m_pars.l1 + m_pars.l2);
   ChebyshevSeries chebyPoly(N_POLY_ORDER);
 
   auto outputHistogram = m_histogram;

--- a/Framework/Algorithms/test/MayersSampleCorrectionStrategyTest.h
+++ b/Framework/Algorithms/test/MayersSampleCorrectionStrategyTest.h
@@ -73,11 +73,11 @@ public:
     TS_ASSERT_DELTA(100.0, tof.front(), delta);
     TS_ASSERT_DELTA(199.0, tof.back(), delta);
 
-    TS_ASSERT_DELTA(2.308089, signal.front(), delta);
-    TS_ASSERT_DELTA(2.314809, signal.back(), delta);
+    TS_ASSERT_DELTA(2.139030, signal.front(), delta);
+    TS_ASSERT_DELTA(2.154289, signal.back(), delta);
 
-    TS_ASSERT_DELTA(1.632065, error.front(), delta);
-    TS_ASSERT_DELTA(1.636817, error.back(), delta);
+    TS_ASSERT_DELTA(1.512522, error.front(), delta);
+    TS_ASSERT_DELTA(1.523313, error.back(), delta);
   }
 
   void test_Corrects_Both_Absorption_And_Multiple_Scattering_For_Histogram_Data() {
@@ -95,11 +95,11 @@ public:
     TS_ASSERT_DELTA(99.5, tof.front(), delta);
     TS_ASSERT_DELTA(199.5, tof.back(), delta);
 
-    TS_ASSERT_DELTA(2.308089, signal.front(), delta);
-    TS_ASSERT_DELTA(2.314809, signal.back(), delta);
+    TS_ASSERT_DELTA(2.139030, signal.front(), delta);
+    TS_ASSERT_DELTA(2.154289, signal.back(), delta);
 
-    TS_ASSERT_DELTA(1.632065, error.front(), delta);
-    TS_ASSERT_DELTA(1.636817, error.back(), delta);
+    TS_ASSERT_DELTA(1.512522, error.front(), delta);
+    TS_ASSERT_DELTA(1.523313, error.back(), delta);
   }
 
   void test_Corrects_For_Absorption_For_Histogram_Data() {
@@ -140,16 +140,15 @@ public:
     const auto &error = outHisto.e();
 
     // Check some values
-    // Check some values
     const double delta(1e-06);
     TS_ASSERT_DELTA(99.5, tof.front(), delta);
     TS_ASSERT_DELTA(199.5, tof.back(), delta);
 
-    TS_ASSERT_DELTA(2.307860, signal.front(), delta);
-    TS_ASSERT_DELTA(2.314794, signal.back(), delta);
+    TS_ASSERT_DELTA(2.137725, signal.front(), delta);
+    TS_ASSERT_DELTA(2.154205, signal.back(), delta);
 
-    TS_ASSERT_DELTA(1.631904, error.front(), delta);
-    TS_ASSERT_DELTA(1.636807, error.back(), delta);
+    TS_ASSERT_DELTA(1.511600, error.front(), delta);
+    TS_ASSERT_DELTA(1.523253, error.back(), delta);
   }
 
   void test_MutlipleScattering_NRuns_Parameter() {
@@ -166,16 +165,15 @@ public:
     const auto &error = outHisto.e();
 
     // Check some values
-    // Check some values
     const double delta(1e-06);
     TS_ASSERT_DELTA(99.5, tof.front(), delta);
     TS_ASSERT_DELTA(199.5, tof.back(), delta);
 
-    TS_ASSERT_DELTA(2.308851, signal.front(), delta);
-    TS_ASSERT_DELTA(2.323555, signal.back(), delta);
+    TS_ASSERT_DELTA(2.143376, signal.front(), delta);
+    TS_ASSERT_DELTA(2.204168, signal.back(), delta);
 
-    TS_ASSERT_DELTA(1.632604, error.front(), delta);
-    TS_ASSERT_DELTA(1.643002, error.back(), delta);
+    TS_ASSERT_DELTA(1.515596, error.front(), delta);
+    TS_ASSERT_DELTA(1.558582, error.back(), delta);
   }
 
   // ---------------------- Failure tests -----------------------------

--- a/Framework/Algorithms/test/MayersSampleCorrectionTest.h
+++ b/Framework/Algorithms/test/MayersSampleCorrectionTest.h
@@ -45,11 +45,11 @@ public:
     TS_ASSERT_DELTA(99.5, tof.front(), delta);
     TS_ASSERT_DELTA(199.5, tof.back(), delta);
 
-    TS_ASSERT_DELTA(2.307439, signal.front(), delta);
-    TS_ASSERT_DELTA(2.314956, signal.back(), delta);
+    TS_ASSERT_DELTA(2.135321, signal.front(), delta);
+    TS_ASSERT_DELTA(2.155129, signal.back(), delta);
 
-    TS_ASSERT_DELTA(1.631606, error.front(), delta);
-    TS_ASSERT_DELTA(1.636921, error.back(), delta);
+    TS_ASSERT_DELTA(1.509900, error.front(), delta);
+    TS_ASSERT_DELTA(1.523906, error.back(), delta);
   }
 
   void test_Success_With_Just_Absorption_Correction() {


### PR DESCRIPTION
**Description of work.**

Remove a term called "rns" from the multiple scattering correction. The term included the density, volume of the sample and three 10^x scaling factors. The effect of this is to increase the size of the multiple scattering correction by about 10% on the V samples used in the unit tests.

The maths for the multiple scattering correction comes from a paper called Experimental Method and Corrections to Data written by Lindley\Mayers that I have a copy of. The relevant page is here:

![MayersCh5MultipleScatteringCorrections](https://user-images.githubusercontent.com/56295817/194016724-fc2759d2-8908-4dad-8a01-185335717dcc.jpg)

If you invert equation 27 this gives single scatter intensity, $N_1 = N_d (1-&beta;)$ where $N_d$ is the detected intensity. If you further correct for absorption in the single scatter intensity this gives $N_1 = N_d AT (1-&beta;)$ where $AT$ is the absorption factor. This is the formula that should be used.

Nearby there is equation 28 expressing $N_d$ in terms of the incident flux $N_0$ that includes a 1/nV factor. This has been inverted in pencil and has the "This is the expression used..." comment written in so it seems like this formula has been mistakenly used. There's no need to be obtaining the incident flux $N_0$ in the code.

In the unit tests and doc tests for the algorithm the rns term equals ~5. Removing it seems to improve the alignment of the Mayers MS results with the other MS algorithms in Mantid so this supports making this change in addition to the reasoning based on the theory

Here is a plot from the Mantid concepts page showing the results from the various algorithms (before on left, after on right). The yellow Mayers line has moved down now closer to the other results:
<p align="center">
  <img alt="Before" src="https://user-images.githubusercontent.com/56295817/194076037-22cac6cb-12cf-4af7-8b24-74e42fb66dd8.png" width="45%">
&nbsp; &nbsp; &nbsp; &nbsp;
  <img alt="After" src="https://user-images.githubusercontent.com/56295817/194076173-6541c5a0-d086-4250-bfe8-80d4e9fc91b7.png" width="45%">
</p>

**To test:**

<!-- Instructions for testing. -->

*There is no associated issue.*

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
