### PR TITLE
Add support for beam profile to DiscusMultipleScatteringCorrection

### DIFF
--- a/Framework/Algorithms/CMakeLists.txt
+++ b/Framework/Algorithms/CMakeLists.txt
@@ -720,6 +720,7 @@ set(TEST_FILES
     ApplyInstrumentToPeaksTest.h
     ApplyTransmissionCorrectionTest.h
     AverageLogDataTest.h
+    BeamProfileFactoryTest.h
     Bin2DPowderDiffractionTest.h
     BinaryOperateMasksTest.h
     BinaryOperationTest.h

--- a/Framework/Algorithms/CMakeLists.txt
+++ b/Framework/Algorithms/CMakeLists.txt
@@ -17,6 +17,7 @@ set(SRC_FILES
     src/ApplyInstrumentToPeaks.cpp
     src/ApplyTransmissionCorrection.cpp
     src/AverageLogData.cpp
+    src/BeamProfileFactory.cpp
     src/Bin2DPowderDiffraction.cpp
     src/BinaryOperateMasks.cpp
     src/BinaryOperation.cpp
@@ -360,6 +361,7 @@ set(INC_FILES
     inc/MantidAlgorithms/ApplyInstrumentToPeaks.h
     inc/MantidAlgorithms/ApplyTransmissionCorrection.h
     inc/MantidAlgorithms/AverageLogData.h
+    inc/MantidAlgorithms/BeamProfileFactory.h
     inc/MantidAlgorithms/Bin2DPowderDiffraction.h
     inc/MantidAlgorithms/BinaryOperateMasks.h
     inc/MantidAlgorithms/BinaryOperation.h

--- a/Framework/Algorithms/inc/MantidAlgorithms/BeamProfileFactory.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/BeamProfileFactory.h
@@ -8,6 +8,7 @@
 
 #include "MantidAPI/Sample.h"
 #include "MantidAlgorithms/SampleCorrections/IBeamProfile.h"
+#include "MantidGeometry/Instrument.h"
 
 namespace Mantid {
 namespace Algorithms {

--- a/Framework/Algorithms/inc/MantidAlgorithms/BeamProfileFactory.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/BeamProfileFactory.h
@@ -1,6 +1,6 @@
 // Mantid Repository : https://github.com/mantidproject/mantid
 //
-// Copyright &copy; 2007 ISIS Rutherford Appleton Laboratory UKRI,
+// Copyright &copy; 2022 ISIS Rutherford Appleton Laboratory UKRI,
 //   NScD Oak Ridge National Laboratory, European Spallation Source,
 //   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 // SPDX - License - Identifier: GPL - 3.0 +

--- a/Framework/Algorithms/inc/MantidAlgorithms/BeamProfileFactory.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/BeamProfileFactory.h
@@ -1,0 +1,22 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2007 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#pragma once
+
+#include "MantidAPI/Sample.h"
+#include "MantidAlgorithms/SampleCorrections/IBeamProfile.h"
+
+namespace Mantid {
+namespace Algorithms {
+
+class MANTID_ALGORITHMS_DLL BeamProfileFactory {
+public:
+  static std::unique_ptr<IBeamProfile> createBeamProfile(const Geometry::Instrument &instrument,
+                                                         const API::Sample &sample);
+};
+
+} // namespace Algorithms
+} // namespace Mantid

--- a/Framework/Algorithms/inc/MantidAlgorithms/DiscusMultipleScatteringCorrection.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/DiscusMultipleScatteringCorrection.h
@@ -12,6 +12,7 @@
 #include "MantidAPI/Algorithm.h"
 #include "MantidAlgorithms/DllConfig.h"
 #include "MantidAlgorithms/InterpolationOption.h"
+#include "MantidAlgorithms/SampleCorrections/IBeamProfile.h"
 #include "MantidAlgorithms/SampleCorrections/SparseWorkspace.h"
 #include "MantidGeometry/IComponent.h"
 #include "MantidGeometry/Instrument/SampleEnvironment.h"
@@ -82,6 +83,7 @@ protected:
                            std::vector<double> &resultY, const bool returnCumulative);
   API::MatrixWorkspace_sptr integrateWS(const API::MatrixWorkspace_sptr &ws);
   void getXMinMax(const Mantid::API::MatrixWorkspace &ws, double &xmin, double &xmax) const;
+  void prepareSampleBeamGeometry(const API::MatrixWorkspace_sptr &inputWS);
 
 private:
   void init() override;
@@ -143,6 +145,8 @@ private:
   std::shared_ptr<const Geometry::ReferenceFrame> m_refframe;
   const Geometry::SampleEnvironment *m_env{nullptr};
   bool m_NormalizeSQ{};
+  Geometry::BoundingBox m_activeRegion;
+  std::unique_ptr<IBeamProfile> m_beamProfile;
 };
 } // namespace Algorithms
 } // namespace Mantid

--- a/Framework/Algorithms/inc/MantidAlgorithms/SampleCorrections/RectangularBeamProfile.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/SampleCorrections/RectangularBeamProfile.h
@@ -46,7 +46,7 @@ private:
   const unsigned short m_horIdx;
   const double m_width;
   const double m_height;
-  /*std::array<double, 3>*/ Kernel::V3D m_min;
+  Kernel::V3D m_min;
   Kernel::V3D m_beamDir;
 };
 

--- a/Framework/Algorithms/src/BeamProfileFactory.cpp
+++ b/Framework/Algorithms/src/BeamProfileFactory.cpp
@@ -1,0 +1,52 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2018 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation BeamProfileFactory,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+
+#include "MantidAlgorithms/BeamProfileFactory.h"
+#include "MantidAlgorithms/SampleCorrections/CircularBeamProfile.h"
+#include "MantidAlgorithms/SampleCorrections/RectangularBeamProfile.h"
+#include "MantidGeometry/Instrument.h"
+#include "MantidGeometry/Instrument/ReferenceFrame.h"
+#include "MantidGeometry/Instrument/SampleEnvironment.h"
+#include "MantidKernel/V3D.h"
+
+namespace Mantid::Algorithms {
+std::unique_ptr<IBeamProfile> BeamProfileFactory::createBeamProfile(const Geometry::Instrument &instrument,
+                                                                    const API::Sample &sample) {
+  const auto frame = instrument.getReferenceFrame();
+  const auto source = instrument.getSource();
+
+  const std::string beamShapeParam = source->getParameterAsString("beam-shape");
+  if (beamShapeParam == "Slit") {
+    const auto beamWidthParam = source->getNumberParameter("beam-width");
+    const auto beamHeightParam = source->getNumberParameter("beam-height");
+    if (beamWidthParam.size() == 1 && beamHeightParam.size() == 1) {
+      return std::make_unique<RectangularBeamProfile>(*frame, source->getPos(), beamWidthParam[0], beamHeightParam[0]);
+    }
+  } else if (beamShapeParam == "Circle") {
+    const auto beamRadiusParam = source->getNumberParameter("beam-radius");
+    if (beamRadiusParam.size() == 1) {
+      return std::make_unique<CircularBeamProfile>(*frame, source->getPos(), beamRadiusParam[0]);
+    }
+  }
+  // revert to sample dimensions if no return by this point
+  if (!sample.getShape().hasValidShape() && !sample.hasEnvironment()) {
+    throw std::invalid_argument("Cannot determine beam profile without a sample shape and environment");
+  }
+  Kernel::V3D bbox;
+  Kernel::V3D bboxCentre;
+  if (sample.getShape().hasValidShape()) {
+    bbox = sample.getShape().getBoundingBox().width();
+    bboxCentre = sample.getShape().getBoundingBox().centrePoint();
+  } else {
+    bbox = sample.getEnvironment().boundingBox().width();
+    bboxCentre = sample.getEnvironment().boundingBox().centrePoint();
+  }
+  const double beamWidth = 2 * bboxCentre[frame->pointingHorizontal()] + bbox[frame->pointingHorizontal()];
+  const double beamHeight = 2 * bboxCentre[frame->pointingUp()] + bbox[frame->pointingUp()];
+  return std::make_unique<RectangularBeamProfile>(*frame, source->getPos(), beamWidth, beamHeight);
+}
+} // namespace Mantid::Algorithms

--- a/Framework/Algorithms/src/BeamProfileFactory.cpp
+++ b/Framework/Algorithms/src/BeamProfileFactory.cpp
@@ -1,6 +1,6 @@
 // Mantid Repository : https://github.com/mantidproject/mantid
 //
-// Copyright &copy; 2018 ISIS Rutherford Appleton Laboratory UKRI,
+// Copyright &copy; 2022 ISIS Rutherford Appleton Laboratory UKRI,
 //   NScD Oak Ridge National Laboratory, European Spallation BeamProfileFactory,
 //   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 // SPDX - License - Identifier: GPL - 3.0 +
@@ -32,7 +32,7 @@ std::unique_ptr<IBeamProfile> BeamProfileFactory::createBeamProfile(const Geomet
       return std::make_unique<CircularBeamProfile>(*frame, source->getPos(), beamRadiusParam[0]);
     }
   }
-  // revert to sample dimensions if no return by this point
+  // revert to rectangular profile enclosing sample dimensions if no return by this point
   if (!sample.getShape().hasValidShape() && !sample.hasEnvironment()) {
     throw std::invalid_argument("Cannot determine beam profile without a sample shape and environment");
   }
@@ -45,6 +45,7 @@ std::unique_ptr<IBeamProfile> BeamProfileFactory::createBeamProfile(const Geomet
     bbox = sample.getEnvironment().boundingBox().width();
     bboxCentre = sample.getEnvironment().boundingBox().centrePoint();
   }
+  // beam profile always centred on zero so set half width = centre + sample half width
   const double beamWidth = 2 * bboxCentre[frame->pointingHorizontal()] + bbox[frame->pointingHorizontal()];
   const double beamHeight = 2 * bboxCentre[frame->pointingUp()] + bbox[frame->pointingUp()];
   return std::make_unique<RectangularBeamProfile>(*frame, source->getPos(), beamWidth, beamHeight);

--- a/Framework/Algorithms/src/DiscusMultipleScatteringCorrection.cpp
+++ b/Framework/Algorithms/src/DiscusMultipleScatteringCorrection.cpp
@@ -1736,7 +1736,7 @@ const Geometry::IObject *DiscusMultipleScatteringCorrection::updateWeightAndPosi
 
 /**
  * Generate an initial track starting at the source and entering
- * the sample\sample environment at a random point on its front surface
+ * the sample/sample environment at a random point on its front surface
  * @param rng Random number generator
  * @return a track
  */

--- a/Framework/Algorithms/src/DiscusMultipleScatteringCorrection.cpp
+++ b/Framework/Algorithms/src/DiscusMultipleScatteringCorrection.cpp
@@ -15,6 +15,7 @@
 #include "MantidAPI/WorkspaceFactory.h"
 #include "MantidAPI/WorkspaceGroup.h"
 #include "MantidAPI/WorkspaceUnitValidator.h"
+#include "MantidAlgorithms/BeamProfileFactory.h"
 #include "MantidDataObjects/Workspace2D.h"
 #include "MantidDataObjects/WorkspaceCreation.h"
 #include "MantidGeometry/Instrument.h"
@@ -463,14 +464,7 @@ void DiscusMultipleScatteringCorrection::exec() {
                              "AlwaysStoreInADS set to true");
   const MatrixWorkspace_sptr inputWS = getProperty("InputWorkspace");
 
-  m_sampleShape = inputWS->sample().getShapePtr();
-  // generate the bounding box before the multithreaded section
-  m_sampleShape->getBoundingBox();
-  try {
-    m_env = &inputWS->sample().getEnvironment();
-  } catch (std::runtime_error &) {
-    // swallow this as no defined environment from getEnvironment
-  }
+  prepareSampleBeamGeometry(inputWS);
   prepareStructureFactors();
 
   MatrixWorkspace_sptr sigmaSSWS = getProperty("ScatteringCrossSection");
@@ -530,9 +524,6 @@ void DiscusMultipleScatteringCorrection::exec() {
     outputWSs.emplace_back(outputWS);
   }
   const MatrixWorkspace &instrumentWS = useSparseInstrument ? *sparseWS : *inputWS;
-
-  m_refframe = inputWS->getInstrument()->getReferenceFrame();
-  m_sourcePos = inputWS->getInstrument()->getSource()->getPos();
   const auto nhists = useSparseInstrument ? sparseWS->getNumberHistograms() : inputWS->getNumberHistograms();
 
   const int nSingleScatterEvents = getProperty("NeutronPathsSingle");
@@ -1745,22 +1736,18 @@ const Geometry::IObject *DiscusMultipleScatteringCorrection::updateWeightAndPosi
 
 /**
  * Generate an initial track starting at the source and entering
- * the sample at a random point on its front surface
+ * the sample\sample environment at a random point on its front surface
  * @param rng Random number generator
  * @return a track
  */
 Geometry::Track DiscusMultipleScatteringCorrection::generateInitialTrack(Kernel::PseudoRandomNumberGenerator &rng) {
-  auto &sampleBox = m_sampleShape->getBoundingBox();
   // generate random point on front surface of sample bounding box
   // The change of variables from length to t1 means this still samples the points fairly in the integration
   // volume even in shapes like cylinders where the depth varies across xy
-  auto sampleBoxWidth = sampleBox.width();
-  auto ptx = sampleBox.minPoint()[m_refframe->pointingHorizontal()] +
-             rng.nextValue() * sampleBoxWidth[m_refframe->pointingHorizontal()];
-  auto pty =
-      sampleBox.minPoint()[m_refframe->pointingUp()] + rng.nextValue() * sampleBoxWidth[m_refframe->pointingUp()];
+  auto neutron = m_beamProfile->generatePoint(rng, m_activeRegion);
+  auto ptx = neutron.startPos.X();
+  auto pty = neutron.startPos.Y();
 
-  // perhaps eventually also generate random point on the beam profile?
   auto ptOnBeamProfile = Kernel::V3D();
   ptOnBeamProfile[m_refframe->pointingHorizontal()] = ptx;
   ptOnBeamProfile[m_refframe->pointingUp()] = pty;
@@ -1916,6 +1903,25 @@ DiscusMultipleScatteringCorrection::findMatchingComponent(const ComponentWorkspa
   // can't return iterator because boost have moved vec_iterator into a different namespace post v1.65.1 so won't
   // build on all platforms
   return &(*componentWSIt);
+}
+
+void DiscusMultipleScatteringCorrection::prepareSampleBeamGeometry(const API::MatrixWorkspace_sptr &inputWS) {
+  m_sampleShape = inputWS->sample().getShapePtr();
+  try {
+    m_env = &inputWS->sample().getEnvironment();
+  } catch (std::runtime_error &) {
+    // swallow this as no defined environment from getEnvironment
+  }
+  // generate the bounding box before the multithreaded section
+  m_activeRegion = m_sampleShape->getBoundingBox();
+  if (m_env) {
+    const auto &envBox = m_env->boundingBox();
+    m_activeRegion.grow(envBox);
+  }
+  auto instrument = inputWS->getInstrument();
+  m_beamProfile = BeamProfileFactory::createBeamProfile(*instrument, inputWS->sample());
+  m_refframe = instrument->getReferenceFrame();
+  m_sourcePos = instrument->getSource()->getPos();
 }
 
 } // namespace Mantid::Algorithms

--- a/Framework/Algorithms/src/DiscusMultipleScatteringCorrection.cpp
+++ b/Framework/Algorithms/src/DiscusMultipleScatteringCorrection.cpp
@@ -546,7 +546,7 @@ void DiscusMultipleScatteringCorrection::exec() {
   m_importanceSampling = getProperty("ImportanceSampling");
 
   Progress prog(this, 0.0, 1.0, nhists * nSimulationPoints);
-  prog.setNotifyStep(0.01);
+  prog.setNotifyStep(0.1);
   const std::string reportMsg = "Computing corrections";
 
   bool enableParallelFor = true;
@@ -594,8 +594,8 @@ void DiscusMultipleScatteringCorrection::exec() {
 
       for (size_t bin = 0; bin < nbins; bin += xStepSize) {
         const double kinc = std::get<0>(kInW[bin]);
-        if (kinc <= 0) {
-          g_log.warning("Skipping calculation for bin with x<=0, workspace index=" + std::to_string(i) +
+        if ((kinc <= 0) || std::isnan(kinc)) {
+          g_log.warning("Skipping calculation for bin with invalid x, workspace index=" + std::to_string(i) +
                         " bin index=" + std::to_string(std::get<1>(kInW[bin])));
           continue;
         }

--- a/Framework/Algorithms/src/SampleCorrections/MCAbsorptionStrategy.cpp
+++ b/Framework/Algorithms/src/SampleCorrections/MCAbsorptionStrategy.cpp
@@ -9,7 +9,6 @@
 #include "MantidKernel/PseudoRandomNumberGenerator.h"
 #include "MantidKernel/V3D.h"
 
-#include "MantidAlgorithms/SampleCorrections/RectangularBeamProfile.h"
 #include "MantidGeometry/Objects/CSGObject.h"
 
 namespace Mantid {

--- a/Framework/Algorithms/test/BeamProfileFactoryTest.h
+++ b/Framework/Algorithms/test/BeamProfileFactoryTest.h
@@ -9,6 +9,7 @@
 #include "MantidAlgorithms/BeamProfileFactory.h"
 #include "MantidAlgorithms/SampleCorrections/RectangularBeamProfile.h"
 #include "MantidFrameworkTestHelpers/ComponentCreationHelper.h"
+#include "MantidFrameworkTestHelpers/WorkspaceCreationHelper.h"
 #include "MantidGeometry/Instrument/ReferenceFrame.h"
 #include <cxxtest/TestSuite.h>
 

--- a/Framework/Algorithms/test/BeamProfileFactoryTest.h
+++ b/Framework/Algorithms/test/BeamProfileFactoryTest.h
@@ -1,0 +1,45 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2022 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#pragma once
+
+#include "MantidAlgorithms/BeamProfileFactory.h"
+#include "MantidAlgorithms/SampleCorrections/RectangularBeamProfile.h"
+#include "MantidFrameworkTestHelpers/ComponentCreationHelper.h"
+#include "MantidGeometry/Instrument/ReferenceFrame.h"
+#include <cxxtest/TestSuite.h>
+
+class BeamProfileFactoryTest : public CxxTest::TestSuite {
+public:
+  // This pair of boilerplate methods prevent the suite being created statically
+  // This means the constructor isn't called when running other tests
+  static BeamProfileFactoryTest *createSuite() { return new BeamProfileFactoryTest(); }
+  static void destroySuite(BeamProfileFactoryTest *suite) { delete suite; }
+
+  void test_Beam_Height_Calculation_With_Offset_Sample() {
+    using namespace Mantid::Kernel;
+    using namespace Mantid::Algorithms;
+    using namespace Mantid::Geometry;
+    // Define a sample shape
+    constexpr double sampleRadius{0.006};
+    constexpr double sampleHeight{0.04};
+    const V3D sampleBaseCentre{0., sampleHeight / 2., 0.};
+    const V3D yAxis{0., 1., 0.};
+    auto sampleShape = ComponentCreationHelper::createCappedCylinder(sampleRadius, sampleHeight, sampleBaseCentre,
+                                                                     yAxis, "sample-cylinder");
+    auto instrument = std::make_shared<Mantid::Geometry::Instrument>("test");
+    instrument->setReferenceFrame(std::make_shared<ReferenceFrame>(Y, Z, Right, ""));
+    ObjComponent *source = new ObjComponent("moderator");
+    source->setPos(V3D(0.0, 0.0, -20.0));
+    instrument->add(source);
+    instrument->markAsSource(source);
+    Mantid::DataObjects::Workspace2D_sptr ws = WorkspaceCreationHelper::create2DWorkspaceWithFullInstrument(5, 5);
+    ws->mutableSample().setShape(sampleShape);
+    std::shared_ptr<IBeamProfile> beam;
+    TS_ASSERT_THROWS_NOTHING(beam = BeamProfileFactory::createBeamProfile(*instrument, ws->sample()));
+    TS_ASSERT(std::dynamic_pointer_cast<RectangularBeamProfile>(beam)->maxPoint()[1] == 0.06);
+  }
+};

--- a/docs/source/release/v6.6.0/Framework/Algorithms/New_features/34705_AddBeamProfileToDiscus.rst
+++ b/docs/source/release/v6.6.0/Framework/Algorithms/New_features/34705_AddBeamProfileToDiscus.rst
@@ -1,0 +1,1 @@
+- Add support for a beam profile (specified in :ref:`SetBeam <algm-SetBeam>`) to :ref:`DiscusMultipleScatteringCorrection <algm-DiscusMultipleScatteringCorrection>`


### PR DESCRIPTION
**Description of work.**

Add support for specifying a beam profile to the DiscusMultipleScatteringCorrection algorithm. This allows partial illumination of the sample and is similar to the feature available in MonteCarloAbsorption\AddAbsorptionWeightedPathLengths. The user can set up a beam profile by running the SetBeam algorithm on the input workspace prior to calling DiscusMultipleScatteringCorrection.

This was mentioned by Joe Kelleher in a recent talk I did on the algorithm at the ISIS Science Seminar series.

Rather than replicating the code to create a beam profile in a 3rd algorithm I have factored out the code into a new BeamFactory class

I've also included these small fixes:
- the algorithm now handles the input workspace having an x axis containing k=inf values. This correspond to wavelength=0
- the progress reporting is not quite so fine grained
- if a container is specified on the input workspace the initial tracks are sampled across the full cross section of the sample and container in the beam rather than just the sample cross section in the beam. Note - if the user doesn't specify a beam profile it defaults to a rectangular profile equal to the bounding box of the sample even with a container present. So this fix only affects a few edge cases when using the default beam profile eg cylindrical sample\container with axis along z where they present a circular cross section to the beam

**To test:**

Run this script which runs the Discus algorithm twice on a cylindrical sample - once with a beam profile that fully illuminates the sample and once with a restricted beam profile. You can use the new "Show Sample Shape" right click option on the ws to see the sample shape:
```
# import mantid algorithms, numpy and matplotlib
from mantid import mtd
from mantid.simpleapi import *
import matplotlib.pyplot as plt
import numpy as np

# Isotropic S(Q)
X=[1.0]
Y=[1.0]
Sofq_isotropic=CreateWorkspace(DataX=X,DataY=Y,UnitX="MomentumTransfer")

two_thetas=[]
for i in range(180):
    two_thetas.append(i)

# workspace with single bin centred at k=1 Angstrom-1
ws = CreateSampleWorkspace(WorkspaceType="Histogram",
                           XUnit="Momentum",
                           Xmin=0.5,
                           Xmax=1.5,
                           BinWidth=1.0,
                           NumBanks=len(two_thetas)//4,
                           BankPixelWidth=2,
                           InstrumentName="testinst")
# add ring of detectors in yz plane (positive y) from 0 to 180 degrees
ids = list(range(1,len(two_thetas)+1))
EditInstrumentGeometry(ws,
    PrimaryFlightPath=14.0,
    SpectrumIDs=ids,
    L2=[2.0] * len(two_thetas),
    Polar=two_thetas,
    Azimuthal=[90.0] * len(two_thetas),
    DetectorIDs=ids,
    InstrumentName="testinst")

# create cylinder along x axis whose bottom lies on y=0 plane, dimensions in metres
cylinder_xml = " \
<cylinder id='A'> \
  <centre-of-bottom-base x='-0.05' y='0.01' z='0' /> \
  <axis x='1' y='0' z='0' /> \
  <radius val='0.01' /> \
  <height val='0.1' /> \
</cylinder>"

SetSample(InputWorkspace=ws,
          Geometry={'Shape': 'CSG', 'Value': cylinder_xml},
          Material={'NumberDensity': 0.02, 'AttenuationXSection': 0.0,
                    'CoherentXSection': 0.0, 'IncoherentXSection': 0.0, 'ScatteringXSection': 80.0})

results_group  = DiscusMultipleScatteringCorrection(InputWorkspace=ws, StructureFactorWorkspace=Sofq_isotropic,
                                                    OutputWorkspace="MuscatResults", NeutronPathsSingle=1000,
                                                    NeutronPathsMultiple=1, NumberScatterings=1)
result_full_illum = CloneWorkspace("MuscatResults_Scatter_1")
DeleteWorkspace("MuscatResults")

# only illuminate bottom of cylinder, tracks to angles ~10-170 will have further to travel through sample
# Note - dimensions are in cm here
SetBeam(ws, Geometry={'Shape': 'Slit', 'Width': 1.0, 'Height': 0.5})

DiscusMultipleScatteringCorrection(InputWorkspace=ws, StructureFactorWorkspace=Sofq_isotropic,
                                   OutputWorkspace="MuscatResults_Partial", NeutronPathsSingle=1000,
                                   NeutronPathsMultiple=1, NumberScatterings=1)
result_part_illum = CloneWorkspace("MuscatResults_Partial_Scatter_1")
DeleteWorkspace("MuscatResults_Partial")

DeleteWorkspace("Sofq_isotropic")
DeleteWorkspace("ws")
```
When you do "Plot, Bin" on the two output workspaces, the intensity vs angle should be different. This is because the narrowed beam (result_part_illum) means the neutrons have travel further through the sample for mid range angles (eg 20-160 degrees) and less for the extreme angles (~0 and ~180 degrees).

Fixes #34705.

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
