### PR TITLE
Optional TimeROI argument in TimeSeriesProperty::getStatistics()

### DIFF
--- a/Framework/Kernel/inc/MantidKernel/ITimeSeriesProperty.h
+++ b/Framework/Kernel/inc/MantidKernel/ITimeSeriesProperty.h
@@ -52,7 +52,7 @@ public:
    */
   virtual double timeAverageValue(const TimeROI &timeRoi) const = 0;
   /// Return a TimeSeriesPropertyStatistics object
-  virtual TimeSeriesPropertyStatistics getStatistics() const = 0;
+  virtual TimeSeriesPropertyStatistics getStatistics(const TimeROI *timeRoi = nullptr) const = 0;
   /// Returns the real size of the time series property map:
   virtual int realSize() const = 0;
   /// Deletes the series of values in the property

--- a/Framework/Kernel/inc/MantidKernel/TimeSeriesProperty.h
+++ b/Framework/Kernel/inc/MantidKernel/TimeSeriesProperty.h
@@ -325,7 +325,7 @@ public:
   bool isDefault() const override;
 
   /// Return a TimeSeriesPropertyStatistics object
-  TimeSeriesPropertyStatistics getStatistics() const override;
+  TimeSeriesPropertyStatistics getStatistics(const TimeROI *timeRoi = nullptr) const override;
 
   /// Detects whether there are duplicated entries (of time) in property &
   /// eliminates them

--- a/Framework/Kernel/inc/MantidKernel/TimeSeriesProperty.h
+++ b/Framework/Kernel/inc/MantidKernel/TimeSeriesProperty.h
@@ -201,7 +201,7 @@ public:
   std::pair<double, double> averageAndStdDevInFilter(const std::vector<SplittingInterval> &filter) const override;
   /// @copydoc Mantid::Kernel::ITimeSeriesProperty::timeAverageValue()
   /// Time weighted mean and standard deviation
-  std::pair<double, double> timeAverageValueAndStdDev() const;
+  std::pair<double, double> timeAverageValueAndStdDev(const TimeROI *timeRoi = nullptr) const;
   double timeAverageValue() const override;
   /** Returns the calculated time weighted average value.
    * @param timeRoi  Object that holds information about when the time measurement was active.

--- a/Framework/Kernel/inc/MantidKernel/TimeSeriesProperty.h
+++ b/Framework/Kernel/inc/MantidKernel/TimeSeriesProperty.h
@@ -221,12 +221,12 @@ public:
   ///  values
   std::multimap<Types::Core::DateAndTime, TYPE> valueAsMultiMap() const;
   /// Get filtered values as a vector
-  std::vector<TYPE> filteredValuesAsVector() const;
+  std::vector<TYPE> filteredValuesAsVector(const TimeROI *timeRoi = nullptr) const;
 
   /// Return the time series's times as a vector<DateAndTime>
   std::vector<Types::Core::DateAndTime> timesAsVector() const override;
   /// Get filtered times as a vector
-  std::vector<Types::Core::DateAndTime> filteredTimesAsVector() const;
+  std::vector<Types::Core::DateAndTime> filteredTimesAsVector(const TimeROI *timeRoi = nullptr) const;
   /// Return the series as list of times, where the time is the number of
   /// seconds since the start.
   std::vector<double> timesAsVectorSeconds() const;

--- a/Framework/Kernel/src/TimeSeriesProperty.cpp
+++ b/Framework/Kernel/src/TimeSeriesProperty.cpp
@@ -1031,7 +1031,10 @@ template <typename TYPE> std::vector<DateAndTime> TimeSeriesProperty<TYPE>::time
  * Return the time series's filtered times as a vector<DateAndTime>
  * @return A vector of DateAndTime objects
  */
-template <typename TYPE> std::vector<DateAndTime> TimeSeriesProperty<TYPE>::filteredTimesAsVector() const {
+template <typename TYPE>
+std::vector<DateAndTime> TimeSeriesProperty<TYPE>::filteredTimesAsVector(const TimeROI *timeRoi) const {
+  UNUSED_ARG(timeRoi);
+
   if (m_filter.empty()) {
     return this->timesAsVector(); // no filtering to do
   }
@@ -1865,6 +1868,7 @@ template <typename TYPE> bool TimeSeriesProperty<TYPE>::isDefault() const { retu
  */
 template <typename TYPE>
 TimeSeriesPropertyStatistics TimeSeriesProperty<TYPE>::getStatistics(const TimeROI *timeRoi) const {
+  UNUSED_ARG(timeRoi);
 
   TimeSeriesPropertyStatistics out(Mantid::Kernel::getStatistics(this->filteredValuesAsVector()));
 
@@ -2334,7 +2338,10 @@ void TimeSeriesProperty<std::string>::histogramData(const Types::Core::DateAndTi
  * false.
  * @returns :: Vector of included values only
  */
-template <typename TYPE> std::vector<TYPE> TimeSeriesProperty<TYPE>::filteredValuesAsVector() const {
+template <typename TYPE>
+std::vector<TYPE> TimeSeriesProperty<TYPE>::filteredValuesAsVector(const TimeROI *timeRoi) const {
+  UNUSED_ARG(timeRoi);
+
   if (m_filter.empty()) {
     return this->valuesAsVector(); // no filtering to do
   }

--- a/Framework/Kernel/src/TimeSeriesProperty.cpp
+++ b/Framework/Kernel/src/TimeSeriesProperty.cpp
@@ -919,11 +919,17 @@ TimeSeriesProperty<TYPE>::averageAndStdDevInFilter(const std::vector<SplittingIn
   return std::pair<double, double>{mean, std::sqrt(numerator / totalTime)};
 }
 
-template <typename TYPE> std::pair<double, double> TimeSeriesProperty<TYPE>::timeAverageValueAndStdDev() const {
+template <typename TYPE>
+std::pair<double, double> TimeSeriesProperty<TYPE>::timeAverageValueAndStdDev(const TimeROI *timeRoi) const {
   std::pair<double, double> retVal{0., 0.}; // mean and stddev
   try {
-    const auto &filter = getSplittingIntervals();
-    retVal = this->averageAndStdDevInFilter(filter);
+    if (timeRoi) {
+      const auto filter = timeRoi->toSplitters();
+      retVal = this->averageAndStdDevInFilter(filter);
+    } else { // to be deleted once we remove m_filter
+      const auto &filter = getSplittingIntervals();
+      retVal = this->averageAndStdDevInFilter(filter);
+    }
   } catch (std::exception &) {
     retVal.first = std::numeric_limits<double>::quiet_NaN();
     retVal.second = std::numeric_limits<double>::quiet_NaN();

--- a/Framework/Kernel/src/TimeSeriesProperty.cpp
+++ b/Framework/Kernel/src/TimeSeriesProperty.cpp
@@ -1857,7 +1857,9 @@ template <typename TYPE> bool TimeSeriesProperty<TYPE>::isDefault() const { retu
  *
  * N.B. This method DOES take filtering into account
  */
-template <typename TYPE> TimeSeriesPropertyStatistics TimeSeriesProperty<TYPE>::getStatistics() const {
+template <typename TYPE>
+TimeSeriesPropertyStatistics TimeSeriesProperty<TYPE>::getStatistics(const TimeROI *timeRoi) const {
+
   TimeSeriesPropertyStatistics out(Mantid::Kernel::getStatistics(this->filteredValuesAsVector()));
 
   if (this->size() > 0) {

--- a/Framework/Kernel/test/TimeSeriesPropertyTest.h
+++ b/Framework/Kernel/test/TimeSeriesPropertyTest.h
@@ -696,6 +696,18 @@ public:
     TS_ASSERT_DELTA(dblMean, expected, .0001);
   }
 
+  void test_timeAverageValueAndStdDev() {
+    auto dblLog = createDoubleTSP();
+    TimeROI *rois = createTimeRoi(); // rois contains two ROI's
+    std::pair<double, double> av_dev = dblLog->timeAverageValueAndStdDev(rois);
+    double avX = (5.0 * 9.99 + 5.0 * 7.55 + 5.0 * 5.55 + 5.0 * 10.55) / (5.0 + 5.0 + 5.0 + 5.0);
+    TS_ASSERT_DELTA(av_dev.first, avX, .0001);
+    double devX = std::sqrt((5.0 * (9.99 - avX) * (9.99 - avX) + 5.0 * (7.55 - avX) * (7.55 - avX) +
+                             5.0 * (5.55 - avX) * (5.55 - avX) + 5.0 * (10.55 - avX) * (10.55 - avX)) /
+                            (5.0 + 5.0 + 5.0 + 5.0));
+    TS_ASSERT_DELTA(av_dev.second, devX, .0001);
+  }
+
   void test_averageValueInFilter_throws_for_string_property() {
     SplittingIntervalVec splitter;
     TS_ASSERT_THROWS(sProp->averageValueInFilter(splitter), const Exception::NotImplementedError &);


### PR DESCRIPTION
**References** [Optional TimeROI argument in TimeSeriesProperty::getStatistics()](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=351)

**Description of work.**
- [x] unit test for timeAverageValueAndStdDev
- [ ] 


**To test:**

<!-- Instructions for testing. -->


This does not require release notes because it's part of a larger effort, at which end release notes will be produced.


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
