### PR TITLE
Muon GUI with nxs_v1

### DIFF
--- a/Framework/DataHandling/src/LoadMuonNexusV2.cpp
+++ b/Framework/DataHandling/src/LoadMuonNexusV2.cpp
@@ -80,7 +80,7 @@ int LoadMuonNexusV2::confidence(NexusHDF5Descriptor &descriptor) const {
 /// Initialization method.
 void LoadMuonNexusV2::init() {
 
-  std::vector<std::string> extensions{".nxs", ".nxs_v2"};
+  std::vector<std::string> extensions{".nxs", ".nxs_v2", ".nxs_v1"};
   declareProperty(std::make_unique<FileProperty>("Filename", "", FileProperty::Load, extensions),
                   "The name of the Nexus file to load");
 

--- a/docs/source/release/v6.6.0/Muon/Algorithms/New_features/35141.rst
+++ b/docs/source/release/v6.6.0/Muon/Algorithms/New_features/35141.rst
@@ -1,0 +1,1 @@
+- :ref:`LoadMuonNexusV2 <algm-LoadMuonNexusV2>` can now accept the `.nxs_v1` extension.

--- a/docs/source/release/v6.6.0/Muon/MA_FDA/New_features/35141.rst
+++ b/docs/source/release/v6.6.0/Muon/MA_FDA/New_features/35141.rst
@@ -1,0 +1,1 @@
+- The Muon Analysis and Frequency Domain Analysis GUI's can now accept the `.nxs_v1` extension.

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/utilities/muon_file_utils.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/utilities/muon_file_utils.py
@@ -10,7 +10,7 @@ from mantidqtinterfaces.Muon.GUI.Common.message_box import warning
 from qtpy import PYQT4, QtWidgets
 
 allowed_instruments = ["EMU", "MUSR", "CHRONUS", "HIFI", "ARGUS", "PSI"]
-allowed_extensions = ["nxs", "nxs_v2", "bin"]
+allowed_extensions = ["nxs", "nxs_v2", "bin", "nxs_v1"]
 FILE_SEP = os.sep
 
 

--- a/qt/python/mantidqtinterfaces/test/Muon/utilities/muon_file_utils_test.py
+++ b/qt/python/mantidqtinterfaces/test/Muon/utilities/muon_file_utils_test.py
@@ -78,7 +78,7 @@ class MuonFileUtilsTest(unittest.TestCase):
         user_input = (
             "C:" + os.sep + "dir1" + os.sep + "dir2" + os.sep + "EMU0001234.nxs;"
             "C:" + os.sep + "dir1" + os.sep + "dir2" + os.sep + "EMU0001244.nxs_v1;"
-            "C:" + os.sep + "dir1" + os.sep + "dir2" + os.sep + "EMU0001245.nxs_v2"
+            "C:" + os.sep + "dir1" + os.sep + "dir2" + os.sep + "EMU0001245.nxs_v2;"
             "C:" + os.sep + "dir1" + os.sep + "dir2" + os.sep + "PSI0001245.bin"
         )
         files = [

--- a/qt/python/mantidqtinterfaces/test/Muon/utilities/muon_file_utils_test.py
+++ b/qt/python/mantidqtinterfaces/test/Muon/utilities/muon_file_utils_test.py
@@ -74,6 +74,25 @@ class MuonFileUtilsTest(unittest.TestCase):
         parsed_file = utils.parse_user_input_to_files(user_input, ["nxs"])
         self.assertEqual(parsed_file, files)
 
+    def test_parse_user_input_to_files_filters_files_with_other_valid_extension(self):
+        user_input = (
+            "C:" + os.sep + "dir1" + os.sep + "dir2" + os.sep + "EMU0001234.nxs;"
+            "C:" + os.sep + "dir1" + os.sep + "dir2" + os.sep + "EMU0001244.nxs_v1;"
+            "C:" + os.sep + "dir1" + os.sep + "dir2" + os.sep + "EMU0001245.nxs_v2"
+            "C:" + os.sep + "dir1" + os.sep + "dir2" + os.sep + "PSI0001245.bin"
+        )
+        files = [
+            "C:" + os.sep + "dir1" + os.sep + "dir2" + os.sep + "EMU0001234.nxs",
+            "C:" + os.sep + "dir1" + os.sep + "dir2" + os.sep + "EMU0001244.nxs_v1",
+            "C:" + os.sep + "dir1" + os.sep + "dir2" + os.sep + "EMU0001245.nxs_v2",
+            "C:" + os.sep + "dir1" + os.sep + "dir2" + os.sep + "PSI0001245.bin",
+        ]
+
+        parsed_file = utils.parse_user_input_to_files(
+            user_input,
+        )
+        self.assertEqual(parsed_file, files)
+
     def test_duplicates_removed_from_list_of_filenames_and_ordering_maintained(self):
         file_list = [
             os.sep + "dir1" + os.sep + "dir2" + os.sep + "file1.nxs",


### PR DESCRIPTION
**Description of work.**

The muon group are changing the extensions for their files in the upcoming cycle (next week). The changes are:

.nxs -> .nxs_v1
.nxs_v2 -> .nxs

we need to be able to load the original (legacy) data and the new data. I will add a test for loading the nxs_v1 files once the scientists have created a suitable one at the beam line

**To test:**

Open file browser and keep it open
Ask me for a link to some recent data

Open muon analysis (MA)
Set the instrument to EMU
In the file browser copy any .nxs file to your local machine
In MA click the browse button and make sure you can load the file you have just copied
At the bottom of the home tab will be a run info section. It will have a "comment" label followed by some text

In the file browser change the file extension to ".nxs_v1"
In file browser copy any .nxs_v2 file to your local machine

In MA click the browse button and make sure you can load the file you have just copied
At the bottom of the home tab will be a run info section. It will have a "comment" label but this time no text will be after the label (fixed in a different PR).

In the file browser change the file extension to ".nxs"

In MA click the browse button and load the ".nxs_v1" file
At the bottom of the home tab will be a run info section. It will have a "comment" label followed by some text

In MA click the browse button and load the ".nxs_v1" file
At the bottom of the home tab will be a run info section. It will have a "comment" label, but this time no text will be after the label (fixed in a different PR).

Fixes #35141. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
