### PR TITLE
Update developer ymls for sphinx bootstrap theme

### DIFF
--- a/mantid-developer-linux.yml
+++ b/mantid-developer-linux.yml
@@ -41,7 +41,7 @@ dependencies:
   - scipy>=1.6.2
   - setuptools=47.0.0 # Pinned purposefully due to incompatibility with later versions
   - sphinx >= 4.5.*
-  - sphinx_bootstrap_theme<=0.7.1
+  - sphinx_bootstrap_theme>=0.8.1
   - tbb-devel=2020.2.*
   - tbb=2020.2.*
   - texlive-core>=20180414

--- a/mantid-developer-osx.yml
+++ b/mantid-developer-osx.yml
@@ -41,7 +41,7 @@ dependencies:
   - scipy>=1.6.2
   - setuptools=47.0.0 # Pinned purposefully due to incompatibility with later versions
   - sphinx >= 4.5.*
-  - sphinx_bootstrap_theme<=0.7.1
+  - sphinx_bootstrap_theme=>0.8.1
   - tbb-devel=2020.2.*
   - tbb=2020.2.*
   - texlive-core>=20180414

--- a/mantid-developer-win.yml
+++ b/mantid-developer-win.yml
@@ -42,7 +42,7 @@ dependencies:
   - scipy>=1.6.2
   - setuptools=47.0.0 # Pinned purposefully due to incompatibility with later versions
   - sphinx >= 4.5.*
-  - sphinx_bootstrap_theme<=0.7.1
+  - sphinx_bootstrap_theme=>0.8.1
   - tbb-devel=2020.2.*
   - tbb=2020.2.*
   - toml>=0.10.2


### PR DESCRIPTION
**Description of work.**

This changes the pinning of the sphinx bootstrap theme in the developer .yml files. We need to upgrade it to a more recent version to try and resolve problems with the website (see #34584 ) for more details.

**To test:**
1. After pulling the branch update your conda environment e.g. for Windows you might run `conda env update -f mantid-developer-win.yml --prune`
2. Delete the docs folder in your build folder (the ensure a clean version)
3. Do a CMake build
4. Build the docs
5. Try looking at different pages including at least one algorithm page with maths equations (e.g. Rebin or Discus Multiple Scattering). Pages should render correctly without error
6.  Use the search box in the top right hand corner of the page. This should work with no issues.

- this is a part fix towards resolving #34584

I'm not sure this requires a release note as it is a change to developer .yml files. What do you think @martyngigg ?


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
