### PR TITLE
Fix units output by SaveSESANS algorithm

### DIFF
--- a/Framework/DataHandling/inc/MantidDataHandling/SaveSESANS.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/SaveSESANS.h
@@ -48,6 +48,7 @@ private:
   const int MAX_HDR_LENGTH = 23;
   const std::vector<std::string> fileExtensions{".ses", ".SES", ".sesans", ".SESANS"};
   const std::vector<std::string> mandatoryDoubleProperties{"ThetaZMax", "ThetaYMax", "EchoConstant"};
+  double m_sampleThickness = EMPTY_DBL();
 
   void init() override;
   void exec() override;

--- a/Framework/DataHandling/inc/MantidDataHandling/SaveSESANS.h
+++ b/Framework/DataHandling/inc/MantidDataHandling/SaveSESANS.h
@@ -46,6 +46,8 @@ private:
   // Length of the longest attribute name in headers (+4 for readability in the
   // file)
   const int MAX_HDR_LENGTH = 23;
+  // Tolerance to use when comparing two doubles for equality
+  const double TOLERANCE = 1e-09;
   const std::vector<std::string> fileExtensions{".ses", ".SES", ".sesans", ".SESANS"};
   const std::vector<std::string> mandatoryDoubleProperties{"ThetaZMax", "ThetaYMax", "EchoConstant"};
   double m_sampleThickness = EMPTY_DBL();

--- a/Framework/DataHandling/src/SaveSESANS.cpp
+++ b/Framework/DataHandling/src/SaveSESANS.cpp
@@ -51,6 +51,12 @@ std::map<std::string, std::string> SaveSESANS::validateInputs() {
   if (getPropertyValue("Sample").empty()) {
     invalidInputs["Sample"] = "Sample must be set";
   }
+
+  m_sampleThickness = static_cast<double>(getProperty("OverrideSampleThickness"));
+  if (m_sampleThickness <= 0) {
+    invalidInputs["OverrideSampleThickness"] = "OverrideSampleThickness value must be greater than 0";
+  }
+
   return invalidInputs;
 }
 
@@ -77,6 +83,11 @@ void SaveSESANS::init() {
   declareProperty<std::string>("Sample", "", "Sample name", Kernel::Direction::Input);
 
   declareProperty<std::string>("Orientation", "Z", validOrientation, "Orientation of the instrument");
+
+  declareProperty("OverrideSampleThickness", EMPTY_DBL(),
+                  "The sample thickness in mm. If set, this value will be used instead of the thickness from the input "
+                  "workspace sample",
+                  Kernel::Direction::Input);
 }
 
 /**
@@ -90,6 +101,17 @@ void SaveSESANS::exec() {
     g_log.error("This algorithm expects a workspace with exactly 1 spectrum");
     throw std::runtime_error("SaveSESANS passed workspace with incorrect "
                              "number of spectra, expected 1");
+  }
+
+  if (m_sampleThickness == EMPTY_DBL()) {
+    m_sampleThickness = ws->sample().getThickness();
+    if (m_sampleThickness <= 0) {
+      g_log.error("The workspace passed in does not provide the sample thickness. Please use the "
+                  "OverrideSampleThickness property to "
+                  "provide this value instead");
+      throw std::runtime_error("SaveSESANS passed workspace with sample thickness less than "
+                               "or equal to 0 and no value provided for OverrideSampleThickness property");
+    }
   }
 
   auto filename = getPropertyValue("Filename");
@@ -131,12 +153,10 @@ void SaveSESANS::exec() {
  * @param ws The workspace to save
  */
 void SaveSESANS::writeHeaders(std::ofstream &outfile, API::MatrixWorkspace_const_sptr &ws) {
-  const API::Sample &sample = ws->sample();
-
   writeHeader(outfile, "FileFormatVersion", "1.0");
   writeHeader(outfile, "DataFileTitle", ws->getTitle());
   writeHeader(outfile, "Sample", getPropertyValue("Sample"));
-  writeHeader(outfile, "Thickness", std::to_string(sample.getThickness()));
+  writeHeader(outfile, "Thickness", std::to_string(m_sampleThickness));
   writeHeader(outfile, "Thickness_unit", "mm");
   writeHeader(outfile, "Theta_zmax", getPropertyValue("ThetaZMax"));
   writeHeader(outfile, "Theta_zmax_unit", getPropertyValue("ThetaZMaxUnit"));
@@ -178,7 +198,7 @@ std::vector<double> SaveSESANS::calculateSpinEchoLength(const HistogramData::Poi
 /**
  * Calculate the depolarisation column from wavelength and Y values in the
  * workspace
- * (depol = ln(y) / wavelength^2)
+ * (depol = ln(y) / wavelength^2 / sample thickness in cm)
  * @param yValues Y column in the workspace
  * @param wavelength Wavelength column
  * @return The depolarisation column
@@ -186,16 +206,18 @@ std::vector<double> SaveSESANS::calculateSpinEchoLength(const HistogramData::Poi
 std::vector<double> SaveSESANS::calculateDepolarisation(const HistogramData::HistogramY &yValues,
                                                         const HistogramData::Points &wavelength) const {
   Mantid::MantidVec depolarisation;
+  // The sample thickness is provided in mm but we need to use cm here
+  double thickness = m_sampleThickness * 0.1;
 
-  // Depol is calculated as ln(y) / wavelength^2
+  // Depol is calculated as ln(y) / wavelength^2 / sample thickness in cm
   transform(yValues.begin(), yValues.end(), wavelength.begin(), back_inserter(depolarisation),
-            [&](double y, double w) { return log(y) / (w * w); });
+            [&](double y, double w) { return log(y) / (w * w) / thickness; });
   return depolarisation;
 }
 
 /**
  * Calculate the error column from the workspace values
- * (error = e / (y * wavelength^2))
+ * (error = e / (y * wavelength^2)) / sample thickness in cm
  * @param eValues Error values from the workspace
  * @param yValues Y values from the workspace
  * @param wavelength Wavelength values (X values from the workspace)
@@ -206,9 +228,12 @@ Mantid::MantidVec SaveSESANS::calculateError(const HistogramData::HistogramE &eV
                                              const HistogramData::Points &wavelength) const {
   Mantid::MantidVec error;
 
-  // Error is calculated as e / (y * wavelength^2)
+  // The sample thickness is provided in mm but we need to use cm here
+  double thickness = m_sampleThickness * 0.1;
+
+  // Error is calculated as e / (y * wavelength^2) / sample thickness in cm
   for (size_t i = 0; i < eValues.size(); i++) {
-    error.emplace_back(eValues[i] / (yValues[i] * wavelength[i] * wavelength[i]));
+    error.emplace_back(eValues[i] / (yValues[i] * wavelength[i] * wavelength[i]) / thickness);
   }
   return error;
 }

--- a/Framework/DataHandling/src/SaveSESANS.cpp
+++ b/Framework/DataHandling/src/SaveSESANS.cpp
@@ -53,8 +53,7 @@ std::map<std::string, std::string> SaveSESANS::validateInputs() {
   }
 
   m_sampleThickness = static_cast<double>(getProperty("OverrideSampleThickness"));
-  const double tolerance = 1e-09;
-  if (m_sampleThickness <= tolerance) {
+  if (m_sampleThickness <= SaveSESANS::TOLERANCE) {
     invalidInputs["OverrideSampleThickness"] = "OverrideSampleThickness value must be greater than 0";
   }
 
@@ -106,7 +105,7 @@ void SaveSESANS::exec() {
 
   if (m_sampleThickness == EMPTY_DBL()) {
     m_sampleThickness = ws->sample().getThickness();
-    if (m_sampleThickness <= 0) {
+    if (m_sampleThickness <= SaveSESANS::TOLERANCE) {
       g_log.error("The workspace passed in does not provide the sample thickness. Please use the "
                   "OverrideSampleThickness property to "
                   "provide this value instead");

--- a/Framework/DataHandling/src/SaveSESANS.cpp
+++ b/Framework/DataHandling/src/SaveSESANS.cpp
@@ -53,7 +53,8 @@ std::map<std::string, std::string> SaveSESANS::validateInputs() {
   }
 
   m_sampleThickness = static_cast<double>(getProperty("OverrideSampleThickness"));
-  if (m_sampleThickness <= 0) {
+  const double tolerance = 1e-09;
+  if (m_sampleThickness <= tolerance) {
     invalidInputs["OverrideSampleThickness"] = "OverrideSampleThickness value must be greater than 0";
   }
 

--- a/Framework/DataHandling/test/SaveSESANSTest.h
+++ b/Framework/DataHandling/test/SaveSESANSTest.h
@@ -72,6 +72,16 @@ public:
     TS_ASSERT_THROWS(testAlg.execute(), const std::runtime_error &);
   }
 
+  void test_exec_with_invalid_sample_thickness() {
+    auto ws = createTestWorkspace();
+    ws->mutableSample().setThickness(withinTolerance);
+
+    setCommonAlgorithmProperties(ws);
+
+    // Execute the algorithm
+    TS_ASSERT_THROWS(testAlg.execute(), const std::runtime_error &);
+  }
+
   void test_exec_thickness_property() {
     auto ws = createTestWorkspace();
 
@@ -101,8 +111,7 @@ public:
 
     testAlg.setProperty("InputWorkspace", ws);
     testAlg.setProperty("Sample", "Sample set in SaveSESANSTest");
-    const double tolerance = 1e-09;
-    testAlg.setProperty("OverrideSampleThickness", tolerance);
+    testAlg.setProperty("OverrideSampleThickness", withinTolerance);
 
     // Execute the algorithm
     TS_ASSERT_THROWS(testAlg.execute(), const std::runtime_error &);
@@ -115,6 +124,7 @@ private:
   const double echoConstant = 1.5;
   const std::string workspaceTitle = "Sample workspace";
   const std::string sampleName = "Sample set in SaveSESANSTest";
+  const double withinTolerance = 1e-10;
 
   Workspace2D_sptr createTestWorkspace() {
     // Set up workspace

--- a/Framework/DataHandling/test/SaveSESANSTest.h
+++ b/Framework/DataHandling/test/SaveSESANSTest.h
@@ -96,6 +96,18 @@ public:
     TS_ASSERT_THROWS(testAlg.execute(), const std::runtime_error &);
   }
 
+  void test_exec_thickness_property_within_tolerance() {
+    auto ws = createTestWorkspace();
+
+    testAlg.setProperty("InputWorkspace", ws);
+    testAlg.setProperty("Sample", "Sample set in SaveSESANSTest");
+    const double tolerance = 1e-09;
+    testAlg.setProperty("OverrideSampleThickness", tolerance);
+
+    // Execute the algorithm
+    TS_ASSERT_THROWS(testAlg.execute(), const std::runtime_error &);
+  }
+
 private:
   SaveSESANS testAlg;
   const double root2 = std::sqrt(2.0);

--- a/Framework/DataHandling/test/SaveSESANSTest.h
+++ b/Framework/DataHandling/test/SaveSESANSTest.h
@@ -22,6 +22,7 @@
 #include <fstream>
 
 using Mantid::DataHandling::SaveSESANS;
+using namespace Mantid::DataObjects;
 using namespace Mantid;
 
 class SaveSESANSTest : public CxxTest::TestSuite {
@@ -51,24 +52,80 @@ public:
   }
 
   void test_exec() {
+    auto ws = createTestWorkspace();
+    ws->mutableSample().setThickness(5);
+
+    setCommonAlgorithmProperties(ws);
+
+    // Execute the algorithm
+    TS_ASSERT_THROWS_NOTHING(testAlg.execute());
+
+    checkOutput(ws->sample().getThickness());
+  }
+
+  void test_exec_with_no_sample_thickness() {
+    auto ws = createTestWorkspace();
+
+    setCommonAlgorithmProperties(ws);
+
+    // Execute the algorithm
+    TS_ASSERT_THROWS(testAlg.execute(), const std::runtime_error &);
+  }
+
+  void test_exec_thickness_property() {
+    auto ws = createTestWorkspace();
+
+    setCommonAlgorithmProperties(ws);
+    const double thickness = 10;
+    testAlg.setProperty("OverrideSampleThickness", thickness);
+
+    // Execute the algorithm
+    TS_ASSERT_THROWS_NOTHING(testAlg.execute());
+
+    checkOutput(thickness);
+  }
+
+  void test_exec_invalid_thickness_property() {
+    auto ws = createTestWorkspace();
+
+    testAlg.setProperty("InputWorkspace", ws);
+    testAlg.setProperty("Sample", "Sample set in SaveSESANSTest");
+    testAlg.setProperty("OverrideSampleThickness", "0");
+
+    // Execute the algorithm
+    TS_ASSERT_THROWS(testAlg.execute(), const std::runtime_error &);
+  }
+
+private:
+  SaveSESANS testAlg;
+  const double root2 = std::sqrt(2.0);
+  const double ln2 = log(2.0);
+  const double echoConstant = 1.5;
+  const std::string workspaceTitle = "Sample workspace";
+  const std::string sampleName = "Sample set in SaveSESANSTest";
+
+  Workspace2D_sptr createTestWorkspace() {
     // Set up workspace
     // X = [1 to 11], Y = [2] * 10, E = [sqrt(2)] * 10
     auto ws = WorkspaceCreationHelper::create2DWorkspaceBinned(1, 10, 1, 1);
 
     // Set workspace attributes
-    ws->setTitle("Sample workspace");
+    ws->setTitle(workspaceTitle);
 
+    return ws;
+  }
+
+  void setCommonAlgorithmProperties(const Workspace2D_sptr &ws) {
     testAlg.setProperty("InputWorkspace", ws);
-    testAlg.setProperty("Sample", "Sample set in SaveSESANSTest");
+    testAlg.setProperty("Sample", sampleName);
 
     // Make a temporary file
     Poco::TemporaryFile tempFile;
     const std::string &tempFileName = tempFile.path();
     TS_ASSERT_THROWS_NOTHING(testAlg.setProperty("Filename", tempFileName));
+  }
 
-    // Execute the algorithm
-    TS_ASSERT_THROWS_NOTHING(testAlg.execute());
-
+  void checkOutput(const double sampleThickness) {
     // Get absolute path to the output file
     std::string outputPath = testAlg.getPropertyValue("Filename");
 
@@ -87,8 +144,8 @@ public:
     TS_ASSERT_THROWS_NOTHING(loadedWS = API::AnalysisDataService::Instance().retrieve(outWSName));
     API::MatrixWorkspace_sptr data = std::dynamic_pointer_cast<API::MatrixWorkspace>(loadedWS);
     // Check titles were set
-    TS_ASSERT_EQUALS(data->getTitle(), "Sample workspace");
-    TS_ASSERT_EQUALS(data->sample().getName(), "Sample set in SaveSESANSTest");
+    TS_ASSERT_EQUALS(data->getTitle(), workspaceTitle);
+    TS_ASSERT_EQUALS(data->sample().getName(), sampleName);
 
     // Check (a small sample of) the values we wrote are correct
     TS_ASSERT_EQUALS(static_cast<int>(data->getNumberHistograms()), 1);
@@ -102,6 +159,7 @@ public:
 
     // Check the actual values match
     double tolerance(1e-05);
+    double thickness = sampleThickness * 0.1;
     for (size_t i = 0; i < xValues.size(); i++) {
       // X values are 0.5 higher than they were when we set them, as we set the
       // bin edges but are now dealing with bin middles
@@ -110,24 +168,18 @@ public:
       double wavelengthSquared = (static_cast<double>(i) + 1.5) * (static_cast<double>(i) + 1.5);
       TS_ASSERT_DELTA(xValues[i], wavelengthSquared * echoConstant, tolerance);
 
-      // Y value is now depolarisation = log(Y) / wavelength ^ 2
+      // Y value is now depolarisation = log(Y) / wavelength ^ 2 / thickness in cm
       // Where Y is Y value from original workspace (constantly 2 in this case)
-      TS_ASSERT_DELTA(yValues[i], ln2 / wavelengthSquared, tolerance);
+      TS_ASSERT_DELTA(yValues[i], ln2 / wavelengthSquared / thickness, tolerance);
 
-      // Error is now E / (Y * wavelength ^ 2)
+      // Error is now E / (Y * wavelength ^ 2) / thickness in cm
       // Where E and Y are from the original workspace (sqrt(2) and 2
       // respectively)
-      TS_ASSERT_DELTA(eValues[i], root2 / (2.0 * wavelengthSquared), tolerance);
+      TS_ASSERT_DELTA(eValues[i], root2 / (2.0 * wavelengthSquared) / thickness, tolerance);
     }
 
     // Clean up the file
     TS_ASSERT_THROWS_NOTHING(Poco::File(outputPath).remove());
     TS_ASSERT(!Poco::File(outputPath).exists());
   }
-
-private:
-  SaveSESANS testAlg;
-  const double root2 = std::sqrt(2.0);
-  const double ln2 = log(2.0);
-  const double echoConstant = 1.5;
 };

--- a/docs/source/algorithms/SaveSESANS-v1.rst
+++ b/docs/source/algorithms/SaveSESANS-v1.rst
@@ -11,7 +11,10 @@ Description
 
 Saves the given workspace to a file which will be formatted in the
 SESANS data format. A workspace with a single spectrum is expected,
-where the X values are wavelength and the Y values are polarisation
+where the X values are wavelength and the Y values are polarisation.
+
+The sample thickness from the run metadata is used to normalise the polarisation data.
+The :literal:`OverrideSampleThickness` parameter can be used to specify a different value for this if needed.
 
 Usage
 -----
@@ -28,6 +31,7 @@ Usage
    dataE = [1,1,4,5]
    out_ws = CreateWorkspace(dataX, dataY, dataE)
    out_ws.setTitle("Dummy workspace")
+   out_ws.sample().setThickness(10)
 
    file_path = os.path.join(config["defaultsave.directory"], "example.ses")
 

--- a/docs/source/algorithms/SaveSESANS-v1.rst
+++ b/docs/source/algorithms/SaveSESANS-v1.rst
@@ -25,7 +25,7 @@ Usage
 
    import os
 
-   # Create dummy workspace
+   # Create dummy workspace with sample thickness metadata
    dataX = [1,2,3,4,5]
    dataY = [6,1,9,14]
    dataE = [1,1,4,5]

--- a/docs/source/release/v6.5.0/SANS/Bugfixes/34491.rst
+++ b/docs/source/release/v6.5.0/SANS/Bugfixes/34491.rst
@@ -1,0 +1,1 @@
+- The depolarisation columns output by algorithm SaveSESANS are now normalised by the sample thickness. A new parameter, OverrideSampleThickness, allows an alternative value for normalisation to be specified if needed.


### PR DESCRIPTION
**Description of work.**

**Report to:** Rob Dalgliesh and Greg Smith

Corrects the calculations for the `Depolarisation` and `Depolarisation_error` columns that are output by the `SaveSESANS` algorithm so that the values have been divided by the sample thickness (in cm). By default the value from the metadata is used, but this PR also adds a new parameter that allows the user to specify a different value if needed. The values provided by the user or taken from the metadata are given in mm, so the calculation converts these to cm before using them.

I've included some validation that values passed in via the parameter should be greater than 0. I've also included a check for the case where there is no value provided plus no value greater than 0 in the metadata. I'm not sure if it would be realistic for the metadata to have a 0 sample thickness (it occurred to me because of some of our test data, but this may not be representative), so I can remove this check if it seems unnecessary.

**To test:**

The script on the documentation page can be used for testing: https://docs.mantidproject.org/nightly/algorithms/SaveSESANS-v1.html.

1) Add line `out_ws.sample().setThickness(10)` to the script to set some sample thickness metadata (this line can be added underneath `out_ws.setTitle("Dummy workspace")`).
2) Run the script and check the content of the `example.ses` file that should be output to your default save location. Check that the values in the `Depolarisation` column match what is expected for the Y values in the documentation.
3) Change the sample thickness to `20` and check that the values in the `Depolarisation` column and the `Depolarisation_error` column are half of what they were previously. This is to check that the values are being normalised by the sample thickness from the metadata.
4) In the `SaveSESANS` algorithm, add a value for parameter `OverrideSampleThickness` that is different to the value specified in the metadata. Check that the `Depolarisation` and `Depolarisation_error` columns have been normalised by the parameter value and not the metadata value.
5) Check that sensible errors are thrown if the sample thickness hasn't been set in the metadata or if a value <= 0 is passed in to the `OverrideSampleThickness` parameter.

Fixes #33983. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
