### PR TITLE
Only add one region if ROI button clicked again

### DIFF
--- a/qt/python/mantidqt/mantidqt/widgets/regionselector/presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/regionselector/presenter.py
@@ -139,6 +139,9 @@ class RegionSelector(ObservingPresenter, SliceViewerBasePresenter):
         for selector in self._selectors:
             selector.set_active(False)
 
+        if self._drawing_region:
+            self._selectors.pop()
+
         self._selectors.append(Selector(region_type, color, self.view._data_view.ax, self._on_rectangle_selected))
 
         self._drawing_region = True

--- a/qt/python/mantidqt/mantidqt/widgets/regionselector/test/test_regionselector_presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/regionselector/test/test_regionselector_presenter.py
@@ -80,6 +80,7 @@ class RegionSelectorTest(unittest.TestCase):
         region_selector = RegionSelector(ws=Mock(), view=Mock())
 
         region_selector.add_rectangular_region("test", "black")
+        region_selector._drawing_region = False
         region_selector.add_rectangular_region("test", "black")
 
         self.assertEqual(2, len(region_selector._selectors))
@@ -280,6 +281,19 @@ class RegionSelectorTest(unittest.TestCase):
         self.assertEqual(1, len(region_selector._selectors))
         region_selector.cancel_drawing_region()
         self.assertEqual(0, len(region_selector._selectors))
+
+    def test_when_multiple_region_adds_are_requested_only_one_region_is_added(self):
+        # Given
+        region_selector = RegionSelector(ws=Mock(), view=Mock())
+        region_selector.add_rectangular_region("test", "black")
+        self.assertEqual(1, len(region_selector._selectors))
+
+        # When
+        region_selector.add_rectangular_region("test2", "green")
+
+        # Then
+        self.assertEqual(1, len(region_selector._selectors))
+        self.assertEqual(region_selector._selectors[0]._region_type, "test2")
 
     def test_cancel_drawing_region_with_no_selectors_does_not_crash(self):
         region_selector = RegionSelector(ws=Mock(), view=Mock())


### PR DESCRIPTION
**Description of work.**

Extra regions of 0-1 would keep being added each time one of the ROI buttons was pressed. This adds a check so that if the user was in draw mode, and an ROI button is clicked, then the previous region that they were drawing is removed before adding the new one.


<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**

1. Open the ISIS Reflectometry interface
2. Go to the Preview tab
3. Enter run `INTER45455_inst` and click Load (This data is available on this Epic and must be in your path: #31069)
4. On the sliceviewer plot:
5.  click the Signal toolbar button **twice**
6.  draw a region on the sliceviewer
7.  click the Apply button at the bottom
8. Go to the Experiment Settings tab and check the ROI field in the table. It should show only your selected region(s), e.g. `30-40`

Fixes #34602 


*This does not require release notes* because **it is part of an unreleased piece of work.**


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
