### PR TITLE
Refactoring assert raises in python algorithm tests part 2

### DIFF
--- a/Framework/PythonInterface/test/python/plugins/algorithms/EnggEstimateFocussedBackgroundTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/EnggEstimateFocussedBackgroundTest.py
@@ -47,7 +47,6 @@ class EnggEstimateFocussedBackground_Test(unittest.TestCase):
             DeleteWorkspace(self.ws)
 
     def test_subtraction(self):
-
         # get bg and subtract
         ws_bg = EnggEstimateFocussedBackground(InputWorkspace="ws", NIterations=20, XWindow=3)
         ws_diff = self.ws - ws_bg
@@ -58,10 +57,10 @@ class EnggEstimateFocussedBackground_Test(unittest.TestCase):
 
     def test_window_validation(self):
         # test too small a window
-        with self.assertRaises(RuntimeError):
+        with self.assertRaisesRegex(RuntimeError, "Convolution window must have at least three points"):
             EnggEstimateFocussedBackground(InputWorkspace="ws", OutputWorkspace="ws_bg", NIterations=20, XWindow=0.1)
         # test too large a window
-        with self.assertRaises(RuntimeError):
+        with self.assertRaisesRegex(RuntimeError, "Data has must have at least the number of points as the convolution window"):
             EnggEstimateFocussedBackground(InputWorkspace="ws", OutputWorkspace="ws_bg", NIterations=20, XWindow=200)
 
 

--- a/Framework/PythonInterface/test/python/plugins/algorithms/EnggFocusTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/EnggFocusTest.py
@@ -76,8 +76,9 @@ class EnggFocusTest(unittest.TestCase):
         self.assertRaises(RuntimeError, EnggFocus, InputWorkspace=self.__class__._data_ws, Detectors=tbl, OutputWorkspace="nop")
 
         # bank and indices list clash. This starts as a ValueError but the managers is raising a RuntimeError
-        self.assertRaises(
+        self.assertRaisesRegex(
             RuntimeError,
+            "It is not possible to use at the same time the input properties 'Bank' and 'DetectorIndices', as they overlap.",
             EnggFocus,
             InputWorkspace=self.__class__._data_ws,
             Bank="2",
@@ -87,8 +88,9 @@ class EnggFocusTest(unittest.TestCase):
         )
 
         # workspace index too big. This starts as a ValueError but the managers is raising a RuntimeError
-        self.assertRaises(
+        self.assertRaisesRegex(
             RuntimeError,
+            "A workspace index equal or bigger than the number of histograms available in the workspace 'ENGIN-X_test_ws'",
             EnggFocus,
             InputWorkspace=self.__class__._data_ws,
             DetectorPositions=tbl,
@@ -108,8 +110,9 @@ class EnggFocusTest(unittest.TestCase):
         )
 
         # wrong bin values for masking
-        self.assertRaises(
+        self.assertRaisesRegex(
             RuntimeError,
+            "The number of minimum and maximum values must match",
             EnggFocus,
             InputWorkspace=self.__class__._data_ws,
             DetectorPositions=tbl,
@@ -119,8 +122,9 @@ class EnggFocusTest(unittest.TestCase):
             OutputWorkspace="nop",
         )
 
-        self.assertRaises(
+        self.assertRaisesRegex(
             RuntimeError,
+            "The number of minimum and maximum values must match",
             EnggFocus,
             InputWorkspace=self.__class__._data_ws,
             DetectorPositions=tbl,
@@ -129,8 +133,9 @@ class EnggFocusTest(unittest.TestCase):
             OutputWorkspace="nop",
         )
 
-        self.assertRaises(
+        self.assertRaisesRegex(
             RuntimeError,
+            "The number of minimum and maximum values must match",
             EnggFocus,
             InputWorkspace=self.__class__._data_ws,
             DetectorPositions=tbl,

--- a/Framework/PythonInterface/test/python/plugins/algorithms/ExtractMonitorsTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/ExtractMonitorsTest.py
@@ -46,12 +46,21 @@ class ExtractMonitorsTest(unittest.TestCase):
         CreateSampleWorkspace(OutputWorkspace="testWS", NumMonitors=3)
         ExtractMonitors(InputWorkspace="testWS", DetectorWorkspace="det", MonitorWorkspace="mon")
 
-        self.assertRaises(RuntimeError, ExtractMonitors, InputWorkspace="det", DetectorWorkspace="det2", MonitorWorkspace="mon2")
+        self.assertRaisesRegex(
+            RuntimeError,
+            "Monitor workspace already exists",
+            ExtractMonitors,
+            InputWorkspace="det",
+            DetectorWorkspace="det2",
+            MonitorWorkspace="mon2",
+        )
 
     def test_workspace_with_no_detector_or_monitor_output_throws_error(self):
         CreateSampleWorkspace(OutputWorkspace="testWS", NumMonitors=3)
 
-        self.assertRaises(RuntimeError, ExtractMonitors, InputWorkspace="testWS")
+        self.assertRaisesRegex(
+            RuntimeError, "Must specify one of DetectorsWorkspace or MonitorsWorkspace", ExtractMonitors, InputWorkspace="testWS"
+        )
 
     def test_workspace_with_no_detectors_gives_no_detector_workspace(self):
         CreateSampleWorkspace(OutputWorkspace="testWS", NumBanks=0, NumMonitors=3)

--- a/Framework/PythonInterface/test/python/plugins/algorithms/FindGlobalBMatrixTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/FindGlobalBMatrixTest.py
@@ -95,7 +95,7 @@ class FindGlobalBMatrixTest(unittest.TestCase):
             "FindGlobalBMatrix", PeakWorkspaces=[peaks1], a=4.1, b=4.2, c=10, alpha=88, beta=88, gamma=89, Tolerance=0.15
         )
 
-        with self.assertRaises(RuntimeError):
+        with self.assertRaisesRegex(RuntimeError, "there must be at least two peak tables provided in total."):
             alg.execute()
 
     def test_peak_workspaces_need_at_least_six_peaks_each(self):
@@ -110,7 +110,7 @@ class FindGlobalBMatrixTest(unittest.TestCase):
             "FindGlobalBMatrix", PeakWorkspaces=[peaks1, peaks2], a=4.1, b=4.2, c=10, alpha=88, beta=88, gamma=89, Tolerance=0.15
         )
 
-        with self.assertRaises(RuntimeError):
+        with self.assertRaisesRegex(RuntimeError, "Accept only peaks workspace with more than 6 peaks"):
             alg.execute()
 
     def test_performs_correct_transform_to_ensure_consistent_indexing(self):

--- a/Framework/PythonInterface/test/python/plugins/algorithms/FindGoniometerFromUBTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/FindGoniometerFromUBTest.py
@@ -15,7 +15,6 @@ import numpy as np
 
 class FindGoniometerFromUB_Test(unittest.TestCase):
     def runTest(self):
-
         ubList = ["WISH00043350", "WISH00043351", "WISH00043353"]
         chiRef = 45.0
         chiTol = 5
@@ -63,9 +62,17 @@ class FindGoniometerFromUB_Test(unittest.TestCase):
 
     def test_InputValidation(self):
         alg = create_algorithm(
-            "FindGoniometerFromUB", UBfiles="WISH00043350", chi=45, chiTol=5, phiTol=10, phiHand=-1, dOmega=0, omegaHand=1
+            "FindGoniometerFromUB",
+            UBfiles="WISH00043350",
+            chi=45,
+            chiTol=5,
+            phiTol=10,
+            phiHand=-1,
+            dOmega=0,
+            omegaHand=1,
+            OutputTable="test",
         )
-        with self.assertRaises(RuntimeError):
+        with self.assertRaisesRegex(RuntimeError, "At least two UB files are required"):
             alg.execute()
 
 

--- a/Framework/PythonInterface/test/python/plugins/algorithms/FitGaussianTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/FitGaussianTest.py
@@ -44,7 +44,7 @@ class FitGaussianTest(unittest.TestCase):
     def test_errors(self):
         """Conditions that raise RuntimeError."""
         self._linearWorkspace(0)
-        self.assertRaises(RuntimeError, FitGaussian, Workspace=self.ws, Index=1)
+        self.assertRaisesRegex(RuntimeError, "Index 1 is out of range", FitGaussian, Workspace=self.ws, Index=1)
 
     def test_noFit(self):
         """Cases where fit is not possible."""

--- a/Framework/PythonInterface/test/python/plugins/algorithms/GenerateLogbookTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/GenerateLogbookTest.py
@@ -12,7 +12,6 @@ from tempfile import gettempdir
 
 
 class GenerateLogbookTest(unittest.TestCase):
-
     _data_directory = None
 
     def setUp(self):
@@ -34,7 +33,7 @@ class GenerateLogbookTest(unittest.TestCase):
 
     def test_instrument_does_not_exist(self):
         self.assertTrue(os.path.exists(self._data_directory))
-        with self.assertRaises(RuntimeError):
+        with self.assertRaisesRegex(RuntimeError, "There is no parameter file for nonexistent instrument."):
             GenerateLogbook(Directory=self._data_directory, OutputWorkspace="__unused", Facility="ISIS", Instrument="nonexistent")
 
     def test_d7_default(self):

--- a/Framework/PythonInterface/test/python/plugins/algorithms/HB3AAdjustSampleNormTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/HB3AAdjustSampleNormTest.py
@@ -68,7 +68,7 @@ class HB3AAdjustSampleNormTest(unittest.TestCase):
         )
 
         # A MDHisto WS with no experiment info should fail
-        with self.assertRaises(RuntimeError):
+        with self.assertRaisesRegex(RuntimeError, "No experiment info was found in 'samplews'"):
             HB3AAdjustSampleNorm(
                 InputWorkspaces=samplews, DetectorHeightOffset=0.0, DetectorDistanceOffset=0.0, OutputWorkspace="__tmpout", Wavelength=2.0
             )

--- a/Framework/PythonInterface/test/python/plugins/algorithms/IndirectTransmissionTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/IndirectTransmissionTest.py
@@ -110,8 +110,9 @@ class IndirectTransmissionTest(unittest.TestCase):
         # Using water sample
         formula = "H2-O"
 
-        self.assertRaises(
+        self.assertRaisesRegex(
             RuntimeError,
+            "Analyser silicon not valid for instrument IRIS",
             IndirectTransmission,
             Instrument=instrument,
             Analyser=analyser,
@@ -132,8 +133,9 @@ class IndirectTransmissionTest(unittest.TestCase):
         # Using water sample
         formula = "H2-O"
 
-        self.assertRaises(
+        self.assertRaisesRegex(
             RuntimeError,
+            "Reflection 111 not valid for analyser graphite on instrument IRIS",
             IndirectTransmission,
             Instrument=instrument,
             Analyser=analyser,

--- a/Framework/PythonInterface/test/python/plugins/algorithms/LoadCIFTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/LoadCIFTest.py
@@ -102,8 +102,15 @@ class UnitCellBuilderTest(unittest.TestCase):
 
     def test_getUnitCell_invalid(self):
         invalid_no_a = {"_cell_length_b": "5.6"}
-        self.assertRaises(RuntimeError, self.builder._getUnitCell, cifData={})
-        self.assertRaises(RuntimeError, self.builder._getUnitCell, cifData=invalid_no_a)
+        self.assertRaisesRegex(
+            RuntimeError, "The a-parameter of the unit cell is not specified in the supplied CIF.", self.builder._getUnitCell, cifData={}
+        )
+        self.assertRaisesRegex(
+            RuntimeError,
+            "The a-parameter of the unit cell is not specified in the supplied CIF.",
+            self.builder._getUnitCell,
+            cifData=invalid_no_a,
+        )
 
     def test_getUnitCell_cubic(self):
         cell = {"_cell_length_a": "5.6"}

--- a/Framework/PythonInterface/test/python/plugins/algorithms/LoadCIFTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/LoadCIFTest.py
@@ -161,11 +161,17 @@ class AtomListBuilderTest(unittest.TestCase):
                 ("_atom_site_fract_z", ["1/8"]),
             ]
         )
+        expected_error_messages = {
+            "_atom_site_label": "Cannot determine atom types",
+            "_atom_site_fract_x": "Mandatory field _atom_site_fract_x not found in CIF-file.",
+            "_atom_site_fract_y": "Mandatory field _atom_site_fract_y not found in CIF-file.",
+            "_atom_site_fract_z": "Mandatory field _atom_site_fract_z not found in CIF-file.",
+        }
 
         for key in mandatoryKeys:
             tmp = mandatoryKeys.copy()
             del tmp[key]
-            self.assertRaises(RuntimeError, self.builder._getAtoms, cifData=tmp)
+            self.assertRaisesRegex(RuntimeError, expected_error_messages[key], self.builder._getAtoms, cifData=tmp)
 
     def test_getAtoms_correct(self):
         data = self._getData(

--- a/Framework/PythonInterface/test/python/plugins/algorithms/LoadCIFTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/LoadCIFTest.py
@@ -402,7 +402,9 @@ class UBMatrixBuilderTest(unittest.TestCase):
             tmp = self.valid_matrix.copy()
             del tmp[key]
 
-            self.assertRaises(RuntimeError, self.builder._getUBMatrix, cifData=tmp)
+            self.assertRaisesRegex(
+                RuntimeError, "Can not load UB matrix from CIF, values are missing.", self.builder._getUBMatrix, cifData=tmp
+            )
 
     def test_getUBMatrix_correct(self):
         self.assertEqual(self.builder._getUBMatrix(self.valid_matrix), "-0.03,0.13,0.31,0.01,-0.31,0.14,0.34,0.02,0.02")

--- a/Framework/PythonInterface/test/python/plugins/algorithms/LoadCIFTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/LoadCIFTest.py
@@ -53,10 +53,19 @@ class SpaceGroupBuilderTest(unittest.TestCase):
         invalid_new = {"_space_group_name_h-m_alt": "invalid"}
         invalid_old = {"_symmetry_space_group_name_h-m": "invalid"}
 
-        self.assertRaises(RuntimeError, self.builder._getSpaceGroupFromString, cifData={})
-        self.assertRaises(ValueError, self.builder._getSpaceGroupFromString, cifData=invalid_new)
-        self.assertRaises(ValueError, self.builder._getSpaceGroupFromString, cifData=invalid_old)
-        self.assertRaises(ValueError, self.builder._getSpaceGroupFromString, cifData=merge_dicts(invalid_new, valid_old))
+        self.assertRaisesRegex(RuntimeError, "No space group symbol in CIF.", self.builder._getSpaceGroupFromString, cifData={})
+        self.assertRaisesRegex(
+            ValueError, "Space group with symbol 'invalid' is not registered.", self.builder._getSpaceGroupFromString, cifData=invalid_new
+        )
+        self.assertRaisesRegex(
+            ValueError, "Space group with symbol 'invalid' is not registered.", self.builder._getSpaceGroupFromString, cifData=invalid_old
+        )
+        self.assertRaisesRegex(
+            ValueError,
+            "Space group with symbol 'invalid' is not registered.",
+            self.builder._getSpaceGroupFromString,
+            cifData=merge_dicts(invalid_new, valid_old),
+        )
 
     def test_getCleanSpaceGroupSymbol(self):
         fn = self.builder._getCleanSpaceGroupSymbol
@@ -72,9 +81,19 @@ class SpaceGroupBuilderTest(unittest.TestCase):
         invalid_old = {"_symmetry_int_tables_number": "400"}
         invalid_new = {"_space_group_it_number": "400"}
 
-        self.assertRaises(RuntimeError, self.builder._getSpaceGroupFromNumber, cifData={})
-        self.assertRaises(RuntimeError, self.builder._getSpaceGroupFromNumber, cifData=invalid_old)
-        self.assertRaises(RuntimeError, self.builder._getSpaceGroupFromNumber, cifData=invalid_new)
+        self.assertRaisesRegex(RuntimeError, "No space group symbol in CIF.", self.builder._getSpaceGroupFromNumber, cifData={})
+        self.assertRaisesRegex(
+            RuntimeError,
+            r"Can not use space group number to determine space group for no. \[400\]",
+            self.builder._getSpaceGroupFromNumber,
+            cifData=invalid_old,
+        )
+        self.assertRaisesRegex(
+            RuntimeError,
+            r"Can not use space group number to determine space group for no. \[400\]",
+            self.builder._getSpaceGroupFromNumber,
+            cifData=invalid_new,
+        )
 
 
 class UnitCellBuilderTest(unittest.TestCase):

--- a/Framework/PythonInterface/test/python/plugins/algorithms/LoadDNSLegacyTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/LoadDNSLegacyTest.py
@@ -77,8 +77,13 @@ class LoadDNSLegacyTest(unittest.TestCase):
         outputWorkspaceName = "LoadDNSLegacyTest_Test2"
         filename = "dns-incomplete.d_dat"
         self._createIncompleteFile(filename)
-        self.assertRaises(
-            RuntimeError, LoadDNSLegacy, Filename=filename, OutputWorkspace=outputWorkspaceName, CoilCurrentsTable=self.curtable
+        self.assertRaisesRegex(
+            RuntimeError,
+            "File dns-incomplete.d_dat does not contain any data!",
+            LoadDNSLegacy,
+            Filename=filename,
+            OutputWorkspace=outputWorkspaceName,
+            CoilCurrentsTable=self.curtable,
         )
         os.remove(filename)
 

--- a/Framework/PythonInterface/test/python/plugins/algorithms/LoadLampTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/LoadLampTest.py
@@ -47,7 +47,9 @@ class LoadLampTest(unittest.TestCase):
         self.assertAlmostEqual(ws.getAxis(1).extractValues()[11], 95.3, 1)
 
     def test_3D_fail(self):
-        self.assertRaises(RuntimeError, LoadLamp, Filename="530333_LAMP.hdf", OutputWorkspace="ws")
+        self.assertRaisesRegex(
+            RuntimeError, "Data with more than 2 dimensions are not supported.", LoadLamp, InputFile="530333_LAMP.hdf", OutputWorkspace="ws"
+        )
 
     def test_no_param(self):
         ws = LoadLamp("no_parameters.hdf")

--- a/Framework/PythonInterface/test/python/plugins/algorithms/LoadNMoldyn3AsciiTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/LoadNMoldyn3AsciiTest.py
@@ -11,7 +11,6 @@ from mantid.api import *
 
 
 class LoadNMoldyn3AsciiTest(unittest.TestCase):
-
     _cdl_filename = "NaF_DISF.cdl"
     _dat_filename = "WSH_test.dat"
 
@@ -83,15 +82,22 @@ class LoadNMoldyn3AsciiTest(unittest.TestCase):
         Tests that the algorithm cannot be run when no functions are specified
         when loading a .cdl file.
         """
-        self.assertRaises(RuntimeError, LoadNMoldyn3Ascii, Filename=self._cdl_filename, OutputWorkspace="__LoadNMoldyn3Ascii_test")
+        self.assertRaisesRegex(
+            RuntimeError,
+            "Must specify at least one function when loading a CDL file",
+            LoadNMoldyn3Ascii,
+            Filename=self._cdl_filename,
+            OutputWorkspace="__LoadNMoldyn3Ascii_test",
+        )
 
     def test_function_validation_dat(self):
         """
         Tests that the algorithm cannot be run when functions are specified
         when loading a .dat file.
         """
-        self.assertRaises(
+        self.assertRaisesRegex(
             RuntimeError,
+            "Cannot specify functions when loading an ASCII file",
             LoadNMoldyn3Ascii,
             Filename=self._dat_filename,
             Functions=["Sqw-total"],

--- a/Framework/PythonInterface/test/python/plugins/algorithms/LoadNMoldyn4Ascii1DTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/LoadNMoldyn4Ascii1DTest.py
@@ -110,8 +110,9 @@ class LoadNMoldyn4Ascii1DTest(unittest.TestCase):
     # ============================= Test failure cases =========================================#
 
     def test_load_all_functions_skipped(self):
-        self.assertRaises(
+        self.assertRaisesRegex(
             RuntimeError,
+            "Failed to load any functions for data",
             LoadNMoldyn4Ascii1D,
             Directory=self._data_directory,
             Functions="something, somethingelse",
@@ -119,7 +120,13 @@ class LoadNMoldyn4Ascii1DTest(unittest.TestCase):
         )
 
     def test_fail_on_no_functions(self):
-        self.assertRaises(RuntimeError, LoadNMoldyn4Ascii1D, Directory=self._data_directory, OutputWorkspace="__LoadNMoldyn4Ascii1D_test")
+        self.assertRaisesRegex(
+            RuntimeError,
+            "Must specify at least one function to load",
+            LoadNMoldyn4Ascii1D,
+            Directory=self._data_directory,
+            OutputWorkspace="__LoadNMoldyn4Ascii1D_test",
+        )
 
 
 if __name__ == "__main__":

--- a/Framework/PythonInterface/test/python/plugins/algorithms/LoadNMoldyn4AsciiTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/LoadNMoldyn4AsciiTest.py
@@ -137,8 +137,9 @@ class LoadNMoldyn4AsciiTest(unittest.TestCase):
         """
         Tests error handling when all functions could not be loaded.
         """
-        self.assertRaises(
+        self.assertRaisesRegex(
             RuntimeError,
+            "Failed to load any functions for data",
             LoadNMoldyn4Ascii,
             Directory=self._data_directory,
             Functions=["sqw_total", "sqw_H"],
@@ -149,7 +150,13 @@ class LoadNMoldyn4AsciiTest(unittest.TestCase):
         """
         Tests error handling when no functions are specified.
         """
-        self.assertRaises(RuntimeError, LoadNMoldyn4Ascii, Directory=self._data_directory, OutputWorkspace="__LoadNMoldyn4Ascii_test")
+        self.assertRaisesRegex(
+            RuntimeError,
+            "Must specify at least one function to load",
+            LoadNMoldyn4Ascii,
+            Directory=self._data_directory,
+            OutputWorkspace="__LoadNMoldyn4Ascii_test",
+        )
 
 
 if __name__ == "__main__":

--- a/Framework/PythonInterface/test/python/plugins/algorithms/MatchPeaksTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/MatchPeaksTest.py
@@ -13,11 +13,9 @@ from testhelpers import run_algorithm
 
 
 class MatchPeaksTest(unittest.TestCase):
-
     _args = {}
 
     def setUp(self):
-
         func0 = "name=Gaussian, PeakCentre=3.2, Height=10, Sigma=0.3"
         func1 = "name=Gaussian, PeakCentre=6, Height=10, Sigma=0.3"
         func2 = "name=Gaussian, PeakCentre=4, Height=10000, Sigma=0.01"
@@ -163,41 +161,33 @@ class MatchPeaksTest(unittest.TestCase):
 
     def testValidateInputWorkspace(self):
         self._args["OutputWorkspace"] = "output"
-        with self.assertRaises(RuntimeError) as contextManager:
+        with self.assertRaisesRegex(RuntimeError, "Incompatible number of spectra"):
             self._args["InputWorkspace"] = self._in1
             run1 = run_algorithm("MatchPeaks", **self._args)
             self.assertTrue(run1.isExecuted())
-        # InputWorkspace2
-        self.assertTrue(str(contextManager.exception).startswith("Some invalid Properties found: "))
-        with self.assertRaises(RuntimeError) as contextManager:
+
+        with self.assertRaisesRegex(RuntimeError, "Incompatible number of bins"):
             self._args["InputWorkspace"] = self._in2
             run2 = run_algorithm("MatchPeaks", **self._args)
             self.assertTrue(run2.isExecuted())
-        # InputWorkspace2
-        self.assertTrue(str(contextManager.exception).startswith("Some invalid Properties found: "))
 
     def testValidateInputWorkspace2(self):
         self._args["InputWorkspace"] = self._ws_shift
         self._args["OutputWorkspace"] = "output"
-        with self.assertRaises(RuntimeError) as contextManager:
+        with self.assertRaisesRegex(RuntimeError, "Incompatible number of spectra"):
             self._args["InputWorkspace2"] = self._in1
             run_algorithm("MatchPeaks", **self._args)
-        # InputWorkspace2 InputWorkspace3
-        self.assertTrue(str(contextManager.exception).startswith("Some invalid Properties found: "))
-        with self.assertRaises(RuntimeError) as contextManager:
+
+        with self.assertRaisesRegex(RuntimeError, "Incompatible number of bins"):
             self._args["InputWorkspace2"] = self._in2
             run_algorithm("MatchPeaks", **self._args)
-        # InputWorkspace2 InputWorkspace3
-        self.assertTrue(str(contextManager.exception).startswith("Some invalid Properties found: "))
 
     def testValidateInputWorkspace3(self):
         self._args["InputWorkspace"] = self._ws_shift
         self._args["InputWorkspace3"] = self._ws_in_3
         self._args["OutputWorkspace"] = "output"
-        with self.assertRaises(RuntimeError) as contextManager:
+        with self.assertRaisesRegex(RuntimeError, "Incompatible number of bins"):
             run_algorithm("MatchPeaks", **self._args)
-        # InputWorkspace2 InputWorkspace3
-        self.assertTrue(str(contextManager.exception).startswith("Some invalid Properties found: "))
 
     def testMatchCenter(self):
         # Input workspace should match its center


### PR DESCRIPTION
**Description of work.**

Second part of the work to remove the blanket use of `assertRaises` when testing algorithm input validation in favour of `assertRaisesRegex`. This way we can expect a certain exception rather than accepting any possible `RuntimeException` which could be an unrelated bug (there were a few found during in the tests from this pr).

Main issue is #34570

**To test:**

 - All tests should pass (handled by Jenkins)
 - Code review

*This does not require release notes* because **it only changes tests**

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
