### PR TITLE
Undo the tight layout change made to plots

### DIFF
--- a/docs/source/release/v6.6.0/Workbench/Bugfixes/34049.rst
+++ b/docs/source/release/v6.6.0/Workbench/Bugfixes/34049.rst
@@ -1,1 +1,0 @@
-- Plot axes labels are no longer hidden when resizing the plot window.

--- a/qt/applications/workbench/workbench/plotting/figuremanager.py
+++ b/qt/applications/workbench/workbench/plotting/figuremanager.py
@@ -14,7 +14,6 @@ import io
 import sys
 import re
 from functools import wraps
-import warnings
 
 import matplotlib
 from matplotlib.axes import Axes
@@ -192,22 +191,6 @@ class FigureManagerWorkbench(FigureManagerBase, QObject):
 
         self.window.setWindowTitle("Figure %d" % num)
         canvas.figure.set_label("Figure %d" % num)
-
-        # Set tight layout so axes labels remain visible
-        canvas.figure.set_layout_engine(layout="tight")
-        # Matplotlib issues a warnings if the window is made too small in the vertical or horizontal direction
-        # Filtering it to only warn once per plot per axis so that it doesn't give a warning everytime the plot window
-        # is resized, filling up the console with warnings
-        warnings.filterwarnings(
-            "once",
-            message="Tight layout not applied. The left and right margins cannot be made "
-            "large enough to accommodate all axes decorations.",
-        )
-        warnings.filterwarnings(
-            "once",
-            message="Tight layout not applied. The bottom and top margins cannot be made "
-            "large enough to accommodate all axes decorations.",
-        )
 
         FigureManagerBase.__init__(self, canvas, num)
         # Give the keyboard focus to the figure instead of the


### PR DESCRIPTION
**Description of work.**

This PR undoes the changes made in #34907 which caused a number of bugs with other plot windows which will be fixed for 6.7.

**To test:**

Ensure that the bugs from the attached issues are no longer present.

Fixes #34973 #34974

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
