### PR TITLE
Improve performance of POLARIS total scattering reduction

### DIFF
--- a/Testing/SystemTests/tests/framework/ISIS_PowderPolarisTest.py
+++ b/Testing/SystemTests/tests/framework/ISIS_PowderPolarisTest.py
@@ -361,7 +361,7 @@ class TotalScatteringFourierFilterTest(systemtesting.MantidSystemTest):
         self.assertTrue(x_data[idx_to_check_filter] < self.r_min)
         self.assertAlmostEqual(y_data[idx_to_check_filter], 0.0, places=1)
         idx = get_bin_number_at_given_r(self.pdf_output.dataX(0), 3.9)
-        self.assertAlmostEqual(y_data[idx], 2.6743, places=3)
+        self.assertAlmostEqual(y_data[idx], 2.6732, places=3)
 
 
 class TotalScatteringLorchFilterTest(systemtesting.MantidSystemTest):

--- a/docs/source/release/v6.6.0/Diffraction/Powder/New_features/34822.rst
+++ b/docs/source/release/v6.6.0/Diffraction/Powder/New_features/34822.rst
@@ -1,0 +1,1 @@
+- Increase the speed of the fourier filter in the POLARIS total scattering reduction by reducing the Rmax parameter used in the pair of (forward and backward) PDFFourierTransform calls and optimising the integration code inside :ref:`PDFFourierTransform v2 <algm-PDFFourierTransform-v2>`

--- a/scripts/Diffraction/isis_powder/polaris_routines/polaris_algs.py
+++ b/scripts/Diffraction/isis_powder/polaris_routines/polaris_algs.py
@@ -238,9 +238,9 @@ def fast_fourier_filter(ws, rho0, freq_params=None):
         r_min = freq_params[0]
         # If no maximum r is given a high r_max prevents loss of detail on the output.
         if len(freq_params) > 1:
-            r_max = min(freq_params[1], 1000)
+            r_max = freq_params[1]
         else:
-            r_max = 1000
+            r_max = 200
         ws_name = str(ws)
         mantid.PDFFourierTransform(Inputworkspace=ws_name, OutputWorkspace=ws_name, SofQType="S(Q)-1", PDFType="g(r)",
                                    Filter=True, DeltaR=0.01, Rmax=r_max, Direction='Forward', rho0=rho0)


### PR DESCRIPTION
**Description of work.**

The total scattering reduction takes a long time if a fourier filter is applied particularly if merge_banks is set to False. The calls to PDFFourierTransform2 are the problem. Having profiled the code the time is taken during the calls to the trigonometric functions (sin and cos) inside a double loop where the Fourier Transform is evaluated.

I've made two changes to speed things up:

1) code change to PDFFourierTransform2.cpp where I've edited the logic to evaluate the integral between each pair of x values to reuse the value evaluated at the right hand limit on the next iteration of the loop (when this becomes the left hand limit). This gives about a x1.6 speed-up
2) the rmax value supplied to PDFFourierTransform2 from the POLARIS scripts has been reduced from 1000 to 200. This gives about a x5 speed-up

**To test:**

Unzip the zip file attached to #34144 which contains some config files necessary to run a POLARIS reduction
Update config_file_path in script below to match where you unzipped the files to + also update the path inside the `polaris_config_example.yaml` config file.
Run the script and note how long it takes and make a copy of the workspace group called `98533_pdf_R`. The setting `freq_params=[1.4]` activates a fourier filter and tells the reduction to set the pdf to 0 for r<1.4 angstroms. Then run the script on the current main code and verify that it's now quicker and that the `98533_pdf_R` workspace group is almost the same
```
# import mantid algorithms, numpy and matplotlib
from mantid.simpleapi import *
import matplotlib.pyplot as plt
import numpy as np

from isis_powder import polaris, SampleDetails

config_file_path = r"C:\Total Scattering\polaris_config_example.yaml"
# mode PDF means normalisation method defaults to absolute
polaris = polaris.Polaris(config_file=config_file_path, user_name="test", mode="PDF")

sample_details = SampleDetails(height=4.0, radius=0.2985, center=[0, 0, 0], shape='cylinder')
# for a compound, need to supply two of number_density, number_density_effective and packing_fraction
sample_details.set_material(chemical_formula='Si', packing_fraction=0.6)
polaris.set_sample_details(sample=sample_details)

polaris.create_vanadium(first_cycle_run_no="98532", multiple_scattering=False)

polaris.focus(run_number="98533", input_mode='Summed')

q_lim = [[2.5, 3, 4, 6, 7], [3.5, 5, 7, 11, 40]]

polaris.create_total_scattering_pdf(run_number="98533", merge_banks=False, q_lims=q_lim, 
                                    freq_params=[1.4], pdf_type="g(r)", debug=True)
```

*There is no associated issue.*

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
