### PR TITLE
Fix bug that prevented workspace update in fit function

### DIFF
--- a/docs/source/release/v6.7.0/Framework/Fit_Functions/Bugfixes/35426.rst
+++ b/docs/source/release/v6.7.0/Framework/Fit_Functions/Bugfixes/35426.rst
@@ -1,0 +1,2 @@
+- Fixed a bug that meant when the workspace attribute of a function was changed (e.g. resolution or tabulated function) in a GUI the function was not updated.
+This would lead to a crash as Mantid believed that the option was invalid.

--- a/docs/source/release/v6.7.0/Indirect/Bugfixes/35426.rst
+++ b/docs/source/release/v6.7.0/Indirect/Bugfixes/35426.rst
@@ -1,0 +1,2 @@
+- Fixed a bug that meant when the workspace attribute of a function was changed (e.g. resolution or tabulated function) the function was not updated.
+This would lead to a crash as Mantid believed that the option was invalid.

--- a/qt/widgets/common/src/FunctionTreeView.cpp
+++ b/qt/widgets/common/src/FunctionTreeView.cpp
@@ -89,7 +89,7 @@ bool containsOneOf(std::string const &str, std::string const &delimiters) {
 
 // These attributes require the function to be fully reconstructed, as a
 // different number of properties will be required
-const std::vector<QString> REQUIRESRECONSTRUCTIONATTRIBUTES = {QString("n"), QString("Formula")};
+const std::vector<QString> REQUIRESRECONSTRUCTIONATTRIBUTES = {QString("n"), QString("Formula"), QString("Workspace")};
 } // namespace
 
 namespace MantidQt::MantidWidgets {


### PR DESCRIPTION
**Description of work.**

This was reported originally for the CovFit tab of the indirect data analysis GUI. However, the bug was present in all GUI's except for the main fit browser (attached to plots). The bug would cause a hard crash as the changed attribute was never updated, so Mantid believed that it was empty. 

**To test:**

<!-- Instructions for testing. -->
Load the data (I will send it to you)
Ungroup all of the workspaces in the ADS
Open Indirect, data analysis
Go to the `conv fit` tab
Click `Add workspace`
Change both options to `workspace` and it will auto-populate
Set the workspace index to 0 (just need some data, which doesnt matter)
Click `ok`

At the top of the `fit function` section, tick the `see full function` box
You will see the normal function browser
Add a product function
Within the product function add a tabulated function and a lorentzian
Fix all of the parameters in the tabulated function
Change the workspace for the tabulated function (e.g. the "total")
Click fit - no crash

Changing the workspace again and pressing fit will change the results as it now reads different data.


Fixes #35426 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->
Added to release notes.

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
