### PR TITLE
Tests for time averages

### DIFF
--- a/Framework/API/inc/MantidAPI/LogManager.h
+++ b/Framework/API/inc/MantidAPI/LogManager.h
@@ -30,6 +30,7 @@ template <typename TYPE> class TimeSeriesProperty;
 class SplittingInterval;
 using TimeSplitterType = std::vector<SplittingInterval>;
 class PropertyManager;
+class TimeROI;
 } // namespace Kernel
 
 namespace API {
@@ -196,6 +197,7 @@ protected:
   void loadNexus(::NeXus::File *file, const std::map<std::string, std::string> &entries);
   /// A pointer to a property manager
   std::unique_ptr<Kernel::PropertyManager> m_manager;
+  std::unique_ptr<Kernel::TimeROI> m_timeroi;
   /// Name of the log entry containing the proton charge when retrieved using
   /// getProtonCharge
   static const char *PROTON_CHARGE_LOG_NAME;

--- a/Framework/API/inc/MantidAPI/LogManager.h
+++ b/Framework/API/inc/MantidAPI/LogManager.h
@@ -160,6 +160,9 @@ public:
   /// Empty all but the last value out of all TimeSeriesProperty logs
   void clearOutdatedTimeSeriesLogValues();
 
+  const Kernel::TimeROI &timeROI() const;
+  void timeROI(const Kernel::TimeROI &);
+
   /// Save the run to a NeXus file with a given group name
   virtual void saveNexus(::NeXus::File *file, const std::string &group, bool keepOpen = false) const;
 
@@ -180,6 +183,9 @@ public:
   virtual void loadNexus(::NeXus::File *file, const std::string &group, bool keepOpen = false);
   /// Clear the logs
   void clearLogs();
+
+  /// Clear ou the cache of calculated statistics
+  void clearSingleValueCache();
 
   // returns true if the log has a matching invalid values log filter
   bool hasInvalidValuesFilter(const std::string &logName) const;
@@ -204,7 +210,8 @@ protected:
 
 private:
   /// Cache for the retrieved single values
-  std::unique_ptr<Kernel::Cache<std::pair<std::string, Kernel::Math::StatisticType>, double>> m_singleValueCache;
+  mutable std::unique_ptr<Kernel::Cache<std::pair<std::string, Kernel::Math::StatisticType>, double>>
+      m_singleValueCache;
 };
 /// shared pointer to the logManager base class
 using LogManager_sptr = std::shared_ptr<LogManager>;

--- a/Framework/API/src/LogManager.cpp
+++ b/Framework/API/src/LogManager.cpp
@@ -238,7 +238,7 @@ void LogManager::splitByTime(TimeSplitterType &splitter, std::vector<LogManager 
 void LogManager::filterByLog(const Kernel::TimeSeriesProperty<bool> &filter,
                              const std::vector<std::string> &excludedFromFiltering) {
   // This will invalidate the cache
-  m_singleValueCache->clear();
+  this->clearSingleValueCache();
   m_manager->filterByProperty(filter, excludedFromFiltering);
 }
 
@@ -297,12 +297,13 @@ const std::vector<Kernel::Property *> &LogManager::getProperties() const { retur
 /** Return the total memory used by the run object, in bytes.
  */
 size_t LogManager::getMemorySize() const {
-  size_t total = 0;
-  std::vector<Property *> props = m_manager->getProperties();
-  for (auto p : props) {
+  size_t total{m_timeroi->getMemorySize()};
+
+  for (const auto &p : m_manager->getProperties()) {
     if (p)
       total += p->getMemorySize() + sizeof(Property *);
   }
+
   return total;
 }
 
@@ -441,6 +442,10 @@ void LogManager::clearOutdatedTimeSeriesLogValues() {
     }
   }
 }
+
+const Kernel::TimeROI &LogManager::timeROI() const { return *(m_timeroi.get()); }
+
+void LogManager::timeROI(const Kernel::TimeROI &timeroi) { m_timeroi->replaceROI(timeroi); }
 
 //--------------------------------------------------------------------------------------------
 /** Save the object to an open NeXus file.
@@ -588,6 +593,8 @@ void LogManager::loadNexus(::NeXus::File *file, const std::map<std::string, std:
  * Clear the logs.
  */
 void LogManager::clearLogs() { m_manager->clear(); }
+
+void LogManager::clearSingleValueCache() { m_singleValueCache->clear(); }
 
 /// Gets the correct log name for the matching invalid values log for a given
 /// log name

--- a/Framework/API/src/LogManager.cpp
+++ b/Framework/API/src/LogManager.cpp
@@ -58,8 +58,13 @@ bool convertTimeSeriesToDouble(const Property *property, double &value, const Ma
     case Math::Median:
       value = log->getStatistics().median;
       break;
+    case Math::StdDev:
+      value = log->getStatistics().standard_deviation;
+      break;
+    case Math::TimeAverageStdDev:
+      throw std::invalid_argument("Statistic type \"TimeAverageStdDev\" is not currently supported");
     default: // should not happen
-      throw std::invalid_argument("Statistic type not recognised/supported");
+      throw std::invalid_argument("Statistic type not recognised");
     }
     return true;
   } else {

--- a/Framework/API/src/LogManager.cpp
+++ b/Framework/API/src/LogManager.cpp
@@ -298,18 +298,16 @@ const std::vector<Kernel::Property *> &LogManager::getProperties() const { retur
 /** Return the total memory used by the run object, in bytes.
  */
 size_t LogManager::getMemorySize() const {
+  size_t total{m_timeroi->getMemorySize()};
 
-  /// lambda function to calculate the size of a property and add it to a cumulant variable
-  auto propSize = [&](size_t cumulant, Property *p) {
-    if (p)
-      cumulant += p->getMemorySize() + sizeof(Property *);
-    return cumulant;
-  };
+  for (const auto &p : m_manager->getProperties()) {
+    if (p) {
+      // cppcheck-suppress useStlAlgorithm
+      total += p->getMemorySize() + sizeof(Property *); // cppcheck-suppress useStlAlgorithm
+    }
+  }
 
-  // accumulate the size of the logged properties
-  size_t allPropsSize = static_cast<size_t>(
-      std::accumulate(m_manager->getProperties().cbegin(), m_manager->getProperties().cend(), 0.0, propSize));
-  return m_timeroi->getMemorySize() + allPropsSize;
+  return total;
 }
 
 /**

--- a/Framework/API/test/LogManagerTest.h
+++ b/Framework/API/test/LogManagerTest.h
@@ -357,6 +357,7 @@ public:
     // const double TIME_AVG_STDDEV {8.523975789812294};
 
     TS_ASSERT_EQUALS(runInfo.getProperty(name)->size(), 10);
+    TS_ASSERT_LESS_THAN(0, runInfo.getMemorySize()); // memory is non-zero
     TS_ASSERT_DELTA(runInfo.getPropertyAsSingleValue(name, Math::Mean), 13.0, 1e-12);
     TS_ASSERT_DELTA(runInfo.getPropertyAsSingleValue(name, Math::Minimum), FIRST_VALUE, 1e-12);
     TS_ASSERT_DELTA(runInfo.getPropertyAsSingleValue(name, Math::Maximum), LAST_VALUE, 1e-12);
@@ -368,22 +369,21 @@ public:
     // TODO not ready
     // TS_ASSERT_DELTA(runInfo.getPropertyAsSingleValue(name, Math::TimeAverageStdDev), TIME_AVG_STDDEV, 1e-12);
 
-    // TODO currently the old values are cached so we need a new LogManager to get nw math done
-    LogManager runInfo2;
-    addTestTimeSeries<double>(runInfo2, name);
+    // the old values are cached so we need clear it to get nw math done
+    dynamic_cast<TimeSeriesProperty<double> *>(runInfo.getProperty(name))->eliminateDuplicates();
+    runInfo.clearSingleValueCache();
 
     // have the duplicate values (two values for the same time) removed
     // this will remove the second to last value which will change the mean, median, and stddev
-    dynamic_cast<TimeSeriesProperty<double> *>(runInfo2.getProperty(name))->eliminateDuplicates();
-    TS_ASSERT_EQUALS(runInfo2.getProperty(name)->size(), 9);
-    TS_ASSERT_DELTA(runInfo2.getPropertyAsSingleValue(name, Math::Mean), 11.88888888888889, 1e-12);   // TODO
-    TS_ASSERT_DELTA(runInfo2.getPropertyAsSingleValue(name, Math::Minimum), FIRST_VALUE, 1e-12);      // TODO
-    TS_ASSERT_DELTA(runInfo2.getPropertyAsSingleValue(name, Math::Maximum), LAST_VALUE, 1e-12);       // TODO
-    TS_ASSERT_DELTA(runInfo2.getPropertyAsSingleValue(name, Math::FirstValue), FIRST_VALUE, 1e-12);   // TODO
-    TS_ASSERT_DELTA(runInfo2.getPropertyAsSingleValue(name, Math::LastValue), LAST_VALUE, 1e-12);     // TODO
-    TS_ASSERT_DELTA(runInfo2.getPropertyAsSingleValue(name, Math::Median), 6.0, 1e-12);               // TODO
-    TS_ASSERT_DELTA(runInfo2.getPropertyAsSingleValue(name, Math::StdDev), 8.937367800973425, 1e-12); // TODO
-    TS_ASSERT_DELTA(runInfo2.getPropertyAsSingleValue(name, Math::TimeAveragedMean), TIME_AVG_MEAN, 1e-12);
+    TS_ASSERT_EQUALS(runInfo.getProperty(name)->size(), 9);
+    TS_ASSERT_DELTA(runInfo.getPropertyAsSingleValue(name, Math::Mean), 11.88888888888889, 1e-12);   // TODO
+    TS_ASSERT_DELTA(runInfo.getPropertyAsSingleValue(name, Math::Minimum), FIRST_VALUE, 1e-12);      // TODO
+    TS_ASSERT_DELTA(runInfo.getPropertyAsSingleValue(name, Math::Maximum), LAST_VALUE, 1e-12);       // TODO
+    TS_ASSERT_DELTA(runInfo.getPropertyAsSingleValue(name, Math::FirstValue), FIRST_VALUE, 1e-12);   // TODO
+    TS_ASSERT_DELTA(runInfo.getPropertyAsSingleValue(name, Math::LastValue), LAST_VALUE, 1e-12);     // TODO
+    TS_ASSERT_DELTA(runInfo.getPropertyAsSingleValue(name, Math::Median), 6.0, 1e-12);               // TODO
+    TS_ASSERT_DELTA(runInfo.getPropertyAsSingleValue(name, Math::StdDev), 8.937367800973425, 1e-12); // TODO
+    TS_ASSERT_DELTA(runInfo.getPropertyAsSingleValue(name, Math::TimeAveragedMean), TIME_AVG_MEAN, 1e-12);
     // TODO not ready
     // TS_ASSERT_DELTA(runInfo.getPropertyAsSingleValue(name, Math::TimeAverageStdDev), TIME_AVG_STDDEV, 1e-12);
   }

--- a/Framework/Kernel/inc/MantidKernel/ITimeSeriesProperty.h
+++ b/Framework/Kernel/inc/MantidKernel/ITimeSeriesProperty.h
@@ -49,7 +49,7 @@ public:
    * @param timeRoi  Object that holds information about when the time measurement was active.
    * @return The time-weighted average value of the log when the time measurement was active.
    */
-  virtual double timeAverageValue2(const TimeROI &timeRoi) const = 0;
+  virtual double timeAverageValue(const TimeROI &timeRoi) const = 0;
   /// Returns the real size of the time series property map:
   virtual int realSize() const = 0;
   /// Deletes the series of values in the property

--- a/Framework/Kernel/inc/MantidKernel/ITimeSeriesProperty.h
+++ b/Framework/Kernel/inc/MantidKernel/ITimeSeriesProperty.h
@@ -21,6 +21,7 @@ namespace Kernel {
 class SplittingInterval;
 class TimeInterval;
 class Property;
+class TimeROI;
 /** A non-templated interface to a TimeSeriesProperty.
  */
 class ITimeSeriesProperty {
@@ -44,6 +45,11 @@ public:
   virtual std::vector<Types::Core::DateAndTime> timesAsVector() const = 0;
   /// Returns the calculated time weighted average value
   virtual double timeAverageValue() const = 0;
+  /** Returns the calculated time weighted average value.
+   * @param timeRoi  Object that holds information about when the time measurement was active.
+   * @return The time-weighted average value of the log when the time measurement was active.
+   */
+  virtual double timeAverageValue2(const TimeROI &timeRoi) const = 0;
   /// Returns the real size of the time series property map:
   virtual int realSize() const = 0;
   /// Deletes the series of values in the property

--- a/Framework/Kernel/inc/MantidKernel/Statistics.h
+++ b/Framework/Kernel/inc/MantidKernel/Statistics.h
@@ -15,7 +15,17 @@ namespace Math {
 /**
  * Maps a "statistic" to a number
  */
-enum StatisticType { FirstValue, LastValue, Minimum, Maximum, Mean, TimeAveragedMean, Median };
+enum StatisticType {
+  FirstValue,
+  LastValue,
+  Minimum,
+  Maximum,
+  Mean,
+  TimeAveragedMean,
+  Median,
+  StdDev,
+  TimeAverageStdDev
+};
 } // namespace Math
 
 /**

--- a/Framework/Kernel/inc/MantidKernel/TimeROI.h
+++ b/Framework/Kernel/inc/MantidKernel/TimeROI.h
@@ -21,6 +21,7 @@ public:
 
   TimeROI();
   TimeROI(const Types::Core::DateAndTime &startTime, const Types::Core::DateAndTime &stopTime);
+  TimeROI(const Kernel::TimeSeriesProperty<bool> &filter);
   double durationInSeconds() const;
   double durationInSeconds(const Types::Core::DateAndTime &startTime, const Types::Core::DateAndTime &stopTime) const;
   std::size_t numBoundaries() const;

--- a/Framework/Kernel/inc/MantidKernel/TimeROI.h
+++ b/Framework/Kernel/inc/MantidKernel/TimeROI.h
@@ -12,14 +12,13 @@
 namespace Mantid {
 namespace Kernel {
 
-namespace {
-// const std::string NAME{"roi"};
-}
-
 /** TimeROI : Object that holds information about when the time measurement was active.
  */
 class MANTID_KERNEL_DLL TimeROI {
 public:
+  /// the underlying property needs a name
+  static const std::string NAME;
+
   TimeROI();
   TimeROI(const Types::Core::DateAndTime &startTime, const Types::Core::DateAndTime &stopTime);
   double durationInSeconds() const;
@@ -33,11 +32,15 @@ public:
   void addMask(const Types::Core::DateAndTime &startTime, const Types::Core::DateAndTime &stopTime);
   void addMask(const std::time_t &startTime, const std::time_t &stopTime);
   bool valueAtTime(const Types::Core::DateAndTime &time) const;
+  void replaceROI(const TimeSeriesProperty<bool> *roi);
   void update_union(const TimeROI &other);
   void update_intersection(const TimeROI &other);
   void removeRedundantEntries();
   bool operator==(const TimeROI &other) const;
   void debugPrint() const;
+
+  // nexus items
+  void saveNexus(::NeXus::File *file) const;
 
 private:
   std::vector<Types::Core::DateAndTime> getAllTimes(const TimeROI &other);

--- a/Framework/Kernel/inc/MantidKernel/TimeROI.h
+++ b/Framework/Kernel/inc/MantidKernel/TimeROI.h
@@ -8,6 +8,7 @@
 
 #include "MantidKernel/DllConfig.h"
 #include "MantidKernel/TimeSeriesProperty.h"
+#include "MantidKernel/TimeSplitter.h"
 
 namespace Mantid {
 namespace Kernel {
@@ -38,6 +39,7 @@ public:
   void update_union(const TimeROI &other);
   void update_intersection(const TimeROI &other);
   void removeRedundantEntries();
+  const std::vector<SplittingInterval> toSplitters() const;
   bool operator==(const TimeROI &other) const;
   void debugPrint() const;
   size_t getMemorySize() const;

--- a/Framework/Kernel/inc/MantidKernel/TimeROI.h
+++ b/Framework/Kernel/inc/MantidKernel/TimeROI.h
@@ -33,11 +33,13 @@ public:
   void addMask(const std::time_t &startTime, const std::time_t &stopTime);
   bool valueAtTime(const Types::Core::DateAndTime &time) const;
   void replaceROI(const TimeSeriesProperty<bool> *roi);
+  void replaceROI(const TimeROI &other);
   void update_union(const TimeROI &other);
   void update_intersection(const TimeROI &other);
   void removeRedundantEntries();
   bool operator==(const TimeROI &other) const;
   void debugPrint() const;
+  size_t getMemorySize() const;
 
   // nexus items
   void saveNexus(::NeXus::File *file) const;

--- a/Framework/Kernel/inc/MantidKernel/TimeSeriesProperty.h
+++ b/Framework/Kernel/inc/MantidKernel/TimeSeriesProperty.h
@@ -159,7 +159,7 @@ public:
   /// @copydoc Mantid::Kernel::ITimeSeriesProperty::timeAverageValue()
   double timeAverageValue() const override;
   /// @copydoc Mantid::Kernel::ITimeSeriesProperty::timeAverageValue(const TimeROI &timeRoi)
-  double timeAverageValue2(const TimeROI &timeRoi) const override;
+  double timeAverageValue(const TimeROI &timeRoi) const override;
   /// generate constant time-step histogram from the property values
   void histogramData(const Types::Core::DateAndTime &tMin, const Types::Core::DateAndTime &tMax,
                      std::vector<double> &counts) const;

--- a/Framework/Kernel/inc/MantidKernel/TimeSeriesProperty.h
+++ b/Framework/Kernel/inc/MantidKernel/TimeSeriesProperty.h
@@ -13,6 +13,7 @@
 #include "MantidKernel/DllConfig.h"
 #include "MantidKernel/ITimeSeriesProperty.h"
 #include "MantidKernel/Property.h"
+
 #include "MantidKernel/Statistics.h"
 #include <cstdint>
 #include <utility>
@@ -157,6 +158,8 @@ public:
   std::pair<double, double> averageAndStdDevInFilter(const std::vector<SplittingInterval> &filter) const override;
   /// @copydoc Mantid::Kernel::ITimeSeriesProperty::timeAverageValue()
   double timeAverageValue() const override;
+  /// @copydoc Mantid::Kernel::ITimeSeriesProperty::timeAverageValue(const TimeROI &timeRoi)
+  double timeAverageValue2(const TimeROI &timeRoi) const override;
   /// generate constant time-step histogram from the property values
   void histogramData(const Types::Core::DateAndTime &tMin, const Types::Core::DateAndTime &tMax,
                      std::vector<double> &counts) const;

--- a/Framework/Kernel/inc/MantidKernel/TimeSeriesProperty.h
+++ b/Framework/Kernel/inc/MantidKernel/TimeSeriesProperty.h
@@ -158,7 +158,10 @@ public:
   std::pair<double, double> averageAndStdDevInFilter(const std::vector<SplittingInterval> &filter) const override;
   /// @copydoc Mantid::Kernel::ITimeSeriesProperty::timeAverageValue()
   double timeAverageValue() const override;
-  /// @copydoc Mantid::Kernel::ITimeSeriesProperty::timeAverageValue(const TimeROI &timeRoi)
+  /** Returns the calculated time weighted average value.
+   * @param timeRoi  Object that holds information about when the time measurement was active.
+   * @return The time-weighted average value of the log when the time measurement was active.
+   */
   double timeAverageValue(const TimeROI &timeRoi) const override;
   /// generate constant time-step histogram from the property values
   void histogramData(const Types::Core::DateAndTime &tMin, const Types::Core::DateAndTime &tMax,

--- a/Framework/Kernel/src/TimeROI.cpp
+++ b/Framework/Kernel/src/TimeROI.cpp
@@ -19,8 +19,6 @@ using Mantid::Types::Core::DateAndTime;
 namespace {
 /// static Logger definition
 Logger g_log("TimeROI");
-/// the underlying property needs a name
-const std::string NAME{"Kernel_TimeROI"};
 
 const bool ROI_USE{true};
 const bool ROI_IGNORE{false};
@@ -63,6 +61,8 @@ bool valuesAreAlternating(const std::vector<bool> &values) {
   return true;
 }
 } // namespace
+
+const std::string TimeROI::NAME = "Kernel_TimeROI";
 
 TimeROI::TimeROI() : m_roi{NAME} {}
 
@@ -207,6 +207,13 @@ void TimeROI::replaceValues(const std::vector<DateAndTime> &times, const std::ve
   if (set_values) {
     this->m_roi.addValues(times, values);
   }
+}
+
+void TimeROI::replaceROI(const TimeSeriesProperty<bool> *roi) {
+  // this is used by LogManager::loadNexus
+  const auto times = roi->timesAsVector();
+  const auto values = roi->valuesAsVector();
+  this->replaceValues(times, values);
 }
 
 /**
@@ -371,6 +378,9 @@ double TimeROI::durationInSeconds(const Types::Core::DateAndTime &startTime,
 std::size_t TimeROI::numBoundaries() const { return static_cast<std::size_t>(m_roi.size()); }
 
 bool TimeROI::empty() const { return bool(this->numBoundaries() == 0); }
+
+// serialization / deserialization items
+void TimeROI::saveNexus(::NeXus::File *file) const { const_cast<TimeSeriesProperty<bool> &>(m_roi).saveProperty(file); }
 
 } // namespace Kernel
 } // namespace Mantid

--- a/Framework/Kernel/src/TimeROI.cpp
+++ b/Framework/Kernel/src/TimeROI.cpp
@@ -70,6 +70,18 @@ TimeROI::TimeROI(const Types::Core::DateAndTime &startTime, const Types::Core::D
   this->addROI(startTime, stopTime);
 }
 
+TimeROI::TimeROI(const Kernel::TimeSeriesProperty<bool> &filter) : m_roi{NAME} {
+  const auto &times = filter.timesAsVector();
+  const auto &values = filter.valuesAsVector();
+
+  const auto NUM_VAL = times.size();
+  for (size_t i = 0; i < NUM_VAL; ++i) {
+    m_roi.addValue(times[i], values[i]);
+  }
+  // assuming the filter was not well specified, clean things up
+  this->removeRedundantEntries();
+}
+
 void TimeROI::addROI(const std::string &startTime, const std::string &stopTime) {
   this->addROI(DateAndTime(startTime), DateAndTime(stopTime));
 }

--- a/Framework/Kernel/src/TimeROI.cpp
+++ b/Framework/Kernel/src/TimeROI.cpp
@@ -38,6 +38,10 @@ void assert_increasing(const DateAndTime &startTime, const DateAndTime &stopTime
  * already unique and minimal number of values.
  */
 bool valuesAreAlternating(const std::vector<bool> &values) {
+  // empty object is fine
+  if (values.empty())
+    return true;
+
   const auto NUM_VALUES = values.size();
   // should be an even number of values
   if (NUM_VALUES % 2 != 0)
@@ -71,15 +75,19 @@ TimeROI::TimeROI(const Types::Core::DateAndTime &startTime, const Types::Core::D
 }
 
 TimeROI::TimeROI(const Kernel::TimeSeriesProperty<bool> &filter) : m_roi{NAME} {
-  const auto &times = filter.timesAsVector();
   const auto &values = filter.valuesAsVector();
 
-  const auto NUM_VAL = times.size();
-  for (size_t i = 0; i < NUM_VAL; ++i) {
-    m_roi.addValue(times[i], values[i]);
+  // only need to do something if values aren't all USE
+  if (!std::all_of(values.cbegin(), values.cend(), [](const bool value) { return value == ROI_USE; })) {
+    const auto &times = filter.timesAsVector();
+    const auto NUM_VAL = times.size();
+    for (size_t i = 0; i < NUM_VAL; ++i) {
+      m_roi.addValue(times[i], values[i]);
+    }
+
+    // assuming the filter was not well specified, clean things up
+    this->removeRedundantEntries();
   }
-  // assuming the filter was not well specified, clean things up
-  this->removeRedundantEntries();
 }
 
 void TimeROI::addROI(const std::string &startTime, const std::string &stopTime) {
@@ -213,7 +221,7 @@ void TimeROI::replaceValues(const std::vector<DateAndTime> &times, const std::ve
   this->m_roi.clear();
 
   // see if everything to add is "IGNORE"
-  bool set_values = std::any_of(values.cbegin(), values.cend(), [](bool value) { return value; });
+  bool set_values = std::any_of(values.cbegin(), values.cend(), [](const bool value) { return value == ROI_USE; });
 
   // set the values if there are any use regions
   if (set_values) {
@@ -292,6 +300,7 @@ void TimeROI::update_intersection(const TimeROI &other) {
 /**
  * Remove time/value pairs that are not necessary to describe the TimeROI
  * - Sort the times/values
+ * - Ensure that values start with USE and should end with IGNORE
  * - Remove values that are not needed (e.g. IGNORE followed by IGNORE)
  * - Remove values that are overridden. Overridden values are ones where a new value was added at the same time, the
  * last one added will be used.
@@ -339,6 +348,35 @@ void TimeROI::removeRedundantEntries() {
   // update the member value if anything has changed
   if (values_new.size() != ORIG_SIZE)
     m_roi.replaceValues(times_new, values_new);
+}
+
+/**
+ * This method is to lend itself to be compatible with existing implementation
+ */
+const std::vector<SplittingInterval> TimeROI::toSplitters() const {
+  std::cout << "TimeROI::toSplitters()" << std::endl;
+  this->debugPrint();
+
+  std::vector<SplittingInterval> output;
+
+  if (!(this->empty())) {
+    // since this is const, complain if there is something not right with assumptions
+    if (!(valuesAreAlternating(m_roi.valuesAsVector()))) {
+      throw std::runtime_error(
+          "Must call TimeROI::removeRedundantEntries() before using TimeROI::toSplitters() to have "
+          "minimal number of splitters");
+    }
+
+    // and the current times
+    const auto times = m_roi.timesAsVector();
+    const auto NUM_TIMES = times.size();
+
+    // convert to a vector of splitters
+    for (size_t i = 0; i < NUM_TIMES - 1; i += 2)
+      output.push_back(SplittingInterval(times[i], times[i + 1]));
+  }
+
+  return output;
 }
 
 bool TimeROI::operator==(const TimeROI &other) const { return this->m_roi == other.m_roi; }

--- a/Framework/Kernel/src/TimeROI.cpp
+++ b/Framework/Kernel/src/TimeROI.cpp
@@ -216,6 +216,12 @@ void TimeROI::replaceROI(const TimeSeriesProperty<bool> *roi) {
   this->replaceValues(times, values);
 }
 
+void TimeROI::replaceROI(const TimeROI &other) {
+  const auto times = other.m_roi.timesAsVector();
+  const auto values = other.m_roi.valuesAsVector();
+  this->replaceValues(times, values);
+}
+
 /**
  * Updates the TimeROI values with the union with another TimeROI.
  * See https://en.wikipedia.org/wiki/Union_(set_theory) for more details
@@ -332,6 +338,8 @@ void TimeROI::debugPrint() const {
     std::cout << i << ": " << times[i] << ", " << values[i] << std::endl;
   }
 }
+
+size_t TimeROI::getMemorySize() const { return m_roi.getMemorySize(); }
 
 /**
  * Duration of the whole TimeROI

--- a/Framework/Kernel/src/TimeSeriesProperty.cpp
+++ b/Framework/Kernel/src/TimeSeriesProperty.cpp
@@ -807,7 +807,7 @@ template <typename TYPE> double TimeSeriesProperty<TYPE>::timeAverageValue() con
  * @param timeRoi  Object that holds information about when the time measurement was active.
  * @return The time-weighted average value of the log when the time measurement was active.
  */
-template <typename TYPE> double TimeSeriesProperty<TYPE>::timeAverageValue2(const TimeROI &timeRoi) const {
+template <typename TYPE> double TimeSeriesProperty<TYPE>::timeAverageValue(const TimeROI &timeRoi) const {
   double retVal = 0.0;
   try {
     const auto &filter = timeRoi.toSplitters();

--- a/Framework/Kernel/src/TimeSeriesProperty.cpp
+++ b/Framework/Kernel/src/TimeSeriesProperty.cpp
@@ -8,6 +8,7 @@
 #include "MantidKernel/EmptyValues.h"
 #include "MantidKernel/Exception.h"
 #include "MantidKernel/Logger.h"
+#include "MantidKernel/TimeROI.h"
 #include "MantidKernel/TimeSplitter.h"
 
 #include <json/value.h>
@@ -794,6 +795,22 @@ template <typename TYPE> double TimeSeriesProperty<TYPE>::timeAverageValue() con
   double retVal = 0.0;
   try {
     const auto &filter = getSplittingIntervals();
+    retVal = this->averageValueInFilter(filter);
+  } catch (std::exception &) {
+    // just return nan
+    retVal = std::numeric_limits<double>::quiet_NaN();
+  }
+  return retVal;
+}
+
+/** Returns the calculated time weighted average value.
+ * @param timeRoi  Object that holds information about when the time measurement was active.
+ * @return The time-weighted average value of the log when the time measurement was active.
+ */
+template <typename TYPE> double TimeSeriesProperty<TYPE>::timeAverageValue2(const TimeROI &timeRoi) const {
+  double retVal = 0.0;
+  try {
+    const auto &filter = timeRoi.toSplitters();
     retVal = this->averageValueInFilter(filter);
   } catch (std::exception &) {
     // just return nan
@@ -2100,7 +2117,7 @@ template <typename TYPE> void TimeSeriesProperty<TYPE>::applyFilter() const {
         } else {
           // ii.  Register the end of a valid log
           if (ilastlog < 0)
-            throw std::logic_error("LastLog is not expected to be less than 0");
+            throw std::logic_error(" LastLog is not expected to be less than 0");
 
           int delta_numintervals = icurlog - ilastlog;
           if (delta_numintervals < 0)

--- a/Framework/Kernel/test/TimeSeriesPropertyTest.h
+++ b/Framework/Kernel/test/TimeSeriesPropertyTest.h
@@ -47,10 +47,10 @@ class TimeSeriesPropertyTest : public CxxTest::TestSuite {
 
   // create a TimeROI object with two ROIS. Overlaps with the TimeSeriesProperty
   // returned by createDoubleTSP()
-  TimeRoi *createTimeRoi() {
+  TimeROI *createTimeRoi() {
     TimeROI *rois = new TimeROI;
-    rois.addROI("2007-11-30T16:17:05", "2007-11-30T16:17:15");
-    rois.addROI("2007-11-30T16:17:25", "2007-11-30T16:17:35");
+    rois->addROI("2007-11-30T16:17:05", "2007-11-30T16:17:15");
+    rois->addROI("2007-11-30T16:17:25", "2007-11-30T16:17:35");
     return rois;
   }
 
@@ -654,7 +654,7 @@ public:
 
   void test_timeAverageValueWithROI() {
     auto dblLog = createDoubleTSP();
-    auto rois = createTimeRoi();
+    TimeROI *rois = createTimeRoi();
     const double dblMean = dblLog->timeAverageValue(*rois);
     delete dblLog; // clean up
     delete rois;

--- a/Framework/Kernel/test/TimeSeriesPropertyTest.h
+++ b/Framework/Kernel/test/TimeSeriesPropertyTest.h
@@ -8,6 +8,7 @@
 
 #include "MantidKernel/Exception.h"
 #include "MantidKernel/PropertyWithValue.h"
+#include "MantidKernel/TimeROI.h"
 #include "MantidKernel/TimeSeriesProperty.h"
 #include "MantidKernel/TimeSplitter.h"
 
@@ -43,6 +44,8 @@ class TimeSeriesPropertyTest : public CxxTest::TestSuite {
     }
     return log;
   }
+
+  // create a small TimeROI object.
 
 public:
   void setUp() override {

--- a/Framework/Kernel/test/TimeSeriesPropertyTest.h
+++ b/Framework/Kernel/test/TimeSeriesPropertyTest.h
@@ -45,7 +45,14 @@ class TimeSeriesPropertyTest : public CxxTest::TestSuite {
     return log;
   }
 
-  // create a small TimeROI object.
+  // create a TimeROI object with two ROIS. Overlaps with the TimeSeriesProperty
+  // returned by createDoubleTSP()
+  TimeRoi *createTimeRoi() {
+    TimeROI *rois = new TimeROI;
+    rois.addROI("2007-11-30T16:17:05", "2007-11-30T16:17:15");
+    rois.addROI("2007-11-30T16:17:25", "2007-11-30T16:17:35");
+    return rois;
+  }
 
 public:
   void setUp() override {
@@ -643,6 +650,16 @@ public:
     // Clean up
     delete dblLog;
     delete intLog;
+  }
+
+  void test_timeAverageValueWithROI() {
+    auto dblLog = createDoubleTSP();
+    auto rois = createTimeRoi();
+    const double dblMean = dblLog->timeAverageValue(*rois);
+    delete dblLog; // clean up
+    delete rois;
+    const double expected = (5.0 * 9.99 + 5.0 * 7.55 + 5.0 * 5.55 + 5.0 * 10.55) / (5.0 + 5.0 + 5.0 + 5.0);
+    TS_ASSERT_DELTA(dblMean, expected, .0001);
   }
 
   void test_averageValueInFilter_throws_for_string_property() {

--- a/Framework/PythonInterface/mantid/kernel/src/Exports/TimeSeriesProperty.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Exports/TimeSeriesProperty.cpp
@@ -112,10 +112,10 @@ template <> std::string dtype(TimeSeriesProperty<std::string> &self) {
            "returns :class:`mantid.kernel.DateAndTime`")                                                               \
       .def("getStatistics", &TimeSeriesProperty<TYPE>::getStatistics, arg("self"),                                     \
            "returns :class:`mantid.kernel.TimeSeriesPropertyStatistics`")                                              \
-      .def("timeAverageValue", (double (TimeSeriesProperty<TYPE>::*)()) & TimeSeriesProperty<TYPE>::timeAverageValue,  \
-           (arg("self")))                                                                                              \
       .def("timeAverageValue",                                                                                         \
-           (double (TimeSeriesProperty<TYPE>::*)(const Mantid::Kernel::TimeROI &)) &                                   \
+           (double (TimeSeriesProperty<TYPE>::*)() const) & TimeSeriesProperty<TYPE>::timeAverageValue, (arg("self"))) \
+      .def("timeAverageValue",                                                                                         \
+           (double (TimeSeriesProperty<TYPE>::*)(const Mantid::Kernel::TimeROI &) const) &                             \
                TimeSeriesProperty<TYPE>::timeAverageValue,                                                             \
            (arg("self"), arg("time_roi")))                                                                             \
       .def("dtype", &dtype<TYPE>, arg("self"));

--- a/Framework/PythonInterface/mantid/kernel/src/Exports/TimeSeriesProperty.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Exports/TimeSeriesProperty.cpp
@@ -5,6 +5,7 @@
 //   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 // SPDX - License - Identifier: GPL - 3.0 +
 #include "MantidKernel/TimeSeriesProperty.h"
+#include "MantidKernel/TimeROI.h"
 #include "MantidPythonInterface/core/Converters/ContainerDtype.h"
 #include "MantidPythonInterface/core/Converters/DateAndTime.h"
 #include "MantidPythonInterface/core/GetPointer.h"
@@ -111,7 +112,12 @@ template <> std::string dtype(TimeSeriesProperty<std::string> &self) {
            "returns :class:`mantid.kernel.DateAndTime`")                                                               \
       .def("getStatistics", &TimeSeriesProperty<TYPE>::getStatistics, arg("self"),                                     \
            "returns :class:`mantid.kernel.TimeSeriesPropertyStatistics`")                                              \
-      .def("timeAverageValue", &TimeSeriesProperty<TYPE>::timeAverageValue, arg("self"))                               \
+      .def("timeAverageValue", (double (TimeSeriesProperty<TYPE>::*)()) & TimeSeriesProperty<TYPE>::timeAverageValue,  \
+           (arg("self")))                                                                                              \
+      .def("timeAverageValue",                                                                                         \
+           (double (TimeSeriesProperty<TYPE>::*)(const Mantid::Kernel::TimeROI &)) &                                   \
+               TimeSeriesProperty<TYPE>::timeAverageValue2,                                                            \
+           (arg("self"), arg("time_roi")))                                                                             \
       .def("dtype", &dtype<TYPE>, arg("self"));
 
 } // namespace

--- a/Framework/PythonInterface/mantid/kernel/src/Exports/TimeSeriesProperty.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Exports/TimeSeriesProperty.cpp
@@ -116,7 +116,7 @@ template <> std::string dtype(TimeSeriesProperty<std::string> &self) {
            (arg("self")))                                                                                              \
       .def("timeAverageValue",                                                                                         \
            (double (TimeSeriesProperty<TYPE>::*)(const Mantid::Kernel::TimeROI &)) &                                   \
-               TimeSeriesProperty<TYPE>::timeAverageValue2,                                                            \
+               TimeSeriesProperty<TYPE>::timeAverageValue,                                                             \
            (arg("self"), arg("time_roi")))                                                                             \
       .def("dtype", &dtype<TYPE>, arg("self"));
 


### PR DESCRIPTION
**Description of work.**

As part of #34794:

- [x] overload `TimeSeriesProperty::timeAverageValue`
- [x] expose `TimeSeriesProperty::timeAverageValue(const TimeROI &timeRoi) const` to Python

**To test:**
```python
# Here code to carry out a test with property.timeAverageValue(time_roi)
```

<!-- alternative
*There is no associated issue.*
-->

This does not require release notes because release notes will be written with the PR that will finally close #34794

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
