### PR TITLE
Remove FunctionBrowser in ALFView

### DIFF
--- a/docs/source/release/v6.6.0/Direct_Geometry/General/New_features/34654.rst
+++ b/docs/source/release/v6.6.0/Direct_Geometry/General/New_features/34654.rst
@@ -1,0 +1,1 @@
+The FunctionBrowser in ALFView has been replaced with a box for entering the PeakCentre parameter.

--- a/qt/scientific_interfaces/Direct/ALFCustomInstrumentPresenter.cpp
+++ b/qt/scientific_interfaces/Direct/ALFCustomInstrumentPresenter.cpp
@@ -85,7 +85,7 @@ void ALFCustomInstrumentPresenter::extractSingleTube() {
   m_model->extractSingleTube();
   const std::string WSName = m_model->WSName();
   m_analysisPane->addSpectrum(WSName);
-  m_analysisPane->updateEstimateAfterExtraction();
+  m_analysisPane->updateEstimateClicked();
 }
 
 void ALFCustomInstrumentPresenter::averageTube() {

--- a/qt/scientific_interfaces/Direct/ALFCustomInstrumentPresenter.cpp
+++ b/qt/scientific_interfaces/Direct/ALFCustomInstrumentPresenter.cpp
@@ -29,8 +29,6 @@ void ALFCustomInstrumentPresenter::addInstrument() {
 }
 
 void ALFCustomInstrumentPresenter::setUpInstrumentAnalysisSplitter() {
-  CompositeFunction_sptr composite = m_model->getDefaultFunction();
-  m_analysisPane->addFunction(composite);
   m_view->setupAnalysisPane(m_analysisPane->getView());
 }
 

--- a/qt/scientific_interfaces/Direct/test/ALFCustomInstrumentPresenterTest.h
+++ b/qt/scientific_interfaces/Direct/test/ALFCustomInstrumentPresenterTest.h
@@ -65,18 +65,8 @@ public:
   }
 
   void test_setUpInstrumentAnalysisSplitter() {
-    CompositeFunction_sptr composite = std::dynamic_pointer_cast<Mantid::API::CompositeFunction>(
-        Mantid::API::FunctionFactory::Instance().createFunction("CompositeFunction"));
-
-    auto func = Mantid::API::FunctionFactory::Instance().createInitialized("name = FlatBackground");
-    composite->addFunction(func);
-
-    EXPECT_CALL(*m_model, getDefaultFunction()).Times(1).WillOnce(Return(composite));
     EXPECT_CALL(*m_view, setupAnalysisPane(m_pane->getView())).Times(1);
-    // this function is called at start up -> count is 1
-    TS_ASSERT_EQUALS(m_pane->getAddCount(), 1);
     m_presenter->setUpInstrumentAnalysisSplitter();
-    TS_ASSERT_EQUALS(m_pane->getAddCount(), 2);
   }
 
   void test_loadSideEffects() {
@@ -136,7 +126,7 @@ public:
     EXPECT_CALL(*m_model, extractSingleTube()).Times(1);
     EXPECT_CALL(*m_model, WSName()).Times(1).WillOnce(Return("test"));
     EXPECT_CALL(*m_pane, addSpectrum("test")).Times(1);
-    EXPECT_CALL(*m_pane, updateEstimateAfterExtraction()).Times(1);
+    EXPECT_CALL(*m_pane, updateEstimateClicked()).Times(1);
     m_presenter->extractSingleTube();
   }
 

--- a/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/PlotFitAnalysisPaneModel.h
+++ b/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/PlotFitAnalysisPaneModel.h
@@ -22,16 +22,19 @@ class EXPORT_OPT_MANTIDQT_INSTRUMENTVIEW PlotFitAnalysisPaneModel {
 public:
   PlotFitAnalysisPaneModel();
   virtual ~PlotFitAnalysisPaneModel(){};
-  virtual IFunction_sptr doFit(const std::string &wsName, const std::pair<double, double> &range,
-                               const IFunction_sptr func);
-  virtual IFunction_sptr calculateEstimate(const std::string &workspaceName, const std::pair<double, double> &range);
+  virtual void doFit(const std::string &wsName, const std::pair<double, double> &range);
+  virtual void calculateEstimate(const std::string &workspaceName, const std::pair<double, double> &range);
 
-  virtual bool hasEstimate() const;
+  void setPeakCentre(const double centre);
+  double peakCentre() const;
+
+  std::string fitStatus() const;
 
 private:
   IFunction_sptr calculateEstimate(MatrixWorkspace_sptr &workspace, const std::pair<double, double> &range);
 
-  IFunction_sptr m_estimateFunction;
+  IFunction_sptr m_function;
+  std::string m_fitStatus;
 };
 
 } // namespace MantidWidgets

--- a/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/PlotFitAnalysisPaneModel.h
+++ b/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/PlotFitAnalysisPaneModel.h
@@ -17,18 +17,33 @@ using namespace Mantid::API;
 namespace MantidQt {
 namespace MantidWidgets {
 
-class EXPORT_OPT_MANTIDQT_INSTRUMENTVIEW PlotFitAnalysisPaneModel {
+class EXPORT_OPT_MANTIDQT_INSTRUMENTVIEW IPlotFitAnalysisPaneModel {
+
+public:
+  IPlotFitAnalysisPaneModel(){};
+  virtual ~IPlotFitAnalysisPaneModel(){};
+
+  virtual void doFit(const std::string &wsName, const std::pair<double, double> &range) = 0;
+  virtual void calculateEstimate(const std::string &workspaceName, const std::pair<double, double> &range) = 0;
+
+  virtual void setPeakCentre(const double centre) = 0;
+  virtual double peakCentre() const = 0;
+
+  virtual std::string fitStatus() const = 0;
+};
+
+class EXPORT_OPT_MANTIDQT_INSTRUMENTVIEW PlotFitAnalysisPaneModel : public IPlotFitAnalysisPaneModel {
 
 public:
   PlotFitAnalysisPaneModel();
   virtual ~PlotFitAnalysisPaneModel(){};
-  virtual void doFit(const std::string &wsName, const std::pair<double, double> &range);
-  virtual void calculateEstimate(const std::string &workspaceName, const std::pair<double, double> &range);
+  void doFit(const std::string &wsName, const std::pair<double, double> &range) override;
+  void calculateEstimate(const std::string &workspaceName, const std::pair<double, double> &range) override;
 
-  void setPeakCentre(const double centre);
-  double peakCentre() const;
+  void setPeakCentre(const double centre) override;
+  double peakCentre() const override;
 
-  std::string fitStatus() const;
+  std::string fitStatus() const override;
 
 private:
   IFunction_sptr calculateEstimate(MatrixWorkspace_sptr &workspace, const std::pair<double, double> &range);

--- a/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/PlotFitAnalysisPanePresenter.h
+++ b/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/PlotFitAnalysisPanePresenter.h
@@ -10,6 +10,8 @@
 #include "MantidQtWidgets/Common/ObserverPattern.h"
 #include "MantidQtWidgets/InstrumentView/PlotFitAnalysisPaneModel.h"
 #include "MantidQtWidgets/InstrumentView/PlotFitAnalysisPaneView.h"
+
+#include <optional>
 #include <string>
 
 namespace MantidQt {
@@ -50,6 +52,9 @@ public:
   void addSpectrum(const std::string &wsName) override;
 
 private:
+  std::optional<std::string> validateFitValues() const;
+  bool checkDataIsExtracted() const;
+  bool checkPeakCentreIsWithinFitRange() const;
   void updatePeakCentreInViewFromModel();
 
   VoidObserver *m_peakCentreObserver;

--- a/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/PlotFitAnalysisPanePresenter.h
+++ b/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/PlotFitAnalysisPanePresenter.h
@@ -24,11 +24,11 @@ public:
   virtual IPlotFitAnalysisPaneView *getView() = 0;
   virtual std::string getCurrentWS() = 0;
   virtual void clearCurrentWS() = 0;
-  virtual void doFit() = 0;
+  virtual void peakCentreEditingFinished() = 0;
+  virtual void fitClicked() = 0;
   virtual void updateEstimateAfterExtraction() = 0;
-  virtual void updateEstimate() = 0;
+  virtual void updateEstimateClicked() = 0;
   virtual void addSpectrum(const std::string &wsName) = 0;
-  virtual void addFunction(Mantid::API::IFunction_sptr func) = 0;
 };
 
 class EXPORT_OPT_MANTIDQT_INSTRUMENTVIEW PlotFitAnalysisPanePresenter : public QObject,
@@ -45,13 +45,16 @@ public:
   IPlotFitAnalysisPaneView *getView() override { return m_view; };
   std::string getCurrentWS() override { return m_currentName; };
   void clearCurrentWS() override { m_currentName = ""; };
-  void doFit() override;
+  void peakCentreEditingFinished() override;
+  void fitClicked() override;
   void updateEstimateAfterExtraction() override;
-  void updateEstimate() override;
+  void updateEstimateClicked() override;
   void addSpectrum(const std::string &wsName) override;
-  void addFunction(Mantid::API::IFunction_sptr func) override;
 
 private:
+  void updatePeakCentreInViewFromModel();
+
+  VoidObserver *m_peakCentreObserver;
   VoidObserver *m_fitObserver;
   VoidObserver *m_updateEstimateObserver;
   IPlotFitAnalysisPaneView *m_view;

--- a/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/PlotFitAnalysisPanePresenter.h
+++ b/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/PlotFitAnalysisPanePresenter.h
@@ -26,7 +26,6 @@ public:
   virtual void clearCurrentWS() = 0;
   virtual void peakCentreEditingFinished() = 0;
   virtual void fitClicked() = 0;
-  virtual void updateEstimateAfterExtraction() = 0;
   virtual void updateEstimateClicked() = 0;
   virtual void addSpectrum(const std::string &wsName) = 0;
 };
@@ -36,7 +35,7 @@ class EXPORT_OPT_MANTIDQT_INSTRUMENTVIEW PlotFitAnalysisPanePresenter : public Q
   Q_OBJECT
 
 public:
-  explicit PlotFitAnalysisPanePresenter(IPlotFitAnalysisPaneView *m_view, PlotFitAnalysisPaneModel *m_model);
+  explicit PlotFitAnalysisPanePresenter(IPlotFitAnalysisPaneView *m_view, IPlotFitAnalysisPaneModel *m_model);
   ~PlotFitAnalysisPanePresenter() {
     delete m_model;
     delete m_fitObserver;
@@ -47,7 +46,6 @@ public:
   void clearCurrentWS() override { m_currentName = ""; };
   void peakCentreEditingFinished() override;
   void fitClicked() override;
-  void updateEstimateAfterExtraction() override;
   void updateEstimateClicked() override;
   void addSpectrum(const std::string &wsName) override;
 
@@ -58,7 +56,7 @@ private:
   VoidObserver *m_fitObserver;
   VoidObserver *m_updateEstimateObserver;
   IPlotFitAnalysisPaneView *m_view;
-  PlotFitAnalysisPaneModel *m_model;
+  IPlotFitAnalysisPaneModel *m_model;
   std::string m_currentName;
 };
 } // namespace MantidWidgets

--- a/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/PlotFitAnalysisPaneView.h
+++ b/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/PlotFitAnalysisPaneView.h
@@ -10,6 +10,7 @@
 #include "MantidQtWidgets/Common/ObserverPattern.h"
 #include "MantidQtWidgets/Plotting/PreviewPlot.h"
 
+#include <QLabel>
 #include <QLineEdit>
 #include <QObject>
 #include <QPushButton>
@@ -76,10 +77,11 @@ private:
 
   MantidWidgets::PreviewPlot *m_plot;
   QLineEdit *m_start, *m_end;
-  QLineEdit *m_peakCentre;
   QSplitter *m_fitPlotLayout;
   QPushButton *m_fitButton;
   QPushButton *m_updateEstimateButton;
+  QLineEdit *m_peakCentre;
+  QLabel *m_fitStatus;
   Observable *m_peakCentreObservable;
   Observable *m_fitObservable;
   Observable *m_updateEstimateObservable;

--- a/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/PlotFitAnalysisPaneView.h
+++ b/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/PlotFitAnalysisPaneView.h
@@ -7,7 +7,6 @@
 #pragma once
 
 #include "DllOption.h"
-#include "MantidQtWidgets/Common/FunctionBrowser.h"
 #include "MantidQtWidgets/Common/ObserverPattern.h"
 #include "MantidQtWidgets/Plotting/PreviewPlot.h"
 
@@ -26,18 +25,19 @@ class EXPORT_OPT_MANTIDQT_INSTRUMENTVIEW IPlotFitAnalysisPaneView {
 public:
   IPlotFitAnalysisPaneView(){};
   virtual ~IPlotFitAnalysisPaneView(){};
+  virtual void observePeakCentreLineEdit(Observer *listener) = 0;
   virtual void observeFitButton(Observer *listener) = 0;
   virtual void observeUpdateEstimateButton(Observer *listener) = 0;
   virtual std::pair<double, double> getRange() = 0;
-  virtual Mantid::API::IFunction_sptr getFunction() = 0;
   virtual void addSpectrum(const std::string &wsName) = 0;
   virtual void addFitSpectrum(const std::string &wsName) = 0;
-  virtual void addFunction(Mantid::API::IFunction_sptr func) = 0;
-  virtual void updateFunction(const Mantid::API::IFunction_sptr func) = 0;
   virtual void displayWarning(const std::string &message) = 0;
   virtual QWidget *getQWidget() = 0;
   virtual void setupPlotFitSplitter(const double &start, const double &end) = 0;
   virtual QWidget *createFitPane(const double &start, const double &end) = 0;
+  virtual void setPeakCentre(const double centre) = 0;
+  virtual double peakCentre() const = 0;
+  virtual void setPeakCentreStatus(const std::string &status) = 0;
 };
 
 class EXPORT_OPT_MANTIDQT_INSTRUMENTVIEW PlotFitAnalysisPaneView : public QWidget, public IPlotFitAnalysisPaneView {
@@ -46,34 +46,41 @@ class EXPORT_OPT_MANTIDQT_INSTRUMENTVIEW PlotFitAnalysisPaneView : public QWidge
 public:
   explicit PlotFitAnalysisPaneView(const double &start, const double &end, QWidget *parent = nullptr);
 
+  void observePeakCentreLineEdit(Observer *listener) override { m_peakCentreObservable->attach(listener); };
   void observeFitButton(Observer *listener) override { m_fitObservable->attach(listener); };
-
   void observeUpdateEstimateButton(Observer *listener) override { m_updateEstimateObservable->attach(listener); };
 
   std::pair<double, double> getRange() override;
-  Mantid::API::IFunction_sptr getFunction() override;
   void addSpectrum(const std::string &wsName) override;
   void addFitSpectrum(const std::string &wsName) override;
-  void addFunction(Mantid::API::IFunction_sptr func) override;
-  void updateFunction(const Mantid::API::IFunction_sptr func) override;
   void displayWarning(const std::string &message) override;
   QWidget *getQWidget() override { return static_cast<QWidget *>(this); };
 
+  void setPeakCentre(const double centre) override;
+  double peakCentre() const override;
+
+  void setPeakCentreStatus(const std::string &status) override;
 public slots:
-  void doFit();
-  void updateEstimate();
+  void notifyPeakCentreEditingFinished();
+  void notifyUpdateEstimateClicked();
+  void notifyFitClicked();
 
 protected:
   void setupPlotFitSplitter(const double &start, const double &end) override;
   QWidget *createFitPane(const double &start, const double &end) override;
 
 private:
+  QWidget *setupFitRangeWidget(const double start, const double end);
+  QWidget *setupFitButtonsWidget();
+  QWidget *setupPeakCentreWidget(const double centre);
+
   MantidWidgets::PreviewPlot *m_plot;
-  MantidWidgets::FunctionBrowser *m_fitBrowser;
   QLineEdit *m_start, *m_end;
+  QLineEdit *m_peakCentre;
   QSplitter *m_fitPlotLayout;
   QPushButton *m_fitButton;
   QPushButton *m_updateEstimateButton;
+  Observable *m_peakCentreObservable;
   Observable *m_fitObservable;
   Observable *m_updateEstimateObservable;
 };

--- a/qt/widgets/instrumentview/src/PlotFitAnalysisPaneModel.cpp
+++ b/qt/widgets/instrumentview/src/PlotFitAnalysisPaneModel.cpp
@@ -83,34 +83,34 @@ using namespace Mantid::API;
 
 namespace MantidQt::MantidWidgets {
 
-PlotFitAnalysisPaneModel::PlotFitAnalysisPaneModel() : m_estimateFunction(nullptr) {}
+PlotFitAnalysisPaneModel::PlotFitAnalysisPaneModel()
+    : m_function(createCompositeFunction(createFlatBackground(), createGaussian())), m_fitStatus("") {}
 
-IFunction_sptr PlotFitAnalysisPaneModel::doFit(const std::string &wsName, const std::pair<double, double> &range,
-                                               const IFunction_sptr func) {
+void PlotFitAnalysisPaneModel::doFit(const std::string &wsName, const std::pair<double, double> &range) {
 
   IAlgorithm_sptr alg = AlgorithmManager::Instance().create("Fit");
   alg->initialize();
-  alg->setProperty("Function", func);
+  alg->setProperty("Function", m_function);
   alg->setProperty("InputWorkspace", wsName);
   alg->setProperty("Output", wsName + "_fits");
   alg->setProperty("StartX", range.first);
   alg->setProperty("EndX", range.second);
   alg->execute();
-  return alg->getProperty("Function");
+  m_function = alg->getProperty("Function");
+  m_fitStatus = alg->getPropertyValue("OutputStatus");
 }
 
-IFunction_sptr PlotFitAnalysisPaneModel::calculateEstimate(const std::string &workspaceName,
-                                                           const std::pair<double, double> &range) {
+void PlotFitAnalysisPaneModel::calculateEstimate(const std::string &workspaceName,
+                                                 const std::pair<double, double> &range) {
   auto &ads = AnalysisDataService::Instance();
   if (ads.doesExist(workspaceName)) {
     auto workspace = ads.retrieveWS<MatrixWorkspace>(workspaceName);
 
-    m_estimateFunction = calculateEstimate(workspace, range);
-    return m_estimateFunction;
+    m_function = calculateEstimate(workspace, range);
   } else {
-    m_estimateFunction = nullptr;
-    return createCompositeFunction(createFlatBackground(), createGaussian());
+    m_function = createCompositeFunction(createFlatBackground(), createGaussian());
   }
+  m_fitStatus = "";
 }
 
 IFunction_sptr PlotFitAnalysisPaneModel::calculateEstimate(MatrixWorkspace_sptr &workspace,
@@ -125,9 +125,16 @@ IFunction_sptr PlotFitAnalysisPaneModel::calculateEstimate(MatrixWorkspace_sptr 
 
     return createCompositeFunction(createFlatBackground(background), createGaussian(xData, yData, background));
   }
-  return nullptr;
+  return createCompositeFunction(createFlatBackground(), createGaussian());
 }
 
-bool PlotFitAnalysisPaneModel::hasEstimate() const { return m_estimateFunction != nullptr; }
+void PlotFitAnalysisPaneModel::setPeakCentre(const double centre) {
+  m_function->setParameter("f1.PeakCentre", centre);
+  m_fitStatus = "";
+}
+
+double PlotFitAnalysisPaneModel::peakCentre() const { return m_function->getParameter("f1.PeakCentre"); }
+
+std::string PlotFitAnalysisPaneModel::fitStatus() const { return m_fitStatus; }
 
 } // namespace MantidQt::MantidWidgets

--- a/qt/widgets/instrumentview/src/PlotFitAnalysisPanePresenter.cpp
+++ b/qt/widgets/instrumentview/src/PlotFitAnalysisPanePresenter.cpp
@@ -12,7 +12,7 @@
 namespace MantidQt::MantidWidgets {
 
 PlotFitAnalysisPanePresenter::PlotFitAnalysisPanePresenter(IPlotFitAnalysisPaneView *view,
-                                                           PlotFitAnalysisPaneModel *model)
+                                                           IPlotFitAnalysisPaneModel *model)
     : m_fitObserver(nullptr), m_updateEstimateObserver(nullptr), m_view(view), m_model(model), m_currentName("") {
 
   m_peakCentreObserver = new VoidObserver();
@@ -50,8 +50,6 @@ void PlotFitAnalysisPanePresenter::fitClicked() {
     m_view->displayWarning("Need to have extracted data to do a fit");
   }
 }
-
-void PlotFitAnalysisPanePresenter::updateEstimateAfterExtraction() { updateEstimateClicked(); }
 
 void PlotFitAnalysisPanePresenter::updateEstimateClicked() {
   if (!m_currentName.empty()) {

--- a/qt/widgets/instrumentview/src/PlotFitAnalysisPaneView.cpp
+++ b/qt/widgets/instrumentview/src/PlotFitAnalysisPaneView.cpp
@@ -9,7 +9,6 @@
 #include <tuple>
 #include <utility>
 
-#include <QApplication>
 #include <QLabel>
 #include <QMessageBox>
 #include <QRegExpValidator>
@@ -21,7 +20,7 @@
 namespace {
 
 std::tuple<QString, QString> getPeakCentreUIProperties(const QString &fitStatus) {
-  QString color("black"), size(QString::number(0.8 * QApplication::font().pointSize())), status("");
+  QString color("black"), status("");
   if (fitStatus.contains("success")) {
     color = "green", status = "Fit success";
   } else if (fitStatus.contains("Failed to converge")) {
@@ -29,7 +28,7 @@ std::tuple<QString, QString> getPeakCentreUIProperties(const QString &fitStatus)
   } else if (!fitStatus.isEmpty()) {
     color = "red", status = fitStatus;
   }
-  return {"QLabel { color: " + color + "; font-size: " + size + "pt; }", status};
+  return {"QLabel { color: " + color + "; }", status};
 }
 
 } // namespace

--- a/qt/widgets/instrumentview/src/PlotFitAnalysisPaneView.cpp
+++ b/qt/widgets/instrumentview/src/PlotFitAnalysisPaneView.cpp
@@ -5,8 +5,9 @@
 //   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 // SPDX - License - Identifier: GPL - 3.0 +
 #include "MantidQtWidgets/InstrumentView/PlotFitAnalysisPaneView.h"
-#include "MantidAPI/CompositeFunction.h"
-#include "MantidAPI/FunctionFactory.h"
+
+#include <tuple>
+#include <utility>
 
 #include <QLabel>
 #include <QMessageBox>
@@ -15,13 +16,28 @@
 #include <QSpacerItem>
 #include <QSplitter>
 #include <QVBoxLayout>
-#include <utility>
+
+namespace {
+
+std::tuple<QString, QString> getPeakCentreUIProperties(const QString &fitStatus) {
+  if (fitStatus.contains("success")) {
+    return {"QLineEdit { background: rgb(179, 240, 153) }", "PeakCentre value is from a successful fit."};
+  } else if (fitStatus.contains("Failed to converge")) {
+    return {"QLineEdit { background: rgb(251, 210, 121) }", "There was a fitting warning: " + fitStatus};
+  } else if (!fitStatus.isEmpty()) {
+    return {"QLineEdit { background: rgb(251, 139, 131) }", "There was a fitting error: " + fitStatus};
+  }
+  return {"", "PeakCentre value is not from a fit."};
+}
+
+} // namespace
 
 namespace MantidQt::MantidWidgets {
 
 PlotFitAnalysisPaneView::PlotFitAnalysisPaneView(const double &start, const double &end, QWidget *parent)
-    : QWidget(parent), m_plot(nullptr), m_fitBrowser(nullptr), m_start(nullptr), m_end(nullptr), m_fitButton(nullptr),
-      m_fitObservable(nullptr), m_updateEstimateObservable(nullptr) {
+    : QWidget(parent), m_plot(nullptr), m_start(nullptr), m_end(nullptr), m_fitButton(nullptr),
+      m_peakCentreObservable(new Observable()), m_fitObservable(new Observable()),
+      m_updateEstimateObservable(new Observable()) {
   setupPlotFitSplitter(start, end);
 }
 
@@ -42,51 +58,71 @@ QWidget *PlotFitAnalysisPaneView::createFitPane(const double &start, const doubl
   auto fitPane = new QWidget();
   auto fitPaneLayout = new QVBoxLayout(fitPane);
 
-  auto fitButtons = new QWidget();
-  auto layout = new QHBoxLayout(fitButtons);
-  m_fitButton = new QPushButton("Fit");
-  m_updateEstimateButton = new QPushButton("Update Estimate");
-  m_fitObservable = new Observable();
-  m_updateEstimateObservable = new Observable();
-  connect(m_fitButton, SIGNAL(clicked()), this, SLOT(doFit()));
-  connect(m_updateEstimateButton, SIGNAL(clicked()), this, SLOT(updateEstimate()));
+  auto fitRangeWidget = setupFitRangeWidget(start, end);
+  fitPaneLayout->addWidget(fitRangeWidget);
 
-  layout->addWidget(m_fitButton);
-  layout->addItem(new QSpacerItem(80, 0, QSizePolicy::Expanding, QSizePolicy::Fixed));
-  layout->addWidget(m_updateEstimateButton);
+  auto fitButtonsWidget = setupFitButtonsWidget();
+  fitPaneLayout->addWidget(fitButtonsWidget);
 
-  fitPaneLayout->addWidget(fitButtons);
-
-  m_fitBrowser = new MantidWidgets::FunctionBrowser(this);
-  fitPaneLayout->addWidget(m_fitBrowser);
-
-  auto *startText = new QLabel("Fit from:");
-  m_start = new QLineEdit(QString::number(start));
-  auto startValidator = new QDoubleValidator(m_start);
-  auto endValidator = new QDoubleValidator(m_start);
-  m_start->setValidator(startValidator);
-  auto *endText = new QLabel("to:");
-  m_end = new QLineEdit(QString::number(end));
-  m_end->setValidator(endValidator);
-  auto *range = new QWidget();
-  auto *rangeLayout = new QHBoxLayout(range);
-  rangeLayout->addWidget(startText);
-  rangeLayout->addWidget(m_start);
-  rangeLayout->addWidget(endText);
-  rangeLayout->addWidget(m_end);
-  fitPaneLayout->addWidget(range);
+  auto peakCentreWidget = setupPeakCentreWidget((start + end) / 2.0);
+  fitPaneLayout->addWidget(peakCentreWidget);
 
   return fitPane;
 }
 
-void PlotFitAnalysisPaneView::doFit() {
-  auto function = m_fitBrowser->getFunction();
-  if (function) {
-    m_fitObservable->notify();
-  }
+QWidget *PlotFitAnalysisPaneView::setupFitRangeWidget(const double start, const double end) {
+  auto *rangeWidget = new QWidget();
+  auto *rangeLayout = new QHBoxLayout(rangeWidget);
+
+  m_start = new QLineEdit(QString::number(start));
+  m_start->setValidator(new QDoubleValidator(m_start));
+
+  m_end = new QLineEdit(QString::number(end));
+  m_end->setValidator(new QDoubleValidator(m_end));
+
+  rangeLayout->addWidget(new QLabel("Fit from:"));
+  rangeLayout->addWidget(m_start);
+  rangeLayout->addWidget(new QLabel("to:"));
+  rangeLayout->addWidget(m_end);
+  return rangeWidget;
 }
 
-void PlotFitAnalysisPaneView::updateEstimate() { m_updateEstimateObservable->notify(); }
+QWidget *PlotFitAnalysisPaneView::setupFitButtonsWidget() {
+  auto fitButtonsWidget = new QWidget();
+  auto fitButtonsLayout = new QHBoxLayout(fitButtonsWidget);
+
+  m_fitButton = new QPushButton("Fit");
+  m_updateEstimateButton = new QPushButton("Update Estimate");
+
+  connect(m_fitButton, SIGNAL(clicked()), this, SLOT(notifyFitClicked()));
+  connect(m_updateEstimateButton, SIGNAL(clicked()), this, SLOT(notifyUpdateEstimateClicked()));
+
+  fitButtonsLayout->addWidget(m_fitButton);
+  fitButtonsLayout->addItem(new QSpacerItem(80, 0, QSizePolicy::Expanding, QSizePolicy::Fixed));
+  fitButtonsLayout->addWidget(m_updateEstimateButton);
+  return fitButtonsWidget;
+}
+
+QWidget *PlotFitAnalysisPaneView::setupPeakCentreWidget(const double centre) {
+  auto *peakCentreWidget = new QWidget();
+  auto *peakCentreLayout = new QHBoxLayout(peakCentreWidget);
+
+  m_peakCentre = new QLineEdit(QString::number(centre));
+  m_peakCentre->setValidator(new QDoubleValidator(m_peakCentre));
+
+  connect(m_peakCentre, SIGNAL(editingFinished()), this, SLOT(notifyPeakCentreEditingFinished()));
+
+  peakCentreLayout->addWidget(new QLabel("Peak Centre:"));
+  peakCentreLayout->addWidget(m_peakCentre);
+
+  return peakCentreWidget;
+}
+
+void PlotFitAnalysisPaneView::notifyPeakCentreEditingFinished() { m_peakCentreObservable->notify(); }
+
+void PlotFitAnalysisPaneView::notifyFitClicked() { m_fitObservable->notify(); }
+
+void PlotFitAnalysisPaneView::notifyUpdateEstimateClicked() { m_updateEstimateObservable->notify(); }
 
 void PlotFitAnalysisPaneView::addSpectrum(const std::string &wsName) {
   m_plot->addSpectrum("Extracted Data", wsName.c_str(), 0, Qt::black);
@@ -96,21 +132,17 @@ void PlotFitAnalysisPaneView::addFitSpectrum(const std::string &wsName) {
 }
 
 std::pair<double, double> PlotFitAnalysisPaneView::getRange() {
-  double start = m_start->text().toDouble();
-  double end = m_end->text().toDouble();
-  return std::make_pair(start, end);
+  return std::make_pair(m_start->text().toDouble(), m_end->text().toDouble());
 }
 
-Mantid::API::IFunction_sptr PlotFitAnalysisPaneView::getFunction() { return m_fitBrowser->getFunction(); }
+void PlotFitAnalysisPaneView::setPeakCentre(const double centre) { m_peakCentre->setText(QString::number(centre)); }
 
-void PlotFitAnalysisPaneView::updateFunction(const Mantid::API::IFunction_sptr func) {
-  if (func) {
-    m_fitBrowser->updateMultiDatasetParameters(*func);
-  }
-}
+double PlotFitAnalysisPaneView::peakCentre() const { return m_peakCentre->text().toDouble(); }
 
-void PlotFitAnalysisPaneView::addFunction(Mantid::API::IFunction_sptr func) {
-  m_fitBrowser->setFunction(std::move(func));
+void PlotFitAnalysisPaneView::setPeakCentreStatus(const std::string &status) {
+  const auto [stylesheet, tooltip] = getPeakCentreUIProperties(QString::fromStdString(status));
+  m_peakCentre->setStyleSheet(stylesheet);
+  m_peakCentre->setToolTip(tooltip);
 }
 
 void PlotFitAnalysisPaneView::displayWarning(const std::string &message) {

--- a/qt/widgets/instrumentview/test/PlotFitAnalysisPaneModelTest.h
+++ b/qt/widgets/instrumentview/test/PlotFitAnalysisPaneModelTest.h
@@ -45,6 +45,18 @@ public:
     m_model.reset();
   }
 
+  void test_that_the_model_is_instantiated_with_a_function_and_empty_fit_status() {
+    TS_ASSERT_THROWS_NOTHING(m_model->peakCentre());
+    TS_ASSERT_EQUALS("", m_model->fitStatus());
+  }
+
+  void test_that_doFit_sets_a_successful_fit_status_for_a_good_fit() {
+    m_model->doFit(m_workspaceName, m_range);
+
+    TS_ASSERT_EQUALS(0.0, m_model->peakCentre());
+    TS_ASSERT_EQUALS("success", m_model->fitStatus());
+  }
+
   void test_that_calculateEstimate_returns_zero_peak_centre_if_the_workspace_does_not_exist_in_the_ADS() {
     AnalysisDataService::Instance().clear();
 

--- a/qt/widgets/instrumentview/test/PlotFitAnalysisPaneModelTest.h
+++ b/qt/widgets/instrumentview/test/PlotFitAnalysisPaneModelTest.h
@@ -45,30 +45,30 @@ public:
     m_model.reset();
   }
 
-  void test_that_calculateEstimate_returns_zero_parameters_if_the_workspace_does_not_exist_in_the_ADS() {
+  void test_that_calculateEstimate_returns_zero_peak_centre_if_the_workspace_does_not_exist_in_the_ADS() {
     AnalysisDataService::Instance().clear();
 
-    const auto function = m_model->calculateEstimate(m_workspaceName, m_range);
+    m_model->calculateEstimate(m_workspaceName, m_range);
 
-    TS_ASSERT_EQUALS(function->asString(), "name=FlatBackground,A0=0;name=Gaussian,Height=0,PeakCentre=0,Sigma=0");
-    TS_ASSERT(!m_model->hasEstimate());
+    TS_ASSERT_EQUALS(0.0, m_model->peakCentre());
+    TS_ASSERT_EQUALS("", m_model->fitStatus());
   }
 
   void test_that_calculateEstimate_returns_an_estimate_if_the_workspace_does_exist_in_the_ADS() {
-    const auto function = m_model->calculateEstimate(m_workspaceName, m_range);
+    m_model->calculateEstimate(m_workspaceName, m_range);
 
-    TS_ASSERT_EQUALS(function->asString(), "name=FlatBackground,A0=2;name=Gaussian,Height=0,"
-                                           "PeakCentre=0.5,Sigma=0");
-    TS_ASSERT(m_model->hasEstimate());
+    TS_ASSERT_EQUALS(0.5, m_model->peakCentre());
+    TS_ASSERT_EQUALS("", m_model->fitStatus());
   }
 
-  void test_that_calculateEstimate_returns_a_nullptr_if_the_crop_range_is_invalid() {
+  void test_that_calculateEstimate_returns_zero_peak_centre_if_the_crop_range_is_invalid() {
     m_workspace = WorkspaceCreationHelper::create2DWorkspaceBinned(1, 100, 300.0);
     AnalysisDataService::Instance().addOrReplace(m_workspaceName, m_workspace);
 
-    const auto function = m_model->calculateEstimate(m_workspaceName, m_range);
+    m_model->calculateEstimate(m_workspaceName, m_range);
 
-    TS_ASSERT_EQUALS(nullptr, function);
+    TS_ASSERT_EQUALS(0.0, m_model->peakCentre());
+    TS_ASSERT_EQUALS("", m_model->fitStatus());
   }
 
 private:

--- a/qt/widgets/instrumentview/test/PlotFitAnalysisPanePresenterTest.h
+++ b/qt/widgets/instrumentview/test/PlotFitAnalysisPanePresenterTest.h
@@ -42,6 +42,9 @@ public:
     m_presenter = new PlotFitAnalysisPanePresenter(m_view, m_model);
     m_workspaceName = "test";
     m_range = std::make_pair(0.0, 1.0);
+    m_peakCentre = 0.5;
+    m_view->setPeakCentre(m_peakCentre);
+    m_model->setPeakCentre(m_peakCentre);
   }
 
   void tearDown() override {
@@ -51,24 +54,65 @@ public:
     m_model = nullptr;
   }
 
-  void test_fitClicked() {
+  void test_peakCentreEditingFinished_sets_the_peak_centre_in_the_model_and_fit_status_in_the_view() {
+    EXPECT_CALL(*m_view, peakCentre()).Times(1).WillOnce(Return(m_peakCentre));
+    EXPECT_CALL(*m_model, setPeakCentre(m_peakCentre)).Times(1);
+
+    EXPECT_CALL(*m_model, fitStatus()).Times(1).WillOnce(Return(""));
+    EXPECT_CALL(*m_view, setPeakCentreStatus("")).Times(1);
+
+    m_presenter->peakCentreEditingFinished();
+  }
+
+  void test_fitClicked_will_display_a_warning_when_the_workspace_name_is_not_set() {
+    EXPECT_CALL(*m_view, displayWarning("Need to have extracted data to do a fit or estimate.")).Times(1);
+    m_presenter->fitClicked();
+  }
+
+  void test_fitClicked_will_display_a_warning_when_the_peak_centre_is_outside_the_fit_range() {
     // set name via addSpectrum
     EXPECT_CALL(*m_view, addSpectrum(m_workspaceName)).Times(1);
     m_presenter->addSpectrum(m_workspaceName);
 
+    EXPECT_CALL(*m_view, peakCentre()).Times(1).WillOnce(Return(-1.0));
     EXPECT_CALL(*m_view, getRange()).Times(1).WillOnce(Return(m_range));
+    EXPECT_CALL(*m_view, displayWarning("The Peak Centre provided is outside the fit range.")).Times(1);
+
+    m_presenter->fitClicked();
+  }
+
+  void test_fitClicked_will_perform_a_fit_when_the_workspace_name_and_peak_centre_is_valid() {
+    // set name via addSpectrum
+    EXPECT_CALL(*m_view, addSpectrum(m_workspaceName)).Times(1);
+    m_presenter->addSpectrum(m_workspaceName);
+
+    EXPECT_CALL(*m_view, peakCentre()).Times(1).WillOnce(Return(m_peakCentre));
+    EXPECT_CALL(*m_view, getRange()).Times(2).WillRepeatedly(Return(m_range));
+
     EXPECT_CALL(*m_model, doFit(m_workspaceName, m_range)).Times(1);
 
     m_presenter->fitClicked();
   }
 
-  void test_addSpectrum() {
+  void test_addSpectrum_will_call_addSpectrum_in_the_view() {
     EXPECT_CALL(*m_view, addSpectrum(m_workspaceName)).Times(1);
     m_presenter->addSpectrum(m_workspaceName);
   }
 
   void test_that_calculateEstimate_is_not_called_when_the_current_workspace_name_is_blank() {
-    EXPECT_CALL(*m_view, displayWarning("Could not update estimate: data has not been extracted.")).Times(1);
+    EXPECT_CALL(*m_view, displayWarning("Need to have extracted data to do a fit or estimate.")).Times(1);
+
+    m_presenter->updateEstimateClicked();
+  }
+
+  void test_that_calculateEstimate_is_not_called_when_the_peak_centre_is_invalid() {
+    // set name via addSpectrum
+    EXPECT_CALL(*m_view, addSpectrum(m_workspaceName)).Times(1);
+    m_presenter->addSpectrum(m_workspaceName);
+
+    EXPECT_CALL(*m_view, peakCentre()).Times(1).WillOnce(Return(-1.0));
+    EXPECT_CALL(*m_view, getRange()).Times(1).WillOnce(Return(m_range));
+    EXPECT_CALL(*m_view, displayWarning("The Peak Centre provided is outside the fit range.")).Times(1);
 
     m_presenter->updateEstimateClicked();
   }
@@ -77,7 +121,9 @@ public:
     EXPECT_CALL(*m_view, addSpectrum(m_workspaceName)).Times(1);
     m_presenter->addSpectrum(m_workspaceName);
 
-    EXPECT_CALL(*m_view, getRange()).Times(1).WillOnce(Return(m_range));
+    EXPECT_CALL(*m_view, peakCentre()).Times(1).WillOnce(Return(m_peakCentre));
+    EXPECT_CALL(*m_view, getRange()).Times(2).WillRepeatedly(Return(m_range));
+
     EXPECT_CALL(*m_model, calculateEstimate(m_workspaceName, m_range)).Times(1);
 
     m_presenter->updateEstimateClicked();
@@ -90,4 +136,5 @@ private:
 
   std::string m_workspaceName;
   std::pair<double, double> m_range;
+  double m_peakCentre;
 };

--- a/qt/widgets/instrumentview/test/PlotFitAnalysisPanePresenterTest.h
+++ b/qt/widgets/instrumentview/test/PlotFitAnalysisPanePresenterTest.h
@@ -51,27 +51,15 @@ public:
     m_model = nullptr;
   }
 
-  void test_doFit() {
+  void test_fitClicked() {
     // set name via addSpectrum
     EXPECT_CALL(*m_view, addSpectrum(m_workspaceName)).Times(1);
     m_presenter->addSpectrum(m_workspaceName);
-    // set up rest of test
 
-    IFunction_sptr function = Mantid::API::FunctionFactory::Instance().createInitialized("name = FlatBackground");
-
-    EXPECT_CALL(*m_view, getFunction()).Times(1).WillOnce(Return(function));
     EXPECT_CALL(*m_view, getRange()).Times(1).WillOnce(Return(m_range));
+    EXPECT_CALL(*m_model, doFit(m_workspaceName, m_range)).Times(1);
 
-    EXPECT_CALL(*m_view, updateFunction(function));
-
-    m_presenter->doFit();
-    TS_ASSERT_EQUALS(m_model->getFitCount(), 1);
-  }
-
-  void test_addFunction() {
-    auto function = Mantid::API::FunctionFactory::Instance().createInitialized("name = FlatBackground");
-    EXPECT_CALL(*m_view, addFunction(function)).Times(1);
-    m_presenter->addFunction(function);
+    m_presenter->fitClicked();
   }
 
   void test_addSpectrum() {
@@ -82,9 +70,7 @@ public:
   void test_that_calculateEstimate_is_not_called_when_the_current_workspace_name_is_blank() {
     EXPECT_CALL(*m_view, displayWarning("Could not update estimate: data has not been extracted.")).Times(1);
 
-    m_presenter->updateEstimate();
-    TS_ASSERT_EQUALS(m_model->getEstimateCount(), 0);
-    TS_ASSERT(!m_model->hasEstimate());
+    m_presenter->updateEstimateClicked();
   }
 
   void test_that_calculateEstimate_is_called_as_expected() {
@@ -92,33 +78,9 @@ public:
     m_presenter->addSpectrum(m_workspaceName);
 
     EXPECT_CALL(*m_view, getRange()).Times(1).WillOnce(Return(m_range));
+    EXPECT_CALL(*m_model, calculateEstimate(m_workspaceName, m_range)).Times(1);
 
-    m_presenter->updateEstimate();
-    TS_ASSERT_EQUALS(m_model->getEstimateCount(), 1);
-    TS_ASSERT(m_model->hasEstimate());
-  }
-
-  void test_that_updateEstimateAfterExtraction_calls_calculateEstimate_if_an_estimate_does_not_exist() {
-    EXPECT_CALL(*m_view, addSpectrum(m_workspaceName)).Times(1);
-    m_presenter->addSpectrum(m_workspaceName);
-
-    EXPECT_CALL(*m_view, getRange()).Times(1).WillOnce(Return(m_range));
-
-    m_presenter->updateEstimateAfterExtraction();
-    TS_ASSERT_EQUALS(m_model->getEstimateCount(), 1);
-    TS_ASSERT(m_model->hasEstimate());
-  }
-
-  void test_that_updateEstimateAfterExtraction_does_not_call_calculateEstimate_if_an_estimate_already_exists() {
-    EXPECT_CALL(*m_view, addSpectrum(m_workspaceName)).Times(1);
-    m_presenter->addSpectrum(m_workspaceName);
-
-    EXPECT_CALL(*m_view, getRange()).Times(1).WillOnce(Return(m_range));
-
-    m_presenter->updateEstimate();
-    m_presenter->updateEstimateAfterExtraction();
-    TS_ASSERT_EQUALS(m_model->getEstimateCount(), 1);
-    TS_ASSERT(m_model->hasEstimate());
+    m_presenter->updateEstimateClicked();
   }
 
 private:


### PR DESCRIPTION
**Description of work.**
This PR removes the FunctionBrowser seen in the ALFView interface and replaces it with a QLineEdit which displays the PeakCentre, and a Fit Status label.

**To test:**
1. Open `Direct`->`ALFView` interface
1) Load data [ALF82301](file:///home/mlc47243/Documents/other-documents/ALFView/ALF82301.zip)
2) Click on `Pick` tab
5) Expand `Rebin` section. Filter by d-spacing range (optional) `5.5,0.01,6`
6) Expand `Plotting detector spectra` section
6) Click on `Select whole tube` icon
9) Right click on peak of interest and select `Extract Single Tube`
11) Press `Update Estimate` button. The Peak Centre box should be updated from zero
12) Press `Fit` button. The peak centre box will be updated again, and a Fit status displayed below this box.
13) Change the Peak Centre to be outside the Fit Range, and then try `Fit` or `Update Estimate`. There should be a warning message displayed.


Part of #34604

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
