### PR TITLE
Add option get TOF window from back-to-back exp parameters in IntegratePeaksSkew

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/IntegratePeaksSkew.py
+++ b/Framework/PythonInterface/plugins/algorithms/IntegratePeaksSkew.py
@@ -924,7 +924,8 @@ class IntegratePeaksSkew(DataProcessorAlgorithm):
         func = FunctionFactory.Instance().createPeakFunction("BackToBackExponential")
         func.setParameter('X0', pk.getTOF())  # set centre
         func.setMatrixWorkspace(ws, ws.getIndicesFromDetectorIDs([int(detid)])[0], 0.0, 0.0)  # calc A,B,S based on peak cen
-        dTOF = 4*func.fwhm() if func.isExplicitlySet(4) else None
+        is_valid = all(func.isExplicitlySet(ipar) for ipar in [1,2,4])
+        dTOF = 4*func.fwhm() if is_valid else None
         return dTOF
 
     @staticmethod

--- a/Framework/PythonInterface/plugins/algorithms/IntegratePeaksSkew.py
+++ b/Framework/PythonInterface/plugins/algorithms/IntegratePeaksSkew.py
@@ -713,11 +713,19 @@ class IntegratePeaksSkew(DataProcessorAlgorithm):
             issues["NPixMin"] = "NPixMin exceeds number of pixels in the window."
         # check valid peak workspace
         ws = self.getProperty("InputWorkspace").value
+        inst = ws.getInstrument()
         pk_ws = self.getProperty("PeaksWorkspace").value
-        if ws.getInstrument().getName() != pk_ws.getInstrument().getName():
+        if inst.getName() != pk_ws.getInstrument().getName():
             issues["PeaksWorkspace"] = "PeaksWorkspace must have same instrument as the InputWorkspace."
         if pk_ws.getNumberPeaks() < 1:
             issues["PeaksWorkspace"] = "PeaksWorkspace must have at least 1 peak."
+        # check that is getting dTOF from back-to-back params then they are present in instrument
+        if self.getProperty("GetTOFWindowFromBackToBackParams").value:
+            # check at least first peak in workspace has back to back params
+            if not inst.getComponentByName(pk_ws.column('BankName')[0]).hasParameter('B'):
+                issues["GetTOFWindowFromBackToBackParams"] = "Workspace doesn't have back to back exponential " \
+                                                             "coefficients defined in the parameters.xml file."
+
         return issues
 
     def PyExec(self):

--- a/Framework/PythonInterface/test/python/plugins/algorithms/IntegratePeaksSkewTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/IntegratePeaksSkewTest.py
@@ -90,6 +90,14 @@ class IntegratePeaksSkewTest(unittest.TestCase):
         for pk_ws in [out, out_scaled]:
             self.assertAlmostEqual(pk_ws.getPeak(0).getIntensityOverSigma(), 12.7636, delta=1e-3)
 
+    def test_integrate_use_nearest_peak_false_update_peak_position_false_with_back_to_back_params(self):
+
+        out = IntegratePeaksSkew(InputWorkspace=self.ws, PeaksWorkspace=self.peaks,
+                                 GetTOFWindowFromBackToBackParams=True, IntegrateIfOnEdge=True,
+                                 UseNearestPeak=False, UpdatePeakPosition=False, OutputWorkspace='out11')
+        # check intensity of first peak - should be same as TOF window comes out as ~0.3 (as in other tests)
+        self.assertAlmostEqual(out.getPeak(0).getIntensityOverSigma(), 12.7636, delta=1e-3)
+
     def test_integrate_use_nearest_peak_true_update_peak_position_false(self):
         out = IntegratePeaksSkew(InputWorkspace=self.ws, PeaksWorkspace=self.peaks, FractionalTOFWindow=0.3,
                                  IntegrateIfOnEdge=True, UseNearestPeak=True, UpdatePeakPosition=False,

--- a/Framework/PythonInterface/test/python/plugins/algorithms/IntegratePeaksSkewTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/IntegratePeaksSkewTest.py
@@ -55,16 +55,16 @@ class IntegratePeaksSkewTest(unittest.TestCase):
         shutil.rmtree(cls._test_dir)
 
     def test_integrate_on_edge_option(self):
-        out = IntegratePeaksSkew(InputWorkspace=self.ws, PeaksWorkspace=self.peaks, FractionalTOFWindow=0.3,
-                           IntegrateIfOnEdge=False, OutputWorkspace='out0')
+        out = IntegratePeaksSkew(InputWorkspace=self.ws, PeaksWorkspace=self.peaks, ThetaWidth=0,
+                                 BackscatteringTOFResolution=0.3, IntegrateIfOnEdge=False, OutputWorkspace='out0')
         # check peaks in bank 1 were not integrated (mask touches edge)
         for ipk, pk in enumerate(out):
             self.assertEqual(pk.getIntensity(), 0)
 
     def test_integrate_use_nearest_peak_false_update_peak_position_false(self):
-        out = IntegratePeaksSkew(InputWorkspace=self.ws, PeaksWorkspace=self.peaks, FractionalTOFWindow=0.3,
-                                 IntegrateIfOnEdge=True, UseNearestPeak=False, UpdatePeakPosition=False,
-                                 OutputWorkspace='out1')
+        out = IntegratePeaksSkew(InputWorkspace=self.ws, PeaksWorkspace=self.peaks, ThetaWidth=0,
+                                 BackscatteringTOFResolution=0.3, IntegrateIfOnEdge=True, UseNearestPeak=False,
+                                 UpdatePeakPosition=False, OutputWorkspace='out1')
         # check intensity of first peak (only valid peak)
         ipk = 0
         pk = out.getPeak(ipk)
@@ -99,9 +99,9 @@ class IntegratePeaksSkewTest(unittest.TestCase):
         self.assertAlmostEqual(out.getPeak(0).getIntensityOverSigma(), 12.7636, delta=1e-3)
 
     def test_integrate_use_nearest_peak_true_update_peak_position_false(self):
-        out = IntegratePeaksSkew(InputWorkspace=self.ws, PeaksWorkspace=self.peaks, FractionalTOFWindow=0.3,
-                                 IntegrateIfOnEdge=True, UseNearestPeak=True, UpdatePeakPosition=False,
-                                 OutputWorkspace='out2')
+        out = IntegratePeaksSkew(InputWorkspace=self.ws, PeaksWorkspace=self.peaks, ThetaWidth=0,
+                                 BackscatteringTOFResolution=0.3, IntegrateIfOnEdge=True, UseNearestPeak=True,
+                                 UpdatePeakPosition=False, OutputWorkspace='out2')
         # check intensity/sigma of first two peaks equal (same peak integrated)
         # note intensity will be different due to lorz factor as position not updated
         for ipk in range(2):
@@ -114,9 +114,9 @@ class IntegratePeaksSkewTest(unittest.TestCase):
         self.assertEqual(out.getPeak(out.getNumberPeaks()-1).getIntensity(), 0)
 
     def test_integrate_use_nearest_peak_true_update_peak_position_true(self):
-        out = IntegratePeaksSkew(InputWorkspace=self.ws, PeaksWorkspace=self.peaks, FractionalTOFWindow=0.3,
-                                 IntegrateIfOnEdge=True, UseNearestPeak=True, UpdatePeakPosition=True,
-                                 OutputWorkspace='out3')
+        out = IntegratePeaksSkew(InputWorkspace=self.ws, PeaksWorkspace=self.peaks, ThetaWidth=0,
+                                 BackscatteringTOFResolution=0.3, IntegrateIfOnEdge=True, UseNearestPeak=True,
+                                 UpdatePeakPosition=True, OutputWorkspace='out3')
         # check intensity/sigma of first two peaks equal (same peak integrated)
         # note intensity will be same now as peak position updated
         for ipk in range(2):
@@ -135,45 +135,46 @@ class IntegratePeaksSkewTest(unittest.TestCase):
 
     def test_print_output_file(self):
         out_file = path.join(self._test_dir, 'out.pdf')
-        out = IntegratePeaksSkew(InputWorkspace=self.ws, PeaksWorkspace=self.peaks, FractionalTOFWindow=0.3,
-                                 IntegrateIfOnEdge=False, OutputWorkspace='out4', OutputFile=out_file)
+        out = IntegratePeaksSkew(InputWorkspace=self.ws, PeaksWorkspace=self.peaks, ThetaWidth=0,
+                                 BackscatteringTOFResolution=0.3, IntegrateIfOnEdge=False, OutputWorkspace='out4',
+                                 OutputFile=out_file)
         # check output file saved
         self.assertTrue(path.exists(out_file))
 
     def test_peak_mask_validation_with_ncol_max(self):
-        out = IntegratePeaksSkew(InputWorkspace=self.ws, PeaksWorkspace=self.peaks, FractionalTOFWindow=0.3,
-                                 IntegrateIfOnEdge=True, UseNearestPeak=False, UpdatePeakPosition=False,
-                                 OutputWorkspace='out5', NColMax=2)
+        out = IntegratePeaksSkew(InputWorkspace=self.ws, PeaksWorkspace=self.peaks, ThetaWidth=0,
+                                 BackscatteringTOFResolution=0.3, IntegrateIfOnEdge=True, UseNearestPeak=False,
+                                 UpdatePeakPosition=False, OutputWorkspace='out5', NColMax=2)
         for ipk, pk in enumerate(out):
             self.assertEqual(pk.getIntensity(), 0)
 
     def test_peak_min_number_tof_bins(self):
-        out = IntegratePeaksSkew(InputWorkspace=self.ws, PeaksWorkspace=self.peaks, FractionalTOFWindow=0.3,
-                                 IntegrateIfOnEdge=True, UseNearestPeak=False, UpdatePeakPosition=False,
-                                 OutputWorkspace='out5', NTOFBinsMin=10)
+        out = IntegratePeaksSkew(InputWorkspace=self.ws, PeaksWorkspace=self.peaks, ThetaWidth=0,
+                                 BackscatteringTOFResolution=0.3, IntegrateIfOnEdge=True, UseNearestPeak=False,
+                                 UpdatePeakPosition=False,OutputWorkspace='out5', NTOFBinsMin=10)
         for ipk, pk in enumerate(out):
             self.assertEqual(pk.getIntensity(), 0)
 
     def test_peak_mask_validation_with_ncol_max(self):
-        out = IntegratePeaksSkew(InputWorkspace=self.ws, PeaksWorkspace=self.peaks, FractionalTOFWindow=0.3,
-                                 IntegrateIfOnEdge=True, UseNearestPeak=False, UpdatePeakPosition=False,
-                                 OutputWorkspace='out6', NColMax=3)
+        out = IntegratePeaksSkew(InputWorkspace=self.ws, PeaksWorkspace=self.peaks, ThetaWidth=0,
+                                 BackscatteringTOFResolution=0.3, IntegrateIfOnEdge=True, UseNearestPeak=False,
+                                 UpdatePeakPosition=False, OutputWorkspace='out6', NColMax=3)
         self.assertEqual(out.getPeak(0).getIntensityOverSigma(), 0)
         # increase ncol to accept peak mask
-        out = IntegratePeaksSkew(InputWorkspace=self.ws, PeaksWorkspace=self.peaks, FractionalTOFWindow=0.3,
-                                 IntegrateIfOnEdge=True, UseNearestPeak=False, UpdatePeakPosition=False,
-                                 OutputWorkspace='out6', NColMax=4)
+        out = IntegratePeaksSkew(InputWorkspace=self.ws, PeaksWorkspace=self.peaks, ThetaWidth=0,
+                                 BackscatteringTOFResolution=0.3, IntegrateIfOnEdge=True, UseNearestPeak=False,
+                                 UpdatePeakPosition=False, OutputWorkspace='out6', NColMax=4)
         self.assertGreater(out.getPeak(0).getIntensityOverSigma(), 0)
 
     def test_peak_mask_validation_with_nrow_max(self):
-        out = IntegratePeaksSkew(InputWorkspace=self.ws, PeaksWorkspace=self.peaks, FractionalTOFWindow=0.3,
-                                 IntegrateIfOnEdge=True, UseNearestPeak=False, UpdatePeakPosition=False,
-                                 OutputWorkspace='out7', NRowMax=2)
+        out = IntegratePeaksSkew(InputWorkspace=self.ws, PeaksWorkspace=self.peaks, ThetaWidth=0,
+                                 BackscatteringTOFResolution=0.3, IntegrateIfOnEdge=True, UseNearestPeak=False,
+                                 UpdatePeakPosition=False, OutputWorkspace='out7', NRowMax=2)
         self.assertEqual(out.getPeak(0).getIntensityOverSigma(), 0)
         # increase nrow to accept peak mask
-        out = IntegratePeaksSkew(InputWorkspace=self.ws, PeaksWorkspace=self.peaks, FractionalTOFWindow=0.3,
-                                 IntegrateIfOnEdge=True, UseNearestPeak=False, UpdatePeakPosition=False,
-                                 OutputWorkspace='out7', NRowMax=3)
+        out = IntegratePeaksSkew(InputWorkspace=self.ws, PeaksWorkspace=self.peaks, ThetaWidth=0,
+                                 BackscatteringTOFResolution=0.3, IntegrateIfOnEdge=True, UseNearestPeak=False,
+                                 UpdatePeakPosition=False, OutputWorkspace='out7', NRowMax=3)
         self.assertGreater(out.getPeak(0).getIntensityOverSigma(), 0)
 
     def test_peak_mask_validation_with_nvacancies(self):
@@ -187,38 +188,40 @@ class IntegratePeaksSkewTest(unittest.TestCase):
             ws_clone.setE(ispec, ws_clone.readE(0))
 
         # check vacancy with 1 pixel detected (and first peak therefore not integrated)
-        out = IntegratePeaksSkew(InputWorkspace=ws_clone, PeaksWorkspace=self.peaks, FractionalTOFWindow=0.3,
-                                 IntegrateIfOnEdge=True, UseNearestPeak=False, UpdatePeakPosition=False,
-                                 OutputWorkspace='out8', NVacanciesMax=0, NPixPerVacancyMin=1)
+        out = IntegratePeaksSkew(InputWorkspace=ws_clone, PeaksWorkspace=self.peaks, ThetaWidth=0,
+                                 BackscatteringTOFResolution=0.3, IntegrateIfOnEdge=True, UseNearestPeak=False,
+                                 UpdatePeakPosition=False, OutputWorkspace='out8', NVacanciesMax=0, NPixPerVacancyMin=1)
         self.assertEqual(out.getPeak(0).getIntensityOverSigma(), 0)
 
         # set npix per vacancies > 1 (should now integrate first peak)
-        out = IntegratePeaksSkew(InputWorkspace=ws_clone, PeaksWorkspace=self.peaks, FractionalTOFWindow=0.3,
-                                 IntegrateIfOnEdge=True, UseNearestPeak=False, UpdatePeakPosition=False,
-                                 OutputWorkspace='out8', NVacanciesMax=0, NPixPerVacancyMin=2)
+        out = IntegratePeaksSkew(InputWorkspace=ws_clone, PeaksWorkspace=self.peaks, ThetaWidth=0,
+                                 BackscatteringTOFResolution=0.3, IntegrateIfOnEdge=True, UseNearestPeak=False,
+                                 UpdatePeakPosition=False, OutputWorkspace='out8', NVacanciesMax=0, NPixPerVacancyMin=2)
         self.assertGreater(out.getPeak(0).getIntensityOverSigma(), 0)
 
         # set nvacancies > 1 (should now integrate first peak)
-        out = IntegratePeaksSkew(InputWorkspace=ws_clone, PeaksWorkspace=self.peaks, FractionalTOFWindow=0.3,
-                                 IntegrateIfOnEdge=True, UseNearestPeak=False, UpdatePeakPosition=False,
-                                 OutputWorkspace='out8', NVacanciesMax=1, NPixPerVacancyMin=1)
+        out = IntegratePeaksSkew(InputWorkspace=ws_clone, PeaksWorkspace=self.peaks, ThetaWidth=0,
+                                 BackscatteringTOFResolution=0.3, IntegrateIfOnEdge=True, UseNearestPeak=False,
+                                 UpdatePeakPosition=False, OutputWorkspace='out8', NVacanciesMax=1, NPixPerVacancyMin=1)
         self.assertGreater(out.getPeak(0).getIntensityOverSigma(), 0)
 
     def test_integration_with_non_square_window_nrows_ncols(self):
-        out = IntegratePeaksSkew(InputWorkspace=self.ws, PeaksWorkspace=self.peaks, FractionalTOFWindow=0.3,
-                                 NRows=5, NCols=3, NRowMax=3, NColMax=3, IntegrateIfOnEdge=True, UseNearestPeak=True,
-                                 UpdatePeakPosition=False, OutputWorkspace='out8')
+        out = IntegratePeaksSkew(InputWorkspace=self.ws, PeaksWorkspace=self.peaks, ThetaWidth=0,
+                                 BackscatteringTOFResolution=0.3, NRows=5, NCols=3, NRowMax=3, NColMax=3,
+                                 IntegrateIfOnEdge=True, UseNearestPeak=True, UpdatePeakPosition=False,
+                                 OutputWorkspace='out8')
         self.assertGreater(out.getPeak(0).getIntensityOverSigma(), 0)
         self.assertAlmostEqual(out.getPeak(0).getIntensityOverSigma(), 10.84209, delta=1e-4)
-        out = IntegratePeaksSkew(InputWorkspace=self.ws, PeaksWorkspace=self.peaks, FractionalTOFWindow=0.3,
-                                 NRows=3, NCols=5, NRowMax=3, NColMax=3, IntegrateIfOnEdge=True, UseNearestPeak=True,
-                                 NPixMin=1, UpdatePeakPosition=False, OutputWorkspace='out9')
+        out = IntegratePeaksSkew(InputWorkspace=self.ws, PeaksWorkspace=self.peaks, ThetaWidth=0,
+                                 BackscatteringTOFResolution=0.3, NRows=3, NCols=5, NRowMax=3, NColMax=3,
+                                 IntegrateIfOnEdge=True, UseNearestPeak=True, NPixMin=1, UpdatePeakPosition=False,
+                                 OutputWorkspace='out9')
         self.assertAlmostEqual(out.getPeak(0).getIntensityOverSigma(), 5.46125, delta=1e-4)  # only one pixel in peak
 
     def test_lorentz_correction_false(self):
-        out = IntegratePeaksSkew(InputWorkspace=self.ws, PeaksWorkspace=self.peaks, FractionalTOFWindow=0.3,
-                                 IntegrateIfOnEdge=True, UseNearestPeak=False, UpdatePeakPosition=False,
-                                 LorentzCorrection=False, OutputWorkspace='out10')
+        out = IntegratePeaksSkew(InputWorkspace=self.ws, PeaksWorkspace=self.peaks, ThetaWidth=0,
+                                 BackscatteringTOFResolution=0.3, IntegrateIfOnEdge=True, UseNearestPeak=False,
+                                 UpdatePeakPosition=False, LorentzCorrection=False, OutputWorkspace='out10')
         # check intensity of first peak (only valid peak)
         pk = out.getPeak(0)
         self.assertAlmostEqual(pk.getIntensity(), 224, delta=1e-2)

--- a/Framework/PythonInterface/test/python/plugins/algorithms/IntegratePeaksSkewTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/IntegratePeaksSkewTest.py
@@ -9,7 +9,7 @@ import tempfile
 import shutil
 from os import path
 from mantid.simpleapi import (IntegratePeaksSkew, CreatePeaksWorkspace, AddPeak, AnalysisDataService, CloneWorkspace,
-                              LoadEmptyInstrument)
+                              LoadEmptyInstrument, SetInstrumentParameter)
 from IntegratePeaksSkew import InstrumentArrayConverter
 from testhelpers import WorkspaceCreationHelper
 from numpy import array, sqrt, arange, ones, zeros
@@ -20,6 +20,7 @@ class IntegratePeaksSkewTest(unittest.TestCase):
     def setUpClass(cls):
         # load empty instrument with RectangularDetector banks and create a peak table
         cls.ws = WorkspaceCreationHelper.create2DWorkspaceWithRectangularInstrument(2, 5, 11)  # nbanks, npix, nbins
+        AnalysisDataService.addOrReplace("ws_rect", cls.ws)
         axis = cls.ws.getAxis(0)
         axis.setUnit("TOF")
         # fake peak in spectra in middle bank 1 (centered on detID=37/spec=12 and TOF=3.5)
@@ -28,6 +29,9 @@ class IntegratePeaksSkewTest(unittest.TestCase):
         for ispec in [7, 11, 12, 13, 17, 22]:
             cls.ws.setY(ispec, cls.ws.readY(ispec) + cls.peak_1D)
             cls.ws.setE(ispec, sqrt(cls.ws.readY(ispec)))
+        # Add back-to-back exponential params
+        for param in ['A','B','S']:
+            SetInstrumentParameter(cls.ws, ParameterName=param, Value="1")
         # make peak table
         # 0) inside fake peak (bank 1)
         # 1) outside fake peak (bank 1)

--- a/Framework/PythonInterface/test/python/plugins/algorithms/IntegratePeaksSkewTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/IntegratePeaksSkewTest.py
@@ -93,7 +93,7 @@ class IntegratePeaksSkewTest(unittest.TestCase):
     def test_integrate_use_nearest_peak_false_update_peak_position_false_with_back_to_back_params(self):
 
         out = IntegratePeaksSkew(InputWorkspace=self.ws, PeaksWorkspace=self.peaks,
-                                 GetTOFWindowFromBackToBackParams=True, IntegrateIfOnEdge=True,
+                                 GetTOFWindowFromBackToBackParams=True, NFWHM=4, IntegrateIfOnEdge=True,
                                  UseNearestPeak=False, UpdatePeakPosition=False, OutputWorkspace='out11')
         # check intensity of first peak - should be same as TOF window comes out as ~0.3 (as in other tests)
         self.assertAlmostEqual(out.getPeak(0).getIntensityOverSigma(), 12.7636, delta=1e-3)

--- a/docs/source/algorithms/IntegratePeaksSkew-v1.rst
+++ b/docs/source/algorithms/IntegratePeaksSkew-v1.rst
@@ -35,8 +35,7 @@ Note this algorithm can apply the Lorentz correction to the integrated intensity
 
 For each peak the algorithm proceeds as follows:
 
-1.  Calculates an initial TOF window using the input parameter ``FractionalTOFWindow`` or (if ``FractionalTOFWindow = 0``)
-    evaluating a resolution function of the form
+1.  Calculates an initial TOF window evaluating a resolution function of the form
 
         .. math::
 

--- a/docs/source/release/v6.6.0/Diffraction/Single_Crystal/Improvements/34657.rst
+++ b/docs/source/release/v6.6.0/Diffraction/Single_Crystal/Improvements/34657.rst
@@ -1,0 +1,1 @@
+* Simplified input arguments to :ref:`IntegratePeaksSkew <algm-IntegratePeaksSkew>`: the parameter `FractionalTOFWindow` has been removed, if a user wants to integrate with an initial window dTOF/TOF = constant for all peaks then this can be achieved by setting ThetaWidth = 0 - note this is technically a breaking change.

--- a/docs/source/release/v6.6.0/Diffraction/Single_Crystal/New_features/34657.rst
+++ b/docs/source/release/v6.6.0/Diffraction/Single_Crystal/New_features/34657.rst
@@ -1,0 +1,2 @@
+* Added new option to :ref:`IntegratePeaksSkew <algm-IntegratePeaksSkew>`: to get intial TOF window from back-to-back exponential coeficients if sepcified in the insturment parameters.xml
+* Added back-to-back exponential coeficients to SXD parameters.xml file

--- a/docs/source/release/v6.6.0/Diffraction/Single_Crystal/New_features/34657.rst
+++ b/docs/source/release/v6.6.0/Diffraction/Single_Crystal/New_features/34657.rst
@@ -1,2 +1,2 @@
-* Added new option to :ref:`IntegratePeaksSkew <algm-IntegratePeaksSkew>`: to get intial TOF window from back-to-back exponential coeficients if sepcified in the insturment parameters.xml
-* Added back-to-back exponential coeficients to SXD parameters.xml file
+* Added new option to :ref:`IntegratePeaksSkew <algm-IntegratePeaksSkew>`: to get initial TOF window from back-to-back exponential coefficients if specified in the instrument parameters.xml
+* Added back-to-back exponential coefficients to SXD parameters.xml file

--- a/instrument/SXD_Parameters.xml
+++ b/instrument/SXD_Parameters.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<parameter-file instrument = "SXD" valid-from = "2013-03-13T00:00:00">
+    
+    <component-link name="SXD" >
+        <parameter name="BackToBackExponential:S" type="fitting">
+            <formula eq="sqrt(22.441*centre^4+6.397*centre^2)" unit="dSpacing" result-unit="TOF" />
+        </parameter>
+        <parameter name="BackToBackExponential:A" type="fitting">
+            <formula eq="2.0" unit="dSpacing" result-unit="1/TOF" /> <fixed />
+        </parameter>
+        <parameter name="BackToBackExponential:B" type="fitting">
+            <formula eq="(0.075+0.025/(centre^4))" unit="Wavelength" result-unit="1/TOF" /> <fixed />
+        </parameter>
+    </component-link>
+
+</parameter-file>


### PR DESCRIPTION
**Description of work.**

Add option get TOF window from back-to-back exponential parameters in `IntegratePeaksSkew` - this is primarily for WISH as the optimal TOF window used for the initial integration does not agree well with the TOF resolution equation (because the width is not dominated by resolution but by the tails of the back-to-back exponential).

Also simplified the algorithm input such that if the user wants to integrate with an initial window dTOF/TOF = constant for all peaks then this can be achieved by setting `ThetaWidth = 0` rather than a separate input parameter  -this is technically a breaking change, but the algorithm is only in use by WISH scientists atm.

I have also added some  back-to-back exponential parameters for SXD to the parameters.xml file - this will let users on SXD to get an estimate for the appropriate resolution parameters in `IntegratePeaksSkew` without needing an initial guess. 
The value for `A` is hard coded (very steep, so width to low TOF is dominated by gaussian sigma, `S`) and the coefficients for `B` are taken from SXD2001 source code (written by Matthias Gutmann) - it is a function of wavelength not d-spacing so can be applied to the entire instrument rather than a specific bank. The coefficients for `S` are taken from WISH 90 degree banks which seem to perform OK  (this is a coincidence, there is no reason for them to be the same - technically SXD should have coeficients for each bank as the dTOF/TOF resolution  depends on scattering angle).

**To test:**
(1) Run this script
```
Load(Filename=r'C:\mantid\build\ExternalData\Testing\Data\SystemTest\SXD23767.raw', OutputWorkspace='SXD23767')
CreatePeaksWorkspace(InstrumentWorkspace='SXD23767', NumberOfPeaks=0, OutputWorkspace='SingleCrystalPeakTable')

AddPeak(PeaksWorkspace='SingleCrystalPeakTable', RunWorkspace='SXD23767', TOF=3271, DetectorID=32615)
AddPeak(PeaksWorkspace='SingleCrystalPeakTable', RunWorkspace='SXD23767', TOF=3806, DetectorID=30017)
AddPeak(PeaksWorkspace='SingleCrystalPeakTable', RunWorkspace='SXD23767', TOF=5009, DetectorID=42513)
AddPeak(PeaksWorkspace='SingleCrystalPeakTable', RunWorkspace='SXD23767', TOF=2486, DetectorID=39170)
AddPeak(PeaksWorkspace='SingleCrystalPeakTable', RunWorkspace='SXD23767', TOF=2613, DetectorID=40740)
AddPeak(PeaksWorkspace='SingleCrystalPeakTable', RunWorkspace='SXD23767', TOF=2328, DetectorID=40905)
AddPeak(PeaksWorkspace='SingleCrystalPeakTable', RunWorkspace='SXD23767', TOF=1703, DetectorID=28764)
AddPeak(PeaksWorkspace='SingleCrystalPeakTable', RunWorkspace='SXD23767', TOF=2449, DetectorID=41068)
AddPeak(PeaksWorkspace='SingleCrystalPeakTable', RunWorkspace='SXD23767', TOF=2303, DetectorID=40121)
AddPeak(PeaksWorkspace='SingleCrystalPeakTable', RunWorkspace='SXD23767', TOF=2038, DetectorID=36910)
AddPeak(PeaksWorkspace='SingleCrystalPeakTable', RunWorkspace='SXD23767', TOF=3787, DetectorID=42749)
AddPeak(PeaksWorkspace='SingleCrystalPeakTable', RunWorkspace='SXD23767', TOF=886, DetectorID=14284)
AddPeak(PeaksWorkspace='SingleCrystalPeakTable', RunWorkspace='SXD23767', TOF=1817, DetectorID=36104)
  
out = IntegratePeaksSkew(InputWorkspace='SXD23767', PeaksWorkspace='SingleCrystalPeakTable',
    OutputFile="out.pdf", OutputWorkspace='out',  UseNearestPeak=True, IntegrateIfOnEdge=True, 
    NVacanciesMax=5, NPixPerVacancyMin=1, UpdatePeakPosition=True, OptimiseMask=True, 
    ScaleThetaWidthByWavelength=True, GetTOFWindowFromBackToBackParams=True)
```
(2) Check in the `out.pdf` file that the initial TOF window looks OK

Fixes #34562 
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
