### PR TITLE
fixed #34451 file without py extension

### DIFF
--- a/docs/source/release/v6.6.0/Workbench/Bugfixes/34451.rst
+++ b/docs/source/release/v6.6.0/Workbench/Bugfixes/34451.rst
@@ -1,0 +1,1 @@
+- Saving script from history dialog in Linux will be saved with :code:`.py` extension

--- a/qt/widgets/common/src/AlgorithmHistoryWindow.cpp
+++ b/qt/widgets/common/src/AlgorithmHistoryWindow.cpp
@@ -414,6 +414,11 @@ void AlgorithmHistoryWindow::writeToScriptFile() {
   if (filePath.isEmpty())
     return;
 
+  // fix for 34451 in Linux, unlike native filedialog, QFileDialog will not add file extension by type
+  // This only occur in Linux as in Win and Mac QFileDialog calls the native filedialog
+  if (!filePath.endsWith(".py"))
+    filePath += ".py";
+
   ScriptBuilder builder(m_view, getScriptVersionMode());
   std::ofstream file(filePath.toStdString().c_str(), std::ofstream::trunc);
   file << builder.build();


### PR DESCRIPTION
**Description of work.**
Appended the file name getter for the `Show History dialog > Script to File` file dialog to add a `.py` extension if it is not supplied by user.

**To test:**
Only for Linux
- Open MantidWorkbench and run CreateSampleWorkspace
- Right-click on the workspace and select Show History
- click Script to File, then type in a filename without `.py` and then click Save.
- The file is saved with the `.py` extension.

For Windows and Mac
- Open MantidWorkbench and run CreateSampleWorkspace
- Right-click on the workspace and select Show History
- click Script to File, then type in a filename with `.py` and then click Save.
- The file is saved correctly with no duplicate `.py` extension


Fixes #34451.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
