### PR TITLE
Fix error when adding/removing all error bars

### DIFF
--- a/Framework/PythonInterface/mantid/plots/mantidaxes.py
+++ b/Framework/PythonInterface/mantid/plots/mantidaxes.py
@@ -349,7 +349,7 @@ class MantidAxes(Axes):
         :param predicate: A unary predicate used to select artists.
         :return: The output of the inner function.
         """
-        if workspace.name() not in self.tracked_workspaces:
+        if workspace is not None and workspace.name() not in self.tracked_workspaces:
             return False
         waterfall_x_offset = copy.copy(self.waterfall_x_offset)
         waterfall_y_offset = copy.copy(self.waterfall_y_offset)


### PR DESCRIPTION
**Description of work.**

Checks to see if the workspace is there before calling for its name. It is possible to call the function without a workspace and use a predicate instead, which meant this check was making calls on `None` objects. 


**To test:**
1. Load a workspace with multiple spectra.
2. Plot >1 in waterfall mode
3. Right click the plot and click Error Bars > Show All Errors
4. Error bars are shown and no exception is raised. 

Fixes #35023 

*This does not require release notes* because **it fixes a bug introduced in this release.**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
