### PR TITLE
Turn off black in pre-commit.ci

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ exclude: ^$|instrument/
 
 ci:
   autofix_prs: true
-  skip: [clang-format]
+  skip: [black,clang-format]
 
 repos:
 


### PR DESCRIPTION
With the size of the repository, it sporadically times out the job.

**To test:**

Look at the pre-commit.ci job and see that black didn't get run
![image](https://user-images.githubusercontent.com/404003/212958405-4e917241-173b-4636-a3ce-92a669f375de.png)

*There is no associated issue.*


*This does not require release notes* because it changes build-server configuration.


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
