### PR TITLE
Fix HKL cursor info for 4D MD workspaces

### DIFF
--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/models/model.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/models/model.py
@@ -576,27 +576,16 @@ class SliceViewerModel(SliceViewerBaseModel):
 
         return xcut_name, ycut_name, help_msg
 
-    @staticmethod
-    def get_dim_indices(slice_point: List[float], qdims: List[int], transpose: bool) -> Tuple[int]:
-        """Returns the indices of the selected x and y axes. It also returns the index of the first non x or y axis."""
-        xdim, ydim = WorkspaceInfo.display_indices(slice_point, transpose)
-        # Get the index of the first axis which is not x or y. Here it is called z.
-        zdim = next(i for i, v in enumerate(slice_point) if v is not None and i in qdims)
-        return xdim, ydim, zdim
-
-    def get_hkl_from_full_point(self, full_point: List[float], qdims: List[int], xdim: int, ydim: int, zdim: int):
+    def get_hkl_from_full_point(self, full_point: List[float], qdims_i: List[int]):
         """Gets the values of h, k and l from a full point which can include 3 or more dimensions."""
         basis_transform = self.get_proj_matrix()
         if basis_transform is None:
             return 0.0, 0.0, 0.0
 
-        # Get the values for h, k and l
-        hkl_point = tuple(full_point[q_i] for q_i in qdims)
+        # Get the values for the h, k and l projections
+        hkl_projection = tuple(full_point[q_i] for q_i in qdims_i)
 
-        h_i, k_i, l_i = np.argsort([xdim, ydim, zdim])
-        return (
-            basis_transform[:, h_i] * hkl_point[h_i] + basis_transform[:, k_i] * hkl_point[k_i] + basis_transform[:, l_i] * hkl_point[l_i]
-        )
+        return np.matmul(basis_transform, hkl_projection)
 
 
 # private functions

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/models/model.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/models/model.py
@@ -582,10 +582,10 @@ class SliceViewerModel(SliceViewerBaseModel):
         if basis_transform is None:
             return 0.0, 0.0, 0.0
 
-        # Get the values for the h, k and l projections
-        hkl_projection = tuple(full_point[q_i] for q_i in qdims_i)
+        # Get the x, y, z values for the q dimensions
+        q_xyz = tuple(full_point[q_i] for q_i in qdims_i)
 
-        return np.matmul(basis_transform, hkl_projection)
+        return np.matmul(basis_transform, q_xyz)
 
 
 # private functions

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/presenters/base_presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/presenters/base_presenter.py
@@ -62,7 +62,7 @@ class SliceViewerBasePresenter(IDataViewSubscriber, ABC):
         return self.view.data_view.dimensions
 
     def get_slicepoint(self):
-        """Returns the current slicepoint as a list of 3 elements.
+        """Returns the current slicepoint as a list of 3 or more elements.
         None indicates that dimension is being displayed"""
         return self._data_view.dimensions.get_slicepoint()
 

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/presenters/presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/presenters/presenter.py
@@ -5,7 +5,7 @@
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
 #  This file is part of the mantid workbench.
-from typing import Callable, Tuple
+from typing import Callable, List, Tuple
 import sys
 
 from mantid.kernel import Logger, SpecialCoordinateSystem
@@ -537,19 +537,29 @@ class SliceViewer(ObservingPresenter, SliceViewerBasePresenter):
 
     def get_extra_image_info_columns(self, xdata, ydata):
         qdims = [i for i, v in enumerate(self.view.data_view.dimensions.qflags) if v]
-        if len(qdims) == 3 and self.get_frame() == SpecialCoordinateSystem.HKL:
-            slice_point = self.get_slicepoint()
-            xdim, ydim = WorkspaceInfo.display_indices(slice_point, self.view.data_view.dimensions.transpose)
-            zdim = next(i for i, v in enumerate(slice_point) if v is not None and i in qdims)
-            if xdata == DBLMAX and ydata == DBLMAX:
-                hkl_as_strings = ["-", "-", "-"]
-            else:
-                hkl = self.model.get_hkl_from_xyz(xdim, ydim, zdim, xdata, ydata, slice_point[zdim])
-                hkl_as_strings = ["{:.4f}".format(element) for element in hkl]
-            extra_cols = {"H": hkl_as_strings[0], "K": hkl_as_strings[1], "L": hkl_as_strings[2]}
-        else:
-            extra_cols = {}
-        return extra_cols
+
+        if len(qdims) != 3 and self.get_frame() != SpecialCoordinateSystem.HKL:
+            return {}
+
+        if xdata == DBLMAX and ydata == DBLMAX:
+            return {"H": "-", "K": "-", "L": "-"}
+
+        slice_point = self.get_slicepoint()
+        xdim, ydim, zdim = self.model.get_dim_indices(slice_point, qdims, self.view.data_view.dimensions.transpose)
+        full_point = self._get_full_point(slice_point, xdata, ydata, xdim, ydim)
+
+        hkl = self.model.get_hkl_from_full_point(full_point, qdims, xdim, ydim, zdim)
+
+        hkl_as_strings = [f"{element:.4f}" for element in hkl]
+        return {"H": hkl_as_strings[0], "K": hkl_as_strings[1], "L": hkl_as_strings[2]}
+
+    @staticmethod
+    def _get_full_point(slice_point: List[float], xdata: float, ydata: float, xdim: int, ydim: int) -> List[float]:
+        """Construct a list containing the full cursor coordinate i.e. x, y, z, and any other dimensions"""
+        full_point = slice_point.copy()
+        full_point[xdim] = xdata
+        full_point[ydim] = ydata
+        return full_point
 
 
 class SliceViewXAxisEditor(XAxisEditor):

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/presenters/presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/presenters/presenter.py
@@ -545,10 +545,10 @@ class SliceViewer(ObservingPresenter, SliceViewerBasePresenter):
             return {"H": "-", "K": "-", "L": "-"}
 
         slice_point = self.get_slicepoint()
-        xdim, ydim, zdim = self.model.get_dim_indices(slice_point, qdims, self.view.data_view.dimensions.transpose)
+        xdim, ydim = WorkspaceInfo.display_indices(slice_point, self.view.data_view.dimensions.transpose)
         full_point = self._get_full_point(slice_point, xdata, ydata, xdim, ydim)
 
-        hkl = self.model.get_hkl_from_full_point(full_point, qdims, xdim, ydim, zdim)
+        hkl = self.model.get_hkl_from_full_point(full_point, qdims)
 
         hkl_as_strings = [f"{element:.4f}" for element in hkl]
         return {"H": hkl_as_strings[0], "K": hkl_as_strings[1], "L": hkl_as_strings[2]}

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/presenters/presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/presenters/presenter.py
@@ -538,7 +538,7 @@ class SliceViewer(ObservingPresenter, SliceViewerBasePresenter):
     def get_extra_image_info_columns(self, xdata, ydata):
         qdims = [i for i, v in enumerate(self.view.data_view.dimensions.qflags) if v]
 
-        if len(qdims) != 3 and self.get_frame() != SpecialCoordinateSystem.HKL:
+        if len(qdims) != 3 or self.get_frame() != SpecialCoordinateSystem.HKL:
             return {}
 
         if xdata == DBLMAX and ydata == DBLMAX:

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_sliceviewer_model.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_sliceviewer_model.py
@@ -831,82 +831,51 @@ class SliceViewerModelTest(unittest.TestCase):
         for export_type in ("r", "c", "x", "y"):
             assert_error_returned_in_help(self.ws_MDE_3D, export_type, mock_binmd, "BinMD failed")
 
-    def test_get_dim_indices_for_3D_slice_point(self):
-        slice_point = [None, None, 3.0]  # [x, y, z]
-        qdims = [0, 1, 2]
-
-        model = SliceViewerModel(self.ws_MDE_3D)
-        dim_indices = model.get_dim_indices(slice_point, qdims, False)
-
-        self.assertEqual((0, 1, 2), dim_indices)
-
-    def test_get_dim_indices_for_3D_slice_point_transpose(self):
-        slice_point = [None, None, 3.0]  # [x, y, z]
-        qdims = [0, 1, 2]
-
-        model = SliceViewerModel(self.ws_MDE_3D)
-        dim_indices = model.get_dim_indices(slice_point, qdims, True)
-
-        self.assertEqual((1, 0, 2), dim_indices)
-
-    def test_get_dim_indices_for_4D_slice_point(self):
-        slice_point = [1.0, 2.0, None, None]  # [e, z, x, y]
-        qdims = [1, 2, 3]
-
-        model = SliceViewerModel(self.ws_MDE_4D)
-        dim_indices = model.get_dim_indices(slice_point, qdims, False)
-
-        self.assertEqual((2, 3, 1), dim_indices)
-
     @patch("mantidqt.widgets.sliceviewer.models.model.SliceViewerModel.get_proj_matrix")
     def test_get_hkl_from_full_point_returns_zeros_for_a_none_transform(self, mock_get_proj_matrix):
         qdims = [0, 1, 2]
-        xdim, ydim, zdim = 0, 1, 2
         point_3d = [1.0, 2.0, 3.0]
 
         model = SliceViewerModel(self.ws_MDE_3D)
         mock_get_proj_matrix.return_value = None
 
-        hkl = model.get_hkl_from_full_point(point_3d, qdims, xdim, ydim, zdim)
+        hkl = model.get_hkl_from_full_point(point_3d, qdims)
 
         self.assertEqual((0.0, 0.0, 0.0), hkl)
 
     @patch("mantidqt.widgets.sliceviewer.models.model.SliceViewerModel.get_proj_matrix")
     def test_get_hkl_from_full_point_for_3D_point(self, mock_get_proj_matrix):
         qdims = [0, 1, 2]
-        xdim, ydim, zdim = 0, 1, 2
         point_3d = [1.0, 2.0, 3.0]  # [x, y, z] = [h, k, l]
 
         model = SliceViewerModel(self.ws_MDE_3D)
         mock_get_proj_matrix.return_value = np.array([[0, 1, -1], [0, 1, 1], [1, 0, 0]])
 
-        hkl = model.get_hkl_from_full_point(point_3d, qdims, xdim, ydim, zdim)
+        hkl = model.get_hkl_from_full_point(point_3d, qdims)
 
         self.assertEqual([-1.0, 5.0, 1.0], list(hkl))
 
     @patch("mantidqt.widgets.sliceviewer.models.model.SliceViewerModel.get_proj_matrix")
     def test_get_hkl_from_full_point_for_4D_point(self, mock_get_proj_matrix):
         qdims = [1, 2, 3]
-        xdim, ydim, zdim = 1, 0, 2
         point_4d = [1.0, 2.0, 3.0, 4.0]  # [y, x, z, ...] = [e, h, k, l]
 
         model = SliceViewerModel(self.ws_MDE_4D)
         mock_get_proj_matrix.return_value = np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1]])
 
-        hkl = model.get_hkl_from_full_point(point_4d, qdims, xdim, ydim, zdim)
+        hkl = model.get_hkl_from_full_point(point_4d, qdims)
 
         self.assertEqual([2.0, 3.0, 4.0], list(hkl))
 
     @patch("mantidqt.widgets.sliceviewer.models.model.SliceViewerModel.get_proj_matrix")
     def test_get_hkl_from_full_point_for_4D_point_with_transformation(self, mock_get_proj_matrix):
         qdims = [1, 2, 3]
-        xdim, ydim, zdim = 3, 0, 1
         point_4d = [1.0, 2.0, 3.0, 4.0]  # [y, z, ..., x] = [e, h, k, l]
 
         model = SliceViewerModel(self.ws_MDE_4D)
         mock_get_proj_matrix.return_value = np.array([[2, 0, 0], [0, -1, 0], [0, 0, 3]])
 
-        hkl = model.get_hkl_from_full_point(point_4d, qdims, xdim, ydim, zdim)
+        hkl = model.get_hkl_from_full_point(point_4d, qdims)
 
         self.assertEqual([4.0, -3.0, 12.0], list(hkl))
 

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_sliceviewer_model.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_sliceviewer_model.py
@@ -831,14 +831,32 @@ class SliceViewerModelTest(unittest.TestCase):
         for export_type in ("r", "c", "x", "y"):
             assert_error_returned_in_help(self.ws_MDE_3D, export_type, mock_binmd, "BinMD failed")
 
-    # def test_get_dim_indices_for_3D_slice_point(self):
-    #     slice_point = [None, None, 3.0]  # [x, y, z]
-    #     qdims = [0, 1, 2]
-    #
-    #     model = SliceViewerModel(self.ws_MDE_3D)
-    #     dim_indices = model.get_dim_indices()
-    #
-    #     self.assertEqual((0, 1, 2), dim_indices)
+    def test_get_dim_indices_for_3D_slice_point(self):
+        slice_point = [None, None, 3.0]  # [x, y, z]
+        qdims = [0, 1, 2]
+
+        model = SliceViewerModel(self.ws_MDE_3D)
+        dim_indices = model.get_dim_indices(slice_point, qdims, False)
+
+        self.assertEqual((0, 1, 2), dim_indices)
+
+    def test_get_dim_indices_for_3D_slice_point_transpose(self):
+        slice_point = [None, None, 3.0]  # [x, y, z]
+        qdims = [0, 1, 2]
+
+        model = SliceViewerModel(self.ws_MDE_3D)
+        dim_indices = model.get_dim_indices(slice_point, qdims, True)
+
+        self.assertEqual((1, 0, 2), dim_indices)
+
+    def test_get_dim_indices_for_4D_slice_point(self):
+        slice_point = [1.0, 2.0, None, None]  # [e, z, x, y]
+        qdims = [1, 2, 3]
+
+        model = SliceViewerModel(self.ws_MDE_4D)
+        dim_indices = model.get_dim_indices(slice_point, qdims, False)
+
+        self.assertEqual((2, 3, 1), dim_indices)
 
     @patch("mantidqt.widgets.sliceviewer.models.model.SliceViewerModel.get_proj_matrix")
     def test_get_hkl_from_full_point_returns_zeros_for_a_none_transform(self, mock_get_proj_matrix):
@@ -882,8 +900,8 @@ class SliceViewerModelTest(unittest.TestCase):
     @patch("mantidqt.widgets.sliceviewer.models.model.SliceViewerModel.get_proj_matrix")
     def test_get_hkl_from_full_point_for_4D_point_with_transformation(self, mock_get_proj_matrix):
         qdims = [1, 2, 3]
-        xdim, ydim, zdim = 1, 0, 2
-        point_4d = [1.0, 2.0, 3.0, 4.0]  # [y, x, z, ...] = [e, h, k, l]
+        xdim, ydim, zdim = 3, 0, 1
+        point_4d = [1.0, 2.0, 3.0, 4.0]  # [y, z, ..., x] = [e, h, k, l]
 
         model = SliceViewerModel(self.ws_MDE_4D)
         mock_get_proj_matrix.return_value = np.array([[2, 0, 0], [0, -1, 0], [0, 0, 3]])

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_sliceviewer_presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_sliceviewer_presenter.py
@@ -23,6 +23,7 @@ sys.modules["mantid.simpleapi"] = mock.MagicMock()
 
 from mantidqt.widgets.sliceviewer.models.model import SliceViewerModel, WS_TYPE  # noqa: E402
 from mantidqt.widgets.sliceviewer.presenters.presenter import (
+    DBLMAX,
     PeaksViewerCollectionPresenter,
     SliceViewer,
     SliceViewXAxisEditor,
@@ -124,7 +125,8 @@ class SliceViewerTest(unittest.TestCase):
         self.model.get_data = mock.Mock()
         self.model.rebin = mock.Mock()
         self.model.workspace_equals = mock.Mock()
-        self.model.get_hkl_from_xyz.return_value = [1.0, 1.0, 1.0]
+        self.model.get_dim_indices.return_value = (0, 1, 2)
+        self.model.get_hkl_from_full_point.return_value = [1.0, 1.0, 1.0]
         self.model.get_properties.return_value = {
             "workspace_type": "WS_TYPE.MATRIX",
             "supports_normalise": True,
@@ -602,11 +604,10 @@ class SliceViewerTest(unittest.TestCase):
     @mock.patch("mantidqt.widgets.sliceviewer.presenters.presenter.SliceViewer.get_frame")
     def test_workspace_requests_hkl_for_image_info(self, mock_get_frame):
         def run_requests_hkl_test(pres, ncols, callcount):
-            self.patched_deps["WorkspaceInfo"].display_indices.return_value = [0, 1]
             mock_get_frame.return_value = SpecialCoordinateSystem.HKL
-            self.model.get_hkl_from_xyz.reset_mock()
+            self.model.get_hkl_from_full_point.reset_mock()
             extra_cols = pres.get_extra_image_info_columns(1.0, 2.0)
-            self.assertEqual(self.model.get_hkl_from_xyz.call_count, callcount)
+            self.assertEqual(self.model.get_hkl_from_full_point.call_count, callcount)
             self.assertEqual(len(extra_cols), ncols)
 
         pres3D = SliceViewer(mock.Mock(), model=self.model, view=self.view)
@@ -615,6 +616,35 @@ class SliceViewerTest(unittest.TestCase):
         run_requests_hkl_test(pres3D_no_q_dim, 0, 0)
         pres4D = SliceViewer(mock.Mock(), model=self.model, view=self.view4D)
         run_requests_hkl_test(pres4D, 3, 1)
+
+    @mock.patch("mantidqt.widgets.sliceviewer.presenters.presenter.SliceViewer.get_frame")
+    def test_get_extra_image_info_columns_for_less_than_three_qdims(self, mock_get_frame):
+        mock_get_frame.return_value = SpecialCoordinateSystem.HKL
+        pres3D_no_q_dim = SliceViewer(mock.Mock(), model=self.model, view=self.view3D_non_QDim)
+
+        hkl = pres3D_no_q_dim.get_extra_image_info_columns(1.0, 2.0)
+
+        self.assertEquals({}, hkl)
+
+    @mock.patch("mantidqt.widgets.sliceviewer.presenters.presenter.SliceViewer.get_frame")
+    def test_get_extra_image_info_columns_for_double_max(self, mock_get_frame):
+        mock_get_frame.return_value = SpecialCoordinateSystem.HKL
+        pres3D = SliceViewer(mock.Mock(), model=self.model, view=self.view)
+
+        hkl = pres3D.get_extra_image_info_columns(DBLMAX, DBLMAX)
+
+        self.assertEquals({"H": "-", "K": "-", "L": "-"}, hkl)
+
+    @mock.patch("mantidqt.widgets.sliceviewer.presenters.presenter.SliceViewer.get_frame")
+    def test_get_extra_image_info_columns_returns_values_with_the_expected_format(self, mock_get_frame):
+        mock_get_frame.return_value = SpecialCoordinateSystem.HKL
+        self.model.get_hkl_from_full_point.return_value = [1.0, 2.0, 3.0]
+
+        pres3D = SliceViewer(mock.Mock(), model=self.model, view=self.view)
+
+        hkl = pres3D.get_extra_image_info_columns(1.0, 2.0)
+
+        self.assertEquals({"H": "1.0000", "K": "2.0000", "L": "3.0000"}, hkl)
 
     @mock.patch("mantidqt.widgets.sliceviewer.presenters.presenter.SliceViewXAxisEditor")
     def test_x_axes_editor_is_opened_on_x_axes_double_click(self, mock_xaxis_editor):

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_sliceviewer_presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_sliceviewer_presenter.py
@@ -125,7 +125,6 @@ class SliceViewerTest(unittest.TestCase):
         self.model.get_data = mock.Mock()
         self.model.rebin = mock.Mock()
         self.model.workspace_equals = mock.Mock()
-        self.model.get_dim_indices.return_value = (0, 1, 2)
         self.model.get_hkl_from_full_point.return_value = [1.0, 1.0, 1.0]
         self.model.get_properties.return_value = {
             "workspace_type": "WS_TYPE.MATRIX",
@@ -603,6 +602,8 @@ class SliceViewerTest(unittest.TestCase):
 
     @mock.patch("mantidqt.widgets.sliceviewer.presenters.presenter.SliceViewer.get_frame")
     def test_workspace_requests_hkl_for_image_info(self, mock_get_frame):
+        self.patched_deps["WorkspaceInfo"].display_indices.return_value = (0, 1)
+
         def run_requests_hkl_test(pres, ncols, callcount):
             mock_get_frame.return_value = SpecialCoordinateSystem.HKL
             self.model.get_hkl_from_full_point.reset_mock()
@@ -624,7 +625,7 @@ class SliceViewerTest(unittest.TestCase):
 
         hkl = pres3D_no_q_dim.get_extra_image_info_columns(1.0, 2.0)
 
-        self.assertEquals({}, hkl)
+        self.assertEqual({}, hkl)
 
     @mock.patch("mantidqt.widgets.sliceviewer.presenters.presenter.SliceViewer.get_frame")
     def test_get_extra_image_info_columns_for_double_max(self, mock_get_frame):
@@ -633,10 +634,11 @@ class SliceViewerTest(unittest.TestCase):
 
         hkl = pres3D.get_extra_image_info_columns(DBLMAX, DBLMAX)
 
-        self.assertEquals({"H": "-", "K": "-", "L": "-"}, hkl)
+        self.assertEqual({"H": "-", "K": "-", "L": "-"}, hkl)
 
     @mock.patch("mantidqt.widgets.sliceviewer.presenters.presenter.SliceViewer.get_frame")
     def test_get_extra_image_info_columns_returns_values_with_the_expected_format(self, mock_get_frame):
+        self.patched_deps["WorkspaceInfo"].display_indices.return_value = (0, 1)
         mock_get_frame.return_value = SpecialCoordinateSystem.HKL
         self.model.get_hkl_from_full_point.return_value = [1.0, 2.0, 3.0]
 
@@ -644,7 +646,7 @@ class SliceViewerTest(unittest.TestCase):
 
         hkl = pres3D.get_extra_image_info_columns(1.0, 2.0)
 
-        self.assertEquals({"H": "1.0000", "K": "2.0000", "L": "3.0000"}, hkl)
+        self.assertEqual({"H": "1.0000", "K": "2.0000", "L": "3.0000"}, hkl)
 
     @mock.patch("mantidqt.widgets.sliceviewer.presenters.presenter.SliceViewXAxisEditor")
     def test_x_axes_editor_is_opened_on_x_axes_double_click(self, mock_xaxis_editor):


### PR DESCRIPTION
**Description of work.**
This PR fixes a bug in the SliceViewer when viewing 4D data. The HKL values are now correctly printed in the cursor info widget even when another dimension exists. The dimensions can now be in any order and it should still work e.g. any of EHKL, HEKL, HKEL, HKLE.

**To test:**
Follow the instructions in the attached issue.
You can also try swapping the order of the dimensions and check it is still working.

Fixes #34986

*This does not require release notes* because **the bug was not present in the previous release**

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
