### PR TITLE
Use job runner for ALFView Analysis

### DIFF
--- a/Framework/API/inc/MantidAPI/AlgorithmProperties.h
+++ b/Framework/API/inc/MantidAPI/AlgorithmProperties.h
@@ -11,6 +11,7 @@
 #include "MantidAPI/IAlgorithm_fwd.h"
 #include "MantidAPI/IFunction.h"
 #include "MantidAPI/MatrixWorkspace.h"
+#include "MantidAPI/Workspace.h"
 #include "MantidKernel/Strings.h"
 
 #include <boost/optional.hpp>
@@ -35,6 +36,9 @@ void MANTID_API_DLL update(std::string const &property, size_t value, IAlgorithm
 void MANTID_API_DLL update(std::string const &property, double value, IAlgorithmRuntimeProps &properties);
 
 void MANTID_API_DLL update(std::string const &property, boost::optional<double> const &value,
+                           IAlgorithmRuntimeProps &properties);
+
+void MANTID_API_DLL update(std::string const &property, Workspace_sptr const &workspace,
                            IAlgorithmRuntimeProps &properties);
 
 void MANTID_API_DLL update(std::string const &property, MatrixWorkspace_sptr const &workspace,

--- a/Framework/API/inc/MantidAPI/AlgorithmProperties.h
+++ b/Framework/API/inc/MantidAPI/AlgorithmProperties.h
@@ -9,6 +9,7 @@
 #include "MantidAPI/DllConfig.h"
 #include "MantidAPI/IAlgorithmRuntimeProps.h"
 #include "MantidAPI/IAlgorithm_fwd.h"
+#include "MantidAPI/IFunction.h"
 #include "MantidAPI/MatrixWorkspace.h"
 #include "MantidKernel/Strings.h"
 
@@ -37,6 +38,9 @@ void MANTID_API_DLL update(std::string const &property, boost::optional<double> 
                            IAlgorithmRuntimeProps &properties);
 
 void MANTID_API_DLL update(std::string const &property, MatrixWorkspace_sptr const &workspace,
+                           IAlgorithmRuntimeProps &properties);
+
+void MANTID_API_DLL update(std::string const &property, IFunction_sptr const &function,
                            IAlgorithmRuntimeProps &properties);
 
 void MANTID_API_DLL updateFromMap(IAlgorithmRuntimeProps &properties,

--- a/Framework/API/src/AlgorithmProperties.cpp
+++ b/Framework/API/src/AlgorithmProperties.cpp
@@ -47,6 +47,10 @@ void update(std::string const &property, boost::optional<double> const &value, I
     update(property, value.get(), properties);
 }
 
+void update(std::string const &property, Workspace_sptr const &workspace, IAlgorithmRuntimeProps &properties) {
+  properties.setProperty(property, workspace);
+}
+
 void update(std::string const &property, MatrixWorkspace_sptr const &workspace, IAlgorithmRuntimeProps &properties) {
   properties.setProperty(property, workspace);
 }

--- a/Framework/API/src/AlgorithmProperties.cpp
+++ b/Framework/API/src/AlgorithmProperties.cpp
@@ -51,6 +51,10 @@ void update(std::string const &property, MatrixWorkspace_sptr const &workspace, 
   properties.setProperty(property, workspace);
 }
 
+void update(std::string const &property, IFunction_sptr const &function, IAlgorithmRuntimeProps &properties) {
+  properties.setProperty(property, function);
+}
+
 void updateFromMap(IAlgorithmRuntimeProps &properties, std::map<std::string, std::string> const &parameterMap) {
   for (auto kvp : parameterMap) {
     update(kvp.first, kvp.second, properties);

--- a/qt/scientific_interfaces/Direct/ALFAlgorithmManager.cpp
+++ b/qt/scientific_interfaces/Direct/ALFAlgorithmManager.cpp
@@ -267,7 +267,7 @@ void ALFAlgorithmManager::notifyFitComplete(Mantid::API::IAlgorithm_sptr const &
   IFunction_sptr function = algorithm->getProperty("Function");
   std::string fitStatus = algorithm->getPropertyValue("OutputStatus");
 
-  m_subscriber->notifyFitComplete(outputWorkspace, function, fitStatus);
+  m_subscriber->notifyFitComplete(std::move(outputWorkspace), std::move(function), std::move(fitStatus));
 }
 
 } // namespace MantidQt::CustomInterfaces

--- a/qt/scientific_interfaces/Direct/ALFAlgorithmManager.cpp
+++ b/qt/scientific_interfaces/Direct/ALFAlgorithmManager.cpp
@@ -18,7 +18,9 @@ using namespace Mantid::API;
 namespace {
 auto constexpr CONVERT_UNITS_ALG_NAME = "ConvertUnits";
 auto constexpr CREATE_WORKSPACE_ALG_NAME = "CreateWorkspace";
+auto constexpr CROP_WORKSPACE_ALG_NAME = "CropWorkspace";
 auto constexpr DIVIDE_ALG_NAME = "Divide";
+auto constexpr FIT_ALG_NAME = "Fit";
 auto constexpr LOAD_ALG_NAME = "Load";
 auto constexpr NORMALISE_CURRENT_ALG_NAME = "NormaliseByCurrent";
 auto constexpr REBIN_TO_WORKSPACE_ALG_NAME = "RebinToWorkspace";
@@ -35,7 +37,9 @@ enum class AlgorithmType {
   CONVERT_UNITS,
   CREATE_WORKSPACE,
   SCALE_X,
-  REBUNCH
+  REBUNCH,
+  CROP_WORKSPACE,
+  FIT
 };
 
 AlgorithmType algorithmType(MantidQt::API::IConfiguredAlgorithm_sptr &configuredAlg) {
@@ -58,6 +62,10 @@ AlgorithmType algorithmType(MantidQt::API::IConfiguredAlgorithm_sptr &configured
     return AlgorithmType::SCALE_X;
   } else if (name == REBUNCH_ALG_NAME) {
     return AlgorithmType::REBUNCH;
+  } else if (name == CROP_WORKSPACE_ALG_NAME) {
+    return AlgorithmType::CROP_WORKSPACE;
+  } else if (name == FIT_ALG_NAME) {
+    return AlgorithmType::FIT;
   } else {
     throw std::logic_error(std::string("ALFView error: callback from invalid algorithm ") + name);
   }
@@ -117,6 +125,14 @@ void ALFAlgorithmManager::rebunch(std::unique_ptr<Mantid::API::AlgorithmRuntimeP
   executeAlgorithm(createAlgorithm(REBUNCH_ALG_NAME), std::move(properties));
 }
 
+void ALFAlgorithmManager::cropWorkspace(std::unique_ptr<Mantid::API::AlgorithmRuntimeProps> properties) {
+  executeAlgorithm(createAlgorithm(CROP_WORKSPACE_ALG_NAME), std::move(properties));
+}
+
+void ALFAlgorithmManager::fit(std::unique_ptr<Mantid::API::AlgorithmRuntimeProps> properties) {
+  executeAlgorithm(createAlgorithm(FIT_ALG_NAME), std::move(properties));
+}
+
 void ALFAlgorithmManager::notifyAlgorithmComplete(API::IConfiguredAlgorithm_sptr &algorithm) {
   switch (algorithmType(algorithm)) {
   case AlgorithmType::LOAD:
@@ -145,6 +161,12 @@ void ALFAlgorithmManager::notifyAlgorithmComplete(API::IConfiguredAlgorithm_sptr
     return;
   case AlgorithmType::REBUNCH:
     notifyRebunchComplete(algorithm->algorithm());
+    return;
+  case AlgorithmType::CROP_WORKSPACE:
+    notifyCropWorkspaceComplete(algorithm->algorithm());
+    return;
+  case AlgorithmType::FIT:
+    notifyFitComplete(algorithm->algorithm());
     return;
   }
 }
@@ -213,6 +235,18 @@ void ALFAlgorithmManager::notifyRebunchComplete(Mantid::API::IAlgorithm_sptr con
   // Explicitly provide return type. Return type must be the same as the input property type to allow type casting
   MatrixWorkspace_sptr outputWorkspace = algorithm->getProperty("OutputWorkspace");
   m_subscriber->notifyRebunchComplete(outputWorkspace);
+}
+
+void ALFAlgorithmManager::notifyCropWorkspaceComplete(Mantid::API::IAlgorithm_sptr const &algorithm) {
+  // Explicitly provide return type. Return type must be the same as the input property type to allow type casting
+  // MatrixWorkspace_sptr outputWorkspace = algorithm->getProperty("OutputWorkspace");
+  // m_subscriber->notifyCropWorkspaceComplete(outputWorkspace);
+}
+
+void ALFAlgorithmManager::notifyFitComplete(Mantid::API::IAlgorithm_sptr const &algorithm) {
+  // Explicitly provide return type. Return type must be the same as the input property type to allow type casting
+  // MatrixWorkspace_sptr outputWorkspace = algorithm->getProperty("OutputWorkspace");
+  // m_subscriber->notifyFitComplete(outputWorkspace);
 }
 
 } // namespace MantidQt::CustomInterfaces

--- a/qt/scientific_interfaces/Direct/ALFAlgorithmManager.h
+++ b/qt/scientific_interfaces/Direct/ALFAlgorithmManager.h
@@ -37,6 +37,10 @@ public:
   virtual void createWorkspace(std::unique_ptr<Mantid::API::AlgorithmRuntimeProps> properties) = 0;
   virtual void scaleX(std::unique_ptr<Mantid::API::AlgorithmRuntimeProps> properties) = 0;
   virtual void rebunch(std::unique_ptr<Mantid::API::AlgorithmRuntimeProps> properties) = 0;
+
+  // The algorithms used for fitting the extracted Out of plane angle workspace
+  virtual void cropWorkspace(std::unique_ptr<Mantid::API::AlgorithmRuntimeProps> properties) = 0;
+  virtual void fit(std::unique_ptr<Mantid::API::AlgorithmRuntimeProps> properties) = 0;
 };
 
 class MANTIDQT_DIRECT_DLL ALFAlgorithmManager final : public IALFAlgorithmManager, public API::JobRunnerSubscriber {
@@ -59,6 +63,10 @@ public:
   void scaleX(std::unique_ptr<Mantid::API::AlgorithmRuntimeProps> properties) override;
   void rebunch(std::unique_ptr<Mantid::API::AlgorithmRuntimeProps> properties) override;
 
+  // The algorithms used for fitting the extracted Out of plane angle workspace
+  void cropWorkspace(std::unique_ptr<Mantid::API::AlgorithmRuntimeProps> properties) override;
+  void fit(std::unique_ptr<Mantid::API::AlgorithmRuntimeProps> properties) override;
+
   void notifyBatchComplete(bool error) override { (void)error; };
   void notifyBatchCancelled() override{};
   void notifyAlgorithmStarted(API::IConfiguredAlgorithm_sptr &algorithm) override { (void)algorithm; };
@@ -79,6 +87,9 @@ private:
   void notifyCreateWorkspaceComplete(Mantid::API::IAlgorithm_sptr const &algorithm);
   void notifyScaleXComplete(Mantid::API::IAlgorithm_sptr const &algorithm);
   void notifyRebunchComplete(Mantid::API::IAlgorithm_sptr const &algorithm);
+
+  void notifyCropWorkspaceComplete(Mantid::API::IAlgorithm_sptr const &algorithm);
+  void notifyFitComplete(Mantid::API::IAlgorithm_sptr const &algorithm);
 
   std::unique_ptr<API::IJobRunner> m_jobRunner;
   IALFAlgorithmManagerSubscriber *m_subscriber;

--- a/qt/scientific_interfaces/Direct/ALFAnalysisModel.cpp
+++ b/qt/scientific_interfaces/Direct/ALFAnalysisModel.cpp
@@ -6,8 +6,6 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 #include "ALFAnalysisModel.h"
 
-#include "MantidAPI/Algorithm.h"
-#include "MantidAPI/AlgorithmManager.h"
 #include "MantidAPI/AlgorithmProperties.h"
 #include "MantidAPI/AnalysisDataService.h"
 #include "MantidAPI/CompositeFunction.h"
@@ -26,17 +24,6 @@ namespace {
 
 std::string const NOT_IN_ADS = "not_stored_in_ads";
 std::string const WS_EXPORT_NAME("ALFView_exported");
-
-MatrixWorkspace_sptr cropWorkspace(MatrixWorkspace_sptr const &workspace, double const startX, double const endX) {
-  auto cropper = AlgorithmManager::Instance().create("CropWorkspace");
-  cropper->setAlwaysStoreInADS(false);
-  cropper->setProperty("InputWorkspace", workspace);
-  cropper->setProperty("OutputWorkspace", "__cropped");
-  cropper->setProperty("XMin", startX);
-  cropper->setProperty("XMax", endX);
-  cropper->execute();
-  return cropper->getProperty("OutputWorkspace");
-}
 
 IFunction_sptr createFlatBackground(double const height = 0.0) {
   auto flatBackground = FunctionFactory::Instance().createFunction("FlatBackground");
@@ -108,25 +95,6 @@ void ALFAnalysisModel::setExtractedWorkspace(Mantid::API::MatrixWorkspace_sptr c
 Mantid::API::MatrixWorkspace_sptr ALFAnalysisModel::extractedWorkspace() const { return m_extractedWorkspace; }
 
 bool ALFAnalysisModel::isDataExtracted() const { return m_extractedWorkspace != nullptr; }
-
-MatrixWorkspace_sptr ALFAnalysisModel::doFit(std::pair<double, double> const &range) {
-
-  IAlgorithm_sptr alg = AlgorithmManager::Instance().create("Fit");
-  alg->initialize();
-  alg->setAlwaysStoreInADS(false);
-  alg->setProperty("Function", m_function);
-  alg->setProperty("InputWorkspace", m_extractedWorkspace);
-  alg->setProperty("CreateOutput", true);
-  alg->setProperty("StartX", range.first);
-  alg->setProperty("EndX", range.second);
-  alg->execute();
-
-  m_function = alg->getProperty("Function");
-  m_fitStatus = alg->getPropertyValue("OutputStatus");
-  m_fitWorkspace = alg->getProperty("OutputWorkspace");
-
-  return m_fitWorkspace;
-}
 
 void ALFAnalysisModel::calculateEstimate(MatrixWorkspace_sptr const &workspace) {
   if (workspace) {

--- a/qt/scientific_interfaces/Direct/ALFAnalysisModel.cpp
+++ b/qt/scientific_interfaces/Direct/ALFAnalysisModel.cpp
@@ -216,11 +216,11 @@ ALFAnalysisModel::fitProperties(std::pair<double, double> const &range) const {
   return properties;
 }
 
-void ALFAnalysisModel::setFitResult(Mantid::API::MatrixWorkspace_sptr const &workspace,
-                                    Mantid::API::IFunction_sptr const &function, std::string const &fitStatus) {
-  m_fitWorkspace = workspace;
-  m_function = function;
-  m_fitStatus = fitStatus;
+void ALFAnalysisModel::setFitResult(Mantid::API::MatrixWorkspace_sptr workspace, Mantid::API::IFunction_sptr function,
+                                    std::string fitStatus) {
+  m_fitWorkspace = std::move(workspace);
+  m_function = std::move(function);
+  m_fitStatus = std::move(fitStatus);
 }
 
 std::string ALFAnalysisModel::fitStatus() const { return m_fitStatus; }

--- a/qt/scientific_interfaces/Direct/ALFAnalysisModel.h
+++ b/qt/scientific_interfaces/Direct/ALFAnalysisModel.h
@@ -51,8 +51,9 @@ public:
   virtual std::unique_ptr<Mantid::API::AlgorithmRuntimeProps>
   fitProperties(std::pair<double, double> const &range) const = 0;
 
-  virtual void setFitResult(Mantid::API::MatrixWorkspace_sptr const &workspace,
-                            Mantid::API::IFunction_sptr const &function, std::string const &fitStatus) = 0;
+  virtual void setFitResult(Mantid::API::MatrixWorkspace_sptr workspace, Mantid::API::IFunction_sptr function,
+                            std::string fitStatus) = 0;
+  virtual Mantid::API::MatrixWorkspace_sptr fitWorkspace() const = 0;
 
   virtual std::string fitStatus() const = 0;
 
@@ -95,8 +96,9 @@ public:
   std::unique_ptr<Mantid::API::AlgorithmRuntimeProps>
   fitProperties(std::pair<double, double> const &range) const override;
 
-  void setFitResult(Mantid::API::MatrixWorkspace_sptr const &workspace, Mantid::API::IFunction_sptr const &function,
-                    std::string const &fitStatus) override;
+  void setFitResult(Mantid::API::MatrixWorkspace_sptr workspace, Mantid::API::IFunction_sptr function,
+                    std::string fitStatus) override;
+  inline Mantid::API::MatrixWorkspace_sptr fitWorkspace() const noexcept override { return m_fitWorkspace; }
 
   std::string fitStatus() const override;
 

--- a/qt/scientific_interfaces/Direct/ALFAnalysisModel.h
+++ b/qt/scientific_interfaces/Direct/ALFAnalysisModel.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include "DllConfig.h"
+#include "MantidAPI/AlgorithmRuntimeProps.h"
 #include "MantidAPI/IFunction_fwd.h"
 #include "MantidAPI/IPeakFunction.h"
 #include "MantidAPI/MatrixWorkspace_fwd.h"
@@ -45,6 +46,11 @@ public:
   virtual double background() const = 0;
   virtual Mantid::API::IPeakFunction_const_sptr getPeakCopy() const = 0;
 
+  virtual std::unique_ptr<Mantid::API::AlgorithmRuntimeProps>
+  cropWorkspaceProperties(std::pair<double, double> const &range) const = 0;
+  virtual std::unique_ptr<Mantid::API::AlgorithmRuntimeProps>
+  fitProperties(std::pair<double, double> const &range) const = 0;
+
   virtual std::string fitStatus() const = 0;
 
   virtual std::size_t numberOfTubes() const = 0;
@@ -80,6 +86,11 @@ public:
   double peakCentre() const override;
   double background() const override;
   Mantid::API::IPeakFunction_const_sptr getPeakCopy() const override;
+
+  std::unique_ptr<Mantid::API::AlgorithmRuntimeProps>
+  cropWorkspaceProperties(std::pair<double, double> const &range) const override;
+  std::unique_ptr<Mantid::API::AlgorithmRuntimeProps>
+  fitProperties(std::pair<double, double> const &range) const override;
 
   std::string fitStatus() const override;
 

--- a/qt/scientific_interfaces/Direct/ALFAnalysisModel.h
+++ b/qt/scientific_interfaces/Direct/ALFAnalysisModel.h
@@ -33,7 +33,7 @@ public:
   virtual bool isDataExtracted() const = 0;
 
   virtual Mantid::API::MatrixWorkspace_sptr doFit(std::pair<double, double> const &range) = 0;
-  virtual void calculateEstimate(std::pair<double, double> const &range) = 0;
+  virtual void calculateEstimate(Mantid::API::MatrixWorkspace_sptr const &workspace) = 0;
 
   virtual void exportWorkspaceCopyToADS() const = 0;
 
@@ -50,6 +50,9 @@ public:
   cropWorkspaceProperties(std::pair<double, double> const &range) const = 0;
   virtual std::unique_ptr<Mantid::API::AlgorithmRuntimeProps>
   fitProperties(std::pair<double, double> const &range) const = 0;
+
+  virtual void setFitResult(Mantid::API::MatrixWorkspace_sptr const &workspace,
+                            Mantid::API::IFunction_sptr const &function, std::string const &fitStatus) = 0;
 
   virtual std::string fitStatus() const = 0;
 
@@ -74,7 +77,7 @@ public:
   bool isDataExtracted() const override;
 
   Mantid::API::MatrixWorkspace_sptr doFit(std::pair<double, double> const &range) override;
-  void calculateEstimate(std::pair<double, double> const &range) override;
+  void calculateEstimate(Mantid::API::MatrixWorkspace_sptr const &workspace) override;
 
   void exportWorkspaceCopyToADS() const override;
 
@@ -92,6 +95,9 @@ public:
   std::unique_ptr<Mantid::API::AlgorithmRuntimeProps>
   fitProperties(std::pair<double, double> const &range) const override;
 
+  void setFitResult(Mantid::API::MatrixWorkspace_sptr const &workspace, Mantid::API::IFunction_sptr const &function,
+                    std::string const &fitStatus) override;
+
   std::string fitStatus() const override;
 
   std::size_t numberOfTubes() const override;
@@ -102,8 +108,7 @@ public:
   std::optional<double> rotationAngle() const override;
 
 private:
-  Mantid::API::IFunction_sptr calculateEstimate(Mantid::API::MatrixWorkspace_sptr &workspace,
-                                                std::pair<double, double> const &range);
+  Mantid::API::IFunction_sptr calculateEstimateImpl(Mantid::API::MatrixWorkspace_sptr const &workspace);
 
   Mantid::API::IFunction_sptr m_function;
   std::string m_fitStatus;

--- a/qt/scientific_interfaces/Direct/ALFAnalysisModel.h
+++ b/qt/scientific_interfaces/Direct/ALFAnalysisModel.h
@@ -32,7 +32,6 @@ public:
   virtual Mantid::API::MatrixWorkspace_sptr extractedWorkspace() const = 0;
   virtual bool isDataExtracted() const = 0;
 
-  virtual Mantid::API::MatrixWorkspace_sptr doFit(std::pair<double, double> const &range) = 0;
   virtual void calculateEstimate(Mantid::API::MatrixWorkspace_sptr const &workspace) = 0;
 
   virtual void exportWorkspaceCopyToADS() const = 0;
@@ -77,7 +76,6 @@ public:
   Mantid::API::MatrixWorkspace_sptr extractedWorkspace() const override;
   bool isDataExtracted() const override;
 
-  Mantid::API::MatrixWorkspace_sptr doFit(std::pair<double, double> const &range) override;
   void calculateEstimate(Mantid::API::MatrixWorkspace_sptr const &workspace) override;
 
   void exportWorkspaceCopyToADS() const override;

--- a/qt/scientific_interfaces/Direct/ALFAnalysisPresenter.cpp
+++ b/qt/scientific_interfaces/Direct/ALFAnalysisPresenter.cpp
@@ -23,9 +23,11 @@ bool equalWithinTolerance(double const val1, double const val2, double const tol
 
 namespace MantidQt::CustomInterfaces {
 
-ALFAnalysisPresenter::ALFAnalysisPresenter(IALFAnalysisView *view, std::unique_ptr<IALFAnalysisModel> model)
-    : m_view(view), m_model(std::move(model)) {
+ALFAnalysisPresenter::ALFAnalysisPresenter(IALFAnalysisView *view, std::unique_ptr<IALFAnalysisModel> model,
+                                           std::unique_ptr<IALFAlgorithmManager> algorithmManager)
+    : m_view(view), m_model(std::move(model)), m_algorithmManager(std::move(algorithmManager)) {
   m_view->subscribePresenter(this);
+  m_algorithmManager->subscribe(this);
 }
 
 QWidget *ALFAnalysisPresenter::getView() { return m_view->getView(); }
@@ -34,7 +36,6 @@ void ALFAnalysisPresenter::setExtractedWorkspace(Mantid::API::MatrixWorkspace_sp
                                                  std::vector<double> const &twoThetas) {
   m_model->setExtractedWorkspace(workspace, twoThetas);
   calculateEstimate();
-  updateViewFromModel();
 }
 
 void ALFAnalysisPresenter::notifyPeakPickerChanged() {
@@ -64,12 +65,22 @@ void ALFAnalysisPresenter::notifyFitClicked() {
     return;
   }
 
-  try {
-    auto const fitWorkspace = m_model->doFit(m_view->getRange());
-    m_view->addFitSpectrum(fitWorkspace);
-  } catch (std::exception const &ex) {
-    m_view->displayWarning(ex.what());
-  }
+  m_algorithmManager->fit(m_model->fitProperties(m_view->getRange()));
+}
+
+void ALFAnalysisPresenter::notifyAlgorithmError(std::string const &message) { m_view->displayWarning(message); }
+
+void ALFAnalysisPresenter::notifyCropWorkspaceComplete(Mantid::API::MatrixWorkspace_sptr const &workspace) {
+  m_model->calculateEstimate(workspace);
+  updateViewFromModel();
+}
+
+void ALFAnalysisPresenter::notifyFitComplete(Mantid::API::MatrixWorkspace_sptr const &workspace,
+                                             Mantid::API::IFunction_sptr const &function,
+                                             std::string const &fitStatus) {
+  m_model->setFitResult(workspace, function, fitStatus);
+  m_view->addFitSpectrum(workspace);
+
   updatePeakCentreInViewFromModel();
   updateRotationAngleInViewFromModel();
 }
@@ -82,11 +93,7 @@ void ALFAnalysisPresenter::notifyExternalPlotClicked() {
   }
 }
 
-void ALFAnalysisPresenter::notifyResetClicked() {
-  calculateEstimate();
-  updatePeakCentreInViewFromModel();
-  updateRotationAngleInViewFromModel();
-}
+void ALFAnalysisPresenter::notifyResetClicked() { calculateEstimate(); }
 
 std::optional<std::string> ALFAnalysisPresenter::validateFitValues() const {
   if (!m_model->isDataExtracted())
@@ -111,7 +118,7 @@ bool ALFAnalysisPresenter::checkPeakCentreIsWithinFitRange() const {
 
 void ALFAnalysisPresenter::calculateEstimate() {
   if (m_model->isDataExtracted()) {
-    m_model->calculateEstimate(m_view->getRange());
+    m_algorithmManager->cropWorkspace(m_model->cropWorkspaceProperties(m_view->getRange()));
   }
 }
 

--- a/qt/scientific_interfaces/Direct/ALFAnalysisPresenter.cpp
+++ b/qt/scientific_interfaces/Direct/ALFAnalysisPresenter.cpp
@@ -118,6 +118,8 @@ bool ALFAnalysisPresenter::checkPeakCentreIsWithinFitRange() const {
 void ALFAnalysisPresenter::calculateEstimate() {
   if (m_model->isDataExtracted()) {
     m_algorithmManager->cropWorkspace(m_model->cropWorkspaceProperties(m_view->getRange()));
+  } else {
+    updatePlotInViewFromModel();
   }
 }
 

--- a/qt/scientific_interfaces/Direct/ALFAnalysisPresenter.cpp
+++ b/qt/scientific_interfaces/Direct/ALFAnalysisPresenter.cpp
@@ -75,11 +75,10 @@ void ALFAnalysisPresenter::notifyCropWorkspaceComplete(Mantid::API::MatrixWorksp
   updateViewFromModel();
 }
 
-void ALFAnalysisPresenter::notifyFitComplete(Mantid::API::MatrixWorkspace_sptr const &workspace,
-                                             Mantid::API::IFunction_sptr const &function,
-                                             std::string const &fitStatus) {
-  m_model->setFitResult(workspace, function, fitStatus);
-  m_view->addFitSpectrum(workspace);
+void ALFAnalysisPresenter::notifyFitComplete(Mantid::API::MatrixWorkspace_sptr workspace,
+                                             Mantid::API::IFunction_sptr function, std::string fitStatus) {
+  m_model->setFitResult(std::move(workspace), std::move(function), std::move(fitStatus));
+  m_view->addFitSpectrum(m_model->fitWorkspace());
 
   updatePeakCentreInViewFromModel();
   updateRotationAngleInViewFromModel();

--- a/qt/scientific_interfaces/Direct/ALFAnalysisPresenter.h
+++ b/qt/scientific_interfaces/Direct/ALFAnalysisPresenter.h
@@ -6,8 +6,10 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 #pragma once
 
+#include "ALFAlgorithmManager.h"
 #include "ALFAnalysisModel.h"
 #include "DllConfig.h"
+#include "IALFAlgorithmManagerSubscriber.h"
 #include "MantidAPI/MatrixWorkspace_fwd.h"
 
 #include <QWidget>
@@ -44,10 +46,12 @@ public:
   virtual void clear() = 0;
 };
 
-class MANTIDQT_DIRECT_DLL ALFAnalysisPresenter final : public IALFAnalysisPresenter {
+class MANTIDQT_DIRECT_DLL ALFAnalysisPresenter final : public IALFAnalysisPresenter,
+                                                       public IALFAlgorithmManagerSubscriber {
 
 public:
-  explicit ALFAnalysisPresenter(IALFAnalysisView *m_view, std::unique_ptr<IALFAnalysisModel> m_model);
+  explicit ALFAnalysisPresenter(IALFAnalysisView *view, std::unique_ptr<IALFAnalysisModel> model,
+                                std::unique_ptr<IALFAlgorithmManager> algorithmManager);
   QWidget *getView() override;
 
   void setExtractedWorkspace(Mantid::API::MatrixWorkspace_sptr const &workspace,
@@ -59,6 +63,11 @@ public:
   void notifyExportWorkspaceToADSClicked() override;
   void notifyExternalPlotClicked() override;
   void notifyResetClicked() override;
+
+  void notifyAlgorithmError(std::string const &message) override;
+  void notifyCropWorkspaceComplete(Mantid::API::MatrixWorkspace_sptr const &workspace) override;
+  void notifyFitComplete(Mantid::API::MatrixWorkspace_sptr const &workspace,
+                         Mantid::API::IFunction_sptr const &function, std::string const &fitStatus) override;
 
   std::size_t numberOfTubes() const override;
 
@@ -78,6 +87,7 @@ private:
 
   IALFAnalysisView *m_view;
   std::unique_ptr<IALFAnalysisModel> m_model;
+  std::unique_ptr<IALFAlgorithmManager> m_algorithmManager;
 };
 } // namespace CustomInterfaces
 } // namespace MantidQt

--- a/qt/scientific_interfaces/Direct/ALFAnalysisPresenter.h
+++ b/qt/scientific_interfaces/Direct/ALFAnalysisPresenter.h
@@ -66,8 +66,8 @@ public:
 
   void notifyAlgorithmError(std::string const &message) override;
   void notifyCropWorkspaceComplete(Mantid::API::MatrixWorkspace_sptr const &workspace) override;
-  void notifyFitComplete(Mantid::API::MatrixWorkspace_sptr const &workspace,
-                         Mantid::API::IFunction_sptr const &function, std::string const &fitStatus) override;
+  void notifyFitComplete(Mantid::API::MatrixWorkspace_sptr workspace, Mantid::API::IFunction_sptr function,
+                         std::string fitStatus) override;
 
   std::size_t numberOfTubes() const override;
 

--- a/qt/scientific_interfaces/Direct/ALFInstrumentPresenter.cpp
+++ b/qt/scientific_interfaces/Direct/ALFInstrumentPresenter.cpp
@@ -37,7 +37,7 @@ void ALFInstrumentPresenter::loadSettings() { m_view->loadSettings(); }
 
 void ALFInstrumentPresenter::saveSettings() { m_view->saveSettings(); }
 
-void ALFInstrumentPresenter::notifyAlgorithmError(std::string const &message) { m_view->warningBox(message); }
+void ALFInstrumentPresenter::notifyAlgorithmError(std::string const &message) { m_view->displayWarning(message); }
 
 void ALFInstrumentPresenter::loadSample() {
   m_dataSwitch = ALFData::SAMPLE;
@@ -64,7 +64,7 @@ void ALFInstrumentPresenter::notifyLoadComplete(Mantid::API::MatrixWorkspace_spt
   if (m_model->isALFData(workspace)) {
     m_algorithmManager->normaliseByCurrent(m_model->normaliseByCurrentProperties(workspace));
   } else {
-    m_view->warningBox("The loaded data is not from the ALF instrument");
+    m_view->displayWarning("The loaded data is not from the ALF instrument");
   }
 }
 

--- a/qt/scientific_interfaces/Direct/ALFInstrumentView.cpp
+++ b/qt/scientific_interfaces/Direct/ALFInstrumentView.cpp
@@ -130,7 +130,7 @@ void ALFInstrumentView::setVanadiumRun(std::string const &runNumber) {
 
 void ALFInstrumentView::sampleLoaded() {
   if (!m_sample->getText().isEmpty() && !m_sample->isValid()) {
-    warningBox(m_sample->getFileProblem().toStdString());
+    displayWarning(m_sample->getFileProblem().toStdString());
     return;
   }
   m_presenter->loadSample();
@@ -138,7 +138,7 @@ void ALFInstrumentView::sampleLoaded() {
 
 void ALFInstrumentView::vanadiumLoaded() {
   if (!m_vanadium->isValid()) {
-    warningBox(m_vanadium->getFileProblem().toStdString());
+    displayWarning(m_vanadium->getFileProblem().toStdString());
     return;
   }
   m_presenter->loadVanadium();
@@ -193,7 +193,7 @@ void ALFInstrumentView::drawRectanglesAbove(std::vector<DetectorTube> const &tub
   }
 }
 
-void ALFInstrumentView::warningBox(std::string const &message) {
+void ALFInstrumentView::displayWarning(std::string const &message) {
   QMessageBox::warning(this, "ALFView", QString::fromStdString(message));
 }
 

--- a/qt/scientific_interfaces/Direct/ALFInstrumentView.h
+++ b/qt/scientific_interfaces/Direct/ALFInstrumentView.h
@@ -62,7 +62,7 @@ public:
   virtual void clearShapes() = 0;
   virtual void drawRectanglesAbove(std::vector<DetectorTube> const &tubes) = 0;
 
-  virtual void warningBox(std::string const &message) = 0;
+  virtual void displayWarning(std::string const &message) = 0;
 };
 
 class MANTIDQT_DIRECT_DLL ALFInstrumentView final : public QWidget, public IALFInstrumentView {
@@ -95,7 +95,7 @@ public:
   void clearShapes() override;
   void drawRectanglesAbove(std::vector<DetectorTube> const &tubes) override;
 
-  void warningBox(std::string const &message) override;
+  void displayWarning(std::string const &message) override;
 
 private slots:
   void reconnectInstrumentActor();

--- a/qt/scientific_interfaces/Direct/ALFView.cpp
+++ b/qt/scientific_interfaces/Direct/ALFView.cpp
@@ -26,14 +26,20 @@ DECLARE_SUBWINDOW(ALFView)
 ALFView::ALFView(QWidget *parent) : UserSubWindow(parent), m_instrumentPresenter(), m_analysisPresenter() {
   this->setWindowTitle("ALFView");
 
-  auto jobRunner = std::make_unique<MantidQt::API::QtJobRunner>();
-  auto algorithmManager = std::make_unique<ALFAlgorithmManager>(std::move(jobRunner));
+  // Algorithm manager for the instrument presenter
+  auto jobRunnerInst = std::make_unique<MantidQt::API::QtJobRunner>();
+  auto algorithmManagerInst = std::make_unique<ALFAlgorithmManager>(std::move(jobRunnerInst));
 
   m_instrumentPresenter = std::make_unique<ALFInstrumentPresenter>(
-      new ALFInstrumentView(this), std::make_unique<ALFInstrumentModel>(), std::move(algorithmManager));
+      new ALFInstrumentView(this), std::make_unique<ALFInstrumentModel>(), std::move(algorithmManagerInst));
 
-  m_analysisPresenter = std::make_unique<ALFAnalysisPresenter>(new ALFAnalysisView(-15.0, 15.0, this),
-                                                               std::make_unique<ALFAnalysisModel>());
+  // Algorithm manager for the analysis presenter
+  auto jobRunnerAnalysis = std::make_unique<MantidQt::API::QtJobRunner>();
+  auto algorithmManagerAnalysis = std::make_unique<ALFAlgorithmManager>(std::move(jobRunnerAnalysis));
+
+  m_analysisPresenter =
+      std::make_unique<ALFAnalysisPresenter>(new ALFAnalysisView(-15.0, 15.0, this),
+                                             std::make_unique<ALFAnalysisModel>(), std::move(algorithmManagerAnalysis));
 
   m_instrumentPresenter->subscribeAnalysisPresenter(m_analysisPresenter.get());
 }

--- a/qt/scientific_interfaces/Direct/IALFAlgorithmManagerSubscriber.h
+++ b/qt/scientific_interfaces/Direct/IALFAlgorithmManagerSubscriber.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include "DllConfig.h"
+#include "MantidAPI/IFunction_fwd.h"
 #include "MantidAPI/MatrixWorkspace_fwd.h"
 
 namespace MantidQt::CustomInterfaces {
@@ -19,17 +20,30 @@ public:
   virtual void notifyAlgorithmError(std::string const &message) = 0;
 
   // Algorithm notifiers used when loading and normalising the Sample
-  virtual void notifyLoadComplete(Mantid::API::MatrixWorkspace_sptr const &workspace) = 0;
-  virtual void notifyNormaliseByCurrentComplete(Mantid::API::MatrixWorkspace_sptr const &workspace) = 0;
-  virtual void notifyRebinToWorkspaceComplete(Mantid::API::MatrixWorkspace_sptr const &workspace) = 0;
-  virtual void notifyDivideComplete(Mantid::API::MatrixWorkspace_sptr const &workspace) = 0;
-  virtual void notifyReplaceSpecialValuesComplete(Mantid::API::MatrixWorkspace_sptr const &workspace) = 0;
-  virtual void notifyConvertUnitsComplete(Mantid::API::MatrixWorkspace_sptr const &workspace) = 0;
+  virtual void notifyLoadComplete(Mantid::API::MatrixWorkspace_sptr const &workspace) { (void)workspace; };
+  virtual void notifyNormaliseByCurrentComplete(Mantid::API::MatrixWorkspace_sptr const &workspace) {
+    (void)workspace;
+  };
+  virtual void notifyRebinToWorkspaceComplete(Mantid::API::MatrixWorkspace_sptr const &workspace) { (void)workspace; };
+  virtual void notifyDivideComplete(Mantid::API::MatrixWorkspace_sptr const &workspace) { (void)workspace; };
+  virtual void notifyReplaceSpecialValuesComplete(Mantid::API::MatrixWorkspace_sptr const &workspace) {
+    (void)workspace;
+  };
+  virtual void notifyConvertUnitsComplete(Mantid::API::MatrixWorkspace_sptr const &workspace) { (void)workspace; };
 
   // Algorithm notifiers used when producing an Out of plane angle workspace
-  virtual void notifyCreateWorkspaceComplete(Mantid::API::MatrixWorkspace_sptr const &workspace) = 0;
-  virtual void notifyScaleXComplete(Mantid::API::MatrixWorkspace_sptr const &workspace) = 0;
-  virtual void notifyRebunchComplete(Mantid::API::MatrixWorkspace_sptr const &workspace) = 0;
+  virtual void notifyCreateWorkspaceComplete(Mantid::API::MatrixWorkspace_sptr const &workspace) { (void)workspace; };
+  virtual void notifyScaleXComplete(Mantid::API::MatrixWorkspace_sptr const &workspace) { (void)workspace; };
+  virtual void notifyRebunchComplete(Mantid::API::MatrixWorkspace_sptr const &workspace) { (void)workspace; };
+
+  // Algorithm notifiers used when fitting the extracted Out of plane angle workspace
+  virtual void notifyCropWorkspaceComplete(Mantid::API::MatrixWorkspace_sptr const &workspace) { (void)workspace; };
+  virtual void notifyFitComplete(Mantid::API::MatrixWorkspace_sptr const &workspace,
+                                 Mantid::API::IFunction_sptr const &function, std::string const &fitStatus) {
+    (void)workspace;
+    (void)function;
+    (void)fitStatus;
+  };
 };
 
 } // namespace MantidQt::CustomInterfaces

--- a/qt/scientific_interfaces/Direct/IALFAlgorithmManagerSubscriber.h
+++ b/qt/scientific_interfaces/Direct/IALFAlgorithmManagerSubscriber.h
@@ -38,8 +38,8 @@ public:
 
   // Algorithm notifiers used when fitting the extracted Out of plane angle workspace
   virtual void notifyCropWorkspaceComplete(Mantid::API::MatrixWorkspace_sptr const &workspace) { (void)workspace; };
-  virtual void notifyFitComplete(Mantid::API::MatrixWorkspace_sptr const &workspace,
-                                 Mantid::API::IFunction_sptr const &function, std::string const &fitStatus) {
+  virtual void notifyFitComplete(Mantid::API::MatrixWorkspace_sptr workspace, Mantid::API::IFunction_sptr function,
+                                 std::string fitStatus) {
     (void)workspace;
     (void)function;
     (void)fitStatus;

--- a/qt/scientific_interfaces/Direct/test/ALFAlgorithmManagerTest.h
+++ b/qt/scientific_interfaces/Direct/test/ALFAlgorithmManagerTest.h
@@ -98,6 +98,16 @@ public:
     m_algorithmManager->rebunch(std::move(m_algProperties));
   }
 
+  void test_cropWorkspace_will_execute_the_crop_workspace_algorithm() {
+    expectExecuteAlgorithm("CropWorkspace");
+    m_algorithmManager->cropWorkspace(std::move(m_algProperties));
+  }
+
+  void test_fit_will_execute_the_fit_algorithm() {
+    expectExecuteAlgorithm("Fit");
+    m_algorithmManager->fit(std::move(m_algProperties));
+  }
+
   void test_notifyAlgorithmError_will_notify_the_subscriber() {
     std::string const errorMessage("Error message");
 

--- a/qt/scientific_interfaces/Direct/test/ALFAlgorithmManagerTest.h
+++ b/qt/scientific_interfaces/Direct/test/ALFAlgorithmManagerTest.h
@@ -12,8 +12,11 @@
 #include "ALFAlgorithmManager.h"
 #include "MockALFAlgorithmManagerSubscriber.h"
 
+#include "MantidAPI/AlgorithmProperties.h"
 #include "MantidAPI/FrameworkManager.h"
+#include "MantidAPI/FunctionFactory.h"
 #include "MantidAPI/MatrixWorkspace.h"
+#include "MantidFrameworkTestHelpers/WorkspaceCreationHelper.h"
 #include "MantidQtWidgets/Common/ConfiguredAlgorithm.h"
 #include "MantidQtWidgets/Common/MockJobRunner.h"
 
@@ -105,6 +108,16 @@ public:
 
   void test_fit_will_execute_the_fit_algorithm() {
     expectExecuteAlgorithm("Fit");
+
+    Mantid::API::IFunction_sptr function = Mantid::API::FunctionFactory::Instance().createFunction("Gaussian");
+    Mantid::API::Workspace_sptr workspace = WorkspaceCreationHelper::create2DWorkspace(10, 10);
+
+    Mantid::API::AlgorithmProperties::update("Function", function, *m_algProperties);
+    Mantid::API::AlgorithmProperties::update("InputWorkspace", workspace, *m_algProperties);
+    Mantid::API::AlgorithmProperties::update("CreateOutput", true, *m_algProperties);
+    Mantid::API::AlgorithmProperties::update("StartX", -15.0, *m_algProperties);
+    Mantid::API::AlgorithmProperties::update("EndX", 15.0, *m_algProperties);
+
     m_algorithmManager->fit(std::move(m_algProperties));
   }
 

--- a/qt/scientific_interfaces/Direct/test/ALFAnalysisMocks.h
+++ b/qt/scientific_interfaces/Direct/test/ALFAnalysisMocks.h
@@ -86,7 +86,7 @@ public:
   MOCK_CONST_METHOD0(isDataExtracted, bool());
 
   MOCK_METHOD1(doFit, Mantid::API::MatrixWorkspace_sptr(std::pair<double, double> const &range));
-  MOCK_METHOD1(calculateEstimate, void(std::pair<double, double> const &range));
+  MOCK_METHOD1(calculateEstimate, void(Mantid::API::MatrixWorkspace_sptr const &workspace));
 
   MOCK_CONST_METHOD0(exportWorkspaceCopyToADS, void());
 
@@ -103,6 +103,9 @@ public:
                      std::unique_ptr<Mantid::API::AlgorithmRuntimeProps>(std::pair<double, double> const &range));
   MOCK_CONST_METHOD1(fitProperties,
                      std::unique_ptr<Mantid::API::AlgorithmRuntimeProps>(std::pair<double, double> const &range));
+
+  MOCK_METHOD3(setFitResult, void(Mantid::API::MatrixWorkspace_sptr const &workspace,
+                                  Mantid::API::IFunction_sptr const &function, std::string const &fitStatus));
 
   MOCK_CONST_METHOD0(fitStatus, std::string());
 

--- a/qt/scientific_interfaces/Direct/test/ALFAnalysisMocks.h
+++ b/qt/scientific_interfaces/Direct/test/ALFAnalysisMocks.h
@@ -104,8 +104,9 @@ public:
   MOCK_CONST_METHOD1(fitProperties,
                      std::unique_ptr<Mantid::API::AlgorithmRuntimeProps>(std::pair<double, double> const &range));
 
-  MOCK_METHOD3(setFitResult, void(Mantid::API::MatrixWorkspace_sptr const &workspace,
-                                  Mantid::API::IFunction_sptr const &function, std::string const &fitStatus));
+  MOCK_METHOD3(setFitResult, void(Mantid::API::MatrixWorkspace_sptr workspace, Mantid::API::IFunction_sptr function,
+                                  std::string fitStatus));
+  MOCK_CONST_METHOD0(fitWorkspace, Mantid::API::MatrixWorkspace_sptr());
 
   MOCK_CONST_METHOD0(fitStatus, std::string());
 

--- a/qt/scientific_interfaces/Direct/test/ALFAnalysisMocks.h
+++ b/qt/scientific_interfaces/Direct/test/ALFAnalysisMocks.h
@@ -14,7 +14,6 @@
 #include "ALFAnalysisView.h"
 #include "MantidAPI/IPeakFunction.h"
 #include "MantidAPI/MatrixWorkspace_fwd.h"
-
 #include "MantidKernel/WarningSuppressions.h"
 
 #include <optional>
@@ -99,6 +98,11 @@ public:
   MOCK_CONST_METHOD0(peakCentre, double());
   MOCK_CONST_METHOD0(background, double());
   MOCK_CONST_METHOD0(getPeakCopy, Mantid::API::IPeakFunction_const_sptr());
+
+  MOCK_CONST_METHOD1(cropWorkspaceProperties,
+                     std::unique_ptr<Mantid::API::AlgorithmRuntimeProps>(std::pair<double, double> const &range));
+  MOCK_CONST_METHOD1(fitProperties,
+                     std::unique_ptr<Mantid::API::AlgorithmRuntimeProps>(std::pair<double, double> const &range));
 
   MOCK_CONST_METHOD0(fitStatus, std::string());
 

--- a/qt/scientific_interfaces/Direct/test/ALFInstrumentMocks.h
+++ b/qt/scientific_interfaces/Direct/test/ALFInstrumentMocks.h
@@ -63,7 +63,7 @@ public:
   MOCK_METHOD0(clearShapes, void());
   MOCK_METHOD1(drawRectanglesAbove, void(std::vector<DetectorTube> const &tubes));
 
-  MOCK_METHOD1(warningBox, void(std::string const &message));
+  MOCK_METHOD1(displayWarning, void(std::string const &message));
 };
 
 class MockALFInstrumentModel : public IALFInstrumentModel {

--- a/qt/scientific_interfaces/Direct/test/ALFInstrumentPresenterTest.h
+++ b/qt/scientific_interfaces/Direct/test/ALFInstrumentPresenterTest.h
@@ -147,7 +147,7 @@ public:
 
   void test_notifyLoadComplete_opens_a_warning_if_the_data_is_not_ALF_data() {
     EXPECT_CALL(*m_model, isALFData(_)).Times(1).WillOnce(Return(false));
-    EXPECT_CALL(*m_view, warningBox("The loaded data is not from the ALF instrument")).Times(1);
+    EXPECT_CALL(*m_view, displayWarning("The loaded data is not from the ALF instrument")).Times(1);
 
     m_presenter->notifyLoadComplete(nullptr);
   }
@@ -159,8 +159,8 @@ public:
         .WillOnce(Return(ByMove(std::move(m_algProperties))));
     EXPECT_CALL(*m_algorithmManager, normaliseByCurrent(NotNull())).Times(1);
 
-    // Expect no call to warningBox
-    EXPECT_CALL(*m_view, warningBox(_)).Times(0);
+    // Expect no call to displayWarning
+    EXPECT_CALL(*m_view, displayWarning(_)).Times(0);
 
     m_presenter->notifyLoadComplete(nullptr);
   }
@@ -271,6 +271,14 @@ public:
     EXPECT_CALL(*m_analysisPresenter, setExtractedWorkspace(_, twoThetas)).Times(1);
 
     m_presenter->notifyRebunchComplete(nullptr);
+  }
+
+  void test_notifyAlgorithmError_will_display_a_message_in_the_view() {
+    std::string const message("This is a warning message");
+
+    EXPECT_CALL(*m_view, displayWarning(message)).Times(1);
+
+    m_presenter->notifyAlgorithmError(message);
   }
 
 private:

--- a/qt/scientific_interfaces/Direct/test/MockALFAlgorithmManager.h
+++ b/qt/scientific_interfaces/Direct/test/MockALFAlgorithmManager.h
@@ -36,6 +36,10 @@ public:
   MOCK_METHOD1(createWorkspace, void(std::unique_ptr<Mantid::API::AlgorithmRuntimeProps> properties));
   MOCK_METHOD1(scaleX, void(std::unique_ptr<Mantid::API::AlgorithmRuntimeProps> properties));
   MOCK_METHOD1(rebunch, void(std::unique_ptr<Mantid::API::AlgorithmRuntimeProps> properties));
+
+  // The algorithms used for fitting the extracted Out of plane angle workspace
+  MOCK_METHOD1(cropWorkspace, void(std::unique_ptr<Mantid::API::AlgorithmRuntimeProps> properties));
+  MOCK_METHOD1(fit, void(std::unique_ptr<Mantid::API::AlgorithmRuntimeProps> properties));
 };
 
 GNU_DIAG_ON_SUGGEST_OVERRIDE

--- a/qt/scientific_interfaces/Direct/test/MockALFAlgorithmManagerSubscriber.h
+++ b/qt/scientific_interfaces/Direct/test/MockALFAlgorithmManagerSubscriber.h
@@ -38,8 +38,8 @@ public:
 
   // Algorithm notifiers used when fitting the extracted Out of plane angle workspace
   MOCK_METHOD1(notifyCropWorkspaceComplete, void(Mantid::API::MatrixWorkspace_sptr const &workspace));
-  MOCK_METHOD3(notifyFitComplete, void(Mantid::API::MatrixWorkspace_sptr const &workspace,
-                                       Mantid::API::IFunction_sptr const &function, std::string const &fitStatus));
+  MOCK_METHOD3(notifyFitComplete, void(Mantid::API::MatrixWorkspace_sptr workspace,
+                                       Mantid::API::IFunction_sptr function, std::string fitStatus));
 };
 
 GNU_DIAG_ON_SUGGEST_OVERRIDE

--- a/qt/scientific_interfaces/Direct/test/MockALFAlgorithmManagerSubscriber.h
+++ b/qt/scientific_interfaces/Direct/test/MockALFAlgorithmManagerSubscriber.h
@@ -35,6 +35,11 @@ public:
   MOCK_METHOD1(notifyCreateWorkspaceComplete, void(Mantid::API::MatrixWorkspace_sptr const &workspace));
   MOCK_METHOD1(notifyScaleXComplete, void(Mantid::API::MatrixWorkspace_sptr const &workspace));
   MOCK_METHOD1(notifyRebunchComplete, void(Mantid::API::MatrixWorkspace_sptr const &workspace));
+
+  // Algorithm notifiers used when fitting the extracted Out of plane angle workspace
+  MOCK_METHOD1(notifyCropWorkspaceComplete, void(Mantid::API::MatrixWorkspace_sptr const &workspace));
+  MOCK_METHOD3(notifyFitComplete, void(Mantid::API::MatrixWorkspace_sptr const &workspace,
+                                       Mantid::API::IFunction_sptr const &function, std::string const &fitStatus));
 };
 
 GNU_DIAG_ON_SUGGEST_OVERRIDE


### PR DESCRIPTION
**Description of work.**
This PR moves the Fit and CropWorkspace algorithms used by the ALFAnalysisModel into the ALFAlgorithmManager. These algorithms are now run on a background process.

A release note will be added in a future PR when the interface gets disabled when processing in the background thread.

**To test:**
Open ALFView from the interface menu
Load ALF84116 as the sample
Load ALF78634 as the vanadium
Go to pick tab and select the `Select whole tube` button
Select the central four tubes (seen in the screenshot below)
The two theta value should be 38.066
Then click `Fit` on the right hand side of the interface
The Rotation angle should have a value of -0.1869...

![image](https://user-images.githubusercontent.com/40830825/216953757-def2ab6d-a0c2-4223-951b-f79753fe1e91.png)

<!-- Instructions for testing. -->

Part of #35114

*This does not require release notes* because **release notes will be added in the next PR**


#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
