### PR TITLE
Updated property handler to remove and rename ties when a function is removed from the fitting widget

### DIFF
--- a/docs/source/release/v6.6.0/Workbench/Bugfixes/31662.rst
+++ b/docs/source/release/v6.6.0/Workbench/Bugfixes/31662.rst
@@ -1,0 +1,1 @@
+- Removing a function from the fitting widget will now remove any ties involving that function and update ties, as function names may change. Before, this was happening behind the scenes but now the GUI updates to reflect that.

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/PropertyHandler.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/PropertyHandler.h
@@ -54,7 +54,7 @@ public:
   // properties from the browser
   void removeFunction();
 
-  void renameChildren(std::shared_ptr<Mantid::API::CompositeFunction> cf);
+  void renameChildren(const Mantid::API::CompositeFunction &cf);
 
   /// Creates name for this function to be displayed
   /// in the browser

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/PropertyHandler.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/PropertyHandler.h
@@ -54,7 +54,7 @@ public:
   // properties from the browser
   void removeFunction();
 
-  void renameChildren() const;
+  void renameChildren(std::shared_ptr<Mantid::API::CompositeFunction> cf);
 
   void refreshTies();
 

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/PropertyHandler.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/PropertyHandler.h
@@ -56,8 +56,6 @@ public:
 
   void renameChildren(std::shared_ptr<Mantid::API::CompositeFunction> cf);
 
-  void refreshTies();
-
   /// Creates name for this function to be displayed
   /// in the browser
   QString functionName() const;

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/PropertyHandler.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/PropertyHandler.h
@@ -56,6 +56,8 @@ public:
 
   void renameChildren() const;
 
+  void refreshTies();
+
   /// Creates name for this function to be displayed
   /// in the browser
   QString functionName() const;

--- a/qt/widgets/common/src/PropertyHandler.cpp
+++ b/qt/widgets/common/src/PropertyHandler.cpp
@@ -461,19 +461,19 @@ void PropertyHandler::removeFunction() {
         break;
       }
     }
-    ph->renameChildren(cf);
+    ph->renameChildren(*cf);
     m_browser->setFitEnabled(cf->nFunctions() > 0);
   }
 }
 
-void PropertyHandler::renameChildren(std::shared_ptr<Mantid::API::CompositeFunction> cf) {
+void PropertyHandler::renameChildren(const Mantid::API::CompositeFunction &cf) {
   m_browser->m_changeSlotsEnabled = false;
   QMap<QString, QtProperty *>::const_iterator it = m_ties.begin();
   for (; it != m_ties.end(); ++it) {
     QString parName = it.key();
     QString fullName = functionPrefix() + "." + parName;
     QtProperty *prop = it.value();
-    Mantid::API::ParameterTie *tie = cf->getTie(cf->parameterIndex(fullName.toStdString()));
+    Mantid::API::ParameterTie *tie = cf.getTie(cf.parameterIndex(fullName.toStdString()));
     if (!tie) {
       // In this case the tie has been removed from the composite function since it contained a refference to
       // the function which was removed

--- a/qt/widgets/common/src/PropertyHandler.cpp
+++ b/qt/widgets/common/src/PropertyHandler.cpp
@@ -462,38 +462,7 @@ void PropertyHandler::removeFunction() {
       }
     }
     ph->renameChildren(cf);
-    // ph->refreshTies();
     m_browser->setFitEnabled(cf->nFunctions() > 0);
-  }
-}
-
-void PropertyHandler::refreshTies() {
-  if (m_cf) {
-    m_browser->m_changeSlotsEnabled = false;
-    for (int i = 0; i < m_cf->nFunctions(); i++) {
-      PropertyHandler *h = getHandler(i);
-      QMap<QString, QtProperty *> ties = h->getTies();
-      for (QString paramName : ties.keys()) {
-        QString fullName = h->functionPrefix() + "." + paramName;
-        size_t paramIndex = m_cf->parameterIndex(fullName.toStdString());
-        const auto tie = m_cf->getTie(paramIndex);
-        QtProperty *prop = ties[paramName];
-        if (!tie) { // tie has been removed from function so needs to removed from gui
-          QtProperty *paramProp = h->getParameterProperty(paramName);
-          if (paramProp != nullptr) {
-            paramProp->removeSubProperty(prop);
-            ties.remove(paramName);
-            paramProp->setEnabled(true);
-          }
-        } else {
-          QStringList tie_strs = QString::fromStdString(tie->asString()).split("=");
-          if (tie_strs.size() < 2)
-            continue;
-          m_browser->m_stringManager->setValue(prop, tie_strs[1]);
-        }
-      }
-    }
-    m_browser->m_changeSlotsEnabled = true;
   }
 }
 

--- a/qt/widgets/common/src/PropertyHandler.cpp
+++ b/qt/widgets/common/src/PropertyHandler.cpp
@@ -468,22 +468,24 @@ void PropertyHandler::removeFunction() {
 
 void PropertyHandler::renameChildren(const Mantid::API::CompositeFunction &cf) {
   m_browser->m_changeSlotsEnabled = false;
-  QMap<QString, QtProperty *>::const_iterator it = m_ties.begin();
-  for (; it != m_ties.end(); ++it) {
+  for (auto it = m_ties.begin(); it != m_ties.end();) {
     QString parName = it.key();
     QString fullName = functionPrefix() + "." + parName;
     QtProperty *prop = it.value();
     Mantid::API::ParameterTie *tie = cf.getTie(cf.parameterIndex(fullName.toStdString()));
     if (!tie) {
-      // In this case the tie has been removed from the composite function since it contained a refference to
+      // In this case the tie has been removed from the composite function since it contained a reference to
       // the function which was removed
       QtProperty *parProp = getParameterProperty(parName);
       if (parProp != nullptr) {
         parProp->removeSubProperty(prop);
-        m_ties.remove(parName);
+        // Don't increment the iterator if we delete the current tie.
+        it = m_ties.erase(it);
         parProp->setEnabled(true);
       }
       continue;
+    } else {
+      ++it;
     }
     // Refresh gui value in case it has been updated by the composite function re-indexing it's functions
     // after one is removed

--- a/qt/widgets/common/src/PropertyHandler.cpp
+++ b/qt/widgets/common/src/PropertyHandler.cpp
@@ -485,7 +485,7 @@ void PropertyHandler::renameChildren(const Mantid::API::CompositeFunction &cf) {
       }
       continue;
     }
-    // Refresh gui value incase it has been updated by the composite function re-indexing it's functions
+    // Refresh gui value in case it has been updated by the composite function re-indexing it's functions
     // after one is removed
     QStringList qtie = QString::fromStdString(tie->asString()).split("=");
     if (qtie.size() < 2)

--- a/qt/widgets/common/src/PropertyHandler.cpp
+++ b/qt/widgets/common/src/PropertyHandler.cpp
@@ -462,7 +462,38 @@ void PropertyHandler::removeFunction() {
       }
     }
     ph->renameChildren();
+    ph->refreshTies();
     m_browser->setFitEnabled(cf->nFunctions() > 0);
+  }
+}
+
+void PropertyHandler::refreshTies() {
+  if (m_cf) {
+    m_browser->m_changeSlotsEnabled = false;
+    for (int i = 0; i < m_cf->nFunctions(); i++) {
+      PropertyHandler *h = getHandler(i);
+      QMap<QString, QtProperty *> ties = h->getTies();
+      for (QString paramName : ties.keys()) {
+        QString fullName = h->functionPrefix() + "." + paramName;
+        size_t paramIndex = m_cf->parameterIndex(fullName.toStdString());
+        const auto tie = m_cf->getTie(paramIndex);
+        QtProperty *prop = ties[paramName];
+        if (!tie) { // tie has been removed from function so needs to removed from gui
+          QtProperty *paramProp = h->getParameterProperty(paramName);
+          if (paramProp != nullptr) {
+            paramProp->removeSubProperty(prop);
+            ties.remove(paramName);
+            paramProp->setEnabled(true);
+          }
+        } else {
+          QStringList tie_strs = QString::fromStdString(tie->asString()).split("=");
+          if (tie_strs.size() < 2)
+            continue;
+          m_browser->m_stringManager->setValue(prop, tie_strs[1]);
+        }
+      }
+    }
+    m_browser->m_changeSlotsEnabled = true;
   }
 }
 
@@ -476,8 +507,8 @@ void PropertyHandler::renameChildren() const {
     Mantid::API::ParameterTie *tie = m_fun->getTie(m_fun->parameterIndex(parName.toStdString()));
     if (!tie) {
       // remove gui tie
-      QtProperty *parProp = getParameterProperty(parName);
-      parProp->removeSubProperty(prop);
+      // QtProperty *parProp = getParameterProperty(parName);
+      // parProp->removeSubProperty(prop);
       continue;
     }
     QStringList qtie = QString::fromStdString(tie->asString()).split("=");

--- a/qt/widgets/common/src/PropertyHandler.cpp
+++ b/qt/widgets/common/src/PropertyHandler.cpp
@@ -471,10 +471,15 @@ void PropertyHandler::renameChildren() const {
   // update tie properties, as the parameter names may change
   QMap<QString, QtProperty *>::const_iterator it = m_ties.begin();
   for (; it != m_ties.end(); ++it) {
+    QString parName = it.key();
     QtProperty *prop = it.value();
-    Mantid::API::ParameterTie *tie = m_fun->getTie(m_fun->parameterIndex(it.key().toStdString()));
-    if (!tie)
+    Mantid::API::ParameterTie *tie = m_fun->getTie(m_fun->parameterIndex(parName.toStdString()));
+    if (!tie) {
+      // remove gui tie
+      QtProperty *parProp = getParameterProperty(parName);
+      parProp->removeSubProperty(prop);
       continue;
+    }
     QStringList qtie = QString::fromStdString(tie->asString()).split("=");
     if (qtie.size() < 2)
       continue;

--- a/qt/widgets/common/test/FitPropertyBrowserTest.h
+++ b/qt/widgets/common/test/FitPropertyBrowserTest.h
@@ -113,7 +113,6 @@ public:
         "name=Gaussian,Height=10.0,PeakCentre=-0.145,Sigma=0.135;name=FlatBackground,A0=10;"
         "ties=(f0.Height=f1.A0)");
     auto f0Handler = m_fitPropertyBrowser->getPeakHandler(QString("f0"));
-    auto f1Handler = m_fitPropertyBrowser->getPeakHandler(QString("f1"));
     TS_ASSERT(QString("f0-Gaussian") == f0Handler->functionName());
     m_fitPropertyBrowser->removeFunction(f0Handler);
     // f0 should now be the flat background function

--- a/qt/widgets/common/test/FitPropertyBrowserTest.h
+++ b/qt/widgets/common/test/FitPropertyBrowserTest.h
@@ -113,7 +113,7 @@ public:
         "name=Gaussian,Height=10.0,PeakCentre=-0.145,Sigma=0.135;name=FlatBackground,A0=10;"
         "ties=(f0.Height=f1.A0)");
     auto f0Handler = m_fitPropertyBrowser->getPeakHandler(QString("f0"));
-    TS_ASSERT(QString("f0-Gaussian") == f0Handler->functionName());
+    TS_ASSERT_EQUALS(QString("f0-Gaussian"), f0Handler->functionName());
     m_fitPropertyBrowser->removeFunction(f0Handler);
     // f0 should now be the flat background function
     f0Handler = m_fitPropertyBrowser->getPeakHandler(QString("f0"));

--- a/qt/widgets/common/test/FitPropertyBrowserTest.h
+++ b/qt/widgets/common/test/FitPropertyBrowserTest.h
@@ -104,6 +104,7 @@ public:
     auto f1Handler = m_fitPropertyBrowser->getPeakHandler(QString("f1"));
     TS_ASSERT(f0Handler->hasTies());
     m_fitPropertyBrowser->removeFunction(f1Handler);
+    f0Handler = m_fitPropertyBrowser->getPeakHandler(QString("f0"));
     TS_ASSERT(!f0Handler->hasTies());
   }
 

--- a/qt/widgets/common/test/FitPropertyBrowserTest.h
+++ b/qt/widgets/common/test/FitPropertyBrowserTest.h
@@ -125,13 +125,20 @@ public:
     m_fitPropertyBrowser->init();
     m_fitPropertyBrowser->createCompositeFunction(
         "name=Gaussian,Height=10.0,PeakCentre=-0.145,Sigma=0.135;name=FlatBackground,A0=10;"
-        "name=Gaussian,Height=10.0,PeakCentre=-0.555,Sigma=0.135;ties=(f0.Height=f2.Height)");
+        "name=Gaussian,Height=10.0,PeakCentre=-0.555,Sigma=0.135;ties=(f0.Height=f2.Sigma)");
+    auto cf = m_fitPropertyBrowser->compositeFunction();
     auto f0Handler = m_fitPropertyBrowser->getPeakHandler(QString("f0"));
     auto f1Handler = m_fitPropertyBrowser->getPeakHandler(QString("f1"));
-    TS_ASSERT_EQUALS(m_fitPropertyBrowser->getOldExpressionAsString(QString("f0.Height")), QString("f2.Height"));
+    auto tie = cf->getTie(cf->parameterIndex("f0.Height"));
+    std::string tie_str = tie->asString();
+    TS_ASSERT_EQUALS(tie_str.substr(tie_str.find("=") + 1), "f2.Sigma");
+
     m_fitPropertyBrowser->removeFunction(f1Handler);
+
     TS_ASSERT(f0Handler->hasTies());
-    TS_ASSERT_EQUALS(m_fitPropertyBrowser->getOldExpressionAsString(QString("f0.Height")), QString("f1.Height"));
+    tie = cf->getTie(cf->parameterIndex("f0.Height"));
+    tie_str = tie->asString();
+    TS_ASSERT_EQUALS(tie_str.substr(tie_str.find("=") + 1), "f1.Sigma");
   }
 
 private:

--- a/qt/widgets/common/test/FitPropertyBrowserTest.h
+++ b/qt/widgets/common/test/FitPropertyBrowserTest.h
@@ -118,7 +118,7 @@ public:
     // f0 should now be the flat background function
     f0Handler = m_fitPropertyBrowser->getPeakHandler(QString("f0"));
     TS_ASSERT(!f0Handler->hasTies());
-    TS_ASSERT(QString("f0-FlatBackground") == f0Handler->functionName());
+    TS_ASSERT_EQUALS(QString("f0-FlatBackground"), f0Handler->functionName());
   }
 
   void test_removeFunctionUpdatesTieString() {
@@ -128,10 +128,10 @@ public:
         "name=Gaussian,Height=10.0,PeakCentre=-0.555,Sigma=0.135;ties=(f0.Height=f2.Height)");
     auto f0Handler = m_fitPropertyBrowser->getPeakHandler(QString("f0"));
     auto f1Handler = m_fitPropertyBrowser->getPeakHandler(QString("f1"));
-    TS_ASSERT(m_fitPropertyBrowser->getOldExpressionAsString(QString("f0.Height")) == QString("f2.Height"));
+    TS_ASSERT_EQUALS(m_fitPropertyBrowser->getOldExpressionAsString(QString("f0.Height")), QString("f2.Height"));
     m_fitPropertyBrowser->removeFunction(f1Handler);
     TS_ASSERT(f0Handler->hasTies());
-    TS_ASSERT(m_fitPropertyBrowser->getOldExpressionAsString(QString("f0.Height")) == QString("f1.Height"));
+    TS_ASSERT_EQUALS(m_fitPropertyBrowser->getOldExpressionAsString(QString("f0.Height")), QString("f1.Height"));
   }
 
 private:


### PR DESCRIPTION
**Description of work.**

When a function if removed / deleted from the fitting widget, `PropertyHandler::removeFunction` calls `renameChildren()` which was intended to rename / refresh the parameter ties since some functions may have had their indexes changed when a function was removed. This function did not work since it assumed that the function ties would be stored in each of the individual functions (i.e a Gaussian) whereas the function ties are stored in the top level composite function (since they can reference any function in the composite function).

To fix this I have changed `renameChildren()` to accept a pointer to the top level composite function, this is necessary since you can't access this function from an individual function's property handler and I wanted to keep the recursive nature of  `renameChildren()`.

Additionally, I have added the functionality to remove ties which made reference to the removed function. This is simple, since those ties are removed from the composite function (although weren't being removed from the property handler).

**To test:**

- Load some data
- Plot a spectrum
- Click 'Fit' to open the fitting window
  - [x] Add two peaks and tie the **first** to the **second** (e.g right click `f0.height` and chose `Tie -> To function -> f1.Height`). Delete the **second** peak and check the tie is removed.
  - [x] Add three peaks and tie the **first** to the **third**. Delete the **second** peak and check the tie has changed (since `f2` has changed to `f1`).
  - [x] Add three peaks, tie the **first** to the **second** and the **second** to the **third**. Delete the **third** peak and check that the tie on the second peak as been removed (the first tie should remain).
  - [x] Add three peaks, tie the **first** to the **second** and the **second** to the **third**. Delete the **second** peak and check that no ties remain.
  - [x] Add three peaks, tie the **first** to the **second** , the **second** to the **third**, and the **third** to the **first**. Delete the ~~**second**~~
  (**first** ?) peak and check that only the tie on the third peak remains.
  - [x] Spend some time trying to break it.



Fixes #31662 

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
