### PR TITLE
Remove sourceforge text from release notes

### DIFF
--- a/docs/source/release/v6.7.0/index.rst
+++ b/docs/source/release/v6.7.0/index.rst
@@ -31,8 +31,8 @@ reported any issues to us. Please keep on reporting any problems you
 have, or crashes that occur on our `forum`_.
 
 Installation packages can be found on our `download page`_
-which now links to sourceforge to mirror our download files around the world. You can also
-access the source code on `GitHub release page`_.
+which now links to the assets on our `GitHub release page`_, where you can also
+access the source code for the release.
 
 Citation
 --------

--- a/docs/source/workbench/scriptrepository.rst
+++ b/docs/source/workbench/scriptrepository.rst
@@ -20,7 +20,7 @@ Installing the Script Repository is simple:
 Features
 --------
 
-.. image:: /images/Workbench/ScriptRepository/ScriptRepository_main.png
+.. image:: /images/Workbench/ScriptRepository/scriptrepository_main.png
    :scale: 50%
    :align: center
 

--- a/tools/release_generator/release.py
+++ b/tools/release_generator/release.py
@@ -43,8 +43,8 @@ reported any issues to us. Please keep on reporting any problems you
 have, or crashes that occur on our `forum`_.
 
 Installation packages can be found on our `download page`_
-which now links to sourceforge to mirror our download files around the world. You can also
-access the source code on `GitHub release page`_.
+which now links to the assets on our `GitHub release page`_, where you can also
+access the source code for the release.
 
 Citation
 --------


### PR DESCRIPTION
**Description of work.**

- Remove old reference to sourceforge in the index of release notes since we now publish our assets on github.
- Also fixed a docs warning caused by incorrect image file name.

**To test:**

- build docs-html and check for warnings (there is currently only one unreleated one about a release notes file in Framework/Beamline/BugFixes not being included)
- check the html pages

*There is no associated issue.*

*This does not require release notes* because **it is release notes**

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
