### PR TITLE
Time roi refactor

### DIFF
--- a/Framework/Kernel/inc/MantidKernel/TimeROI.h
+++ b/Framework/Kernel/inc/MantidKernel/TimeROI.h
@@ -41,7 +41,7 @@ public:
   void removeRedundantEntries();
   const Kernel::SplittingIntervalVec toSplitters() const;
   bool operator==(const TimeROI &other) const;
-  void debugPrint() const;
+  void debugPrint(const std::size_t type = 0) const;
   size_t getMemorySize() const;
 
   // nexus items
@@ -49,14 +49,9 @@ public:
 
 private:
   std::vector<Types::Core::DateAndTime> getAllTimes(const TimeROI &other);
-  void replaceValues(const std::vector<Types::Core::DateAndTime> &times, const std::vector<bool> &values);
+  void validateValues(const std::string &label);
   bool isCompletelyInROI(const Types::Core::DateAndTime &startTime, const Types::Core::DateAndTime &stopTime) const;
-  /**
-   * @brief m_roi private member that holds most of the information
-   *
-   * This handles the details of the ROI and guarantees that views into the underlying structure is sorted by time.
-   */
-  TimeSeriesProperty<bool> m_roi;
+  std::vector<Types::Core::DateAndTime> m_roi;
 };
 
 } // namespace Kernel

--- a/Framework/Kernel/inc/MantidKernel/TimeROI.h
+++ b/Framework/Kernel/inc/MantidKernel/TimeROI.h
@@ -22,7 +22,7 @@ public:
 
   TimeROI();
   TimeROI(const Types::Core::DateAndTime &startTime, const Types::Core::DateAndTime &stopTime);
-  TimeROI(const Kernel::TimeSeriesProperty<bool> &filter);
+  TimeROI(const Kernel::TimeSeriesProperty<bool> *filter);
   double durationInSeconds() const;
   double durationInSeconds(const Types::Core::DateAndTime &startTime, const Types::Core::DateAndTime &stopTime) const;
   std::size_t numBoundaries() const;
@@ -38,7 +38,6 @@ public:
   void replaceROI(const TimeROI &other);
   void update_union(const TimeROI &other);
   void update_intersection(const TimeROI &other);
-  void removeRedundantEntries();
   const Kernel::SplittingIntervalVec toSplitters() const;
   bool operator==(const TimeROI &other) const;
   void debugPrint(const std::size_t type = 0) const;

--- a/Framework/Kernel/src/TimeROI.cpp
+++ b/Framework/Kernel/src/TimeROI.cpp
@@ -5,7 +5,7 @@
 //   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 // SPDX - License - Identifier: GPL - 3.0 +
 
-#include <iostream> // TODO REMOVE
+#include <iostream>
 #include <limits>
 
 #include "MantidKernel/Logger.h"
@@ -43,7 +43,7 @@ TimeROI::TimeROI(const Types::Core::DateAndTime &startTime, const Types::Core::D
   this->addROI(startTime, stopTime);
 }
 
-TimeROI::TimeROI(const Kernel::TimeSeriesProperty<bool> &filter) { this->replaceROI(filter); }
+TimeROI::TimeROI(const Kernel::TimeSeriesProperty<bool> *filter) { this->replaceROI(filter); }
 
 void TimeROI::addROI(const std::string &startTime, const std::string &stopTime) {
   this->addROI(DateAndTime(startTime), DateAndTime(stopTime));
@@ -340,61 +340,6 @@ void TimeROI::update_intersection(const TimeROI &other) {
   if (m_roi.back() > other.m_roi.back()) {
     this->addMask(other.m_roi.back(), m_roi.back());
   }
-}
-
-/**
- * Remove time/value pairs that are not necessary to describe the TimeROI
- * - Sort the times/values
- * - Ensure that values start with USE and should end with IGNORE
- * - Remove values that are not needed (e.g. IGNORE followed by IGNORE)
- * - Remove values that are overridden. Overridden values are ones where a new value was added at the same time, the
- * last one added will be used.
- */
-void TimeROI::removeRedundantEntries() {
-  /* TODO
-if (this->numBoundaries() < 2) {
-  return; // nothing to do with zero or one elements
-}
-
-// when an individual time has multiple values, use the last value added
-m_roi.eliminateDuplicates();
-
-// get a copy of the current roi
-const auto values_old = m_roi.valuesAsVector();
-if (valuesAreAlternating(values_old)) {
-  // there is nothing more to do
-  return;
-}
-const auto times_old = m_roi.timesAsVector();
-const auto ORIG_SIZE = values_old.size();
-
-// create new vector to put result into
-std::vector<bool> values_new;
-std::vector<DateAndTime> times_new;
-
-// skip ahead to first time that isn't ignore
-// since before being in the ROI means ignore
-std::size_t index_old = 0;
-while (values_old[index_old] == ROI_IGNORE) {
-  index_old++;
-}
-// add the current location which will always start with use
-values_new.push_back(ROI_USE);
-times_new.push_back(times_old[index_old]);
-index_old++; // advance past location just added
-
-// copy in values that aren't the same as the ones before them
-for (; index_old < ORIG_SIZE; ++index_old) {
-  if (values_old[index_old] != values_old[index_old - 1]) {
-    values_new.push_back(values_old[index_old]);
-    times_new.push_back(times_old[index_old]);
-  }
-}
-
-// update the member value if anything has changed
-if (values_new.size() != ORIG_SIZE)
-  m_roi.replaceValues(times_new, values_new);
-  */
 }
 
 /**

--- a/Framework/Kernel/test/TimeROITest.h
+++ b/Framework/Kernel/test/TimeROITest.h
@@ -51,7 +51,6 @@ public:
     TS_ASSERT_EQUALS(value.durationInSeconds(), 0.);
     TS_ASSERT(value.empty());
     TS_ASSERT_EQUALS(value.numBoundaries(), 0);
-    value.removeRedundantEntries();
   }
 
   void test_badRegions() {
@@ -123,7 +122,6 @@ public:
     TS_ASSERT_EQUALS(value.numBoundaries(), 4);
 
     // get rid of entries that have no effect
-    value.removeRedundantEntries();
     TS_ASSERT_EQUALS(value.numBoundaries(), 4);
   }
 
@@ -204,7 +202,6 @@ public:
     TS_ASSERT_EQUALS(value.numBoundaries(), 2);
     value.addROI(CHRISTMAS_START, CHRISTMAS_STOP);
     TS_ASSERT_EQUALS(value.numBoundaries(), 2);
-    value.removeRedundantEntries();
   }
 
   void test_reversesortedROI() {
@@ -228,7 +225,6 @@ public:
 
     // since it ends with "on" the duration is infinite
     TS_ASSERT_EQUALS(value.durationInSeconds(), 0.);
-    value.removeRedundantEntries();
     TS_ASSERT(value.empty());
   }
 
@@ -242,7 +238,6 @@ public:
 
     value1.addROI(DateAndTime(NEW_YEARS_START), DateAndTime(NEW_YEARS_STOP));
     TS_ASSERT_EQUALS(value1.durationInSeconds(), ONE_DAY_DURATION);
-    value1.removeRedundantEntries();
     TS_ASSERT_EQUALS(value1.numBoundaries(), 2);
 
     // roi first
@@ -253,7 +248,6 @@ public:
 
     value2.addMask(DateAndTime(NEW_YEARS_START), DateAndTime(NEW_YEARS_STOP));
     TS_ASSERT_EQUALS(value2.durationInSeconds(), 0.);
-    value2.removeRedundantEntries();
     TS_ASSERT_EQUALS(value2.numBoundaries(), 0);
   }
 

--- a/Framework/Kernel/test/TimeROITest.h
+++ b/Framework/Kernel/test/TimeROITest.h
@@ -216,9 +216,18 @@ public:
   }
 
   void test_valueAtTime() {
-    TS_ASSERT_EQUALS(DECEMBER.valueAtTime(DECEMBER_STOP), false);
-    TS_ASSERT_EQUALS(DECEMBER.valueAtTime(CHRISTMAS_START), true);
-    TS_ASSERT_EQUALS(DECEMBER.valueAtTime(DECEMBER_START), true);
+    // to understand the checks, note that
+    // USE = true
+    // IGNORE = false
+
+    // values outside of the TimeROI should be ignore
+    TS_ASSERT_EQUALS(CHRISTMAS.valueAtTime(DECEMBER_START), false);
+    TS_ASSERT_EQUALS(CHRISTMAS.valueAtTime(DECEMBER_STOP), false);
+
+    // tests for more interesting values
+    TS_ASSERT_EQUALS(DECEMBER.valueAtTime(DECEMBER_START), true);  // first in region
+    TS_ASSERT_EQUALS(DECEMBER.valueAtTime(CHRISTMAS_START), true); // middle of region
+    TS_ASSERT_EQUALS(DECEMBER.valueAtTime(DECEMBER_STOP), false);  // last of region
   }
 
   void runIntersectionTest(const TimeROI &left, const TimeROI &right, const double exp_duration) {

--- a/Framework/Kernel/test/TimeROITest.h
+++ b/Framework/Kernel/test/TimeROITest.h
@@ -30,6 +30,13 @@ const TimeROI CHRISTMAS{CHRISTMAS_START, CHRISTMAS_STOP};
 const std::string NEW_YEARS_START("2022-12-31T00:01");
 const std::string NEW_YEARS_STOP("2023-01-01T00:01");
 
+const DateAndTime ONE("2023-01-01T00:01");
+const DateAndTime TWO("2023-01-02T00:01");
+const DateAndTime THREE("2023-01-03T00:01");
+const DateAndTime FOUR("2023-01-04T00:01");
+const DateAndTime FIVE("2023-01-05T00:01");
+const DateAndTime SIX("2023-01-06T00:01");
+
 class TimeROITest : public CxxTest::TestSuite {
 public:
   // This pair of boilerplate methods prevent the suite being created statically
@@ -99,13 +106,27 @@ public:
     TS_ASSERT_EQUALS(value.numBoundaries(), 4);
   }
 
-  void test_addOverlapping() {
-    const DateAndTime ONE("2023-01-01T00:01");
-    const DateAndTime TWO("2023-01-02T00:01");
-    const DateAndTime THREE("2023-01-03T00:01");
-    const DateAndTime FOUR("2023-01-04T00:01");
-    const DateAndTime FIVE("2023-01-05T00:01");
+  void test_addROI() {
+    TimeROI value{THREE, FOUR}; // 3-4
+    TS_ASSERT_EQUALS(value.durationInSeconds() / ONE_DAY_DURATION, 1.);
 
+    value.addROI(TWO, FIVE); // 2-5
+    TS_ASSERT_EQUALS(value.durationInSeconds() / ONE_DAY_DURATION, 3.);
+
+    value.addROI(TWO, SIX); // 2-6
+    TS_ASSERT_EQUALS(value.durationInSeconds() / ONE_DAY_DURATION, 4.);
+
+    value.addROI(THREE, FIVE); // 2-6
+    TS_ASSERT_EQUALS(value.durationInSeconds() / ONE_DAY_DURATION, 4.);
+
+    value.addROI(ONE, TWO); // 1-6
+    TS_ASSERT_EQUALS(value.durationInSeconds() / ONE_DAY_DURATION, 5.);
+
+    value.addMask(ONE, SIX); // empty
+    TS_ASSERT_EQUALS(value.durationInSeconds() / ONE_DAY_DURATION, 0.);
+  }
+
+  void test_addOverlapping() {
     TimeROI value{ONE, FOUR}; // 1-4
     TS_ASSERT_EQUALS(value.durationInSeconds() / ONE_DAY_DURATION, 3.);
     TS_ASSERT_EQUALS(value.numBoundaries(), 2);
@@ -169,7 +190,7 @@ public:
     TimeROI value;
     // add New Year's eve
     value.addROI(DateAndTime(NEW_YEARS_START), DateAndTime(NEW_YEARS_STOP));
-    TS_ASSERT_EQUALS(value.durationInSeconds(), ONE_DAY_DURATION);
+    TS_ASSERT_EQUALS(value.durationInSeconds() / ONE_DAY_DURATION, 1.);
     TS_ASSERT_EQUALS(value.numBoundaries(), 2);
 
     // add Hanukkah


### PR DESCRIPTION
So `TimeSeriesProperty` can have a reference to `TimeROI` the underlying implementation of `TimeROI` needs to be something else. This is that change.  At the end of this, `TimeROI` always has a valid state with the smallest number of values in it.

**To test:**

See the additional unit tests for things that were discovered during the refactor.

Refs #34794

*This does not require release notes* because it is a code refactor.

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
