### PR TITLE
Correct Visual Studio 2022 toolset prefix from vs to just v

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -119,7 +119,7 @@
         "conda"
       ],
       "generator": "Visual Studio 17 2022",
-      "toolset": "vc142"
+      "toolset": "v142"
     },
     {
       "name": "win-ninja",


### PR DESCRIPTION
**Description of work.**

Correct typo from https://github.com/mantidproject/mantid/pull/35179 where extra "c" added to toolset entry in CMakePresets.json which prevents CMake running using the win-vs preset.

**To test:**

Given that this is so minor I suggest code review only. Documentation on the toolset values that are valid here: https://cmake.org/cmake/help/latest/variable/CMAKE_VS_PLATFORM_TOOLSET_VERSION.html

In my VS2022 install I have a file called `Microsoft.VCToolsVersion.v142.default.props`

*There is no associated issue.*

*This does not require release notes* because **only affects developers**

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
