### PR TITLE
Stop axes labels being hidden by the plot window

### DIFF
--- a/docs/source/release/v6.6.0/Workbench/Bugfixes/34049.rst
+++ b/docs/source/release/v6.6.0/Workbench/Bugfixes/34049.rst
@@ -1,0 +1,1 @@
+- Plot axes labels are no longer hidden when resizing the plot window.

--- a/qt/applications/workbench/workbench/plotting/figuremanager.py
+++ b/qt/applications/workbench/workbench/plotting/figuremanager.py
@@ -199,12 +199,12 @@ class FigureManagerWorkbench(FigureManagerBase, QObject):
         warnings.filterwarnings(
             "once",
             message="Tight layout not applied. The left and right margins cannot be made "
-            "large enough to accommodate all axes decorations."
+            "large enough to accommodate all axes decorations.",
         )
         warnings.filterwarnings(
             "once",
             message="Tight layout not applied. The bottom and top margins cannot be made "
-            "large enough to accommodate all axes decorations."
+            "large enough to accommodate all axes decorations.",
         )
 
         FigureManagerBase.__init__(self, canvas, num)

--- a/qt/applications/workbench/workbench/plotting/figuremanager.py
+++ b/qt/applications/workbench/workbench/plotting/figuremanager.py
@@ -14,6 +14,7 @@ import io
 import sys
 import re
 from functools import wraps
+import warnings
 
 import matplotlib
 from matplotlib.axes import Axes
@@ -189,6 +190,10 @@ class FigureManagerWorkbench(FigureManagerBase, QObject):
 
         self.window.setWindowTitle("Figure %d" % num)
         canvas.figure.set_label("Figure %d" % num)
+
+        # Set tight layout so axes labels remain visible
+        canvas.figure.set_layout_engine(layout="tight")
+        warnings.filterwarnings("ignore", message="Tight layout not applied.")
 
         FigureManagerBase.__init__(self, canvas, num)
         # Give the keyboard focus to the figure instead of the

--- a/qt/applications/workbench/workbench/plotting/figuremanager.py
+++ b/qt/applications/workbench/workbench/plotting/figuremanager.py
@@ -193,7 +193,13 @@ class FigureManagerWorkbench(FigureManagerBase, QObject):
 
         # Set tight layout so axes labels remain visible
         canvas.figure.set_layout_engine(layout="tight")
-        warnings.filterwarnings("ignore", message="Tight layout not applied.")
+        # Matplotlib issues a warnings if the window is made too small in the vertical or horizontal direction
+        # Filtering it to only warn once per plot per axis so that it doesn't give a warning everytime the plot window
+        # is resized, filling up the console with warnings
+        warnings.filterwarnings("once", message="Tight layout not applied. The left and right margins cannot be made "
+                                                "large enough to accommodate all axes decorations.")
+        warnings.filterwarnings("once", message="Tight layout not applied. The bottom and top margins cannot be made "
+                                                "large enough to accommodate all axes decorations.")
 
         FigureManagerBase.__init__(self, canvas, num)
         # Give the keyboard focus to the figure instead of the

--- a/qt/applications/workbench/workbench/plotting/figuremanager.py
+++ b/qt/applications/workbench/workbench/plotting/figuremanager.py
@@ -196,10 +196,16 @@ class FigureManagerWorkbench(FigureManagerBase, QObject):
         # Matplotlib issues a warnings if the window is made too small in the vertical or horizontal direction
         # Filtering it to only warn once per plot per axis so that it doesn't give a warning everytime the plot window
         # is resized, filling up the console with warnings
-        warnings.filterwarnings("once", message="Tight layout not applied. The left and right margins cannot be made "
-                                                "large enough to accommodate all axes decorations.")
-        warnings.filterwarnings("once", message="Tight layout not applied. The bottom and top margins cannot be made "
-                                                "large enough to accommodate all axes decorations.")
+        warnings.filterwarnings(
+            "once",
+            message="Tight layout not applied. The left and right margins cannot be made "
+            "large enough to accommodate all axes decorations."
+        )
+        warnings.filterwarnings(
+            "once",
+            message="Tight layout not applied. The bottom and top margins cannot be made "
+            "large enough to accommodate all axes decorations."
+        )
 
         FigureManagerBase.__init__(self, canvas, num)
         # Give the keyboard focus to the figure instead of the


### PR DESCRIPTION
**Description of work.**

This PR fixes the bug where the axes labels of a plot could be hidden outside the edge of the plot window after resizing.

**To test:**

- Load some data
- Plot a spectrum
- Play around with resizing the window and check that the axes labels remain visible up until matplotlib is forced to push them outside the window (almost minimum window size).
  - When this happens there should be one warning issued for horizontal and vertical limits respectively

It may be worth comparing to another branch to observe how it was problematic before.

Fixes #34049

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
