### PR TITLE
Cleaner check for nexus file version in Salsa loader

### DIFF
--- a/Framework/DataHandling/src/LoadILLSALSA.cpp
+++ b/Framework/DataHandling/src/LoadILLSALSA.cpp
@@ -67,22 +67,15 @@ void LoadILLSALSA::exec() {
 
   FileType fileType = NONE;
   // guess type of file
-  try {
-    H5::Group detectorDataset = h5file.openGroup("entry0/data");
-    detectorDataset.close();
+  if (!h5file.nameExists("entry0"))
+    throw std::runtime_error(
+        "The Nexus file your are trying to open is incorrectly formatted, 'entry0' group does not exist");
+  H5::Group entryGroup = h5file.openGroup("entry0");
+  if (entryGroup.nameExists("data"))
     fileType = V1;
-  } catch (H5::Exception &) {
-    fileType = NONE;
-  }
-  if (fileType == NONE) {
-    try {
-      H5::Group detectorDataset = h5file.openGroup("entry0/data_scan");
-      detectorDataset.close();
-      fileType = V2;
-    } catch (H5::Exception &) {
-      fileType = NONE;
-    }
-  }
+  else if (entryGroup.nameExists("data_scan"))
+    fileType = V2;
+  entryGroup.close();
 
   switch (fileType) {
   case NONE:


### PR DESCRIPTION
This PR slightly changes the way the nexus file version is checked for Salsa instrument.

Instead of a nested try/catch, it uses `H5::H5Location::nameExists` which was not available in the previous version of the HDF5 library.

**To test:**

* Code review
* Follow the description of the original Salsa loader PR: #33693.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
