### PR TITLE
Fix bug SaveReflections with empty table

### DIFF
--- a/docs/source/release/v6.6.0/Diffraction/Single_Crystal/Bugfixes/34796.rst
+++ b/docs/source/release/v6.6.0/Diffraction/Single_Crystal/Bugfixes/34796.rst
@@ -1,0 +1,1 @@
+- :ref:`SaveReflections <algm-SaveReflections>` now warns if an empty peak table is saved and doesn't fail with an error


### PR DESCRIPTION
**Description of work.**

There was an error in `SaveReflections` as the code didn't check if there are any peaks before attempting to get the maximum intensity (used to determine a scale factor to avoid as much as possible truncating error when saving to a fixed width column). 

In this PR I warn if peak table is empty and set scale factor to 1. I considered putting a check for an empty peak table in the input validation  - however that would be a breaking change from behaviour pre 6.5 (and would cause a `ValueError` that may break user scripts, e.g. stopping a loop over runs because a run was empty). In addition other algorithms that save peak tables (`SaveHKL`, `SaveIsawPeaks`) do accept empty peak tables.

**To test:**

Follow instructions in the original issue - a warning should be shown and no error.

Fixes #34795
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
