### PR TITLE
Avoid implicit conversion between bool & int

### DIFF
--- a/Framework/Kernel/test/TimeROITest.h
+++ b/Framework/Kernel/test/TimeROITest.h
@@ -216,9 +216,9 @@ public:
   }
 
   void test_valueAtTime() {
-    TS_ASSERT_EQUALS(DECEMBER.valueAtTime(DECEMBER_STOP), 0);
-    TS_ASSERT_EQUALS(DECEMBER.valueAtTime(CHRISTMAS_START), 1);
-    TS_ASSERT_EQUALS(DECEMBER.valueAtTime(DECEMBER_START), 1);
+    TS_ASSERT_EQUALS(DECEMBER.valueAtTime(DECEMBER_STOP), false);
+    TS_ASSERT_EQUALS(DECEMBER.valueAtTime(CHRISTMAS_START), true);
+    TS_ASSERT_EQUALS(DECEMBER.valueAtTime(DECEMBER_START), true);
   }
 
   void runIntersectionTest(const TimeROI &left, const TimeROI &right, const double exp_duration) {


### PR DESCRIPTION
**Description of work.**

MSVC warns on this and produces an "unsafe mix of type" warning. #35005 highlighted that this slipped through and made it to `main` before we branched and created `release-next` so the fix is targeted at `release-next`.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**

* MSVC should compile and produce no warnings.

*There is no associated issue.*

*This does not require release notes* because **it is an internal change.**

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
