### PR TITLE
Fix for ALFView when Maintain Aspect Ratio is on

### DIFF
--- a/qt/scientific_interfaces/Direct/ALFInstrumentView.cpp
+++ b/qt/scientific_interfaces/Direct/ALFInstrumentView.cpp
@@ -153,12 +153,16 @@ MantidWidgets::IInstrumentActor const &ALFInstrumentView::getInstrumentActor() c
 }
 
 std::vector<DetectorTube> ALFInstrumentView::getSelectedDetectors() const {
-  auto const surface = std::dynamic_pointer_cast<MantidQt::MantidWidgets::UnwrappedSurface>(
-      m_instrumentWidget->getInstrumentDisplay()->getSurface());
+  auto const surface = m_instrumentWidget->getInstrumentDisplay()->getSurface();
+  auto const unwrappedSurface = std::dynamic_pointer_cast<MantidQt::MantidWidgets::UnwrappedSurface>(surface);
+
+  if (!unwrappedSurface) {
+    return {};
+  }
 
   std::vector<size_t> detectorIndices;
   // Find the detectors which are being intersected by the "masked" shapes.
-  surface->getIntersectingDetectors(detectorIndices);
+  unwrappedSurface->getIntersectingDetectors(detectorIndices);
   // Find all the detector indices in the entirety of the selected tubes
   return m_instrumentWidget->findWholeTubeDetectorIndices(detectorIndices);
 }

--- a/qt/widgets/instrumentview/src/UnwrappedSurface.cpp
+++ b/qt/widgets/instrumentview/src/UnwrappedSurface.cpp
@@ -495,19 +495,21 @@ QRect UnwrappedSurface::detectorQRectInPixels(const std::size_t detectorIndex) c
     return QRect();
   }
 
+  const auto expandedViewRect = correctForAspectRatioAndZoom(m_viewImage->width(), m_viewImage->height());
+
   const QSizeF viewSizeLogical(m_viewImage->width() / m_viewImage->devicePixelRatio(),
                                m_viewImage->height() / m_viewImage->devicePixelRatio());
   const double vwidth = viewSizeLogical.width();
   const double vheight = viewSizeLogical.height();
-  const double dw = fabs(m_viewRect.width() / vwidth);
-  const double dh = fabs(m_viewRect.height() / vheight);
+  const double dw = fabs(expandedViewRect.width() / vwidth);
+  const double dh = fabs(expandedViewRect.height() / vheight);
 
   const auto detRect = detIter->toQRectF();
 
   // Calculate the centre position of the QRect. The x position will be different depending on if the view is flipped
-  const auto xCentre =
-      m_flippedView ? (m_viewRect.x0() - detRect.center().x()) / dw : (detRect.center().x() - m_viewRect.x0()) / dw;
-  const auto yCentre = (detRect.center().y() - m_viewRect.y0()) / dh;
+  const auto xCentre = m_flippedView ? (expandedViewRect.x0() - detRect.center().x()) / dw
+                                     : (detRect.center().x() - expandedViewRect.x0()) / dw;
+  const auto yCentre = (detRect.center().y() - expandedViewRect.y0()) / dh;
 
   // Calculate the width and height of the QRect
   const auto size = QSize(static_cast<int>(detRect.width() / dw), static_cast<int>(detRect.height() / dh));


### PR DESCRIPTION
**Description of work.**
This PR fixes the calculation of a detectors QRect when the `Maintain aspect ratio` option is turned on in the Instrument View Render tab. 

**To test:**
Follow the instructions in the linked issue, and code review.

Fixes #35314

*This does not require release notes* because **the bug does not exist in Mantid v6.6. The problem was introduced in https://github.com/mantidproject/mantid/pull/35090**

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
