### PR TITLE
Prevent crash on ALFView when extracting single tube

### DIFF
--- a/docs/source/release/v6.6.0/Direct_Geometry/General/Bugfixes/34564.rst
+++ b/docs/source/release/v6.6.0/Direct_Geometry/General/Bugfixes/34564.rst
@@ -1,1 +1,1 @@
-A crash is now avoided when extracting a tube while an invalid axis is selected.
+A crash is now avoided when extracting a tube in ALFView while an invalid axis is selected.

--- a/docs/source/release/v6.6.0/Direct_Geometry/General/Bugfixes/34564.rst
+++ b/docs/source/release/v6.6.0/Direct_Geometry/General/Bugfixes/34564.rst
@@ -1,0 +1,1 @@
+A crash is now avoided when extracting a tube while an invalid axis is selected.

--- a/qt/scientific_interfaces/Direct/ALFCustomInstrumentMocks.h
+++ b/qt/scientific_interfaces/Direct/ALFCustomInstrumentMocks.h
@@ -36,7 +36,8 @@ using namespace MantidQt::MantidWidgets;
 
 class mockALFData {
 public:
-  mockALFData(const std::string &name, const std::string &instName, const int &run, const bool TOF) : m_name(name) {
+  mockALFData(const std::string &name, const std::string &instName, const int &run, const std::string &unit)
+      : m_name(name) {
     auto ws = WorkspaceCreationHelper::create2DWorkspaceWithValuesAndXerror(1, 10, false, 0.1, 0.2, 0.01, 0.3);
     // set instrument
     std::shared_ptr<Instrument> inst = std::make_shared<Instrument>();
@@ -46,11 +47,7 @@ public:
     // set units
     ws->setInstrument(inst);
     auto axis = ws->getAxis(0);
-    if (TOF) {
-      axis->setUnit("TOF");
-    } else {
-      axis->setUnit("dSpacing");
-    }
+    axis->setUnit(unit);
     AnalysisDataService::Instance().addOrReplace(m_name, ws);
   }
   ~mockALFData() { AnalysisDataService::Instance().remove(m_name); }

--- a/qt/scientific_interfaces/Direct/ALFCustomInstrumentModel.h
+++ b/qt/scientific_interfaces/Direct/ALFCustomInstrumentModel.h
@@ -9,10 +9,12 @@
 #include "DllConfig.h"
 #include "MantidAPI/CompositeFunction.h"
 #include "MantidAPI/FunctionFactory.h"
+#include "MantidAPI/MatrixWorkspace_fwd.h"
 #include "MantidQtWidgets/InstrumentView/BaseCustomInstrumentModel.h"
 
 #include <map>
 #include <memory>
+#include <optional>
 #include <string>
 
 namespace MantidQt {
@@ -64,6 +66,7 @@ public:
   std::string dataFileName() override { return m_base->dataFileName(); };
   int currentRun() override { return m_base->currentRun(); };
   bool isErrorCode(const int run) override { return m_base->isErrorCode(run); };
+  std::optional<double> xConversionFactor(Mantid::API::MatrixWorkspace_const_sptr workspace) const;
   const std::string getInstrument() override { return m_base->getInstrument(); };
   const std::string getTmpName() override { return m_base->getTmpName(); };
   const std::string getWSName() override { return m_base->getWSName(); };

--- a/qt/scientific_interfaces/Direct/test/ALFCustomInstrumentModelTest.h
+++ b/qt/scientific_interfaces/Direct/test/ALFCustomInstrumentModelTest.h
@@ -50,7 +50,7 @@ public:
   }
 
   void test_loadData() {
-    auto data = mockALFData("ALF_tmp", "ALF", 6113, true);
+    auto data = mockALFData("ALF_tmp", "ALF", 6113, "TOF");
     TS_ASSERT_EQUALS(m_model->getLoadCount(), 0);
 
     std::pair<int, std::string> loadResult = m_model->loadData(notALFFile);
@@ -61,7 +61,7 @@ public:
   }
 
   void test_loadDataNotALF() {
-    auto data = mockALFData("ALF_tmp", "EMU", 6113, true);
+    auto data = mockALFData("ALF_tmp", "EMU", 6113, "TOF");
     TS_ASSERT_EQUALS(m_model->getLoadCount(), 0);
 
     std::pair<int, std::string> loadResult = m_model->loadData(notALFFile);
@@ -72,7 +72,7 @@ public:
   }
 
   void test_loadDataDSpace() {
-    auto data = mockALFData("ALF_tmp", "ALF", 6113, false);
+    auto data = mockALFData("ALF_tmp", "ALF", 6113, "dSpacing");
     TS_ASSERT_EQUALS(m_model->getLoadCount(), 0);
 
     std::pair<int, std::string> loadResult = m_model->loadData(notALFFile);
@@ -83,7 +83,7 @@ public:
   }
 
   void test_isDataValid() {
-    auto data = mockALFData("ALF_tmp", "ALF", 6113, true);
+    auto data = mockALFData("ALF_tmp", "ALF", 6113, "TOF");
     std::map<std::string, bool> isDataValid = m_model->isDataValid();
 
     TS_ASSERT(isDataValid["IsValidInstrument"])
@@ -91,14 +91,14 @@ public:
   }
 
   void test_isDataValidNotALF() {
-    auto data = mockALFData("ALF_tmp", "EMU", 6113, true);
+    auto data = mockALFData("ALF_tmp", "EMU", 6113, "TOF");
     std::map<std::string, bool> isDataValid = m_model->isDataValid();
     TS_ASSERT(!isDataValid["IsValidInstrument"])
     TS_ASSERT(!isDataValid["IsItDSpace"])
   }
 
   void test_isDataValidDSpace() {
-    auto data = mockALFData("ALF_tmp", "ALF", 6113, false);
+    auto data = mockALFData("ALF_tmp", "ALF", 6113, "dSpacing");
     std::map<std::string, bool> isDataValid = m_model->isDataValid();
 
     TS_ASSERT(isDataValid["IsValidInstrument"]);
@@ -106,7 +106,7 @@ public:
   }
 
   void test_storeSingleTube() {
-    auto data = mockALFData("CURVES", "ALF", 6113, false);
+    auto data = mockALFData("CURVES", "ALF", 6113, "Phi");
 
     m_model->storeSingleTube("test");
 
@@ -121,7 +121,7 @@ public:
 
   void test_averageTube() {
     int run = 6113;
-    auto data = mockALFData("CURVES", "ALF", run, false);
+    auto data = mockALFData("CURVES", "ALF", run, "Phi");
     m_model->setCurrentRun(run);
     m_model->extractSingleTube();
 
@@ -137,7 +137,7 @@ public:
     ws->mutableRun().addProperty("run_number", run, true);
     ws->setInstrument(inst);
     auto axis = ws->getAxis(0);
-    axis->setUnit("dSpacing");
+    axis->setUnit("Phi");
     AnalysisDataService::Instance().addOrReplace("CURVES", ws);
 
     // check second WS y values
@@ -160,7 +160,7 @@ public:
     ws3->mutableRun().addProperty("run_number", run, true);
     ws3->setInstrument(inst);
     axis = ws3->getAxis(0);
-    axis->setUnit("dSpacing");
+    axis->setUnit("Phi");
     AnalysisDataService::Instance().addOrReplace("CURVES", ws3);
 
     // check second WS y values
@@ -184,7 +184,7 @@ public:
     // not extracted -> false
     TS_ASSERT(!m_model->hasTubeBeenExtracted(name));
     // create data to store
-    auto data = mockALFData("CURVES", "ALF", 6113, false);
+    auto data = mockALFData("CURVES", "ALF", 6113, "dSpacing");
     m_model->storeSingleTube(name);
     // stored data -> true
     TS_ASSERT(m_model->hasTubeBeenExtracted(name));
@@ -215,7 +215,7 @@ public:
   void test_averageTubeCondition() {
     std::map<std::string, bool> conditions = {{"plotStored", true}, {"hasCurve", true}, {"isTube", true}};
     int run = 6113;
-    auto data = mockALFData("CURVES", "ALF", run, false);
+    auto data = mockALFData("CURVES", "ALF", run, "dSpacing");
     m_model->setCurrentRun(run);
     m_model->extractSingleTube();
 
@@ -225,7 +225,7 @@ public:
   void test_averageTubeConditionNotTube() {
     std::map<std::string, bool> conditions = {{"plotStored", true}, {"hasCurve", true}, {"isTube", false}};
     int run = 6113;
-    auto data = mockALFData("CURVES", "ALF", run, false);
+    auto data = mockALFData("CURVES", "ALF", run, "dSpacing");
     m_model->setCurrentRun(run);
     m_model->extractSingleTube();
 
@@ -236,7 +236,7 @@ public:
   void test_averageTubeConditionNoPlot() {
     std::map<std::string, bool> conditions = {{"plotStored", false}, {"hasCurve", false}, {"isTube", true}};
     int run = 6113;
-    auto data = mockALFData("CURVES", "ALF", run, false);
+    auto data = mockALFData("CURVES", "ALF", run, "dSpacing");
     m_model->setCurrentRun(run);
     m_model->extractSingleTube();
 
@@ -248,7 +248,7 @@ public:
     std::map<std::string, bool> conditions = {{"plotStored", true}, {"hasCurve", true}, {"isTube", true}};
     int run = 6113;
     // the extraced ws will exist but average will be 0 -> change runs
-    auto data = mockALFData("extractedTubes_ALF6113", "ALF", run, false);
+    auto data = mockALFData("extractedTubes_ALF6113", "ALF", run, "dSpacing");
     m_model->setCurrentRun(run);
 
     TS_ASSERT(!m_model->averageTubeCondition(conditions));
@@ -257,7 +257,7 @@ public:
   void test_averageTubeConditionNoWSToAverage() {
     std::map<std::string, bool> conditions = {{"plotStored", true}, {"hasCurve", true}, {"isTube", true}};
     int run = 6113;
-    auto data = mockALFData("CURVES", "ALF", run, false);
+    auto data = mockALFData("CURVES", "ALF", run, "dSpacing");
     m_model->setCurrentRun(run);
     m_model->extractSingleTube();
 

--- a/qt/scientific_interfaces/Direct/test/ALFCustomInstrumentPresenterTest.h
+++ b/qt/scientific_interfaces/Direct/test/ALFCustomInstrumentPresenterTest.h
@@ -106,7 +106,7 @@ public:
     // cannot compare std::function directly
     // check behaviour instead
     int run = 6113;
-    auto data = mockALFData("CURVES", "ALF", run, false);
+    auto data = mockALFData("CURVES", "ALF", run, "dSpacing");
     m_model->setCurrentRun(run);
 
     std::map<std::string, bool> conditions = {{"plotStored", true}, {"hasCurve", true}, {"isTube", true}};

--- a/qt/widgets/instrumentview/src/PlotFitAnalysisPaneModel.cpp
+++ b/qt/widgets/instrumentview/src/PlotFitAnalysisPaneModel.cpp
@@ -115,15 +115,17 @@ IFunction_sptr PlotFitAnalysisPaneModel::calculateEstimate(const std::string &wo
 
 IFunction_sptr PlotFitAnalysisPaneModel::calculateEstimate(MatrixWorkspace_sptr &workspace,
                                                            const std::pair<double, double> &range) {
-  workspace = cropWorkspace(workspace, range.first, range.second);
-  workspace = convertToPointData(workspace);
+  if (workspace = cropWorkspace(workspace, range.first, range.second)) {
+    workspace = convertToPointData(workspace);
 
-  const auto xData = workspace->readX(0);
-  const auto yData = workspace->readY(0);
+    const auto xData = workspace->readX(0);
+    const auto yData = workspace->readY(0);
 
-  const auto background = std::accumulate(yData.begin(), yData.end(), 0.0) / static_cast<double>(yData.size());
+    const auto background = std::accumulate(yData.begin(), yData.end(), 0.0) / static_cast<double>(yData.size());
 
-  return createCompositeFunction(createFlatBackground(background), createGaussian(xData, yData, background));
+    return createCompositeFunction(createFlatBackground(background), createGaussian(xData, yData, background));
+  }
+  return nullptr;
 }
 
 bool PlotFitAnalysisPaneModel::hasEstimate() const { return m_estimateFunction != nullptr; }

--- a/qt/widgets/instrumentview/src/PlotFitAnalysisPaneModel.cpp
+++ b/qt/widgets/instrumentview/src/PlotFitAnalysisPaneModel.cpp
@@ -115,11 +115,11 @@ IFunction_sptr PlotFitAnalysisPaneModel::calculateEstimate(const std::string &wo
 
 IFunction_sptr PlotFitAnalysisPaneModel::calculateEstimate(MatrixWorkspace_sptr &workspace,
                                                            const std::pair<double, double> &range) {
-  if (workspace = cropWorkspace(workspace, range.first, range.second)) {
-    workspace = convertToPointData(workspace);
+  if (auto alteredWorkspace = cropWorkspace(workspace, range.first, range.second)) {
+    alteredWorkspace = convertToPointData(alteredWorkspace);
 
-    const auto xData = workspace->readX(0);
-    const auto yData = workspace->readY(0);
+    const auto xData = alteredWorkspace->readX(0);
+    const auto yData = alteredWorkspace->readY(0);
 
     const auto background = std::accumulate(yData.begin(), yData.end(), 0.0) / static_cast<double>(yData.size());
 

--- a/qt/widgets/instrumentview/src/PlotFitAnalysisPaneView.cpp
+++ b/qt/widgets/instrumentview/src/PlotFitAnalysisPaneView.cpp
@@ -104,7 +104,9 @@ std::pair<double, double> PlotFitAnalysisPaneView::getRange() {
 Mantid::API::IFunction_sptr PlotFitAnalysisPaneView::getFunction() { return m_fitBrowser->getFunction(); }
 
 void PlotFitAnalysisPaneView::updateFunction(const Mantid::API::IFunction_sptr func) {
-  m_fitBrowser->updateMultiDatasetParameters(*func);
+  if (func) {
+    m_fitBrowser->updateMultiDatasetParameters(*func);
+  }
 }
 
 void PlotFitAnalysisPaneView::addFunction(Mantid::API::IFunction_sptr func) {

--- a/qt/widgets/instrumentview/test/PlotFitAnalysisPaneModelTest.h
+++ b/qt/widgets/instrumentview/test/PlotFitAnalysisPaneModelTest.h
@@ -62,6 +62,15 @@ public:
     TS_ASSERT(m_model->hasEstimate());
   }
 
+  void test_that_calculateEstimate_returns_a_nullptr_if_the_crop_range_is_invalid() {
+    m_workspace = WorkspaceCreationHelper::create2DWorkspaceBinned(1, 100, 300.0);
+    AnalysisDataService::Instance().addOrReplace(m_workspaceName, m_workspace);
+
+    const auto function = m_model->calculateEstimate(m_workspaceName, m_range);
+
+    TS_ASSERT_EQUALS(nullptr, function);
+  }
+
 private:
   std::unique_ptr<PlotFitAnalysisPaneModel> m_model;
 


### PR DESCRIPTION
**Description of work.**
This PR fixes a crash on ALFView when extracting a single tube with the x axis of the mini-plot set to d-spacing. There was an assumption in the code that a conversion from radians to degrees was required whenever extracting a single tube. This is only true if the x Axis has units in `Phi` or `Out of plane angle`.

**To test:**
Load data ALF82301
Click on Pick tab
Click on Add single crystal peak icon
Click on the peak in the instrument view
Expand Rebin section. Filter by d-spacing range (optional) 5.5,0.1,6
Click on Select whole tube icon
Right click on peak of interest and select Extract Single Tube
There should be no crash, and a plot should appear on the right hand side.

Fixes #34564

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
