### PR TITLE
Fixed duplicate lowercase load an rebin algorithms in the algorithms tab

### DIFF
--- a/Framework/API/src/AlgorithmFactory.cpp
+++ b/Framework/API/src/AlgorithmFactory.cpp
@@ -11,6 +11,7 @@
 #include "MantidAPI/Algorithm.h"
 #include "MantidKernel/ConfigService.h"
 #include "MantidKernel/LibraryManager.h"
+#include <algorithm>
 #include <boost/algorithm/string.hpp>
 #include <memory>
 #include <sstream>
@@ -387,12 +388,13 @@ std::vector<AlgorithmDescriptor> AlgorithmFactoryImpl::getDescriptors(bool inclu
         res.emplace_back(desc);
         // Add alias to results if included
         if (!desc.alias.empty() && includeAliases) {
-          /*AlgorithmDescriptor aliasDesc;
-          aliasDesc.name = desc.alias;
-          aliasDesc.category = desc.category;
-          aliasDesc.version = desc.version;
-          res.emplace_back(aliasDesc);*/
-          res.emplace_back(AlgorithmDescriptor{desc.alias, desc.version, desc.category, ""});
+          // Avoid adding lowercase aliases to the algorithm tab
+          std::string lowerCaseName = desc.name;
+          std::transform(desc.name.cbegin(), desc.name.cend(), lowerCaseName.begin(),
+                         [](unsigned char c) { return std::tolower(c); });
+          if (lowerCaseName != desc.alias) {
+            res.emplace_back(AlgorithmDescriptor{desc.alias, desc.version, desc.category, ""});
+          }
         }
       }
     }

--- a/Framework/API/test/AlgorithmFactoryTest.h
+++ b/Framework/API/test/AlgorithmFactoryTest.h
@@ -267,6 +267,26 @@ public:
     algFactory.unsubscribe("ToyAlgorithm", 1);
   }
 
+  void testLowerCaseAlliasesAreNotAddedToDescriptions() {
+    auto &algFactory = AlgorithmFactory::Instance();
+    algFactory.subscribe<LowerCaseAliasAlgorithm>();
+    std::vector<AlgorithmDescriptor> descriptors;
+    descriptors = algFactory.getDescriptors(false, true);
+
+    auto resAlg = std::find_if(descriptors.cbegin(), descriptors.cend(), [](const AlgorithmDescriptor &d) {
+      return (("Lower" == d.name) && ("lower" == d.alias) && (1 == d.version));
+    });
+
+    auto resAlias = std::find_if(descriptors.cbegin(), descriptors.cend(), [](const AlgorithmDescriptor &d) {
+      return (("lower" == d.name) && ("" == d.alias) && (1 == d.version));
+    });
+
+    TS_ASSERT(resAlg != descriptors.cend());
+    TS_ASSERT(resAlias == descriptors.cend());
+
+    algFactory.unsubscribe("LowerCaseAliasAlgorithm", 1);
+  }
+
   void testGetCategories() {
     auto &algFactory = AlgorithmFactory::Instance();
     algFactory.subscribe<CategoryAlgorithm>();

--- a/Framework/API/test/FakeAlgorithms.h
+++ b/Framework/API/test/FakeAlgorithms.h
@@ -91,3 +91,20 @@ public:
   }
   void exec() override {}
 };
+
+class LowerCaseAliasAlgorithm : public Algorithm {
+public:
+  LowerCaseAliasAlgorithm() : Algorithm() {}
+  ~LowerCaseAliasAlgorithm() override = default;
+  const std::string name() const override { return "Lower"; }
+  int version() const override { return 1; }                          ///< Algorithm's version for identification
+  const std::string category() const override { return "Lowercase"; } ///< Algorithm's category for identification
+  const std::string alias() const override { return "lower"; }
+  const std::string summary() const override { return "Test summary"; }
+
+  void init() override {
+    declareProperty("prop1", "value");
+    declareProperty("prop2", 1);
+  }
+  void exec() override {}
+};

--- a/docs/source/release/v6.6.0/Workbench/Bugfixes/34385.rst
+++ b/docs/source/release/v6.6.0/Workbench/Bugfixes/34385.rst
@@ -1,0 +1,1 @@
+- Fixed bug where Load and Rebin showed up twice (upper and lower case) in the algorithms tab search.


### PR DESCRIPTION
**Description of work.**

Added check to exclude alias algorithms, whose names are lower case versions of the parent algorithm, from the descriptions list.

Load and Rebin had lowercase aliases added here https://github.com/mantidproject/mantid/commit/3133d77f44a4e7824490d9ce25ebbbd67e2b482c. Some scientists may be using these lower case aliases in scripts therefore they have been left in.

Added a test to check lowercase aliases don't make it into the algorithm descriptions list.
Added a new fake algorithm for this test.

**To test:**

- Launch Mantid
- Search for 'Rebin' in the algorithm tab and check that only 'Rebin' appears and not 'rebin'
- Do the same for 'Load'
- Run `rebin()` (lowercase) in the script editor on some data and check that it still works (`load()` does not work in the script editor)

Fixes #34385

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
