### PR TITLE
Shut down FrameworkManager on close

### DIFF
--- a/dev-docs/source/CLion.rst
+++ b/dev-docs/source/CLion.rst
@@ -137,5 +137,7 @@ To debug workbench, you'll need to edit the ``workbench`` CMake Application conf
 
 #. Set the working directory to be the full path to your ``build/bin`` directory
 
+The ``--single-process`` flag is necessary for debugging. See the :ref:`Running Workbench <RunningWorkbench>` documentation for more information.
+
 You should now be able to set breakpoints and start debugging by clicking the bug icon.
 

--- a/dev-docs/source/PyCharm.rst
+++ b/dev-docs/source/PyCharm.rst
@@ -65,7 +65,7 @@ Now that your Python development environment has been setup we can setup the deb
 - Name it something to do with ``Workbench``
 - In the ``Script Path:`` box, on Linux/MacOS enter the ``{BUILD}/bin/workbench`` Python script, on Windows enter ``{BUILD}/bin/DebugWithRelRuntime/workbench-script.pyw``, ``.pyw`` files will not appear in the search window as it only shows ``.py`` files, so you cannot search for it with the GUI.
 - In the ``Working directory:`` box, on Linux/MacOS enter the ``{BUILD}/bin`` directory, on Windows enter ``{BUILD}/bin/DebugWithRelRuntime`` directory.
-- In the ``Parameters`` box add ``--single-process`` so that the multiprocess startup is disabled and breakpoints can be attached to the primary process.
+- In the ``Parameters`` box add ``--single-process`` so that the multiprocess startup is disabled and breakpoints can be attached to the primary process. See the :ref:`Running Workbench <RunningWorkbench>` documentation for more information.
 - Ensure the ``Python Interpreter:`` box is your Python version following by ``(mantid-developer)``, this ensures it runs using your Conda environment.
 - Click Ok and exit out the window.
 - You can now click the green play button in the top right of the window to create a Workbench instance from pycharm.

--- a/dev-docs/source/VSCode.rst
+++ b/dev-docs/source/VSCode.rst
@@ -165,7 +165,7 @@ To debug C++ and start directly into the Workbench, add this to the configuratio
       "type": "cppdbg",
       "request": "launch",
       "program": "/usr/bin/python3", // Path to your used Python interpreter, here and below
-      "args": ["Path/To/Build/Directory/bin/workbench", "&&","gdb","/usr/bin/python3","$!"], // $! gets the process ID
+      "args": ["Path/To/Build/Directory/bin/workbench", "--single-process", "&&","gdb","/usr/bin/python3","$!"], // $! gets the process ID
       "stopAtEntry": false,
       "cwd": "Path/To/Build/Directory/bin", // this should point to bin inside the build directory
       "environment": [],
@@ -180,6 +180,8 @@ To debug C++ and start directly into the Workbench, add this to the configuratio
         }
       ]
     }
+
+The ``--single-process`` flag is necessary for debugging. See the :ref:`Running Workbench <RunningWorkbench>` documentation for more information.
 
 If this fails, try adding the following environment variables:
 

--- a/dev-docs/source/Workbench/RunningWorkbench.rst
+++ b/dev-docs/source/Workbench/RunningWorkbench.rst
@@ -20,13 +20,13 @@ an ErrorReporter window needs to be opened depending on the exit code of the Wor
 A note on debugging
 ###################
 
-Debuggers can sometimes attach to the parent process, causing your breakpoints not to be hit. To avoid this, we can run the Workbench using the ``--single-process`` flag which will ensure only one process is used to run the Workbench.
+The default behaviour of Workbench is to start as a parent and child process as described above. For debugging, we want to attach to the main process that users see (i.e. the child process). If we attach to the parent process, your breakpoints will not be hit. To ensure we attach to the correct process, we can run the Workbench with the ``--single-process`` flag.
 
 .. code-block:: sh
 
   workbench --single-process
 
-For a development environment you might also want to specify the ``PYTHONPATH`` where ``<config>`` is only required when using the VS generator on Windows.
+For a developer environment you might also want to specify the ``PYTHONPATH`` where ``<config>`` is only required when using the VS generator on Windows.
 
 .. code-block:: sh
 

--- a/dev-docs/source/Workbench/RunningWorkbench.rst
+++ b/dev-docs/source/Workbench/RunningWorkbench.rst
@@ -1,0 +1,34 @@
+.. _RunningWorkbench:
+
+=================
+Running Workbench
+=================
+
+How does Workbench get run
+##########################
+
+Mantid Workbench is run on two separate Processes. The first process, known as the parent process, creates a second process using the
+`multiprocessing python package <https://docs.python.org/3/library/multiprocessing.html>`_, known as the child process. The responsibilities
+of the two processes are roughly as follows:
+
+- The child process is the process on which the Workbench is opened. If there is a terminating fault that occurs when using the Workbench,
+such as a segmentation fault, this process will exit. Alternatively, a close event triggered by a user will also cause this process to exit.
+
+- The responsibility of the parent process is to wait for the child process to exit. When the child process exits, a decision is made whether
+an ErrorReporter window needs to be opened depending on the exit code of the Workbench.
+
+A note on debugging
+###################
+
+Debuggers can sometimes attach to the parent process, causing your breakpoints not to be hit. To avoid this, we can run the Workbench using the ``--single-process`` flag which will ensure only one process is used to run the Workbench.
+
+.. code-block:: sh
+
+  workbench --single-process
+
+For a development environment you might also want to specify the ``PYTHONPATH`` where ``<config>`` is only required when using the VS generator on Windows.
+
+.. code-block:: sh
+
+  PYTHONPATH=/path/to/build/bin/<config> workbench --single-process
+

--- a/dev-docs/source/Workbench/index.rst
+++ b/dev-docs/source/Workbench/index.rst
@@ -15,10 +15,14 @@ interacting with the mantid framework. The plotting is provided by
    :hidden:
 
    BuildingWorkbench
+   RunningWorkbench
    ProjectSaveInterfaces
 
 :doc:`Build Workbench <BuildingWorkbench>`
    A document detailing how to build and package the workbench.
+
+:doc:`Running Workbench <RunningWorkbench>`
+   A document detailing the two processes used to run the workbench.
 
 :doc:`Project Save <ProjectSaveInterfaces>`
    This document details Project Save on workbench and gives details on how to allow the saving and loading of interfaces in workbench.

--- a/qt/applications/workbench/workbench/app/mainwindow.py
+++ b/qt/applications/workbench/workbench/app/mainwindow.py
@@ -622,9 +622,6 @@ class MainWindow(QMainWindow):
                 # after a month
                 self.project_recovery.remove_current_pid_folder(ignore_errors=True)
 
-            # Shutdown the FrameworkManager. This is required for the UsageService to shutdown and send a Feature usage report
-            FrameworkManager.Instance().shutdown()
-
             event.accept()
         else:
             # Cancel was pressed when closing an editor

--- a/qt/applications/workbench/workbench/app/mainwindow.py
+++ b/qt/applications/workbench/workbench/app/mainwindow.py
@@ -622,6 +622,9 @@ class MainWindow(QMainWindow):
                 # after a month
                 self.project_recovery.remove_current_pid_folder(ignore_errors=True)
 
+            # Shutdown the FrameworkManager. This is required for the UsageService to shutdown and send a Feature usage report
+            FrameworkManager.Instance().shutdown()
+
             event.accept()
         else:
             # Cancel was pressed when closing an editor

--- a/qt/applications/workbench/workbench/app/start.py
+++ b/qt/applications/workbench/workbench/app/start.py
@@ -239,7 +239,8 @@ def start(options: argparse.ArgumentParser):
     if options.single_process:
         initialise_qapp_and_launch_workbench(options)
     else:
-        workbench_process = multiprocessing.Process(target=initialise_qapp_and_launch_workbench, args=[options])
+        context = multiprocessing.get_context("spawn")
+        workbench_process = context.Process(target=initialise_qapp_and_launch_workbench, args=[options])
         workbench_process.start()
         workbench_process.join()
 

--- a/qt/applications/workbench/workbench/app/start.py
+++ b/qt/applications/workbench/workbench/app/start.py
@@ -239,8 +239,12 @@ def start(options: argparse.ArgumentParser):
     if options.single_process:
         initialise_qapp_and_launch_workbench(options)
     else:
-        # We require the start method to be 'spawn' so that we do not inherit resources such as 'std::once_flag' from
-        # the parent process. This will mean the relevant 'atexit' code will execute in the child process, and therefore the
+        # Mantid's FrameworkManagerImpl::Instance Python export uses a process-wide static flag to ensure code
+        # only runs once (see Instance function in Framework/PythonInterface/mantid/api/src/Exports/FrameworkManager.cpp).
+        # The default start method on Unix ('fork') inherits resources such as these flags from the parent.
+        # We require the start method to be 'spawn' so that we do not inherit these resources from the parent process,
+        # this is already the default on Windows/macOS.
+        # This will mean the relevant 'atexit' code will execute in the child process, and therefore the
         # FrameworkManager and UsageService will be shutdown as expected.
         context = multiprocessing.get_context("spawn")
         workbench_process = context.Process(target=initialise_qapp_and_launch_workbench, args=[options])

--- a/qt/applications/workbench/workbench/app/start.py
+++ b/qt/applications/workbench/workbench/app/start.py
@@ -239,6 +239,9 @@ def start(options: argparse.ArgumentParser):
     if options.single_process:
         initialise_qapp_and_launch_workbench(options)
     else:
+        # We require the start method to be 'spawn' so that we do not inherit resources such as 'std::once_flag' from
+        # the parent process. This will mean the relevant 'atexit' code will execute in the child process, and therefore the
+        # FrameworkManager and UsageService will be shutdown as expected.
         context = multiprocessing.get_context("spawn")
         workbench_process = context.Process(target=initialise_qapp_and_launch_workbench, args=[options])
         workbench_process.start()


### PR DESCRIPTION
**Description of work.**
This PR ensures the FrameworkManager gets shut down when MantidWorkbench is closed. This is required so that the UsageService sends a feature usage report while also being shut down.

**To test:**
Clone the reports repo https://github.com/mantidproject/reports
Follow the development setup instructions in this repo
Open Mantid. Open interfaces and run algorithms
Close Mantid
Check that the feature usages are recorded in the Django admin database on your local port

Fixes https://github.com/mantidproject/reports/issues/59

*This does not require release notes* because **the usage service is a developer tool and is not visible to users**

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
