### PR TITLE
Allow background for PeakPicker tool

### DIFF
--- a/docs/source/release/v6.7.0/Direct_Geometry/General/Bugfixes/35002.rst
+++ b/docs/source/release/v6.7.0/Direct_Geometry/General/Bugfixes/35002.rst
@@ -1,0 +1,2 @@
+- The peak picker tool is now offset on the y axis by the background amount.
+- The peak picker tool is now set as activate by default.

--- a/qt/python/mantidqt/mantidqt/plotting/markers.py
+++ b/qt/python/mantidqt/mantidqt/plotting/markers.py
@@ -498,7 +498,7 @@ class PeakMarker(QObject):
     peak_moved = Signal(int, float, float)
     fwhm_changed = Signal(int, float)
 
-    def __init__(self, canvas, peak_id, x, y_top, y_bottom, fwhm):
+    def __init__(self, canvas, peak_id, x, height, fwhm, background):
         """
         Init the marker.
         :param canvas: The MPL canvas.
@@ -510,7 +510,7 @@ class PeakMarker(QObject):
         """
         super(PeakMarker, self).__init__()
         self.peak_id = peak_id
-        self.centre_marker = CentreMarker(canvas, x, y0=y_bottom, y1=y_top)
+        self.centre_marker = CentreMarker(canvas, x, y0=background, y1=background + height)
         self.left_width = WidthMarker(canvas, x - fwhm / 2)
         self.right_width = WidthMarker(canvas, x + fwhm / 2)
         self.is_selected = False

--- a/qt/python/mantidqt/mantidqt/plotting/markers.py
+++ b/qt/python/mantidqt/mantidqt/plotting/markers.py
@@ -640,14 +640,16 @@ class PeakMarker(QObject):
         """
         return self.centre(), self.height(), self.fwhm()
 
-    def update_peak(self, centre, height, fwhm):
+    def update_peak(self, centre, height, fwhm, background=0.0):
         """
         Update this marker.
         :param centre: A new peak centre.
         :param height: A new peak height.
         :param fwhm: A new peak FWHM.
+        :param background: The background to place the peak on top of.
         """
         self.centre_marker.x = centre
+        self.centre_marker.y0 = background
         self.centre_marker.set_height(height)
         dx = fwhm / 2
         self.left_width.x = centre - dx

--- a/qt/python/mantidqt/mantidqt/widgets/fitpropertybrowser/interactive_tool.py
+++ b/qt/python/mantidqt/mantidqt/widgets/fitpropertybrowser/interactive_tool.py
@@ -270,7 +270,7 @@ class FitInteractiveTool(QObject):
         if fwhm is None:
             fwhm = self.fwhm
         peak_id = self._make_peak_id()
-        peak = PeakMarker(self.canvas, peak_id, x, y_top, y_bottom, fwhm=fwhm)
+        peak = PeakMarker(self.canvas, peak_id, x, y_top - y_bottom, fwhm=fwhm, background=y_bottom)
         peak.peak_moved.connect(self.peak_moved)
         peak.fwhm_changed.connect(self.peak_fwhm_changed_slot)
         self.peak_markers.append(peak)

--- a/qt/scientific_interfaces/Direct/ALFAnalysisModel.cpp
+++ b/qt/scientific_interfaces/Direct/ALFAnalysisModel.cpp
@@ -186,6 +186,8 @@ void ALFAnalysisModel::setPeakCentre(double const centre) {
 
 double ALFAnalysisModel::peakCentre() const { return m_function->getParameter("f1.PeakCentre"); }
 
+double ALFAnalysisModel::background() const { return m_function->getParameter("f0.A0"); }
+
 Mantid::API::IPeakFunction_const_sptr ALFAnalysisModel::getPeakCopy() const {
   auto const gaussian = m_function->getFunction(1)->clone();
   return std::dynamic_pointer_cast<Mantid::API::IPeakFunction>(gaussian);

--- a/qt/scientific_interfaces/Direct/ALFAnalysisModel.h
+++ b/qt/scientific_interfaces/Direct/ALFAnalysisModel.h
@@ -42,6 +42,7 @@ public:
   virtual void setPeakParameters(Mantid::API::IPeakFunction_const_sptr const &peak) = 0;
   virtual void setPeakCentre(double const centre) = 0;
   virtual double peakCentre() const = 0;
+  virtual double background() const = 0;
   virtual Mantid::API::IPeakFunction_const_sptr getPeakCopy() const = 0;
 
   virtual std::string fitStatus() const = 0;
@@ -77,6 +78,7 @@ public:
   void setPeakParameters(Mantid::API::IPeakFunction_const_sptr const &peak) override;
   void setPeakCentre(double const centre) override;
   double peakCentre() const override;
+  double background() const override;
   Mantid::API::IPeakFunction_const_sptr getPeakCopy() const override;
 
   std::string fitStatus() const override;

--- a/qt/scientific_interfaces/Direct/ALFAnalysisPresenter.cpp
+++ b/qt/scientific_interfaces/Direct/ALFAnalysisPresenter.cpp
@@ -129,7 +129,7 @@ void ALFAnalysisPresenter::updateTwoThetaInViewFromModel() {
 }
 
 void ALFAnalysisPresenter::updatePeakCentreInViewFromModel() {
-  m_view->setPeak(m_model->getPeakCopy());
+  m_view->setPeak(m_model->getPeakCopy(), m_model->background());
 
   auto const fitStatus = m_model->fitStatus();
   m_view->setPeakCentreStatus(fitStatus);

--- a/qt/scientific_interfaces/Direct/ALFAnalysisView.cpp
+++ b/qt/scientific_interfaces/Direct/ALFAnalysisView.cpp
@@ -269,10 +269,10 @@ void ALFAnalysisView::setAverageTwoTheta(std::optional<double> average, std::vec
   m_numberOfTubes->setToolTip(constructNumberOfTubesTooltip(all));
 }
 
-void ALFAnalysisView::setPeak(Mantid::API::IPeakFunction_const_sptr const &peak) {
+void ALFAnalysisView::setPeak(Mantid::API::IPeakFunction_const_sptr const &peak, double const background) {
   setPeakCentre(peak->getParameter("PeakCentre"));
 
-  m_peakPicker->setPeak(peak);
+  m_peakPicker->setPeak(peak, background);
   m_peakPicker->select(false);
 }
 

--- a/qt/scientific_interfaces/Direct/ALFAnalysisView.cpp
+++ b/qt/scientific_interfaces/Direct/ALFAnalysisView.cpp
@@ -273,7 +273,7 @@ void ALFAnalysisView::setPeak(Mantid::API::IPeakFunction_const_sptr const &peak,
   setPeakCentre(peak->getParameter("PeakCentre"));
 
   m_peakPicker->setPeak(peak, background);
-  m_peakPicker->select(false);
+  m_peakPicker->select(true);
 }
 
 Mantid::API::IPeakFunction_const_sptr ALFAnalysisView::getPeak() const { return m_peakPicker->peak(); }

--- a/qt/scientific_interfaces/Direct/ALFAnalysisView.h
+++ b/qt/scientific_interfaces/Direct/ALFAnalysisView.h
@@ -53,7 +53,7 @@ public:
 
   virtual void setAverageTwoTheta(std::optional<double> average, std::vector<double> const &all) = 0;
 
-  virtual void setPeak(Mantid::API::IPeakFunction_const_sptr const &peak) = 0;
+  virtual void setPeak(Mantid::API::IPeakFunction_const_sptr const &peak, double const background) = 0;
   virtual Mantid::API::IPeakFunction_const_sptr getPeak() const = 0;
 
   virtual void setPeakCentre(double const centre) = 0;
@@ -88,7 +88,7 @@ public:
 
   void setAverageTwoTheta(std::optional<double> average, std::vector<double> const &all) override;
 
-  void setPeak(Mantid::API::IPeakFunction_const_sptr const &peak) override;
+  void setPeak(Mantid::API::IPeakFunction_const_sptr const &peak, double const background) override;
   Mantid::API::IPeakFunction_const_sptr getPeak() const override;
 
   void setPeakCentre(double const centre) override;

--- a/qt/scientific_interfaces/Direct/test/ALFAnalysisMocks.h
+++ b/qt/scientific_interfaces/Direct/test/ALFAnalysisMocks.h
@@ -63,7 +63,7 @@ public:
   MOCK_METHOD1(addFitSpectrum, void(Mantid::API::MatrixWorkspace_sptr const &workspace));
   MOCK_METHOD0(removeFitSpectrum, void());
 
-  MOCK_METHOD1(setPeak, void(Mantid::API::IPeakFunction_const_sptr const &peak));
+  MOCK_METHOD2(setPeak, void(Mantid::API::IPeakFunction_const_sptr const &peak, double const background));
   MOCK_CONST_METHOD0(getPeak, Mantid::API::IPeakFunction_const_sptr());
 
   MOCK_METHOD1(setPeakCentre, void(double const centre));
@@ -97,6 +97,7 @@ public:
   MOCK_METHOD1(setPeakParameters, void(Mantid::API::IPeakFunction_const_sptr const &peak));
   MOCK_METHOD1(setPeakCentre, void(double const centre));
   MOCK_CONST_METHOD0(peakCentre, double());
+  MOCK_CONST_METHOD0(background, double());
   MOCK_CONST_METHOD0(getPeakCopy, Mantid::API::IPeakFunction_const_sptr());
 
   MOCK_CONST_METHOD0(fitStatus, std::string());

--- a/qt/scientific_interfaces/Direct/test/ALFAnalysisPresenterTest.h
+++ b/qt/scientific_interfaces/Direct/test/ALFAnalysisPresenterTest.h
@@ -42,6 +42,7 @@ public:
     m_workspaceName = "test";
     m_range = std::make_pair(0.0, 1.0);
     m_peakCentre = 0.5;
+    m_background = 1.0;
     m_allTwoTheta = std::vector<double>{1.0, 2.3, 3.3};
     m_averageTwoTheta = 2.2;
 
@@ -116,8 +117,9 @@ public:
     EXPECT_CALL(*m_model, peakCentre()).Times(1).WillOnce(Return(0.0));
     EXPECT_CALL(*m_model, setPeakCentre(m_peakCentre)).Times(1);
 
+    EXPECT_CALL(*m_model, background()).Times(1).WillOnce(Return(m_background));
     EXPECT_CALL(*m_model, getPeakCopy()).Times(1).WillOnce(Return(nullptr));
-    EXPECT_CALL(*m_view, setPeak(_)).Times(1);
+    EXPECT_CALL(*m_view, setPeak(_, m_background)).Times(1);
 
     EXPECT_CALL(*m_model, fitStatus()).Times(1).WillOnce(Return(""));
     EXPECT_CALL(*m_view, setPeakCentreStatus("")).Times(1);
@@ -136,8 +138,9 @@ public:
 
     // Assert not called as the peak centre remains the same
     EXPECT_CALL(*m_model, setPeakCentre(m_peakCentre)).Times(0);
+    EXPECT_CALL(*m_model, background()).Times(0);
     EXPECT_CALL(*m_model, getPeakCopy()).Times(0);
-    EXPECT_CALL(*m_view, setPeak(_)).Times(0);
+    EXPECT_CALL(*m_view, setPeak(_, _)).Times(0);
     EXPECT_CALL(*m_model, fitStatus()).Times(0);
     EXPECT_CALL(*m_view, setPeakCentreStatus("")).Times(0);
     EXPECT_CALL(*m_view, removeFitSpectrum()).Times(0);
@@ -152,8 +155,9 @@ public:
     EXPECT_CALL(*m_view, peakCentre()).Times(1).WillOnce(Return(m_peakCentre));
     EXPECT_CALL(*m_model, setPeakCentre(m_peakCentre)).Times(1);
 
+    EXPECT_CALL(*m_model, background()).Times(1).WillOnce(Return(m_background));
     EXPECT_CALL(*m_model, getPeakCopy()).Times(1).WillOnce(Return(nullptr));
-    EXPECT_CALL(*m_view, setPeak(_)).Times(1);
+    EXPECT_CALL(*m_view, setPeak(_, m_background)).Times(1);
 
     EXPECT_CALL(*m_model, fitStatus()).Times(1).WillOnce(Return("Success"));
     EXPECT_CALL(*m_view, setPeakCentreStatus("Success")).Times(1);
@@ -288,6 +292,7 @@ private:
   std::string m_workspaceName;
   std::pair<double, double> m_range;
   double m_peakCentre;
+  double m_background;
   std::vector<double> m_allTwoTheta;
   std::optional<double> m_averageTwoTheta;
 

--- a/qt/widgets/mplcpp/inc/MantidQtWidgets/MplCpp/PeakMarker.h
+++ b/qt/widgets/mplcpp/inc/MantidQtWidgets/MplCpp/PeakMarker.h
@@ -22,7 +22,7 @@ namespace MplCpp {
  */
 class MANTID_MPLCPP_DLL PeakMarker : public Common::Python::InstanceHolder {
 public:
-  explicit PeakMarker(FigureCanvasQt *canvas, int peakID, double x, double yTop, double yBottom, double fwhm,
+  explicit PeakMarker(FigureCanvasQt *canvas, int peakID, double x, double height, double fwhm, double background,
                       QHash<QString, QVariant> const &otherKwargs = QHash<QString, QVariant>());
 
   void redraw();

--- a/qt/widgets/mplcpp/inc/MantidQtWidgets/MplCpp/PeakMarker.h
+++ b/qt/widgets/mplcpp/inc/MantidQtWidgets/MplCpp/PeakMarker.h
@@ -28,7 +28,7 @@ public:
   void redraw();
   void remove();
 
-  void updatePeak(double centre, double height, double fwhm);
+  void updatePeak(double centre, double height, double fwhm, double background);
   std::tuple<double, double, double> peakProperties() const;
 
   bool isMoving() const;

--- a/qt/widgets/mplcpp/src/PeakMarker.cpp
+++ b/qt/widgets/mplcpp/src/PeakMarker.cpp
@@ -59,8 +59,8 @@ void PeakMarker::remove() { callMethodNoCheck<void>(pyobj(), "remove"); }
  * @param height The new height.
  * @param fwhm The new height.
  */
-void PeakMarker::updatePeak(double centre, double height, double fwhm) {
-  callMethodNoCheck<void>(pyobj(), "update_peak", centre, height, fwhm);
+void PeakMarker::updatePeak(double centre, double height, double fwhm, double background) {
+  callMethodNoCheck<void>(pyobj(), "update_peak", centre, height, fwhm, background);
 }
 
 /**

--- a/qt/widgets/mplcpp/src/PeakMarker.cpp
+++ b/qt/widgets/mplcpp/src/PeakMarker.cpp
@@ -18,13 +18,14 @@ using Mantid::PythonInterface::PythonException;
 
 namespace {
 
-Python::Object newMarker(FigureCanvasQt *canvas, int peakID, double x, double yTop, double yBottom, double fwhm,
+Python::Object newMarker(FigureCanvasQt *canvas, int peakID, double x, double height, double fwhm, double background,
                          boost::optional<QHash<QString, QVariant>> const &otherKwargs) {
   GlobalInterpreterLock lock;
 
   Python::Object markersModule{Python::NewRef(PyImport_ImportModule("mantidqt.plotting.markers"))};
 
-  auto const args = Python::NewRef(Py_BuildValue("(Oidddd)", canvas->pyobj().ptr(), peakID, x, yTop, yBottom, fwhm));
+  auto const args =
+      Python::NewRef(Py_BuildValue("(Oidddd)", canvas->pyobj().ptr(), peakID, x, height, fwhm, background));
   Python::Dict kwargs = Python::qHashToDict(otherKwargs.get());
 
   auto const marker = markersModule.attr("PeakMarker")(*args, **kwargs);
@@ -38,9 +39,9 @@ namespace MantidQt::Widgets::MplCpp {
 /**
  * @brief Create a PeakMarker instance
  */
-PeakMarker::PeakMarker(FigureCanvasQt *canvas, int peakID, double x, double yTop, double yBottom, double fwhm,
+PeakMarker::PeakMarker(FigureCanvasQt *canvas, int peakID, double x, double height, double fwhm, double background,
                        QHash<QString, QVariant> const &otherKwargs)
-    : InstanceHolder(newMarker(canvas, peakID, x, yTop, yBottom, fwhm, otherKwargs)) {}
+    : InstanceHolder(newMarker(canvas, peakID, x, height, fwhm, background, otherKwargs)) {}
 
 /**
  * @brief Redraw the PeakMarker

--- a/qt/widgets/plotting/inc/MantidQtWidgets/Plotting/PeakPicker.h
+++ b/qt/widgets/plotting/inc/MantidQtWidgets/Plotting/PeakPicker.h
@@ -28,7 +28,7 @@ public:
   void redraw();
   void remove();
 
-  void setPeak(const Mantid::API::IPeakFunction_const_sptr &peak);
+  void setPeak(const Mantid::API::IPeakFunction_const_sptr &peak, const double background = 0.0);
   Mantid::API::IPeakFunction_sptr peak() const;
 
   void select(bool select);

--- a/qt/widgets/plotting/src/PeakPicker.cpp
+++ b/qt/widgets/plotting/src/PeakPicker.cpp
@@ -15,8 +15,7 @@ namespace MantidQt::MantidWidgets {
 
 PeakPicker::PeakPicker(PreviewPlot *plot)
     : QObject(), m_plot(plot), m_peak(nullptr),
-      m_peakMarker(std::make_unique<PeakMarker>(m_plot->canvas(), 1, std::get<0>(m_plot->getAxisRange()),
-                                                std::get<1>(m_plot->getAxisRange(AxisID::YLeft)), 0.0, 0.0)) {
+      m_peakMarker(std::make_unique<PeakMarker>(m_plot->canvas(), 1, 1.0, 0.0, 0.0, 0.0)) {
   m_plot->canvas()->draw();
 
   connect(m_plot, SIGNAL(mouseDown(QPoint)), this, SLOT(handleMouseDown(QPoint)));

--- a/qt/widgets/plotting/src/PeakPicker.cpp
+++ b/qt/widgets/plotting/src/PeakPicker.cpp
@@ -30,10 +30,10 @@ void PeakPicker::redraw() { m_peakMarker->redraw(); }
 
 void PeakPicker::remove() { m_peakMarker->remove(); }
 
-void PeakPicker::setPeak(const Mantid::API::IPeakFunction_const_sptr &peak) {
+void PeakPicker::setPeak(const Mantid::API::IPeakFunction_const_sptr &peak, const double background) {
   if (peak) {
     m_peak = std::dynamic_pointer_cast<IPeakFunction>(peak->clone());
-    m_peakMarker->updatePeak(peak->centre(), peak->height(), peak->fwhm());
+    m_peakMarker->updatePeak(peak->centre(), peak->height(), peak->fwhm(), background);
   }
 }
 


### PR DESCRIPTION
**Description of work.**
This PR makes it possible to specify a background value for the peak picker tool. This feature is now used on the ALFView interface so that the peak picker lines up with the peak in the y direction.

This PR also makes it so that the peak picker is activated by default when data is extracted on ALFView. This makes more sense than having it deactivated because it is only possible to have one peak picker on this interface so there can be no confusion between which peak picker is active.

**To test:**
Open the ALFView interface
Load ALF82301 as sample
Select the pick tab
Click the 'Select whole tube' button
Select the two middle tubes
There should be a red vertical line on the right-hand side plot. It should be taking into account the background below the peak.

Fixes #35002 


#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
