### PR TITLE
Enable default sitich output parameters to be pulled from IPF

### DIFF
--- a/instrument/unit_testing/REFL_Parameters_Experiment.xml
+++ b/instrument/unit_testing/REFL_Parameters_Experiment.xml
@@ -105,6 +105,12 @@
     <value val="17.0"/>
   </parameter>
 
+  <!-- Stitch Parameters used by Stitch1DMany -->
+
+  <parameter name="StitchManualScaleFactors" type="string">
+    <value val="1"/>
+  </parameter>
+
 </component-link>
 
 </parameter-file>

--- a/qt/scientific_interfaces/ISISReflectometry/Common/OptionDefaults.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/Common/OptionDefaults.cpp
@@ -12,14 +12,9 @@
 
 namespace MantidQt::CustomInterfaces::ISISReflectometry {
 
-OptionDefaults::OptionDefaults(Mantid::Geometry::Instrument_const_sptr instrument, bool stitchDefault)
-    : m_instrument(std::move(instrument)) {
-  if (stitchDefault) {
-    m_algorithm = Mantid::API::AlgorithmManager::Instance().createUnmanaged("Stitch1DMany");
-    // m_algorithm->initialize();
-  } else {
-    m_algorithm = Mantid::API::AlgorithmManager::Instance().createUnmanaged("ReflectometryReductionOneAuto");
-  }
+OptionDefaults::OptionDefaults(Mantid::Geometry::Instrument_const_sptr instrument, const std::string &algorithmName)
+    : m_algorithm(Mantid::API::AlgorithmManager::Instance().createUnmanaged(algorithmName)),
+      m_instrument(std::move(instrument)) {
   m_algorithm->initialize();
 }
 

--- a/qt/scientific_interfaces/ISISReflectometry/Common/OptionDefaults.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/Common/OptionDefaults.cpp
@@ -12,7 +12,7 @@
 
 namespace MantidQt::CustomInterfaces::ISISReflectometry {
 
-OptionDefaults::OptionDefaults(Mantid::Geometry::Instrument_const_sptr instrument, const std::string &algorithmName)
+OptionDefaults::OptionDefaults(Mantid::Geometry::Instrument_const_sptr instrument, std::string const &algorithmName)
     : m_algorithm(Mantid::API::AlgorithmManager::Instance().createUnmanaged(algorithmName)),
       m_instrument(std::move(instrument)) {
   m_algorithm->initialize();

--- a/qt/scientific_interfaces/ISISReflectometry/Common/OptionDefaults.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/Common/OptionDefaults.cpp
@@ -12,9 +12,14 @@
 
 namespace MantidQt::CustomInterfaces::ISISReflectometry {
 
-OptionDefaults::OptionDefaults(Mantid::Geometry::Instrument_const_sptr instrument)
-    : m_algorithm(Mantid::API::AlgorithmManager::Instance().createUnmanaged("ReflectometryReductionOneAuto")),
-      m_instrument(std::move(instrument)) {
+OptionDefaults::OptionDefaults(Mantid::Geometry::Instrument_const_sptr instrument, bool stitchDefault)
+    : m_instrument(std::move(instrument)) {
+  if (stitchDefault) {
+    m_algorithm = Mantid::API::AlgorithmManager::Instance().createUnmanaged("Stitch1DMany");
+    // m_algorithm->initialize();
+  } else {
+    m_algorithm = Mantid::API::AlgorithmManager::Instance().createUnmanaged("ReflectometryReductionOneAuto");
+  }
   m_algorithm->initialize();
 }
 

--- a/qt/scientific_interfaces/ISISReflectometry/Common/OptionDefaults.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Common/OptionDefaults.h
@@ -20,7 +20,7 @@ namespace ISISReflectometry {
 */
 class OptionDefaults {
 public:
-  explicit OptionDefaults(Mantid::Geometry::Instrument_const_sptr instrument, bool stitchDefault);
+  explicit OptionDefaults(Mantid::Geometry::Instrument_const_sptr instrument, const std::string &algorithmName);
 
   template <typename T>
   T getValueOrDefault(std::string const &propertyName, std::string const &parameterName, T defaultValue) const;

--- a/qt/scientific_interfaces/ISISReflectometry/Common/OptionDefaults.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Common/OptionDefaults.h
@@ -20,7 +20,7 @@ namespace ISISReflectometry {
 */
 class OptionDefaults {
 public:
-  explicit OptionDefaults(Mantid::Geometry::Instrument_const_sptr instrument, const std::string &algorithmName);
+  explicit OptionDefaults(Mantid::Geometry::Instrument_const_sptr instrument, std::string const &algorithmName);
 
   template <typename T>
   T getValueOrDefault(std::string const &propertyName, std::string const &parameterName, T defaultValue) const;

--- a/qt/scientific_interfaces/ISISReflectometry/Common/OptionDefaults.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Common/OptionDefaults.h
@@ -20,7 +20,7 @@ namespace ISISReflectometry {
 */
 class OptionDefaults {
 public:
-  explicit OptionDefaults(Mantid::Geometry::Instrument_const_sptr instrument);
+  explicit OptionDefaults(Mantid::Geometry::Instrument_const_sptr instrument, bool stitchDefault);
 
   template <typename T>
   T getValueOrDefault(std::string const &propertyName, std::string const &parameterName, T defaultValue) const;

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/ExperimentOptionDefaults.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/ExperimentOptionDefaults.cpp
@@ -12,7 +12,6 @@
 #include "LookupTableValidator.h"
 #include "MantidAPI/AlgorithmManager.h"
 #include "Reduction/Experiment.h"
-#include "Reduction/ParseReflectometryStrings.h"
 
 namespace MantidQt::CustomInterfaces::ISISReflectometry {
 

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/ExperimentOptionDefaults.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/ExperimentOptionDefaults.cpp
@@ -24,7 +24,7 @@ std::string stringValueOrEmpty(boost::optional<double> value) { return value ? s
 
 Experiment getExperimentDefaults(Mantid::Geometry::Instrument_const_sptr instrument) {
   // Looks for defaults for use in ReflectometryReductionOneAuto algorithm
-  auto defaults = OptionDefaults(instrument, false);
+  auto defaults = OptionDefaults(instrument, "ReflectometryReductionOneAuto");
 
   auto analysisMode =
       analysisModeFromString(defaults.getStringOrDefault("AnalysisMode", "AnalysisMode", "PointDetectorAnalysis"));
@@ -66,7 +66,7 @@ Experiment getExperimentDefaults(Mantid::Geometry::Instrument_const_sptr instrum
       TransmissionStitchOptions(transmissionRunRange, transmissionStitchParams, transmissionScaleRHS);
 
   // Looks for default Output Stitch Properties for use in Stitch1DMany algorithm
-  auto stitchDefaults = OptionDefaults(std::move(instrument), true);
+  auto stitchDefaults = OptionDefaults(std::move(instrument), "Stitch1DMany");
   auto stitchParameters = std::map<std::string, std::string>();
   stitchParameters["Params"] = stitchDefaults.getStringOrEmpty("Params", "StitchParams");
   stitchParameters["StartOverlaps"] = stitchDefaults.getStringOrEmpty("StartOverlaps", "StitchStartOverlaps");

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/ExperimentOptionDefaults.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/ExperimentOptionDefaults.cpp
@@ -22,15 +22,15 @@ Mantid::Kernel::Logger g_log("Reflectometry GUI");
 
 std::string stringValueOrEmpty(boost::optional<double> value) { return value ? std::to_string(*value) : ""; }
 
-std::map<std::string, std::string> getStitchParams(Mantid::Geometry::Instrument_const_sptr instrument,
-                                                   OptionDefaults &stitchDefaults) {
-  auto initialStitchParameters = std::map<std::string, std::string>();
-  auto alg = Mantid::API::AlgorithmManager::Instance().create("Stitch1DMany");
-  auto params = alg->getProperties();
-  for (auto &prop : params) {
-    std::string stitchName = "Stitch" + (*prop).name();
-    if (!stitchDefaults.getStringOrEmpty((*prop).name(), stitchName).empty()) {
-      initialStitchParameters[(*prop).name()] = stitchDefaults.getStringOrEmpty((*prop).name(), stitchName);
+std::map<std::string, std::string> getStitchParams(OptionDefaults const &stitchDefaults) {
+  std::map<std::string, std::string> initialStitchParameters;
+  auto const &alg = Mantid::API::AlgorithmManager::Instance().create("Stitch1DMany");
+  auto const &propNames = alg->getDeclaredPropertyNames();
+  for (auto const &propName : propNames) {
+    std::string const &stitchName = "Stitch" + propName;
+    auto const &propValue = stitchDefaults.getStringOrEmpty(propName, stitchName);
+    if (!propValue.empty()) {
+      initialStitchParameters[propName] = propValue;
     }
   }
   return initialStitchParameters;
@@ -80,9 +80,8 @@ Experiment getExperimentDefaults(Mantid::Geometry::Instrument_const_sptr instrum
       TransmissionStitchOptions(transmissionRunRange, transmissionStitchParams, transmissionScaleRHS);
 
   // Looks for default Output Stitch Properties for use in Stitch1DMany algorithm
-  auto stitchDefaults = OptionDefaults(std::move(instrument), "Stitch1DMany");
-  auto stitchParameters = std::map<std::string, std::string>();
-  stitchParameters = getStitchParams(instrument, stitchDefaults);
+  auto const &stitchDefaults = OptionDefaults(std::move(instrument), "Stitch1DMany");
+  auto const &stitchParameters = getStitchParams(stitchDefaults);
 
   // For per-theta defaults, we can only specify defaults for the wildcard row
   // i.e.  where theta is empty. It probably doesn't make sense to specify

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/ExperimentOptionDefaults.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Experiment/ExperimentOptionDefaults.cpp
@@ -25,12 +25,12 @@ std::string stringValueOrEmpty(boost::optional<double> value) { return value ? s
 std::map<std::string, std::string> getStitchParams(OptionDefaults const &stitchDefaults) {
   std::map<std::string, std::string> initialStitchParameters;
   auto const &alg = Mantid::API::AlgorithmManager::Instance().create("Stitch1DMany");
-  auto const &propNames = alg->getDeclaredPropertyNames();
-  for (auto const &propName : propNames) {
-    std::string const &stitchName = "Stitch" + propName;
-    auto const &propValue = stitchDefaults.getStringOrEmpty(propName, stitchName);
+  auto const &algPropNames = alg->getDeclaredPropertyNames();
+  for (auto const &algPropName : algPropNames) {
+    std::string const &defaultPropName = "Stitch" + algPropName;
+    auto const &propValue = stitchDefaults.getStringOrEmpty(algPropName, defaultPropName);
     if (!propValue.empty()) {
-      initialStitchParameters[propName] = propValue;
+      initialStitchParameters[algPropName] = propValue;
     }
   }
   return initialStitchParameters;

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Instrument/InstrumentOptionDefaults.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Instrument/InstrumentOptionDefaults.cpp
@@ -19,7 +19,7 @@ namespace {
 Mantid::Kernel::Logger g_log("Reflectometry GUI");
 
 Instrument getInstrumentDefaults(Mantid::Geometry::Instrument_const_sptr instrument) {
-  auto defaults = OptionDefaults(std::move(instrument), false);
+  auto defaults = OptionDefaults(std::move(instrument), "ReflectometryReductionOneAuto");
 
   auto wavelengthRange = RangeInLambda(defaults.getValue<double>("WavelengthMin", "LambdaMin"),
                                        defaults.getValue<double>("WavelengthMax", "LambdaMax"));

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Instrument/InstrumentOptionDefaults.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Instrument/InstrumentOptionDefaults.cpp
@@ -19,7 +19,7 @@ namespace {
 Mantid::Kernel::Logger g_log("Reflectometry GUI");
 
 Instrument getInstrumentDefaults(Mantid::Geometry::Instrument_const_sptr instrument) {
-  auto defaults = OptionDefaults(std::move(instrument));
+  auto defaults = OptionDefaults(std::move(instrument), false);
 
   auto wavelengthRange = RangeInLambda(defaults.getValue<double>("WavelengthMin", "LambdaMin"),
                                        defaults.getValue<double>("WavelengthMax", "LambdaMax"));

--- a/qt/scientific_interfaces/ISISReflectometry/test/Experiment/ExperimentOptionDefaultsTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Experiment/ExperimentOptionDefaultsTest.h
@@ -141,6 +141,16 @@ public:
 
   void testInvalidCorrectionOptionsFromParamsFile() { getDefaultsFromParamsFileThrows("Correction_Invalid"); }
 
+  void testDefaultStitchParamsOptions() {
+    auto result = getDefaults();
+    TS_ASSERT_EQUALS(result.stitchParameters().empty(), true);
+  }
+
+  void testValidStitchParamsOptionsFromParamsFile() {
+    auto result = getDefaultsFromParamsFile("Experiment");
+    TS_ASSERT_EQUALS(result.stitchParameters().size(), 1);
+  }
+
 private:
   Experiment getDefaults() {
     // Provide the mandatory params file so that we don't throw. Other params

--- a/qt/scientific_interfaces/ISISReflectometry/test/Experiment/ExperimentOptionDefaultsTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Experiment/ExperimentOptionDefaultsTest.h
@@ -148,7 +148,10 @@ public:
 
   void testValidStitchParamsOptionsFromParamsFile() {
     auto result = getDefaultsFromParamsFile("Experiment");
-    TS_ASSERT_EQUALS(result.stitchParameters().size(), 1);
+    auto stitchResults = result.stitchParameters();
+    TS_ASSERT_EQUALS(stitchResults.size(), 1);
+    TS_ASSERT_EQUALS(stitchResults.begin()->first, "ManualScaleFactors");
+    TS_ASSERT_EQUALS(stitchResults.begin()->second, "1");
   }
 
 private:


### PR DESCRIPTION
**Description of work.**
The first step in completing #34843 has been to put in the functionality to allow default stitch parameters to be taken from IPF files and added to the Experiment Tab on the Reflectometry GUI. A separate PR will be follow with changes to POLREF IPF and will include the release note.


**To test:**
1) Testing GUI still works/default is empty
- Open Mantid
- Open ISIS Reflectometry GUI
- Go to Experiment Settings Tab and check the `Output Stitch Properties` box at the bottom of the GUI is empty

2) Test it will pull in defaults when they exist
- Edit the `INTER_Parameters.xml` file that Mantid will use. This will either be located in your development folders (`../instrument/INTER_Parameters.xml`) or for Windows users it might be in `../Users/yourFedID/AppData/Roaming/mantidproject/mantid/instrument/INTER_Parameters.xml` . Add the following bit of code 

```  xml
<parameter name="StitchManualScaleFactors" type="string">
    <value val="1"/>
</parameter> 
```
- Open Mantid
- Open ISIS Reflectometry GUI
- Go to Experiment Settings Tab and check the `Output Stitch Properties` box at the bottom of the GUI should have `ManualScaleFactors='1'` in it
- Don't forget to remove edits from your IPF file when you're finished!


*This does not require release notes* because **they will be added in the 2nd PR for this issue**.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
