### PR TITLE
Fix Error when Renaming Workspaces with Open Plots

### DIFF
--- a/qt/applications/workbench/workbench/plotting/figuremanager.py
+++ b/qt/applications/workbench/workbench/plotting/figuremanager.py
@@ -159,7 +159,9 @@ class FigureManagerADSObserver(AnalysisDataServiceObserver):
                 ax.make_legend()
             ax.set_title(_replace_workspace_name_in_string(oldName, newName, ax.get_title()))
         if self.canvas.manager is not None:
-            self.canvas.manager.set_window_title(_replace_workspace_name_in_string(oldName, newName, self.canvas.get_window_title()))
+            self.canvas.manager.set_window_title(
+                _replace_workspace_name_in_string(oldName, newName, self.canvas.manager.get_window_title())
+            )
         self.canvas.draw()
 
 


### PR DESCRIPTION
**Description of work.**

Direct calls to the window title have now been deprecated. They are now behind an extra call to a manager object.

Handle that. 


**To test:**
1. Load some data
2. Make a plot
3. Rename the workspace
4. The window and plot titles should change to the chosen name. 


Fixes #35088 


*This does not require release notes* because **fixes a bug introduced in this release.**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
