### PR TITLE
Improve sample shape plotting performance

### DIFF
--- a/docs/source/release/v6.7.0/Workbench/Bugfixes/35369.rst
+++ b/docs/source/release/v6.7.0/Workbench/Bugfixes/35369.rst
@@ -1,0 +1,1 @@
+- the performance of the Show Sample Shape screen has been improved for workspaces with complex CSG shapes for either the sample or container

--- a/qt/python/mantidqt/mantidqt/plotting/sample_shape.py
+++ b/qt/python/mantidqt/mantidqt/plotting/sample_shape.py
@@ -197,10 +197,11 @@ def is_mesh_not_empty(mesh):
         return True
 
 
-def get_valid_sample_shape_from_workspace(workspace):
+def get_valid_sample_mesh_from_workspace(workspace):
     sample_shape = get_sample_shape_from_workspace(workspace)
-    if is_shape_valid(sample_shape):
-        return sample_shape
+    mesh = sample_shape.getMesh()
+    if is_mesh_not_empty(mesh):
+        return mesh
 
 
 def does_workspace_have_valid_sample_shape(workspace):
@@ -216,10 +217,11 @@ def get_sample_shape_from_workspace(workspace_with_sample):
         return workspace_with_sample.sample().getShape()
 
 
-def get_valid_container_shape_from_workspace(workspace):
+def get_valid_container_mesh_from_workspace(workspace):
     container_shape = get_container_shape_from_workspace(workspace)
-    if is_shape_valid(container_shape):
-        return container_shape
+    mesh = container_shape.getMesh()
+    if is_mesh_not_empty(mesh):
+        return mesh
 
 
 def get_container_shape_from_workspace(workspace_with_container):
@@ -227,10 +229,11 @@ def get_container_shape_from_workspace(workspace_with_container):
         return workspace_with_container.sample().getEnvironment().getContainer().getShape()
 
 
-def get_valid_component_shape_from_workspace(workspace, component_index):
+def get_valid_component_mesh_from_workspace(workspace, component_index):
     component_shape = get_component_shape_from_workspace(workspace, component_index)
-    if is_shape_valid(component_shape):
-        return component_shape
+    mesh = component_shape.getMesh()
+    if is_mesh_not_empty(mesh):
+        return mesh
 
 
 def get_component_shape_from_workspace(workspace_with_components, component_index):
@@ -241,9 +244,8 @@ def get_component_shape_from_workspace(workspace_with_components, component_inde
 def plot_sample_only(workspace, figure):
     axes = figure.gca()
     # get shape and mesh vertices
-    shape = get_valid_sample_shape_from_workspace(workspace)
-    if shape:
-        mesh = shape.getMesh()
+    mesh = get_valid_sample_mesh_from_workspace(workspace)
+    if mesh is not None:
         if len(mesh) < 13:
             face_colors = [
                 "purple",
@@ -271,8 +273,7 @@ def plot_sample_only(workspace, figure):
 
 def plot_container(workspace, figure):
     axes = figure.gca()
-    container_shape = get_valid_container_shape_from_workspace(workspace)
-    container_mesh = container_shape.getMesh()
+    container_mesh = get_valid_container_mesh_from_workspace(workspace)
     mesh_polygon = Poly3DCollection(container_mesh, edgecolors="black", alpha=0.1, linewidths=0.05, zorder=0.5)
     mesh_polygon.set_facecolor((0, 1, 0, 0.5))
     axes.add_collection3d(mesh_polygon)
@@ -283,8 +284,7 @@ def plot_components(workspace, figure):
     axes = figure.gca()
     number_of_components = workspace.sample().getEnvironment().nelements()
     for component_index in range(1, number_of_components):
-        component_shape = get_valid_component_shape_from_workspace(workspace, component_index)
-        component_mesh = component_shape.getMesh()
+        component_mesh = get_valid_component_mesh_from_workspace(workspace, component_index)
         mesh_polygon_loop = Poly3DCollection(component_mesh, edgecolors="black", alpha=0.1, linewidths=0.05, zorder=0.5)
         mesh_polygon_loop.set_facecolor((0, 0, 1, 0.5))
         axes.add_collection3d(mesh_polygon_loop)
@@ -369,18 +369,18 @@ def set_axes_to_largest_mesh(axes, workspace):
 
 def overall_limits_for_all_meshes(workspace, include_components=True):
     overall_limits = None
-    sample_shape = get_valid_sample_shape_from_workspace(workspace)
-    if sample_shape:
-        overall_limits = overall_limits_for_every_axis(sample_shape.getMesh())
+    sample_mesh = get_valid_sample_mesh_from_workspace(workspace)
+    if sample_mesh is not None:
+        overall_limits = overall_limits_for_every_axis(sample_mesh)
     if workspace.sample():
         if include_components and workspace.sample().hasEnvironment():
             environment = workspace.sample().getEnvironment()
             number_of_components = environment.nelements()
             for component_index in range(number_of_components):
                 if component_index == 0:  # Container
-                    loop_component_mesh = get_valid_container_shape_from_workspace(workspace).getMesh()
+                    loop_component_mesh = get_valid_container_mesh_from_workspace(workspace)
                 else:
-                    loop_component_mesh = get_valid_component_shape_from_workspace(workspace, component_index).getMesh()
+                    loop_component_mesh = get_valid_component_mesh_from_workspace(workspace, component_index)
                 current_mesh_limits = overall_limits_for_every_axis(loop_component_mesh)
                 overall_limits = greater_limits(current_mesh_limits, overall_limits)
         return overall_limits

--- a/qt/python/mantidqt/mantidqt/plotting/sample_shape.py
+++ b/qt/python/mantidqt/mantidqt/plotting/sample_shape.py
@@ -64,7 +64,15 @@ class SampleShapePlot:
     def create_plot(self, workspace_name, figure=None, test=None):
         self.workspace_name = workspace_name
         workspace = ADS.retrieve(workspace_name)
-        if not does_workspace_have_valid_sample_shape(workspace) and not workspace.sample().hasEnvironment():
+        sample_mesh = get_valid_sample_mesh_from_workspace(workspace)
+        container_mesh = get_valid_container_mesh_from_workspace(workspace)
+        component_meshes = []
+        if workspace.sample().hasEnvironment():
+            number_of_components = workspace.sample().getEnvironment().nelements()
+            for component_index in range(1, number_of_components):
+                component_mesh = get_valid_component_mesh_from_workspace(workspace, component_index)
+                component_meshes.append(component_mesh)
+        if sample_mesh is None and container_mesh is None and not component_meshes:
             raise Exception("Workspace must have attached Sample Shape or Environment")
         if figure:
             axes = figure.gca()
@@ -72,12 +80,14 @@ class SampleShapePlot:
             self.plot_visible = True
             figure, axes = plt.subplots(subplot_kw={"projection": "mantid3d", "proj_type": "ortho"})
 
-        sample_plotted, container_plotted, components_plotted = try_to_plot_all_sample_shapes(workspace, figure)
+        sample_plotted, container_plotted, components_plotted = try_to_plot_all_sample_shapes(
+            figure, sample_mesh, container_mesh, component_meshes
+        )
         if int(sample_plotted) + int(container_plotted) + int(components_plotted) == 0:
             raise Exception("Workspace has no valid Sample, Container or Component Shapes to plot")
 
         add_title(sample_plotted, container_plotted, components_plotted, axes, workspace_name)
-        set_axes_to_largest_mesh(axes, workspace)
+        set_axes_to_largest_mesh(axes, sample_mesh, container_mesh, component_meshes)
         self.beam_direction = set_perspective(axes, workspace=workspace)
         set_axes_labels(axes)
         add_beam_arrow(axes, workspace)
@@ -176,20 +186,14 @@ def plot_sample_container_and_components(workspace_name, test=None):
     return new_plot.create_plot(workspace_name, test=test)
 
 
-def try_to_plot_all_sample_shapes(workspace, figure):
+def try_to_plot_all_sample_shapes(figure, sample_mesh, container_mesh, component_meshes):
     container_plotted = components_plotted = False
-    sample_plotted = plot_sample_only(workspace, figure)
-    if workspace.sample().hasEnvironment():
-        container_plotted = plot_container(workspace, figure)
-        number_of_components = workspace.sample().getEnvironment().nelements()
-        if number_of_components > 1:  # the first component is the container
-            components_plotted = plot_components(workspace, figure)
+    sample_plotted = plot_sample_only(figure, sample_mesh)
+    if container_mesh is not None:
+        container_plotted = plot_container(figure, container_mesh)
+    if component_meshes:
+        components_plotted = plot_components(figure, component_meshes)
     return sample_plotted, container_plotted, components_plotted
-
-
-def is_shape_valid(shape):
-    if is_mesh_not_empty(shape.getMesh()):
-        return True
 
 
 def is_mesh_not_empty(mesh):
@@ -199,17 +203,10 @@ def is_mesh_not_empty(mesh):
 
 def get_valid_sample_mesh_from_workspace(workspace):
     sample_shape = get_sample_shape_from_workspace(workspace)
-    mesh = sample_shape.getMesh()
-    if is_mesh_not_empty(mesh):
-        return mesh
-
-
-def does_workspace_have_valid_sample_shape(workspace):
-    if not workspace.sample().hasShape():
-        return False
-    sample_shape = get_sample_shape_from_workspace(workspace)
-    if is_shape_valid(sample_shape):
-        return True
+    if sample_shape:
+        mesh = sample_shape.getMesh()
+        if is_mesh_not_empty(mesh):
+            return mesh
 
 
 def get_sample_shape_from_workspace(workspace_with_sample):
@@ -218,10 +215,11 @@ def get_sample_shape_from_workspace(workspace_with_sample):
 
 
 def get_valid_container_mesh_from_workspace(workspace):
-    container_shape = get_container_shape_from_workspace(workspace)
-    mesh = container_shape.getMesh()
-    if is_mesh_not_empty(mesh):
-        return mesh
+    if workspace.sample().hasEnvironment():
+        container_shape = get_container_shape_from_workspace(workspace)
+        mesh = container_shape.getMesh()
+        if is_mesh_not_empty(mesh):
+            return mesh
 
 
 def get_container_shape_from_workspace(workspace_with_container):
@@ -241,10 +239,8 @@ def get_component_shape_from_workspace(workspace_with_components, component_inde
         return workspace_with_components.sample().getEnvironment().getComponent(component_index)
 
 
-def plot_sample_only(workspace, figure):
+def plot_sample_only(figure, mesh):
     axes = figure.gca()
-    # get shape and mesh vertices
-    mesh = get_valid_sample_mesh_from_workspace(workspace)
     if mesh is not None:
         if len(mesh) < 13:
             face_colors = [
@@ -271,20 +267,17 @@ def plot_sample_only(workspace, figure):
         return False
 
 
-def plot_container(workspace, figure):
+def plot_container(figure, container_mesh):
     axes = figure.gca()
-    container_mesh = get_valid_container_mesh_from_workspace(workspace)
     mesh_polygon = Poly3DCollection(container_mesh, edgecolors="black", alpha=0.1, linewidths=0.05, zorder=0.5)
     mesh_polygon.set_facecolor((0, 1, 0, 0.5))
     axes.add_collection3d(mesh_polygon)
     return True
 
 
-def plot_components(workspace, figure):
+def plot_components(figure, component_meshes):
     axes = figure.gca()
-    number_of_components = workspace.sample().getEnvironment().nelements()
-    for component_index in range(1, number_of_components):
-        component_mesh = get_valid_component_mesh_from_workspace(workspace, component_index)
+    for component_mesh in component_meshes:
         mesh_polygon_loop = Poly3DCollection(component_mesh, edgecolors="black", alpha=0.1, linewidths=0.05, zorder=0.5)
         mesh_polygon_loop.set_facecolor((0, 0, 1, 0.5))
         axes.add_collection3d(mesh_polygon_loop)
@@ -361,29 +354,23 @@ def call_set_mesh_axes_equal(axes, mesh):
     axes.set_mesh_axes_equal(mesh)
 
 
-def set_axes_to_largest_mesh(axes, workspace):
-    overall_limits = overall_limits_for_all_meshes(workspace)
+def set_axes_to_largest_mesh(axes, sample_mesh, container_mesh=None, component_meshes=[]):
+    overall_limits = overall_limits_for_all_meshes(sample_mesh, container_mesh, component_meshes)
     call_set_mesh_axes_equal(axes, np.array(overall_limits))
     axes.set_box_aspect((1, 1, 1))  # when upgraded to matplotlib 3.6 use axes.set_aspect('equal')
 
 
-def overall_limits_for_all_meshes(workspace, include_components=True):
+def overall_limits_for_all_meshes(sample_mesh, container_mesh=None, component_meshes=[]):
     overall_limits = None
-    sample_mesh = get_valid_sample_mesh_from_workspace(workspace)
     if sample_mesh is not None:
         overall_limits = overall_limits_for_every_axis(sample_mesh)
-    if workspace.sample():
-        if include_components and workspace.sample().hasEnvironment():
-            environment = workspace.sample().getEnvironment()
-            number_of_components = environment.nelements()
-            for component_index in range(number_of_components):
-                if component_index == 0:  # Container
-                    loop_component_mesh = get_valid_container_mesh_from_workspace(workspace)
-                else:
-                    loop_component_mesh = get_valid_component_mesh_from_workspace(workspace, component_index)
-                current_mesh_limits = overall_limits_for_every_axis(loop_component_mesh)
-                overall_limits = greater_limits(current_mesh_limits, overall_limits)
-        return overall_limits
+    if container_mesh is not None:
+        current_mesh_limits = overall_limits_for_every_axis(container_mesh)
+        overall_limits = greater_limits(current_mesh_limits, overall_limits)
+    for component_mesh in component_meshes:
+        current_mesh_limits = overall_limits_for_every_axis(component_mesh)
+        overall_limits = greater_limits(current_mesh_limits, overall_limits)
+    return overall_limits
 
 
 def overall_limits_for_every_axis(mesh):

--- a/qt/python/mantidqt/mantidqt/plotting/sample_shape.py
+++ b/qt/python/mantidqt/mantidqt/plotting/sample_shape.py
@@ -66,12 +66,7 @@ class SampleShapePlot:
         workspace = ADS.retrieve(workspace_name)
         sample_mesh = get_valid_sample_mesh_from_workspace(workspace)
         container_mesh = get_valid_container_mesh_from_workspace(workspace)
-        component_meshes = []
-        if workspace.sample().hasEnvironment():
-            number_of_components = workspace.sample().getEnvironment().nelements()
-            for component_index in range(1, number_of_components):
-                component_mesh = get_valid_component_mesh_from_workspace(workspace, component_index)
-                component_meshes.append(component_mesh)
+        component_meshes = get_valid_component_meshes_from_workspace(workspace)
         if sample_mesh is None and container_mesh is None and not component_meshes:
             raise Exception("Workspace must have attached Sample Shape or Environment")
         if figure:
@@ -227,11 +222,16 @@ def get_container_shape_from_workspace(workspace_with_container):
         return workspace_with_container.sample().getEnvironment().getContainer().getShape()
 
 
-def get_valid_component_mesh_from_workspace(workspace, component_index):
-    component_shape = get_component_shape_from_workspace(workspace, component_index)
-    mesh = component_shape.getMesh()
-    if is_mesh_not_empty(mesh):
-        return mesh
+def get_valid_component_meshes_from_workspace(workspace):
+    component_meshes = []
+    if workspace.sample().hasEnvironment():
+        number_of_components = workspace.sample().getEnvironment().nelements()
+        for component_index in range(1, number_of_components):
+            component_shape = get_component_shape_from_workspace(workspace, component_index)
+            component_mesh = component_shape.getMesh()
+            if is_mesh_not_empty(component_mesh):
+                component_meshes.append(component_mesh)
+    return component_meshes
 
 
 def get_component_shape_from_workspace(workspace_with_components, component_index):

--- a/qt/python/mantidqt/mantidqt/plotting/test/test_sample_shape.py
+++ b/qt/python/mantidqt/mantidqt/plotting/test/test_sample_shape.py
@@ -116,42 +116,42 @@ class PlotSampleShapeTest(TestCase):
     def test_CSG_merged_shape_is_valid(self):
         workspace = setup_workspace_shape_from_CSG_merged()
         self.assertTrue(workspace.sample().getShape())
-        self.assertTrue(sample_shape.get_valid_sample_shape_from_workspace(workspace))
+        self.assertTrue(sample_shape.get_valid_sample_mesh_from_workspace(workspace) is not None)
 
     def test_CSG_sphere_is_valid(self):
         workspace = CreateSampleWorkspace(OutputWorkspace="ws_shape")
         self.assertTrue(workspace.sample().getShape())
-        self.assertTrue(sample_shape.get_valid_sample_shape_from_workspace(workspace))
+        self.assertTrue(sample_shape.get_valid_sample_mesh_from_workspace(workspace) is not None)
 
     def test_CSG_empty_shape_is_not_valid(self):
         workspace = CreateWorkspace(OutputWorkspace="ws_shape", DataX=[1, 1], DataY=[2, 2])
         self.assertTrue(workspace.sample().getShape())
-        self.assertFalse(sample_shape.get_valid_sample_shape_from_workspace(workspace))
+        self.assertFalse(sample_shape.get_valid_sample_mesh_from_workspace(workspace))
 
     def test_mesh_is_valid(self):
         workspace = setup_workspace_shape_from_mesh()
         self.assertTrue(workspace.sample().getShape())
-        self.assertTrue(sample_shape.get_valid_sample_shape_from_workspace(workspace))
+        self.assertTrue(sample_shape.get_valid_sample_mesh_from_workspace(workspace) is not None)
 
     def test_container_valid(self):
         workspace = setup_workspace_container_CSG()
-        self.assertTrue(sample_shape.get_valid_container_shape_from_workspace(workspace))
+        self.assertTrue(sample_shape.get_valid_container_mesh_from_workspace(workspace) is not None)
 
     @patch("mantidqt.plotting.sample_shape.is_mesh_not_empty")
     def test_container_invalid(self, mock_is_mesh_not_empty):
         workspace = setup_workspace_sample_container_and_components_from_mesh()
         mock_is_mesh_not_empty.return_value = False
-        self.assertFalse(sample_shape.get_valid_container_shape_from_workspace(workspace))
+        self.assertFalse(sample_shape.get_valid_container_mesh_from_workspace(workspace))
 
     def test_component_valid(self):
         workspace = setup_workspace_sample_container_and_components_from_mesh()
-        self.assertTrue(sample_shape.get_valid_component_shape_from_workspace(workspace, 1))
+        self.assertTrue(sample_shape.get_valid_component_mesh_from_workspace(workspace, 1) is not None)
 
     @patch("mantidqt.plotting.sample_shape.is_mesh_not_empty")
     def test_component_invalid(self, mock_is_mesh_not_empty):
         workspace = setup_workspace_sample_container_and_components_from_mesh()
         mock_is_mesh_not_empty.return_value = False
-        self.assertFalse(sample_shape.get_valid_container_shape_from_workspace(workspace))
+        self.assertFalse(sample_shape.get_valid_container_mesh_from_workspace(workspace))
 
     def test_plot_created_for_CSG_sphere_sample_only(self):
         CreateSampleWorkspace(OutputWorkspace="ws_shape")
@@ -260,7 +260,6 @@ class PlotSampleShapeTest(TestCase):
         assert_allclose([-0.1, -0.099993, -0.15, 0.1, 0.099993, 0.15], minmax_xyz, rtol=self.RELATIVE_TOLERANCE)
 
     def test_overall_limits_for_every_axis(self):
-
         mesh_points = np.array([np.array([3, 5, 1]), np.array([4, 7, 8]), np.array([5, 6, 9]), np.array([3, 4, 5])])
         self.assertEqual([3, 4, 1, 5, 7, 9], sample_shape.overall_limits_for_every_axis(mesh_points))
 
@@ -382,9 +381,9 @@ class PlotSampleShapeTest(TestCase):
         )
 
     @patch("mantidqt.plotting.sample_shape.overall_limits_for_every_axis")
-    @patch("mantidqt.plotting.sample_shape.get_valid_component_shape_from_workspace")
-    @patch("mantidqt.plotting.sample_shape.get_valid_container_shape_from_workspace")
-    @patch("mantidqt.plotting.sample_shape.get_valid_sample_shape_from_workspace")
+    @patch("mantidqt.plotting.sample_shape.get_valid_component_mesh_from_workspace")
+    @patch("mantidqt.plotting.sample_shape.get_valid_container_mesh_from_workspace")
+    @patch("mantidqt.plotting.sample_shape.get_valid_sample_mesh_from_workspace")
     def test_overall_limits_calls_get_valid_shape_methods(
         self, mock_get_valid_sample, mock_get_valid_container, mock_get_valid_component, mock_overall_limits
     ):

--- a/qt/python/mantidqt/mantidqt/plotting/test/test_sample_shape.py
+++ b/qt/python/mantidqt/mantidqt/plotting/test/test_sample_shape.py
@@ -115,67 +115,67 @@ class PlotSampleShapeTest(TestCase):
 
     def test_CSG_merged_shape_is_valid(self):
         workspace = setup_workspace_shape_from_CSG_merged()
-        self.assertTrue(workspace.sample().getShape())
-        self.assertTrue(sample_shape.get_valid_sample_mesh_from_workspace(workspace) is not None)
+        self.assertIsNotNone(workspace.sample().getShape())
+        self.assertIsNotNone(sample_shape.get_valid_sample_mesh_from_workspace(workspace))
 
     def test_CSG_sphere_is_valid(self):
         workspace = CreateSampleWorkspace(OutputWorkspace="ws_shape")
-        self.assertTrue(workspace.sample().getShape())
-        self.assertTrue(sample_shape.get_valid_sample_mesh_from_workspace(workspace) is not None)
+        self.assertIsNotNone(workspace.sample().getShape())
+        self.assertIsNotNone(sample_shape.get_valid_sample_mesh_from_workspace(workspace))
 
     def test_CSG_empty_shape_is_not_valid(self):
         workspace = CreateWorkspace(OutputWorkspace="ws_shape", DataX=[1, 1], DataY=[2, 2])
-        self.assertTrue(workspace.sample().getShape())
-        self.assertFalse(sample_shape.get_valid_sample_mesh_from_workspace(workspace))
+        self.assertIsNotNone(workspace.sample().getShape())
+        self.assertIsNone(sample_shape.get_valid_sample_mesh_from_workspace(workspace))
 
     def test_mesh_is_valid(self):
         workspace = setup_workspace_shape_from_mesh()
-        self.assertTrue(workspace.sample().getShape())
-        self.assertTrue(sample_shape.get_valid_sample_mesh_from_workspace(workspace) is not None)
+        self.assertIsNotNone(workspace.sample().getShape())
+        self.assertIsNotNone(sample_shape.get_valid_sample_mesh_from_workspace(workspace))
 
     def test_container_valid(self):
         workspace = setup_workspace_container_CSG()
-        self.assertTrue(sample_shape.get_valid_container_mesh_from_workspace(workspace) is not None)
+        self.assertIsNotNone(sample_shape.get_valid_container_mesh_from_workspace(workspace))
 
     @patch("mantidqt.plotting.sample_shape.is_mesh_not_empty")
     def test_container_invalid(self, mock_is_mesh_not_empty):
         workspace = setup_workspace_sample_container_and_components_from_mesh()
         mock_is_mesh_not_empty.return_value = False
-        self.assertFalse(sample_shape.get_valid_container_mesh_from_workspace(workspace))
+        self.assertIsNone(sample_shape.get_valid_container_mesh_from_workspace(workspace))
 
     def test_component_valid(self):
         workspace = setup_workspace_sample_container_and_components_from_mesh()
-        self.assertTrue(sample_shape.get_valid_component_mesh_from_workspace(workspace, 1) is not None)
+        self.assertIsNotNone(sample_shape.get_valid_component_mesh_from_workspace(workspace, 1))
 
     @patch("mantidqt.plotting.sample_shape.is_mesh_not_empty")
     def test_component_invalid(self, mock_is_mesh_not_empty):
         workspace = setup_workspace_sample_container_and_components_from_mesh()
         mock_is_mesh_not_empty.return_value = False
-        self.assertFalse(sample_shape.get_valid_container_mesh_from_workspace(workspace))
+        self.assertIsNone(sample_shape.get_valid_container_mesh_from_workspace(workspace))
 
     def test_plot_created_for_CSG_sphere_sample_only(self):
         CreateSampleWorkspace(OutputWorkspace="ws_shape")
         shape_plot = sample_shape.plot_sample_container_and_components("ws_shape")
-        self.assertTrue(shape_plot)
+        self.assertIsNotNone(shape_plot)
 
     def test_plot_created_for_CSG_merged_sample_only(self):
         workspace = setup_workspace_shape_from_CSG_merged()
         shape_plot = sample_shape.plot_sample_container_and_components(workspace.name())
-        self.assertTrue(shape_plot)
+        self.assertIsNotNone(shape_plot)
 
     def test_plot_created_for_mesh_sample_only(self):
         workspace = setup_workspace_shape_from_mesh()
         shape_plot_axes = sample_shape.plot_sample_container_and_components(workspace.name())
-        self.assertTrue(shape_plot_axes)
+        self.assertIsNotNone(shape_plot_axes)
 
     def test_plot_created_for_mesh_container_and_components(self):
         workspace = setup_workspace_sample_container_and_components_from_mesh()
         shape_plot_figure = sample_shape.plot_sample_container_and_components(workspace.name())
-        self.assertTrue(shape_plot_figure)
+        self.assertIsNotNone(shape_plot_figure)
         container_added_to_plot = sample_shape.plot_container(workspace, shape_plot_figure)
         components_added_to_plot = sample_shape.plot_components(workspace, shape_plot_figure)
-        self.assertTrue(container_added_to_plot)
-        self.assertTrue(components_added_to_plot)
+        self.assertIsNotNone(container_added_to_plot)
+        self.assertIsNotNone(components_added_to_plot)
 
     @patch("mantidqt.plotting.sample_shape.set_perspective")
     @patch("mantidqt.plotting.sample_shape.set_axes_labels")
@@ -274,19 +274,19 @@ class PlotSampleShapeTest(TestCase):
     def test_sample_valid_and_container_invalid(self):
         workspace = setup_workspace_shape_from_CSG_merged()
         figure = sample_shape.plot_sample_container_and_components(workspace.name())
-        self.assertTrue(figure)
+        self.assertIsNotNone(figure)
         self.assertEqual(f"Sample: {workspace.name()}", figure.gca().get_title())
 
     def test_sample_container_valid(self):
         workspace = setup_workspace_sample_and_container_CSG()
         figure = sample_shape.plot_sample_container_and_components(workspace.name())
-        self.assertTrue(figure)
+        self.assertIsNotNone(figure)
         self.assertEqual(f"Sample and Container: {workspace.name()}", figure.gca().get_title())
 
     def test_sample_invalid_container_valid(self):
         workspace = setup_workspace_container_CSG()
         figure = sample_shape.plot_sample_container_and_components(workspace.name())
-        self.assertTrue(figure)
+        self.assertIsNotNone(figure)
         self.assertEqual(f"Container: {workspace.name()}", figure.gca().get_title())
 
     def test_sample_and_container_invalid(self):
@@ -302,7 +302,7 @@ class PlotSampleShapeTest(TestCase):
     def test_sample_container_and_components_valid(self):
         workspace = setup_workspace_sample_container_and_components_from_mesh()
         figure = sample_shape.plot_sample_container_and_components(workspace.name())
-        self.assertTrue(figure)
+        self.assertIsNotNone(figure)
         self.assertEqual(f"Sample, Container and Components: {workspace.name()}", figure.gca().get_title())
 
     def test_plot_title_for_other_component_arrangements_that_are_less_likely(self):
@@ -314,14 +314,14 @@ class PlotSampleShapeTest(TestCase):
     def test_add_beam_arrow_called_once(self, mock_add_beam_arrow):
         workspace = setup_workspace_sample_container_and_components_from_mesh()
         figure = sample_shape.plot_sample_container_and_components(workspace.name())
-        self.assertTrue(figure)
+        self.assertIsNotNone(figure)
         self.assertEqual(1, mock_add_beam_arrow.call_count)
 
     @patch("mantidqt.plotting.sample_shape.add_arrow")
     def test_add_arrow_called_once(self, mock_add_arrow):
         workspace = setup_workspace_sample_container_and_components_from_mesh()
         figure = sample_shape.plot_sample_container_and_components(workspace.name())
-        self.assertTrue(figure)
+        self.assertIsNotNone(figure)
         self.assertEqual(1, mock_add_arrow.call_count)
 
     @patch("mantidqt.plotting.sample_shape.add_arrow")
@@ -331,7 +331,7 @@ class PlotSampleShapeTest(TestCase):
         SaveNexusESS(workspace, temp_file_name)
         workspace = LoadNexus(temp_file_name)
         figure = sample_shape.plot_sample_container_and_components(workspace.name())
-        self.assertTrue(figure)
+        self.assertIsNotNone(figure)
         self.assertEqual(1, mock_add_arrow.call_count)
         remove(temp_file_name)
 
@@ -344,7 +344,7 @@ class PlotSampleShapeTest(TestCase):
 
         workspace = setup_workspace_sample_container_and_components_from_mesh()
         figure = sample_shape.plot_sample_container_and_components(workspace.name())
-        self.assertTrue(figure)
+        self.assertIsNotNone(figure)
         self.assertEqual([each_call[0] for each_call in manager.mock_calls], ["mock_call_set_mesh_axes_equal", "mock_add_beam_arrow"])
 
     def test_beam_direction(self):

--- a/qt/python/mantidqt/mantidqt/plotting/test/test_sample_shape.py
+++ b/qt/python/mantidqt/mantidqt/plotting/test/test_sample_shape.py
@@ -102,11 +102,7 @@ def get_sample_container_components_meshes():
     workspace = setup_workspace_sample_container_and_components_from_mesh()
     sample_mesh = workspace.sample().getShape().getMesh()
     container_mesh = workspace.sample().getEnvironment().getContainer().getShape().getMesh()
-    component_meshes = []
-    number_of_components = workspace.sample().getEnvironment().nelements()
-    for component_index in range(1, number_of_components):
-        component_mesh = workspace.sample().getEnvironment().getComponent(component_index).getMesh()
-        component_meshes.append(component_mesh)
+    component_meshes = sample_shape.get_valid_component_meshes_from_workspace(workspace)
     return sample_mesh, container_mesh, component_meshes
 
 
@@ -157,7 +153,7 @@ class PlotSampleShapeTest(TestCase):
 
     def test_component_valid(self):
         workspace = setup_workspace_sample_container_and_components_from_mesh()
-        self.assertIsNotNone(sample_shape.get_valid_component_mesh_from_workspace(workspace, 1))
+        self.assertIsNotNone(sample_shape.get_valid_component_meshes_from_workspace(workspace))
 
     @patch("mantidqt.plotting.sample_shape.is_mesh_not_empty")
     def test_component_invalid(self, mock_is_mesh_not_empty):


### PR DESCRIPTION
**Description of work.**

Speed up performance of the plotting of the sample shape and container in cases where shapes are complex. Normally anything involving mesh shapes is the slowest type of shape but I've found that complex CSG shapes can cause problems with the shape plotting. This is because the CSG shapes need converting to a mesh before plotting which involves a costly call to a third party library called Open Cascade.

The performance improvement has been achieved by reducing the number of calls to getMesh from the sample shape plotting code.

The reason I noticed this was a bit of investigation I was doing for one of the ENGINX instrument scientists which involved me creating a description of a collimator from lots of CSG cuboids. The getMesh call in this case involves creating a mesh description of each CSG shape.

**To test:**

Run this script and then "Show Sample shape" from the right click menu of the ws workspace. Verify it's quicker than before. For me it still takes ~30 seconds so not rapid but better than it was:
```
# import mantid algorithms, numpy and matplotlib
from mantid.simpleapi import *
import matplotlib.pyplot as plt
import numpy as np

ws = Load("ENGINX00305761") # 2513 histograms, 10186 bins

cuboid_height=0.85
cuboid_depth=0.0045246
cuboid_width=0.2
z_min = -0.364503 # -0.364503 to 0.367428
z_spacing = 0.0045746
n_cuboids=161 # giving 160 veins

cuboid_xml_template = f" \
<cuboid id='cuboid-1'> \
<height val='{cuboid_height}'  /> \
<width val='{cuboid_width}' />  \
<depth  val='{cuboid_depth}' />  \
<centre x='0.5' y='0.0' z='-0.1'  />  \
</cuboid>"

multiple_cuboid_xml = ''
algebra_xml = "<algebra val='"
for i in range(1,n_cuboids):
    single_cuboid_xml = cuboid_xml_template.replace("cuboid-1","cuboid-" + str(i))
    single_cuboid_xml = single_cuboid_xml.replace("z='-0.1'","z='" + str(z_min + i*z_spacing) + "'")
    multiple_cuboid_xml += single_cuboid_xml
    if (i==1):
        algebra_xml += "cuboid-" + str(i)
    else:
        algebra_xml += " : cuboid-" + str(i)
algebra_xml += "'/>"
multiple_cuboid_xml = multiple_cuboid_xml + algebra_xml

SetSample(ws,
          Geometry={'Shape': 'Cylinder', 'Height': 4.0,
                  'Radius': 2.0, 'Center': [0.,0.,0.]},
          Material={'ChemicalFormula': 'Fe'},
          ContainerGeometry={'Shape': 'CSG', 'Value': multiple_cuboid_xml},
          ContainerMaterial={'ChemicalFormula': 'V'})
```

*There is no associated issue.*

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
