### PR TITLE
Fix for LoadNXSPE warning

### DIFF
--- a/Framework/DataHandling/src/LoadNXSPE.cpp
+++ b/Framework/DataHandling/src/LoadNXSPE.cpp
@@ -139,8 +139,10 @@ void LoadNXSPE::exec() {
     file.openData("psi");
     file.getData(temporary);
     psi = temporary.at(0);
-    if (std::isnan(psi))
+    if (std::isnan(psi)) {
       psi = 0.;
+      g_log.warning("Entry for PSI is empty, will use default of 0.0 instead.");
+    }
     file.closeData();
   }
 

--- a/Framework/DataHandling/src/LoadNXSPE.cpp
+++ b/Framework/DataHandling/src/LoadNXSPE.cpp
@@ -139,6 +139,8 @@ void LoadNXSPE::exec() {
     file.openData("psi");
     file.getData(temporary);
     psi = temporary.at(0);
+    if (std::isnan(psi))
+      psi = 0.;
     file.closeData();
   }
 

--- a/docs/source/algorithms/LoadNexusProcessed-v2.rst
+++ b/docs/source/algorithms/LoadNexusProcessed-v2.rst
@@ -11,7 +11,7 @@ Description
 -----------
 
 The algorithm LoadNexusProcessed will read a Nexus data file created
-by :ref:`algm-SaveNexusProcessed` or `algm-SaveNexusESS` and place the data into the named workspace. The file name can be an absolute or relative path and
+by :ref:`algm-SaveNexusProcessed` or :ref:`algm-SaveNexusESS` and place the data into the named workspace. The file name can be an absolute or relative path and
 should have the extension .nxs, .nx5 or .xml.
 
 .. warning::
@@ -33,7 +33,7 @@ is read, earlier ones can be accessed by setting the EntryNumber.
 If the saved data has a reference to an XML file defining instrument
 geometry this will be read.
 
-This is version 2 of the algorithm. For old behaviour :ref:`algm-SaveNexusProcessed-v1`, which does not handle :ref:`algm-SaveNexusESS` outputs. This is the only difference between the two versions.
+This is version 2 of the algorithm. Information about the previous behaviour can be found in :ref:`algm-SaveNexusProcessed-v1`, which does not handle :ref:`algm-SaveNexusESS` outputs. This is the only difference between the two versions.
 
 Time series data
 ################

--- a/docs/source/algorithms/SaveNXSPE-v1.rst
+++ b/docs/source/algorithms/SaveNXSPE-v1.rst
@@ -44,7 +44,7 @@ Usage
    # Do a "roundtrip" of the data.
    SaveNXSPE(out_ws, file_path,Psi=32)
 
-   # By desigghn, SaveMXSPE does not store detector's ID-s. LoadNXSPE sets detector's ID-s to defaults.
+   # By design, SaveMXSPE does not store detector's ID-s. LoadNXSPE sets detector's ID-s to defaults.
    # To compare loaded and saved workspaces here, one needs to set-up default detector's ID-s to the source workspace.
    nSpec = out_ws.getNumberHistograms()
    for i in range(0,nSpec):

--- a/docs/source/algorithms/SaveNXSPE-v1.rst
+++ b/docs/source/algorithms/SaveNXSPE-v1.rst
@@ -44,7 +44,7 @@ Usage
    # Do a "roundtrip" of the data.
    SaveNXSPE(out_ws, file_path,Psi=32)
 
-   # By design, SaveMXSPE does not store detector's ID-s. LoadNXSPE sets detector's ID-s to defaults.
+   # By design, SaveNXSPE does not store detector's ID-s. LoadNXSPE sets detector's ID-s to defaults.
    # To compare loaded and saved workspaces here, one needs to set-up default detector's ID-s to the source workspace.
    nSpec = out_ws.getNumberHistograms()
    for i in range(0,nSpec):

--- a/docs/source/release/v6.6.0/Framework/Data_Objects/Bugfixes/34864.rst
+++ b/docs/source/release/v6.6.0/Framework/Data_Objects/Bugfixes/34864.rst
@@ -1,1 +1,1 @@
-- Fixed a minor bug in LoadNXSPE
+- Fixed a minor bug in LoadNXSPE that caused an invalid value for PSI when the corresponding entry in the NXSPE file is empty

--- a/docs/source/release/v6.6.0/Framework/Data_Objects/Bugfixes/34864.rst
+++ b/docs/source/release/v6.6.0/Framework/Data_Objects/Bugfixes/34864.rst
@@ -1,0 +1,1 @@
+- Fixed a minor bug in LoadNXSPE


### PR DESCRIPTION
When there is an entry for psi in a NXSPE file it is read as NaN and subsequently causes an error when configuring the Goniometer. This has been changed so psi remains 0.0 (the default) if NaN is read.

In addition, a few typos and incomplete sentences were corrected in the corresponding documentation.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**

Run script from https://github.com/mantidproject/mantid/issues/30296 with one minor modification: use `InstrumentName=''` instead of `InstrumentName='Bizarrio'`.

Fixes #[30296](https://github.com/mantidproject/mantid/issues/30296) 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
