### PR TITLE
Fix for marker labels detatching when panning and zooming with the mouse

### DIFF
--- a/docs/source/release/v6.6.0/Workbench/Bugfixes/33907.rst
+++ b/docs/source/release/v6.6.0/Workbench/Bugfixes/33907.rst
@@ -1,0 +1,1 @@
+- Fixed bug where marker labels became unattached when zooming and panning.

--- a/qt/applications/workbench/workbench/plotting/figureinteraction.py
+++ b/qt/applications/workbench/workbench/plotting/figureinteraction.py
@@ -125,6 +125,7 @@ class FigureInteraction(object):
             zoom(event.inaxes, event.xdata, event.ydata, factor=zoom_factor)
         elif event.button == 'down':  # zoom out
             zoom(event.inaxes, event.xdata, event.ydata, factor=1 / zoom_factor)
+        self.redraw_annotations()
         event.canvas.draw()
 
     def on_mouse_button_press(self, event):
@@ -141,8 +142,7 @@ class FigureInteraction(object):
 
         # If left button clicked, start moving peaks
         if self.toolbar_manager.is_tool_active():
-            for marker in self.markers:
-                marker.remove_all_annotations()
+            self._remove_all_marker_annotations()
         elif event.button == 1 and marker_selected is not None:
             for marker in marker_selected:
                 if len(marker_selected) > 1:
@@ -171,6 +171,7 @@ class FigureInteraction(object):
                 if event.inaxes and event.inaxes.can_pan():
                     event.button = 1
                     try:
+                        self._remove_all_marker_annotations()
                         self.canvas.toolbar.press_pan(event)
                     finally:
                         event.button = 3
@@ -185,6 +186,7 @@ class FigureInteraction(object):
                 event.button = 1
                 try:
                     self.canvas.toolbar.release_pan(event)
+                    self._add_all_marker_annotations()
                 finally:
                     event.button = 3
         elif event.button == self.canvas.buttond.get(Qt.RightButton) and self.toolbar_manager.is_zoom_active():
@@ -192,8 +194,7 @@ class FigureInteraction(object):
             self.toolbar_manager.emit_sig_home_clicked()
 
         if self.toolbar_manager.is_tool_active():
-            for marker in self.markers:
-                marker.add_all_annotations()
+            self._add_all_marker_annotations()
         else:
             x_pos = event.xdata
             y_pos = event.ydata
@@ -720,6 +721,14 @@ class FigureInteraction(object):
         """Remove all annotations and add them again."""
         for marker in self.markers:
             marker.remove_all_annotations()
+            marker.add_all_annotations()
+
+    def _remove_all_marker_annotations(self):
+        for marker in self.markers:
+            marker.remove_all_annotations()
+
+    def _add_all_marker_annotations(self):
+        for marker in self.markers:
             marker.add_all_annotations()
 
     def mpl_redraw_annotations(self, event):

--- a/qt/applications/workbench/workbench/plotting/test/test_figureinteraction.py
+++ b/qt/applications/workbench/workbench/plotting/test/test_figureinteraction.py
@@ -646,7 +646,7 @@ class FigureInteractionTest(unittest.TestCase):
         self.interactor.on_scroll(event)
         self.interactor.redraw_annotations.assert_called_once()
 
-    def test_marker_annotations_are_removed_on_pan_begin(self):
+    def test_marker_annotations_are_removed_on_middle_mouse_pan_begin(self):
         fig_manager = self._create_mock_fig_manager_to_accept_middle_click()
         fig_manager.fit_browser.tool = None
         interactor = FigureInteraction(fig_manager)
@@ -659,7 +659,7 @@ class FigureInteractionTest(unittest.TestCase):
         interactor.on_mouse_button_press(mouse_event)
         interactor._remove_all_marker_annotations.assert_called_once()
 
-    def test_marker_annotations_are_added_on_pan_end(self):
+    def test_marker_annotations_are_added_on_middle_mouse_pan_end(self):
         fig_manager = self._create_mock_fig_manager_to_accept_middle_click()
         fig_manager.fit_browser.tool = None
         interactor = FigureInteraction(fig_manager)

--- a/qt/applications/workbench/workbench/plotting/test/test_figureinteraction.py
+++ b/qt/applications/workbench/workbench/plotting/test/test_figureinteraction.py
@@ -647,15 +647,11 @@ class FigureInteractionTest(unittest.TestCase):
         self.interactor.redraw_annotations.assert_called_once()
 
     def test_marker_annotations_are_removed_on_pan_begin(self):
-        fig_manager = MagicMock()
-        canvas = MagicMock()
-        type(canvas).buttond = PropertyMock(return_value={Qt.MiddleButton: 4})
-        fig_manager.canvas = canvas
+        fig_manager = self._create_mock_fig_manager_to_accept_middle_click()
         fig_manager.fit_browser.tool = None
         interactor = FigureInteraction(fig_manager)
+        mouse_event = self._create_mock_middle_click()
 
-        mouse_event = MagicMock(inaxes=MagicMock(spec=MantidAxes, collections=[], creation_args=[{}]))
-        type(mouse_event).button = PropertyMock(return_value=4)
         interactor.toolbar_manager.is_tool_active = MagicMock(return_value=False)
         interactor.toolbar_manager.is_zoom_active = MagicMock(return_value=False)
 
@@ -664,15 +660,11 @@ class FigureInteractionTest(unittest.TestCase):
         interactor._remove_all_marker_annotations.assert_called_once()
 
     def test_marker_annotations_are_added_on_pan_end(self):
-        fig_manager = MagicMock()
-        canvas = MagicMock()
-        type(canvas).buttond = PropertyMock(return_value={Qt.MiddleButton: 4})
-        fig_manager.canvas = canvas
+        fig_manager = self._create_mock_fig_manager_to_accept_middle_click()
         fig_manager.fit_browser.tool = None
         interactor = FigureInteraction(fig_manager)
+        mouse_event = self._create_mock_middle_click()
 
-        mouse_event = MagicMock(inaxes=MagicMock(spec=MantidAxes, collections=[], creation_args=[{}]))
-        type(mouse_event).button = PropertyMock(return_value=4)
         interactor.toolbar_manager.is_tool_active = MagicMock(return_value=False)
 
         interactor._add_all_marker_annotations = MagicMock()
@@ -687,9 +679,21 @@ class FigureInteractionTest(unittest.TestCase):
         fig_manager.canvas = canvas
         return fig_manager
 
+    def _create_mock_fig_manager_to_accept_middle_click(self):
+        fig_manager = MagicMock()
+        canvas = MagicMock()
+        type(canvas).buttond = PropertyMock(return_value={Qt.MiddleButton: 4})
+        fig_manager.canvas = canvas
+        return fig_manager
+
     def _create_mock_right_click(self):
         mouse_event = MagicMock(inaxes=MagicMock(spec=MantidAxes, collections = [], creation_args = [{}]))
         type(mouse_event).button = PropertyMock(return_value=3)
+        return mouse_event
+
+    def _create_mock_middle_click(self):
+        mouse_event = MagicMock(inaxes=MagicMock(spec=MantidAxes, collections = [], creation_args = [{}]))
+        type(mouse_event).button = PropertyMock(return_value=4)
         return mouse_event
 
     def _test_toggle_normalization(self, errorbars_on, plot_kwargs):

--- a/qt/applications/workbench/workbench/plotting/test/test_figureinteraction.py
+++ b/qt/applications/workbench/workbench/plotting/test/test_figureinteraction.py
@@ -637,7 +637,49 @@ class FigureInteractionTest(unittest.TestCase):
         self.assertFalse(fig.axes[0].tracked_workspaces['ws'][0].is_normalized)
         self.assertFalse(fig.axes[1].tracked_workspaces['ws'][0].is_normalized)
 
- # Private methods
+    def test_marker_annotations_are_removed_and_redrawn_on_scroll_zoom(self):
+        event = MagicMock()
+        event.inaxes = MagicMock()
+        event.inaxes.lines = ["line"]
+
+        self.interactor.redraw_annotations = MagicMock()
+        self.interactor.on_scroll(event)
+        self.interactor.redraw_annotations.assert_called_once()
+
+    def test_marker_annotations_are_removed_on_pan_begin(self):
+        fig_manager = MagicMock()
+        canvas = MagicMock()
+        type(canvas).buttond = PropertyMock(return_value={Qt.MiddleButton: 4})
+        fig_manager.canvas = canvas
+        fig_manager.fit_browser.tool = None
+        interactor = FigureInteraction(fig_manager)
+
+        mouse_event = MagicMock(inaxes=MagicMock(spec=MantidAxes, collections=[], creation_args=[{}]))
+        type(mouse_event).button = PropertyMock(return_value=4)
+        interactor.toolbar_manager.is_tool_active = MagicMock(return_value=False)
+        interactor.toolbar_manager.is_zoom_active = MagicMock(return_value=False)
+
+        interactor._remove_all_marker_annotations = MagicMock()
+        interactor.on_mouse_button_press(mouse_event)
+        interactor._remove_all_marker_annotations.assert_called_once()
+
+    def test_marker_annotations_are_added_on_pan_end(self):
+        fig_manager = MagicMock()
+        canvas = MagicMock()
+        type(canvas).buttond = PropertyMock(return_value={Qt.MiddleButton: 4})
+        fig_manager.canvas = canvas
+        fig_manager.fit_browser.tool = None
+        interactor = FigureInteraction(fig_manager)
+
+        mouse_event = MagicMock(inaxes=MagicMock(spec=MantidAxes, collections=[], creation_args=[{}]))
+        type(mouse_event).button = PropertyMock(return_value=4)
+        interactor.toolbar_manager.is_tool_active = MagicMock(return_value=False)
+
+        interactor._add_all_marker_annotations = MagicMock()
+        interactor.on_mouse_button_release(mouse_event)
+        interactor._add_all_marker_annotations.assert_called_once()
+
+# Private methods
     def _create_mock_fig_manager_to_accept_right_click(self):
         fig_manager = MagicMock()
         canvas = MagicMock()


### PR DESCRIPTION
**Description of work.**

Added methods to remove marker annotations when panning with the middle mouse button and scrolling to zoom. This is what is done when using Matplotlib's built-in pan and zoom toolbar buttons but was missing from our implementations using the mouse.

**To test:**

- Plot a spectrum of data
- Right click and add a marker
- Scroll to zoom in and out to see that the annotation label does not become detached
- Use middle mouse to pan around and check that the annotations does not become detached (it should be removed when moving around then come back when the button is released)
- Click the pan button in the tool bar and check that the behaviour is the same as using middle mouse to pan

Fixes #33907

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
