### PR TITLE
MDNormBackgroundHYSPECTest increase tolerance

### DIFF
--- a/Testing/SystemTests/tests/framework/MDNormBackgroundHYSPECTest.py
+++ b/Testing/SystemTests/tests/framework/MDNormBackgroundHYSPECTest.py
@@ -44,7 +44,6 @@ MDNormResults = namedtuple("MDNormResults", "cleaned sample_data, sample_norm, b
 
 
 class MDNormBackgroundHYSPECTest(systemtesting.MantidSystemTest):
-
     tolerance = 1e-8
 
     @staticmethod
@@ -266,7 +265,7 @@ class MDNormBackgroundHYSPECTest(systemtesting.MantidSystemTest):
         r89 = CompareMDWorkspaces(Workspace1=benchmark.bkgd_norm, Workspace2="background_normMD", Tolerance=1e-9)
         assert r89.Equals, f"Incompatible background normalization workspaces: {r89.Result}"
         # Compare the cleaned MD
-        r_out = CompareMDWorkspaces(Workspace1=benchmark.cleaned, Workspace2="clean_data", Tolerance=1e-16)
+        r_out = CompareMDWorkspaces(Workspace1=benchmark.cleaned, Workspace2="clean_data", Tolerance=1e-15)
         if not r_out.Equals:
             raise ValueError(f"Sample output data does not match: {r_out.Result}")
 


### PR DESCRIPTION
Since the test gives slightly [different results on osx](https://builds.mantidproject.org/view/Nightly%20Pipelines/job/main_nightly_deployment_prototype/498/testReport/junit/SystemTests/MDNormBackgroundHYSPECTest/Build_Test__Development__Package__Conda___Matrix___PLATFORM____osx_64___BUILD_TYPE____conda_devel____build_and_test___MDNormBackgroundHYSPECTest/) and windows compared to linux, increase the tolerance for the comparison.

**To test:**

The system test should still pass

*There is no associated issue.*


*This does not require release notes* because it is fixing a system test.

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
