### PR TITLE
AlignAndFocusPowderFromFilesTest.ChunkingCompare system test stability

### DIFF
--- a/Testing/SystemTests/tests/framework/AlignAndFocusPowderFromFilesTest.py
+++ b/Testing/SystemTests/tests/framework/AlignAndFocusPowderFromFilesTest.py
@@ -90,15 +90,17 @@ class ChunkingCompare(systemtesting.MantidSystemTest):
         return 24*1024  # GiB
 
     def runTest(self):
+        GRP_WKSP = 'SNAP_chnk_grouping'
+
         # 11MB file
         kwargs = {'Filename':'SNAP_45874',
-                  'Params':(.5,-.004,7)}
+                  'Params':(.5,-.004,7),
+                  'GroupingWorkspace': GRP_WKSP}
 
         # create grouping for two output spectra
         CreateGroupingWorkspace(InstrumentFilename='SNAP_Definition.xml',
                                 GroupDetectorsBy='Group',
-                                OutputWorkspace='SNAP_grouping')
-
+                                OutputWorkspace=GRP_WKSP)
         # process in 4 chunks
         AlignAndFocusPowderFromFiles(OutputWorkspace='with_chunks', MaxChunkSize=.01, **kwargs)
         # process without chunks


### PR DESCRIPTION
`AlignAndFocusPowderFromFilesTest.ChunkingCompare` was discovered to be unstable. The solution is to name the grouping workspace and share it with `AlignAndFocusPowderFromFiles` rather than have the algorithm guess what the grouping workspace name is.

This fix was able to run 40 times without issue. Without this change was able to run (at most) 5 times without issue.

**To test:**

The system tests should pass. To be thorough, one could run the system test multiple times without errors. Example script
```sh
for i in {0..20}
do
    echo "#################### iteration ${i}"
    ./systemtest -R AlignAndFocusPowderFromFilesTest.ChunkingCompare || exit 1
done
```

Refs #32088.

*This does not require release notes* because it fixes stability in a system test.

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
