### PR TITLE
Add extra validation to GSAS2 path in Engineering UI

### DIFF
--- a/docs/source/release/v6.7.0/Diffraction/Engineering/Bugfixes/35185 HandleErrorOnRunningGSASRefinement.rst
+++ b/docs/source/release/v6.7.0/Diffraction/Engineering/Bugfixes/35185 HandleErrorOnRunningGSASRefinement.rst
@@ -1,0 +1,1 @@
+- extra validation has been added to the "Path to GSASII" setting so that Workbench no longer crashes if a GSAS refinement is run with an invalid GSASII path in settings

--- a/qt/python/mantidqt/mantidqt/_common.sip
+++ b/qt/python/mantidqt/mantidqt/_common.sip
@@ -1024,6 +1024,7 @@ public:
     void setLabelMinWidth(const int);
     void setText(const QString&);
     void setUserInput(const QVariant &);
+    void setFileProblem(const QString &message);
     QVariant getUserInput() const;
     void setReadOnly(bool readOnly);
     void setFileExtensions(const QStringList &extensions);

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/settings/settings_view.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/settings/settings_view.py
@@ -29,6 +29,7 @@ class SettingsView(QtWidgets.QDialog, Ui_settings):
         self.finder_path_to_gsas2.setLabelText("Path to GSASII")
         self.finder_path_to_gsas2.isForRunFiles(False)
         self.finder_path_to_gsas2.isForDirectory(True)
+        self.finder_path_to_gsas2.isOptional(True)
 
         self.timeout_lineedit.setValidator(QIntValidator(0, 200))
         self.dSpacing_min_lineedit.setValidator(QDoubleValidator(0.0, 200.0, 3))
@@ -62,6 +63,9 @@ class SettingsView(QtWidgets.QDialog, Ui_settings):
 
     def set_on_check_descending_changed(self, slot):
         self.check_descending.stateChanged.connect(slot)
+
+    def set_on_gsas2_path_edited(self, slot):
+        self.finder_path_to_gsas2.fileEditingFinished.connect(slot)
 
     # =================
     # Component Getters

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/gsas2/model.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/gsas2/model.py
@@ -174,6 +174,9 @@ class GSAS2Model(object):
         if self.refinement_method == "Pawley" and not self.mantid_pawley_reflections:
             logger.error("No Pawley Reflections were generated for the phases provided. Not calling GSAS-II.")
             return None
+        if not self.path_to_gsas2:
+            logger.error("The Path to GSAS2 setting is empty. " "Please provide a valid path in Engineering Diffraction Settings")
+            return None
         return True
 
     # ===============
@@ -267,6 +270,12 @@ class GSAS2Model(object):
                 f"GSAS-II call did not complete after {self.timeout} seconds, so it was"
                 f" aborted. Check the inputs, such as Refinement Method are correct. The"
                 f" timeout interval can be increased in the Engineering Diffraction Settings."
+            )
+            return None
+        except Exception as exc:
+            logger.error(
+                f"GSAS-II call failed with error: {str(exc)}. "
+                "Please check the Path to GSASII in the Engineering Diffraction Settings is valid"
             )
             return None
 

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/gsas2/test/test_gsas2_model.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/gsas2/test/test_gsas2_model.py
@@ -37,6 +37,7 @@ class TestGSAS2Model(unittest.TestCase):
         self.maxDiff = None
         self.model.user_save_directory = os.path.dirname(self.lst_result_filepath)
         self.model.project_name = "gsas2_output"
+        self.model.path_to_gsas2 = "/opt/gsas2"
 
     def tearDown(self) -> None:
         self.model.clear_input_components()

--- a/qt/widgets/common/src/FileFinderWidget.cpp
+++ b/qt/widgets/common/src/FileFinderWidget.cpp
@@ -504,7 +504,10 @@ void FileFinderWidget::findFiles(bool isModified) {
   if (m_isForDirectory) {
     m_foundFiles.clear();
     if (searchText.isEmpty()) {
-      setFileProblem("A directory must be provided");
+      if (!m_isOptional)
+        setFileProblem("A directory must be provided");
+      else
+        setFileProblem("");
     } else {
       setFileProblem("");
       m_foundFiles.append(searchText);


### PR DESCRIPTION
**Description of work.**

I've added more validation to the GSAS 2 Path in the settings screen of the Engineering Diffraction UI to avoid a crash on running a GSAS refinement if the path isn't valid. As part of this I catch more exceptions if GSAS2 call fails + only use the IDAaaS default value if that directory exists. So that default doesn't get used any more on Windows for example.

The settings screen doesn't currently force the user to correct invalid entries on hitting OK at the moment so have continued with that approach so the settings screen validation just triggers the red asterisk next to the file edit box.

As part of this I've added support for an optional directory widget in FileFinderWidget and I've also exposed the setFileProblem method to python so I can add validation that the directory actually exists. I don't think this should be supported globally because the FileFinderWidget may be used to specify a save directory which is created on use.

**To test:**

Open up the Engineering Diffraction UI from the Interfaces, Diffraction menu in workbench
Open the settings cog in the bottom left corner
Clear the "Path to GSASII" setting and tab out of the edit box. There should be no red asterisk (blank is valid - user may want to just used the tabs other than the GSAS2 tab)
Set "Path to GSASII" to an invalid path eg xxxx and tab out of the edit box. There should be a red asterisk
Hit OK
Run a refinement on the GSAS2 tab using the instructions on https://github.com/mantidproject/mantid/pull/34790. This should produce an error in the log but not crash Mantid

*There is no associated issue.*

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
