### PR TITLE
Reset GUI tie upon editing to invalid value

### DIFF
--- a/docs/source/release/v6.6.0/Workbench/Bugfixes/31310.rst
+++ b/docs/source/release/v6.6.0/Workbench/Bugfixes/31310.rst
@@ -1,1 +1,1 @@
-- In the fitting widget, if a tie is edited to an invalid value Mantid will display an error and revert the tie to it's previous value.
+- In the fitting widget, if a tie is edited to an invalid value Workbench will display an error and revert the tie to its previous value.

--- a/docs/source/release/v6.6.0/Workbench/Bugfixes/31310.rst
+++ b/docs/source/release/v6.6.0/Workbench/Bugfixes/31310.rst
@@ -1,0 +1,1 @@
+- In the fitting widget, if a tie is edited to an invalid value Mantid will display an error and revert the tie to it's previous value.

--- a/qt/widgets/common/src/FitPropertyBrowser.cpp
+++ b/qt/widgets/common/src/FitPropertyBrowser.cpp
@@ -1449,9 +1449,8 @@ void FitPropertyBrowser::stringChanged(QtProperty *prop) {
       tie->set(str.toStdString());
       h->addTie(parName + "=" + str);
     } catch (...) {
-      g_log.error() << "Failed to update tie on " << parName.toLatin1().constData() << "\n";
-      // throw std::runtime_error("Failed to update tie on " + parName.toStdString() + " Error in expresseion " +
-      // parName.toStdString() + "=" + str.toStdString());
+      std::string msg = "Failed to update tie on " + parName.toStdString();
+      QMessageBox::critical(this, "Mantid - Error", msg.c_str());
 
       m_stringManager->setValue(prop, old_exp);
     }

--- a/qt/widgets/common/src/FitPropertyBrowser.cpp
+++ b/qt/widgets/common/src/FitPropertyBrowser.cpp
@@ -1433,12 +1433,12 @@ void FitPropertyBrowser::stringChanged(QtProperty *prop) {
 
     // Get the tie expression stored in the function in case the new expression is invalid
     // and the GUI needs to be reset
-    const size_t parIndex = compositeFunction()->parameterIndex(parName.toStdString());
+    const auto parIndex = compositeFunction()->parameterIndex(parName.toStdString());
     const auto oldTie = compositeFunction()->getTie(parIndex);
-    const std::string oldTieStr = oldTie->asString();
-    QString oldExp = QString::fromStdString(oldTieStr.substr(oldTieStr.find("=") + 1));
+    const auto oldTieStr = oldTie->asString();
+    const auto oldExp = QString::fromStdString(oldTieStr.substr(oldTieStr.find("=") + 1));
 
-    QString exp = m_stringManager->value(prop);
+    const auto exp = m_stringManager->value(prop);
 
     if (oldExp == exp)
       return;

--- a/qt/widgets/common/src/FitPropertyBrowser.cpp
+++ b/qt/widgets/common/src/FitPropertyBrowser.cpp
@@ -1431,13 +1431,29 @@ void FitPropertyBrowser::stringChanged(QtProperty *prop) {
 
     QString parName = h->functionPrefix() + "." + parProp->propertyName();
 
+    const size_t index = compositeFunction()->parameterIndex(parName.toStdString());
+    const auto old_tie = compositeFunction()->getTie(index);
+    const std::string old_tie_str = old_tie->asString();
+    QString old_exp = QString::fromStdString(old_tie_str.substr(old_tie_str.find("=") + 1));
+
     QString str = m_stringManager->value(prop);
+
+    std::string old_exp_str = old_exp.toStdString();
+    std::string str_str = str.toStdString();
+
+    if (old_exp == str)
+      return;
+
     Mantid::API::ParameterTie *tie = new Mantid::API::ParameterTie(compositeFunction().get(), parName.toStdString());
     try {
       tie->set(str.toStdString());
       h->addTie(parName + "=" + str);
     } catch (...) {
-      g_log.warning() << "Failed to update tie on " << parName.toLatin1().constData() << "\n";
+      g_log.error() << "Failed to update tie on " << parName.toLatin1().constData() << "\n";
+      // throw std::runtime_error("Failed to update tie on " + parName.toStdString() + " Error in expresseion " +
+      // parName.toStdString() + "=" + str.toStdString());
+
+      setStringPropertyValue(prop, old_exp);
     }
     delete tie;
   } else if (getHandler()->setAttribute(prop)) { // setting an attribute may

--- a/qt/widgets/common/src/FitPropertyBrowser.cpp
+++ b/qt/widgets/common/src/FitPropertyBrowser.cpp
@@ -1453,7 +1453,7 @@ void FitPropertyBrowser::stringChanged(QtProperty *prop) {
       // throw std::runtime_error("Failed to update tie on " + parName.toStdString() + " Error in expresseion " +
       // parName.toStdString() + "=" + str.toStdString());
 
-      setStringPropertyValue(prop, old_exp);
+      m_stringManager->setValue(prop, old_exp);
     }
     delete tie;
   } else if (getHandler()->setAttribute(prop)) { // setting an attribute may

--- a/qt/widgets/common/src/FitPropertyBrowser.cpp
+++ b/qt/widgets/common/src/FitPropertyBrowser.cpp
@@ -1448,7 +1448,8 @@ void FitPropertyBrowser::stringChanged(QtProperty *prop) {
       tie->set(exp.toStdString());
       h->addTie(parName + "=" + exp);
     } catch (...) {
-      std::string msg = "Failed to update tie on " + parName.toStdString();
+      std::string msg =
+          "Failed to update tie on " + parName.toStdString() + ". Expression " + exp.toStdString() + " is invalid.";
       QMessageBox::critical(this, "Mantid - Error", msg.c_str());
 
       m_stringManager->setValue(prop, oldExp);

--- a/qt/widgets/common/src/FitPropertyBrowser.cpp
+++ b/qt/widgets/common/src/FitPropertyBrowser.cpp
@@ -1448,7 +1448,7 @@ void FitPropertyBrowser::stringChanged(QtProperty *prop) {
       tie->set(exp.toStdString());
       h->addTie(parName + "=" + exp);
     } catch (...) {
-      std::string msg =
+      const auto msg =
           "Failed to update tie on " + parName.toStdString() + ". Expression " + exp.toStdString() + " is invalid.";
       QMessageBox::critical(this, "Mantid - Error", msg.c_str());
 

--- a/qt/widgets/common/src/FitPropertyBrowser.cpp
+++ b/qt/widgets/common/src/FitPropertyBrowser.cpp
@@ -1431,28 +1431,27 @@ void FitPropertyBrowser::stringChanged(QtProperty *prop) {
 
     QString parName = h->functionPrefix() + "." + parProp->propertyName();
 
-    const size_t index = compositeFunction()->parameterIndex(parName.toStdString());
-    const auto old_tie = compositeFunction()->getTie(index);
-    const std::string old_tie_str = old_tie->asString();
-    QString old_exp = QString::fromStdString(old_tie_str.substr(old_tie_str.find("=") + 1));
+    // Get the tie expression stored in the function in case the new expression is invalid
+    // and the GUI needs to be reset
+    const size_t parIndex = compositeFunction()->parameterIndex(parName.toStdString());
+    const auto oldTie = compositeFunction()->getTie(parIndex);
+    const std::string oldTieStr = oldTie->asString();
+    QString oldExp = QString::fromStdString(oldTieStr.substr(oldTieStr.find("=") + 1));
 
-    QString str = m_stringManager->value(prop);
+    QString exp = m_stringManager->value(prop);
 
-    std::string old_exp_str = old_exp.toStdString();
-    std::string str_str = str.toStdString();
-
-    if (old_exp == str)
+    if (oldExp == exp)
       return;
 
     Mantid::API::ParameterTie *tie = new Mantid::API::ParameterTie(compositeFunction().get(), parName.toStdString());
     try {
-      tie->set(str.toStdString());
-      h->addTie(parName + "=" + str);
+      tie->set(exp.toStdString());
+      h->addTie(parName + "=" + exp);
     } catch (...) {
       std::string msg = "Failed to update tie on " + parName.toStdString();
       QMessageBox::critical(this, "Mantid - Error", msg.c_str());
 
-      m_stringManager->setValue(prop, old_exp);
+      m_stringManager->setValue(prop, oldExp);
     }
     delete tie;
   } else if (getHandler()->setAttribute(prop)) { // setting an attribute may

--- a/qt/widgets/common/src/QtPropertyBrowser/qtpropertymanager.cpp
+++ b/qt/widgets/common/src/QtPropertyBrowser/qtpropertymanager.cpp
@@ -1023,8 +1023,8 @@ void QtStringPropertyManager::setValue(QtProperty *property, const QString &val)
 
   it.value() = data;
 
-  emit propertyChanged(property);
   emit valueChanged(property, data.val);
+  emit propertyChanged(property);
 }
 
 /**

--- a/qt/widgets/common/src/QtPropertyBrowser/qtpropertymanager.cpp
+++ b/qt/widgets/common/src/QtPropertyBrowser/qtpropertymanager.cpp
@@ -1010,8 +1010,6 @@ void QtStringPropertyManager::setValue(QtProperty *property, const QString &val)
     return;
 
   QtStringPropertyManagerPrivate::Data data = it.value();
-  auto data_str = data.val.toStdString();
-  auto val_str = val.toStdString();
 
   if (data.val == val)
     return;

--- a/qt/widgets/common/src/QtPropertyBrowser/qtpropertymanager.cpp
+++ b/qt/widgets/common/src/QtPropertyBrowser/qtpropertymanager.cpp
@@ -1010,6 +1010,8 @@ void QtStringPropertyManager::setValue(QtProperty *property, const QString &val)
     return;
 
   QtStringPropertyManagerPrivate::Data data = it.value();
+  auto data_str = data.val.toStdString();
+  auto val_str = val.toStdString();
 
   if (data.val == val)
     return;

--- a/qt/widgets/common/src/QtPropertyBrowser/qtpropertymanager.cpp
+++ b/qt/widgets/common/src/QtPropertyBrowser/qtpropertymanager.cpp
@@ -1023,8 +1023,8 @@ void QtStringPropertyManager::setValue(QtProperty *property, const QString &val)
 
   it.value() = data;
 
-  emit valueChanged(property, data.val);
   emit propertyChanged(property);
+  emit valueChanged(property, data.val);
 }
 
 /**


### PR DESCRIPTION
**Description of work.**

In the fitting widget, if a tie is added (successfully) and then edited to be something invalid, the GUI does not update to reflect the fact that the change has been rejected. A warning is given in the console, but this is easy to miss.

This change ensures that, visually, the tie reverts to its old value when an invalid expression is entered. Also, an error message box is now shown to mimic the behaviour of initialising a tie with an invalid expression.

**To test:**

 - Load some data
 - Plot a spectrum
 - Click 'Fit' to open the fitting widget
 - Right click and add a peak, then a second
 - Right click `f0.Height -> Tie -> To function -> f1.Height`
 - Click on the tie box and change it from `f1.Height` to something invalid (e.g `hello`)
 - Check that an error box was shown
 - Click okay on the error box and check the tie value has reverted to `f1.Height`
 - Click on the tie box and change the value to `f1.Sigma` to test it will update correctly

Fixes #31310

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
