### PR TITLE
Get current device pixel ratio for Zoombox

### DIFF
--- a/docs/source/release/v6.7.0/Workbench/Bugfixes/34079.rst
+++ b/docs/source/release/v6.7.0/Workbench/Bugfixes/34079.rst
@@ -1,0 +1,1 @@
+- Corrected plotting zoom box location on MacOS

--- a/qt/applications/workbench/workbench/plotting/mantidfigurecanvas.py
+++ b/qt/applications/workbench/workbench/plotting/mantidfigurecanvas.py
@@ -8,10 +8,8 @@
 """
 Qt-based matplotlib canvas
 """
-from distutils.version import LooseVersion
 from qtpy.QtCore import Qt
-from qtpy.QtGui import QPen
-import matplotlib
+from qtpy.QtGui import QPen, QColor
 from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg, draw_if_interactive, show  # noqa: F401
 from mantid.plots.mantidimage import MantidImage, ImageIntensity
 
@@ -20,9 +18,7 @@ class MantidFigureCanvas(FigureCanvasQTAgg):
     def __init__(self, figure):
         super().__init__(figure=figure)
         self._pen_color = Qt.black
-        self._pen_thickness = 1.5
-        if LooseVersion(matplotlib.__version__) >= LooseVersion("3.5.0"):
-            self._dpi_ratio = self.devicePixelRatio() or 1
+        self._pen_thickness = 1.0
 
     # options controlling the pen used by tools that manipulate the graph - e.g the zoom box
     @property
@@ -43,19 +39,38 @@ class MantidFigureCanvas(FigureCanvasQTAgg):
 
     # Method used by the zoom box tool on the matplotlib toolbar
     def drawRectangle(self, rect):
+        """Override of matplotlib.lib.matplotlib.backends.backend_qt.drawRectangle
+        only to update the zoombox pen color.
+        """
         self.update_pen_color()
         # Draw the zoom rectangle to the QPainter.  _draw_rect_callback needs
         # to be called at the end of paintEvent.
         if rect is not None:
-            self._drawRect = [pt / self._dpi_ratio for pt in rect]
+            x0, y0, w, h = [int(pt / self.device_pixel_ratio) for pt in rect]
+            x1 = x0 + w
+            y1 = y0 + h
 
             def _draw_rect_callback(painter):
-                pen = QPen(self.pen_color, self.pen_thickness / self._dpi_ratio, Qt.DotLine)
-                painter.setPen(pen)
-                painter.drawRect(*(pt / self._dpi_ratio for pt in rect))
+                pen = QPen(
+                    self.pen_color,
+                    self.pen_thickness / self.device_pixel_ratio,
+                )
+                pen.setDashPattern([3, 3])
+                for color, offset in [
+                    (QColor("black"), 0),
+                    (QColor("white"), 3),
+                ]:
+                    pen.setDashOffset(offset)
+                    pen.setColor(color)
+                    painter.setPen(pen)
+                    # Draw the lines from x0, y0 towards x1, y1 so that the
+                    # dashes don't "jump" when moving the zoom box.
+                    painter.drawLine(x0, y0, x0, y1)
+                    painter.drawLine(x0, y0, x1, y0)
+                    painter.drawLine(x0, y1, x1, y1)
+                    painter.drawLine(x1, y0, x1, y1)
 
         else:
-            self._drawRect = None
 
             def _draw_rect_callback(painter):
                 return

--- a/qt/applications/workbench/workbench/plotting/test/test_mantidfigurecanvas.py
+++ b/qt/applications/workbench/workbench/plotting/test/test_mantidfigurecanvas.py
@@ -11,12 +11,12 @@ from workbench.plotting.mantidfigurecanvas import MantidFigureCanvas
 
 
 class MantidFigureCanvasTest(unittest.TestCase):
-    def test_dpi_attribute_exists(self):
+    def test_device_pixel_ratio_attribute_exists(self):
         fig = MagicMock()
         fig.bbox.max = [1, 1]
         canvas = MantidFigureCanvas(fig)
 
-        self.assertTrue(hasattr(canvas, "_dpi_ratio"))
+        self.assertTrue(hasattr(canvas, "device_pixel_ratio"))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
**Description of work.**

When zooming on a plot, check the device pixel ratio on the current screen. Previously, it was only checked when creating the plot so dragging the plot to another screen zoomed in the wrong location. I have updated this override with the most recent code in the main matplotlib codebase: https://github.com/matplotlib/matplotlib/blob/6a9a07155c0e7f91c20dd4c7e280198ec652c4ae/lib/matplotlib/backends/backend_qt.py#L473
I also opted for a generally thinner line by setting the default to 1.0 

**To test:**

This needs to be tested on a mac with retina screen and an additional lower-resolution screen connected.
Use the following script to determine this information: 

```python
from qtpy.QtWidgets import QApplication
for screen in QApplication.screens():
    print(screen.name())
    print(screen.devicePixelRatio())
```

It should print 2.0 for a retina display and 1.0 for a standard external screen.
If all values are the same then the test of moving the window between screens will not be valid.

- Throughout, check that the zoombox linewidth is good. I've opted for a thinner line.
- run the CreateSampleWorkspace() algorithm
- plot a spectrum or even a colorfill of this workspace, select the Zoom toolbar button and zoom in on a region.
- drag the plot to the other screen and try zooming again
- Close the plot 
- Move the main workbench window to the other screen and generate a new plot from this screen. Check zooming works for this new plot on both screens.

Fixes #34079 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
