### PR TITLE
Refactoring assert raises in python algorithm tests part 3

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/NormaliseSpectra.py
+++ b/Framework/PythonInterface/plugins/algorithms/NormaliseSpectra.py
@@ -13,7 +13,6 @@ import numpy as np
 
 
 class NormaliseSpectra(DataProcessorAlgorithm):
-
     _input_ws_name = None
     _input_ws = None
     _output_ws_name = None
@@ -46,7 +45,7 @@ class NormaliseSpectra(DataProcessorAlgorithm):
                 DeleteWorkspace("single_spectrum")
                 raise RuntimeError(
                     "Spectrum number %d:" % (spectrum_no)
-                    + "has a maximum y value of 0 or less. "
+                    + " has a maximum y value of 0 or less. "
                     + "All spectra must have a maximum y value more than 0"
                 )
             Scale(InputWorkspace=single_spectrum, Operation="Multiply", Factor=(1 / ymax), OutputWorkspace=single_spectrum)

--- a/Framework/PythonInterface/plugins/algorithms/TOFTOFCropWorkspace.py
+++ b/Framework/PythonInterface/plugins/algorithms/TOFTOFCropWorkspace.py
@@ -46,7 +46,7 @@ class TOFTOFCropWorkspace(PythonAlgorithm):
 
         xunit = input_workspace.getAxis(0).getUnit().unitID()
         if xunit != "TOF":
-            issues["InputWorkspace"] = "X axis units must be TOF. "
+            issues["InputWorkspace"] = "X axis units must be TOF."
 
         # check for required properties
         run = input_workspace.getRun()

--- a/Framework/PythonInterface/plugins/algorithms/VesuvioThickness.py
+++ b/Framework/PythonInterface/plugins/algorithms/VesuvioThickness.py
@@ -12,7 +12,6 @@ import math
 
 
 class VesuvioThickness(PythonAlgorithm):
-
     _masses = None
     _amplitudes = None
     _transmission_guess = None
@@ -62,13 +61,17 @@ class VesuvioThickness(PythonAlgorithm):
 
         num_masses = len(self._masses)
         num_amplitudes = len(self._amplitudes)
+
+        if num_masses != num_amplitudes:
+            issues["Masses"] = "The number of masses: %d, " % num_masses + "is not equal to the number of amplitudes: %d" % num_amplitudes
+            issues["Amplitudes"] = (
+                "The number of masses: %d, " % num_masses + "is not equal to the number of amplitudes: %d" % num_amplitudes
+            )
+
         if num_masses == 0:
             issues["Masses"] = "Must have 1 or more Masses defined"
         if num_amplitudes == 0:
             issues["Amplitudes"] = "Must have 1 or more Amplitudes defined"
-
-        if num_masses != num_amplitudes:
-            issues["Masses"] = "The number of masses: %d, " % num_masses + "is not equal to the number of amplitudes: %d" % num_amplitudes
 
         return issues
 

--- a/Framework/PythonInterface/test/python/plugins/algorithms/MatchSpectraTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/MatchSpectraTest.py
@@ -76,7 +76,7 @@ class MatchSpectraTest(unittest.TestCase):
         for histogram in (True, False):
             self.__createWorkspace(inwsname, histogram, False)
 
-            with self.assertRaises(RuntimeError):
+            with self.assertRaisesRegex(RuntimeError, "None of the uncertainties in the reference spectrum is greater than zero."):
                 results = MatchSpectra(
                     InputWorkspace=inwsname, OutputWorkspace=outwsname, ReferenceSpectrum=1, CalculateOffset=True, CalculateScale=True
                 )

--- a/Framework/PythonInterface/test/python/plugins/algorithms/MeanTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/MeanTest.py
@@ -12,35 +12,31 @@ from mantid.api import *
 class MeanTest(unittest.TestCase):
     def test_throws_if_non_existing_names(self):
         a = CreateWorkspace(DataX=[1, 2, 3], DataY=[1, 2, 3], DataE=[1, 1, 1], UnitX="TOF")
-        with self.assertRaises(RuntimeError) as contextManager:
+        with self.assertRaisesRegex(RuntimeError, "Workspace 'b' does not exist"):
             c = Mean(Workspaces="a,b")  # 'b' does not exist.
-        self.assertIn("Workspace 'b' does not exist", str(contextManager.exception))
         DeleteWorkspace(a)
 
     def test_throws_if_workspace_axis0_unequal(self):
         a = CreateWorkspace(DataX=[1, 2, 3], DataY=[1, 2, 3], DataE=[1, 1, 1], UnitX="TOF")
         b = CreateWorkspace(DataX=[1, 2, 3, 4], DataY=[1, 2, 3, 4], DataE=[1, 1, 1, 1], UnitX="TOF")
-        with self.assertRaises(RuntimeError) as contextManager:
+        with self.assertRaisesRegex(RuntimeError, "Input Workspaces are not the same shape."):
             c = Mean(Workspaces="a,b")  # 'a' and 'b' are different sizes.
-        self.assertIn("Input Workspaces are not the same shape.", str(contextManager.exception))
         DeleteWorkspace(a)
         DeleteWorkspace(b)
 
     def test_throws_if_workspace_axis1_unequal(self):
         a = CreateWorkspace(DataX=[1, 2, 3, 4], DataY=[1, 2, 3, 4], DataE=[1, 1, 1, 1], UnitX="TOF", NSpec=1)
         b = CreateWorkspace(DataX=[1, 2, 3, 4], DataY=[1, 2, 3, 4], DataE=[1, 1, 1, 1], UnitX="TOF", NSpec=2)
-        with self.assertRaises(RuntimeError) as contextManager:
+        with self.assertRaisesRegex(RuntimeError, "Input Workspaces are not the same shape."):
             c = Mean(Workspaces="a,b")  # 'a' and 'b' are different sizes.
-        self.assertIn("Input Workspaces are not the same shape.", str(contextManager.exception))
         DeleteWorkspace(a)
         DeleteWorkspace(b)
 
     def test_throws_if_workspace_unorded(self):
         a = CreateWorkspace(DataX=[1, 2, 1, 2], DataY=[1, 2, 3, 4], DataE=[1, 1, 1, 1], UnitX="TOF", NSpec=2)
         b = CreateWorkspace(DataX=[1, 2, 2, 1], DataY=[1, 2, 3, 4], DataE=[1, 1, 1, 1], UnitX="TOF", NSpec=2)
-        with self.assertRaises(RuntimeError) as contextManager:
+        with self.assertRaisesRegex(RuntimeError, "The data should have the same order for x values. Sort your data first"):
             c = Mean(Workspaces="a,b")  # 'a' and 'b' have different x data.
-        self.assertIn("The data should have the same order for x values. Sort your data first", str(contextManager.exception))
         DeleteWorkspace(a)
         DeleteWorkspace(b)
 

--- a/Framework/PythonInterface/test/python/plugins/algorithms/MedianBinWidthTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/MedianBinWidthTest.py
@@ -63,7 +63,9 @@ class MedianBinWidthTest(unittest.TestCase):
         ys = numpy.zeros(len(xs))
         ws = CreateWorkspace(DataX=xs, DataY=ys, Distribution=True)
         params = self._make_algorithm_params(ws)
-        self.assertRaises(ValueError, testhelpers.create_algorithm, "BinWidthAtX", **params)
+        self.assertRaisesRegex(
+            ValueError, "The workspace must contain histogram data", testhelpers.create_algorithm, "BinWidthAtX", **params
+        )
         DeleteWorkspace(ws)
 
     def test_positive_output_even_if_descending_x(self):

--- a/Framework/PythonInterface/test/python/plugins/algorithms/NMoldyn4InterpolationTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/NMoldyn4InterpolationTest.py
@@ -53,8 +53,9 @@ class NMoldyn4InterpolationTest(unittest.TestCase):
         y_data = y_data.flatten()
         x_data = np.tile(x_data, len(q_data))
         sim = CreateWorkspace(DataX=x_data, DataY=y_data, NSpec=len(q_data), VerticalAxisUnit="MomentumTransfer", VerticalAxisValues=q_data)
-        self.assertRaises(
+        self.assertRaisesRegex(
             RuntimeError,
+            "Minimum simulated X value is higher than minimum reference X value",
             NMoldyn4Interpolation,
             InputWorkspace=sim,
             ReferenceWorkspace=self.osiris,
@@ -68,8 +69,25 @@ class NMoldyn4InterpolationTest(unittest.TestCase):
         y_data = y_data.flatten()
         x_data = np.tile(x_data, len(q_data))
         sim = CreateWorkspace(DataX=x_data, DataY=y_data, NSpec=len(q_data), VerticalAxisUnit="MomentumTransfer", VerticalAxisValues=q_data)
-        self.assertRaises(
+        self.assertRaisesRegex(
             RuntimeError,
+            "Maximum simulated X value is lower than maximum reference X value",
+            NMoldyn4Interpolation,
+            InputWorkspace=sim,
+            ReferenceWorkspace=self.osiris,
+            OutputWorkspace="__NMoldyn4Interpolation_test",
+        )
+
+    def test_Q_min_too_big(self):
+        x_data = np.arange(-2, 2, 0.05)
+        q_data = np.arange(0.8, 1.3, 0.1)
+        y_data = np.asarray([val * (np.cos(5 * x_data) + 1) for val in q_data])
+        y_data = y_data.flatten()
+        x_data = np.tile(x_data, len(q_data))
+        sim = CreateWorkspace(DataX=x_data, DataY=y_data, NSpec=len(q_data), VerticalAxisUnit="MomentumTransfer", VerticalAxisValues=q_data)
+        self.assertRaisesRegex(
+            RuntimeError,
+            "Minimum simulated Q value is higher than minimum reference Q value",
             NMoldyn4Interpolation,
             InputWorkspace=sim,
             ReferenceWorkspace=self.osiris,
@@ -78,28 +96,14 @@ class NMoldyn4InterpolationTest(unittest.TestCase):
 
     def test_Q_max_too_small(self):
         x_data = np.arange(-2, 2, 0.05)
-        q_data = np.arange(0.8, 1.3, 0.1)
-        y_data = np.asarray([val * (np.cos(5 * x_data) + 1) for val in q_data])
-        y_data = y_data.flatten()
-        x_data = np.tile(x_data, len(q_data))
-        sim = CreateWorkspace(DataX=x_data, DataY=y_data, NSpec=len(q_data), VerticalAxisUnit="MomentumTransfer", VerticalAxisValues=q_data)
-        self.assertRaises(
-            RuntimeError,
-            NMoldyn4Interpolation,
-            InputWorkspace=sim,
-            ReferenceWorkspace=self.osiris,
-            OutputWorkspace="__NMoldyn4Interpolation_test",
-        )
-
-    def test_Q_min_too_large(self):
-        x_data = np.arange(-2, 2, 0.05)
         q_data = np.arange(0.5, 1.0, 0.1)
         y_data = np.asarray([val * (np.cos(5 * x_data) + 1) for val in q_data])
         y_data = y_data.flatten()
         x_data = np.tile(x_data, len(q_data))
         sim = CreateWorkspace(DataX=x_data, DataY=y_data, NSpec=len(q_data), VerticalAxisUnit="MomentumTransfer", VerticalAxisValues=q_data)
-        self.assertRaises(
+        self.assertRaisesRegex(
             RuntimeError,
+            "Maximum simulated Q value is lower than maximum reference Q value",
             NMoldyn4Interpolation,
             InputWorkspace=sim,
             ReferenceWorkspace=self.osiris,

--- a/Framework/PythonInterface/test/python/plugins/algorithms/NormaliseSpectraTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/NormaliseSpectraTest.py
@@ -12,7 +12,6 @@ from mantid.api import MatrixWorkspace, WorkspaceGroup
 
 
 class NormaliseSpectraTest(unittest.TestCase):
-
     _positive = "1,2,3,4,5"
     _negative = "-5,-4,-3,-2,-1"
     _zeros = "0,0,0,0,0"
@@ -27,11 +26,23 @@ class NormaliseSpectraTest(unittest.TestCase):
 
     def test_one_hist_negative(self):
         in_ws = self._create_workspace(1, "test", self._negative)
-        self.assertRaises(RuntimeError, NormaliseSpectra, InputWorkspace=in_ws, OutputWorkspace="out_ws")
+        self.assertRaisesRegex(
+            RuntimeError,
+            "Spectrum number 1: has a maximum y value of 0 or less. All spectra must have a maximum y value more than 0",
+            NormaliseSpectra,
+            InputWorkspace=in_ws,
+            OutputWorkspace="out_ws",
+        )
 
     def test_one_hist_zeros(self):
         in_ws = self._create_workspace(1, "test", self._zeros)
-        self.assertRaises(RuntimeError, NormaliseSpectra, InputWorkspace=in_ws, OutputWorkspace="out_ws")
+        self.assertRaisesRegex(
+            RuntimeError,
+            "Spectrum number 1: has a maximum y value of 0 or less. All spectra must have a maximum y value more than 0",
+            NormaliseSpectra,
+            InputWorkspace=in_ws,
+            OutputWorkspace="out_ws",
+        )
 
     def test_one_hist_mixed(self):
         in_ws = self._create_workspace(1, "test", self._mixed)

--- a/Framework/PythonInterface/test/python/plugins/algorithms/PoldiMergeTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/PoldiMergeTest.py
@@ -83,19 +83,29 @@ class PoldiMergeTest(unittest.TestCase):
         DeleteWorkspace("PoldiMergeOutput")
 
     def test_timingDelta(self):
-        self.assertRaises(RuntimeError, lambda: self.__runMerge__("Base,BadTimingDelta"))
+        self.assertRaisesRegex(
+            RuntimeError, "Workspaces can not be merged. Timings don't match. Aborting.", lambda: self.__runMerge__("Base,BadTimingDelta")
+        )
         self.assertFalse(AnalysisDataService.doesExist("PoldiMergeOutput"))
 
     def test_timingOffset(self):
-        self.assertRaises(RuntimeError, lambda: self.__runMerge__("Base,BadTimingOffset"))
+        self.assertRaisesRegex(
+            RuntimeError, "Workspaces can not be merged. Timings don't match. Aborting.", lambda: self.__runMerge__("Base,BadTimingOffset")
+        )
         self.assertFalse(AnalysisDataService.doesExist("PoldiMergeOutput"))
 
     def test_badProperties(self):
-        self.assertRaises(RuntimeError, lambda: self.__runMerge__("Base,GoodTimingBadProperties", True))
+        self.assertRaisesRegex(
+            RuntimeError,
+            "Workspaces can not be merged. Property 'TablePositionX' does not match. Aborting.",
+            lambda: self.__runMerge__("Base,GoodTimingBadProperties", True),
+        )
         self.assertFalse(AnalysisDataService.doesExist("PoldiMergeOutput"))
 
     def test_badName(self):
-        self.assertRaises(RuntimeError, lambda: self.__runMerge__("Base,NotExisting"))
+        self.assertRaisesRegex(
+            RuntimeError, "Not all strings in the input list are valid workspace names.", lambda: self.__runMerge__("Base,NotExisting")
+        )
         self.assertFalse(AnalysisDataService.doesExist("PoldiMergeOutput"))
 
 

--- a/Framework/PythonInterface/test/python/plugins/algorithms/ReflectometryReductionOneLiveDataTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/ReflectometryReductionOneLiveDataTest.py
@@ -255,8 +255,9 @@ class ReflectometryReductionOneLiveDataTest(unittest.TestCase):
         self.assertEqual(sorted(matched_names), sorted(expected_names))
 
     def test_algorithm_fails_for_invalid_block_names(self):
-        self.assertRaises(
+        self.assertRaisesRegex(
             RuntimeError,
+            "Unknown algorithm 'GetFakeLiveInstrumentValueInvalidNames'",
             ReflectometryReductionOneLiveData,
             InputWorkspace=self.__class__._input_ws,
             OutputWorkspace="output",

--- a/Framework/PythonInterface/test/python/plugins/algorithms/RetrieveRunInfoTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/RetrieveRunInfoTest.py
@@ -14,7 +14,6 @@ from testhelpers import run_algorithm
 
 
 class RetrieveRunInfoTest(unittest.TestCase):
-
     class_has_been_set_up = False
 
     def setUp(self):
@@ -40,20 +39,33 @@ class RetrieveRunInfoTest(unittest.TestCase):
     def test_wrong_facility_throws(self):
         """Dont expect to be able to support non-ISIS runs."""
         config["default.facility"] = "SNS"
-        self.assertRaises(
-            RuntimeError, run_algorithm, "RetrieveRunInfo", Runs=self.__existing_range_of_run_files, OutputWorkspace="test", rethrow=True
+        self.assertRaisesRegex(
+            RuntimeError,
+            "Only ISIS runs are supported by this alg.",
+            run_algorithm,
+            "RetrieveRunInfo",
+            Runs=self.__existing_range_of_run_files,
+            OutputWorkspace="test",
+            rethrow=True,
         )
 
     def test_missing_run_file_throws(self):
         """Check that ALL files are present before proceeding."""
-        self.assertRaises(
-            RuntimeError, run_algorithm, "RetrieveRunInfo", Runs=self.__nonexistant_run_file, OutputWorkspace="test", rethrow=True
+        self.assertRaisesRegex(
+            RuntimeError,
+            "Unable to find file: search object 99999",
+            run_algorithm,
+            "RetrieveRunInfo",
+            Runs=self.__nonexistant_run_file,
+            OutputWorkspace="test",
+            rethrow=True,
         )
 
     def test_pre_existing_non_table_workspace_throws(self):
         """Only allow TableWorkspaces."""
-        self.assertRaises(
+        self.assertRaisesRegex(
             RuntimeError,
+            'Workspace "matrix_ws" already exists. Either delete it, or choose another workspace name.',
             run_algorithm,
             "RetrieveRunInfo",
             Runs=self.__existing_range_of_run_files,
@@ -63,8 +75,9 @@ class RetrieveRunInfoTest(unittest.TestCase):
 
     def test_existing_table_workspace_throws(self):
         """Dont bother trying to append.  If it exists already, we throw."""
-        self.assertRaises(
+        self.assertRaisesRegex(
             RuntimeError,
+            'Workspace "__empty_table" already exists. Either delete it, or choose another workspace name.',
             run_algorithm,
             "RetrieveRunInfo",
             Runs=self.__existing_range_of_run_files,

--- a/Framework/PythonInterface/test/python/plugins/algorithms/SANSWideAngleCorrectionTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/SANSWideAngleCorrectionTest.py
@@ -61,16 +61,37 @@ class SANSWideAngleCorrectionTest(unittest.TestCase):
 
     def test_negative_trans_data(self):
         trans_invalid = self._trans * -1
-        self.assertRaises(RuntimeError, SANSWideAngleCorrection, self._sample, trans_invalid, OutputWorkspace="out")
+        self.assertRaisesRegex(
+            RuntimeError,
+            "Invalid workspace for transmission, it does not accept negative values.",
+            SANSWideAngleCorrection,
+            self._sample,
+            trans_invalid,
+            OutputWorkspace="out",
+        )
 
     def test_shorter_trans_data(self):
         Trans = CreateWorkspace([0.3, 1, 2], [1, 2])
-        self.assertRaises(RuntimeError, SANSWideAngleCorrection, self._sample, self._trans, OutputWorkspace="out")
+        self.assertRaisesRegex(
+            RuntimeError,
+            "Uncompatible sizes. Transmission must have the same bins of sample values",
+            SANSWideAngleCorrection,
+            self._sample,
+            Trans,
+            OutputWorkspace="out",
+        )
 
     def test_no_instrument_associated(self):
         Sample = CreateWorkspace([1, 2, 3], [1, 2])
         Trans = CreateWorkspace([1, 2, 3], [1, 2])
-        self.assertRaises(RuntimeError, SANSWideAngleCorrection, Sample, Trans, OutputWorkspace="out")
+        self.assertRaisesRegex(
+            RuntimeError,
+            "You can not apply this correction for workspace not associated to instrument",
+            SANSWideAngleCorrection,
+            Sample,
+            Trans,
+            OutputWorkspace="out",
+        )
 
 
 if __name__ == "__main__":

--- a/Framework/PythonInterface/test/python/plugins/algorithms/SaveReflectionsTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/SaveReflectionsTest.py
@@ -258,7 +258,14 @@ class SaveReflectionsTest(unittest.TestCase):
         output_format = "SHELX"
 
         # Act
-        self.assertRaises(RuntimeError, SaveReflections, InputWorkspace=workspace, Filename=file_name, Format=output_format)
+        self.assertRaisesRegex(
+            RuntimeError,
+            "Cannot currently save modulated structures to GSAS or SHELX formats",
+            SaveReflections,
+            InputWorkspace=workspace,
+            Filename=file_name,
+            Format=output_format,
+        )
 
     def test_save_invalid_format(self):
         # Arrange
@@ -266,7 +273,14 @@ class SaveReflectionsTest(unittest.TestCase):
         output_format = "InvalidFormatName"
 
         # Act
-        self.assertRaises(ValueError, SaveReflections, InputWorkspace=self._workspace, Filename=file_name, Format=output_format)
+        self.assertRaisesRegex(
+            ValueError,
+            'The value "InvalidFormatName" is not in the list of allowed values',
+            SaveReflections,
+            InputWorkspace=self._workspace,
+            Filename=file_name,
+            Format=output_format,
+        )
 
     @patch("mantid.kernel.logger.warning")
     def test_save_empty_peak_table(self, mock_log):

--- a/Framework/PythonInterface/test/python/plugins/algorithms/SaveYDATest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/SaveYDATest.py
@@ -218,9 +218,8 @@ class SaveYDATest(unittest.TestCase):
         if not yAxMt and not yAxSpec:
             ws = CreateWorkspace(DataX=self.data_x, DataY=self.data_y, DataE=np.sqrt(self.data_y), NSpec=1, UnitX="DeltaE")
             LoadInstrument(ws, True, InstrumentName="TOFTOF")
-            ConvertSpectrumAxis(InputWorkspace=ws, OutputWorkspace="ws2", Target="theta", EMode="Direct")
-            ws2 = mtd["ws2"]
-            return ws2
+            ouput_ws = ConvertSpectrumAxis(InputWorkspace=ws, Target="theta", EMode="Direct")
+            return ouput_ws 
         if not yAxSpec and yAxMt:
             ws = CreateWorkspace(DataX=self.data_x, DataY=self.data_y, DataE=np.sqrt(self.data_y), NSpec=1, UnitX="DeltaE")
             LoadInstrument(ws, True, InstrumentName="TOFTOF")

--- a/Framework/PythonInterface/test/python/plugins/algorithms/SaveYDATest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/SaveYDATest.py
@@ -14,7 +14,6 @@ import unittest
 
 class SaveYDATest(unittest.TestCase):
     def setUp(self):
-
         self.prop_num = 3
         self.prop_title = "PropTitle"
         self.exp_team = "Experiment Team"
@@ -28,7 +27,6 @@ class SaveYDATest(unittest.TestCase):
         self._no_sample_file = self._file(ws, "noSampleFile")
 
     def cleanup(self, ws_name, filename):
-
         if os.path.exists(filename):
             os.remove(filename)
         if mantid.mtd.doesExist(ws_name):
@@ -154,7 +152,7 @@ class SaveYDATest(unittest.TestCase):
     def test_event_ws(self):
         """Test algorithm is not running with EventWorkspace"""
         ws = self._create_workspace(False)
-        self.assertRaises(RuntimeError, SaveYDA, InputWorkspace=ws, Filename="File")
+        self.assertRaisesRegex(RuntimeError, "Input Workspace is not a Workspace2D", SaveYDA, InputWorkspace=ws, Filename="File")
 
     def test_x_not_detaE(self):
         """Test algorithm is not running if X axis is not DeltaE"""
@@ -169,7 +167,9 @@ class SaveYDATest(unittest.TestCase):
     def test_y_not_mt_or_spec(self):
         """Test algorithm is not running if Y axis is not SpectrumAxis or MomentumTransfer"""
         ws = self._create_workspace(yAxMt=False, yAxSpec=False)
-        self.assertRaises(RuntimeError, SaveYDA, InputWorkspace=ws, Filename="File")
+        self.assertRaisesRegex(
+            RuntimeError, "Y axis is not 'Spectrum Axis' or 'Momentum Transfer'", SaveYDA, InputWorkspace=ws, Filename="File"
+        )
 
     def _init_ws_normal(self):
         """init normal workspace, normal workspace is workspace with all sample logs and save file from workspace"""
@@ -218,8 +218,9 @@ class SaveYDATest(unittest.TestCase):
         if not yAxMt and not yAxSpec:
             ws = CreateWorkspace(DataX=self.data_x, DataY=self.data_y, DataE=np.sqrt(self.data_y), NSpec=1, UnitX="DeltaE")
             LoadInstrument(ws, True, InstrumentName="TOFTOF")
-            ConvertSpectrumAxis(InputWorkspace=ws, OutputWorkspace=ws, Target="theta", EMode="Direct")
-            return ws
+            ConvertSpectrumAxis(InputWorkspace=ws, OutputWorkspace="ws2", Target="theta", EMode="Direct")
+            ws2 = mtd["ws2"]
+            return ws2
         if not yAxSpec and yAxMt:
             ws = CreateWorkspace(DataX=self.data_x, DataY=self.data_y, DataE=np.sqrt(self.data_y), NSpec=1, UnitX="DeltaE")
             LoadInstrument(ws, True, InstrumentName="TOFTOF")

--- a/Framework/PythonInterface/test/python/plugins/algorithms/SaveYDATest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/SaveYDATest.py
@@ -218,8 +218,8 @@ class SaveYDATest(unittest.TestCase):
         if not yAxMt and not yAxSpec:
             ws = CreateWorkspace(DataX=self.data_x, DataY=self.data_y, DataE=np.sqrt(self.data_y), NSpec=1, UnitX="DeltaE")
             LoadInstrument(ws, True, InstrumentName="TOFTOF")
-            ouput_ws = ConvertSpectrumAxis(InputWorkspace=ws, Target="theta", EMode="Direct")
-            return ouput_ws
+            output_ws = ConvertSpectrumAxis(InputWorkspace=ws, Target="theta", EMode="Direct")
+            return output_ws
         if not yAxSpec and yAxMt:
             ws = CreateWorkspace(DataX=self.data_x, DataY=self.data_y, DataE=np.sqrt(self.data_y), NSpec=1, UnitX="DeltaE")
             LoadInstrument(ws, True, InstrumentName="TOFTOF")

--- a/Framework/PythonInterface/test/python/plugins/algorithms/SaveYDATest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/SaveYDATest.py
@@ -219,7 +219,7 @@ class SaveYDATest(unittest.TestCase):
             ws = CreateWorkspace(DataX=self.data_x, DataY=self.data_y, DataE=np.sqrt(self.data_y), NSpec=1, UnitX="DeltaE")
             LoadInstrument(ws, True, InstrumentName="TOFTOF")
             ouput_ws = ConvertSpectrumAxis(InputWorkspace=ws, Target="theta", EMode="Direct")
-            return ouput_ws 
+            return ouput_ws
         if not yAxSpec and yAxMt:
             ws = CreateWorkspace(DataX=self.data_x, DataY=self.data_y, DataE=np.sqrt(self.data_y), NSpec=1, UnitX="DeltaE")
             LoadInstrument(ws, True, InstrumentName="TOFTOF")

--- a/Framework/PythonInterface/test/python/plugins/algorithms/SelectNexusFilesByMetadataTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/SelectNexusFilesByMetadataTest.py
@@ -10,12 +10,10 @@ from mantid.simpleapi import *
 
 
 class SelectNexusFilesByMetadataTest(unittest.TestCase):
-
     _fileslist = "INTER00013460,13463,13464.nxs"
     _sumfileslist = "INTER00013460+13463+13464.nxs"
 
     def test_happy_case(self):
-
         criteria = "$raw_data_1/duration$ > 1000 or $raw_data_1/good_frames$ > 10000"
         res = SelectNexusFilesByMetadata(FileList=self._fileslist, NexusCriteria=criteria)
         outfiles = res.split(",")
@@ -32,30 +30,21 @@ class SelectNexusFilesByMetadataTest(unittest.TestCase):
         self.assertTrue(outfiles[1].endswith("INTER00013464.nxs"), "Should be second file name")
 
     def test_invalid_syntax(self):
-
         criteria = "$raw_data_1/duration$ += 1000"
-        throws = False
-        try:
+        with self.assertRaisesRegex(RuntimeError, "Invalid syntax, check NexusCriteria."):
             SelectNexusFilesByMetadata(FileList=self._fileslist, NexusCriteria=criteria)
-        except RuntimeError:
-            throws = True
-        self.assertTrue(throws, "Should raise a runtime error")
-        # asserRaises does not work with python 2.6 so fails on RHEL 6
 
     def test_wrong_nexus_entry(self):
-
         criteria = "$raw_data_1/duration$ > 1000 or $raw_data_1/good_Grames$ > 10000"
         res = SelectNexusFilesByMetadata(FileList=self._fileslist, NexusCriteria=criteria)
         self.assertFalse(res, "Output should be empty since 2nd nexus entry name does not exist")
 
     def test_unsatisfying_criteria(self):
-
         criteria = "$raw_data_1/duration$ > 1000 and $raw_data_1/good_frames$ < 10000"
         res = SelectNexusFilesByMetadata(FileList=self._fileslist, NexusCriteria=criteria)
         self.assertFalse(res, "Output should be empty since no file satisfies this criteria")
 
     def test_cross_criteria(self):
-
         criteria = "10 * $raw_data_1/duration$ < $raw_data_1/good_frames$"
         res = SelectNexusFilesByMetadata(FileList=self._fileslist, NexusCriteria=criteria)
         outfiles = res.split(",")
@@ -63,7 +52,6 @@ class SelectNexusFilesByMetadataTest(unittest.TestCase):
         self.assertTrue(outfiles[0].endswith("INTER00013460.nxs"), "Should be 1st first file name")
 
     def test_string_criteria(self):
-
         filelist = "ILL/D33/001030.nxs"
         criteria = '$entry0/D33/name$ == "D33"'
         res = SelectNexusFilesByMetadata(FileList=filelist, NexusCriteria=criteria)

--- a/Framework/PythonInterface/test/python/plugins/algorithms/SetSampleFromLogsTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/SetSampleFromLogsTest.py
@@ -74,7 +74,7 @@ class SetSampleFromLogsTest(unittest.TestCase):
         environment = {"Name": "InAir"}
         geometry = {}
 
-        with self.assertRaises(RuntimeError):
+        with self.assertRaisesRegex(RuntimeError, "Resulting sample shape has volume of 0"):
             SetSampleFromLogs(InputWorkspace=wksp, Environment=environment, Material=material, Geometry=geometry)
 
         del wksp  # remove from the ADS

--- a/Framework/PythonInterface/test/python/plugins/algorithms/SymmetriseTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/SymmetriseTest.py
@@ -130,32 +130,51 @@ class SymmetriseTest(unittest.TestCase):
         """
         Tests validation on entering an XMin value lower than the smallest value in the X range.
         """
-        self.assertRaises(
-            RuntimeError, Symmetrise, InputWorkspace=self._sample_ws, OutputWOrkspace="__Symmetrise_TestWS", XMin=-5, XMax=0.2
+        self.assertRaisesRegex(
+            RuntimeError,
+            "XMin must be greater than or equal to zero",
+            Symmetrise,
+            InputWorkspace=self._sample_ws,
+            OutputWOrkspace="__Symmetrise_TestWS",
+            XMin=-5,
+            XMax=0.2,
         )
 
     def test_failure_xmax_out_of_range(self):
         """
         Tests validation on entering an XMax value greater than the largest value in the X range.
         """
-        self.assertRaises(
-            RuntimeError, Symmetrise, InputWorkspace=self._sample_ws, OutputWOrkspace="__Symmetrise_TestWS", XMin=0.05, XMax=15
+        self.assertRaisesRegex(
+            RuntimeError,
+            r"XMax value .* is greater than largest X value",
+            Symmetrise,
+            InputWorkspace=self._sample_ws,
+            OutputWOrkspace="__Symmetrise_TestWS",
+            XMin=0.05,
+            XMax=15,
         )
 
     def test_failure_invalid_x_range(self):
         """
         Tests validation on entering an XMax value lower then XMin.
         """
-        self.assertRaises(
-            RuntimeError, Symmetrise, InputWorkspace=self._sample_ws, OutputWOrkspace="__Symmetrise_TestWS", XMin=0.2, XMax=0.1
+        self.assertRaisesRegex(
+            RuntimeError,
+            "XMax must be greater than XMin",
+            Symmetrise,
+            InputWorkspace=self._sample_ws,
+            OutputWOrkspace="__Symmetrise_TestWS",
+            XMin=0.2,
+            XMax=0.1,
         )
 
     def test_failure_spectra_range_lower(self):
         """
         Tests validation on entering a minimum spectra number lower then that of the workspace.
         """
-        self.assertRaises(
+        self.assertRaisesRegex(
             RuntimeError,
+            "Minimum spectra must be greater than or equal to",
             Symmetrise,
             InputWorkspace=self._sample_ws,
             OutputWOrkspace="__Symmetrise_TestWS",
@@ -168,8 +187,9 @@ class SymmetriseTest(unittest.TestCase):
         """
         Tests validation on entering a maximum spectra number higher then that of the workspace.
         """
-        self.assertRaises(
+        self.assertRaisesRegex(
             RuntimeError,
+            "Maximum spectra must be less than or equal to",
             Symmetrise,
             InputWorkspace=self._sample_ws,
             OutputWOrkspace="__Symmetrise_TestWS",

--- a/Framework/PythonInterface/test/python/plugins/algorithms/TOFTOFCropWorkspaceTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/TOFTOFCropWorkspaceTest.py
@@ -11,7 +11,6 @@ from mantid.api import AnalysisDataService
 
 
 class TOFTOFCropWorkspaceTest(unittest.TestCase):
-
     _input_ws = None
     _cropped_ws = None
 
@@ -48,7 +47,13 @@ class TOFTOFCropWorkspaceTest(unittest.TestCase):
     def test_invalid_xunits(self):
         self._input_ws.getAxis(0).setUnit("Wavelength")
         OutputWorkspaceName = "cropped_ws"
-        self.assertRaises(RuntimeError, TOFTOFCropWorkspace, InputWorkspace=self._input_ws, OutputWorkspace=OutputWorkspaceName)
+        self.assertRaisesRegex(
+            RuntimeError,
+            "X axis units must be TOF.",
+            TOFTOFCropWorkspace,
+            InputWorkspace=self._input_ws,
+            OutputWorkspace=OutputWorkspaceName,
+        )
 
     def cleanUp(self):
         if AnalysisDataService.doesExist(self._input_ws):

--- a/Framework/PythonInterface/test/python/plugins/algorithms/TOFTOFMergeRunsTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/TOFTOFMergeRunsTest.py
@@ -74,8 +74,9 @@ class TOFTOFMergeRunsTest(unittest.TestCase):
         """
         OutputWorkspaceName = "output_ws"
         Inputws_badvalue = "%s, %s" % (self._input_ws_base.name(), self._input_bad_value.name())
-        self.assertRaises(
+        self.assertRaisesRegex(
             RuntimeError,
+            "Sample logs wavelength do not match!",
             run_algorithm,
             "TOFTOFMergeRuns",
             InputWorkspaces=Inputws_badvalue,
@@ -84,8 +85,9 @@ class TOFTOFMergeRunsTest(unittest.TestCase):
         )
 
         Inputws_badentry = "%s, %s" % (self._input_ws_base.name(), self._input_bad_entry.name())
-        self.assertRaises(
+        self.assertRaisesRegex(
             RuntimeError,
+            r"Workspace .* does not have property duration. Cannot merge.",
             run_algorithm,
             "TOFTOFMergeRuns",
             InputWorkspaces=Inputws_badentry,

--- a/Framework/PythonInterface/test/python/plugins/algorithms/VesuvioPeakPredictionTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/VesuvioPeakPredictionTest.py
@@ -40,8 +40,9 @@ class VesuvioPeakPredictionTest(unittest.TestCase):
         """
         Test negative input temperature
         """
-        self.assertRaises(
+        self.assertRaisesRegex(
             ValueError,
+            "Selected value -20 is < the lower bound",
             VesuvioPeakPrediction,
             Model="Debye",
             Temperature=[100, 0, 240, -20],
@@ -54,8 +55,9 @@ class VesuvioPeakPredictionTest(unittest.TestCase):
         """
         Test zero frequency
         """
-        self.assertRaises(
+        self.assertRaisesRegex(
             ValueError,
+            "Selected value 0 is <= the lower bound",
             VesuvioPeakPrediction,
             Model="Einstein",
             Temperature=[100, 0, 240],
@@ -68,8 +70,9 @@ class VesuvioPeakPredictionTest(unittest.TestCase):
         """
         Test zero debye temp
         """
-        self.assertRaises(
+        self.assertRaisesRegex(
             ValueError,
+            "Selected value -540 is <= the lower bound",
             VesuvioPeakPrediction,
             Model="Debye",
             Temperature=[100, 0, 240],

--- a/Framework/PythonInterface/test/python/plugins/algorithms/VesuvioPreFitTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/VesuvioPreFitTest.py
@@ -21,7 +21,6 @@ import vesuvio.testing as testing
 
 
 class VesuvioPreFitTest(unittest.TestCase):
-
     _test_ws = None
 
     def setUp(self):
@@ -97,7 +96,7 @@ class VesuvioPreFitTest(unittest.TestCase):
 
     def test_invalid_smooth_opt_raises_error_on_validate(self):
         alg = self._create_algorithm(InputWorkspace=self._test_ws, Smoothing="Neighbour", SmoothingOptions="npts=3")
-        self.assertRaises(RuntimeError, alg.execute)
+        self.assertRaisesRegex(RuntimeError, "Invalid value for smoothing option. It must begin the format NPoints=3", alg.execute)
 
     # -------------- Helpers --------------------
 

--- a/Framework/PythonInterface/test/python/plugins/algorithms/VesuvioResolutionTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/VesuvioResolutionTest.py
@@ -32,14 +32,18 @@ class VesuvioResolutionTest(unittest.TestCase):
         Tests that validation fails if no output workspace is given.
         """
 
-        self.assertRaises(RuntimeError, VesuvioResolution, Workspace=self._sample_ws, Mass=1.0079)
+        self.assertRaisesRegex(
+            RuntimeError, "Must output in either time of flight or ySpace", VesuvioResolution, Workspace=self._sample_ws, Mass=1.0079
+        )
 
     def test_ws_index_validation(self):
         """
         Tests that validation fails if ws index is out of range.
         """
 
-        self.assertRaises(RuntimeError, VesuvioResolution, Workspace=self._sample_ws, Mass=1.0079, WorkspaceIndex=50)
+        self.assertRaisesRegex(
+            RuntimeError, "Workspace index is out of range", VesuvioResolution, Workspace=self._sample_ws, Mass=1.0079, WorkspaceIndex=50
+        )
 
 
 if __name__ == "__main__":

--- a/Framework/PythonInterface/test/python/plugins/algorithms/VesuvioTOFFitTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/VesuvioTOFFitTest.py
@@ -19,7 +19,6 @@ import vesuvio.commands as vesuvio
 
 
 class VesuvioTOFFitTest(unittest.TestCase):
-
     _test_ws = None
 
     def setUp(self):
@@ -188,7 +187,7 @@ class VesuvioTOFFitTest(unittest.TestCase):
     def test_number_functions_in_list_not_matching_length_masses_throws_error(self):
         alg = self._create_algorithm(InputWorkspace=self._test_ws, Masses=[1.0079, 33], MassProfiles="function=Gaussian,width=5;")
 
-        self.assertRaises(RuntimeError, alg.execute)
+        self.assertRaisesRegex(RuntimeError, "Found 2 masses but 1 function definition", alg.execute)
 
     # -------------- Helpers --------------------
 

--- a/Framework/PythonInterface/test/python/plugins/algorithms/VesuvioThicknessTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/VesuvioThicknessTest.py
@@ -12,7 +12,6 @@ from mantid.api import ITableWorkspace
 
 
 class VesuvioThicknessTest(unittest.TestCase):
-
     # ----------------------------------Algorithm tests----------------------------------------
 
     def test_basic_input(self):
@@ -50,8 +49,9 @@ class VesuvioThicknessTest(unittest.TestCase):
     def test_mismatch_mass_amplitude_inputs(self):
         masses = [1.0, 2.0, 3.0, 4.0]
         amplitudes = [1.0, 2.0]
-        self.assertRaises(
+        self.assertRaisesRegex(
             RuntimeError,
+            "The number of masses: 4, is not equal to the number of amplitudes: 2",
             VesuvioThickness,
             Masses=masses,
             Amplitudes=amplitudes,
@@ -62,8 +62,9 @@ class VesuvioThicknessTest(unittest.TestCase):
     def test_no_masses_input(self):
         masses = []
         amplitudes = [1.0, 2.0]
-        self.assertRaises(
+        self.assertRaisesRegex(
             RuntimeError,
+            "Must have 1 or more Masses defined",
             VesuvioThickness,
             Masses=masses,
             Amplitudes=amplitudes,
@@ -74,8 +75,9 @@ class VesuvioThicknessTest(unittest.TestCase):
     def test_no_amplitudes_input(self):
         masses = [1.0, 2.0]
         amplitudes = []
-        self.assertRaises(
+        self.assertRaisesRegex(
             RuntimeError,
+            "Must have 1 or more Amplitudes defined",
             VesuvioThickness,
             Masses=masses,
             Amplitudes=amplitudes,


### PR DESCRIPTION
**Description of work.**

**Part 2 #35297 must be merged first**

Third part of the work to remove the blanket use of `assertRaises` when testing algorithm input validation in favour of `assertRaisesRegex`. This way we can expect a certain exception rather than accepting any possible `RuntimeException` which could be an unrelated bug (there were a few found during in the tests from this pr).

Main issue is #34570

**To test:**

 - All tests should pass (handled by Jenkins)
 - Code review

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
