### PR TITLE
Rename methods in TimeInterval to help cppcheck

### DIFF
--- a/Framework/Algorithms/src/FilterEvents.cpp
+++ b/Framework/Algorithms/src/FilterEvents.cpp
@@ -824,8 +824,8 @@ void FilterEvents::convertSplittersWorkspaceToVectors() {
   for (size_t i_splitter = 0; i_splitter < num_splitters; ++i_splitter) {
     // get splitter
     Kernel::SplittingInterval splitter = m_splitters[i_splitter];
-    int64_t start_time_i64 = splitter.begin().totalNanoseconds();
-    int64_t stop_time_i64 = splitter.end().totalNanoseconds();
+    int64_t start_time_i64 = splitter.start().totalNanoseconds();
+    int64_t stop_time_i64 = splitter.stop().totalNanoseconds();
     if (m_vecSplitterTime.empty()) {
       // first entry: add
       m_vecSplitterTime.emplace_back(start_time_i64);
@@ -1100,8 +1100,9 @@ void FilterEvents::createOutputWorkspacesSplitters() {
       if (descriptiveNames && splitByTime) {
         auto splitter = m_splitters[wsgroup];
         auto startTimeInSeconds =
-            Mantid::Types::Core::DateAndTime::secondsFromDuration(splitter.begin() - m_runStartTime);
-        auto stopTimeInSeconds = Mantid::Types::Core::DateAndTime::secondsFromDuration(splitter.end() - m_runStartTime);
+            Mantid::Types::Core::DateAndTime::secondsFromDuration(splitter.start() - m_runStartTime);
+        auto stopTimeInSeconds =
+            Mantid::Types::Core::DateAndTime::secondsFromDuration(splitter.stop() - m_runStartTime);
         wsname << startTimeInSeconds << "_" << stopTimeInSeconds;
       } else if (descriptiveNames) {
         auto infoiter = infomap.find(wsgroup);
@@ -1842,15 +1843,15 @@ void FilterEvents::generateSplitterTSPalpha(
     if (itarget >= static_cast<int>(split_tsp_vec.size()))
       throw std::runtime_error("Target workspace index is out of range!");
 
-    if (splitter.begin() == m_runStartTime) {
+    if (splitter.start() == m_runStartTime) {
       // there should be only 1 value in the splitter and clear it.
       if (split_tsp_vec[itarget]->size() != 1) {
         throw std::runtime_error("Splitter must have 1 value with initialization.");
       }
       split_tsp_vec[itarget]->clear();
     }
-    split_tsp_vec[itarget]->addValue(splitter.begin(), 1);
-    split_tsp_vec[itarget]->addValue(splitter.end(), 0);
+    split_tsp_vec[itarget]->addValue(splitter.start(), 1);
+    split_tsp_vec[itarget]->addValue(splitter.stop(), 0);
   }
 
   return;

--- a/Framework/Algorithms/test/GenerateEventsFilterTest.h
+++ b/Framework/Algorithms/test/GenerateEventsFilterTest.h
@@ -133,8 +133,8 @@ public:
     TS_ASSERT_EQUALS(splittersws->getNumberSplitters(), 1);
     Kernel::SplittingInterval splitter0 = splittersws->getSplitter(0);
     Types::Core::DateAndTime runstart(3000000000);
-    TS_ASSERT_EQUALS(splitter0.begin().totalNanoseconds(), runstart.totalNanoseconds() + 100);
-    TS_ASSERT_EQUALS(splitter0.end().totalNanoseconds(), runstart.totalNanoseconds() + 1000000);
+    TS_ASSERT_EQUALS(splitter0.start().totalNanoseconds(), runstart.totalNanoseconds() + 100);
+    TS_ASSERT_EQUALS(splitter0.stop().totalNanoseconds(), runstart.totalNanoseconds() + 1000000);
     TS_ASSERT_EQUALS(splitter0.index(), 0);
 
     TS_ASSERT_EQUALS(splittersws->rowCount(), 1);
@@ -195,19 +195,19 @@ public:
 
     // b) First interval
     Kernel::SplittingInterval splitter0 = splittersws->getSplitter(0);
-    TS_ASSERT_EQUALS(splitter0.begin().totalNanoseconds(), 0 + runstarttime_ns);
-    TS_ASSERT_EQUALS(splitter0.end().totalNanoseconds(), timeinterval_ns + runstarttime_ns);
+    TS_ASSERT_EQUALS(splitter0.start().totalNanoseconds(), 0 + runstarttime_ns);
+    TS_ASSERT_EQUALS(splitter0.stop().totalNanoseconds(), timeinterval_ns + runstarttime_ns);
     TS_ASSERT_EQUALS(splitter0.index(), 0);
 
     // c) Last interval
     Kernel::SplittingInterval splitterf = splittersws->getSplitter(numintervals - 1);
-    TS_ASSERT_EQUALS(splitterf.end(), runstoptime);
+    TS_ASSERT_EQUALS(splitterf.stop(), runstoptime);
     TS_ASSERT_EQUALS(splitterf.index(), numintervals - 1);
 
     // d) Randomly
     Kernel::SplittingInterval splitterR = splittersws->getSplitter(40);
-    Types::Core::DateAndTime t0 = splitterR.begin();
-    Types::Core::DateAndTime tf = splitterR.end();
+    Types::Core::DateAndTime t0 = splitterR.start();
+    Types::Core::DateAndTime tf = splitterR.stop();
     int64_t dt_ns = tf.totalNanoseconds() - t0.totalNanoseconds();
     TS_ASSERT_EQUALS(dt_ns, timeinterval_ns);
     int64_t dt_runtimestart = t0.totalNanoseconds() - runstarttime_ns;
@@ -262,19 +262,19 @@ public:
 
     // b) First interval
     Kernel::SplittingInterval splitter0 = splittersws->getSplitter(0);
-    TS_ASSERT_EQUALS(splitter0.begin().totalNanoseconds(), basetimeinterval_ns + runstarttime_ns);
-    TS_ASSERT_EQUALS(splitter0.end().totalNanoseconds(), basetimeinterval_ns * 2 + runstarttime_ns);
+    TS_ASSERT_EQUALS(splitter0.start().totalNanoseconds(), basetimeinterval_ns + runstarttime_ns);
+    TS_ASSERT_EQUALS(splitter0.stop().totalNanoseconds(), basetimeinterval_ns * 2 + runstarttime_ns);
     TS_ASSERT_EQUALS(splitter0.index(), 0);
 
     // c) Last interval
     Kernel::SplittingInterval splitterf = splittersws->getSplitter(numintervals - 1);
-    TS_ASSERT_EQUALS(splitterf.end().totalNanoseconds(), runstarttime.totalNanoseconds() + 1000);
+    TS_ASSERT_EQUALS(splitterf.stop().totalNanoseconds(), runstarttime.totalNanoseconds() + 1000);
     TS_ASSERT_EQUALS(splitterf.index(), numintervals - 1);
 
     // d) Randomly
     Kernel::SplittingInterval splitterR = splittersws->getSplitter(5);
-    Types::Core::DateAndTime t0 = splitterR.begin();
-    Types::Core::DateAndTime tf = splitterR.end();
+    Types::Core::DateAndTime t0 = splitterR.start();
+    Types::Core::DateAndTime tf = splitterR.stop();
     int64_t dt_ns = tf.totalNanoseconds() - t0.totalNanoseconds();
     TS_ASSERT_EQUALS(dt_ns, basetimeinterval_ns * static_cast<int64_t>(std::pow(2, 5)));
     int64_t dt_runtimestart = t0.totalNanoseconds() - runstarttime_ns;
@@ -331,8 +331,8 @@ public:
     // b) First interval - which is actually the last one because we are generating them from the end, ie the closest
     // to endTime
     Kernel::SplittingInterval splitter0 = splittersws->getSplitter(0);
-    TS_ASSERT_EQUALS(splitter0.begin().totalNanoseconds(), runstarttime_ns + stopTime - startTime);
-    TS_ASSERT_EQUALS(splitter0.end().totalNanoseconds(), runstarttime_ns + stopTime);
+    TS_ASSERT_EQUALS(splitter0.start().totalNanoseconds(), runstarttime_ns + stopTime - startTime);
+    TS_ASSERT_EQUALS(splitter0.stop().totalNanoseconds(), runstarttime_ns + stopTime);
 
     TS_ASSERT_EQUALS(splitter0.index(), numintervals - 1);
 
@@ -340,15 +340,15 @@ public:
 
     // c) Last interval - ie the closest to startTime
     Kernel::SplittingInterval splitterf = splittersws->getSplitter(numintervals - 1);
-    TS_ASSERT_EQUALS(splitterf.begin().totalNanoseconds(), runstarttime_ns + startTime);
-    TS_ASSERT_EQUALS(splitterf.end().totalNanoseconds(),
+    TS_ASSERT_EQUALS(splitterf.start().totalNanoseconds(), runstarttime_ns + startTime);
+    TS_ASSERT_EQUALS(splitterf.stop().totalNanoseconds(),
                      runstarttime_ns + stopTime - static_cast<int>(std::pow(2, 12)) + 1);
     TS_ASSERT_EQUALS(splitterf.index(), 0);
 
     // d) Randomly
     Kernel::SplittingInterval splitterR = splittersws->getSplitter(4);
-    Types::Core::DateAndTime t0 = splitterR.begin();
-    Types::Core::DateAndTime tf = splitterR.end();
+    Types::Core::DateAndTime t0 = splitterR.start();
+    Types::Core::DateAndTime tf = splitterR.stop();
     int64_t dt_ns = tf.totalNanoseconds() - t0.totalNanoseconds();
     TS_ASSERT_EQUALS(dt_ns, static_cast<int64_t>(std::pow(2, 4)));
     TS_ASSERT_EQUALS(t0.totalNanoseconds(), runstarttime_ns + stopTime - static_cast<int>(std::pow(2, 5)) + 1);
@@ -405,8 +405,8 @@ public:
     // b) First interval - which is actually the last one because we are generating them from the end, ie the closest
     // to endTime.
     Kernel::SplittingInterval splitter0 = splittersws->getSplitter(0);
-    TS_ASSERT_EQUALS(splitter0.begin().totalNanoseconds(), runstarttime_ns + stopTime - startTime);
-    TS_ASSERT_EQUALS(splitter0.end().totalNanoseconds(), runstarttime_ns + stopTime);
+    TS_ASSERT_EQUALS(splitter0.start().totalNanoseconds(), runstarttime_ns + stopTime - startTime);
+    TS_ASSERT_EQUALS(splitter0.stop().totalNanoseconds(), runstarttime_ns + stopTime);
 
     TS_ASSERT_EQUALS(splitter0.index(), numintervals - 1);
 
@@ -414,15 +414,15 @@ public:
 
     // c) Last interval - ie the closest to startTime
     Kernel::SplittingInterval splitterf = splittersws->getSplitter(numintervals - 1);
-    TS_ASSERT_EQUALS(splitterf.begin().totalNanoseconds(), runstarttime_ns + startTime);
-    TS_ASSERT_EQUALS(splitterf.end().totalNanoseconds(),
+    TS_ASSERT_EQUALS(splitterf.start().totalNanoseconds(), runstarttime_ns + startTime);
+    TS_ASSERT_EQUALS(splitterf.stop().totalNanoseconds(),
                      runstarttime_ns + stopTime - static_cast<int>(std::pow(2, 13)) + 1);
     TS_ASSERT_EQUALS(splitterf.index(), 0);
 
     // d) Randomly
     Kernel::SplittingInterval splitterR = splittersws->getSplitter(4);
-    Types::Core::DateAndTime t0 = splitterR.begin();
-    Types::Core::DateAndTime tf = splitterR.end();
+    Types::Core::DateAndTime t0 = splitterR.start();
+    Types::Core::DateAndTime tf = splitterR.stop();
     int64_t dt_ns = tf.totalNanoseconds() - t0.totalNanoseconds();
     TS_ASSERT_EQUALS(dt_ns, static_cast<int64_t>(std::pow(2, 4)));
     TS_ASSERT_EQUALS(t0.totalNanoseconds(), runstarttime_ns + stopTime - static_cast<int>(std::pow(2, 5)) + 1);
@@ -475,12 +475,12 @@ public:
     TS_ASSERT_EQUALS(splittersws->getNumberSplitters(), numsplitters);
 
     Kernel::SplittingInterval s0 = splittersws->getSplitter(0);
-    TS_ASSERT_EQUALS(s0.begin().totalNanoseconds(), 3000000000 - static_cast<int64_t>(1.0E-8 * 1.0E9));
-    TS_ASSERT_EQUALS(s0.end().totalNanoseconds(), 3000050000 - static_cast<int64_t>(1.0E-8 * 1.0E9));
+    TS_ASSERT_EQUALS(s0.start().totalNanoseconds(), 3000000000 - static_cast<int64_t>(1.0E-8 * 1.0E9));
+    TS_ASSERT_EQUALS(s0.stop().totalNanoseconds(), 3000050000 - static_cast<int64_t>(1.0E-8 * 1.0E9));
 
     Kernel::SplittingInterval s1 = splittersws->getSplitter(1);
-    TS_ASSERT_EQUALS(s1.begin().totalNanoseconds(), 3000775000 - static_cast<int64_t>(1.0E-8 * 1.0E9));
-    TS_ASSERT_EQUALS(s1.end().totalNanoseconds(), 3000850000 - static_cast<int64_t>(1.0E-8 * 1.0E9));
+    TS_ASSERT_EQUALS(s1.start().totalNanoseconds(), 3000775000 - static_cast<int64_t>(1.0E-8 * 1.0E9));
+    TS_ASSERT_EQUALS(s1.stop().totalNanoseconds(), 3000850000 - static_cast<int64_t>(1.0E-8 * 1.0E9));
 
     TS_ASSERT_EQUALS(infows->rowCount(), 1);
 
@@ -536,12 +536,12 @@ public:
     TS_ASSERT_EQUALS(infows->rowCount(), numoutputs);
 
     Kernel::SplittingInterval s0 = splittersws->getSplitter(0);
-    TS_ASSERT_EQUALS(s0.begin(), 3000000000 - static_cast<int>(1.0E-8 * 1.0E9));
+    TS_ASSERT_EQUALS(s0.start(), 3000000000 - static_cast<int>(1.0E-8 * 1.0E9));
     TS_ASSERT_EQUALS(s0.index(), 5);
 
     Kernel::SplittingInterval s15 = splittersws->getSplitter(15);
-    TS_ASSERT_EQUALS(s15.begin(), 3000924990);
-    TS_ASSERT_EQUALS(s15.end(), 3000974990);
+    TS_ASSERT_EQUALS(s15.start(), 3000924990);
+    TS_ASSERT_EQUALS(s15.stop(), 3000974990);
     TS_ASSERT_EQUALS(s15.index(), 9);
   }
 
@@ -591,7 +591,7 @@ public:
     int64_t factor = static_cast<int64_t>(1.0E9 + 0.5);
 
     Kernel::SplittingInterval s0 = splittersws->getSplitter(0);
-    TS_ASSERT_EQUALS(s0.begin().totalNanoseconds(), 11 * factor - 5 * factor / 100);
+    TS_ASSERT_EQUALS(s0.start().totalNanoseconds(), 11 * factor - 5 * factor / 100);
     TS_ASSERT_EQUALS(s0.index(), 0);
 
     Kernel::SplittingInterval s9 = splittersws->getSplitter(9);
@@ -651,7 +651,7 @@ public:
     int64_t factor = static_cast<int64_t>(1.0E9 + 0.5);
 
     Kernel::SplittingInterval s0 = splittersws->getSplitter(0);
-    TS_ASSERT_EQUALS(s0.begin().totalNanoseconds(), 11 * factor - 5 * factor / 100);
+    TS_ASSERT_EQUALS(s0.start().totalNanoseconds(), 11 * factor - 5 * factor / 100);
     TS_ASSERT_EQUALS(s0.index(), 0);
 
     // Clean
@@ -918,8 +918,8 @@ public:
       for (size_t i = 0; i < numsplitters; ++i) {
         Kernel::SplittingInterval s2 = splittersws2->getSplitter(i);
         Kernel::SplittingInterval s1 = splitters[i];
-        TS_ASSERT_EQUALS(s1.begin(), s2.begin());
-        TS_ASSERT_EQUALS(s1.end(), s2.end());
+        TS_ASSERT_EQUALS(s1.start(), s2.start());
+        TS_ASSERT_EQUALS(s1.stop(), s2.stop());
         TS_ASSERT_EQUALS(s1.index(), s2.index());
       }
     }
@@ -1007,8 +1007,8 @@ public:
       for (size_t i = 0; i < numsplitters; ++i) {
         Kernel::SplittingInterval s2 = splittersws2->getSplitter(i);
         Kernel::SplittingInterval s1 = splitters[i];
-        TS_ASSERT_EQUALS(s1.begin(), s2.begin());
-        TS_ASSERT_EQUALS(s1.end(), s2.end());
+        TS_ASSERT_EQUALS(s1.start(), s2.start());
+        TS_ASSERT_EQUALS(s1.stop(), s2.stop());
         TS_ASSERT_EQUALS(s1.index(), s2.index());
       }
     }

--- a/Framework/DataObjects/src/EventList.cpp
+++ b/Framework/DataObjects/src/EventList.cpp
@@ -3802,8 +3802,8 @@ void EventList::filterInPlaceHelper(Kernel::SplittingIntervalVec &splitter, type
   // This is the time of the first section. Anything before is thrown out.
   while (itspl != itspl_end) {
     // Get the splitting interval times and destination
-    start = itspl->begin();
-    stop = itspl->end();
+    start = itspl->start();
+    stop = itspl->stop();
     const int index = itspl->index();
 
     // Skip the events before the start of the time
@@ -3904,8 +3904,8 @@ void EventList::splitByTimeHelper(Kernel::SplittingIntervalVec &splitter, std::v
   // This is the time of the first section. Anything before is thrown out.
   while (itspl != itspl_end) {
     // Get the splitting interval times and destination
-    start = itspl->begin();
-    stop = itspl->end();
+    start = itspl->start();
+    stop = itspl->stop();
     const size_t index = itspl->index();
 
     // Skip the events before the start of the time
@@ -4010,8 +4010,8 @@ void EventList::splitByFullTimeHelper(Kernel::SplittingIntervalVec &splitter, st
   // 3. This is the time of the first section. Anything before is thrown out.
   while (itspl != itspl_end) {
     // Get the splitting interval times and destination
-    int64_t start = itspl->begin().totalNanoseconds();
-    int64_t stop = itspl->end().totalNanoseconds();
+    int64_t start = itspl->start().totalNanoseconds();
+    int64_t stop = itspl->stop().totalNanoseconds();
     const int index = itspl->index();
 
     // a) Skip the events before the start of the time
@@ -4378,8 +4378,8 @@ void EventList::splitByPulseTimeHelper(Kernel::SplittingIntervalVec &splitter, s
   // Iterate (loop) on all splitters
   while (itspl != itspl_end) {
     // Get the splitting interval times and destination group
-    start = itspl->begin().totalNanoseconds();
-    stop = itspl->end().totalNanoseconds();
+    start = itspl->start().totalNanoseconds();
+    stop = itspl->stop().totalNanoseconds();
     const int index = itspl->index();
 
     // Skip the events before the start of the time and put to 'unfiltered'

--- a/Framework/DataObjects/src/SplittersWorkspace.cpp
+++ b/Framework/DataObjects/src/SplittersWorkspace.cpp
@@ -31,8 +31,8 @@ SplittersWorkspace::SplittersWorkspace() {
  */
 void SplittersWorkspace::addSplitter(const Mantid::Kernel::SplittingInterval &splitter) {
   Mantid::API::TableRow row = this->appendRow();
-  row << splitter.begin().totalNanoseconds();
-  row << splitter.end().totalNanoseconds();
+  row << splitter.start().totalNanoseconds();
+  row << splitter.stop().totalNanoseconds();
   row << splitter.index();
 }
 
@@ -72,10 +72,10 @@ DataObjects::TimeSplitter SplittersWorkspace::convertToTimeSplitter() {
   DataObjects::TimeSplitter splitter;
   for (size_t i = 0; i < this->rowCount(); i++) {
     Kernel::SplittingInterval interval = this->getSplitter(i);
-    if (splitter.valueAtTime(interval.begin()) > 0 || splitter.valueAtTime(interval.end()) > 0) {
+    if (splitter.valueAtTime(interval.start()) > 0 || splitter.valueAtTime(interval.stop()) > 0) {
       g_log.warning() << "SplitterWorkspace row may be overwritten in conversion to TimeSplitter: " << i << '\n';
     }
-    splitter.addROI(interval.begin(), interval.end(), interval.index());
+    splitter.addROI(interval.start(), interval.stop(), interval.index());
   }
 
   return splitter;

--- a/Framework/DataObjects/test/SplittersWorkspaceTest.h
+++ b/Framework/DataObjects/test/SplittersWorkspaceTest.h
@@ -76,8 +76,8 @@ public:
 
     for (size_t i = 0; i < 3; i++) {
       Kernel::SplittingInterval splitter = splitterws.getSplitter(i);
-      TS_ASSERT_EQUALS(splitter.begin(), splitters[i].begin());
-      TS_ASSERT_EQUALS(splitter.end(), splitters[i].end());
+      TS_ASSERT_EQUALS(splitter.start(), splitters[i].start());
+      TS_ASSERT_EQUALS(splitter.stop(), splitters[i].stop());
       TS_ASSERT_EQUALS(splitter.index(), splitters[i].index());
     }
   }

--- a/Framework/Kernel/inc/MantidKernel/DateAndTime.h
+++ b/Framework/Kernel/inc/MantidKernel/DateAndTime.h
@@ -25,23 +25,23 @@ namespace Kernel {
 class MANTID_KERNEL_DLL TimeInterval {
 public:
   /// Default constructor
-  TimeInterval() : m_begin(), m_end() {}
+  TimeInterval() : m_start(), m_stop() {}
   /// Constructor
   TimeInterval(const Types::Core::DateAndTime &from, const Types::Core::DateAndTime &to);
   TimeInterval(const std::string &from, const std::string &to);
 
   /// Beginning of the interval
-  Types::Core::DateAndTime begin() const { return m_begin; }
+  Types::Core::DateAndTime start() const { return m_start; }
   /// End of the interval
-  Types::Core::DateAndTime end() const { return m_end; }
+  Types::Core::DateAndTime stop() const { return m_stop; }
   /// True if the interval is not empty
-  bool isValid() const { return m_end > m_begin; }
+  bool isValid() const { return m_stop > m_start; }
 
   /// Interval length (in seconds?)
-  Types::Core::time_duration length() const { return m_end - m_begin; }
+  Types::Core::time_duration length() const { return m_stop - m_start; }
 
   /// True if the interval contains \a t.
-  bool contains(const Types::Core::DateAndTime &t) const { return t >= begin() && t < end(); }
+  bool contains(const Types::Core::DateAndTime &t) const { return t >= start() && t < stop(); }
   /// Return true if the SplittingInterval overlaps with this one.
   bool overlaps(const TimeInterval *other) const;
   /// Return true if the SplittingInterval overlaps with this one.
@@ -63,9 +63,9 @@ public:
 
 private:
   /// begin
-  Types::Core::DateAndTime m_begin;
+  Types::Core::DateAndTime m_start;
   /// end
-  Types::Core::DateAndTime m_end;
+  Types::Core::DateAndTime m_stop;
 };
 
 } // namespace Kernel

--- a/Framework/Kernel/src/DateAndTime.cpp
+++ b/Framework/Kernel/src/DateAndTime.cpp
@@ -21,29 +21,29 @@ namespace Mantid {
 using namespace Types::Core;
 namespace Kernel {
 
-TimeInterval::TimeInterval(const Types::Core::DateAndTime &from, const Types::Core::DateAndTime &to) : m_begin(from) {
+TimeInterval::TimeInterval(const Types::Core::DateAndTime &from, const Types::Core::DateAndTime &to) : m_start(from) {
   if (to > from)
-    m_end = to;
+    m_stop = to;
   else
-    m_end = from;
+    m_stop = from;
 }
 
 TimeInterval::TimeInterval(const std::string &from, const std::string &to) {
   const DateAndTime fromObj(from);
   const DateAndTime toObj(to);
 
-  m_begin = fromObj;
+  m_start = fromObj;
   if (toObj > fromObj)
-    m_end = toObj;
+    m_stop = toObj;
   else
-    m_end = fromObj;
+    m_stop = fromObj;
 }
 
 bool TimeInterval::overlaps(const TimeInterval *other) const {
-  const auto thisBegin = this->begin();
-  const auto thisEnd = this->end();
-  const auto otherBegin = other->begin();
-  const auto otherEnd = other->end();
+  const auto thisBegin = this->start();
+  const auto thisEnd = this->stop();
+  const auto otherBegin = other->start();
+  const auto otherEnd = other->stop();
 
   return ((otherBegin < thisEnd) && (otherBegin >= thisBegin)) || ((otherEnd < thisEnd) && (otherEnd >= thisBegin)) ||
          ((thisBegin < otherEnd) && (thisBegin >= otherBegin)) || ((thisEnd < otherEnd) && (thisEnd >= otherBegin));
@@ -60,39 +60,39 @@ TimeInterval TimeInterval::intersection(const TimeInterval &ti) const {
   if (!isValid() || !ti.isValid() || !this->overlaps(&ti))
     return TimeInterval();
 
-  const auto t1 = std::max(begin(), ti.begin());
-  const auto t2 = std::min(end(), ti.end());
+  const auto t1 = std::max(start(), ti.start());
+  const auto t2 = std::min(stop(), ti.stop());
 
   return t1 < t2 ? TimeInterval(t1, t2) : TimeInterval();
 }
 
 bool TimeInterval::operator<(const TimeInterval &ti) const {
-  if (end() < ti.begin())
+  if (stop() < ti.start())
     return true;
-  else if (end() == ti.begin())
-    return begin() < ti.begin();
+  else if (stop() == ti.start())
+    return start() < ti.start();
   else
     return false;
 }
 bool TimeInterval::operator>(const TimeInterval &ti) const {
-  if (begin() > ti.end())
+  if (start() > ti.stop())
     return true;
-  else if (begin() == ti.end())
-    return begin() > ti.begin();
+  else if (start() == ti.stop())
+    return start() > ti.start();
   else
     return false;
 }
 
-bool TimeInterval::operator==(const TimeInterval &ti) const { return (begin() == ti.begin()) && (end() == ti.end()); }
+bool TimeInterval::operator==(const TimeInterval &ti) const { return (start() == ti.start()) && (stop() == ti.stop()); }
 
 /// String representation of the begin time
-std::string TimeInterval::begin_str() const { return boost::posix_time::to_simple_string(this->m_begin.to_ptime()); }
+std::string TimeInterval::begin_str() const { return boost::posix_time::to_simple_string(this->m_start.to_ptime()); }
 
 /// String representation of the end time
-std::string TimeInterval::end_str() const { return boost::posix_time::to_simple_string(this->m_end.to_ptime()); }
+std::string TimeInterval::end_str() const { return boost::posix_time::to_simple_string(this->m_stop.to_ptime()); }
 
 std::ostream &operator<<(std::ostream &s, const Mantid::Kernel::TimeInterval &t) {
-  s << t.begin().toSimpleString() << " - " << t.end().toSimpleString();
+  s << t.start().toSimpleString() << " - " << t.stop().toSimpleString();
   return s;
 }
 

--- a/Framework/Kernel/src/LogFilter.cpp
+++ b/Framework/Kernel/src/LogFilter.cpp
@@ -52,12 +52,12 @@ void LogFilter::addFilter(const TimeSeriesProperty<bool> &filter) {
     TimeInterval time1 = filter1->nthInterval(filter1->size() - 1);
     TimeInterval time2 = filter2->nthInterval(filter2->size() - 1);
 
-    if (time1.begin() < time2.begin()) {
-      filter1->addValue(time2.begin(),
+    if (time1.start() < time2.start()) {
+      filter1->addValue(time2.start(),
                         true); // should be f1->lastValue, but it doesnt
                                // matter for boolean AND
-    } else if (time2.begin() < time1.begin()) {
-      filter2->addValue(time1.begin(), true);
+    } else if (time2.start() < time1.start()) {
+      filter2->addValue(time1.start(), true);
     }
 
     int i = 0;
@@ -71,11 +71,11 @@ void LogFilter::addFilter(const TimeSeriesProperty<bool> &filter) {
     // of the filter that starts later to equalise their staring times. The new
     // interval will have
     // value opposite to the one it started with originally.
-    if (time1.begin() > time2.begin()) {
-      filter1->addValue(time2.begin(), !filter1->nthValue(i));
+    if (time1.start() > time2.start()) {
+      filter1->addValue(time2.start(), !filter1->nthValue(i));
       time1 = filter1->nthInterval(i);
-    } else if (time2.begin() > time1.begin()) {
-      filter2->addValue(time1.begin(), !filter2->nthValue(j));
+    } else if (time2.start() > time1.start()) {
+      filter2->addValue(time1.start(), !filter2->nthValue(j));
       time2 = filter2->nthInterval(j);
     }
 
@@ -83,12 +83,12 @@ void LogFilter::addFilter(const TimeSeriesProperty<bool> &filter) {
       TimeInterval time3;
       time3 = time1.intersection(time2);
       if (time3.isValid()) {
-        filterProperty->addValue(time3.begin(), (filter1->nthValue(i) && filter2->nthValue(j)));
+        filterProperty->addValue(time3.start(), (filter1->nthValue(i) && filter2->nthValue(j)));
       }
 
-      if (time1.end() < time2.end()) {
+      if (time1.stop() < time2.stop()) {
         i++;
-      } else if (time2.end() < time1.end()) {
+      } else if (time2.stop() < time1.stop()) {
         j++;
       } else {
         i++;

--- a/Framework/Kernel/src/SplittingInterval.cpp
+++ b/Framework/Kernel/src/SplittingInterval.cpp
@@ -29,8 +29,8 @@ int SplittingInterval::index() const { return m_index; }
 /// And operator. Return the smallest time interval where both intervals are
 /// TRUE.
 SplittingInterval SplittingInterval::operator&(const SplittingInterval &b) const {
-  const auto begin = std::max(this->begin(), b.begin());
-  const auto end = std::min(this->end(), b.end());
+  const auto begin = std::max(this->start(), b.start());
+  const auto end = std::min(this->stop(), b.stop());
 
   return SplittingInterval(begin, end, this->index());
 }
@@ -43,8 +43,8 @@ SplittingInterval SplittingInterval::operator|(const SplittingInterval &b) const
                                 "operator to non-overlapping "
                                 "SplittingInterval's.");
 
-  const auto begin = std::min(this->begin(), b.begin());
-  const auto end = std::max(this->end(), b.end());
+  const auto begin = std::min(this->start(), b.start());
+  const auto end = std::max(this->stop(), b.stop());
 
   return SplittingInterval(begin, end, this->index());
 }
@@ -151,16 +151,16 @@ SplittingIntervalVec removeFilterOverlap(const SplittingIntervalVec &a) {
   auto it = a.cbegin();
   while (it != a.cend()) {
     // All following intervals will start at or after this one
-    DateAndTime start = it->begin();
-    DateAndTime stop = it->end();
+    DateAndTime start = it->start();
+    DateAndTime stop = it->stop();
 
     // Keep looking for the next interval where there is a gap (start > old
     // stop);
-    while ((it != a.cend()) && (it->begin() <= stop)) {
+    while ((it != a.cend()) && (it->start() <= stop)) {
       // Extend the stop point (the start cannot be extended since the list is
       // sorted)
-      if (it->end() > stop)
-        stop = it->end();
+      if (it->stop() > stop)
+        stop = it->stop();
       ++it;
     }
     // We've reached a gap point. Output this merged interval and move on.
@@ -188,11 +188,7 @@ SplittingIntervalVec operator|(const SplittingIntervalVec &a, const SplittingInt
 
   // Sort by start time rather than the default
   auto compareStart = [](const SplittingInterval &left, const SplittingInterval &right) {
-    // because of the field names, cppcheck thinks the wrong thing is being compared
-    // let the compiler optimize the memory layout
-    const auto leftStart = left.begin();
-    const auto rightStart = right.begin();
-    return leftStart < rightStart;
+    return left.start() < right.start();
   };
   std::sort(temp.begin(), temp.end(), compareStart);
 
@@ -224,16 +220,16 @@ SplittingIntervalVec operator~(const SplittingIntervalVec &a) {
   ait = temp.begin();
   if (ait != temp.end()) {
     // First entry; start at -infinite time
-    out.emplace_back(DateAndTime::minimum(), ait->begin(), 0);
+    out.emplace_back(DateAndTime::minimum(), ait->start(), 0);
     // Now start at the second entry
     while (ait != temp.end()) {
       DateAndTime start, stop;
-      start = ait->end();
+      start = ait->stop();
       ++ait;
       if (ait == temp.end()) { // Reached the end - go to inf
         stop = DateAndTime::maximum();
       } else { // Stop at the start of the next entry
-        stop = ait->begin();
+        stop = ait->start();
       }
       out.emplace_back(start, stop, 0);
     }

--- a/Framework/Kernel/src/TimeSeriesProperty.cpp
+++ b/Framework/Kernel/src/TimeSeriesProperty.cpp
@@ -332,8 +332,8 @@ void TimeSeriesProperty<TYPE>::filterByTimes(const std::vector<SplittingInterval
 
   // 4. Create new
   for (const auto &splitter : splittervec) {
-    Types::Core::DateAndTime t_start = splitter.begin();
-    Types::Core::DateAndTime t_stop = splitter.end();
+    Types::Core::DateAndTime t_start = splitter.start();
+    Types::Core::DateAndTime t_stop = splitter.stop();
 
     int tstartindex = findIndex(t_start);
     if (tstartindex < 0) {
@@ -442,8 +442,8 @@ void TimeSeriesProperty<TYPE>::splitByTime(std::vector<SplittingInterval> &split
                 << ", Number of splitters = " << splitter.size() << "\n";
   while (itspl != splitter.end() && i_property < m_values.size()) {
     // Get the splitting interval times and destination
-    DateAndTime start = itspl->begin();
-    DateAndTime stop = itspl->end();
+    DateAndTime start = itspl->start();
+    DateAndTime stop = itspl->stop();
 
     int output_index = itspl->index();
     // output workspace index is out of range. go to the next splitter
@@ -760,7 +760,7 @@ void TimeSeriesProperty<TYPE>::expandFilterToRange(std::vector<SplittingInterval
   double val = static_cast<double>(firstValue());
   if ((val >= min) && (val <= max)) {
     SplittingIntervalVec extraFilter;
-    extraFilter.emplace_back(range.begin(), firstTime(), 0);
+    extraFilter.emplace_back(range.start(), firstTime(), 0);
     // Include everything from the start of the run to the first time measured
     // (which may be a null time interval; this'll be ignored)
     split = split | extraFilter;
@@ -770,7 +770,7 @@ void TimeSeriesProperty<TYPE>::expandFilterToRange(std::vector<SplittingInterval
   val = static_cast<double>(lastValue());
   if ((val >= min) && (val <= max)) {
     SplittingIntervalVec extraFilter;
-    extraFilter.emplace_back(lastTime(), range.end(), 0);
+    extraFilter.emplace_back(lastTime(), range.stop(), 0);
     // Include everything from the start of the run to the first time measured
     // (which may be a null time interval; this'll be ignored)
     split = split | extraFilter;
@@ -839,10 +839,10 @@ double TimeSeriesProperty<TYPE>::averageValueInFilter(const std::vector<Splittin
 
     // Get the log value and index at the start time of the filter
     int index;
-    double value = static_cast<double>(getSingleValue(time.begin(), index));
-    DateAndTime startTime = time.begin();
+    double value = static_cast<double>(getSingleValue(time.start(), index));
+    DateAndTime startTime = time.start();
 
-    while (index < realSize() - 1 && m_values[index + 1].time() < time.end()) {
+    while (index < realSize() - 1 && m_values[index + 1].time() < time.stop()) {
       ++index;
       numerator += DateAndTime::secondsFromDuration(m_values[index].time() - startTime) * value;
       startTime = m_values[index].time();
@@ -850,7 +850,7 @@ double TimeSeriesProperty<TYPE>::averageValueInFilter(const std::vector<Splittin
     }
 
     // Now close off with the end of the current filter range
-    numerator += DateAndTime::secondsFromDuration(time.end() - startTime) * value;
+    numerator += DateAndTime::secondsFromDuration(time.stop() - startTime) * value;
   }
 
   if (totalTime > 0) {
@@ -884,12 +884,12 @@ TimeSeriesProperty<TYPE>::averageAndStdDevInFilter(const std::vector<SplittingIn
   auto real_size = realSize();
   for (const auto &time : intervals) {
     int index;
-    auto value = static_cast<double>(getSingleValue(time.begin(), index));
-    DateAndTime startTime = time.begin();
+    auto value = static_cast<double>(getSingleValue(time.start(), index));
+    DateAndTime startTime = time.start();
     while (index < real_size) {
       index++;
       if (index == real_size)
-        duration = DateAndTime::secondsFromDuration(time.end() - startTime);
+        duration = DateAndTime::secondsFromDuration(time.stop() - startTime);
       else {
         duration = DateAndTime::secondsFromDuration(m_values[index].time() - startTime);
         startTime = m_values[index].time();
@@ -2394,7 +2394,7 @@ template <typename TYPE> std::vector<SplittingInterval> TimeSeriesProperty<TYPE>
     // the last log value. The value is different than that from lastTime()
     auto lastInterval = this->nthInterval(this->size() - 1);
 
-    intervals.emplace_back(firstTime(), lastInterval.end());
+    intervals.emplace_back(firstTime(), lastInterval.stop());
 
     return intervals;
   }

--- a/Framework/Kernel/test/SplittingIntervalTest.h
+++ b/Framework/Kernel/test/SplittingIntervalTest.h
@@ -40,8 +40,8 @@ public:
     b = SplittingInterval(start_b, stop_b, 0);
     c = a & b;
     TS_ASSERT(a.overlaps(b));
-    TS_ASSERT_EQUALS(c.begin(), start_b);
-    TS_ASSERT_EQUALS(c.end(), stop_b);
+    TS_ASSERT_EQUALS(c.start(), start_b);
+    TS_ASSERT_EQUALS(c.stop(), stop_b);
 
     // a is all inside b
     start_b = DateAndTime("2007-11-30T16:17:05");
@@ -49,8 +49,8 @@ public:
     b = SplittingInterval(start_b, stop_b, 0);
     c = a & b;
     TS_ASSERT(a.overlaps(b));
-    TS_ASSERT_EQUALS(c.begin(), start_a);
-    TS_ASSERT_EQUALS(c.end(), stop_a);
+    TS_ASSERT_EQUALS(c.start(), start_a);
+    TS_ASSERT_EQUALS(c.stop(), stop_a);
 
     // b goes past the end of a
     start_b = DateAndTime("2007-11-30T16:17:12");
@@ -58,8 +58,8 @@ public:
     b = SplittingInterval(start_b, stop_b, 0);
     c = a & b;
     TS_ASSERT(a.overlaps(b));
-    TS_ASSERT_EQUALS(c.begin(), start_b);
-    TS_ASSERT_EQUALS(c.end(), stop_a);
+    TS_ASSERT_EQUALS(c.start(), start_b);
+    TS_ASSERT_EQUALS(c.stop(), stop_a);
 
     // b starts before a and ends before
     start_b = DateAndTime("2007-11-30T16:17:05");
@@ -67,8 +67,8 @@ public:
     b = SplittingInterval(start_b, stop_b, 0);
     c = a & b;
     TS_ASSERT(a.overlaps(b));
-    TS_ASSERT_EQUALS(c.begin(), start_a);
-    TS_ASSERT_EQUALS(c.end(), stop_b);
+    TS_ASSERT_EQUALS(c.start(), start_a);
+    TS_ASSERT_EQUALS(c.stop(), stop_b);
 
     // No overlap (b < a)
     start_b = DateAndTime("2007-11-30T16:17:01");
@@ -105,8 +105,8 @@ public:
     b = SplittingInterval(start_b, stop_b, 0);
     c = a | b;
     TS_ASSERT(a.overlaps(b));
-    TS_ASSERT_EQUALS(c.begin(), start_a);
-    TS_ASSERT_EQUALS(c.end(), stop_a);
+    TS_ASSERT_EQUALS(c.start(), start_a);
+    TS_ASSERT_EQUALS(c.stop(), stop_a);
 
     // a is all inside b
     start_b = DateAndTime("2007-11-30T16:17:05");
@@ -114,8 +114,8 @@ public:
     b = SplittingInterval(start_b, stop_b, 0);
     c = a | b;
     TS_ASSERT(a.overlaps(b));
-    TS_ASSERT_EQUALS(c.begin(), start_b);
-    TS_ASSERT_EQUALS(c.end(), stop_b);
+    TS_ASSERT_EQUALS(c.start(), start_b);
+    TS_ASSERT_EQUALS(c.stop(), stop_b);
 
     // b goes past the end of a
     start_b = DateAndTime("2007-11-30T16:17:12");
@@ -123,8 +123,8 @@ public:
     b = SplittingInterval(start_b, stop_b, 0);
     c = a | b;
     TS_ASSERT(a.overlaps(b));
-    TS_ASSERT_EQUALS(c.begin(), start_a);
-    TS_ASSERT_EQUALS(c.end(), stop_b);
+    TS_ASSERT_EQUALS(c.start(), start_a);
+    TS_ASSERT_EQUALS(c.stop(), stop_b);
 
     // b starts before a and ends before
     start_b = DateAndTime("2007-11-30T16:17:05");
@@ -132,8 +132,8 @@ public:
     b = SplittingInterval(start_b, stop_b, 0);
     c = a | b;
     TS_ASSERT(a.overlaps(b));
-    TS_ASSERT_EQUALS(c.begin(), start_b);
-    TS_ASSERT_EQUALS(c.end(), stop_a);
+    TS_ASSERT_EQUALS(c.start(), start_b);
+    TS_ASSERT_EQUALS(c.stop(), stop_a);
 
     // No overlap (b < a) - This throws an exception because you need two
     // outputs!
@@ -199,20 +199,20 @@ public:
 
     SplittingInterval i;
     i = c[0];
-    TS_ASSERT_EQUALS(i.begin(), DateAndTime("2007-11-30T16:17:01"));
-    TS_ASSERT_EQUALS(i.end(), DateAndTime("2007-11-30T16:17:10"));
+    TS_ASSERT_EQUALS(i.start(), DateAndTime("2007-11-30T16:17:01"));
+    TS_ASSERT_EQUALS(i.stop(), DateAndTime("2007-11-30T16:17:10"));
     i = c[1];
-    TS_ASSERT_EQUALS(i.begin(), DateAndTime("2007-11-30T16:17:20"));
-    TS_ASSERT_EQUALS(i.end(), DateAndTime("2007-11-30T16:17:25"));
+    TS_ASSERT_EQUALS(i.start(), DateAndTime("2007-11-30T16:17:20"));
+    TS_ASSERT_EQUALS(i.stop(), DateAndTime("2007-11-30T16:17:25"));
     i = c[2];
-    TS_ASSERT_EQUALS(i.begin(), DateAndTime("2007-11-30T16:17:26"));
-    TS_ASSERT_EQUALS(i.end(), DateAndTime("2007-11-30T16:17:27"));
+    TS_ASSERT_EQUALS(i.start(), DateAndTime("2007-11-30T16:17:26"));
+    TS_ASSERT_EQUALS(i.stop(), DateAndTime("2007-11-30T16:17:27"));
     i = c[3];
-    TS_ASSERT_EQUALS(i.begin(), DateAndTime("2007-11-30T16:17:45"));
-    TS_ASSERT_EQUALS(i.end(), DateAndTime("2007-11-30T16:17:50"));
+    TS_ASSERT_EQUALS(i.start(), DateAndTime("2007-11-30T16:17:45"));
+    TS_ASSERT_EQUALS(i.stop(), DateAndTime("2007-11-30T16:17:50"));
     i = c[4];
-    TS_ASSERT_EQUALS(i.begin(), DateAndTime("2007-11-30T16:18:00"));
-    TS_ASSERT_EQUALS(i.end(), DateAndTime("2007-11-30T16:18:10"));
+    TS_ASSERT_EQUALS(i.start(), DateAndTime("2007-11-30T16:18:00"));
+    TS_ASSERT_EQUALS(i.stop(), DateAndTime("2007-11-30T16:18:10"));
   }
 
   //----------------------------------------------------------------------------
@@ -267,17 +267,17 @@ public:
 
     SplittingInterval i;
     i = c[0];
-    TS_ASSERT_EQUALS(i.begin(), DateAndTime("2007-11-30T16:17:00"));
-    TS_ASSERT_EQUALS(i.end(), DateAndTime("2007-11-30T16:17:30"));
+    TS_ASSERT_EQUALS(i.start(), DateAndTime("2007-11-30T16:17:00"));
+    TS_ASSERT_EQUALS(i.stop(), DateAndTime("2007-11-30T16:17:30"));
     i = c[1];
-    TS_ASSERT_EQUALS(i.begin(), DateAndTime("2007-11-30T16:17:40"));
-    TS_ASSERT_EQUALS(i.end(), DateAndTime("2007-11-30T16:18:15"));
+    TS_ASSERT_EQUALS(i.start(), DateAndTime("2007-11-30T16:17:40"));
+    TS_ASSERT_EQUALS(i.stop(), DateAndTime("2007-11-30T16:18:15"));
     i = c[2];
-    TS_ASSERT_EQUALS(i.begin(), DateAndTime("2007-11-30T16:18:20"));
-    TS_ASSERT_EQUALS(i.end(), DateAndTime("2007-11-30T16:18:30"));
+    TS_ASSERT_EQUALS(i.start(), DateAndTime("2007-11-30T16:18:20"));
+    TS_ASSERT_EQUALS(i.stop(), DateAndTime("2007-11-30T16:18:30"));
     i = c[3];
-    TS_ASSERT_EQUALS(i.begin(), DateAndTime("2007-11-30T16:18:50"));
-    TS_ASSERT_EQUALS(i.end(), DateAndTime("2007-11-30T16:18:55"));
+    TS_ASSERT_EQUALS(i.start(), DateAndTime("2007-11-30T16:18:50"));
+    TS_ASSERT_EQUALS(i.stop(), DateAndTime("2007-11-30T16:18:55"));
   }
 
   //----------------------------------------------------------------------------
@@ -315,8 +315,8 @@ public:
 
     SplittingInterval i;
     i = c[0];
-    TS_ASSERT_EQUALS(i.begin(), DateAndTime("2007-11-30T16:17:20"));
-    TS_ASSERT_EQUALS(i.end(), DateAndTime("2007-11-30T16:17:30"));
+    TS_ASSERT_EQUALS(i.start(), DateAndTime("2007-11-30T16:17:20"));
+    TS_ASSERT_EQUALS(i.stop(), DateAndTime("2007-11-30T16:17:30"));
   }
 
   //----------------------------------------------------------------------------
@@ -342,14 +342,14 @@ public:
       return; // avoid segfaults if this part of the test fails
 
     i = c[0];
-    TS_ASSERT_EQUALS(i.begin(), DateAndTime::minimum());
-    TS_ASSERT_EQUALS(i.end(), DateAndTime("2007-11-30T16:17:00"));
+    TS_ASSERT_EQUALS(i.start(), DateAndTime::minimum());
+    TS_ASSERT_EQUALS(i.stop(), DateAndTime("2007-11-30T16:17:00"));
     i = c[1];
-    TS_ASSERT_EQUALS(i.begin(), DateAndTime("2007-11-30T16:17:10"));
-    TS_ASSERT_EQUALS(i.end(), DateAndTime("2007-11-30T16:17:20"));
+    TS_ASSERT_EQUALS(i.start(), DateAndTime("2007-11-30T16:17:10"));
+    TS_ASSERT_EQUALS(i.stop(), DateAndTime("2007-11-30T16:17:20"));
     i = c[2];
-    TS_ASSERT_EQUALS(i.begin(), DateAndTime("2007-11-30T16:17:30"));
-    TS_ASSERT_EQUALS(i.end(), DateAndTime::maximum());
+    TS_ASSERT_EQUALS(i.start(), DateAndTime("2007-11-30T16:17:30"));
+    TS_ASSERT_EQUALS(i.stop(), DateAndTime::maximum());
   }
 
   //----------------------------------------------------------------------------
@@ -364,8 +364,8 @@ public:
     if (c.size() < 1)
       return; // avoid segfaults if this part of the test fails
     i = c[0];
-    TS_ASSERT_EQUALS(i.begin(), DateAndTime::minimum());
-    TS_ASSERT_EQUALS(i.end(), DateAndTime::maximum());
+    TS_ASSERT_EQUALS(i.start(), DateAndTime::minimum());
+    TS_ASSERT_EQUALS(i.stop(), DateAndTime::maximum());
   }
 
   //----------------------------------------------------------------------------
@@ -388,11 +388,11 @@ public:
       return; // avoid segfaults if this part of the test fails
 
     i = c[0];
-    TS_ASSERT_EQUALS(i.begin(), DateAndTime::minimum());
-    TS_ASSERT_EQUALS(i.end(), DateAndTime("2007-11-30T16:17:00"));
+    TS_ASSERT_EQUALS(i.start(), DateAndTime::minimum());
+    TS_ASSERT_EQUALS(i.stop(), DateAndTime("2007-11-30T16:17:00"));
     i = c[1];
-    TS_ASSERT_EQUALS(i.begin(), DateAndTime("2007-11-30T16:17:30"));
-    TS_ASSERT_EQUALS(i.end(), DateAndTime::maximum());
+    TS_ASSERT_EQUALS(i.start(), DateAndTime("2007-11-30T16:17:30"));
+    TS_ASSERT_EQUALS(i.stop(), DateAndTime::maximum());
   }
 
   //----------------------------------------------------------------------------
@@ -447,28 +447,28 @@ public:
       return; // avoid segfaults if this part of the test fails
 
     i = c[0];
-    TS_ASSERT_EQUALS(i.begin(), DateAndTime("2007-11-30T16:17:00"));
-    TS_ASSERT_EQUALS(i.end(), DateAndTime("2007-11-30T16:17:10"));
+    TS_ASSERT_EQUALS(i.start(), DateAndTime("2007-11-30T16:17:00"));
+    TS_ASSERT_EQUALS(i.stop(), DateAndTime("2007-11-30T16:17:10"));
     TS_ASSERT_EQUALS(i.index(), 1);
 
     i = c[1];
-    TS_ASSERT_EQUALS(i.begin(), DateAndTime("2007-11-30T16:17:20"));
-    TS_ASSERT_EQUALS(i.end(), DateAndTime("2007-11-30T16:17:30"));
+    TS_ASSERT_EQUALS(i.start(), DateAndTime("2007-11-30T16:17:20"));
+    TS_ASSERT_EQUALS(i.stop(), DateAndTime("2007-11-30T16:17:30"));
     TS_ASSERT_EQUALS(i.index(), 1);
 
     i = c[2];
-    TS_ASSERT_EQUALS(i.begin(), DateAndTime("2007-11-30T16:17:40"));
-    TS_ASSERT_EQUALS(i.end(), DateAndTime("2007-11-30T16:18:00"));
+    TS_ASSERT_EQUALS(i.start(), DateAndTime("2007-11-30T16:17:40"));
+    TS_ASSERT_EQUALS(i.stop(), DateAndTime("2007-11-30T16:18:00"));
     TS_ASSERT_EQUALS(i.index(), 1);
 
     i = c[3];
-    TS_ASSERT_EQUALS(i.begin(), DateAndTime("2007-11-30T16:18:00"));
-    TS_ASSERT_EQUALS(i.end(), DateAndTime("2007-11-30T16:18:10"));
+    TS_ASSERT_EQUALS(i.start(), DateAndTime("2007-11-30T16:18:00"));
+    TS_ASSERT_EQUALS(i.stop(), DateAndTime("2007-11-30T16:18:10"));
     TS_ASSERT_EQUALS(i.index(), 2);
 
     i = c[4];
-    TS_ASSERT_EQUALS(i.begin(), DateAndTime("2007-11-30T16:18:50"));
-    TS_ASSERT_EQUALS(i.end(), DateAndTime("2007-11-30T16:18:55"));
+    TS_ASSERT_EQUALS(i.start(), DateAndTime("2007-11-30T16:18:50"));
+    TS_ASSERT_EQUALS(i.stop(), DateAndTime("2007-11-30T16:18:55"));
     TS_ASSERT_EQUALS(i.index(), 2);
 
     // This fails since you can't add splitters together
@@ -500,10 +500,10 @@ public:
     // sort using the operator<
     std::sort(b.begin(), b.end());
 
-    TS_ASSERT_EQUALS(b[0].begin(), DateAndTime("2007-11-30T16:15:00"));
-    TS_ASSERT_EQUALS(b[1].begin(), DateAndTime("2007-11-30T16:17:00"));
-    TS_ASSERT_EQUALS(b[2].begin(), DateAndTime("2007-11-30T16:18:00"));
-    TS_ASSERT_EQUALS(b[3].begin(), DateAndTime("2007-11-30T16:19:00"));
+    TS_ASSERT_EQUALS(b[0].start(), DateAndTime("2007-11-30T16:15:00"));
+    TS_ASSERT_EQUALS(b[1].start(), DateAndTime("2007-11-30T16:17:00"));
+    TS_ASSERT_EQUALS(b[2].start(), DateAndTime("2007-11-30T16:18:00"));
+    TS_ASSERT_EQUALS(b[3].start(), DateAndTime("2007-11-30T16:19:00"));
   }
 
   //----------------------------------------------------------------------------

--- a/Framework/Kernel/test/TimeSeriesPropertyTest.h
+++ b/Framework/Kernel/test/TimeSeriesPropertyTest.h
@@ -516,15 +516,15 @@ public:
 
     s = splitter[0];
     t = DateAndTime("2007-11-30T16:17:09");
-    TS_ASSERT_DELTA(s.begin(), t, 1e-3);
+    TS_ASSERT_DELTA(s.start(), t, 1e-3);
     t = DateAndTime("2007-11-30T16:17:11");
-    TS_ASSERT_DELTA(s.end(), t, 1e-3);
+    TS_ASSERT_DELTA(s.stop(), t, 1e-3);
 
     s = splitter[1];
     t = DateAndTime("2007-11-30T16:17:29");
-    TS_ASSERT_DELTA(s.begin(), t, 1e-3);
+    TS_ASSERT_DELTA(s.start(), t, 1e-3);
     t = DateAndTime("2007-11-30T16:17:41");
-    TS_ASSERT_DELTA(s.end(), t, 1e-3);
+    TS_ASSERT_DELTA(s.stop(), t, 1e-3);
 
     // Now test with left-aligned log value boundaries
     log->makeFilterByValue(splitter, 1.8, 2.2, 1.0);
@@ -533,15 +533,15 @@ public:
 
     s = splitter[0];
     t = DateAndTime("2007-11-30T16:17:10");
-    TS_ASSERT_DELTA(s.begin(), t, 1e-3);
+    TS_ASSERT_DELTA(s.start(), t, 1e-3);
     t = DateAndTime("2007-11-30T16:17:20");
-    TS_ASSERT_DELTA(s.end(), t, 1e-3);
+    TS_ASSERT_DELTA(s.stop(), t, 1e-3);
 
     s = splitter[1];
     t = DateAndTime("2007-11-30T16:17:30");
-    TS_ASSERT_DELTA(s.begin(), t, 1e-3);
+    TS_ASSERT_DELTA(s.start(), t, 1e-3);
     t = DateAndTime("2007-11-30T16:17:50");
-    TS_ASSERT_DELTA(s.end(), t, 1e-3);
+    TS_ASSERT_DELTA(s.stop(), t, 1e-3);
 
     // Check throws if min > max
     TS_ASSERT_THROWS(log->makeFilterByValue(splitter, 2.0, 1.0, 0.0, true), const std::invalid_argument &);
@@ -572,33 +572,33 @@ public:
     log.makeFilterByValue(splitter, 1.0, 2.2, 1.0, false);
     log.expandFilterToRange(splitter, 1.0, 2.2, interval);
     TS_ASSERT_EQUALS(splitter.size(), 2);
-    TS_ASSERT_DELTA(splitter[0].begin(), DateAndTime("2007-11-30T16:16:00"), 1e-3);
-    TS_ASSERT_DELTA(splitter[0].end(), DateAndTime("2007-11-30T16:17:20"), 1e-3);
-    TS_ASSERT_DELTA(splitter[1].begin(), DateAndTime("2007-11-30T16:17:50"), 1e-3);
-    TS_ASSERT_DELTA(splitter[1].end(), DateAndTime("2007-11-30T16:18:50"), 1e-3);
+    TS_ASSERT_DELTA(splitter[0].start(), DateAndTime("2007-11-30T16:16:00"), 1e-3);
+    TS_ASSERT_DELTA(splitter[0].stop(), DateAndTime("2007-11-30T16:17:20"), 1e-3);
+    TS_ASSERT_DELTA(splitter[1].start(), DateAndTime("2007-11-30T16:17:50"), 1e-3);
+    TS_ASSERT_DELTA(splitter[1].stop(), DateAndTime("2007-11-30T16:18:50"), 1e-3);
 
     // Test bad at both ends
     log.makeFilterByValue(splitter, 2.5, 10.0, 0.0, false);
     log.expandFilterToRange(splitter, 2.5, 10.0, interval);
     TS_ASSERT_EQUALS(splitter.size(), 1);
-    TS_ASSERT_DELTA(splitter[0].begin(), DateAndTime("2007-11-30T16:17:20"), 1e-3);
-    TS_ASSERT_DELTA(splitter[0].end(), DateAndTime("2007-11-30T16:17:50"), 1e-3);
+    TS_ASSERT_DELTA(splitter[0].start(), DateAndTime("2007-11-30T16:17:20"), 1e-3);
+    TS_ASSERT_DELTA(splitter[0].stop(), DateAndTime("2007-11-30T16:17:50"), 1e-3);
 
     // Test good at start, bad at end
     log.makeFilterByValue(splitter, -1.0, 1.5, 0.0, false);
     log.expandFilterToRange(splitter, -1.0, 1.5, interval);
     TS_ASSERT_EQUALS(splitter.size(), 1);
-    TS_ASSERT_DELTA(splitter[0].begin(), DateAndTime("2007-11-30T16:16:00"), 1e-3);
-    TS_ASSERT_DELTA(splitter[0].end(), DateAndTime("2007-11-30T16:17:10"), 1e-3);
+    TS_ASSERT_DELTA(splitter[0].start(), DateAndTime("2007-11-30T16:16:00"), 1e-3);
+    TS_ASSERT_DELTA(splitter[0].stop(), DateAndTime("2007-11-30T16:17:10"), 1e-3);
 
     // Test good at end, bad at start
     log.makeFilterByValue(splitter, 1.99, 2.5, 1.0, false);
     log.expandFilterToRange(splitter, 1.99, 2.5, interval);
     TS_ASSERT_EQUALS(splitter.size(), 2);
-    TS_ASSERT_DELTA(splitter[0].begin(), DateAndTime("2007-11-30T16:17:10"), 1e-3);
-    TS_ASSERT_DELTA(splitter[0].end(), DateAndTime("2007-11-30T16:17:20"), 1e-3);
-    TS_ASSERT_DELTA(splitter[1].begin(), DateAndTime("2007-11-30T16:17:50"), 1e-3);
-    TS_ASSERT_DELTA(splitter[1].end(), DateAndTime("2007-11-30T16:18:50"), 1e-3);
+    TS_ASSERT_DELTA(splitter[0].start(), DateAndTime("2007-11-30T16:17:10"), 1e-3);
+    TS_ASSERT_DELTA(splitter[0].stop(), DateAndTime("2007-11-30T16:17:20"), 1e-3);
+    TS_ASSERT_DELTA(splitter[1].start(), DateAndTime("2007-11-30T16:17:50"), 1e-3);
+    TS_ASSERT_DELTA(splitter[1].stop(), DateAndTime("2007-11-30T16:18:50"), 1e-3);
 
     // Check throws if min > max
     TS_ASSERT_THROWS(log.expandFilterToRange(splitter, 2.0, 1.0, interval), const std::invalid_argument &);
@@ -608,8 +608,8 @@ public:
     log.makeFilterByValue(splitter, 0.0, 10.0, 0.0, false);
     log.expandFilterToRange(splitter, 0.0, 10.0, narrowinterval);
     TS_ASSERT_EQUALS(splitter.size(), 1);
-    TS_ASSERT_DELTA(splitter[0].begin(), DateAndTime("2007-11-30T16:17:00"), 1e-3);
-    TS_ASSERT_DELTA(splitter[0].end(), DateAndTime("2007-11-30T16:17:50"), 1e-3);
+    TS_ASSERT_DELTA(splitter[0].start(), DateAndTime("2007-11-30T16:17:00"), 1e-3);
+    TS_ASSERT_DELTA(splitter[0].stop(), DateAndTime("2007-11-30T16:17:50"), 1e-3);
   }
 
   void test_expandFilterToRange_throws_for_string_property() {
@@ -1820,16 +1820,16 @@ public:
 
     // 3. Test
     Mantid::Kernel::TimeInterval dt0 = p->nthInterval(0);
-    TS_ASSERT_EQUALS(dt0.begin(), Mantid::Types::Core::DateAndTime("2007-11-30T16:17:00"));
-    TS_ASSERT_EQUALS(dt0.end(), Mantid::Types::Core::DateAndTime("2007-11-30T16:17:05"));
+    TS_ASSERT_EQUALS(dt0.start(), Mantid::Types::Core::DateAndTime("2007-11-30T16:17:00"));
+    TS_ASSERT_EQUALS(dt0.stop(), Mantid::Types::Core::DateAndTime("2007-11-30T16:17:05"));
 
     Mantid::Kernel::TimeInterval dt1 = p->nthInterval(1);
-    TS_ASSERT_EQUALS(dt1.begin(), Mantid::Types::Core::DateAndTime("2007-11-30T16:17:05"));
-    TS_ASSERT_EQUALS(dt1.end(), Mantid::Types::Core::DateAndTime("2007-11-30T16:17:15"));
+    TS_ASSERT_EQUALS(dt1.start(), Mantid::Types::Core::DateAndTime("2007-11-30T16:17:05"));
+    TS_ASSERT_EQUALS(dt1.stop(), Mantid::Types::Core::DateAndTime("2007-11-30T16:17:15"));
 
     Mantid::Kernel::TimeInterval dt2 = p->nthInterval(2);
-    TS_ASSERT_EQUALS(dt2.begin(), Mantid::Types::Core::DateAndTime("2007-11-30T16:17:15"));
-    TS_ASSERT_EQUALS(dt2.end(), Mantid::Types::Core::DateAndTime("2007-11-30T16:17:35"));
+    TS_ASSERT_EQUALS(dt2.start(), Mantid::Types::Core::DateAndTime("2007-11-30T16:17:15"));
+    TS_ASSERT_EQUALS(dt2.stop(), Mantid::Types::Core::DateAndTime("2007-11-30T16:17:35"));
 
     // -1 Clean
     delete p;
@@ -1877,12 +1877,12 @@ public:
     TS_ASSERT_EQUALS(p1->size(), 7);
 
     Mantid::Kernel::TimeInterval dt1 = p1->nthInterval(1);
-    TS_ASSERT_EQUALS(dt1.begin(), Mantid::Types::Core::DateAndTime("2007-11-30T16:17:10"));
-    TS_ASSERT_EQUALS(dt1.end(), Mantid::Types::Core::DateAndTime("2007-11-30T16:17:16"));
+    TS_ASSERT_EQUALS(dt1.start(), Mantid::Types::Core::DateAndTime("2007-11-30T16:17:10"));
+    TS_ASSERT_EQUALS(dt1.stop(), Mantid::Types::Core::DateAndTime("2007-11-30T16:17:16"));
 
     Mantid::Kernel::TimeInterval dt2 = p1->nthInterval(2);
-    TS_ASSERT_EQUALS(dt2.begin(), Mantid::Types::Core::DateAndTime("2007-11-30T16:18:40"));
-    TS_ASSERT_EQUALS(dt2.end(), Mantid::Types::Core::DateAndTime("2007-11-30T16:18:50"));
+    TS_ASSERT_EQUALS(dt2.start(), Mantid::Types::Core::DateAndTime("2007-11-30T16:18:40"));
+    TS_ASSERT_EQUALS(dt2.stop(), Mantid::Types::Core::DateAndTime("2007-11-30T16:18:50"));
 
     // 4. Clear filter
     p1->clearFilter();
@@ -1894,8 +1894,8 @@ public:
     if (finalsize == origsize) {
       for (size_t i = 0; i < finalsize; i++) {
         Mantid::Kernel::TimeInterval dt = p1->nthInterval(static_cast<int>(i));
-        TS_ASSERT_EQUALS(dt.begin(), dts[i].begin());
-        TS_ASSERT_EQUALS(dt.end(), dts[i].end());
+        TS_ASSERT_EQUALS(dt.start(), dts[i].start());
+        TS_ASSERT_EQUALS(dt.stop(), dts[i].stop());
       }
     }
 
@@ -1959,26 +1959,26 @@ public:
 
     // 4. Check interval & Value
     Mantid::Kernel::TimeInterval dt0 = p1->nthInterval(0);
-    TS_ASSERT_EQUALS(dt0.begin(), Mantid::Types::Core::DateAndTime("2007-11-30T16:17:00"));
-    TS_ASSERT_EQUALS(dt0.end(), Mantid::Types::Core::DateAndTime("2007-11-30T16:17:10"));
+    TS_ASSERT_EQUALS(dt0.start(), Mantid::Types::Core::DateAndTime("2007-11-30T16:17:00"));
+    TS_ASSERT_EQUALS(dt0.stop(), Mantid::Types::Core::DateAndTime("2007-11-30T16:17:10"));
     double v0 = p1->nthValue(0);
     TS_ASSERT_DELTA(v0, 1, 0.00000001);
 
     Mantid::Kernel::TimeInterval dt1 = p1->nthInterval(1);
-    TS_ASSERT_EQUALS(dt1.begin(), Mantid::Types::Core::DateAndTime("2007-11-30T16:17:10"));
-    TS_ASSERT_EQUALS(dt1.end(), Mantid::Types::Core::DateAndTime("2007-11-30T16:17:16"));
+    TS_ASSERT_EQUALS(dt1.start(), Mantid::Types::Core::DateAndTime("2007-11-30T16:17:10"));
+    TS_ASSERT_EQUALS(dt1.stop(), Mantid::Types::Core::DateAndTime("2007-11-30T16:17:16"));
     double v1 = p1->nthValue(1);
     TS_ASSERT_DELTA(v1, 2, 0.00000001);
 
     Mantid::Kernel::TimeInterval dt2 = p1->nthInterval(2);
-    TS_ASSERT_EQUALS(dt2.begin(), Mantid::Types::Core::DateAndTime("2007-11-30T16:18:40"));
-    TS_ASSERT_EQUALS(dt2.end(), Mantid::Types::Core::DateAndTime("2007-11-30T16:18:50"));
+    TS_ASSERT_EQUALS(dt2.start(), Mantid::Types::Core::DateAndTime("2007-11-30T16:18:40"));
+    TS_ASSERT_EQUALS(dt2.stop(), Mantid::Types::Core::DateAndTime("2007-11-30T16:18:50"));
     double v2 = p1->nthValue(2);
     TS_ASSERT_DELTA(v2, 11, 0.00000001);
 
     Mantid::Kernel::TimeInterval dt12 = p1->nthInterval(11);
-    TS_ASSERT_EQUALS(dt12.begin(), Mantid::Types::Core::DateAndTime("2007-11-30T16:20:10"));
-    TS_ASSERT_EQUALS(dt12.end(), Mantid::Types::Core::DateAndTime("2007-11-30T17:19:30"));
+    TS_ASSERT_EQUALS(dt12.start(), Mantid::Types::Core::DateAndTime("2007-11-30T16:20:10"));
+    TS_ASSERT_EQUALS(dt12.stop(), Mantid::Types::Core::DateAndTime("2007-11-30T17:19:30"));
     double v12 = p1->nthValue(11);
     TS_ASSERT_DELTA(v12, 20, 1.0E-8);
 
@@ -2026,8 +2026,8 @@ public:
 
     // 4. Check interval
     Mantid::Kernel::TimeInterval dt0 = p1->nthInterval(0);
-    TS_ASSERT_EQUALS(dt0.begin(), Mantid::Types::Core::DateAndTime("2007-11-30T16:17:16"));
-    TS_ASSERT_EQUALS(dt0.end(), Mantid::Types::Core::DateAndTime("2007-11-30T16:17:20"));
+    TS_ASSERT_EQUALS(dt0.start(), Mantid::Types::Core::DateAndTime("2007-11-30T16:17:16"));
+    TS_ASSERT_EQUALS(dt0.stop(), Mantid::Types::Core::DateAndTime("2007-11-30T16:17:20"));
     double v0 = p1->nthValue(0);
     TS_ASSERT_DELTA(v0, 2, 1.0E-8);
 
@@ -2075,14 +2075,14 @@ public:
 
     // 4. Check interval
     Mantid::Kernel::TimeInterval dt1 = p1->nthInterval(1);
-    TS_ASSERT_EQUALS(dt1.begin(), Mantid::Types::Core::DateAndTime("2007-11-30T16:17:10"));
-    TS_ASSERT_EQUALS(dt1.end(), Mantid::Types::Core::DateAndTime("2007-11-30T16:17:16"));
+    TS_ASSERT_EQUALS(dt1.start(), Mantid::Types::Core::DateAndTime("2007-11-30T16:17:10"));
+    TS_ASSERT_EQUALS(dt1.stop(), Mantid::Types::Core::DateAndTime("2007-11-30T16:17:16"));
     double v1 = p1->nthValue(1);
     TS_ASSERT_DELTA(v1, 2, 1.0E-8);
 
     Mantid::Kernel::TimeInterval dt2 = p1->nthInterval(2);
-    TS_ASSERT_EQUALS(dt2.begin(), Mantid::Types::Core::DateAndTime("2007-11-30T16:18:40"));
-    TS_ASSERT_EQUALS(dt2.end(), Mantid::Types::Core::DateAndTime("2007-11-30T16:18:50"));
+    TS_ASSERT_EQUALS(dt2.start(), Mantid::Types::Core::DateAndTime("2007-11-30T16:18:40"));
+    TS_ASSERT_EQUALS(dt2.stop(), Mantid::Types::Core::DateAndTime("2007-11-30T16:18:50"));
     double v2 = p1->nthValue(2);
     TS_ASSERT_DELTA(v2, 11, 1.0E-8);
 
@@ -2131,8 +2131,8 @@ public:
 
     // 4. Check interval
     Mantid::Kernel::TimeInterval dt0 = p1->nthInterval(0);
-    TS_ASSERT_EQUALS(dt0.begin(), Mantid::Types::Core::DateAndTime("2007-11-30T16:17:16"));
-    TS_ASSERT_EQUALS(dt0.end(), Mantid::Types::Core::DateAndTime("2007-11-30T16:17:20"));
+    TS_ASSERT_EQUALS(dt0.start(), Mantid::Types::Core::DateAndTime("2007-11-30T16:17:16"));
+    TS_ASSERT_EQUALS(dt0.stop(), Mantid::Types::Core::DateAndTime("2007-11-30T16:17:20"));
     double v0 = p1->nthValue(0);
     TS_ASSERT_DELTA(v0, 2, 1.0E-8);
 
@@ -2311,13 +2311,13 @@ public:
     const auto &intervals = log->getSplittingIntervals();
     TS_ASSERT_EQUALS(intervals.size(), 1);
     const auto &range = intervals.front();
-    TS_ASSERT_EQUALS(range.begin(), log->firstTime());
+    TS_ASSERT_EQUALS(range.start(), log->firstTime());
 
     // the range is extended by the last difference in times
     // this is to make the last value count as much as the penultimate
     const auto lastDuration = log->nthInterval(log->size() - 1).length();
     const auto stop = log->lastTime() + lastDuration;
-    TS_ASSERT_EQUALS(range.end(), stop);
+    TS_ASSERT_EQUALS(range.stop(), stop);
   }
 
   void test_getSplittingIntervals_repeatedEntries() {
@@ -2337,10 +2337,10 @@ public:
     TS_ASSERT_EQUALS(intervals.size(), 2);
     if (intervals.size() == 2) {
       const auto &firstRange = intervals.front(), &secondRange = intervals.back();
-      TS_ASSERT_EQUALS(firstRange.begin(), firstStart);
-      TS_ASSERT_EQUALS(firstRange.end(), firstEnd);
-      TS_ASSERT_EQUALS(secondRange.begin(), secondStart);
-      TS_ASSERT_EQUALS(secondRange.end(), secondEnd);
+      TS_ASSERT_EQUALS(firstRange.start(), firstStart);
+      TS_ASSERT_EQUALS(firstRange.stop(), firstEnd);
+      TS_ASSERT_EQUALS(secondRange.start(), secondStart);
+      TS_ASSERT_EQUALS(secondRange.stop(), secondEnd);
     }
   }
 
@@ -2359,12 +2359,12 @@ public:
     const auto &intervals = log->getSplittingIntervals();
     TS_ASSERT_EQUALS(intervals.size(), 3);
     if (intervals.size() == 3) {
-      TS_ASSERT_EQUALS(intervals[0].begin(), log->firstTime());
-      TS_ASSERT_EQUALS(intervals[0].end(), firstEnd);
-      TS_ASSERT_EQUALS(intervals[1].begin(), secondStart);
-      TS_ASSERT_EQUALS(intervals[1].end(), secondEnd);
-      TS_ASSERT_EQUALS(intervals[2].begin(), thirdStart);
-      TS_ASSERT(intervals[2].end() > thirdStart);
+      TS_ASSERT_EQUALS(intervals[0].start(), log->firstTime());
+      TS_ASSERT_EQUALS(intervals[0].stop(), firstEnd);
+      TS_ASSERT_EQUALS(intervals[1].start(), secondStart);
+      TS_ASSERT_EQUALS(intervals[1].stop(), secondEnd);
+      TS_ASSERT_EQUALS(intervals[2].start(), thirdStart);
+      TS_ASSERT(intervals[2].stop() > thirdStart);
     }
   }
 

--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -35,12 +35,6 @@ unusedPrivateFunction
 // ----------- New list of supressions after updating to cppcheck 2.5 -------------
 // - If the line number changes then update it here, or resolve the defect and remove from list
 
-mismatchingContainerExpression:${CMAKE_SOURCE_DIR}/Framework/Kernel/src/LogFilter.cpp:55
-mismatchingContainerExpression:${CMAKE_SOURCE_DIR}/Framework/Kernel/src/LogFilter.cpp:59
-mismatchingContainerExpression:${CMAKE_SOURCE_DIR}/Framework/Kernel/src/LogFilter.cpp:74
-mismatchingContainerExpression:${CMAKE_SOURCE_DIR}/Framework/Kernel/src/LogFilter.cpp:77
-mismatchingContainerExpression:${CMAKE_SOURCE_DIR}/Framework/Kernel/src/LogFilter.cpp:89
-mismatchingContainerExpression:${CMAKE_SOURCE_DIR}/Framework/Kernel/src/LogFilter.cpp:91
 knownConditionTrueFalse:${CMAKE_SOURCE_DIR}/Framework/Kernel/src/Memory.cpp:284
 unassignedVariable:${CMAKE_SOURCE_DIR}/Framework/Kernel/src/Quat.cpp:687
 unassignedVariable:${CMAKE_SOURCE_DIR}/Framework/Kernel/src/Quat.cpp:687


### PR DESCRIPTION
Since the names were `begin()` and `end()`, cppcheck was frequently convinced that the returns were iterators and would generate warnings. This rename makes it easier for cppcheck.

**To test:**

It is a refactor and should pass all automated tests

Refs #34794.


*This does not require release notes* because it is a code refactor.


<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
