### PR TITLE
Stop Multiple SANS GUIs From Being Open

### DIFF
--- a/docs/source/release/v6.6.0/SANS/Bugfixes/34120.rst
+++ b/docs/source/release/v6.6.0/SANS/Bugfixes/34120.rst
@@ -1,0 +1,1 @@
+- There can now only be one instance of the GUI open at any time. Selecting the GUI from the ``Interfaces`` menu when there is already one open will now re-show the currently open GUI.

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/ISIS_SANS.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/ISIS_SANS.py
@@ -4,11 +4,12 @@
 #   NScD Oak Ridge National Laboratory, European Spallation Source,
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
-#pylint: disable=invalid-name
+# pylint: disable=invalid-name
 """
     Script used to start the Test Interface from MantidPlot
 """
 import sys
+from qtpy import QtCore
 from sans.common.enums import SANSFacility
 from sans.gui_logic.models.run_tab_model import RunTabModel
 from sans.gui_logic.presenter.run_tab_presenter import RunTabPresenter
@@ -21,10 +22,19 @@ if 'workbench' in sys.modules:
 else:
     parent, flags = None, None
 
-main_window_view = sans_data_processor_gui.SANSDataProcessorGui(parent, flags)
-
-run_tab_presenter = RunTabPresenter(SANSFacility.ISIS, run_tab_model=RunTabModel(), view=main_window_view)
-
-
-# Show
-main_window_view.show()
+if 'isis_sans_reduction_view' in globals():
+    isis_sans_reduction_view = globals()['isis_sans_reduction_view']
+    if not isis_sans_reduction_view.isHidden():
+        isis_sans_reduction_view.setWindowState(
+            isis_sans_reduction_view.windowState(
+            ) & ~QtCore.Qt.WindowMinimized | QtCore.Qt.WindowActive)
+        isis_sans_reduction_view.activateWindow()
+    else:
+        isis_sans_reduction_view = sans_data_processor_gui.SANSDataProcessorGui(parent, flags)
+        run_tab_presenter = RunTabPresenter(SANSFacility.ISIS, run_tab_model=RunTabModel(),
+                                            view=isis_sans_reduction_view)
+        isis_sans_reduction_view.show()
+else:
+    isis_sans_reduction_view = sans_data_processor_gui.SANSDataProcessorGui(parent, flags)
+    run_tab_presenter = RunTabPresenter(SANSFacility.ISIS, run_tab_model=RunTabModel(), view=isis_sans_reduction_view)
+    isis_sans_reduction_view.show()


### PR DESCRIPTION
**Description of work.**
Adds checks to the SANS GUI startup script to check if it has already been started, and if so, just show the existing one. 


**To test:**
1. Start the SANS GUI
2. Start the SANS GUI
3. Is there only one SANS GUI? Good.

Fixes #34120 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
