### PR TITLE
Avoid overwriting output workspace during processing

### DIFF
--- a/docs/source/release/v6.6.0/Reflectometry/Bugfixes/34575.rst
+++ b/docs/source/release/v6.6.0/Reflectometry/Bugfixes/34575.rst
@@ -1,0 +1,1 @@
+- Fixed an issue where the live data output would update during processing of a new chunk of live data; it now only updates with the final IvsQ result, avoiding the axes changing during processing.


### PR DESCRIPTION
When running live data from the ISIS Reflectometry interface, we now clone the input to a hidden workspace and just set the final output when processing is complete. This is required because users will leave the plot of the IvsQ workspace open while live data runs repeatedly and it is confusing if the plot is cleared and updated during processing a new chunk of live data; they just want to see it update with the final result

I haven't added a test because this changes the interim behaviour during processing, so it is difficult to test, and the final output is unchanged, which is the important thing anyway.

Fixes #34575

**Report to:** Max and Becky at ISIS

**To test:**

Requires live data to be running at ISIS

- In workbench settings, enable display of hidden workspaces
- Open the ISIS Reflectometry interface and click Start Monitor
- After a few seconds three workspaces should appear: `TOF_live`, `__IvsQ_binned_live` and `IvsQ_binned_live`. The hidden workspace (prefixed with `__`) appears first before the final IvsQ workspace. It is then deleted when the final workspace is produced.
- Plot `IvsQ_binned_live` and leave the plot open until the next chunk of live data is received (you'll see in the log output when this happens). The plot axes should not change significantly between the old and new chunk of data (previously the axes would change units and the plot would flash up with very different values).


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
