### PR TITLE
Remove instrument information from workspace

### DIFF
--- a/Framework/Algorithms/CMakeLists.txt
+++ b/Framework/Algorithms/CMakeLists.txt
@@ -29,7 +29,6 @@ set(SRC_FILES
     src/CalculateEfficiency2.cpp
     src/CalculateFlatBackground.cpp
     src/CalculateIqt.cpp
-    src/DiscusMultipleScatteringCorrection.cpp
     src/CalculatePlaczek.cpp
     src/CalculatePlaczekSelfScattering.cpp
     src/CalculatePlaczekSelfScattering2.cpp
@@ -115,6 +114,7 @@ set(SRC_FILES
     src/DiffractionFocussing.cpp
     src/DiffractionFocussing2.cpp
     src/DirectILLTubeBackground.cpp
+    src/DiscusMultipleScatteringCorrection.cpp
     src/Divide.cpp
     src/EQSANSCorrectFrame.cpp
     src/EQSANSResolution.cpp
@@ -261,6 +261,7 @@ set(SRC_FILES
     src/Regroup.cpp
     src/RemoveBackground.cpp
     src/RemoveBins.cpp
+    src/RemoveInstrumentGeometry.cpp
     src/RemoveLowResTOF.cpp
     src/RemoveMaskedSpectra.cpp
     src/RemovePromptPulse.cpp
@@ -373,7 +374,6 @@ set(INC_FILES
     inc/MantidAlgorithms/CalculateEfficiency2.h
     inc/MantidAlgorithms/CalculateFlatBackground.h
     inc/MantidAlgorithms/CalculateIqt.h
-    inc/MantidAlgorithms/DiscusMultipleScatteringCorrection.h
     inc/MantidAlgorithms/CalculatePlaczek.h
     inc/MantidAlgorithms/CalculatePlaczekSelfScattering.h
     inc/MantidAlgorithms/CalculatePlaczekSelfScattering2.h
@@ -459,6 +459,7 @@ set(INC_FILES
     inc/MantidAlgorithms/DiffractionFocussing.h
     inc/MantidAlgorithms/DiffractionFocussing2.h
     inc/MantidAlgorithms/DirectILLTubeBackground.h
+    inc/MantidAlgorithms/DiscusMultipleScatteringCorrection.h
     inc/MantidAlgorithms/Divide.h
     inc/MantidAlgorithms/EQSANSCorrectFrame.h
     inc/MantidAlgorithms/EQSANSResolution.h
@@ -609,6 +610,7 @@ set(INC_FILES
     inc/MantidAlgorithms/Regroup.h
     inc/MantidAlgorithms/RemoveBackground.h
     inc/MantidAlgorithms/RemoveBins.h
+    inc/MantidAlgorithms/RemoveInstrumentGeometry.h
     inc/MantidAlgorithms/RemoveLowResTOF.h
     inc/MantidAlgorithms/RemoveMaskedSpectra.h
     inc/MantidAlgorithms/RemovePromptPulse.h
@@ -732,7 +734,6 @@ set(TEST_FILES
     CalculateEfficiencyTest.h
     CalculateFlatBackgroundTest.h
     CalculateIqtTest.h
-    DiscusMultipleScatteringCorrectionTest.h
     CalculatePlaczekSelfScattering2Test.h
     CalculatePlaczekSelfScatteringTest.h
     CalculatePlaczekTest.h
@@ -820,6 +821,7 @@ set(TEST_FILES
     DiffractionFocussing2Test.h
     DiffractionFocussingTest.h
     DirectILLTubeBackgroundTest.h
+    DiscusMultipleScatteringCorrectionTest.h
     DivideTest.h
     EQSANSCorrectFrameTest.h
     EditInstrumentGeometryTest.h
@@ -959,6 +961,7 @@ set(TEST_FILES
     RegroupTest.h
     RemoveBackgroundTest.h
     RemoveBinsTest.h
+    RemoveInstrumentGeometryTest.h
     RemoveLowResTOFTest.h
     RemoveMaskedSpectraTest.h
     RemovePromptPulseTest.h

--- a/Framework/Algorithms/inc/MantidAlgorithms/RemoveInstrumentGeometry.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/RemoveInstrumentGeometry.h
@@ -1,0 +1,30 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2022 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#pragma once
+
+#include "MantidAPI/Algorithm.h"
+#include "MantidAlgorithms/DllConfig.h"
+
+namespace Mantid {
+namespace Algorithms {
+
+/** RemoveInstrumentGeometry : TODO: DESCRIPTION
+ */
+class MANTID_ALGORITHMS_DLL RemoveInstrumentGeometry : public API::Algorithm {
+public:
+  const std::string name() const override;
+  int version() const override;
+  const std::string category() const override;
+  const std::string summary() const override;
+
+private:
+  void init() override;
+  void exec() override;
+};
+
+} // namespace Algorithms
+} // namespace Mantid

--- a/Framework/Algorithms/inc/MantidAlgorithms/RemoveInstrumentGeometry.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/RemoveInstrumentGeometry.h
@@ -12,8 +12,11 @@
 namespace Mantid {
 namespace Algorithms {
 
-/** RemoveInstrumentGeometry : TODO: DESCRIPTION
- */
+/** RemoveInstrumentGeometry :
+
+  Removes instrument geometry records from a given workspace.
+*/
+
 class MANTID_ALGORITHMS_DLL RemoveInstrumentGeometry : public API::Algorithm {
 public:
   const std::string name() const override;

--- a/Framework/Algorithms/src/RemoveInstrumentGeometry.cpp
+++ b/Framework/Algorithms/src/RemoveInstrumentGeometry.cpp
@@ -1,0 +1,50 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2022 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+
+#include "MantidAlgorithms/RemoveInstrumentGeometry.h"
+
+namespace Mantid {
+namespace Algorithms {
+using Mantid::API::WorkspaceProperty;
+using Mantid::Kernel::Direction;
+
+// Register the algorithm into the AlgorithmFactory
+DECLARE_ALGORITHM(RemoveInstrumentGeometry)
+
+//----------------------------------------------------------------------------------------------
+
+/// Algorithms name for identification. @see Algorithm::name
+const std::string RemoveInstrumentGeometry::name() const { return "RemoveInstrumentGeometry"; }
+
+/// Algorithm's version for identification. @see Algorithm::version
+int RemoveInstrumentGeometry::version() const { return 1; }
+
+/// Algorithm's category for identification. @see Algorithm::category
+const std::string RemoveInstrumentGeometry::category() const { return "TODO: FILL IN A CATEGORY"; }
+
+/// Algorithm's summary for use in the GUI and help. @see Algorithm::summary
+const std::string RemoveInstrumentGeometry::summary() const { return "TODO: FILL IN A SUMMARY"; }
+
+//----------------------------------------------------------------------------------------------
+/** Initialize the algorithm's properties.
+ */
+void RemoveInstrumentGeometry::init() {
+  declareProperty(std::make_unique<WorkspaceProperty<API::Workspace>>("InputWorkspace", "", Direction::Input),
+                  "An input workspace.");
+  declareProperty(std::make_unique<WorkspaceProperty<API::Workspace>>("OutputWorkspace", "", Direction::Output),
+                  "An output workspace.");
+}
+
+//----------------------------------------------------------------------------------------------
+/** Execute the algorithm.
+ */
+void RemoveInstrumentGeometry::exec() {
+  // TODO Auto-generated execute stub
+}
+
+} // namespace Algorithms
+} // namespace Mantid

--- a/Framework/Algorithms/src/RemoveInstrumentGeometry.cpp
+++ b/Framework/Algorithms/src/RemoveInstrumentGeometry.cpp
@@ -7,6 +7,7 @@
 
 #include "MantidAlgorithms/RemoveInstrumentGeometry.h"
 #include "MantidAPI/Workspace.h"
+#include "MantidKernel/ArrayProperty.h"
 
 namespace Mantid {
 namespace Algorithms {
@@ -38,6 +39,10 @@ void RemoveInstrumentGeometry::init() {
                   "An input workspace.");
   declareProperty(std::make_unique<WorkspaceProperty<API::Workspace>>("OutputWorkspace", "", Direction::Output),
                   "An output workspace.");
+  declareProperty(std::make_unique<Kernel::ArrayProperty<int>>("MDExperimentInfoNumbers"),
+                  "For MD workspaces, the ExperimentInfo indices to have the instrument removed."
+                  "If empty, the instrument will be removed from all ExperimentInfo objects."
+                  "The parameter is ignored for any other workspace type.");
 }
 
 //----------------------------------------------------------------------------------------------
@@ -47,9 +52,9 @@ void RemoveInstrumentGeometry::exec() {
   // TODO Auto-generated execute stub
   API::Workspace_const_sptr inputWS = this->getProperty("InputWorkspace");
   API::Workspace_sptr outputWS = this->getProperty("OutputWorkspace");
-  // if (outputWS != inputWS) {
-  outputWS = inputWS->clone();
-  //}
+  if (outputWS != inputWS) {
+    outputWS = inputWS->clone();
+  }
   this->setProperty("OutputWorkspace", outputWS);
 }
 

--- a/Framework/Algorithms/src/RemoveInstrumentGeometry.cpp
+++ b/Framework/Algorithms/src/RemoveInstrumentGeometry.cpp
@@ -6,9 +6,17 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 
 #include "MantidAlgorithms/RemoveInstrumentGeometry.h"
-#include "MantidAPI/Workspace.h"
+#include "MantidAPI/IMDEventWorkspace.h"
+#include "MantidAPI/MatrixWorkspace.h"
+#include "MantidGeometry/Instrument.h"
 #include "MantidKernel/ArrayProperty.h"
 
+#include <boost/algorithm/string/classification.hpp>
+#include <boost/algorithm/string/split.hpp>
+#include <boost/lexical_cast.hpp>
+
+using namespace Mantid::API;
+using namespace Mantid::Geometry;
 namespace Mantid {
 namespace Algorithms {
 using Mantid::API::WorkspaceProperty;
@@ -26,10 +34,12 @@ const std::string RemoveInstrumentGeometry::name() const { return "RemoveInstrum
 int RemoveInstrumentGeometry::version() const { return 1; }
 
 /// Algorithm's category for identification. @see Algorithm::category
-const std::string RemoveInstrumentGeometry::category() const { return "TODO: FILL IN A CATEGORY"; }
+const std::string RemoveInstrumentGeometry::category() const { return "Utility\\Workspaces"; }
 
 /// Algorithm's summary for use in the GUI and help. @see Algorithm::summary
-const std::string RemoveInstrumentGeometry::summary() const { return "TODO: FILL IN A SUMMARY"; }
+const std::string RemoveInstrumentGeometry::summary() const {
+  return "Removes instrument geometry records from a given workspace.";
+}
 
 //----------------------------------------------------------------------------------------------
 /** Initialize the algorithm's properties.
@@ -49,12 +59,48 @@ void RemoveInstrumentGeometry::init() {
 /** Execute the algorithm.
  */
 void RemoveInstrumentGeometry::exec() {
-  // TODO Auto-generated execute stub
-  API::Workspace_const_sptr inputWS = this->getProperty("InputWorkspace");
-  API::Workspace_sptr outputWS = this->getProperty("OutputWorkspace");
+  Workspace_const_sptr inputWS = this->getProperty("InputWorkspace");
+
+  Workspace_sptr outputWS = this->getProperty("OutputWorkspace");
   if (outputWS != inputWS) {
     outputWS = inputWS->clone();
   }
+
+  // create an empty instrument
+  Instrument_sptr emptyInstrument(new Geometry::Instrument());
+
+  MatrixWorkspace_sptr outputMtrxWS = std::dynamic_pointer_cast<API::MatrixWorkspace>(outputWS);
+  if (outputMtrxWS != nullptr) { // it is a matrix workspace
+    outputMtrxWS->setInstrument(emptyInstrument);
+  } else {
+    MultipleExperimentInfos_sptr outputMDWS = std::dynamic_pointer_cast<Mantid::API::MultipleExperimentInfos>(outputWS);
+    if (outputMDWS != nullptr) { // it is an MD workspace
+                                 // for which experiment indices do we need to remove the instrument geometry?
+      std::vector<uint16_t> indicesToRemoveInstrument;
+      std::string indicesToRemoveInstrument_str = this->getProperty("MDExperimentInfoNumbers");
+      if (!indicesToRemoveInstrument_str.empty()) {
+        std::vector<std::string> strs;
+        boost::split(strs, indicesToRemoveInstrument_str, boost::is_any_of(","));
+        if (!strs.empty()) {
+          std::transform(strs.begin(), strs.end(), std::back_inserter(indicesToRemoveInstrument),
+                         [&](std::string s) { return boost::lexical_cast<uint16_t>(s); });
+        } else {
+          throw std::invalid_argument("Invalid argument MDExperimentInfoNumbers");
+        }
+      } else { // use all available indices
+        indicesToRemoveInstrument.resize(outputMDWS->getNumExperimentInfo());
+        std::iota(indicesToRemoveInstrument.begin(), indicesToRemoveInstrument.end(), 0U);
+      }
+
+      for (uint16_t i = 0; i < indicesToRemoveInstrument.size(); i++) {
+        auto ei = outputMDWS->getExperimentInfo(indicesToRemoveInstrument[i]);
+        ei->setInstrument(emptyInstrument);
+      }
+    } else {
+      throw std::invalid_argument("Wrong type of input workspace");
+    }
+  }
+
   this->setProperty("OutputWorkspace", outputWS);
 }
 

--- a/Framework/Algorithms/src/RemoveInstrumentGeometry.cpp
+++ b/Framework/Algorithms/src/RemoveInstrumentGeometry.cpp
@@ -6,6 +6,7 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 
 #include "MantidAlgorithms/RemoveInstrumentGeometry.h"
+#include "MantidAPI/Workspace.h"
 
 namespace Mantid {
 namespace Algorithms {
@@ -44,6 +45,12 @@ void RemoveInstrumentGeometry::init() {
  */
 void RemoveInstrumentGeometry::exec() {
   // TODO Auto-generated execute stub
+  API::Workspace_const_sptr inputWS = this->getProperty("InputWorkspace");
+  API::Workspace_sptr outputWS = this->getProperty("OutputWorkspace");
+  // if (outputWS != inputWS) {
+  outputWS = inputWS->clone();
+  //}
+  this->setProperty("OutputWorkspace", outputWS);
 }
 
 } // namespace Algorithms

--- a/Framework/Algorithms/src/RemoveInstrumentGeometry.cpp
+++ b/Framework/Algorithms/src/RemoveInstrumentGeometry.cpp
@@ -75,25 +75,16 @@ void RemoveInstrumentGeometry::exec() {
   } else {
     MultipleExperimentInfos_sptr outputMDWS = std::dynamic_pointer_cast<Mantid::API::MultipleExperimentInfos>(outputWS);
     if (outputMDWS != nullptr) { // it is an MD workspace
-                                 // for which experiment indices do we need to remove the instrument geometry?
-      std::vector<uint16_t> indicesToRemoveInstrument;
-      std::string indicesToRemoveInstrument_str = this->getProperty("MDExperimentInfoNumbers");
-      if (!indicesToRemoveInstrument_str.empty()) {
-        std::vector<std::string> strs;
-        boost::split(strs, indicesToRemoveInstrument_str, boost::is_any_of(","));
-        if (!strs.empty()) {
-          std::transform(strs.begin(), strs.end(), std::back_inserter(indicesToRemoveInstrument),
-                         [&](std::string s) { return boost::lexical_cast<uint16_t>(s); });
-        } else {
-          throw std::invalid_argument("Invalid argument MDExperimentInfoNumbers");
-        }
-      } else { // use all available indices
+                                 // which experiments do we remove instrument geometry from?
+      std::vector<int> indicesToRemoveInstrument = this->getProperty("MDExperimentInfoNumbers");
+
+      if (indicesToRemoveInstrument.empty()) { // remove instrument geometry from all experiments
         indicesToRemoveInstrument.resize(outputMDWS->getNumExperimentInfo());
-        std::iota(indicesToRemoveInstrument.begin(), indicesToRemoveInstrument.end(), 0U);
+        std::iota(indicesToRemoveInstrument.begin(), indicesToRemoveInstrument.end(), 0);
       }
 
       for (uint16_t i = 0; i < indicesToRemoveInstrument.size(); i++) {
-        auto ei = outputMDWS->getExperimentInfo(indicesToRemoveInstrument[i]);
+        auto ei = outputMDWS->getExperimentInfo(static_cast<uint16_t>(indicesToRemoveInstrument[i]));
         ei->setInstrument(emptyInstrument);
       }
     } else {

--- a/Framework/Algorithms/test/RemoveInstrumentGeometryTest.h
+++ b/Framework/Algorithms/test/RemoveInstrumentGeometryTest.h
@@ -1,0 +1,52 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2022 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#pragma once
+
+#include <cxxtest/TestSuite.h>
+
+#include "MantidAlgorithms/RemoveInstrumentGeometry.h"
+
+using Mantid::Algorithms::RemoveInstrumentGeometry;
+
+class RemoveInstrumentGeometryTest : public CxxTest::TestSuite {
+public:
+  // This pair of boilerplate methods prevent the suite being created statically
+  // This means the constructor isn't called when running other tests
+  static RemoveInstrumentGeometryTest *createSuite() { return new RemoveInstrumentGeometryTest(); }
+  static void destroySuite(RemoveInstrumentGeometryTest *suite) { delete suite; }
+
+  void test_Init() {
+    RemoveInstrumentGeometry alg;
+    TS_ASSERT_THROWS_NOTHING(alg.initialize())
+    TS_ASSERT(alg.isInitialized())
+  }
+
+  void test_exec() {
+    // Create test input if necessary
+    MatrixWorkspace_sptr
+        inputWS = //-- Fill in appropriate code. Consider using TestHelpers/WorkspaceCreationHelpers.h --
+
+        RemoveInstrumentGeometry alg;
+    // Don't put output in ADS by default
+    alg.setChild(true);
+    TS_ASSERT_THROWS_NOTHING(alg.initialize())
+    TS_ASSERT(alg.isInitialized())
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("InputWorkspace", inputWS));
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("OutputWorkspace", "_unused_for_child"));
+    TS_ASSERT_THROWS_NOTHING(alg.execute(););
+    TS_ASSERT(alg.isExecuted());
+
+    // Retrieve the workspace from the algorithm. The type here will probably need to change. It should
+    // be the type using in declareProperty for the "OutputWorkspace" type.
+    // We can't use auto as it's an implicit conversion.
+    Workspace_sptr outputWS = alg.getProperty("OutputWorkspace");
+    TS_ASSERT(outputWS);
+    TS_FAIL("TODO: Check the results and remove this line");
+  }
+
+  void test_Something() { TS_FAIL("You forgot to write a test!"); }
+};

--- a/docs/source/algorithms/RemoveInstrumentGeometry-v1.rst
+++ b/docs/source/algorithms/RemoveInstrumentGeometry-v1.rst
@@ -22,13 +22,14 @@ Usage
 
     # create some workspace with an instrument
     ws = CreateSampleWorkspace()
-    print("Instrument Geometry exists:  {}".format(!ws.getInstrument().isEmptyInstrument()))
+    print("Instrument Geometry exists:  {}".format(ws.getInstrument().nElements() > 0))
 
     # delete instrument geometry
-    RemoveInstrumentGeometry(ws)
-    print("Instrument Geometry exists (should be false):  {}".format(!ws.getInstrument().isEmptyInstrument()))
+    ws = RemoveInstrumentGeometry(ws)
+    print("Instrument Geometry is empty:  {}".format(ws.getInstrument().nElements() == 0))
 
-.. testcleanup:: RemoveInstrumentGeometry
+
+.. testcleanup:: RemoveInstrumentGeometryExample
 
    DeleteWorkspace(ws)
 
@@ -39,7 +40,7 @@ Output:
 .. testoutput:: RemoveInstrumentGeometryExample
 
     Instrument Geometry exists:  True
-    Instrument Geometry exists (should be false):  False
+    Instrument Geometry is empty:  True
 
 .. categories::
 

--- a/docs/source/algorithms/RemoveInstrumentGeometry-v1.rst
+++ b/docs/source/algorithms/RemoveInstrumentGeometry-v1.rst
@@ -22,11 +22,11 @@ Usage
 
     # create some workspace with an instrument
     ws = CreateSampleWorkspace()
-    print("Instrument Geometry exists:  {}".format(ws.getInstrument().nElements() > 0))
+    print("Instrument Geometry exists:  {}".format(ws.getInstrument().nelements() > 0))
 
     # delete instrument geometry
     ws = RemoveInstrumentGeometry(ws)
-    print("Instrument Geometry is empty:  {}".format(ws.getInstrument().nElements() == 0))
+    print("Instrument Geometry is empty:  {}".format(ws.getInstrument().nelements() == 0))
 
 
 .. testcleanup:: RemoveInstrumentGeometryExample

--- a/docs/source/algorithms/RemoveInstrumentGeometry-v1.rst
+++ b/docs/source/algorithms/RemoveInstrumentGeometry-v1.rst
@@ -1,0 +1,46 @@
+
+.. algorithm::
+
+.. summary::
+
+.. relatedalgorithms::
+
+.. properties::
+
+Description
+-----------
+
+TODO: Enter a full rst-markup description of your algorithm here.
+
+
+Usage
+-----
+..  Try not to use files in your examples,
+    but if you cannot avoid it then the (small) files must be added to
+    autotestdata\UsageData and the following tag unindented
+    .. include:: ../usagedata-note.txt
+
+**Example - RemoveInstrumentGeometry**
+
+.. testcode:: RemoveInstrumentGeometryExample
+
+   # Create a host workspace
+   ws = CreateWorkspace(DataX=range(0,3), DataY=(0,2))
+   or
+   ws = CreateSampleWorkspace()
+
+   wsOut = RemoveInstrumentGeometry()
+
+   # Print the result
+   print "The output workspace has %%i spectra" %% wsOut.getNumberHistograms()
+
+Output:
+
+.. testoutput:: RemoveInstrumentGeometryExample
+
+  The output workspace has ?? spectra
+
+.. categories::
+
+.. sourcelink::
+

--- a/docs/source/algorithms/RemoveInstrumentGeometry-v1.rst
+++ b/docs/source/algorithms/RemoveInstrumentGeometry-v1.rst
@@ -10,35 +10,36 @@
 Description
 -----------
 
-TODO: Enter a full rst-markup description of your algorithm here.
+Remove Instrument Geometry from workspace.
 
 
 Usage
 -----
-..  Try not to use files in your examples,
-    but if you cannot avoid it then the (small) files must be added to
-    autotestdata\UsageData and the following tag unindented
-    .. include:: ../usagedata-note.txt
 
 **Example - RemoveInstrumentGeometry**
 
 .. testcode:: RemoveInstrumentGeometryExample
 
-   # Create a host workspace
-   ws = CreateWorkspace(DataX=range(0,3), DataY=(0,2))
-   or
-   ws = CreateSampleWorkspace()
+    # create some workspace with an instrument
+    ws = CreateSampleWorkspace()
+    print("Instrument Geometry exists:  {}".format(!ws.getInstrument().isEmptyInstrument()))
 
-   wsOut = RemoveInstrumentGeometry()
+    # delete instrument geometry
+    RemoveInstrumentGeometry(ws)
+    print("Instrument Geometry exists (should be false):  {}".format(!ws.getInstrument().isEmptyInstrument()))
 
-   # Print the result
-   print "The output workspace has %%i spectra" %% wsOut.getNumberHistograms()
+.. testcleanup:: RemoveInstrumentGeometry
+
+   DeleteWorkspace(ws)
+
+
 
 Output:
 
 .. testoutput:: RemoveInstrumentGeometryExample
 
-  The output workspace has ?? spectra
+    Instrument Geometry exists:  True
+    Instrument Geometry exists (should be false):  False
 
 .. categories::
 

--- a/docs/source/release/v6.6.0/Framework/Algorithms/New_features/34818.rst
+++ b/docs/source/release/v6.6.0/Framework/Algorithms/New_features/34818.rst
@@ -1,0 +1,1 @@
+- Added support for removal of instrument information from workspace - see :ref:`RemoveInstrumentGeometry <algm-RemoveInstrumentGeometry>`. This will allow saving smaller nexus files.


### PR DESCRIPTION
**Description of work.**

The issue: https://code.ornl.gov/sns-hfir-scse/spectroscopy/spectroscopy/-/issues/128

Created an algorithm and a test for removal of instrument information from workspace.  The algorithm sets an empty Instrument object to one or more experiments contained in the workspace.


**To test:**

ctest -R RemoveInstrumentGeometry

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
