### PR TITLE
DrILL: fix for loading export algorithms from rundex

### DIFF
--- a/docs/source/release/v6.7.0/Workbench/Bugfixes/35322.rst
+++ b/docs/source/release/v6.7.0/Workbench/Bugfixes/35322.rst
@@ -1,0 +1,1 @@
+- Fixed issue in DrILL with loading rundexes related to issue in processing export algorithm name and the extension simultaneously.

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/drill/model/DrillExportModel.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/drill/model/DrillExportModel.py
@@ -55,7 +55,7 @@ class DrillExportModel:
         """
         self._exportAlgorithms = {k: v for k, v in RundexSettings.EXPORT_ALGORITHMS[acquisitionMode].items()}
         self._exportDocs = dict()
-        for (a, _) in self._exportAlgorithms.keys():
+        for a, _ in self._exportAlgorithms.keys():
             try:
                 alg = AlgorithmManager.createUnmanaged(a)
                 self._exportDocs[a] = alg.summary()
@@ -100,8 +100,9 @@ class DrillExportModel:
         Activate a spefific algorithm.
 
         Args:
-            algorithm (str, str)): name of the algo and output file extension
+            algorithm list(str, str): name of the algo and output file extension
         """
+        algorithm = tuple(algorithm)  # tuples are hashable and can be a key in a dictionary _exportAlgorithms
         if algorithm in self._exportAlgorithms:
             self._exportAlgorithms[algorithm] = True
 

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/drill/model/DrillExportModel.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/drill/model/DrillExportModel.py
@@ -20,14 +20,14 @@ import os
 class DrillExportModel:
 
     """
-    Dictionnary containing algorithm (name, extension) tuples and activation
+    Dictionary containing algorithm (name, extension) tuples and activation
     state.
     """
 
     _exportAlgorithms = None
 
     """
-    Dictionnary of export algorithm short doc.
+    Dictionary of export algorithm short doc.
     """
     _exportDocs = None
 
@@ -37,12 +37,12 @@ class DrillExportModel:
     _pool = None
 
     """
-    Dictionnary of all the exports (dict(str:set(str))).
+    Dictionary of all the exports (dict(str:set(str))).
     """
     _exports = None
 
     """
-    Dictionnary of the successful exports (dict(str:set(str))).
+    Dictionary of the successful exports (dict(str:set(str))).
     """
     _successExport = None
 
@@ -79,7 +79,7 @@ class DrillExportModel:
         Get the short documentation of each export algorithm.
 
         Return:
-            dict(str:str): dictionnary algo:doc
+            dict(str:str): dictionary algo:doc
         """
         return {k: v for k, v in self._exportDocs.items()}
 
@@ -97,7 +97,7 @@ class DrillExportModel:
 
     def activateAlgorithm(self, algorithm):
         """
-        Activate a spefific algorithm.
+        Activate a specific algorithm.
 
         Args:
             algorithm list(str, str): name of the algo and output file extension


### PR DESCRIPTION
**Description of work.**

This PR fixes the observed issue when rundex is loaded in DrILL where enabled save algorithms are defined. The fix corrects a bug that was assuming that the provided algorithm pair is hashable, which was not the case, as it was interpreted as a list instead of a tuple. The proposed fix casts the loaded algorithm name + extension pack to a tuple type and checks if that exists in the supported export algorithm dictionary. 

**To test:**

1. Test the case from the related issue.
2. There should be no warnings or errors when loading that rundex, and SaveCanSAS1D and SaveNISTDAT algorithms should be enabled in the Export setting window

Fixes #35322 .

Release note added.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
