### PR TITLE
Mean algorithm input workspace validation

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/Mean.py
+++ b/Framework/PythonInterface/plugins/algorithms/Mean.py
@@ -63,9 +63,9 @@ class Mean(PythonAlgorithm):
         return issues
 
     def _are_workspaces_compatible(self, ws_a, ws_b):
-        sizeA = ws_a.blocksize() * ws_a.getNumberHistograms()
-        sizeB = ws_b.blocksize() * ws_b.getNumberHistograms()
-        return sizeA == sizeB
+        match_bins = ws_a.blocksize() == ws_b.blocksize()
+        match_histograms = ws_a.getNumberHistograms() == ws_b.getNumberHistograms()
+        return match_bins and match_histograms
 
     def PyExec(self):
         workspaces = self.getProperty("Workspaces").value.split(',')

--- a/Framework/PythonInterface/plugins/algorithms/Mean.py
+++ b/Framework/PythonInterface/plugins/algorithms/Mean.py
@@ -40,23 +40,18 @@ class Mean(PythonAlgorithm):
         issues = dict()
         workspaces = self.getProperty("Workspaces").value.split(',')
         name = workspaces[0].strip()
-        ws1 = None
-        if name in mtd:
-            ws1 = mtd[name]
-        else:
+        if name not in mtd:
             issues["Workspaces"] = f"Workspace '{name}' does not exist"
             return issues
-
+        ws1 = mtd[name]
         nSpectra = ws1.getNumberHistograms()
 
         for index in range(1, len(workspaces)):
             name = workspaces[index].strip()
-            ws2 = None
-            if name in mtd:
-                ws2 = mtd[name]
-            else:
+            if name not in mtd:
                 issues["Workspaces"] = f"Workspace '{name}' does not exist"
                 return issues
+            ws2 = mtd[name]
 
             if not self._are_workspaces_compatible(ws1, ws2):
                 issues["Workspaces"] = "Input Workspaces are not the same shape."

--- a/Framework/PythonInterface/plugins/algorithms/Mean.py
+++ b/Framework/PythonInterface/plugins/algorithms/Mean.py
@@ -40,14 +40,26 @@ class Mean(PythonAlgorithm):
         issues = dict()
         workspaces = self.getProperty("Workspaces").value.split(',')
         name = workspaces[0].strip()
-        ws1 = mtd[name]
+        ws1 = None
+        if name in mtd:
+            ws1 = mtd[name]
+        else:
+            issues["Workspaces"] = f"Workspace '{name}' does not exist"
+            return issues
+
         nSpectra = ws1.getNumberHistograms()
 
         for index in range(1, len(workspaces)):
             name = workspaces[index].strip()
-            ws2 = mtd[name]
+            ws2 = None
+            if name in mtd:
+                ws2 = mtd[name]
+            else:
+                issues["Workspaces"] = f"Workspace '{name}' does not exist"
+                return issues
+
             if not self._are_workspaces_compatible(ws1, ws2):
-                issues["workspaces"]="Input Workspaces are not the same shape."
+                issues["Workspaces"] = "Input Workspaces are not the same shape."
                 # cannot run the next test if this fails
                 return issues
             for spectra in range(0,nSpectra):

--- a/Framework/PythonInterface/test/python/plugins/algorithms/MeanTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/MeanTest.py
@@ -13,53 +13,37 @@ class MeanTest(unittest.TestCase):
 
     def test_throws_if_non_existing_names(self):
         a = CreateWorkspace(DataX=[1,2,3],DataY=[1,2,3],DataE=[1,1,1],UnitX='TOF')
-        try:
-            c = Mean(Workspaces='a,b') # 'b' does not exist.
-        except RuntimeError:
-            pass
-        else:
-            self.fail("Should not have got here. Should throw without both workspace names indexing real workspaces in IDF.")
-        finally:
-            DeleteWorkspace(a)
+        with self.assertRaises(RuntimeError) as contextManager:
+            c = Mean(Workspaces='a,b')  # 'b' does not exist.
+        self.assertIn("Workspace 'b' does not exist", str(contextManager.exception))
+        DeleteWorkspace(a)
 
     def test_throws_if_workspace_axis0_unequal(self):
         a = CreateWorkspace(DataX=[1,2,3],DataY=[1,2,3],DataE=[1,1,1],UnitX='TOF')
         b = CreateWorkspace(DataX=[1,2,3,4],DataY=[1,2,3,4],DataE=[1,1,1,1],UnitX='TOF')
-        try:
-            c = Mean(Workspaces='a,b') # 'a' and 'b' are different sizes.
-        except RuntimeError:
-            pass
-        else:
-            self.fail("Should not have got here. Should throw as axis0 is unequal in size between a and b.")
-        finally:
-            DeleteWorkspace(a)
-            DeleteWorkspace(b)
+        with self.assertRaises(RuntimeError) as contextManager:
+            c = Mean(Workspaces='a,b')  # 'a' and 'b' are different sizes.
+        self.assertIn("Input Workspaces are not the same shape.", str(contextManager.exception))
+        DeleteWorkspace(a)
+        DeleteWorkspace(b)
 
     def test_throws_if_workspace_axis1_unequal(self):
         a = CreateWorkspace(DataX=[1,2,3,4],DataY=[1,2,3,4],DataE=[1,1,1,1],UnitX='TOF',NSpec=1)
         b = CreateWorkspace(DataX=[1,2,3,4],DataY=[1,2,3,4],DataE=[1,1,1,1],UnitX='TOF',NSpec=2)
-        try:
-            c = Mean(Workspaces='a,b') # 'a' and 'b' are different sizes.
-        except RuntimeError:
-            pass
-        else:
-            self.fail("Should not have got here. Should throw as axis1 is unequal in size between a and b.")
-        finally:
-            DeleteWorkspace(a)
-            DeleteWorkspace(b)
+        with self.assertRaises(RuntimeError) as contextManager:
+            c = Mean(Workspaces='a,b')  # 'a' and 'b' are different sizes.
+        self.assertIn("Input Workspaces are not the same shape.", str(contextManager.exception))
+        DeleteWorkspace(a)
+        DeleteWorkspace(b)
 
     def test_throws_if_workspace_unorded(self):
         a = CreateWorkspace(DataX=[1,2,1,2],DataY=[1,2,3,4],DataE=[1,1,1,1],UnitX='TOF',NSpec=2)
         b = CreateWorkspace(DataX=[1,2,2,1],DataY=[1,2,3,4],DataE=[1,1,1,1],UnitX='TOF',NSpec=2)
-        try:
-            c = Mean(Workspaces='a,b') # 'a' and 'b' have different x data.
-        except RuntimeError:
-            pass
-        else:
-            self.fail("Should not have got here. Should throw as the x data is unsorted")
-        finally:
-            DeleteWorkspace(a)
-            DeleteWorkspace(b)
+        with self.assertRaises(RuntimeError) as contextManager:
+            c = Mean(Workspaces='a,b')  # 'a' and 'b' have different x data.
+        self.assertIn("The data should have the same order for x values. Sort your data first", str(contextManager.exception))
+        DeleteWorkspace(a)
+        DeleteWorkspace(b)
 
     def test_mean(self):
         a = CreateWorkspace(DataX=[1,2,3],DataY=[1,2,3],DataE=[1,1,1],UnitX='TOF')

--- a/docs/source/release/v6.6.0/Workbench/Bugfixes/34545.rst
+++ b/docs/source/release/v6.6.0/Workbench/Bugfixes/34545.rst
@@ -1,0 +1,1 @@
+- Fixed bug in the Mean algorithm where an invalid input workspace name would cause Mantid to crash.


### PR DESCRIPTION
**Description of work.**

- Added a check to see if the input workspaces exist before trying to access them. If any don't exist then a relevant issue is returned.
- Updated the tests to check exceptions more explictly
- The updated tests uncovered a problem with `_are_workspaces_compatible()` so that has been changed too

**To test:**

- Follow steps to reproduce #34545 and check that an error reporting an invalid workspace name is shown rather than a crash
- Follow steps to reproduce #34476 and check that the Mean algorithm can be opened with the correct defaults rather than a crash
- Follow steps to reproduce #34554 and check that an error reporting mismatching workspace sizes is shown rather than a crash

Fixes #34545 #34476 #34554

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
