### PR TITLE
Discus performance improvements for ENGINX

### DIFF
--- a/docs/source/release/v6.7.0/Framework/Algorithms/New_features/35370.rst
+++ b/docs/source/release/v6.7.0/Framework/Algorithms/New_features/35370.rst
@@ -1,0 +1,2 @@
+- the beta test warning has been removed from the :ref:`DiscusMultipleScatteringCorrection <algm-DiscusMultipleScatteringCorrection>` algorithm
+- the performance of the :ref:`DiscusMultipleScatteringCorrection <algm-DiscusMultipleScatteringCorrection>` algorithm has been improved on elastic instruments with large numbers of bins


### PR DESCRIPTION
**Description of work.**

I recently tried running the Discus algorithm on an ENGINX dataset as a result of a conversation with Joe Kelleher and found that the large number of bins on the ENGINX workspaces caused some slowness in the algorithm. This PR covers a performance improvement to the function `calculateQSQIntegralAsFunctionOfK` for elastic instruments. 

This function was doing a set of very similar integrals across a workspace with ~10,000 bins where the lower integration limit was always zero and the upper integration limit increased slightly between integrals. The code now reuses the result from the previous integral and just does a "top up" integral for the extra bit of range included in the next integral.

I've also included some other small changes:
- remove the beta testing warning that the algorithm generated whenever it was run. The algorithm has been in place now for a few months so major rework of the parameter list or algorithm is unlikely
- couple of formatting changes to validation messages in case where more than one validation message is returned
- improve the progress message so it doesn't get stuck at 100%

**To test:**

Do a release build and run this script and verify it's quicker than before. On my machine it was taking ~4 minutes but now it's about 10 seconds. The calculation uses an unrealistically small number of scenarios but fine for testing the performance. The file ENGINX00305761.nxs is in the Mantid test datasets, the other data file is attached here:
[ENGINX_305761_307521_bank_1_TOF.zip](https://github.com/mantidproject/mantid/files/10989731/ENGINX_305761_307521_bank_1_TOF.zip)

```
# import mantid algorithms, numpy and matplotlib
from mantid.simpleapi import *
import matplotlib.pyplot as plt
import numpy as np

ws = Load("ENGINX00305761") # 2513 histograms, 10186 bins

SetSample(ws,
          Geometry={'Shape': 'Cylinder', 'Height': 4.0,
                  'Radius': 2.0, 'Center': [0.,0.,0.]},
          Material={'ChemicalFormula': 'Fe'})
          
Sofq = Load(r'ENGINX_305761_307521_bank_1_TOF.nxs')
Sofq = ConvertUnits(Sofq, "MomentumTransfer")
ws = ConvertUnits(ws, "Momentum")
          
results_group = DiscusMultipleScatteringCorrection(InputWorkspace=ws, StructureFactorWorkspace=Sofq,
                                                   OutputWorkspace="MuscatResults", NeutronPathsSingle=10,
                                                   NeutronPathsMultiple=10, ImportanceSampling=False,
                                                   NumberScatterings=2, NumberOfSimulationPoints=10)
```

*There is no associated issue.*

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
