### PR TITLE
Support peak overlay in instrument viewer side by side view

### DIFF
--- a/docs/source/release/v6.7.0/Workbench/InstrumentViewer/New_features/35345 Support peak overlay in side by side view.rst
+++ b/docs/source/release/v6.7.0/Workbench/InstrumentViewer/New_features/35345 Support peak overlay in side by side view.rst
@@ -1,0 +1,1 @@
+- The peak overlay feature in the instrument viewer now works in the Side by Side view

--- a/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/PanelsSurface.h
+++ b/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/PanelsSurface.h
@@ -28,6 +28,7 @@ struct EXPORT_OPT_MANTIDQT_INSTRUMENTVIEW FlatBankInfo {
   QPolygonF polygon;
   /// optional override u, v for the bank
   std::optional<Mantid::Kernel::V2D> bankCentreOverride;
+  Mantid::Kernel::V3D refPos;
   // translate the bank by a vector
   void translate(const QPointF &shift);
 
@@ -77,8 +78,7 @@ protected:
   void constructFromComponentInfo();
   Mantid::Kernel::Quat calcBankRotation(const Mantid::Kernel::V3D &detPos, Mantid::Kernel::V3D normal) const;
   // Add a detector from an assembly
-  void addDetector(size_t detIndex, const Mantid::Kernel::V3D &refPos, int bankIndex,
-                   const Mantid::Kernel::Quat &rotation);
+  void addDetector(size_t detIndex, int bankIndex);
   // Arrange the banks on the projection plane
   void arrangeBanks();
   // Spread the banks over the projection plane

--- a/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/PanelsSurface.h
+++ b/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/PanelsSurface.h
@@ -28,6 +28,7 @@ struct EXPORT_OPT_MANTIDQT_INSTRUMENTVIEW FlatBankInfo {
   QPolygonF polygon;
   /// optional override u, v for the bank
   std::optional<Mantid::Kernel::V2D> bankCentreOverride;
+  std::optional<Mantid::Kernel::V2D> bankCentreOffset;
   Mantid::Kernel::V3D refPos;
   // translate the bank by a vector
   void translate(const QPointF &shift);
@@ -56,8 +57,7 @@ public:
   PanelsSurface() : m_zaxis({0., 0., 1.0}){};
   ~PanelsSurface() override;
   void init() override;
-  void project(const Mantid::Kernel::V3D & /*pos*/, double & /*u*/, double & /*v*/, double & /*uscale*/,
-               double & /*vscale*/) const override;
+  void project(const size_t detIndex, double &u, double &v, double &uscale, double &vscale) const override;
   void resetInstrumentActor(const IInstrumentActor *rootActor) override;
 
 protected:

--- a/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/PanelsSurface.h
+++ b/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/PanelsSurface.h
@@ -28,7 +28,10 @@ struct EXPORT_OPT_MANTIDQT_INSTRUMENTVIEW FlatBankInfo {
   QPolygonF polygon;
   /// optional override u, v for the bank
   std::optional<Mantid::Kernel::V2D> bankCentreOverride;
+  /// further offset that is applied to bank following projection calculation as
+  /// a result of bank arrangement logic
   std::optional<Mantid::Kernel::V2D> bankCentreOffset;
+  /// the point on the bank about which rotation occurs during projection
   Mantid::Kernel::V3D refPos;
   // translate the bank by a vector
   void translate(const QPointF &shift);

--- a/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/UnwrappedCylinder.h
+++ b/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/UnwrappedCylinder.h
@@ -21,7 +21,7 @@ public:
                     const Mantid::Kernel::V3D &axis, const QSize &widgetSize, const bool maintainAspectRatio);
 
 protected:
-  void project(const Mantid::Kernel::V3D &pos, double &u, double &v, double &uscale, double &vscale) const override;
+  void project(const size_t detIndex, double &u, double &v, double &uscale, double &vscale) const override;
   void rotate(const UnwrappedDetector &udet, Mantid::Kernel::Quat &R) const override;
 };
 } // namespace MantidWidgets

--- a/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/UnwrappedSphere.h
+++ b/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/UnwrappedSphere.h
@@ -22,7 +22,7 @@ public:
 
 protected:
   void rotate(const UnwrappedDetector &udet, Mantid::Kernel::Quat &R) const override;
-  void project(const Mantid::Kernel::V3D &pos, double &u, double &v, double &uscale, double &vscale) const override;
+  void project(const size_t detIndex, double &u, double &v, double &uscale, double &vscale) const override;
 };
 
 } // namespace MantidWidgets

--- a/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/UnwrappedSurface.h
+++ b/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/UnwrappedSurface.h
@@ -89,13 +89,13 @@ public:
    *object onto the tagent plane to the
    * surface at point (uv) and scaled along u and v by the corresponding factor.
    *
-   * @param pos :: A position of a 3D point.
+   * @param detIndex :: The index of a detector in detectorInfo\componentInfo
    * @param u (output) :: u-coordinate of the projection.
    * @param v (output) :: v-coordinate of the projection.
    * @param uscale (output) :: The scaling factor along the u-coordinate.
    * @param vscale (output) :: The scaling factor along the v-coordinate.
    */
-  virtual void project(const Mantid::Kernel::V3D &pos, double &u, double &v, double &uscale, double &vscale) const = 0;
+  virtual void project(const size_t detIndex, double &u, double &v, double &uscale, double &vscale) const = 0;
   //@}
 
   /** @name Public methods */
@@ -148,7 +148,7 @@ protected:
    * @param R :: The result rotaion.
    */
   virtual void rotate(const UnwrappedDetector &udet, Mantid::Kernel::Quat &R) const = 0;
-  virtual void calcUV(UnwrappedDetector &udet, Mantid::Kernel::V3D &pos);
+  virtual void calcUV(UnwrappedDetector &udet);
   virtual void calcSize(UnwrappedDetector &udet);
   virtual QString getDimInfo() const;
   /// Called in non-picking drawSimpleToImage to draw something other than

--- a/qt/widgets/instrumentview/src/PanelsSurface.cpp
+++ b/qt/widgets/instrumentview/src/PanelsSurface.cpp
@@ -439,11 +439,14 @@ boost::optional<size_t> PanelsSurface::processTubes(size_t rootIndex) {
   auto *info = new FlatBankInfo(this);
   m_flatBanks << info;
   // record the first detector index of the bank
-  info->startDetectorIndex = componentInfo.children(tubes.front()).front();
-  info->endDetectorIndex = componentInfo.children(tubes.back()).back();
+  auto corner1Index = componentInfo.children(tubes.front()).front();
+  auto corner2Index = componentInfo.children(tubes.front()).back();
+  auto corner3Index = componentInfo.children(tubes.back()).front();
+  auto corner4Index = componentInfo.children(tubes.back()).back();
+  info->startDetectorIndex = std::min(corner1Index, std::min(corner2Index, std::min(corner3Index, corner4Index)));
+  info->endDetectorIndex = std::max(corner1Index, std::max(corner2Index, std::max(corner3Index, corner4Index)));
 
-  // Now go over all detectors in the tubes and put them onto the unwrapped
-  // surfeace.
+  // Now go over all detectors in the tubes and put them onto the unwrapped surface.
   auto pos0 = componentInfo.position(componentInfo.children(tubes.front()).front());
   auto pos1 = componentInfo.position(componentInfo.children(tubes.front()).back());
 

--- a/qt/widgets/instrumentview/src/PanelsSurface.cpp
+++ b/qt/widgets/instrumentview/src/PanelsSurface.cpp
@@ -674,7 +674,6 @@ Mantid::Kernel::Quat PanelsSurface::calcBankRotation(const Mantid::Kernel::V3D &
 }
 
 void PanelsSurface::addDetector(size_t detIndex, int bankIndex) {
-  const auto &detectorInfo = m_instrActor->detectorInfo();
   m_detector2bankMap[detIndex] = bankIndex;
   // get the colour
   UnwrappedDetector udet(m_instrActor->getColor(detIndex), detIndex);

--- a/qt/widgets/instrumentview/src/PanelsSurface.cpp
+++ b/qt/widgets/instrumentview/src/PanelsSurface.cpp
@@ -675,7 +675,6 @@ Mantid::Kernel::Quat PanelsSurface::calcBankRotation(const Mantid::Kernel::V3D &
 
 void PanelsSurface::addDetector(size_t detIndex, int bankIndex) {
   const auto &detectorInfo = m_instrActor->detectorInfo();
-  auto pos = detectorInfo.position(detIndex);
   m_detector2bankMap[detIndex] = bankIndex;
   // get the colour
   UnwrappedDetector udet(m_instrActor->getColor(detIndex), detIndex);

--- a/qt/widgets/instrumentview/src/PanelsSurface.cpp
+++ b/qt/widgets/instrumentview/src/PanelsSurface.cpp
@@ -279,10 +279,10 @@ void PanelsSurface::init() {
   m_v_max = m_viewRect.y1();
 }
 
-void PanelsSurface::project(const Mantid::Kernel::V3D & /*pos*/, double &u, double &v, double &uscale,
-                            double &vscale) const {
-  /* const auto &detectorInfo = m_instrActor->detectorInfo();
-  auto pos = detectorInfo.position(detIndex);
+void PanelsSurface::project(const size_t detIndex, double &u, double &v, double &uscale, double &vscale) const {
+  const auto &detectorInfo = m_instrActor->detectorInfo();
+  auto pos = detectorInfo.position(detIndex) - m_pos;
+  const int bankIndex = m_detector2bankMap[detIndex];
   const FlatBankInfo &info = *m_flatBanks[bankIndex];
   auto refPos = info.refPos;
   auto rotation = info.rotation;
@@ -291,7 +291,9 @@ void PanelsSurface::project(const Mantid::Kernel::V3D & /*pos*/, double &u, doub
   pos += refPos;
   u = m_xaxis.scalar_prod(pos);
   v = m_yaxis.scalar_prod(pos);
-  uscale = vscale = 1.0;*/
+  u += info.bankCentreOffset->X();
+  v += info.bankCentreOffset->Y();
+  uscale = vscale = 1.0;
 }
 
 void PanelsSurface::rotate(const UnwrappedDetector &udet, Mantid::Kernel::Quat &R) const {
@@ -715,6 +717,7 @@ void PanelsSurface::ApplyBankCentreOverrides() {
     if (info->bankCentreOverride) {
       auto overrideBankCentre = *info->bankCentreOverride;
       auto offset = overrideBankCentre - currentBankCentre;
+      info->bankCentreOffset = offset;
       info->polygon.translate(offset.X(), offset.Y());
       for (size_t iDet = info->startDetectorIndex; iDet <= info->endDetectorIndex; ++iDet) {
         UnwrappedDetector &udet = m_unwrappedDetectors[iDet];

--- a/qt/widgets/instrumentview/src/PeakOverlay.cpp
+++ b/qt/widgets/instrumentview/src/PeakOverlay.cpp
@@ -237,7 +237,6 @@ void PeakOverlay::createMarkers(const PeakMarker2D::Style &style) {
   this->clear();
   for (int i = 0; i < nPeaks; ++i) {
     Mantid::Geometry::IPeak &peak = getPeak(i);
-    Mantid::Kernel::V3D pos;
     int detID;
     try {
       auto peakFull = dynamic_cast<Mantid::DataObjects::Peak &>(peak);

--- a/qt/widgets/instrumentview/src/PeakOverlay.cpp
+++ b/qt/widgets/instrumentview/src/PeakOverlay.cpp
@@ -8,6 +8,7 @@
 #include "MantidAPI/AlgorithmManager.h"
 #include "MantidAPI/IPeaksWorkspace.h"
 #include "MantidDataObjects/Peak.h"
+#include "MantidGeometry/Instrument/DetectorInfo.h"
 #include "MantidQtWidgets/InstrumentView/UnwrappedSurface.h"
 
 #include <QList>
@@ -237,9 +238,10 @@ void PeakOverlay::createMarkers(const PeakMarker2D::Style &style) {
   for (int i = 0; i < nPeaks; ++i) {
     Mantid::Geometry::IPeak &peak = getPeak(i);
     Mantid::Kernel::V3D pos;
+    int detID;
     try {
       auto peakFull = dynamic_cast<Mantid::DataObjects::Peak &>(peak);
-      pos = peakFull.getDetPos();
+      detID = peakFull.getDetectorID();
     } catch (std::bad_cast &) {
       g_log.error("Cannot create markers for this type of peak");
       return;
@@ -247,7 +249,9 @@ void PeakOverlay::createMarkers(const PeakMarker2D::Style &style) {
     // Project the peak (detector) position onto u,v coords
     try {
       double u, v, uscale, vscale;
-      m_surface->project(pos, u, v, uscale, vscale);
+      auto &detInfo = m_peaksWorkspace->detectorInfo();
+      auto detIndex = detInfo.indexOf(detID);
+      m_surface->project(detIndex, u, v, uscale, vscale);
       // Create a peak marker at this position
       PeakMarker2D *r =
           new PeakMarker2D(*this, u, v, m_peakIntensityScale->getScaledMarker(peak.getIntensity(), style));

--- a/qt/widgets/instrumentview/src/RotationSurface.cpp
+++ b/qt/widgets/instrumentview/src/RotationSurface.cpp
@@ -122,14 +122,11 @@ void RotationSurface::createUnwrappedDetectors() {
         if (detectorInfo.isMonitor(i) || detIds[i] < 0) {
           m_unwrappedDetectors[i] = UnwrappedDetector();
         } else {
-          // A real detector.
-          // Position, relative to origin
-          auto rpos = detectorInfo.position(i) - m_pos;
           // Create the unwrapped shape
           UnwrappedDetector udet(m_instrActor->getColor(i), i);
           // Calculate its position/size in UV
           // coordinates
-          this->calcUV(udet, rpos);
+          this->calcUV(udet);
 
           m_unwrappedDetectors[i] = udet;
         } // is a real detector

--- a/qt/widgets/instrumentview/src/UnwrappedCylinder.cpp
+++ b/qt/widgets/instrumentview/src/UnwrappedCylinder.cpp
@@ -27,8 +27,9 @@ UnwrappedCylinder::UnwrappedCylinder(const InstrumentActor *rootActor, const Man
  * @param uscale :: scaling for u direction
  * @param vscale :: scaling for v direction
  */
-void UnwrappedCylinder::project(const Mantid::Kernel::V3D &pos, double &u, double &v, double &uscale,
-                                double &vscale) const {
+void UnwrappedCylinder::project(const size_t detIndex, double &u, double &v, double &uscale, double &vscale) const {
+  const auto &componentInfo = m_instrActor->componentInfo();
+  auto pos = componentInfo.position(detIndex) - m_pos;
   double z = pos.scalar_prod(m_zaxis);
   double x = pos.scalar_prod(m_xaxis);
   double y = pos.scalar_prod(m_yaxis);

--- a/qt/widgets/instrumentview/src/UnwrappedCylinder.cpp
+++ b/qt/widgets/instrumentview/src/UnwrappedCylinder.cpp
@@ -19,9 +19,9 @@ UnwrappedCylinder::UnwrappedCylinder(const InstrumentActor *rootActor, const Man
 }
 
 //------------------------------------------------------------------------------
-/** Convert physical position to UV projection
+/** Convert detector (physical position) to UV projection
  *
- * @param pos :: position in 3D
+ * @param detIndex :: detector index in DetectorInfo or ComponentInfo
  * @param u :: set to U
  * @param v :: set to V
  * @param uscale :: scaling for u direction

--- a/qt/widgets/instrumentview/src/UnwrappedSphere.cpp
+++ b/qt/widgets/instrumentview/src/UnwrappedSphere.cpp
@@ -19,9 +19,9 @@ UnwrappedSphere::UnwrappedSphere(const InstrumentActor *rootActor, const Mantid:
 }
 
 //------------------------------------------------------------------------------
-/** Convert physical position to UV projection
+/** Convert detector (physical position) to UV projection
  *
- * @param pos :: position in 3D
+ * @param detIndex :: detector index in DetectorInfo or ComponentInfo
  * @param u :: set to U
  * @param v :: set to V
  * @param uscale :: scaling for u direction

--- a/qt/widgets/instrumentview/src/UnwrappedSphere.cpp
+++ b/qt/widgets/instrumentview/src/UnwrappedSphere.cpp
@@ -27,8 +27,9 @@ UnwrappedSphere::UnwrappedSphere(const InstrumentActor *rootActor, const Mantid:
  * @param uscale :: scaling for u direction
  * @param vscale :: scaling for v direction
  */
-void UnwrappedSphere::project(const Mantid::Kernel::V3D &pos, double &u, double &v, double &uscale,
-                              double &vscale) const {
+void UnwrappedSphere::project(const size_t detIndex, double &u, double &v, double &uscale, double &vscale) const {
+  const auto &componentInfo = m_instrActor->componentInfo();
+  auto pos = componentInfo.position(detIndex) - m_pos;
   // projection to cylinder axis
   v = pos.scalar_prod(m_zaxis);
   double x = pos.scalar_prod(m_xaxis);

--- a/qt/widgets/instrumentview/src/UnwrappedSurface.cpp
+++ b/qt/widgets/instrumentview/src/UnwrappedSurface.cpp
@@ -666,8 +666,8 @@ void UnwrappedSurface::zoom() {
  * @param udet :: detector to unwrap.
  * @param pos :: detector position relative to the sample origin
  */
-void UnwrappedSurface::calcUV(UnwrappedDetector &udet, Mantid::Kernel::V3D &pos) {
-  this->project(pos, udet.u, udet.v, udet.uscale, udet.vscale);
+void UnwrappedSurface::calcUV(UnwrappedDetector &udet) {
+  this->project(udet.detIndex, udet.u, udet.v, udet.uscale, udet.vscale);
   calcSize(udet);
 }
 

--- a/qt/widgets/instrumentview/test/InstrumentWidget/PanelsSurfaceTest.h
+++ b/qt/widgets/instrumentview/test/InstrumentWidget/PanelsSurfaceTest.h
@@ -24,7 +24,7 @@ public:
       : PanelsSurface(rootActor, origin, axis, widgetSize, maintainAspectRatio) {}
   PanelsSurfaceHelper() : PanelsSurface() {}
   void setupAxes() { PanelsSurface::setupAxes(); };
-  void project(const size_t detIndex, double &u, double &v, double &uscale, double &vscale) {
+  void project(const size_t detIndex, double &u, double &v, double &uscale, double &vscale) const override {
     PanelsSurface::project(detIndex, u, v, uscale, vscale);
   }
   Mantid::Kernel::Quat calcBankRotation(const Mantid::Kernel::V3D &detPos, Mantid::Kernel::V3D normal) {


### PR DESCRIPTION
**Description of work.**

Enable the peak overlay functionality in the side by side view. This will be useful for the SXD instrument.

This feature is currently only enabled in the Spherical and Cylindrical projected views.

The code change involved changing the signature of the `UnwrappedSurface::project()` function to pass in the detector id instead of the detector position. This is necessary because the transformation performed in the side by side view projection is bit different to the spherical\cylindrical projections in that it doesn't just depend on the position of the detector being transformed. It also depends on the position of the corner of the bank that the detector is in. Both can be determined from a detector id.

**To test:**

Run the script and steps described on https://github.com/mantidproject/mantid/issues/34365 and verify that the single peak displayed sits on the detector specified in the script by moving to the Pick tab (32615 on bank 8).

Edit the SXD_Definition.xml instrument definition file and remove the side-by-side-view-location tags. Restart workbench and repeat the test.  The SXD banks should now be displayed in different positions in the side by side view. Verify that the peak is still shown on detector 32615 on bank 8 even though the bank is now in a different position. The purpose of this part of the test is to check the change will work for other instruments that don't have the bank centre overrides specified in the IDF

*There is no associated issue.*

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
