### PR TITLE
Fix for issue 33508 gridlines turn on unexpectedly

### DIFF
--- a/docs/source/release/v6.6.0/Workbench/Bugfixes/33508.rst
+++ b/docs/source/release/v6.6.0/Workbench/Bugfixes/33508.rst
@@ -1,0 +1,1 @@
+- Grid lines will not turn on unexpectedly when changing axis format.

--- a/docs/source/release/v6.6.0/Workbench/Bugfixes/33508.rst
+++ b/docs/source/release/v6.6.0/Workbench/Bugfixes/33508.rst
@@ -1,1 +1,1 @@
-- Grid lines will not turn on unexpectedly when changing axis format.
+- Grid lines will not turn on unexpectedly when changing axis format in a 3-D plot.

--- a/qt/applications/workbench/workbench/plotting/propertiesdialog.py
+++ b/qt/applications/workbench/workbench/plotting/propertiesdialog.py
@@ -201,11 +201,12 @@ class AxisEditor(PropertiesEditorBase):
             self.limit_min, self.limit_max = self._check_log_limits(self.limit_min, self.limit_max)
         else:
             self.scale_setter('linear')
-
         self.lim_setter(self.limit_min, self.limit_max)
         self._set_tick_format()
         which = 'both' if hasattr(axes, 'show_minor_gridlines') and axes.show_minor_gridlines else 'major'
-        axes.grid(self.ui.gridBox.isChecked(), axis=self.axis_id, which=which)
+
+        if self.ui.gridBox.isChecked():
+            axes.grid(visible=self.ui.gridBox.isChecked(), axis=self.axis_id, which=which)
 
     def error_occurred(self, exc):
         # revert

--- a/qt/applications/workbench/workbench/plotting/propertiesdialog.py
+++ b/qt/applications/workbench/workbench/plotting/propertiesdialog.py
@@ -204,9 +204,9 @@ class AxisEditor(PropertiesEditorBase):
         self.lim_setter(self.limit_min, self.limit_max)
         self._set_tick_format()
         which = 'both' if hasattr(axes, 'show_minor_gridlines') and axes.show_minor_gridlines else 'major'
-
+        # visible will always be True if you pass axis or which argument into axes.grid due to matplotlib
         if self.ui.gridBox.isChecked():
-            axes.grid(visible=self.ui.gridBox.isChecked(), axis=self.axis_id, which=which)
+            axes.grid(visible=True, axis=self.axis_id, which=which)
 
     def error_occurred(self, exc):
         # revert


### PR DESCRIPTION
**Description of work.**
Fixes #33508.  Gridline turn on after updating axis scale. This inconsistency is caused by the `change_accepted` function in `AxisEditor`.

**Report to:** thomashampson

**To test:**
Test if gridline remain off
1. Load a workspace and plot a 3D surface plot
2. Turn off gridlines using the toolbar button
3. Double click an axis value to bring up the "Edit axis" dialog
4. Change the tick format to Scientific Format and click OK.
5. Grid lines will remain invisible.

Test if gridline will turn on
1. Load a workspace and plot a 3D surface plot
2. Turn on gridlines using the toolbar button
3. Double click an axis value to bring up the "Edit axis" dialog
4. Change the tick format to Scientific Format and click OK.
5. Grid lines will be visible.



---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
