### PR TITLE
Fix overwriting of settings for existing batches when adding a new one

### DIFF
--- a/docs/source/release/v6.6.0/Reflectometry/Bugfixes/34915.rst
+++ b/docs/source/release/v6.6.0/Reflectometry/Bugfixes/34915.rst
@@ -1,0 +1,1 @@
+- Fixed an issue where adding a new batch for instruments other than INTER causes settings on any existing batch tabs to be cleared.

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchPresenter.cpp
@@ -69,7 +69,9 @@ BatchPresenter::BatchPresenter(IBatchView *view, std::unique_ptr<IBatch> model, 
  */
 void BatchPresenter::acceptMainPresenter(IMainWindowPresenter *mainPresenter) { m_mainPresenter = mainPresenter; }
 
-void BatchPresenter::initInstrumentList() { m_runsPresenter->initInstrumentList(); }
+void BatchPresenter::initInstrumentList(const std::string &selectedInstrument) {
+  m_runsPresenter->initInstrumentList(selectedInstrument);
+}
 
 bool BatchPresenter::requestClose() const { return true; }
 

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchPresenter.h
@@ -57,7 +57,7 @@ public:
 
   // IBatchPresenter overrides
   void acceptMainPresenter(IMainWindowPresenter *mainPresenter) override;
-  void initInstrumentList() override;
+  void initInstrumentList(const std::string &selectedInstrument = "") override;
   void notifyPauseReductionRequested() override;
   void notifyResumeReductionRequested() override;
   void notifyResumeAutoreductionRequested() override;

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/IBatchPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/IBatchPresenter.h
@@ -32,7 +32,7 @@ public:
   virtual ~IBatchPresenter() = default;
 
   virtual void acceptMainPresenter(IMainWindowPresenter *mainPresenter) = 0;
-  virtual void initInstrumentList() = 0;
+  virtual void initInstrumentList(const std::string &selectedInstrument = "") = 0;
 
   virtual void notifyPauseReductionRequested() = 0;
   virtual void notifyResumeReductionRequested() = 0;

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/MainWindow/MainWindowPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/MainWindow/MainWindowPresenter.cpp
@@ -270,7 +270,7 @@ void MainWindowPresenter::addNewBatch(IBatchView *batchView) {
 void MainWindowPresenter::initNewBatch(IBatchPresenter *batchPresenter, std::string const &instrument,
                                        boost::optional<int> precision) {
 
-  batchPresenter->initInstrumentList();
+  batchPresenter->initInstrumentList(instrument);
   batchPresenter->notifyInstrumentChanged(instrument);
   if (precision.is_initialized())
     batchPresenter->notifySetRoundPrecision(precision.get());

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/IRunsPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/IRunsPresenter.h
@@ -24,7 +24,7 @@ class IRunsPresenter {
 public:
   virtual ~IRunsPresenter() = default;
   virtual void acceptMainPresenter(IBatchPresenter *mainPresenter) = 0;
-  virtual void initInstrumentList() = 0;
+  virtual void initInstrumentList(const std::string &selectedInstrument = "") = 0;
   virtual RunsTable const &runsTable() const = 0;
   virtual RunsTable &mutableRunsTable() = 0;
 

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/IRunsView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/IRunsView.h
@@ -83,7 +83,8 @@ public:
   virtual ISearchModel &mutableSearchResults() = 0;
 
   // Setter methods
-  virtual void setInstrumentList(const std::vector<std::string> &instruments) = 0;
+  virtual void setInstrumentList(const std::vector<std::string> &instruments,
+                                 const std::string &selectedInstrument = "") = 0;
   virtual void updateMenuEnabledState(bool isProcessing) = 0;
   virtual void setAutoreduceButtonEnabled(bool enabled) = 0;
   virtual void setAutoreducePauseButtonEnabled(bool enabled) = 0;

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/QtRunsView.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/QtRunsView.cpp
@@ -158,14 +158,24 @@ void QtRunsView::setUpdateIntervalSpinBoxEnabled(bool enabled) { m_ui.spinBoxUpd
 
 /**
 Set the list of available instruments to search for and updates the list of
-available instruments in the table view
+available instruments in the table view. The selected instrument will be the first item added to the combobox,
+unless a valid value for selectedInstrument is provided.
 @param instruments : The list of instruments available
+@param selectedInstrument : The name of an instrument to select from the dropdown
 default
 */
-void QtRunsView::setInstrumentList(const std::vector<std::string> &instruments) {
+void QtRunsView::setInstrumentList(const std::vector<std::string> &instruments, const std::string &selectedInstrument) {
+  // We block signals while populating the list and setting the selected instrument because adding the first item
+  // will trigger a currentIndexChanged signal. This causes existing batch settings to be overwritten when we're
+  // initialising a new batch for an instrument that isn't the first in the list.
+  m_ui.comboSearchInstrument->blockSignals(true);
   m_ui.comboSearchInstrument->clear();
   for (auto &&instrument : instruments)
     m_ui.comboSearchInstrument->addItem(QString::fromStdString(instrument));
+  setSearchInstrument(selectedInstrument);
+  m_ui.comboSearchInstrument->blockSignals(false);
+  // Manually emit the signal once we've finished setting up the dropdown.
+  emit m_ui.comboSearchInstrument->currentIndexChanged(m_ui.comboSearchInstrument->currentIndex());
 }
 
 /**

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/QtRunsView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/QtRunsView.h
@@ -51,7 +51,8 @@ public:
   ISearchModel &mutableSearchResults() override;
 
   // Setter methods
-  void setInstrumentList(const std::vector<std::string> &instruments) override;
+  void setInstrumentList(const std::vector<std::string> &instruments,
+                         const std::string &selectedInstrument = "") override;
   void updateMenuEnabledState(bool isProcessing) override;
   void setAutoreduceButtonEnabled(bool enabled) override;
   void setAutoreducePauseButtonEnabled(bool enabled) override;

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/RunsPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/RunsPresenter.cpp
@@ -72,7 +72,9 @@ RunsPresenter::~RunsPresenter() {
  */
 void RunsPresenter::acceptMainPresenter(IBatchPresenter *mainPresenter) { m_mainPresenter = mainPresenter; }
 
-void RunsPresenter::initInstrumentList() { m_view->setInstrumentList(m_instruments); }
+void RunsPresenter::initInstrumentList(const std::string &selectedInstrument) {
+  m_view->setInstrumentList(m_instruments, selectedInstrument);
+}
 
 RunsTable const &RunsPresenter::runsTable() const { return tablePresenter()->runsTable(); }
 

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/RunsPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/RunsPresenter.h
@@ -67,7 +67,7 @@ public:
 
   // IRunsPresenter overrides
   void acceptMainPresenter(IBatchPresenter *mainPresenter) override;
-  void initInstrumentList() override;
+  void initInstrumentList(const std::string &selectedInstrument = "") override;
   RunsTable const &runsTable() const override;
   RunsTable &mutableRunsTable() override;
   bool isProcessing() const override;

--- a/qt/scientific_interfaces/ISISReflectometry/test/Batch/BatchPresenterTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Batch/BatchPresenterTest.h
@@ -54,7 +54,7 @@ public:
 
   void testInitInstrumentListUpdatesRunsPresenter() {
     auto presenter = makePresenter(makeModel());
-    EXPECT_CALL(*m_runsPresenter, initInstrumentList()).Times(1);
+    EXPECT_CALL(*m_runsPresenter, initInstrumentList(_)).Times(1);
     presenter->initInstrumentList();
     verifyAndClear();
   }

--- a/qt/scientific_interfaces/ISISReflectometry/test/MainWindow/MainWindowPresenterTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/MainWindow/MainWindowPresenterTest.h
@@ -579,7 +579,7 @@ private:
 
   void expectBatchAdded(MockBatchPresenter *batchPresenter) {
     EXPECT_CALL(*batchPresenter, acceptMainPresenter(_)).Times(1);
-    EXPECT_CALL(*batchPresenter, initInstrumentList()).Times(1);
+    EXPECT_CALL(*batchPresenter, initInstrumentList(_)).Times(1);
     EXPECT_CALL(*batchPresenter, notifyInstrumentChanged(_)).Times(1);
     EXPECT_CALL(*batchPresenter, notifyReductionPaused()).Times(1);
     EXPECT_CALL(*batchPresenter, notifyAnyBatchAutoreductionPaused()).Times(1);

--- a/qt/scientific_interfaces/ISISReflectometry/test/ReflMockObjects.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/ReflMockObjects.h
@@ -65,7 +65,7 @@ public:
 class MockBatchPresenter : public IBatchPresenter {
 public:
   MOCK_METHOD1(acceptMainPresenter, void(IMainWindowPresenter *));
-  MOCK_METHOD0(initInstrumentList, void());
+  MOCK_METHOD1(initInstrumentList, void(const std::string &));
   MOCK_METHOD0(notifyResumeReductionRequested, void());
   MOCK_METHOD0(notifyPauseReductionRequested, void());
   MOCK_METHOD0(notifyResumeAutoreductionRequested, void());
@@ -111,7 +111,7 @@ public:
 class MockRunsPresenter : public IRunsPresenter {
 public:
   MOCK_METHOD1(acceptMainPresenter, void(IBatchPresenter *));
-  MOCK_METHOD0(initInstrumentList, void());
+  MOCK_METHOD1(initInstrumentList, void(const std::string &));
   MOCK_CONST_METHOD0(runsTable, RunsTable const &());
   MOCK_METHOD0(mutableRunsTable, RunsTable &());
   MOCK_METHOD1(notifyChangeInstrumentRequested, bool(std::string const &));

--- a/qt/scientific_interfaces/ISISReflectometry/test/Runs/MockRunsView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Runs/MockRunsView.h
@@ -32,7 +32,7 @@ public:
   MOCK_CONST_METHOD0(searchResults, ISearchModel const &());
   MOCK_METHOD0(mutableSearchResults, ISearchModel &());
 
-  MOCK_METHOD1(setInstrumentList, void(const std::vector<std::string> &));
+  MOCK_METHOD2(setInstrumentList, void(const std::vector<std::string> &, const std::string &));
   MOCK_METHOD1(updateMenuEnabledState, void(bool));
   MOCK_METHOD1(setAutoreduceButtonEnabled, void(bool));
   MOCK_METHOD1(setAutoreducePauseButtonEnabled, void(bool));

--- a/qt/scientific_interfaces/ISISReflectometry/test/Runs/RunsPresenterTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Runs/RunsPresenterTest.h
@@ -80,7 +80,7 @@ public:
 
   void testInitInstrumentListUpdatesView() {
     auto presenter = makePresenter();
-    EXPECT_CALL(m_view, setInstrumentList(m_instruments)).Times(1);
+    EXPECT_CALL(m_view, setInstrumentList(m_instruments, _)).Times(1);
     presenter.initInstrumentList();
     verifyAndClear();
   }


### PR DESCRIPTION
**Description of work:**

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

The first step we perform when adding a new batch is to populate the dropdown list of instruments on the Runs tab. It seems that when you add a new item to a `QComboBox` it is automatically selected and this triggers the signal `currentIndexChanged`. In our code this then kicks off the workflow to handle a change in instrument. Within this workflow, we load the new instrument and then, if the new instrument is different to the old instrument, we reset the settings across all batch tabs and notify the slit calculator. This behaviour meant that when we added a new batch for an instrument other than the one selected by default (INTER), the step that populated the dropdown for the new batch would trigger a reset of any existing batch settings.

When we create the very first batch as part of creating the Reflectometry GUI we need to run through the steps that populate the dropdown, load the instrument and configure the slits. When we're adding new batches for the current instrument, we just need to populate the dropdown and (as commented in the code) reload the instrument to ensure all settings are up to date. Loading the instrument and configuring the slits are currently only included in the workflow that is triggered when the selected instrument is changed, there isn't a separate workflow that handles these steps when adding a new batch.

I think the ideal fix for this issue would involve looking at where we could separate the workflows for setting up a new batch vs handling a change in instrument, obviously being mindful of duplication. However, because we are so close to the next release, the fix in this PR simply refactors the `QtRunsView::setInstrumentList` method so that it takes the name of the instrument that should be selected, blocks all signals while the dropdown is populated and the correct instrument selected, and then manually emits the signal to trigger the rest of the workflow using the correct selection.

Even as part of a short-term fix, it feels like we shouldn't need to be blocking signals, however I couldn't find anything in the docs for `QComboBox` that seemed to allow you to populate the dropdown and specify the item you want to be selected at the same time.

Unfortunately I also couldn't see a way to add a test for the changes in this PR, but happy to take advice on that if there's a way to do it that I've missed.


**To test:**

<!-- Instructions for testing. -->
See steps on the linked issue that would have previously reproduced the bug. Now no settings should be overwritten on existing batch tabs. Note that changes in the Runs and Instrument settings tabs should be tested too, as these were also being overwritten by the bug.

Fixes #34845. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
