### PR TITLE
Avoid unnecessary update of waterfall plots

### DIFF
--- a/Framework/PythonInterface/mantid/plots/mantidaxes.py
+++ b/Framework/PythonInterface/mantid/plots/mantidaxes.py
@@ -348,6 +348,8 @@ class MantidAxes(Axes):
         :param predicate: A unary predicate used to select artists.
         :return: The output of the inner function.
         """
+        if workspace.name() not in self.tracked_workspaces:
+            return False
         waterfall_x_offset = copy.copy(self.waterfall_x_offset)
         waterfall_y_offset = copy.copy(self.waterfall_y_offset)
         has_fills = self.waterfall_has_fill()

--- a/docs/source/release/v6.6.0/Workbench/Bugfixes/34609.rst
+++ b/docs/source/release/v6.6.0/Workbench/Bugfixes/34609.rst
@@ -1,0 +1,1 @@
+- Fixed a bug where waterfall plots were updated unconditionally during ADS updates


### PR DESCRIPTION
**Description of work.**

Any workflow doing updates of ADS were slowed down by a open waterfall plot. This was due to an unconditional update of waterfall plots on every workspace modification.

This PR adds a check to verify whether it is necessary to update the plot before actually updating it.

**To test:**

* Create a sample workspace:
```python
from mantid.simpleapi import CreateSampleWorkspace
CreateSampleWorkspace(OutputWorkspace="waterfall")
```

* Plot it as waterfall. Selecting a large number of spectra to be plotted makes the issue more obvious.
* Run the following script and observe the update of the plot:
```python
from mantid.simpleapi import CreateSampleWorkspace, DeleteWorkspace
for i in range(1, 100):
    CreateSampleWorkspace(OutputWorkspace="ws")
    DeleteWorkspace("ws")
```

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
