### PR TITLE
Added tolerance in CEF tests for ResolutionModel

### DIFF
--- a/scripts/test/CrystalFieldTest.py
+++ b/scripts/test/CrystalFieldTest.py
@@ -1181,7 +1181,7 @@ class CrystalFieldFitTest(unittest.TestCase):
         rm = CrystalField.ResolutionModel(func, 0, np.pi)
         self.assertEqual(len(rm.model[0]), 129)
         self.assertEqual(len(rm.model[1]), 129)
-        self.assertTrue(np.all(func(rm.model[0]) == rm.model[1]))
+        self.assertTrue(np.allclose(func(rm.model[0]), rm.model[1], 0.000001))
 
     def test_ResolutionModel_func_multi(self):
         def func0(x):
@@ -1205,9 +1205,9 @@ class CrystalFieldFitTest(unittest.TestCase):
         self.assertEqual(len(rm.model[1][1]), 9)
         self.assertEqual(len(rm.model[2][0]), 17)
         self.assertEqual(len(rm.model[2][1]), 17)
-        self.assertTrue(np.all(func0(rm.model[0][0]) == rm.model[0][1]))
-        self.assertTrue(np.all(func1(rm.model[1][0]) == rm.model[1][1]))
-        self.assertTrue(np.all(func2(rm.model[2][0]) == rm.model[2][1]))
+        self.assertTrue(np.allclose(func0(rm.model[0][0]), rm.model[0][1], 0.000001))
+        self.assertTrue(np.allclose(func1(rm.model[1][0]), rm.model[1][1], 0.000001))
+        self.assertTrue(np.allclose(func2(rm.model[2][0]), rm.model[2][1], 0.000001))
 
     def test_ResolutionModel_array_single(self):
         x = [1, 2, 3]


### PR DESCRIPTION
**Description of work.**

Added tolerance in CEF tests for the ResolutionModel to avoid occasional failures due to rounding errors.

**To test:**

Monitor nightly tests on Linux for a while and ensure there are no failures anymore.

*There is no associated issue.*

*This does not require release notes* because **it only fixes an unreliable test.**

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
