### PR TITLE
Normalise sample by vanadium before dSpacing conversion

### DIFF
--- a/qt/scientific_interfaces/Direct/ALFInstrumentModel.cpp
+++ b/qt/scientific_interfaces/Direct/ALFInstrumentModel.cpp
@@ -202,7 +202,7 @@ ALFInstrumentModel::ALFInstrumentModel() : m_sample(), m_vanadium(), m_tubes() {
 }
 
 /*
- * Loads the provided ALF file and normalises it by current. Converts to DSpacing if necessary.
+ * Loads the provided ALF file and normalises it by current.
  * @param filename:: The filepath to the ALF data
  * @return The loaded and normalised workspace
  */
@@ -213,28 +213,28 @@ MatrixWorkspace_sptr ALFInstrumentModel::loadAndNormalise(std::string const &fil
     throw std::invalid_argument("The loaded data is not from the ALF instrument");
   }
 
-  if (!isAxisDSpacing(loadedWorkspace)) {
-    return convertUnits(normaliseByCurrent(loadedWorkspace), "dSpacing");
-  }
-
-  return loadedWorkspace;
+  return normaliseByCurrent(loadedWorkspace);
 }
 
 /*
- * Normalises the sample by the vanadium if a vanadium has been loaded. Adds the resulting workspace to the ADS.
+ * Normalises the sample by the vanadium if a vanadium has been loaded. Converts the result to dSpacing if it is not
+ * already in these units. Adds the resulting workspace to the ADS.
  */
 void ALFInstrumentModel::generateLoadedWorkspace() {
   if (!m_sample) {
     return;
   }
 
-  if (m_vanadium) {
-    auto const vanadium =
-        !WorkspaceHelpers::matchingBins(*m_sample, *m_vanadium) ? rebinToWorkspace(m_vanadium, m_sample) : m_vanadium;
-    ADS.addOrReplace(loadedWsName(), replaceSpecialValues(m_sample / vanadium));
-  } else {
-    ADS.addOrReplace(loadedWsName(), m_sample->clone());
+  // Rebin the vanadium to match the sample binning if the bins do not match
+  if (m_vanadium && !WorkspaceHelpers::matchingBins(*m_sample, *m_vanadium)) {
+    m_vanadium = rebinToWorkspace(m_vanadium, m_sample);
   }
+
+  // Normalise the sample using the vanadium if it is provided
+  auto const normalised = m_vanadium ? replaceSpecialValues(m_sample / m_vanadium) : m_sample;
+  // Convert the normalisation result to dSpacing, and add it to the ADS
+  auto const normalisedDSpacing = !isAxisDSpacing(normalised) ? convertUnits(normalised, "dSpacing") : normalised;
+  ADS.addOrReplace(loadedWsName(), normalisedDSpacing);
 }
 
 void ALFInstrumentModel::setSample(MatrixWorkspace_sptr const &sample) { m_sample = sample; }

--- a/qt/scientific_interfaces/Direct/test/ALFInstrumentModelTest.h
+++ b/qt/scientific_interfaces/Direct/test/ALFInstrumentModelTest.h
@@ -98,9 +98,9 @@ public:
     TS_ASSERT(m_model->loadAndNormalise(m_ALFData));
   }
 
-  void test_loadAndNormalise_transforms_the_data_to_dSpacing_if_not_already() {
+  void test_loadAndNormalise_does_not_transform_to_dSpacing() {
     auto const workspace = m_model->loadAndNormalise(m_ALFData);
-    TS_ASSERT_EQUALS("dSpacing", workspace->getAxis(0)->unit()->unitID());
+    TS_ASSERT_DIFFERS("dSpacing", workspace->getAxis(0)->unit()->unitID());
   }
 
   void test_sampleRun_and_vanadiumRun_returns_zero_when_no_data_is_loaded() {
@@ -206,6 +206,7 @@ public:
     TS_ASSERT(ADS.doesExist("ALFData"));
 
     auto const workspace = ADS.retrieveWS<MatrixWorkspace>("ALFData");
+    TS_ASSERT_EQUALS("dSpacing", workspace->getAxis(0)->unit()->unitID());
     TS_ASSERT_EQUALS(sample->y(0), workspace->y(0));
   }
 
@@ -219,6 +220,7 @@ public:
     TS_ASSERT(ADS.doesExist("ALFData"));
 
     auto const workspace = ADS.retrieveWS<MatrixWorkspace>("ALFData");
+    TS_ASSERT_EQUALS("dSpacing", workspace->getAxis(0)->unit()->unitID());
     TS_ASSERT_EQUALS(1.0, workspace->y(0)[0]);
     TS_ASSERT_EQUALS(1.0, workspace->y(0)[1]);
   }
@@ -233,6 +235,7 @@ public:
     TS_ASSERT(ADS.doesExist("ALFData"));
 
     auto const workspace = ADS.retrieveWS<MatrixWorkspace>("ALFData");
+    TS_ASSERT_EQUALS("dSpacing", workspace->getAxis(0)->unit()->unitID());
     TS_ASSERT_EQUALS(1.0, workspace->y(0)[0]);
     TS_ASSERT_EQUALS(1.0, workspace->y(0)[1]);
   }


### PR DESCRIPTION
**Description of work.**
This PR ensures the normalisation of the sample by the vanadium is performed before converting the result to dSpacing. If you convert the sample and vanadium to dSpacing first, the resulting normalised data is incorrect.

The problem was spotted by Russell during beta testing.

**To test:**
Open ALFView
Load ALF84116 as sample
Load ALF78634 as vanadium
There should be no error message, and a plot should appear in the instrument widget:
![image](https://user-images.githubusercontent.com/40830825/215531757-5ab8123a-5d48-4805-b60b-72444f138742.png)

Fixes #35097

*This does not require release notes* because **vanadium normalisation was not possible in the previous version.**

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
