### PR TITLE
Pin libcxx to fix OSX PR pipeline

### DIFF
--- a/mantid-developer-osx.yml
+++ b/mantid-developer-osx.yml
@@ -51,6 +51,7 @@ dependencies:
   - cppcheck==2.5
   - pygments==2.11.2 # Had to pin back to 2.11 due to cppcheck error which is only fixed in cppcheck>=2.8
   - pre-commit>=2.12.0
+  - libcxx<16 # Had to pin back below 16 to prevent an issue with boost (https://github.com/boostorg/container_hash/issues/22).
 
   # Use conda version of clang to get matching CXXFLAGS.
   # Pinned to same version as conda forge: https://github.com/conda-forge/conda-forge-pinning-feedstock/blob/main/recipe/conda_build_config.yaml


### PR DESCRIPTION
**Description of work.**

This PR pins `libcxx` to `<16` to enable the OSX PR pipeline to function.

An issue has been raised to remove this pin: #35417

**To test:**

Observe all tests pass.

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
