### PR TITLE
Calculate errors on Discus results

### DIFF
--- a/Framework/Algorithms/inc/MantidAlgorithms/DiscusMultipleScatteringCorrection.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/DiscusMultipleScatteringCorrection.h
@@ -119,10 +119,10 @@ private:
   std::map<std::string, std::string> validateInputs() override;
   API::MatrixWorkspace_sptr createOutputWorkspace(const API::MatrixWorkspace &inputWS) const;
   std::tuple<double, double> new_vector(const Kernel::Material &material, double k, bool specialSingleScatterCalc);
-  std::vector<double> simulatePaths(const int nEvents, const int nScatters, Kernel::PseudoRandomNumberGenerator &rng,
-                                    ComponentWorkspaceMappings &componentWorkspaces, const double kinc,
-                                    const std::vector<double> &wValues, const Kernel::V3D &detPos,
-                                    bool specialSingleScatterCalc);
+  std::tuple<std::vector<double>, std::vector<double>>
+  simulatePaths(const int nEvents, const int nScatters, Kernel::PseudoRandomNumberGenerator &rng,
+                ComponentWorkspaceMappings &componentWorkspaces, const double kinc, const std::vector<double> &wValues,
+                const Kernel::V3D &detPos, bool specialSingleScatterCalc);
   std::tuple<bool, std::vector<double>> scatter(const int nScatters, Kernel::PseudoRandomNumberGenerator &rng,
                                                 const ComponentWorkspaceMappings &componentWorkspaces,
                                                 const double kinc, const std::vector<double> &wValues,

--- a/Framework/Algorithms/src/DiscusMultipleScatteringCorrection.cpp
+++ b/Framework/Algorithms/src/DiscusMultipleScatteringCorrection.cpp
@@ -641,7 +641,7 @@ void DiscusMultipleScatteringCorrection::exec() {
         for (int ne = 0; ne < nScatters; ne++) {
           int nEvents = ne == 0 ? nSingleScatterEvents : nMultiScatterEvents;
 
-          auto [weights, weightsErrors] =
+          std::tie(weights, weightsErrors) =
               simulatePaths(nEvents, ne + 1, rng, componentWorkspaces, kinc, wValues, detPos, false);
           if (std::get<1>(kInW[bin]) == -1.0) {
             simulationWSs[ne]->getSpectrum(i).mutableY() += weights;

--- a/Framework/Algorithms/src/DiscusMultipleScatteringCorrection.cpp
+++ b/Framework/Algorithms/src/DiscusMultipleScatteringCorrection.cpp
@@ -1042,7 +1042,7 @@ void DiscusMultipleScatteringCorrection::integrateCumulative(const DiscusData1D 
                                                              const double xmax, std::vector<double> &resultX,
                                                              std::vector<double> &resultY,
                                                              const bool returnCumulative) {
-  assert(h.histogram().xMode() == HistogramData::Histogram::XMode::Points);
+  assert(h.X.size() == h.Y.size());
   const std::vector<double> &xValues = h.X;
   const std::vector<double> &yValues = h.Y;
 

--- a/Framework/Algorithms/src/DiscusMultipleScatteringCorrection.cpp
+++ b/Framework/Algorithms/src/DiscusMultipleScatteringCorrection.cpp
@@ -1334,7 +1334,8 @@ std::tuple<std::vector<double>, std::vector<double>> DiscusMultipleScatteringCor
     ComponentWorkspaceMappings &componentWorkspaces, const double kinc, const std::vector<double> &wValues,
     const Kernel::V3D &detPos, bool specialSingleScatterCalc) {
   // countZeroWeights for debugging and analysis of where importance sampling may help
-  std::vector<double> sumOfWeights(wValues.size(), 0.), countZeroWeights(wValues.size(), 0);
+  std::vector<int> countZeroWeights(wValues.size(), 0);
+  std::vector<double> sumOfWeights(wValues.size(), 0.);
   std::vector<double> weightsMeans(wValues.size(), 0.), deltas(wValues.size(), 0.), weightsM2(wValues.size(), 0.),
       weightsErrors(wValues.size(), 0.);
 

--- a/Framework/HistogramData/src/Interpolate.cpp
+++ b/Framework/HistogramData/src/Interpolate.cpp
@@ -124,6 +124,10 @@ void interpolateYCSplineInplace(const Mantid::HistogramData::Histogram &input,
       }
     }
   }
+  double xsMaxEpsilon = *(std::max_element(xs.begin(), xs.end())) * std::numeric_limits<double>::epsilon();
+  // elements with i=j will have the largest value
+  double hMaxEpsilon = xsMaxEpsilon * 2 / 3;
+
   std::vector<double> d(xs.size() - 2);
   auto ys = input.dataY();
   for (size_t i = 0; i < xs.size() - 2; i++) {
@@ -134,7 +138,7 @@ void interpolateYCSplineInplace(const Mantid::HistogramData::Histogram &input,
   std::vector<double> ypp(xs.size() - 2);
   // would be quicker to solve linear equation rather than invert h but also
   // need h-1 elements later on
-  h.invertTridiagonal();
+  h.invertTridiagonal(2 * hMaxEpsilon);
   ypp = h * d;
 
   // add in the zero second derivatives at extreme pts to give natural splines

--- a/Framework/HistogramData/src/Interpolate.cpp
+++ b/Framework/HistogramData/src/Interpolate.cpp
@@ -245,7 +245,7 @@ void interpolateYCSplineInplace(const Mantid::HistogramData::Histogram &input,
  */
 void interpolateYLinearInplace(const Mantid::HistogramData::Histogram &input,
                                const Mantid::HistogramData::Points &points, Mantid::HistogramData::Histogram &output,
-                               bool calculateErrors = false, const bool independentErrors = true) {
+                               const bool calculateErrors = false, const bool independentErrors = true) {
   const auto xold = input.points();
   const auto &yold = input.y();
   const auto &eold = input.e();
@@ -254,12 +254,13 @@ void interpolateYLinearInplace(const Mantid::HistogramData::Histogram &input,
   auto &ynew = output.mutableY();
   auto &enew = output.mutableE();
 
+  bool calculateInterpolationErrors = true;
   std::vector<double> secondDeriv(input.size() - 1);
   for (size_t i = 0; i < input.size() - 1; i++) {
     if (calculateErrors) {
       if (xold.size() < 3) {
-        g_log.warning("Number of x points too small to calculate errors");
-        calculateErrors = false;
+        g_log.warning("Number of x points too small to calculate interpolation errors");
+        calculateInterpolationErrors = false;
       } else {
 
         auto x0_secondDeriv = i < 1 ? 0 : i - 1;
@@ -306,7 +307,8 @@ void interpolateYLinearInplace(const Mantid::HistogramData::Histogram &input,
         sourcePointsError = (xp - x1) * e2 + (x2 - xp) * e1;
       }
       // calculate interpolation error
-      auto interpError = 0.5 * (xp - x1) * (x2 - xp) * std::abs(secondDeriv[index - 1]);
+      auto interpError =
+          calculateInterpolationErrors ? 0.5 * (xp - x1) * (x2 - xp) * std::abs(secondDeriv[index - 1]) : 0;
       // combine the two errors
       enew[i] = sqrt(pow(sourcePointsError, 2) + pow(interpError, 2));
     } else {

--- a/Framework/HistogramData/src/Interpolate.cpp
+++ b/Framework/HistogramData/src/Interpolate.cpp
@@ -106,7 +106,7 @@ void interpolateYCSplineInplace(const Mantid::HistogramData::Histogram &input,
                                 const Mantid::HistogramData::Points &points, Mantid::HistogramData::Histogram &output,
                                 const bool calculateErrors = false, const bool independentErrors = true) {
   auto xs = input.dataX();
-  // Error propagation follows method described in Gardner paper
+  // Interpolation and Error propagation follows method described in Gardner paper
   // "Uncertainties in Interpolated Spectral Data", Journal of Research of the
   // National Institute of Standards and Technology, 2003
   // create tridiagonal "h" matrix
@@ -171,8 +171,11 @@ void interpolateYCSplineInplace(const Mantid::HistogramData::Histogram &input,
     }
   }
 
-  // plug the calculated second derivatives into the formula for each cubic
-  // polynomial y = A*y_i + B*y_i+1 + C*ypp_i + D*ypp_i+1
+  // Plug the calculated second derivatives into the formula for each cubic polynomial:
+  // y = A*y_i + B*y_i+1 + C*ypp_i + D*ypp_i+1
+  // Formula is from Gardner paper which references it from Numerical Recipes in C
+  // It is derived from Taylor expansion about x_i with term in yp_i expressed in terms of
+  // y_i, y_i+1, ypp_i, ypp_i+1
   auto &ynew = output.mutableY();
   for (size_t i = 0; i < points.size(); i++) {
     auto it = std::upper_bound(xs.begin(), xs.end(), points[i]);

--- a/Framework/HistogramData/test/InterpolateTest.h
+++ b/Framework/HistogramData/test/InterpolateTest.h
@@ -120,6 +120,11 @@ public:
     checkData(input, output, {}, expectedE);
   }
 
+  void test_interpolateLinearPointDataSet_Too_Few_Points_For_Error_Calc() {
+    Histogram input(Points(5, LinearGenerator(0, 0.5)), {-2, 0, 0, 0, 2}, CountStandardDeviations{1., 0., 0., 0., 1.});
+    TS_ASSERT_THROWS_NOTHING(interpolateLinear(input, 4, true));
+  }
+
   void test_interpolateLinearInplace_interpolates() {
     Histogram input(Points(2, LinearGenerator(0, 1.0)), {-0.72, -0.72});
     Histogram output(Points(1, LinearGenerator(0.5, 1.0)), {0.0});
@@ -344,11 +349,6 @@ public:
   void test_interpolatelinear_throws_if_stepsize_greater_or_equal_number_points() {
     TS_ASSERT_THROWS(interpolateLinear(Histogram(Points(6, LinearGenerator(0, 0.5))), 6), const std::runtime_error &);
     TS_ASSERT_THROWS(interpolateLinear(Histogram(Points(6, LinearGenerator(0, 0.5))), 7), const std::runtime_error &);
-  }
-
-  void test_interpolateLinearPointDataSet_Errors_Too_Few_Points() {
-    Histogram input(Points(5, LinearGenerator(0, 0.5)), {-2, 0, 0, 0, 2}, CountStandardDeviations{1., 0., 0., 0., 1.});
-    TS_ASSERT_THROWS(interpolateLinear(input, 4, true), const std::runtime_error &);
   }
 
   // ---------------------------------------------------------------------------

--- a/Framework/Kernel/inc/MantidKernel/Matrix.h
+++ b/Framework/Kernel/inc/MantidKernel/Matrix.h
@@ -154,7 +154,7 @@ public:
 
   T Invert(); ///< LU inversion routine
   // Optimized inversion routine for tridiagonal matrices
-  void invertTridiagonal(double tolerance = Kernel::Tolerance);
+  void invertTridiagonal(double tolerance = FLT_EPSILON);
   void averSymmetric();                            ///< make Matrix symmetric
   int Diagonalise(Matrix<T> &, Matrix<T> &) const; ///< (only Symmetric matrix)
   void sortEigen(Matrix<T> &);                     ///< Sort eigenvectors

--- a/Framework/Kernel/inc/MantidKernel/Matrix.h
+++ b/Framework/Kernel/inc/MantidKernel/Matrix.h
@@ -154,7 +154,7 @@ public:
 
   T Invert(); ///< LU inversion routine
   // Optimized inversion routine for tridiagonal matrices
-  void invertTridiagonal();
+  void invertTridiagonal(double tolerance = Kernel::Tolerance);
   void averSymmetric();                            ///< make Matrix symmetric
   int Diagonalise(Matrix<T> &, Matrix<T> &) const; ///< (only Symmetric matrix)
   void sortEigen(Matrix<T> &);                     ///< Sort eigenvectors

--- a/Framework/Kernel/src/Matrix.cpp
+++ b/Framework/Kernel/src/Matrix.cpp
@@ -960,7 +960,7 @@ using LU decomposition
 }
 
 template <typename T>
-void Matrix<T>::invertTridiagonal()
+void Matrix<T>::invertTridiagonal(double tolerance)
 /**
 Check it's a square tridiagonal matrix with all diagonal elements equal and if
 yes invert the matrix using analytic formula. If not then use standard Invert
@@ -974,7 +974,7 @@ yes invert the matrix using analytic formula. If not then use standard Invert
         for (size_t j = 1; i < numCols() && regular; i++) {
           size_t diff = std::abs(static_cast<int>(i - j));
           if (diff < 2) {
-            if (std::abs(diagonal[diff] - m_rawData[i][j]) > std::numeric_limits<double>::epsilon()) {
+            if (std::abs(diagonal[diff] - m_rawData[i][j]) > tolerance) {
               regular = false;
             }
           } else if (m_rawData[i][j] != 0) {

--- a/Framework/PythonInterface/mantid/api/src/Exports/MatrixWorkspace.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/MatrixWorkspace.cpp
@@ -159,7 +159,7 @@ void setYFromPyObject(MatrixWorkspace &self, const size_t wsIndex, const boost::
  * @param wsIndex :: The workspace index for the spectrum to set
  * @param values :: A numpy array. The length must match the size of the
  */
-void setEFromPyObject(MatrixWorkspace &self, const size_t wsIndex, const NDArray &values) {
+void setEFromPyObject(MatrixWorkspace &self, const size_t wsIndex, const boost::python::object &values) {
   setSpectrumFromPyObject(self, &MatrixWorkspace::dataE, wsIndex, values);
 }
 

--- a/Framework/PythonInterface/mantid/plots/datafunctions.py
+++ b/Framework/PythonInterface/mantid/plots/datafunctions.py
@@ -933,8 +933,9 @@ def get_errorbar_bounds(container):
     y_segments = _get_y_errorbar_segments(container)
     if y_segments:
         coords = [array[:, 1] for array in y_segments if len(array.shape) == 2]
-        max_y = np.max(coords)
-        min_y = np.min(coords)
+        if coords:
+            max_y = np.max(coords)
+            min_y = np.min(coords)
     return min_x, max_x, min_y, max_y
 
 

--- a/Framework/PythonInterface/mantid/plots/datafunctions.py
+++ b/Framework/PythonInterface/mantid/plots/datafunctions.py
@@ -932,7 +932,7 @@ def get_errorbar_bounds(container):
         min_x = np.min(coords)
     y_segments = _get_y_errorbar_segments(container)
     if y_segments:
-        coords = [array[:, 1] for array in y_segments]
+        coords = [array[:, 1] for array in y_segments if len(array.shape) == 2]
         max_y = np.max(coords)
         min_y = np.min(coords)
     return min_x, max_x, min_y, max_y

--- a/Framework/PythonInterface/mantid/plots/datafunctions.py
+++ b/Framework/PythonInterface/mantid/plots/datafunctions.py
@@ -927,9 +927,10 @@ def get_errorbar_bounds(container):
     min_x, max_x, min_y, max_y = None, None, None, None
     x_segments = _get_x_errorbar_segments(container)
     if x_segments:
-        coords = [array[:, 0] for array in x_segments]
-        max_x = np.max(coords)
-        min_x = np.min(coords)
+        coords = [array[:, 0] for array in x_segments if len(array.shape) == 2]
+        if coords:
+            max_x = np.max(coords)
+            min_x = np.min(coords)
     y_segments = _get_y_errorbar_segments(container)
     if y_segments:
         coords = [array[:, 1] for array in y_segments if len(array.shape) == 2]

--- a/Framework/PythonInterface/test/python/mantid/api/MatrixWorkspaceTest.py
+++ b/Framework/PythonInterface/test/python/mantid/api/MatrixWorkspaceTest.py
@@ -220,22 +220,24 @@ class MatrixWorkspaceTest(unittest.TestCase):
         self.assertTrue(np.array_equal(x_expected, x_extracted))
         self.assertTrue(np.array_equal(y_expected, y_extracted))
 
-    def test_setxy_accepts_python_list(self):
+    def test_setxye_accepts_python_list(self):
         nbins = 10
         nspec = 2
         xdata = list(range(nbins + 1))
         ydata = list(range(nbins))
+        edata = [0.1] * nbins
         ws = WorkspaceFactory.create("Workspace2D", NVectors=nspec, XLength=nbins + 1, YLength=nbins)
         for i in range(nspec):
             ws.setX(i, xdata)
             ws.setY(i, ydata)
-
+            ws.setE(i, edata)
         # Verify
-        xdata, ydata = np.array(xdata), np.array(ydata)
-        x_expected, y_expected = np.vstack((xdata, xdata)), np.vstack((ydata, ydata))
-        x_extracted, y_extracted = ws.extractX(), ws.extractY()
+        xdata, ydata, edata = np.array(xdata), np.array(ydata), np.array(edata)
+        x_expected, y_expected, e_expected = np.vstack((xdata, xdata)), np.vstack((ydata, ydata)), np.vstack((edata, edata))
+        x_extracted, y_extracted, e_extracted = ws.extractX(), ws.extractY(), ws.extractE()
         self.assertTrue(np.array_equal(x_expected, x_extracted))
         self.assertTrue(np.array_equal(y_expected, y_extracted))
+        self.assertTrue(np.array_equal(e_expected, e_extracted))
 
     def test_data_can_be_extracted_to_numpy_successfully(self):
         x = self._test_ws.extractX()

--- a/Framework/PythonInterface/test/python/mantid/plots/datafunctionsTest.py
+++ b/Framework/PythonInterface/test/python/mantid/plots/datafunctionsTest.py
@@ -833,6 +833,18 @@ class DataFunctionsTest(unittest.TestCase):
         self.assertTrue(isinstance(bin_indices, np.ndarray))
         ConfigService.Instance().setString("default.facility", " ")
 
+    def test_errorbar_bounds_if_some_errors_nan(self):
+        fig = figure()
+        ax = fig.add_subplot(111)
+        container = ax.errorbar([0, 1], [0, 1], xerr=[np.nan, 0.1], yerr=[np.nan, 0.1])
+        bounds = mantid.plots.datafunctions.get_errorbar_bounds(container)
+
+    def test_errorbar_bounds_if_all_errors_nan(self):
+        fig = figure()
+        ax = fig.add_subplot(111)
+        container = ax.errorbar([0, 1], [0, 1], xerr=[np.nan, np.nan], yerr=[np.nan, np.nan])
+        bounds = mantid.plots.datafunctions.get_errorbar_bounds(container)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/Framework/PythonInterface/test/python/mantid/plots/datafunctionsTest.py
+++ b/Framework/PythonInterface/test/python/mantid/plots/datafunctionsTest.py
@@ -836,13 +836,15 @@ class DataFunctionsTest(unittest.TestCase):
     def test_errorbar_bounds_if_some_errors_nan(self):
         fig = figure()
         ax = fig.add_subplot(111)
-        container = ax.errorbar([0, 1], [0, 1], xerr=[np.nan, 0.1], yerr=[np.nan, 0.1])
+        masked_errors = np.ma.masked_invalid([np.nan, 0.1])
+        container = ax.errorbar([0, 1], [0, 1], xerr=masked_errors, yerr=masked_errors)
         bounds = mantid.plots.datafunctions.get_errorbar_bounds(container)
 
     def test_errorbar_bounds_if_all_errors_nan(self):
         fig = figure()
         ax = fig.add_subplot(111)
-        container = ax.errorbar([0, 1], [0, 1], xerr=[np.nan, np.nan], yerr=[np.nan, np.nan])
+        masked_errors = np.ma.masked_invalid([np.nan, np.nan])
+        container = ax.errorbar([0, 1], [0, 1], xerr=masked_errors, yerr=masked_errors)
         bounds = mantid.plots.datafunctions.get_errorbar_bounds(container)
 
 

--- a/docs/source/algorithms/DiscusMultipleScatteringCorrection-v1.rst
+++ b/docs/source/algorithms/DiscusMultipleScatteringCorrection-v1.rst
@@ -376,10 +376,14 @@ The double scatter profile shows a similar shape to the analytic result calculat
    # reverse w axis because Discus w = Ef-Ei (opposite to Mantid)
    for i in range(mtd['MuscatResults_Scatter_1'].getNumberHistograms()):
        y = np.flip(mtd['MuscatResults_Scatter_1'].dataY(i),0)
+       e = np.flip(mtd['MuscatResults_Scatter_1'].dataE(i),0)
        mtd['MuscatResults_Scatter_1'].setY(i,y.tolist())
+       mtd['MuscatResults_Scatter_1'].setE(i,e)
    for i in range(mtd['MuscatResults_Scatter_2'].getNumberHistograms()):
        y = np.flip(mtd['MuscatResults_Scatter_2'].dataY(i),0)
+       e = np.flip(mtd['MuscatResults_Scatter_2'].dataE(i),0)
        mtd['MuscatResults_Scatter_2'].setY(i,y.tolist())
+       mtd['MuscatResults_Scatter_2'].setE(i,e)
 
    plt.rcParams['figure.figsize'] = (5, 6)
    fig, ax = plt.subplots(subplot_kw={'projection':'mantid'})

--- a/docs/source/algorithms/MonteCarloAbsorption-v1.rst
+++ b/docs/source/algorithms/MonteCarloAbsorption-v1.rst
@@ -90,7 +90,7 @@ Interpolation
 #############
 
 The default linear interpolation method will produce an absorption curve that is not smooth. CSpline interpolation
-will produce a smoother result by using a 3rd-order polynomial to approximate the original points.
+will produce a smoother result by using a 3rd-order polynomial to approximate the original points - although if the data includes sudden changes it may introduce oscillations including negative values at the interpolated points.
 
 The errors that the Monte Carlo simulation calculates for different wavelength points in a single spectrum may or may not be independent. If the same set of tracks have been used for different wavelengths (ResimulateTracksForDifferentWavelengths=False) then the errors will be correlated. A worst case positive correlation has been assumed giving an error on the interpolated point that is approximately the same as the surrounding simulated points.
 

--- a/docs/source/release/v6.6.0/Framework/Algorithms/New_features/34783.rst
+++ b/docs/source/release/v6.6.0/Framework/Algorithms/New_features/34783.rst
@@ -1,0 +1,1 @@
+- Add error calculation to :ref:`DiscusMultipleScatteringCorrection` following similar approach to :ref:`MonteCarloAbsorption`


### PR DESCRIPTION
**Description of work.**

Calculate the errors on the weights calculated by DiscusMultipleScatteringCorrection. Follow similar approach to MonteCarloAbsorption where the error is calculated based on the standard deviation of the weights per scenario divided by the square root of the number of scenarios. When interpolation is used combine the errors from the simulated points using standard error propagation formulae and combine with interpolation error when using linear interpolation.

As part of this I've fixed a few of issues:
- a crash in workbench when plotting error bars on a spectrum where any of the points has an error=NaN
- a bug in the the python export of MatrixWorkspace where the setE function only worked if a numpy array was supplied. The equivalent setY function had been previously modified to accept lists. It's helpful for them to accept lists because if you supply a flipped numpy array the setY\setE functions don't work (see https://github.com/mantidproject/mantid/issues/33673)
- the error calculation when using spline interpolation involves calling Matrix<T>::invertTridiagonal. This function has a check in it to see if a matrix was tridiagonal and the check wasn't handling the numerical precision properly. It used `std::numeric_limits<double>::epsilon()` but this needs scaling by the numbers being compared

**To test:**

Run the second usage example from the DiscusMultipleScatteringCorrection documentation (without the final mtd.clear() line).
Right click in the plot area and select Error Bars, All Errors
Observe that visible error bars appear for the double scatter lines. The errors on the single scatter lines are much smaller and aren't visible:
![image](https://user-images.githubusercontent.com/56295817/204315899-7f4f724d-f0c1-4b91-8950-a88af1b16dcb.png)
Change the NeutronPathsMultiple setting to 10,000 and rerun and observe that the errors get smaller


Fixes #34770.

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
