### PR TITLE
Fix problem with Discus MS call picking wrong workspaces

### DIFF
--- a/docs/source/concepts/AbsorptionAndMultipleScattering_plot_common.py
+++ b/docs/source/concepts/AbsorptionAndMultipleScattering_plot_common.py
@@ -1,5 +1,6 @@
 from __future__ import (absolute_import, division, print_function)
 
+from mantid.api import *
 from mantid.simpleapi import *
 import matplotlib.pyplot as plt
 
@@ -75,9 +76,9 @@ def get_montecarlo_results(sample_ws):
     Y=[1,1,1,1,1]
     SQ=CreateWorkspace(DataX=X,DataY=Y,UnitX="MomentumTransfer")
     ConvertUnits(InputWorkspace=sample_ws, OutputWorkspace=sample_ws, Target="Momentum")
-    mc_corrections = DiscusMultipleScatteringCorrection(sample_ws, StructureFactorWorkspace=SQ, NumberScatterings=2)
+    DiscusMultipleScatteringCorrection(sample_ws, StructureFactorWorkspace=SQ, NumberScatterings=2, OutputWorkspace="mc_corrections")
     # apply ms correction using ratio method
-    multi_scatt_ratio = mc_corrections[1]/(mc_corrections[1] + mc_corrections[2])
+    multi_scatt_ratio = mtd["mc_corrections_Scatter_1"]/(mtd["mc_corrections_Scatter_1"] + mtd["mc_corrections_Scatter_2"])
     mc_ms = sample_ws * multi_scatt_ratio
     # apply absorption correction after ms correction to get fully corrected result
     ConvertUnits(InputWorkspace=mc_ms, OutputWorkspace=mc_ms, Target="Wavelength")


### PR DESCRIPTION
**Description of work.**

The Discus line in the following plot in the "Absorption Corrections and Multiple Scattering" concepts page is close to zero and is incorrect. This is caused by a bug in the python script in doc page where the wrong workspace is picked out from a workspace group - due to a change to the DiscusMultipleScatteringCorrection algorithm that added some extra workspaces in the group. This PR fixes the problem by accessing the workspaces by name:
![image](https://user-images.githubusercontent.com/56295817/194069146-5aa6cc30-11e2-4821-9ba6-fa7a5ad07896.png)
Fixed:
![image](https://user-images.githubusercontent.com/56295817/194068991-116a6a2a-a5d0-479d-818b-476e58854313.png)


**To test:**

Build docs and look at this plot in the Absorption Corrections and Multiple Scattering concepts page.

*There is no associated issue.*

*This does not require release notes* because **it's a doc change only**

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
