### PR TITLE
Avoid scope issue with tbb global_control object

### DIFF
--- a/Framework/API/src/FrameworkManager.cpp
+++ b/Framework/API/src/FrameworkManager.cpp
@@ -27,21 +27,7 @@
 #include <cstdarg>
 #include <memory>
 
-// The below can be replaced with global_control when all platforms
-// have 2019U4
-#if __has_include("tbb/tbb_stddef.h")
-#include "tbb/tbb_stddef.h"
-#if TBB_INTERFACE_VERSION_MAJOR < 11
-#include "tbb/task_scheduler_init.h"
-#include <thread>
-#else
-#define TBB_HAS_GLOBAL_CONTROL
 #include "tbb/global_control.h"
-#endif
-#else
-#define TBB_HAS_GLOBAL_CONTROL
-#include "tbb/global_control.h"
-#endif
 
 #ifdef _WIN32
 #include <winsock2.h>
@@ -57,11 +43,7 @@
 #endif
 
 namespace {
-#ifdef TBB_HAS_GLOBAL_CONTROL
-std::unique_ptr<tbb::global_control> m_globalTbbControl;
-#else
-thread_local std::unique_ptr<tbb::task_scheduler_init> m_globalTbbControl;
-#endif
+tbb::global_control *GLOBAL_TBB_CONTROL = nullptr;
 } // namespace
 
 namespace Mantid {
@@ -187,15 +169,11 @@ void FrameworkManagerImpl::setNumOMPThreadsToConfigValue() {
 void FrameworkManagerImpl::setNumOMPThreads(const int nthreads) {
   g_log.debug() << "Setting maximum number of threads to " << nthreads << "\n";
   PARALLEL_SET_NUM_THREADS(nthreads);
-  if (m_globalTbbControl) {
-    m_globalTbbControl.reset(); // Have to reset to change the number of threads at runtime
+  if (GLOBAL_TBB_CONTROL) {
+    delete GLOBAL_TBB_CONTROL; // Have to reset to change the number of threads at runtime
   }
 
-#ifdef TBB_HAS_GLOBAL_CONTROL
-  m_globalTbbControl = std::make_unique<tbb::global_control>(tbb::global_control::max_allowed_parallelism, nthreads);
-#else
-  m_globalTbbControl = std::make_unique<tbb::task_scheduler_init>(nthreads);
-#endif
+  GLOBAL_TBB_CONTROL = new tbb::global_control(tbb::global_control::max_allowed_parallelism, nthreads);
 }
 
 /**
@@ -219,7 +197,7 @@ void FrameworkManagerImpl::clear() {
 void FrameworkManagerImpl::shutdown() {
   Kernel::UsageService::Instance().shutdown();
   // Ensure we don't run into static init ordering issues with TBB
-  m_globalTbbControl.reset();
+  delete GLOBAL_TBB_CONTROL;
   clear();
 }
 

--- a/Framework/API/src/FrameworkManager.cpp
+++ b/Framework/API/src/FrameworkManager.cpp
@@ -43,6 +43,13 @@
 #endif
 
 namespace {
+// We use a raw pointer over a unique_ptr to avoid problems with static deallocation order of static
+// variables. In certain circumstances, e.g. unit testing, the shutdown method on FrameworkManager is
+// not called. In this situation unique_ptr causes the tbb::global_control object to be destroyed
+// *after* its own internal static data has been destroyed and we see a random segfault.
+// We have technically introduced a leak by not deleting this object in the situation where
+// `FrameworkManager::shutdown` is not called but the memory cannot be used again by the program since
+// it survives for the duration of the program. It will ultimately be reclaimed by the OS.
 tbb::global_control *GLOBAL_TBB_CONTROL = nullptr;
 } // namespace
 


### PR DESCRIPTION
**Description of work.**

A few algorithm tests (especially LogarithmTest) were failing quite consistently on Windows since moving to a newer version of tbb (2020.2 -> 2021). The cause was determined to be a problem with the lifetime of a tbb `global_control` object (which is only created when `MultiThreaded.MaxCores=1` (or higher) is set in the Mantid.User.properties file). We now use a raw pointer instead of a unique pointer to avoid the static object going out of scope too early and causing unhandled exceptions to be thrown from tbb.

Some out-of-date code has also been removed.

**To test:**
All tests should pass now.

On Windows only:
1. Set `MultiThreaded.MaxCores=1` in the Mantid.user.properties file in your build directory.
2. Run the LogarithmTest unit test. It should pass now every time you run it.

*There is no associated issue.*

*This does not require release notes* because **it is an internal change not visibile to the user**

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
