### PR TITLE
Fix Crash From Toolbar Buttons When Loading 1D after 2D in Refl Preview

### DIFF
--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.cpp
@@ -108,6 +108,7 @@ void PreviewPresenter::notifyLoadWorkspaceCompleted() {
 
   if (hasLinearDetector(ws)) {
     m_view->resetInstView();
+    m_view->setInstViewToolbarEnabled(false);
     m_model->setSummedWs(ws);
     notifySumBanksCompleted();
   } else {

--- a/qt/scientific_interfaces/ISISReflectometry/test/Preview/PreviewPresenterTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Preview/PreviewPresenterTest.h
@@ -133,6 +133,7 @@ public:
 
     expectRegionSelectorToolbarEnabled(*mockView, true);
 
+    EXPECT_CALL(*mockView, setInstViewToolbarEnabled(Eq(false))).Times(1);
     presenter.notifyLoadWorkspaceCompleted();
   }
 


### PR DESCRIPTION
**Description of work.**
If 2D data was loaded the Instrument View's ROI toolbar was enabled.
This is fine, but when 1D data is loaded afterwards the button could
still be pressed. This was causing a crash as the IV had no data to put
and ROI over.

**To test:**
1. Open the ISIS Reflectometry interface
2. Go to the Preview tab
3. Enter run `INTER45455_inst` and click Load (This data is available on this Epic and must be in your path: #31069)
4. Load some 1D data (INTER43583)
5. The Instrument viewer toolbar should be disabled. 

Fixes #34673 


*This does not require release notes* because **the preview tab is not yet user facing.**

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
