### PR TITLE
Avoid calling OpenGL functions too early in Instrument View

### DIFF
--- a/qt/widgets/instrumentview/src/InstrumentWidget.cpp
+++ b/qt/widgets/instrumentview/src/InstrumentWidget.cpp
@@ -190,9 +190,6 @@ InstrumentWidget::InstrumentWidget(QString wsName, QWidget *parent, bool resetGe
                                  Q_ARG(bool, resetGeometry), Q_ARG(bool, setDefaultView));
   }
 
-  // Background colour
-  setBackgroundColor(settings.value("BackgroundColor", QColor(0, 0, 0, 1.0)).value<QColor>());
-
   // Create the b=tabs
   createTabs(settings, customizations);
 
@@ -580,19 +577,21 @@ void InstrumentWidget::setSurfaceType(int type) {
     bool showPeakRow = true;
     bool showPeakLabels = true;
     bool showPeakRelativeIntensity = true;
+    QColor backgroundColor;
     if (surface) {
       peakLabelPrecision = surface->getPeakLabelPrecision();
       showPeakRow = surface->getShowPeakRowsFlag();
       showPeakLabels = surface->getShowPeakLabelsFlag();
+      backgroundColor = surface->getBackgroundColor();
     } else {
       QSettings settings;
       settings.beginGroup(InstrumentWidgetSettingsGroup);
       peakLabelPrecision = settings.value("PeakLabelPrecision", 2).toInt();
       showPeakRow = settings.value("ShowPeakRows", true).toBool();
       showPeakLabels = settings.value("ShowPeakLabels", true).toBool();
-
       // By default this is should be off for now.
       showPeakRelativeIntensity = settings.value("ShowPeakRelativeIntensities", false).toBool();
+      backgroundColor = settings.value("BackgroundColor", QColor(0, 0, 0, 1.0)).value<QColor>();
       settings.endGroup();
     }
 
@@ -654,6 +653,7 @@ void InstrumentWidget::setSurfaceType(int type) {
     surface->setShowPeakRowsFlag(showPeakRow);
     surface->setShowPeakLabelsFlag(showPeakLabels);
     surface->setShowPeakRelativeIntensityFlag(showPeakRelativeIntensity);
+    surface->setBackgroundColor(backgroundColor);
     // set new surface
     setSurface(surface);
 

--- a/qt/widgets/instrumentview/src/Viewport.cpp
+++ b/qt/widgets/instrumentview/src/Viewport.cpp
@@ -301,6 +301,12 @@ void Viewport::setViewToZNegative() {
   adjustProjection();
 }
 
+/**
+ * Adjusts the current projection coordinates based on a any prevoius calls
+ * to change the view. Note that this does not issue any drawing commands
+ * it sets up the internal matrices for the next call to applyProjection
+ * by the view code.
+ */
 void Viewport::adjustProjection() {
   // reset the projection bounds to the original values
   m_left = m_leftOrig;
@@ -312,9 +318,6 @@ void Viewport::adjustProjection() {
 
   // rotate the original projection based on the new quaternion
   m_quaternion.rotateBB(m_left, m_bottom, m_zmin, m_right, m_top, m_zmax);
-
-  // update the GL projection with the new bounds
-  applyProjection();
 }
 
 /**

--- a/qt/widgets/instrumentview/test/InstrumentWidget/InstrumentWidgetTest.h
+++ b/qt/widgets/instrumentview/test/InstrumentWidget/InstrumentWidgetTest.h
@@ -372,8 +372,6 @@ private:
     ON_CALL(*displayMock, getGLDisplay()).WillByDefault(Return(glMock));
     ON_CALL(*displayMock, getQtDisplay()).WillByDefault(Return(qtMock));
 
-    EXPECT_CALL(*glMock, setBackgroundColor(_)).Times(1);
-
     auto surfaceMock = std::make_shared<MockProjectionSurface>();
     EXPECT_CALL(*glMock, currentBackgroundColor()).Times(1);
 


### PR DESCRIPTION
**Description of work.**

#35104 replaced `QGLWidget` with the more modern `QOpenGLWidget` but this is now more restrictive on where OpenGL calls can be made. If calls are made before `OpenGLWidget::initializeGL` then this can trigger OpenGL errors on some platforms (seen on Windows) that are actually benign but do not look it. This fixes the calls so they are all made after `initializeGL()`

Example errors that were seen:

```
OpenGL error detected in GLDisplay::setBackgroundColor: invalid operation
```

and specifically for any instrument that has a default view axis of something other than `Z+`:

![image](https://user-images.githubusercontent.com/733773/219595544-64fbe277-c77e-4d62-a1fa-a8843b828e5d.png)


<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**

* Load any raw data file and show the instrument. You should not see the `setBackgroundColor` error.
* Load an instrument with a default axis view that is not Z+, e.g. BILBY and see that there are no errors generated.
* Try operations like setting the background color and choosing a different axis view and check they still work.

*There is no associated issue.*

*This does not require release notes* because **this was a regression introduced in this dev cycle.**
<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
