### PR TITLE
Preview: Output Binned Data onto the 1D Plot

### DIFF
--- a/docs/source/release/v6.7.0/Reflectometry/Bugfixes/35275.rst
+++ b/docs/source/release/v6.7.0/Reflectometry/Bugfixes/35275.rst
@@ -1,1 +1,1 @@
-- Fixed the labelling of the workspaces output by :ref:`PolarizationCorrectionWildes` which were being inverted, while ensuring the output workspace group order continues to match the documentation.
+- The Preview tab now shows the binned output of the reduction on the 1D plot.

--- a/docs/source/release/v6.7.0/Reflectometry/Bugfixes/35275.rst
+++ b/docs/source/release/v6.7.0/Reflectometry/Bugfixes/35275.rst
@@ -1,0 +1,1 @@
+- Fixed the labelling of the workspaces output by :ref:`PolarizationCorrectionWildes` which were being inverted, while ensuring the output workspace group order continues to match the documentation.

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/RowProcessingAlgorithm.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/RowProcessingAlgorithm.cpp
@@ -346,7 +346,7 @@ std::unique_ptr<Mantid::API::IAlgorithmRuntimeProps> createAlgorithmRuntimeProps
 
 void updateRowOnAlgorithmComplete(const IAlgorithm_sptr &algorithm, Item &item) {
   auto &row = dynamic_cast<PreviewRow &>(item);
-  MatrixWorkspace_sptr outputWs = algorithm->getProperty("OutputWorkspace");
+  MatrixWorkspace_sptr outputWs = algorithm->getProperty("OutputWorkspaceBinned");
   row.setReducedWs(outputWs);
 }
 } // namespace MantidQt::CustomInterfaces::ISISReflectometry::Reduction

--- a/qt/scientific_interfaces/ISISReflectometry/test/Batch/RowProcessingAlgorithmTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Batch/RowProcessingAlgorithmTest.h
@@ -313,10 +313,10 @@ private:
     }
 
     void addOutputWorkspace(Mantid::API::MatrixWorkspace_sptr &ws) {
-      this->getPointerToProperty("OutputWorkspace")->createTemporaryValue();
+      this->getPointerToProperty("OutputWorkspaceBinned")->createTemporaryValue();
       setProperty(m_propName, ws);
     }
-    const std::string m_propName = "OutputWorkspace";
+    const std::string m_propName = "OutputWorkspaceBinned";
   };
 
   PreviewRow makePreviewRow(double theta = 0.1, const std::string &processingInstructions = "10-11",


### PR DESCRIPTION
**Description of work.**
Replaces the output from LoadAndProcess/ReductionOneAuto on the preview tab with the binned version, which is more useful for scientists. 

**To test:**

1. Start the ISIS Reflectometry Interface
2. Load INTER45455 with an angle in the preview tab
3. Switch to the Experiment Settings tab and type 0.2 in the dQ/Q column
4. Switch back to the preview tab and reload the data. 
5. Check that the 1D plot has been rebinned. 

Fixes #35275 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
