### PR TITLE
Fix inconsistent fonts across script editor tabs on macOS

### DIFF
--- a/docs/source/release/v6.6.0/Workbench/Bugfixes/35060.rst
+++ b/docs/source/release/v6.6.0/Workbench/Bugfixes/35060.rst
@@ -1,0 +1,1 @@
+- Fix inconsistent text size when opening multiple script editor tabs on macOS

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/ScriptEditor.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/ScriptEditor.h
@@ -130,9 +130,6 @@ public slots:
   /// Raise find replace dialog
   virtual void showFindReplaceDialog();
 
-  /// Override zoomTo slot
-  void zoomTo(int level) override;
-
 signals:
   /// Inform observers that undo information is available
   void undoAvailable(bool /*_t1*/);

--- a/qt/widgets/common/src/ScriptEditor.cpp
+++ b/qt/widgets/common/src/ScriptEditor.cpp
@@ -513,19 +513,6 @@ void ScriptEditor::print() {
 void ScriptEditor::showFindReplaceDialog() { m_findDialog->show(); }
 
 /**
- * Override the zoomTo slot to make the font size larger on Mac as the
- * defaults are tiny
- * @param level Set the font size to this level of zoom
- */
-void ScriptEditor::zoomTo(int level) {
-#ifdef __APPLE__
-  // Make all fonts 4 points bigger on the Mac because otherwise they're tiny!
-  level += 4;
-#endif
-  QsciScintilla::zoomTo(level);
-}
-
-/**
  * Write to the given device
  */
 void ScriptEditor::writeToDevice(QIODevice &device) const { this->write(&device); }


### PR DESCRIPTION
**Description of work.**

Removes ancient override of QScintilla2 zoom function that artificially inflated the zoom level causing strange inconsistency when creating new tabs and trying to set the same level across then all. We now set the font so the
default is fine and it's better to have consistent behaviour with how zooming works.

**To test:**

Please follow the instructions in the linked issue.

Fixes #29118

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
