### PR TITLE
Add peak picker to ALFView analysis plot

### DIFF
--- a/qt/python/mantidqt/mantidqt/plotting/markers.py
+++ b/qt/python/mantidqt/mantidqt/plotting/markers.py
@@ -54,7 +54,7 @@ class HorizontalMarker(QObject):
                                linewidth=line_width,
                                linestyle=line_style,
                                animated=True)
-        self.axis.add_patch(self.patch)
+        self.axis.add_artist_correctly(self.patch)
         self.axis.interactive_markers.append(self.patch)
         self.is_moving = False
         self.move_cursor = move_cursor
@@ -76,7 +76,10 @@ class HorizontalMarker(QObject):
         """
         Remove this marker from the canvas.
         """
-        self.patch.remove()
+        try:
+            self.patch.remove()
+        except ValueError:
+            pass
 
     def redraw(self):
         """
@@ -237,7 +240,7 @@ class VerticalMarker(QObject):
         path = Path([(x, y0), (x, y1)], [Path.MOVETO, Path.LINETO])
         self.patch = PathPatch(path, facecolor='None', edgecolor=color, picker=picker_width,
                                linewidth=line_width, linestyle=line_style, animated=True)
-        self.axis.add_patch(self.patch)
+        self.axis.add_artist_correctly(self.patch)
         self.axis.interactive_markers.append(self.patch)
         self.is_moving = False
         self.move_cursor = move_cursor

--- a/qt/python/mantidqt/mantidqt/plotting/markers.py
+++ b/qt/python/mantidqt/mantidqt/plotting/markers.py
@@ -516,6 +516,8 @@ class PeakMarker(QObject):
         self.left_width = WidthMarker(canvas, x - fwhm / 2)
         self.right_width = WidthMarker(canvas, x + fwhm / 2)
         self.is_selected = False
+        # True if the mouse is currently hovering over the centre marker
+        self._centre_hover = False
 
     def redraw(self):
         """
@@ -598,6 +600,17 @@ class PeakMarker(QObject):
             if moved:
                 self.fwhm_changed.emit(self.peak_id, self.fwhm())
         return moved
+
+    def mouse_move_hover(self, x: float, y: float) -> None:
+        """
+        Check if the provided coordinate is above the centre marker.
+        """
+        is_above_centre = self.centre_marker.is_above(x, y)
+        if not self._centre_hover and is_above_centre:
+            QApplication.setOverrideCursor(Qt.SizeHorCursor)
+        elif self._centre_hover and not is_above_centre:
+            QApplication.restoreOverrideCursor()
+        self._centre_hover = is_above_centre
 
     def is_moving(self):
         """

--- a/qt/scientific_interfaces/Direct/ALFAnalysisModel.cpp
+++ b/qt/scientific_interfaces/Direct/ALFAnalysisModel.cpp
@@ -11,6 +11,7 @@
 #include "MantidAPI/CompositeFunction.h"
 #include "MantidAPI/FunctionFactory.h"
 #include "MantidAPI/IFunction.h"
+#include "MantidAPI/IPeakFunction.h"
 #include "MantidAPI/MatrixWorkspace.h"
 
 #include <algorithm>
@@ -154,7 +155,10 @@ void ALFAnalysisModel::setPeakCentre(double const centre) {
   m_fitStatus = "";
 }
 
-double ALFAnalysisModel::peakCentre() const { return m_function->getParameter("f1.PeakCentre"); }
+Mantid::API::IPeakFunction_const_sptr ALFAnalysisModel::getPeakCopy() const {
+  auto const gaussian = m_function->getFunction(1)->clone();
+  return std::dynamic_pointer_cast<Mantid::API::IPeakFunction>(gaussian);
+}
 
 std::string ALFAnalysisModel::fitStatus() const { return m_fitStatus; }
 

--- a/qt/scientific_interfaces/Direct/ALFAnalysisModel.cpp
+++ b/qt/scientific_interfaces/Direct/ALFAnalysisModel.cpp
@@ -44,6 +44,7 @@ MatrixWorkspace_sptr convertToPointData(MatrixWorkspace_sptr const &workspace) {
 IFunction_sptr createFlatBackground(double const height = 0.0) {
   auto flatBackground = FunctionFactory::Instance().createFunction("FlatBackground");
   flatBackground->setParameter("A0", height);
+  flatBackground->addConstraints("A0 > 0");
   return flatBackground;
 }
 
@@ -52,6 +53,7 @@ IFunction_sptr createGaussian(double const height = 0.0, double const peakCentre
   gaussian->setParameter("Height", height);
   gaussian->setParameter("PeakCentre", peakCentre);
   gaussian->setParameter("Sigma", sigma);
+  gaussian->addConstraints("Height > 0");
   return gaussian;
 }
 

--- a/qt/scientific_interfaces/Direct/ALFAnalysisModel.cpp
+++ b/qt/scientific_interfaces/Direct/ALFAnalysisModel.cpp
@@ -150,10 +150,22 @@ IFunction_sptr ALFAnalysisModel::calculateEstimate(MatrixWorkspace_sptr &workspa
   return createCompositeFunction(createFlatBackground(), createGaussian());
 }
 
+void ALFAnalysisModel::setPeakParameters(Mantid::API::IPeakFunction_const_sptr const &peak) {
+  auto const centre = peak->getParameter("PeakCentre");
+  auto const height = peak->getParameter("Height");
+  auto const sigma = peak->getParameter("Sigma");
+
+  setPeakCentre(centre);
+  m_function->setParameter("f1.Height", height);
+  m_function->setParameter("f1.Sigma", sigma);
+}
+
 void ALFAnalysisModel::setPeakCentre(double const centre) {
   m_function->setParameter("f1.PeakCentre", centre);
   m_fitStatus = "";
 }
+
+double ALFAnalysisModel::peakCentre() const { return m_function->getParameter("f1.PeakCentre"); }
 
 Mantid::API::IPeakFunction_const_sptr ALFAnalysisModel::getPeakCopy() const {
   auto const gaussian = m_function->getFunction(1)->clone();

--- a/qt/scientific_interfaces/Direct/ALFAnalysisModel.h
+++ b/qt/scientific_interfaces/Direct/ALFAnalysisModel.h
@@ -8,6 +8,7 @@
 
 #include "DllConfig.h"
 #include "MantidAPI/IFunction_fwd.h"
+#include "MantidAPI/IPeakFunction.h"
 #include "MantidAPI/MatrixWorkspace_fwd.h"
 
 #include <optional>
@@ -34,7 +35,7 @@ public:
   virtual void calculateEstimate(std::pair<double, double> const &range) = 0;
 
   virtual void setPeakCentre(double const centre) = 0;
-  virtual double peakCentre() const = 0;
+  virtual Mantid::API::IPeakFunction_const_sptr getPeakCopy() const = 0;
 
   virtual std::string fitStatus() const = 0;
 
@@ -60,7 +61,7 @@ public:
   void calculateEstimate(std::pair<double, double> const &range) override;
 
   void setPeakCentre(double const centre) override;
-  double peakCentre() const override;
+  Mantid::API::IPeakFunction_const_sptr getPeakCopy() const override;
 
   std::string fitStatus() const override;
 

--- a/qt/scientific_interfaces/Direct/ALFAnalysisModel.h
+++ b/qt/scientific_interfaces/Direct/ALFAnalysisModel.h
@@ -34,7 +34,9 @@ public:
   virtual Mantid::API::MatrixWorkspace_sptr doFit(std::pair<double, double> const &range) = 0;
   virtual void calculateEstimate(std::pair<double, double> const &range) = 0;
 
+  virtual void setPeakParameters(Mantid::API::IPeakFunction_const_sptr const &peak) = 0;
   virtual void setPeakCentre(double const centre) = 0;
+  virtual double peakCentre() const = 0;
   virtual Mantid::API::IPeakFunction_const_sptr getPeakCopy() const = 0;
 
   virtual std::string fitStatus() const = 0;
@@ -60,7 +62,9 @@ public:
   Mantid::API::MatrixWorkspace_sptr doFit(std::pair<double, double> const &range) override;
   void calculateEstimate(std::pair<double, double> const &range) override;
 
+  void setPeakParameters(Mantid::API::IPeakFunction_const_sptr const &peak) override;
   void setPeakCentre(double const centre) override;
+  double peakCentre() const override;
   Mantid::API::IPeakFunction_const_sptr getPeakCopy() const override;
 
   std::string fitStatus() const override;

--- a/qt/scientific_interfaces/Direct/ALFAnalysisPresenter.cpp
+++ b/qt/scientific_interfaces/Direct/ALFAnalysisPresenter.cpp
@@ -23,6 +23,7 @@ QWidget *ALFAnalysisPresenter::getView() { return m_view->getView(); }
 void ALFAnalysisPresenter::setExtractedWorkspace(Mantid::API::MatrixWorkspace_sptr const &workspace,
                                                  std::vector<double> const &twoThetas) {
   m_model->setExtractedWorkspace(workspace, twoThetas);
+  calculateEstimate(true);
   updateViewFromModel();
 }
 
@@ -59,13 +60,8 @@ void ALFAnalysisPresenter::notifyFitClicked() {
 }
 
 void ALFAnalysisPresenter::notifyUpdateEstimateClicked() {
-  auto const validationMessage = validateFitValues();
-  if (!validationMessage) {
-    m_model->calculateEstimate(m_view->getRange());
-    updatePeakCentreInViewFromModel();
-  } else {
-    m_view->displayWarning(*validationMessage);
-  }
+  calculateEstimate();
+  updatePeakCentreInViewFromModel();
 }
 
 std::optional<std::string> ALFAnalysisPresenter::validateFitValues() const {
@@ -87,6 +83,15 @@ bool ALFAnalysisPresenter::checkPeakCentreIsWithinFitRange() const {
   auto const peakCentre = m_view->peakCentre();
   auto const range = m_view->getRange();
   return range.first < peakCentre && peakCentre < range.second;
+}
+
+void ALFAnalysisPresenter::calculateEstimate(bool const silent) {
+  auto const validationMessage = validateFitValues();
+  if (!validationMessage) {
+    m_model->calculateEstimate(m_view->getRange());
+  } else if (!silent) {
+    m_view->displayWarning(*validationMessage);
+  }
 }
 
 void ALFAnalysisPresenter::updateViewFromModel() {

--- a/qt/scientific_interfaces/Direct/ALFAnalysisPresenter.cpp
+++ b/qt/scientific_interfaces/Direct/ALFAnalysisPresenter.cpp
@@ -11,6 +11,16 @@
 
 #include <exception>
 
+namespace {
+
+double constexpr EPSILON = std::numeric_limits<double>::epsilon();
+
+bool equalWithinTolerance(double const val1, double const val2, double const tolerance = 0.000001) {
+  return std::abs(val1 - val2) <= (tolerance + 2.0 * EPSILON);
+}
+
+} // namespace
+
 namespace MantidQt::CustomInterfaces {
 
 ALFAnalysisPresenter::ALFAnalysisPresenter(IALFAnalysisView *view, std::unique_ptr<IALFAnalysisModel> model)
@@ -40,8 +50,11 @@ void ALFAnalysisPresenter::notifyPeakPickerChanged() {
 }
 
 void ALFAnalysisPresenter::notifyPeakCentreEditingFinished() {
-  m_model->setPeakCentre(m_view->peakCentre());
-  updatePeakCentreInViewFromModel();
+  auto const newPeakCentre = m_view->peakCentre();
+  if (!equalWithinTolerance(m_model->peakCentre(), newPeakCentre)) {
+    m_model->setPeakCentre(newPeakCentre);
+    updatePeakCentreInViewFromModel();
+  }
 }
 
 void ALFAnalysisPresenter::notifyFitClicked() {

--- a/qt/scientific_interfaces/Direct/ALFAnalysisPresenter.cpp
+++ b/qt/scientific_interfaces/Direct/ALFAnalysisPresenter.cpp
@@ -26,6 +26,18 @@ void ALFAnalysisPresenter::setExtractedWorkspace(Mantid::API::MatrixWorkspace_sp
   updateViewFromModel();
 }
 
+void ALFAnalysisPresenter::notifyPeakPickerChanged() {
+  m_model->setPeakParameters(m_view->getPeak());
+
+  auto const fitStatus = m_model->fitStatus();
+
+  m_view->setPeakCentre(m_model->peakCentre());
+  m_view->setPeakCentreStatus(fitStatus);
+  if (fitStatus.empty()) {
+    m_view->removeFitSpectrum();
+  }
+}
+
 void ALFAnalysisPresenter::notifyPeakCentreEditingFinished() {
   m_model->setPeakCentre(m_view->peakCentre());
   updatePeakCentreInViewFromModel();

--- a/qt/scientific_interfaces/Direct/ALFAnalysisPresenter.cpp
+++ b/qt/scientific_interfaces/Direct/ALFAnalysisPresenter.cpp
@@ -28,7 +28,7 @@ void ALFAnalysisPresenter::setExtractedWorkspace(Mantid::API::MatrixWorkspace_sp
 
 void ALFAnalysisPresenter::notifyPeakCentreEditingFinished() {
   m_model->setPeakCentre(m_view->peakCentre());
-  m_view->setPeakCentreStatus(m_model->fitStatus());
+  updatePeakCentreInViewFromModel();
 }
 
 void ALFAnalysisPresenter::notifyFitClicked() {
@@ -86,8 +86,14 @@ void ALFAnalysisPresenter::updateViewFromModel() {
 void ALFAnalysisPresenter::updatePlotInViewFromModel() { m_view->addSpectrum(m_model->extractedWorkspace()); }
 
 void ALFAnalysisPresenter::updatePeakCentreInViewFromModel() {
-  m_view->setPeakCentre(m_model->peakCentre());
-  m_view->setPeakCentreStatus(m_model->fitStatus());
+  m_view->setPeak(m_model->getPeakCopy());
+
+  auto const fitStatus = m_model->fitStatus();
+  m_view->setPeakCentreStatus(fitStatus);
+  if (fitStatus.empty()) {
+    m_view->removeFitSpectrum();
+  }
+  m_view->replot();
 }
 
 void ALFAnalysisPresenter::updateTwoThetaInViewFromModel() {

--- a/qt/scientific_interfaces/Direct/ALFAnalysisPresenter.cpp
+++ b/qt/scientific_interfaces/Direct/ALFAnalysisPresenter.cpp
@@ -86,11 +86,10 @@ bool ALFAnalysisPresenter::checkPeakCentreIsWithinFitRange() const {
 }
 
 void ALFAnalysisPresenter::calculateEstimate(bool const silent) {
-  auto const validationMessage = validateFitValues();
-  if (!validationMessage) {
+  if (m_model->isDataExtracted()) {
     m_model->calculateEstimate(m_view->getRange());
   } else if (!silent) {
-    m_view->displayWarning(*validationMessage);
+    m_view->displayWarning("Need to have extracted data to do a fit or estimate.");
   }
 }
 

--- a/qt/scientific_interfaces/Direct/ALFAnalysisPresenter.h
+++ b/qt/scientific_interfaces/Direct/ALFAnalysisPresenter.h
@@ -64,6 +64,8 @@ private:
   std::optional<std::string> validateFitValues() const;
   bool checkPeakCentreIsWithinFitRange() const;
 
+  void calculateEstimate(bool const silent = false);
+
   void updateViewFromModel();
   void updatePlotInViewFromModel();
   void updatePeakCentreInViewFromModel();

--- a/qt/scientific_interfaces/Direct/ALFAnalysisPresenter.h
+++ b/qt/scientific_interfaces/Direct/ALFAnalysisPresenter.h
@@ -32,6 +32,7 @@ public:
   virtual void setExtractedWorkspace(Mantid::API::MatrixWorkspace_sptr const &workspace,
                                      std::vector<double> const &twoThetas) = 0;
 
+  virtual void notifyPeakPickerChanged() = 0;
   virtual void notifyPeakCentreEditingFinished() = 0;
   virtual void notifyFitClicked() = 0;
   virtual void notifyUpdateEstimateClicked() = 0;
@@ -50,6 +51,7 @@ public:
   void setExtractedWorkspace(Mantid::API::MatrixWorkspace_sptr const &workspace,
                              std::vector<double> const &twoThetas) override;
 
+  void notifyPeakPickerChanged() override;
   void notifyPeakCentreEditingFinished() override;
   void notifyFitClicked() override;
   void notifyUpdateEstimateClicked() override;

--- a/qt/scientific_interfaces/Direct/ALFAnalysisView.cpp
+++ b/qt/scientific_interfaces/Direct/ALFAnalysisView.cpp
@@ -7,6 +7,8 @@
 #include "ALFAnalysisView.h"
 #include "ALFAnalysisPresenter.h"
 
+#include "MantidAPI/IPeakFunction.h"
+#include "MantidQtWidgets/Plotting/PeakPicker.h"
 #include "MantidQtWidgets/Plotting/PreviewPlot.h"
 
 #include <tuple>
@@ -52,7 +54,7 @@ QString constructAverageString(std::vector<double> const &twoThetas) {
 namespace MantidQt::CustomInterfaces {
 
 ALFAnalysisView::ALFAnalysisView(double const start, double const end, QWidget *parent)
-    : QWidget(parent), m_plot(nullptr), m_start(nullptr), m_end(nullptr), m_fitButton(nullptr) {
+    : QWidget(parent), m_plot(nullptr), m_peakPicker(nullptr), m_start(nullptr), m_end(nullptr), m_fitButton(nullptr) {
   setupPlotFitSplitter(start, end);
 }
 
@@ -66,6 +68,9 @@ void ALFAnalysisView::setupPlotFitSplitter(double const start, double const end)
 
   m_plot = new MantidWidgets::PreviewPlot();
   m_plot->setCanvasColour(Qt::white);
+
+  m_peakPicker = new MantidWidgets::PeakPicker(m_plot, Qt::red);
+
   splitter->addWidget(m_plot);
 
   splitter->addWidget(createFitPane(start, end));
@@ -156,6 +161,8 @@ void ALFAnalysisView::notifyFitClicked() { m_presenter->notifyFitClicked(); }
 
 void ALFAnalysisView::notifyUpdateEstimateClicked() { m_presenter->notifyUpdateEstimateClicked(); }
 
+void ALFAnalysisView::replot() { m_plot->replot(); }
+
 std::pair<double, double> ALFAnalysisView::getRange() const {
   return std::make_pair(m_start->text().toDouble(), m_end->text().toDouble());
 }
@@ -173,7 +180,14 @@ void ALFAnalysisView::addFitSpectrum(Mantid::API::MatrixWorkspace_sptr const &wo
   }
 }
 
-void ALFAnalysisView::setPeakCentre(double const centre) { m_peakCentre->setText(QString::number(centre)); }
+void ALFAnalysisView::removeFitSpectrum() { m_plot->removeSpectrum("Fitted Data"); }
+
+void ALFAnalysisView::setPeak(Mantid::API::IPeakFunction_const_sptr const &peak) {
+  m_peakCentre->setText(QString::number(peak->getParameter("PeakCentre")));
+
+  m_peakPicker->setPeak(peak);
+  m_peakPicker->select(false);
+}
 
 double ALFAnalysisView::peakCentre() const { return m_peakCentre->text().toDouble(); }
 

--- a/qt/scientific_interfaces/Direct/ALFAnalysisView.cpp
+++ b/qt/scientific_interfaces/Direct/ALFAnalysisView.cpp
@@ -67,7 +67,11 @@ void ALFAnalysisView::setupPlotFitSplitter(double const start, double const end)
   auto splitter = new QSplitter(Qt::Vertical);
 
   m_plot = new MantidWidgets::PreviewPlot();
-  m_plot->setCanvasColour(Qt::white);
+
+  // Set the preview plot background as transparent. Also seems to stop the figure resizing each time replotting
+  // happens.
+  m_plot->canvas()->gcf().setFaceColor("None");
+  m_plot->canvas()->setStyleSheet("background-color:transparent;");
 
   m_peakPicker = new MantidWidgets::PeakPicker(m_plot, Qt::red);
   connect(m_peakPicker, SIGNAL(changed()), this, SLOT(notifyPeakPickerChanged()));

--- a/qt/scientific_interfaces/Direct/ALFAnalysisView.cpp
+++ b/qt/scientific_interfaces/Direct/ALFAnalysisView.cpp
@@ -68,12 +68,12 @@ void ALFAnalysisView::setupPlotFitSplitter(double const start, double const end)
 
   m_plot = new MantidWidgets::PreviewPlot();
 
-  // Set the preview plot background as transparent. Also seems to stop the figure resizing each time replotting
-  // happens.
+  // Set the preview plot background as transparent.
   m_plot->canvas()->gcf().setFaceColor("None");
   m_plot->canvas()->setStyleSheet("background-color:transparent;");
 
   m_peakPicker = new MantidWidgets::PeakPicker(m_plot, Qt::red);
+  m_peakPicker->setVisible(false);
   connect(m_peakPicker, SIGNAL(changed()), this, SLOT(notifyPeakPickerChanged()));
 
   splitter->addWidget(m_plot);
@@ -175,8 +175,10 @@ std::pair<double, double> ALFAnalysisView::getRange() const {
 }
 
 void ALFAnalysisView::addSpectrum(Mantid::API::MatrixWorkspace_sptr const &workspace) {
+  m_peakPicker->setVisible(false);
   m_plot->clear();
   if (workspace) {
+    m_peakPicker->setVisible(true);
     m_plot->addSpectrum("Extracted Data", workspace, 0, Qt::black);
   }
 }

--- a/qt/scientific_interfaces/Direct/ALFAnalysisView.cpp
+++ b/qt/scientific_interfaces/Direct/ALFAnalysisView.cpp
@@ -70,6 +70,7 @@ void ALFAnalysisView::setupPlotFitSplitter(double const start, double const end)
   m_plot->setCanvasColour(Qt::white);
 
   m_peakPicker = new MantidWidgets::PeakPicker(m_plot, Qt::red);
+  connect(m_peakPicker, SIGNAL(changed()), this, SLOT(notifyPeakPickerChanged()));
 
   splitter->addWidget(m_plot);
 
@@ -155,6 +156,8 @@ QWidget *ALFAnalysisView::setupResultsWidget(double const centre) {
   return resultsWidget;
 }
 
+void ALFAnalysisView::notifyPeakPickerChanged() { m_presenter->notifyPeakPickerChanged(); }
+
 void ALFAnalysisView::notifyPeakCentreEditingFinished() { m_presenter->notifyPeakCentreEditingFinished(); }
 
 void ALFAnalysisView::notifyFitClicked() { m_presenter->notifyFitClicked(); }
@@ -183,11 +186,15 @@ void ALFAnalysisView::addFitSpectrum(Mantid::API::MatrixWorkspace_sptr const &wo
 void ALFAnalysisView::removeFitSpectrum() { m_plot->removeSpectrum("Fitted Data"); }
 
 void ALFAnalysisView::setPeak(Mantid::API::IPeakFunction_const_sptr const &peak) {
-  m_peakCentre->setText(QString::number(peak->getParameter("PeakCentre")));
+  setPeakCentre(peak->getParameter("PeakCentre"));
 
   m_peakPicker->setPeak(peak);
   m_peakPicker->select(false);
 }
+
+Mantid::API::IPeakFunction_const_sptr ALFAnalysisView::getPeak() const { return m_peakPicker->peak(); }
+
+void ALFAnalysisView::setPeakCentre(double const centre) { m_peakCentre->setText(QString::number(centre)); }
 
 double ALFAnalysisView::peakCentre() const { return m_peakCentre->text().toDouble(); }
 

--- a/qt/scientific_interfaces/Direct/ALFAnalysisView.h
+++ b/qt/scientific_interfaces/Direct/ALFAnalysisView.h
@@ -49,6 +49,9 @@ public:
   virtual void removeFitSpectrum() = 0;
 
   virtual void setPeak(Mantid::API::IPeakFunction_const_sptr const &peak) = 0;
+  virtual Mantid::API::IPeakFunction_const_sptr getPeak() const = 0;
+
+  virtual void setPeakCentre(double const centre) = 0;
   virtual double peakCentre() const = 0;
   virtual void setPeakCentreStatus(std::string const &status) = 0;
 
@@ -76,7 +79,9 @@ public:
   void removeFitSpectrum();
 
   void setPeak(Mantid::API::IPeakFunction_const_sptr const &peak) override;
+  Mantid::API::IPeakFunction_const_sptr getPeak() const override;
 
+  void setPeakCentre(double const centre) override;
   double peakCentre() const override;
   void setPeakCentreStatus(std::string const &status) override;
 
@@ -85,6 +90,7 @@ public:
   void displayWarning(std::string const &message) override;
 
 public slots:
+  void notifyPeakPickerChanged();
   void notifyPeakCentreEditingFinished();
   void notifyUpdateEstimateClicked();
   void notifyFitClicked();

--- a/qt/scientific_interfaces/Direct/ALFAnalysisView.h
+++ b/qt/scientific_interfaces/Direct/ALFAnalysisView.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include "DllConfig.h"
+#include "MantidAPI/IPeakFunction.h"
 #include "MantidAPI/MatrixWorkspace_fwd.h"
 
 #include <QLabel>
@@ -23,8 +24,9 @@
 namespace MantidQt {
 
 namespace MantidWidgets {
+class PeakPicker;
 class PreviewPlot;
-}
+} // namespace MantidWidgets
 
 namespace CustomInterfaces {
 
@@ -38,12 +40,15 @@ public:
 
   virtual void subscribePresenter(IALFAnalysisPresenter *presenter) = 0;
 
+  virtual void replot() = 0;
+
   virtual std::pair<double, double> getRange() const = 0;
 
   virtual void addSpectrum(Mantid::API::MatrixWorkspace_sptr const &workspace) = 0;
   virtual void addFitSpectrum(Mantid::API::MatrixWorkspace_sptr const &workspace) = 0;
+  virtual void removeFitSpectrum() = 0;
 
-  virtual void setPeakCentre(double const centre) = 0;
+  virtual void setPeak(Mantid::API::IPeakFunction_const_sptr const &peak) = 0;
   virtual double peakCentre() const = 0;
   virtual void setPeakCentreStatus(std::string const &status) = 0;
 
@@ -62,12 +67,16 @@ public:
 
   void subscribePresenter(IALFAnalysisPresenter *presenter) override;
 
+  void replot() override;
+
   std::pair<double, double> getRange() const override;
 
   void addSpectrum(Mantid::API::MatrixWorkspace_sptr const &workspace) override;
   void addFitSpectrum(Mantid::API::MatrixWorkspace_sptr const &workspace) override;
+  void removeFitSpectrum();
 
-  void setPeakCentre(double const centre) override;
+  void setPeak(Mantid::API::IPeakFunction_const_sptr const &peak) override;
+
   double peakCentre() const override;
   void setPeakCentreStatus(std::string const &status) override;
 
@@ -88,6 +97,7 @@ private:
   QWidget *setupResultsWidget(double const centre);
 
   MantidWidgets::PreviewPlot *m_plot;
+  MantidWidgets::PeakPicker *m_peakPicker;
   QLineEdit *m_start, *m_end;
   QSplitter *m_fitPlotLayout;
   QPushButton *m_fitButton;

--- a/qt/scientific_interfaces/Direct/ALFAnalysisView.h
+++ b/qt/scientific_interfaces/Direct/ALFAnalysisView.h
@@ -76,7 +76,7 @@ public:
 
   void addSpectrum(Mantid::API::MatrixWorkspace_sptr const &workspace) override;
   void addFitSpectrum(Mantid::API::MatrixWorkspace_sptr const &workspace) override;
-  void removeFitSpectrum();
+  void removeFitSpectrum() override;
 
   void setPeak(Mantid::API::IPeakFunction_const_sptr const &peak) override;
   Mantid::API::IPeakFunction_const_sptr getPeak() const override;

--- a/qt/scientific_interfaces/Direct/ALFInstrumentView.cpp
+++ b/qt/scientific_interfaces/Direct/ALFInstrumentView.cpp
@@ -33,6 +33,9 @@ void ALFInstrumentView::setUpInstrument(std::string const &fileName) {
   m_instrumentWidget->removeTab("Draw");
   m_instrumentWidget->hideHelp();
 
+  connect(m_instrumentWidget, SIGNAL(instrumentActorReset()), this, SLOT(reconnectInstrumentActor()));
+  reconnectInstrumentActor();
+
   auto surface = m_instrumentWidget->getInstrumentDisplay()->getSurface().get();
   connect(surface, SIGNAL(shapeChangeFinished()), this, SLOT(notifyShapeChanged()));
   connect(surface, SIGNAL(shapesRemoved()), this, SLOT(notifyShapeChanged()));
@@ -59,6 +62,10 @@ QWidget *ALFInstrumentView::generateLoadWidget() {
   loadLayout->addItem(new QSpacerItem(20, 40, QSizePolicy::Minimum, QSizePolicy::Expanding));
 
   return loadWidget;
+}
+
+void ALFInstrumentView::reconnectInstrumentActor() {
+  connect(&m_instrumentWidget->getInstrumentActor(), SIGNAL(refreshView()), this, SLOT(notifyShapeChanged()));
 }
 
 void ALFInstrumentView::subscribePresenter(IALFInstrumentPresenter *presenter) { m_presenter = presenter; }

--- a/qt/scientific_interfaces/Direct/ALFInstrumentView.cpp
+++ b/qt/scientific_interfaces/Direct/ALFInstrumentView.cpp
@@ -33,8 +33,10 @@ void ALFInstrumentView::setUpInstrument(std::string const &fileName) {
   m_instrumentWidget->removeTab("Draw");
   m_instrumentWidget->hideHelp();
 
-  connect(m_instrumentWidget->getInstrumentDisplay()->getSurface().get(), SIGNAL(shapeChangeFinished()), this,
-          SLOT(notifyShapeChanged()));
+  auto surface = m_instrumentWidget->getInstrumentDisplay()->getSurface().get();
+  connect(surface, SIGNAL(shapeChangeFinished()), this, SLOT(notifyShapeChanged()));
+  connect(surface, SIGNAL(shapesRemoved()), this, SLOT(notifyShapeChanged()));
+  connect(surface, SIGNAL(shapesCleared()), this, SLOT(notifyShapeChanged()));
 
   auto pickTab = m_instrumentWidget->getPickTab();
   pickTab->expandPlotPanel();

--- a/qt/scientific_interfaces/Direct/ALFInstrumentView.h
+++ b/qt/scientific_interfaces/Direct/ALFInstrumentView.h
@@ -79,6 +79,7 @@ public:
   void warningBox(std::string const &message) override;
 
 private slots:
+  void reconnectInstrumentActor();
   void fileLoaded();
   void notifyShapeChanged();
   void selectWholeTube();

--- a/qt/scientific_interfaces/Direct/test/ALFAnalysisMocks.h
+++ b/qt/scientific_interfaces/Direct/test/ALFAnalysisMocks.h
@@ -34,6 +34,7 @@ public:
   MOCK_METHOD2(setExtractedWorkspace,
                void(Mantid::API::MatrixWorkspace_sptr const &workspace, std::vector<double> const &twoThetas));
 
+  MOCK_METHOD0(notifyPeakPickerChanged, void());
   MOCK_METHOD0(notifyPeakCentreEditingFinished, void());
   MOCK_METHOD0(notifyFitClicked, void());
   MOCK_METHOD0(notifyUpdateEstimateClicked, void());
@@ -58,8 +59,10 @@ public:
   MOCK_METHOD0(removeFitSpectrum, void());
 
   MOCK_METHOD1(setPeak, void(Mantid::API::IPeakFunction_const_sptr const &peak));
-  MOCK_CONST_METHOD0(peakCentre, double());
+  MOCK_CONST_METHOD0(getPeak, Mantid::API::IPeakFunction_const_sptr());
 
+  MOCK_METHOD1(setPeakCentre, void(double const centre));
+  MOCK_CONST_METHOD0(peakCentre, double());
   MOCK_METHOD1(setPeakCentreStatus, void(std::string const &status));
 
   MOCK_METHOD2(setAverageTwoTheta, void(std::optional<double> average, std::vector<double> const &all));
@@ -79,7 +82,9 @@ public:
   MOCK_METHOD1(doFit, Mantid::API::MatrixWorkspace_sptr(std::pair<double, double> const &range));
   MOCK_METHOD1(calculateEstimate, void(std::pair<double, double> const &range));
 
+  MOCK_METHOD1(setPeakParameters, void(Mantid::API::IPeakFunction_const_sptr const &peak));
   MOCK_METHOD1(setPeakCentre, void(double const centre));
+  MOCK_CONST_METHOD0(peakCentre, double());
   MOCK_CONST_METHOD0(getPeakCopy, Mantid::API::IPeakFunction_const_sptr());
 
   MOCK_CONST_METHOD0(fitStatus, std::string());

--- a/qt/scientific_interfaces/Direct/test/ALFAnalysisMocks.h
+++ b/qt/scientific_interfaces/Direct/test/ALFAnalysisMocks.h
@@ -12,6 +12,7 @@
 #include "ALFAnalysisModel.h"
 #include "ALFAnalysisPresenter.h"
 #include "ALFAnalysisView.h"
+#include "MantidAPI/IPeakFunction.h"
 #include "MantidAPI/MatrixWorkspace_fwd.h"
 
 #include "MantidKernel/WarningSuppressions.h"
@@ -48,12 +49,15 @@ public:
 
   MOCK_METHOD1(subscribePresenter, void(IALFAnalysisPresenter *presenter));
 
+  MOCK_METHOD0(replot, void());
+
   MOCK_CONST_METHOD0(getRange, std::pair<double, double>());
 
   MOCK_METHOD1(addSpectrum, void(Mantid::API::MatrixWorkspace_sptr const &workspace));
   MOCK_METHOD1(addFitSpectrum, void(Mantid::API::MatrixWorkspace_sptr const &workspace));
+  MOCK_METHOD0(removeFitSpectrum, void());
 
-  MOCK_METHOD1(setPeakCentre, void(double const centre));
+  MOCK_METHOD1(setPeak, void(Mantid::API::IPeakFunction_const_sptr const &peak));
   MOCK_CONST_METHOD0(peakCentre, double());
 
   MOCK_METHOD1(setPeakCentreStatus, void(std::string const &status));
@@ -76,7 +80,7 @@ public:
   MOCK_METHOD1(calculateEstimate, void(std::pair<double, double> const &range));
 
   MOCK_METHOD1(setPeakCentre, void(double const centre));
-  MOCK_CONST_METHOD0(peakCentre, double());
+  MOCK_CONST_METHOD0(getPeakCopy, Mantid::API::IPeakFunction_const_sptr());
 
   MOCK_CONST_METHOD0(fitStatus, std::string());
 

--- a/qt/scientific_interfaces/Direct/test/ALFAnalysisModelTest.h
+++ b/qt/scientific_interfaces/Direct/test/ALFAnalysisModelTest.h
@@ -43,7 +43,8 @@ public:
 
   void test_that_the_model_is_instantiated_with_a_function_and_empty_fit_status() {
     TS_ASSERT_EQUALS(nullptr, m_model->extractedWorkspace());
-    TS_ASSERT_THROWS_NOTHING(m_model->peakCentre());
+    TS_ASSERT_THROWS_NOTHING(m_model->getPeakCopy());
+    TS_ASSERT_THROWS_NOTHING(m_model->getPeakCopy()->getParameter("PeakCentre"));
     TS_ASSERT_EQUALS("", m_model->fitStatus());
     TS_ASSERT_EQUALS(0u, m_model->numberOfTubes());
     TS_ASSERT_EQUALS(std::nullopt, m_model->averageTwoTheta());
@@ -58,7 +59,7 @@ public:
     TS_ASSERT(!AnalysisDataService::Instance().doesExist("__fit_Parameters"));
     TS_ASSERT(!AnalysisDataService::Instance().doesExist("__fit_NormalisedCovarianceWorkspace"));
 
-    TS_ASSERT_EQUALS(0.0, m_model->peakCentre());
+    TS_ASSERT_EQUALS(0.0, m_model->getPeakCopy()->getParameter("PeakCentre"));
     TS_ASSERT_EQUALS("success", m_model->fitStatus());
   }
 
@@ -67,7 +68,7 @@ public:
 
     m_model->calculateEstimate(m_range);
 
-    TS_ASSERT_EQUALS(0.0, m_model->peakCentre());
+    TS_ASSERT_EQUALS(0.0, m_model->getPeakCopy()->getParameter("PeakCentre"));
     TS_ASSERT_EQUALS("", m_model->fitStatus());
   }
 
@@ -76,7 +77,7 @@ public:
 
     m_model->calculateEstimate(m_range);
 
-    TS_ASSERT_EQUALS(0.5, m_model->peakCentre());
+    TS_ASSERT_EQUALS(0.5, m_model->getPeakCopy()->getParameter("PeakCentre"));
     TS_ASSERT_EQUALS("", m_model->fitStatus());
   }
 
@@ -86,7 +87,7 @@ public:
 
     m_model->calculateEstimate(m_range);
 
-    TS_ASSERT_EQUALS(0.0, m_model->peakCentre());
+    TS_ASSERT_EQUALS(0.0, m_model->getPeakCopy()->getParameter("PeakCentre"));
     TS_ASSERT_EQUALS("", m_model->fitStatus());
   }
 
@@ -97,7 +98,7 @@ public:
 
     m_model->setPeakCentre(1.1);
 
-    TS_ASSERT_EQUALS(1.1, m_model->peakCentre());
+    TS_ASSERT_EQUALS(1.1, m_model->getPeakCopy()->getParameter("PeakCentre"));
     TS_ASSERT_EQUALS("", m_model->fitStatus());
   }
 

--- a/qt/scientific_interfaces/Direct/test/ALFAnalysisPresenterTest.h
+++ b/qt/scientific_interfaces/Direct/test/ALFAnalysisPresenterTest.h
@@ -78,6 +78,37 @@ public:
     m_presenter->setExtractedWorkspace(nullptr, twoThetas);
   }
 
+  void test_notifyPeakPickerChanged_will_removeFitSpectrum_if_fit_status_is_empty() {
+    EXPECT_CALL(*m_view, getPeak()).Times(1).WillOnce(Return(nullptr));
+    EXPECT_CALL(*m_model, setPeakParameters(_)).Times(1);
+
+    EXPECT_CALL(*m_model, fitStatus()).Times(1).WillOnce(Return(""));
+    EXPECT_CALL(*m_view, setPeakCentreStatus("")).Times(1);
+
+    EXPECT_CALL(*m_view, removeFitSpectrum()).Times(1);
+
+    // Assert is not called as is unnecessary
+    EXPECT_CALL(*m_view, replot()).Times(0);
+
+    m_presenter->notifyPeakPickerChanged();
+  }
+
+  void test_notifyPeakPickerChanged_will_not_removeFitSpectrum_if_fit_status_is_not_empty() {
+    EXPECT_CALL(*m_view, getPeak()).Times(1).WillOnce(Return(nullptr));
+    EXPECT_CALL(*m_model, setPeakParameters(_)).Times(1);
+
+    EXPECT_CALL(*m_model, fitStatus()).Times(1).WillOnce(Return("Success"));
+    EXPECT_CALL(*m_view, setPeakCentreStatus("Success")).Times(1);
+
+    // Assert is not called
+    EXPECT_CALL(*m_view, removeFitSpectrum()).Times(0);
+
+    // Assert is not called as is unnecessary
+    EXPECT_CALL(*m_view, replot()).Times(0);
+
+    m_presenter->notifyPeakPickerChanged();
+  }
+
   void test_notifyPeakCentreEditingFinished_sets_the_peak_centre_in_the_model_and_fit_status_in_the_view() {
     EXPECT_CALL(*m_view, peakCentre()).Times(1).WillOnce(Return(m_peakCentre));
     EXPECT_CALL(*m_model, setPeakCentre(m_peakCentre)).Times(1);

--- a/qt/scientific_interfaces/Direct/test/ALFAnalysisPresenterTest.h
+++ b/qt/scientific_interfaces/Direct/test/ALFAnalysisPresenterTest.h
@@ -49,9 +49,6 @@ public:
     m_model = model.get();
     m_view = std::make_unique<NiceMock<MockALFAnalysisView>>();
     m_presenter = std::make_unique<ALFAnalysisPresenter>(m_view.get(), std::move(model));
-
-    m_view->setPeakCentre(m_peakCentre);
-    m_model->setPeakCentre(m_peakCentre);
   }
 
   void tearDown() override {
@@ -85,8 +82,32 @@ public:
     EXPECT_CALL(*m_view, peakCentre()).Times(1).WillOnce(Return(m_peakCentre));
     EXPECT_CALL(*m_model, setPeakCentre(m_peakCentre)).Times(1);
 
+    EXPECT_CALL(*m_model, getPeakCopy()).Times(1).WillOnce(Return(nullptr));
+    EXPECT_CALL(*m_view, setPeak(_)).Times(1);
+
     EXPECT_CALL(*m_model, fitStatus()).Times(1).WillOnce(Return(""));
     EXPECT_CALL(*m_view, setPeakCentreStatus("")).Times(1);
+
+    EXPECT_CALL(*m_view, removeFitSpectrum()).Times(1);
+    EXPECT_CALL(*m_view, replot()).Times(1);
+
+    m_presenter->notifyPeakCentreEditingFinished();
+  }
+
+  void test_notifyPeakCentreEditingFinished_does_not_remove_fit_spectrum_when_fit_status_is_not_empty() {
+    EXPECT_CALL(*m_view, peakCentre()).Times(1).WillOnce(Return(m_peakCentre));
+    EXPECT_CALL(*m_model, setPeakCentre(m_peakCentre)).Times(1);
+
+    EXPECT_CALL(*m_model, getPeakCopy()).Times(1).WillOnce(Return(nullptr));
+    EXPECT_CALL(*m_view, setPeak(_)).Times(1);
+
+    EXPECT_CALL(*m_model, fitStatus()).Times(1).WillOnce(Return("Success"));
+    EXPECT_CALL(*m_view, setPeakCentreStatus("Success")).Times(1);
+
+    // Assert is not called
+    EXPECT_CALL(*m_view, removeFitSpectrum()).Times(0);
+
+    EXPECT_CALL(*m_view, replot()).Times(1);
 
     m_presenter->notifyPeakCentreEditingFinished();
   }

--- a/qt/scientific_interfaces/Direct/test/ALFAnalysisPresenterTest.h
+++ b/qt/scientific_interfaces/Direct/test/ALFAnalysisPresenterTest.h
@@ -68,6 +68,8 @@ public:
 
     EXPECT_CALL(*m_model, setExtractedWorkspace(_, twoThetas)).Times(1);
 
+    expectCalculateEstimate();
+
     EXPECT_CALL(*m_model, extractedWorkspace()).Times(1).WillOnce(Return(nullptr));
     EXPECT_CALL(*m_view, addSpectrum(_)).Times(1);
 
@@ -186,12 +188,7 @@ public:
   }
 
   void test_that_calculateEstimate_is_called_as_expected() {
-    EXPECT_CALL(*m_model, isDataExtracted()).Times(1).WillOnce(Return(true));
-    EXPECT_CALL(*m_view, peakCentre()).Times(1).WillOnce(Return(m_peakCentre));
-    EXPECT_CALL(*m_view, getRange()).Times(2).WillRepeatedly(Return(m_range));
-
-    EXPECT_CALL(*m_model, calculateEstimate(m_range)).Times(1);
-
+    expectCalculateEstimate();
     m_presenter->notifyUpdateEstimateClicked();
   }
 
@@ -216,6 +213,14 @@ public:
   }
 
 private:
+  void expectCalculateEstimate() {
+    EXPECT_CALL(*m_model, isDataExtracted()).Times(1).WillOnce(Return(true));
+    EXPECT_CALL(*m_view, peakCentre()).Times(1).WillOnce(Return(m_peakCentre));
+    EXPECT_CALL(*m_view, getRange()).Times(2).WillRepeatedly(Return(m_range));
+
+    EXPECT_CALL(*m_model, calculateEstimate(m_range)).Times(1);
+  }
+
   std::string m_workspaceName;
   std::pair<double, double> m_range;
   double m_peakCentre;

--- a/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/InstrumentWidget.h
+++ b/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/InstrumentWidget.h
@@ -218,6 +218,7 @@ signals:
   void preDeletingHandle();
   void clearingHandle();
   void maskedWorkspaceOverlayed();
+  void instrumentActorReset();
 
 protected:
   /// Implements AlgorithmObserver's finish handler

--- a/qt/widgets/instrumentview/src/InstrumentWidget.cpp
+++ b/qt/widgets/instrumentview/src/InstrumentWidget.cpp
@@ -377,6 +377,8 @@ void InstrumentWidget::resetInstrumentActor(bool resetGeometry, bool autoscaling
 
   m_instrumentActor = std::make_unique<InstrumentActor>(m_workspaceName.toStdString(), *m_messageHandler, autoscaling,
                                                         scaleMin, scaleMax);
+  emit instrumentActorReset();
+
   if (m_useThread) {
     m_instrumentActor->moveToThread(&m_thread);
     m_qtConnect->connect(m_instrumentActor.get(), SIGNAL(initWidget(bool, bool)), this, SLOT(initWidget(bool, bool)));

--- a/qt/widgets/mplcpp/inc/MantidQtWidgets/MplCpp/PeakMarker.h
+++ b/qt/widgets/mplcpp/inc/MantidQtWidgets/MplCpp/PeakMarker.h
@@ -39,6 +39,7 @@ public:
   void mouseMoveStart(double x, double y);
   void mouseMoveStop();
   bool mouseMove(double x, double y);
+  void mouseMoveHover(double x, double y);
 };
 
 } // namespace MplCpp

--- a/qt/widgets/mplcpp/inc/MantidQtWidgets/MplCpp/PeakMarker.h
+++ b/qt/widgets/mplcpp/inc/MantidQtWidgets/MplCpp/PeakMarker.h
@@ -36,6 +36,8 @@ public:
   void select();
   void deselect();
 
+  void setVisible(bool visible);
+
   void mouseMoveStart(double x, double y);
   void mouseMoveStop();
   bool mouseMove(double x, double y);

--- a/qt/widgets/mplcpp/src/PeakMarker.cpp
+++ b/qt/widgets/mplcpp/src/PeakMarker.cpp
@@ -123,4 +123,11 @@ bool PeakMarker::mouseMove(double x, double y) {
   return PyLong_AsLong(movedPy.ptr()) > 0;
 }
 
+/**
+ * @brief Notifies when the mouse is hovering over the plot.
+ * @param x The x position of the mouse press in axes coords.
+ * @param y The y position of the mouse press in axes coords.
+ */
+void PeakMarker::mouseMoveHover(double x, double y) { callMethodNoCheck<void>(pyobj(), "mouse_move_hover", x, y); }
+
 } // namespace MantidQt::Widgets::MplCpp

--- a/qt/widgets/mplcpp/src/PeakMarker.cpp
+++ b/qt/widgets/mplcpp/src/PeakMarker.cpp
@@ -98,6 +98,12 @@ void PeakMarker::select() { callMethodNoCheck<void>(pyobj(), "select"); }
 void PeakMarker::deselect() { callMethodNoCheck<void>(pyobj(), "deselect"); }
 
 /**
+ * @brief Sets the marker as visible or invisible.
+ * @param visible If true the marker is set as visible.
+ */
+void PeakMarker::setVisible(bool visible) { callMethodNoCheck<void>(pyobj(), "set_visible", visible); }
+
+/**
  * @brief Notifies the relevant marker to start moving.
  * @param x The x position of the mouse press in axes coords.
  * @param y The y position of the mouse press in axes coords.

--- a/qt/widgets/plotting/inc/MantidQtWidgets/Plotting/PeakPicker.h
+++ b/qt/widgets/plotting/inc/MantidQtWidgets/Plotting/PeakPicker.h
@@ -40,6 +40,7 @@ private slots:
   void handleMouseDown(const QPoint &point);
   void handleMouseMove(const QPoint &point);
   void handleMouseUp(const QPoint &point);
+  void handleMouseHovering(const QPoint &point);
 
   void redrawMarker();
 
@@ -50,6 +51,8 @@ private:
   Mantid::API::IPeakFunction_sptr m_peak;
   /// The minimum marker
   std::unique_ptr<MantidQt::Widgets::MplCpp::PeakMarker> m_peakMarker;
+  /// True if the mouse is hovering over the centre of the peak picker
+  bool m_centreHover;
 };
 
 } // namespace MantidWidgets

--- a/qt/widgets/plotting/inc/MantidQtWidgets/Plotting/PeakPicker.h
+++ b/qt/widgets/plotting/inc/MantidQtWidgets/Plotting/PeakPicker.h
@@ -52,8 +52,6 @@ private:
   Mantid::API::IPeakFunction_sptr m_peak;
   /// The minimum marker
   std::unique_ptr<MantidQt::Widgets::MplCpp::PeakMarker> m_peakMarker;
-  /// True if the mouse is hovering over the centre of the peak picker
-  bool m_centreHover;
 };
 
 } // namespace MantidWidgets

--- a/qt/widgets/plotting/inc/MantidQtWidgets/Plotting/PeakPicker.h
+++ b/qt/widgets/plotting/inc/MantidQtWidgets/Plotting/PeakPicker.h
@@ -32,6 +32,7 @@ public:
   Mantid::API::IPeakFunction_sptr peak() const;
 
   void select(bool select);
+  void setVisible(bool visible);
 
 signals:
   void changed();

--- a/qt/widgets/plotting/inc/MantidQtWidgets/Plotting/PreviewPlot.h
+++ b/qt/widgets/plotting/inc/MantidQtWidgets/Plotting/PreviewPlot.h
@@ -98,6 +98,7 @@ signals:
   void mouseDown(const QPoint &point);
   void mouseUp(const QPoint &point);
   void mouseMove(const QPoint &point);
+  void mouseHovering(const QPoint &point);
 
   void redraw();
   void resetSelectorBounds();

--- a/qt/widgets/plotting/src/PeakPicker.cpp
+++ b/qt/widgets/plotting/src/PeakPicker.cpp
@@ -8,6 +8,8 @@
 #include "MantidAPI/FunctionFactory.h"
 #include "MantidQtWidgets/Plotting/PreviewPlot.h"
 
+#include <QApplication>
+
 using namespace Mantid::API;
 using namespace MantidQt::Widgets::MplCpp;
 
@@ -16,7 +18,8 @@ namespace MantidQt::MantidWidgets {
 PeakPicker::PeakPicker(PreviewPlot *plot, const QColor &colour)
     : QObject(), m_plot(plot), m_peak(nullptr),
       m_peakMarker(std::make_unique<PeakMarker>(m_plot->canvas(), 1, std::get<0>(m_plot->getAxisRange()),
-                                                std::get<1>(m_plot->getAxisRange(AxisID::YLeft)), 0.0, 0.0)) {
+                                                std::get<1>(m_plot->getAxisRange(AxisID::YLeft)), 0.0, 0.0)),
+      m_centreHover(false) {
   UNUSED_ARG(colour);
 
   m_plot->canvas()->draw();
@@ -24,6 +27,7 @@ PeakPicker::PeakPicker(PreviewPlot *plot, const QColor &colour)
   connect(m_plot, SIGNAL(mouseDown(QPoint)), this, SLOT(handleMouseDown(QPoint)));
   connect(m_plot, SIGNAL(mouseMove(QPoint)), this, SLOT(handleMouseMove(QPoint)));
   connect(m_plot, SIGNAL(mouseUp(QPoint)), this, SLOT(handleMouseUp(QPoint)));
+  connect(m_plot, SIGNAL(mouseHovering(QPoint)), this, SLOT(handleMouseHovering(QPoint)));
 
   connect(m_plot, SIGNAL(redraw()), this, SLOT(redrawMarker()));
 }
@@ -74,6 +78,11 @@ void PeakPicker::handleMouseMove(const QPoint &point) {
 void PeakPicker::handleMouseUp(const QPoint &point) {
   UNUSED_ARG(point);
   m_peakMarker->mouseMoveStop();
+}
+
+void PeakPicker::handleMouseHovering(const QPoint &point) {
+  const auto dataCoords = m_plot->toDataCoords(point);
+  m_peakMarker->mouseMoveHover(dataCoords.x(), dataCoords.y());
 }
 
 void PeakPicker::redrawMarker() { m_peakMarker->redraw(); }

--- a/qt/widgets/plotting/src/PeakPicker.cpp
+++ b/qt/widgets/plotting/src/PeakPicker.cpp
@@ -8,8 +8,6 @@
 #include "MantidAPI/FunctionFactory.h"
 #include "MantidQtWidgets/Plotting/PreviewPlot.h"
 
-#include <QApplication>
-
 using namespace Mantid::API;
 using namespace MantidQt::Widgets::MplCpp;
 
@@ -18,8 +16,7 @@ namespace MantidQt::MantidWidgets {
 PeakPicker::PeakPicker(PreviewPlot *plot, const QColor &colour)
     : QObject(), m_plot(plot), m_peak(nullptr),
       m_peakMarker(std::make_unique<PeakMarker>(m_plot->canvas(), 1, std::get<0>(m_plot->getAxisRange()),
-                                                std::get<1>(m_plot->getAxisRange(AxisID::YLeft)), 0.0, 0.0)),
-      m_centreHover(false) {
+                                                std::get<1>(m_plot->getAxisRange(AxisID::YLeft)), 0.0, 0.0)) {
   UNUSED_ARG(colour);
 
   m_plot->canvas()->draw();

--- a/qt/widgets/plotting/src/PeakPicker.cpp
+++ b/qt/widgets/plotting/src/PeakPicker.cpp
@@ -53,6 +53,8 @@ void PeakPicker::select(bool select) {
     m_peakMarker->deselect();
 }
 
+void PeakPicker::setVisible(bool visible) { m_peakMarker->setVisible(visible); }
+
 void PeakPicker::handleMouseDown(const QPoint &point) {
   const auto dataCoords = m_plot->toDataCoords(point);
   m_peakMarker->mouseMoveStart(dataCoords.x(), dataCoords.y());

--- a/qt/widgets/plotting/src/PreviewPlot.cpp
+++ b/qt/widgets/plotting/src/PreviewPlot.cpp
@@ -469,6 +469,8 @@ bool PreviewPlot::handleMouseMoveEvent(QMouseEvent *evt) {
     const auto position = evt->pos();
     if (!position.isNull())
       emit mouseMove(position);
+  } else {
+    emit mouseHovering(evt->pos());
   }
   return stopEvent;
 }


### PR DESCRIPTION
**Description of work.**
This PR adds a peak picker tool to the PreviewPlot in the analysis part of the ALFView interface. This makes it easier to adjust the peak centre in a visual way.

**To test:**
Open ALFView and load ALF82301
Click on Pick tab
Expand Rebin section. Rebin with 5.5,0.01,6
Click the Rectangle region selection tool at the top of the Pick tab
Select the two tubes in the centre with the yellow peak
The peak centre estimate should be updated automatically. There should be a grey line roughly down the centre of the peak,
Try and move this grey line. It will turn red when you grab it, and moving it should cause the peak centre box to update
clicking on the fit or update estimate button should deselect the peak picker.

Fixes #34604

*This does not require release notes* because **release notes will be added in a later PR**

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
