### PR TITLE
Refactoring assert raises in python algorithm tests part 5

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/MSDFit.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/MSDFit.py
@@ -77,7 +77,7 @@ class MSDFit(DataProcessorAlgorithm):
             issues["InputWorkspace"] = "The InputWorkspace must be a MatrixWorkspace."
 
         if x_min > x_max:
-            msg = "XStart must be less then XEnd"
+            msg = "XStart must be less than XEnd"
             issues["XStart"] = msg
             issues["XEnd"] = msg
 
@@ -85,7 +85,7 @@ class MSDFit(DataProcessorAlgorithm):
             issues["SpecMin"] = "Minimum spectrum number must be greater than or equal to 0"
 
         if spec_min > spec_max:
-            msg = "SpecMin must be less then SpecMax"
+            msg = "SpecMin must be less than SpecMax"
             issues["SpecMin"] = msg
             issues["SpecMax"] = msg
 

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ResNorm2.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ResNorm2.py
@@ -20,7 +20,6 @@ from mantid.simpleapi import *
 
 
 class ResNorm(PythonAlgorithm):
-
     _res_ws_clone = None
     _res_ws = None
     _van_ws = None
@@ -70,7 +69,7 @@ class ResNorm(PythonAlgorithm):
 
         # Validate fitting range in energy
         if self._e_min > self._e_max:
-            issues["EnergyMax"] = "Must be less than EnergyMin"
+            issues["EnergyMax"] = "Must be greater than EnergyMin"
 
         res_ws = mtd[self._res_ws]
         # Can't use a WorkspaceGroup for resolution

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SANSILLAutoProcess.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SANSILLAutoProcess.py
@@ -159,7 +159,7 @@ class SANSILLAutoProcess(DataProcessorAlgorithm):
         if sens_dim != sample_dim and sens_dim > 1:
             result["SensitivityMaps"] = message.format("Sensitivity", sens_dim, sample_dim)
         if flux_dim != sample_dim and flux_dim > 1:
-            result["FluxRuns"] = message.format("Flux")
+            result["FluxRuns"] = message.format("Flux", flux_dim, sample_dim)
         if maxqxy_dim != sample_dim and maxqxy_dim > 1:
             result["MaxQxy"] = message_value.format("MaxQxy", maxqxy_dim, sample_dim)
         if deltaq_dim != sample_dim and deltaq_dim > 1:

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SANSILLMultiProcess.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SANSILLMultiProcess.py
@@ -375,8 +375,7 @@ class SANSILLMultiProcess(DataProcessorAlgorithm):
             if n_thick > 1 and n_thick != self.n_samples:
                 issues[
                     "SampleThickness"
-                ] = f"SampleThickness has {n_thick} elements \
-                                             which does not match the number of samples {self.n_samples}."
+                ] = f"SampleThickness has {n_thick} elements which does not match the number of samples {self.n_samples}."
         return issues
 
     def _check_sample_names_dimensions(self):
@@ -387,10 +386,7 @@ class SANSILLMultiProcess(DataProcessorAlgorithm):
         if read_from == "User":
             n_names = len(user_names)
             if n_names != self.n_samples:
-                issues[
-                    "SampleNames"
-                ] = f"SampleNames has {n_names} elements \
-                                         which does not match the number of samples {self.n_samples}."
+                issues["SampleNames"] = f"SampleNames has {n_names} elements which does not match the number of samples {self.n_samples}."
         return issues
 
     def _check_aux_tr_params_dimensions(self):

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SimulatedDensityOfStates.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SimulatedDensityOfStates.py
@@ -26,7 +26,6 @@ PEAK_WIDTH_ENERGY_FLAG = "energy"
 
 
 class SimulatedDensityOfStates(PythonAlgorithm):
-
     _spec_type = None
     _peak_func = None
     _out_ws_name = None
@@ -439,7 +438,10 @@ class SimulatedDensityOfStates(PythonAlgorithm):
             peak_widths = np.abs(peak_widths)
             logger.debug("Peak widths: %s" % (str(peak_widths)))
         else:
-            single_val = np.array([float(self._peak_width)])
+            try:
+                single_val = np.array([float(self._peak_width)])
+            except ValueError:
+                raise ValueError('Invalid peak width function (must be either a decimal or function containing "energy")')
             peak_widths = np.repeat(single_val, len(peaks))
 
         if self._peak_func == "Gaussian":

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/TOSCABankCorrection.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/TOSCABankCorrection.py
@@ -11,7 +11,6 @@ from mantid.simpleapi import *
 
 
 class TOSCABankCorrection(DataProcessorAlgorithm):
-
     _input_ws = None
     _output_ws = None
     _search_range = None
@@ -90,10 +89,7 @@ class TOSCABankCorrection(DataProcessorAlgorithm):
 
         # Ensure there is at least one peak found
         if peak is None:
-            raise RuntimeError(
-                "Could not find any peaks. Try increasing \
-                                width of SearchRange and/or ClosePeakTolerance"
-            )
+            raise RuntimeError("Could not find any peaks. Try increasing width of SearchRange and/or ClosePeakTolerance")
 
         target_centre = (peak[0] + peak[1]) / 2.0
         bank_1_scale_factor = target_centre / peak[0]

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/TotScatCalculateSelfScattering.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/TotScatCalculateSelfScattering.py
@@ -91,8 +91,11 @@ class TotScatCalculateSelfScattering(DataProcessorAlgorithm):
 
         placzek_kwargs = {"InputWorkspace": raw_ws, "IncidentSpectra": fit_spectra, "ScalebyPackingFraction": False, "Order": placzek_order}
         sample_temp = self.getPropertyValue("SampleTemp")
-        if placzek_order == 2 and sample_temp:
-            placzek_kwargs.update({"SampleTemperature": sample_temp})
+        if placzek_order == 2:
+            if sample_temp:
+                placzek_kwargs.update({"SampleTemperature": sample_temp})
+            else:
+                raise ValueError("SampleTemperature must be provided")
         self_scattering_correction = CalculatePlaczek(**placzek_kwargs)
         # Convert to Q
         self_scattering_correction = ConvertUnits(InputWorkspace=self_scattering_correction, Target="MomentumTransfer", EMode="Elastic")

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/TotScatCalculateSelfScattering.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/TotScatCalculateSelfScattering.py
@@ -92,10 +92,9 @@ class TotScatCalculateSelfScattering(DataProcessorAlgorithm):
         placzek_kwargs = {"InputWorkspace": raw_ws, "IncidentSpectra": fit_spectra, "ScalebyPackingFraction": False, "Order": placzek_order}
         sample_temp = self.getPropertyValue("SampleTemp")
         if placzek_order == 2:
-            if sample_temp:
-                placzek_kwargs.update({"SampleTemperature": sample_temp})
-            else:
+            if not sample_temp:
                 raise ValueError("SampleTemperature must be provided")
+            placzek_kwargs.update({"SampleTemperature": sample_temp})
         self_scattering_correction = CalculatePlaczek(**placzek_kwargs)
         # Convert to Q
         self_scattering_correction = ConvertUnits(InputWorkspace=self_scattering_correction, Target="MomentumTransfer", EMode="Elastic")

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/MSDFitTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/MSDFitTest.py
@@ -117,7 +117,7 @@ class MSDFitTest(unittest.TestCase):
 
         self.assertRaisesRegex(
             RuntimeError,
-            "XStart must be less then XEnd",
+            "XStart must be less than XEnd",
             MSDFit,
             InputWorkspace=self._ws,
             XStart=10.0,

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/MSDFitTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/MSDFitTest.py
@@ -100,7 +100,7 @@ class MSDFitTest(unittest.TestCase):
 
         self.assertRaisesRegex(
             RuntimeError,
-            "SpecMin must be less then SpecMax",
+            "SpecMin must be less than SpecMax",
             MSDFit,
             InputWorkspace=self._ws,
             XStart=0.0,

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/MSDFitTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/MSDFitTest.py
@@ -73,36 +73,76 @@ class MSDFitTest(unittest.TestCase):
         Tests validation for SpecMin >= 0.
         """
 
-        with self.assertRaises(RuntimeError):
+        with self.assertRaisesRegex(RuntimeError, "Minimum spectrum number must be greater than or equal to 0"):
             msd, param, fit = MSDFit(InputWorkspace=self._ws, XStart=0.0, XEnd=5.0, SpecMin=-1, SpecMax=0)
 
-    def test_fail_spec_min(self):
+    def test_fail_spec_max(self):
         """
-        Tests validation for SpecMin >= num histograms.
+        Tests validation for SpecMax >= num histograms.
         """
 
-        self.assertRaises(RuntimeError, MSDFit, InputWorkspace=self._ws, XStart=0.0, XEnd=5.0, SpecMin=0, SpecMax=20, OutputWorkspace="msd")
+        self.assertRaisesRegex(
+            RuntimeError,
+            "Maximum spectrum number must be less than number of spectra in workspace",
+            MSDFit,
+            InputWorkspace=self._ws,
+            XStart=0.0,
+            XEnd=5.0,
+            SpecMin=0,
+            SpecMax=20,
+            OutputWorkspace="msd",
+        )
 
     def test_fail_spec_range(self):
         """
-        Tests validation for SpecMax >= SpecMin.
+        Tests validation for SpecMin >= SpecMax.
         """
 
-        self.assertRaises(RuntimeError, MSDFit, InputWorkspace=self._ws, XStart=0.0, XEnd=5.0, SpecMin=1, SpecMax=0, OutputWorkspace="msd")
+        self.assertRaisesRegex(
+            RuntimeError,
+            "SpecMin must be less then SpecMax",
+            MSDFit,
+            InputWorkspace=self._ws,
+            XStart=0.0,
+            XEnd=5.0,
+            SpecMin=1,
+            SpecMax=0,
+            OutputWorkspace="msd",
+        )
 
     def test_fail_x_range(self):
         """
-        Tests validation for XStart < XEnd.
+        Tests validation for XStart > XEnd.
         """
 
-        self.assertRaises(RuntimeError, MSDFit, InputWorkspace=self._ws, XStart=10.0, XEnd=5.0, SpecMin=0, SpecMax=0, OutputWorkspace="msd")
+        self.assertRaisesRegex(
+            RuntimeError,
+            "XStart must be less then XEnd",
+            MSDFit,
+            InputWorkspace=self._ws,
+            XStart=10.0,
+            XEnd=5.0,
+            SpecMin=0,
+            SpecMax=0,
+            OutputWorkspace="msd",
+        )
 
     def test_fail_x_range_ws(self):
         """
         Tests validation for X range in workspace range
         """
 
-        self.assertRaises(RuntimeError, MSDFit, InputWorkspace=self._ws, XStart=0.0, XEnd=20.0, SpecMin=0, SpecMax=0, OutputWorkspace="msd")
+        self.assertRaisesRegex(
+            RuntimeError,
+            "Must be less than maximum X value in workspace",
+            MSDFit,
+            InputWorkspace=self._ws,
+            XStart=0.0,
+            XEnd=20.0,
+            SpecMin=0,
+            SpecMax=0,
+            OutputWorkspace="msd",
+        )
 
 
 if __name__ == "__main__":

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/MatchAndMergeWorkspacesTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/MatchAndMergeWorkspacesTest.py
@@ -86,22 +86,38 @@ class MatchAndMergeWorkspacesTest(unittest.TestCase):
     def test_MatchAndMergeWorkspaces_fails_with_wrong_number_min_limits(self):
         x_min = np.array([0])
         x_max = np.array([10, 20, 30, 40, 50])
-        self.assertRaises(RuntimeError, MatchAndMergeWorkspaces, InputWorkspaces="ws_group", XMin=x_min, XMax=x_max)
+        self.assertRaisesRegex(
+            RuntimeError,
+            "XMin entries does not match size of workspace group",
+            MatchAndMergeWorkspaces,
+            InputWorkspaces="ws_group",
+            XMin=x_min,
+            XMax=x_max,
+            OutputWorkspace="wks",
+        )
 
     def test_MatchAndMergeWorkspaces_fails_with_wrong_number_max_limits(self):
         x_min = np.array([0, 5, 10, 15, 20])
         x_max = np.array([10])
-        self.assertRaises(RuntimeError, MatchAndMergeWorkspaces, InputWorkspaces="ws_group", XMin=x_min, XMax=x_max)
+        self.assertRaisesRegex(
+            RuntimeError,
+            "XMax entries does not match size of workspace group",
+            MatchAndMergeWorkspaces,
+            InputWorkspaces="ws_group",
+            XMin=x_min,
+            XMax=x_max,
+            OutputWorkspace="wks",
+        )
 
     def test_MatchAndMergeWorkspaces_fails_with_wrong_ws_input(self):
         x_min = np.array([0, 5, 10, 15, 20])
         x_max = np.array([10, 20, 30, 40, 50])
-        self.assertRaises(ValueError, MatchAndMergeWorkspaces, InputWorkspaces="fake_group", XMin=x_min, XMax=x_max)
+        self.assertRaises(ValueError, MatchAndMergeWorkspaces, InputWorkspaces="fake_group", XMin=x_min, XMax=x_max, OutputWorkspace="wks")
 
     def test_MatchAndMergeWorkspaces_fails_with_min_larger_than_max(self):
         x_min = np.array([10, 20, 30, 40, 50])
         x_max = np.array([0, 5, 10, 15, 20])
-        self.assertRaises(ValueError, MatchAndMergeWorkspaces, InputWorkspaces="fake_group", XMin=x_min, XMax=x_max)
+        self.assertRaises(RuntimeError, MatchAndMergeWorkspaces, InputWorkspaces="ws_group", XMin=x_min, XMax=x_max, OutputWorkspace="wks")
 
     def test_exclude_banks(self):
         self.create_larger_group()
@@ -121,16 +137,40 @@ class MatchAndMergeWorkspacesTest(unittest.TestCase):
     def test_excluding_banks_fails_with_wrong_input(self):
         x_min = np.array([2, -1, 10, -1, 20])
         x_max = np.array([10, 20, 30, -1, 45])
-        self.assertRaises(RuntimeError, MatchAndMergeWorkspaces, InputWorkspaces="ws_group", XMin=x_min, XMax=x_max)
+        self.assertRaisesRegex(
+            RuntimeError,
+            "The banks to be excluded in q_lims do not match. Please check that -1 has been added in the correct place on both lists.",
+            MatchAndMergeWorkspaces,
+            InputWorkspaces="ws_group",
+            XMin=x_min,
+            XMax=x_max,
+            OutputWorkspace="wks",
+        )
 
         x_min = np.array([2, 5, 10, -1, 20])
         x_max = np.array([10, -1, 30, -1, 45])
-        self.assertRaises(RuntimeError, MatchAndMergeWorkspaces, InputWorkspaces="ws_group", XMin=x_min, XMax=x_max)
+        self.assertRaisesRegex(
+            RuntimeError,
+            "The banks to be excluded in q_lims do not match. Please check that -1 has been added in the correct place on both lists.",
+            MatchAndMergeWorkspaces,
+            InputWorkspaces="ws_group",
+            XMin=x_min,
+            XMax=x_max,
+            OutputWorkspace="wks",
+        )
 
     def test_excluding_all_banks_fails_with_wrong_input(self):
         x_min = np.array([-1, -1, -1, -1, -1])
         x_max = np.array([-1, -1, -1, -1, -1])
-        self.assertRaises(RuntimeError, MatchAndMergeWorkspaces, InputWorkspaces="ws_group", XMin=x_min, XMax=x_max)
+        self.assertRaisesRegex(
+            RuntimeError,
+            "You have excluded all banks. Merging requires at least one bank.",
+            MatchAndMergeWorkspaces,
+            InputWorkspaces="ws_group",
+            XMin=x_min,
+            XMax=x_max,
+            OutputWorkspace="wks",
+        )
 
 
 if __name__ == "__main__":

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/OSIRISDiffractionReductionTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/OSIRISDiffractionReductionTest.py
@@ -142,8 +142,9 @@ class OSIRISDiffractionReductionTest(unittest.TestCase):
         """
         Test error handling when there is no overlap between the sample and container d-ranges
         """
-        self.assertRaises(
+        self.assertRaisesRegex(
             RuntimeError,
+            "D-Ranges found in runs have no overlap",
             OSIRISDiffractionReduction,
             Sample=["OSI89813.raw"],
             CalFile="osiris_041_RES10.cal",
@@ -151,6 +152,7 @@ class OSIRISDiffractionReductionTest(unittest.TestCase):
             Container=["OSI10241.raw"],
             SpectraMin=3,
             SpectraMax=361,
+            OutputWorkspace="wks",
         )
 
     def test_spectra_with_bad_detectors(self):
@@ -158,8 +160,9 @@ class OSIRISDiffractionReductionTest(unittest.TestCase):
         Tests reduction with a spectra range that includes no selected Detectors from the Cal file
         """
 
-        self.assertRaises(
+        self.assertRaisesRegex(
             RuntimeError,
+            "No selected Detectors found in .cal file for input range.",
             OSIRISDiffractionReduction,
             Sample=["OSI10203.raw"],
             CalFile="osiris_041_RES10.cal",
@@ -167,20 +170,23 @@ class OSIRISDiffractionReductionTest(unittest.TestCase):
             Container=["OSI10241.raw"],
             SpectraMin=16,
             SpectraMax=17,
+            OutputWorkspace="wks",
         )
 
     def test_failure_no_vanadium(self):
         """
         Tests error handling when failed to obtain a vanadium run.
         """
-        self.assertRaises(
+        self.assertRaisesRegex(
             RuntimeError,
+            "D-Ranges found in runs have no overlap",
             OSIRISDiffractionReduction,
             Sample=["OSI89813.raw"],
             CalFile="osiris_041_RES10.cal",
             Vanadium=["OSI10156.raw"],
             SpectraMin=3,
             SpectraMax=361,
+            OutputWorkspace="wks",
         )
 
 

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/ReflectometryILL_commonTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/ReflectometryILL_commonTest.py
@@ -143,7 +143,7 @@ class ReflectometryILL_commonTest(unittest.TestCase):
         self.assertAlmostEqual(detector_angle, 1.862, delta=1e-3)
 
     def testDetectorAngleNonExistingFile(self):
-        self.assertRaises(RuntimeError, common.detector_angle, "wrong.nxs")
+        self.assertRaisesRegex(RuntimeError, "Cannot load file wrong.nxs.", common.detector_angle, "wrong.nxs")
 
     def testDetectorResolution(self):
         detector_resolution = common.detector_resolution()
@@ -155,7 +155,9 @@ class ReflectometryILL_commonTest(unittest.TestCase):
 
     def testInstrumentNameIncorrectInstrument(self):
         incorrect_ws = illhelpers.create_poor_mans_in5_workspace(0.0, illhelpers.default_test_detectors)
-        self.assertRaises(RuntimeError, common.instrument_name, incorrect_ws)
+        self.assertRaisesRegex(
+            RuntimeError, "Unrecognized instrument IN5. Only D17 and FIGARO are supported.", common.instrument_name, incorrect_ws
+        )
 
     def testPixelSizeD17(self):
         pixel_size = common.pixel_size("D17")
@@ -170,7 +172,7 @@ class ReflectometryILL_commonTest(unittest.TestCase):
         self.assertAlmostEqual(sample_angle, 0.002, delta=1e-3)
 
     def testSampleAngleNonExistingFile(self):
-        self.assertRaises(RuntimeError, common.sample_angle, "wrong.nxs")
+        self.assertRaisesRegex(RuntimeError, "Cannot load file wrong.nxs.", common.sample_angle, "wrong.nxs")
 
     def testSlitSizeLogEntryD17(self):
         slit_log_entry = common.slit_size_log_entry("D17", 1)
@@ -182,7 +184,7 @@ class ReflectometryILL_commonTest(unittest.TestCase):
 
     def testSlitSizeLogEntryIncorrectSlit(self):
         args = {"instr_name": "_", "slit_number": 3}
-        self.assertRaises(RuntimeError, common.slit_size_log_entry, **args)
+        self.assertRaisesRegex(RuntimeError, "Slit number out of range.", common.slit_size_log_entry, **args)
 
     def testSlitSizes(self):
         illhelpers.add_slit_configuration_D17(self._ws, 0.03, 0.02)

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/ResNorm2Test.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/ResNorm2Test.py
@@ -10,7 +10,6 @@ from mantid.api import MatrixWorkspace, WorkspaceGroup
 
 
 class ResNorm2Test(unittest.TestCase):
-
     _res_ws = None
     _van_ws = None
 
@@ -56,14 +55,16 @@ class ResNorm2Test(unittest.TestCase):
         """
         Tests validation for energy range.
         """
-        self.assertRaises(
+        self.assertRaisesRegex(
             RuntimeError,
+            "Must be greater than EnergyMin",
             ResNorm,
             ResolutionWorkspace=self._res_ws,
             VanadiumWorkspace=self._van_ws,
             EnergyMin=0.1,
             EnergyMax=-0.1,
             Version=2,
+            OutputWorkspace="wks",
         )
 
 

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/SANSDarkRunBackgroundCorrectionTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/SANSDarkRunBackgroundCorrectionTest.py
@@ -380,7 +380,14 @@ class SANSDarkRunBackgroundCorrectionTest(unittest.TestCase):
 
         AnalysisDataService.add(scatter_name, scatter_ws)
         AnalysisDataService.add(dark_name, dark_run)
-        self.assertRaises(RuntimeError, run_algorithm, "SANSDarkRunBackgroundCorrection", rethrow=True, **kwds)
+        self.assertRaisesRegex(
+            RuntimeError,
+            "The selected monitors are not part of the workspace.",
+            run_algorithm,
+            "SANSDarkRunBackgroundCorrection",
+            rethrow=True,
+            **kwds
+        )
 
         # Clean up
         ws_to_clean = [scatter_name, dark_name]
@@ -423,7 +430,14 @@ class SANSDarkRunBackgroundCorrectionTest(unittest.TestCase):
 
         AnalysisDataService.add(scatter_name, scatter_ws)
         AnalysisDataService.add(dark_name, dark_run)
-        self.assertRaises(RuntimeError, run_algorithm, "SANSDarkRunBackgroundCorrection", rethrow=True, **kwds)
+        self.assertRaisesRegex(
+            RuntimeError,
+            "Must provide either ApplyToDetectors or ApplyToMonitors or both",
+            run_algorithm,
+            "SANSDarkRunBackgroundCorrection",
+            rethrow=True,
+            **kwds
+        )
 
         # Clean up
         ws_to_clean = [scatter_name, dark_name]
@@ -700,7 +714,9 @@ class DarkRunMonitorAndDetectorRemoverTest(unittest.TestCase):
 
         # Act+ Assert
         args = [ws, monitor_selection]
-        dark_run_corrected = self.assertRaises(RuntimeError, remover.set_pure_monitor_dark_run, *args)
+        dark_run_corrected = self.assertRaisesRegex(
+            RuntimeError, "The selected monitors are not part of the workspace.", remover.set_pure_monitor_dark_run, *args
+        )
 
         # Clean up
         ws_to_clean = [test_ws]

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/SANSFitShiftScaleTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/SANSFitShiftScaleTest.py
@@ -227,7 +227,9 @@ class SANSFitShiftScaleTest(unittest.TestCase):
         hab_range = list(range(5, 14))
         hab_range[6] = np.nan
         hab_range[7] = np.nan
-        self.assertRaises(RuntimeError, self.do_test_scale_both, hab_range)
+        self.assertRaisesRegex(
+            RuntimeError, "Trying to merge the two reduced data sets for HAB and LAB failed.", self.do_test_scale_both, hab_range
+        )
 
     def test_scale_both_with_q_range(self):
         hab_range = list(range(5, 14))

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/SANSILLAutoProcessTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/SANSILLAutoProcessTest.py
@@ -37,43 +37,133 @@ class SANSILLAutoProcessTest(unittest.TestCase):
         self.assertRaises(RuntimeError, SANSILLAutoProcess, SampleRuns="010462")
 
     def test_wrongAbsorberDim(self):
-        self.assertRaises(RuntimeError, SANSILLAutoProcess, SampleRuns="010462", AbsorberRuns="010462,010462", OutputWorkspace="ws")
+        self.assertRaisesRegex(
+            RuntimeError,
+            "Wrong number of Absorber runs: 2. Provide one or as many as sample runs: 1.",
+            SANSILLAutoProcess,
+            SampleRuns="010462",
+            AbsorberRuns="010462,010462",
+            OutputWorkspace="ws",
+        )
 
     def test_wrongBeamDim(self):
-        self.assertRaises(RuntimeError, SANSILLAutoProcess, SampleRuns="010462", BeamRuns="010462,010462", OutputWorkspace="ws")
+        self.assertRaisesRegex(
+            RuntimeError,
+            "Wrong number of Beam runs: 2. Provide one or as many as sample runs: 1.",
+            SANSILLAutoProcess,
+            SampleRuns="010462",
+            BeamRuns="010462,010462",
+            OutputWorkspace="ws",
+        )
 
     def test_wrongContainerDim(self):
-        self.assertRaises(RuntimeError, SANSILLAutoProcess, SampleRuns="010462", ContainerRuns="010462,010462", OutputWorkspace="ws")
+        self.assertRaisesRegex(
+            RuntimeError,
+            "Wrong number of Container runs: 2. Provide one or as many as sample runs: 1.",
+            SANSILLAutoProcess,
+            SampleRuns="010462",
+            ContainerRuns="010462,010462",
+            OutputWorkspace="ws",
+        )
 
     def test_wrongMaskDim(self):
-        self.assertRaises(RuntimeError, SANSILLAutoProcess, SampleRuns="010462", MaskFiles="010462,010462", OutputWorkspace="ws")
+        self.assertRaisesRegex(
+            RuntimeError,
+            "Wrong number of Mask runs: 2. Provide one or as many as sample runs: 1.",
+            SANSILLAutoProcess,
+            SampleRuns="010462",
+            MaskFiles="010462,010462",
+            OutputWorkspace="ws",
+        )
 
     def test_wrongReferenceDim(self):
-        self.assertRaises(RuntimeError, SANSILLAutoProcess, SampleRuns="010462", ReferenceFiles="010462,010462", OutputWorkspace="ws")
+        self.assertRaisesRegex(
+            RuntimeError,
+            "Wrong number of Reference runs: 2. Provide one or as many as sample runs: 1.",
+            SANSILLAutoProcess,
+            SampleRuns="010462",
+            ReferenceFiles="010462,010462",
+            OutputWorkspace="ws",
+        )
 
-    def test_wrongSensivityDim(self):
-        self.assertRaises(RuntimeError, SANSILLAutoProcess, SampleRuns="010462", SensitivityMaps="010462,010462", OutputWorkspace="ws")
+    def test_wrongSensitivityDim(self):
+        self.assertRaisesRegex(
+            RuntimeError,
+            "Wrong number of Sensitivity runs: 2. Provide one or as many as sample runs: 1.",
+            SANSILLAutoProcess,
+            SampleRuns="010462",
+            SensitivityMaps="010462,010462",
+            OutputWorkspace="ws",
+        )
 
     def test_wrongFluxDim(self):
-        self.assertRaises(RuntimeError, SANSILLAutoProcess, SampleRuns="010462", FluxRuns="010462,010462", OutputWorkspace="ws")
+        self.assertRaisesRegex(
+            RuntimeError,
+            "Wrong number of Flux runs: 2. Provide one or as many as sample runs: 1.",
+            SANSILLAutoProcess,
+            SampleRuns="010462",
+            FluxRuns="010462,010462",
+            OutputWorkspace="ws",
+        )
 
     def test_wrongParametersDim(self):
-        self.assertRaises(RuntimeError, SANSILLAutoProcess, SampleRuns="010462", MaxQxy="1,1", OutputWorkspace="ws")
-        self.assertRaises(RuntimeError, SANSILLAutoProcess, SampleRuns="010462", DeltaQ="1,1", OutputWorkspace="ws")
-        self.assertRaises(RuntimeError, SANSILLAutoProcess, SampleRuns="010462", BeamRadius="1,1", OutputWorkspace="ws")
+        self.assertRaisesRegex(
+            RuntimeError,
+            "Wrong number of MaxQxy values: 2. Provide one or as many as sample runs: 1.",
+            SANSILLAutoProcess,
+            SampleRuns="010462",
+            MaxQxy="1,1",
+            OutputWorkspace="ws",
+        )
+        self.assertRaisesRegex(
+            RuntimeError,
+            "Wrong number of DeltaQ values: 2. Provide one or as many as sample runs: 1.",
+            SANSILLAutoProcess,
+            SampleRuns="010462",
+            DeltaQ="1,1",
+            OutputWorkspace="ws",
+        )
+        self.assertRaisesRegex(
+            RuntimeError,
+            "Wrong number of BeamRadius values: 2. Provide one or as many as sample runs: 1.",
+            SANSILLAutoProcess,
+            SampleRuns="010462",
+            BeamRadius="1,1",
+            OutputWorkspace="ws",
+        )
 
     def test_wrongTransmissionDim(self):
-        self.assertRaises(
-            RuntimeError, SANSILLAutoProcess, SampleRuns="010462,010462", SampleTransmissionRuns="010462,010462", OutputWorkspace="ws"
+        self.assertRaisesRegex(
+            RuntimeError,
+            "Wrong number of SampleTransmission runs: 2. Provide one or as many as sample runs: 1.",
+            SANSILLAutoProcess,
+            SampleRuns="010462",
+            SampleTransmissionRuns="010462,010462",
+            OutputWorkspace="ws",
         )
-        self.assertRaises(
-            RuntimeError, SANSILLAutoProcess, SampleRuns="010462,010462", ContainerTransmissionRuns="010462,010462", OutputWorkspace="ws"
+        self.assertRaisesRegex(
+            RuntimeError,
+            "Wrong number of ContainerTransmission runs: 2. Provide one or as many as sample runs: 1.",
+            SANSILLAutoProcess,
+            SampleRuns="010462",
+            ContainerTransmissionRuns="010462,010462",
+            OutputWorkspace="ws",
         )
-        self.assertRaises(
-            RuntimeError, SANSILLAutoProcess, SampleRuns="010462,010462", TransmissionBeamRuns="010462,010462", OutputWorkspace="ws"
+        self.assertRaisesRegex(
+            RuntimeError,
+            "Wrong number of TransmissionBeam runs: 2. Provide one or as many as sample runs: 1.",
+            SANSILLAutoProcess,
+            SampleRuns="010462",
+            TransmissionBeamRuns="010462,010462",
+            OutputWorkspace="ws",
         )
-        self.assertRaises(
-            RuntimeError, SANSILLAutoProcess, SampleRuns="010462,010462", TransmissionAbsorberRuns="010462,010462", OutputWorkspace="ws"
+        self.assertRaisesRegex(
+            RuntimeError,
+            "Wrong number of TransmissionAbsorber runs: 2. Provide one or as many as sample runs: 1.",
+            SANSILLAutoProcess,
+            SampleRuns="010462",
+            TransmissionAbsorberRuns="010462,010462",
+            OutputWorkspace="ws",
         )
 
     def test_flux(self):

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/SANSILLMultiProcessTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/SANSILLMultiProcessTest.py
@@ -62,20 +62,44 @@ class SANSILLMultiProcessTest(unittest.TestCase):
         self.assertTrue(iq.getHistory())
 
     def test_fail_d2_before_d1_samples(self):
-        self.assertRaises(RuntimeError, SANSILLMultiProcess, OutputWorkspace="out", SampleRunsD2="010569")
+        self.assertRaisesRegex(
+            RuntimeError, "Samples have to be filled from D1 onwards", SANSILLMultiProcess, OutputWorkspace="out", SampleRunsD2="010569"
+        )
 
     def test_fail_d2_skipped_samples(self):
-        self.assertRaises(RuntimeError, SANSILLMultiProcess, OutputWorkspace="out", SampleRunsD1="010569", SampleRunsD3="010455")
+        self.assertRaisesRegex(
+            RuntimeError,
+            "Samples have to be filled from D1 onwards:",
+            SANSILLMultiProcess,
+            OutputWorkspace="out",
+            SampleRunsD1="010569",
+            SampleRunsD3="010455",
+        )
 
     def test_fail_different_number_of_samples(self):
-        self.assertRaises(RuntimeError, SANSILLMultiProcess, OutputWorkspace="out", SampleRunsD1="010569", SampleRunsD2="010455,010460")
+        self.assertRaisesRegex(
+            RuntimeError,
+            "SampleRunsD2 has 2 elements instead of 1",
+            SANSILLMultiProcess,
+            OutputWorkspace="out",
+            SampleRunsD1="010569",
+            SampleRunsD2="010455,010460",
+        )
 
     def test_fail_transmission_wo_empty_beam(self):
-        self.assertRaises(RuntimeError, SANSILLMultiProcess, OutputWorkspace="out", SampleRunsD1="010569", SampleTrRunsW1="010585")
+        self.assertRaisesRegex(
+            RuntimeError,
+            "Empty beam flux input workspace is mandatory for transmission calculation.",
+            SANSILLMultiProcess,
+            OutputWorkspace="out",
+            SampleRunsD1="010569",
+            SampleTrRunsW1="010585",
+        )
 
     def test_fail_different_number_of_tr_runs(self):
-        self.assertRaises(
+        self.assertRaisesRegex(
             RuntimeError,
+            "Input and transmission workspaces have a different number of wavelength bins",
             SANSILLMultiProcess,
             OutputWorkspace="out",
             SampleRunsD1="010569,010460",
@@ -84,8 +108,9 @@ class SANSILLMultiProcessTest(unittest.TestCase):
         )
 
     def test_fail_w2_before_w1_tr_runs(self):
-        self.assertRaises(
+        self.assertRaisesRegex(
             RuntimeError,
+            "If there is one wavelength, transmissions must be filled in W1.",
             SANSILLMultiProcess,
             OutputWorkspace="out",
             SampleRunsD1="010569",
@@ -94,19 +119,39 @@ class SANSILLMultiProcessTest(unittest.TestCase):
         )
 
     def test_fail_output_name_not_alphanumeric(self):
-        self.assertRaises(RuntimeError, SANSILLMultiProcess, OutputWorkspace="7out", SampleRunsD1="010569")
+        self.assertRaisesRegex(
+            RuntimeError,
+            "Output workspace name must be alphanumeric, it should start with a letter.",
+            SANSILLMultiProcess,
+            OutputWorkspace="7out",
+            SampleRunsD1="010569",
+        )
 
     def test_fail_wedges_and_panels(self):
-        self.assertRaises(
-            RuntimeError, SANSILLMultiProcess, OutputWorkspace="out", SampleRunsD1="010569", OutputPanels=True, NumberOfWedges=2
+        self.assertRaisesRegex(
+            RuntimeError,
+            "Panels cannot be calculated together with the wedges, please choose one or the other.",
+            SANSILLMultiProcess,
+            OutputWorkspace="out",
+            SampleRunsD1="010569",
+            OutputPanels=True,
+            NumberOfWedges=2,
         )
 
     def test_fail_wrong_q_range(self):
-        self.assertRaises(RuntimeError, SANSILLMultiProcess, OutputWorkspace="out", SampleRunsD1="010569", OutputBinning="0.05,0.3:")
+        self.assertRaisesRegex(
+            RuntimeError,
+            "Number of Q binning parameter sets must be equal to the number of distances.",
+            SANSILLMultiProcess,
+            OutputWorkspace="out",
+            SampleRunsD1="010569",
+            OutputBinning="0.05,0.3:",
+        )
 
     def test_fail_wrong_tr_beam_radius_dimension(self):
-        self.assertRaises(
+        self.assertRaisesRegex(
             RuntimeError,
+            "TrBeamRadius has 2 elements which does not match the number of distances 1",
             SANSILLMultiProcess,
             OutputWorkspace="out",
             SampleRunsD1="010569",
@@ -116,8 +161,9 @@ class SANSILLMultiProcessTest(unittest.TestCase):
         )
 
     def test_fail_wrong_sample_names_dimension(self):
-        self.assertRaises(
+        self.assertRaisesRegex(
             RuntimeError,
+            "SampleNames has 2 elements which does not match the number of samples 1.",
             SANSILLMultiProcess,
             OutputWorkspace="out",
             SampleRunsD1="010569",
@@ -126,10 +172,24 @@ class SANSILLMultiProcessTest(unittest.TestCase):
         )
 
     def test_fail_wrong_sample_thickness_dimension(self):
-        self.assertRaises(RuntimeError, SANSILLMultiProcess, OutputWorkspace="out", SampleRunsD1="010569", SampleThickness=[0.1, 0.11])
+        self.assertRaisesRegex(
+            RuntimeError,
+            "SampleThickness has 2 elements which does not match the number of samples 1.",
+            SANSILLMultiProcess,
+            OutputWorkspace="out",
+            SampleRunsD1="010569",
+            SampleThickness=[0.1, 0.11],
+        )
 
     def test_fail_wrong_beam_radius_dimension(self):
-        self.assertRaises(RuntimeError, SANSILLMultiProcess, OutputWorkspace="out", SampleRunsD1="010569", BeamRadius=[0.1, 0.11])
+        self.assertRaisesRegex(
+            RuntimeError,
+            "BeamRadius has 2 elements which does not match the number of distances 1",
+            SANSILLMultiProcess,
+            OutputWorkspace="out",
+            SampleRunsD1="010569",
+            BeamRadius=[0.1, 0.11],
+        )
 
 
 if __name__ == "__main__":

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/SANSILLReduction2Test.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/SANSILLReduction2Test.py
@@ -97,9 +97,16 @@ class SANSILLReduction2Test(unittest.TestCase):
         self._check_process_flag(mtd["sample"], "Sample")
 
     def test_kinetic_calibrants_not_allowed(self):
-        calibrants = ["EmptyBeam", "DarkCurrent", "Water", "EmptyContainer", "Solvent"]
+        calibrants = ["EmptyBeam", "DarkCurrent", "Water", "Solvent"]
         for process in calibrants:
-            self.assertRaises(RuntimeError, SANSILLReduction, OutputWorkspace="out", SampleRunsD1="017251", ProcessAs=process)
+            self.assertRaisesRegex(
+                RuntimeError,
+                "Only the sample and transmission can be kinetic measurements, the calibration measurements cannot.",
+                SANSILLReduction,
+                OutputWorkspace="out",
+                Runs="017251",
+                ProcessAs=process,
+            )
 
     def test_sample_tof(self):
         SANSILLReduction(Runs="042610", ProcessAs="Sample", OutputWorkspace="sample", NormaliseBy="Time")

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/SimpleShapeDiscusInelasticTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/SimpleShapeDiscusInelasticTest.py
@@ -86,7 +86,6 @@ class SimpleShapeDiscusInelasticTest(unittest.TestCase):
         self._test_corrections_workspace(results)
 
     def test_annulus_with_container(self):
-
         kwargs = self._annulus_arguments
         results = SimpleShapeDiscusInelastic(
             ReducedWorkspace=self._red_ws,
@@ -95,7 +94,7 @@ class SimpleShapeDiscusInelasticTest(unittest.TestCase):
             CanInnerRadius=0.9,
             CanOuterRadius=2.1,
             Container=True,
-            **kwargs
+            **kwargs,
         )
 
         self._test_corrections_workspace(results)
@@ -115,25 +114,28 @@ class SimpleShapeDiscusInelasticTest(unittest.TestCase):
             "Thickness": 2.1,
         }
 
-        with self.assertRaises(RuntimeError):
+        with self.assertRaisesRegex(RuntimeError, "Please enter a chemical formula."):
             SimpleShapeDiscusInelastic(**kwargs)
 
     def test_flat_plate_no_params(self):
         # If the shape is flat plate but the relevant parameters haven't been entered this should throw
         # relevant params are Height, Width, Thickness
+        params = ["Height", "Width", "Thickness"]
 
-        kwargs = {
-            "ReducedWorkspace": self._red_ws,
-            "SqwWorkspace": self._sqw_ws,
-            "ChemicalFormula": "H2-O",
-            "SampleMassDensity": 1.0,
-            "NeutronPathsSingle": 50,
-            "NeutronPathsMultiple": 50,
-            "Shape": "FlatPlate",
-        }
+        for param in params:
+            kwargs = {
+                "ReducedWorkspace": self._red_ws,
+                "SqwWorkspace": self._sqw_ws,
+                "SampleChemicalFormula": "H2-O",
+                "SampleMassDensity": 1.0,
+                "NeutronPathsSingle": 50,
+                "NeutronPathsMultiple": 50,
+                param: 0,
+                "Shape": "FlatPlate",
+            }
 
-        with self.assertRaises(RuntimeError):
-            SimpleShapeDiscusInelastic(**kwargs)
+            with self.assertRaisesRegex(RuntimeError, f"Please enter a non-zero number for {param.lower()}"):
+                SimpleShapeDiscusInelastic(**kwargs)
 
     def test_not_in_deltaE(self):
         red_ws_not_deltaE = Load("irs26176_graphite002_red.nxs")
@@ -143,7 +145,7 @@ class SimpleShapeDiscusInelasticTest(unittest.TestCase):
         kwargs = {
             "ReducedWorkspace": red_ws_not_deltaE,
             "SqwWorkspace": self._sqw_ws,
-            "ChemicalFormula": "H2-O",
+            "SampleChemicalFormula": "H2-O",
             "SampleMassDensity": 1.0,
             "NeutronPathsSingle": 50,
             "NeutronPathsMultiple": 50,
@@ -153,7 +155,7 @@ class SimpleShapeDiscusInelasticTest(unittest.TestCase):
             "Thickness": 2.1,
         }
 
-        with self.assertRaises(RuntimeError):
+        with self.assertRaisesRegex(RuntimeError, "Input workspace must have units of DeltaE for inelastic instrument"):
             SimpleShapeDiscusInelastic(**kwargs)
 
         DeleteWorkspace(red_ws_not_deltaE)

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/SimpleShapeMonteCarloAbsorptionTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/SimpleShapeMonteCarloAbsorptionTest.py
@@ -114,7 +114,6 @@ class SimpleShapeMonteCarloAbsorptionTest(unittest.TestCase):
         CompareWorkspaces(self._corrected_flat_plate, corrected, Tolerance=1e-6)
 
     def test_ILL_reduced(self):
-
         ill_red_ws = Load("ILL/IN16B/091515_red.nxs")
 
         ill_red_ws = ConvertUnits(ill_red_ws, Target="Wavelength", EMode="Indirect", EFixed=1.845)
@@ -190,9 +189,10 @@ class SimpleShapeMonteCarloAbsorptionTest(unittest.TestCase):
             "Shape": "FlatPlate",
             "Width": 1.4,
             "Thickness": 2.1,
+            "OutputWorkspace": "wks",
         }
 
-        with self.assertRaises(RuntimeError):
+        with self.assertRaisesRegex(RuntimeError, "The cross section must be specified when no ChemicalFormula or AtomicNumber is given."):
             SimpleShapeMonteCarloAbsorption(**kwargs)
 
     def test_flat_plate_no_params(self):
@@ -208,9 +208,10 @@ class SimpleShapeMonteCarloAbsorptionTest(unittest.TestCase):
             "BeamHeight": 3.5,
             "BeamWidth": 4.0,
             "Shape": "FlatPlate",
+            "OutputWorkspace": "wks",
         }
 
-        with self.assertRaises(RuntimeError):
+        with self.assertRaisesRegex(RuntimeError, "Please enter a non-zero number for width"):
             SimpleShapeMonteCarloAbsorption(**kwargs)
 
     def test_not_in_wavelength(self):
@@ -228,9 +229,10 @@ class SimpleShapeMonteCarloAbsorptionTest(unittest.TestCase):
             "Shape": "FlatPlate",
             "Width": 1.4,
             "Thickness": 2.1,
+            "OutputWorkspace": "wks",
         }
 
-        with self.assertRaises(RuntimeError):
+        with self.assertRaisesRegex(RuntimeError, "The workspace must have units of Wavelength"):
             SimpleShapeMonteCarloAbsorption(**kwargs)
 
         DeleteWorkspace(red_ws_not_wavelength)
@@ -244,6 +246,7 @@ class SimpleShapeMonteCarloAbsorptionTest(unittest.TestCase):
         kwargs = self._annulus_arguments
         kwargs["InnerRadius"] = 1.0
         kwargs["MaxScatterPtAttempts"] = 0
+        kwargs["OutputWorkspace"] = "wks"
 
         with self.assertRaises(RuntimeError):
             SimpleShapeMonteCarloAbsorption(**kwargs)
@@ -257,6 +260,7 @@ class SimpleShapeMonteCarloAbsorptionTest(unittest.TestCase):
         kwargs = self._annulus_arguments
         kwargs["InnerRadius"] = 1.99999
         kwargs["MaxScatterPtAttempts"] = 1
+        kwargs["OutputWorkspace"] = "wks"
 
         with self.assertRaises(RuntimeError):
             SimpleShapeMonteCarloAbsorption(**kwargs)

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/SimulatedDensityOfStatesTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/SimulatedDensityOfStatesTest.py
@@ -94,7 +94,14 @@ class SimulatedDensityOfStatesTest(unittest.TestCase):
         """
         Using an invalid peak width function should raise RuntimeError.
         """
-        self.assertRaises(RuntimeError, SimulatedDensityOfStates, PHONONFile=self._phonon_file, PeakWidth="10*")
+        self.assertRaisesRegex(
+            RuntimeError,
+            "Invalid peak width function",
+            SimulatedDensityOfStates,
+            PHONONFile=self._phonon_file,
+            PeakWidth="10*",
+            OutputWorkspace="wks",
+        )
 
     def test_temperature(self):
         wks = SimulatedDensityOfStates(PHONONFile=self._phonon_file, Temperature=50)
@@ -183,7 +190,14 @@ class SimulatedDensityOfStatesTest(unittest.TestCase):
         Creating an ion table from a castep file is not possible and should fail
         validation.
         """
-        self.assertRaises(RuntimeError, SimulatedDensityOfStates, CASTEPFile=self._castep_file, SpectrumType="IonTable")
+        self.assertRaisesRegex(
+            RuntimeError,
+            "Cannot produce ion table when only .castep file is provided",
+            SimulatedDensityOfStates,
+            CASTEPFile=self._castep_file,
+            SpectrumType="IonTable",
+            OutputWorkspace="wks",
+        )
 
     def test_bond_table(self):
         wks = SimulatedDensityOfStates(CASTEPFile=self._castep_file, SpectrumType="BondTable")
@@ -197,7 +211,14 @@ class SimulatedDensityOfStatesTest(unittest.TestCase):
         Creating a bond table from a phonon file is not possible and should
         fail validation.
         """
-        self.assertRaises(RuntimeError, SimulatedDensityOfStates, PHONONFile=self._phonon_file, SpectrumType="IonTable")
+        self.assertRaisesRegex(
+            RuntimeError,
+            "Require a .castep file for bond table output",
+            SimulatedDensityOfStates,
+            PHONONFile=self._phonon_file,
+            SpectrumType="BondTable",
+            OutputWorkspace="wks",
+        )
 
     def test_bin_ranges_are_correct(self):
         """

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/TOSCABankCorrectionTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/TOSCABankCorrectionTest.py
@@ -68,8 +68,9 @@ class TOSCABankCorrectionTest(unittest.TestCase):
         Tests error handling when a peak cannot be found using a manual peak position.
         """
 
-        self.assertRaises(
+        self.assertRaisesRegex(
             RuntimeError,
+            "Could not find any peaks. Try increasing width of SearchRange and/or ClosePeakTolerance",
             TOSCABankCorrection,
             InputWorkspace=self._original,
             OutputWorkspace="__TOSCABankCorrectionTest_output",
@@ -81,8 +82,9 @@ class TOSCABankCorrectionTest(unittest.TestCase):
         Tests validation to ensure low and high values are entered in correct order.
         """
 
-        self.assertRaises(
+        self.assertRaisesRegex(
             RuntimeError,
+            'Search range must be in format "low,high"',
             TOSCABankCorrection,
             InputWorkspace=self._original,
             OutputWorkspace="__TOSCABankCorrectionTest_output",
@@ -94,8 +96,9 @@ class TOSCABankCorrectionTest(unittest.TestCase):
         Tests validation to ensure two values exist values are entered in correct order.
         """
 
-        self.assertRaises(
+        self.assertRaisesRegex(
             RuntimeError,
+            "Search range must have two values",
             TOSCABankCorrection,
             InputWorkspace=self._original,
             OutputWorkspace="__TOSCABankCorrectionTest_output",
@@ -107,8 +110,9 @@ class TOSCABankCorrectionTest(unittest.TestCase):
         Tests validation to ensure that the PeakPosition falls inside SearchRange.
         """
 
-        self.assertRaises(
+        self.assertRaisesRegex(
             RuntimeError,
+            "Peak position must be inside SearchRange",
             TOSCABankCorrection,
             InputWorkspace=self._original,
             OutputWorkspace="__TOSCABankCorrectionTest_output",

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/TimeSliceTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/TimeSliceTest.py
@@ -47,8 +47,9 @@ class TimeSliceTest(unittest.TestCase):
         Tests validation of the PeakRange property.
         """
 
-        self.assertRaises(
+        self.assertRaisesRegex(
             RuntimeError,
+            'Range must be in format "low,high"',
             TimeSlice,
             InputFiles=["IRS26173.raw"],
             SpectraRange=[3, 53],
@@ -63,8 +64,9 @@ class TimeSliceTest(unittest.TestCase):
         Tests validation of the PeakRange property.
         """
 
-        self.assertRaises(
+        self.assertRaisesRegex(
             RuntimeError,
+            "Range must have two values",
             TimeSlice,
             InputFiles=["IRS26173.raw"],
             SpectraRange=[3, 53],
@@ -79,8 +81,9 @@ class TimeSliceTest(unittest.TestCase):
         Tests validation of the BackgroundRange property.
         """
 
-        self.assertRaises(
+        self.assertRaisesRegex(
             RuntimeError,
+            'Range must be in format "low,high"',
             TimeSlice,
             InputFiles=["IRS26173.raw"],
             SpectraRange=[3, 53],
@@ -95,8 +98,9 @@ class TimeSliceTest(unittest.TestCase):
         Tests validation of the BackgroundRange property.
         """
 
-        self.assertRaises(
+        self.assertRaisesRegex(
             RuntimeError,
+            "Range must have two values",
             TimeSlice,
             InputFiles=["IRS26173.raw"],
             SpectraRange=[3, 53],

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/TotScatCalculateSelfScatteringTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/TotScatCalculateSelfScatteringTest.py
@@ -78,7 +78,7 @@ class TotScatCalculateSelfScatteringTest(unittest.TestCase):
         raw_ws = WorkspaceCreationHelper.create2DWorkspaceWithFullInstrument(6, 100, True)
         mtd.addOrReplace("tot_scat_test", raw_ws)
 
-        with self.assertRaises(RuntimeError):
+        with self.assertRaisesRegex(RuntimeError, "SampleTemperature must be provided"):
             correction_ws = TotScatCalculateSelfScattering(
                 InputWorkspace="tot_scat_test",
                 CalFileName=self.cal_file_path,


### PR DESCRIPTION
**Description of work.**

Fifth (and last) part of the work to remove the blanket use of `assertRaises` when testing algorithm input validation in favour of `assertRaisesRegex`. This way we can expect a certain exception rather than accepting any possible `RuntimeException` which could be an unrelated bug (there were a few found during in the tests from this pr).

Main issue is #34570

**To test:**

 - All tests should pass (handled by Jenkins)
 - Code review

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
