### PR TITLE
Refactoring assert raises in python algorithm tests part 4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -121,6 +121,9 @@ ipch/
 *.psess
 *.vsp
 
+# Visual Studio worksapce state
+.vs/
+
 # ReSharper is a .NET coding add-in
 _ReSharper*
 

--- a/.gitignore
+++ b/.gitignore
@@ -121,7 +121,7 @@ ipch/
 *.psess
 *.vsp
 
-# Visual Studio worksapce state
+# Visual Studio workspace state
 .vs/
 
 # ReSharper is a .NET coding add-in

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/FlatPlatePaalmanPingsCorrection.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/FlatPlatePaalmanPingsCorrection.py
@@ -221,13 +221,16 @@ class FlatPlatePaalmanPingsCorrection(PythonAlgorithm):
         # Ensure that a can chemical formula is given when using a can workspace
         if use_can:
             can_chemical_formula = self.getPropertyValue("CanChemicalFormula")
-            can_coherent_cross_section = self.getPropertyValue("CanCoherentXSection")
-            can_incoherent_cross_section = self.getPropertyValue("CanIncoherentXSection")
-            can_attenuation_cross_section = self.getPropertyValue("CanAttenuationXSection")
-            if can_chemical_formula == "" and (
-                can_coherent_cross_section == 0.0 and can_incoherent_cross_section == 0.0 and can_attenuation_cross_section == 0.0
+            can_coherent_cross_section = self.getProperty("CanCoherentXSection").value
+            can_incoherent_cross_section = self.getProperty("CanIncoherentXSection").value
+            can_attenuation_cross_section = self.getProperty("CanAttenuationXSection").value
+            if (
+                can_chemical_formula == ""
+                and can_coherent_cross_section == 0.0
+                and can_incoherent_cross_section == 0.0
+                and can_attenuation_cross_section == 0.0
             ):
-                issues["CanChemicalFormula"] = "Must provide a chemical formula or cross sections when providing a " "can workspace."
+                issues["CanChemicalFormula"] = "Must provide a chemical formula or cross sections when providing a can workspace."
 
         self._emode = self.getPropertyValue("Emode")
         self._efixed = self.getProperty("Efixed").value
@@ -553,7 +556,6 @@ class FlatPlatePaalmanPingsCorrection(PythonAlgorithm):
             self._wavelengths.append(lambda_fixed)
             logger.information("Efixed mode, setting lambda_fixed to {0}".format(lambda_fixed))
         else:
-
             wave_range = "__WaveRange"
             ExtractSingleSpectrum(InputWorkspace=self._sample_ws_name, OutputWorkspace=wave_range, WorkspaceIndex=0)
             Xin = mtd[wave_range].readX(0)

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/AddSampleLogMultipleTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/AddSampleLogMultipleTest.py
@@ -116,7 +116,15 @@ class AddSampleLogMultipleTest(unittest.TestCase):
         values = ["one", "two", "three"]
         units = ["unit_a", "unit_b"]
 
-        self.assertRaises(RuntimeError, AddSampleLogMultiple, Workspace=self._workspace, LogNames=names, LogValues=values, LogUnits=units)
+        self.assertRaisesRegex(
+            RuntimeError,
+            "Number of log units must be 0 or match the number of log names",
+            AddSampleLogMultiple,
+            Workspace=self._workspace,
+            LogNames=names,
+            LogValues=values,
+            LogUnits=units,
+        )
 
     def test_validation_no_names(self):
         """
@@ -125,7 +133,14 @@ class AddSampleLogMultipleTest(unittest.TestCase):
         names = []
         values = ["one", "two", "three"]
 
-        self.assertRaises(RuntimeError, AddSampleLogMultiple, Workspace=self._workspace, LogNames=names, LogValues=values)
+        self.assertRaisesRegex(
+            RuntimeError,
+            "Must have at least one log name",
+            AddSampleLogMultiple,
+            Workspace=self._workspace,
+            LogNames=names,
+            LogValues=values,
+        )
 
     def test_validation_no_values(self):
         """
@@ -134,7 +149,14 @@ class AddSampleLogMultipleTest(unittest.TestCase):
         names = ["a", "b", "c"]
         values = []
 
-        self.assertRaises(RuntimeError, AddSampleLogMultiple, Workspace=self._workspace, LogNames=names, LogValues=values)
+        self.assertRaisesRegex(
+            RuntimeError,
+            "Must have at least one log value",
+            AddSampleLogMultiple,
+            Workspace=self._workspace,
+            LogNames=names,
+            LogValues=values,
+        )
 
     def test_validation_differing_counts(self):
         """
@@ -143,7 +165,14 @@ class AddSampleLogMultipleTest(unittest.TestCase):
         names = ["a", "b", "c"]
         values = ["one", "two"]
 
-        self.assertRaises(RuntimeError, AddSampleLogMultiple, Workspace=self._workspace, LogNames=names, LogValues=values)
+        self.assertRaisesRegex(
+            RuntimeError,
+            "Number of log values must match number of log names",
+            AddSampleLogMultiple,
+            Workspace=self._workspace,
+            LogNames=names,
+            LogValues=values,
+        )
 
     def test_validation_differing_types(self):
         """
@@ -152,8 +181,15 @@ class AddSampleLogMultipleTest(unittest.TestCase):
         names = ["a", "b", "c"]
         values = ["one", "two", "three"]
         types = ["String", "String", "String"]
-        self.assertRaises(
-            RuntimeError, AddSampleLogMultiple, Workspace=self._workspace, LogNames=names, LogValues=values, ParseType=True, LogTypes=types
+        self.assertRaisesRegex(
+            RuntimeError,
+            "LogTypes array not used when ParseType=True",
+            AddSampleLogMultiple,
+            Workspace=self._workspace,
+            LogNames=names,
+            LogValues=values,
+            ParseType=True,
+            LogTypes=types,
         )
 
     def test_validation_differing_types(self):
@@ -164,8 +200,15 @@ class AddSampleLogMultipleTest(unittest.TestCase):
         values = ["one", "two", "three"]
         types = ["String", "String"]
 
-        self.assertRaises(
-            RuntimeError, AddSampleLogMultiple, Workspace=self._workspace, LogNames=names, LogValues=values, ParseType=False, LogTypes=types
+        self.assertRaisesRegex(
+            RuntimeError,
+            "Number of log types must be 0 or match the number of log names",
+            AddSampleLogMultiple,
+            Workspace=self._workspace,
+            LogNames=names,
+            LogValues=values,
+            ParseType=False,
+            LogTypes=types,
         )
 
     def test_validation_invalid_types(self):
@@ -176,8 +219,15 @@ class AddSampleLogMultipleTest(unittest.TestCase):
         values = ["one", "two", "three"]
         types = ["String", "String", "String Series"]
 
-        self.assertRaises(
-            RuntimeError, AddSampleLogMultiple, Workspace=self._workspace, LogNames=names, LogValues=values, ParseType=False, LogTypes=types
+        self.assertRaisesRegex(
+            RuntimeError,
+            "String Series is not an allowed log type",
+            AddSampleLogMultiple,
+            Workspace=self._workspace,
+            LogNames=names,
+            LogValues=values,
+            ParseType=False,
+            LogTypes=types,
         )
 
 

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/ApplyPaalmanPingsCorrectionTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/ApplyPaalmanPingsCorrectionTest.py
@@ -186,7 +186,7 @@ class ApplyPaalmanPingsCorrectionTest(unittest.TestCase):
         kwargs = {
             "SampleWorkspace": sample_1,
             "CanWorkspace": container_1,
-            "OutputWorkspaced": corrected_ws_name,
+            "OutputWorkspace": corrected_ws_name,
             "RebinCanToSample": False,
         }
         # The Minus algorithm will fail due to different bins in sample and
@@ -196,7 +196,6 @@ class ApplyPaalmanPingsCorrectionTest(unittest.TestCase):
         DeleteWorkspace(container_1)
 
     def test_fixed_window_scan(self):
-
         out_ws = ApplyPaalmanPingsCorrection(
             SampleWorkspace=mtd["fapi"][0], CorrectionsWorkspace="fws_corrections", OutputWorkspace="wsfapicorr"
         )
@@ -207,7 +206,7 @@ class ApplyPaalmanPingsCorrectionTest(unittest.TestCase):
         self.assertEqual(out_ws.getAxis(0).getUnit().unitID(), mtd["fapi"][0].getAxis(0).getUnit().unitID())
 
     def test_group_raise(self):
-        kwargs = {"SampleWorkspace": "fapi", "CorrectionsWorkspace": "fws_corrections", "OutputWorkspaced": "wsfapicorr"}
+        kwargs = {"SampleWorkspace": "fapi", "CorrectionsWorkspace": "fws_corrections", "OutputWorkspace": "wsfapicorr"}
         self.assertRaises(RuntimeError, ApplyPaalmanPingsCorrection, **kwargs)
 
 

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/BayesStretchTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/BayesStretchTest.py
@@ -14,7 +14,6 @@ from IndirectImport import is_supported_f2py_platform
 if is_supported_f2py_platform():
 
     class BayesStretchTest(unittest.TestCase):
-
         _res_ws = None
         _sample_ws = None
         _resnorm_ws = None
@@ -49,8 +48,9 @@ if is_supported_f2py_platform():
             """
             Test that an EMin of less than the data range is invalid
             """
-            self.assertRaises(
+            self.assertRaisesRegex(
                 RuntimeError,
+                "EMin must be more than the minimum x range of the data.",
                 BayesStretch,
                 OutputWorkspaceFit="fit_group",
                 OutputWorkspaceContour="contour",
@@ -61,10 +61,11 @@ if is_supported_f2py_platform():
 
         def test_invalid_e_max(self):
             """
-            Test that an EMin of less than the data range is invalid
+            Test that an EMax of more than the data range is invalid
             """
-            self.assertRaises(
+            self.assertRaisesRegex(
                 RuntimeError,
+                "EMax must be less than the maximum x range of the data",
                 BayesStretch,
                 OutputWorkspaceFit="fit_group",
                 OutputWorkspaceContour="contour",

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/D7YIGPositionCalibrationTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/D7YIGPositionCalibrationTest.py
@@ -26,7 +26,10 @@ class D7YIGPositionCalibrationTest(unittest.TestCase):
             os.remove(output_path)
 
     def test_algorithm_with_no_input_workspace_raises_exception(self):
-        with self.assertRaises(RuntimeError):
+        with self.assertRaisesRegex(
+            RuntimeError,
+            "Either a list of file names containing YIG scan or the workspace with the loaded scan is required for calibration.",
+        ):
             D7YIGPositionCalibration()
 
     def test_no_fitting(self):

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/DetectorFloodWeightingTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/DetectorFloodWeightingTest.py
@@ -51,7 +51,7 @@ class DetectorFloodWeightingTest(unittest.TestCase):
         bands = [1, 3, 2, 4]  # Overlap!
         alg.setProperty("Bands", bands)  # One band
         alg.setPropertyValue("OutputWorkspace", "dummy")
-        self.assertRaises(RuntimeError, alg.execute)
+        self.assertRaisesRegex(RuntimeError, "Bands must not intersect", alg.execute)
 
     def test_execute_single_no_solid_angle(self):
         alg = AlgorithmManager.create("DetectorFloodWeighting")

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/DirectILLReductionTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/DirectILLReductionTest.py
@@ -75,6 +75,9 @@ class DirectILLReductionTest(unittest.TestCase):
 
     def testAbsoluteUnitsNoSampleMaterial(self):
         _add_natural_angle_step_parameter(self._TEST_WS_NAME)
+        vgeometry = {"Shape": "HollowCylinder", "Height": 4.0, "InnerRadius": 1.9, "OuterRadius": 2.0, "Center": [0.0, 0.0, 0.0]}
+        vmaterial = {"ChemicalFormula": "V", "SampleNumberDensity": 0.1}
+        SetSample(self._VANADIUM_WS_NAME, vgeometry, vmaterial)
         algProperties = {
             "InputWorkspace": self._TEST_WS_NAME,
             "OutputWorkspace": "outWS",
@@ -82,7 +85,9 @@ class DirectILLReductionTest(unittest.TestCase):
             "AbsoluteUnitsNormalisation": "Absolute Units ON",
             "IntegratedVanadiumWorkspace": self._VANADIUM_WS_NAME,
         }
-        self.assertRaises(RuntimeError, DirectILLReduction, **algProperties)
+        self.assertRaisesRegex(
+            RuntimeError, "Invalid sample number density, consider setting the sample material before", DirectILLReduction, **algProperties
+        )
 
     def testAbsoluteUnitsNoVanadiumMaterial(self):
         _add_natural_angle_step_parameter(self._TEST_WS_NAME)
@@ -96,7 +101,9 @@ class DirectILLReductionTest(unittest.TestCase):
             "AbsoluteUnitsNormalisation": "Absolute Units ON",
             "IntegratedVanadiumWorkspace": self._VANADIUM_WS_NAME,
         }
-        self.assertRaises(RuntimeError, DirectILLReduction, **algProperties)
+        self.assertRaisesRegex(
+            RuntimeError, "Invalid vanadium number density, consider setting the material before", DirectILLReduction, **algProperties
+        )
 
     def testDetectorGrouping(self):
         ws = illhelpers.create_poor_mans_in5_workspace(0.0, _groupingTestDetectors)

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/FindPeakAutomaticTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/FindPeakAutomaticTest.py
@@ -202,7 +202,7 @@ class FindPeaksAutomaticTest(unittest.TestCase):
         y_values += background
 
         raw_ws = CreateWorkspace(DataX=x_values, DataY=y_values, OutputWorkspace="raw_ws", NSpec=2)
-        with self.assertRaises(RuntimeError):
+        with self.assertRaisesRegex(RuntimeError, "Spectrum number is not valid"):
             FindPeaksAutomatic(
                 InputWorkspace=raw_ws,
                 SpectrumNumber=3,
@@ -375,17 +375,12 @@ class FindPeaksAutomaticTest(unittest.TestCase):
             mock_fit.return_value = None, None, mock_table
 
             # chi2 cost
-            with self.assertRaises(ValueError) as chi2:
+            with self.assertRaisesRegex(ValueError, "Index = 0"):
                 self.alg_instance.find_good_peaks(self.x_values, [], 0.1, 5, False, self.data_ws, 5)
 
             # poisson cost
-            with self.assertRaises(ValueError) as poisson:
+            with self.assertRaisesRegex(ValueError, "Index = 1"):
                 self.alg_instance.find_good_peaks(self.x_values, [], 0.1, 5, True, self.data_ws, 5)
-
-            self.assertIn("Index = 0", chi2.exception.args)
-            self.assertNotIn("Index = 1", chi2.exception.args)
-            self.assertNotIn("Index = 0", poisson.exception.args)
-            self.assertIn("Index = 1", poisson.exception.args)
 
     def test_find_good_peaks_returns_correct_peaks(self):
         self.alg_instance._min_sigma = 1

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/FitGaussianPeaksTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/FitGaussianPeaksTest.py
@@ -123,7 +123,7 @@ class FitGaussianPeaksTest(unittest.TestCase):
             FitGaussianPeaks(InputWorkspace=self.data_ws, PeakGuessTable=self.peak_guess_table, MaxPeakSigma=-1.0)
 
     def test_algorithm_with_even_fit_window_throws(self):
-        with self.assertRaises(RuntimeError):
+        with self.assertRaisesRegex(RuntimeError, "WindowSize must be an odd number"):
             FitGaussianPeaks(InputWorkspace=self.data_ws, PeakGuessTable=self.peak_guess_table, FitWindowSize=6)
 
     def test_algorithm_with_fit_window_lower_than_5_throws(self):

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/FlatPlatePaalmanPingsCorrectionTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/FlatPlatePaalmanPingsCorrectionTest.py
@@ -299,8 +299,9 @@ class FlatPlatePaalmanPingsCorrectionTest(unittest.TestCase):
         Tests validation for no chemical formula for can when a can WS is provided.
         """
 
-        self.assertRaises(
+        self.assertRaisesRegex(
             RuntimeError,
+            "Must provide a chemical formula or cross sections when providing a can workspace.",
             FlatPlatePaalmanPingsCorrection,
             OutputWorkspace=self._corrections_ws_name,
             SampleWorkspace=self._sample_ws,

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/ISISIndirectDiffractionReductionTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/ISISIndirectDiffractionReductionTest.py
@@ -272,8 +272,9 @@ class ISISIndirectDiffractionReductionTest(unittest.TestCase):
         """
         Test to ensure cal file can not be used in diffonly mode
         """
-        self.assertRaises(
+        self.assertRaisesRegex(
             RuntimeError,
+            "Cal Files are currently only available for use in OSIRIS diffspec mode",
             ISISIndirectDiffractionReduction,
             InputFiles=["osi89813.raw"],
             Instrument="OSIRIS",
@@ -287,8 +288,9 @@ class ISISIndirectDiffractionReductionTest(unittest.TestCase):
         """
         Test to ensure cal file can not be used on a different instrument other than OSIRIS
         """
-        self.assertRaises(
+        self.assertRaisesRegex(
             RuntimeError,
+            "Cal Files are currently only available for use in OSIRIS diffspec mode",
             ISISIndirectDiffractionReduction,
             InputFiles=["IRS26176.RAW"],
             Instrument="IRIS",
@@ -299,15 +301,23 @@ class ISISIndirectDiffractionReductionTest(unittest.TestCase):
         )
 
     def test_that_reduction_fails_if_provided_a_range_of_run_numbers_which_goes_from_high_to_low(self):
-        with self.assertRaises(RuntimeError):
+        with self.assertRaisesRegex(RuntimeError, "Run number ranges must go from low to high"):
             ISISIndirectDiffractionReduction(
-                InputFiles=["137793-137796", "137813-814"], Instrument="OSIRIS", Mode="diffspec", SpectraRange=[105, 112]
+                InputFiles=["137793-137796", "137813-814"],
+                Instrument="OSIRIS",
+                Mode="diffspec",
+                OutputWorkspace="wks",
+                SpectraRange=[105, 112],
             )
 
     def test_that_reduction_fails_if_provided_a_range_of_run_numbers_which_is_not_a_range(self):
-        with self.assertRaises(RuntimeError):
+        with self.assertRaisesRegex(RuntimeError, "Run number ranges must go from low to high"):
             ISISIndirectDiffractionReduction(
-                InputFiles=["137793-137796", "137813-137813"], Instrument="OSIRIS", Mode="diffspec", SpectraRange=[105, 112]
+                InputFiles=["137793-137796", "137813-137813"],
+                Instrument="OSIRIS",
+                Mode="diffspec",
+                OutputWorkspace="wks",
+                SpectraRange=[105, 112],
             )
 
 

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/ISISIndirectEnergyTransferTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/ISISIndirectEnergyTransferTest.py
@@ -276,8 +276,9 @@ class ISISIndirectEnergyTransferTest(unittest.TestCase):
         fail.
         """
 
-        self.assertRaises(
+        self.assertRaisesRegex(
             RuntimeError,
+            "Invalid instrument configuration",
             ISISIndirectEnergyTransfer,
             OutputWorkspace="__ISISIndirectEnergyTransferTest_ws",
             InputFiles=["IRS26176.RAW"],
@@ -293,8 +294,9 @@ class ISISIndirectEnergyTransferTest(unittest.TestCase):
         GroupingMethod but no workspace is provided.
         """
 
-        self.assertRaises(
+        self.assertRaisesRegex(
             RuntimeError,
+            "Must select a grouping workspace for current GroupingWorkspace",
             ISISIndirectEnergyTransfer,
             OutputWorkspace="__ISISIndirectEnergyTransferTest_ws",
             InputFiles=["IRS26176.RAW"],

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/ISISIndirectEnergyTransferWrapperTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/ISISIndirectEnergyTransferWrapperTest.py
@@ -405,7 +405,7 @@ class ISISIndirectEnergyTransferWrapperTest(unittest.TestCase):
         self.assertTrue(CompareWorkspaces(reference, workspace)[0])
 
     def test_that_a_runtime_error_is_raised_when_there_is_an_instrument_validation_failure(self):
-        with self.assertRaises(RuntimeError):
+        with self.assertRaisesRegex(RuntimeError, "Invalid instrument configuration"):
             ISISIndirectEnergyTransferWrapper(
                 InputFiles=["IRS26176.RAW"],
                 Instrument="IRIS",
@@ -416,7 +416,7 @@ class ISISIndirectEnergyTransferWrapperTest(unittest.TestCase):
             )
 
     def test_that_a_runtime_error_is_raised_when_the_grouping_method_is_Workspace_but_no_workspace_is_provided(self):
-        with self.assertRaises(RuntimeError):
+        with self.assertRaisesRegex(RuntimeError, "Must select a grouping workspace for current GroupingWorkspace"):
             ISISIndirectEnergyTransferWrapper(
                 InputFiles=["IRS26176.RAW"],
                 Instrument="IRIS",

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/IndirectReplaceFitResultTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/IndirectReplaceFitResultTest.py
@@ -124,20 +124,16 @@ class IndirectReplaceFitResultTest(unittest.TestCase):
         self.assertEqual(self._result_group.getNumberOfEntries(), 1)
 
     def test_that_the_algorithm_will_throw_when_given_a_single_fit_workspace_containing_more_than_one_fit(self):
-        with self.assertRaises(RuntimeError):
+        with self.assertRaisesRegex(RuntimeError, "The single fit workspace must contain data from a single fit."):
             execute_algorithm(self._input_workspace, self._input_workspace, self._output_name)
 
     def test_that_the_algorithm_will_throw_when_given_an_input_workspace_containing_data_for_one_fit(self):
-        with self.assertRaises(RuntimeError):
+        with self.assertRaisesRegex(RuntimeError, "The input workspace must contain result data from a fit involving 2 or more spectra."):
             execute_algorithm(self._single_fit_workspace, self._single_fit_workspace, self._output_name)
 
     def test_that_the_algorithm_will_throw_when_provided_an_empty_output_workspace_name(self):
-        with self.assertRaises(RuntimeError):
+        with self.assertRaisesRegex(RuntimeError, "No OutputWorkspace name was provided."):
             execute_algorithm(self._input_workspace, self._single_fit_workspace, "")
-
-    def test_that_the_algorithm_will_throw_when_provided_an_single_fit_workspace_which_is_a_group(self):
-        with self.assertRaises(RuntimeError):
-            execute_algorithm(self._input_workspace, self._result_group, self._output_name)
 
     def test_that_the_algorithm_produces_a_workspace_containing_the_expected_values(self):
         execute_algorithm(self._input_workspace, self._single_fit_workspace, self._output_name)

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/IndirectSampleChangerTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/IndirectSampleChangerTest.py
@@ -79,8 +79,9 @@ class IndirectSampleChangerTest(unittest.TestCase):
         self.assertEqual(round(msd_ws.readY(1)[2], 7), 0.5845778)
 
     def test_that_IndirectSampleChanger_will_raise_an_error_when_given_run_numbers_in_the_wrong_order(self):
-        self.assertRaises(
+        self.assertRaisesRegex(
             RuntimeError,
+            "First run must be before last run",
             IndirectSampleChanger,
             FirstRun=self._last_run,
             LastRun=self._first_run,
@@ -95,8 +96,9 @@ class IndirectSampleChangerTest(unittest.TestCase):
         )
 
     def test_that_IndirectSampleChanger_will_raise_an_error_when_given_more_samples_tan_runs(self):
-        self.assertRaises(
+        self.assertRaisesRegex(
             RuntimeError,
+            "There must be at least 1 run per sample",
             IndirectSampleChanger,
             FirstRun=self._first_run,
             LastRun=self._last_run,

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/IqtFitMultipleTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/IqtFitMultipleTest.py
@@ -10,7 +10,6 @@ from mantid.api import MatrixWorkspace, WorkspaceGroup, ITableWorkspace
 
 
 class IqtFitMultipleTest(unittest.TestCase):
-
     _iqt_ws = None
     _function = r"name=LinearBackground,A0=0.027668,A1=0,ties=(A1=0);name=StretchExp,Height=0.972332,Lifetime=0.0247558,Stretching=1;ties=(f1.Height=1-f0.A0)"
 
@@ -185,8 +184,9 @@ class IqtFitMultipleTest(unittest.TestCase):
         )
 
     def test_maximum_spectra_more_than_workspace_spectra(self):
-        self.assertRaises(
+        self.assertRaisesRegex(
             RuntimeError,
+            "SpecMax must be smaller or equal to the number of spectra in the input workspace",
             IqtFitMultiple,
             InputWorkspace=self._iqt_ws,
             Function=self._function,
@@ -200,8 +200,9 @@ class IqtFitMultipleTest(unittest.TestCase):
         )
 
     def test_minimum_spectra_more_than_maximum_spectra(self):
-        self.assertRaises(
+        self.assertRaisesRegex(
             RuntimeError,
+            "SpecMax must be more than or equal to SpecMin",
             IqtFitMultiple,
             InputWorkspace=self._iqt_ws,
             Function=self._function,
@@ -231,8 +232,9 @@ class IqtFitMultipleTest(unittest.TestCase):
         )
 
     def test_maximum_x_more_than_workspace_max_x(self):
-        self.assertRaises(
+        self.assertRaisesRegex(
             RuntimeError,
+            "EndX must be less than the highest x value in the workspace",
             IqtFitMultiple,
             InputWorkspace=self._iqt_ws,
             Function=self._function,
@@ -247,8 +249,9 @@ class IqtFitMultipleTest(unittest.TestCase):
         )
 
     def test_minimum_spectra_more_than_maximum_spectra(self):
-        self.assertRaises(
+        self.assertRaisesRegex(
             RuntimeError,
+            "EndX must be more than StartX",
             IqtFitMultiple,
             InputWorkspace=self._iqt_ws,
             Function=self._function,

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/IqtFitSequentialTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/IqtFitSequentialTest.py
@@ -10,7 +10,6 @@ from mantid.api import MatrixWorkspace, WorkspaceGroup, ITableWorkspace
 
 
 class IqtFitSequentialTest(unittest.TestCase):
-
     _iqt_ws = None
     _function = r"name=LinearBackground,A0=0,A1=0,ties=(A1=0);name=ExpDecay,Height=1,Lifetime=0.0247558;ties=(f1.Height=1-f0.A0)"
 
@@ -185,8 +184,9 @@ class IqtFitSequentialTest(unittest.TestCase):
         )
 
     def test_minimum_spectra_more_than_maximum_spectra(self):
-        self.assertRaises(
+        self.assertRaisesRegex(
             RuntimeError,
+            "SpecMin must be less than or equal to SpecMax.",
             IqtFitSequential,
             InputWorkspace=self._iqt_ws,
             Function=self._function,
@@ -200,8 +200,9 @@ class IqtFitSequentialTest(unittest.TestCase):
         )
 
     def test_minimum_x_less_than_0(self):
-        self.assertRaises(
+        self.assertRaisesRegex(
             RuntimeError,
+            "StartX must be greater than or equal to 0.",
             IqtFitSequential,
             InputWorkspace=self._iqt_ws,
             Function=self._function,


### PR DESCRIPTION
**Description of work.**

Fourth part of the work to remove the blanket use of `assertRaises` when testing algorithm input validation in favour of `assertRaisesRegex`. This way we can expect a certain exception rather than accepting any possible `RuntimeException` which could be an unrelated bug (there were a few found during in the tests from this pr).

Main issue is #34570

**To test:**

 - All tests should pass (handled by Jenkins)
 - Code review

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
