### PR TITLE
Allow Linear Detectors on the Preview Tab

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ReflectometryISISSumBanks.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ReflectometryISISSumBanks.py
@@ -118,10 +118,6 @@ class ReflectometryISISSumBanks(DataProcessorAlgorithm):
         alg.execute()
         return alg.getProperty("OutputWorkspace").value
 
-    def _run_child_without_out_props(self, *args, **kwargs) -> None:
-        alg = self.createChildAlgorithm(*args, **kwargs)
-        alg.execute()
-
     def _prepend_monitors(self, input_workspace, summed_workspace):
         crop_alg = self.createChildAlgorithm(
             "ExtractMonitors", InputWorkspace=input_workspace, MonitorWorkspace="__preview_summed_ws_monitors"

--- a/docs/source/release/v6.7.0/Reflectometry/New_features/35264_preview_1d.rst
+++ b/docs/source/release/v6.7.0/Reflectometry/New_features/35264_preview_1d.rst
@@ -1,0 +1,1 @@
+- 1D Detectors can now be loaded into and cropped in the preview tab.

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.cpp
@@ -116,21 +116,14 @@ void PreviewPresenter::notifyLoadWorkspaceCompleted() {
     m_view->setAngle(*theta);
   }
 
-  if (hasLinearDetector(ws)) {
-    m_dockedWidgets->resetInstView();
-    m_dockedWidgets->setInstViewToolbarEnabled(false);
-    m_model->setSummedWs(ws);
-    notifySumBanksCompleted();
-  } else {
-    // Notify the instrument view model that the workspace has changed before we get the surface
-    m_instViewModel->updateWorkspace(ws);
-    plotInstView();
-    // Ensure the toolbar is enabled, and reset the instrument view to zoom mode
-    m_dockedWidgets->setInstViewToolbarEnabled(true);
-    notifyInstViewZoomRequested();
-    // Perform summing banks to update the next plot, if possible
-    runSumBanks();
-  }
+  // Notify the instrument view model that the workspace has changed before we get the surface
+  m_instViewModel->updateWorkspace(ws);
+  plotInstView();
+  // Ensure the toolbar is enabled, and reset the instrument view to zoom mode
+  m_dockedWidgets->setInstViewToolbarEnabled(true);
+  notifyInstViewZoomRequested();
+  // Perform summing banks to update the next plot, if possible
+  runSumBanks();
 }
 
 void PreviewPresenter::notifyUpdateAngle() { runReduction(); }

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.cpp
@@ -116,6 +116,9 @@ void PreviewPresenter::notifyLoadWorkspaceCompleted() {
     m_view->setAngle(*theta);
   }
 
+  // Clear the region selector to ensure all spectra are shown.
+  m_regionSelector->clearWorkspace();
+
   // Notify the instrument view model that the workspace has changed before we get the surface
   m_instViewModel->updateWorkspace(ws);
   plotInstView();

--- a/qt/scientific_interfaces/ISISReflectometry/test/Preview/PreviewPresenterTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Preview/PreviewPresenterTest.h
@@ -130,20 +130,14 @@ public:
     auto mockJobManager = makeJobManager();
     auto mockDockedWidgets = makePreviewDockedWidgets();
     auto mockRegionSelector = makeRegionSelector();
+    auto mockInstViewModel = makeInstViewModel();
 
-    expectRegionSelectorToolbarEnabled(*mockDockedWidgets, false);
-    expectLoadWorkspaceCompletedForLinearDetector(*mockView, *mockModel, *mockJobManager, *mockDockedWidgets,
-                                                  *mockRegionSelector);
+    expectLoadWorkspaceCompletedForLinearDetector(*mockModel, *mockJobManager, *mockDockedWidgets, *mockInstViewModel);
 
-    auto rawMockDockedWidgets = mockDockedWidgets.get();
-
-    auto deps = packDeps(mockView.get(), std::move(mockModel), std::move(mockJobManager), makeInstViewModel(),
+    auto deps = packDeps(mockView.get(), std::move(mockModel), std::move(mockJobManager), std::move(mockInstViewModel),
                          std::move(mockDockedWidgets), std::move(mockRegionSelector));
     auto presenter = PreviewPresenter(std::move(deps));
 
-    expectRegionSelectorToolbarEnabled(*rawMockDockedWidgets, true);
-
-    EXPECT_CALL(*rawMockDockedWidgets, setInstViewToolbarEnabled(Eq(false))).Times(1);
     presenter.notifyLoadWorkspaceCompleted();
   }
 
@@ -596,18 +590,16 @@ private:
     EXPECT_CALL(linePlot, setPlotErrorBars(true)).Times(1);
   }
 
-  void expectLoadWorkspaceCompletedForLinearDetector(MockPreviewView &mockView, MockPreviewModel &mockModel,
-                                                     MockJobManager &mockJobManager,
+  void expectLoadWorkspaceCompletedForLinearDetector(MockPreviewModel &mockModel, MockJobManager &mockJobManager,
                                                      MockPreviewDockedWidgets &mockDockedWidgets,
-                                                     MockRegionSelector &mockRegionSelector) {
+                                                     MockInstViewModel &mockInstViewModel) {
     auto ws = createLinearDetectorWorkspace();
 
     EXPECT_CALL(mockModel, getLoadedWs()).Times(1).WillOnce(Return(ws));
-
-    EXPECT_CALL(mockDockedWidgets, resetInstView()).Times(1);
-    EXPECT_CALL(mockModel, setSummedWs(ws)).Times(1);
-
-    expectRunReduction(mockView, mockModel, mockJobManager, mockRegionSelector);
+    EXPECT_CALL(mockModel, getDefaultTheta()).Times(1);
+    EXPECT_CALL(mockInstViewModel, updateWorkspace(ws)).Times(1);
+    EXPECT_CALL(mockDockedWidgets, setInstViewToolbarEnabled(true)).Times(1);
+    EXPECT_CALL(mockModel, sumBanksAsync(Ref(mockJobManager))).Times(1);
   }
 
   void expectLoadWorkspaceCompletedUpdatesInstrumentView(MockPreviewDockedWidgets &mockDockedWidgets,

--- a/qt/scientific_interfaces/ISISReflectometry/test/Preview/PreviewPresenterTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Preview/PreviewPresenterTest.h
@@ -134,6 +134,8 @@ public:
 
     expectLoadWorkspaceCompletedForLinearDetector(*mockModel, *mockJobManager, *mockDockedWidgets, *mockInstViewModel);
 
+    EXPECT_CALL(*mockRegionSelector, clearWorkspace()).Times(1);
+
     auto deps = packDeps(mockView.get(), std::move(mockModel), std::move(mockJobManager), std::move(mockInstViewModel),
                          std::move(mockDockedWidgets), std::move(mockRegionSelector));
     auto presenter = PreviewPresenter(std::move(deps));


### PR DESCRIPTION
**Description of work.**
Shows 1D detector workspaces on the inst view of the preview tab. Allows for cropping. 


**To test:**
1. Test with the usual instructions for 2D detectors
3. Switch to exp settings tab and change to multipointdetectors
2. Load a 1D workspace (45454)
5. Check that the same functionality is available on  the preview tab for the 1D workspace. 

Fixes #35264 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
