### PR TITLE
Stopped SliceViewer wobbling when moving the cursor around

### DIFF
--- a/docs/source/release/v6.6.0/Workbench/SliceViewer/Bugfixes/32358.rst
+++ b/docs/source/release/v6.6.0/Workbench/SliceViewer/Bugfixes/32358.rst
@@ -1,0 +1,1 @@
+-  Fixed bug where the SliceViewer plot would would resize by small amounts as the cursor info changed.

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/views/dataview.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/views/dataview.py
@@ -99,6 +99,7 @@ class SliceViewerDataView(QWidget):
         self.colorbar_layout.addWidget(self.colorbar_label)
         norm_scale = self.get_default_scale_norm()
         self.colorbar = ColorbarWidget(self, norm_scale)
+        # fix colour bar to stop plot and color bar making small size readjustments when the image info table updates
         self.colorbar.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Preferred)
         self.colorbar.cmap.setToolTip("Colormap options")
         self.colorbar.crev.setToolTip("Reverse colormap")

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/views/dataview.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/views/dataview.py
@@ -9,7 +9,7 @@ import sys
 
 from qtpy.QtCore import Qt
 from qtpy.QtWidgets import QWidget, QGridLayout, QVBoxLayout, QCheckBox, QLabel, QComboBox, QHBoxLayout, QStatusBar, \
-    QToolButton
+    QToolButton, QSizePolicy
 from matplotlib.figure import Figure
 from mpl_toolkits.axisartist import Subplot as CurveLinearSubPlot, GridHelperCurveLinear
 
@@ -99,6 +99,7 @@ class SliceViewerDataView(QWidget):
         self.colorbar_layout.addWidget(self.colorbar_label)
         norm_scale = self.get_default_scale_norm()
         self.colorbar = ColorbarWidget(self, norm_scale)
+        self.colorbar.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Preferred)
         self.colorbar.cmap.setToolTip("Colormap options")
         self.colorbar.crev.setToolTip("Reverse colormap")
         self.colorbar.norm.setToolTip("Colormap normalisation options")


### PR DESCRIPTION
**Description of work.**

Set the colorbar's horizontal size policy to `Fixed` to stop the plot and colorbar resizing when the cursor is moved arround the plot (due to the size of the image info table changing).

**To test:**

- Load some data
- Right click an open the SliceViewer
- Moving the cursor around should now resize the top image info table but keep the plot static

It could be worth trying this on a different branch to observe what is being fixed.

Fixes #32358

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
