### PR TITLE
Tidy up pearl output files naming and save directories

### DIFF
--- a/Testing/SystemTests/tests/framework/ISIS_PowderPearlTest.py
+++ b/Testing/SystemTests/tests/framework/ISIS_PowderPearlTest.py
@@ -141,8 +141,8 @@ class FocusTest(systemtesting.MantidSystemTest):
         user_output = os.path.join(output_dir, cycle, user_name)
         assert_output_file_exists(user_output, "PRL98507_tt70.nxs")
         assert_output_file_exists(user_output, "PRL98507_tt70.gsas")
-        assert_output_file_exists(user_output, "PRL98507_tt70_tof-0.xye")
-        assert_output_file_exists(user_output, "PRL98507_tt70_d-0.xye")
+        assert_output_file_exists(user_output, "PRL98507_tt70_tof.xye")
+        assert_output_file_exists(user_output, "PRL98507_tt70_d.xye")
 
         self.tolerance = 1e-8  # Required for difference in spline data between operating systems
         return "PEARL98507_tt70-Results-D-Grp", "ISIS_Powder-PEARL00098507_tt70Atten.nxs"
@@ -195,10 +195,10 @@ class FocusLongThenShortTest(systemtesting.MantidSystemTest):
         assert_output_file_exists(user_output, "PRL98507_tt70_long.nxs")
         assert_output_file_exists(user_output, "PRL98507_tt70.gsas")
         assert_output_file_exists(user_output, "PRL98507_tt70_long.gsas")
-        assert_output_file_exists(user_output, "PRL98507_tt70_tof-0.xye")
-        assert_output_file_exists(user_output, "PRL98507_tt70_d-0.xye")
-        assert_output_file_exists(user_output, "PRL98507_tt70_long_tof-0.xye")
-        assert_output_file_exists(user_output, "PRL98507_tt70_long_d-0.xye")
+        assert_output_file_exists(user_output, "PRL98507_tt70_tof.xye")
+        assert_output_file_exists(user_output, "PRL98507_tt70_d.xye")
+        assert_output_file_exists(user_output, "PRL98507_tt70_long_tof.xye")
+        assert_output_file_exists(user_output, "PRL98507_tt70_long_d.xye")
 
         self.tolerance = 1e-8  # Required for difference in spline data between operating systems
         return (

--- a/Testing/SystemTests/tests/framework/ISIS_PowderPearlTest.py
+++ b/Testing/SystemTests/tests/framework/ISIS_PowderPearlTest.py
@@ -39,6 +39,10 @@ working_dir = os.path.join(DIRS[0], working_folder_name)
 
 input_dir = os.path.join(working_dir, input_folder_name)
 output_dir = os.path.join(working_dir, output_folder_name)
+user_dir = os.path.join(output_dir, cycle, user_name)
+xye_tof_outdir = os.path.join(user_dir, "ToF")
+xye_dSpac_outdir = os.path.join(user_dir, "dSpacing")
+gss_outdir = os.path.join(user_dir, "GSAS")
 
 calibration_map_path = os.path.join(input_dir, calibration_map_rel_path)
 calibration_dir = os.path.join(input_dir, calibration_folder_name)
@@ -138,11 +142,10 @@ class FocusTest(systemtesting.MantidSystemTest):
         def assert_output_file_exists(directory, filename):
             self.assertTrue(os.path.isfile(os.path.join(directory, filename)), msg=generate_error_message(filename, directory))
 
-        user_output = os.path.join(output_dir, cycle, user_name)
-        assert_output_file_exists(user_output, "PRL98507_tt70.nxs")
-        assert_output_file_exists(user_output, "PRL98507_tt70.gsas")
-        assert_output_file_exists(user_output, "PRL98507_tt70_tof.xye")
-        assert_output_file_exists(user_output, "PRL98507_tt70_d.xye")
+        assert_output_file_exists(user_dir, "PRL98507_tt70.nxs")
+        assert_output_file_exists(gss_outdir, "PRL98507_tt70.gsas")
+        assert_output_file_exists(xye_tof_outdir, "PRL98507_tt70_tof.xye")
+        assert_output_file_exists(xye_dSpac_outdir, "PRL98507_tt70_d.xye")
 
         self.tolerance = 1e-8  # Required for difference in spline data between operating systems
         return "PEARL98507_tt70-Results-D-Grp", "ISIS_Powder-PEARL00098507_tt70Atten.nxs"
@@ -190,15 +193,14 @@ class FocusLongThenShortTest(systemtesting.MantidSystemTest):
         def assert_output_file_exists(directory, filename):
             self.assertTrue(os.path.isfile(os.path.join(directory, filename)), msg=generate_error_message(filename, directory))
 
-        user_output = os.path.join(output_dir, cycle, user_name)
-        assert_output_file_exists(user_output, "PRL98507_tt70.nxs")
-        assert_output_file_exists(user_output, "PRL98507_tt70_long.nxs")
-        assert_output_file_exists(user_output, "PRL98507_tt70.gsas")
-        assert_output_file_exists(user_output, "PRL98507_tt70_long.gsas")
-        assert_output_file_exists(user_output, "PRL98507_tt70_tof.xye")
-        assert_output_file_exists(user_output, "PRL98507_tt70_d.xye")
-        assert_output_file_exists(user_output, "PRL98507_tt70_long_tof.xye")
-        assert_output_file_exists(user_output, "PRL98507_tt70_long_d.xye")
+        assert_output_file_exists(user_dir, "PRL98507_tt70.nxs")
+        assert_output_file_exists(user_dir, "PRL98507_tt70_long.nxs")
+        assert_output_file_exists(gss_outdir, "PRL98507_tt70.gsas")
+        assert_output_file_exists(gss_outdir, "PRL98507_tt70_long.gsas")
+        assert_output_file_exists(xye_tof_outdir, "PRL98507_tt70_tof.xye")
+        assert_output_file_exists(xye_dSpac_outdir, "PRL98507_tt70_d.xye")
+        assert_output_file_exists(xye_tof_outdir, "PRL98507_tt70_long_tof.xye")
+        assert_output_file_exists(xye_dSpac_outdir, "PRL98507_tt70_long_d.xye")
 
         self.tolerance = 1e-8  # Required for difference in spline data between operating systems
         return (

--- a/Testing/SystemTests/tests/framework/ISIS_PowderPearlTest.py
+++ b/Testing/SystemTests/tests/framework/ISIS_PowderPearlTest.py
@@ -51,7 +51,6 @@ summed_empty_path = os.path.join(calibration_dir, summed_empty_rel_path)
 
 
 class _CreateVanadiumTest(systemtesting.MantidSystemTest):
-
     existing_config = config["datasearch.directories"]
     focus_mode = None
 
@@ -118,7 +117,6 @@ class CreateVanadiumModsTest(_CreateVanadiumTest):
 
 
 class FocusTest(systemtesting.MantidSystemTest):
-
     focus_results = None
     existing_config = config["datasearch.directories"]
 
@@ -160,7 +158,6 @@ class FocusTest(systemtesting.MantidSystemTest):
 
 
 class FocusLongThenShortTest(systemtesting.MantidSystemTest):
-
     focus_results = None
     existing_config = config["datasearch.directories"]
 
@@ -220,7 +217,6 @@ class FocusLongThenShortTest(systemtesting.MantidSystemTest):
 
 
 class FocusWithAbsorbCorrectionsTest(systemtesting.MantidSystemTest):
-
     focus_results = None
     existing_config = config["datasearch.directories"]
 
@@ -243,7 +239,6 @@ class FocusWithAbsorbCorrectionsTest(systemtesting.MantidSystemTest):
 
 
 class FocusWithoutEmptySubtractionTest(systemtesting.MantidSystemTest):
-
     focus_results = None
     existing_config = config["datasearch.directories"]
 
@@ -268,7 +263,6 @@ class FocusWithoutEmptySubtractionTest(systemtesting.MantidSystemTest):
 
 
 class CreateCalTest(systemtesting.MantidSystemTest):
-
     calibration_results = None
     existing_config = config["datasearch.directories"]
     run_number = 98494
@@ -300,7 +294,6 @@ class CreateCalTest(systemtesting.MantidSystemTest):
 
 
 class CreateVanadiumAndFocusCustomMode(systemtesting.MantidSystemTest):
-
     existing_config = config["datasearch.directories"]
 
     def runTest(self):

--- a/docs/source/release/v6.7.0/Diffraction/Powder/Improvements/35334.rst
+++ b/docs/source/release/v6.7.0/Diffraction/Powder/Improvements/35334.rst
@@ -1,0 +1,1 @@
+- Improvements to PEARL powder reduction output file and directory naming (.gss files and TOF and d-spacing .xye files are now in separate directories)

--- a/docs/source/release/v6.7.0/Diffraction/Single_Crystal/Improvements/35334.rst
+++ b/docs/source/release/v6.7.0/Diffraction/Single_Crystal/Improvements/35334.rst
@@ -1,1 +1,0 @@
-- Improvements to PEARL powder reduction output file and directory naming

--- a/docs/source/release/v6.7.0/Diffraction/Single_Crystal/Improvements/35334.rst
+++ b/docs/source/release/v6.7.0/Diffraction/Single_Crystal/Improvements/35334.rst
@@ -1,0 +1,1 @@
+- Improvements to PEARL powder reduction output file and directory naming

--- a/scripts/Diffraction/isis_powder/abstract_inst.py
+++ b/scripts/Diffraction/isis_powder/abstract_inst.py
@@ -317,9 +317,9 @@ class AbstractInst(object):
         """
         output_directory = os.path.join(self._output_dir, run_details.label, self._user_name)
         output_directory = os.path.abspath(os.path.expanduser(output_directory))
-        dat_files_directory = output_directory
+        xye_files_directory = output_directory
         if self._inst_settings.dat_files_directory:
-            dat_files_directory = os.path.join(output_directory, self._inst_settings.dat_files_directory)
+            xye_files_directory = os.path.join(output_directory, self._inst_settings.dat_files_directory)
 
         file_type = "" if run_details.file_extension is None else run_details.file_extension.lstrip(".")
         out_file_names = {"output_folder": output_directory}
@@ -334,18 +334,21 @@ class AbstractInst(object):
         }
         format_options = self._add_formatting_options(format_options)
 
-        output_formats = {
-            "nxs_filename": output_directory,
-            "gss_filename": output_directory,
-            "tof_xye_filename": dat_files_directory,
-            "dspacing_xye_filename": dat_files_directory,
-        }
+        output_formats = self._get_output_formats(output_directory, xye_files_directory)
         for key, output_dir in output_formats.items():
             filepath = os.path.join(output_dir, getattr(self._inst_settings, key).format(**format_options))
             out_file_names[key] = filepath
 
         out_file_names["output_name"] = os.path.splitext(os.path.basename(out_file_names["nxs_filename"]))[0]
         return out_file_names
+
+    def _get_output_formats(self, output_directory, xye_files_directory):
+        return {
+            "nxs_filename": output_directory,
+            "gss_filename": output_directory,
+            "tof_xye_filename": xye_files_directory,
+            "dspacing_xye_filename": xye_files_directory,
+        }
 
     def _generate_inst_filename(self, run_number, file_ext):
         if isinstance(run_number, list):

--- a/scripts/Diffraction/isis_powder/pearl.py
+++ b/scripts/Diffraction/isis_powder/pearl.py
@@ -89,43 +89,13 @@ class Pearl(AbstractInst):
     def should_subtract_empty_inst(self):
         return self._inst_settings.subtract_empty_inst
 
-    def _generate_out_file_paths(self, run_details):
-        """
-        Generates the various output paths and file names to be used during saving or as workspace names
-        :param run_details: The run details associated with this run
-        :return: A dictionary containing the various output paths and generated output name
-        """
-        output_directory = os.path.join(self._output_dir, run_details.label, self._user_name)
-        output_directory = os.path.abspath(os.path.expanduser(output_directory))
-        xye_files_directory = output_directory
-        if self._inst_settings.dat_files_directory:
-            xye_files_directory = os.path.join(output_directory, self._inst_settings.dat_files_directory)
-
-        file_type = "" if run_details.file_extension is None else run_details.file_extension.lstrip(".")
-        out_file_names = {"output_folder": output_directory}
-        format_options = {
-            "inst": self._inst_prefix,
-            "instlow": self._inst_prefix.lower(),
-            "instshort": self._inst_prefix_short,
-            "runno": run_details.output_run_string,
-            "fileext": file_type,
-            "_fileext": "_" + file_type if file_type else "",
-            "suffix": run_details.output_suffix if run_details.output_suffix else "",
-        }
-        format_options = self._add_formatting_options(format_options)
-
-        output_formats = {
+    def _get_output_formats(self, output_directory, xye_files_directory):
+        return {
             "nxs_filename": output_directory,
             "gss_filename": os.path.join(output_directory, "GSAS"),
             "tof_xye_filename": os.path.join(xye_files_directory, "ToF"),
             "dspacing_xye_filename": os.path.join(xye_files_directory, "dSpacing"),
         }
-        for key, output_dir in output_formats.items():
-            filepath = os.path.join(output_dir, getattr(self._inst_settings, key).format(**format_options))
-            out_file_names[key] = filepath
-
-        out_file_names["output_name"] = os.path.splitext(os.path.basename(out_file_names["nxs_filename"]))[0]
-        return out_file_names
 
     @contextmanager
     def _apply_temporary_inst_settings(self, kwargs, run):

--- a/scripts/Diffraction/isis_powder/pearl.py
+++ b/scripts/Diffraction/isis_powder/pearl.py
@@ -89,6 +89,44 @@ class Pearl(AbstractInst):
     def should_subtract_empty_inst(self):
         return self._inst_settings.subtract_empty_inst
 
+    def _generate_out_file_paths(self, run_details):
+        """
+        Generates the various output paths and file names to be used during saving or as workspace names
+        :param run_details: The run details associated with this run
+        :return: A dictionary containing the various output paths and generated output name
+        """
+        output_directory = os.path.join(self._output_dir, run_details.label, self._user_name)
+        output_directory = os.path.abspath(os.path.expanduser(output_directory))
+        xye_files_directory = output_directory
+        if self._inst_settings.dat_files_directory:
+            xye_files_directory = os.path.join(output_directory, self._inst_settings.dat_files_directory)
+
+        file_type = "" if run_details.file_extension is None else run_details.file_extension.lstrip(".")
+        out_file_names = {"output_folder": output_directory}
+        format_options = {
+            "inst": self._inst_prefix,
+            "instlow": self._inst_prefix.lower(),
+            "instshort": self._inst_prefix_short,
+            "runno": run_details.output_run_string,
+            "fileext": file_type,
+            "_fileext": "_" + file_type if file_type else "",
+            "suffix": run_details.output_suffix if run_details.output_suffix else "",
+        }
+        format_options = self._add_formatting_options(format_options)
+
+        output_formats = {
+            "nxs_filename": output_directory,
+            "gss_filename": os.path.join(output_directory, "GSAS"),
+            "tof_xye_filename": os.path.join(xye_files_directory, "ToF"),
+            "dspacing_xye_filename": os.path.join(xye_files_directory, "dSpacing"),
+        }
+        for key, output_dir in output_formats.items():
+            filepath = os.path.join(output_dir, getattr(self._inst_settings, key).format(**format_options))
+            out_file_names[key] = filepath
+
+        out_file_names["output_name"] = os.path.splitext(os.path.basename(out_file_names["nxs_filename"]))[0]
+        return out_file_names
+
     @contextmanager
     def _apply_temporary_inst_settings(self, kwargs, run):
 

--- a/scripts/Diffraction/isis_powder/pearl.py
+++ b/scripts/Diffraction/isis_powder/pearl.py
@@ -129,7 +129,6 @@ class Pearl(AbstractInst):
 
     @contextmanager
     def _apply_temporary_inst_settings(self, kwargs, run):
-
         self._inst_settings.update_attributes(kwargs=kwargs)
         self._switch_long_mode_inst_settings(self._inst_settings.long_mode)
 

--- a/scripts/Diffraction/isis_powder/pearl_routines/pearl_output.py
+++ b/scripts/Diffraction/isis_powder/pearl_routines/pearl_output.py
@@ -50,7 +50,11 @@ def _focus_mode_all(output_file_paths, processed_spectra, attenuation_filepath):
 
     mantid.SaveGSS(InputWorkspace=summed_spectra, Filename=output_file_paths["gss_filename"], Append=False, Bank=1)
     mantid.SaveFocusedXYE(
-        InputWorkspace=summed_spectra_name, Filename=output_file_paths["tof_xye_filename"], Append=False, IncludeHeader=False
+        InputWorkspace=summed_spectra_name,
+        Filename=output_file_paths["tof_xye_filename"],
+        Append=False,
+        IncludeHeader=False,
+        SplitFiles=False,
     )
 
     summed_spectra = mantid.ConvertUnits(InputWorkspace=summed_spectra, Target="dSpacing", OutputWorkspace=summed_spectra_name)
@@ -66,7 +70,7 @@ def _focus_mode_all(output_file_paths, processed_spectra, attenuation_filepath):
         mantid.SaveGSS(InputWorkspace=ws_to_save, Filename=output_file_paths["gss_filename"], Append=True, Bank=i + 2)
         splits = output_file_paths["tof_xye_filename"].split(".")
         tof_xye_name = splits[0] + "-" + str(i + 10) + "." + splits[1]
-        mantid.SaveFocusedXYE(InputWorkspace=ws_to_save, Filename=tof_xye_name, Append=False, IncludeHeader=False)
+        mantid.SaveFocusedXYE(InputWorkspace=ws_to_save, Filename=tof_xye_name, Append=False, IncludeHeader=False, SplitFiles=False)
         ws_to_save = mantid.ConvertUnits(InputWorkspace=ws_to_save, OutputWorkspace=output_name, Target="dSpacing")
         mantid.SaveNexus(Filename=output_file_paths["nxs_filename"], InputWorkspace=ws_to_save, Append=True)
 
@@ -91,7 +95,9 @@ def _focus_mode_groups(output_file_paths, calibrated_spectra):
     for ws in to_save:
         ws = mantid.ConvertUnits(InputWorkspace=ws, OutputWorkspace=ws, Target="TOF")
         mantid.SaveGSS(InputWorkspace=ws, Filename=output_file_paths["gss_filename"], Append=False, Bank=index)
-        mantid.SaveFocusedXYE(InputWorkspace=ws, Filename=output_file_paths["tof_xye_filename"], Append=False, IncludeHeader=False)
+        mantid.SaveFocusedXYE(
+            InputWorkspace=ws, Filename=output_file_paths["tof_xye_filename"], Append=False, IncludeHeader=False, SplitFiles=False
+        )
         workspace_names = ws.name()
         ws = mantid.ConvertUnits(InputWorkspace=ws, OutputWorkspace=workspace_names, Target="dSpacing")
         output_list.append(ws)
@@ -110,7 +116,7 @@ def _focus_mode_groups(output_file_paths, calibrated_spectra):
         splits = output_file_paths["tof_xye_filename"].split(".")
         tof_xye_name = splits[0] + "-" + str(i + 10) + "." + splits[1]
         mantid.SaveGSS(InputWorkspace=to_save, Filename=output_file_paths["gss_filename"], Append=True, Bank=i + 5)
-        mantid.SaveFocusedXYE(InputWorkspace=to_save, Filename=tof_xye_name, Append=False, IncludeHeader=False)
+        mantid.SaveFocusedXYE(InputWorkspace=to_save, Filename=tof_xye_name, Append=False, IncludeHeader=False, SplitFiles=False)
         to_save = mantid.ConvertUnits(InputWorkspace=to_save, OutputWorkspace=monitor_ws_name, Target="dSpacing")
         mantid.SaveNexus(Filename=output_file_paths["nxs_filename"], InputWorkspace=to_save, Append=True)
 
@@ -125,7 +131,9 @@ def _focus_mode_mods(output_file_paths, calibrated_spectra):
     for index, ws in enumerate(calibrated_spectra):
         output_name = output_file_paths["output_name"] + "_mod" + str(index + 1)
         tof_ws = mantid.ConvertUnits(InputWorkspace=ws, OutputWorkspace=output_name, Target=WORKSPACE_UNITS.tof)
-        mantid.SaveFocusedXYE(InputWorkspace=tof_ws, Filename=output_file_paths["tof_xye_filename"], Append=False, IncludeHeader=False)
+        mantid.SaveFocusedXYE(
+            InputWorkspace=tof_ws, Filename=output_file_paths["tof_xye_filename"], Append=False, IncludeHeader=False, SplitFiles=False
+        )
         mantid.SaveGSS(InputWorkspace=tof_ws, Filename=output_file_paths["gss_filename"], Append=append, Bank=index + 1)
         dspacing_ws = mantid.ConvertUnits(InputWorkspace=ws, OutputWorkspace=output_name, Target=WORKSPACE_UNITS.d_spacing)
         output_list.append(dspacing_ws)
@@ -148,7 +156,9 @@ def _focus_mode_trans(output_file_paths, attenuation_filepath, calibrated_spectr
     summed_ws = mantid.ConvertUnits(InputWorkspace=summed_ws, Target="TOF")
     mantid.SaveGSS(InputWorkspace=summed_ws, Filename=output_file_paths["gss_filename"], Append=False, Bank=1)
 
-    mantid.SaveFocusedXYE(InputWorkspace=summed_ws, Filename=output_file_paths["tof_xye_filename"], Append=False, IncludeHeader=False)
+    mantid.SaveFocusedXYE(
+        InputWorkspace=summed_ws, Filename=output_file_paths["tof_xye_filename"], Append=False, IncludeHeader=False, SplitFiles=False
+    )
 
     summed_ws = mantid.ConvertUnits(InputWorkspace=summed_ws, Target="dSpacing")
 
@@ -156,7 +166,9 @@ def _focus_mode_trans(output_file_paths, attenuation_filepath, calibrated_spectr
     summed_ws_name = output_file_paths["output_name"] + "_mods1-9"
     summed_ws = mantid.RenameWorkspace(InputWorkspace=summed_ws, OutputWorkspace=summed_ws_name)
 
-    mantid.SaveFocusedXYE(InputWorkspace=summed_ws, Filename=output_file_paths["dspacing_xye_filename"], Append=False, IncludeHeader=False)
+    mantid.SaveFocusedXYE(
+        InputWorkspace=summed_ws, Filename=output_file_paths["dspacing_xye_filename"], Append=False, IncludeHeader=False, SplitFiles=False
+    )
     mantid.SaveNexus(InputWorkspace=summed_ws, Filename=output_file_paths["nxs_filename"], Append=False)
 
     output_list = [summed_ws]


### PR DESCRIPTION
**Description of work.**

Tidy up pearl output files naming and save directories

**To test:**

Follow Danny's instructions on a comment on the original issue:

> Script to run a PEARL reduction. The C:\PEARL\ folder will need changing to wherever your config files are stored:
> 
> ```
> # import mantid algorithms, numpy and matplotlib
> from mantid.simpleapi import *
> import matplotlib.pyplot as plt
> import numpy as np
> 
> from isis_powder.pearl import Pearl
> 
> pearl = Pearl(user_name="Danny",
>                     output_directory=r"C:\PEARL",   #directory above cycle number 
>                     config_file=r"C:\PEARL\User_experiment.yaml",
>                     calibration_directory=r"C:\PEARL\calib_critical_files",
>                     calibration_mapping_file=r"C:\PEARL\calib_critical_files\pearl_run_mapping.yaml")
> 
> pearl.create_vanadium(run_in_cycle=116374, do_absorb_corrections=True)
> 
> pearl.focus(run_number="116374", file_ext=".s02", perform_attenuation=False, 
>                   subtract_empty_instrument=False, focus_mode="all")
> ```
> 
> In addition to the script above you'll also need a zip file with some config (.yaml) files in it and a couple of data files (eg a .nxs file). This is too big to attach to this issue so I'll put it in \\olympic\Babylon5\Public\DannyHindson\PEARLExampleForSarah.zip


There should be separate directories for tof and d-spacing xye files and the .gss files
![image](https://user-images.githubusercontent.com/55979119/222676281-f2c9aa90-d89e-4837-b3bd-cb8b3ce14553.png)
The .nxs files are still saved in the top directory as before.

Fixes #30883 
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
