### PR TITLE
Fix for D16 single scan monitors loading

### DIFF
--- a/Framework/DataHandling/src/LoadILLSANS.cpp
+++ b/Framework/DataHandling/src/LoadILLSANS.cpp
@@ -320,7 +320,8 @@ void LoadILLSANS::initWorkSpace(NeXus::NXEntry &firstEntry, const std::string &i
 
   size_t nextIndex;
   nextIndex = loadDataFromTubes(data, binning, 0);
-  if (!m_isD16Omega) {
+  if (!m_isD16Omega ||
+      (m_isD16Omega && data.dim0() == 1)) { // second condition covers legacy D16 omega scans with single scan point
     loadDataFromMonitors(firstEntry, nextIndex);
   } else
     loadDataFromD16ScanMonitors(firstEntry, nextIndex, binning);

--- a/Framework/DataHandling/src/LoadILLSANS.cpp
+++ b/Framework/DataHandling/src/LoadILLSANS.cpp
@@ -320,8 +320,7 @@ void LoadILLSANS::initWorkSpace(NeXus::NXEntry &firstEntry, const std::string &i
 
   size_t nextIndex;
   nextIndex = loadDataFromTubes(data, binning, 0);
-  if (!m_isD16Omega ||
-      (m_isD16Omega && data.dim0() == 1)) { // second condition covers legacy D16 omega scans with single scan point
+  if (!m_isD16Omega || data.dim0() == 1) { // second condition covers legacy D16 omega scans with single scan point
     loadDataFromMonitors(firstEntry, nextIndex);
   } else
     loadDataFromD16ScanMonitors(firstEntry, nextIndex, binning);

--- a/Framework/DataHandling/test/LoadILLSANSTest.h
+++ b/Framework/DataHandling/test/LoadILLSANSTest.h
@@ -86,6 +86,10 @@ public:
     IComponent_const_sptr component = instrument->getComponentByName("detector");
     V3D pos = component->getPos();
     TS_ASSERT_DELTA(pos.Z(), 20.007, 1E-3)
+    // check for the correct unit
+    const auto unit = outputWS->getAxis(0)->unit()->unitID();
+    TS_ASSERT_EQUALS(unit, "Wavelength");
+    // check loaded data contains expected values
     const auto &xAxis = outputWS->x(0).rawData();
     const auto &spec6 = outputWS->y(6).rawData();
     const auto &err6 = outputWS->e(6).rawData();
@@ -94,8 +98,11 @@ public:
     TS_ASSERT_DELTA(xAxis[1], 6.27, 1E-5)
     TS_ASSERT_EQUALS(spec6[0], 20)
     TS_ASSERT_DELTA(err6[0], sqrt(20), 1E-5)
-    const auto unit = outputWS->getAxis(0)->unit()->unitID();
-    TS_ASSERT_EQUALS(unit, "Wavelength");
+    TS_ASSERT_DELTA(outputWS->y(0)[0], 0.0, 1E-5)
+    TS_ASSERT_DELTA(outputWS->y(1)[0], 3.0, 1E-5)
+    TS_ASSERT_DELTA(outputWS->y(16384)[0], 10418891.0, 1E-5)
+    TS_ASSERT_DELTA(outputWS->y(16385)[0], 0.0, 1E-5)
+
     checkTimeFormat(outputWS);
     checkDuration(outputWS, 1200.);
     checkWavelength(outputWS, 6.);
@@ -134,13 +141,19 @@ public:
     component = instrument->getComponentByName("detector_right");
     pos = component->getPos();
     TS_ASSERT_DELTA(pos.Z(), l2 - panelOffset, 1E-5)
+    // check for the correct unit
+    const auto unit = outputWS->getAxis(0)->unit()->unitID();
+    TS_ASSERT_EQUALS(unit, "Wavelength");
+    // check loaded data contains expected values
     const auto &xAxis = outputWS->x(0).rawData();
     TS_ASSERT_EQUALS(outputWS->blocksize(), 1);
     TS_ASSERT_EQUALS(xAxis.size(), 2)
     TS_ASSERT_DELTA(xAxis[0], 5.73, 1E-5)
     TS_ASSERT_DELTA(xAxis[1], 6.27, 1E-5)
-    const auto unit = outputWS->getAxis(0)->unit()->unitID();
-    TS_ASSERT_EQUALS(unit, "Wavelength");
+    TS_ASSERT_DELTA(outputWS->y(0)[0], 0.0, 1E-5)
+    TS_ASSERT_DELTA(outputWS->y(192 * 256 + 2 * 32 * 256)[0], 1.0, 1E-5)
+    TS_ASSERT_DELTA(outputWS->y(192 * 256 + 2 * 32 * 256 + 1)[0], 0.0, 1E-5)
+
     checkTimeFormat(outputWS);
     checkDuration(outputWS, 600.);
     checkWavelength(outputWS, 6.);
@@ -157,6 +170,7 @@ public:
     MatrixWorkspace_const_sptr outputWS = alg.getProperty("OutputWorkspace");
     TS_ASSERT(outputWS)
     TS_ASSERT_EQUALS(outputWS->getNumberHistograms(), 192 * 256 + 2 * 32 * 256 + 2)
+    TS_ASSERT(!outputWS->detectorInfo().isMonitor(0))
     TS_ASSERT(outputWS->detectorInfo().isMonitor(192 * 256 + 2 * 32 * 256))
     TS_ASSERT(outputWS->detectorInfo().isMonitor(192 * 256 + 2 * 32 * 256 + 1))
     TS_ASSERT(!outputWS->isHistogramData())
@@ -188,6 +202,7 @@ public:
     TS_ASSERT_EQUALS(xAxis.size(), nExpectedFrames)
     TS_ASSERT_DELTA(xAxis[0], 0, 1E-9)
     TS_ASSERT_DELTA(xAxis[13], 13, 1E-9)
+    // check loaded data contains expected values
     const auto &mon1 = outputWS->y(192 * 256 + 2 * 32 * 256).rawData();
     const auto &mon1err = outputWS->e(192 * 256 + 2 * 32 * 256).rawData();
     TS_ASSERT_EQUALS(mon1.size(), nExpectedFrames)
@@ -200,8 +215,12 @@ public:
     TS_ASSERT_DELTA(mon2[0], 0.05, 1E-3)
     TS_ASSERT_EQUALS(mon2err.size(), nExpectedFrames)
     TS_ASSERT_DELTA(mon2err[0], 0, 1E-9)
+    TS_ASSERT_DELTA(outputWS->y(0)[0], 0, 1E-5)
+    TS_ASSERT_DELTA(outputWS->y(0)[84], 1.0, 1E-5)
+    // check for the correct unit
     const auto unit = outputWS->getAxis(0)->unit()->unitID();
     TS_ASSERT_EQUALS(unit, "Empty");
+
     checkTimeFormat(outputWS);
     checkDuration(outputWS, 0.);
     checkWavelength(outputWS, 6.);
@@ -219,6 +238,7 @@ public:
     TS_ASSERT(outputWS)
     TS_ASSERT_EQUALS(outputWS->getNumberHistograms(), 128 * 256 + 2)
     TS_ASSERT_EQUALS(outputWS->blocksize(), 1)
+    TS_ASSERT(!outputWS->detectorInfo().isMonitor(0))
     TS_ASSERT(outputWS->detectorInfo().isMonitor(128 * 256))
     TS_ASSERT(outputWS->detectorInfo().isMonitor(128 * 256 + 1))
     TS_ASSERT(outputWS->isHistogramData())
@@ -228,6 +248,7 @@ public:
     V3D pos = component->getPos();
     TS_ASSERT_DELTA(pos.Z(), 8, 0.01)
     TS_ASSERT_DELTA(pos.X(), -0.35, 0.01)
+    // check loaded data contains expected values
     const auto &xAxis = outputWS->x(0).rawData();
     const auto &spec6 = outputWS->y(6).rawData();
     const auto &err6 = outputWS->e(6).rawData();
@@ -236,6 +257,11 @@ public:
     TS_ASSERT_DELTA(xAxis[1], 5.25, 1E-5)
     TS_ASSERT_EQUALS(spec6[0], 45)
     TS_ASSERT_DELTA(err6[0], sqrt(45), 1E-5)
+    TS_ASSERT_DELTA(outputWS->y(128 * 256)[0], 245681.0, 1E-5)
+    TS_ASSERT_DELTA(outputWS->e(128 * 256)[0], 495.66218, 1E-5)
+    TS_ASSERT_DELTA(outputWS->y(128 * 256 + 1)[0], 0.0, 1E-5)
+    TS_ASSERT_DELTA(outputWS->e(128 * 256 + 1)[0], 0.0, 1E-5)
+    // check for the correct unit
     const auto unit = outputWS->getAxis(0)->unit()->unitID();
     TS_ASSERT_EQUALS(unit, "Wavelength");
     checkTimeFormat(outputWS);
@@ -257,6 +283,7 @@ public:
     TS_ASSERT(outputWS)
     TS_ASSERT_EQUALS(outputWS->getNumberHistograms(), 128 * 256 + 96 * 256 + 2)
     TS_ASSERT_EQUALS(outputWS->blocksize(), 1)
+    TS_ASSERT(!outputWS->detectorInfo().isMonitor(0))
     TS_ASSERT(outputWS->detectorInfo().isMonitor(128 * 256 + 96 * 256))
     TS_ASSERT(outputWS->detectorInfo().isMonitor(128 * 256 + 96 * 256 + 1))
     TS_ASSERT(outputWS->isHistogramData())
@@ -291,6 +318,14 @@ public:
     TS_ASSERT_EQUALS(qx, 0.)
     TS_ASSERT_DELTA(std::fabs(qy), 1., 1E-6)
     TS_ASSERT_EQUALS(qz, 0.)
+    // check loaded data contains expected values
+    const auto &xAxis = outputWS->x(0).rawData();
+    TS_ASSERT_DELTA(xAxis[0], 5.7, 1E-5)
+    TS_ASSERT_DELTA(xAxis[1], 6.3, 1E-5)
+    TS_ASSERT_DELTA(outputWS->y(0)[0], 0.0, 1E-5)
+    TS_ASSERT_DELTA(outputWS->e(0)[0], 0.0, 1E-5)
+    TS_ASSERT_DELTA(outputWS->y(128 * 256 + 96 * 256)[0], 0.0, 1E-5)
+    TS_ASSERT_DELTA(outputWS->e(128 * 256 + 96 * 256)[0], 0.0, 1E-5)
     checkTimeFormat(outputWS);
     checkDuration(outputWS, 60.);
     checkWavelength(outputWS, 6.);
@@ -308,6 +343,7 @@ public:
     TS_ASSERT(outputWS)
     TS_ASSERT_EQUALS(outputWS->getNumberHistograms(), 128 * 256 + 96 * 256 + 2)
     TS_ASSERT_EQUALS(outputWS->blocksize(), 1)
+    TS_ASSERT(!outputWS->detectorInfo().isMonitor(0))
     TS_ASSERT(outputWS->detectorInfo().isMonitor(128 * 256 + 96 * 256))
     TS_ASSERT(outputWS->detectorInfo().isMonitor(128 * 256 + 96 * 256 + 1))
     TS_ASSERT(outputWS->isHistogramData())
@@ -342,6 +378,16 @@ public:
     TS_ASSERT_EQUALS(qx, 0.)
     TS_ASSERT_DELTA(std::fabs(qy), 1., 1E-6)
     TS_ASSERT_EQUALS(qz, 0.)
+    // check loaded data contains expected values
+    const auto &xAxis = outputWS->x(0).rawData();
+    TS_ASSERT_DELTA(xAxis[0], 10.4595, 1E-5)
+    TS_ASSERT_DELTA(xAxis[1], 11.5605, 1E-5)
+    TS_ASSERT_DELTA(outputWS->y(17263)[0], 100.0, 1E-5)
+    TS_ASSERT_DELTA(outputWS->e(17263)[0], 10.0, 1E-5)
+    TS_ASSERT_DELTA(outputWS->y(128 * 256 + 96 * 256)[0], 74361.0, 1E-5)
+    TS_ASSERT_DELTA(outputWS->e(128 * 256 + 96 * 256)[0], 272.69213, 1E-5)
+    TS_ASSERT_DELTA(outputWS->y(128 * 256 + 96 * 256 + 1)[0], 0.0, 1E-5)
+    TS_ASSERT_DELTA(outputWS->e(128 * 256 + 96 * 256 + 1)[0], 0.0, 1E-5)
     checkTimeFormat(outputWS);
     checkDuration(outputWS, 60.);
     checkWavelength(outputWS, 11.01);
@@ -358,11 +404,13 @@ public:
     MatrixWorkspace_const_sptr outputWS = alg.getProperty("OutputWorkspace");
     TS_ASSERT(outputWS)
     TS_ASSERT_EQUALS(outputWS->getNumberHistograms(), 128 * 256 + 96 * 256 + 2)
+    TS_ASSERT(!outputWS->detectorInfo().isMonitor(0))
     TS_ASSERT(outputWS->detectorInfo().isMonitor(128 * 256 + 96 * 256 + 1))
     TS_ASSERT(outputWS->detectorInfo().isMonitor(128 * 256 + 96 * 256))
     TS_ASSERT(!outputWS->isHistogramData())
     TS_ASSERT(!outputWS->isDistribution())
     TS_ASSERT(outputWS->isCommonBins())
+    TS_ASSERT_EQUALS(outputWS->blocksize(), 400)
     const auto &instrument = outputWS->getInstrument();
     const auto &run = outputWS->run();
     TS_ASSERT(run.hasProperty("Detector 1.det1_calc"));
@@ -394,6 +442,17 @@ public:
     TS_ASSERT_EQUALS(qx, 0.)
     TS_ASSERT_DELTA(std::fabs(qy), 1., 1E-6)
     TS_ASSERT_EQUALS(qz, 0.)
+    // check loaded data contains expected values
+    const auto &xAxis = outputWS->x(0).rawData();
+    TS_ASSERT_DELTA(xAxis[0], 0.0, 1E-5)
+    TS_ASSERT_DELTA(xAxis[5], 5.0, 1E-5)
+    TS_ASSERT_DELTA(xAxis[399], 399.0, 1E-5)
+    TS_ASSERT_DELTA(outputWS->y(51192)[155], 1.0, 1E-5)
+    TS_ASSERT_DELTA(outputWS->e(51192)[155], 1.0, 1E-5)
+    TS_ASSERT_DELTA(outputWS->y(128 * 256 + 96 * 256)[0], 173.0, 1E-5)
+    TS_ASSERT_DELTA(outputWS->e(128 * 256 + 96 * 256)[0], 13.15295, 1E-5)
+    TS_ASSERT_DELTA(outputWS->y(128 * 256 + 96 * 256 + 1)[0], 0.05, 1E-5)
+    TS_ASSERT_DELTA(outputWS->e(128 * 256 + 96 * 256 + 1)[0], 0.0, 1E-5)
     checkTimeFormat(outputWS);
     checkDuration(outputWS, 20.);
     checkWavelength(outputWS, 6.);
@@ -410,6 +469,7 @@ public:
     MatrixWorkspace_const_sptr outputWS = alg.getProperty("OutputWorkspace");
     TS_ASSERT(outputWS);
     TS_ASSERT(outputWS->isHistogramData())
+    TS_ASSERT(!outputWS->detectorInfo().isMonitor(0));
     TS_ASSERT(outputWS->detectorInfo().isMonitor(320 * 320));
     TS_ASSERT(outputWS->detectorInfo().isMonitor(320 * 320 + 1));
     const auto &instrument = outputWS->getInstrument();
@@ -434,6 +494,7 @@ public:
     TS_ASSERT_DELTA(tl_pos.Z(), 0.95711, 1E-5);
     TS_ASSERT_DELTA(br_pos.X(), -0.01657, 1E-5);
     TS_ASSERT_DELTA(br_pos.Z(), 1.01250, 1E-5);
+    // check loaded data contains expected values
     const auto &xAxis = outputWS->x(0).rawData();
     const auto &spec = outputWS->y(51972).rawData();
     const auto &err = outputWS->e(51972).rawData();
@@ -442,6 +503,10 @@ public:
     TS_ASSERT_DELTA(xAxis[1], 7.035, 1E-3)
     TS_ASSERT_EQUALS(spec[0], 17)
     TS_ASSERT_DELTA(err[0], sqrt(17), 1E-5)
+    TS_ASSERT_DELTA(outputWS->y(320 * 320)[0], 0.0, 1E-5)
+    TS_ASSERT_DELTA(outputWS->e(320 * 320)[0], 0.0, 1E-5)
+    TS_ASSERT_DELTA(outputWS->y(320 * 320 + 1)[0], 124744.0, 1E-5)
+    TS_ASSERT_DELTA(outputWS->e(320 * 320 + 1)[0], 353.19117, 1E-5)
     checkTimeFormat(outputWS);
     checkDuration(outputWS, 30.);
     checkWavelength(outputWS, 7.);
@@ -459,10 +524,22 @@ public:
     MatrixWorkspace_const_sptr outputWS = alg.getProperty("OutputWorkspace");
     TS_ASSERT(outputWS);
     TS_ASSERT(outputWS->isHistogramData())
+    TS_ASSERT(!outputWS->detectorInfo().isMonitor(0));
     TS_ASSERT(outputWS->detectorInfo().isMonitor(320 * 320));
     TS_ASSERT(outputWS->detectorInfo().isMonitor(320 * 320 + 1));
     TS_ASSERT_EQUALS(outputWS->blocksize(), 1)
     TS_ASSERT_EQUALS(outputWS->getNumberHistograms(), 320 * 320 + 2);
+    // check loaded data contains expected values
+    const auto &xAxis = outputWS->x(0).rawData();
+    TS_ASSERT_EQUALS(xAxis.size(), 2)
+    TS_ASSERT_DELTA(xAxis[0], 4.776, 1E-3)
+    TS_ASSERT_DELTA(xAxis[1], 4.824, 1E-3)
+    TS_ASSERT_DELTA(outputWS->y(0)[0], 3.0, 1E-3)
+    TS_ASSERT_DELTA(outputWS->e(0)[0], 1.732, 1E-3)
+    TS_ASSERT_DELTA(outputWS->y(320 * 320)[0], 0.0, 1E-3)
+    TS_ASSERT_DELTA(outputWS->e(320 * 320)[0], 0.0, 1E-3) // apparently, the error is 0
+    TS_ASSERT_DELTA(outputWS->y(320 * 320 + 1)[0], 213094.0, 1E-3)
+    TS_ASSERT_DELTA(outputWS->e(320 * 320 + 1)[0], 461.621, 1E-3)
     checkTimeFormat(outputWS);
     checkDuration(outputWS, 5.);
     checkWavelength(outputWS, 4.8);
@@ -499,9 +576,19 @@ public:
     MatrixWorkspace_const_sptr outputWS = alg.getProperty("OutputWorkspace");
     TS_ASSERT(outputWS);
     TS_ASSERT(!outputWS->isHistogramData())
+    TS_ASSERT(!outputWS->detectorInfo().isMonitor(0));
     TS_ASSERT(outputWS->detectorInfo().isMonitor(192 * 1152));
     TS_ASSERT_EQUALS(outputWS->blocksize(), 6)
     TS_ASSERT_EQUALS(outputWS->getNumberHistograms(), 192 * 1152 + 1);
+    // check loaded data contains expected values
+    TS_ASSERT_DELTA(outputWS->x(0)[0], 5.0, 1E-3)
+    TS_ASSERT_DELTA(outputWS->x(0)[5], 6.0, 1E-3)
+    TS_ASSERT_DELTA(outputWS->y(0)[0], 3304.0, 1E-3)
+    TS_ASSERT_DELTA(outputWS->e(0)[0], 57.480, 1E-3)
+    TS_ASSERT_DELTA(outputWS->y(192 * 1152 - 1)[5], 1131.0, 1E-3)
+    TS_ASSERT_DELTA(outputWS->e(192 * 1152 - 1)[5], 33.630, 1E-3)
+    TS_ASSERT_DELTA(outputWS->y(192 * 1152)[0], 0.0, 1E-3)
+    TS_ASSERT_DELTA(outputWS->e(192 * 1152)[0], 0.0, 1E-3)
     checkTimeFormat(outputWS);
     checkDuration(outputWS, 3.);
     checkWavelength(outputWS, 4.45);
@@ -519,6 +606,7 @@ public:
     TS_ASSERT(outputWS)
     TS_ASSERT_EQUALS(outputWS->getNumberHistograms(), 256 * 256 + 2)
     TS_ASSERT_EQUALS(outputWS->blocksize(), 1)
+    TS_ASSERT(!outputWS->detectorInfo().isMonitor(0))
     TS_ASSERT(outputWS->detectorInfo().isMonitor(256 * 256))
     TS_ASSERT(outputWS->detectorInfo().isMonitor(256 * 256 + 1))
     TS_ASSERT(outputWS->isHistogramData())
@@ -561,21 +649,28 @@ public:
     TS_ASSERT(outputWS)
     TS_ASSERT_EQUALS(outputWS->getNumberHistograms(), 256 * 256 + 2)
     TS_ASSERT_EQUALS(outputWS->blocksize(), 200)
+    TS_ASSERT(!outputWS->detectorInfo().isMonitor(0))
     TS_ASSERT(outputWS->detectorInfo().isMonitor(256 * 256))
     TS_ASSERT(outputWS->detectorInfo().isMonitor(256 * 256 + 1))
     TS_ASSERT(outputWS->isHistogramData())
     TS_ASSERT(!outputWS->isDistribution())
     TS_ASSERT(!outputWS->isCommonBins())
-    const auto &x = outputWS->x(0).rawData();
-    TS_ASSERT_DELTA(x[0], 0.04969, 1E-5)
-    TS_ASSERT_DELTA(x[1], 0.14873, 1E-5)
-    TS_ASSERT_DELTA(x[200], 19.85713, 1E-5)
     const auto &run = outputWS->run();
     TS_ASSERT(run.hasProperty("tof_mode"))
     const auto tof = run.getLogData("tof_mode");
     TS_ASSERT_EQUALS(tof->value(), "TOF");
     const auto unit = outputWS->getAxis(0)->unit()->unitID();
     TS_ASSERT_EQUALS(unit, "Wavelength");
+    // check loaded data contains expected values
+    TS_ASSERT_DELTA(outputWS->x(0)[0], 0.04969, 1E-5)
+    TS_ASSERT_DELTA(outputWS->x(0)[1], 0.14873, 1E-5)
+    TS_ASSERT_DELTA(outputWS->x(0)[200], 19.85713, 1E-5)
+    TS_ASSERT_DELTA(outputWS->y(0)[124], 1.0, 1E-3)
+    TS_ASSERT_DELTA(outputWS->e(0)[124], 1.0, 1E-3)
+    TS_ASSERT_DELTA(outputWS->y(256 * 256)[0], 0.0, 1E-3)
+    TS_ASSERT_DELTA(outputWS->e(256 * 256)[0], 0.0, 1E-3)
+    TS_ASSERT_DELTA(outputWS->y(256 * 256)[0], 0.0, 1E-3)
+    TS_ASSERT_DELTA(outputWS->e(256 * 256)[0], 0.0, 1E-3)
     checkTimeFormat(outputWS);
     checkDuration(outputWS, 30.);
   }
@@ -592,21 +687,28 @@ public:
     TS_ASSERT(outputWS)
     TS_ASSERT_EQUALS(outputWS->getNumberHistograms(), 256 * 256 + 2)
     TS_ASSERT_EQUALS(outputWS->blocksize(), 30)
+    TS_ASSERT(!outputWS->detectorInfo().isMonitor(0))
     TS_ASSERT(outputWS->detectorInfo().isMonitor(256 * 256))
     TS_ASSERT(outputWS->detectorInfo().isMonitor(256 * 256 + 1))
     TS_ASSERT(outputWS->isHistogramData())
     TS_ASSERT(!outputWS->isDistribution())
     TS_ASSERT(!outputWS->isCommonBins())
-    const auto &x = outputWS->x(0).rawData();
-    TS_ASSERT_DELTA(x[0], 0., 1E-5)
-    TS_ASSERT_DELTA(x[1], 0.1998, 1E-5)
-    TS_ASSERT_DELTA(x[2], 0.3996, 1E-5)
     const auto &run = outputWS->run();
     TS_ASSERT(run.hasProperty("tof_mode"))
     const auto tof = run.getLogData("tof_mode");
     TS_ASSERT_EQUALS(tof->value(), "TOF");
     const auto unit = outputWS->getAxis(0)->unit()->unitID();
     TS_ASSERT_EQUALS(unit, "Wavelength");
+    // check loaded data contains expected values
+    TS_ASSERT_DELTA(outputWS->x(0)[0], 0.0, 1E-5)
+    TS_ASSERT_DELTA(outputWS->x(0)[1], 0.1998, 1E-5)
+    TS_ASSERT_DELTA(outputWS->x(0)[2], 0.3996, 1E-5)
+    TS_ASSERT_DELTA(outputWS->y(0)[23], 1.0, 1E-3)
+    TS_ASSERT_DELTA(outputWS->e(0)[23], 1.0, 1E-3)
+    TS_ASSERT_DELTA(outputWS->y(256 * 256)[0], 0.0, 1E-3)
+    TS_ASSERT_DELTA(outputWS->e(256 * 256)[0], 0.0, 1E-3)
+    TS_ASSERT_DELTA(outputWS->y(256 * 256)[0], 0.0, 1E-3)
+    TS_ASSERT_DELTA(outputWS->e(256 * 256)[0], 0.0, 1E-3)
     checkTimeFormat(outputWS);
     checkDuration(outputWS, 120.);
   }


### PR DESCRIPTION
**Description of work.**

This PR fixes the issue of loading the single scan monitor for D16. After recent changes to loading D16 data (PR #34643), it seems that the monitor data in case of a single-point scan is loaded incorrectly. It is taken from `scanned_variables` dataset rather than from `monitorN/data`. This PR also improves the test coverage of the unit test to include asserts on exact values loaded from SANS ILL NeXus files.

**To test:**

The extended test should be passing.

- Load `023583.nxs` from `Testing/Data/UnitTest/ILL/D16`
- The value of the first monitor spectrum should be 0.0
- The value of the second monitor spectrum should be 213094.0 instead of 0.0.


<!-- Instructions for testing. -->

Fixes #34711 . 

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
