### PR TITLE
Archive logs of conda-build environments

### DIFF
--- a/buildconfig/Jenkins/Conda/nightly_build_and_deploy.jenkinsfile
+++ b/buildconfig/Jenkins/Conda/nightly_build_and_deploy.jenkinsfile
@@ -163,6 +163,7 @@ pipeline {
               // Build the base set of packages (ones not required for mantidworkbench)
               // in parallel
               package_conda("${PLATFORM}", "base")
+              archive_env_logs("${PLATFORM}")
               archive_conda_packages("${PLATFORM}", false)
               archive_conda_packages("noarch", true)
             }
@@ -208,6 +209,7 @@ pipeline {
                 target: './',
                 flatten: false
               package_conda("${PLATFORM}", "workbench")
+              archive_env_logs("${PLATFORM}")
               archive_conda_packages("${PLATFORM}", false)
               package_standalone()
               archive_standalone_package("${PLATFORM}")
@@ -451,4 +453,12 @@ def archive_standalone_package(platform) {
 
 def archive_ctest_log(){
   archiveArtifacts artifacts: "${CHECKOUT_DIR}/build/ctest_log/*.log", fingerprint: true
+}
+
+def archive_env_logs(platform) {
+  env_log_dir = "**/conda-bld/${platform}/env_logs"
+  archiveArtifacts artifacts: env_log_dir += "/**/*.*",
+    allowEmptyArchive: false,
+    fingerprint: true,
+    onlyIfSuccessful: false
 }

--- a/conda/recipes/archive_env_logs.bat
+++ b/conda/recipes/archive_env_logs.bat
@@ -1,0 +1,7 @@
+set build_prefix=%1
+set prefix=%2
+set package_name=%3
+
+if not exist ..\..\win-64\env_logs mkdir ..\..\win-64\env_logs
+conda list --explicit --prefix %build_prefix% > ..\..\win-64\env_logs\%package_name%_build_environment.txt
+conda list --explicit --prefix %prefix% > ..\..\win-64\env_logs\%package_name%_host_environment.txt

--- a/conda/recipes/archive_env_logs.bat
+++ b/conda/recipes/archive_env_logs.bat
@@ -1,7 +1,10 @@
-set build_prefix=%1
-set prefix=%2
+@echo on
+
+set build_env_prefix=%1
+set host_env_prefix=%2
 set package_name=%3
 
-if not exist ..\..\win-64\env_logs mkdir ..\..\win-64\env_logs
-conda list --explicit --prefix %build_prefix% > ..\..\win-64\env_logs\%package_name%_build_environment.txt
-conda list --explicit --prefix %prefix% > ..\..\win-64\env_logs\%package_name%_host_environment.txt
+if not exist ..\win-64\env_logs mkdir ..\win-64\env_logs
+call conda list --explicit --prefix %host_env_prefix% > ..\win-64\env_logs\%package_name%_host_environment.txt
+call conda list --explicit --prefix %build_env_prefix% > ..\win-64\env_logs\%package_name%_build_environment.txt
+

--- a/conda/recipes/archive_env_logs.sh
+++ b/conda/recipes/archive_env_logs.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -ex
+
+build_prefix=$1
+prefix=$2
+package_name=$3
+
+platform=$(uname)
+if [ "$platform" == Linux ] ; then
+  platform_dir=linux-64
+elif [ "$platform" == Darwin ] ; then
+  platform_dir=osx-64
+else
+  platform_dir=none
+fi
+
+mkdir -p ../../$platform_dir/env_logs
+conda list --explicit --prefix "$build_prefix" > ../../$platform_dir/env_logs/"${package_name}"_build_environment.txt
+conda list --explicit --prefix "$prefix" > ../../$platform_dir/env_logs/"${package_name}"_host_environment.txt

--- a/conda/recipes/mantid/bld.bat
+++ b/conda/recipes/mantid/bld.bat
@@ -1,5 +1,7 @@
+@echo on
+
 set "parent_dir=%RECIPE_DIR%\.."
-CALL "%parent_dir%\archive_env_logs.bat" %BUILD_PREFIX% %PREFIX% 'mantid'
+CALL "%parent_dir%\archive_env_logs.bat" %BUILD_PREFIX% %PREFIX% mantid
 
 mkdir build && cd build
 

--- a/conda/recipes/mantid/bld.bat
+++ b/conda/recipes/mantid/bld.bat
@@ -1,3 +1,7 @@
+if not exist ..\..\env_logs mkdir ..\..\env_logs
+conda list --explicit --prefix %BUILD_PREFIX% > ..\..\env_logs\mantid_build_environment.txt
+conda list --explicit --prefix %PREFIX% > ..\..\env_logs\mantid_host_environment.txt
+
 mkdir build && cd build
 
 cmake ^

--- a/conda/recipes/mantid/bld.bat
+++ b/conda/recipes/mantid/bld.bat
@@ -1,6 +1,5 @@
-if not exist ..\..\env_logs mkdir ..\..\env_logs
-conda list --explicit --prefix %BUILD_PREFIX% > ..\..\env_logs\mantid_build_environment.txt
-conda list --explicit --prefix %PREFIX% > ..\..\env_logs\mantid_host_environment.txt
+set "parent_dir=%RECIPE_DIR%\.."
+CALL "%parent_dir%\archive_env_logs.bat" %BUILD_PREFIX% %PREFIX% 'mantid'
 
 mkdir build && cd build
 

--- a/conda/recipes/mantid/build.sh
+++ b/conda/recipes/mantid/build.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 set -ex
 
+parent_dir="$(dirname "$RECIPE_DIR")"
+
+bash "${parent_dir}"/archive_env_logs.sh "$BUILD_PREFIX" "$PREFIX" 'mantid'
+
 mkdir build
 cd build
 

--- a/conda/recipes/mantiddocs/build.sh
+++ b/conda/recipes/mantiddocs/build.sh
@@ -29,6 +29,9 @@ function terminate_xvfb_sessions {
     fi
 }
 
+parent_dir="$(dirname "$RECIPE_DIR")"
+bash "${parent_dir}"/archive_env_logs.sh "$BUILD_PREFIX" "$PREFIX" 'mantiddocs'
+
 mkdir build
 cd build
 

--- a/conda/recipes/mantidqt/bld.bat
+++ b/conda/recipes/mantidqt/bld.bat
@@ -1,3 +1,7 @@
+if not exist ..\..\env_logs mkdir ..\..\env_logs
+conda list --explicit --prefix %BUILD_PREFIX% > ..\..\env_logs\mantidqt_build_environment.txt
+conda list --explicit --prefix %PREFIX% > ..\..\env_logs\mantidqt_host_environment.txt
+
 mkdir build && cd build
 
 cmake ^

--- a/conda/recipes/mantidqt/bld.bat
+++ b/conda/recipes/mantidqt/bld.bat
@@ -1,5 +1,5 @@
 set "parent_dir=%RECIPE_DIR%\.."
-CALL "%parent_dir%\archive_env_logs.bat" %BUILD_PREFIX% %PREFIX% 'mantid'
+CALL "%parent_dir%\archive_env_logs.bat" %BUILD_PREFIX% %PREFIX% mantidqt
 
 mkdir build && cd build
 

--- a/conda/recipes/mantidqt/bld.bat
+++ b/conda/recipes/mantidqt/bld.bat
@@ -1,6 +1,5 @@
-if not exist ..\..\env_logs mkdir ..\..\env_logs
-conda list --explicit --prefix %BUILD_PREFIX% > ..\..\env_logs\mantidqt_build_environment.txt
-conda list --explicit --prefix %PREFIX% > ..\..\env_logs\mantidqt_host_environment.txt
+set "parent_dir=%RECIPE_DIR%\.."
+CALL "%parent_dir%\archive_env_logs.bat" %BUILD_PREFIX% %PREFIX% 'mantid'
 
 mkdir build && cd build
 

--- a/conda/recipes/mantidqt/build.sh
+++ b/conda/recipes/mantidqt/build.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 set -ex
 
+parent_dir="$(dirname "$RECIPE_DIR")"
+bash "${parent_dir}"/archive_env_logs.sh "$BUILD_PREFIX" "$PREFIX" 'mantidqt'
+
 mkdir build
 cd build
 

--- a/conda/recipes/mantidworkbench/bld.bat
+++ b/conda/recipes/mantidworkbench/bld.bat
@@ -1,3 +1,7 @@
+if not exist ..\..\env_logs mkdir ..\..\env_logs
+conda list --explicit --prefix %BUILD_PREFIX% > ..\..\env_logs\mantidworkbench_build_environment.txt
+conda list --explicit --prefix %PREFIX% > ..\..\env_logs\mantidworkbench_host_environment.txt
+
 mkdir build && cd build
 
 cmake ^

--- a/conda/recipes/mantidworkbench/bld.bat
+++ b/conda/recipes/mantidworkbench/bld.bat
@@ -1,6 +1,5 @@
-if not exist ..\..\env_logs mkdir ..\..\env_logs
-conda list --explicit --prefix %BUILD_PREFIX% > ..\..\env_logs\mantidworkbench_build_environment.txt
-conda list --explicit --prefix %PREFIX% > ..\..\env_logs\mantidworkbench_host_environment.txt
+set "parent_dir=%RECIPE_DIR%\.."
+CALL "%parent_dir%\archive_env_logs.bat" %BUILD_PREFIX% %PREFIX% 'mantid'
 
 mkdir build && cd build
 

--- a/conda/recipes/mantidworkbench/bld.bat
+++ b/conda/recipes/mantidworkbench/bld.bat
@@ -1,5 +1,5 @@
 set "parent_dir=%RECIPE_DIR%\.."
-CALL "%parent_dir%\archive_env_logs.bat" %BUILD_PREFIX% %PREFIX% 'mantid'
+CALL "%parent_dir%\archive_env_logs.bat" %BUILD_PREFIX% %PREFIX% mantidworkbench
 
 mkdir build && cd build
 

--- a/conda/recipes/mantidworkbench/build.sh
+++ b/conda/recipes/mantidworkbench/build.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 set -ex
 
+parent_dir="$(dirname "$RECIPE_DIR")"
+bash "${parent_dir}"/archive_env_logs.sh "$BUILD_PREFIX" "$PREFIX" 'mantidworkbench'
+
+
 mkdir build
 cd build
 


### PR DESCRIPTION
**Description of work.**

This PR ensures that `conda-bld` archives `.txt` logs of its `build` and `host` environments. This will enable us to better track which packages change from build to build, and to easily recreate the environments for testing.

**To test:**

<!-- Instructions for testing. -->
See successful build packages from branch job, and associated archived env logs for each OS:
https://builds.mantidproject.org/job/build_packages_from_branch/341/

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
