### PR TITLE
Deprecated factorial scipy function

### DIFF
--- a/docs/source/release/v6.6.0/Diffraction/Single_Crystal/Bugfixes/34889.rst
+++ b/docs/source/release/v6.6.0/Diffraction/Single_Crystal/Bugfixes/34889.rst
@@ -1,0 +1,1 @@
+- :ref:`IntegratePeaksProfileFitting <algm-IntegratePeaksProfileFitting>` library `ICCFitTools` module updated to support more recent versions of SciPy where the factorial function moved from `scipy.misc.factorial` to `scipy.special.factorial`. On newer versions of SciPy, the algorithm previously failed.

--- a/scripts/SCD_Reduction/ICCFitTools.py
+++ b/scripts/SCD_Reduction/ICCFitTools.py
@@ -7,7 +7,7 @@
 import matplotlib.pyplot as plt
 import numpy as np
 import sys
-from scipy.misc import factorial
+from scipy.special import factorial
 from scipy.optimize import curve_fit
 from mantid.simpleapi import *
 from mantid.kernel import V3D


### PR DESCRIPTION
**Description of work.**

The factorial function in scipy has a deprecated location. It is moved from `scipy.misc.factorial` to `scipy.special.factorial`.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**

Run tests with scipy > v1.3.0 

<!-- Instructions for testing. -->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
