### PR TITLE
Fix crash caused by missing method on sliceviewer base presenter

### DIFF
--- a/qt/python/mantidqt/mantidqt/widgets/regionselector/presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/regionselector/presenter.py
@@ -207,3 +207,6 @@ class RegionSelector(ObservingPresenter, SliceViewerBasePresenter):
         if x is None or y is None:
             return False
         return extents[0] <= x <= extents[1] and extents[2] <= y <= extents[3]
+
+    def get_extra_image_info_columns(self, xdata, ydata):
+        return {}

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/presenters/base_presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/presenters/base_presenter.py
@@ -117,3 +117,7 @@ class SliceViewerBasePresenter(IDataViewSubscriber, ABC):
             data_view.enable_tool_button(ToolItemText.ZOOM)
             data_view.enable_tool_button(ToolItemText.PAN)
             data_view.switch_line_plots_tool(PixelLinePlot, self)
+
+    @abc.abstractmethod
+    def get_extra_image_info_columns(self, xdata, ydata):
+        pass

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_base_presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_base_presenter.py
@@ -37,6 +37,9 @@ class SliceViewerBasePresenterShim(SliceViewerBasePresenter):
     def zoom_pan_clicked(self, active) -> None:
         pass
 
+    def get_extra_image_info_columns(self):
+        return {}
+
 
 class SliceViewerBasePresenterTest(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
A new method was added to the SliceViewer presenter class but not to the base class, so the other derived type, RegionSelector, was missing this method. This caused a crash when attempting to load data into the RegionSelector, because the image info widget was attempting to call the new method.

I'm not sure how to add a meaningful test for this. The image info widget will actually be removed from RegionSelector soon anyway.

Fixes #34700

**To test:**

See linked issue and check the crash is fixed.

*This does not require release notes* because **it fixes a regression on main**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
