### PR TITLE
Windows compilation warnings fix

### DIFF
--- a/Framework/Algorithms/CMakeLists.txt
+++ b/Framework/Algorithms/CMakeLists.txt
@@ -1045,7 +1045,9 @@ endif()
 enable_precompiled_headers(inc/MantidAlgorithms/PrecompiledHeader.h SRC_FILES)
 # Disable optimization for certain Segfault as the key lines that cause the segfault can be optimized away but this
 # algorithm is only ever intended to test the crashing behaviour of the framework
-set_source_files_properties(src/Segfault.cpp PROPERTIES COMPILE_FLAGS -O0)
+if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+  set_source_files_properties(src/Segfault.cpp PROPERTIES COMPILE_FLAGS -O0)
+endif()
 
 # Add the target for this directory
 add_library(Algorithms ${SRC_FILES} ${C_SRC_FILES} ${INC_FILES})

--- a/buildconfig/CMake/WindowsSetup.cmake
+++ b/buildconfig/CMake/WindowsSetup.cmake
@@ -17,6 +17,9 @@ add_definitions(-DBOOST_CONFIG_SUPPRESS_OUTDATED_MESSAGE)
 add_definitions(-D_SCL_SECURE_NO_WARNINGS -D_CRT_SECURE_NO_WARNINGS)
 # Prevent deprecation errors from std::tr1 in googletest until it is fixed upstream. In MSVC 2017 and later
 add_definitions(-D_SILENCE_TR1_NAMESPACE_DEPRECATION_WARNING)
+# Suppress codecvt deprecation warning when building with Ninja. Using codecvt is still the recommended solution for
+# converting from std::string to std::wstring. See https://stackoverflow.com/a/18597384
+add_definitions(-D_SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING)
 # Suppress warnings about std::iterator as a base. TBB emits this warning and it is not yet fixed.
 add_definitions(-D_SILENCE_CXX17_ITERATOR_BASE_CLASS_DEPRECATION_WARNING)
 add_definitions(-D_SILENCE_CXX17_SHARED_PTR_UNIQUE_DEPRECATION_WARNING)

--- a/qt/scientific_interfaces/Indirect/CMakeLists.txt
+++ b/qt/scientific_interfaces/Indirect/CMakeLists.txt
@@ -170,11 +170,9 @@ set(MOC_FILES
     IndirectFitPropertyBrowser.h
     InelasticDataManipulation.h
     InelasticDataManipulationElwinTab.h
-    InelasticDataManipulationElwinTabModel.h
     InelasticDataManipulationElwinTabView.h
     InelasticDataManipulationIqtTab.h
     InelasticDataManipulationIqtTabView.h
-    InelasticDataManipulationIqtTabModel.h
     InelasticDataManipulationMomentsTab.h
     InelasticDataManipulationMomentsTabView.h
     InelasticDataManipulationSqwTab.h
@@ -207,6 +205,8 @@ set(INC_FILES
     IndirectFunctionBrowser/ConvFunctionModel.h
     IndirectPlotOptionsModel.h
     IndirectSettingsHelper.h
+    InelasticDataManipulationElwinTabModel.h
+    InelasticDataManipulationIqtTabModel.h
     InelasticDataManipulationMomentsTabModel.h
     InelasticDataManipulationSqwTabModel.h
     InelasticDataManipulationSymmetriseTabModel.h


### PR DESCRIPTION
**Description of work.**
This PR fixes two compilation warnings seen on windows. One when building with Ninja, and the other when building with VS.

It also suppresses a deprecation warning seen when building with Ninja on windows. See this issue for more info #34103

**To test:**
1. Build Mantid using the Ninja generator:
```
cmake --preset=win-ninja -B=../buildninja
cd ../buildninja && ninja
```
There should be no warnings

2. Build Mantid using the VS generator:
```
cmake --preset=win-msvc -B=../buildvs
cd ../buildvs && cmake --build .
```
There should be no warnings

Fixes #34103

*There is no associated issue.*

*This does not require release notes* because **these are compilation warnings only seen by devs**

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
