### PR TITLE
Remove error on running POLARIS focus twice

### DIFF
--- a/Testing/SystemTests/tests/framework/ISIS_PowderPolarisTest.py
+++ b/Testing/SystemTests/tests/framework/ISIS_PowderPolarisTest.py
@@ -245,6 +245,34 @@ class FocusTestChopperMode(systemtesting.MantidSystemTest):
             config['datasearch.directories'] = self.existing_config
 
 
+class FocusTestRunTwice(systemtesting.MantidSystemTest):
+
+    focus_results = None
+    existing_config = config['datasearch.directories']
+
+    def requiredFiles(self):
+        return _gen_required_files()
+
+    def runTest(self):
+        # Gen vanadium calibration first
+        setup_mantid_paths()
+        self.focus_results = run_focus_absorption("98533", paalman_pings=False)
+        self.focus_results = run_focus_absorption("98533", paalman_pings=False)
+
+    def validate(self):
+        self.tolerance_is_rel_err = True
+        self.tolerance = 1e-6
+        return self.focus_results.name(), "ISIS_Powder-POLARIS98533_FocusMayers.nxs"
+
+    def cleanup(self):
+        try:
+            _try_delete(spline_path)
+            _try_delete(output_dir)
+        finally:
+            mantid.mtd.clear()
+            config['datasearch.directories'] = self.existing_config
+
+
 class TotalScatteringTest(systemtesting.MantidSystemTest):
 
     pdf_output = None

--- a/docs/source/release/v6.6.0/Diffraction/Powder/Bugfixes/34778.rst
+++ b/docs/source/release/v6.6.0/Diffraction/Powder/Bugfixes/34778.rst
@@ -1,0 +1,1 @@
+- Fix problem when calling focus twice in a reduction using the ISIS Powder diffraction scripts. The second run of focus was using a partially processed input file from the first focus resulting in some of the reduction steps (normalisation, absorption correction) were being run twice

--- a/scripts/Diffraction/isis_powder/routines/absorb_corrections.py
+++ b/scripts/Diffraction/isis_powder/routines/absorb_corrections.py
@@ -100,17 +100,19 @@ def _do_cylinder_absorb_corrections(ws_to_correct, multiple_scattering, is_vanad
 
     # Mayers Sample correction must be completed in TOF, convert if needed. Then back to original units afterwards
     if previous_units != ws_units.tof:
-        ws_to_correct = mantid.ConvertUnits(InputWorkspace=ws_to_correct, Target=ws_units.tof)
+        ws_to_correct = mantid.ConvertUnits(InputWorkspace=ws_to_correct, Target=ws_units.tof, OutputWorkspace=ws_to_correct)
 
     if is_vanadium:
         ws_to_correct = mantid.MayersSampleCorrection(InputWorkspace=ws_to_correct,
-                                                      MultipleScattering=multiple_scattering)
+                                                      MultipleScattering=multiple_scattering,
+                                                      OutputWorkspace=ws_to_correct)
     else:
         # Ensure we never do multiple scattering if the sample is not isotropic (e.g. not a Vanadium)
         ws_to_correct = mantid.MayersSampleCorrection(InputWorkspace=ws_to_correct,
-                                                      MultipleScattering=False)
+                                                      MultipleScattering=False,
+                                                      OutputWorkspace=ws_to_correct)
     if previous_units != ws_units.tof:
-        ws_to_correct = mantid.ConvertUnits(InputWorkspace=ws_to_correct, Target=previous_units)
+        ws_to_correct = mantid.ConvertUnits(InputWorkspace=ws_to_correct, Target=previous_units, OutputWorkspace=ws_to_correct)
     return ws_to_correct
 
 

--- a/scripts/Diffraction/isis_powder/routines/calibrate.py
+++ b/scripts/Diffraction/isis_powder/routines/calibrate.py
@@ -23,15 +23,15 @@ def create_van(instrument, run_details, absorb):
     # Always sum a range of inputs as its a vanadium run over multiple captures
     input_van_ws_list = common.load_current_normalised_ws_list(run_number_string=van, instrument=instrument,
                                                                input_batching=INPUT_BATCHING.Summed)
-    input_van_ws = input_van_ws_list[0]  # As we asked for a summed ws there should only be one returned
+    corrected_van_ws = input_van_ws_list[0]  # As we asked for a summed ws there should only be one returned
 
-    instrument.create_solid_angle_corrections(input_van_ws, run_details)
+    instrument.create_solid_angle_corrections(corrected_van_ws, run_details)
 
     if not (run_details.empty_inst_runs is None):
         summed_empty_inst = common.generate_summed_runs(empty_sample_ws_string=run_details.empty_inst_runs,
                                                         instrument=instrument)
         mantid.SaveNexus(Filename=run_details.summed_empty_inst_file_path, InputWorkspace=summed_empty_inst)
-        corrected_van_ws = common.subtract_summed_runs(ws_to_correct=input_van_ws, empty_sample=summed_empty_inst)
+        corrected_van_ws = common.subtract_summed_runs(ws_to_correct=corrected_van_ws, empty_sample=summed_empty_inst)
 
     # Crop the tail end of the data on PEARL if they are not capturing slow neutrons
     corrected_van_ws = instrument._crop_raw_to_expected_tof_range(ws_to_crop=corrected_van_ws)

--- a/scripts/Diffraction/isis_powder/routines/calibrate.py
+++ b/scripts/Diffraction/isis_powder/routines/calibrate.py
@@ -28,10 +28,10 @@ def create_van(instrument, run_details, absorb):
     instrument.create_solid_angle_corrections(corrected_van_ws, run_details)
 
     if not (run_details.empty_inst_runs is None):
-        summed_empty_inst = common.generate_summed_runs(empty_sample_ws_string=run_details.empty_inst_runs,
+        summed_empty_inst = common.generate_summed_runs(empty_ws_string=run_details.empty_inst_runs,
                                                         instrument=instrument)
         mantid.SaveNexus(Filename=run_details.summed_empty_inst_file_path, InputWorkspace=summed_empty_inst)
-        corrected_van_ws = common.subtract_summed_runs(ws_to_correct=corrected_van_ws, empty_sample=summed_empty_inst)
+        corrected_van_ws = common.subtract_summed_runs(ws_to_correct=corrected_van_ws, empty_ws=summed_empty_inst)
 
     # Crop the tail end of the data on PEARL if they are not capturing slow neutrons
     corrected_van_ws = instrument._crop_raw_to_expected_tof_range(ws_to_crop=corrected_van_ws)

--- a/scripts/Diffraction/isis_powder/routines/common.py
+++ b/scripts/Diffraction/isis_powder/routines/common.py
@@ -499,45 +499,44 @@ def spline_workspaces(focused_vanadium_spectra, num_splines):
     return splined_ws_list
 
 
-def generate_summed_runs(empty_sample_ws_string, instrument, scale_factor=None):
+def generate_summed_runs(empty_ws_string, instrument, scale_factor=None):
     """
-    Loads the list of empty runs specified by the empty_sample_ws_string and sums
+    Loads the list of empty runs specified by the empty_ws_string and sums
     them (and optionally scales). Returns the summed workspace.
-    :param empty_sample_ws_string: The empty run numbers to sum
+    :param empty_ws_string: The empty run numbers to sum
     :param instrument: The instrument object these runs belong to
     :param scale_factor: The percentage to scale the loaded runs by
     :return: The summed and normalised empty runs
     """
 
-    empty_sample = load_current_normalised_ws_list(run_number_string=empty_sample_ws_string, instrument=instrument,
-                                                   input_batching=INPUT_BATCHING.Summed)
-    empty_sample = empty_sample[0]
+    empty_ws_list = load_current_normalised_ws_list(run_number_string=empty_ws_string, instrument=instrument,
+                                                    input_batching=INPUT_BATCHING.Summed)
+    empty_ws = empty_ws_list[0]
     if scale_factor:
-        empty_sample = mantid.Scale(InputWorkspace=empty_sample, OutputWorkspace=empty_sample, Factor=scale_factor,
+        empty_ws = mantid.Scale(InputWorkspace=empty_ws, OutputWorkspace=empty_ws, Factor=scale_factor,
                                     Operation="Multiply")
-    return empty_sample
+    return empty_ws
 
 
-def subtract_summed_runs(ws_to_correct, empty_sample):
+def subtract_summed_runs(ws_to_correct, empty_ws):
     """
-    Subtracts the list of empty runs specified by the empty_sample_ws_string
-    from the workspace specified. Returns the subtracted workspace.
+    Subtracts empty_ws from ws_to_correct. Returns the subtracted workspace.
     :param ws_to_correct: The workspace to correct
-    :param empty_sample: The empty workspace to subtract
+    :param empty_ws: The empty workspace to subtract
     :return: The workspace with the empty runs subtracted
     """
     # Skip this step if the workspace has no current, as subtracting empty
     # would give us negative counts
     if workspace_has_current(ws_to_correct):
         try:
-            mantid.Minus(LHSWorkspace=ws_to_correct, RHSWorkspace=empty_sample, OutputWorkspace=ws_to_correct)
+            mantid.Minus(LHSWorkspace=ws_to_correct, RHSWorkspace=empty_ws, OutputWorkspace=ws_to_correct)
         except ValueError:
             raise ValueError("The empty run(s) specified for this file do not have matching binning. Do the TOF windows of"
                              " the empty and sample match?")
     else:
         ws_to_correct = copy.deepcopy(ws_to_correct)
 
-    remove_intermediate_workspace(empty_sample)
+    remove_intermediate_workspace(empty_ws)
 
     return ws_to_correct
 
@@ -659,6 +658,7 @@ def _load_list_of_files(run_numbers_list, instrument, file_ext=None):
 
     for run_number in run_numbers_list:
         file_name = instrument._generate_input_file_name(run_number=run_number, file_ext=file_ext)
+        # include file extension in ws name to allow users to distinguish different partial files (eg .s1 or .s2)
         if not AnalysisDataService.doesExist(file_name):
             read_ws = mantid.Load(Filename=file_name, OutputWorkspace=file_name)
         else:

--- a/scripts/Diffraction/isis_powder/routines/focus.py
+++ b/scripts/Diffraction/isis_powder/routines/focus.py
@@ -46,14 +46,14 @@ def _focus_one_ws(input_workspace, run_number, instrument, perform_vanadium_norm
             logger.warning('Pre-summed empty instrument workspace found at ' + run_details.summed_empty_inst_file_path)
             summed_empty = mantid.LoadNexus(Filename=run_details.summed_empty_inst_file_path)
         else:
-            summed_empty = common.generate_summed_runs(empty_sample_ws_string=run_details.empty_inst_runs,
+            summed_empty = common.generate_summed_runs(empty_ws_string=run_details.empty_inst_runs,
                                                        instrument=instrument)
     elif run_details.sample_empty:
         scale_factor = 1.0
         if empty_can_subtraction_method != 'PaalmanPings':
             scale_factor = instrument._inst_settings.sample_empty_scale
         # Subtract a sample empty if specified ie empty can
-        summed_empty = common.generate_summed_runs(empty_sample_ws_string=run_details.sample_empty,
+        summed_empty = common.generate_summed_runs(empty_ws_string=run_details.sample_empty,
                                                    instrument=instrument,
                                                    scale_factor=scale_factor)
 
@@ -70,7 +70,7 @@ def _focus_one_ws(input_workspace, run_number, instrument, perform_vanadium_norm
             raise TypeError("The PaalmanPings absorption method requires 'sample_empty' to be supplied.")
     else:
         if summed_empty:
-            input_workspace = common.subtract_summed_runs(ws_to_correct=input_workspace, empty_sample=summed_empty)
+            input_workspace = common.subtract_summed_runs(ws_to_correct=input_workspace, empty_ws=summed_empty)
         # Crop to largest acceptable TOF range
         input_workspace = instrument._crop_raw_to_expected_tof_range(ws_to_crop=input_workspace)
 

--- a/scripts/Diffraction/isis_powder/test/ISISPowderCommonTest.py
+++ b/scripts/Diffraction/isis_powder/test/ISISPowderCommonTest.py
@@ -560,7 +560,7 @@ class ISISPowderCommonTest(unittest.TestCase):
         original_y = original_ws.readY(0)
         scale_factor = 0.75
 
-        scaled_ws = common.generate_summed_runs(empty_sample_ws_string=sample_empty_number, instrument=ISISPowderMockInst(),
+        scaled_ws = common.generate_summed_runs(empty_ws_string=sample_empty_number, instrument=ISISPowderMockInst(),
                                                 scale_factor=scale_factor)
         scaled_y_values = scaled_ws.readY(0)
         self.assertAlmostEqual(scaled_y_values[2], original_y[2]*scale_factor)
@@ -582,7 +582,7 @@ class ISISPowderCommonTest(unittest.TestCase):
         empty_ws = empty_ws * 0.3
 
         returned_ws = common.subtract_summed_runs(ws_to_correct=no_scale_ws,
-                                                  empty_sample=empty_ws)
+                                                  empty_ws=empty_ws)
         y_values = returned_ws.readY(0)
         original_y_values = original_ws.readY(0)
         for i in range(returned_ws.blocksize()):
@@ -603,7 +603,7 @@ class ISISPowderCommonTest(unittest.TestCase):
         empty_ws = empty_ws * 0.3
 
         returned_ws = common.subtract_summed_runs(ws_to_correct=ws_to_correct,
-                                                  empty_sample=empty_ws)
+                                                  empty_ws=empty_ws)
         y_values = returned_ws.readY(0)
         original_y_values = original_ws.readY(0)
         # subtraction should be skipped leaving original values
@@ -624,7 +624,7 @@ class ISISPowderCommonTest(unittest.TestCase):
         # This should throw as the TOF ranges do not match
         with self.assertRaisesRegex(ValueError, "specified for this file do not have matching binning. Do the "):
             common.subtract_summed_runs(ws_to_correct=sample_ws,
-                                        empty_sample=empty_ws)
+                                        empty_ws=empty_ws)
 
         mantid.DeleteWorkspace(sample_ws)
 


### PR DESCRIPTION
**Description of work.**

Running two consecutive focus actions in a POLARIS powder previously generated an error from the NormaliseByCurrent algorithm. This was because a check introduced into common.py to retrieve the input workspace from the ADS (if present) wasn't working for the focus action. The focus action applies some changes to the input workspace in situ in the ADS without changing its name eg normalising, applying absorption correction. So running focus twice applied the changes twice which either gave the wrong answer or if the step had some logic to prevent double running (like NormaliseByCurrent) it generated an error

I've fixed this in two ways:

a) the load logic in common.py now creates a renamed copy of the input workspace (eg POLARIS00098533_red) which means a fresh\unaltered copy of the input workspace (POLARIS00098533) is available in the ADS at the end of the focus action

b) the focus function in focus.py now deletes the workspace it was supplied at the end in all cases - previously when running a focus including absorption correction the input_workspace variable was switched to point at a new workspace which meant the delete(input_workspace) statement at the end of focus didn't clear down the input as expected. This change on its own would have fixed the bug without a) but I decided it was nice to have the caching feature

**To test:**

Unzip the zip file attached to https://github.com/mantidproject/mantid/pull/34144 which contains some config files necessary to run a POLARIS reduction
Update `config_file_path` in script below to match where you unzipped the files to.
Run this script and check the script completes without errors (previously the second focus action would generate an error):
```
# import mantid algorithms, numpy and matplotlib
from mantid.simpleapi import *
import matplotlib.pyplot as plt
import numpy as np

from isis_powder import polaris, SampleDetails

config_file_path = r"C:\Total Scattering\polaris_config_example.yaml"
# mode PDF means normalisation method defaults to absolute
polaris = polaris.Polaris(config_file=config_file_path, user_name="test", mode="PDF")

sample_details = SampleDetails(height=4.0, radius=0.2985, center=[0, 0, 0], shape='cylinder')
sample_details.set_material(chemical_formula='Si', packing_fraction=0.6)
polaris.set_sample_details(sample=sample_details)

polaris.create_vanadium(first_cycle_run_no="98532", multiple_scattering=False)

polaris.focus(run_number="98533", input_mode='Summed')
polaris.focus(run_number="98533", input_mode='Summed')
```

Fixes #34749.

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
