### PR TITLE
InstrumentView Control points too large

### DIFF
--- a/qt/widgets/instrumentview/src/Shape2D.cpp
+++ b/qt/widgets/instrumentview/src/Shape2D.cpp
@@ -12,6 +12,8 @@
 #include <QWheelEvent>
 
 #include <QApplication>
+#include <QFont>
+#include <QFontInfo>
 #include <QLine>
 #include <QMap>
 #include <QRectF>
@@ -86,7 +88,7 @@ size_t Shape2D::getNControlPoints() const { return NCommonCP + this->getShapeNCo
 /**
  * Return the radius to use for the control points.
  */
-int Shape2D::controlPointSize() const { return QApplication::font().pointSize(); }
+int Shape2D::controlPointSize() const { return QFontInfo(QFont(QApplication::font().family(), 2)).pixelSize(); }
 
 /**
  * Return coordinates of i-th control point.


### PR DESCRIPTION
**Description of work.**
This PR fixes a regression where the control point size of shapes on the InstrumentView were very big for certain displays. This was found on macOS, but could also be reproduced on windows when using multiple screens with different resolution sizes.

Regression was caused by #34782

**To test:**
Open Mantid and load data
Right click the workspace and `Show Instrument`
Click on the Pick tab
Select the rectangle shape
Draw a rectangle
Make sure the control points on the corners are a sensible size.

*There is no associated issue.*

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
