### PR TITLE
Add cmake preset for windows ninja ci

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -77,20 +77,13 @@
     },
     {
       "name": "win-64-ci-ninja",
-      "vendor": {
-        "microsoft.com/VisualStudioSettings/CMake/1.0": {
-          "cacheRoot": "${sourceDir}/build"
-        }
-      },
       "description": "Build options for a CI build on windows with Ninja",
       "inherits": [
         "ci-default",
         "conda"
       ],
-      "cmakeExecutable": "cmake.exe",
       "cacheVariables": {
         "USE_PRECOMPILED_HEADERS": "OFF",
-        "CMAKE_MAKE_PROGRAM": "ninja.exe"
       }
     },
     {

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -76,6 +76,23 @@
       "generator": "Visual Studio 16 2019"
     },
     {
+      "name": "win-64-ci-ninja",
+      "vendor": {
+        "microsoft.com/VisualStudioSettings/CMake/1.0": {
+          "cacheRoot": "${sourceDir}/build"
+        }
+      },
+      "description": "Build options for a CI build on windows with Ninja",
+      "inherits": [
+        "ci-default",
+        "conda"
+      ],
+      "cacheVariables": {
+        "USE_PRECOMPILED_HEADERS": "OFF",
+        "CMAKE_MAKE_PROGRAM": "ninja.exe"
+      }
+    },
+    {
       "name": "cppcheck-ci",
       "description": "Build options for CppCheck CI build",
       "inherits": [

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -87,6 +87,7 @@
         "ci-default",
         "conda"
       ],
+      "cmakeExecutable": "cmake.exe",
       "cacheVariables": {
         "USE_PRECOMPILED_HEADERS": "OFF",
         "CMAKE_MAKE_PROGRAM": "ninja.exe"

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -83,7 +83,7 @@
         "conda"
       ],
       "cacheVariables": {
-        "USE_PRECOMPILED_HEADERS": "OFF",
+        "USE_PRECOMPILED_HEADERS": "OFF"
       }
     },
     {

--- a/buildconfig/Jenkins/Conda/run-tests
+++ b/buildconfig/Jenkins/Conda/run-tests
@@ -58,7 +58,12 @@ function onexit {
 # Prevent race conditions when creating the user config directory
 if [[ $OSTYPE == "msys"* ]]; then
     userconfig_dir=$APPDATA/mantidproject/mantid
-    userprops=$WORKSPACE/build/bin/Release/Mantid.user.properties
+    if [ -d "$WORKSPACE/build/bin/Release" ]; then
+        binary_dir=$WORKSPACE/build/bin/Release
+    else
+        binary_dir=$WORKSPACE/build/bin
+    fi
+    userprops=$binary_dir/Mantid.user.properties
     workbench_ini=$APPDATA/mantidproject/mantidworkbench.ini
 else
     userconfig_dir=$HOME/.mantid


### PR DESCRIPTION
**Description of work.**

This PR adds a new `cmake` preset `win-64-ci-ninja` to enable the use of `ninja` as the generator when building in our CI pipelines.

In addition, the `run-tests` script has been edited to reflect the fact `Ninja` does not place binaries in a `Release` sub-directory of the binary directory.

**To test:**

- Observe the tests related to this PR pass (using `win-64-ci` preset)
- Observe this job has been successful (using `win-64-ci-ninja` preset) https://builds.mantidproject.org/job/pull_requests-conda-windows-cloud/59/

Resolves #34490

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
