### PR TITLE
Fxed muon bug caused by spaces in run bar

### DIFF
--- a/docs/source/release/v6.6.0/Muon/MA_FDA/Bugfixes/35153.rst
+++ b/docs/source/release/v6.6.0/Muon/MA_FDA/Bugfixes/35153.rst
@@ -1,0 +1,1 @@
+- Fixed a bug that caused a crash when using a trailing `,` or `-` and then a space.

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/utilities/run_string_utils.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/utilities/run_string_utils.py
@@ -82,6 +82,7 @@ def run_string_to_list(run_string, max_value=True):
     if not validate_run_string(run_string):
         raise IndexError("{} is not a valid run string".format(run_string))
     run_list = []
+    run_string = run_string.replace(" ", "")
     if run_string.endswith(",") or run_string.endswith("-"):
         run_string = run_string[:-1]
     if run_string == "":
@@ -89,7 +90,6 @@ def run_string_to_list(run_string, max_value=True):
 
     run_string_list = run_string.split(delimiter)
     for runs in run_string_list:
-        runs = runs.replace(" ", "")
         split_runs = runs.split(range_separator)
         if len(runs) == 1:
             run_list += [int(runs)]

--- a/qt/python/mantidqtinterfaces/test/Muon/utilities/run_string_utils_conversion_test.py
+++ b/qt/python/mantidqtinterfaces/test/Muon/utilities/run_string_utils_conversion_test.py
@@ -137,6 +137,11 @@ class RunStringUtilsStringToListTest(unittest.TestCase):
         expected_list = [1, 2, 3] + list(range(10, 10011))
         self.assertEqual(utils.run_string_to_list(run_string), expected_list)
 
+    def test_run_string_to_list_allows_trailing_dash_and_space_in_long_string(self):
+        run_string = "1,2,3,10-10010- "
+        expected_list = [1, 2, 3] + list(range(10, 10011))
+        self.assertEqual(utils.run_string_to_list(run_string), expected_list)
+
     def test_run_string_allows_incomplete_upper_range(self):
         run_string = "62260-66"
         run_list = [62260, 62261, 62262, 62263, 62264, 62265, 62266]
@@ -144,6 +149,11 @@ class RunStringUtilsStringToListTest(unittest.TestCase):
 
     def test_run_string_allows_trailing_comma(self):
         run_string = "5,4,3,2,1,"
+        run_list = utils.run_string_to_list(run_string)
+        self.assertEqual(run_list, [1, 2, 3, 4, 5])
+
+    def test_run_string_allows_trailing_comma_and_space(self):
+        run_string = "5,4,3,2,1, "
         run_list = utils.run_string_to_list(run_string)
         self.assertEqual(run_list, [1, 2, 3, 4, 5])
 


### PR DESCRIPTION
**Description of work.**

The muon GUI's would crash if the values in the run bar had a trailing `,` or `-` followed by a space (the space is important). This PR fixes it by moving the replacement of the spaces to earlier in the code.

**To test:**

<!-- Instructions for testing. -->

Open muon analysis
Set it to the MUSR instrument
In the run bar type `87050` and data should load
In the run bar type `87050 , 87052` and data should load
In the run bar type `87050 - 87052` and data should load

The following two, used to crash (make sure to include the space):
In the run bar type `87050 - 87052, ` and data should load
In the run bar type `87050 - 87052- ` and data should load

Fixes #35153. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
