### PR TITLE
Fix bug in sliceviewer ROI for cursor released out of axes

### DIFF
--- a/docs/source/release/v6.6.0/Workbench/SliceViewer/Bugfixes/34722.rst
+++ b/docs/source/release/v6.6.0/Workbench/SliceViewer/Bugfixes/34722.rst
@@ -1,0 +1,1 @@
+* Fix bug in sliceviewer where the line plots produced by the ROI tool were not updated if the cursor was released outside the axes.

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/presenters/lineplots.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/presenters/lineplots.py
@@ -434,7 +434,7 @@ def cursor_info(image: AxesImage, xdata: float, ydata: float, full_bbox: Bbox = 
         return None
 
     point = point.astype(int)
-    if 0 <= point[0] < arr.shape[0] and 0 <= point[1] < arr.shape[1]:
+    if 0 <= point[0] <= arr.shape[0] and 0 <= point[1] <= arr.shape[1]:
         return CursorInfo(array=arr, extent=extent, point=point)
     else:
         return None


### PR DESCRIPTION
**Description of work.**

One line fix to allow the x/y index of the cursor to be equal to array extents (as is the case when the cursor is released outside of the axes). This does not produce an out-of-range error because the limits are used in a slice so the final index is not included.

This also explains why the issue was not seen if the cursor was relased inside the line plot axes (because the cursor index was set to 0 and that was allowed when creating the CursorInfo object).



<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**

(1) Follow the instructions in the original issue - release the cursor outside the top or right-hand-side of the colorfill axes

- It should update the line plots with the extents of the red box as drawn

Fixes #34546 
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
