### PR TITLE
Added cursor feedback for Shape2DResizing

### DIFF
--- a/docs/source/release/v6.6.0/Workbench/InstrumentViewer/New_features/30891.rst
+++ b/docs/source/release/v6.6.0/Workbench/InstrumentViewer/New_features/30891.rst
@@ -1,0 +1,1 @@
+- Control points on the shapes drawn using the Pick or Draw tab now give cursor feedback.

--- a/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/Shape2DCollection.h
+++ b/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/Shape2DCollection.h
@@ -160,6 +160,8 @@ protected:
   QList<Shape2D *> m_selectedShapes; ///< A list of selected shapes (can be moved or deleted)
   QList<Shape2D *> m_copiedShapes;   ///< A list of shapes to be pasted if requiered
   bool m_overridingCursor;
+  bool m_cursorOverShape;
+  bool m_cursorOverControlPoint;
   friend class InstrumentWidgetEncoder;
   friend class InstrumentWidgetDecoder;
 };

--- a/qt/widgets/instrumentview/src/Shape2DCollection.cpp
+++ b/qt/widgets/instrumentview/src/Shape2DCollection.cpp
@@ -301,13 +301,19 @@ void Shape2DCollection::touchShapeOrControlPointAt(int x, int y) {
       if (difference.x() > 0) {
         if (difference.y() > 0)
           QApplication::setOverrideCursor(Qt::SizeBDiagCursor);
-        else
+        else if (difference.y() < 0)
           QApplication::setOverrideCursor(Qt::SizeFDiagCursor);
-      } else {
+        else
+          QApplication::setOverrideCursor(Qt::SizeHorCursor);
+      } else if (difference.x() < 0) {
         if (difference.y() > 0)
           QApplication::setOverrideCursor(Qt::SizeFDiagCursor);
-        else
+        else if (difference.y() < 0)
           QApplication::setOverrideCursor(Qt::SizeBDiagCursor);
+        else
+          QApplication::setOverrideCursor(Qt::SizeHorCursor);
+      } else {
+        QApplication::setOverrideCursor(Qt::SizeVerCursor);
       }
     }
   } else if (isOverSelectionAt(x, y)) {

--- a/qt/widgets/instrumentview/src/Shape2DCollection.cpp
+++ b/qt/widgets/instrumentview/src/Shape2DCollection.cpp
@@ -291,8 +291,24 @@ void Shape2DCollection::touchShapeOrControlPointAt(int x, int y) {
       m_cursorOverControlPoint = true;
       m_cursorOverShape = false;
       QApplication::restoreOverrideCursor();
-      (m_currentCP % 2 == 0) ? QApplication::setOverrideCursor(Qt::SizeBDiagCursor)
-                             : QApplication::setOverrideCursor(Qt::SizeFDiagCursor);
+
+      // Since shapes can be flipped by, for example, dragging the bottom left point past the bottom right,
+      // m_currentCP can't be relyed upon to set the correct diagonal cursor
+      QPointF centre = m_currentShape->origin();
+      QPointF cp = m_currentShape->getControlPoint(m_currentCP);
+      QPointF difference = centre - cp;
+
+      if (difference.x() > 0) {
+        if (difference.y() > 0)
+          QApplication::setOverrideCursor(Qt::SizeBDiagCursor);
+        else
+          QApplication::setOverrideCursor(Qt::SizeFDiagCursor);
+      } else {
+        if (difference.y() > 0)
+          QApplication::setOverrideCursor(Qt::SizeFDiagCursor);
+        else
+          QApplication::setOverrideCursor(Qt::SizeBDiagCursor);
+      }
     }
   } else if (isOverSelectionAt(x, y)) {
     if (!m_overridingCursor || m_cursorOverControlPoint) {

--- a/qt/widgets/instrumentview/src/Shape2DCollection.cpp
+++ b/qt/widgets/instrumentview/src/Shape2DCollection.cpp
@@ -293,7 +293,7 @@ void Shape2DCollection::touchShapeOrControlPointAt(int x, int y) {
       QApplication::restoreOverrideCursor();
 
       // Since shapes can be flipped by, for example, dragging the bottom left point past the bottom right,
-      // m_currentCP can't be relyed upon to set the correct diagonal cursor
+      // m_currentCP can't be relyed upon to describe a point's relative position (e.g top left)
       QPointF centre = m_currentShape->origin();
       QPointF cp = m_currentShape->getControlPoint(m_currentCP);
       QPointF difference = centre - cp;

--- a/qt/widgets/instrumentview/src/Shape2DCollection.cpp
+++ b/qt/widgets/instrumentview/src/Shape2DCollection.cpp
@@ -285,7 +285,13 @@ void Shape2DCollection::moveShapeOrControlPointBy(int dx, int dy) {
  * override the cursor image.
  */
 void Shape2DCollection::touchShapeOrControlPointAt(int x, int y) {
-  if (selectControlPointAt(x, y) || isOverSelectionAt(x, y)) {
+  if (selectControlPointAt(x, y)) {
+    if (!m_overridingCursor) {
+      m_overridingCursor = true;
+      (m_currentCP % 2 == 0) ? QApplication::setOverrideCursor(Qt::SizeBDiagCursor)
+                             : QApplication::setOverrideCursor(Qt::SizeFDiagCursor);
+    }
+  } else if (isOverSelectionAt(x, y)) {
     if (!m_overridingCursor) {
       m_overridingCursor = true;
       QApplication::setOverrideCursor(Qt::SizeAllCursor);

--- a/qt/widgets/instrumentview/src/Shape2DCollection.cpp
+++ b/qt/widgets/instrumentview/src/Shape2DCollection.cpp
@@ -286,19 +286,27 @@ void Shape2DCollection::moveShapeOrControlPointBy(int dx, int dy) {
  */
 void Shape2DCollection::touchShapeOrControlPointAt(int x, int y) {
   if (selectControlPointAt(x, y)) {
-    if (!m_overridingCursor) {
+    if (!m_overridingCursor || m_cursorOverShape) {
       m_overridingCursor = true;
+      m_cursorOverControlPoint = true;
+      m_cursorOverShape = false;
+      QApplication::restoreOverrideCursor();
       (m_currentCP % 2 == 0) ? QApplication::setOverrideCursor(Qt::SizeBDiagCursor)
                              : QApplication::setOverrideCursor(Qt::SizeFDiagCursor);
     }
   } else if (isOverSelectionAt(x, y)) {
-    if (!m_overridingCursor) {
+    if (!m_overridingCursor || m_cursorOverControlPoint) {
       m_overridingCursor = true;
+      m_cursorOverShape = true;
+      m_cursorOverControlPoint = false;
+      QApplication::restoreOverrideCursor();
       QApplication::setOverrideCursor(Qt::SizeAllCursor);
     }
   } else if (m_overridingCursor) {
     deselectControlPoint();
     m_overridingCursor = false;
+    m_cursorOverShape = false;
+    m_cursorOverControlPoint = false;
     QApplication::restoreOverrideCursor();
   }
 }


### PR DESCRIPTION
**Description of work.**

When a shape is drawn onto the Instrument Viewer, using the Pick or Draw tab, there is now cursor feedback when interacting with the shape's control points.

**To test:**

 - Load some data
 - Right click and open the Instrument Viewer
 - Go to the pick tab
   - Draw a **Rectangle** - Hover over each of the control points (corners) and check that the cursor changes to something sensible (the correct diagonal arrow head in this case)
   - Repeat this for the **Ellipse**, **Rectangular Ring**, and **Circular Sector** shapes

Fixes #30891

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
