### PR TITLE
Fix a bug with preview reduction when ROI detector IDs set

### DIFF
--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/RowProcessingAlgorithm.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/RowProcessingAlgorithm.cpp
@@ -134,7 +134,6 @@ void updateLookupRowProperties(AlgorithmRuntimeProps &properties, LookupRow cons
   AlgorithmProperties::update("ProcessingInstructions", lookupRow.processingInstructions(), properties);
   AlgorithmProperties::update("BackgroundProcessingInstructions", lookupRow.backgroundProcessingInstructions(),
                               properties);
-  AlgorithmProperties::update("ROIDetectorIDs", lookupRow.roiDetectorIDs(), properties);
 }
 
 void updateWavelengthRangeProperties(AlgorithmRuntimeProps &properties,
@@ -369,6 +368,7 @@ std::unique_ptr<MantidQt::API::IAlgorithmRuntimeProps> createAlgorithmRuntimePro
   auto lookupRow = row ? findLookupRow(*row, model) : findWildcardLookupRow(model);
   if (lookupRow) {
     updateLookupRowProperties(*properties, *lookupRow);
+    AlgorithmProperties::update("ROIDetectorIDs", lookupRow->roiDetectorIDs(), *properties);
   }
   // Update properties the user has specifically set for this run
   if (row) {

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/RowProcessingAlgorithm.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/RowProcessingAlgorithm.cpp
@@ -310,7 +310,7 @@ std::unique_ptr<MantidQt::API::IAlgorithmRuntimeProps> createAlgorithmRuntimePro
                                                                                    PreviewRow const &previewRow) {
   auto properties = std::make_unique<MantidQt::API::AlgorithmRuntimeProps>();
   updatePropertiesFromBatchModel(*properties, model);
-  // Look up properties for this run on the lookup table (or use wildcard defaults if no run is given)
+  // Look up properties for this run on the lookup table
   auto lookupRow = model.findLookupRow(previewRow);
   if (lookupRow) {
     updateLookupRowProperties(*properties, *lookupRow);

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/SumBanksAlgorithm.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/SumBanksAlgorithm.cpp
@@ -13,6 +13,7 @@
 #include "MantidQtWidgets/Common/AlgorithmRuntimeProps.h"
 #include "MantidQtWidgets/Common/BatchAlgorithmRunner.h"
 #include "MantidQtWidgets/Common/IAlgorithmRuntimeProps.h"
+#include "Reduction/IBatch.h"
 #include "Reduction/Item.h"
 #include "Reduction/PreviewRow.h"
 
@@ -44,7 +45,7 @@ namespace MantidQt::CustomInterfaces::ISISReflectometry::SumBanks {
  * @param alg : this param allows the caller to override the default algorithm type e.g. for injection of a mock;
  * in normal usage this should be left as the default nullptr
  */
-IConfiguredAlgorithm_sptr createConfiguredAlgorithm(IBatch const & /*model*/, PreviewRow &row, IAlgorithm_sptr alg) {
+IConfiguredAlgorithm_sptr createConfiguredAlgorithm(IBatch const &model, PreviewRow &row, IAlgorithm_sptr alg) {
   // Create the algorithm
   if (!alg) {
     alg = Mantid::API::AlgorithmManager::Instance().create("ReflectometryISISSumBanks");
@@ -53,8 +54,15 @@ IConfiguredAlgorithm_sptr createConfiguredAlgorithm(IBatch const & /*model*/, Pr
   alg->setAlwaysStoreInADS(false);
   alg->getPointerToProperty("OutputWorkspace")->createTemporaryValue();
 
-  // Set the algorithm properties from the model
   auto properties = std::make_unique<MantidQt::API::AlgorithmRuntimeProps>();
+
+  // Look up properties for this run on the lookup table
+  auto lookupRow = model.findLookupRow(row);
+  if (lookupRow) {
+    AlgorithmProperties::update("ROIDetectorIDs", lookupRow->roiDetectorIDs(), *properties);
+  }
+
+  // Set the algorithm properties from the row
   updateInputProperties(*properties, row.getLoadedWs(), row.getSelectedBanks());
 
   // Return the configured algorithm

--- a/qt/scientific_interfaces/ISISReflectometry/test/Reduction/MockBatch.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Reduction/MockBatch.h
@@ -25,8 +25,8 @@ public:
   MOCK_METHOD(RunsTable const &, runsTable, (), (const, override));
   MOCK_METHOD(Slicing const &, slicing, (), (const, override));
 
-  MOCK_METHOD(boost::optional<LookupRow>, findLookupRow, (Row const &), (const, override));
-  MOCK_METHOD(boost::optional<LookupRow>, findLookupRow, (PreviewRow const &), (const, override));
+  MOCK_METHOD(boost::optional<LookupRow>, findLookupRowProxy, (Row const &), (const));
+  MOCK_METHOD(boost::optional<LookupRow>, findLookupPreviewRowProxy, (PreviewRow const &), (const));
   MOCK_METHOD(boost::optional<LookupRow>, findWildcardLookupRow, (), (const, override));
   MOCK_METHOD(boost::optional<Item &>, getItemWithOutputWorkspaceOrNone, (std::string const &), (override));
   MOCK_METHOD(bool, isInSelection, (const Item &, const std::vector<MantidWidgets::Batch::RowLocation> &), (override));
@@ -38,5 +38,11 @@ public:
   MOCK_METHOD(void, updateLookupIndex, (Row &), (override));
   MOCK_METHOD(void, updateLookupIndexesOfGroup, (Group &), (override));
   MOCK_METHOD(void, updateLookupIndexesOfTable, (), (override));
+
+  // gtest struggles with the combination of overrides and references, so create proxies
+  boost::optional<LookupRow> findLookupRow(Row const &row) const override { return findLookupRowProxy(row); }
+  boost::optional<LookupRow> findLookupRow(PreviewRow const &row) const override {
+    return findLookupPreviewRowProxy(row);
+  }
 };
 } // namespace MantidQt::CustomInterfaces::ISISReflectometry


### PR DESCRIPTION
**Description of work.**
This PR fixes a bug where the Preview tab reduction would fail if a detector ROI is set on the Experiment Settings tab. This was because they were being applied to ReflectometryReductionOneAuto as well as ReflectometryISISLoadAndProcess. They are not applicable to the former but they should be passed to ReflectometryISISSumBanks instead. 

Fixes #34619

**To test:**

Follow the instructions in the linked issue and check the bugs are fixed.

*This does not require release notes* because **it fixes a bug in a new tab that has not been released yet**


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
