### PR TITLE
Disable optimization for the Segfault algorithm

### DIFF
--- a/Framework/Algorithms/CMakeLists.txt
+++ b/Framework/Algorithms/CMakeLists.txt
@@ -1043,6 +1043,10 @@ endif()
 
 # Add a precompiled header where they are supported
 enable_precompiled_headers(inc/MantidAlgorithms/PrecompiledHeader.h SRC_FILES)
+# Disable optimization for certain Segfault as the key lines that cause the segfault can be optimized away but this
+# algorithm is only ever intended to test the crashing behaviour of the framework
+set_source_files_properties(src/Segfault.cpp PROPERTIES COMPILE_FLAGS -O0)
+
 # Add the target for this directory
 add_library(Algorithms ${SRC_FILES} ${C_SRC_FILES} ${INC_FILES})
 add_library(Mantid::Algorithms ALIAS Algorithms)


### PR DESCRIPTION
**Description of work.**

Segfault appeared to stop working on recent versions of AppleClang when building Mantid in release. This is likely due to the optimizer taking out the lines that make no difference but this is the line that
causes the crash.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**

* On macOS, build a `Release` configuration build
* Run Segfault with `DryRun=False`
* Workbench should crash.

Fixes #35008 

*This does not require release notes* because **we should not highlight an internal-testing algorithm that will crash the code.**

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
