### PR TITLE
Modify processTubes so that bank identification works for Bilby

### DIFF
--- a/instrument/BILBY_Definition.xml
+++ b/instrument/BILBY_Definition.xml
@@ -87,6 +87,7 @@
         <logfile id="D_curtainl_value" eq="1*value + 0.004"/>
         <!-- from beam center to the edge of the tube-->
       </parameter>
+      <side-by-side-view-location x="-0.6" y="0.0"/>
     </component>
   </type>
 
@@ -111,6 +112,7 @@
         <logfile id="D_curtainu_value" eq="value + 0.004"/>
         <!-- from beam center to the edge of the tube-->
       </parameter>
+      <side-by-side-view-location x="0.0" y="0.6"/>
     </component>
   </type>
 
@@ -134,6 +136,7 @@
         <logfile id="D_curtainr_value" eq="-1 * value - 0.004"/>
         <!-- from beam center -->
       </parameter>
+      <side-by-side-view-location x="0.6" y="0.0"/>
     </component>
   </type>
 
@@ -157,6 +160,7 @@
         <logfile id="D_curtaind_value" eq="-1 * value - 0.004"/>
         <!-- from beam center -->
       </parameter>
+      <side-by-side-view-location x="0.0" y="-0.6"/>
     </component>
   </type>
 
@@ -172,6 +176,7 @@
         <!-- Distance from sample to the Left (West) rear detector panel-->
         <logfile id="L2_det_value"/>
       </parameter>
+      <side-by-side-view-location x="-0.17" y="0.0"/>
     </component>
   </type>
 
@@ -188,6 +193,7 @@
         <!-- Distance from sample to the Right (East) rear detector panel-->
         <logfile id="L2_det_value"/>
       </parameter>
+      <side-by-side-view-location x="0.17" y="0.0"/>
     </component>
   </type>
 

--- a/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/GLColor.h
+++ b/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/GLColor.h
@@ -6,6 +6,7 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 #pragma once
 
+#include "DllOption.h"
 #include <iosfwd>
 
 namespace MantidQt {
@@ -22,7 +23,7 @@ GLColor class handles the OpenGL color for an object based on the type of the
 rendering selected. eg. MATERIAL by specifying color as glMaterial rather than
 glColor.
 */
-class GLColor {
+class EXPORT_OPT_MANTIDQT_INSTRUMENTVIEW GLColor {
 public:
   /// Default Constructor
   GLColor(float red = 0, float green = 0, float blue = 0, float alpha = 1.0f);
@@ -50,6 +51,6 @@ private:
   unsigned char m_rgba[4];
 };
 
-std::ostream &operator<<(std::ostream &ostr, const GLColor &c);
+EXPORT_OPT_MANTIDQT_INSTRUMENTVIEW std::ostream &operator<<(std::ostream &ostr, const GLColor &c);
 } // namespace MantidWidgets
 } // namespace MantidQt

--- a/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/PanelsSurface.h
+++ b/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/PanelsSurface.h
@@ -15,7 +15,7 @@ namespace MantidQt {
 namespace MantidWidgets {
 class PanelsSurface;
 
-struct FlatBankInfo {
+struct EXPORT_OPT_MANTIDQT_INSTRUMENTVIEW FlatBankInfo {
   explicit FlatBankInfo(PanelsSurface *s);
   /// Bank's rotation
   Mantid::Kernel::Quat rotation;
@@ -48,14 +48,16 @@ private:
  *       cannot lie on the same line (being parallel is alright)
  *  - CompAssembly with detectors lying in the same plane
  */
-class PanelsSurface : public UnwrappedSurface {
+class EXPORT_OPT_MANTIDQT_INSTRUMENTVIEW PanelsSurface : public UnwrappedSurface {
 public:
-  PanelsSurface(const InstrumentActor *rootActor, const Mantid::Kernel::V3D &origin, const Mantid::Kernel::V3D &axis,
+  PanelsSurface(const IInstrumentActor *rootActor, const Mantid::Kernel::V3D &origin, const Mantid::Kernel::V3D &axis,
                 const QSize &widgetSize, const bool maintainAspectRatio);
+  PanelsSurface() : m_zaxis({0., 0., 1.0}){};
   ~PanelsSurface() override;
   void init() override;
   void project(const Mantid::Kernel::V3D & /*pos*/, double & /*u*/, double & /*v*/, double & /*uscale*/,
                double & /*vscale*/) const override;
+  void resetInstrumentActor(const IInstrumentActor *rootActor) override;
 
 protected:
   void findFlatPanels(size_t rootIndex, std::vector<bool> &visited);

--- a/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/ProjectionSurface.h
+++ b/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/ProjectionSurface.h
@@ -40,8 +40,6 @@ class InputController;
 }
 } // namespace MantidQt
 
-class GLColor;
-
 class QMouseEvent;
 class QWheelEvent;
 
@@ -80,11 +78,15 @@ public:
     InteractionModeSize
   };
   /// Constructor
-  explicit ProjectionSurface(const InstrumentActor *rootActor);
+  explicit ProjectionSurface(const IInstrumentActor *rootActor);
+  ProjectionSurface()
+      : m_viewImage(nullptr), m_pickImage(nullptr), m_isLightingOn(false), m_peakLabelPrecision(2),
+        m_showPeakRows(false), m_showPeakLabels(false), m_showPeakRelativeIntensity(false), m_peakShapesStyle(0),
+        m_viewChanged(true), m_redrawPicking(true){};
   /// Destructor
   ~ProjectionSurface() override;
   /// Resets the instrument actor.
-  void resetInstrumentActor(const InstrumentActor *rootActor);
+  virtual void resetInstrumentActor(const IInstrumentActor *rootActor);
 
   //-----------------------------------
   //     Public virtual methods
@@ -332,7 +334,7 @@ protected:
   //     Protected data
   //-----------------------------------
 
-  const InstrumentActor *m_instrActor;
+  const IInstrumentActor *m_instrActor;
   mutable QImage *m_viewImage; ///< storage for view image
   mutable QImage *m_pickImage; ///< storage for picking image
   QColor m_backgroundColor;    ///< The background colour

--- a/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/Shape2DCollection.h
+++ b/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/Shape2DCollection.h
@@ -6,6 +6,7 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 #pragma once
 
+#include "DllOption.h"
 #include "MantidAPI/ITableWorkspace.h"
 
 #include "RectF.h"
@@ -44,7 +45,7 @@ namespace MantidWidgets {
  * must be called again. Changing the logical drawing bounds translates and
  *zooms the picture. The transformation is done by Qt's QTransform object.
  */
-class Shape2DCollection : public QObject, public Shape2D {
+class EXPORT_OPT_MANTIDQT_INSTRUMENTVIEW Shape2DCollection : public QObject, public Shape2D {
   Q_OBJECT
 public:
   Shape2DCollection();

--- a/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/UnwrappedDetector.h
+++ b/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/UnwrappedDetector.h
@@ -33,7 +33,7 @@ namespace MantidWidgets {
 This class keeps information used to draw a detector on an unwrapped surface.
 
 */
-class UnwrappedDetector {
+class EXPORT_OPT_MANTIDQT_INSTRUMENTVIEW UnwrappedDetector {
 public:
   UnwrappedDetector();
   UnwrappedDetector(const GLColor &color, size_t detIndex);

--- a/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/UnwrappedSurface.h
+++ b/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/UnwrappedSurface.h
@@ -32,7 +32,6 @@ class IPeaksWorkspace;
 }
 } // namespace Mantid
 
-class GLColor;
 class QGLWidget;
 class GL3DWidget;
 
@@ -62,8 +61,11 @@ namespace MantidWidgets {
 class EXPORT_OPT_MANTIDQT_INSTRUMENTVIEW UnwrappedSurface : public ProjectionSurface {
   Q_OBJECT
 public:
-  explicit UnwrappedSurface(const InstrumentActor *rootActor, const QSize &widgetSize,
+  explicit UnwrappedSurface(const IInstrumentActor *rootActor, const QSize &widgetSize,
                             const bool maintainAspectRatio = true);
+  UnwrappedSurface()
+      : m_u_min(DBL_MAX), m_u_max(-DBL_MAX), m_v_min(DBL_MAX), m_v_max(-DBL_MAX), m_height_max(0), m_width_max(0),
+        m_flippedView(false), m_startPeakShapes(false), m_maintainAspectRatio(true){};
 
   /** @name Implemented public virtual methods */
   //@{

--- a/qt/widgets/instrumentview/src/PanelsSurface.cpp
+++ b/qt/widgets/instrumentview/src/PanelsSurface.cpp
@@ -612,7 +612,7 @@ Mantid::Kernel::Quat PanelsSurface::calcBankRotation(const Mantid::Kernel::V3D &
     directionToViewer *= -1;
   }
   if (directionToViewer == -normal) {
-    return Mantid::Kernel::Quat(0, 0, 0, 1); // 180 degree rotation about z axis
+    return Mantid::Kernel::Quat(0, m_yaxis.X(), m_yaxis.Y(), m_yaxis.Z()); // 180 degree rotation about y axis
   } else if (normal.cross_prod(directionToViewer).nullVector()) {
     return Mantid::Kernel::Quat();
   }

--- a/qt/widgets/instrumentview/src/ProjectionSurface.cpp
+++ b/qt/widgets/instrumentview/src/ProjectionSurface.cpp
@@ -44,7 +44,7 @@ namespace MantidQt::MantidWidgets {
  * @param rootActor :: The instrument actor containing all info about the
  * instrument
  */
-ProjectionSurface::ProjectionSurface(const InstrumentActor *rootActor)
+ProjectionSurface::ProjectionSurface(const IInstrumentActor *rootActor)
     : m_instrActor(rootActor), m_viewImage(nullptr), m_pickImage(nullptr), m_viewRect(), m_selectRect(),
       m_interactionMode(MoveMode), m_isLightingOn(false), m_peakLabelPrecision(2), m_showPeakRows(false),
       m_showPeakLabels(false), m_showPeakRelativeIntensity(false), m_peakShapesStyle(0), m_viewChanged(true),
@@ -146,7 +146,7 @@ void ProjectionSurface::toggleToolTip(bool activateToolTip) {
  * Resets the instrument actor. The caller must ensure that the instrument
  * stays the same and workspace dimensions also don't change.
  */
-void ProjectionSurface::resetInstrumentActor(const InstrumentActor *rootActor) {
+void ProjectionSurface::resetInstrumentActor(const IInstrumentActor *rootActor) {
   m_instrActor = rootActor;
   connect(rootActor, SIGNAL(colorMapChanged()), this, SLOT(colorMapChanged()));
 }

--- a/qt/widgets/instrumentview/src/UnwrappedSurface.cpp
+++ b/qt/widgets/instrumentview/src/UnwrappedSurface.cpp
@@ -49,7 +49,7 @@ QRectF getArea(const UnwrappedDetector &udet, double maxWidth, double maxHeight)
  * Constructor.
  * @param rootActor :: The instrument actor.
  */
-UnwrappedSurface::UnwrappedSurface(const InstrumentActor *rootActor, const QSize &widgetSize,
+UnwrappedSurface::UnwrappedSurface(const IInstrumentActor *rootActor, const QSize &widgetSize,
                                    const bool maintainAspectRatio)
     : ProjectionSurface(rootActor), m_u_min(DBL_MAX), m_u_max(-DBL_MAX), m_v_min(DBL_MAX), m_v_max(-DBL_MAX),
       m_height_max(0), m_width_max(0), m_flippedView(false), m_startPeakShapes(false), m_widgetSize(widgetSize),

--- a/qt/widgets/instrumentview/test/CMakeLists.txt
+++ b/qt/widgets/instrumentview/test/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Testing
 set(TEST_FILES InstrumentWidgetDecoderTest.h InstrumentWidgetEncoderTest.h InstrumentWidget/InstrumentDisplayTest.h
-               InstrumentWidget/InstrumentWidgetTest.h
+               InstrumentWidget/InstrumentWidgetTest.h InstrumentWidget/PanelsSurfaceTest.h
 )
 
 set(MOCK_HEADER_DIRS InstrumentWidget)

--- a/qt/widgets/instrumentview/test/InstrumentWidget/MockInstrumentActor.h
+++ b/qt/widgets/instrumentview/test/InstrumentWidget/MockInstrumentActor.h
@@ -1,6 +1,6 @@
 // Mantid Repository : https://github.com/mantidproject/mantid
 //
-// Copyright &copy; 2022 ISIS Rutherford Appleton Laboratory UKRI,
+// Copyright &copy; 2023 ISIS Rutherford Appleton Laboratory UKRI,
 //     NScD Oak Ridge National Laboratory, European Spallation Source
 //     & Institut Laue - Langevin
 // SPDX - License - Identifier: GPL - 3.0 +
@@ -42,8 +42,8 @@ public:
   MOCK_CONST_METHOD1(getDetID, Mantid::detid_t(std::size_t pickID));
   MOCK_CONST_METHOD1(getDetPos, const Mantid::Kernel::V3D(std::size_t pickID));
   MOCK_CONST_METHOD1(getWorkspaceIndex, std::size_t(std::size_t index));
-  MOCK_CONST_METHOD3(getBinMinMaxIndex, void(std::size_t wi, std::size_t &imin, std::size_t &imax));
   MOCK_CONST_METHOD1(getIntegratedCounts, double(std::size_t index));
+  MOCK_CONST_METHOD3(getBinMinMaxIndex, void(std::size_t wi, std::size_t &imin, std::size_t &imax));
   MOCK_CONST_METHOD0(components, const std::vector<size_t> &());
   MOCK_CONST_METHOD0(getInstrumentRenderer, const InstrumentRenderer &());
 };

--- a/qt/widgets/instrumentview/test/InstrumentWidget/PanelsSurfaceTest.h
+++ b/qt/widgets/instrumentview/test/InstrumentWidget/PanelsSurfaceTest.h
@@ -1,0 +1,138 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2023 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#pragma once
+
+#include <cxxtest/TestSuite.h>
+#include <gmock/gmock.h>
+
+#include "MantidFrameworkTestHelpers/ComponentCreationHelper.h"
+#include "MantidFrameworkTestHelpers/WorkspaceCreationHelper.h"
+#include "MantidKernel/V3D.h"
+#include "MantidQtWidgets/InstrumentView/PanelsSurface.h"
+#include "MockInstrumentActor.h"
+
+using namespace testing;
+
+class PanelsSurfaceHelper : public PanelsSurface {
+public:
+  PanelsSurfaceHelper(const IInstrumentActor *rootActor, const Mantid::Kernel::V3D &origin,
+                      const Mantid::Kernel::V3D &axis, const QSize &widgetSize, const bool maintainAspectRatio)
+      : PanelsSurface(rootActor, origin, axis, widgetSize, maintainAspectRatio) {}
+  PanelsSurfaceHelper() : PanelsSurface() {}
+  void setupAxes() { PanelsSurface::setupAxes(); };
+  void addDetector(size_t detIndex, const Mantid::Kernel::V3D &refPos, int bankIndex,
+                   const Mantid::Kernel::Quat &rotation) {
+    return PanelsSurface::addDetector(detIndex, refPos, bankIndex, rotation);
+  }
+  Mantid::Kernel::Quat calcBankRotation(const Mantid::Kernel::V3D &detPos, Mantid::Kernel::V3D normal) {
+    return PanelsSurface::calcBankRotation(detPos, normal);
+  }
+  boost::optional<size_t> processTubes(size_t rootIndex) { return PanelsSurface::processTubes(rootIndex); }
+  std::vector<UnwrappedDetector> getUnwrappedDetectors() { return m_unwrappedDetectors; };
+  void addFlatBank() {
+    auto *info = new FlatBankInfo(this);
+    m_flatBanks << info;
+  }
+};
+
+class PanelsSurfaceTest : public CxxTest::TestSuite {
+public:
+  static PanelsSurfaceTest *createSuite() { return new PanelsSurfaceTest(); }
+  static void destroySuite(PanelsSurfaceTest *suite) { delete suite; }
+
+  std::unique_ptr<NiceMock<MockInstrumentActor>> createMockInstrumentActor(MatrixWorkspace_sptr ws, int ndetectors) {
+    // Hard to mock DetectorInfo and ComponentInfo so use real objects from a real workspace
+    auto &detInfo = ws->detectorInfo();
+    auto &compInfo = ws->componentInfo();
+    auto instrumentActor = std::make_unique<NiceMock<MockInstrumentActor>>();
+    EXPECT_CALL(*instrumentActor, ndetectors()).WillRepeatedly(Return(ndetectors));
+    EXPECT_CALL(*instrumentActor, detectorInfo()).WillRepeatedly(ReturnRef(detInfo));
+    EXPECT_CALL(*instrumentActor, componentInfo()).WillRepeatedly(ReturnRef(compInfo));
+    EXPECT_CALL(*instrumentActor, getInstrument()).WillRepeatedly(Return(ws->getInstrument()));
+    return instrumentActor;
+  }
+
+  void test_addDetector() {
+    const int NDETECTORS = 2;
+    auto ws = WorkspaceCreationHelper::create2DWorkspace(NDETECTORS, 1);
+    Mantid::Kernel::V3D samplePosition{0., 0., 0.};
+    Mantid::Kernel::V3D sourcePosition{0., 0., -10.};
+    WorkspaceCreationHelper::createInstrumentForWorkspaceWithDistances(ws, samplePosition, sourcePosition,
+                                                                       {{0., 0.1, -5.0}, {0., 0.1, 5.0}});
+    auto instrumentActor = createMockInstrumentActor(ws, NDETECTORS);
+    PanelsSurfaceHelper surface;
+    surface.setupAxes();
+    surface.resetInstrumentActor(instrumentActor.get());
+    Mantid::Kernel::Quat q(90, {0., 0., 1.});
+    surface.addFlatBank();
+    surface.addDetector(0, {0., 0., 0.}, 0, q);
+    surface.addDetector(1, {0., 0., 0.}, 0, q);
+    auto unwrapppedDet = surface.getUnwrappedDetectors();
+    TS_ASSERT(unwrapppedDet.size() == 2);
+    TS_ASSERT_EQUALS(unwrapppedDet[0].u, -0.1);
+    TS_ASSERT_DELTA(unwrapppedDet[0].v, 0., 1E-08);
+    TS_ASSERT_EQUALS(unwrapppedDet[1].u, 0.1);
+    TS_ASSERT_DELTA(unwrapppedDet[1].v, 0., 1E-08);
+  }
+
+  void test_calcBankRotation() {
+    PanelsSurfaceHelper surface;
+    Mantid::Kernel::V3D detPosPositiveZ{1.0, 0., 1.0};
+    Mantid::Kernel::V3D detPosNegativeZ{1.0, 0., -1.0};
+
+    // general case where rotation constructed in two stages
+    Mantid::Kernel::V3D normalPointingToPlusYNegativeZ{0., 1.0, -1.0};
+    normalPointingToPlusYNegativeZ.normalize();
+    auto quat = surface.calcBankRotation(detPosPositiveZ, normalPointingToPlusYNegativeZ);
+    auto anglesVector = quat.getEulerAngles("XYZ");
+    TS_ASSERT_DELTA(anglesVector[0], -45.0, 1E-06);
+    Mantid::Kernel::V3D normalPointingToPlusYPositiveZ{0., 1.0, 1.0};
+    normalPointingToPlusYPositiveZ.normalize();
+    quat = surface.calcBankRotation(detPosNegativeZ, normalPointingToPlusYPositiveZ);
+    anglesVector = quat.getEulerAngles("XYZ");
+    TS_ASSERT_DELTA(anglesVector[0], 45.0, 1E-06);
+
+    // special case where normal is initially pointing away from viewer and is flipped to point at viewer
+    normalPointingToPlusYPositiveZ.normalize();
+    quat = surface.calcBankRotation(detPosNegativeZ, normalPointingToPlusYNegativeZ);
+    anglesVector = quat.getEulerAngles("XYZ");
+    TS_ASSERT_DELTA(anglesVector[0], -45.0, 1E-06);
+
+    // special case where construct quaternion from a single rotation
+    Mantid::Kernel::V3D normalPointingUp{0., 1.0, 0.};
+    quat = surface.calcBankRotation(detPosPositiveZ, normalPointingUp);
+    anglesVector = quat.getEulerAngles("XYZ");
+    TS_ASSERT_DELTA(anglesVector[0], -90.0, 1E-06);
+    quat = surface.calcBankRotation(detPosNegativeZ, normalPointingUp);
+    anglesVector = quat.getEulerAngles("XYZ");
+    TS_ASSERT_DELTA(anglesVector[0], 90.0, 1E-06);
+  }
+
+  void test_ProcessTubes() {
+    const int NTUBES = 2;
+    const int NDETSPERTUBE = 2;
+    Mantid::API::MatrixWorkspace_sptr ws = WorkspaceCreationHelper::create2DWorkspace(2, 1);
+    auto instrument = ComponentCreationHelper::createCylInstrumentWithVerticalOffsetsSpecified(
+        NTUBES, {0., 0.}, NDETSPERTUBE, 0., 1., 0., 1.);
+    ws->setInstrument(instrument);
+    auto instAct = createMockInstrumentActor(ws, 4);
+    PanelsSurfaceHelper surface;
+    surface.setupAxes();
+    surface.resetInstrumentActor(instAct.get());
+    /*     9
+          /|\
+         8 7 6 <= sixteen pack
+          / \
+         4    5 <== tubes
+        / \  / \
+       0  1 2   3 <= detectors
+    */
+    surface.processTubes(4);
+    auto unwrapppedDet = surface.getUnwrappedDetectors();
+    TS_ASSERT(unwrapppedDet.size() == NTUBES * NDETSPERTUBE);
+  }
+};


### PR DESCRIPTION
**Description of work.**

Modification to the side by side view in the instrument view to be more flexible in the way banks of tubes are identified. The processTubes function previously only went up to the grandparent level of the supplied tube if the parent of the supplied tube only had a single child. Broaden this out to always go up to the grandparent level and if the set of tubes found isn't flat, fall back to considering the parent level. This will help identify banks in the Bilby instrument where a bank consists of several eight packs of tubes.

I've also modified the function calcBankRotation which is used for all different types of detector (tubes, rectangular, structured):

- update the logic when the normal and the bank centre are parallel that returned an empty Quat - didn't work for case where normal and z axis were 180 degrees apart
- Rotate bank normal to +ve or -ve z depending on whether bank is at -ve or +ve z respectively

Finally I've added some bank centre overrides to the Bilby instrument definition using the new feature implemented in https://github.com/mantidproject/mantid/pull/35070

**To test:**

Run the LoadBBY algorithm with the BBY0001356.tar file available here: [https://cloudstor.aarnet.edu.au/plus/s/j7dBLMlaKd9QwGS](https://aus01.safelinks.protection.outlook.com/?url=https%3A%2F%2Fcloudstor.aarnet.edu.au%2Fplus%2Fs%2Fj7dBLMlaKd9QwGS&data=05%7C01%7Clilianad%40ansto.gov.au%7Ca70c66778516482e4ca508db05ce42e5%7C4cbf9a84567a44d09db11dbfbf8393f0%7C0%7C0%7C638110155748664879%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C3000%7C%7C%7C&sdata=xM8UJ28z94wCAHOeBrmgswZxMx3k%2B%2F8DR7zDbvURhg8%3D&reserved=0)

Right click on the resulting workspace in the ADS and select Show Instrument
Select Side by Side view
Observe that there are now 6 banks

Run the LoadEmptyInstrument algorithm on the `VISION_Definition_20160815-.xml` instrument definition file and check the side by side view renders OK. The last significant change to processTubes prior to this PR was to accommodate the VISION IDF and its definition of banks so need to check I've not broken that

Fixes #34760.

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
