### PR TITLE
Fix problem with beam arrow not showing when sample shape loaded from file

### DIFF
--- a/qt/python/mantidqt/mantidqt/plotting/sample_shape.py
+++ b/qt/python/mantidqt/mantidqt/plotting/sample_shape.py
@@ -326,7 +326,6 @@ def set_perspective(plot_axes, workspace=None, beam_direction=None):
         # guess the original beam_direction and raise warning
         plot_axes.view_init(vertical_axis='y', elev=30, azim=-135)
         raise Exception("set_perspective must be called with either beam_direction or a workspace")
-
     if direction_not_valid(beam_direction):
         frame = workspace.getInstrument().getReferenceFrame()
         if frame.pointingUpAxis() == "Y" and frame.pointingAlongBeamAxis() == "Z":
@@ -426,7 +425,7 @@ def add_beam_arrow(plot_axes, workspace):
     # Add arrow along beam direction
     source = workspace.getInstrument().getSource()
     sample = workspace.getInstrument().getSample()
-    if source and sample:
+    if source is not None and sample is not None:
         beam_origin = plot_axes.get_xlim3d()[0], plot_axes.get_ylim3d()[0], plot_axes.get_zlim3d()[0]
         beam_direction = calculate_beam_direction(source, sample)
         add_arrow(plot_axes, beam_direction, origin=beam_origin)

--- a/qt/python/mantidqt/mantidqt/plotting/test/test_sample_shape.py
+++ b/qt/python/mantidqt/mantidqt/plotting/test/test_sample_shape.py
@@ -9,6 +9,8 @@
 #
 
 from numpy.testing import assert_array_equal, assert_allclose
+from os import path, remove
+from tempfile import gettempdir
 from unittest import TestCase, main
 from unittest.mock import patch, Mock
 import numpy as np
@@ -18,7 +20,7 @@ matplotlib.use('AGG')  # noqa
 import mantid
 from mantid.api import AnalysisDataService as ADS
 from mantid.simpleapi import (CreateWorkspace, CreateSampleWorkspace, SetSample, LoadSampleShape, DeleteWorkspace,
-                              LoadInstrument, SetUB, RenameWorkspace)
+                              LoadInstrument, SetUB, RenameWorkspace, LoadNexus, SaveNexusESS)
 from mantidqt.plotting import sample_shape
 from workbench.plotting.globalfiguremanager import FigureAction, GlobalFigureManager
 
@@ -320,6 +322,17 @@ class PlotSampleShapeTest(TestCase):
         figure = sample_shape.plot_sample_container_and_components(workspace.name())
         self.assertTrue(figure)
         self.assertEqual(1, mock_add_arrow.call_count)
+
+    @patch("mantidqt.plotting.sample_shape.add_arrow")
+    def test_add_arrow_called_once_for_nexus_ws(self, mock_add_arrow):
+        workspace = CreateSampleWorkspace(OutputWorkspace="ws_shape")
+        temp_file_name = path.join(gettempdir(), 'ws_shape.nxs')
+        SaveNexusESS(workspace, temp_file_name)
+        workspace = LoadNexus(temp_file_name)
+        figure = sample_shape.plot_sample_container_and_components(workspace.name())
+        self.assertTrue(figure)
+        self.assertEqual(1, mock_add_arrow.call_count)
+        remove(temp_file_name)
 
     @patch("mantidqt.plotting.sample_shape.call_set_mesh_axes_equal")
     @patch("mantidqt.plotting.sample_shape.add_beam_arrow")


### PR DESCRIPTION
**Description of work.**

Modify check on whether source and sample present before beam arrow is plotted

Previous check involved casting source and sample to boolean. If either object implemented `__len__` then (as is case for ICompAssembly) then there was a chance a valid source or sample ptr could evaluate the false if `__len__`=0

I noticed this while loading a workspace containing a sample shape from a .nxs file that I'd created using the SaveNexusESS algorithm. I use this save algorithm because it saves the instrument geometry inside the .nxs file without requiring an IDF file and that's useful when the instrument geometry has been created using a the WorkspaceCreationHelper class.

I think the source and sample in a workspace that are loaded from an ESS .nxs file are of type ICompAssembly due to the code in InstrumentBuilder::addComponent. For most sources\samples this won't have any children meaning `__len__` is zero. It's not very clear to me why InstrumentBuilder chooses to use the ICompAssembly class for things like source\sample but since the shape plotting can be made to work using this fix I've not investigated changing InstrumentBuilder.

**To test:**

1) Run the lines up to and including call to SetSample in the following script
2) Right click on ws and select show sample
3) Observe beam arrow present
4) Run remaining lines that save ws to a file and reload it
5) Right click on ws and select show sample
6) Observe beam arrow still present

```
# import mantid algorithms, numpy and matplotlib
from mantid.simpleapi import *
import matplotlib.pyplot as plt
import numpy as np
from mpl_toolkits.mplot3d.art3d import Poly3DCollection

cuboid = " \
<cuboid id='some-cuboid'> \
<height val='2.0'  /> \
<width val='2.0' />  \
<depth  val='0.2' />  \
<centre x='10.0' y='10.0' z='10.0'  />  \
</cuboid>  \
<algebra val='some-cuboid' /> \
"

ws = CreateSampleWorkspace()
SetGoniometer(ws, Axis0="45,0,1,0,-1")
SetSample(ws, Geometry={'Shape': 'CSG', 'Value': cuboid})

SaveNexusESS(ws,'test_ws.nxs')
mtd.clear()
ws = LoadNexus('test_ws.nxs')
```

*There is no associated issue.*

*This does not require release notes* because **problem relates to show sample shape functionality added during this release**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
