### PR TITLE
Improve Colours on the Preview Tab's ROI Selectors

### DIFF
--- a/docs/source/release/v6.7.0/Reflectometry/Bugfixes/35349.rst
+++ b/docs/source/release/v6.7.0/Reflectometry/Bugfixes/35349.rst
@@ -1,0 +1,1 @@
+- The Signal, Transmission, and Background ROI selectors on the Preview Tab have been made more visible.

--- a/qt/python/mantidqt/mantidqt/widgets/regionselector/presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/regionselector/presenter.py
@@ -28,8 +28,8 @@ class Selector(RectangleSelector):
         "interactive": True,
     }
 
-    def __init__(self, region_type: str, color: str, *args):
-        self.kwargs["props"] = dict(facecolor=color, edgecolor=color, alpha=0.4, linewidth=3, fill=True)
+    def __init__(self, region_type: str, color: str, hatch: str, *args):
+        self.kwargs["props"] = dict(facecolor=color, edgecolor=color, alpha=0.4, hatch=hatch, linewidth=3, fill=True)
         self.kwargs["handle_props"] = dict(markersize=6)
         self.kwargs["drag_from_anywhere"] = True
         self.kwargs["ignore_event_outside"] = True
@@ -133,7 +133,7 @@ class RegionSelector(ObservingPresenter, SliceViewerBasePresenter):
             self._selectors.pop()
             self._drawing_region = False
 
-    def add_rectangular_region(self, region_type, color):
+    def add_rectangular_region(self, region_type: str, color: str, hatch: str):
         """
         Add a rectangular region selection tool.
         """
@@ -143,7 +143,7 @@ class RegionSelector(ObservingPresenter, SliceViewerBasePresenter):
         if self._drawing_region:
             self._selectors.pop()
 
-        self._selectors.append(Selector(region_type, color, self.view._data_view.ax, self._on_rectangle_selected))
+        self._selectors.append(Selector(region_type, color, hatch, self.view._data_view.ax, self._on_rectangle_selected))
 
         self._drawing_region = True
 

--- a/qt/python/mantidqt/mantidqt/widgets/regionselector/presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/regionselector/presenter.py
@@ -29,8 +29,8 @@ class Selector(RectangleSelector):
     }
 
     def __init__(self, region_type: str, color: str, *args):
-        self.kwargs["props"] = dict(facecolor="white", edgecolor=color, alpha=0.2, linewidth=2, fill=True)
-        self.kwargs["handle_props"] = dict(markersize=4)
+        self.kwargs["props"] = dict(facecolor=color, edgecolor=color, alpha=0.4, linewidth=3, fill=True)
+        self.kwargs["handle_props"] = dict(markersize=6)
         self.kwargs["drag_from_anywhere"] = True
         self.kwargs["ignore_event_outside"] = True
 

--- a/qt/python/mantidqt/mantidqt/widgets/regionselector/test/test_regionselector_presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/regionselector/test/test_regionselector_presenter.py
@@ -288,7 +288,7 @@ class RegionSelectorTest(unittest.TestCase):
         self.assertEqual(1, len(region_selector._selectors))
 
         # When
-        region_selector.add_rectangular_region("test", "black", "O")
+        region_selector.add_rectangular_region("test2", "green", "O")
 
         # Then
         self.assertEqual(1, len(region_selector._selectors))

--- a/qt/python/mantidqt/mantidqt/widgets/regionselector/test/test_regionselector_presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/regionselector/test/test_regionselector_presenter.py
@@ -70,7 +70,7 @@ class RegionSelectorTest(unittest.TestCase):
     def test_add_rectangular_region_creates_selector(self):
         region_selector = RegionSelector(ws=Mock(), view=self.mock_view)
 
-        region_selector.add_rectangular_region("test", "black")
+        region_selector.add_rectangular_region("test", "black", "/")
 
         self.assertEqual(1, len(region_selector._selectors))
         self.assertTrue(region_selector._selectors[0].active)
@@ -79,9 +79,9 @@ class RegionSelectorTest(unittest.TestCase):
     def test_add_second_rectangular_region_deactivates_first_selector(self):
         region_selector = RegionSelector(ws=Mock(), view=self.mock_view)
 
-        region_selector.add_rectangular_region("test", "black")
+        region_selector.add_rectangular_region("test", "black", "/")
         region_selector._drawing_region = False
-        region_selector.add_rectangular_region("test", "black")
+        region_selector.add_rectangular_region("test", "black", "/")
 
         self.assertEqual(2, len(region_selector._selectors))
 
@@ -93,8 +93,8 @@ class RegionSelectorTest(unittest.TestCase):
         mock_ws = Mock()
 
         region_selector.update_workspace(mock_ws)
-        region_selector.add_rectangular_region("test", "black")
-        region_selector.add_rectangular_region("test", "black")
+        region_selector.add_rectangular_region("test", "black", "/")
+        region_selector.add_rectangular_region("test", "black", "/")
 
         region_selector.clear_workspace()
 
@@ -269,14 +269,14 @@ class RegionSelectorTest(unittest.TestCase):
         mock_observer = Mock()
         region_selector.subscribe(mock_observer)
 
-        region_selector.add_rectangular_region("test", "black")
+        region_selector.add_rectangular_region("test", "black", "/")
         region_selector._on_rectangle_selected(Mock(), Mock())
 
         mock_observer.notifyRegionChanged.assert_called_once()
 
     def test_cancel_drawing_region_will_remove_last_selector(self):
         region_selector = RegionSelector(ws=Mock(), view=self.mock_view)
-        region_selector.add_rectangular_region("test", "black")
+        region_selector.add_rectangular_region("test", "black", "/")
         self.assertEqual(1, len(region_selector._selectors))
         region_selector.cancel_drawing_region()
         self.assertEqual(0, len(region_selector._selectors))
@@ -284,11 +284,11 @@ class RegionSelectorTest(unittest.TestCase):
     def test_when_multiple_region_adds_are_requested_only_one_region_is_added(self):
         # Given
         region_selector = RegionSelector(ws=Mock(), view=self.mock_view)
-        region_selector.add_rectangular_region("test", "black")
+        region_selector.add_rectangular_region("test", "black", "/")
         self.assertEqual(1, len(region_selector._selectors))
 
         # When
-        region_selector.add_rectangular_region("test2", "green")
+        region_selector.add_rectangular_region("test", "black", "O")
 
         # Then
         self.assertEqual(1, len(region_selector._selectors))

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.cpp
@@ -210,7 +210,7 @@ void PreviewPresenter::notifyRectangularROIModeRequested() {
   auto const roiType = roiTypeFromString(regionType);
   m_dockedWidgets->setEditROIState(false);
   m_dockedWidgets->setRectangularROIState(true);
-  m_regionSelector->addRectangularRegion(regionType, roiTypeToColor(roiType));
+  m_regionSelector->addRectangularRegion(regionType, roiTypeToColor(roiType), roiTypeToHatch(roiType));
 }
 
 void PreviewPresenter::notifyRegionChanged() {

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/ROIType.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/ROIType.h
@@ -39,11 +39,11 @@ inline std::string roiTypeToString(ROIType roiType) {
 inline std::string roiTypeToColor(ROIType roiType) {
   switch (roiType) {
   case ROIType::Signal:
-    return "green";
+    return "#00FF00";
   case ROIType::Background:
-    return "magenta";
+    return "#FF00FF";
   case ROIType::Transmission:
-    return "blue";
+    return "#0000FF";
   }
   throw std::invalid_argument("Unexpected ROI type");
 }

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/ROIType.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/ROIType.h
@@ -39,11 +39,23 @@ inline std::string roiTypeToString(ROIType roiType) {
 inline std::string roiTypeToColor(ROIType roiType) {
   switch (roiType) {
   case ROIType::Signal:
-    return "#00FF00";
-  case ROIType::Background:
     return "#FF00FF";
+  case ROIType::Background:
+    return "#00FF00";
   case ROIType::Transmission:
     return "#0000FF";
+  }
+  throw std::invalid_argument("Unexpected ROI type");
+}
+
+inline std::string roiTypeToHatch(ROIType roiType) {
+  switch (roiType) {
+  case ROIType::Signal:
+    return "//";
+  case ROIType::Background:
+    return "\\\\";
+  case ROIType::Transmission:
+    return "O";
   }
   throw std::invalid_argument("Unexpected ROI type");
 }

--- a/qt/scientific_interfaces/ISISReflectometry/test/Preview/PreviewPresenterTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Preview/PreviewPresenterTest.h
@@ -303,10 +303,11 @@ public:
     auto mockRegionSelector = mockRegionSelector_uptr.get();
     const std::string regionType = roiTypeToString(ROIType::Signal);
     const std::string color = roiTypeToColor(ROIType::Signal);
+    const std::string hatch = roiTypeToHatch(ROIType::Signal);
 
     EXPECT_CALL(*mockDockedWidgets, getRegionType()).Times(1).WillOnce(Return(regionType));
     expectRectangularROIMode(*mockDockedWidgets);
-    EXPECT_CALL(*mockRegionSelector, addRectangularRegion(regionType, color)).Times(1);
+    EXPECT_CALL(*mockRegionSelector, addRectangularRegion(regionType, color, hatch)).Times(1);
     auto presenter = PreviewPresenter(packDeps(mockView.get(), makeModel(), makeJobManager(), makeInstViewModel(),
                                                std::move(mockDockedWidgets), std::move(mockRegionSelector_uptr)));
 

--- a/qt/widgets/regionselector/inc/MantidQtWidgets/RegionSelector/IRegionSelector.h
+++ b/qt/widgets/regionselector/inc/MantidQtWidgets/RegionSelector/IRegionSelector.h
@@ -22,7 +22,8 @@ public:
   virtual void subscribe(std::shared_ptr<Mantid::API::RegionSelectorObserver> const &notifyee) = 0;
   virtual void clearWorkspace() = 0;
   virtual void updateWorkspace(Mantid::API::Workspace_sptr const &workspace) = 0;
-  virtual void addRectangularRegion(const std::string &regionType, const std::string &color) = 0;
+  virtual void addRectangularRegion(const std::string &regionType, const std::string &color,
+                                    const std::string &hatch) = 0;
   virtual void deselectAllSelectors() = 0;
   virtual Selection getRegion(const std::string &regionType) = 0;
   virtual void cancelDrawingRegion() = 0;

--- a/qt/widgets/regionselector/inc/MantidQtWidgets/RegionSelector/RegionSelector.h
+++ b/qt/widgets/regionselector/inc/MantidQtWidgets/RegionSelector/RegionSelector.h
@@ -28,7 +28,7 @@ public:
   void subscribe(std::shared_ptr<Mantid::API::RegionSelectorObserver> const &notifyee) override;
   void clearWorkspace() override;
   void updateWorkspace(Mantid::API::Workspace_sptr const &workspace) override;
-  void addRectangularRegion(const std::string &regionType, const std::string &color) override;
+  void addRectangularRegion(const std::string &regionType, const std::string &color, const std::string &hatch) override;
   void deselectAllSelectors() override;
   Selection getRegion(const std::string &regionType) override;
   void cancelDrawingRegion() override;

--- a/qt/widgets/regionselector/src/RegionSelector.cpp
+++ b/qt/widgets/regionselector/src/RegionSelector.cpp
@@ -94,9 +94,10 @@ void RegionSelector::updateWorkspace(Workspace_sptr const &workspace) {
   pyobj().attr("update_workspace")(*boost::python::tuple(), **kwargs);
 }
 
-void RegionSelector::addRectangularRegion(const std::string &regionType, const std::string &color) {
+void RegionSelector::addRectangularRegion(const std::string &regionType, const std::string &color,
+                                          const std::string &hatch) {
   GlobalInterpreterLock lock;
-  pyobj().attr("add_rectangular_region")(regionType, color);
+  pyobj().attr("add_rectangular_region")(regionType, color, hatch);
 }
 
 void RegionSelector::cancelDrawingRegion() {

--- a/qt/widgets/regionselector/test/MockRegionSelector.h
+++ b/qt/widgets/regionselector/test/MockRegionSelector.h
@@ -15,7 +15,8 @@ public:
   MOCK_METHOD(void, subscribe, (std::shared_ptr<Mantid::API::RegionSelectorObserver> const &), (override));
   MOCK_METHOD(void, clearWorkspace, (), (override));
   MOCK_METHOD(void, updateWorkspace, (Mantid::API::Workspace_sptr const &workspace), (override));
-  MOCK_METHOD(void, addRectangularRegion, (const std::string &regionType, const std::string &color), (override));
+  MOCK_METHOD(void, addRectangularRegion,
+              (std::string const &regionType, std::string const &color, std::string const &hatch), (override));
   MOCK_METHOD(void, deselectAllSelectors, (), (override));
   MOCK_METHOD(Selection, getRegion, (const std::string &regionType), (override));
   MOCK_METHOD(void, cancelDrawingRegion, (), (override));


### PR DESCRIPTION
**Description of work.**
Changed the colours and outlines of the ROI selectors on the Region Selector (SliceViewer) to make then more visible on a variety of colourmaps. 

**To test:**
1. Boot the Refl GUI
2. Switch to the preview tab
3. Load any file (45455 is best though)
4. Select a colourmap of choice on the region selector (middle widget)
5. Select a mix of signals, transmissions, and backgrounds
6. Check that it is clear which ROI is selected and what areas are covered by the various ROI selectors. 

Fixes #35349 

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
