### PR TITLE
Make Indirect Symmetrise tab mvp

### DIFF
--- a/docs/source/interfaces/indirect/Indirect Data Reduction.rst
+++ b/docs/source/interfaces/indirect/Indirect Data Reduction.rst
@@ -687,7 +687,7 @@ produce this file is IRIS, the analyser is graphite and the reflection is 002. S
 1. In the **Input** box, load the file named ``iris26176_graphite002_red``. This will
    automatically plot the data on the first mini-plot.
 
-2. Move the green slider located at x = -0.5 to be at x = -0.4.
+2. Move the magenta slider located at x = 0.5 to be at x = 0.4.
 
 3. Click **Preview**. This will update the :ref:`Preview properties <preview-properties>` and
    the neighbouring mini-plot.

--- a/qt/scientific_interfaces/Indirect/CMakeLists.txt
+++ b/qt/scientific_interfaces/Indirect/CMakeLists.txt
@@ -83,6 +83,7 @@ set(SRC_FILES
     IndirectSqwModel.cpp
     IndirectSqwView.cpp
     IndirectSymmetrise.cpp
+    IndirectSymmetriseView.cpp
     IndirectTab.cpp
     IndirectTools.cpp
     IndirectToolsTab.cpp
@@ -161,6 +162,7 @@ set(MOC_FILES
     IndirectSqw.h
     IndirectSqwView.h
     IndirectSymmetrise.h
+    IndirectSymmetriseView.h
     IndirectTab.h
     IndirectTools.h
     IndirectToolsTab.h

--- a/qt/scientific_interfaces/Indirect/CMakeLists.txt
+++ b/qt/scientific_interfaces/Indirect/CMakeLists.txt
@@ -84,6 +84,7 @@ set(SRC_FILES
     IndirectSqwView.cpp
     IndirectSymmetrise.cpp
     IndirectSymmetriseView.cpp
+    IndirectSymmetriseModel.cpp
     IndirectTab.cpp
     IndirectTools.cpp
     IndirectToolsTab.cpp
@@ -163,6 +164,7 @@ set(MOC_FILES
     IndirectSqwView.h
     IndirectSymmetrise.h
     IndirectSymmetriseView.h
+    IndirectSymmetriseModel.h
     IndirectTab.h
     IndirectTools.h
     IndirectToolsTab.h

--- a/qt/scientific_interfaces/Indirect/IndirectSqwModel.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectSqwModel.cpp
@@ -29,8 +29,6 @@ std::pair<double, double> convertTupleToPair(std::tuple<double, double> const &t
   return std::make_pair(std::get<0>(tuple), std::get<1>(tuple));
 }
 
-double roundToPrecision(double value, double precision) { return value - std::remainder(value, precision); }
-
 void convertToSpectrumAxis(std::string const &inputName, std::string const &outputName) {
   auto converter = AlgorithmManager::Instance().create("ConvertSpectrumAxis");
   converter->initialize();

--- a/qt/scientific_interfaces/Indirect/IndirectSqwModel.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectSqwModel.cpp
@@ -150,9 +150,4 @@ UserInputValidator IndirectSqwModel::validate(std::tuple<double, double> const q
   return uiv;
 }
 
-std::pair<double, double> IndirectSqwModel::roundToWidth(std::tuple<double, double> const &axisRange, double width) {
-  return std::make_pair(roundToPrecision(std::get<0>(axisRange), width) + width,
-                        roundToPrecision(std::get<1>(axisRange), width) - width);
-}
-
 } // namespace MantidQt::CustomInterfaces

--- a/qt/scientific_interfaces/Indirect/IndirectSqwModel.h
+++ b/qt/scientific_interfaces/Indirect/IndirectSqwModel.h
@@ -37,7 +37,6 @@ public:
   std::string getOutputWorkspace();
   MatrixWorkspace_sptr getRqwWorkspace();
   UserInputValidator validate(std::tuple<double, double> const qRange, std::tuple<double, double> const eRange);
-  std::pair<double, double> roundToWidth(std::tuple<double, double> const &axisRange, double width);
 
 private:
   std::string m_inputWorkspace;

--- a/qt/scientific_interfaces/Indirect/IndirectSqwView.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectSqwView.cpp
@@ -34,8 +34,6 @@ namespace MantidQt::CustomInterfaces {
  */
 IndirectSqwView::IndirectSqwView(QWidget *parent) {
   m_uiForm.setupUi(parent);
-  m_dblManager = new QtDoublePropertyManager();
-  m_dblEdFac = new DoubleEditorFactory(this);
 
   m_uiForm.rqwPlot2D->setCanvasColour(QColor(240, 240, 240));
 

--- a/qt/scientific_interfaces/Indirect/IndirectSymmetrise.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectSymmetrise.cpp
@@ -148,12 +148,10 @@ void IndirectSymmetrise::setFileExtensionsByName(bool filter) {
 void IndirectSymmetrise::handleValueChanged(QtProperty *prop, double value) {
   if (prop->propertyName() == "Spectrum No") {
     m_view->replotNewSpectrum(value);
-  }
-  if (prop->propertyName() == "EMin") {
+  } else if (prop->propertyName() == "EMin") {
     m_view->verifyERange(prop, value);
     m_model->setEMin(m_view->getEMin());
-  }
-  if (prop->propertyName() == "EMax") {
+  } else if (prop->propertyName() == "EMax") {
     m_view->verifyERange(prop, value);
     m_model->setEMax(m_view->getEMax());
   }

--- a/qt/scientific_interfaces/Indirect/IndirectSymmetrise.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectSymmetrise.cpp
@@ -27,13 +27,11 @@ namespace CustomInterfaces {
  */
 IndirectSymmetrise::IndirectSymmetrise(IndirectDataReduction *idrUI, QWidget *parent)
     : IndirectDataReductionTab(idrUI, parent), m_adsInstance(Mantid::API::AnalysisDataService::Instance()),
-      m_view(std::make_unique<IndirectSymmetriseView>(parent)) {
+      m_view(std::make_unique<IndirectSymmetriseView>(parent)), m_model(std::make_unique<IndirectSymmetriseModel>()) {
   setOutputPlotOptionsPresenter(
       std::make_unique<IndirectPlotOptionsPresenter>(m_view->getPlotOptions(), PlotWidget::Spectra));
 
   // SIGNAL/SLOT CONNECTIONS
-  // Plot miniplot when file has finished loading
-  connect(m_view.get(), SIGNAL(dataReady(QString const &)), this, SLOT(handleDataReady(QString const &)));
   // Preview symmetrise
   connect(m_view.get(), SIGNAL(previewClicked()), this, SLOT(preview()));
   // Handle running, plotting and saving
@@ -44,17 +42,6 @@ IndirectSymmetrise::IndirectSymmetrise(IndirectDataReduction *idrUI, QWidget *pa
 IndirectSymmetrise::~IndirectSymmetrise() { m_propTrees["SymmPropTree"]->unsetFactoryForManager(m_dblManager); }
 
 void IndirectSymmetrise::setup() {}
-
-/**
- * Handles the event of data being loaded. Validates the loaded data.
- *
- * @param dataName The name of the data that has been loaded
- */
-void IndirectSymmetrise::handleDataReady(QString const &dataName) {
-  if (m_view->validate()) {
-    plotNewData(dataName);
-  }
-}
 
 bool IndirectSymmetrise::validate() { return m_view->validate(); }
 
@@ -72,24 +59,11 @@ void IndirectSymmetrise::saveClicked() {
 void IndirectSymmetrise::run() {
   m_view->setRawPlotWatchADS(false);
 
-  QString workspaceName = m_view->getInputName();
-  QString outputWorkspaceName = workspaceName.left(workspaceName.length() - 4) + "_sym" + workspaceName.right(4);
-
-  double e_min = m_view->getEMin();
-  double e_max = m_view->getEMax();
-
-  IAlgorithm_sptr symmetriseAlg = AlgorithmManager::Instance().create("Symmetrise", -1);
-  symmetriseAlg->initialize();
-  symmetriseAlg->setProperty("InputWorkspace", workspaceName.toStdString());
-  symmetriseAlg->setProperty("XMin", e_min);
-  symmetriseAlg->setProperty("XMax", e_max);
-  symmetriseAlg->setProperty("OutputWorkspace", outputWorkspaceName.toStdString());
-  symmetriseAlg->setProperty("OutputPropertiesTable", "__SymmetriseProps_temp");
-
-  m_batchAlgoRunner->addAlgorithm(symmetriseAlg);
+  auto const outputWorkspaceName = m_model->setupSymmetriseAlgorithm(m_batchAlgoRunner, m_view->getInputName(),
+                                                                     m_view->getEMin(), m_view->getEMax());
 
   // Set the workspace name for Python script export
-  m_pythonExportWsName = outputWorkspaceName.toStdString();
+  m_pythonExportWsName = outputWorkspaceName;
 
   // Handle algorithm completion signal
   connect(m_batchAlgoRunner, SIGNAL(batchComplete(bool)), this, SLOT(algorithmComplete(bool)));
@@ -106,23 +80,12 @@ void IndirectSymmetrise::run() {
 void IndirectSymmetrise::algorithmComplete(bool error) {
   disconnect(m_batchAlgoRunner, SIGNAL(batchComplete(bool)), this, SLOT(algorithmComplete(bool)));
   m_view->setRawPlotWatchADS(true);
-
   if (error)
     return;
-
   setOutputPlotOptionsWorkspaces({m_pythonExportWsName});
-
   // Enable save and plot
   m_view->enableSave(true);
 }
-
-/**
- * Plots a new workspace in the mini plot when it is loaded form the data
- *selector.
- *
- * @param workspaceName Name of the workspace that has been loaded
- */
-void IndirectSymmetrise::plotNewData(QString const &workspaceName) { m_view->plotNewData(workspaceName); }
 
 /**
  * Handles a request to preview the symmetrise.
@@ -142,23 +105,18 @@ void IndirectSymmetrise::preview() {
   if (workspaceName.isEmpty())
     return;
 
-  double e_min = m_view->getEMin();
-  double e_max = m_view->getEMax();
-
   long spectrumNumber = static_cast<long>(m_view->getPreviewSpec());
   std::vector<long> spectraRange(2, spectrumNumber);
 
-  // Run the algorithm on the preview spectrum only
-  IAlgorithm_sptr symmetriseAlg = AlgorithmManager::Instance().create("Symmetrise", -1);
-  symmetriseAlg->initialize();
-  symmetriseAlg->setProperty("InputWorkspace", workspaceName.toStdString());
-  symmetriseAlg->setProperty("XMin", e_min);
-  symmetriseAlg->setProperty("XMax", e_max);
-  symmetriseAlg->setProperty("SpectraRange", spectraRange);
-  symmetriseAlg->setProperty("OutputWorkspace", "__Symmetrise_temp");
-  symmetriseAlg->setProperty("OutputPropertiesTable", "__SymmetriseProps_temp");
+  m_model->setupPreviewAlgorithm(m_batchAlgoRunner, workspaceName, m_view->getEMin(), m_view->getEMax(), spectraRange);
 
-  runAlgorithm(symmetriseAlg);
+  // There should never really be unexecuted algorithms in the queue, but it is
+  // worth warning in case of possible weirdness
+  size_t batchQueueLength = m_batchAlgoRunner->queueLength();
+  if (batchQueueLength > 0)
+    g_log.warning() << "Batch queue already contains " << batchQueueLength << " algorithms!\n";
+
+  m_batchAlgoRunner->executeBatchAsync();
 
   // Now enable the run function
   m_view->enableRun(true);

--- a/qt/scientific_interfaces/Indirect/IndirectSymmetrise.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectSymmetrise.cpp
@@ -7,7 +7,6 @@
 #include "IndirectSymmetrise.h"
 #include "IndirectDataValidationHelper.h"
 
-#include "MantidAPI/ITableWorkspace.h"
 #include "MantidAPI/MatrixWorkspace.h"
 #include "MantidKernel/Logger.h"
 #include "MantidQtWidgets/Common/UserInputValidator.h"
@@ -27,126 +26,19 @@ namespace CustomInterfaces {
 /** Constructor
  */
 IndirectSymmetrise::IndirectSymmetrise(IndirectDataReduction *idrUI, QWidget *parent)
-    : IndirectDataReductionTab(idrUI, parent), m_adsInstance(Mantid::API::AnalysisDataService::Instance()) {
-  m_uiForm.setupUi(parent);
+    : IndirectDataReductionTab(idrUI, parent), m_adsInstance(Mantid::API::AnalysisDataService::Instance()),
+      m_view(std::make_unique<IndirectSymmetriseView>(parent)) {
   setOutputPlotOptionsPresenter(
-      std::make_unique<IndirectPlotOptionsPresenter>(m_uiForm.ipoPlotOptions, PlotWidget::Spectra));
-
-  m_uiForm.ppRawPlot->setCanvasColour(QColor(240, 240, 240));
-  m_uiForm.ppPreviewPlot->setCanvasColour(QColor(240, 240, 240));
-
-  int numDecimals = 6;
-
-  // Property Trees
-  m_propTrees["SymmPropTree"] = new QtTreePropertyBrowser();
-  m_uiForm.properties->addWidget(m_propTrees["SymmPropTree"]);
-
-  m_propTrees["SymmPVPropTree"] = new QtTreePropertyBrowser();
-  m_uiForm.propertiesPreview->addWidget(m_propTrees["SymmPVPropTree"]);
-
-  // Editor Factories
-  auto *doubleEditorFactory = new DoubleEditorFactory();
-  m_propTrees["SymmPropTree"]->setFactoryForManager(m_dblManager, doubleEditorFactory);
-
-  // Raw Properties
-  m_properties["EMin"] = m_dblManager->addProperty("EMin");
-  m_dblManager->setDecimals(m_properties["EMin"], numDecimals);
-  m_propTrees["SymmPropTree"]->addProperty(m_properties["EMin"]);
-  m_properties["EMax"] = m_dblManager->addProperty("EMax");
-  m_dblManager->setDecimals(m_properties["EMax"], numDecimals);
-  m_propTrees["SymmPropTree"]->addProperty(m_properties["EMax"]);
-
-  QtProperty *rawPlotProps = m_grpManager->addProperty("Raw Plot");
-  m_propTrees["SymmPropTree"]->addProperty(rawPlotProps);
-
-  m_properties["PreviewSpec"] = m_dblManager->addProperty("Spectrum No");
-  m_dblManager->setDecimals(m_properties["PreviewSpec"], 0);
-  rawPlotProps->addSubProperty(m_properties["PreviewSpec"]);
-
-  // Preview Properties
-  // Mainly used for display rather than getting user input
-  m_properties["NegativeYValue"] = m_dblManager->addProperty("Negative Y");
-  m_dblManager->setDecimals(m_properties["NegativeYValue"], numDecimals);
-  m_propTrees["SymmPVPropTree"]->addProperty(m_properties["NegativeYValue"]);
-
-  m_properties["PositiveYValue"] = m_dblManager->addProperty("Positive Y");
-  m_dblManager->setDecimals(m_properties["PositiveYValue"], numDecimals);
-  m_propTrees["SymmPVPropTree"]->addProperty(m_properties["PositiveYValue"]);
-
-  m_properties["DeltaY"] = m_dblManager->addProperty("Delta Y");
-  m_dblManager->setDecimals(m_properties["DeltaY"], numDecimals);
-  m_propTrees["SymmPVPropTree"]->addProperty(m_properties["DeltaY"]);
-
-  auto const xLimits = m_uiForm.ppRawPlot->getAxisRange(AxisID::XBottom);
-  auto const yLimits = m_uiForm.ppRawPlot->getAxisRange(AxisID::YLeft);
-
-  // Indicators for Y value at each EMin position
-  auto negativeEMinYPos =
-      m_uiForm.ppRawPlot->addSingleSelector("NegativeEMinYPos", MantidWidgets::SingleSelector::YSINGLE, 0.0);
-  negativeEMinYPos->setColour(Qt::blue);
-  negativeEMinYPos->setBounds(std::get<0>(yLimits), std::get<1>(yLimits));
-
-  auto positiveEMinYPos =
-      m_uiForm.ppRawPlot->addSingleSelector("PositiveEMinYPos", MantidWidgets::SingleSelector::YSINGLE, 1.0);
-  positiveEMinYPos->setColour(Qt::red);
-  positiveEMinYPos->setBounds(std::get<0>(yLimits), std::get<1>(yLimits));
-
-  // Indicator for centre of symmetry (x=0)
-  auto centreMarkRaw = m_uiForm.ppRawPlot->addSingleSelector("CentreMark", MantidWidgets::SingleSelector::XSINGLE, 0.0);
-  centreMarkRaw->setColour(Qt::cyan);
-  centreMarkRaw->setBounds(std::get<0>(xLimits), std::get<1>(xLimits));
-
-  // Indicators for negative and positive X range values on X axis
-  // The user can use these to move the X range
-  // Note that the max and min of the negative range selector corespond to the
-  // opposite X value
-  // i.e. RS min is X max
-  auto negativeERaw = m_uiForm.ppRawPlot->addRangeSelector("NegativeE");
-  negativeERaw->setColour(Qt::darkGreen);
-
-  auto positiveERaw = m_uiForm.ppRawPlot->addRangeSelector("PositiveE");
-  positiveERaw->setColour(Qt::darkGreen);
+      std::make_unique<IndirectPlotOptionsPresenter>(m_view->getPlotOptions(), PlotWidget::Spectra));
 
   // SIGNAL/SLOT CONNECTIONS
-  // Validate the E range when it is changed
-  connect(m_dblManager, SIGNAL(valueChanged(QtProperty *, double)), this, SLOT(verifyERange(QtProperty *, double)));
-  // Plot a new spectrum when the user changes the value of the preview spectrum
-  connect(m_dblManager, SIGNAL(valueChanged(QtProperty *, double)), this,
-          SLOT(replotNewSpectrum(QtProperty *, double)));
   // Plot miniplot when file has finished loading
-  connect(m_uiForm.dsInput, SIGNAL(dataReady(QString const &)), this, SLOT(handleDataReady(QString const &)));
+  connect(m_view.get(), SIGNAL(dataReady(QString const &)), this, SLOT(handleDataReady(QString const &)));
   // Preview symmetrise
-  connect(m_uiForm.pbPreview, SIGNAL(clicked()), this, SLOT(preview()));
-  // X range selectors
-  connect(positiveERaw, SIGNAL(minValueChanged(double)), this, SLOT(xRangeMinChanged(double)));
-  connect(positiveERaw, SIGNAL(maxValueChanged(double)), this, SLOT(xRangeMaxChanged(double)));
-  connect(negativeERaw, SIGNAL(minValueChanged(double)), this, SLOT(xRangeMinChanged(double)));
-  connect(negativeERaw, SIGNAL(maxValueChanged(double)), this, SLOT(xRangeMaxChanged(double)));
+  connect(m_view.get(), SIGNAL(previewClicked()), this, SLOT(preview()));
   // Handle running, plotting and saving
-  connect(m_uiForm.pbRun, SIGNAL(clicked()), this, SLOT(runClicked()));
-  connect(m_uiForm.pbSave, SIGNAL(clicked()), this, SLOT(saveClicked()));
-
-  connect(this, SIGNAL(updateRunButton(bool, std::string const &, QString const &, QString const &)), this,
-          SLOT(updateRunButton(bool, std::string const &, QString const &, QString const &)));
-
-  // Set default X range values
-  m_dblManager->setValue(m_properties["EMin"], 0.1);
-  m_dblManager->setValue(m_properties["EMax"], 0.5);
-
-  // Set default x axis range
-  QPair<double, double> defaultRange(-1.0, 1.0);
-  m_uiForm.ppRawPlot->setAxisRange(defaultRange, AxisID::XBottom);
-  m_uiForm.ppPreviewPlot->setAxisRange(defaultRange, AxisID::XBottom);
-
-  // Disable run until preview is clicked
-  m_uiForm.pbRun->setEnabled(false);
-  m_uiForm.pbPreview->setEnabled(false);
-
-  // Allows empty workspace selector when initially selected
-  m_uiForm.dsInput->isOptional(true);
-
-  // Disables searching for run files in the data archive
-  m_uiForm.dsInput->isForRunFiles(false);
+  connect(m_view.get(), SIGNAL(runClicked()), this, SLOT(runClicked()));
+  connect(m_view.get(), SIGNAL(saveClicked()), this, SLOT(saveClicked()));
 }
 
 IndirectSymmetrise::~IndirectSymmetrise() { m_propTrees["SymmPropTree"]->unsetFactoryForManager(m_dblManager); }
@@ -159,44 +51,32 @@ void IndirectSymmetrise::setup() {}
  * @param dataName The name of the data that has been loaded
  */
 void IndirectSymmetrise::handleDataReady(QString const &dataName) {
-  UserInputValidator uiv;
-  validateDataIsOfType(uiv, m_uiForm.dsInput, "Sample", DataType::Red);
-
-  auto const errorMessage = uiv.generateErrorMessage();
-  if (!errorMessage.isEmpty())
-    showMessageBox(errorMessage);
-  else
+  if (m_view->validate()) {
     plotNewData(dataName);
+  }
 }
 
-bool IndirectSymmetrise::validate() {
-  UserInputValidator uiv;
-  // Validate the sample workspace
-  validateDataIsOfType(uiv, m_uiForm.dsInput, "Sample", DataType::Red);
+bool IndirectSymmetrise::validate() { return m_view->validate(); }
 
-  // EMin and EMax must be positive
-  if (m_dblManager->value(m_properties["EMin"]) <= 0.0)
-    uiv.addErrorMessage("EMin must be positive.");
-  if (m_dblManager->value(m_properties["EMax"]) <= 0.0)
-    uiv.addErrorMessage("EMax must be positive.");
+void IndirectSymmetrise::runClicked() { runTab(); }
 
-  auto const errorMessage = uiv.generateErrorMessage();
-
-  // Show an error message if needed
-  if (!errorMessage.isEmpty())
-    emit showMessageBox(errorMessage);
-
-  return errorMessage.isEmpty();
+/**
+ * Handles saving of workspace
+ */
+void IndirectSymmetrise::saveClicked() {
+  if (checkADSForPlotSaveWorkspace(m_pythonExportWsName, false))
+    addSaveWorkspaceToQueue(QString::fromStdString(m_pythonExportWsName), QString::fromStdString(m_pythonExportWsName));
+  m_batchAlgoRunner->executeBatch();
 }
 
 void IndirectSymmetrise::run() {
-  m_uiForm.ppRawPlot->watchADS(false);
+  m_view->setRawPlotWatchADS(false);
 
-  QString workspaceName = m_uiForm.dsInput->getCurrentDataName();
+  QString workspaceName = m_view->getInputName();
   QString outputWorkspaceName = workspaceName.left(workspaceName.length() - 4) + "_sym" + workspaceName.right(4);
 
-  double e_min = m_dblManager->value(m_properties["EMin"]);
-  double e_max = m_dblManager->value(m_properties["EMax"]);
+  double e_min = m_view->getEMin();
+  double e_max = m_view->getEMax();
 
   IAlgorithm_sptr symmetriseAlg = AlgorithmManager::Instance().create("Symmetrise", -1);
   symmetriseAlg->initialize();
@@ -225,7 +105,7 @@ void IndirectSymmetrise::run() {
  */
 void IndirectSymmetrise::algorithmComplete(bool error) {
   disconnect(m_batchAlgoRunner, SIGNAL(batchComplete(bool)), this, SLOT(algorithmComplete(bool)));
-  m_uiForm.ppRawPlot->watchADS(true);
+  m_view->setRawPlotWatchADS(true);
 
   if (error)
     return;
@@ -233,7 +113,7 @@ void IndirectSymmetrise::algorithmComplete(bool error) {
   setOutputPlotOptionsWorkspaces({m_pythonExportWsName});
 
   // Enable save and plot
-  m_uiForm.pbSave->setEnabled(true);
+  m_view->enableSave(true);
 }
 
 /**
@@ -242,148 +122,7 @@ void IndirectSymmetrise::algorithmComplete(bool error) {
  *
  * @param workspaceName Name of the workspace that has been loaded
  */
-void IndirectSymmetrise::plotNewData(QString const &workspaceName) {
-  // Set the preview spectrum number to the first spectrum in the workspace
-  auto sampleWS = AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(workspaceName.toStdString());
-  int minSpectrumRange = sampleWS->getSpectrum(0).getSpectrumNo();
-  m_dblManager->setValue(m_properties["PreviewSpec"], static_cast<double>(minSpectrumRange));
-
-  updateMiniPlots();
-
-  // Set the preview range to the maximum absolute X value
-  auto const axisRange = getXRangeFromWorkspace(sampleWS);
-  double symmRange = std::max(fabs(axisRange.first), fabs(axisRange.second));
-
-  // Set valid range for range selectors
-  auto negativeESelector = m_uiForm.ppRawPlot->getRangeSelector("NegativeE");
-  negativeESelector->setBounds(axisRange.first, axisRange.second);
-  negativeESelector->setRange(-symmRange, 0);
-  auto positiveESelector = m_uiForm.ppRawPlot->getRangeSelector("PositiveE");
-  positiveESelector->setBounds(axisRange.first, axisRange.second);
-  positiveESelector->setRange(0, symmRange);
-
-  // Set some default (and valid) values for E range
-  m_dblManager->setValue(m_properties["EMax"], axisRange.second);
-  m_dblManager->setValue(m_properties["EMin"], axisRange.second / 10);
-  m_originalMax = axisRange.second;
-  m_originalMin = axisRange.second / 10;
-
-  updateMiniPlots();
-
-  auto const xLimits = m_uiForm.ppRawPlot->getAxisRange(AxisID::XBottom);
-  auto const yLimits = m_uiForm.ppRawPlot->getAxisRange(AxisID::YLeft);
-
-  // Set indicator positions
-  auto negativeEMinYPos = m_uiForm.ppRawPlot->getSingleSelector("NegativeEMinYPos");
-  negativeEMinYPos->setBounds(std::get<0>(yLimits), std::get<1>(yLimits));
-
-  auto positiveEMinYPos = m_uiForm.ppRawPlot->getSingleSelector("PositiveEMinYPos");
-  positiveEMinYPos->setBounds(std::get<0>(yLimits), std::get<1>(yLimits));
-
-  auto centreMarkRaw = m_uiForm.ppRawPlot->getSingleSelector("CentreMark");
-  centreMarkRaw->setBounds(std::get<0>(xLimits), std::get<1>(xLimits));
-}
-
-/**
- * Updates the mini plots.
- */
-void IndirectSymmetrise::updateMiniPlots() {
-  if (!m_uiForm.dsInput->isValid())
-    return;
-
-  QString workspaceName = m_uiForm.dsInput->getCurrentDataName();
-  int spectrumNumber = static_cast<int>(m_dblManager->value(m_properties["PreviewSpec"]));
-
-  Mantid::API::MatrixWorkspace_sptr input =
-      std::dynamic_pointer_cast<Mantid::API::MatrixWorkspace>(m_adsInstance.retrieve(workspaceName.toStdString()));
-
-  // Plot the spectrum chosen by the user
-  size_t spectrumIndex = input->getIndexFromSpectrumNumber(spectrumNumber);
-  m_uiForm.ppRawPlot->clear();
-  m_uiForm.ppRawPlot->addSpectrum("Raw", input, spectrumIndex);
-
-  // Match X axis range on preview plot
-  auto const axisRange = getXRangeFromWorkspace(input);
-  m_uiForm.ppPreviewPlot->setAxisRange(axisRange, AxisID::XBottom);
-  m_uiForm.ppPreviewPlot->replot();
-}
-
-/**
- * Redraws mini plots when user changes previw range or spectrum.
- *
- * @param prop QtProperty that was changed
- * @param value Value it was changed to
- */
-void IndirectSymmetrise::replotNewSpectrum(QtProperty *prop, double value) {
-  // Validate the preview spectra
-  if (prop == m_properties["PreviewSpec"]) {
-    // Get the range of possible spectra numbers
-    QString workspaceName = m_uiForm.dsInput->getCurrentDataName();
-    MatrixWorkspace_sptr sampleWS =
-        AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(workspaceName.toStdString());
-    int minSpectrumRange = sampleWS->getSpectrum(0).getSpectrumNo();
-    int maxSpectrumRange = sampleWS->getSpectrum(sampleWS->getNumberHistograms() - 1).getSpectrumNo();
-
-    // If entered value is lower then set spectra number to lowest valid value
-    if (value < minSpectrumRange) {
-      m_dblManager->setValue(m_properties["PreviewSpec"], minSpectrumRange);
-      return;
-    }
-
-    // If entered value is higer then set spectra number to highest valid value
-    if (value > maxSpectrumRange) {
-      m_dblManager->setValue(m_properties["PreviewSpec"], maxSpectrumRange);
-      return;
-    }
-    // If we get this far then properties are valid so update mini plots
-    updateMiniPlots();
-  }
-}
-
-/**
- * Verifies that the E Range is valid.
- *
- * @param prop QtProperty changed
- * @param value Value it was changed to (unused)
- */
-void IndirectSymmetrise::verifyERange(QtProperty *prop, double value) {
-  UNUSED_ARG(value);
-
-  double eMin = m_dblManager->value(m_properties["EMin"]);
-  double eMax = m_dblManager->value(m_properties["EMax"]);
-
-  if (prop == m_properties["EMin"]) {
-    // If the value of EMin is negative try negating it to get a valid range
-    if (eMin < 0) {
-      eMin = -eMin;
-      m_dblManager->setValue(m_properties["EMin"], eMin);
-      return;
-    }
-
-    // If range is still invalid reset EMin to half EMax
-    if (eMin > eMax) {
-      m_dblManager->setValue(m_properties["EMin"], eMax / 2);
-      return;
-    }
-  } else if (prop == m_properties["EMax"]) {
-    // If the value of EMax is negative try negating it to get a valid range
-    if (eMax < 0) {
-      eMax = -eMax;
-      m_dblManager->setValue(m_properties["EMax"], eMax);
-      return;
-    }
-
-    // If range is invalid reset EMax to double EMin
-    if (eMin > eMax) {
-      m_dblManager->setValue(m_properties["EMax"], eMin * 2);
-      return;
-    }
-  }
-
-  // If we get this far then the E range is valid
-  // Update the range selectors with the new values.
-  updateRangeSelectors(prop, value);
-}
+void IndirectSymmetrise::plotNewData(QString const &workspaceName) { m_view->plotNewData(workspaceName); }
 
 /**
  * Handles a request to preview the symmetrise.
@@ -395,23 +134,18 @@ void IndirectSymmetrise::verifyERange(QtProperty *prop, double value) {
 void IndirectSymmetrise::preview() {
   // Handle algorithm completion signal
   connect(m_batchAlgoRunner, SIGNAL(batchComplete(bool)), this, SLOT(previewAlgDone(bool)));
-  m_uiForm.ppRawPlot->watchADS(false);
+
+  m_view->setRawPlotWatchADS(false);
 
   // Do nothing if no data has been laoded
-  QString workspaceName = m_uiForm.dsInput->getCurrentDataName();
+  QString workspaceName = m_view->getInputName();
   if (workspaceName.isEmpty())
     return;
 
-  double e_min = m_dblManager->value(m_properties["EMin"]);
-  double e_max = m_dblManager->value(m_properties["EMax"]);
+  double e_min = m_view->getEMin();
+  double e_max = m_view->getEMax();
 
-  if (e_min == m_originalMin && e_max == m_originalMax) {
-    IndirectTab::showMessageBox("Preview has been called, but the max and min are still default. "
-                                "Please update the min and max lines on the top graph.");
-    return;
-  }
-
-  long spectrumNumber = static_cast<long>(m_dblManager->value(m_properties["PreviewSpec"]));
+  long spectrumNumber = static_cast<long>(m_view->getPreviewSpec());
   std::vector<long> spectraRange(2, spectrumNumber);
 
   // Run the algorithm on the preview spectrum only
@@ -427,7 +161,7 @@ void IndirectSymmetrise::preview() {
   runAlgorithm(symmetriseAlg);
 
   // Now enable the run function
-  m_uiForm.pbRun->setEnabled(true);
+  m_view->enableRun(true);
 }
 
 /**
@@ -438,142 +172,16 @@ void IndirectSymmetrise::preview() {
 void IndirectSymmetrise::previewAlgDone(bool error) {
   if (error)
     return;
-
-  QString workspaceName = m_uiForm.dsInput->getCurrentDataName();
-  int spectrumNumber = static_cast<int>(m_dblManager->value(m_properties["PreviewSpec"]));
-
-  MatrixWorkspace_sptr sampleWS =
-      AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(workspaceName.toStdString());
-  ITableWorkspace_sptr propsTable =
-      AnalysisDataService::Instance().retrieveWS<ITableWorkspace>("__SymmetriseProps_temp");
-  MatrixWorkspace_sptr symmWS = AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>("__Symmetrise_temp");
-
-  // Get the index of XCut on each side of zero
-  int negativeIndex = propsTable->getColumn("NegativeXMinIndex")->cell<int>(0);
-  int positiveIndex = propsTable->getColumn("PositiveXMinIndex")->cell<int>(0);
-
-  // Get the Y values for each XCut and the difference between them
-  double negativeY = sampleWS->y(0)[negativeIndex];
-  double positiveY = sampleWS->y(0)[positiveIndex];
-  double deltaY = fabs(negativeY - positiveY);
-
-  // Show values in property tree
-  m_dblManager->setValue(m_properties["NegativeYValue"], negativeY);
-  m_dblManager->setValue(m_properties["PositiveYValue"], positiveY);
-  m_dblManager->setValue(m_properties["DeltaY"], deltaY);
-
-  auto const yLimits = m_uiForm.ppRawPlot->getAxisRange(AxisID::YLeft);
-  // Set indicator positions
-  auto const negativeEMinYPos = m_uiForm.ppRawPlot->getSingleSelector("NegativeEMinYPos");
-  negativeEMinYPos->setBounds(std::get<0>(yLimits), std::get<1>(yLimits));
-  negativeEMinYPos->setPosition(negativeY);
-
-  auto const positiveEMinYPos = m_uiForm.ppRawPlot->getSingleSelector("PositiveEMinYPos");
-  positiveEMinYPos->setBounds(std::get<0>(yLimits), std::get<1>(yLimits));
-  positiveEMinYPos->setPosition(positiveY);
-
-  // Plot preview plot
-  size_t spectrumIndex = symmWS->getIndexFromSpectrumNumber(spectrumNumber);
-  m_uiForm.ppPreviewPlot->clear();
-  m_uiForm.ppPreviewPlot->addSpectrum("Symmetrised", "__Symmetrise_temp", spectrumIndex);
-
+  m_view->previewAlgDone();
   // Don't want this to trigger when the algorithm is run for all spectra
   disconnect(m_batchAlgoRunner, SIGNAL(batchComplete(bool)), this, SLOT(previewAlgDone(bool)));
-  m_uiForm.ppRawPlot->watchADS(true);
-}
-
-/**
- * Updates position of XCut range selectors when used changed value of XCut.
- *
- * @param prop QtProperty changed
- * @param value Value it was changed to (unused)
- */
-void IndirectSymmetrise::updateRangeSelectors(QtProperty *prop, double value) {
-  auto negativeERaw = m_uiForm.ppRawPlot->getRangeSelector("NegativeE");
-  auto positiveERaw = m_uiForm.ppRawPlot->getRangeSelector("PositiveE");
-
-  value = fabs(value);
-
-  if (prop == m_properties["EMin"]) {
-    negativeERaw->setMaximum(-value);
-    positiveERaw->setMinimum(value);
-  }
-
-  if (prop == m_properties["EMax"]) {
-    negativeERaw->setMinimum(-value);
-    positiveERaw->setMaximum(value);
-  }
-}
-
-/**
- * Handles the X minimum value being changed from a range selector.
- *
- * @param value New range selector value
- */
-void IndirectSymmetrise::xRangeMinChanged(double value) {
-  auto negativeERaw = m_uiForm.ppRawPlot->getRangeSelector("NegativeE");
-  auto positiveERaw = m_uiForm.ppRawPlot->getRangeSelector("PositiveE");
-
-  MantidWidgets::RangeSelector *from = qobject_cast<MantidWidgets::RangeSelector *>(sender());
-
-  if (from == positiveERaw) {
-    m_dblManager->setValue(m_properties["EMin"], std::abs(value));
-  } else if (from == negativeERaw) {
-    m_dblManager->setValue(m_properties["EMax"], std::abs(value));
-  }
-  m_uiForm.pbPreview->setEnabled(true);
-}
-
-/**
- * Handles the X maximum value being changed from a range selector.
- *
- * @param value New range selector value
- */
-void IndirectSymmetrise::xRangeMaxChanged(double value) {
-  auto negativeERaw = m_uiForm.ppRawPlot->getRangeSelector("NegativeE");
-  auto positiveERaw = m_uiForm.ppRawPlot->getRangeSelector("PositiveE");
-
-  MantidWidgets::RangeSelector *from = qobject_cast<MantidWidgets::RangeSelector *>(sender());
-
-  if (from == positiveERaw) {
-    m_dblManager->setValue(m_properties["EMax"], std::abs(value));
-  } else if (from == negativeERaw) {
-    m_dblManager->setValue(m_properties["EMin"], std::abs(value));
-  }
-  m_uiForm.pbPreview->setEnabled(true);
 }
 
 void IndirectSymmetrise::setFileExtensionsByName(bool filter) {
   QStringList const noSuffixes{""};
   auto const tabName("Symmetrise");
-  m_uiForm.dsInput->setFBSuffixes(filter ? getSampleFBSuffixes(tabName) : getExtensions(tabName));
-  m_uiForm.dsInput->setWSSuffixes(filter ? getSampleWSSuffixes(tabName) : noSuffixes);
-}
-
-/**
- * Handle when Run is clicked
- */
-void IndirectSymmetrise::runClicked() { runTab(); }
-
-/**
- * Handles saving of workspace
- */
-void IndirectSymmetrise::saveClicked() {
-  if (checkADSForPlotSaveWorkspace(m_pythonExportWsName, false))
-    addSaveWorkspaceToQueue(QString::fromStdString(m_pythonExportWsName), QString::fromStdString(m_pythonExportWsName));
-}
-
-void IndirectSymmetrise::setRunEnabled(bool enabled) { m_uiForm.pbRun->setEnabled(enabled); }
-
-void IndirectSymmetrise::setSaveEnabled(bool enabled) { m_uiForm.pbSave->setEnabled(enabled); }
-
-void IndirectSymmetrise::updateRunButton(bool enabled, std::string const &enableOutputButtons, QString const &message,
-                                         QString const &tooltip) {
-  setRunEnabled(enabled);
-  m_uiForm.pbRun->setText(message);
-  m_uiForm.pbRun->setToolTip(tooltip);
-  if (enableOutputButtons != "unchanged")
-    setSaveEnabled(enableOutputButtons == "enable");
+  m_view->setFBSuffixes(filter ? getSampleFBSuffixes(tabName) : getExtensions(tabName));
+  m_view->setWSSuffixes(filter ? getSampleWSSuffixes(tabName) : noSuffixes);
 }
 
 } // namespace CustomInterfaces

--- a/qt/scientific_interfaces/Indirect/IndirectSymmetrise.h
+++ b/qt/scientific_interfaces/Indirect/IndirectSymmetrise.h
@@ -51,6 +51,8 @@ public:
   bool validate() override;
 
 private slots:
+  void handleValueChanged(QtProperty *, double);
+  void handleDataReady(QString const &dataName) override;
   void algorithmComplete(bool error);
   void preview();
   void previewAlgDone(bool error);

--- a/qt/scientific_interfaces/Indirect/IndirectSymmetrise.h
+++ b/qt/scientific_interfaces/Indirect/IndirectSymmetrise.h
@@ -8,6 +8,7 @@
 
 #include "IndirectDataReductionTab.h"
 
+#include "IndirectSymmetriseModel.h"
 #include "IndirectSymmetriseView.h"
 #include "MantidAPI/MatrixWorkspace_fwd.h"
 #include "MantidKernel/System.h"
@@ -51,8 +52,6 @@ public:
 
 private slots:
   void algorithmComplete(bool error);
-  void handleDataReady(QString const &dataName) override;
-  void plotNewData(QString const &workspaceName);
   void preview();
   void previewAlgDone(bool error);
 
@@ -64,6 +63,7 @@ private:
 
   Mantid::API::AnalysisDataServiceImpl &m_adsInstance;
   std::unique_ptr<IndirectSymmetriseView> m_view;
+  std::unique_ptr<IndirectSymmetriseModel> m_model;
 };
 } // namespace CustomInterfaces
 } // namespace MantidQt

--- a/qt/scientific_interfaces/Indirect/IndirectSymmetrise.h
+++ b/qt/scientific_interfaces/Indirect/IndirectSymmetrise.h
@@ -8,6 +8,7 @@
 
 #include "IndirectDataReductionTab.h"
 
+#include "IndirectSymmetriseView.h"
 #include "MantidAPI/MatrixWorkspace_fwd.h"
 #include "MantidKernel/System.h"
 #include "ui_IndirectSymmetrise.h"
@@ -52,30 +53,17 @@ private slots:
   void algorithmComplete(bool error);
   void handleDataReady(QString const &dataName) override;
   void plotNewData(QString const &workspaceName);
-  void updateMiniPlots();
-  void replotNewSpectrum(QtProperty *prop, double value);
-  void verifyERange(QtProperty *prop, double value);
-  void updateRangeSelectors(QtProperty *prop, double value);
   void preview();
   void previewAlgDone(bool error);
-  void xRangeMaxChanged(double value);
-  void xRangeMinChanged(double value);
 
   void runClicked();
   void saveClicked();
 
-  void setRunEnabled(bool enabled);
-  void setSaveEnabled(bool enabled);
-  void updateRunButton(bool enabled = true, std::string const &enableOutputButtons = "unchanged",
-                       QString const &message = "Run", QString const &tooltip = "");
-
 private:
   void setFileExtensionsByName(bool filter) override;
 
-  Ui::IndirectSymmetrise m_uiForm;
-  double m_originalMax;
-  double m_originalMin;
   Mantid::API::AnalysisDataServiceImpl &m_adsInstance;
+  std::unique_ptr<IndirectSymmetriseView> m_view;
 };
 } // namespace CustomInterfaces
 } // namespace MantidQt

--- a/qt/scientific_interfaces/Indirect/IndirectSymmetriseModel.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectSymmetriseModel.cpp
@@ -1,0 +1,62 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2022 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#include "IndirectSymmetriseModel.h"
+#include "IndirectDataValidationHelper.h"
+
+#include "MantidAPI/AlgorithmManager.h"
+#include "MantidAPI/MatrixWorkspace.h"
+#include "MantidAPI/WorkspaceGroup.h"
+#include "MantidQtWidgets/Common/AlgorithmRuntimeProps.h"
+#include "MantidQtWidgets/Common/UserInputValidator.h"
+
+#include <QDoubleValidator>
+#include <QFileInfo>
+
+using namespace IndirectDataValidationHelper;
+using namespace Mantid::API;
+
+namespace MantidQt::CustomInterfaces {
+
+//----------------------------------------------------------------------------------------------
+/** Constructor
+ */
+IndirectSymmetriseModel::IndirectSymmetriseModel() {}
+
+void IndirectSymmetriseModel::setupPreviewAlgorithm(MantidQt::API::BatchAlgorithmRunner *batchAlgoRunner,
+                                                    QString workspaceName, double eMin, double eMax,
+                                                    std::vector<long> spectraRange) {
+  // Run the algorithm on the preview spectrum only
+  IAlgorithm_sptr symmetriseAlg = AlgorithmManager::Instance().create("Symmetrise", -1);
+  symmetriseAlg->initialize();
+  symmetriseAlg->setProperty("InputWorkspace", workspaceName.toStdString());
+  symmetriseAlg->setProperty("XMin", eMin);
+  symmetriseAlg->setProperty("XMax", eMax);
+  symmetriseAlg->setProperty("SpectraRange", spectraRange);
+  symmetriseAlg->setProperty("OutputWorkspace", "__Symmetrise_temp");
+  symmetriseAlg->setProperty("OutputPropertiesTable", "__SymmetriseProps_temp");
+  symmetriseAlg->setRethrows(true);
+
+  batchAlgoRunner->addAlgorithm(symmetriseAlg);
+}
+
+std::string IndirectSymmetriseModel::setupSymmetriseAlgorithm(MantidQt::API::BatchAlgorithmRunner *batchAlgoRunner,
+                                                              QString workspaceName, double eMin, double eMax) {
+  QString outputWorkspaceName = workspaceName.left(workspaceName.length() - 4) + "_sym" + workspaceName.right(4);
+
+  IAlgorithm_sptr symmetriseAlg = AlgorithmManager::Instance().create("Symmetrise", -1);
+  symmetriseAlg->initialize();
+  symmetriseAlg->setProperty("InputWorkspace", workspaceName.toStdString());
+  symmetriseAlg->setProperty("XMin", eMin);
+  symmetriseAlg->setProperty("XMax", eMax);
+  symmetriseAlg->setProperty("OutputWorkspace", outputWorkspaceName.toStdString());
+  symmetriseAlg->setProperty("OutputPropertiesTable", "__SymmetriseProps_temp");
+
+  batchAlgoRunner->addAlgorithm(symmetriseAlg);
+  return outputWorkspaceName.toStdString();
+}
+
+} // namespace MantidQt::CustomInterfaces

--- a/qt/scientific_interfaces/Indirect/IndirectSymmetriseModel.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectSymmetriseModel.cpp
@@ -28,7 +28,8 @@ IndirectSymmetriseModel::IndirectSymmetriseModel() {}
 
 void IndirectSymmetriseModel::setupPreviewAlgorithm(MantidQt::API::BatchAlgorithmRunner *batchAlgoRunner,
                                                     std::vector<long> spectraRange) {
-  // Run the algorithm on the preview spectrum only
+  // Run the algorithm on the preview spectrum only, these outputs are only for plotting in the preview window and are
+  // not accessed by users directly.
   IAlgorithm_sptr symmetriseAlg = AlgorithmManager::Instance().create("Symmetrise");
   symmetriseAlg->initialize();
   symmetriseAlg->setProperty("InputWorkspace", m_inputWorkspace);
@@ -57,6 +58,8 @@ std::string IndirectSymmetriseModel::setupSymmetriseAlgorithm(MantidQt::API::Bat
 
 void IndirectSymmetriseModel::setWorkspaceName(QString workspaceName) {
   m_inputWorkspace = workspaceName.toStdString();
+  // the last 4 characters in the workspace name are '_red' the ouput weorkspace name is inserting '_sym' before that
+  // '_red'
   m_outputWorkspace = (workspaceName.left(workspaceName.length() - 4) + "_sym" + workspaceName.right(4)).toStdString();
 }
 

--- a/qt/scientific_interfaces/Indirect/IndirectSymmetriseModel.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectSymmetriseModel.cpp
@@ -27,14 +27,13 @@ namespace MantidQt::CustomInterfaces {
 IndirectSymmetriseModel::IndirectSymmetriseModel() {}
 
 void IndirectSymmetriseModel::setupPreviewAlgorithm(MantidQt::API::BatchAlgorithmRunner *batchAlgoRunner,
-                                                    QString workspaceName, double eMin, double eMax,
                                                     std::vector<long> spectraRange) {
   // Run the algorithm on the preview spectrum only
-  IAlgorithm_sptr symmetriseAlg = AlgorithmManager::Instance().create("Symmetrise", -1);
+  IAlgorithm_sptr symmetriseAlg = AlgorithmManager::Instance().create("Symmetrise");
   symmetriseAlg->initialize();
-  symmetriseAlg->setProperty("InputWorkspace", workspaceName.toStdString());
-  symmetriseAlg->setProperty("XMin", eMin);
-  symmetriseAlg->setProperty("XMax", eMax);
+  symmetriseAlg->setProperty("InputWorkspace", m_inputWorkspace);
+  symmetriseAlg->setProperty("XMin", m_eMin);
+  symmetriseAlg->setProperty("XMax", m_eMax);
   symmetriseAlg->setProperty("SpectraRange", spectraRange);
   symmetriseAlg->setProperty("OutputWorkspace", "__Symmetrise_temp");
   symmetriseAlg->setProperty("OutputPropertiesTable", "__SymmetriseProps_temp");
@@ -43,20 +42,26 @@ void IndirectSymmetriseModel::setupPreviewAlgorithm(MantidQt::API::BatchAlgorith
   batchAlgoRunner->addAlgorithm(symmetriseAlg);
 }
 
-std::string IndirectSymmetriseModel::setupSymmetriseAlgorithm(MantidQt::API::BatchAlgorithmRunner *batchAlgoRunner,
-                                                              QString workspaceName, double eMin, double eMax) {
-  QString outputWorkspaceName = workspaceName.left(workspaceName.length() - 4) + "_sym" + workspaceName.right(4);
-
-  IAlgorithm_sptr symmetriseAlg = AlgorithmManager::Instance().create("Symmetrise", -1);
+std::string IndirectSymmetriseModel::setupSymmetriseAlgorithm(MantidQt::API::BatchAlgorithmRunner *batchAlgoRunner) {
+  IAlgorithm_sptr symmetriseAlg = AlgorithmManager::Instance().create("Symmetrise");
   symmetriseAlg->initialize();
-  symmetriseAlg->setProperty("InputWorkspace", workspaceName.toStdString());
-  symmetriseAlg->setProperty("XMin", eMin);
-  symmetriseAlg->setProperty("XMax", eMax);
-  symmetriseAlg->setProperty("OutputWorkspace", outputWorkspaceName.toStdString());
+  symmetriseAlg->setProperty("InputWorkspace", m_inputWorkspace);
+  symmetriseAlg->setProperty("XMin", m_eMin);
+  symmetriseAlg->setProperty("XMax", m_eMax);
+  symmetriseAlg->setProperty("OutputWorkspace", m_outputWorkspace);
   symmetriseAlg->setProperty("OutputPropertiesTable", "__SymmetriseProps_temp");
 
   batchAlgoRunner->addAlgorithm(symmetriseAlg);
-  return outputWorkspaceName.toStdString();
+  return m_outputWorkspace;
 }
+
+void IndirectSymmetriseModel::setWorkspaceName(QString workspaceName) {
+  m_inputWorkspace = workspaceName.toStdString();
+  m_outputWorkspace = (workspaceName.left(workspaceName.length() - 4) + "_sym" + workspaceName.right(4)).toStdString();
+}
+
+void IndirectSymmetriseModel::setEMin(double value) { m_eMin = value; }
+
+void IndirectSymmetriseModel::setEMax(double value) { m_eMax = value; }
 
 } // namespace MantidQt::CustomInterfaces

--- a/qt/scientific_interfaces/Indirect/IndirectSymmetriseModel.h
+++ b/qt/scientific_interfaces/Indirect/IndirectSymmetriseModel.h
@@ -1,0 +1,31 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2022 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#pragma once
+
+#include "DllConfig.h"
+#include "IndirectDataValidationHelper.h"
+#include "MantidQtWidgets/Common/BatchAlgorithmRunner.h"
+#include "MantidQtWidgets/Common/QtPropertyBrowser/QtTreePropertyBrowser"
+#include <typeinfo>
+
+using namespace Mantid::API;
+
+namespace MantidQt {
+namespace CustomInterfaces {
+
+class MANTIDQT_INDIRECT_DLL IndirectSymmetriseModel {
+
+public:
+  IndirectSymmetriseModel();
+  ~IndirectSymmetriseModel() = default;
+  void setupPreviewAlgorithm(MantidQt::API::BatchAlgorithmRunner *batchAlgoRunner, QString workspaceName, double eMin,
+                             double eMax, std::vector<long> spectraRange);
+  std::string setupSymmetriseAlgorithm(MantidQt::API::BatchAlgorithmRunner *batchAlgoRunner, QString workspaceName,
+                                       double eMin, double eMax);
+};
+} // namespace CustomInterfaces
+} // namespace MantidQt

--- a/qt/scientific_interfaces/Indirect/IndirectSymmetriseModel.h
+++ b/qt/scientific_interfaces/Indirect/IndirectSymmetriseModel.h
@@ -22,10 +22,19 @@ class MANTIDQT_INDIRECT_DLL IndirectSymmetriseModel {
 public:
   IndirectSymmetriseModel();
   ~IndirectSymmetriseModel() = default;
-  void setupPreviewAlgorithm(MantidQt::API::BatchAlgorithmRunner *batchAlgoRunner, QString workspaceName, double eMin,
-                             double eMax, std::vector<long> spectraRange);
-  std::string setupSymmetriseAlgorithm(MantidQt::API::BatchAlgorithmRunner *batchAlgoRunner, QString workspaceName,
-                                       double eMin, double eMax);
+  void setupPreviewAlgorithm(MantidQt::API::BatchAlgorithmRunner *batchAlgoRunner, std::vector<long> spectraRange);
+  std::string setupSymmetriseAlgorithm(MantidQt::API::BatchAlgorithmRunner *batchAlgoRunner);
+  void setWorkspaceName(QString workspaceName);
+  void setEMin(double value);
+  void setEMax(double value);
+
+private:
+  std::string m_inputWorkspace;
+  std::string m_outputWorkspace;
+  double m_eMin;
+  double m_eMax;
+  std::vector<long> m_spectraRange;
 };
+
 } // namespace CustomInterfaces
 } // namespace MantidQt

--- a/qt/scientific_interfaces/Indirect/IndirectSymmetriseView.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectSymmetriseView.cpp
@@ -37,7 +37,6 @@ namespace MantidQt::CustomInterfaces {
 IndirectSymmetriseView::IndirectSymmetriseView(QWidget *parent) {
   m_uiForm.setupUi(parent);
   m_dblManager = new QtDoublePropertyManager();
-  m_dblEdFac = new DoubleEditorFactory(this);
   m_grpManager = new QtGroupPropertyManager();
 
   m_uiForm.ppRawPlot->setCanvasColour(QColor(240, 240, 240));
@@ -111,7 +110,7 @@ IndirectSymmetriseView::IndirectSymmetriseView(QWidget *parent) {
   // i.e. RS min is X max
 
   auto positiveERaw = m_uiForm.ppRawPlot->addRangeSelector("PositiveE");
-  positiveERaw->setColour(Qt::darkGreen);
+  positiveERaw->setColour(Qt::darkMagenta);
 
   // SIGNAL/SLOT CONNECTIONS
   // Validate the E range when it is changed
@@ -179,9 +178,8 @@ void IndirectSymmetriseView::verifyERange(QtProperty *prop, double value) {
       m_dblManager->setValue(m_properties["EMin"], eMin);
       return;
     }
-
     // If range is still invalid reset EMin to half EMax
-    if (eMin > eMax) {
+    else if (eMin > eMax) {
       m_dblManager->setValue(m_properties["EMin"], eMax / 2);
       return;
     }
@@ -192,9 +190,8 @@ void IndirectSymmetriseView::verifyERange(QtProperty *prop, double value) {
       m_dblManager->setValue(m_properties["EMax"], eMax);
       return;
     }
-
     // If range is invalid reset EMax to double EMin
-    if (eMin > eMax) {
+    else if (eMin > eMax) {
       m_dblManager->setValue(m_properties["EMax"], eMin * 2);
       return;
     }
@@ -218,9 +215,7 @@ void IndirectSymmetriseView::updateRangeSelectors(QtProperty *prop, double value
 
   if (prop == m_properties["EMin"]) {
     positiveERaw->setMinimum(value);
-  }
-
-  if (prop == m_properties["EMax"]) {
+  } else if (prop == m_properties["EMax"]) {
     positiveERaw->setMaximum(value);
   }
 }

--- a/qt/scientific_interfaces/Indirect/IndirectSymmetriseView.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectSymmetriseView.cpp
@@ -1,0 +1,414 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2022 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#include "IndirectSymmetriseView.h"
+#include "IndirectDataValidationHelper.h"
+
+#include "MantidAPI/AlgorithmManager.h"
+#include "MantidAPI/ITableWorkspace.h"
+#include "MantidAPI/MatrixWorkspace.h"
+#include "MantidAPI/WorkspaceGroup.h"
+#include "MantidQtWidgets/Common/UserInputValidator.h"
+#include "MantidQtWidgets/Plotting/SingleSelector.h"
+
+#include <QDoubleValidator>
+#include <QFileInfo>
+
+using namespace IndirectDataValidationHelper;
+using namespace Mantid::API;
+
+namespace {
+double roundToPrecision(double value, double precision) { return value - std::remainder(value, precision); }
+
+std::pair<double, double> roundRangeToPrecision(double rangeStart, double rangeEnd, double width) {
+  return std::make_pair(roundToPrecision(rangeStart, width) + width, roundToPrecision(rangeEnd, width) - width);
+}
+
+QPair<double, double> getXRangeFromWorkspace(const Mantid::API::MatrixWorkspace_const_sptr &workspace) {
+  auto const xValues = workspace->x(0);
+  return QPair<double, double>(xValues.front(), xValues.back());
+}
+} // namespace
+
+using MantidQt::MantidWidgets::AxisID;
+namespace MantidQt::CustomInterfaces {
+
+//----------------------------------------------------------------------------------------------
+/** Constructor
+ */
+IndirectSymmetriseView::IndirectSymmetriseView(QWidget *parent) {
+  m_uiForm.setupUi(parent);
+  m_dblManager = new QtDoublePropertyManager();
+  m_dblEdFac = new DoubleEditorFactory(this);
+  m_grpManager = new QtGroupPropertyManager();
+
+  m_uiForm.ppRawPlot->setCanvasColour(QColor(240, 240, 240));
+  m_uiForm.ppPreviewPlot->setCanvasColour(QColor(240, 240, 240));
+
+  int numDecimals = 6;
+
+  // Property Trees
+  m_propTrees["SymmPropTree"] = new QtTreePropertyBrowser();
+  m_uiForm.properties->addWidget(m_propTrees["SymmPropTree"]);
+
+  m_propTrees["SymmPVPropTree"] = new QtTreePropertyBrowser();
+  m_uiForm.propertiesPreview->addWidget(m_propTrees["SymmPVPropTree"]);
+
+  // Editor Factories
+  auto *doubleEditorFactory = new DoubleEditorFactory();
+  m_propTrees["SymmPropTree"]->setFactoryForManager(m_dblManager, doubleEditorFactory);
+
+  // Raw Properties
+  m_properties["EMin"] = m_dblManager->addProperty("EMin");
+  m_dblManager->setDecimals(m_properties["EMin"], numDecimals);
+  m_propTrees["SymmPropTree"]->addProperty(m_properties["EMin"]);
+  m_properties["EMax"] = m_dblManager->addProperty("EMax");
+  m_dblManager->setDecimals(m_properties["EMax"], numDecimals);
+  m_propTrees["SymmPropTree"]->addProperty(m_properties["EMax"]);
+
+  QtProperty *rawPlotProps = m_grpManager->addProperty("Raw Plot");
+  m_propTrees["SymmPropTree"]->addProperty(rawPlotProps);
+
+  m_properties["PreviewSpec"] = m_dblManager->addProperty("Spectrum No");
+  m_dblManager->setDecimals(m_properties["PreviewSpec"], 0);
+  rawPlotProps->addSubProperty(m_properties["PreviewSpec"]);
+
+  // Preview Properties
+  // Mainly used for display rather than getting user input
+  m_properties["NegativeYValue"] = m_dblManager->addProperty("Negative Y");
+  m_dblManager->setDecimals(m_properties["NegativeYValue"], numDecimals);
+  m_propTrees["SymmPVPropTree"]->addProperty(m_properties["NegativeYValue"]);
+
+  m_properties["PositiveYValue"] = m_dblManager->addProperty("Positive Y");
+  m_dblManager->setDecimals(m_properties["PositiveYValue"], numDecimals);
+  m_propTrees["SymmPVPropTree"]->addProperty(m_properties["PositiveYValue"]);
+
+  m_properties["DeltaY"] = m_dblManager->addProperty("Delta Y");
+  m_dblManager->setDecimals(m_properties["DeltaY"], numDecimals);
+  m_propTrees["SymmPVPropTree"]->addProperty(m_properties["DeltaY"]);
+
+  auto const xLimits = m_uiForm.ppRawPlot->getAxisRange(AxisID::XBottom);
+  auto const yLimits = m_uiForm.ppRawPlot->getAxisRange(AxisID::YLeft);
+
+  // Indicators for Y value at each EMin position
+  auto negativeEMinYPos =
+      m_uiForm.ppRawPlot->addSingleSelector("NegativeEMinYPos", MantidWidgets::SingleSelector::YSINGLE, 0.0);
+  negativeEMinYPos->setColour(Qt::blue);
+  negativeEMinYPos->setBounds(std::get<0>(yLimits), std::get<1>(yLimits));
+
+  auto positiveEMinYPos =
+      m_uiForm.ppRawPlot->addSingleSelector("PositiveEMinYPos", MantidWidgets::SingleSelector::YSINGLE, 1.0);
+  positiveEMinYPos->setColour(Qt::red);
+  positiveEMinYPos->setBounds(std::get<0>(yLimits), std::get<1>(yLimits));
+
+  // Indicator for centre of symmetry (x=0)
+  auto centreMarkRaw = m_uiForm.ppRawPlot->addSingleSelector("CentreMark", MantidWidgets::SingleSelector::XSINGLE, 0.0);
+  centreMarkRaw->setColour(Qt::cyan);
+  centreMarkRaw->setBounds(std::get<0>(xLimits), std::get<1>(xLimits));
+
+  // Indicators for negative and positive X range values on X axis
+  // The user can use these to move the X range
+  // Note that the max and min of the negative range selector corespond to the
+  // opposite X value
+  // i.e. RS min is X max
+
+  auto positiveERaw = m_uiForm.ppRawPlot->addRangeSelector("PositiveE");
+  positiveERaw->setColour(Qt::darkGreen);
+
+  // SIGNAL/SLOT CONNECTIONS
+  // Validate the E range when it is changed
+  connect(m_dblManager, SIGNAL(valueChanged(QtProperty *, double)), this, SLOT(verifyERange(QtProperty *, double)));
+  // Plot miniplot when file has finished loading
+  connect(m_uiForm.dsInput, SIGNAL(dataReady(QString const &)), this, SIGNAL(dataReady(QString const &)));
+  // Preview symmetrise
+  connect(m_uiForm.pbPreview, SIGNAL(clicked()), this, SIGNAL(previewClicked()));
+  // X range selectors
+  connect(positiveERaw, SIGNAL(minValueChanged(double)), this, SLOT(xRangeMinChanged(double)));
+  connect(positiveERaw, SIGNAL(maxValueChanged(double)), this, SLOT(xRangeMaxChanged(double)));
+  // Handle running, plotting and saving
+  connect(m_uiForm.pbRun, SIGNAL(clicked()), this, SIGNAL(runClicked()));
+  connect(m_uiForm.pbSave, SIGNAL(clicked()), this, SIGNAL(saveClicked()));
+
+  connect(this, SIGNAL(updateRunButton(bool, std::string const &, QString const &, QString const &)), this,
+          SLOT(updateRunButton(bool, std::string const &, QString const &, QString const &)));
+
+  // Set default X range values
+  m_dblManager->setValue(m_properties["EMax"], 0.5);
+  m_dblManager->setValue(m_properties["EMin"], 0.1);
+
+  // Set default x axis range
+  QPair<double, double> defaultRange(-1.0, 1.0);
+  m_uiForm.ppRawPlot->setAxisRange(defaultRange, AxisID::XBottom);
+  m_uiForm.ppPreviewPlot->setAxisRange(defaultRange, AxisID::XBottom);
+
+  // Disable run until preview is clicked
+  m_uiForm.pbRun->setEnabled(false);
+  m_uiForm.pbPreview->setEnabled(false);
+
+  // Allows empty workspace selector when initially selected
+  m_uiForm.dsInput->isOptional(true);
+
+  // Disables searching for run files in the data archive
+  m_uiForm.dsInput->isForRunFiles(false);
+}
+
+//----------------------------------------------------------------------------------------------
+/** Destructor
+ */
+IndirectSymmetriseView::~IndirectSymmetriseView() {}
+
+IndirectPlotOptionsView *IndirectSymmetriseView::getPlotOptions() { return m_uiForm.ipoPlotOptions; }
+
+/**
+ * Verifies that the E Range is valid.
+ *
+ * @param prop QtProperty changed
+ * @param value Value it was changed to (unused)
+ */
+void IndirectSymmetriseView::verifyERange(QtProperty *prop, double value) {
+  UNUSED_ARG(value);
+
+  double eMin = m_dblManager->value(m_properties["EMin"]);
+  double eMax = m_dblManager->value(m_properties["EMax"]);
+
+  if (prop == m_properties["EMin"]) {
+    // If the value of EMin is negative try negating it to get a valid range
+    if (eMin < 0) {
+      eMin = -eMin;
+      m_dblManager->setValue(m_properties["EMin"], eMin);
+      return;
+    }
+
+    // If range is still invalid reset EMin to half EMax
+    if (eMin > eMax) {
+      m_dblManager->setValue(m_properties["EMin"], eMax / 2);
+      return;
+    }
+  } else if (prop == m_properties["EMax"]) {
+    // If the value of EMax is negative try negating it to get a valid range
+    if (eMax < 0) {
+      eMax = -eMax;
+      m_dblManager->setValue(m_properties["EMax"], eMax);
+      return;
+    }
+
+    // If range is invalid reset EMax to double EMin
+    if (eMin > eMax) {
+      m_dblManager->setValue(m_properties["EMax"], eMin * 2);
+      return;
+    }
+  }
+
+  // If we get this far then the E range is valid
+  // Update the range selectors with the new values.
+  updateRangeSelectors(prop, value);
+}
+
+/**
+ * Updates position of XCut range selectors when used changed value of XCut.
+ *
+ * @param prop QtProperty changed
+ * @param value Value it was changed to (unused)
+ */
+void IndirectSymmetriseView::updateRangeSelectors(QtProperty *prop, double value) {
+  auto positiveERaw = m_uiForm.ppRawPlot->getRangeSelector("PositiveE");
+
+  value = fabs(value);
+
+  if (prop == m_properties["EMin"]) {
+    positiveERaw->setMinimum(value);
+  }
+
+  if (prop == m_properties["EMax"]) {
+    positiveERaw->setMaximum(value);
+  }
+}
+
+/**
+ * Handles the X minimum value being changed from a range selector.
+ *
+ * @param value New range selector value
+ */
+void IndirectSymmetriseView::xRangeMinChanged(double value) {
+  auto positiveERaw = m_uiForm.ppRawPlot->getRangeSelector("PositiveE");
+
+  MantidWidgets::RangeSelector *from = qobject_cast<MantidWidgets::RangeSelector *>(sender());
+
+  m_dblManager->setValue(m_properties["EMin"], std::abs(value));
+  m_uiForm.pbPreview->setEnabled(true);
+}
+
+/**
+ * Handles the X maximum value being changed from a range selector.
+ *
+ * @param value New range selector value
+ */
+void IndirectSymmetriseView::xRangeMaxChanged(double value) {
+  auto positiveERaw = m_uiForm.ppRawPlot->getRangeSelector("PositiveE");
+
+  MantidWidgets::RangeSelector *from = qobject_cast<MantidWidgets::RangeSelector *>(sender());
+
+  m_dblManager->setValue(m_properties["EMax"], std::abs(value));
+  m_uiForm.pbPreview->setEnabled(true);
+}
+
+void IndirectSymmetriseView::updateRunButton(bool enabled, std::string const &enableOutputButtons,
+                                             QString const &message, QString const &tooltip) {
+  setRunEnabled(enabled);
+  m_uiForm.pbRun->setText(message);
+  m_uiForm.pbRun->setToolTip(tooltip);
+  if (enableOutputButtons != "unchanged")
+    setSaveEnabled(enableOutputButtons == "enable");
+}
+
+void IndirectSymmetriseView::setRunEnabled(bool enabled) { m_uiForm.pbRun->setEnabled(enabled); }
+
+void IndirectSymmetriseView::setSaveEnabled(bool enabled) { m_uiForm.pbSave->setEnabled(enabled); }
+
+void IndirectSymmetriseView::setFBSuffixes(QStringList const suffix) { m_uiForm.dsInput->setFBSuffixes(suffix); }
+
+void IndirectSymmetriseView::setWSSuffixes(QStringList const suffix) { m_uiForm.dsInput->setWSSuffixes(suffix); }
+
+/**
+ * Plots a new workspace in the mini plot when it is loaded form the data
+ *selector.
+ *
+ * @param workspaceName Name of the workspace that has been loaded
+ */
+void IndirectSymmetriseView::plotNewData(QString const &workspaceName) {
+  // Set the preview spectrum number to the first spectrum in the workspace
+  auto sampleWS = AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(workspaceName.toStdString());
+  int minSpectrumRange = sampleWS->getSpectrum(0).getSpectrumNo();
+  m_dblManager->setValue(m_properties["PreviewSpec"], static_cast<double>(minSpectrumRange));
+
+  updateMiniPlots();
+
+  // Set the preview range to the maximum absolute X value
+  auto const axisRange = getXRangeFromWorkspace(sampleWS);
+  double symmRange = std::max(fabs(axisRange.first), fabs(axisRange.second));
+
+  // Set valid range for range selectors
+  auto positiveESelector = m_uiForm.ppRawPlot->getRangeSelector("PositiveE");
+  positiveESelector->setBounds(axisRange.first, axisRange.second);
+  positiveESelector->setRange(0, symmRange);
+
+  // Set some default (and valid) values for E range
+  m_dblManager->setValue(m_properties["EMax"], axisRange.second);
+  m_dblManager->setValue(m_properties["EMin"], axisRange.second / 10);
+
+  updateMiniPlots();
+
+  auto const xLimits = m_uiForm.ppRawPlot->getAxisRange(AxisID::XBottom);
+  auto const yLimits = m_uiForm.ppRawPlot->getAxisRange(AxisID::YLeft);
+
+  // Set indicator positions
+  auto negativeEMinYPos = m_uiForm.ppRawPlot->getSingleSelector("NegativeEMinYPos");
+  negativeEMinYPos->setBounds(std::get<0>(yLimits), std::get<1>(yLimits));
+
+  auto positiveEMinYPos = m_uiForm.ppRawPlot->getSingleSelector("PositiveEMinYPos");
+  positiveEMinYPos->setBounds(std::get<0>(yLimits), std::get<1>(yLimits));
+
+  auto centreMarkRaw = m_uiForm.ppRawPlot->getSingleSelector("CentreMark");
+  centreMarkRaw->setBounds(std::get<0>(xLimits), std::get<1>(xLimits));
+}
+
+/**
+ * Updates the mini plots.
+ */
+void IndirectSymmetriseView::updateMiniPlots() {
+  if (!m_uiForm.dsInput->isValid())
+    return;
+
+  QString workspaceName = m_uiForm.dsInput->getCurrentDataName();
+  int spectrumNumber = static_cast<int>(m_dblManager->value(m_properties["PreviewSpec"]));
+
+  Mantid::API::MatrixWorkspace_sptr input =
+      AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(workspaceName.toStdString());
+
+  // Plot the spectrum chosen by the user
+  size_t spectrumIndex = input->getIndexFromSpectrumNumber(spectrumNumber);
+  m_uiForm.ppRawPlot->clear();
+  m_uiForm.ppRawPlot->addSpectrum("Raw", input, spectrumIndex);
+
+  // Match X axis range on preview plot
+  auto const axisRange = getXRangeFromWorkspace(input);
+  m_uiForm.ppPreviewPlot->setAxisRange(axisRange, AxisID::XBottom);
+  m_uiForm.ppPreviewPlot->replot();
+}
+
+bool IndirectSymmetriseView::validate() {
+  UserInputValidator uiv;
+  validateDataIsOfType(uiv, m_uiForm.dsInput, "Sample", DataType::Red);
+
+  // EMin and EMax must be positive
+  if (m_dblManager->value(m_properties["EMin"]) <= 0.0)
+    uiv.addErrorMessage("EMin must be positive.");
+  if (m_dblManager->value(m_properties["EMax"]) <= 0.0)
+    uiv.addErrorMessage("EMax must be positive.");
+
+  auto const errorMessage = uiv.generateErrorMessage();
+  if (!errorMessage.isEmpty())
+    showMessageBox(errorMessage);
+  return errorMessage.isEmpty();
+}
+
+void IndirectSymmetriseView::setRawPlotWatchADS(bool watchADS) { m_uiForm.ppRawPlot->watchADS(watchADS); }
+
+double IndirectSymmetriseView::getEMin() { return m_dblManager->value(m_properties["EMin"]); }
+
+double IndirectSymmetriseView::getEMax() { return m_dblManager->value(m_properties["EMax"]); }
+
+double IndirectSymmetriseView::getPreviewSpec() { return m_dblManager->value(m_properties["PreviewSpec"]); }
+
+QString IndirectSymmetriseView::getInputName() { return m_uiForm.dsInput->getCurrentDataName(); }
+
+void IndirectSymmetriseView::previewAlgDone() {
+  QString workspaceName = getInputName();
+  int spectrumNumber = static_cast<int>(m_dblManager->value(m_properties["PreviewSpec"]));
+
+  MatrixWorkspace_sptr sampleWS =
+      AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>(workspaceName.toStdString());
+  ITableWorkspace_sptr propsTable =
+      AnalysisDataService::Instance().retrieveWS<ITableWorkspace>("__SymmetriseProps_temp");
+  MatrixWorkspace_sptr symmWS = AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>("__Symmetrise_temp");
+
+  // Get the index of XCut on each side of zero
+  int negativeIndex = propsTable->getColumn("NegativeXMinIndex")->cell<int>(0);
+  int positiveIndex = propsTable->getColumn("PositiveXMinIndex")->cell<int>(0);
+
+  // Get the Y values for each XCut and the difference between them
+  double negativeY = sampleWS->y(0)[negativeIndex];
+  double positiveY = sampleWS->y(0)[positiveIndex];
+  double deltaY = fabs(negativeY - positiveY);
+
+  // Show values in property tree
+  m_dblManager->setValue(m_properties["NegativeYValue"], negativeY);
+  m_dblManager->setValue(m_properties["PositiveYValue"], positiveY);
+  m_dblManager->setValue(m_properties["DeltaY"], deltaY);
+
+  auto const yLimits = m_uiForm.ppRawPlot->getAxisRange(AxisID::YLeft);
+  // Set indicator positions
+  auto const negativeEMinYPos = m_uiForm.ppRawPlot->getSingleSelector("NegativeEMinYPos");
+  negativeEMinYPos->setBounds(std::get<0>(yLimits), std::get<1>(yLimits));
+  negativeEMinYPos->setPosition(negativeY);
+
+  auto const positiveEMinYPos = m_uiForm.ppRawPlot->getSingleSelector("PositiveEMinYPos");
+  positiveEMinYPos->setBounds(std::get<0>(yLimits), std::get<1>(yLimits));
+  positiveEMinYPos->setPosition(positiveY);
+
+  // Plot preview plot
+  size_t spectrumIndex = symmWS->getIndexFromSpectrumNumber(spectrumNumber);
+  m_uiForm.ppPreviewPlot->clear();
+  m_uiForm.ppPreviewPlot->addSpectrum("Symmetrised", "__Symmetrise_temp", spectrumIndex);
+
+  m_uiForm.ppRawPlot->watchADS(true);
+}
+
+void IndirectSymmetriseView::enableSave(bool save) { m_uiForm.pbSave->setEnabled(save); }
+
+void IndirectSymmetriseView::enableRun(bool run) { m_uiForm.pbRun->setEnabled(run); }
+
+} // namespace MantidQt::CustomInterfaces

--- a/qt/scientific_interfaces/Indirect/IndirectSymmetriseView.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectSymmetriseView.cpp
@@ -122,7 +122,7 @@ IndirectSymmetriseView::IndirectSymmetriseView(QWidget *parent) {
   // Validate the E range when it is changed
   connect(m_dblManager, SIGNAL(valueChanged(QtProperty *, double)), this, SLOT(verifyERange(QtProperty *, double)));
   // Plot miniplot when file has finished loading
-  connect(m_uiForm.dsInput, SIGNAL(dataReady(QString const &)), this, SIGNAL(dataReady(QString const &)));
+  connect(m_uiForm.dsInput, SIGNAL(dataReady(QString const &)), this, SLOT(handleDataReady(QString const &)));
   // Preview symmetrise
   connect(m_uiForm.pbPreview, SIGNAL(clicked()), this, SIGNAL(previewClicked()));
   // X range selectors
@@ -161,6 +161,17 @@ IndirectSymmetriseView::IndirectSymmetriseView(QWidget *parent) {
 IndirectSymmetriseView::~IndirectSymmetriseView() {}
 
 IndirectPlotOptionsView *IndirectSymmetriseView::getPlotOptions() { return m_uiForm.ipoPlotOptions; }
+
+/**
+ * Handles the event of data being loaded. Validates the loaded data.
+ *
+ * @param dataName The name of the data that has been loaded
+ */
+void IndirectSymmetriseView::handleDataReady(QString const &dataName) {
+  if (validate()) {
+    plotNewData(dataName);
+  }
+}
 
 /**
  * Verifies that the E Range is valid.

--- a/qt/scientific_interfaces/Indirect/IndirectSymmetriseView.h
+++ b/qt/scientific_interfaces/Indirect/IndirectSymmetriseView.h
@@ -22,7 +22,7 @@ class MANTIDQT_INDIRECT_DLL IndirectSymmetriseView : public QWidget {
 public:
   IndirectSymmetriseView(QWidget *perent = nullptr);
   ~IndirectSymmetriseView();
-
+  void setDefaults();
   IndirectPlotOptionsView *getPlotOptions();
   void setFBSuffixes(QStringList const suffix);
   void setWSSuffixes(QStringList const suffix);
@@ -38,6 +38,8 @@ public:
   void enableSave(bool save);
   void enableRun(bool save);
   void updateRangeSelectors(QtProperty *prop, double value);
+  void replotNewSpectrum(double value);
+  void verifyERange(QtProperty *prop, double value);
 
 public slots:
   void updateRunButton(bool enabled = true, std::string const &enableOutputButtons = "unchanged",
@@ -52,10 +54,8 @@ signals:
   void showMessageBox(const QString &message);
 
 private slots:
-  void verifyERange(QtProperty *prop, double value);
   void xRangeMaxChanged(double value);
   void xRangeMinChanged(double value);
-  void handleDataReady(QString const &dataName);
 
 private:
   void setRunEnabled(bool enabled);

--- a/qt/scientific_interfaces/Indirect/IndirectSymmetriseView.h
+++ b/qt/scientific_interfaces/Indirect/IndirectSymmetriseView.h
@@ -66,7 +66,6 @@ private:
   std::map<QString, QtTreePropertyBrowser *> m_propTrees;
   /// Internal list of the properties
   QMap<QString, QtProperty *> m_properties;
-  DoubleEditorFactory *m_dblEdFac;
   QtDoublePropertyManager *m_dblManager;
   QtGroupPropertyManager *m_grpManager;
 };

--- a/qt/scientific_interfaces/Indirect/IndirectSymmetriseView.h
+++ b/qt/scientific_interfaces/Indirect/IndirectSymmetriseView.h
@@ -55,6 +55,7 @@ private slots:
   void verifyERange(QtProperty *prop, double value);
   void xRangeMaxChanged(double value);
   void xRangeMinChanged(double value);
+  void handleDataReady(QString const &dataName);
 
 private:
   void setRunEnabled(bool enabled);

--- a/qt/scientific_interfaces/Indirect/IndirectSymmetriseView.h
+++ b/qt/scientific_interfaces/Indirect/IndirectSymmetriseView.h
@@ -11,58 +11,63 @@
 #include "MantidQtWidgets/Common/QtPropertyBrowser/QtTreePropertyBrowser"
 #include "MantidQtWidgets/Common/QtPropertyBrowser/qtpropertymanager.h"
 #include "MantidQtWidgets/Plotting/RangeSelector.h"
-#include "ui_IndirectSqw.h"
+#include "ui_IndirectSymmetrise.h"
 
 namespace MantidQt {
 namespace CustomInterfaces {
 
-class MANTIDQT_INDIRECT_DLL IndirectSqwView : public QWidget {
+class MANTIDQT_INDIRECT_DLL IndirectSymmetriseView : public QWidget {
   Q_OBJECT
 
 public:
-  IndirectSqwView(QWidget *perent = nullptr);
-  ~IndirectSqwView();
+  IndirectSymmetriseView(QWidget *perent = nullptr);
+  ~IndirectSymmetriseView();
 
   IndirectPlotOptionsView *getPlotOptions();
-  void setFBSuffixes(QStringList suffix);
-  void setWSSuffixes(QStringList suffix);
-  std::tuple<double, double> getQRangeFromPlot();
-  std::tuple<double, double> getERangeFromPlot();
-  std::string getDataName();
-  void plotRqwContour(Mantid::API::MatrixWorkspace_sptr rqwWorkspace);
-  void setDefaultQAndEnergy();
-  void setSaveEnabled(bool enabled);
+  void setFBSuffixes(QStringList const suffix);
+  void setWSSuffixes(QStringList const suffix);
+  void plotNewData(QString const &workspaceName);
+  void updateMiniPlots();
   bool validate();
+  void setRawPlotWatchADS(bool watchADS);
+  double getEMin();
+  double getEMax();
+  double getPreviewSpec();
+  QString getInputName();
+  void previewAlgDone();
+  void enableSave(bool save);
+  void enableRun(bool save);
+  void updateRangeSelectors(QtProperty *prop, double value);
+
+public slots:
+  void updateRunButton(bool enabled = true, std::string const &enableOutputButtons = "unchanged",
+                       QString const &message = "Run", QString const &tooltip = "");
 
 signals:
   void valueChanged(QtProperty *, double);
   void dataReady(QString const &);
-  void qLowChanged(double);
-  void qWidthChanged(double);
-  void qHighChanged(double);
-  void eLowChanged(double);
-  void eWidthChanged(double);
-  void eHighChanged(double);
-  void rebinEChanged(int);
+  void previewClicked();
   void runClicked();
   void saveClicked();
   void showMessageBox(const QString &message);
 
-public slots:
-  void updateRunButton(bool enabled, std::string const &enableOutputButtons, QString const &message,
-                       QString const &tooltip);
+private slots:
+  void verifyERange(QtProperty *prop, double value);
+  void xRangeMaxChanged(double value);
+  void xRangeMinChanged(double value);
 
 private:
-  void setQRange(std::tuple<double, double> const &axisRange);
-  void setEnergyRange(std::tuple<double, double> const &axisRange);
-
   void setRunEnabled(bool enabled);
-  Ui::IndirectSqw m_uiForm;
+  void setSaveEnabled(bool enabled);
+  Ui::IndirectSymmetrise m_uiForm;
 
   /// Tree of the properties
   std::map<QString, QtTreePropertyBrowser *> m_propTrees;
   /// Internal list of the properties
   QMap<QString, QtProperty *> m_properties;
+  DoubleEditorFactory *m_dblEdFac;
+  QtDoublePropertyManager *m_dblManager;
+  QtGroupPropertyManager *m_grpManager;
 };
 } // namespace CustomInterfaces
 } // namespace MantidQt

--- a/qt/scientific_interfaces/Indirect/test/CMakeLists.txt
+++ b/qt/scientific_interfaces/Indirect/test/CMakeLists.txt
@@ -24,6 +24,7 @@ set(TEST_FILES
     IndirectSettingsModelTest.h
     IndirectSettingsPresenterTest.h
     IndirectSqwModelTest.h
+    IndirectSymmetriseModelTest.h
     IqtFitModelTest.h
 )
 

--- a/qt/scientific_interfaces/Indirect/test/IndirectMomentsModelTest.h
+++ b/qt/scientific_interfaces/Indirect/test/IndirectMomentsModelTest.h
@@ -23,7 +23,7 @@ public:
   void setUp() override { m_model = std::make_unique<IndirectMomentsModel>(); }
 
   void test_algorrithm_set_up() {
-    // The Moments algorithm is a python algorithm and so can not be called in
+    // The Moments algorithm is a python algorithm and so can not be called in c++ tests
     m_workspace = WorkspaceCreationHelper::create2DWorkspace(5, 4);
     Mantid::API::AnalysisDataService::Instance().addOrReplace("Workspace_name_sqw", m_workspace);
     m_model->setInputWorkspace("Workspace_name_sqw");

--- a/qt/scientific_interfaces/Indirect/test/IndirectSymmetriseModelTest.h
+++ b/qt/scientific_interfaces/Indirect/test/IndirectSymmetriseModelTest.h
@@ -1,0 +1,40 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2019 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#pragma once
+
+#include "IndirectDataValidationHelper.h"
+#include "IndirectSymmetriseModel.h"
+#include "MantidAPI/AnalysisDataService.h"
+#include "MantidFrameworkTestHelpers/WorkspaceCreationHelper.h"
+#include <cxxtest/TestSuite.h>
+#include <gmock/gmock.h>
+
+using namespace MantidQt::CustomInterfaces;
+
+class IndirectSymmetriseModelTest : public CxxTest::TestSuite {
+public:
+  /// Needed to make sure everything is initialized
+  IndirectSymmetriseModelTest() = default;
+
+  void setUp() override { m_model = std::make_unique<IndirectSymmetriseModel>(); }
+
+  void tearDown() override { AnalysisDataService::Instance().clear(); }
+
+  void test_setupPropertiesAlgorithm() {
+    QString inputWS = "Workspace_name_red";
+    m_workspace = WorkspaceCreationHelper::createProcessedWorkspaceWithCylComplexInstrument(5, 6, true);
+    Mantid::API::AnalysisDataService::Instance().addOrReplace(inputWS.toStdString(), m_workspace);
+    MantidQt::API::BatchAlgorithmRunner batch;
+    m_model->setEMin(0.05);
+    m_model->setEMax(0.6);
+    m_model->setWorkspaceName(inputWS);
+  }
+
+private:
+  MatrixWorkspace_sptr m_workspace;
+  std::unique_ptr<IndirectSymmetriseModel> m_model;
+};


### PR DESCRIPTION
This PR changes the Indirect Symmetrise tab to follow MVP format

**To test:**

1. Open the Indirect Data Reduction Tab and go to the symmetrise tab. 
2. Load a _red data file.
3. click preview and the second preview plot should be filled.
4. change the values in the table, the marker lines should change with them.
5. change the markers and the values in the table should also change.
6. change the spectrum number and the plot shouldchange to reflect that.
7. click preview again, the plot should refresh with the new previewed attempt.
8. click run.

Fixes #33677 

*This does not require release n

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
