### PR TITLE
Added control for index overflow in isMonitor methods

### DIFF
--- a/Framework/API/test/DetectorInfoTest.h
+++ b/Framework/API/test/DetectorInfoTest.h
@@ -84,6 +84,7 @@ public:
     TS_ASSERT_EQUALS(detectorInfo.isMonitor(2), false);
     TS_ASSERT_EQUALS(detectorInfo.isMonitor(3), true);
     TS_ASSERT_EQUALS(detectorInfo.isMonitor(4), true);
+    TS_ASSERT_THROWS(detectorInfo.isMonitor(5), const std::runtime_error &);
   }
 
   void test_isMasked() {

--- a/Framework/Beamline/src/DetectorInfo.cpp
+++ b/Framework/Beamline/src/DetectorInfo.cpp
@@ -10,7 +10,6 @@
 
 #include <algorithm>
 #include <exception>
-#include <iostream>
 
 namespace Mantid::Beamline {
 
@@ -91,6 +90,7 @@ bool DetectorInfo::isMonitor(const size_t index) const {
   if (index >= m_isMonitor->size()) {
     throw std::runtime_error("Invalid monitor index");
   }
+  // No check for time dependence since monitor flags are not time dependent.
   return (*m_isMonitor)[index];
 }
 

--- a/Framework/Beamline/src/DetectorInfo.cpp
+++ b/Framework/Beamline/src/DetectorInfo.cpp
@@ -9,6 +9,8 @@
 #include "MantidKernel/make_cow.h"
 
 #include <algorithm>
+#include <exception>
+#include <iostream>
 
 namespace Mantid::Beamline {
 
@@ -86,7 +88,9 @@ bool DetectorInfo::isEquivalent(const DetectorInfo &other) const {
 
 /// Returns true if the detector with given detector index is a monitor.
 bool DetectorInfo::isMonitor(const size_t index) const {
-  // No check for time dependence since monitor flags are not time dependent.
+  if (index >= m_isMonitor->size()) {
+    throw std::runtime_error("Invalid monitor index");
+  }
   return (*m_isMonitor)[index];
 }
 
@@ -95,6 +99,9 @@ bool DetectorInfo::isMonitor(const size_t index) const {
  * The time component of the index is ignored since a detector is a monitor
  * either for *all* times or for *none*. */
 bool DetectorInfo::isMonitor(const std::pair<size_t, size_t> &index) const {
+  if (index.first >= m_isMonitor->size()) {
+    throw std::runtime_error("Invalid monitor index");
+  }
   // Monitors are not time dependent, ignore time component of index.
   return (*m_isMonitor)[index.first];
 }

--- a/Framework/Beamline/test/DetectorInfoTest.h
+++ b/Framework/Beamline/test/DetectorInfoTest.h
@@ -178,6 +178,7 @@ public:
     TS_ASSERT(info.isMonitor(0));
     TS_ASSERT(!info.isMonitor(1));
     TS_ASSERT(info.isMonitor(2));
+    TS_ASSERT_THROWS(info.isMonitor(3), const std::runtime_error &)
   }
 
   void test_duplicate_monitors_ignored() {

--- a/Framework/DataHandling/test/LoadILLDiffractionTest.h
+++ b/Framework/DataHandling/test/LoadILLDiffractionTest.h
@@ -284,8 +284,9 @@ public:
     TS_ASSERT_EQUALS(outputWS->getNumberHistograms(), 3073 * nScans)
     TS_ASSERT_EQUALS(outputWS->blocksize(), 1)
     TS_ASSERT(outputWS->detectorInfo().isMonitor(0))
-    TS_ASSERT(!outputWS->detectorInfo().isMonitor(nScans + 1))
-    TS_ASSERT(!outputWS->detectorInfo().isMonitor(3073))
+    for (int i = 1; i < 3072; i++) {
+      TS_ASSERT(!outputWS->detectorInfo().isMonitor(i))
+    }
     TS_ASSERT(!outputWS->isHistogramData())
     TS_ASSERT(!outputWS->isDistribution())
 
@@ -355,7 +356,9 @@ public:
     TS_ASSERT_EQUALS(outputWS->getNumberHistograms(), 16385 * 25) // 25 step scan
     TS_ASSERT_EQUALS(outputWS->blocksize(), 1)
     TS_ASSERT(outputWS->detectorInfo().isMonitor(0))
-    TS_ASSERT(!outputWS->detectorInfo().isMonitor(16385 * 25))
+    for (int i = 1; i < 16385; i++) {
+      TS_ASSERT(!outputWS->detectorInfo().isMonitor(i))
+    }
     TS_ASSERT(!outputWS->isHistogramData())
     TS_ASSERT(!outputWS->isDistribution())
     const auto &run = outputWS->run();
@@ -512,7 +515,9 @@ public:
     TS_ASSERT_EQUALS(outputWS->getNumberHistograms(), 16385)
     TS_ASSERT_EQUALS(outputWS->blocksize(), 1)
     TS_ASSERT(outputWS->detectorInfo().isMonitor(0))
-    TS_ASSERT(!outputWS->detectorInfo().isMonitor(16385))
+    for (int i = 1; i < 16385; i++) {
+      TS_ASSERT(!outputWS->detectorInfo().isMonitor(i))
+    }
     TS_ASSERT(!outputWS->isHistogramData())
     TS_ASSERT(!outputWS->isDistribution())
     const auto run = outputWS->run();
@@ -560,7 +565,9 @@ public:
     TS_ASSERT_EQUALS(outputWS->getNumberHistograms(), NUMBER_OF_TUBES + NUMBER_OF_MONITORS)
     TS_ASSERT_EQUALS(outputWS->blocksize(), 1)
     TS_ASSERT(outputWS->detectorInfo().isMonitor(0))
-    TS_ASSERT(!outputWS->detectorInfo().isMonitor(NUMBER_OF_TUBES + NUMBER_OF_MONITORS))
+    for (int i = 1; i < 1280; i++) {
+      TS_ASSERT(!outputWS->detectorInfo().isMonitor(i))
+    }
     TS_ASSERT(!outputWS->isHistogramData())
     TS_ASSERT(!outputWS->isDistribution())
 

--- a/docs/source/release/v6.7.0/Framework/Beamline/BugFixes/35227.rst
+++ b/docs/source/release/v6.7.0/Framework/Beamline/BugFixes/35227.rst
@@ -1,0 +1,1 @@
+- Added throw statement in case of index overflow in isMonitor methods


### PR DESCRIPTION
In `Framework/Beamline/src/DetectorInfo.cpp file`, we noticed that no control was made about index overflow in both `isMonitor` methods. 

This can lead to random behavior depending on the memory state when an index overflow occurs (i.e. index exceeds the size of `m_monitor` array).

In that PR, we setup controls on index overflow in `isMonitor` methods throwing a `std::runtime_error` in case of overflow. We also improved the unit tests by adding throw assertions in case of index overflow.