### PR TITLE
Corrected merged log for D16

### DIFF
--- a/instrument/D16B_Parameters.xml
+++ b/instrument/D16B_Parameters.xml
@@ -4,7 +4,7 @@
     <component-link name="D16B">
       <!-- Logs to sum when merging the runs -->
       <parameter name="sample_logs_sum" type="string" visible="false">
-        <value val="time, duration, timer" />
+        <value val="time, duration, Detector1.detsum" />
       </parameter>
 
       <!-- The pixel sizes [mm] used by SolidAngle, resolution and default Q binning calculations. -->

--- a/instrument/D16_Parameters.xml
+++ b/instrument/D16_Parameters.xml
@@ -4,7 +4,7 @@
     <component-link name="D16">
       <!-- Logs to sum when merging the runs -->
       <parameter name="sample_logs_sum" type="string" visible="false">
-        <value val="time, duration, timer" />
+        <value val="time, duration, Detector1.detsum" />
       </parameter>
       <!-- The pixel sizes [mm] used by SolidAngle, resolution and default Q binning calculations.
       Note that for the panels, often pixels have transposed shape, but the surface is the same.


### PR DESCRIPTION
by removing nonexistent 'timer' and replacing it with detector counter.

**Description of work.**

This PR replaces the non-existent log of 'timer' from the section of logs for merging in `MergeRuns` algorithm in instrument parameter files for D16 and D16B .  Instead, an actually existing log containing detector count (`Detector1.detsum`) is taking its place.

**To test:**

<!-- Instructions for testing. -->
1. Open workbench
2. Load two or more D16 data files from the `UnitTest/ILL/D16` directory
3. Run `MergeRuns` algorithm on the loaded data.
4. Make sure the logs: `duration`, `time`, and `Detector1.detsum` are indeed a sum of logs from the input data.

Part of #35092 .

*This does not require release notes* because it does not change behaviour of any algorithm nor workflow.

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
