### PR TITLE
Fail Jenkins pipeline early if publishing parameters aren't specified

### DIFF
--- a/buildconfig/Jenkins/Conda/nightly_build_and_deploy.jenkinsfile
+++ b/buildconfig/Jenkins/Conda/nightly_build_and_deploy.jenkinsfile
@@ -61,6 +61,22 @@ pipeline {
     GIT_COMMITTER_EMAIL = "${GITHUB_USER_EMAIL}"
   }
   stages {
+    // Fail the pipeline early if any parameters are incorrect.
+    stage('Check parameters') {
+      agent { label 'linux-64' }
+      steps {
+        script {
+          if(env.PUBLISH_PACKAGES == 'true') {
+            if(!env.ANACONDA_CHANNEL_LABEL.trim()) {
+              error("You must specify an Anaconda label to publish packages.")
+            }
+            if(!env.ANACONDA_CHANNEL.trim()) {
+              error("You must specify an Anaconda channel to publish packages.")
+            }
+          }
+        }
+      }
+    }
     // Store the git commit hash in an environment variable so that we can use
     // the same commit for all stages of the pipeline. This is perfomed by using
     // the following step at the start of each subsequent stage:


### PR DESCRIPTION
**Description of work.**
If you want to publish packages using the Jenkins pipeline, but forget to specify a label or channel for Anaconda, it will fail the publishing step. Currently you have to wait several hours for this feedback. Here, we introduce a new stage at the start of the pipeline to check the input paremeters and fail early if neither are specified and publishing is selected.

**To test:**
Check the error message at the bottom of the console output for the following test pipeline jobs:
1. This job had `publish packages` ticked, but no anaconda label specified:
https://builds.mantidproject.org/job/build_packages_from_branch/279/console
2. This job had publish packages ticked, but no anaconda channel specified:
https://builds.mantidproject.org/job/build_packages_from_branch/280/console


Fixes #35266 
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
