### PR TITLE
Add CLion instructions for windows

### DIFF
--- a/dev-docs/source/CLion.rst
+++ b/dev-docs/source/CLion.rst
@@ -16,38 +16,82 @@ You will also need to have Visual Studio installed on windows.
 
 If you haven't installed CLion yet do that now, CLion can be installed from `here <https://jetbrains.com/clion/download/>`_.
 
+Opening CLion
+#############
+
+The first time you build from CLion, you will most likely need to launch it from a terminal or command line to make sure you have access to all the relevent tools.
+
+* On Linux,
+
+  #. Open any terminal
+  #. Run ``conda activate mantid-developer``
+  #. Then launch CLion from this terminal with ``<CLION_INSTALL>/bin/clion.sh``
+
+
+* On Windows,
+
+  #. Using your search bar, open the ``x64 Native Tools Command Prompt for VS 2019`` command prompt
+  #. Run ``conda activate mantid-developer``
+  #. Then launch CLion with ``<CLION_INSTALL>/bin/clion.bat``
+
+If you get errors about being unable to compile a 'simple test program', then doing the above should fix your issue.
+
 Setup for a CLion Build
 #######################
 
-To build using a Ninja generator from the CLion IDE, follow these instructions from within CLion:
+Follow these instructions when the CLion IDE has opened:
 
 To set up your toolchain:
 
-- Navigate to ``File > Settings > Build, Execution, Deployment > Toolchains``
-- Create a new ``System`` toolchain using the ``+`` icon and call it ``Default``
-- Edit the CMake field to point to your conda installed ``cmake``, e.g.
-   - On Linux: ``/path/to/mambaforge/envs/mantid-developer/bin/cmake``
-   - On Windows: ``/path/to/mambaforge/envs/mantid-developer/Library/bin/cmake.exe``
-- Edit the Build Tool field to point to your conda installed ``ninja``, e.g.
-   - On Linux: ``/path/to/mambaforge/envs/mantid-developer/bin/ninja``
-   - On Windows: ``/path/to/mambaforge/envs/mantid-developer/Library/bin/ninja.exe``
-- For the C Compiler and C++ Compiler fields,
-   - On Linux: choose ``Let CMake detect``
-   - On Windows: direct them both at the same ``cl.exe`` in your Visual Studio installation, e.g. ``C:/Program Files (x86)/Microsoft Visual Studio/2019/Community/VC/Tools/MSVC/14.29.30133/bin/Hostx64/x64/cl.exe``
+#. Navigate to ``File > Settings > Build, Execution, Deployment > Toolchains``
+#. Create a new ``System`` toolchain using the ``+`` icon and call it ``Default``
+#. Edit the CMake field to point to your conda installed ``cmake``
+
+   .. hlist::
+      :columns: 1
+
+      * On Linux: ``/path/to/mambaforge/envs/mantid-developer/bin/cmake``
+      * On Windows: ``/path/to/mambaforge/envs/mantid-developer/Library/bin/cmake.exe``
+
+#. Edit the Build Tool field to point to your conda installed ``ninja``
+
+   .. hlist::
+      :columns: 1
+
+      * On Linux: ``/path/to/mambaforge/envs/mantid-developer/bin/ninja``
+      * On Windows: ``/path/to/mambaforge/envs/mantid-developer/Library/bin/ninja.exe``
+
+#. For the C Compiler and C++ Compiler fields,
+
+   .. hlist::
+      :columns: 1
+
+      * On Linux: choose ``Let CMake detect``
+      * On Windows: direct them both at the same ``cl.exe`` in your Visual Studio installation, e.g. ``C:/Program Files (x86)/Microsoft Visual Studio/2019/Community/VC/Tools/MSVC/14.29.30133/bin/Hostx64/x64/cl.exe``
 
 To set up CMake:
 
-- Navigate to ``File > Settings > Build, Execution, Deployment > CMake``
-- Edit the Build type field by either selecting an option, or typing in a string,
-   - On Linux: ``Debug``
-   - On Windows: ``DebugWithRelRuntime``
-- Set your Toolchain to be the ``Default`` toolchain that you just created
-- Set your generator to be ``Ninja``
-- Edit your cmake options to be,
-   - On Linux: ``--preset=linux``
-   - On Windows: ``--preset=win-ninja``
-- Set the build directory to the ``build`` directory if it is not the default (you'll need to use the full path if its outside the source directory)
-- The configurations drop-down at the top should show all of the build targets. If not, the CMake project is probably not loaded. Go to ``File > Reload CMake Project``. The configurations should be populated
+#. Navigate to ``File > Settings > Build, Execution, Deployment > CMake``
+#. Edit the Build type field by either selecting an option, or typing in a string
+
+   .. hlist::
+      :columns: 1
+
+      * On Linux: ``Debug``
+      * On Windows: ``DebugWithRelRuntime``
+
+#. Set your Toolchain to be the ``Default`` toolchain that you just created
+#. Set your generator to be ``Ninja``
+#. Edit your Cmake options to be
+
+   .. hlist::
+      :columns: 1
+
+      - On Linux: ``--preset=linux``
+      - On Windows: ``--preset=win-ninja``
+
+#. Set the build directory to the ``build`` directory if it is not the default (you'll need to use the full path if its outside the source directory)
+#. The configurations drop-down at the top should show all of the build targets. If not, the CMake project is probably not loaded. Go to ``File > Reload CMake Project``. The configurations should be populated
 
 Building with CLion
 ###################
@@ -55,32 +99,43 @@ Building with CLion
 - To build all targets, navigate to ``Build > Build All in 'Debug'``. Check that the build command displayed in the Messages window is running the correct cmake executable from your conda installation.
 - To build a specific target, select it in the configurations drop-down menu and click the hammar icon next to it.
 
-If this fails, you may need to open CLion from a terminal with your conda environment activated:
-
-- Open a terminal and run ``conda activate mantid-developer``
-- Launch CLion through that terminal with ``<CLION_INSTALL>/bin/clion.sh`` for Linux or ``<CLION_INSTALL>/bin/clion.bat`` for Windows
+If this fails, you may need to open CLion from a terminal with your conda environment activated.
 
 It is also useful to have your terminals in CLion to run with this environment:
 
-- In your ``home`` directory create a file named ``.clionrc`` and open in your favourite text editor, adding these lines:
+#. In your ``home`` directory create a file named ``.clionrc`` and open in your favourite text editor, adding these lines:
 
-  ```
-  source ~/.bashrc
-  source ~/mambaforge/bin/activate mantid-developer
-  ```
+   .. code-block::
 
-- Start CLion using the above steps
-- Navigate to ``File > Settings > Tools > Terminal``
-- To the end of the ``Shell path`` option, add ``--rcfile ~/.clionrc``
+      source ~/.bashrc
+      source ~/mambaforge/bin/activate mantid-developer
+
+#. Start CLion using the above steps
+#. Navigate to ``File > Settings > Tools > Terminal``
+#. To the end of the ``Shell path`` option, add ``--rcfile ~/.clionrc``
 
 Debugging with CLion
 ####################
 
 To debug workbench, you'll need to edit the ``workbench`` CMake Application configuration.
 
-- Set the executable to be the ``python.exe`` in your conda installation, e.g. ``/path/to/mambaforge/envs/mantid-developer/bin/python.exe``
-- Set the program arguments to be ``workbench --single-process`` on Linux, or ``workbench-script.pyw --single-process`` on Windows
-- Set the working directory to be the full path to your ``build/bin`` directory
+#. Set the executable to be the ``python.exe`` in your conda installation
+
+   .. hlist::
+      :columns: 1
+
+      - On Linux: ``/path/to/mambaforge/envs/mantid-developer/bin/python.exe``
+      - On Windows: ``/path/to/mambaforge/envs/mantid-developer/python.exe``
+
+#. Set the program arguments
+
+   .. hlist::
+      :columns: 1
+
+      - On Linux: ``workbench --single-process``
+      - On Windows: ``workbench-script.pyw --single-process``
+
+#. Set the working directory to be the full path to your ``build/bin`` directory
 
 You should now be able to set breakpoints and start debugging by clicking the bug icon.
 

--- a/dev-docs/source/CLion.rst
+++ b/dev-docs/source/CLion.rst
@@ -1,0 +1,52 @@
+.. _clion-ref:
+
+=====
+CLion
+=====
+
+.. contents::
+  :local:
+
+Installing CLion
+################
+
+Please note that these instructions only work when using a Ninja generator from a Windows or Linux operating system.
+
+You will also need to have Visual Studio installed on windows.
+
+If you haven't installed CLion yet do that now, CLion can be installed from `here <https://jetbrains.com/clion/download/>`_.
+
+Setup for a CLion Build
+#######################
+
+To build using a Ninja generator from the CLion IDE, follow these instructions from within CLion:
+
+To set up your toolchain:
+
+- Navigate to `File > Settings > Build, Execution, Deployment > Toolchains`
+- Create a new `System` toolchain using the `+` icon and call it `Default`
+- Edit the CMake field to point to your conda installed `cmake`, e.g. `/path/to/mambaforge/envs/mantid-developer/bin/cmake`
+- Edit the Build Tool field to point to your conda installed `ninja`, e.g. `/path/to/mambaforge/envs/mantid-developer/bin/ninja`
+- On Linux, `Let CMake detect` the C Compiler and C++ Compiler.
+- On Windows, the C Compiler and C++ Compiler should be directed at the same `cl.exe` in your Visual Studio installation, e.g. `C:/Program Files (x86)/Microsoft Visual Studio/2019/Community/VC/Tools/MSVC/14.29.30133/bin/Hostx64/x64/cl.exe`
+
+To set up CMake:
+
+- Navigate to `File > Settings > Build, Execution, Deployment > CMake`
+- On Linux, set your Build type to be `Debug`. On Windows, set your build type to be `DebugWithRelRuntime`
+- Set your Toolchain to be the `Default` toolchain that you just created
+- Set your generator to be `Ninja`
+- Set your cmake options to be `--preset=linux` or `--preset=win-ninja`
+- Set the build directory to the `build` directory if it is not the default (you'll need to use the full path if its outside the source directory)
+- The configurations drop-down at the top should show all of the build targets. If not, the CMake project is probably not loaded. Open the root `CMakeLists.txt` file in a tab and there should be a `Load CMake Project` option at the top right. Click it and the configurations should be populated.
+
+Building with CLion
+###################
+
+- To build all targets, navigate to `Build > Build All in 'Debug'`. Check that the build command displayed in the Messages window is running the correct cmake executable from your conda installation.
+- To build a specific target, select it in the configurations drop-down menu and click the hammar icon next to it.
+
+Debugging with CLion
+####################
+
+

--- a/dev-docs/source/CLion.rst
+++ b/dev-docs/source/CLion.rst
@@ -23,37 +23,37 @@ To build using a Ninja generator from the CLion IDE, follow these instructions f
 
 To set up your toolchain:
 
-- Navigate to `File > Settings > Build, Execution, Deployment > Toolchains`
-- Create a new `System` toolchain using the `+` icon and call it `Default`
-- Edit the CMake field to point to your conda installed `cmake`, e.g. `/path/to/mambaforge/envs/mantid-developer/bin/cmake`
-- Edit the Build Tool field to point to your conda installed `ninja`, e.g. `/path/to/mambaforge/envs/mantid-developer/bin/ninja`
-- On Linux, `Let CMake detect` the C Compiler and C++ Compiler.
-- On Windows, the C Compiler and C++ Compiler should be directed at the same `cl.exe` in your Visual Studio installation, e.g. `C:/Program Files (x86)/Microsoft Visual Studio/2019/Community/VC/Tools/MSVC/14.29.30133/bin/Hostx64/x64/cl.exe`
+- Navigate to ``File > Settings > Build, Execution, Deployment > Toolchains``
+- Create a new ``System`` toolchain using the ``+`` icon and call it ``Default``
+- Edit the CMake field to point to your conda installed ``cmake``, e.g. ``/path/to/mambaforge/envs/mantid-developer/bin/cmake``
+- Edit the Build Tool field to point to your conda installed ``ninja``, e.g. ``/path/to/mambaforge/envs/mantid-developer/bin/ninja``
+- On Linux, ``Let CMake detect`` the C Compiler and C++ Compiler.
+- On Windows, the C Compiler and C++ Compiler should be directed at the same ``cl.exe`` in your Visual Studio installation, e.g. ``C:/Program Files (x86)/Microsoft Visual Studio/2019/Community/VC/Tools/MSVC/14.29.30133/bin/Hostx64/x64/cl.exe``
 
 To set up CMake:
 
-- Navigate to `File > Settings > Build, Execution, Deployment > CMake`
-- On Linux, set your Build type to be `Debug`. On Windows, set your build type to be `DebugWithRelRuntime`
-- Set your Toolchain to be the `Default` toolchain that you just created
-- Set your generator to be `Ninja`
-- Set your cmake options to be `--preset=linux` or `--preset=win-ninja`
-- Set the build directory to the `build` directory if it is not the default (you'll need to use the full path if its outside the source directory)
-- The configurations drop-down at the top should show all of the build targets. If not, the CMake project is probably not loaded. Open the root `CMakeLists.txt` file in a tab and there should be a `Load CMake Project` option at the top right. Click it and the configurations should be populated
+- Navigate to ``File > Settings > Build, Execution, Deployment > CMake``
+- On Linux, set your Build type to be ``Debug``. On Windows, set your build type to be ``DebugWithRelRuntime``
+- Set your Toolchain to be the ``Default`` toolchain that you just created
+- Set your generator to be ``Ninja``
+- Set your cmake options to be ``--preset=linux`` or ``--preset=win-ninja``
+- Set the build directory to the ``build`` directory if it is not the default (you'll need to use the full path if its outside the source directory)
+- The configurations drop-down at the top should show all of the build targets. If not, the CMake project is probably not loaded. Open the root ``CMakeLists.txt`` file in a tab and there should be a ``Load CMake Project`` option at the top right. Click it and the configurations should be populated
 
 Building with CLion
 ###################
 
-- To build all targets, navigate to `Build > Build All in 'Debug'`. Check that the build command displayed in the Messages window is running the correct cmake executable from your conda installation.
+- To build all targets, navigate to ``Build > Build All in 'Debug'``. Check that the build command displayed in the Messages window is running the correct cmake executable from your conda installation.
 - To build a specific target, select it in the configurations drop-down menu and click the hammar icon next to it.
 
 If this fails, you may need to open CLion from a terminal with your conda environment activated:
 
-- Open a terminal and run `conda activate mantid-developer`
-- Launch CLion through that terminal with `<CLION_INSTALL>/bin/clion.sh` for Linux or `<CLION_INSTALL>/bin/clion.bat` for Windows
+- Open a terminal and run ``conda activate mantid-developer``
+- Launch CLion through that terminal with ``<CLION_INSTALL>/bin/clion.sh`` for Linux or ``<CLION_INSTALL>/bin/clion.bat`` for Windows
 
 It is also useful to have your terminals in CLion to run with this environment:
 
-- In your `home` directory create a file named `.clionrc` and open in your favourite text editor, adding these lines:
+- In your ``home`` directory create a file named ``.clionrc`` and open in your favourite text editor, adding these lines:
 
   ```
   source ~/.bashrc
@@ -61,10 +61,17 @@ It is also useful to have your terminals in CLion to run with this environment:
   ```
 
 - Start CLion using the above steps
-- Navigate to `File > Settings > Tools > Terminal`
-- To the end of the `Shell path` option, add `--rcfile ~/.clionrc`
+- Navigate to ``File > Settings > Tools > Terminal``
+- To the end of the ``Shell path`` option, add ``--rcfile ~/.clionrc``
 
 Debugging with CLion
 ####################
 
+To debug workbench, you'll need to edit the ``workbench`` CMake Application configuration.
+
+- Set the executable to be the ``python.exe`` in your conda installation, e.g. ``/path/to/mambaforge/envs/mantid-developer/bin/python.exe``
+- Set the program arguments to be ``workbench --single-process`` on Linux, or ``workbench-script.pyw --single-process`` on Windows
+- Set the working directory to be the full path to your ``build/bin`` directory
+
+You should now be able to set breakpoints and start debugging by clicking the bug icon.
 

--- a/dev-docs/source/CLion.rst
+++ b/dev-docs/source/CLion.rst
@@ -25,20 +25,29 @@ To set up your toolchain:
 
 - Navigate to ``File > Settings > Build, Execution, Deployment > Toolchains``
 - Create a new ``System`` toolchain using the ``+`` icon and call it ``Default``
-- Edit the CMake field to point to your conda installed ``cmake``, e.g. ``/path/to/mambaforge/envs/mantid-developer/bin/cmake``
-- Edit the Build Tool field to point to your conda installed ``ninja``, e.g. ``/path/to/mambaforge/envs/mantid-developer/bin/ninja``
-- On Linux, ``Let CMake detect`` the C Compiler and C++ Compiler.
-- On Windows, the C Compiler and C++ Compiler should be directed at the same ``cl.exe`` in your Visual Studio installation, e.g. ``C:/Program Files (x86)/Microsoft Visual Studio/2019/Community/VC/Tools/MSVC/14.29.30133/bin/Hostx64/x64/cl.exe``
+- Edit the CMake field to point to your conda installed ``cmake``, e.g.
+   - On Linux: ``/path/to/mambaforge/envs/mantid-developer/bin/cmake``
+   - On Windows: ``/path/to/mambaforge/envs/mantid-developer/Library/bin/cmake.exe``
+- Edit the Build Tool field to point to your conda installed ``ninja``, e.g.
+   - On Linux: ``/path/to/mambaforge/envs/mantid-developer/bin/ninja``
+   - On Windows: ``/path/to/mambaforge/envs/mantid-developer/Library/bin/ninja.exe``
+- For the C Compiler and C++ Compiler fields,
+   - On Linux: choose ``Let CMake detect``
+   - On Windows: direct them both at the same ``cl.exe`` in your Visual Studio installation, e.g. ``C:/Program Files (x86)/Microsoft Visual Studio/2019/Community/VC/Tools/MSVC/14.29.30133/bin/Hostx64/x64/cl.exe``
 
 To set up CMake:
 
 - Navigate to ``File > Settings > Build, Execution, Deployment > CMake``
-- On Linux, set your Build type to be ``Debug``. On Windows, set your build type to be ``DebugWithRelRuntime``
+- Edit the Build type field by either selecting an option, or typing in a string,
+   - On Linux: ``Debug``
+   - On Windows: ``DebugWithRelRuntime``
 - Set your Toolchain to be the ``Default`` toolchain that you just created
 - Set your generator to be ``Ninja``
-- Set your cmake options to be ``--preset=linux`` or ``--preset=win-ninja``
+- Edit your cmake options to be,
+   - On Linux: ``--preset=linux``
+   - On Windows: ``--preset=win-ninja``
 - Set the build directory to the ``build`` directory if it is not the default (you'll need to use the full path if its outside the source directory)
-- The configurations drop-down at the top should show all of the build targets. If not, the CMake project is probably not loaded. Open the root ``CMakeLists.txt`` file in a tab and there should be a ``Load CMake Project`` option at the top right. Click it and the configurations should be populated
+- The configurations drop-down at the top should show all of the build targets. If not, the CMake project is probably not loaded. Go to ``File > Reload CMake Project``. The configurations should be populated
 
 Building with CLion
 ###################

--- a/dev-docs/source/CLion.rst
+++ b/dev-docs/source/CLion.rst
@@ -38,13 +38,31 @@ To set up CMake:
 - Set your generator to be `Ninja`
 - Set your cmake options to be `--preset=linux` or `--preset=win-ninja`
 - Set the build directory to the `build` directory if it is not the default (you'll need to use the full path if its outside the source directory)
-- The configurations drop-down at the top should show all of the build targets. If not, the CMake project is probably not loaded. Open the root `CMakeLists.txt` file in a tab and there should be a `Load CMake Project` option at the top right. Click it and the configurations should be populated.
+- The configurations drop-down at the top should show all of the build targets. If not, the CMake project is probably not loaded. Open the root `CMakeLists.txt` file in a tab and there should be a `Load CMake Project` option at the top right. Click it and the configurations should be populated
 
 Building with CLion
 ###################
 
 - To build all targets, navigate to `Build > Build All in 'Debug'`. Check that the build command displayed in the Messages window is running the correct cmake executable from your conda installation.
 - To build a specific target, select it in the configurations drop-down menu and click the hammar icon next to it.
+
+If this fails, you may need to open CLion from a terminal with your conda environment activated:
+
+- Open a terminal and run `conda activate mantid-developer`
+- Launch CLion through that terminal with `<CLION_INSTALL>/bin/clion.sh` for Linux or `<CLION_INSTALL>/bin/clion.bat` for Windows
+
+It is also useful to have your terminals in CLion to run with this environment:
+
+- In your `home` directory create a file named `.clionrc` and open in your favourite text editor, adding these lines:
+
+  ```
+  source ~/.bashrc
+  source ~/mambaforge/bin/activate mantid-developer
+  ```
+
+- Start CLion using the above steps
+- Navigate to `File > Settings > Tools > Terminal`
+- To the end of the `Shell path` option, add `--rcfile ~/.clionrc`
 
 Debugging with CLion
 ####################

--- a/dev-docs/source/CLion.rst
+++ b/dev-docs/source/CLion.rst
@@ -19,7 +19,7 @@ If you haven't installed CLion yet do that now, CLion can be installed from `her
 Opening CLion
 #############
 
-The first time you build from CLion, you will most likely need to launch it from a terminal or command line to make sure you have access to all the relevent tools.
+The first time you build from CLion, you will most likely need to launch it from a terminal or command line to make sure you have access to all the relevant tools.
 
 * On Linux,
 
@@ -97,7 +97,7 @@ Building with CLion
 ###################
 
 - To build all targets, navigate to ``Build > Build All in 'Debug'``. Check that the build command displayed in the Messages window is running the correct cmake executable from your conda installation.
-- To build a specific target, select it in the configurations drop-down menu and click the hammar icon next to it.
+- To build a specific target, select it in the configurations drop-down menu and click the hammer icon next to it.
 
 If this fails, you may need to open CLion from a terminal with your conda environment activated.
 

--- a/dev-docs/source/GettingStarted/GettingStartedCondaLinux.rst
+++ b/dev-docs/source/GettingStarted/GettingStartedCondaLinux.rst
@@ -55,33 +55,7 @@ How to build
 
 Building and debugging with CLion
 ---------------------------------
-CLion will fail to find the build targets if the conda environment is not enabled:
-
-* Navigate to ``File > Settings > Build,Execution,Deployment > Toolchains``
-* Edit the CMake and Build Tool settings to point to your conda installed ``cmake`` and ``ninja`` respectively, e.g. ``/home/<user>/mambaforge/envs/mantid-developer/bin/cmake``
-* Navigate to ``File > Settings > Build,Execution,Deployment > CMake`` and change the generator to ``Ninja`` and the CMake options to ``--preset=linux``. Change the build directory to ``build`` (or your own build directory if not the default; you'll need to use the full path if outside the source directory).
-* The configurations drop-down at the top should show all of the build targets. If not, the CMake project is probably not loaded; open the root ``CMakeLists.txt`` file in a tab and there should be a ``Load CMake Project`` option at the top right. Click it and the configurations should be populated.
-* To test a build, navigate to ``Build > Build All in 'Debug'``. Check that the build command displayed in the Messages window is running the correct cmake executable from your conda installation.
-* Note that you can build a specific target by selecting it in the configurations drop-down menu and clicking the hammer icon next to it.
-* To debug workbench, you'll need to edit the ``workbench`` CMake Application configuration. Set the executable to ``python`` in your conda installation, and program arguments to ``workbench --single-process``. Set the working directory to the full path to your ``build/bin`` directory
-
-If this fails you may need to open CLion from a terminal with conda activated, although I have not found this necessary:
-
-* Open a terminal and run ``conda activate mantid-developer``
-* Launch CLion through that terminal (``<CLION_INSTALL>/bin/clion.sh``)
-
-It is also useful to have your terminals in CLion also run with this environment:
-
-* In your ``home`` directory create a file named ``.clionrc`` and open in your favourite text editor, adding these lines:
-
-.. code-block:: text
-
-    source ~/.bashrc
-    source ~/mambaforge/bin/activate mantid-developer
-
-* Start CLion using the above steps
-* Navigate to ``File > Settings > Tools > Terminal``.
-* To the end of the ``Shell path`` option, add: ``--rcfile ~/.clionrc``.
+Please follow the Linux related instructions on :ref:`this page <clion-ref>`.
 
 CMake Conda variables
 -----------------------

--- a/dev-docs/source/GettingStarted/GettingStartedCondaWindows.rst
+++ b/dev-docs/source/GettingStarted/GettingStartedCondaWindows.rst
@@ -82,6 +82,10 @@ Compile and Build using Ninja
 * To build Mantid Workbench use: ``ninja``
 * To build the unit tests use: ``ninja AllTests``
 
+Building and debugging with CLion
+---------------------------------
+Please follow the Windows related instructions on :ref:`this page <clion-ref>`.
+
 CMake Conda variables
 ---------------------
 There are two Conda specific CMake options `CONDA_ENV` and `CONDA_BUILD`. The former should be used whenever you are building within a Conda environment, as it ensures our finders (e.g FindNexus.cmake) look in the correct locations for libraries.

--- a/dev-docs/source/index.rst
+++ b/dev-docs/source/index.rst
@@ -118,6 +118,7 @@ Tools
    FlowchartCreation
    VisualStudioBuildImpact
    PyCharm
+   CLion
    VSCode
    Eclipse
    WindowsSubsystemForLinux
@@ -137,6 +138,9 @@ Tools
 
 :doc:`PyCharm`
    Describes how to set up the PyCharm interpreter, and debug python code (Windows/Linux only).
+
+:doc:`CLion`
+   Describes how to set up CLion to build and debug using a Ninja generator (Windows/Linux only).
 
 :doc:`VSCode`
    Guide to using VSCode for C++ with Mantid.


### PR DESCRIPTION
**Description of work.**
This PR adds a new developer documentation page for setting up CLion on Linux and Windows. It moves previously existing Linux documentation to this page, and expands on the instructions to help set it up on a Windows environment.

**To test:**
Build the dev docs target and make sure the links on the documentation work.

Read through the documentation and try set up CLion on windows to make sure it makes sense

Part of #34490 

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
