### PR TITLE
Updated Polarization Efficiencies error for PolRef

### DIFF
--- a/Framework/DataHandling/src/ExtractPolarizationEfficiencies.cpp
+++ b/Framework/DataHandling/src/ExtractPolarizationEfficiencies.cpp
@@ -98,7 +98,7 @@ void ExtractPolarizationEfficiencies::exec() {
   auto instrument = inputWS->getInstrument();
   auto const method = instrument->getParameterAsString(METHOD_PARAMETER);
   if (method.empty()) {
-    throw std::invalid_argument("Correction method is undefined");
+    throw std::invalid_argument("Polarization Efficiencies method is not provided by the instrument parameter file");
   }
   if (method != METHOD_FREDRIKZE && method != METHOD_WILDES) {
     throw std::invalid_argument("Unknown correction method: " + method);

--- a/docs/source/release/v6.7.0/Reflectometry/Bugfixes/34812.rst
+++ b/docs/source/release/v6.7.0/Reflectometry/Bugfixes/34812.rst
@@ -1,1 +1,1 @@
-- Changed the error message when the Polarization Corrections for PolRef are set using the Parameter File. The error now explains the required information is missing.
+- Changed the error message when the Polarization Corrections are set using a Parameter File without the necessary settings defined. The error now explains the required information is missing.

--- a/docs/source/release/v6.7.0/Reflectometry/Bugfixes/34812.rst
+++ b/docs/source/release/v6.7.0/Reflectometry/Bugfixes/34812.rst
@@ -1,0 +1,1 @@
+- Changed the error message when the Polarization Corrections for PolRef are set using the Parameter File. The error now explains the required information is missing.


### PR DESCRIPTION
**Description of work.**

Changes we made to the Reflectometry GUI to enable Polarization Corrections to be selected from a drop down menu of choices. However POLREF paramaters file does not contain any Polarization Efficiencies corrections. The error message that was being returned was not helpful for users and so this has been updated to make it clearer.

This error message is already tested - see https://github.com/mantidproject/mantid/blob/main/Framework/DataHandling/test/ExtractPolarizationEfficienciesTest.h#L56

**To test:**
1. Open Mantid
2. Open `Reflectometry->ISIS Reflectometry` GUI
3. Change Instrument to `PoleRef`
4. On the Runs tab add the run `31835` and give it the angle `1.0`
5. Click the process button
6. An error should appear on the right hand side explaining that the efficiencies were not available in the parameter file.


Fixes #34812 



---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
