### PR TITLE
Don't Apply ROI's to an Invalid Experiment Settings Table

### DIFF
--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/ExperimentPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/ExperimentPresenter.cpp
@@ -105,6 +105,9 @@ void ExperimentPresenter::notifyInstrumentChanged(std::string const &instrumentN
 }
 
 void ExperimentPresenter::notifyPreviewApplyRequested(PreviewRow const &previewRow) {
+  if (!hasValidSettings()) {
+    throw InvalidTableException("The Experiment Settings table contains invalid settings.");
+  }
   if (auto const foundRow = m_model.findLookupRow(previewRow, m_thetaTolerance)) {
     auto lookupRowCopy = *foundRow;
 

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.cpp
@@ -203,6 +203,12 @@ void PreviewPresenter::notifyLinePlotExportAdsRequested() { m_model->exportReduc
 void PreviewPresenter::notifyApplyRequested() {
   try {
     m_mainPresenter->notifyPreviewApplyRequested();
+  } catch (InvalidTableException const &ex) {
+    std::ostringstream msg;
+    msg << "Could not update Experiment Settings: ";
+    msg << ex.what();
+    msg << " Please fix any errors in the Experiment Settings table and try again.";
+    g_log.error(msg.str());
   } catch (RowNotFoundException const &ex) {
     std::ostringstream msg;
     msg << "Could not update Experiment Settings: ";

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/RowExceptions.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/RowExceptions.h
@@ -21,4 +21,10 @@ struct MultipleRowsFoundException : public std::length_error {
 public:
   MultipleRowsFoundException(std::string s) : std::length_error(std::move(s)){};
 };
+
+struct InvalidTableException : public std::runtime_error {
+public:
+  InvalidTableException(std::string s) : std::runtime_error(std::move(s)){};
+};
+
 } // namespace MantidQt::CustomInterfaces::ISISReflectometry

--- a/qt/scientific_interfaces/ISISReflectometry/test/Experiment/ExperimentPresenterTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Experiment/ExperimentPresenterTest.h
@@ -725,6 +725,20 @@ public:
     TS_ASSERT_THROWS(presenter.notifyPreviewApplyRequested(previewRow), RowNotFoundException const &);
   }
 
+  void testNotifyPreviewApplyRequestedInvalidTable() {
+    // GIVEN an invalid table
+    OptionsTable const optionsTable = {optionsRowWithWildcard(), optionsRowWithWildcard()};
+    auto presenter = makePresenter();
+    EXPECT_CALL(m_view, getLookupTable()).WillOnce(Return(optionsTable));
+    presenter.notifyLookupRowChanged(1, 1);
+
+    // WHEN we look for any row in the table
+    auto previewRow = PreviewRow({""});
+
+    // THEN an InvalidTableException is thrown.
+    TS_ASSERT_THROWS(presenter.notifyPreviewApplyRequested(previewRow), InvalidTableException const &);
+  }
+
 private:
   NiceMock<MockExperimentView> m_view;
   NiceMock<MockBatchPresenter> m_mainPresenter;

--- a/qt/scientific_interfaces/ISISReflectometry/test/Preview/PreviewPresenterTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Preview/PreviewPresenterTest.h
@@ -405,6 +405,19 @@ public:
     presenter.notifyApplyRequested();
   }
 
+  void test_notify_apply_requested_will_catch_InvalidTableException() {
+    auto mockView = makeView();
+    auto mainPresenter = MockBatchPresenter();
+    auto presenter = PreviewPresenter(packDeps(mockView.get()));
+    presenter.acceptMainPresenter(&mainPresenter);
+
+    EXPECT_CALL(mainPresenter, notifyPreviewApplyRequested())
+        .Times(1)
+        .WillRepeatedly(Throw(InvalidTableException("Error message")));
+
+    presenter.notifyApplyRequested();
+  }
+
   void test_region_selector_and_reduction_plot_is_cleared_on_a_sum_banks_algorithm_error() {
     auto mockView = makeView();
     auto mockModel = makeModel();


### PR DESCRIPTION
**Description of work.**
The experiment settings table model is only allowed to be valid. If invalid changes are made on the view then the error is displayed but the model _is not_ updated. This was causing issues with the preview tab, which updates the Experiment model and then updates the view from that model. This cleared any invalid changes to the table (which may be a work in progress or something). 

Now, we stop the apply button from making changes to the model if the table view has any invalid values on it. 

We currently print this to the logger, but it might be nice in future to make these error messages appear as pop-ups similar to the way most errors are presented on the GUI.

**To test:**
1. Boot the Refl GUI
2. Add an extra blank row to the Exp settings tab
3. See it turn red to indicate an invalid setup
4. Hit apply in the preview tab
5. A clear error message should appear in the logger

Fixes #34603 


*This does not require release notes* because **it's part of the ongoing Preview tab work that's hasn't been released yet.**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
