### PR TITLE
Remove matplotlib version checks

### DIFF
--- a/Framework/PythonInterface/mantid/plots/mantidaxes.py
+++ b/Framework/PythonInterface/mantid/plots/mantidaxes.py
@@ -7,10 +7,8 @@
 #  This file is part of the mantid package
 from collections.abc import Iterable
 import copy
-from distutils.version import LooseVersion
 from functools import wraps
 
-import matplotlib
 import numpy as np
 import re
 
@@ -1324,8 +1322,7 @@ class MantidAxes3D(Axes3D):
     name = "mantid3d"
 
     def __init__(self, *args, **kwargs):
-        if LooseVersion("3.4.0") <= LooseVersion(matplotlib.__version__):
-            kwargs["auto_add_to_figure"] = False
+        kwargs["auto_add_to_figure"] = False
         super().__init__(*args, **kwargs)
 
     def set_title(self, *args, **kwargs):
@@ -1378,7 +1375,6 @@ class MantidAxes3D(Axes3D):
                     self.collections[0]._vec[axis_index] = axis_data
 
         if hasattr(self, "original_data_wireframe"):
-
             all_data = copy.deepcopy(self.original_data_wireframe)
 
             for spectrum in range(len(all_data)):

--- a/Framework/PythonInterface/mantid/plots/modest_image/modest_image.py
+++ b/Framework/PythonInterface/mantid/plots/modest_image/modest_image.py
@@ -9,7 +9,6 @@
 Modification of Chris Beaumont's mpl-modest-image package to allow the use of
 set_extent.
 """
-from distutils.version import LooseVersion
 
 import matplotlib
 
@@ -110,9 +109,7 @@ class ModestImage(MantidImage):
 
     @property
     def _pixel2world(self):
-
         if self._pixel2world_cache is None:
-
             # Pre-compute affine transforms to convert between the 'world'
             # coordinates of the axes (what is shown by the axis labels) to
             # 'pixel' coordinates in the underlying array.
@@ -300,11 +297,7 @@ def imshow(
     # to tightly fit the image, regardless of dataLim.
     im.set_extent(im.get_extent())
 
-    if LooseVersion(matplotlib.__version__) <= LooseVersion("3.1.3"):
-        axes.images.append(im)
-        im._remove_method = lambda h: axes.images.remove(h)
-    else:
-        axes.add_image(im)
+    axes.add_image(im)
 
     return im
 

--- a/Framework/PythonInterface/plugins/algorithms/StringToPng.py
+++ b/Framework/PythonInterface/plugins/algorithms/StringToPng.py
@@ -40,10 +40,7 @@ class StringToPng(mantid.api.PythonAlgorithm):
             import matplotlib
         except ImportError:
             ok2run = "Problem importing matplotlib"
-            from distutils.version import LooseVersion
 
-            if LooseVersion(matplotlib.__version__) < LooseVersion("1.2.0"):
-                ok2run = "Wrong version of matplotlib. Required >= 1.2.0"
         if ok2run != "":
             raise RuntimeError(ok2run)
         matplotlib.use("agg")

--- a/Framework/PythonInterface/plugins/algorithms/StringToPng.py
+++ b/Framework/PythonInterface/plugins/algorithms/StringToPng.py
@@ -35,14 +35,8 @@ class StringToPng(mantid.api.PythonAlgorithm):
         )
 
     def PyExec(self):
-        ok2run = ""
-        try:
-            import matplotlib
-        except ImportError:
-            ok2run = "Problem importing matplotlib"
+        import matplotlib
 
-        if ok2run != "":
-            raise RuntimeError(ok2run)
         matplotlib.use("agg")
         import matplotlib.pyplot as plt
 

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SavePlot1D.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SavePlot1D.py
@@ -11,7 +11,6 @@ import importlib
 
 
 class SavePlot1D(mantid.api.PythonAlgorithm):
-
     _wksp = None
 
     def category(self):
@@ -194,19 +193,6 @@ class SavePlot1D(mantid.api.PythonAlgorithm):
         return (data, xlabel, ylabel)
 
     def saveImage(self):
-        """Save image"""
-        ok2run = ""
-        try:
-            import matplotlib
-            from distutils.version import LooseVersion
-
-            if LooseVersion(matplotlib.__version__) < LooseVersion("1.2.0"):
-                ok2run = "Wrong version of matplotlib. Required >= 1.2.0"
-        except ImportError:
-            ok2run = "Problem importing matplotlib"
-        if len(ok2run) > 0:
-            raise RuntimeError(ok2run)
-
         import matplotlib.pyplot as plt
 
         if isinstance(self._wksp, mantid.api.WorkspaceGroup):

--- a/Framework/PythonInterface/test/python/mantid/plots/axesfunctionsTest.py
+++ b/Framework/PythonInterface/test/python/mantid/plots/axesfunctionsTest.py
@@ -184,13 +184,8 @@ class PlotFunctionsTest(unittest.TestCase):
         ax.set_ylim(-0.05, 0.05)
         funcs.update_colorplot_datalimits(ax, mesh)
         self.assertAlmostEqual(10.0, ax.get_xlim()[0])
-        from distutils.version import LooseVersion
 
-        # different results with 1.5.3 and 2.1.1
-        if color_func.__name__ != "imshow" and LooseVersion(matplotlib.__version__) < LooseVersion("2"):
-            self.assertAlmostEqual(100.0, ax.get_xlim()[1])
-        else:
-            self.assertAlmostEqual(30.0, ax.get_xlim()[1])
+        self.assertAlmostEqual(30.0, ax.get_xlim()[1])
         self.assertAlmostEqual(4.0, ax.get_ylim()[0])
         self.assertAlmostEqual(8.0, ax.get_ylim()[1])
 

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/SavePlot1DTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/SavePlot1DTest.py
@@ -17,10 +17,7 @@ except ImportError:
 matplotlibissue = None  # indicates there are no issues
 try:
     import matplotlib
-    from distutils.version import LooseVersion
 
-    if LooseVersion(matplotlib.__version__) < LooseVersion("1.2.0"):
-        matplotlibissue = "Wrong version of matplotlib. Required >= 1.2.0"
     matplotlib.use("agg")
     import matplotlib.pyplot as plt
 except:

--- a/qt/applications/workbench/workbench/plotting/figuremanager.py
+++ b/qt/applications/workbench/workbench/plotting/figuremanager.py
@@ -506,14 +506,12 @@ class FigureManagerWorkbench(FigureManagerBase, QObject):
 
         for cap in errorbar_cap_lines:
             ax.add_line(cap)
-        if LooseVersion("3.7") > LooseVersion(matplotlib.__version__) >= LooseVersion("3.2"):
-            for line_fill in fills:
-                if line_fill not in ax.collections:
-                    ax.add_collection(line_fill)
-        else:
-            raise NotImplementedError(
-                "ArtistList will become an immutable tuple in matplotlib 3.7 and thus, " "this code doesn't work anymore."
-            )
+
+        """ArtistList will become an immutable tuple in matplotlib 3.7 which will prevent iterating through line_fill"""
+        for line_fill in fills:
+            if line_fill not in ax.collections:
+                ax.add_collection(line_fill)
+
         ax.collections.reverse()
         ax.update_waterfall(x, y)
 

--- a/qt/applications/workbench/workbench/plotting/figuremanager.py
+++ b/qt/applications/workbench/workbench/plotting/figuremanager.py
@@ -510,8 +510,6 @@ class FigureManagerWorkbench(FigureManagerBase, QObject):
             for line_fill in fills:
                 if line_fill not in ax.collections:
                     ax.add_collection(line_fill)
-        elif LooseVersion(matplotlib.__version__) < LooseVersion("3.2"):
-            ax.collections += fills
         else:
             raise NotImplementedError(
                 "ArtistList will become an immutable tuple in matplotlib 3.7 and thus, " "this code doesn't work anymore."

--- a/qt/applications/workbench/workbench/plotting/plotscriptgenerator/figure.py
+++ b/qt/applications/workbench/workbench/plotting/plotscriptgenerator/figure.py
@@ -5,9 +5,7 @@
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
 #  This file is part of the mantid workbench.
-from distutils.version import LooseVersion
 
-import matplotlib
 from matplotlib import rcParams
 from numpy import isclose
 
@@ -39,12 +37,8 @@ def get_subplots_command_kwargs(fig):
         "num": fig.get_label(),
         "subplot_kw": {"projection": "mantid"},
     }
-    if LooseVersion("3.1.3") < LooseVersion(matplotlib.__version__):
-        kwargs["ncols"] = ax.get_gridspec().ncols
-        kwargs["nrows"] = ax.get_gridspec().nrows
-    else:
-        kwargs["ncols"] = ax.numCols
-        kwargs["nrows"] = ax.numRows
+    kwargs["ncols"] = ax.get_gridspec().ncols
+    kwargs["nrows"] = ax.get_gridspec().nrows
     return kwargs
 
 

--- a/qt/applications/workbench/workbench/plotting/plotscriptgenerator/test/test_plotscriptgenerator.py
+++ b/qt/applications/workbench/workbench/plotting/plotscriptgenerator/test/test_plotscriptgenerator.py
@@ -7,7 +7,6 @@
 #  This file is part of the mantid workbench.
 
 import unittest
-from distutils.version import LooseVersion
 
 import matplotlib
 
@@ -149,16 +148,11 @@ class PlotScriptGeneratorTest(unittest.TestCase):
         mock_ax = MagicMock(spec=MantidAxes, **mock_kwargs)
         num_rows = kwargs.get("numRows", 1)
         num_cols = kwargs.get("numCols", 1)
-        if LooseVersion("3.1.3") < LooseVersion(matplotlib.__version__):
-            setattr(mock_ax, "get_gridspec", MagicMock())
-            mock_ax.get_gridspec.return_value.nrows = num_rows
-            mock_ax.get_gridspec.return_value.ncols = num_cols
-            setattr(mock_ax, "get_subplotspec", MagicMock())
-            mock_ax.get_subplotspec.return_value.colspan.start = colNum
-        else:
-            mock_kwargs["numRows"] = num_rows
-            mock_kwargs["numCols"] = num_cols
-            mock_ax.colNum = colNum
+        setattr(mock_ax, "get_gridspec", MagicMock())
+        mock_ax.get_gridspec.return_value.nrows = num_rows
+        mock_ax.get_gridspec.return_value.ncols = num_cols
+        setattr(mock_ax, "get_subplotspec", MagicMock())
+        mock_ax.get_subplotspec.return_value.colspan.start = colNum
 
         mock_ax.xaxis.minor.locator = Mock(spec=NullLocator)
         mock_ax.xaxis._major_tick_kw = {"gridOn": False}
@@ -249,7 +243,6 @@ class PlotScriptGeneratorTest(unittest.TestCase):
     def test_generate_script_compiles_script_correctly_with_fit(
         self, mock_subplots_cmd, mock_plot_cmd, mock_retrieval_cmd, mock_axis_lim_cmd, mock_autoscale_lims, mock_fit_cmds
     ):
-
         mock_retrieval_cmd.return_value = self.retrieval_cmds
         mock_subplots_cmd.return_value = self.subplots_cmd
         mock_plot_cmd.return_value = self.plot_cmd

--- a/qt/applications/workbench/workbench/plotting/propertiesdialog.py
+++ b/qt/applications/workbench/workbench/plotting/propertiesdialog.py
@@ -9,7 +9,6 @@
 #
 
 # 3rdparty imports
-from distutils.version import LooseVersion
 
 from mantid.plots.datafunctions import update_colorbar_scale, get_images_from_figure
 from mantidqt.plotting.figuretype import FigureType, figure_type
@@ -17,7 +16,6 @@ from mantidqt.utils.qt import load_ui
 
 from matplotlib.colors import LogNorm, Normalize
 from matplotlib.ticker import ScalarFormatter, LogFormatterSciNotation
-from matplotlib import __version__ as matplotlib_version
 from mpl_toolkits.mplot3d.axes3d import Axes3D
 from qtpy.QtGui import QDoubleValidator, QIcon
 from qtpy.QtWidgets import QDialog, QWidget
@@ -169,7 +167,7 @@ class AxisEditor(PropertiesEditorBase):
             self.lim_setter = getattr(axes, "set_{}lim".format(axis_id))
 
         self.scale_setter = getattr(axes, "set_{}scale".format(axis_id))
-        self.nonposkw = "nonpos" + axis_id if LooseVersion(matplotlib_version) < LooseVersion("3.3.1") else "nonpositive"
+        self.nonposkw = "nonpositive"
 
         # Store the axis for attributes that can't be directly accessed
         # from axes object (e.g. grid and tick parameters).

--- a/qt/python/mantidqt/mantidqt/plotting/functions.py
+++ b/qt/python/mantidqt/mantidqt/plotting/functions.py
@@ -12,7 +12,6 @@ our custom window.
 """
 
 # std imports
-from distutils.version import LooseVersion
 
 import matplotlib
 import numpy as np
@@ -354,11 +353,8 @@ def plot_surface(workspaces, fig=None):
             fig.clf()
             ax = fig.add_subplot(111, projection="mantid3d")
         else:
-            if LooseVersion("3.4.0") <= LooseVersion(matplotlib.__version__):
-                fig, ax = plt.subplots(subplot_kw={"projection": "mantid3d", "auto_add_to_figure": False})
-                fig.add_axes(ax)
-            else:
-                fig, ax = plt.subplots(subplot_kw={"projection": "mantid3d"})
+            fig, ax = plt.subplots(subplot_kw={"projection": "mantid3d", "auto_add_to_figure": False})
+            fig.add_axes(ax)
 
         surface = ax.plot_surface(ws, cmap=ConfigService.getString("plots.images.Colormap"))
         ax.set_title(ws.name())

--- a/qt/python/mantidqt/mantidqt/plotting/mantid_navigation_toolbar.py
+++ b/qt/python/mantidqt/mantidqt/plotting/mantid_navigation_toolbar.py
@@ -16,7 +16,6 @@ from matplotlib.backend_bases import NavigationToolbar2
 from matplotlib.backends.backend_qt5 import SubplotToolQt
 from matplotlib import backend_tools
 
-from distutils.version import LooseVersion
 import os
 
 
@@ -179,13 +178,12 @@ class MantidNavigationToolbar(NavigationToolbar2, QToolBar):
                 QMessageBox.critical(self, "Error saving file", str(e), QMessageBox.Ok, QMessageBox.NoButton)
 
     def set_history_buttons(self):
-        if LooseVersion(matplotlib.__version__) >= LooseVersion("2.1.1"):
-            can_backward = self._nav_stack._pos > 0
-            can_forward = self._nav_stack._pos < len(self._nav_stack._elements) - 1
-            if "back" in self._actions:
-                self._actions["back"].setEnabled(can_backward)
-            if "forward" in self._actions:
-                self._actions["forward"].setEnabled(can_forward)
+        can_backward = self._nav_stack._pos > 0
+        can_forward = self._nav_stack._pos < len(self._nav_stack._elements) - 1
+        if "back" in self._actions:
+            self._actions["back"].setEnabled(can_backward)
+        if "forward" in self._actions:
+            self._actions["forward"].setEnabled(can_forward)
 
     def _get_mode(self):
         if hasattr(self, "name"):

--- a/qt/python/mantidqt/mantidqt/plotting/test/test_tiledplots.py
+++ b/qt/python/mantidqt/mantidqt/plotting/test/test_tiledplots.py
@@ -8,7 +8,6 @@
 #
 #
 # std imports
-from distutils.version import LooseVersion
 from unittest import TestCase, main
 
 # third party imports
@@ -50,12 +49,9 @@ def set_figure_as_current_figure(initial_fig):
     fig_manager = mock.MagicMock()
     fig_manager.canvas.figure = initial_fig
     _pylab_helpers.Gcf.figs.update({1: fig_manager})
-    if LooseVersion("3.1.3") > LooseVersion(matplotlib.__version__):
-        _pylab_helpers.Gcf._activeQue.append(fig_manager)
 
 
 class TiledPlotsTest(TestCase):
-
     _test_ws = None
     _test_ws_2 = None
 

--- a/qt/python/mantidqt/mantidqt/widgets/plotconfigdialog/imagestabwidget/test/test_imagestabwidgetpresenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/plotconfigdialog/imagestabwidget/test/test_imagestabwidgetpresenter.py
@@ -7,7 +7,6 @@
 #  This file is part of the mantid workbench.
 
 import unittest
-from distutils.version import LooseVersion
 
 import matplotlib
 from matplotlib import use as mpl_use
@@ -191,10 +190,7 @@ class ImagesTabWidgetPresenterTest(unittest.TestCase):
     def test_apply_properties_applies_to_all_images_if_multiple_colorfill_plots_and_one_colorbar(self):
         fig = pcolormesh([self.ws, self.ws])
         props = {"label": "New Label", "colormap": "jet", "vmin": 0, "vmax": 2, "scale": "Linear", "interpolation": "None"}
-        if LooseVersion(matplotlib.__version__) > LooseVersion("3.1.3"):
-            mock_view = Mock(get_selected_image_name=lambda: "ws: (0, 0) - child0", get_properties=lambda: ImageProperties(props))
-        else:
-            mock_view = Mock(get_selected_image_name=lambda: "ws: (0, 0) - image0", get_properties=lambda: ImageProperties(props))
+        mock_view = Mock(get_selected_image_name=lambda: "ws: (0, 0) - child0", get_properties=lambda: ImageProperties(props))
         presenter = self._generate_presenter(fig=fig, view=mock_view)
         presenter.apply_properties()
 
@@ -224,10 +220,7 @@ class ImagesTabWidgetPresenterTest(unittest.TestCase):
         self.assertTrue(isinstance(fig.axes[0].images[0], matplotlib.image.AxesImage))
         self.assertTrue(isinstance(fig.axes[1].collections[0], matplotlib.collections.QuadMesh))
         props = {"label": "New Label", "colormap": "jet", "vmin": 0, "vmax": 2, "scale": "Linear", "interpolation": "None"}
-        if LooseVersion(matplotlib.__version__) > LooseVersion("3.1.3"):
-            mock_view = Mock(get_selected_image_name=lambda: "ws: (0, 0) - child0", get_properties=lambda: ImageProperties(props))
-        else:
-            mock_view = Mock(get_selected_image_name=lambda: "ws: (0, 0) - image0", get_properties=lambda: ImageProperties(props))
+        mock_view = Mock(get_selected_image_name=lambda: "ws: (0, 0) - child0", get_properties=lambda: ImageProperties(props))
         presenter = self._generate_presenter(fig=fig, view=mock_view)
         presenter.apply_properties()
 

--- a/qt/python/mantidqt/mantidqt/widgets/plotconfigdialog/test/test_apply_all_properties.py
+++ b/qt/python/mantidqt/mantidqt/widgets/plotconfigdialog/test/test_apply_all_properties.py
@@ -347,10 +347,7 @@ class ApplyAllPropertiesTest(unittest.TestCase):
         self.assertEqual(new_legend_props["round_edges"], isinstance(self.new_legend.legendPatch.get_boxstyle(), BoxStyle.Round))
 
     def test_apply_properties_on_figure_with_legend_sets_number_of_columns(self):
-        if LooseVersion(matplotlib.__version__) >= LooseVersion("3.6.0"):
-            self.assertEqual(new_legend_props["columns"], self.new_legend._ncols)
-        else:
-            self.assertEqual(new_legend_props["columns"], self.new_legend._ncol)
+        self.assertEqual(new_legend_props["columns"], self.new_legend._ncols)
 
     def test_apply_properties_on_figure_with_legend_sets_column_spacing(self):
         self.assertEqual(new_legend_props["column_spacing"], self.new_legend.columnspacing)

--- a/qt/python/mantidqt/mantidqt/widgets/plotconfigdialog/test/test_apply_all_properties.py
+++ b/qt/python/mantidqt/mantidqt/widgets/plotconfigdialog/test/test_apply_all_properties.py
@@ -7,7 +7,6 @@
 #  This file is part of the mantid workbench.
 
 import unittest
-from distutils.version import LooseVersion
 
 import matplotlib
 from matplotlib import use as mpl_use
@@ -180,14 +179,7 @@ class ApplyAllPropertiesTest(unittest.TestCase):
         cls.new_curve = cls.ax.containers[0]
 
         # Mock images tab view
-        if LooseVersion(matplotlib.__version__) > LooseVersion("3.1.3"):
-            cls.img_view_mock = Mock(
-                get_selected_image_name=lambda: "(0, 0) - child0", get_properties=lambda: ImageProperties(new_image_props)
-            )
-        else:
-            cls.img_view_mock = Mock(
-                get_selected_image_name=lambda: "(0, 0) - image0", get_properties=lambda: ImageProperties(new_image_props)
-            )
+        cls.img_view_mock = Mock(get_selected_image_name=lambda: "(0, 0) - child0", get_properties=lambda: ImageProperties(new_image_props))
         cls.img_view_patch = patch(IMAGE_VIEW, lambda x: cls.img_view_mock)
         cls.img_view_patch.start()
 

--- a/qt/python/mantidqt/mantidqt/widgets/regionselector/presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/regionselector/presenter.py
@@ -4,7 +4,6 @@
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
 #  This file is part of the mantid workbench.
-from distutils.version import LooseVersion
 from typing import Callable
 
 from .view import RegionSelectorView
@@ -15,7 +14,6 @@ from ..sliceviewer.presenters.base_presenter import SliceViewerBasePresenter
 from mantid.api import RegionSelectorObserver
 
 # 3rd party imports
-import matplotlib
 from matplotlib.widgets import RectangleSelector
 
 
@@ -31,11 +29,10 @@ class Selector(RectangleSelector):
     }
 
     def __init__(self, region_type: str, color: str, *args):
-        if LooseVersion(matplotlib.__version__) >= LooseVersion("3.5.0"):
-            self.kwargs["props"] = dict(facecolor="white", edgecolor=color, alpha=0.2, linewidth=2, fill=True)
-            self.kwargs["handle_props"] = dict(markersize=4)
-            self.kwargs["drag_from_anywhere"] = True
-            self.kwargs["ignore_event_outside"] = True
+        self.kwargs["props"] = dict(facecolor="white", edgecolor=color, alpha=0.2, linewidth=2, fill=True)
+        self.kwargs["handle_props"] = dict(markersize=4)
+        self.kwargs["drag_from_anywhere"] = True
+        self.kwargs["ignore_event_outside"] = True
 
         super().__init__(*args, **self.kwargs)
         self._region_type = region_type
@@ -45,8 +42,7 @@ class Selector(RectangleSelector):
 
     def set_active(self, active: bool) -> None:
         """Hide the handles of a selector if it is not active."""
-        if LooseVersion(matplotlib.__version__) >= LooseVersion("3.5.0"):
-            self.set_handle_props(alpha=self.active_handle_alpha if active else 0)
+        self.set_handle_props(alpha=self.active_handle_alpha if active else 0)
         super().set_active(active)
 
 

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/DGSPlanner/DGSPlannerGUI.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/DGSPlanner/DGSPlannerGUI.py
@@ -8,9 +8,7 @@
 import copy
 import os
 import sys
-from distutils.version import LooseVersion
 
-import matplotlib
 import numpy
 from mantidqt.MPLwidgets import *
 from mantidqt.gui_helper import show_interface_help
@@ -105,8 +103,6 @@ class DGSPlannerGUI(QtWidgets.QWidget):
         self.canvas = FigureCanvas(self.figure)
         self.grid_helper = GridHelperCurveLinear((self.tr, self.inv_tr))
         self.trajfig = Subplot(self.figure, 1, 1, 1, grid_helper=self.grid_helper)
-        if LooseVersion("2.1.0") > LooseVersion(matplotlib.__version__):
-            self.trajfig.hold(True)  # hold is deprecated since 2.1.0, true by default
         self.figure.add_subplot(self.trajfig)
         self.toolbar = MantidNavigationToolbar(self.canvas, self)
         figureLayout = QtWidgets.QVBoxLayout()

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/DGSPlanner/InstrumentSetupWidget.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/DGSPlanner/InstrumentSetupWidget.py
@@ -5,7 +5,6 @@
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
 # pylint: disable=invalid-name,no-name-in-module,too-many-instance-attributes,too-many-public-methods
-from distutils.version import LooseVersion
 
 from qtpy import QtGui, QtCore, QtWidgets
 import sys
@@ -307,13 +306,8 @@ class InstrumentSetupWidget(QtWidgets.QWidget):
         # plot directions
         if self.gonfig is not None:
             self.gonfig.clear()
-        if LooseVersion("3.4.0") <= LooseVersion(matplotlib.__version__):
-            self.gonfig = Axes3D(self.figure, auto_add_to_figure=False)
-            self.figure.add_axes(self.gonfig)
-        else:
-            self.gonfig = Axes3D(self.figure)
-        if LooseVersion("2.1.0") > LooseVersion(matplotlib.__version__):
-            self.gonfig.hold(True)  # hold is deprecated since 2.1.0, true by default
+        self.gonfig = Axes3D(self.figure, auto_add_to_figure=False)
+        self.figure.add_axes(self.gonfig)
         self.gonfig.set_frame_on(False)
         self.gonfig.set_xlim3d(-0.6, 0.6)
         self.gonfig.set_ylim3d(-0.6, 0.6)

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/HFIR_4Circle_Reduction/mplgraphicsview3d.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/HFIR_4Circle_Reduction/mplgraphicsview3d.py
@@ -5,9 +5,7 @@
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
 # pylint: disable=R0901,R0902,R0904
-from distutils.version import LooseVersion
 
-import matplotlib
 import numpy as np
 import os
 
@@ -39,11 +37,8 @@ class MplPlot3dCanvas(FigureCanvas):
         FigureCanvas.updateGeometry(self)
 
         # Axes
-        if LooseVersion("3.4.0") <= LooseVersion(matplotlib.__version__):
-            self._myAxes = Axes3D(self._myFigure, auto_add_to_figure=False)  # Canvas figure must be created for mouse rotation
-            self._myFigure.add_axes(self._myAxes)
-        else:
-            self._myAxes = Axes3D(self._myFigure)
+        self._myAxes = Axes3D(self._myFigure, auto_add_to_figure=False)  # Canvas figure must be created for mouse rotation
+        self._myFigure.add_axes(self._myAxes)
         self.format_coord_org = self._myAxes.format_coord
         self._myAxes.format_coord = self.report_pixel
 

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/PyChop/PyChopGui.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/PyChop/PyChopGui.py
@@ -16,7 +16,6 @@ This module contains a class to create a graphical user interface for PyChop.
 
 import sys
 import re
-from distutils.version import LooseVersion
 
 import numpy as np
 import os
@@ -45,7 +44,6 @@ from qtpy.QtWidgets import (
     QVBoxLayout,
     QWidget,
 )  # noqa
-import matplotlib
 from matplotlib.figure import Figure
 from matplotlib.widgets import Slider
 
@@ -335,10 +333,7 @@ class PyChopGui(QMainWindow):
 
     def _set_overplot(self, overplot, axisname):
         axis = getattr(self, axisname)
-        if overplot:
-            if LooseVersion("2.1.0") > LooseVersion(matplotlib.__version__):
-                axis.hold(True)
-        else:
+        if not overplot:
             setattr(self, axisname + "_xlim", 0)
             axis.clear()
             axis.axhline(color="k")
@@ -356,8 +351,6 @@ class PyChopGui(QMainWindow):
         if hasattr(freq, "__len__"):
             freq = freq[0]
         if multiplot:
-            if LooseVersion("2.1.0") > LooseVersion(matplotlib.__version__):
-                self.resaxes.hold(True)
             for ie, Ei in enumerate(self.eis):
                 en = np.linspace(0, 0.95 * Ei, 200)
                 if any(self.res[ie]):
@@ -369,8 +362,6 @@ class PyChopGui(QMainWindow):
                     if self.tabs.isTabEnabled(self.qetabID):
                         self.plot_qe(Ei, label_text, hold=True)
                     self.resaxes_xlim = max(Ei, self.resaxes_xlim)
-            if LooseVersion("2.1.0") > LooseVersion(matplotlib.__version__):
-                self.resaxes.hold(False)
         else:
             ei = self.engine.getEi()
             en = np.linspace(0, 0.95 * ei, 200)
@@ -445,9 +436,6 @@ class PyChopGui(QMainWindow):
         if update:
             self.flxaxes1.clear()
             self.flxaxes2.clear()
-            if LooseVersion("2.1.0") > LooseVersion(matplotlib.__version__):
-                self.flxaxes1.hold(True)
-                self.flxaxes2.hold(True)
             for ii, instrument in enumerate(tmpinst):
                 for ie, ei in enumerate(eis):
                     with warnings.catch_warnings(record=True):
@@ -463,11 +451,7 @@ class PyChopGui(QMainWindow):
                     warnings.simplefilter("always", UserWarning)
                     flux[ie] = self.engine.getFlux(ei)
                     elres[ie] = self.engine.getResolution(0.0, ei)[0]
-            if overplot:
-                if LooseVersion("2.1.0") > LooseVersion(matplotlib.__version__):
-                    self.flxaxes1.hold(True)
-                    self.flxaxes2.hold(True)
-            else:
+            if not overplot:
                 self.flxaxes1.clear()
                 self.flxaxes2.clear()
             self.flxaxes1.plot(eis, flux)
@@ -530,11 +514,7 @@ class PyChopGui(QMainWindow):
                 warnings.simplefilter("always", UserWarning)
                 flux[ie] = self.engine.getFlux(ei)
                 elres[ie] = self.engine.getResolution(0.0, ei)[0]
-        if overplot:
-            if LooseVersion("2.1.0") > LooseVersion(matplotlib.__version__):
-                self.frqaxes1.hold(True)
-                self.frqaxes2.hold(True)
-        else:
+        if not overplot:
             self.frqaxes1.clear()
             self.frqaxes2.clear()
         self.setFreq(manual_freq=freq0)

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/QECoverage/QECoverageGUI.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/QECoverage/QECoverageGUI.py
@@ -4,14 +4,12 @@
 #   NScD Oak Ridge National Laboratory, European Spallation Source,
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
-from distutils.version import LooseVersion
 
 from mantidqt.gui_helper import show_interface_help
 import numpy as np
 import mantid
 from qtpy import QtWidgets, QtCore
 from mantidqt.MPLwidgets import *
-import matplotlib
 from matplotlib.figure import Figure
 from scipy import constants
 
@@ -383,8 +381,6 @@ class QECoverageGUI(QtWidgets.QWidget):
             self.xlim = 0
             self.axes.clear()
             self.axes.axhline(color="k")
-        if LooseVersion("2.1.0") > LooseVersion(matplotlib.__version__):
-            self.axes.hold(True)  # hold is deprecated since 2.1.0, true by default
         Inst = self.direct_inst_box.currentText()
         for n in range(len(qe)):
             name = Inst + "_Ei=" + str(ei_vec[n])
@@ -417,9 +413,6 @@ class QECoverageGUI(QtWidgets.QWidget):
             self.xlim = 0
             self.axes.clear()
             self.axes.axhline(color="k")
-        else:
-            if LooseVersion("2.1.0") > LooseVersion(matplotlib.__version__):
-                self.axes.hold(True)  # hold is deprecated since 2.1.0, true by default
         (line,) = self.axes.plot(qe[0][0], qe[0][1])
         line.set_label(inst + "_" + ana)
         if max(qe[0][0]) > self.xlim:
@@ -433,7 +426,6 @@ class QECoverageGUI(QtWidgets.QWidget):
         self.canvas.draw()
 
     def direct_input_check(self, ei_vec):
-
         if len(ei_vec) > 0:
             ei_str = ""
             update_ei_str = False
@@ -480,7 +472,6 @@ class QECoverageGUI(QtWidgets.QWidget):
         return ei_vec
 
     def indirect_input_check(self, ana):
-
         Emax_min = 0
         if ana == "PG002" or ana == "Mica006":
             Emax_min = -1


### PR DESCRIPTION
**Description of work.**

Remove unneccessary matplotlib version checks. Newer conda packaging means very old versions of matplotlib no longer need to be supported.

**To test:**
1. Tests need to pass
2. Undertake the Smoke Testing for plotting (including SliceViewer) - see #35238 for examples.

Fixes #34650


*This does not require release notes* because **users should not see any difference**



---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
