### PR TITLE
Export workspace to ADS on ALFView

### DIFF
--- a/qt/scientific_interfaces/Direct/ALFAnalysisModel.cpp
+++ b/qt/scientific_interfaces/Direct/ALFAnalysisModel.cpp
@@ -177,11 +177,11 @@ void ALFAnalysisModel::openExternalPlot() const {
 MatrixWorkspace_sptr ALFAnalysisModel::plottedWorkspace() const {
   if (m_fitWorkspace) {
     return m_fitWorkspace;
-  } else if (m_extractedWorkspace) {
-    return m_extractedWorkspace;
-  } else {
-    return nullptr;
   }
+  if (m_extractedWorkspace) {
+    return m_extractedWorkspace;
+  }
+  return nullptr;
 }
 
 std::vector<int> ALFAnalysisModel::plottedWorkspaceIndices() const {

--- a/qt/scientific_interfaces/Direct/ALFAnalysisModel.cpp
+++ b/qt/scientific_interfaces/Direct/ALFAnalysisModel.cpp
@@ -14,7 +14,6 @@
 #include "MantidAPI/IFunction.h"
 #include "MantidAPI/IPeakFunction.h"
 #include "MantidAPI/MatrixWorkspace.h"
-#include "MantidQtWidgets/MplCpp/Plot.h"
 
 #include <algorithm>
 #include <numeric>
@@ -164,13 +163,6 @@ void ALFAnalysisModel::exportWorkspaceCopyToADS() const {
   // The ADS should not be used anywhere else apart from here. Note that a copy is exported.
   if (auto const workspace = plottedWorkspace()) {
     AnalysisDataService::Instance().addOrReplace(WS_EXPORT_NAME, workspace->clone());
-  }
-}
-
-void ALFAnalysisModel::openExternalPlot() const {
-  // Externally plot the extracted workspace or fitted workspace depending on which one is available.
-  if (auto const workspace = plottedWorkspace()) {
-    MantidQt::Widgets::MplCpp::plot({workspace}, boost::none, plottedWorkspaceIndices());
   }
 }
 

--- a/qt/scientific_interfaces/Direct/ALFAnalysisModel.cpp
+++ b/qt/scientific_interfaces/Direct/ALFAnalysisModel.cpp
@@ -169,7 +169,9 @@ void ALFAnalysisModel::exportWorkspaceCopyToADS() const {
 
 void ALFAnalysisModel::openExternalPlot() const {
   // Externally plot the extracted workspace or fitted workspace depending on which one is available.
-  MantidQt::Widgets::MplCpp::plot({plottedWorkspace()}, boost::none, plottedWorkspaceIndices());
+  if (auto const workspace = plottedWorkspace()) {
+    MantidQt::Widgets::MplCpp::plot({workspace}, boost::none, plottedWorkspaceIndices());
+  }
 }
 
 MatrixWorkspace_sptr ALFAnalysisModel::plottedWorkspace() const {

--- a/qt/scientific_interfaces/Direct/ALFAnalysisModel.h
+++ b/qt/scientific_interfaces/Direct/ALFAnalysisModel.h
@@ -35,7 +35,9 @@ public:
   virtual void calculateEstimate(std::pair<double, double> const &range) = 0;
 
   virtual void exportWorkspaceCopyToADS() const = 0;
-  virtual void openExternalPlot() const = 0;
+
+  virtual Mantid::API::MatrixWorkspace_sptr plottedWorkspace() const = 0;
+  virtual std::vector<int> plottedWorkspaceIndices() const = 0;
 
   virtual void setPeakParameters(Mantid::API::IPeakFunction_const_sptr const &peak) = 0;
   virtual void setPeakCentre(double const centre) = 0;
@@ -68,7 +70,9 @@ public:
   void calculateEstimate(std::pair<double, double> const &range) override;
 
   void exportWorkspaceCopyToADS() const override;
-  void openExternalPlot() const override;
+
+  Mantid::API::MatrixWorkspace_sptr plottedWorkspace() const override;
+  std::vector<int> plottedWorkspaceIndices() const override;
 
   void setPeakParameters(Mantid::API::IPeakFunction_const_sptr const &peak) override;
   void setPeakCentre(double const centre) override;
@@ -85,8 +89,6 @@ public:
   std::optional<double> rotationAngle() const override;
 
 private:
-  Mantid::API::MatrixWorkspace_sptr plottedWorkspace() const;
-  std::vector<int> plottedWorkspaceIndices() const;
   Mantid::API::IFunction_sptr calculateEstimate(Mantid::API::MatrixWorkspace_sptr &workspace,
                                                 std::pair<double, double> const &range);
 

--- a/qt/scientific_interfaces/Direct/ALFAnalysisModel.h
+++ b/qt/scientific_interfaces/Direct/ALFAnalysisModel.h
@@ -34,6 +34,8 @@ public:
   virtual Mantid::API::MatrixWorkspace_sptr doFit(std::pair<double, double> const &range) = 0;
   virtual void calculateEstimate(std::pair<double, double> const &range) = 0;
 
+  virtual void exportWorkspaceCopyToADS() const = 0;
+
   virtual void setPeakParameters(Mantid::API::IPeakFunction_const_sptr const &peak) = 0;
   virtual void setPeakCentre(double const centre) = 0;
   virtual double peakCentre() const = 0;
@@ -64,6 +66,8 @@ public:
   Mantid::API::MatrixWorkspace_sptr doFit(std::pair<double, double> const &range) override;
   void calculateEstimate(std::pair<double, double> const &range) override;
 
+  void exportWorkspaceCopyToADS() const override;
+
   void setPeakParameters(Mantid::API::IPeakFunction_const_sptr const &peak) override;
   void setPeakCentre(double const centre) override;
   double peakCentre() const override;
@@ -87,6 +91,7 @@ private:
   std::string m_fitStatus;
   std::vector<double> m_twoThetas;
   Mantid::API::MatrixWorkspace_sptr m_extractedWorkspace;
+  Mantid::API::MatrixWorkspace_sptr m_fitWorkspace;
 };
 
 } // namespace CustomInterfaces

--- a/qt/scientific_interfaces/Direct/ALFAnalysisModel.h
+++ b/qt/scientific_interfaces/Direct/ALFAnalysisModel.h
@@ -35,6 +35,7 @@ public:
   virtual void calculateEstimate(std::pair<double, double> const &range) = 0;
 
   virtual void exportWorkspaceCopyToADS() const = 0;
+  virtual void openExternalPlot() const = 0;
 
   virtual void setPeakParameters(Mantid::API::IPeakFunction_const_sptr const &peak) = 0;
   virtual void setPeakCentre(double const centre) = 0;
@@ -67,6 +68,7 @@ public:
   void calculateEstimate(std::pair<double, double> const &range) override;
 
   void exportWorkspaceCopyToADS() const override;
+  void openExternalPlot() const override;
 
   void setPeakParameters(Mantid::API::IPeakFunction_const_sptr const &peak) override;
   void setPeakCentre(double const centre) override;
@@ -83,7 +85,8 @@ public:
   std::optional<double> rotationAngle() const override;
 
 private:
-  std::string extractedWsName(std::size_t const runNumber) const;
+  Mantid::API::MatrixWorkspace_sptr plottedWorkspace() const;
+  std::vector<int> plottedWorkspaceIndices() const;
   Mantid::API::IFunction_sptr calculateEstimate(Mantid::API::MatrixWorkspace_sptr &workspace,
                                                 std::pair<double, double> const &range);
 

--- a/qt/scientific_interfaces/Direct/ALFAnalysisPresenter.cpp
+++ b/qt/scientific_interfaces/Direct/ALFAnalysisPresenter.cpp
@@ -74,6 +74,8 @@ void ALFAnalysisPresenter::notifyFitClicked() {
   updateRotationAngleInViewFromModel();
 }
 
+void ALFAnalysisPresenter::notifyExportWorkspaceToADSClicked() { m_model->exportWorkspaceCopyToADS(); }
+
 void ALFAnalysisPresenter::notifyResetClicked() {
   calculateEstimate();
   updatePeakCentreInViewFromModel();

--- a/qt/scientific_interfaces/Direct/ALFAnalysisPresenter.cpp
+++ b/qt/scientific_interfaces/Direct/ALFAnalysisPresenter.cpp
@@ -76,7 +76,11 @@ void ALFAnalysisPresenter::notifyFitClicked() {
 
 void ALFAnalysisPresenter::notifyExportWorkspaceToADSClicked() { m_model->exportWorkspaceCopyToADS(); }
 
-void ALFAnalysisPresenter::notifyExternalPlotClicked() { m_model->openExternalPlot(); }
+void ALFAnalysisPresenter::notifyExternalPlotClicked() {
+  if (auto const plotWorkspace = m_model->plottedWorkspace()) {
+    m_view->openExternalPlot(plotWorkspace, m_model->plottedWorkspaceIndices());
+  }
+}
 
 void ALFAnalysisPresenter::notifyResetClicked() {
   calculateEstimate();

--- a/qt/scientific_interfaces/Direct/ALFAnalysisPresenter.cpp
+++ b/qt/scientific_interfaces/Direct/ALFAnalysisPresenter.cpp
@@ -76,6 +76,8 @@ void ALFAnalysisPresenter::notifyFitClicked() {
 
 void ALFAnalysisPresenter::notifyExportWorkspaceToADSClicked() { m_model->exportWorkspaceCopyToADS(); }
 
+void ALFAnalysisPresenter::notifyExternalPlotClicked() { m_model->openExternalPlot(); }
+
 void ALFAnalysisPresenter::notifyResetClicked() {
   calculateEstimate();
   updatePeakCentreInViewFromModel();

--- a/qt/scientific_interfaces/Direct/ALFAnalysisPresenter.h
+++ b/qt/scientific_interfaces/Direct/ALFAnalysisPresenter.h
@@ -35,6 +35,7 @@ public:
   virtual void notifyPeakPickerChanged() = 0;
   virtual void notifyPeakCentreEditingFinished() = 0;
   virtual void notifyFitClicked() = 0;
+  virtual void notifyExportWorkspaceToADSClicked() = 0;
   virtual void notifyResetClicked() = 0;
 
   virtual std::size_t numberOfTubes() const = 0;
@@ -54,6 +55,7 @@ public:
   void notifyPeakPickerChanged() override;
   void notifyPeakCentreEditingFinished() override;
   void notifyFitClicked() override;
+  void notifyExportWorkspaceToADSClicked() override;
   void notifyResetClicked() override;
 
   std::size_t numberOfTubes() const override;

--- a/qt/scientific_interfaces/Direct/ALFAnalysisPresenter.h
+++ b/qt/scientific_interfaces/Direct/ALFAnalysisPresenter.h
@@ -36,6 +36,7 @@ public:
   virtual void notifyPeakCentreEditingFinished() = 0;
   virtual void notifyFitClicked() = 0;
   virtual void notifyExportWorkspaceToADSClicked() = 0;
+  virtual void notifyExternalPlotClicked() = 0;
   virtual void notifyResetClicked() = 0;
 
   virtual std::size_t numberOfTubes() const = 0;
@@ -56,6 +57,7 @@ public:
   void notifyPeakCentreEditingFinished() override;
   void notifyFitClicked() override;
   void notifyExportWorkspaceToADSClicked() override;
+  void notifyExternalPlotClicked() override;
   void notifyResetClicked() override;
 
   std::size_t numberOfTubes() const override;

--- a/qt/scientific_interfaces/Direct/ALFAnalysisView.cpp
+++ b/qt/scientific_interfaces/Direct/ALFAnalysisView.cpp
@@ -117,6 +117,10 @@ QWidget *ALFAnalysisView::createPlotWidget() {
 }
 
 QWidget *ALFAnalysisView::createPlotToolbar() {
+  m_exportToADS = new QPushButton(MantidQt::Icons::getIcon("mdi.export-variant"), "");
+  m_exportToADS->setToolTip("Export plot to workspace. The workspace is named 'ALFView_exported'");
+  connect(m_exportToADS, SIGNAL(clicked()), this, SLOT(notifyExportWorkspaceToADSClicked()));
+
   m_resetButton = new QPushButton(MantidQt::Icons::getIcon("mdi.replay"), "");
   m_resetButton->setToolTip("Reset extracted plot");
   connect(m_resetButton, SIGNAL(clicked()), this, SLOT(notifyResetClicked()));
@@ -125,6 +129,7 @@ QWidget *ALFAnalysisView::createPlotToolbar() {
   auto *toolbarLayout = new QHBoxLayout(toolbarWidget);
   toolbarLayout->setMargin(0);
   toolbarLayout->addItem(new QSpacerItem(80, 0, QSizePolicy::Expanding, QSizePolicy::Fixed));
+  toolbarLayout->addWidget(m_exportToADS);
   toolbarLayout->addWidget(m_resetButton);
 
   return toolbarWidget;
@@ -215,6 +220,8 @@ void ALFAnalysisView::notifyPeakPickerChanged() { m_presenter->notifyPeakPickerC
 void ALFAnalysisView::notifyPeakCentreEditingFinished() { m_presenter->notifyPeakCentreEditingFinished(); }
 
 void ALFAnalysisView::notifyFitClicked() { m_presenter->notifyFitClicked(); }
+
+void ALFAnalysisView::notifyExportWorkspaceToADSClicked() { m_presenter->notifyExportWorkspaceToADSClicked(); }
 
 void ALFAnalysisView::notifyResetClicked() { m_presenter->notifyResetClicked(); }
 

--- a/qt/scientific_interfaces/Direct/ALFAnalysisView.cpp
+++ b/qt/scientific_interfaces/Direct/ALFAnalysisView.cpp
@@ -228,6 +228,8 @@ void ALFAnalysisView::notifyFitClicked() { m_presenter->notifyFitClicked(); }
 
 void ALFAnalysisView::notifyExportWorkspaceToADSClicked() { m_presenter->notifyExportWorkspaceToADSClicked(); }
 
+void ALFAnalysisView::notifyExternalPlotClicked() { m_presenter->notifyExternalPlotClicked(); }
+
 void ALFAnalysisView::notifyResetClicked() { m_presenter->notifyResetClicked(); }
 
 void ALFAnalysisView::replot() { m_plot->replot(); }

--- a/qt/scientific_interfaces/Direct/ALFAnalysisView.cpp
+++ b/qt/scientific_interfaces/Direct/ALFAnalysisView.cpp
@@ -137,11 +137,7 @@ QWidget *ALFAnalysisView::createFitWidget(double const start, double const end) 
   setupTwoThetaWidget(analysisLayout);
   setupFitRangeWidget(analysisLayout, start, end);
   setupPeakCentreWidget(analysisLayout, (start + end) / 2.0);
-<<<<<<< HEAD
   setupRotationAngleWidget(analysisLayout);
-=======
-  setupRAngleWidget(analysisLayout);
->>>>>>> d6895ed6a94 (Setup R angle widget)
 
   return analysisPane;
 }

--- a/qt/scientific_interfaces/Direct/ALFAnalysisView.cpp
+++ b/qt/scientific_interfaces/Direct/ALFAnalysisView.cpp
@@ -9,6 +9,7 @@
 
 #include "MantidAPI/IPeakFunction.h"
 #include "MantidQtIcons/Icon.h"
+#include "MantidQtWidgets/MplCpp/Plot.h"
 #include "MantidQtWidgets/Plotting/PeakPicker.h"
 #include "MantidQtWidgets/Plotting/PreviewPlot.h"
 
@@ -233,6 +234,12 @@ void ALFAnalysisView::notifyExternalPlotClicked() { m_presenter->notifyExternalP
 void ALFAnalysisView::notifyResetClicked() { m_presenter->notifyResetClicked(); }
 
 void ALFAnalysisView::replot() { m_plot->replot(); }
+
+void ALFAnalysisView::openExternalPlot(Mantid::API::MatrixWorkspace_sptr const &workspace,
+                                       std::vector<int> const &workspaceIndices) const {
+  // Externally plot the plotted workspace.
+  MantidQt::Widgets::MplCpp::plot({workspace}, boost::none, workspaceIndices);
+}
 
 std::pair<double, double> ALFAnalysisView::getRange() const {
   return std::make_pair(m_start->text().toDouble(), m_end->text().toDouble());

--- a/qt/scientific_interfaces/Direct/ALFAnalysisView.cpp
+++ b/qt/scientific_interfaces/Direct/ALFAnalysisView.cpp
@@ -117,9 +117,13 @@ QWidget *ALFAnalysisView::createPlotWidget() {
 }
 
 QWidget *ALFAnalysisView::createPlotToolbar() {
-  m_exportToADS = new QPushButton(MantidQt::Icons::getIcon("mdi.export-variant"), "");
-  m_exportToADS->setToolTip("Export plot to workspace. The workspace is named 'ALFView_exported'");
+  m_exportToADS = new QPushButton(MantidQt::Icons::getIcon("mdi.download"), "");
+  m_exportToADS->setToolTip("Generate workspace from plot. The workspace is named 'ALFView_exported'");
   connect(m_exportToADS, SIGNAL(clicked()), this, SLOT(notifyExportWorkspaceToADSClicked()));
+
+  m_externalPlot = new QPushButton(MantidQt::Icons::getIcon("mdi.open-in-new"), "");
+  m_externalPlot->setToolTip("Open plot in new window. The new window has more plotting options.");
+  connect(m_externalPlot, SIGNAL(clicked()), this, SLOT(notifyExternalPlotClicked()));
 
   m_resetButton = new QPushButton(MantidQt::Icons::getIcon("mdi.replay"), "");
   m_resetButton->setToolTip("Reset extracted plot");
@@ -130,6 +134,7 @@ QWidget *ALFAnalysisView::createPlotToolbar() {
   toolbarLayout->setMargin(0);
   toolbarLayout->addItem(new QSpacerItem(80, 0, QSizePolicy::Expanding, QSizePolicy::Fixed));
   toolbarLayout->addWidget(m_exportToADS);
+  toolbarLayout->addWidget(m_externalPlot);
   toolbarLayout->addWidget(m_resetButton);
 
   return toolbarWidget;

--- a/qt/scientific_interfaces/Direct/ALFAnalysisView.cpp
+++ b/qt/scientific_interfaces/Direct/ALFAnalysisView.cpp
@@ -137,7 +137,11 @@ QWidget *ALFAnalysisView::createFitWidget(double const start, double const end) 
   setupTwoThetaWidget(analysisLayout);
   setupFitRangeWidget(analysisLayout, start, end);
   setupPeakCentreWidget(analysisLayout, (start + end) / 2.0);
+<<<<<<< HEAD
   setupRotationAngleWidget(analysisLayout);
+=======
+  setupRAngleWidget(analysisLayout);
+>>>>>>> d6895ed6a94 (Setup R angle widget)
 
   return analysisPane;
 }

--- a/qt/scientific_interfaces/Direct/ALFAnalysisView.h
+++ b/qt/scientific_interfaces/Direct/ALFAnalysisView.h
@@ -97,6 +97,7 @@ private slots:
   void notifyPeakPickerChanged();
   void notifyPeakCentreEditingFinished();
   void notifyFitClicked();
+  void notifyExportWorkspaceToADSClicked();
   void notifyResetClicked();
 
 private:
@@ -113,6 +114,7 @@ private:
   MantidWidgets::PeakPicker *m_peakPicker;
   QLineEdit *m_start, *m_end;
   QPushButton *m_fitButton;
+  QPushButton *m_exportToADS;
   QPushButton *m_resetButton;
   QLineEdit *m_peakCentre;
   QLabel *m_fitStatus;

--- a/qt/scientific_interfaces/Direct/ALFAnalysisView.h
+++ b/qt/scientific_interfaces/Direct/ALFAnalysisView.h
@@ -98,6 +98,7 @@ private slots:
   void notifyPeakCentreEditingFinished();
   void notifyFitClicked();
   void notifyExportWorkspaceToADSClicked();
+  void notifyExternalPlotClicked();
   void notifyResetClicked();
 
 private:

--- a/qt/scientific_interfaces/Direct/ALFAnalysisView.h
+++ b/qt/scientific_interfaces/Direct/ALFAnalysisView.h
@@ -114,6 +114,7 @@ private:
   MantidWidgets::PeakPicker *m_peakPicker;
   QLineEdit *m_start, *m_end;
   QPushButton *m_fitButton;
+  QPushButton *m_externalPlot;
   QPushButton *m_exportToADS;
   QPushButton *m_resetButton;
   QLineEdit *m_peakCentre;

--- a/qt/scientific_interfaces/Direct/ALFAnalysisView.h
+++ b/qt/scientific_interfaces/Direct/ALFAnalysisView.h
@@ -42,6 +42,9 @@ public:
 
   virtual void replot() = 0;
 
+  virtual void openExternalPlot(Mantid::API::MatrixWorkspace_sptr const &workspace,
+                                std::vector<int> const &workspaceIndices) const = 0;
+
   virtual std::pair<double, double> getRange() const = 0;
 
   virtual void addSpectrum(Mantid::API::MatrixWorkspace_sptr const &workspace) = 0;
@@ -73,6 +76,9 @@ public:
   void subscribePresenter(IALFAnalysisPresenter *presenter) override;
 
   void replot() override;
+
+  void openExternalPlot(Mantid::API::MatrixWorkspace_sptr const &workspace,
+                        std::vector<int> const &workspaceIndices) const override;
 
   std::pair<double, double> getRange() const override;
 

--- a/qt/scientific_interfaces/Direct/test/ALFAnalysisMocks.h
+++ b/qt/scientific_interfaces/Direct/test/ALFAnalysisMocks.h
@@ -37,6 +37,7 @@ public:
   MOCK_METHOD0(notifyPeakPickerChanged, void());
   MOCK_METHOD0(notifyPeakCentreEditingFinished, void());
   MOCK_METHOD0(notifyFitClicked, void());
+  MOCK_METHOD0(notifyExportWorkspaceToADSClicked, void());
   MOCK_METHOD0(notifyResetClicked, void());
 
   MOCK_CONST_METHOD0(numberOfTubes, std::size_t());
@@ -83,6 +84,8 @@ public:
 
   MOCK_METHOD1(doFit, Mantid::API::MatrixWorkspace_sptr(std::pair<double, double> const &range));
   MOCK_METHOD1(calculateEstimate, void(std::pair<double, double> const &range));
+
+  MOCK_CONST_METHOD0(exportWorkspaceCopyToADS, void());
 
   MOCK_METHOD1(setPeakParameters, void(Mantid::API::IPeakFunction_const_sptr const &peak));
   MOCK_METHOD1(setPeakCentre, void(double const centre));

--- a/qt/scientific_interfaces/Direct/test/ALFAnalysisMocks.h
+++ b/qt/scientific_interfaces/Direct/test/ALFAnalysisMocks.h
@@ -38,6 +38,7 @@ public:
   MOCK_METHOD0(notifyPeakCentreEditingFinished, void());
   MOCK_METHOD0(notifyFitClicked, void());
   MOCK_METHOD0(notifyExportWorkspaceToADSClicked, void());
+  MOCK_METHOD0(notifyExternalPlotClicked, void());
   MOCK_METHOD0(notifyResetClicked, void());
 
   MOCK_CONST_METHOD0(numberOfTubes, std::size_t());
@@ -86,6 +87,7 @@ public:
   MOCK_METHOD1(calculateEstimate, void(std::pair<double, double> const &range));
 
   MOCK_CONST_METHOD0(exportWorkspaceCopyToADS, void());
+  MOCK_CONST_METHOD0(openExternalPlot, void());
 
   MOCK_METHOD1(setPeakParameters, void(Mantid::API::IPeakFunction_const_sptr const &peak));
   MOCK_METHOD1(setPeakCentre, void(double const centre));

--- a/qt/scientific_interfaces/Direct/test/ALFAnalysisMocks.h
+++ b/qt/scientific_interfaces/Direct/test/ALFAnalysisMocks.h
@@ -54,6 +54,9 @@ public:
 
   MOCK_METHOD0(replot, void());
 
+  MOCK_CONST_METHOD2(openExternalPlot,
+                     void(Mantid::API::MatrixWorkspace_sptr const &workspace, std::vector<int> const &worspaceIndices));
+
   MOCK_CONST_METHOD0(getRange, std::pair<double, double>());
 
   MOCK_METHOD1(addSpectrum, void(Mantid::API::MatrixWorkspace_sptr const &workspace));
@@ -87,7 +90,9 @@ public:
   MOCK_METHOD1(calculateEstimate, void(std::pair<double, double> const &range));
 
   MOCK_CONST_METHOD0(exportWorkspaceCopyToADS, void());
-  MOCK_CONST_METHOD0(openExternalPlot, void());
+
+  MOCK_CONST_METHOD0(plottedWorkspace, Mantid::API::MatrixWorkspace_sptr());
+  MOCK_CONST_METHOD0(plottedWorkspaceIndices, std::vector<int>());
 
   MOCK_METHOD1(setPeakParameters, void(Mantid::API::IPeakFunction_const_sptr const &peak));
   MOCK_METHOD1(setPeakCentre, void(double const centre));

--- a/qt/scientific_interfaces/Direct/test/ALFAnalysisModelTest.h
+++ b/qt/scientific_interfaces/Direct/test/ALFAnalysisModelTest.h
@@ -33,7 +33,7 @@ public:
 
   void setUp() override {
     m_workspace = WorkspaceCreationHelper::create2DWorkspace(1, 100);
-    m_workspaceName = "test";
+    m_exportWorkspaceName = "ALFView_exported";
     m_range = std::make_pair<double, double>(0.0, 100.0);
     m_twoThetas = std::vector<double>{29.5, 30.4, 31.0};
 
@@ -168,9 +168,39 @@ public:
     TS_ASSERT_DELTA(-0.0557, *m_model->rotationAngle(), 0.0001);
   }
 
+  void test_exportWorkspaceCopyToADS_does_not_create_an_exported_workspace_if_data_is_not_extracted() {
+    m_model->exportWorkspaceCopyToADS();
+    TS_ASSERT(!AnalysisDataService::Instance().doesExist(m_exportWorkspaceName));
+  }
+
+  void test_exportWorkspaceCopyToADS_exports_a_workspace_with_three_spectra_when_fit_workspace_exists() {
+    m_model->setExtractedWorkspace(m_workspace, m_twoThetas);
+    m_model->doFit(m_range);
+
+    m_model->exportWorkspaceCopyToADS();
+
+    auto &ads = AnalysisDataService::Instance();
+    TS_ASSERT(ads.doesExist(m_exportWorkspaceName));
+
+    auto const workspace = ads.retrieveWS<MatrixWorkspace>(m_exportWorkspaceName);
+    TS_ASSERT_EQUALS(3u, workspace->getNumberHistograms());
+  }
+
+  void test_exportWorkspaceCopyToADS_exports_a_workspace_with_one_spectra_when_fit_workspace_does_not_exist() {
+    m_model->setExtractedWorkspace(m_workspace, m_twoThetas);
+
+    m_model->exportWorkspaceCopyToADS();
+
+    auto &ads = AnalysisDataService::Instance();
+    TS_ASSERT(ads.doesExist(m_exportWorkspaceName));
+
+    auto const workspace = ads.retrieveWS<MatrixWorkspace>(m_exportWorkspaceName);
+    TS_ASSERT_EQUALS(1u, workspace->getNumberHistograms());
+  }
+
 private:
   MatrixWorkspace_sptr m_workspace;
-  std::string m_workspaceName;
+  std::string m_exportWorkspaceName;
   std::pair<double, double> m_range;
   std::vector<double> m_twoThetas;
 

--- a/qt/scientific_interfaces/Direct/test/ALFAnalysisModelTest.h
+++ b/qt/scientific_interfaces/Direct/test/ALFAnalysisModelTest.h
@@ -168,8 +168,26 @@ public:
     TS_ASSERT_DELTA(-0.0557, *m_model->rotationAngle(), 0.0001);
   }
 
-  void test_openExternalPlot_does_not_error_if_data_is_not_extracted() {
-    TS_ASSERT_THROWS_NOTHING(m_model->openExternalPlot());
+  void test_plottedWorkspace_returns_nullptr_data_is_not_extracted() {
+    TS_ASSERT_EQUALS(nullptr, m_model->plottedWorkspace());
+  }
+
+  void test_plottedWorkspace_returns_a_non_null_value_if_data_is_extracted() {
+    m_model->setExtractedWorkspace(m_workspace, m_twoThetas);
+    TS_ASSERT(m_model->plottedWorkspace());
+  }
+
+  void test_plottedWorkspaceIndices_returns_zero_if_there_is_no_fitted_workspace() {
+    auto const expectedIndices = std::vector<int>{0};
+    TS_ASSERT_EQUALS(expectedIndices, m_model->plottedWorkspaceIndices());
+  }
+
+  void test_plottedWorkspaceIndices_returns_zero_and_one_if_there_is_a_fitted_workspace() {
+    m_model->setExtractedWorkspace(m_workspace, m_twoThetas);
+    m_model->doFit(m_range);
+
+    auto const expectedIndices = std::vector<int>{0, 1};
+    TS_ASSERT_EQUALS(expectedIndices, m_model->plottedWorkspaceIndices());
   }
 
   void test_exportWorkspaceCopyToADS_does_not_create_an_exported_workspace_if_data_is_not_extracted() {

--- a/qt/scientific_interfaces/Direct/test/ALFAnalysisModelTest.h
+++ b/qt/scientific_interfaces/Direct/test/ALFAnalysisModelTest.h
@@ -168,6 +168,10 @@ public:
     TS_ASSERT_DELTA(-0.0557, *m_model->rotationAngle(), 0.0001);
   }
 
+  void test_openExternalPlot_does_not_error_if_data_is_not_extracted() {
+    TS_ASSERT_THROWS_NOTHING(m_model->openExternalPlot());
+  }
+
   void test_exportWorkspaceCopyToADS_does_not_create_an_exported_workspace_if_data_is_not_extracted() {
     m_model->exportWorkspaceCopyToADS();
     TS_ASSERT(!AnalysisDataService::Instance().doesExist(m_exportWorkspaceName));

--- a/qt/scientific_interfaces/Direct/test/ALFAnalysisPresenterTest.h
+++ b/qt/scientific_interfaces/Direct/test/ALFAnalysisPresenterTest.h
@@ -200,6 +200,11 @@ public:
     m_presenter->notifyFitClicked();
   }
 
+  void test_that_notifyExportWorkspaceToADSClicked_calls_the_expected_model_function() {
+    EXPECT_CALL(*m_model, exportWorkspaceCopyToADS()).Times(1);
+    m_presenter->notifyExportWorkspaceToADSClicked();
+  }
+
   void test_that_calculateEstimate_is_not_called_when_data_is_not_extracted() {
     EXPECT_CALL(*m_model, isDataExtracted()).Times(1).WillOnce(Return(false));
 

--- a/qt/scientific_interfaces/Direct/test/ALFAnalysisPresenterTest.h
+++ b/qt/scientific_interfaces/Direct/test/ALFAnalysisPresenterTest.h
@@ -205,8 +205,25 @@ public:
     m_presenter->notifyExportWorkspaceToADSClicked();
   }
 
-  void test_that_notifyExternalPlotClicked_calls_the_expected_model_function() {
-    EXPECT_CALL(*m_model, openExternalPlot()).Times(1);
+  void test_that_notifyExternalPlotClicked_will_open_an_external_plot_from_view() {
+    auto const workspace = WorkspaceCreationHelper::create2DWorkspace(1, 100);
+    std::vector<int> const workspaceIndices{0, 1};
+
+    EXPECT_CALL(*m_model, plottedWorkspace()).Times(1).WillOnce(Return(workspace));
+
+    EXPECT_CALL(*m_model, plottedWorkspaceIndices()).Times(1).WillOnce(Return(workspaceIndices));
+    EXPECT_CALL(*m_view, openExternalPlot(_, workspaceIndices)).Times(1);
+
+    m_presenter->notifyExternalPlotClicked();
+  }
+
+  void test_that_notifyExternalPlotClicked_will_not_open_external_plot_if_workspace_is_null() {
+    EXPECT_CALL(*m_model, plottedWorkspace()).Times(1).WillOnce(Return(nullptr));
+
+    // Assert not called
+    EXPECT_CALL(*m_model, plottedWorkspaceIndices()).Times(0);
+    EXPECT_CALL(*m_view, openExternalPlot(_, _)).Times(0);
+
     m_presenter->notifyExternalPlotClicked();
   }
 

--- a/qt/scientific_interfaces/Direct/test/ALFAnalysisPresenterTest.h
+++ b/qt/scientific_interfaces/Direct/test/ALFAnalysisPresenterTest.h
@@ -205,6 +205,11 @@ public:
     m_presenter->notifyExportWorkspaceToADSClicked();
   }
 
+  void test_that_notifyExternalPlotClicked_calls_the_expected_model_function() {
+    EXPECT_CALL(*m_model, openExternalPlot()).Times(1);
+    m_presenter->notifyExternalPlotClicked();
+  }
+
   void test_that_calculateEstimate_is_not_called_when_data_is_not_extracted() {
     EXPECT_CALL(*m_model, isDataExtracted()).Times(1).WillOnce(Return(false));
 

--- a/qt/scientific_interfaces/Direct/test/ALFAnalysisPresenterTest.h
+++ b/qt/scientific_interfaces/Direct/test/ALFAnalysisPresenterTest.h
@@ -212,7 +212,7 @@ public:
     EXPECT_CALL(*m_model, plottedWorkspace()).Times(1).WillOnce(Return(workspace));
 
     EXPECT_CALL(*m_model, plottedWorkspaceIndices()).Times(1).WillOnce(Return(workspaceIndices));
-    EXPECT_CALL(*m_view, openExternalPlot(_, workspaceIndices)).Times(1);
+    EXPECT_CALL(*m_view, openExternalPlot(Eq(workspace), workspaceIndices)).Times(1);
 
     m_presenter->notifyExternalPlotClicked();
   }


### PR DESCRIPTION
**Description of work.**
This PR adds the ability to export the plot to the ADS by placing a copy of the workspace in the ADS.

There is also the ability to open the plot in a separate window. This allows for a wider range of plotting options to be used, and the ability to save the plot to an image, etc.

**To test:**
Select ALF instrument in settings, and turn on data archive.
Open ALFView
Load run 82301
Click on Pick tab
Expand Rebin section. Rebin with 5.5,0.01,6
Click the Rectangle region selection tool at the top of the Pick tab
Select the two tubes in the centre with the yellow peak. The RHS plot should be updated.
Click Fit, and a Successful fit status label should appear.
Click the "Generate workspace from plot" button in the toolbar above the RHS plot. A workspace named "ALFView_exported" should appear in the ADS
Click the "Open plot in new window" button in the same toolbar. The plot should be opened in a new window. It is ok if the plot looks slightly different (e.g. the line colors etc. are different)

Fixes #34823

*This does not require release notes* because **release notes will be added in a later PR**

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
