### PR TITLE
Reduce dependency on MatrixWorkspace in DiscusMultipleScatteringCorrection

### DIFF
--- a/Framework/Algorithms/inc/MantidAlgorithms/DiscusMultipleScatteringCorrection.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/DiscusMultipleScatteringCorrection.h
@@ -36,6 +36,8 @@ struct DiscusData1D {
   // separate vectors of X and Y rather than vector of pairs to mirror Histogram class and support edges\points
   std::vector<double> X;
   std::vector<double> Y;
+  DiscusData1D(){};
+  DiscusData1D(std::vector<double> X, std::vector<double> Y) : X(std::move(X)), Y(std::move(Y)) {}
 };
 
 class DiscusData2D {
@@ -43,7 +45,7 @@ public:
   DiscusData2D() : m_data(std::vector<DiscusData1D>{}), m_specAxis(nullptr){};
   DiscusData2D(const std::vector<DiscusData1D> &data, const std::shared_ptr<std::vector<double>> &specAxis)
       : m_data(data), m_specAxis(specAxis){};
-  std::unique_ptr<DiscusData2D> CreateCopy(bool clearY = false);
+  std::unique_ptr<DiscusData2D> createCopy(bool clearY = false);
   size_t getNumberHistograms() { return m_data.size(); }
   DiscusData1D &histogram(const size_t i) { return m_data[i]; }
   std::vector<DiscusData1D> &histograms() { return m_data; }
@@ -154,7 +156,7 @@ private:
   double getQSQIntegral(const DiscusData1D &QSQScaleFactor, double k);
   const ComponentWorkspaceMapping *findMatchingComponent(const ComponentWorkspaceMappings &componentWorkspaces,
                                                          const Geometry::IObject *shapeObjectWithScatter);
-  void AddWorkspaceToDiscus2DData(const Geometry::IObject_const_sptr &shape, const std::string_view &matName,
+  void addWorkspaceToDiscus2DData(const Geometry::IObject_const_sptr &shape, const std::string_view &matName,
                                   API::MatrixWorkspace_sptr ws);
   long long m_callsToInterceptSurface{0};
   long long m_IkCalculations{0};

--- a/Framework/Algorithms/inc/MantidAlgorithms/DiscusMultipleScatteringCorrection.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/DiscusMultipleScatteringCorrection.h
@@ -45,7 +45,7 @@ public:
       : m_data(data), m_specAxis(specAxis){};
   std::unique_ptr<DiscusData2D> CreateCopy(bool clearY = false);
   size_t getNumberHistograms() { return m_data.size(); }
-  DiscusData1D &histogram(int i) { return m_data[i]; }
+  DiscusData1D &histogram(const size_t i) { return m_data[i]; }
   std::vector<DiscusData1D> &histograms() { return m_data; }
   const std::vector<double> &getSpecAxisValues();
 
@@ -155,7 +155,7 @@ private:
   const ComponentWorkspaceMapping *findMatchingComponent(const ComponentWorkspaceMappings &componentWorkspaces,
                                                          const Geometry::IObject *shapeObjectWithScatter);
   void AddWorkspaceToDiscus2DData(const Geometry::IObject_const_sptr &shape, const std::string_view &matName,
-                                  API::MatrixWorkspace_sptr &ws);
+                                  API::MatrixWorkspace_sptr ws);
   long long m_callsToInterceptSurface{0};
   long long m_IkCalculations{0};
   std::map<int, int> m_attemptsToGenerateInitialTrack;

--- a/Framework/Algorithms/inc/MantidAlgorithms/DiscusMultipleScatteringCorrection.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/DiscusMultipleScatteringCorrection.h
@@ -29,14 +29,40 @@ class Instrument;
 
 namespace Algorithms {
 
+// define some simple classes to store 2D datasets instead of using MatrixWorkspace internally
+// This couples the algorithm more loosely to Mantid and avoids some complexity in choosing whether
+// to call readX, dataX etc
+struct DiscusData1D {
+  // separate vectors of X and Y rather than vector of pairs to mirror Histogram class and support edges\points
+  std::vector<double> X;
+  std::vector<double> Y;
+};
+
+class DiscusData2D {
+public:
+  DiscusData2D() : m_data(std::vector<DiscusData1D>{}), m_specAxis(nullptr){};
+  DiscusData2D(const std::vector<DiscusData1D> &data, const std::shared_ptr<std::vector<double>> &specAxis)
+      : m_data(data), m_specAxis(specAxis){};
+  std::unique_ptr<DiscusData2D> CreateCopy(bool clearY = false);
+  size_t getNumberHistograms() { return m_data.size(); }
+  DiscusData1D &histogram(int i) { return m_data[i]; }
+  std::vector<DiscusData1D> &histograms() { return m_data; }
+  const std::vector<double> &getSpecAxisValues();
+
+private:
+  std::vector<DiscusData1D> m_data;
+  // optional spectrum axis
+  std::shared_ptr<std::vector<double>> m_specAxis;
+};
+
 struct ComponentWorkspaceMapping {
   Geometry::IObject_const_sptr ComponentPtr;
   std::string_view materialName;
-  API::MatrixWorkspace_sptr SQ;
-  API::MatrixWorkspace_sptr logSQ{};
-  std::shared_ptr<DataObjects::Histogram1D> QSQScaleFactor{};
-  API::MatrixWorkspace_sptr QSQ{};
-  API::MatrixWorkspace_sptr InvPOfQ{};
+  std::shared_ptr<DiscusData2D> SQ;
+  std::shared_ptr<DiscusData2D> logSQ{};
+  std::shared_ptr<DiscusData1D> QSQScaleFactor{};
+  std::shared_ptr<DiscusData2D> QSQ{};
+  std::shared_ptr<DiscusData2D> InvPOfQ{};
   std::shared_ptr<int> scatterCount = std::make_shared<int>(0);
 };
 
@@ -72,13 +98,13 @@ protected:
                                                                  const size_t nXPoints, const size_t rows,
                                                                  const size_t columns);
   virtual std::unique_ptr<InterpolationOption> createInterpolateOption();
-  double interpolateFlat(const API::ISpectrum &histToInterpolate, double x);
-  std::tuple<double, int> sampleQW(const API::MatrixWorkspace_sptr &CumulativeProb, double x);
-  double interpolateSquareRoot(const API::ISpectrum &histToInterpolate, double x);
-  double interpolateGaussian(const API::ISpectrum &histToInterpolate, double x);
+  double interpolateFlat(const DiscusData1D &histToInterpolate, double x);
+  std::tuple<double, int> sampleQW(const std::shared_ptr<DiscusData2D> &CumulativeProb, double x);
+  double interpolateSquareRoot(const DiscusData1D &histToInterpolate, double x);
+  double interpolateGaussian(const DiscusData1D &histToInterpolate, double x);
   double Interpolate2D(const ComponentWorkspaceMapping &SQWSMapping, double q, double w);
   void updateTrackDirection(Geometry::Track &track, const double cosT, const double phi);
-  void integrateCumulative(const API::ISpectrum &h, const double xmin, const double xmax, std::vector<double> &resultX,
+  void integrateCumulative(const DiscusData1D &h, const double xmin, const double xmax, std::vector<double> &resultX,
                            std::vector<double> &resultY, const bool returnCumulative);
   API::MatrixWorkspace_sptr integrateWS(const API::MatrixWorkspace_sptr &ws);
   void getXMinMax(const Mantid::API::MatrixWorkspace &ws, double &xmin, double &xmax) const;
@@ -111,7 +137,7 @@ private:
   void correctForWorkspaceNameClash(std::string &wsName);
   void setWorkspaceName(const API::MatrixWorkspace_sptr &ws, std::string wsName);
   void createInvPOfQWorkspaces(ComponentWorkspaceMappings &matWSs, size_t nhists);
-  void convertToLogWorkspace(const API::MatrixWorkspace_sptr &SOfQ);
+  void convertToLogWorkspace(const std::shared_ptr<DiscusData2D> &SOfQ);
   void calculateQSQIntegralAsFunctionOfK(ComponentWorkspaceMappings &matWSs, const std::vector<double> &specialKs);
   void prepareCumulativeProbForQ(double kinc, const ComponentWorkspaceMappings &PInvOfQs);
   void prepareQSQ(double kinc);
@@ -124,15 +150,17 @@ private:
   std::vector<std::tuple<double, int, double>> generateInputKOutputWList(const double efixed,
                                                                          const std::vector<double> &xPoints);
   std::tuple<std::vector<double>, std::vector<double>, std::vector<double>>
-  integrateQSQ(const API::MatrixWorkspace_sptr &QSQ, double kinc, const bool returnCumulative);
-  double getQSQIntegral(const API::ISpectrum &QSQScaleFactor, double k);
+  integrateQSQ(const std::shared_ptr<DiscusData2D> &QSQ, double kinc, const bool returnCumulative);
+  double getQSQIntegral(const DiscusData1D &QSQScaleFactor, double k);
   const ComponentWorkspaceMapping *findMatchingComponent(const ComponentWorkspaceMappings &componentWorkspaces,
                                                          const Geometry::IObject *shapeObjectWithScatter);
+  void AddWorkspaceToDiscus2DData(const Geometry::IObject_const_sptr &shape, const std::string_view &matName,
+                                  API::MatrixWorkspace_sptr &ws);
   long long m_callsToInterceptSurface{0};
   long long m_IkCalculations{0};
   std::map<int, int> m_attemptsToGenerateInitialTrack;
   int m_maxScatterPtAttempts{};
-  std::shared_ptr<const DataObjects::Histogram1D> m_sigmaSS; // scattering cross section as a function of k
+  std::shared_ptr<const DiscusData1D> m_sigmaSS; // scattering cross section as a function of k
   // vectors of S(Q,w) and derived quantities. One entry for sample and each environment component
   ComponentWorkspaceMappings m_SQWSs;
   Geometry::IObject_const_sptr m_sampleShape;

--- a/Framework/Algorithms/src/DiscusMultipleScatteringCorrection.cpp
+++ b/Framework/Algorithms/src/DiscusMultipleScatteringCorrection.cpp
@@ -75,6 +75,26 @@ private:
 
 namespace Mantid::Algorithms {
 
+std::unique_ptr<DiscusData2D> DiscusData2D::CreateCopy(bool clearY) {
+  auto data2DNew = std::make_unique<DiscusData2D>();
+  data2DNew->m_data.resize(m_data.size());
+  for (size_t i = 0; i < m_data.size(); i++) {
+    data2DNew->m_data[i].X = m_data[i].X;
+    if (clearY)
+      data2DNew->m_data[i].Y = std::vector<double>(m_data[i].Y.size(), 0.);
+    else
+      data2DNew->m_data[i].Y = m_data[i].Y;
+  }
+  data2DNew->m_specAxis = m_specAxis;
+  return data2DNew;
+}
+
+const std::vector<double> &DiscusData2D::getSpecAxisValues() {
+  if (!m_specAxis)
+    throw std::runtime_error("DiscusData2D::getSpecAxisValues - No spec axis has been defined.");
+  return *m_specAxis;
+}
+
 // Register the algorithm into the AlgorithmFactory
 DECLARE_ALGORITHM(DiscusMultipleScatteringCorrection)
 
@@ -362,56 +382,70 @@ void DiscusMultipleScatteringCorrection::prepareStructureFactors() {
   if (SQWSGroup) {
     std::string matName = m_sampleShape->material().name();
     auto SQWSGroupMember = std::static_pointer_cast<MatrixWorkspace>(SQWSGroup->getItem(matName));
-    m_SQWSs.push_back(ComponentWorkspaceMapping{m_sampleShape, matName, SQWSGroupMember});
+    AddWorkspaceToDiscus2DData(m_sampleShape, matName, SQWSGroupMember);
     if (nEnvComponents > 0) {
       matName = m_env->getContainer().material().name();
       SQWSGroupMember = std::static_pointer_cast<MatrixWorkspace>(SQWSGroup->getItem(matName));
-      m_SQWSs.push_back(ComponentWorkspaceMapping{m_env->getContainer().getShapePtr(), matName, SQWSGroupMember});
+      AddWorkspaceToDiscus2DData(m_env->getContainer().getShapePtr(), matName, SQWSGroupMember);
     }
     for (size_t i = 1; i < nEnvComponents; i++) {
       matName = m_env->getComponent(i).material().name();
       SQWSGroupMember = std::static_pointer_cast<MatrixWorkspace>(SQWSGroup->getItem(matName));
-      m_SQWSs.push_back(ComponentWorkspaceMapping{m_env->getComponentPtr(i), matName, SQWSGroupMember});
+      AddWorkspaceToDiscus2DData(m_env->getComponentPtr(i), matName, SQWSGroupMember);
     }
   } else {
-    m_SQWSs.push_back(ComponentWorkspaceMapping{m_sampleShape, m_sampleShape->material().name(),
-                                                std::dynamic_pointer_cast<MatrixWorkspace>(suppliedSQWS)});
+    AddWorkspaceToDiscus2DData(m_sampleShape, m_sampleShape->material().name(),
+                               std::dynamic_pointer_cast<MatrixWorkspace>(suppliedSQWS));
     MatrixWorkspace_sptr isotropicSQ = DataObjects::create<Workspace2D>(
-        *m_SQWSs[0].SQ, static_cast<size_t>(1),
+        *std::dynamic_pointer_cast<MatrixWorkspace>(suppliedSQWS), static_cast<size_t>(1),
         HistogramData::Histogram(HistogramData::Points{0.}, HistogramData::Frequencies{1.}));
     if (nEnvComponents > 0) {
       std::string_view matName = m_env->getContainer().material().name();
       g_log.information() << "Creating isotropic structure factor for " << matName << std::endl;
-      m_SQWSs.push_back(ComponentWorkspaceMapping{m_env->getContainer().getShapePtr(), matName, isotropicSQ});
+      AddWorkspaceToDiscus2DData(m_env->getContainer().getShapePtr(), matName, isotropicSQ);
     }
     for (size_t i = 1; i < nEnvComponents; i++) {
       std::string_view matName = m_env->getComponent(i).material().name();
       g_log.information() << "Creating isotropic structure factor for " << matName << std::endl;
-      m_SQWSs.push_back(ComponentWorkspaceMapping{m_env->getComponentPtr(i), matName, isotropicSQ});
+      AddWorkspaceToDiscus2DData(m_env->getComponentPtr(i), matName, isotropicSQ);
     }
   }
+}
 
+/**
+ * Function to convert between a Matrix workspace and the internal simplified 2D data structure. This decouples the
+ * internal calculation logic from the Mantid workspaces
+ */
+void DiscusMultipleScatteringCorrection::AddWorkspaceToDiscus2DData(const Geometry::IObject_const_sptr &shape,
+                                                                    const std::string_view &matName,
+                                                                    API::MatrixWorkspace_sptr &SQWS) {
   // avoid repeated conversion of bin edges to points inside loop by converting to point data
-  for (auto &SQWSMapping : m_SQWSs) {
-    auto &SQWS = SQWSMapping.SQ;
-    convertWsBothAxesToPoints(SQWS);
-    // if S(Q,w) has been supplied ensure Q is along the x axis of each spectrum (so same as S(Q))
-    if (SQWS->getAxis(1)->unit()->unitID() == "MomentumTransfer") {
-      auto transposeAlgorithm = this->createChildAlgorithm("Transpose");
-      transposeAlgorithm->initialize();
-      transposeAlgorithm->setProperty("InputWorkspace", SQWS);
-      transposeAlgorithm->setProperty("OutputWorkspace", "_");
-      transposeAlgorithm->execute();
-      SQWS = transposeAlgorithm->getProperty("OutputWorkspace");
-    } else if (SQWS->getAxis(1)->isSpectra()) {
-      // for elastic set w=0 on the spectrum axis to align code with inelastic
-      auto newAxis = std::make_unique<NumericAxis>(std::vector<double>{0.});
-      newAxis->setUnit("DeltaE");
-      SQWS->replaceAxis(1, std::move(newAxis));
-    }
-    SQWSMapping.logSQ = SQWSMapping.SQ->clone();
-    convertToLogWorkspace(SQWSMapping.logSQ);
+  convertWsBothAxesToPoints(SQWS);
+  // if S(Q,w) has been supplied ensure Q is along the x axis of each spectrum (so same as S(Q))
+  if (SQWS->getAxis(1)->unit()->unitID() == "MomentumTransfer") {
+    auto transposeAlgorithm = this->createChildAlgorithm("Transpose");
+    transposeAlgorithm->initialize();
+    transposeAlgorithm->setProperty("InputWorkspace", SQWS);
+    transposeAlgorithm->setProperty("OutputWorkspace", "_");
+    transposeAlgorithm->execute();
+    SQWS = transposeAlgorithm->getProperty("OutputWorkspace");
+  } else if (SQWS->getAxis(1)->isSpectra()) {
+    // for elastic set w=0 on the spectrum axis to align code with inelastic
+    auto newAxis = std::make_unique<NumericAxis>(std::vector<double>{0.});
+    newAxis->setUnit("DeltaE");
+    SQWS->replaceAxis(1, std::move(newAxis));
   }
+  auto specAxis = dynamic_cast<NumericAxis *>(SQWS->getAxis(1));
+  std::vector<DiscusData1D> data;
+  for (int i = 0; i < SQWS->getNumberHistograms(); i++) {
+    data.push_back(DiscusData1D{SQWS->histogram(i).dataX(), SQWS->histogram(i).dataY()});
+  }
+  ComponentWorkspaceMapping SQWSMapping{
+      shape, matName,
+      std::make_shared<DiscusData2D>(data, std::make_shared<std::vector<double>>(specAxis->getValues()))};
+  SQWSMapping.logSQ = SQWSMapping.SQ->CreateCopy();
+  convertToLogWorkspace(SQWSMapping.logSQ);
+  m_SQWSs.push_back(SQWSMapping);
 }
 
 /**
@@ -475,7 +509,8 @@ void DiscusMultipleScatteringCorrection::exec() {
 
   MatrixWorkspace_sptr sigmaSSWS = getProperty("ScatteringCrossSection");
   if (sigmaSSWS)
-    m_sigmaSS = std::make_shared<DataObjects::Histogram1D>(sigmaSSWS->getSpectrum(0));
+    m_sigmaSS = std::make_shared<DiscusData1D>(
+        DiscusData1D{sigmaSSWS->getSpectrum(0).readX(), sigmaSSWS->getSpectrum(0).readY()});
 
   // for inelastic we could calculate the qmax based on the min\max w in the S(Q,w) but that
   // would bake as assumption that S(Q,w)=0 beyond the limits of the supplied data
@@ -798,12 +833,12 @@ DiscusMultipleScatteringCorrection::generateInputKOutputWList(const double efixe
 void DiscusMultipleScatteringCorrection::prepareQSQ(double qmax) {
   for (auto &SQWSMapping : m_SQWSs) {
     auto &SQWS = SQWSMapping.SQ;
-    MatrixWorkspace_sptr outputWS = DataObjects::create<Workspace2D>(*SQWS);
+    std::shared_ptr<DiscusData2D> outputWS = SQWS->CreateCopy(true);
     std::vector<double> IOfQYFull;
     // loop through the S(Q) spectra for the different energy transfer values
     for (size_t iW = 0; iW < SQWS->getNumberHistograms(); iW++) {
-      std::vector<double> qValues = SQWS->histogram(iW).readX();
-      std::vector<double> SQValues = SQWS->histogram(iW).readY();
+      std::vector<double> qValues = SQWS->histogram(iW).X;
+      std::vector<double> SQValues = SQWS->histogram(iW).Y;
       // add terminating points at 0 and qmax before multiplying by Q so no extrapolation problems
       if (qValues.front() > 0.) {
         qValues.insert(qValues.begin(), 0.);
@@ -827,10 +862,10 @@ void DiscusMultipleScatteringCorrection::prepareQSQ(double qmax) {
       std::transform(SQValues.begin(), SQValues.end(), qValues.begin(), std::back_inserter(QSQValues),
                      std::multiplies<double>());
 
-      outputWS->dataX(iW).resize(qValues.size());
-      outputWS->dataX(iW) = qValues;
-      outputWS->dataY(iW).resize(QSQValues.size());
-      outputWS->dataY(iW) = QSQValues;
+      outputWS->histogram(iW).X.resize(qValues.size());
+      outputWS->histogram(iW).X = qValues;
+      outputWS->histogram(iW).Y.resize(QSQValues.size());
+      outputWS->histogram(iW).Y = QSQValues;
     }
     SQWSMapping.QSQ = outputWS;
   }
@@ -847,15 +882,12 @@ void DiscusMultipleScatteringCorrection::prepareQSQ(double qmax) {
  * variable, the w values corresponding to each value of the pseudo variable
  */
 std::tuple<std::vector<double>, std::vector<double>, std::vector<double>>
-DiscusMultipleScatteringCorrection::integrateQSQ(const API::MatrixWorkspace_sptr &QSQ, double kinc,
+DiscusMultipleScatteringCorrection::integrateQSQ(const std::shared_ptr<DiscusData2D> &QSQ, double kinc,
                                                  const bool returnCumulative) {
   std::vector<double> IOfQYFull, qValuesFull, wIndices;
   double IOfQMaxPreviousRow = 0.;
 
-  auto wAxis = dynamic_cast<NumericAxis *>(QSQ->getAxis(1));
-  if (!wAxis)
-    throw std::invalid_argument("Cannot calculate cumulative probability for S(Q,w) without a numeric w axis");
-  auto &wValues = wAxis->getValues();
+  auto &wValues = QSQ->getSpecAxisValues();
   std::vector<double> wWidths;
   if (wValues.size() == 1) {
     // convertToBinBoundary currently gives width of 1 for single point but because this is essential for the maths
@@ -882,11 +914,11 @@ DiscusMultipleScatteringCorrection::integrateQSQ(const API::MatrixWorkspace_sptr
   wIndices.reserve(nAccessibleWPoints);
   //}
   for (size_t iW = 0; iW < nAccessibleWPoints; iW++) {
-    auto kf = getKf(wValues[iW], kinc);
+    auto kf = getKf((wValues)[iW], kinc);
     auto [qmin, qrange] = getKinematicRange(kf, kinc);
     IOfQX.clear();
     IOfQY.clear();
-    integrateCumulative(QSQ->getSpectrum(iW), qmin, qmin + qrange, IOfQX, IOfQY, returnCumulative);
+    integrateCumulative(QSQ->histogram(iW), qmin, qmin + qrange, IOfQX, IOfQY, returnCumulative);
     // w bin width for elastic will equal 1
     double wBinWidth = wWidths[iW];
     std::transform(IOfQY.begin(), IOfQY.end(), IOfQY.begin(),
@@ -923,21 +955,21 @@ void DiscusMultipleScatteringCorrection::prepareCumulativeProbForQ(
     // The y values in the two spectra store Q, w (or w index to be precise)
     auto &InvPOfQ = materialWorkspaces[iMat].InvPOfQ;
     for (size_t i = 0; i < InvPOfQ->getNumberHistograms(); i++) {
-      InvPOfQ->dataX(i).resize(IOfQYNorm.size());
-      InvPOfQ->dataX(i) = IOfQYNorm;
+      InvPOfQ->histogram(i).X.resize(IOfQYNorm.size());
+      InvPOfQ->histogram(i).X = IOfQYNorm;
     }
-    InvPOfQ->dataY(0).resize(qValuesFull.size());
-    InvPOfQ->dataY(0) = qValuesFull;
-    InvPOfQ->dataY(1).resize(wIndices.size());
-    InvPOfQ->dataY(1) = wIndices;
+    InvPOfQ->histogram(0).Y.resize(qValuesFull.size());
+    InvPOfQ->histogram(0).Y = qValuesFull;
+    InvPOfQ->histogram(1).Y.resize(wIndices.size());
+    InvPOfQ->histogram(1).Y = wIndices;
   }
 }
 
-void DiscusMultipleScatteringCorrection::convertToLogWorkspace(const API::MatrixWorkspace_sptr &SOfQ) {
+void DiscusMultipleScatteringCorrection::convertToLogWorkspace(const std::shared_ptr<DiscusData2D> &SOfQ) {
   // generate log of the structure factor to support gaussian interpolation
 
   for (size_t i = 0; i < SOfQ->getNumberHistograms(); i++) {
-    auto &ySQ = SOfQ->mutableY(i);
+    auto &ySQ = SOfQ->histogram(i).Y;
 
     std::transform(ySQ.begin(), ySQ.end(), ySQ.begin(), [](double d) -> double {
       const double exp_that_gives_close_to_zero = -20.0;
@@ -963,7 +995,7 @@ void DiscusMultipleScatteringCorrection::calculateQSQIntegralAsFunctionOfK(Compo
     std::set<double> kValues(specialKs.begin(), specialKs.end());
     // Calculate the integral for a range of k values. Not massively important which k values but choose them here
     // based on the q points in the S(Q) profile and the initial k values incident on the sample
-    const std::vector<double> qValues = SQWSMapping.SQ->histogram(0).readX();
+    const std::vector<double> qValues = SQWSMapping.SQ->histogram(0).X;
     for (auto q : qValues) {
       if (q > 0)
         kValues.insert(q / 2);
@@ -992,10 +1024,7 @@ void DiscusMultipleScatteringCorrection::calculateQSQIntegralAsFunctionOfK(Compo
         QSQIntegrals.push_back(normalisedIntegral);
       }
     }
-    auto QSQScaleFactor = std::make_shared<DataObjects::Histogram1D>(HistogramData::Histogram::XMode::Points,
-                                                                     HistogramData::Histogram::YMode::Frequencies);
-    QSQScaleFactor->dataX() = finalkValues;
-    QSQScaleFactor->dataY() = QSQIntegrals;
+    auto QSQScaleFactor = std::make_shared<DiscusData1D>(DiscusData1D{finalkValues, QSQIntegrals});
     SQWSMapping.QSQScaleFactor = QSQScaleFactor;
   }
 }
@@ -1014,11 +1043,12 @@ void DiscusMultipleScatteringCorrection::calculateQSQIntegralAsFunctionOfK(Compo
  * @param returnCumulative Flag to indicate whether the function should return the cumulative integral at each x value
  * in the histogram or whether to just return the total integral (quicker)
  */
-void DiscusMultipleScatteringCorrection::integrateCumulative(const ISpectrum &h, const double xmin, const double xmax,
-                                                             std::vector<double> &resultX, std::vector<double> &resultY,
+void DiscusMultipleScatteringCorrection::integrateCumulative(const DiscusData1D &h, const double xmin,
+                                                             const double xmax, std::vector<double> &resultX,
+                                                             std::vector<double> &resultY,
                                                              const bool returnCumulative) {
-  const std::vector<double> &xValues = h.dataX();
-  const std::vector<double> &yValues = h.dataY();
+  const std::vector<double> &xValues = h.X;
+  const std::vector<double> &yValues = h.Y;
   bool isPoints = xValues.size() == yValues.size();
 
   // set the integral to zero at xmin
@@ -1116,7 +1146,8 @@ API::MatrixWorkspace_sptr DiscusMultipleScatteringCorrection::integrateWS(const 
   auto wsIntegrals = DataObjects::create<Workspace2D>(*ws, HistogramData::Points{0.});
   for (size_t i = 0; i < ws->getNumberHistograms(); i++) {
     std::vector<double> IOfQX, IOfQY;
-    integrateCumulative(ws->getSpectrum(i), ws->x(i).front(), ws->x(i).back(), IOfQX, IOfQY, false);
+    integrateCumulative(DiscusData1D{ws->histogram(i).dataX(), ws->histogram(i).dataY()}, ws->x(i).front(),
+                        ws->x(i).back(), IOfQX, IOfQY, false);
     wsIntegrals->mutableY(i) = IOfQY.back();
   }
   return wsIntegrals;
@@ -1158,10 +1189,10 @@ std::tuple<double, double> DiscusMultipleScatteringCorrection::new_vector(const 
  * @param x A randomly chosen value between 0 and 1
  * @return A tuple containing the sampled Q value and the index of the sampled w value in the S(Q,w) distribution
  */
-std::tuple<double, int> DiscusMultipleScatteringCorrection::sampleQW(const MatrixWorkspace_sptr &CumulativeProb,
-                                                                     double x) {
-  return {interpolateSquareRoot(CumulativeProb->getSpectrum(0), x),
-          static_cast<int>(interpolateFlat(CumulativeProb->getSpectrum(1), x))};
+std::tuple<double, int>
+DiscusMultipleScatteringCorrection::sampleQW(const std::shared_ptr<DiscusData2D> &CumulativeProb, double x) {
+  return {interpolateSquareRoot(CumulativeProb->histogram(0), x),
+          static_cast<int>(interpolateFlat(CumulativeProb->histogram(1), x))};
 }
 
 /**
@@ -1169,10 +1200,10 @@ std::tuple<double, int> DiscusMultipleScatteringCorrection::sampleQW(const Matri
  * Used to lookup value in the cumulative probability distribution of Q S(Q) which
  * for flat S(Q) will be a quadratic
  */
-double DiscusMultipleScatteringCorrection::interpolateSquareRoot(const ISpectrum &histToInterpolate, double x) {
-  const auto &histx = histToInterpolate.x();
-  const auto &histy = histToInterpolate.y();
-  assert(histToInterpolate.histogram().xMode() == HistogramData::Histogram::XMode::Points);
+double DiscusMultipleScatteringCorrection::interpolateSquareRoot(const DiscusData1D &histToInterpolate, double x) {
+  const auto &histx = histToInterpolate.X;
+  const auto &histy = histToInterpolate.Y;
+  assert(histToInterpolate.X.size() == histToInterpolate.Y.size());
   if (x > histx.back()) {
     return histy.back();
   }
@@ -1197,9 +1228,9 @@ double DiscusMultipleScatteringCorrection::interpolateSquareRoot(const ISpectrum
  * @param x The x value to interpolate at
  * @return The interpolated value
  */
-double DiscusMultipleScatteringCorrection::interpolateFlat(const ISpectrum &histToInterpolate, double x) {
-  auto &xHisto = histToInterpolate.x();
-  auto &yHisto = histToInterpolate.y();
+double DiscusMultipleScatteringCorrection::interpolateFlat(const DiscusData1D &histToInterpolate, double x) {
+  auto &xHisto = histToInterpolate.X;
+  auto &yHisto = histToInterpolate.Y;
   if (x > xHisto.back()) {
     return yHisto.back();
   }
@@ -1220,25 +1251,25 @@ double DiscusMultipleScatteringCorrection::interpolateFlat(const ISpectrum &hist
  * @param x The x value to interpolate at
  * @return The exponential of the interpolated value
  */
-double DiscusMultipleScatteringCorrection::interpolateGaussian(const ISpectrum &histToInterpolate, double x) {
+double DiscusMultipleScatteringCorrection::interpolateGaussian(const DiscusData1D &histToInterpolate, double x) {
   // could have written using points() method so it also worked on histogram data but found that the points
   // method was bottleneck on multithreaded code due to cow_ptr atomic_load
-  assert(histToInterpolate.histogram().xMode() == HistogramData::Histogram::XMode::Points);
-  if (x > histToInterpolate.x().back()) {
-    return exp(histToInterpolate.y().back());
+  assert(histToInterpolate.X.size() == histToInterpolate.Y.size());
+  if (x > histToInterpolate.X.back()) {
+    return exp(histToInterpolate.Y.back());
   }
-  if (x < histToInterpolate.x().front()) {
-    return exp(histToInterpolate.y().front());
+  if (x < histToInterpolate.X.front()) {
+    return exp(histToInterpolate.Y.front());
   }
   // assume log(cross section) is quadratic in k
-  auto deltax = histToInterpolate.x()[1] - histToInterpolate.x()[0];
+  auto deltax = histToInterpolate.X[1] - histToInterpolate.X[0];
 
-  auto iter = std::upper_bound(histToInterpolate.x().cbegin(), histToInterpolate.x().cend(), x);
-  auto idx = static_cast<size_t>(std::distance(histToInterpolate.x().cbegin(), iter) - 1);
+  auto iter = std::upper_bound(histToInterpolate.X.cbegin(), histToInterpolate.X.cend(), x);
+  auto idx = static_cast<size_t>(std::distance(histToInterpolate.X.cbegin(), iter) - 1);
 
   // need at least two points to the right of the x value for the quadratic
   // interpolation to work
-  auto ny = histToInterpolate.y().size();
+  auto ny = histToInterpolate.Y.size();
   if (ny < 3) {
     throw std::runtime_error("Need at least 3 y values to perform quadratic interpolation");
   }
@@ -1247,8 +1278,8 @@ double DiscusMultipleScatteringCorrection::interpolateGaussian(const ISpectrum &
   }
   // this interpolation assumes the set of 3 bins\point have the same width
   // U=0 on point or bin edge to the left of where x lies
-  const auto U = (x - histToInterpolate.x()[idx]) / deltax;
-  const auto &y = histToInterpolate.y();
+  const auto U = (x - histToInterpolate.X[idx]) / deltax;
+  const auto &y = histToInterpolate.Y;
   const auto A = (y[idx] - 2 * y[idx + 1] + y[idx + 2]) / 2;
   const auto B = (-3 * y[idx] + 4 * y[idx + 1] - y[idx + 2]) / 2;
   const auto C = y[idx];
@@ -1268,13 +1299,10 @@ double DiscusMultipleScatteringCorrection::Interpolate2D(const ComponentWorkspac
                                                          double w) {
   double SQ = 0.;
   int iW = -1;
-  auto wAxis = dynamic_cast<NumericAxis *>(SQWSMapping.SQ->getAxis(1));
-  if (!wAxis)
-    throw std::invalid_argument("Cannot perform 2D interpolation on S(Q,w) that doesn't have a numeric w axis");
-  auto &wValues = wAxis->getValues();
+  auto &wValues = SQWSMapping.SQ->getSpecAxisValues();
   if (wValues.size() == 1) {
     // don't use indexOfValue here because for single point it invents a bin width of +/-0.5
-    if (w == wValues[0])
+    if (w == (wValues)[0])
       iW = 0;
   } else
     try {
@@ -1286,9 +1314,9 @@ double DiscusMultipleScatteringCorrection::Interpolate2D(const ComponentWorkspac
     if (m_importanceSampling)
       // the square root interpolation used to look up Q, w in InvPOfQ is based on flat interpolation of S(Q) so use
       // same interpolation here for consistency
-      SQ = interpolateFlat(SQWSMapping.SQ->getSpectrum(iW), q);
+      SQ = interpolateFlat(SQWSMapping.SQ->histogram(iW), q);
     else
-      SQ = interpolateGaussian(SQWSMapping.logSQ->getSpectrum(iW), q);
+      SQ = interpolateGaussian(SQWSMapping.logSQ->histogram(iW), q);
   }
 
   return SQ;
@@ -1375,7 +1403,7 @@ DiscusMultipleScatteringCorrection::scatter(const int nScatters, Kernel::PseudoR
       if (m_importanceSampling) {
         auto newComponentWorkspaces = componentWorkspaces;
         for (auto &SQWSMapping : currentComponentWorkspaces)
-          SQWSMapping.InvPOfQ = SQWSMapping.InvPOfQ->clone();
+          SQWSMapping.InvPOfQ = SQWSMapping.InvPOfQ->CreateCopy();
         prepareCumulativeProbForQ(k, newComponentWorkspaces);
         currentComponentWorkspaces = newComponentWorkspaces;
       }
@@ -1539,7 +1567,7 @@ DiscusMultipleScatteringCorrection::sampleQWUniform(const std::vector<double> &w
  * The approach here will cope with multiple scatters by calculating a sumQSS at each required
  * kinc values and cache the results
  */
-double DiscusMultipleScatteringCorrection::getQSQIntegral(const ISpectrum &QSQScaleFactor, double k) {
+double DiscusMultipleScatteringCorrection::getQSQIntegral(const DiscusData1D &QSQScaleFactor, double k) {
   // the QSQIntegrals were divided by k^2 so in theory they should be ~flat
   return interpolateFlat(QSQScaleFactor, k) * 2 * k * k;
 }
@@ -1565,18 +1593,18 @@ bool DiscusMultipleScatteringCorrection::q_dir(Geometry::Track &track, const Geo
   auto componentWSIt = findMatchingComponent(componentWorkspaces, shapePtr);
   if (m_importanceSampling) {
     std::tie(QQ, iW) = sampleQW(componentWSIt->InvPOfQ, rng.nextValue());
-    k = getKf(componentWSIt->SQ->getAxis(1)->getValue(iW), kinc);
+    k = getKf(componentWSIt->SQ->getSpecAxisValues()[iW], kinc);
     weight = weight * scatteringXSection;
   } else {
     double qrange, wRange;
-    auto &wValues = dynamic_cast<NumericAxis *>(componentWSIt->SQ->getAxis(1))->getValues();
+    auto &wValues = componentWSIt->SQ->getSpecAxisValues();
     std::tie(QQ, qrange, iW, wRange) = sampleQWUniform(wValues, rng, kinc);
     // if w inaccessible return (ie treat as zero weight) rather than retry so that integration stays over full w
     // range
     if (fromWaveVector(kinc) - wValues[iW] <= 0)
       return false;
     k = getKf(wValues[iW], kinc);
-    double SQ = interpolateGaussian(componentWSIt->logSQ->getSpectrum(iW), QQ);
+    double SQ = interpolateGaussian(componentWSIt->logSQ->histogram(iW), QQ);
     // integrate over rectangular area of qw space
     weight = weight * scatteringXSection * SQ * QQ * qrange * wRange;
     if (SQ > 0) {
@@ -1807,11 +1835,13 @@ DiscusMultipleScatteringCorrection::createSparseWorkspace(const API::MatrixWorks
 void DiscusMultipleScatteringCorrection::createInvPOfQWorkspaces(ComponentWorkspaceMappings &matWSs, size_t nhists) {
   for (auto &SQWSMapping : matWSs) {
     auto &QSQ = SQWSMapping.QSQ;
-    size_t expectedMaxSize = QSQ->size();
-    MatrixWorkspace_sptr ws = DataObjects::create<Workspace2D>(nhists, HistogramData::Points{0.});
-    ws->dataX(0).reserve(expectedMaxSize);
+    size_t expectedMaxSize =
+        std::accumulate(QSQ->histograms().begin(), QSQ->histograms().end(), static_cast<size_t>(0),
+                        [](const size_t value, const DiscusData1D &histo) { return value + histo.Y.size(); });
+    auto ws = std::make_shared<DiscusData2D>(std::vector<DiscusData1D>(nhists), nullptr);
+    ws->histogram(0).X.reserve(expectedMaxSize);
     for (size_t i = 0; i < nhists; i++)
-      ws->dataY(i).reserve(expectedMaxSize);
+      ws->histogram(i).Y.reserve(expectedMaxSize);
     SQWSMapping.InvPOfQ = ws;
   }
 }

--- a/Framework/Algorithms/src/DiscusMultipleScatteringCorrection.cpp
+++ b/Framework/Algorithms/src/DiscusMultipleScatteringCorrection.cpp
@@ -418,7 +418,7 @@ void DiscusMultipleScatteringCorrection::prepareStructureFactors() {
  */
 void DiscusMultipleScatteringCorrection::AddWorkspaceToDiscus2DData(const Geometry::IObject_const_sptr &shape,
                                                                     const std::string_view &matName,
-                                                                    API::MatrixWorkspace_sptr &SQWS) {
+                                                                    API::MatrixWorkspace_sptr SQWS) {
   // avoid repeated conversion of bin edges to points inside loop by converting to point data
   convertWsBothAxesToPoints(SQWS);
   // if S(Q,w) has been supplied ensure Q is along the x axis of each spectrum (so same as S(Q))
@@ -437,7 +437,7 @@ void DiscusMultipleScatteringCorrection::AddWorkspaceToDiscus2DData(const Geomet
   }
   auto specAxis = dynamic_cast<NumericAxis *>(SQWS->getAxis(1));
   std::vector<DiscusData1D> data;
-  for (int i = 0; i < SQWS->getNumberHistograms(); i++) {
+  for (size_t i = 0; i < SQWS->getNumberHistograms(); i++) {
     data.push_back(DiscusData1D{SQWS->histogram(i).dataX(), SQWS->histogram(i).dataY()});
   }
   ComponentWorkspaceMapping SQWSMapping{


### PR DESCRIPTION
**Description of work.**

These changes remove the use of the MatrixWorkspace class from the internal calculation logic in the DiscusMultipleScatteringCorrection algorithm and replaces it with some simple data structures for 2D data based on std::vector. The MatrixWorkspace class is now only used to read input data and save the results to the ADS at the end.

The aim of this was to more loosely couple the algorithm to Mantid so that it might be usable by a wider audience eg Scipp. Although note - there still is significant Mantid coupling (eg in the use of the Mantid Geometry framework) but thought it would be a useful exercise to see how difficult it would be to loosen the coupling in terms of the workspaces at least.

**To test:**

Main things to check are that the algorithm is functionally the same and that I've not slowed it down. The unit tests on the algorithm are pretty comprehensive so hopefully they will cover the "functionally the same" part. Re performance I suggest running this Discus calculation on a release build before\after these changes and confirm it doesn't run any slower with these changes. It should take about a minute although depends on the power of your machine. Test files here [TestFiles.zip](https://github.com/mantidproject/mantid/files/10001709/TestFiles.zip):
```
# import mantid algorithms, numpy and matplotlib

from mantid.simpleapi import *
import matplotlib.pyplot as plt
import numpy as np
import math

folder = r"C:\Multiple Scattering\"

sqw = Load(Filename=os.path.join(folder,'irs17901_multi_graphite002_sqw_widerq.nxs'))

sqw = Rebin(sqw,'4,0.1,21')

inputWS = Load(Filename=os.path.join(folder,'irs17901_multi_graphite002_red.nxs'))

# default cylinder axis is "up" ie y
SetSample(InputWorkspace=inputWS,
          Geometry={'Shape': 'Cylinder', 'Height': 3.0,'Radius': 1.0,'Center': [0.,0.,0.]},
          Material={'ChemicalFormula': 'He'})

DiscusMultipleScatteringCorrection(InputWorkspace=inputWS, StructureFactorWorkspace=sqw,
                                   OutputWorkspace="MuscatResultsHe", NeutronPathsSingle=200,
                                   NeutronPathsMultiple=1000, NormalizeStructureFactors=False)
```

*There is no associated issue.*

*This does not require release notes* because **there is no functional change**

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
