### PR TITLE
Fix matplotlib depreciation in SliceViewer

### DIFF
--- a/docs/source/release/v6.6.0/Workbench/New_features/34774.rst
+++ b/docs/source/release/v6.6.0/Workbench/New_features/34774.rst
@@ -1,0 +1,1 @@
+- Mantid Workbench is now compatible with matplotlib v3.6

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/presenters/lineplots.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/presenters/lineplots.py
@@ -375,7 +375,7 @@ class RectangleSelectionLinePlot(KeyHandler):
         if not self._selector.artists[0].get_visible():
             return
 
-        rect = self._selector.to_draw
+        rect = self._selector._selection_artist
         ll_x, ll_y = rect.get_xy()
         limits = ((ll_x, ll_x + rect.get_width()), (ll_y, ll_y + rect.get_height()))
 

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/simplescanviewer/rectangle_selection.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/simplescanviewer/rectangle_selection.py
@@ -24,7 +24,7 @@ class RectangleSelection(RectangleSelector):
         """
 
         if not self._interactive:
-            self.to_draw.set_visible(False)
+            self._selection_artist.set_visible(False)
 
         # update the eventpress and eventrelease with the resulting extents
         x1, x2, y1, y2 = self.extents


### PR DESCRIPTION
**Description of work.**
- Fix depreciation in matplotlib RectangleSelector.
- Added general release note for matplotlib migration to 3.6 because it was missing.

**To test:**
1. Open a workspace, e.g. MAR11015 from training course data
2. Open the Slice Viewer
3. Use the region selection tool to select a region
4. Press `x` on your keyboard to export cuts, you should see **no** depreciation warning.

Fixes #34647


<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
