### PR TITLE
Update h5py

### DIFF
--- a/Framework/API/inc/MantidAPI/IBoxControllerIO.h
+++ b/Framework/API/inc/MantidAPI/IBoxControllerIO.h
@@ -37,6 +37,8 @@ public:
   virtual bool isOpened() const = 0;
   /**@return the full name of the used data file*/
   virtual const std::string &getFileName() const = 0;
+  /** Copy the file contents to a new location. */
+  virtual void copyFileTo(const std::string &destFilename) = 0;
 
   /**Save a float data block in the specified file position */
   virtual void saveBlock(const std::vector<float> & /* DataBlock */, const uint64_t /*blockPosition*/) const = 0;

--- a/Framework/DataObjects/inc/MantidDataObjects/BoxControllerNeXusIO.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/BoxControllerNeXusIO.h
@@ -32,6 +32,9 @@ public:
   bool isOpened() const override { return m_File.get() != nullptr; }
   /// get the full file name of the file used for IO operations
   const std::string &getFileName() const override { return m_fileName; }
+  /** Copy the file contents to a new location. */
+  void copyFileTo(const std::string &destFilename) override;
+
   /**Return the size of the NeXus data block used in NeXus data array*/
   size_t getDataChunk() const override { return m_dataChunk; }
 

--- a/Framework/DataObjects/test/BoxControllerNeXusIOTest.h
+++ b/Framework/DataObjects/test/BoxControllerNeXusIOTest.h
@@ -38,12 +38,12 @@ public:
       Poco::File(FullPathFile).remove();
   }
 
+  void test_constructor_does_not_throw() { TS_ASSERT_THROWS_NOTHING(createTestBoxController()); }
+
   void test_constructor_setters() {
     using Mantid::DataObjects::BoxControllerNeXusIO;
     using EDV = Mantid::DataObjects::BoxControllerNeXusIO::EventDataVersion;
-
-    BoxControllerNeXusIO *pSaver(nullptr);
-    TS_ASSERT_THROWS_NOTHING(pSaver = createTestBoxController());
+    auto pSaver = createTestBoxController();
 
     size_t CoordSize;
     std::string typeName;
@@ -74,16 +74,13 @@ public:
     pSaver->setDataType(CoordSize, "MDEvent");
     TS_ASSERT_THROWS_NOTHING(pSaver->setEventDataVersion(EDV::EDVOriginal));
     TS_ASSERT_EQUALS(EDV::EDVOriginal, pSaver->getEventDataVersion());
-
-    delete pSaver;
   }
 
   void test_eventDataVersion() {
     // initialization
     using Mantid::DataObjects::BoxControllerNeXusIO;
     using EDV = Mantid::DataObjects::BoxControllerNeXusIO::EventDataVersion;
-    BoxControllerNeXusIO *pSaver(nullptr);
-    TS_ASSERT_THROWS_NOTHING(pSaver = createTestBoxController());
+    auto pSaver = createTestBoxController();
 
     // valid values
     std::map<EDV, size_t> traitsCountToEDV = {{EDV::EDVLean, 2}, {EDV::EDVOriginal, 4}, {EDV::EDVGoniometer, 5}};
@@ -94,7 +91,6 @@ public:
     std::vector<size_t> invalids{3, 6, 7, 8, 9, 42};
     for (auto const &invalid : invalids)
       TS_ASSERT_THROWS(pSaver->setEventDataVersion(invalid), const std::invalid_argument &)
-    delete pSaver;
   }
 
   void test_CreateOrOpenFile() {
@@ -103,8 +99,7 @@ public:
     using Mantid::DataObjects::BoxControllerNeXusIO;
     using Mantid::Kernel::Exception::FileError;
 
-    BoxControllerNeXusIO *pSaver(nullptr);
-    TS_ASSERT_THROWS_NOTHING(pSaver = createTestBoxController());
+    auto pSaver = createTestBoxController();
     pSaver->setDataType(sizeof(coord_t), "MDLeanEvent");
     std::string FullPathFile;
 
@@ -133,7 +128,6 @@ public:
     TS_ASSERT_THROWS_NOTHING(pSaver->closeFile());
     TS_ASSERT(!pSaver->isOpened());
 
-    delete pSaver;
     if (Poco::File(FullPathFile).exists())
       Poco::File(FullPathFile).remove();
   }
@@ -141,8 +135,7 @@ public:
   void test_free_space_index_is_written_out_and_read_in() {
     using Mantid::DataObjects::BoxControllerNeXusIO;
 
-    BoxControllerNeXusIO *pSaver(nullptr);
-    TS_ASSERT_THROWS_NOTHING(pSaver = createTestBoxController());
+    auto pSaver = createTestBoxController();
     std::string FullPathFile;
 
     TS_ASSERT_THROWS_NOTHING(pSaver->openFile(this->xxfFileName, "w"));
@@ -167,7 +160,6 @@ public:
 
     TS_ASSERT_THROWS_NOTHING(pSaver->closeFile());
 
-    delete pSaver;
     if (Poco::File(FullPathFile).exists())
       Poco::File(FullPathFile).remove();
   }
@@ -208,8 +200,7 @@ public:
   template <typename FROM, typename TO> void WriteReadRead() {
     using Mantid::DataObjects::BoxControllerNeXusIO;
 
-    BoxControllerNeXusIO *pSaver(nullptr);
-    TS_ASSERT_THROWS_NOTHING(pSaver = createTestBoxController());
+    auto pSaver = createTestBoxController();
     pSaver->setDataType(sizeof(FROM), "MDEvent");
     std::string FullPathFile;
 
@@ -228,7 +219,7 @@ public:
 
     TS_ASSERT_THROWS_NOTHING(pSaver->saveBlock(toWrite, 100));
 
-    IF<FROM, TO>::compareReadTheSame(pSaver, toWrite, nEvents, nColumns);
+    IF<FROM, TO>::compareReadTheSame(pSaver.get(), toWrite, nEvents, nColumns);
 
     // open and read what was written,
     pSaver->setDataType(sizeof(TO), "MDEvent");
@@ -239,7 +230,7 @@ public:
       TS_ASSERT_DELTA(toWrite[(nEvents - 1) * nColumns + i], toRead2[i], 1.e-6);
     }
 
-    delete pSaver;
+    pSaver->closeFile();
     if (Poco::File(FullPathFile).exists())
       Poco::File(FullPathFile).remove();
   }
@@ -255,8 +246,7 @@ public:
     using EDV = BoxControllerNeXusIO::EventDataVersion;
 
     // MDEvents, where the dimensionality of the event coordinates is 4
-    BoxControllerNeXusIO *pSaver(nullptr);
-    TS_ASSERT_THROWS_NOTHING(pSaver = createTestBoxController());
+    auto pSaver = createTestBoxController();
 
     // MDEvent cannot accept EDVLean
     TS_ASSERT_THROWS(pSaver->setEventDataVersion(EDV::EDVLean), const std::invalid_argument &);
@@ -267,8 +257,6 @@ public:
     TS_ASSERT_EQUALS(pSaver->dataEventCount(), dataSizePerEvent - 1);
     pSaver->setEventDataVersion(EDV::EDVGoniometer);
     TS_ASSERT_EQUALS(pSaver->dataEventCount(), dataSizePerEvent);
-
-    delete (pSaver);
   }
 
   void test_adjustEventDataBlock() {
@@ -277,8 +265,7 @@ public:
     using EDV = BoxControllerNeXusIO::EventDataVersion;
 
     // MDEvents, where the dimensionality of the event coordinates is 4
-    BoxControllerNeXusIO *pSaver(nullptr);
-    TS_ASSERT_THROWS_NOTHING(pSaver = createTestBoxController());
+    auto pSaver = createTestBoxController();
 
     // We're dealing with an old Nexus file
     pSaver->setEventDataVersion(EDV::EDVOriginal);
@@ -309,7 +296,7 @@ public:
 
 private:
   /// Create a Nexus reader/writer for boxController sc
-  Mantid::DataObjects::BoxControllerNeXusIO *createTestBoxController() {
-    return new Mantid::DataObjects::BoxControllerNeXusIO(sc.get());
+  std::unique_ptr<Mantid::DataObjects::BoxControllerNeXusIO> createTestBoxController() {
+    return std::make_unique<Mantid::DataObjects::BoxControllerNeXusIO>(sc.get());
   }
 };

--- a/Framework/DataObjects/test/BoxControllerNeXusIOTest.h
+++ b/Framework/DataObjects/test/BoxControllerNeXusIOTest.h
@@ -164,6 +164,21 @@ public:
       Poco::File(FullPathFile).remove();
   }
 
+  void test_copyToFile_successfully_copies_open_file_handle() {
+    using Mantid::DataObjects::BoxControllerNeXusIO;
+
+    auto pSaver = createTestBoxController();
+    pSaver->openFile(xxfFileName, "w");
+    const std::string destFilename(xxfFileName + "_copied");
+
+    TS_ASSERT_THROWS_NOTHING(pSaver->copyFileTo(destFilename));
+
+    TSM_ASSERT("File not copied successfully.", Poco::File(destFilename).exists());
+
+    if (Poco::File(destFilename).exists())
+      Poco::File(destFilename).remove();
+  }
+
   //---------------------------------------------------------------------------------------------------------
   // tests to read/write double/vs float events
   template <typename FROM, typename TO>

--- a/Framework/MDAlgorithms/src/SaveMD.cpp
+++ b/Framework/MDAlgorithms/src/SaveMD.cpp
@@ -143,7 +143,7 @@ template <typename MDE, size_t nd> void SaveMD::doSaveEvents(typename MDEventWor
       prepareUpdate<MDE, nd>(BoxFlatStruct, bc.get(), ws, filename);
       BoxFlatStruct.saveBoxStructure(filename);
     }
-    Poco::File(bc->getFilename()).copyTo(filename);
+    bc->getFileIO()->copyFileTo(filename);
   } else // not file backed;
   {
     // the boxes file positions are unknown and we need to calculate it.

--- a/Framework/MDAlgorithms/test/CMakeLists.txt
+++ b/Framework/MDAlgorithms/test/CMakeLists.txt
@@ -15,8 +15,7 @@ if(CXXTEST_FOUND)
   add_framework_test_helpers(MDAlgorithmsTest)
   add_dependencies(MDAlgorithmsTest DataHandling Algorithms CurveFitting)
   add_dependencies(FrameworkTests MDAlgorithmsTest)
-  # Test data
-  add_dependencies(MDAlgorithmsTest StandardTestData)
+  # Test data add_dependencies(MDAlgorithmsTest StandardTestData)
 
   # Add to the 'FrameworkTests' group in VS
   set_property(TARGET MDAlgorithmsTest PROPERTY FOLDER "UnitTests")

--- a/Framework/MDAlgorithms/test/CloneMDWorkspaceTest.h
+++ b/Framework/MDAlgorithms/test/CloneMDWorkspaceTest.h
@@ -77,12 +77,13 @@ public:
     {
       if (!Filename.empty()) {
         file1 = alg.getPropertyValue("Filename");
-        TS_ASSERT(Poco::File(file1).exists());
         file2 = ws1->getBoxController()->getFileIO()->getFileName();
       } else {
         file1 = ws1->getBoxController()->getFileIO()->getFileName();
         file2 = ws2->getBoxController()->getFileIO()->getFileName();
       }
+      TS_ASSERT(Poco::File(file1).exists());
+      TS_ASSERT(Poco::File(file2).exists());
     }
 
     // Clean up files

--- a/Framework/PythonInterface/test/python/plugins/algorithms/EnggSaveGSASIIFitResultsToHDF5Test.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/EnggSaveGSASIIFitResultsToHDF5Test.py
@@ -55,10 +55,10 @@ class EnggSaveGSASIIFitResultsToHDF5Test(unittest.TestCase):
             lattice_params_row = lattice_params.row(0)
 
             for param in self.LATTICE_PARAMS:
-                self.assertAlmostEqual(lattice_params_row[param], lattice_params_dataset[param].value)
+                self.assertAlmostEqual(lattice_params_row[param], lattice_params_dataset[param][()])
 
     def test_saveRefinementParameters(self):
-        refinement_method = "Rietveld refinement"
+        refinement_method = b"Rietveld refinement"
         x_min = 10000
         x_max = 40000
         lattice_params = self._create_lattice_params_table()
@@ -80,11 +80,11 @@ class EnggSaveGSASIIFitResultsToHDF5Test(unittest.TestCase):
             self.assertEqual(len(refinement_params), 5)
 
             # refinement_params is a tuple, so test that parameters are at the correct index
-            self.assertEqual(refinement_params["RefinementMethod"].value, refinement_method)
-            self.assertTrue(refinement_params["RefineSigma"].value)
-            self.assertFalse(refinement_params["RefineGamma"].value)
-            self.assertEqual(refinement_params["XMin"].value, x_min)
-            self.assertEqual(refinement_params["XMax"].value, x_max)
+            self.assertEqual(refinement_params["RefinementMethod"][()], refinement_method)
+            self.assertTrue(refinement_params["RefineSigma"][()])
+            self.assertFalse(refinement_params["RefineGamma"][()])
+            self.assertEqual(refinement_params["XMin"][()], x_min)
+            self.assertEqual(refinement_params["XMax"][()], x_max)
 
     def test_saveProfileCoefficients(self):
         sigma = 13
@@ -102,8 +102,8 @@ class EnggSaveGSASIIFitResultsToHDF5Test(unittest.TestCase):
             profile_coeffs = fit_results_group["Profile Coefficients"]
 
             self.assertEqual(len(profile_coeffs), 2)
-            self.assertEqual(profile_coeffs["Sigma"].value, sigma)
-            self.assertEqual(profile_coeffs["Gamma"].value, gamma)
+            self.assertEqual(profile_coeffs["Sigma"][()], sigma)
+            self.assertEqual(profile_coeffs["Gamma"][()], gamma)
 
     def test_profileCoeffsNotSavedWhenNotRefined(self):
         run_algorithm(self.ALG_NAME,
@@ -126,8 +126,8 @@ class EnggSaveGSASIIFitResultsToHDF5Test(unittest.TestCase):
             fit_results_group = output_file["Bank 1"]["GSAS-II Fitting"]
             refinement_params = fit_results_group["Refinement Parameters"]
             self.assertEqual(len(refinement_params), 7)
-            self.assertEqual(refinement_params["PawleyDMin"].value, d_min)
-            self.assertEqual(refinement_params["PawleyNegativeWeight"].value, negative_weight)
+            self.assertEqual(refinement_params["PawleyDMin"][()], d_min)
+            self.assertEqual(refinement_params["PawleyNegativeWeight"][()], negative_weight)
 
     def test_saveRwp(self):
         rwp = 75
@@ -139,7 +139,7 @@ class EnggSaveGSASIIFitResultsToHDF5Test(unittest.TestCase):
             fit_results_group = output_file["Bank 1"]["GSAS-II Fitting"]
             self.assertTrue("Rwp" in fit_results_group)
             rwp_from_file = fit_results_group["Rwp"]
-            self.assertEqual(rwp_from_file.value, rwp)
+            self.assertEqual(rwp_from_file[()], rwp)
 
     def test_saveToExistingFileDoesNotOverwrite(self):
         run_algorithm(self.ALG_NAME,

--- a/Framework/PythonInterface/test/python/plugins/algorithms/ExportSampleLogsToHDF5Test.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/ExportSampleLogsToHDF5Test.py
@@ -45,8 +45,8 @@ class ExportSampleLogsToHDF5Test(unittest.TestCase):
         with h5py.File(self.TEMP_FILE_NAME, "r") as output_file:
             self.assertTrue("Sample Logs" in output_file)
             logs_group = output_file["Sample Logs"]
-            self.assertEqual(logs_group["Test1"].value, 1.0)
-            self.assertEqual(logs_group["Test2"].value[0], b"Test2")
+            self.assertEqual(logs_group["Test1"][()], 1.0)
+            self.assertEqual(logs_group["Test2"][()], b"Test2")
 
     def test_blacklistExcludesLogs(self):
         input_ws = self._create_sample_workspace()
@@ -72,7 +72,7 @@ class ExportSampleLogsToHDF5Test(unittest.TestCase):
 
         with h5py.File(self.TEMP_FILE_NAME, "r") as output_file:
             logs_group = output_file["Sample Logs"]
-            self.assertEqual(logs_group["TestLog"].value, 1.5)
+            self.assertEqual(logs_group["TestLog"][()], 1.5)
 
     def test_unitAreAddedIfPresent(self):
         input_ws = self._create_sample_workspace()

--- a/Framework/TestHelpers/inc/MantidFrameworkTestHelpers/BoxControllerDummyIO.h
+++ b/Framework/TestHelpers/inc/MantidFrameworkTestHelpers/BoxControllerDummyIO.h
@@ -37,6 +37,7 @@ public:
   bool isOpened() const override { return (m_isOpened); }
   /// get the full file name of the file used for IO operations
   const std::string &getFileName() const override { return m_fileName; }
+  void copyFileTo(const std::string &) override {}
   /**Return the size of the NeXus data block used in NeXus data array*/
   size_t getDataChunk() const override { return 1; }
 

--- a/docs/source/release/v6.6.0/Framework/New_features/34806.rst
+++ b/docs/source/release/v6.6.0/Framework/New_features/34806.rst
@@ -1,0 +1,1 @@
+- HDF5 has been upgraded to v1.12 along with h5py to version 3.

--- a/docs/source/release/v6.6.0/framework.rst
+++ b/docs/source/release/v6.6.0/framework.rst
@@ -5,6 +5,10 @@ Framework Changes
 .. contents:: Table of Contents
    :local:
 
+New Features
+------------
+.. amalgamate:: Framework/New_features
+
 Algorithms
 ----------
 

--- a/mantid-developer-linux.yml
+++ b/mantid-developer-linux.yml
@@ -13,8 +13,8 @@ dependencies:
   - euphonic=0.6.*
   - graphviz>=2.47.0
   - gsl=2.7 # Keep gsl a specific version to reduce changes in our fitting
-  - h5py>=2.10.0,<3 # Pinned back due to api differences
-  - hdf5=1.10.*
+  - h5py
+  - hdf5
   - ipykernel<6 # Added as hard dependency only to deal with an issue with ipykernel v6 and incompatibility with qtconsole/workbench, was previously a soft dependency that was allowed to update to v6 by qtconsole, at present it stops workbench from loading.
   - jemalloc=5.2.0 # We have noticed 5.2.1 can cause a hang on older glibc versions (Cent OS 7, Ubuntu 18.04). Observed with import CaChannel and also our MeierTest.
   - jsoncpp>=1.9.4,<2

--- a/mantid-developer-linux.yml
+++ b/mantid-developer-linux.yml
@@ -14,7 +14,7 @@ dependencies:
   - graphviz>=2.47.0
   - gsl=2.7 # Keep gsl a specific version to reduce changes in our fitting
   - h5py
-  - hdf5
+  - hdf5>=1.12,<1.13
   - ipykernel<6 # Added as hard dependency only to deal with an issue with ipykernel v6 and incompatibility with qtconsole/workbench, was previously a soft dependency that was allowed to update to v6 by qtconsole, at present it stops workbench from loading.
   - jemalloc=5.2.0 # We have noticed 5.2.1 can cause a hang on older glibc versions (Cent OS 7, Ubuntu 18.04). Observed with import CaChannel and also our MeierTest.
   - jsoncpp>=1.9.4,<2

--- a/mantid-developer-osx.yml
+++ b/mantid-developer-osx.yml
@@ -12,8 +12,8 @@ dependencies:
   - euphonic=0.6.*
   - graphviz>=2.47.0
   - gsl=2.7 # Keep gsl a specific version to reduce changes in our fitting
-  - h5py>=2.10.0,<3 # Pinned back due to api differences
-  - hdf5=1.10.*
+  - h5py
+  - hdf5
   - ipykernel<6 # Added as hard dependency only to deal with an issue with ipykernel v6 and incompatibility with qtconsole/workbench, was previously a soft dependency that was allowed to update to v6 by qtconsole, at present it stops workbench from loading.
   - jemalloc>=5.2.1
   - jsoncpp>=1.9.4,<2

--- a/mantid-developer-osx.yml
+++ b/mantid-developer-osx.yml
@@ -13,7 +13,7 @@ dependencies:
   - graphviz>=2.47.0
   - gsl=2.7 # Keep gsl a specific version to reduce changes in our fitting
   - h5py
-  - hdf5
+  - hdf5>=1.12,<1.13
   - ipykernel<6 # Added as hard dependency only to deal with an issue with ipykernel v6 and incompatibility with qtconsole/workbench, was previously a soft dependency that was allowed to update to v6 by qtconsole, at present it stops workbench from loading.
   - jemalloc>=5.2.1
   - jsoncpp>=1.9.4,<2

--- a/mantid-developer-win.yml
+++ b/mantid-developer-win.yml
@@ -14,7 +14,7 @@ dependencies:
   - graphviz>=2.47.0
   - gsl=2.7 # Keep gsl a specific version to reduce changes in our fitting
   - h5py
-  - hdf5
+  - hdf5>=1.12,<1.13
   - ipykernel<6 # Added as hard dependency only to deal with an issue with ipykernel v6 and incompatibility with qtconsole/workbench, was previously a soft dependency that was allowed to update to v6 by qtconsole, at present it stops workbench from loading.
   - jsoncpp>=1.9.4,<2
   - librdkafka>=1.6.0

--- a/mantid-developer-win.yml
+++ b/mantid-developer-win.yml
@@ -13,8 +13,8 @@ dependencies:
   - euphonic=0.6.*
   - graphviz>=2.47.0
   - gsl=2.7 # Keep gsl a specific version to reduce changes in our fitting
-  - h5py>=2.10.0,<3 # Pinned back due to api differences
-  - hdf5=1.10.*
+  - h5py
+  - hdf5
   - ipykernel<6 # Added as hard dependency only to deal with an issue with ipykernel v6 and incompatibility with qtconsole/workbench, was previously a soft dependency that was allowed to update to v6 by qtconsole, at present it stops workbench from loading.
   - jsoncpp>=1.9.4,<2
   - librdkafka>=1.6.0

--- a/scripts/test/Abins/AbinsIOmoduleTest.py
+++ b/scripts/test/Abins/AbinsIOmoduleTest.py
@@ -86,10 +86,10 @@ class IOTest(unittest.TestCase):
 
         data = self.loader.load(list_of_datasets=["wheels", "chairs"])
 
-        self.assertEqual([{"Winter": False, "Punctured": False, "Brand": "Mercedes", "Age": 2},
-                          {"Winter": False, "Punctured": False, "Brand": "Mercedes", "Age": 3},
-                          {"Winter": False, "Punctured": False, "Brand": "Mercedes", "Age": 5},
-                          {"Winter": False, "Punctured": True,  "Brand": "Mercedes", "Age":  7}],
+        self.assertEqual([{"Winter": False, "Punctured": False, "Brand": b"Mercedes", "Age": 2},
+                          {"Winter": False, "Punctured": False, "Brand": b"Mercedes", "Age": 3},
+                          {"Winter": False, "Punctured": False, "Brand": b"Mercedes", "Age": 5},
+                          {"Winter": False, "Punctured": True,  "Brand": b"Mercedes", "Age":  7}],
                          data["datasets"]["wheels"])
 
         self.assertEqual({"AdjustableHeadrests": True, "ExtraPadding": True},


### PR DESCRIPTION
**Note to gatekeepers: Please also merge mantidproject/conda-recipes#89 when this is merged.**

**Description of work.**

Remove ancient h5py/hdf5 pin and move to HDF5 1.12/h5py.

**To test:**

* Code review and all automated tests should pass. HDF5 is core to all NeXus loading so any failures would be picked up by the wealth of tests that load/save files.

Fixes #34731 

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
