### PR TITLE
Add tolerance for SCDCalibratePanels

### DIFF
--- a/Framework/Crystal/src/SCDCalibratePanels2.cpp
+++ b/Framework/Crystal/src/SCDCalibratePanels2.cpp
@@ -96,6 +96,8 @@ void SCDCalibratePanels2::init() {
   setPropertySettings("beta", std::make_unique<EnabledWhenProperty>("RecalculateUB", IS_DEFAULT));
   setPropertySettings("gamma", std::make_unique<EnabledWhenProperty>("RecalculateUB", IS_DEFAULT));
 
+  declareProperty("Tolerance", 0.15, mustBeNonNegative, "Peak indexing tolerance");
+
   // Calibration options group
   // NOTE:
   //  The general workflow of calibration is
@@ -887,12 +889,14 @@ void SCDCalibratePanels2::updateUBMatrix(const IPeaksWorkspace_sptr &pws) {
   calcUB_alg->setProperty("gamma", m_gamma);
   calcUB_alg->executeAsChildAlg();
 
+  double tol = getProperty("Tolerance");
+
   // Since UB is updated, we need to redo the indexation
   auto idxpks_alg = createChildAlgorithm("IndexPeaks", -1, -1, false);
   idxpks_alg->setLogging(LOGCHILDALG);
   idxpks_alg->setProperty("PeaksWorkspace", pws);
-  idxpks_alg->setProperty("RoundHKLs", true); // both are using default
-  idxpks_alg->setProperty("Tolerance", 0.15); // values
+  idxpks_alg->setProperty("RoundHKLs", true); // using default
+  idxpks_alg->setProperty("Tolerance", tol);  // values
   idxpks_alg->executeAsChildAlg();
 }
 

--- a/docs/source/release/v6.6.0/Diffraction/Single_Crystal/Improvements/34890.rst
+++ b/docs/source/release/v6.6.0/Diffraction/Single_Crystal/Improvements/34890.rst
@@ -1,0 +1,1 @@
+* Exposed indexing tolerance for :ref:`SCDCalibratePanels  <algm-SCDCalibratePanels >` when using `RecalculateUB` option.


### PR DESCRIPTION
**Description of work.**

Instrument team requests an additional parameter to control re-indexing. This does not affect the default behavior, it simply exposes the parameter to the algorithm.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**

<!-- Instructions for testing. -->

*There is no associated issue.*
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
