### PR TITLE
Add negative reflection option to indirect data manipulation symmetrise tab

### DIFF
--- a/docs/source/interfaces/indirect/Indirect Data Manipulation.rst
+++ b/docs/source/interfaces/indirect/Indirect Data Manipulation.rst
@@ -68,7 +68,7 @@ EMin & EMax
   Sets the energy range that is to be reflected about :math:`y=0`.
 
 Reflect Type
-  Wheather to do *Positive to Negative* or *Negative to Positive* reflection.
+  Whether to do *Positive to Negative* or *Negative to Positive* reflection.
 
 Spectrum No
   Changes the spectrum shown in the preview plots.

--- a/docs/source/interfaces/indirect/Indirect Data Manipulation.rst
+++ b/docs/source/interfaces/indirect/Indirect Data Manipulation.rst
@@ -42,9 +42,16 @@ Symmetrise
 This tab allows you to take an asymmetric reduced file (*_red.nxs*) and symmetrise it about
 the Y axis.
 
-The curve is symmetrised such that the range of positive values between :math:`EMin`
+The curve can be symmetrised using two methods depending on the value of **Reflect Type**:
+
+1. *Positive to Negative* (default): the range of the positive values between :math:`EMin`
 and :math:`EMax` are reflected about the Y axis and replaces the negative values
 in the range :math:`-EMax` to :math:`-EMin`, the curve between :math:`-EMin` and
+:math:`EMin` is not modified.
+
+2. *Negative to Positive*: the range of the negative values between :math:`-EMax`
+and :math:`EMin` are reflected about the Y axis and replaces the positive values
+in the range :math:`EMin` to :math:`-EMax`, the curve between :math:`-EMin` and
 :math:`EMin` is not modified.
 
 .. interface:: Data Manipulation
@@ -59,6 +66,9 @@ Input
 
 EMin & EMax
   Sets the energy range that is to be reflected about :math:`y=0`.
+
+Reflect Type
+  Wheather to do *Positive to Negative* or *Negative to Positive* reflection.
 
 Spectrum No
   Changes the spectrum shown in the preview plots.

--- a/docs/source/interfaces/indirect/Indirect Data Manipulation.rst
+++ b/docs/source/interfaces/indirect/Indirect Data Manipulation.rst
@@ -129,7 +129,7 @@ produce this file is IRIS, the analyser is graphite and the reflection is 002. S
 
 4. Click **Run** and wait for the interface to finish processing. This will run the
    :ref:`Symmetrise <algm-Symmetrise>` algorithm. The output workspace is called
-   ``iris26176_graphite002_sym_red``.
+   ``iris26176_graphite002_sym_pn_red``.
 
 5. Click **Plot Spectra** to produce a spectra plot of the output workspace. Other indices can be
    plotted by entering indices in the box next to the **Plot Spectra** button. For example,

--- a/docs/source/release/v6.6.0/Indirect/New_features/34633.rst
+++ b/docs/source/release/v6.6.0/Indirect/New_features/34633.rst
@@ -1,0 +1,1 @@
+- Add option for negative reflection to the indrect data manipulation symmetrise tab

--- a/qt/scientific_interfaces/Indirect/InelasticDataManipulationSymmetriseTab.cpp
+++ b/qt/scientific_interfaces/Indirect/InelasticDataManipulationSymmetriseTab.cpp
@@ -34,8 +34,10 @@ InelasticDataManipulationSymmetriseTab::InelasticDataManipulationSymmetriseTab(Q
 
   // SIGNAL/SLOT CONNECTIONS
   // Preview symmetrise
-  connect(m_view.get(), SIGNAL(valueChanged(QtProperty *, double)), this,
-          SLOT(handleValueChanged(QtProperty *, double)));
+  connect(m_view.get(), SIGNAL(doubleValueChanged(QtProperty *, double)), this,
+          SLOT(handleDoubleValueChanged(QtProperty *, double)));
+  connect(m_view.get(), SIGNAL(enumValueChanged(QtProperty *, int)), this,
+          SLOT(handleEnumValueChanged(QtProperty *, int)));
   connect(m_view.get(), SIGNAL(dataReady(QString const &)), this, SLOT(handleDataReady(QString const &)));
   connect(m_view.get(), SIGNAL(previewClicked()), this, SLOT(preview()));
   // Handle running, plotting and saving
@@ -148,7 +150,13 @@ void InelasticDataManipulationSymmetriseTab::setFileExtensionsByName(bool filter
   m_view->setWSSuffixes(filter ? getSampleWSSuffixes(tabName) : noSuffixes);
 }
 
-void InelasticDataManipulationSymmetriseTab::handleValueChanged(QtProperty *prop, double value) {
+void InelasticDataManipulationSymmetriseTab::handleEnumValueChanged(QtProperty *prop, int value) {
+  if (prop->propertyName() == "Reflect Type") {
+    m_model->setIsPositiveReflect(value == 0);
+  }
+}
+
+void InelasticDataManipulationSymmetriseTab::handleDoubleValueChanged(QtProperty *prop, double value) {
   if (prop->propertyName() == "Spectrum No") {
     m_view->replotNewSpectrum(value);
   } else if (prop->propertyName() == "EMin") {

--- a/qt/scientific_interfaces/Indirect/InelasticDataManipulationSymmetriseTab.h
+++ b/qt/scientific_interfaces/Indirect/InelasticDataManipulationSymmetriseTab.h
@@ -51,7 +51,8 @@ public:
   bool validate() override;
 
 private slots:
-  void handleValueChanged(QtProperty *, double);
+  void handleEnumValueChanged(QtProperty *, int);
+  void handleDoubleValueChanged(QtProperty *, double);
   void handleDataReady(QString const &dataName) override;
   void algorithmComplete(bool error);
   void preview();

--- a/qt/scientific_interfaces/Indirect/InelasticDataManipulationSymmetriseTabModel.cpp
+++ b/qt/scientific_interfaces/Indirect/InelasticDataManipulationSymmetriseTabModel.cpp
@@ -36,7 +36,7 @@ void InelasticDataManipulationSymmetriseTabModel::setupPreviewAlgorithm(
   // not accessed by users directly.
   IAlgorithm_sptr symmetriseAlg = AlgorithmManager::Instance().create("Symmetrise");
   symmetriseAlg->initialize();
-  symmetriseAlg->setProperty("InputWorkspace", m_isPositiveReflect ? m_inputWorkspace : m_refelctedInputWorkspace);
+  symmetriseAlg->setProperty("InputWorkspace", m_isPositiveReflect ? m_inputWorkspace : m_reflctedInputWorkspace);
   symmetriseAlg->setProperty("XMin", m_eMin);
   symmetriseAlg->setProperty("XMax", m_eMax);
   symmetriseAlg->setProperty("SpectraRange", spectraRange);
@@ -55,7 +55,7 @@ std::string InelasticDataManipulationSymmetriseTabModel::setupSymmetriseAlgorith
   }
   IAlgorithm_sptr symmetriseAlg = AlgorithmManager::Instance().create("Symmetrise");
   symmetriseAlg->initialize();
-  symmetriseAlg->setProperty("InputWorkspace", m_isPositiveReflect ? m_inputWorkspace : m_refelctedInputWorkspace);
+  symmetriseAlg->setProperty("InputWorkspace", m_isPositiveReflect ? m_inputWorkspace : m_reflctedInputWorkspace);
   symmetriseAlg->setProperty("XMin", m_eMin);
   symmetriseAlg->setProperty("XMax", m_eMax);
   symmetriseAlg->setProperty("OutputWorkspace", m_outputWorkspace);
@@ -71,19 +71,19 @@ void InelasticDataManipulationSymmetriseTabModel::reflectNegativeToPositive() {
   scaleXAlg->setProperty("InputWorkspace", m_inputWorkspace);
   scaleXAlg->setProperty("Operation", "Multiply");
   scaleXAlg->setProperty("Factor", -1.0);
-  scaleXAlg->setProperty("OutputWorkspace", m_refelctedInputWorkspace);
+  scaleXAlg->setProperty("OutputWorkspace", m_reflctedInputWorkspace);
   scaleXAlg->execute();
 
   IAlgorithm_sptr sortXAxisAlg = AlgorithmManager::Instance().create("SortXAxis");
   sortXAxisAlg->initialize();
-  sortXAxisAlg->setProperty("InputWorkspace", m_refelctedInputWorkspace);
-  sortXAxisAlg->setProperty("OutputWorkspace", m_refelctedInputWorkspace);
+  sortXAxisAlg->setProperty("InputWorkspace", m_reflctedInputWorkspace);
+  sortXAxisAlg->setProperty("OutputWorkspace", m_reflctedInputWorkspace);
   sortXAxisAlg->execute();
 }
 
 void InelasticDataManipulationSymmetriseTabModel::setWorkspaceName(QString workspaceName) {
   m_inputWorkspace = workspaceName.toStdString();
-  m_refelctedInputWorkspace = m_inputWorkspace + "_reflected";
+  m_reflctedInputWorkspace = m_inputWorkspace + "_reflected";
   // the last 4 characters in the workspace name are '_red' the ouput weorkspace name is inserting '_sym' before that
   // '_red'
   m_outputWorkspace = (workspaceName.left(workspaceName.length() - 4) + "_sym" + workspaceName.right(4)).toStdString();

--- a/qt/scientific_interfaces/Indirect/InelasticDataManipulationSymmetriseTabModel.cpp
+++ b/qt/scientific_interfaces/Indirect/InelasticDataManipulationSymmetriseTabModel.cpp
@@ -30,7 +30,7 @@ void InelasticDataManipulationSymmetriseTabModel::setupPreviewAlgorithm(
     MantidQt::API::BatchAlgorithmRunner *batchAlgoRunner, std::vector<long> spectraRange) {
 
   if (!m_isPositiveReflect) {
-    reflectNegativeToPositive(batchAlgoRunner);
+    reflectNegativeToPositive();
   }
   // Run the algorithm on the preview spectrum only, these outputs are only for plotting in the preview window and are
   // not accessed by users directly.
@@ -51,7 +51,7 @@ std::string InelasticDataManipulationSymmetriseTabModel::setupSymmetriseAlgorith
     MantidQt::API::BatchAlgorithmRunner *batchAlgoRunner) {
 
   if (!m_isPositiveReflect) {
-    reflectNegativeToPositive(batchAlgoRunner);
+    reflectNegativeToPositive();
   }
   IAlgorithm_sptr symmetriseAlg = AlgorithmManager::Instance().create("Symmetrise");
   symmetriseAlg->initialize();

--- a/qt/scientific_interfaces/Indirect/InelasticDataManipulationSymmetriseTabModel.cpp
+++ b/qt/scientific_interfaces/Indirect/InelasticDataManipulationSymmetriseTabModel.cpp
@@ -65,8 +65,7 @@ std::string InelasticDataManipulationSymmetriseTabModel::setupSymmetriseAlgorith
   return m_outputWorkspace;
 }
 
-void InelasticDataManipulationSymmetriseTabModel::reflectNegativeToPositive(
-    MantidQt::API::BatchAlgorithmRunner *batchAlgoRunner) {
+void InelasticDataManipulationSymmetriseTabModel::reflectNegativeToPositive() {
   IAlgorithm_sptr scaleXAlg = AlgorithmManager::Instance().create("ScaleX");
   scaleXAlg->initialize();
   scaleXAlg->setProperty("InputWorkspace", m_inputWorkspace);

--- a/qt/scientific_interfaces/Indirect/InelasticDataManipulationSymmetriseTabModel.cpp
+++ b/qt/scientific_interfaces/Indirect/InelasticDataManipulationSymmetriseTabModel.cpp
@@ -28,11 +28,15 @@ InelasticDataManipulationSymmetriseTabModel::InelasticDataManipulationSymmetrise
 
 void InelasticDataManipulationSymmetriseTabModel::setupPreviewAlgorithm(
     MantidQt::API::BatchAlgorithmRunner *batchAlgoRunner, std::vector<long> spectraRange) {
+
+  if (!m_isPositiveReflect) {
+    reflectNegativeToPositive(batchAlgoRunner);
+  }
   // Run the algorithm on the preview spectrum only, these outputs are only for plotting in the preview window and are
   // not accessed by users directly.
   IAlgorithm_sptr symmetriseAlg = AlgorithmManager::Instance().create("Symmetrise");
   symmetriseAlg->initialize();
-  symmetriseAlg->setProperty("InputWorkspace", m_inputWorkspace);
+  symmetriseAlg->setProperty("InputWorkspace", m_isPositiveReflect ? m_inputWorkspace : m_refelctedInputWorkspace);
   symmetriseAlg->setProperty("XMin", m_eMin);
   symmetriseAlg->setProperty("XMax", m_eMax);
   symmetriseAlg->setProperty("SpectraRange", spectraRange);
@@ -45,9 +49,13 @@ void InelasticDataManipulationSymmetriseTabModel::setupPreviewAlgorithm(
 
 std::string InelasticDataManipulationSymmetriseTabModel::setupSymmetriseAlgorithm(
     MantidQt::API::BatchAlgorithmRunner *batchAlgoRunner) {
+
+  if (!m_isPositiveReflect) {
+    reflectNegativeToPositive(batchAlgoRunner);
+  }
   IAlgorithm_sptr symmetriseAlg = AlgorithmManager::Instance().create("Symmetrise");
   symmetriseAlg->initialize();
-  symmetriseAlg->setProperty("InputWorkspace", m_inputWorkspace);
+  symmetriseAlg->setProperty("InputWorkspace", m_isPositiveReflect ? m_inputWorkspace : m_refelctedInputWorkspace);
   symmetriseAlg->setProperty("XMin", m_eMin);
   symmetriseAlg->setProperty("XMax", m_eMax);
   symmetriseAlg->setProperty("OutputWorkspace", m_outputWorkspace);
@@ -57,8 +65,26 @@ std::string InelasticDataManipulationSymmetriseTabModel::setupSymmetriseAlgorith
   return m_outputWorkspace;
 }
 
+void InelasticDataManipulationSymmetriseTabModel::reflectNegativeToPositive(
+    MantidQt::API::BatchAlgorithmRunner *batchAlgoRunner) {
+  IAlgorithm_sptr scaleXAlg = AlgorithmManager::Instance().create("ScaleX");
+  scaleXAlg->initialize();
+  scaleXAlg->setProperty("InputWorkspace", m_inputWorkspace);
+  scaleXAlg->setProperty("Operation", "Multiply");
+  scaleXAlg->setProperty("Factor", -1.0);
+  scaleXAlg->setProperty("OutputWorkspace", m_refelctedInputWorkspace);
+  scaleXAlg->execute();
+
+  IAlgorithm_sptr sortXAxisAlg = AlgorithmManager::Instance().create("SortXAxis");
+  sortXAxisAlg->initialize();
+  sortXAxisAlg->setProperty("InputWorkspace", m_refelctedInputWorkspace);
+  sortXAxisAlg->setProperty("OutputWorkspace", m_refelctedInputWorkspace);
+  sortXAxisAlg->execute();
+}
+
 void InelasticDataManipulationSymmetriseTabModel::setWorkspaceName(QString workspaceName) {
   m_inputWorkspace = workspaceName.toStdString();
+  m_refelctedInputWorkspace = m_inputWorkspace + "_reflected";
   // the last 4 characters in the workspace name are '_red' the ouput weorkspace name is inserting '_sym' before that
   // '_red'
   m_outputWorkspace = (workspaceName.left(workspaceName.length() - 4) + "_sym" + workspaceName.right(4)).toStdString();
@@ -67,5 +93,7 @@ void InelasticDataManipulationSymmetriseTabModel::setWorkspaceName(QString works
 void InelasticDataManipulationSymmetriseTabModel::setEMin(double value) { m_eMin = value; }
 
 void InelasticDataManipulationSymmetriseTabModel::setEMax(double value) { m_eMax = value; }
+
+void InelasticDataManipulationSymmetriseTabModel::setIsPositiveReflect(bool value) { m_isPositiveReflect = value; }
 
 } // namespace MantidQt::CustomInterfaces

--- a/qt/scientific_interfaces/Indirect/InelasticDataManipulationSymmetriseTabModel.cpp
+++ b/qt/scientific_interfaces/Indirect/InelasticDataManipulationSymmetriseTabModel.cpp
@@ -50,19 +50,22 @@ void InelasticDataManipulationSymmetriseTabModel::setupPreviewAlgorithm(
 std::string InelasticDataManipulationSymmetriseTabModel::setupSymmetriseAlgorithm(
     MantidQt::API::BatchAlgorithmRunner *batchAlgoRunner) {
 
+  std::string outputWorkspace = m_positiveOutputWorkspace;
   if (!m_isPositiveReflect) {
     reflectNegativeToPositive();
+    outputWorkspace = m_negativeOutputWorkspace;
   }
+
   IAlgorithm_sptr symmetriseAlg = AlgorithmManager::Instance().create("Symmetrise");
   symmetriseAlg->initialize();
   symmetriseAlg->setProperty("InputWorkspace", m_isPositiveReflect ? m_inputWorkspace : m_reflctedInputWorkspace);
   symmetriseAlg->setProperty("XMin", m_eMin);
   symmetriseAlg->setProperty("XMax", m_eMax);
-  symmetriseAlg->setProperty("OutputWorkspace", m_outputWorkspace);
+  symmetriseAlg->setProperty("OutputWorkspace", outputWorkspace);
   symmetriseAlg->setProperty("OutputPropertiesTable", "__SymmetriseProps_temp");
 
   batchAlgoRunner->addAlgorithm(symmetriseAlg);
-  return m_outputWorkspace;
+  return outputWorkspace;
 }
 
 void InelasticDataManipulationSymmetriseTabModel::reflectNegativeToPositive() {
@@ -86,7 +89,10 @@ void InelasticDataManipulationSymmetriseTabModel::setWorkspaceName(QString works
   m_reflctedInputWorkspace = m_inputWorkspace + "_reflected";
   // the last 4 characters in the workspace name are '_red' the ouput weorkspace name is inserting '_sym' before that
   // '_red'
-  m_outputWorkspace = (workspaceName.left(workspaceName.length() - 4) + "_sym" + workspaceName.right(4)).toStdString();
+  m_positiveOutputWorkspace =
+      (workspaceName.left(workspaceName.length() - 4) + "_sym" + "_pn" + workspaceName.right(4)).toStdString();
+  m_negativeOutputWorkspace =
+      (workspaceName.left(workspaceName.length() - 4) + "_sym" + "_np" + workspaceName.right(4)).toStdString();
 }
 
 void InelasticDataManipulationSymmetriseTabModel::setEMin(double value) { m_eMin = value; }

--- a/qt/scientific_interfaces/Indirect/InelasticDataManipulationSymmetriseTabModel.h
+++ b/qt/scientific_interfaces/Indirect/InelasticDataManipulationSymmetriseTabModel.h
@@ -33,7 +33,8 @@ public:
 private:
   std::string m_inputWorkspace;
   std::string m_reflctedInputWorkspace;
-  std::string m_outputWorkspace;
+  std::string m_negativeOutputWorkspace;
+  std::string m_positiveOutputWorkspace;
   double m_eMin;
   double m_eMax;
   bool m_isPositiveReflect;

--- a/qt/scientific_interfaces/Indirect/InelasticDataManipulationSymmetriseTabModel.h
+++ b/qt/scientific_interfaces/Indirect/InelasticDataManipulationSymmetriseTabModel.h
@@ -32,7 +32,7 @@ public:
 
 private:
   std::string m_inputWorkspace;
-  std::string m_refelctedInputWorkspace;
+  std::string m_reflctedInputWorkspace;
   std::string m_outputWorkspace;
   double m_eMin;
   double m_eMax;

--- a/qt/scientific_interfaces/Indirect/InelasticDataManipulationSymmetriseTabModel.h
+++ b/qt/scientific_interfaces/Indirect/InelasticDataManipulationSymmetriseTabModel.h
@@ -24,15 +24,19 @@ public:
   ~InelasticDataManipulationSymmetriseTabModel() = default;
   void setupPreviewAlgorithm(MantidQt::API::BatchAlgorithmRunner *batchAlgoRunner, std::vector<long> spectraRange);
   std::string setupSymmetriseAlgorithm(MantidQt::API::BatchAlgorithmRunner *batchAlgoRunner);
+  void reflectNegativeToPositive(MantidQt::API::BatchAlgorithmRunner *batchAlgoRunner);
   void setWorkspaceName(QString workspaceName);
   void setEMin(double value);
   void setEMax(double value);
+  void setIsPositiveReflect(bool value);
 
 private:
   std::string m_inputWorkspace;
+  std::string m_refelctedInputWorkspace;
   std::string m_outputWorkspace;
   double m_eMin;
   double m_eMax;
+  bool m_isPositiveReflect;
   std::vector<long> m_spectraRange;
 };
 

--- a/qt/scientific_interfaces/Indirect/InelasticDataManipulationSymmetriseTabModel.h
+++ b/qt/scientific_interfaces/Indirect/InelasticDataManipulationSymmetriseTabModel.h
@@ -24,7 +24,7 @@ public:
   ~InelasticDataManipulationSymmetriseTabModel() = default;
   void setupPreviewAlgorithm(MantidQt::API::BatchAlgorithmRunner *batchAlgoRunner, std::vector<long> spectraRange);
   std::string setupSymmetriseAlgorithm(MantidQt::API::BatchAlgorithmRunner *batchAlgoRunner);
-  void reflectNegativeToPositive(MantidQt::API::BatchAlgorithmRunner *batchAlgoRunner);
+  void reflectNegativeToPositive();
   void setWorkspaceName(QString workspaceName);
   void setEMin(double value);
   void setEMax(double value);

--- a/qt/scientific_interfaces/Indirect/InelasticDataManipulationSymmetriseTabView.h
+++ b/qt/scientific_interfaces/Indirect/InelasticDataManipulationSymmetriseTabView.h
@@ -9,6 +9,7 @@
 #include "MantidAPI/MatrixWorkspace.h"
 #include "MantidQtWidgets/Common/QtPropertyBrowser/DoubleEditorFactory.h"
 #include "MantidQtWidgets/Common/QtPropertyBrowser/QtTreePropertyBrowser"
+#include "MantidQtWidgets/Common/QtPropertyBrowser/qteditorfactory.h"
 #include "MantidQtWidgets/Common/QtPropertyBrowser/qtpropertymanager.h"
 #include "MantidQtWidgets/Plotting/RangeSelector.h"
 #include "ui_InelasticDataManipulationSymmetriseTab.h"
@@ -46,7 +47,8 @@ public slots:
                        QString const &message = "Run", QString const &tooltip = "");
 
 signals:
-  void valueChanged(QtProperty *, double);
+  void doubleValueChanged(QtProperty *, double);
+  void enumValueChanged(QtProperty *, int);
   void dataReady(QString const &);
   void previewClicked();
   void runClicked();
@@ -56,10 +58,12 @@ signals:
 private slots:
   void xRangeMaxChanged(double value);
   void xRangeMinChanged(double value);
+  void reflectTypeChanged(QtProperty *, int value);
 
 private:
   void setRunEnabled(bool enabled);
   void setSaveEnabled(bool enabled);
+  void resetEDefaults(bool isPositive, QPair<double, double> range);
   Ui::InelasticDataManipulationSymmetriseTab m_uiForm;
 
   /// Tree of the properties
@@ -68,6 +72,7 @@ private:
   QMap<QString, QtProperty *> m_properties;
   QtDoublePropertyManager *m_dblManager;
   QtGroupPropertyManager *m_grpManager;
+  QtEnumPropertyManager *m_enumManager;
 };
 } // namespace CustomInterfaces
 } // namespace MantidQt

--- a/qt/scientific_interfaces/Indirect/test/InelasticDataManipulationSymmetriseTabModelTest.h
+++ b/qt/scientific_interfaces/Indirect/test/InelasticDataManipulationSymmetriseTabModelTest.h
@@ -9,11 +9,55 @@
 #include "IndirectDataValidationHelper.h"
 #include "InelasticDataManipulationSymmetriseTabModel.h"
 #include "MantidAPI/AnalysisDataService.h"
+#include "MantidAPI/ITableWorkspace.h"
+#include "MantidAPI/TableRow.h"
 #include "MantidFrameworkTestHelpers/WorkspaceCreationHelper.h"
 #include <cxxtest/TestSuite.h>
 #include <gmock/gmock.h>
 
 using namespace MantidQt::CustomInterfaces;
+
+class Symmetrise : public Algorithm {
+public:
+  const std::string name() const override { return "Symmetrise"; };
+  int version() const override { return 1; };
+  const std::string summary() const override { return "Symmetrise Mock algorithm"; };
+
+private:
+  void init() override {
+    declareProperty("InputWorkspace", "InputWorkspace");
+
+    declareProperty("OutputWorkspace", "OutputWorkspace");
+    declareProperty("OutputPropertiesTable", "OutputPropertiesTable");
+
+    declareProperty("SpectraRange", std::vector<long>{0, 2});
+    declareProperty("XMin", 0.05);
+    declareProperty("XMax", 0.6);
+  };
+
+  void exec() override {
+    ITableWorkspace_sptr outputWS = WorkspaceFactory::Instance().createTable();
+    outputWS->addColumn("str", "InputWorkspace");
+    outputWS->addColumn("str", "OutputWorkspace");
+    outputWS->addColumn("str", "OutputPropertiesTable");
+    outputWS->addColumn("str", "SpectraRange");
+    outputWS->addColumn("double", "XMin");
+    outputWS->addColumn("double", "XMax");
+
+    TableRow newRow = outputWS->appendRow();
+    auto inWS = getPropertyValue("InputWorkspace");
+    auto outWs = getPropertyValue("OutputWorkspace");
+    auto outPropWs = getPropertyValue("OutputPropertiesTable");
+    auto spectraRange = getPropertyValue("SpectraRange");
+    double xMin = getProperty("XMin");
+    double xMax = getProperty("XMax");
+
+    newRow << inWS << outWs << outPropWs << spectraRange << xMin << xMax;
+
+    Mantid::API::AnalysisDataService::Instance().addOrReplace("outputWS", outputWS);
+  };
+};
+DECLARE_ALGORITHM(Symmetrise)
 
 class InelasticDataManipulationSymmetriseTabModelTest : public CxxTest::TestSuite {
 public:
@@ -24,14 +68,108 @@ public:
 
   void tearDown() override { AnalysisDataService::Instance().clear(); }
 
-  void test_setupPropertiesAlgorithm() {
+  void test_preview_positive_setup() {
     QString inputWS = "Workspace_name_red";
     m_workspace = WorkspaceCreationHelper::createProcessedWorkspaceWithCylComplexInstrument(5, 6, true);
+
     Mantid::API::AnalysisDataService::Instance().addOrReplace(inputWS.toStdString(), m_workspace);
     MantidQt::API::BatchAlgorithmRunner batch;
+
     m_model->setEMin(0.05);
     m_model->setEMax(0.6);
     m_model->setWorkspaceName(inputWS);
+    m_model->setIsPositiveReflect(true);
+
+    std::vector<long> spectraRange(2, 4);
+    m_model->setupPreviewAlgorithm(&batch, spectraRange);
+    batch.executeBatch();
+
+    ITableWorkspace_sptr outputWS =
+        Mantid::API::AnalysisDataService::Instance().retrieveWS<Mantid::DataObjects::TableWorkspace>("outputWS");
+
+    TS_ASSERT_EQUALS(outputWS->cell<std::string>(0, 0), "Workspace_name_red");
+    TS_ASSERT_EQUALS(outputWS->cell<std::string>(0, 1), "__Symmetrise_temp");
+    TS_ASSERT_EQUALS(outputWS->cell<std::string>(0, 2), "__SymmetriseProps_temp");
+    TS_ASSERT_EQUALS(outputWS->cell<std::string>(0, 3), "4,4");
+    TS_ASSERT_EQUALS(outputWS->cell<double>(0, 4), 0.05);
+    TS_ASSERT_EQUALS(outputWS->cell<double>(0, 5), 0.6);
+  }
+
+  void test_preview_negative_setup() {
+    QString inputWS = "Workspace_name_red";
+    m_workspace = WorkspaceCreationHelper::createProcessedWorkspaceWithCylComplexInstrument(5, 6, true);
+
+    Mantid::API::AnalysisDataService::Instance().addOrReplace(inputWS.toStdString(), m_workspace);
+    MantidQt::API::BatchAlgorithmRunner batch;
+
+    m_model->setEMin(0.05);
+    m_model->setEMax(0.6);
+    m_model->setWorkspaceName(inputWS);
+    m_model->setIsPositiveReflect(false);
+
+    std::vector<long> spectraRange(2, 4);
+    m_model->setupPreviewAlgorithm(&batch, spectraRange);
+    batch.executeBatch();
+
+    ITableWorkspace_sptr outputWS =
+        Mantid::API::AnalysisDataService::Instance().retrieveWS<Mantid::DataObjects::TableWorkspace>("outputWS");
+
+    TS_ASSERT_EQUALS(outputWS->cell<std::string>(0, 0), "Workspace_name_red_reflected");
+    TS_ASSERT_EQUALS(outputWS->cell<std::string>(0, 1), "__Symmetrise_temp");
+    TS_ASSERT_EQUALS(outputWS->cell<std::string>(0, 2), "__SymmetriseProps_temp");
+    TS_ASSERT_EQUALS(outputWS->cell<std::string>(0, 3), "4,4");
+    TS_ASSERT_EQUALS(outputWS->cell<double>(0, 4), 0.05);
+    TS_ASSERT_EQUALS(outputWS->cell<double>(0, 5), 0.6);
+  }
+
+  void test_run_positive_setup() {
+    QString inputWS = "Workspace_name_red";
+    m_workspace = WorkspaceCreationHelper::createProcessedWorkspaceWithCylComplexInstrument(5, 6, true);
+
+    Mantid::API::AnalysisDataService::Instance().addOrReplace(inputWS.toStdString(), m_workspace);
+    MantidQt::API::BatchAlgorithmRunner batch;
+
+    m_model->setEMin(0.05);
+    m_model->setEMax(0.6);
+    m_model->setWorkspaceName(inputWS);
+    m_model->setIsPositiveReflect(true);
+
+    m_model->setupSymmetriseAlgorithm(&batch);
+    batch.executeBatch();
+
+    ITableWorkspace_sptr outputWS =
+        Mantid::API::AnalysisDataService::Instance().retrieveWS<Mantid::DataObjects::TableWorkspace>("outputWS");
+
+    TS_ASSERT_EQUALS(outputWS->cell<std::string>(0, 0), "Workspace_name_red");
+    TS_ASSERT_EQUALS(outputWS->cell<std::string>(0, 1), "Workspace_name_sym_pn_red");
+    TS_ASSERT_EQUALS(outputWS->cell<std::string>(0, 2), "__SymmetriseProps_temp");
+    TS_ASSERT_EQUALS(outputWS->cell<double>(0, 4), 0.05);
+    TS_ASSERT_EQUALS(outputWS->cell<double>(0, 5), 0.6);
+  }
+
+  void test_run_negative_setup() {
+    QString inputWS = "Workspace_name_red";
+    m_workspace = WorkspaceCreationHelper::createProcessedWorkspaceWithCylComplexInstrument(5, 6, true);
+
+    Mantid::API::AnalysisDataService::Instance().addOrReplace(inputWS.toStdString(), m_workspace);
+    MantidQt::API::BatchAlgorithmRunner batch;
+
+    m_model->setEMin(0.05);
+    m_model->setEMax(0.6);
+    m_model->setWorkspaceName(inputWS);
+    m_model->setIsPositiveReflect(false);
+
+    m_model->setupSymmetriseAlgorithm(&batch);
+    batch.executeBatch();
+
+    ITableWorkspace_sptr outputWS =
+        Mantid::API::AnalysisDataService::Instance().retrieveWS<Mantid::DataObjects::TableWorkspace>("outputWS");
+
+    TS_ASSERT_EQUALS(outputWS->cell<std::string>(0, 0), "Workspace_name_red_reflected");
+    TS_ASSERT_EQUALS(outputWS->cell<std::string>(0, 1), "Workspace_name_sym_np_red");
+    TS_ASSERT_EQUALS(outputWS->cell<std::string>(0, 2), "__SymmetriseProps_temp");
+    TS_ASSERT_EQUALS(outputWS->cell<double>(0, 4), 0.05);
+    TS_ASSERT_EQUALS(outputWS->cell<double>(0, 5), 0.6);
   }
 
 private:


### PR DESCRIPTION
**Description of work.**
This PR adds an option for negative reflection in the indirect data manipulation symmetrize tab. Previously, the user can only reflect the positive range of the x values to the negative range but now they can reflect the negative range of the x values to the positive.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**

<!-- Instructions for testing. -->
Go to Interfaces->Inelastic->Data Manipulation->symmetrise:
1- Load some data 
2- Try both the "Positive to Negative" and "Negative to Positive" options
3- Make sure when you change the option the values of the EMin and EMax are reset to the default values (EMax is the maximum x value in the given direction (negative or positive) and Emin is 0.1 times the EMax)

Fixes #34633. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
