### PR TITLE
Disable PowderReduceP2DTest on Windows

### DIFF
--- a/Testing/SystemTests/tests/framework/PowderReduceP2DTest.py
+++ b/Testing/SystemTests/tests/framework/PowderReduceP2DTest.py
@@ -16,6 +16,10 @@ class PowderReduceP2DTest(systemtesting.MantidSystemTest):
         self.tolerance = 1e-6
         self.setUp()
 
+    def skipTests(self):
+        # Windows produces different outputs. Disable there for further investigation
+        return sys.platform.startswith("win")
+        
     def setUp(self):
         self.sample = self._sampleEventData()
         self.vana = self._vanadiumEventData()

--- a/Testing/SystemTests/tests/framework/PowderReduceP2DTest.py
+++ b/Testing/SystemTests/tests/framework/PowderReduceP2DTest.py
@@ -19,7 +19,7 @@ class PowderReduceP2DTest(systemtesting.MantidSystemTest):
     def skipTests(self):
         # Windows produces different outputs. Disable there for further investigation
         return sys.platform.startswith("win")
-        
+
     def setUp(self):
         self.sample = self._sampleEventData()
         self.vana = self._vanadiumEventData()


### PR DESCRIPTION
**Description of work.**

Current nightly builds show this test fails on [Windows](https://builds.mantidproject.org/view/Nightly%20Pipelines/job/main_nightly_deployment_prototype/475/testReport/junit/SystemTests/PowderReduceP2DTest/Build_Test__Development__Package__Conda___Matrix___PLATFORM____win_64___BUILD_TYPE____conda_devel____build_and_test___PowderReduceP2DTest/). Disabling only on this platform for further investigation. It should not hold up nightly releases as it was not being tested at all until recently and we at least now have 2/3 platform coverage.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**

Automated tests should pass.

*There is no associated issue.*

*This does not require release notes* because **it is an internal change.**

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
