### PR TITLE
Prepend drive to jenkins workspace if missing on VM agents

### DIFF
--- a/buildconfig/Jenkins/Conda/nightly_build_and_deploy.jenkinsfile
+++ b/buildconfig/Jenkins/Conda/nightly_build_and_deploy.jenkinsfile
@@ -289,13 +289,16 @@ pipeline {
 
 def git_branch_name() {
   name = scm.branches[0].name
-  if (name.contains("*/")) {
+  if(name.contains("*/")) {
     name = name.split("\\*/")[1]
   }
   return name
 }
 
 def toUnixStylePath(path) {
+  if(!path.startsWith("C:")) {
+    path = "C:" + path
+  }
   return path.replaceAll("\\\\", "/")
 }
 


### PR DESCRIPTION
**Description of work.**
The `WORKSPACE` variable used in the nightly pipeline Jenkinsfile is missing the `C:` on cloud VM Windows nodes. Here it is prepended if it's not there.

**To test:**

Verify that this job passed all build/test and package steps:
https://builds.mantidproject.org/job/build_packages_from_branch/249/

Fixes #35119

*This does not require release notes* because **it's a change to our build config**

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
