### PR TITLE
Add method to have a replacing intersection method

### DIFF
--- a/Framework/Kernel/inc/MantidKernel/TimeROI.h
+++ b/Framework/Kernel/inc/MantidKernel/TimeROI.h
@@ -38,6 +38,7 @@ public:
   void replaceROI(const TimeROI &other);
   void update_union(const TimeROI &other);
   void update_intersection(const TimeROI &other);
+  void update_or_replace_intersection(const TimeROI &other);
   const Kernel::SplittingIntervalVec toSplitters() const;
   bool operator==(const TimeROI &other) const;
   void debugPrint(const std::size_t type = 0) const;

--- a/Framework/Kernel/test/TimeROITest.h
+++ b/Framework/Kernel/test/TimeROITest.h
@@ -293,6 +293,22 @@ public:
 
   void test_intersection_no_overlap() { runIntersectionTest(CHRISTMAS, TimeROI{NEW_YEARS_START, NEW_YEARS_STOP}, 0.); }
 
+  void test_intersection_one_empty() { runIntersectionTest(CHRISTMAS, TimeROI(), 0.); }
+
+  /*
+   * This test is similar to test_intersection_one_empty, except the function that is called will replace the TimeROI
+   * with the non-empty one.
+   */
+  void test_replace_intersection() {
+    TimeROI one(CHRISTMAS);
+    one.update_or_replace_intersection(TimeROI());
+    TS_ASSERT_EQUALS(one.durationInSeconds() / ONE_DAY_DURATION, CHRISTMAS.durationInSeconds() / ONE_DAY_DURATION);
+
+    TimeROI two;
+    two.update_or_replace_intersection(CHRISTMAS);
+    TS_ASSERT_EQUALS(two.durationInSeconds() / ONE_DAY_DURATION, CHRISTMAS.durationInSeconds() / ONE_DAY_DURATION);
+  }
+
   void runUnionTest(const TimeROI &left, const TimeROI &right, const double exp_duration) {
     // left union with right
     TimeROI one(left);
@@ -321,4 +337,6 @@ public:
   void test_union_no_overlap() {
     runUnionTest(CHRISTMAS, TimeROI{NEW_YEARS_START, NEW_YEARS_STOP}, 2. * ONE_DAY_DURATION);
   }
+
+  void test_union_one_empty() { runUnionTest(CHRISTMAS, TimeROI(), CHRISTMAS.durationInSeconds()); }
 };


### PR DESCRIPTION
Add a new method `TimeROI::update_or_replace_intersection()` for use in the larger event filtering work. There is no equivalent for union because it already does the same thing for empty `TimeROI`.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**

<!-- Instructions for testing. -->

Refs #34794

*This does not require release notes* because it is an internal change for other code to use.

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
