### PR TITLE
Make Inelastic Iqt tab mvp

### DIFF
--- a/qt/scientific_interfaces/Indirect/CMakeLists.txt
+++ b/qt/scientific_interfaces/Indirect/CMakeLists.txt
@@ -85,6 +85,7 @@ set(SRC_FILES
     InelasticDataManipulationElwinTabView.cpp
     InelasticDataManipulationIqtTab.cpp
     InelasticDataManipulationIqtTabView.cpp
+    InelasticDataManipulationIqtTabModel.cpp
     InelasticDataManipulationMomentsTab.cpp
     InelasticDataManipulationMomentsTabModel.cpp
     InelasticDataManipulationMomentsTabView.cpp
@@ -173,6 +174,7 @@ set(MOC_FILES
     InelasticDataManipulationElwinTabView.h
     InelasticDataManipulationIqtTab.h
     InelasticDataManipulationIqtTabView.h
+    InelasticDataManipulationIqtTabModel.h
     InelasticDataManipulationMomentsTab.h
     InelasticDataManipulationMomentsTabView.h
     InelasticDataManipulationSqwTab.h

--- a/qt/scientific_interfaces/Indirect/CMakeLists.txt
+++ b/qt/scientific_interfaces/Indirect/CMakeLists.txt
@@ -84,6 +84,7 @@ set(SRC_FILES
     InelasticDataManipulationElwinTabModel.cpp
     InelasticDataManipulationElwinTabView.cpp
     InelasticDataManipulationIqtTab.cpp
+    InelasticDataManipulationIqtTabView.cpp
     InelasticDataManipulationMomentsTab.cpp
     InelasticDataManipulationMomentsTabModel.cpp
     InelasticDataManipulationMomentsTabView.cpp
@@ -171,6 +172,7 @@ set(MOC_FILES
     InelasticDataManipulationElwinTabModel.h
     InelasticDataManipulationElwinTabView.h
     InelasticDataManipulationIqtTab.h
+    InelasticDataManipulationIqtTabView.h
     InelasticDataManipulationMomentsTab.h
     InelasticDataManipulationMomentsTabView.h
     InelasticDataManipulationSqwTab.h

--- a/qt/scientific_interfaces/Indirect/InelasticDataManipulationElwinTab.cpp
+++ b/qt/scientific_interfaces/Indirect/InelasticDataManipulationElwinTab.cpp
@@ -12,7 +12,6 @@
 #include "MantidAPI/MatrixWorkspace.h"
 #include "MantidGeometry/Instrument.h"
 #include "MantidQtWidgets/Common/SignalBlocker.h"
-#include "MantidQtWidgets/Plotting/RangeSelector.h"
 
 #include <QFileInfo>
 
@@ -107,6 +106,7 @@ InelasticDataManipulationElwinTab::InelasticDataManipulationElwinTab(QWidget *pa
 
   setOutputPlotOptionsPresenter(
       std::make_unique<IndirectPlotOptionsPresenter>(m_view->getPlotOptions(), PlotWidget::Spectra));
+  connect(m_view.get(), SIGNAL(showMessageBox(const QString &)), this, SIGNAL(showMessageBox(const QString &)));
   connect(m_view.get(), SIGNAL(addDataClicked()), this, SLOT(showAddWorkspaceDialog()));
   connect(m_view.get(), SIGNAL(removeDataClicked()), this, SLOT(removeSelectedData()));
 

--- a/qt/scientific_interfaces/Indirect/InelasticDataManipulationElwinTabView.cpp
+++ b/qt/scientific_interfaces/Indirect/InelasticDataManipulationElwinTabView.cpp
@@ -5,11 +5,11 @@
 //   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 // SPDX - License - Identifier: GPL - 3.0 +
 #include "InelasticDataManipulationElwinTabView.h"
-#include "MantidQtWidgets/Common/AlgorithmRuntimeProps.h"
-#include "MantidQtWidgets/Common/UserInputValidator.h"
-
 #include "MantidGeometry/Instrument.h"
+#include "MantidQtWidgets/Common/AlgorithmRuntimeProps.h"
+#include "MantidQtWidgets/Common/QtPropertyBrowser/qteditorfactory.h"
 #include "MantidQtWidgets/Common/SignalBlocker.h"
+#include "MantidQtWidgets/Common/UserInputValidator.h"
 #include "MantidQtWidgets/Plotting/RangeSelector.h"
 
 #include <QFileInfo>

--- a/qt/scientific_interfaces/Indirect/InelasticDataManipulationElwinTabView.h
+++ b/qt/scientific_interfaces/Indirect/InelasticDataManipulationElwinTabView.h
@@ -8,8 +8,6 @@
 
 #include "IAddWorkspaceDialog.h"
 #include "IndirectFitDataModel.h"
-#include "InelasticDataManipulation.h"
-#include "InelasticDataManipulationElwinTabView.h"
 #include "InelasticDataManipulationTab.h"
 #include "MantidAPI/MatrixWorkspace.h"
 #include "MantidAPI/MatrixWorkspace_fwd.h"

--- a/qt/scientific_interfaces/Indirect/InelasticDataManipulationIqtTab.cpp
+++ b/qt/scientific_interfaces/Indirect/InelasticDataManipulationIqtTab.cpp
@@ -51,7 +51,7 @@ void InelasticDataManipulationIqtTab::setup() {
   connect(m_view.get(), SIGNAL(saveClicked()), this, SLOT(saveClicked()));
   connect(m_view.get(), SIGNAL(plotCurrentPreview()), this, SLOT(plotCurrentPreview()));
 
-  connect(m_view.get(), SIGNAL(PreviewSpectrumChanged(int)), this, SLOT(handlePreviewSpectrumChanged(int)));
+  connect(m_view.get(), SIGNAL(previewSpectrumChanged(int)), this, SLOT(handlePreviewSpectrumChanged(int)));
 
   m_view->setup();
 }

--- a/qt/scientific_interfaces/Indirect/InelasticDataManipulationIqtTab.cpp
+++ b/qt/scientific_interfaces/Indirect/InelasticDataManipulationIqtTab.cpp
@@ -72,108 +72,53 @@ std::tuple<bool, float, int, int> calculateBinParameters(std::string const &wsNa
 
 namespace MantidQt::CustomInterfaces::IDA {
 InelasticDataManipulationIqtTab::InelasticDataManipulationIqtTab(QWidget *parent)
-    : InelasticDataManipulationTab(parent), m_iqtTree(nullptr), m_iqtResFileType(), m_selectedSpectrum(0) {
-  m_uiForm.setupUi(parent);
+    : InelasticDataManipulationTab(parent), m_view(std::make_unique<InelasticDataManipulationIqtTabView>(parent)),
+      m_iqtResFileType(), m_selectedSpectrum(0) {
   setOutputPlotOptionsPresenter(
-      std::make_unique<IndirectPlotOptionsPresenter>(m_uiForm.ipoPlotOptions, PlotWidget::SpectraTiled));
+      std::make_unique<IndirectPlotOptionsPresenter>(m_view->getPlotOptions(), PlotWidget::SpectraTiled));
 }
 
-InelasticDataManipulationIqtTab::~InelasticDataManipulationIqtTab() { m_iqtTree->unsetFactoryForManager(m_dblManager); }
+InelasticDataManipulationIqtTab::~InelasticDataManipulationIqtTab() {}
 
 void InelasticDataManipulationIqtTab::setup() {
-  m_iqtTree = new QtTreePropertyBrowser();
-  m_uiForm.properties->addWidget(m_iqtTree);
-
-  // Number of decimal places in property browsers.
-  static const unsigned int NUM_DECIMALS = 6;
-  // Create and configure properties
-  m_properties["ELow"] = m_dblManager->addProperty("ELow");
-  m_dblManager->setDecimals(m_properties["ELow"], NUM_DECIMALS);
-
-  m_properties["EWidth"] = m_dblManager->addProperty("EWidth");
-  m_dblManager->setDecimals(m_properties["EWidth"], NUM_DECIMALS);
-  m_properties["EWidth"]->setEnabled(false);
-
-  m_properties["EHigh"] = m_dblManager->addProperty("EHigh");
-  m_dblManager->setDecimals(m_properties["EHigh"], NUM_DECIMALS);
-
-  m_properties["SampleBinning"] = m_dblManager->addProperty("SampleBinning");
-  m_dblManager->setDecimals(m_properties["SampleBinning"], 0);
-
-  m_properties["SampleBins"] = m_dblManager->addProperty("SampleBins");
-  m_dblManager->setDecimals(m_properties["SampleBins"], 0);
-  m_properties["SampleBins"]->setEnabled(false);
-
-  m_properties["ResolutionBins"] = m_dblManager->addProperty("ResolutionBins");
-  m_dblManager->setDecimals(m_properties["ResolutionBins"], 0);
-  m_properties["ResolutionBins"]->setEnabled(false);
-
-  m_iqtTree->addProperty(m_properties["ELow"]);
-  m_iqtTree->addProperty(m_properties["EWidth"]);
-  m_iqtTree->addProperty(m_properties["EHigh"]);
-  m_iqtTree->addProperty(m_properties["SampleBinning"]);
-  m_iqtTree->addProperty(m_properties["SampleBins"]);
-  m_iqtTree->addProperty(m_properties["ResolutionBins"]);
-
-  m_dblManager->setValue(m_properties["SampleBinning"], 10);
-
-  m_iqtTree->setFactoryForManager(m_dblManager, m_dblEdFac);
-
-  // Format the tree widget so its easier to read the contents
-  m_iqtTree->setIndentation(0);
-  for (auto const &item : m_properties)
-    m_iqtTree->setBackgroundColor(m_iqtTree->topLevelItem(item), QColor(246, 246, 246));
-
-  setPreviewSpectrumMaximum(0);
-
-  auto xRangeSelector = m_uiForm.ppPlot->addRangeSelector("IqtRange");
-  xRangeSelector->setBounds(-DBL_MAX, DBL_MAX);
-
   // signals / slots & validators
-  connect(xRangeSelector, SIGNAL(selectionChanged(double, double)), this, SLOT(rangeChanged(double, double)));
-  connect(m_dblManager, SIGNAL(valueChanged(QtProperty *, double)), this,
-          SLOT(updateRangeSelector(QtProperty *, double)));
-  connect(m_uiForm.dsInput, SIGNAL(dataReady(const QString &)), this, SLOT(plotInput(const QString &)));
-  connect(m_uiForm.dsResolution, SIGNAL(dataReady(const QString &)), this, SLOT(updateDisplayedBinParameters()));
+  connect(m_view.get(), SIGNAL(sampDataReady(const QString &)), this, SLOT(plotInput(const QString &)));
+
   connect(m_batchAlgoRunner, SIGNAL(batchComplete(bool)), this, SLOT(algorithmComplete(bool)));
-  connect(m_uiForm.pbRun, SIGNAL(clicked()), this, SLOT(runClicked()));
-  connect(m_uiForm.pbSave, SIGNAL(clicked()), this, SLOT(saveClicked()));
-  connect(m_uiForm.pbPlotPreview, SIGNAL(clicked()), this, SLOT(plotCurrentPreview()));
-  connect(m_uiForm.cbCalculateErrors, SIGNAL(clicked()), this, SLOT(errorsClicked()));
 
-  connect(m_uiForm.spPreviewSpec, SIGNAL(valueChanged(int)), this, SLOT(handlePreviewSpectrumChanged(int)));
+  connect(m_view.get(), SIGNAL(showMessageBox(const QString &)), this, SIGNAL(showMessageBox(const QString &)));
+  connect(m_view.get(), SIGNAL(runClicked()), this, SLOT(runClicked()));
+  connect(m_view.get(), SIGNAL(saveClicked()), this, SLOT(saveClicked()));
+  connect(m_view.get(), SIGNAL(plotCurrentPreview()), this, SLOT(plotCurrentPreview()));
 
-  connect(m_uiForm.ckSymmetricEnergy, SIGNAL(stateChanged(int)), this, SLOT(updateEnergyRange(int)));
-
-  m_uiForm.dsInput->isOptional(true);
-  m_uiForm.dsResolution->isOptional(true);
+  connect(m_view.get(), SIGNAL(PreviewSpectrumChanged(int)), this, SLOT(handlePreviewSpectrumChanged(int)));
 }
 
 void InelasticDataManipulationIqtTab::run() {
-  m_uiForm.ppPlot->watchADS(false);
+  m_view->setWatchADS(false);
   setRunIsRunning(true);
 
-  updateDisplayedBinParameters();
+  m_view->updateDisplayedBinParameters();
 
   // Construct the result workspace for Python script export
-  QString const sampleName = m_uiForm.dsInput->getCurrentDataName();
+  QString const sampleName = QString::fromStdString(m_view->getSampleName());
   m_pythonExportWsName = sampleName.left(sampleName.lastIndexOf("_")).toStdString() + "_iqt";
 
-  QString const wsName = m_uiForm.dsInput->getCurrentDataName();
-  QString const resName = m_uiForm.dsResolution->getCurrentDataName();
-  QString const nIterations = m_uiForm.spIterations->cleanText();
-  bool const calculateErrors = m_uiForm.cbCalculateErrors->isChecked();
+  auto const wsName = m_view->getSampleName();
+  auto const resName = m_view->getResolutionName();
+  auto const nIterations = m_view->getIterations();
+  bool const calculateErrors = m_view->getCalculateErrors();
 
-  double const energyMin = m_dblManager->value(m_properties["ELow"]);
-  double const energyMax = m_dblManager->value(m_properties["EHigh"]);
-  double const numBins = m_dblManager->value(m_properties["SampleBinning"]);
+  double const energyMin = m_view->getELow();
+  double const energyMax = m_view->getEHigh();
+  double const numBins = m_view->getSampleBinning();
 
   auto IqtAlg = AlgorithmManager::Instance().create("TransformToIqt");
   IqtAlg->initialize();
 
-  IqtAlg->setProperty("SampleWorkspace", wsName.toStdString());
-  IqtAlg->setProperty("ResolutionWorkspace", resName.toStdString());
-  IqtAlg->setProperty("NumberOfIterations", nIterations.toStdString());
+  IqtAlg->setProperty("SampleWorkspace", wsName);
+  IqtAlg->setProperty("ResolutionWorkspace", resName);
+  IqtAlg->setProperty("NumberOfIterations", nIterations);
   IqtAlg->setProperty("CalculateErrors", calculateErrors);
 
   IqtAlg->setProperty("EnergyMin", energyMin);
@@ -193,10 +138,10 @@ void InelasticDataManipulationIqtTab::run() {
  * @param error If the algorithm failed
  */
 void InelasticDataManipulationIqtTab::algorithmComplete(bool error) {
-  m_uiForm.ppPlot->watchADS(true);
+  m_view->setWatchADS(true);
   setRunIsRunning(false);
   if (error)
-    setSaveResultEnabled(false);
+    m_view->setSaveResultEnabled(false);
   else
     setOutputPlotOptionsWorkspaces({m_pythonExportWsName});
 }
@@ -215,95 +160,26 @@ void InelasticDataManipulationIqtTab::runClicked() {
   runTab();
 }
 
-void InelasticDataManipulationIqtTab::errorsClicked() { m_uiForm.spIterations->setEnabled(isErrorsEnabled()); }
-
-bool InelasticDataManipulationIqtTab::isErrorsEnabled() { return m_uiForm.cbCalculateErrors->isChecked(); }
-
 /**
  * Ensure we have present and valid file/ws inputs.
  *
  * The underlying Fourier transform of Iqt
  * also means we must enforce several rules on the parameters.
  */
-bool InelasticDataManipulationIqtTab::validate() {
-  UserInputValidator uiv;
-
-  uiv.checkDataSelectorIsValid("Sample", m_uiForm.dsInput);
-  uiv.checkDataSelectorIsValid("Resolution", m_uiForm.dsResolution);
-
-  auto const eLow = m_dblManager->value(m_properties["ELow"]);
-  auto const eHigh = m_dblManager->value(m_properties["EHigh"]);
-
-  if (eLow >= eHigh)
-    uiv.addErrorMessage("ELow must be less than EHigh.\n");
-
-  auto const message = uiv.generateErrorMessage();
-  showMessageBox(message);
-
-  return message.isEmpty();
-}
-
-/**
- * Calculates binning parameters.
- */
-void InelasticDataManipulationIqtTab::updateDisplayedBinParameters() {
-  auto const sampleName = m_uiForm.dsInput->getCurrentDataName().toStdString();
-  auto const resolutionName = m_uiForm.dsResolution->getCurrentDataName().toStdString();
-
-  auto &ads = AnalysisDataService::Instance();
-  if (!ads.doesExist(sampleName) || !ads.doesExist(resolutionName))
-    return;
-
-  double energyMin = m_dblManager->value(m_properties["ELow"]);
-  double energyMax = m_dblManager->value(m_properties["EHigh"]);
-  double numBins = m_dblManager->value(m_properties["SampleBinning"]);
-
-  if (numBins == 0)
-    return;
-  if (energyMin == 0 && energyMax == 0)
-    return;
-
-  bool success(false);
-  float energyWidth(0.0f);
-  int resolutionBins(0), sampleBins(0);
-  std::tie(success, energyWidth, sampleBins, resolutionBins) =
-      calculateBinParameters(sampleName, resolutionName, energyMin, energyMax, numBins);
-  if (success) {
-    disconnect(m_dblManager, SIGNAL(valueChanged(QtProperty *, double)), this,
-               SLOT(updateRangeSelector(QtProperty *, double)));
-
-    // Update data in property editor
-    m_dblManager->setValue(m_properties["EWidth"], energyWidth);
-    m_dblManager->setValue(m_properties["ResolutionBins"], resolutionBins);
-    m_dblManager->setValue(m_properties["SampleBins"], sampleBins);
-
-    connect(m_dblManager, SIGNAL(valueChanged(QtProperty *, double)), this,
-            SLOT(updateRangeSelector(QtProperty *, double)));
-
-    // Warn for low number of resolution bins
-    if (resolutionBins < 5)
-      showMessageBox("Results may be inaccurate as ResolutionBins is "
-                     "less than 5.\nLower the SampleBinning.");
-  }
-}
-
-void InelasticDataManipulationIqtTab::loadTabSettings(const QSettings &settings) {
-  m_uiForm.dsInput->readSettings(settings.group());
-  m_uiForm.dsResolution->readSettings(settings.group());
-}
+bool InelasticDataManipulationIqtTab::validate() { return m_view->validate(); }
 
 void InelasticDataManipulationIqtTab::handlePreviewSpectrumChanged(int spectra) {
   setSelectedSpectrum(spectra);
-  plotInput(m_uiForm.ppPlot);
+  m_view->plotInput(getInputWorkspace(), getSelectedSpectrum());
 }
 
 void InelasticDataManipulationIqtTab::setFileExtensionsByName(bool filter) {
   QStringList const noSuffixes{""};
   auto const tabName("Iqt");
-  m_uiForm.dsInput->setFBSuffixes(filter ? getSampleFBSuffixes(tabName) : getExtensions(tabName));
-  m_uiForm.dsInput->setWSSuffixes(filter ? getSampleWSSuffixes(tabName) : noSuffixes);
-  m_uiForm.dsResolution->setFBSuffixes(filter ? getResolutionFBSuffixes(tabName) : getExtensions(tabName));
-  m_uiForm.dsResolution->setWSSuffixes(filter ? getResolutionWSSuffixes(tabName) : noSuffixes);
+  m_view->setSampleFBSuffixes(filter ? getSampleFBSuffixes(tabName) : getExtensions(tabName));
+  m_view->setSampleWSSuffixes(filter ? getSampleWSSuffixes(tabName) : noSuffixes);
+  m_view->setResolutionFBSuffixes(filter ? getResolutionFBSuffixes(tabName) : getExtensions(tabName));
+  m_view->setResolutionWSSuffixes(filter ? getResolutionWSSuffixes(tabName) : noSuffixes);
 }
 
 void InelasticDataManipulationIqtTab::plotInput(const QString &wsname) {
@@ -313,171 +189,23 @@ void InelasticDataManipulationIqtTab::plotInput(const QString &wsname) {
     setInputWorkspace(workspace);
   } catch (Mantid::Kernel::Exception::NotFoundError &) {
     showMessageBox(QString("Unable to retrieve workspace: " + wsname));
-    setPreviewSpectrumMaximum(0);
+    m_view->setPreviewSpectrumMaximum(0);
     return;
   }
 
-  setPreviewSpectrumMaximum(static_cast<int>(getInputWorkspace()->getNumberHistograms()) - 1);
-
-  plotInput(m_uiForm.ppPlot);
-  auto xRangeSelector = m_uiForm.ppPlot->getRangeSelector("IqtRange");
-
-  try {
-    auto const range = getXRangeFromWorkspace(workspace);
-    double rounded_min(range.first);
-    double rounded_max(range.second);
-    const std::string instrName(workspace->getInstrument()->getName());
-    if (instrName == "BASIS") {
-      xRangeSelector->setRange(range.first, range.second);
-      m_dblManager->setValue(m_properties["ELow"], rounded_min);
-      m_dblManager->setValue(m_properties["EHigh"], rounded_max);
-      m_dblManager->setValue(m_properties["EWidth"], 0.0004);
-      m_dblManager->setValue(m_properties["SampleBinning"], 1);
-    } else {
-      rounded_min = floor(rounded_min * 10 + 0.5) / 10.0;
-      rounded_max = floor(rounded_max * 10 + 0.5) / 10.0;
-
-      // corrections for if nearest value is outside of range
-      if (rounded_max > range.second) {
-        rounded_max -= 0.1;
-      }
-
-      if (rounded_min < range.first) {
-        rounded_min += 0.1;
-      }
-
-      // check incase we have a really small range
-      if (fabs(rounded_min) > 0 && fabs(rounded_max) > 0) {
-        xRangeSelector->setRange(rounded_min, rounded_max);
-        m_dblManager->setValue(m_properties["ELow"], rounded_min);
-        m_dblManager->setValue(m_properties["EHigh"], rounded_max);
-      } else {
-        xRangeSelector->setRange(range.first, range.second);
-        m_dblManager->setValue(m_properties["ELow"], range.first);
-        m_dblManager->setValue(m_properties["EHigh"], range.second);
-      }
-      // set default value for width
-      m_dblManager->setValue(m_properties["EWidth"], 0.005);
-    }
-  } catch (std::invalid_argument &exc) {
-    showMessageBox(exc.what());
-  }
-
-  updateDisplayedBinParameters();
+  m_view->setPreviewSpectrumMaximum(static_cast<int>(getInputWorkspace()->getNumberHistograms()) - 1);
+  m_view->plotInput(getInputWorkspace(), getSelectedSpectrum());
+  m_view->setRangeSelectorDefault(getInputWorkspace(), getXRangeFromWorkspace(getInputWorkspace()));
+  m_view->updateDisplayedBinParameters();
 }
-
-/**
- * Plots the selected spectrum of the input workspace.
- *
- * @param previewPlot The preview plot widget in which to plot the input
- *                    input workspace.
- */
-void InelasticDataManipulationIqtTab::plotInput(MantidQt::MantidWidgets::PreviewPlot *previewPlot) {
-  previewPlot->clear();
-  auto inputWS = getInputWorkspace();
-  auto spectrum = getSelectedSpectrum();
-
-  if (inputWS && inputWS->x(spectrum).size() > 1)
-    previewPlot->addSpectrum("Sample", getInputWorkspace(), spectrum);
-}
-
-void InelasticDataManipulationIqtTab::setPreviewSpectrumMaximum(int value) {
-  m_uiForm.spPreviewSpec->setMaximum(value);
-}
-
-/**
- * Updates the range selectors and properties when range selector is moved.
- *
- * @param min Range selector min value
- * @param max Range selector max value
- */
-void InelasticDataManipulationIqtTab::rangeChanged(double min, double max) {
-  double oldMin = m_dblManager->value(m_properties["ELow"]);
-  double oldMax = m_dblManager->value(m_properties["EHigh"]);
-
-  auto xRangeSelector = m_uiForm.ppPlot->getRangeSelector("IqtRange");
-
-  disconnect(xRangeSelector, SIGNAL(selectionChanged(double, double)), this, SLOT(rangeChanged(double, double)));
-  disconnect(m_dblManager, SIGNAL(valueChanged(QtProperty *, double)), this,
-             SLOT(updateRangeSelector(QtProperty *, double)));
-
-  if (fabs(oldMin - min) > 0.0000001) {
-    m_dblManager->setValue(m_properties["ELow"], min);
-    xRangeSelector->setMinimum(min);
-    if (m_uiForm.ckSymmetricEnergy->isChecked()) {
-      m_dblManager->setValue(m_properties["EHigh"], -min);
-      xRangeSelector->setMaximum(-min);
-    }
-  }
-
-  if (fabs(oldMax - max) > 0.0000001) {
-    m_dblManager->setValue(m_properties["EHigh"], max);
-    xRangeSelector->setMaximum(max);
-    if (m_uiForm.ckSymmetricEnergy->isChecked()) {
-      m_dblManager->setValue(m_properties["ELow"], -max);
-      xRangeSelector->setMinimum(-max);
-    }
-  }
-
-  connect(xRangeSelector, SIGNAL(selectionChanged(double, double)), this, SLOT(rangeChanged(double, double)));
-  connect(m_dblManager, SIGNAL(valueChanged(QtProperty *, double)), this,
-          SLOT(updateRangeSelector(QtProperty *, double)));
-}
-
-/**
- * Updates the range selectors when the ELow or EHigh property is changed in the
- * table.
- *
- * @param prop The property which has been changed
- * @param val The new position for the range selector
- */
-void InelasticDataManipulationIqtTab::updateRangeSelector(QtProperty *prop, double val) {
-  auto xRangeSelector = m_uiForm.ppPlot->getRangeSelector("IqtRange");
-
-  disconnect(xRangeSelector, SIGNAL(selectionChanged(double, double)), this, SLOT(rangeChanged(double, double)));
-  disconnect(m_dblManager, SIGNAL(valueChanged(QtProperty *, double)), this,
-             SLOT(updateRangeSelector(QtProperty *, double)));
-
-  if (prop == m_properties["ELow"]) {
-    setRangeSelectorMin(m_properties["ELow"], m_properties["EHigh"], xRangeSelector, val);
-    if (m_uiForm.ckSymmetricEnergy->isChecked()) {
-      m_dblManager->setValue(m_properties["EHigh"], -val);
-      setRangeSelectorMax(m_properties["ELow"], m_properties["EHigh"], xRangeSelector, -val);
-    }
-
-  } else if (prop == m_properties["EHigh"]) {
-    setRangeSelectorMax(m_properties["ELow"], m_properties["EHigh"], xRangeSelector, val);
-    if (m_uiForm.ckSymmetricEnergy->isChecked()) {
-      m_dblManager->setValue(m_properties["ELow"], -val);
-      setRangeSelectorMin(m_properties["ELow"], m_properties["EHigh"], xRangeSelector, -val);
-    }
-  }
-
-  connect(xRangeSelector, SIGNAL(selectionChanged(double, double)), this, SLOT(rangeChanged(double, double)));
-  connect(m_dblManager, SIGNAL(valueChanged(QtProperty *, double)), this,
-          SLOT(updateRangeSelector(QtProperty *, double)));
-
-  updateDisplayedBinParameters();
-}
-
-void InelasticDataManipulationIqtTab::updateEnergyRange(int state) {
-  if (state != 0) {
-    auto const value = m_dblManager->value(m_properties["ELow"]);
-    m_dblManager->setValue(m_properties["EHigh"], -value);
-  }
-}
-
-void InelasticDataManipulationIqtTab::setRunEnabled(bool enabled) { m_uiForm.pbRun->setEnabled(enabled); }
-
-void InelasticDataManipulationIqtTab::setSaveResultEnabled(bool enabled) { m_uiForm.pbSave->setEnabled(enabled); }
 
 void InelasticDataManipulationIqtTab::setButtonsEnabled(bool enabled) {
-  setRunEnabled(enabled);
-  setSaveResultEnabled(enabled);
+  m_view->setRunEnabled(enabled);
+  m_view->setSaveResultEnabled(enabled);
 }
 
 void InelasticDataManipulationIqtTab::setRunIsRunning(bool running) {
-  m_uiForm.pbRun->setText(running ? "Running..." : "Run");
+  m_view->setRunText(running);
   setButtonsEnabled(!running);
 }
 

--- a/qt/scientific_interfaces/Indirect/InelasticDataManipulationIqtTab.h
+++ b/qt/scientific_interfaces/Indirect/InelasticDataManipulationIqtTab.h
@@ -6,6 +6,7 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 #pragma once
 
+#include "InelasticDataManipulationIqtTabView.h"
 #include "InelasticDataManipulationTab.h"
 #include "ui_InelasticDataManipulationIqtTab.h"
 namespace MantidQt {
@@ -23,7 +24,6 @@ private:
   void run() override;
   void setup() override;
   bool validate() override;
-  void loadTabSettings(const QSettings &settings);
   void setFileExtensionsByName(bool filter) override;
 
   /// Retrieve the selected spectrum
@@ -40,16 +40,10 @@ private:
   /// Set input workspace
   void setInputWorkspace(Mantid::API::MatrixWorkspace_sptr inputWorkspace);
 
-  bool isErrorsEnabled();
-
-  void setRunEnabled(bool enabled);
-  void setSaveResultEnabled(bool enabled);
   void setButtonsEnabled(bool enabled);
   void setRunIsRunning(bool running);
-  void setPreviewSpectrumMaximum(int value);
 
-  Ui::InelasticDataManipulationIqtTab m_uiForm;
-  QtTreePropertyBrowser *m_iqtTree;
+  std::unique_ptr<InelasticDataManipulationIqtTabView> m_view;
   bool m_iqtResFileType;
   int m_selectedSpectrum;
   Mantid::API::MatrixWorkspace_sptr m_inputWorkspace;
@@ -58,14 +52,8 @@ private slots:
   void algorithmComplete(bool error);
   void handlePreviewSpectrumChanged(int spectra);
   void plotInput(const QString &wsname);
-  void plotInput(MantidQt::MantidWidgets::PreviewPlot *previewPlot);
-  void rangeChanged(double min, double max);
-  void updateRangeSelector(QtProperty *prop, double val);
-  void updateDisplayedBinParameters();
   void runClicked();
   void saveClicked();
-  void errorsClicked();
-  void updateEnergyRange(int state);
   void plotCurrentPreview();
 };
 } // namespace IDA

--- a/qt/scientific_interfaces/Indirect/InelasticDataManipulationIqtTab.h
+++ b/qt/scientific_interfaces/Indirect/InelasticDataManipulationIqtTab.h
@@ -6,6 +6,7 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 #pragma once
 
+#include "InelasticDataManipulationIqtTabModel.h"
 #include "InelasticDataManipulationIqtTabView.h"
 #include "InelasticDataManipulationTab.h"
 #include "ui_InelasticDataManipulationIqtTab.h"
@@ -44,12 +45,17 @@ private:
   void setRunIsRunning(bool running);
 
   std::unique_ptr<InelasticDataManipulationIqtTabView> m_view;
+  std::unique_ptr<InelasticDataManipulationIqtTabModel> m_model;
   bool m_iqtResFileType;
   int m_selectedSpectrum;
   Mantid::API::MatrixWorkspace_sptr m_inputWorkspace;
 
 private slots:
   void algorithmComplete(bool error);
+  void handleResDataReady(const QString &resWorkspace);
+  void handleIterationsChanged(int iterations);
+  void handleErrorsClicked(int state);
+  void handleValueChanged(QtProperty *, double);
   void handlePreviewSpectrumChanged(int spectra);
   void plotInput(const QString &wsname);
   void runClicked();

--- a/qt/scientific_interfaces/Indirect/InelasticDataManipulationIqtTabModel.cpp
+++ b/qt/scientific_interfaces/Indirect/InelasticDataManipulationIqtTabModel.cpp
@@ -1,0 +1,70 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2022 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#include "InelasticDataManipulationIqtTabModel.h"
+#include "IndirectDataValidationHelper.h"
+
+#include "MantidAPI/AlgorithmManager.h"
+#include "MantidAPI/MatrixWorkspace.h"
+#include "MantidAPI/WorkspaceGroup.h"
+#include "MantidQtWidgets/Common/AlgorithmRuntimeProps.h"
+#include "MantidQtWidgets/Common/UserInputValidator.h"
+
+#include <QDoubleValidator>
+#include <QFileInfo>
+
+using namespace IndirectDataValidationHelper;
+using namespace Mantid::API;
+
+namespace MantidQt::CustomInterfaces {
+
+//----------------------------------------------------------------------------------------------
+/** Constructor
+ */
+InelasticDataManipulationIqtTabModel::InelasticDataManipulationIqtTabModel() {}
+
+void InelasticDataManipulationIqtTabModel::setupTransformToIqt(MantidQt::API::BatchAlgorithmRunner *batchAlgoRunner,
+                                                               std::string const &outputWorkspace) {
+  auto IqtAlg = AlgorithmManager::Instance().create("TransformToIqt");
+  IqtAlg->initialize();
+  IqtAlg->setProperty("SampleWorkspace", m_sampleWorkspace);
+  IqtAlg->setProperty("ResolutionWorkspace", m_resWorkspace);
+  IqtAlg->setProperty("NumberOfIterations", m_nIterations);
+  IqtAlg->setProperty("CalculateErrors", m_calculateErrors);
+
+  IqtAlg->setProperty("EnergyMin", m_energyMin);
+  IqtAlg->setProperty("EnergyMax", m_energyMax);
+  IqtAlg->setProperty("BinReductionFactor", m_numBins);
+  IqtAlg->setProperty("OutputWorkspace", outputWorkspace);
+
+  IqtAlg->setProperty("DryRun", false);
+
+  batchAlgoRunner->addAlgorithm(IqtAlg);
+}
+
+void InelasticDataManipulationIqtTabModel::setSampleWorkspace(std::string const &sampleWorkspace) {
+  m_sampleWorkspace = sampleWorkspace;
+}
+
+void InelasticDataManipulationIqtTabModel::setResWorkspace(std::string const &resWorkspace) {
+  m_resWorkspace = resWorkspace;
+}
+
+void InelasticDataManipulationIqtTabModel::setNIterations(std::string const &nIterations) {
+  m_nIterations = nIterations;
+}
+
+void InelasticDataManipulationIqtTabModel::setEnergyMin(double energyMin) { m_energyMin = energyMin; }
+
+void InelasticDataManipulationIqtTabModel::setEnergyMax(double energyMax) { m_energyMax = energyMax; }
+
+void InelasticDataManipulationIqtTabModel::setNumBins(double numBins) { m_numBins = numBins; }
+
+void InelasticDataManipulationIqtTabModel::setCalculateErrors(bool calculateErrors) {
+  m_calculateErrors = calculateErrors;
+}
+
+} // namespace MantidQt::CustomInterfaces

--- a/qt/scientific_interfaces/Indirect/InelasticDataManipulationIqtTabModel.cpp
+++ b/qt/scientific_interfaces/Indirect/InelasticDataManipulationIqtTabModel.cpp
@@ -34,12 +34,10 @@ void InelasticDataManipulationIqtTabModel::setupTransformToIqt(MantidQt::API::Ba
   IqtAlg->setProperty("ResolutionWorkspace", m_resWorkspace);
   IqtAlg->setProperty("NumberOfIterations", m_nIterations);
   IqtAlg->setProperty("CalculateErrors", m_calculateErrors);
-
   IqtAlg->setProperty("EnergyMin", m_energyMin);
   IqtAlg->setProperty("EnergyMax", m_energyMax);
   IqtAlg->setProperty("BinReductionFactor", m_numBins);
   IqtAlg->setProperty("OutputWorkspace", outputWorkspace);
-
   IqtAlg->setProperty("DryRun", false);
 
   batchAlgoRunner->addAlgorithm(IqtAlg);

--- a/qt/scientific_interfaces/Indirect/InelasticDataManipulationIqtTabModel.h
+++ b/qt/scientific_interfaces/Indirect/InelasticDataManipulationIqtTabModel.h
@@ -1,0 +1,44 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2022 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#pragma once
+
+#include "DllConfig.h"
+#include "IndirectDataValidationHelper.h"
+#include "MantidQtWidgets/Common/BatchAlgorithmRunner.h"
+#include "MantidQtWidgets/Common/QtPropertyBrowser/QtTreePropertyBrowser"
+#include <typeinfo>
+
+using namespace Mantid::API;
+
+namespace MantidQt {
+namespace CustomInterfaces {
+
+class MANTIDQT_INDIRECT_DLL InelasticDataManipulationIqtTabModel {
+
+public:
+  InelasticDataManipulationIqtTabModel();
+  ~InelasticDataManipulationIqtTabModel() = default;
+  void setupTransformToIqt(MantidQt::API::BatchAlgorithmRunner *batchAlgoRunner, std::string const &outputWorkspace);
+  void setSampleWorkspace(std::string const &sampleWorkspace);
+  void setResWorkspace(std::string const &resWorkspace);
+  void setNIterations(std::string const &nIterations);
+  void setEnergyMin(double energyMin);
+  void setEnergyMax(double energyMax);
+  void setNumBins(double numBins);
+  void setCalculateErrors(bool calculateErrors);
+
+private:
+  std::string m_sampleWorkspace;
+  std::string m_resWorkspace;
+  std::string m_nIterations;
+  double m_energyMin;
+  double m_energyMax;
+  double m_numBins;
+  bool m_calculateErrors;
+};
+} // namespace CustomInterfaces
+} // namespace MantidQt

--- a/qt/scientific_interfaces/Indirect/InelasticDataManipulationIqtTabView.cpp
+++ b/qt/scientific_interfaces/Indirect/InelasticDataManipulationIqtTabView.cpp
@@ -143,7 +143,7 @@ void InelasticDataManipulationIqtTabView::setup() {
   connect(m_uiForm.pbPlotPreview, SIGNAL(clicked()), this, SIGNAL(plotCurrentPreview()));
   connect(m_uiForm.cbCalculateErrors, SIGNAL(stateChanged(int)), this, SIGNAL(errorsClicked(int)));
   connect(m_uiForm.cbCalculateErrors, SIGNAL(stateChanged(int)), this, SLOT(handleErrorsClicked(int)));
-  connect(m_uiForm.spPreviewSpec, SIGNAL(valueChanged(int)), this, SIGNAL(PreviewSpectrumChanged(int)));
+  connect(m_uiForm.spPreviewSpec, SIGNAL(valueChanged(int)), this, SIGNAL(previewSpectrumChanged(int)));
   connect(m_uiForm.ckSymmetricEnergy, SIGNAL(stateChanged(int)), this, SLOT(updateEnergyRange(int)));
   connect(xRangeSelector, SIGNAL(selectionChanged(double, double)), this, SLOT(rangeChanged(double, double)));
   connect(m_dblManager, SIGNAL(valueChanged(QtProperty *, double)), this,

--- a/qt/scientific_interfaces/Indirect/InelasticDataManipulationIqtTabView.cpp
+++ b/qt/scientific_interfaces/Indirect/InelasticDataManipulationIqtTabView.cpp
@@ -1,0 +1,452 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2018 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#include "InelasticDataManipulationIqtTabView.h"
+#include "MantidAPI/AlgorithmManager.h"
+#include "MantidAPI/ITableWorkspace.h"
+#include "MantidGeometry/Instrument.h"
+#include "MantidQtWidgets/Common/AlgorithmRuntimeProps.h"
+#include "MantidQtWidgets/Common/QtPropertyBrowser/qteditorfactory.h"
+#include "MantidQtWidgets/Common/SignalBlocker.h"
+#include "MantidQtWidgets/Common/UserInputValidator.h"
+#include "MantidQtWidgets/Plotting/RangeSelector.h"
+
+#include <QFileInfo>
+
+#include <algorithm>
+
+#include "IndirectAddWorkspaceDialog.h"
+
+using namespace Mantid::API;
+using namespace MantidQt::API;
+using namespace MantidQt::MantidWidgets;
+
+namespace {
+
+/**
+ * Calculate the number of bins in the sample & resolution workspaces
+ * @param wsName The sample workspace name
+ * @param resName the resolution woskapce name
+ * @param energyMin Minimum energy for chosen bin range
+ * @param energyMax Maximum energy for chosen bin range
+ * @param binReductionFactor The factor by which to reduce the number of bins
+ * @return A 4-tuple where the first entry denotes whether the
+ * calculation was successful or not. The final 3 values
+ * are EWidth, SampleBins, ResolutionBins if the calculation succeeded,
+ * otherwise they are undefined.
+ */
+std::tuple<bool, float, int, int> calculateBinParameters(std::string const &wsName, std::string const &resName,
+                                                         double energyMin, double energyMax,
+                                                         double binReductionFactor) {
+  ITableWorkspace_sptr propsTable;
+  try {
+    const auto paramTableName = "__IqtProperties_temp";
+    auto toIqt = AlgorithmManager::Instance().createUnmanaged("TransformToIqt");
+    toIqt->initialize();
+    toIqt->setChild(true); // record this as internal
+    toIqt->setProperty("SampleWorkspace", wsName);
+    toIqt->setProperty("ResolutionWorkspace", resName);
+    toIqt->setProperty("ParameterWorkspace", paramTableName);
+    toIqt->setProperty("EnergyMin", energyMin);
+    toIqt->setProperty("EnergyMax", energyMax);
+    toIqt->setProperty("BinReductionFactor", binReductionFactor);
+    toIqt->setProperty("DryRun", true);
+    toIqt->execute();
+    propsTable = toIqt->getProperty("ParameterWorkspace");
+    // the algorithm can create output even if it failed...
+    auto deleter = AlgorithmManager::Instance().create("DeleteWorkspace");
+    deleter->initialize();
+    deleter->setChild(true);
+    deleter->setProperty("Workspace", paramTableName);
+    deleter->execute();
+  } catch (std::exception &) {
+    return std::make_tuple(false, 0.0f, 0, 0);
+  }
+  assert(propsTable);
+  return std::make_tuple(true, propsTable->getColumn("EnergyWidth")->cell<float>(0),
+                         propsTable->getColumn("SampleOutputBins")->cell<int>(0),
+                         propsTable->getColumn("ResolutionBins")->cell<int>(0));
+}
+} // namespace
+
+namespace MantidQt::CustomInterfaces {
+using namespace IDA;
+InelasticDataManipulationIqtTabView::InelasticDataManipulationIqtTabView(QWidget *parent) : m_iqtTree(nullptr) {
+  m_uiForm.setupUi(parent);
+  m_dblEdFac = new DoubleEditorFactory(this);
+  m_dblManager = new QtDoublePropertyManager();
+  setup();
+}
+
+InelasticDataManipulationIqtTabView::~InelasticDataManipulationIqtTabView() {
+  m_iqtTree->unsetFactoryForManager(m_dblManager);
+}
+
+IndirectPlotOptionsView *InelasticDataManipulationIqtTabView::getPlotOptions() { return m_uiForm.ipoPlotOptions; }
+
+void InelasticDataManipulationIqtTabView::setup() {
+  m_iqtTree = new QtTreePropertyBrowser();
+  m_uiForm.properties->addWidget(m_iqtTree);
+
+  // Number of decimal places in property browsers.
+  static const unsigned int NUM_DECIMALS = 6;
+  // Create and configure properties
+  m_properties["ELow"] = m_dblManager->addProperty("ELow");
+  m_dblManager->setDecimals(m_properties["ELow"], NUM_DECIMALS);
+
+  m_properties["EWidth"] = m_dblManager->addProperty("EWidth");
+  m_dblManager->setDecimals(m_properties["EWidth"], NUM_DECIMALS);
+  m_properties["EWidth"]->setEnabled(false);
+
+  m_properties["EHigh"] = m_dblManager->addProperty("EHigh");
+  m_dblManager->setDecimals(m_properties["EHigh"], NUM_DECIMALS);
+
+  m_properties["SampleBinning"] = m_dblManager->addProperty("SampleBinning");
+  m_dblManager->setDecimals(m_properties["SampleBinning"], 0);
+
+  m_properties["SampleBins"] = m_dblManager->addProperty("SampleBins");
+  m_dblManager->setDecimals(m_properties["SampleBins"], 0);
+  m_properties["SampleBins"]->setEnabled(false);
+
+  m_properties["ResolutionBins"] = m_dblManager->addProperty("ResolutionBins");
+  m_dblManager->setDecimals(m_properties["ResolutionBins"], 0);
+  m_properties["ResolutionBins"]->setEnabled(false);
+
+  m_iqtTree->addProperty(m_properties["ELow"]);
+  m_iqtTree->addProperty(m_properties["EWidth"]);
+  m_iqtTree->addProperty(m_properties["EHigh"]);
+  m_iqtTree->addProperty(m_properties["SampleBinning"]);
+  m_iqtTree->addProperty(m_properties["SampleBins"]);
+  m_iqtTree->addProperty(m_properties["ResolutionBins"]);
+
+  m_dblManager->setValue(m_properties["SampleBinning"], 10);
+
+  m_iqtTree->setFactoryForManager(m_dblManager, m_dblEdFac);
+
+  // Format the tree widget so its easier to read the contents
+  m_iqtTree->setIndentation(0);
+  for (auto const &item : m_properties)
+    m_iqtTree->setBackgroundColor(m_iqtTree->topLevelItem(item), QColor(246, 246, 246));
+
+  setPreviewSpectrumMaximum(0);
+
+  auto xRangeSelector = m_uiForm.ppPlot->addRangeSelector("IqtRange");
+  xRangeSelector->setBounds(-DBL_MAX, DBL_MAX);
+
+  // signals / slots & validators
+  connect(m_uiForm.dsInput, SIGNAL(dataReady(const QString &)), this, SIGNAL(sampDataReady(const QString &)));
+  connect(m_uiForm.dsResolution, SIGNAL(dataReady(const QString &)), this, SLOT(updateDisplayedBinParameters()));
+  connect(m_uiForm.pbRun, SIGNAL(clicked()), this, SIGNAL(runClicked()));
+  connect(m_uiForm.pbSave, SIGNAL(clicked()), this, SIGNAL(saveClicked()));
+  connect(m_uiForm.pbPlotPreview, SIGNAL(clicked()), this, SIGNAL(plotCurrentPreview()));
+  connect(m_uiForm.cbCalculateErrors, SIGNAL(clicked()), this, SLOT(errorsClicked()));
+  connect(m_uiForm.spPreviewSpec, SIGNAL(valueChanged(int)), this, SIGNAL(PreviewSpectrumChanged(int)));
+  connect(m_uiForm.ckSymmetricEnergy, SIGNAL(stateChanged(int)), this, SLOT(updateEnergyRange(int)));
+  connect(xRangeSelector, SIGNAL(selectionChanged(double, double)), this, SLOT(rangeChanged(double, double)));
+  connect(m_dblManager, SIGNAL(valueChanged(QtProperty *, double)), this,
+          SLOT(updateRangeSelector(QtProperty *, double)));
+
+  m_uiForm.dsInput->isOptional(true);
+  m_uiForm.dsResolution->isOptional(true);
+}
+
+void InelasticDataManipulationIqtTabView::setPreviewSpectrumMaximum(int value) {
+  m_uiForm.spPreviewSpec->setMaximum(value);
+}
+
+/**
+ * Ensure we have present and valid file/ws inputs.
+ *
+ * The underlying Fourier transform of Iqt
+ * also means we must enforce several rules on the parameters.
+ */
+bool InelasticDataManipulationIqtTabView::validate() {
+  UserInputValidator uiv;
+
+  uiv.checkDataSelectorIsValid("Sample", m_uiForm.dsInput);
+  uiv.checkDataSelectorIsValid("Resolution", m_uiForm.dsResolution);
+
+  auto const eLow = m_dblManager->value(m_properties["ELow"]);
+  auto const eHigh = m_dblManager->value(m_properties["EHigh"]);
+
+  if (eLow >= eHigh)
+    uiv.addErrorMessage("ELow must be less than EHigh.\n");
+
+  auto const message = uiv.generateErrorMessage();
+  showMessageBox(message);
+
+  return message.isEmpty();
+}
+
+void InelasticDataManipulationIqtTabView::setSampleFBSuffixes(QStringList const suffix) {
+  m_uiForm.dsInput->setFBSuffixes(suffix);
+}
+
+void InelasticDataManipulationIqtTabView::setSampleWSSuffixes(QStringList const suffix) {
+  m_uiForm.dsInput->setWSSuffixes(suffix);
+}
+
+void InelasticDataManipulationIqtTabView::setResolutionFBSuffixes(QStringList const suffix) {
+  m_uiForm.dsResolution->setFBSuffixes(suffix);
+}
+
+void InelasticDataManipulationIqtTabView::setResolutionWSSuffixes(QStringList const suffix) {
+  m_uiForm.dsResolution->setWSSuffixes(suffix);
+}
+
+void InelasticDataManipulationIqtTabView::setRunEnabled(bool enabled) { m_uiForm.pbRun->setEnabled(enabled); }
+
+void InelasticDataManipulationIqtTabView::setSaveResultEnabled(bool enabled) { m_uiForm.pbSave->setEnabled(enabled); }
+
+void InelasticDataManipulationIqtTabView::setRunText(bool running) {
+  m_uiForm.pbRun->setText(running ? "Running..." : "Run");
+}
+
+void InelasticDataManipulationIqtTabView::setWatchADS(bool watch) { m_uiForm.ppPlot->watchADS(watch); }
+
+/**
+ * Plots the selected spectrum of the input workspace.
+ */
+void InelasticDataManipulationIqtTabView::plotInput(MatrixWorkspace_sptr inputWS, int spectrum) {
+  m_uiForm.ppPlot->clear();
+
+  if (inputWS && inputWS->x(spectrum).size() > 1) {
+    m_uiForm.ppPlot->addSpectrum("Sample", inputWS, spectrum);
+  }
+}
+
+/**
+ * Updates the range selectors and properties when range selector is moved.
+ *
+ * @param min Range selector min value
+ * @param max Range selector max value
+ */
+void InelasticDataManipulationIqtTabView::rangeChanged(double min, double max) {
+  double oldMin = m_dblManager->value(m_properties["ELow"]);
+  double oldMax = m_dblManager->value(m_properties["EHigh"]);
+
+  auto xRangeSelector = m_uiForm.ppPlot->getRangeSelector("IqtRange");
+
+  disconnect(xRangeSelector, SIGNAL(selectionChanged(double, double)), this, SLOT(rangeChanged(double, double)));
+  disconnect(m_dblManager, SIGNAL(valueChanged(QtProperty *, double)), this,
+             SLOT(updateRangeSelector(QtProperty *, double)));
+
+  if (fabs(oldMin - min) > 0.0000001) {
+    m_dblManager->setValue(m_properties["ELow"], min);
+    xRangeSelector->setMinimum(min);
+    if (m_uiForm.ckSymmetricEnergy->isChecked()) {
+      m_dblManager->setValue(m_properties["EHigh"], -min);
+      xRangeSelector->setMaximum(-min);
+    }
+  }
+
+  if (fabs(oldMax - max) > 0.0000001) {
+    m_dblManager->setValue(m_properties["EHigh"], max);
+    xRangeSelector->setMaximum(max);
+    if (m_uiForm.ckSymmetricEnergy->isChecked()) {
+      m_dblManager->setValue(m_properties["ELow"], -max);
+      xRangeSelector->setMinimum(-max);
+    }
+  }
+
+  connect(xRangeSelector, SIGNAL(selectionChanged(double, double)), this, SLOT(rangeChanged(double, double)));
+  connect(m_dblManager, SIGNAL(valueChanged(QtProperty *, double)), this,
+          SLOT(updateRangeSelector(QtProperty *, double)));
+}
+
+void InelasticDataManipulationIqtTabView::setRangeSelectorDefault(const MatrixWorkspace_sptr workspace,
+                                                                  const QPair<double, double> &range) {
+  auto xRangeSelector = m_uiForm.ppPlot->getRangeSelector("IqtRange");
+  try {
+    double rounded_min(range.first);
+    double rounded_max(range.second);
+    const std::string instrName(workspace->getInstrument()->getName());
+    if (instrName == "BASIS") {
+      xRangeSelector->setRange(range.first, range.second);
+      m_dblManager->setValue(m_properties["ELow"], rounded_min);
+      m_dblManager->setValue(m_properties["EHigh"], rounded_max);
+      m_dblManager->setValue(m_properties["EWidth"], 0.0004);
+      m_dblManager->setValue(m_properties["SampleBinning"], 1);
+    } else {
+      rounded_min = floor(rounded_min * 10 + 0.5) / 10.0;
+      rounded_max = floor(rounded_max * 10 + 0.5) / 10.0;
+
+      // corrections for if nearest value is outside of range
+      if (rounded_max > range.second) {
+        rounded_max -= 0.1;
+      }
+
+      if (rounded_min < range.first) {
+        rounded_min += 0.1;
+      }
+
+      // check incase we have a really small range
+      if (fabs(rounded_min) > 0 && fabs(rounded_max) > 0) {
+        xRangeSelector->setRange(rounded_min, rounded_max);
+        m_dblManager->setValue(m_properties["ELow"], rounded_min);
+        m_dblManager->setValue(m_properties["EHigh"], rounded_max);
+      } else {
+        xRangeSelector->setRange(range.first, range.second);
+        m_dblManager->setValue(m_properties["ELow"], range.first);
+        m_dblManager->setValue(m_properties["EHigh"], range.second);
+      }
+      // set default value for width
+      m_dblManager->setValue(m_properties["EWidth"], 0.005);
+    }
+  } catch (std::invalid_argument &exc) {
+    showMessageBox(exc.what());
+  }
+}
+
+/**
+ * Updates the range selectors when the ELow or EHigh property is changed in the
+ * table.
+ *
+ * @param prop The property which has been changed
+ * @param val The new position for the range selector
+ */
+void InelasticDataManipulationIqtTabView::updateRangeSelector(QtProperty *prop, double val) {
+  auto xRangeSelector = m_uiForm.ppPlot->getRangeSelector("IqtRange");
+
+  disconnect(xRangeSelector, SIGNAL(selectionChanged(double, double)), this, SLOT(rangeChanged(double, double)));
+  disconnect(m_dblManager, SIGNAL(valueChanged(QtProperty *, double)), this,
+             SLOT(updateRangeSelector(QtProperty *, double)));
+
+  if (prop == m_properties["ELow"]) {
+    setRangeSelectorMin(m_properties["ELow"], m_properties["EHigh"], xRangeSelector, val);
+    if (m_uiForm.ckSymmetricEnergy->isChecked()) {
+      m_dblManager->setValue(m_properties["EHigh"], -val);
+      setRangeSelectorMax(m_properties["ELow"], m_properties["EHigh"], xRangeSelector, -val);
+    }
+
+  } else if (prop == m_properties["EHigh"]) {
+    setRangeSelectorMax(m_properties["ELow"], m_properties["EHigh"], xRangeSelector, val);
+    if (m_uiForm.ckSymmetricEnergy->isChecked()) {
+      m_dblManager->setValue(m_properties["ELow"], -val);
+      setRangeSelectorMin(m_properties["ELow"], m_properties["EHigh"], xRangeSelector, -val);
+    }
+  }
+
+  connect(xRangeSelector, SIGNAL(selectionChanged(double, double)), this, SLOT(rangeChanged(double, double)));
+  connect(m_dblManager, SIGNAL(valueChanged(QtProperty *, double)), this,
+          SLOT(updateRangeSelector(QtProperty *, double)));
+
+  updateDisplayedBinParameters();
+}
+
+/**
+ * Calculates binning parameters.
+ */
+void InelasticDataManipulationIqtTabView::updateDisplayedBinParameters() {
+  auto const sampleName = m_uiForm.dsInput->getCurrentDataName().toStdString();
+  auto const resolutionName = m_uiForm.dsResolution->getCurrentDataName().toStdString();
+
+  auto &ads = AnalysisDataService::Instance();
+  if (!ads.doesExist(sampleName) || !ads.doesExist(resolutionName))
+    return;
+
+  double energyMin = m_dblManager->value(m_properties["ELow"]);
+  double energyMax = m_dblManager->value(m_properties["EHigh"]);
+  double numBins = m_dblManager->value(m_properties["SampleBinning"]);
+
+  if (numBins == 0)
+    return;
+  if (energyMin == 0 && energyMax == 0)
+    return;
+
+  bool success(false);
+  float energyWidth(0.0f);
+  int resolutionBins(0), sampleBins(0);
+  std::tie(success, energyWidth, sampleBins, resolutionBins) =
+      calculateBinParameters(sampleName, resolutionName, energyMin, energyMax, numBins);
+  if (success) {
+    disconnect(m_dblManager, SIGNAL(valueChanged(QtProperty *, double)), this,
+               SLOT(updateRangeSelector(QtProperty *, double)));
+
+    // Update data in property editor
+    m_dblManager->setValue(m_properties["EWidth"], energyWidth);
+    m_dblManager->setValue(m_properties["ResolutionBins"], resolutionBins);
+    m_dblManager->setValue(m_properties["SampleBins"], sampleBins);
+
+    connect(m_dblManager, SIGNAL(valueChanged(QtProperty *, double)), this,
+            SLOT(updateRangeSelector(QtProperty *, double)));
+
+    // Warn for low number of resolution bins
+    if (resolutionBins < 5)
+      showMessageBox("Results may be inaccurate as ResolutionBins is "
+                     "less than 5.\nLower the SampleBinning.");
+  }
+}
+
+/**
+ * Set the minimum of a range selector if it is less than the maximum value.
+ * To be used when changing the min or max via the Property table
+ *
+ * @param minProperty :: The property managing the minimum of the range
+ * @param maxProperty :: The property managing the maximum of the range
+ * @param rangeSelector :: The range selector
+ * @param newValue :: The new value for the minimum
+ */
+void InelasticDataManipulationIqtTabView::setRangeSelectorMin(QtProperty *minProperty, QtProperty *maxProperty,
+                                                              RangeSelector *rangeSelector, double newValue) {
+  if (newValue <= maxProperty->valueText().toDouble())
+    rangeSelector->setMinimum(newValue);
+  else
+    m_dblManager->setValue(minProperty, rangeSelector->getMinimum());
+}
+
+/**
+ * Set the maximum of a range selector if it is greater than the minimum value
+ * To be used when changing the min or max via the Property table
+ *
+ * @param minProperty :: The property managing the minimum of the range
+ * @param maxProperty :: The property managing the maximum of the range
+ * @param rangeSelector :: The range selector
+ * @param newValue :: The new value for the maximum
+ */
+void InelasticDataManipulationIqtTabView::setRangeSelectorMax(QtProperty *minProperty, QtProperty *maxProperty,
+                                                              RangeSelector *rangeSelector, double newValue) {
+  if (newValue >= minProperty->valueText().toDouble())
+    rangeSelector->setMaximum(newValue);
+  else
+    m_dblManager->setValue(maxProperty, rangeSelector->getMaximum());
+}
+
+void InelasticDataManipulationIqtTabView::updateEnergyRange(int state) {
+  if (state != 0) {
+    auto const value = m_dblManager->value(m_properties["ELow"]);
+    m_dblManager->setValue(m_properties["EHigh"], -value);
+  }
+}
+
+void InelasticDataManipulationIqtTabView::errorsClicked() {
+  m_uiForm.spIterations->setEnabled(m_uiForm.cbCalculateErrors->isChecked());
+}
+
+// getters for properties
+std::string InelasticDataManipulationIqtTabView::getSampleName() {
+  return m_uiForm.dsInput->getCurrentDataName().toStdString();
+}
+
+std::string InelasticDataManipulationIqtTabView::getResolutionName() {
+  return m_uiForm.dsResolution->getCurrentDataName().toStdString();
+}
+
+std::string InelasticDataManipulationIqtTabView::getIterations() {
+  return m_uiForm.spIterations->cleanText().toStdString();
+}
+
+double InelasticDataManipulationIqtTabView::getELow() { return m_dblManager->value(m_properties["ELow"]); }
+
+double InelasticDataManipulationIqtTabView::getEHigh() { return m_dblManager->value(m_properties["EHigh"]); }
+
+double InelasticDataManipulationIqtTabView::getSampleBinning() {
+  return m_dblManager->value(m_properties["SampleBinning"]);
+}
+
+bool InelasticDataManipulationIqtTabView::getCalculateErrors() { return m_uiForm.cbCalculateErrors->isChecked(); }
+
+} // namespace MantidQt::CustomInterfaces

--- a/qt/scientific_interfaces/Indirect/InelasticDataManipulationIqtTabView.cpp
+++ b/qt/scientific_interfaces/Indirect/InelasticDataManipulationIqtTabView.cpp
@@ -259,6 +259,8 @@ void InelasticDataManipulationIqtTabView::rangeChanged(double min, double max) {
   connect(xRangeSelector, SIGNAL(selectionChanged(double, double)), this, SLOT(rangeChanged(double, double)));
   connect(m_dblManager, SIGNAL(valueChanged(QtProperty *, double)), this,
           SLOT(updateRangeSelector(QtProperty *, double)));
+
+  updateDisplayedBinParameters();
 }
 
 void InelasticDataManipulationIqtTabView::setRangeSelectorDefault(const MatrixWorkspace_sptr workspace,

--- a/qt/scientific_interfaces/Indirect/InelasticDataManipulationIqtTabView.h
+++ b/qt/scientific_interfaces/Indirect/InelasticDataManipulationIqtTabView.h
@@ -39,26 +39,24 @@ public:
   void setSaveResultEnabled(bool enabled);
   void setRunText(bool running);
   void setWatchADS(bool watch);
+  void setup();
 
   // getters for properties
   std::string getSampleName();
-  std::string getResolutionName();
-  std::string getIterations();
-  double getELow();
-  double getEHigh();
-  double getSampleBinning();
-  bool getCalculateErrors();
 
 signals:
   void sampDataReady(const QString &);
+  void resDataReady(const QString &);
+  void iterationsChanged(int);
+  void errorsClicked(int);
   void PreviewSpectrumChanged(int);
   void runClicked();
   void saveClicked();
   void plotCurrentPreview();
   void showMessageBox(const QString &message);
+  void valueChanged(QtProperty *, double);
 
 private:
-  void setup();
   void setRangeSelectorMax(QtProperty *minProperty, QtProperty *maxProperty, RangeSelector *rangeSelector,
                            double newValue);
   void setRangeSelectorMin(QtProperty *minProperty, QtProperty *maxProperty, RangeSelector *rangeSelector,
@@ -77,7 +75,7 @@ private slots:
   void rangeChanged(double min, double max);
   void updateRangeSelector(QtProperty *prop, double val);
   void updateEnergyRange(int state);
-  void errorsClicked();
+  void handleErrorsClicked(int);
 };
 
 } // namespace CustomInterfaces

--- a/qt/scientific_interfaces/Indirect/InelasticDataManipulationIqtTabView.h
+++ b/qt/scientific_interfaces/Indirect/InelasticDataManipulationIqtTabView.h
@@ -49,7 +49,7 @@ signals:
   void resDataReady(const QString &);
   void iterationsChanged(int);
   void errorsClicked(int);
-  void PreviewSpectrumChanged(int);
+  void previewSpectrumChanged(int);
   void runClicked();
   void saveClicked();
   void plotCurrentPreview();

--- a/qt/scientific_interfaces/Indirect/InelasticDataManipulationIqtTabView.h
+++ b/qt/scientific_interfaces/Indirect/InelasticDataManipulationIqtTabView.h
@@ -1,0 +1,84 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2018 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#pragma once
+
+#include "MantidAPI/MatrixWorkspace.h"
+#include "MantidAPI/MatrixWorkspace_fwd.h"
+#include "MantidQtWidgets/Common/QtPropertyBrowser/DoubleEditorFactory.h"
+#include "MantidQtWidgets/Common/QtPropertyBrowser/QtTreePropertyBrowser"
+#include "MantidQtWidgets/Common/QtPropertyBrowser/qteditorfactory.h"
+#include "MantidQtWidgets/Plotting/RangeSelector.h"
+#include "ui_InelasticDataManipulationIqtTab.h"
+
+namespace MantidQt {
+namespace CustomInterfaces {
+using namespace Mantid::API;
+using namespace MantidQt::MantidWidgets;
+
+class MANTIDQT_INDIRECT_DLL InelasticDataManipulationIqtTabView : public QWidget {
+  Q_OBJECT
+
+public:
+  InelasticDataManipulationIqtTabView(QWidget *parent = nullptr);
+  ~InelasticDataManipulationIqtTabView();
+  IndirectPlotOptionsView *getPlotOptions();
+  void plotInput(MatrixWorkspace_sptr inputWS, int spectrum);
+  void setPreviewSpectrumMaximum(int value);
+  void updateDisplayedBinParameters();
+  void setRangeSelectorDefault(const MatrixWorkspace_sptr inputWorkspace, const QPair<double, double> &range);
+  bool validate();
+  void setSampleFBSuffixes(QStringList const suffix);
+  void setSampleWSSuffixes(QStringList const suffix);
+  void setResolutionFBSuffixes(QStringList const suffix);
+  void setResolutionWSSuffixes(QStringList const suffix);
+  void setRunEnabled(bool enabled);
+  void setSaveResultEnabled(bool enabled);
+  void setRunText(bool running);
+  void setWatchADS(bool watch);
+
+  // getters for properties
+  std::string getSampleName();
+  std::string getResolutionName();
+  std::string getIterations();
+  double getELow();
+  double getEHigh();
+  double getSampleBinning();
+  bool getCalculateErrors();
+
+signals:
+  void sampDataReady(const QString &);
+  void PreviewSpectrumChanged(int);
+  void runClicked();
+  void saveClicked();
+  void plotCurrentPreview();
+  void showMessageBox(const QString &message);
+
+private:
+  void setup();
+  void setRangeSelectorMax(QtProperty *minProperty, QtProperty *maxProperty, RangeSelector *rangeSelector,
+                           double newValue);
+  void setRangeSelectorMin(QtProperty *minProperty, QtProperty *maxProperty, RangeSelector *rangeSelector,
+                           double newValue);
+
+  Ui::InelasticDataManipulationIqtTab m_uiForm;
+  QtTreePropertyBrowser *m_iqtTree;
+  /// Internal list of the properties
+  QMap<QString, QtProperty *> m_properties;
+  /// Double manager to create properties
+  QtDoublePropertyManager *m_dblManager;
+  /// Double editor facotry for the properties browser
+  DoubleEditorFactory *m_dblEdFac;
+
+private slots:
+  void rangeChanged(double min, double max);
+  void updateRangeSelector(QtProperty *prop, double val);
+  void updateEnergyRange(int state);
+  void errorsClicked();
+};
+
+} // namespace CustomInterfaces
+} // namespace MantidQt

--- a/qt/scientific_interfaces/Indirect/InelasticDataManipulationMomentsTabModel.h
+++ b/qt/scientific_interfaces/Indirect/InelasticDataManipulationMomentsTabModel.h
@@ -8,7 +8,6 @@
 
 #include "DllConfig.h"
 #include "IndirectDataValidationHelper.h"
-#include "MantidQtWidgets/Common/QtPropertyBrowser/QtTreePropertyBrowser"
 #include <typeinfo>
 
 using namespace Mantid::API;

--- a/qt/scientific_interfaces/Indirect/test/CMakeLists.txt
+++ b/qt/scientific_interfaces/Indirect/test/CMakeLists.txt
@@ -23,6 +23,7 @@ set(TEST_FILES
     IndirectSettingsModelTest.h
     IndirectSettingsPresenterTest.h
     InelasticDataManipulationElwinTabModelTest.h
+    InelasticDataManipulationIqtTabModelTest.h
     InelasticDataManipulationMomentsTabModelTest.h
     InelasticDataManipulationSqwTabModelTest.h
     InelasticDataManipulationSymmetriseTabModelTest.h

--- a/qt/scientific_interfaces/Indirect/test/InelasticDataManipulationIqtTabModelTest.h
+++ b/qt/scientific_interfaces/Indirect/test/InelasticDataManipulationIqtTabModelTest.h
@@ -1,0 +1,113 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2019 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#pragma once
+
+#include "IndirectDataValidationHelper.h"
+#include "InelasticDataManipulationIqtTabModel.h"
+#include "MantidAPI/AnalysisDataService.h"
+#include "MantidAPI/ITableWorkspace.h"
+#include "MantidAPI/TableRow.h"
+#include "MantidFrameworkTestHelpers/WorkspaceCreationHelper.h"
+#include <cxxtest/TestSuite.h>
+#include <gmock/gmock.h>
+
+using namespace MantidQt::CustomInterfaces;
+
+class TransformToIqt : public Algorithm {
+public:
+  const std::string name() const override { return "TransformToIqt"; };
+  int version() const override { return 1; };
+  const std::string summary() const override { return "A mock the TransformToIqt algorithm"; };
+
+private:
+  void init() override {
+    declareProperty("SampleWorkspace", "SampleWorkspace");
+    declareProperty("ResolutionWorkspace", "ResolutionWorkspace");
+
+    declareProperty("OutputWorkspace", "OutputWorkspace");
+
+    declareProperty("NumberOfIterations", "NumberOfIterations");
+    declareProperty("CalculateErrors", false);
+    declareProperty("DryRun", true);
+    declareProperty("EnergyMin", 0.0);
+    declareProperty("EnergyMax", 1.0);
+    declareProperty("BinReductionFactor", 2.0);
+  };
+  void exec() override {
+    ITableWorkspace_sptr outputWS = WorkspaceFactory::Instance().createTable();
+    outputWS->addColumn("str", "SampleWorkspace");
+    outputWS->addColumn("str", "ResolutionWorkspace");
+    outputWS->addColumn("str", "OutputWorkspace");
+    outputWS->addColumn("str", "NumberOfIterations");
+    outputWS->addColumn("str", "CalculateErrors");
+    outputWS->addColumn("str", "DryRun");
+    outputWS->addColumn("double", "EnergyMin");
+    outputWS->addColumn("double", "EnergyMax");
+    outputWS->addColumn("double", "BinReductionFactor");
+
+    TableRow newRow = outputWS->appendRow();
+    auto inWS = getPropertyValue("SampleWorkspace");
+    auto resWS = getPropertyValue("ResolutionWorkspace");
+    auto outWS = getPropertyValue("OutputWorkspace");
+    auto nIt = getPropertyValue("NumberOfIterations");
+    auto calcErr = getPropertyValue("CalculateErrors");
+    auto dryRun = getPropertyValue("DryRun");
+    double eMin = getProperty("EnergyMin");
+    double eMax = getProperty("EnergyMax");
+    double bRF = getProperty("BinReductionFactor");
+
+    newRow << inWS << resWS << outWS << nIt << calcErr << dryRun << eMin << eMax << bRF;
+
+    Mantid::API::AnalysisDataService::Instance().addOrReplace("outputWS", outputWS);
+  };
+};
+DECLARE_ALGORITHM(TransformToIqt)
+
+class InelasticDataManipulationIqtTabModelTest : public CxxTest::TestSuite {
+public:
+  /// Needed to make sure everything is initialized
+  InelasticDataManipulationIqtTabModelTest() = default;
+
+  void setUp() override { m_model = std::make_unique<InelasticDataManipulationIqtTabModel>(); }
+
+  void test_algorrithm_set_up() {
+    MantidQt::API::BatchAlgorithmRunner batch;
+    // The Moments algorithm is a python algorithm and so can not be called in c++ tests
+    m_sampWorkspace = WorkspaceCreationHelper::create2DWorkspace(5, 4);
+    Mantid::API::AnalysisDataService::Instance().addOrReplace("sample_name_sqw", m_sampWorkspace);
+    m_resWorkspace = WorkspaceCreationHelper::create2DWorkspace(5, 4);
+    Mantid::API::AnalysisDataService::Instance().addOrReplace("res_name_sqw", m_resWorkspace);
+
+    m_model->setSampleWorkspace("sample_name_sqw");
+    m_model->setResWorkspace("res_name_sqw");
+    m_model->setEnergyMin(-0.1);
+    m_model->setEnergyMax(0.1);
+    m_model->setNumBins(10);
+    m_model->setCalculateErrors(true);
+    m_model->setNIterations("50");
+
+    m_model->setupTransformToIqt(&batch, "outputWS");
+    batch.executeBatch();
+
+    ITableWorkspace_sptr outputWS =
+        Mantid::API::AnalysisDataService::Instance().retrieveWS<Mantid::DataObjects::TableWorkspace>("outputWS");
+    TS_ASSERT_EQUALS(outputWS->cell<std::string>(0, 0), "sample_name_sqw");
+    TS_ASSERT_EQUALS(outputWS->cell<std::string>(0, 1), "res_name_sqw");
+    TS_ASSERT_EQUALS(outputWS->cell<std::string>(0, 2), "outputWS");
+    TS_ASSERT_EQUALS(outputWS->cell<std::string>(0, 3), "50");
+    TS_ASSERT_EQUALS(outputWS->cell<std::string>(0, 4), "1");
+    TS_ASSERT_EQUALS(outputWS->cell<std::string>(0, 5), "0");
+    TS_ASSERT_EQUALS(outputWS->cell<double>(0, 6), -0.1);
+    TS_ASSERT_EQUALS(outputWS->cell<double>(0, 7), 0.1);
+    TS_ASSERT_EQUALS(outputWS->cell<double>(0, 8), 10);
+  }
+
+private:
+  MatrixWorkspace_sptr m_sampWorkspace;
+  MatrixWorkspace_sptr m_resWorkspace;
+  std::unique_ptr<InelasticDataManipulationIqtTabModel> m_model;
+};


### PR DESCRIPTION
**Description of work.**

This PR makes the Iqt tab in inelastic data Manipulation interface MVP compatable.

**To test:**
for this testing you will new sqw workspaces, If you don't have them contact me and I can supply them

1. Open Inelastic data manipulaton
2. Go to the iqt tab
3. Load data for the sample. the data should be plotted and the Elow and EHigh should be updated.
4. Load a resolution File.
5. change the range markers on the plot and the Elow and Ehigh should update, likewise changing the value in the table with to the same for the range markers.
6. Uncheck Symmetric Ener and move the markers, they should no longer mirror each other.
7. uncheck calculate errors the number of itterations box should be greyed out, re-enable calculate errors
8. click run, check output of Iqt workspace.

Fixes #34802 

*This does not require release notes* because the changes are all internale and not noticable by the users.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
