### PR TITLE
Ability to customize available toolbar options in InstrumentWidget

### DIFF
--- a/qt/scientific_interfaces/Direct/ALFInstrumentWidget.cpp
+++ b/qt/scientific_interfaces/Direct/ALFInstrumentWidget.cpp
@@ -27,12 +27,21 @@ namespace MantidQt::CustomInterfaces {
 
 ALFInstrumentWidget::ALFInstrumentWidget(QString workspaceName)
     : MantidWidgets::InstrumentWidget(std::move(workspaceName), nullptr, true, true, 0.0, 0.0, true,
-                                      MantidWidgets::InstrumentWidget::Dependencies(), false) {
+                                      MantidWidgets::InstrumentWidget::Dependencies(), false, getTabCustomizations()) {
   removeTab("Instrument");
   removeTab("Draw");
   hideHelp();
 
-  getPickTab()->expandPlotPanel();
+  m_pickTab->expandPlotPanel();
+}
+
+MantidWidgets::InstrumentWidget::TabCustomizations ALFInstrumentWidget::getTabCustomizations() const {
+  MantidWidgets::InstrumentWidget::TabCustomizations customizations;
+  customizations.pickTools = std::vector<MantidWidgets::IWPickToolType>{
+      MantidWidgets::IWPickToolType::Zoom,       MantidWidgets::IWPickToolType::PixelSelect,
+      MantidWidgets::IWPickToolType::TubeSelect, MantidWidgets::IWPickToolType::PeakSelect,
+      MantidWidgets::IWPickToolType::EditShape,  MantidWidgets::IWPickToolType::DrawRectangle};
+  return customizations;
 }
 
 void ALFInstrumentWidget::handleActiveWorkspaceDeleted() {

--- a/qt/scientific_interfaces/Direct/ALFInstrumentWidget.h
+++ b/qt/scientific_interfaces/Direct/ALFInstrumentWidget.h
@@ -17,6 +17,9 @@ public:
   explicit ALFInstrumentWidget(QString workspaceName);
 
   void handleActiveWorkspaceDeleted() override;
+
+private:
+  MantidWidgets::InstrumentWidget::TabCustomizations getTabCustomizations() const;
 };
 
 } // namespace MantidQt::CustomInterfaces

--- a/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/InstrumentWidget.h
+++ b/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/InstrumentWidget.h
@@ -24,6 +24,7 @@
 #include "MantidQtWidgets/Common/GraphOptions.h"
 #include "MantidQtWidgets/Common/IMessageHandler.h"
 #include "MantidQtWidgets/Common/WorkspaceObserver.h"
+#include "MantidQtWidgets/InstrumentView/InstrumentWidgetPickTab.h"
 
 #include <memory>
 
@@ -59,7 +60,6 @@ class InstrumentActor;
 class InstrumentWidgetTab;
 class InstrumentWidgetRenderTab;
 class InstrumentWidgetMaskTab;
-class InstrumentWidgetPickTab;
 class InstrumentWidgetTreeTab;
 class CollapsiblePanel;
 class XIntegrationControl;
@@ -74,6 +74,15 @@ struct Dependencies {
   std::unique_ptr<QtConnect> qtConnect = std::make_unique<QtConnect>();
   std::unique_ptr<QtMetaObject> qtMetaObject = std::make_unique<QtMetaObject>();
   std::unique_ptr<IMessageHandler> messageHandler = nullptr;
+};
+
+struct TabCustomizations {
+  std::vector<IWPickToolType> pickTools = std::vector<IWPickToolType>{
+      IWPickToolType::Zoom,          IWPickToolType::PixelSelect,     IWPickToolType::WholeInstrumentSelect,
+      IWPickToolType::TubeSelect,    IWPickToolType::PeakSelect,      IWPickToolType::PeakErase,
+      IWPickToolType::PeakCompare,   IWPickToolType::PeakAlign,       IWPickToolType::DrawEllipse,
+      IWPickToolType::DrawRectangle, IWPickToolType::DrawSector,      IWPickToolType::DrawFree,
+      IWPickToolType::EditShape,     IWPickToolType::DrawRingEllipse, IWPickToolType::DrawRingRectangle};
 };
 
 } // namespace Detail
@@ -102,6 +111,7 @@ class EXPORT_OPT_MANTIDQT_INSTRUMENTVIEW InstrumentWidget : public QWidget,
 
 public:
   using Dependencies = Detail::Dependencies;
+  using TabCustomizations = Detail::TabCustomizations;
   enum SurfaceType {
     FULL3D = 0,
     CYLINDRICAL_X,
@@ -117,7 +127,8 @@ public:
 
   explicit InstrumentWidget(QString wsName, QWidget *parent = nullptr, bool resetGeometry = true,
                             bool autoscaling = true, double scaleMin = 0.0, double scaleMax = 0.0,
-                            bool setDefaultView = true, Dependencies deps = Dependencies(), bool useThread = false);
+                            bool setDefaultView = true, Dependencies deps = Dependencies(), bool useThread = false,
+                            TabCustomizations customizations = TabCustomizations());
   ~InstrumentWidget() override;
   QString getWorkspaceName() const;
   std::string getWorkspaceNameStdString() const;
@@ -281,7 +292,7 @@ protected:
   /// Set newly created projection surface
   void setSurface(ProjectionSurface *surface);
   QWidget *createInstrumentTreeTab(QTabWidget *ControlsTab);
-  void createTabs(const QSettings &settings);
+  void createTabs(const QSettings &settings, TabCustomizations customizations);
   void saveSettings();
 
   QString asString(const std::vector<int> &numbers) const;

--- a/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/InstrumentWidgetPickTab.h
+++ b/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/InstrumentWidgetPickTab.h
@@ -28,6 +28,7 @@ class QActionGroup;
 class QSignalMapper;
 class QMenu;
 class QLineEdit;
+class QGridLayout;
 
 namespace MantidQt {
 namespace MantidWidgets {
@@ -38,6 +39,23 @@ class ProjectionSurface;
 class ComponentInfoController;
 class DetectorPlotController;
 
+enum EXPORT_OPT_MANTIDQT_INSTRUMENTVIEW IWPickToolType {
+  Zoom,
+  PixelSelect,
+  WholeInstrumentSelect,
+  TubeSelect,
+  PeakSelect,
+  PeakErase,
+  PeakCompare,
+  PeakAlign,
+  DrawEllipse,
+  DrawRectangle,
+  DrawSector,
+  DrawFree,
+  EditShape,
+  DrawRingEllipse,
+  DrawRingRectangle
+};
 enum EXPORT_OPT_MANTIDQT_INSTRUMENTVIEW IWPickPlotType { SINGLE = 0, DETECTOR_SUM, TUBE_SUM, TUBE_INTEGRAL };
 enum EXPORT_OPT_MANTIDQT_INSTRUMENTVIEW IWPickXUnits {
   DETECTOR_ID = 0,
@@ -80,30 +98,15 @@ public:
     Tube,
     Draw
   };
-  enum ToolType {
-    Zoom,
-    PixelSelect,
-    WholeInstrumentSelect,
-    TubeSelect,
-    PeakSelect,
-    PeakErase,
-    PeakCompare,
-    PeakAlign,
-    DrawEllipse,
-    DrawRectangle,
-    DrawSector,
-    DrawFree,
-    EditShape
-  };
 
-  explicit InstrumentWidgetPickTab(InstrumentWidget *instrWidget);
+  explicit InstrumentWidgetPickTab(InstrumentWidget *instrWidget, std::vector<IWPickToolType> const &tools);
   bool canUpdateTouchedDetector() const;
   void initSurface() override;
   void saveSettings(QSettings &settings) const override;
   void loadSettings(const QSettings &settings) override;
   bool addToDisplayContextMenu(QMenu & /*unused*/) const override;
   void expandPlotPanel();
-  void selectTool(const ToolType tool);
+  void selectTool(const IWPickToolType tool);
   SelectionType getSelectionType() const { return m_selectionType; }
   std::shared_ptr<ProjectionSurface> getSurface() const;
   const InstrumentWidget *getInstrumentWidget() const;
@@ -116,6 +119,7 @@ public:
   void addToContextMenu(QAction *action, std::function<bool(std::map<std::string, bool>)> &actionCondition);
   QPushButton *getSelectTubeButton();
   void setPlotType(const IWPickPlotType type);
+  void setAvailableTools(std::vector<IWPickToolType> const &toolTypes);
 
 public slots:
   void setTubeXUnits(int units);
@@ -144,6 +148,8 @@ private slots:
   void onKeepOriginalStateChanged(int state);
 
 private:
+  void addToolbarWidget(const IWPickToolType toolType, int &row, int &column);
+  void addToolbarWidget(QPushButton *toolbarButton, int &row, int &column) const;
   void showEvent(QShowEvent * /*unused*/) override;
   QColor getShapeBorderColor() const;
   void collapsePlotPanel();
@@ -167,6 +173,7 @@ private:
   QPushButton *m_free_draw;      ///< Button switching on drawing a region of arbitrary shape
   QPushButton *m_edit;           ///< Button switching on editing the selection region
   bool m_plotSum;
+  QGridLayout *m_toolBox;
 
   // Actions to set integration option for the detector's parent selection mode
   QAction *m_sumDetectors;      ///< Sets summation over detectors (m_plotSum = true)

--- a/qt/widgets/instrumentview/src/InstrumentWidget.cpp
+++ b/qt/widgets/instrumentview/src/InstrumentWidget.cpp
@@ -115,7 +115,7 @@ public:
  */
 InstrumentWidget::InstrumentWidget(QString wsName, QWidget *parent, bool resetGeometry, bool autoscaling,
                                    double scaleMin, double scaleMax, bool setDefaultView, Dependencies deps,
-                                   bool useThread)
+                                   bool useThread, TabCustomizations customizations)
     : QWidget(parent), WorkspaceObserver(), m_instrumentDisplay(std::move(deps.instrumentDisplay)),
       m_workspaceName(std::move(wsName)), m_instrumentActor(nullptr), m_surfaceType(FULL3D),
       m_savedialog_dir(
@@ -193,7 +193,7 @@ InstrumentWidget::InstrumentWidget(QString wsName, QWidget *parent, bool resetGe
   setBackgroundColor(settings.value("BackgroundColor", QColor(0, 0, 0, 1.0)).value<QColor>());
 
   // Create the b=tabs
-  createTabs(settings);
+  createTabs(settings, customizations);
 
   settings.endGroup();
 
@@ -1445,7 +1445,7 @@ bool InstrumentWidget::isGLEnabled() const { return m_useOpenGL; }
 /**
  * Create and add the tab widgets.
  */
-void InstrumentWidget::createTabs(const QSettings &settings) {
+void InstrumentWidget::createTabs(const QSettings &settings, TabCustomizations customizations) {
   // Render Controls
   m_renderTab = new InstrumentWidgetRenderTab(this);
   m_qtConnect->connect(m_renderTab, SIGNAL(setAutoscaling(bool)), this, SLOT(setColorMapAutoscaling(bool)));
@@ -1453,7 +1453,7 @@ void InstrumentWidget::createTabs(const QSettings &settings) {
   m_renderTab->loadSettings(settings);
 
   // Pick controls
-  m_pickTab = new InstrumentWidgetPickTab(this);
+  m_pickTab = new InstrumentWidgetPickTab(this, customizations.pickTools);
   m_pickTab->loadSettings(settings);
 
   // Mask controls

--- a/qt/widgets/instrumentview/src/InstrumentWidgetPickTab.cpp
+++ b/qt/widgets/instrumentview/src/InstrumentWidgetPickTab.cpp
@@ -58,6 +58,9 @@ namespace MantidQt::MantidWidgets {
 using namespace boost::math;
 
 namespace {
+
+int constexpr N_TOOLBAR_COLUMNS(7);
+
 // Get the phi angle between the detector with reference to the origin
 // Makes assumptions about beam direction. Legacy code and not robust.
 double getPhi(const Mantid::Kernel::V3D &pos) { return std::atan2(pos[1], pos[0]); }
@@ -87,7 +90,8 @@ void rebin(const T &inputWorkspace, const std::string &rebinString, const bool p
  * Constructor.
  * @param instrWidget :: Parent InstrumentWidget.
  */
-InstrumentWidgetPickTab::InstrumentWidgetPickTab(InstrumentWidget *instrWidget)
+InstrumentWidgetPickTab::InstrumentWidgetPickTab(InstrumentWidget *instrWidget,
+                                                 std::vector<IWPickToolType> const &tools)
     : InstrumentWidgetTab(instrWidget), m_freezePlot(false), m_originalWorkspace(nullptr), m_tubeXUnitsCache(0),
       m_plotTypeCache(0),
       m_addedActions(std::vector<std::pair<QAction *, std::function<bool(std::map<std::string, bool>)>>>{}) {
@@ -307,24 +311,6 @@ InstrumentWidgetPickTab::InstrumentWidgetPickTab(InstrumentWidget *instrWidget)
   m_peakAlign->setIcon(QIcon(":/PickTools/selection-peak-plane.png"));
   m_peakAlign->setToolTip("Crystal peak alignment tool");
 
-  auto *toolBox = new QGridLayout();
-  toolBox->addWidget(m_zoom, 0, 0);
-  toolBox->addWidget(m_edit, 0, 1);
-  toolBox->addWidget(m_ellipse, 0, 2);
-  toolBox->addWidget(m_rectangle, 0, 3);
-  toolBox->addWidget(m_ring_ellipse, 0, 4);
-  toolBox->addWidget(m_ring_rectangle, 0, 5);
-  toolBox->addWidget(m_sector, 0, 6);
-  toolBox->addWidget(m_free_draw, 0, 7);
-  toolBox->addWidget(m_one, 1, 0);
-  toolBox->addWidget(m_whole, 1, 1);
-  toolBox->addWidget(m_tube, 1, 2);
-  toolBox->addWidget(m_peakAdd, 1, 3);
-  toolBox->addWidget(m_peakErase, 1, 4);
-  toolBox->addWidget(m_peakCompare, 1, 5);
-  toolBox->addWidget(m_peakAlign, 1, 6);
-  toolBox->setColumnStretch(8, 1);
-  toolBox->setSpacing(2);
   connect(m_zoom, SIGNAL(clicked()), this, SLOT(setSelectionType()));
   connect(m_one, SIGNAL(clicked()), this, SLOT(setSelectionType()));
   connect(m_whole, SIGNAL(clicked()), this, SLOT(setSelectionType()));
@@ -342,9 +328,80 @@ InstrumentWidgetPickTab::InstrumentWidgetPickTab(InstrumentWidget *instrWidget)
   connect(m_edit, SIGNAL(clicked()), this, SLOT(setSelectionType()));
 
   // lay out the widgets
+  m_toolBox = new QGridLayout();
+  setAvailableTools(tools);
+  m_toolBox->setColumnStretch(8, 1);
+  m_toolBox->setSpacing(2);
   layout->addWidget(m_activeTool);
-  layout->addLayout(toolBox);
+  layout->addLayout(m_toolBox);
   layout->addWidget(panelStack);
+}
+
+void InstrumentWidgetPickTab::setAvailableTools(std::vector<IWPickToolType> const &toolTypes) {
+  int row(0), column(0);
+  for (const auto &toolType : toolTypes) {
+    addToolbarWidget(toolType, row, column);
+  }
+}
+
+void InstrumentWidgetPickTab::addToolbarWidget(const IWPickToolType toolType, int &row, int &column) {
+  switch (toolType) {
+  case IWPickToolType::Zoom:
+    addToolbarWidget(m_zoom, row, column);
+    break;
+  case IWPickToolType::EditShape:
+    addToolbarWidget(m_edit, row, column);
+    break;
+  case IWPickToolType::DrawEllipse:
+    addToolbarWidget(m_ellipse, row, column);
+    break;
+  case IWPickToolType::DrawRectangle:
+    addToolbarWidget(m_rectangle, row, column);
+    break;
+  case IWPickToolType::DrawRingEllipse:
+    addToolbarWidget(m_ring_ellipse, row, column);
+    break;
+  case IWPickToolType::DrawRingRectangle:
+    addToolbarWidget(m_ring_rectangle, row, column);
+    break;
+  case IWPickToolType::DrawSector:
+    addToolbarWidget(m_sector, row, column);
+    break;
+  case IWPickToolType::DrawFree:
+    addToolbarWidget(m_free_draw, row, column);
+    break;
+  case IWPickToolType::PixelSelect:
+    addToolbarWidget(m_one, row, column);
+    break;
+  case IWPickToolType::WholeInstrumentSelect:
+    addToolbarWidget(m_whole, row, column);
+    break;
+  case IWPickToolType::TubeSelect:
+    addToolbarWidget(m_tube, row, column);
+    break;
+  case IWPickToolType::PeakSelect:
+    addToolbarWidget(m_peakAdd, row, column);
+    break;
+  case IWPickToolType::PeakErase:
+    addToolbarWidget(m_peakErase, row, column);
+    break;
+  case IWPickToolType::PeakCompare:
+    addToolbarWidget(m_peakCompare, row, column);
+    break;
+  case IWPickToolType::PeakAlign:
+    addToolbarWidget(m_peakAlign, row, column);
+    break;
+  }
+}
+
+void InstrumentWidgetPickTab::addToolbarWidget(QPushButton *toolbarButton, int &row, int &column) const {
+  m_toolBox->addWidget(toolbarButton, row, column);
+  if (column == 0 || column % N_TOOLBAR_COLUMNS != 0) {
+    ++column;
+  } else {
+    column = 0;
+    ++row;
+  }
 }
 
 QPushButton *InstrumentWidgetPickTab::getSelectTubeButton() { return m_tube; }
@@ -755,7 +812,7 @@ bool InstrumentWidgetPickTab::addToDisplayContextMenu(QMenu &context) const {
  * Select a tool on the tab
  * @param tool One of the enumerated tool types, @see ToolType
  */
-void InstrumentWidgetPickTab::selectTool(const ToolType tool) {
+void InstrumentWidgetPickTab::selectTool(const IWPickToolType tool) {
   switch (tool) {
   case Zoom:
     m_zoom->setChecked(true);
@@ -910,7 +967,7 @@ void InstrumentWidgetPickTab::resetOriginalWorkspace() { m_originalWorkspace.res
 void InstrumentWidgetPickTab::clearWidgets() {
   m_plotController->clear();
   m_infoController->clear();
-  selectTool(ToolType::PixelSelect);
+  selectTool(IWPickToolType::PixelSelect);
   collapsePlotPanel();
 }
 


### PR DESCRIPTION
**Description of work.**
This PR makes it possible to customize which toolbar buttons should be available on the Pick tab of the InstrumentWidget.

This was needed for the ALFView interface which has an InstrumentWidget embedded inside its interface. To make the interface easier to use, the Pick tab will only show the buttons which are useful to the users of ALFView.

**To test:**
Open ALFView
Click on Pick tab
There should be 6 toolbar buttons at the top of the pick tab

*There is no associated issue.*

*This does not require release notes* because **release notes will be added in a later PR**

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
