### PR TITLE
Fixed buggy logger call

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/LoadFullprofFile.py
+++ b/Framework/PythonInterface/plugins/algorithms/LoadFullprofFile.py
@@ -156,7 +156,7 @@ class LoadFullprofFile(PythonAlgorithm):
             if fwhm < 1.0e-5:
                 # Peak width is too small/annihilated peak
                 if _OUTPUTLEVEL == "INFORMATION":
-                    self.log.information("Peak (%d, %d, %d) has an unreasonable small FWHM.  Peak does not exist. " % (h, k, l))
+                    self.log().information("Peak (%d, %d, %d) has an unreasonable small FWHM.  Peak does not exist. " % (h, k, l))
                 continue
 
             hkldict[dkey] = {}

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/DirectILLCollectData.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/DirectILLCollectData.py
@@ -205,7 +205,7 @@ def _get_instrument_structure(ws):
     instrument."""
     instrument = ws.getInstrument().getName()
     if instrument in ["IN4", "IN6"]:
-        self.log.warning("Grouping pattern cannot be provided for IN4 and IN6.")
+        self.log().warning("Grouping pattern cannot be provided for IN4 and IN6.")
         return ""
     tmp_inst = "{}_tmp".format(instrument)
     LoadEmptyInstrument(InstrumentName=instrument, OutputWorkspace=tmp_inst)

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/PowderILLDetectorScan.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/PowderILLDetectorScan.py
@@ -51,7 +51,6 @@ class PowderILLDetectorScan(DataProcessorAlgorithm):
         return issues
 
     def PyInit(self):
-
         self.declareProperty(MultipleFileProperty("Run", extensions=["nxs"]), doc="File path of run(s).")
 
         self.declareProperty(
@@ -144,10 +143,9 @@ class PowderILLDetectorScan(DataProcessorAlgorithm):
         return mask[:-1]
 
     def _validate_instrument(self, instrument_name):
-
         supported_instruments = ["D2B", "D20"]
         if instrument_name not in supported_instruments:
-            self.log.warning(
+            self.log().warning(
                 "Running for unsupported instrument, use with caution. Supported instruments are: " + str(supported_instruments)
             )
         if instrument_name == "D20":

--- a/docs/source/release/v6.7.0/Framework/Algorithms/Bugfixes/Used/35212.rst
+++ b/docs/source/release/v6.7.0/Framework/Algorithms/Bugfixes/Used/35212.rst
@@ -1,0 +1,1 @@
+- Fixed bugs when calling logger instances


### PR DESCRIPTION
In `LoadFullprofFile.py`, `DirectILLCollectData.py` and `PowderILLDetectorScan.py` files, there were some calls to `self.log` which were missing parenthesis. This has been fixed in this PR.