### PR TITLE
Fixed errorbar spectra plots not de-normalising

### DIFF
--- a/docs/source/release/v6.6.0/Workbench/Bugfixes/33914.rst
+++ b/docs/source/release/v6.6.0/Workbench/Bugfixes/33914.rst
@@ -1,0 +1,1 @@
+- Fixed a bug where spectra plots with error bars could not have normalisation turned off.

--- a/qt/applications/workbench/workbench/plotting/figureinteraction.py
+++ b/qt/applications/workbench/workbench/plotting/figureinteraction.py
@@ -811,12 +811,6 @@ class FigureInteraction(object):
             if arg_set['workspaces'] in ax.tracked_workspaces:
                 workspace = ads.retrieve(arg_set['workspaces'])
                 arg_set['distribution'] = is_normalized
-                arg_set_copy = copy(arg_set)
-                [
-                    arg_set_copy.pop(key)
-                    for key in ['function', 'workspaces', 'autoscale_on_update', 'norm']
-                    if key in arg_set_copy.keys()
-                ]
                 if 'specNum' not in arg_set:
                     if 'wkspIndex' in arg_set:
                         arg_set['specNum'] = workspace.getSpectrum(
@@ -824,6 +818,12 @@ class FigureInteraction(object):
                     else:
                         raise RuntimeError("No spectrum number associated with plot of "
                                            "workspace '{}'".format(workspace.name()))
+                arg_set_copy = copy(arg_set)
+                [
+                    arg_set_copy.pop(key)
+                    for key in ['function', 'workspaces', 'autoscale_on_update', 'norm']
+                    if key in arg_set_copy.keys()
+                ]
                 # 2D plots have no spec number so remove it
                 if figure_type(self.canvas.figure) in [FigureType.Image, FigureType.Contour]:
                     arg_set_copy.pop('specNum')

--- a/qt/applications/workbench/workbench/plotting/figureinteraction.py
+++ b/qt/applications/workbench/workbench/plotting/figureinteraction.py
@@ -818,6 +818,7 @@ class FigureInteraction(object):
                     else:
                         raise RuntimeError("No spectrum number associated with plot of "
                                            "workspace '{}'".format(workspace.name()))
+
                 arg_set_copy = copy(arg_set)
                 [
                     arg_set_copy.pop(key)

--- a/qt/applications/workbench/workbench/plotting/figureinteraction.py
+++ b/qt/applications/workbench/workbench/plotting/figureinteraction.py
@@ -820,11 +820,11 @@ class FigureInteraction(object):
                                            "workspace '{}'".format(workspace.name()))
 
                 arg_set_copy = copy(arg_set)
-                [
-                    arg_set_copy.pop(key)
-                    for key in ['function', 'workspaces', 'autoscale_on_update', 'norm']
-                    if key in arg_set_copy.keys()
-                ]
+                for key in ['function', 'workspaces', 'autoscale_on_update', 'norm']:
+                    try:
+                        del arg_set_copy[key]
+                    except KeyError:
+                        continue
                 # 2D plots have no spec number so remove it
                 if figure_type(self.canvas.figure) in [FigureType.Image, FigureType.Contour]:
                     arg_set_copy.pop('specNum')


### PR DESCRIPTION
**Description of work.**

Moved check for spectrum number to before where the line arguments copy is made (instead of after). 

**To test:**

Follow the instructions in #33914 to check that spectra with error bars will change when normalisation is set to 'None'.

Fixes #33914

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
