### PR TITLE
Added button to hide plot in the plot toolbar

### DIFF
--- a/docs/source/release/v6.6.0/Workbench/New_features/34050.rst
+++ b/docs/source/release/v6.6.0/Workbench/New_features/34050.rst
@@ -1,0 +1,1 @@
+- Added button to figure tool bar which hides the figure (unhidden using the plots tab).

--- a/qt/applications/workbench/workbench/plotting/figuremanager.py
+++ b/qt/applications/workbench/workbench/plotting/figuremanager.py
@@ -232,6 +232,7 @@ class FigureManagerWorkbench(FigureManagerBase, QObject):
             self.toolbar.sig_waterfall_conversion.connect(self.update_toolbar_waterfall_plot)
             self.toolbar.sig_change_line_collection_colour_triggered.connect(
                 self.change_line_collection_colour)
+            self.toolbar.sig_hide_plot_triggered.connect(self.hide_plot)
             self.toolbar.setFloatable(False)
             tbs_height = self.toolbar.sizeHint().height()
         else:
@@ -354,6 +355,9 @@ class FigureManagerWorkbench(FigureManagerBase, QObject):
 
     def launch_plot_help(self):
         PlotHelpPages.show_help_page_for_figure(self.canvas.figure)
+
+    def hide_plot(self):
+        self.window.hide()
 
     def copy_to_clipboard(self):
         """Copy the current figure image to clipboard"""

--- a/qt/applications/workbench/workbench/plotting/test/test_toolbar.py
+++ b/qt/applications/workbench/workbench/plotting/test/test_toolbar.py
@@ -150,6 +150,22 @@ class ToolBarTest(unittest.TestCase):
             for is_grid in (True, False):
                 self._test_grid_button_state_for_3d_plot(plot_type, is_grid, mock_qappthread)
 
+    @patch("workbench.plotting.figuremanager.QAppThreadCall")
+    def test_hide_button_hides_window(self, mock_qappthread):
+        """ Check that the window is hidden when hide plot button is pressed"""
+        mock_qappthread.return_value = mock_qappthread
+
+        fig, axes = plt.subplots(subplot_kw={'projection': 'mantid'})
+        axes.plot([-10, 10], [1, 2])
+
+        canvas = MantidFigureCanvas(fig)
+        fig_manager = FigureManagerWorkbench(canvas, 1)
+        # This is only called when show() is called on the figure manager, so we have to manually call it here.
+        fig_manager.toolbar.set_buttons_visibility(fig)
+        fig_manager.toolbar.hide_plot()
+
+        self.assertTrue(fig_manager.window.isHidden())
+
     def _test_grid_button_state_for_3d_plot(self, plot_type, is_grid, mock_qappthread):
         """Check whether grid button check state is correct for a given plot type"""
         mock_qappthread.return_value = mock_qappthread

--- a/qt/applications/workbench/workbench/plotting/test/test_toolbar.py
+++ b/qt/applications/workbench/workbench/plotting/test/test_toolbar.py
@@ -162,6 +162,7 @@ class ToolBarTest(unittest.TestCase):
         fig_manager = FigureManagerWorkbench(canvas, 1)
         # This is only called when show() is called on the figure manager, so we have to manually call it here.
         fig_manager.toolbar.set_buttons_visibility(fig)
+        fig_manager.window.show()
         fig_manager.toolbar.hide_plot()
 
         self.assertTrue(fig_manager.window.isHidden())

--- a/qt/applications/workbench/workbench/plotting/toolbar.py
+++ b/qt/applications/workbench/workbench/plotting/toolbar.py
@@ -51,6 +51,7 @@ class WorkbenchNavigationToolbar(MantidNavigationToolbar):
     sig_waterfall_fill_area_triggered = QtCore.Signal()
     sig_waterfall_conversion = QtCore.Signal(bool)
     sig_change_line_collection_colour_triggered = QtCore.Signal(QtGui.QColor)
+    sig_hide_plot_triggered = QtCore.Signal()
 
     toolitems = (
         MantidNavigationTool('Home', 'Reset axes limits', 'mdi.home', 'on_home_clicked', None),
@@ -79,7 +80,8 @@ class WorkbenchNavigationToolbar(MantidNavigationToolbar):
         MantidNavigationTool('Reverse Order', 'Reverse curve order', 'mdi.swap-horizontal', 'waterfall_reverse_order', None),
         MantidNavigationTool('Fill Area', 'Fill area under curves', 'mdi.format-color-fill', 'waterfall_fill_area', None),
         MantidStandardNavigationTools.SEPARATOR,
-        MantidNavigationTool('Help', 'Open plotting help documentation', 'mdi.help', 'launch_plot_help', None)
+        MantidNavigationTool('Help', 'Open plotting help documentation', 'mdi.help', 'launch_plot_help', None),
+        MantidNavigationTool('Hide', 'Hide the plot', 'mdi.eye', 'hide_plot', None)
     )
 
     def __init__(self, canvas, parent, coordinates=True):
@@ -88,6 +90,9 @@ class WorkbenchNavigationToolbar(MantidNavigationToolbar):
         # Adjust icon size or they are too small in PyQt5 by default
         dpi_ratio = QtWidgets.QApplication.instance().desktop().physicalDpiX() / 100
         self.setIconSize(QtCore.QSize(int(24 * dpi_ratio), int(24 * dpi_ratio)))
+
+    def hide_plot(self):
+        self.sig_hide_plot_triggered.emit()
 
     def copy_to_clipboard(self):
         self.sig_copy_to_clipboard_triggered.emit()


### PR DESCRIPTION
**Description of work.**

Added button to hide plot in the plot toolbar.

**To test:**

- Load data and open a spectrum plot
- Click the new hide plot button (eye icon) and check that the plot is hidden
- Go to the plots tab and checked the plot is showing as hidden (grey eye)
- Click the show plot button in the plots tab and check that the plot reappears
- Try this with some different kinds of plots

Fixes #34050

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
