### PR TITLE
Disable SNSPowderRedux tests due to failures

### DIFF
--- a/Testing/SystemTests/tests/framework/SNSPowderRedux.py
+++ b/Testing/SystemTests/tests/framework/SNSPowderRedux.py
@@ -61,7 +61,8 @@ class PG3Analysis(systemtesting.MantidSystemTest):
     char_file = "PG3_characterization_2011_08_31-HR.txt"
 
     def skipTests(self):
-        return _skip_test()
+        # disabled
+        return True
 
     def cleanup(self):
         return do_cleanup()


### PR DESCRIPTION
**Description of work.**
PG3Analysis test continues to fail so temporarily disabling it until it can be fixed. Issue for fixing already raised (#34867 )

**To test:**
1. Tests should pass
2. Code review


*There is no associated issue.*


*This does not require release notes* because **it is a change to System Tests**




---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
