### PR TITLE
Revert "Clean before checkout and increase timeout"

### DIFF
--- a/buildconfig/Jenkins/Conda/nightly_build_and_deploy.jenkinsfile
+++ b/buildconfig/Jenkins/Conda/nightly_build_and_deploy.jenkinsfile
@@ -304,7 +304,7 @@ def toUnixStylePath(path) {
 
 def checkoutSource(sha) {
   dir(CHECKOUT_DIR) {
-    checkout scm: [$class: 'GitSCM', branches: [[name: sha]], extensions: [[$class: 'CheckoutOption', timeout: 20], [$class: 'CleanBeforeCheckout', deleteUntrackedNestedRepositories: true], pruneTags(true)]]
+    checkout scm: [$class: 'GitSCM', branches: [[name: sha]], extensions: [[$class: 'CleanCheckout', deleteUntrackedNestedRepositories: true], pruneTags(true)]]
   }
 }
 


### PR DESCRIPTION
This reverts commit 2120309d4494f57d97810de5208edc2b062be59e.

**Description of work.**
We think this change has somehow caused sporadic failures in the conda build stages of the pipeline.

**To test:**
This test build was successful:
https://builds.mantidproject.org/job/build_packages_from_branch/274/

*There is no associated issue.*



*This does not require release notes* because **it's a change to the jenkinsfile**


<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
