### PR TITLE
Fix for bad validation in AddSampleLogMultiple

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/AddSampleLogMultiple.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/AddSampleLogMultiple.py
@@ -108,7 +108,7 @@ class AddSampleLogMultiple(PythonAlgorithm):
             issues['LogUnits'] = 'Number of log units must be 0 or match the number of log names'
 
         if self.getProperty('ParseType').value and num_types != 0:
-            issue['LogTypes'] = 'LogTypes array not used when ParseType=True'
+            issues['LogTypes'] = 'LogTypes array not used when ParseType=True'
 
         if num_names > 0 and num_types != 0 and num_types != num_names:
             issues['LogTypes'] = 'Number of log types must be 0 or match the number of log names'

--- a/docs/source/release/v6.6.0/Workbench/Bugfixes/34553.rst
+++ b/docs/source/release/v6.6.0/Workbench/Bugfixes/34553.rst
@@ -1,0 +1,1 @@
+- Fixed bug with AddSampleLogMultiple where including log types and keeping the parser box ticked would crash Mantid.


### PR DESCRIPTION
**Description of work.**

Fixed a typo in `AddSampleLogMultiple` which caused a crash when reporting an issue where the parse type box was ticked and log types were supplied.

**To test:**

 - Follow example in #34553 and check that an error about not requiring types when parse type is checked is returned.
 - Uncheck parse type, enter incorrect type names, and check that an appropriate error is returned.

Fixes #34553

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
