### PR TITLE
Fix problem with output workspace x range in ConvolveWorkspaces

### DIFF
--- a/Framework/CurveFitting/src/Algorithms/ConvolveWorkspaces.cpp
+++ b/Framework/CurveFitting/src/Algorithms/ConvolveWorkspaces.cpp
@@ -31,9 +31,9 @@ using namespace Functions;
 
 void ConvolveWorkspaces::init() {
   declareProperty(std::make_unique<WorkspaceProperty<Workspace2D>>("Workspace1", "", Direction::Input),
-                  "The name of the first input workspace.");
+                  "The name of the resolution workspace");
   declareProperty(std::make_unique<WorkspaceProperty<Workspace2D>>("Workspace2", "", Direction::Input),
-                  "The name of the second input workspace.");
+                  "The name of the data workspace.");
 
   declareProperty(std::make_unique<WorkspaceProperty<Workspace2D>>("OutputWorkspace", "", Direction::Output),
                   "The name of the output workspace.");
@@ -47,7 +47,7 @@ void ConvolveWorkspaces::exec() {
 
   // Cache a few things for later use
   const size_t numHists = ws1->getNumberHistograms();
-  Workspace2D_sptr outputWS = std::dynamic_pointer_cast<Workspace2D>(WorkspaceFactory::Instance().create(ws1));
+  Workspace2D_sptr outputWS = std::dynamic_pointer_cast<Workspace2D>(WorkspaceFactory::Instance().create(ws2));
 
   // First check that the workspace are the same size
   if (numHists != ws2->getNumberHistograms()) {

--- a/Framework/CurveFitting/src/Algorithms/ConvolveWorkspaces.cpp
+++ b/Framework/CurveFitting/src/Algorithms/ConvolveWorkspaces.cpp
@@ -60,7 +60,7 @@ void ConvolveWorkspaces::exec() {
   for (int i = 0; i < static_cast<int>(numHists); ++i) {
     PARALLEL_START_INTERRUPT_REGION
     m_progress->report();
-    outputWS->setSharedX(i, ws1->sharedX(i));
+    outputWS->setSharedX(i, ws2->sharedX(i));
     auto &Yout = outputWS->mutableY(i);
     Convolution conv;
 

--- a/Framework/CurveFitting/src/Algorithms/ConvolveWorkspaces.cpp
+++ b/Framework/CurveFitting/src/Algorithms/ConvolveWorkspaces.cpp
@@ -76,8 +76,9 @@ void ConvolveWorkspaces::exec() {
 
     conv.addFunction(fun);
     size_t N = Yout.size();
+    size_t Nx = outputWS->mutableX(i).size();
     const double *firstX = &outputWS->mutableX(i)[0];
-    FunctionDomain1DView xView(firstX, N);
+    FunctionDomain1DView xView(firstX, Nx);
     FunctionValues out(xView);
     conv.function(xView, out);
 

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/MolDyn.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/MolDyn.py
@@ -208,8 +208,8 @@ class MolDyn(PythonAlgorithm):
 
         # Convolve the symmetrised sample with the resolution
         ConvolveWorkspaces(OutputWorkspace=function_ws_name,
-                           Workspace1=function_ws_name,
-                           Workspace2=resolution_ws)
+                           Workspace1=resolution_ws,
+                           Workspace2=function_ws_name)
 
     def _plot_spectra(self, ws_name):
         """

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/MolDyn.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/MolDyn.py
@@ -208,8 +208,8 @@ class MolDyn(PythonAlgorithm):
 
         # Convolve the symmetrised sample with the resolution
         ConvolveWorkspaces(OutputWorkspace=function_ws_name,
-                           Workspace1=resolution_ws,
-                           Workspace2=function_ws_name)
+                           Workspace1=function_ws_name,
+                           Workspace2=resolution_ws)
 
     def _plot_spectra(self, ws_name):
         """

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/MolDynTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/MolDynTest.py
@@ -91,8 +91,10 @@ class MolDynTest(unittest.TestCase):
 
 
     def test_loadSqwWithRes(self):
-        # Create a sample workspace thet looks like an instrument resolution
-        sample_res = CreateSampleWorkspace(NumBanks=1,
+        # Create a sample workspace that looks like an instrument resolution, area under curve ~1
+        sample_res = CreateSampleWorkspace(Function='User Defined',
+                                           UserDefinedFunction='name=Gaussian, PeakCentre=0, Height=3.99, Sigma=0.1',
+                                           NumBanks=1,
                                            BankPixelWidth=1,
                                            XUnit='Energy',
                                            XMin=-10,

--- a/docs/source/algorithms/ConvolveWorkspaces-v1.rst
+++ b/docs/source/algorithms/ConvolveWorkspaces-v1.rst
@@ -12,6 +12,8 @@ Description
 Convolution of two workspaces using :ref:`Convolution <func-Convolution>` from
 CurveFitting. Workspaces must have the same number of spectra.
 
+The resolution workspace will be evaluated in the range :math:`-L` to :math:`+L` where :math:`L` is defined in terms of the :math:`x` range of the data workspace as follows :math:`L=(x_{max}-x_{min})/2`. The resolution workspace therefore needs to have values specified in this range.
+
 Usage
 -----
 

--- a/docs/source/algorithms/ConvolveWorkspaces-v1.rst
+++ b/docs/source/algorithms/ConvolveWorkspaces-v1.rst
@@ -9,10 +9,7 @@
 Description
 -----------
 
-Convolution of two workspaces using :ref:`Convolution <func-Convolution>` from
-CurveFitting. Workspaces must have the same number of spectra.
-
-The resolution workspace will be evaluated in the range :math:`-L` to :math:`+L` where :math:`L` is defined in terms of the :math:`x` range of the data workspace as follows :math:`L=(x_{max}-x_{min})/2`. The resolution workspace therefore needs to have values specified in this range.
+Convolution of two workspaces using the :ref:`Convolution <func-Convolution>` function. Workspaces must have the same number of spectra.
 
 Usage
 -----

--- a/docs/source/fitting/fitfunctions/Convolution.rst
+++ b/docs/source/fitting/fitfunctions/Convolution.rst
@@ -34,7 +34,7 @@ evaluated on different intervals. :math:`F` is computed on :math:`[A,B]`
 while :math:`R` is computed on :math:`[-\Delta/2, \Delta/2]`, where
 :math:`\Delta=B-A`.
 
-In the following example a :ref:`func-Convolution` is convolved with a
+In the following example a :ref:`func-Gaussian` is convolved with a
 box function:
 
 .. figure:: /images/Convolution.png

--- a/docs/source/fitting/fitfunctions/Convolution.rst
+++ b/docs/source/fitting/fitfunctions/Convolution.rst
@@ -24,7 +24,7 @@ fitting interval.
 FFT mode
 ========
 
-if :math:`|A|` similar to :math:`|B|`, the function is evaluated
+if :math:`|A|` similar to :math:`|B|` or :math:`AB > 0`, the function is evaluated
 by first transforming :math:`R` and :math:`F` to the Fourier domain,
 multiplying the transforms, then transforming back to the original domain.
 The GSL FFT routines are used to do the actual transformations.

--- a/docs/source/release/v6.6.0/Framework/Algorithms/Bugfixes/34665.rst
+++ b/docs/source/release/v6.6.0/Framework/Algorithms/Bugfixes/34665.rst
@@ -1,0 +1,1 @@
+- fix problem with the :ref:`ConvolveWorkspaces  <algm-ConvolveWorkspaces>` algorithm when run on input workspaces with different x ranges. The x range of the output workspace was being taken from the resolution workspace instead of the data workspace


### PR DESCRIPTION
**Description of work.**

The ConvolveWorkspaces algorithm doesn't work if the x min\max of the resolution function (which would normally be centred on zero) is different to the x min\max of the data eg in the case where resolution function has x range -5 to +5 and the data has x range +10 to +20 the result is empty (all zeroes) and has x range -5 to +5. This is the example given on the [documentation page](https://docs.mantidproject.org/nightly/fitting/fitfunctions/Convolution.html) for the Convolution function so the plots (which are .png files generated outside of Mantid) can't be replicated using Mantid. The problem is caused by the x range of the output workspace being taken from the resolution function instead of the data function.

If the two input workspaces were centered on zero but had different extents (eg -5 to +5 and -10 to +10) I think it was possible to reduce the impact of the bug by swapping the order of the input workspaces. This gives an output with the correct x range. If the FFT method is used it seems like the y values are also correct using this workaround but if the Direct method is used the y values seem to be slightly off meaning the workaround isn't 100% effective.

The workaround of swapping the workspaces around was being used in the MolDyn workflow algorithm where the input data workspace has an x axis of energy transfer which is typically centered at zero. As part of this change I've swapped the order of the arguments to the call to ConvolveWorkspaces in MolDyn.py. It uses the Direct method to do the convolution so the result isn't quite the same as before (see separate note)

In general the ConvolveWorkspaces documentation isn't very clear that the two input workspaces aren't interchangeable so I've also updated the documentation a bit.

**To test:**

Run this script which convolutes a box shaped resolution function centred on zero with a data function that is a gaussian not centered on zero. Plot the resulting workspaces (all containing a single spectrum) on the same axes:
```
# import mantid algorithms, numpy and matplotlib
from mantid.simpleapi import *
import matplotlib.pyplot as plt
import math

x_box=[]
y_box=[]
centre=0

for i in range(101):
    xval = -5 + 0.1*i
    x_box.append(xval)
    if abs(xval-centre)<1:
        yval=0.5
    else:
        yval=0
    y_box.append(yval)
box_ws = CreateWorkspace(DataX=x_box, DataY=y_box)
x_gaussian = []
y_gaussian = []
sigma = 0.25
centre = 15
for i in range(101):
    xval = 10 + 0.1*i
    x_gaussian.append(xval)
    y_gaussian.append(math.exp(-math.pow(xval-centre,2)/sigma*sigma))

gaussian_ws = CreateWorkspace(DataX=x_gaussian, DataY=y_gaussian)
conv_ws1 = ConvolveWorkspaces(box_ws, gaussian_ws)
```

It should look like this. Before these changes the output (conv_ws1) had x range -5 to +5 with all y values set to zero:
![image](https://user-images.githubusercontent.com/56295817/199686366-cf6de7a7-c143-4ab0-91ed-a1b2d4be87a7.png)

*There is no associated issue.*

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
