### PR TITLE
Add HKL to cursor info in slice viewer

### DIFF
--- a/docs/source/release/v6.6.0/Workbench/SliceViewer/New_features/34645.rst
+++ b/docs/source/release/v6.6.0/Workbench/SliceViewer/New_features/34645.rst
@@ -1,0 +1,1 @@
+- add HKL values to the image info table in the slice viewer when viewing a workspace with HKL coordinates

--- a/docs/source/workbench/sliceviewer.rst
+++ b/docs/source/workbench/sliceviewer.rst
@@ -195,6 +195,7 @@ and for an MDWorkspace:
 - Signal
 - x
 - y
+- H, K, L (if workspace has HKL coordinates)
 
 .. figure:: ../images/wb-sliceviewer51-cursorinfo-md.png
    :class: screenshot

--- a/qt/python/mantidqt/mantidqt/_common.sip
+++ b/qt/python/mantidqt/mantidqt/_common.sip
@@ -1060,10 +1060,10 @@ class ImageInfoWidget : public QTableWidget {
 %End
 public:
     ImageInfoWidget(QWidget *parent = nullptr);
-    void cursorAt(const double x, const double y, const double signal);
+    void cursorAt(const double x, const double y, const double signal, const QMap<QString, QString>& extraValues);
     %MethodCode
     try {
-      sipCpp->cursorAt(a0, a1, a2);
+      sipCpp->cursorAt(a0, a1, a2, *a3);
     } catch(const std::exception & exc) {
       SIP_BLOCK_THREADS
       PyErr_SetString(PyExc_RuntimeError, exc.what());

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/models/model.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/models/model.py
@@ -549,6 +549,15 @@ class SliceViewerModel(SliceViewerBaseModel):
 
         return xcut_name, ycut_name, help_msg
 
+    def get_hkl_from_xyz(self, xdim, ydim, zdim, xdata, ydata, zdata):
+        basis_transform = self.get_proj_matrix()
+        if basis_transform is not None:
+            hkl = basis_transform[:, xdim] * xdata + basis_transform[:, ydim] * ydata \
+                  + basis_transform[:, zdim] * zdata
+        else:
+            hkl = {0., 0., 0.}
+        return hkl
+
 
 # private functions
 def _roi_binmd_parameters(workspace, slicepoint: Sequence[Optional[float]],

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_sliceviewer_dataview.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_sliceviewer_dataview.py
@@ -168,6 +168,7 @@ class SliceviewerDataViewTest(unittest.TestCase):
     def test_plot_matrix(self):
         self.view.image = None
         self.view.clear_image = mock.Mock()
+        self.view.on_track_cursor_state_change = mock.Mock()
         self.view.ax = mock.Mock()
         self.view.colorbar = mock.Mock()
 
@@ -183,6 +184,7 @@ class SliceviewerDataViewTest(unittest.TestCase):
         self.view.image = original_image
         self.view.image.transpose = self.view.dimensions.transpose
         self.view.clear_image = mock.Mock()
+        self.view.on_track_cursor_state_change = mock.Mock()
         self.view.ax = mock.Mock()
         self.view.colorbar = mock.Mock()
 

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_sliceviewer_imageinfowidget.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_sliceviewer_imageinfowidget.py
@@ -34,7 +34,7 @@ class ImageInfoTrackerTest(unittest.TestCase):
 
         tracker.on_cursor_at(1.0, 1.0)
 
-        self.image_info_widget.cursorAt.assert_called_with(1.0, 1.0, float_info.max)
+        self.image_info_widget.cursorAt.assert_called_with(1.0, 1.0, float_info.max, {})
 
     def test_nonortho_transform_applied_when_mesh_and_transfrom_true(self):
         del self.image.get_extent  # so image treated as mesh
@@ -46,7 +46,7 @@ class ImageInfoTrackerTest(unittest.TestCase):
 
         tracker.on_cursor_at(1.0, 1.0)
 
-        self.image_info_widget.cursorAt.assert_called_with(0.42264973081037405, 1.1547005383792517, float_info.max)
+        self.image_info_widget.cursorAt.assert_called_with(0.42264973081037405, 1.1547005383792517, float_info.max, {})
 
     @patch("mantidqt.widgets.sliceviewer.presenters.imageinfowidget.cursor_info")
     def test_nonortho_transform_not_applied_when_not_mesh(self, mock_cursorinfo):
@@ -117,6 +117,27 @@ class ImageInfoTrackerTest(unittest.TestCase):
 
         tracker.on_cursor_at(xdata, ydata)
         self.image_info_widget.cursorAt.assert_called_with(xdata, ydata, underlying_array[xindex][yindex], extra_cols)
+
+    @patch("mantidqt.widgets.sliceviewer.presenters.imageinfowidget.cursor_info")
+    def test_cursorAt_called_with_extra_cols_specified_by_model_mesh(self, mock_cursorinfo):
+        underlying_array = array([[1.0, 2.0], [3.0, 4.0]])
+        xdata, ydata = 0.0, 1.0  # Data on image x and y axes at cursor position
+        xindex, yindex = 0, 1
+        mock_cursorinfo.return_value = (underlying_array, None, (xindex, yindex))
+        extra_cols = {"H":"1.0", "K":"2.0", "L":"0.0"}
+        presenter_with_extra_cols = MagicMock()
+        presenter_with_extra_cols.get_extra_image_info_columns.return_value = extra_cols
+        del self.image.get_extent  # so image treated as mesh
+        image = self.image
+        image.transpose = False
+        tracker = ImageInfoTracker(image=self.image,
+                                   presenter=presenter_with_extra_cols,
+                                   transform=None,
+                                   do_transform=False,
+                                   widget=self.image_info_widget)
+
+        tracker.on_cursor_at(xdata, ydata)
+        self.image_info_widget.cursorAt.assert_called_with(xdata, ydata, float_info.max, extra_cols)
 
 
 if __name__ == '__main__':

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_sliceviewer_imageinfowidget.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_sliceviewer_imageinfowidget.py
@@ -21,10 +21,13 @@ class ImageInfoTrackerTest(unittest.TestCase):
         self.image = MagicMock()
         self.nonortho_transform = NonOrthogonalTransform(radians(60))
         self.image_info_widget = MagicMock(ImageInfoWidget)
+        self.presenter = MagicMock()
+        self.presenter.get_extra_image_info_columns.return_value = {}
 
     def test_nonortho_transform_not_applied_when_mesh_and_transfrom_false(self):
         del self.image.get_extent  # so image treated as mesh
         tracker = ImageInfoTracker(image=self.image,
+                                   presenter=self.presenter,
                                    transform=self.nonortho_transform,
                                    do_transform=False,
                                    widget=self.image_info_widget)
@@ -36,6 +39,7 @@ class ImageInfoTrackerTest(unittest.TestCase):
     def test_nonortho_transform_applied_when_mesh_and_transfrom_true(self):
         del self.image.get_extent  # so image treated as mesh
         tracker = ImageInfoTracker(image=self.image,
+                                   presenter=self.presenter,
                                    transform=self.nonortho_transform,
                                    do_transform=True,
                                    widget=self.image_info_widget)
@@ -49,13 +53,14 @@ class ImageInfoTrackerTest(unittest.TestCase):
         mock_cursorinfo.return_value = (
             2 * eye(2, dtype=float), None, (1, 1))  # output simple 2D array and slice indices
         tracker = ImageInfoTracker(image=self.image,
+                                   presenter=self.presenter,
                                    transform=self.nonortho_transform,
                                    do_transform=True,
                                    widget=self.image_info_widget)
 
         tracker.on_cursor_at(1.0, 1.0)
 
-        self.image_info_widget.cursorAt.assert_called_with(1.0, 1.0, 2.0)
+        self.image_info_widget.cursorAt.assert_called_with(1.0, 1.0, 2.0, {})
 
     @patch("mantidqt.widgets.sliceviewer.presenters.imageinfowidget.cursor_info")
     def test_cursorAt_arguments_correct_when_not_mesh_and_not_transposed(self, mock_cursorinfo):
@@ -66,12 +71,13 @@ class ImageInfoTrackerTest(unittest.TestCase):
         image = self.image
         image.transpose = False
         tracker = ImageInfoTracker(image=self.image,
+                                   presenter=self.presenter,
                                    transform=None,
                                    do_transform=False,
                                    widget=self.image_info_widget)
 
         tracker.on_cursor_at(xdata, ydata)
-        self.image_info_widget.cursorAt.assert_called_with(xdata, ydata, underlying_array[xindex][yindex])
+        self.image_info_widget.cursorAt.assert_called_with(xdata, ydata, underlying_array[xindex][yindex], {})
 
     @patch("mantidqt.widgets.sliceviewer.presenters.imageinfowidget.cursor_info")
     def test_cursorAt_arguments_correct_when_not_mesh_and_transposed(self, mock_cursorinfo):
@@ -82,6 +88,7 @@ class ImageInfoTrackerTest(unittest.TestCase):
         image = self.image
         image.transpose = True
         tracker = ImageInfoTracker(image=self.image,
+                                   presenter=self.presenter,
                                    transform=None,
                                    do_transform=False,
                                    widget=self.image_info_widget)
@@ -89,7 +96,27 @@ class ImageInfoTrackerTest(unittest.TestCase):
         tracker.on_cursor_at(xdata, ydata)
         # Since the image is transposed, the x and y on the axes with respect to the data is the wrong way around,
         # but the 'signal' at this point in the underlying array is still 2.0
-        self.image_info_widget.cursorAt.assert_called_with(ydata, xdata, underlying_array[xindex][yindex])
+        self.image_info_widget.cursorAt.assert_called_with(ydata, xdata, underlying_array[xindex][yindex], {})
+
+    @patch("mantidqt.widgets.sliceviewer.presenters.imageinfowidget.cursor_info")
+    def test_cursorAt_called_with_extra_cols_specified_by_model(self, mock_cursorinfo):
+        underlying_array = array([[1.0, 2.0], [3.0, 4.0]])
+        xdata, ydata = 0.0, 1.0  # Data on image x and y axes at cursor position
+        xindex, yindex = 0, 1
+        mock_cursorinfo.return_value = (underlying_array, None, (xindex, yindex))
+        extra_cols = {"H":"1.0", "K":"2.0", "L":"0.0"}
+        presenter_with_extra_cols = MagicMock()
+        presenter_with_extra_cols.get_extra_image_info_columns.return_value = extra_cols
+        image = self.image
+        image.transpose = False
+        tracker = ImageInfoTracker(image=self.image,
+                                   presenter=presenter_with_extra_cols,
+                                   transform=None,
+                                   do_transform=False,
+                                   widget=self.image_info_widget)
+
+        tracker.on_cursor_at(xdata, ydata)
+        self.image_info_widget.cursorAt.assert_called_with(xdata, ydata, underlying_array[xindex][yindex], extra_cols)
 
 
 if __name__ == '__main__':

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_sliceviewer_model.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_sliceviewer_model.py
@@ -878,6 +878,13 @@ class SliceViewerModelTest(unittest.TestCase):
         for export_type in ('r', 'c', 'x', 'y'):
             assert_error_returned_in_help(self.ws_MDE_3D, export_type, mock_binmd, 'BinMD failed')
 
+    @patch('mantidqt.widgets.sliceviewer.models.model.SliceViewerModel.get_proj_matrix')
+    def test_get_hkl_from_xyz(self, mock_get_proj_matrix):
+        model = SliceViewerModel(self.ws_MDE_3D)
+        mock_get_proj_matrix.return_value = np.array([[0, 1, -1], [0, 1, 1], [1, 0, 0]])
+        hkl = model.get_hkl_from_xyz(0, 1, 2, 1.0, 2.0, 3.0)
+        self.assertTrue((hkl == [-1, 5, 1]).all())
+
     # private
     def _assert_supports_non_orthogonal_axes(self, expectation, ws_type, coords,
                                              has_oriented_lattice):

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_sliceviewer_presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_sliceviewer_presenter.py
@@ -10,8 +10,9 @@
 import sys
 import unittest
 from unittest import mock
-from unittest.mock import patch
+from unittest.mock import patch, call
 from mantid.api import IMDHistoWorkspace
+from mantid.kernel import SpecialCoordinateSystem
 
 import matplotlib
 
@@ -68,8 +69,8 @@ def create_mdhistoworkspace_mock():
 
 
 class SliceViewerTest(unittest.TestCase):
-    def setUp(self):
-        self.view = mock.Mock(spec=SliceViewerView)
+
+    def createMockDataView(self):
         data_view = mock.Mock(spec=SliceViewerDataView)
         data_view.plot_MDH = mock.Mock()
         data_view.dimensions = mock.Mock()
@@ -80,7 +81,11 @@ class SliceViewerTest(unittest.TestCase):
         data_view.nonorthogonal_mode = False
         data_view.nonortho_transform = None
         data_view.get_axes_limits.return_value = None
+        return data_view
 
+    def setUp(self):
+        self.view = mock.Mock(spec=SliceViewerView)
+        data_view = self.createMockDataView()
         dimensions = mock.Mock()
         dimensions.get_slicepoint.return_value = [None, None, 0.5]
         dimensions.transpose = False
@@ -89,11 +94,32 @@ class SliceViewerTest(unittest.TestCase):
         data_view.dimensions = dimensions
         self.view.data_view = data_view
 
+        self.view3D_non_QDim = mock.Mock(spec=SliceViewerView)
+        data_view3D_non_QDim = self.createMockDataView()
+        dimensions3D_non_QDim = mock.Mock()
+        dimensions3D_non_QDim.get_slicepoint.return_value = [None, None, 0.5]
+        dimensions3D_non_QDim.transpose = False
+        dimensions3D_non_QDim.get_slicerange.return_value = [None, None, (-15, 15)]
+        dimensions3D_non_QDim.qflags = [False, True, True]
+        data_view3D_non_QDim.dimensions = dimensions3D_non_QDim
+        self.view3D_non_QDim.data_view = data_view3D_non_QDim
+
+        self.view4D = mock.Mock(spec=SliceViewerView)
+        data_view4D = self.createMockDataView()
+        dimensions4D = mock.Mock()
+        dimensions4D.get_slicepoint.return_value = [None, None, 0.5, 0.5]
+        dimensions4D.transpose = False
+        dimensions4D.get_slicerange.return_value = [None, None, (-15, 15), (-15, 15)]
+        dimensions4D.qflags = [False, True, True, True]
+        data_view4D.dimensions = dimensions4D
+        self.view4D.data_view = data_view4D
+
         self.model = mock.Mock(spec=SliceViewerModel)
         self.model.get_ws = mock.Mock()
         self.model.get_data = mock.Mock()
         self.model.rebin = mock.Mock()
         self.model.workspace_equals = mock.Mock()
+        self.model.get_hkl_from_xyz.return_value = [1.0, 1.0, 1.0]
         self.model.get_properties.return_value = {
             "workspace_type": "WS_TYPE.MATRIX",
             "supports_normalise": True,
@@ -203,21 +229,21 @@ class SliceViewerTest(unittest.TestCase):
         presenter.normalization_changed("By bin width")
         self.view.data_view.plot_matrix.assert_called_with(self.model.ws, distribution=False)
 
-    def peaks_button_disabled_if_model_cannot_support_it(self):
+    def test_peaks_button_disabled_if_model_cannot_support_it(self):
         self.patched_deps["WorkspaceInfo"].get_ws_type.return_value = WS_TYPE.MATRIX
-        self.model.can_support_peaks_overlay.return_value = False
+        self.model.can_support_peaks_overlays.return_value = False
 
         SliceViewer(None, model=self.model, view=self.view)
 
-        self.view.data_view.disable_tool_button.assert_called_once_with(ToolItemText.OVERLAY_PEAKS)
+        self.view.data_view.disable_tool_button.assert_any_call(ToolItemText.OVERLAY_PEAKS)
 
-    def peaks_button_not_disabled_if_model_can_support_it(self):
+    def test_peaks_button_not_disabled_if_model_can_support_it(self):
         self.patched_deps["WorkspaceInfo"].get_ws_type.return_value = WS_TYPE.MATRIX
-        self.model.can_support_peaks_overlay.return_value = True
+        self.model.can_support_peaks_overlays.return_value = True
 
         SliceViewer(None, model=self.model, view=self.view)
 
-        self.view.data_view.disable_tool_button.assert_not_called()
+        assert call(ToolItemText.OVERLAY_PEAKS) not in self.view.data_view.disable_tool_button.mock_calls
 
     def test_non_orthogonal_axes_toggled_on(self):
         self.patched_deps["WorkspaceInfo"].get_ws_type.return_value = WS_TYPE.MDE
@@ -626,6 +652,23 @@ class SliceViewerTest(unittest.TestCase):
 
         mock_peaks_presenter.add_delete_peak.assert_called_once_with([3, 2, 1])
         self.view.data_view.canvas.draw_idle.assert_called_once()
+
+    @mock.patch("mantidqt.widgets.sliceviewer.presenters.presenter.SliceViewer.get_frame")
+    def test_workspace_requests_hkl_for_image_info(self, mock_get_frame):
+        def run_requests_hkl_test(pres, ncols, callcount):
+            self.patched_deps["WorkspaceInfo"].display_indices.return_value = [0, 1]
+            mock_get_frame.return_value = SpecialCoordinateSystem.HKL
+            self.model.get_hkl_from_xyz.reset_mock()
+            extra_cols = pres.get_extra_image_info_columns(1.0, 2.0, False)
+            self.assertEqual(self.model.get_hkl_from_xyz.call_count, callcount)
+            self.assertEqual(len(extra_cols), ncols)
+
+        pres3D = SliceViewer(mock.Mock(), model=self.model, view=self.view)
+        run_requests_hkl_test(pres3D, 3, 1)
+        pres3D_no_q_dim = SliceViewer(mock.Mock(), model=self.model, view=self.view3D_non_QDim)
+        run_requests_hkl_test(pres3D_no_q_dim, 0, 0)
+        pres4D = SliceViewer(mock.Mock(), model=self.model, view=self.view4D)
+        run_requests_hkl_test(pres4D, 3, 1)
 
 
 if __name__ == '__main__':

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_sliceviewer_presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_sliceviewer_presenter.py
@@ -659,7 +659,7 @@ class SliceViewerTest(unittest.TestCase):
             self.patched_deps["WorkspaceInfo"].display_indices.return_value = [0, 1]
             mock_get_frame.return_value = SpecialCoordinateSystem.HKL
             self.model.get_hkl_from_xyz.reset_mock()
-            extra_cols = pres.get_extra_image_info_columns(1.0, 2.0, False)
+            extra_cols = pres.get_extra_image_info_columns(1.0, 2.0)
             self.assertEqual(self.model.get_hkl_from_xyz.call_count, callcount)
             self.assertEqual(len(extra_cols), ncols)
 

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/views/dataview.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/views/dataview.py
@@ -325,7 +325,7 @@ class SliceViewerDataView(QWidget):
         if self.image is not None:
             if self.line_plots_active:
                 self._line_plots.plotter.delete_line_plot_lines()
-            self.image_info_widget.cursorAt(DBLMAX, DBLMAX, DBLMAX)
+            self._image_info_tracker.on_cursor_outside_axes()
             if hasattr(self.ax, "remove_artists_if"):
                 self.ax.remove_artists_if(lambda art: art == self.image)
             else:
@@ -388,7 +388,8 @@ class SliceViewerDataView(QWidget):
                                                     transform=self.nonortho_transform,
                                                     do_transform=self.nonorthogonal_mode,
                                                     widget=self.image_info_widget,
-                                                    cursor_transform=self._orig_lims)
+                                                    cursor_transform=self._orig_lims,
+                                                    presenter=self.presenter)
 
         if state:
             self._image_info_tracker.connect()
@@ -398,6 +399,7 @@ class SliceViewerDataView(QWidget):
             self._image_info_tracker.disconnect()
             if self._line_plots and not self._region_selection_on:
                 self._line_plots.disconnect()
+        self._image_info_tracker.on_cursor_outside_axes()
 
     def on_home_clicked(self):
         """Reset the view to encompass all of the data"""

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/IImageInfoWidget.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/IImageInfoWidget.h
@@ -19,7 +19,8 @@ class EXPORT_OPT_MANTIDQT_COMMON IImageInfoWidget : public QTableWidget {
 public:
   IImageInfoWidget(QWidget *parent = nullptr) : QTableWidget(0, 0, parent) {}
 
-  virtual void cursorAt(const double x, const double y, const double signal) = 0;
+  virtual void cursorAt(const double x, const double y, const double signal,
+                        const QMap<QString, QString> &extraValues) = 0;
   virtual void showInfo(const ImageInfoModel::ImageInfo &info) = 0;
   virtual void setWorkspace(const Mantid::API::Workspace_sptr &ws) = 0;
 };

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/ImageInfoModel.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/ImageInfoModel.h
@@ -11,6 +11,7 @@
 #include "MantidAPI/Workspace.h"
 #include "MantidKernel/Unit.h"
 #include "MantidKernel/UnitFactory.h"
+#include <QMap>
 #include <QString>
 #include <cmath>
 #include <vector>
@@ -59,9 +60,11 @@ public:
   @param x: x data coordinate
   @param y: y data coordinate
   @param signal: the signal value at x, y
+  @param extraValues: extra values to be displayed in the image info table
   @return An ImageInfo object
   */
-  virtual ImageInfoModel::ImageInfo info(const double x, const double y, const double signal) const = 0;
+  virtual ImageInfoModel::ImageInfo info(const double x, const double y, const double signal,
+                                         const QMap<QString, QString> &extraValues) const = 0;
 };
 
 } // namespace MantidWidgets

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/ImageInfoModelMD.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/ImageInfoModelMD.h
@@ -21,9 +21,11 @@ public:
    * @param x: x data coordinate
    * @param y: y data coordinate
    * @param signal: the signal value at x, y
+   * @param extraValues: extra values to be displayed in the image info table
    * @return An ImageInfo object describing the point
    */
-  ImageInfoModel::ImageInfo info(const double x, const double y, const double signal) const override;
+  ImageInfoModel::ImageInfo info(const double x, const double y, const double signal,
+                                 const QMap<QString, QString> &extraValues) const override;
 };
 
 } // namespace MantidWidgets

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/ImageInfoModelMatrixWS.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/ImageInfoModelMatrixWS.h
@@ -36,7 +36,8 @@ class EXPORT_OPT_MANTIDQT_COMMON ImageInfoModelMatrixWS : public ImageInfoModel 
 public:
   ImageInfoModelMatrixWS(Mantid::API::MatrixWorkspace_sptr workspace);
 
-  ImageInfoModel::ImageInfo info(const double x, const double y, const double signal) const override;
+  ImageInfoModel::ImageInfo info(const double x, const double y, const double signal,
+                                 const QMap<QString, QString> &extraValues) const override;
 
 private:
   void setUnitsInfo(ImageInfoModel::ImageInfo *info, int infoIndex, const size_t wsIndex, const double x) const;

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/ImageInfoPresenter.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/ImageInfoPresenter.h
@@ -25,7 +25,7 @@ public:
 
   inline const ImageInfoModel &model() { return *m_model; }
 
-  void cursorAt(const double x, const double y, const double signal);
+  void cursorAt(const double x, const double y, const double signal, const QMap<QString, QString> extraValues);
   void setWorkspace(const Mantid::API::Workspace_sptr &ws);
 
 private:

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/ImageInfoWidget.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/ImageInfoWidget.h
@@ -10,6 +10,7 @@
 #include "DllOption.h"
 #include "MantidQtWidgets/Common/IImageInfoWidget.h"
 #include "MantidQtWidgets/Common/ImageInfoPresenter.h"
+#include <QMap>
 
 namespace MantidQt {
 namespace MantidWidgets {
@@ -24,7 +25,10 @@ class EXPORT_OPT_MANTIDQT_COMMON ImageInfoWidget : public IImageInfoWidget {
 public:
   ImageInfoWidget(QWidget *parent = nullptr);
 
-  void cursorAt(const double x, const double y, const double signal) override;
+  // Note: QMap has sip binding via PyQt but only for specific types (both types have to be classes or the first type
+  // has to be int)
+  void cursorAt(const double x, const double y, const double signal,
+                const QMap<QString, QString> &extraValues) override;
   void setWorkspace(const Mantid::API::Workspace_sptr &ws) override;
   void showInfo(const ImageInfoModel::ImageInfo &info) override;
 

--- a/qt/widgets/common/src/ImageInfoModelMD.cpp
+++ b/qt/widgets/common/src/ImageInfoModelMD.cpp
@@ -11,13 +11,18 @@
 namespace MantidQt::MantidWidgets {
 
 /// @copydoc MantidQt::MantidWidgets::ImageInfoModel::info
-ImageInfoModel::ImageInfo ImageInfoModelMD::info(const double x, const double y, const double signal) const {
+ImageInfoModel::ImageInfo ImageInfoModelMD::info(const double x, const double y, const double signal,
+                                                 const QMap<QString, QString> &extraValues) const {
   ImageInfo info({"x", "y", "Signal"});
+  for (auto &extraName : extraValues.keys())
+    info.m_names.push_back(extraName);
 
   auto valueOrMissing = [](double value) { return value == UnsetValue ? MissingValue : defaultFormat(value); };
   info.setValue(0, valueOrMissing(x));
   info.setValue(1, valueOrMissing(y));
   info.setValue(2, valueOrMissing(signal));
+  for (auto &extraValue : extraValues.values())
+    info.m_values.push_back(extraValue);
 
   return info;
 }

--- a/qt/widgets/common/src/ImageInfoModelMatrixWS.cpp
+++ b/qt/widgets/common/src/ImageInfoModelMatrixWS.cpp
@@ -51,7 +51,8 @@ ImageInfoModelMatrixWS::ImageInfoModelMatrixWS(Mantid::API::MatrixWorkspace_sptr
 }
 
 /// @copydoc MantidQt::MantidWidgets::ImageInfoModel::info
-ImageInfoModel::ImageInfo ImageInfoModelMatrixWS::info(const double x, const double y, const double signal) const {
+ImageInfoModel::ImageInfo ImageInfoModelMatrixWS::info(const double x, const double y, const double signal,
+                                                       const QMap<QString, QString> &) const {
   ImageInfo info(m_names);
   if (x == UnsetValue || y == UnsetValue || signal == UnsetValue)
     return info;

--- a/qt/widgets/common/src/ImageInfoPresenter.cpp
+++ b/qt/widgets/common/src/ImageInfoPresenter.cpp
@@ -23,10 +23,12 @@ ImageInfoPresenter::ImageInfoPresenter(IImageInfoWidget *view) : m_model(), m_vi
  * @param x X position on an image of the workspace
  * @param y Y position on an image of the workspace
  * @param signal The signal value at the given position
+ * @param extraValues A map of extra column names and values to display
  */
-void ImageInfoPresenter::cursorAt(const double x, const double y, const double signal) {
+void ImageInfoPresenter::cursorAt(const double x, const double y, const double signal,
+                                  const QMap<QString, QString> extraValues) {
   assert(m_model);
-  m_view->showInfo(m_model->info(x, y, signal));
+  m_view->showInfo(m_model->info(x, y, signal, extraValues));
 }
 
 /**
@@ -39,8 +41,6 @@ void ImageInfoPresenter::setWorkspace(const Mantid::API::Workspace_sptr &workspa
   else {
     m_model = std::make_unique<ImageInfoModelMD>();
   }
-  // Blank view
-  cursorAt(ImageInfoModel::UnsetValue, ImageInfoModel::UnsetValue, ImageInfoModel::UnsetValue);
 }
 
 } // namespace MantidQt::MantidWidgets

--- a/qt/widgets/common/src/ImageInfoWidget.cpp
+++ b/qt/widgets/common/src/ImageInfoWidget.cpp
@@ -30,9 +30,11 @@ ImageInfoWidget::ImageInfoWidget(QWidget *parent)
  * @param x X position if the cursor
  * @param y Y position if the cursor
  * @param signal Signal value at cursor position
+ * @param extraValues A map of extra column names and values to display
  */
-void ImageInfoWidget::cursorAt(const double x, const double y, const double signal) {
-  m_presenter->cursorAt(x, y, signal);
+void ImageInfoWidget::cursorAt(const double x, const double y, const double signal,
+                               const QMap<QString, QString> &extraValues) {
+  m_presenter->cursorAt(x, y, signal, extraValues);
 }
 
 /**

--- a/qt/widgets/common/test/ImageInfoModelMDTest.h
+++ b/qt/widgets/common/test/ImageInfoModelMDTest.h
@@ -21,22 +21,30 @@ public:
   void test_info_with_md_ws() {
     ImageInfoModelMD model;
 
-    auto info = model.info(2, 4, 7.5);
+    auto info = model.info(2, 4, 7.5, {});
 
-    assertInfoMatches(info, {"2.0000", "4.0000", "7.5000"});
+    assertInfoMatches(info, {"x", "y", "Signal"}, {"2.0000", "4.0000", "7.5000"});
   }
 
   void test_info_returns_dashes_when_given_double_max() {
     ImageInfoModelMD model;
 
-    auto info = model.info(2, std::numeric_limits<double>::max(), 7);
+    auto info = model.info(2, std::numeric_limits<double>::max(), 7, {});
 
-    assertInfoMatches(info, {"2.0000", "-", "7.0000"});
+    assertInfoMatches(info, {"x", "y", "Signal"}, {"2.0000", "-", "7.0000"});
+  }
+
+  void test_info_returns_extra_values() {
+    ImageInfoModelMD model;
+
+    auto info = model.info(2, std::numeric_limits<double>::max(), 7, {{"Extra1", "1.0"}, {"Extra2", "1.5"}});
+
+    assertInfoMatches(info, {"x", "y", "Signal", "Extra1", "Extra2"}, {"2.0000", "-", "7.0000", "1.0", "1.5"});
   }
 
 private:
-  void assertInfoMatches(const ImageInfoModel::ImageInfo &info, const std::vector<std::string> &expectedValues) {
-    constexpr std::array<const char *, 3> expectedHeaders{"x", "y", "Signal"};
+  void assertInfoMatches(const ImageInfoModel::ImageInfo &info, const std::vector<const char *> &expectedHeaders,
+                         const std::vector<std::string> &expectedValues) {
     TS_ASSERT_EQUALS(expectedHeaders.size(), info.size())
     for (int i = 0; i < info.size(); ++i) {
       TS_ASSERT_EQUALS(expectedHeaders[i], info.name(i).toStdString());

--- a/qt/widgets/common/test/ImageInfoModelMatrixWSTest.h
+++ b/qt/widgets/common/test/ImageInfoModelMatrixWSTest.h
@@ -72,7 +72,7 @@ public:
     auto workspace = WorkspaceCreationHelper::create2DWorkspaceBinned(10, 10, 15000.0, 100.);
     ImageInfoModelMatrixWS model(workspace);
 
-    const auto info = model.info(15200, 4, 7);
+    const auto info = model.info(15200, 4, 7, {});
 
     const InfoItems expectedInfo = {{"x", "15200.0000"},
                                     {"Spectrum", "4"},
@@ -122,9 +122,9 @@ public:
     };
 
     constexpr auto dblmax = std::numeric_limits<double>::max();
-    assertBlankInfo(model.info(dblmax, 4, 7));
-    assertBlankInfo(model.info(15200, dblmax, 7));
-    assertBlankInfo(model.info(15200, 4, dblmax));
+    assertBlankInfo(model.info(dblmax, 4, 7, {}));
+    assertBlankInfo(model.info(15200, dblmax, 7, {}));
+    assertBlankInfo(model.info(15200, 4, dblmax, {}));
   }
 
   void test_info_for_monitor() {
@@ -185,7 +185,7 @@ public:
 
       ImageInfoModelMatrixWS model(DirectEFixed(logName)(workspace));
 
-      TS_ASSERT_THROWS_NOTHING(model.info(x, y, signal));
+      TS_ASSERT_THROWS_NOTHING(model.info(x, y, signal, {}));
     }
   }
 
@@ -203,7 +203,7 @@ private:
     }
     ImageInfoModelMatrixWS model(addEfixed(workspace));
 
-    const auto info = model.info(x, y, signal);
+    const auto info = model.info(x, y, signal, {});
 
     TS_ASSERT_EQUALS(expectedInfo.size(), info.size());
     int index(0);

--- a/qt/widgets/common/test/ImageInfoPresenterTest.h
+++ b/qt/widgets/common/test/ImageInfoPresenterTest.h
@@ -43,19 +43,17 @@ public:
   static ImageInfoPresenterTest *createSuite() { return new ImageInfoPresenterTest(); }
   static void destroySuite(ImageInfoPresenterTest *suite) { delete suite; }
 
-  void test_constructor_calls_view_showInfo() {
+  void test_constructor_calls_view_set_row_count() {
     auto mockView = std::make_unique<StrictMock<MockImageInfoView>>();
 
-    EXPECT_CALL(*mockView, showInfo(_)).Times(1);
-
     ImageInfoPresenter presenter(mockView.get());
-    presenter.setWorkspace(WorkspaceCreationHelper::create2DWorkspace123(10, 10));
+    TS_ASSERT_EQUALS(mockView->rowCount(), 2);
   }
 
   void test_cursorAt_calls_view_showInfo() {
     auto mockView = std::make_unique<StrictMock<MockImageInfoView>>();
 
-    EXPECT_CALL(*mockView, showInfo(_)).Times(2);
+    EXPECT_CALL(*mockView, showInfo(_)).Times(1);
 
     ImageInfoPresenter presenter(mockView.get());
     presenter.setWorkspace(WorkspaceCreationHelper::create2DWorkspace123(10, 10));
@@ -66,7 +64,6 @@ public:
     auto mockView = std::make_unique<MockImageInfoView>();
     ImageInfoPresenter presenter(mockView.get());
     auto matrixWS = WorkspaceCreationHelper::create1DWorkspaceRand(1, true);
-    EXPECT_CALL(*mockView, showInfo(_)).Times(1);
 
     presenter.setWorkspace(matrixWS);
 
@@ -79,7 +76,6 @@ public:
     auto mockView = std::make_unique<MockImageInfoView>();
     ImageInfoPresenter presenter(mockView.get());
     const auto mdWS = makeFakeMDEventWorkspace("dummyName", 100);
-    EXPECT_CALL(*mockView, showInfo(_)).Times(1);
 
     presenter.setWorkspace(mdWS);
 

--- a/qt/widgets/common/test/ImageInfoPresenterTest.h
+++ b/qt/widgets/common/test/ImageInfoPresenterTest.h
@@ -28,7 +28,8 @@ GNU_DIAG_OFF_SUGGEST_OVERRIDE
 
 class MockImageInfoView : public IImageInfoWidget {
 public:
-  MOCK_METHOD3(cursorAt, void(const double x, const double y, const double z));
+  MOCK_METHOD4(cursorAt,
+               void(const double x, const double y, const double signal, const QMap<QString, QString> &extraValues));
   MOCK_METHOD1(showInfo, void(const ImageInfoModel::ImageInfo &info));
   MOCK_METHOD1(setWorkspace, void(const Mantid::API::Workspace_sptr &ws));
 };
@@ -58,7 +59,7 @@ public:
 
     ImageInfoPresenter presenter(mockView.get());
     presenter.setWorkspace(WorkspaceCreationHelper::create2DWorkspace123(10, 10));
-    presenter.cursorAt(1, 2, 1);
+    presenter.cursorAt(1, 2, 1, {});
   }
 
   void test_setWorkspace_creates_matrix_ws_model_with_matrix_ws() {


### PR DESCRIPTION
**Description of work.**

Adds HKL to the image info table widget in the slice viewer when the workspace has HKL coordinates. This could be a 3D or 4D MD workspace.

I considered adding the logic to calculate the HKL in the ImageInfoModelMD.cpp unit but it's not possible to determine the HKL values from the underlying workspace alone - there are choices the user can make in the slice viewer UI around which dimensions are displayed that aren't reflected in the underlying workspace. So I've implemented this in the UI python code instead.

While adding the unit tests for the new feature I noticed a couple of tests in test_sliceviewer_presenter.py weren't being run due to the name not starting "test_" so have fixed that up.

**To test:**

Run this script:
```
ws = CreateMDWorkspace(Dimensions='3', Extents='-3,3,-3,3,-3,3',
                       Names='H,K,L', Units='r.l.u.,r.l.u.,r.l.u.',
                       Frames='HKL,HKL,HKL',
                       SplitInto='2', SplitThreshold='10')

# add fake Bragg peaks for primitive lattice in data
for h in range(-3,4):
    for k in range(-3,4):
        for l in range(-3,4):
            hkl = ",".join([str(x) for x in [h,k,l]])
            FakeMDEventData(ws, PeakParams='1e+02,' + hkl + ',0.02', RandomSeed='3873875')

BinMD(InputWorkspace=ws, AxisAligned=False,
    BasisVector0='[00L],U,0,0,1',
    BasisVector1='[HH0],U,1,1,0',
    BasisVector2='[-HH0],U,-1,1,0',
    OutputExtents='-4,4,-4,4,-4,4',
    OutputBins='101,101,101', OutputWorkspace='BinMD_out', NormalizeBasisVectors=False)
```

and then open up BinMD_out in slice viewer. Set the slice point to 3 and then move the cursor to X=1, Y=2. The HKL displayed in the image info table widget should be ~ (-1,5,1). Then transpose the X and Y axes and move the cursor to X=2, Y=1. The HKL should still be ~ (-1,5,1)

Fixes #34561. 

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
