### PR TITLE
Add 1D plot Controls to the Preview Tab

### DIFF
--- a/docs/source/release/v6.7.0/Reflectometry/New_features/35265.rst
+++ b/docs/source/release/v6.7.0/Reflectometry/New_features/35265.rst
@@ -1,0 +1,1 @@
+- Panning, zooming, gridlines, and scale adjustment are now available on the Preview Tab's 1D plot.

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewDockedWidgets.ui
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewDockedWidgets.ui
@@ -197,30 +197,12 @@
          </property>
         </widget>
        </item>
-       <item>
-        <widget class="MantidQt::MantidWidgets::PreviewPlot" name="line_plot" native="true">
-         <property name="toolTip">
-          <string>Reduced data. Use right-click for plot options</string>
-         </property>
-         <property name="toolTipDuration">
-          <number>2000</number>
-         </property>
-        </widget>
-       </item>
       </layout>
      </item>
     </layout>
    </widget>
   </widget>
  </widget>
- <customwidgets>
-  <customwidget>
-   <class>MantidQt::MantidWidgets::PreviewPlot</class>
-   <extends>QWidget</extends>
-   <header>MantidQtWidgets/Plotting/PreviewPlot.h</header>
-   <container>1</container>
-  </customwidget>
- </customwidgets>
  <resources/>
  <connections/>
 </ui>

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewDockedWidgets.ui
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewDockedWidgets.ui
@@ -170,8 +170,8 @@
   <widget class="QDockWidget" name="lp_dock">
    <property name="minimumSize">
     <size>
-     <width>0</width>
-     <height>0</height>
+     <width>216</width>
+     <height>69</height>
     </size>
    </property>
    <property name="features">
@@ -198,7 +198,7 @@
         </widget>
        </item>
        <item>
-        <widget class="MantidQt::MantidWidgets::QtPlotView" name="line_plot" native="true">
+        <widget class="MantidQt::MantidWidgets::PreviewPlot" name="line_plot" native="true">
          <property name="toolTip">
           <string>Reduced data. Use right-click for plot options</string>
          </property>
@@ -215,9 +215,9 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>MantidQt::MantidWidgets::QtPlotView</class>
+   <class>MantidQt::MantidWidgets::PreviewPlot</class>
    <extends>QWidget</extends>
-   <header>MantidQtWidgets/Plotting/PlotWidget/QtPlotView.h</header>
+   <header>MantidQtWidgets/Plotting/PreviewPlot.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/QtPreviewDockedWidgets.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/QtPreviewDockedWidgets.cpp
@@ -29,6 +29,9 @@ QtPreviewDockedWidgets::QtPreviewDockedWidgets(QWidget *parent, QLayout *layout)
   m_ui.setupUi(this);
   m_layout->addWidget(this);
 
+  m_previewPlot = new MantidQt::MantidWidgets::PreviewPlot(this);
+  m_ui.lp_layout->addWidget(m_previewPlot);
+
   resetInstView();
   loadToolbarIcons();
   setupSelectRegionTypes();
@@ -128,7 +131,7 @@ void QtPreviewDockedWidgets::plotInstView(MantidWidgets::InstrumentActor *instAc
 
 QLayout *QtPreviewDockedWidgets::getRegionSelectorLayout() const { return m_ui.rs_plot_layout; }
 
-IPlotView *QtPreviewDockedWidgets::getLinePlotView() const { return m_ui.line_plot; }
+IPlotView *QtPreviewDockedWidgets::getLinePlotView() const { return m_previewPlot; }
 
 void QtPreviewDockedWidgets::setInstViewZoomState(bool isChecked) { m_ui.iv_zoom_button->setDown(isChecked); }
 void QtPreviewDockedWidgets::setInstViewEditState(bool isChecked) { m_ui.iv_edit_button->setDown(isChecked); }

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/QtPreviewDockedWidgets.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/QtPreviewDockedWidgets.h
@@ -64,6 +64,7 @@ private:
   QLayout *m_layout;
   PreviewDockedWidgetsSubscriber *m_notifyee{nullptr};
   std::unique_ptr<MantidQt::MantidWidgets::InstrumentDisplay> m_instDisplay{nullptr};
+  MantidQt::MantidWidgets::PreviewPlot *m_previewPlot{nullptr};
 
   void connectSignals() const;
   void loadToolbarIcons();

--- a/qt/widgets/mplcpp/inc/MantidQtWidgets/MplCpp/Axes.h
+++ b/qt/widgets/mplcpp/inc/MantidQtWidgets/MplCpp/Axes.h
@@ -73,6 +73,7 @@ public:
   void autoscale(bool enable);
   void autoscaleView(bool scaleX = true, bool scaleY = true);
   void autoscaleView(bool tight, bool scaleX, bool scaleY);
+  void grid(bool const &visible);
   /// @}
 
   ///@name Transformations

--- a/qt/widgets/mplcpp/src/Axes.cpp
+++ b/qt/widgets/mplcpp/src/Axes.cpp
@@ -357,6 +357,11 @@ void Axes::autoscaleView(bool tight, bool scaleX, bool scaleY) {
   callMethodNoCheck<void, bool, bool, bool>(pyobj(), "autoscale_view", tight, scaleX, scaleY);
 }
 
+void Axes::grid(bool const &grid) {
+  GlobalInterpreterLock lock;
+  pyobj().attr("grid")(grid);
+}
+
 /**
  * Returns the blended transform that treats X in data coordinates and Y in axes coordinates
  * https://matplotlib.org/stable/tutorials/advanced/transforms_tutorial.html#blended-transformations

--- a/qt/widgets/mplcpp/src/PanZoomTool.cpp
+++ b/qt/widgets/mplcpp/src/PanZoomTool.cpp
@@ -34,6 +34,7 @@ constexpr auto TOOLBAR_PAN_METHOD = "pan";
 /// Return the matplotlib NavigationToolbar type appropriate
 /// for our backend. It is returned hidden
 Python::Object mplNavigationToolbar(FigureCanvasQt *canvas) {
+  GlobalInterpreterLock lock;
   const auto backend = backendModule();
   bool showCoordinates(false);
   auto obj = Python::Object(backend.attr(TOOLBAR_CLS)(canvas->pyobj(), canvas->pyobj(), showCoordinates));

--- a/qt/widgets/plotting/inc/MantidQtWidgets/Plotting/PlotWidget/IPlotView.h
+++ b/qt/widgets/plotting/inc/MantidQtWidgets/Plotting/PlotWidget/IPlotView.h
@@ -16,7 +16,7 @@ class EXPORT_OPT_MANTIDQT_PLOTTING IPlotView {
 public:
   virtual void setScaleLinear(const AxisID axisID) = 0;
   virtual void setScaleLog(const AxisID axisID) = 0;
-  virtual void plot(const std::vector<Mantid::API::MatrixWorkspace_sptr> &workspaces,
-                    const std::vector<int> &workspaceIndices, const bool plotErrorBars) = 0;
+  virtual void addAllSpectra(const std::vector<Mantid::API::MatrixWorkspace_sptr> &workspaces,
+                             const std::vector<int> &workspaceIndices, const bool plotErrorBars) = 0;
 };
 } // namespace MantidQt::MantidWidgets

--- a/qt/widgets/plotting/inc/MantidQtWidgets/Plotting/PlotWidget/QtPlotView.h
+++ b/qt/widgets/plotting/inc/MantidQtWidgets/Plotting/PlotWidget/QtPlotView.h
@@ -23,8 +23,8 @@ public:
   void setScaleLinear(const AxisID axisID) override;
   void setScaleLog(const AxisID axisID) override;
 
-  void plot(const std::vector<Mantid::API::MatrixWorkspace_sptr> &workspaces, const std::vector<int> &workspaceIndices,
-            const bool plotErrorBars) override;
+  void addAllSpectra(const std::vector<Mantid::API::MatrixWorkspace_sptr> &workspaces,
+                     const std::vector<int> &workspaceIndices, const bool plotErrorBars) override;
 
 private:
   Widgets::MplCpp::FigureCanvasQt *m_canvas;

--- a/qt/widgets/plotting/inc/MantidQtWidgets/Plotting/PreviewPlot.h
+++ b/qt/widgets/plotting/inc/MantidQtWidgets/Plotting/PreviewPlot.h
@@ -12,6 +12,7 @@
 #include "MantidQtWidgets/MplCpp/PanZoomTool.h"
 #include "MantidQtWidgets/Plotting/AxisID.h"
 #include "MantidQtWidgets/Plotting/DllOption.h"
+#include "MantidQtWidgets/Plotting/PlotWidget/IPlotView.h"
 #include "MantidQtWidgets/Plotting/RangeSelector.h"
 #include "MantidQtWidgets/Plotting/SingleSelector.h"
 
@@ -36,9 +37,9 @@ class FigureCanvasQt;
 namespace MantidWidgets {
 
 /**
- * Displays several workpaces on a matplotlib figure
+ * Displays several workspaces on a matplotlib figure
  */
-class EXPORT_OPT_MANTIDQT_PLOTTING PreviewPlot : public QWidget {
+class EXPORT_OPT_MANTIDQT_PLOTTING PreviewPlot : public QWidget, public IPlotView {
   Q_OBJECT
 
   Q_PROPERTY(QColor canvasColour READ canvasColour WRITE setCanvasColour)
@@ -55,6 +56,11 @@ public:
   QPointF toDataCoords(const QPoint &point) const;
 
   void setTightLayout(QHash<QString, QVariant> const &args);
+
+  void addAllSpectra(const std::vector<Mantid::API::MatrixWorkspace_sptr> &workspaces,
+                     const std::vector<int> &workspaceIndices, const bool plotErrorBars) override;
+  void setScaleLinear(const AxisID axisID) override;
+  void setScaleLog(const AxisID axisID) override;
 
   void addSpectrum(const QString &lineLabel, const Mantid::API::MatrixWorkspace_sptr &ws, const size_t wsIndex = 0,
                    const QColor &lineColour = QColor(),

--- a/qt/widgets/plotting/inc/MantidQtWidgets/Plotting/PreviewPlot.h
+++ b/qt/widgets/plotting/inc/MantidQtWidgets/Plotting/PreviewPlot.h
@@ -134,12 +134,15 @@ private:
   void regenerateLegend();
   void removeLegend();
 
+  void setGridlinesVisible(bool const &visible);
+
   void switchPlotTool(QAction *selected);
   void setXScaleType(QAction *selected);
   void setYScaleType(QAction *selected);
   void setErrorBars(QAction *selected);
   void setScaleType(AxisID id, const QString &actionName);
   void toggleLegend(const bool checked);
+  void toggleGridlines(const bool &checked);
 
   boost::optional<char const *> overrideAxisLabel(AxisID const &axisID);
   void setAxisLabel(AxisID const &axisID, char const *const label);
@@ -201,6 +204,7 @@ private:
   QAction *m_contextResetView;
   QActionGroup *m_contextXScale, *m_contextYScale;
   QAction *m_contextLegend;
+  QAction *m_contextGridlines;
   QActionGroup *m_contextErrorBars;
 };
 

--- a/qt/widgets/plotting/src/PlotWidget/PlotPresenter.cpp
+++ b/qt/widgets/plotting/src/PlotWidget/PlotPresenter.cpp
@@ -30,6 +30,6 @@ void PlotPresenter::setScaleLog(const AxisID axisID) { m_view->setScaleLog(axisI
 void PlotPresenter::setPlotErrorBars(const bool plotErrorBars) { m_model->setPlotErrorBars(plotErrorBars); }
 
 void PlotPresenter::plot() {
-  m_view->plot(m_model->getWorkspaces(), m_model->getWorkspaceIndices(), m_model->getPlotErrorBars());
+  m_view->addAllSpectra(m_model->getWorkspaces(), m_model->getWorkspaceIndices(), m_model->getPlotErrorBars());
 }
 } // namespace MantidQt::MantidWidgets

--- a/qt/widgets/plotting/src/PlotWidget/QtPlotView.cpp
+++ b/qt/widgets/plotting/src/PlotWidget/QtPlotView.cpp
@@ -43,8 +43,8 @@ void QtPlotView::setScaleLog(const AxisID axisID) {
   }
 }
 
-void QtPlotView::plot(const std::vector<Mantid::API::MatrixWorkspace_sptr> &workspaces,
-                      const std::vector<int> &workspaceIndices, const bool plotErrorBars) {
+void QtPlotView::addAllSpectra(const std::vector<Mantid::API::MatrixWorkspace_sptr> &workspaces,
+                               const std::vector<int> &workspaceIndices, const bool plotErrorBars) {
   Widgets::MplCpp::plot(workspaces, boost::none, workspaceIndices, m_canvas->gcf().pyobj(), boost::none,
                         m_axisProperties, boost::none, plotErrorBars, false);
 }

--- a/qt/widgets/plotting/src/PreviewPlot.cpp
+++ b/qt/widgets/plotting/src/PreviewPlot.cpp
@@ -716,13 +716,25 @@ void PreviewPlot::switchPlotTool(QAction *selected) {
  * Set the scale to linear on a given axis
  * @param axisID Axis to set to linear
  */
-void PreviewPlot::setScaleLinear(const AxisID axisID) { setScaleType(axisID, "linear"); }
+void PreviewPlot::setScaleLinear(const AxisID axisID) {
+  if (axisID == AxisID::XBottom)
+    m_contextXScale->actions()[0]->setChecked(true);
+  if (axisID == AxisID::YLeft)
+    m_contextYScale->actions()[0]->setChecked(true);
+  setScaleType(axisID, "linear");
+}
 
 /**
  * Set the scale to log on a given axis
  * @param axisID Axis to set to log
  */
-void PreviewPlot::setScaleLog(const AxisID axisID) { setScaleType(axisID, "log"); }
+void PreviewPlot::setScaleLog(const AxisID axisID) {
+  if (axisID == AxisID::XBottom)
+    m_contextXScale->actions()[1]->setChecked(true);
+  if (axisID == AxisID::YLeft)
+    m_contextYScale->actions()[1]->setChecked(true);
+  setScaleType(axisID, "log");
+}
 
 /**
  * Set the X scale based on the given QAction

--- a/qt/widgets/plotting/src/PreviewPlot.cpp
+++ b/qt/widgets/plotting/src/PreviewPlot.cpp
@@ -158,6 +158,7 @@ void PreviewPlot::addSpectrum(const QString &lineName, const Mantid::API::Matrix
     setAxisLabel(AxisID::YLeft, yLabel.get());
 
   regenerateLegend();
+  toggleGridlines(m_contextGridlines->isChecked());
   axes.relim();
 
   replot();
@@ -185,6 +186,7 @@ void PreviewPlot::removeSpectrum(const QString &lineName) {
   auto axes = m_canvas->gca();
   axes.removeArtists("lines", lineName);
   m_lines.remove(lineName);
+  toggleGridlines(m_contextGridlines->isChecked());
   regenerateLegend();
 }
 
@@ -531,6 +533,9 @@ void PreviewPlot::showContextMenu(QMouseEvent *evt) {
   contextMenu.addSeparator();
   contextMenu.addAction(m_contextLegend);
 
+  contextMenu.addSeparator();
+  contextMenu.addAction(m_contextGridlines);
+
   contextMenu.exec(evt->globalPos());
 }
 
@@ -583,6 +588,12 @@ void PreviewPlot::createActions() {
   m_contextLegend->setCheckable(true);
   m_contextLegend->setChecked(true);
   connect(m_contextLegend, &QAction::toggled, this, &PreviewPlot::toggleLegend);
+
+  // gridlines
+  m_contextGridlines = new QAction("Gridlines", this);
+  m_contextGridlines->setCheckable(true);
+  m_contextGridlines->setChecked(false);
+  connect(m_contextGridlines, &QAction::toggled, this, &PreviewPlot::toggleGridlines);
 }
 
 /**
@@ -669,6 +680,13 @@ void PreviewPlot::removeLegend() {
   if (!legend.pyobj().is_none()) {
     m_canvas->gca().legendInstance().remove();
   }
+}
+
+void PreviewPlot::setGridlinesVisible(bool const &visible) {
+  if (m_lines.isEmpty()) {
+    return;
+  }
+  m_canvas->gca().grid(visible);
 }
 
 /**
@@ -765,6 +783,11 @@ void PreviewPlot::toggleLegend(const bool checked) {
   } else {
     removeLegend();
   }
+  this->replot();
+}
+
+void PreviewPlot::toggleGridlines(const bool &checked) {
+  setGridlinesVisible(checked);
   this->replot();
 }
 

--- a/qt/widgets/plotting/test/PlotWidget/MockPlotView.h
+++ b/qt/widgets/plotting/test/PlotWidget/MockPlotView.h
@@ -18,7 +18,7 @@ public:
 
   MOCK_METHOD(void, setScaleLinear, (const AxisID), (override));
   MOCK_METHOD(void, setScaleLog, (const AxisID), (override));
-  MOCK_METHOD(void, plot,
+  MOCK_METHOD(void, addAllSpectra,
               (const std::vector<Mantid::API::MatrixWorkspace_sptr> &, const std::vector<int> &, const bool),
               (override));
 };

--- a/qt/widgets/plotting/test/PlotWidget/PlotPresenterTest.h
+++ b/qt/widgets/plotting/test/PlotWidget/PlotPresenterTest.h
@@ -55,7 +55,7 @@ public:
     EXPECT_CALL(*model, getWorkspaces()).Times(1).WillOnce(Return(workspaces));
     EXPECT_CALL(*model, getWorkspaceIndices()).Times(1).WillOnce(Return(wsIndices));
     EXPECT_CALL(*model, getPlotErrorBars()).Times(1).WillOnce(Return(plotErrors));
-    EXPECT_CALL(view, plot(workspaces, wsIndices, plotErrors)).Times(1);
+    EXPECT_CALL(view, addAllSpectra(workspaces, wsIndices, plotErrors)).Times(1);
 
     auto presenter = PlotPresenter(&view, std::move(model));
 


### PR DESCRIPTION
**Description of work.**
Allows for panning, zooming, and gridlines to be enabled. 

**To test:**
1. Open the preview tab and load 45455
2. Select a region to run a reduction 
3. Use right click to play with the 1D plot's functionality. 

Fixes #35265 


<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
