### PR TITLE
Fix for cursor interacting with hidden width markers

### DIFF
--- a/docs/source/release/v6.6.0/Workbench/Bugfixes/35100.rst
+++ b/docs/source/release/v6.6.0/Workbench/Bugfixes/35100.rst
@@ -1,0 +1,1 @@
+- Fixed a bug where the user could drag the width handles of an unselected peak in the fit browser.

--- a/qt/python/mantidqt/mantidqt/plotting/markers.py
+++ b/qt/python/mantidqt/mantidqt/plotting/markers.py
@@ -551,7 +551,7 @@ class PeakMarker(QObject):
         if self.centre_marker.is_moving:
             self.left_width.is_moving = True
             self.right_width.is_moving = True
-        else:
+        elif self.is_selected:
             self.left_width.mouse_move_start(x, y)
             self.right_width.mouse_move_start(x, y)
 
@@ -583,7 +583,7 @@ class PeakMarker(QObject):
             self.left_width.mouse_move(x - dx, y)
             self.right_width.mouse_move(x + dx, y)
             self.peak_moved.emit(self.peak_id, x, self.height())
-        else:
+        elif self.is_selected:
             moved = self.left_width.mouse_move(x, y)
             if moved:
                 self.right_width.x = 2 * self.centre_marker.x - x

--- a/qt/python/mantidqt/mantidqt/widgets/fitpropertybrowser/interactive_tool.py
+++ b/qt/python/mantidqt/mantidqt/widgets/fitpropertybrowser/interactive_tool.py
@@ -159,7 +159,11 @@ class FitInteractiveTool(QObject):
             return
 
         for pm in self.peak_markers:
-            if pm.left_width.is_above(x, y) or pm.right_width.is_above(x, y) or pm.centre_marker.is_above(x, y):
+            if pm.centre_marker.is_above(x, y):
+                if not cursor:
+                    QApplication.setOverrideCursor(Qt.SizeHorCursor)
+                return
+            if pm.is_selected and (pm.left_width.is_above(x, y) or pm.right_width.is_above(x, y)):
                 if not cursor:
                     QApplication.setOverrideCursor(Qt.SizeHorCursor)
                 return


### PR DESCRIPTION
**Description of work.**

This PR stops the cursor changing when hovering over the hidden width handles of an unselected peak in the fit browser. It also fixes a bug where the same hidden width handles could be dragged and changed while hidden.

**To test:**

 - Load some data
 - Plot a spectrum
 - Click 'Fit' to open the fit browser
 - Add a peak and remember where its widths markers are
 - Add a second peak (this should unselect the first peak and hide the width markers)
 - [ ] Check that when you hover over where the first peak's width markers were, the cursor does not change
 - [ ] Check that you can't click and drag the width markers while they are hidden
 - [ ] Check that other hovering and dragging behaviour works as expected

Fixes #35100

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
