### PR TITLE
Separate QSettings for ALFView and InstrumentView

### DIFF
--- a/docs/source/release/v6.7.0/Direct_Geometry/General/Bugfixes/35003.rst
+++ b/docs/source/release/v6.7.0/Direct_Geometry/General/Bugfixes/35003.rst
@@ -1,0 +1,1 @@
+- The settings loaded into the ALFView interface are now separate from those loaded into the InstrumentView.

--- a/qt/scientific_interfaces/Direct/ALFInstrumentWidget.cpp
+++ b/qt/scientific_interfaces/Direct/ALFInstrumentWidget.cpp
@@ -28,7 +28,8 @@ namespace MantidQt::CustomInterfaces {
 
 ALFInstrumentWidget::ALFInstrumentWidget(QString workspaceName)
     : MantidWidgets::InstrumentWidget(std::move(workspaceName), nullptr, true, true, 0.0, 0.0, true,
-                                      MantidWidgets::InstrumentWidget::Dependencies(), false, getTabCustomizations()) {
+                                      MantidWidgets::InstrumentWidget::Dependencies(), false,
+                                      "ALFView/InstrumentWidget", getTabCustomizations()) {
   removeTab("Instrument");
   removeTab("Draw");
   hideHelp();

--- a/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/InstrumentActor.h
+++ b/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/InstrumentActor.h
@@ -19,6 +19,7 @@
 #include "MaskBinsData.h"
 
 #include <QObject>
+#include <QString>
 
 #include <limits>
 #include <memory>
@@ -98,10 +99,10 @@ public:
 
   /// Constructor
   InstrumentActor(const std::string &wsName, MantidWidgets::IMessageHandler &messageHandler, bool autoscaling = true,
-                  double scaleMin = 0.0, double scaleMax = 0.0);
+                  double scaleMin = 0.0, double scaleMax = 0.0, QString settingsGroup = "Mantid/InstrumentWidget");
   InstrumentActor(Mantid::API::MatrixWorkspace_sptr workspace, MantidWidgets::IMessageHandler &messageHandler,
-                  bool autoscaling = true, double scaleMin = 0.0, double scaleMax = 0.0);
-  ///< Destructor
+                  bool autoscaling = true, double scaleMin = 0.0, double scaleMax = 0.0,
+                  QString settingsGroup = "Mantid/InstrumentWidget");
   ~InstrumentActor();
 
   /// Draw the instrument in 3D
@@ -250,6 +251,8 @@ public:
   void setGridLayer(bool isUsingLayer, int layer) const;
   const InstrumentRenderer &getInstrumentRenderer() const override;
 
+  void saveSettings() const;
+
 public slots:
   void initialize(bool resetGeometry, bool setDefaultView);
   void cancel();
@@ -260,9 +263,8 @@ private:
   void setUpWorkspace(const std::shared_ptr<const Mantid::API::MatrixWorkspace> &sharedWorkspace, double scaleMin,
                       double scaleMax);
   void setupPhysicalInstrumentIfExists();
-  void resetColors();
   void loadSettings();
-  void saveSettings();
+  void resetColors();
   void setDataMinMaxRange(double vmin, double vmax);
   void setDataIntegrationRange(const double &xmin, const double &xmax);
   void calculateIntegratedSpectra(const Mantid::API::MatrixWorkspace &workspace);
@@ -275,6 +277,8 @@ private:
 
   /// The workspace whose data are shown
   std::shared_ptr<Mantid::API::MatrixWorkspace> m_workspace;
+  /// The name of the settings group to store settings in
+  QString m_settingsGroup;
   /// The helper masking workspace keeping the mask build in the mask tab but
   /// not applied to the data workspace.
   mutable std::shared_ptr<Mantid::API::MatrixWorkspace> m_maskWorkspace;

--- a/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/InstrumentWidget.h
+++ b/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/InstrumentWidget.h
@@ -128,6 +128,7 @@ public:
   explicit InstrumentWidget(QString wsName, QWidget *parent = nullptr, bool resetGeometry = true,
                             bool autoscaling = true, double scaleMin = 0.0, double scaleMax = 0.0,
                             bool setDefaultView = true, Dependencies deps = Dependencies(), bool useThread = false,
+                            QString settingsGroup = "Mantid/InstrumentWidget",
                             TabCustomizations customizations = TabCustomizations());
   ~InstrumentWidget() override;
   QString getWorkspaceName() const;
@@ -177,7 +178,7 @@ public:
   /// Get a filename for saving
   QString getSaveFileName(const QString &title, const QString &filters, QString *selectedFilter = nullptr);
   /// Get a name for settings group
-  QString getSettingsGroupName() const;
+  inline QString getSettingsGroupName() const noexcept { return m_settingsGroup; }
   /// Get a name for a instrument-specific settings group
   QString getInstrumentSettingsGroupName() const;
 
@@ -333,6 +334,8 @@ protected:
   /// The name of workspace that this window is associated with. The
   /// InstrumentActor holds a pointer to the workspace itself.
   QString m_workspaceName;
+  /// The name of the settings group to store settings in
+  QString m_settingsGroup;
   /// Instrument actor is an interface to the instrument
   std::unique_ptr<InstrumentActor> m_instrumentActor;
   /// Option to use or not OpenGL display for "unwrapped" view, 3D is always in

--- a/qt/widgets/instrumentview/src/InstrumentWidget.cpp
+++ b/qt/widgets/instrumentview/src/InstrumentWidget.cpp
@@ -182,7 +182,7 @@ InstrumentWidget::InstrumentWidget(QString wsName, QWidget *parent, bool resetGe
   } else {
     // create and setup the instrument actor immediately if not using the background thread
     m_instrumentActor = std::make_unique<InstrumentActor>(m_workspaceName.toStdString(), *m_messageHandler, autoscaling,
-                                                          scaleMin, scaleMax);
+                                                          scaleMin, scaleMax, m_settingsGroup);
     m_qtMetaObject->invokeMethod(m_instrumentActor.get(), "initialize", Qt::DirectConnection,
                                  Q_ARG(bool, resetGeometry), Q_ARG(bool, setDefaultView));
   }
@@ -374,7 +374,8 @@ void InstrumentWidget::resetInstrumentActor(bool resetGeometry, bool autoscaling
   updateInfoText("Loading instrument...");
 
   m_instrumentActor = std::make_unique<InstrumentActor>(m_workspaceName.toStdString(), *m_messageHandler, autoscaling,
-                                                        scaleMin, scaleMax);
+                                                        scaleMin, scaleMax, m_settingsGroup);
+
   emit instrumentActorReset();
 
   if (m_useThread) {
@@ -1015,6 +1016,9 @@ void InstrumentWidget::saveSettings() {
 
   if (m_instrumentDisplay->getGLDisplay())
     settings.setValue("BackgroundColor", m_instrumentDisplay->getGLDisplay()->currentBackgroundColor());
+  if (m_instrumentActor) {
+    m_instrumentActor->saveSettings();
+  }
 
   auto surface = getSurface();
   if (surface) {


### PR DESCRIPTION
**Description of work.**
This PR fixes an issue where the QSettings loaded on the InstrumentView are also the QSettings loaded onto the ALFView interface when it gets opened. These settings should be saved as separate settings.

**To test:**
Follow the instructions in the issue to test.

Fixes #35003

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
