### PR TITLE
Added option to specify x range for getSpectrum in CEF Python interface

### DIFF
--- a/docs/source/interfaces/direct/Crystal Field Python Interface.rst
+++ b/docs/source/interfaces/direct/Crystal Field Python Interface.rst
@@ -156,12 +156,11 @@ The three peaks now have all different widths. The first peak (index 0) keeps th
    :height: 300
 
 If called without arguments `getSpectrum()` determines automatically the range and number of the `x`-points. To have more control
-of how the spectrum is calculated a list (or numpy array) of x-values can be provided as a first argument to `getSpectrum`.
+of how the spectrum is calculated a tuple with the range for the x values can be provided as an argument to `getSpectrum`.
 Alternatively, the x-values can be taken from a workspace::
 
-  # Use a list for x-values
-  x = [0, 1, 2, 3, ...]
-  sp = cf.getSpectrum(x)
+  # Use a tuple for x range
+  sp = cf.getSpectrum(x_range=(0,30))
 
   # Use the first spectrum of a workspace
   sp = cf.getSpectrum(ws)

--- a/docs/source/interfaces/direct/Crystal Field Python Interface.rst
+++ b/docs/source/interfaces/direct/Crystal Field Python Interface.rst
@@ -156,8 +156,8 @@ The three peaks now have all different widths. The first peak (index 0) keeps th
    :height: 300
 
 If called without arguments `getSpectrum()` determines automatically the range and number of the `x`-points. To have more control
-of how the spectrum is calculated either a list (or numpy array) of x-values or a tuple with the range for the x values can be
-provided as a first argument to `getSpectrum`.
+of how the spectrum is calculated either a list (or numpy array) of x-values or a keyword argument using `x_range` with a tuple
+containing the range for the x values can be provided as a first argument to `getSpectrum`.
 Alternatively, the x-values can be taken from a workspace::
 
   # Use a list for x-values

--- a/docs/source/interfaces/direct/Crystal Field Python Interface.rst
+++ b/docs/source/interfaces/direct/Crystal Field Python Interface.rst
@@ -156,8 +156,13 @@ The three peaks now have all different widths. The first peak (index 0) keeps th
    :height: 300
 
 If called without arguments `getSpectrum()` determines automatically the range and number of the `x`-points. To have more control
-of how the spectrum is calculated a tuple with the range for the x values can be provided as an argument to `getSpectrum`.
+of how the spectrum is calculated either a list (or numpy array) of x-values or a tuple with the range for the x values can be
+provided as a first argument to `getSpectrum`.
 Alternatively, the x-values can be taken from a workspace::
+
+  # Use a list for x-values
+  x = [0, 1, 2, 3, 4]
+  sp = cf.getSpectrum(x)
 
   # Use a tuple for x range
   sp = cf.getSpectrum(x_range=(0,30))

--- a/docs/source/release/v6.7.0/Direct_Geometry/CrystalField/New_features/35339.rst
+++ b/docs/source/release/v6.7.0/Direct_Geometry/CrystalField/New_features/35339.rst
@@ -1,0 +1,1 @@
+- Allow specifying the range for the x values in getSpectrum in the Crystal Field Python interface

--- a/scripts/Inelastic/CrystalField/CrystalFieldMultiSite.py
+++ b/scripts/Inelastic/CrystalField/CrystalFieldMultiSite.py
@@ -174,7 +174,7 @@ class CrystalFieldMultiSite(object):
             peaks = np.append(peaks, _cft.getPeakList()[0])
         return np.min(peaks), np.max(peaks)
 
-    def getSpectrum(self, *args):
+    def getSpectrum(self, *args, **kwargs):
         """
         Get a specified spectrum calculated with the current field and peak parameters.
 
@@ -191,26 +191,32 @@ class CrystalFieldMultiSite(object):
                                      # in workspace ws.
             cf.getSpectrum(2, ws)    # Calculate the third spectrum using the x-values from the 1st spectrum
                                      # in workspace ws.
+            cf.getSpectrum(x_range=(-2,4)) # Return the first spectrum calculated from -2 to 4.
 
         @return: A tuple of (x, y) arrays
         """
-        if len(args) == 3:
-            if self.Temperatures[args[0]] < 0:
-                raise RuntimeError("You must first define a temperature for the spectrum")
-            return self._calcSpectrum(args[0], args[1], args[2])
-        elif len(args) == 1:
-            if isinstance(args[0], int):
-                x_min, x_max = self.calc_xmin_xmax(args[0])
-                xArray = np.linspace(x_min, x_max, self.default_spectrum_size)
-                return self._calcSpectrum(args[0], xArray, 0)
-            else:
-                return self._calcSpectrum(0, args[0], 0)
-        elif len(args) == 2:
-            return self._getSpectrumTwoArgs(*args)
+        i = 0
+        xrange = kwargs.get("x_range")
+        if xrange is not None:
+            x_min, x_max = xrange
         else:
-            x_min, x_max = self.calc_xmin_xmax()
-            xArray = np.linspace(x_min, x_max, self.default_spectrum_size)
-            return self._calcSpectrum(0, xArray, 0)
+            if len(args) == 3:
+                if self.Temperatures[args[0]] < 0:
+                    raise RuntimeError("You must first define a temperature for the spectrum")
+                return self._calcSpectrum(args[0], args[1], args[2])
+            elif len(args) == 1:
+                if isinstance(args[0], int):
+                    x_min, x_max = self.calc_xmin_xmax(args[0])
+                    i = args[0]
+                else:
+                    return self._calcSpectrum(0, args[0], 0)
+            elif len(args) == 2:
+                return self._getSpectrumTwoArgs(*args)
+            else:
+                x_min, x_max = self.calc_xmin_xmax()
+
+        xArray = np.linspace(x_min, x_max, self.default_spectrum_size)
+        return self._calcSpectrum(i, xArray, 0)
 
     def _convertToWS(self, wksp_list):
         """

--- a/scripts/Inelastic/CrystalField/fitting.py
+++ b/scripts/Inelastic/CrystalField/fitting.py
@@ -809,7 +809,7 @@ class CrystalField(object):
         peaks = np.array([self._peakList.column(0), self._peakList.column(1)])
         return peaks
 
-    def getSpectrum(self, i=0, workspace=None, ws_index=0):
+    def getSpectrum(self, i=0, workspace=None, ws_index=0, x_range: Tuple[int, int] = None):
         """
         Get the i-th spectrum calculated with the current field and peak parameters.
 
@@ -824,11 +824,14 @@ class CrystalField(object):
                                # in workspace ws.
             cf.getSpectrum(ws, 3) # Calculate the first spectrum using the x-values from the 4th spectrum
                                   # in workspace ws.
+            cf.getSpectrum(x_range=(-2,4)) # Return the first spectrum calculated from -2 to 4.
 
         @param i: Index of a spectrum to get.
         @param workspace: A workspace to base on. If not given the x-values of the output spectrum will be
-                          generated.
+                          generated if not specified with x_range.
         @param ws_index:  An index of a spectrum from workspace to use.
+        @param x_range: Return the first spectrum calculated on the specified set of x-values. This setting is
+                        ignored when a workspace to base on was provided.
         @return: A tuple of (x, y) arrays
         """
         wksp = workspace
@@ -853,7 +856,10 @@ class CrystalField(object):
             return self._calcSpectrum(i, wksp, ws_index)
 
         if xArray is None:
-            x_min, x_max = self.calc_xmin_xmax(i)
+            if x_range is None:
+                x_min, x_max = self.calc_xmin_xmax(i)
+            else:
+                x_min, x_max = x_range
             xArray = np.linspace(x_min, x_max, self.default_spectrum_size)
 
         yArray = np.zeros_like(xArray)
@@ -1028,12 +1034,12 @@ class CrystalField(object):
         )
         return trans
 
-    def plot(self, i=0, workspace=None, ws_index=0, name=None):
+    def plot(self, i=0, workspace=None, ws_index=0, x_range: Tuple[int, int] = None, name=None):
         """Plot a spectrum. Parameters are the same as in getSpectrum(...)"""
         createWS = AlgorithmManager.createUnmanaged("CreateWorkspace")
         createWS.initialize()
 
-        xArray, yArray = self.getSpectrum(i, workspace, ws_index)
+        xArray, yArray = self.getSpectrum(i, workspace, ws_index, x_range)
         ws_name = name if name is not None else "CrystalField_%s" % self.Ion
 
         if isinstance(i, int):
@@ -1770,7 +1776,7 @@ class CrystalFieldFit(object):
         opt = {"disp": False}
         if Options is not None:
             opt = Options
-        for (x, pos) in zip(x0, self._free_cef_parameters):
+        for x, pos in zip(x0, self._free_cef_parameters):
             fun.removeTie(pos)
             res = sp.minimize(self._evaluate_cf, [x], args=(fun, pos), method=Solver, options=opt)
             fun.fixParameter(pos)

--- a/scripts/test/CrystalFieldMultiSiteTest.py
+++ b/scripts/test/CrystalFieldMultiSiteTest.py
@@ -188,6 +188,31 @@ class CrystalFieldMultiSiteTests(unittest.TestCase):
         self.assertAlmostEqual(y[0], 0.050130, 6)
         self.assertAlmostEqual(y[1], 0.054428, 6)
 
+    def test_get_spectrum_xrange(self):
+        cfms = CrystalField.CrystalFieldMultiSite(
+            ["Ce"],
+            ["C2v"],
+            B20=0.035,
+            B40=-0.012,
+            B43=-0.027,
+            B60=-0.00012,
+            B63=0.0025,
+            B66=0.0068,
+            Temperatures=[4.0],
+            FWHM=[0.1],
+            ToleranceIntensity=0.001 * c_mbsr,
+        )
+
+        x, y = cfms.getSpectrum(x_range=(0, 3))
+        y = y / c_mbsr
+        self.assertAlmostEqual(y[0], 6.389155669562915, 6)
+        self.assertAlmostEqual(y[1], 5.857124191993273, 6)
+        self.assertAlmostEqual(y[2], 4.686601510335353, 6)
+        self.assertAlmostEqual(y[3], 3.516068536602892, 6)
+        self.assertAlmostEqual(y[4], 2.605655839607991, 6)
+        self.assertAlmostEqual(y[15], 0.30241905775681543, 6)
+        self.assertAlmostEqual(y[16], 0.2679124634961843, 6)
+
     def test_get_spectrum_from_list_multi_spectra(self):
         cfms = CrystalField.CrystalFieldMultiSite(
             Ions=["Ce"],

--- a/scripts/test/CrystalFieldMultiSiteTest.py
+++ b/scripts/test/CrystalFieldMultiSiteTest.py
@@ -205,13 +205,13 @@ class CrystalFieldMultiSiteTests(unittest.TestCase):
 
         x, y = cfms.getSpectrum(x_range=(0, 3))
         y = y / c_mbsr
-        self.assertAlmostEqual(y[0], 6.389155669562915, 6)
-        self.assertAlmostEqual(y[1], 5.857124191993273, 6)
-        self.assertAlmostEqual(y[2], 4.686601510335353, 6)
-        self.assertAlmostEqual(y[3], 3.516068536602892, 6)
-        self.assertAlmostEqual(y[4], 2.605655839607991, 6)
-        self.assertAlmostEqual(y[15], 0.30241905775681543, 6)
-        self.assertAlmostEqual(y[16], 0.2679124634961843, 6)
+        self.assertAlmostEqual(y[0], 12.474954833572541, 6)
+        self.assertAlmostEqual(y[1], 11.435723018801308, 6)
+        self.assertAlmostEqual(y[2], 9.14934495705407, 6)
+        self.assertAlmostEqual(y[3], 6.862946934125062, 6)
+        self.assertAlmostEqual(y[4], 5.0846344775777395, 6)
+        self.assertAlmostEqual(y[15], 0.5854829967281244, 6)
+        self.assertAlmostEqual(y[16], 0.5180575611727711, 6)
 
     def test_get_spectrum_from_list_multi_spectra(self):
         cfms = CrystalField.CrystalFieldMultiSite(

--- a/scripts/test/CrystalFieldTest.py
+++ b/scripts/test/CrystalFieldTest.py
@@ -280,6 +280,21 @@ class CrystalFieldTests(unittest.TestCase):
         self.assertAlmostEqual(y[0], 0.050129858433581413, 6)
         self.assertAlmostEqual(y[1], 0.054427788297191478, 6)
 
+    def test_api_CrystalField_spectrum_xrange(self):
+        cf = CrystalField.CrystalField(
+            "Ce", "C2v", B20=0.035, B40=-0.012, B43=-0.027, B60=-0.00012, B63=0.0025, B66=0.0068, Temperature=[4.0, 50.0], FWHM=[0.1, 0.2]
+        )
+
+        x, y = cf.getSpectrum(x_range=(1, 2))
+        y = y / c_mbsr
+        self.assertAlmostEqual(y[0], 0.049501635768339734, 6)
+        self.assertAlmostEqual(y[1], 0.04954322145208576, 6)
+        self.assertAlmostEqual(y[2], 0.04960108662053217, 6)
+        self.assertAlmostEqual(y[3], 0.04967567690256641, 6)
+        self.assertAlmostEqual(y[4], 0.049767471202505846, 6)
+        self.assertAlmostEqual(y[15], 0.0520903205156656, 6)
+        self.assertAlmostEqual(y[16], 0.05244155491870547, 6)
+
     def test_api_CrystalField_spectrum_peaks(self):
         cf = CrystalField.CrystalField(
             "Ce", "C2v", B20=0.035, B40=-0.012, B43=-0.027, B60=-0.00012, B63=0.0025, B66=0.0068, Temperature=10.0, FWHM=0.1


### PR DESCRIPTION
**Description of work.**

There are different options for specifying the x values for the getSpectrum function in the Crystal Field Python interface. Now a new option has been added to allow specifying the range of the x values by providing a tuple with x_min and x_max.

**To test:**

Check that getSpectrum uses the correct range of x values when configured with a tuple for x_range.
https://docs.mantidproject.org/nightly/interfaces/direct/Crystal%20Field%20Python%20Interface.html#calculating-a-spectrum

Fixes #[35288](https://github.com/mantidproject/mantid/issues/35288)

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
