### PR TITLE
Use reference to avoid copy

### DIFF
--- a/Framework/DataObjects/src/TimeSplitter.cpp
+++ b/Framework/DataObjects/src/TimeSplitter.cpp
@@ -39,7 +39,7 @@ TimeSplitter::TimeSplitter(const DateAndTime &start, const DateAndTime &stop) {
 
 std::string TimeSplitter::debugPrint() const {
   std::stringstream msg;
-  for (const auto iter : m_roi_map)
+  for (const auto &iter : m_roi_map)
     msg << iter.second << "|" << iter.first << "\n";
   return msg.str();
 }
@@ -147,7 +147,7 @@ std::vector<int> TimeSplitter::outputWorkspaceIndices() const {
   std::set<int> outputSet;
 
   // copy all of the (not ignore) output workspace indices
-  for (const auto iter : m_roi_map) {
+  for (const auto &iter : m_roi_map) {
     if (iter.second > IGNORE_VALUE)
       outputSet.insert(iter.second);
   }

--- a/Framework/Kernel/src/TimeROI.cpp
+++ b/Framework/Kernel/src/TimeROI.cpp
@@ -189,7 +189,7 @@ void TimeROI::addMask(const Types::Core::DateAndTime &startTime, const Types::Co
     // loop through all current splitters and get new intersections
     std::vector<TimeInterval> output;
     TimeInterval intersection;
-    for (const auto interval : this->toSplitters()) {
+    for (const auto &interval : this->toSplitters()) {
       intersection = use_before.intersection(interval);
       if (intersection.isValid()) {
         output.push_back(intersection);
@@ -200,7 +200,7 @@ void TimeROI::addMask(const Types::Core::DateAndTime &startTime, const Types::Co
       }
     }
     this->clear();
-    for (const auto interval : output) {
+    for (const auto &interval : output) {
       m_roi.push_back(interval.start());
       m_roi.push_back(interval.stop());
     }
@@ -404,7 +404,7 @@ void TimeROI::update_union(const TimeROI &other) {
     return;
 
   // add all the intervals from the other
-  for (const auto interval : other.toSplitters()) {
+  for (const auto &interval : other.toSplitters()) {
     this->addROI(interval.start(), interval.stop());
   }
 }
@@ -490,7 +490,7 @@ std::string TimeROI::debugStrPrint(const std::size_t type) const {
       ss << (i / 2) << ": " << m_roi[i] << " to " << m_roi[i + 1] << "\n";
     }
   } else if (type == 1) {
-    for (const auto val : m_roi)
+    for (const auto &val : m_roi)
       ss << val << " ";
     ss << "\n";
   } else {
@@ -576,7 +576,7 @@ void TimeROI::clear() { m_roi.clear(); }
 void TimeROI::saveNexus(::NeXus::File *file) const {
   // create a local TimeSeriesProperty which will do the actual work
   TimeSeriesProperty<bool> tsp(NAME);
-  for (const auto interval : this->toSplitters()) {
+  for (const auto &interval : this->toSplitters()) {
     tsp.addValue(interval.start(), ROI_USE);
     tsp.addValue(interval.stop(), ROI_IGNORE);
   }


### PR DESCRIPTION
[coverity](https://scan.coverity.com/) pointed out that rather than `for (const auto iter:` one should use `for (const auto &iter:` to avoid making a temporary copy of objects. This changes things as suggested.

**To test:**

Code review should be enough.

*There is no associated issue.*

*This does not require release notes* because this is an internal enhancement.

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
