### PR TITLE
Run operator iadd

### DIFF
--- a/Framework/API/src/Run.cpp
+++ b/Framework/API/src/Run.cpp
@@ -108,8 +108,8 @@ void Run::filterByTime(const Types::Core::DateAndTime start, const Types::Core::
 }
 
 namespace {
-void findAndCombineTimeStrProp(const Run *runObjLHS, const Run *runObjRHS, const std::string &firstSuggestion,
-                               const std::string &secondSuggestion, std::string &propName, std::string &propValue) {
+void findAndConcatenateTimeStrProp(const Run *runObjLHS, const Run *runObjRHS, const std::string &firstSuggestion,
+                                   const std::string &secondSuggestion, std::string &propName, std::string &propValue) {
   // get the name/value from the right-hand-side
   // this should get overwritten below by the left
   std::string rhsValue;
@@ -189,8 +189,8 @@ Run &Run::operator+=(const Run &rhs) {
   std::string startTimePropValue;
   std::string endTimePropName;
   std::string endTimePropValue;
-  findAndCombineTimeStrProp(this, &rhs, "start_time", "start_run", startTimePropName, startTimePropValue);
-  findAndCombineTimeStrProp(this, &rhs, "end_time", "run_end", endTimePropName, endTimePropValue);
+  findAndConcatenateTimeStrProp(this, &rhs, "start_time", "start_run", startTimePropName, startTimePropValue);
+  findAndConcatenateTimeStrProp(this, &rhs, "end_time", "run_end", endTimePropName, endTimePropValue);
 
   // merge and copy properties where there is no risk of corrupting data
   mergeMergables(*m_manager, *rhs.m_manager);


### PR DESCRIPTION
In preparation of other work, this adds behavior for merging two `Run` objects that have `TimeROI` set on them.

**To test:**

Reviewing the changeset is the best way to verify the code.

This is part of #34794.

*This does not require release notes* because it is part of the larger course of work to refactor event filtering.

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
