### PR TITLE
Add Q-Spacing Output for OSIRIS Instrument in Indirect Diffraction UI

### DIFF
--- a/docs/source/release/v6.7.0/Indirect/New_features/35449.rst
+++ b/docs/source/release/v6.7.0/Indirect/New_features/35449.rst
@@ -1,0 +1,1 @@
+-  Add Q-Spacing Output for OSIRIS Instrument in Indirect Diffraction UI. The interface now produces three outputs in three units (Q-spacing, D-spacing, and Tof) instead of the previous two (D-spacing and Tof).

--- a/qt/scientific_interfaces/Indirect/IndirectDiffractionReduction.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectDiffractionReduction.cpp
@@ -413,10 +413,12 @@ void IndirectDiffractionReduction::runOSIRISdiffonlyReduction() {
   // and stop if unable to parse correctly.
   QString drangeWsName;
   QString tofWsName;
+  QString qWsName;
   try {
     QString nameBase = QString::fromStdString(Mantid::Kernel::MultiFileNameParsing::suggestWorkspaceName(stlFileNames));
     tofWsName = nameBase + "_tof";
     drangeWsName = nameBase + "_dRange";
+    qWsName = nameBase + "_q";
   } catch (std::runtime_error &re) {
     g_log.error(re.what());
     return;
@@ -445,15 +447,25 @@ void IndirectDiffractionReduction::runOSIRISdiffonlyReduction() {
   auto inputFromReductionProps = std::make_unique<Mantid::API::AlgorithmRuntimeProps>();
   inputFromReductionProps->setPropertyValue("InputWorkspace", drangeWsName.toStdString());
 
-  IAlgorithm_sptr convertUnits = AlgorithmManager::Instance().create("ConvertUnits");
-  convertUnits->initialize();
-  convertUnits->setProperty("OutputWorkspace", tofWsName.toStdString());
-  convertUnits->setProperty("Target", "TOF");
-  m_batchAlgoRunner->addAlgorithm(convertUnits, std::move(inputFromReductionProps));
+  IAlgorithm_sptr tofConvertUnits = AlgorithmManager::Instance().create("ConvertUnits");
+  tofConvertUnits->initialize();
+  tofConvertUnits->setProperty("OutputWorkspace", tofWsName.toStdString());
+  tofConvertUnits->setProperty("Target", "TOF");
+  m_batchAlgoRunner->addAlgorithm(tofConvertUnits, std::move(inputFromReductionProps));
+
+  inputFromReductionProps = std::make_unique<Mantid::API::AlgorithmRuntimeProps>();
+  inputFromReductionProps->setPropertyValue("InputWorkspace", drangeWsName.toStdString());
+
+  IAlgorithm_sptr qConvertUnits = AlgorithmManager::Instance().create("ConvertUnits");
+  qConvertUnits->initialize();
+  qConvertUnits->setProperty("OutputWorkspace", qWsName.toStdString());
+  qConvertUnits->setProperty("Target", "QSquared");
+  m_batchAlgoRunner->addAlgorithm(qConvertUnits, std::move(inputFromReductionProps));
 
   m_plotWorkspaces.clear();
   m_plotWorkspaces.emplace_back(tofWsName.toStdString());
   m_plotWorkspaces.emplace_back(drangeWsName.toStdString());
+  m_plotWorkspaces.emplace_back(qWsName.toStdString());
 
   // Handles completion of the diffraction algorithm chain
   connect(m_batchAlgoRunner, SIGNAL(batchComplete(bool)), this, SLOT(algorithmComplete(bool)));


### PR DESCRIPTION
**Description of work.**
This PR adds Q-spacing output for OSIRIS Instrument in the indirect diffraction interface. The interface now produces three outputs in three units (Q-spacing, D-spacing, and Tof) instead of the previous two (D-spacing and Tof).

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**
1- Go to interfaces->indirect->diffraction interface
2- Change the instrument to OSIRIS
3- Set Run Numbers to 120032
4- Set Cal File to the directory of the grouping file (asks me for the file)
5- Set Vanadium Runs to 119963
6- Click Run
7- You should see three different outputs in three units (Q-spacing, D-spacing, and Tof)

Fixes #34635. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
