### PR TITLE
Load Dialog crash after closing when loading

### DIFF
--- a/docs/source/release/v6.7.0/Workbench/Bugfixes/35056.rst
+++ b/docs/source/release/v6.7.0/Workbench/Bugfixes/35056.rst
@@ -1,0 +1,1 @@
+- A crash caused by closing the Load Dialog while it is still attempting to loading a file has been fixed.

--- a/docs/source/release/v6.7.0/Workbench/Bugfixes/35056.rst
+++ b/docs/source/release/v6.7.0/Workbench/Bugfixes/35056.rst
@@ -1,1 +1,1 @@
-- A crash caused by closing the Load Dialog while it is still attempting to loading a file has been fixed.
+- A crash caused by closing the Load Dialog while it is attempting to load a file has been fixed.

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FindFilesThreadPoolManager.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FindFilesThreadPoolManager.h
@@ -47,10 +47,6 @@ signals:
   // Signal emitted to cancel any already running workers
   void disconnectWorkers();
 
-private slots:
-  // Handle when a search is finished
-  void searchFinished();
-
 private:
   /// Get a handle to the static file finder thread pool instance
   const std::unique_ptr<QThreadPool> &poolInstance() const;
@@ -61,8 +57,6 @@ private:
 
   /// Handle to the allocator function for creating new worker threads
   ThreadAllocator m_workerAllocator;
-  /// Flag set if a search is currently running
-  bool m_searchIsRunning;
 };
 
 } // namespace API

--- a/qt/widgets/common/src/FindFilesThreadPoolManager.cpp
+++ b/qt/widgets/common/src/FindFilesThreadPoolManager.cpp
@@ -112,7 +112,7 @@ void FindFilesThreadPoolManager::cancelWorker() {
 
 /** Check if a search is currently executing.
  *
- * @returns true if the current worker object is null
+ * @returns true if no worker threads are active
  */
 bool FindFilesThreadPoolManager::isSearchRunning() const { return poolInstance()->activeThreadCount() > 0; }
 

--- a/qt/widgets/common/src/FindFilesThreadPoolManager.cpp
+++ b/qt/widgets/common/src/FindFilesThreadPoolManager.cpp
@@ -73,7 +73,6 @@ void FindFilesThreadPoolManager::createWorker(const QObject *parent, const FindF
   // pass ownership to the thread pool
   // we do not need to worry about deleting worker
   poolInstance()->start(worker);
-  m_searchIsRunning = true;
 }
 
 /** Connect a new worker to the listening parent
@@ -93,9 +92,6 @@ void FindFilesThreadPoolManager::connectWorker(const QObject *parent, const Find
   parent->connect(worker, SIGNAL(finished(const FindFilesSearchResults &)), parent, SIGNAL(fileFindingFinished()),
                   Qt::QueuedConnection);
 
-  this->connect(worker, SIGNAL(finished(const FindFilesSearchResults &)), this, SLOT(searchFinished()),
-                Qt::QueuedConnection);
-
   this->connect(this, SIGNAL(disconnectWorkers()), worker, SLOT(disconnectWorker()), Qt::QueuedConnection);
 }
 
@@ -111,7 +107,6 @@ void FindFilesThreadPoolManager::cancelWorker() {
   // waiting for it to finish before starting a new thread locks up the GUI
   // event loop.
   emit disconnectWorkers();
-  m_searchIsRunning = false;
   QCoreApplication::sendPostedEvents();
 }
 
@@ -119,7 +114,7 @@ void FindFilesThreadPoolManager::cancelWorker() {
  *
  * @returns true if the current worker object is null
  */
-bool FindFilesThreadPoolManager::isSearchRunning() const { return m_searchIsRunning; }
+bool FindFilesThreadPoolManager::isSearchRunning() const { return poolInstance()->activeThreadCount() > 0; }
 
 /** Wait for all threads in the pool to finish running.
  *
@@ -128,7 +123,3 @@ bool FindFilesThreadPoolManager::isSearchRunning() const { return m_searchIsRunn
  * to freeze up.
  */
 void FindFilesThreadPoolManager::waitForDone() { poolInstance()->waitForDone(); }
-
-/** Mark the search as being finished.
- */
-void FindFilesThreadPoolManager::searchFinished() { m_searchIsRunning = false; }

--- a/qt/widgets/common/src/FindFilesThreadPoolManager.cpp
+++ b/qt/widgets/common/src/FindFilesThreadPoolManager.cpp
@@ -112,7 +112,7 @@ void FindFilesThreadPoolManager::cancelWorker() {
 
 /** Check if a search is currently executing.
  *
- * @returns true if no worker threads are active
+ * @returns true if at least one worker thread is active
  */
 bool FindFilesThreadPoolManager::isSearchRunning() const { return poolInstance()->activeThreadCount() > 0; }
 

--- a/qt/widgets/plugins/algorithm_dialogs/inc/MantidQtWidgets/Plugins/AlgorithmDialogs/LoadDialog.h
+++ b/qt/widgets/plugins/algorithm_dialogs/inc/MantidQtWidgets/Plugins/AlgorithmDialogs/LoadDialog.h
@@ -43,11 +43,9 @@ namespace CustomDialogs {
   @author Martyn Gigg, Tessella plc
   @date 31/01/2011
 */
-class PreventLoadRequests;
 
 class LoadDialog final : public API::AlgorithmDialog {
   Q_OBJECT
-  friend PreventLoadRequests;
 
 public:
   /// Default constructor
@@ -66,6 +64,8 @@ private slots:
   void enableNameSuggestion(const bool on = false);
   /// Override accept() slot
   void accept() override;
+  ///  Accept the load dialog when user input is inspected and is valid
+  void resultInspectionFinished();
 
 private:
   /// Initialize the layout
@@ -80,10 +80,6 @@ private:
   void createDynamicLayout();
   /// Create the widgets for a given property
   int createWidgetsForProperty(const Mantid::Kernel::Property *prop, QVBoxLayout *propertyLayout, QWidget *parent);
-  /// Ignore requests to load until they are re-enabled.
-  void disableLoadRequests();
-  /// Accept requests to load until they are disabled.
-  void enableLoadRequests();
 
 private:
   /// Form
@@ -94,6 +90,8 @@ private:
   int m_initialHeight;
   /// Flag to indicating if we are populating the dialog
   bool m_populating;
+  /// Flag to indicate the user accepted the load dialog
+  bool m_userAccept;
 };
 } // namespace CustomDialogs
 } // namespace MantidQt

--- a/qt/widgets/plugins/algorithm_dialogs/src/LoadDialog.cpp
+++ b/qt/widgets/plugins/algorithm_dialogs/src/LoadDialog.cpp
@@ -116,10 +116,11 @@ void LoadDialog::enableNameSuggestion(const bool on) {
  */
 void LoadDialog::accept() {
   // If the LoadDialog is already loading data, or is populating, then ignore the accept
-  if (!m_form.fileWidget->isSearching() && !m_populating) {
-    m_userAccept = true;
-    m_form.fileWidget->findFiles();
+  if (m_form.fileWidget->isSearching() || m_populating) {
+    return;
   }
+  m_userAccept = true;
+  m_form.fileWidget->findFiles();
 }
 
 void LoadDialog::resultInspectionFinished() {


### PR DESCRIPTION
**Description of work.**
This PR fixes a crash caused by closing the LoadDialog while it was still attempting to load a file.

The code was previously using a while loop to wait for the LoadDialog to search for the specified file before continuing with accepting the dialog. In this while loop it was calling `QApplication->processEvents()` to refresh the GUI. This means you can close the LoadDialog whilst it is still in the while loop, as events are being processed. This is not recommended in the Qt documentation for processEvents https://doc.qt.io/qt-6/qcoreapplication.html#processEvents .

A safer way to handle this is to connect a signal to the FileFinder worker and then do any post-processing in a separate slot function. This means if the LoadDialog is closed while it is still searching for a file, the signal connection is also removed, and this avoids the read access violation.

This has also allowed me to do some cleaning and remove some unnecessary code.

**To test:**
Follow the instructions in the attached issue
Also try load files which should be found successfully

Fixes #35056

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
