### PR TITLE
SplittingInterval extends TimeInterval

### DIFF
--- a/Framework/Algorithms/src/FilterEvents.cpp
+++ b/Framework/Algorithms/src/FilterEvents.cpp
@@ -824,8 +824,8 @@ void FilterEvents::convertSplittersWorkspaceToVectors() {
   for (size_t i_splitter = 0; i_splitter < num_splitters; ++i_splitter) {
     // get splitter
     Kernel::SplittingInterval splitter = m_splitters[i_splitter];
-    int64_t start_time_i64 = splitter.start().totalNanoseconds();
-    int64_t stop_time_i64 = splitter.stop().totalNanoseconds();
+    int64_t start_time_i64 = splitter.begin().totalNanoseconds();
+    int64_t stop_time_i64 = splitter.end().totalNanoseconds();
     if (m_vecSplitterTime.empty()) {
       // first entry: add
       m_vecSplitterTime.emplace_back(start_time_i64);
@@ -1100,9 +1100,8 @@ void FilterEvents::createOutputWorkspacesSplitters() {
       if (descriptiveNames && splitByTime) {
         auto splitter = m_splitters[wsgroup];
         auto startTimeInSeconds =
-            Mantid::Types::Core::DateAndTime::secondsFromDuration(splitter.start() - m_runStartTime);
-        auto stopTimeInSeconds =
-            Mantid::Types::Core::DateAndTime::secondsFromDuration(splitter.stop() - m_runStartTime);
+            Mantid::Types::Core::DateAndTime::secondsFromDuration(splitter.begin() - m_runStartTime);
+        auto stopTimeInSeconds = Mantid::Types::Core::DateAndTime::secondsFromDuration(splitter.end() - m_runStartTime);
         wsname << startTimeInSeconds << "_" << stopTimeInSeconds;
       } else if (descriptiveNames) {
         auto infoiter = infomap.find(wsgroup);
@@ -1843,15 +1842,15 @@ void FilterEvents::generateSplitterTSPalpha(
     if (itarget >= static_cast<int>(split_tsp_vec.size()))
       throw std::runtime_error("Target workspace index is out of range!");
 
-    if (splitter.start() == m_runStartTime) {
+    if (splitter.begin() == m_runStartTime) {
       // there should be only 1 value in the splitter and clear it.
       if (split_tsp_vec[itarget]->size() != 1) {
         throw std::runtime_error("Splitter must have 1 value with initialization.");
       }
       split_tsp_vec[itarget]->clear();
     }
-    split_tsp_vec[itarget]->addValue(splitter.start(), 1);
-    split_tsp_vec[itarget]->addValue(splitter.stop(), 0);
+    split_tsp_vec[itarget]->addValue(splitter.begin(), 1);
+    split_tsp_vec[itarget]->addValue(splitter.end(), 0);
   }
 
   return;

--- a/Framework/Algorithms/test/GenerateEventsFilterTest.h
+++ b/Framework/Algorithms/test/GenerateEventsFilterTest.h
@@ -133,8 +133,8 @@ public:
     TS_ASSERT_EQUALS(splittersws->getNumberSplitters(), 1);
     Kernel::SplittingInterval splitter0 = splittersws->getSplitter(0);
     Types::Core::DateAndTime runstart(3000000000);
-    TS_ASSERT_EQUALS(splitter0.start().totalNanoseconds(), runstart.totalNanoseconds() + 100);
-    TS_ASSERT_EQUALS(splitter0.stop().totalNanoseconds(), runstart.totalNanoseconds() + 1000000);
+    TS_ASSERT_EQUALS(splitter0.begin().totalNanoseconds(), runstart.totalNanoseconds() + 100);
+    TS_ASSERT_EQUALS(splitter0.end().totalNanoseconds(), runstart.totalNanoseconds() + 1000000);
     TS_ASSERT_EQUALS(splitter0.index(), 0);
 
     TS_ASSERT_EQUALS(splittersws->rowCount(), 1);
@@ -195,19 +195,19 @@ public:
 
     // b) First interval
     Kernel::SplittingInterval splitter0 = splittersws->getSplitter(0);
-    TS_ASSERT_EQUALS(splitter0.start().totalNanoseconds(), 0 + runstarttime_ns);
-    TS_ASSERT_EQUALS(splitter0.stop().totalNanoseconds(), timeinterval_ns + runstarttime_ns);
+    TS_ASSERT_EQUALS(splitter0.begin().totalNanoseconds(), 0 + runstarttime_ns);
+    TS_ASSERT_EQUALS(splitter0.end().totalNanoseconds(), timeinterval_ns + runstarttime_ns);
     TS_ASSERT_EQUALS(splitter0.index(), 0);
 
     // c) Last interval
     Kernel::SplittingInterval splitterf = splittersws->getSplitter(numintervals - 1);
-    TS_ASSERT_EQUALS(splitterf.stop(), runstoptime);
+    TS_ASSERT_EQUALS(splitterf.end(), runstoptime);
     TS_ASSERT_EQUALS(splitterf.index(), numintervals - 1);
 
     // d) Randomly
     Kernel::SplittingInterval splitterR = splittersws->getSplitter(40);
-    Types::Core::DateAndTime t0 = splitterR.start();
-    Types::Core::DateAndTime tf = splitterR.stop();
+    Types::Core::DateAndTime t0 = splitterR.begin();
+    Types::Core::DateAndTime tf = splitterR.end();
     int64_t dt_ns = tf.totalNanoseconds() - t0.totalNanoseconds();
     TS_ASSERT_EQUALS(dt_ns, timeinterval_ns);
     int64_t dt_runtimestart = t0.totalNanoseconds() - runstarttime_ns;
@@ -262,19 +262,19 @@ public:
 
     // b) First interval
     Kernel::SplittingInterval splitter0 = splittersws->getSplitter(0);
-    TS_ASSERT_EQUALS(splitter0.start().totalNanoseconds(), basetimeinterval_ns + runstarttime_ns);
-    TS_ASSERT_EQUALS(splitter0.stop().totalNanoseconds(), basetimeinterval_ns * 2 + runstarttime_ns);
+    TS_ASSERT_EQUALS(splitter0.begin().totalNanoseconds(), basetimeinterval_ns + runstarttime_ns);
+    TS_ASSERT_EQUALS(splitter0.end().totalNanoseconds(), basetimeinterval_ns * 2 + runstarttime_ns);
     TS_ASSERT_EQUALS(splitter0.index(), 0);
 
     // c) Last interval
     Kernel::SplittingInterval splitterf = splittersws->getSplitter(numintervals - 1);
-    TS_ASSERT_EQUALS(splitterf.stop().totalNanoseconds(), runstarttime.totalNanoseconds() + 1000);
+    TS_ASSERT_EQUALS(splitterf.end().totalNanoseconds(), runstarttime.totalNanoseconds() + 1000);
     TS_ASSERT_EQUALS(splitterf.index(), numintervals - 1);
 
     // d) Randomly
     Kernel::SplittingInterval splitterR = splittersws->getSplitter(5);
-    Types::Core::DateAndTime t0 = splitterR.start();
-    Types::Core::DateAndTime tf = splitterR.stop();
+    Types::Core::DateAndTime t0 = splitterR.begin();
+    Types::Core::DateAndTime tf = splitterR.end();
     int64_t dt_ns = tf.totalNanoseconds() - t0.totalNanoseconds();
     TS_ASSERT_EQUALS(dt_ns, basetimeinterval_ns * static_cast<int64_t>(std::pow(2, 5)));
     int64_t dt_runtimestart = t0.totalNanoseconds() - runstarttime_ns;
@@ -331,8 +331,8 @@ public:
     // b) First interval - which is actually the last one because we are generating them from the end, ie the closest
     // to endTime
     Kernel::SplittingInterval splitter0 = splittersws->getSplitter(0);
-    TS_ASSERT_EQUALS(splitter0.start().totalNanoseconds(), runstarttime_ns + stopTime - startTime);
-    TS_ASSERT_EQUALS(splitter0.stop().totalNanoseconds(), runstarttime_ns + stopTime);
+    TS_ASSERT_EQUALS(splitter0.begin().totalNanoseconds(), runstarttime_ns + stopTime - startTime);
+    TS_ASSERT_EQUALS(splitter0.end().totalNanoseconds(), runstarttime_ns + stopTime);
 
     TS_ASSERT_EQUALS(splitter0.index(), numintervals - 1);
 
@@ -340,15 +340,15 @@ public:
 
     // c) Last interval - ie the closest to startTime
     Kernel::SplittingInterval splitterf = splittersws->getSplitter(numintervals - 1);
-    TS_ASSERT_EQUALS(splitterf.start().totalNanoseconds(), runstarttime_ns + startTime);
-    TS_ASSERT_EQUALS(splitterf.stop().totalNanoseconds(),
+    TS_ASSERT_EQUALS(splitterf.begin().totalNanoseconds(), runstarttime_ns + startTime);
+    TS_ASSERT_EQUALS(splitterf.end().totalNanoseconds(),
                      runstarttime_ns + stopTime - static_cast<int>(std::pow(2, 12)) + 1);
     TS_ASSERT_EQUALS(splitterf.index(), 0);
 
     // d) Randomly
     Kernel::SplittingInterval splitterR = splittersws->getSplitter(4);
-    Types::Core::DateAndTime t0 = splitterR.start();
-    Types::Core::DateAndTime tf = splitterR.stop();
+    Types::Core::DateAndTime t0 = splitterR.begin();
+    Types::Core::DateAndTime tf = splitterR.end();
     int64_t dt_ns = tf.totalNanoseconds() - t0.totalNanoseconds();
     TS_ASSERT_EQUALS(dt_ns, static_cast<int64_t>(std::pow(2, 4)));
     TS_ASSERT_EQUALS(t0.totalNanoseconds(), runstarttime_ns + stopTime - static_cast<int>(std::pow(2, 5)) + 1);
@@ -405,8 +405,8 @@ public:
     // b) First interval - which is actually the last one because we are generating them from the end, ie the closest
     // to endTime.
     Kernel::SplittingInterval splitter0 = splittersws->getSplitter(0);
-    TS_ASSERT_EQUALS(splitter0.start().totalNanoseconds(), runstarttime_ns + stopTime - startTime);
-    TS_ASSERT_EQUALS(splitter0.stop().totalNanoseconds(), runstarttime_ns + stopTime);
+    TS_ASSERT_EQUALS(splitter0.begin().totalNanoseconds(), runstarttime_ns + stopTime - startTime);
+    TS_ASSERT_EQUALS(splitter0.end().totalNanoseconds(), runstarttime_ns + stopTime);
 
     TS_ASSERT_EQUALS(splitter0.index(), numintervals - 1);
 
@@ -414,15 +414,15 @@ public:
 
     // c) Last interval - ie the closest to startTime
     Kernel::SplittingInterval splitterf = splittersws->getSplitter(numintervals - 1);
-    TS_ASSERT_EQUALS(splitterf.start().totalNanoseconds(), runstarttime_ns + startTime);
-    TS_ASSERT_EQUALS(splitterf.stop().totalNanoseconds(),
+    TS_ASSERT_EQUALS(splitterf.begin().totalNanoseconds(), runstarttime_ns + startTime);
+    TS_ASSERT_EQUALS(splitterf.end().totalNanoseconds(),
                      runstarttime_ns + stopTime - static_cast<int>(std::pow(2, 13)) + 1);
     TS_ASSERT_EQUALS(splitterf.index(), 0);
 
     // d) Randomly
     Kernel::SplittingInterval splitterR = splittersws->getSplitter(4);
-    Types::Core::DateAndTime t0 = splitterR.start();
-    Types::Core::DateAndTime tf = splitterR.stop();
+    Types::Core::DateAndTime t0 = splitterR.begin();
+    Types::Core::DateAndTime tf = splitterR.end();
     int64_t dt_ns = tf.totalNanoseconds() - t0.totalNanoseconds();
     TS_ASSERT_EQUALS(dt_ns, static_cast<int64_t>(std::pow(2, 4)));
     TS_ASSERT_EQUALS(t0.totalNanoseconds(), runstarttime_ns + stopTime - static_cast<int>(std::pow(2, 5)) + 1);
@@ -475,12 +475,12 @@ public:
     TS_ASSERT_EQUALS(splittersws->getNumberSplitters(), numsplitters);
 
     Kernel::SplittingInterval s0 = splittersws->getSplitter(0);
-    TS_ASSERT_EQUALS(s0.start().totalNanoseconds(), 3000000000 - static_cast<int64_t>(1.0E-8 * 1.0E9));
-    TS_ASSERT_EQUALS(s0.stop().totalNanoseconds(), 3000050000 - static_cast<int64_t>(1.0E-8 * 1.0E9));
+    TS_ASSERT_EQUALS(s0.begin().totalNanoseconds(), 3000000000 - static_cast<int64_t>(1.0E-8 * 1.0E9));
+    TS_ASSERT_EQUALS(s0.end().totalNanoseconds(), 3000050000 - static_cast<int64_t>(1.0E-8 * 1.0E9));
 
     Kernel::SplittingInterval s1 = splittersws->getSplitter(1);
-    TS_ASSERT_EQUALS(s1.start().totalNanoseconds(), 3000775000 - static_cast<int64_t>(1.0E-8 * 1.0E9));
-    TS_ASSERT_EQUALS(s1.stop().totalNanoseconds(), 3000850000 - static_cast<int64_t>(1.0E-8 * 1.0E9));
+    TS_ASSERT_EQUALS(s1.begin().totalNanoseconds(), 3000775000 - static_cast<int64_t>(1.0E-8 * 1.0E9));
+    TS_ASSERT_EQUALS(s1.end().totalNanoseconds(), 3000850000 - static_cast<int64_t>(1.0E-8 * 1.0E9));
 
     TS_ASSERT_EQUALS(infows->rowCount(), 1);
 
@@ -536,12 +536,12 @@ public:
     TS_ASSERT_EQUALS(infows->rowCount(), numoutputs);
 
     Kernel::SplittingInterval s0 = splittersws->getSplitter(0);
-    TS_ASSERT_EQUALS(s0.start(), 3000000000 - static_cast<int>(1.0E-8 * 1.0E9));
+    TS_ASSERT_EQUALS(s0.begin(), 3000000000 - static_cast<int>(1.0E-8 * 1.0E9));
     TS_ASSERT_EQUALS(s0.index(), 5);
 
     Kernel::SplittingInterval s15 = splittersws->getSplitter(15);
-    TS_ASSERT_EQUALS(s15.start(), 3000924990);
-    TS_ASSERT_EQUALS(s15.stop(), 3000974990);
+    TS_ASSERT_EQUALS(s15.begin(), 3000924990);
+    TS_ASSERT_EQUALS(s15.end(), 3000974990);
     TS_ASSERT_EQUALS(s15.index(), 9);
   }
 
@@ -591,7 +591,7 @@ public:
     int64_t factor = static_cast<int64_t>(1.0E9 + 0.5);
 
     Kernel::SplittingInterval s0 = splittersws->getSplitter(0);
-    TS_ASSERT_EQUALS(s0.start().totalNanoseconds(), 11 * factor - 5 * factor / 100);
+    TS_ASSERT_EQUALS(s0.begin().totalNanoseconds(), 11 * factor - 5 * factor / 100);
     TS_ASSERT_EQUALS(s0.index(), 0);
 
     Kernel::SplittingInterval s9 = splittersws->getSplitter(9);
@@ -651,7 +651,7 @@ public:
     int64_t factor = static_cast<int64_t>(1.0E9 + 0.5);
 
     Kernel::SplittingInterval s0 = splittersws->getSplitter(0);
-    TS_ASSERT_EQUALS(s0.start().totalNanoseconds(), 11 * factor - 5 * factor / 100);
+    TS_ASSERT_EQUALS(s0.begin().totalNanoseconds(), 11 * factor - 5 * factor / 100);
     TS_ASSERT_EQUALS(s0.index(), 0);
 
     // Clean
@@ -918,8 +918,8 @@ public:
       for (size_t i = 0; i < numsplitters; ++i) {
         Kernel::SplittingInterval s2 = splittersws2->getSplitter(i);
         Kernel::SplittingInterval s1 = splitters[i];
-        TS_ASSERT_EQUALS(s1.start(), s2.start());
-        TS_ASSERT_EQUALS(s1.stop(), s2.stop());
+        TS_ASSERT_EQUALS(s1.begin(), s2.begin());
+        TS_ASSERT_EQUALS(s1.end(), s2.end());
         TS_ASSERT_EQUALS(s1.index(), s2.index());
       }
     }
@@ -1007,8 +1007,8 @@ public:
       for (size_t i = 0; i < numsplitters; ++i) {
         Kernel::SplittingInterval s2 = splittersws2->getSplitter(i);
         Kernel::SplittingInterval s1 = splitters[i];
-        TS_ASSERT_EQUALS(s1.start(), s2.start());
-        TS_ASSERT_EQUALS(s1.stop(), s2.stop());
+        TS_ASSERT_EQUALS(s1.begin(), s2.begin());
+        TS_ASSERT_EQUALS(s1.end(), s2.end());
         TS_ASSERT_EQUALS(s1.index(), s2.index());
       }
     }

--- a/Framework/DataObjects/src/EventList.cpp
+++ b/Framework/DataObjects/src/EventList.cpp
@@ -3802,8 +3802,8 @@ void EventList::filterInPlaceHelper(Kernel::SplittingIntervalVec &splitter, type
   // This is the time of the first section. Anything before is thrown out.
   while (itspl != itspl_end) {
     // Get the splitting interval times and destination
-    start = itspl->start();
-    stop = itspl->stop();
+    start = itspl->begin();
+    stop = itspl->end();
     const int index = itspl->index();
 
     // Skip the events before the start of the time
@@ -3904,8 +3904,8 @@ void EventList::splitByTimeHelper(Kernel::SplittingIntervalVec &splitter, std::v
   // This is the time of the first section. Anything before is thrown out.
   while (itspl != itspl_end) {
     // Get the splitting interval times and destination
-    start = itspl->start();
-    stop = itspl->stop();
+    start = itspl->begin();
+    stop = itspl->end();
     const size_t index = itspl->index();
 
     // Skip the events before the start of the time
@@ -4010,8 +4010,8 @@ void EventList::splitByFullTimeHelper(Kernel::SplittingIntervalVec &splitter, st
   // 3. This is the time of the first section. Anything before is thrown out.
   while (itspl != itspl_end) {
     // Get the splitting interval times and destination
-    int64_t start = itspl->start().totalNanoseconds();
-    int64_t stop = itspl->stop().totalNanoseconds();
+    int64_t start = itspl->begin().totalNanoseconds();
+    int64_t stop = itspl->end().totalNanoseconds();
     const int index = itspl->index();
 
     // a) Skip the events before the start of the time
@@ -4378,8 +4378,8 @@ void EventList::splitByPulseTimeHelper(Kernel::SplittingIntervalVec &splitter, s
   // Iterate (loop) on all splitters
   while (itspl != itspl_end) {
     // Get the splitting interval times and destination group
-    start = itspl->start().totalNanoseconds();
-    stop = itspl->stop().totalNanoseconds();
+    start = itspl->begin().totalNanoseconds();
+    stop = itspl->end().totalNanoseconds();
     const int index = itspl->index();
 
     // Skip the events before the start of the time and put to 'unfiltered'

--- a/Framework/DataObjects/src/SplittersWorkspace.cpp
+++ b/Framework/DataObjects/src/SplittersWorkspace.cpp
@@ -31,8 +31,8 @@ SplittersWorkspace::SplittersWorkspace() {
  */
 void SplittersWorkspace::addSplitter(const Mantid::Kernel::SplittingInterval &splitter) {
   Mantid::API::TableRow row = this->appendRow();
-  row << splitter.start().totalNanoseconds();
-  row << splitter.stop().totalNanoseconds();
+  row << splitter.begin().totalNanoseconds();
+  row << splitter.end().totalNanoseconds();
   row << splitter.index();
 }
 

--- a/Framework/DataObjects/test/SplittersWorkspaceTest.h
+++ b/Framework/DataObjects/test/SplittersWorkspaceTest.h
@@ -75,8 +75,8 @@ public:
 
     for (size_t i = 0; i < 3; i++) {
       Kernel::SplittingInterval splitter = splitterws.getSplitter(i);
-      TS_ASSERT_EQUALS(splitter.start(), splitters[i].start());
-      TS_ASSERT_EQUALS(splitter.stop(), splitters[i].stop());
+      TS_ASSERT_EQUALS(splitter.begin(), splitters[i].begin());
+      TS_ASSERT_EQUALS(splitter.end(), splitters[i].end());
       TS_ASSERT_EQUALS(splitter.index(), splitters[i].index());
     }
   }

--- a/Framework/Kernel/CMakeLists.txt
+++ b/Framework/Kernel/CMakeLists.txt
@@ -429,6 +429,7 @@ set(TEST_FILES
     ThreadPoolTest.h
     ThreadSchedulerMutexesTest.h
     ThreadSchedulerTest.h
+    TimeIntervalTest.h
     TimeROITest.h
     TimeSeriesPropertyTest.h
     TimerTest.h

--- a/Framework/Kernel/inc/MantidKernel/DateAndTime.h
+++ b/Framework/Kernel/inc/MantidKernel/DateAndTime.h
@@ -28,6 +28,8 @@ public:
   TimeInterval() : m_begin(), m_end() {}
   /// Constructor
   TimeInterval(const Types::Core::DateAndTime &from, const Types::Core::DateAndTime &to);
+  TimeInterval(const std::string &from, const std::string &to);
+
   /// Beginning of the interval
   Types::Core::DateAndTime begin() const { return m_begin; }
   /// End of the interval
@@ -50,6 +52,7 @@ public:
   /// Returns true if this interval ends before \a ti starts
   bool operator<(const TimeInterval &ti) const;
   bool operator>(const TimeInterval &ti) const;
+  bool operator==(const TimeInterval &ti) const;
   /// String representation of the begin time
   std::string begin_str() const;
   /// String representation of the end time

--- a/Framework/Kernel/inc/MantidKernel/DateAndTime.h
+++ b/Framework/Kernel/inc/MantidKernel/DateAndTime.h
@@ -52,7 +52,7 @@ public:
   /** Stream output operator  */
   friend MANTID_KERNEL_DLL std::ostream &operator<<(std::ostream &s, const Mantid::Kernel::TimeInterval &t);
 
-private:
+protected:
   /// begin
   Types::Core::DateAndTime m_begin;
   /// end

--- a/Framework/Kernel/inc/MantidKernel/DateAndTime.h
+++ b/Framework/Kernel/inc/MantidKernel/DateAndTime.h
@@ -46,7 +46,8 @@ public:
   /// Returns an intersection of two intervals
   TimeInterval intersection(const TimeInterval &ti) const;
   /// Returns true if this interval ends before \a ti starts
-  bool operator<(const TimeInterval &ti) const { return end() < ti.begin(); }
+  bool operator<(const TimeInterval &ti) const;
+  bool operator>(const TimeInterval &ti) const;
   /// String representation of the begin time
   std::string begin_str() const;
   /// String representation of the end time
@@ -55,7 +56,7 @@ public:
   /** Stream output operator  */
   friend MANTID_KERNEL_DLL std::ostream &operator<<(std::ostream &s, const Mantid::Kernel::TimeInterval &t);
 
-protected:
+private:
   /// begin
   Types::Core::DateAndTime m_begin;
   /// end

--- a/Framework/Kernel/inc/MantidKernel/DateAndTime.h
+++ b/Framework/Kernel/inc/MantidKernel/DateAndTime.h
@@ -42,6 +42,8 @@ public:
   bool contains(const Types::Core::DateAndTime &t) const { return t >= begin() && t < end(); }
   /// Return true if the b SplittingInterval overlaps with this one.
   bool overlaps(const TimeInterval *t) const;
+  /// Return true if the b SplittingInterval overlaps with this one.
+  bool overlaps(const TimeInterval &t) const;
 
   /// Returns an intersection of two intervals
   TimeInterval intersection(const TimeInterval &ti) const;

--- a/Framework/Kernel/inc/MantidKernel/DateAndTime.h
+++ b/Framework/Kernel/inc/MantidKernel/DateAndTime.h
@@ -40,6 +40,9 @@ public:
 
   /// True if the interval contains \a t.
   bool contains(const Types::Core::DateAndTime &t) const { return t >= begin() && t < end(); }
+  /// Return true if the b SplittingInterval overlaps with this one.
+  bool overlaps(const TimeInterval *t) const;
+
   /// Returns an intersection of two intervals
   TimeInterval intersection(const TimeInterval &ti) const;
   /// Returns true if this interval ends before \a ti starts

--- a/Framework/Kernel/inc/MantidKernel/DateAndTime.h
+++ b/Framework/Kernel/inc/MantidKernel/DateAndTime.h
@@ -40,10 +40,10 @@ public:
 
   /// True if the interval contains \a t.
   bool contains(const Types::Core::DateAndTime &t) const { return t >= begin() && t < end(); }
-  /// Return true if the b SplittingInterval overlaps with this one.
-  bool overlaps(const TimeInterval *t) const;
-  /// Return true if the b SplittingInterval overlaps with this one.
-  bool overlaps(const TimeInterval &t) const;
+  /// Return true if the SplittingInterval overlaps with this one.
+  bool overlaps(const TimeInterval *other) const;
+  /// Return true if the SplittingInterval overlaps with this one.
+  bool overlaps(const TimeInterval &other) const;
 
   /// Returns an intersection of two intervals
   TimeInterval intersection(const TimeInterval &ti) const;

--- a/Framework/Kernel/inc/MantidKernel/SplittingInterval.h
+++ b/Framework/Kernel/inc/MantidKernel/SplittingInterval.h
@@ -36,6 +36,8 @@ public:
   /// @endcond
   SplittingInterval operator|(const SplittingInterval &b) const;
 
+  bool operator==(const SplittingInterval &ti) const;
+
 private:
   /// Index of the destination
   int m_index;

--- a/Framework/Kernel/inc/MantidKernel/SplittingInterval.h
+++ b/Framework/Kernel/inc/MantidKernel/SplittingInterval.h
@@ -31,7 +31,6 @@ public:
 
   int index() const;
 
-  bool overlaps(const SplittingInterval &b) const;
   /// @cond
   SplittingInterval operator&(const SplittingInterval &b) const;
   /// @endcond

--- a/Framework/Kernel/inc/MantidKernel/SplittingInterval.h
+++ b/Framework/Kernel/inc/MantidKernel/SplittingInterval.h
@@ -20,7 +20,7 @@ namespace Kernel {
  *
  * Author: Janik Zikovsky, SNS
  */
-class MANTID_KERNEL_DLL SplittingInterval {
+class MANTID_KERNEL_DLL SplittingInterval : public TimeInterval {
 public:
   /// Default constructor
   SplittingInterval();
@@ -44,10 +44,6 @@ public:
   bool operator>(const SplittingInterval &b) const;
 
 private:
-  /// begin
-  Types::Core::DateAndTime m_start;
-  /// end
-  Types::Core::DateAndTime m_stop;
   /// Index of the destination
   int m_index;
 };

--- a/Framework/Kernel/inc/MantidKernel/SplittingInterval.h
+++ b/Framework/Kernel/inc/MantidKernel/SplittingInterval.h
@@ -27,9 +27,6 @@ public:
 
   SplittingInterval(const Types::Core::DateAndTime &start, const Types::Core::DateAndTime &stop, const int index = 0);
 
-  Types::Core::DateAndTime start() const;
-  Types::Core::DateAndTime stop() const;
-
   double duration() const;
 
   int index() const;

--- a/Framework/Kernel/inc/MantidKernel/SplittingInterval.h
+++ b/Framework/Kernel/inc/MantidKernel/SplittingInterval.h
@@ -40,9 +40,6 @@ public:
   /// @endcond
   SplittingInterval operator|(const SplittingInterval &b) const;
 
-  bool operator<(const SplittingInterval &b) const;
-  bool operator>(const SplittingInterval &b) const;
-
 private:
   /// Index of the destination
   int m_index;

--- a/Framework/Kernel/src/DateAndTime.cpp
+++ b/Framework/Kernel/src/DateAndTime.cpp
@@ -28,6 +28,17 @@ TimeInterval::TimeInterval(const Types::Core::DateAndTime &from, const Types::Co
     m_end = from;
 }
 
+TimeInterval::TimeInterval(const std::string &from, const std::string &to) {
+  const DateAndTime fromObj(from);
+  const DateAndTime toObj(to);
+
+  m_begin = fromObj;
+  if (toObj > fromObj)
+    m_end = toObj;
+  else
+    m_end = fromObj;
+}
+
 bool TimeInterval::overlaps(const TimeInterval *other) const {
   const auto thisBegin = this->begin();
   const auto thisEnd = this->end();
@@ -64,13 +75,15 @@ bool TimeInterval::operator<(const TimeInterval &ti) const {
     return false;
 }
 bool TimeInterval::operator>(const TimeInterval &ti) const {
-  if (begin() < ti.end())
+  if (begin() > ti.end())
     return true;
   else if (begin() == ti.end())
     return begin() > ti.begin();
   else
     return false;
 }
+
+bool TimeInterval::operator==(const TimeInterval &ti) const { return (begin() == ti.begin()) && (end() == ti.end()); }
 
 /// String representation of the begin time
 std::string TimeInterval::begin_str() const { return boost::posix_time::to_simple_string(this->m_begin.to_ptime()); }

--- a/Framework/Kernel/src/DateAndTime.cpp
+++ b/Framework/Kernel/src/DateAndTime.cpp
@@ -28,22 +28,24 @@ TimeInterval::TimeInterval(const Types::Core::DateAndTime &from, const Types::Co
     m_end = from;
 }
 
+bool TimeInterval::overlaps(const TimeInterval *t) const {
+  return ((t->begin() < this->end()) && (t->begin() >= this->begin())) ||
+         ((t->end() < this->end()) && (t->end() >= this->begin())) ||
+         ((this->begin() < t->end()) && (this->begin() >= t->begin())) ||
+         ((this->end() < t->end()) && (this->end() >= t->begin()));
+}
+
 /**  Returns an intersection of this interval with \a ti
      @param ti :: Time interval
      @return A valid time interval if this interval intersects with \a ti or
              an empty interval otherwise.
  */
 TimeInterval TimeInterval::intersection(const TimeInterval &ti) const {
-  if (!isValid() || !ti.isValid())
+  if (!isValid() || !ti.isValid() || !this->overlaps(&ti))
     return TimeInterval();
 
-  DateAndTime t1 = begin();
-  if (ti.begin() > t1)
-    t1 = ti.begin();
-
-  DateAndTime t2 = end();
-  if (ti.end() < t2)
-    t2 = ti.end();
+  const auto t1 = std::max(begin(), ti.begin());
+  const auto t2 = std::min(end(), ti.end());
 
   return t1 < t2 ? TimeInterval(t1, t2) : TimeInterval();
 }

--- a/Framework/Kernel/src/DateAndTime.cpp
+++ b/Framework/Kernel/src/DateAndTime.cpp
@@ -28,14 +28,17 @@ TimeInterval::TimeInterval(const Types::Core::DateAndTime &from, const Types::Co
     m_end = from;
 }
 
-bool TimeInterval::overlaps(const TimeInterval *t) const {
-  return ((t->begin() < this->end()) && (t->begin() >= this->begin())) ||
-         ((t->end() < this->end()) && (t->end() >= this->begin())) ||
-         ((this->begin() < t->end()) && (this->begin() >= t->begin())) ||
-         ((this->end() < t->end()) && (this->end() >= t->begin()));
+bool TimeInterval::overlaps(const TimeInterval *other) const {
+  const auto thisBegin = this->begin();
+  const auto thisEnd = this->end();
+  const auto otherBegin = other->begin();
+  const auto otherEnd = other->end();
+
+  return ((otherBegin < thisEnd) && (otherBegin >= thisBegin)) || ((otherEnd < thisEnd) && (otherEnd >= thisBegin)) ||
+         ((thisBegin < otherEnd) && (thisBegin >= otherBegin)) || ((thisEnd < otherEnd) && (thisEnd >= otherBegin));
 }
 
-bool TimeInterval::overlaps(const TimeInterval &t) const { return this->overlaps(&t); }
+bool TimeInterval::overlaps(const TimeInterval &other) const { return this->overlaps(&other); }
 
 /**  Returns an intersection of this interval with \a ti
      @param ti :: Time interval

--- a/Framework/Kernel/src/DateAndTime.cpp
+++ b/Framework/Kernel/src/DateAndTime.cpp
@@ -35,6 +35,8 @@ bool TimeInterval::overlaps(const TimeInterval *t) const {
          ((this->end() < t->end()) && (this->end() >= t->begin()));
 }
 
+bool TimeInterval::overlaps(const TimeInterval &t) const { return this->overlaps(&t); }
+
 /**  Returns an intersection of this interval with \a ti
      @param ti :: Time interval
      @return A valid time interval if this interval intersects with \a ti or

--- a/Framework/Kernel/src/DateAndTime.cpp
+++ b/Framework/Kernel/src/DateAndTime.cpp
@@ -50,6 +50,23 @@ TimeInterval TimeInterval::intersection(const TimeInterval &ti) const {
   return t1 < t2 ? TimeInterval(t1, t2) : TimeInterval();
 }
 
+bool TimeInterval::operator<(const TimeInterval &ti) const {
+  if (end() < ti.begin())
+    return true;
+  else if (end() == ti.begin())
+    return begin() < ti.begin();
+  else
+    return false;
+}
+bool TimeInterval::operator>(const TimeInterval &ti) const {
+  if (begin() < ti.end())
+    return true;
+  else if (begin() == ti.end())
+    return begin() > ti.begin();
+  else
+    return false;
+}
+
 /// String representation of the begin time
 std::string TimeInterval::begin_str() const { return boost::posix_time::to_simple_string(this->m_begin.to_ptime()); }
 

--- a/Framework/Kernel/src/SplittingInterval.cpp
+++ b/Framework/Kernel/src/SplittingInterval.cpp
@@ -32,12 +32,7 @@ double SplittingInterval::duration() const { return DateAndTime::secondsFromDura
 int SplittingInterval::index() const { return m_index; }
 
 /// Return true if the b SplittingInterval overlaps with this one.
-bool SplittingInterval::overlaps(const SplittingInterval &b) const {
-  return ((b.begin() < this->end()) && (b.begin() >= this->begin())) ||
-         ((b.end() < this->end()) && (b.end() >= this->begin())) ||
-         ((this->begin() < b.end()) && (this->begin() >= b.begin())) ||
-         ((this->end() < b.end()) && (this->end() >= b.begin()));
-}
+bool SplittingInterval::overlaps(const SplittingInterval &b) const { return TimeInterval::overlaps(&b); }
 
 /// @cond DOXYGEN_BUG
 /// And operator. Return the smallest time interval where both intervals are

--- a/Framework/Kernel/src/SplittingInterval.cpp
+++ b/Framework/Kernel/src/SplittingInterval.cpp
@@ -49,6 +49,14 @@ SplittingInterval SplittingInterval::operator|(const SplittingInterval &b) const
   return SplittingInterval(begin, end, this->index());
 }
 
+bool SplittingInterval::operator==(const SplittingInterval &ti) const {
+  if (TimeInterval::operator==(ti)) {
+    return index() == ti.index();
+  } else {
+    return false;
+  }
+}
+
 //------------------------------------------------------------------------------------------------
 /** Return true if the SplittingIntervalVec provided is a filter,
  * meaning that it only has an output index of 0.

--- a/Framework/Kernel/src/SplittingInterval.cpp
+++ b/Framework/Kernel/src/SplittingInterval.cpp
@@ -25,9 +25,6 @@ double SplittingInterval::duration() const { return DateAndTime::secondsFromDura
 /// Return the index (destination of this split time block)
 int SplittingInterval::index() const { return m_index; }
 
-/// Return true if the b SplittingInterval overlaps with this one.
-bool SplittingInterval::overlaps(const SplittingInterval &b) const { return TimeInterval::overlaps(&b); }
-
 /// @cond DOXYGEN_BUG
 /// And operator. Return the smallest time interval where both intervals are
 /// TRUE.
@@ -41,7 +38,7 @@ SplittingInterval SplittingInterval::operator&(const SplittingInterval &b) const
 
 /// Or operator. Return the largest time interval.
 SplittingInterval SplittingInterval::operator|(const SplittingInterval &b) const {
-  if (!this->overlaps(b))
+  if (!this->overlaps(&b))
     throw std::invalid_argument("SplittingInterval: cannot apply the OR (|) "
                                 "operator to non-overlapping "
                                 "SplittingInterval's.");
@@ -121,7 +118,7 @@ SplittingIntervalVec operator&(const SplittingIntervalVec &a, const SplittingInt
   // sorted.
   for (ait = a.begin(); ait != a.end(); ++ait) {
     for (bit = b.begin(); bit != b.end(); ++bit) {
-      if (ait->overlaps(*bit)) {
+      if (ait->overlaps(&(*bit))) {
         // The & operator for SplittingInterval keeps the index of the
         // left-hand-side (ait in this case)
         //  meaning that a has to be the splitter because the b index is

--- a/Framework/Kernel/src/SplittingInterval.cpp
+++ b/Framework/Kernel/src/SplittingInterval.cpp
@@ -58,17 +58,6 @@ SplittingInterval SplittingInterval::operator|(const SplittingInterval &b) const
   return SplittingInterval(begin, end, this->index());
 }
 
-/// Compare two splitter by the begin time
-bool SplittingInterval::operator<(const SplittingInterval &b) const { return (this->begin() < b.begin()); }
-
-/// Compare two splitter by the begin time
-bool SplittingInterval::operator>(const SplittingInterval &b) const { return (this->begin() > b.begin()); }
-
-/** Comparator for sorting lists of SplittingInterval */
-bool compareSplittingInterval(const SplittingInterval &si1, const SplittingInterval &si2) {
-  return (si1.begin() < si2.begin());
-}
-
 //------------------------------------------------------------------------------------------------
 /** Return true if the SplittingIntervalVec provided is a filter,
  * meaning that it only has an output index of 0.
@@ -196,20 +185,16 @@ SplittingIntervalVec operator|(const SplittingIntervalVec &a, const SplittingInt
 
   // Concatenate the two lists
   SplittingIntervalVec temp;
-  // temp.insert(temp.end(), b.begin(), b.end());
+  for (auto &it : a)
+    if (it.isValid())
+      temp.emplace_back(it);
+  for (auto &it : b)
+    if (it.isValid())
+      temp.emplace_back(it);
 
-  // Add the intervals, but don't add any invalid (empty) ranges
-  SplittingIntervalVec::const_iterator it;
-  ;
-  for (it = a.begin(); it != a.end(); ++it)
-    if (it->end() > it->begin())
-      temp.emplace_back(*it);
-  for (it = b.begin(); it != b.end(); ++it)
-    if (it->end() > it->begin())
-      temp.emplace_back(*it);
-
-  // Sort by start time
-  std::sort(temp.begin(), temp.end(), compareSplittingInterval);
+  // Sort by start time rather than the default
+  std::sort(temp.begin(), temp.end(),
+            [](const SplittingInterval &left, const SplittingInterval &right) { return left.begin() < right.begin(); });
 
   out = removeFilterOverlap(temp);
 

--- a/Framework/Kernel/src/SplittingInterval.cpp
+++ b/Framework/Kernel/src/SplittingInterval.cpp
@@ -19,14 +19,8 @@ SplittingInterval::SplittingInterval(const Types::Core::DateAndTime &start, cons
                                      const int index)
     : TimeInterval(start, stop), m_index(index) {}
 
-/// Return the start time
-DateAndTime SplittingInterval::start() const { return this->begin(); }
-
-/// Return the stop time
-DateAndTime SplittingInterval::stop() const { return this->end(); }
-
 /// Returns the duration in seconds
-double SplittingInterval::duration() const { return DateAndTime::secondsFromDuration(end() - begin()); }
+double SplittingInterval::duration() const { return DateAndTime::secondsFromDuration(this->length()); }
 
 /// Return the index (destination of this split time block)
 int SplittingInterval::index() const { return m_index; }

--- a/Framework/Kernel/src/SplittingInterval.cpp
+++ b/Framework/Kernel/src/SplittingInterval.cpp
@@ -172,18 +172,11 @@ SplittingIntervalVec removeFilterOverlap(const SplittingIntervalVec &a) {
  * @return the ORed filter
  */
 SplittingIntervalVec operator|(const SplittingIntervalVec &a, const SplittingIntervalVec &b) {
-  SplittingIntervalVec out;
-
-  auto isValid = [](const SplittingInterval &value) { return value.isValid(); };
-
   // Concatenate the two lists
   SplittingIntervalVec temp;
-  for (auto &it : a)
-    if (it.isValid())
-      temp.emplace_back(it);
-  for (auto &it : b)
-    if (it.isValid())
-      temp.emplace_back(it);
+  auto isValid = [](const SplittingInterval &value) { return value.isValid(); };
+  std::copy_if(a.begin(), a.end(), std::back_insert_iterator(temp), isValid);
+  std::copy_if(b.begin(), b.end(), std::back_insert_iterator(temp), isValid);
 
   // Sort by start time rather than the default
   auto compareStart = [](const SplittingInterval &left, const SplittingInterval &right) {
@@ -195,7 +188,7 @@ SplittingIntervalVec operator|(const SplittingIntervalVec &a, const SplittingInt
   };
   std::sort(temp.begin(), temp.end(), compareStart);
 
-  out = removeFilterOverlap(temp);
+  SplittingIntervalVec out = removeFilterOverlap(temp);
 
   return out;
 }

--- a/Framework/Kernel/src/SplittingInterval.cpp
+++ b/Framework/Kernel/src/SplittingInterval.cpp
@@ -174,6 +174,8 @@ SplittingIntervalVec removeFilterOverlap(const SplittingIntervalVec &a) {
 SplittingIntervalVec operator|(const SplittingIntervalVec &a, const SplittingIntervalVec &b) {
   SplittingIntervalVec out;
 
+  auto isValid = [](const SplittingInterval &value) { return value.isValid(); };
+
   // Concatenate the two lists
   SplittingIntervalVec temp;
   for (auto &it : a)
@@ -184,8 +186,14 @@ SplittingIntervalVec operator|(const SplittingIntervalVec &a, const SplittingInt
       temp.emplace_back(it);
 
   // Sort by start time rather than the default
-  std::sort(temp.begin(), temp.end(),
-            [](const SplittingInterval &left, const SplittingInterval &right) { return left.begin() < right.begin(); });
+  auto compareStart = [](const SplittingInterval &left, const SplittingInterval &right) {
+    // because of the field names, cppcheck thinks the wrong thing is being compared
+    // let the compiler optimize the memory layout
+    const auto leftStart = left.begin();
+    const auto rightStart = right.begin();
+    return leftStart < rightStart;
+  };
+  std::sort(temp.begin(), temp.end(), compareStart);
 
   out = removeFilterOverlap(temp);
 

--- a/Framework/Kernel/src/TimeROI.cpp
+++ b/Framework/Kernel/src/TimeROI.cpp
@@ -310,7 +310,7 @@ void TimeROI::update_union(const TimeROI &other) {
 
   // add all the intervals from the other
   for (const auto interval : other.toSplitters()) {
-    this->addROI(interval.start(), interval.stop());
+    this->addROI(interval.begin(), interval.end());
   }
 }
 
@@ -446,8 +446,8 @@ void TimeROI::saveNexus(::NeXus::File *file) const {
   // create a local TimeSeriesProperty which will do the actual work
   TimeSeriesProperty<bool> tsp(NAME);
   for (const auto interval : this->toSplitters()) {
-    tsp.addValue(interval.start(), ROI_USE);
-    tsp.addValue(interval.stop(), ROI_IGNORE);
+    tsp.addValue(interval.begin(), ROI_USE);
+    tsp.addValue(interval.end(), ROI_IGNORE);
   }
 
   // save things to to disk

--- a/Framework/Kernel/src/TimeSeriesProperty.cpp
+++ b/Framework/Kernel/src/TimeSeriesProperty.cpp
@@ -332,8 +332,8 @@ void TimeSeriesProperty<TYPE>::filterByTimes(const std::vector<SplittingInterval
 
   // 4. Create new
   for (const auto &splitter : splittervec) {
-    Types::Core::DateAndTime t_start = splitter.start();
-    Types::Core::DateAndTime t_stop = splitter.stop();
+    Types::Core::DateAndTime t_start = splitter.begin();
+    Types::Core::DateAndTime t_stop = splitter.end();
 
     int tstartindex = findIndex(t_start);
     if (tstartindex < 0) {
@@ -442,8 +442,8 @@ void TimeSeriesProperty<TYPE>::splitByTime(std::vector<SplittingInterval> &split
                 << ", Number of splitters = " << splitter.size() << "\n";
   while (itspl != splitter.end() && i_property < m_values.size()) {
     // Get the splitting interval times and destination
-    DateAndTime start = itspl->start();
-    DateAndTime stop = itspl->stop();
+    DateAndTime start = itspl->begin();
+    DateAndTime stop = itspl->end();
 
     int output_index = itspl->index();
     // output workspace index is out of range. go to the next splitter
@@ -849,10 +849,10 @@ double TimeSeriesProperty<TYPE>::averageValueInFilter(const std::vector<Splittin
 
     // Get the log value and index at the start time of the filter
     int index;
-    double value = static_cast<double>(getSingleValue(time.start(), index));
-    DateAndTime startTime = time.start();
+    double value = static_cast<double>(getSingleValue(time.begin(), index));
+    DateAndTime startTime = time.begin();
 
-    while (index < realSize() - 1 && m_values[index + 1].time() < time.stop()) {
+    while (index < realSize() - 1 && m_values[index + 1].time() < time.end()) {
       ++index;
       numerator += DateAndTime::secondsFromDuration(m_values[index].time() - startTime) * value;
       startTime = m_values[index].time();
@@ -860,7 +860,7 @@ double TimeSeriesProperty<TYPE>::averageValueInFilter(const std::vector<Splittin
     }
 
     // Now close off with the end of the current filter range
-    numerator += DateAndTime::secondsFromDuration(time.stop() - startTime) * value;
+    numerator += DateAndTime::secondsFromDuration(time.end() - startTime) * value;
   }
 
   // 'Normalise' by the total time
@@ -898,11 +898,11 @@ TimeSeriesProperty<TYPE>::averageAndStdDevInFilter(const std::vector<SplittingIn
 
     // Get the log value and index at the start time of the filter
     int index;
-    double value = static_cast<double>(getSingleValue(time.start(), index));
+    double value = static_cast<double>(getSingleValue(time.begin(), index));
     double valuestddev = (value - mean) * (value - mean);
-    DateAndTime startTime = time.start();
+    DateAndTime startTime = time.begin();
 
-    while (index < realSize() - 1 && m_values[index + 1].time() < time.stop()) {
+    while (index < realSize() - 1 && m_values[index + 1].time() < time.end()) {
       ++index;
 
       numerator += DateAndTime::secondsFromDuration(m_values[index].time() - startTime) * valuestddev;
@@ -912,7 +912,7 @@ TimeSeriesProperty<TYPE>::averageAndStdDevInFilter(const std::vector<SplittingIn
     }
 
     // Now close off with the end of the current filter range
-    numerator += DateAndTime::secondsFromDuration(time.stop() - startTime) * valuestddev;
+    numerator += DateAndTime::secondsFromDuration(time.end() - startTime) * valuestddev;
   }
 
   // Normalise by the total time

--- a/Framework/Kernel/test/SplittingIntervalTest.h
+++ b/Framework/Kernel/test/SplittingIntervalTest.h
@@ -481,7 +481,7 @@ public:
     DateAndTime start, stop;
     SplittingIntervalVec b;
 
-    //  the splitter ------
+    //  the splitter intentionally has overlapping intervals
     start = DateAndTime("2007-11-30T16:15:00");
     stop = DateAndTime("2007-11-30T16:16:00");
     b.emplace_back(SplittingInterval(start, stop, 0));
@@ -498,6 +498,7 @@ public:
     stop = DateAndTime("2007-11-30T16:18:00");
     b.emplace_back(SplittingInterval(start, stop, 1));
 
+    // sort using the operator<
     std::sort(b.begin(), b.end());
 
     TS_ASSERT_EQUALS(b[0].start(), DateAndTime("2007-11-30T16:15:00"));

--- a/Framework/Kernel/test/SplittingIntervalTest.h
+++ b/Framework/Kernel/test/SplittingIntervalTest.h
@@ -41,8 +41,8 @@ public:
     b = SplittingInterval(start_b, stop_b, 0);
     c = a & b;
     TS_ASSERT(a.overlaps(b));
-    TS_ASSERT_EQUALS(c.start(), start_b);
-    TS_ASSERT_EQUALS(c.stop(), stop_b);
+    TS_ASSERT_EQUALS(c.begin(), start_b);
+    TS_ASSERT_EQUALS(c.end(), stop_b);
 
     // a is all inside b
     start_b = DateAndTime("2007-11-30T16:17:05");
@@ -50,8 +50,8 @@ public:
     b = SplittingInterval(start_b, stop_b, 0);
     c = a & b;
     TS_ASSERT(a.overlaps(b));
-    TS_ASSERT_EQUALS(c.start(), start_a);
-    TS_ASSERT_EQUALS(c.stop(), stop_a);
+    TS_ASSERT_EQUALS(c.begin(), start_a);
+    TS_ASSERT_EQUALS(c.end(), stop_a);
 
     // b goes past the end of a
     start_b = DateAndTime("2007-11-30T16:17:12");
@@ -59,8 +59,8 @@ public:
     b = SplittingInterval(start_b, stop_b, 0);
     c = a & b;
     TS_ASSERT(a.overlaps(b));
-    TS_ASSERT_EQUALS(c.start(), start_b);
-    TS_ASSERT_EQUALS(c.stop(), stop_a);
+    TS_ASSERT_EQUALS(c.begin(), start_b);
+    TS_ASSERT_EQUALS(c.end(), stop_a);
 
     // b starts before a and ends before
     start_b = DateAndTime("2007-11-30T16:17:05");
@@ -68,8 +68,8 @@ public:
     b = SplittingInterval(start_b, stop_b, 0);
     c = a & b;
     TS_ASSERT(a.overlaps(b));
-    TS_ASSERT_EQUALS(c.start(), start_a);
-    TS_ASSERT_EQUALS(c.stop(), stop_b);
+    TS_ASSERT_EQUALS(c.begin(), start_a);
+    TS_ASSERT_EQUALS(c.end(), stop_b);
 
     // No overlap (b < a)
     start_b = DateAndTime("2007-11-30T16:17:01");
@@ -106,8 +106,8 @@ public:
     b = SplittingInterval(start_b, stop_b, 0);
     c = a | b;
     TS_ASSERT(a.overlaps(b));
-    TS_ASSERT_EQUALS(c.start(), start_a);
-    TS_ASSERT_EQUALS(c.stop(), stop_a);
+    TS_ASSERT_EQUALS(c.begin(), start_a);
+    TS_ASSERT_EQUALS(c.end(), stop_a);
 
     // a is all inside b
     start_b = DateAndTime("2007-11-30T16:17:05");
@@ -115,8 +115,8 @@ public:
     b = SplittingInterval(start_b, stop_b, 0);
     c = a | b;
     TS_ASSERT(a.overlaps(b));
-    TS_ASSERT_EQUALS(c.start(), start_b);
-    TS_ASSERT_EQUALS(c.stop(), stop_b);
+    TS_ASSERT_EQUALS(c.begin(), start_b);
+    TS_ASSERT_EQUALS(c.end(), stop_b);
 
     // b goes past the end of a
     start_b = DateAndTime("2007-11-30T16:17:12");
@@ -124,8 +124,8 @@ public:
     b = SplittingInterval(start_b, stop_b, 0);
     c = a | b;
     TS_ASSERT(a.overlaps(b));
-    TS_ASSERT_EQUALS(c.start(), start_a);
-    TS_ASSERT_EQUALS(c.stop(), stop_b);
+    TS_ASSERT_EQUALS(c.begin(), start_a);
+    TS_ASSERT_EQUALS(c.end(), stop_b);
 
     // b starts before a and ends before
     start_b = DateAndTime("2007-11-30T16:17:05");
@@ -133,8 +133,8 @@ public:
     b = SplittingInterval(start_b, stop_b, 0);
     c = a | b;
     TS_ASSERT(a.overlaps(b));
-    TS_ASSERT_EQUALS(c.start(), start_b);
-    TS_ASSERT_EQUALS(c.stop(), stop_a);
+    TS_ASSERT_EQUALS(c.begin(), start_b);
+    TS_ASSERT_EQUALS(c.end(), stop_a);
 
     // No overlap (b < a) - This throws an exception because you need two
     // outputs!
@@ -200,20 +200,20 @@ public:
 
     SplittingInterval i;
     i = c[0];
-    TS_ASSERT_EQUALS(i.start(), DateAndTime("2007-11-30T16:17:01"));
-    TS_ASSERT_EQUALS(i.stop(), DateAndTime("2007-11-30T16:17:10"));
+    TS_ASSERT_EQUALS(i.begin(), DateAndTime("2007-11-30T16:17:01"));
+    TS_ASSERT_EQUALS(i.end(), DateAndTime("2007-11-30T16:17:10"));
     i = c[1];
-    TS_ASSERT_EQUALS(i.start(), DateAndTime("2007-11-30T16:17:20"));
-    TS_ASSERT_EQUALS(i.stop(), DateAndTime("2007-11-30T16:17:25"));
+    TS_ASSERT_EQUALS(i.begin(), DateAndTime("2007-11-30T16:17:20"));
+    TS_ASSERT_EQUALS(i.end(), DateAndTime("2007-11-30T16:17:25"));
     i = c[2];
-    TS_ASSERT_EQUALS(i.start(), DateAndTime("2007-11-30T16:17:26"));
-    TS_ASSERT_EQUALS(i.stop(), DateAndTime("2007-11-30T16:17:27"));
+    TS_ASSERT_EQUALS(i.begin(), DateAndTime("2007-11-30T16:17:26"));
+    TS_ASSERT_EQUALS(i.end(), DateAndTime("2007-11-30T16:17:27"));
     i = c[3];
-    TS_ASSERT_EQUALS(i.start(), DateAndTime("2007-11-30T16:17:45"));
-    TS_ASSERT_EQUALS(i.stop(), DateAndTime("2007-11-30T16:17:50"));
+    TS_ASSERT_EQUALS(i.begin(), DateAndTime("2007-11-30T16:17:45"));
+    TS_ASSERT_EQUALS(i.end(), DateAndTime("2007-11-30T16:17:50"));
     i = c[4];
-    TS_ASSERT_EQUALS(i.start(), DateAndTime("2007-11-30T16:18:00"));
-    TS_ASSERT_EQUALS(i.stop(), DateAndTime("2007-11-30T16:18:10"));
+    TS_ASSERT_EQUALS(i.begin(), DateAndTime("2007-11-30T16:18:00"));
+    TS_ASSERT_EQUALS(i.end(), DateAndTime("2007-11-30T16:18:10"));
   }
 
   //----------------------------------------------------------------------------
@@ -268,17 +268,17 @@ public:
 
     SplittingInterval i;
     i = c[0];
-    TS_ASSERT_EQUALS(i.start(), DateAndTime("2007-11-30T16:17:00"));
-    TS_ASSERT_EQUALS(i.stop(), DateAndTime("2007-11-30T16:17:30"));
+    TS_ASSERT_EQUALS(i.begin(), DateAndTime("2007-11-30T16:17:00"));
+    TS_ASSERT_EQUALS(i.end(), DateAndTime("2007-11-30T16:17:30"));
     i = c[1];
-    TS_ASSERT_EQUALS(i.start(), DateAndTime("2007-11-30T16:17:40"));
-    TS_ASSERT_EQUALS(i.stop(), DateAndTime("2007-11-30T16:18:15"));
+    TS_ASSERT_EQUALS(i.begin(), DateAndTime("2007-11-30T16:17:40"));
+    TS_ASSERT_EQUALS(i.end(), DateAndTime("2007-11-30T16:18:15"));
     i = c[2];
-    TS_ASSERT_EQUALS(i.start(), DateAndTime("2007-11-30T16:18:20"));
-    TS_ASSERT_EQUALS(i.stop(), DateAndTime("2007-11-30T16:18:30"));
+    TS_ASSERT_EQUALS(i.begin(), DateAndTime("2007-11-30T16:18:20"));
+    TS_ASSERT_EQUALS(i.end(), DateAndTime("2007-11-30T16:18:30"));
     i = c[3];
-    TS_ASSERT_EQUALS(i.start(), DateAndTime("2007-11-30T16:18:50"));
-    TS_ASSERT_EQUALS(i.stop(), DateAndTime("2007-11-30T16:18:55"));
+    TS_ASSERT_EQUALS(i.begin(), DateAndTime("2007-11-30T16:18:50"));
+    TS_ASSERT_EQUALS(i.end(), DateAndTime("2007-11-30T16:18:55"));
   }
 
   //----------------------------------------------------------------------------
@@ -316,8 +316,8 @@ public:
 
     SplittingInterval i;
     i = c[0];
-    TS_ASSERT_EQUALS(i.start(), DateAndTime("2007-11-30T16:17:20"));
-    TS_ASSERT_EQUALS(i.stop(), DateAndTime("2007-11-30T16:17:30"));
+    TS_ASSERT_EQUALS(i.begin(), DateAndTime("2007-11-30T16:17:20"));
+    TS_ASSERT_EQUALS(i.end(), DateAndTime("2007-11-30T16:17:30"));
   }
 
   //----------------------------------------------------------------------------
@@ -343,14 +343,14 @@ public:
       return; // avoid segfaults if this part of the test fails
 
     i = c[0];
-    TS_ASSERT_EQUALS(i.start(), DateAndTime::minimum());
-    TS_ASSERT_EQUALS(i.stop(), DateAndTime("2007-11-30T16:17:00"));
+    TS_ASSERT_EQUALS(i.begin(), DateAndTime::minimum());
+    TS_ASSERT_EQUALS(i.end(), DateAndTime("2007-11-30T16:17:00"));
     i = c[1];
-    TS_ASSERT_EQUALS(i.start(), DateAndTime("2007-11-30T16:17:10"));
-    TS_ASSERT_EQUALS(i.stop(), DateAndTime("2007-11-30T16:17:20"));
+    TS_ASSERT_EQUALS(i.begin(), DateAndTime("2007-11-30T16:17:10"));
+    TS_ASSERT_EQUALS(i.end(), DateAndTime("2007-11-30T16:17:20"));
     i = c[2];
-    TS_ASSERT_EQUALS(i.start(), DateAndTime("2007-11-30T16:17:30"));
-    TS_ASSERT_EQUALS(i.stop(), DateAndTime::maximum());
+    TS_ASSERT_EQUALS(i.begin(), DateAndTime("2007-11-30T16:17:30"));
+    TS_ASSERT_EQUALS(i.end(), DateAndTime::maximum());
   }
 
   //----------------------------------------------------------------------------
@@ -365,8 +365,8 @@ public:
     if (c.size() < 1)
       return; // avoid segfaults if this part of the test fails
     i = c[0];
-    TS_ASSERT_EQUALS(i.start(), DateAndTime::minimum());
-    TS_ASSERT_EQUALS(i.stop(), DateAndTime::maximum());
+    TS_ASSERT_EQUALS(i.begin(), DateAndTime::minimum());
+    TS_ASSERT_EQUALS(i.end(), DateAndTime::maximum());
   }
 
   //----------------------------------------------------------------------------
@@ -389,11 +389,11 @@ public:
       return; // avoid segfaults if this part of the test fails
 
     i = c[0];
-    TS_ASSERT_EQUALS(i.start(), DateAndTime::minimum());
-    TS_ASSERT_EQUALS(i.stop(), DateAndTime("2007-11-30T16:17:00"));
+    TS_ASSERT_EQUALS(i.begin(), DateAndTime::minimum());
+    TS_ASSERT_EQUALS(i.end(), DateAndTime("2007-11-30T16:17:00"));
     i = c[1];
-    TS_ASSERT_EQUALS(i.start(), DateAndTime("2007-11-30T16:17:30"));
-    TS_ASSERT_EQUALS(i.stop(), DateAndTime::maximum());
+    TS_ASSERT_EQUALS(i.begin(), DateAndTime("2007-11-30T16:17:30"));
+    TS_ASSERT_EQUALS(i.end(), DateAndTime::maximum());
   }
 
   //----------------------------------------------------------------------------
@@ -448,28 +448,28 @@ public:
       return; // avoid segfaults if this part of the test fails
 
     i = c[0];
-    TS_ASSERT_EQUALS(i.start(), DateAndTime("2007-11-30T16:17:00"));
-    TS_ASSERT_EQUALS(i.stop(), DateAndTime("2007-11-30T16:17:10"));
+    TS_ASSERT_EQUALS(i.begin(), DateAndTime("2007-11-30T16:17:00"));
+    TS_ASSERT_EQUALS(i.end(), DateAndTime("2007-11-30T16:17:10"));
     TS_ASSERT_EQUALS(i.index(), 1);
 
     i = c[1];
-    TS_ASSERT_EQUALS(i.start(), DateAndTime("2007-11-30T16:17:20"));
-    TS_ASSERT_EQUALS(i.stop(), DateAndTime("2007-11-30T16:17:30"));
+    TS_ASSERT_EQUALS(i.begin(), DateAndTime("2007-11-30T16:17:20"));
+    TS_ASSERT_EQUALS(i.end(), DateAndTime("2007-11-30T16:17:30"));
     TS_ASSERT_EQUALS(i.index(), 1);
 
     i = c[2];
-    TS_ASSERT_EQUALS(i.start(), DateAndTime("2007-11-30T16:17:40"));
-    TS_ASSERT_EQUALS(i.stop(), DateAndTime("2007-11-30T16:18:00"));
+    TS_ASSERT_EQUALS(i.begin(), DateAndTime("2007-11-30T16:17:40"));
+    TS_ASSERT_EQUALS(i.end(), DateAndTime("2007-11-30T16:18:00"));
     TS_ASSERT_EQUALS(i.index(), 1);
 
     i = c[3];
-    TS_ASSERT_EQUALS(i.start(), DateAndTime("2007-11-30T16:18:00"));
-    TS_ASSERT_EQUALS(i.stop(), DateAndTime("2007-11-30T16:18:10"));
+    TS_ASSERT_EQUALS(i.begin(), DateAndTime("2007-11-30T16:18:00"));
+    TS_ASSERT_EQUALS(i.end(), DateAndTime("2007-11-30T16:18:10"));
     TS_ASSERT_EQUALS(i.index(), 2);
 
     i = c[4];
-    TS_ASSERT_EQUALS(i.start(), DateAndTime("2007-11-30T16:18:50"));
-    TS_ASSERT_EQUALS(i.stop(), DateAndTime("2007-11-30T16:18:55"));
+    TS_ASSERT_EQUALS(i.begin(), DateAndTime("2007-11-30T16:18:50"));
+    TS_ASSERT_EQUALS(i.end(), DateAndTime("2007-11-30T16:18:55"));
     TS_ASSERT_EQUALS(i.index(), 2);
 
     // This fails since you can't add splitters together
@@ -501,10 +501,10 @@ public:
     // sort using the operator<
     std::sort(b.begin(), b.end());
 
-    TS_ASSERT_EQUALS(b[0].start(), DateAndTime("2007-11-30T16:15:00"));
-    TS_ASSERT_EQUALS(b[1].start(), DateAndTime("2007-11-30T16:17:00"));
-    TS_ASSERT_EQUALS(b[2].start(), DateAndTime("2007-11-30T16:18:00"));
-    TS_ASSERT_EQUALS(b[3].start(), DateAndTime("2007-11-30T16:19:00"));
+    TS_ASSERT_EQUALS(b[0].begin(), DateAndTime("2007-11-30T16:15:00"));
+    TS_ASSERT_EQUALS(b[1].begin(), DateAndTime("2007-11-30T16:17:00"));
+    TS_ASSERT_EQUALS(b[2].begin(), DateAndTime("2007-11-30T16:18:00"));
+    TS_ASSERT_EQUALS(b[3].begin(), DateAndTime("2007-11-30T16:19:00"));
   }
 
   //----------------------------------------------------------------------------

--- a/Framework/Kernel/test/SplittingIntervalTest.h
+++ b/Framework/Kernel/test/SplittingIntervalTest.h
@@ -541,6 +541,6 @@ public:
     SplittingInterval temp2(DateAndTime("2007-11-30T16:17:10"), DateAndTime("2007-11-30T16:17:00"), -1);
     sit = std::lower_bound(b.begin(), b.end(), temp2);
     int index2 = int(sit - b.begin());
-    TS_ASSERT_EQUALS(index2, 2);
+    TS_ASSERT_EQUALS(index2, 1);
   }
 };

--- a/Framework/Kernel/test/TimeIntervalTest.h
+++ b/Framework/Kernel/test/TimeIntervalTest.h
@@ -1,0 +1,73 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2018 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#pragma once
+
+#include "MantidKernel/DateAndTime.h"
+
+#include <cxxtest/TestSuite.h>
+
+using Mantid::Kernel::TimeInterval;
+using Mantid::Types::Core::DateAndTime;
+
+// some intervals to use
+const TimeInterval ONE("2007-11-30T16:00:00", "2007-11-30T17:00:00");
+const TimeInterval TWO("2007-11-30T16:30:00", "2007-11-30T17:30:00");
+const TimeInterval THREE("2007-11-30T17:00:00", "2007-11-30T18:00:00");
+const TimeInterval FOUR("2007-11-30T19:00:00", "2007-11-30T20:00:00");
+
+class TimeIntervalTest : public CxxTest::TestSuite {
+
+public:
+  void test_constructors() {
+    TimeInterval one(DateAndTime("2007-11-30T16:16:00"), DateAndTime("2007-11-30T16:18:50"));
+    TimeInterval two("2007-11-30T16:16:00", "2007-11-30T16:18:50");
+    TS_ASSERT_EQUALS(one, two);
+  }
+
+  void test_contains() {
+    DateAndTime start("2007-11-30T16:00:00");
+    DateAndTime stop("2007-11-30T17:00:00");
+    TimeInterval interval(start, stop);
+
+    TS_ASSERT(interval.contains(start));
+    TS_ASSERT(interval.contains(DateAndTime("2007-11-30T16:30:00")));
+    TS_ASSERT(!interval.contains(stop));
+  }
+
+  void test_overlaps() {
+    // overlaps with self
+    TS_ASSERT(ONE.overlaps(ONE));
+    // overlaps with middle
+    TS_ASSERT(ONE.overlaps(TWO));
+    // overlaps with edge
+    TS_ASSERT(ONE.overlaps(THREE));
+    // doesn't overlap
+    TS_ASSERT(!ONE.overlaps(FOUR));
+  }
+
+  void test_comparisions() {
+    // self comparisons
+    TS_ASSERT(!(ONE < ONE));
+    TS_ASSERT(!(ONE > ONE));
+    TS_ASSERT(ONE == ONE);
+
+    // compare with distinct intervals
+    TS_ASSERT(ONE < FOUR);
+    TS_ASSERT(FOUR > ONE);
+    TS_ASSERT(!(ONE == FOUR));
+
+    // compare with shared edge
+    TS_ASSERT(ONE < THREE);
+    TS_ASSERT(THREE > ONE);
+    TS_ASSERT(!(ONE == THREE));
+
+    // compare with overlap never returns true
+    TS_ASSERT(!(ONE < TWO));
+    TS_ASSERT(!(TWO > ONE));
+    TS_ASSERT(!(ONE == TWO));
+  }
+};

--- a/Framework/Kernel/test/TimeSeriesPropertyTest.h
+++ b/Framework/Kernel/test/TimeSeriesPropertyTest.h
@@ -516,15 +516,15 @@ public:
 
     s = splitter[0];
     t = DateAndTime("2007-11-30T16:17:09");
-    TS_ASSERT_DELTA(s.start(), t, 1e-3);
+    TS_ASSERT_DELTA(s.begin(), t, 1e-3);
     t = DateAndTime("2007-11-30T16:17:11");
-    TS_ASSERT_DELTA(s.stop(), t, 1e-3);
+    TS_ASSERT_DELTA(s.end(), t, 1e-3);
 
     s = splitter[1];
     t = DateAndTime("2007-11-30T16:17:29");
-    TS_ASSERT_DELTA(s.start(), t, 1e-3);
+    TS_ASSERT_DELTA(s.begin(), t, 1e-3);
     t = DateAndTime("2007-11-30T16:17:41");
-    TS_ASSERT_DELTA(s.stop(), t, 1e-3);
+    TS_ASSERT_DELTA(s.end(), t, 1e-3);
 
     // Now test with left-aligned log value boundaries
     log->makeFilterByValue(splitter, 1.8, 2.2, 1.0);
@@ -533,15 +533,15 @@ public:
 
     s = splitter[0];
     t = DateAndTime("2007-11-30T16:17:10");
-    TS_ASSERT_DELTA(s.start(), t, 1e-3);
+    TS_ASSERT_DELTA(s.begin(), t, 1e-3);
     t = DateAndTime("2007-11-30T16:17:20");
-    TS_ASSERT_DELTA(s.stop(), t, 1e-3);
+    TS_ASSERT_DELTA(s.end(), t, 1e-3);
 
     s = splitter[1];
     t = DateAndTime("2007-11-30T16:17:30");
-    TS_ASSERT_DELTA(s.start(), t, 1e-3);
+    TS_ASSERT_DELTA(s.begin(), t, 1e-3);
     t = DateAndTime("2007-11-30T16:17:50");
-    TS_ASSERT_DELTA(s.stop(), t, 1e-3);
+    TS_ASSERT_DELTA(s.end(), t, 1e-3);
 
     // Check throws if min > max
     TS_ASSERT_THROWS(log->makeFilterByValue(splitter, 2.0, 1.0, 0.0, true), const std::invalid_argument &);
@@ -572,33 +572,33 @@ public:
     log.makeFilterByValue(splitter, 1.0, 2.2, 1.0, false);
     log.expandFilterToRange(splitter, 1.0, 2.2, interval);
     TS_ASSERT_EQUALS(splitter.size(), 2);
-    TS_ASSERT_DELTA(splitter[0].start(), DateAndTime("2007-11-30T16:16:00"), 1e-3);
-    TS_ASSERT_DELTA(splitter[0].stop(), DateAndTime("2007-11-30T16:17:20"), 1e-3);
-    TS_ASSERT_DELTA(splitter[1].start(), DateAndTime("2007-11-30T16:17:50"), 1e-3);
-    TS_ASSERT_DELTA(splitter[1].stop(), DateAndTime("2007-11-30T16:18:50"), 1e-3);
+    TS_ASSERT_DELTA(splitter[0].begin(), DateAndTime("2007-11-30T16:16:00"), 1e-3);
+    TS_ASSERT_DELTA(splitter[0].end(), DateAndTime("2007-11-30T16:17:20"), 1e-3);
+    TS_ASSERT_DELTA(splitter[1].begin(), DateAndTime("2007-11-30T16:17:50"), 1e-3);
+    TS_ASSERT_DELTA(splitter[1].end(), DateAndTime("2007-11-30T16:18:50"), 1e-3);
 
     // Test bad at both ends
     log.makeFilterByValue(splitter, 2.5, 10.0, 0.0, false);
     log.expandFilterToRange(splitter, 2.5, 10.0, interval);
     TS_ASSERT_EQUALS(splitter.size(), 1);
-    TS_ASSERT_DELTA(splitter[0].start(), DateAndTime("2007-11-30T16:17:20"), 1e-3);
-    TS_ASSERT_DELTA(splitter[0].stop(), DateAndTime("2007-11-30T16:17:50"), 1e-3);
+    TS_ASSERT_DELTA(splitter[0].begin(), DateAndTime("2007-11-30T16:17:20"), 1e-3);
+    TS_ASSERT_DELTA(splitter[0].end(), DateAndTime("2007-11-30T16:17:50"), 1e-3);
 
     // Test good at start, bad at end
     log.makeFilterByValue(splitter, -1.0, 1.5, 0.0, false);
     log.expandFilterToRange(splitter, -1.0, 1.5, interval);
     TS_ASSERT_EQUALS(splitter.size(), 1);
-    TS_ASSERT_DELTA(splitter[0].start(), DateAndTime("2007-11-30T16:16:00"), 1e-3);
-    TS_ASSERT_DELTA(splitter[0].stop(), DateAndTime("2007-11-30T16:17:10"), 1e-3);
+    TS_ASSERT_DELTA(splitter[0].begin(), DateAndTime("2007-11-30T16:16:00"), 1e-3);
+    TS_ASSERT_DELTA(splitter[0].end(), DateAndTime("2007-11-30T16:17:10"), 1e-3);
 
     // Test good at end, bad at start
     log.makeFilterByValue(splitter, 1.99, 2.5, 1.0, false);
     log.expandFilterToRange(splitter, 1.99, 2.5, interval);
     TS_ASSERT_EQUALS(splitter.size(), 2);
-    TS_ASSERT_DELTA(splitter[0].start(), DateAndTime("2007-11-30T16:17:10"), 1e-3);
-    TS_ASSERT_DELTA(splitter[0].stop(), DateAndTime("2007-11-30T16:17:20"), 1e-3);
-    TS_ASSERT_DELTA(splitter[1].start(), DateAndTime("2007-11-30T16:17:50"), 1e-3);
-    TS_ASSERT_DELTA(splitter[1].stop(), DateAndTime("2007-11-30T16:18:50"), 1e-3);
+    TS_ASSERT_DELTA(splitter[0].begin(), DateAndTime("2007-11-30T16:17:10"), 1e-3);
+    TS_ASSERT_DELTA(splitter[0].end(), DateAndTime("2007-11-30T16:17:20"), 1e-3);
+    TS_ASSERT_DELTA(splitter[1].begin(), DateAndTime("2007-11-30T16:17:50"), 1e-3);
+    TS_ASSERT_DELTA(splitter[1].end(), DateAndTime("2007-11-30T16:18:50"), 1e-3);
 
     // Check throws if min > max
     TS_ASSERT_THROWS(log.expandFilterToRange(splitter, 2.0, 1.0, interval), const std::invalid_argument &);
@@ -608,8 +608,8 @@ public:
     log.makeFilterByValue(splitter, 0.0, 10.0, 0.0, false);
     log.expandFilterToRange(splitter, 0.0, 10.0, narrowinterval);
     TS_ASSERT_EQUALS(splitter.size(), 1);
-    TS_ASSERT_DELTA(splitter[0].start(), DateAndTime("2007-11-30T16:17:00"), 1e-3);
-    TS_ASSERT_DELTA(splitter[0].stop(), DateAndTime("2007-11-30T16:17:50"), 1e-3);
+    TS_ASSERT_DELTA(splitter[0].begin(), DateAndTime("2007-11-30T16:17:00"), 1e-3);
+    TS_ASSERT_DELTA(splitter[0].end(), DateAndTime("2007-11-30T16:17:50"), 1e-3);
   }
 
   void test_expandFilterToRange_throws_for_string_property() {
@@ -2312,8 +2312,8 @@ public:
     const auto &intervals = log->getSplittingIntervals();
     TS_ASSERT_EQUALS(intervals.size(), 1);
     const auto &range = intervals.front();
-    TS_ASSERT_EQUALS(range.start(), log->firstTime());
-    TS_ASSERT_EQUALS(range.stop(), log->lastTime());
+    TS_ASSERT_EQUALS(range.begin(), log->firstTime());
+    TS_ASSERT_EQUALS(range.end(), log->lastTime());
   }
 
   void test_getSplittingIntervals_repeatedEntries() {
@@ -2333,10 +2333,10 @@ public:
     TS_ASSERT_EQUALS(intervals.size(), 2);
     if (intervals.size() == 2) {
       const auto &firstRange = intervals.front(), &secondRange = intervals.back();
-      TS_ASSERT_EQUALS(firstRange.start(), firstStart);
-      TS_ASSERT_EQUALS(firstRange.stop(), firstEnd);
-      TS_ASSERT_EQUALS(secondRange.start(), secondStart);
-      TS_ASSERT_EQUALS(secondRange.stop(), secondEnd);
+      TS_ASSERT_EQUALS(firstRange.begin(), firstStart);
+      TS_ASSERT_EQUALS(firstRange.end(), firstEnd);
+      TS_ASSERT_EQUALS(secondRange.begin(), secondStart);
+      TS_ASSERT_EQUALS(secondRange.end(), secondEnd);
     }
   }
 
@@ -2355,12 +2355,12 @@ public:
     const auto &intervals = log->getSplittingIntervals();
     TS_ASSERT_EQUALS(intervals.size(), 3);
     if (intervals.size() == 3) {
-      TS_ASSERT_EQUALS(intervals[0].start(), log->firstTime());
-      TS_ASSERT_EQUALS(intervals[0].stop(), firstEnd);
-      TS_ASSERT_EQUALS(intervals[1].start(), secondStart);
-      TS_ASSERT_EQUALS(intervals[1].stop(), secondEnd);
-      TS_ASSERT_EQUALS(intervals[2].start(), thirdStart);
-      TS_ASSERT(intervals[2].stop() > thirdStart);
+      TS_ASSERT_EQUALS(intervals[0].begin(), log->firstTime());
+      TS_ASSERT_EQUALS(intervals[0].end(), firstEnd);
+      TS_ASSERT_EQUALS(intervals[1].begin(), secondStart);
+      TS_ASSERT_EQUALS(intervals[1].end(), secondEnd);
+      TS_ASSERT_EQUALS(intervals[2].begin(), thirdStart);
+      TS_ASSERT(intervals[2].end() > thirdStart);
     }
   }
 


### PR DESCRIPTION
Since `SplittingInterval` is essentially a `TimeInterval` plus a field, make it a formal inheritance and reduce code. 

**To test:**

This is a refactor so shouldn't need direct testing.

Refs #34794

*This does not require release notes* because it is a refactor to reduce duplicated code.

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
