### PR TITLE
Clean before checkout and increase timeout

### DIFF
--- a/buildconfig/Jenkins/Conda/nightly_build_and_deploy.jenkinsfile
+++ b/buildconfig/Jenkins/Conda/nightly_build_and_deploy.jenkinsfile
@@ -304,7 +304,7 @@ def toUnixStylePath(path) {
 
 def checkoutSource(sha) {
   dir(CHECKOUT_DIR) {
-    checkout scm: [$class: 'GitSCM', branches: [[name: sha]], extensions: [[$class: 'CleanCheckout', deleteUntrackedNestedRepositories: true], pruneTags(true)]]
+    checkout scm: [$class: 'GitSCM', branches: [[name: sha]], extensions: [[$class: 'CheckoutOption', timeout: 20], [$class: 'CleanBeforeCheckout', deleteUntrackedNestedRepositories: true], pruneTags(true)]]
   }
 }
 


### PR DESCRIPTION
**Description of work.**
This PR attempts to fix some of the issues we are having in the main nightly pipeline where there is sometimes a timeout after checking out main and attempting to do a `git clean`. There appears to be a timeout after 10 minutes when doing the `git clean` (after the checkout). This PR makes two changes:

- The clean is now done before the checkout
- The timeout has been doubled from 10 minutes to 20 minutes

The previous timeouts can be seen on jobs 500, 502, 506.

**To test:**
Read the documentation [here](https://www.jenkins.io/doc/pipeline/steps/params/gitscm/) for `CheckoutOption` and `CleanBeforeCheckout` to make sure I have the correct options set in the code.

*There is no associated issue.*

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
