### PR TITLE
speed wand2 reduction for event filtering mode

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/WANDPowderReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/WANDPowderReduction.py
@@ -199,7 +199,7 @@ class WANDPowderReduction(DataProcessorAlgorithm):
             else:
                 _ws_cal_resampled = self._resample_calibration(data[0], "mask_shared", xMin, xMax)
 
-            if bkg is None:
+            if bkg is None or bkg.strip() == "":
                 _ws_bkg_resampled = None
             else:
                 _ws_bkg_resampled = self._resample_background(bkg, data[0], "mask_shared",

--- a/docs/source/release/v6.6.0/Diffraction/Powder/New_features/34754.rst
+++ b/docs/source/release/v6.6.0/Diffraction/Powder/New_features/34754.rst
@@ -1,0 +1,1 @@
+- Introduce an input parameter in :ref:`WANDPowderReduction <algm-WANDPowderReduction>` to specify that the input workspaces are from event filtering. In such a situation, the overall reduction time could be reduced significantly.


### PR DESCRIPTION
**Description of work.**

When the input for `WANDPowderReduction` is a group of workspaces coming from event filtering, we can make the reduction running faster by pulling out the common part out of the for loop (over all the input workspaces). Specifically,

1.  The calibration and background part can be pulled out.

2. All the input workspaces should be sharing the same mask so there is no need to extract mask for each filtered workspace.

3. The convert unit part can also be accomplished at the state of event filtering so we save the conversion time when running over each of the input workspaces.

**To test:**

Grab the following script and run it, 
[event_filter_hb2c.zip](https://github.com/mantidproject/mantid/files/10037193/event_filter_hb2c.zip)

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
