### PR TITLE
Prevent error on ALFView when not drawing miniplot

### DIFF
--- a/qt/widgets/instrumentview/src/InstrumentWidgetPickTab.cpp
+++ b/qt/widgets/instrumentview/src/InstrumentWidgetPickTab.cpp
@@ -1251,11 +1251,7 @@ void DetectorPlotController::addPeakLabels(const std::vector<size_t> &detIndices
 /**
  * Update the miniplot for a selected detector.
  */
-void DetectorPlotController::updatePlot() {
-  if (!m_instrWidget->isTabFolded()) {
-    m_plot->replot();
-  }
-}
+void DetectorPlotController::updatePlot() { m_plot->replot(); }
 
 /**
  * Clear the plot.


### PR DESCRIPTION
**Description of work.**
This PR prevents an error on ALFView by ensuring a draw event is scheduled to update a mini-plot upon returning to the GUI thread. The replot method calls `drawIdle`, and this will render the plot again once control returns to the GUI thread. It also ensures only one render event happens even if multiple `drawIdle`'s are called. 

This bug was unknowingly introduced in #34646 .

**To test:**
1. Open ALFView interface
2. Without loading any data, click on the `Pick` tab
3. You should see no errors and the miniplot on the pick tab will have an x range between 0 and 1

*There is no associated issue.*

No release notes required as this problem was introduced in #34646

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
