### PR TITLE
Add indeterminate progress bar below EngDiff FitPropertyBrowser

### DIFF
--- a/docs/source/release/v6.6.0/Diffraction/Engineering/New_features/34776.rst
+++ b/docs/source/release/v6.6.0/Diffraction/Engineering/New_features/34776.rst
@@ -1,0 +1,2 @@
+- An indeterminate progress bar has been added below the FitPropertyBrowser on the Engineering Diffraction Fitting tab.
+  This will display when the fit is in progress and whether the recent fit status was success or fail.

--- a/qt/python/mantidqt/mantidqt/utils/asynchronous.py
+++ b/qt/python/mantidqt/mantidqt/utils/asynchronous.py
@@ -77,13 +77,14 @@ class AsyncTask(threading.Thread):
 
         self.finished_cb()
 
-    def abort(self):
+    def abort(self, interrupt=True):
         """Cancel an asynchronous execution"""
         # Implementation is based on
         # https://stackoverflow.com/questions/5019436/python-how-to-terminate-a-blocking-thread
-        ctypes.pythonapi.PyThreadState_SetAsyncExc(ctypes.c_long(self.ident),
-                                                   ctypes.py_object(KeyboardInterrupt))
-        #now try and cancel the running algorithm
+        if interrupt:
+            ctypes.pythonapi.PyThreadState_SetAsyncExc(ctypes.c_long(self.ident),
+                                                       ctypes.py_object(KeyboardInterrupt))
+        # now try and cancel the running algorithm
         alg = IAlgorithm._algorithmInThread(self.ident)
         if alg is not None:
             alg.cancel()
@@ -217,7 +218,7 @@ class AsyncTaskFailure(AsyncTaskResult):
         error_name = type(self.exc_value).__name__
         filename, lineno, _, _ = extract_tb(self.stack)[-1]
         msg = self.exc_value.args
-        if isinstance(msg, tuple):
+        if msg and isinstance(msg, tuple):
             msg = msg[0]
         return '{} on line {} of \'{}\': {}'.format(error_name, lineno, filename, msg)
 

--- a/qt/python/mantidqt/mantidqt/utils/asynchronous.py
+++ b/qt/python/mantidqt/mantidqt/utils/asynchronous.py
@@ -112,7 +112,7 @@ class _Receiver(object):
 
 class BlockingAsyncTaskWithCallback(AsyncTask):
     def __init__(self, target, args=(), kwargs=None, success_cb=None, error_cb=None, blocking_cb=None,
-                 period_secs=0.05):
+                 period_secs=0.05, finished_cb=None):
         """Run the target in a separate thread and block the calling thread
         until execution is complete,the calling thread is blocked, except that
         the blocking_cb will be executed in every period in it.
@@ -136,9 +136,11 @@ class BlockingAsyncTaskWithCallback(AsyncTask):
         self.blocking_cb = create_callback(blocking_cb)
         self.success_cb = create_callback(success_cb)
         self.error_cb = create_callback(error_cb)
+        self.finished_cb = create_callback(finished_cb)
 
         self.recv = _Receiver(success_cb=success_cb, error_cb=error_cb)
-        self.task = AsyncTask(target, args, kwargs, success_cb=self.recv.on_success, error_cb=self.recv.on_error)
+        self.task = AsyncTask(target, args, kwargs, success_cb=self.recv.on_success, error_cb=self.recv.on_error,
+                              finished_cb=finished_cb)
 
     def start(self):
         """:returns: An AsyncTaskResult object"""

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/CMakeLists.txt
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/CMakeLists.txt
@@ -14,6 +14,7 @@ set(TEST_PY_FILES
     engineering_diffraction/tabs/calibration/test/test_calib_model.py
     engineering_diffraction/tabs/calibration/test/test_calib_presenter.py
     # Fitting
+    engineering_diffraction/tabs/fitting/test/test_presenter.py
     engineering_diffraction/tabs/fitting/data_handling/test/test_data_model.py
     engineering_diffraction/tabs/fitting/data_handling/test/test_data_presenter.py
     engineering_diffraction/tabs/fitting/plotting/test/test_plot_presenter.py

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/engineering_diffraction_io.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/engineering_diffraction_io.py
@@ -89,7 +89,7 @@ class EngineeringDiffractionDecoder(EngineeringDiffractionUIAttributes):
             if fit_properties is not None:
                 fit_browser = presenter.fitting_presenter.plot_widget.view.fit_browser
                 fit_browser.show()  # show the fit browser, default is off
-                presenter.fitting_presenter.plot_widget.view.fit_toggle()  # show the fit browser, default is off
+                presenter.fitting_presenter.plot_widget.fit_toggle()  # show the fit browser, default is off
                 fit_props = fit_properties["properties"]
                 fit_function = fit_props["Function"]
                 output_name = fit_props["Output"]

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/data_handling/data_presenter.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/data_handling/data_presenter.py
@@ -48,7 +48,8 @@ class FittingDataPresenter(object):
         self.view.set_fit_buttons_enabled(fit_enabled)
 
     def fit_completed(self, fit_props):
-        self.model.update_fit(fit_props)
+        if fit_props:
+            self.model.update_fit(fit_props)
 
     def _start_seq_fit(self):
         ws_name_list = self.model.get_active_ws_sorted_by_primary_log()

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/data_handling/data_presenter.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/data_handling/data_presenter.py
@@ -40,10 +40,7 @@ class FittingDataPresenter(object):
         self.all_plots_removed_notifier = GenericObservable()
         self.fit_all_started_notifier = GenericObservable()
         # Observers
-        self.fit_observer = GenericObserverWithArgPassing(self.fit_completed)
-        #
         self.fit_enabled_observer = GenericObserverWithArgPassing(self.set_fit_enabled)
-        self.fit_all_done_observer = GenericObserverWithArgPassing(self.fit_completed)
         self.focus_run_observer = GenericObserverWithArgPassing(
             self.view.set_default_files)
 

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/data_handling/data_presenter.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/data_handling/data_presenter.py
@@ -53,11 +53,11 @@ class FittingDataPresenter(object):
 
     def _start_seq_fit(self):
         ws_name_list = self.model.get_active_ws_sorted_by_primary_log()
-        self.fit_all_started_notifier.notify_subscribers(ws_name_list, do_sequential=True)
+        self.fit_all_started_notifier.notify_subscribers((ws_name_list, True))
 
     def _start_serial_fit(self):
         ws_name_list = self.model.get_active_ws_name_list()
-        self.fit_all_started_notifier.notify_subscribers(ws_name_list, do_sequential=False)
+        self.fit_all_started_notifier.notify_subscribers((ws_name_list, False))
 
     def _update_file_filter(self, region, xunit):
         self.view.update_file_filter(region, xunit)

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/plotting/EngDiff_fitpropertybrowser.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/plotting/EngDiff_fitpropertybrowser.py
@@ -34,6 +34,8 @@ class EngDiffFitPropertyBrowser(FitPropertyBrowser):
         self.setDefaultPeakType(default_peak)
         self.fit_notifier = GenericObservable()
         self.fit_enabled_notifier = GenericObservable()
+        self.fit_started_notifier = GenericObservable()
+        self.algorithmStarted.connect(self.fitting_started_slot)
 
     def set_output_window_names(self):
         """
@@ -158,3 +160,11 @@ class EngDiffFitPropertyBrowser(FitPropertyBrowser):
         """
         super(EngDiffFitPropertyBrowser, self).function_changed_slot()
         self.fit_enabled_notifier.notify_subscribers(self.isFitEnabled() and self.isVisible())
+
+    @Slot()
+    def fitting_started_slot(self):
+        """
+        Set the progress bar to in progress.
+        # :param name: The name of Fit's input workspace.
+        """
+        self.fit_started_notifier.notify_subscribers()

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/plotting/plot_presenter.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/plotting/plot_presenter.py
@@ -68,13 +68,12 @@ class FittingPlotPresenter(object):
     def on_cancel_clicked(self):
         if self.worker:
             self.abort_worker()
-            logger.warning("Fit cancelled and KeyboardInterrupt Exception expected.")
-            logger.warning("The fit property browser and output fit results may be out of sync.")
+            logger.warning("Fit cancelled therefore the fitpropertybrowser and output fit results may be out of sync.")
             self.fitprop_list = None
             self._finished()
 
     def abort_worker(self):
-        self.worker.abort()
+        self.worker.abort(interrupt=False)
 
     def enable_view_components(self, enable: bool):
         # enable / disable all widgets apart from the cancel button
@@ -111,9 +110,8 @@ class FittingPlotPresenter(object):
         self.fitprop_list = async_success.output
 
     def _on_worker_error(self, async_failure=None):
-        # when the user cancels the fit all, this is not called
         error_message = str(async_failure)
-        if "unknown" not in error_message:
+        if "KeyboardInterrupt" not in error_message:
             logger.error(str(async_failure))
 
     def _finished(self, _=None):

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/plotting/plot_presenter.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/plotting/plot_presenter.py
@@ -11,6 +11,12 @@ from mantid.simpleapi import Fit, logger
 from copy import deepcopy
 
 PLOT_KWARGS = {"linestyle": "", "marker": "x", "markersize": "3"}
+FAILED_STYLE_SHEET = """QProgressBar {border: 1px solid red; border-radius: 2px}"""
+SUCCESS_STYLE_SHEET = """QProgressBar::chunk {background-color: #2de100; margin: 0.5px;}"""
+IN_PROGRESS_STYLE_SHEET = """QProgressBar::chunk { width: 25px; margin: 0.5px;
+                                        background-color: qlineargradient(spread:reflect, x1:0, y1:0, x2:0.5, y2:0,
+                                                                          stop:0 white, stop:1 blue);}"""
+EMPTY_STYLE_SHEET = """QProgressBar {color: blue;}"""
 
 
 class FittingPlotPresenter(object):
@@ -29,28 +35,41 @@ class FittingPlotPresenter(object):
         self.all_workspaces_removed_observer = GenericObserver(self.clear_plot)
         self.fit_all_started_observer = GenericObserverWithArgPassing(self.do_fit_all)
         self.fit_all_done_notifier = GenericObservable()
+        self.fit_started_observer = GenericObserver(self.set_progress_bar_to_in_progress)
+        self.fit_complete_observer = GenericObserverWithArgPassing(self.set_final_state_progress_bar)
+
+        self.setup_toolbar()
+
+    def setup_toolbar(self):
+        self.view.set_slot_for_display_all()
+        self.view.set_slot_for_fit_toggled(self.fit_toggle)
 
     def add_workspace_to_plot(self, ws):
         axes = self.view.get_axes()
         for ax in axes:
             self.model.add_workspace_to_plot(ws, ax, PLOT_KWARGS)
         self.view.update_figure()
+        self.set_progress_bar_zero()
 
     def remove_workspace_from_plot(self, ws):
         for ax in self.view.get_axes():
             self.model.remove_workspace_from_plot(ws, ax)
             self.view.remove_ws_from_fitbrowser(ws)
         self.view.update_figure()
+        self.set_progress_bar_zero()
 
     def clear_plot(self):
         for ax in self.view.get_axes():
             self.model.remove_all_workspaces_from_plot(ax)
         self.view.clear_figure()
         self.view.update_fitbrowser()
+        self.set_progress_bar_zero()
 
     def do_fit_all(self, ws_name_list, do_sequential=True):
+        self.set_progress_bar_to_in_progress()
         fitprop_list = []
         prev_fitprop = self.view.read_fitprop_from_browser()
+        final_status = None
         for ws_name in ws_name_list:
             logger.notice(f'Starting to fit workspace {ws_name}')
             fitprop = deepcopy(prev_fitprop)
@@ -70,6 +89,45 @@ class FittingPlotPresenter(object):
             self.view.update_browser(fit_output.OutputStatus, funcstr, ws_name)
             # append a deep copy to output list (will be initial parameters if not successful)
             fitprop_list.append(fitprop)
+            final_status = fit_output.OutputStatus
 
+        self.set_final_state_progress_bar(output_list=None, status=final_status)
         logger.notice('Sequential fitting finished.')
         self.fit_all_done_notifier.notify_subscribers(fitprop_list)
+
+    def fit_toggle(self):
+        """Toggle fit browser and tool on/off"""
+        if self.view.is_fit_browser_visible():
+            self.view.hide_fit_browser()
+            self.view.hide_fit_progress_bar()
+        else:
+            self.view.show_fit_browser()  # if no data is plotted, the fit browser will fail to show
+            if self.view.is_fit_browser_visible():
+                self.view.show_fit_progress_bar()
+        self.set_progress_bar_zero()
+
+    # ==============================
+    # Indeterminate Fit Progress Bar
+    # ==============================
+
+    def set_final_state_progress_bar(self, output_list, status=None):
+        if not status:
+            status = output_list[0]['status'].lower()
+        if "success" in status:
+            self.set_progress_bar_success(status)
+        else:
+            self.set_progress_bar_failed(status)
+
+    def set_progress_bar_failed(self, status):
+        self.view.set_progress_bar(status=status, minimum=0, maximum=100, value=0, style_sheet=FAILED_STYLE_SHEET)
+
+    def set_progress_bar_success(self, status):
+        self.view.set_progress_bar(status=status, minimum=0, maximum=100, value=100, style_sheet=SUCCESS_STYLE_SHEET)
+
+    def set_progress_bar_to_in_progress(self):
+        # indeterminate progress bar
+        self.view.set_progress_bar(status="fitting...", minimum=0, maximum=0, value=0,
+                                   style_sheet=IN_PROGRESS_STYLE_SHEET)
+
+    def set_progress_bar_zero(self):
+        self.view.set_progress_bar(status="", minimum=0, maximum=100, value=0, style_sheet=EMPTY_STYLE_SHEET)

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/plotting/plot_view.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/plotting/plot_view.py
@@ -74,6 +74,7 @@ class FittingPlotView(QtWidgets.QWidget, Ui_plot):
         self.vLayout_fitprop.addWidget(self.fit_browser)
         self.hide_fit_browser()
         self.hide_fit_progress_bar()
+        self.show_cancel_button(False)
 
     def mouse_click(self, event):
         if event.button == event.canvas.buttond.get(Qt.RightButton):
@@ -103,6 +104,13 @@ class FittingPlotView(QtWidgets.QWidget, Ui_plot):
         if self.plot_dock.isFloating():
             self.plot_dock.close()
 
+    # ===============
+    # Slot Connectors
+    # ===============
+
+    def set_cancel_clicked(self, slot):
+        self.cancel_button.clicked.connect(slot)
+
     # =================
     # Component Setters
     # =================
@@ -112,6 +120,10 @@ class FittingPlotView(QtWidgets.QWidget, Ui_plot):
 
     def set_slot_for_display_all(self):
         self.toolbar.sig_home_clicked.connect(self.display_all)
+
+    def show_cancel_button(self, show: bool):
+        self.cancel_button.setVisible(show)
+        self.cancel_button.setEnabled(show)
 
     def hide_fit_browser(self):
         self.fit_browser.hide()
@@ -196,12 +208,13 @@ class FittingPlotView(QtWidgets.QWidget, Ui_plot):
         return self.fit_browser.read_current_fitprop()
 
     def update_browser(self, status, func_str, setup_name):
-        self.fit_browser.fitResultsChanged.emit(status)
-        self.fit_browser.changeWindowTitle.emit(status)
-        # update browser with output function and save setup if successful
-        if "success" in status.lower():
-            self.fit_browser.loadFunction(func_str)
-            self.fit_browser.save_current_setup(setup_name)
+        if status:
+            self.fit_browser.fitResultsChanged.emit(status)
+            self.fit_browser.changeWindowTitle.emit(status)
+            # update browser with output function and save setup if successful
+            if "success" in status.lower():
+                self.fit_browser.loadFunction(func_str)
+                self.fit_browser.save_current_setup(setup_name)
 
     # =================
     # Component Getters

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/plotting/plot_view.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/plotting/plot_view.py
@@ -34,7 +34,6 @@ class FittingPlotView(QtWidgets.QWidget, Ui_plot):
         self.has_first_undock_occurred = 0
 
         self.setup_figure()
-        self.setup_toolbar()
 
     def setup_figure(self):
         self.figure = Figure()
@@ -73,7 +72,8 @@ class FittingPlotView(QtWidgets.QWidget, Ui_plot):
         self.fit_browser.toggleWsListVisible()
         self.fit_browser.closing.connect(self.toolbar.handle_fit_browser_close)
         self.vLayout_fitprop.addWidget(self.fit_browser)
-        self.fit_browser.hide()
+        self.hide_fit_browser()
+        self.hide_fit_progress_bar()
 
     def mouse_click(self, event):
         if event.button == event.canvas.buttond.get(Qt.RightButton):
@@ -103,20 +103,34 @@ class FittingPlotView(QtWidgets.QWidget, Ui_plot):
         if self.plot_dock.isFloating():
             self.plot_dock.close()
 
-    def setup_toolbar(self):
-        self.toolbar.sig_home_clicked.connect(self.display_all)
-        self.toolbar.sig_toggle_fit_triggered.connect(self.fit_toggle)
-
     # =================
     # Component Setters
     # =================
 
-    def fit_toggle(self):
-        """Toggle fit browser and tool on/off"""
-        if self.fit_browser.isVisible():
-            self.fit_browser.hide()
-        else:
-            self.fit_browser.show()
+    def set_slot_for_fit_toggled(self, presenter_func):
+        self.toolbar.sig_toggle_fit_triggered.connect(presenter_func)
+
+    def set_slot_for_display_all(self):
+        self.toolbar.sig_home_clicked.connect(self.display_all)
+
+    def hide_fit_browser(self):
+        self.fit_browser.hide()
+
+    def show_fit_browser(self):
+        self.fit_browser.show()
+
+    def hide_fit_progress_bar(self):
+        self.fit_progress_bar.hide()
+
+    def show_fit_progress_bar(self):
+        self.fit_progress_bar.show()
+
+    def set_progress_bar(self, status, minimum, maximum, value, style_sheet):
+        self.fit_progress_bar.setToolTip(str(status))
+        self.fit_progress_bar.setMinimum(minimum)
+        self.fit_progress_bar.setMaximum(maximum)
+        self.fit_progress_bar.setValue(value)
+        self.fit_progress_bar.setStyleSheet(style_sheet)
 
     def clear_figure(self):
         self.figure.clf()
@@ -150,16 +164,18 @@ class FittingPlotView(QtWidgets.QWidget, Ui_plot):
         is_visible = self.fit_browser.isVisible()
         self.toolbar.set_fit_checkstate(False)
         self.fit_browser.hide()
+        self.fit_progress_bar.hide()
         if self.fit_browser.getWorkspaceNames() and is_visible:
             self.toolbar.set_fit_checkstate(True)
             self.fit_browser.show()
+            self.fit_progress_bar.show()
 
     def remove_ws_from_fitbrowser(self, ws):
-        # only one spectra per workspace
+        # only one spectrum per workspace
         try:
             self.fit_browser.removeWorkspaceAndSpectra(ws.name())
         except:
-            pass # name may not be available if ws has just been deleted
+            pass  # name may not be available if ws has just been deleted
 
     def update_legend(self, ax):
         if ax.get_lines():
@@ -196,3 +212,6 @@ class FittingPlotView(QtWidgets.QWidget, Ui_plot):
 
     def get_figure(self):
         return self.figure
+
+    def is_fit_browser_visible(self):
+        return self.fit_browser.isVisible()

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/plotting/plot_widget.ui
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/plotting/plot_widget.ui
@@ -52,7 +52,30 @@ QGroupBox:title {
          <layout class="QVBoxLayout" name="vLayout_plot"/>
         </item>
         <item row="0" column="1">
-         <layout class="QVBoxLayout" name="vLayout_fitprop"/>
+         <layout class="QGridLayout" name="gridLayout_3">
+          <item row="0" column="0">
+           <layout class="QVBoxLayout" name="vLayout_fitprop"/>
+          </item>
+          <item row="1" column="0">
+           <widget class="QProgressBar" name="fit_progress_bar">
+            <property name="maximumSize">
+             <size>
+              <width>16777215</width>
+              <height>5</height>
+             </size>
+            </property>
+            <property name="maximum">
+             <number>100</number>
+            </property>
+            <property name="value">
+             <number>0</number>
+            </property>
+            <property name="textVisible">
+             <bool>false</bool>
+            </property>
+           </widget>
+          </item>
+         </layout>
         </item>
        </layout>
       </widget>

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/plotting/plot_widget.ui
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/plotting/plot_widget.ui
@@ -57,23 +57,37 @@ QGroupBox:title {
            <layout class="QVBoxLayout" name="vLayout_fitprop"/>
           </item>
           <item row="1" column="0">
-           <widget class="QProgressBar" name="fit_progress_bar">
-            <property name="maximumSize">
-             <size>
-              <width>16777215</width>
-              <height>5</height>
-             </size>
-            </property>
-            <property name="maximum">
-             <number>100</number>
-            </property>
-            <property name="value">
-             <number>0</number>
-            </property>
-            <property name="textVisible">
-             <bool>false</bool>
-            </property>
-           </widget>
+           <layout class="QGridLayout" name="gridLayout_4">
+            <item row="1" column="0">
+             <widget class="QProgressBar" name="fit_progress_bar">
+              <property name="maximumSize">
+               <size>
+                <width>16777215</width>
+                <height>5</height>
+               </size>
+              </property>
+              <property name="maximum">
+               <number>100</number>
+              </property>
+              <property name="value">
+               <number>0</number>
+              </property>
+              <property name="textVisible">
+               <bool>false</bool>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="1">
+             <widget class="QPushButton" name="cancel_button">
+              <property name="enabled">
+               <bool>false</bool>
+              </property>
+              <property name="text">
+               <string>Cancel</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
           </item>
          </layout>
         </item>

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/plotting/test/test_plot_presenter.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/plotting/test/test_plot_presenter.py
@@ -187,7 +187,7 @@ class FittingPlotPresenterTest(unittest.TestCase):
         self.presenter.on_cancel_clicked()
 
         self.presenter.worker.abort.assert_called_once()
-        self.assertEqual(2, mock_logger.call_count)
+        mock_logger.assert_called_once()
         self.assertEqual(None, self.presenter.fitprop_list)
         self.presenter._finished.assert_called_once()
 
@@ -211,6 +211,18 @@ class FittingPlotPresenterTest(unittest.TestCase):
         self.presenter.worker.abort = mock.MagicMock()
         self.presenter.abort_worker()
         self.presenter.worker.abort.assert_called_once()
+
+    @mock.patch(dir_path + ".logger.error")
+    def test_on_worker_error_valid(self, mock_logger):
+        error_message = "There was an error in the fitting routine."
+        self.presenter._on_worker_error(error_message)
+        mock_logger.assert_called_once_with("There was an error in the fitting routine.")
+
+    @mock.patch(dir_path + ".logger.error")
+    def test_on_worker_error_KeyboardInterrupt(self, mock_logger):
+        error_message = "KeyboardInterrupt: There was an error in the fitting routine."
+        self.presenter._on_worker_error(error_message)
+        mock_logger.assert_not_called()
 
 
 if __name__ == '__main__':

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/plotting/test/test_plot_presenter.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/plotting/test/test_plot_presenter.py
@@ -9,6 +9,7 @@ import unittest
 from unittest import mock
 
 from mantidqtinterfaces.Engineering.gui.engineering_diffraction.tabs.fitting.plotting import plot_model, plot_view, plot_presenter
+from mantidqt.utils.asynchronous import BlockingAsyncTaskWithCallback
 
 dir_path = "mantidqtinterfaces.Engineering.gui.engineering_diffraction.tabs.fitting.plotting.plot_presenter"
 
@@ -59,16 +60,19 @@ class FittingPlotPresenterTest(unittest.TestCase):
         self.model.remove_all_workspaces_from_plot.assert_any_call("axis1")
         self.model.remove_all_workspaces_from_plot.assert_any_call("axis2")
 
+    @mock.patch(dir_path + '.AsyncTask', wraps=BlockingAsyncTaskWithCallback)
     @mock.patch(dir_path + '.Fit')
-    def test_do_sequential_fit(self, mock_fit):
+    def test_do_sequential_fit(self, mock_fit, mock_async):
         self.fit_all_helper(mock_fit, do_sequential=True)
 
+    @mock.patch(dir_path + '.AsyncTask', wraps=BlockingAsyncTaskWithCallback)
     @mock.patch(dir_path + '.Fit')
-    def test_do_serial_fit(self, mock_fit):
+    def test_do_serial_fit(self, mock_fit, mock_async):
         self.fit_all_helper(mock_fit, do_sequential=False)
 
+    @mock.patch(dir_path + '.AsyncTask', wraps=BlockingAsyncTaskWithCallback)
     @mock.patch(dir_path + '.Fit')
-    def test_do_sequential_fit_does_not_use_failed_fit_as_input(self, mock_fit):
+    def test_do_sequential_fit_does_not_use_failed_fit_as_input(self, mock_fit, mock_async):
         ws_list = ['ws1', 'ws2']
         fun_str_list = ['name=Gaussian,Height=11,PeakCentre=30000,Sigma=40',  # initial
                         'name=Gaussian,Height=10,PeakCentre=35000,Sigma=50']  # fit result of ws1 (and ws2)
@@ -77,8 +81,8 @@ class FittingPlotPresenterTest(unittest.TestCase):
         mock_fit_output.OutputStatus = "fail"
         mock_fit_output.Function.fun = fun_str_list[1]
         mock_fit.return_value = mock_fit_output
-
-        self.presenter.do_fit_all(ws_list, do_sequential=True)
+        previous_fit_properties = self.view.read_fitprop_from_browser()
+        self.presenter.do_fit_all(previous_fit_properties, ws_list, do_sequential=True)
 
         self.assertEqual(mock_fit.call_count, len(ws_list))
         for iws, ws in enumerate(ws_list):
@@ -101,7 +105,7 @@ class FittingPlotPresenterTest(unittest.TestCase):
         mock_notifier = mock.MagicMock()
         self.presenter.fit_all_done_notifier = mock_notifier
 
-        self.presenter.do_fit_all(ws_list, do_sequential=do_sequential)
+        self.presenter.do_fit_all_async(ws_list, do_sequential=do_sequential)
 
         self.assertEqual(mock_fit.call_count, len(ws_list))
         fitprop_list = []
@@ -114,12 +118,11 @@ class FittingPlotPresenterTest(unittest.TestCase):
                 # use same initial params for all workspaces
                 self.assertEqual(kwargs, {'Function': fun_str_list[0], 'InputWorkspace': ws, 'Output': ws})
             # check update browser with fit results
-            _, args, _ = self.view.update_browser.mock_calls[iws]
-            self.assertEqual(args, (mock_fit_output[iws].OutputStatus, fun_str_list[iws + 1], ws))
+            self.view.update_browser.assert_not_called()
             # collect all fitprop dicts together to test notifier
             fitprop_list.append({'properties': {'Function': fun_str_list[iws + 1], 'InputWorkspace': ws, 'Output': ws},
                                  'status': mock_fit_output[iws].OutputStatus})
-        mock_notifier.notify_subscribers.assert_called_once_with(fitprop_list)
+        self.assertEqual(self.presenter.fitprop_list, fitprop_list)
 
     def test_add_workspace_sets_progress_to_zero(self):
         self.presenter.add_workspace_to_plot("workspace")
@@ -132,12 +135,6 @@ class FittingPlotPresenterTest(unittest.TestCase):
     def test_clear_plot_sets_progress_to_zero(self):
         self.presenter.clear_plot()
         self.view.set_progress_bar.assert_has_calls([self.call_empty])
-
-    @mock.patch(dir_path + '.Fit')
-    def test_do_all_fit_sets_progress_bar_to_in_progress_then_final(self, mock_fit):
-        self.fit_all_helper(mock_fit, do_sequential=False)
-        self.assertEqual(2, self.view.set_progress_bar.call_count)
-        self.view.set_progress_bar.assert_has_calls([self.call_in_progress, self.call_fail], any_order=False)
 
     def test_final_state_fail_output_list(self):
         self.presenter.set_final_state_progress_bar([{'status': "fail"}])
@@ -179,6 +176,41 @@ class FittingPlotPresenterTest(unittest.TestCase):
 
     def set_browser_visible(self):
         self.view.is_fit_browser_visible.return_value = True
+
+    @mock.patch(dir_path + ".logger.warning")
+    def test_cancel_worker_valid(self, mock_logger):
+        self.presenter.fitprop_list = True
+        self.presenter.worker = mock.MagicMock(return_value=True)
+        self.presenter.worker.abort = mock.MagicMock()
+        self.presenter._finished = mock.MagicMock()
+
+        self.presenter.on_cancel_clicked()
+
+        self.presenter.worker.abort.assert_called_once()
+        self.assertEqual(2, mock_logger.call_count)
+        self.assertEqual(None, self.presenter.fitprop_list)
+        self.presenter._finished.assert_called_once()
+
+    @mock.patch(dir_path + ".logger.warning")
+    def test_cancel_worker_invalid(self, mock_logger):
+        self.presenter.fitprop_list = True
+        self.presenter.worker = None
+        self.presenter.abort_worker = mock.MagicMock()
+        self.presenter._finished = mock.MagicMock()
+
+        self.presenter.on_cancel_clicked()
+
+        self.presenter.abort_worker.assert_not_called()
+        self.assertEqual(0, mock_logger.call_count)
+        self.assertEqual(True, self.presenter.fitprop_list)
+        self.presenter._finished.assert_not_called()
+
+    def test_abort_worker(self):
+        # this behaviour is assumed in the above cancel worker tests
+        self.presenter.worker = mock.MagicMock()
+        self.presenter.worker.abort = mock.MagicMock()
+        self.presenter.abort_worker()
+        self.presenter.worker.abort.assert_called_once()
 
 
 if __name__ == '__main__':

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/presenter.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/presenter.py
@@ -27,11 +27,13 @@ class FittingPresenter(object):
         self.data_widget.presenter.fit_all_started_notifier.add_subscriber(self.fit_all_started_observer)
         self.data_widget.presenter.fit_all_started_notifier.add_subscriber(self.plot_widget.fit_all_started_observer)
         self.plot_widget.view.fit_browser.fit_notifier.add_subscriber(self.data_widget.presenter.fit_observer)
-        #
+        self.plot_widget.view.fit_browser.fit_notifier.add_subscriber(self.plot_widget.fit_complete_observer)
         self.plot_widget.view.fit_browser.fit_enabled_notifier.add_subscriber(
             self.data_widget.presenter.fit_enabled_observer)
         self.plot_widget.fit_all_done_notifier.add_subscriber(self.data_widget.presenter.fit_all_done_observer)
         self.plot_widget.fit_all_done_notifier.add_subscriber(self.fit_all_done_observer)
+        self.plot_widget.view.fit_browser.fit_started_notifier.add_subscriber(
+            self.plot_widget.fit_started_observer)
 
     def disable_view(self, _):
         self.view.setEnabled(False)

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/presenter.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/presenter.py
@@ -42,17 +42,20 @@ class FittingPresenter(object):
         self.plot_widget.view.fit_browser.fit_enabled_notifier.add_subscriber(
             self.data_widget.presenter.fit_enabled_observer)
 
-    def fit_all_started(self, ws_name_list, do_sequential=True):
+        self.connect_view_signals()
+
+    def fit_all_started(self, inputs):
+        ws_name_list, do_sequential = inputs
         # "all" refers to sequential/serial fit triggered in the data widget
         self.plot_widget.set_progress_bar_to_in_progress()
-        self.disable_view()
+        self.disable_view(fit_all=True)
         self.plot_widget.do_fit_all_async(ws_name_list, do_sequential)
 
     def fit_all_done(self, fit_props):
         # "all" refers to sequential/serial fit triggered in the data widget
         self.plot_widget.update_browser()
         self.plot_widget.set_progress_bar()
-        self.enable_view()
+        self.enable_view(fit_all=True)
         self.data_widget.presenter.fit_completed(fit_props=fit_props)
 
     def fit_started(self):
@@ -66,8 +69,22 @@ class FittingPresenter(object):
         self.plot_widget.set_final_state_progress_bar(fit_props)
         self.data_widget.presenter.fit_completed(fit_props=fit_props)
 
-    def disable_view(self, _=None):
-        self.view.setEnabled(False)
+    def disable_view(self, _=None, fit_all=False):
+        self.data_widget.view.setEnabled(False)
+        self.plot_widget.enable_view_components(False)
+        if fit_all:
+            self.plot_widget.view.show_cancel_button(True)
 
-    def enable_view(self, _=None):
-        self.view.setEnabled(True)
+    def enable_view(self, _=None, fit_all=False):
+        self.data_widget.view.setEnabled(True)
+        self.plot_widget.enable_view_components(True)
+        if fit_all:
+            self.plot_widget.view.show_cancel_button(False)
+
+    def connect_view_signals(self):
+        self.plot_widget.view.set_cancel_clicked(self.on_cancel_clicked)
+
+    def on_cancel_clicked(self):
+        self.plot_widget.on_cancel_clicked()
+        self.enable_view()
+        self.plot_widget.set_progress_bar_zero()

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/presenter.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/presenter.py
@@ -54,7 +54,7 @@ class FittingPresenter(object):
     def fit_all_done(self, fit_props):
         # "all" refers to sequential/serial fit triggered in the data widget
         self.plot_widget.update_browser()
-        self.plot_widget.set_progress_bar()
+        self.plot_widget.update_progress_bar()
         self.enable_view(fit_all=True)
         self.data_widget.presenter.fit_completed(fit_props=fit_props)
 

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/presenter.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/presenter.py
@@ -50,8 +50,9 @@ class FittingPresenter(object):
 
     def fit_all_done(self, fit_props):
         # "all" refers to sequential/serial fit triggered in the data widget
-        self.enable_view()
+        self.plot_widget.update_browser()
         self.plot_widget.set_progress_bar()
+        self.enable_view()
         self.data_widget.presenter.fit_completed(fit_props=fit_props)
 
     def fit_started(self):

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/test/test_presenter.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/test/test_presenter.py
@@ -1,0 +1,257 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2022 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+import unittest
+from unittest import mock
+
+from mantidqtinterfaces.Engineering.gui.engineering_diffraction.tabs.fitting import view, presenter
+from mantidqtinterfaces.Engineering.gui.engineering_diffraction.tabs.fitting.plotting import plot_presenter
+from mantidqt.utils.asynchronous import BlockingAsyncTaskWithCallback
+
+dir_path = "mantidqtinterfaces.Engineering.gui.engineering_diffraction.tabs.fitting.presenter"
+plot_dir_path = "mantidqtinterfaces.Engineering.gui.engineering_diffraction.tabs.fitting.plotting.plot_presenter"
+
+ws_list = ['ws1', 'ws2']
+fun_str_list = ['name=Gaussian,Height=11,PeakCentre=30000,Sigma=40',  # initial
+                'name=Gaussian,Height=10,PeakCentre=35000,Sigma=50',  # fit result of ws1
+                'name=Gaussian,Height=9,PeakCentre=40000,Sigma=60']  # fit result of ws2
+fitprop_list = []
+for iws in range(len(ws_list)):
+    fitprop_list.append({'properties': {'Function': fun_str_list[iws + 1],
+                                        'InputWorkspace': ws_list[0], 'Output': ws_list[iws]},
+                         'status': "success"})
+
+
+class FittingPresenterTest(unittest.TestCase):
+    def setUp(self):
+        self.view = mock.create_autospec(view.FittingView)
+        self.presenter = presenter.FittingPresenter(self.view)
+
+        self.call_in_progress = mock.call(status='fitting...', minimum=0, maximum=0, value=0,
+                                          style_sheet=plot_presenter.IN_PROGRESS_STYLE_SHEET)
+        self.call_fail = mock.call(status='fail', minimum=0, maximum=100, value=0,
+                                   style_sheet=plot_presenter.FAILED_STYLE_SHEET)
+        self.call_success = mock.call(status='success', minimum=0, maximum=100, value=100,
+                                      style_sheet=plot_presenter.SUCCESS_STYLE_SHEET)
+        self.call_empty = mock.call(status="", minimum=0, maximum=100, value=0,
+                                    style_sheet=plot_presenter.EMPTY_STYLE_SHEET)
+
+    def fit_all_helper(self, mock_fit, do_sequential):
+        self.presenter.plot_widget.view.read_fitprop_from_browser.return_value = \
+            {'properties': {'Function': fun_str_list[0]}}  # initial
+        mock_fit_output = [mock.MagicMock(), mock.MagicMock()]
+        mock_fit_output[0].OutputStatus = "success"
+        mock_fit_output[0].Function.fun = fun_str_list[1]
+        mock_fit_output[1].OutputStatus = "fail"
+        mock_fit_output[1].Function.fun = fun_str_list[2]
+        mock_fit.side_effect = mock_fit_output
+        mock_notifier = mock.MagicMock()
+        self.presenter.plot_widget.fit_all_done_notifier = mock_notifier
+
+        self.presenter.plot_widget.do_fit_all_async(ws_list, do_sequential=do_sequential)
+
+        self.assertEqual(mock_fit.call_count, len(ws_list))
+        fitprop_list = []
+        for iws, ws in enumerate(ws_list):
+            # check calls to fit
+            _, _, kwargs = mock_fit.mock_calls[iws]
+            if do_sequential:
+                self.assertEqual(kwargs, {'Function': fun_str_list[iws], 'InputWorkspace': ws, 'Output': ws})
+            else:
+                # use same initial params for all workspaces
+                self.assertEqual(kwargs, {'Function': fun_str_list[0], 'InputWorkspace': ws, 'Output': ws})
+            # check update browser with fit results
+            self.presenter.plot_widget.view.update_browser.assert_not_called()
+            # collect all fitprop dicts together to test notifier
+            fitprop_list.append({'properties': {'Function': fun_str_list[iws + 1], 'InputWorkspace': ws, 'Output': ws},
+                                 'status': mock_fit_output[iws].OutputStatus})
+        self.assertEqual(self.presenter.plot_widget.fitprop_list, fitprop_list)
+
+    @mock.patch(plot_dir_path + '.FittingPlotPresenter._finished')
+    @mock.patch(plot_dir_path + '.AsyncTask', wraps=BlockingAsyncTaskWithCallback)
+    @mock.patch(plot_dir_path + '.Fit')
+    def test_do_all_fit_calls_finished(self, mock_fit, mock_async, mock_fit_all_done):
+        self.fit_all_helper(mock_fit, do_sequential=False)
+        self.assertEqual(1, mock_fit_all_done.call_count)
+
+    @mock.patch(plot_dir_path + '.FittingPlotPresenter._finished')
+    @mock.patch(plot_dir_path + '.AsyncTask', wraps=BlockingAsyncTaskWithCallback)
+    @mock.patch(plot_dir_path + '.Fit')
+    def test_do_all_fit_sets_progress_bar_to_in_progress_then_final(self, mock_fit, mock_async, mock_fit_all_done):
+        self.presenter.plot_widget.view.read_fitprop_from_browser.return_value = {'properties': {'Function': fun_str_list[0]}}  # initial
+        mock_fit_output = mock.MagicMock()
+        mock_fit_output.OutputStatus = "fail"
+        mock_fit_output.Function.fun = fun_str_list[1]
+        mock_fit.return_value = mock_fit_output
+        fitprop_list = []
+        for iws in range(len(ws_list)):
+            fitprop_list.append({'properties': {'Function': fun_str_list[iws + 1],
+                                                'InputWorkspace': ws_list[0], 'Output': ws_list[iws]},
+                                 'status': "success"})
+        self.presenter.data_widget.presenter.fit_all_started_notifier.notify_subscribers((ws_list, True))
+        self.presenter.plot_widget.fitprop_list = fitprop_list
+        self.assertEqual(1, mock_fit_all_done.call_count)
+
+    def test_do_all_fit_finished_notifies_presenter(self):
+        self.presenter.plot_widget.fit_all_done_notifier.notify_subscribers = mock.MagicMock()
+        self.presenter.plot_widget.fitprop_list = fitprop_list
+        self.presenter.plot_widget._finished()
+        self.assertEqual(1, self.presenter.plot_widget.fit_all_done_notifier.notify_subscribers.call_count)
+
+    def test_fit_all_done(self):
+        self.presenter.plot_widget.update_browser = mock.MagicMock()
+        self.presenter.plot_widget.set_final_state_progress_bar = mock.MagicMock()
+        self.presenter.enable_view = mock.MagicMock()
+        self.presenter.data_widget.presenter.fit_completed = mock.MagicMock()
+
+        self.presenter.plot_widget.fitprop_list = fitprop_list
+        self.presenter.plot_widget._finished()
+
+        self.presenter.plot_widget.update_browser.assert_called_once()
+        self.presenter.plot_widget.set_final_state_progress_bar.assert_called_once_with(output_list=fitprop_list)
+        self.presenter.enable_view.assert_called_once_with(fit_all=True)
+        self.presenter.data_widget.presenter.fit_completed.assert_called_once_with(fit_props=fitprop_list)
+
+    def test_fit_all_done_calls_set_final_state_indirectly(self):
+        self.presenter.plot_widget.update_browser = mock.MagicMock()
+        self.presenter.plot_widget.update_progress_bar = mock.MagicMock()
+        self.presenter.plot_widget.set_final_state_progress_bar = mock.MagicMock()
+        self.presenter.enable_view = mock.MagicMock()
+        self.presenter.data_widget.presenter.fit_completed = mock.MagicMock()
+
+        self.presenter.plot_widget.fitprop_list = fitprop_list
+        self.presenter.plot_widget._finished()
+
+        self.presenter.plot_widget.update_progress_bar.assert_called_once()
+        self.presenter.plot_widget.set_final_state_progress_bar.assert_not_called()
+        # blocked by mocking out update_progress_bar which uses fit_props saved to the plot_presenter class
+
+    def test_fit_all_started_notified_sequential(self):
+        self.presenter.data_widget.model.get_active_ws_sorted_by_primary_log = mock.MagicMock(return_value=ws_list)
+        self.presenter.data_widget.presenter.fit_all_started_notifier.notify_subscribers = mock.MagicMock()
+        self.presenter.data_widget.presenter._start_seq_fit()
+        self.presenter.data_widget.presenter.fit_all_started_notifier.\
+            notify_subscribers.assert_called_once_with((ws_list, True))
+
+    def test_fit_all_started_notified_serial(self):
+        self.presenter.data_widget.model.get_active_ws_name_list = mock.MagicMock(return_value=ws_list)
+        self.presenter.data_widget.presenter.fit_all_started_notifier.notify_subscribers = mock.MagicMock()
+        self.presenter.data_widget.presenter._start_serial_fit()
+        self.presenter.data_widget.presenter.fit_all_started_notifier. \
+            notify_subscribers.assert_called_once_with((ws_list, False))
+
+    def test_fit_all_started_sequential(self):
+        self.presenter.data_widget.model.get_active_ws_sorted_by_primary_log = mock.MagicMock(return_value=ws_list)
+        self.presenter.plot_widget.set_progress_bar_to_in_progress = mock.MagicMock()
+        self.presenter.disable_view = mock.MagicMock()
+        self.presenter.plot_widget.do_fit_all_async = mock.MagicMock()
+
+        self.presenter.plot_widget.fitprop_list = fitprop_list
+        self.presenter.data_widget.presenter._start_seq_fit()
+
+        self.presenter.plot_widget.set_progress_bar_to_in_progress(output_list=fitprop_list)
+        self.presenter.disable_view.assert_called_once_with(fit_all=True)
+        self.presenter.plot_widget.do_fit_all_async.assert_called_once_with(ws_list, True)
+
+    def test_fit_all_started_serial(self):
+        self.presenter.data_widget.model.get_active_ws_name_list = mock.MagicMock(return_value=ws_list)
+        self.presenter.plot_widget.set_progress_bar_to_in_progress = mock.MagicMock()
+        self.presenter.disable_view = mock.MagicMock()
+        self.presenter.plot_widget.do_fit_all_async = mock.MagicMock()
+
+        self.presenter.plot_widget.fitprop_list = fitprop_list
+        self.presenter.data_widget.presenter._start_serial_fit()
+
+        self.presenter.plot_widget.set_progress_bar_to_in_progress(output_list=fitprop_list)
+        self.presenter.disable_view.assert_called_once_with(fit_all=True)
+        self.presenter.plot_widget.do_fit_all_async.assert_called_once_with(ws_list, False)
+
+    def test_fit_started_call_order(self):
+        mock_manager = mock.Mock()
+        self.presenter.disable_view = mock.MagicMock()
+        self.presenter.plot_widget.set_progress_bar_to_in_progress = mock.MagicMock()
+        mock_manager.disable, mock_manager.progress_bar = \
+            self.presenter.disable_view, self.presenter.plot_widget.set_progress_bar_to_in_progress
+
+        self.presenter.fit_started()
+        self.presenter.disable_view.assert_called_once_with()
+        mock_manager.assert_has_calls([mock.call.progress_bar(), mock.call.disable()])
+
+    def test_fit_done_call_order(self):
+        mock_manager = mock.Mock()
+        self.presenter.enable_view = mock.MagicMock()
+        self.presenter.plot_widget.set_final_state_progress_bar = mock.MagicMock()
+        self.presenter.data_widget.presenter.fit_completed = mock.MagicMock()
+        mock_manager.enable, mock_manager.progress_bar, mock_manager.fit_completed = \
+            self.presenter.enable_view, \
+            self.presenter.plot_widget.set_final_state_progress_bar, \
+            self.presenter.data_widget.presenter.fit_completed
+
+        self.presenter.fit_done(fitprop_list)
+        mock_manager.assert_has_calls([mock.call.enable(), mock.call.progress_bar(fitprop_list),
+                                       mock.call.fit_completed(fit_props=fitprop_list)])
+
+    def test_enable_view_not_fit_all(self):
+        self.presenter.data_widget.view.setEnabled = mock.MagicMock()
+        self.presenter.plot_widget.enable_view_components = mock.MagicMock()
+        self.presenter.plot_widget.view.show_cancel_button = mock.MagicMock()
+
+        self.presenter.enable_view()
+
+        self.presenter.data_widget.view.setEnabled.assert_called_once_with(True)
+        self.presenter.plot_widget.enable_view_components.assert_called_once_with(True)
+        self.presenter.plot_widget.view.show_cancel_button.assert_not_called()
+
+    def test_enable_view_fit_all(self):
+        self.presenter.data_widget.view.setEnabled = mock.MagicMock()
+        self.presenter.plot_widget.enable_view_components = mock.MagicMock()
+        self.presenter.plot_widget.view.show_cancel_button = mock.MagicMock()
+
+        self.presenter.enable_view(fit_all=True)
+
+        self.presenter.data_widget.view.setEnabled.assert_called_once_with(True)
+        self.presenter.plot_widget.enable_view_components.assert_called_once_with(True)
+        self.presenter.plot_widget.view.show_cancel_button.assert_called_once_with(False)
+
+    def test_disable_view_not_fit_all(self):
+        self.presenter.data_widget.view.setEnabled = mock.MagicMock()
+        self.presenter.plot_widget.enable_view_components = mock.MagicMock()
+        self.presenter.plot_widget.view.show_cancel_button = mock.MagicMock()
+
+        self.presenter.disable_view()
+
+        self.presenter.data_widget.view.setEnabled.assert_called_once_with(False)
+        self.presenter.plot_widget.enable_view_components.assert_called_once_with(False)
+        self.presenter.plot_widget.view.show_cancel_button.assert_not_called()
+
+    def test_disable_view_fit_all(self):
+        self.presenter.data_widget.view.setEnabled = mock.MagicMock()
+        self.presenter.plot_widget.enable_view_components = mock.MagicMock()
+        self.presenter.plot_widget.view.show_cancel_button = mock.MagicMock()
+
+        self.presenter.disable_view(fit_all=True)
+
+        self.presenter.data_widget.view.setEnabled.assert_called_once_with(False)
+        self.presenter.plot_widget.enable_view_components.assert_called_once_with(False)
+        self.presenter.plot_widget.view.show_cancel_button.assert_called_once_with(True)
+
+    def test_on_cancel_clicked(self):
+        mock_manager = mock.Mock()
+        self.presenter.plot_widget.on_cancel_clicked = mock.MagicMock()
+        self.presenter.enable_view = mock.MagicMock()
+        self.presenter.plot_widget.set_progress_bar_zero = mock.MagicMock()
+        mock_manager.cancel_clicked, mock_manager.enable, mock_manager.progress_bar = \
+            self.presenter.plot_widget.on_cancel_clicked, \
+            self.presenter.enable_view, \
+            self.presenter.plot_widget.set_progress_bar_zero
+
+        self.presenter.on_cancel_clicked()
+
+        mock_manager.assert_has_calls([mock.call.cancel_clicked(), mock.call.enable(), mock.call.progress_bar])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FitPropertyBrowser.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FitPropertyBrowser.h
@@ -333,6 +333,7 @@ signals:
   void currentChanged() const;
   void functionRemoved();
   void algorithmFinished(const QString & /*_t1*/);
+  void algorithmStarted(const QString & /*_t1*/);
   void workspaceIndexChanged(int index);
   void updatePlotSpectrum(int index);
   void workspaceNameChanged(const QString & /*_t1*/);

--- a/qt/widgets/common/src/FitPropertyBrowser.cpp
+++ b/qt/widgets/common/src/FitPropertyBrowser.cpp
@@ -1556,6 +1556,7 @@ void FitPropertyBrowser::doFit(int maxIterations) {
   }
 
   try {
+    emit algorithmStarted(QString::fromStdString(wsName));
     m_initialParameters.resize(compositeFunction()->nParams());
     for (size_t i = 0; i < compositeFunction()->nParams(); i++) {
       m_initialParameters[i] = compositeFunction()->getParameter(i);


### PR DESCRIPTION
**Description of work.**
Add new indeterminate progress bar to show when fitting is happening or has finished on the EngDiff fitting tab.

**To test:**

Please try to break this new progress bar in as many ways as possible! And together we can check that its style is clear on all OS (I've checked Ubuntu and MacOS so far). It has a moving partially blue bar when fitting, solid green for successful fit and empty with red border for failed fit. The progress bar resets to empty with a normal grey border when the fit browser is toggled open/close or a workspace is added or removed from the plot. The progress bar should mostly be in sync with the status reported text at the top of the embedded fit property browser.

- Load some focussed data into the EngDiff fitting tab and add it to the plot. Click the Fit toolbar button to enable the FitPropertyBrowser. Right-click in the plot and add a peak. 
- Click Fit > Fit and notice how the progress bar works.
- Add a few more peaks to get a longer fitting time.
- When a peaks are added to the model you should be able to click "Sequential Fit" or "Serial Fit" in the data table just above the plot. Check these methods of fitting also interact with the progress bar well.
- When sequentially or serially fitting it is possible that some spectra may succeed and some may fail. The progress bar should be in sync with the reported status at the top of the Fit property browser and report the status for the last fitted spectrum!
- again please try and break this as much as possible!
- check if tests are good enough and if I need more, I'd really like this new feature to be reliable for the users!

Fixes #34414 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
