### PR TITLE
Lagrange: fix for apparent 'keep open' memory leak

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/LagrangeILLReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/LagrangeILLReduction.py
@@ -67,6 +67,9 @@ class LagrangeILLReduction(DataProcessorAlgorithm):
         self.convert_to_wavenumber = self.getProperty("ConvertToWaveNumber").value
         self.normalise_by = self.getPropertyValue("NormaliseBy")
 
+        # the list of all the intermediate workspaces to group at the end
+        self.intermediate_workspaces = []
+
     def PyInit(self):
         self.declareProperty(MultipleFileProperty("SampleRuns", action=FileAction.Load, extensions=[""]), doc="Sample run(s).")
 
@@ -93,9 +96,6 @@ class LagrangeILLReduction(DataProcessorAlgorithm):
         self.declareProperty(name="UseIncidentEnergy", defaultValue=False, doc="Show the energies as incident energies, not transfer ones.")
 
         self.declareProperty(name="ConvertToWaveNumber", defaultValue=False, doc="Convert axis unit to energy in wave number (cm-1)")
-
-        # the list of all the intermediate workspaces to group at the end
-        self.intermediate_workspaces = []
 
     def PyExec(self):
         self.setup()


### PR DESCRIPTION
**Description of work.**

The initialization of the list containing hidden intermediate workspaces was moved from the init of the algorithm to the setup method in the execution. This way, even if user keeps the algorithm dialog open, we can be certain that the list will be created anew each time the algorithm is executed and thus fixing the related issue. 

**To test:**

Run the test from the issue. The hidden workspace group should contain only relevant workspaces, with the same prefixes as the name of the group. 

<!-- Instructions for testing. -->

Fixes #35019 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->

*This does not require release notes* because it is a hidden workspaces fix, and is not impacting the general functionality of the algorithm.

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
