### PR TITLE
Add missing python exports to TimeROI

### DIFF
--- a/Framework/PythonInterface/mantid/api/src/Exports/Run.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/Run.cpp
@@ -6,6 +6,7 @@
 // SPDX - License - Identifier: GPL - 3.0 +
 #include "MantidAPI/Run.h"
 #include "MantidGeometry/Instrument/Goniometer.h"
+#include "MantidKernel/TimeROI.h"
 #include "MantidKernel/WarningSuppressions.h"
 #include "MantidPythonInterface/core/Copyable.h"
 #include "MantidPythonInterface/core/GetPointer.h"
@@ -230,6 +231,9 @@ void export_Run() {
       .def("startTime", &Run::startTime, arg("self"), "Return the total starting time of the run.")
 
       .def("endTime", &Run::endTime, arg("self"), "Return the total ending time of the run.")
+
+      .def("getTimeROI", &Run::getTimeROI, arg("self"), return_value_policy<reference_existing_object>(),
+           "Return the time regoin of interest")
 
       //-------------------- Dictionary access----------------------------
       .def("get", &getWithDefault, (arg("self"), arg("key"), arg("default")),

--- a/Framework/PythonInterface/mantid/kernel/src/Exports/TimeROI.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Exports/TimeROI.cpp
@@ -8,11 +8,21 @@
 #include "MantidTypes/Core/DateAndTime.h"
 #include <boost/python/class.hpp>
 #include <boost/python/copy_const_reference.hpp>
+#include <boost/python/list.hpp>
 #include <boost/python/register_ptr_to_python.hpp>
 
 using Mantid::Kernel::TimeROI;
 using Mantid::Types::Core::DateAndTime;
 using namespace boost::python;
+
+boost::python::list getSplittingIntervals(const TimeROI &self) {
+  boost::python::list times;
+  for (const auto &splitter : self.toSplitters()) {
+    times.append(splitter.start());
+    times.append(splitter.stop());
+  }
+  return times;
+}
 
 void export_TimeROI() {
   register_ptr_to_python<TimeROI *>();
@@ -30,5 +40,9 @@ void export_TimeROI() {
       .def("update_intersection", &TimeROI::update_intersection, (arg("self"), arg("other")),
            return_value_policy<copy_const_reference>(),
            "Updates the TimeROI values with the intersection with another TimeROI."
-           "See https://en.wikipedia.org/wiki/Intersection for more details");
+           "See https://en.wikipedia.org/wiki/Intersection for more details")
+      .def("useAll", &TimeROI::useAll, "True if all times are use")
+      .def("useNone", &TimeROI::useNone, "True if all times are ignore")
+      .def("toSplitters", &getSplittingIntervals, arg("self"),
+           "Returns a list of start and stop times for all splitting intervals");
 }

--- a/Framework/PythonInterface/mantid/kernel/src/Exports/TimeROI.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Exports/TimeROI.cpp
@@ -10,6 +10,7 @@
 #include <boost/python/copy_const_reference.hpp>
 #include <boost/python/list.hpp>
 #include <boost/python/register_ptr_to_python.hpp>
+#include <boost/python/tuple.hpp>
 
 using Mantid::Kernel::TimeROI;
 using Mantid::Types::Core::DateAndTime;
@@ -18,8 +19,7 @@ using namespace boost::python;
 boost::python::list getSplittingIntervals(const TimeROI &self) {
   boost::python::list times;
   for (const auto &splitter : self.toSplitters()) {
-    times.append(splitter.start());
-    times.append(splitter.stop());
+    times.append(make_tuple(splitter.start(), splitter.stop()));
   }
   return times;
 }

--- a/Framework/PythonInterface/test/python/mantid/api/RunTest.py
+++ b/Framework/PythonInterface/test/python/mantid/api/RunTest.py
@@ -7,7 +7,7 @@
 import unittest
 import copy
 from mantid.geometry import Goniometer
-from mantid.kernel import DateAndTime, FloatTimeSeriesProperty
+from mantid.kernel import DateAndTime, FloatTimeSeriesProperty, TimeROI
 from mantid.api import Run
 import numpy as np
 
@@ -37,6 +37,17 @@ class RunTest(unittest.TestCase):
         charge = run.getProtonCharge()
         self.assertEqual(type(charge), float)
         self.assertAlmostEqual(charge, 10.05)
+
+    def test_get_time_roi(self):
+        # there is intentionally no way create a TimeROI from python
+        run = Run()
+        roi = run.getTimeROI()
+        self.assertTrue(isinstance(roi, TimeROI))
+        self.assertTrue(roi.useAll())
+        self.assertFalse(roi.useNone())
+        values = roi.toSplitters()
+        self.assertTrue(isinstance(values, list))
+        self.assertEqual(len(values), 0)
 
     def test_run_hasProperty(self):
         self.assertTrue(self._run.hasProperty("start_time"))

--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -159,7 +159,7 @@ constParameter:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/mantid/api/src/Expo
 constParameter:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/mantid/api/src/Exports/IPeaksWorkspace.cpp:161
 unknownMacro:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/mantid/api/src/Exports/Axis.cpp:44
 syntaxError:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/mantid/api/src/Exports/Sample.cpp:81
-syntaxError:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/mantid/api/src/Exports/Run.cpp:247
+syntaxError:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/mantid/api/src/Exports/Run.cpp:251
 syntaxError:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/mantid/api/src/Exports/SpectrumDefinition.cpp:40
 syntaxError:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/mantid/dataobjects/src/Exports/EventList.cpp:37
 knownConditionTrueFalse:${CMAKE_SOURCE_DIR}/Framework/Reflectometry/src/CreateTransmissionWorkspace2.cpp:179


### PR DESCRIPTION
This adds the methods
* `Run.getTimeROI()`
* `TimeROI.toIntervals()` - simple list of `DateAndTime` objects with the start and stops for all intervals
* `TimeROI.useAll()`
* `TimeROI.useNone()`

**To test:**

Since one cannot create a `TimeROI` in python, run the following which is based off of the first usage example in the [FilterByTime algorithm docs](https://docs.mantidproject.org/nightly/algorithms/FilterByTime-v1.html#usage)

```python
from mantid.simpleapi import *

ws = CreateSampleWorkspace("Event",BankPixelWidth=1)
AddTimeSeriesLog(ws, Name="proton_charge", Time="2010-01-01T00:00:00", Value=100)
AddTimeSeriesLog(ws, Name="proton_charge", Time="2010-01-01T00:10:00", Value=100)
AddTimeSeriesLog(ws, Name="proton_charge", Time="2010-01-01T00:20:00", Value=100)
AddTimeSeriesLog(ws, Name="proton_charge", Time="2010-01-01T00:30:00", Value=100)
AddTimeSeriesLog(ws, Name="proton_charge", Time="2010-01-01T00:40:00", Value=15)
AddTimeSeriesLog(ws, Name="proton_charge", Time="2010-01-01T00:50:00", Value=100)

#Extract the first 30 minutes  * 60 = 1800 seconds (roughly half of the data)
wsFiltered = FilterByTime(ws,StartTime=0,StopTime=1800)
roi = wsFiltered.run().getTimeROI()
print("duration=", roi.durationInSeconds()) # should be 1800
print("useAll:", roi.useAll()) # should be false
print("useNone:", roi.useNone()) # should be false
print("splitters:") # should be 00:00:00 and 00:30:00
for item in roi.toSplitters():
    print(item)
```

Refs #34794

*This does not require release notes* because it is part of the larger release note described in #35423.

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
