### PR TITLE
Pin filelock to <3.10.2 to fix doc segmentation fault

### DIFF
--- a/conda/recipes/conda_build_config.yaml
+++ b/conda/recipes/conda_build_config.yaml
@@ -68,6 +68,10 @@ ipykernel:
 readline:
   - <8.2
 
+# Pinned to prevent a segmentation fault when running doc tests
+filelock:
+  - <3.10.2
+
 pin_run_as_build:
     boost:
       max_pin: x.x

--- a/conda/recipes/mantid/meta.yaml
+++ b/conda/recipes/mantid/meta.yaml
@@ -27,6 +27,7 @@ requirements:
     - {{ cdt('libx11-devel') }}  # [linux]
     - {{ cdt('xorg-x11-proto-devel') }}  # [linux]
     - readline {{ readline }} # [linux or osx]
+    - filelock {{ filelock }} # [linux or osx]
   host:
     - boost {{ boost }}
     - eigen

--- a/conda/recipes/mantiddocs/meta.yaml
+++ b/conda/recipes/mantiddocs/meta.yaml
@@ -25,6 +25,7 @@ requirements:
     - {{ cdt('libxxf86vm') }}  # [linux]
     - {{ cdt('libx11-devel') }}  # [linux]
     - {{ cdt('xorg-x11-proto-devel') }}  # [linux]
+    - filelock {{ filelock }} # [linux or osx]
   host:
     - python {{ python }}
     - setuptools {{ setuptools }}

--- a/conda/recipes/mantiddocs/meta.yaml
+++ b/conda/recipes/mantiddocs/meta.yaml
@@ -25,7 +25,6 @@ requirements:
     - {{ cdt('libxxf86vm') }}  # [linux]
     - {{ cdt('libx11-devel') }}  # [linux]
     - {{ cdt('xorg-x11-proto-devel') }}  # [linux]
-    - filelock {{ filelock }} # [linux or osx]
   host:
     - python {{ python }}
     - setuptools {{ setuptools }}

--- a/mantid-developer-linux.yml
+++ b/mantid-developer-linux.yml
@@ -56,6 +56,7 @@ dependencies:
   - gxx_linux-64==10.3.*
   - libglu>=9.0.0
   - readline<8.2
+  - filelock<3.10.2 # Pinned to prevent a segmentation fault when running doc tests
 
   # Needed for test suite on Linux
   - pciutils-libs-cos7-x86_64>=3.5.1


### PR DESCRIPTION
**Description of work.**
This PR pins the `filelock` package to <3.10.2 in order to fix a documentation segmentation fault on the following pipeline
https://builds.mantidproject.org/job/build_and_publish_docs/

**To test:**
See the jobs 25 and 27 passing on this pipeline:
https://builds.mantidproject.org/job/build_and_publish_docs/

*There is no associated issue.*

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
