### PR TITLE
Refl Preview: Replace Image Info On RegionSelector with Statusbar

### DIFF
--- a/qt/python/mantidqt/mantidqt/_common.sip
+++ b/qt/python/mantidqt/mantidqt/_common.sip
@@ -1089,6 +1089,48 @@ public:
     %End
 };
 
+class ImageInfoWidgetMini : public QLabel {
+%TypeHeaderCode
+#include "MantidQtWidgets/Common/ImageInfoWidgetMini.h"
+#include "MantidPythonInterface/core/ExtractSharedPtr.h"
+#include <boost/python/object.hpp>
+#include <boost/python/handle.hpp>
+%End
+public:
+    ImageInfoWidgetMini(QWidget *parent = nullptr);
+    void cursorAt(const double x, const double y, const double signal, const QMap<QString, QString>& extraValues);
+    %MethodCode
+    try {
+      sipCpp->cursorAt(a0, a1, a2, *a3);
+    } catch(const std::exception & exc) {
+      SIP_BLOCK_THREADS
+      PyErr_SetString(PyExc_RuntimeError, exc.what());
+      SIP_UNBLOCK_THREADS
+      return NULL;
+    } catch(...) {
+      sipRaiseUnknownException();
+      return NULL;
+    }
+    %End
+    void setWorkspace(SIP_PYOBJECT);
+    %MethodCode
+    try {
+      using boost::python::extract;
+      using Mantid::PythonInterface::ExtractSharedPtr;
+      sipCpp->setWorkspace(ExtractSharedPtr<Mantid::API::Workspace>(a0)());
+    } catch(const std::exception & exc) {
+      SIP_BLOCK_THREADS
+      PyErr_SetString(PyExc_RuntimeError, exc.what());
+      SIP_UNBLOCK_THREADS
+      return NULL;
+    } catch(...) {
+      sipRaiseUnknownException();
+      return NULL;
+    }
+    %End
+};
+
+
 // ---------------------------------
 // DataSelector
 // ---------------------------------

--- a/qt/python/mantidqt/mantidqt/widgets/regionselector/presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/regionselector/presenter.py
@@ -49,12 +49,12 @@ class Selector(RectangleSelector):
 
 
 class RegionSelector(ObservingPresenter, SliceViewerBasePresenter):
-    def __init__(self, ws=None, parent=None, view=None):
+    def __init__(self, ws=None, parent=None, view=None, image_info_widget=None):
         if ws and WorkspaceInfo.get_ws_type(ws) != WS_TYPE.MATRIX:
             raise NotImplementedError("Only Matrix Workspaces are currently supported by the region selector.")
 
         self.notifyee = None
-        self.view = view if view else RegionSelectorView(self, parent)
+        self.view = view if view else RegionSelectorView(self, parent, image_info_widget=image_info_widget)
         super().__init__(ws, self.view._data_view)
         self._selectors: list[Selector] = []
         self._drawing_region = False

--- a/qt/python/mantidqt/mantidqt/widgets/regionselector/view.py
+++ b/qt/python/mantidqt/mantidqt/widgets/regionselector/view.py
@@ -31,7 +31,7 @@ class RegionSelectorView(QWidget):
         self._data_view.image_info_widget.setWorkspace(workspace)
 
     def create_dimensions(self, dims_info):
-        self._data_view.create_dimensions(dims_info=dims_info)
+        self._data_view.create_dimensions(dims_info=dims_info, custom_image_info=True)
 
     def create_axes_orthogonal(self, redraw_on_zoom):
         self._data_view.create_axes_orthogonal(redraw_on_zoom=redraw_on_zoom)

--- a/qt/python/mantidqt/mantidqt/widgets/regionselector/view.py
+++ b/qt/python/mantidqt/mantidqt/widgets/regionselector/view.py
@@ -15,10 +15,10 @@ from mantidqt.widgets.sliceviewer.views.dataview import SliceViewerDataView
 class RegionSelectorView(QWidget):
     """The view for the data portion of the sliceviewer"""
 
-    def __init__(self, presenter, parent=None, dims_info=None):
+    def __init__(self, presenter, parent=None, dims_info=None, image_info_widget=None):
         super().__init__(parent)
         self.setWindowFlags(Qt.Window)
-        self._data_view = SliceViewerDataView(presenter, dims_info, None, self, None)
+        self._data_view = SliceViewerDataView(presenter, dims_info, None, self, None, image_info_widget)
 
         layout = QHBoxLayout(self)
         layout.setContentsMargins(0, 0, 0, 0)

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/presenters/imageinfowidget.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/presenters/imageinfowidget.py
@@ -22,6 +22,7 @@ from mantidqt.widgets.sliceviewer.models.transform import NonOrthogonalTransform
 DBLMAX = sys.float_info.max
 
 ImageInfoWidget = import_qt('.._common', 'mantidqt.widgets', 'ImageInfoWidget')
+ImageInfoWidgetMini = import_qt('.._common', 'mantidqt.widgets', 'ImageInfoWidgetMini')
 
 
 class ImageInfoTracker(CursorTracker):

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/views/dataview.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/views/dataview.py
@@ -37,7 +37,8 @@ class SliceViewerCanvas(ScrollZoomMixin, MantidFigureCanvas):
 class SliceViewerDataView(QWidget):
     """The view for the data portion of the sliceviewer"""
 
-    def __init__(self, presenter: IDataViewSubscriber, dims_info, can_normalise, parent=None, conf=None):
+    def __init__(self, presenter: IDataViewSubscriber, dims_info, can_normalise, parent=None, conf=None,
+                 image_info_widget=None):
         super().__init__(parent)
 
         self.presenter = presenter
@@ -57,7 +58,10 @@ class SliceViewerDataView(QWidget):
         self.colorbar_layout.setContentsMargins(0, 0, 0, 0)
         self.colorbar_layout.setSpacing(0)
 
-        self.image_info_widget = ImageInfoWidget(self)
+        if image_info_widget is None:
+            self.image_info_widget = ImageInfoWidget(self)
+        else:
+            self.image_info_widget = image_info_widget
         self.image_info_widget.setToolTip("Information about the selected pixel")
         self.track_cursor = QCheckBox("Track Cursor", self)
         self.track_cursor.setToolTip(

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/views/dataview.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/views/dataview.py
@@ -155,9 +155,9 @@ class SliceViewerDataView(QWidget):
         self.dimensions = DimensionWidget(dims_info, parent=self)
         self.dimensions.dimensionsChanged.connect(self.presenter.dimensions_changed)
         self.dimensions.valueChanged.connect(self.presenter.slicepoint_changed)
-        self.dimensions_layout.addWidget(self.dimensions, 1, 0, 1, 1)
         self.dimensions_layout.addWidget(self.track_cursor, 0, 1, Qt.AlignRight)
         if not custom_image_info:
+            self.dimensions_layout.addWidget(self.dimensions, 1, 0, 1, 1)
             self.dimensions_layout.addWidget(self.image_info_widget, 1, 1)
 
     @property

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/views/dataview.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/views/dataview.py
@@ -60,8 +60,10 @@ class SliceViewerDataView(QWidget):
 
         if image_info_widget is None:
             self.image_info_widget = ImageInfoWidget(self)
+            custom_widget = False
         else:
             self.image_info_widget = image_info_widget
+            custom_widget = True
         self.image_info_widget.setToolTip("Information about the selected pixel")
         self.track_cursor = QCheckBox("Track Cursor", self)
         self.track_cursor.setToolTip(
@@ -74,7 +76,7 @@ class SliceViewerDataView(QWidget):
         self.dimensions_layout = QGridLayout()
         self.dimensions_layout.setHorizontalSpacing(10)
         if (dims_info):
-            self.create_dimensions(dims_info)
+            self.create_dimensions(dims_info, custom_widget)
         else:
             self.dimensions = None
 
@@ -149,13 +151,14 @@ class SliceViewerDataView(QWidget):
         layout.addWidget(self.status_bar, 3, 0, 1, 1)
         layout.setRowStretch(2, 1)
 
-    def create_dimensions(self, dims_info):
+    def create_dimensions(self, dims_info, custom_image_info=False):
         self.dimensions = DimensionWidget(dims_info, parent=self)
         self.dimensions.dimensionsChanged.connect(self.presenter.dimensions_changed)
         self.dimensions.valueChanged.connect(self.presenter.slicepoint_changed)
         self.dimensions_layout.addWidget(self.dimensions, 1, 0, 1, 1)
         self.dimensions_layout.addWidget(self.track_cursor, 0, 1, Qt.AlignRight)
-        self.dimensions_layout.addWidget(self.image_info_widget, 1, 1)
+        if not custom_image_info:
+            self.dimensions_layout.addWidget(self.image_info_widget, 1, 1)
 
     @property
     def grid_on(self):

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/IPreviewView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/IPreviewView.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include "MantidAPI/MatrixWorkspace_fwd.h"
+#include "MantidQtWidgets/Common/IImageInfoWidget.h"
 #include "MantidQtWidgets/InstrumentView/RotationSurface.h"
 
 #include <QLayout>
@@ -36,6 +37,7 @@ public:
   virtual ~IPreviewView() = default;
   virtual void subscribe(PreviewViewSubscriber *notifyee) noexcept = 0;
   virtual QLayout *getDockedWidgetsLayout() noexcept = 0;
+  virtual MantidWidgets::IImageInfoWidget *getImageInfo() noexcept = 0;
   virtual void enableApplyButton() = 0;
   virtual void disableApplyButton() = 0;
 

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.cpp
@@ -11,6 +11,8 @@
 #include "GUI/Preview/QtPreviewDockedWidgets.h"
 #include "MantidAPI/MatrixWorkspace.h"
 #include "MantidKernel/Strings.h"
+#include "MantidQtWidgets/Common/ImageInfoWidget.h"
+#include "MantidQtWidgets/Common/ImageInfoWidgetMini.h"
 #include "MantidQtWidgets/Plotting/AxisID.h"
 #include "MantidQtWidgets/RegionSelector/IRegionSelector.h"
 #include "MantidQtWidgets/RegionSelector/RegionSelector.h"
@@ -20,6 +22,7 @@
 
 using Mantid::API::MatrixWorkspace_sptr;
 using MantidQt::MantidWidgets::AxisID;
+using MantidQt::MantidWidgets::ImageInfoWidgetMini;
 using MantidQt::MantidWidgets::PlotPresenter;
 using MantidQt::Widgets::IRegionSelector;
 using MantidQt::Widgets::RegionSelector;
@@ -40,7 +43,8 @@ PreviewPresenter::PreviewPresenter(Dependencies dependencies)
     m_dockedWidgets = std::make_unique<QtPreviewDockedWidgets>(nullptr, m_view->getDockedWidgetsLayout());
   }
   if (!m_regionSelector) {
-    m_regionSelector = std::make_unique<RegionSelector>(nullptr, m_dockedWidgets->getRegionSelectorLayout());
+    m_regionSelector =
+        std::make_unique<RegionSelector>(nullptr, m_dockedWidgets->getRegionSelectorLayout(), m_view->getImageInfo());
   }
   if (!m_plotPresenter) {
     m_plotPresenter = std::make_unique<PlotPresenter>(m_dockedWidgets->getLinePlotView());

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.h
@@ -15,6 +15,7 @@
 #include "IPreviewPresenter.h"
 #include "IPreviewView.h"
 #include "MantidAPI/RegionSelectorObserver.h"
+#include "MantidQtWidgets/Common/IImageInfoWidget.h"
 #include "MantidQtWidgets/Plotting/PlotWidget/PlotPresenter.h"
 #include <memory>
 
@@ -101,6 +102,7 @@ private:
   std::unique_ptr<IJobManager> m_jobManager;
   std::unique_ptr<IInstViewModel> m_instViewModel;
   std::unique_ptr<IPreviewDockedWidgets> m_dockedWidgets{nullptr};
+  std::unique_ptr<MantidQt::MantidWidgets::IImageInfoWidget> m_imageInfo;
   std::unique_ptr<MantidQt::Widgets::IRegionSelector> m_regionSelector;
   std::unique_ptr<MantidQt::MantidWidgets::PlotPresenter> m_plotPresenter;
   std::shared_ptr<StubRegionObserver> m_stubRegionObserver;

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewWidget.ui
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewWidget.ui
@@ -127,6 +127,9 @@
       <enum>QLayout::SetMinimumSize</enum>
      </property>
      <item>
+      <layout class="QHBoxLayout" name="statusbar_layout"/>
+     </item>
+     <item>
       <spacer name="output_tool_spacer">
        <property name="orientation">
         <enum>Qt::Horizontal</enum>

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/QtPreviewView.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/QtPreviewView.cpp
@@ -21,15 +21,18 @@
 using namespace Mantid::Kernel;
 
 namespace MantidQt::CustomInterfaces::ISISReflectometry {
-QtPreviewView::QtPreviewView(QWidget *parent) : QWidget(parent) {
+QtPreviewView::QtPreviewView(QWidget *parent)
+    : QWidget(parent), m_imageInfo(new MantidQt::MantidWidgets::ImageInfoWidgetMini(this)) {
   m_ui.setupUi(this);
-
+  m_ui.statusbar_layout->addWidget(m_imageInfo);
   connectSignals();
 }
 
 void QtPreviewView::subscribe(PreviewViewSubscriber *notifyee) noexcept { m_notifyee = notifyee; }
 
 QLayout *QtPreviewView::getDockedWidgetsLayout() noexcept { return m_ui.dockable_widgets_layout; }
+
+MantidWidgets::IImageInfoWidget *QtPreviewView::getImageInfo() noexcept { return m_imageInfo; }
 
 void QtPreviewView::enableApplyButton() { m_ui.apply_button->setEnabled(true); }
 

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/QtPreviewView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/QtPreviewView.h
@@ -9,6 +9,7 @@
 #include "Common/DllConfig.h"
 #include "IPreviewView.h"
 #include "MantidAPI/MatrixWorkspace_fwd.h"
+#include "MantidQtWidgets/Common/ImageInfoWidgetMini.h"
 #include "MantidQtWidgets/InstrumentView/InstrumentDisplay.h"
 #include "MantidQtWidgets/InstrumentView/RotationSurface.h"
 #include "MantidQtWidgets/Plotting/PreviewPlot.h"
@@ -37,6 +38,7 @@ public:
   void subscribe(PreviewViewSubscriber *notifyee) noexcept override;
 
   QLayout *getDockedWidgetsLayout() noexcept override;
+  MantidWidgets::IImageInfoWidget *getImageInfo() noexcept override;
 
   void enableApplyButton() override;
   void disableApplyButton() override;
@@ -50,6 +52,7 @@ private:
   Ui::PreviewWidget m_ui;
   PreviewViewSubscriber *m_notifyee{nullptr};
   std::unique_ptr<MantidQt::MantidWidgets::InstrumentDisplay> m_instDisplay{nullptr};
+  MantidQt::MantidWidgets::ImageInfoWidgetMini *m_imageInfo{nullptr};
 
   void connectSignals() const;
 

--- a/qt/scientific_interfaces/ISISReflectometry/test/Preview/MockPreviewView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Preview/MockPreviewView.h
@@ -20,6 +20,7 @@ class MockPreviewView : public IPreviewView {
 public:
   MOCK_METHOD(void, subscribe, (PreviewViewSubscriber *), (noexcept, override));
   MOCK_METHOD(QLayout *, getDockedWidgetsLayout, (), (noexcept, override));
+  MOCK_METHOD(MantidWidgets::IImageInfoWidget *, getImageInfo, (), (noexcept, override));
   MOCK_METHOD(void, enableApplyButton, (), (override));
   MOCK_METHOD(void, disableApplyButton, (), (override));
   MOCK_METHOD(std::string, getWorkspaceName, (), (const, override));

--- a/qt/widgets/common/CMakeLists.txt
+++ b/qt/widgets/common/CMakeLists.txt
@@ -181,7 +181,6 @@ set(QT5_MOC_FILES
     inc/MantidQtWidgets/Common/HintingLineEdit.h
     inc/MantidQtWidgets/Common/IFitScriptGeneratorView.h
     inc/MantidQtWidgets/Common/IFunctionView.h
-    inc/MantidQtWidgets/Common/IImageInfoWidget.h
     inc/MantidQtWidgets/Common/ImageInfoWidget.h
     inc/MantidQtWidgets/Common/ImageInfoWidgetMini.h
     inc/MantidQtWidgets/Common/InputController.h
@@ -283,6 +282,7 @@ set(QT5_INC_FILES
     inc/MantidQtWidgets/Common/IFunctionBrowser.h
     inc/MantidQtWidgets/Common/IFunctionView.h
     inc/MantidQtWidgets/Common/ImageInfoModel.h
+    inc/MantidQtWidgets/Common/IImageInfoWidget.h
     inc/MantidQtWidgets/Common/ImageInfoModelMatrixWS.h
     inc/MantidQtWidgets/Common/ImageInfoModelMD.h
     inc/MantidQtWidgets/Common/ImageInfoPresenter.h
@@ -405,7 +405,6 @@ set(MOC_FILES
     inc/MantidQtWidgets/Common/CatalogSearch.h
     inc/MantidQtWidgets/Common/CatalogSelector.h
     inc/MantidQtWidgets/Common/IFitScriptGeneratorView.h
-    inc/MantidQtWidgets/Common/IImageInfoWidget.h
     inc/MantidQtWidgets/Common/ImageInfoWidget.h
     inc/MantidQtWidgets/Common/InstrumentSelector.h
     inc/MantidQtWidgets/Common/InputController.h

--- a/qt/widgets/common/CMakeLists.txt
+++ b/qt/widgets/common/CMakeLists.txt
@@ -49,6 +49,7 @@ set(SRC_FILES
     src/ImageInfoModelMD.cpp
     src/ImageInfoPresenter.cpp
     src/ImageInfoWidget.cpp
+    src/ImageInfoWidgetMini.cpp
     src/InputController.cpp
     src/InstrumentSelector.cpp
     src/InterfaceManager.cpp
@@ -182,6 +183,7 @@ set(QT5_MOC_FILES
     inc/MantidQtWidgets/Common/IFunctionView.h
     inc/MantidQtWidgets/Common/IImageInfoWidget.h
     inc/MantidQtWidgets/Common/ImageInfoWidget.h
+    inc/MantidQtWidgets/Common/ImageInfoWidgetMini.h
     inc/MantidQtWidgets/Common/InputController.h
     inc/MantidQtWidgets/Common/InstrumentSelector.h
     inc/MantidQtWidgets/Common/LineEditWithClear.h

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/IImageInfoWidget.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/IImageInfoWidget.h
@@ -15,8 +15,6 @@ namespace MantidWidgets {
 
 class EXPORT_OPT_MANTIDQT_COMMON IImageInfoWidget {
 public:
-  IImageInfoWidget(QWidget *parent = nullptr) {}
-
   virtual void cursorAt(const double x, const double y, const double signal,
                         const QMap<QString, QString> &extraValues) = 0;
   virtual void showInfo(const ImageInfoModel::ImageInfo &info) = 0;

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/IImageInfoWidget.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/IImageInfoWidget.h
@@ -9,20 +9,19 @@
 #include "DllOption.h"
 #include "MantidAPI/Workspace_fwd.h"
 #include "MantidQtWidgets/Common/ImageInfoModel.h"
-#include <QTableWidget>
 
 namespace MantidQt {
 namespace MantidWidgets {
 
-class EXPORT_OPT_MANTIDQT_COMMON IImageInfoWidget : public QTableWidget {
-  Q_OBJECT
+class EXPORT_OPT_MANTIDQT_COMMON IImageInfoWidget {
 public:
-  IImageInfoWidget(QWidget *parent = nullptr) : QTableWidget(0, 0, parent) {}
+  IImageInfoWidget(QWidget *parent = nullptr) {}
 
   virtual void cursorAt(const double x, const double y, const double signal,
                         const QMap<QString, QString> &extraValues) = 0;
   virtual void showInfo(const ImageInfoModel::ImageInfo &info) = 0;
   virtual void setWorkspace(const Mantid::API::Workspace_sptr &ws) = 0;
+  virtual void setRowCount(const int count) = 0;
 };
 
 } // namespace MantidWidgets

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/IImageInfoWidget.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/IImageInfoWidget.h
@@ -15,6 +15,7 @@ namespace MantidWidgets {
 
 class EXPORT_OPT_MANTIDQT_COMMON IImageInfoWidget {
 public:
+  virtual ~IImageInfoWidget() = default;
   virtual void cursorAt(const double x, const double y, const double signal,
                         const QMap<QString, QString> &extraValues) = 0;
   virtual void showInfo(const ImageInfoModel::ImageInfo &info) = 0;

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/ImageInfoWidget.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/ImageInfoWidget.h
@@ -11,15 +11,15 @@
 #include "MantidQtWidgets/Common/IImageInfoWidget.h"
 #include "MantidQtWidgets/Common/ImageInfoPresenter.h"
 #include <QMap>
+#include <QTableWidget>
 
-namespace MantidQt {
-namespace MantidWidgets {
+namespace MantidQt::MantidWidgets {
 
 /**
  * A table widget containing information about the pixel the mouse is over in
  * an image
  */
-class EXPORT_OPT_MANTIDQT_COMMON ImageInfoWidget : public IImageInfoWidget {
+class EXPORT_OPT_MANTIDQT_COMMON ImageInfoWidget : public QTableWidget, public IImageInfoWidget {
   Q_OBJECT
 
 public:
@@ -31,10 +31,10 @@ public:
                 const QMap<QString, QString> &extraValues) override;
   void setWorkspace(const Mantid::API::Workspace_sptr &ws) override;
   void showInfo(const ImageInfoModel::ImageInfo &info) override;
+  void setRowCount(const int count) override;
 
 private:
   std::unique_ptr<ImageInfoPresenter> m_presenter;
 };
 
-} // namespace MantidWidgets
-} // namespace MantidQt
+} // namespace MantidQt::MantidWidgets

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/ImageInfoWidgetMini.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/ImageInfoWidgetMini.h
@@ -1,0 +1,40 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2022 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+
+#pragma once
+
+#include "DllOption.h"
+#include "MantidQtWidgets/Common/IImageInfoWidget.h"
+#include "MantidQtWidgets/Common/ImageInfoPresenter.h"
+#include <QLabel>
+#include <QMap>
+
+namespace MantidQt::MantidWidgets {
+
+/**
+ * A table widget containing information about the pixel the mouse is over in
+ * an image
+ */
+class EXPORT_OPT_MANTIDQT_COMMON ImageInfoWidgetMini : public QLabel, public IImageInfoWidget {
+  Q_OBJECT
+
+public:
+  ImageInfoWidgetMini(QWidget *parent = nullptr);
+
+  // Note: QMap has sip binding via PyQt but only for specific types (both types have to be classes or the first type
+  // has to be int)
+  void cursorAt(const double x, const double y, const double signal,
+                const QMap<QString, QString> &extraValues) override;
+  void setWorkspace(const Mantid::API::Workspace_sptr &ws) override;
+  void showInfo(const ImageInfoModel::ImageInfo &info) override;
+  void setRowCount(const int count) override;
+
+private:
+  std::unique_ptr<ImageInfoPresenter> m_presenter;
+};
+
+} // namespace MantidQt::MantidWidgets

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/Python/Sip.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/Python/Sip.h
@@ -45,6 +45,7 @@ template <typename T> T *extract(const Object &obj) {
 /**
  * Convert a C++ object of type T to a Python object
  * @param obj A C++ object
+ * @param nameOfType The type of the C++ object as a string. Allows SIP to find the right export.
  */
 template <typename T> Object wrap(const T &obj, char const *nameOfType) {
   const auto sipapi = Detail::sipAPI();

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/Python/Sip.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/Python/Sip.h
@@ -42,6 +42,16 @@ template <typename T> T *extract(const Object &obj) {
 #endif
 }
 
+/**
+ * Convert a C++ object of type T to a Python object
+ * @param obj A C++ object
+ */
+template <typename T> Object wrap(const T &obj, char const *nameOfType) {
+  const auto sipapi = Detail::sipAPI();
+  auto pyObj = sipapi->api_convert_from_type(obj, sipapi->api_find_type(nameOfType), nullptr);
+  return NewRef(pyObj);
+}
+
 } // namespace Python
 } // namespace Common
 } // namespace Widgets

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/Python/Sip.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/Python/Sip.h
@@ -49,7 +49,11 @@ template <typename T> T *extract(const Object &obj) {
  */
 template <typename T> Object wrap(const T &obj, char const *nameOfType) {
   const auto sipapi = Detail::sipAPI();
-  auto pyObj = sipapi->api_convert_from_type(obj, sipapi->api_find_type(nameOfType), nullptr);
+  const auto type = sipapi->api_find_type(nameOfType);
+  if (!type) {
+    return Python::Object();
+  }
+  auto pyObj = sipapi->api_convert_from_type(obj, type, nullptr);
   return NewRef(pyObj);
 }
 

--- a/qt/widgets/common/src/ImageInfoWidget.cpp
+++ b/qt/widgets/common/src/ImageInfoWidget.cpp
@@ -64,4 +64,7 @@ void ImageInfoWidget::showInfo(const ImageInfoModel::ImageInfo &info) {
  * @param ws A pointer to a Workspace object
  */
 void ImageInfoWidget::setWorkspace(const Mantid::API::Workspace_sptr &ws) { m_presenter->setWorkspace(ws); }
+
+void ImageInfoWidget::setRowCount(const int count) { QTableWidget::setRowCount(count); }
+
 } // namespace MantidQt::MantidWidgets

--- a/qt/widgets/common/src/ImageInfoWidget.cpp
+++ b/qt/widgets/common/src/ImageInfoWidget.cpp
@@ -19,7 +19,7 @@ namespace MantidQt::MantidWidgets {
  * @param parent A QWidget to act as the parent widget
  */
 ImageInfoWidget::ImageInfoWidget(QWidget *parent)
-    : IImageInfoWidget(parent), m_presenter(std::make_unique<ImageInfoPresenter>(this)) {
+    : QTableWidget(0, 0, parent), m_presenter(std::make_unique<ImageInfoPresenter>(this)) {
   setSizeAdjustPolicy(QAbstractScrollArea::AdjustToContents);
   setSizePolicy(QSizePolicy::Maximum, QSizePolicy::Maximum);
   horizontalHeader()->hide();

--- a/qt/widgets/common/src/ImageInfoWidgetMini.cpp
+++ b/qt/widgets/common/src/ImageInfoWidgetMini.cpp
@@ -39,10 +39,12 @@ void ImageInfoWidgetMini::showInfo(const ImageInfoModel::ImageInfo &info) {
   if (info.empty())
     return;
   auto text = QString{};
-  // TOF
-  text += info.name(0) + "=" + info.value(0) + ", ";
-  // Spectrum
-  text += info.name(1) + "=" + info.value(1);
+
+  if (!info.value(0).isEmpty() && info.value(0) != "-") {
+    text += info.name(0) + "=" + info.value(0) + ", "; // TOF
+    text += info.name(1) + "=" + info.value(1) + ", "; // Spectrum
+    text += info.name(2) + "=" + info.value(2);        // Signal
+  }
 
   setText(text);
 }

--- a/qt/widgets/common/src/ImageInfoWidgetMini.cpp
+++ b/qt/widgets/common/src/ImageInfoWidgetMini.cpp
@@ -1,0 +1,59 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2022 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+
+#include "MantidQtWidgets/Common/ImageInfoWidgetMini.h"
+#include "MantidAPI/Workspace_fwd.h"
+
+#include <QAbstractScrollArea>
+#include <QHeaderView>
+#include <QTableWidget>
+
+namespace MantidQt::MantidWidgets {
+
+/**
+ * Constructor
+ * @param parent A QWidget to act as the parent widget
+ */
+ImageInfoWidgetMini::ImageInfoWidgetMini(QWidget *parent)
+    : QLabel(parent), m_presenter(std::make_unique<ImageInfoPresenter>(this)) {}
+
+/**
+ * @param x X position if the cursor
+ * @param y Y position if the cursor
+ * @param signal Signal value at cursor position
+ * @param extraValues A map of extra column names and values to display
+ */
+void ImageInfoWidgetMini::cursorAt(const double x, const double y, const double signal,
+                                   const QMap<QString, QString> &extraValues) {
+  m_presenter->cursorAt(x, y, signal, extraValues);
+}
+
+/**
+ * Display the information provided within the table cells
+ * @param info A reference to a collection of header/value pairs
+ */
+void ImageInfoWidgetMini::showInfo(const ImageInfoModel::ImageInfo &info) {
+  if (info.empty())
+    return;
+  auto text = QString{};
+  const auto itemCount(info.size());
+  for (int i = 0; i < itemCount; ++i) {
+    text += info.name(i) + "=";
+    text += info.value(i) + ", ";
+  }
+  setText(text);
+}
+
+/**
+ * Set the workspace to probe for information
+ * @param ws A pointer to a Workspace object
+ */
+void ImageInfoWidgetMini::setWorkspace(const Mantid::API::Workspace_sptr &ws) { m_presenter->setWorkspace(ws); }
+
+void ImageInfoWidgetMini::setRowCount(const int count) {}
+
+} // namespace MantidQt::MantidWidgets

--- a/qt/widgets/common/src/ImageInfoWidgetMini.cpp
+++ b/qt/widgets/common/src/ImageInfoWidgetMini.cpp
@@ -53,6 +53,6 @@ void ImageInfoWidgetMini::showInfo(const ImageInfoModel::ImageInfo &info) {
  */
 void ImageInfoWidgetMini::setWorkspace(const Mantid::API::Workspace_sptr &ws) { m_presenter->setWorkspace(ws); }
 
-void ImageInfoWidgetMini::setRowCount(const int count) {}
+void ImageInfoWidgetMini::setRowCount(const int /*count*/) {}
 
 } // namespace MantidQt::MantidWidgets

--- a/qt/widgets/common/src/ImageInfoWidgetMini.cpp
+++ b/qt/widgets/common/src/ImageInfoWidgetMini.cpp
@@ -10,7 +10,6 @@
 
 #include <QAbstractScrollArea>
 #include <QHeaderView>
-#include <QTableWidget>
 
 namespace MantidQt::MantidWidgets {
 
@@ -40,11 +39,11 @@ void ImageInfoWidgetMini::showInfo(const ImageInfoModel::ImageInfo &info) {
   if (info.empty())
     return;
   auto text = QString{};
-  const auto itemCount(info.size());
-  for (int i = 0; i < itemCount; ++i) {
-    text += info.name(i) + "=";
-    text += info.value(i) + ", ";
-  }
+  // TOF
+  text += info.name(0) + "=" + info.value(0) + ", ";
+  // Spectrum
+  text += info.name(1) + "=" + info.value(1);
+
   setText(text);
 }
 

--- a/qt/widgets/common/test/ImageInfoPresenterTest.h
+++ b/qt/widgets/common/test/ImageInfoPresenterTest.h
@@ -32,6 +32,7 @@ public:
                void(const double x, const double y, const double signal, const QMap<QString, QString> &extraValues));
   MOCK_METHOD1(showInfo, void(const ImageInfoModel::ImageInfo &info));
   MOCK_METHOD1(setWorkspace, void(const Mantid::API::Workspace_sptr &ws));
+  MOCK_METHOD1(setRowCount, void(const int count));
 };
 
 GNU_DIAG_ON_SUGGEST_OVERRIDE
@@ -46,13 +47,15 @@ public:
   void test_constructor_calls_view_set_row_count() {
     auto mockView = std::make_unique<StrictMock<MockImageInfoView>>();
 
+    EXPECT_CALL(*mockView, setRowCount(2)).Times(1);
+
     ImageInfoPresenter presenter(mockView.get());
-    TS_ASSERT_EQUALS(mockView->rowCount(), 2);
   }
 
   void test_cursorAt_calls_view_showInfo() {
     auto mockView = std::make_unique<StrictMock<MockImageInfoView>>();
 
+    EXPECT_CALL(*mockView, setRowCount(2)).Times(1);
     EXPECT_CALL(*mockView, showInfo(_)).Times(1);
 
     ImageInfoPresenter presenter(mockView.get());

--- a/qt/widgets/regionselector/inc/MantidQtWidgets/RegionSelector/RegionSelector.h
+++ b/qt/widgets/regionselector/inc/MantidQtWidgets/RegionSelector/RegionSelector.h
@@ -8,6 +8,7 @@
 
 #include "MantidAPI/RegionSelectorObserver.h"
 #include "MantidAPI/Workspace_fwd.h"
+#include "MantidQtWidgets/Common/IImageInfoWidget.h"
 #include "MantidQtWidgets/Common/Python/Object.h"
 #include "MantidQtWidgets/RegionSelector/DllConfig.h"
 #include "MantidQtWidgets/RegionSelector/IRegionSelector.h"
@@ -17,7 +18,8 @@ class QLayout;
 namespace MantidQt::Widgets {
 class MANTID_REGIONSELECTOR_DLL RegionSelector : public Common::Python::InstanceHolder, public IRegionSelector {
 public:
-  RegionSelector(Mantid::API::Workspace_sptr const &workspace, QLayout *layout);
+  RegionSelector(Mantid::API::Workspace_sptr const &workspace, QLayout *layout,
+                 MantidWidgets::IImageInfoWidget *imageInfoWidget = nullptr);
   RegionSelector(RegionSelector const &) = delete;
   RegionSelector(RegionSelector &&);
   RegionSelector &operator=(RegionSelector const &) = delete;

--- a/qt/widgets/regionselector/src/RegionSelector.cpp
+++ b/qt/widgets/regionselector/src/RegionSelector.cpp
@@ -8,14 +8,17 @@
 #include "MantidQtWidgets/RegionSelector/RegionSelector.h"
 #include "MantidAPI/RegionSelectorObserver.h"
 #include "MantidAPI/Workspace.h"
+#include "MantidPythonInterface/core/ErrorHandling.h"
 #include "MantidPythonInterface/core/GlobalInterpreterLock.h"
 #include "MantidQtWidgets/Common/IImageInfoWidget.h"
+#include "MantidQtWidgets/Common/ImageInfoWidgetMini.h"
 #include "MantidQtWidgets/Common/Python/Object.h"
 #include "MantidQtWidgets/Common/Python/Sip.h"
 
 #include <QLayout>
 #include <QWidget>
 #include <boost/python/extract.hpp>
+#include <iostream>
 #include <vector>
 
 using Mantid::API::Workspace_sptr;
@@ -37,7 +40,8 @@ Python::Object newPresenter(Workspace_sptr workspace, MantidQt::MantidWidgets::I
     options["ws"] = workspace;
   }
   if (imageInfoWidget) {
-    options["image_info_widget"] = imageInfoWidget;
+    options["image_info_widget"] = Python::wrap(
+        static_cast<MantidQt::MantidWidgets::ImageInfoWidgetMini *>(imageInfoWidget), "ImageInfoWidgetMini");
   }
   auto constructor = presenterModule().attr("RegionSelector");
   return constructor(*boost::python::tuple(), **options);

--- a/qt/widgets/regionselector/src/RegionSelector.cpp
+++ b/qt/widgets/regionselector/src/RegionSelector.cpp
@@ -9,6 +9,7 @@
 #include "MantidAPI/RegionSelectorObserver.h"
 #include "MantidAPI/Workspace.h"
 #include "MantidPythonInterface/core/GlobalInterpreterLock.h"
+#include "MantidQtWidgets/Common/IImageInfoWidget.h"
 #include "MantidQtWidgets/Common/Python/Object.h"
 #include "MantidQtWidgets/Common/Python/Sip.h"
 
@@ -28,12 +29,15 @@ Python::Object presenterModule() {
   return module;
 }
 
-Python::Object newPresenter(Workspace_sptr workspace) {
+Python::Object newPresenter(Workspace_sptr workspace, MantidQt::MantidWidgets::IImageInfoWidget *imageInfoWidget) {
   GlobalInterpreterLock lock;
 
   boost::python::dict options;
   if (workspace) {
     options["ws"] = workspace;
+  }
+  if (imageInfoWidget) {
+    options["image_info_widget"] = imageInfoWidget;
   }
   auto constructor = presenterModule().attr("RegionSelector");
   return constructor(*boost::python::tuple(), **options);
@@ -42,8 +46,9 @@ Python::Object newPresenter(Workspace_sptr workspace) {
 
 namespace MantidQt::Widgets {
 
-RegionSelector::RegionSelector(Workspace_sptr const &workspace, QLayout *layout)
-    : Python::InstanceHolder(newPresenter(workspace)), m_layout(layout) {
+RegionSelector::RegionSelector(Workspace_sptr const &workspace, QLayout *layout,
+                               MantidWidgets::IImageInfoWidget *imageInfoWidget)
+    : Python::InstanceHolder(newPresenter(workspace, imageInfoWidget)), m_layout(layout) {
   GlobalInterpreterLock lock;
   auto view = Python::extract<QWidget>(getView());
   constexpr auto MIN_SLICEVIEWER_HEIGHT = 250;


### PR DESCRIPTION
**Description of work.**
Removed the ImageInfoWidget from the regionselector and allowed it to be passed in instead. This means that we can pass in a much more minimal version that sits at the bottom of the tab. Future work will hopefully allow this to be used for all three of the widgets on the Preview Tab. 

**To test:**

1. Open the ISIS Reflectometry interface
2. Go to the Preview tab
3. Enter run `INTER45455_inst` and click Load (This data is available on this Epic and must be in your user search path: #31069)
4. Check that the region selector doesn't have the table or dimension selector on it any more (open the sliceviewer for reference)
5. Check that the statusbar at the bottom of the tab is being updated with the X and Y values from the regionselector. 

Fixes #34671 


<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
