### PR TITLE
Add coverity to conda build scripts

### DIFF
--- a/buildconfig/Jenkins/Conda/build
+++ b/buildconfig/Jenkins/Conda/build
@@ -21,8 +21,9 @@ ENABLE_DEV_DOCS=$4
 ENABLE_BUILD_CODE=$5
 ENABLE_UNIT_TESTS=$6
 ENABLE_SYSTEM_TESTS=$7
-EXTRA_CMAKE_FLAGS=$8
-BUILD_THREADS=$9
+ENABLE_COVERITY=$8
+EXTRA_CMAKE_FLAGS=$9
+BUILD_THREADS=${10}
 
 # Only pass MANTID_DATA_STORE to CMake if present in the environment otherwise rely on CMake default
 if [[ -n "${MANTID_DATA_STORE}" ]]; then
@@ -39,6 +40,22 @@ cmake --preset=${CMAKE_PRESET} ${MANTID_DATA_STORE_CMAKE} ${EXTRA_CMAKE_FLAGS} $
 
 # Run the actual builds for the code, unit tests, and system tests.
 cd $WORKSPACE/build
+
+if [[ $ENABLE_COVERITY == true ]]; then
+    ${COVERITY_DIR}/cov-build --dir cov-int cmake --build . $BUILD_OPTIONS
+    tar czvf mantid.tgz cov-int
+    status=$(curl --form token=$COVERITY_TOKEN --form email=mantidproject@gmail.com \
+		  --form file=@mantid.tgz --form version=$GIT_COMMIT \
+		  https://scan.coverity.com/builds?project=mantidproject%2Fmantid)
+    status=$(echo ${status} | sed -e 's/^ *//' -e 's/ *$//')
+    if [[ -z $status ]] || [[ ${status} == "Build successfully submitted." ]]; then
+        exit 0
+    else
+        echo "$status"
+        exit 1
+    fi
+fi
+
 if [[ $ENABLE_BUILD_CODE == true ]]; then
     cmake --build . $BUILD_OPTIONS
 fi

--- a/buildconfig/Jenkins/Conda/conda-buildscript
+++ b/buildconfig/Jenkins/Conda/conda-buildscript
@@ -21,6 +21,7 @@
 #   --enable-docs: Runs the docs from being built
 #   --enable-dev-docs: Runs the developer docs from being built
 #   --enable-doctests: Runs the documentation tests
+#   --enable-coverity: Runs coverity and submits results, ignore all other options and does not run unit tests
 #   --clean-build: Clears the build folder and builds from scratch
 #   --clean-external-projects: Clear the external projects from the build folder
 #   --use-core-dumps: Activate core dumps (Linux only)
@@ -60,6 +61,7 @@ ENABLE_PACKAGE=false
 ENABLE_DOCS=false
 ENABLE_DOC_TESTS=false
 ENABLE_DEV_DOCS=false
+ENABLE_COVERITY=false
 CLEAN_BUILD=false
 CLEAN_EXTERNAL_PROJECTS=false
 USE_CORE_DUMPS=false
@@ -74,6 +76,10 @@ do
         --enable-docs) ENABLE_DOCS=true ;;
         --enable-doctests) ENABLE_DOC_TESTS=true ;;
         --enable-dev-docs) ENABLE_DEV_DOCS=true ;;
+        --enable-coverity)
+	    ENABLE_COVERITY=true
+	    ENABLE_UNIT_TESTS=false
+	    ;;
         --clean-build) CLEAN_BUILD=true ;;
         --clean-external-projects) CLEAN_EXTERNAL_PROJECTS=true ;;
         --use-core-dumps) USE_CORE_DUMPS=true ;;
@@ -133,7 +139,7 @@ rm -f -- *.dmg *.rpm *.deb *.tar.gz *.tar.xz *.exe
 rm -rf  $BUILD_DIR/ctest_log
 
 # Run the script that handles the build
-$SCRIPT_DIR/build $WORKSPACE $CMAKE_PRESET $ENABLE_DOCS $ENABLE_DEV_DOCS $ENABLE_BUILD_CODE $ENABLE_UNIT_TESTS $ENABLE_SYSTEM_TESTS "$EXTRA_CMAKE_FLAGS" $BUILD_THREADS
+$SCRIPT_DIR/build $WORKSPACE $CMAKE_PRESET $ENABLE_DOCS $ENABLE_DEV_DOCS $ENABLE_BUILD_CODE $ENABLE_UNIT_TESTS $ENABLE_SYSTEM_TESTS $ENABLE_COVERITY "$EXTRA_CMAKE_FLAGS" $BUILD_THREADS
 
 # Run unit and system tests
 $SCRIPT_DIR/run-tests $WORKSPACE $ENABLE_SYSTEM_TESTS $ENABLE_UNIT_TESTS $ENABLE_DOCS $ENABLE_DOC_TESTS $BUILD_THREADS $USE_CORE_DUMPS


### PR DESCRIPTION
**Description of work.**

Get coverity running with the conda build.

FYI to setup coverity to find the conda compilers you need to run

```bash
cov-configure --template --comptype prefix --compiler ccache
cov-configure --template --comptype g++ --compiler x86_64-conda-linux-gnu-c++
cov-configure --template --template --comptype gcc --compiler x86_64-conda-linux-gnu-cc
```

**To test:**

Currently [coverity_build_and_submit](https://builds.mantidproject.org/job/coverity_build_and_submit/) points to my branch and it successfully ran [here](https://builds.mantidproject.org/job/coverity_build_and_submit/1510/)

Results can be seen at https://scan.coverity.com/projects/mantidproject-mantid

<!-- Instructions for testing. -->


*This does not require release notes* because internal change only

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
