### PR TITLE
Fix for crashes and errors on collapsing plots

### DIFF
--- a/docs/source/release/v6.6.0/Workbench/Bugfixes/34549.rst
+++ b/docs/source/release/v6.6.0/Workbench/Bugfixes/34549.rst
@@ -1,0 +1,1 @@
+- Fixed a bug where collapsing plots using a splitter handle could result in a crash.

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/views/view.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/views/view.py
@@ -41,6 +41,7 @@ class SliceViewerView(QWidget, ObservingView):
         self._splitter = QSplitter(self)
         self._data_view = SliceViewerDataView(presenter, dims_info, can_normalise, self, conf)
         self._splitter.addWidget(self._data_view)
+        self._splitter.setCollapsible(0, False)
         self._splitter.splitterMoved.connect(self._data_view.on_resize)
         #  peaks viewer off by default
         self._peaks_view = None
@@ -83,6 +84,8 @@ class SliceViewerView(QWidget, ObservingView):
 
     def add_widget_to_splitter(self, widget):
         self._splitter.addWidget(widget)
+        widget_index = self._splitter.indexOf(widget)
+        self._splitter.setCollapsible(widget_index, False)
         self._data_view.on_resize()
 
     def peaks_overlay_clicked(self):

--- a/qt/scientific_interfaces/Direct/ALFView.cpp
+++ b/qt/scientific_interfaces/Direct/ALFView.cpp
@@ -38,6 +38,9 @@ void ALFView::initLayout() {
   splitter->addWidget(m_instrumentPresenter->getInstrumentView());
   splitter->addWidget(m_analysisPresenter->getView());
 
+  splitter->setCollapsible(0, false);
+  splitter->setCollapsible(1, false);
+
   auto mainWidget = new QSplitter(Qt::Vertical);
   mainWidget->addWidget(m_instrumentPresenter->getLoadWidget());
   mainWidget->addWidget(splitter);

--- a/qt/scientific_interfaces/Direct/ALFView.cpp
+++ b/qt/scientific_interfaces/Direct/ALFView.cpp
@@ -45,6 +45,9 @@ void ALFView::initLayout() {
   mainWidget->addWidget(m_instrumentPresenter->getLoadWidget());
   mainWidget->addWidget(splitter);
 
+  mainWidget->setCollapsible(0, false);
+  mainWidget->setCollapsible(1, false);
+
   auto centralWidget = new QWidget();
   auto verticalLayout = new QVBoxLayout(centralWidget);
   verticalLayout->addWidget(mainWidget);

--- a/qt/scientific_interfaces/Indirect/InelasticDataManipulationElwinTab.ui
+++ b/qt/scientific_interfaces/Indirect/InelasticDataManipulationElwinTab.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>600</width>
+    <width>579</width>
     <height>841</height>
    </rect>
   </property>
@@ -165,6 +165,9 @@
       <property name="orientation">
        <enum>Qt::Horizontal</enum>
       </property>
+      <property name="childrenCollapsible">
+       <bool>false</bool>
+      </property>
       <widget class="QWidget" name="layoutWidget1">
        <layout class="QVBoxLayout" name="properties"/>
       </widget>
@@ -174,6 +177,12 @@
          <layout class="QHBoxLayout" name="loPreviewSelection">
           <item>
            <widget class="QLabel" name="lbPreviewFile">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
             <property name="text">
              <string>Preview file:</string>
             </property>
@@ -182,15 +191,40 @@
           <item>
            <widget class="QComboBox" name="cbPreviewFile">
             <property name="sizePolicy">
-             <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+             <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
               <horstretch>0</horstretch>
               <verstretch>0</verstretch>
              </sizepolicy>
             </property>
+            <property name="minimumSize">
+             <size>
+              <width>100</width>
+              <height>0</height>
+             </size>
+            </property>
            </widget>
           </item>
           <item>
+           <spacer name="horizontalSpacer_4">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>40</width>
+              <height>20</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+          <item>
            <widget class="QLabel" name="lbPreviewSpec">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
             <property name="text">
              <string>Spectrum:</string>
             </property>
@@ -199,26 +233,29 @@
           <item>
            <widget class="QStackedWidget" name="elwinPreviewSpec">
             <property name="sizePolicy">
-             <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+             <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
               <horstretch>0</horstretch>
               <verstretch>0</verstretch>
              </sizepolicy>
             </property>
             <property name="minimumSize">
              <size>
-              <width>0</width>
+              <width>75</width>
               <height>50</height>
              </size>
             </property>
             <property name="lineWidth">
              <number>-1</number>
             </property>
+            <property name="currentIndex">
+             <number>0</number>
+            </property>
             <widget class="QWidget" name="pgPlotSpinBox">
              <widget class="QSpinBox" name="spPlotSpectrum">
               <property name="geometry">
                <rect>
-                <x>150</x>
-                <y>10</y>
+                <x>0</x>
+                <y>15</y>
                 <width>33</width>
                 <height>22</height>
                </rect>
@@ -238,8 +275,8 @@
              <widget class="QComboBox" name="cbPlotSpectrum">
               <property name="geometry">
                <rect>
-                <x>170</x>
-                <y>10</y>
+                <x>0</x>
+                <y>15</y>
                 <width>73</width>
                 <height>22</height>
                </rect>

--- a/qt/scientific_interfaces/Indirect/InelasticDataManipulationElwinTab.ui
+++ b/qt/scientific_interfaces/Indirect/InelasticDataManipulationElwinTab.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>579</width>
+    <width>600</width>
     <height>841</height>
    </rect>
   </property>

--- a/qt/widgets/instrumentview/src/InstrumentWidget.cpp
+++ b/qt/widgets/instrumentview/src/InstrumentWidget.cpp
@@ -152,6 +152,9 @@ InstrumentWidget::InstrumentWidget(QString wsName, QWidget *parent, bool resetGe
 
   m_controlPanelLayout->addWidget(aWidget);
 
+  m_controlPanelLayout->setCollapsible(0, false);
+  m_controlPanelLayout->setCollapsible(1, false);
+
   m_mainLayout->addWidget(m_controlPanelLayout);
 
   m_xIntegration = new XIntegrationControl(this);

--- a/qt/widgets/plotting/src/PreviewPlot.cpp
+++ b/qt/widgets/plotting/src/PreviewPlot.cpp
@@ -309,7 +309,7 @@ std::tuple<double, double> PreviewPlot::getAxisRange(AxisID axisID) {
 
 void PreviewPlot::replot() {
   if (m_allowRedraws) {
-    m_canvas->draw();
+    m_canvas->drawIdle();
     emit redraw();
   }
 }


### PR DESCRIPTION
**Description of work.**

There are certain areas of the Mantid UI where there are plots inside of QSplitter frames. In some cases when the QSplitter handle is dragged so that the plot is collapsed beyond it's minimum width (it snaps to 0 width) Mantid would crash. This was fixed by changing `PreviewPlot` to us `drawIdle()` instead of `draw()` however this still produced a nasty error in the log.

To avoid this problem entirely, QSplitter's `setCollapsible()` method can be used to ensure the plot widgets cannot be fully collapsed to 0 width. There are likely many other QSplitters across Mantid where it would make sense for them to not collapse entirely but this PR only fixes those containing plots to avoid crashes / errors.

- `PreviewPlot` now uses `drawIdle()` instead of `draw()` so that the plot is not asked to draw when it can't.
- `InelasticDataManipulationElwinTab.ui` has been altered:
  - The QSplitter containing the plot will now not collapse it's children
  - The VBox containing the settings above the plot has been altered so that when the splitter handle is moved the settings are compressed rather than being pushed out of the window
- `ALFView.cpp`, the main sliceviewer `view.py`, and `InstrumentWidget.cpp` have had their QSplitters set to not collapse children

**To test:**

It mat be useful to compare behaviour with another branch / version of Mantid without these changes.

- Open the Indirect Data Anaslysis interface and on the Elwin tab drag the splitter handle to the right so that the plot is compressed
  - Check that no crash or errors occurs
  - Check that the plot will not collapse to 0 width
  - Check that none of the widgets above the plot are pushed of the screen and that they compress nicely
- Repeat the above instructions with the Direct Data Analysis interface
- Load some data an open the instrument viewer then swich to the 'pick' tab and drag the splitter handle to the left to compress the plot
  - Check that no errors are output
  - Check that the plot will not collapse to 0 width
- Open the Direct ALF View interface and drag the splitter handel to the right to compress the plot
  - Check that no errors are output
  - Check that the plot will not collapse to 0 width

Fixes #34549

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
