### PR TITLE
Fix problem with logic for checking Efixed on indirect instruments

### DIFF
--- a/Framework/Algorithms/src/SampleCorrections/SparseWorkspace.cpp
+++ b/Framework/Algorithms/src/SampleCorrections/SparseWorkspace.cpp
@@ -132,7 +132,14 @@ SparseWorkspace::SparseWorkspace(const API::MatrixWorkspace &modelWS, const size
   if (eMode == Kernel::DeltaEMode::Direct) {
     mutableRun().addProperty("Ei", modelWS.getEFixed());
   } else if (eMode == Kernel::DeltaEMode::Indirect) {
-    const auto &detIDs = modelWS.detectorInfo().detectorIDs();
+    std::vector<detid_t> detIDs;
+    auto modelInstrument = modelWS.getInstrument();
+    for (size_t i = 0; i < modelWS.getNumberHistograms(); i++) {
+      const auto &spec = modelWS.getSpectrum(i);
+      const auto &specDetIDs = spec.getDetectorIDs();
+      if (!modelInstrument->isMonitor(specDetIDs))
+        detIDs.insert(detIDs.end(), specDetIDs.begin(), specDetIDs.end());
+    }
     if (!constantIndirectEFixed(modelWS, detIDs)) {
       throw std::runtime_error("Sparse instrument with variable EFixed not supported.");
     }

--- a/Framework/Algorithms/test/SparseWorkspaceTest.h
+++ b/Framework/Algorithms/test/SparseWorkspaceTest.h
@@ -469,4 +469,32 @@ public:
     TS_ASSERT_EQUALS(weights[2], 1 / 0.1 / 0.1)
     TS_ASSERT_EQUALS(weights[3], 1 / 0.4 / 0.4)
   }
+
+  void test_efixed_extraction_direct() {
+    using namespace WorkspaceCreationHelper;
+    auto ws = create2DWorkspaceWithRectangularInstrument(1, 2, 1);
+    auto inst = ws->getInstrument();
+    auto &pmap = ws->instrumentParameters();
+    pmap.addString(inst.get(), "deltaE-mode", "Direct");
+    ws->mutableRun().addProperty<double>("Ei", 1.845);
+    constexpr size_t gridRows = 3;
+    constexpr size_t gridCols = 4;
+    auto sparseWS = std::make_unique<SparseWorkspace>(*ws, 1, gridRows, gridCols);
+    TS_ASSERT_EQUALS(sparseWS->getEFixed(4), 1.845);
+  }
+
+  void test_efixed_extraction_indirect_efixed_on_compassembly() {
+    // IRIS stores the efixed on the analyser CompAssembly
+    using namespace WorkspaceCreationHelper;
+    auto ws = createGroupedWorkspace2D(1, 10, 1.0);
+    auto inst = ws->getInstrument();
+    auto &pmap = ws->instrumentParameters();
+    pmap.addString(inst.get(), "deltaE-mode", "Indirect");
+    auto bankComp = inst->getComponentByName("bank1");
+    pmap.addDouble(bankComp.get(), "Efixed", 1.845);
+    constexpr size_t gridRows = 3;
+    constexpr size_t gridCols = 4;
+    auto sparseWS = std::make_unique<SparseWorkspace>(*ws, 1, gridRows, gridCols);
+    TS_ASSERT_EQUALS(sparseWS->getEFixed(1), 1.845);
+  }
 };

--- a/docs/source/release/v6.6.0/Indirect/Algorithms/Bugfixes/35086_FixIndirectSparseLogic.rst
+++ b/docs/source/release/v6.6.0/Indirect/Algorithms/Bugfixes/35086_FixIndirectSparseLogic.rst
@@ -1,0 +1,1 @@
+- a problem has been fixed running :ref:`MonteCarloAbsorption <algm-MonteCarloAbsorption-v1>` on an indirect instrument using the Sparse Instrument feature. Detectors that are associated with an inactive analyser in the instrument definition no longer cause an error about retrieving the efixed value


### PR DESCRIPTION
**Description of work.**

Only check for efixed on detectors that are associated with a spectrum when creating a sparse workspace. For the IRIS instrument only a subset of the detectors are associated with a spectrum depending on which analyzer is active.

These changes avoid an exception when trying to run an absorption correction on an IRIS workspace using the sparse workspace feature.

**To test:**

Run script on attached issue and check it doesn't fail with an exception

Fixes #35080.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
