### PR TITLE
Tool for finding unused release notes during release

### DIFF
--- a/tools/ReleaseNotes/unused_release_note_finder.py
+++ b/tools/ReleaseNotes/unused_release_note_finder.py
@@ -45,7 +45,6 @@ if __name__ == '__main__':
     args = parse_args()
     args.release = fixReleaseName(args.release)
     main_release_dir = createFileLocation(args.release)
-    # main_release_dir = createFileLocation('v6.5.0')
     release_note_dirs = checkContainsReleaseNote(main_release_dir)
     unused_note_dirs = check_for_unused_files(release_note_dirs)
     print_paths(unused_note_dirs)

--- a/tools/ReleaseNotes/unused_release_note_finder.py
+++ b/tools/ReleaseNotes/unused_release_note_finder.py
@@ -1,0 +1,51 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2022 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+
+
+from argparse import ArgumentParser
+from release_editor import fixReleaseName, createFileLocation, checkContainsReleaseNote
+
+
+def parse_args():
+    parser = ArgumentParser(description="Locate unused release notes")
+    parser.add_argument('--release', required=True)
+    return parser.parse_args()
+
+
+def check_for_unused_files(dirs):
+    unused_dirs = []
+    for p in dirs:
+        if p.name != "Used":
+            unused_dirs.append(p)
+    return unused_dirs
+
+
+def find_files(dirs):
+    file_paths = []
+    for p in dirs:
+        file_paths += list(p.glob('*.rst'))
+    return file_paths
+
+
+def print_paths(dirs):
+    if not dirs:
+        print("No unused release notes!")
+    else:
+        paths = find_files(dirs)
+        print(f"{len(paths)} unused release notes found!")
+        for p in paths:
+            print(str(p))
+
+
+if __name__ == '__main__':
+    args = parse_args()
+    args.release = fixReleaseName(args.release)
+    main_release_dir = createFileLocation(args.release)
+    # main_release_dir = createFileLocation('v6.5.0')
+    release_note_dirs = checkContainsReleaseNote(main_release_dir)
+    unused_note_dirs = check_for_unused_files(release_note_dirs)
+    print_paths(unused_note_dirs)


### PR DESCRIPTION
**Description of work.**

It can be tricky to keep on top of new release notes added during release (after the main docs are already built and new notes must be moved manually). Searching through the nested directories to find new files can take some time.

This script searches through a specified release version directory and find all release note files which aren't within a 'used' directory (indicating they need to be moved to the main files).

**To test:**

- `cd tools/ReleaseNotes`
- `python unused_release_note_finder.py --release 6.6.0`
- The script should print out the locations of unused release notes
- Temporarily move some notes in / out of 'Used' directories to check that they no longer appear / appear in the search
- Try with `6.4.0` and it should find none

*There is no associated issue.*


*This does not require release notes* because adds a tool just for the release editor role.

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
