### PR TITLE
Separate out publishing to github

### DIFF
--- a/buildconfig/Jenkins/Conda/nightly_build_and_deploy.jenkinsfile
+++ b/buildconfig/Jenkins/Conda/nightly_build_and_deploy.jenkinsfile
@@ -233,8 +233,10 @@ pipeline {
       when {
         beforeAgent true
         beforeOptions true
-        expression { env.PUBLISH_PACKAGES == 'true' }
-        expression { env.GITHUB_RELEASES_REPO.trim() != '' }
+        allOf {
+          expression { env.PUBLISH_PACKAGES == 'true' }
+          expression { env.GITHUB_RELEASES_REPO.trim() != '' }
+        }
       }
       agent { label 'linux-64' } // Use linux for simplicity with shell scripts
       options {

--- a/buildconfig/Jenkins/Conda/nightly_build_and_deploy.jenkinsfile
+++ b/buildconfig/Jenkins/Conda/nightly_build_and_deploy.jenkinsfile
@@ -199,7 +199,7 @@ pipeline {
       }
     }
 
-    stage ('Publishing') {
+    stage ('Publishing to Anaconda') {
       when {
         beforeAgent true
         beforeOptions true
@@ -212,7 +212,6 @@ pipeline {
        }
       environment {
         ANACONDA_TOKEN = credentials("${ANACONDA_TOKEN_CREDENTIAL_ID}")
-        GITHUB_TOKEN = credentials("${GITHUB_TOKEN_CREDENTIAL_ID}")
       }
       steps {
         checkoutSource("${GIT_SHA}")
@@ -227,6 +226,26 @@ pipeline {
         // Single quotes are required for token variables to avoid them leaking
         sh "${CISCRIPT_DIR}/publish-to-anaconda ${WORKSPACE}" + ' ${ANACONDA_TOKEN} ' +\
           "${ANACONDA_CHANNEL} ${ANACONDA_CHANNEL_LABEL} ${WORKSPACE}/conda-packages/*.tar.bz2"
+      }
+    }
+
+    stage ('Publishing to Github') {
+      when {
+        beforeAgent true
+        beforeOptions true
+        expression { env.PUBLISH_PACKAGES == 'true' }
+        expression { env.GITHUB_RELEASES_REPO.trim() != '' }
+      }
+      agent { label 'linux-64' } // Use linux for simplicity with shell scripts
+      options {
+        timestamps ()
+        retry(3)
+       }
+      environment {
+        GITHUB_TOKEN = credentials("${GITHUB_TOKEN_CREDENTIAL_ID}")
+      }
+      steps {
+        checkoutSource("${GIT_SHA}")
         // Standalone packages next
         sh 'rm -fr ${WORKSPACE}/standalone-packages'
         copyArtifacts filter: '*.exe, *.dmg, *.tar.xz',
@@ -235,10 +254,12 @@ pipeline {
           selector: specific('${BUILD_NUMBER}'),
           target: 'standalone-packages',
           flatten: true
+        // Single quotes are required for token variables to avoid them leaking
         sh "${CISCRIPT_DIR}/publish-to-github ${WORKSPACE}" + ' ${GITHUB_TOKEN} ' +\
           "${GITHUB_RELEASES_REPO} ${generate_git_tag()} ${GIT_SHA} ${prerelease_option()} ${WORKSPACE}/standalone-packages/*"
-      }
+        }
     }
+
     stage ('Delete old non-main packages from Anaconda') {
       when {
         beforeAgent true


### PR DESCRIPTION
**Description of work.**

Jenkins would report a failure if the publishing to github failed because a repo wasn't given. But if you don't want to publish to github that's a valid entry.

**To test:**
1. Use the `build_packages_from_branch` pipeline with the following settings:
```
BUILD_DEVL = none
BUILD_PACKAGE = linux64    // It's quickest
PACKAGE_SUFFIX = publishtestgh
PUBLISH_PACKAGES = true
ANACONDA_CHANNEL_LABEL = publishtestconda
GITHUB_RELEASES_REPO = 
GITHUB_RELEASES_TAG =
GH_ORGANIZATION_OR_USERNAME = ConorMFinn
BRANCH_NAME = jenkins_github_publish
```
2. Check that the jenkins job passed and successfully published to condaforge without publishing to github. 

*There is no associated issue.*



*This does not require release notes* because **this is related only to our build servers.**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
