### PR TITLE
DAT files are also accepted by UpdateInstrumentFromFile

### DIFF
--- a/Framework/DataHandling/src/UpdateInstrumentFromFile.cpp
+++ b/Framework/DataHandling/src/UpdateInstrumentFromFile.cpp
@@ -48,7 +48,7 @@ void UpdateInstrumentFromFile::init() {
   declareProperty(std::make_unique<WorkspaceProperty<MatrixWorkspace>>("Workspace", "Anonymous", Direction::InOut),
                   "The name of the workspace in which to store the imported instrument");
   declareProperty(std::make_unique<FileProperty>("Filename", "", FileProperty::Load,
-                                                 std::vector<std::string>{".raw", ".nxs", ".s*"}),
+                                                 std::vector<std::string>{".raw", ".nxs", ".dat", ".s*"}),
                   "The filename of the input file.\n"
                   "Currently supports RAW, ISIS NeXus, DAT & multi-column (at "
                   "least 2) ascii files");

--- a/docs/source/release/v6.6.0/Framework/Algorithms/Bugfixes/34768.rst
+++ b/docs/source/release/v6.6.0/Framework/Algorithms/Bugfixes/34768.rst
@@ -1,0 +1,1 @@
+The algorithm GUI for UpdateInstrumentFromFile now accepts .DAT files for the Filename property.


### PR DESCRIPTION
**Description of work.**
This PR updates the algorithm documentation for UpdateInstrumentFromFile. It also appears to accept .dat files but this is not made very clear in the documentation.

**To test:**
Make sure the changes look sensible

*This does not require release notes* because **its a very minor change to documentation**


#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
