### PR TITLE
Hide non-working help button from regionselector

### DIFF
--- a/qt/python/mantidqt/mantidqt/widgets/regionselector/view.py
+++ b/qt/python/mantidqt/mantidqt/widgets/regionselector/view.py
@@ -19,6 +19,7 @@ class RegionSelectorView(QWidget):
         super().__init__(parent)
         self.setWindowFlags(Qt.Window)
         self._data_view = SliceViewerDataView(presenter, dims_info, None, self, None, image_info_widget)
+        self._data_view.help_button.hide()
 
         layout = QHBoxLayout(self)
         layout.setContentsMargins(0, 0, 0, 0)


### PR DESCRIPTION
**Description of work.**
Hides the button from the regionselector, which would link to the sliceviewer docs, but wasn't working anyway.

**To test:**
1. Open the ISIS Reflectometry GUI.
2. Go to the preview tab
3. Check that the `?` button isn't there in the bottom right of the region selector. 

Part of #34745 

*This does not require release notes* because **it is part of an unreleased element of the GUI**


<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
