### PR TITLE
Added the ability read the notes from ISIS nexus files

### DIFF
--- a/Framework/DataHandling/src/LoadISISNexus2.cpp
+++ b/Framework/DataHandling/src/LoadISISNexus2.cpp
@@ -758,6 +758,14 @@ void LoadISISNexus2::loadPeriodData(int64_t period, NXEntry &entry, DataObjects:
   } catch (std::runtime_error &) {
     g_log.debug() << "No title was found in the input file, " << getPropertyValue("Filename") << '\n';
   }
+
+  std::string notes = "";
+  try {
+    notes = entry.getString("notes");
+  } catch (std::runtime_error &) {
+    // if no notes, add empty string
+  }
+  local_workspace->setComment(notes);
 }
 
 /**

--- a/Framework/DataHandling/test/LoadISISNexusTest.h
+++ b/Framework/DataHandling/test/LoadISISNexusTest.h
@@ -1463,7 +1463,7 @@ public:
 
     LoadISISNexus2 load;
     load.initialize();
-    load.setPropertyValue("Filename", "EMU000102347.nxs_v2");
+    load.setPropertyValue("Filename", "EMU00102347.nxs_v2");
     load.setPropertyValue("OutputWorkspace", "outWS");
     load.setPropertyValue("SpectrumMin", "10");
     load.setPropertyValue("SpectrumMax", "20");

--- a/Framework/DataHandling/test/LoadISISNexusTest.h
+++ b/Framework/DataHandling/test/LoadISISNexusTest.h
@@ -1488,7 +1488,6 @@ public:
     MatrixWorkspace_sptr ws = AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>("outWS");
     TS_ASSERT_EQUALS(ws->getComment(), "");
   }
-
 };
 
 //------------------------------------------------------------------------------

--- a/Framework/DataHandling/test/LoadISISNexusTest.h
+++ b/Framework/DataHandling/test/LoadISISNexusTest.h
@@ -1458,6 +1458,37 @@ public:
                       "select monitors, but to also exclude them",
                       ld.execute(), const std::invalid_argument &);
   }
+
+  void testReadNotes() {
+
+    LoadISISNexus2 load;
+    load.initialize();
+    load.setPropertyValue("Filename", "EMU000102347.nxs_v2");
+    load.setPropertyValue("OutputWorkspace", "outWS");
+    load.setPropertyValue("SpectrumMin", "10");
+    load.setPropertyValue("SpectrumMax", "20");
+    TS_ASSERT_THROWS_NOTHING(load.execute());
+    TS_ASSERT(load.isExecuted());
+
+    MatrixWorkspace_sptr ws = AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>("outWS");
+    TS_ASSERT_EQUALS(ws->getComment(), "TF20 as insert cools");
+  }
+
+  void testDoesNotFailWhenNoNotes() {
+
+    LoadISISNexus2 load;
+    load.initialize();
+    load.setPropertyValue("Filename", "LOQ49886.nxs");
+    load.setPropertyValue("OutputWorkspace", "outWS");
+    load.setPropertyValue("SpectrumMin", "10");
+    load.setPropertyValue("SpectrumMax", "20");
+    TS_ASSERT_THROWS_NOTHING(load.execute());
+    TS_ASSERT(load.isExecuted());
+
+    MatrixWorkspace_sptr ws = AnalysisDataService::Instance().retrieveWS<MatrixWorkspace>("outWS");
+    TS_ASSERT_EQUALS(ws->getComment(), "");
+  }
+
 };
 
 //------------------------------------------------------------------------------

--- a/docs/source/release/v6.7.0/Framework/Data_Objects/New_features/34908.rst
+++ b/docs/source/release/v6.7.0/Framework/Data_Objects/New_features/34908.rst
@@ -1,1 +1,1 @@
-- `LoadISISNexus <alg-LoadISISNNexus>` will not load the notes from the nxs file as a comment.
+- :ref:`LoadISISNexus <alg-LoadISISNNexus>` will now load the notes from the ``.nxs`` file as a comment.

--- a/docs/source/release/v6.7.0/Framework/Data_Objects/New_features/34908.rst
+++ b/docs/source/release/v6.7.0/Framework/Data_Objects/New_features/34908.rst
@@ -1,0 +1,1 @@
+- `LoadISISNexus <alg-LoadISISNNexus>` will not load the notes from the nxs file as a comment.

--- a/docs/source/release/v6.7.0/Muon/Algorithms/New_features/34908.rst
+++ b/docs/source/release/v6.7.0/Muon/Algorithms/New_features/34908.rst
@@ -1,0 +1,1 @@
+- The comments are no longer empty when loading the newest version of the nxs file.

--- a/docs/source/release/v6.7.0/Muon/MA_FDA/New_features/34908.rst
+++ b/docs/source/release/v6.7.0/Muon/MA_FDA/New_features/34908.rst
@@ -1,0 +1,1 @@
+- The comments are no longer empty when loading the newest version of the nxs file.


### PR DESCRIPTION
**Description of work.**
The muon group wanted to be able to read the notes from a nxs file. Turns out that it a field in all ISIS nxs files. I have updated the main reader to handle this. 

**To test:**

Load files from different instruments. The below script is a nice way to check things (EMU and IRIS have comments)

```
files = ['EMU115363.nxs_v2', 'POLREF00004699.nxs', 'IRIS56944.nxs']

for file in files:
    ws = LoadISISNexus(file)
    if "POL" in file:
        # returns a group
        ws = ws[0]
    print("file: ", file)
    print("comment: ", ws.getComment())
    print()
```

Fixes #34908 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
