### PR TITLE
Prevented matplotlib 3.5 deprecation error with SliceViewer

### DIFF
--- a/Framework/PythonInterface/mantid/plots/axesfunctions.py
+++ b/Framework/PythonInterface/mantid/plots/axesfunctions.py
@@ -62,6 +62,7 @@ def _pcolormesh_nonortho(axes, workspace, nonortho_tr, *args, **kwargs):
     X, Y = numpy.meshgrid(x, y)
     xx, yy = nonortho_tr(X, Y)
     _setLabels2D(axes, workspace, indices, transpose)
+    axes.grid(False)
     mesh = axes.pcolormesh(xx, yy, z, *args, **kwargs)
     return QuadMeshWrapper(mesh)
 

--- a/docs/source/release/v6.6.0/Workbench/SliceViewer/Bugfixes/34648.rst
+++ b/docs/source/release/v6.6.0/Workbench/SliceViewer/Bugfixes/34648.rst
@@ -1,0 +1,1 @@
+* Fixed a bug in sliceviewer where a matplotlib deprecation warning appears when toggling on the nonorthogonal axes.


### PR DESCRIPTION
**Description of work.**

Set `axes.grid(False)` in Sliceviewer's nonorthogonal view to prevent deprecation warning.

**To test:**
1. Follow instructions in #34648 

Fixes #34648 


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
