### PR TITLE
Calculate Rotation angle on ALFView

### DIFF
--- a/qt/scientific_interfaces/Direct/ALFAnalysisModel.cpp
+++ b/qt/scientific_interfaces/Direct/ALFAnalysisModel.cpp
@@ -185,4 +185,15 @@ std::optional<double> ALFAnalysisModel::averageTwoTheta() const {
   return std::reduce(m_twoThetas.cbegin(), m_twoThetas.cend()) / static_cast<double>(numberOfTubes());
 }
 
+std::optional<double> ALFAnalysisModel::rotationAngle() const {
+  if (m_fitStatus.empty()) {
+    return std::nullopt;
+  }
+  auto const twoTheta = averageTwoTheta();
+  if (!twoTheta) {
+    return std::nullopt;
+  }
+  return peakCentre() / (2 * sin(*twoTheta));
+}
+
 } // namespace MantidQt::CustomInterfaces

--- a/qt/scientific_interfaces/Direct/ALFAnalysisModel.h
+++ b/qt/scientific_interfaces/Direct/ALFAnalysisModel.h
@@ -45,6 +45,8 @@ public:
 
   virtual std::optional<double> averageTwoTheta() const = 0;
   virtual std::vector<double> allTwoThetas() const = 0;
+
+  virtual std::optional<double> rotationAngle() const = 0;
 };
 
 class MANTIDQT_DIRECT_DLL ALFAnalysisModel final : public IALFAnalysisModel {
@@ -73,6 +75,8 @@ public:
 
   std::optional<double> averageTwoTheta() const override;
   inline std::vector<double> allTwoThetas() const noexcept override { return m_twoThetas; };
+
+  std::optional<double> rotationAngle() const override;
 
 private:
   std::string extractedWsName(std::size_t const runNumber) const;

--- a/qt/scientific_interfaces/Direct/ALFAnalysisPresenter.cpp
+++ b/qt/scientific_interfaces/Direct/ALFAnalysisPresenter.cpp
@@ -54,6 +54,7 @@ void ALFAnalysisPresenter::notifyPeakCentreEditingFinished() {
   if (!equalWithinTolerance(m_model->peakCentre(), newPeakCentre)) {
     m_model->setPeakCentre(newPeakCentre);
     updatePeakCentreInViewFromModel();
+    updateRotationAngleInViewFromModel();
   }
 }
 
@@ -70,11 +71,13 @@ void ALFAnalysisPresenter::notifyFitClicked() {
     m_view->displayWarning(ex.what());
   }
   updatePeakCentreInViewFromModel();
+  updateRotationAngleInViewFromModel();
 }
 
 void ALFAnalysisPresenter::notifyResetClicked() {
   calculateEstimate();
   updatePeakCentreInViewFromModel();
+  updateRotationAngleInViewFromModel();
 }
 
 std::optional<std::string> ALFAnalysisPresenter::validateFitValues() const {
@@ -106,11 +109,16 @@ void ALFAnalysisPresenter::calculateEstimate() {
 
 void ALFAnalysisPresenter::updateViewFromModel() {
   updatePlotInViewFromModel();
-  updatePeakCentreInViewFromModel();
   updateTwoThetaInViewFromModel();
+  updatePeakCentreInViewFromModel();
+  updateRotationAngleInViewFromModel();
 }
 
 void ALFAnalysisPresenter::updatePlotInViewFromModel() { m_view->addSpectrum(m_model->extractedWorkspace()); }
+
+void ALFAnalysisPresenter::updateTwoThetaInViewFromModel() {
+  m_view->setAverageTwoTheta(m_model->averageTwoTheta(), m_model->allTwoThetas());
+}
 
 void ALFAnalysisPresenter::updatePeakCentreInViewFromModel() {
   m_view->setPeak(m_model->getPeakCopy());
@@ -123,8 +131,6 @@ void ALFAnalysisPresenter::updatePeakCentreInViewFromModel() {
   m_view->replot();
 }
 
-void ALFAnalysisPresenter::updateTwoThetaInViewFromModel() {
-  m_view->setAverageTwoTheta(m_model->averageTwoTheta(), m_model->allTwoThetas());
-}
+void ALFAnalysisPresenter::updateRotationAngleInViewFromModel() { m_view->setRotationAngle(m_model->rotationAngle()); }
 
 } // namespace MantidQt::CustomInterfaces

--- a/qt/scientific_interfaces/Direct/ALFAnalysisPresenter.h
+++ b/qt/scientific_interfaces/Direct/ALFAnalysisPresenter.h
@@ -68,8 +68,9 @@ private:
 
   void updateViewFromModel();
   void updatePlotInViewFromModel();
-  void updatePeakCentreInViewFromModel();
   void updateTwoThetaInViewFromModel();
+  void updatePeakCentreInViewFromModel();
+  void updateRotationAngleInViewFromModel();
 
   IALFAnalysisView *m_view;
   std::unique_ptr<IALFAnalysisModel> m_model;

--- a/qt/scientific_interfaces/Direct/ALFAnalysisView.cpp
+++ b/qt/scientific_interfaces/Direct/ALFAnalysisView.cpp
@@ -137,7 +137,7 @@ QWidget *ALFAnalysisView::createFitWidget(double const start, double const end) 
   setupTwoThetaWidget(analysisLayout);
   setupFitRangeWidget(analysisLayout, start, end);
   setupPeakCentreWidget(analysisLayout, (start + end) / 2.0);
-  setupRAngleWidget(analysisLayout);
+  setupRotationAngleWidget(analysisLayout);
 
   return analysisPane;
 }
@@ -197,7 +197,7 @@ void ALFAnalysisView::setupPeakCentreWidget(QGridLayout *layout, double const ce
   layout->addWidget(new QLabel(""), 4, 4);
 }
 
-void ALFAnalysisView::setupRAngleWidget(QGridLayout *layout) {
+void ALFAnalysisView::setupRotationAngleWidget(QGridLayout *layout) {
   m_rotationAngle = new QLineEdit("-");
   m_rotationAngle->setReadOnly(true);
   m_rotationAngle->setToolTip(ROTATION_ANGLE_TOOLTIP);

--- a/qt/scientific_interfaces/Direct/ALFAnalysisView.cpp
+++ b/qt/scientific_interfaces/Direct/ALFAnalysisView.cpp
@@ -28,9 +28,10 @@ namespace {
 QString const DEFAULT_TUBES_TOOLTIP = "No tubes have been selected";
 QString const FIT_BUTTON_TOOLTIP =
     "Fit to find the Peak Centre. Repeated Fits will attempt to refine the Peak Centre value further.";
-QString const PEAK_CENTRE_TOOLTIP = "The centre of the Gaussian peak function.";
+QString const PEAK_CENTRE_TOOLTIP = "The centre of the Gaussian peak function, V.";
 QString const TWO_THETA_TOOLTIP = "The average two theta of the extracted tubes. The two theta of a tube is taken to "
                                   "be the two theta at which the Out of Plane angle is closest to zero.";
+QString const R_ANGLE_TOOLTIP = "The R parameter angle. R = V / (2*sin(theta))";
 
 QString const INFO_LABEL_STYLE = "QLabel { border-radius: 5px; border: 2px solid black; }";
 QString const ERROR_LABEL_STYLE = "QLabel { color: red; border-radius: 5px; border: 2px solid red; }";
@@ -136,6 +137,7 @@ QWidget *ALFAnalysisView::createFitWidget(double const start, double const end) 
   setupTwoThetaWidget(analysisLayout);
   setupFitRangeWidget(analysisLayout, start, end);
   setupPeakCentreWidget(analysisLayout, (start + end) / 2.0);
+  setupRAngleWidget(analysisLayout);
 
   return analysisPane;
 }
@@ -190,6 +192,18 @@ void ALFAnalysisView::setupPeakCentreWidget(QGridLayout *layout, double const ce
   setPeakCentreStatus("");
 
   layout->addWidget(m_fitStatus, 3, 4);
+
+  // Add an empty label to act as empty space
+  layout->addWidget(new QLabel(""), 4, 4);
+}
+
+void ALFAnalysisView::setupRAngleWidget(QGridLayout *layout) {
+  m_rAngle = new QLineEdit("-");
+  m_rAngle->setReadOnly(true);
+  m_rAngle->setToolTip(R_ANGLE_TOOLTIP);
+
+  layout->addWidget(new QLabel("R:"), 5, 0);
+  layout->addWidget(m_rAngle, 5, 1, 1, 3);
 }
 
 void ALFAnalysisView::notifyPeakPickerChanged() { m_presenter->notifyPeakPickerChanged(); }

--- a/qt/scientific_interfaces/Direct/ALFAnalysisView.cpp
+++ b/qt/scientific_interfaces/Direct/ALFAnalysisView.cpp
@@ -28,10 +28,10 @@ namespace {
 QString const DEFAULT_TUBES_TOOLTIP = "No tubes have been selected";
 QString const FIT_BUTTON_TOOLTIP =
     "Fit to find the Peak Centre. Repeated Fits will attempt to refine the Peak Centre value further.";
-QString const PEAK_CENTRE_TOOLTIP = "The centre of the Gaussian peak function, V.";
+QString const PEAK_CENTRE_TOOLTIP = "The centre of the Gaussian peak function, V, in degrees.";
 QString const TWO_THETA_TOOLTIP = "The average two theta of the extracted tubes. The two theta of a tube is taken to "
                                   "be the two theta at which the Out of Plane angle is closest to zero.";
-QString const R_ANGLE_TOOLTIP = "The R parameter angle. R = V / (2*sin(theta))";
+QString const ROTATION_ANGLE_TOOLTIP = "The Rotation or tilt angle, R, in degrees. R = V / (2*sin(theta))";
 
 QString const INFO_LABEL_STYLE = "QLabel { border-radius: 5px; border: 2px solid black; }";
 QString const ERROR_LABEL_STYLE = "QLabel { color: red; border-radius: 5px; border: 2px solid red; }";
@@ -198,12 +198,16 @@ void ALFAnalysisView::setupPeakCentreWidget(QGridLayout *layout, double const ce
 }
 
 void ALFAnalysisView::setupRAngleWidget(QGridLayout *layout) {
-  m_rAngle = new QLineEdit("-");
-  m_rAngle->setReadOnly(true);
-  m_rAngle->setToolTip(R_ANGLE_TOOLTIP);
+  m_rotationAngle = new QLineEdit("-");
+  m_rotationAngle->setReadOnly(true);
+  m_rotationAngle->setToolTip(ROTATION_ANGLE_TOOLTIP);
+  m_fitRequired = new QLabel("*");
+  m_fitRequired->setToolTip("A Fit to find the peak centre is required.");
+  m_fitRequired->setStyleSheet("QLabel { color: red; }");
 
-  layout->addWidget(new QLabel("R:"), 5, 0);
-  layout->addWidget(m_rAngle, 5, 1, 1, 3);
+  layout->addWidget(new QLabel("Rotation:"), 5, 0);
+  layout->addWidget(m_rotationAngle, 5, 1, 1, 3);
+  layout->addWidget(m_fitRequired, 5, 4);
 }
 
 void ALFAnalysisView::notifyPeakPickerChanged() { m_presenter->notifyPeakPickerChanged(); }
@@ -237,6 +241,13 @@ void ALFAnalysisView::addFitSpectrum(Mantid::API::MatrixWorkspace_sptr const &wo
 
 void ALFAnalysisView::removeFitSpectrum() { m_plot->removeSpectrum("Fitted Data"); }
 
+void ALFAnalysisView::setAverageTwoTheta(std::optional<double> average, std::vector<double> const &all) {
+  m_averageTwoTheta->setText(average ? QString::number(*average) : "-");
+  m_numberOfTubes->setText(all.size() == 1u ? QString::number(all.size()) + " tube"
+                                            : QString::number(all.size()) + " tubes");
+  m_numberOfTubes->setToolTip(constructNumberOfTubesTooltip(all));
+}
+
 void ALFAnalysisView::setPeak(Mantid::API::IPeakFunction_const_sptr const &peak) {
   setPeakCentre(peak->getParameter("PeakCentre"));
 
@@ -257,11 +268,9 @@ void ALFAnalysisView::setPeakCentreStatus(std::string const &status) {
   m_fitStatus->setToolTip(tooltip);
 }
 
-void ALFAnalysisView::setAverageTwoTheta(std::optional<double> average, std::vector<double> const &all) {
-  m_averageTwoTheta->setText(average ? QString::number(*average) : "-");
-  m_numberOfTubes->setText(all.size() == 1u ? QString::number(all.size()) + " tube"
-                                            : QString::number(all.size()) + " tubes");
-  m_numberOfTubes->setToolTip(constructNumberOfTubesTooltip(all));
+void ALFAnalysisView::setRotationAngle(std::optional<double> rotation) {
+  m_rotationAngle->setText(rotation ? QString::number(*rotation) : "-");
+  m_fitRequired->setVisible(!rotation);
 }
 
 void ALFAnalysisView::displayWarning(std::string const &message) {

--- a/qt/scientific_interfaces/Direct/ALFAnalysisView.h
+++ b/qt/scientific_interfaces/Direct/ALFAnalysisView.h
@@ -107,7 +107,7 @@ private:
   void setupTwoThetaWidget(QGridLayout *layout);
   void setupFitRangeWidget(QGridLayout *layout, double const start, double const end);
   void setupPeakCentreWidget(QGridLayout *layout, double const centre);
-  void setupRAngleWidget(QGridLayout *layout);
+  void setupRotationAngleWidget(QGridLayout *layout);
 
   MantidWidgets::PreviewPlot *m_plot;
   MantidWidgets::PeakPicker *m_peakPicker;

--- a/qt/scientific_interfaces/Direct/ALFAnalysisView.h
+++ b/qt/scientific_interfaces/Direct/ALFAnalysisView.h
@@ -103,6 +103,7 @@ private:
   void setupTwoThetaWidget(QGridLayout *layout);
   void setupFitRangeWidget(QGridLayout *layout, double const start, double const end);
   void setupPeakCentreWidget(QGridLayout *layout, double const centre);
+  void setupRAngleWidget(QGridLayout *layout);
 
   MantidWidgets::PreviewPlot *m_plot;
   MantidWidgets::PeakPicker *m_peakPicker;
@@ -113,6 +114,7 @@ private:
   QLabel *m_fitStatus;
   QLineEdit *m_averageTwoTheta;
   QLabel *m_numberOfTubes;
+  QLineEdit *m_rAngle;
 
   IALFAnalysisPresenter *m_presenter;
 };

--- a/qt/scientific_interfaces/Direct/ALFAnalysisView.h
+++ b/qt/scientific_interfaces/Direct/ALFAnalysisView.h
@@ -48,6 +48,8 @@ public:
   virtual void addFitSpectrum(Mantid::API::MatrixWorkspace_sptr const &workspace) = 0;
   virtual void removeFitSpectrum() = 0;
 
+  virtual void setAverageTwoTheta(std::optional<double> average, std::vector<double> const &all) = 0;
+
   virtual void setPeak(Mantid::API::IPeakFunction_const_sptr const &peak) = 0;
   virtual Mantid::API::IPeakFunction_const_sptr getPeak() const = 0;
 
@@ -55,7 +57,7 @@ public:
   virtual double peakCentre() const = 0;
   virtual void setPeakCentreStatus(std::string const &status) = 0;
 
-  virtual void setAverageTwoTheta(std::optional<double> average, std::vector<double> const &all) = 0;
+  virtual void setRotationAngle(std::optional<double> rotation) = 0;
 
   virtual void displayWarning(std::string const &message) = 0;
 };
@@ -78,6 +80,8 @@ public:
   void addFitSpectrum(Mantid::API::MatrixWorkspace_sptr const &workspace) override;
   void removeFitSpectrum() override;
 
+  void setAverageTwoTheta(std::optional<double> average, std::vector<double> const &all) override;
+
   void setPeak(Mantid::API::IPeakFunction_const_sptr const &peak) override;
   Mantid::API::IPeakFunction_const_sptr getPeak() const override;
 
@@ -85,7 +89,7 @@ public:
   double peakCentre() const override;
   void setPeakCentreStatus(std::string const &status) override;
 
-  void setAverageTwoTheta(std::optional<double> average, std::vector<double> const &all) override;
+  void setRotationAngle(std::optional<double> rotation) override;
 
   void displayWarning(std::string const &message) override;
 
@@ -114,7 +118,8 @@ private:
   QLabel *m_fitStatus;
   QLineEdit *m_averageTwoTheta;
   QLabel *m_numberOfTubes;
-  QLineEdit *m_rAngle;
+  QLineEdit *m_rotationAngle;
+  QLabel *m_fitRequired;
 
   IALFAnalysisPresenter *m_presenter;
 };

--- a/qt/scientific_interfaces/Direct/test/ALFAnalysisMocks.h
+++ b/qt/scientific_interfaces/Direct/test/ALFAnalysisMocks.h
@@ -67,6 +67,8 @@ public:
 
   MOCK_METHOD2(setAverageTwoTheta, void(std::optional<double> average, std::vector<double> const &all));
 
+  MOCK_METHOD1(setRotationAngle, void(std::optional<double> rotation));
+
   MOCK_METHOD1(displayWarning, void(std::string const &message));
 };
 
@@ -93,6 +95,8 @@ public:
 
   MOCK_CONST_METHOD0(averageTwoTheta, std::optional<double>());
   MOCK_CONST_METHOD0(allTwoThetas, std::vector<double>());
+
+  MOCK_CONST_METHOD0(rotationAngle, std::optional<double>());
 };
 
 GNU_DIAG_ON_SUGGEST_OVERRIDE

--- a/qt/scientific_interfaces/Direct/test/ALFAnalysisModelTest.h
+++ b/qt/scientific_interfaces/Direct/test/ALFAnalysisModelTest.h
@@ -162,9 +162,10 @@ public:
 
   void test_rotationAngle_returns_the_correct_value_with_valid_data() {
     m_model->setExtractedWorkspace(m_workspace, m_twoThetas);
+    m_model->setPeakCentre(0.1);
     m_model->doFit(m_range);
 
-    TS_ASSERT_DIFFERS(1.2000, *m_model->rotationAngle(), 0.000001);
+    TS_ASSERT_DELTA(-0.0557, *m_model->rotationAngle(), 0.0001);
   }
 
 private:

--- a/qt/scientific_interfaces/Direct/test/ALFAnalysisModelTest.h
+++ b/qt/scientific_interfaces/Direct/test/ALFAnalysisModelTest.h
@@ -155,6 +155,18 @@ public:
     TS_ASSERT_EQUALS(3u, m_model->numberOfTubes());
   }
 
+  void test_rotationAngle_returns_nullopt_if_the_fit_status_is_empty() {
+    m_model->setExtractedWorkspace(m_workspace, m_twoThetas);
+    TS_ASSERT_EQUALS(std::nullopt, m_model->rotationAngle());
+  }
+
+  void test_rotationAngle_returns_the_correct_value_with_valid_data() {
+    m_model->setExtractedWorkspace(m_workspace, m_twoThetas);
+    m_model->doFit(m_range);
+
+    TS_ASSERT_DIFFERS(1.2000, *m_model->rotationAngle(), 0.000001);
+  }
+
 private:
   MatrixWorkspace_sptr m_workspace;
   std::string m_workspaceName;

--- a/qt/scientific_interfaces/Direct/test/ALFAnalysisPresenterTest.h
+++ b/qt/scientific_interfaces/Direct/test/ALFAnalysisPresenterTest.h
@@ -125,6 +125,8 @@ public:
     EXPECT_CALL(*m_view, removeFitSpectrum()).Times(1);
     EXPECT_CALL(*m_view, replot()).Times(1);
 
+    expectUpdateRotationAngleCalled();
+
     m_presenter->notifyPeakCentreEditingFinished();
   }
 
@@ -134,12 +136,14 @@ public:
 
     // Assert not called as the peak centre remains the same
     EXPECT_CALL(*m_model, setPeakCentre(m_peakCentre)).Times(0);
-    EXPECT_CALL(*m_model, getPeakCopy()).Times(0).WillOnce(Return(nullptr));
+    EXPECT_CALL(*m_model, getPeakCopy()).Times(0);
     EXPECT_CALL(*m_view, setPeak(_)).Times(0);
-    EXPECT_CALL(*m_model, fitStatus()).Times(0).WillOnce(Return(""));
+    EXPECT_CALL(*m_model, fitStatus()).Times(0);
     EXPECT_CALL(*m_view, setPeakCentreStatus("")).Times(0);
     EXPECT_CALL(*m_view, removeFitSpectrum()).Times(0);
     EXPECT_CALL(*m_view, replot()).Times(0);
+
+    expectUpdateRotationAngleNotCalled();
 
     m_presenter->notifyPeakCentreEditingFinished();
   }
@@ -159,12 +163,16 @@ public:
 
     EXPECT_CALL(*m_view, replot()).Times(1);
 
+    expectUpdateRotationAngleCalled();
+
     m_presenter->notifyPeakCentreEditingFinished();
   }
 
   void test_notifyFitClicked_will_display_a_warning_when_data_is_not_extracted() {
     EXPECT_CALL(*m_model, isDataExtracted()).Times(1).WillOnce(Return(false));
     EXPECT_CALL(*m_view, displayWarning("Need to have extracted data to do a fit or estimate.")).Times(1);
+
+    expectUpdateRotationAngleNotCalled();
 
     m_presenter->notifyFitClicked();
   }
@@ -174,6 +182,8 @@ public:
     EXPECT_CALL(*m_view, peakCentre()).Times(1).WillOnce(Return(-1.0));
     EXPECT_CALL(*m_view, getRange()).Times(1).WillOnce(Return(m_range));
     EXPECT_CALL(*m_view, displayWarning("The Peak Centre provided is outside the fit range.")).Times(1);
+
+    expectUpdateRotationAngleNotCalled();
 
     m_presenter->notifyFitClicked();
   }
@@ -185,6 +195,8 @@ public:
 
     EXPECT_CALL(*m_model, doFit(m_range)).Times(1);
 
+    expectUpdateRotationAngleCalled();
+
     m_presenter->notifyFitClicked();
   }
 
@@ -194,11 +206,15 @@ public:
     // Assert no call to calculateEstimate
     EXPECT_CALL(*m_model, calculateEstimate(_)).Times(0);
 
+    expectUpdateRotationAngleCalled();
+
     m_presenter->notifyResetClicked();
   }
 
   void test_that_calculateEstimate_is_called_as_expected() {
     expectCalculateEstimate();
+    expectUpdateRotationAngleCalled();
+
     m_presenter->notifyResetClicked();
   }
 
@@ -228,6 +244,18 @@ private:
     EXPECT_CALL(*m_view, getRange()).Times(1).WillRepeatedly(Return(m_range));
 
     EXPECT_CALL(*m_model, calculateEstimate(m_range)).Times(1);
+  }
+
+  void expectUpdateRotationAngleCalled() {
+    std::optional<double> const angle(1.20003);
+    EXPECT_CALL(*m_model, rotationAngle()).Times(1).WillOnce(Return(angle));
+    EXPECT_CALL(*m_view, setRotationAngle(angle)).Times(1);
+  }
+
+  void expectUpdateRotationAngleNotCalled() {
+    // Assert these functions are not called
+    EXPECT_CALL(*m_model, rotationAngle()).Times(0);
+    EXPECT_CALL(*m_view, setRotationAngle(_)).Times(0);
   }
 
   std::string m_workspaceName;


### PR DESCRIPTION
**Description of work.**
This PR adds the calculation of the Rotation angle to the ALFView interface. If a Fit hasn't been performed, then the Rotation angle will be blank and a red asterisk displayed next to it.

**To test:**
Select ALF instrument in settings, and turn on data archive.
Open ALFView
Load run 82301
Click on Pick tab
Expand Rebin section. Rebin with 5.5,0.01,6
Click the Rectangle region selection tool at the top of the Pick tab
Select the two tubes in the centre with the yellow peak. The RHS plot should be updated.
Click Fit, and a Successful fit status label should appear.
You should also see a value for the "Rotation" angle appears.
If you Reset the plot with the button in the top right then the Rotation angle should go blank, and a red asterisk appear next to the box.

Fixes #34569

*This does not require release notes* because **release notes will be added later**

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
