### PR TITLE
Add `--debug` flag for package-conda script

### DIFF
--- a/buildconfig/Jenkins/Conda/package-conda
+++ b/buildconfig/Jenkins/Conda/package-conda
@@ -104,8 +104,11 @@ if [[ -d $CONDA_BLD_PATH ]]; then
 fi
 cd $RECIPES_DIR
 
+# Add the '--debug' option to EXTRA_BUILD_OPTIONS if you want conda build to provide verbose debug info
+EXTRA_BUILD_OPTIONS="--debug "
+
 if [[ $OSTYPE == "msys" ]]; then
-    EXTRA_BUILD_OPTIONS="--no-build-id" # Do not use build id as it makes the path too long (>260 chars) for CMake (Legacy Windows API issue)
+    EXTRA_BUILD_OPTIONS+="--no-build-id" # Do not use build id as it makes the path too long (>260 chars) for CMake (Legacy Windows API issue)
 fi
 
 if [[ $ENABLE_BUILD_MANTID == true ]]; then


### PR DESCRIPTION
**Description of work.**
This PR adds a `--debug` flag for the `buildconfig/Jenkins/Conda/package-conda` bash script. When given the `--debug` flag, the `package-conda` script should print debug information when doing a conda build. This debug information would be useful for issues such as those seen in the following builds, which do not provide much info:

Here is a Linux example
https://builds.mantidproject.org/view/Nightly%20Pipelines/job/main_nightly_deployment_prototype/510/execution/node/289/log/
Here is a Windows example
https://builds.mantidproject.org/view/Nightly%20Pipelines/job/main_nightly_deployment_prototype/510/execution/node/216/log/

**To test:**

<!-- Instructions for testing. -->

*There is no associated issue.*

*This does not require release notes* because **its an internal change**

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
