### PR TITLE
Bug fix for Mantid not opening on windows with a non-ascii username

### DIFF
--- a/Framework/Kernel/src/ConfigService.cpp
+++ b/Framework/Kernel/src/ConfigService.cpp
@@ -54,10 +54,12 @@
 
 #include <algorithm>
 #include <cctype>
+#include <codecvt>
 #include <exception>
 #include <fstream>
 #include <functional>
 #include <iostream>
+#include <locale>
 #include <stdexcept>
 #include <utility>
 
@@ -1206,7 +1208,9 @@ std::string ConfigServiceImpl::getAppDataDir() {
   const std::string applicationName = "mantid";
 #if POCO_OS == POCO_OS_WINDOWS_NT
   const std::string vendorName = "mantidproject";
-  std::string appdata = std::getenv("APPDATA");
+  wchar_t *w_appdata = _wgetenv(L"APPDATA");
+  std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
+  std::string appdata = converter.to_bytes(w_appdata);
   Poco::Path path(appdata);
   path.makeDirectory();
   path.pushDirectory(vendorName);

--- a/Framework/PythonInterface/test/python/mantid/kernel/ConfigServiceTest.py
+++ b/Framework/PythonInterface/test/python/mantid/kernel/ConfigServiceTest.py
@@ -14,9 +14,9 @@ from mantid.kernel import ConfigService, ConfigServiceImpl, config, std_vector_s
 
 
 class ConfigServiceTest(unittest.TestCase):
-
     __dirs_to_rm = []
     __init_dir_list = ""
+    _oringinal_appdata_path = os.environ["APPDATA"]
 
     def test_singleton_returns_instance_of_ConfigService(self):
         self.assertTrue(isinstance(config, ConfigServiceImpl))
@@ -217,6 +217,17 @@ class ConfigServiceTest(unittest.TestCase):
         # verify check for converting checked value to string
         self.assertFalse(1 in ConfigService)
 
+    def test_get_app_data_dir(self):
+        self.assertEqual(
+            os.path.join(self._oringinal_appdata_path, "mantidproject", "mantid"), os.path.abspath(ConfigService.getAppDataDirectory())
+        )
+
+        unicode_string = "Ťėst μДنא"
+        unicode_path = os.path.join(self._oringinal_appdata_path, unicode_string)
+        os.environ["APPDATA"] = unicode_path
+
+        self.assertEqual(os.path.join(unicode_path, "mantidproject", "mantid"), os.path.abspath(ConfigService.getAppDataDirectory()))
+
     def _setup_test_areas(self):
         """Create a new data search path string"""
         self.__init_dir_list = config["datasearch.directories"]
@@ -239,6 +250,7 @@ class ConfigServiceTest(unittest.TestCase):
 
     def _clean_up_test_areas(self):
         config["datasearch.directories"] = self.__init_dir_list
+        os.environ["APPDATA"] = self._oringinal_appdata_path
 
         # Remove temp directories
         for p in self.__dirs_to_rm:

--- a/Framework/PythonInterface/test/python/mantid/kernel/ConfigServiceTest.py
+++ b/Framework/PythonInterface/test/python/mantid/kernel/ConfigServiceTest.py
@@ -17,7 +17,9 @@ from mantid.kernel import ConfigService, ConfigServiceImpl, config, std_vector_s
 class ConfigServiceTest(unittest.TestCase):
     __dirs_to_rm = []
     __init_dir_list = ""
-    _oringinal_appdata_path = os.environ["APPDATA"]
+    _on_windows = sys.platform == "win32"
+    if _on_windows:
+        _original_appdata_path = os.environ["APPDATA"]
 
     def test_singleton_returns_instance_of_ConfigService(self):
         self.assertTrue(isinstance(config, ConfigServiceImpl))
@@ -218,14 +220,14 @@ class ConfigServiceTest(unittest.TestCase):
         # verify check for converting checked value to string
         self.assertFalse(1 in ConfigService)
 
-    @unittest.skipIf(sys.platform != "win32", "Windows only test, uses APPDATA")
+    @unittest.skipIf(not _on_windows, "Windows only test, uses APPDATA")
     def test_get_app_data_dir(self):
         self.assertEqual(
-            os.path.join(self._oringinal_appdata_path, "mantidproject", "mantid"), os.path.abspath(ConfigService.getAppDataDirectory())
+            os.path.join(self._original_appdata_path, "mantidproject", "mantid"), os.path.abspath(ConfigService.getAppDataDirectory())
         )
 
         unicode_string = "Ťėst μДنא"
-        unicode_path = os.path.join(self._oringinal_appdata_path, unicode_string)
+        unicode_path = os.path.join(self._original_appdata_path, unicode_string)
         os.environ["APPDATA"] = unicode_path
 
         self.assertEqual(os.path.join(unicode_path, "mantidproject", "mantid"), os.path.abspath(ConfigService.getAppDataDirectory()))
@@ -252,7 +254,8 @@ class ConfigServiceTest(unittest.TestCase):
 
     def _clean_up_test_areas(self):
         config["datasearch.directories"] = self.__init_dir_list
-        os.environ["APPDATA"] = self._oringinal_appdata_path
+        if self._on_windows:
+            os.environ["APPDATA"] = self._original_appdata_path
 
         # Remove temp directories
         for p in self.__dirs_to_rm:

--- a/Framework/PythonInterface/test/python/mantid/kernel/ConfigServiceTest.py
+++ b/Framework/PythonInterface/test/python/mantid/kernel/ConfigServiceTest.py
@@ -7,6 +7,7 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 import inspect
 import os
+import sys
 import testhelpers
 import unittest
 
@@ -217,6 +218,7 @@ class ConfigServiceTest(unittest.TestCase):
         # verify check for converting checked value to string
         self.assertFalse(1 in ConfigService)
 
+    @unittest.skipIf(sys.platform != "win32", "Windows only test, uses APPDATA")
     def test_get_app_data_dir(self):
         self.assertEqual(
             os.path.join(self._oringinal_appdata_path, "mantidproject", "mantid"), os.path.abspath(ConfigService.getAppDataDirectory())

--- a/docs/source/release/v6.7.0/Workbench/Bugfixes/35091.rst
+++ b/docs/source/release/v6.7.0/Workbench/Bugfixes/35091.rst
@@ -1,0 +1,1 @@
+- Fixed a bug where Mantid would not open on Windows when a user has non-ascii characters in their username.


### PR DESCRIPTION
**Description of work.**

Use `_wgetenv` over `getenv` when getting the user's appdata path to deal with non-ascii characters.

**To test:**

This is a tricky one to test...

 - [ ] Check that Mantid opens normally and a script runs.

What I did was make a windows virtual machine (images [here](https://developer.microsoft.com/en-us/windows/downloads/virtual-machines/)) with a non-ascii username. I used the one from the issue but maybe good to test with some non-Latin characters like Chinese.

 - On the VM install the branch executable from [here](https://builds.mantidproject.org/job/build_packages_from_branch/278/))
 - Also install the normal Mantid exe from [here](https://www.mantidproject.org/installation/index)
 - [ ] Check that normal Mantid doesn't open
 - [ ] Check that Mantid from this branch will open

Fixes #35091

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
