### PR TITLE
Fix missing script from nightly pipeline

### DIFF
--- a/buildconfig/Jenkins/Conda/package-standalone
+++ b/buildconfig/Jenkins/Conda/package-standalone
@@ -19,6 +19,9 @@
 # Possible parameters:
 #   --package-suffix: An optional suffix to pass to the standalone package step.
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source $SCRIPT_DIR/mamba-utils
+
 # Setup expected variables
 WORKSPACE=$1
 if [[ -z "$WORKSPACE" ]]; then


### PR DESCRIPTION
**Description of work.**
The nightly pipeline is failing on the standalone packaging segment because a call to the mamba_utils script is missing.

**To test:**

Check the tests pass and code review

*There is no associated issue.*

*This does not require release notes* because **the nightly pipeline is not user facing**


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
