### PR TITLE
Prevent PeakPicker from going missing on ALFView

### DIFF
--- a/qt/scientific_interfaces/Direct/ALFAnalysisView.cpp
+++ b/qt/scientific_interfaces/Direct/ALFAnalysisView.cpp
@@ -106,7 +106,7 @@ QWidget *ALFAnalysisView::createPlotWidget() {
   m_plot->canvas()->gcf().setFaceColor("None");
   m_plot->canvas()->setStyleSheet("background-color:transparent;");
 
-  m_peakPicker = new MantidWidgets::PeakPicker(m_plot, Qt::red);
+  m_peakPicker = new MantidWidgets::PeakPicker(m_plot);
   m_peakPicker->setVisible(false);
   connect(m_peakPicker, SIGNAL(changed()), this, SLOT(notifyPeakPickerChanged()));
 

--- a/qt/widgets/plotting/inc/MantidQtWidgets/Plotting/PeakPicker.h
+++ b/qt/widgets/plotting/inc/MantidQtWidgets/Plotting/PeakPicker.h
@@ -23,7 +23,7 @@ class EXPORT_OPT_MANTIDQT_PLOTTING PeakPicker : public QObject {
   Q_OBJECT
 
 public:
-  PeakPicker(PreviewPlot *plot, const QColor &colour = Qt::black);
+  PeakPicker(PreviewPlot *plot);
 
   void redraw();
   void remove();

--- a/qt/widgets/plotting/inc/MantidQtWidgets/Plotting/PreviewPlot.h
+++ b/qt/widgets/plotting/inc/MantidQtWidgets/Plotting/PreviewPlot.h
@@ -187,6 +187,9 @@ private:
   std::string m_xAxisScale;
   std::string m_yAxisScale;
 
+  // Whether to redraw markers when a paint event occurs
+  bool m_redrawOnPaint;
+
   // Context menu actions
   QActionGroup *m_contextPlotTools;
   QAction *m_contextResetView;

--- a/qt/widgets/plotting/src/PeakPicker.cpp
+++ b/qt/widgets/plotting/src/PeakPicker.cpp
@@ -13,12 +13,10 @@ using namespace MantidQt::Widgets::MplCpp;
 
 namespace MantidQt::MantidWidgets {
 
-PeakPicker::PeakPicker(PreviewPlot *plot, const QColor &colour)
+PeakPicker::PeakPicker(PreviewPlot *plot)
     : QObject(), m_plot(plot), m_peak(nullptr),
       m_peakMarker(std::make_unique<PeakMarker>(m_plot->canvas(), 1, std::get<0>(m_plot->getAxisRange()),
                                                 std::get<1>(m_plot->getAxisRange(AxisID::YLeft)), 0.0, 0.0)) {
-  UNUSED_ARG(colour);
-
   m_plot->canvas()->draw();
 
   connect(m_plot, SIGNAL(mouseDown(QPoint)), this, SLOT(handleMouseDown(QPoint)));

--- a/qt/widgets/plotting/src/PeakPicker.cpp
+++ b/qt/widgets/plotting/src/PeakPicker.cpp
@@ -33,8 +33,7 @@ void PeakPicker::remove() { m_peakMarker->remove(); }
 
 void PeakPicker::setPeak(const Mantid::API::IPeakFunction_const_sptr &peak) {
   if (peak) {
-    m_peak = std::dynamic_pointer_cast<Mantid::API::IPeakFunction>(
-        Mantid::API::FunctionFactory::Instance().createInitialized(peak->asString()));
+    m_peak = std::dynamic_pointer_cast<IPeakFunction>(peak->clone());
     m_peakMarker->updatePeak(peak->centre(), peak->height(), peak->fwhm());
   }
 }
@@ -64,10 +63,10 @@ void PeakPicker::handleMouseMove(const QPoint &point) {
 
   if (markerMoved) {
     m_plot->replot();
-    const auto properties = m_peakMarker->peakProperties();
-    m_peak->setCentre(std::get<0>(properties));
-    m_peak->setHeight(std::get<1>(properties));
-    m_peak->setFwhm(std::get<2>(properties));
+    const auto [centre, height, fwhm] = m_peakMarker->peakProperties();
+    m_peak->setCentre(centre);
+    m_peak->setHeight(height);
+    m_peak->setFwhm(fwhm);
     emit changed();
   }
 }

--- a/qt/widgets/plotting/src/PreviewPlot.cpp
+++ b/qt/widgets/plotting/src/PreviewPlot.cpp
@@ -56,7 +56,7 @@ PreviewPlot::PreviewPlot(QWidget *parent, bool observeADS)
     : QWidget(parent), m_canvas{new FigureCanvasQt(111, MANTID_PROJECTION, parent)}, m_panZoomTool(m_canvas),
       m_wsRemovedObserver(*this, &PreviewPlot::onWorkspaceRemoved),
       m_wsReplacedObserver(*this, &PreviewPlot::onWorkspaceReplaced), m_axis("both"), m_style("sci"), m_useOffset(true),
-      m_xAxisScale("linear"), m_yAxisScale("linear") {
+      m_xAxisScale("linear"), m_yAxisScale("linear"), m_redrawOnPaint(false) {
   createLayout();
   createActions();
 
@@ -310,7 +310,7 @@ std::tuple<double, double> PreviewPlot::getAxisRange(AxisID axisID) {
 void PreviewPlot::replot() {
   if (m_allowRedraws) {
     m_canvas->drawIdle();
-    emit redraw();
+    m_redrawOnPaint = true;
   }
 }
 
@@ -413,6 +413,12 @@ bool PreviewPlot::eventFilter(QObject *watched, QEvent *evt) {
     break;
   case QEvent::Resize:
     stopEvent = handleWindowResizeEvent();
+    break;
+  case QEvent::Paint:
+    if (m_redrawOnPaint) {
+      m_redrawOnPaint = false;
+      emit redraw();
+    }
     break;
   default:
     break;


### PR DESCRIPTION
**Description of work.**
This PR fixes a bug on the ALFView interface where the PeakPicker tool had gone missing from the right hand side plot. This was caused by the redraw event for the markers happening _before_ the draw event for the plot itself. We want this redraw event to happen _after_ the draw event.

The PR also cleans up some of the code in the PeakPicker class to make it easier to read.

**To test:**
Open ALFView and load ALF82301
Click on Pick tab
Expand Rebin section. Rebin with 5.5,0.01,6
Click the Rectangle region selection tool at the top of the Pick tab
Select the two tubes in the centre with the yellow peak
A plot should be plotted on the right hand side of the interface. There should be a central grey line near the peak which signifies the peak picker.
It should be possible to select this peak picker and move it around


*There is no associated issue.*

*This does not require release notes* because **the bug was introduced since the last release**


#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
