### PR TITLE
Prevent close of InstrumentWidget on ALFView

### DIFF
--- a/docs/source/release/v6.6.0/Direct_Geometry/General/Bugfixes/34663.rst
+++ b/docs/source/release/v6.6.0/Direct_Geometry/General/Bugfixes/34663.rst
@@ -1,0 +1,1 @@
+It is now possible to delete the workspace loaded into ALFView and then load in a new dataset without issue

--- a/qt/scientific_interfaces/Direct/ALFInstrumentPresenter.cpp
+++ b/qt/scientific_interfaces/Direct/ALFInstrumentPresenter.cpp
@@ -22,7 +22,7 @@ ALFInstrumentPresenter::ALFInstrumentPresenter(IALFInstrumentView *view, std::un
 
 QWidget *ALFInstrumentPresenter::getLoadWidget() { return m_view->generateLoadWidget(); }
 
-MantidWidgets::InstrumentWidget *ALFInstrumentPresenter::getInstrumentView() { return m_view->getInstrumentView(); }
+ALFInstrumentWidget *ALFInstrumentPresenter::getInstrumentView() { return m_view->getInstrumentView(); }
 
 void ALFInstrumentPresenter::subscribeAnalysisPresenter(IALFAnalysisPresenter *presenter) {
   m_analysisPresenter = presenter;

--- a/qt/scientific_interfaces/Direct/ALFInstrumentPresenter.h
+++ b/qt/scientific_interfaces/Direct/ALFInstrumentPresenter.h
@@ -15,14 +15,9 @@
 
 #include <QWidget>
 
-namespace MantidQt {
+namespace MantidQt::CustomInterfaces {
 
-namespace MantidWidgets {
-class InstrumentWidget;
-} // namespace MantidWidgets
-
-namespace CustomInterfaces {
-
+class ALFInstrumentWidget;
 class IALFInstrumentView;
 class IALFAnalysisPresenter;
 
@@ -30,7 +25,7 @@ class MANTIDQT_DIRECT_DLL IALFInstrumentPresenter {
 
 public:
   virtual QWidget *getLoadWidget() = 0;
-  virtual MantidWidgets::InstrumentWidget *getInstrumentView() = 0;
+  virtual ALFInstrumentWidget *getInstrumentView() = 0;
 
   virtual void subscribeAnalysisPresenter(IALFAnalysisPresenter *presenter) = 0;
 
@@ -45,7 +40,7 @@ public:
   ALFInstrumentPresenter(IALFInstrumentView *view, std::unique_ptr<IALFInstrumentModel> model);
 
   QWidget *getLoadWidget() override;
-  MantidWidgets::InstrumentWidget *getInstrumentView() override;
+  ALFInstrumentWidget *getInstrumentView() override;
 
   void subscribeAnalysisPresenter(IALFAnalysisPresenter *presenter) override;
 
@@ -62,5 +57,4 @@ private:
   std::unique_ptr<IALFInstrumentModel> m_model;
 };
 
-} // namespace CustomInterfaces
-} // namespace MantidQt
+} // namespace MantidQt::CustomInterfaces

--- a/qt/scientific_interfaces/Direct/ALFInstrumentView.cpp
+++ b/qt/scientific_interfaces/Direct/ALFInstrumentView.cpp
@@ -7,8 +7,8 @@
 #include "ALFInstrumentView.h"
 
 #include "ALFInstrumentPresenter.h"
-#include "MantidGeometry/Instrument/ComponentInfo.h"
 #include "ALFInstrumentWidget.h"
+#include "MantidGeometry/Instrument/ComponentInfo.h"
 #include "MantidQtWidgets/Common/FileFinderWidget.h"
 #include "MantidQtWidgets/InstrumentView/InstrumentWidget.h"
 #include "MantidQtWidgets/InstrumentView/InstrumentWidgetPickTab.h"

--- a/qt/scientific_interfaces/Direct/ALFInstrumentView.cpp
+++ b/qt/scientific_interfaces/Direct/ALFInstrumentView.cpp
@@ -7,9 +7,8 @@
 #include "ALFInstrumentView.h"
 
 #include "ALFInstrumentPresenter.h"
-#include "MantidAPI/MatrixWorkspace.h"
 #include "MantidGeometry/Instrument/ComponentInfo.h"
-#include "MantidGeometry/Instrument/DetectorInfo.h"
+#include "ALFInstrumentWidget.h"
 #include "MantidQtWidgets/Common/FileFinderWidget.h"
 #include "MantidQtWidgets/InstrumentView/InstrumentWidget.h"
 #include "MantidQtWidgets/InstrumentView/InstrumentWidgetPickTab.h"
@@ -26,18 +25,12 @@ namespace MantidQt::CustomInterfaces {
 ALFInstrumentView::ALFInstrumentView(QWidget *parent) : QWidget(parent), m_files(), m_instrumentWidget() {}
 
 void ALFInstrumentView::setUpInstrument(std::string const &fileName) {
-  m_instrumentWidget =
-      new MantidWidgets::InstrumentWidget(QString::fromStdString(fileName), nullptr, true, true, 0.0, 0.0, true,
-                                          MantidWidgets::InstrumentWidget::Dependencies(), false);
-  m_instrumentWidget->removeTab("Instrument");
-  m_instrumentWidget->removeTab("Draw");
-  m_instrumentWidget->hideHelp();
+  m_instrumentWidget = new ALFInstrumentWidget(QString::fromStdString(fileName));
 
   connect(m_instrumentWidget->getInstrumentDisplay()->getSurface().get(), SIGNAL(shapeChangeFinished()), this,
           SLOT(notifyShapeChanged()));
 
   auto pickTab = m_instrumentWidget->getPickTab();
-  pickTab->expandPlotPanel();
   connect(pickTab->getSelectTubeButton(), SIGNAL(clicked()), this, SLOT(selectWholeTube()));
 }
 

--- a/qt/scientific_interfaces/Direct/ALFInstrumentView.h
+++ b/qt/scientific_interfaces/Direct/ALFInstrumentView.h
@@ -27,11 +27,11 @@ class FileFinderWidget;
 
 namespace MantidWidgets {
 class IInstrumentActor;
-class InstrumentWidget;
-} // namespace MantidWidgets
+}
 
 namespace CustomInterfaces {
 
+class ALFInstrumentWidget;
 class IALFInstrumentPresenter;
 
 class MANTIDQT_DIRECT_DLL IALFInstrumentView {
@@ -40,7 +40,7 @@ public:
   virtual void setUpInstrument(std::string const &fileName) = 0;
 
   virtual QWidget *generateLoadWidget() = 0;
-  virtual MantidWidgets::InstrumentWidget *getInstrumentView() = 0;
+  virtual ALFInstrumentWidget *getInstrumentView() = 0;
 
   virtual void subscribePresenter(IALFInstrumentPresenter *presenter) = 0;
 
@@ -64,7 +64,7 @@ public:
   void setUpInstrument(std::string const &fileName) override;
 
   QWidget *generateLoadWidget() override;
-  MantidWidgets::InstrumentWidget *getInstrumentView() override { return m_instrumentWidget; };
+  ALFInstrumentWidget *getInstrumentView() override { return m_instrumentWidget; };
 
   void subscribePresenter(IALFInstrumentPresenter *presenter) override;
 
@@ -85,8 +85,7 @@ private slots:
 
 private:
   API::FileFinderWidget *m_files;
-  MantidWidgets::InstrumentWidget *m_instrumentWidget;
-
+  ALFInstrumentWidget *m_instrumentWidget;
   IALFInstrumentPresenter *m_presenter;
 };
 } // namespace CustomInterfaces

--- a/qt/scientific_interfaces/Direct/ALFInstrumentWidget.cpp
+++ b/qt/scientific_interfaces/Direct/ALFInstrumentWidget.cpp
@@ -1,0 +1,45 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2022 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#include "ALFInstrumentWidget.h"
+
+#include "MantidAPI/AlgorithmManager.h"
+#include "MantidQtWidgets/InstrumentView/InstrumentWidgetPickTab.h"
+
+using namespace Mantid::API;
+
+namespace {
+
+void loadEmptyInstrument(std::string const &instrumentName, std::string const &outputName) {
+  auto alg = AlgorithmManager::Instance().create("LoadEmptyInstrument");
+  alg->initialize();
+  alg->setProperty("InstrumentName", instrumentName);
+  alg->setProperty("OutputWorkspace", outputName);
+  alg->execute();
+}
+
+} // namespace
+
+namespace MantidQt::CustomInterfaces {
+
+ALFInstrumentWidget::ALFInstrumentWidget(QString workspaceName)
+    : MantidWidgets::InstrumentWidget(std::move(workspaceName), nullptr, true, true, 0.0, 0.0, true,
+                                      MantidWidgets::InstrumentWidget::Dependencies(), false) {
+  removeTab("Instrument");
+  removeTab("Draw");
+  hideHelp();
+
+  getPickTab()->expandPlotPanel();
+}
+
+void ALFInstrumentWidget::handleActiveWorkspaceDeleted() {
+  // We do not want to close the InstrumentWidget. Instead we want to load an empty ALF instrument and reset the
+  // instrument view.
+  loadEmptyInstrument("ALF", getWorkspaceNameStdString());
+  resetInstrumentActor(true, true, 0.0, 0.0, true);
+}
+
+} // namespace MantidQt::CustomInterfaces

--- a/qt/scientific_interfaces/Direct/ALFInstrumentWidget.h
+++ b/qt/scientific_interfaces/Direct/ALFInstrumentWidget.h
@@ -1,0 +1,22 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2022 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#pragma once
+
+#include "DllConfig.h"
+
+#include "MantidQtWidgets/InstrumentView/InstrumentWidget.h"
+
+namespace MantidQt::CustomInterfaces {
+
+class MANTIDQT_DIRECT_DLL ALFInstrumentWidget : public MantidWidgets::InstrumentWidget {
+public:
+  explicit ALFInstrumentWidget(QString workspaceName);
+
+  void handleActiveWorkspaceDeleted() override;
+};
+
+} // namespace MantidQt::CustomInterfaces

--- a/qt/scientific_interfaces/Direct/ALFView.cpp
+++ b/qt/scientific_interfaces/Direct/ALFView.cpp
@@ -10,8 +10,8 @@
 #include "ALFAnalysisView.h"
 #include "ALFInstrumentModel.h"
 #include "ALFInstrumentView.h"
+#include "ALFInstrumentWidget.h"
 #include "MantidQtWidgets/Common/HelpWindow.h"
-#include "MantidQtWidgets/InstrumentView/InstrumentWidget.h"
 
 #include <QString>
 #include <QVBoxLayout>

--- a/qt/scientific_interfaces/Direct/CMakeLists.txt
+++ b/qt/scientific_interfaces/Direct/CMakeLists.txt
@@ -5,10 +5,11 @@ set(SRC_FILES
     ALFInstrumentModel.cpp
     ALFInstrumentPresenter.cpp
     ALFInstrumentView.cpp
+    ALFInstrumentWidget.cpp
     ALFView.cpp
 )
 
-set(MOC_FILES ALFAnalysisView.h ALFInstrumentView.h ALFView.h)
+set(MOC_FILES ALFAnalysisView.h ALFInstrumentView.h ALFInstrumentWidget.h ALFView.h)
 
 set(INC_FILES ALFAnalysisModel.h ALFAnalysisPresenter.h ALFInstrumentModel.h ALFInstrumentPresenter.h DllConfig.h)
 

--- a/qt/scientific_interfaces/Direct/test/ALFInstrumentMocks.h
+++ b/qt/scientific_interfaces/Direct/test/ALFInstrumentMocks.h
@@ -41,7 +41,7 @@ public:
   MOCK_METHOD1(setUpInstrument, void(const std::string &fileName));
 
   MOCK_METHOD0(generateLoadWidget, QWidget *());
-  MOCK_METHOD0(getInstrumentView, MantidWidgets::InstrumentWidget *());
+  MOCK_METHOD0(getInstrumentView, ALFInstrumentWidget *());
 
   MOCK_METHOD1(subscribePresenter, void(IALFInstrumentPresenter *presenter));
 
@@ -75,7 +75,7 @@ public:
 class MockALFInstrumentPresenter : public IALFInstrumentPresenter {
 public:
   MOCK_METHOD0(getLoadWidget, QWidget *());
-  MOCK_METHOD0(getInstrumentView, MantidWidgets::InstrumentWidget *());
+  MOCK_METHOD0(getInstrumentView, ALFInstrumentWidget *());
 
   MOCK_METHOD1(subscribeAnalysisPresenter, void(IALFAnalysisPresenter *presenter));
 

--- a/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/InstrumentWidget.h
+++ b/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/InstrumentWidget.h
@@ -360,6 +360,8 @@ private:
                           const std::shared_ptr<Mantid::API::Workspace> &workspace_ptr) override;
   void renameHandle(const std::string &oldName, const std::string &newName) override;
   void clearADSHandle() override;
+  /// close the widget after an ADS event removes the workspace
+  virtual void handleActiveWorkspaceDeleted();
   /// overlay a peaks workspace on the projection surface
   void overlayPeaksWorkspace(const Mantid::API::IPeaksWorkspace_sptr &ws);
   /// overlay a masked workspace on the projection surface

--- a/qt/widgets/instrumentview/src/InstrumentWidget.cpp
+++ b/qt/widgets/instrumentview/src/InstrumentWidget.cpp
@@ -1562,7 +1562,7 @@ void InstrumentWidget::handleWorkspaceReplacement(const std::string &wsName,
   auto matrixWS = std::dynamic_pointer_cast<const MatrixWorkspace>(workspace);
   if (!matrixWS || matrixWS->detectorInfo().size() == 0) {
     emit preDeletingHandle();
-    close();
+    handleActiveWorkspaceDeleted();
     return;
   }
   // try to detect if the instrument changes (unlikely if the workspace
@@ -1585,7 +1585,7 @@ void InstrumentWidget::preDeleteHandle(const std::string &ws_name, const std::sh
   if (hasWorkspace(ws_name)) {
     m_pickTab->resetOriginalWorkspace();
     emit preDeletingHandle();
-    close();
+    handleActiveWorkspaceDeleted();
     return;
   }
   Mantid::API::IPeaksWorkspace_sptr pws = std::dynamic_pointer_cast<Mantid::API::IPeaksWorkspace>(workspace_ptr);
@@ -1609,8 +1609,13 @@ void InstrumentWidget::renameHandle(const std::string &oldName, const std::strin
 void InstrumentWidget::clearADSHandle() {
   emit clearingHandle();
   m_pickTab->resetOriginalWorkspace();
-  close();
+  handleActiveWorkspaceDeleted();
 }
+
+/**
+ * Handles when the workspace opened in the instrument view is removed from the ADS.
+ */
+void InstrumentWidget::handleActiveWorkspaceDeleted() { close(); }
 
 /**
  * Overlay a peaks workspace on the surface projection


### PR DESCRIPTION
**Description of work.**
This PR fixes a bug where the InstrumentWidget used on the ALFView interface would be closed when the loaded workspace was deleted from the ADS. This made the interface unusable and you would need to close and reopen the interface.

**To test:**
1. Load ALF82301 into ALFView
![image](https://user-images.githubusercontent.com/40830825/204492986-6970537e-68eb-41d8-aeaa-7d937380acd5.png)

3. Clear the ADS

5. The ALFInstrumentView should go blank (i.e. an empty ALF instrument is loaded into the interface)
![image](https://user-images.githubusercontent.com/40830825/204493073-712bd53c-c061-4f03-b5b6-c28cc8034bc7.png)

7. Try loading a dataset again and see that the instrument view is populated with data again.

Fixes #34663

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
