### PR TITLE
Move QtJobRunner and IJobRunner to the MantidQtWidgetsCommon library

### DIFF
--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchPresenter.cpp
@@ -33,14 +33,12 @@ using API::IConfiguredAlgorithm_sptr;
  * presenter
  * @param savePresenter :: [input] A pointer to the 'Save ASCII' tab presenter
  */
-BatchPresenter::BatchPresenter(IBatchView *view, std::unique_ptr<IBatch> model, std::unique_ptr<IJobRunner> jobRunner,
-                               std::unique_ptr<IRunsPresenter> runsPresenter,
-                               std::unique_ptr<IEventPresenter> eventPresenter,
-                               std::unique_ptr<IExperimentPresenter> experimentPresenter,
-                               std::unique_ptr<IInstrumentPresenter> instrumentPresenter,
-                               std::unique_ptr<ISavePresenter> savePresenter,
-                               std::unique_ptr<IPreviewPresenter> previewPresenter,
-                               MantidQt::MantidWidgets::IMessageHandler *messageHandler)
+BatchPresenter::BatchPresenter(
+    IBatchView *view, std::unique_ptr<IBatch> model, std::unique_ptr<API::IJobRunner> jobRunner,
+    std::unique_ptr<IRunsPresenter> runsPresenter, std::unique_ptr<IEventPresenter> eventPresenter,
+    std::unique_ptr<IExperimentPresenter> experimentPresenter,
+    std::unique_ptr<IInstrumentPresenter> instrumentPresenter, std::unique_ptr<ISavePresenter> savePresenter,
+    std::unique_ptr<IPreviewPresenter> previewPresenter, MantidQt::MantidWidgets::IMessageHandler *messageHandler)
     : m_view(view), m_model(std::move(model)), m_mainPresenter(), m_runsPresenter(std::move(runsPresenter)),
       m_eventPresenter(std::move(eventPresenter)), m_experimentPresenter(std::move(experimentPresenter)),
       m_instrumentPresenter(std::move(instrumentPresenter)), m_savePresenter(std::move(savePresenter)),

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchPresenter.h
@@ -7,7 +7,6 @@
 #pragma once
 
 #include "Common/DllConfig.h"
-#include "GUI/Common/IJobRunner.h"
 #include "GUI/Event/IEventPresenter.h"
 #include "GUI/Experiment/IExperimentPresenter.h"
 #include "GUI/Instrument/IInstrumentPresenter.h"
@@ -16,6 +15,7 @@
 #include "GUI/Save/ISavePresenter.h"
 #include "IBatchJobManager.h"
 #include "IBatchPresenter.h"
+#include "MantidQtWidgets/Common/IJobRunner.h"
 #include "MantidQtWidgets/Common/WorkspaceObserver.h"
 #include <memory>
 
@@ -33,11 +33,11 @@ class IBatchView;
     functionality defined by the interface IBatchPresenter.
 */
 class MANTIDQT_ISISREFLECTOMETRY_DLL BatchPresenter : public IBatchPresenter,
-                                                      public JobRunnerSubscriber,
+                                                      public MantidQt::API::JobRunnerSubscriber,
                                                       public MantidQt::API::WorkspaceObserver {
 public:
   /// Constructor
-  BatchPresenter(IBatchView *view, std::unique_ptr<IBatch> model, std::unique_ptr<IJobRunner> jobRunner,
+  BatchPresenter(IBatchView *view, std::unique_ptr<IBatch> model, std::unique_ptr<MantidQt::API::IJobRunner> jobRunner,
                  std::unique_ptr<IRunsPresenter> runsPresenter, std::unique_ptr<IEventPresenter> eventPresenter,
                  std::unique_ptr<IExperimentPresenter> experimentPresenter,
                  std::unique_ptr<IInstrumentPresenter> instrumentPresenter,
@@ -121,7 +121,7 @@ private:
   std::unique_ptr<ISavePresenter> m_savePresenter;
   std::unique_ptr<IPreviewPresenter> m_previewPresenter;
   bool m_unsavedBatchFlag;
-  std::unique_ptr<IJobRunner> m_jobRunner;
+  std::unique_ptr<MantidQt::API::IJobRunner> m_jobRunner;
   MantidQt::MantidWidgets::IMessageHandler *m_messageHandler;
 
   friend class Encoder;

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchPresenterFactory.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchPresenterFactory.h
@@ -7,7 +7,6 @@
 #pragma once
 #include "BatchPresenter.h"
 #include "Common/DllConfig.h"
-#include "GUI/Common/QtJobRunner.h"
 #include "GUI/Event/EventPresenterFactory.h"
 #include "GUI/Experiment/ExperimentPresenterFactory.h"
 #include "GUI/Instrument/InstrumentPresenterFactory.h"
@@ -17,6 +16,7 @@
 #include "IBatchPresenter.h"
 #include "IBatchPresenterFactory.h"
 #include "IBatchView.h"
+#include "MantidQtWidgets/Common/QtJobRunner.h"
 #include "ReflAlgorithmFactory.h"
 #include <memory>
 
@@ -53,7 +53,7 @@ public:
     auto algFactory = std::make_unique<ReflAlgorithmFactory>(*batchModel);
     auto previewPresenter = m_previewPresenterFactory.make(view->preview(), std::move(algFactory));
 
-    auto jobRunner = std::make_unique<QtJobRunner>();
+    auto jobRunner = std::make_unique<MantidQt::API::QtJobRunner>();
     return std::make_unique<BatchPresenter>(view, std::move(batchModel), std::move(jobRunner), std::move(runsPresenter),
                                             std::move(eventPresenter), std::move(experimentPresenter),
                                             std::move(instrumentPresenter), std::move(savePresenter),

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/IBatchView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/IBatchView.h
@@ -6,7 +6,6 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 #pragma once
 
-#include "GUI/Common/IJobRunner.h"
 #include "GUI/Event/IEventView.h"
 #include "GUI/Experiment/IExperimentView.h"
 #include "GUI/Instrument/IInstrumentView.h"

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/QtBatchView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/QtBatchView.h
@@ -6,7 +6,6 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 #pragma once
 
-#include "GUI/Common/IJobRunner.h"
 #include "GUI/Event/QtEventView.h"
 #include "GUI/Experiment/QtExperimentView.h"
 #include "GUI/Instrument/QtInstrumentView.h"

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Common/CMakeLists.txt
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Common/CMakeLists.txt
@@ -1,9 +1,8 @@
-set(COMMON_SRC_FILES Plotter.cpp Encoder.cpp Decoder.cpp QtJobRunner.cpp)
+set(COMMON_SRC_FILES Plotter.cpp Encoder.cpp Decoder.cpp)
 
 # Include files aren't required, but this makes them appear in Visual Studio
 set(COMMON_INC_FILES
     IFileHandler.h
-    IJobRunner.h
     IJobManager.h
     IReflMessageHandler.h
     IPythonRunner.h
@@ -11,14 +10,10 @@ set(COMMON_INC_FILES
     Plotter.h
     Encoder.h
     Decoder.h
-    QtJobRunner.h
 )
-
-set(COMMON_MOC_FILES QtJobRunner.h)
 
 prepend(COMMON_SRC_FILES GUI/Common ${COMMON_SRC_FILES})
 prepend(COMMON_INC_FILES GUI/Common ${COMMON_INC_FILES})
-prepend(COMMON_MOC_FILES GUI/Common ${COMMON_MOC_FILES})
 
 set(COMMON_SRC_FILES
     ${COMMON_SRC_FILES}
@@ -26,9 +21,5 @@ set(COMMON_SRC_FILES
 )
 set(COMMON_INC_FILES
     ${COMMON_INC_FILES}
-    PARENT_SCOPE
-)
-set(COMMON_MOC_FILES
-    ${COMMON_MOC_FILES}
     PARENT_SCOPE
 )

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewJobManager.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewJobManager.cpp
@@ -9,8 +9,8 @@
 #include "GUI/Batch/IBatchJobAlgorithm.h"
 #include "GUI/Batch/IReflAlgorithmFactory.h"
 #include "GUI/Batch/ReflAlgorithmFactory.h"
-#include "GUI/Common/IJobRunner.h"
 #include "MantidQtWidgets/Common/BatchAlgorithmRunner.h"
+#include "MantidQtWidgets/Common/IJobRunner.h"
 #include "Reduction/Item.h"
 
 #include <memory>
@@ -42,7 +42,7 @@ namespace MantidQt::CustomInterfaces::ISISReflectometry {
 
 using MantidQt::API::IConfiguredAlgorithm_sptr;
 
-PreviewJobManager::PreviewJobManager(std::unique_ptr<IJobRunner> jobRunner,
+PreviewJobManager::PreviewJobManager(std::unique_ptr<API::IJobRunner> jobRunner,
                                      std::unique_ptr<IReflAlgorithmFactory> algFactory)
     : m_jobRunner(std::move(jobRunner)), m_algFactory(std::move(algFactory)) {
   m_jobRunner->subscribe(this);

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewJobManager.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewJobManager.h
@@ -9,16 +9,16 @@
 #include "Common/DllConfig.h"
 #include "GUI/Batch/IReflAlgorithmFactory.h"
 #include "GUI/Common/IJobManager.h"
-#include "GUI/Common/IJobRunner.h"
+#include "MantidQtWidgets/Common/IJobRunner.h"
 
 #include <memory>
 
 namespace MantidQt::CustomInterfaces::ISISReflectometry {
 class IBatch;
 
-class MANTIDQT_ISISREFLECTOMETRY_DLL PreviewJobManager final : public IJobManager, public JobRunnerSubscriber {
+class MANTIDQT_ISISREFLECTOMETRY_DLL PreviewJobManager final : public IJobManager, public API::JobRunnerSubscriber {
 public:
-  PreviewJobManager(std::unique_ptr<IJobRunner> jobRunner, std::unique_ptr<IReflAlgorithmFactory> algFactory);
+  PreviewJobManager(std::unique_ptr<API::IJobRunner> jobRunner, std::unique_ptr<IReflAlgorithmFactory> algFactory);
 
   // IJobManager overrides
   void subscribe(JobManagerSubscriber *notifyee) override;
@@ -34,7 +34,7 @@ public:
   void notifyAlgorithmError(API::IConfiguredAlgorithm_sptr, std::string const &) override;
 
 private:
-  std::unique_ptr<IJobRunner> m_jobRunner;
+  std::unique_ptr<API::IJobRunner> m_jobRunner;
   std::unique_ptr<IReflAlgorithmFactory> m_algFactory;
   JobManagerSubscriber *m_notifyee;
 

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenterFactory.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenterFactory.h
@@ -6,11 +6,11 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 #pragma once
 #include "Common/DllConfig.h"
-#include "GUI/Common/QtJobRunner.h"
 #include "IPreviewModel.h"
 #include "IPreviewPresenter.h"
 #include "IPreviewView.h"
 #include "InstViewModel.h"
+#include "MantidQtWidgets/Common/QtJobRunner.h"
 #include "PreviewJobManager.h"
 #include "PreviewModel.h"
 #include "PreviewPresenter.h"
@@ -23,7 +23,7 @@ public:
   PreviewPresenterFactory() = default;
 
   std::unique_ptr<IPreviewPresenter> make(IPreviewView *view, std::unique_ptr<IReflAlgorithmFactory> algFactory) {
-    auto jobRunner = std::make_unique<QtJobRunner>();
+    auto jobRunner = std::make_unique<MantidQt::API::QtJobRunner>();
     auto jobManager = std::make_unique<PreviewJobManager>(std::move(jobRunner), std::move(algFactory));
     auto dependencies = PreviewPresenter::Dependencies{view, std::make_unique<PreviewModel>(), std::move(jobManager),
                                                        std::make_unique<InstViewModel>()};

--- a/qt/scientific_interfaces/ISISReflectometry/test/Batch/BatchPresenterTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Batch/BatchPresenterTest.h
@@ -14,6 +14,7 @@
 #include "../ReflMockObjects.h"
 #include "MantidAPI/FrameworkManager.h"
 #include "MantidKernel/WarningSuppressions.h"
+#include "MantidQtWidgets/Common/MockJobRunner.h"
 #include "MockBatchView.h"
 
 #include <cxxtest/TestSuite.h>
@@ -592,7 +593,8 @@ private:
     friend class BatchPresenterTest;
 
   public:
-    BatchPresenterFriend(IBatchView *view, std::unique_ptr<IBatch> model, std::unique_ptr<IJobRunner> jobRunner,
+    BatchPresenterFriend(IBatchView *view, std::unique_ptr<IBatch> model,
+                         std::unique_ptr<MantidQt::API::IJobRunner> jobRunner,
                          std::unique_ptr<IRunsPresenter> runsPresenter, std::unique_ptr<IEventPresenter> eventPresenter,
                          std::unique_ptr<IExperimentPresenter> experimentPresenter,
                          std::unique_ptr<IInstrumentPresenter> instrumentPresenter,

--- a/qt/scientific_interfaces/ISISReflectometry/test/Preview/PreviewJobManagerTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Preview/PreviewJobManagerTest.h
@@ -10,6 +10,7 @@
 #include "MantidFrameworkTestHelpers/WorkspaceCreationHelper.h"
 #include "MantidQtWidgets/Common/AlgorithmRuntimeProps.h"
 #include "MantidQtWidgets/Common/BatchAlgorithmRunner.h"
+#include "MantidQtWidgets/Common/MockJobRunner.h"
 #include "PreviewJobManager.h"
 
 #include "test/Batch/BatchJobManagerTest.h"

--- a/qt/scientific_interfaces/ISISReflectometry/test/ReflMockObjects.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/ReflMockObjects.h
@@ -14,7 +14,6 @@
 #include "GUI/Common/IEncoder.h"
 #include "GUI/Common/IFileHandler.h"
 #include "GUI/Common/IJobManager.h"
-#include "GUI/Common/IJobRunner.h"
 #include "GUI/Common/IPlotter.h"
 #include "GUI/Common/IPythonRunner.h"
 #include "GUI/Common/IReflMessageHandler.h"
@@ -286,15 +285,6 @@ public:
   MOCK_METHOD1(loadJSONFromFile, QMap<QString, QVariant>(const std::string &));
   MOCK_CONST_METHOD2(saveCSVToFile, void(std::string const &, std::string const &));
   MOCK_CONST_METHOD1(fileExists, bool(std::string const &));
-};
-
-class MockJobRunner : public IJobRunner {
-public:
-  MOCK_METHOD1(subscribe, void(JobRunnerSubscriber *));
-  MOCK_METHOD0(clearAlgorithmQueue, void());
-  MOCK_METHOD1(setAlgorithmQueue, void(std::deque<MantidQt::API::IConfiguredAlgorithm_sptr>));
-  MOCK_METHOD0(executeAlgorithmQueue, void());
-  MOCK_METHOD0(cancelAlgorithmQueue, void());
 };
 
 class MockJobManager : public IJobManager {

--- a/qt/widgets/common/CMakeLists.txt
+++ b/qt/widgets/common/CMakeLists.txt
@@ -86,6 +86,7 @@ set(SRC_FILES
     src/PropertyWidget.cpp
     src/PropertyWidgetFactory.cpp
     src/PythonRunner.cpp
+    src/QtJobRunner.cpp
     src/QtSignalChannel.cpp
     src/QtJSONUtils.cpp
     src/RenameParDialog.cpp
@@ -209,6 +210,7 @@ set(QT5_MOC_FILES
     inc/MantidQtWidgets/Common/PropertyHandler.h
     inc/MantidQtWidgets/Common/PropertyWidget.h
     inc/MantidQtWidgets/Common/PythonRunner.h
+    inc/MantidQtWidgets/Common/QtJobRunner.h
     inc/MantidQtWidgets/Common/QtSignalChannel.h
     inc/MantidQtWidgets/Common/RenameParDialog.h
     inc/MantidQtWidgets/Common/RepoModel.h
@@ -281,6 +283,7 @@ set(QT5_INC_FILES
     inc/MantidQtWidgets/Common/IFitScriptGeneratorPresenter.h
     inc/MantidQtWidgets/Common/IFunctionBrowser.h
     inc/MantidQtWidgets/Common/IFunctionView.h
+    inc/MantidQtWidgets/Common/IJobRunner.h
     inc/MantidQtWidgets/Common/ImageInfoModel.h
     inc/MantidQtWidgets/Common/IImageInfoWidget.h
     inc/MantidQtWidgets/Common/ImageInfoModelMatrixWS.h
@@ -291,6 +294,7 @@ set(QT5_INC_FILES
     inc/MantidQtWidgets/Common/LogValueFinder.h
     inc/MantidQtWidgets/Common/MantidDesktopServices.h
     inc/MantidQtWidgets/Common/MantidTreeWidgetItem.h
+    inc/MantidQtWidgets/Common/MockJobRunner.h
     inc/MantidQtWidgets/Common/MultifitSetupDialog.h
     inc/MantidQtWidgets/Common/MuonPeriodInfo.h
     inc/MantidQtWidgets/Common/ParseKeyValueString.h

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/IJobRunner.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/IJobRunner.h
@@ -6,7 +6,7 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 #pragma once
 
-#include "Common/DllConfig.h"
+#include "DllOption.h"
 
 #include <deque>
 #include <memory>
@@ -15,15 +15,12 @@
 namespace MantidQt::API {
 class IConfiguredAlgorithm;
 using IConfiguredAlgorithm_sptr = std::shared_ptr<IConfiguredAlgorithm>;
-} // namespace MantidQt::API
-
-namespace MantidQt::CustomInterfaces::ISISReflectometry {
 
 /** @class JobRunnerSubscriber
  *
  * JobRunnerSubscriber is an interface to a class that subscribes to notifications from an IJobRunner
  */
-class MANTIDQT_ISISREFLECTOMETRY_DLL JobRunnerSubscriber {
+class EXPORT_OPT_MANTIDQT_COMMON JobRunnerSubscriber {
 public:
   virtual ~JobRunnerSubscriber() = default;
 
@@ -38,7 +35,7 @@ public:
  *
  * IJobRunner is an interface to a class that provides functionality to run a batch algorithm queue
  */
-class MANTIDQT_ISISREFLECTOMETRY_DLL IJobRunner {
+class EXPORT_OPT_MANTIDQT_COMMON IJobRunner {
 public:
   virtual ~IJobRunner() = default;
   virtual void subscribe(JobRunnerSubscriber *notifyee) = 0;
@@ -47,4 +44,4 @@ public:
   virtual void executeAlgorithmQueue() = 0;
   virtual void cancelAlgorithmQueue() = 0;
 };
-} // namespace MantidQt::CustomInterfaces::ISISReflectometry
+} // namespace MantidQt::API

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/MockJobRunner.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/MockJobRunner.h
@@ -1,0 +1,26 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2023 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#pragma once
+
+#include "MantidKernel/WarningSuppressions.h"
+#include "MantidQtWidgets/Common/IJobRunner.h"
+
+#include <gmock/gmock.h>
+#include <memory>
+
+GNU_DIAG_OFF_SUGGEST_OVERRIDE
+
+class MockJobRunner : public MantidQt::API::IJobRunner {
+public:
+  MOCK_METHOD1(subscribe, void(MantidQt::API::JobRunnerSubscriber *));
+  MOCK_METHOD0(clearAlgorithmQueue, void());
+  MOCK_METHOD1(setAlgorithmQueue, void(std::deque<MantidQt::API::IConfiguredAlgorithm_sptr>));
+  MOCK_METHOD0(executeAlgorithmQueue, void());
+  MOCK_METHOD0(cancelAlgorithmQueue, void());
+};
+
+GNU_DIAG_ON_SUGGEST_OVERRIDE

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/QtJobRunner.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/QtJobRunner.h
@@ -6,7 +6,7 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 #pragma once
 
-#include "Common/DllConfig.h"
+#include "DllOption.h"
 #include "IJobRunner.h"
 #include "MantidAPI/IAlgorithm_fwd.h"
 #include "MantidQtWidgets/Common/BatchAlgorithmRunner.h"
@@ -14,10 +14,10 @@
 #include <deque>
 #include <vector>
 
-namespace MantidQt::CustomInterfaces::ISISReflectometry {
+namespace MantidQt::API {
 class JobRunnerSubscriber;
 
-class MANTIDQT_ISISREFLECTOMETRY_DLL QtJobRunner : public QWidget, public IJobRunner {
+class EXPORT_OPT_MANTIDQT_COMMON QtJobRunner : public QWidget, public IJobRunner {
   Q_OBJECT
 public:
   QtJobRunner();
@@ -39,4 +39,4 @@ private:
   JobRunnerSubscriber *m_notifyee;
   void connectBatchAlgoRunnerSlots();
 };
-} // namespace MantidQt::CustomInterfaces::ISISReflectometry
+} // namespace MantidQt::API

--- a/qt/widgets/common/inc/MantidQtWidgets/Common/QtJobRunner.h
+++ b/qt/widgets/common/inc/MantidQtWidgets/Common/QtJobRunner.h
@@ -10,14 +10,16 @@
 #include "IJobRunner.h"
 #include "MantidAPI/IAlgorithm_fwd.h"
 #include "MantidQtWidgets/Common/BatchAlgorithmRunner.h"
-#include <QWidget>
+
+#include <QObject>
+
 #include <deque>
 #include <vector>
 
 namespace MantidQt::API {
 class JobRunnerSubscriber;
 
-class EXPORT_OPT_MANTIDQT_COMMON QtJobRunner : public QWidget, public IJobRunner {
+class EXPORT_OPT_MANTIDQT_COMMON QtJobRunner : public QObject, public IJobRunner {
   Q_OBJECT
 public:
   QtJobRunner();

--- a/qt/widgets/common/src/QtJobRunner.cpp
+++ b/qt/widgets/common/src/QtJobRunner.cpp
@@ -5,14 +5,14 @@
 //   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 // SPDX - License - Identifier: GPL - 3.0 +
 
-#include "QtJobRunner.h"
-#include "GUI/Common/IJobRunner.h"
+#include "MantidQtWidgets/Common/QtJobRunner.h"
 #include "MantidQtWidgets/Common/BatchAlgorithmRunner.h"
 #include "MantidQtWidgets/Common/IConfiguredAlgorithm.h"
+#include "MantidQtWidgets/Common/IJobRunner.h"
 
 using namespace MantidQt::API;
 
-namespace MantidQt::CustomInterfaces::ISISReflectometry {
+namespace MantidQt::API {
 
 QtJobRunner::QtJobRunner() : QWidget(), m_batchAlgoRunner(this) {
   qRegisterMetaType<API::IConfiguredAlgorithm_sptr>("MantidQt::API::IConfiguredAlgorithm_sptr");
@@ -59,4 +59,4 @@ void QtJobRunner::onAlgorithmError(API::IConfiguredAlgorithm_sptr algorithm, con
   m_notifyee->notifyAlgorithmError(algorithm, message);
 }
 
-} // namespace MantidQt::CustomInterfaces::ISISReflectometry
+} // namespace MantidQt::API

--- a/qt/widgets/common/src/QtJobRunner.cpp
+++ b/qt/widgets/common/src/QtJobRunner.cpp
@@ -14,7 +14,7 @@ using namespace MantidQt::API;
 
 namespace MantidQt::API {
 
-QtJobRunner::QtJobRunner() : QWidget(), m_batchAlgoRunner(this) {
+QtJobRunner::QtJobRunner() : QObject(), m_batchAlgoRunner(this) {
   qRegisterMetaType<API::IConfiguredAlgorithm_sptr>("MantidQt::API::IConfiguredAlgorithm_sptr");
   m_batchAlgoRunner.stopOnFailure(false);
   connectBatchAlgoRunnerSlots();


### PR DESCRIPTION
**Description of work.**
This PR moves the `QtJobRunner` and `IJobRunner` classes used by the Reflectometry interface to a more common location so that they can be used by the ALFView.

**To test:**
Make sure Mantid builds, and in particular the Reflectometry target
Make sure the tests pass
Give the Reflectometry interface a quick manual test. The BatchPresenter and PreviewPresenter should still be executing algorithms asynchronously

Part of #35184

*This does not require release notes* because **its an internal change**


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
