### PR TITLE
Update Reflectometry algorithms to take optional polarization efficiencies workspace

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/ReflectometryReductionOneLiveData.py
+++ b/Framework/PythonInterface/plugins/algorithms/ReflectometryReductionOneLiveData.py
@@ -61,10 +61,10 @@ class ReflectometryReductionOneLiveData(DataProcessorAlgorithm):
             'ScaleRHSWorkspace', 'TransmissionProcessingInstructions',
             'CorrectionAlgorithm', 'Polynomial', 'C0', 'C1',
             'MomentumTransferMin', 'MomentumTransferStep', 'MomentumTransferMax',
-            'ScaleFactor', 'PolarizationAnalysis', 'PolarizationEfficiencies',
-            'FloodCorrection', 'FloodWorkspace', 'Debug',
+            'ScaleFactor', 'PolarizationAnalysis', 'FloodCorrection', 'FloodWorkspace', 'Debug',
             'TimeInterval', 'LogValueInterval', 'LogName', 'UseNewFilterAlgorithm',
-            'ReloadInvalidWorkspaces', 'GroupTOFWorkspaces', 'CalibrationFile', 'OutputWorkspace']
+            'ReloadInvalidWorkspaces', 'GroupTOFWorkspaces', 'CalibrationFile', 'OutputWorkspace',
+            'PolarizationEfficiencies']
         self.copyProperties('ReflectometryISISLoadAndProcess', self._child_properties)
 
     def PyExec(self):

--- a/Framework/PythonInterface/plugins/algorithms/ReflectometryReductionOneLiveData.py
+++ b/Framework/PythonInterface/plugins/algorithms/ReflectometryReductionOneLiveData.py
@@ -61,7 +61,7 @@ class ReflectometryReductionOneLiveData(DataProcessorAlgorithm):
             'ScaleRHSWorkspace', 'TransmissionProcessingInstructions',
             'CorrectionAlgorithm', 'Polynomial', 'C0', 'C1',
             'MomentumTransferMin', 'MomentumTransferStep', 'MomentumTransferMax',
-            'ScaleFactor', 'PolarizationAnalysis',
+            'ScaleFactor', 'PolarizationAnalysis', 'PolarizationEfficiencies',
             'FloodCorrection', 'FloodWorkspace', 'Debug',
             'TimeInterval', 'LogValueInterval', 'LogName', 'UseNewFilterAlgorithm',
             'ReloadInvalidWorkspaces', 'GroupTOFWorkspaces', 'CalibrationFile', 'OutputWorkspace']

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ReflectometryISISLoadAndProcess.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ReflectometryISISLoadAndProcess.py
@@ -127,6 +127,10 @@ class ReflectometryISISLoadAndProcess(DataProcessorAlgorithm):
             issues[Prop.SLICE] = "Cannot perform slicing when summing multiple input runs"
         return issues
 
+    def _copy_properties_from_reduction_algorithm(self, properties):
+        self.copyProperties('ReflectometryReductionOneAuto', properties)
+        self._reduction_properties += properties
+
     def _declareRunProperties(self):
         mandatoryInputRuns = CompositeValidator()
         mandatoryInputRuns.add(StringArrayMandatoryValidator())
@@ -143,8 +147,7 @@ class ReflectometryISISLoadAndProcess(DataProcessorAlgorithm):
         properties = [
             'ThetaIn', 'ThetaLogName',
         ]
-        self.copyProperties('ReflectometryReductionOneAuto', properties)
-        self._reduction_properties += properties
+        self._copy_properties_from_reduction_algorithm(properties)
         # Add properties for settings to apply to input runs
         self.declareProperty(Prop.RELOAD, True,
                              doc='If true, reload input workspaces if they are of the incorrect type')
@@ -190,12 +193,19 @@ class ReflectometryISISLoadAndProcess(DataProcessorAlgorithm):
             'MonitorIntegrationWavelengthMin', 'MonitorIntegrationWavelengthMax',
             'SubtractBackground', 'BackgroundProcessingInstructions', 'BackgroundCalculationMethod',
             'DegreeOfPolynomial', 'CostFunction',
-            'NormalizeByIntegratedMonitors', 'PolarizationAnalysis',
+            'NormalizeByIntegratedMonitors', 'PolarizationAnalysis'
+        ]
+        self._copy_properties_from_reduction_algorithm(properties)
+
+        self.declareProperty('PolarizationEfficiencies', "",
+                             'A workspace or file name containing the polarization efficiency factors for either '
+                             'the Wildes or Fredrikze correction methods.', Direction.Input)
+
+        properties = [
             'FloodCorrection', 'FloodWorkspace',
             'CorrectionAlgorithm', 'Polynomial', 'C0', 'C1'
         ]
-        self.copyProperties('ReflectometryReductionOneAuto', properties)
-        self._reduction_properties += properties
+        self._copy_properties_from_reduction_algorithm(properties)
 
     def _declareTransmissionProperties(self):
         # Add input transmission run properties
@@ -214,8 +224,7 @@ class ReflectometryISISLoadAndProcess(DataProcessorAlgorithm):
             'Params', 'StartOverlap', 'EndOverlap',
             'ScaleRHSWorkspace', 'TransmissionProcessingInstructions'
         ]
-        self.copyProperties('ReflectometryReductionOneAuto', properties)
-        self._reduction_properties += properties
+        self._copy_properties_from_reduction_algorithm(properties)
 
     def _declareOutputProperties(self):
         properties = [Prop.DEBUG,
@@ -223,8 +232,7 @@ class ReflectometryISISLoadAndProcess(DataProcessorAlgorithm):
                       'ScaleFactor',
                       Prop.OUTPUT_WS_BINNED, Prop.OUTPUT_WS, Prop.OUTPUT_WS_LAM,
                       Prop.OUTPUT_WS_TRANS, Prop.OUTPUT_WS_FIRST_TRANS, Prop.OUTPUT_WS_SECOND_TRANS]
-        self.copyProperties('ReflectometryReductionOneAuto', properties)
-        self._reduction_properties += properties
+        self._copy_properties_from_reduction_algorithm(properties)
 
     def _getInputWorkspaces(self, runs, isTrans):
         """Convert the given run numbers into real workspace names. Uses workspaces from
@@ -238,6 +246,28 @@ class ReflectometryISISLoadAndProcess(DataProcessorAlgorithm):
                 raise RuntimeError('Error loading run ' + run)
             workspaces.append(ws)
         return workspaces
+
+    def _loadPolarizationCorrectionWorkspace(self):
+        efficiencies_ws = self.getPropertyValue('PolarizationEfficiencies')
+        if not efficiencies_ws:
+            return None
+
+        if AnalysisDataService.doesExist(efficiencies_ws):
+            self.log().information(f'Loading polarization efficiency information from workspace \"{efficiencies_ws}\"')
+            return AnalysisDataService.retrieve(efficiencies_ws)
+
+        args = {'InputRunList': [efficiencies_ws], 'EventMode': False}
+        alg = self.createChildAlgorithm('ReflectometryISISPreprocess', **args)
+        alg.setRethrows(True)
+
+        try:
+            alg.execute()
+        except:
+            raise RuntimeError(f'Could not load polarization efficiency information from file \"{efficiencies_ws}\"')
+
+        ws = alg.getProperty('OutputWorkspace').value
+        self.log().information(f'Loaded polarization efficiency information from file \"{efficiencies_ws}\"')
+        return ws
 
     def _sumBanks(self, workspace_names, roiDetectorIDs):
         output_workspace_names = workspace_names.copy()
@@ -521,6 +551,9 @@ class ReflectometryISISLoadAndProcess(DataProcessorAlgorithm):
         alg.setProperty("InputWorkspace", input_workspace)
         alg.setProperty("FirstTransmissionRun", first_trans_workspace)
         alg.setProperty("SecondTransmissionRun", second_trans_workspace)
+        efficiencies_ws = self._loadPolarizationCorrectionWorkspace()
+        if efficiencies_ws:
+            alg.setProperty("PolarizationEfficiencies", efficiencies_ws)
         alg.execute()
         return alg
 

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ReflectometryISISLoadAndProcess.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ReflectometryISISLoadAndProcess.py
@@ -75,6 +75,7 @@ class ReflectometryISISLoadAndProcess(DataProcessorAlgorithm):
         self._declareReductionProperties()
         self._declareTransmissionProperties()
         self._declareOutputProperties()
+        self._declarePolarizationEfficiencyProperties()
 
     def PyExec(self):
         """Execute the algorithm."""
@@ -193,16 +194,7 @@ class ReflectometryISISLoadAndProcess(DataProcessorAlgorithm):
             'MonitorIntegrationWavelengthMin', 'MonitorIntegrationWavelengthMax',
             'SubtractBackground', 'BackgroundProcessingInstructions', 'BackgroundCalculationMethod',
             'DegreeOfPolynomial', 'CostFunction',
-            'NormalizeByIntegratedMonitors', 'PolarizationAnalysis'
-        ]
-        self._copy_properties_from_reduction_algorithm(properties)
-
-        self.declareProperty('PolarizationEfficiencies', "",
-                             'A workspace or file name containing the polarization efficiency factors for either '
-                             'the Wildes or Fredrikze correction methods.', Direction.Input)
-
-        properties = [
-            'FloodCorrection', 'FloodWorkspace',
+            'NormalizeByIntegratedMonitors', 'PolarizationAnalysis', 'FloodCorrection', 'FloodWorkspace',
             'CorrectionAlgorithm', 'Polynomial', 'C0', 'C1'
         ]
         self._copy_properties_from_reduction_algorithm(properties)
@@ -233,6 +225,11 @@ class ReflectometryISISLoadAndProcess(DataProcessorAlgorithm):
                       Prop.OUTPUT_WS_BINNED, Prop.OUTPUT_WS, Prop.OUTPUT_WS_LAM,
                       Prop.OUTPUT_WS_TRANS, Prop.OUTPUT_WS_FIRST_TRANS, Prop.OUTPUT_WS_SECOND_TRANS]
         self._copy_properties_from_reduction_algorithm(properties)
+
+    def _declarePolarizationEfficiencyProperties(self):
+        self.declareProperty('PolarizationEfficiencies', "",
+                             'A workspace or file name containing the polarization efficiency factors for either '
+                             'the Wildes or Fredrikze correction methods.', Direction.Input)
 
     def _getInputWorkspaces(self, runs, isTrans):
         """Convert the given run numbers into real workspace names. Uses workspaces from

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ReflectometryISISLoadAndProcess.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ReflectometryISISLoadAndProcess.py
@@ -256,11 +256,10 @@ class ReflectometryISISLoadAndProcess(DataProcessorAlgorithm):
             self.log().information(f'Loading polarization efficiency information from workspace \"{efficiencies_ws}\"')
             return AnalysisDataService.retrieve(efficiencies_ws)
 
-        args = {'InputRunList': [efficiencies_ws], 'EventMode': False}
-        alg = self.createChildAlgorithm('ReflectometryISISPreprocess', **args)
-        alg.setRethrows(True)
-
+        alg = self.createChildAlgorithm('LoadNexus')
         try:
+            alg.setRethrows(True)
+            alg.setProperty('Filename', efficiencies_ws)
             alg.execute()
         except:
             raise RuntimeError(f'Could not load polarization efficiency information from file \"{efficiencies_ws}\"')

--- a/Framework/Reflectometry/inc/MantidReflectometry/ReflectometryReductionOneAuto3.h
+++ b/Framework/Reflectometry/inc/MantidReflectometry/ReflectometryReductionOneAuto3.h
@@ -86,6 +86,8 @@ private:
   /// Populate algorithmic correction properties
   void populateAlgorithmicCorrectionProperties(const Mantid::API::IAlgorithm_sptr &alg,
                                                const Mantid::Geometry::Instrument_const_sptr &instrument);
+  std::string findPolarizationCorrectionMethod(const API::MatrixWorkspace_sptr &efficiencies);
+  std::string findPolarizationCorrectionOption(const std::string &correctionMethod);
   /// Get a polarization efficiencies workspace.
   std::tuple<API::MatrixWorkspace_sptr, std::string, std::string> getPolarizationEfficiencies();
   void applyPolarizationCorrection(const std::string &outputIvsLam);

--- a/Framework/Reflectometry/src/ReflectometryReductionOneAuto3.cpp
+++ b/Framework/Reflectometry/src/ReflectometryReductionOneAuto3.cpp
@@ -7,6 +7,7 @@
 #include "MantidReflectometry/ReflectometryReductionOneAuto3.h"
 #include "MantidAPI/BoostOptionalToAlgorithmProperty.h"
 #include "MantidAPI/MatrixWorkspace.h"
+#include "MantidAPI/TextAxis.h"
 #include "MantidAPI/WorkspaceGroup.h"
 #include "MantidKernel/ArrayProperty.h"
 #include "MantidKernel/CompositeValidator.h"
@@ -36,6 +37,9 @@ namespace CorrectionMethod {
 static const std::string WILDES{"Wildes"};
 static const std::string FREDRIKZE{"Fredrikze"};
 
+static const std::vector<std::string> WILDES_AXES = {{"P1", "P2", "F1", "F2"}};
+static const std::vector<std::string> FREDRIKZE_AXES = {{"Pp", "Ap", "Rho", "Alpha"}};
+
 // Map correction methods to which correction-option property name they use
 static const std::map<std::string, std::string> OPTION_NAME{{CorrectionMethod::WILDES, Prop::FLIPPERS},
                                                             {CorrectionMethod::FREDRIKZE, Prop::POLARIZATION_ANALYSIS}};
@@ -45,6 +49,13 @@ void validate(const std::string &method) {
     throw std::invalid_argument("Unsupported polarization correction method: " + method);
 }
 } // namespace CorrectionMethod
+
+namespace CorrectionOption {
+static const std::string PNR{"PNR"};
+static const std::string PA{"PA"};
+static const std::string FLIPPERS_NO_ANALYSER{"0, 1"};
+static const std::string FLIPPERS_FULL{"00, 01, 10, 11"};
+} // namespace CorrectionOption
 
 std::vector<std::string> getGroupMemberNames(const std::string &groupName) {
   auto group = AnalysisDataService::Instance().retrieveWS<WorkspaceGroup>(groupName);
@@ -277,6 +288,10 @@ void ReflectometryReductionOneAuto3::init() {
   // Polarization correction
   declareProperty(std::make_unique<PropertyWithValue<bool>>("PolarizationAnalysis", false, Direction::Input),
                   "Apply polarization corrections");
+  declareProperty(std::make_unique<WorkspaceProperty<MatrixWorkspace>>("PolarizationEfficiencies", "", Direction::Input,
+                                                                       PropertyMode::Optional),
+                  "A workspace to be used for polarization analysis that contains the efficiency factors as "
+                  "histograms: P1, P2, F1 and F2 in the Wildes method and Pp, Ap, Rho and Alpha for Fredrikze.");
 
   // Flood correction
   std::vector<std::string> propOptions = {"Workspace", "ParameterFile"};
@@ -948,22 +963,79 @@ auto ReflectometryReductionOneAuto3::getOutputNamesForGroupMember(const std::vec
   return outputNames;
 }
 
+/** Find the polarization correction method to use for the given efficiencies workspace.
+ * Checks the workspace axes labels to determine the appropriate correction method.
+ * We don't check all the workspace labels here, we just look for the first label that matches
+ * one of the efficiency factors for a supported correction method.
+ */
+std::string
+ReflectometryReductionOneAuto3::findPolarizationCorrectionMethod(const API::MatrixWorkspace_sptr &efficiencies) {
+  try {
+    auto const &axis = dynamic_cast<TextAxis &>(*efficiencies->getAxis(1));
+
+    for (size_t i = 0; i < axis.length(); ++i) {
+      if (std::find(CorrectionMethod::WILDES_AXES.begin(), CorrectionMethod::WILDES_AXES.end(), axis.label(i)) !=
+          CorrectionMethod::WILDES_AXES.end()) {
+        return CorrectionMethod::WILDES;
+      } else if (std::find(CorrectionMethod::FREDRIKZE_AXES.begin(), CorrectionMethod::FREDRIKZE_AXES.end(),
+                           axis.label(i)) != CorrectionMethod::FREDRIKZE_AXES.end()) {
+        return CorrectionMethod::FREDRIKZE;
+      }
+    }
+  } catch (std::bad_cast &) {
+    throw std::runtime_error("Efficiencies workspace is not in a supported format");
+  }
+  throw std::runtime_error(
+      "Axes labels for efficiencies workspace do not match any supported polarization correction method");
+}
+
+/** Find the polarization correction option to use for the given correction method, based on the number of workspaces
+ * in the input workspace group.
+ * For the Fredrikze algorithm the correction option represents the polarization analysis mode.
+ * For Wildes the correction option is the flipper configuration. There are more than two possible flipper
+ * configurations, but this is mainly intended for use by POLREF initially so we only need to support two for now.
+ */
+std::string ReflectometryReductionOneAuto3::findPolarizationCorrectionOption(const std::string &correctionMethod) {
+  auto groupIvsLam =
+      AnalysisDataService::Instance().retrieveWS<WorkspaceGroup>(getPropertyValue("OutputWorkspaceWavelength"));
+  auto numWorkspacesInGrp = groupIvsLam->size();
+  if (numWorkspacesInGrp == 2) {
+    return (correctionMethod == CorrectionMethod::FREDRIKZE) ? CorrectionOption::PNR
+                                                             : CorrectionOption::FLIPPERS_NO_ANALYSER;
+  } else if (numWorkspacesInGrp == 4) {
+    return (correctionMethod == CorrectionMethod::FREDRIKZE) ? CorrectionOption::PA : CorrectionOption::FLIPPERS_FULL;
+  }
+  throw std::runtime_error("Only input workspace groups with two or four periods are supported");
+}
+
 /** Construct a polarization efficiencies workspace based on values of input
  * properties.
  */
 std::tuple<API::MatrixWorkspace_sptr, std::string, std::string>
 ReflectometryReductionOneAuto3::getPolarizationEfficiencies() {
-  auto groupIvsLam =
-      AnalysisDataService::Instance().retrieveWS<WorkspaceGroup>(getPropertyValue("OutputWorkspaceWavelength"));
+  MatrixWorkspace_sptr efficiencies;
+  std::string correctionMethod;
+  std::string correctionOption;
 
-  Workspace_sptr workspace = groupIvsLam->getItem(0);
+  if (!isDefault("PolarizationEfficiencies")) {
+    // Get the efficiencies from the provided workspace
+    efficiencies = getProperty("PolarizationEfficiencies");
+    correctionMethod = findPolarizationCorrectionMethod(efficiencies);
+    correctionOption = findPolarizationCorrectionOption(correctionMethod);
+  } else {
+    // Get the efficiencies from the parameter file
+    auto groupIvsLam =
+        AnalysisDataService::Instance().retrieveWS<WorkspaceGroup>(getPropertyValue("OutputWorkspaceWavelength"));
 
-  auto effAlg = createChildAlgorithm("ExtractPolarizationEfficiencies");
-  effAlg->setProperty("InputWorkspace", workspace);
-  effAlg->execute();
-  MatrixWorkspace_sptr efficiencies = effAlg->getProperty("OutputWorkspace");
-  std::string correctionMethod = effAlg->getPropertyValue("CorrectionMethod");
-  std::string correctionOption = effAlg->getPropertyValue("CorrectionOption");
+    Workspace_sptr workspace = groupIvsLam->getItem(0);
+
+    auto effAlg = createChildAlgorithm("ExtractPolarizationEfficiencies");
+    effAlg->setProperty("InputWorkspace", workspace);
+    effAlg->execute();
+    efficiencies = effAlg->getProperty("OutputWorkspace");
+    correctionMethod = effAlg->getPropertyValue("CorrectionMethod");
+    correctionOption = effAlg->getPropertyValue("CorrectionOption");
+  }
 
   return std::make_tuple(efficiencies, correctionMethod, correctionOption);
 }

--- a/Framework/Reflectometry/src/ReflectometryReductionOneAuto3.cpp
+++ b/Framework/Reflectometry/src/ReflectometryReductionOneAuto3.cpp
@@ -977,8 +977,9 @@ ReflectometryReductionOneAuto3::findPolarizationCorrectionMethod(const API::Matr
       if (std::find(CorrectionMethod::WILDES_AXES.begin(), CorrectionMethod::WILDES_AXES.end(), axis.label(i)) !=
           CorrectionMethod::WILDES_AXES.end()) {
         return CorrectionMethod::WILDES;
-      } else if (std::find(CorrectionMethod::FREDRIKZE_AXES.begin(), CorrectionMethod::FREDRIKZE_AXES.end(),
-                           axis.label(i)) != CorrectionMethod::FREDRIKZE_AXES.end()) {
+      }
+      if (std::find(CorrectionMethod::FREDRIKZE_AXES.begin(), CorrectionMethod::FREDRIKZE_AXES.end(), axis.label(i)) !=
+          CorrectionMethod::FREDRIKZE_AXES.end()) {
         return CorrectionMethod::FREDRIKZE;
       }
     }

--- a/Framework/Reflectometry/src/ReflectometryReductionOneAuto3.cpp
+++ b/Framework/Reflectometry/src/ReflectometryReductionOneAuto3.cpp
@@ -37,8 +37,8 @@ namespace CorrectionMethod {
 static const std::string WILDES{"Wildes"};
 static const std::string FREDRIKZE{"Fredrikze"};
 
-static const std::vector<std::string> WILDES_AXES = {{"P1", "P2", "F1", "F2"}};
-static const std::vector<std::string> FREDRIKZE_AXES = {{"Pp", "Ap", "Rho", "Alpha"}};
+static const std::vector<std::string> WILDES_AXES = {"P1", "P2", "F1", "F2"};
+static const std::vector<std::string> FREDRIKZE_AXES = {"Pp", "Ap", "Rho", "Alpha"};
 
 // Map correction methods to which correction-option property name they use
 static const std::map<std::string, std::string> OPTION_NAME{{CorrectionMethod::WILDES, Prop::FLIPPERS},

--- a/Framework/Reflectometry/src/ReflectometryReductionOneAuto3.cpp
+++ b/Framework/Reflectometry/src/ReflectometryReductionOneAuto3.cpp
@@ -288,10 +288,6 @@ void ReflectometryReductionOneAuto3::init() {
   // Polarization correction
   declareProperty(std::make_unique<PropertyWithValue<bool>>("PolarizationAnalysis", false, Direction::Input),
                   "Apply polarization corrections");
-  declareProperty(std::make_unique<WorkspaceProperty<MatrixWorkspace>>("PolarizationEfficiencies", "", Direction::Input,
-                                                                       PropertyMode::Optional),
-                  "A workspace to be used for polarization analysis that contains the efficiency factors as "
-                  "histograms: P1, P2, F1 and F2 in the Wildes method and Pp, Ap, Rho and Alpha for Fredrikze.");
 
   // Flood correction
   std::vector<std::string> propOptions = {"Workspace", "ParameterFile"};
@@ -326,6 +322,11 @@ void ReflectometryReductionOneAuto3::init() {
                       std::make_unique<Kernel::EnabledWhenProperty>("Debug", IS_EQUAL_TO, "1"));
 
   initTransmissionOutputProperties();
+
+  declareProperty(std::make_unique<WorkspaceProperty<MatrixWorkspace>>("PolarizationEfficiencies", "", Direction::Input,
+                                                                       PropertyMode::Optional),
+                  "A workspace to be used for polarization analysis that contains the efficiency factors as "
+                  "histograms: P1, P2, F1 and F2 in the Wildes method and Pp, Ap, Rho and Alpha for Fredrikze.");
 }
 
 /** Execute the algorithm.
@@ -1003,7 +1004,8 @@ std::string ReflectometryReductionOneAuto3::findPolarizationCorrectionOption(con
   if (numWorkspacesInGrp == 2) {
     return (correctionMethod == CorrectionMethod::FREDRIKZE) ? CorrectionOption::PNR
                                                              : CorrectionOption::FLIPPERS_NO_ANALYSER;
-  } else if (numWorkspacesInGrp == 4) {
+  }
+  if (numWorkspacesInGrp == 4) {
     return (correctionMethod == CorrectionMethod::FREDRIKZE) ? CorrectionOption::PA : CorrectionOption::FLIPPERS_FULL;
   }
   throw std::runtime_error("Only input workspace groups with two or four periods are supported");

--- a/Framework/Reflectometry/test/ReflectometryReductionOneAuto3Test.h
+++ b/Framework/Reflectometry/test/ReflectometryReductionOneAuto3Test.h
@@ -1129,6 +1129,100 @@ public:
     ADS.clear();
   }
 
+  void test_polarization_correction_with_efficiency_workspace() {
+
+    std::string const name = "input";
+    prepareInputGroup(name, "Fredrikze");
+    auto efficiencies = createPolarizationEfficienciesWorkspace("Fredrikze");
+
+    ReflectometryReductionOneAuto3 alg;
+    alg.initialize();
+    alg.setPropertyValue("InputWorkspace", name);
+    alg.setProperty("ThetaIn", 10.0);
+    alg.setProperty("WavelengthMin", 1.0);
+    alg.setProperty("WavelengthMax", 15.0);
+    alg.setProperty("ProcessingInstructions", "2");
+    alg.setProperty("MomentumTransferStep", 0.04);
+    alg.setProperty("PolarizationAnalysis", true);
+    alg.setProperty("PolarizationEfficiencies", efficiencies);
+    alg.setPropertyValue("OutputWorkspace", "IvsQ");
+    alg.setPropertyValue("OutputWorkspaceBinned", "IvsQ_binned");
+    alg.setPropertyValue("OutputWorkspaceWavelength", "IvsLam");
+    alg.execute();
+
+    auto outQGroup = retrieveOutWS("IvsQ");
+    auto outLamGroup = retrieveOutWS("IvsLam");
+
+    TS_ASSERT_EQUALS(outQGroup.size(), 4);
+    TS_ASSERT_EQUALS(outLamGroup.size(), 4);
+
+    TS_ASSERT_EQUALS(outLamGroup[0]->blocksize(), 9);
+    // X range in outLam
+    TS_ASSERT_DELTA(outLamGroup[0]->x(0).front(), 2.0729661466, 0.0001);
+    TS_ASSERT_DELTA(outLamGroup[0]->x(0).back(), 14.2963182408, 0.0001);
+
+    TS_ASSERT_DELTA(outLamGroup[0]->y(0)[0], 1.9267, 0.0001);
+    TS_ASSERT_DELTA(outLamGroup[1]->y(0)[0], 1.7838, 0.0001);
+    TS_ASSERT_DELTA(outLamGroup[2]->y(0)[0], -0.3231, 0.0001);
+    TS_ASSERT_DELTA(outLamGroup[3]->y(0)[0], -0.4659, 0.0001);
+
+    TS_ASSERT_EQUALS(outQGroup[0]->blocksize(), 9);
+
+    TS_ASSERT_DELTA(outQGroup[0]->y(0)[0], 1.9267, 0.0001);
+    TS_ASSERT_DELTA(outQGroup[1]->y(0)[0], 1.7838, 0.0001);
+    TS_ASSERT_DELTA(outQGroup[2]->y(0)[0], -0.3231, 0.0001);
+    TS_ASSERT_DELTA(outQGroup[3]->y(0)[0], -0.4659, 0.0001);
+
+    ADS.clear();
+  }
+
+  void test_polarization_correction_with_efficiency_workspace_Wildes() {
+
+    std::string const name = "input";
+    prepareInputGroup(name, "Wildes");
+    auto efficiencies = createPolarizationEfficienciesWorkspace("Wildes");
+
+    ReflectometryReductionOneAuto3 alg;
+    alg.initialize();
+    alg.setPropertyValue("InputWorkspace", name);
+    alg.setProperty("ThetaIn", 10.0);
+    alg.setProperty("WavelengthMin", 1.0);
+    alg.setProperty("WavelengthMax", 15.0);
+    alg.setProperty("ProcessingInstructions", "2");
+    alg.setProperty("MomentumTransferStep", 0.04);
+    alg.setProperty("PolarizationAnalysis", true);
+    alg.setProperty("PolarizationEfficiencies", efficiencies);
+    alg.setPropertyValue("OutputWorkspace", "IvsQ");
+    alg.setPropertyValue("OutputWorkspaceBinned", "IvsQ_binned");
+    alg.setPropertyValue("OutputWorkspaceWavelength", "IvsLam");
+    alg.execute();
+
+    auto outQGroup = retrieveOutWS("IvsQ");
+    auto outLamGroup = retrieveOutWS("IvsLam");
+
+    TS_ASSERT_EQUALS(outQGroup.size(), 4);
+    TS_ASSERT_EQUALS(outLamGroup.size(), 4);
+
+    TS_ASSERT_EQUALS(outLamGroup[0]->blocksize(), 9);
+    // X range in outLam
+    TS_ASSERT_DELTA(outLamGroup[0]->x(0).front(), 2.0729661466, 0.0001);
+    TS_ASSERT_DELTA(outLamGroup[0]->x(0).back(), 14.2963182408, 0.0001);
+
+    TS_ASSERT_DELTA(outLamGroup[0]->y(0)[0], 0.6552, 0.0001);
+    TS_ASSERT_DELTA(outLamGroup[1]->y(0)[0], 0.4330, 0.0001);
+    TS_ASSERT_DELTA(outLamGroup[2]->y(0)[0], 0.9766, 0.0001);
+    TS_ASSERT_DELTA(outLamGroup[3]->y(0)[0], 0.7544, 0.0001);
+
+    TS_ASSERT_EQUALS(outQGroup[0]->blocksize(), 9);
+
+    TS_ASSERT_DELTA(outQGroup[0]->y(0)[0], 0.6552, 0.0001);
+    TS_ASSERT_DELTA(outQGroup[1]->y(0)[0], 0.4330, 0.0001);
+    TS_ASSERT_DELTA(outQGroup[2]->y(0)[0], 0.9766, 0.0001);
+    TS_ASSERT_DELTA(outQGroup[3]->y(0)[0], 0.7544, 0.0001);
+
+    ADS.clear();
+  }
+
   void test_polarization_correction_with_invalid_efficiencies_workspace_labels() {
 
     std::string const name = "input";
@@ -1672,29 +1766,36 @@ private:
   }
 
   MatrixWorkspace_sptr createPolarizationEfficienciesWorkspace(const std::string &correctionMethod) {
-    std::vector<std::string> efficiencyFactors;
+    // The workspace created here takes most of its values from the test parameter files, however the P1/Pp
+    // efficiency factor has been changed so that we can distinguish between tests that use a workspace vs those
+    // that use the test parameter file
+    std::vector<std::string> axisLabels;
     if (correctionMethod == "Wildes") {
-      efficiencyFactors = {"P1", "P2", "F1", "F2"};
+      axisLabels = {"P1", "P2", "F1", "F2"};
     } else {
-      efficiencyFactors = {"Pp", "Ap", "Rho", "Alpha"};
+      axisLabels = {"Pp", "Ap", "Rho", "Alpha"};
     }
+
+    std::vector<double> lambda{0, 3, 6, 10, 15, 20};
+
+    std::map<std::string, std::vector<double>> efficiencyFactors;
+    efficiencyFactors[axisLabels[0]] = {0.1, 0.1, 0.1, 0.1, 0.1, 0.1};
+    efficiencyFactors[axisLabels[1]] = {0.8, 0.8, 0.8, 0.8, 0.8, 0.8};
+    efficiencyFactors[axisLabels[2]] = {0.778, 0.778, 0.778, 0.778, 0.778, 0.778};
+    efficiencyFactors[axisLabels[3]] = {0.75, 0.75, 0.75, 0.75, 0.75, 0.75};
 
     auto join_alg = AlgorithmManager::Instance().create("JoinISISPolarizationEfficiencies");
     join_alg->setChild(true);
     join_alg->initialize();
 
-    for (auto const &factor : efficiencyFactors) {
-      std::vector<double> x{0.1, 0.2, 0.3, 0.4, 0.5};
-      std::vector<double> y{0.001, 0.02, 0.4, 0.02, 0.1};
-      std::vector<double> e{0.00001, 0.0002, 0.004, 0.0002, 0.001};
-
-      Points xVals(x);
-      Counts yVals(y);
-      CountStandardDeviations eVals(e.empty() ? std::vector<double>(y.size()) : e);
+    for (auto const &label : axisLabels) {
+      Points xVals(lambda);
+      Counts yVals(efficiencyFactors[label]);
+      CountStandardDeviations eVals(std::vector<double>(efficiencyFactors[label].size()));
       auto factorWs = std::make_shared<Workspace2D>();
       factorWs->initialize(1, Histogram(xVals, yVals, eVals));
 
-      join_alg->setProperty(factor, factorWs);
+      join_alg->setProperty(label, factorWs);
     }
     join_alg->setPropertyValue("OutputWorkspace", "efficiencies");
     join_alg->execute();

--- a/Framework/Reflectometry/test/ReflectometryReductionOneAuto3Test.h
+++ b/Framework/Reflectometry/test/ReflectometryReductionOneAuto3Test.h
@@ -1176,6 +1176,49 @@ public:
     ADS.clear();
   }
 
+  void test_polarization_correction_with_efficiency_workspace_Fredrikze_PNR() {
+
+    std::string const name = "input";
+    prepareInputGroup(name, "Fredrikze", 2);
+    auto efficiencies = createPolarizationEfficienciesWorkspace("Fredrikze");
+
+    ReflectometryReductionOneAuto3 alg;
+    alg.initialize();
+    alg.setPropertyValue("InputWorkspace", name);
+    alg.setProperty("ThetaIn", 10.0);
+    alg.setProperty("WavelengthMin", 1.0);
+    alg.setProperty("WavelengthMax", 15.0);
+    alg.setProperty("ProcessingInstructions", "2");
+    alg.setProperty("MomentumTransferStep", 0.04);
+    alg.setProperty("PolarizationAnalysis", true);
+    alg.setProperty("PolarizationEfficiencies", efficiencies);
+    alg.setPropertyValue("OutputWorkspace", "IvsQ");
+    alg.setPropertyValue("OutputWorkspaceBinned", "IvsQ_binned");
+    alg.setPropertyValue("OutputWorkspaceWavelength", "IvsLam");
+    alg.execute();
+
+    auto outQGroup = retrieveOutWS("IvsQ");
+    auto outLamGroup = retrieveOutWS("IvsLam");
+
+    TS_ASSERT_EQUALS(outQGroup.size(), 2);
+    TS_ASSERT_EQUALS(outLamGroup.size(), 2);
+
+    TS_ASSERT_EQUALS(outLamGroup[0]->blocksize(), 9);
+    // X range in outLam
+    TS_ASSERT_DELTA(outLamGroup[0]->x(0).front(), 2.0729661466, 0.0001);
+    TS_ASSERT_DELTA(outLamGroup[0]->x(0).back(), 14.2963182408, 0.0001);
+
+    TS_ASSERT_DELTA(outLamGroup[0]->y(0)[0], 1.4062, 0.0001);
+    TS_ASSERT_DELTA(outLamGroup[1]->y(0)[0], 0.2813, 0.0001);
+
+    TS_ASSERT_EQUALS(outQGroup[0]->blocksize(), 9);
+
+    TS_ASSERT_DELTA(outQGroup[0]->y(0)[0], 1.4062, 0.0001);
+    TS_ASSERT_DELTA(outQGroup[1]->y(0)[0], 0.2813, 0.0001);
+
+    ADS.clear();
+  }
+
   void test_polarization_correction_with_efficiency_workspace_Wildes() {
 
     std::string const name = "input";
@@ -1219,6 +1262,49 @@ public:
     TS_ASSERT_DELTA(outQGroup[1]->y(0)[0], 0.4330, 0.0001);
     TS_ASSERT_DELTA(outQGroup[2]->y(0)[0], 0.9766, 0.0001);
     TS_ASSERT_DELTA(outQGroup[3]->y(0)[0], 0.7544, 0.0001);
+
+    ADS.clear();
+  }
+
+  void test_polarization_correction_with_efficiency_workspace_Wildes_no_analyser() {
+
+    std::string const name = "input";
+    prepareInputGroup(name, "Wildes", 2);
+    auto efficiencies = createPolarizationEfficienciesWorkspace("Wildes");
+
+    ReflectometryReductionOneAuto3 alg;
+    alg.initialize();
+    alg.setPropertyValue("InputWorkspace", name);
+    alg.setProperty("ThetaIn", 10.0);
+    alg.setProperty("WavelengthMin", 1.0);
+    alg.setProperty("WavelengthMax", 15.0);
+    alg.setProperty("ProcessingInstructions", "2");
+    alg.setProperty("MomentumTransferStep", 0.04);
+    alg.setProperty("PolarizationAnalysis", true);
+    alg.setProperty("PolarizationEfficiencies", efficiencies);
+    alg.setPropertyValue("OutputWorkspace", "IvsQ");
+    alg.setPropertyValue("OutputWorkspaceBinned", "IvsQ_binned");
+    alg.setPropertyValue("OutputWorkspaceWavelength", "IvsLam");
+    alg.execute();
+
+    auto outQGroup = retrieveOutWS("IvsQ");
+    auto outLamGroup = retrieveOutWS("IvsLam");
+
+    TS_ASSERT_EQUALS(outQGroup.size(), 2);
+    TS_ASSERT_EQUALS(outLamGroup.size(), 2);
+
+    TS_ASSERT_EQUALS(outLamGroup[0]->blocksize(), 9);
+    // X range in outLam
+    TS_ASSERT_DELTA(outLamGroup[0]->x(0).front(), 2.0729661466, 0.0001);
+    TS_ASSERT_DELTA(outLamGroup[0]->x(0).back(), 14.2963182408, 0.0001);
+
+    TS_ASSERT_DELTA(outLamGroup[0]->y(0)[0], 0.7554, 0.0001);
+    TS_ASSERT_DELTA(outLamGroup[1]->y(0)[0], 0.9161, 0.0001);
+
+    TS_ASSERT_EQUALS(outQGroup[0]->blocksize(), 9);
+
+    TS_ASSERT_DELTA(outQGroup[0]->y(0)[0], 0.7554, 0.0001);
+    TS_ASSERT_DELTA(outQGroup[1]->y(0)[0], 0.9161, 0.0001);
 
     ADS.clear();
   }


### PR DESCRIPTION
**Description of work.**

Makes the algorithm changes required for issue #34744. The GUI side of the work will be added in a separate PR.

`ReflectometryReductionOneAuto` now optionally takes a workspace containing the polarization analysis efficiency factors so that values can now be supplied this way instead of via the parameter file, if preferred.

`ReflectometryISISLoadAndProcess` has been updated so that the user can supply the name of either a workspace in the ADS or a file name to be loaded and passed to `ReflectometryReductionOneAuto` as the polarization efficiency workspace.

The method of polarization correction to be applied is inferred from the efficiency workspace labels, although I've left full validation of the efficiency workspace to the algorithms that it is passed to later in the process. The correction method (analysis mode/flipper configuration) is inferred from the input workspace group.

As explained on the issue, the changes are required to be available in a nightly build by 9th December. I've added unit tests but there is quite a bit of duplication in the tests for `ReflectometryReductionOneAuto`. Given the time constraint, I felt this could be improved in a follow-up PR to allow the rest of the work to progress.

**To test:**

1) Run the `ReflectometryISISLoadAndProcess` algorithm using the POLREF test data provided by Andrew (check with Rachel about this). Test running the algorithm with `PolarizationAnalysis` ticked and the test file name entered into `PolarizationEfficiencies`. There should be two IvsLam workspaces in the IvsLam output group, one with suffix `_--` and the other with suffix `_++`.
1) Load the test file name as a workspace into the ADS with a new name. Run the algorithm again using the workspace name for the `PolarizationEfficiencies` parameters to check it is picked up from the ADS.
1) Check that sensible error messages are displayed if an invalid name is provided for `PolarizationEfficiencies`.
1) Check that polarization correction is not applied if the `PolarizationAnalysis` option is unticked, regardless of whether or not a value is provided to `PolarizationEfficiencies`. This can be checked by looking at the suffixes for workspaces in the IvsLam group (see step 1).
1) Check that with `PolarizationAnalysis` ticked and `PolarizationEfficiencies` left blank, the efficiency factors are looked up from the parameter file (POLREF doesn't have the necessary information defined in the parameter file, so you should expect this to fail with error "Correction method is undefined").
1) Check that running a normal reduction and preview reduction via the interface still works as it did previously.


Refs #34744. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->


*This does not require release notes* because **they should be added in the PR that includes the GUI side of the changes.**

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
