### PR TITLE
Expand plotting panel on ALFView by default

### DIFF
--- a/docs/source/release/v6.6.0/Direct_Geometry/General/Bugfixes/34638.rst
+++ b/docs/source/release/v6.6.0/Direct_Geometry/General/Bugfixes/34638.rst
@@ -1,0 +1,1 @@
+The plotting panel on the ALFView pick tab is now expanded by default when first opening the interface.

--- a/qt/scientific_interfaces/Direct/ALFInstrumentView.cpp
+++ b/qt/scientific_interfaces/Direct/ALFInstrumentView.cpp
@@ -46,6 +46,7 @@ void ALFInstrumentView::setUpInstrument(std::string const &fileName) {
   m_instrumentWidget->hideHelp();
 
   auto pickTab = m_instrumentWidget->getPickTab();
+  pickTab->expandPlotPanel();
 
   connect(pickTab->getSelectTubeButton(), SIGNAL(clicked()), this, SLOT(selectWholeTube()));
 

--- a/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/InstrumentWidgetPickTab.h
+++ b/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/InstrumentWidgetPickTab.h
@@ -101,6 +101,7 @@ public:
   void saveSettings(QSettings &settings) const override;
   void loadSettings(const QSettings &settings) override;
   bool addToDisplayContextMenu(QMenu & /*unused*/) const override;
+  void expandPlotPanel();
   void selectTool(const ToolType tool);
   SelectionType getSelectionType() const { return m_selectionType; }
   std::shared_ptr<ProjectionSurface> getSurface() const;

--- a/qt/widgets/instrumentview/src/InstrumentWidget.cpp
+++ b/qt/widgets/instrumentview/src/InstrumentWidget.cpp
@@ -1339,7 +1339,7 @@ void InstrumentWidget::setBackgroundColor(const QColor &color) {
  * Get the surface info string
  */
 QString InstrumentWidget::getSurfaceInfoText() const {
-  ProjectionSurface *surface = getSurface().get();
+  auto surface = getSurface();
   return surface ? surface->getInfoText() : "";
 }
 

--- a/qt/widgets/instrumentview/src/InstrumentWidgetPickTab.cpp
+++ b/qt/widgets/instrumentview/src/InstrumentWidgetPickTab.cpp
@@ -326,6 +326,11 @@ InstrumentWidgetPickTab::InstrumentWidgetPickTab(InstrumentWidget *instrWidget)
 QPushButton *InstrumentWidgetPickTab::getSelectTubeButton() { return m_tube; }
 
 /**
+ * Expands the plot panel
+ */
+void InstrumentWidgetPickTab::expandPlotPanel() { m_plotPanel->expandCaption(); }
+
+/**
  * If the workspace is monochromatic, the plot panel is useless and should be collapsed
  */
 void InstrumentWidgetPickTab::collapsePlotPanel() {

--- a/qt/widgets/instrumentview/src/MiniPlotMpl.cpp
+++ b/qt/widgets/instrumentview/src/MiniPlotMpl.cpp
@@ -224,9 +224,10 @@ QColor MiniPlotMpl::getCurveColor(const QString &label) const {
 bool MiniPlotMpl::isYLogScale() const { return m_canvas->gca().getYScale() == LOG_SCALE_NAME; }
 
 /**
- * Redraws the canvas
+ * Redraws the canvas only if in the GUI event loop. This avoids a crash when calling draw() on a plot which is on a
+ * different tab to the currently selected tab.
  */
-void MiniPlotMpl::replot() { m_canvas->draw(); }
+void MiniPlotMpl::replot() { m_canvas->drawIdle(); }
 
 /**
  * Remove the active curve, keeping any stored curves


### PR DESCRIPTION
**Description of work.**
This PR ensures the plotting panel on the pick tab of the ALFView interface is automatically expanded when the GUI is first opened.

**To test:**

1. Open ALFView
2. Click on `Pick Tab`
3. The plotting panel should be open already.

Fixes #34638 

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
