### PR TITLE
Add calibration file input to ISIS Reflectometry GUI

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ReflectometryISISCalibration.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ReflectometryISISCalibration.py
@@ -20,10 +20,10 @@ import math
 
 
 class ReflectometryISISCalibration(DataProcessorAlgorithm):
-    _WORKSPACE = 'InputWorkspace'
-    _CALIBRATION_FILE = 'CalibrationFile'
-    _OUTPUT_WORKSPACE = 'OutputWorkspace'
-    _DEBUG = 'Debug'
+    _WORKSPACE = "InputWorkspace"
+    _CALIBRATION_FILE = "CalibrationFile"
+    _OUTPUT_WORKSPACE = "OutputWorkspace"
+    _DEBUG = "Debug"
 
     def category(self):
         """Return the categories of the algorithm."""
@@ -39,23 +39,21 @@ class ReflectometryISISCalibration(DataProcessorAlgorithm):
 
     def seeAlso(self):
         """Return a list of related algorithm names."""
-        return ['ReflectometryISISLoadAndProcess']
+        return ["ReflectometryISISLoadAndProcess"]
 
     def PyInit(self):
         self.declareProperty(
             WorkspaceProperty(self._WORKSPACE, "", direction=Direction.Input, optional=PropertyMode.Mandatory),
             doc="An input workspace or workspace group",
         )
-        self.declareProperty(FileProperty(self._CALIBRATION_FILE, "",
-                                          action=FileAction.OptionalLoad,
-                                          direction=Direction.Input,
-                                          extensions=["dat"]),
+        self.declareProperty(
+            FileProperty(self._CALIBRATION_FILE, "", action=FileAction.OptionalLoad, direction=Direction.Input, extensions=["dat"]),
             doc="Calibration data file containing Y locations for detector pixels in mm.",
         )
         self.declareProperty(
-            WorkspaceProperty(self._OUTPUT_WORKSPACE, '', direction=Direction.Output),
-            doc='The calibrated output workspace.')
-        self.copyProperties('ReflectometryReductionOneAuto', [self._DEBUG])
+            WorkspaceProperty(self._OUTPUT_WORKSPACE, "", direction=Direction.Output), doc="The calibrated output workspace."
+        )
+        self.copyProperties("ReflectometryReductionOneAuto", [self._DEBUG])
 
     def PyExec(self):
         ws = self.getProperty(self._WORKSPACE).value
@@ -69,7 +67,7 @@ class ReflectometryISISCalibration(DataProcessorAlgorithm):
         output_ws = CloneWorkspace(InputWorkspace=ws)
         ApplyCalibration(Workspace=output_ws, CalibrationTable=calib_table)
         self.setProperty(self._OUTPUT_WORKSPACE, output_ws)
-        AnalysisDataService.remove('output_ws')
+        AnalysisDataService.remove("output_ws")
         if self.getProperty(self._DEBUG).isDefault:
             # Only output the calibration table if we're in debug mode
             AnalysisDataService.remove(calib_table.name())
@@ -134,7 +132,7 @@ class ReflectometryISISCalibration(DataProcessorAlgorithm):
     def _get_pixel_positions_from_file(self, filepath):
         # Create dictionary of pixel spectrum number and position from scan
         scanned_pixel_positions = {}
-        with open(filepath, 'r') as file:
+        with open(filepath, "r") as file:
             pixels = csv.reader(file)
             for pixel in pixels:
                 pixel_info = pixel[0].split()

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ReflectometryISISCalibration.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ReflectometryISISCalibration.py
@@ -20,9 +20,10 @@ import math
 
 
 class ReflectometryISISCalibration(DataProcessorAlgorithm):
-    _WORKSPACE = "InputWorkspace"
-    _CALIBRATION_FILE = "CalibrationFile"
-    _OUTPUT_WORKSPACE = "OutputWorkspace"
+    _WORKSPACE = 'InputWorkspace'
+    _CALIBRATION_FILE = 'CalibrationFile'
+    _OUTPUT_WORKSPACE = 'OutputWorkspace'
+    _DEBUG = 'Debug'
 
     def category(self):
         """Return the categories of the algorithm."""
@@ -45,13 +46,16 @@ class ReflectometryISISCalibration(DataProcessorAlgorithm):
             WorkspaceProperty(self._WORKSPACE, "", direction=Direction.Input, optional=PropertyMode.Mandatory),
             doc="An input workspace or workspace group",
         )
-        self.declareProperty(
-            FileProperty(self._CALIBRATION_FILE, "", action=FileAction.OptionalLoad, direction=Direction.Input, extensions=["dat"]),
+        self.declareProperty(FileProperty(self._CALIBRATION_FILE, "",
+                                          action=FileAction.OptionalLoad,
+                                          direction=Direction.Input,
+                                          extensions=["dat"]),
             doc="Calibration data file containing Y locations for detector pixels in mm.",
         )
         self.declareProperty(
-            WorkspaceProperty(self._OUTPUT_WORKSPACE, "", direction=Direction.Output), doc="The calibrated output workspace."
-        )
+            WorkspaceProperty(self._OUTPUT_WORKSPACE, '', direction=Direction.Output),
+            doc='The calibrated output workspace.')
+        self.copyProperties('ReflectometryReductionOneAuto', [self._DEBUG])
 
     def PyExec(self):
         ws = self.getProperty(self._WORKSPACE).value
@@ -65,7 +69,10 @@ class ReflectometryISISCalibration(DataProcessorAlgorithm):
         output_ws = CloneWorkspace(InputWorkspace=ws)
         ApplyCalibration(Workspace=output_ws, CalibrationTable=calib_table)
         self.setProperty(self._OUTPUT_WORKSPACE, output_ws)
-        AnalysisDataService.remove("output_ws")
+        AnalysisDataService.remove('output_ws')
+        if self.getProperty(self._DEBUG).isDefault:
+            # Only output the calibration table if we're in debug mode
+            AnalysisDataService.remove(calib_table.name())
 
     def validateInputs(self):
         """Return a dictionary containing issues found in properties."""

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ReflectometryISISCalibration.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ReflectometryISISCalibration.py
@@ -39,7 +39,7 @@ class ReflectometryISISCalibration(DataProcessorAlgorithm):
 
     def seeAlso(self):
         """Return a list of related algorithm names."""
-        return ["ReflectometryISISLoadAndProcess"]
+        return ['ReflectometryISISLoadAndProcess']
 
     def PyInit(self):
         self.declareProperty(

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ReflectometryISISLoadAndProcess.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ReflectometryISISLoadAndProcess.py
@@ -470,8 +470,9 @@ class ReflectometryISISLoadAndProcess(DataProcessorAlgorithm):
         args = {"InputRunList": [run], "EventMode": event_mode}
         calibration_filepath = self.getPropertyValue("CalibrationFile")
         if calibration_filepath:
-            args["CalibrationFile"] = calibration_filepath
-        alg = self.createChildAlgorithm("ReflectometryISISPreprocess", **args)
+            args['CalibrationFile'] = calibration_filepath
+            args[Prop.DEBUG] = self.getPropertyValue(Prop.DEBUG)
+        alg = self.createChildAlgorithm('ReflectometryISISPreprocess', **args)
         alg.setRethrows(True)
         alg.execute()
 

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ReflectometryISISLoadAndProcess.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ReflectometryISISLoadAndProcess.py
@@ -470,9 +470,9 @@ class ReflectometryISISLoadAndProcess(DataProcessorAlgorithm):
         args = {"InputRunList": [run], "EventMode": event_mode}
         calibration_filepath = self.getPropertyValue("CalibrationFile")
         if calibration_filepath:
-            args['CalibrationFile'] = calibration_filepath
+            args["CalibrationFile"] = calibration_filepath
             args[Prop.DEBUG] = self.getPropertyValue(Prop.DEBUG)
-        alg = self.createChildAlgorithm('ReflectometryISISPreprocess', **args)
+        alg = self.createChildAlgorithm("ReflectometryISISPreprocess", **args)
         alg.setRethrows(True)
         alg.execute()
 

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ReflectometryISISPreprocess.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ReflectometryISISPreprocess.py
@@ -23,7 +23,8 @@ class ReflectometryISISPreprocess(DataProcessorAlgorithm):
     _OUTPUT_WS = "OutputWorkspace"
     _MONITOR_WS = "MonitorWorkspace"
     _EVENT_MODE = "EventMode"
-    _CALIBRATION_FILE = "CalibrationFile"
+    _CALIBRATION_FILE = 'CalibrationFile'
+    _DEBUG = 'Debug'
 
     def __init__(self):
         """Initialize an instance of the algorithm."""
@@ -56,11 +57,9 @@ class ReflectometryISISPreprocess(DataProcessorAlgorithm):
             doc="The preprocessed output workspace. If multiple input runs are specified "
             "they will be summed into a single output workspace.",
         )
-        self.declareProperty(
-            MatrixWorkspaceProperty(self._MONITOR_WS, "", direction=Direction.Output, optional=PropertyMode.Optional),
-            doc="The loaded monitors workspace. This is only output in event mode.",
-        )
-        self.copyProperties("ReflectometryISISCalibration", [self._CALIBRATION_FILE])
+        self.declareProperty(MatrixWorkspaceProperty(self._MONITOR_WS, '', direction=Direction.Output, optional=PropertyMode.Optional),
+            doc='The loaded monitors workspace. This is only output in event mode.')
+        self.copyProperties('ReflectometryISISCalibration', [self._CALIBRATION_FILE, self._DEBUG])
 
     def PyExec(self):
         workspace, monitor_ws = self._loadRun(self.getPropertyValue(self._RUNS))
@@ -105,6 +104,7 @@ class ReflectometryISISPreprocess(DataProcessorAlgorithm):
         alg = self.createChildAlgorithm("ReflectometryISISCalibration")
         alg.setProperty("InputWorkspace", ws)
         alg.setProperty("CalibrationFile", calibration_filepath)
+        alg.setProperty("Debug", self.getPropertyValue(self._DEBUG))
         alg.execute()
         calibrated_ws = alg.getProperty("OutputWorkspace").value
         self.log().information("Calibrated workspace")

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ReflectometryISISPreprocess.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ReflectometryISISPreprocess.py
@@ -23,8 +23,8 @@ class ReflectometryISISPreprocess(DataProcessorAlgorithm):
     _OUTPUT_WS = "OutputWorkspace"
     _MONITOR_WS = "MonitorWorkspace"
     _EVENT_MODE = "EventMode"
-    _CALIBRATION_FILE = 'CalibrationFile'
-    _DEBUG = 'Debug'
+    _CALIBRATION_FILE = "CalibrationFile"
+    _DEBUG = "Debug"
 
     def __init__(self):
         """Initialize an instance of the algorithm."""
@@ -57,9 +57,11 @@ class ReflectometryISISPreprocess(DataProcessorAlgorithm):
             doc="The preprocessed output workspace. If multiple input runs are specified "
             "they will be summed into a single output workspace.",
         )
-        self.declareProperty(MatrixWorkspaceProperty(self._MONITOR_WS, '', direction=Direction.Output, optional=PropertyMode.Optional),
-            doc='The loaded monitors workspace. This is only output in event mode.')
-        self.copyProperties('ReflectometryISISCalibration', [self._CALIBRATION_FILE, self._DEBUG])
+        self.declareProperty(
+            MatrixWorkspaceProperty(self._MONITOR_WS, "", direction=Direction.Output, optional=PropertyMode.Optional),
+            doc="The loaded monitors workspace. This is only output in event mode.",
+        )
+        self.copyProperties("ReflectometryISISCalibration", [self._CALIBRATION_FILE, self._DEBUG])
 
     def PyExec(self):
         workspace, monitor_ws = self._loadRun(self.getPropertyValue(self._RUNS))

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ReflectometryISISPreprocess.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ReflectometryISISPreprocess.py
@@ -103,6 +103,9 @@ class ReflectometryISISPreprocess(DataProcessorAlgorithm):
         return ws, monitor_ws
 
     def _applyCalibration(self, ws: MatrixWorkspace, calibration_filepath: str) -> MatrixWorkspace:
+        if isinstance(ws, WorkspaceGroup):
+            raise RuntimeError("Calibrating a Workspace Group as part of pre-processing is not currently supported")
+
         alg = self.createChildAlgorithm("ReflectometryISISCalibration")
         alg.setProperty("InputWorkspace", ws)
         alg.setProperty("CalibrationFile", calibration_filepath)

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/ReflectometryISISCalibrationTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/ReflectometryISISCalibrationTest.py
@@ -123,7 +123,15 @@ class ReflectometryISISCalibrationTest(unittest.TestCase):
         args = {"InputWorkspace": ws, "OutputWorkspace": "test_calibrated"}
         self._assert_run_algorithm_raises_exception(args, "Calibration file path must be provided")
 
-    def _check_detector_positions(self, workspace, expected_positions, pos_type="final"):
+    def test_exception_raised_if_invalid_calibration_filepath_supplied(self):
+        input_ws_name = 'test_1234'
+        ws = self._create_sample_workspace(input_ws_name, 4)
+        args = {'InputWorkspace': ws,
+                'CalibrationFile': 'invalid/file_path.dat',
+                'OutputWorkspace': 'test_calibrated'}
+        self._assert_run_algorithm_raises_exception(args, "Calibration file path cannot be found")
+
+    def _check_detector_positions(self, workspace, expected_positions, pos_type='final'):
         for i in range(0, workspace.getNumberHistograms()):
             det = workspace.getDetector(i)
             np.testing.assert_almost_equal(

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/ReflectometryISISCalibrationTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/ReflectometryISISCalibrationTest.py
@@ -44,10 +44,8 @@ class ReflectometryISISCalibrationTest(unittest.TestCase):
         ws = self._create_sample_workspace(input_ws_name, spec_det_idx)
         expected_final_xyz, expected_final_dimensions = self._calculate_expected_final_detector_values(ws, spec_det_idx)
 
-        output_ws_name = 'test_calibrated'
-        args = {'InputWorkspace': ws,
-                'CalibrationFile': self._CALIBRATION_TEST_DATA,
-                'OutputWorkspace': output_ws_name}
+        output_ws_name = "test_calibrated"
+        args = {"InputWorkspace": ws, "CalibrationFile": self._CALIBRATION_TEST_DATA, "OutputWorkspace": output_ws_name}
         outputs = [input_ws_name, output_ws_name]
         self._assert_run_algorithm_succeeds(args, outputs)
 
@@ -56,18 +54,15 @@ class ReflectometryISISCalibrationTest(unittest.TestCase):
         self._check_detector_positions(retrieved_ws, expected_final_xyz)
 
     def test_calibration_successful_in_debug_mode(self):
-        input_ws_name = 'test_1234'
+        input_ws_name = "test_1234"
         # We use workspace ID 4 (or detector ID 13) as the specular detector
         spec_det_idx = 4
         ws = self._create_sample_workspace(input_ws_name, spec_det_idx)
         expected_final_xyz, expected_final_dimensions = self._calculate_expected_final_detector_values(ws, spec_det_idx)
 
         calibration_ws_name = self._calibration_ws_name(ws)
-        output_ws_name = 'test_calibrated'
-        args = {'InputWorkspace': ws,
-                'Debug': True,
-                'CalibrationFile': self._CALIBRATION_TEST_DATA,
-                'OutputWorkspace': output_ws_name}
+        output_ws_name = "test_calibrated"
+        args = {"InputWorkspace": ws, "Debug": True, "CalibrationFile": self._CALIBRATION_TEST_DATA, "OutputWorkspace": output_ws_name}
         outputs = [input_ws_name, calibration_ws_name, output_ws_name]
         self._assert_run_algorithm_succeeds(args, outputs)
 
@@ -94,14 +89,12 @@ class ReflectometryISISCalibrationTest(unittest.TestCase):
         for i in range(ws_grp.getNumberOfEntries()):
             ws = ws_grp[i]
             input_ws_names.append(ws.name())
-            output_ws_names.append(f'{output_grp_name}_{i + 1}')
+            output_ws_names.append(f"{output_grp_name}_{i + 1}")
             pos_xyz, dimensions = self._calculate_expected_final_detector_values(ws, spec_det_idx_list[i])
             expected_final_xyz.append(pos_xyz)
             expected_final_dimensions.append(dimensions)
 
-        args = {'InputWorkspace': ws_grp,
-                'CalibrationFile': self._CALIBRATION_TEST_DATA,
-                'OutputWorkspace': output_grp_name}
+        args = {"InputWorkspace": ws_grp, "CalibrationFile": self._CALIBRATION_TEST_DATA, "OutputWorkspace": output_grp_name}
         outputs = input_ws_names + [grp_name, output_grp_name] + output_ws_names
         self._assert_run_algorithm_succeeds(args, outputs)
 
@@ -113,8 +106,8 @@ class ReflectometryISISCalibrationTest(unittest.TestCase):
             self._check_detector_positions(retrieved_grp[i], expected_final_xyz[i])
 
     def test_calibration_successful_for_workspace_group_in_debug_mode(self):
-        grp_name = 'test'
-        output_grp_name = 'test_calibrated'
+        grp_name = "test"
+        output_grp_name = "test_calibrated"
         # Create a group of two workspaces. The first workspace uses workspace index 4 as the specular detector.
         # The second workspace uses workspace index 2 as the specular detector.
         spec_det_idx_list = [4, 2]
@@ -136,10 +129,7 @@ class ReflectometryISISCalibrationTest(unittest.TestCase):
             expected_final_dimensions.append(dimensions)
             calibration_ws_names.append(self._calibration_ws_name(ws))
 
-        args = {'InputWorkspace': ws_grp,
-                'Debug': True,
-                'CalibrationFile': self._CALIBRATION_TEST_DATA,
-                'OutputWorkspace': output_grp_name}
+        args = {"InputWorkspace": ws_grp, "Debug": True, "CalibrationFile": self._CALIBRATION_TEST_DATA, "OutputWorkspace": output_grp_name}
         outputs = input_ws_names + [grp_name, output_grp_name] + calibration_ws_names + output_ws_names
         self._assert_run_algorithm_succeeds(args, outputs)
 
@@ -183,14 +173,12 @@ class ReflectometryISISCalibrationTest(unittest.TestCase):
         self._assert_run_algorithm_raises_exception(args, "Calibration file path must be provided")
 
     def test_exception_raised_if_invalid_calibration_filepath_supplied(self):
-        input_ws_name = 'test_1234'
+        input_ws_name = "test_1234"
         ws = self._create_sample_workspace(input_ws_name, 4)
-        args = {'InputWorkspace': ws,
-                'CalibrationFile': 'invalid/file_path.dat',
-                'OutputWorkspace': 'test_calibrated'}
+        args = {"InputWorkspace": ws, "CalibrationFile": "invalid/file_path.dat", "OutputWorkspace": "test_calibrated"}
         self._assert_run_algorithm_raises_exception(args, "Calibration file path cannot be found")
 
-    def _check_detector_positions(self, workspace, expected_positions, pos_type='final'):
+    def _check_detector_positions(self, workspace, expected_positions, pos_type="final"):
         for i in range(0, workspace.getNumberHistograms()):
             det = workspace.getDetector(i)
             np.testing.assert_almost_equal(

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/ReflectometryISISCalibrationTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/ReflectometryISISCalibrationTest.py
@@ -44,9 +44,30 @@ class ReflectometryISISCalibrationTest(unittest.TestCase):
         ws = self._create_sample_workspace(input_ws_name, spec_det_idx)
         expected_final_xyz, expected_final_dimensions = self._calculate_expected_final_detector_values(ws, spec_det_idx)
 
+        output_ws_name = 'test_calibrated'
+        args = {'InputWorkspace': ws,
+                'CalibrationFile': self._CALIBRATION_TEST_DATA,
+                'OutputWorkspace': output_ws_name}
+        outputs = [input_ws_name, output_ws_name]
+        self._assert_run_algorithm_succeeds(args, outputs)
+
+        # Check the final output workspace
+        retrieved_ws = AnalysisDataService.retrieve(output_ws_name)
+        self._check_detector_positions(retrieved_ws, expected_final_xyz)
+
+    def test_calibration_successful_in_debug_mode(self):
+        input_ws_name = 'test_1234'
+        # We use workspace ID 4 (or detector ID 13) as the specular detector
+        spec_det_idx = 4
+        ws = self._create_sample_workspace(input_ws_name, spec_det_idx)
+        expected_final_xyz, expected_final_dimensions = self._calculate_expected_final_detector_values(ws, spec_det_idx)
+
         calibration_ws_name = self._calibration_ws_name(ws)
-        output_ws_name = "test_calibrated"
-        args = {"InputWorkspace": ws, "CalibrationFile": self._CALIBRATION_TEST_DATA, "OutputWorkspace": output_ws_name}
+        output_ws_name = 'test_calibrated'
+        args = {'InputWorkspace': ws,
+                'Debug': True,
+                'CalibrationFile': self._CALIBRATION_TEST_DATA,
+                'OutputWorkspace': output_ws_name}
         outputs = [input_ws_name, calibration_ws_name, output_ws_name]
         self._assert_run_algorithm_succeeds(args, outputs)
 
@@ -59,6 +80,41 @@ class ReflectometryISISCalibrationTest(unittest.TestCase):
     def test_calibration_successful_for_workspace_group(self):
         grp_name = "test"
         output_grp_name = "test_calibrated"
+        # Create a group of two workspaces. The first workspace uses workspace index 4 as the specular detector.
+        # The second workspace uses workspace index 2 as the specular detector.
+        spec_det_idx_list = [4, 2]
+        input_ws_grp_size = len(spec_det_idx_list)
+        ws_grp = self._create_workspace_group(grp_name, spec_det_idx_list, input_ws_grp_size)
+
+        expected_final_xyz = []
+        expected_final_dimensions = []
+        input_ws_names = []
+        output_ws_names = []
+
+        for i in range(ws_grp.getNumberOfEntries()):
+            ws = ws_grp[i]
+            input_ws_names.append(ws.name())
+            output_ws_names.append(f'{output_grp_name}_{i + 1}')
+            pos_xyz, dimensions = self._calculate_expected_final_detector_values(ws, spec_det_idx_list[i])
+            expected_final_xyz.append(pos_xyz)
+            expected_final_dimensions.append(dimensions)
+
+        args = {'InputWorkspace': ws_grp,
+                'CalibrationFile': self._CALIBRATION_TEST_DATA,
+                'OutputWorkspace': output_grp_name}
+        outputs = input_ws_names + [grp_name, output_grp_name] + output_ws_names
+        self._assert_run_algorithm_succeeds(args, outputs)
+
+        # Check the final output workspace and calibration table
+        retrieved_grp = AnalysisDataService.retrieve(output_grp_name)
+        self.assertIsInstance(retrieved_grp, WorkspaceGroup)
+        self.assertEqual(retrieved_grp.getNumberOfEntries(), input_ws_grp_size)
+        for i in range(retrieved_grp.getNumberOfEntries()):
+            self._check_detector_positions(retrieved_grp[i], expected_final_xyz[i])
+
+    def test_calibration_successful_for_workspace_group_in_debug_mode(self):
+        grp_name = 'test'
+        output_grp_name = 'test_calibrated'
         # Create a group of two workspaces. The first workspace uses workspace index 4 as the specular detector.
         # The second workspace uses workspace index 2 as the specular detector.
         spec_det_idx_list = [4, 2]
@@ -80,7 +136,10 @@ class ReflectometryISISCalibrationTest(unittest.TestCase):
             expected_final_dimensions.append(dimensions)
             calibration_ws_names.append(self._calibration_ws_name(ws))
 
-        args = {"InputWorkspace": ws_grp, "CalibrationFile": self._CALIBRATION_TEST_DATA, "OutputWorkspace": output_grp_name}
+        args = {'InputWorkspace': ws_grp,
+                'Debug': True,
+                'CalibrationFile': self._CALIBRATION_TEST_DATA,
+                'OutputWorkspace': output_grp_name}
         outputs = input_ws_names + [grp_name, output_grp_name] + calibration_ws_names + output_ws_names
         self._assert_run_algorithm_succeeds(args, outputs)
 

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/ReflectometryISISLoadAndProcessTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/ReflectometryISISLoadAndProcessTest.py
@@ -657,11 +657,21 @@ class ReflectometryISISLoadAndProcessTest(unittest.TestCase):
 
     def test_algorithm_passes_calibration_filepath_to_preprocessing_step(self):
         args = self._default_options
-        args["InputRunList"] = "INTER45455"
-        del args["ProcessingInstructions"]
-        args["CalibrationFile"] = self._CALIBRATION_TEST_DATA
-        args["AnalysisMode"] = "MultiDetectorAnalysis"
-        outputs = ["IvsQ_45455", "IvsQ_binned_45455", "TOF", "TOF_45455", "Calib_Table_45455", "TOF_45455_summed_segment"]
+        args['InputRunList'] = 'INTER45455'
+        del args['ProcessingInstructions']
+        args['CalibrationFile'] = self._CALIBRATION_TEST_DATA
+        args['AnalysisMode'] = 'MultiDetectorAnalysis'
+        outputs = ['IvsQ_45455', 'IvsQ_binned_45455', 'TOF', 'TOF_45455', 'TOF_45455_summed_segment']
+        self._assert_run_algorithm_succeeds(args, outputs)
+
+    def test_algorithm_passes_calibration_filepath_to_preprocessing_step_in_debug_mode(self):
+        args = self._default_options
+        args['InputRunList'] = 'INTER45455'
+        del args['ProcessingInstructions']
+        args['CalibrationFile'] = self._CALIBRATION_TEST_DATA
+        args['Debug'] = True
+        args['AnalysisMode'] = 'MultiDetectorAnalysis'
+        outputs = ['IvsQ_45455', 'IvsQ_binned_45455', 'TOF', 'TOF_45455', 'Calib_Table_45455', 'TOF_45455_summed_segment', 'IvsLam_45455']
         self._assert_run_algorithm_succeeds(args, outputs)
 
     def test_invalid_polarization_efficiency_file_name_raises_error(self):

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/ReflectometryISISLoadAndProcessTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/ReflectometryISISLoadAndProcessTest.py
@@ -657,21 +657,21 @@ class ReflectometryISISLoadAndProcessTest(unittest.TestCase):
 
     def test_algorithm_passes_calibration_filepath_to_preprocessing_step(self):
         args = self._default_options
-        args['InputRunList'] = 'INTER45455'
-        del args['ProcessingInstructions']
-        args['CalibrationFile'] = self._CALIBRATION_TEST_DATA
-        args['AnalysisMode'] = 'MultiDetectorAnalysis'
-        outputs = ['IvsQ_45455', 'IvsQ_binned_45455', 'TOF', 'TOF_45455', 'TOF_45455_summed_segment']
+        args["InputRunList"] = "INTER45455"
+        del args["ProcessingInstructions"]
+        args["CalibrationFile"] = self._CALIBRATION_TEST_DATA
+        args["AnalysisMode"] = "MultiDetectorAnalysis"
+        outputs = ["IvsQ_45455", "IvsQ_binned_45455", "TOF", "TOF_45455", "TOF_45455_summed_segment"]
         self._assert_run_algorithm_succeeds(args, outputs)
 
     def test_algorithm_passes_calibration_filepath_to_preprocessing_step_in_debug_mode(self):
         args = self._default_options
-        args['InputRunList'] = 'INTER45455'
-        del args['ProcessingInstructions']
-        args['CalibrationFile'] = self._CALIBRATION_TEST_DATA
-        args['Debug'] = True
-        args['AnalysisMode'] = 'MultiDetectorAnalysis'
-        outputs = ['IvsQ_45455', 'IvsQ_binned_45455', 'TOF', 'TOF_45455', 'Calib_Table_45455', 'TOF_45455_summed_segment', 'IvsLam_45455']
+        args["InputRunList"] = "INTER45455"
+        del args["ProcessingInstructions"]
+        args["CalibrationFile"] = self._CALIBRATION_TEST_DATA
+        args["Debug"] = True
+        args["AnalysisMode"] = "MultiDetectorAnalysis"
+        outputs = ["IvsQ_45455", "IvsQ_binned_45455", "TOF", "TOF_45455", "Calib_Table_45455", "TOF_45455_summed_segment", "IvsLam_45455"]
         self._assert_run_algorithm_succeeds(args, outputs)
 
     def test_invalid_polarization_efficiency_file_name_raises_error(self):

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/ReflectometryISISPreprocessTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/ReflectometryISISPreprocessTest.py
@@ -77,18 +77,13 @@ class ReflectometryISISPreprocessTest(unittest.TestCase):
         self.assertEqual(output_ws.getNumberOfEntries(), 2)
 
     def test_calibration_file_is_applied_when_provided(self):
-        args = {'InputRunList': 'INTER45455',
-                'Debug': True,
-                'CalibrationFile': self._CALIBRATION_TEST_DATA,
-                "OutputWorkspace": "ws"}
+        args = {"InputRunList": "INTER45455", "Debug": True, "CalibrationFile": self._CALIBRATION_TEST_DATA, "OutputWorkspace": "ws"}
         output_ws = self._run_test(args)
         self.assertIsInstance(output_ws, MatrixWorkspace)
         self._check_calibration(output_ws, is_calibrated=True)
 
     def test_calibration_is_skipped_if_file_not_provided(self):
-        args = {'InputRunList': 'INTER45455',
-                'Debug': True,
-                "OutputWorkspace": "ws"}
+        args = {"InputRunList": "INTER45455", "Debug": True, "OutputWorkspace": "ws"}
         output_ws = self._run_test(args)
         self.assertIsInstance(output_ws, MatrixWorkspace)
         self._check_calibration(output_ws, is_calibrated=False)

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/ReflectometryISISPreprocessTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/ReflectometryISISPreprocessTest.py
@@ -77,13 +77,18 @@ class ReflectometryISISPreprocessTest(unittest.TestCase):
         self.assertEqual(output_ws.getNumberOfEntries(), 2)
 
     def test_calibration_file_is_applied_when_provided(self):
-        args = {"InputRunList": "INTER45455", "CalibrationFile": self._CALIBRATION_TEST_DATA, "OutputWorkspace": "ws"}
+        args = {'InputRunList': 'INTER45455',
+                'Debug': True,
+                'CalibrationFile': self._CALIBRATION_TEST_DATA,
+                "OutputWorkspace": "ws"}
         output_ws = self._run_test(args)
         self.assertIsInstance(output_ws, MatrixWorkspace)
         self._check_calibration(output_ws, is_calibrated=True)
 
     def test_calibration_is_skipped_if_file_not_provided(self):
-        args = {"InputRunList": "INTER45455", "OutputWorkspace": "ws"}
+        args = {'InputRunList': 'INTER45455',
+                'Debug': True,
+                "OutputWorkspace": "ws"}
         output_ws = self._run_test(args)
         self.assertIsInstance(output_ws, MatrixWorkspace)
         self._check_calibration(output_ws, is_calibrated=False)

--- a/docs/source/algorithms/ReflectometryISISLoadAndProcess-v1.rst
+++ b/docs/source/algorithms/ReflectometryISISLoadAndProcess-v1.rst
@@ -24,6 +24,8 @@ The steps this algorithm performs are:
 
 Input runs and transmission runs are loaded if required, or existing workspaces are used if they are already loaded. When runs are loaded, they are named based on the run number with a ``TOF_`` or ``TRANS_`` prefix. To determine whether workspaces are already loaded, workspace names are matched based on the run number with or without this prefix. Other naming formats are not considered to match.
 
+If a value is provided for the ``CalibrationFile`` property then calibration will be applied for input runs that are loaded (but not where existing workspaces are being used). The calibration file supplied should be a ``.dat`` file containing two columns separated by a single space. The left hand column should contain the workspace indices of the detectors to move. The right hand column should contain the Y locations of the corresponding detector pixels in mm.
+
 If time slicing is enabled, the input run must be an event workspace and have monitors loaded; otherwise, it must be a histogram workspace. If the workspace already exists but is the incorrect type or is missing monitors, it will be reloaded.
 
 Input runs can be combined before reduction by supplying a comma-separated list of run numbers. They will be summed using the :ref:`algm-Plus` algorithm. Similarly, multiple input workspaces for the first and/or second transmission inputs can be summed prior to reduction.

--- a/docs/source/release/v6.6.0/Reflectometry/New_features/34775.rst
+++ b/docs/source/release/v6.6.0/Reflectometry/New_features/34775.rst
@@ -1,0 +1,1 @@
+- It is now possible to provide a calibration file on the Instrument Settings tab of the ISIS Reflectometry interface. The calibration step will be applied as part of pre-processing when a reduction is run or previewed.

--- a/docs/source/release/v6.6.0/Reflectometry/New_features/34775.rst
+++ b/docs/source/release/v6.6.0/Reflectometry/New_features/34775.rst
@@ -1,1 +1,1 @@
-- It is now possible to provide a calibration file on the Instrument Settings tab of the ISIS Reflectometry interface. The calibration step will be applied as part of pre-processing when a reduction is run or previewed.
+- It is now possible to provide a calibration file on the Instrument Settings tab of the ISIS Reflectometry interface. The calibration step will be applied as part of pre-processing when a reduction is run or previewed. See :ref:`ReflectometryISISLoadAndProcess <algm-ReflectometryISISLoadAndProcess>` for more details.

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/RowPreprocessingAlgorithm.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/RowPreprocessingAlgorithm.cpp
@@ -5,6 +5,8 @@
 //   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 // SPDX - License - Identifier: GPL - 3.0 +
 #include "RowPreprocessingAlgorithm.h"
+#include "../../Reduction/IBatch.h"
+#include "../../Reduction/Instrument.h"
 #include "AlgorithmProperties.h"
 #include "BatchJobAlgorithm.h"
 #include "MantidAPI/AlgorithmManager.h"
@@ -29,6 +31,11 @@ void updateInputWorkspacesProperties(MantidQt::API::IAlgorithmRuntimeProps &prop
   AlgorithmProperties::update("InputRunList", inputRunNumbers, properties);
 }
 
+void updateInstrumentSettingsProperties(MantidQt::API::IAlgorithmRuntimeProps &properties,
+                                        Instrument const &instrument) {
+  AlgorithmProperties::update("CalibrationFile", instrument.calibrationFilePath(), properties);
+}
+
 } // namespace
 
 namespace MantidQt::CustomInterfaces::ISISReflectometry::PreprocessRow {
@@ -39,7 +46,7 @@ namespace MantidQt::CustomInterfaces::ISISReflectometry::PreprocessRow {
  * @param model : the reduction configuration model
  * @param row : the row from the preview tab
  */
-IConfiguredAlgorithm_sptr createConfiguredAlgorithm(IBatch const & /*model*/, PreviewRow &row, IAlgorithm_sptr alg) {
+IConfiguredAlgorithm_sptr createConfiguredAlgorithm(IBatch const &model, PreviewRow &row, IAlgorithm_sptr alg) {
   // Create the algorithm
   if (!alg) {
     alg = Mantid::API::AlgorithmManager::Instance().create("ReflectometryISISPreprocess");
@@ -51,6 +58,7 @@ IConfiguredAlgorithm_sptr createConfiguredAlgorithm(IBatch const & /*model*/, Pr
   // Set the algorithm properties from the model
   auto properties = std::make_unique<MantidQt::API::AlgorithmRuntimeProps>();
   updateInputWorkspacesProperties(*properties, row.runNumbers());
+  updateInstrumentSettingsProperties(*properties, model.instrument());
 
   // Return the configured algorithm
   auto jobAlgorithm =

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/RowPreprocessingAlgorithm.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/RowPreprocessingAlgorithm.cpp
@@ -5,6 +5,7 @@
 //   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 // SPDX - License - Identifier: GPL - 3.0 +
 #include "RowPreprocessingAlgorithm.h"
+#include "../../Reduction/Experiment.h"
 #include "../../Reduction/IBatch.h"
 #include "../../Reduction/Instrument.h"
 #include "AlgorithmProperties.h"
@@ -36,6 +37,11 @@ void updateInstrumentSettingsProperties(MantidQt::API::IAlgorithmRuntimeProps &p
   AlgorithmProperties::update("CalibrationFile", instrument.calibrationFilePath(), properties);
 }
 
+void updateExperimentSettingsProperties(MantidQt::API::IAlgorithmRuntimeProps &properties,
+                                        Experiment const &experiment) {
+  AlgorithmProperties::update("Debug", experiment.debug(), properties);
+}
+
 } // namespace
 
 namespace MantidQt::CustomInterfaces::ISISReflectometry::PreprocessRow {
@@ -59,6 +65,7 @@ IConfiguredAlgorithm_sptr createConfiguredAlgorithm(IBatch const &model, Preview
   auto properties = std::make_unique<MantidQt::API::AlgorithmRuntimeProps>();
   updateInputWorkspacesProperties(*properties, row.runNumbers());
   updateInstrumentSettingsProperties(*properties, model.instrument());
+  updateExperimentSettingsProperties(*properties, model.experiment());
 
   // Return the configured algorithm
   auto jobAlgorithm =

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/RowProcessingAlgorithm.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/RowProcessingAlgorithm.cpp
@@ -168,10 +168,15 @@ void updateDetectorCorrectionProperties(AlgorithmRuntimeProps &properties, Detec
                                 properties);
 }
 
-void updateInstrumentProperties(AlgorithmRuntimeProps &properties, Instrument const &instrument) {
+void updatePreviewInstrumentProperties(AlgorithmRuntimeProps &properties, Instrument const &instrument) {
   updateWavelengthRangeProperties(properties, instrument.wavelengthRange());
   updateMonitorCorrectionProperties(properties, instrument.monitorCorrections());
   updateDetectorCorrectionProperties(properties, instrument.detectorCorrections());
+}
+
+void updateInstrumentProperties(AlgorithmRuntimeProps &properties, Instrument const &instrument) {
+  updatePreviewInstrumentProperties(properties, instrument);
+  AlgorithmProperties::update("CalibrationFile", instrument.calibrationFilePath(), properties);
 }
 
 class UpdateEventPropertiesVisitor : public boost::static_visitor<> {
@@ -272,6 +277,13 @@ void updatePropertiesFromBatchModel(AlgorithmRuntimeProps &properties, IBatch co
   updateExperimentProperties(properties, model.experiment());
   updateInstrumentProperties(properties, model.instrument());
 }
+
+void updatePreviewPropertiesFromBatchModel(AlgorithmRuntimeProps &properties, IBatch const &model) {
+  // Update properties for running a preview reduction from settings in the event, experiment and instrument tabs
+  updateEventProperties(properties, model.slicing());
+  updateExperimentProperties(properties, model.experiment());
+  updatePreviewInstrumentProperties(properties, model.instrument());
+}
 } // unnamed namespace
 
 namespace MantidQt::CustomInterfaces::ISISReflectometry::Reduction {
@@ -312,7 +324,7 @@ IConfiguredAlgorithm_sptr createConfiguredAlgorithm(IBatch const &model, Preview
 std::unique_ptr<MantidQt::API::IAlgorithmRuntimeProps> createAlgorithmRuntimeProps(IBatch const &model,
                                                                                    PreviewRow const &previewRow) {
   auto properties = std::make_unique<MantidQt::API::AlgorithmRuntimeProps>();
-  updatePropertiesFromBatchModel(*properties, model);
+  updatePreviewPropertiesFromBatchModel(*properties, model);
   // Look up properties for this run on the lookup table
   auto lookupRow = model.findLookupRow(previewRow);
   if (lookupRow) {

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Common/Decoder.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Common/Decoder.cpp
@@ -175,6 +175,7 @@ void Decoder::decodeInstrument(const QtInstrumentView *gui, const QMap<QString, 
   gui->m_ui.I0MonitorIndex->setValue(static_cast<int>(map[QString("I0MonitorIndex")].toDouble()));
   gui->m_ui.correctDetectorsCheckBox->setChecked(map[QString("correctDetectorsCheckBox")].toBool());
   gui->m_ui.detectorCorrectionTypeComboBox->setCurrentIndex(map[QString("detectorCorrectionTypeComboBox")].toInt());
+  gui->m_ui.calibrationPathEdit->setText(map[QString("calibrationPathEdit")].toString());
 }
 
 void Decoder::decodeRuns(QtRunsView *gui, ReductionJobs *redJobs, RunsTablePresenter *presenter,

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Common/Encoder.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Common/Encoder.cpp
@@ -259,6 +259,7 @@ QMap<QString, QVariant> Encoder::encodeInstrument(const QtInstrumentView *gui) {
   instrumentMap.insert(QString("correctDetectorsCheckBox"), QVariant(gui->m_ui.correctDetectorsCheckBox->isChecked()));
   instrumentMap.insert(QString("detectorCorrectionTypeComboBox"),
                        QVariant(gui->m_ui.detectorCorrectionTypeComboBox->currentIndex()));
+  instrumentMap.insert(QString("calibrationPathEdit"), QVariant(gui->m_ui.calibrationPathEdit->text()));
   return instrumentMap;
 }
 

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Common/IFileHandler.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Common/IFileHandler.h
@@ -24,6 +24,7 @@ public:
   virtual void saveJSONToFile(std::string const &filename, QMap<QString, QVariant> const &map) = 0;
   virtual QMap<QString, QVariant> loadJSONFromFile(std::string const &filename) = 0;
   virtual void saveCSVToFile(std::string const &filename, std::string const &content) const = 0;
+  virtual bool fileExists(std::string const &filepath) const = 0;
 };
 } // namespace ISISReflectometry
 } // namespace CustomInterfaces

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Instrument/IInstrumentView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Instrument/IInstrumentView.h
@@ -25,7 +25,6 @@ class MANTIDQT_ISISREFLECTOMETRY_DLL InstrumentViewSubscriber {
 public:
   virtual void notifySettingsChanged() = 0;
   virtual void notifyRestoreDefaultsRequested() = 0;
-  virtual void notifyEditingCalibFilePathFinished() = 0;
   virtual void notifyBrowseToCalibrationFileRequested() = 0;
 };
 
@@ -62,6 +61,8 @@ public:
   virtual void setMonitorIntegralMax(double value) = 0;
   virtual void showMonitorIntegralRangeInvalid() = 0;
   virtual void showMonitorIntegralRangeValid() = 0;
+  virtual void showCalibrationFilePathInvalid() = 0;
+  virtual void showCalibrationFilePathValid() = 0;
 
   virtual bool getCorrectDetectors() const = 0;
   virtual void setCorrectDetectors(bool value) = 0;
@@ -70,8 +71,6 @@ public:
 
   virtual std::string getCalibrationFilePath() const = 0;
   virtual void setCalibrationFilePath(std::string const &value) = 0;
-
-  virtual void errorInvalidCalibrationFilePath() = 0;
 
   virtual void disableAll() = 0;
   virtual void enableAll() = 0;

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Instrument/IInstrumentView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Instrument/IInstrumentView.h
@@ -66,6 +66,9 @@ public:
   virtual std::string getDetectorCorrectionType() const = 0;
   virtual void setDetectorCorrectionType(std::string const &value) = 0;
 
+  virtual std::string getCalibrationFilePath() const = 0;
+  virtual void setCalibrationFilePath(std::string const &value) = 0;
+
   virtual void disableAll() = 0;
   virtual void enableAll() = 0;
   virtual void enableDetectorCorrectionType() = 0;

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Instrument/IInstrumentView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Instrument/IInstrumentView.h
@@ -25,6 +25,7 @@ class MANTIDQT_ISISREFLECTOMETRY_DLL InstrumentViewSubscriber {
 public:
   virtual void notifySettingsChanged() = 0;
   virtual void notifyRestoreDefaultsRequested() = 0;
+  virtual void notifyEditingCalibFilePathFinished() = 0;
 };
 
 class MANTIDQT_ISISREFLECTOMETRY_DLL IInstrumentView {
@@ -68,6 +69,8 @@ public:
 
   virtual std::string getCalibrationFilePath() const = 0;
   virtual void setCalibrationFilePath(std::string const &value) = 0;
+
+  virtual void errorInvalidCalibrationFilePath() = 0;
 
   virtual void disableAll() = 0;
   virtual void enableAll() = 0;

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Instrument/IInstrumentView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Instrument/IInstrumentView.h
@@ -26,6 +26,7 @@ public:
   virtual void notifySettingsChanged() = 0;
   virtual void notifyRestoreDefaultsRequested() = 0;
   virtual void notifyEditingCalibFilePathFinished() = 0;
+  virtual void notifyBrowseToCalibrationFileRequested() = 0;
 };
 
 class MANTIDQT_ISISREFLECTOMETRY_DLL IInstrumentView {

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Instrument/InstrumentOptionDefaults.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Instrument/InstrumentOptionDefaults.cpp
@@ -49,7 +49,10 @@ Instrument getInstrumentDefaults(Mantid::Geometry::Instrument_const_sptr instrum
   auto detectorCorrections = DetectorCorrections(defaults.getBoolOrTrue("CorrectDetectors", "CorrectDetectors"),
                                                  detectorCorrectionTypeFromString(detectorCorrectionString));
 
-  return Instrument(wavelengthRange, std::move(monitorCorrections), detectorCorrections);
+  // For now, we're not providing a default for the CalibrationFilePath in the parameter file, so use an empty string
+  auto calibrationFilePath = "";
+
+  return Instrument(wavelengthRange, std::move(monitorCorrections), detectorCorrections, calibrationFilePath);
 }
 } // unnamed namespace
 

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Instrument/InstrumentPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Instrument/InstrumentPresenter.cpp
@@ -24,9 +24,10 @@ boost::optional<RangeInLambda> rangeOrNone(const RangeInLambda &range, const boo
 } // namespace
 
 InstrumentPresenter::InstrumentPresenter(IInstrumentView *view, Instrument instrument, IFileHandler *fileHandler,
+                                         IReflMessageHandler *messageHandler,
                                          std::unique_ptr<IInstrumentOptionDefaults> instrumentDefaults)
     : m_instrumentDefaults(std::move(instrumentDefaults)), m_view(view), m_model(std::move(instrument)),
-      m_fileHandler(fileHandler) {
+      m_fileHandler(fileHandler), m_messageHandler(messageHandler) {
   m_view->subscribe(this);
 }
 
@@ -47,6 +48,13 @@ void InstrumentPresenter::notifyEditingCalibFilePathFinished() {
   auto const calibrationFilePath = m_view->getCalibrationFilePath();
   if (!calibrationFilePath.empty() && !m_fileHandler->fileExists(calibrationFilePath))
     m_view->errorInvalidCalibrationFilePath();
+}
+
+void InstrumentPresenter::notifyBrowseToCalibrationFileRequested() {
+  auto calibrationFilePath = m_messageHandler->askUserForLoadFileName("Data Files (*.dat)");
+  if (!calibrationFilePath.empty()) {
+    m_view->setCalibrationFilePath(calibrationFilePath);
+  }
 }
 
 Instrument const &InstrumentPresenter::instrument() const { return m_model; }

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Instrument/InstrumentPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Instrument/InstrumentPresenter.cpp
@@ -8,6 +8,8 @@
 #include "GUI/Batch/IBatchPresenter.h"
 #include "InstrumentOptionDefaults.h"
 #include "MantidGeometry/Instrument_fwd.h"
+#include <Poco/File.h>
+#include <Poco/Path.h>
 #include <ostream>
 
 namespace MantidQt::CustomInterfaces::ISISReflectometry {
@@ -40,6 +42,20 @@ void InstrumentPresenter::notifyRestoreDefaultsRequested() {
   // Trigger a reload of the instrument to get up-to-date settings.
   m_mainPresenter->notifyUpdateInstrumentRequested();
   restoreDefaults();
+}
+
+void InstrumentPresenter::notifyEditingCalibFilePathFinished() {
+  auto const calibrationFilePath = m_view->getCalibrationFilePath();
+  if (!calibrationFilePath.empty()) {
+    try {
+      auto pocoPath = Poco::Path().parseDirectory(calibrationFilePath);
+      auto pocoFile = Poco::File(pocoPath);
+      if (!pocoFile.exists())
+        m_view->errorInvalidCalibrationFilePath();
+    } catch (Poco::PathSyntaxException &) {
+      m_view->errorInvalidCalibrationFilePath();
+    }
+  }
 }
 
 Instrument const &InstrumentPresenter::instrument() const { return m_model; }

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Instrument/InstrumentPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Instrument/InstrumentPresenter.cpp
@@ -44,12 +44,6 @@ void InstrumentPresenter::notifyRestoreDefaultsRequested() {
   restoreDefaults();
 }
 
-void InstrumentPresenter::notifyEditingCalibFilePathFinished() {
-  auto const calibrationFilePath = m_view->getCalibrationFilePath();
-  if (!calibrationFilePath.empty() && !m_fileHandler->fileExists(calibrationFilePath))
-    m_view->errorInvalidCalibrationFilePath();
-}
-
 void InstrumentPresenter::notifyBrowseToCalibrationFileRequested() {
   auto calibrationFilePath = m_messageHandler->askUserForLoadFileName("Data Files (*.dat)");
   if (!calibrationFilePath.empty()) {
@@ -99,6 +93,16 @@ void InstrumentPresenter::updateWidgetValidState() {
     m_view->showMonitorIntegralRangeValid();
   else
     m_view->showMonitorIntegralRangeInvalid();
+
+  updateCalibrationFileValidState(m_model.calibrationFilePath());
+}
+
+void InstrumentPresenter::updateCalibrationFileValidState(const std::string &calibrationFilePath) {
+  if (!calibrationFilePath.empty() && !m_fileHandler->fileExists(calibrationFilePath)) {
+    m_view->showCalibrationFilePathInvalid();
+  } else {
+    m_view->showCalibrationFilePathValid();
+  }
 }
 
 void InstrumentPresenter::notifyReductionPaused() { updateWidgetEnabledState(); }
@@ -189,11 +193,17 @@ DetectorCorrections InstrumentPresenter::detectorCorrectionsFromView() {
   return DetectorCorrections(correctPositions, correctionType);
 }
 
+std::string InstrumentPresenter::calibrationFilePathFromView() {
+  auto const calibrationFilePath = m_view->getCalibrationFilePath();
+  updateCalibrationFileValidState(calibrationFilePath);
+  return calibrationFilePath;
+}
+
 void InstrumentPresenter::updateModelFromView() {
   auto const wavelengthRange = wavelengthRangeFromView();
   auto const monitorCorrections = monitorCorrectionsFromView();
   auto const detectorCorrections = detectorCorrectionsFromView();
-  auto const calibrationFilePath = m_view->getCalibrationFilePath();
+  auto const calibrationFilePath = calibrationFilePathFromView();
   m_model = Instrument(wavelengthRange, monitorCorrections, detectorCorrections, calibrationFilePath);
 }
 

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Instrument/InstrumentPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Instrument/InstrumentPresenter.cpp
@@ -178,7 +178,8 @@ void InstrumentPresenter::updateModelFromView() {
   auto const wavelengthRange = wavelengthRangeFromView();
   auto const monitorCorrections = monitorCorrectionsFromView();
   auto const detectorCorrections = detectorCorrectionsFromView();
-  m_model = Instrument(wavelengthRange, monitorCorrections, detectorCorrections);
+  auto const calibrationFilePath = m_view->getCalibrationFilePath();
+  m_model = Instrument(wavelengthRange, monitorCorrections, detectorCorrections, calibrationFilePath);
 }
 
 void InstrumentPresenter::updateViewFromModel() {
@@ -202,6 +203,7 @@ void InstrumentPresenter::updateViewFromModel() {
   }
   m_view->setCorrectDetectors(m_model.correctDetectors());
   m_view->setDetectorCorrectionType(detectorCorrectionTypeToString(m_model.detectorCorrectionType()));
+  m_view->setCalibrationFilePath(m_model.calibrationFilePath());
 
   updateWidgetEnabledState();
   updateWidgetValidState();

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Instrument/InstrumentPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Instrument/InstrumentPresenter.h
@@ -8,6 +8,7 @@
 
 #include "../../Reduction/Instrument.h"
 #include "Common/DllConfig.h"
+#include "GUI/Common/IFileHandler.h"
 #include "IInstrumentPresenter.h"
 #include "IInstrumentView.h"
 #include "InstrumentOptionDefaults.h"
@@ -27,7 +28,7 @@ class MANTIDQT_ISISREFLECTOMETRY_DLL InstrumentPresenter : public InstrumentView
                                                            public IInstrumentPresenter {
 public:
   InstrumentPresenter(
-      IInstrumentView *view, Instrument instrument,
+      IInstrumentView *view, Instrument instrument, IFileHandler *fileHandler,
       std::unique_ptr<IInstrumentOptionDefaults> instrumentDefaults = std::make_unique<InstrumentOptionDefaults>());
   Instrument const &instrument() const override;
 
@@ -52,6 +53,7 @@ private:
   IInstrumentView *m_view;
   Instrument m_model;
   IBatchPresenter *m_mainPresenter;
+  IFileHandler *m_fileHandler;
 
   boost::optional<RangeInLambda> wavelengthRangeFromView();
   boost::optional<RangeInLambda> monitorBackgroundRangeFromView();

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Instrument/InstrumentPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Instrument/InstrumentPresenter.h
@@ -45,7 +45,6 @@ public:
   // InstrumentViewSubscriber overrides
   void notifySettingsChanged() override;
   void notifyRestoreDefaultsRequested() override;
-  void notifyEditingCalibFilePathFinished() override;
   void notifyBrowseToCalibrationFileRequested() override;
 
 protected:
@@ -64,10 +63,12 @@ private:
   MonitorCorrections monitorCorrectionsFromView();
   DetectorCorrectionType detectorCorrectionTypeFromView();
   DetectorCorrections detectorCorrectionsFromView();
+  std::string calibrationFilePathFromView();
   void updateModelFromView();
   void updateViewFromModel();
   void updateWidgetEnabledState();
   void updateWidgetValidState();
+  void updateCalibrationFileValidState(const std::string &calibrationFilePath);
   bool isProcessing() const;
   bool isAutoreducing() const;
 };

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Instrument/InstrumentPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Instrument/InstrumentPresenter.h
@@ -43,6 +43,7 @@ public:
   // InstrumentViewSubscriber overrides
   void notifySettingsChanged() override;
   void notifyRestoreDefaultsRequested() override;
+  void notifyEditingCalibFilePathFinished() override;
 
 protected:
   std::unique_ptr<IInstrumentOptionDefaults> m_instrumentDefaults;

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Instrument/InstrumentPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Instrument/InstrumentPresenter.h
@@ -9,6 +9,7 @@
 #include "../../Reduction/Instrument.h"
 #include "Common/DllConfig.h"
 #include "GUI/Common/IFileHandler.h"
+#include "GUI/Common/IReflMessageHandler.h"
 #include "IInstrumentPresenter.h"
 #include "IInstrumentView.h"
 #include "InstrumentOptionDefaults.h"
@@ -28,11 +29,11 @@ class MANTIDQT_ISISREFLECTOMETRY_DLL InstrumentPresenter : public InstrumentView
                                                            public IInstrumentPresenter {
 public:
   InstrumentPresenter(
-      IInstrumentView *view, Instrument instrument, IFileHandler *fileHandler,
+      IInstrumentView *view, Instrument instrument, IFileHandler *fileHandler, IReflMessageHandler *messageHandler,
       std::unique_ptr<IInstrumentOptionDefaults> instrumentDefaults = std::make_unique<InstrumentOptionDefaults>());
   Instrument const &instrument() const override;
 
-  // IInstrumentPresenver overrides
+  // IInstrumentPresenter overrides
   void acceptMainPresenter(IBatchPresenter *mainPresenter) override;
   void notifyReductionPaused() override;
   void notifyReductionResumed() override;
@@ -45,6 +46,7 @@ public:
   void notifySettingsChanged() override;
   void notifyRestoreDefaultsRequested() override;
   void notifyEditingCalibFilePathFinished() override;
+  void notifyBrowseToCalibrationFileRequested() override;
 
 protected:
   std::unique_ptr<IInstrumentOptionDefaults> m_instrumentDefaults;
@@ -54,6 +56,7 @@ private:
   Instrument m_model;
   IBatchPresenter *m_mainPresenter;
   IFileHandler *m_fileHandler;
+  IReflMessageHandler *m_messageHandler;
 
   boost::optional<RangeInLambda> wavelengthRangeFromView();
   boost::optional<RangeInLambda> monitorBackgroundRangeFromView();

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Instrument/InstrumentPresenterFactory.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Instrument/InstrumentPresenterFactory.h
@@ -18,11 +18,14 @@ namespace ISISReflectometry {
 
 class InstrumentPresenterFactory {
 public:
-  InstrumentPresenterFactory() {}
+  InstrumentPresenterFactory(IFileHandler *fileHandler) : m_fileHandler(fileHandler) {}
 
   std::unique_ptr<IInstrumentPresenter> make(IInstrumentView *view) {
-    return std::make_unique<InstrumentPresenter>(view, Instrument());
+    return std::make_unique<InstrumentPresenter>(view, Instrument(), m_fileHandler);
   }
+
+private:
+  IFileHandler *m_fileHandler;
 };
 } // namespace ISISReflectometry
 } // namespace CustomInterfaces

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Instrument/InstrumentPresenterFactory.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Instrument/InstrumentPresenterFactory.h
@@ -18,14 +18,16 @@ namespace ISISReflectometry {
 
 class InstrumentPresenterFactory {
 public:
-  InstrumentPresenterFactory(IFileHandler *fileHandler) : m_fileHandler(fileHandler) {}
+  InstrumentPresenterFactory(IFileHandler *fileHandler, IReflMessageHandler *messageHandler)
+      : m_fileHandler(fileHandler), m_messageHandler(messageHandler) {}
 
   std::unique_ptr<IInstrumentPresenter> make(IInstrumentView *view) {
-    return std::make_unique<InstrumentPresenter>(view, Instrument(), m_fileHandler);
+    return std::make_unique<InstrumentPresenter>(view, Instrument(), m_fileHandler, m_messageHandler);
   }
 
 private:
   IFileHandler *m_fileHandler;
+  IReflMessageHandler *m_messageHandler;
 };
 } // namespace ISISReflectometry
 } // namespace CustomInterfaces

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Instrument/InstrumentWidget.ui
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Instrument/InstrumentWidget.ui
@@ -369,6 +369,23 @@
           <layout class="QHBoxLayout" name="getInstDefaultsButtonLayout"/>
          </widget>
         </item>
+        <item row="7" column="0">
+         <widget class="QLabel" name="calibrationPathLabel">
+          <property name="text">
+           <string>CalibrationFile</string>
+          </property>
+         </widget>
+        </item>
+        <item row="7" column="1">
+         <widget class="QLineEdit" name="calibrationPathEdit"/>
+        </item>
+        <item row="7" column="2">
+         <widget class="QPushButton" name="calibrationPathButton">
+          <property name="text">
+           <string>Browse To File</string>
+          </property>
+         </widget>
+        </item>
        </layout>
       </item>
      </layout>

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Instrument/QtInstrumentView.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Instrument/QtInstrumentView.cpp
@@ -102,6 +102,8 @@ void QtInstrumentView::browseToCalibrationFile() {
   }
 }
 
+void QtInstrumentView::editingCalibFilePathFinished() { m_notifyee->notifyEditingCalibFilePathFinished(); }
+
 void QtInstrumentView::onRestoreDefaultsRequested() {
   Mantid::Kernel::UsageService::Instance().registerFeatureUsage(
       Mantid::Kernel::FeatureType::Feature, {"ISIS Reflectometry", "InstrumentTab", "RestoreDefaults"}, false);
@@ -132,6 +134,7 @@ void QtInstrumentView::registerInstrumentSettingsWidgets(const Mantid::API::IAlg
   registerSettingWidget(*m_ui.detectorCorrectionTypeComboBox, "DetectorCorrectionType", alg);
   registerSettingWidget(*m_ui.correctDetectorsCheckBox, "CorrectDetectors", alg);
   registerSettingWidget(*m_ui.calibrationPathEdit, "CalibrationFile", alg);
+  connect(m_ui.calibrationPathEdit, SIGNAL(editingFinished()), this, SLOT(editingCalibFilePathFinished()));
 }
 
 void QtInstrumentView::connectInstrumentSettingsWidgets() {
@@ -297,5 +300,9 @@ std::string QtInstrumentView::getCalibrationFilePath() const { return m_ui.calib
 
 void QtInstrumentView::setCalibrationFilePath(std::string const &value) {
   m_ui.calibrationPathEdit->setText(QString::fromStdString(value));
+}
+
+void QtInstrumentView::errorInvalidCalibrationFilePath() {
+  QMessageBox::critical(this, "Invalid file", "The calibration file specified cannot be found.");
 }
 } // namespace MantidQt::CustomInterfaces::ISISReflectometry

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Instrument/QtInstrumentView.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Instrument/QtInstrumentView.cpp
@@ -7,6 +7,7 @@
 #include "QtInstrumentView.h"
 #include "MantidKernel/UsageService.h"
 
+#include <QFileDialog>
 #include <QMessageBox>
 #include <QScrollBar>
 #include <boost/algorithm/string/join.hpp>
@@ -49,6 +50,7 @@ void QtInstrumentView::initLayout() {
   m_ui.lamMinEdit->setSpecialValueText("Unset");
   m_ui.lamMaxEdit->setSpecialValueText("Unset");
   connect(m_ui.getInstDefaultsButton, SIGNAL(clicked()), this, SLOT(onRestoreDefaultsRequested()));
+  connect(m_ui.calibrationPathButton, SIGNAL(clicked()), this, SLOT(browseToCalibrationFile()));
 }
 
 void QtInstrumentView::connectSettingsChange(QLineEdit &edit) {
@@ -93,6 +95,13 @@ void QtInstrumentView::disconnectSettingsChange(QCheckBox &edit) {
 
 void QtInstrumentView::onSettingsChanged() { m_notifyee->notifySettingsChanged(); }
 
+void QtInstrumentView::browseToCalibrationFile() {
+  auto calibrationFilePath = QFileDialog::getOpenFileName(this, QString(), QString(), tr("Data Files (*.dat)"));
+  if (!calibrationFilePath.isEmpty()) {
+    m_ui.calibrationPathEdit->setText(calibrationFilePath);
+  }
+}
+
 void QtInstrumentView::onRestoreDefaultsRequested() {
   Mantid::Kernel::UsageService::Instance().registerFeatureUsage(
       Mantid::Kernel::FeatureType::Feature, {"ISIS Reflectometry", "InstrumentTab", "RestoreDefaults"}, false);
@@ -122,6 +131,7 @@ void QtInstrumentView::registerInstrumentSettingsWidgets(const Mantid::API::IAlg
   registerSettingWidget(*m_ui.I0MonitorIndex, "I0MonitorIndex", alg);
   registerSettingWidget(*m_ui.detectorCorrectionTypeComboBox, "DetectorCorrectionType", alg);
   registerSettingWidget(*m_ui.correctDetectorsCheckBox, "CorrectDetectors", alg);
+  registerSettingWidget(*m_ui.calibrationPathEdit, "CalibrationFile", alg);
 }
 
 void QtInstrumentView::connectInstrumentSettingsWidgets() {
@@ -135,6 +145,7 @@ void QtInstrumentView::connectInstrumentSettingsWidgets() {
   connectSettingsChange(*m_ui.I0MonitorIndex);
   connectSettingsChange(*m_ui.detectorCorrectionTypeComboBox);
   connectSettingsChange(*m_ui.correctDetectorsCheckBox);
+  connectSettingsChange(*m_ui.calibrationPathEdit);
 }
 
 void QtInstrumentView::disconnectInstrumentSettingsWidgets() {
@@ -148,6 +159,7 @@ void QtInstrumentView::disconnectInstrumentSettingsWidgets() {
   disconnectSettingsChange(*m_ui.I0MonitorIndex);
   disconnectSettingsChange(*m_ui.detectorCorrectionTypeComboBox);
   disconnectSettingsChange(*m_ui.correctDetectorsCheckBox);
+  disconnectSettingsChange(*m_ui.calibrationPathEdit);
 }
 
 template <typename Widget>

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Instrument/QtInstrumentView.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Instrument/QtInstrumentView.cpp
@@ -7,7 +7,6 @@
 #include "QtInstrumentView.h"
 #include "MantidKernel/UsageService.h"
 
-#include <QFileDialog>
 #include <QMessageBox>
 #include <QScrollBar>
 #include <boost/algorithm/string/join.hpp>
@@ -95,12 +94,7 @@ void QtInstrumentView::disconnectSettingsChange(QCheckBox &edit) {
 
 void QtInstrumentView::onSettingsChanged() { m_notifyee->notifySettingsChanged(); }
 
-void QtInstrumentView::browseToCalibrationFile() {
-  auto calibrationFilePath = QFileDialog::getOpenFileName(this, QString(), QString(), tr("Data Files (*.dat)"));
-  if (!calibrationFilePath.isEmpty()) {
-    m_ui.calibrationPathEdit->setText(calibrationFilePath);
-  }
-}
+void QtInstrumentView::browseToCalibrationFile() { m_notifyee->notifyBrowseToCalibrationFileRequested(); }
 
 void QtInstrumentView::editingCalibFilePathFinished() { m_notifyee->notifyEditingCalibFilePathFinished(); }
 

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Instrument/QtInstrumentView.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Instrument/QtInstrumentView.cpp
@@ -22,6 +22,10 @@ namespace {
 void showAsInvalid(QDoubleSpinBox &spinBox) { spinBox.setStyleSheet("QDoubleSpinBox { background-color: #ffb8ad; }"); }
 
 void showAsValid(QDoubleSpinBox &spinBox) { spinBox.setStyleSheet(""); }
+
+void showAsInvalid(QLineEdit &lineEdit) { lineEdit.setStyleSheet("QLineEdit { background-color: #ffb8ad; }"); }
+
+void showAsValid(QLineEdit &lineEdit) { lineEdit.setStyleSheet(""); }
 } // namespace
 
 /** Constructor
@@ -96,8 +100,6 @@ void QtInstrumentView::onSettingsChanged() { m_notifyee->notifySettingsChanged()
 
 void QtInstrumentView::browseToCalibrationFile() { m_notifyee->notifyBrowseToCalibrationFileRequested(); }
 
-void QtInstrumentView::editingCalibFilePathFinished() { m_notifyee->notifyEditingCalibFilePathFinished(); }
-
 void QtInstrumentView::onRestoreDefaultsRequested() {
   Mantid::Kernel::UsageService::Instance().registerFeatureUsage(
       Mantid::Kernel::FeatureType::Feature, {"ISIS Reflectometry", "InstrumentTab", "RestoreDefaults"}, false);
@@ -128,7 +130,6 @@ void QtInstrumentView::registerInstrumentSettingsWidgets(const Mantid::API::IAlg
   registerSettingWidget(*m_ui.detectorCorrectionTypeComboBox, "DetectorCorrectionType", alg);
   registerSettingWidget(*m_ui.correctDetectorsCheckBox, "CorrectDetectors", alg);
   registerSettingWidget(*m_ui.calibrationPathEdit, "CalibrationFile", alg);
-  connect(m_ui.calibrationPathEdit, SIGNAL(editingFinished()), this, SLOT(editingCalibFilePathFinished()));
 }
 
 void QtInstrumentView::connectInstrumentSettingsWidgets() {
@@ -296,7 +297,7 @@ void QtInstrumentView::setCalibrationFilePath(std::string const &value) {
   m_ui.calibrationPathEdit->setText(QString::fromStdString(value));
 }
 
-void QtInstrumentView::errorInvalidCalibrationFilePath() {
-  QMessageBox::critical(this, "Invalid file", "The calibration file specified cannot be found.");
-}
+void QtInstrumentView::showCalibrationFilePathInvalid() { showAsInvalid(*m_ui.calibrationPathEdit); }
+
+void QtInstrumentView::showCalibrationFilePathValid() { showAsValid(*m_ui.calibrationPathEdit); }
 } // namespace MantidQt::CustomInterfaces::ISISReflectometry

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Instrument/QtInstrumentView.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Instrument/QtInstrumentView.cpp
@@ -292,4 +292,10 @@ std::string QtInstrumentView::getDetectorCorrectionType() const {
 void QtInstrumentView::setDetectorCorrectionType(std::string const &value) {
   setSelected(*m_ui.detectorCorrectionTypeComboBox, value);
 }
+
+std::string QtInstrumentView::getCalibrationFilePath() const { return m_ui.calibrationPathEdit->text().toStdString(); }
+
+void QtInstrumentView::setCalibrationFilePath(std::string const &value) {
+  m_ui.calibrationPathEdit->setText(QString::fromStdString(value));
+}
 } // namespace MantidQt::CustomInterfaces::ISISReflectometry

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Instrument/QtInstrumentView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Instrument/QtInstrumentView.h
@@ -53,6 +53,8 @@ public:
   void setMonitorIntegralMax(double value) override;
   void showMonitorIntegralRangeInvalid() override;
   void showMonitorIntegralRangeValid() override;
+  void showCalibrationFilePathInvalid() override;
+  void showCalibrationFilePathValid() override;
 
   bool getCorrectDetectors() const override;
   void setCorrectDetectors(bool value) override;
@@ -61,8 +63,6 @@ public:
 
   std::string getCalibrationFilePath() const override;
   void setCalibrationFilePath(std::string const &value) override;
-
-  void errorInvalidCalibrationFilePath() override;
 
   void disableAll() override;
   void enableAll() override;
@@ -73,7 +73,6 @@ public slots:
   void onSettingsChanged();
   void onRestoreDefaultsRequested();
   void browseToCalibrationFile();
-  void editingCalibFilePathFinished();
 
 private:
   /// Initialise the interface

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Instrument/QtInstrumentView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Instrument/QtInstrumentView.h
@@ -62,6 +62,8 @@ public:
   std::string getCalibrationFilePath() const override;
   void setCalibrationFilePath(std::string const &value) override;
 
+  void errorInvalidCalibrationFilePath() override;
+
   void disableAll() override;
   void enableAll() override;
   void enableDetectorCorrectionType() override;
@@ -71,6 +73,7 @@ public slots:
   void onSettingsChanged();
   void onRestoreDefaultsRequested();
   void browseToCalibrationFile();
+  void editingCalibFilePathFinished();
 
 private:
   /// Initialise the interface

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Instrument/QtInstrumentView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Instrument/QtInstrumentView.h
@@ -67,6 +67,7 @@ public:
 public slots:
   void onSettingsChanged();
   void onRestoreDefaultsRequested();
+  void browseToCalibrationFile();
 
 private:
   /// Initialise the interface

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Instrument/QtInstrumentView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Instrument/QtInstrumentView.h
@@ -59,6 +59,9 @@ public:
   std::string getDetectorCorrectionType() const override;
   void setDetectorCorrectionType(std::string const &value) override;
 
+  std::string getCalibrationFilePath() const override;
+  void setCalibrationFilePath(std::string const &value) override;
+
   void disableAll() override;
   void enableAll() override;
   void enableDetectorCorrectionType() override;

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/MainWindow/QtMainWindowView.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/MainWindow/QtMainWindowView.cpp
@@ -17,6 +17,8 @@
 #include "MantidKernel/UsageService.h"
 #include "MantidQtWidgets/Common/QtJSONUtils.h"
 #include "MantidQtWidgets/Common/SlitCalculator.h"
+#include <Poco/File.h>
+#include <Poco/Path.h>
 #include <QFileDialog>
 #include <QMessageBox>
 #include <QToolButton>
@@ -86,7 +88,7 @@ void QtMainWindowView::initLayout() {
   auto makeEventPresenter = EventPresenterFactory();
   auto makeSaveSettingsPresenter = SavePresenterFactory();
   auto makeExperimentPresenter = ExperimentPresenterFactory(thetaTolerance);
-  auto makeInstrumentPresenter = InstrumentPresenterFactory();
+  auto makeInstrumentPresenter = InstrumentPresenterFactory(fileHandler);
   auto makePreviewPresenter = PreviewPresenterFactory();
 
   auto makeBatchPresenter = std::make_unique<BatchPresenterFactory>(
@@ -235,6 +237,22 @@ void QtMainWindowView::saveCSVToFile(const std::string &filename, const std::str
   }
   outFile << content;
   outFile.close();
+}
+
+bool QtMainWindowView::fileExists(std::string const &filepath) const {
+  if (filepath.empty())
+    return false;
+
+  try {
+    auto pocoPath = Poco::Path().parseDirectory(filepath);
+    auto pocoFile = Poco::File(pocoPath);
+    if (!pocoFile.exists())
+      return false;
+  } catch (Poco::PathSyntaxException &) {
+    return false;
+  }
+
+  return true;
 }
 
 } // namespace CustomInterfaces::ISISReflectometry

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/MainWindow/QtMainWindowView.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/MainWindow/QtMainWindowView.cpp
@@ -88,7 +88,7 @@ void QtMainWindowView::initLayout() {
   auto makeEventPresenter = EventPresenterFactory();
   auto makeSaveSettingsPresenter = SavePresenterFactory();
   auto makeExperimentPresenter = ExperimentPresenterFactory(thetaTolerance);
-  auto makeInstrumentPresenter = InstrumentPresenterFactory(fileHandler);
+  auto makeInstrumentPresenter = InstrumentPresenterFactory(fileHandler, messageHandler);
   auto makePreviewPresenter = PreviewPresenterFactory();
 
   auto makeBatchPresenter = std::make_unique<BatchPresenterFactory>(

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/MainWindow/QtMainWindowView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/MainWindow/QtMainWindowView.h
@@ -74,6 +74,7 @@ public:
   void saveJSONToFile(std::string const &filename, QMap<QString, QVariant> const &map) override;
   QMap<QString, QVariant> loadJSONFromFile(std::string const &filename) override;
   void saveCSVToFile(std::string const &filename, std::string const &content) const override;
+  bool fileExists(std::string const &filepath) const override;
 
 public slots:
   void helpPressed();

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/Instrument.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/Instrument.cpp
@@ -18,14 +18,6 @@ Instrument::Instrument(boost::optional<RangeInLambda> wavelengthRange, MonitorCo
     : m_wavelengthRange(std::move(wavelengthRange)), m_monitorCorrections(std::move(monitorCorrections)),
       m_detectorCorrections(detectorCorrections), m_calibrationFilePath(std::move(calibrationFilePath)) {}
 
-Instrument &Instrument::operator=(Instrument const &old_instrument) {
-  m_wavelengthRange = old_instrument.wavelengthRange();
-  m_monitorCorrections = old_instrument.monitorCorrections();
-  m_detectorCorrections = old_instrument.detectorCorrections();
-  m_calibrationFilePath = old_instrument.calibrationFilePath();
-  return *this;
-}
-
 boost::optional<RangeInLambda> const &Instrument::wavelengthRange() const { return m_wavelengthRange; }
 
 MonitorCorrections const &Instrument::monitorCorrections() const { return m_monitorCorrections; }

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/Instrument.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/Instrument.cpp
@@ -16,7 +16,7 @@ Instrument::Instrument()
 Instrument::Instrument(boost::optional<RangeInLambda> wavelengthRange, MonitorCorrections monitorCorrections,
                        DetectorCorrections detectorCorrections, std::string calibrationFilePath)
     : m_wavelengthRange(std::move(wavelengthRange)), m_monitorCorrections(std::move(monitorCorrections)),
-      m_detectorCorrections(detectorCorrections), m_calibrationFilePath(calibrationFilePath) {}
+      m_detectorCorrections(detectorCorrections), m_calibrationFilePath(std::move(calibrationFilePath)) {}
 
 Instrument &Instrument::operator=(Instrument const &old_instrument) {
   m_wavelengthRange = old_instrument.wavelengthRange();

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/Instrument.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/Instrument.cpp
@@ -10,7 +10,8 @@ namespace MantidQt::CustomInterfaces::ISISReflectometry {
 Instrument::Instrument()
     : m_wavelengthRange(RangeInLambda(0.0, 0.0)),
       m_monitorCorrections(MonitorCorrections(0, true, RangeInLambda(0.0, 0.0), RangeInLambda(0.0, 0.0))),
-      m_detectorCorrections(DetectorCorrections(false, DetectorCorrectionType::VerticalShift)) {}
+      m_detectorCorrections(DetectorCorrections(false, DetectorCorrectionType::VerticalShift)),
+      m_calibrationFilePath("") {}
 
 Instrument::Instrument(boost::optional<RangeInLambda> wavelengthRange, MonitorCorrections monitorCorrections,
                        DetectorCorrections detectorCorrections, std::string calibrationFilePath)

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/Instrument.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/Instrument.cpp
@@ -13,15 +13,25 @@ Instrument::Instrument()
       m_detectorCorrections(DetectorCorrections(false, DetectorCorrectionType::VerticalShift)) {}
 
 Instrument::Instrument(boost::optional<RangeInLambda> wavelengthRange, MonitorCorrections monitorCorrections,
-                       DetectorCorrections detectorCorrections)
+                       DetectorCorrections detectorCorrections, std::string calibrationFilePath)
     : m_wavelengthRange(std::move(wavelengthRange)), m_monitorCorrections(std::move(monitorCorrections)),
-      m_detectorCorrections(detectorCorrections) {}
+      m_detectorCorrections(detectorCorrections), m_calibrationFilePath(calibrationFilePath) {}
+
+Instrument &Instrument::operator=(Instrument const &old_instrument) {
+  m_wavelengthRange = old_instrument.wavelengthRange();
+  m_monitorCorrections = old_instrument.monitorCorrections();
+  m_detectorCorrections = old_instrument.detectorCorrections();
+  m_calibrationFilePath = old_instrument.calibrationFilePath();
+  return *this;
+}
 
 boost::optional<RangeInLambda> const &Instrument::wavelengthRange() const { return m_wavelengthRange; }
 
 MonitorCorrections const &Instrument::monitorCorrections() const { return m_monitorCorrections; }
 
 DetectorCorrections const &Instrument::detectorCorrections() const { return m_detectorCorrections; }
+
+std::string const &Instrument::calibrationFilePath() const { return m_calibrationFilePath; }
 
 size_t Instrument::monitorIndex() const { return m_monitorCorrections.monitorIndex(); }
 
@@ -41,6 +51,7 @@ bool operator!=(Instrument const &lhs, Instrument const &rhs) { return !(lhs == 
 
 bool operator==(Instrument const &lhs, Instrument const &rhs) {
   return lhs.wavelengthRange() == rhs.wavelengthRange() && lhs.monitorCorrections() == rhs.monitorCorrections() &&
-         lhs.detectorCorrections() == rhs.detectorCorrections();
+         lhs.detectorCorrections() == rhs.detectorCorrections() &&
+         lhs.calibrationFilePath() == rhs.calibrationFilePath();
 }
 } // namespace MantidQt::CustomInterfaces::ISISReflectometry

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/Instrument.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/Instrument.h
@@ -28,8 +28,6 @@ public:
   Instrument(boost::optional<RangeInLambda> wavelengthRange, MonitorCorrections monitorCorrections,
              DetectorCorrections detectorCorrections, std::string calibrationFilePath);
 
-  Instrument &operator=(Instrument const &);
-
   boost::optional<RangeInLambda> const &wavelengthRange() const;
   bool integratedMonitors() const;
   MonitorCorrections const &monitorCorrections() const;

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/Instrument.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/Instrument.h
@@ -11,6 +11,8 @@
 #include "MonitorCorrections.h"
 #include "RangeInLambda.h"
 
+#include <string>
+
 namespace MantidQt {
 namespace CustomInterfaces {
 namespace ISISReflectometry {
@@ -24,12 +26,15 @@ class MANTIDQT_ISISREFLECTOMETRY_DLL Instrument {
 public:
   Instrument();
   Instrument(boost::optional<RangeInLambda> wavelengthRange, MonitorCorrections monitorCorrections,
-             DetectorCorrections detectorCorrections);
+             DetectorCorrections detectorCorrections, std::string calibrationFilePath);
+
+  Instrument &operator=(Instrument const &);
 
   boost::optional<RangeInLambda> const &wavelengthRange() const;
   bool integratedMonitors() const;
   MonitorCorrections const &monitorCorrections() const;
   DetectorCorrections const &detectorCorrections() const;
+  std::string const &calibrationFilePath() const;
 
   size_t monitorIndex() const;
   boost::optional<RangeInLambda> monitorIntegralRange() const;
@@ -41,6 +46,7 @@ private:
   boost::optional<RangeInLambda> m_wavelengthRange;
   MonitorCorrections m_monitorCorrections;
   DetectorCorrections m_detectorCorrections;
+  std::string m_calibrationFilePath;
 };
 
 MANTIDQT_ISISREFLECTOMETRY_DLL bool operator==(Instrument const &lhs, Instrument const &rhs);

--- a/qt/scientific_interfaces/ISISReflectometry/TestHelpers/ModelCreationHelper.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/TestHelpers/ModelCreationHelper.cpp
@@ -465,13 +465,13 @@ DetectorCorrections makeDetectorCorrections() {
 }
 
 Instrument makeInstrument() {
-  return Instrument(makeWavelengthRange(), makeMonitorCorrections(), makeDetectorCorrections());
+  return Instrument(makeWavelengthRange(), makeMonitorCorrections(), makeDetectorCorrections(), "");
 }
 
 Instrument makeEmptyInstrument() {
   return Instrument(RangeInLambda(0.0, 0.0),
                     MonitorCorrections(0, true, RangeInLambda(0.0, 0.0), RangeInLambda(0.0, 0.0)),
-                    DetectorCorrections(false, DetectorCorrectionType::VerticalShift));
+                    DetectorCorrections(false, DetectorCorrectionType::VerticalShift), "");
 }
 
 /* Preview */

--- a/qt/scientific_interfaces/ISISReflectometry/TestHelpers/ModelCreationHelper.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/TestHelpers/ModelCreationHelper.cpp
@@ -465,7 +465,7 @@ DetectorCorrections makeDetectorCorrections() {
 }
 
 Instrument makeInstrument() {
-  return Instrument(makeWavelengthRange(), makeMonitorCorrections(), makeDetectorCorrections(), "");
+  return Instrument(makeWavelengthRange(), makeMonitorCorrections(), makeDetectorCorrections(), "test/calib_file.dat");
 }
 
 Instrument makeEmptyInstrument() {

--- a/qt/scientific_interfaces/ISISReflectometry/test/Batch/RowPreprocessingAlgorithmTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Batch/RowPreprocessingAlgorithmTest.h
@@ -56,7 +56,9 @@ public:
     auto mockAlg = std::make_shared<StubbedPreProcess>();
 
     auto instrument = makeEmptyInstrument();
+    auto experiment = makeEmptyExperiment();
     EXPECT_CALL(batch, instrument()).WillOnce(ReturnRef(instrument));
+    EXPECT_CALL(batch, experiment()).WillOnce(ReturnRef(experiment));
 
     auto configuredAlg = createConfiguredAlgorithm(batch, row, mockAlg);
     TS_ASSERT_EQUALS(configuredAlg->algorithm(), mockAlg);
@@ -73,13 +75,15 @@ public:
     TS_ASSERT(Mock::VerifyAndClearExpectations(&batch));
   }
 
-  void test_calibration_file_forwarded() {
+  void test_calibration_properties_forwarded() {
     auto batch = MockBatch();
     auto row = PreviewRow(std::vector<std::string>{"12345"});
     auto mockAlg = std::make_shared<StubbedPreProcess>();
 
     auto instrument = makeInstrument();
+    auto experiment = makeExperiment();
     EXPECT_CALL(batch, instrument()).WillOnce(ReturnRef(instrument));
+    EXPECT_CALL(batch, experiment()).WillOnce(ReturnRef(experiment));
 
     auto configuredAlg = createConfiguredAlgorithm(batch, row, mockAlg);
     TS_ASSERT_EQUALS(configuredAlg->algorithm(), mockAlg);
@@ -87,6 +91,8 @@ public:
     const auto &setProps = configuredAlg->getAlgorithmRuntimeProps();
     TS_ASSERT(setProps.existsProperty("CalibrationFile"));
     TS_ASSERT_EQUALS(setProps.getPropertyValue("CalibrationFile"), instrument.calibrationFilePath());
+    TS_ASSERT(setProps.existsProperty("Debug"));
+    TS_ASSERT_EQUALS(setProps.getPropertyValue("Debug"), "1");
 
     TS_ASSERT(Mock::VerifyAndClearExpectations(&batch));
   }

--- a/qt/scientific_interfaces/ISISReflectometry/test/Batch/RowProcessingAlgorithmTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Batch/RowProcessingAlgorithmTest.h
@@ -123,7 +123,7 @@ public:
   void testInstrumentSettingsWithPreviewRow() {
     auto model = Batch(m_experiment, m_instrument, m_runsTable, m_slicing);
     auto result = Reduction::createAlgorithmRuntimeProps(model, makePreviewRow());
-    checkMatchesInstrument(*result);
+    checkMatchesInstrument(*result, true);
   }
 
   void testSettingsForSlicingWithEmptyRow() {
@@ -398,7 +398,7 @@ private:
     TS_ASSERT_EQUALS(result.getPropertyValue("BackgroundProcessingInstructions"), "3,7");
   }
 
-  void checkMatchesInstrument(IAlgorithmRuntimeProps const &result) {
+  void checkMatchesInstrument(IAlgorithmRuntimeProps const &result, bool isPreview = false) {
     assertProperty(result, "WavelengthMin", 2.3);
     assertProperty(result, "WavelengthMax", 14.4);
     TS_ASSERT_EQUALS(result.getPropertyValue("I0MonitorIndex"), "2");
@@ -409,6 +409,12 @@ private:
     assertProperty(result, "MonitorIntegrationWavelengthMax", 10.8);
     TS_ASSERT_EQUALS(result.getPropertyValue("CorrectDetectors"), "1");
     TS_ASSERT_EQUALS(result.getPropertyValue("DetectorCorrectionType"), "RotateAroundSample");
+    if (isPreview) {
+      auto props = result.getDeclaredPropertyNames();
+      TS_ASSERT(std::none_of(props.begin(), props.end(), [](std::string prop) { return prop == "CalibrationFile"; }));
+    } else {
+      TS_ASSERT_EQUALS(result.getPropertyValue("CalibrationFile"), "test/calib_file.dat");
+    }
   }
 
   void checkMatchesSlicing(IAlgorithmRuntimeProps const &result) { assertProperty(result, "TimeInterval", 123.4); }

--- a/qt/scientific_interfaces/ISISReflectometry/test/Common/CoderCommonTester.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Common/CoderCommonTester.h
@@ -116,6 +116,7 @@ private:
     TS_ASSERT_EQUALS(gui->m_ui.correctDetectorsCheckBox->isChecked(), map[QString("correctDetectorsCheckBox")].toBool())
     TS_ASSERT_EQUALS(gui->m_ui.detectorCorrectionTypeComboBox->currentIndex(),
                      map[QString("detectorCorrectionTypeComboBox")].toInt())
+    TS_ASSERT_EQUALS(gui->m_ui.calibrationPathEdit->text(), map[QString("calibrationPathEdit")].toString())
   }
 
   void testRuns(const QtRunsView *gui, const ReductionJobs *redJobs, QtCatalogSearcher *searcher,
@@ -329,6 +330,7 @@ public:
     declareProperty("DetectorCorrectionType", "");
     declareProperty("CorrectDetectors", "");
     declareProperty("ROIDetectorIDs", "");
+    declareProperty("CalibrationFile", "");
   }
   void exec() override {}
 };

--- a/qt/scientific_interfaces/ISISReflectometry/test/Instrument/InstrumentOptionDefaultsTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Instrument/InstrumentOptionDefaultsTest.h
@@ -66,6 +66,11 @@ public:
     TS_ASSERT_EQUALS(result.detectorCorrections(), expected);
   }
 
+  void testDefaultCalibrationFilePathOptions() {
+    auto result = getDefaults();
+    TS_ASSERT_EQUALS(result.calibrationFilePath(), "");
+  }
+
   void testValidDetectorOptionsFromParamsFile() {
     auto result = getDefaultsFromParamsFile("Instrument");
     auto expected = DetectorCorrections(true, DetectorCorrectionType::RotateAroundSample);

--- a/qt/scientific_interfaces/ISISReflectometry/test/Instrument/InstrumentPresenterTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Instrument/InstrumentPresenterTest.h
@@ -363,6 +363,7 @@ private:
   NiceMock<MockInstrumentView> m_view;
   NiceMock<MockBatchPresenter> m_mainPresenter;
   NiceMock<MockFileHandler> m_fileHandler;
+  NiceMock<MockMessageHandler> m_messageHandler;
 
   Instrument makeModelWithMonitorOptions(MonitorCorrections monitorCorrections) {
     auto wavelengthRange = RangeInLambda(0.0, 0.0);
@@ -393,7 +394,7 @@ private:
   InstrumentPresenter makePresenter(
       std::unique_ptr<IInstrumentOptionDefaults> defaultOptions = std::make_unique<MockInstrumentOptionDefaults>()) {
     auto presenter = InstrumentPresenter(&m_view, ModelCreationHelper::makeEmptyInstrument(), &m_fileHandler,
-                                         std::move(defaultOptions));
+                                         &m_messageHandler, std::move(defaultOptions));
     presenter.acceptMainPresenter(&m_mainPresenter);
     return presenter;
   }

--- a/qt/scientific_interfaces/ISISReflectometry/test/Instrument/InstrumentPresenterTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Instrument/InstrumentPresenterTest.h
@@ -195,6 +195,17 @@ public:
     verifyAndClear();
   }
 
+  void testSetCalibrationFileUpdatesModel() {
+    auto calibrationFilePath = "/path/to/calibration_file.dat";
+    auto presenter = makePresenter();
+
+    EXPECT_CALL(m_view, getCalibrationFilePath()).WillOnce(Return(calibrationFilePath));
+    presenter.notifySettingsChanged();
+
+    TS_ASSERT_EQUALS(presenter.instrument().calibrationFilePath(), calibrationFilePath);
+    verifyAndClear();
+  }
+
   void testAllWidgetsAreEnabledWhenReductionPaused() {
     auto presenter = makePresenter();
 
@@ -320,6 +331,16 @@ public:
     verifyAndClear();
   }
 
+  void testInstrumentChangedUpdatesCalibrationFilePathInView() {
+    auto defaultFilepath = "default/path.dat";
+    auto model = makeModelWithCalibrationFilePath(defaultFilepath);
+    auto defaultOptions = expectDefaults(model);
+    auto presenter = makePresenter(std::move(defaultOptions));
+    EXPECT_CALL(m_view, setCalibrationFilePath(defaultFilepath)).Times(1);
+    presenter.notifyInstrumentChanged("POLREF");
+    verifyAndClear();
+  }
+
 private:
   NiceMock<MockInstrumentView> m_view;
   NiceMock<MockBatchPresenter> m_mainPresenter;
@@ -327,19 +348,27 @@ private:
   Instrument makeModelWithMonitorOptions(MonitorCorrections monitorCorrections) {
     auto wavelengthRange = RangeInLambda(0.0, 0.0);
     auto detectorCorrections = DetectorCorrections(false, DetectorCorrectionType::VerticalShift);
-    return Instrument(std::move(wavelengthRange), std::move(monitorCorrections), std::move(detectorCorrections));
+    return Instrument(std::move(wavelengthRange), std::move(monitorCorrections), std::move(detectorCorrections), "");
   }
 
   Instrument makeModelWithWavelengthRange(RangeInLambda wavelengthRange) {
     auto monitorCorrections = MonitorCorrections(0, false, RangeInLambda(0.0, 0.0), RangeInLambda(0.0, 0.0));
     auto detectorCorrections = DetectorCorrections(false, DetectorCorrectionType::VerticalShift);
-    return Instrument(std::move(wavelengthRange), std::move(monitorCorrections), std::move(detectorCorrections));
+    return Instrument(std::move(wavelengthRange), std::move(monitorCorrections), std::move(detectorCorrections), "");
   }
 
   Instrument makeModelWithDetectorCorrections(DetectorCorrections detectorCorrections) {
     auto wavelengthRange = RangeInLambda(0.0, 0.0);
     auto monitorCorrections = MonitorCorrections(0, false, RangeInLambda(0.0, 0.0), RangeInLambda(0.0, 0.0));
-    return Instrument(std::move(wavelengthRange), std::move(monitorCorrections), std::move(detectorCorrections));
+    return Instrument(std::move(wavelengthRange), std::move(monitorCorrections), std::move(detectorCorrections), "");
+  }
+
+  Instrument makeModelWithCalibrationFilePath(const std::string &filepath) {
+    auto wavelengthRange = RangeInLambda(0.0, 0.0);
+    auto monitorCorrections = MonitorCorrections(0, false, RangeInLambda(0.0, 0.0), RangeInLambda(0.0, 0.0));
+    auto detectorCorrections = DetectorCorrections(false, DetectorCorrectionType::VerticalShift);
+    return Instrument(std::move(wavelengthRange), std::move(monitorCorrections), std::move(detectorCorrections),
+                      filepath);
   }
 
   InstrumentPresenter makePresenter(

--- a/qt/scientific_interfaces/ISISReflectometry/test/Instrument/InstrumentPresenterTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Instrument/InstrumentPresenterTest.h
@@ -341,6 +341,30 @@ public:
     verifyAndClear();
   }
 
+  void testEnteringInvalidCalibrationFilePathTriggersError() {
+    auto presenter = makePresenter();
+    EXPECT_CALL(m_view, getCalibrationFilePath()).WillOnce(Return("test"));
+    EXPECT_CALL(m_view, errorInvalidCalibrationFilePath()).Times(1);
+    presenter.notifyEditingCalibFilePathFinished();
+    verifyAndClear();
+  }
+
+  void testEnteringEmptyCalibrationFilePathDoesNotTriggerError() {
+    auto presenter = makePresenter();
+    EXPECT_CALL(m_view, getCalibrationFilePath()).WillOnce(Return(""));
+    EXPECT_CALL(m_view, errorInvalidCalibrationFilePath()).Times(0);
+    presenter.notifyEditingCalibFilePathFinished();
+    verifyAndClear();
+  }
+
+  void testEnteringSpecialCharactersAsCalibrationFilePathTriggersError() {
+    auto presenter = makePresenter();
+    EXPECT_CALL(m_view, getCalibrationFilePath()).WillOnce(Return("?"));
+    EXPECT_CALL(m_view, errorInvalidCalibrationFilePath()).Times(1);
+    presenter.notifyEditingCalibFilePathFinished();
+    verifyAndClear();
+  }
+
 private:
   NiceMock<MockInstrumentView> m_view;
   NiceMock<MockBatchPresenter> m_mainPresenter;

--- a/qt/scientific_interfaces/ISISReflectometry/test/Instrument/InstrumentPresenterTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Instrument/InstrumentPresenterTest.h
@@ -345,8 +345,8 @@ public:
     auto presenter = makePresenter();
     EXPECT_CALL(m_view, getCalibrationFilePath()).WillOnce(Return("test"));
     EXPECT_CALL(m_fileHandler, fileExists("test")).WillOnce(Return(false));
-    EXPECT_CALL(m_view, errorInvalidCalibrationFilePath()).Times(1);
-    presenter.notifyEditingCalibFilePathFinished();
+    EXPECT_CALL(m_view, showCalibrationFilePathInvalid()).Times(1);
+    presenter.notifySettingsChanged();
     verifyAndClear();
   }
 
@@ -354,8 +354,8 @@ public:
     auto presenter = makePresenter();
     EXPECT_CALL(m_view, getCalibrationFilePath()).WillOnce(Return(""));
     EXPECT_CALL(m_fileHandler, fileExists("")).Times(0);
-    EXPECT_CALL(m_view, errorInvalidCalibrationFilePath()).Times(0);
-    presenter.notifyEditingCalibFilePathFinished();
+    EXPECT_CALL(m_view, showCalibrationFilePathValid()).Times(1);
+    presenter.notifySettingsChanged();
     verifyAndClear();
   }
 

--- a/qt/scientific_interfaces/ISISReflectometry/test/Instrument/MockInstrumentView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Instrument/MockInstrumentView.h
@@ -49,7 +49,8 @@ public:
   MOCK_METHOD1(setDetectorCorrectionType, void(std::string const &));
   MOCK_CONST_METHOD0(getCalibrationFilePath, std::string());
   MOCK_METHOD1(setCalibrationFilePath, void(std::string const &));
-  MOCK_METHOD0(errorInvalidCalibrationFilePath, void());
+  MOCK_METHOD0(showCalibrationFilePathInvalid, void());
+  MOCK_METHOD0(showCalibrationFilePathValid, void());
   MOCK_METHOD0(disableAll, void());
   MOCK_METHOD0(enableAll, void());
   MOCK_METHOD0(enableDetectorCorrectionType, void());

--- a/qt/scientific_interfaces/ISISReflectometry/test/Instrument/MockInstrumentView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Instrument/MockInstrumentView.h
@@ -49,6 +49,7 @@ public:
   MOCK_METHOD1(setDetectorCorrectionType, void(std::string const &));
   MOCK_CONST_METHOD0(getCalibrationFilePath, std::string());
   MOCK_METHOD1(setCalibrationFilePath, void(std::string const &));
+  MOCK_METHOD0(errorInvalidCalibrationFilePath, void());
   MOCK_METHOD0(disableAll, void());
   MOCK_METHOD0(enableAll, void());
   MOCK_METHOD0(enableDetectorCorrectionType, void());

--- a/qt/scientific_interfaces/ISISReflectometry/test/Instrument/MockInstrumentView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Instrument/MockInstrumentView.h
@@ -47,6 +47,8 @@ public:
   MOCK_METHOD1(setCorrectDetectors, void(bool));
   MOCK_CONST_METHOD0(getDetectorCorrectionType, std::string());
   MOCK_METHOD1(setDetectorCorrectionType, void(std::string const &));
+  MOCK_CONST_METHOD0(getCalibrationFilePath, std::string());
+  MOCK_METHOD1(setCalibrationFilePath, void(std::string const &));
   MOCK_METHOD0(disableAll, void());
   MOCK_METHOD0(enableAll, void());
   MOCK_METHOD0(enableDetectorCorrectionType, void());

--- a/qt/scientific_interfaces/ISISReflectometry/test/ReflMockObjects.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/ReflMockObjects.h
@@ -285,6 +285,7 @@ public:
   MOCK_METHOD2(saveJSONToFile, void(std::string const &, QMap<QString, QVariant> const &));
   MOCK_METHOD1(loadJSONFromFile, QMap<QString, QVariant>(const std::string &));
   MOCK_CONST_METHOD2(saveCSVToFile, void(std::string const &, std::string const &));
+  MOCK_CONST_METHOD1(fileExists, bool(std::string const &));
 };
 
 class MockJobRunner : public IJobRunner {


### PR DESCRIPTION
**Description of work.**
This PR adds a new `CalibrationFile` input to the Instrument Settings tab of the Reflectometry interface. This input is blank by default, but when a file path is provided a calibration step will automatically be applied for normal reductions, live reductions or when loading preview data.

If the Debug checkbox on the Experiment Settings tab is ticked then the calibration step will output a table workspace containing the calibration data that is being applied. If the Debug checkbox is unticked then the calibration table workspace is removed from the ADS before the calibration step completes.

Although the calibration file path is optional data, I didn't use a `boost::optional` for holding the data in the Instrument model as it seemed sufficient to hold it as an empty string.

**Report to:** Max at ISIS

**To test:**

1) Open the ISIS Reflectometry interface and set the instrument to INTER.
2) On the Experiment Settings tab, tick the Debug checkbox. This will make sure that a calibration table is output to the ADS when the calibration step is run. Also set the AnalysisMode to `MultiDetectorAnalysis`.
3) Download the example calibration data from issue #32022. On the Instrument Settings tab, find the CalibrationFile input at the bottom of the tab and click the button to browse to the calibration file provided in the example data (`pixel_centers_repeat.dat`).
4) Go to the Runs tab. In the Runs table (on the right hand side) enter run `61135` and angle `0.5` into the first row of the table. Select the row and click to process. The reduction should complete successfully and the calibration step should have been applied (see messages in the panel, output calibration workspace and also `ReflectometryISISCalibration` should be in the history of workspace `IvsQ_binned_61135`).
5) Clear all the workspaces and go to the Reduction Preview tab. Load the `INTER45455_inst` dataset and again check that the calibration step is applied (there should be messages in the panel plus an output calibration workspace).
6) Finally, check live data reduction by clicking the Start Monitor button on the Runs tab (this will need to be tested at ISIS while instruments are live). The calibration step may throw errors if the test calibration file doesn't contain the right entries for the experiment, however that's sufficient to prove that calibration is being applied to live data reductions.
7) Test running reductions with the Debug checkbox unticked, which should prevent the calibration table workspace being left in the ADS. Also check that calibration is not applied when the CalibrationFile input is left blank.

Fixes #34111.

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
