### PR TITLE
Formatting of property values in the history

### DIFF
--- a/docs/source/release/v6.6.0/Workbench/Bugfixes/34597.rst
+++ b/docs/source/release/v6.6.0/Workbench/Bugfixes/34597.rst
@@ -1,0 +1,1 @@
+- Fixed a bug where property values were shortened in history

--- a/qt/widgets/common/src/AlgorithmHistoryWindow.cpp
+++ b/qt/widgets/common/src/AlgorithmHistoryWindow.cpp
@@ -511,6 +511,7 @@ AlgHistoryProperties::AlgHistoryProperties(QWidget *w, std::vector<PropertyHisto
         << "";
 
   m_histpropTree = new QTreeWidget(w);
+  m_histpropTree->setTextElideMode(Qt::ElideMiddle);
   m_histpropTree->setColumnCount(5);
   m_histpropTree->setSelectionMode(QAbstractItemView::NoSelection);
   m_histpropTree->setHeaderLabels(hList);
@@ -575,7 +576,7 @@ void AlgHistoryProperties::displayAlgHistoryProperties() {
     sProperty = (*pIter)->name();
     propList.append(sProperty.c_str());
 
-    sProperty = Strings::shorten((*pIter)->value(), 40);
+    sProperty = (*pIter)->value();
     bool bisDefault = (*pIter)->isDefault();
     if (bisDefault == true) {
       if ((*pIter)->isEmptyDefault()) {


### PR DESCRIPTION
**Description of work.**

The property values are shortened to a 40 characters string when written in the history. This PR moves this formatting issue into the Qt layer.

**To test:**

You can use any Mantid Algorithm with a long parameter value (more than 40 characters). Example here with `CreateSampleWorkspace`:
```python
from mantid.simpleapi import CreateSampleWorkspace

CreateSampleWorkspace(OutputWorkspace="veryyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyylonnnnnnnnnnnnnnnnnnnnnnnnnngnaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaame")
```
Without the fix, the value of the workspace name property was shortened in the history. Extending the column size does not help:

![prop_values](https://user-images.githubusercontent.com/35613913/197178006-cfc06984-f37a-4952-af08-31fd15fcf896.png)

Copy-pasting uses the shortened value as well:
```
veryyyyyyyyyyyyyy ... aaaaaaaaaaaaaaame
```

With the fix, the value in not changed, only its formatting.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
