### PR TITLE
Errorbars do not get plotted for nan spectra

### DIFF
--- a/Framework/PythonInterface/mantid/plots/datafunctions.py
+++ b/Framework/PythonInterface/mantid/plots/datafunctions.py
@@ -908,7 +908,12 @@ def _get_x_errorbar_segments(err_cont):
 
 def _get_y_errorbar_segments(err_cont):
     if err_cont.has_yerr and not err_cont.has_xerr:
-        return err_cont[2][0].get_segments()
+        y_errorbar_segments = err_cont[2][0].get_segments()
+        # if y axis contains all nan then
+        if not [i for i in y_errorbar_segments if i.size > 0]:
+            return None
+        else:
+            return y_errorbar_segments
     elif err_cont.has_yerr and err_cont.has_xerr:
         return err_cont[2][1].get_segments()
     else:

--- a/docs/source/release/v6.6.0/Workbench/Bugfixes/34485.rst
+++ b/docs/source/release/v6.6.0/Workbench/Bugfixes/34485.rst
@@ -1,0 +1,1 @@
+- Fixed a bug where Mantid would crash when trying to plot errorbars on nan spectra.


### PR DESCRIPTION
**Description of work.**
A crash was happening when Mantid tried to add errorbars to spectra that were all nan. They also appear in the legend. I decided not to remove them from the legend but prevent the assignment of errorbars when trying to fit an array of empty arrays (the result of all nan spectra). There was already code to prevent the assignment of errorbars in certain circumstances so I just added another case.

Test added also.

**To test:**
1. Follow the instructions in #34485 to replicate the issue. Mantid should no longer crash.

Fixes #34485

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
