### PR TITLE
Avoid using any agent in pipeline

### DIFF
--- a/buildconfig/Jenkins/Conda/nightly_build_and_deploy.jenkinsfile
+++ b/buildconfig/Jenkins/Conda/nightly_build_and_deploy.jenkinsfile
@@ -58,7 +58,7 @@ pipeline {
     // the following step at the start of each subsequent stage:
     //   checkout scm: [$class: 'GitSCM', branches: [[name: "${GIT_SHA}"]]]
     stage('Store git commit') {
-      agent any
+      agent { label 'linux-64' }
       steps {
         script {
           env.GIT_SHA = GIT_COMMIT


### PR DESCRIPTION
**Description of work.**

Using `agent any` in a pipeline stage restricts our ability to have test agents online, so the first stage is now set to run on a `linux-64` node.

**To test:**
Check that the first stage (Store git commit) was successful and ran on a linux-64 node:
https://builds.mantidproject.org/job/build_packages_from_branch/162/

(If you can't find it, it's here https://builds.mantidproject.org/job/build_packages_from_branch/162/execution/node/7/log/)


*There is no associated issue.*

*This does not require release notes* because **it's a change to our build pipeline**



<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
