### PR TITLE
Add Logbook Export Functionality to the Search Runs Widget

### DIFF
--- a/docs/source/release/v6.6.0/Reflectometry/New_features/33468.rst
+++ b/docs/source/release/v6.6.0/Reflectometry/New_features/33468.rst
@@ -1,0 +1,1 @@
+- It is now possible to save the content of the ``Search Runs`` table into a ``.csv`` file, allowing the table to be used as a logbook.

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Common/IFileHandler.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Common/IFileHandler.h
@@ -23,6 +23,7 @@ public:
   virtual ~IFileHandler(){};
   virtual void saveJSONToFile(std::string const &filename, QMap<QString, QVariant> const &map) = 0;
   virtual QMap<QString, QVariant> loadJSONFromFile(std::string const &filename) = 0;
+  virtual void saveCSVToFile(std::string const &filename, std::string const &content) const = 0;
 };
 } // namespace ISISReflectometry
 } // namespace CustomInterfaces

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/MainWindow/QtMainWindowView.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/MainWindow/QtMainWindowView.cpp
@@ -21,6 +21,8 @@
 #include <QMessageBox>
 #include <QToolButton>
 
+#include <fstream>
+
 namespace MantidQt {
 
 using MantidWidgets::SlitCalculator;
@@ -79,7 +81,7 @@ void QtMainWindowView::initLayout() {
   auto messageHandler = this;
   auto fileHandler = this;
   auto makeRunsPresenter =
-      RunsPresenterFactory(std::move(makeRunsTablePresenter), thetaTolerance, instruments, messageHandler);
+      RunsPresenterFactory(std::move(makeRunsTablePresenter), thetaTolerance, instruments, messageHandler, fileHandler);
 
   auto makeEventPresenter = EventPresenterFactory();
   auto makeSaveSettingsPresenter = SavePresenterFactory();
@@ -225,5 +227,15 @@ void QtMainWindowView::saveJSONToFile(std::string const &filename, QMap<QString,
 QMap<QString, QVariant> QtMainWindowView::loadJSONFromFile(std::string const &filename) {
   return MantidQt::API::loadJSONFromFile(QString::fromStdString(filename));
 }
+
+void QtMainWindowView::saveCSVToFile(const std::string &filename, const std::string &content) const {
+  std::ofstream outFile(filename, std::ios::trunc);
+  if (!outFile) {
+    throw std::runtime_error("Saving to " + filename + "failed. Please try again.");
+  }
+  outFile << content;
+  outFile.close();
+}
+
 } // namespace CustomInterfaces::ISISReflectometry
 } // namespace MantidQt

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/MainWindow/QtMainWindowView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/MainWindow/QtMainWindowView.h
@@ -73,6 +73,7 @@ public:
   // QtJSONUtils if possible
   void saveJSONToFile(std::string const &filename, QMap<QString, QVariant> const &map) override;
   QMap<QString, QVariant> loadJSONFromFile(std::string const &filename) override;
+  void saveCSVToFile(std::string const &filename, std::string const &content) const override;
 
 public slots:
   void helpPressed();

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/IRunsView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/IRunsView.h
@@ -80,6 +80,7 @@ public:
   virtual void setSearchResultsColumnWidth(int column, int width) = 0;
   virtual ISearchModel const &searchResults() const = 0;
   virtual ISearchModel &mutableSearchResults() = 0;
+  virtual std::string getLogbookCSV() const = 0;
 
   // Setter methods
   virtual void setInstrumentList(const std::vector<std::string> &instruments) = 0;

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/IRunsView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/IRunsView.h
@@ -39,7 +39,7 @@ public:
   virtual void notifyStartMonitor() = 0;
   virtual void notifyStopMonitor() = 0;
   virtual void notifyStartMonitorComplete() = 0;
-  virtual void notifyExportLogbook() const = 0;
+  virtual void notifyExportSearchResults() const = 0;
 };
 
 class RunsViewTimerSubscriber {
@@ -81,7 +81,7 @@ public:
   virtual void setSearchResultsColumnWidth(int column, int width) = 0;
   virtual ISearchModel const &searchResults() const = 0;
   virtual ISearchModel &mutableSearchResults() = 0;
-  virtual std::string getLogbookCSV() const = 0;
+  virtual std::string getSearchResultsCSV() const = 0;
 
   // Setter methods
   virtual void setInstrumentList(const std::vector<std::string> &instruments) = 0;

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/IRunsView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/IRunsView.h
@@ -39,6 +39,7 @@ public:
   virtual void notifyStartMonitor() = 0;
   virtual void notifyStopMonitor() = 0;
   virtual void notifyStartMonitorComplete() = 0;
+  virtual void notifyExportLogbook() const = 0;
 };
 
 class RunsViewTimerSubscriber {

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/IRunsView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/IRunsView.h
@@ -81,7 +81,6 @@ public:
   virtual void setSearchResultsColumnWidth(int column, int width) = 0;
   virtual ISearchModel const &searchResults() const = 0;
   virtual ISearchModel &mutableSearchResults() = 0;
-  virtual std::string getSearchResultsCSV() const = 0;
 
   // Setter methods
   virtual void setInstrumentList(const std::vector<std::string> &instruments) = 0;

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/ISearchModel.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/ISearchModel.h
@@ -32,6 +32,7 @@ public:
   virtual bool hasUnsavedChanges() const = 0;
   virtual void setUnsaved() = 0;
   virtual void setSaved() = 0;
+  virtual std::string getSearchResultsCSV() const = 0;
 };
 } // namespace ISISReflectometry
 } // namespace CustomInterfaces

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/ISearcher.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/ISearcher.h
@@ -38,6 +38,7 @@ public:
   virtual bool hasUnsavedChanges() const = 0;
   virtual void setSaved() = 0;
   virtual SearchCriteria searchCriteria() const = 0;
+  virtual std::string getSearchResultsCSV() const = 0;
 };
 } // namespace ISISReflectometry
 } // namespace CustomInterfaces

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/QtCatalogSearcher.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/QtCatalogSearcher.cpp
@@ -188,6 +188,8 @@ void QtCatalogSearcher::setSaved() { results().setSaved(); }
 
 SearchCriteria QtCatalogSearcher::searchCriteria() const { return m_searchCriteria; }
 
+std::string QtCatalogSearcher::getSearchResultsCSV() const { return results().getSearchResultsCSV(); }
+
 bool QtCatalogSearcher::hasActiveCatalogSession() const {
   auto sessions = CatalogManager::Instance().getActiveSessions();
   return !sessions.empty();

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/QtCatalogSearcher.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/QtCatalogSearcher.h
@@ -41,6 +41,7 @@ public:
   bool hasUnsavedChanges() const override;
   void setSaved() override;
   SearchCriteria searchCriteria() const override;
+  std::string getSearchResultsCSV() const override;
 
   // RunsViewSearchSubscriber overrides
   void notifySearchComplete() override;

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/QtRunsView.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/QtRunsView.cpp
@@ -215,8 +215,6 @@ ISearchModel const &QtRunsView::searchResults() const { return m_searchModel; }
 
 ISearchModel &QtRunsView::mutableSearchResults() { return m_searchModel; }
 
-std::string QtRunsView::getSearchResultsCSV() const { return m_searchModel.getSearchResultsCSV(); }
-
 /**
 This slot notifies the presenter that the user has modified some values in the
 search results table

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/QtRunsView.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/QtRunsView.cpp
@@ -213,6 +213,8 @@ ISearchModel const &QtRunsView::searchResults() const { return m_searchModel; }
 
 ISearchModel &QtRunsView::mutableSearchResults() { return m_searchModel; }
 
+std::string QtRunsView::getLogbookCSV() const { return m_searchModel.getLogbookCSV(); }
+
 /**
 This slot notifies the presenter that the user has modified some values in the
 search results table

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/QtRunsView.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/QtRunsView.cpp
@@ -215,7 +215,7 @@ ISearchModel const &QtRunsView::searchResults() const { return m_searchModel; }
 
 ISearchModel &QtRunsView::mutableSearchResults() { return m_searchModel; }
 
-std::string QtRunsView::getLogbookCSV() const { return m_searchModel.getLogbookCSV(); }
+std::string QtRunsView::getSearchResultsCSV() const { return m_searchModel.getSearchResultsCSV(); }
 
 /**
 This slot notifies the presenter that the user has modified some values in the
@@ -274,7 +274,7 @@ void QtRunsView::on_actionTransfer_triggered() {
 void QtRunsView::on_actionExport_triggered() {
   Mantid::Kernel::UsageService::Instance().registerFeatureUsage(Mantid::Kernel::FeatureType::Feature,
                                                                 {"ISIS Reflectometry", "RunsTab", "Export"}, false);
-  m_notifyee->notifyExportLogbook();
+  m_notifyee->notifyExportSearchResults();
 }
 
 /**

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/QtRunsView.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/QtRunsView.cpp
@@ -46,6 +46,7 @@ void QtRunsView::initLayout() {
   m_ui.setupUi(this);
 
   m_ui.buttonTransfer->setDefaultAction(m_ui.actionTransfer);
+  m_ui.buttonExport->setDefaultAction(m_ui.actionExport);
 
   // Expand the process runs column at the expense of the search column
   m_ui.splitterTables->setStretchFactor(0, 0);
@@ -61,6 +62,7 @@ void QtRunsView::initLayout() {
   m_ui.actionAutoreduce->setIcon(getIcon("mdi.play", "green", 1.3));
   m_ui.actionSearch->setIcon(getIcon("mdi.folder", "black", 1.3));
   m_ui.actionTransfer->setIcon(getIcon("mdi.file-move", "black", 1.3));
+  m_ui.actionExport->setIcon(getIcon("mdi.content-save", "black", 1.3));
 
   m_algoRunner = std::make_shared<MantidQt::API::AlgorithmRunner>(this);
   m_monitorAlgoRunner = std::make_shared<MantidQt::API::AlgorithmRunner>(this);
@@ -264,6 +266,15 @@ void QtRunsView::on_actionTransfer_triggered() {
   Mantid::Kernel::UsageService::Instance().registerFeatureUsage(Mantid::Kernel::FeatureType::Feature,
                                                                 {"ISIS Reflectometry", "RunsTab", "Transfer"}, false);
   m_notifyee->notifyTransfer();
+}
+
+/**
+ * This slot notifies the presenter that the "Export" button has been pressed
+ */
+void QtRunsView::on_actionExport_triggered() {
+  Mantid::Kernel::UsageService::Instance().registerFeatureUsage(Mantid::Kernel::FeatureType::Feature,
+                                                                {"ISIS Reflectometry", "RunsTab", "Export"}, false);
+  m_notifyee->notifyExportLogbook();
 }
 
 /**

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/QtRunsView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/QtRunsView.h
@@ -120,6 +120,7 @@ private slots:
   void on_actionAutoreduce_triggered();
   void on_actionAutoreducePause_triggered();
   void on_actionTransfer_triggered();
+  void on_actionExport_triggered();
   void on_buttonMonitor_clicked();
   void on_buttonStopMonitor_clicked();
   void onStartMonitorComplete();

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/QtRunsView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/QtRunsView.h
@@ -49,7 +49,7 @@ public:
   void setSearchResultsColumnWidth(int column, int width) override;
   ISearchModel const &searchResults() const override;
   ISearchModel &mutableSearchResults() override;
-  std::string getLogbookCSV() const override;
+  std::string getSearchResultsCSV() const override;
 
   // Setter methods
   void setInstrumentList(const std::vector<std::string> &instruments) override;

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/QtRunsView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/QtRunsView.h
@@ -49,7 +49,6 @@ public:
   void setSearchResultsColumnWidth(int column, int width) override;
   ISearchModel const &searchResults() const override;
   ISearchModel &mutableSearchResults() override;
-  std::string getSearchResultsCSV() const override;
 
   // Setter methods
   void setInstrumentList(const std::vector<std::string> &instruments) override;

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/QtRunsView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/QtRunsView.h
@@ -49,6 +49,7 @@ public:
   void setSearchResultsColumnWidth(int column, int width) override;
   ISearchModel const &searchResults() const override;
   ISearchModel &mutableSearchResults() override;
+  std::string getLogbookCSV() const override;
 
   // Setter methods
   void setInstrumentList(const std::vector<std::string> &instruments) override;

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/QtSearchModel.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/QtSearchModel.cpp
@@ -219,18 +219,20 @@ SearchResult const &QtSearchModel::getRowData(int index) const { return m_runDet
 
 SearchResults const &QtSearchModel::getRows() const { return m_runDetails; }
 
-std::string QtSearchModel::getLogbookCSV(SearchResults const &results) const {
+std::string QtSearchModel::getLogbookCSV() const { return makeLogbookCSV(getRows()); }
+
+std::string QtSearchModel::makeLogbookCSV(SearchResults const &results) const {
   if (results.empty()) {
     return "";
   }
-  std::string csv = getLogbookHeaders();
+  std::string csv = makeLogbookHeaders();
   for (SearchResult const &result : results) {
     csv += result.runNumber() + "," + result.title() + "," + result.excludeReason() + "," + result.comment() + "\n";
   }
   return csv;
 }
 
-std::string QtSearchModel::getLogbookHeaders() const {
+std::string QtSearchModel::makeLogbookHeaders() const {
   std::string header;
   header +=
       headerData(static_cast<int>(Column::RUN), Qt::Orientation::Horizontal, Qt::DisplayRole).toString().toStdString() +

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/QtSearchModel.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/QtSearchModel.cpp
@@ -227,6 +227,8 @@ std::string QtSearchModel::makeLogbookCSV(SearchResults const &results) const {
   }
   std::string csv = makeLogbookHeaders();
   for (SearchResult const &result : results) {
+    // Should be suppressed until C++20. std::accumulate is less efficient as it makes needless copies.
+    // cppcheck-suppress useStlAlgorithm
     csv += result.runNumber() + "," + result.title() + "," + result.excludeReason() + "," + result.comment() + "\n";
   }
   return csv;

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/QtSearchModel.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/QtSearchModel.cpp
@@ -220,6 +220,9 @@ SearchResult const &QtSearchModel::getRowData(int index) const { return m_runDet
 SearchResults const &QtSearchModel::getRows() const { return m_runDetails; }
 
 std::string QtSearchModel::getLogbookCSV(SearchResults const &results) const {
+  if (results.empty()) {
+    return "";
+  }
   std::string csv = getLogbookHeaders();
   for (SearchResult const &result : results) {
     csv += result.runNumber() + "," + result.title() + "," + result.excludeReason() + "," + result.comment() + "\n";

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/QtSearchModel.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/QtSearchModel.cpp
@@ -219,13 +219,13 @@ SearchResult const &QtSearchModel::getRowData(int index) const { return m_runDet
 
 SearchResults const &QtSearchModel::getRows() const { return m_runDetails; }
 
-std::string QtSearchModel::getLogbookCSV() const { return makeLogbookCSV(getRows()); }
+std::string QtSearchModel::getSearchResultsCSV() const { return makeSearchResultsCSV(getRows()); }
 
-std::string QtSearchModel::makeLogbookCSV(SearchResults const &results) const {
+std::string QtSearchModel::makeSearchResultsCSV(SearchResults const &results) const {
   if (results.empty()) {
     return "";
   }
-  std::string csv = makeLogbookHeaders();
+  std::string csv = makeSearchResultsCSVHeaders();
   for (SearchResult const &result : results) {
     // Should be suppressed until C++20. std::accumulate is less efficient as it makes needless copies.
     // cppcheck-suppress useStlAlgorithm
@@ -234,7 +234,7 @@ std::string QtSearchModel::makeLogbookCSV(SearchResults const &results) const {
   return csv;
 }
 
-std::string QtSearchModel::makeLogbookHeaders() const {
+std::string QtSearchModel::makeSearchResultsCSVHeaders() const {
   std::string header;
   header +=
       headerData(static_cast<int>(Column::RUN), Qt::Orientation::Horizontal, Qt::DisplayRole).toString().toStdString() +

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/QtSearchModel.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/QtSearchModel.cpp
@@ -218,4 +218,33 @@ void QtSearchModel::setSaved() { m_hasUnsavedChanges = false; }
 SearchResult const &QtSearchModel::getRowData(int index) const { return m_runDetails[index]; }
 
 SearchResults const &QtSearchModel::getRows() const { return m_runDetails; }
+
+std::string QtSearchModel::getLogbookCSV(SearchResults const &results) const {
+  std::string csv = getLogbookHeaders();
+  for (SearchResult const &result : results) {
+    csv += result.runNumber() + "," + result.title() + "," + result.excludeReason() + "," + result.comment() + "\n";
+  }
+  return csv;
+}
+
+std::string QtSearchModel::getLogbookHeaders() const {
+  std::string header;
+  header +=
+      headerData(static_cast<int>(Column::RUN), Qt::Orientation::Horizontal, Qt::DisplayRole).toString().toStdString() +
+      ",";
+  header += headerData(static_cast<int>(Column::TITLE), Qt::Orientation::Horizontal, Qt::DisplayRole)
+                .toString()
+                .toStdString() +
+            ",";
+  header += headerData(static_cast<int>(Column::EXCLUDE), Qt::Orientation::Horizontal, Qt::DisplayRole)
+                .toString()
+                .toStdString() +
+            ",";
+  header += headerData(static_cast<int>(Column::COMMENT), Qt::Orientation::Horizontal, Qt::DisplayRole)
+                .toString()
+                .toStdString() +
+            "\n";
+  return header;
+}
+
 } // namespace MantidQt::CustomInterfaces::ISISReflectometry

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/QtSearchModel.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/QtSearchModel.h
@@ -36,7 +36,7 @@ public:
   void setUnsaved() override;
   void setSaved() override;
   // generate csv string for exporting
-  std::string getSearchResultsCSV() const;
+  std::string getSearchResultsCSV() const override;
   std::string makeSearchResultsCSV(const SearchResults &results) const;
 
   // QAbstractTableModel overrides

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/QtSearchModel.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/QtSearchModel.h
@@ -36,7 +36,8 @@ public:
   void setUnsaved() override;
   void setSaved() override;
   // generate csv string for exporting the logbook
-  std::string getLogbookCSV(const SearchResults &results) const;
+  std::string getLogbookCSV() const;
+  std::string makeLogbookCSV(const SearchResults &results) const;
 
   // QAbstractTableModel overrides
   // row and column counts
@@ -57,7 +58,7 @@ protected:
   bool m_hasUnsavedChanges;
 
 private:
-  std::string getLogbookHeaders() const;
+  std::string makeLogbookHeaders() const;
 };
 } // namespace ISISReflectometry
 } // namespace CustomInterfaces

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/QtSearchModel.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/QtSearchModel.h
@@ -35,9 +35,9 @@ public:
   bool hasUnsavedChanges() const override;
   void setUnsaved() override;
   void setSaved() override;
-  // generate csv string for exporting the logbook
-  std::string getLogbookCSV() const;
-  std::string makeLogbookCSV(const SearchResults &results) const;
+  // generate csv string for exporting
+  std::string getSearchResultsCSV() const;
+  std::string makeSearchResultsCSV(const SearchResults &results) const;
 
   // QAbstractTableModel overrides
   // row and column counts
@@ -58,7 +58,7 @@ protected:
   bool m_hasUnsavedChanges;
 
 private:
-  std::string makeLogbookHeaders() const;
+  std::string makeSearchResultsCSVHeaders() const;
 };
 } // namespace ISISReflectometry
 } // namespace CustomInterfaces

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/QtSearchModel.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/QtSearchModel.h
@@ -35,6 +35,8 @@ public:
   bool hasUnsavedChanges() const override;
   void setUnsaved() override;
   void setSaved() override;
+  // generate csv string for exporting the logbook
+  std::string getLogbookCSV(const SearchResults &results) const;
 
   // QAbstractTableModel overrides
   // row and column counts
@@ -53,6 +55,9 @@ protected:
   SearchResults m_runDetails;
   // Flag to indicate whether there are unsaved changes
   bool m_hasUnsavedChanges;
+
+private:
+  std::string getLogbookHeaders() const;
 };
 } // namespace ISISReflectometry
 } // namespace CustomInterfaces

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/RunsPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/RunsPresenter.cpp
@@ -133,24 +133,27 @@ void RunsPresenter::notifyChangeInstrumentRequested() {
 
 void RunsPresenter::notifyExportSearchResults() const {
   auto csv = m_view->getSearchResultsCSV();
-  if (!csv.empty()) {
-    auto filename = m_messageHandler->askUserForSaveFileName("CSV (*.csv)");
-    std::cerr << filename;
-    if (filename.find_last_of('.') == std::string::npos ||
-        filename.substr(filename.find_last_of('.') + 1) != std::string("csv")) {
-      filename += ".csv";
-    }
-    std::ofstream outFile(filename, std::ios::trunc);
-    if (!outFile) {
-      m_messageHandler->giveUserCritical("Saving to " + filename + "failed. Please try again.", "Error");
-      return;
-    }
-    outFile << csv;
-    outFile.close();
-  } else {
+  if (csv.empty()) {
     m_messageHandler->giveUserCritical(
         "No search results loaded. Enter an Investigation ID (and a cycle if using) to load results.", "Error");
+    return;
   }
+
+  // Append a .csv extension if the user didn't add one manually.
+  auto filename = m_messageHandler->askUserForSaveFileName("CSV (*.csv)");
+  std::cerr << filename;
+  if (filename.find_last_of('.') == std::string::npos ||
+      filename.substr(filename.find_last_of('.') + 1) != std::string("csv")) {
+    filename += ".csv";
+  }
+
+  std::ofstream outFile(filename, std::ios::trunc);
+  if (!outFile) {
+    m_messageHandler->giveUserCritical("Saving to " + filename + "failed. Please try again.", "Error");
+    return;
+  }
+  outFile << csv;
+  outFile.close();
 }
 
 // Notification from a child presenter that the instrument needs to be changed

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/RunsPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/RunsPresenter.cpp
@@ -132,7 +132,7 @@ void RunsPresenter::notifyChangeInstrumentRequested() {
 }
 
 void RunsPresenter::notifyExportSearchResults() const {
-  auto csv = m_view->getSearchResultsCSV();
+  auto csv = m_searcher->getSearchResultsCSV();
   if (csv.empty()) {
     m_messageHandler->giveUserCritical(
         "No search results loaded. Enter an Investigation ID (and a cycle if using) to load results.", "Error");

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/RunsPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/RunsPresenter.cpp
@@ -140,8 +140,12 @@ void RunsPresenter::notifyExportSearchResults() const {
     return;
   }
 
-  // Append a .csv extension if the user didn't add one manually.
   auto filename = m_messageHandler->askUserForSaveFileName("CSV (*.csv)");
+  if (filename.empty()) {
+    return;
+  }
+
+  // Append a .csv extension if the user didn't add one manually.
   if (filename.find_last_of('.') == std::string::npos ||
       filename.substr(filename.find_last_of('.') + 1) != std::string("csv")) {
     filename += ".csv";

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/RunsPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/RunsPresenter.cpp
@@ -131,6 +131,20 @@ void RunsPresenter::notifyChangeInstrumentRequested() {
     m_mainPresenter->notifyChangeInstrumentRequested(newName);
 }
 
+void RunsPresenter::notifyExportLogbook() const {
+  auto csv = m_view->getLogbookCSV();
+  if (!csv.empty()) {
+    auto filename = m_messageHandler->askUserForSaveFileName("CSV (*.csv)");
+    std::ofstream outFile(filename, std::ios::trunc);
+    outFile << csv;
+    outFile.close();
+  } else {
+    m_messageHandler->giveUserCritical(
+        "No logbook loaded. Enter an Investigation ID (and a cycle when using the archive) to load a logbook.",
+        "Error");
+  }
+}
+
 // Notification from a child presenter that the instrument needs to be changed
 // Returns true and continues to change the instrument if possible; returns
 // false if not

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/RunsPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/RunsPresenter.cpp
@@ -135,7 +135,16 @@ void RunsPresenter::notifyExportLogbook() const {
   auto csv = m_view->getLogbookCSV();
   if (!csv.empty()) {
     auto filename = m_messageHandler->askUserForSaveFileName("CSV (*.csv)");
+    std::cerr << filename;
+    if (filename.find_last_of('.') == std::string::npos ||
+        filename.substr(filename.find_last_of('.') + 1) != std::string("csv")) {
+      filename += ".csv";
+    }
     std::ofstream outFile(filename, std::ios::trunc);
+    if (!outFile) {
+      m_messageHandler->giveUserCritical("Saving to " + filename + "failed. Please try again.", "Error");
+      return;
+    }
     outFile << csv;
     outFile.close();
   } else {

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/RunsPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/RunsPresenter.cpp
@@ -131,8 +131,8 @@ void RunsPresenter::notifyChangeInstrumentRequested() {
     m_mainPresenter->notifyChangeInstrumentRequested(newName);
 }
 
-void RunsPresenter::notifyExportLogbook() const {
-  auto csv = m_view->getLogbookCSV();
+void RunsPresenter::notifyExportSearchResults() const {
+  auto csv = m_view->getSearchResultsCSV();
   if (!csv.empty()) {
     auto filename = m_messageHandler->askUserForSaveFileName("CSV (*.csv)");
     std::cerr << filename;
@@ -149,8 +149,7 @@ void RunsPresenter::notifyExportLogbook() const {
     outFile.close();
   } else {
     m_messageHandler->giveUserCritical(
-        "No logbook loaded. Enter an Investigation ID (and a cycle when using the archive) to load a logbook.",
-        "Error");
+        "No search results loaded. Enter an Investigation ID (and a cycle if using) to load results.", "Error");
   }
 }
 

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/RunsPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/RunsPresenter.h
@@ -115,7 +115,7 @@ public:
   void notifyStartMonitor() override;
   void notifyStopMonitor() override;
   void notifyStartMonitorComplete() override;
-  void notifyExportLogbook() const override;
+  void notifyExportSearchResults() const override;
 
   // RunNotifierSubscriber overrides
   void notifyCheckForNewRuns() override;

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/RunsPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/RunsPresenter.h
@@ -16,6 +16,7 @@
 #include "MantidAPI/AlgorithmObserver.h"
 #include "MantidAPI/IAlgorithm.h"
 #include "SearchResult.h"
+#include <fstream>
 #include <memory>
 #include <optional>
 
@@ -114,6 +115,7 @@ public:
   void notifyStartMonitor() override;
   void notifyStopMonitor() override;
   void notifyStartMonitorComplete() override;
+  void notifyExportLogbook() const override;
 
   // RunNotifierSubscriber overrides
   void notifyCheckForNewRuns() override;

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/RunsPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/RunsPresenter.h
@@ -8,6 +8,7 @@
 
 #include "CatalogRunNotifier.h"
 #include "Common/DllConfig.h"
+#include "GUI/Common/IFileHandler.h"
 #include "GUI/RunsTable/IRunsTablePresenter.h"
 #include "GUI/RunsTable/RunsTablePresenterFactory.h"
 #include "IRunsPresenter.h"
@@ -16,7 +17,6 @@
 #include "MantidAPI/AlgorithmObserver.h"
 #include "MantidAPI/IAlgorithm.h"
 #include "SearchResult.h"
-#include <fstream>
 #include <memory>
 #include <optional>
 
@@ -57,7 +57,7 @@ class MANTIDQT_ISISREFLECTOMETRY_DLL RunsPresenter : public IRunsPresenter,
 public:
   RunsPresenter(IRunsView *mainView, ProgressableView *progressView,
                 const RunsTablePresenterFactory &makeRunsTablePresenter, double thetaTolerance,
-                std::vector<std::string> instruments, IReflMessageHandler *messageHandler);
+                std::vector<std::string> instruments, IReflMessageHandler *messageHandler, IFileHandler *fileHandler);
   RunsPresenter(RunsPresenter const &) = delete;
   ~RunsPresenter() override;
   RunsPresenter const &operator=(RunsPresenter const &) = delete;
@@ -146,6 +146,8 @@ private:
   IBatchPresenter *m_mainPresenter;
   /// The message reporting implementation
   IReflMessageHandler *m_messageHandler;
+  /// The file handler
+  IFileHandler *m_fileHandler;
   /// The list of instruments
   std::vector<std::string> m_instruments;
   /// The tolerance used when looking up settings by theta

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/RunsPresenterFactory.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/RunsPresenterFactory.h
@@ -20,13 +20,14 @@ namespace ISISReflectometry {
 class RunsPresenterFactory {
 public:
   RunsPresenterFactory(RunsTablePresenterFactory runsTablePresenterFactory, double thetaTolerance,
-                       std::vector<std::string> instruments, IReflMessageHandler *messageHandler)
+                       std::vector<std::string> instruments, IReflMessageHandler *messageHandler,
+                       IFileHandler *fileHandler)
       : m_runsTablePresenterFactory(std::move(runsTablePresenterFactory)), m_thetaTolerance(std::move(thetaTolerance)),
-        m_instruments(std::move(instruments)), m_messageHandler(messageHandler) {}
+        m_instruments(std::move(instruments)), m_messageHandler(messageHandler), m_fileHandler(fileHandler) {}
 
   std::unique_ptr<IRunsPresenter> make(IRunsView *view) {
     return std::make_unique<RunsPresenter>(view, view, m_runsTablePresenterFactory, m_thetaTolerance, m_instruments,
-                                           m_messageHandler);
+                                           m_messageHandler, m_fileHandler);
   }
 
 private:
@@ -34,6 +35,7 @@ private:
   double m_thetaTolerance;
   std::vector<std::string> m_instruments;
   IReflMessageHandler *m_messageHandler;
+  IFileHandler *m_fileHandler;
 };
 } // namespace ISISReflectometry
 } // namespace CustomInterfaces

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/RunsWidget.ui
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/RunsWidget.ui
@@ -2,6 +2,14 @@
 <ui version="4.0">
  <class>RunsWidget</class>
  <widget class="QWidget" name="RunsWidget">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>450</width>
+    <height>474</height>
+   </rect>
+  </property>
   <property name="windowTitle">
    <string>RunsTab</string>
   </property>
@@ -289,6 +297,16 @@
           </widget>
          </item>
          <item>
+          <widget class="QToolButton" name="buttonExport">
+           <property name="text">
+            <string>Export</string>
+           </property>
+           <property name="toolButtonStyle">
+            <enum>Qt::ToolButtonTextBesideIcon</enum>
+           </property>
+          </widget>
+         </item>
+         <item>
           <widget class="QToolButton" name="buttonTransfer">
            <property name="toolTip">
             <string>Transfer the selected run(s) into the processing table</string>
@@ -487,6 +505,14 @@
    </property>
    <property name="whatsThis">
     <string>Pause any processing or auto-processing that is in progress. Pressing Autoprocess again after pausing will resume from where it was stopped, unless the instrument or investigation ID has changed, in which case the table will cleared and auto-processing will restart</string>
+   </property>
+  </action>
+  <action name="actionExport">
+   <property name="text">
+    <string>Export</string>
+   </property>
+   <property name="toolTip">
+    <string>Export the search results to a logbook .csv file</string>
    </property>
   </action>
  </widget>

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/RunsWidget.ui
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/RunsWidget.ui
@@ -512,7 +512,7 @@
     <string>Export</string>
    </property>
    <property name="toolTip">
-    <string>Export the search results to a logbook .csv file. Note: You must press enter or click out of any edited cells before exporting the logbook.</string>
+    <string>Export the search results to a .csv file. Note: You must press enter or click out of any edited cells before exporting the results.</string>
    </property>
   </action>
  </widget>

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/RunsWidget.ui
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/RunsWidget.ui
@@ -512,7 +512,7 @@
     <string>Export</string>
    </property>
    <property name="toolTip">
-    <string>Export the search results to a logbook .csv file</string>
+    <string>Export the search results to a logbook .csv file. Note: You must press enter or click out of any edited cells before exporting the logbook.</string>
    </property>
   </action>
  </widget>

--- a/qt/scientific_interfaces/ISISReflectometry/test/CMakeLists.txt
+++ b/qt/scientific_interfaces/ISISReflectometry/test/CMakeLists.txt
@@ -23,6 +23,7 @@ set(TEST_FILES
     Runs/RunsPresenterTest.h
     Runs/CatalogRunNotifierTest.h
     Runs/QtCatalogSearcherTest.h
+    Runs/QtSearchModelTest.h
     Runs/SearchResultTest.h
     Options/OptionsDialogPresenterTest.h
     Common/ClipboardTest.h

--- a/qt/scientific_interfaces/ISISReflectometry/test/ReflMockObjects.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/ReflMockObjects.h
@@ -284,6 +284,7 @@ class MockFileHandler : public IFileHandler {
 public:
   MOCK_METHOD2(saveJSONToFile, void(std::string const &, QMap<QString, QVariant> const &));
   MOCK_METHOD1(loadJSONFromFile, QMap<QString, QVariant>(const std::string &));
+  MOCK_CONST_METHOD2(saveCSVToFile, void(std::string const &, std::string const &));
 };
 
 class MockJobRunner : public IJobRunner {

--- a/qt/scientific_interfaces/ISISReflectometry/test/ReflMockObjects.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/ReflMockObjects.h
@@ -236,6 +236,7 @@ public:
   MOCK_CONST_METHOD0(hasUnsavedChanges, bool());
   MOCK_METHOD0(setSaved, void());
   MOCK_CONST_METHOD0(searchCriteria, SearchCriteria());
+  MOCK_CONST_METHOD0(getSearchResultsCSV, std::string());
 };
 
 class MockSearcherSubscriber : public SearcherSubscriber {
@@ -266,6 +267,7 @@ public:
   MOCK_CONST_METHOD0(hasUnsavedChanges, bool());
   MOCK_METHOD0(setUnsaved, void());
   MOCK_METHOD0(setSaved, void());
+  MOCK_CONST_METHOD0(getSearchResultsCSV, std::string());
 };
 
 class MockMessageHandler : public IReflMessageHandler {

--- a/qt/scientific_interfaces/ISISReflectometry/test/Runs/MockRunsView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Runs/MockRunsView.h
@@ -31,6 +31,7 @@ public:
   MOCK_METHOD2(setSearchResultsColumnWidth, void(int, int));
   MOCK_CONST_METHOD0(searchResults, ISearchModel const &());
   MOCK_METHOD0(mutableSearchResults, ISearchModel &());
+  MOCK_CONST_METHOD0(getLogbookCSV, std::string());
 
   MOCK_METHOD1(setInstrumentList, void(const std::vector<std::string> &));
   MOCK_METHOD1(updateMenuEnabledState, void(bool));

--- a/qt/scientific_interfaces/ISISReflectometry/test/Runs/MockRunsView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Runs/MockRunsView.h
@@ -31,7 +31,7 @@ public:
   MOCK_METHOD2(setSearchResultsColumnWidth, void(int, int));
   MOCK_CONST_METHOD0(searchResults, ISearchModel const &());
   MOCK_METHOD0(mutableSearchResults, ISearchModel &());
-  MOCK_CONST_METHOD0(getLogbookCSV, std::string());
+  MOCK_CONST_METHOD0(getSearchResultsCSV, std::string());
 
   MOCK_METHOD1(setInstrumentList, void(const std::vector<std::string> &));
   MOCK_METHOD1(updateMenuEnabledState, void(bool));

--- a/qt/scientific_interfaces/ISISReflectometry/test/Runs/MockRunsView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Runs/MockRunsView.h
@@ -31,7 +31,6 @@ public:
   MOCK_METHOD2(setSearchResultsColumnWidth, void(int, int));
   MOCK_CONST_METHOD0(searchResults, ISearchModel const &());
   MOCK_METHOD0(mutableSearchResults, ISearchModel &());
-  MOCK_CONST_METHOD0(getSearchResultsCSV, std::string());
 
   MOCK_METHOD1(setInstrumentList, void(const std::vector<std::string> &));
   MOCK_METHOD1(updateMenuEnabledState, void(bool));

--- a/qt/scientific_interfaces/ISISReflectometry/test/Runs/QtCatalogSearcherTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Runs/QtCatalogSearcherTest.h
@@ -302,6 +302,13 @@ public:
     verifyAndClear();
   }
 
+  void test_search_results_collection_passed_to_results() {
+    auto searcher = makeCatalogSearcher(true);
+    EXPECT_CALL(m_searchResults, getSearchResultsCSV()).Times(1);
+    searcher.getSearchResultsCSV();
+    verifyAndClear();
+  }
+
 private:
   NiceMock<MockRunsView> m_view;
   NiceMock<MockSearcherSubscriber> m_notifyee;

--- a/qt/scientific_interfaces/ISISReflectometry/test/Runs/QtSearchModelTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Runs/QtSearchModelTest.h
@@ -38,4 +38,14 @@ public:
     auto csv = model.getLogbookCSV(results);
     TS_ASSERT_EQUALS(expectedCsv, csv)
   }
+
+  void test_csv_string_not_generated_with_no_results() {
+    auto results = SearchResults();
+
+    auto expectedCsv = "";
+
+    auto model = QtSearchModel();
+    auto csv = model.getLogbookCSV(results);
+    TS_ASSERT_EQUALS(expectedCsv, csv);
+  }
 };

--- a/qt/scientific_interfaces/ISISReflectometry/test/Runs/QtSearchModelTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Runs/QtSearchModelTest.h
@@ -25,7 +25,7 @@ public:
     auto results = getTestSearchResults();
 
     auto model = QtSearchModel();
-    auto csv = model.makeLogbookCSV(results);
+    auto csv = model.makeSearchResultsCSV(results);
     TS_ASSERT_EQUALS(getTestCSV(), csv)
   }
 
@@ -35,16 +35,16 @@ public:
     auto expectedCsv = "";
 
     auto model = QtSearchModel();
-    auto csv = model.makeLogbookCSV(results);
+    auto csv = model.makeSearchResultsCSV(results);
     TS_ASSERT_EQUALS(expectedCsv, csv)
   }
 
-  void test_get_logbook_csv_uses_member_results() {
+  void test_getSearchResultsCSV_uses_member_results() {
     auto results = getTestSearchResults();
 
     auto model = QtSearchModel();
     model.replaceResults(results);
-    auto csv = model.getLogbookCSV();
+    auto csv = model.getSearchResultsCSV();
     TS_ASSERT_EQUALS(getTestCSV(), csv)
   }
 

--- a/qt/scientific_interfaces/ISISReflectometry/test/Runs/QtSearchModelTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Runs/QtSearchModelTest.h
@@ -1,0 +1,41 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2022 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#pragma once
+
+#include <vector>
+
+#include "../../../ISISReflectometry/GUI/Runs/QtSearchModel.h"
+#include "../../../ISISReflectometry/GUI/Runs/SearchResult.h"
+
+#include <cxxtest/TestSuite.h>
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+using MantidQt::CustomInterfaces::ISISReflectometry::QtSearchModel;
+using MantidQt::CustomInterfaces::ISISReflectometry::SearchResult;
+using MantidQt::CustomInterfaces::ISISReflectometry::SearchResults;
+
+class QtSearchModelTest : public CxxTest::TestSuite {
+public:
+  void test_csv_string_generated_correctly_from_search_results() {
+    auto results = SearchResults();
+    results.push_back(SearchResult("111111", "a title with a theta th=0.1", "a title with a theta", "0.1", "", "",
+                                   "this is a good one"));
+    results.push_back(SearchResult("222222", "a title without a theta"));
+    results.push_back(SearchResult("333333", "This one is purposely excluded th=0.2", "This one is purposely excluded",
+                                   "0.2", "", "it's bad", "something"));
+
+    auto expectedCsv = "Run,Description,Exclude,Comment\n"
+                       "111111,a title with a theta th=0.1,,this is a good one\n"
+                       "222222,a title without a theta,,\n"
+                       "333333,This one is purposely excluded th=0.2,it's bad,something\n";
+
+    auto model = QtSearchModel();
+    auto csv = model.getLogbookCSV(results);
+    TS_ASSERT_EQUALS(expectedCsv, csv)
+  }
+};

--- a/qt/scientific_interfaces/ISISReflectometry/test/Runs/QtSearchModelTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Runs/QtSearchModelTest.h
@@ -22,21 +22,11 @@ using MantidQt::CustomInterfaces::ISISReflectometry::SearchResults;
 class QtSearchModelTest : public CxxTest::TestSuite {
 public:
   void test_csv_string_generated_correctly_from_search_results() {
-    auto results = SearchResults();
-    results.push_back(SearchResult("111111", "a title with a theta th=0.1", "a title with a theta", "0.1", "", "",
-                                   "this is a good one"));
-    results.push_back(SearchResult("222222", "a title without a theta"));
-    results.push_back(SearchResult("333333", "This one is purposely excluded th=0.2", "This one is purposely excluded",
-                                   "0.2", "", "it's bad", "something"));
-
-    auto expectedCsv = "Run,Description,Exclude,Comment\n"
-                       "111111,a title with a theta th=0.1,,this is a good one\n"
-                       "222222,a title without a theta,,\n"
-                       "333333,This one is purposely excluded th=0.2,it's bad,something\n";
+    auto results = getTestSearchResults();
 
     auto model = QtSearchModel();
-    auto csv = model.getLogbookCSV(results);
-    TS_ASSERT_EQUALS(expectedCsv, csv)
+    auto csv = model.makeLogbookCSV(results);
+    TS_ASSERT_EQUALS(getTestCSV(), csv)
   }
 
   void test_csv_string_not_generated_with_no_results() {
@@ -45,7 +35,35 @@ public:
     auto expectedCsv = "";
 
     auto model = QtSearchModel();
-    auto csv = model.getLogbookCSV(results);
-    TS_ASSERT_EQUALS(expectedCsv, csv);
+    auto csv = model.makeLogbookCSV(results);
+    TS_ASSERT_EQUALS(expectedCsv, csv)
+  }
+
+  void test_get_logbook_csv_uses_member_results() {
+    auto results = getTestSearchResults();
+
+    auto model = QtSearchModel();
+    model.replaceResults(results);
+    auto csv = model.getLogbookCSV();
+    TS_ASSERT_EQUALS(getTestCSV(), csv)
+  }
+
+private:
+  static SearchResults getTestSearchResults() {
+    auto results = SearchResults();
+    results.push_back(SearchResult("111111", "a title with a theta th=0.1", "a title with a theta", "0.1", "", "",
+                                   "this is a good one"));
+    results.push_back(SearchResult("222222", "a title without a theta"));
+    results.push_back(SearchResult("333333", "This one is purposely excluded th=0.2", "This one is purposely excluded",
+                                   "0.2", "", "it's bad", "something"));
+
+    return results;
+  }
+
+  static std::string getTestCSV() {
+    return "Run,Description,Exclude,Comment\n"
+           "111111,a title with a theta th=0.1,,this is a good one\n"
+           "222222,a title without a theta,,\n"
+           "333333,This one is purposely excluded th=0.2,it's bad,something\n";
   }
 };

--- a/qt/scientific_interfaces/ISISReflectometry/test/Runs/RunsPresenterTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Runs/RunsPresenterTest.h
@@ -883,6 +883,21 @@ public:
     verifyAndClear();
   }
 
+  void testNotifyExportSearchResultsDoesNotSaveWhenFileCancelled() {
+    auto csv = "this, is, some, csv\n"
+               "and,some,more,words";
+    auto filename = "";
+
+    auto presenter = makePresenter();
+
+    EXPECT_CALL(*m_searcher, getSearchResultsCSV()).Times(1).WillOnce(Return(csv));
+    EXPECT_CALL(m_messageHandler, askUserForSaveFileName("CSV (*.csv)")).Times(1).WillOnce(Return(filename));
+    EXPECT_CALL(m_fileHandler, saveCSVToFile(filename, csv)).Times(0);
+
+    presenter.notifyExportSearchResults();
+    verifyAndClear();
+  }
+
 private:
   class RunsPresenterFriend : public RunsPresenter {
     friend class RunsPresenterTest;

--- a/qt/scientific_interfaces/ISISReflectometry/test/Runs/RunsPresenterTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Runs/RunsPresenterTest.h
@@ -37,6 +37,10 @@ using testing::NiceMock;
 using testing::Return;
 using testing::ReturnRef;
 
+namespace {
+ACTION(ThrowFileSavingRuntimeError) { throw std::runtime_error("Could not open file at: test.csv"); }
+} // namespace
+
 //=====================================================================================
 // Functional tests
 //=====================================================================================
@@ -815,6 +819,70 @@ public:
     verifyAndClear();
   }
 
+  void testNotifyExportSearchResultsWhenNoResults() {
+    auto presenter = makePresenter();
+
+    EXPECT_CALL(*m_searcher, getSearchResultsCSV()).Times(1).WillOnce(Return(""));
+    EXPECT_CALL(
+        m_messageHandler,
+        giveUserCritical("No search results loaded. Enter an Investigation ID (and a cycle if using) to load results.",
+                         "Error"))
+        .Times(1);
+
+    presenter.notifyExportSearchResults();
+    verifyAndClear();
+  }
+
+  void testNotifyExportSearchResultsWithResultsAndCSVFileExtension() {
+    auto csv = "this, is, some, csv\n"
+               "and,some,more,words";
+    auto filename = "test.csv";
+
+    auto presenter = makePresenter();
+
+    EXPECT_CALL(*m_searcher, getSearchResultsCSV()).Times(1).WillOnce(Return(csv));
+    EXPECT_CALL(m_messageHandler, askUserForSaveFileName("CSV (*.csv)")).Times(1).WillOnce(Return(filename));
+    EXPECT_CALL(m_fileHandler, saveCSVToFile(filename, csv)).Times(1);
+
+    presenter.notifyExportSearchResults();
+    verifyAndClear();
+  }
+
+  void testNotifyExportSearchResultsWithResultsAndNoCSVFileExtension() {
+    auto csv = "this, is, some, csv\n"
+               "and,some,more,words";
+    auto filename_before_asking = "test";
+    auto filename_after_asking = "test.csv";
+
+    auto presenter = makePresenter();
+
+    EXPECT_CALL(*m_searcher, getSearchResultsCSV()).Times(1).WillOnce(Return(csv));
+    EXPECT_CALL(m_messageHandler, askUserForSaveFileName("CSV (*.csv)"))
+        .Times(1)
+        .WillOnce(Return(filename_before_asking));
+    EXPECT_CALL(m_fileHandler, saveCSVToFile(filename_after_asking, csv)).Times(1);
+
+    presenter.notifyExportSearchResults();
+    verifyAndClear();
+  }
+
+  void testNotifyExportSearchResultsWhenSavingFails() {
+    auto csv = "this, is, some, csv\n"
+               "and,some,more,words";
+    auto filename = "test.csv";
+
+    auto presenter = makePresenter();
+
+    EXPECT_CALL(*m_searcher, getSearchResultsCSV()).Times(1).WillOnce(Return(csv));
+    EXPECT_CALL(m_messageHandler, askUserForSaveFileName("CSV (*.csv)")).Times(1).WillOnce(Return(filename));
+    EXPECT_CALL(m_fileHandler, saveCSVToFile(filename, csv)).Times(1).WillRepeatedly(ThrowFileSavingRuntimeError());
+
+    EXPECT_CALL(m_messageHandler, giveUserCritical("Could not open file at: test.csv", "Error")).Times(1);
+
+    presenter.notifyExportSearchResults();
+    verifyAndClear();
+  }
+
 private:
   class RunsPresenterFriend : public RunsPresenter {
     friend class RunsPresenterTest;
@@ -822,8 +890,10 @@ private:
   public:
     RunsPresenterFriend(IRunsView *mainView, ProgressableView *progressView,
                         const RunsTablePresenterFactory &makeRunsTablePresenter, double thetaTolerance,
-                        std::vector<std::string> const &instruments, IReflMessageHandler *messageHandler)
-        : RunsPresenter(mainView, progressView, makeRunsTablePresenter, thetaTolerance, instruments, messageHandler) {}
+                        std::vector<std::string> const &instruments, IReflMessageHandler *messageHandler,
+                        IFileHandler *fileHandler)
+        : RunsPresenter(mainView, progressView, makeRunsTablePresenter, thetaTolerance, instruments, messageHandler,
+                        fileHandler) {}
   };
 
   RunsPresenterFriend makePresenter() {
@@ -831,7 +901,7 @@ private:
 
     auto makeRunsTablePresenter = RunsTablePresenterFactory(m_instruments, m_thetaTolerance, std::move(plotter));
     auto presenter = RunsPresenterFriend(&m_view, &m_progressView, makeRunsTablePresenter, m_thetaTolerance,
-                                         m_instruments, &m_messageHandler);
+                                         m_instruments, &m_messageHandler, &m_fileHandler);
 
     presenter.acceptMainPresenter(&m_mainPresenter);
     presenter.m_tablePresenter.reset(new NiceMock<MockRunsTablePresenter>());
@@ -1202,6 +1272,7 @@ private:
   NiceMock<MockBatchPresenter> m_mainPresenter;
   NiceMock<MockProgressableView> m_progressView;
   NiceMock<MockMessageHandler> m_messageHandler;
+  NiceMock<MockFileHandler> m_fileHandler;
   NiceMock<MantidQt::MantidWidgets::Batch::MockJobTreeView> m_jobs;
   NiceMock<MockSearcher> *m_searcher;
   MockPythonRunner *m_pythonRunner;


### PR DESCRIPTION
**Description of work.**
Adds a button to the Search Runs widget on the Refl gui that allows the user to export the content of the table out to a `.csv` file that can be loaded into a spreadsheet program.

Scientists were using this widget as a logbook rather than an external one, so having something they can save out and take away has been highly requested. 

**To test:**
*NOTE: The implementation of this makes use of the `QFileDialog`, which has [some interesting fights with Jetbrains IDE's](https://stackoverflow.com/questions/57646908/pyqt5-qfiledialog-is-not-returning-correct-paths-in-ubuntu) when launched from there and causing messed up paths. To see a representative example of the code working, launch workbench from a terminal.*

1. Load an experiment (ID: 1120015 Cycle: 11_3 is my usual testing go-to)
2. Type some details into the Comment and exclude columns
3. Hit enter after editing (this bit is important, and a limit of the QTableView, the changes don't get picked up otherwise)
4. Click the export button
5. Think up a name and a place for your logbook
6. Hit enter
7. Check the contents of the CSV is as expected and the correct file extension was applied to the file.  

Fixes #33468 

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
