### PR TITLE
Update Jenkins workflow to allow for use of Windows Cloud Jenkins Nodes

### DIFF
--- a/buildconfig/Jenkins/Conda/conda-buildscript
+++ b/buildconfig/Jenkins/Conda/conda-buildscript
@@ -42,18 +42,6 @@ shift
 CMAKE_PRESET=$1
 shift
 
-# Check if preset is valid, if not try old style preset.
-grep -q $CMAKE_PRESET $WORKSPACE/CMakePresets.json
-if [[ $? == 1 ]]; then
-  if [[ $CMAKE_PRESET == 'win'* ]]; then
-    CMAKE_PRESET='win'
-  elif [[ $CMAKE_PRESET == 'linux'* ]]; then
-    CMAKE_PRESET='linux-ci'
-  elif [[ $CMAKE_PRESET == 'osx'* ]]; then
-    CMAKE_PRESET='osx-ci'
-  fi
-fi
-
 if [[ -z "$BUILD_THREADS" ]]; then
     if [[ $OSTYPE == 'darwin'* ]]; then
         BUILD_THREADS="$(sysctl -n hw.logicalcpu)"

--- a/buildconfig/Jenkins/Conda/conda-buildscript
+++ b/buildconfig/Jenkins/Conda/conda-buildscript
@@ -42,6 +42,18 @@ shift
 CMAKE_PRESET=$1
 shift
 
+# Check if preset is valid, if not try old style preset.
+grep -q $CMAKE_PRESET $WORKSPACE/CMakePresets.json
+if [[ $? == 1 ]]; then
+  if [[ $CMAKE_PRESET == 'win'* ]]; then
+    CMAKE_PRESET='win'
+  elif [[ $CMAKE_PRESET == 'linux'* ]]; then
+    CMAKE_PRESET='linux-ci'
+  elif [[ $CMAKE_PRESET == 'osx'* ]]; then
+    CMAKE_PRESET='osx-ci'
+  fi
+fi
+
 if [[ -z "$BUILD_THREADS" ]]; then
     if [[ $OSTYPE == 'darwin'* ]]; then
         BUILD_THREADS="$(sysctl -n hw.logicalcpu)"

--- a/buildconfig/Jenkins/Conda/nightly_build_and_deploy.jenkinsfile
+++ b/buildconfig/Jenkins/Conda/nightly_build_and_deploy.jenkinsfile
@@ -21,7 +21,7 @@ switch(GIT_BRANCH) {
     PACKAGE_SUFFIX_DEFAULT = 'Unstable'
     ANACONDA_CHANNEL_LABEL_DEFAULT = 'unstable'
     GITHUB_RELEASES_TAG_DEFAULT = ''
-    PLATFORM_CHOICES = ['none', 'all', 'linux-64', 'win-64', 'osx-64']
+    PLATFORM_CHOICES = ['none', 'all', 'linux-64', 'win-64', 'win-64-cloud', 'osx-64']
     break
 }
 
@@ -81,7 +81,7 @@ pipeline {
           // match labels on the agents
           axis {
             name 'PLATFORM'
-            values 'linux-64', 'win-64', 'osx-64'
+            values 'linux-64', 'win-64', 'win-64-cloud', 'osx-64'
           }
           axis {
             name 'BUILD_TYPE'
@@ -157,7 +157,7 @@ pipeline {
         axes {
           axis {
             name 'PLATFORM'
-            values 'linux-64', 'win-64', 'osx-64'
+            values 'linux-64', 'win-64', 'win-64-cloud', 'osx-64'
           }
         }
         stages {
@@ -294,7 +294,8 @@ def git_branch_name() {
 }
 
 def toUnixStylePath(path) {
-  return path.replaceAll("\\\\", "/")
+  path.replaceAll("\\\\", "/")
+  return path
 }
 
 def checkoutSource(sha) {


### PR DESCRIPTION
**Description of work.**

This PR enables the jenkins workflow to execute for machines labelled both `win-64` and `win-64-cloud`.

This is needed so that paths to be used on the new windows cloud Jenkins nodes can be prepended with `C:`, which is required (this happens automatically on the old windows nodes).

**To test:**
1) Send this PR to build on a cloud Jenkins node, observe success.
2) Repeat on a physical Jenkins node, observe success.

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
