### PR TITLE
Avoid comparison of size_t and int

### DIFF
--- a/Framework/CurveFitting/src/CostFunctions/CostFuncFitting.cpp
+++ b/Framework/CurveFitting/src/CostFunctions/CostFuncFitting.cpp
@@ -125,7 +125,7 @@ void CostFuncFitting::calActiveCovarianceMatrix(EigenMatrix &covar, double epsre
   EigenJacobian J(*m_function, m_values->size());
   size_t na = this->nParams(); // number of active parameters
   const auto &j = J.getJ();
-  assert(j.cols() == na);
+  assert(static_cast<size_t>(j.cols()) == na);
   covar.resize(na, na);
 
   // calculate the derivatives


### PR DESCRIPTION
**Description of work.**
This PR fixes a warning when building with ninja on linux (or windows) caused by a conversion between a size_t and an int. I think the warning doesn't occur on the jenkins jobs because the comparison is done in an `assert` statement which is only seen in Debug mode.

**To test:**
Build mantid using Ninja on linux (or windows), and make sure you don't see the following warning:

```
In file included from /home/mlc47243/mambaforge/envs/mantid-developer-4/x86_64-conda-linux-gnu/include/c++/10.3.0/cassert:44,
                 from /home/mlc47243/mambaforge/envs/mantid-developer-4/include/eigen3/Eigen/Core:84,
                 from /home/mlc47243/Documents/mantid-development/mantid-conda-4/mantid/Framework/CurveFitting/inc/MantidCurveFitting/EigenVector.h:11,
                 from /home/mlc47243/Documents/mantid-development/mantid-conda-4/mantid/Framework/CurveFitting/inc/MantidCurveFitting/EigenMatrix.h:9,
                 from /home/mlc47243/Documents/mantid-development/mantid-conda-4/mantid/Framework/CurveFitting/inc/MantidCurveFitting/CostFunctions/CostFuncFitting.h:15,
                 from /home/mlc47243/Documents/mantid-development/mantid-conda-4/mantid/Framework/CurveFitting/src/CostFunctions/CostFuncFitting.cpp:10:
/home/mlc47243/Documents/mantid-development/mantid-conda-4/mantid/Framework/CurveFitting/src/CostFunctions/CostFuncFitting.cpp: In member function 'virtual void Mantid::CurveFitting::CostFunctions::CostFuncFitting::calActiveCovarianceMatrix(Mantid::CurveFitting::EigenMatrix&, double)':
/home/mlc47243/Documents/mantid-development/mantid-conda-4/mantid/Framework/CurveFitting/src/CostFunctions/CostFuncFitting.cpp:128:19: warning: comparison of integer expressions of different signedness: 'Eigen::Index' {aka 'long int'} and 'size_t' {aka 'long unsigned int'} [-Wsign-compare]
  128 |   assert(j.cols() == na);

```

*There is no associated issue.*

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
