### PR TITLE
Deallocate memory when batch tab is deleted from Reflectometry GUI

### DIFF
--- a/docs/source/release/v6.6.0/Reflectometry/Bugfixes/34919.rst
+++ b/docs/source/release/v6.6.0/Reflectometry/Bugfixes/34919.rst
@@ -1,0 +1,1 @@
+- Fixed an issue where Mantid could crash when workspaces were cleared from the ADS after deleting a batch from the ISIS Reflectometry GUI.

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/MainWindow/QtMainWindowView.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/MainWindow/QtMainWindowView.cpp
@@ -49,7 +49,10 @@ IBatchView *QtMainWindowView::newBatch() {
 
 void QtMainWindowView::removeBatch(int batchIndex) {
   m_batchViews.erase(m_batchViews.begin() + batchIndex);
+  auto *batchToRemove = m_ui.mainTabs->widget(batchIndex);
   m_ui.mainTabs->removeTab(batchIndex);
+  // Calling removeTab doesn't deallocate the memory for the QtBatchView, so we must do that here
+  delete batchToRemove;
   if (m_ui.mainTabs->count() == 0) {
     m_notifyee->notifyNewBatchRequested();
   }


### PR DESCRIPTION
**Description of work.**

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->
The issue was being caused by the memory for the batch view not being deallocated when the batch tab was removed from the GUI. The batch view is created as a raw pointer and I think we were relying on Qt clearing the memory when we called `QTabWidget::removeTab` to remove it. According to the Qt docs, though, this method removes the widget from the stack of tab widgets but does not delete it, so the batch view remained in memory. This meant it was still possible for it to receive signals, and we have a couple of `WorkspaceSelector` widgets on the Experiment settings tab of a batch view that respond to changes in the ADS. When this happened we would end up with a call through to the BatchPresenter, which caused a memory access error as the presenter is correctly deleted as part of removing a batch tab.

I've added a simple fix here to deallocate the memory for the batch view after removing the tab. I wasn't sure if it was preferable to continue using a raw pointer for the batch view or switch to using a shared pointer, so I stuck with the raw pointer in this PR. I'm happy to change it if a different solution would be better/more in-keeping with our conventions, though.

I haven't added a test for the bug as I couldn't see a way to do this.

**To test:**

<!-- Instructions for testing. -->
Follow instructions on the linked issue and check that Mantid does not crash.

Fixes #34916. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
