### PR TITLE
Better formatting for arrays of values in the sample logs

### DIFF
--- a/docs/source/release/v6.6.0/Workbench/Bugfixes/34870.rst
+++ b/docs/source/release/v6.6.0/Workbench/Bugfixes/34870.rst
@@ -1,0 +1,1 @@
+- Fixed a bug that prevented arrays from displaying properly in sample logs

--- a/qt/python/mantidqt/mantidqt/widgets/samplelogs/model.py
+++ b/qt/python/mantidqt/mantidqt/widgets/samplelogs/model.py
@@ -60,7 +60,11 @@ def get_value(log):
             return entry_descr
     else:
         # convert to numpy array to fix some issues converting _kernel.std_vector_dbl to string
-        return str(np.array(log.value))
+        opt = np.get_printoptions()
+        np.set_printoptions(threshold=np.inf, linewidth=np.inf)
+        s = str(np.array(log.value))
+        np.set_printoptions(**opt)  # reset the default options
+        return s
 
 
 class SampleLogsModel():


### PR DESCRIPTION
**Description of work.**

This PR changes the way the list of values are displayed in the samples logs.

The generation of the string in the sample logs relies on the `__str__()` function of the numpy arrays. The defaults options split the line every 75 characters and this prevents the string to be properly extended when the size of the window is changed.

**To test:**

Run the following script,
```python
from mantid.simpleapi import CreateSampleWorkspace

CreateSampleWorkspace(OutputWorkspace="ws")
run = mtd["ws"].getRun()
run.addProperty("test", [9999]*30, True)
```

and check the samples logs.

Without the fix, the list cannot be extended to display all the numbers:
![sample_logs](https://user-images.githubusercontent.com/35613913/208444795-eb8af37a-0aba-4d35-a6ef-11aa17116f90.png)

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
