### PR TITLE
Fix load and merge mergerunsoptions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,7 +40,7 @@ repos:
     #- id: cmake-lint <- not ready yet
 
   - repo: https://github.com/psf/black
-    rev: 22.12.0
+    rev: 23.1.0
     hooks:
       - id: black
         exclude: scripts/templates/reference/|Testing/Tools/cxxtest

--- a/Framework/PythonInterface/plugins/algorithms/LoadAndMerge.py
+++ b/Framework/PythonInterface/plugins/algorithms/LoadAndMerge.py
@@ -26,7 +26,6 @@ from mantid.simpleapi import MergeRuns, RenameWorkspace, DeleteWorkspace, GroupW
 
 
 class LoadAndMerge(PythonAlgorithm):
-
     _loader = None
     _version = None
     _loader_options = None

--- a/Framework/PythonInterface/plugins/algorithms/LoadAndMerge.py
+++ b/Framework/PythonInterface/plugins/algorithms/LoadAndMerge.py
@@ -123,6 +123,7 @@ class LoadAndMerge(PythonAlgorithm):
         self._version = self.getProperty("LoaderVersion").value
         self._loader_options = self.getProperty("LoaderOptions").value
         merge_options = self.getProperty("MergeRunsOptions").value
+        merge_options = dict([(k, merge_options.getProperty(k).value) for k in merge_options.keys()])
         output = self.getPropertyValue("OutputWorkspace")
         if output.startswith("__"):
             self._prefix = "__"

--- a/Framework/PythonInterface/test/python/plugins/algorithms/LoadAndMergeTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/LoadAndMergeTest.py
@@ -81,24 +81,35 @@ class LoadAndMergeTest(unittest.TestCase):
         )
         self.assertEqual(out5.getRun().getLogData("Doppler.maximum_delta_energy").value, "2, 0")
 
-    @mock.patch("mantid.Framework.PythonInterface.plugins.algorithms.LoadAndMerge.MergeRuns")
-    def test_merge_options_2(self, m_merge_runs):
-        out5 = LoadAndMerge(
-            Filename="170300+170301",
-            OutputWorkspace="out5",
-            LoaderName="LoadILLIndirect",
-            MergeRunsOptions={
-                "SampleLogsFail": "Doppler.maximum_delta_energy,Doppler.mirror_sense,acquisition_mode",
-                "SampleLogsFailTolerances": "10.0,10.0,10.0",
-                "SampleLogsWarn": "Doppler.maximum_delta_energy,Doppler.mirror_sense,acquisition_mode",
-                "SampleLogsWarnTolerances": "0.0,0.0,0.0",
-                "SampleLogsList": "Doppler.maximum_delta_energy",
-            },
-        )
+    @mock.patch("plugins.algorithms.LoadAndMerge.MergeRuns")
+    def test_merge_runs_call(self, m_merge_runs):
+        # This try/except block is compulsory as the use of the mocked MergeRuns inside the
+        # LoadAndMerge algorithm triggers errors further
+        try:
+            LoadAndMerge(
+                Filename="170300+170301",
+                OutputWorkspace="out5",
+                LoaderName="LoadILLIndirect",
+                MergeRunsOptions={
+                    "SampleLogsFail": "Doppler.maximum_delta_energy,Doppler.mirror_sense,acquisition_mode",
+                    "SampleLogsFailTolerances": "10.0,10.0,10.0",
+                    "SampleLogsWarn": "Doppler.maximum_delta_energy,Doppler.mirror_sense,acquisition_mode",
+                    "SampleLogsWarnTolerances": "0.0,0.0,0.0",
+                    "SampleLogsList": "Doppler.maximum_delta_energy",
+                },
+            )
+        except RuntimeError:
+            pass
+
         m_merge_runs.assert_called_with(
-            SampleLogsWarn="Doppler.maximum_delta_energy,Doppler.mirror_sense,acquisition_mode", SampleLogsWarnTolerances="0.0,0.0,0.0"
+            InputWorkspaces=["170300", "170301"],
+            OutputWorkspace="__tmp_170300",
+            SampleLogsFail="Doppler.maximum_delta_energy,Doppler.mirror_sense,acquisition_mode",
+            SampleLogsFailTolerances="10.0,10.0,10.0",
+            SampleLogsWarn="Doppler.maximum_delta_energy,Doppler.mirror_sense,acquisition_mode",
+            SampleLogsWarnTolerances="0.0,0.0,0.0",
+            SampleLogsList="Doppler.maximum_delta_energy",
         )
-        self.assertEqual(out5.getRun().getLogData("Doppler.maximum_delta_energy").value, "2, 0")
 
     def test_specific_loader(self):
         out5 = LoadAndMerge(

--- a/docs/source/release/v6.7.0/Framework/Algorithms/Bugfixes/Used/35197.rst
+++ b/docs/source/release/v6.7.0/Framework/Algorithms/Bugfixes/Used/35197.rst
@@ -1,0 +1,1 @@
+- Fixed bug when passing merge run options to LoadAndMerge algorithm


### PR DESCRIPTION
If one wants to overwrite the `MergeRunOptions` in `LoadAndMerge` algorithm using a dictionary as indicated in the documentation (e.g. `{"SampleLogsSum":"DetectorS.detsum"}`) this triggers the following error:
```
Error in execution of algorithm LoadAndMerge:
Problem setting "SampleLogsList" in MergeRuns-v1: No registered converter was able to produce a C++ rvalue of type std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > from this Python object of type StringPropertyWithValue
  at line 166 in '/home/pellegrini/git/mantid/Framework/PythonInterface/plugins/algorithms/LoadAndMerge.py'
  caused by line 1068 in '/home/pellegrini/git/mantid/Framework/PythonInterface/mantid/simpleapi.py'
  caused by line 956 in '/home/pellegrini/git/mantid/Framework/PythonInterface/mantid/simpleapi.py'
  caused by line 939 in '/home/pellegrini/git/mantid/Framework/PythonInterface/mantid/simpleapi.py'
```
After investigations, it seems that something is buggy with the `LoadAndMerge.py` implementation. Indeed,
at lines 124 and 125 of `LoadAndMerge.py` we have:
```
self._loader_options = self.getProperty("LoaderOptions").value
merge_options = self.getProperty("MergeRunsOptions").value
```

Both statements return a `_kernel.PropertyManager` wrapped-C++ object. The question was why in case of `LoaderOptions` it did not trigger an error and for `MergeRunsOptions` it triggered one. The answer is because the `self._loader_options` variable is used safely elsewhere in the code through a loop using the `keys()` method while the merge_options variable is used through the python dictionary expansion operator (`**`) which is obviously not suitable with a non dict-like object such as a `_kernel.PropertyManager` object.

Two possible fixes:
```
merge_options = eval(self.getPropertyValue("MergeRunsOptions"))
```
or
```
merge_options = self.getProperty("MergeRunsOptions").value
merge_options = dict([(k,merge_options.getProperty(k).value) for k in merge_options.keys()])

```
The second one is the one I chose as 1) it is more pythonic 2) it avoids the use of an eval which is always a bit controversial.

