### PR TITLE
Remove maximum page width for user/dev docs

### DIFF
--- a/dev-docs/source/conf.py
+++ b/dev-docs/source/conf.py
@@ -9,7 +9,6 @@ from sphinx import __version__ as sphinx_version
 import sphinx_bootstrap_theme
 from distutils.version import LooseVersion
 
-
 # -- General configuration ------------------------------------------------
 if LooseVersion(sphinx_version) > LooseVersion("1.6"):
 
@@ -20,6 +19,7 @@ if LooseVersion(sphinx_version) > LooseVersion("1.6"):
             app.add_css_file("custom.css")
         else:
             app.add_stylesheet("custom.css")  # v1.6-1.8
+
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
@@ -64,7 +64,7 @@ pygments_style = 'sphinx'
 # -- Options for pngmath --------------------------------------------------
 
 # Load the preview package into latex
-pngmath_latex_preamble=r'\usepackage[active]{preview}'
+pngmath_latex_preamble = r'\usepackage[active]{preview}'
 
 # Ensures that the vertical alignment of equations is correct.
 # See http://sphinx-doc.org/ext/math.html#confval-pngmath_use_preview
@@ -115,7 +115,7 @@ html_show_copyright = False
 # custom.css rather than here.
 html_theme_options = {
     # Navigation bar title.
-    'navbar_title': " ", # deliberate single space so it's not visible
+    'navbar_title': " ",  # deliberate single space so it's not visible
     # Tab name for entire site.
     'navbar_site_name': "Mantid",
     # Add links to the nav bar. Third param of tuple is true to create absolute url.
@@ -136,6 +136,8 @@ html_theme_options = {
     'bootstrap_version': "3",
     # Ensure the nav bar always stays on top of page.
     'navbar_fixed_top': "false",
+    # Don't limit the width
+    'body_max_width': "none"
 }
 
 # -- Options for Epub output ---------------------------------------------------
@@ -161,7 +163,7 @@ epub_identifier = "www.mantidproject.org"
 #The publication scheme for the epub_identifier. This is put in the Dublin Core metadata.
 #For published books the scheme is 'ISBN'. If you use the project homepage, 'URL' seems reasonable.
 #The default value is 'unknown'.
-epub_scheme='URL'
+epub_scheme = 'URL'
 
 #A unique identifier for the document. This is put in the Dublin Core metadata. You may use a random string.
 #The default value is 'unknown'.

--- a/docs/source/conf-html.py
+++ b/docs/source/conf-html.py
@@ -38,6 +38,8 @@ html_theme_options = {
     'bootstrap_version': "3",
     # Ensure the nav bar always stays on top of page.
     'navbar_fixed_top': "false",
+    # Don't limit the width
+    'body_max_width': "none"
 }
 
 # -- Fix up angstrom symbol for mathjax


### PR DESCRIPTION
**Description of work.**

Jumping from Sphinx 1.6 -> Sphinx 5 caused
the default content width to be fixed in the
basic.css of Sphinx (it was introduced [here](https://github.com/sphinx-doc/sphinx/commit/bf29ffb284f74b99adbc64d12b58ef4cef123af6). This is too restrictive
so we allow the full container width to be
used.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**

* Build the HTML docs (docs-html) and open in a browser.
* See that the text still uses the same width as the docs online

*This does not require release notes* because **it is an internal change**

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
