### PR TITLE
Fix GSAS-II interaction in Engineering UI

### DIFF
--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/gsas2/model.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/gsas2/model.py
@@ -88,7 +88,6 @@ class GSAS2Model(object):
         self.phase_names_list = None
 
     def run_model(self, load_parameters, refinement_parameters, project_name, rb_num, user_limits):
-
         self.clear_input_components()
         if not self.initial_validation(project_name, load_parameters):
             return None
@@ -227,6 +226,20 @@ class GSAS2Model(object):
         try:
             env = os.environ.copy()
             env["PYTHONHOME"] = self.path_to_gsas2
+            # Search for binaries in GSASII directory before Mantid Conda environment
+            # Need to activate GSASII conda environment by calling "activate" script for proper solution
+            if platform.system() == "Windows":
+                extra_paths = [
+                    self.path_to_gsas2,
+                    os.path.join(self.path_to_gsas2, "bin"),
+                    os.path.join(self.path_to_gsas2, "Library", "bin"),
+                    os.path.join(self.path_to_gsas2, "Library", "usr", "bin"),
+                    os.path.join(self.path_to_gsas2, "Library", "mingw-w64", "bin"),
+                    os.path.join(self.path_to_gsas2, "Scripts"),
+                ]
+            else:
+                extra_paths = [os.path.join(self.path_to_gsas2, "bin")]
+            env["PATH"] = ";".join(extra_paths + [env["PATH"]])
             # The PyCharm debugger attempts to debug into any python subprocesses spawned by Workbench
             # On Windows (see pydev_monkey.py) this results in the command line arguments being manipulated and
             # the GSASII json parameter string gets corrupted
@@ -439,7 +452,6 @@ class GSAS2Model(object):
         return generated_reflections
 
     def generate_reflections_from_space_group(self, phase_filepath, cell_lengths):
-
         space_group = self.read_space_group(phase_filepath)
         found_basis = self.read_basis(phase_filepath)
         if not found_basis:
@@ -595,7 +607,6 @@ class GSAS2Model(object):
         return gsas_result_filepath
 
     def check_for_output_file(self, file_extension, file_descriptor, test=False):
-
         gsas_output_filename = self.project_name + file_extension
         if gsas_output_filename not in os.listdir(self.temporary_save_directory):
             logged_failure = (
@@ -731,7 +742,7 @@ class GSAS2Model(object):
 
     def get_txt_files_that_include(self, sub_string):
         output_files = []
-        for (_, _, filenames) in os.walk(self.user_save_directory):
+        for _, _, filenames in os.walk(self.user_save_directory):
             for loop_filename in filenames:
                 if sub_string in loop_filename and loop_filename[-4:] == ".txt":
                     output_files.append(os.path.join(self.user_save_directory, loop_filename))


### PR DESCRIPTION
**Description of work.**

Correct GSASII path for finding dlls when called from Engineering Diffraction UI in Mantid. GSAS was previously running mkl from the Mantid conda environment which worked if the GSAS\Mantid mkl versions were approximately the same but broke recently when Mantid increased its version. This only affected Windows where finding shared libraries (dlls) is more reliant on the PATH environment variable+ the mkl package is Windows-only. It may be the case though that even on Linux, GSAS is relying on some part of the Mantid Conda environment so I've included an edit to PATH on Linux also.

Solution could be improved calling activate script for GSASII Conda environment. Not doing that in release sprint because it probably involves inserting a new .bat file layer that calls activate followed by the G2SC python script so changes to PATH are retained in the same subprocess

**To test:**

Install GSAS2 from here: https://subversion.xray.aps.anl.gov/trac/pyGSAS/wiki/InstallWindows

Open up the Engineering Diffraction interface and perform the Calibration and Focus steps from Test 1 of the Engineering Diffraction manual testing instructions: https://developer.mantidproject.org/Testing/EngineeringDiffraction/EngineeringDiffractionTestGuide.html

Then move to the GSAS tab. Enter:
- a project name
- Select ENGINX_305738_all_banks.prm as the Instrument Group (perhaps this is auto populated)
- select `scripts/Engineering/ENGINX/phase_info/FE_GAMMA.cif` as the phase file
- Select ENGINX_305761_307521_all_banks_TOF.gss as Focused Data (perhaps this is auto populated)

Click on the "Refine in GSAS II" button and check it completes without errors

Fixes #35134. 

*This does not require release notes* because **it was a regression in this release**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
