### PR TITLE
Disable ALFView when running algorithms

### DIFF
--- a/docs/source/release/v6.7.0/Direct_Geometry/General/New_features/35114.rst
+++ b/docs/source/release/v6.7.0/Direct_Geometry/General/New_features/35114.rst
@@ -1,0 +1,2 @@
+- The ALFView interface executes any algorithms on a background thread to provide a smoother user experience.
+- The ALFView interface is disabled when running an algorithm, and re-enabled when it has finished. The title of the ALFView window is changed to indicate why the interface is disabled.

--- a/qt/scientific_interfaces/Direct/ALFAnalysisPresenter.cpp
+++ b/qt/scientific_interfaces/Direct/ALFAnalysisPresenter.cpp
@@ -65,10 +65,14 @@ void ALFAnalysisPresenter::notifyFitClicked() {
     return;
   }
 
+  m_view->disable("Fitting");
   m_algorithmManager->fit(m_model->fitProperties(m_view->getRange()));
 }
 
-void ALFAnalysisPresenter::notifyAlgorithmError(std::string const &message) { m_view->displayWarning(message); }
+void ALFAnalysisPresenter::notifyAlgorithmError(std::string const &message) {
+  m_view->enable();
+  m_view->displayWarning(message);
+}
 
 void ALFAnalysisPresenter::notifyCropWorkspaceComplete(Mantid::API::MatrixWorkspace_sptr const &workspace) {
   m_model->calculateEstimate(workspace);
@@ -82,6 +86,8 @@ void ALFAnalysisPresenter::notifyFitComplete(Mantid::API::MatrixWorkspace_sptr w
 
   updatePeakCentreInViewFromModel();
   updateRotationAngleInViewFromModel();
+
+  m_view->enable();
 }
 
 void ALFAnalysisPresenter::notifyExportWorkspaceToADSClicked() { m_model->exportWorkspaceCopyToADS(); }

--- a/qt/scientific_interfaces/Direct/ALFAnalysisPresenter.cpp
+++ b/qt/scientific_interfaces/Direct/ALFAnalysisPresenter.cpp
@@ -77,6 +77,7 @@ void ALFAnalysisPresenter::notifyAlgorithmError(std::string const &message) {
 void ALFAnalysisPresenter::notifyCropWorkspaceComplete(Mantid::API::MatrixWorkspace_sptr const &workspace) {
   m_model->calculateEstimate(workspace);
   updateViewFromModel();
+  m_view->enable();
 }
 
 void ALFAnalysisPresenter::notifyFitComplete(Mantid::API::MatrixWorkspace_sptr workspace,
@@ -123,6 +124,7 @@ bool ALFAnalysisPresenter::checkPeakCentreIsWithinFitRange() const {
 
 void ALFAnalysisPresenter::calculateEstimate() {
   if (m_model->isDataExtracted()) {
+    m_view->disable("Calculating estimate parameters");
     m_algorithmManager->cropWorkspace(m_model->cropWorkspaceProperties(m_view->getRange()));
   } else {
     updatePlotInViewFromModel();

--- a/qt/scientific_interfaces/Direct/ALFAnalysisView.cpp
+++ b/qt/scientific_interfaces/Direct/ALFAnalysisView.cpp
@@ -6,6 +6,7 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 #include "ALFAnalysisView.h"
 #include "ALFAnalysisPresenter.h"
+#include "ALFView.h"
 
 #include "MantidAPI/IPeakFunction.h"
 #include "MantidQtIcons/Icon.h"
@@ -219,6 +220,18 @@ void ALFAnalysisView::setupRotationAngleWidget(QGridLayout *layout) {
   layout->addWidget(new QLabel("Rotation:"), 5, 0);
   layout->addWidget(m_rotationAngle, 5, 1, 1, 3);
   layout->addWidget(m_fitRequired, 5, 4);
+}
+
+void ALFAnalysisView::disable(std::string const &reason) {
+  if (auto parent = static_cast<ALFView *>(parentWidget())) {
+    parent->disable(reason);
+  }
+}
+
+void ALFAnalysisView::enable() {
+  if (auto parent = static_cast<ALFView *>(parentWidget())) {
+    parent->enable();
+  }
 }
 
 void ALFAnalysisView::notifyPeakPickerChanged() { m_presenter->notifyPeakPickerChanged(); }

--- a/qt/scientific_interfaces/Direct/ALFAnalysisView.h
+++ b/qt/scientific_interfaces/Direct/ALFAnalysisView.h
@@ -40,6 +40,9 @@ public:
 
   virtual void subscribePresenter(IALFAnalysisPresenter *presenter) = 0;
 
+  virtual void disable(std::string const &reason) = 0;
+  virtual void enable() = 0;
+
   virtual void replot() = 0;
 
   virtual void openExternalPlot(Mantid::API::MatrixWorkspace_sptr const &workspace,
@@ -74,6 +77,9 @@ public:
   QWidget *getView() override;
 
   void subscribePresenter(IALFAnalysisPresenter *presenter) override;
+
+  void disable(std::string const &reason) override;
+  void enable() override;
 
   void replot() override;
 

--- a/qt/scientific_interfaces/Direct/ALFInstrumentPresenter.cpp
+++ b/qt/scientific_interfaces/Direct/ALFInstrumentPresenter.cpp
@@ -174,10 +174,12 @@ void ALFInstrumentPresenter::updateInstrumentViewFromModel() {
 }
 
 void ALFInstrumentPresenter::updateAnalysisViewFromModel() {
+  m_view->disable("Processing selection");
   if (m_model->hasSelectedTubes()) {
     m_algorithmManager->createWorkspace(m_model->createWorkspaceAlgorithmProperties(m_view->getInstrumentActor()));
   } else {
     m_analysisPresenter->setExtractedWorkspace(nullptr, {});
+    m_view->enable();
   }
 }
 
@@ -191,6 +193,7 @@ void ALFInstrumentPresenter::notifyScaleXComplete(Mantid::API::MatrixWorkspace_s
 
 void ALFInstrumentPresenter::notifyRebunchComplete(Mantid::API::MatrixWorkspace_sptr const &workspace) {
   m_analysisPresenter->setExtractedWorkspace(workspace, m_model->twoThetasClosestToZero());
+  m_view->enable();
 }
 
 } // namespace MantidQt::CustomInterfaces

--- a/qt/scientific_interfaces/Direct/ALFInstrumentPresenter.cpp
+++ b/qt/scientific_interfaces/Direct/ALFInstrumentPresenter.cpp
@@ -37,7 +37,10 @@ void ALFInstrumentPresenter::loadSettings() { m_view->loadSettings(); }
 
 void ALFInstrumentPresenter::saveSettings() { m_view->saveSettings(); }
 
-void ALFInstrumentPresenter::notifyAlgorithmError(std::string const &message) { m_view->displayWarning(message); }
+void ALFInstrumentPresenter::notifyAlgorithmError(std::string const &message) {
+  m_view->enable();
+  m_view->displayWarning(message);
+}
 
 void ALFInstrumentPresenter::loadSample() {
   m_dataSwitch = ALFData::SAMPLE;
@@ -50,6 +53,7 @@ void ALFInstrumentPresenter::loadVanadium() {
 }
 
 void ALFInstrumentPresenter::loadAndNormalise() {
+  m_view->disable(m_dataSwitch == ALFData::SAMPLE ? "Loading sample" : "Loading vanadium");
   m_analysisPresenter->clear();
 
   if (auto const filepath = getFileFromView()) {
@@ -64,6 +68,7 @@ void ALFInstrumentPresenter::notifyLoadComplete(Mantid::API::MatrixWorkspace_spt
   if (m_model->isALFData(workspace)) {
     m_algorithmManager->normaliseByCurrent(m_model->normaliseByCurrentProperties(workspace));
   } else {
+    m_view->enable();
     m_view->displayWarning("The loaded data is not from the ALF instrument");
   }
 }
@@ -76,6 +81,7 @@ void ALFInstrumentPresenter::notifyNormaliseByCurrentComplete(Mantid::API::Matri
 
 void ALFInstrumentPresenter::generateLoadedWorkspace() {
   if (!m_model->hasData(ALFData::SAMPLE)) {
+    m_view->enable();
     return;
   }
 
@@ -120,6 +126,7 @@ void ALFInstrumentPresenter::convertSampleToDSpacing(Mantid::API::MatrixWorkspac
 
 void ALFInstrumentPresenter::notifyConvertUnitsComplete(Mantid::API::MatrixWorkspace_sptr const &workspace) {
   m_model->replaceSampleWorkspaceInADS(workspace);
+  m_view->enable();
 }
 
 void ALFInstrumentPresenter::notifyInstrumentActorReset() { updateAnalysisViewFromModel(); }

--- a/qt/scientific_interfaces/Direct/ALFInstrumentView.cpp
+++ b/qt/scientific_interfaces/Direct/ALFInstrumentView.cpp
@@ -8,6 +8,7 @@
 
 #include "ALFInstrumentPresenter.h"
 #include "ALFInstrumentWidget.h"
+#include "ALFView.h"
 #include "MantidGeometry/Instrument/ComponentInfo.h"
 #include "MantidQtWidgets/Common/FileFinderWidget.h"
 #include "MantidQtWidgets/Common/InputController.h"
@@ -86,6 +87,18 @@ void ALFInstrumentView::saveSettings() {
   settings.beginGroup(m_settingsGroup);
   settings.setValue("vanadium-run", m_vanadium->getText());
   settings.endGroup();
+}
+
+void ALFInstrumentView::disable(std::string const &reason) {
+  if (auto parent = static_cast<ALFView *>(parentWidget())) {
+    parent->disable(reason);
+  }
+}
+
+void ALFInstrumentView::enable() {
+  if (auto parent = static_cast<ALFView *>(parentWidget())) {
+    parent->enable();
+  }
 }
 
 void ALFInstrumentView::reconnectInstrumentActor() {

--- a/qt/scientific_interfaces/Direct/ALFInstrumentView.cpp
+++ b/qt/scientific_interfaces/Direct/ALFInstrumentView.cpp
@@ -78,6 +78,7 @@ void ALFInstrumentView::loadSettings() {
   settings.endGroup();
 
   if (!vanadiumRun.toString().isEmpty()) {
+    disable("Loading vanadium");
     m_vanadium->setUserInput(vanadiumRun);
   }
 }

--- a/qt/scientific_interfaces/Direct/ALFInstrumentView.h
+++ b/qt/scientific_interfaces/Direct/ALFInstrumentView.h
@@ -49,6 +49,9 @@ public:
   virtual void loadSettings() = 0;
   virtual void saveSettings() = 0;
 
+  virtual void disable(std::string const &reason) = 0;
+  virtual void enable() = 0;
+
   virtual std::optional<std::string> getSampleFile() const = 0;
   virtual std::optional<std::string> getVanadiumFile() const = 0;
 
@@ -81,6 +84,9 @@ public:
 
   void loadSettings() override;
   void saveSettings() override;
+
+  void disable(std::string const &reason) override;
+  void enable() override;
 
   std::optional<std::string> getSampleFile() const override;
   std::optional<std::string> getVanadiumFile() const override;

--- a/qt/scientific_interfaces/Direct/ALFView.cpp
+++ b/qt/scientific_interfaces/Direct/ALFView.cpp
@@ -46,6 +46,16 @@ ALFView::ALFView(QWidget *parent) : UserSubWindow(parent), m_instrumentPresenter
 
 ALFView::~ALFView() { m_instrumentPresenter->saveSettings(); }
 
+void ALFView::disable(std::string const &reason) {
+  this->setEnabled(false);
+  this->setWindowTitle("ALFView - " + QString::fromStdString(reason));
+}
+
+void ALFView::enable() {
+  this->setEnabled(true);
+  this->setWindowTitle("ALFView");
+}
+
 void ALFView::initLayout() {
   auto *splitter = new QSplitter(Qt::Horizontal);
   splitter->addWidget(m_instrumentPresenter->getInstrumentView());

--- a/qt/scientific_interfaces/Direct/ALFView.cpp
+++ b/qt/scientific_interfaces/Direct/ALFView.cpp
@@ -48,7 +48,7 @@ ALFView::~ALFView() { m_instrumentPresenter->saveSettings(); }
 
 void ALFView::disable(std::string const &reason) {
   this->setEnabled(false);
-  this->setWindowTitle("ALFView - " + QString::fromStdString(reason));
+  this->setWindowTitle("ALFView - " + QString::fromStdString(reason) + "...");
 }
 
 void ALFView::enable() {

--- a/qt/scientific_interfaces/Direct/ALFView.h
+++ b/qt/scientific_interfaces/Direct/ALFView.h
@@ -30,6 +30,9 @@ public:
   static std::string name() { return "ALFView"; }
   static QString categoryInfo() { return "Direct"; }
 
+  void disable(std::string const &reason);
+  void enable();
+
 protected:
   void initLayout() override;
 

--- a/qt/scientific_interfaces/Direct/test/ALFAnalysisMocks.h
+++ b/qt/scientific_interfaces/Direct/test/ALFAnalysisMocks.h
@@ -88,7 +88,6 @@ public:
   MOCK_CONST_METHOD0(extractedWorkspace, Mantid::API::MatrixWorkspace_sptr());
   MOCK_CONST_METHOD0(isDataExtracted, bool());
 
-  MOCK_METHOD1(doFit, Mantid::API::MatrixWorkspace_sptr(std::pair<double, double> const &range));
   MOCK_METHOD1(calculateEstimate, void(Mantid::API::MatrixWorkspace_sptr const &workspace));
 
   MOCK_CONST_METHOD0(exportWorkspaceCopyToADS, void());

--- a/qt/scientific_interfaces/Direct/test/ALFAnalysisMocks.h
+++ b/qt/scientific_interfaces/Direct/test/ALFAnalysisMocks.h
@@ -51,6 +51,9 @@ public:
 
   MOCK_METHOD1(subscribePresenter, void(IALFAnalysisPresenter *presenter));
 
+  MOCK_METHOD1(disable, void(std::string const &reason));
+  MOCK_METHOD0(enable, void());
+
   MOCK_METHOD0(replot, void());
 
   MOCK_CONST_METHOD2(openExternalPlot,

--- a/qt/scientific_interfaces/Direct/test/ALFAnalysisPresenterTest.h
+++ b/qt/scientific_interfaces/Direct/test/ALFAnalysisPresenterTest.h
@@ -272,6 +272,8 @@ public:
 
   void test_notifyCropWorkspaceComplete_triggers_the_model_to_calculate_an_estimate_peak() {
     EXPECT_CALL(*m_model, calculateEstimate(_)).Times(1);
+    EXPECT_CALL(*m_view, enable()).Times(1);
+
     m_presenter->notifyCropWorkspaceComplete(nullptr);
   }
 
@@ -301,6 +303,7 @@ private:
   void expectCalculateEstimate(MatrixWorkspace_sptr const &workspace) {
     EXPECT_CALL(*m_model, isDataExtracted()).Times(1).WillOnce(Return(workspace != nullptr));
     if (workspace) {
+      EXPECT_CALL(*m_view, disable("Calculating estimate parameters")).Times(1);
       EXPECT_CALL(*m_view, getRange()).Times(1).WillRepeatedly(Return(m_range));
 
       EXPECT_CALL(*m_model, cropWorkspaceProperties(m_range))

--- a/qt/scientific_interfaces/Direct/test/ALFAnalysisPresenterTest.h
+++ b/qt/scientific_interfaces/Direct/test/ALFAnalysisPresenterTest.h
@@ -202,6 +202,7 @@ public:
     EXPECT_CALL(*m_view, peakCentre()).Times(1).WillOnce(Return(m_peakCentre));
     EXPECT_CALL(*m_view, getRange()).Times(2).WillRepeatedly(Return(m_range));
 
+    EXPECT_CALL(*m_view, disable("Fitting")).Times(1);
     EXPECT_CALL(*m_model, fitProperties(m_range)).Times(1).WillOnce(Return(ByMove(std::move(m_algProperties))));
     EXPECT_CALL(*m_algorithmManager, fit(NotNull())).Times(1);
 
@@ -282,6 +283,7 @@ public:
     EXPECT_CALL(*m_view, addFitSpectrum(Eq(m_workspace))).Times(1);
     expectUpdatePeakCentreInViewFromModel();
     expectUpdateRotationAngleCalled();
+    EXPECT_CALL(*m_view, enable()).Times(1);
 
     m_presenter->notifyFitComplete(m_workspace, m_function, fitStatus);
   }
@@ -289,6 +291,7 @@ public:
   void test_notifyAlgorithmError_will_display_a_message_in_the_view() {
     std::string const message("This is a warning message");
 
+    EXPECT_CALL(*m_view, enable()).Times(1);
     EXPECT_CALL(*m_view, displayWarning(message)).Times(1);
 
     m_presenter->notifyAlgorithmError(message);

--- a/qt/scientific_interfaces/Direct/test/ALFInstrumentMocks.h
+++ b/qt/scientific_interfaces/Direct/test/ALFInstrumentMocks.h
@@ -50,6 +50,9 @@ public:
   MOCK_METHOD0(loadSettings, void());
   MOCK_METHOD0(saveSettings, void());
 
+  MOCK_METHOD1(disable, void(std::string const &reason));
+  MOCK_METHOD0(enable, void());
+
   MOCK_CONST_METHOD0(getSampleFile, std::optional<std::string>());
   MOCK_CONST_METHOD0(getVanadiumFile, std::optional<std::string>());
 

--- a/qt/scientific_interfaces/Direct/test/ALFInstrumentPresenterTest.h
+++ b/qt/scientific_interfaces/Direct/test/ALFInstrumentPresenterTest.h
@@ -273,6 +273,7 @@ public:
     std::vector<double> twoThetas{1.0, 2.0};
     EXPECT_CALL(*m_model, twoThetasClosestToZero()).Times(1).WillOnce(Return(twoThetas));
     EXPECT_CALL(*m_analysisPresenter, setExtractedWorkspace(_, twoThetas)).Times(1);
+    EXPECT_CALL(*m_view, enable()).Times(1);
 
     m_presenter->notifyRebunchComplete(nullptr);
   }
@@ -320,6 +321,7 @@ private:
   }
 
   void expectUpdateAnalysisViewFromModel(bool hasTubes = true) {
+    EXPECT_CALL(*m_view, disable("Processing selection")).Times(1);
     EXPECT_CALL(*m_model, hasSelectedTubes()).Times(1).WillOnce(Return(hasTubes));
 
     if (hasTubes) {
@@ -328,6 +330,7 @@ private:
       EXPECT_CALL(*m_algorithmManager, createWorkspace(NotNull())).Times(1);
     } else {
       EXPECT_CALL(*m_analysisPresenter, setExtractedWorkspace(IsNull(), std::vector<double>{})).Times(1);
+      EXPECT_CALL(*m_view, enable()).Times(1);
     }
   }
 

--- a/qt/scientific_interfaces/Direct/test/ALFInstrumentPresenterTest.h
+++ b/qt/scientific_interfaces/Direct/test/ALFInstrumentPresenterTest.h
@@ -121,6 +121,7 @@ public:
   }
 
   void test_loadSample_will_not_attempt_a_load_when_an_empty_filepath_is_provided() {
+    EXPECT_CALL(*m_view, disable("Loading sample")).Times(1);
     EXPECT_CALL(*m_analysisPresenter, clear()).Times(1);
 
     EXPECT_CALL(*m_view, getSampleFile()).Times(1).WillOnce(Return(std::nullopt));
@@ -138,6 +139,7 @@ public:
     std::string const filename("ALF82301");
 
     EXPECT_CALL(*m_view, getSampleFile()).Times(1).WillOnce(Return(filename));
+    EXPECT_CALL(*m_view, disable("Loading sample")).Times(1);
     EXPECT_CALL(*m_analysisPresenter, clear()).Times(1);
     EXPECT_CALL(*m_model, loadProperties(filename)).Times(1).WillOnce(Return(ByMove(std::move(m_algProperties))));
     EXPECT_CALL(*m_algorithmManager, load(_)).Times(1);
@@ -147,6 +149,7 @@ public:
 
   void test_notifyLoadComplete_opens_a_warning_if_the_data_is_not_ALF_data() {
     EXPECT_CALL(*m_model, isALFData(_)).Times(1).WillOnce(Return(false));
+    EXPECT_CALL(*m_view, enable()).Times(1);
     EXPECT_CALL(*m_view, displayWarning("The loaded data is not from the ALF instrument")).Times(1);
 
     m_presenter->notifyLoadComplete(nullptr);
@@ -248,6 +251,7 @@ public:
 
   void test_notifyConvertUnitsComplete_adds_the_workspace_to_the_ADS() {
     EXPECT_CALL(*m_model, replaceSampleWorkspaceInADS(_)).Times(1);
+    EXPECT_CALL(*m_view, enable()).Times(1);
     m_presenter->notifyConvertUnitsComplete(nullptr);
   }
 
@@ -276,6 +280,7 @@ public:
   void test_notifyAlgorithmError_will_display_a_message_in_the_view() {
     std::string const message("This is a warning message");
 
+    EXPECT_CALL(*m_view, enable()).Times(1);
     EXPECT_CALL(*m_view, displayWarning(message)).Times(1);
 
     m_presenter->notifyAlgorithmError(message);

--- a/qt/widgets/plotting/src/PreviewPlot.cpp
+++ b/qt/widgets/plotting/src/PreviewPlot.cpp
@@ -414,6 +414,9 @@ bool PreviewPlot::eventFilter(QObject *watched, QEvent *evt) {
   case QEvent::Resize:
     stopEvent = handleWindowResizeEvent();
     break;
+  case QEvent::UpdateLater:
+    m_redrawOnPaint = true;
+    break;
   case QEvent::Paint:
     if (m_redrawOnPaint) {
       m_redrawOnPaint = false;


### PR DESCRIPTION
**Description of work.**
This PR ensures the ALFView interface is disabled when algorithms are being executed on the background thread.

**To test:**
Open ALFView from the interface menu
Load ALF84116 as the sample. The interface should be disabled while loading is happening.
Load ALF78634 as the vanadium. The interface should be disabled while loading is happening.
Go to pick tab and select the `Select whole tube` button
Select the central four tubes (seen in the screenshot below)
The two theta value should be 38.066
Then click `Fit` on the right hand side of the interface. The interface should be disabled when fitting.
The Rotation angle should have a value of -0.1869...

![image](https://user-images.githubusercontent.com/40830825/216953757-def2ab6d-a0c2-4223-951b-f79753fe1e91.png)

Fixes #35114

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
