### PR TITLE
Make Preview Reduction Use All Values From Experiment Settings Tab

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ReflectometryISISLoadAndProcess.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ReflectometryISISLoadAndProcess.py
@@ -166,7 +166,7 @@ class ReflectometryISISLoadAndProcess(DataProcessorAlgorithm):
         self.declareProperty(Prop.RELOAD, True, doc="If true, reload input workspaces if they are of the incorrect type")
         self.declareProperty(Prop.GROUP_TOF, True, doc="If true, group the TOF workspaces")
 
-        self.declareProperty(Prop.HIDE_INPUT, False, doc="If true, hide the output workspaces in the ADS.")
+        self.declareProperty(Prop.HIDE_INPUT, False, doc="If true, make the input workspaces invisible in the ADS.")
 
     def _declarePreprocessProperties(self):
         """Copy properties from the child preprocess algorithm"""

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ReflectometryISISLoadAndProcess.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ReflectometryISISLoadAndProcess.py
@@ -35,6 +35,7 @@ class Prop:
     GROUP_TOF = "GroupTOFWorkspaces"
     RELOAD = "ReloadInvalidWorkspaces"
     DEBUG = "Debug"
+    HIDE_INPUT = "HideInputWorkspaces"
     OUTPUT_WS = "OutputWorkspace"
     OUTPUT_WS_BINNED = "OutputWorkspaceBinned"
     OUTPUT_WS_LAM = "OutputWorkspaceWavelength"
@@ -85,6 +86,9 @@ class ReflectometryISISLoadAndProcess(DataProcessorAlgorithm):
 
     def PyExec(self):
         """Execute the algorithm."""
+        if self.getProperty(Prop.HIDE_INPUT).value:
+            self._tofPrefix = "__" + self._tofPrefix
+            self._transPrefix = "__" + self._transPrefix
         self._reload = self.getProperty(Prop.RELOAD).value
         # Convert run numbers to real workspaces
         inputRuns = self.getProperty(Prop.RUNS).value
@@ -125,7 +129,10 @@ class ReflectometryISISLoadAndProcess(DataProcessorAlgorithm):
             if AnalysisDataService.doesExist(summed_seg_name):
                 tofWorkspaces.add(summed_seg_name)
         # Create the group
-        self._group_workspaces(tofWorkspaces, "TOF")
+        if self.getProperty(Prop.HIDE_INPUT).value:
+            self._group_workspaces(tofWorkspaces, "__TOF")
+        else:
+            self._group_workspaces(tofWorkspaces, "TOF")
 
     def validateInputs(self):
         """Return a dictionary containing issues found in properties."""
@@ -158,6 +165,8 @@ class ReflectometryISISLoadAndProcess(DataProcessorAlgorithm):
         # Add properties for settings to apply to input runs
         self.declareProperty(Prop.RELOAD, True, doc="If true, reload input workspaces if they are of the incorrect type")
         self.declareProperty(Prop.GROUP_TOF, True, doc="If true, group the TOF workspaces")
+
+        self.declareProperty(Prop.HIDE_INPUT, False, doc="If true, hide the output workspaces in the ADS.")
 
     def _declarePreprocessProperties(self):
         """Copy properties from the child preprocess algorithm"""

--- a/Framework/PythonInterface/test/python/plugins/algorithms/ReflectometryReductionOneLiveDataTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/ReflectometryReductionOneLiveDataTest.py
@@ -198,6 +198,7 @@ class ReflectometryReductionOneLiveDataTest(unittest.TestCase):
             "ROIDetectorIDs",
             "ThetaIn",
             "ThetaLogName",
+            "HideInputWorkspaces",
             "OutputWorkspaceTransmission",
             "OutputWorkspaceFirstTransmission",
             "OutputWorkspaceSecondTransmission",

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/ReflectometryISISLoadAndProcessTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/ReflectometryISISLoadAndProcessTest.py
@@ -194,10 +194,10 @@ class ReflectometryISISLoadAndProcessTest(unittest.TestCase):
     def test_hide_workspaces_option_hides_input_workspaces(self):
         args = self._default_options
         args["InputRunList"] = "13460"
-        args["FirstTransmissionRunList"] = "13450"
+        args["FirstTransmissionRunList"] = "13460"
         args["ProcessingInstructions"] = "4"
         args["HideInputWorkspaces"] = True
-        outputs = ["IvsQ_13460", "IvsQ_binned_13460", "TRANS_LAM_13450"]
+        outputs = ["IvsQ_13460", "IvsQ_binned_13460", "TRANS_LAM_13460"]
         self._assert_run_algorithm_succeeds(args, outputs)
         history = ["ReflectometryISISPreprocess", "ReflectometryISISPreprocess", "ReflectometryReductionOneAuto", "GroupWorkspaces"]
         self._check_history(AnalysisDataService.retrieve("IvsQ_binned_13460"), history)

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/ReflectometryISISLoadAndProcessTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/ReflectometryISISLoadAndProcessTest.py
@@ -191,6 +191,17 @@ class ReflectometryISISLoadAndProcessTest(unittest.TestCase):
         history = ["ReflectometryReductionOneAuto", "GroupWorkspaces"]
         self._check_history(AnalysisDataService.retrieve("testIvsQBin"), history)
 
+    def test_hide_workspaces_option_hides_input_workspaces(self):
+        args = self._default_options
+        args["InputRunList"] = "13460"
+        args["FirstTransmissionRunList"] = "13450"
+        args["ProcessingInstructions"] = "4"
+        args["HideInputWorkspaces"] = True
+        outputs = ["IvsQ_13460", "IvsQ_binned_13460", "TRANS_LAM_13450"]
+        self._assert_run_algorithm_succeeds(args, outputs)
+        history = ["ReflectometryISISPreprocess", "ReflectometryISISPreprocess", "ReflectometryReductionOneAuto", "GroupWorkspaces"]
+        self._check_history(AnalysisDataService.retrieve("IvsQ_binned_13460"), history)
+
     def test_debug_option_outputs_extra_workspaces(self):
         self._create_workspace(13460, "TOF_")
         args = self._default_options

--- a/docs/source/release/v6.7.0/Reflectometry/Bugfixes/35276.rst
+++ b/docs/source/release/v6.7.0/Reflectometry/Bugfixes/35276.rst
@@ -1,0 +1,1 @@
+- The ``Reduction Preview`` tab now correctly uses the values from the ``Experiment Settings`` tab in the final reduction.

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/RowProcessingAlgorithm.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/RowProcessingAlgorithm.cpp
@@ -344,6 +344,8 @@ std::unique_ptr<Mantid::API::IAlgorithmRuntimeProps> createAlgorithmRuntimeProps
     properties->setProperty("ROIDetectorIDs", previewRow.getSelectedBanks().get());
   }
   updateProcessingInstructionsProperties(*properties, previewRow);
+
+  properties->setProperty("HideInputWorkspaces", true);
   return properties;
 }
 

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/RowProcessingAlgorithm.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/RowProcessingAlgorithm.cpp
@@ -304,7 +304,7 @@ IConfiguredAlgorithm_sptr createConfiguredAlgorithm(IBatch const &model, Preview
                                                     Mantid::API::IAlgorithm_sptr alg) {
   // Create the algorithm
   if (!alg) {
-    alg = Mantid::API::AlgorithmManager::Instance().create("ReflectometryReductionOneAuto");
+    alg = Mantid::API::AlgorithmManager::Instance().create("ReflectometryISISLoadAndProcess");
   }
   alg->setRethrows(true);
   alg->setAlwaysStoreInADS(false);
@@ -338,8 +338,11 @@ std::unique_ptr<Mantid::API::IAlgorithmRuntimeProps> createAlgorithmRuntimeProps
     updateLookupRowProperties(*properties, *lookupRow);
   }
   // Update properties from the preview tab
-  properties->setProperty("InputWorkspace", previewRow.getSummedWs());
+  properties->setProperty("InputRunList", previewRow.runNumbers());
   properties->setProperty("ThetaIn", previewRow.theta());
+  if (previewRow.getSelectedBanks().has_value()) {
+    properties->setProperty("ROIDetectorIDs", previewRow.getSelectedBanks().get());
+  }
   updateProcessingInstructionsProperties(*properties, previewRow);
   return properties;
 }

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewJobManager.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewJobManager.cpp
@@ -20,7 +20,7 @@ Mantid::Kernel::Logger g_log("Reflectometry Preview Job Manager");
 
 constexpr auto PREPROCESS_ALG_NAME = "ReflectometryISISPreprocess";
 constexpr auto SUM_BANKS_ALG_NAME = "ReflectometryISISSumBanks";
-constexpr auto REDUCTION_ALG_NAME = "ReflectometryReductionOneAuto";
+constexpr auto REDUCTION_ALG_NAME = "ReflectometryISISLoadAndProcess";
 
 enum class AlgorithmType { PREPROCESS, SUM_BANKS, REDUCTION };
 

--- a/qt/scientific_interfaces/ISISReflectometry/test/Preview/PreviewJobManagerTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Preview/PreviewJobManagerTest.h
@@ -261,7 +261,7 @@ private:
 
   class StubAlgReduction : public StubAlgorithm {
   public:
-    const std::string name() const override { return "ReflectometryReductionOneAuto"; }
+    const std::string name() const override { return "ReflectometryISISLoadAndProcess"; }
   };
 
   std::unique_ptr<MockJobRunner> makeJobRunner() { return std::make_unique<MockJobRunner>(); }


### PR DESCRIPTION
**Description of work.**

Adjusted the preview reduction process to do the full `LoadAndProccess` reduction in the final step, ensuring that it fully matches the behaviour of the main reduction. 

**To test:**
1. Boot the refl GUI
2. Go to the exp settings tab and write `13550` in the first trans run column of the lookup table
3. Go to the preview tab, select an angle, and load 13560 to perform the reduction
4. Ensure it completes without errors, there is nothing visible in the ADS, and that the final reduced workspace can be output to the ADS and contains sensible values. 

Fixes #35276 


---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
