### PR TITLE
Fix workbench not launching from Windows Conda install

### DIFF
--- a/conda/recipes/mantidworkbench/post-link.bat
+++ b/conda/recipes/mantidworkbench/post-link.bat
@@ -1,0 +1,1 @@
+conda env config vars set QT_PLUGIN_PATH=%PREFIX%\Library\plugins

--- a/conda/recipes/mantidworkbench/pre-unlink.bat
+++ b/conda/recipes/mantidworkbench/pre-unlink.bat
@@ -1,0 +1,1 @@
+conda env config vars unset QT_PLUGIN_PATH


### PR DESCRIPTION
**Description of work.**
Since moving to Qt 5.15 the Windows Conda installed mantidworkbench won't launch with the following error:
```
qt.qpa.plugin: Could not find the Qt platform plugin "windows" in ""
This application failed to start because no Qt platform plugin could be initialized. Reinstalling the application may fix this problem.
```
To workaround this issue, the user could manually set the environment variable `QT_PLUGIN_PATH` within their conda environment.

Here we add a post install script to the mantidworkbench conda recipe that sets the environment variable automatically after workbench is installed into a conda environment. (see [here](https://docs.conda.io/projects/conda-build/en/3.23.x/resources/link-scripts.html))


**To test:**
The Windows pacakges were built here:
https://builds.mantidproject.org/job/build_packages_from_branch/221/
and the conda packages have been uploaded to my anaconda channel.

1. Create and activate a new conda environment to install the mantidworkbench Conda packge.
2. Install with `mamba install -c thomashampson mantidworkbench`
3. Launch with `workbench`, it should work as expected
4. (Optional) Verify the existence of the env variable with `conda env config vars list`

Fixes #34923

*This does not require release notes* because **this is a new bug that was introduced after the last release**


<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
