### PR TITLE
Fix #31603 - Non compliant NeXus dimension IDs

### DIFF
--- a/Framework/MDAlgorithms/src/LoadMD.cpp
+++ b/Framework/MDAlgorithms/src/LoadMD.cpp
@@ -393,7 +393,7 @@ void LoadMD::loadDimensions2() {
     Geometry::MDFrame_const_uptr mdFrame = Geometry::makeMDFrameFactoryChain()->create(MDFrameArgument(frame, units));
     m_file->getData(axis);
     m_file->closeData();
-    m_dims.emplace_back(std::make_shared<MDHistoDimension>(long_name, splitAxes[d - 1], *mdFrame,
+    m_dims.emplace_back(std::make_shared<MDHistoDimension>(long_name, long_name, *mdFrame,
                                                            static_cast<coord_t>(axis.front()),
                                                            static_cast<coord_t>(axis.back()), axis.size() - 1));
   }

--- a/Framework/MDAlgorithms/src/SaveMD2.cpp
+++ b/Framework/MDAlgorithms/src/SaveMD2.cpp
@@ -131,10 +131,12 @@ void SaveMD2::doSaveHisto(const Mantid::DataObjects::MDHistoWorkspace_sptr &ws) 
   for (size_t d = 0; d < numDims; d++) {
     std::vector<double> axis;
     IMDDimension_const_sptr dim = ws->getDimension(d);
+    // NeXus field names must be alphanumeric only
+    std::string axis_title("D" + std::to_string(d));
     auto nbounds = dim->getNBoundaries();
     for (size_t n = 0; n < nbounds; n++)
       axis.emplace_back(dim->getX(n));
-    file->makeData(dim->getDimensionId(), ::NeXus::FLOAT64, static_cast<int>(dim->getNBoundaries()), true);
+    file->makeData(axis_title, ::NeXus::FLOAT64, static_cast<int>(dim->getNBoundaries()), true);
     file->putData(&axis[0]);
     file->putAttr("units", std::string(dim->getUnits()));
     file->putAttr("long_name", std::string(dim->getName()));
@@ -142,7 +144,7 @@ void SaveMD2::doSaveHisto(const Mantid::DataObjects::MDHistoWorkspace_sptr &ws) 
     file->closeData();
     if (d != 0)
       axes_label.insert(0, ":");
-    axes_label.insert(0, dim->getDimensionId());
+    axes_label.insert(0, axis_title);
   }
 
   // Number of data points


### PR DESCRIPTION
Ensures MD NeXus files have dimension names which adhere to the [NeXus definitions](https://manual.nexusformat.org/datarules.html#regexpname).

**Description of work.**

Some Mantid algorithms (e.g. `MDNorm`) need axes with names in a specific format, e.g. `[H,0,0]`, which is not allowed by the NeXus standard. We have a separate attribute `long_name` which is a free format string where these names can be stored, but currently the `SaveMD2` algorithm also writes the Mantid (non-NeXus-compliant) names as the dimension ID.

This PR changes `SaveMD2` to write a NeXus compliant ID and `LoadMD` to rename the axes name from the `long_name` if it detects that the name has been changed by `SaveMD2`.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**

Run the following script:

```python
# import mantid algorithms, numpy and matplotlib
from mantid.simpleapi import *

wd = 'C:/mantid/build/ExternalData/Testing/Data/SystemTest/'

Load(Filename=wd+"CORELLI_29782.nxs", OutputWorkspace="data")
Load(Filename=wd+"SingleCrystalDiffuseReduction_SA.nxs", OutputWorkspace="SolidAngle")
Load(Filename=wd+"SingleCrystalDiffuseReduction_Flux.nxs", OutputWorkspace="Flux")
MaskDetectors(Workspace="data", MaskedWorkspace="SolidAngle")
ConvertUnits(InputWorkspace="data", OutputWorkspace="data", Target="Momentum")
CropWorkspaceForMDNorm(InputWorkspace="data", XMin=2.5, XMax=10, OutputWorkspace="data")
LoadIsawUB(InputWorkspace="data", Filename="SingleCrystalDiffuseReduction_UB.mat")
SetGoniometer(Workspace="data", Axis0="BL9:Mot:Sample:Axis1,0,1,0,1")
min_vals, max_vals = ConvertToMDMinMaxGlobal(InputWorkspace="data", QDimensions="Q3D",
    dEAnalysisMode="Elastic", Q3DFrames="Q")

ConvertToMD(InputWorkspace="data", QDimensions="Q3D", dEAnalysisMode="Elastic", Q3DFrames="Q_sample",
    OutputWorkspace="md", MinValues=min_vals, MaxValues=max_vals)

MDNorm(InputWorkspace="md", SolidAngleWorkspace="SolidAngle", FluxWorkspace="Flux",
    QDimension0="1,1,0", QDimension1="1,-1,0", QDimension2="0,0,1",
    Dimension0Binning="-10.0,0.1,10.0", Dimension1Binning="-10.0,0.1,10.0", Dimension2Binning="-0.1,0.1",
    SymmetryOperations="P 31 2 1", OutputWorkspace="result", OutputDataWorkspace="dataMD", 
    OutputNormalizationWorkspace="normMD",
)

SaveMD(InputWorkspace='result', Filename='c:/Temp/corelli_test.nxs')
LoadMD(Filename='C:/Temp/corelli_test.nxs', OutputWorkspace='res_reloaded')
print(mtd['result'].getDimension(0).getDimensionId())
print(mtd['res_reloaded'].getDimension(0).getDimensionId())
```

The script is a version of the Corelli reduction script and uses data in the Mantid system test suite.

The `DimensionId` of the processed and reloaded workspaces should be the same (and be `[H,0,0]`). 
Open up the `corelli_test.nxs` file using [nexpy](https://nexpy.github.io/nexpy/) or run this script

```python
import h5py

nxf = h5py.File('C:/Temp/corelli_test.nxs', 'r')
for itm in nxf['MDHistoWorkspace/data'].items():
    print(itm)
```

And check that the axes datasets are labelled `D0`, `D1`, `D2` (and not `[H,0,0]` etc.)

<!-- Instructions for testing. -->

Fixes #31603. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

*This does not require release notes* because *it is an internal change to be compliant with the NeXus standard and should not affect any user functionality.*

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
