### PR TITLE
Replace deprecated matplotlib function in profile fit tools

### DIFF
--- a/docs/source/release/v6.6.0/Diffraction/Single_Crystal/Bugfixes/34971.rst
+++ b/docs/source/release/v6.6.0/Diffraction/Single_Crystal/Bugfixes/34971.rst
@@ -1,0 +1,1 @@
+* Replaced deprecated Matplotlib `bivariate_normal` function in `BVGFitTools.py`

--- a/scripts/SCD_Reduction/BVGFitTools.py
+++ b/scripts/SCD_Reduction/BVGFitTools.py
@@ -11,7 +11,7 @@ from mantid.simpleapi import *
 from scipy.interpolate import interp1d
 from scipy.ndimage.filters import convolve
 import ICConvoluted as ICC
-import BivariateGaussian as BivariateGaussian
+from mantid.simpleapi import BivariateGaussian
 
 plt.ion()
 

--- a/scripts/SCD_Reduction/BVGFitTools.py
+++ b/scripts/SCD_Reduction/BVGFitTools.py
@@ -10,7 +10,6 @@ import ICCFitTools as ICCFT
 from mantid.simpleapi import *
 from scipy.interpolate import interp1d
 from scipy.ndimage.filters import convolve
-from matplotlib.mlab import bivariate_normal
 import ICConvoluted as ICC
 import BivariateGaussian as BivariateGaussian
 
@@ -744,7 +743,9 @@ def bvg(A, mu, sigma, x, y, bg):
     """
 
     if is_pos_def(sigma):
-        f = bivariate_normal(x, y, sigmax=np.sqrt(sigma[0, 0]), sigmay=np.sqrt(sigma[1, 1]), sigmaxy=sigma[1, 0], mux=mu[0], muy=mu[1])
+        f = BivariateGaussian.bivariate_normal(
+            x, y, sigmax=np.sqrt(sigma[0, 0]), sigmay=np.sqrt(sigma[1, 1]), sigmaxy=sigma[1, 0], mux=mu[0], muy=mu[1]
+        )
         return A * f + bg
     else:
         system.information("   BVGFT:bvg:not PSD Matrix")


### PR DESCRIPTION
**Description of work.**

Matplotlib removed the `bivariate_normal` function from mlab in v3.1.0 https://matplotlib.org/3.3.3/api/prev_api_changes/api_changes_3.1.0.html. The profile fitting tools have been updated to use the one embedded in `BivariateGaussian.py`

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**

Run this with matplotlib > v3.1.0:

```python
 Load(Filename='/SNS/MANDI/IPTS-8776/0/5921/NeXus/MANDI_5921_event.nxs', OutputWorkspace='MANDI_5921_event')
 MANDI_5921_md = ConvertToMD(InputWorkspace='MANDI_5921_event',  QDimensions='Q3D', dEAnalysisMode='Elastic',
                          Q3DFrames='Q_lab', QConversionScales='Q in A^-1',
                          MinValues='-5, -5, -5', Maxvalues='5, 5, 5', MaxRecursionDepth=10,
                          LorentzCorrection=False)
 LoadIsawPeaks(Filename='/SNS/MANDI/shared/ProfileFitting/demo_5921.integrate', OutputWorkspace='peaks_ws')

 IntegratePeaksProfileFitting(OutputPeaksWorkspace='peaks_ws_out', OutputParamsWorkspace='params_ws',
         InputWorkspace='MANDI_5921_md', PeaksWorkspace='peaks_ws',
         UBFile='/SNS/MANDI/shared/ProfileFitting/demo_5921.mat', MinpplFrac=0.9, MaxpplFrac=1.1,
         ModeratorCoefficientsFile='/SNS/MANDI/shared/ProfileFitting/franz_coefficients_2017.dat',
         StrongPeakParamsFile='/SNS/MANDI/shared/ProfileFitting/strongPeakParams_beta_lac_mut_mbvg.pkl',
         peakNumber=30)
```

<!-- Instructions for testing. -->

*There is no associated issue.*

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
