### PR TITLE
Update MSlice SHA for latest bug fixes

### DIFF
--- a/docs/source/release/v6.7.0/Direct_Geometry/MSlice/Bugfixes/35386.rst
+++ b/docs/source/release/v6.7.0/Direct_Geometry/MSlice/Bugfixes/35386.rst
@@ -1,0 +1,2 @@
+- Fixed GDOS intensity correction so that the correction is applied in the same way regardless of rotation of the slice plot.
+- Fix for error when saving a slice plot as a matlab file.

--- a/scripts/ExternalInterfaces/CMakeLists.txt
+++ b/scripts/ExternalInterfaces/CMakeLists.txt
@@ -2,7 +2,7 @@
 include(ExternalProject)
 
 # mslice
-set(_mslice_external_root ${CMAKE_CURRENT_BINARY_DIR}/mslice)
+set(_mslice_external_root ${CMAKE_CURRENT_BINARY_DIR}/src/mslice)
 externalproject_add(
   mslice
   PREFIX ${_mslice_external_root}

--- a/scripts/ExternalInterfaces/CMakeLists.txt
+++ b/scripts/ExternalInterfaces/CMakeLists.txt
@@ -30,14 +30,14 @@ else()
 endif()
 # Let the parent lists file know where dev copy of mslice is
 set(MSLICE_DEV
-    ${_mslice_external_root}/src/mslice
+    ${_mslice_external_root}/src/mslice/src
     PARENT_SCOPE
 )
 
 # Installation MSLICE_DEV is only set in PARENT_SCOPE! so don't use it here
 foreach(_bundle ${BUNDLES})
   install(
-    DIRECTORY ${_mslice_external_root}/src/mslice/mslice/
+    DIRECTORY ${_mslice_external_root}/src/mslice/src/mslice/
     DESTINATION ${_bundle}scripts/ExternalInterfaces/mslice
     COMPONENT Runtime
   )

--- a/scripts/ExternalInterfaces/CMakeLists.txt
+++ b/scripts/ExternalInterfaces/CMakeLists.txt
@@ -7,7 +7,7 @@ externalproject_add(
   mslice
   PREFIX ${_mslice_external_root}
   GIT_REPOSITORY "https://github.com/mantidproject/mslice.git"
-  GIT_TAG b22da15086e3b3f7755c5209ef03f869ce561aa2
+  GIT_TAG 07af50cb4e4956a71e5dfa15647ce07bdfe2de73
   EXCLUDE_FROM_ALL 1
   CONFIGURE_COMMAND ""
   BUILD_COMMAND ""


### PR DESCRIPTION
**Description of work.**

Replaced MSlice SHA for Mantid with SHA of current MSlice main branch to make latest bug fixes available in Mantid nightly.

Added release notes for all changes since the last SHA update.

**To test:**

Double-check SHA with SHA of current MSlice main branch.

There is no associated issue.

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
