### PR TITLE
Support d-spacing workspaces in IntegratePeaksSkew and improve peak validation

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/IntegratePeaksSkew.py
+++ b/Framework/PythonInterface/plugins/algorithms/IntegratePeaksSkew.py
@@ -1087,7 +1087,7 @@ class IntegratePeaksSkew(DataProcessorAlgorithm):
         # estimate TOF resolution params
         thetas = np.array([pk_data.theta for pk_data in peak_data_collection if pk_data.status == PEAK_MASK_STATUS.VALID])
         wavelengths = np.array([pk_data.wl for pk_data in peak_data_collection if pk_data.status == PEAK_MASK_STATUS.VALID])
-        scaled_cot_th_sq = ((wavelengths**2) / np.tan(thetas)) ** 2 if scale_dth else (1 / np.tan(thetas))
+        scaled_cot_th_sq = (wavelengths / np.tan(thetas)) ** 2 if scale_dth else (1 / np.tan(thetas)) ** 2
         frac_tof_widths = np.array(
             [pk_data.get_dTOF_over_TOF() for pk_data in peak_data_collection if pk_data.status == PEAK_MASK_STATUS.VALID]
         )
@@ -1204,7 +1204,7 @@ class IntegratePeaksSkew(DataProcessorAlgorithm):
             ax[1].plot(xlim, slope * xlim + intercept, "-k", label="fit")
             xvals = np.linspace(min(thetas), max(thetas))
             if not scale_dth:
-                ax[0].plot(np.degrees(xvals), np.sqrt(intercept * (1 / np.tan(xvals) ** 2) + slope), "-k", label="fit")
+                ax[0].plot(np.degrees(xvals), np.sqrt(slope * (1 / np.tan(xvals) ** 2) + intercept), "-k", label="fit")
             else:
                 ylim = ax[0].get_ylim()
                 colors = line.get_cmap().colors
@@ -1212,7 +1212,7 @@ class IntegratePeaksSkew(DataProcessorAlgorithm):
                 wls = np.linspace(wavelengths.min(), wavelengths.max(), nwl)
                 icolors = np.linspace(0, len(colors) - 1, nwl, dtype=int)
                 for wl, icolor in zip(wls, icolors):
-                    ax[0].plot(np.degrees(xvals), np.sqrt(intercept * ((wl**2) / np.tan(xvals) ** 2) + slope), "-", color=colors[icolor])
+                    ax[0].plot(np.degrees(xvals), np.sqrt(slope * (wl / np.tan(xvals)) ** 2 + intercept), "-", color=colors[icolor])
                 ax[0].set_ylim(*ylim)  # reset limits so suitable for data point coverage not fit lines
             # add resolution parameters to the plot title
             ax[1].set_title(rf"$d\theta$={np.degrees(estimated_dth):.2f}$^\circ$" + "\n$dT_{bk}/T_{bk}$" + f"={estimated_dt0_over_t0:.2E}")

--- a/Framework/PythonInterface/plugins/algorithms/IntegratePeaksSkew.py
+++ b/Framework/PythonInterface/plugins/algorithms/IntegratePeaksSkew.py
@@ -409,21 +409,21 @@ class PeakData:
         return np.sum(signal) / np.sqrt(np.sum(error_sq))
 
     def _focus_detids(self, detids):
-        grp_ws = exec_CreateGroupingWorkspace(
-            InputWorkspace=self.ws,
-            CustomGroupingString="+".join([str(id) for id in detids]),
-            OutputWorkspace="__grp",
-            ComponentName=self.ws.getInstrument().getName(),
-        )
         if self.ws.getAxis(0).getUnit().unitID() == "dSpacing":
+            grp_ws = exec_CreateGroupingWorkspace(
+                InputWorkspace=self.ws,
+                CustomGroupingString="+".join([str(id) for id in detids]),
+                OutputWorkspace="__grp",
+                ComponentName=self.ws.getInstrument().getName(),
+            )
             ws_foc = exec_DiffractionFocussing(InputWorkspace=self.ws, GroupingWorkspace=grp_ws, OutputWorkspace=f"__foc{detids[0]}")
+            exec_DeleteWorkspaces(WorkspaceList=[grp_ws])
         else:
             ws_foc = exec_GroupDetectors(
                 InputWorkspace=self.ws,
-                CopyGroupingFromWorkspace=grp_ws,
+                DetectorList=",".join([str(id) for id in detids]),
                 OutputWorkspace=f"__foc{detids[0]}",
             )
-        exec_DeleteWorkspaces(WorkspaceList=[grp_ws])
         return ws_foc
 
     def focus_data_in_detector_mask(self):

--- a/Framework/PythonInterface/plugins/algorithms/IntegratePeaksSkew.py
+++ b/Framework/PythonInterface/plugins/algorithms/IntegratePeaksSkew.py
@@ -599,14 +599,14 @@ class PeakData:
         if np.any(self.x_integrated_data > 0):
             inonzero = self.x_integrated_data > 0
             vmin = self.x_integrated_data[inonzero].min()
-            vmax = self.x_integrated_data[inonzero].mean()
+            vmax = self.x_integrated_data[self.peak_mask].mean()
             if vmax <= vmin:
                 vmax = self.x_integrated_data.max()
         else:
             vmin, vmax = 1, 1
         norm = norm_func(vmin=vmin, vmax=vmax)
         # limits for 1D plot
-        ipad = (self.ixmax - self.ixmin) // 2  # extra portion of data shown outside the 1D window
+        ipad = (self.ixmax - self.ixmin) // 4  # extra portion of data shown outside the 1D window
         istart = max(min(self.ixmin, self.ixmin_opt) - ipad, 0)
         iend = min(max(self.ixmax, self.ixmax_opt) + ipad, len(self.xpk) - 1)
         # 2D plot - data integrated over optimal TOF range (not range for which mask determined)
@@ -632,11 +632,13 @@ class PeakData:
                 color="k",
                 label="data",
             )
-            ax[1].axvline(self.xpos, ls="--", color="k", label="Centre")
+            ax[1].axvline(self.xpos, ls="--", color=3 * [0.5], alpha=0.5, label="Centre")
             ax[1].axvline(self.xmin, ls=":", color="r", label="Initial window")
             ax[1].axvline(self.xmax, ls=":", color="r")
-            ax[1].axhline(0, ls=":", color="k")
-            ax[1].legend(fontsize=7, loc=1, ncol=2)
+            ax[1].axhline(0, ls=":", color=3 * [0.5], alpha=0.5)
+            ax[1].legend(fontsize=7, ncol=2, bbox_to_anchor=(0.75, 0), loc="lower center", bbox_transform=fig.transFigure)
+            box = ax[1].get_position()
+            ax[1].set_position([box.x0, box.y0 + 0.1, box.width, box.height - 0.1])
             ax[1].set_xlabel(r"TOF ($\mu$s)")
             ax[1].set_ylabel("Intensity")
         else:

--- a/Framework/PythonInterface/plugins/algorithms/IntegratePeaksSkew.py
+++ b/Framework/PythonInterface/plugins/algorithms/IntegratePeaksSkew.py
@@ -211,12 +211,7 @@ class InstrumentArrayConverter:
         :param detid: detector id of peak (from peak table)
         :param bank_name: bank name on which detector resides (from peak table)
         :param dpixel: width of detector window in pixels (along row and columns)
-        :return signal: 3D numpy array containing signal/intensities (row x cols x bins)
-        :return errors: 3D numpy array containing errors (row x cols x bins)
-        :return irow_peak: index of peak position along first dim (row)
-        :return icol_peak: index of peak position along second dim (col)
-        :return ispec: spectrum index corresponding to detid of peak
-        :return edges: bool mask True for pixels on the edge of a detector bank/panel
+        :return peak_data: PeakData object storing detids in peak region
         """
         bank = self.inst.getComponentByName(bank_name)
         row, col = peak.getRow(), peak.getCol()

--- a/Framework/PythonInterface/test/python/plugins/algorithms/IntegratePeaksSkewTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/IntegratePeaksSkewTest.py
@@ -178,11 +178,11 @@ class IntegratePeaksSkewTest(unittest.TestCase):
         # note intensity will be same now as peak position updated
         for ipk in range(2):
             pk = out.getPeak(ipk)
-            self.assertAlmostEqual(pk.getIntensity(), 379281975.3, delta=1)
+            self.assertAlmostEqual(pk.getIntensity(), 259054692.5, delta=1)
             self.assertAlmostEqual(pk.getIntensityOverSigma(), 12.7636, delta=1e-3)
             # check peak pos moved to maximum
             self.assertEqual(out.column("DetID")[ipk], 37)
-            self.assertAlmostEqual(pk.getTOF(), 5, delta=1e-10)
+            self.assertAlmostEqual(pk.getTOF(), 5.5, delta=1e-10)
             # check that HKL have been stored
             hkl = pk.getHKL()
             for miller_index in hkl:

--- a/Framework/PythonInterface/test/python/plugins/algorithms/IntegratePeaksSkewTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/IntegratePeaksSkewTest.py
@@ -350,6 +350,7 @@ class IntegratePeaksSkewTest(unittest.TestCase):
         out = IntegratePeaksSkew(
             InputWorkspace=self.ws,
             PeaksWorkspace=self.peaks,
+            NTOFBinsMin=1,
             ThetaWidth=0,
             BackscatteringTOFResolution=0.3,
             NRows=5,
@@ -366,6 +367,7 @@ class IntegratePeaksSkewTest(unittest.TestCase):
         out = IntegratePeaksSkew(
             InputWorkspace=self.ws,
             PeaksWorkspace=self.peaks,
+            NTOFBinsMin=1,
             ThetaWidth=0,
             BackscatteringTOFResolution=0.3,
             NRows=3,

--- a/Framework/PythonInterface/test/python/plugins/algorithms/IntegratePeaksSkewTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/IntegratePeaksSkewTest.py
@@ -30,7 +30,7 @@ class IntegratePeaksSkewTest(unittest.TestCase):
         AnalysisDataService.addOrReplace("ws_rect", cls.ws)
         axis = cls.ws.getAxis(0)
         axis.setUnit("TOF")
-        # fake peak in spectra in middle bank 1 (centered on detID=37/spec=12 and TOF=3.5)
+        # fake peak in spectra in middle bank 1 (centered on detID=37/spec=12 and TOF=5)
         cls.peak_1D = 2 * array([0, 0, 0, 1, 4, 6, 4, 1, 0, 0, 0])
         cls.ws.setY(12, cls.ws.readY(12) + cls.peak_1D)
         for ispec in [7, 11, 12, 13, 17, 22]:
@@ -45,7 +45,7 @@ class IntegratePeaksSkewTest(unittest.TestCase):
         # 2) middle bank 2 (no peak)
         cls.peaks = CreatePeaksWorkspace(InstrumentWorkspace=cls.ws, NumberOfPeaks=0, OutputWorkspace="peaks")
         for ipk, detid in enumerate([32, 27, 62]):
-            AddPeak(PeaksWorkspace=cls.peaks, RunWorkspace=cls.ws, TOF=5, DetectorID=detid)
+            AddPeak(PeaksWorkspace=cls.peaks, RunWorkspace=cls.ws, TOF=4, DetectorID=detid)
             cls.peaks.getPeak(ipk).setHKL(ipk, ipk, ipk)
 
         # Load empty WISH with ComponentArray banks
@@ -91,7 +91,7 @@ class IntegratePeaksSkewTest(unittest.TestCase):
         # check intensity of first peak (only valid peak)
         ipk = 0
         pk = out.getPeak(ipk)
-        self.assertAlmostEqual(pk.getIntensity(), 237051386.2, delta=1)
+        self.assertAlmostEqual(pk.getIntensity(), 578738736.0, delta=1)
         self.assertAlmostEqual(pk.getIntensityOverSigma(), 12.7636, delta=1e-3)
         # check peak pos not moved
         self.assertEqual(out.column("DetID")[ipk], self.peaks.column("DetID")[ipk])
@@ -178,11 +178,11 @@ class IntegratePeaksSkewTest(unittest.TestCase):
         # note intensity will be same now as peak position updated
         for ipk in range(2):
             pk = out.getPeak(ipk)
-            self.assertAlmostEqual(pk.getIntensity(), 259054692.5, delta=1)
+            self.assertAlmostEqual(pk.getIntensity(), 379281975.3, delta=1)
             self.assertAlmostEqual(pk.getIntensityOverSigma(), 12.7636, delta=1e-3)
             # check peak pos moved to maximum
             self.assertEqual(out.column("DetID")[ipk], 37)
-            self.assertAlmostEqual(pk.getTOF(), 5.5, delta=1e-10)
+            self.assertAlmostEqual(pk.getTOF(), 5, delta=1e-10)
             # check that HKL have been stored
             hkl = pk.getHKL()
             for miller_index in hkl:
@@ -304,6 +304,7 @@ class IntegratePeaksSkewTest(unittest.TestCase):
             PeaksWorkspace=self.peaks,
             ThetaWidth=0,
             BackscatteringTOFResolution=0.3,
+            NTOFBinsMin=2,
             IntegrateIfOnEdge=True,
             UseNearestPeak=False,
             UpdatePeakPosition=False,
@@ -319,6 +320,7 @@ class IntegratePeaksSkewTest(unittest.TestCase):
             PeaksWorkspace=self.peaks,
             ThetaWidth=0,
             BackscatteringTOFResolution=0.3,
+            NTOFBinsMin=2,
             IntegrateIfOnEdge=True,
             UseNearestPeak=False,
             UpdatePeakPosition=False,
@@ -334,6 +336,7 @@ class IntegratePeaksSkewTest(unittest.TestCase):
             PeaksWorkspace=self.peaks,
             ThetaWidth=0,
             BackscatteringTOFResolution=0.3,
+            NTOFBinsMin=2,
             IntegrateIfOnEdge=True,
             UseNearestPeak=False,
             UpdatePeakPosition=False,

--- a/docs/source/algorithms/IntegratePeaksSkew-v1.rst
+++ b/docs/source/algorithms/IntegratePeaksSkew-v1.rst
@@ -19,13 +19,13 @@ data [2]_, however it has been noted that skew methods typically underestimate t
 (due to premature termination of the seed growth) - a systematic effect that is expected to be worse for 3D Bragg peaks.
 
 In order to improve the performance and more accurately integrate weak reflections a different approach is used here:
-data are integrated over an initial TOF window in order to maximise the signal-to-noise and then a 2D peak mask is
-determined to find the detectors contributing to the peak; data in these detectors are then focused (and a
+data are integrated over an initial TOF (or d-spacing) window in order to maximise the signal-to-noise and then a 2D
+peak mask is determined to find the detectors contributing to the peak; data in these detectors are then focused (and a
 background subtracted) before applying the same method to identify the bins that contribute to the peak in the focused
-spectrum. The full TOF extent of the peak is determined by maximising :math:`I/\sigma` (similar to integration methods
-for step-scans with monochromatic x-rays [3]_) starting from a seed of bins identified using the skew method.
-The user can then optionally use the optimal TOF extent to repeat the procedure to find the detectors contributing to
-the peak.
+spectrum. The full TOF (or d-spacing) extent of the peak is determined by maximising :math:`I/\sigma` (similar to
+integration methods for step-scans with monochromatic x-rays [3]_) starting from a seed of bins identified using the
+skew method. The user can then optionally use the optimal TOF  (or d-spacing)  extent to repeat the procedure to find
+the detectors contributing to the peak.
 
 Technically this algorithm does not use the seed-skew algorithm to grow an initial seed, rather non-background points
 are found by minimising the skew of the background, subsequently nearest-neighbour connected regions are found in the
@@ -35,7 +35,9 @@ Note this algorithm can apply the Lorentz correction to the integrated intensity
 
 For each peak the algorithm proceeds as follows:
 
-1.  Calculates an initial TOF window evaluating a resolution function of the form
+1.  Calculates an initial TOF (or d-spacing) window evaluating a resolution function for the fractional width
+    (which is the same for TOF and d-spacing) of the form
+
 
         .. math::
 
@@ -189,7 +191,7 @@ Useage
     IntegratePeaksSkew(InputWorkspace='SXD23767', PeaksWorkspace='SingleCrystalPeakTable',
         OutputWorkspace='out', OutputFile="out.pdf",
         UseNearestPeak=True, IntegrateIfOnEdge=True, NVacanciesMax=0, NPixPerVacancyMin=2,
-        BackScatteringTOFResolution=0.04, ThetaWidth=0.02, UpdatePeakPosition=True)
+        BackScatteringTOFResolution=0.04, ThetaWidth=1, UpdatePeakPosition=True)
 
 
 References

--- a/docs/source/release/v6.7.0/Diffraction/Single_Crystal/Bugfixes/35411.rst
+++ b/docs/source/release/v6.7.0/Diffraction/Single_Crystal/Bugfixes/35411.rst
@@ -1,0 +1,1 @@
+- Fix bug in estimating TOF window parameters in :ref:`IntegratePeaksSkew <algm-IntegratePeaksSkew>`

--- a/docs/source/release/v6.7.0/Diffraction/Single_Crystal/Improvements/35411.rst
+++ b/docs/source/release/v6.7.0/Diffraction/Single_Crystal/Improvements/35411.rst
@@ -1,0 +1,2 @@
+- Improved formatting of plots in pdf output of :ref:`IntegratePeaksSkew <algm-IntegratePeaksSkew>`
+- Parameter ``NTOFBinsMin`` in :ref:`IntegratePeaksSkew <algm-IntegratePeaksSkew>` now refers to the number of non-zero bins in the integration window with y/error > 1

--- a/docs/source/release/v6.7.0/Diffraction/Single_Crystal/Improvements/35411.rst
+++ b/docs/source/release/v6.7.0/Diffraction/Single_Crystal/Improvements/35411.rst
@@ -1,2 +1,0 @@
-- Improved formatting of plots in pdf output of :ref:`IntegratePeaksSkew <algm-IntegratePeaksSkew>`
-- Parameter ``NTOFBinsMin`` in :ref:`IntegratePeaksSkew <algm-IntegratePeaksSkew>` now refers to the number of non-zero bins in the integration window with y/error > 1

--- a/docs/source/release/v6.7.0/Diffraction/Single_Crystal/New_features/354111.rst
+++ b/docs/source/release/v6.7.0/Diffraction/Single_Crystal/New_features/354111.rst
@@ -1,3 +1,5 @@
 - Support workspaces with d-spacing xunit in :ref:`IntegratePeaksSkew <algm-IntegratePeaksSkew>`
 - Add option ``OptimiseXWindowSize`` to fix TOF (or d-sapcing) window extent below a threshold intensity/sigma (``ThresholdIoverSigma``) in :ref:`IntegratePeaksSkew <algm-IntegratePeaksSkew>`
+- Improved formatting of plots in pdf output of :ref:`IntegratePeaksSkew <algm-IntegratePeaksSkew>`
+- Parameter ``NTOFBinsMin`` in :ref:`IntegratePeaksSkew <algm-IntegratePeaksSkew>` now refers to the number of non-zero bins in the integration window with y/error > 1
 

--- a/docs/source/release/v6.7.0/Diffraction/Single_Crystal/New_features/354111.rst
+++ b/docs/source/release/v6.7.0/Diffraction/Single_Crystal/New_features/354111.rst
@@ -1,0 +1,3 @@
+- Support workspaces with d-spacing xunit in :ref:`IntegratePeaksSkew <algm-IntegratePeaksSkew>`
+- Add option ``OptimiseXWindowSize`` to fix TOF (or d-sapcing) window extent below a threshold intensity/sigma (``ThresholdIoverSigma``) in :ref:`IntegratePeaksSkew <algm-IntegratePeaksSkew>`
+


### PR DESCRIPTION
**Description of work.**

Several improvements to the `IntegratePeaksSkew` algorithm

1. Allow integration of workspaces in d-spacing (previously just TOF) - this required re-writing a lot of code to use mantid algorithms as opposed to numpy operations (due to non-aligned bin edges)
2. Add option not to optimise 1D window size below a threshold Intensity/sigma ratio
3. Improve formatting of output plot by putting legend outside the axes
4. Validate peaks based on number of statistically significant non-zero TOF bins

In addition a bug in estimating resolution parameters has been fixed

Note that as part of this PR this PR the error on empty bins is no longer increased to 1 (as is done in SXD2001) as this has been show to be invalid in issue #34841


**To test:**

(1) Run this script

```
Load(Filename='SXD26062.raw', OutputWorkspace='SXD26062')

CreatePeaksWorkspace(InstrumentWorkspace='SXD26062', NUmberOfPeaks=0, OutputWorkspace='SingleCrystalPeakTable')

AddPeak(PeaksWorkspace='SingleCrystalPeakTable', RunWorkspace='SXD26062', TOF=2366.8220873404448, DetectorID=34389, Height=1772, BinCount=95.229762433928016)
AddPeak(PeaksWorkspace='SingleCrystalPeakTable', RunWorkspace='SXD26062', TOF=2126.2022543400831, DetectorID=33804, Height=1505, BinCount=27.480506255931004)
AddPeak(PeaksWorkspace='SingleCrystalPeakTable', RunWorkspace='SXD26062', TOF=2184.0008770008217, DetectorID=35949, Height=1808, BinCount=52.661280309925587)
AddPeak(PeaksWorkspace='SingleCrystalPeakTable', RunWorkspace='SXD26062', TOF=1995.2115486292446, DetectorID=31765, Height=1513, BinCount=23.65730722975853)
AddPeak(PeaksWorkspace='SingleCrystalPeakTable', RunWorkspace='SXD26062', TOF=2252.1712809128194, DetectorID=30058, Height=2302, BinCount=84.449848622374006)
AddPeak(PeaksWorkspace='SingleCrystalPeakTable', RunWorkspace='SXD26062', TOF=5843.6050001340082, DetectorID=15121, Height=1639, BinCount=63.362132138439677)
AddPeak(PeaksWorkspace='SingleCrystalPeakTable', RunWorkspace='SXD26062', TOF=4419.0059861014552, DetectorID=38933, Height=885, BinCount=17.337073210576683)
AddPeak(PeaksWorkspace='SingleCrystalPeakTable', RunWorkspace='SXD26062', TOF=3023.5648640387335, DetectorID=37810, Height=710, BinCount=12.82320474223436)
AddPeak(PeaksWorkspace='SingleCrystalPeakTable', RunWorkspace='SXD26062', TOF=5145.6860467522974, DetectorID=38691, Height=1325, BinCount=126.70521154333336)
AddPeak(PeaksWorkspace='SingleCrystalPeakTable', RunWorkspace='SXD26062', TOF=4975.3450154521515, DetectorID=8558, Height=1345, BinCount=7.0523493183511672)
AddPeak(PeaksWorkspace='SingleCrystalPeakTable', RunWorkspace='SXD26062', TOF=16259.3, DetectorID=19474, Height=39, BinCount=6.5623281756867184)
 
ConvertUnits(InputWorkspace='SXD26062', Target='dSpacing',  OutputWorkspace='SXD26062')

fpath = '/mnt/babylon/Public/RWaite/SXD26062_peaks_int_skew.pdf'
IntegratePeaksSkew(InputWorkspace='SXD26062', PeaksWorkspace='SingleCrystalPeakTable', 
                   # NCols=3, NRows=3, NRowMax=3,NColMax=3,
                   BackscatteringTOFResolution=0.06, ThetaWidth=1.5, 
                   ScaleThetaWidthByWavelength=True, OptimiseMask=False, NVacanciesMax=1, 
                   UseNearestPeak=True, UpdatePeakPosition=False, 
                   OutputFile=fpath, 
                   LorentzCorrection=False, OutputWorkspace='SXD26062_peaks_int', 
                   OptimiseXWindowSize=True,
                   ThresholdIOverSigma=0.0)
```
(2) Inspect the output table - the peaks should be integrated
(3) Inspect the output pdf - the peak window should look like it covers the majority of the peaks (in 2D and 1D)
Fixes #35271

<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
