### PR TITLE
Upgrade to tbb 2021 to match conda-forge

### DIFF
--- a/Framework/Algorithms/test/SofQCommonTest.h
+++ b/Framework/Algorithms/test/SofQCommonTest.h
@@ -200,10 +200,11 @@ public:
     s.initCachedValues(*ws, &alg);
     const auto &detectorInfo = ws->detectorInfo();
     const auto testDeltaE = -Ei / 1.8;
+    const auto allowedDelta(1e-10);
     for (size_t i = 0; i < detectorInfo.size(); ++i) {
       const auto twoTheta = detectorInfo.twoTheta(i);
       const auto expected = directQ(Ei, testDeltaE, twoTheta);
-      TS_ASSERT_EQUALS(s.q(testDeltaE, twoTheta, nullptr), expected)
+      TS_ASSERT_DELTA(s.q(testDeltaE, twoTheta, nullptr), expected, allowedDelta)
     }
   }
 

--- a/buildconfig/CMake/DarwinSetup.cmake
+++ b/buildconfig/CMake/DarwinSetup.cmake
@@ -31,25 +31,13 @@ if(MACOS_VERSION VERSION_LESS 10.13)
   message(FATAL_ERROR "The minimum supported version of Mac OS X is 10.13 (High Sierra).")
 endif()
 
-if(MACOS_VERSION VERSION_GREATER 10.13 OR MACOS_VERSION VERSION_EQUAL 10.13)
-  set(MACOS_CODENAME "High Sierra")
-elseif(MACOS_VERSION VERSION_GREATER 10.14 OR MACOS_VERSION VERSION_EQUAL 10.14)
-  set(MACOS_CODENAME "Mojave")
-else()
-  message(FATAL_ERROR "Unknown version of macOS")
-endif()
-
 # Export variables globally
 set(MACOS_VERSION
     ${MACOS_VERSION}
     CACHE INTERNAL ""
 )
-set(MACOS_CODENAME
-    ${MACOS_CODENAME}
-    CACHE INTERNAL ""
-)
 
-message(STATUS "Operating System: Mac OS X ${MACOS_VERSION} (${MACOS_CODENAME})")
+message(STATUS "Operating System: macOS ${MACOS_VERSION}")
 
 # Enable the use of the -isystem flag to mark headers in Third_Party as system headers
 set(CMAKE_INCLUDE_SYSTEM_FLAG_CXX "-isystem ")

--- a/buildconfig/CMake/GNUSetup.cmake
+++ b/buildconfig/CMake/GNUSetup.cmake
@@ -68,6 +68,10 @@ if(CMAKE_COMPILER_IS_GNUCXX)
   endif()
 elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
   add_compile_options(-Wno-sign-conversion)
+  # Conda uses its own newer compilers so these checks are not needed
+  if(CONDA_ENV OR CONDA_BUILD)
+    add_definitions(-D_LIBCPP_DISABLE_AVAILABILITY)
+  endif()
 endif()
 
 # Add some options for debug build to help the Zoom profiler

--- a/buildconfig/CMake/GNUSetup.cmake
+++ b/buildconfig/CMake/GNUSetup.cmake
@@ -71,8 +71,8 @@ elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
   if(CONDA_ENV OR CONDA_BUILD)
     # Conda uses its own newer compilers so these checks are not needed
     add_definitions(-D_LIBCPP_DISABLE_AVAILABILITY)
-    # Keep C++14 alignment behaviour while older macOS C++ ABI
-    # does not contain the required symbols. Minimum=macos 10.14
+    # Keep C++14 alignment behaviour while older macOS C++ ABI does not contain the required symbols. Minimum=macos
+    # 10.14
     add_compile_options(-fno-aligned-new)
   endif()
 endif()

--- a/buildconfig/CMake/GNUSetup.cmake
+++ b/buildconfig/CMake/GNUSetup.cmake
@@ -68,9 +68,12 @@ if(CMAKE_COMPILER_IS_GNUCXX)
   endif()
 elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
   add_compile_options(-Wno-sign-conversion)
-  # Conda uses its own newer compilers so these checks are not needed
   if(CONDA_ENV OR CONDA_BUILD)
+    # Conda uses its own newer compilers so these checks are not needed
     add_definitions(-D_LIBCPP_DISABLE_AVAILABILITY)
+    # Keep C++14 alignment behaviour while older macOS C++ ABI
+    # does not contain the required symbols. Minimum=macos 10.14
+    add_compile_options(-fno-aligned-new)
   endif()
 endif()
 

--- a/mantid-developer-linux.yml
+++ b/mantid-developer-linux.yml
@@ -42,8 +42,7 @@ dependencies:
   - setuptools=47.0.0 # Pinned purposefully due to incompatibility with later versions
   - sphinx >= 4.5.*
   - sphinx_bootstrap_theme>=0.8.1
-  - tbb-devel=2020.2.*
-  - tbb=2020.2.*
+  - tbb-devel=2021.*
   - texlive-core>=20180414
   - toml>=0.10.2
   - zlib>=1.2.11

--- a/mantid-developer-osx.yml
+++ b/mantid-developer-osx.yml
@@ -56,4 +56,4 @@ dependencies:
   # Pinned to same version as conda forge: https://github.com/conda-forge/conda-forge-pinning-feedstock/blob/main/recipe/conda_build_config.yaml
   - clang_osx-64=14
   - clangxx_osx-64=14
-  - llvm-openmp=13
+  - llvm-openmp=14

--- a/mantid-developer-osx.yml
+++ b/mantid-developer-osx.yml
@@ -42,8 +42,7 @@ dependencies:
   - setuptools=47.0.0 # Pinned purposefully due to incompatibility with later versions
   - sphinx >= 4.5.*
   - sphinx_bootstrap_theme=>0.8.1
-  - tbb-devel=2020.2.*
-  - tbb=2020.2.*
+  - tbb-devel=2021.*
   - texlive-core>=20180414
   - toml>=0.10.2
   - zlib>=1.2.11
@@ -54,7 +53,7 @@ dependencies:
   - pre-commit>=2.12.0
 
   # Use conda version of clang to get matching CXXFLAGS.
-  # Pinned to same version as conda forge: https://github.com/conda-forge/conda-forge-pinning-feedstock/blob/main/recipe/conda_build_config.yaml#L23
-  - clang_osx-64=12
-  - clangxx_osx-64=12
-  - llvm-openmp=12
+  # Pinned to same version as conda forge: https://github.com/conda-forge/conda-forge-pinning-feedstock/blob/main/recipe/conda_build_config.yaml
+  - clang_osx-64=14
+  - clangxx_osx-64=14
+  - llvm-openmp=13

--- a/mantid-developer-win.yml
+++ b/mantid-developer-win.yml
@@ -43,8 +43,7 @@ dependencies:
   - setuptools=47.0.0 # Pinned purposefully due to incompatibility with later versions
   - sphinx >= 4.5.*
   - sphinx_bootstrap_theme=>0.8.1
-  - tbb-devel=2020.2.*
-  - tbb=2020.2.*
+  - tbb-devel=2021.*
   - toml>=0.10.2
   - zlib>=1.2.11
   # Needed only for development


### PR DESCRIPTION
**Please merge mantidproject/conda-recipes#90** at the same time.

**Description of work.**

Conda-forge has updated to tbb 2021. We need to update to keep pace and ensure
other libraries like vtk that depend on tbb can be installed in our environments.

The current [nightly builds](https://builds.mantidproject.org/job/main_nightly_deployment_prototype/481/) are broken because of this.

**To test:**

* Builds should pass.

*This does not require release notes* because **it is an internal change to developer libraries**

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
