### PR TITLE
Allow removal of Sample on ALFView

### DIFF
--- a/docs/source/release/v6.7.0/Direct_Geometry/General/Bugfixes/35107.rst
+++ b/docs/source/release/v6.7.0/Direct_Geometry/General/Bugfixes/35107.rst
@@ -1,0 +1,1 @@
+- Removing the sample on the ALFView interface will now clear the InstrumentWidget plot.

--- a/qt/scientific_interfaces/Direct/ALFInstrumentModel.cpp
+++ b/qt/scientific_interfaces/Direct/ALFInstrumentModel.cpp
@@ -237,7 +237,13 @@ void ALFInstrumentModel::generateLoadedWorkspace() {
   ADS.addOrReplace(loadedWsName(), normalisedDSpacing);
 }
 
-void ALFInstrumentModel::setSample(MatrixWorkspace_sptr const &sample) { m_sample = sample; }
+void ALFInstrumentModel::setSample(MatrixWorkspace_sptr const &sample) {
+  auto const sampleRemoved = m_sample && !sample;
+  m_sample = sample;
+  if (sampleRemoved) {
+    loadEmptyInstrument("ALF", loadedWsName());
+  }
+}
 
 void ALFInstrumentModel::setVanadium(MatrixWorkspace_sptr const &vanadium) { m_vanadium = vanadium; }
 

--- a/qt/scientific_interfaces/Direct/ALFInstrumentPresenter.cpp
+++ b/qt/scientific_interfaces/Direct/ALFInstrumentPresenter.cpp
@@ -47,15 +47,14 @@ void ALFInstrumentPresenter::loadSettings() { m_view->loadSettings(); }
 void ALFInstrumentPresenter::saveSettings() { m_view->saveSettings(); }
 
 void ALFInstrumentPresenter::loadSample() {
-  auto const filepath = m_view->getSampleFile();
-  if (!filepath) {
-    return;
-  }
-
   m_analysisPresenter->clear();
 
-  m_model->setSample(loadAndNormalise(*filepath));
-  m_view->setSampleRun(std::to_string(m_model->sampleRun()));
+  if (auto const filepath = m_view->getSampleFile()) {
+    m_model->setSample(loadAndNormalise(*filepath));
+    m_view->setSampleRun(std::to_string(m_model->sampleRun()));
+  } else {
+    m_model->setSample(nullptr);
+  }
 
   generateLoadedWorkspace();
 }

--- a/qt/scientific_interfaces/Direct/ALFInstrumentPresenter.cpp
+++ b/qt/scientific_interfaces/Direct/ALFInstrumentPresenter.cpp
@@ -13,17 +13,6 @@
 #include "MantidAPI/FileFinder.h"
 #include "MantidAPI/MatrixWorkspace.h"
 
-#include <map>
-
-namespace {
-
-// A map of the message to display for a returned exception.
-static std::map<std::string, std::string> const EXCEPTION_MAP{
-    {"X arrays must match when dividing 2D workspaces.",
-     "Vanadium normalisation failed:\nX arrays must match when dividing two workspaces."}};
-
-} // namespace
-
 namespace MantidQt::CustomInterfaces {
 
 ALFInstrumentPresenter::ALFInstrumentPresenter(IALFInstrumentView *view, std::unique_ptr<IALFInstrumentModel> model)
@@ -85,8 +74,7 @@ void ALFInstrumentPresenter::generateLoadedWorkspace() {
   try {
     m_model->generateLoadedWorkspace();
   } catch (std::exception const &ex) {
-    auto const iter = EXCEPTION_MAP.find(ex.what());
-    m_view->warningBox(iter != EXCEPTION_MAP.cend() ? iter->second : ex.what());
+    m_view->warningBox(std::string("Vanadium normalisation failed: ") + ex.what());
   }
 }
 

--- a/qt/scientific_interfaces/Direct/ALFInstrumentView.cpp
+++ b/qt/scientific_interfaces/Direct/ALFInstrumentView.cpp
@@ -129,11 +129,7 @@ void ALFInstrumentView::setVanadiumRun(std::string const &runNumber) {
 }
 
 void ALFInstrumentView::sampleLoaded() {
-  if (m_sample->getText().isEmpty()) {
-    return;
-  }
-
-  if (!m_sample->isValid()) {
+  if (!m_sample->getText().isEmpty() && !m_sample->isValid()) {
     warningBox(m_sample->getFileProblem().toStdString());
     return;
   }

--- a/qt/scientific_interfaces/Direct/ALFInstrumentView.cpp
+++ b/qt/scientific_interfaces/Direct/ALFInstrumentView.cpp
@@ -170,7 +170,10 @@ void ALFInstrumentView::selectWholeTube() {
 }
 
 void ALFInstrumentView::notifyWholeTubeSelected(std::size_t pickID) {
-  m_presenter->notifyTubesSelected(m_instrumentWidget->findWholeTubeDetectorIndices({pickID}));
+  auto const pickTab = m_instrumentWidget->getPickTab();
+  if (pickTab->getSelectTubeButton()->isChecked()) {
+    m_presenter->notifyTubesSelected(m_instrumentWidget->findWholeTubeDetectorIndices({pickID}));
+  }
 }
 
 void ALFInstrumentView::clearShapes() {

--- a/qt/scientific_interfaces/Direct/test/ALFInstrumentModelTest.h
+++ b/qt/scientific_interfaces/Direct/test/ALFInstrumentModelTest.h
@@ -109,6 +109,7 @@ public:
   void test_loadAndNormalise_does_not_transform_to_dSpacing() {
     auto const workspace = m_model->loadAndNormalise(m_ALFData);
     TS_ASSERT_DIFFERS("dSpacing", workspace->getAxis(0)->unit()->unitID());
+  }
 
   void test_setSample_will_not_load_an_empty_instrument_workspace_if_the_sample_was_previously_null() {
     ADS.clear();

--- a/qt/scientific_interfaces/Direct/test/ALFInstrumentPresenterTest.h
+++ b/qt/scientific_interfaces/Direct/test/ALFInstrumentPresenterTest.h
@@ -109,10 +109,12 @@ public:
   }
 
   void test_loadSample_will_not_attempt_a_load_when_an_empty_filepath_is_provided() {
+    EXPECT_CALL(*m_analysisPresenter, clear()).Times(1);
+
     EXPECT_CALL(*m_view, getSampleFile()).Times(1).WillOnce(Return(std::nullopt));
+    EXPECT_CALL(*m_model, setSample(Eq(nullptr))).Times(1);
 
     // Expect no calls to these methods
-    EXPECT_CALL(*m_analysisPresenter, clear()).Times(0);
     EXPECT_CALL(*m_model, loadAndNormalise(_)).Times(0);
 
     m_presenter->loadSample();


### PR DESCRIPTION
**Description of work.**
This PR fixes an issue on the ALFView interface where the InstrumentWidget doesn't recognise when the sample has been removed from the GUI.

**To test:**
Open ALFView
Load ALF82301
Remove the sample by emptying the box, and clicking elsewhere on the interface
The instrument widget should be cleared
Go to the Pick tab
Rebin by `5.5,0.01,6` and click Run
The instrument widget should remain the same


*There is no associated issue.*

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
