### PR TITLE
Fixed about widget URLs

### DIFF
--- a/docs/source/release/v6.6.0/Workbench/Bugfixes/34738.rst
+++ b/docs/source/release/v6.6.0/Workbench/Bugfixes/34738.rst
@@ -1,0 +1,1 @@
+- Fixed links to tutorials on the About widget.

--- a/qt/applications/workbench/workbench/widgets/about/presenter.py
+++ b/qt/applications/workbench/workbench/widgets/about/presenter.py
@@ -148,19 +148,19 @@ class AboutPresenter(object):
         InterfaceManager().showHelpPage(release_notes_url())
 
     def action_open_download_website(self):
-        InterfaceManager().showWebPage('http://download.mantidproject.org')
+        InterfaceManager().showWebPage('https://www.mantidproject.org/installation/index#sample-data')
 
     def action_open_mantid_introduction(self):
-        InterfaceManager().showWebPage('http://www.mantidproject.org/Mantid_Basic_Course')
+        InterfaceManager().showWebPage('https://docs.mantidproject.org/nightly/tutorials/mantid_basic_course')
 
     def action_open_python_introduction(self):
-        InterfaceManager().showWebPage('http://www.mantidproject.org/Introduction_To_Python')
+        InterfaceManager().showWebPage('https://docs.mantidproject.org/nightly/tutorials/introduction_to_python')
 
     def action_open_python_in_mantid(self):
-        InterfaceManager().showWebPage('http://www.mantidproject.org/Python_In_Mantid')
+        InterfaceManager().showWebPage('https://docs.mantidproject.org/nightly/tutorials/python_in_mantid')
 
     def action_open_extending_mantid(self):
-        InterfaceManager().showWebPage('http://www.mantidproject.org/Extending_Mantid_With_Python')
+        InterfaceManager().showWebPage('https://docs.mantidproject.org/nightly/tutorials/extending_mantid_with_python')
 
     def action_open_external_link(self, url):
         InterfaceManager().showWebPage(url)

--- a/qt/applications/workbench/workbench/widgets/about/presenter.py
+++ b/qt/applications/workbench/workbench/widgets/about/presenter.py
@@ -16,7 +16,7 @@ from mantidqt.widgets import manageuserdirectories  # noqa
 
 class AboutPresenter(object):
 
-    USAGE_REPORTING = "usagereports.enabled"
+    USAGE_REPORTING = "usagereports.enabled"z
     DO_NOT_SHOW_GROUP = "Mantid/FirstUse"
     DO_NOT_SHOW = "DoNotShowUntilNextRelease"
     PREVIOUS_VERSION = "PreviousVersion"

--- a/qt/applications/workbench/workbench/widgets/about/presenter.py
+++ b/qt/applications/workbench/workbench/widgets/about/presenter.py
@@ -16,7 +16,7 @@ from mantidqt.widgets import manageuserdirectories  # noqa
 
 class AboutPresenter(object):
 
-    USAGE_REPORTING = "usagereports.enabled"z
+    USAGE_REPORTING = "usagereports.enabled"
     DO_NOT_SHOW_GROUP = "Mantid/FirstUse"
     DO_NOT_SHOW = "DoNotShowUntilNextRelease"
     PREVIOUS_VERSION = "PreviousVersion"


### PR DESCRIPTION
**Description of work.**

URLs to tutorials on the About widget (window which opens on launch) have been fixed to link to their new locations.

*Question:* Would it be better for the old URLs to redirect to the new ones? This would fix the issue in previous versions. 

**To test:**

Open Mantid and click on the:
 - 'Mantid Introduction'
 - 'Introduction to Python'
 - 'Python in Mantid'
 - 'Extending Mantid with Python'

buttons and check they open to the correct tutorials.

Click the 'Sample Datasets' button and check that it now links to the specific page section for sample datasets.

Fixes #34738 

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
