### PR TITLE
Superplot shrinks on some data

### DIFF
--- a/docs/source/release/v6.6.0/Workbench/Bugfixes/34876.rst
+++ b/docs/source/release/v6.6.0/Workbench/Bugfixes/34876.rst
@@ -1,1 +1,1 @@
-- Fixed a bug where the superplot plot area shrinked on some data
+- Fixed a bug where the superplot plot area shrunk on some data

--- a/docs/source/release/v6.6.0/Workbench/Bugfixes/34876.rst
+++ b/docs/source/release/v6.6.0/Workbench/Bugfixes/34876.rst
@@ -1,0 +1,1 @@
+- Fixed a bug where the superplot plot area shrinked on some data

--- a/qt/python/mantidqt/mantidqt/widgets/superplot/presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/superplot/presenter.py
@@ -393,6 +393,9 @@ class SuperplotPresenter:
         self._remove_unneeded_curves(replot)
         self._plot_selection()
 
+        legend = axes.get_legend()
+        if legend:
+            legend.remove()
         if selection or plotted_data:
             axes.set_axis_on()
             try:
@@ -403,9 +406,6 @@ class SuperplotPresenter:
             if legend:
                 legend_set_draggable(legend, True)
         else:
-            legend = axes.get_legend()
-            if legend:
-                legend.remove()
             axes.set_axis_off()
             axes.set_title("")
         self._canvas.draw_idle()


### PR DESCRIPTION
**Description of work.**

See #34876 for a description.

This PR fixes the bug by removing the legend temporarily for the `tight_layout()` function.


**To test:**

Follow the issue instruction.

Fixes #34876 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
