### PR TITLE
Make for-loop over peaks in IntegratePeaksMD use openMP parallelisation 

### DIFF
--- a/Framework/MDAlgorithms/src/IntegratePeaksMD2.cpp
+++ b/Framework/MDAlgorithms/src/IntegratePeaksMD2.cpp
@@ -470,11 +470,10 @@ template <typename MDE, size_t nd> void IntegratePeaksMD2::integrate(typename MD
   // Initialize progress reporting
   int nPeaks = peakWS->getNumberPeaks();
   Progress progress(this, 0., 1., nPeaks);
-  PARALLEL_FOR_IF(Kernel::threadSafe(*ws, *peakWS, *wsProfile2D, *wsFit2D, *wsDiff2D))
+  bool doParallel = (cylinderBool) ? false : Kernel::threadSafe(*ws, *peakWS);
+  PARALLEL_FOR_IF(doParallel)
   for (int i = 0; i < nPeaks; ++i) {
     PARALLEL_START_INTERRUPT_REGION
-    if (this->getCancel())
-      break; // User cancellation
     progress.report();
 
     // Get a direct ref to that peak.

--- a/Framework/MDAlgorithms/src/IntegratePeaksMD2.cpp
+++ b/Framework/MDAlgorithms/src/IntegratePeaksMD2.cpp
@@ -457,16 +457,7 @@ template <typename MDE, size_t nd> void IntegratePeaksMD2::integrate(typename MD
   double volumeBkg = 4.0 / 3.0 * M_PI * (std::pow(BackgroundOuterRadius[0], 3) - std::pow(BackgroundOuterRadius[0], 3));
   // volume of PeakRadius sphere
   double volumeRadius = 4.0 / 3.0 * M_PI * std::pow(PeakRadius[0], 3);
-  //
-  // If the following OMP pragma is included, this algorithm seg faults
-  // sporadically when processing multiple TOPAZ runs in a script, on
-  // Scientific Linux 6.2.  Typically, it seg faults after 2 to 6 runs are
-  // processed, though occasionally it will process all 8 requested in the
-  // script without crashing.  Since the lower level codes already use OpenMP,
-  // parallelizing at this level is only marginally useful, giving about a
-  // 5-10% speedup.  Perhaps is should just be removed permanantly, but for
-  // now it is commented out to avoid the seg faults.  Refs #5533
-  // PRAGMA_OMP(parallel for schedule(dynamic, 10) )
+
   // Initialize progress reporting
   int nPeaks = peakWS->getNumberPeaks();
   Progress progress(this, 0., 1., nPeaks);

--- a/Framework/MDAlgorithms/src/IntegratePeaksMD2.cpp
+++ b/Framework/MDAlgorithms/src/IntegratePeaksMD2.cpp
@@ -470,7 +470,7 @@ template <typename MDE, size_t nd> void IntegratePeaksMD2::integrate(typename MD
   // Initialize progress reporting
   int nPeaks = peakWS->getNumberPeaks();
   Progress progress(this, 0., 1., nPeaks);
-  bool doParallel = (cylinderBool) ? false : Kernel::threadSafe(*ws, *peakWS);
+  bool doParallel = cylinderBool ? false : Kernel::threadSafe(*ws, *peakWS);
   PARALLEL_FOR_IF(doParallel)
   for (int i = 0; i < nPeaks; ++i) {
     PARALLEL_START_INTERRUPT_REGION
@@ -768,9 +768,9 @@ template <typename MDE, size_t nd> void IntegratePeaksMD2::integrate(typename MD
         signal = 0.;
         for (size_t j = 0; j < numSteps; j++) {
           if (j < peakMin || j > peakMax)
-            background_total = background_total + wsProfile2D->mutableY(i)[j];
+            background_total = background_total + wsProfile2D->y(i)[j];
           else
-            signal = signal + wsProfile2D->mutableY(i)[j];
+            signal = signal + wsProfile2D->y(i)[j];
         }
         errorSquared = std::fabs(signal);
       } else {

--- a/Framework/MDAlgorithms/src/IntegratePeaksMD2.cpp
+++ b/Framework/MDAlgorithms/src/IntegratePeaksMD2.cpp
@@ -470,7 +470,9 @@ template <typename MDE, size_t nd> void IntegratePeaksMD2::integrate(typename MD
   // Initialize progress reporting
   int nPeaks = peakWS->getNumberPeaks();
   Progress progress(this, 0., 1., nPeaks);
+  PARALLEL_FOR_IF(Kernel::threadSafe(*ws, *peakWS, *wsProfile2D, *wsFit2D, *wsDiff2D))
   for (int i = 0; i < nPeaks; ++i) {
+    PARALLEL_START_INTERRUPT_REGION
     if (this->getCancel())
       break; // User cancellation
     progress.report();
@@ -891,7 +893,9 @@ template <typename MDE, size_t nd> void IntegratePeaksMD2::integrate(typename MD
     g_log.information() << "Peak " << i << " at " << pos << ": signal " << signal << " (sig^2 " << errorSquared
                         << "), with background " << bgSignal + ratio * background_total << " (sig^2 "
                         << bgErrorSquared + ratio * ratio * std::fabs(background_total) << ") subtracted.\n";
+    PARALLEL_END_INTERRUPT_REGION
   }
+  PARALLEL_CHECK_INTERRUPT_REGION
   // This flag is used by the PeaksWorkspace to evaluate whether it has
   // been integrated.
   peakWS->mutableRun().addProperty("PeaksIntegrated", 1, true);

--- a/docs/source/release/v6.6.0/Diffraction/Single_Crystal/Improvements/34729.rst
+++ b/docs/source/release/v6.6.0/Diffraction/Single_Crystal/Improvements/34729.rst
@@ -1,0 +1,1 @@
+* Parallelize loop over peaks in IntegratePEaksMD which provides significant speed-up for ellipsoid integration.


### PR DESCRIPTION
**Description of work.**

Make for-loop over peaks an openMP loop using the recommended macro (as opposed to the old style `PRAGMA_OMP(parallel for schedule(dynamic, 10) )` which was commented out). Apparently the `PRAGMA_OMP` used to cause a seg fault for TOPAZ
https://trac.mantidproject.org/mantid/ticket/5533
The comments in the code states that the parallelisation of this loop only gives modest speed-up of ~10% - however for the ellipsoid integration it is about a factor of ~4 on my computer (in DebugWithRelRuntime build) because the loop over events to evaluate the covariance is not parallelised. But the comments in the ticket #5533 also see large speed-up for the fitting.

I think that using the macro as in this PR is safer and I can't see anywhere that would require a `PARALLEL_CRITICAL` block - but I may be mistaken!

**To test:**

(1) Run this script

```
Load(Filename='SXD23767.raw', OutputWorkspace='SXD23767')
ConvertToDiffractionMDWorkspace(InputWorkspace='SXD23767', OutputWorkspace='SXD23767_MD', 
                                OneEventPerBin=False, SplitThreshold=30)
FindPeaksMD(InputWorkspace='SXD23767_MD', PeakDistanceThreshold=0.4, MaxPeaks=1000, 
            PeakFindingStrategy='NumberOfEventsNormalization', SignalThresholdFactor=5, 
            OutputType='Peak', OutputWorkspace='SingleCrystalPeakTable', EdgePixels=1) 
IntegratePeaksMD(InputWorkspace='SXD23767_MD', PeakRadius='0.15', BackgroundInnerRadius='0.15',
                BackgroundOuterRadius='0.1875', PeaksWorkspace='SingleCrystalPeakTable', 
                OutputWorkspace='peaks_int', Ellipsoid=True, FixQAxis=True, UseOnePercentBackgroundCorrection=False, UseCentroid=True)
```
* The call to `IntegratePEaksMD` takes ~1m14s on my laptop (but 5m45s on main)

(2) Try the cylinder and spherical integration options - you may not notice the speed up but it shouldn't crash/seg fault!

*There is no associated issue.*


<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
