### PR TITLE
Use more appropriate test value and add new test

### DIFF
--- a/Framework/DataHandling/test/SaveSESANSTest.h
+++ b/Framework/DataHandling/test/SaveSESANSTest.h
@@ -86,7 +86,7 @@ public:
     auto ws = createTestWorkspace();
 
     setCommonAlgorithmProperties(ws);
-    const double thickness = 10;
+    const double thickness = 20;
     testAlg.setProperty("OverrideSampleThickness", thickness);
 
     // Execute the algorithm
@@ -115,6 +115,20 @@ public:
 
     // Execute the algorithm
     TS_ASSERT_THROWS(testAlg.execute(), const std::runtime_error &);
+  }
+
+  void test_exec_thickness_property_plus_sample_thickness_uses_property_value() {
+    auto ws = createTestWorkspace();
+    ws->mutableSample().setThickness(5);
+
+    setCommonAlgorithmProperties(ws);
+    const double thickness = 20;
+    testAlg.setProperty("OverrideSampleThickness", thickness);
+
+    // Execute the algorithm
+    TS_ASSERT_THROWS_NOTHING(testAlg.execute());
+
+    checkOutput(thickness);
   }
 
 private:


### PR DESCRIPTION
**Description of work.**

Changes the thickness value in the SaveSESANS unit tests to avoid using 10mm, which doesn't check effectively that the depolarisation output has been divided by the sample thickness (see comment on PR #34491).

This PR also adds another test to check for the case where there is both a sample thickness set for the workspace plus a value passed in as a parameter. The test confirms that the parameter value will be used.

**To test:**

All tests should pass

*There is no associated issue.*

*This does not require release notes* because the change is only to unit tests and is covered by release notes on PR #34491.

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
