### PR TITLE
muon GUI vanishing data

### DIFF
--- a/docs/source/release/v6.6.0/Muon/MA_FDA/Bugfixes/35125.rst
+++ b/docs/source/release/v6.6.0/Muon/MA_FDA/Bugfixes/35125.rst
@@ -1,0 +1,1 @@
+- Fixed a bug that prevented non-consecutive co-added runs from being completed.

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/contexts/muon_context.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/contexts/muon_context.py
@@ -517,7 +517,9 @@ class MuonContext(object):
         if runs == "All":
             run_list = self.data_context.current_runs
         else:
-            run_list = [run_string_to_list(item) for item in runs.replace(" ", "").split(",")]
+            # runs will always be the current "run"
+            # so either a single run or a co-add list
+            run_list = [run_string_to_list(runs.replace(" ", ""))]
             flat_list = []
             for sublist in run_list:
                 flat_list += [[run] for run in sublist if len(sublist) > 1]

--- a/qt/python/mantidqtinterfaces/test/Muon/muon_context_test.py
+++ b/qt/python/mantidqtinterfaces/test/Muon/muon_context_test.py
@@ -120,6 +120,10 @@ class MuonContextTest(unittest.TestCase):
         runs = self.context.get_runs(" 19489 ")
         self.assertEqual(runs, [[19489]])
 
+    def test_get_runs_coadd(self):
+        runs = self.context.get_runs(" 19489, 19491 ")
+        self.assertEqual(runs, [[19489, 19491]])
+
     def test_get_group_or_pair(self):
         group_and_pair = self.context.get_group_and_pair("All")
         self.assertEqual(group_and_pair, (["fwd", "bwd"], ["long"]))

--- a/qt/python/mantidqtinterfaces/test/Muon/muon_context_test.py
+++ b/qt/python/mantidqtinterfaces/test/Muon/muon_context_test.py
@@ -122,7 +122,7 @@ class MuonContextTest(unittest.TestCase):
 
     def test_get_runs_coadd(self):
         # need to update the run list
-        self.run_list = [19489, 19491]
+        self.data_context.current_runs = [19489, 19491]
         runs = self.context.get_runs(" 19489, 19491 ")
         self.assertEqual(runs, [[19489, 19491]])
 

--- a/qt/python/mantidqtinterfaces/test/Muon/muon_context_test.py
+++ b/qt/python/mantidqtinterfaces/test/Muon/muon_context_test.py
@@ -121,6 +121,8 @@ class MuonContextTest(unittest.TestCase):
         self.assertEqual(runs, [[19489]])
 
     def test_get_runs_coadd(self):
+        # need to update the run list
+        self.run_list = [19489, 19491]
         runs = self.context.get_runs(" 19489, 19491 ")
         self.assertEqual(runs, [[19489, 19491]])
 

--- a/qt/python/mantidqtinterfaces/test/Muon/muon_context_test.py
+++ b/qt/python/mantidqtinterfaces/test/Muon/muon_context_test.py
@@ -122,7 +122,7 @@ class MuonContextTest(unittest.TestCase):
 
     def test_get_runs_coadd(self):
         # need to update the run list
-        self.data_context.current_runs = [19489, 19491]
+        self.data_context.current_runs = [[19489, 19491]]
         runs = self.context.get_runs(" 19489, 19491 ")
         self.assertEqual(runs, [[19489, 19491]])
 


### PR DESCRIPTION
**Description of work.**

In the muon GUI's it was possible to create a situation where the data would not appear in the GUI. In fact it was not even calculated. This PR fixes the issue. The bug occurred when co-adding non-consecutive runs and was due to a split of the run string.

**To test:**

<!-- Instructions for testing. -->
Open muon analysis
Set the instrument to MUSR

**Checking simultaneous loading**
In the run bar enter `62251`
A single plot should appear (the label will have the run number)

In the run bar enter `62251, 62253`
Two plots should appear (the labels will have the respective run numbers)

In the run bar enter `62251-62253`
Three plots should appear (the labels will have the respective run numbers)

**Checking co-add**
Tick the co-add button
Now there will be one plot and the label will have "62251-62253" in the name

In the run bar enter `62251`
A single plot should appear (the label will have the run number)

In the run bar enter `62251, 62253`
A single plot should appear (the label will have "62251,62253" in the name)

**Checking simultaneous loading for multiperiod**
Change the instrument to HIFI
In the run bar enter `84447`
Four plots should appear (the label will have the run number)

In the run bar enter `84447, 84449`
Eight plots should appear (the labels will have the respective run numbers)

In the run bar enter `84447-9`
12 plots should appear (the labels will have the respective run numbers)

**Checking co-add with multiperiod**
Tick the co-add button
Now there will be four plots and the labels will have "84447-84449" in the name

In the run bar enter `84447`
Four plots should appear (the label will have the run number)

In the run bar enter `84447, 84449`
Four plots should appear (the label will have "84447, 84449" in the name)

Fixes #35125 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

Added a release note

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
