### PR TITLE
Allow Preview Widgets to be Dockable

### DIFF
--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/CMakeLists.txt
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/CMakeLists.txt
@@ -1,4 +1,6 @@
-set(PREVIEW_SRC_FILES InstViewModel.cpp PreviewJobManager.cpp PreviewPresenter.cpp QtPreviewView.cpp PreviewModel.cpp)
+set(PREVIEW_SRC_FILES InstViewModel.cpp PreviewJobManager.cpp PreviewPresenter.cpp QtPreviewView.cpp
+                      QtPreviewDockedWidgets.cpp PreviewModel.cpp
+)
 
 # Include files aren't required, but this makes them appear in Visual Studio IMPORTANT: Include files are required in
 # the MOC_FILES set. Scroll down to find it.
@@ -12,11 +14,12 @@ set(PREVIEW_INC_FILES
     PreviewPresenterFactory.h
     PreviewPresenter.h
     IPreviewView.h
+    IPreviewDockedWidgets.h
     ROIType.h
     QtPreviewView.h
 )
 
-set(PREVIEW_MOC_FILES QtPreviewView.h)
+set(PREVIEW_MOC_FILES QtPreviewView.h QtPreviewDockedWidgets.h)
 
 set(PREVIEW_UI_FILES PreviewWidget.ui PreviewDockedWidgets.ui)
 

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/CMakeLists.txt
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/CMakeLists.txt
@@ -18,7 +18,7 @@ set(PREVIEW_INC_FILES
 
 set(PREVIEW_MOC_FILES QtPreviewView.h)
 
-set(PREVIEW_UI_FILES PreviewWidget.ui)
+set(PREVIEW_UI_FILES PreviewWidget.ui PreviewDockedWidgets.ui)
 
 prepend(PREVIEW_SRC_FILES GUI/Preview ${PREVIEW_SRC_FILES})
 prepend(PREVIEW_INC_FILES GUI/Preview ${PREVIEW_INC_FILES})

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/IPreviewDockedWidgets.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/IPreviewDockedWidgets.h
@@ -1,0 +1,68 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2022 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#pragma once
+
+#include "MantidQtWidgets/InstrumentView/RotationSurface.h"
+
+#include <QLayout>
+#include <memory>
+#include <string>
+
+namespace MantidQt::MantidWidgets {
+class IPlotView;
+}
+
+namespace MantidQt::CustomInterfaces::ISISReflectometry {
+class IBatchPresenter;
+
+class PreviewDockedWidgetsSubscriber {
+public:
+  virtual ~PreviewDockedWidgetsSubscriber() = default;
+
+  virtual void acceptMainPresenter(IBatchPresenter *mainPresenter) = 0;
+
+  virtual void notifyInstViewZoomRequested() = 0;
+  virtual void notifyInstViewEditRequested() = 0;
+  virtual void notifyInstViewSelectRectRequested() = 0;
+  virtual void notifyInstViewShapeChanged() = 0;
+
+  virtual void notifyRegionSelectorExportAdsRequested() = 0;
+  virtual void notifyLinePlotExportAdsRequested() = 0;
+
+  virtual void notifyEditROIModeRequested() = 0;
+  virtual void notifyRectangularROIModeRequested() = 0;
+};
+
+class IPreviewDockedWidgets {
+public:
+  virtual ~IPreviewDockedWidgets() = default;
+  virtual void subscribe(PreviewDockedWidgetsSubscriber *notifyee) noexcept = 0;
+
+  // Plotting
+  virtual void resetInstView() = 0;
+  virtual void plotInstView(MantidWidgets::InstrumentActor *instActor, Mantid::Kernel::V3D const &samplePos,
+                            Mantid::Kernel::V3D const &axis) = 0;
+  //  Instrument viewer toolbar
+  virtual void setInstViewZoomState(bool on) = 0;
+  virtual void setInstViewEditState(bool on) = 0;
+  virtual void setInstViewSelectRectState(bool on) = 0;
+  virtual void setInstViewZoomMode() = 0;
+  virtual void setInstViewEditMode() = 0;
+  virtual void setInstViewSelectRectMode() = 0;
+  virtual void setInstViewToolbarEnabled(bool enable) = 0;
+  virtual void setRegionSelectorEnabled(bool enable) = 0;
+  // Region selector toolbar
+  virtual void setEditROIState(bool state) = 0;
+  virtual void setRectangularROIState(bool state) = 0;
+
+  virtual std::vector<size_t> getSelectedDetectors() const = 0;
+  virtual std::string getRegionType() const = 0;
+
+  virtual QLayout *getRegionSelectorLayout() const = 0;
+  virtual MantidQt::MantidWidgets::IPlotView *getLinePlotView() const = 0;
+};
+} // namespace MantidQt::CustomInterfaces::ISISReflectometry

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/IPreviewView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/IPreviewView.h
@@ -28,18 +28,6 @@ public:
 
   virtual void notifyLoadWorkspaceRequested() = 0;
   virtual void notifyUpdateAngle() = 0;
-
-  virtual void notifyInstViewZoomRequested() = 0;
-  virtual void notifyInstViewEditRequested() = 0;
-  virtual void notifyInstViewSelectRectRequested() = 0;
-  virtual void notifyInstViewShapeChanged() = 0;
-
-  virtual void notifyRegionSelectorExportAdsRequested() = 0;
-  virtual void notifyLinePlotExportAdsRequested() = 0;
-
-  virtual void notifyEditROIModeRequested() = 0;
-  virtual void notifyRectangularROIModeRequested() = 0;
-
   virtual void notifyApplyRequested() = 0;
 };
 
@@ -47,34 +35,13 @@ class IPreviewView {
 public:
   virtual ~IPreviewView() = default;
   virtual void subscribe(PreviewViewSubscriber *notifyee) noexcept = 0;
+  virtual QLayout *getDockedWidgetsLayout() noexcept = 0;
   virtual void enableApplyButton() = 0;
   virtual void disableApplyButton() = 0;
 
   virtual std::string getWorkspaceName() const = 0;
   virtual double getAngle() const = 0;
-  // Plotting
-  virtual void resetInstView() = 0;
-  virtual void plotInstView(MantidWidgets::InstrumentActor *instActor, Mantid::Kernel::V3D const &samplePos,
-                            Mantid::Kernel::V3D const &axis) = 0;
-  //  Instrument viewer toolbar
-  virtual void setInstViewZoomState(bool on) = 0;
-  virtual void setInstViewEditState(bool on) = 0;
-  virtual void setInstViewSelectRectState(bool on) = 0;
-  virtual void setInstViewZoomMode() = 0;
-  virtual void setInstViewEditMode() = 0;
-  virtual void setInstViewSelectRectMode() = 0;
-  virtual void setInstViewToolbarEnabled(bool enable) = 0;
-  virtual void setRegionSelectorEnabled(bool enable) = 0;
   virtual void setAngle(double angle) = 0;
   virtual void setUpdateAngleButtonEnabled(bool enabled) = 0;
-  // Region selector toolbar
-  virtual void setEditROIState(bool state) = 0;
-  virtual void setRectangularROIState(bool state) = 0;
-
-  virtual std::vector<size_t> getSelectedDetectors() const = 0;
-  virtual std::string getRegionType() const = 0;
-
-  virtual QLayout *getRegionSelectorLayout() const = 0;
-  virtual MantidQt::MantidWidgets::IPlotView *getLinePlotView() const = 0;
 };
 } // namespace MantidQt::CustomInterfaces::ISISReflectometry

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewDockedWidgets.ui
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewDockedWidgets.ui
@@ -1,0 +1,205 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>PreviewDockedWidgets</class>
+ <widget class="QMainWindow" name="PreviewDockedWidgets">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>800</width>
+    <height>600</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>MainWindow</string>
+  </property>
+  <widget class="QWidget" name="centralwidget"/>
+  <widget class="QDockWidget" name="iv_dock">
+   <property name="features">
+    <set>QDockWidget::DockWidgetFloatable|QDockWidget::DockWidgetMovable</set>
+   </property>
+   <attribute name="dockWidgetArea">
+    <number>4</number>
+   </attribute>
+   <widget class="QWidget" name="iv_dock_content">
+    <layout class="QVBoxLayout" name="verticalLayout_5">
+     <item>
+      <layout class="QVBoxLayout" name="iv_layout">
+       <item>
+        <layout class="QHBoxLayout" name="iv_toolbar_layout">
+         <property name="sizeConstraint">
+          <enum>QLayout::SetMinimumSize</enum>
+         </property>
+         <item>
+          <widget class="QToolButton" name="iv_zoom_button">
+           <property name="toolTip">
+            <string>Move the instrument</string>
+           </property>
+           <property name="text">
+            <string>Zoom</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QToolButton" name="iv_edit_button">
+           <property name="toolTip">
+            <string>Select and edit shapes</string>
+           </property>
+           <property name="text">
+            <string>Edit</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QToolButton" name="iv_rect_select_button">
+           <property name="toolTip">
+            <string>Draw a rectangle</string>
+           </property>
+           <property name="text">
+            <string>Rect. Select</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <spacer name="iv_toolbar_spacer">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <widget class="QWidget" name="iv_placeholder" native="true"/>
+       </item>
+      </layout>
+     </item>
+    </layout>
+   </widget>
+  </widget>
+  <widget class="QDockWidget" name="rs_dock">
+   <property name="features">
+    <set>QDockWidget::DockWidgetFloatable|QDockWidget::DockWidgetMovable</set>
+   </property>
+   <attribute name="dockWidgetArea">
+    <number>4</number>
+   </attribute>
+   <widget class="QWidget" name="rs_dock_content">
+    <layout class="QHBoxLayout" name="horizontalLayout_2">
+     <item>
+      <layout class="QVBoxLayout" name="rs_plot_layout">
+       <item>
+        <layout class="QHBoxLayout" name="rs_toolbar_layout">
+         <item>
+          <widget class="QToolButton" name="rs_ads_export_button">
+           <property name="toolTip">
+            <string>Export the summed workspace to the workspaces list</string>
+           </property>
+           <property name="text">
+            <string>Export summed workspace</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QToolButton" name="rs_edit_button">
+           <property name="toolTip">
+            <string>Edit a rectangular region of interest</string>
+           </property>
+           <property name="text">
+            <string>Edit ROI</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QToolButton" name="rs_rect_select_button">
+           <property name="toolTip">
+            <string>Select a rectangular region of interest</string>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+           <property name="popupMode">
+            <enum>QToolButton::MenuButtonPopup</enum>
+           </property>
+           <property name="toolButtonStyle">
+            <enum>Qt::ToolButtonTextBesideIcon</enum>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <spacer name="rs_toolbar_spacer">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <widget class="QWidget" name="region_selector" native="true"/>
+       </item>
+      </layout>
+     </item>
+    </layout>
+   </widget>
+  </widget>
+  <widget class="QDockWidget" name="lp_dock">
+   <property name="features">
+    <set>QDockWidget::DockWidgetFloatable|QDockWidget::DockWidgetMovable</set>
+   </property>
+   <attribute name="dockWidgetArea">
+    <number>4</number>
+   </attribute>
+   <widget class="QWidget" name="lp_dock_content">
+    <layout class="QVBoxLayout" name="verticalLayout_4">
+     <item>
+      <layout class="QVBoxLayout" name="lp_layout">
+       <item>
+        <widget class="QToolButton" name="lp_ads_export_button">
+         <property name="toolTip">
+          <string>Export the reduced workspace to the workspaces list</string>
+         </property>
+         <property name="text">
+          <string>Export reduced workspace</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="MantidQt::MantidWidgets::QtPlotView" name="line_plot" native="true">
+         <property name="toolTip">
+          <string>Reduced data. Use right-click for plot options</string>
+         </property>
+         <property name="toolTipDuration">
+          <number>2000</number>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </item>
+    </layout>
+   </widget>
+  </widget>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>MantidQt::MantidWidgets::QtPlotView</class>
+   <extends>QWidget</extends>
+   <header>MantidQtWidgets/Plotting/PlotWidget/QtPlotView.h</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewDockedWidgets.ui
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewDockedWidgets.ui
@@ -7,8 +7,14 @@
     <x>0</x>
     <y>0</y>
     <width>800</width>
-    <height>600</height>
+    <height>469</height>
    </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
   </property>
   <property name="windowTitle">
    <string>MainWindow</string>
@@ -17,6 +23,9 @@
   <widget class="QDockWidget" name="iv_dock">
    <property name="features">
     <set>QDockWidget::DockWidgetFloatable|QDockWidget::DockWidgetMovable</set>
+   </property>
+   <property name="allowedAreas">
+    <set>Qt::LeftDockWidgetArea|Qt::RightDockWidgetArea|Qt::TopDockWidgetArea</set>
    </property>
    <attribute name="dockWidgetArea">
     <number>4</number>
@@ -87,11 +96,14 @@
    <property name="features">
     <set>QDockWidget::DockWidgetFloatable|QDockWidget::DockWidgetMovable</set>
    </property>
+   <property name="allowedAreas">
+    <set>Qt::LeftDockWidgetArea|Qt::RightDockWidgetArea|Qt::TopDockWidgetArea</set>
+   </property>
    <attribute name="dockWidgetArea">
     <number>4</number>
    </attribute>
    <widget class="QWidget" name="rs_dock_content">
-    <layout class="QHBoxLayout" name="horizontalLayout_2">
+    <layout class="QVBoxLayout" name="verticalLayout">
      <item>
       <layout class="QVBoxLayout" name="rs_plot_layout">
        <item>
@@ -156,8 +168,17 @@
    </widget>
   </widget>
   <widget class="QDockWidget" name="lp_dock">
+   <property name="minimumSize">
+    <size>
+     <width>0</width>
+     <height>0</height>
+    </size>
+   </property>
    <property name="features">
     <set>QDockWidget::DockWidgetFloatable|QDockWidget::DockWidgetMovable</set>
+   </property>
+   <property name="allowedAreas">
+    <set>Qt::LeftDockWidgetArea|Qt::RightDockWidgetArea|Qt::TopDockWidgetArea</set>
    </property>
    <attribute name="dockWidgetArea">
     <number>4</number>

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.cpp
@@ -8,6 +8,7 @@
 #include "PreviewPresenter.h"
 #include "Common/Detector.h"
 #include "GUI/Batch/IBatchPresenter.h"
+#include "GUI/Preview/QtPreviewDockedWidgets.h"
 #include "MantidAPI/MatrixWorkspace.h"
 #include "MantidKernel/Strings.h"
 #include "MantidQtWidgets/Plotting/AxisID.h"
@@ -35,12 +36,14 @@ PreviewPresenter::PreviewPresenter(Dependencies dependencies)
       m_jobManager(std::move(dependencies.jobManager)), m_instViewModel(std::move(dependencies.instViewModel)),
       m_regionSelector(std::move(dependencies.regionSelector)),
       m_plotPresenter(std::move(dependencies.plotPresenter)), m_stubRegionObserver{new StubRegionObserver} {
-
+  if (!m_dockedWidgets) {
+    m_dockedWidgets = std::make_unique<QtPreviewDockedWidgets>(nullptr, m_view->getDockedWidgetsLayout());
+  }
   if (!m_regionSelector) {
-    m_regionSelector = std::make_unique<RegionSelector>(nullptr, m_view->getRegionSelectorLayout());
+    m_regionSelector = std::make_unique<RegionSelector>(nullptr, m_dockedWidgets->getRegionSelectorLayout());
   }
   if (!m_plotPresenter) {
-    m_plotPresenter = std::make_unique<PlotPresenter>(m_view->getLinePlotView());
+    m_plotPresenter = std::make_unique<PlotPresenter>(m_dockedWidgets->getLinePlotView());
   }
   // stub observer subscribes to the region selector
   m_regionSelector->subscribe(m_stubRegionObserver);
@@ -50,8 +53,8 @@ PreviewPresenter::PreviewPresenter(Dependencies dependencies)
   m_view->subscribe(this);
   m_jobManager->subscribe(this);
 
-  m_view->setInstViewToolbarEnabled(false);
-  m_view->setRegionSelectorEnabled(false);
+  m_dockedWidgets->setInstViewToolbarEnabled(false);
+  m_dockedWidgets->setRegionSelectorEnabled(false);
 
   m_plotPresenter->setScaleLog(AxisID::YLeft);
   m_plotPresenter->setScaleLog(AxisID::XBottom);
@@ -107,8 +110,8 @@ void PreviewPresenter::notifyLoadWorkspaceCompleted() {
   }
 
   if (hasLinearDetector(ws)) {
-    m_view->resetInstView();
-    m_view->setInstViewToolbarEnabled(false);
+    m_dockedWidgets->resetInstView();
+    m_dockedWidgets->setInstViewToolbarEnabled(false);
     m_model->setSummedWs(ws);
     notifySumBanksCompleted();
   } else {
@@ -116,7 +119,7 @@ void PreviewPresenter::notifyLoadWorkspaceCompleted() {
     m_instViewModel->updateWorkspace(ws);
     plotInstView();
     // Ensure the toolbar is enabled, and reset the instrument view to zoom mode
-    m_view->setInstViewToolbarEnabled(true);
+    m_dockedWidgets->setInstViewToolbarEnabled(true);
     notifyInstViewZoomRequested();
     // Perform summing banks to update the next plot, if possible
     runSumBanks();
@@ -127,7 +130,7 @@ void PreviewPresenter::notifyUpdateAngle() { runReduction(); }
 
 void PreviewPresenter::notifySumBanksCompleted() {
   plotRegionSelector();
-  m_view->setRegionSelectorEnabled(true);
+  m_dockedWidgets->setRegionSelectorEnabled(true);
   // Perform reduction to update the next plot, if possible
   runReduction();
 }
@@ -145,31 +148,31 @@ void PreviewPresenter::notifySumBanksAlgorithmError() {
 void PreviewPresenter::notifyReductionAlgorithmError() { clearReductionPlot(); }
 
 void PreviewPresenter::notifyInstViewSelectRectRequested() {
-  m_view->setInstViewZoomState(false);
-  m_view->setInstViewEditState(false);
-  m_view->setInstViewSelectRectState(true);
-  m_view->setInstViewSelectRectMode();
+  m_dockedWidgets->setInstViewZoomState(false);
+  m_dockedWidgets->setInstViewEditState(false);
+  m_dockedWidgets->setInstViewSelectRectState(true);
+  m_dockedWidgets->setInstViewSelectRectMode();
 }
 
 void PreviewPresenter::notifyInstViewEditRequested() {
-  m_view->setInstViewZoomState(false);
-  m_view->setInstViewEditState(true);
-  m_view->setInstViewSelectRectState(false);
-  m_view->setInstViewEditMode();
+  m_dockedWidgets->setInstViewZoomState(false);
+  m_dockedWidgets->setInstViewEditState(true);
+  m_dockedWidgets->setInstViewSelectRectState(false);
+  m_dockedWidgets->setInstViewEditMode();
 }
 
 void PreviewPresenter::notifyInstViewZoomRequested() {
-  m_view->setInstViewZoomState(true);
-  m_view->setInstViewEditState(false);
-  m_view->setInstViewSelectRectState(false);
-  m_view->setInstViewZoomMode();
+  m_dockedWidgets->setInstViewZoomState(true);
+  m_dockedWidgets->setInstViewEditState(false);
+  m_dockedWidgets->setInstViewSelectRectState(false);
+  m_dockedWidgets->setInstViewZoomMode();
 }
 
 void PreviewPresenter::notifyInstViewShapeChanged() {
   // Change to shape editing after a selection has been done to match instrument viewer default behaviour
   notifyInstViewEditRequested();
   // Get the masked workspace indices
-  auto indices = m_instViewModel->detIndicesToDetIDs(m_view->getSelectedDetectors());
+  auto indices = m_instViewModel->detIndicesToDetIDs(m_dockedWidgets->getSelectedDetectors());
   auto detIDsStr = Mantid::Kernel::Strings::joinCompress(indices.cbegin(), indices.cend(), ",");
   m_model->setSelectedBanks(ProcessingInstructions{detIDsStr});
   // Execute summing the selected banks
@@ -179,22 +182,22 @@ void PreviewPresenter::notifyInstViewShapeChanged() {
 void PreviewPresenter::notifyRegionSelectorExportAdsRequested() { m_model->exportSummedWsToAds(); }
 
 void PreviewPresenter::notifyEditROIModeRequested() {
-  m_view->setRectangularROIState(false);
-  m_view->setEditROIState(true);
+  m_dockedWidgets->setRectangularROIState(false);
+  m_dockedWidgets->setEditROIState(true);
   m_regionSelector->cancelDrawingRegion();
 }
 
 void PreviewPresenter::notifyRectangularROIModeRequested() {
-  auto const regionType = m_view->getRegionType();
+  auto const regionType = m_dockedWidgets->getRegionType();
   auto const roiType = roiTypeFromString(regionType);
-  m_view->setEditROIState(false);
-  m_view->setRectangularROIState(true);
+  m_dockedWidgets->setEditROIState(false);
+  m_dockedWidgets->setRectangularROIState(true);
   m_regionSelector->addRectangularRegion(regionType, roiTypeToColor(roiType));
 }
 
 void PreviewPresenter::notifyRegionChanged() {
-  m_view->setRectangularROIState(false);
-  m_view->setEditROIState(true);
+  m_dockedWidgets->setRectangularROIState(false);
+  m_dockedWidgets->setEditROIState(true);
 
   runReduction();
 }
@@ -226,8 +229,8 @@ void PreviewPresenter::notifyApplyRequested() {
 }
 
 void PreviewPresenter::plotInstView() {
-  m_view->plotInstView(m_instViewModel->getInstrumentViewActor(), m_instViewModel->getSamplePos(),
-                       m_instViewModel->getAxis());
+  m_dockedWidgets->plotInstView(m_instViewModel->getInstrumentViewActor(), m_instViewModel->getSamplePos(),
+                                m_instViewModel->getAxis());
 }
 
 void PreviewPresenter::plotRegionSelector() { m_regionSelector->updateWorkspace(m_model->getSummedWs()); }
@@ -259,7 +262,7 @@ PreviewRow const &PreviewPresenter::getPreviewRow() const { return m_model->getP
 
 void PreviewPresenter::clearRegionSelector() {
   m_regionSelector->clearWorkspace();
-  m_view->setRegionSelectorEnabled(false);
+  m_dockedWidgets->setRegionSelectorEnabled(false);
 }
 
 void PreviewPresenter::clearReductionPlot() {

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.cpp
@@ -34,7 +34,7 @@ namespace MantidQt::CustomInterfaces::ISISReflectometry {
 PreviewPresenter::PreviewPresenter(Dependencies dependencies)
     : m_view(dependencies.view), m_model(std::move(dependencies.model)),
       m_jobManager(std::move(dependencies.jobManager)), m_instViewModel(std::move(dependencies.instViewModel)),
-      m_regionSelector(std::move(dependencies.regionSelector)),
+      m_dockedWidgets(std::move(dependencies.dockedWidgets)), m_regionSelector(std::move(dependencies.regionSelector)),
       m_plotPresenter(std::move(dependencies.plotPresenter)), m_stubRegionObserver{new StubRegionObserver} {
   if (!m_dockedWidgets) {
     m_dockedWidgets = std::make_unique<QtPreviewDockedWidgets>(nullptr, m_view->getDockedWidgetsLayout());

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.cpp
@@ -52,6 +52,7 @@ PreviewPresenter::PreviewPresenter(Dependencies dependencies)
 
   m_view->subscribe(this);
   m_jobManager->subscribe(this);
+  m_dockedWidgets->subscribe(this);
 
   m_dockedWidgets->setInstViewToolbarEnabled(false);
   m_dockedWidgets->setRegionSelectorEnabled(false);

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.h
@@ -49,6 +49,7 @@ public:
     std::unique_ptr<IPreviewModel> model;
     std::unique_ptr<IJobManager> jobManager;
     std::unique_ptr<IInstViewModel> instViewModel;
+    std::unique_ptr<IPreviewDockedWidgets> dockedWidgets{nullptr};
     std::unique_ptr<MantidQt::Widgets::IRegionSelector> regionSelector{nullptr};
     std::unique_ptr<MantidQt::MantidWidgets::PlotPresenter> plotPresenter{nullptr};
   };
@@ -95,11 +96,11 @@ public:
 
 private:
   IPreviewView *m_view{nullptr};
-  std::unique_ptr<IPreviewDockedWidgets> m_dockedWidgets{nullptr};
   IBatchPresenter *m_mainPresenter{nullptr};
   std::unique_ptr<IPreviewModel> m_model;
   std::unique_ptr<IJobManager> m_jobManager;
   std::unique_ptr<IInstViewModel> m_instViewModel;
+  std::unique_ptr<IPreviewDockedWidgets> m_dockedWidgets{nullptr};
   std::unique_ptr<MantidQt::Widgets::IRegionSelector> m_regionSelector;
   std::unique_ptr<MantidQt::MantidWidgets::PlotPresenter> m_plotPresenter;
   std::shared_ptr<StubRegionObserver> m_stubRegionObserver;

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.h
@@ -10,6 +10,7 @@
 #include "GUI/Batch/IBatchView.h"
 #include "GUI/Common/IJobManager.h"
 #include "IInstViewModel.h"
+#include "IPreviewDockedWidgets.h"
 #include "IPreviewModel.h"
 #include "IPreviewPresenter.h"
 #include "IPreviewView.h"
@@ -26,6 +27,7 @@ class IBatchPresenter;
 
 class MANTIDQT_ISISREFLECTOMETRY_DLL PreviewPresenter : public IPreviewPresenter,
                                                         public PreviewViewSubscriber,
+                                                        public PreviewDockedWidgetsSubscriber,
                                                         public JobManagerSubscriber,
                                                         public Mantid::API::RegionSelectorObserver {
 public:
@@ -93,6 +95,7 @@ public:
 
 private:
   IPreviewView *m_view{nullptr};
+  std::unique_ptr<IPreviewDockedWidgets> m_dockedWidgets{nullptr};
   IBatchPresenter *m_mainPresenter{nullptr};
   std::unique_ptr<IPreviewModel> m_model;
   std::unique_ptr<IJobManager> m_jobManager;

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewWidget.ui
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewWidget.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>1000</width>
-    <height>873</height>
+    <height>633</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -97,20 +97,27 @@
     </layout>
    </item>
    <item>
-    <layout class="QVBoxLayout" name="dockable_widgets_layout"/>
-   </item>
-   <item>
-    <widget class="QSplitter" name="inst_view_2d_plot_splitter">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
+    <widget class="QScrollArea" name="scrollArea">
+     <property name="verticalScrollBarPolicy">
+      <enum>Qt::ScrollBarAlwaysOff</enum>
      </property>
-     <widget class="QSplitter" name="subplot_splitter">
-      <property name="orientation">
-       <enum>Qt::Vertical</enum>
+     <property name="widgetResizable">
+      <bool>true</bool>
+     </property>
+     <widget class="QWidget" name="scrollAreaWidgetContents_2">
+      <property name="geometry">
+       <rect>
+        <x>0</x>
+        <y>0</y>
+        <width>980</width>
+        <height>546</height>
+       </rect>
       </property>
-      <property name="handleWidth">
-       <number>2</number>
-      </property>
+      <layout class="QVBoxLayout" name="verticalLayout_2">
+       <item>
+        <layout class="QVBoxLayout" name="dockable_widgets_layout"/>
+       </item>
+      </layout>
      </widget>
     </widget>
    </item>
@@ -120,7 +127,17 @@
       <enum>QLayout::SetMinimumSize</enum>
      </property>
      <item>
-      <widget class="QTableWidget" name="tableWidget_2"/>
+      <spacer name="output_tool_spacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
      </item>
      <item>
       <widget class="QPushButton" name="apply_button">
@@ -135,7 +152,6 @@
  </widget>
  <tabstops>
   <tabstop>workspace_line_edit</tabstop>
-  <tabstop>tableWidget_2</tabstop>
   <tabstop>apply_button</tabstop>
  </tabstops>
  <resources>

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewWidget.ui
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewWidget.ui
@@ -97,67 +97,13 @@
     </layout>
    </item>
    <item>
+    <layout class="QVBoxLayout" name="dockable_widgets_layout"/>
+   </item>
+   <item>
     <widget class="QSplitter" name="inst_view_2d_plot_splitter">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
      </property>
-     <widget class="QWidget" name="instViewayoutWidget">
-      <layout class="QVBoxLayout" name="inst_view_layout">
-       <item>
-        <layout class="QHBoxLayout" name="inst_view_toolbar_layout">
-         <property name="sizeConstraint">
-          <enum>QLayout::SetMinimumSize</enum>
-         </property>
-         <item>
-          <widget class="QToolButton" name="iv_zoom_button">
-           <property name="toolTip">
-            <string>Move the instrument</string>
-           </property>
-           <property name="text">
-            <string>Zoom</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QToolButton" name="iv_edit_button">
-           <property name="toolTip">
-            <string>Select and edit shapes</string>
-           </property>
-           <property name="text">
-            <string>Edit</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QToolButton" name="iv_rect_select_button">
-           <property name="toolTip">
-            <string>Draw a rectangle</string>
-           </property>
-           <property name="text">
-            <string>Rect. Select</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <spacer name="iv_toolbar_spacer">
-           <property name="orientation">
-            <enum>Qt::Horizontal</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>40</width>
-             <height>20</height>
-            </size>
-           </property>
-          </spacer>
-         </item>
-        </layout>
-       </item>
-       <item>
-        <widget class="QWidget" name="inst_view_placeholder" native="true"/>
-       </item>
-      </layout>
-     </widget>
      <widget class="QSplitter" name="subplot_splitter">
       <property name="orientation">
        <enum>Qt::Vertical</enum>
@@ -165,90 +111,6 @@
       <property name="handleWidth">
        <number>2</number>
       </property>
-      <widget class="QWidget" name="rsPlotLayoutWidget">
-       <layout class="QVBoxLayout" name="rs_plot_layout">
-        <item>
-         <layout class="QHBoxLayout" name="horizontalLayout">
-          <item>
-           <widget class="QToolButton" name="rs_ads_export_button">
-            <property name="toolTip">
-             <string>Export the summed workspace to the workspaces list</string>
-            </property>
-            <property name="text">
-             <string>Export summed workspace</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QToolButton" name="rs_edit_button">
-            <property name="toolTip">
-             <string>Edit a rectangular region of interest</string>
-            </property>
-            <property name="text">
-             <string>Edit ROI</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QToolButton" name="rs_rect_select_button">
-            <property name="toolTip">
-             <string>Select a rectangular region of interest</string>
-            </property>
-            <property name="text">
-             <string/>
-            </property>
-            <property name="popupMode">
-             <enum>QToolButton::MenuButtonPopup</enum>
-            </property>
-            <property name="toolButtonStyle">
-             <enum>Qt::ToolButtonTextBesideIcon</enum>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <spacer name="rs_toolbar_spacer">
-            <property name="orientation">
-             <enum>Qt::Horizontal</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>40</width>
-              <height>20</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
-         </layout>
-        </item>
-        <item>
-         <widget class="QWidget" name="region_selector" native="true"/>
-        </item>
-       </layout>
-      </widget>
-      <widget class="QWidget" name="linePlotLayoutWidget">
-       <layout class="QVBoxLayout" name="line_plot_layout">
-        <item>
-         <widget class="QToolButton" name="lp_ads_export_button">
-          <property name="toolTip">
-           <string>Export the reduced workspace to the workspaces list</string>
-          </property>
-          <property name="text">
-           <string>Export reduced workspace</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="MantidQt::MantidWidgets::QtPlotView" name="line_plot" native="true">
-          <property name="toolTip">
-           <string>Reduced data. Use right-click for plot options</string>
-          </property>
-          <property name="toolTipDuration">
-           <number>2000</number>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </widget>
      </widget>
     </widget>
    </item>
@@ -271,18 +133,8 @@
    </item>
   </layout>
  </widget>
- <customwidgets>
-  <customwidget>
-   <class>MantidQt::MantidWidgets::QtPlotView</class>
-   <extends>QWidget</extends>
-   <header>MantidQtWidgets/Plotting/PlotWidget/QtPlotView.h</header>
-   <container>1</container>
-  </customwidget>
- </customwidgets>
  <tabstops>
   <tabstop>workspace_line_edit</tabstop>
-  <tabstop>rs_ads_export_button</tabstop>
-  <tabstop>lp_ads_export_button</tabstop>
   <tabstop>tableWidget_2</tabstop>
   <tabstop>apply_button</tabstop>
  </tabstops>

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/QtPreviewDockedWidgets.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/QtPreviewDockedWidgets.cpp
@@ -23,7 +23,7 @@ using MantidQt::MantidWidgets::ProjectionSurface;
 
 namespace MantidQt::CustomInterfaces::ISISReflectometry {
 QtPreviewDockedWidgets::QtPreviewDockedWidgets(QWidget *parent, QLayout *layout)
-    : QMainWindow(parent), m_layout(std::move(layout)) {
+    : QMainWindow(parent), m_layout(layout) {
   QMainWindow::setWindowFlags(Qt::Widget);
   setDockOptions(QMainWindow::AnimatedDocks);
   m_ui.setupUi(this);

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/QtPreviewDockedWidgets.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/QtPreviewDockedWidgets.cpp
@@ -1,0 +1,170 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2022 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#include "QtPreviewDockedWidgets.h"
+#include "MantidAPI/MatrixWorkspace_fwd.h"
+#include "MantidQtIcons/Icon.h"
+#include "MantidQtWidgets/InstrumentView/InstrumentActor.h"
+#include "MantidQtWidgets/InstrumentView/ProjectionSurface.h"
+#include "MantidQtWidgets/InstrumentView/UnwrappedCylinder.h"
+#include "MantidQtWidgets/Plotting/PreviewPlot.h"
+#include "ROIType.h"
+
+#include <QAction>
+#include <QMainWindow>
+#include <QMenu>
+
+using namespace Mantid::Kernel;
+using MantidQt::MantidWidgets::IPlotView;
+using MantidQt::MantidWidgets::ProjectionSurface;
+
+namespace MantidQt::CustomInterfaces::ISISReflectometry {
+QtPreviewDockedWidgets::QtPreviewDockedWidgets(QWidget *parent, QLayout *layout)
+    : QMainWindow(parent), m_layout(std::move(layout)) {
+  QMainWindow::setWindowFlags(Qt::Widget);
+  setDockOptions(QMainWindow::AnimatedDocks);
+  m_ui.setupUi(this);
+  m_layout->addWidget(this);
+
+  resetInstView();
+  loadToolbarIcons();
+  setupSelectRegionTypes();
+  connectSignals();
+}
+
+void QtPreviewDockedWidgets::loadToolbarIcons() {
+  m_ui.iv_zoom_button->setIcon(MantidQt::Icons::getIcon("mdi.magnify", "black", 1.3));
+  m_ui.iv_edit_button->setIcon(MantidQt::Icons::getIcon("mdi.pencil", "black", 1.3));
+  m_ui.iv_rect_select_button->setIcon(MantidQt::Icons::getIcon("mdi.selection", "black", 1.3));
+  m_ui.rs_ads_export_button->setIcon(MantidQt::Icons::getIcon("mdi.file-export", "black", 1.3));
+  m_ui.rs_edit_button->setIcon(MantidQt::Icons::getIcon("mdi.pencil", "black", 1.3));
+  m_ui.lp_ads_export_button->setIcon(MantidQt::Icons::getIcon("mdi.file-export", "black", 1.3));
+}
+
+void QtPreviewDockedWidgets::setupSelectRegionTypes() {
+  QMenu *menu = new QMenu();
+  QAction *signalAction = new QAction(
+      MantidQt::Icons::getIcon("mdi.selection", QString::fromStdString(roiTypeToColor(ROIType::Signal)), 1.3),
+      QString::fromStdString(roiTypeToString(ROIType::Signal)));
+  QAction *backgroundAction = new QAction(
+      MantidQt::Icons::getIcon("mdi.selection", QString::fromStdString(roiTypeToColor(ROIType::Background)), 1.3),
+      QString::fromStdString(roiTypeToString(ROIType::Background)));
+  QAction *transmissionAction = new QAction(
+      MantidQt::Icons::getIcon("mdi.selection", QString::fromStdString(roiTypeToColor(ROIType::Transmission)), 1.3),
+      QString::fromStdString(roiTypeToString(ROIType::Transmission)));
+
+  signalAction->setToolTip("Add rectangular signal region");
+  backgroundAction->setToolTip("Add rectangular background region");
+  transmissionAction->setToolTip("Add rectangular transmission region");
+
+  menu->addAction(signalAction);
+  menu->addAction(backgroundAction);
+  menu->addAction(transmissionAction);
+
+  m_ui.rs_rect_select_button->setMenu(menu);
+  m_ui.rs_rect_select_button->setDefaultAction(signalAction);
+
+  connect(menu, SIGNAL(triggered(QAction *)), this, SLOT(onAddRectangularROIClicked(QAction *)));
+}
+
+void QtPreviewDockedWidgets::subscribe(PreviewDockedWidgetsSubscriber *notifyee) noexcept { m_notifyee = notifyee; }
+
+void QtPreviewDockedWidgets::connectSignals() const {
+  // Instrument viewer toolbar
+  connect(m_ui.iv_zoom_button, SIGNAL(clicked()), this, SLOT(onInstViewZoomClicked()));
+  connect(m_ui.iv_edit_button, SIGNAL(clicked()), this, SLOT(onInstViewEditClicked()));
+  connect(m_ui.iv_rect_select_button, SIGNAL(clicked()), this, SLOT(onInstViewSelectRectClicked()));
+  // Region selector toolbar
+  connect(m_ui.rs_ads_export_button, SIGNAL(clicked()), this, SLOT(onRegionSelectorExportToAdsClicked()));
+  connect(m_ui.rs_edit_button, SIGNAL(clicked()), this, SLOT(onEditROIClicked()));
+  // Line plot toolbar
+  connect(m_ui.lp_ads_export_button, SIGNAL(clicked()), this, SLOT(onLinePlotExportToAdsClicked()));
+}
+
+void QtPreviewDockedWidgets::onInstViewZoomClicked() const { m_notifyee->notifyInstViewZoomRequested(); }
+void QtPreviewDockedWidgets::onInstViewEditClicked() const { m_notifyee->notifyInstViewEditRequested(); }
+void QtPreviewDockedWidgets::onInstViewSelectRectClicked() const { m_notifyee->notifyInstViewSelectRectRequested(); }
+void QtPreviewDockedWidgets::onInstViewShapeChanged() const { m_notifyee->notifyInstViewShapeChanged(); }
+
+void QtPreviewDockedWidgets::onRegionSelectorExportToAdsClicked() const {
+  m_notifyee->notifyRegionSelectorExportAdsRequested();
+}
+
+void QtPreviewDockedWidgets::onEditROIClicked() const { m_notifyee->notifyEditROIModeRequested(); }
+
+void QtPreviewDockedWidgets::onAddRectangularROIClicked(QAction *regionType) const {
+  m_ui.rs_rect_select_button->setDefaultAction(regionType);
+  m_notifyee->notifyRectangularROIModeRequested();
+}
+
+void QtPreviewDockedWidgets::onLinePlotExportToAdsClicked() const { m_notifyee->notifyLinePlotExportAdsRequested(); }
+
+void QtPreviewDockedWidgets::resetInstView() {
+  if (m_instDisplay) {
+    // Destruct the previous instance
+    m_instDisplay = nullptr;
+  }
+  m_instDisplay = std::make_unique<MantidWidgets::InstrumentDisplay>(m_ui.iv_placeholder);
+}
+
+void QtPreviewDockedWidgets::plotInstView(MantidWidgets::InstrumentActor *instActor, V3D const &samplePos,
+                                          V3D const &axis) {
+  // We need to recreate the surface so disconnect any existing signals first
+  if (m_instDisplay->getSurface()) {
+    disconnect(m_instDisplay->getSurface().get(), SIGNAL(shapeChangeFinished()));
+  }
+  m_instDisplay->setSurface(std::make_shared<MantidWidgets::UnwrappedCylinder>(instActor, samplePos, axis));
+  connect(m_instDisplay->getSurface().get(), SIGNAL(shapeChangeFinished()), this, SLOT(onInstViewShapeChanged()));
+}
+
+QLayout *QtPreviewDockedWidgets::getRegionSelectorLayout() const { return m_ui.rs_plot_layout; }
+
+IPlotView *QtPreviewDockedWidgets::getLinePlotView() const { return m_ui.line_plot; }
+
+void QtPreviewDockedWidgets::setInstViewZoomState(bool isChecked) { m_ui.iv_zoom_button->setDown(isChecked); }
+void QtPreviewDockedWidgets::setInstViewEditState(bool isChecked) { m_ui.iv_edit_button->setDown(isChecked); }
+
+void QtPreviewDockedWidgets::setInstViewSelectRectState(bool isChecked) {
+  m_ui.iv_rect_select_button->setDown(isChecked);
+}
+
+void QtPreviewDockedWidgets::setInstViewZoomMode() {
+  m_instDisplay->getSurface()->setInteractionMode(ProjectionSurface::MoveMode);
+}
+
+void QtPreviewDockedWidgets::setInstViewEditMode() {
+  m_instDisplay->getSurface()->setInteractionMode(ProjectionSurface::EditShapeMode);
+}
+
+void QtPreviewDockedWidgets::setInstViewSelectRectMode() {
+  m_instDisplay->getSurface()->setInteractionMode(ProjectionSurface::EditShapeMode);
+  m_instDisplay->getSurface()->startCreatingShape2D("rectangle", Qt::green, QColor(255, 255, 255, 80));
+}
+
+void QtPreviewDockedWidgets::setInstViewToolbarEnabled(bool enable) {
+  m_ui.iv_zoom_button->setEnabled(enable);
+  m_ui.iv_edit_button->setEnabled(enable);
+  m_ui.iv_rect_select_button->setEnabled(enable);
+}
+
+void QtPreviewDockedWidgets::setRegionSelectorEnabled(bool enable) { m_ui.rs_dock_content->setEnabled(enable); }
+
+void QtPreviewDockedWidgets::setEditROIState(bool state) { m_ui.rs_edit_button->setDown(state); }
+
+void QtPreviewDockedWidgets::setRectangularROIState(bool state) { m_ui.rs_rect_select_button->setDown(state); }
+
+std::vector<size_t> QtPreviewDockedWidgets::getSelectedDetectors() const {
+  std::vector<size_t> result;
+  // The name is confusing here but "masked" detectors refers to those selected by a "mask shape"
+  // (although weather it's treated as a mask or not is up to the caller)
+  m_instDisplay->getSurface()->getMaskedDetectors(result);
+  return result;
+}
+
+std::string QtPreviewDockedWidgets::getRegionType() const {
+  return m_ui.rs_rect_select_button->defaultAction()->text().toStdString();
+}
+} // namespace MantidQt::CustomInterfaces::ISISReflectometry

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/QtPreviewDockedWidgets.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/QtPreviewDockedWidgets.h
@@ -1,0 +1,82 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2022 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#pragma once
+
+#include "Common/DllConfig.h"
+#include "IPreviewDockedWidgets.h"
+#include "MantidQtWidgets/InstrumentView/InstrumentDisplay.h"
+#include "MantidQtWidgets/InstrumentView/RotationSurface.h"
+#include "MantidQtWidgets/Plotting/PreviewPlot.h"
+#include "MantidQtWidgets/RegionSelector/RegionSelector.h"
+#include "ui_PreviewDockedWidgets.h"
+#include <QMainWindow>
+#include <QObject>
+#include <QWidget>
+
+#include <memory>
+#include <string>
+
+namespace MantidQt::MantidWidgets {
+class IPlotView;
+}
+
+namespace MantidQt::CustomInterfaces::ISISReflectometry {
+
+/** QtInstrumentView : Provides an interface for the "Preview" tab in the
+ISIS Reflectometry interface.
+*/
+class MANTIDQT_ISISREFLECTOMETRY_DLL QtPreviewDockedWidgets final : public QMainWindow, public IPreviewDockedWidgets {
+  Q_OBJECT
+public:
+  QtPreviewDockedWidgets(QWidget *parent = nullptr, QLayout *layout = nullptr);
+
+  void subscribe(PreviewDockedWidgetsSubscriber *notifyee) noexcept override;
+
+  // Plotting
+  void resetInstView() override;
+  void plotInstView(MantidWidgets::InstrumentActor *instActor, Mantid::Kernel::V3D const &samplePos,
+                    Mantid::Kernel::V3D const &axis) override;
+  // Instrument viewer toolbar
+  void setInstViewZoomState(bool isChecked) override;
+  void setInstViewEditState(bool isChecked) override;
+  void setInstViewSelectRectState(bool isChecked) override;
+  void setInstViewZoomMode() override;
+  void setInstViewEditMode() override;
+  void setInstViewSelectRectMode() override;
+  void setInstViewToolbarEnabled(bool enable) override;
+  void setRegionSelectorEnabled(bool enable) override;
+  // Region selector toolbar
+  void setEditROIState(bool state) override;
+  void setRectangularROIState(bool state) override;
+
+  std::vector<size_t> getSelectedDetectors() const override;
+  std::string getRegionType() const override;
+
+  QLayout *getRegionSelectorLayout() const override;
+  MantidQt::MantidWidgets::IPlotView *getLinePlotView() const override;
+
+private:
+  Ui::PreviewDockedWidgets m_ui;
+  QLayout *m_layout;
+  PreviewDockedWidgetsSubscriber *m_notifyee{nullptr};
+  std::unique_ptr<MantidQt::MantidWidgets::InstrumentDisplay> m_instDisplay{nullptr};
+
+  void connectSignals() const;
+  void loadToolbarIcons();
+  void setupSelectRegionTypes();
+
+private slots:
+  void onInstViewSelectRectClicked() const;
+  void onInstViewZoomClicked() const;
+  void onInstViewEditClicked() const;
+  void onInstViewShapeChanged() const;
+  void onRegionSelectorExportToAdsClicked() const;
+  void onLinePlotExportToAdsClicked() const;
+  void onEditROIClicked() const;
+  void onAddRectangularROIClicked(QAction *regionType) const;
+};
+} // namespace MantidQt::CustomInterfaces::ISISReflectometry

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/QtPreviewView.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/QtPreviewView.cpp
@@ -19,55 +19,17 @@
 #include <string>
 
 using namespace Mantid::Kernel;
-using MantidQt::MantidWidgets::IPlotView;
-using MantidQt::MantidWidgets::ProjectionSurface;
 
 namespace MantidQt::CustomInterfaces::ISISReflectometry {
 QtPreviewView::QtPreviewView(QWidget *parent) : QWidget(parent) {
   m_ui.setupUi(this);
 
-  resetInstView();
-  loadToolbarIcons();
-  setupSelectRegionTypes();
   connectSignals();
 }
 
-void QtPreviewView::loadToolbarIcons() {
-  m_ui.iv_zoom_button->setIcon(MantidQt::Icons::getIcon("mdi.magnify", "black", 1.3));
-  m_ui.iv_edit_button->setIcon(MantidQt::Icons::getIcon("mdi.pencil", "black", 1.3));
-  m_ui.iv_rect_select_button->setIcon(MantidQt::Icons::getIcon("mdi.selection", "black", 1.3));
-  m_ui.rs_ads_export_button->setIcon(MantidQt::Icons::getIcon("mdi.file-export", "black", 1.3));
-  m_ui.rs_edit_button->setIcon(MantidQt::Icons::getIcon("mdi.pencil", "black", 1.3));
-  m_ui.lp_ads_export_button->setIcon(MantidQt::Icons::getIcon("mdi.file-export", "black", 1.3));
-}
-
-void QtPreviewView::setupSelectRegionTypes() {
-  QMenu *menu = new QMenu();
-  QAction *signalAction = new QAction(
-      MantidQt::Icons::getIcon("mdi.selection", QString::fromStdString(roiTypeToColor(ROIType::Signal)), 1.3),
-      QString::fromStdString(roiTypeToString(ROIType::Signal)));
-  QAction *backgroundAction = new QAction(
-      MantidQt::Icons::getIcon("mdi.selection", QString::fromStdString(roiTypeToColor(ROIType::Background)), 1.3),
-      QString::fromStdString(roiTypeToString(ROIType::Background)));
-  QAction *transmissionAction = new QAction(
-      MantidQt::Icons::getIcon("mdi.selection", QString::fromStdString(roiTypeToColor(ROIType::Transmission)), 1.3),
-      QString::fromStdString(roiTypeToString(ROIType::Transmission)));
-
-  signalAction->setToolTip("Add rectangular signal region");
-  backgroundAction->setToolTip("Add rectangular background region");
-  transmissionAction->setToolTip("Add rectangular transmission region");
-
-  menu->addAction(signalAction);
-  menu->addAction(backgroundAction);
-  menu->addAction(transmissionAction);
-
-  m_ui.rs_rect_select_button->setMenu(menu);
-  m_ui.rs_rect_select_button->setDefaultAction(signalAction);
-
-  connect(menu, SIGNAL(triggered(QAction *)), this, SLOT(onAddRectangularROIClicked(QAction *)));
-}
-
 void QtPreviewView::subscribe(PreviewViewSubscriber *notifyee) noexcept { m_notifyee = notifyee; }
+
+QLayout *QtPreviewView::getDockedWidgetsLayout() noexcept { return m_ui.dockable_widgets_layout; }
 
 void QtPreviewView::enableApplyButton() { m_ui.apply_button->setEnabled(true); }
 
@@ -78,37 +40,12 @@ void QtPreviewView::connectSignals() const {
   connect(m_ui.load_button, SIGNAL(clicked()), this, SLOT(onLoadWorkspaceRequested()));
   connect(m_ui.update_button, SIGNAL(clicked()), this, SLOT(onUpdateClicked()));
   connect(m_ui.angle_spin_box, SIGNAL(valueChanged(double)), this, SLOT(onAngleEdited()));
-  // Instrument viewer toolbar
-  connect(m_ui.iv_zoom_button, SIGNAL(clicked()), this, SLOT(onInstViewZoomClicked()));
-  connect(m_ui.iv_edit_button, SIGNAL(clicked()), this, SLOT(onInstViewEditClicked()));
-  connect(m_ui.iv_rect_select_button, SIGNAL(clicked()), this, SLOT(onInstViewSelectRectClicked()));
-  // Region selector toolbar
-  connect(m_ui.rs_ads_export_button, SIGNAL(clicked()), this, SLOT(onRegionSelectorExportToAdsClicked()));
-  connect(m_ui.rs_edit_button, SIGNAL(clicked()), this, SLOT(onEditROIClicked()));
-  // Line plot toolbar
-  connect(m_ui.lp_ads_export_button, SIGNAL(clicked()), this, SLOT(onLinePlotExportToAdsClicked()));
   // Apply button
   connect(m_ui.apply_button, SIGNAL(clicked()), this, SLOT(onApplyClicked()));
 }
 
 void QtPreviewView::onLoadWorkspaceRequested() const { m_notifyee->notifyLoadWorkspaceRequested(); }
 void QtPreviewView::onUpdateClicked() const { m_notifyee->notifyUpdateAngle(); }
-
-void QtPreviewView::onInstViewZoomClicked() const { m_notifyee->notifyInstViewZoomRequested(); }
-void QtPreviewView::onInstViewEditClicked() const { m_notifyee->notifyInstViewEditRequested(); }
-void QtPreviewView::onInstViewSelectRectClicked() const { m_notifyee->notifyInstViewSelectRectRequested(); }
-void QtPreviewView::onInstViewShapeChanged() const { m_notifyee->notifyInstViewShapeChanged(); }
-
-void QtPreviewView::onRegionSelectorExportToAdsClicked() const { m_notifyee->notifyRegionSelectorExportAdsRequested(); }
-
-void QtPreviewView::onEditROIClicked() const { m_notifyee->notifyEditROIModeRequested(); }
-
-void QtPreviewView::onAddRectangularROIClicked(QAction *regionType) const {
-  m_ui.rs_rect_select_button->setDefaultAction(regionType);
-  m_notifyee->notifyRectangularROIModeRequested();
-}
-
-void QtPreviewView::onLinePlotExportToAdsClicked() const { m_notifyee->notifyLinePlotExportAdsRequested(); }
 
 void QtPreviewView::onAngleEdited() { m_ui.update_button->setEnabled(true); }
 
@@ -118,53 +55,6 @@ std::string QtPreviewView::getWorkspaceName() const { return m_ui.workspace_line
 
 double QtPreviewView::getAngle() const { return m_ui.angle_spin_box->value(); }
 
-void QtPreviewView::resetInstView() {
-  if (m_instDisplay) {
-    // Destruct the previous instance
-    m_instDisplay = nullptr;
-  }
-  m_instDisplay = std::make_unique<MantidWidgets::InstrumentDisplay>(m_ui.inst_view_placeholder);
-}
-
-void QtPreviewView::plotInstView(MantidWidgets::InstrumentActor *instActor, V3D const &samplePos, V3D const &axis) {
-  // We need to recreate the surface so disconnect any existing signals first
-  if (m_instDisplay->getSurface()) {
-    disconnect(m_instDisplay->getSurface().get(), SIGNAL(shapeChangeFinished()));
-  }
-  m_instDisplay->setSurface(std::make_shared<MantidWidgets::UnwrappedCylinder>(instActor, samplePos, axis));
-  connect(m_instDisplay->getSurface().get(), SIGNAL(shapeChangeFinished()), this, SLOT(onInstViewShapeChanged()));
-}
-
-QLayout *QtPreviewView::getRegionSelectorLayout() const { return m_ui.rs_plot_layout; }
-
-IPlotView *QtPreviewView::getLinePlotView() const { return m_ui.line_plot; }
-
-void QtPreviewView::setInstViewZoomState(bool isChecked) { m_ui.iv_zoom_button->setDown(isChecked); }
-void QtPreviewView::setInstViewEditState(bool isChecked) { m_ui.iv_edit_button->setDown(isChecked); }
-
-void QtPreviewView::setInstViewSelectRectState(bool isChecked) { m_ui.iv_rect_select_button->setDown(isChecked); }
-
-void QtPreviewView::setInstViewZoomMode() {
-  m_instDisplay->getSurface()->setInteractionMode(ProjectionSurface::MoveMode);
-}
-
-void QtPreviewView::setInstViewEditMode() {
-  m_instDisplay->getSurface()->setInteractionMode(ProjectionSurface::EditShapeMode);
-}
-
-void QtPreviewView::setInstViewSelectRectMode() {
-  m_instDisplay->getSurface()->setInteractionMode(ProjectionSurface::EditShapeMode);
-  m_instDisplay->getSurface()->startCreatingShape2D("rectangle", Qt::green, QColor(255, 255, 255, 80));
-}
-
-void QtPreviewView::setInstViewToolbarEnabled(bool enable) {
-  m_ui.iv_zoom_button->setEnabled(enable);
-  m_ui.iv_edit_button->setEnabled(enable);
-  m_ui.iv_rect_select_button->setEnabled(enable);
-}
-
-void QtPreviewView::setRegionSelectorEnabled(bool enable) { m_ui.rsPlotLayoutWidget->setEnabled(enable); }
-
 void QtPreviewView::setAngle(double angle) {
   m_ui.angle_spin_box->blockSignals(true);
   m_ui.angle_spin_box->setValue(angle);
@@ -173,19 +63,4 @@ void QtPreviewView::setAngle(double angle) {
 
 void QtPreviewView::setUpdateAngleButtonEnabled(bool enabled) { m_ui.update_button->setEnabled(enabled); }
 
-void QtPreviewView::setEditROIState(bool state) { m_ui.rs_edit_button->setDown(state); }
-
-void QtPreviewView::setRectangularROIState(bool state) { m_ui.rs_rect_select_button->setDown(state); }
-
-std::vector<size_t> QtPreviewView::getSelectedDetectors() const {
-  std::vector<size_t> result;
-  // The name is confusing here but "masked" detectors refers to those selected by a "mask shape"
-  // (although weather it's treated as a mask or not is up to the caller)
-  m_instDisplay->getSurface()->getMaskedDetectors(result);
-  return result;
-}
-
-std::string QtPreviewView::getRegionType() const {
-  return m_ui.rs_rect_select_button->defaultAction()->text().toStdString();
-}
 } // namespace MantidQt::CustomInterfaces::ISISReflectometry

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/QtPreviewView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/QtPreviewView.h
@@ -35,35 +35,16 @@ public:
   QtPreviewView(QWidget *parent = nullptr);
 
   void subscribe(PreviewViewSubscriber *notifyee) noexcept override;
+
+  QLayout *getDockedWidgetsLayout() noexcept override;
+
   void enableApplyButton() override;
   void disableApplyButton() override;
 
   std::string getWorkspaceName() const override;
   double getAngle() const override;
-  // Plotting
-  void resetInstView() override;
-  void plotInstView(MantidWidgets::InstrumentActor *instActor, Mantid::Kernel::V3D const &samplePos,
-                    Mantid::Kernel::V3D const &axis) override;
-  // Instrument viewer toolbar
-  void setInstViewZoomState(bool isChecked) override;
-  void setInstViewEditState(bool isChecked) override;
-  void setInstViewSelectRectState(bool isChecked) override;
-  void setInstViewZoomMode() override;
-  void setInstViewEditMode() override;
-  void setInstViewSelectRectMode() override;
-  void setInstViewToolbarEnabled(bool enable) override;
-  void setRegionSelectorEnabled(bool enable) override;
   void setAngle(double angle) override;
   void setUpdateAngleButtonEnabled(bool enable) override;
-  // Region selector toolbar
-  void setEditROIState(bool state) override;
-  void setRectangularROIState(bool state) override;
-
-  std::vector<size_t> getSelectedDetectors() const override;
-  std::string getRegionType() const override;
-
-  QLayout *getRegionSelectorLayout() const override;
-  MantidQt::MantidWidgets::IPlotView *getLinePlotView() const override;
 
 private:
   Ui::PreviewWidget m_ui;
@@ -71,20 +52,10 @@ private:
   std::unique_ptr<MantidQt::MantidWidgets::InstrumentDisplay> m_instDisplay{nullptr};
 
   void connectSignals() const;
-  void loadToolbarIcons();
-  void setupSelectRegionTypes();
 
 private slots:
   void onLoadWorkspaceRequested() const;
   void onUpdateClicked() const;
-  void onInstViewSelectRectClicked() const;
-  void onInstViewZoomClicked() const;
-  void onInstViewEditClicked() const;
-  void onInstViewShapeChanged() const;
-  void onRegionSelectorExportToAdsClicked() const;
-  void onLinePlotExportToAdsClicked() const;
-  void onEditROIClicked() const;
-  void onAddRectangularROIClicked(QAction *regionType) const;
   void onAngleEdited();
   void onApplyClicked() const;
 };

--- a/qt/scientific_interfaces/ISISReflectometry/test/Preview/MockPreviewDockedWidgets.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Preview/MockPreviewDockedWidgets.h
@@ -1,0 +1,40 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2022 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#pragma once
+
+#include "IPreviewDockedWidgets.h"
+#include "MantidKernel/V3D.h"
+#include "MantidQtWidgets/InstrumentView/RotationSurface.h"
+
+#include <gmock/gmock.h>
+
+#include <string>
+
+namespace MantidQt::CustomInterfaces::ISISReflectometry {
+
+class MockPreviewDockedWidgets : public IPreviewDockedWidgets {
+public:
+  MOCK_METHOD(void, subscribe, (PreviewDockedWidgetsSubscriber *), (noexcept, override));
+  MOCK_METHOD(void, resetInstView, (), (override));
+  MOCK_METHOD(void, plotInstView,
+              (MantidWidgets::InstrumentActor *, Mantid::Kernel::V3D const &, Mantid::Kernel::V3D const &), (override));
+  MOCK_METHOD(void, setInstViewZoomState, (bool), (override));
+  MOCK_METHOD(void, setInstViewEditState, (bool), (override));
+  MOCK_METHOD(void, setInstViewSelectRectState, (bool), (override));
+  MOCK_METHOD(void, setInstViewSelectRectMode, (), (override));
+  MOCK_METHOD(void, setInstViewToolbarEnabled, (bool), (override));
+  MOCK_METHOD(void, setRegionSelectorEnabled, (bool), (override));
+  MOCK_METHOD(void, setInstViewZoomMode, (), (override));
+  MOCK_METHOD(void, setInstViewEditMode, (), (override));
+  MOCK_METHOD(void, setRectangularROIState, (bool), (override));
+  MOCK_METHOD(void, setEditROIState, (bool), (override));
+  MOCK_METHOD(std::vector<size_t>, getSelectedDetectors, (), (const, override));
+  MOCK_METHOD(std::string, getRegionType, (), (const, override));
+  MOCK_METHOD(QLayout *, getRegionSelectorLayout, (), (const, override));
+  MOCK_METHOD(MantidQt::MantidWidgets::IPlotView *, getLinePlotView, (), (const, override));
+};
+} // namespace MantidQt::CustomInterfaces::ISISReflectometry

--- a/qt/scientific_interfaces/ISISReflectometry/test/Preview/MockPreviewView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Preview/MockPreviewView.h
@@ -19,28 +19,12 @@ namespace MantidQt::CustomInterfaces::ISISReflectometry {
 class MockPreviewView : public IPreviewView {
 public:
   MOCK_METHOD(void, subscribe, (PreviewViewSubscriber *), (noexcept, override));
+  MOCK_METHOD(QLayout *, getDockedWidgetsLayout, (), (noexcept, override));
   MOCK_METHOD(void, enableApplyButton, (), (override));
   MOCK_METHOD(void, disableApplyButton, (), (override));
   MOCK_METHOD(std::string, getWorkspaceName, (), (const, override));
   MOCK_METHOD(double, getAngle, (), (const, override));
-  MOCK_METHOD(void, resetInstView, (), (override));
-  MOCK_METHOD(void, plotInstView,
-              (MantidWidgets::InstrumentActor *, Mantid::Kernel::V3D const &, Mantid::Kernel::V3D const &), (override));
-  MOCK_METHOD(void, setInstViewZoomState, (bool), (override));
-  MOCK_METHOD(void, setInstViewEditState, (bool), (override));
-  MOCK_METHOD(void, setInstViewSelectRectState, (bool), (override));
-  MOCK_METHOD(void, setInstViewSelectRectMode, (), (override));
-  MOCK_METHOD(void, setInstViewToolbarEnabled, (bool), (override));
-  MOCK_METHOD(void, setRegionSelectorEnabled, (bool), (override));
-  MOCK_METHOD(void, setInstViewZoomMode, (), (override));
-  MOCK_METHOD(void, setInstViewEditMode, (), (override));
-  MOCK_METHOD(void, setRectangularROIState, (bool), (override));
-  MOCK_METHOD(void, setEditROIState, (bool), (override));
   MOCK_METHOD(void, setAngle, (double), (override));
   MOCK_METHOD(void, setUpdateAngleButtonEnabled, (bool), (override));
-  MOCK_METHOD(std::vector<size_t>, getSelectedDetectors, (), (const, override));
-  MOCK_METHOD(std::string, getRegionType, (), (const, override));
-  MOCK_METHOD(QLayout *, getRegionSelectorLayout, (), (const, override));
-  MOCK_METHOD(MantidQt::MantidWidgets::IPlotView *, getLinePlotView, (), (const, override));
 };
 } // namespace MantidQt::CustomInterfaces::ISISReflectometry

--- a/qt/scientific_interfaces/ISISReflectometry/test/Preview/PreviewPresenterTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Preview/PreviewPresenterTest.h
@@ -15,6 +15,7 @@
 #include "MantidQtWidgets/Plotting/AxisID.h"
 #include "MockInstViewModel.h"
 #include "MockPlotPresenter.h"
+#include "MockPreviewDockedWidgets.h"
 #include "MockPreviewModel.h"
 #include "MockPreviewView.h"
 #include "PreviewPresenter.h"
@@ -53,6 +54,7 @@ class PreviewPresenterTest : public CxxTest::TestSuite {
   using MockJobManagerT = std::unique_ptr<MockJobManager>;
   using MockModelT = std::unique_ptr<MockPreviewModel>;
   using MockViewT = std::unique_ptr<MockPreviewView>;
+  using MockPreviewDockedWidgetsT = std::unique_ptr<MockPreviewDockedWidgets>;
   using MockRegionSelectorT = std::unique_ptr<MockRegionSelector>;
   using MockPlotPresenterT = std::unique_ptr<MockPlotPresenter>;
 
@@ -75,13 +77,14 @@ public:
     auto mockModel = makeModel();
     auto mockView = makeView();
     auto mockInstViewModel = makeInstViewModel();
+    auto mockDockedWidgets = makePreviewDockedWidgets();
     auto mockJobManager = makeJobManager();
     auto const workspaceName = std::string("test workspace");
 
     EXPECT_CALL(*mockView, getWorkspaceName()).Times(1).WillOnce(Return(workspaceName));
     EXPECT_CALL(*mockModel, loadWorkspaceFromAds(workspaceName)).Times(1).WillOnce(Return(true));
     EXPECT_CALL(*mockModel, loadAndPreprocessWorkspaceAsync(_, _)).Times(0);
-    expectLoadWorkspaceCompletedUpdatesInstrumentView(*mockView, *mockModel, *mockInstViewModel);
+    expectLoadWorkspaceCompletedUpdatesInstrumentView(*mockDockedWidgets, *mockModel, *mockInstViewModel);
 
     auto presenter = PreviewPresenter(
         packDeps(mockView.get(), std::move(mockModel), std::move(mockJobManager), std::move(mockInstViewModel)));
@@ -97,7 +100,6 @@ public:
     EXPECT_CALL(*mockView, getWorkspaceName()).Times(1).WillOnce(Return(workspaceName));
     EXPECT_CALL(*mockModel, loadWorkspaceFromAds(workspaceName)).Times(1).WillOnce(Throw(error));
     EXPECT_CALL(*mockModel, loadAndPreprocessWorkspaceAsync(_, _)).Times(0);
-    EXPECT_CALL(*mockView, plotInstView(_, _, _)).Times(0);
 
     auto presenter = PreviewPresenter(packDeps(mockView.get(), std::move(mockModel)));
     TS_ASSERT_THROWS_NOTHING(presenter.notifyLoadWorkspaceRequested());
@@ -112,7 +114,6 @@ public:
     EXPECT_CALL(*mockView, getWorkspaceName()).Times(1).WillOnce(Return(workspaceName));
     EXPECT_CALL(*mockModel, loadWorkspaceFromAds(workspaceName)).Times(1).WillOnce(Throw(error));
     EXPECT_CALL(*mockModel, loadAndPreprocessWorkspaceAsync(_, _)).Times(0);
-    EXPECT_CALL(*mockView, plotInstView(_, _, _)).Times(0);
 
     auto presenter = PreviewPresenter(packDeps(mockView.get(), std::move(mockModel)));
     TS_ASSERT_THROWS(presenter.notifyLoadWorkspaceRequested(), std::invalid_argument const &);
@@ -122,16 +123,18 @@ public:
     auto mockModel = makeModel();
     auto mockView = makeView();
     auto mockJobManager = makeJobManager();
+    auto mockDockedWidgets = makePreviewDockedWidgets();
     auto mockRegionSelector = makeRegionSelector();
 
-    expectRegionSelectorToolbarEnabled(*mockView, false);
-    expectLoadWorkspaceCompletedForLinearDetector(*mockView, *mockModel, *mockJobManager, *mockRegionSelector);
+    expectRegionSelectorToolbarEnabled(*mockDockedWidgets, false);
+    expectLoadWorkspaceCompletedForLinearDetector(*mockView, *mockModel, *mockJobManager, *mockDockedWidgets,
+                                                  *mockRegionSelector);
 
     auto deps = packDeps(mockView.get(), std::move(mockModel), std::move(mockJobManager), makeInstViewModel(),
-                         std::move(mockRegionSelector));
+                         std::move(mockDockedWidgets), std::move(mockRegionSelector));
     auto presenter = PreviewPresenter(std::move(deps));
 
-    expectRegionSelectorToolbarEnabled(*mockView, true);
+    expectRegionSelectorToolbarEnabled(*mockDockedWidgets, true);
 
     EXPECT_CALL(*mockView, setInstViewToolbarEnabled(Eq(false))).Times(1);
     presenter.notifyLoadWorkspaceCompleted();
@@ -141,9 +144,10 @@ public:
     auto mockModel = makeModel();
     auto mockView = makeView();
     auto mockJobManager = makeJobManager();
+    auto mockDockedWidgets = makePreviewDockedWidgets();
     auto mockInstViewModel = makeInstViewModel();
 
-    expectLoadWorkspaceCompletedUpdatesInstrumentView(*mockView, *mockModel, *mockInstViewModel);
+    expectLoadWorkspaceCompletedUpdatesInstrumentView(*mockDockedWidgets, *mockModel, *mockInstViewModel);
 
     auto deps = packDeps(mockView.get(), std::move(mockModel), std::move(mockJobManager), std::move(mockInstViewModel));
     auto presenter = PreviewPresenter(std::move(deps));
@@ -162,23 +166,26 @@ public:
   }
 
   void test_notify_inst_view_select_rect_requested() {
-    auto mockView = makeView();
-    expectInstViewSetToSelectRectMode(*mockView);
-    auto presenter = PreviewPresenter(packDeps(mockView.get()));
+    auto mockDockedWidgets = makePreviewDockedWidgets();
+    expectInstViewSetToSelectRectMode(*mockDockedWidgets);
+    auto presenter = PreviewPresenter(
+        packDeps(makeView().get(), makeModel(), makeJobManager(), makeInstViewModel(), std::move(mockDockedWidgets)));
     presenter.notifyInstViewSelectRectRequested();
   }
 
   void test_notify_inst_view_pan_requested() {
-    auto mockView = makeView();
-    expectInstViewSetToEditMode(*mockView);
-    auto presenter = PreviewPresenter(packDeps(mockView.get()));
+    auto mockDockedWidgets = makePreviewDockedWidgets();
+    expectInstViewSetToEditMode(*mockDockedWidgets);
+    auto presenter = PreviewPresenter(
+        packDeps(makeView().get(), makeModel(), makeJobManager(), makeInstViewModel(), std::move(mockDockedWidgets)));
     presenter.notifyInstViewEditRequested();
   }
 
   void test_notify_inst_view_zoom_requested() {
-    auto mockView = makeView();
-    expectInstViewSetToZoomMode(*mockView);
-    auto presenter = PreviewPresenter(packDeps(mockView.get()));
+    auto mockDockedWidgets = makePreviewDockedWidgets();
+    expectInstViewSetToZoomMode(*mockDockedWidgets);
+    auto presenter = PreviewPresenter(
+        packDeps(makeView().get(), makeModel(), makeJobManager(), makeInstViewModel(), std::move(mockDockedWidgets)));
     presenter.notifyInstViewZoomRequested();
   }
 
@@ -187,11 +194,12 @@ public:
     auto mockModel = makeModel();
     auto mockInstViewModel = makeInstViewModel();
     auto mockJobManager = makeJobManager();
-    expectInstViewSetToEditMode(*mockView);
-    expectSumBanksCalledOnSelectedDetectors(*mockView, *mockModel, *mockInstViewModel, *mockJobManager);
+    auto mockDockedWidgets = makePreviewDockedWidgets();
+    expectInstViewSetToEditMode(*mockDockedWidgets);
+    expectSumBanksCalledOnSelectedDetectors(*mockModel, *mockInstViewModel, *mockDockedWidgets, *mockJobManager);
     // TODO check that the model is called to sum banks
-    auto presenter = PreviewPresenter(
-        packDeps(mockView.get(), std::move(mockModel), std::move(mockJobManager), std::move(mockInstViewModel)));
+    auto presenter = PreviewPresenter(packDeps(mockView.get(), std::move(mockModel), std::move(mockJobManager),
+                                               std::move(mockInstViewModel), std::move(mockDockedWidgets)));
     presenter.notifyInstViewShapeChanged();
   }
 
@@ -220,18 +228,20 @@ public:
     auto mockModel = makeModel();
     auto mockJobManager = makeJobManager();
     auto mockRegionSelector = makeRegionSelector();
+    auto mockDockedWidgets = makePreviewDockedWidgets();
 
     auto ws = createRectangularDetectorWorkspace();
     EXPECT_CALL(*mockModel, getSummedWs).Times(1).WillOnce(Return(ws));
     EXPECT_CALL(*mockRegionSelector, updateWorkspace(Eq(ws))).Times(1);
-    expectRegionSelectorToolbarEnabled(*mockView, false);
+    expectRegionSelectorToolbarEnabled(*mockDockedWidgets, false);
 
     expectRunReduction(*mockView, *mockModel, *mockJobManager, *mockRegionSelector);
 
-    auto presenter = PreviewPresenter(packDeps(mockView.get(), std::move(mockModel), std::move(mockJobManager),
-                                               makeInstViewModel(), std::move(mockRegionSelector)));
+    auto presenter =
+        PreviewPresenter(packDeps(mockView.get(), std::move(mockModel), std::move(mockJobManager), makeInstViewModel(),
+                                  std::move(mockDockedWidgets), std::move(mockRegionSelector)));
 
-    expectRegionSelectorToolbarEnabled(*mockView, true);
+    expectRegionSelectorToolbarEnabled(*mockDockedWidgets, true);
 
     presenter.notifySumBanksCompleted();
   }
@@ -240,41 +250,45 @@ public:
     auto mockView = makeView();
     auto mockModel = makeModel();
     auto mockJobManager = makeJobManager();
+    auto mockDockedWidgets = makePreviewDockedWidgets();
     auto mockRegionSelector = makeRegionSelector();
 
     expectRunReduction(*mockView, *mockModel, *mockJobManager, *mockRegionSelector);
 
-    auto presenter = PreviewPresenter(packDeps(mockView.get(), std::move(mockModel), std::move(mockJobManager),
-                                               makeInstViewModel(), std::move(mockRegionSelector)));
+    auto presenter =
+        PreviewPresenter(packDeps(mockView.get(), std::move(mockModel), std::move(mockJobManager), makeInstViewModel(),
+                                  std::move(mockDockedWidgets), std::move(mockRegionSelector)));
 
     presenter.notifyUpdateAngle();
   }
 
   void test_rectangular_roi_requested() {
     auto mockView = makeView();
+    auto mockDockedWidgets = makePreviewDockedWidgets();
     auto mockRegionSelector_uptr = makeRegionSelector();
     auto mockRegionSelector = mockRegionSelector_uptr.get();
     const std::string regionType = roiTypeToString(ROIType::Signal);
     const std::string color = roiTypeToColor(ROIType::Signal);
 
-    EXPECT_CALL(*mockView, getRegionType()).Times(1).WillOnce(Return(regionType));
-    expectRectangularROIMode(*mockView);
+    EXPECT_CALL(*mockDockedWidgets, getRegionType()).Times(1).WillOnce(Return(regionType));
+    expectRectangularROIMode(*mockDockedWidgets);
     EXPECT_CALL(*mockRegionSelector, addRectangularRegion(regionType, color)).Times(1);
     auto presenter = PreviewPresenter(packDeps(mockView.get(), makeModel(), makeJobManager(), makeInstViewModel(),
-                                               std::move(mockRegionSelector_uptr)));
+                                               std::move(mockDockedWidgets), std::move(mockRegionSelector_uptr)));
 
     presenter.notifyRectangularROIModeRequested();
   }
 
   void test_edit_roi_mode_requested() {
     auto mockView = makeView();
+    auto mockDockedWidgets = makePreviewDockedWidgets();
     auto mockRegionSelector_uptr = makeRegionSelector();
     auto mockRegionSelector = mockRegionSelector_uptr.get();
 
-    expectEditROIMode(*mockView);
+    expectEditROIMode(*mockDockedWidgets);
     EXPECT_CALL(*mockRegionSelector, cancelDrawingRegion()).Times(1);
     auto presenter = PreviewPresenter(packDeps(mockView.get(), makeModel(), makeJobManager(), makeInstViewModel(),
-                                               std::move(mockRegionSelector_uptr)));
+                                               std::move(mockDockedWidgets), std::move(mockRegionSelector_uptr)));
 
     presenter.notifyEditROIModeRequested();
   }
@@ -283,13 +297,15 @@ public:
     auto mockView = makeView();
     auto mockModel = makeModel();
     auto mockJobManager = makeJobManager();
+    auto mockDockedWidgets = makePreviewDockedWidgets();
     auto mockRegionSelector = makeRegionSelector();
 
-    expectEditROIMode(*mockView);
+    expectEditROIMode(*mockDockedWidgets);
     expectRunReduction(*mockView, *mockModel, *mockJobManager, *mockRegionSelector);
 
-    auto presenter = PreviewPresenter(packDeps(mockView.get(), std::move(mockModel), std::move(mockJobManager),
-                                               makeInstViewModel(), std::move(mockRegionSelector)));
+    auto presenter =
+        PreviewPresenter(packDeps(mockView.get(), std::move(mockModel), std::move(mockJobManager), makeInstViewModel(),
+                                  std::move(mockDockedWidgets), std::move(mockRegionSelector)));
     presenter.notifyRegionChanged();
   }
 
@@ -304,8 +320,9 @@ public:
     EXPECT_CALL(*mockLinePlot, setSpectrum(ws, 0)).Times(1);
     EXPECT_CALL(*mockLinePlot, plot()).Times(1);
 
-    auto presenter = PreviewPresenter(packDeps(mockView.get(), std::move(mockModel), makeJobManager(),
-                                               makeInstViewModel(), makeRegionSelector(), std::move(mockLinePlot)));
+    auto presenter =
+        PreviewPresenter(packDeps(mockView.get(), std::move(mockModel), makeJobManager(), makeInstViewModel(),
+                                  makePreviewDockedWidgets(), makeRegionSelector(), std::move(mockLinePlot)));
 
     presenter.notifyReductionCompleted();
   }
@@ -422,6 +439,7 @@ public:
   void test_region_selector_and_reduction_plot_is_cleared_on_a_sum_banks_algorithm_error() {
     auto mockView = makeView();
     auto mockModel = makeModel();
+    auto mockDockableWidgets = makePreviewDockedWidgets();
     auto mockRegionSelector = makeRegionSelector();
     auto mockPlotPresenter = std::make_unique<MockPlotPresenter>();
 
@@ -430,11 +448,11 @@ public:
     auto rawMockRegionSelector = mockRegionSelector.get();
     auto rawMockPlotPresenter = mockPlotPresenter.get();
 
-    auto presenter =
-        PreviewPresenter(packDeps(mockView.get(), std::move(mockModel), makeJobManager(), makeInstViewModel(),
-                                  std::move(mockRegionSelector), std::move(mockPlotPresenter)));
+    auto presenter = PreviewPresenter(packDeps(mockView.get(), std::move(mockModel), makeJobManager(),
+                                               makeInstViewModel(), std::move(mockDockableWidgets),
+                                               std::move(mockRegionSelector), std::move(mockPlotPresenter)));
 
-    expectRegionSelectorCleared(*mockView, rawMockRegionSelector);
+    expectRegionSelectorCleared(*mockDockableWidgets, rawMockRegionSelector);
     expectReductionPlotCleared(rawMockPlotPresenter);
 
     presenter.notifySumBanksAlgorithmError();
@@ -451,7 +469,7 @@ public:
 
     auto presenter =
         PreviewPresenter(packDeps(mockView.get(), std::move(mockModel), makeJobManager(), makeInstViewModel(),
-                                  makeRegionSelector(), std::move(mockPlotPresenter)));
+                                  makePreviewDockedWidgets(), makeRegionSelector(), std::move(mockPlotPresenter)));
 
     expectReductionPlotCleared(rawMockPlotPresenter);
 
@@ -462,7 +480,6 @@ private:
   MockViewT makeView() {
     auto mockView = std::make_unique<MockPreviewView>();
     EXPECT_CALL(*mockView, subscribe(NotNull())).Times(1);
-    EXPECT_CALL(*mockView, setInstViewToolbarEnabled(Eq(false))).Times(1);
     return mockView;
   }
 
@@ -476,19 +493,27 @@ private:
 
   MockInstViewModelT makeInstViewModel() { return std::make_unique<MockInstViewModel>(); }
 
+  MockPreviewDockedWidgetsT makePreviewDockedWidgets() {
+    auto mockDockedWidgets = std::make_unique<MockPreviewDockedWidgets>();
+    EXPECT_CALL(*mockDockedWidgets, setInstViewToolbarEnabled(Eq(false))).Times(1);
+    return mockDockedWidgets;
+  }
+
   MockRegionSelectorT makeRegionSelector() { return std::make_unique<MockRegionSelector>(); }
 
-  PreviewPresenter::Dependencies packDeps(MockPreviewView *view,
-                                          MockModelT model = std::make_unique<MockPreviewModel>(),
-                                          MockJobManagerT jobManager = std::make_unique<NiceMock<MockJobManager>>(),
-                                          MockInstViewModelT instView = std::make_unique<MockInstViewModel>(),
-                                          MockRegionSelectorT regionSelector = std::make_unique<MockRegionSelector>(),
-                                          MockPlotPresenterT linePlot = std::make_unique<MockPlotPresenter>()) {
+  PreviewPresenter::Dependencies
+  packDeps(MockPreviewView *view, MockModelT model = std::make_unique<MockPreviewModel>(),
+           MockJobManagerT jobManager = std::make_unique<NiceMock<MockJobManager>>(),
+           MockInstViewModelT instView = std::make_unique<MockInstViewModel>(),
+           MockPreviewDockedWidgetsT dockedWidgets = std::make_unique<MockPreviewDockedWidgets>(),
+           MockRegionSelectorT regionSelector = std::make_unique<MockRegionSelector>(),
+           MockPlotPresenterT linePlot = std::make_unique<MockPlotPresenter>()) {
     expectPresenterConstructed(*regionSelector, *linePlot);
     return PreviewPresenter::Dependencies{view,
                                           std::move(model),
                                           std::move(jobManager),
                                           std::move(instView),
+                                          std::move(dockedWidgets),
                                           std::move(regionSelector),
                                           std::move(linePlot)};
   }
@@ -502,23 +527,25 @@ private:
 
   void expectLoadWorkspaceCompletedForLinearDetector(MockPreviewView &mockView, MockPreviewModel &mockModel,
                                                      MockJobManager &mockJobManager,
+                                                     MockPreviewDockedWidgets &mockDockedWidgets,
                                                      MockRegionSelector &mockRegionSelector) {
     auto ws = createLinearDetectorWorkspace();
 
     EXPECT_CALL(mockModel, getLoadedWs()).Times(1).WillOnce(Return(ws));
 
-    EXPECT_CALL(mockView, resetInstView()).Times(1);
+    EXPECT_CALL(mockDockedWidgets, resetInstView()).Times(1);
     EXPECT_CALL(mockModel, setSummedWs(ws)).Times(1);
 
     expectRunReduction(mockView, mockModel, mockJobManager, mockRegionSelector);
   }
 
-  void expectLoadWorkspaceCompletedUpdatesInstrumentView(MockPreviewView &mockView, MockPreviewModel &mockModel,
+  void expectLoadWorkspaceCompletedUpdatesInstrumentView(MockPreviewDockedWidgets &mockDockedWidgets,
+                                                         MockPreviewModel &mockModel,
                                                          MockInstViewModel &mockInstViewModel) {
     expectInstViewModelUpdatedWithLoadedWorkspace(mockModel, mockInstViewModel);
-    expectPlotInstView(mockView, mockInstViewModel);
-    expectInstViewToolbarEnabled(mockView);
-    expectInstViewSetToZoomMode(mockView);
+    expectPlotInstView(mockInstViewModel, mockDockedWidgets);
+    expectInstViewToolbarEnabled(mockDockedWidgets);
+    expectInstViewSetToZoomMode(mockDockedWidgets);
   }
 
   void expectLoadWorkspaceCompletedUpdatesAngle(MockPreviewView &mockView, MockPreviewModel &mockModel) {
@@ -537,63 +564,64 @@ private:
     EXPECT_CALL(mockInstViewModel, updateWorkspace(Eq(ws))).Times(1);
   }
 
-  void expectSumBanksCalledOnSelectedDetectors(MockPreviewView &mockView, MockPreviewModel &mockModel,
-                                               MockInstViewModel &mockInstViewModel, MockJobManager &mockJobManager) {
+  void expectSumBanksCalledOnSelectedDetectors(MockPreviewModel &mockModel, MockInstViewModel &mockInstViewModel,
+                                               MockPreviewDockedWidgets &mockDockedWidgets,
+                                               MockJobManager &mockJobManager) {
     auto detIndices = std::vector<size_t>{44, 45, 46};
     auto detIDs = std::vector<Mantid::detid_t>{2, 3, 4};
     auto detIDsStr = ProcessingInstructions{"2-4"};
-    EXPECT_CALL(mockView, getSelectedDetectors()).Times(1).WillOnce(Return(detIndices));
+    EXPECT_CALL(mockDockedWidgets, getSelectedDetectors()).Times(1).WillOnce(Return(detIndices));
     EXPECT_CALL(mockInstViewModel, detIndicesToDetIDs(Eq(detIndices))).Times(1).WillOnce(Return(detIDs));
     EXPECT_CALL(mockModel, setSelectedBanks(Eq(detIDsStr))).Times(1);
     EXPECT_CALL(mockModel, sumBanksAsync(Ref(mockJobManager))).Times(1);
   }
 
-  void expectPlotInstView(MockPreviewView &mockView, MockInstViewModel &mockInstViewModel) {
+  void expectPlotInstView(MockInstViewModel &mockInstViewModel, MockPreviewDockedWidgets &mockDockedWidgets) {
     auto samplePos = V3D(1, 2, 3);
     auto axes = V3D(4, 5, 6);
     EXPECT_CALL(mockInstViewModel, getInstrumentViewActor()).Times(1).WillOnce(Return(nullptr));
     EXPECT_CALL(mockInstViewModel, getSamplePos()).Times(1).WillOnce(Return(samplePos));
     EXPECT_CALL(mockInstViewModel, getAxis()).Times(1).WillOnce(Return(axes));
-    EXPECT_CALL(mockView, plotInstView(Eq(nullptr), Eq(samplePos), Eq(axes))).Times(1);
+    EXPECT_CALL(mockDockedWidgets, plotInstView(Eq(nullptr), Eq(samplePos), Eq(axes))).Times(1);
   }
 
-  void expectInstViewToolbarEnabled(MockPreviewView &mockView) {
-    EXPECT_CALL(mockView, setInstViewToolbarEnabled(Eq(true))).Times(1);
+  void expectInstViewToolbarEnabled(MockPreviewDockedWidgets &mockDockedWidgets) {
+    EXPECT_CALL(mockDockedWidgets, setInstViewToolbarEnabled(Eq(true))).Times(1);
   }
 
-  void expectRegionSelectorToolbarEnabled(MockPreviewView &mockView, bool enable) {
-    EXPECT_CALL(mockView, setRegionSelectorEnabled(Eq(enable))).Times(1);
+  void expectRegionSelectorToolbarEnabled(MockPreviewDockedWidgets &mockDockedWidgets, bool enable) {
+    EXPECT_CALL(mockDockedWidgets, setRegionSelectorEnabled(Eq(enable))).Times(1);
   }
 
-  void expectInstViewSetToZoomMode(MockPreviewView &mockView) {
-    EXPECT_CALL(mockView, setInstViewSelectRectState(Eq(false))).Times(1);
-    EXPECT_CALL(mockView, setInstViewEditState(Eq(false))).Times(1);
-    EXPECT_CALL(mockView, setInstViewZoomState(Eq(true))).Times(1);
-    EXPECT_CALL(mockView, setInstViewZoomMode()).Times(1);
+  void expectInstViewSetToZoomMode(MockPreviewDockedWidgets &mockDockedWidgets) {
+    EXPECT_CALL(mockDockedWidgets, setInstViewSelectRectState(Eq(false))).Times(1);
+    EXPECT_CALL(mockDockedWidgets, setInstViewEditState(Eq(false))).Times(1);
+    EXPECT_CALL(mockDockedWidgets, setInstViewZoomState(Eq(true))).Times(1);
+    EXPECT_CALL(mockDockedWidgets, setInstViewZoomMode()).Times(1);
   }
 
-  void expectInstViewSetToEditMode(MockPreviewView &mockView) {
-    EXPECT_CALL(mockView, setInstViewZoomState(Eq(false))).Times(1);
-    EXPECT_CALL(mockView, setInstViewSelectRectState(Eq(false))).Times(1);
-    EXPECT_CALL(mockView, setInstViewEditState(Eq(true))).Times(1);
-    EXPECT_CALL(mockView, setInstViewEditMode()).Times(1);
+  void expectInstViewSetToEditMode(MockPreviewDockedWidgets &mockDockedWidgets) {
+    EXPECT_CALL(mockDockedWidgets, setInstViewZoomState(Eq(false))).Times(1);
+    EXPECT_CALL(mockDockedWidgets, setInstViewSelectRectState(Eq(false))).Times(1);
+    EXPECT_CALL(mockDockedWidgets, setInstViewEditState(Eq(true))).Times(1);
+    EXPECT_CALL(mockDockedWidgets, setInstViewEditMode()).Times(1);
   }
 
-  void expectInstViewSetToSelectRectMode(MockPreviewView &mockView) {
-    EXPECT_CALL(mockView, setInstViewEditState(Eq(false))).Times(1);
-    EXPECT_CALL(mockView, setInstViewZoomState(Eq(false))).Times(1);
-    EXPECT_CALL(mockView, setInstViewSelectRectState(Eq(true))).Times(1);
-    EXPECT_CALL(mockView, setInstViewSelectRectMode()).Times(1);
+  void expectInstViewSetToSelectRectMode(MockPreviewDockedWidgets &mockDockedWidgets) {
+    EXPECT_CALL(mockDockedWidgets, setInstViewEditState(Eq(false))).Times(1);
+    EXPECT_CALL(mockDockedWidgets, setInstViewZoomState(Eq(false))).Times(1);
+    EXPECT_CALL(mockDockedWidgets, setInstViewSelectRectState(Eq(true))).Times(1);
+    EXPECT_CALL(mockDockedWidgets, setInstViewSelectRectMode()).Times(1);
   }
 
-  void expectRectangularROIMode(MockPreviewView &mockView) {
-    EXPECT_CALL(mockView, setEditROIState(Eq(false))).Times(1);
-    EXPECT_CALL(mockView, setRectangularROIState(Eq(true))).Times(1);
+  void expectRectangularROIMode(MockPreviewDockedWidgets &mockDockedWidgets) {
+    EXPECT_CALL(mockDockedWidgets, setEditROIState(Eq(false))).Times(1);
+    EXPECT_CALL(mockDockedWidgets, setRectangularROIState(Eq(true))).Times(1);
   }
 
-  void expectEditROIMode(MockPreviewView &mockView) {
-    EXPECT_CALL(mockView, setEditROIState(Eq(true))).Times(1);
-    EXPECT_CALL(mockView, setRectangularROIState(Eq(false))).Times(1);
+  void expectEditROIMode(MockPreviewDockedWidgets &mockDockedWidgets) {
+    EXPECT_CALL(mockDockedWidgets, setEditROIState(Eq(true))).Times(1);
+    EXPECT_CALL(mockDockedWidgets, setRectangularROIState(Eq(false))).Times(1);
   }
 
   void expectRunReduction(MockPreviewView &mockView, MockPreviewModel &mockModel, MockJobManager &mockJobManager,
@@ -635,9 +663,10 @@ private:
     EXPECT_CALL(mainPresenter, isAutoreducing()).Times(AtLeast(1)).WillRepeatedly(Return(false));
   }
 
-  void expectRegionSelectorCleared(MockPreviewView &mockView, MockRegionSelector *mockRegionSelector) {
+  void expectRegionSelectorCleared(MockPreviewDockedWidgets &mockDockedWidgets,
+                                   MockRegionSelector *mockRegionSelector) {
     EXPECT_CALL(*mockRegionSelector, clearWorkspace()).Times(1);
-    EXPECT_CALL(mockView, setRegionSelectorEnabled(false)).Times(1);
+    EXPECT_CALL(mockDockedWidgets, setRegionSelectorEnabled(false)).Times(1);
   }
 
   void expectReductionPlotCleared(MockPlotPresenter *mockPlotPresenter) {

--- a/qt/scientific_interfaces/ISISReflectometry/test/Preview/PreviewPresenterTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Preview/PreviewPresenterTest.h
@@ -138,7 +138,7 @@ public:
 
     expectRegionSelectorToolbarEnabled(*rawMockDockedWidgets, true);
 
-    EXPECT_CALL(*mockView, setInstViewToolbarEnabled(Eq(false))).Times(1);
+    EXPECT_CALL(*rawMockDockedWidgets, setInstViewToolbarEnabled(Eq(false))).Times(1);
     presenter.notifyLoadWorkspaceCompleted();
   }
 


### PR DESCRIPTION
**Description of work.**
Make the widgets on the preview tab side-by-side and dockable. This means that they can be re-ordered on the gui or separated out and resized individually. 

**To test:**
1. Open the ISIS Reflectometry interface
2. Go to the Preview tab
3. Enter run `INTER45455_inst` and click Load (This data is available on this Epic and must be in your path: #31069)
4. Check that the widgets are nicely visible after loading
5. Check widgets can be undocked and still used
6. Set the angle >0
7. Draw a box on the inst viewer
8. Draw a box on the region selector
9. See the line plot update
10. Click apply
11. Check the chosen ROIs from the drawn boxes appear on the experiment settings tab. 

Fixes #34670 


*This does not require release notes* because **this tab is still work in progress so hasn't been shown to users yet.**


<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
