### PR TITLE
Update gravity correction docs in Q1D

### DIFF
--- a/docs/source/algorithms/Q1D-v2.rst
+++ b/docs/source/algorithms/Q1D-v2.rst
@@ -20,7 +20,8 @@ reason the output unit is 1/cm.
 Q Unit Conversion
 #################
 
-Section includes explanation for the effect of setting AccountForGravity to true.
+This section includes an explanation for the effect of setting
+``AccountForGravity`` to true along with ``ExtraLength``.
 
 The equation for :math:`Q` as a function of wavelength, :math:`\lambda`,
 and neglecting gravity, is
@@ -34,15 +35,26 @@ the y-axis then :math:`\theta` is
 
 .. math:: \theta = \frac{1}{2} arcsin\left (\frac{\sqrt{x^2+y^2}}{L_2} \right )
 
-Including gravity adds another term to this equation which becomes:
+Including gravity this becomes:
 
-.. math:: \theta = \frac{1}{2} arcsin\left (\frac{ \sqrt{x^2+\left (y+\frac{gm^2}{2h^2} \lambda^2 L_2^2 \right)^2}}{L_2} \right )
+.. math:: \theta = \frac{1}{2} arcsin\left (\frac{ \sqrt{x^2+\left (y+\frac{gm^2}{2h^2} \lambda^2 L_{corr}^2 \right)^2}}{L_2} \right )
 
 where :math:`m` is the particle's mass, :math:`g` is the acceleration
 due to gravity and :math:`h` is `plank's
-constant <http://en.wikipedia.org/wiki/Planks_constant>`__ (this assumes
-neutrons are all travelling in horizontal at sample, and that
-:math:`x=y=0` would be beam centre at :math:`\lambda = 0`).
+constant <http://en.wikipedia.org/wiki/Planks_constant>`__ .
+
+The correction assumes that :math:`x=y=0` would be beam centre at :math:`\lambda = 0`.
+In order to correct for the fact that the beam may not be travelling horizontal
+at the sample an extra path length (``ExtraLength`` property) can be included in the
+numerator where
+
+.. math:: L_{corr}^2 = (L_2 + L_{extra})^2 - L_{extra}^2
+
+The value of :math:`L_{extra}` is likely :math:`0.5*L_1`, where :math:`L_1` is the
+collimation length, but may be less than this depending on where scraper baffles
+are inside the collimation.
+See :ref:`algm-TOFSANSResolutionByPixel` for more detail on the how the collimation
+length ties in with the resolution calculation.
 
 Normalizing the input workspace
 ###############################

--- a/docs/source/techniques/SANS-Toml-v1.rst
+++ b/docs/source/techniques/SANS-Toml-v1.rst
@@ -778,6 +778,9 @@ to the gravity correction. The extra length is only taken into account
 when the gravity correction is enabled and the default value is x=0.0.
 See also :ref:`gravity_on-ref`.
 
+Unless there is a reason not too, set the value of *gravity_extra_length* equal
+to 0.5 * collimation_length. See also :ref:`QRESOL/LCOLLIM=z <qresol-lcollim-z>`.
+
 **Replacement**
 
 ..  code-block:: none
@@ -2061,6 +2064,8 @@ the heights and widths of a slit do not have to be the same.
     w1 = 0.016
     h2 = 0.008
     w2 = 0.008
+
+.. _qresol-lcollim-z:
 
 QRESOL/LCOLLIM=z
 ----------------


### PR DESCRIPTION
**Description of work.**

The equation was missing a reference to the
optional extra length that can be supplied
to account for the beam not travelling horizontal
at the sample.

**Report to:** @smk78 

**To test:**

Read the changes and check they make sense. The image below is provided to avoid having to build the latex.
<img width="927" alt="image" src="https://user-images.githubusercontent.com/733773/194040602-4ef06e85-a85d-42ca-b391-833b295be92e.png">

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
