### PR TITLE
Fix Multiple Calib Paths Appearing on GSAS II Tab

### DIFF
--- a/docs/source/release/v6.7.0/Diffraction/Engineering/Bugfixes/34829.txt
+++ b/docs/source/release/v6.7.0/Diffraction/Engineering/Bugfixes/34829.txt
@@ -1,0 +1,1 @@
+- Loading or creating a calibration now fills the GSAS II tab with the currently loaded calibration's ``.prm`` file.

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/calibration/model.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/calibration/model.py
@@ -13,22 +13,20 @@ from mantidqtinterfaces.Engineering.gui.engineering_diffraction.settings.setting
 class CalibrationModel(object):
     # model shares code with the EnginX auto reduction script - code is kept in EnggUtils.py
     def __init__(self):
-        self._saved_prm_files = []
+        self._saved_prm_file = ""
 
-    def get_last_prm_files_gsas2(self):
-        return self._saved_prm_files
+    def get_last_prm_file_gsas2(self):
+        return self._saved_prm_file
 
     def create_new_calibration(self, calibration, rb_num, plot_output, save_dir=None):
         if save_dir is None:
             save_dir = output_settings.get_output_path()
         full_calib = load_full_instrument_calibration()
-        prm_filepath = EnggUtils.create_new_calibration(calibration, rb_num, plot_output, save_dir, full_calib)
-        self._saved_prm_files.extend(prm_filepath)
+        self._saved_prm_file = EnggUtils.create_new_calibration(calibration, rb_num, plot_output, save_dir, full_calib)
 
     def load_existing_calibration_files(self, calibration):
         load_full_instrument_calibration()
-        prm_filepath = EnggUtils.load_existing_calibration_files(calibration)
-        self._saved_prm_files.extend(prm_filepath)
+        self._saved_prm_file = EnggUtils.load_existing_calibration_files(calibration)
 
 
 def load_full_instrument_calibration():

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/calibration/presenter.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/calibration/presenter.py
@@ -103,7 +103,7 @@ class CalibrationPresenter(object):
             "last_calibration_path",
             self.current_calibration.get_prm_filepath(),
         )
-        self.prm_filepath_notifier_gsas2.notify_subscribers(self.model.get_last_prm_files_gsas2())
+        self.prm_filepath_notifier_gsas2.notify_subscribers(self.model.get_last_prm_file_gsas2())
 
     def set_field_value(self):
         self.view.set_sample_text(self.current_calibration.get_sample())

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/calibration/test/test_calib_model.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/calibration/test/test_calib_model.py
@@ -138,7 +138,7 @@ class CalibrationModelTest(unittest.TestCase):
         self.assertEqual(path, self.model.get_last_prm_file_gsas2())
 
     def test_get_last_prm_file_gsas2_returns_none_initially(self):
-        self.assertEqual(None, self.model.get_last_prm_file_gsas2())
+        self.assertEqual("", self.model.get_last_prm_file_gsas2())
 
 
 if __name__ == "__main__":

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/calibration/test/test_calib_model.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/calibration/test/test_calib_model.py
@@ -37,6 +37,7 @@ class CalibrationModelTest(unittest.TestCase):
         mock_load_full_calib.assert_called_once()
         mock_write_diff_consts.assert_called_once_with(self.calibration_info.prm_filepath)
         self.calibration_info.load_relevant_calibration_files.assert_called_once()
+        self.assertEqual(self.calibration_info.prm_filepath, self.model._saved_prm_file)
 
     @patch(file_path + ".output_settings.get_output_path")
     @patch(enggutils_path + ".create_new_calibration")
@@ -129,6 +130,15 @@ class CalibrationModelTest(unittest.TestCase):
         self.model.create_new_calibration(self.calibration_info, rb_num, plot_output=False, save_dir="dir")
 
         mock_create_out.assert_called_once_with(path.join("dir", "User", "1", "Calibration", ""), self.calibration_info, "foc_ceria_ws")
+
+    def test_get_last_prm_file_gsas2(self):
+        path = "fake/path/to/calib/prm"
+        self.model._saved_prm_file = path
+
+        self.assertEqual(path, self.model.get_last_prm_file_gsas2())
+
+    def test_get_last_prm_file_gsas2_returns_none_initially(self):
+        self.assertEqual(None, self.model.get_last_prm_file_gsas2())
 
 
 if __name__ == "__main__":

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/gsas2/view.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/gsas2/view.py
@@ -99,8 +99,8 @@ class GSAS2View(QtWidgets.QWidget, Ui_calib):
     def set_default_gss_files(self, filepaths):
         self.set_default_files(filepaths, self.focused_data_file_finder)
 
-    def set_default_prm_files(self, filepaths):
-        self.set_default_files(filepaths, self.instrument_group_file_finder)
+    def set_default_prm_files(self, filepath):
+        self.set_default_files([filepath], self.instrument_group_file_finder)
 
     def set_default_files(self, filepaths, file_finder):
         if not filepaths:

--- a/scripts/CMakeLists.txt
+++ b/scripts/CMakeLists.txt
@@ -64,6 +64,7 @@ mtd_install_files(
 # Testing
 add_subdirectory(test)
 add_subdirectory(Diffraction/isis_powder)
+add_subdirectory(Engineering)
 
 # Ensure we don't get stale pyc files around
 clean_orphaned_pyc_files(${CMAKE_CURRENT_SOURCE_DIR})

--- a/scripts/Engineering/EnggUtils.py
+++ b/scripts/Engineering/EnggUtils.py
@@ -219,7 +219,7 @@ def create_new_calibration(calibration, rb_num, plot_output, save_dir, full_cali
 
     mantid.DeleteWorkspace(ceria_workspace)
 
-    return [prm_filepath]  # only from last calib_dir
+    return prm_filepath  # only from last calib_dir
 
 
 def write_prm_file(ws_foc, prm_savepath, spec_nums=None):
@@ -280,7 +280,7 @@ def load_existing_calibration_files(calibration):
         logger.error(f"Invalid file selected: {prm_filepath}")
         return None
     calibration.load_relevant_calibration_files()
-    return [prm_filepath]
+    return prm_filepath
 
 
 def write_diff_consts_to_table_from_prm(prm_filepath):

--- a/scripts/Engineering/test/test_EnggUtils.py
+++ b/scripts/Engineering/test/test_EnggUtils.py
@@ -188,8 +188,8 @@ INS  2 ICONS  18497.75    -29.68    -26.50"""
         ]
         mock_add_log.assert_has_calls(add_log_calls)
         save_nxs_calls = [
-            call(InputWorkspace=ws_foc, Filename=focused_files[0], WorkspaceIndexList=[0]),
-            call(InputWorkspace=ws_foc, Filename=focused_files[1], WorkspaceIndexList=[1]),
+            call(InputWorkspace=ws_foc, Filename=focused_files[0][0], WorkspaceIndexList=[0]),
+            call(InputWorkspace=ws_foc, Filename=focused_files[0][1], WorkspaceIndexList=[1]),
         ]
         mock_save_nxs.assert_has_calls(save_nxs_calls)
 
@@ -225,7 +225,7 @@ INS  2 ICONS  18497.75    -29.68    -26.50"""
             call(Workspace=ws_foc, LogName="bankid", LogText="bank 1"),
         ]
         mock_add_log.assert_has_calls(add_log_calls)
-        mock_save_nxs.assert_called_once_with(InputWorkspace=ws_foc, Filename=focused_files[0], WorkspaceIndexList=[0])
+        mock_save_nxs.assert_called_once_with(InputWorkspace=ws_foc, Filename=focused_files[0][0], WorkspaceIndexList=[0])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
**Description of work.**

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**
1. Open Eng Diff GUI
2. Load or create a calibration (305738)
3. Hit calibrate/load a bunch of times
4. Switch to GSAS II 
5. Check that only a single string of the most recently created/loaded `.prm` is present in the `Instrument Group` field. 

Fixes #34829 
Fixes #35204


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
