### PR TITLE
Updated MSlice SHA after beta testing

### DIFF
--- a/docs/source/release/v6.5.0/Direct_Geometry/MSlice/Bugfixes/34479.rst
+++ b/docs/source/release/v6.5.0/Direct_Geometry/MSlice/Bugfixes/34479.rst
@@ -1,0 +1,4 @@
+- The temperature is now cached for access from derived cuts to prevent MSlice from crashing.
+- Improved logic behind intensity type changes to fix a bug impacting both cut and slice plots.
+- Font size changes are now propagated in scripts generated from plots.
+- Fixed a bug that caused the duplication of suffixes when renaming workspaces.

--- a/scripts/ExternalInterfaces/CMakeLists.txt
+++ b/scripts/ExternalInterfaces/CMakeLists.txt
@@ -7,7 +7,7 @@ externalproject_add(
   mslice
   PREFIX ${_mslice_external_root}
   GIT_REPOSITORY "https://github.com/mantidproject/mslice.git"
-  GIT_TAG afdda390d4df198c9373663525a9c6e3239f7f4f
+  GIT_TAG 425465fd4f7628b89b63596fe67f3e4bb7dba640
   EXCLUDE_FROM_ALL 1
   CONFIGURE_COMMAND ""
   BUILD_COMMAND ""


### PR DESCRIPTION
**Description of work.**

Replaced MSlice SHA for Mantid with SHA of current MSlice release-next branch.

Added release notes for all changes since the last SHA update.

**To test:**

Double-check SHA with SHA of current MSlice release-next branch.

There is no associated issue.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
