### PR TITLE
Fix Detector QRect x centre when in flipped view

### DIFF
--- a/qt/widgets/instrumentview/src/UnwrappedSurface.cpp
+++ b/qt/widgets/instrumentview/src/UnwrappedSurface.cpp
@@ -405,6 +405,11 @@ void UnwrappedSurface::setFlippedView(bool on) {
   }
 }
 
+/**
+ * Calculate the QRect of a particular detector in units of pixels.
+ * @param detectorIndex :: The index of the detector to calculate the QRect for.
+ * @returns The bounding QRect of a particular detector in units of pixels.
+ */
 QRect UnwrappedSurface::detectorQRectInPixels(const std::size_t detectorIndex) const {
   const auto detIter =
       std::find_if(m_unwrappedDetectors.cbegin(), m_unwrappedDetectors.cend(),
@@ -419,10 +424,18 @@ QRect UnwrappedSurface::detectorQRectInPixels(const std::size_t detectorIndex) c
   const double dw = fabs(m_viewRect.width() / vwidth);
   const double dh = fabs(m_viewRect.height() / vheight);
 
-  const auto size = QSize(int((*detIter).width / dw), int((*detIter).height / dh));
-  const auto position =
-      QPoint(int(static_cast<int>(((*detIter).u - m_viewRect.x0()) / dw - size.width() / 2.0)),
-             int(vheight - static_cast<int>(((*detIter).v - m_viewRect.y0()) / dh) - size.height() / 2.0));
+  const auto detRect = detIter->toQRectF();
+
+  // Calculate the centre position of the QRect. The x position will be different depending on if the view is flipped
+  const auto xCentre =
+      m_flippedView ? (m_viewRect.x0() - detRect.center().x()) / dw : (detRect.center().x() - m_viewRect.x0()) / dw;
+  const auto yCentre = (detRect.center().y() - m_viewRect.y0()) / dh;
+
+  // Calculate the width and height of the QRect
+  const auto size = QSize(static_cast<int>(detRect.width() / dw), static_cast<int>(detRect.height() / dh));
+  // Calculate the position of the top left corner of the QRect
+  const auto position = QPoint(static_cast<int>(xCentre) - static_cast<int>(size.width() / 2.0),
+                               vheight - static_cast<int>(yCentre) - static_cast<int>(size.height() / 2.0));
   return QRect(position, size);
 }
 


### PR DESCRIPTION
**Description of work.**
This PR ensures the QRect returned for a detector on an unwrapped surface has the correct x position when the x view is flipped. Previously the code assumed that the flipped view option was turned off, but this fix now means tubes can be selected when the flipped view option is turned on.

**To test:**
Load ALF82301
Open the Pick tab
Click the Select whole tube button
Click the left-most tube
Open the Render tab
Tick 'Flip view'
The view and selection should now be flipped on the x axis
Open the Pick tab
Make sure you can select another tube using the Select whole tube button

*There is no associated issue.*

*This does not require release notes* because **this code was not in the last release**

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
