### PR TITLE
Fix for fit browser cursor bug

### DIFF
--- a/qt/python/mantidqt/mantidqt/widgets/fitpropertybrowser/interactive_tool.py
+++ b/qt/python/mantidqt/mantidqt/widgets/fitpropertybrowser/interactive_tool.py
@@ -75,7 +75,7 @@ class FitInteractiveTool(QObject):
         self._cids.append(canvas.mpl_connect("motion_notify_event", self.motion_notify_callback))
         self._cids.append(canvas.mpl_connect("button_press_event", self.button_press_callback))
         self._cids.append(canvas.mpl_connect("button_release_event", self.button_release_callback))
-        self._cids.append(canvas.mpl_connect("figure_leave_event", self.stop_add_peak))
+        self._cids.append(canvas.mpl_connect("axes_leave_event", self.stop_add_peak))
 
         # The mouse state machine that handles responses to the mouse events.
         self.mouse_state = StateMachine(self)
@@ -152,13 +152,16 @@ class FitInteractiveTool(QObject):
         if x is None or y is None:
             return
 
+        cursor = QApplication.overrideCursor()
         if self.fit_range.min_marker.is_above(x, y) or self.fit_range.max_marker.is_above(x, y):
-            QApplication.setOverrideCursor(Qt.SizeHorCursor)
+            if not cursor:
+                QApplication.setOverrideCursor(Qt.SizeHorCursor)
             return
 
         for pm in self.peak_markers:
             if pm.left_width.is_above(x, y) or pm.right_width.is_above(x, y) or pm.centre_marker.is_above(x, y):
-                QApplication.setOverrideCursor(Qt.SizeHorCursor)
+                if not cursor:
+                    QApplication.setOverrideCursor(Qt.SizeHorCursor)
                 return
 
         QApplication.restoreOverrideCursor()

--- a/qt/python/mantidqt/mantidqt/widgets/fitpropertybrowser/mouse_state_machine.py
+++ b/qt/python/mantidqt/mantidqt/widgets/fitpropertybrowser/mouse_state_machine.py
@@ -87,6 +87,7 @@ class MoveMarkersState(object):
         """
         Get the state the machine should return to after the mouse button release: self
         """
+        QApplication.restoreOverrideCursor()
         return self
 
 


### PR DESCRIPTION
**Description of work.**

Fix for the bug in the fit browser where the cursor would stay as a horizontal double arrow if moved up and out of the figure axes via a vertical marker.

**To test:**

 - Load some data
 - Plot a spectrum
 - Click 'Fit' to switch to the fit browser
 - [x] Hover over the green width markers and check that the cursor changes to a horizontal double arrow
 - [x] Move the cursor up one of the width markers and check that it changes back to the normal cursor once exiting the graph axes
 - [x] Add a peak and check this holds true for the three peak vertical markers.

Fixes #34975


*This does not require release notes* because **It fixes a bug for a 6.6 feature**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
