### PR TITLE
Prevent crash when fixing fit parameter

### DIFF
--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FitPropertyBrowser.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FitPropertyBrowser.h
@@ -444,7 +444,7 @@ private slots:
   void clearFitResultStatus();
 
 public: // functions declared public for testing
-  QString getOldExpressionAsString(QString &parameterName) const;
+  QString getOldExpressionAsString(const QString &parameterName) const;
   /// Create CompositeFunction from string
   void createCompositeFunction(const QString &str = "");
 

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/FitPropertyBrowser.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/FitPropertyBrowser.h
@@ -443,6 +443,11 @@ private slots:
   /// Clear the Fit status display
   void clearFitResultStatus();
 
+public: // functions declared public for testing
+  QString getOldExpressionAsString(QString &parameterName) const;
+  /// Create CompositeFunction from string
+  void createCompositeFunction(const QString &str = "");
+
 protected:
   void modifyFitMenu(QAction *fitAction, bool enabled);
   virtual void populateFitMenuButton(QSignalMapper *fitMapper, QMenu *fitMenu);
@@ -475,8 +480,6 @@ protected:
   void minimizerChanged();
   /// Do the fitting
   void doFit(int maxIterations);
-  /// Create CompositeFunction from string
-  void createCompositeFunction(const QString &str = "");
   /// Catches unexpected not found exceptions
   Mantid::API::IFunction_sptr tryCreateFitFunction(const QString &str);
   /// Create CompositeFunction from pointer

--- a/qt/widgets/common/src/FitPropertyBrowser.cpp
+++ b/qt/widgets/common/src/FitPropertyBrowser.cpp
@@ -1459,14 +1459,14 @@ void FitPropertyBrowser::stringChanged(QtProperty *prop) {
 /** Get the tie expression stored in the function in case the new expression is invalid and the GUI needs to be reset
  * @param parameterName :: A pointer to the parameter name
  */
-QString FitPropertyBrowser::getOldExpressionAsString(QString &parameterName) const {
+QString FitPropertyBrowser::getOldExpressionAsString(const QString &parameterName) const {
   // Note this only finds the oldTie if it was a tie to a function (e.g. f0.Height=f1.Height)
   // but not if it was a custom tie (e.g. f0.Height=2.0)
   QString oldExp;
   size_t parIndex;
   try {
     parIndex = compositeFunction()->parameterIndex(parameterName.toStdString());
-  } catch (std::exception) {
+  } catch (std::exception &) {
     return "";
   }
   const auto oldTie = compositeFunction()->getTie(parIndex);

--- a/qt/widgets/common/src/FitPropertyBrowser.cpp
+++ b/qt/widgets/common/src/FitPropertyBrowser.cpp
@@ -1431,13 +1431,7 @@ void FitPropertyBrowser::stringChanged(QtProperty *prop) {
 
     QString parName = h->functionPrefix() + "." + parProp->propertyName();
 
-    // Get the tie expression stored in the function in case the new expression is invalid
-    // and the GUI needs to be reset
-    const auto parIndex = compositeFunction()->parameterIndex(parName.toStdString());
-    const auto oldTie = compositeFunction()->getTie(parIndex);
-    const auto oldTieStr = oldTie->asString();
-    const auto oldExp = QString::fromStdString(oldTieStr.substr(oldTieStr.find("=") + 1));
-
+    const auto oldExp = getOldExpressionAsString(parName);
     const auto exp = m_stringManager->value(prop);
 
     if (oldExp == exp)
@@ -1460,6 +1454,29 @@ void FitPropertyBrowser::stringChanged(QtProperty *prop) {
     emit functionChanged();
     return;
   }
+}
+
+/** Get the tie expression stored in the function in case the new expression is invalid and the GUI needs to be reset
+ * @param parameterName :: A pointer to the parameter name
+ */
+QString FitPropertyBrowser::getOldExpressionAsString(QString &parameterName) const {
+  // Note this only finds the oldTie if it was a tie to a function (e.g. f0.Height=f1.Height)
+  // but not if it was a custom tie (e.g. f0.Height=2.0)
+  QString oldExp;
+  size_t parIndex;
+  try {
+    parIndex = compositeFunction()->parameterIndex(parameterName.toStdString());
+  } catch (std::exception) {
+    return "";
+  }
+  const auto oldTie = compositeFunction()->getTie(parIndex);
+  if (oldTie) {
+    const auto oldTieStr = oldTie->asString();
+    oldExp = QString::fromStdString(oldTieStr.substr(oldTieStr.find("=") + 1));
+  } else {
+    oldExp = "";
+  }
+  return oldExp;
 }
 
 /** Called when a filename property changed

--- a/qt/widgets/common/test/FitPropertyBrowserTest.h
+++ b/qt/widgets/common/test/FitPropertyBrowserTest.h
@@ -10,6 +10,7 @@
 #include "MantidAPI/IFunction1D.h"
 #include "MantidAPI/ParamFunction.h"
 #include "MantidQtWidgets/Common/FitPropertyBrowser.h"
+#include <QString>
 #include <cxxtest/TestSuite.h>
 
 using namespace Mantid::API;
@@ -39,8 +40,16 @@ DECLARE_FUNCTION(FitPropertyBrowserTest_Funct)
 
 class FitPropertyBrowserTest : public CxxTest::TestSuite {
 public:
-  // This is a very specific test for a bug that is now fixed to prevent
-  // regression
+  static FitPropertyBrowserTest *createSuite() { return new FitPropertyBrowserTest; }
+  static void destroySuite(FitPropertyBrowserTest *suite) { delete suite; }
+
+  void setUp() override { // create a FunctionBrowser
+    m_fitPropertyBrowser = std::make_unique<MantidQt::MantidWidgets::FitPropertyBrowser>();
+  }
+
+  void tearDown() override { m_fitPropertyBrowser.reset(); }
+
+  // This is a very specific test for a bug that is now fixed to prevent regression
   void test_FunctionFactory_notification_is_released() {
 
     // create a FunctionBrowser
@@ -53,4 +62,39 @@ public:
     // Make sure the FunctionFactory does not have a dead link as an observer
     TS_ASSERT_THROWS_NOTHING(FunctionFactory::Instance().unsubscribe("FitPropertyBrowserTest_Funct");)
   }
+
+  void test_getOldExpressionAsString_returns_empty_string_when_tie_is_null() {
+    // initialise it fitPropertyBrowser- this adds an observer on the function factory update message
+    m_fitPropertyBrowser->init();
+    m_fitPropertyBrowser->createCompositeFunction("name=Gaussian,Height=100,PeakCentre=1.45,Sigma=0.2;");
+    QString parameterName = "f0.Height";
+    auto oldExpString = m_fitPropertyBrowser->getOldExpressionAsString(parameterName);
+    TS_ASSERT_EQUALS(oldExpString.toStdString(), "");
+  }
+
+  void test_getOldExpressionAsString_returns_empty_string_when_parameter_is_null() {
+    // initialise it fitPropertyBrowser- this adds an observer on the function factory update message
+    m_fitPropertyBrowser->init();
+    m_fitPropertyBrowser->createCompositeFunction("name=Gaussian,Height=100,PeakCentre=1.45,Sigma=0.2;");
+    QString parameterName = "InvalidParameterName";
+    auto oldExpString = m_fitPropertyBrowser->getOldExpressionAsString(parameterName);
+    TS_ASSERT_EQUALS(oldExpString.toStdString(), "");
+  }
+
+  void test_getOldExpressionAsString_returns_function_expression() {
+    // Note this test only works for a tie to a function (e.g. f0.Height=f1.Height) but not a constant (e.g.
+    // f0.Height=5.0)
+
+    m_fitPropertyBrowser->init();
+    m_fitPropertyBrowser->createCompositeFunction(
+        "name=Gaussian,Height=10.0,PeakCentre=-0.145,Sigma=0.135;name=Gaussian,Height=12.0,PeakCentre=0.245,Sigma=0."
+        "135;ties=(f0.Height=f1.Height)");
+    QString parameterName = "f0.Height";
+    const std::string expectedTieExpression = "f1.Height";
+    auto oldExpString = m_fitPropertyBrowser->getOldExpressionAsString(parameterName);
+    TS_ASSERT_EQUALS(oldExpString.toStdString(), expectedTieExpression);
+  }
+
+private:
+  std::unique_ptr<MantidQt::MantidWidgets::FitPropertyBrowser> m_fitPropertyBrowser;
 };

--- a/qt/widgets/common/test/FitPropertyBrowserTest.h
+++ b/qt/widgets/common/test/FitPropertyBrowserTest.h
@@ -54,8 +54,7 @@ public:
 
     // create a FunctionBrowser
     auto fpBrowser = std::make_unique<MantidQt::MantidWidgets::FitPropertyBrowser>();
-    // initialise it - this adds an observer on the function factory update
-    // message
+    // initialise it - this adds an observer on the function factory update message
     fpBrowser->init();
     // delete the FunctionBrowser
     fpBrowser.reset();
@@ -64,7 +63,7 @@ public:
   }
 
   void test_getOldExpressionAsString_returns_empty_string_when_tie_is_null() {
-    // initialise it fitPropertyBrowser- this adds an observer on the function factory update message
+    // initialise fitPropertyBrowser- this adds an observer on the function factory update message
     m_fitPropertyBrowser->init();
     m_fitPropertyBrowser->createCompositeFunction("name=Gaussian,Height=100,PeakCentre=1.45,Sigma=0.2;");
     QString parameterName = "f0.Height";
@@ -73,7 +72,7 @@ public:
   }
 
   void test_getOldExpressionAsString_returns_empty_string_when_parameter_is_null() {
-    // initialise it fitPropertyBrowser- this adds an observer on the function factory update message
+    // initialise fitPropertyBrowser- this adds an observer on the function factory update message
     m_fitPropertyBrowser->init();
     m_fitPropertyBrowser->createCompositeFunction("name=Gaussian,Height=100,PeakCentre=1.45,Sigma=0.2;");
     QString parameterName = "InvalidParameterName";


### PR DESCRIPTION
I have added a new separate function getOldExpressionAsString() which returns a previously set tie value and this new function enabled testing.
If there is an oldTie for the parameter, which was a tie to function (e.g. f0.Height=f1.Height) then the oldTieExpression is returned. This allows an edited Tie to function text box to revert upon an invalid entry see pr #34817 Note this function does not get an oldTie if it was custom (e.g. f0.Height=2.0) This new function also allows fixing a parameter, when oldTie is nullptr.

**Description of work.**

Prevent crash on fixing a fit parameter. The whole point of looking for the oldTieExpression is, only in the case of a tie to a function, a new invalid entry to the textbox for the Tie will be reverted to the old function.

**To test:**

- [ ] Check no crash when fixing a parameter
  - Open Workbench and run CreateSampleWorkspace()
  - Double Click on the produced workspace and plot the first spectrum
  - Click the Fit toolbar button to activate the FitPropertyBrowser
  - Right-click on the plot and Add a Peak
  - Click the triangle by the newly added peak function to get the parameter dropdownlist.
  - Right-click on a parameter, such as Height, and select "Fix".
  - A fix should be applied with no crash!
  - Run Fit>Fit, a success or failed fit is fine. 
- [ ] Run through these instructions I copied over from on this PR: https://github.com/mantidproject/mantid/pull/34817
  - Load some data
  - Plot a spectrum
  - Click 'Fit' to open the fitting widget
  - Right click and add a peak, then a second
  - Right click f0.Height -> Tie -> To function -> f1.Height
  - Click on the tie box and change it from f1.Height to something invalid (e.g hello)
  - Check that an error box was shown
  - Click okay on the error box and check the tie value has reverted to f1.Height
  - Click on the tie box and change the value to f1.Sigma to test it will update correctly
  - Note that if you run these instructions but set your "invalid entry" as a number (e.g. `6`) then you have reproduced a different issue: https://github.com/mantidproject/mantid/issues/34980
- [ ] Code review

Fixes #34982

*This does not require release notes* because **fix bug introduced in this release cycle**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
