### PR TITLE
Update LogManager assignment operator

### DIFF
--- a/Framework/Kernel/inc/MantidKernel/FilteredTimeSeriesProperty.h
+++ b/Framework/Kernel/inc/MantidKernel/FilteredTimeSeriesProperty.h
@@ -81,6 +81,9 @@ public:
 
   const Kernel::TimeROI &getTimeROI() const;
 
+  bool operator==(const TimeSeriesProperty<HeldType> &right) const override;
+  bool operator==(const Property &right) const override;
+
 private:
   /// Apply a filter
   void applyFilter() const;

--- a/Framework/Kernel/src/FilteredTimeSeriesProperty.cpp
+++ b/Framework/Kernel/src/FilteredTimeSeriesProperty.cpp
@@ -422,6 +422,37 @@ std::vector<SplittingInterval> FilteredTimeSeriesProperty<TYPE>::getSplittingInt
   }
 }
 
+template <typename HeldType>
+bool FilteredTimeSeriesProperty<HeldType>::operator==(const TimeSeriesProperty<HeldType> &right) const {
+  const bool time_and_value_compare = TimeSeriesProperty<HeldType>::operator==(right);
+  if (!time_and_value_compare) {
+    // unfiltered doesn't match
+    return false;
+  } else {
+    // only need to compare the filters
+    const auto rhs_ftsp = dynamic_cast<const FilteredTimeSeriesProperty<HeldType> *>(&right);
+    if (m_filter->empty()) {
+      if (!rhs_ftsp) {
+        // simple compare is fine
+        return time_and_value_compare;
+      } else {
+        // can't compare filters
+        return false;
+      }
+    } else {
+      // only need to compare filters
+      return m_filter == rhs_ftsp->m_filter;
+    }
+  }
+}
+
+template <typename HeldType> bool FilteredTimeSeriesProperty<HeldType>::operator==(const Property &right) const {
+  auto rhs_tsp = dynamic_cast<const TimeSeriesProperty<HeldType> *>(&right);
+  if (!rhs_tsp)
+    return false;
+  return this->operator==(*rhs_tsp);
+}
+
 /// @cond
 // -------------------------- Macro to instantiation concrete types
 // --------------------------------


### PR DESCRIPTION
Do not merge before #35168

In previous PRs the assignment operator and comparison operator for `LogManager` wasn't updated to account for `TimeROI`. This fixes that issue.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**

Code review is most appropriate.

Refs #34794.

*This does not require release notes* because it is accounted for in the larger filter events work.

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
