### PR TITLE
Typo in Lorentz correction for HB3A

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/HB3AIntegrateDetectorPeaks.py
+++ b/Framework/PythonInterface/plugins/algorithms/HB3AIntegrateDetectorPeaks.py
@@ -200,7 +200,7 @@ class HB3AIntegrateDetectorPeaks(PythonAlgorithm):
                 if use_lorentz:
                     # ILL Neutron Data Booklet, Second Edition, Section 2.9, Part 4.1, Equation 7
                     peak = __tmp_pw.getPeak(0)
-                    lorentz = abs(np.sin(peak.getScattering() * np.cos(peak.getAzimuthal())))
+                    lorentz = abs(np.sin(peak.getScattering()) * np.cos(peak.getAzimuthal()))
                     peak.setIntensity(peak.getIntensity() * lorentz)
                     peak.setSigmaIntensity(peak.getSigmaIntensity() * lorentz)
 

--- a/Framework/PythonInterface/plugins/algorithms/HB3AIntegratePeaks.py
+++ b/Framework/PythonInterface/plugins/algorithms/HB3AIntegratePeaks.py
@@ -151,7 +151,7 @@ class HB3AIntegratePeaks(PythonAlgorithm):
             peaks = AnalysisDataService[peaks_ws_name]
             for p in range(peaks.getNumberPeaks()):
                 peak = peaks.getPeak(p)
-                lorentz = abs(np.sin(peak.getScattering() * np.cos(peak.getAzimuthal())))
+                lorentz = abs(np.sin(peak.getScattering()) * np.cos(peak.getAzimuthal()))
                 peak.setIntensity(peak.getIntensity() * lorentz)
                 peak.setSigmaIntensity(peak.getSigmaIntensity() * lorentz)
 

--- a/Framework/PythonInterface/test/python/plugins/algorithms/HB3AIntegrateDetectorPeaksTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/HB3AIntegrateDetectorPeaksTest.py
@@ -98,7 +98,7 @@ class HB3ADetectorPeaksTest(unittest.TestCase):
         # G. J. McIntyre and R. F. D. Stansfield, Acta Cryst A 44, 257 (1988).
         lorentz = abs(np.cos(nu)*np.sin(gamma))
         self.assertAlmostEqual(peak0.getIntensity(), 961.6164021216964 * lorentz, delta=1e-5)
-        self.assertAlmostEqual(peak0.getSigmaIntensity(), 10.479567046232615 * lorentz, delta=2e-1)
+        self.assertAlmostEqual(peak0.getSigmaIntensity(), 10.479567046232615 * lorentz, delta=2e-2)
         q_sample = peak0.getQSampleFrame()
         for i in range(3):
             self.assertNotAlmostEqual(q_sample[i], expected_q_sample[i])

--- a/Framework/PythonInterface/test/python/plugins/algorithms/HB3AIntegrateDetectorPeaksTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/HB3AIntegrateDetectorPeaksTest.py
@@ -98,7 +98,7 @@ class HB3ADetectorPeaksTest(unittest.TestCase):
         # G. J. McIntyre and R. F. D. Stansfield, Acta Cryst A 44, 257 (1988).
         lorentz = abs(np.cos(nu)*np.sin(gamma))
         self.assertAlmostEqual(peak0.getIntensity(), 961.6164021216964 * lorentz, delta=1e-5)
-        self.assertAlmostEqual(peak0.getSigmaIntensity(), 10.479567046232615 * lorentz, delta=1e-5)
+        self.assertAlmostEqual(peak0.getSigmaIntensity(), 10.479567046232615 * lorentz, delta=2e-1)
         q_sample = peak0.getQSampleFrame()
         for i in range(3):
             self.assertNotAlmostEqual(q_sample[i], expected_q_sample[i])

--- a/Framework/PythonInterface/test/python/plugins/algorithms/HB3AIntegrateDetectorPeaksTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/HB3AIntegrateDetectorPeaksTest.py
@@ -91,9 +91,14 @@ class HB3ADetectorPeaksTest(unittest.TestCase):
         self.assertEqual(peaks.getNumberPeaks(), 1)
 
         peak0 = peaks.getPeak(0)
-        lorentz = abs(np.cos(peak0.getAzimuthal()) * np.sin(peak0.getScattering()))
-        self.assertAlmostEqual(peak0.getIntensity(), 961.6164021216964 * lorentz, delta=1e-2)
-        self.assertAlmostEqual(peak0.getSigmaIntensity(), 10.479567046232615 * lorentz, delta=2e-2)
+        two_th = peak0.getScattering()
+        az = peak0.getAzimuthal()
+        nu = np.arcsin(np.sin(two_th)*np.sin(az))
+        gamma = np.arctan(np.tan(two_th)*np.cos(az))
+        # G. J. McIntyre and R. F. D. Stansfield, Acta Cryst A 44, 257 (1988).
+        lorentz = abs(np.cos(nu)*np.sin(gamma))
+        self.assertAlmostEqual(peak0.getIntensity(), 961.6164021216964 * lorentz, delta=1e-5)
+        self.assertAlmostEqual(peak0.getSigmaIntensity(), 10.479567046232615 * lorentz, delta=1e-5)
         q_sample = peak0.getQSampleFrame()
         for i in range(3):
             self.assertNotAlmostEqual(q_sample[i], expected_q_sample[i])

--- a/Framework/PythonInterface/test/python/plugins/algorithms/HB3AIntegratePeaksTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/HB3AIntegratePeaksTest.py
@@ -60,7 +60,7 @@ class HB3AIntegratePeaksTest(unittest.TestCase):
         for p in range(int_peaks2.getNumberPeaks()):
             peak1 = int_peaks.getPeak(p)
             peak2 = int_peaks2.getPeak(p)
-            lorentz = abs(np.sin(peak2.getScattering() * np.cos(peak2.getAzimuthal())))
+            lorentz = abs(np.sin(peak2.getScattering()) * np.cos(peak2.getAzimuthal()))
             self.assertAlmostEqual(peak1.getIntensity() * lorentz, peak2.getIntensity())
             self.assertAlmostEqual(peak1.getSigmaIntensity() * lorentz, peak2.getSigmaIntensity())
 

--- a/Framework/PythonInterface/test/python/plugins/algorithms/HB3AIntegratePeaksTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/HB3AIntegratePeaksTest.py
@@ -60,7 +60,12 @@ class HB3AIntegratePeaksTest(unittest.TestCase):
         for p in range(int_peaks2.getNumberPeaks()):
             peak1 = int_peaks.getPeak(p)
             peak2 = int_peaks2.getPeak(p)
-            lorentz = abs(np.sin(peak2.getScattering()) * np.cos(peak2.getAzimuthal()))
+            two_th = peak2.getScattering()
+            az = peak2.getAzimuthal()
+            nu = np.arcsin(np.sin(two_th)*np.sin(az))
+            gamma = np.arctan(np.tan(two_th)*np.cos(az))
+            # G. J. McIntyre and R. F. D. Stansfield, Acta Cryst A 44, 257 (1988).
+            lorentz = abs(np.cos(nu)*np.sin(gamma))
             self.assertAlmostEqual(peak1.getIntensity() * lorentz, peak2.getIntensity())
             self.assertAlmostEqual(peak1.getSigmaIntensity() * lorentz, peak2.getSigmaIntensity())
 

--- a/Testing/SystemTests/tests/framework/HB3AWorkflowTests.py
+++ b/Testing/SystemTests/tests/framework/HB3AWorkflowTests.py
@@ -161,7 +161,7 @@ class MultiFileFindPeaksIntegrate(systemtesting.MantidSystemTest):
         self.assertEqual(peak0.getL(), 10)
         self.assertEqual(peak0.getRunNumber(), 182)
         self.assertAlmostEqual(peak0.getWavelength(), 1.008, places=5)
-        self.assertAlmostEqual(peak0.getIntensity(), 6581.5580392, places=5)
+        self.assertAlmostEqual(peak0.getIntensity(), 6578.5329412, places=5)
         self.assertEqual(peak0.getBinCount(), 827)
 
         peak1 = integrated.getPeak(integrated.getNumberPeaks()-1)
@@ -170,7 +170,7 @@ class MultiFileFindPeaksIntegrate(systemtesting.MantidSystemTest):
         self.assertEqual(peak1.getL(), 0)
         self.assertEqual(peak1.getRunNumber(), 183)
         self.assertAlmostEqual(peak1.getWavelength(), 1.008, places=5)
-        self.assertAlmostEqual(peak1.getIntensity(), 11853.7538139, places=5)
+        self.assertAlmostEqual(peak1.getIntensity(), 11316.7193962, places=5)
         self.assertEqual(peak1.getBinCount(), 134)
 
         DeleteWorkspaces([ws_name+'_data',
@@ -217,7 +217,7 @@ class MultiFilePredictPeaksIntegrate(systemtesting.MantidSystemTest):
         self.assertEqual(peak0.getL(), -11)
         self.assertEqual(peak0.getRunNumber(), 182)
         self.assertAlmostEqual(peak0.getWavelength(), 1.008, places=5)
-        self.assertAlmostEqual(peak0.getIntensity(), 127.20005, places=5)
+        self.assertAlmostEqual(peak0.getIntensity(), 127.13211, places=5)
         self.assertEqual(peak0.getBinCount(), 0)
 
         peak1 = integrated.getPeak(integrated.getNumberPeaks()-1)
@@ -226,7 +226,7 @@ class MultiFilePredictPeaksIntegrate(systemtesting.MantidSystemTest):
         self.assertEqual(peak1.getL(), 1)
         self.assertEqual(peak1.getRunNumber(), 183)
         self.assertAlmostEqual(peak1.getWavelength(), 1.008, places=5)
-        self.assertAlmostEqual(peak1.getIntensity(), 66.0945249, places=5)
+        self.assertAlmostEqual(peak1.getIntensity(), 60.928141, places=5)
         self.assertEqual(peak1.getBinCount(), 0)
 
         DeleteWorkspaces([ws_name+'_data',
@@ -285,7 +285,7 @@ class MultiFilePredictPeaksUBFromFindPeaksIntegrate(systemtesting.MantidSystemTe
         self.assertEqual(peak0.getL(), 8)
         self.assertEqual(peak0.getRunNumber(), 182)
         self.assertAlmostEqual(peak0.getWavelength(), 1.008, places=5)
-        self.assertAlmostEqual(peak0.getIntensity(), 124.408590, places=5)
+        self.assertAlmostEqual(peak0.getIntensity(), 122.269802, places=5)
         self.assertEqual(peak0.getBinCount(), 0)
 
         peak1 = integrated.getPeak(integrated.getNumberPeaks()-1)
@@ -294,7 +294,7 @@ class MultiFilePredictPeaksUBFromFindPeaksIntegrate(systemtesting.MantidSystemTe
         self.assertEqual(peak1.getL(), 3)
         self.assertEqual(peak1.getRunNumber(), 183)
         self.assertAlmostEqual(peak1.getWavelength(), 1.008, places=5)
-        self.assertAlmostEqual(peak1.getIntensity(), 101.3689957, places=5)
+        self.assertAlmostEqual(peak1.getIntensity(), 101.175119, places=5)
         self.assertEqual(peak1.getBinCount(), 0)
 
         DeleteWorkspaces([ws_name+'_data',

--- a/docs/source/release/v6.5.0/Diffraction/Single_Crystal/Bugfixes/34481.rst
+++ b/docs/source/release/v6.5.0/Diffraction/Single_Crystal/Bugfixes/34481.rst
@@ -1,0 +1,1 @@
+- Fix typo in :ref:`HB3AIntegratePeaks <algm-HB3AIntegratePeaks>` and :ref:`HB3AIntegrateDetectorPeaks <algm-HB3AIntegrateDetectorPeaks>` Lorentz correction factors.


### PR DESCRIPTION
**Description of work.**

Fixes two HB3A algorithms with typos in Lorentz correction.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**

Run the unit tests `HB3AIntegrateDetectorPeaksTest.py` and `HB3AIntegratePeaksTest.py`. An alternative but equivalent expression is now used in place to cross-check the result.

<!-- Instructions for testing. -->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
