### PR TITLE
Add build pin to cmake to fix packaging error

### DIFF
--- a/conda/recipes/conda_build_config.yaml
+++ b/conda/recipes/conda_build_config.yaml
@@ -72,9 +72,16 @@ readline:
 filelock:
   - <3.10.2
 
+cmake:
+  - <3.26.1
+
+libcxx:
+  - <16
+
 pin_run_as_build:
     boost:
       max_pin: x.x
+
 
 # Otherwise it will find the wrong sdk, currently working on 10.10 as that is what Anaconda/conda-build does.
 CONDA_BUILD_SYSROOT:

--- a/conda/recipes/mantid/bld.bat
+++ b/conda/recipes/mantid/bld.bat
@@ -1,3 +1,7 @@
+conda list --explicit --prefix %BUILD_PREFIX% > %SRC_DIR%\mantid_build_environment.txt
+
+conda list --explicit --prefix %PREFIX% > %SRC_DIR%\mantid_host_environment.txt
+
 mkdir build && cd build
 
 cmake ^
@@ -14,9 +18,6 @@ cmake ^
     -DENABLE_WORKBENCH=OFF ^
     ..
 
-conda list --explicit --prefix %BUILD_PREFIX% > %SRC_DIR%\mantid_build_environment.txt
-
-conda list --explicit --prefix %PREFIX% > %SRC_DIR%\mantid_host_environment.txt
 
 if errorlevel 1 exit 1
 cmake --build . --config Release

--- a/conda/recipes/mantid/bld.bat
+++ b/conda/recipes/mantid/bld.bat
@@ -14,6 +14,10 @@ cmake ^
     -DENABLE_WORKBENCH=OFF ^
     ..
 
+conda list --explicit --prefix %BUILD_PREFIX% > %SRC_DIR%\mantid_build_environment.txt
+
+conda list --explicit --prefix %PREFIX% > %SRC_DIR%\mantid_host_environment.txt
+
 if errorlevel 1 exit 1
 cmake --build . --config Release
 cmake --build . --config Release --target install

--- a/conda/recipes/mantid/build.sh
+++ b/conda/recipes/mantid/build.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 set -ex
 
+conda list --explicit --prefix $BUILD_PREFIX > $SRC_DIR/mantid_build_environment.txt
+
+conda list --explicit --prefix $PREFIX > $SRC_DIR/mantid_host_environment.txt
+
 mkdir build
 cd build
 

--- a/conda/recipes/mantid/meta.yaml
+++ b/conda/recipes/mantid/meta.yaml
@@ -19,7 +19,7 @@ requirements:
     - llvm-openmp  # [osx]
     - libgomp  # [linux]
     - ninja  # [unix]
-    - cmake
+    - cmake {{ cmake }}  # [linux or osx]
     - git
     - {{ cdt('mesa-libgl-devel') }}  # [linux]
     - {{ cdt('mesa-dri-drivers') }}  # [linux]
@@ -49,6 +49,7 @@ requirements:
     - pip
     - openssl {{ openssl }}
     - versioningit
+    - libcxx {{ libcxx }}  # [osx]
   run:
     - {{ pin_compatible("boost", max_pin="x.x") }}
     - {{ pin_compatible("gsl", max_pin="x.x") }}


### PR DESCRIPTION
**Description of work.**

Our nightly pipeline is currently down. This appears to be caused by the most recent `cmake` update, `3.26.1`. As such, we are pinning `cmake` back to `<3.26.1`.

**To test:**

This job must pass: 
https://builds.mantidproject.org/job/build_packages_from_branch/296/

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
