### PR TITLE
Fix dev-docs warning

### DIFF
--- a/dev-docs/source/ReleaseChecklist.rst
+++ b/dev-docs/source/ReleaseChecklist.rst
@@ -110,13 +110,13 @@ Manual Testing
 *  Ensure that Manual testing begins by creating the testing tasks as GitHub issues, assigning them and posting on
    Slack. Most of our Manual testing instructions are :ref:`here <Testing>`. Generate the Manual testing issues by
    following the instructions in the
-   `README file <https://github.com/mantidproject/documents/tree/main/Project-Management/Tools/RoadmapUpdate>`_.
+   `README file <https://github.com/mantidproject/documents/tree/main/Project-Management/Tools/RoadmapUpdate>`__.
    Please raise the issues from the ISIS and Non-ISIS manual testing spreadsheets.
 *  Over the next week, check the Manual testing GitHub issues. Testers should raise any
    serious problems as separate GitHub issues with a relevant milestone. When testing tasks are complete and all serious
    problems raised as issues, then the testing GitHub issue should be closed.
 *  Manual testing at ISIS as of release 6.3, has taken the form of
-   `Ensemble Manual Testing <https://github.com/mantidproject/documents/blob/main/Project-Management/Tools/RoadmapUpdate/Ensemble%20Manual%20Testing.pptx>`_.
+   `Ensemble Manual Testing <https://github.com/mantidproject/documents/blob/main/Project-Management/Tools/RoadmapUpdate/Ensemble%20Manual%20Testing.pptx>`__.
    In short, testing teams of around 3-5 developers, spread across sub-teams
    are assigned tasks with the code expert in that testing team.
 
@@ -137,7 +137,7 @@ Smoke Testing
 *  It is likely that many changes have been made over the beta test period, therefore
    we must do some more manual testing to ensure everything still works. This stage is
    called Smoke testing. Generate the Smoke testing issues by following the instructions
-   `here <https://github.com/mantidproject/documents/tree/main/Project-Management/Tools/RoadmapUpdate/SmokeTesting>`_.
+   `here <https://github.com/mantidproject/documents/tree/main/Project-Management/Tools/RoadmapUpdate/SmokeTesting>`__.
 *  Liaise with the Technical Release Manager and together announce the creation of the
    Smoke testing issues and Release Candidates in the *\#general* slack channel.
 
@@ -156,15 +156,15 @@ Beta Testing Begins
 * Initial amalgamation of the the release notes:
 
   * ``git pull`` on ``release-next``.
-  * Create a new branch using the `Mantid Git Workflow guidance <https://developer.mantidproject.org/GitWorkflow.html#new-branches>`_.
+  * Create a new branch using the `Mantid Git Workflow guidance <https://developer.mantidproject.org/GitWorkflow.html#new-branches>`__.
   * Navigate to your Mantid 'build' directory and open ``command-prompt.bat``.
-  * In the new command prompt, navigate to the `release_editor.py script <https://github.com/mantidproject/mantid/blob/main/tools/ReleaseNotes/release_editor.py>`_ and run, parsing the correct version number. The script copies all of the separate release notes under the correct heading of their upper level file, e.g. ``framework.rst``, and moves the original release notes into a 'Used' directory.
+  * In the new command prompt, navigate to the `release_editor.py script <https://github.com/mantidproject/mantid/blob/main/tools/ReleaseNotes/release_editor.py>`__ and run, parsing the correct version number. The script copies all of the separate release notes under the correct heading of their upper level file, e.g. ``framework.rst``, and moves the original release notes into a 'Used' directory.
 
     .. code-block:: bash
 
       python release_editor.py --release 6.5.0
 
-  * Check the script has run correctly by checking all individual rst files have been moved into their respective 'used' directories. You could use the `unused_release_note_finder.py script <https://github.com/mantidproject/mantid/blob/main/tools/ReleaseNotes/unused_release_note_finder.py>`_ for this (explained further bellow).
+  * Check the script has run correctly by checking all individual rst files have been moved into their respective 'used' directories. You could use the `unused_release_note_finder.py script <https://github.com/mantidproject/mantid/blob/main/tools/ReleaseNotes/unused_release_note_finder.py>`__ for this (explained further bellow).
   * Look over the files to make sure they look roughly correct then submit a PR to be merged into ``release-next``.
 
 * Initial changes:
@@ -175,7 +175,7 @@ Beta Testing Begins
 
   * As the release sprint goes on, new release note files will be created (existing outside of the 'Used' directories). The text from these will need to be copped into the main release note pages (``diffraction.rst``, ``mantidworkbench.rst`` etc.) and the file itself moved to it's corresponding 'Used' directory.
   * It is best to wait until several of these have built up before making a new branch / pr.
-  * To help with finding the new release notes, use the `unused_release_note_finder.py script <https://github.com/mantidproject/mantid/blob/main/tools/ReleaseNotes/unused_release_note_finder.py>`_ which will print the location of release notes not within a 'Used' directory.
+  * To help with finding the new release notes, use the `unused_release_note_finder.py script <https://github.com/mantidproject/mantid/blob/main/tools/ReleaseNotes/unused_release_note_finder.py>`__ which will print the location of release notes not within a 'Used' directory.
 
     .. code-block:: bash
 
@@ -303,8 +303,8 @@ After the Technical Release Manager has finished their release day tasks:
 *  Also post the contents of the message to the *\#announcements* channel on
    Slack.
 *  Create a new item on the forum news.
-*  Add a news item linking to the forum post on the `mantidproject website <https://www.mantidproject.org>`_
-   by manually editing `sidebar-news.html <https://github.com/mantidproject/www/blob/main/source/_templates/sidebar-news.html>`_.
+*  Add a news item linking to the forum post on the `mantidproject website <https://www.mantidproject.org>`__
+   by manually editing `sidebar-news.html <https://github.com/mantidproject/www/blob/main/source/_templates/sidebar-news.html>`__.
    Restrict the number of news items to five.
 *  Close the release milestone on GitHub.
 
@@ -323,11 +323,11 @@ Code Freeze
 **Create the Release Branch (once most PR's are merged)**
 
 * Ensure the latest `main nightly deployment pipeline
-  <https://builds.mantidproject.org/view/Nightly%20Pipelines/job/main_nightly_deployment_prototype/>`_
+  <https://builds.mantidproject.org/view/Nightly%20Pipelines/job/main_nightly_deployment_prototype/>`__
   has passed for all build environments. If it fails, decide if a fix is needed before moving on to
   the next steps.
 * Click ``Build Now`` on `open-release-testing
-  <https://builds.mantidproject.org/view/All/job/open-release-testing/>`_,
+  <https://builds.mantidproject.org/view/All/job/open-release-testing/>`__,
   which will perform the following actions:
 
   * Create or update the ``release-next`` branch.
@@ -340,7 +340,7 @@ Code Freeze
   pull requests not targeted for this release out of the milestone, and then change
   the base branch of the remaining pull requests to ``release-next``. You can either
   manually change the base branch in GitHub or use the `update-pr-base-branch.py
-  <https://github.com/mantidproject/mantid/blob/main/tools/scripts/update-pr-base-branch.py>`_
+  <https://github.com/mantidproject/mantid/blob/main/tools/scripts/update-pr-base-branch.py>`__
   script to update the base branches of these pull requests.
   A quick example to show how the arguments should be provided to this script is seen below:
 
@@ -365,7 +365,7 @@ Code Freeze
 
 *  Create a skeleton set of release notes and subfolders on ``main`` for the next version using the
    `python helper tool
-   <https://github.com/mantidproject/mantid/blob/main/tools/release_generator/release.py>`_
+   <https://github.com/mantidproject/mantid/blob/main/tools/release_generator/release.py>`__
    and open a pull request to put them on ``main``. Make sure the
    ``docs/source/release/index.rst`` file has a link to the new release docs.
 
@@ -383,7 +383,7 @@ have been fixed. Then:
 * Liaise with the release editor to ensure that they have completed all of their tasks.
 * Check the release notes and verify that the "Under Construction" paragraph on the main
   index page has been removed. Remove the paragraph if it still exists.
-* Run the `close-release-testing <https://builds.mantidproject.org/view/All/job/close-release-testing>`_
+* Run the `close-release-testing <https://builds.mantidproject.org/view/All/job/close-release-testing>`__
   job, which will do the following:
 
   * Disable the job that periodically merges ``release-next`` into ``main``.
@@ -395,15 +395,15 @@ have been fixed. Then:
 We are now ready to create the release candidates for Smoke testing.
 
 * On the ``release-next`` branch, check whether the `git SHA
-  <https://github.com/mantidproject/mantid/blob/343037c685c0aca9151523d6a3e105504f8cf218/scripts/ExternalInterfaces/CMakeLists.txt#L11>`_
+  <https://github.com/mantidproject/mantid/blob/343037c685c0aca9151523d6a3e105504f8cf218/scripts/ExternalInterfaces/CMakeLists.txt#L11>`__
   for MSlice is up to date. If not, create a PR to update it and ask a gatekeeper to merge it.
 * On the ``release-next`` branch, create a PR to update the `major & minor
-  <https://github.com/mantidproject/mantid/blob/release-next/buildconfig/CMake/VersionNumber.cmake>`_
+  <https://github.com/mantidproject/mantid/blob/release-next/buildconfig/CMake/VersionNumber.cmake>`__
   versions accordingly. Also, uncomment ``VERSION_PATCH`` and set it to ``0``. Ask a gatekeeper to merge the PR.
 * Ask a gatekeeper to merge the ``release-next`` branch back to ``main`` locally, and then comment
   out the ``VERSION_PATCH`` on the ``main`` branch. They should then commit and push these changes
   directly to the remote ``main`` without making a PR.
-* Build the `release-next_nightly_deployment Jenkins pipeline <https://builds.mantidproject.org/view/Release%20Pipeline/>`_
+* Build the `release-next_nightly_deployment Jenkins pipeline <https://builds.mantidproject.org/view/Release%20Pipeline/>`__
   with the following parameters (most are already defaulted to the correct values):
 
   * set ``BUILD_DEVEL`` to ``all``
@@ -420,7 +420,7 @@ We are now ready to create the release candidates for Smoke testing.
 
 * Once the packages have been published to GitHub and Anaconda, ask someone in the ISIS core or DevOps
   team to manually sign the Windows binary and re-upload it to the GitHub
-  `draft release <https://github.com/mantidproject/mantid/releases>`_.
+  `draft release <https://github.com/mantidproject/mantid/releases>`__.
 * Liaise with the Quality Assurance Manager and together announce the creation of the smoke testing
   issues and Release Candidates in the *\#general* slack channel.
 
@@ -430,28 +430,28 @@ Release Day
 Check with the Quality Assurance Manager that the Smoke testing has been completed, and any issues
 have been fixed.
 
-*  Edit the `draft release <https://github.com/mantidproject/mantid/releases>`_ on
+*  Edit the `draft release <https://github.com/mantidproject/mantid/releases>`__ on
    GitHub. A new tag should be created based off the release branch in the form ``vX.Y.Z``. The
    description of the new release can be copied from the release notes ``index.rst`` file, and
    edited appropriately. See previous release descriptions for inspiration.
 *  Publish the GitHub release. This will create the tag required to generate the DOI.
-*  Change the labels for the release candidates on our `Anaconda site <https://anaconda.org/mantid/mantid/files>`_
+*  Change the labels for the release candidates on our `Anaconda site <https://anaconda.org/mantid/mantid/files>`__
    from ``rcN`` to ``main``. You may need to ask a member of the ISIS core or DevOps team to do this.
-*  Update the `download page <https://download.mantidproject.org>`_ by running the `Update latest release links
-   <https://github.com/mantidproject/www/actions/workflows/update-latest-release.yml>`_ workflow in the
-   `mantidproject/www repository <https://github.com/mantidproject/www>`_.
+*  Update the `download page <https://download.mantidproject.org>`__ by running the `Update latest release links
+   <https://github.com/mantidproject/www/actions/workflows/update-latest-release.yml>`__ workflow in the
+   `mantidproject/www repository <https://github.com/mantidproject/www>`__.
 *  Ask someone with access to the `daaas-ansible-workspace repository
-   <https://github.com/ral-facilities/daaas-ansible-workspace>`_ (a member of the ISIS core team or IDAaaS support)
+   <https://github.com/ral-facilities/daaas-ansible-workspace>`__ (a member of the ISIS core team or IDAaaS support)
    to add the new release to IDAaaS. They can do this by creating a PR targeting the ``preprod`` branch, adding
    the new release version to the list of versions installed on IDAaaS `here
-   <https://github.com/ral-facilities/daaas-ansible-workspace/blob/master/roles/software/analysis/mantid/defaults/main.yml>`_.
+   <https://github.com/ral-facilities/daaas-ansible-workspace/blob/master/roles/software/analysis/mantid/defaults/main.yml>`__.
    Make sure that there are only three ``mantid_versions`` in the list (delete the oldest one if applicable).
    The changes need to be verified on an IDAaaS test instance before the PR can be accepted.
 
 **Generate DOI**
 
 This requires that a tag has been created for this release. This tag is created when you draft and
-publish a new `release <https://github.com/mantidproject/mantid/releases>`_ on GitHub.
+publish a new `release <https://github.com/mantidproject/mantid/releases>`__ on GitHub.
 
 *  Make sure that you have updated your local copy of git to grab the new tag.
    ``git fetch -p``


### PR DESCRIPTION
**Description of work.**
I introduced a dev-docs warning in the latest build:
https://builds.mantidproject.org/job/build_and_publish_developer_site/57/
The hypelinks should all have had double underscores at the end, see here for why:
https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html#hyperlink-references

**To test:**
1. activate your mantid conda environment
2. build dev-docs by: `python -m sphinx <path_to_mantid_repo>/dev-docs/source/ <somewhere_to_put_the_built_hmtl_files>`
3. check that there are no build warnings


*There is no associated issue.*


*This does not require release notes* because it is a fix to dev-docs


<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
