### PR TITLE
Update technical release manager instructions

### DIFF
--- a/dev-docs/source/ReleaseChecklist.rst
+++ b/dev-docs/source/ReleaseChecklist.rst
@@ -110,13 +110,13 @@ Manual Testing
 *  Ensure that Manual testing begins by creating the testing tasks as GitHub issues, assigning them and posting on
    Slack. Most of our Manual testing instructions are :ref:`here <Testing>`. Generate the Manual testing issues by
    following the instructions in the
-   `README file <https://github.com/mantidproject/documents/tree/main/Project-Management/Tools/RoadmapUpdate>`__.
+   `README file <https://github.com/mantidproject/documents/tree/main/Project-Management/Tools/RoadmapUpdate>`_.
    Please raise the issues from the ISIS and Non-ISIS manual testing spreadsheets.
 *  Over the next week, check the Manual testing GitHub issues. Testers should raise any
    serious problems as separate GitHub issues with a relevant milestone. When testing tasks are complete and all serious
    problems raised as issues, then the testing GitHub issue should be closed.
 *  Manual testing at ISIS as of release 6.3, has taken the form of
-   `Ensemble Manual Testing <https://github.com/mantidproject/documents/blob/main/Project-Management/Tools/RoadmapUpdate/Ensemble%20Manual%20Testing.pptx>`__.
+   `Ensemble Manual Testing <https://github.com/mantidproject/documents/blob/main/Project-Management/Tools/RoadmapUpdate/Ensemble%20Manual%20Testing.pptx>`_.
    In short, testing teams of around 3-5 developers, spread across sub-teams
    are assigned tasks with the code expert in that testing team.
 
@@ -137,7 +137,7 @@ Smoke Testing
 *  It is likely that many changes have been made over the beta test period, therefore
    we must do some more manual testing to ensure everything still works. This stage is
    called Smoke testing. Generate the Smoke testing issues by following the instructions
-   `here <https://github.com/mantidproject/documents/tree/main/Project-Management/Tools/RoadmapUpdate/SmokeTesting>`__.
+   `here <https://github.com/mantidproject/documents/tree/main/Project-Management/Tools/RoadmapUpdate/SmokeTesting>`_.
 *  Liaise with the Technical Release Manager and together announce the creation of the
    Smoke testing issues and Release Candidates in the *\#general* slack channel.
 
@@ -323,11 +323,11 @@ Code Freeze
 **Create the Release Branch (once most PR's are merged)**
 
 * Ensure the latest `main nightly deployment pipeline
-  <https://builds.mantidproject.org/view/Nightly%20Pipelines/job/main_nightly_deployment_prototype/>`__
+  <https://builds.mantidproject.org/view/Nightly%20Pipelines/job/main_nightly_deployment_prototype/>`_
   has passed for all build environments. If it fails, decide if a fix is needed before moving on to
   the next steps.
 * Click ``Build Now`` on `open-release-testing
-  <https://builds.mantidproject.org/view/All/job/open-release-testing/>`__,
+  <https://builds.mantidproject.org/view/All/job/open-release-testing/>`_,
   which will perform the following actions:
 
   * Create or update the ``release-next`` branch.
@@ -340,7 +340,7 @@ Code Freeze
   pull requests not targeted for this release out of the milestone, and then change
   the base branch of the remaining pull requests to ``release-next``. You can either
   manually change the base branch in GitHub or use the `update-pr-base-branch.py
-  <https://github.com/mantidproject/mantid/blob/main/tools/scripts/update-pr-base-branch.py>`__
+  <https://github.com/mantidproject/mantid/blob/main/tools/scripts/update-pr-base-branch.py>`_
   script to update the base branches of these pull requests.
   A quick example to show how the arguments should be provided to this script is seen below:
 
@@ -383,7 +383,7 @@ have been fixed. Then:
 * Liaise with the release editor to ensure that they have completed all of their tasks.
 * Check the release notes and verify that the "Under Construction" paragraph on the main
   index page has been removed. Remove the paragraph if it still exists.
-* Run the `close-release-testing <https://builds.mantidproject.org/view/All/job/close-release-testing>`__
+* Run the `close-release-testing <https://builds.mantidproject.org/view/All/job/close-release-testing>`_
   job, which will do the following:
 
   * Disable the job that periodically merges ``release-next`` into ``main``.
@@ -395,15 +395,15 @@ have been fixed. Then:
 We are now ready to create the release candidates for Smoke testing.
 
 * On the ``release-next`` branch, check whether the `git SHA
-  <https://github.com/mantidproject/mantid/blob/343037c685c0aca9151523d6a3e105504f8cf218/scripts/ExternalInterfaces/CMakeLists.txt#L11>`__
+  <https://github.com/mantidproject/mantid/blob/343037c685c0aca9151523d6a3e105504f8cf218/scripts/ExternalInterfaces/CMakeLists.txt#L11>`_
   for MSlice is up to date. If not, create a PR to update it and ask a gatekeeper to merge it.
 * On the ``release-next`` branch, create a PR to update the `major & minor
-  <https://github.com/mantidproject/mantid/blob/release-next/buildconfig/CMake/VersionNumber.cmake>`__
+  <https://github.com/mantidproject/mantid/blob/release-next/buildconfig/CMake/VersionNumber.cmake>`_
   versions accordingly. Also, uncomment ``VERSION_PATCH`` and set it to ``0``. Ask a gatekeeper to merge the PR.
 * Ask a gatekeeper to merge the ``release-next`` branch back to ``main`` locally, and then comment
   out the ``VERSION_PATCH`` on the ``main`` branch. They should then commit and push these changes
   directly to the remote ``main`` without making a PR.
-* Build the `release-next_nightly_deployment Jenkins pipeline <https://builds.mantidproject.org/view/Release%20Pipeline/>`__
+* Build the `release-next_nightly_deployment Jenkins pipeline <https://builds.mantidproject.org/view/Release%20Pipeline/>`_
   with the following parameters (most are already defaulted to the correct values):
 
   * set ``BUILD_DEVEL`` to ``all``
@@ -420,7 +420,7 @@ We are now ready to create the release candidates for Smoke testing.
 
 * Once the packages have been published to GitHub and Anaconda, ask someone in the ISIS core or DevOps
   team to manually sign the Windows binary and re-upload it to the GitHub
-  `draft release <https://github.com/mantidproject/mantid/releases>`__.
+  `draft release <https://github.com/mantidproject/mantid/releases>`_.
 * Liaise with the Quality Assurance Manager and together announce the creation of the smoke testing
   issues and Release Candidates in the *\#general* slack channel.
 
@@ -430,16 +430,16 @@ Release Day
 Check with the Quality Assurance Manager that the Smoke testing has been completed, and any issues
 have been fixed.
 
-*  Edit the `draft release <https://github.com/mantidproject/mantid/releases>`__ on
+*  Edit the `draft release <https://github.com/mantidproject/mantid/releases>`_ on
    GitHub. A new tag should be created based off the release branch in the form ``vX.Y.Z``. The
    description of the new release can be copied from the release notes ``index.rst`` file, and
    edited appropriately. See previous release descriptions for inspiration.
 *  Publish the GitHub release. This will create the tag required to generate the DOI.
 *  Change the labels for the release candidates on our `Anaconda site <https://anaconda.org/mantid/mantid/files>`_
    from ``rcN`` to ``main``. You may need to ask a member of the ISIS core or DevOps team to do this.
-*  Update the `download page <https://download.mantidproject.org>`__ by running the `Update latest release links
-   <https://github.com/mantidproject/www/actions/workflows/update-latest-release.yml>`__ workflow in the
-   `mantidproject/www repository <https://github.com/mantidproject/www>`__.
+*  Update the `download page <https://download.mantidproject.org>`_ by running the `Update latest release links
+   <https://github.com/mantidproject/www/actions/workflows/update-latest-release.yml>`_ workflow in the
+   `mantidproject/www repository <https://github.com/mantidproject/www>`_.
 *  Create a PR targeting the ``preprod`` branch in the `daaas-ansible-worksapce repository
    <https://github.com/ral-facilities/daaas-ansible-workspace>`_ to add the new release to IDAaaS. Add the new release
    version to the list of versions installed on IDAaaS `here
@@ -451,7 +451,7 @@ have been fixed.
 **Generate DOI**
 
 This requires that a tag has been created for this release. This tag is created when you draft and
-publish a new `release <https://github.com/mantidproject/mantid/releases>`__ on GitHub.
+publish a new `release <https://github.com/mantidproject/mantid/releases>`_ on GitHub.
 
 *  Make sure that you have updated your local copy of git to grab the new tag.
    ``git fetch -p``

--- a/dev-docs/source/ReleaseChecklist.rst
+++ b/dev-docs/source/ReleaseChecklist.rst
@@ -298,9 +298,9 @@ Code Freeze
 
 **Create the Release Branch (once most PR's are merged)**
 
-*  Ensure the `main build and system test
-   <https://builds.mantidproject.org/view/Main%20Pipeline/>`__
-   jobs have passed for all build environments for this release.
+*  Ensure the latest `main nightly deployment pipeline
+   https://builds.mantidproject.org/view/Nightly%20Pipelines/job/main_nightly_deployment_prototype/`__
+   has passed for all build environments.
 *  Run `open-release-testing
    <https://builds.mantidproject.org/view/All/job/open-release-testing/>`__
    to create the release branch and prepare build jobs by clicking ``Build Now``.

--- a/dev-docs/source/ReleaseChecklist.rst
+++ b/dev-docs/source/ReleaseChecklist.rst
@@ -107,14 +107,14 @@ with the Release Manager.
 Manual Testing
 ###############
 
-*  Ensure that Manual testing begins by creating the testing tasks as Github issues, assigning them and posting on
+*  Ensure that Manual testing begins by creating the testing tasks as GitHub issues, assigning them and posting on
    Slack. Most of our Manual testing instructions are :ref:`here <Testing>`. Generate the Manual testing issues by
    following the instructions in the
    `README file <https://github.com/mantidproject/documents/tree/main/Project-Management/Tools/RoadmapUpdate>`__.
    Please raise the issues from the ISIS and Non-ISIS manual testing spreadsheets.
-*  Over the next week, check the Manual testing Github issues. Testers should raise any
-   serious problems as separate Github issues with a relevant milestone. When testing tasks are complete and all serious
-   problems raised as issues, then the testing Github issue should be closed.
+*  Over the next week, check the Manual testing GitHub issues. Testers should raise any
+   serious problems as separate GitHub issues with a relevant milestone. When testing tasks are complete and all serious
+   problems raised as issues, then the testing GitHub issue should be closed.
 *  Manual testing at ISIS as of release 6.3, has taken the form of
    `Ensemble Manual Testing <https://github.com/mantidproject/documents/blob/main/Project-Management/Tools/RoadmapUpdate/Ensemble%20Manual%20Testing.pptx>`__.
    In short, testing teams of around 3-5 developers, spread across sub-teams
@@ -303,7 +303,10 @@ After the Technical Release Manager has finished their release day tasks:
 *  Also post the contents of the message to the *\#announcements* channel on
    Slack.
 *  Create a new item on the forum news.
-*  Close the release milestone on github.
+*  Add a news item linking to the forum post on the `mantidproject website <https://www.mantidproject.org>`_
+   by manually editing `sidebar-news.html <https://github.com/mantidproject/www/blob/main/source/_templates/sidebar-news.html>`_.
+   Restrict the number of news items to five.
+*  Close the release milestone on GitHub.
 
 .. _technical-release-manager-checklist:
 
@@ -324,7 +327,7 @@ Code Freeze
   has passed for all build environments. If it fails, decide if a fix is needed before moving on to
   the next steps.
 * Click ``Build Now`` on `open-release-testing
-  <https://builds.mantidproject.org/view/All/job/open-release-testing/>`__
+  <https://builds.mantidproject.org/view/All/job/open-release-testing/>`__,
   which will perform the following actions:
 
   * Create or update the ``release-next`` branch.
@@ -336,9 +339,9 @@ Code Freeze
   should be kept for the release, liaise with the Release Manager on this. Move any
   pull requests not targeted for this release out of the milestone, and then change
   the base branch of the remaining pull requests to ``release-next``. You can either
-  manually change the base branch in GitHub or use the following script to update
-  the base branches of these pull requests `update-pr-base-branch.py
+  manually change the base branch in GitHub or use the `update-pr-base-branch.py
   <https://github.com/mantidproject/mantid/blob/main/tools/scripts/update-pr-base-branch.py>`__
+  script to update the base branches of these pull requests.
   A quick example to show how the arguments should be provided to this script is seen below:
 
 .. code-block:: bash
@@ -416,7 +419,7 @@ We are now ready to create the release candidates for Smoke testing.
     and ``N`` is an incremental build number for release candidates, starting at ``1``.
 
 * Once the packages have been published to GitHub and Anaconda, ask someone in the ISIS core or DevOps
-  team to manually sign the Windows binary and re-upload it to the github
+  team to manually sign the Windows binary and re-upload it to the GitHub
   `draft release <https://github.com/mantidproject/mantid/releases>`__.
 * Liaise with the Quality Assurance Manager and together announce the creation of the smoke testing
   issues and Release Candidates in the *\#general* slack channel.
@@ -432,10 +435,18 @@ have been fixed.
    description of the new release can be copied from the release notes ``index.rst`` file, and
    edited appropriately. See previous release descriptions for inspiration.
 *  Publish the GitHub release. This will create the tag required to generate the DOI.
-*  Update the `download page <https://download.mantidproject.org>`__ by creating a PR after
-   following the instructions in the `Adding a new release section
-   <https://github.com/mantidproject/download.mantidproject.org#adding-a-new-release>`__. Once the
-   new file in the `releases` directory is merged, Jenkins will publish the new page.
+*  Change the labels for the release candidates on our `Anaconda site <https://anaconda.org/mantid/mantid/files>`_
+   from ``rcN`` to ``main``. You may need to ask a member of the ISIS core or DevOps team to do this.
+*  Update the `download page <https://download.mantidproject.org>`__ by running the `Update latest release links
+   <https://github.com/mantidproject/www/actions/workflows/update-latest-release.yml>`__ workflow in the
+   `mantidproject/www repository <https://github.com/mantidproject/www>`__.
+*  Create a PR targeting the ``preprod`` branch in the `daaas-ansible-worksapce repository
+   <https://github.com/ral-facilities/daaas-ansible-workspace>`_ to add the new release to IDAaaS. Add the new release
+   version to the list of versions installed on IDAaaS `here
+   <https://github.com/ral-facilities/daaas-ansible-workspace/blob/master/roles/software/analysis/mantid/defaults/main.yml>`_
+   making sure that there are only three ``mantid_versions`` in the list (delete the oldest one if applicable).
+   The changes need to be verified on an IDAaaS test instance before the PR is created. Ask a member of the
+   ISIS core team for assistance if you don't have access to this repository.
 
 **Generate DOI**
 

--- a/dev-docs/source/ReleaseChecklist.rst
+++ b/dev-docs/source/ReleaseChecklist.rst
@@ -349,7 +349,14 @@ Code Freeze
 * Inform other developers that ``release-next`` has been created by posting to the
   *\#announcements* slack channel. You can use an adapted version of the
   following announcement:
-    The release branch for <version>, called ``release-next``, has now been created: https://github.com/mantidproject/mantid/tree/release-next.  If you've not worked with the release/main/-branch workflow before then please take a moment to familiarise yourself with the process: https://developer.mantidproject.org/GitWorkflow.html#code-freeze. The part about ensuring new branches have the correct parent is the most important part (although this can be corrected afterwards). All branches and PRs that were created before this release branch was created are fine, as their history is the same as ``main``.
+
+  * The release branch for <version>, called ``release-next``, has now been created:
+    https://github.com/mantidproject/mantid/tree/release-next. If you've not worked with
+    the release/main/-branch workflow before then please take a moment to familiarise
+    yourself with the process: https://developer.mantidproject.org/GitWorkflow.html#code-freeze.
+    The part about ensuring new branches have the correct parent is the most important part
+    (although this can be corrected afterwards). All branches and PRs that were created
+    before this release branch was created are fine, as their history is the same as ``main``.
 
 **Create Release Notes Skeleton**
 

--- a/dev-docs/source/ReleaseChecklist.rst
+++ b/dev-docs/source/ReleaseChecklist.rst
@@ -304,7 +304,7 @@ Code Freeze
    the next steps.
 *  Click ``Build Now`` on `open-release-testing
    <https://builds.mantidproject.org/view/All/job/open-release-testing/>`__
-   to create the ``release-next`` branch and disable the main nightly deployment jobs.
+   to create the ``release-next`` branch and to prepare build jobs.
 *  Check the state of all open pull requests for this milestone and decide which
    should be kept for the release, liaise with the Release Manager on this. Move any
    pull requests not targeted for release out of the milestone, and then change the base branch
@@ -318,13 +318,13 @@ Code Freeze
     python update-pr-base-branch.py [milestone] [newbase] --token [generated_token]
     python update-pr-base-branch.py "Release 6.1" "release-next" --token fake123gener8ed456token
 
-*  Inform other developers that release-next has been created by posting to the
+*  Inform other developers that ``release-next`` has been created by posting to the
    *\#announcements* slack channel. You can use an adapted version of the
    following announcement:
 
   .. code
 
-  The release branch for <version>, called release-next, has now been created: https://github.com/mantidproject/mantid/tree/release-next.  If you've not worked with the release/main/-branch workflow before then please take a moment to familiarise yourself with the process: https://developer.mantidproject.org/GitWorkflow.html#code-freeze. The part about ensuring new branches have the correct parent is the most important part (although this can be corrected afterwards). All branches and PRs that were created before this release branch was created are fine, as their history is the same as ``main``.
+  The release branch for <version>, called ``release-next``, has now been created: https://github.com/mantidproject/mantid/tree/release-next.  If you've not worked with the release/main/-branch workflow before then please take a moment to familiarise yourself with the process: https://developer.mantidproject.org/GitWorkflow.html#code-freeze. The part about ensuring new branches have the correct parent is the most important part (although this can be corrected afterwards). All branches and PRs that were created before this release branch was created are fine, as their history is the same as ``main``.
 
 **Create Release Notes Skeleton**
 

--- a/dev-docs/source/ReleaseChecklist.rst
+++ b/dev-docs/source/ReleaseChecklist.rst
@@ -300,10 +300,11 @@ Code Freeze
 
 *  Ensure the latest `main nightly deployment pipeline
    https://builds.mantidproject.org/view/Nightly%20Pipelines/job/main_nightly_deployment_prototype/`__
-   has passed for all build environments.
-*  Run `open-release-testing
+   has passed for all build environments. If it fails, decide if a fix is needed before moving on to
+   the next steps.
+*  Click ``Build Now`` on `open-release-testing
    <https://builds.mantidproject.org/view/All/job/open-release-testing/>`__
-   to create the release branch and prepare build jobs by clicking ``Build Now``.
+   to create the ``release-next`` branch and disable the main nightly deployment jobs.
 *  Check the state of all open pull requests for this milestone and decide which
    should be kept for the release, liaise with the Release Manager on this. Move any
    pull requests not targeted for release out of the milestone, and then change the base branch

--- a/dev-docs/source/ReleaseChecklist.rst
+++ b/dev-docs/source/ReleaseChecklist.rst
@@ -440,13 +440,13 @@ have been fixed.
 *  Update the `download page <https://download.mantidproject.org>`_ by running the `Update latest release links
    <https://github.com/mantidproject/www/actions/workflows/update-latest-release.yml>`_ workflow in the
    `mantidproject/www repository <https://github.com/mantidproject/www>`_.
-*  Create a PR targeting the ``preprod`` branch in the `daaas-ansible-worksapce repository
-   <https://github.com/ral-facilities/daaas-ansible-workspace>`_ to add the new release to IDAaaS. Add the new release
-   version to the list of versions installed on IDAaaS `here
-   <https://github.com/ral-facilities/daaas-ansible-workspace/blob/master/roles/software/analysis/mantid/defaults/main.yml>`_
-   making sure that there are only three ``mantid_versions`` in the list (delete the oldest one if applicable).
-   The changes need to be verified on an IDAaaS test instance before the PR is created. Ask a member of the
-   ISIS core team for assistance if you don't have access to this repository.
+*  Ask someone with access to the `daaas-ansible-workspace repository
+   <https://github.com/ral-facilities/daaas-ansible-workspace>`_ (a member of the ISIS core team or IDAaaS support)
+   to add the new release to IDAaaS. They can do this by creating a PR targeting the ``preprod`` branch, adding
+   the new release version to the list of versions installed on IDAaaS `here
+   <https://github.com/ral-facilities/daaas-ansible-workspace/blob/master/roles/software/analysis/mantid/defaults/main.yml>`_.
+   Make sure that there are only three ``mantid_versions`` in the list (delete the oldest one if applicable).
+   The changes need to be verified on an IDAaaS test instance before the PR can be accepted.
 
 **Generate DOI**
 

--- a/dev-docs/source/ReleaseChecklist.rst
+++ b/dev-docs/source/ReleaseChecklist.rst
@@ -319,33 +319,37 @@ Code Freeze
 
 **Create the Release Branch (once most PR's are merged)**
 
-*  Ensure the latest `main nightly deployment pipeline
-   https://builds.mantidproject.org/view/Nightly%20Pipelines/job/main_nightly_deployment_prototype/`__
-   has passed for all build environments. If it fails, decide if a fix is needed before moving on to
-   the next steps.
-*  Click ``Build Now`` on `open-release-testing
-   <https://builds.mantidproject.org/view/All/job/open-release-testing/>`__
-   to create the ``release-next`` branch and to prepare build jobs.
-*  Check the state of all open pull requests for this milestone and decide which
-   should be kept for the release, liaise with the Release Manager on this. Move any
-   pull requests not targeted for release out of the milestone, and then change the base branch
-   of the remaining pull requests to ``release-next``. You can use the following script
-   to update the base branches of these pull requests `update-pr-base-branch.py
-   <https://github.com/mantidproject/mantid/blob/main/tools/scripts/update-pr-base-branch.py>`__
-   A quick example to show how the arguments should be provided to this script is seen below:
+* Ensure the latest `main nightly deployment pipeline
+  <https://builds.mantidproject.org/view/Nightly%20Pipelines/job/main_nightly_deployment_prototype/>`__
+  has passed for all build environments. If it fails, decide if a fix is needed before moving on to
+  the next steps.
+* Click ``Build Now`` on `open-release-testing
+  <https://builds.mantidproject.org/view/All/job/open-release-testing/>`__
+  which will perform the following actions:
+
+  * Create or update the ``release-next`` branch.
+  * Enable the job to periodically merge ``release-next`` into ``main``.
+  * Enable the ``release-next_nightly_deployment`` pipeline.
+  * Disable the ``main_nightly_deployment_prototype`` pipeline.
+
+* Check the state of all open pull requests for this milestone and decide which
+  should be kept for the release, liaise with the Release Manager on this. Move any
+  pull requests not targeted for this release out of the milestone, and then change
+  the base branch of the remaining pull requests to ``release-next``. You can either
+  manually change the base branch in GitHub or use the following script to update
+  the base branches of these pull requests `update-pr-base-branch.py
+  <https://github.com/mantidproject/mantid/blob/main/tools/scripts/update-pr-base-branch.py>`__
+  A quick example to show how the arguments should be provided to this script is seen below:
 
 .. code-block:: bash
 
     python update-pr-base-branch.py [milestone] [newbase] --token [generated_token]
     python update-pr-base-branch.py "Release 6.1" "release-next" --token fake123gener8ed456token
 
-*  Inform other developers that ``release-next`` has been created by posting to the
-   *\#announcements* slack channel. You can use an adapted version of the
-   following announcement:
-
-  .. code
-
-  The release branch for <version>, called ``release-next``, has now been created: https://github.com/mantidproject/mantid/tree/release-next.  If you've not worked with the release/main/-branch workflow before then please take a moment to familiarise yourself with the process: https://developer.mantidproject.org/GitWorkflow.html#code-freeze. The part about ensuring new branches have the correct parent is the most important part (although this can be corrected afterwards). All branches and PRs that were created before this release branch was created are fine, as their history is the same as ``main``.
+* Inform other developers that ``release-next`` has been created by posting to the
+  *\#announcements* slack channel. You can use an adapted version of the
+  following announcement:
+    The release branch for <version>, called ``release-next``, has now been created: https://github.com/mantidproject/mantid/tree/release-next.  If you've not worked with the release/main/-branch workflow before then please take a moment to familiarise yourself with the process: https://developer.mantidproject.org/GitWorkflow.html#code-freeze. The part about ensuring new branches have the correct parent is the most important part (although this can be corrected afterwards). All branches and PRs that were created before this release branch was created are fine, as their history is the same as ``main``.
 
 **Create Release Notes Skeleton**
 
@@ -366,31 +370,49 @@ Smoke Testing
 Check with the Quality Assurance Manager that the initial Manual testing has been completed, and any issues
 have been fixed. Then:
 
-*  Email ``mantid-builder@mantidproject.org`` and ask that a new token be generated for
-   the instrument updates and placed in the appropriate place in Jenkins.
-*  Check the release notes and verify that the "Under Construction" paragraph on the main
-   index page has been removed. Remove the paragraph if it still exists.
-*  Disable release deploy jobs by building the
-   `close-release-testing <https://builds.mantidproject.org/view/All/job/close-release-testing>`__
-   job.
+* Liaise with the release editor to ensure that they have completed all of their tasks.
+* Check the release notes and verify that the "Under Construction" paragraph on the main
+  index page has been removed. Remove the paragraph if it still exists.
+* Run the `close-release-testing <https://builds.mantidproject.org/view/All/job/close-release-testing>`__
+  job, which will do the following:
+
+  * Disable the job that periodically merges ``release-next`` into ``main``.
+  * Disable the ``release-next_nightly_deployment`` pipeline.
+  * Enable the ``main_nightly_deployment_prototype`` pipeline.
 
 **Create the Release Candidates**
 
-We are now ready to create the release candidates ready for Smoke testing.
+We are now ready to create the release candidates for Smoke testing.
 
-*  On the ``release-next`` branch, check whether the `git SHA
-   <https://github.com/mantidproject/mantid/blob/343037c685c0aca9151523d6a3e105504f8cf218/scripts/ExternalInterfaces/CMakeLists.txt#L11>`__
-   for MSlice is up to date. If not, create a PR to update it.
-*  On the ``release-next`` branch, create a PR to update the `major & minor
-   <https://github.com/mantidproject/mantid/blob/release-next/buildconfig/CMake/VersionNumber.cmake>`__
-   versions accordingly. Also, uncomment ``VERSION_PATCH`` and set it to ``0``.
-*  Ask a gatekeeper to: merge the ``release-next`` branch back to ``main`` locally, and then comment
-   out the ``VERSION_PATCH`` on the ``main`` branch. They should then commit and push these changes
-   directly to the remote ``main`` without making a PR.
-*  Build the `release kit builds <https://builds.mantidproject.org/view/Release%20Pipeline/>`__
-   and set the ``PACKAGE_SUFFIX`` parameter to an empty string
-*  Liaise with the Quality Assurance Manager and together announce the creation of the
-   Smoke testing issues and Release Candidates in the *\#general* slack channel.
+* On the ``release-next`` branch, check whether the `git SHA
+  <https://github.com/mantidproject/mantid/blob/343037c685c0aca9151523d6a3e105504f8cf218/scripts/ExternalInterfaces/CMakeLists.txt#L11>`__
+  for MSlice is up to date. If not, create a PR to update it and ask a gatekeeper to merge it.
+* On the ``release-next`` branch, create a PR to update the `major & minor
+  <https://github.com/mantidproject/mantid/blob/release-next/buildconfig/CMake/VersionNumber.cmake>`__
+  versions accordingly. Also, uncomment ``VERSION_PATCH`` and set it to ``0``. Ask a gatekeeper to merge the PR.
+* Ask a gatekeeper to merge the ``release-next`` branch back to ``main`` locally, and then comment
+  out the ``VERSION_PATCH`` on the ``main`` branch. They should then commit and push these changes
+  directly to the remote ``main`` without making a PR.
+* Build the `release-next_nightly_deployment Jenkins pipeline <https://builds.mantidproject.org/view/Release%20Pipeline/>`__
+  with the following parameters (most are already defaulted to the correct values):
+
+  * set ``BUILD_DEVEL`` to ``all``
+  * set ``BUILD_PACKAGE`` to ``all``
+  * set ``CONDA_RECIPES_BRANCH_NAME`` to ``main``
+  * set ``PACKAGE_SUFFIX`` to an **empty string**
+  * tick the ``PUBLISH_PACKAGES`` checkbox
+  * set the ``ANACONDA_CHANNEL`` to ``mantid``
+  * set the ``ANACONDA_CHANNEL_LABEL`` to ``rcN`` where ``N`` is an incremental build number for release
+    candidates, starting at ``1``
+  * set ``GITHUB_RELEASES_REPO`` to ``mantidproject/mantid``
+  * set ``GITHUB_RELEASES_TAG`` to ``vX.Y.Z-rcN``, where ``X.Y.Z`` is the release number,
+    and ``N`` is an incremental build number for release candidates, starting at ``1``.
+
+* Once the packages have been published to GitHub and Anaconda, ask someone in the ISIS core or DevOps
+  team to manually sign the Windows binary and re-upload it to the github
+  `draft release <https://github.com/mantidproject/mantid/releases>`__.
+* Liaise with the Quality Assurance Manager and together announce the creation of the smoke testing
+  issues and Release Candidates in the *\#general* slack channel.
 
 Release Day
 ###########
@@ -398,26 +420,15 @@ Release Day
 Check with the Quality Assurance Manager that the Smoke testing has been completed, and any issues
 have been fixed.
 
-*  Run the `release_deploy <https://builds.mantidproject.org/view/Release%20Pipeline/job/release_deploy/>`__
-   job to put the packages, with the exception of Windows, on Sourceforge. Set ``SOURCEFORGE_DIR`` to <major version>.<minor version> (e.g. 6.3)
-
-  *  Have someone at ISIS sign the Windows binary and upload this manually to Sourceforge
-
-  *  Set the default package for each OS to the new version using the information icon
-     next to the file list on Sourceforge
-
-*  Draft a `new release <https://github.com/mantidproject/mantid/releases>`__ on
-   GitHub. The new tag should be created based off the release branch in the form ``vX.Y.Z``. The
-   description of the new release can be copied from the release notes ``index.rst`` file.
-*  Upload the packages to the GitHub release (essentially for a backup), and then publish it. This
-   will create the tag required to generate the DOI.
+*  Edit the `draft release <https://github.com/mantidproject/mantid/releases>`__ on
+   GitHub. A new tag should be created based off the release branch in the form ``vX.Y.Z``. The
+   description of the new release can be copied from the release notes ``index.rst`` file, and
+   edited appropriately. See previous release descriptions for inspiration.
+*  Publish the GitHub release. This will create the tag required to generate the DOI.
 *  Update the `download page <https://download.mantidproject.org>`__ by creating a PR after
    following the instructions in the `Adding a new release section
    <https://github.com/mantidproject/download.mantidproject.org#adding-a-new-release>`__. Once the
    new file in the `releases` directory is merged, Jenkins will publish the new page.
-*  Kick off the build for ``mantidXY`` on RHEL7 for the SNS with ``PACKAGE_SUFFIX`` set to
-   ``XY`` where ``X`` and ``Y`` correspond to the Major and Minor release version numbers:
-   https://builds.mantidproject.org/job/release_clean-rhel7/
 
 **Generate DOI**
 


### PR DESCRIPTION
**Description of work.**
Since moving to our Conda-based Jenkins pipeline, the instructions for the technical release manager role have become outdated. Here they are updated so that they are consistent with our new deployment strategy.

**To test:**
- Build dev docs, checking that there are no warnings.
- Read through the Technical Release Manager section in `build/dev-docs/html/ReleaseChecklist.html`

Fixes #34290

*This does not require release notes* because it's a change to our developer documentation.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
