### PR TITLE
Disable region selector when no graph present

### DIFF
--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/IPreviewView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/IPreviewView.h
@@ -64,7 +64,7 @@ public:
   virtual void setInstViewEditMode() = 0;
   virtual void setInstViewSelectRectMode() = 0;
   virtual void setInstViewToolbarEnabled(bool enable) = 0;
-  virtual void setRegionSelectorToolbarEnabled(bool enable) = 0;
+  virtual void setRegionSelectorEnabled(bool enable) = 0;
   virtual void setAngle(double angle) = 0;
   virtual void setUpdateAngleButtonEnabled(bool enabled) = 0;
   // Region selector toolbar

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.cpp
@@ -51,7 +51,7 @@ PreviewPresenter::PreviewPresenter(Dependencies dependencies)
   m_jobManager->subscribe(this);
 
   m_view->setInstViewToolbarEnabled(false);
-  m_view->setRegionSelectorToolbarEnabled(false);
+  m_view->setRegionSelectorEnabled(false);
 
   m_plotPresenter->setScaleLog(AxisID::YLeft);
   m_plotPresenter->setScaleLog(AxisID::XBottom);
@@ -126,7 +126,7 @@ void PreviewPresenter::notifyUpdateAngle() { runReduction(); }
 
 void PreviewPresenter::notifySumBanksCompleted() {
   plotRegionSelector();
-  m_view->setRegionSelectorToolbarEnabled(true);
+  m_view->setRegionSelectorEnabled(true);
   // Perform reduction to update the next plot, if possible
   runReduction();
 }
@@ -252,7 +252,7 @@ PreviewRow const &PreviewPresenter::getPreviewRow() const { return m_model->getP
 
 void PreviewPresenter::clearRegionSelector() {
   m_regionSelector->clearWorkspace();
-  m_view->setRegionSelectorToolbarEnabled(false);
+  m_view->setRegionSelectorEnabled(false);
 }
 
 void PreviewPresenter::clearReductionPlot() {

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/QtPreviewView.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/QtPreviewView.cpp
@@ -163,11 +163,7 @@ void QtPreviewView::setInstViewToolbarEnabled(bool enable) {
   m_ui.iv_rect_select_button->setEnabled(enable);
 }
 
-void QtPreviewView::setRegionSelectorToolbarEnabled(bool enable) {
-  m_ui.rs_ads_export_button->setEnabled(enable);
-  m_ui.rs_edit_button->setEnabled(enable);
-  m_ui.rs_rect_select_button->setEnabled(enable);
-}
+void QtPreviewView::setRegionSelectorEnabled(bool enable) { m_ui.rsPlotLayoutWidget->setEnabled(enable); }
 
 void QtPreviewView::setAngle(double angle) {
   m_ui.angle_spin_box->blockSignals(true);

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/QtPreviewView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/QtPreviewView.h
@@ -52,7 +52,7 @@ public:
   void setInstViewEditMode() override;
   void setInstViewSelectRectMode() override;
   void setInstViewToolbarEnabled(bool enable) override;
-  void setRegionSelectorToolbarEnabled(bool enable) override;
+  void setRegionSelectorEnabled(bool enable) override;
   void setAngle(double angle) override;
   void setUpdateAngleButtonEnabled(bool enable) override;
   // Region selector toolbar

--- a/qt/scientific_interfaces/ISISReflectometry/test/Preview/MockPreviewView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Preview/MockPreviewView.h
@@ -31,7 +31,7 @@ public:
   MOCK_METHOD(void, setInstViewSelectRectState, (bool), (override));
   MOCK_METHOD(void, setInstViewSelectRectMode, (), (override));
   MOCK_METHOD(void, setInstViewToolbarEnabled, (bool), (override));
-  MOCK_METHOD(void, setRegionSelectorToolbarEnabled, (bool), (override));
+  MOCK_METHOD(void, setRegionSelectorEnabled, (bool), (override));
   MOCK_METHOD(void, setInstViewZoomMode, (), (override));
   MOCK_METHOD(void, setInstViewEditMode, (), (override));
   MOCK_METHOD(void, setRectangularROIState, (bool), (override));

--- a/qt/scientific_interfaces/ISISReflectometry/test/Preview/PreviewPresenterTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Preview/PreviewPresenterTest.h
@@ -548,7 +548,7 @@ private:
   }
 
   void expectRegionSelectorToolbarEnabled(MockPreviewView &mockView, bool enable) {
-    EXPECT_CALL(mockView, setRegionSelectorToolbarEnabled(Eq(enable))).Times(1);
+    EXPECT_CALL(mockView, setRegionSelectorEnabled(Eq(enable))).Times(1);
   }
 
   void expectInstViewSetToZoomMode(MockPreviewView &mockView) {
@@ -623,7 +623,7 @@ private:
 
   void expectRegionSelectorCleared(MockPreviewView &mockView, MockRegionSelector *mockRegionSelector) {
     EXPECT_CALL(*mockRegionSelector, clearWorkspace()).Times(1);
-    EXPECT_CALL(mockView, setRegionSelectorToolbarEnabled(false)).Times(1);
+    EXPECT_CALL(mockView, setRegionSelectorEnabled(false)).Times(1);
   }
 
   void expectReductionPlotCleared(MockPlotPresenter *mockPlotPresenter) {


### PR DESCRIPTION
**Description of work.**

This was allowing some unhandled exceptions to occur fairly frequently. Disabling the region selector (sliceviewer) stops the user being able to cause these. The SV isn't really meant to exist without data, and so doesn't handle these cases gracefully.

**To test:**
Data available from: https://github.com/mantidproject/mantid/issues/31069

1. Boot up the refl GUI
2. Check that you cannot interact with the sliceviewer and cause unhandled exceptions. 
3. Load `INTER45455_inst` on the preview tab with an angle (0.7 I think is the actual angle)
4. Check you can now interact properly. Changing scales and adding rectangular regions. 

Fixes #34601 


*This does not require release notes* because **because this tab isn't user facing yet.**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
