### PR TITLE
Support multiple phases in GSAS tab

### DIFF
--- a/docs/source/release/v6.7.0/Diffraction/Engineering/New_features/35286.rst
+++ b/docs/source/release/v6.7.0/Diffraction/Engineering/New_features/35286.rst
@@ -1,0 +1,1 @@
+- It is now possible to load and plot multiple phases in the GSASII tab.

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/gsas2/call_G2sc.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/gsas2/call_G2sc.py
@@ -124,8 +124,7 @@ def export_refinement_to_csv(temp_save_directory, name_of_project, project):
 def export_reflections(temp_save_directory, name_of_project, project):
     for histogram_index, loop_histogram in enumerate(project.histograms()):
         loop_histogram_name = loop_histogram.name.replace(".gss", "").replace(" ", "_")
-        phase_names = [list(loop_histogram.reflections().keys())[0]]
-        for phase_name in phase_names:
+        for phase_name in loop_histogram.reflections().keys():
             reflection_positions = loop_histogram.reflections()[phase_name]["RefList"][:, 5]
             reflection_file_path = os.path.join(temp_save_directory, name_of_project + f"_reflections_{histogram_index+1}_{phase_name}.txt")
             with open(reflection_file_path, "wt", encoding="utf-8") as file:

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/gsas2/model.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/gsas2/model.py
@@ -928,17 +928,19 @@ class GSAS2Model(object):
         axis.plot(gsas_histogram, color="#09acb8", label="difference", wkspIndex=2)
         axis.plot(gsas_histogram, color="#ff0000", label="background", wkspIndex=3)
         _, y_max = axis.get_ylim()
-        if reflection_positions:
-            axis.plot(
-                reflection_positions,
-                [-0.10 * y_max] * len(reflection_positions),
-                color="#1105f0",
-                label="reflections",
-                linestyle="None",
-                marker="|",
-                mew=1.5,
-                ms=8,
-            )
+
+        for i_phase, positions in enumerate(reflection_positions):
+            if len(positions) > 0:
+                y_offset_positions = [(i_phase + 1) * -0.05 * y_max] * len(positions)
+                axis.plot(
+                    positions,
+                    y_offset_positions,
+                    label=f"reflections_{i_phase}",
+                    linestyle="None",
+                    marker="|",
+                    mew=1.5,
+                    ms=8,
+                )
         axis.set_xlabel("Time-of-flight ($\\mu s$)")
         axis.set_ylabel("Normalized Intensity")
         plt.show()

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/gsas2/model.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/gsas2/model.py
@@ -14,6 +14,8 @@ import json
 import matplotlib.pyplot as plt
 import numpy as np
 
+from typing import List
+
 from mantid.geometry import CrystalStructure, ReflectionGenerator, ReflectionConditionFilter
 from mantid.simpleapi import CreateWorkspace, LoadGSS, DeleteWorkspace, CreateEmptyTableWorkspace, Load, logger
 from mantid.api import AnalysisDataService as ADS
@@ -919,15 +921,17 @@ class GSAS2Model(object):
 
     def plot_result(self, index_histograms, axis):
         gsas_histogram_workspace, reflections = self.load_result_for_plot(index_histograms)
-        plot_window_title = self.plot_gsas_histogram(axis, gsas_histogram_workspace, reflections, index_histograms, self.data_files)
+        plot_window_title = self.plot_gsas_histogram(axis, gsas_histogram_workspace, reflections, index_histograms)
         return plot_window_title
 
-    def plot_gsas_histogram(self, axis, gsas_histogram, reflection_positions, histogram_index, data_file_list):
+    def plot_gsas_histogram(self, axis, gsas_histogram, reflection_positions, histogram_index):
         axis.plot(gsas_histogram, color="#1105f0", label="observed", linestyle="None", marker="+", wkspIndex=0)
         axis.plot(gsas_histogram, color="#246b01", label="calculated", wkspIndex=1)
         axis.plot(gsas_histogram, color="#09acb8", label="difference", wkspIndex=2)
         axis.plot(gsas_histogram, color="#ff0000", label="background", wkspIndex=3)
         _, y_max = axis.get_ylim()
+
+        reflection_labels = self._create_reflection_labels(reflection_positions)
 
         for i_phase, positions in enumerate(reflection_positions):
             if len(positions) > 0:
@@ -935,7 +939,7 @@ class GSAS2Model(object):
                 axis.plot(
                     positions,
                     y_offset_positions,
-                    label=f"reflections_{i_phase}",
+                    label=reflection_labels[i_phase],
                     linestyle="None",
                     marker="|",
                     mew=1.5,
@@ -946,9 +950,19 @@ class GSAS2Model(object):
         plt.show()
 
         input_file_name = ""
-        if data_file_list:
-            if len(data_file_list) == 1:
-                input_file_name = os.path.basename(data_file_list[0])
+        if self.data_files:
+            if len(self.data_files) == 1:
+                input_file_name = os.path.basename(self.data_files[0])
             else:
-                input_file_name = os.path.basename(data_file_list[histogram_index - 1])
+                input_file_name = os.path.basename(self.data_files[histogram_index - 1])
         return "GSAS-II Refinement " + input_file_name
+
+    def _create_reflection_labels(self, reflection_positions: List[np.array]) -> List[str]:
+        """Create the labels used to identify different phase reflection lists
+        The primary format, if the number of phase names equals the number of positions, is 'reflections_{phase_name}'
+        The fallback format is 'reflections_phase_{index}' where index starts at 1
+        """
+        reflection_labels = [f"reflections_{phase_name}" for phase_name in self.phase_names_list]
+        if len(reflection_labels) != len(reflection_positions):
+            return [f"reflections_phase_{i}" for i in range(1, len(reflection_positions) + 1)]
+        return reflection_labels

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/gsas2/test/test_gsas2_model.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/gsas2/test/test_gsas2_model.py
@@ -353,6 +353,24 @@ class TestGSAS2Model(unittest.TestCase):
             _try_delete(stem_user_dir)
             _try_delete(save_directory)
 
+    def test_create_reflection_labels_returns_a_primary_format_when_lists_match_size(self):
+        phase_names = ["Fe", "Fe_gamma"]
+        positions = [[1.0, 2.0], [3.0, 4.0]]
+
+        self.model.phase_names_list = phase_names
+        labels = self.model._create_reflection_labels(positions)
+
+        self.assertEqual(["reflections_Fe", "reflections_Fe_gamma"], labels)
+
+    def test_create_reflection_labels_returns_indexed_labels_when_positions_have_a_different_size(self):
+        phase_names = ["Fe", "Fe_gamma"]
+        positions = [[1.0, 2.0]]
+
+        self.model.phase_names_list = phase_names
+        labels = self.model._create_reflection_labels(positions)
+
+        self.assertEqual(["reflections_phase_1"], labels)
+
     def test_load_gsas_histogram(self):
         self.model.x_min = [20000]
         self.model.x_max = [21000]


### PR DESCRIPTION
**Description of work.**
This PR makes it possible to load multiple phases into the GSASII tab of the Engineering diffraction interface.

**To test:**
Enter a project name in the GSAS tab
Load the following data into the GSAS tab

Calibration C:/Users/mlc47243/Engineering_Mantid/Calibration/ENGINX_305738_all_banks.prm

Phases C:/Users/mlc47243/Documents/mantid-dev/mantid-2/mantid/scripts/Engineering/ENGINX/phase_info/FE_ALPHA.cif, C:/Users/mlc47243/Documents/mantid-dev/mantid-2/mantid/scripts/Engineering/ENGINX/phase_info/FE_GAMMA.cif

Focus C:/Users/mlc47243/Engineering_Mantid/Focus/ENGINX_305761_307521_all_banks_TOF.gss

Enter the Override Unit Cell Length to be 3.65

Click `Refine in GSAS II`

You should see a plot similar to the following:

![image](https://user-images.githubusercontent.com/40830825/220618637-09eacd28-c297-466e-93e2-5623e7e64210.png)


Fixes #34591

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
