### PR TITLE
Fix bug in PolarizationCorrectionWildes matrix definitions

### DIFF
--- a/Framework/Algorithms/src/PolarizationCorrectionWildes.cpp
+++ b/Framework/Algorithms/src/PolarizationCorrectionWildes.cpp
@@ -99,12 +99,12 @@ void fourInputsCorrectedAndErrors(Eigen::Vector4d &corrected, Eigen::Vector4d &e
   const auto off2 = (f2 - 1.) / f2;
   Eigen::Matrix4d F2m;
   F2m << 1., 0., 0., 0., off2, diag2, 0., 0., 0., 0., 1., 0., 0., 0., off2, diag2;
-  const auto diag3 = (p1 - 1.) / (2. * p1 - 1.);
-  const auto off3 = p1 / (2. * p1 - 1);
+  const auto diag3 = p1 / (2. * p1 - 1);
+  const auto off3 = (p1 - 1.) / (2. * p1 - 1.);
   Eigen::Matrix4d P1m;
   P1m << diag3, 0, off3, 0, 0, diag3, 0, off3, off3, 0, diag3, 0, 0, off3, 0, diag3;
-  const auto diag4 = (p2 - 1.) / (2. * p2 - 1.);
-  const auto off4 = p2 / (2. * p2 - 1.);
+  const auto diag4 = p2 / (2. * p2 - 1.);
+  const auto off4 = (p2 - 1.) / (2. * p2 - 1.);
   Eigen::Matrix4d P2m;
   P2m << diag4, off4, 0., 0., off4, diag4, 0., 0., 0., 0., diag4, off4, 0., 0., off4, diag4;
   const Eigen::Vector4d intensities(ppy, pmy, mpy, mmy);
@@ -633,8 +633,8 @@ PolarizationCorrectionWildes::analyzerlessCorrections(const WorkspaceMap &inputs
       Eigen::Matrix2d F1m;
       F1m << 1., 0., (F1 - 1.) / F1, 1. / F1;
       const double divisor = (2. * P1 - 1.);
-      const double diag = (P1 - 1.) / divisor;
-      const double off = P1 / divisor;
+      const double off = (P1 - 1.) / divisor;
+      const double diag = P1 / divisor;
       Eigen::Matrix2d P1m;
       P1m << diag, off, off, diag;
       const Eigen::Vector2d intensities(ppY[binIndex], mmY[binIndex]);

--- a/Framework/Algorithms/src/PolarizationCorrectionWildes.cpp
+++ b/Framework/Algorithms/src/PolarizationCorrectionWildes.cpp
@@ -447,16 +447,16 @@ void PolarizationCorrectionWildes::checkConsistentNumberHistograms(const Workspa
     }
   };
   if (inputs.mmWS) {
-    checkNHist(inputs.mmWS, Flippers::OffOff);
+    checkNHist(inputs.mmWS, Flippers::OnOn);
   }
   if (inputs.mpWS) {
-    checkNHist(inputs.mpWS, Flippers::OffOn);
+    checkNHist(inputs.mpWS, Flippers::OnOff);
   }
   if (inputs.pmWS) {
-    checkNHist(inputs.pmWS, Flippers::OnOff);
+    checkNHist(inputs.pmWS, Flippers::OffOn);
   }
   if (inputs.ppWS) {
-    checkNHist(inputs.ppWS, Flippers::OnOn);
+    checkNHist(inputs.ppWS, Flippers::OffOff);
   }
 }
 
@@ -493,16 +493,16 @@ void PolarizationCorrectionWildes::checkConsistentX(const WorkspaceMap &inputs, 
     }
   };
   if (inputs.mmWS) {
-    checkWS(inputs.mmWS, Flippers::OffOff);
+    checkWS(inputs.mmWS, Flippers::OnOn);
   }
   if (inputs.mpWS) {
-    checkWS(inputs.mpWS, Flippers::OffOn);
+    checkWS(inputs.mpWS, Flippers::OnOff);
   }
   if (inputs.pmWS) {
-    checkWS(inputs.pmWS, Flippers::OnOff);
+    checkWS(inputs.pmWS, Flippers::OffOn);
   }
   if (inputs.ppWS) {
-    checkWS(inputs.ppWS, Flippers::OnOn);
+    checkWS(inputs.ppWS, Flippers::OffOff);
   }
 }
 

--- a/Framework/Algorithms/src/PolarizationCorrectionWildes.cpp
+++ b/Framework/Algorithms/src/PolarizationCorrectionWildes.cpp
@@ -516,21 +516,21 @@ void PolarizationCorrectionWildes::checkConsistentX(const WorkspaceMap &inputs, 
 API::WorkspaceGroup_sptr PolarizationCorrectionWildes::groupOutput(const WorkspaceMap &outputs) {
   const std::string outWSName = getProperty(Prop::OUTPUT_WS);
   std::vector<std::string> names;
-  if (outputs.mmWS) {
-    names.emplace_back(outWSName + "_--");
-    API::AnalysisDataService::Instance().addOrReplace(names.back(), outputs.mmWS);
-  }
-  if (outputs.mpWS) {
-    names.emplace_back(outWSName + "_-+");
-    API::AnalysisDataService::Instance().addOrReplace(names.back(), outputs.mpWS);
+  if (outputs.ppWS) {
+    names.emplace_back(outWSName + "_++");
+    API::AnalysisDataService::Instance().addOrReplace(names.back(), outputs.ppWS);
   }
   if (outputs.pmWS) {
     names.emplace_back(outWSName + "_+-");
     API::AnalysisDataService::Instance().addOrReplace(names.back(), outputs.pmWS);
   }
-  if (outputs.ppWS) {
-    names.emplace_back(outWSName + "_++");
-    API::AnalysisDataService::Instance().addOrReplace(names.back(), outputs.ppWS);
+  if (outputs.mpWS) {
+    names.emplace_back(outWSName + "_-+");
+    API::AnalysisDataService::Instance().addOrReplace(names.back(), outputs.mpWS);
+  }
+  if (outputs.mmWS) {
+    names.emplace_back(outWSName + "_--");
+    API::AnalysisDataService::Instance().addOrReplace(names.back(), outputs.mmWS);
   }
   auto group = createChildAlgorithm("GroupWorkspaces");
   group->initialize();

--- a/Framework/Algorithms/test/PolarizationCorrectionWildesTest.h
+++ b/Framework/Algorithms/test/PolarizationCorrectionWildesTest.h
@@ -739,9 +739,9 @@ private:
     return ws;
   }
 
-  void idealCaseFullCorrectionsTest(const Mantid::HistogramData::BinEdges edges,
-                                    const Mantid::API::MatrixWorkspace_sptr effWS,
-                                    const std::array<std::string, 4> outputSpinStates) {
+  void idealCaseFullCorrectionsTest(const Mantid::HistogramData::BinEdges &edges,
+                                    const Mantid::API::MatrixWorkspace_sptr &effWS,
+                                    const std::array<std::string, 4> &outputSpinStates) {
     using namespace Mantid::API;
     using namespace Mantid::DataObjects;
     using namespace Mantid::HistogramData;

--- a/Framework/Algorithms/test/PolarizationCorrectionWildesTest.h
+++ b/Framework/Algorithms/test/PolarizationCorrectionWildesTest.h
@@ -41,12 +41,8 @@ public:
   }
 
   void test_IdealCaseFullCorrections() {
-    using namespace Mantid::API;
-    using namespace Mantid::DataObjects;
     using namespace Mantid::HistogramData;
-    using namespace Mantid::Kernel;
-    constexpr size_t nBins{3};
-    constexpr size_t nHist{2};
+
     BinEdges edges{0.3, 0.6, 0.9, 1.2};
     auto effWS = idealEfficiencies(edges);
     const std::array<std::string, 4> POL_DIRS{{"++", "+-", "-+", "--"}};
@@ -629,10 +625,8 @@ public:
   }
 
   void test_IdealCrossPolarizationCaseFullCorrections() {
-    using namespace Mantid::API;
-    using namespace Mantid::DataObjects;
     using namespace Mantid::HistogramData;
-    using namespace Mantid::Kernel;
+
     BinEdges edges{0.3, 0.6, 0.9, 1.2};
     auto crossPolarizationEffWS = idealEfficiencies(edges, false);
     // Cross polarized ideal efficiencies should give us the same ouput as for ideal efficiencies but in the reverse
@@ -745,7 +739,6 @@ private:
     using namespace Mantid::API;
     using namespace Mantid::DataObjects;
     using namespace Mantid::HistogramData;
-    using namespace Mantid::Kernel;
     constexpr size_t nBins{3};
     constexpr size_t nHist{2};
     const double yVal = 2.3;

--- a/docs/source/release/v6.7.0/Reflectometry/Bugfixes/35333.rst
+++ b/docs/source/release/v6.7.0/Reflectometry/Bugfixes/35333.rst
@@ -1,0 +1,1 @@
+- Fixed the labelling of the workspaces output by :ref:`PolarizationCorrectionWildes` which were being inverted, while ensuring the output workspace group order continues to match the documentation.


### PR DESCRIPTION
**Description of work.**

**Report to:** Andrew at ISIS

Fixes the bug described in the attached issue and changes the order of the output workspace group so that it matches what is described in the algorithm's documentation. This PR also fixes a few bugs in the unit tests so that they are providing the required coverage. I've also added a couple of new tests to cover the output workspace group order and to test for cross-polarized ideal efficiencies, which should help ensure that we would spot this error if it were ever re-introduced.

**To test:**

<!-- Instructions for testing. -->

_Note, you may want to run through the following on a version of Mantid without the changes first to provide a benchmark for testing these changes._

1) Ask Rachel for the necessary test efficiencies workspace, as we haven't confirmed that it can be made public. Load this workspace into Mantid.
1) In the ISIS Reflectometry GUI, select POLREF as the instrument on the Runs tab.
1) On the Experiment Settings tab, tick the `Polarization Corrections` checkbox and select the loaded efficiencies workspace from the `Polarization Efficiencies` drop-down. Some other settings will be required here that Rachel can provide with the test efficiencies workspace.
1) On the Runs tab, enter `31835` in the first row (not group) of the runs table (in the right hand panel). Click the process button.
1) Expand the `IvsLam_31835` workspace that is output to the ADS. It should contain two workspaces, the first should have `_++` as the suffix and the second should have suffix `_--`. This will be the reverse order than you would have seen prior to the change. Inspecting the data using `Show Data`, you should also see that the values in the `_++` workspace are the values that you would previously have seen in the `_--` output workspace, and vice versa.


Fixes #34940. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
