### PR TITLE
Slice viewer improvements - extents and tick behavior changes

### DIFF
--- a/Testing/SystemTests/tests/qt/SliceViewerIntegrationTest.py
+++ b/Testing/SystemTests/tests/qt/SliceViewerIntegrationTest.py
@@ -580,7 +580,7 @@ class SliceViewerTestAxesLimitsRespectNonorthogonalTransform(systemtesting.Manti
         # set nonorthog view and retrieve new limits
         pres.nonorthogonal_axes(True)
         limits_nonorthog = pres.view.data_view.get_data_limits_to_fill_current_axes()
-        self.assertAlmostEqual(limits_nonorthog[0][0], -10, delta=1e-5)
+        self.assertAlmostEqual(limits_nonorthog[0][0], -19, delta=1e-5)
         self.assertAlmostEqual(limits_nonorthog[0][1], 19, delta=1e-5)
         self.assertEqual(limits_nonorthog[1], limits[2:])
 

--- a/Testing/SystemTests/tests/qt/SliceViewerIntegrationTest.py
+++ b/Testing/SystemTests/tests/qt/SliceViewerIntegrationTest.py
@@ -581,7 +581,7 @@ class SliceViewerTestAxesLimitsRespectNonorthogonalTransform(systemtesting.Manti
         pres.nonorthogonal_axes(True)
         limits_nonorthog = pres.view.data_view.get_data_limits_to_fill_current_axes()
         self.assertAlmostEqual(limits_nonorthog[0][0], -10, delta=1e-5)
-        self.assertAlmostEqual(limits_nonorthog[0][1], 10, delta=1e-5)
+        self.assertAlmostEqual(limits_nonorthog[0][1], 19, delta=1e-5)
         self.assertEqual(limits_nonorthog[1], limits[2:])
 
         pres.view.close()

--- a/Testing/SystemTests/tests/qt/SliceViewerIntegrationTest.py
+++ b/Testing/SystemTests/tests/qt/SliceViewerIntegrationTest.py
@@ -28,7 +28,7 @@ from mantid.simpleapi import (
     SetUB,
     RenameWorkspace,
     ClearUB,
-    LoadMD,
+    Load,
 )
 from mantid.api import AnalysisDataService
 from mantidqt.utils.qt.testing import get_application
@@ -593,7 +593,7 @@ class SliceViewerTestAxesLimitsRespectNonorthogonalTransform(systemtesting.Manti
 class SliceViewerTestLoadMD(systemtesting.MantidSystemTest, HelperTestingClass):
     def runTest(self):
         HelperTestingClass.__init__(self)
-        ws = LoadMD("MDNormHYSPEC.nxs")
+        ws = Load("MDNormHYSPEC.nxs")
         pres = SliceViewer(ws)
         self.assertAlmostEqual(pres.get_proj_matrix().flatten().tolist(), [1, 0, 0, 0, 1, 0, 0, 0, 1])
         pres.view.close()

--- a/Testing/SystemTests/tests/qt/SliceViewerIntegrationTest.py
+++ b/Testing/SystemTests/tests/qt/SliceViewerIntegrationTest.py
@@ -506,8 +506,8 @@ class SliceViewerTestAxesLimitsRespectNonorthogonalTransform(systemtesting.Manti
         # set nonorthog view and retrieve new limits
         pres.nonorthogonal_axes(True)
         limits_nonorthog = pres.view.data_view.get_data_limits_to_fill_current_axes()
-        self.assertAlmostEqual(limits_nonorthog[0][0], -19, delta=1e-5)
-        self.assertAlmostEqual(limits_nonorthog[0][1], 19, delta=1e-5)
+        self.assertAlmostEqual(limits_nonorthog[0][0], -10, delta=1e-5)
+        self.assertAlmostEqual(limits_nonorthog[0][1], 10, delta=1e-5)
         self.assertEqual(limits_nonorthog[1], limits[2:])
 
         pres.view.close()

--- a/Testing/SystemTests/tests/qt/SliceViewerIntegrationTest.py
+++ b/Testing/SystemTests/tests/qt/SliceViewerIntegrationTest.py
@@ -8,7 +8,11 @@
 from functools import partial
 import io
 import systemtesting
+import os
 import sys
+import shutil
+import tempfile
+
 from threading import Thread
 from unittest.mock import patch
 
@@ -28,7 +32,10 @@ from mantid.simpleapi import (
     SetUB,
     RenameWorkspace,
     ClearUB,
-    Load,
+    LoadMD,
+    SaveMD,
+    AddSampleLog,
+    SetMDFrame,
 )
 from mantid.api import AnalysisDataService
 from mantidqt.utils.qt.testing import get_application
@@ -116,9 +123,6 @@ class HelperTestingClass(QtWidgetFinder):
 
     def requiredMemoryMB(self):
         return 5000
-
-    def requiredFiles(self):
-        return ["MDNormHYSPEC.nxs"]
 
     # private methods
     def _assertNoErrorInADSHandlerFromSeparateThread(self, operation):
@@ -593,10 +597,32 @@ class SliceViewerTestAxesLimitsRespectNonorthogonalTransform(systemtesting.Manti
 class SliceViewerTestLoadMD(systemtesting.MantidSystemTest, HelperTestingClass):
     def runTest(self):
         HelperTestingClass.__init__(self)
-        ws = Load("MDNormHYSPEC.nxs")
+
+        test_dir = tempfile.mkdtemp()
+
+        ws = CreateMDHistoWorkspace(
+            Dimensionality=4,
+            Extents="-3,3,-10,10,-5,5,0,2",
+            SignalInput=[1] * 11**4,
+            ErrorInput=[1] * 11**4,
+            NumberOfBins="11,11,11,11",
+            Names="values,[H,0,0],[0,K,0],[0,0,L]",
+            Units="a.b.u.,r.l.u.,r.l.u.,r.l.u.",
+            Frames="General Frame,HKL,HKL,HKL",
+        )
+
+        SetMDFrame("ws", MDFrame="HKL", Axes=[1, 2, 3])
+        AddSampleLog("ws", LogName="sample")
+        ws.getExperimentInfo(0).run().addProperty("W_MATRIX", [1, 0, 0, 0, 1, 0, 0, 0, 1], True)
+        SaveMD("ws", Filename=os.path.join(test_dir, "mdhist_4d.nxs"))
+        DeleteWorkspace("ws")
+
+        ws = LoadMD(os.path.join(test_dir, "mdhist_4d.nxs"))
         pres = SliceViewer(ws)
         self.assertAlmostEqual(pres.get_proj_matrix().flatten().tolist(), [1, 0, 0, 0, 1, 0, 0, 0, 1])
         pres.view.close()
+
+        shutil.rmtree(test_dir)
 
     def cleanup(self):
         HelperTestingClass.cleanup(self)

--- a/Testing/SystemTests/tests/qt/SliceViewerIntegrationTest.py
+++ b/Testing/SystemTests/tests/qt/SliceViewerIntegrationTest.py
@@ -28,6 +28,7 @@ from mantid.simpleapi import (
     SetUB,
     RenameWorkspace,
     ClearUB,
+    LoadMD,
 )
 from mantid.api import AnalysisDataService
 from mantidqt.utils.qt.testing import get_application
@@ -109,6 +110,12 @@ class HelperTestingClass(QtWidgetFinder):
         self._qapp.sendPostedEvents()
         self.assert_no_toplevel_widgets()
         self._qapp = None
+
+    def requiredMemoryMB(self):
+        return 5000
+
+    def requiredFiles(self):
+        return ["MDNormHYSPEC.nxs"]
 
     # private methods
     def _assertNoErrorInADSHandlerFromSeparateThread(self, operation):
@@ -510,6 +517,15 @@ class SliceViewerTestAxesLimitsRespectNonorthogonalTransform(systemtesting.Manti
         self.assertAlmostEqual(limits_nonorthog[0][1], 10, delta=1e-5)
         self.assertEqual(limits_nonorthog[1], limits[2:])
 
+        pres.view.close()
+
+
+class SliceViewerTestLoadMD(systemtesting.MantidSystemTest, HelperTestingClass):
+    def runTest(self):
+        HelperTestingClass.__init__(self)
+        ws = LoadMD("MDNormHYSPEC.nxs")
+        pres = SliceViewer(ws)
+        self.assertAlmostEqual(pres.get_proj_matrix().flatten().tolist(), [1, 0, 0, 0, 1, 0, 0, 0, 1])
         pres.view.close()
 
 

--- a/Testing/SystemTests/tests/qt/SliceViewerIntegrationTest.py
+++ b/Testing/SystemTests/tests/qt/SliceViewerIntegrationTest.py
@@ -22,6 +22,7 @@ from mantid.simpleapi import (
     CreateMDWorkspace,
     CreateSampleWorkspace,
     DeleteWorkspace,
+    DeleteWorkspaces,
     FakeMDEventData,
     ConvertToDistribution,
     Scale,
@@ -103,6 +104,9 @@ class HelperTestingClass(QtWidgetFinder):
     def __init__(self):
         self._qapp = get_application()
 
+    def workspaces_to_delete(self):
+        return None
+
     def cleanup(self):
         for ii in self._qapp.topLevelWidgets():
             ii.close()
@@ -110,6 +114,10 @@ class HelperTestingClass(QtWidgetFinder):
         self._qapp.sendPostedEvents()
         self.assert_no_toplevel_widgets()
         self._qapp = None
+
+        names = self.workspaces_to_delete()
+        if names is not None:
+            DeleteWorkspaces(names)
 
     def requiredMemoryMB(self):
         return 5000
@@ -150,6 +158,9 @@ class SliceViewerTestDeleteOnClose(systemtesting.MantidSystemTest, HelperTesting
         self.assert_no_toplevel_widgets()
         self.assertEqual(pres.ads_observer, None)
 
+    def workspaces_to_delete(self):
+        return "ws_MD_2d"
+
 
 class SliceViewerTestNonorthogonalViewDisablesLineplots(systemtesting.MantidSystemTest, HelperTestingClass):
     def runTest(self):
@@ -173,6 +184,9 @@ class SliceViewerTestNonorthogonalViewDisablesLineplots(systemtesting.MantidSyst
 
         pres.view.close()
 
+    def workspaces_to_delete(self):
+        return "hkl_ws,expt_info"
+
 
 class SliceViewerTestNonorthogonalViewDisabledWhenEaxisViewed(systemtesting.MantidSystemTest, HelperTestingClass):
     def runTest(self):
@@ -195,6 +209,9 @@ class SliceViewerTestNonorthogonalViewDisabledWhenEaxisViewed(systemtesting.Mant
 
         pres.view.close()
 
+    def workspaces_to_delete(self):
+        return "ws_4D,expt_info_4D"
+
 
 class SliceViewerTestRegionSelectorDisabledWithLineplots(systemtesting.MantidSystemTest, HelperTestingClass):
     def runTest(self):
@@ -213,6 +230,9 @@ class SliceViewerTestRegionSelectorDisabledWithLineplots(systemtesting.MantidSys
         self.assertFalse(region_sel_action.isChecked())
 
         pres.view.close()
+
+    def workspaces_to_delete(self):
+        return "hkl_ws,expt_info"
 
 
 class SliceViewerTestClimPreventsNegativeValuesIfLognorm(systemtesting.MantidSystemTest, HelperTestingClass):
@@ -234,6 +254,9 @@ class SliceViewerTestClimPreventsNegativeValuesIfLognorm(systemtesting.MantidSys
 
         pres.view.close()
 
+    def workspaces_to_delete(self):
+        return "ws_MD_2d"
+
 
 class SliceViewerTestNormSwitchesIfContainsNonPositiveData(systemtesting.MantidSystemTest, HelperTestingClass):
     def runTest(self):
@@ -244,6 +267,9 @@ class SliceViewerTestNormSwitchesIfContainsNonPositiveData(systemtesting.MantidS
         colorbar = pres.view.data_view.colorbar
         self.assertTrue(isinstance(colorbar.get_norm(), Normalize))
         pres.view.close()
+
+    def workspaces_to_delete(self):
+        return "ws_MD_2d"
 
 
 class SliceViewerTestChangingNormUpdatesClimValidators(systemtesting.MantidSystemTest, HelperTestingClass):
@@ -261,6 +287,9 @@ class SliceViewerTestChangingNormUpdatesClimValidators(systemtesting.MantidSyste
         self.assertEqual(colorbar.cmin.validator().bottom(), -inf)
 
         pres.view.close()
+
+    def workspaces_to_delete(self):
+        return "ws_MD_2d_pos"
 
 
 class SliceViewerTestUpdatePlotDataUpdatesAxesLimits(systemtesting.MantidSystemTest, HelperTestingClass):
@@ -286,6 +315,9 @@ class SliceViewerTestUpdatePlotDataUpdatesAxesLimits(systemtesting.MantidSystemT
         assert_allclose(extent[2:], list(pres.view.data_view.ax.get_ylim()))
 
         pres.view.close()
+
+    def workspaces_to_delete(self):
+        return "hkl_ws"
 
 
 class SliceViewerTestViewClosedOnWorkspaceDeleted(systemtesting.MantidSystemTest, HelperTestingClass):
@@ -319,6 +351,9 @@ class SliceViewerTestViewNotClosedOnOtherWorkspaceDeleted(systemtesting.MantidSy
 
         pres.view.close()
 
+    def workspaces_to_delete(self):
+        return "ws"
+
 
 class SliceViewerTestViewClosedOnReplaceWhenModelPropertiesChange(systemtesting.MantidSystemTest, HelperTestingClass):
     def runTest(self):
@@ -331,6 +366,9 @@ class SliceViewerTestViewClosedOnReplaceWhenModelPropertiesChange(systemtesting.
 
         self.assert_no_toplevel_widgets()
         self.assertEqual(pres.ads_observer, None)
+
+    def workspaces_to_delete(self):
+        return "ws"
 
 
 class SliceViewerTestViewUpdatedOnReplaceWhenModelPropertiesNotChangedMatrixWs(systemtesting.MantidSystemTest, HelperTestingClass):
@@ -350,6 +388,9 @@ class SliceViewerTestViewUpdatedOnReplaceWhenModelPropertiesNotChangedMatrixWs(s
         self.assertNotEqual(pres.ads_observer, None)
 
         pres.view.close()
+
+    def workspaces_to_delete(self):
+        return "ws"
 
 
 class SliceViewerTestViewUpdatedOnReplaceWhenModelPropertiesNotChangedMDEventWs(systemtesting.MantidSystemTest, HelperTestingClass):
@@ -373,6 +414,9 @@ class SliceViewerTestViewUpdatedOnReplaceWhenModelPropertiesNotChangedMDEventWs(
 
         pres.view.close()
 
+    def workspaces_to_delete(self):
+        return "ws"
+
 
 class SliceViewerTestViewTitleOnWorkspaceRename(systemtesting.MantidSystemTest, HelperTestingClass):
     def runTest(self):
@@ -395,6 +439,9 @@ class SliceViewerTestViewTitleOnWorkspaceRename(systemtesting.MantidSystemTest, 
 
         pres.view.close()
 
+    def workspaces_to_delete(self):
+        return "ws,renamed"
+
 
 class SliceViewerTestViewTitleNotChangedOnOtherWorkspaceRename(systemtesting.MantidSystemTest, HelperTestingClass):
     def runTest(self):
@@ -408,6 +455,9 @@ class SliceViewerTestViewTitleNotChangedOnOtherWorkspaceRename(systemtesting.Man
         self.assertEqual(pres.model.get_title(), title)
         self.assertEqual(pres.view.windowTitle(), pres.model.get_title())
 
+    def workspaces_to_delete(self):
+        return "ws"
+
 
 class SliceViewerTestViewClosedOnADSCleared(systemtesting.MantidSystemTest, HelperTestingClass):
     def runTest(self):
@@ -419,6 +469,9 @@ class SliceViewerTestViewClosedOnADSCleared(systemtesting.MantidSystemTest, Help
         self._qapp.sendPostedEvents()
 
         self.assert_no_toplevel_widgets()
+
+    def workspaces_to_delete(self):
+        return "ws"
 
 
 class SliceViewerTestClosedOnReplaceWhenChangedNonorthogonalTransformSupport(systemtesting.MantidSystemTest, HelperTestingClass):
@@ -444,6 +497,9 @@ class SliceViewerTestClosedOnReplaceWhenChangedNonorthogonalTransformSupport(sys
         self.assert_no_toplevel_widgets()
         self.assertEqual(pres.ads_observer, None)
 
+    def workspaces_to_delete(self):
+        return "ws_non_ortho,expt_info_nonortho"
+
 
 class SliceViewerTestPlotMatrixXlimitsIgnoresMonitors(systemtesting.MantidSystemTest, HelperTestingClass):
     def runTest(self):
@@ -457,6 +513,9 @@ class SliceViewerTestPlotMatrixXlimitsIgnoresMonitors(systemtesting.MantidSystem
         pres.view.data_view.plot_matrix(ws)
 
         self.assertEqual(pres.view.data_view.get_data_limits_to_fill_current_axes()[0], (xmin, xmax))
+
+    def workspaces_to_delete(self):
+        return "ws"
 
 
 class SliceViewerTestPlotMatrixXlimitsIgnoresNans(systemtesting.MantidSystemTest, HelperTestingClass):
@@ -474,6 +533,9 @@ class SliceViewerTestPlotMatrixXlimitsIgnoresNans(systemtesting.MantidSystemTest
 
         self.assertEqual(pres.view.data_view.get_data_limits_to_fill_current_axes()[0], (xmin, xmax))
 
+    def workspaces_to_delete(self):
+        return "ws"
+
 
 class SliceViewerTestCloseEvent(systemtesting.MantidSystemTest, HelperTestingClass):
     def runTest(self):
@@ -488,12 +550,15 @@ class SliceViewerTestCloseEvent(systemtesting.MantidSystemTest, HelperTestingCla
 
         self.assert_no_toplevel_widgets()
 
+    def workspaces_to_delete(self):
+        return "ws"
+
 
 class SliceViewerTestAxesLimitsRespectNonorthogonalTransform(systemtesting.MantidSystemTest, HelperTestingClass):
     def runTest(self):
         HelperTestingClass.__init__(self)
         limits = (-10.0, 10.0, -9.0, 9.0)
-        ws_nonrotho = CreateMDWorkspace(
+        ws_nonortho = CreateMDWorkspace(
             Dimensions=3,
             Extents=",".join([str(lim) for lim in limits]) + ",-8,8",
             Names="A,B,C",
@@ -501,9 +566,9 @@ class SliceViewerTestAxesLimitsRespectNonorthogonalTransform(systemtesting.Manti
             Frames="HKL,HKL,HKL",
         )
         expt_info_nonortho = CreateSampleWorkspace()
-        ws_nonrotho.addExperimentInfo(expt_info_nonortho)
-        SetUB(ws_nonrotho, 1, 1, 2, 90, 90, 120)
-        pres = SliceViewer(ws_nonrotho)
+        ws_nonortho.addExperimentInfo(expt_info_nonortho)
+        SetUB(ws_nonortho, 1, 1, 2, 90, 90, 120)
+        pres = SliceViewer(ws_nonortho)
 
         # assert limits of orthog
         limits_orthog = pres.view.data_view.get_data_limits_to_fill_current_axes()
@@ -519,6 +584,9 @@ class SliceViewerTestAxesLimitsRespectNonorthogonalTransform(systemtesting.Manti
 
         pres.view.close()
 
+    def workspaces_to_delete(self):
+        return "ws_nonortho,expt_info_nonortho"
+
 
 class SliceViewerTestLoadMD(systemtesting.MantidSystemTest, HelperTestingClass):
     def runTest(self):
@@ -527,6 +595,9 @@ class SliceViewerTestLoadMD(systemtesting.MantidSystemTest, HelperTestingClass):
         pres = SliceViewer(ws)
         self.assertAlmostEqual(pres.get_proj_matrix().flatten().tolist(), [1, 0, 0, 0, 1, 0, 0, 0, 1])
         pres.view.close()
+
+    def workspaces_to_delete(self):
+        return "ws"
 
 
 # private helper functions

--- a/Testing/SystemTests/tests/qt/SliceViewerIntegrationTest.py
+++ b/Testing/SystemTests/tests/qt/SliceViewerIntegrationTest.py
@@ -22,7 +22,6 @@ from mantid.simpleapi import (
     CreateMDWorkspace,
     CreateSampleWorkspace,
     DeleteWorkspace,
-    DeleteWorkspaces,
     FakeMDEventData,
     ConvertToDistribution,
     Scale,
@@ -115,10 +114,6 @@ class HelperTestingClass(QtWidgetFinder):
         self.assert_no_toplevel_widgets()
         self._qapp = None
 
-        names = self.workspaces_to_delete()
-        if names is not None:
-            DeleteWorkspaces(names)
-
     def requiredMemoryMB(self):
         return 5000
 
@@ -158,8 +153,8 @@ class SliceViewerTestDeleteOnClose(systemtesting.MantidSystemTest, HelperTesting
         self.assert_no_toplevel_widgets()
         self.assertEqual(pres.ads_observer, None)
 
-    def workspaces_to_delete(self):
-        return "ws_MD_2d"
+    def cleanup(self):
+        HelperTestingClass.cleanup(self)
 
 
 class SliceViewerTestNonorthogonalViewDisablesLineplots(systemtesting.MantidSystemTest, HelperTestingClass):
@@ -184,8 +179,8 @@ class SliceViewerTestNonorthogonalViewDisablesLineplots(systemtesting.MantidSyst
 
         pres.view.close()
 
-    def workspaces_to_delete(self):
-        return "hkl_ws,expt_info"
+    def cleanup(self):
+        HelperTestingClass.cleanup(self)
 
 
 class SliceViewerTestNonorthogonalViewDisabledWhenEaxisViewed(systemtesting.MantidSystemTest, HelperTestingClass):
@@ -209,8 +204,8 @@ class SliceViewerTestNonorthogonalViewDisabledWhenEaxisViewed(systemtesting.Mant
 
         pres.view.close()
 
-    def workspaces_to_delete(self):
-        return "ws_4D,expt_info_4D"
+    def cleanup(self):
+        HelperTestingClass.cleanup(self)
 
 
 class SliceViewerTestRegionSelectorDisabledWithLineplots(systemtesting.MantidSystemTest, HelperTestingClass):
@@ -231,8 +226,8 @@ class SliceViewerTestRegionSelectorDisabledWithLineplots(systemtesting.MantidSys
 
         pres.view.close()
 
-    def workspaces_to_delete(self):
-        return "hkl_ws,expt_info"
+    def cleanup(self):
+        HelperTestingClass.cleanup(self)
 
 
 class SliceViewerTestClimPreventsNegativeValuesIfLognorm(systemtesting.MantidSystemTest, HelperTestingClass):
@@ -254,8 +249,8 @@ class SliceViewerTestClimPreventsNegativeValuesIfLognorm(systemtesting.MantidSys
 
         pres.view.close()
 
-    def workspaces_to_delete(self):
-        return "ws_MD_2d"
+    def cleanup(self):
+        HelperTestingClass.cleanup(self)
 
 
 class SliceViewerTestNormSwitchesIfContainsNonPositiveData(systemtesting.MantidSystemTest, HelperTestingClass):
@@ -268,8 +263,8 @@ class SliceViewerTestNormSwitchesIfContainsNonPositiveData(systemtesting.MantidS
         self.assertTrue(isinstance(colorbar.get_norm(), Normalize))
         pres.view.close()
 
-    def workspaces_to_delete(self):
-        return "ws_MD_2d"
+    def cleanup(self):
+        HelperTestingClass.cleanup(self)
 
 
 class SliceViewerTestChangingNormUpdatesClimValidators(systemtesting.MantidSystemTest, HelperTestingClass):
@@ -288,8 +283,8 @@ class SliceViewerTestChangingNormUpdatesClimValidators(systemtesting.MantidSyste
 
         pres.view.close()
 
-    def workspaces_to_delete(self):
-        return "ws_MD_2d_pos"
+    def cleanup(self):
+        HelperTestingClass.cleanup(self)
 
 
 class SliceViewerTestUpdatePlotDataUpdatesAxesLimits(systemtesting.MantidSystemTest, HelperTestingClass):
@@ -316,8 +311,8 @@ class SliceViewerTestUpdatePlotDataUpdatesAxesLimits(systemtesting.MantidSystemT
 
         pres.view.close()
 
-    def workspaces_to_delete(self):
-        return "hkl_ws"
+    def cleanup(self):
+        HelperTestingClass.cleanup(self)
 
 
 class SliceViewerTestViewClosedOnWorkspaceDeleted(systemtesting.MantidSystemTest, HelperTestingClass):
@@ -331,6 +326,9 @@ class SliceViewerTestViewClosedOnWorkspaceDeleted(systemtesting.MantidSystemTest
 
         self.assert_no_toplevel_widgets()
         self.assertEqual(pres.ads_observer, None)
+
+    def cleanup(self):
+        HelperTestingClass.cleanup(self)
 
 
 class SliceViewerTestViewNotClosedOnOtherWorkspaceDeleted(systemtesting.MantidSystemTest, HelperTestingClass):
@@ -349,10 +347,8 @@ class SliceViewerTestViewNotClosedOnOtherWorkspaceDeleted(systemtesting.MantidSy
         self.assertTrue(pres.view in self.find_widgets_of_type(str(type(pres.view))))
         self.assertNotEqual(pres.ads_observer, None)
 
-        pres.view.close()
-
-    def workspaces_to_delete(self):
-        return "ws"
+    def cleanup(self):
+        HelperTestingClass.cleanup(self)
 
 
 class SliceViewerTestViewClosedOnReplaceWhenModelPropertiesChange(systemtesting.MantidSystemTest, HelperTestingClass):
@@ -367,8 +363,8 @@ class SliceViewerTestViewClosedOnReplaceWhenModelPropertiesChange(systemtesting.
         self.assert_no_toplevel_widgets()
         self.assertEqual(pres.ads_observer, None)
 
-    def workspaces_to_delete(self):
-        return "ws"
+    def cleanup(self):
+        HelperTestingClass.cleanup(self)
 
 
 class SliceViewerTestViewUpdatedOnReplaceWhenModelPropertiesNotChangedMatrixWs(systemtesting.MantidSystemTest, HelperTestingClass):
@@ -389,8 +385,8 @@ class SliceViewerTestViewUpdatedOnReplaceWhenModelPropertiesNotChangedMatrixWs(s
 
         pres.view.close()
 
-    def workspaces_to_delete(self):
-        return "ws"
+    def cleanup(self):
+        HelperTestingClass.cleanup(self)
 
 
 class SliceViewerTestViewUpdatedOnReplaceWhenModelPropertiesNotChangedMDEventWs(systemtesting.MantidSystemTest, HelperTestingClass):
@@ -403,7 +399,7 @@ class SliceViewerTestViewUpdatedOnReplaceWhenModelPropertiesNotChangedMDEventWs(
         ws = CreateMDWorkspace(
             Dimensions="3", EventType="MDEvent", Extents="-10,10,-5,5,-1,1", Names="Q_lab_x,Q_lab_y,Q_lab_z", Units="1\\A,1\\A,1\\A"
         )
-        FakeMDEventData(ws, UniformParams="1000000")
+        FakeMDEventData(ws, UniformParams="100000")
         pres = SliceViewer(ws)
         self._assertNoErrorInADSHandlerFromSeparateThread(partial(scale_ws, ws))
 
@@ -414,8 +410,8 @@ class SliceViewerTestViewUpdatedOnReplaceWhenModelPropertiesNotChangedMDEventWs(
 
         pres.view.close()
 
-    def workspaces_to_delete(self):
-        return "ws"
+    def cleanup(self):
+        HelperTestingClass.cleanup(self)
 
 
 class SliceViewerTestViewTitleOnWorkspaceRename(systemtesting.MantidSystemTest, HelperTestingClass):
@@ -439,8 +435,8 @@ class SliceViewerTestViewTitleOnWorkspaceRename(systemtesting.MantidSystemTest, 
 
         pres.view.close()
 
-    def workspaces_to_delete(self):
-        return "ws,renamed"
+    def cleanup(self):
+        HelperTestingClass.cleanup(self)
 
 
 class SliceViewerTestViewTitleNotChangedOnOtherWorkspaceRename(systemtesting.MantidSystemTest, HelperTestingClass):
@@ -455,8 +451,10 @@ class SliceViewerTestViewTitleNotChangedOnOtherWorkspaceRename(systemtesting.Man
         self.assertEqual(pres.model.get_title(), title)
         self.assertEqual(pres.view.windowTitle(), pres.model.get_title())
 
-    def workspaces_to_delete(self):
-        return "ws"
+        pres.view.close()
+
+    def cleanup(self):
+        HelperTestingClass.cleanup(self)
 
 
 class SliceViewerTestViewClosedOnADSCleared(systemtesting.MantidSystemTest, HelperTestingClass):
@@ -470,8 +468,8 @@ class SliceViewerTestViewClosedOnADSCleared(systemtesting.MantidSystemTest, Help
 
         self.assert_no_toplevel_widgets()
 
-    def workspaces_to_delete(self):
-        return "ws"
+    def cleanup(self):
+        HelperTestingClass.cleanup(self)
 
 
 class SliceViewerTestClosedOnReplaceWhenChangedNonorthogonalTransformSupport(systemtesting.MantidSystemTest, HelperTestingClass):
@@ -497,8 +495,8 @@ class SliceViewerTestClosedOnReplaceWhenChangedNonorthogonalTransformSupport(sys
         self.assert_no_toplevel_widgets()
         self.assertEqual(pres.ads_observer, None)
 
-    def workspaces_to_delete(self):
-        return "ws_non_ortho,expt_info_nonortho"
+    def cleanup(self):
+        HelperTestingClass.cleanup(self)
 
 
 class SliceViewerTestPlotMatrixXlimitsIgnoresMonitors(systemtesting.MantidSystemTest, HelperTestingClass):
@@ -514,8 +512,10 @@ class SliceViewerTestPlotMatrixXlimitsIgnoresMonitors(systemtesting.MantidSystem
 
         self.assertEqual(pres.view.data_view.get_data_limits_to_fill_current_axes()[0], (xmin, xmax))
 
-    def workspaces_to_delete(self):
-        return "ws"
+        pres.view.close()
+
+    def cleanup(self):
+        HelperTestingClass.cleanup(self)
 
 
 class SliceViewerTestPlotMatrixXlimitsIgnoresNans(systemtesting.MantidSystemTest, HelperTestingClass):
@@ -533,8 +533,10 @@ class SliceViewerTestPlotMatrixXlimitsIgnoresNans(systemtesting.MantidSystemTest
 
         self.assertEqual(pres.view.data_view.get_data_limits_to_fill_current_axes()[0], (xmin, xmax))
 
-    def workspaces_to_delete(self):
-        return "ws"
+        pres.view.close()
+
+    def cleanup(self):
+        HelperTestingClass.cleanup(self)
 
 
 class SliceViewerTestCloseEvent(systemtesting.MantidSystemTest, HelperTestingClass):
@@ -550,8 +552,8 @@ class SliceViewerTestCloseEvent(systemtesting.MantidSystemTest, HelperTestingCla
 
         self.assert_no_toplevel_widgets()
 
-    def workspaces_to_delete(self):
-        return "ws"
+    def cleanup(self):
+        HelperTestingClass.cleanup(self)
 
 
 class SliceViewerTestAxesLimitsRespectNonorthogonalTransform(systemtesting.MantidSystemTest, HelperTestingClass):
@@ -584,8 +586,8 @@ class SliceViewerTestAxesLimitsRespectNonorthogonalTransform(systemtesting.Manti
 
         pres.view.close()
 
-    def workspaces_to_delete(self):
-        return "ws_nonortho,expt_info_nonortho"
+    def cleanup(self):
+        HelperTestingClass.cleanup(self)
 
 
 class SliceViewerTestLoadMD(systemtesting.MantidSystemTest, HelperTestingClass):
@@ -596,8 +598,8 @@ class SliceViewerTestLoadMD(systemtesting.MantidSystemTest, HelperTestingClass):
         self.assertAlmostEqual(pres.get_proj_matrix().flatten().tolist(), [1, 0, 0, 0, 1, 0, 0, 0, 1])
         pres.view.close()
 
-    def workspaces_to_delete(self):
-        return "ws"
+    def cleanup(self):
+        HelperTestingClass.cleanup(self)
 
 
 # private helper functions

--- a/docs/source/release/v6.7.0/Workbench/SliceViewer/Bugfixes/35425.rst
+++ b/docs/source/release/v6.7.0/Workbench/SliceViewer/Bugfixes/35425.rst
@@ -1,1 +1,1 @@
-- Fixed issue with projection matrix calculation when workspaces is loaded.
+- Fixed issue with projection matrix calculation when workspaces are loaded. The affected 4d workspaces.

--- a/docs/source/release/v6.7.0/Workbench/SliceViewer/Bugfixes/35425.rst
+++ b/docs/source/release/v6.7.0/Workbench/SliceViewer/Bugfixes/35425.rst
@@ -1,0 +1,1 @@
+- Fixed issue with projection matrix calculation when workspaces is loaded.

--- a/docs/source/release/v6.7.0/Workbench/SliceViewer/New_features/35425.rst
+++ b/docs/source/release/v6.7.0/Workbench/SliceViewer/New_features/35425.rst
@@ -1,0 +1,2 @@
+- Integer tick marks are now used for axes in HKL-frame
+- Dimension widget now supports the ability to change the min/max extents

--- a/docs/source/release/v6.7.0/Workbench/SliceViewer/New_features/35425.rst
+++ b/docs/source/release/v6.7.0/Workbench/SliceViewer/New_features/35425.rst
@@ -1,2 +1,2 @@
 - Integer tick marks are now used for axes in HKL-frame
-- Dimension widget now supports the ability to change the min/max extents
+- Dimension widget now supports the ability to change the min/max extents in addition to the orthogonal axis editor

--- a/qt/python/mantidqt/mantidqt/widgets/instrumentview/_instrumentview.sip
+++ b/qt/python/mantidqt/mantidqt/widgets/instrumentview/_instrumentview.sip
@@ -329,10 +329,11 @@ public:
     ----------------------------------
 
     Args:
-      index: valid option including [0, 1, 2] where
+      index: valid option including [0, 1, 2, 3] where
           0: Linear
-          1: SymmetricLog10
-          2: Power
+          1: Logarithmic
+          2: SymmetricLog10
+          3: Power
 %End
 
   // set Axis at Full 3D

--- a/qt/python/mantidqt/mantidqt/widgets/instrumentview/_instrumentview.sip
+++ b/qt/python/mantidqt/mantidqt/widgets/instrumentview/_instrumentview.sip
@@ -329,11 +329,10 @@ public:
     ----------------------------------
 
     Args:
-      index: valid option including [0, 1, 2, 3] where
+      index: valid option including [0, 1, 2] where
           0: Linear
-          1: Logarithmic
-          2: SymmetricLog10
-          3: Power
+          1: SymmetricLog10
+          2: Power
 %End
 
   // set Axis at Full 3D

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/models/dimensions.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/models/dimensions.py
@@ -39,7 +39,7 @@ class Dimensions:
     @staticmethod
     def get_dim_limits(workspace, slicepoint, transpose):
         """
-        Return a xlim, ylim) for the display dimensions where xlim, ylim are tuples
+        Return a xlim, ylim for the display dimensions where xlim, ylim are tuples
         :param slicepoint: Sequence containing either a float or None where None indicates a display dimension
         :param transpose: A boolean flag indicating if the display dimensions are transposed
         """

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/models/model.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/models/model.py
@@ -537,10 +537,12 @@ class SliceViewerModel(SliceViewerBaseModel):
             # exclude non-Q dim elements from basis vectors
             qflags = [ws.getDimension(idim).getMDFrame().isQ() for idim in range(ndims)]
             i_nonq = np.flatnonzero(np.invert(qflags))
-            qmask = np.invert(basis_matrix[i_nonq, :].astype(bool).sum(axis=0).astype(bool))
+            col_q = np.flatnonzero(qflags)
+            qmask = np.invert(basis_matrix[:, i_nonq].astype(bool).sum(axis=1).astype(bool))
+            row_q = np.flatnonzero(qmask)
             # extract proj matrix from basis vectors of q dimension
             # note for 2D the last col/row of proj_matrix is 0,0,1 - i.e. L
-            proj_matrix[: qmask.sum(), : qmask.sum()] = basis_matrix[qmask, :][:, qflags]
+            proj_matrix[: qmask.sum(), : qmask.sum()] = basis_matrix[:, col_q][row_q]
         return proj_matrix
 
     def projection_matrix_from_log(self, ws):

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/models/model.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/models/model.py
@@ -517,33 +517,6 @@ class SliceViewerModel(SliceViewerBaseModel):
 
     def check_for_removed_original_workspace(self):
         return self.num_original_workspaces_at_init != self.number_of_active_original_workspaces()
-    def projection_matrix_from_log(self, ws):
-        try:
-            expt_info = ws.getExperimentInfo(0)
-            proj_matrix = np.array(expt_info.run().get(PROJ_MATRIX_LOG_NAME).value, dtype=float).reshape(3, 3)
-        except (AttributeError, KeyError, ValueError):  # run can be None so no .get()
-            # assume orthogonal projection if no log exists (i.e. proj_matrix is identity)
-            # needs to be 3x3 even if 2D ws as columns passed to recAngle when calc axes angles
-            proj_matrix = np.eye(3)
-        return proj_matrix
-
-    def projection_matrix_from_basis(self, ws):
-        proj_matrix = np.zeros((3, 3))
-        ndims = ws.getNumDims()
-        basis_matrix = np.zeros((ndims, ndims))
-        if len(list(ws.getBasisVector(0))) == ndims:  # basis vectors valid
-            for idim in range(ndims):
-                basis_matrix[:, idim] = list(ws.getBasisVector(idim))
-            # exclude non-Q dim elements from basis vectors
-            qflags = [ws.getDimension(idim).getMDFrame().isQ() for idim in range(ndims)]
-            i_nonq = np.flatnonzero(np.invert(qflags))
-            col_q = np.flatnonzero(qflags)
-            qmask = np.invert(basis_matrix[:, i_nonq].astype(bool).sum(axis=1).astype(bool))
-            row_q = np.flatnonzero(qmask)
-            # extract proj matrix from basis vectors of q dimension
-            # note for 2D the last col/row of proj_matrix is 0,0,1 - i.e. L
-            proj_matrix[: qmask.sum(), : qmask.sum()] = basis_matrix[:, col_q][row_q]
-        return proj_matrix
 
     def projection_matrix_from_log(self, ws):
         try:

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/models/model.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/models/model.py
@@ -526,9 +526,12 @@ class SliceViewerModel(SliceViewerBaseModel):
             if ws_type == WS_TYPE.MDH:
                 # get basis vectors from workspace
                 ndims = ws.getNumDims()
-                basis_matrix = np.zeros((ndims, ndims))
+                basis_matrix = np.eye(ndims)
                 for idim in range(ndims):
-                    basis_matrix[:, idim] = list(ws.getBasisVector(idim))
+                    vec = list(ws.getBasisVector(idim))
+                    # if basis vetor is valid, overwrite the column vector
+                    if len(vec) == ndims:
+                        basis_matrix[:, idim] = vec
                 # exclude non-Q dim elements from basis vectors
                 qflags = [ws.getDimension(idim).getMDFrame().isQ() for idim in range(ndims)]
                 i_nonq = np.flatnonzero(np.invert(qflags))

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/models/model.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/models/model.py
@@ -518,44 +518,45 @@ class SliceViewerModel(SliceViewerBaseModel):
     def check_for_removed_original_workspace(self):
         return self.num_original_workspaces_at_init != self.number_of_active_original_workspaces()
 
+    def projection_matrix_from_log(self, ws):
+        try:
+            expt_info = ws.getExperimentInfo(0)
+            proj_matrix = np.array(expt_info.run().get(PROJ_MATRIX_LOG_NAME).value, dtype=float).reshape(3, 3)
+        except (AttributeError, KeyError, ValueError):  # run can be None so no .get()
+            # assume orthogonal projection if no log exists (i.e. proj_matrix is identity)
+            # needs to be 3x3 even if 2D ws as columns passed to recAngle when calc axes angles
+            proj_matrix = np.eye(3)
+        return proj_matrix
+
+    def projection_matrix_from_basis(self, ws):
+        proj_matrix = np.zeros((3, 3))
+        ndims = ws.getNumDims()
+        basis_matrix = np.zeros((ndims, ndims))
+        if len(list(ws.getBasisVector(0))) == ndims:  # basis vectors valid
+            for idim in range(ndims):
+                basis_matrix[:, idim] = list(ws.getBasisVector(idim))
+            # exclude non-Q dim elements from basis vectors
+            qflags = [ws.getDimension(idim).getMDFrame().isQ() for idim in range(ndims)]
+            i_nonq = np.flatnonzero(np.invert(qflags))
+            qmask = np.invert(basis_matrix[i_nonq, :].astype(bool).sum(axis=0).astype(bool))
+            # extract proj matrix from basis vectors of q dimension
+            # note for 2D the last col/row of proj_matrix is 0,0,1 - i.e. L
+            proj_matrix[: qmask.sum(), : qmask.sum()] = basis_matrix[qmask, :][:, qflags]
+        return proj_matrix
+
     def get_proj_matrix(self):
         ws = self._get_ws()
         ws_type = WorkspaceInfo.get_ws_type(ws)
         if ws_type != WS_TYPE.MATRIX:
-            proj_matrix = np.eye(3)  # needs to be 3x3 even if 2D ws as columns passed to recAngle when calc axes angles
             if ws_type == WS_TYPE.MDH:
                 # get basis vectors from workspace
-                ndims = ws.getNumDims()
-                basis_matrix = np.eye(ndims)
-                for idim in range(ndims):
-                    vec = list(ws.getBasisVector(idim))
-                    # if basis vetor is valid, overwrite the column vector
-                    if len(vec) == ndims:
-                        basis_matrix[:, idim] = vec
-                # exclude non-Q dim elements from basis vectors
-                qflags = [ws.getDimension(idim).getMDFrame().isQ() for idim in range(ndims)]
-                i_nonq = np.flatnonzero(np.invert(qflags))
-                qmask = np.invert(basis_matrix[i_nonq, :].astype(bool).sum(axis=0).astype(bool))
-                # extract proj matrix from basis vectors of q dimension
-                # note for 2D the last col/row of proj_matrix is 0,0,1 - i.e. L
-                proj_matrix[: qmask.sum(), : qmask.sum()] = basis_matrix[qmask, :][:, qflags]
+                proj_matrix = self.projection_matrix_from_basis(ws)
                 # if determinant is zero, try to get the info from log or revert back to identity matrix
                 if np.isclose(np.linalg.det(proj_matrix), 0):
-                    # for histo try to find axes from log
-                    try:
-                        expt_info = ws.getExperimentInfo(0)
-                        proj_matrix = np.array(expt_info.run().get(PROJ_MATRIX_LOG_NAME).value, dtype=float).reshape(3, 3)
-                    except (AttributeError, KeyError, ValueError):
-                        # revert back to orthogonal projection
-                        proj_matrix = np.eye(3)
+                    proj_matrix = self.projection_matrix_from_log(ws)
             else:
                 # for event try to find axes from log
-                try:
-                    expt_info = ws.getExperimentInfo(0)
-                    proj_matrix = np.array(expt_info.run().get(PROJ_MATRIX_LOG_NAME).value, dtype=float).reshape(3, 3)
-                except (AttributeError, KeyError, ValueError):  # run can be None so no .get()
-                    # assume orthogonal projection if no log exists (i.e. proj_matrix is identity)
-                    pass
+                proj_matrix = self.projection_matrix_from_log(ws)
             return proj_matrix
         else:
             return None

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/models/sliceinfo.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/models/sliceinfo.py
@@ -165,3 +165,10 @@ class SliceInfo:
         :return: index of q dim ignoring non q dims - i.e. index in range(0,3)
         """
         return int(display_index - np.sum(self.i_non_q < display_index))  # cast to int from numpy int32 type
+
+    def is_xy_q_frame(self) -> tuple:
+        """
+        Determine if the display x- and y-axis are part of a q-frame
+        :return: 2-tuple of bool whether the x- and y-axis are in a q-frame
+        """
+        return (self._display_x not in self.i_non_q, self._display_y not in self.i_non_q)

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/peaksviewer/view.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/peaksviewer/view.py
@@ -142,6 +142,7 @@ class PeaksViewerView(QWidget):
                                by the sliceinfo
         """
         self._sliceinfo_provider.set_axes_limits(xlim, ylim, auto_transform)
+        self._sliceinfo_provider.data_limits_changed()
 
     def set_peak_color(self, peak_color):
         """

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/presenters/base_presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/presenters/base_presenter.py
@@ -50,7 +50,7 @@ class SliceViewerBasePresenter(IDataViewSubscriber, ABC):
         limits = self._data_view.get_axes_limits()
         if limits is not None:
             if self._data_view.nonorthogonal_mode:
-                limits = self._data_view.transform_limits_to_extents_inv(*limits)
+                limits = self._data_view.inverse_transform_limits_to_extents(*limits)
             self._data_view.dimensions.set_extents(*limits)
         self.update_data_limits()
 

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/presenters/base_presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/presenters/base_presenter.py
@@ -47,9 +47,16 @@ class SliceViewerBasePresenter(IDataViewSubscriber, ABC):
             xlim, ylim = (xmin_p, xmax_p), (ymin_p, ymax_p)
 
         self._data_view.set_axes_limits(xlim, ylim)
-        self.data_limits_changed()
+        self.update_data_limits()
 
     def data_limits_changed(self):
+        """Notify data limits on image axes have changed"""
+        limits = self._data_view.get_data_limits_to_fill_current_axes()
+        if limits is not None:
+            self._data_view.dimensions.set_extents(*limits)
+        self.update_data_limits()
+
+    def update_data_limits(self):
         """Notify data limits on image axes have changed"""
         if WorkspaceInfo.can_support_dynamic_rebinning(self.model.ws):
             self.new_plot()  # automatically uses current display limits

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/presenters/base_presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/presenters/base_presenter.py
@@ -41,18 +41,16 @@ class SliceViewerBasePresenter(IDataViewSubscriber, ABC):
         coordinate before passing to the view
         """
         if auto_transform and self._data_view.nonorthogonal_mode:
-            to_display = self._data_view.nonortho_transform.tr
-            xmin_p, ymin_p = to_display(xlim[0], ylim[0])
-            xmax_p, ymax_p = to_display(xlim[1], ylim[1])
-            xlim, ylim = (xmin_p, xmax_p), (ymin_p, ymax_p)
-
+            xlim, ylim = self._data_view.transform_limits_to_extents(xlim, ylim)
         self._data_view.set_axes_limits(xlim, ylim)
         self.update_data_limits()
 
     def data_limits_changed(self):
         """Notify data limits on image axes have changed"""
-        limits = self._data_view.get_data_limits_to_fill_current_axes()
+        limits = self._data_view.get_axes_limits()
         if limits is not None:
+            if self._data_view.nonorthogonal_mode:
+                limits = self._data_view.transform_limits_to_extents_inv(*limits)
             self._data_view.dimensions.set_extents(*limits)
         self.update_data_limits()
 

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/presenters/base_presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/presenters/base_presenter.py
@@ -32,6 +32,7 @@ class SliceViewerBasePresenter(IDataViewSubscriber, ABC):
             limits = self.get_data_limits()
         self._data_view.dimensions.set_extents(*limits)
         self.set_axes_limits(*limits)
+        self.update_data_limits()
 
     def set_axes_limits(self, xlim, ylim, auto_transform=True):
         """Set the axes limits on the view.
@@ -43,7 +44,6 @@ class SliceViewerBasePresenter(IDataViewSubscriber, ABC):
         if auto_transform and self._data_view.nonorthogonal_mode:
             xlim, ylim = self._data_view.transform_limits_to_extents(xlim, ylim)
         self._data_view.set_axes_limits(xlim, ylim)
-        self.update_data_limits()
 
     def data_limits_changed(self):
         """Notify data limits on image axes have changed"""

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/presenters/base_presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/presenters/base_presenter.py
@@ -31,6 +31,7 @@ class SliceViewerBasePresenter(IDataViewSubscriber, ABC):
             # otherwise query data model based on slice info and transpose
             limits = self.get_data_limits()
         self.set_axes_limits(*limits)
+        self._data_view.dimensions.set_extents(*limits)
 
     def set_axes_limits(self, xlim, ylim, auto_transform=True):
         """Set the axes limits on the view.

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/presenters/base_presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/presenters/base_presenter.py
@@ -30,8 +30,8 @@ class SliceViewerBasePresenter(IDataViewSubscriber, ABC):
         else:
             # otherwise query data model based on slice info and transpose
             limits = self.get_data_limits()
-        self.set_axes_limits(*limits)
         self._data_view.dimensions.set_extents(*limits)
+        self.set_axes_limits(*limits)
 
     def set_axes_limits(self, xlim, ylim, auto_transform=True):
         """Set the axes limits on the view.

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/presenters/presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/presenters/presenter.py
@@ -226,6 +226,11 @@ class SliceViewer(ObservingPresenter, SliceViewerBasePresenter):
             self.new_plot()
         self._call_cutviewer_presenter_if_created("on_dimension_changed")
 
+    def extents_changed(self):
+        xlim, ylim = self.view.data_view.dimensions.get_extents()
+        self.set_axes_limits(xlim, ylim)
+        self.update_plot_data()
+
     def slicepoint_changed(self):
         """Indicates the slicepoint has been updated"""
         self._call_peaks_presenter_if_created("notify", PeaksViewerPresenter.Event.SlicePointChanged)

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/presenters/presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/presenters/presenter.py
@@ -542,6 +542,12 @@ class SliceViewer(ObservingPresenter, SliceViewerBasePresenter):
     def action_open_help_window(self):
         InterfaceManager().showHelpPage("qthelp://org.mantidproject/doc/workbench/sliceviewer.html")
 
+    def is_integer_frame(self):
+        if self.get_frame() != SpecialCoordinateSystem.HKL:
+            return (False, False)
+        else:
+            return self.get_sliceinfo().is_xy_q_frame()
+
     def get_extra_image_info_columns(self, xdata, ydata):
         qdims = [i for i, v in enumerate(self.view.data_view.dimensions.qflags) if v]
 

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/presenters/presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/presenters/presenter.py
@@ -226,6 +226,7 @@ class SliceViewer(ObservingPresenter, SliceViewerBasePresenter):
         else:
             self.new_plot()
         self._call_cutviewer_presenter_if_created("on_dimension_changed")
+        self.extents_changed()
 
     def extents_changed(self):
         xlim, ylim = self.view.data_view.dimensions.get_extents()

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/presenters/presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/presenters/presenter.py
@@ -223,10 +223,11 @@ class SliceViewer(ObservingPresenter, SliceViewerBasePresenter):
                 self.new_plot(dimensions_changing=True)
             else:
                 self.new_plot(dimensions_transposing=True)
+                xlim, ylim = self.view.data_view.dimensions.get_extents()
+                self.set_axes_limits(xlim, ylim)
         else:
             self.new_plot()
         self._call_cutviewer_presenter_if_created("on_dimension_changed")
-        self.extents_changed()
 
     def extents_changed(self):
         xlim, ylim = self.view.data_view.dimensions.get_extents()

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/presenters/presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/presenters/presenter.py
@@ -223,7 +223,7 @@ class SliceViewer(ObservingPresenter, SliceViewerBasePresenter):
                 self.new_plot(dimensions_changing=True)
             else:
                 self.new_plot(dimensions_transposing=True)
-                self.update_axes_limits_to_extents()
+                self.extents_changed()
         else:
             self.new_plot()
         self._call_cutviewer_presenter_if_created("on_dimension_changed")
@@ -234,7 +234,7 @@ class SliceViewer(ObservingPresenter, SliceViewerBasePresenter):
 
     def extents_changed(self):
         self.update_axes_limits_to_extents()
-        self.update_plot_data()
+        self.new_plot()
 
     def slicepoint_changed(self):
         """Indicates the slicepoint has been updated"""

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/presenters/presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/presenters/presenter.py
@@ -223,15 +223,17 @@ class SliceViewer(ObservingPresenter, SliceViewerBasePresenter):
                 self.new_plot(dimensions_changing=True)
             else:
                 self.new_plot(dimensions_transposing=True)
-                xlim, ylim = self.view.data_view.dimensions.get_extents()
-                self.set_axes_limits(xlim, ylim)
+                self.update_axes_limits_to_extents()
         else:
             self.new_plot()
         self._call_cutviewer_presenter_if_created("on_dimension_changed")
 
-    def extents_changed(self):
+    def update_axes_limits_to_extents(self):
         xlim, ylim = self.view.data_view.dimensions.get_extents()
         self.set_axes_limits(xlim, ylim)
+
+    def extents_changed(self):
+        self.update_axes_limits_to_extents()
         self.update_plot_data()
 
     def slicepoint_changed(self):

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_base_presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_base_presenter.py
@@ -56,6 +56,7 @@ class SliceViewerBasePresenterTest(unittest.TestCase):
         self.patched_deps["WorkspaceInfo"].can_support_dynamic_rebinning.return_value = True
         new_plot_mock = mock.MagicMock()
         presenter.new_plot = new_plot_mock
+        presenter._data_view.get_data_limits_to_fill_current_axes = mock.MagicMock(return_value=None)
 
         presenter.data_limits_changed()
 
@@ -66,6 +67,7 @@ class SliceViewerBasePresenterTest(unittest.TestCase):
         self.patched_deps["WorkspaceInfo"].can_support_dynamic_rebinning.return_value = False
         new_plot_mock = mock.MagicMock()
         presenter.new_plot = new_plot_mock
+        presenter._data_view.get_data_limits_to_fill_current_axes = mock.MagicMock(return_value=None)
 
         presenter.data_limits_changed()
 

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_base_presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_base_presenter.py
@@ -56,7 +56,7 @@ class SliceViewerBasePresenterTest(unittest.TestCase):
         self.patched_deps["WorkspaceInfo"].can_support_dynamic_rebinning.return_value = True
         new_plot_mock = mock.MagicMock()
         presenter.new_plot = new_plot_mock
-        presenter._data_view.get_data_limits_to_fill_current_axes = mock.MagicMock(return_value=None)
+        presenter._data_view.get_axes_limits = mock.MagicMock(return_value=None)
 
         presenter.data_limits_changed()
 
@@ -67,7 +67,7 @@ class SliceViewerBasePresenterTest(unittest.TestCase):
         self.patched_deps["WorkspaceInfo"].can_support_dynamic_rebinning.return_value = False
         new_plot_mock = mock.MagicMock()
         presenter.new_plot = new_plot_mock
-        presenter._data_view.get_data_limits_to_fill_current_axes = mock.MagicMock(return_value=None)
+        presenter._data_view.get_axes_limits = mock.MagicMock(return_value=None)
 
         presenter.data_limits_changed()
 

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_sliceviewer_dataview.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_sliceviewer_dataview.py
@@ -92,6 +92,8 @@ class SliceviewerDataViewTest(unittest.TestCase):
         self.view.canvas = mock.Mock()
         self.view.clear_figure = mock.Mock()
 
+        self.view.grid_helper = mock.Mock()
+
         self.view.create_axes_nonorthogonal(mock.NonCallableMock())
 
         self.view.clear_figure.assert_called_once()
@@ -107,6 +109,8 @@ class SliceviewerDataViewTest(unittest.TestCase):
         self.view.clear_figure = mock.Mock()
         self.view._grid_on = mock.NonCallableMock()
 
+        self.view.set_integer_axes_ticks = mock.Mock()
+
         self.view.create_axes_orthogonal()
 
         self.view.clear_figure.assert_called_once()
@@ -117,6 +121,7 @@ class SliceviewerDataViewTest(unittest.TestCase):
     def test_create_axes_orthogonal_redraws_on_zoom(self):
         for redraw in [True, False]:
             self.view.canvas = mock.Mock()
+            self.view.set_integer_axes_ticks = mock.Mock()
             self.view.create_axes_orthogonal(redraw_on_zoom=redraw)
             self.view.canvas.enable_zoom_on_scroll.assert_called_once_with(mock.ANY, redraw=redraw, toolbar=mock.ANY, callback=mock.ANY)
 

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_sliceviewer_model.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_sliceviewer_model.py
@@ -509,7 +509,7 @@ class SliceViewerModelTest(unittest.TestCase):
 
         # should revert to orthogonal
         axes_angles = model.get_axes_angles()
-        self.assertAlmostEqual(axes_angles[1, 2], np.pi / 2, delta=1e-10)
+        self.assertAlmostEqual(axes_angles[1, 2], np.pi / 4, delta=1e-10)
         for iy in range(1, 3):
             self.assertAlmostEqual(axes_angles[0, iy], np.pi / 2, delta=1e-10)
 

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_sliceviewer_model.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_sliceviewer_model.py
@@ -507,7 +507,7 @@ class SliceViewerModelTest(unittest.TestCase):
         ws.getExperimentInfo().run().get().value = [0, 1, 1, 0, 0, 1, 1, 0, 0]
         model = SliceViewerModel(ws)
 
-        # should revert to orthogonal
+        # should NOT revert to orthogonal
         axes_angles = model.get_axes_angles()
         self.assertAlmostEqual(axes_angles[1, 2], np.pi / 4, delta=1e-10)
         for iy in range(1, 3):

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_sliceviewer_presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_sliceviewer_presenter.py
@@ -364,7 +364,7 @@ class SliceViewerTest(unittest.TestCase):
         presenter.update_axes_limits_to_extents = mock.Mock(return_value=None)
         presenter.dimensions_changed()
 
-        mock_new_plot.assert_called_with(dimensions_transposing=True)
+        mock_new_plot.assert_called_with(dimensions_transposing=False)
 
     @mock.patch("mantidqt.widgets.sliceviewer.presenters.presenter.SliceInfo")
     def test_changing_dimensions_in_nonortho_mode_switches_to_ortho_when_dim_not_Q(self, mock_sliceinfo_cls):

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_sliceviewer_presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_sliceviewer_presenter.py
@@ -364,7 +364,7 @@ class SliceViewerTest(unittest.TestCase):
         presenter.update_axes_limits_to_extents = mock.Mock(return_value=None)
         presenter.dimensions_changed()
 
-        mock_new_plot.assert_called_with(dimensions_transposing=False)
+        mock_new_plot.assert_called_with()
 
     @mock.patch("mantidqt.widgets.sliceviewer.presenters.presenter.SliceInfo")
     def test_changing_dimensions_in_nonortho_mode_switches_to_ortho_when_dim_not_Q(self, mock_sliceinfo_cls):

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_sliceviewer_presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_sliceviewer_presenter.py
@@ -774,7 +774,7 @@ class SliceViewerTest(unittest.TestCase):
         presenter.view.data_view.dimensions.set_y_extents = mock.MagicMock()
 
         mock_axes = mock.MagicMock()
-        mock_axes.get_xlim = mock.MagicMock(return_value=[0, 1])
+        mock_axes.get_ylim = mock.MagicMock(return_value=[0, 1])
         yaxes_edit = SliceViewYAxisEditor(
             mock.MagicMock(), mock_axes, presenter.dimensions_changed, presenter.view.data_view.dimensions.set_y_extents
         )

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_sliceviewer_presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_sliceviewer_presenter.py
@@ -361,6 +361,7 @@ class SliceViewerTest(unittest.TestCase):
         mock_sliceinfo_cls.slicepoint = [None, None]  # no slicepoint as 2D ws
         data_view_mock.dimensions.get_previous_states.return_value = [0, 1]  # no None that indicates integrated dim
 
+        presenter.update_axes_limits_to_extents = mock.Mock(return_value=None)
         presenter.dimensions_changed()
 
         mock_new_plot.assert_called_with(dimensions_transposing=True)
@@ -372,6 +373,7 @@ class SliceViewerTest(unittest.TestCase):
         )
         self.model.get_number_dimensions.return_value = 2
 
+        presenter.update_axes_limits_to_extents = mock.Mock(return_value=None)
         presenter.dimensions_changed()
 
         data_view_mock.disable_tool_button.assert_called_once_with(ToolItemText.NONORTHOGONAL_AXES)
@@ -387,6 +389,7 @@ class SliceViewerTest(unittest.TestCase):
         self.patched_deps["WorkspaceInfo"].is_ragged_matrix_workspace.return_value = False
         self.model.get_number_dimensions.return_value = 2
 
+        presenter.update_axes_limits_to_extents = mock.Mock(return_value=None)
         presenter.dimensions_changed()
 
         data_view_mock.create_axes_nonorthogonal.assert_called_once()
@@ -400,6 +403,7 @@ class SliceViewerTest(unittest.TestCase):
         )
         self.model.get_number_dimensions.return_value = 2
 
+        presenter.update_axes_limits_to_extents = mock.Mock(return_value=None)
         presenter.dimensions_changed()
 
         data_view_mock.disable_tool_button.assert_called_once_with(ToolItemText.NONORTHOGONAL_AXES)
@@ -411,6 +415,7 @@ class SliceViewerTest(unittest.TestCase):
         )
         self.model.get_number_dimensions.return_value = 2
 
+        presenter.update_axes_limits_to_extents = mock.Mock(return_value=None)
         presenter.dimensions_changed()
 
         data_view_mock.enable_tool_button.assert_called_once_with(ToolItemText.NONORTHOGONAL_AXES)

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_sliceviewer_presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_sliceviewer_presenter.py
@@ -756,10 +756,13 @@ class SliceViewerTest(unittest.TestCase):
     def test_x_axes_editor_calls_dimensions_changed(self):
         presenter = SliceViewer(None, model=self.model, view=self.view)
         presenter.dimensions_changed = mock.MagicMock()
+        presenter.view.data_view.dimensions.set_x_extents = mock.MagicMock()
 
         mock_axes = mock.MagicMock()
         mock_axes.get_xlim = mock.MagicMock(return_value=[0, 1])
-        xaxes_edit = SliceViewXAxisEditor(canvas=mock.MagicMock(), axes=mock_axes, dimensions_changed=presenter.dimensions_changed)
+        xaxes_edit = SliceViewXAxisEditor(
+            mock.MagicMock(), mock_axes, presenter.dimensions_changed, presenter.view.data_view.dimensions.set_x_extents
+        )
 
         xaxes_edit.on_ok()
 
@@ -768,10 +771,13 @@ class SliceViewerTest(unittest.TestCase):
     def test_y_axes_editor_calls_dimensions_changed(self):
         presenter = SliceViewer(None, model=self.model, view=self.view)
         presenter.dimensions_changed = mock.MagicMock()
+        presenter.view.data_view.dimensions.set_y_extents = mock.MagicMock()
 
         mock_axes = mock.MagicMock()
-        mock_axes.get_ylim = mock.MagicMock(return_value=[0, 1])
-        yaxes_edit = SliceViewYAxisEditor(canvas=mock.MagicMock(), axes=mock_axes, dimensions_changed=presenter.dimensions_changed)
+        mock_axes.get_xlim = mock.MagicMock(return_value=[0, 1])
+        yaxes_edit = SliceViewYAxisEditor(
+            mock.MagicMock(), mock_axes, presenter.dimensions_changed, presenter.view.data_view.dimensions.set_y_extents
+        )
 
         yaxes_edit.on_ok()
 

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/views/dataview.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/views/dataview.py
@@ -205,10 +205,14 @@ class SliceViewerDataView(QWidget):
         self.clear_figure()
         self.set_nonorthogonal_transform(transform)
         extreme_finder = ExtremeFinderSimple(20, 20)
-        grid_locator1 = MaxNLocator(nbins=10)
-        grid_locator2 = MaxNLocator(nbins=10)
-        grid_locator1.set_params(integer=True)
-        grid_locator2.set_params(integer=True)
+        xint, yint = self.presenter.is_integer_frame()
+        grid_locator1, grid_locator2 = None, None
+        if xint:
+            grid_locator1 = MaxNLocator(nbins=10)
+            grid_locator1.set_params(integer=True)
+        if yint:
+            grid_locator2 = MaxNLocator(nbins=10)
+            grid_locator2.set_params(integer=True)
         grid_helper = GridHelperCurveLinear(
             (transform.tr, transform.inv_tr), extreme_finder=extreme_finder, grid_locator1=grid_locator1, grid_locator2=grid_locator2
         )
@@ -289,6 +293,7 @@ class SliceViewerDataView(QWidget):
         self._orig_lims = self.get_data_limits_to_fill_current_axes()
 
         self.on_track_cursor_state_change(self.track_cursor_checked())
+        self.set_integer_axes_ticks()
 
         self.draw_plot()
 
@@ -305,7 +310,6 @@ class SliceViewerDataView(QWidget):
         # pcolormesh clears any grid that was previously visible
         if self.grid_on:
             self.ax.grid(self.grid_on)
-        self.set_integer_axes_ticks()
         self.draw_plot()
 
     def plot_matrix(self, ws, **kwargs):
@@ -513,9 +517,9 @@ class SliceViewerDataView(QWidget):
         """
         Set axis locators at integer positions, if possible
         """
-        self.ax.minorticks_on()
-        self.ax.xaxis.get_major_locator().set_params(integer=True)
-        self.ax.yaxis.get_major_locator().set_params(integer=True)
+        xint, yint = self.presenter.is_integer_frame()
+        self.ax.xaxis.get_major_locator().set_params(integer=xint)
+        self.ax.yaxis.get_major_locator().set_params(integer=yint)
 
     def set_grid_on(self):
         """

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/views/dataview.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/views/dataview.py
@@ -313,7 +313,10 @@ class SliceViewerDataView(QWidget):
         xlim, ylim = self.transform_limits_to_extents(xlim, ylim)
         self.set_axes_limits(xlim, ylim)
 
+        self._orig_lims = self.get_data_limits_to_fill_current_axes()
+
         self.on_track_cursor_state_change(self.track_cursor_checked())
+        self.set_integer_axes_ticks()
         # pcolormesh clears any grid that was previously visible
         if self.grid_on:
             self.ax.grid(self.grid_on)
@@ -493,6 +496,14 @@ class SliceViewerDataView(QWidget):
             if self.nonorthogonal_mode:
                 xlim, ylim = self.inverse_transform_extents_to_limits(xlim, ylim)
             return xlim, ylim
+
+    def transform_extents_to_limits(self, xlim, ylim):
+        # viewing axis y not aligned with plot axis
+        # transform top left and bottom right corner
+        # of the zoomed rectangle extents needed to cover the data limits
+        xmin_p, ymax_p = self.nonortho_transform.tr(xlim[0], ylim[1])
+        xmax_p, ymin_p = self.nonortho_transform.tr(xlim[1], ylim[0])
+        return (xmin_p, xmax_p), (ymin_p, ymax_p)
 
     def transform_limits_to_extents(self, xlim, ylim):
         # viewing axis y not aligned with plot axis

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/views/dataview.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/views/dataview.py
@@ -491,26 +491,29 @@ class SliceViewerDataView(QWidget):
         else:
             xlim, ylim = self.get_axes_limits()
             if self.nonorthogonal_mode:
-                xlim, ylim = self.transform_extents_to_limits_inv(xlim, ylim)
+                xlim, ylim = self.inverse_transform_extents_to_limits(xlim, ylim)
             return xlim, ylim
 
     def transform_limits_to_extents(self, xlim, ylim):
         # viewing axis y not aligned with plot axis
-        # transform bottom left and top right corner so data fills the initial or zoomed rectangle
+        # transform bottom left and top right corner
+        # of the data limits needed to fill the initial or zoomed rectangle extents
         xmin_p, ymin_p = self.nonortho_transform.tr(xlim[0], ylim[0])
         xmax_p, ymax_p = self.nonortho_transform.tr(xlim[1], ylim[1])
         return (xmin_p, xmax_p), (ymin_p, ymax_p)
 
-    def transform_extents_to_limits_inv(self, xlim, ylim):
+    def inverse_transform_extents_to_limits(self, xlim, ylim):
         # viewing axis y not aligned with plot axis
-        # inverse transform top left and bottom right corner so data fills the initial or zoomed rectangle
+        # inverse transform top left and bottom right corner
+        # of the zoomed rectangle extents needed to cover the data limits
         xmin_p, ymax_p = self.nonortho_transform.inv_tr(xlim[0], ylim[1])
         xmax_p, ymin_p = self.nonortho_transform.inv_tr(xlim[1], ylim[0])
         return (xmin_p, xmax_p), (ymin_p, ymax_p)
 
-    def transform_limits_to_extents_inv(self, xlim, ylim):
+    def inverse_transform_limits_to_extents(self, xlim, ylim):
         # viewing axis y not aligned with plot axis
-        # inverse transform bottom left and top right corner so data fills the initial or zoomed rectangle
+        # inverse transform bottom left and top right corner
+        # of the data limits needed to fill the initial or zoomed rectangle extents
         xmin_p, ymin_p = self.nonortho_transform.inv_tr(xlim[0], ylim[0])
         xmax_p, ymax_p = self.nonortho_transform.inv_tr(xlim[1], ylim[1])
         return (xmin_p, xmax_p), (ymin_p, ymax_p)

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/views/dataview.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/views/dataview.py
@@ -201,9 +201,7 @@ class SliceViewerDataView(QWidget):
 
         self.canvas.draw_idle()
 
-    def create_axes_nonorthogonal(self, transform):
-        self.clear_figure()
-        self.set_nonorthogonal_transform(transform)
+    def grid_helper(self, transform):
         extreme_finder = ExtremeFinderSimple(20, 20)
         xint, yint = self.presenter.is_integer_frame()
         grid_locator1, grid_locator2 = None, None
@@ -216,6 +214,12 @@ class SliceViewerDataView(QWidget):
         grid_helper = GridHelperCurveLinear(
             (transform.tr, transform.inv_tr), extreme_finder=extreme_finder, grid_locator1=grid_locator1, grid_locator2=grid_locator2
         )
+        return grid_helper
+
+    def create_axes_nonorthogonal(self, transform):
+        self.clear_figure()
+        self.set_nonorthogonal_transform(transform)
+        grid_helper = self.grid_helper(transform)
         self.ax = CurveLinearSubPlot(self.fig, 1, 1, 1, grid_helper=grid_helper)
         # don't redraw on zoom as the data is rebinned and has to be redrawn again anyway
         self.enable_zoom_on_mouse_scroll(redraw=False)

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/views/dataview.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/views/dataview.py
@@ -490,14 +490,15 @@ class SliceViewerDataView(QWidget):
         if self.image is None:
             return None
         else:
-            xlim, ylim = self.ax.get_xlim(), self.ax.get_ylim()
+            xlim, ylim = self.get_axes_limits()
             if self.nonorthogonal_mode:
                 inv_tr = self.nonortho_transform.inv_tr
                 # viewing axis y not aligned with plot axis
                 # transform top left and bottom right corner so data fills the initial or zoomed rectangle
-                xmin_p, ymax_p = inv_tr(xlim[0], ylim[1])
-                xmax_p, ymin_p = inv_tr(xlim[1], ylim[0])
-
+                # xmin_p, ymax_p = inv_tr(xlim[0], ylim[1])
+                # xmax_p, ymin_p = inv_tr(xlim[1], ylim[0])
+                xmin_p, ymin_p = inv_tr(xlim[0], ylim[0])
+                xmax_p, ymax_p = inv_tr(xlim[1], ylim[1])
                 xlim, ylim = (xmin_p, xmax_p), (ymin_p, ymax_p)
             return xlim, ylim
 
@@ -520,6 +521,15 @@ class SliceViewerDataView(QWidget):
         """
         self.ax.set_xlim(xlim)
         self.ax.set_ylim(ylim)
+
+    def get_axes_limits(self):
+        """
+        Get the view limits on the image axes. Assume the
+        limits are in the orthogonal frame.
+        """
+        xlim = self.ax.get_xlim()
+        ylim = self.ax.get_ylim()
+        return xlim, ylim
 
     def set_integer_axes_ticks(self):
         """

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/views/dataview.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/views/dataview.py
@@ -166,6 +166,7 @@ class SliceViewerDataView(QWidget):
         self.dimensions = DimensionWidget(dims_info, parent=self)
         self.dimensions.dimensionsChanged.connect(self.presenter.dimensions_changed)
         self.dimensions.valueChanged.connect(self.presenter.slicepoint_changed)
+        self.dimensions.extentsChanged.connect(self.presenter.extents_changed)
         self.dimensions_layout.addWidget(self.track_cursor, 0, 1, Qt.AlignRight)
         if not custom_image_info:
             self.dimensions_layout.addWidget(self.dimensions, 1, 0, 1, 1)
@@ -202,6 +203,9 @@ class SliceViewerDataView(QWidget):
         self.canvas.draw_idle()
 
     def grid_helper(self, transform):
+        """
+        Grid helper for CurveLinearSubplot
+        """
         extreme_finder = ExtremeFinderSimple(20, 20)
         xint, yint = self.presenter.is_integer_frame()
         grid_locator1, grid_locator2 = None, None

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/views/dimensionwidget.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/views/dimensionwidget.py
@@ -264,9 +264,6 @@ class Dimension(QWidget):
         self.spinMin.editingFinished.connect(self.spinMin_changed)
         self.spinMax.editingFinished.connect(self.spinMax_changed)
 
-        self.spinMin.valueChanged.connect(self.minChanged)
-        self.spinMax.valueChanged.connect(self.maxChanged)
-
         self.layout.addWidget(self.name)
         self.button_layout = QHBoxLayout()
         self.button_layout.setContentsMargins(0, 0, 0, 0)

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/views/dimensionwidget.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/views/dimensionwidget.py
@@ -268,9 +268,6 @@ class Dimension(QWidget):
         self.spinMin.setDecimals(3)
         self.spinMax.setDecimals(3)
 
-        self.spinMin.setRange(self.minimum, self.maximum)
-        self.spinMax.setRange(self.minimum, self.maximum)
-
         self.spinMin.setSingleStep(self.width)
         self.spinMax.setSingleStep(self.width)
 

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/views/dimensionwidget.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/views/dimensionwidget.py
@@ -141,7 +141,24 @@ class DimensionWidget(QWidget):
             return None
 
     def get_extents(self):
-        return [(d.get_min(), d.get_max()) for d in self.dims for state in (State.X, State.Y) if d.get_state() == state]
+        for d in self.dims:
+            if d.get_state() == State.X:
+                xlim = d.get_min(), d.get_max()
+            elif d.get_state() == State.Y:
+                ylim = d.get_min(), d.get_max()
+        return xlim, ylim
+
+    def set_x_extents(self, xlim):
+        for d in self.dims:
+            if d.get_state() == State.X:
+                d.set_min(xlim[0])
+                d.set_max(xlim[1])
+
+    def set_y_extents(self, ylim):
+        for d in self.dims:
+            if d.get_state() == State.Y:
+                d.set_min(ylim[0])
+                d.set_max(ylim[1])
 
     def set_extents(self, xlim, ylim):
         for d in self.dims:

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/views/dimensionwidget.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/views/dimensionwidget.py
@@ -271,11 +271,11 @@ class Dimension(QWidget):
         self.spinMin.setSingleStep(self.width)
         self.spinMax.setSingleStep(self.width)
 
+        self.spinMin.setRange(-float("inf"), float("inf"))
+        self.spinMax.setRange(-float("inf"), float("inf"))
+
         self.set_min(self.minimum)
         self.set_max(self.maximum)
-
-        self.update_min()
-        self.update_max()
 
         self.spinMin.editingFinished.connect(self.spinMin_changed)
         self.spinMax.editingFinished.connect(self.spinMax_changed)

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/views/dimensionwidget.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/views/dimensionwidget.py
@@ -153,12 +153,14 @@ class DimensionWidget(QWidget):
             if d.get_state() == State.X:
                 d.set_min(xlim[0])
                 d.set_max(xlim[1])
+        self.previous_dimensions_state = self.dimensions_state
 
     def set_y_extents(self, ylim):
         for d in self.dims:
             if d.get_state() == State.Y:
                 d.set_min(ylim[0])
                 d.set_max(ylim[1])
+        self.previous_dimensions_state = self.dimensions_state
 
     def set_extents(self, xlim, ylim):
         for d in self.dims:

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/views/dimensionwidget.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/views/dimensionwidget.py
@@ -271,8 +271,8 @@ class Dimension(QWidget):
         self.spinMin.setSingleStep(self.width)
         self.spinMax.setSingleStep(self.width)
 
-        self.spinMin.setRange(-float("inf"), float("inf"))
-        self.spinMax.setRange(-float("inf"), float("inf"))
+        self.spinMin.setRange(-float("inf"), self.maximum)
+        self.spinMax.setRange(self.minimum, float("inf"))
 
         self.set_min(self.minimum)
         self.set_max(self.maximum)

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/views/view.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/views/view.py
@@ -50,7 +50,7 @@ class SliceViewerView(QWidget, ObservingView):
         self._peaks_view = None
         # config the splitter appearance
         splitterStyleStr = """QSplitter::handle{
-            border: 1px dotted gray;
+            border: 1px solid gray;
             min-height: 10px;
             max-height: 20px;
             }"""


### PR DESCRIPTION
**Description of work.**

This PR addresses a few requests from users to improve the usability of slice viewer. 

1. Integer ticks/gridlines for hkl-frames
2. Ability to change extents/limits of slice
3. Fix uninteded bug with 4d MDHisto workspaces when loading/creating histo workspaces directly

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**

Run this script to generate a 4d workspace with HKL frame and 1 general frame.

1. Ensure in ortho mode and non-ortho mode that integer-only tick marks are displayed when X and/or Y are in units of HKL. 
2. Zoom in to a region and make sure the limiting case with range smaller than 1.0 reverts to fractional ticks
3. Notice new min/max limit spin boxes in the dimension widget. Modify them by hand to ensure the frame extents get updated accordingly in ortho mode and non-ortho mode
5. Return to home to ensure everything gets set back to original
6. Zoom in and verify the zoomed extents match the display in the spin boxes

![image](https://user-images.githubusercontent.com/13754794/229773137-aa62dd7e-161d-4398-894b-c21bf56b0377.png)
![image](https://user-images.githubusercontent.com/13754794/229773233-9efa391f-253c-4950-a111-15a0495584b0.png)
![image](https://user-images.githubusercontent.com/13754794/229773288-1c27edac-63e0-47aa-a7db-e2405e51ccf0.png)

MDHisto script
```python
# import mantid algorithms, numpy and matplotlib
from mantid.simpleapi import *
import matplotlib.pyplot as plt
import numpy as np

signal = np.linspace(0,1,14641)
error = np.sqrt(signal)

signal -= 0.5

signal[signal>0.25] = np.nan

ws = CreateMDHistoWorkspace(Dimensionality=4,
                            Extents='-3,3,-10,10,-5,5,0,1',
                            SignalInput=signal,
                            ErrorInput=error,
                            NumberOfBins='11,11,11,11',
                            Names='[H,0,0],[0,K,0],[0,0,L],values',
                            Units='r.l.u.,r.l.u.,r.l.u.,a.b.u.',
                            Frames='HKL,HKL,HKL,General Frame')

SetMDFrame('ws', MDFrame='HKL', Axes=[0,1,2])

AddSampleLog('ws', LogName='sample')
ws.getExperimentInfo(0).run().addProperty('W_MATRIX', list(np.eye(3).flatten()), True)

SetUB('ws', a=5, b=5, c=7, alpha=90, beta=90, gamma=120)
```

MDEvent script
```python
# import mantid algorithms, numpy and matplotlib
from mantid.simpleapi import *
import matplotlib.pyplot as plt
import numpy as np

ws = CreateMDWorkspace(Dimensions='4', 
                       EventType='MDEvent',
                       Extents='-10,10,-10,10,-10,10,0,1',
                       Names='[H,0,0],[0,K,0],[0,0,L],values',
                       Units='r.l.u.,r.l.u.,r.l.u.,a.b.u.')

FakeMDEventData(ws, UniformParams='1000000')

SetMDFrame('ws', MDFrame='HKL', Axes=[0,1,2])

AddSampleLog('ws', LogName='sample')
ws.getExperimentInfo(0).run().addProperty('W_MATRIX', list(np.eye(3).flatten()), True)

SetUB('ws', a=5, b=5, c=7, alpha=90, beta=90, gamma=120)

CreatePeaksWorkspace(OutputWorkspace='peaks', OutputType='LeanElasticPeak')
```

<!-- Instructions for testing. -->

*There is no associated issue.*

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
