### PR TITLE
SANS: Remove Log Binning for 2D Reductions

### DIFF
--- a/Testing/SystemTests/tests/framework/ISIS/SANS/SANS2D/SANS2DReductionGUI.py
+++ b/Testing/SystemTests/tests/framework/ISIS/SANS/SANS2D/SANS2DReductionGUI.py
@@ -147,7 +147,7 @@ class SANS2DGUIBatchReduction(SANS2DMinimalBatchReduction):
         i.ReductionSingleton().user_settings.readLimitValues('L/R '+'41 '+'-1 '+'1', i.ReductionSingleton())
         i.LimitsWav(1.5,12.5,0.125,'LIN')
         i.ReductionSingleton().user_settings.readLimitValues('L/Q .001,.001,.0126,-.08,.2', i.ReductionSingleton())
-        i.LimitsQXY(0.0,0.05,0.001,'LIN')
+        i.LimitsQXY(0.0,0.05,0.001)
         i.SetPhiLimit(-90.0,90.0, True)
         i.SetDetectorFloodFile('','REAR')
         i.SetDetectorFloodFile('','FRONT')

--- a/dev-docs/source/ISISSANSReductionBackend.rst
+++ b/dev-docs/source/ISISSANSReductionBackend.rst
@@ -593,7 +593,6 @@ q_max                            Max momentum transfer value for 1D reduction  *
 q_1d_rebin_string                Rebin string for Q1D                          *StringParameter*                             N,                              if 1D  N         -
 q_xy_max                         Max momentum transfer value for 2D reduction  *PositiveFloatParameter*                      N,                              if 2D  N         -
 q_xy_step                        Momentum transfer step for 2D reduction       *PositiveFloatParameter*                      N,                              if 2D  N         -
-q_xy_step_type                   The step type, i.e. lin or log                *Enum(RangeStepType)*                         N,                              if 2D  N         -
 use_q_resolution                 If should perform a q resolution calculation  *BoolParameter*                               Y                               N                False
 q_resolution_collimation_length  Collimation length                            *PositiveFloatParameter*                      N, if performing q resolution   N                -
 q_resolution_delta_r             Virtual ring width on the detector            *PositiveFloatParameter*                      N, if performing q resolution   N                -

--- a/docs/source/release/v6.6.0/SANS/Bugfixes/34572.rst
+++ b/docs/source/release/v6.6.0/SANS/Bugfixes/34572.rst
@@ -1,0 +1,1 @@
+- The invalid Log binning option for 2D reductions has been removed. Loading a ``TOML`` user file with this value set will now give a warning.

--- a/scripts/Interface/ui/sans_isis/sans_data_processor_gui.py
+++ b/scripts/Interface/ui/sans_isis/sans_data_processor_gui.py
@@ -341,10 +341,6 @@ class SANSDataProcessorGui(QMainWindow,
             self._on_q_1d_step_type_has_changed)
         self._on_q_1d_step_type_has_changed()
 
-        self.q_xy_step_type_combo_box.currentIndexChanged.connect(
-            self._on_q_xy_step_type_has_changed)
-        self._on_q_xy_step_type_has_changed()
-
         # Set the q resolution aperture shape settings
         self.q_resolution_shape_combo_box.currentIndexChanged.connect(
             self._on_q_resolution_shape_has_changed)
@@ -799,11 +795,6 @@ class SANSDataProcessorGui(QMainWindow,
 
             step_label = u'dQ/Q' if u'Log' in selection else u'Step [\u00c5^-1]'
             self.q_step_label.setText(step_label)
-
-    def _on_q_xy_step_type_has_changed(self):
-        selection = self.q_xy_step_type_combo_box.currentText()
-        step_label = u'dQ/Q' if u'Log' in selection else u'Step [\u00c5^-1]'
-        self.q_xy_step_label.setText(step_label)
 
     def set_q_resolution_shape_to_rectangular(self, is_rectangular):
         index = 1 if is_rectangular else 0
@@ -1716,29 +1707,6 @@ class SANSDataProcessorGui(QMainWindow,
     def q_xy_step(self, value):
         self.update_simple_line_edit_field(line_edit="q_xy_step_line_edit", value=value)
 
-    @property
-    def q_xy_step_type(self):
-        q_xy_step_type_as_string = self.q_xy_step_type_combo_box.currentText()
-        try:
-            return RangeStepType(q_xy_step_type_as_string)
-        except ValueError:
-            return None
-
-    @q_xy_step_type.setter
-    def q_xy_step_type(self, value):
-        if value is None:
-            # Set to the default
-            self.q_xy_step_type_combo_box.setCurrentIndex(0)
-        else:
-            self.update_gui_combo_box(value=value, expected_type=RangeStepType,
-                                      combo_box="q_xy_step_type_combo_box")
-
-            if isinstance(value, list):
-                gui_element = self.q_xy_step_type_combo_box
-                gui_element.clear()
-                for element in value:
-                    self._add_list_element_to_combo_box(gui_element=gui_element, element=element)
-
     # ------------------------------------------------------------------------------------------------------------------
     # Gravity
     # ------------------------------------------------------------------------------------------------------------------
@@ -2097,7 +2065,6 @@ class SANSDataProcessorGui(QMainWindow,
 
         self.q_xy_max_line_edit.setText("")
         self.q_xy_step_line_edit.setText("")
-        self.q_xy_step_type_combo_box.setCurrentIndex(0)
 
         self.gravity_group_box.setChecked(False)
         self.gravity_extra_length_line_edit.setText("")

--- a/scripts/Interface/ui/sans_isis/sans_data_processor_window.ui
+++ b/scripts/Interface/ui/sans_isis/sans_data_processor_window.ui
@@ -95,7 +95,7 @@ QGroupBox::title {
       <item>
        <widget class="QStackedWidget" name="main_stacked_widget">
         <property name="currentIndex">
-         <number>0</number>
+         <number>1</number>
         </property>
         <widget class="QWidget" name="run_page">
          <layout class="QVBoxLayout" name="verticalLayout_3">
@@ -648,7 +648,7 @@ QGroupBox::title {
           <item>
            <widget class="QTabWidget" name="settings_tab_widget">
             <property name="currentIndex">
-             <number>0</number>
+             <number>3</number>
             </property>
             <widget class="QWidget" name="general_tab">
              <attribute name="title">
@@ -1836,7 +1836,7 @@ QGroupBox::title {
                      <number>0</number>
                     </property>
                     <property name="currentIndex">
-                     <number>0</number>
+                     <number>1</number>
                     </property>
                     <widget class="QWidget" name="page">
                      <layout class="QGridLayout" name="gridLayout_3">
@@ -2016,13 +2016,6 @@ QGroupBox::title {
                    <widget class="QLabel" name="q_step_label">
                     <property name="text">
                      <string>Step [Å^-1]</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="3" column="5">
-                   <widget class="QComboBox" name="q_xy_step_type_combo_box">
-                    <property name="toolTip">
-                     <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The step type of the momentum transfer for a 2D reduction.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                     </property>
                    </widget>
                   </item>
@@ -2392,7 +2385,6 @@ QGroupBox::title {
   <tabstop>q_1d_step_type_combo_box</tabstop>
   <tabstop>q_xy_max_line_edit</tabstop>
   <tabstop>q_xy_step_line_edit</tabstop>
-  <tabstop>q_xy_step_type_combo_box</tabstop>
   <tabstop>gravity_group_box</tabstop>
   <tabstop>gravity_extra_length_line_edit</tabstop>
   <tabstop>q_resolution_group_box</tabstop>

--- a/scripts/SANS/ISISCommandInterface.py
+++ b/scripts/SANS/ISISCommandInterface.py
@@ -981,20 +981,19 @@ def LimitsWav(lmin, lmax, step, bin_type):
     ReductionSingleton().to_wavelen.set_rebin(lmin, bin_sym + str(step), lmax)
 
 
-def LimitsQXY(qmin, qmax, step, type):
+def LimitsQXY(qmin, qmax, step):
     """
         To set the bin parameters for the algorithm Qxy()
         @param qmin: the first Q value to include
         @param qmaz: the last Q value to include
         @param step: bin width
-        @param type: pass LOG for logarithmic binning
     """
-    _printMessage('LimitsQXY(' + str(qmin) + ', ' + str(qmax) + ', ' + str(step) + ', ' + str(type) + ')')
+    _printMessage('LimitsQXY(' + str(qmin) + ', ' + str(qmax) + ', ' + str(step) + ')')
     settings = ReductionSingleton().user_settings
     if settings is None:
         raise RuntimeError('MaskFile() first')
 
-    settings.readLimitValues('L/QXY ' + str(qmin) + ' ' + str(qmax) + ' ' + str(step) + '/' + type,
+    settings.readLimitValues('L/QXY ' + str(qmin) + ' ' + str(qmax) + ' ' + str(step),
                              ReductionSingleton())
 
 

--- a/scripts/SANS/sans/algorithm_detail/convert_to_q.py
+++ b/scripts/SANS/sans/algorithm_detail/convert_to_q.py
@@ -8,7 +8,7 @@
 from math import sqrt
 
 from sans.common.constants import EMPTY_NAME
-from sans.common.enums import (ReductionDimensionality, RangeStepType)
+from sans.common.enums import (ReductionDimensionality)
 from sans.common.general_functions import (create_unmanaged_algorithm, append_to_sans_file_tag)
 
 
@@ -109,7 +109,6 @@ def _run_q_2d(workspace, output_summed_parts, state_convert_to_q,
 
     # Extract relevant settings
     max_q_xy = state_convert_to_q.q_xy_max
-    log_binning = True if state_convert_to_q.q_xy_step_type is RangeStepType.LOG else False
     delta_q = state_convert_to_q.q_xy_step
     radius_cutoff = state_convert_to_q.radius_cutoff / 1000.  # Qxy expects the radius cutoff to be in mm
     wavelength_cutoff = state_convert_to_q.wavelength_cutoff
@@ -121,7 +120,7 @@ def _run_q_2d(workspace, output_summed_parts, state_convert_to_q,
                    "OutputWorkspace": EMPTY_NAME,
                    "MaxQxy": max_q_xy,
                    "DeltaQ": delta_q,
-                   "IQxQyLogBinning": log_binning,
+                   "IQxQyLogBinning": False,  # Log binning disabled for 2D reductions.
                    "AccountForGravity": use_gravity,
                    "RadiusCut": radius_cutoff,
                    "WaveCut": wavelength_cutoff,

--- a/scripts/SANS/sans/command_interface/ISISCommandInterface.py
+++ b/scripts/SANS/sans/command_interface/ISISCommandInterface.py
@@ -617,25 +617,19 @@ def LimitsWav(lmin, lmax, step, bin_type):
     director.add_command(wavelength_command)
 
 
-def LimitsQXY(qmin, qmax, step, type):
+def LimitsQXY(qmin, qmax, step):
     """
         To set the bin parameters for the algorithm Qxy()
         @param qmin: the first Q value to include
         @param qmaz: the last Q value to include
         @param step: bin width
-        @param type: pass LOG for logarithmic binning
     """
     qmin = float(qmin)
     qmax = float(qmax)
     step = float(step)
 
-    print_message('LimitsQXY(' + str(qmin) + ', ' + str(qmax) + ', ' + str(step) + ', ' + str(type) + ')')
-    step_type_string = type.strip().upper()
-    if step_type_string == "LOGARITHMIC" or step_type_string == "LOG":
-        step_type = RangeStepType.LOG
-    else:
-        step_type = RangeStepType.LIN
-    qxy_command = NParameterCommand(command_id=NParameterCommandId.QXY_LIMIT, values=[qmin, qmax, step, step_type])
+    print_message('LimitsQXY(' + str(qmin) + ', ' + str(qmax) + ', ' + str(step) + ')')
+    qxy_command = NParameterCommand(command_id=NParameterCommandId.QXY_LIMIT, values=[qmin, qmax, step])
     director.add_command(qxy_command)
 
 

--- a/scripts/SANS/sans/command_interface/command_interface_state_director.py
+++ b/scripts/SANS/sans/command_interface/command_interface_state_director.py
@@ -11,7 +11,7 @@ from sans.state.AllStates import AllStates
 from sans.state.StateObjects.StateData import get_data_builder
 from sans.user_file.settings_tags import (MonId, monitor_spectrum, OtherId, SampleId, GravityId, SetId, position_entry,
                                           fit_general, FitId, monitor_file, mask_angle_entry, LimitsId, range_entry,
-                                          simple_range, DetectorId, event_binning_string_values, det_fit_range,
+                                          simple_range, q_xy_range, DetectorId, event_binning_string_values, det_fit_range,
                                           single_entry_with_detector)
 from sans.user_file.toml_parsers.toml_parser import TomlParser
 from sans.user_file.txt_parsers.CommandInterfaceAdapter import CommandInterfaceAdapter
@@ -600,8 +600,7 @@ class CommandInterfaceStateDirector(object):
         q_min = command.values[0]
         q_max = command.values[1]
         q_step = command.values[2]
-        q_step_type = command.values[3]
-        new_state_entries = {LimitsId.QXY: simple_range(start=q_min, stop=q_max, step=q_step, step_type=q_step_type)}
+        new_state_entries = {LimitsId.QXY: q_xy_range(start=q_min, stop=q_max, step=q_step)}
         self.add_to_processed_state_settings(new_state_entries)
 
     def _process_compatibility_mode(self, command):

--- a/scripts/SANS/sans/gui_logic/models/state_gui_model.py
+++ b/scripts/SANS/sans/gui_logic/models/state_gui_model.py
@@ -519,15 +519,6 @@ class StateGuiModel(ModelCommon):
         self._all_states.convert_to_q.q_xy_step = value
 
     @property
-    def q_xy_step_type(self):
-        # Can return None
-        return self._all_states.convert_to_q.q_xy_step_type
-
-    @q_xy_step_type.setter
-    def q_xy_step_type(self, value):
-        self._all_states.convert_to_q.q_xy_step_type = value
-
-    @property
     def r_cut(self):
         val = self._all_states.convert_to_q.radius_cutoff
         return meter_2_millimeter(self._get_val_or_default(val, 0))

--- a/scripts/SANS/sans/gui_logic/presenter/run_tab_presenter.py
+++ b/scripts/SANS/sans/gui_logic/presenter/run_tab_presenter.py
@@ -282,8 +282,6 @@ class RunTabPresenter(PresenterCommon):
         # Set the q range
         self._view.q_1d_step_type = [RangeStepType.LIN.value,
                                      RangeStepType.LOG.value]
-        self._view.q_xy_step_type = [RangeStepType.LIN.value,
-                                     RangeStepType.LOG.value]
 
     def _handle_output_directory_changed(self, new_directory):
         """
@@ -991,7 +989,6 @@ class RunTabPresenter(PresenterCommon):
         self._set_on_view_q_rebin_string()
         self._set_on_view("q_xy_max")
         self._set_on_view("q_xy_step")
-        self._set_on_view("q_xy_step_type")
 
         self._set_on_view("gravity_on_off")
         self._set_on_view("gravity_extra_length")
@@ -1105,7 +1102,6 @@ class RunTabPresenter(PresenterCommon):
             self._set_on_state_model_q_1d_rebin_string(state_model)
             self._set_on_custom_model("q_xy_max", state_model)
             self._set_on_custom_model("q_xy_step", state_model)
-            self._set_on_custom_model("q_xy_step_type", state_model)
 
             self._set_on_custom_model("gravity_on_off", state_model)
             self._set_on_custom_model("gravity_extra_length", state_model)

--- a/scripts/SANS/sans/state/StateObjects/StateConvertToQ.py
+++ b/scripts/SANS/sans/state/StateObjects/StateConvertToQ.py
@@ -12,7 +12,7 @@ import json
 import copy
 
 from sans.state.JsonSerializable import JsonSerializable
-from sans.common.enums import (ReductionDimensionality, RangeStepType, SANSFacility)
+from sans.common.enums import (ReductionDimensionality, SANSFacility)
 from sans.state.automatic_setters import automatic_setters
 from sans.state.state_functions import (is_pure_none_or_not_none, is_not_none_and_first_larger_than_second,
                                         validation_message)
@@ -40,7 +40,6 @@ class StateConvertToQ(metaclass=JsonSerializable):
         # 2D settings
         self.q_xy_max = None  # : Float (Positive)
         self.q_xy_step = None  # : Float (Positive)
-        self.q_xy_step_type: RangeStepType = None
 
         # -----------------------
         # Q Resolution specific
@@ -165,9 +164,6 @@ class StateConvertToQBuilder(object):
 
     def set_reduction_dimensionality(self, val):
         self.state.reduction_dimensionality = val
-
-    def set_q_xy_step_type(self, val):
-        self.state.q_xy_step_type = val
 
 
 # ------------------------------------------

--- a/scripts/SANS/sans/user_file/settings_tags.py
+++ b/scripts/SANS/sans/user_file/settings_tags.py
@@ -22,6 +22,7 @@ back_single_monitor_entry = namedtuple('back_single_monitor_entry', 'monitor, st
 # Limits
 mask_angle_entry = namedtuple('mask_angle_entry', 'min, max, use_mirror')
 simple_range = namedtuple('simple_range', 'start, stop, step, step_type')
+q_xy_range = namedtuple('q_xy_range', 'start, stop, step')
 complex_range = namedtuple('complex_steps', 'start, step1, mid, step2, stop, step_type1, step_type2')
 rebin_string_values = namedtuple('rebin_string_values', 'value')
 event_binning_string_values = namedtuple('event_binning_string_values', 'value')

--- a/scripts/SANS/sans/user_file/toml_parsers/toml_v1_parser.py
+++ b/scripts/SANS/sans/user_file/toml_parsers/toml_v1_parser.py
@@ -238,8 +238,8 @@ class _TomlV1ParserImpl(TomlParserImplBase):
         self.convert_to_q.q_xy_max = self.get_val(["2d_reduction", "stop"], binning_dict)
         self.convert_to_q.q_xy_step = self.get_val(["2d_reduction", "step"], binning_dict)
         two_d_step_type = self.get_val(["2d_reduction", "type"], binning_dict)
-        if two_d_step_type:
-            self.convert_to_q.q_xy_step_type = RangeStepType(two_d_step_type)
+        if two_d_step_type == RangeStepType.LOG.value:
+            raise ValueError("Log binning is not supported for 2D reductions. The type must be set to \"Lin\".")
 
         # We could previous interpolate. This is now obsolete, see the docs for details
         self.calculate_transmission.rebin_type = RebinType.REBIN

--- a/scripts/SANS/sans/user_file/toml_parsers/toml_v1_parser.py
+++ b/scripts/SANS/sans/user_file/toml_parsers/toml_v1_parser.py
@@ -238,7 +238,7 @@ class _TomlV1ParserImpl(TomlParserImplBase):
         self.convert_to_q.q_xy_max = self.get_val(["2d_reduction", "stop"], binning_dict)
         self.convert_to_q.q_xy_step = self.get_val(["2d_reduction", "step"], binning_dict)
         two_d_step_type = self.get_val(["2d_reduction", "type"], binning_dict)
-        if two_d_step_type != RangeStepType.LIN.value:
+        if two_d_step_type and two_d_step_type != RangeStepType.LIN.value:
             raise ValueError(
                 f"{two_d_step_type} binning is not supported for 2D reductions. The type must be set to \"Lin\".")
 

--- a/scripts/SANS/sans/user_file/toml_parsers/toml_v1_parser.py
+++ b/scripts/SANS/sans/user_file/toml_parsers/toml_v1_parser.py
@@ -238,8 +238,9 @@ class _TomlV1ParserImpl(TomlParserImplBase):
         self.convert_to_q.q_xy_max = self.get_val(["2d_reduction", "stop"], binning_dict)
         self.convert_to_q.q_xy_step = self.get_val(["2d_reduction", "step"], binning_dict)
         two_d_step_type = self.get_val(["2d_reduction", "type"], binning_dict)
-        if two_d_step_type == RangeStepType.LOG.value:
-            raise ValueError("Log binning is not supported for 2D reductions. The type must be set to \"Lin\".")
+        if two_d_step_type != RangeStepType.LIN.value:
+            raise ValueError(
+                f"{two_d_step_type} binning is not supported for 2D reductions. The type must be set to \"Lin\".")
 
         # We could previous interpolate. This is now obsolete, see the docs for details
         self.calculate_transmission.rebin_type = RebinType.REBIN

--- a/scripts/SANS/sans/user_file/txt_parsers/ParsedDictConverter.py
+++ b/scripts/SANS/sans/user_file/txt_parsers/ParsedDictConverter.py
@@ -245,7 +245,6 @@ class ParsedDictConverter(IStateParser):
                 raise RuntimeError("Qxy cannot handle settings of type: L/Q l1,dl1,l3,dl2,l2 [/LIN|/LOG] ")
             else:
                 state.q_xy_step = limits_qxy.step
-                state.q_xy_step_type = limits_qxy.step_type
 
         # Get the Gravity settings
         self._set_single_entry(state, "use_gravity", GravityId.ON_OFF)

--- a/scripts/test/SANS/SansIsisGuiSettings.py
+++ b/scripts/test/SANS/SansIsisGuiSettings.py
@@ -93,7 +93,7 @@ class Sans2DIsisGuiSettings(unittest.TestCase):
 
     def test_qy(self):  # qy_max, qy_dqy, qy_dqy_opt
         value_max, value_step = 0.06, 0.002
-        i.LimitsQXY(0.0, value_max, value_step, 'LIN')
+        i.LimitsQXY(0.0, value_max, value_step)
         self.checkFloat(i.ReductionSingleton().QXY2, value_max)
         self.checkFloat(i.ReductionSingleton().DQXY, value_step)
 

--- a/scripts/test/SANS/algorithm_detail/convert_to_q_test.py
+++ b/scripts/test/SANS/algorithm_detail/convert_to_q_test.py
@@ -37,7 +37,7 @@ class ConvertToQTest(unittest.TestCase):
 
     @staticmethod
     def _get_sample_state(q_min=1., q_max=2., q_step=0.1, q_step_type=RangeStepType.LIN,
-                          q_xy_max=None, q_xy_step=None, q_xy_step_type=None,
+                          q_xy_max=None, q_xy_step=None,
                           use_gravity=False, dim=ReductionDimensionality.ONE_DIM):
         facility = SANSFacility.ISIS
         file_information = SANSFileInformationMock(instrument=SANSInstrument.LOQ, run_number=74044)
@@ -60,8 +60,6 @@ class ConvertToQTest(unittest.TestCase):
             convert_to_q_builder.set_q_xy_max(q_xy_max)
         if q_xy_step is not None:
             convert_to_q_builder.set_q_xy_step(q_xy_step)
-        if q_xy_step_type is not None:
-            convert_to_q_builder.set_q_xy_step_type(q_xy_step_type)
 
         convert_to_q_state = convert_to_q_builder.build()
 
@@ -106,7 +104,7 @@ class ConvertToQTest(unittest.TestCase):
         workspace = self._get_workspace(is_adjustment=False)
         adj_workspace = self._get_workspace(is_adjustment=True)
 
-        state = self._get_sample_state(q_xy_max=2., q_xy_step=0.5, q_xy_step_type=RangeStepType.LIN,
+        state = self._get_sample_state(q_xy_max=2., q_xy_step=0.5,
                                        dim=ReductionDimensionality.TWO_DIM)
 
         output_dict = convert_workspace(workspace=workspace, output_summed_parts=True,

--- a/scripts/test/SANS/command_interface/command_interface_state_director_test.py
+++ b/scripts/test/SANS/command_interface/command_interface_state_director_test.py
@@ -111,7 +111,7 @@ class CommandInterfaceStateDirectorTest(unittest.TestCase):
 
         # QXY Limits
         command = NParameterCommand(command_id=NParameterCommandId.QXY_LIMIT,
-                                    values=[1.23, 23., 1.1, RangeStepType.LIN])
+                                    values=[1.23, 23., 1.1])
         self._assert_raises_nothing(command_interface.add_command, command)
 
         # Process all commands
@@ -183,7 +183,6 @@ class CommandInterfaceStateDirectorTest(unittest.TestCase):
         self.assertEqual(state.adjustment.calculate_transmission.wavelength_step_type, RangeStepType.LIN)
         self.assertEqual(state.convert_to_q.q_xy_max,  23.)
         self.assertEqual(state.convert_to_q.q_xy_step,  1.1)
-        self.assertEqual(state.convert_to_q.q_xy_step_type, RangeStepType.LIN)
 
     def test_that_can_remove_last_command(self):
         # Arrange

--- a/scripts/test/SANS/gui_logic/state_gui_model_test.py
+++ b/scripts/test/SANS/gui_logic/state_gui_model_test.py
@@ -403,7 +403,6 @@ class StateGuiModelTest(unittest.TestCase):
 
         self.assertEqual(state_gui_model.q_xy_max, "")
         self.assertEqual(state_gui_model.q_xy_step, "")
-        self.assertEqual(state_gui_model.q_xy_step_type, None)
         self.assertEqual(state_gui_model.r_cut, 0.0)
         self.assertEqual(state_gui_model.w_cut, 0.0)
 

--- a/scripts/test/SANS/gui_logic/state_gui_model_test.py
+++ b/scripts/test/SANS/gui_logic/state_gui_model_test.py
@@ -411,14 +411,12 @@ class StateGuiModelTest(unittest.TestCase):
         state_gui_model.q_1d_rebin_string = "test"
         state_gui_model.q_xy_max = 1.
         state_gui_model.q_xy_step = 122.
-        state_gui_model.q_xy_step_type = RangeStepType.LOG
         state_gui_model.r_cut = 45.
         state_gui_model.w_cut = 890.
 
         self.assertEqual(state_gui_model.q_1d_rebin_string, "test")
         self.assertEqual(state_gui_model.q_xy_max, 1.)
         self.assertEqual(state_gui_model.q_xy_step, 122.)
-        self.assertEqual(state_gui_model.q_xy_step_type, RangeStepType.LOG)
         self.assertEqual(state_gui_model.r_cut, 45.)
         self.assertEqual(state_gui_model.w_cut, 890.)
 

--- a/scripts/test/SANS/state/convert_to_q_test.py
+++ b/scripts/test/SANS/state/convert_to_q_test.py
@@ -23,7 +23,7 @@ class StateConvertToQTest(unittest.TestCase):
                            "gravity_extra_length": 12., "radius_cutoff": 1.5, "wavelength_cutoff": 2.7,
                            "q_min": 0.5, "q_max": 1., "q_1d_rebin_string": "0.5,0.2,1.",
                            "q_step2": 1., "q_step_type2": RangeStepType.LIN, "q_mid": 1.,
-                           "q_xy_max": 1.4, "q_xy_step": 24.5, "q_xy_step_type": RangeStepType.LIN,
+                           "q_xy_max": 1.4, "q_xy_step": 24.5,
                            "use_q_resolution": True, "q_resolution_collimation_length": 12.,
                            "q_resolution_delta_r": 12., "moderator_file": "test.txt", "q_resolution_a1": 1.,
                            "q_resolution_a2": 2., "q_resolution_h1": 1., "q_resolution_h2": 2., "q_resolution_w1": 1.,

--- a/scripts/test/SANS/user_file/toml_parsers/toml_v1_parser_test.py
+++ b/scripts/test/SANS/user_file/toml_parsers/toml_v1_parser_test.py
@@ -179,6 +179,28 @@ class TomlV1ParserTest(unittest.TestCase):
         self.assertEqual(1.0, two_d_convert_to_q.q_xy_step)
         self.assertTrue(results.get_state_calculate_transmission().rebin_type is RebinType.REBIN)
 
+    def test_binning_commands_ignores_log(self):
+        # Wavelength
+        for bin_type in ["Lin", "Log"]:
+            wavelength_dict = {"binning": {"wavelength": {"start": 1.1, "step": 0.1, "stop": 2.2, "type": bin_type}}}
+            wavelength = self._setup_parser(wavelength_dict).get_state_wavelength()
+            self.assertEqual((1.1, 2.2), wavelength.wavelength_interval.wavelength_full_range)
+            self.assertEqual(0.1, wavelength.wavelength_interval.wavelength_step)
+            self.assertEqual(RangeStepType(bin_type), wavelength.wavelength_step_type)
+
+        one_d_reduction_q_dict = {"binning": {"1d_reduction": {"binning": "1.0, 0.1, 2.0, -0.2, 3.0",
+                                                               "radius_cut": 12.3,
+                                                               "wavelength_cut": 23.4}}}
+        one_d_convert_to_q = self._setup_parser(one_d_reduction_q_dict).get_state_convert_to_q()
+        self.assertEqual(1.0, one_d_convert_to_q.q_min)
+        self.assertEqual(3.0, one_d_convert_to_q.q_max)
+        self.assertEqual("1.0, 0.1, 2.0, -0.2, 3.0", one_d_convert_to_q.q_1d_rebin_string.strip())
+        self.assertEqual(12.3, one_d_convert_to_q.radius_cutoff)
+        self.assertEqual(23.4, one_d_convert_to_q.wavelength_cutoff)
+
+        two_d_reduction_q_dict = {"binning": {"2d_reduction": {"step": 1.0, "stop": 5.0, "type": "Log"}}}
+        self.assertRaises(ValueError, self._setup_parser, two_d_reduction_q_dict)
+
     def test_reduction_commands_parsed(self):
         top_level_dict = {"reduction": {"merged": {},
                                         "events": {}}}

--- a/scripts/test/SANS/user_file/toml_parsers/toml_v1_parser_test.py
+++ b/scripts/test/SANS/user_file/toml_parsers/toml_v1_parser_test.py
@@ -177,7 +177,6 @@ class TomlV1ParserTest(unittest.TestCase):
         two_d_convert_to_q = results.get_state_convert_to_q()
         self.assertEqual(5.0, two_d_convert_to_q.q_xy_max)
         self.assertEqual(1.0, two_d_convert_to_q.q_xy_step)
-        self.assertTrue(two_d_convert_to_q.q_xy_step_type is RangeStepType.LIN)
         self.assertTrue(results.get_state_calculate_transmission().rebin_type is RebinType.REBIN)
 
     def test_reduction_commands_parsed(self):


### PR DESCRIPTION
**Description of work.**
Log binning doesn't make sense for these reductions as they have to start from 0. Remove it and show a warning if a user happens to load a TOML user file containing the invalid setup. 

**To test:**
1. Make sure you have the Training Course Data
2. Go into the `maskfile.toml` in the `loqdemo` and save a copy with the `[binning.2d_reduction]` `type` set to `"Log"`.
3. Boot the ISIS SANS GUI
4. Load the user file you just made
5. You should get a warning with a useful message in the details. 
6. Change the `type` back to `"Lin"`.
7. Load the file again. It should load cleanly and correctly set the values on the GUI (Settings -> Q, Wavelength, Detector Limits). 
8. There should not be a way to change the step type for Qxy present on the GUI. 

Fixes #34572 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
