### PR TITLE
LoadIsawPeaks fix loading modulation vectors

### DIFF
--- a/docs/source/release/v6.6.0/Diffraction/Single_Crystal/Bugfixes/34623.rst
+++ b/docs/source/release/v6.6.0/Diffraction/Single_Crystal/Bugfixes/34623.rst
@@ -1,0 +1,1 @@
+* Fix issue where :ref:`LoadIsawPeaks <algm-LoadIsawPeaks>` fails when loading peaks with modulation vectors that cannot recover modulated UB matrix.


### PR DESCRIPTION
**Description of work.**

A bug fix for `LoadIsawPeaks`  with modulation vectors. To recover the fractional HKL offsets and modulated UB matrix, the algorithm uses `FindUBUsingIndexedPeaks` to determine the parameters. If they cannot be determined, it becomes impossible to load the peaks workspace.

A try/catch is added and if the error is caught, a warning is raised to the users letting them know they need to load a UB or determine it in some other way.

**To test:**

Run the `LoadIsawPeaks` unit test. Make sure the new test catches the error and provides the appropriate response to the user.

<!-- Instructions for testing. -->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
