### PR TITLE
Update WSL developer documentation to refer to X Server use

### DIFF
--- a/dev-docs/source/WindowsSubsystemForLinux.rst
+++ b/dev-docs/source/WindowsSubsystemForLinux.rst
@@ -98,7 +98,7 @@ To use an XServer:
 
      `export DISPLAY=$(route.exe print | grep 0.0.0.0 | head -1 | awk '{print $4}'):0.0`.
   3. Exit and re-enter WSL via the command prompt.
-  4. Echo the `DISPLAY` variable, you should see the value `<host machine IP Address>:0.0`. You can compare this output IP address to that found in `ipconfig /all`.
+  4. Echo the `DISPLAY` variable, you should see the value `<host machine IP Address>:0.0`. You can compare this output IP address to that output when running `ipconfig /all` through the command line on the host machine.
 
 Tips
 ####

--- a/dev-docs/source/WindowsSubsystemForLinux.rst
+++ b/dev-docs/source/WindowsSubsystemForLinux.rst
@@ -98,7 +98,7 @@ To use an XServer:
 
      `export DISPLAY=$(route.exe print | grep 0.0.0.0 | head -1 | awk '{print $4}'):0.0`.
   3. Exit and re-enter WSL via the command prompt.
-  4. Echo the `DISPLAY` variable, you should see the value `<host machine IP Address>:0.0`.
+  4. Echo the `DISPLAY` variable, you should see the value `<host machine IP Address>:0.0`. You can compare this output IP address to that found in `ipconfig /all`.
 
 Tips
 ####

--- a/dev-docs/source/WindowsSubsystemForLinux.rst
+++ b/dev-docs/source/WindowsSubsystemForLinux.rst
@@ -83,7 +83,7 @@ WSL does not currently support GUIs. In order to display a GUI from an applicati
 
 To use an XServer:
 
-1. Download a compatible XServer onto the host Windows machine. `MobaXterm <https://mobaxterm.mobatek.net/>`_ is recommended and has been confirmed to work with Mantid workbench.
+1. Download a compatible XServer onto the host Windows machine. `MobaXterm <https://mobaxterm.mobatek.net/>`_ is recommended and has been confirmed to work with Mantid Workbench.
 
 2. Install `MobaXterm` and open the MobaXterm app upon completion. Using the `Settings` drop down menu select `Configure`. On the `X11` tab ensure that `X11 server display mode` is set to
    `Multiwindow mode` and that `X11 remote access` is set to `full`.

--- a/dev-docs/source/WindowsSubsystemForLinux.rst
+++ b/dev-docs/source/WindowsSubsystemForLinux.rst
@@ -79,24 +79,26 @@ You are now ready to CMake and build the Mantid code. Follow the Ubuntu 18.04 or
 Using Graphical User Interfaces (GUI)
 #####################################
 
-WSL does not currently support GUIs. In order to display a GUI from an application running in WSL you will therefore need to use an `XServer`. Failure to do so will result in a crash upon launching `workbench`.
+WSL does not currently support GUIs. In order to display a GUI from an application running in WSL you will therefore need to use an XServer. Failure to do so will result in a crash upon launching `workbench`.
 
-To use an `XServer`:
+To use an XServer:
 
-1. Download a compatible `XServer` onto the host Windows machine. `MobaXterm <https://mobaxterm.mobatek.net/>`_ is recommended and has been confirmed to work with `workbench`.
+1. Download a compatible XServer onto the host Windows machine. `MobaXterm <https://mobaxterm.mobatek.net/>`_ is recommended and has been confirmed to work with Mantid workbench.
 
 2. Install `MobaXterm` and open the MobaXterm app upon completion. Using the `Settings` drop down menu select `Configure`. On the `X11` tab ensure that `X11 server display mode` is set to
    `Multiwindow mode` and that `X11 remote access` is set to `full`.
 
-3. The `XSever` should be running by default - this can be checked by clicking the `X server` icon in the top right hand corner of the `MobaXterm` interface.
+3. The XServer should be running by default - this can be checked by clicking the `X server` icon in the top right hand corner of the `MobaXterm` interface.
 
 4. Configure the `DISPLAY` variable on WSL. The manner in which this is done differs between WSL1 and WSL2. To check which version you have use the command `wsl -l -v` in the command prompt on the host machine.
-   If you have WSL1, it is recommended to upgrade to `WSL2 <https://learn.microsoft.com/en-us/windows/wsl/install>`_
+   If you have WSL1, it is recommended to upgrade to `WSL2 <https://learn.microsoft.com/en-us/windows/wsl/install>`_.
 
   1. On WSL, use `cd` to navigate to your home directory containing the `.bashrc` file.
-  2. Using `vi .bashrc` append the following to the file contents: export `DISPLAY=$(route.exe print | grep 0.0.0.0 | head -1 | awk '{print $4}'):0.0`
+  2. Using `vi .bashrc` append the following to the file contents:
+
+     `export DISPLAY=$(route.exe print | grep 0.0.0.0 | head -1 | awk '{print $4}'):0.0`.
   3. Exit and re-enter WSL via the command prompt.
-  4. Echo the `DISPLAY` variable, you should see the value `<host machine IP Address>:0.0`
+  4. Echo the `DISPLAY` variable, you should see the value `<host machine IP Address>:0.0`.
 
 Tips
 ####

--- a/dev-docs/source/WindowsSubsystemForLinux.rst
+++ b/dev-docs/source/WindowsSubsystemForLinux.rst
@@ -79,7 +79,7 @@ You are now ready to CMake and build the Mantid code. Follow the Ubuntu 18.04 or
 Using Graphical User Interfaces (GUI)
 #####################################
 
-WSL does not currently support GUIs. In order to display a GUI from an application running in WSL you will therefore need to use an XServer. Failure to do so will result in a crash upon launching `workbench`.
+WSL does not currently support GUIs. In order to display a GUI from an application running in WSL you will need to use an XServer. Failure to do so will result in a crash upon launching `workbench`.
 
 To use an XServer:
 

--- a/dev-docs/source/WindowsSubsystemForLinux.rst
+++ b/dev-docs/source/WindowsSubsystemForLinux.rst
@@ -76,6 +76,28 @@ The Mantid code can then be retrieved in the usual way using `git clone` from th
 
 You are now ready to CMake and build the Mantid code. Follow the Ubuntu 18.04 or Centos 7 build instructions `here <https://developer.mantidproject.org/GettingStarted.html#linux>`_.
 
+Using Graphical User Interfaces (GUI)
+#####################################
+
+WSL does not currently support GUIs. In order to display a GUI from an application running in WSL you will therefore need to use an `XServer`. Failure to do so will result in a crash upon launching `workbench`.
+
+To use an `XServer`:
+
+1. Download a compatible `XServer` onto the host Windows machine. `MobaXterm <https://mobaxterm.mobatek.net/>`_ is recommended and has been confirmed to work with `workbench`.
+
+2. Install `MobaXterm` and open the MobaXterm app upon completion. Using the `Settings` drop down menu select `Configure`. On the `X11` tab ensure that `X11 server display mode` is set to
+   `Multiwindow mode` and that `X11 remote access` is set to `full`.
+
+3. The `XSever` should be running by default - this can be checked by clicking the `X server` icon in the top right hand corner of the `MobaXterm` interface.
+
+4. Configure the `DISPLAY` variable on WSL. The manner in which this is done differs between WSL1 and WSL2. To check which version you have use the command `wsl -l -v` in the command prompt on the host machine.
+   If you have WSL1, it is recommended to upgrade to `WSL2 <https://learn.microsoft.com/en-us/windows/wsl/install>`_
+
+  1. On WSL, use `cd` to navigate to your home directory containing the `.bashrc` file.
+  2. Using `vi .bashrc` append the following to the file contents: export `DISPLAY=$(route.exe print | grep 0.0.0.0 | head -1 | awk '{print $4}'):0.0`
+  3. Exit and re-enter WSL via the command prompt.
+  4. Echo the `DISPLAY` variable, you should see the value `<host machine IP Address>:0.0`
+
 Tips
 ####
 


### PR DESCRIPTION
**Description of work.**

This adds instruction for the use of an XServer when using WSL on windows. Without this, the workbench GUI cannot be used.

**To test:**
1) Read through documentation for typos etc.
2) Ideally, follow through instructions to set up and use an XServer with WSL

<!-- Instructions for testing. -->

Resolves #35030 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
