### PR TITLE
Divide two theta by two for rotation angle calculation

### DIFF
--- a/qt/scientific_interfaces/Direct/ALFAnalysisModel.cpp
+++ b/qt/scientific_interfaces/Direct/ALFAnalysisModel.cpp
@@ -210,7 +210,7 @@ std::optional<double> ALFAnalysisModel::rotationAngle() const {
   if (!twoTheta) {
     return std::nullopt;
   }
-  return peakCentre() / (2 * sin((*twoTheta) * M_PI / 180.0));
+  return peakCentre() / (2 * sin((*twoTheta / 2.0) * M_PI / 180.0));
 }
 
 } // namespace MantidQt::CustomInterfaces

--- a/qt/scientific_interfaces/Direct/test/ALFAnalysisModelTest.h
+++ b/qt/scientific_interfaces/Direct/test/ALFAnalysisModelTest.h
@@ -168,7 +168,7 @@ public:
     m_model->setPeakCentre(0.1);
     m_model->doFit(m_range);
 
-    TS_ASSERT_DELTA(0.0991, *m_model->rotationAngle(), 0.0001);
+    TS_ASSERT_DELTA(0.1913, *m_model->rotationAngle(), 0.0001);
   }
 
   void test_plottedWorkspace_returns_nullptr_data_is_not_extracted() {


### PR DESCRIPTION
**Description of work.**
This PR fixes a bug where the equation for the rotation angle is `R=V/2sin(theta)`, but I was using `R=V/2sin(2theta)`. The two theta value needs to be divided by two.

**Report to:** Russell

**To test:**
Open ALFView from the interface menu
Load ALF84116 as the sample
Load ALF78634 as the vanadium
Go to pick tab and select the `Select whole tube` button
Select the central four tubes (seen in the screenshot below)
The two theta value should be 38.066
Then click `Fit` on the right hand side of the interface
The Rotation angle should have a value of -0.1869...

![image](https://user-images.githubusercontent.com/40830825/216953757-def2ab6d-a0c2-4223-951b-f79753fe1e91.png)


*There is no associated issue.*

*This does not require release notes* because **the rotation angle calculation is new**

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
