### PR TITLE
Remove dependence on FilteredTimeSeriesProperty from ISISRunLogs

### DIFF
--- a/Framework/DataHandling/test/LoadISISNexusTest.h
+++ b/Framework/DataHandling/test/LoadISISNexusTest.h
@@ -15,7 +15,6 @@
 #include "MantidDataHandling/LoadISISNexus2.h"
 #include "MantidGeometry/Instrument.h"
 #include "MantidKernel/ArrayProperty.h"
-#include "MantidKernel/FilteredTimeSeriesProperty.h"
 #include "MantidKernel/TimeSeriesProperty.h"
 
 #include <cmath>
@@ -64,7 +63,7 @@ private:
     // Check time series properties have been filtered by period
     p = nullptr;
     TSM_ASSERT_THROWS_NOTHING("Cannot retrieve stheta log", p = workspace->run().getLogData("stheta"));
-    auto stheta = dynamic_cast<FilteredTimeSeriesProperty<double> *>(p);
+    auto stheta = dynamic_cast<TimeSeriesProperty<double> *>(p);
     TSM_ASSERT("stheta log has not been converted to a FilteredTimeSeries", stheta);
     TS_ASSERT(42 > stheta->size());
   }

--- a/Framework/Kernel/inc/MantidKernel/ITimeSeriesProperty.h
+++ b/Framework/Kernel/inc/MantidKernel/ITimeSeriesProperty.h
@@ -36,6 +36,7 @@ public:
   // After trying to use return type covariance, but that showed Error C2908
   // Using property seemed to be the most straightforward solution.
   virtual Property *cloneWithTimeShift(const double timeShift) const = 0;
+  virtual void filterByTimes(const std::vector<SplittingInterval> &splittervec) = 0;
   /// Calculate the time-weighted average of a property in a filtered range
   virtual double averageValueInFilter(const std::vector<SplittingInterval> &filter) const = 0;
   /// Calculate the time-weighted average and standard deviation of a property

--- a/Framework/Kernel/inc/MantidKernel/TimeROI.h
+++ b/Framework/Kernel/inc/MantidKernel/TimeROI.h
@@ -23,6 +23,7 @@ public:
   TimeROI();
   TimeROI(const Types::Core::DateAndTime &startTime, const Types::Core::DateAndTime &stopTime);
   TimeROI(const Kernel::TimeSeriesProperty<bool> &filter);
+  TimeROI(const Kernel::TimeSeriesProperty<bool> *filter);
   double durationInSeconds() const;
   double durationInSeconds(const Types::Core::DateAndTime &startTime, const Types::Core::DateAndTime &stopTime) const;
   std::size_t numBoundaries() const;
@@ -48,6 +49,7 @@ public:
   void saveNexus(::NeXus::File *file) const;
 
 private:
+  void initializeFromTSP(const Kernel::TimeSeriesProperty<bool> *filter);
   std::vector<Types::Core::DateAndTime> getAllTimes(const TimeROI &other);
   void replaceValues(const std::vector<Types::Core::DateAndTime> &times, const std::vector<bool> &values);
   bool isCompletelyInROI(const Types::Core::DateAndTime &startTime, const Types::Core::DateAndTime &stopTime) const;

--- a/Framework/Kernel/inc/MantidKernel/TimeSeriesProperty.h
+++ b/Framework/Kernel/inc/MantidKernel/TimeSeriesProperty.h
@@ -136,7 +136,7 @@ public:
   /// Filter out a run by time.
   void filterByTime(const Types::Core::DateAndTime &start, const Types::Core::DateAndTime &stop) override;
   /// Filter by a range of times
-  void filterByTimes(const std::vector<SplittingInterval> &splittervec);
+  void filterByTimes(const std::vector<SplittingInterval> &splittervec) override;
 
   /// Split out a time series property by time intervals.
   void splitByTime(std::vector<SplittingInterval> &splitter, std::vector<Property *> outputs,

--- a/Framework/Kernel/src/PropertyManager.cpp
+++ b/Framework/Kernel/src/PropertyManager.cpp
@@ -215,11 +215,11 @@ void PropertyManager::filterByProperty(const Kernel::TimeSeriesProperty<bool> &f
       auto filterProp = getPointerToProperty(invalidFilterName);
       auto tspFilterProp = dynamic_cast<TimeSeriesProperty<bool> *>(filterProp);
       if (tspFilterProp) {
-        const auto splitter = TimeROI(tspFilterProp).toSplitters();
-        if (!splitter.empty()) {
+        const auto mysplitter = TimeROI(tspFilterProp).toSplitters();
+        if (!mysplitter.empty()) {
           auto prop = dynamic_cast<ITimeSeriesProperty *>(orderedProperty);
 
-          prop->filterByTimes(splitter);
+          prop->filterByTimes(mysplitter);
         }
       }
 

--- a/Framework/Kernel/src/PropertyManager.cpp
+++ b/Framework/Kernel/src/PropertyManager.cpp
@@ -197,6 +197,8 @@ void PropertyManager::filterByProperty(const Kernel::TimeSeriesProperty<bool> &f
                                        const std::vector<std::string> &excludedFromFiltering) {
   // convert to splitters
   const auto splitter = TimeROI(filter).toSplitters();
+  if (splitter.empty())
+    return;
 
   for (auto &orderedProperty : m_orderedProperties) {
     if (std::find(excludedFromFiltering.cbegin(), excludedFromFiltering.cend(), orderedProperty->name()) !=

--- a/Framework/Kernel/test/PropertyManagerTest.h
+++ b/Framework/Kernel/test/PropertyManagerTest.h
@@ -12,7 +12,6 @@
 #include "MantidKernel/ArrayProperty.h"
 #include "MantidKernel/BoundedValidator.h"
 #include "MantidKernel/EnabledWhenProperty.h"
-#include "MantidKernel/FilteredTimeSeriesProperty.h"
 #include "MantidKernel/MandatoryValidator.h"
 #include "MantidKernel/OptionalBool.h"
 #include "MantidKernel/PropertyManager.h"
@@ -118,13 +117,13 @@ public:
     for (auto iter : props) {
       Property *prop = iter;
       std::string msg = "Property " + prop->name() + " has not been changed to a FilteredTimeSeries";
-      auto filteredProp = dynamic_cast<FilteredTimeSeriesProperty<double> *>(iter);
+      auto filteredProp = dynamic_cast<TimeSeriesProperty<double> *>(iter);
       TSM_ASSERT(msg, filteredProp);
     }
 
     // Also check the single getter
     Property *log2 = manager.getProperty("log2");
-    auto filteredProp = dynamic_cast<FilteredTimeSeriesProperty<double> *>(log2);
+    auto filteredProp = dynamic_cast<TimeSeriesProperty<double> *>(log2);
     TSM_ASSERT("getProperty has not returned a FilteredProperty as expected", filteredProp);
 
     delete filter;


### PR DESCRIPTION
As part of #34794 this starts removing dependency on `FilteredTimeSeriesProperty` which is only used by one algorithm, `ISSRunLogs`. The change is to filter the logs the same way as everywhere else currently in mantid by removing and adding values for the various windows.

**To test:**

This is a refactor that should not break any existing tests.

*There is no associated issue.*

*This does not require release notes* because it is a refactor of underlying code.

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
