### PR TITLE
Restrict MeierTest to Windows and OSX machines

### DIFF
--- a/Framework/PythonInterface/test/python/plugins/functions/MeierTest.py
+++ b/Framework/PythonInterface/test/python/plugins/functions/MeierTest.py
@@ -6,6 +6,7 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 import unittest
 import numpy as np
+import sys
 
 from MsdTestHelper import (is_registered, check_output, do_a_fit)
 

--- a/Framework/PythonInterface/test/python/plugins/functions/MeierTest.py
+++ b/Framework/PythonInterface/test/python/plugins/functions/MeierTest.py
@@ -26,8 +26,10 @@ class MeierTest(unittest.TestCase):
 			msg = 'Computed output {} from input {} unequal to expected: {}'
 			self.fail(msg.format(*[str(i) for i in (output, input, expected)]))
 
+	@unittest.skipIf(sys.platform.startswith("linux"), "test fails on Centos 7 machines")
 	def test_do_fit(self):
 		do_a_fit(np.arange(0.1, 16, 0.2), 'Meier', guess = dict(A0 = 0.55, FreqD = 0.015, FreqQ = 0.055, Spin = 3.55, Lambda = 0.15, Sigma = 0.25), target = dict(A0 = 0.5, FreqD = 0.01, FreqQ = 0.05, Spin = 3.5, Lambda = 0.1, Sigma = 0.2), atol = 0.01)
+
 
 if __name__ == '__main__':
 	unittest.main()


### PR DESCRIPTION
**Description of work.**
During work to set up new linux cloud VMs we found there were problems with the Meier test running on Linux machines (especially Centos 7 machines). Whilst the test is being investigated we want to temporarily disable the final test of the three when it is run on Linux machines. It still should run on Windows and OSX.

**To test:**
Check that the following two builds are successful
1. All current servers - https://builds.mantidproject.org/job/build_packages_from_branch/108/
2. New linux cloud vms -  https://builds.mantidproject.org/job/Core_Team_test_pipeline/8/


*There is no associated issue.*

*This does not require release notes* because **it does not affect users**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
