### PR TITLE
Reconnect ProjectionSurface on ALFView after reset

### DIFF
--- a/docs/source/release/v6.7.0/Direct_Geometry/General/Bugfixes/35108.rst
+++ b/docs/source/release/v6.7.0/Direct_Geometry/General/Bugfixes/35108.rst
@@ -1,0 +1,1 @@
+- The 'Reset View' button on the 'Render' tab of ALFView will no longer prevent the 'Pick' tab tools from working.

--- a/qt/scientific_interfaces/Direct/ALFInstrumentModel.cpp
+++ b/qt/scientific_interfaces/Direct/ALFInstrumentModel.cpp
@@ -259,7 +259,7 @@ std::size_t ALFInstrumentModel::runNumber(Mantid::API::MatrixWorkspace_sptr cons
 }
 
 bool ALFInstrumentModel::setSelectedTubes(std::vector<DetectorTube> tubes) {
-  // If the number of tubes is different then we need definitely need to update the stored tubes
+  // If the number of tubes is different then we definitely need to update the stored tubes
   if (tubes.size() != m_tubes.size()) {
     m_tubes = std::move(tubes);
     return true;

--- a/qt/scientific_interfaces/Direct/ALFInstrumentView.cpp
+++ b/qt/scientific_interfaces/Direct/ALFInstrumentView.cpp
@@ -33,6 +33,7 @@ void ALFInstrumentView::setUpInstrument(std::string const &fileName) {
 
   connect(m_instrumentWidget, SIGNAL(instrumentActorReset()), this, SLOT(reconnectInstrumentActor()));
   connect(m_instrumentWidget, SIGNAL(surfaceTypeChanged(int)), this, SLOT(reconnectSurface()));
+  connect(m_instrumentWidget, SIGNAL(surfaceTypeChanged(int)), this, SLOT(notifyShapeChanged()));
   reconnectInstrumentActor();
   reconnectSurface();
 

--- a/qt/scientific_interfaces/Direct/ALFInstrumentView.cpp
+++ b/qt/scientific_interfaces/Direct/ALFInstrumentView.cpp
@@ -32,16 +32,9 @@ void ALFInstrumentView::setUpInstrument(std::string const &fileName) {
   m_instrumentWidget = new ALFInstrumentWidget(QString::fromStdString(fileName));
 
   connect(m_instrumentWidget, SIGNAL(instrumentActorReset()), this, SLOT(reconnectInstrumentActor()));
+  connect(m_instrumentWidget, SIGNAL(surfaceTypeChanged(int)), this, SLOT(reconnectSurface()));
   reconnectInstrumentActor();
-
-  auto surface = m_instrumentWidget->getInstrumentDisplay()->getSurface().get();
-  // This signal has been disconnected as we do not want a copy and paste event to update the analysis plot, unless
-  // the pasted shape is subsequently moved
-  // connect(surface, SIGNAL(shapeCreated()), this, SLOT(notifyShapeChanged()));
-  connect(surface, SIGNAL(shapeChangeFinished()), this, SLOT(notifyShapeChanged()));
-  connect(surface, SIGNAL(shapesRemoved()), this, SLOT(notifyShapeChanged()));
-  connect(surface, SIGNAL(shapesCleared()), this, SLOT(notifyShapeChanged()));
-  connect(surface, SIGNAL(singleComponentPicked(size_t)), this, SLOT(notifyWholeTubeSelected(size_t)));
+  reconnectSurface();
 
   auto pickTab = m_instrumentWidget->getPickTab();
   connect(pickTab->getSelectTubeButton(), SIGNAL(clicked()), this, SLOT(selectWholeTube()));
@@ -96,6 +89,18 @@ void ALFInstrumentView::saveSettings() {
 
 void ALFInstrumentView::reconnectInstrumentActor() {
   connect(&m_instrumentWidget->getInstrumentActor(), SIGNAL(refreshView()), this, SLOT(notifyInstrumentActorReset()));
+}
+
+void ALFInstrumentView::reconnectSurface() {
+  auto surface = m_instrumentWidget->getInstrumentDisplay()->getSurface().get();
+
+  // This signal has been disconnected as we do not want a copy and paste event to update the analysis plot, unless
+  // the pasted shape is subsequently moved
+  // connect(surface, SIGNAL(shapeCreated()), this, SLOT(notifyShapeChanged()));
+  connect(surface, SIGNAL(shapeChangeFinished()), this, SLOT(notifyShapeChanged()));
+  connect(surface, SIGNAL(shapesRemoved()), this, SLOT(notifyShapeChanged()));
+  connect(surface, SIGNAL(shapesCleared()), this, SLOT(notifyShapeChanged()));
+  connect(surface, SIGNAL(singleComponentPicked(size_t)), this, SLOT(notifyWholeTubeSelected(size_t)));
 }
 
 void ALFInstrumentView::subscribePresenter(IALFInstrumentPresenter *presenter) { m_presenter = presenter; }

--- a/qt/scientific_interfaces/Direct/ALFInstrumentView.h
+++ b/qt/scientific_interfaces/Direct/ALFInstrumentView.h
@@ -99,6 +99,7 @@ public:
 
 private slots:
   void reconnectInstrumentActor();
+  void reconnectSurface();
   void sampleLoaded();
   void vanadiumLoaded();
   void notifyInstrumentActorReset();


### PR DESCRIPTION
**Description of work.**
This PR fixes an issue where the ALFView pick tools would stop working after pressing the 'Reset View' button on the 'Render' tab. This was caused by the new surface not being reconnected to the ALFInstrumentPresenter.

**To test:**
Follow the instruction in the attached issue.
It should be possible to use the 'Pick' tab tools after pressing the 'Reset View' button.

Fixes #35108

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
