### PR TITLE
Temporarily pinning numpy version in developer .yaml files

### DIFF
--- a/mantid-developer-linux.yml
+++ b/mantid-developer-linux.yml
@@ -23,7 +23,7 @@ dependencies:
   - muparser>=2.3.2
   - nexus=4.4.*
   - ninja>=1.10.2
-  - numpy<=1.23.5
+  - numpy=1.19
   - occt>=7.4.0
   - pip>=21.0.1
   - poco=1.10.*

--- a/mantid-developer-linux.yml
+++ b/mantid-developer-linux.yml
@@ -23,7 +23,7 @@ dependencies:
   - muparser>=2.3.2
   - nexus=4.4.*
   - ninja>=1.10.2
-  - numpy=1.19
+  - numpy<=1.23
   - occt>=7.4.0
   - pip>=21.0.1
   - poco=1.10.*

--- a/mantid-developer-linux.yml
+++ b/mantid-developer-linux.yml
@@ -23,7 +23,7 @@ dependencies:
   - muparser>=2.3.2
   - nexus=4.4.*
   - ninja>=1.10.2
-  - numpy>=1.20.2
+  - numpy<=1.23.5
   - occt>=7.4.0
   - pip>=21.0.1
   - poco=1.10.*

--- a/mantid-developer-osx.yml
+++ b/mantid-developer-osx.yml
@@ -22,7 +22,7 @@ dependencies:
   - matplotlib=3.5.*
   - nexus=4.4.*
   - ninja>=1.10.2
-  - numpy=1.19
+  - numpy<=1.23
   - occt
   - pip>=21.0.1
   - poco=1.10.*

--- a/mantid-developer-osx.yml
+++ b/mantid-developer-osx.yml
@@ -22,7 +22,7 @@ dependencies:
   - matplotlib=3.5.*
   - nexus=4.4.*
   - ninja>=1.10.2
-  - numpy>=1.20.2
+  - numpy<=1.23.5
   - occt
   - pip>=21.0.1
   - poco=1.10.*

--- a/mantid-developer-osx.yml
+++ b/mantid-developer-osx.yml
@@ -22,7 +22,7 @@ dependencies:
   - matplotlib=3.5.*
   - nexus=4.4.*
   - ninja>=1.10.2
-  - numpy<=1.23.5
+  - numpy=1.19
   - occt
   - pip>=21.0.1
   - poco=1.10.*

--- a/mantid-developer-win.yml
+++ b/mantid-developer-win.yml
@@ -23,7 +23,7 @@ dependencies:
   - matplotlib=3.5.*
   - nexus=4.4.*
   - ninja>=1.10.2
-  - numpy=1.19
+  - numpy<=1.23
   - occt>=7.4.0
   - conda-wrappers
   - pip>=21.0.1

--- a/mantid-developer-win.yml
+++ b/mantid-developer-win.yml
@@ -23,7 +23,7 @@ dependencies:
   - matplotlib=3.5.*
   - nexus=4.4.*
   - ninja>=1.10.2
-  - numpy<=1.23.5
+  - numpy=1.19
   - occt>=7.4.0
   - conda-wrappers
   - pip>=21.0.1

--- a/mantid-developer-win.yml
+++ b/mantid-developer-win.yml
@@ -23,7 +23,7 @@ dependencies:
   - matplotlib=3.5.*
   - nexus=4.4.*
   - ninja>=1.10.2
-  - numpy>=1.20.2
+  - numpy<=1.23.5
   - occt>=7.4.0
   - conda-wrappers
   - pip>=21.0.1


### PR DESCRIPTION
**Description of work.**
The latest update of numpy is incompatible with our current pinned version of h5py. Untill #34806 is complete and merged in we need to temporarily pin numpy version to 1.23.5 or less.

**To test:**

Tests should pass 

*There is no associated issue.*

*This does not require release notes* because **it is library pinning**


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
