### PR TITLE
Add instructions for installing Java 11 on macOS

### DIFF
--- a/buildconfig/Jenkins/jenkins-slave.sh
+++ b/buildconfig/Jenkins/jenkins-slave.sh
@@ -4,12 +4,29 @@
 # It also downloads the slave.jar to /tmp if it does not already
 # exist.
 #
-# The settings at the top must be filled in for each slave.
+# The variables in the User configuration section below
+# must be updated for each agent.
 #####################################################################
-# Crontab setting should be something like
-# 0,30 * * * * /home/builder/jenkins-linode/jenkins-slave.sh nodename secret
-# or (on mac)
-# 0,30 * * * * /Users/builder/jenkins-linode/jenkins-slave.sh nodename secret
+# Setting up a scheduled task using crontab to ensure agent stays
+# connected
+#####################################################################
+# Download this script to a path under the account that will run the agent
+# Run "crontab -e" under the user that will connect to jenkins and add
+# a line such as
+#
+# 0,5 * * * * <downloaded path>/jenkins-slave.sh nodename secret
+#
+# If you have installed a newer version of Java then this can be used
+# by specifying the JAVA environment variable on the line above, e.g.
+#
+# 0,5 * * * * env JAVA=<full-path-to-java-executable> <downloaded path>/jenkins-slave.sh nodename secret
+#
+# Note that for the Adoptium Java releases the java path is usually something
+# like /Library/Java/JavaVirtualMachines/temurin-11.jre/Contents/Home/bin/java
+# It may also be necessary to customize the PATH for the crontab entry if
+# other software has been installed in /usr/local for example,
+#
+# 0,5 * * * * env PATH=<path1>:<path2>:$PATH JAVA=<full-path-to-java-executable> <downloaded path>/jenkins-slave.sh nodename secret
 #####################################################################
 # User configuration
 #####################################################################

--- a/dev-docs/source/JenkinsConfiguration.rst
+++ b/dev-docs/source/JenkinsConfiguration.rst
@@ -101,11 +101,14 @@ The agent will connect automatically when the Docker container starts running.
 Mac OS
 ------
 
-Enable `SSH ("Remote Login") and VNC ("Remote Management") <https://apple.stackexchange.com/a/73919>`__.
-If you have connection issues from a non-OS X client then try adjusting your color depth settings (True Color 32bpp works on Remmina).
+Enable `SSH ("Remote Login") and VNC ("Remote Management")
+<https://apple.stackexchange.com/a/73919>`__.
+If you have connection issues from a non-OS X client then try adjusting your color
+depth settings (True Color 32bpp works on Remmina).
 
 In order to run the Qt tests, which require a connection to the windowing system,
-the user that is running the Jenkins agent must have logged in.
+the user that is running the Jenkins agent must be left logged in and the
+automatic screen lock must be disabled.
 This is most easily done by VNC - connect, log in, then disconnect.
 If you see errors such as::
 
@@ -114,21 +117,25 @@ If you see errors such as::
 
 then no one is logged in to the system.
 
-Finally, disable saved application states that cause a dialog to be raised after a program crash resulting in a test hanging waiting for a user to click ok on a dialog::
+Disable saved application states that cause a dialog to be raised after a
+program crash resulting in a test hanging waiting for a user to click ok on a dialog::
 
     defaults write org.python.python NSQuitAlwaysKeepsWindows -bool false
     defaults write org.mantidproject.MantidPlot NSQuitAlwaysKeepsWindows -bool false
+
+Finally, install Java 11 JRE from https://adoptium.net/temurin/releases/ by selecting
+``macOS``, ``x64``, ``JRE`` and ``11`` for the respective options.
+Download the ``.pkg`` and install following the instructions.
+
+Restart the machine and ensure you leave the jenkins-agent user logged in as
+per the instructions above.
 
 Agent Connection
 ^^^^^^^^^^^^^^^^
 
 The Jenkins JNLP connections are maintained by a crontab entry.
 The script is in the `mantid repository <https://github.com/mantidproject/mantid/blob/main/buildconfig/Jenkins/jenkins-slave.sh>`__.
-
-The comments at the top describe a typical crontab entry for the script.
-This needs to be manually set for each agent. Ensure the script is marked executable after downloading it.
-Also ensure the entry in the crontab has the correct ``PATH`` setting (by default cron uses a reduced ``PATH`` entry).
-On macOS ``latex`` and ``sysctl`` should be available.
+The comments at the top describe a how to customize the script for a new agent.
 
 Misc Groovy Scripts
 ###################


### PR DESCRIPTION
**Description of work.**

Jenkins now requires Java 11 and this must be installed manually on macOS nodes. This improves the instructions
for setting up a macOS agent with this information.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**

Please review the wording to make sure it makes sense.

Refs #34683 
*This does not require release notes* because **it is an internal tooling change.**

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
