### PR TITLE
Create a function for creating TimeROI map from splitting intervals

### DIFF
--- a/Framework/Kernel/inc/MantidKernel/SplittingInterval.h
+++ b/Framework/Kernel/inc/MantidKernel/SplittingInterval.h
@@ -11,6 +11,11 @@
 namespace Mantid {
 namespace Kernel {
 
+//-----------------------------------------------------------------------------
+// Forward declarations
+//-----------------------------------------------------------------------------
+class TimeROI;
+
 /**
  * Class holding a start/end time and a destination for splitting
  * event lists and logs.
@@ -55,6 +60,10 @@ MANTID_KERNEL_DLL SplittingIntervalVec operator+(const SplittingIntervalVec &a, 
 MANTID_KERNEL_DLL SplittingIntervalVec operator&(const SplittingIntervalVec &a, const SplittingIntervalVec &b);
 MANTID_KERNEL_DLL SplittingIntervalVec operator|(const SplittingIntervalVec &a, const SplittingIntervalVec &b);
 MANTID_KERNEL_DLL SplittingIntervalVec operator~(const SplittingIntervalVec &a);
+
+// -------------- Helper Functions ---------------------
+// for every workspace index, create a TimeROI out of its associated spliting intervals
+MANTID_KERNEL_DLL std::map<int, TimeROI> timeROIsFromSplitters(const SplittingIntervalVec &splitters);
 
 } // Namespace Kernel
 } // Namespace Mantid


### PR DESCRIPTION
This adds a new function for converting a bunch of SplittingIntervals into a map of TimeROI. This is a  pulling a atomic set of changes from #35168 into a separate PR to reduce the review burden.

**To test:**

<!-- Instructions for testing. -->

Refs  #34794

*This does not require release notes* because it is a small component of the larger event filtering overhaul.

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
