### PR TITLE
ReflectometryILL: fixes for normalisation issues

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ReflectometryILLPreprocess.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ReflectometryILLPreprocess.py
@@ -115,7 +115,6 @@ def normalisation_monitor_workspace_index(ws: MatrixWorkspace) -> int:
 
 
 class ReflectometryILLPreprocess(DataProcessorAlgorithm):
-
     _bragg_angle = None
     _theta_zero = None
     _instrument_name = None
@@ -744,7 +743,7 @@ class ReflectometryILLPreprocess(DataProcessorAlgorithm):
             scaled_ws = Scale(InputWorkspace=det_ws, OutputWorkspace=normalised_ws_name, Factor=1.0 / t, EnableLogging=self._subalgLogging)
             self._cleanup.cleanup(det_ws)
             return scaled_ws
-        return detWS
+        return det_ws
 
     def _normalise_to_slits(self, ws: MatrixWorkspace) -> MatrixWorkspace:
         """Normalize workspace to slit opening and update slit widths.

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ReflectometryILLPreprocess.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ReflectometryILLPreprocess.py
@@ -38,6 +38,7 @@ from mantid.simpleapi import (
     Minus,
     MoveInstrumentComponent,
     mtd,
+    NormaliseToMonitor,
     Scale,
     SpecularReflectionPositionCorrect,
     RebinToWorkspace,

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/ReflectometryILLPreprocessTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/ReflectometryILLPreprocessTest.py
@@ -118,6 +118,41 @@ class ReflectometryILLPreprocessTest(unittest.TestCase):
         self.assertEqual(outWS.getAxis(0).getUnit().caption(), "Wavelength")
         self.assertEqual(mtd.getObjectNames(), [])
 
+    def test_no_normalisation(self):
+        outWSName = "outWS"
+        args = {
+            "Run": "ILL/D17/317370.nxs",
+            "OutputWorkspace": outWSName,
+            "FluxNormalisation": "Normalisation OFF",
+            "rethrow": True,
+            "child": True,
+        }
+        alg = create_algorithm("ReflectometryILLPreprocess", **args)
+        assertRaisesNothing(self, alg.execute)
+        outWS = alg.getProperty("OutputWorkspace").value
+        self.assertEqual(outWS.getAxis(0).getUnit().caption(), "Wavelength")
+        self.assertEqual(mtd.getObjectNames(), [])
+        self.assertAlmostEqual(outWS.readY(69)[307], 5.240, 3)
+        self.assertAlmostEqual(outWS.readE(69)[307], 6.550, 3)
+
+    def test_time_normalisation(self):
+        outWSName = "outWS"
+        args = {
+            "Run": "ILL/D17/317370.nxs",
+            "OutputWorkspace": outWSName,
+            "FluxNormalisation": "Normalise To Time",
+            "rethrow": True,
+            "child": True,
+        }
+        alg = create_algorithm("ReflectometryILLPreprocess", **args)
+        assertRaisesNothing(self, alg.execute)
+        outWS = alg.getProperty("OutputWorkspace").value
+        self.assertEqual(outWS.getAxis(0).getUnit().caption(), "Wavelength")
+        self.assertEqual(mtd.getObjectNames(), [])
+        duration = outWS.getRun().getLogData("duration").value
+        self.assertAlmostEqual(outWS.readY(69)[307], 5.240 / duration, 3)
+        self.assertAlmostEqual(outWS.readE(69)[307], 6.550 / duration, 3)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/ReflectometryILLPreprocessTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/ReflectometryILLPreprocessTest.py
@@ -153,6 +153,23 @@ class ReflectometryILLPreprocessTest(unittest.TestCase):
         self.assertAlmostEqual(outWS.readY(69)[307], 5.240 / duration, 3)
         self.assertAlmostEqual(outWS.readE(69)[307], 6.550 / duration, 3)
 
+    def test_monitor_normalisation(self):
+        outWSName = "outWS"
+        args = {
+            "Run": "ILL/D17/317370.nxs",
+            "OutputWorkspace": outWSName,
+            "FluxNormalisation": "Normalise To Monitor",
+            "rethrow": True,
+            "child": True,
+        }
+        alg = create_algorithm("ReflectometryILLPreprocess", **args)
+        assertRaisesNothing(self, alg.execute)
+        outWS = alg.getProperty("OutputWorkspace").value
+        self.assertEqual(outWS.getAxis(0).getUnit().caption(), "Wavelength")
+        self.assertEqual(mtd.getObjectNames(), [])
+        self.assertAlmostEqual(outWS.readY(69)[307], 9.080e-07, 3)
+        self.assertAlmostEqual(outWS.readE(69)[307], 1.135e-06, 3)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/docs/source/release/v6.7.0/Reflectometry/Bugfixes/35277.rst
+++ b/docs/source/release/v6.7.0/Reflectometry/Bugfixes/35277.rst
@@ -1,0 +1,1 @@
+- Fixed two minor issues in :ref:`ReflectometryILLPreprocessing` blocking the normalisation to monitor for D17, and no normalisation for both Figaro and D17.


### PR DESCRIPTION
**Description of work.**

This PR fixes two minor issues with normalisation observed in the `ReflectometryILLPreprocess` algorithm. One is a variable name typo blocking no-normalisation case, and the other is a missing import of `NormaliseToMonitor` algorithm, which was blocking normalisation to monitor. Three new unit tests were added to cover these cases in the future.

**To test:**

1. Code review.
2. Test cases from the related issue.

Fixes #35277 . 

Release note mention added.

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
