### PR TITLE
Avoid live data stopping for transmission runs

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/ReflectometryReductionOneLiveData.py
+++ b/Framework/PythonInterface/plugins/algorithms/ReflectometryReductionOneLiveData.py
@@ -85,9 +85,7 @@ class ReflectometryReductionOneLiveData(DataProcessorAlgorithm):
 
     def _setup_reduction_algorithm(self):
         """Set up the reduction algorithm"""
-        alg = AlgorithmManager.create("ReflectometryISISLoadAndProcess")
-        alg.initialize()
-        alg.setChild(True)
+        alg = self.createChildAlgorithm("ReflectometryISISLoadAndProcess")
         self._copy_property_values_to(alg)
         alg.setProperty("InputRunList", self._out_ws_name)
         alg.setProperty("ThetaLogName", "Theta")

--- a/Framework/PythonInterface/test/python/plugins/algorithms/ReflectometryReductionOneLiveDataTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/ReflectometryReductionOneLiveDataTest.py
@@ -137,7 +137,7 @@ class ReflectometryReductionOneLiveDataTest(unittest.TestCase):
         workspace = self._run_algorithm_with_defaults()
         expected = ['CloneWorkspace', 'LoadInstrument', 'GetFakeLiveInstrumentValue', 'GetFakeLiveInstrumentValue',
                     'GetFakeLiveInstrumentValue', 'AddSampleLogMultiple', 'SetInstrumentParameter',
-                    'SetInstrumentParameter']
+                    'SetInstrumentParameter', 'ReflectometryISISLoadAndProcess']
         self._check_history(workspace, expected)
 
     def test_missing_inputs(self):
@@ -232,7 +232,8 @@ class ReflectometryReductionOneLiveDataTest(unittest.TestCase):
         workspace = self._run_algorithm_with_zero_theta()
         expected = ['CloneWorkspace', 'LoadInstrument', 'GetFakeLiveInstrumentValuesWithZeroTheta',
                     'GetFakeLiveInstrumentValuesWithZeroTheta', 'GetFakeLiveInstrumentValuesWithZeroTheta',
-                    'AddSampleLogMultiple', 'SetInstrumentParameter', 'SetInstrumentParameter']
+                    'AddSampleLogMultiple', 'SetInstrumentParameter', 'SetInstrumentParameter',
+                    'ReflectometryISISLoadAndProcess']
         self._check_history(workspace, expected)
 
     def test_slits_gaps_are_set_up_on_output_workspace(self):

--- a/Framework/PythonInterface/test/python/plugins/algorithms/ReflectometryReductionOneLiveDataTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/ReflectometryReductionOneLiveDataTest.py
@@ -228,7 +228,7 @@ class ReflectometryReductionOneLiveDataTest(unittest.TestCase):
                           Instrument='INTER',
                           GetLiveValueAlgorithm='GetFakeLiveInstrumentValueInvalidNames')
 
-    def test_algorithm_fails_if_theta_is_zero(self):
+    def test_reduction_works_if_theta_is_zero(self):
         workspace = self._run_algorithm_with_zero_theta()
         expected = ['CloneWorkspace', 'LoadInstrument', 'GetFakeLiveInstrumentValuesWithZeroTheta',
                     'GetFakeLiveInstrumentValuesWithZeroTheta', 'GetFakeLiveInstrumentValuesWithZeroTheta',

--- a/Framework/PythonInterface/test/python/plugins/algorithms/ReflectometryReductionOneLiveDataTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/ReflectometryReductionOneLiveDataTest.py
@@ -229,13 +229,11 @@ class ReflectometryReductionOneLiveDataTest(unittest.TestCase):
                           GetLiveValueAlgorithm='GetFakeLiveInstrumentValueInvalidNames')
 
     def test_algorithm_fails_if_theta_is_zero(self):
-        self.assertRaises(RuntimeError,
-                          ReflectometryReductionOneLiveData,
-                          InputWorkspace=self.__class__._input_ws,
-                          OutputWorkspace='output',
-                          Instrument='INTER',
-                          GetLiveValueAlgorithm='GetFakeLiveInstrumentValuesWithZeroTheta')
-
+        workspace = self._run_algorithm_with_zero_theta()
+        expected = ['CloneWorkspace', 'LoadInstrument', 'GetFakeLiveInstrumentValuesWithZeroTheta',
+                    'GetFakeLiveInstrumentValuesWithZeroTheta', 'GetFakeLiveInstrumentValuesWithZeroTheta',
+                    'AddSampleLogMultiple', 'SetInstrumentParameter', 'SetInstrumentParameter']
+        self._check_history(workspace, expected)
 
     def test_slits_gaps_are_set_up_on_output_workspace(self):
         workspace = self._run_algorithm_with_defaults()
@@ -296,6 +294,13 @@ class ReflectometryReductionOneLiveDataTest(unittest.TestCase):
     def _run_algorithm_with_alternative_names(self):
         args = self._default_args
         args['GetLiveValueAlgorithm'] = 'GetFakeLiveInstrumentValueAlternativeNames'
+        alg = create_algorithm('ReflectometryReductionOneLiveData', **args)
+        assertRaisesNothing(self, alg.execute)
+        return mtd['output']
+
+    def _run_algorithm_with_zero_theta(self):
+        args = self._default_args
+        args['GetLiveValueAlgorithm'] = 'GetFakeLiveInstrumentValuesWithZeroTheta'
         alg = create_algorithm('ReflectometryReductionOneLiveData', **args)
         assertRaisesNothing(self, alg.execute)
         return mtd['output']

--- a/Framework/PythonInterface/test/python/plugins/algorithms/ReflectometryReductionOneLiveDataTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/ReflectometryReductionOneLiveDataTest.py
@@ -115,6 +115,13 @@ class ReflectometryReductionOneLiveDataTest(unittest.TestCase):
         self._assert_delta(workspace.dataY(0)[33], 0.000029)
         self._assert_delta(workspace.dataY(0)[53], 0.0)
 
+    def test_basic_reduction_history(self):
+        workspace = self._run_algorithm_with_defaults()
+        expected = ['CloneWorkspace', 'LoadInstrument', 'GetFakeLiveInstrumentValue', 'GetFakeLiveInstrumentValue',
+                    'GetFakeLiveInstrumentValue', 'AddSampleLogMultiple', 'SetInstrumentParameter',
+                    'SetInstrumentParameter']
+        self._check_history(workspace, expected)
+
     def test_missing_inputs(self):
         self.assertRaises(RuntimeError,
                           ReflectometryReductionOneLiveData)
@@ -267,6 +274,21 @@ class ReflectometryReductionOneLiveDataTest(unittest.TestCase):
 
     def _assert_delta(self, value1, value2):
         self.assertEqual(round(value1, 6), round(value2, 6))
+
+    def _check_history(self, ws, expected, unroll = True):
+        """Return true if algorithm names listed in algorithmNames are found in the
+        workspace's history. If unroll is true, checks the child histories, otherwise
+        checks the top level history (the latter is required for sliced workspaces where
+        the child workspaces have lost their parent's history)
+        """
+        history = ws.getHistory()
+        if unroll:
+            reductionHistory = history.getAlgorithmHistory(history.size() - 1)
+            algHistories = reductionHistory.getChildHistories()
+            algNames = [alg.name() for alg in algHistories]
+        else:
+            algNames = [alg.name() for alg in history]
+        self.assertEqual(algNames, expected)
 
 
 if __name__ == '__main__':

--- a/docs/source/release/v6.6.0/Reflectometry/Bugfixes/34574.rst
+++ b/docs/source/release/v6.6.0/Reflectometry/Bugfixes/34574.rst
@@ -1,0 +1,1 @@
+- Fix a bug where the live data monitor would stop running when it encounters a transmission run. This was because the reduction would fail when the angle is zero.


### PR DESCRIPTION
**Description of work.**
This PR fixes a problem where the live data monitor would stop running when it encounters a transmission run. This is because we attempt to run a normal reduction, but it fails because the angle is zero. For now I've gone with a simple fix (suggested by scientists) to just run the reduction with a fake angle to allow it to succeed. Longer term I think it would be better to add proper error handling into the GUI to identify this type of error, but I'd like to get this into a nightly first so the scientists can test it and see what the usability is like.

**Report to:** Max and Becky at ISIS

**To test:**

Needs to be tested at ISIS while instruments are live.

- Open the ISIS Reflectometry interface.
- Set instrument to INTER
- On the Experiment Settings tab, in the AnalysisMode drop down, select MultiDetectorAnalysis.
- On the Runs tab, click the Start Monitor button.
- Check for messages in the log. After a short while you should get some output detailing which angle the instrument is currently running with, e.g.:
```
Theta = 3.0001
s1vgap = 29.9990
s2vgap = 30.0005
```
- Theta will be zero if a transmission is currently running; greater than zero otherwise. Either way, the reduction should finish successfully.
- There should be a `TOF_live` and `IvsQ_binned_live` workspace which are updated each time a live data chunk is received.
- Plot the `IvsQ_binned_live` workspace - it should contain a single spectrum, and will be an almost-flat line if a transmission is running.
- Click Stop Monitor and after a few seconds the live data monitor should stop

Fixes #34574


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
