### PR TITLE
fixed #33224 changing the plot title in figure will change window title

### DIFF
--- a/docs/source/release/v6.6.0/Workbench/Bugfixes/33224.rst
+++ b/docs/source/release/v6.6.0/Workbench/Bugfixes/33224.rst
@@ -1,0 +1,1 @@
+- Plot window title will now track the title of the plot.

--- a/qt/applications/workbench/workbench/plotting/figureinteraction.py
+++ b/qt/applications/workbench/workbench/plotting/figureinteraction.py
@@ -35,7 +35,7 @@ from mantidqt.plotting.figuretype import FigureType, figure_type
 from mantidqt.plotting.markers import SingleMarker
 from mantidqt.widgets.plotconfigdialog.curvestabwidget import curve_has_errors, CurveProperties
 from workbench.plotting.figureerrorsmanager import FigureErrorsManager
-from workbench.plotting.propertiesdialog import (LabelEditor, XAxisEditor, YAxisEditor,
+from workbench.plotting.propertiesdialog import (LabelEditor, TitleLabelEditor, XAxisEditor, YAxisEditor,
                                                  SingleMarkerEditor, GlobalMarkerEditor,
                                                  ColorbarAxisEditor, ZAxisEditor, LegendEditor)
 from workbench.plotting.style import VALID_LINE_STYLE, VALID_COLORS
@@ -249,7 +249,7 @@ class FigureInteraction(object):
 
         for ax in axes:
             if ax.title.contains(event)[0]:
-                move_and_show(LabelEditor(canvas, ax.title))
+                move_and_show(TitleLabelEditor(canvas, ax.title))
             elif ax.xaxis.label.contains(event)[0]:
                 move_and_show(LabelEditor(canvas, ax.xaxis.label))
             elif ax.yaxis.label.contains(event)[0]:

--- a/qt/applications/workbench/workbench/plotting/propertiesdialog.py
+++ b/qt/applications/workbench/workbench/plotting/propertiesdialog.py
@@ -97,6 +97,17 @@ class LabelEditor(PropertiesEditorBase):
         self.ui.errors.show()
 
 
+class TitleLabelEditor(LabelEditor):
+    """Provides a dialog box to edit title of a figure that will change the window title"""
+
+    def __init__(self, canvas, target):
+        super().__init__(canvas, target)
+
+    def changes_accepted(self):
+        super().changes_accepted()
+        self.canvas.manager.set_window_title(self.ui.editor.text())
+
+
 class LegendEditorModel(object):
 
     def __init__(self, label_text):

--- a/qt/python/mantidqt/mantidqt/widgets/plotconfigdialog/axestabwidget/presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/plotconfigdialog/axestabwidget/presenter.py
@@ -56,6 +56,7 @@ class AxesTabWidgetPresenter:
         self.axis_changed()
         ax = self.get_selected_ax()
         self.set_ax_title(ax, self.current_view_props['title'])
+        ax.figure.canvas.manager.set_window_title(self.current_view_props['title'])
         self._apply_properties_to_axes(ax)
         self.update_view()
 


### PR DESCRIPTION
**Description of work.**
Fixes #33224. When a user renames the title of a plot, the window title will update to match that title.

! not sure if we should implement this as sometimes it is not sensible for plot title and windows title to be in sync such as plotting in grid style

**To test:**
Rename by clicking title
- Load a workspace and plot a spectrum.
- double click title to bring up the label editor
- change the title
- verify that the title of the plot is updated, in sync with window title and title in plot manager

Rename by axes tab widget
- Load a workspace and plot a spectrum.
- Open the figure options.
- change the title in the textbox
- apply the change
- verify that the title of the plot is updated, in sync with window title and title in plot manager

Fixes #33224.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
