### PR TITLE
Fix compiler error on Windows with Ninja

### DIFF
--- a/Framework/Geometry/src/MDGeometry/MDBoxImplicitFunction.cpp
+++ b/Framework/Geometry/src/MDGeometry/MDBoxImplicitFunction.cpp
@@ -9,6 +9,8 @@
 #include "MantidKernel/System.h"
 #include "MantidKernel/VMD.h"
 
+#include <algorithm>
+
 using Mantid::Kernel::VMD;
 
 namespace Mantid::Geometry {


### PR DESCRIPTION
A missing include was causing std::max etc not to be found

**To test:**

Code review should be sufficient, but if you have a Windows Ninja build it would be good to also check that that works

*There is no associated issue.*

*This does not require release notes* because **it fixes a niche compiler error**


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
