### PR TITLE
Stop AbinsAdvancedParametersTest and AbinsCalculateSPowderTest from deleting themselves when run from PyCharm

### DIFF
--- a/Framework/PythonInterface/test/python/plugins/algorithms/AbinsAdvancedParametersTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/AbinsAdvancedParametersTest.py
@@ -52,7 +52,7 @@ class AbinsAdvancedParametersTest(unittest.TestCase):
         abins.parameters.performance = {"optimal_size": int(5e6), "threads": 1}
 
     def tearDown(self):
-        test_helpers.remove_output_files(list_of_names=["AbinsAdvanced"])
+        test_helpers.remove_output_files(list_of_names=["_AbinsAdvanced"])
         mtd.clear()
 
     def test_wrong_fwhm(self):
@@ -70,7 +70,6 @@ class AbinsAdvancedParametersTest(unittest.TestCase):
 
     # Tests for TOSCA parameters
     def test_wrong_tosca_final_energy(self):
-
         # final energy should be a float not str
         abins.parameters.instruments["TOSCA"]["final_neutron_energy"] = "0"
         self.assertRaises(RuntimeError, Abins, VibrationalOrPhononFile=self._Si2 + ".phonon", OutputWorkspace=self._wrk_name)
@@ -84,7 +83,6 @@ class AbinsAdvancedParametersTest(unittest.TestCase):
         self.assertRaises(RuntimeError, Abins, VibrationalOrPhononFile=self._Si2 + ".phonon", OutputWorkspace=self._wrk_name)
 
     def test_wrong_tosca_cos_scattering_angle(self):
-
         # cosines of scattering angle is float
         abins.parameters.instruments["TOSCA"]["cos_scattering_angle"] = "0.0334"
         self.assertRaises(RuntimeError, Abins, VibrationalOrPhononFile=self._Si2 + ".phonon", OutputWorkspace=self._wrk_name)

--- a/scripts/test/Abins/AbinsCalculateSPowderTest.py
+++ b/scripts/test/Abins/AbinsCalculateSPowderTest.py
@@ -40,7 +40,7 @@ class SCalculatorFactoryPowderTest(unittest.TestCase):
         self._instruments_defaults = deepcopy(abins.parameters.instruments)
 
     def tearDown(self):
-        abins.test_helpers.remove_output_files(list_of_names=["CalculateSPowder"])
+        abins.test_helpers.remove_output_files(list_of_names=["_CalculateSPowder"])
         abins.parameters.performance["threads"] = self.default_threads
         abins.parameters.instruments.update(self._instruments_defaults)
 
@@ -216,7 +216,6 @@ class SCalculatorFactoryPowderTest(unittest.TestCase):
         return correct_data
 
     def _check_data(self, good_data=None, data=None):
-
         for array_key in ("frequencies", "q_bins"):
             if good_data.get(array_key) is not None:
                 assert_almost_equal(good_data[array_key], data[array_key])


### PR DESCRIPTION
**Description of work.**

The Abins tests use a helper function called `remove_output_files` which aims to clean up any files made when running the test. It identifies which files to delete by finding all files in the default save directory which contain a substring passed to the function. When I ran these two tests from PyCharm (using the 'play' arrow by the class names) they ended up deleting themselves since the substrings were contained within their file names.

I've mimicked the other Abins tests and added an underscore to the front of the substring to stop this problem, but still clean up the test file(s).

**To test:**

Run `AbinsAdvancedParametersTest` and `AbinsCalculateSPowderTest` from PyCharm to check they run properly.

*There is no associated issue.*

*This does not require release notes* because **it changes a test**

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
