### PR TITLE
Fix DllConfig.h error in nightly conda builds

### DIFF
--- a/Framework/DataObjects/CMakeLists.txt
+++ b/Framework/DataObjects/CMakeLists.txt
@@ -254,7 +254,7 @@ generate_mantid_export_header(DataObjects FALSE)
 # Installation settings
 if(CONDA_ENV)
   set(TARGET_EXPORT_NAME "MantidDataObjectsTargets")
-  mtd_install_framework_lib(TARGETS DataObjects EXPORT_NAME ${TARGET_EXPORT_NAME})
+  mtd_install_framework_lib(TARGETS DataObjects INSTALL_EXPORT_FILE EXPORT_NAME ${TARGET_EXPORT_NAME})
 else()
   mtd_install_targets(TARGETS DataObjects INSTALL_DIRS ${LIB_DIR} ${WORKBENCH_LIB_DIR})
 endif()

--- a/Framework/Geometry/CMakeLists.txt
+++ b/Framework/Geometry/CMakeLists.txt
@@ -504,7 +504,7 @@ generate_mantid_export_header(Geometry TRUE)
 # Installation settings
 if(CONDA_ENV)
   set(TARGET_EXPORT_NAME "MantidGeometryTargets")
-  mtd_install_framework_lib(TARGETS Geometry EXPORT_NAME ${TARGET_EXPORT_NAME})
+  mtd_install_framework_lib(TARGETS Geometry INSTALL_EXPORT_FILE EXPORT_NAME ${TARGET_EXPORT_NAME})
 else()
   mtd_install_targets(TARGETS Geometry INSTALL_DIRS ${LIB_DIR} ${WORKBENCH_LIB_DIR})
 endif()

--- a/Framework/Kernel/CMakeLists.txt
+++ b/Framework/Kernel/CMakeLists.txt
@@ -663,7 +663,7 @@ mtd_install_files(
 # Installation settings
 if(CONDA_ENV)
   set(TARGET_EXPORT_NAME "MantidKernelTargets")
-  mtd_install_framework_lib(TARGETS Kernel EXPORT_NAME ${TARGET_EXPORT_NAME})
+  mtd_install_framework_lib(TARGETS Kernel INSTALL_EXPORT_FILE EXPORT_NAME ${TARGET_EXPORT_NAME})
 else()
   mtd_install_targets(TARGETS Kernel INSTALL_DIRS ${LIB_DIR} ${WORKBENCH_LIB_DIR})
 endif()

--- a/Framework/Nexus/CMakeLists.txt
+++ b/Framework/Nexus/CMakeLists.txt
@@ -47,7 +47,7 @@ generate_mantid_export_header(Nexus TRUE)
 # Installation settings
 if(CONDA_ENV)
   set(TARGET_EXPORT_NAME "MantidNexusTargets")
-  mtd_install_framework_lib(TARGETS Nexus EXPORT_NAME ${TARGET_EXPORT_NAME})
+  mtd_install_framework_lib(TARGETS Nexus INSTALL_EXPORT_FILE EXPORT_NAME ${TARGET_EXPORT_NAME})
 else()
   mtd_install_targets(TARGETS Nexus INSTALL_DIRS ${LIB_DIR} ${WORKBENCH_LIB_DIR})
 endif()

--- a/Framework/Parallel/CMakeLists.txt
+++ b/Framework/Parallel/CMakeLists.txt
@@ -134,7 +134,7 @@ generate_mantid_export_header(Parallel FALSE)
 # Installation settings
 if(CONDA_ENV)
   set(TARGET_EXPORT_NAME "MantidParallelTargets")
-  mtd_install_framework_lib(TARGETS Parallel EXPORT_NAME ${TARGET_EXPORT_NAME})
+  mtd_install_framework_lib(TARGETS Parallel INSTALL_EXPORT_FILE EXPORT_NAME ${TARGET_EXPORT_NAME})
 else()
   mtd_install_targets(TARGETS Parallel INSTALL_DIRS ${LIB_DIR} ${WORKBENCH_LIB_DIR})
 endif()


### PR DESCRIPTION
**Description of work.**

The nightly build job is falling over with a `MantidKernel/DllConfig.h: No such file or directory` error while trying to do the conda package builds (separate Framework\Qt packages). The main build of the entire code base is fine.

Eg see https://builds.mantidproject.org/view/Nightly%20Pipelines/job/main_nightly_deployment_prototype/427/execution/node/109/log/?consoleFull

Caused by recent work on cmake export header feature in #34482 and #34497

Fix is to add missing INSTALL_EXPORT_FILE keyword to cmake install instructions for Conda builds on targets that aren't PLUGIN_LIB. This causes the automatically generated DllConfig.h file (that lives in the build directory) to be installed

**To test:**

Will run a build package on branch job to test:
https://builds.mantidproject.org/job/build_packages_from_branch/95/

*There is no associated issue.*

*This does not require release notes* because **it's a technical change to the builds only**

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
