### PR TITLE
Remove old ctest logs

### DIFF
--- a/buildconfig/Jenkins/Conda/conda-buildscript
+++ b/buildconfig/Jenkins/Conda/conda-buildscript
@@ -129,6 +129,8 @@ fi
 
 # Clean up artifacts from previous builds
 rm -f -- *.dmg *.rpm *.deb *.tar.gz *.tar.xz *.exe
+# Remove ctest logs from previous builds
+rm -rf  $BUILD_DIR/ctest_log
 
 # Run the script that handles the build
 $SCRIPT_DIR/build $WORKSPACE $CMAKE_PRESET $ENABLE_DOCS $ENABLE_DEV_DOCS $ENABLE_BUILD_CODE $ENABLE_UNIT_TESTS $ENABLE_SYSTEM_TESTS "$EXTRA_CMAKE_FLAGS" $BUILD_THREADS

--- a/qt/widgets/instrumentview/src/InstrumentWidget.cpp
+++ b/qt/widgets/instrumentview/src/InstrumentWidget.cpp
@@ -136,7 +136,7 @@ InstrumentWidget::InstrumentWidget(QString wsName, QWidget *parent, bool resetGe
   if (!m_messageHandler) {
     m_messageHandler = std::make_unique<MessageHandler>();
   }
-  rip;
+
   setFocusPolicy(Qt::StrongFocus);
   m_mainLayout = new QVBoxLayout(this);
   m_controlPanelLayout = new QSplitter(Qt::Horizontal);

--- a/qt/widgets/instrumentview/src/InstrumentWidget.cpp
+++ b/qt/widgets/instrumentview/src/InstrumentWidget.cpp
@@ -136,7 +136,7 @@ InstrumentWidget::InstrumentWidget(QString wsName, QWidget *parent, bool resetGe
   if (!m_messageHandler) {
     m_messageHandler = std::make_unique<MessageHandler>();
   }
-
+  rip;
   setFocusPolicy(Qt::StrongFocus);
   m_mainLayout = new QVBoxLayout(this);
   m_controlPanelLayout = new QSplitter(Qt::Horizontal);


### PR DESCRIPTION
**Description of work.**
If the build fails before it reaches the test step the ctest log from the previous build on the same machine will be archived. This can be confusing and misleading, and also will duplicate any flakey test statistics on the test monitor dashboard.
Here we remove the old ctest log when other build artifacts tare removed.

**To test:**
Check the following builds to see if the ctest logs were archived:
1. The first commit deliberately causes compilation error to demonstrate the issue on all systems - **the existing ctest log from a previous build is being archived**:
https://builds.mantidproject.org/job/pull_requests-conda-linux/2736/
https://builds.mantidproject.org/job/pull_requests-conda-osx/1390/
https://builds.mantidproject.org/job/pull_requests-conda-windows/1478/
2. The second commit fixes the issue by removing ctest logs from a previous run, and **should not have any ctest logs archived**: 
https://builds.mantidproject.org/job/pull_requests-conda-linux/2784/
https://builds.mantidproject.org/job/pull_requests-conda-osx/1431/
https://builds.mantidproject.org/job/pull_requests-conda-windows/1524/
3. The third commit fixes the compilation error and **should have all of the new ctest logs archived**:
(see the PR builds below)

*There is no associated issue.*

*This does not require release notes* because it is a build script change.

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
