### PR TITLE
Fix SANSILLParameterScan inverted axis

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SANSILLParameterScan.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SANSILLParameterScan.py
@@ -151,7 +151,17 @@ class SANSILLParameterScan(DataProcessorAlgorithm):
                             startProgress=0.95,
                             endProgress=1)
 
+        # ConvertSpectrumAxis uses a different convention from D16 when it comes to detector orientation, and thus the
+        # 2theta axis is inverted from what is expected, so we flip it back
+        # and since it is a widespread behavior for ILL instruments, this is now the default behaviour
+        ConvertAxisByFormula(InputWorkspace=self.output2D, OutputWorkspace=self.output2D, Axis="Y", Formula="-y")
+
         Transpose(InputWorkspace=self.output2D, OutputWorkspace=self.output2D)
+
+        # flipping the sign of the axis means it is now inverted, which is something matplotlib can't render (and is
+        # really unpleasant to read anyway), so we sort everything again ...
+        # which means cloning the workspace since that's what SortXaAxis does
+        SortXAxis(InputWorkspace=self.output2D, OutputWorkspace=self.output2D, Ordering="Ascending")
 
         self.setProperty('OutputWorkspace', mtd[self.output2D])
 

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/SANSILLParameterScanTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/SANSILLParameterScanTest.py
@@ -26,29 +26,34 @@ class SANSILLParameterScanTest(unittest.TestCase):
         mtd.clear()
 
     def test_D16_omega(self):
+        output_name = "output2d"
         SANSILLParameterScan(SampleRun="066321.nxs",
-                             OutputWorkspace="output2d",
+                             OutputWorkspace=output_name,
                              OutputJoinedWorkspace="reduced",
                              Observable="Omega.value",
                              PixelYmin=3,
                              PixelYMax=189)
-        self._check_output(mtd["output2d"], 6)
+
+        ws = mtd[output_name]
+        self._check_output(ws, 6, 1152)
+        self.assertAlmostEqual(ws.getAxis(0).getValue(0), -42.9348, delta=4)
+        self.assertAlmostEqual(ws.getAxis(0).getValue(1151), 43.0836, delta=4)
+        self.assertAlmostEqual(ws.getAxis(1).getValue(0), 5.2, delta=3)
+        self.assertAlmostEqual(ws.getAxis(1).getValue(1), 5.4, delta=3)
         self.assertTrue(mtd["reduced"])
 
-    def _check_output(self, ws, spectra=1):
+    def _check_output(self, ws, spectra, blocksize):
         self.assertTrue(ws)
         self.assertTrue(isinstance(ws, MatrixWorkspace))
         self.assertEqual(str(ws.getAxis(0).getUnit().symbol()), "degrees")
         self.assertEqual(ws.getAxis(0).getUnit().caption(), "Scattering angle")
         self.assertEqual(str(ws.getAxis(1).getUnit().symbol()), "degrees")
         self.assertEqual(ws.getAxis(1).getUnit().caption(), "Omega.value")
-        self.assertAlmostEqual(ws.getAxis(1).getValue(0), 5.2, delta=3)
-        self.assertAlmostEqual(ws.getAxis(1).getValue(1), 5.4, delta=3)
         self.assertEqual(ws.getNumberHistograms(), spectra)
         self.assertTrue(ws.getInstrument())
         self.assertTrue(ws.getRun())
         self.assertTrue(ws.getHistory())
-        self.assertTrue(ws.blocksize(), 1152)
+        self.assertTrue(ws.blocksize(), blocksize)
         self.assertTrue(not ws.isHistogramData())
         self.assertTrue(not ws.isDistribution())
 

--- a/docs/source/release/v6.6.0/SANS/New_features/34752.rst
+++ b/docs/source/release/v6.6.0/SANS/New_features/34752.rst
@@ -1,0 +1,1 @@
+- Fix the inverted 2 theta axis of the output for data treated using `SANSILLParameterScan`.


### PR DESCRIPTION
**Description of work.**
This PR inverts the 2 theta axis of the output of `SANSILLParameterScan`, so it agrees with the users' convention.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**
- Run `SANSILLParameterScan` with `Runs=UnitTest/ILL/D16/066321.nxs`
- The output workspace should have X values ranging from -42.9348 to 43.0836, values that a (very careful, this is awful data to check this bug) look at the instrument viewer in Z- should confirm.

<!-- Instructions for testing. -->

Fixes #34752 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
