### PR TITLE
Update tied properties in the FitPropertyBrowser

### DIFF
--- a/Framework/API/inc/MantidAPI/IFunction.h
+++ b/Framework/API/inc/MantidAPI/IFunction.h
@@ -557,7 +557,7 @@ public:
   /// Ignore a tie
   virtual bool ignoreTie(const ParameterTie &) const { return false; }
   /// Put all ties in order in which they will be applied correctly.
-  void sortTies();
+  void sortTies(const bool checkOnly = false);
   /// Write a parameter tie to a string
   [[nodiscard]] std::string writeTies() const;
   //@}

--- a/Framework/API/src/IFunction.cpp
+++ b/Framework/API/src/IFunction.cpp
@@ -294,7 +294,7 @@ void IFunction::addTie(std::unique_ptr<ParameterTie> tie) {
 
   try {
     // sortTies checks for circular and self ties
-    sortTies();
+    sortTies(true);
   } catch (std::runtime_error &) {
     // revert / remove tie if invalid
     if (oldTie) {
@@ -1597,8 +1597,13 @@ std::vector<IFunction_sptr> IFunction::createEquivalentFunctions() const {
 }
 
 /// Put all ties in order in which they will be applied correctly.
-void IFunction::sortTies() {
-  m_orderedTies.clear();
+/// @param checkOnly :: If true then do not clear or write to m_orderedTies, only check for circular and self ties.
+/// @throws std::runtime_error :: On finding a circular or self tie
+void IFunction::sortTies(const bool checkOnly) {
+  if (!checkOnly) {
+    m_orderedTies.clear();
+  }
+
   std::list<TieNode> orderedTieNodes;
   for (size_t i = 0; i < nParams(); ++i) {
     auto const tie = getTie(i);
@@ -1642,9 +1647,11 @@ void IFunction::sortTies() {
       orderedTieNodes.emplace_back(newNode);
     }
   }
-  for (auto &&node : orderedTieNodes) {
-    auto const tie = getTie(node.left);
-    m_orderedTies.emplace_back(tie);
+  if (!checkOnly) {
+    for (auto &&node : orderedTieNodes) {
+      auto const tie = getTie(node.left);
+      m_orderedTies.emplace_back(tie);
+    }
   }
 }
 

--- a/Framework/API/src/IFunction.cpp
+++ b/Framework/API/src/IFunction.cpp
@@ -293,8 +293,10 @@ void IFunction::addTie(std::unique_ptr<ParameterTie> tie) {
   }
 
   try {
+    // sortTies checks for circular and self ties
     sortTies();
-  } catch (const std::runtime_error &error) {
+  } catch (std::runtime_error &) {
+    // revert / remove tie if invalid
     if (oldTie) {
       const auto oldTieStr = oldTie->asString();
       const auto oldExp = oldTieStr.substr(oldTieStr.find("=") + 1);
@@ -302,7 +304,7 @@ void IFunction::addTie(std::unique_ptr<ParameterTie> tie) {
     } else {
       removeTie(m_ties.size() - 1);
     }
-    throw error;
+    throw;
   }
 }
 

--- a/Framework/API/test/FunctionParameterDecoratorTest.h
+++ b/Framework/API/test/FunctionParameterDecoratorTest.h
@@ -271,7 +271,7 @@ public:
     FunctionParameterDecorator_sptr fn = getFunctionParameterDecoratorGaussian();
     IFunction_sptr decoratedFunction = fn->getDecoratedFunction();
 
-    fn->tie("Height", "Height=2.0*Sigma");
+    fn->tie("Height", "2.0*Sigma");
     ParameterTie *tie = fn->getTie(fn->parameterIndex("Height"));
     TS_ASSERT(tie);
     TS_ASSERT_EQUALS(decoratedFunction->getTie(0), tie);

--- a/Framework/API/test/ParameterTieTest.h
+++ b/Framework/API/test/ParameterTieTest.h
@@ -259,25 +259,22 @@ public:
     mf->tie("f0.a", "f3.f1.hi");
     mf->tie("f0.b", "f2.sig + f0.a");
     mf->tie("f2.sig", "f3.f1.hi");
-    mf->tie("f3.f1.hi", "f0.b");
 
-    TS_ASSERT_THROWS_EQUALS(mf->sortTies(), std::runtime_error & e, std::string(e.what()),
+    TS_ASSERT_THROWS_EQUALS(mf->tie("f3.f1.hi", "f0.b"), std::runtime_error & e, std::string(e.what()),
                             "Circular dependency in "
                             "ties:\nf3.f1.hi=f0.b\nf0.a=f3.f1.hi\nf0.b=f2.sig + f0.a");
   }
 
   void test_circular_dependency_a_a() {
     ParameterTieTest_Linear fun;
-    fun.tie("a", "2*a");
-    TS_ASSERT_THROWS_EQUALS(fun.sortTies(), std::runtime_error & e, std::string(e.what()),
+    TS_ASSERT_THROWS_EQUALS(fun.tie("a", "2*a"), std::runtime_error & e, std::string(e.what()),
                             "Parameter is tied to itself: a=2*a");
   }
 
   void test_circular_dependency_a_b_a() {
     ParameterTieTest_Linear fun;
     fun.tie("a", "2*b");
-    fun.tie("b", "a/2");
-    TS_ASSERT_THROWS_EQUALS(fun.sortTies(), std::runtime_error & e, std::string(e.what()),
+    TS_ASSERT_THROWS_EQUALS(fun.tie("b", "a/2"), std::runtime_error & e, std::string(e.what()),
                             "Circular dependency in ties:\nb=a/2\na=2*b");
   }
 
@@ -285,8 +282,7 @@ public:
     ParameterTieTest_Gauss fun;
     fun.tie("cen", "2*hi");
     fun.tie("hi", "sig/2");
-    fun.tie("sig", "cen + 1");
-    TS_ASSERT_THROWS_EQUALS(fun.sortTies(), std::runtime_error & e, std::string(e.what()),
+    TS_ASSERT_THROWS_EQUALS(fun.tie("sig", "cen + 1"), std::runtime_error & e, std::string(e.what()),
                             "Circular dependency in ties:\nsig=cen + 1\nhi=sig/2\ncen=2*hi");
   }
 

--- a/docs/source/release/v6.7.0/Workbench/Bugfixes/32365.rst
+++ b/docs/source/release/v6.7.0/Workbench/Bugfixes/32365.rst
@@ -1,0 +1,1 @@
+- Fixed a bug in the fitting window where tied parameters would not update graphically. Additionally, the user can no longer add circular ties which would cause the fit to send back an error.

--- a/qt/widgets/common/src/FitPropertyBrowser.cpp
+++ b/qt/widgets/common/src/FitPropertyBrowser.cpp
@@ -1437,9 +1437,8 @@ void FitPropertyBrowser::stringChanged(QtProperty *prop) {
     if (oldExp == exp)
       return;
 
-    Mantid::API::ParameterTie *tie = new Mantid::API::ParameterTie(compositeFunction().get(), parName.toStdString());
     try {
-      tie->set(exp.toStdString());
+      compositeFunction().get()->tie(parName.toStdString(), exp.toStdString());
       h->addTie(parName + "=" + exp);
     } catch (...) {
       const auto msg =
@@ -1448,7 +1447,6 @@ void FitPropertyBrowser::stringChanged(QtProperty *prop) {
 
       m_stringManager->setValue(prop, oldExp);
     }
-    delete tie;
   } else if (getHandler()->setAttribute(prop)) { // setting an attribute may
                                                  // change function parameters
     emit functionChanged();

--- a/qt/widgets/common/src/PropertyHandler.cpp
+++ b/qt/widgets/common/src/PropertyHandler.cpp
@@ -673,8 +673,11 @@ bool PropertyHandler::setParameter(QtProperty *prop) {
   if (m_cf) {
     for (size_t i = 0; i < m_cf->nFunctions(); i++) {
       bool res = getHandler(i)->setParameter(prop);
-      if (res)
+      if (res) {
+        m_cf->applyTies();
+        updateParameters();
         return true;
+      }
     }
   }
   return false;

--- a/qt/widgets/common/src/PropertyHandler.cpp
+++ b/qt/widgets/common/src/PropertyHandler.cpp
@@ -658,6 +658,14 @@ bool PropertyHandler::setParameter(QtProperty *prop) {
     std::string parName = prop->propertyName().toStdString();
     double parValue = m_browser->m_parameterManager->value(prop);
     m_fun->setParameter(parName, parValue);
+
+    foreach (QtProperty *subProp, prop->subProperties()) {
+      if (subProp->propertyName() == "Fix") {
+        fix(prop->propertyName());
+        break;
+      }
+    }
+
     m_browser->sendParameterChanged(m_fun.get());
     m_browser->sendParameterChanged(functionPrefix());
     return true;
@@ -1153,7 +1161,7 @@ void PropertyHandler::fix(const QString &parName) {
     m_browser->m_changeSlotsEnabled = false;
     QtProperty *tieProp = m_ties[parName];
     if (!tieProp) {
-      tieProp = m_browser->m_stringManager->addProperty("Tie");
+      tieProp = m_browser->m_stringManager->addProperty("Fix");
       m_ties[parName] = tieProp;
     }
     m_browser->m_stringManager->setValue(tieProp, parValue);

--- a/qt/widgets/common/src/PropertyHandler.cpp
+++ b/qt/widgets/common/src/PropertyHandler.cpp
@@ -1133,6 +1133,7 @@ void PropertyHandler::addTie(const QString &tieStr) {
   try {
     auto &cfun = *m_browser->compositeFunction();
     cfun.tie(name, expr);
+    cfun.applyTies();
     const bool recursive = true;
     QString parName = QString::fromStdString(cfun.parameterLocalName(cfun.parameterIndex(name), recursive));
     foreach (QtProperty *parProp, m_parameters) {
@@ -1146,7 +1147,6 @@ void PropertyHandler::addTie(const QString &tieStr) {
         m_browser->m_stringManager->setValue(tieProp, QString::fromStdString(expr));
         m_browser->m_changeSlotsEnabled = true;
         parProp->addSubProperty(tieProp);
-        cfun.applyTies();
         updateParameters();
         return;
       }

--- a/qt/widgets/common/src/PropertyHandler.cpp
+++ b/qt/widgets/common/src/PropertyHandler.cpp
@@ -1146,6 +1146,8 @@ void PropertyHandler::addTie(const QString &tieStr) {
         m_browser->m_stringManager->setValue(tieProp, QString::fromStdString(expr));
         m_browser->m_changeSlotsEnabled = true;
         parProp->addSubProperty(tieProp);
+        cfun.applyTies();
+        updateParameters();
         return;
       }
     }

--- a/qt/widgets/common/src/PropertyHandler.cpp
+++ b/qt/widgets/common/src/PropertyHandler.cpp
@@ -659,10 +659,13 @@ bool PropertyHandler::setParameter(QtProperty *prop) {
     double parValue = m_browser->m_parameterManager->value(prop);
     m_fun->setParameter(parName, parValue);
 
-    foreach (QtProperty *subProp, prop->subProperties()) {
-      if (subProp->propertyName() == "Fix") {
-        fix(prop->propertyName());
-        break;
+    // If the parameter is fixed, re-fix to update the subproperty.
+    if (m_fun->isFixed(m_fun->parameterIndex(parName))) {
+      foreach (QtProperty *subProp, prop->subProperties()) {
+        if (subProp->propertyName() == "Fix") {
+          fix(prop->propertyName());
+          break;
+        }
       }
     }
 

--- a/qt/widgets/common/test/FitPropertyBrowserTest.h
+++ b/qt/widgets/common/test/FitPropertyBrowserTest.h
@@ -12,7 +12,9 @@
 #include "MantidQtWidgets/Common/FitPropertyBrowser.h"
 #include "MantidQtWidgets/Common/PropertyHandler.h"
 #include "MantidQtWidgets/Common/QtPropertyBrowser/qtpropertybrowser.h"
+#include <QApplication>
 #include <QString>
+#include <QTimer>
 #include <cxxtest/TestSuite.h>
 
 using namespace Mantid::API;
@@ -150,6 +152,9 @@ public:
                                                   "ties=(f0.Height=f1.Height)");
 
     auto f1Handler = m_fitPropertyBrowser->getPeakHandler(QString("f1"));
+
+    expect_and_close_message_box();
+
     // bad circualr tie
     f1Handler->addTie("f1.Height=f0.Height");
     TS_ASSERT(!f1Handler->hasTies());
@@ -160,6 +165,9 @@ public:
     m_fitPropertyBrowser->createCompositeFunction("name=Gaussian,Height=10.0,PeakCentre=-0.145,Sigma=0.135");
 
     auto f0Handler = m_fitPropertyBrowser->getPeakHandler(QString("f0"));
+
+    expect_and_close_message_box();
+
     // bad self tie
     f0Handler->addTie("f0.Height=f0.Height");
     TS_ASSERT(!f0Handler->hasTies());
@@ -196,4 +204,15 @@ public:
 
 private:
   std::unique_ptr<MantidQt::MantidWidgets::FitPropertyBrowser> m_fitPropertyBrowser;
+
+  void expect_and_close_message_box() {
+    QTimer::singleShot(0, [=]() {
+      auto msgBox = QApplication::activeModalWidget();
+      if (msgBox) {
+        msgBox->close();
+      } else {
+        TS_FAIL("Expected critical error message box to be shown");
+      }
+    });
+  }
 };


### PR DESCRIPTION
**Description of work.**

This PR improves how the `FitProperyBrowser` graphically updates in response to parameters being changed. Predominantly, the addition of real-time updates to tied parameters (dependent on other, free, parameters) in the property browser and graph. It also disables the ability to add circular (two parameters tied to each other) and self ties, which would trigger an error upon running a fit.

**To test:**

 - Load some data (e.g. `164199.nxs`), plot a spectrum, and open the fitting window (by clicking the Fit button)
 - Right click and add a peak
 - Expand the function in the property browser on the left
 - Fix the Peak Centre with `rightclick` ⇾ `Fix`
 - [ ] Alter Peak Centre by typing in a new value and check that the "Fix" subproperty, and the plot peak, updates as expected (Peak Centre is fixed in terms of the fit, so it is okay that it can be altered now)
 - [ ] Run the fit and check that Peak Centre has remained at the new value
 - Clear the result with `Display` ⇾ `Clear fit curves` and the model with `Setup` ⇾ `Clear Model`
 - Add two peaks this time
 - Tie the second peak's centre to the first by right-clicking on `f1.PeakCentre` ⇾ `Tie` ⇾ `To Function` ⇾ `f0.PeakCentre`
 - [ ] The second peak will then jump to be on top of the first
 - [ ] Edit the tie to read `f0.PeakCentre + 200` and the second peak should move +200 X
 - [ ] Drag the first peak left and right a bit and the second peak should update with it
 - [ ] Attempting to drag the right peak left and right should fail since it is bound to the first
 - [ ] Adjusting the standard deviation markers of the second peak should however function as normal
 - [ ] Run the fit to check that the second peak's centre stays tied to the first +200
 - Clear the plot and the model as done before
 - Add another two peaks
 - This time, tie the second peak's height to the first peak's height (`f1.Height = f0.Height`)
 - [ ] Now attempt to tie the first peak's height to the second (`f0.Height = f1.Height`), an error box should appear, and the tie should not have been added
 - Tie the first peak's height to a custom tie of `f1.Sigma` (right click `f0.Height` -> `Tie` -> `Custom Tie`)
 - [ ] Edit the tie you have just made to read `f1.Height`, an error box should appear again, and the change to the tie reverted
 - Clear the model
 - Add a single peak
 - [ ] With a custom tie, attempt to tie the peak's height to itself (`f0.Height = f0.Height`), this should produce an error box and not add a tie.
 - [ ] Using the same trick as before, first create a custom tie to the peak's centre (`f0.Height = f0.PeakCentre`) and then attempt to edit the tie to read `f0.Height`. An error box should appear and the change reset

Fixes #32365

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
