### PR TITLE
Reset cut view presenter to None on tool closing

### DIFF
--- a/docs/source/release/v6.6.0/Workbench/SliceViewer/Bugfixes/35069.rst
+++ b/docs/source/release/v6.6.0/Workbench/SliceViewer/Bugfixes/35069.rst
@@ -1,0 +1,1 @@
+* Fix bug causing cut representation to be re-drawn on the sliceviewer colorfill plot on changing viewing axes when non-axis aligned cutting tool was not enabled.

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/presenters/presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/presenters/presenter.py
@@ -372,6 +372,7 @@ class SliceViewer(ObservingPresenter, SliceViewerBasePresenter):
                 data_view.enable_tool_button(tool)
             if self.get_sliceinfo().can_support_nonorthogonal_axes():
                 data_view.enable_tool_button(ToolItemText.NONORTHOGONAL_AXES)
+            self._cutviewer_presenter = None
 
     def replace_workspace(self, workspace_name, workspace):
         """

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_sliceviewer_presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_sliceviewer_presenter.py
@@ -334,15 +334,18 @@ class SliceViewerTest(unittest.TestCase):
     def test_cut_view_toggled_off(self, mock_get_sliceinfo):
         presenter = SliceViewer(None, model=self.model, view=self.view)
         presenter._cutviewer_presenter = mock.MagicMock()
+        self.hide_view_called = False
+        presenter._cutviewer_presenter.hide_view.side_effect = lambda: setattr(self, "hide_view_called", True)
         mock_get_sliceinfo.return_value.can_support_nonorthogonal_axes.return_value = True
 
         presenter.non_axis_aligned_cut(False)
 
-        presenter._cutviewer_presenter.hide_view.assert_called_once()
+        self.assertTrue(self.hide_view_called)
         # test correct buttons disabled
         self.view.data_view.enable_tool_button.assert_has_calls(
             [mock.call(tool) for tool in (ToolItemText.REGIONSELECTION, ToolItemText.LINEPLOTS, ToolItemText.NONORTHOGONAL_AXES)]
         )
+        self.assertTrue(presenter._cutviewer_presenter is None)
 
     @mock.patch("mantidqt.widgets.sliceviewer.presenters.presenter.SliceViewer.new_plot_MDH")
     @mock.patch("mantidqt.widgets.sliceviewer.presenters.presenter.SliceInfo")


### PR DESCRIPTION
**Description of work.**

Reset cut view presenter to None on tool closing - this means it will be None when dimensions_changed called and cut representation will not be drawn

**To test:**

(1) Follow instruction on issue - the cut view tool will no longer be drawn

Fixes #34983 
<!-- alternative
*There is no associated issue.*
-->



<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
