### PR TITLE
Get correct axes extents for peak overlay in non-ortho view

### DIFF
--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/peaksviewer/presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/peaksviewer/presenter.py
@@ -135,7 +135,7 @@ class PeaksViewerPresenter:
         #   - first update slice point so we are in the correct plane
         #   - find and set limits required to "zoom" to the selected peak
         self._view.set_slicepoint(self.model.slicepoint(selected_index, self._view.sliceinfo, self._view.frame))
-        self._view.set_axes_limits(*self.model.viewlimits(selected_index), auto_transform=True)
+        self._view.set_axes_limits(*self.model.viewlimits(selected_index), auto_transform=False)
 
     def _peaks_list_changed(self):
         """

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/peaksviewer/test/test_peaksviewer_presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/peaksviewer/test/test_peaksviewer_presenter.py
@@ -112,7 +112,7 @@ class PeaksViewerPresenterTest(unittest.TestCase):
         presenter.notify(PeaksViewerPresenter.Event.PeakSelected)
 
         mock_model.viewlimits.assert_called_once_with(0)
-        self.mock_view.set_axes_limits.assert_called_once_with(*viewlimits, auto_transform=True)
+        self.mock_view.set_axes_limits.assert_called_once_with(*viewlimits, auto_transform=False)
 
     def test_single_peak_selection_if_peaks_not_drawn(self, mock_peaks_list_presenter):
         # peaks not drawn if one fo viewing axes non-Q


### PR DESCRIPTION
**Description of work.**

Get correct axes extents for peak overlay in non-ortho view.
This partially undo changes made in 2a2a8a24d69ca0066d7f9c59d18149b2542af9be

**To test:**

(1) Follow instruction on the issue - should now zoom to position of the peaks when rows are clicked

Fixes #34985 
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
