### PR TITLE
Set the help window in read only mode

### DIFF
--- a/qt/widgets/common/inc/MantidQtWidgets/Common/MantidHelpWindow.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/MantidHelpWindow.h
@@ -49,9 +49,6 @@ private:
 
   /// The full path of the collection file.
   std::string m_collectionFile;
-  /** The full path of the cache file. If it is not
-      determined this is an empty string. */
-  std::string m_cacheFile;
   /// The window that renders the help information
   static QPointer<pqHelpWindow> g_helpWindow;
 

--- a/qt/widgets/common/src/MantidHelpWindow.cpp
+++ b/qt/widgets/common/src/MantidHelpWindow.cpp
@@ -304,6 +304,8 @@ void MantidHelpWindow::shutdown() {
   if (helpWindowExists()) {
     g_helpWindow->setAttribute(Qt::WA_DeleteOnClose);
     g_helpWindow->close();
+  } else {
+    g_log.warning("Something really wrong in MantidHelpWindow::shutdown()");
   }
 }
 

--- a/qt/widgets/common/src/MantidHelpWindow.cpp
+++ b/qt/widgets/common/src/MantidHelpWindow.cpp
@@ -294,8 +294,10 @@ void MantidHelpWindow::shutdown() {
   // close the window and delete the object
   // Deleting the object ensures the help engine's destructor is called and
   // avoids a segfault when workbench is closed
-  g_helpWindow->setAttribute(Qt::WA_DeleteOnClose);
-  g_helpWindow->close();
+  if (helpWindowExists()) {
+    g_helpWindow->setAttribute(Qt::WA_DeleteOnClose);
+    g_helpWindow->close();
+  }
 }
 
 /**

--- a/qt/widgets/common/src/MantidHelpWindow.cpp
+++ b/qt/widgets/common/src/MantidHelpWindow.cpp
@@ -91,15 +91,18 @@ MantidHelpWindow::MantidHelpWindow(const Qt::WindowFlags &flags)
       // create the help engine with the found location
       g_log.debug() << "Loading " << m_collectionFile << "\n";
       auto helpEngine = new QHelpEngine(QString(m_collectionFile.c_str()));
+      helpEngine->setProperty("_q_readonly", QVariant::fromValue<bool>(true));
       QObject::connect(helpEngine, SIGNAL(warning(QString)), this, SLOT(warning(QString)));
       g_log.debug() << "Making local cache copy for saving information at " << m_cacheFile << "\n";
 
+      /*
       if (helpEngine->copyCollectionFile(QString(m_cacheFile.c_str()))) {
         helpEngine->setCollectionFile(QString(m_cacheFile.c_str()));
       } else {
         g_log.warning("Failed to copy collection file");
         g_log.debug(helpEngine->error().toStdString());
       }
+      */
       g_log.debug() << "helpengine.setupData() returned " << helpEngine->setupData() << "\n";
 
       // create a new help window


### PR DESCRIPTION
Rather than copying the help file (qhc) to a different directory that is user writable, just tell qt that the file is read only. Also redirects help requests to the default browser if no help file is found.

**To test:**

Build the help and see that it can still be rendered and navigatable.

*There is no associated issue.*

*This does not require release notes* because it is changing the help system in a way that will not affect the end user.

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
