### PR TITLE
Muon analysis load files without all cap instrument name

### DIFF
--- a/docs/source/release/v6.5.0/Muon/MA_FDA/Bugfixes/34458.rst
+++ b/docs/source/release/v6.5.0/Muon/MA_FDA/Bugfixes/34458.rst
@@ -1,0 +1,1 @@
+- Fixed a bug that prevented the loading of files that did not have the instrument name in all capitals.

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/utilities/load_utils.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/utilities/load_utils.py
@@ -192,6 +192,22 @@ def load_dead_time_from_filename(filename):
     return dead_times
 
 
+def get_correct_file_path(filename_in, alg):
+    """
+    The filename given to the loading algorithm can be different to the file that was actually loaded.
+    Pulling the filename back out of the algorithm after loading ensures that the path is accurate.
+
+    The load alg will always change the instrument name to all caps,
+    this behaviour is not wanted as the path is used as a key and may
+    not match the "real" name.
+    """
+    _, correct_filename = os.path.split(filename_in)
+
+    filename = alg.getProperty("Filename").value[0]
+    _, filename_all_caps = os.path.split(filename)
+    return filename.replace(filename_all_caps, correct_filename)
+
+
 def load_workspace_from_filename(filename,
                                  input_properties=DEFAULT_INPUTS,
                                  output_properties=DEFAULT_OUTPUTS):
@@ -202,9 +218,8 @@ def load_workspace_from_filename(filename,
         alg, psi_data = create_load_algorithm(filename.split(os.sep)[-1], input_properties)
         alg.execute()
 
-    # The filename given to the loading algorithm can be different to the file that was actually loaded.
-    # Pulling the filename back out of the algorithm after loading ensures that the path is accurate.
-    filename = alg.getProperty("Filename").value[0]
+    filename = get_correct_file_path(filename, alg)
+
     workspace = AnalysisDataService.retrieve(alg.getProperty("OutputWorkspace").valueAsStr)
     if is_workspace_group(workspace):
         # handle multi-period data

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/utilities/load_utils.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/utilities/load_utils.py
@@ -192,6 +192,10 @@ def load_dead_time_from_filename(filename):
     return dead_times
 
 
+def get_filename_from_alg(alg):
+    return alg.getProperty("Filename").value[0]
+
+
 def get_correct_file_path(filename_in, alg):
     """
     The filename given to the loading algorithm can be different to the file that was actually loaded.
@@ -203,7 +207,7 @@ def get_correct_file_path(filename_in, alg):
     """
     _, correct_filename = os.path.split(filename_in)
 
-    filename = alg.getProperty("Filename").value[0]
+    filename = get_filename_from_alg(alg)
     _, filename_all_caps = os.path.split(filename)
     return filename.replace(filename_all_caps, correct_filename)
 

--- a/qt/python/mantidqtinterfaces/test/Muon/utilities/load_utils_test.py
+++ b/qt/python/mantidqtinterfaces/test/Muon/utilities/load_utils_test.py
@@ -80,7 +80,7 @@ class MuonFileUtilsTest(unittest.TestCase):
         self.assertEqual(run, 22725)
         ConfigService.Instance().setString("default.facility", " ")
 
-    @mock.patch('mantidqtinterfaces.Muon.GUI.Common.utilities.load_utils')
+    @mock.patch('mantidqtinterfaces.Muon.GUI.Common.utilities.load_utils.get_filename_from_alg')
     def test_filename_not_caps(self, mock_get_name):
         alg = mock.Mock()
 

--- a/qt/python/mantidqtinterfaces/test/Muon/utilities/load_utils_test.py
+++ b/qt/python/mantidqtinterfaces/test/Muon/utilities/load_utils_test.py
@@ -80,9 +80,10 @@ class MuonFileUtilsTest(unittest.TestCase):
         self.assertEqual(run, 22725)
         ConfigService.Instance().setString("default.facility", " ")
 
-    def test_filename_not_caps(self):
+    @mock.patch('mantidqtinterfaces.Muon.GUI.Common.utilities.load_utils')
+    def test_filename_not_caps(self, mock_get_name):
         alg = mock.Mock()
-        alg.get_property = mock.Mock()
+
         mock_path = 'C:/users/test/data/'
         wrong_path = 'C:/users/t/data/'
 
@@ -90,7 +91,7 @@ class MuonFileUtilsTest(unittest.TestCase):
         run_number = "125846.nxs"
         for name in instrument_names:
             # this will alway return all caps for the name -> use upper
-            alg.get_property.return_value = [mock_path+name.upper()+run_number]
+            mock_get_name.return_value = mock_path+name.upper()+run_number
             # load will have correct path -> use wrong path for filename
             filename = utils.get_correct_file_path(wrong_path+name+run_number, alg)
 

--- a/qt/python/mantidqtinterfaces/test/Muon/utilities/load_utils_test.py
+++ b/qt/python/mantidqtinterfaces/test/Muon/utilities/load_utils_test.py
@@ -80,6 +80,22 @@ class MuonFileUtilsTest(unittest.TestCase):
         self.assertEqual(run, 22725)
         ConfigService.Instance().setString("default.facility", " ")
 
+    def test_filename_not_caps(self):
+        alg = mock.Mock()
+        alg.get_property = mock.Mock()
+        mock_path = 'C:/users/test/data/'
+        wrong_path = 'C:/users/t/data/'
+
+        instrument_names = ["hifi", "Hifi", "hIfI", "hifI"]
+        run_number = "125846.nxs"
+        for name in instrument_names:
+            # this will alway return all caps for the name -> use upper
+            alg.get_property.return_value = [mock_path+name.upper()+run_number]
+            # load will have correct path -> use wrong path for filename
+            filename = utils.get_correct_file_path(wrong_path+name+run_number, alg)
+
+            self.assertEqual(filename, mock_path+name+run_number)
+
     def test_create_load_alg_for_nxs_files(self):
         filename = "EMU00019489.nxs"
         inputs = {}


### PR DESCRIPTION
**Description of work.**

The muon analysis (and by extension the frequency domain analysis) GUI was unable to load files if the instrument name was not all capitals (i.e. hifi instead of HIFI). The path was taken from the load algorithm, which automatically makes the instrument name all capitals. This caused problems as the dict for storing runs used the non-caps instrument name, so when searching for runs it would never find a match (as the search had all caps). This PR fixes the problem by always returning the capitalisation used in the original file.

**To test:**

<!-- Instructions for testing. -->
1. Get the data from me (it has a mix of capitalisation), turn off the archive and set the data to the search path 
2. Open muon analysis
3. Set the instrument to HIFI
4. use the browse button to load all of the data (can highlight all of it using shift)
5. All of the data will be loaded into the GUI
6. Close muon analysis
7. Clear the ADS
8. Open frequency domain analysis
9. Type 35972 into the run bar and press enter
10. The data should load
11. Type 35974
12. The data should load
13. use the arrow button to step to the next data set (35975)
14. The data should load
15. Repeat stepping through the data until you get to 35980

Fixes #34458 
<!-- alternative
*There is no associated issue.*
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
