### PR TITLE
Remove all of build directory when doing a clean build

### DIFF
--- a/buildconfig/Jenkins/Conda/conda-buildscript
+++ b/buildconfig/Jenkins/Conda/conda-buildscript
@@ -96,7 +96,11 @@ done
 # Clean the source tree to remove stale configured files. Only remove
 # the build and mambaforge directories if this is a clean build
 pushd $WORKSPACE
-if [[ $CLEAN_BUILD  != true ]]; then
+if [[ $CLEAN_BUILD  == true ]]; then
+    # git clean will delete most things in build but leave subrepositories such as build/_deps/span-src
+    # so we need to remove the whole of build/ by hand
+    rm -fr $BUILD_DIR
+else
     git_clean_excludes_extra="--exclude=build --exclude=mambaforge"
 fi
 git clean -d -x --force --exclude=".Xauthority-*" $git_clean_excludes_extra


### PR DESCRIPTION
**Description of work.**

git clean will leave repositories that have been checked out under build but remove everything else. We want everything deleted so we remove by hand.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**

Check the build log and `git clean` should have run with `--exclude=build --exclude=mambaforge` options
on the PR.

*There is no associated issue.*

*This does not require release notes* because **it is an internal change.**


<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
