### PR TITLE
Implement an invalid TimeROI constant

### DIFF
--- a/Framework/API/src/LogManager.cpp
+++ b/Framework/API/src/LogManager.cpp
@@ -509,7 +509,7 @@ void LogManager::saveNexus(::NeXus::File *file, const std::string &group, bool k
     }
   }
   // save the timeROI to the nexus file
-  if (!(m_timeroi->empty()))
+  if (!(m_timeroi->useAll()))
     m_timeroi->saveNexus(file);
 
   if (!keepOpen)

--- a/Framework/API/src/Run.cpp
+++ b/Framework/API/src/Run.cpp
@@ -166,16 +166,16 @@ void findAndConcatenateTimeStrProp(const Run *runObjLHS, const Run *runObjRHS, c
  */
 Run &Run::operator+=(const Run &rhs) {
   // combine the two TimeROI if either is non-empty
-  if ((!m_timeroi->empty()) || (!rhs.m_timeroi->empty())) {
+  if ((!m_timeroi->useAll()) || (!rhs.m_timeroi->useAll())) {
     TimeROI combined(*m_timeroi);
     // set this start/end time as the only ROI if it is empty
-    if (combined.empty()) {
+    if (combined.useAll()) {
       combined.addROI(this->startTime(), this->endTime());
     }
 
     // fixup the timeroi from the other
     TimeROI rightROI(*rhs.m_timeroi);
-    if (rightROI.empty() && rhs.hasStartTime() && rhs.hasEndTime()) {
+    if (rightROI.useAll() && rhs.hasStartTime() && rhs.hasEndTime()) {
       rightROI.addROI(rhs.startTime(), rhs.endTime());
     }
 
@@ -329,7 +329,7 @@ void Run::integrateProtonCharge(const std::string &logname) const {
     if (filteredLog)
       timeroi.update_or_replace_intersection(filteredLog->getTimeROI());
 
-    if (timeroi.empty()) {
+    if (timeroi.useAll()) {
       // simple accumulation
       const std::vector<double> logValues = log->valuesAsVector();
       total = std::accumulate(logValues.begin(), logValues.end(), 0.0);
@@ -375,7 +375,7 @@ void Run::integrateProtonCharge(const std::string &logname) const {
  * If the Run's TimeROI is empty, this member function does nothing.
  */
 void Run::setDuration() {
-  if (m_timeroi->empty())
+  if (m_timeroi->useAll())
     return;
   double duration{m_timeroi->durationInSeconds()};
   const std::string NAME("duration");

--- a/Framework/DataObjects/src/EventList.cpp
+++ b/Framework/DataObjects/src/EventList.cpp
@@ -3821,8 +3821,8 @@ void EventList::filterByPulseTime(Kernel::TimeROI *timeRoi, EventList &output) c
   output.setHistogram(m_histogram);
   output.setSortOrder(this->order);
 
-  if ((timeRoi == nullptr) || (timeRoi->empty())) {
-    throw std::invalid_argument("TimeROI can not be empty");
+  if ((timeRoi == nullptr) || (timeRoi->useAll())) {
+    throw std::invalid_argument("TimeROI can not use all time");
   }
   const auto &intervals = timeRoi->toSplitters();
 

--- a/Framework/DataObjects/src/TimeSplitter.cpp
+++ b/Framework/DataObjects/src/TimeSplitter.cpp
@@ -280,7 +280,7 @@ TimeROI TimeSplitter::getTimeROI(const int workspaceIndex) {
 
   // error check that something is there
   // ignore index being empty is ok
-  if ((workspaceIndex >= 0) && (output.empty())) {
+  if ((workspaceIndex >= 0) && (output.useAll())) {
     std::stringstream msg;
     msg << "No regions exist for workspace index " << workspaceIndex;
   }

--- a/Framework/DataObjects/test/TimeSplitterTest.h
+++ b/Framework/DataObjects/test/TimeSplitterTest.h
@@ -266,30 +266,30 @@ public:
 
     // start with empty TimeSplitter
     TimeSplitter splitter;
-    TS_ASSERT(splitter.getTimeROI(TimeSplitter::NO_TARGET).empty());
-    TS_ASSERT(splitter.getTimeROI(0).empty());
+    TS_ASSERT(splitter.getTimeROI(TimeSplitter::NO_TARGET).useAll());
+    TS_ASSERT(splitter.getTimeROI(0).useAll());
 
     // place to put the output
     TimeROI roi;
 
     // add a single TimeROI
     splitter.addROI(ONE, THREE, 1);
-    TS_ASSERT(splitter.getTimeROI(TimeSplitter::NO_TARGET).empty());
-    TS_ASSERT(splitter.getTimeROI(0).empty());
-    TS_ASSERT(splitter.getTimeROI(0).empty());
+    TS_ASSERT(splitter.getTimeROI(TimeSplitter::NO_TARGET).useAll());
+    TS_ASSERT(splitter.getTimeROI(0).useAll());
+    TS_ASSERT(splitter.getTimeROI(0).useAll());
     roi = splitter.getTimeROI(1);
-    TS_ASSERT(!roi.empty());
+    TS_ASSERT(!roi.useAll());
     TS_ASSERT_EQUALS(roi.numBoundaries(), 2);
 
     // add the same output index, but with a gap from the previous
     splitter.addROI(FOUR, FIVE, 1);
     roi = splitter.getTimeROI(TimeSplitter::NO_TARGET - 1); // intentionally trying a "big" negative for ignore filter
-    TS_ASSERT(!roi.empty());
+    TS_ASSERT(!roi.useAll());
     TS_ASSERT_EQUALS(roi.numBoundaries(), 2);
-    TS_ASSERT(splitter.getTimeROI(0).empty());
-    TS_ASSERT(splitter.getTimeROI(0).empty());
+    TS_ASSERT(splitter.getTimeROI(0).useAll());
+    TS_ASSERT(splitter.getTimeROI(0).useAll());
     roi = splitter.getTimeROI(1);
-    TS_ASSERT(!roi.empty());
+    TS_ASSERT(!roi.useAll());
     TS_ASSERT_EQUALS(roi.numBoundaries(), 4);
   }
 

--- a/Framework/Kernel/inc/MantidKernel/TimeROI.h
+++ b/Framework/Kernel/inc/MantidKernel/TimeROI.h
@@ -19,6 +19,7 @@ class MANTID_KERNEL_DLL TimeROI {
 public:
   /// the underlying property needs a name
   static const std::string NAME;
+  static const TimeROI INVALID_ROI;
 
   TimeROI();
   TimeROI(const Types::Core::DateAndTime &startTime, const Types::Core::DateAndTime &stopTime);
@@ -27,6 +28,7 @@ public:
   double durationInSeconds(const Types::Core::DateAndTime &startTime, const Types::Core::DateAndTime &stopTime) const;
   std::size_t numBoundaries() const;
   bool empty() const;
+  bool isValid() const;
   void clear();
   void addROI(const std::string &startTime, const std::string &stopTime);
   void addROI(const Types::Core::DateAndTime &startTime, const Types::Core::DateAndTime &stopTime);

--- a/Framework/Kernel/inc/MantidKernel/TimeROI.h
+++ b/Framework/Kernel/inc/MantidKernel/TimeROI.h
@@ -19,7 +19,7 @@ class MANTID_KERNEL_DLL TimeROI {
 public:
   /// the underlying property needs a name
   static const std::string NAME;
-  static const TimeROI INVALID_ROI;
+  static const TimeROI USE_NONE;
 
   TimeROI();
   TimeROI(const Types::Core::DateAndTime &startTime, const Types::Core::DateAndTime &stopTime);
@@ -27,8 +27,10 @@ public:
   double durationInSeconds() const;
   double durationInSeconds(const Types::Core::DateAndTime &startTime, const Types::Core::DateAndTime &stopTime) const;
   std::size_t numBoundaries() const;
-  bool empty() const;
-  bool isValid() const;
+  /// TimeROI selects all time to be used
+  bool useAll() const;
+  /// TimeROI selects no time to be used as all is invalid
+  bool useNone() const;
   void clear();
   void addROI(const std::string &startTime, const std::string &stopTime);
   void addROI(const Types::Core::DateAndTime &startTime, const Types::Core::DateAndTime &stopTime);
@@ -58,6 +60,7 @@ public:
 private:
   std::vector<Types::Core::DateAndTime> getAllTimes(const TimeROI &other);
   void validateValues(const std::string &label);
+  bool empty() const;
   bool isCompletelyInROI(const Types::Core::DateAndTime &startTime, const Types::Core::DateAndTime &stopTime) const;
   bool isCompletelyInMask(const Types::Core::DateAndTime &startTime, const Types::Core::DateAndTime &stopTime) const;
   bool valueAtTime(const std::vector<Types::Core::DateAndTime>::iterator &time);

--- a/Framework/Kernel/src/FilteredTimeSeriesProperty.cpp
+++ b/Framework/Kernel/src/FilteredTimeSeriesProperty.cpp
@@ -97,7 +97,7 @@ template <typename HeldType> FilteredTimeSeriesProperty<HeldType>::~FilteredTime
 template <typename TYPE>
 std::vector<TYPE> FilteredTimeSeriesProperty<TYPE>::filteredValuesAsVector(const Kernel::TimeROI *roi) const {
   // if this is not filtered just return the parent version
-  if (this->m_filter->empty()) {
+  if (this->m_filter->useAll()) {
     return TimeSeriesProperty<TYPE>::filteredValuesAsVector(roi); // no filtering to do
   }
   // if the supplied roi is empty use just this one
@@ -115,7 +115,7 @@ template <typename TYPE> std::vector<TYPE> FilteredTimeSeriesProperty<TYPE>::fil
  */
 template <typename TYPE>
 std::vector<DateAndTime> FilteredTimeSeriesProperty<TYPE>::filteredTimesAsVector(const Kernel::TimeROI *roi) const {
-  if (m_filter->empty()) {
+  if (m_filter->useAll()) {
     return TimeSeriesProperty<TYPE>::filteredTimesAsVector(roi); // no filtering to do
   }
   const auto internalRoi = this->intersectFilterWithOther(roi);
@@ -146,7 +146,7 @@ template <typename TYPE> TimeInterval FilteredTimeSeriesProperty<TYPE>::nthInter
 
   // Calculate time interval
   Kernel::TimeInterval deltaT;
-  if (m_filter->empty()) {
+  if (m_filter->useAll()) {
     // No filter uses the parent class implmentation
     deltaT = TimeSeriesProperty<TYPE>::nthInterval(n);
   } else {
@@ -172,7 +172,7 @@ template <typename TYPE> TYPE FilteredTimeSeriesProperty<TYPE>::nthValue(int n) 
   }
 
   TYPE value;
-  if (m_filter->empty()) {
+  if (m_filter->useAll()) {
     // 3. Situation 1:  No filter
     value = TimeSeriesProperty<TYPE>::nthValue(n);
   } else {
@@ -233,7 +233,7 @@ template <typename TYPE> void FilteredTimeSeriesProperty<TYPE>::filterWith(const
 }
 
 template <typename TYPE> void FilteredTimeSeriesProperty<TYPE>::filterWith(const TimeROI &filter) {
-  if (filter.empty()) {
+  if (filter.useAll()) {
     // if filter is empty, clear the current
     this->clearFilter();
   } else {
@@ -267,7 +267,7 @@ template <typename TYPE> void FilteredTimeSeriesProperty<TYPE>::clearFilterCache
  * Updates size()
  */
 template <typename TYPE> void FilteredTimeSeriesProperty<TYPE>::countSize() const {
-  if (m_filter->empty()) {
+  if (m_filter->useAll()) {
     // 1. Not filter
     this->m_size = int(this->m_values.size());
   } else {
@@ -298,7 +298,7 @@ template <typename TYPE> void FilteredTimeSeriesProperty<TYPE>::applyFilter() co
   // clear out the previous version
   this->clearFilterCache();
 
-  if (m_filter->empty())
+  if (m_filter->useAll())
     return;
 
   // 2. Apply filter
@@ -394,7 +394,7 @@ template <typename TYPE> std::string FilteredTimeSeriesProperty<TYPE>::setValueF
 template <typename TYPE>
 Kernel::TimeROI *FilteredTimeSeriesProperty<TYPE>::intersectFilterWithOther(const TimeROI *other) const {
   auto roi = new TimeROI(*m_filter.get());
-  if (other && (!other->empty()))
+  if (other && (!other->useAll()))
     roi->update_or_replace_intersection(*other);
   return roi;
 }
@@ -410,7 +410,7 @@ template <typename TYPE> const Kernel::TimeROI &FilteredTimeSeriesProperty<TYPE>
  */
 template <typename TYPE>
 std::vector<SplittingInterval> FilteredTimeSeriesProperty<TYPE>::getSplittingIntervals() const {
-  if (m_filter->empty()) {
+  if (m_filter->useAll()) {
     // Case where there is no filter just use the parent implementation
     return TimeSeriesProperty<TYPE>::getSplittingIntervals();
   } else {
@@ -431,7 +431,7 @@ bool FilteredTimeSeriesProperty<HeldType>::operator==(const TimeSeriesProperty<H
   } else {
     // only need to compare the filters
     const auto rhs_ftsp = dynamic_cast<const FilteredTimeSeriesProperty<HeldType> *>(&right);
-    if (m_filter->empty()) {
+    if (m_filter->useAll()) {
       if (!rhs_ftsp) {
         // simple compare is fine
         return time_and_value_compare;

--- a/Framework/Kernel/src/TimeROI.cpp
+++ b/Framework/Kernel/src/TimeROI.cpp
@@ -60,7 +60,8 @@ bool overlaps(const TimeInterval &left, const TimeInterval &right) {
 } // namespace
 
 const std::string TimeROI::NAME = "Kernel_TimeROI";
-const TimeROI TimeROI::INVALID_ROI{DateAndTime::GPS_EPOCH - DateAndTime::ONE_SECOND, DateAndTime::GPS_EPOCH};
+/// Constant for TimeROI where no time is used
+const TimeROI TimeROI::USE_NONE{DateAndTime::GPS_EPOCH - DateAndTime::ONE_SECOND, DateAndTime::GPS_EPOCH};
 
 TimeROI::TimeROI() {}
 
@@ -145,7 +146,7 @@ void TimeROI::addMask(const std::string &startTime, const std::string &stopTime)
 void TimeROI::addMask(const Types::Core::DateAndTime &startTime, const Types::Core::DateAndTime &stopTime) {
   assert_increasing(startTime, stopTime);
 
-  if (this->empty()) {
+  if (this->useAll()) {
     g_log.debug("TimeROI::addMask to an empty object is ignored");
   } else if (this->isCompletelyInMask(startTime, stopTime)) {
     g_log.debug("TimeROI::addMask to ignored region");
@@ -242,7 +243,7 @@ bool TimeROI::isCompletelyInROI(const Types::Core::DateAndTime &startTime,
  */
 bool TimeROI::isCompletelyInMask(const Types::Core::DateAndTime &startTime,
                                  const Types::Core::DateAndTime &stopTime) const {
-  if (this->empty())
+  if (this->useAll())
     return true;
   if (startTime >= m_roi.back())
     return true;
@@ -266,7 +267,7 @@ bool TimeROI::isCompletelyInMask(const Types::Core::DateAndTime &startTime,
  * The value is, essentially, whatever it was at the last recorded time before or equal to the one requested.
  */
 bool TimeROI::valueAtTime(const Types::Core::DateAndTime &time) const {
-  if (this->empty() || time < m_roi.front() || time >= m_roi.back()) {
+  if (this->useAll() || time < m_roi.front() || time >= m_roi.back()) {
     // ignore everything outside of range
     return ROI_IGNORE;
   } else {
@@ -394,7 +395,7 @@ void TimeROI::replaceROI(const TimeSeriesProperty<bool> *roi) {
 
 void TimeROI::replaceROI(const TimeROI &other) {
   m_roi.clear();
-  if (!other.empty())
+  if (!other.useAll())
     m_roi.assign(other.m_roi.cbegin(), other.m_roi.cend());
 }
 
@@ -426,7 +427,7 @@ void TimeROI::update_intersection(const TimeROI &other) {
   if (*this == other)
     return;
 
-  if (other.empty() || this->empty()) {
+  if (other.useAll() || this->useAll()) {
     // empty out this environment
     m_roi.clear();
   } else {
@@ -449,7 +450,7 @@ void TimeROI::update_intersection(const TimeROI &other) {
     // if the TimeROI became empty it is because there is no overlap
     // reset the value to INVALID_ROI
     if (this->empty()) {
-      this->replaceROI(INVALID_ROI);
+      this->replaceROI(USE_NONE);
     }
   }
 }
@@ -463,9 +464,9 @@ void TimeROI::update_intersection(const TimeROI &other) {
  * @param other :: the replacing or intersecting TimeROI.
  */
 void TimeROI::update_or_replace_intersection(const TimeROI &other) {
-  if (this->empty()) {
+  if (this->useAll()) {
     this->replaceROI(other);
-  } else if (!other.empty()) {
+  } else if (!other.useAll()) {
     this->update_intersection(other);
   }
 }
@@ -521,7 +522,7 @@ double TimeROI::durationInSeconds() const {
   const auto ROI_SIZE = this->numBoundaries();
   if (ROI_SIZE == 0) {
     return 0.;
-  } else if (!this->isValid()) {
+  } else if (this->useNone()) {
     return -1.;
   } else {
     double total{0.};
@@ -541,7 +542,7 @@ double TimeROI::durationInSeconds(const Types::Core::DateAndTime &startTime,
   assert_increasing(startTime, stopTime);
 
   // just return the difference between the supplied other times if this has no regions
-  if (this->empty()) {
+  if (this->useAll()) {
     return DateAndTime::secondsFromDuration(stopTime - startTime);
   }
 
@@ -584,7 +585,9 @@ std::size_t TimeROI::numBoundaries() const { return static_cast<std::size_t>(m_r
 
 bool TimeROI::empty() const { return bool(this->numBoundaries() == 0); }
 
-bool TimeROI::isValid() const { return *this != INVALID_ROI; }
+bool TimeROI::useAll() const { return this->empty(); }
+
+bool TimeROI::useNone() const { return *this == USE_NONE; }
 
 /// Removes all ROI's, leaving an empty object
 void TimeROI::clear() { m_roi.clear(); }

--- a/Framework/Kernel/src/TimeROI.cpp
+++ b/Framework/Kernel/src/TimeROI.cpp
@@ -60,6 +60,7 @@ bool overlaps(const TimeInterval &left, const TimeInterval &right) {
 } // namespace
 
 const std::string TimeROI::NAME = "Kernel_TimeROI";
+const TimeROI TimeROI::INVALID_ROI{DateAndTime::GPS_EPOCH - DateAndTime::ONE_SECOND, DateAndTime::GPS_EPOCH};
 
 TimeROI::TimeROI() {}
 
@@ -444,6 +445,12 @@ void TimeROI::update_intersection(const TimeROI &other) {
     if (m_roi.back() > other.m_roi.back()) {
       this->addMask(other.m_roi.back(), m_roi.back());
     }
+
+    // if the TimeROI became empty it is because there is no overlap
+    // reset the value to INVALID_ROI
+    if (this->empty()) {
+      this->replaceROI(INVALID_ROI);
+    }
   }
 }
 
@@ -514,6 +521,8 @@ double TimeROI::durationInSeconds() const {
   const auto ROI_SIZE = this->numBoundaries();
   if (ROI_SIZE == 0) {
     return 0.;
+  } else if (!this->isValid()) {
+    return -1.;
   } else {
     double total{0.};
     for (std::size_t i = 0; i < ROI_SIZE - 1; i += 2) {
@@ -574,6 +583,8 @@ void TimeROI::validateValues(const std::string &label) {
 std::size_t TimeROI::numBoundaries() const { return static_cast<std::size_t>(m_roi.size()); }
 
 bool TimeROI::empty() const { return bool(this->numBoundaries() == 0); }
+
+bool TimeROI::isValid() const { return *this != INVALID_ROI; }
 
 /// Removes all ROI's, leaving an empty object
 void TimeROI::clear() { m_roi.clear(); }

--- a/Framework/Kernel/src/TimeSeriesProperty.cpp
+++ b/Framework/Kernel/src/TimeSeriesProperty.cpp
@@ -798,7 +798,7 @@ void TimeSeriesProperty<std::string>::expandFilterToRange(std::vector<SplittingI
 template <typename TYPE> double TimeSeriesProperty<TYPE>::timeAverageValue(const TimeROI *timeRoi) const {
   double retVal = 0.0;
   try {
-    if ((timeRoi == nullptr) || (timeRoi->empty())) {
+    if ((timeRoi == nullptr) || (timeRoi->useAll())) {
       const auto &filter = getSplittingIntervals();
       retVal = this->averageValueInFilter(filter);
     } else {
@@ -946,7 +946,7 @@ std::pair<double, double> TimeSeriesProperty<TYPE>::timeAverageValueAndStdDev(co
 
   // Derive splitting intervals from either the roi or from the first/last entries in the time series
   std::vector<SplittingInterval> filter;
-  if (timeRoi && !timeRoi->empty()) {
+  if (timeRoi && !timeRoi->useAll()) {
     filter = timeRoi->toSplitters();
   } else {
     filter = this->getSplittingIntervals();
@@ -1049,7 +1049,7 @@ template <typename TYPE> std::vector<DateAndTime> TimeSeriesProperty<TYPE>::time
  */
 template <typename TYPE>
 std::vector<DateAndTime> TimeSeriesProperty<TYPE>::filteredTimesAsVector(const Kernel::TimeROI *roi) const {
-  if (!roi || roi->empty()) {
+  if (!roi || roi->useAll()) {
     return this->timesAsVector();
   } else {
     std::vector<DateAndTime> out;
@@ -1243,7 +1243,7 @@ template <typename TYPE> TYPE TimeSeriesProperty<TYPE>::lastValue() const {
 template <typename TYPE> double TimeSeriesProperty<TYPE>::durationInSeconds(const Kernel::TimeROI *roi) const {
   if (this->size() == 0)
     return std::numeric_limits<double>::quiet_NaN();
-  if (roi && !roi->empty()) {
+  if (roi && !roi->useAll()) {
     Kernel::TimeROI seriesSpan(*roi);
     // remove everything before the start time
     seriesSpan.addMask(DateAndTime::GPS_EPOCH, this->firstTime());
@@ -2105,7 +2105,7 @@ void TimeSeriesProperty<std::string>::histogramData(const Types::Core::DateAndTi
  * @returns :: Vector of included values only.
  */
 template <typename TYPE> std::vector<TYPE> TimeSeriesProperty<TYPE>::filteredValuesAsVector(const TimeROI *roi) const {
-  if (roi && !roi->empty()) {
+  if (roi && !roi->useAll()) {
     std::vector<TYPE> filteredValues;
     for (const auto &timeAndValue : this->m_values)
       if (roi->valueAtTime(timeAndValue.time()))

--- a/Framework/Kernel/test/TimeROITest.h
+++ b/Framework/Kernel/test/TimeROITest.h
@@ -49,7 +49,7 @@ public:
   void test_emptyROI() {
     TimeROI value;
     TS_ASSERT_EQUALS(value.durationInSeconds(), 0.);
-    TS_ASSERT(value.empty());
+    TS_ASSERT(value.useAll());
     TS_ASSERT_EQUALS(value.numBoundaries(), 0);
   }
 
@@ -109,7 +109,7 @@ public:
     value.addROI(HANUKKAH_START, HANUKKAH_STOP);
     TS_ASSERT_EQUALS(value.durationInSeconds(), HANUKKAH_DURATION);
     TS_ASSERT_EQUALS(value.numBoundaries(), 2);
-    TS_ASSERT(!value.empty());
+    TS_ASSERT(!value.useAll());
 
     // add New Year's eve
     value.addROI(NEW_YEARS_START, NEW_YEARS_STOP);
@@ -210,7 +210,7 @@ public:
     // remove the rest
     value.addMask(ONE, FOUR);
     TS_ASSERT_EQUALS(value.durationInSeconds() / ONE_DAY_DURATION, 0.);
-    TS_ASSERT(value.empty());
+    TS_ASSERT(value.useAll());
 
     // add back an ROI then remove parts until nothing is left
     value.addROI(TWO, FIVE); // 2-5
@@ -227,7 +227,7 @@ public:
 
     value.addMask(FOUR, FIVE); // empty
     TS_ASSERT_EQUALS(value.durationInSeconds() / ONE_DAY_DURATION, 0.);
-    TS_ASSERT(value.empty());
+    TS_ASSERT(value.useAll());
   }
 
   void test_redundantValues() {
@@ -255,11 +255,11 @@ public:
     TimeROI value;
     // the result is empty
     value.addMask(DateAndTime(NEW_YEARS_START), DateAndTime(NEW_YEARS_STOP));
-    TS_ASSERT(value.empty());
+    TS_ASSERT(value.useAll());
 
     // since it ends with "on" the duration is infinite
     TS_ASSERT_EQUALS(value.durationInSeconds(), 0.);
-    TS_ASSERT(value.empty());
+    TS_ASSERT(value.useAll());
   }
 
   void test_overwrite() {
@@ -268,7 +268,7 @@ public:
     value1.addMask(DateAndTime(NEW_YEARS_START), DateAndTime(NEW_YEARS_STOP));
     // since it ends with "on" the duration is infinite
     TS_ASSERT_EQUALS(value1.durationInSeconds(), 0.);
-    TS_ASSERT(value1.empty());
+    TS_ASSERT(value1.useAll());
 
     value1.addROI(DateAndTime(NEW_YEARS_START), DateAndTime(NEW_YEARS_STOP));
     TS_ASSERT_EQUALS(value1.durationInSeconds(), ONE_DAY_DURATION);
@@ -436,8 +436,8 @@ public:
   }
 
   void test_invalidROI() {
-    TS_ASSERT(!TimeROI::INVALID_ROI.isValid());
-    TS_ASSERT_EQUALS(TimeROI::INVALID_ROI.durationInSeconds(), -1);
+    TS_ASSERT(TimeROI::USE_NONE.useNone());
+    TS_ASSERT_EQUALS(TimeROI::USE_NONE.durationInSeconds(), -1);
   }
 
   void test_debugStrPrint() {

--- a/Framework/Kernel/test/TimeROITest.h
+++ b/Framework/Kernel/test/TimeROITest.h
@@ -325,7 +325,7 @@ public:
     runIntersectionTest(left, right, 5. * ONE_DAY_DURATION);
   }
 
-  void test_intersection_no_overlap() { runIntersectionTest(CHRISTMAS, TimeROI{NEW_YEARS_START, NEW_YEARS_STOP}, 0.); }
+  void test_intersection_no_overlap() { runIntersectionTest(CHRISTMAS, TimeROI{NEW_YEARS_START, NEW_YEARS_STOP}, -1.); }
 
   void test_intersection_one_empty() { runIntersectionTest(CHRISTMAS, TimeROI(), 0.); }
 
@@ -433,6 +433,11 @@ public:
     TS_ASSERT_EQUALS(roi.getEffectiveTime(HANUKKAH_START), HANUKKAH_START);
     TS_ASSERT_EQUALS(roi.getEffectiveTime(CHRISTMAS_START), CHRISTMAS_START);
     TS_ASSERT_THROWS(roi.getEffectiveTime(DECEMBER_STOP), const std::runtime_error &);
+  }
+
+  void test_invalidROI() {
+    TS_ASSERT(!TimeROI::INVALID_ROI.isValid());
+    TS_ASSERT_EQUALS(TimeROI::INVALID_ROI.durationInSeconds(), -1);
   }
 
   void test_debugStrPrint() {


### PR DESCRIPTION
It is necessary to have a constant for invalid `TimeROI` since an empty one means to use everything.

**To test:**

Look at the new unit tests

Refs #34794

*This does not require release notes* because they are already covered in #35423.

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
