### PR TITLE
Added axis editors on double click for the sliceviewer plot axis

### DIFF
--- a/docs/source/release/v6.6.0/Workbench/SliceViewer/New_features/34608.rst
+++ b/docs/source/release/v6.6.0/Workbench/SliceViewer/New_features/34608.rst
@@ -1,0 +1,1 @@
+- Users can now double click on the SliceViewer plot axis to edit their limits more accurately.

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/presenters/presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/presenters/presenter.py
@@ -548,6 +548,8 @@ class SliceViewXAxisEditor(XAxisEditor):
     def __init__(self, canvas, axes, slice_viewer):
         super(SliceViewXAxisEditor, self).__init__(canvas, axes)
         self.sv = slice_viewer
+        self.ui.logBox.hide()
+        self.ui.gridBox.hide()
 
     def on_ok(self):
         super(SliceViewXAxisEditor, self).on_ok()
@@ -559,6 +561,8 @@ class SliceViewYAxisEditor(YAxisEditor):
     def __init__(self, canvas, axes, slice_viewer):
         super(SliceViewYAxisEditor, self).__init__(canvas, axes)
         self.sv = slice_viewer
+        self.ui.logBox.hide()
+        self.ui.gridBox.hide()
 
     def on_ok(self):
         super(SliceViewYAxisEditor, self).on_ok()

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/presenters/presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/presenters/presenter.py
@@ -431,7 +431,8 @@ class SliceViewer(ObservingPresenter, SliceViewerBasePresenter):
                 self._logger.debug(f"Coordinates transformed into {self.get_frame()} frame, pos={pos}")
                 self._peaks_presenter.add_delete_peak(pos)
                 self.view.data_view.canvas.draw_idle()
-        elif event.dblclick and event.button == data_view.canvas.buttond.get(Qt.LeftButton):
+        elif event.dblclick and event.button == data_view.canvas.buttond.get(Qt.LeftButton)\
+                and not data_view.nonorthogonal_mode:
             if (data_view.ax.xaxis.contains(event)[0]
                  or any(tick.contains(event)[0] for tick in data_view.ax.get_xticklabels())):
                 editor = XAxisEditor(data_view.canvas, data_view.ax)

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/presenters/presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/presenters/presenter.py
@@ -435,12 +435,12 @@ class SliceViewer(ObservingPresenter, SliceViewerBasePresenter):
                 and not data_view.nonorthogonal_mode:
             if (data_view.ax.xaxis.contains(event)[0]
                  or any(tick.contains(event)[0] for tick in data_view.ax.get_xticklabels())):
-                editor = XAxisEditor(data_view.canvas, data_view.ax)
+                editor = SliceViewXAxisEditor(data_view.canvas, data_view.ax, self)
                 editor.move(QCursor.pos())
                 editor.exec_()
             elif (data_view.ax.yaxis.contains(event)[0]
                   or any(tick.contains(event)[0] for tick in data_view.ax.get_yticklabels())):
-                editor = YAxisEditor(data_view.canvas, data_view.ax)
+                editor = SliceViewYAxisEditor(data_view.canvas, data_view.ax, self)
                 editor.move(QCursor.pos())
                 editor.exec_()
 
@@ -541,3 +541,25 @@ class SliceViewer(ObservingPresenter, SliceViewerBasePresenter):
         else:
             extra_cols = {}
         return extra_cols
+
+
+class SliceViewXAxisEditor(XAxisEditor):
+
+    def __init__(self, canvas, axes, slice_viewer):
+        super(SliceViewXAxisEditor, self).__init__(canvas, axes)
+        self.sv = slice_viewer
+
+    def on_ok(self):
+        super(SliceViewXAxisEditor, self).on_ok()
+        self.sv.dimensions_changed()
+
+
+class SliceViewYAxisEditor(YAxisEditor):
+
+    def __init__(self, canvas, axes, slice_viewer):
+        super(SliceViewYAxisEditor, self).__init__(canvas, axes)
+        self.sv = slice_viewer
+
+    def on_ok(self):
+        super(SliceViewYAxisEditor, self).on_ok()
+        self.sv.dimensions_changed()

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/presenters/presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/presenters/presenter.py
@@ -435,12 +435,12 @@ class SliceViewer(ObservingPresenter, SliceViewerBasePresenter):
                 and not data_view.nonorthogonal_mode:
             if (data_view.ax.xaxis.contains(event)[0]
                  or any(tick.contains(event)[0] for tick in data_view.ax.get_xticklabels())):
-                editor = SliceViewXAxisEditor(data_view.canvas, data_view.ax, self)
+                editor = SliceViewXAxisEditor(data_view.canvas, data_view.ax, self.dimensions_changed)
                 editor.move(QCursor.pos())
                 editor.exec_()
             elif (data_view.ax.yaxis.contains(event)[0]
                   or any(tick.contains(event)[0] for tick in data_view.ax.get_yticklabels())):
-                editor = SliceViewYAxisEditor(data_view.canvas, data_view.ax, self)
+                editor = SliceViewYAxisEditor(data_view.canvas, data_view.ax, self.dimensions_changed)
                 editor.move(QCursor.pos())
                 editor.exec_()
 
@@ -545,25 +545,25 @@ class SliceViewer(ObservingPresenter, SliceViewerBasePresenter):
 
 class SliceViewXAxisEditor(XAxisEditor):
 
-    def __init__(self, canvas, axes, slice_viewer):
+    def __init__(self, canvas, axes, dimensions_changed):
         super(SliceViewXAxisEditor, self).__init__(canvas, axes)
-        self.sv = slice_viewer
+        self.dimensions_changed = dimensions_changed
         self.ui.logBox.hide()
         self.ui.gridBox.hide()
 
     def on_ok(self):
         super(SliceViewXAxisEditor, self).on_ok()
-        self.sv.dimensions_changed()
+        self.dimensions_changed()
 
 
 class SliceViewYAxisEditor(YAxisEditor):
 
-    def __init__(self, canvas, axes, slice_viewer):
+    def __init__(self, canvas, axes, dimensions_changed):
         super(SliceViewYAxisEditor, self).__init__(canvas, axes)
-        self.sv = slice_viewer
+        self.dimensions_changed = dimensions_changed
         self.ui.logBox.hide()
         self.ui.gridBox.hide()
 
     def on_ok(self):
         super(SliceViewYAxisEditor, self).on_ok()
-        self.sv.dimensions_changed()
+        self.dimensions_changed()

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/presenters/presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/presenters/presenter.py
@@ -10,6 +10,7 @@ import sys
 
 from mantid.kernel import Logger, SpecialCoordinateSystem
 from qtpy.QtCore import Qt
+from qtpy.QtGui import QCursor
 
 from mantidqt.interfacemanager import InterfaceManager
 from mantidqt.widgets.observers.observing_presenter import ObservingPresenter
@@ -23,6 +24,8 @@ from mantidqt.widgets.sliceviewer.peaksviewer import PeaksViewerPresenter, Peaks
 from mantidqt.widgets.sliceviewer.presenters.base_presenter import SliceViewerBasePresenter
 from mantidqt.widgets.sliceviewer.views.toolbar import ToolItemText
 from mantidqt.widgets.sliceviewer.views.view import SliceViewerView
+
+from workbench.plotting.propertiesdialog import XAxisEditor, YAxisEditor
 
 DBLMAX = sys.float_info.max
 
@@ -419,6 +422,7 @@ class SliceViewer(ObservingPresenter, SliceViewerBasePresenter):
             self._peaks_presenter.clear_observer()
 
     def canvas_clicked(self, event):
+        data_view = self.view.data_view
         if self._peaks_presenter is not None and event.inaxes:
             sliceinfo = self.get_sliceinfo()
             if sliceinfo.can_support_peak_overlay():
@@ -427,6 +431,17 @@ class SliceViewer(ObservingPresenter, SliceViewerBasePresenter):
                 self._logger.debug(f"Coordinates transformed into {self.get_frame()} frame, pos={pos}")
                 self._peaks_presenter.add_delete_peak(pos)
                 self.view.data_view.canvas.draw_idle()
+        elif event.dblclick and event.button == data_view.canvas.buttond.get(Qt.LeftButton):
+            if (data_view.ax.xaxis.contains(event)[0]
+                 or any(tick.contains(event)[0] for tick in data_view.ax.get_xticklabels())):
+                editor = XAxisEditor(data_view.canvas, data_view.ax)
+                editor.move(QCursor.pos())
+                editor.exec_()
+            elif (data_view.ax.yaxis.contains(event)[0]
+                  or any(tick.contains(event)[0] for tick in data_view.ax.get_yticklabels())):
+                editor = YAxisEditor(data_view.canvas, data_view.ax)
+                editor.move(QCursor.pos())
+                editor.exec_()
 
     def key_pressed(self, event) -> None:
         pass

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_sliceviewer_presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_sliceviewer_presenter.py
@@ -337,106 +337,6 @@ class SliceViewerTest(unittest.TestCase):
         self.view.data_view.deactivate_tool.assert_called_once_with(ToolItemText.ZOOM)
         self.view.data_view.track_cursor.setChecked.assert_called_once_with(False)
 
-    @mock.patch("mantidqt.widgets.sliceviewer.presenters.presenter.SliceViewXAxisEditor")
-    def test_x_axes_editor_is_opened_on_x_axes_double_click(self, mock_xaxis_editor):
-        presenter = SliceViewer(None, model=self.model, view=self.view)
-        event = mock.MagicMock()
-        event.dblclick = True
-        event.button = 1
-        self.view.data_view.nonorthogonal_mode = False
-        self.view.data_view.ax = mock.MagicMock()
-        self.view.data_view.ax.xaxis.contains.return_value = (True, {})
-        self.view.data_view.ax.yaxis.contains.return_value = (False, {})
-        self.view.data_view.canvas = mock.MagicMock()
-        self.view.data_view.canvas.buttond = mock.MagicMock()
-        self.view.data_view.canvas.buttond.get.return_value = 1
-
-        presenter.canvas_clicked(event)
-
-        mock_xaxis_editor.assert_called_once()
-
-    @mock.patch("mantidqt.widgets.sliceviewer.presenters.presenter.SliceViewYAxisEditor")
-    def test_y_axes_editor_is_opened_on_y_axes_double_click(self, mock_yaxis_editor):
-        presenter = SliceViewer(None, model=self.model, view=self.view)
-        event = mock.MagicMock()
-        event.dblclick = True
-        event.button = 1
-        self.view.data_view.nonorthogonal_mode = False
-        self.view.data_view.ax = mock.MagicMock()
-        self.view.data_view.ax.yaxis.contains.return_value = (True, {})
-        self.view.data_view.ax.xaxis.contains.return_value = (False, {})
-        self.view.data_view.canvas = mock.MagicMock()
-        self.view.data_view.canvas.buttond = mock.MagicMock()
-        self.view.data_view.canvas.buttond.get.return_value = 1
-
-        presenter.canvas_clicked(event)
-
-        mock_yaxis_editor.assert_called_once()
-
-    @mock.patch("mantidqt.widgets.sliceviewer.presenters.presenter.SliceViewXAxisEditor")
-    def test_x_axes_editor_is_opened_on_x_axes_tick_label_double_click(self, mock_xaxis_editor):
-        presenter = SliceViewer(None, model=self.model, view=self.view)
-        event = mock.MagicMock()
-        event.dblclick = True
-        event.button = 1
-        self.view.data_view.nonorthogonal_mode = False
-        self.view.data_view.ax = mock.MagicMock()
-        tick_label = mock.MagicMock()
-        tick_label.contains.return_value = (True, {})
-        self.view.data_view.ax.get_xticklabels.return_value = [tick_label]
-        self.view.data_view.ax.yaxis.contains.return_value = (False, {})
-        self.view.data_view.canvas = mock.MagicMock()
-        self.view.data_view.canvas.buttond = mock.MagicMock()
-        self.view.data_view.canvas.buttond.get.return_value = 1
-
-        presenter.canvas_clicked(event)
-
-        mock_xaxis_editor.assert_called_once()
-
-    @mock.patch("mantidqt.widgets.sliceviewer.presenters.presenter.SliceViewYAxisEditor")
-    def test_y_axes_editor_is_opened_on_y_axes_tick_label_double_click(self, mock_yaxis_editor):
-        presenter = SliceViewer(None, model=self.model, view=self.view)
-        event = mock.MagicMock()
-        event.dblclick = True
-        event.button = 1
-        self.view.data_view.nonorthogonal_mode = False
-        self.view.data_view.ax = mock.MagicMock()
-        tick_label = mock.MagicMock()
-        tick_label.contains.return_value = (True, {})
-        self.view.data_view.ax.get_yticklabels.return_value = [tick_label]
-        self.view.data_view.ax.xaxis.contains.return_value = (False, {})
-        self.view.data_view.canvas = mock.MagicMock()
-        self.view.data_view.canvas.buttond = mock.MagicMock()
-        self.view.data_view.canvas.buttond.get.return_value = 1
-
-        presenter.canvas_clicked(event)
-
-        mock_yaxis_editor.assert_called_once()
-
-    def test_x_axes_editor_calls_dimensions_changed(self):
-        presenter = SliceViewer(None, model=self.model, view=self.view)
-        presenter.dimensions_changed = mock.MagicMock()
-
-        mock_axes = mock.MagicMock()
-        mock_axes.get_xlim = mock.MagicMock(return_value=[0, 1])
-        xaxes_edit = SliceViewXAxisEditor(canvas=mock.MagicMock(), axes=mock_axes, slice_viewer=presenter)
-
-        xaxes_edit.on_ok()
-
-        presenter.dimensions_changed.assert_called_once()
-
-    def test_y_axes_editor_calls_dimensions_changed(self):
-        presenter = SliceViewer(None, model=self.model, view=self.view)
-        presenter.dimensions_changed = mock.MagicMock()
-
-        mock_axes = mock.MagicMock()
-        mock_axes.get_ylim = mock.MagicMock(return_value=[0, 1])
-        yaxes_edit = SliceViewYAxisEditor(canvas=mock.MagicMock(), axes=mock_axes, slice_viewer=presenter)
-
-        yaxes_edit.on_ok()
-
-        presenter.dimensions_changed.assert_called_once()
-
     @mock.patch("mantidqt.widgets.sliceviewer.presenters.presenter.SliceViewer.get_sliceinfo")
     def test_cut_view_toggled_off(self, mock_get_sliceinfo):
         presenter = SliceViewer(None, model=self.model, view=self.view)
@@ -771,6 +671,110 @@ class SliceViewerTest(unittest.TestCase):
         run_requests_hkl_test(pres3D_no_q_dim, 0, 0)
         pres4D = SliceViewer(mock.Mock(), model=self.model, view=self.view4D)
         run_requests_hkl_test(pres4D, 3, 1)
+
+    @mock.patch("mantidqt.widgets.sliceviewer.presenters.presenter.SliceViewXAxisEditor")
+    def test_x_axes_editor_is_opened_on_x_axes_double_click(self, mock_xaxis_editor):
+        presenter = SliceViewer(None, model=self.model, view=self.view)
+        # mouse event
+        event = mock.MagicMock()
+        event.dblclick = True
+        event.button = 1
+        # conditions to activate the x-axis editor
+        self.view.data_view.nonorthogonal_mode = False
+        self.view.data_view.ax = mock.MagicMock()
+        self.view.data_view.ax.xaxis.contains.return_value = (True, {})
+        self.view.data_view.ax.yaxis.contains.return_value = (False, {})
+        self.view.data_view.canvas = mock.MagicMock()
+        self.view.data_view.canvas.buttond.get.return_value = 1
+
+        presenter.canvas_clicked(event)
+
+        mock_xaxis_editor.assert_called_once()
+
+    @mock.patch("mantidqt.widgets.sliceviewer.presenters.presenter.SliceViewYAxisEditor")
+    def test_y_axes_editor_is_opened_on_y_axes_double_click(self, mock_yaxis_editor):
+        presenter = SliceViewer(None, model=self.model, view=self.view)
+        # mouse event
+        event = mock.MagicMock()
+        event.dblclick = True
+        event.button = 1
+        # conditions to activate the y-axis editor
+        self.view.data_view.nonorthogonal_mode = False
+        self.view.data_view.ax = mock.MagicMock()
+        self.view.data_view.ax.yaxis.contains.return_value = (True, {})
+        self.view.data_view.ax.xaxis.contains.return_value = (False, {})
+        self.view.data_view.canvas = mock.MagicMock()
+        self.view.data_view.canvas.buttond.get.return_value = 1
+
+        presenter.canvas_clicked(event)
+
+        mock_yaxis_editor.assert_called_once()
+
+    @mock.patch("mantidqt.widgets.sliceviewer.presenters.presenter.SliceViewXAxisEditor")
+    def test_x_axes_editor_is_opened_on_x_axes_tick_label_double_click(self, mock_xaxis_editor):
+        presenter = SliceViewer(None, model=self.model, view=self.view)
+        # mouse event
+        event = mock.MagicMock()
+        event.dblclick = True
+        event.button = 1
+        # conditions to activate the x-axis editor
+        self.view.data_view.nonorthogonal_mode = False
+        self.view.data_view.ax = mock.MagicMock()
+        tick_label = mock.MagicMock()
+        tick_label.contains.return_value = (True, {})
+        self.view.data_view.ax.get_xticklabels.return_value = [tick_label]
+        self.view.data_view.ax.yaxis.contains.return_value = (False, {})
+        self.view.data_view.canvas = mock.MagicMock()
+        self.view.data_view.canvas.buttond.get.return_value = 1
+
+        presenter.canvas_clicked(event)
+
+        mock_xaxis_editor.assert_called_once()
+
+    @mock.patch("mantidqt.widgets.sliceviewer.presenters.presenter.SliceViewYAxisEditor")
+    def test_y_axes_editor_is_opened_on_y_axes_tick_label_double_click(self, mock_yaxis_editor):
+        presenter = SliceViewer(None, model=self.model, view=self.view)
+        # mouse event
+        event = mock.MagicMock()
+        event.dblclick = True
+        event.button = 1
+        # conditions to activate the y-axis editor
+        self.view.data_view.nonorthogonal_mode = False
+        self.view.data_view.ax = mock.MagicMock()
+        tick_label = mock.MagicMock()
+        tick_label.contains.return_value = (True, {})
+        self.view.data_view.ax.get_yticklabels.return_value = [tick_label]
+        self.view.data_view.ax.xaxis.contains.return_value = (False, {})
+        self.view.data_view.canvas = mock.MagicMock()
+        self.view.data_view.canvas.buttond.get.return_value = 1
+
+        presenter.canvas_clicked(event)
+
+        mock_yaxis_editor.assert_called_once()
+
+    def test_x_axes_editor_calls_dimensions_changed(self):
+        presenter = SliceViewer(None, model=self.model, view=self.view)
+        presenter.dimensions_changed = mock.MagicMock()
+
+        mock_axes = mock.MagicMock()
+        mock_axes.get_xlim = mock.MagicMock(return_value=[0, 1])
+        xaxes_edit = SliceViewXAxisEditor(canvas=mock.MagicMock(), axes=mock_axes, slice_viewer=presenter)
+
+        xaxes_edit.on_ok()
+
+        presenter.dimensions_changed.assert_called_once()
+
+    def test_y_axes_editor_calls_dimensions_changed(self):
+        presenter = SliceViewer(None, model=self.model, view=self.view)
+        presenter.dimensions_changed = mock.MagicMock()
+
+        mock_axes = mock.MagicMock()
+        mock_axes.get_ylim = mock.MagicMock(return_value=[0, 1])
+        yaxes_edit = SliceViewYAxisEditor(canvas=mock.MagicMock(), axes=mock_axes, slice_viewer=presenter)
+
+        yaxes_edit.on_ok()
+
+        presenter.dimensions_changed.assert_called_once()
 
 
 if __name__ == '__main__':

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_sliceviewer_presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_sliceviewer_presenter.py
@@ -335,6 +335,82 @@ class SliceViewerTest(unittest.TestCase):
         self.view.data_view.deactivate_tool.assert_called_once_with(ToolItemText.ZOOM)
         self.view.data_view.track_cursor.setChecked.assert_called_once_with(False)
 
+    @mock.patch("mantidqt.widgets.sliceviewer.presenters.presenter.SliceViewXAxisEditor")
+    def test_x_axes_editor_is_opened_on_x_axes_double_click(self, mock_xaxis_editor):
+        presenter = SliceViewer(None, model=self.model, view=self.view)
+        event = mock.MagicMock()
+        event.dblclick = True
+        event.button = 1
+        self.view.data_view.nonorthogonal_mode = False
+        self.view.data_view.ax = mock.MagicMock()
+        self.view.data_view.ax.xaxis.contains.return_value = (True, {})
+        self.view.data_view.ax.yaxis.contains.return_value = (False, {})
+        self.view.data_view.canvas = mock.MagicMock()
+        self.view.data_view.canvas.buttond = mock.MagicMock()
+        self.view.data_view.canvas.buttond.get.return_value = 1
+
+        presenter.canvas_clicked(event)
+
+        mock_xaxis_editor.assert_called_once()
+
+    @mock.patch("mantidqt.widgets.sliceviewer.presenters.presenter.SliceViewYAxisEditor")
+    def test_y_axes_editor_is_opened_on_y_axes_double_click(self, mock_yaxis_editor):
+        presenter = SliceViewer(None, model=self.model, view=self.view)
+        event = mock.MagicMock()
+        event.dblclick = True
+        event.button = 1
+        self.view.data_view.nonorthogonal_mode = False
+        self.view.data_view.ax = mock.MagicMock()
+        self.view.data_view.ax.yaxis.contains.return_value = (True, {})
+        self.view.data_view.ax.xaxis.contains.return_value = (False, {})
+        self.view.data_view.canvas = mock.MagicMock()
+        self.view.data_view.canvas.buttond = mock.MagicMock()
+        self.view.data_view.canvas.buttond.get.return_value = 1
+
+        presenter.canvas_clicked(event)
+
+        mock_yaxis_editor.assert_called_once()
+
+    @mock.patch("mantidqt.widgets.sliceviewer.presenters.presenter.SliceViewXAxisEditor")
+    def test_x_axes_editor_is_opened_on_x_axes_tick_lable_double_click(self, mock_xaxis_editor):
+        presenter = SliceViewer(None, model=self.model, view=self.view)
+        event = mock.MagicMock()
+        event.dblclick = True
+        event.button = 1
+        self.view.data_view.nonorthogonal_mode = False
+        self.view.data_view.ax = mock.MagicMock()
+        tick_lable = mock.MagicMock()
+        tick_lable.contains.return_value = (True, {})
+        self.view.data_view.ax.get_xticklabels.return_value = [tick_lable]
+        self.view.data_view.ax.yaxis.contains.return_value = (False, {})
+        self.view.data_view.canvas = mock.MagicMock()
+        self.view.data_view.canvas.buttond = mock.MagicMock()
+        self.view.data_view.canvas.buttond.get.return_value = 1
+
+        presenter.canvas_clicked(event)
+
+        mock_xaxis_editor.assert_called_once()
+
+    @mock.patch("mantidqt.widgets.sliceviewer.presenters.presenter.SliceViewYAxisEditor")
+    def test_y_axes_editor_is_opened_on_y_axes_tick_lable_double_click(self, mock_yaxis_editor):
+        presenter = SliceViewer(None, model=self.model, view=self.view)
+        event = mock.MagicMock()
+        event.dblclick = True
+        event.button = 1
+        self.view.data_view.nonorthogonal_mode = False
+        self.view.data_view.ax = mock.MagicMock()
+        tick_lable = mock.MagicMock()
+        tick_lable.contains.return_value = (True, {})
+        self.view.data_view.ax.get_yticklabels.return_value = [tick_lable]
+        self.view.data_view.ax.xaxis.contains.return_value = (False, {})
+        self.view.data_view.canvas = mock.MagicMock()
+        self.view.data_view.canvas.buttond = mock.MagicMock()
+        self.view.data_view.canvas.buttond.get.return_value = 1
+
+        presenter.canvas_clicked(event)
+
+        mock_yaxis_editor.assert_called_once()
+
     @mock.patch("mantidqt.widgets.sliceviewer.presenters.presenter.SliceViewer.get_sliceinfo")
     def test_cut_view_toggled_off(self, mock_get_sliceinfo):
         presenter = SliceViewer(None, model=self.model, view=self.view)

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_sliceviewer_presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_sliceviewer_presenter.py
@@ -675,17 +675,8 @@ class SliceViewerTest(unittest.TestCase):
     @mock.patch("mantidqt.widgets.sliceviewer.presenters.presenter.SliceViewXAxisEditor")
     def test_x_axes_editor_is_opened_on_x_axes_double_click(self, mock_xaxis_editor):
         presenter = SliceViewer(None, model=self.model, view=self.view)
-        # mouse event
-        event = mock.MagicMock()
-        event.dblclick = True
-        event.button = 1
-        # conditions to activate the x-axis editor
-        self.view.data_view.nonorthogonal_mode = False
-        self.view.data_view.ax = mock.MagicMock()
-        self.view.data_view.ax.xaxis.contains.return_value = (True, {})
-        self.view.data_view.ax.yaxis.contains.return_value = (False, {})
-        self.view.data_view.canvas = mock.MagicMock()
-        self.view.data_view.canvas.buttond.get.return_value = 1
+        event = self._double_left_click_event()
+        self._setup_data_view_for_axes_double_click('x', tick_label=False)
 
         presenter.canvas_clicked(event)
 
@@ -694,17 +685,8 @@ class SliceViewerTest(unittest.TestCase):
     @mock.patch("mantidqt.widgets.sliceviewer.presenters.presenter.SliceViewYAxisEditor")
     def test_y_axes_editor_is_opened_on_y_axes_double_click(self, mock_yaxis_editor):
         presenter = SliceViewer(None, model=self.model, view=self.view)
-        # mouse event
-        event = mock.MagicMock()
-        event.dblclick = True
-        event.button = 1
-        # conditions to activate the y-axis editor
-        self.view.data_view.nonorthogonal_mode = False
-        self.view.data_view.ax = mock.MagicMock()
-        self.view.data_view.ax.yaxis.contains.return_value = (True, {})
-        self.view.data_view.ax.xaxis.contains.return_value = (False, {})
-        self.view.data_view.canvas = mock.MagicMock()
-        self.view.data_view.canvas.buttond.get.return_value = 1
+        event = self._double_left_click_event()
+        self._setup_data_view_for_axes_double_click('y', tick_label=False)
 
         presenter.canvas_clicked(event)
 
@@ -713,19 +695,8 @@ class SliceViewerTest(unittest.TestCase):
     @mock.patch("mantidqt.widgets.sliceviewer.presenters.presenter.SliceViewXAxisEditor")
     def test_x_axes_editor_is_opened_on_x_axes_tick_label_double_click(self, mock_xaxis_editor):
         presenter = SliceViewer(None, model=self.model, view=self.view)
-        # mouse event
-        event = mock.MagicMock()
-        event.dblclick = True
-        event.button = 1
-        # conditions to activate the x-axis editor
-        self.view.data_view.nonorthogonal_mode = False
-        self.view.data_view.ax = mock.MagicMock()
-        tick_label = mock.MagicMock()
-        tick_label.contains.return_value = (True, {})
-        self.view.data_view.ax.get_xticklabels.return_value = [tick_label]
-        self.view.data_view.ax.yaxis.contains.return_value = (False, {})
-        self.view.data_view.canvas = mock.MagicMock()
-        self.view.data_view.canvas.buttond.get.return_value = 1
+        event = self._double_left_click_event()
+        self._setup_data_view_for_axes_double_click('x', tick_label=True)
 
         presenter.canvas_clicked(event)
 
@@ -734,23 +705,40 @@ class SliceViewerTest(unittest.TestCase):
     @mock.patch("mantidqt.widgets.sliceviewer.presenters.presenter.SliceViewYAxisEditor")
     def test_y_axes_editor_is_opened_on_y_axes_tick_label_double_click(self, mock_yaxis_editor):
         presenter = SliceViewer(None, model=self.model, view=self.view)
-        # mouse event
-        event = mock.MagicMock()
-        event.dblclick = True
-        event.button = 1
-        # conditions to activate the y-axis editor
-        self.view.data_view.nonorthogonal_mode = False
-        self.view.data_view.ax = mock.MagicMock()
-        tick_label = mock.MagicMock()
-        tick_label.contains.return_value = (True, {})
-        self.view.data_view.ax.get_yticklabels.return_value = [tick_label]
-        self.view.data_view.ax.xaxis.contains.return_value = (False, {})
-        self.view.data_view.canvas = mock.MagicMock()
-        self.view.data_view.canvas.buttond.get.return_value = 1
+        event = self._double_left_click_event()
+        self._setup_data_view_for_axes_double_click('y', tick_label=True)
 
         presenter.canvas_clicked(event)
 
         mock_yaxis_editor.assert_called_once()
+
+    def _setup_data_view_for_axes_double_click(self, orientation: str, tick_label: bool):
+        self.view.data_view.nonorthogonal_mode = False
+        self.view.data_view.ax = mock.MagicMock()
+        is_x = orientation == 'x'
+        is_y = orientation == 'y'
+        if tick_label:
+            tick_label = mock.MagicMock()
+            tick_label.contains.return_value = (True, {})
+            if is_x:
+                self.view.data_view.ax.get_xticklabels.return_value = [tick_label]
+            elif is_y:
+                self.view.data_view.ax.get_yticklabels.return_value = [tick_label]
+
+            self.view.data_view.ax.xaxis.contains.return_value = (False, {})
+            self.view.data_view.ax.yaxis.contains.return_value = (False, {})
+        else:
+            self.view.data_view.ax.xaxis.contains.return_value = (is_x, {})
+            self.view.data_view.ax.yaxis.contains.return_value = (is_y, {})
+
+        self.view.data_view.canvas = mock.MagicMock()
+        self.view.data_view.canvas.buttond.get.return_value = 1
+
+    def _double_left_click_event(self):
+        event = mock.MagicMock()
+        event.dblclick = True
+        event.button = 1
+        return event
 
     def test_x_axes_editor_calls_dimensions_changed(self):
         presenter = SliceViewer(None, model=self.model, view=self.view)
@@ -758,7 +746,8 @@ class SliceViewerTest(unittest.TestCase):
 
         mock_axes = mock.MagicMock()
         mock_axes.get_xlim = mock.MagicMock(return_value=[0, 1])
-        xaxes_edit = SliceViewXAxisEditor(canvas=mock.MagicMock(), axes=mock_axes, slice_viewer=presenter)
+        xaxes_edit = SliceViewXAxisEditor(canvas=mock.MagicMock(), axes=mock_axes,
+                                          dimensions_changed=presenter.dimensions_changed)
 
         xaxes_edit.on_ok()
 
@@ -770,7 +759,8 @@ class SliceViewerTest(unittest.TestCase):
 
         mock_axes = mock.MagicMock()
         mock_axes.get_ylim = mock.MagicMock(return_value=[0, 1])
-        yaxes_edit = SliceViewYAxisEditor(canvas=mock.MagicMock(), axes=mock_axes, slice_viewer=presenter)
+        yaxes_edit = SliceViewYAxisEditor(canvas=mock.MagicMock(), axes=mock_axes,
+                                          dimensions_changed=presenter.dimensions_changed)
 
         yaxes_edit.on_ok()
 


### PR DESCRIPTION
**Description of work.**

When viewing a normal plot in Mantid you can double click the axis to edit their limits more precisely.
This PR adds this functionality to the SliceViewer.

**To test:**

- Load some data (prefferably some with some distinct features visible in the slice viewer)
- Test that double clicking either axis or axis tick lables brings up the correct axis editor window.
- Edit the axis limits to 'zoom in' on a feature and check that the plot updates expectedly.
- Edit the axis limits to zoom back out to check that the data is preserved.

Fixes #34608

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
