### PR TITLE
Catch exception when workspace was deleted

### DIFF
--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/DGSPlanner/DGSPlannerGUI.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/DGSPlanner/DGSPlannerGUI.py
@@ -235,8 +235,10 @@ class DGSPlannerGUI(QtWidgets.QWidget):
                 if reply == QtWidgets.QMessageBox.No:
                     return
 
-            if self.wg is not None:
+            try:
                 mantid.simpleapi.DeleteWorkspace(self.wg)
+            except:
+                pass
 
             instrumentName = self.masterDict['instrument']
             if instrumentName == 'WAND\u00B2':


### PR DESCRIPTION
**Description of work.**

Noticed in the error-reports on slack

```
Name: Not provided  Email: Not provided
        Additional text:
        Not provided
        Stack Trace:
        Traceback (most recent call last):
  File "/opt/anaconda/envs/mantid/lib/python3.8/site-packages/mantid/simpleapi.py", line 920, in do_set_property
    if isinstance(new_value, _kernel.DataItem) and new_value.name():
RuntimeError: Variable invalidated, data has been deleted.
The above exception was the direct cause of the following exception:
Traceback (most recent call last):
  File "/opt/anaconda/envs/mantid/lib/python3.8/site-packages/mantidqtinterfaces/DGSPlanner/DGSPlannerGUI.py", line 239, in updateFigure
    mantid.simpleapi.DeleteWorkspace(self.wg)
  File "/opt/anaconda/envs/mantid/lib/python3.8/site-packages/mantid/simpleapi.py", line 1056, in __call__
    set_properties(algm, *args, **final_keywords)
  File "/opt/anaconda/envs/mantid/lib/python3.8/site-packages/mantid/simpleapi.py", line 950, in set_properties
    do_set_property(key, value)
  File "/opt/anaconda/envs/mantid/lib/python3.8/site-packages/mantid/simpleapi.py", line 927, in do_set_property
    raise e.__class__(msg) from e
RuntimeError: Problem setting "Workspace" in DeleteWorkspace-v1: Variable invalidated, data has been deleted.
        Using: workbench 6.5.0 on Red Hat Enterprise Linux
```

When the workspace is deleted is not `None` any more

**To test:**

<!-- Instructions for testing. -->
I don't know how to reproduce the issue.

*There is no associated issue.*

*This does not require release notes* because **minor bug fix**
---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
