### PR TITLE
Integrate proton charge

### DIFF
--- a/Framework/API/inc/MantidAPI/LogManager.h
+++ b/Framework/API/inc/MantidAPI/LogManager.h
@@ -164,8 +164,8 @@ public:
   /// Empty all but the last value out of all TimeSeriesProperty logs
   void clearOutdatedTimeSeriesLogValues();
 
-  const Kernel::TimeROI &timeROI() const;
-  void timeROI(const Kernel::TimeROI &);
+  const Kernel::TimeROI &getTimeROI() const;
+  virtual void setTimeROI(const Kernel::TimeROI &timeroi);
 
   /// Save the run to a NeXus file with a given group name
   virtual void saveNexus(::NeXus::File *file, const std::string &group, bool keepOpen = false) const;

--- a/Framework/API/inc/MantidAPI/Run.h
+++ b/Framework/API/inc/MantidAPI/Run.h
@@ -55,6 +55,8 @@ public:
   /// Split the logs based on the given intervals
   void splitByTime(Kernel::SplittingIntervalVec &splitter, std::vector<LogManager *> outputs) const override;
 
+  void setTimeROI(const Kernel::TimeROI &timeroi) override;
+
   /// Return an approximate memory size for the object in bytes
   size_t getMemorySize() const override;
 

--- a/Framework/API/src/ExperimentInfo.cpp
+++ b/Framework/API/src/ExperimentInfo.cpp
@@ -256,7 +256,7 @@ struct ParameterValue {
     if (info.m_logfileID.empty())
       return boost::lexical_cast<double>(info.m_value);
     else {
-      const TimeROI *roi = &runData.timeROI();
+      const TimeROI *roi = &runData.getTimeROI();
       return info.createParamValue(runData.getTimeSeriesProperty<double>(info.m_logfileID), roi);
     }
   }

--- a/Framework/API/src/LogManager.cpp
+++ b/Framework/API/src/LogManager.cpp
@@ -483,7 +483,10 @@ void LogManager::clearOutdatedTimeSeriesLogValues() {
 
 const Kernel::TimeROI &LogManager::getTimeROI() const { return *(m_timeroi.get()); }
 
-void LogManager::setTimeROI(const Kernel::TimeROI &timeroi) { m_timeroi->replaceROI(timeroi); }
+void LogManager::setTimeROI(const Kernel::TimeROI &timeroi) {
+  m_timeroi->replaceROI(timeroi);
+  clearSingleValueCache();
+}
 
 //--------------------------------------------------------------------------------------------
 /** Save the object to an open NeXus file.

--- a/Framework/API/src/LogManager.cpp
+++ b/Framework/API/src/LogManager.cpp
@@ -481,9 +481,9 @@ void LogManager::clearOutdatedTimeSeriesLogValues() {
   }
 }
 
-const Kernel::TimeROI &LogManager::timeROI() const { return *(m_timeroi.get()); }
+const Kernel::TimeROI &LogManager::getTimeROI() const { return *(m_timeroi.get()); }
 
-void LogManager::timeROI(const Kernel::TimeROI &timeroi) { m_timeroi->replaceROI(timeroi); }
+void LogManager::setTimeROI(const Kernel::TimeROI &timeroi) { m_timeroi->replaceROI(timeroi); }
 
 //--------------------------------------------------------------------------------------------
 /** Save the object to an open NeXus file.

--- a/Framework/API/src/Run.cpp
+++ b/Framework/API/src/Run.cpp
@@ -227,7 +227,7 @@ void Run::integrateProtonCharge(const std::string &logname) const {
 
   if (log) {
     // start with a clearly nonsense accumulated value
-    double total = std::numeric_limits<double>::quiet_NaN();
+    double total;
 
     // get a copy of the TimeROI for selecting values
     const auto timeroi = this->getTimeROI();

--- a/Framework/API/test/RunTest.h
+++ b/Framework/API/test/RunTest.h
@@ -12,6 +12,7 @@
 #include "MantidKernel/Exception.h"
 #include "MantidKernel/Matrix.h"
 #include "MantidKernel/Property.h"
+#include "MantidKernel/TimeROI.h"
 #include "MantidKernel/TimeSeriesProperty.h"
 #include "MantidKernel/V3D.h"
 #include "MantidKernel/WarningSuppressions.h"
@@ -524,6 +525,32 @@ public:
     DblMatrix r = runInfo.getGoniometerMatrix();
     V3D rot = r * V3D(-1, 0, 0);
     TS_ASSERT_EQUALS(rot, V3D(0, -sqrt(0.5), sqrt(0.5)));
+  }
+
+  void test_integratePCharge() {
+    // create a p-charge log
+    TimeSeriesProperty<double> *pcharge = new TimeSeriesProperty<double>("proton_charge");
+    pcharge->setUnits("uAh"); // use native units
+    pcharge->addValue("2011-05-24T00:00:00", 1);
+    pcharge->addValue("2011-05-24T01:00:00", 2);
+    pcharge->addValue("2011-05-24T02:00:00", 3);
+    pcharge->addValue("2011-05-24T03:00:00", 4);
+    pcharge->addValue("2011-05-24T04:00:00", 5);
+
+    // attach it to a run object
+    Run run;
+    run.addProperty(pcharge);
+
+    // check the unfiltered value
+    TS_ASSERT_EQUALS(run.getProtonCharge(), 15.);
+
+    // create roi that excludes the last value
+    TimeROI roi;
+    roi.addROI("2011-05-24T00:00:00", "2011-05-24T04:00:00");
+    run.setTimeROI(roi);
+
+    // check the unfiltered value
+    TS_ASSERT_EQUALS(run.getProtonCharge(), 10.);
   }
 
   /** Save and load to NXS file */


### PR DESCRIPTION
Add support for having a `TimeROI` to `Run::integrateProtonCharge()`. Unfortunately, the compiler had a time disambiguating methods once they were overloaded so `timeROI` was renamed as well.

**To test:**

Look at the new unit test

Refs #34794 

*This does not require release notes* because it will be covered by a separate event filtering release note in future PRs.

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
