### PR TITLE
[SANS984] add dev notes to explain EventList::filterInPlaceHelper

### DIFF
--- a/Framework/DataObjects/src/EventList.cpp
+++ b/Framework/DataObjects/src/EventList.cpp
@@ -3769,7 +3769,7 @@ void EventList::filterByTimeAtSample(Types::Core::DateAndTime start, Types::Core
 }
 
 //------------------------------------------------------------------------------------------------
-/** Perform an in-place filtering on a vector of either TofEvent's or
+/** @brief Perform an in-place filtering on a vector of either TofEvent's or
  *WeightedEvent's.
  *
  * @param splitter :: a TimeSplitterType where all the entries (start/end time)
@@ -3777,27 +3777,27 @@ void EventList::filterByTimeAtSample(Types::Core::DateAndTime start, Types::Core
  *     that will be kept. Any other events will be deleted.
  * @param events :: either this->events or this->weightedEvents.
  *
- * @brief This helper function uses a two pointer technique where
-    - itOut: the storage pointer
-    - itev: the scan pointer
-    When itev is traversing through the list of events, it will check against the
-    current splitter interval identified by itspl.
-
-    If itev->m_pulsetime is within the interval, the event, *itev, will be copied
-    to the location pointed by itOut, and itOut will be incremented.
-    When either splitter intervals or events are exhausted, truncate the events
-    list to the current location of itOut.
-
-    This linear scanning ensures that
-    - it will only traverse the events once in the worst case.
-    - overlapping splitter intervals will be handled correctly.
-    - the memory usage is capped at the size of the events list.
-
-    The splitter intervals must be sorted by start time, which is not enforced
-    in this helper function and is expected to be implicitly followed by the
-    caller.
-
-    Also, a future version using TimeROI will automatically sort the intervals.
+ * This helper function uses a two pointer technique where
+ *  - itOut: the storage pointer
+ *  - itev: the scan pointer
+ *  When itev is traversing through the list of events, it will check against the
+ *  current splitter interval identified by itspl.
+ *
+ *  If itev->m_pulsetime is within the interval, the event, *itev, will be copied
+ *  to the location pointed by itOut, and itOut will be incremented.
+ *  When either splitter intervals or events are exhausted, truncate the events
+ *  list to the current location of itOut.
+ *
+ *  This linear scanning ensures that
+ *  - it will only traverse the events once in the worst case.
+ *  - overlapping splitter intervals will be handled correctly.
+ *  - the memory usage is capped at the size of the events list.
+ *
+ *  The splitter intervals must be sorted by start time, which is not enforced
+ *  in this helper function and is expected to be implicitly followed by the
+ *  caller.
+ *
+ *  Also, a future version using TimeROI will automatically sort the intervals.
  */
 template <class T>
 void EventList::filterInPlaceHelper(Kernel::TimeSplitterType &splitter, typename std::vector<T> &events) {

--- a/Framework/DataObjects/src/EventList.cpp
+++ b/Framework/DataObjects/src/EventList.cpp
@@ -3776,33 +3776,31 @@ void EventList::filterByTimeAtSample(Types::Core::DateAndTime start, Types::Core
  *indicate events
  *     that will be kept. Any other events will be deleted.
  * @param events :: either this->events or this->weightedEvents.
+ *
+ * @brief This helper function uses a two pointer technique where
+    - itOut: the storage pointer
+    - itev: the scan pointer
+    When itev is traversing through the list of events, it will check against the
+    current splitter interval identified by itspl.
+
+    If itev->m_pulsetime is within the interval, the event, *itev, will be copied
+    to the location pointed by itOut, and itOut will be incremented.
+    When either splitter intervals or events are exhausted, truncate the events
+    list to the current location of itOut.
+
+    This linear scanning ensures that
+    - it will only traverse the events once in the worst case.
+    - overlapping splitter intervals will be handled correctly.
+    - the memory usage is capped at the size of the events list.
+
+    The splitter intervals must be sorted by start time, which is not enforced
+    in this helper function and is expected to be implicitly followed by the
+    caller.
+
+    Also, a future version using TimeROI will automatically sort the intervals.
  */
 template <class T>
 void EventList::filterInPlaceHelper(Kernel::TimeSplitterType &splitter, typename std::vector<T> &events) {
-  // ---------
-  // DEV NOTES
-  // ---------
-  // The current algorithm for inplace filter is using a two pointer technique where
-  // - itOut: the storage pointer
-  // - itev: the scan pointer
-  // When itev is traversing through the list of events, it will check against the
-  // current splitter interval identified by itspl.
-  // If itev->m_pulsetime is within the interval, the event, *itev, will be copied
-  // to the location pointed by itOut, and itOut will be incremented.
-  // When either splitter intervals or events are exhausted, truncate the events list
-  // to the current location of itOut.
-  //
-  // This linear scanning ensures that
-  // - it will only traverse the events once in the worst case.
-  // - overlapping splitter intervals will be handled correctly.
-  // - the memory usage is capped at the size of the events list.
-  //
-  // Due to the linear scanning process, the splitter intervals must be sorted by
-  // start time, which is not enforced in this helper function and is expected to
-  // be implicitly followed by the caller.
-  //
-  // Also, a future version using TimeROI will automatically sort the intervals.
-
   // Iterate through the splitter at the same time
   auto itspl = splitter.begin();
   auto itspl_end = splitter.end();


### PR DESCRIPTION
**Description of work.**

- Original Gitlab Task: [SANS984](https://code.ornl.gov/sns-hfir-scse/sans/sans-backend/-/issues/984)
<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

tl;dr;
-----

Added developer notes as comments to explain the two pointer technique used in `EventList::filterInPlaceHelper`.

Details
--------

As part of the efforts in developing TimeROI, a refactor effort was proposed for `EventList` in preparation of the upcoming replacement of TimeSplitter.
The two pointer scanning technique used in `EventList::filterInPlaceHelper` was not clearly understood and was labeled for refactor process.
Upon close inspection, the current implementation is sufficiently optimized for TimeROI and it was decided that the refactor effort should be changed into a documentation update.

**To test:**

No testing is required as this is a in-code developer documentation improvement.

<!-- Instructions for testing. -->

<!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
