### PR TITLE
Fix for not being able to copy data from fit browser workspaces

### DIFF
--- a/docs/source/release/v6.6.0/Workbench/Bugfixes/32778.rst
+++ b/docs/source/release/v6.6.0/Workbench/Bugfixes/32778.rst
@@ -1,0 +1,1 @@
+- Fixed a bug where data from workspaces (i.e the fit parameters) accessed from the Fit Browser could not be copied.

--- a/qt/python/mantidqt/mantidqt/widgets/fitpropertybrowser/fitpropertybrowser.py
+++ b/qt/python/mantidqt/mantidqt/widgets/fitpropertybrowser/fitpropertybrowser.py
@@ -544,5 +544,5 @@ class FitPropertyBrowser(FitPropertyBrowserBase):
                 presenter = MatrixWorkspaceDisplay(ws, plot=plot)
                 presenter.show_view()
             elif isinstance(ws, ITableWorkspace):
-                presenter = TableWorkspaceDisplay(ws, plot=matplotlib.pyplot)
+                presenter = TableWorkspaceDisplay(ws, plot=matplotlib.pyplot, batch=True)
                 presenter.show_view()


### PR DESCRIPTION
**Description of work.**

When copying data from a workspace opened from the bottom left of the fit browser, all values would change to None.
`TableWorkspaceDisplay` needed to be initialised with `batch=True` (the same way it is used when opening one of these workspaces from the main Mantid window).

**To test:**

Follow the instructions in #32778.
The data should now correctly copy.

Fixes #32778

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
