### PR TITLE
Move functionality from Property.h to ITimeSeriesProperty.h

### DIFF
--- a/Framework/Algorithms/inc/MantidAlgorithms/GetAllEi.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/GetAllEi.h
@@ -9,8 +9,8 @@
 #include "MantidAPI/Algorithm.h"
 #include "MantidAPI/MatrixWorkspace.h"
 #include "MantidAlgorithms/DllConfig.h"
+#include "MantidKernel/TimeROI.h"
 #include "MantidKernel/cow_ptr.h"
-//#include "MantidAPI/IAlgorithm.h"
 
 namespace Mantid {
 
@@ -65,7 +65,7 @@ protected: // for testing, private otherwise.
 
   /**Return average time series log value for the appropriately filtered log*/
   double getAvrgLogValue(const API::MatrixWorkspace_sptr &inputWS, const std::string &propertyName,
-                         std::vector<Kernel::SplittingInterval> &splitter);
+                         Kernel::TimeROI &timeroi);
   /**process logs and retrieve chopper speed and chopper delay*/
   void findChopSpeedAndDelay(const API::MatrixWorkspace_sptr &inputWS, double &chop_speed, double &chop_delay);
   void findGuessOpeningTimes(const std::pair<double, double> &TOF_range, double ChopDelay, double Period,

--- a/Framework/Algorithms/inc/MantidAlgorithms/SumEventsByLogValue.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/SumEventsByLogValue.h
@@ -53,8 +53,7 @@ private:
   void addMonitorCounts(const API::ITableWorkspace_sptr &outputWorkspace, const Kernel::TimeSeriesProperty<int> *log,
                         const int minVal, const int maxVal);
   std::vector<std::pair<std::string, const Kernel::ITimeSeriesProperty *>> getNumberSeriesLogs();
-  double sumProtonCharge(const Kernel::TimeSeriesProperty<double> *protonChargeLog,
-                         const Kernel::SplittingIntervalVec &filter);
+  double sumProtonCharge(const Kernel::TimeSeriesProperty<double> *protonChargeLog, const Kernel::TimeROI &filter);
 
   DataObjects::EventWorkspace_const_sptr m_inputWorkspace; ///< The input workspace
   std::string m_logName;                                   ///< The name of the log to sum against

--- a/Framework/Algorithms/src/GetAllEi.cpp
+++ b/Framework/Algorithms/src/GetAllEi.cpp
@@ -18,6 +18,7 @@
 #include "MantidIndexing/IndexInfo.h"
 #include "MantidKernel/BoundedValidator.h"
 #include "MantidKernel/EnabledWhenProperty.h"
+#include "MantidKernel/TimeROI.h"
 #include "MantidKernel/TimeSeriesProperty.h"
 #include "MantidKernel/Unit.h"
 #include "MantidKernel/UnitFactory.h"
@@ -530,7 +531,7 @@ bool GetAllEi::peakGuess(const API::MatrixWorkspace_sptr &inputWS, size_t index,
 
   peakPos = peaks[0];
   if (nHills > 2) {
-    size_t peakIndex = Kernel::VectorHelper::getBinIndex(hillsPos, peaks[0]);
+    auto peakIndex = std::size_t(Kernel::VectorHelper::getBinIndex(hillsPos, peaks[0]));
     peakTwoSigma = hillsPos[peakIndex + 1] - hillsPos[peakIndex];
   } else {
     if (hillsPos.size() == 2) {
@@ -685,13 +686,13 @@ void getBinRange(const HistogramData::HistogramX &eBins, double eMin, double eMa
   if (eMin <= bins[0]) {
     index_min = 0;
   } else {
-    index_min = Kernel::VectorHelper::getBinIndex(bins, eMin);
+    index_min = std::size_t(Kernel::VectorHelper::getBinIndex(bins, eMin));
   }
 
   if (eMax >= eBins[nBins - 1]) {
     index_max = nBins - 1;
   } else {
-    index_max = Kernel::VectorHelper::getBinIndex(bins, eMax) + 1;
+    index_max = std::size_t(Kernel::VectorHelper::getBinIndex(bins, eMax)) + 1;
     if (index_max >= nBins)
       index_max = nBins - 1; // last bin range anyway. Should not happen
   }
@@ -920,7 +921,7 @@ double GetAllEi::getAvrgLogValue(const API::MatrixWorkspace_sptr &inputWS, const
     auto TimeEnd = inputWS->run().endTime();
     pTimeSeries->filterByTime(TimeStart, TimeEnd);
   } else {
-    pTimeSeries->filterByTimes(splitter);
+    pTimeSeries->filterByTimes(Kernel::TimeROI(splitter));
   }
   if (pTimeSeries->size() == 0) {
     throw std::runtime_error("Can not find average value for log defined by property" + propertyName +

--- a/Framework/Algorithms/src/GetAllEi.cpp
+++ b/Framework/Algorithms/src/GetAllEi.cpp
@@ -898,8 +898,7 @@ Kernel::Property *GetAllEi::getPLogForProperty(const API::MatrixWorkspace_sptr &
  * @param inputWS      -- shared pointer to the input workspace containing
  *                        the log to process
  * @param propertyName -- log name
- * @param splitter     -- array of Kernel::splittingInterval data, used to
- *                        filter input events or empty array to use
+ * @param timeroi      -- used to filter input events or empty to use
  *                        experiment start/end times.
  */
 double GetAllEi::getAvrgLogValue(const API::MatrixWorkspace_sptr &inputWS, const std::string &propertyName,

--- a/Framework/Algorithms/src/SumEventsByLogValue.cpp
+++ b/Framework/Algorithms/src/SumEventsByLogValue.cpp
@@ -16,6 +16,7 @@
 #include "MantidKernel/ArrayProperty.h"
 #include "MantidKernel/MandatoryValidator.h"
 #include "MantidKernel/RebinParamsValidator.h"
+#include "MantidKernel/TimeROI.h"
 #include "MantidKernel/VectorHelper.h"
 
 #include <numeric>
@@ -357,7 +358,7 @@ double SumEventsByLogValue::sumProtonCharge(const Kernel::TimeSeriesProperty<dou
                                             const Kernel::SplittingIntervalVec &filter) {
   // Clone the proton charge log and filter the clone on this log value
   std::unique_ptr<Kernel::TimeSeriesProperty<double>> protonChargeLogClone(protonChargeLog->clone());
-  protonChargeLogClone->filterByTimes(filter);
+  protonChargeLogClone->filterByTimes(TimeROI(filter));
   // Seems like the only way to sum this is to yank out the values
   const std::vector<double> pcValues = protonChargeLogClone->valuesAsVector();
   return std::accumulate(pcValues.begin(), pcValues.end(), 0.0);

--- a/Framework/Algorithms/src/SumEventsByLogValue.cpp
+++ b/Framework/Algorithms/src/SumEventsByLogValue.cpp
@@ -204,8 +204,7 @@ void SumEventsByLogValue::createTableOutput(const Kernel::TimeSeriesProperty<int
     const auto row = std::size_t(value - minVal);
     // Create a filter giving the times when this log has the current value
     SplittingIntervalVec filter;
-    log->makeFilterByValue(filter, value,
-                           value); // min & max are the same of course
+    log->makeFilterByValue(filter, value, value); // min & max are the same of course
 
     // This section ensures that the filter goes to the end of the run
     if (value == log->lastValue() && protonChargeLog) {
@@ -226,15 +225,16 @@ void SumEventsByLogValue::createTableOutput(const Kernel::TimeSeriesProperty<int
       protonChgCol->cell<double>(row) = sumProtonCharge(protonChargeLog, filter);
     interruption_point();
 
-    auto timeROI = new TimeROI(filter);
+    // filter the logs
+    TimeROI timeROI(filter, true);
     for (auto &otherLog : otherLogs) {
       // Calculate the average value of each 'other' log for the current value
       // of the main log
       // Have to (maybe inefficiently) fetch back column by name - move outside
       // loop if too slow
-      outputWorkspace->getColumn(otherLog.first)->cell<double>(row) = otherLog.second->timeAverageValue(timeROI);
+      outputWorkspace->getColumn(otherLog.first)->cell<double>(row) = otherLog.second->timeAverageValue(&timeROI);
     }
-    delete timeROI;
+
     prog.report();
   }
 

--- a/Framework/Algorithms/test/GetAllEiTest.h
+++ b/Framework/Algorithms/test/GetAllEiTest.h
@@ -108,8 +108,8 @@ public:
   }
   bool filterLogProvided() const { return (m_pFilterLog != nullptr); }
   double getAvrgLogValue(const API::MatrixWorkspace_sptr &inputWS, const std::string &propertyName) {
-    std::vector<Kernel::SplittingInterval> splitter;
-    return GetAllEi::getAvrgLogValue(inputWS, propertyName, splitter);
+    Kernel::TimeROI timeroi;
+    return GetAllEi::getAvrgLogValue(inputWS, propertyName, timeroi);
   }
   API::MatrixWorkspace_sptr buildWorkspaceToFit(const API::MatrixWorkspace_sptr &inputWS, size_t &wsIndex0) {
     return GetAllEi::buildWorkspaceToFit(inputWS, wsIndex0);

--- a/Framework/DataObjects/inc/MantidDataObjects/EventList.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/EventList.h
@@ -432,7 +432,7 @@ private:
                                          Types::Core::DateAndTime stop, double tofFactor, double tofOffset,
                                          std::vector<T> &output);
   template <class T>
-  static void filterByTimeROIHelper(std::vector<T> &events, const Kernel::SplittingIntervalVec &intervals,
+  static void filterByTimeROIHelper(std::vector<T> &events, const std::vector<Kernel::TimeInterval> &intervals,
                                     std::vector<T> &output);
 
   template <class T> void filterInPlaceHelper(Kernel::SplittingIntervalVec &splitter, typename std::vector<T> &events);

--- a/Framework/DataObjects/src/EventList.cpp
+++ b/Framework/DataObjects/src/EventList.cpp
@@ -3713,7 +3713,7 @@ void EventList::filterByTimeAtSampleHelper(std::vector<T> &events, DateAndTime s
  * @param output :: reference to an event list that will be output.
  */
 template <class T>
-void EventList::filterByTimeROIHelper(std::vector<T> &events, const Kernel::SplittingIntervalVec &intervals,
+void EventList::filterByTimeROIHelper(std::vector<T> &events, const std::vector<Kernel::TimeInterval> &intervals,
                                       std::vector<T> &output) {
   for (const auto &time : intervals) {
     const DateAndTime start = time.start();
@@ -3824,7 +3824,7 @@ void EventList::filterByPulseTime(Kernel::TimeROI *timeRoi, EventList &output) c
   if ((timeRoi == nullptr) || (timeRoi->useAll())) {
     throw std::invalid_argument("TimeROI can not use all time");
   }
-  const auto &intervals = timeRoi->toSplitters();
+  const auto &intervals = timeRoi->toTimeIntervals();
 
   switch (eventType) {
   case TOF:

--- a/Framework/Kernel/inc/MantidKernel/DateAndTime.h
+++ b/Framework/Kernel/inc/MantidKernel/DateAndTime.h
@@ -38,7 +38,9 @@ public:
   bool isValid() const { return m_stop > m_start; }
 
   /// Interval length (in seconds?)
-  Types::Core::time_duration length() const { return m_stop - m_start; }
+  Types::Core::time_duration length() const;
+  /// in seconds
+  double duration() const;
 
   /// True if the interval contains \a t.
   bool contains(const Types::Core::DateAndTime &t) const { return t >= start() && t < stop(); }

--- a/Framework/Kernel/inc/MantidKernel/FilteredTimeSeriesProperty.h
+++ b/Framework/Kernel/inc/MantidKernel/FilteredTimeSeriesProperty.h
@@ -77,7 +77,7 @@ public:
   const TimeSeriesProperty<HeldType> *unfiltered() const;
 
   /// If filtering by log, get the time intervals for splitting
-  std::vector<Mantid::Kernel::SplittingInterval> getSplittingIntervals() const override;
+  std::vector<Mantid::Kernel::TimeInterval> getTimeIntervals() const override;
 
   const Kernel::TimeROI &getTimeROI() const;
 

--- a/Framework/Kernel/inc/MantidKernel/ITimeSeriesProperty.h
+++ b/Framework/Kernel/inc/MantidKernel/ITimeSeriesProperty.h
@@ -40,6 +40,10 @@ public:
   // After trying to use return type covariance, but that showed Error C2908
   // Using property seemed to be the most straightforward solution.
   virtual Property *cloneWithTimeShift(const double timeShift) const = 0;
+
+  virtual void filterByTime(const Types::Core::DateAndTime &start, const Types::Core::DateAndTime &stop) = 0;
+  virtual void splitByTime(const std::vector<SplittingInterval> &splitter, std::vector<Property *> outputs,
+                           bool isProtonCharge = true) const = 0;
   /// Calculate the time-weighted average of a property in a filtered range
   virtual double averageValueInFilter(const std::vector<SplittingInterval> &filter) const = 0;
   /// Calculate the time-weighted average and standard deviation of a property

--- a/Framework/Kernel/inc/MantidKernel/ITimeSeriesProperty.h
+++ b/Framework/Kernel/inc/MantidKernel/ITimeSeriesProperty.h
@@ -44,11 +44,6 @@ public:
   virtual void filterByTime(const Types::Core::DateAndTime &start, const Types::Core::DateAndTime &stop) = 0;
   virtual void splitByTime(const std::vector<SplittingInterval> &splitter, std::vector<Property *> outputs,
                            bool isProtonCharge = true) const = 0;
-  /// Calculate the time-weighted average of a property in a filtered range
-  virtual double averageValueInFilter(const std::vector<SplittingInterval> &filter) const = 0;
-  /// Calculate the time-weighted average and standard deviation of a property
-  /// in a filtered range
-  virtual std::pair<double, double> averageAndStdDevInFilter(const std::vector<SplittingInterval> &filter) const = 0;
   /// Return the time series's times as a vector<DateAndTime>
   virtual std::vector<Types::Core::DateAndTime> timesAsVector() const = 0;
   /** Returns the calculated time weighted average value.
@@ -56,6 +51,10 @@ public:
    * @return The time-weighted average value of the log when the time measurement was active.
    */
   virtual double timeAverageValue(const TimeROI *timeRoi = nullptr) const = 0;
+  /** Returns the calculated time weighted mean and standard deviation values.
+   * @param timeRoi  Object that holds information about when the time measurement was active.
+   */
+  virtual std::pair<double, double> timeAverageValueAndStdDev(const Kernel::TimeROI *timeRoi = nullptr) const = 0;
   /// Return a TimeSeriesPropertyStatistics object
   virtual TimeSeriesPropertyStatistics getStatistics(const TimeROI *roi = nullptr) const = 0;
   /// Filtering the series according to the selected statistical measure

--- a/Framework/Kernel/inc/MantidKernel/Property.h
+++ b/Framework/Kernel/inc/MantidKernel/Property.h
@@ -173,9 +173,6 @@ public:
 
   /// Add to this
   virtual Property &operator+=(Property const *rhs) = 0;
-  virtual void filterByTime(const Types::Core::DateAndTime &start, const Types::Core::DateAndTime &stop);
-  virtual void splitByTime(std::vector<SplittingInterval> &splitter, std::vector<Property *> outputs,
-                           bool isProtonCharge = true) const;
 
   virtual int size() const;
 

--- a/Framework/Kernel/inc/MantidKernel/SplittingInterval.h
+++ b/Framework/Kernel/inc/MantidKernel/SplittingInterval.h
@@ -32,8 +32,6 @@ public:
 
   SplittingInterval(const Types::Core::DateAndTime &start, const Types::Core::DateAndTime &stop, const int index = 0);
 
-  double duration() const;
-
   int index() const;
 
   /// @cond

--- a/Framework/Kernel/inc/MantidKernel/TimeROI.h
+++ b/Framework/Kernel/inc/MantidKernel/TimeROI.h
@@ -24,6 +24,8 @@ public:
   TimeROI();
   TimeROI(const Types::Core::DateAndTime &startTime, const Types::Core::DateAndTime &stopTime);
   TimeROI(const Kernel::TimeSeriesProperty<bool> *filter);
+  /// Constructor ignores the index of the splitter
+  TimeROI(const Kernel::SplittingIntervalVec &splitter);
   double durationInSeconds() const;
   double durationInSeconds(const Types::Core::DateAndTime &startTime, const Types::Core::DateAndTime &stopTime) const;
   std::size_t numBoundaries() const;
@@ -48,6 +50,7 @@ public:
   void update_intersection(const TimeROI &other);
   void update_or_replace_intersection(const TimeROI &other);
   const Kernel::SplittingIntervalVec toSplitters() const;
+  const std::vector<Kernel::TimeInterval> toIntervals() const;
   bool operator==(const TimeROI &other) const;
   bool operator!=(const TimeROI &other) const;
   /// print the ROI boundaries to a string

--- a/Framework/Kernel/inc/MantidKernel/TimeROI.h
+++ b/Framework/Kernel/inc/MantidKernel/TimeROI.h
@@ -24,8 +24,6 @@ public:
   TimeROI();
   TimeROI(const Types::Core::DateAndTime &startTime, const Types::Core::DateAndTime &stopTime);
   TimeROI(const Kernel::TimeSeriesProperty<bool> *filter);
-  /// Constructor ignores the index of the splitter
-  TimeROI(const Kernel::SplittingIntervalVec &splitter, const bool skipEmpty = false);
   double durationInSeconds() const;
   double durationInSeconds(const Types::Core::DateAndTime &startTime, const Types::Core::DateAndTime &stopTime) const;
   std::size_t numBoundaries() const;

--- a/Framework/Kernel/inc/MantidKernel/TimeROI.h
+++ b/Framework/Kernel/inc/MantidKernel/TimeROI.h
@@ -50,7 +50,7 @@ public:
   void update_intersection(const TimeROI &other);
   void update_or_replace_intersection(const TimeROI &other);
   const Kernel::SplittingIntervalVec toSplitters() const;
-  const std::vector<Kernel::TimeInterval> toIntervals() const;
+  const std::vector<Kernel::TimeInterval> toTimeIntervals() const;
   bool operator==(const TimeROI &other) const;
   bool operator!=(const TimeROI &other) const;
   /// print the ROI boundaries to a string

--- a/Framework/Kernel/inc/MantidKernel/TimeROI.h
+++ b/Framework/Kernel/inc/MantidKernel/TimeROI.h
@@ -47,7 +47,6 @@ public:
   void update_union(const TimeROI &other);
   void update_intersection(const TimeROI &other);
   void update_or_replace_intersection(const TimeROI &other);
-  const Kernel::SplittingIntervalVec toSplitters() const;
   const std::vector<Kernel::TimeInterval> toTimeIntervals() const;
   bool operator==(const TimeROI &other) const;
   bool operator!=(const TimeROI &other) const;

--- a/Framework/Kernel/inc/MantidKernel/TimeROI.h
+++ b/Framework/Kernel/inc/MantidKernel/TimeROI.h
@@ -25,7 +25,7 @@ public:
   TimeROI(const Types::Core::DateAndTime &startTime, const Types::Core::DateAndTime &stopTime);
   TimeROI(const Kernel::TimeSeriesProperty<bool> *filter);
   /// Constructor ignores the index of the splitter
-  TimeROI(const Kernel::SplittingIntervalVec &splitter);
+  TimeROI(const Kernel::SplittingIntervalVec &splitter, const bool skipEmpty = false);
   double durationInSeconds() const;
   double durationInSeconds(const Types::Core::DateAndTime &startTime, const Types::Core::DateAndTime &stopTime) const;
   std::size_t numBoundaries() const;

--- a/Framework/Kernel/inc/MantidKernel/TimeSeriesProperty.h
+++ b/Framework/Kernel/inc/MantidKernel/TimeSeriesProperty.h
@@ -350,7 +350,7 @@ public:
 private:
   /// Calculate the time-weighted average of a property in a filtered range
   double averageValueInFilter(const std::vector<SplittingInterval> &filter) const;
-  /// @copydoc Mantid::Kernel::ITimeSeriesProperty::averageAndStdDevInFilter()
+  /// Calculate the time-weighted average and std-deviation of a property in a filtered range
   std::pair<double, double> averageAndStdDevInFilter(const std::vector<SplittingInterval> &intervals) const;
 
 protected:

--- a/Framework/Kernel/inc/MantidKernel/TimeSeriesProperty.h
+++ b/Framework/Kernel/inc/MantidKernel/TimeSeriesProperty.h
@@ -183,10 +183,10 @@ public:
   /// Filter out a run by time.
   void filterByTime(const Types::Core::DateAndTime &start, const Types::Core::DateAndTime &stop) override;
   /// Filter by a range of times
-  void filterByTimes(const std::vector<SplittingInterval> &splittervec);
+  void filterByTimes(const TimeROI &timeroi);
 
   /// Split out a time series property by time intervals.
-  void splitByTime(std::vector<SplittingInterval> &splitter, std::vector<Property *> outputs,
+  void splitByTime(const std::vector<SplittingInterval> &splitter, std::vector<Property *> outputs,
                    bool isPeriodic) const override;
 
   /// New split method

--- a/Framework/Kernel/inc/MantidKernel/TimeSeriesProperty.h
+++ b/Framework/Kernel/inc/MantidKernel/TimeSeriesProperty.h
@@ -345,13 +345,13 @@ public:
   void reserve(size_t size) { m_values.reserve(size); };
 
   /// If filtering by log, get the time intervals for splitting
-  virtual std::vector<Mantid::Kernel::SplittingInterval> getSplittingIntervals() const;
+  virtual std::vector<Mantid::Kernel::TimeInterval> getTimeIntervals() const;
 
 private:
   /// Calculate the time-weighted average of a property in a filtered range
-  double averageValueInFilter(const std::vector<SplittingInterval> &filter) const;
+  double averageValueInFilter(const std::vector<TimeInterval> &filter) const;
   /// Calculate the time-weighted average and std-deviation of a property in a filtered range
-  std::pair<double, double> averageAndStdDevInFilter(const std::vector<SplittingInterval> &intervals) const;
+  std::pair<double, double> averageAndStdDevInFilter(const std::vector<TimeInterval> &intervals) const;
 
 protected:
   //----------------------------------------------------------------------------------------------

--- a/Framework/Kernel/inc/MantidKernel/TimeSeriesProperty.h
+++ b/Framework/Kernel/inc/MantidKernel/TimeSeriesProperty.h
@@ -199,14 +199,10 @@ public:
   /// Make sure an existing filter covers the full time range given
   void expandFilterToRange(std::vector<SplittingInterval> &split, double min, double max,
                            const TimeInterval &range) const override;
-  /// Calculate the time-weighted average of a property in a filtered range
-  double averageValueInFilter(const std::vector<SplittingInterval> &filter) const override;
-  /// @copydoc Mantid::Kernel::ITimeSeriesProperty::averageAndStdDevInFilter()
-  std::pair<double, double> averageAndStdDevInFilter(const std::vector<SplittingInterval> &intervals) const override;
   /** Returns the calculated time weighted mean and standard deviation values.
    * @param timeRoi  Object that holds information about when the time measurement was active.
    */
-  std::pair<double, double> timeAverageValueAndStdDev(const Kernel::TimeROI *timeRoi = nullptr) const;
+  std::pair<double, double> timeAverageValueAndStdDev(const Kernel::TimeROI *timeRoi = nullptr) const override;
   /// Returns the calculated time weighted average value.
   double timeAverageValue(const TimeROI *timeRoi = nullptr) const override;
   /// generate constant time-step histogram from the property values
@@ -350,6 +346,12 @@ public:
 
   /// If filtering by log, get the time intervals for splitting
   virtual std::vector<Mantid::Kernel::SplittingInterval> getSplittingIntervals() const;
+
+private:
+  /// Calculate the time-weighted average of a property in a filtered range
+  double averageValueInFilter(const std::vector<SplittingInterval> &filter) const;
+  /// @copydoc Mantid::Kernel::ITimeSeriesProperty::averageAndStdDevInFilter()
+  std::pair<double, double> averageAndStdDevInFilter(const std::vector<SplittingInterval> &intervals) const;
 
 protected:
   //----------------------------------------------------------------------------------------------

--- a/Framework/Kernel/src/DateAndTime.cpp
+++ b/Framework/Kernel/src/DateAndTime.cpp
@@ -83,6 +83,10 @@ bool TimeInterval::operator>(const TimeInterval &ti) const {
     return false;
 }
 
+Types::Core::time_duration TimeInterval::length() const { return m_stop - m_start; }
+
+double TimeInterval::duration() const { return Types::Core::DateAndTime::secondsFromDuration(this->length()); }
+
 bool TimeInterval::operator==(const TimeInterval &ti) const { return (start() == ti.start()) && (stop() == ti.stop()); }
 
 /// String representation of the begin time

--- a/Framework/Kernel/src/FilteredTimeSeriesProperty.cpp
+++ b/Framework/Kernel/src/FilteredTimeSeriesProperty.cpp
@@ -411,17 +411,16 @@ template <typename TYPE> const Kernel::TimeROI &FilteredTimeSeriesProperty<TYPE>
  * Otherwise the interval is just first time - last time.
  * @returns :: Vector of splitting intervals
  */
-template <typename TYPE>
-std::vector<SplittingInterval> FilteredTimeSeriesProperty<TYPE>::getSplittingIntervals() const {
+template <typename TYPE> std::vector<TimeInterval> FilteredTimeSeriesProperty<TYPE>::getTimeIntervals() const {
   if (m_filter->useAll()) {
     // Case where there is no filter just use the parent implementation
-    return TimeSeriesProperty<TYPE>::getSplittingIntervals();
+    return TimeSeriesProperty<TYPE>::getTimeIntervals();
   } else {
     if (!m_filterApplied) {
       applyFilter();
     }
 
-    return m_filter->toSplitters();
+    return m_filter->toTimeIntervals();
   }
 }
 

--- a/Framework/Kernel/src/FilteredTimeSeriesProperty.cpp
+++ b/Framework/Kernel/src/FilteredTimeSeriesProperty.cpp
@@ -309,7 +309,7 @@ template <typename TYPE> void FilteredTimeSeriesProperty<TYPE>::applyFilter() co
   // the index into the m_values array of the time, or -1 (before) or m_values.size() (after)
   std::size_t index_current_log{0};
 
-  for (const auto &splitter : m_filter->toSplitters()) {
+  for (const auto &splitter : m_filter->toTimeIntervals()) {
     const auto endTime = splitter.stop();
 
     // check if the splitter starts too early

--- a/Framework/Kernel/src/LogFilter.cpp
+++ b/Framework/Kernel/src/LogFilter.cpp
@@ -197,7 +197,7 @@ void LogFilter::setFilter(const TimeROI &roi, const bool filterOpenEnded) {
   // put the results into the TimeSeriesProperty
   std::vector<bool> values;
   std::vector<DateAndTime> times;
-  for (const auto &splitter : roi.toSplitters()) {
+  for (const auto &splitter : roi.toTimeIntervals()) {
     values.emplace_back(true);
     values.emplace_back(false);
     times.emplace_back(splitter.start());

--- a/Framework/Kernel/src/Property.cpp
+++ b/Framework/Kernel/src/Property.cpp
@@ -185,33 +185,6 @@ const std::string &Property::units() const { return m_units; }
  */
 void Property::setUnits(const std::string &unit) { m_units = unit; }
 
-//-------------------------------------------------------------------------------------------------
-/** Filter out a property by time. Will be overridden by TimeSeriesProperty
- * (only)
- * @param start :: the beginning time to filter from
- * @param stop :: the ending time to filter to
- * */
-void Property::filterByTime(const Types::Core::DateAndTime &start, const Types::Core::DateAndTime &stop) {
-  UNUSED_ARG(start);
-  UNUSED_ARG(stop);
-  // Do nothing in general
-}
-
-//-----------------------------------------------------------------------------------------------
-/** Split a property by time. Will be overridden by TimeSeriesProperty (only)
- * For any other property type, this does nothing.
- * @param splitter :: time splitter
- * @param outputs :: holder for splitter output
- * @param isProtonCharge :: a flag to tell whether the property is periodic or
- * not
- */
-void Property::splitByTime(std::vector<SplittingInterval> &splitter, std::vector<Property *> outputs,
-                           bool isProtonCharge) const {
-  UNUSED_ARG(splitter);
-  UNUSED_ARG(outputs);
-  UNUSED_ARG(isProtonCharge);
-}
-
 } // namespace Kernel
 
 //-------------------------- Utility function for class name lookup

--- a/Framework/Kernel/src/PropertyManager.cpp
+++ b/Framework/Kernel/src/PropertyManager.cpp
@@ -158,7 +158,9 @@ void PropertyManager::splitByTime(std::vector<SplittingInterval> &splitter,
 
     // Now the property does the splitting.
     bool isProtonCharge = prop->name() == "proton_charge";
-    prop->splitByTime(splitter, output_properties, isProtonCharge);
+    if (auto timeSeriesProperty = dynamic_cast<ITimeSeriesProperty *>(prop)) {
+      timeSeriesProperty->splitByTime(splitter, output_properties, isProtonCharge);
+    }
 
   } // for each property
 }

--- a/Framework/Kernel/src/SplittingInterval.cpp
+++ b/Framework/Kernel/src/SplittingInterval.cpp
@@ -20,9 +20,6 @@ SplittingInterval::SplittingInterval(const Types::Core::DateAndTime &start, cons
                                      const int index)
     : TimeInterval(start, stop), m_index(index) {}
 
-/// Returns the duration in seconds
-double SplittingInterval::duration() const { return DateAndTime::secondsFromDuration(this->length()); }
-
 /// Return the index (destination of this split time block)
 int SplittingInterval::index() const { return m_index; }
 

--- a/Framework/Kernel/src/TimeROI.cpp
+++ b/Framework/Kernel/src/TimeROI.cpp
@@ -99,7 +99,7 @@ void TimeROI::addROI(const Types::Core::DateAndTime &startTime, const Types::Cor
     TimeInterval roi_to_add(startTime, stopTime);
     std::vector<TimeInterval> output;
     bool union_added = false;
-    for (const auto &interval : this->toSplitters()) {
+    for (const auto &interval : this->toTimeIntervals()) {
       if (overlaps(roi_to_add, interval)) {
         // the roi absorbs this interval
         // this check must be first
@@ -191,7 +191,7 @@ void TimeROI::addMask(const Types::Core::DateAndTime &startTime, const Types::Co
     // loop through all current splitters and get new intersections
     std::vector<TimeInterval> output;
     TimeInterval intersection;
-    for (const auto &interval : this->toSplitters()) {
+    for (const auto &interval : this->toTimeIntervals()) {
       intersection = use_before.intersection(interval);
       if (intersection.isValid()) {
         output.push_back(intersection);
@@ -411,7 +411,7 @@ void TimeROI::update_union(const TimeROI &other) {
     return;
 
   // add all the intervals from the other
-  for (const auto &interval : other.toSplitters()) {
+  for (const auto &interval : other.toTimeIntervals()) {
     this->addROI(interval.start(), interval.stop());
   }
 }
@@ -469,20 +469,6 @@ void TimeROI::update_or_replace_intersection(const TimeROI &other) {
   } else if (!other.useAll()) {
     this->update_intersection(other);
   }
-}
-
-/**
- * This method is to lend itself to be compatible with existing implementation
- */
-const std::vector<SplittingInterval> TimeROI::toSplitters() const {
-  const auto NUM_VAL = m_roi.size();
-  std::vector<SplittingInterval> output;
-  // every other value is a start/stop
-  for (std::size_t i = 0; i < NUM_VAL; i += 2) {
-    output.emplace_back(m_roi[i], m_roi[i + 1]);
-  }
-
-  return output;
 }
 
 /// This method is to lend itself to helping with transition
@@ -608,7 +594,7 @@ void TimeROI::clear() { m_roi.clear(); }
 void TimeROI::saveNexus(::NeXus::File *file) const {
   // create a local TimeSeriesProperty which will do the actual work
   TimeSeriesProperty<bool> tsp(NAME);
-  for (const auto &interval : this->toSplitters()) {
+  for (const auto &interval : this->toTimeIntervals()) {
     tsp.addValue(interval.start(), ROI_USE);
     tsp.addValue(interval.stop(), ROI_IGNORE);
   }

--- a/Framework/Kernel/src/TimeROI.cpp
+++ b/Framework/Kernel/src/TimeROI.cpp
@@ -71,14 +71,6 @@ TimeROI::TimeROI(const Types::Core::DateAndTime &startTime, const Types::Core::D
 
 TimeROI::TimeROI(const Kernel::TimeSeriesProperty<bool> *filter) { this->replaceROI(filter); }
 
-TimeROI::TimeROI(const SplittingIntervalVec &splitter, const bool skipEmpty) {
-  for (const auto &split : splitter) {
-    if (skipEmpty && split.start() == split.stop())
-      continue;
-    this->addROI(split.start(), split.stop());
-  }
-}
-
 void TimeROI::addROI(const std::string &startTime, const std::string &stopTime) {
   this->addROI(DateAndTime(startTime), DateAndTime(stopTime));
 }

--- a/Framework/Kernel/src/TimeROI.cpp
+++ b/Framework/Kernel/src/TimeROI.cpp
@@ -71,8 +71,10 @@ TimeROI::TimeROI(const Types::Core::DateAndTime &startTime, const Types::Core::D
 
 TimeROI::TimeROI(const Kernel::TimeSeriesProperty<bool> *filter) { this->replaceROI(filter); }
 
-TimeROI::TimeROI(const SplittingIntervalVec &splitter) {
+TimeROI::TimeROI(const SplittingIntervalVec &splitter, const bool skipEmpty) {
   for (const auto &split : splitter) {
+    if (skipEmpty && split.start() == split.stop())
+      continue;
     this->addROI(split.start(), split.stop());
   }
 }

--- a/Framework/Kernel/src/TimeROI.cpp
+++ b/Framework/Kernel/src/TimeROI.cpp
@@ -71,6 +71,12 @@ TimeROI::TimeROI(const Types::Core::DateAndTime &startTime, const Types::Core::D
 
 TimeROI::TimeROI(const Kernel::TimeSeriesProperty<bool> *filter) { this->replaceROI(filter); }
 
+TimeROI::TimeROI(const SplittingIntervalVec &splitter) {
+  for (const auto &split : splitter) {
+    this->addROI(split.start(), split.stop());
+  }
+}
+
 void TimeROI::addROI(const std::string &startTime, const std::string &stopTime) {
   this->addROI(DateAndTime(startTime), DateAndTime(stopTime));
 }
@@ -479,7 +485,19 @@ const std::vector<SplittingInterval> TimeROI::toSplitters() const {
   std::vector<SplittingInterval> output;
   // every other value is a start/stop
   for (std::size_t i = 0; i < NUM_VAL; i += 2) {
-    output.push_back({m_roi[i], m_roi[i + 1]});
+    output.emplace_back(m_roi[i], m_roi[i + 1]);
+  }
+
+  return output;
+}
+
+/// This method is to lend itself to helping with transition
+const std::vector<Kernel::TimeInterval> TimeROI::toIntervals() const {
+  const auto NUM_VAL = m_roi.size();
+  std::vector<TimeInterval> output;
+  // every other value is a start/stop
+  for (std::size_t i = 0; i < NUM_VAL; i += 2) {
+    output.emplace_back(m_roi[i], m_roi[i + 1]);
   }
 
   return output;

--- a/Framework/Kernel/src/TimeROI.cpp
+++ b/Framework/Kernel/src/TimeROI.cpp
@@ -492,7 +492,7 @@ const std::vector<SplittingInterval> TimeROI::toSplitters() const {
 }
 
 /// This method is to lend itself to helping with transition
-const std::vector<Kernel::TimeInterval> TimeROI::toIntervals() const {
+const std::vector<Kernel::TimeInterval> TimeROI::toTimeIntervals() const {
   const auto NUM_VAL = m_roi.size();
   std::vector<TimeInterval> output;
   // every other value is a start/stop

--- a/Framework/Kernel/src/TimeSeriesProperty.cpp
+++ b/Framework/Kernel/src/TimeSeriesProperty.cpp
@@ -813,6 +813,10 @@ template <typename TYPE> double TimeSeriesProperty<TYPE>::timeAverageValue(const
   return retVal;
 }
 
+template <> double TimeSeriesProperty<std::string>::timeAverageValue(const TimeROI * /*timeRoi*/) const {
+  throw Exception::NotImplementedError("TimeSeriesProperty::timeAverageValue is not implemented for string properties");
+}
+
 /** Calculates the time-weighted average of a property in a filtered range.
  *  This is written for that case of logs whose values start at the times given.
  *  @param filter The splitter/filter restricting the range of values included
@@ -958,9 +962,10 @@ std::pair<double, double> TimeSeriesProperty<TYPE>::timeAverageValueAndStdDev(co
  *  @return pair (Nan, Nan) always.
  */
 template <>
-std::pair<double, double> TimeSeriesProperty<std::string>::timeAverageValueAndStdDev(const Kernel::TimeROI *roi) const {
-  UNUSED_ARG(roi);
-  return std::pair<double, double>(std::numeric_limits<double>::quiet_NaN(), std::numeric_limits<double>::quiet_NaN());
+std::pair<double, double>
+TimeSeriesProperty<std::string>::timeAverageValueAndStdDev(const Kernel::TimeROI * /*roi*/) const {
+  throw Exception::NotImplementedError(
+      "TimeSeriesProperty::timeAverageValueAndStdDev is not implemented for string properties");
 }
 
 // Re-enable the warnings disabled before makeFilterByValue

--- a/Framework/Kernel/src/TimeSeriesProperty.cpp
+++ b/Framework/Kernel/src/TimeSeriesProperty.cpp
@@ -314,8 +314,7 @@ void TimeSeriesProperty<TYPE>::filterByTime(const Types::Core::DateAndTime &star
  * unaffected
  * @param splittervec :: A list of intervals to split filter on
  */
-template <typename TYPE>
-void TimeSeriesProperty<TYPE>::filterByTimes(const std::vector<SplittingInterval> &splittervec) {
+template <typename TYPE> void TimeSeriesProperty<TYPE>::filterByTimes(const TimeROI &timeroi) {
   // 1. Sort
   sortIfNecessary();
 
@@ -330,7 +329,7 @@ void TimeSeriesProperty<TYPE>::filterByTimes(const std::vector<SplittingInterval
   g_log.debug() << "DB541  mp_copy Size = " << mp_copy.size() << "  Original MP Size = " << m_values.size() << "\n";
 
   // 4. Create new
-  for (const auto &splitter : splittervec) {
+  for (const auto &splitter : timeroi.toIntervals()) {
     Types::Core::DateAndTime t_start = splitter.start();
     Types::Core::DateAndTime t_stop = splitter.stop();
 
@@ -397,8 +396,8 @@ void TimeSeriesProperty<TYPE>::filterByTimes(const std::vector<SplittingInterval
  *                    proton-charge is periodic log.
  */
 template <typename TYPE>
-void TimeSeriesProperty<TYPE>::splitByTime(std::vector<SplittingInterval> &splitter, std::vector<Property *> outputs,
-                                           bool isPeriodic) const {
+void TimeSeriesProperty<TYPE>::splitByTime(const std::vector<SplittingInterval> &splitter,
+                                           std::vector<Property *> outputs, bool isPeriodic) const {
   // 0. Sort if necessary
   sortIfNecessary();
 

--- a/Framework/Kernel/src/TimeSeriesProperty.cpp
+++ b/Framework/Kernel/src/TimeSeriesProperty.cpp
@@ -329,7 +329,7 @@ template <typename TYPE> void TimeSeriesProperty<TYPE>::filterByTimes(const Time
   g_log.debug() << "DB541  mp_copy Size = " << mp_copy.size() << "  Original MP Size = " << m_values.size() << "\n";
 
   // 4. Create new
-  for (const auto &splitter : timeroi.toIntervals()) {
+  for (const auto &splitter : timeroi.toTimeIntervals()) {
     Types::Core::DateAndTime t_start = splitter.start();
     Types::Core::DateAndTime t_stop = splitter.stop();
 

--- a/Framework/Kernel/src/TimeSeriesProperty.cpp
+++ b/Framework/Kernel/src/TimeSeriesProperty.cpp
@@ -800,6 +800,11 @@ template <typename TYPE> double TimeSeriesProperty<TYPE>::timeAverageValue(const
     if ((timeRoi == nullptr) || (timeRoi->useAll())) {
       const auto &filter = getSplittingIntervals();
       retVal = this->averageValueInFilter(filter);
+    } else if (timeRoi->useNone()) {
+      // if TimeROI bans everything, use the simple mean
+      const auto stats =
+          Mantid::Kernel::getStatistics(this->valuesAsVector(), Mantid::Kernel::Math::StatisticType::Mean);
+      return stats.mean;
     } else {
       const auto &filter = timeRoi->toSplitters();
       retVal = this->averageValueInFilter(filter);

--- a/Framework/Kernel/src/TimeSeriesProperty.cpp
+++ b/Framework/Kernel/src/TimeSeriesProperty.cpp
@@ -1747,6 +1747,15 @@ TimeSeriesPropertyStatistics TimeSeriesProperty<TYPE>::getStatistics(const TimeR
   return out;
 }
 
+template <>
+TimeSeriesPropertyStatistics TimeSeriesProperty<std::string>::getStatistics(const TimeROI * /* roi*/) const {
+  // statistics of a string property doesn't make sense
+  TimeSeriesPropertyStatistics out;
+  out.setAllToNan();
+
+  return out;
+}
+
 /** Calculate a particular statistical quantity from the values of the time series.
  *  @param selection : Enum indicating the selected statistical quantity.
  *  @param roi : optional pointer to TimeROI object for filtering the time series values.

--- a/Framework/Kernel/src/TimeSeriesProperty.cpp
+++ b/Framework/Kernel/src/TimeSeriesProperty.cpp
@@ -312,7 +312,7 @@ void TimeSeriesProperty<TYPE>::filterByTime(const Types::Core::DateAndTime &star
 /**
  * Filter by a range of times. If current property has a single value it remains
  * unaffected
- * @param splittervec :: A list of intervals to split filter on
+ * @param timeroi :: A list of intervals to split filter on
  */
 template <typename TYPE> void TimeSeriesProperty<TYPE>::filterByTimes(const TimeROI &timeroi) {
   // 1. Sort

--- a/Framework/Kernel/test/FilteredTimeSeriesPropertyTest.h
+++ b/Framework/Kernel/test/FilteredTimeSeriesPropertyTest.h
@@ -588,7 +588,7 @@ public:
 
     // Test that the other time-average mean code is correct
     const auto roi = log->getTimeROI();
-    TS_ASSERT_DELTA(log->averageValueInFilter(roi.toSplitters()), exp_time_mean, 1.e-3);
+    TS_ASSERT_DELTA(log->timeAverageValue(&roi), exp_time_mean, 1.e-3);
   }
 
   /// Test that timeAverageValue respects the filter

--- a/Framework/Kernel/test/FilteredTimeSeriesPropertyTest.h
+++ b/Framework/Kernel/test/FilteredTimeSeriesPropertyTest.h
@@ -628,7 +628,7 @@ public:
     filter->addValue("2007-11-30T16:18:38", true);
     filter->addValue(secondEnd.toISO8601String(), false);
     log->filterWith(filter.get());
-    const auto &intervals = log->getSplittingIntervals();
+    const auto &intervals = log->getTimeIntervals();
     TS_ASSERT_EQUALS(intervals.size(), 2);
     if (intervals.size() == 2) {
       const auto &firstRange = intervals.front(), &secondRange = intervals.back();
@@ -651,7 +651,7 @@ public:
     filter->addValue(secondEnd.toISO8601String(), false);
     filter->addValue(thirdStart.toISO8601String(), true);
     log->filterWith(filter.get());
-    const auto &intervals = log->getSplittingIntervals();
+    const auto &intervals = log->getTimeIntervals();
     TS_ASSERT_EQUALS(intervals.size(), 3);
     if (intervals.size() == 3) {
       TS_ASSERT_EQUALS(intervals[0].start(), log->firstTime());

--- a/Framework/Kernel/test/TimeSeriesPropertyTest.h
+++ b/Framework/Kernel/test/TimeSeriesPropertyTest.h
@@ -420,16 +420,12 @@ public:
     TimeSeriesProperty<int> *log = createIntegerTSP(6);
     TS_ASSERT_EQUALS(log->realSize(), 6);
 
-    Mantid::Kernel::SplittingInterval interval0(DateAndTime("2007-11-30T16:17:10"), DateAndTime("2007-11-30T16:17:40"),
-                                                0);
-
-    Mantid::Kernel::SplittingIntervalVec splitters;
-    splitters.emplace_back(interval0);
+    TimeROI roi(DateAndTime("2007-11-30T16:17:10"), DateAndTime("2007-11-30T16:17:40"));
 
     // Since the filter is < stop, the last one is not counted, so there are  3
     // taken out.
 
-    log->filterByTimes(splitters);
+    log->filterByTimes(roi);
 
     TS_ASSERT_EQUALS(log->realSize(), 3);
 
@@ -440,20 +436,14 @@ public:
     TimeSeriesProperty<int> *log = createIntegerTSP(10);
     TS_ASSERT_EQUALS(log->realSize(), 10);
 
-    Mantid::Kernel::SplittingInterval interval0(DateAndTime("2007-11-30T16:17:10"), DateAndTime("2007-11-30T16:17:40"),
-                                                0);
-
-    Mantid::Kernel::SplittingInterval interval1(DateAndTime("2007-11-30T16:18:05"), DateAndTime("2007-11-30T16:18:25"),
-                                                0);
-
-    Mantid::Kernel::SplittingIntervalVec splitters;
-    splitters.emplace_back(interval0);
-    splitters.emplace_back(interval1);
+    TimeROI roi;
+    roi.addROI(DateAndTime("2007-11-30T16:17:10"), DateAndTime("2007-11-30T16:17:40"));
+    roi.addROI(DateAndTime("2007-11-30T16:18:05"), DateAndTime("2007-11-30T16:18:25"));
 
     // Since the filter is < stop, the last one is not counted, so there are  3
     // taken out.
 
-    log->filterByTimes(splitters);
+    log->filterByTimes(roi);
 
     TS_ASSERT_EQUALS(log->realSize(), 6);
 

--- a/Framework/Kernel/test/TimeSeriesPropertyTest.h
+++ b/Framework/Kernel/test/TimeSeriesPropertyTest.h
@@ -623,47 +623,51 @@ public:
     auto intLog = createIntegerTSP(5);
 
     // Test a filter that's fully within the range of both properties
-    SplittingIntervalVec filter;
-    filter.emplace_back(SplittingInterval(DateAndTime("2007-11-30T16:17:05"), DateAndTime("2007-11-30T16:17:29")));
-    TS_ASSERT_DELTA(dblLog->averageValueInFilter(filter), 7.308, 0.001);
-    TS_ASSERT_DELTA(intLog->averageValueInFilter(filter), 2.167, 0.001);
+    TimeROI filter(DateAndTime("2007-11-30T16:17:05"), DateAndTime("2007-11-30T16:17:29"));
+    TS_ASSERT_DELTA(dblLog->timeAverageValue(&filter), 7.308, 0.001);
+    TS_ASSERT_DELTA(intLog->timeAverageValue(&filter), 2.167, 0.001);
 
     // Test a filter that starts before the log start time
-    filter[0] = SplittingInterval(DateAndTime("2007-11-30T16:16:30"), DateAndTime("2007-11-30T16:17:13"));
-    TS_ASSERT_DELTA(dblLog->averageValueInFilter(filter), 9.820, 0.001);
-    TS_ASSERT_DELTA(intLog->averageValueInFilter(filter), 1.070, 0.001);
+    filter.clear();
+    filter.addROI(DateAndTime("2007-11-30T16:16:30"), DateAndTime("2007-11-30T16:17:13"));
+    TS_ASSERT_DELTA(dblLog->timeAverageValue(&filter), 9.820, 0.001);
+    TS_ASSERT_DELTA(intLog->timeAverageValue(&filter), 1.070, 0.001);
 
     // How about one that's entirely outside the log range (should just take the
     // last value)
-    filter[0] = SplittingInterval(DateAndTime("2013-01-01T00:00:00"), DateAndTime("2013-01-01T01:00:00"));
-    TS_ASSERT_DELTA(dblLog->averageValueInFilter(filter), 10.55, 0.001);
-    TS_ASSERT_DELTA(intLog->averageValueInFilter(filter), 5.0, 0.001);
+    filter.clear();
+    filter.addROI(DateAndTime("2013-01-01T00:00:00"), DateAndTime("2013-01-01T01:00:00"));
+    TS_ASSERT_DELTA(dblLog->timeAverageValue(&filter), 10.55, 0.001);
+    TS_ASSERT_DELTA(intLog->timeAverageValue(&filter), 5.0, 0.001);
 
     // Test a filter with two separate ranges, one of which goes past the end of
     // the log
-    filter[0] = SplittingInterval(DateAndTime("2007-11-30T16:17:05"), DateAndTime("2007-11-30T16:17:15"));
-    filter.emplace_back(SplittingInterval(DateAndTime("2007-11-30T16:17:25"), DateAndTime("2007-11-30T16:17:45")));
-    TS_ASSERT_DELTA(dblLog->averageValueInFilter(filter), 9.123, 0.001);
-    TS_ASSERT_DELTA(intLog->averageValueInFilter(filter), 3.167, 0.001);
+    filter.clear();
+    filter.addROI(DateAndTime("2007-11-30T16:17:05"), DateAndTime("2007-11-30T16:17:15"));
+    filter.addROI(DateAndTime("2007-11-30T16:17:25"), DateAndTime("2007-11-30T16:17:45"));
+    TS_ASSERT_DELTA(dblLog->timeAverageValue(&filter), 9.123, 0.001);
+    TS_ASSERT_DELTA(intLog->timeAverageValue(&filter), 3.167, 0.001);
 
     // Test a filter with two out of order ranges (the second one coming before
     // the first)
     // It should work fine.
-    filter[0] = filter[1];
-    filter[0] = SplittingInterval(DateAndTime("2007-11-30T16:17:05"), DateAndTime("2007-11-30T16:17:15"));
-    TS_ASSERT_DELTA(dblLog->averageValueInFilter(filter), 9.123, 0.001);
-    TS_ASSERT_DELTA(intLog->averageValueInFilter(filter), 3.167, 0.001);
+    filter.clear();
+    filter.addROI(DateAndTime("2007-11-30T16:17:25"), DateAndTime("2007-11-30T16:17:45"));
+    filter.addROI(DateAndTime("2007-11-30T16:17:05"), DateAndTime("2007-11-30T16:17:15"));
+    TS_ASSERT_DELTA(dblLog->timeAverageValue(&filter), 9.123, 0.001);
+    TS_ASSERT_DELTA(intLog->timeAverageValue(&filter), 3.167, 0.001);
 
     // What about an overlap between the filters? It's odd, but it's allowed.
-    filter[0] = SplittingInterval(DateAndTime("2007-11-30T16:17:05"), DateAndTime("2007-11-30T16:17:15"));
-    filter[1] = SplittingInterval(DateAndTime("2007-11-30T16:17:10"), DateAndTime("2007-11-30T16:17:20"));
-    TS_ASSERT_DELTA(dblLog->averageValueInFilter(filter), 8.16, 0.001);
-    TS_ASSERT_DELTA(intLog->averageValueInFilter(filter), 1.75, 0.001);
+    filter.clear();
+    filter.addROI(DateAndTime("2007-11-30T16:17:05"), DateAndTime("2007-11-30T16:17:15"));
+    filter.addROI(DateAndTime("2007-11-30T16:17:10"), DateAndTime("2007-11-30T16:17:20"));
+    TS_ASSERT_DELTA(dblLog->timeAverageValue(&filter), (9.99 * 5. + 7.55 * 10.) / 15., 0.001);
+    TS_ASSERT_DELTA(intLog->timeAverageValue(&filter), (1. * 5. + 2. * 10.) / 15., 0.001);
 
     // Check the correct behaviour of empty of single value logs.
-    TS_ASSERT(std::isnan(dProp->averageValueInFilter(filter)));
+    TS_ASSERT(std::isnan(dProp->timeAverageValue(&filter)));
     iProp->addValue(DateAndTime("2010-11-30T16:17:25"), 99);
-    TS_ASSERT_EQUALS(iProp->averageValueInFilter(filter), 99.0);
+    TS_ASSERT_EQUALS(iProp->timeAverageValue(&filter), 99.0);
 
     // Clean up
     delete dblLog;
@@ -695,9 +699,8 @@ public:
   }
 
   void test_averageValueInFilter_throws_for_string_property() {
-    SplittingIntervalVec splitter;
-    TS_ASSERT_THROWS(sProp->averageValueInFilter(splitter), const Exception::NotImplementedError &);
-    TS_ASSERT_THROWS(sProp->averageAndStdDevInFilter(splitter), const Exception::NotImplementedError &);
+    TS_ASSERT_THROWS(sProp->timeAverageValue(), const Exception::NotImplementedError &);
+    TS_ASSERT_THROWS(sProp->timeAverageValueAndStdDev(), const Exception::NotImplementedError &);
   }
 
   //----------------------------------------------------------------------------

--- a/Framework/Kernel/test/TimeSeriesPropertyTest.h
+++ b/Framework/Kernel/test/TimeSeriesPropertyTest.h
@@ -1969,7 +1969,7 @@ public:
 
   void test_getSplittingIntervals_noFilter() {
     const auto &log = getTestLog(); // no filter
-    const auto &intervals = log->getSplittingIntervals();
+    const auto &intervals = log->getTimeIntervals();
     TS_ASSERT_EQUALS(intervals.size(), 1);
     const auto &range = intervals.front();
     TS_ASSERT_EQUALS(range.start(), log->firstTime());

--- a/Framework/Muon/src/PlotAsymmetryByLogValue.cpp
+++ b/Framework/Muon/src/PlotAsymmetryByLogValue.cpp
@@ -900,7 +900,9 @@ double PlotAsymmetryByLogValue::getLogValue(MatrixWorkspace &ws) {
   if (!property) {
     throw std::invalid_argument("Log " + m_logName + " does not exist.");
   }
-  property->filterByTime(start, end);
+  if (auto timeSeriesProperty = dynamic_cast<ITimeSeriesProperty *>(property)) {
+    timeSeriesProperty->filterByTime(start, end);
+  }
 
   double value = 0;
   // try different property types

--- a/Framework/Muon/src/PlotAsymmetryByLogValue.cpp
+++ b/Framework/Muon/src/PlotAsymmetryByLogValue.cpp
@@ -895,7 +895,7 @@ double PlotAsymmetryByLogValue::getLogValue(MatrixWorkspace &ws) {
   double value = 0.;
   if (auto timeSeriesProperty = dynamic_cast<ITimeSeriesProperty *>(property)) {
     timeSeriesProperty->filterByTime(start, end);
-    if (m_logFunc == "Mean" || m_logFunc == "Min" || m_logFunc == "Min") {
+    if (m_logFunc == "Mean" || m_logFunc == "Min" || m_logFunc == "Max") {
       const auto stats = timeSeriesProperty->getStatistics();
       if (m_logFunc == "Mean")
         return stats.time_mean;

--- a/Framework/Muon/src/PlotAsymmetryByLogValue.cpp
+++ b/Framework/Muon/src/PlotAsymmetryByLogValue.cpp
@@ -46,27 +46,18 @@ namespace // anonymous
  */
 template <typename T>
 bool convertLogToDouble(const Mantid::Kernel::Property *property, double &value, const std::string &function) {
-  const auto *log = dynamic_cast<const Mantid::Kernel::TimeSeriesProperty<T> *>(property);
-  if (log) {
-    if (function == "Mean") {
-      value = static_cast<double>(log->timeAverageValue());
-    } else if (function == "First") {
+  if (const auto *log = dynamic_cast<const Mantid::Kernel::TimeSeriesProperty<T> *>(property)) {
+    if (function == "First") {
       value = static_cast<double>(log->firstValue());
-    } else if (function == "Min") {
-      value = static_cast<double>(log->minValue());
-    } else if (function == "Max") {
-      value = static_cast<double>(log->maxValue());
-    } else { // Default
+    } else if (function == "Last") { // Default
       value = static_cast<double>(log->lastValue());
+    } else {
+      return false;
     }
     return true;
+  } else {
+    return false;
   }
-  auto tlog = dynamic_cast<const Mantid::Kernel::PropertyWithValue<T> *>(property);
-  if (tlog) {
-    value = static_cast<double>(*tlog);
-    return true;
-  }
-  return false;
 }
 
 } // namespace
@@ -895,32 +886,40 @@ double PlotAsymmetryByLogValue::getLogValue(MatrixWorkspace &ws) {
     return static_cast<double>(end.totalNanoseconds() - m_firstStart_ns) * nanosec_to_sec;
   }
 
-  // Otherwise, try converting the log value to a double
-  auto *property = run.getLogData(m_logName);
-  if (!property) {
+  if (!run.hasProperty(m_logName)) {
     throw std::invalid_argument("Log " + m_logName + " does not exist.");
   }
+
+  // Otherwise, try converting the log value to a double
+  auto *property = run.getLogData(m_logName);
+  double value = 0.;
   if (auto timeSeriesProperty = dynamic_cast<ITimeSeriesProperty *>(property)) {
     timeSeriesProperty->filterByTime(start, end);
-  }
-
-  double value = 0;
-  // try different property types
-  if (convertLogToDouble<double>(property, value, m_logFunc))
-    return value;
-  if (convertLogToDouble<float>(property, value, m_logFunc))
-    return value;
-  if (convertLogToDouble<int32_t>(property, value, m_logFunc))
-    return value;
-  if (convertLogToDouble<int64_t>(property, value, m_logFunc))
-    return value;
-  if (convertLogToDouble<uint32_t>(property, value, m_logFunc))
-    return value;
-  if (convertLogToDouble<uint64_t>(property, value, m_logFunc))
-    return value;
-  // try if it's a string and can be lexically cast to double
-  auto slog = dynamic_cast<const Mantid::Kernel::PropertyWithValue<std::string> *>(property);
-  if (slog) {
+    if (m_logFunc == "Mean" || m_logFunc == "Min" || m_logFunc == "Min") {
+      const auto stats = timeSeriesProperty->getStatistics();
+      if (m_logFunc == "Mean")
+        return stats.time_mean;
+      else if (m_logFunc == "Min")
+        return stats.minimum;
+      else // maximum
+        return stats.maximum;
+    } else {
+      // try different property to get first or last value
+      if (convertLogToDouble<double>(property, value, m_logFunc))
+        return value;
+      if (convertLogToDouble<float>(property, value, m_logFunc))
+        return value;
+      if (convertLogToDouble<int32_t>(property, value, m_logFunc))
+        return value;
+      if (convertLogToDouble<int64_t>(property, value, m_logFunc))
+        return value;
+      if (convertLogToDouble<uint32_t>(property, value, m_logFunc))
+        return value;
+      if (convertLogToDouble<uint64_t>(property, value, m_logFunc))
+        return value;
+    }
+  } else if (const auto *slog = dynamic_cast<const Mantid::Kernel::PropertyWithValue<std::string> *>(property)) {
+    // try if it's a string and can be lexically cast to double
     try {
       value = boost::lexical_cast<double>(slog->value());
       return value;
@@ -929,7 +928,7 @@ double PlotAsymmetryByLogValue::getLogValue(MatrixWorkspace &ws) {
     }
   }
 
-  throw std::invalid_argument("Log " + m_logName + " cannot be converted to a double type.");
+  return run.getPropertyAsSingleValue(m_logName); // time average but only simple property with value come in
 }
 
 } // namespace Mantid::Algorithms

--- a/Framework/PythonInterface/mantid/kernel/src/Exports/TimeROI.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Exports/TimeROI.cpp
@@ -16,9 +16,9 @@ using Mantid::Kernel::TimeROI;
 using Mantid::Types::Core::DateAndTime;
 using namespace boost::python;
 
-boost::python::list getSplittingIntervals(const TimeROI &self) {
+boost::python::list getTimeIntervals(const TimeROI &self) {
   boost::python::list times;
-  for (const auto &splitter : self.toSplitters()) {
+  for (const auto &splitter : self.toTimeIntervals()) {
     times.append(make_tuple(splitter.start(), splitter.stop()));
   }
   return times;
@@ -43,6 +43,6 @@ void export_TimeROI() {
            "See https://en.wikipedia.org/wiki/Intersection for more details")
       .def("useAll", &TimeROI::useAll, "True if all times are use")
       .def("useNone", &TimeROI::useNone, "True if all times are ignore")
-      .def("toSplitters", &getSplittingIntervals, arg("self"),
-           "Returns a list of start and stop times for all splitting intervals");
+      .def("toTimeIntervals", &getTimeIntervals, arg("self"),
+           "Returns a list of start and stop times for all time intervals");
 }

--- a/Framework/PythonInterface/test/python/mantid/api/RunTest.py
+++ b/Framework/PythonInterface/test/python/mantid/api/RunTest.py
@@ -45,7 +45,7 @@ class RunTest(unittest.TestCase):
         self.assertTrue(isinstance(roi, TimeROI))
         self.assertTrue(roi.useAll())
         self.assertFalse(roi.useNone())
-        values = roi.toSplitters()
+        values = roi.toTimeIntervals()
         self.assertTrue(isinstance(values, list))
         self.assertEqual(len(values), 0)
 

--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -44,7 +44,7 @@ constParameter:${CMAKE_SOURCE_DIR}/Framework/API/inc/MantidAPI/IFunction.h:211
 constParameter:${CMAKE_SOURCE_DIR}/Framework/API/inc/MantidAPI/IFunction.h:213
 constParameter:${CMAKE_SOURCE_DIR}/Framework/API/inc/MantidAPI/IFunction.h:215
 unassignedVariable:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/CorelliCalibrationDatabase.cpp:460
-unreadVariable:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/GetAllEi.cpp:759
+unreadVariable:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/GetAllEi.cpp:758
 constStatement:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/PolarizationCorrectionWildes.cpp:96
 constStatement:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/PolarizationCorrectionWildes.cpp:101
 constStatement:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/PolarizationCorrectionWildes.cpp:105

--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -44,7 +44,7 @@ constParameter:${CMAKE_SOURCE_DIR}/Framework/API/inc/MantidAPI/IFunction.h:211
 constParameter:${CMAKE_SOURCE_DIR}/Framework/API/inc/MantidAPI/IFunction.h:213
 constParameter:${CMAKE_SOURCE_DIR}/Framework/API/inc/MantidAPI/IFunction.h:215
 unassignedVariable:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/CorelliCalibrationDatabase.cpp:460
-unreadVariable:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/GetAllEi.cpp:758
+unreadVariable:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/GetAllEi.cpp:759
 constStatement:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/PolarizationCorrectionWildes.cpp:96
 constStatement:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/PolarizationCorrectionWildes.cpp:101
 constStatement:${CMAKE_SOURCE_DIR}/Framework/Algorithms/src/PolarizationCorrectionWildes.cpp:105

--- a/qt/scientific_interfaces/Muon/MuonAnalysisHelper.cpp
+++ b/qt/scientific_interfaces/Muon/MuonAnalysisHelper.cpp
@@ -17,6 +17,7 @@
 #include "MantidKernel/EmptyValues.h"
 #include "MantidKernel/InstrumentInfo.h"
 #include "MantidKernel/StringTokenizer.h"
+#include "MantidKernel/TimeROI.h"
 #include "MantidKernel/TimeSeriesProperty.h"
 
 #include <QCheckBox>
@@ -184,13 +185,11 @@ void printRunInfo(const MatrixWorkspace_sptr &runWs, std::ostringstream &out) {
   out << "\nAverage Temperature: ";
   if (run.hasProperty("Temp_Sample")) {
     // Filter the temperatures by the start and end times for the run.
-    Mantid::Kernel::SplittingInterval time_split(start, end);
-    std::vector<Mantid::Kernel::SplittingInterval> splitVector = {time_split};
+    Mantid::Kernel::TimeROI timeroi(start, end);
     auto tempSample = run.getProperty("Temp_Sample");
-    const auto *tempSampleTimeSeries = dynamic_cast<const TimeSeriesProperty<double> *>(tempSample);
 
-    if (tempSampleTimeSeries) {
-      out << tempSampleTimeSeries->averageValueInFilter(splitVector);
+    if (const auto *tempSampleTimeSeries = dynamic_cast<const ITimeSeriesProperty *>(tempSample)) {
+      out << tempSampleTimeSeries->timeAverageValue(&timeroi);
     } else {
       out << "Not set";
     }


### PR DESCRIPTION
Since general properties cannot be filtered by time, there is no need for them to have empty methods to deal with filtering. This moves that functionality down to a more appropriate interface class, `ITimeSeriesProperty`.

There are also a some additional conversion methods added to `TimeROI` to simplify other code.

**To test:**

This is a refactor and a code review is more appropriate.

Refs #34794.

*This does not require release notes* because it is accounted for in a larger release note.

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
