### PR TITLE
Add unit option to Indirection Diffraction UI output plot options

### DIFF
--- a/docs/source/release/v6.7.0/Indirect/New_features/35456.rst
+++ b/docs/source/release/v6.7.0/Indirect/New_features/35456.rst
@@ -1,0 +1,1 @@
+- Add unit option to Indirection Diffraction UI output plot options. Users can now choose from "D-spacing" or "Q-spacing" unit options.

--- a/qt/scientific_interfaces/Indirect/IndirectDiffractionReduction.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectDiffractionReduction.cpp
@@ -797,10 +797,10 @@ void IndirectDiffractionReduction::runFilesFound() {
 void IndirectDiffractionReduction::manualGroupingToggled(int state) {
   switch (state) {
   case Qt::Unchecked:
-    m_plotOptionsPresenter->setPlotType(PlotWidget::Spectra);
+    m_plotOptionsPresenter->setPlotType(PlotWidget::SpectraUnit);
     break;
   case Qt::Checked:
-    m_plotOptionsPresenter->setPlotType(PlotWidget::SpectraContour);
+    m_plotOptionsPresenter->setPlotType(PlotWidget::SpectraContourUnit);
     break;
   default:
     return;

--- a/qt/scientific_interfaces/Indirect/IndirectDiffractionReduction.ui
+++ b/qt/scientific_interfaces/Indirect/IndirectDiffractionReduction.ui
@@ -634,6 +634,9 @@
              <property name="enabled">
               <bool>false</bool>
              </property>
+             <property name="minimum">
+                <number>1</number>
+             </property>
             </widget>
            </item>
            <item>

--- a/qt/scientific_interfaces/Indirect/IndirectPlotOptions.ui
+++ b/qt/scientific_interfaces/Indirect/IndirectPlotOptions.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>432</width>
-    <height>40</height>
+    <width>597</width>
+    <height>63</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -116,6 +116,25 @@
         </property>
         <property name="text">
          <string/>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QComboBox" name="cbPlotUnit">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>100</width>
+          <height>22</height>
+         </size>
+        </property>
+        <property name="maximumSize">
+         <size>
+          <width>100</width>
+          <height>22</height>
+         </size>
         </property>
        </widget>
       </item>

--- a/qt/scientific_interfaces/Indirect/IndirectPlotOptionsModel.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectPlotOptionsModel.cpp
@@ -200,19 +200,23 @@ void IndirectPlotOptionsModel::plotSpectra() {
   auto const indicesString = indices();
   auto const unitName = unit();
 
-  if (unitName) {
-    const std::string target = (unitName.get() == "D-spacing") ? "dSpacing" : "QSquared";
+  if (workspaceName && indicesString) {
+    std::string workspaceNameString = workspaceName.get();
 
-    IAlgorithm_sptr convertUnits = AlgorithmManager::Instance().create("ConvertUnits");
-    convertUnits->initialize();
-    convertUnits->setProperty("InputWorkspace", workspaceName.get());
-    convertUnits->setProperty("OutputWorkspace", workspaceName.get());
-    convertUnits->setProperty("Target", target);
-    convertUnits->execute();
+    if (unitName) {
+      const std::string target = (unitName.get() == "D-spacing") ? "dSpacing" : "QSquared";
+      workspaceNameString = workspaceNameString + "_" + target;
+
+      IAlgorithm_sptr convertUnits = AlgorithmManager::Instance().create("ConvertUnits");
+      convertUnits->initialize();
+      convertUnits->setProperty("InputWorkspace", workspaceName.get());
+      convertUnits->setProperty("OutputWorkspace", workspaceNameString);
+      convertUnits->setProperty("Target", target);
+      convertUnits->execute();
+    }
+
+    m_plotter->plotSpectra(workspaceNameString, indicesString.get(), IndirectSettingsHelper::externalPlotErrorBars());
   }
-
-  if (workspaceName && indicesString)
-    m_plotter->plotSpectra(workspaceName.get(), indicesString.get(), IndirectSettingsHelper::externalPlotErrorBars());
 }
 
 void IndirectPlotOptionsModel::plotBins(std::string const &binIndices) {

--- a/qt/scientific_interfaces/Indirect/IndirectPlotOptionsModel.h
+++ b/qt/scientific_interfaces/Indirect/IndirectPlotOptionsModel.h
@@ -37,6 +37,9 @@ public:
   virtual void setFixedIndices(std::string const &indices);
   virtual bool indicesFixed() const;
 
+  virtual void setUnit(std::string const &unit);
+  boost::optional<std::string> unit();
+
   virtual std::string formatIndices(std::string const &indices) const;
   virtual bool validateIndices(std::string const &indices, MantidAxis const &axisType = MantidAxis::Spectrum) const;
   virtual bool setIndices(std::string const &indices);
@@ -62,6 +65,7 @@ private:
   bool m_fixedIndices;
   boost::optional<std::string> m_workspaceIndices;
   boost::optional<std::string> m_workspaceName;
+  boost::optional<std::string> m_unit;
   std::unique_ptr<ExternalPlotter> m_plotter;
 };
 

--- a/qt/scientific_interfaces/Indirect/IndirectPlotOptionsModel.h
+++ b/qt/scientific_interfaces/Indirect/IndirectPlotOptionsModel.h
@@ -58,6 +58,7 @@ public:
 private:
   bool validateSpectra(const Mantid::API::MatrixWorkspace_sptr &workspace, std::string const &spectra) const;
   bool validateBins(const Mantid::API::MatrixWorkspace_sptr &workspace, std::string const &bins) const;
+  std::string convertUnit(const std::string &workspaceName, const std::string &unit);
 
   boost::optional<std::string> checkWorkspaceSize(std::string const &workspaceName, MantidAxis const &axisType) const;
 

--- a/qt/scientific_interfaces/Indirect/IndirectPlotOptionsPresenter.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectPlotOptionsPresenter.cpp
@@ -59,6 +59,7 @@ void IndirectPlotOptionsPresenter::setupPresenter(PlotWidget const &plotType, st
 
   connect(m_view, SIGNAL(selectedWorkspaceChanged(std::string const &)), this,
           SLOT(workspaceChanged(std::string const &)));
+  connect(m_view, SIGNAL(selectedUnitChanged(std::string const &)), this, SLOT(unitChanged(std::string const &)));
   connect(m_view, SIGNAL(selectedIndicesChanged(std::string const &)), this, SLOT(indicesChanged(std::string const &)));
 
   connect(m_view, SIGNAL(plotSpectraClicked()), this, SLOT(plotSpectra()));
@@ -99,6 +100,7 @@ void IndirectPlotOptionsPresenter::setOptionsEnabled(bool enable) {
   m_view->setWorkspaceComboBoxEnabled(m_view->numberOfWorkspaces() > 1 ? enable : false);
   m_view->setIndicesLineEditEnabled(!m_model->indicesFixed() ? enable : false);
   m_view->setPlotButtonEnabled(enable);
+  m_view->setUnitComboBoxEnabled(enable);
 }
 
 void IndirectPlotOptionsPresenter::onWorkspaceRemoved(WorkspacePreDeleteNotification_ptr nf) {
@@ -139,6 +141,8 @@ void IndirectPlotOptionsPresenter::clearWorkspaces() {
   setOptionsEnabled(false);
 }
 
+void IndirectPlotOptionsPresenter::setUnit(std::string const &unit) { m_model->setUnit(unit); }
+
 void IndirectPlotOptionsPresenter::setIndices() {
   auto const selectedIndices = m_view->selectedIndices().toStdString();
   if (auto const indices = m_model->indices())
@@ -150,6 +154,8 @@ void IndirectPlotOptionsPresenter::setIndices() {
 }
 
 void IndirectPlotOptionsPresenter::workspaceChanged(std::string const &workspaceName) { setWorkspace(workspaceName); }
+
+void IndirectPlotOptionsPresenter::unitChanged(std::string const &unit) { setUnit(unit); }
 
 void IndirectPlotOptionsPresenter::indicesChanged(std::string const &indices) {
   auto const formattedIndices = m_model->formatIndices(indices);

--- a/qt/scientific_interfaces/Indirect/IndirectPlotOptionsPresenter.h
+++ b/qt/scientific_interfaces/Indirect/IndirectPlotOptionsPresenter.h
@@ -40,6 +40,7 @@ public:
 
 private slots:
   void workspaceChanged(std::string const &workspaceName);
+  void unitChanged(std::string const &unit);
   void indicesChanged(std::string const &indices);
   void plotSpectra();
   void plotBins();
@@ -57,6 +58,7 @@ private:
   void onWorkspaceReplaced(Mantid::API::WorkspaceBeforeReplaceNotification_ptr nf);
 
   void setWorkspace(std::string const &plotWorkspace);
+  void setUnit(std::string const &unit);
   void setIndices();
 
   bool validateWorkspaceSize(MantidAxis const &axisType);

--- a/qt/scientific_interfaces/Indirect/IndirectPlotOptionsView.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectPlotOptionsView.cpp
@@ -68,6 +68,9 @@ void IndirectPlotOptionsView::setupView() {
   connect(m_plotOptions->cbWorkspace, SIGNAL(currentIndexChanged(QString const &)), this,
           SLOT(emitSelectedWorkspaceChanged(QString const &)));
 
+  connect(m_plotOptions->cbPlotUnit, SIGNAL(currentIndexChanged(QString const &)), this,
+          SLOT(emitSelectedUnitChanged(QString const &)));
+
   connect(m_plotOptions->leIndices, SIGNAL(editingFinished()), this, SLOT(emitSelectedIndicesChanged()));
   connect(m_plotOptions->leIndices, SIGNAL(textEdited(QString const &)), this,
           SLOT(emitSelectedIndicesChanged(QString const &)));
@@ -84,6 +87,10 @@ void IndirectPlotOptionsView::setupView() {
 
 void IndirectPlotOptionsView::emitSelectedWorkspaceChanged(QString const &workspaceName) {
   emit selectedWorkspaceChanged(workspaceName.toStdString());
+}
+
+void IndirectPlotOptionsView::emitSelectedUnitChanged(QString const &unit) {
+  emit selectedUnitChanged(unit.toStdString());
 }
 
 void IndirectPlotOptionsView::emitSelectedIndicesChanged() {
@@ -157,17 +164,36 @@ void IndirectPlotOptionsView::setPlotType(PlotWidget const &plotType,
     plotMenu->addAction(plotSpectraAction);
     plotMenu->addAction(plotTiledAction);
     break;
+  case PlotWidget::SpectraUnit:
+    m_plotOptions->tbPlot->setVisible(false);
+    m_plotOptions->cbPlotUnit->setVisible(true);
+    break;
+  case PlotWidget::SpectraContourUnit:
+    m_plotOptions->pbPlotSpectra->setVisible(false);
+    m_plotOptions->cbPlotUnit->setVisible(true);
+    plotMenu->addAction(plotSpectraAction);
+    plotMenu->addAction(plotContourAction);
+    break;
   default:
     std::runtime_error("Plot option not found. Plot types are Spectra, "
                        "SpectraContour or SpectraTiled.");
   }
   m_plotOptions->tbPlot->setMenu(plotMenu);
   m_plotOptions->tbPlot->setDefaultAction(plotSpectraAction);
+
+  m_plotOptions->cbPlotUnit->clear();
+  m_plotOptions->cbPlotUnit->addItem(QString::fromStdString("D-spacing"));
+  m_plotOptions->cbPlotUnit->addItem(QString::fromStdString("Q-spacing"));
 }
 
 void IndirectPlotOptionsView::setWorkspaceComboBoxEnabled(bool enable) {
   QSignalBlocker blocker(m_plotOptions->cbWorkspace);
   m_plotOptions->cbWorkspace->setEnabled(enable);
+}
+
+void IndirectPlotOptionsView::setUnitComboBoxEnabled(bool enable) {
+  QSignalBlocker blocker(m_plotOptions->cbPlotUnit);
+  m_plotOptions->cbPlotUnit->setEnabled(enable);
 }
 
 void IndirectPlotOptionsView::setIndicesLineEditEnabled(bool enable) {

--- a/qt/scientific_interfaces/Indirect/IndirectPlotOptionsView.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectPlotOptionsView.cpp
@@ -21,6 +21,13 @@ auto constexpr SETTINGS_GROUP = "Indices suggestions";
 auto constexpr SETTING_NAME = "Suggestions";
 auto constexpr NUMBER_OF_SUGGESTIONS = 5;
 
+// make sure the unit id is a valid unit factory id
+// (https://docs.mantidproject.org/nightly/concepts/UnitFactory.html#id2)
+const std::map<std::string, std::string> displayStrToUnitId = {
+    {"D-Spacing", "dSpacing"},
+    {"Q-Squared", "QSquared"},
+};
+
 void saveIndicesSuggestions(QStringList const &suggestions) {
   QSettings settings;
   settings.beginGroup(SETTINGS_GROUP);
@@ -90,7 +97,9 @@ void IndirectPlotOptionsView::emitSelectedWorkspaceChanged(QString const &worksp
 }
 
 void IndirectPlotOptionsView::emitSelectedUnitChanged(QString const &unit) {
-  emit selectedUnitChanged(unit.toStdString());
+  if (unit.toStdString() != "") {
+    emit selectedUnitChanged(displayStrToUnitId.at(unit.toStdString()));
+  }
 }
 
 void IndirectPlotOptionsView::emitSelectedIndicesChanged() {
@@ -182,8 +191,9 @@ void IndirectPlotOptionsView::setPlotType(PlotWidget const &plotType,
   m_plotOptions->tbPlot->setDefaultAction(plotSpectraAction);
 
   m_plotOptions->cbPlotUnit->clear();
-  m_plotOptions->cbPlotUnit->addItem(QString::fromStdString("D-spacing"));
-  m_plotOptions->cbPlotUnit->addItem(QString::fromStdString("Q-spacing"));
+  for (const auto &item : displayStrToUnitId) {
+    m_plotOptions->cbPlotUnit->addItem(QString::fromStdString(item.first));
+  }
 }
 
 void IndirectPlotOptionsView::setWorkspaceComboBoxEnabled(bool enable) {

--- a/qt/scientific_interfaces/Indirect/IndirectPlotOptionsView.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectPlotOptionsView.cpp
@@ -65,10 +65,10 @@ IndirectPlotOptionsView::IndirectPlotOptionsView(QWidget *parent)
 IndirectPlotOptionsView::~IndirectPlotOptionsView() = default;
 
 void IndirectPlotOptionsView::setupView() {
-  connect(m_plotOptions->cbWorkspace, SIGNAL(currentIndexChanged(QString const &)), this,
+  connect(m_plotOptions->cbWorkspace, SIGNAL(currentTextChanged(QString const &)), this,
           SLOT(emitSelectedWorkspaceChanged(QString const &)));
 
-  connect(m_plotOptions->cbPlotUnit, SIGNAL(currentIndexChanged(QString const &)), this,
+  connect(m_plotOptions->cbPlotUnit, SIGNAL(currentTextChanged(QString const &)), this,
           SLOT(emitSelectedUnitChanged(QString const &)));
 
   connect(m_plotOptions->leIndices, SIGNAL(editingFinished()), this, SLOT(emitSelectedIndicesChanged()));

--- a/qt/scientific_interfaces/Indirect/IndirectPlotOptionsView.h
+++ b/qt/scientific_interfaces/Indirect/IndirectPlotOptionsView.h
@@ -22,7 +22,7 @@
 namespace MantidQt {
 namespace CustomInterfaces {
 
-enum PlotWidget { Spectra, SpectraBin, SpectraContour, SpectraTiled };
+enum PlotWidget { Spectra, SpectraBin, SpectraContour, SpectraTiled, SpectraUnit, SpectraContourUnit };
 
 class MANTIDQT_INDIRECT_DLL IndirectPlotOptionsView : public API::MantidWidget {
   Q_OBJECT
@@ -33,6 +33,7 @@ public:
 
   virtual void setPlotType(PlotWidget const &plotType, std::map<std::string, std::string> const &availableActions);
   virtual void setWorkspaceComboBoxEnabled(bool enable);
+  virtual void setUnitComboBoxEnabled(bool enable);
   virtual void setIndicesLineEditEnabled(bool enable);
   virtual void setPlotButtonEnabled(bool enable);
   void setPlotButtonText(QString const &text);
@@ -57,6 +58,7 @@ public:
 
 signals:
   void selectedWorkspaceChanged(std::string const &workspaceName);
+  void selectedUnitChanged(std::string const &unit);
   void selectedIndicesChanged(std::string const &indices);
   void plotSpectraClicked();
   void plotBinsClicked();
@@ -65,6 +67,7 @@ signals:
 
 private slots:
   void emitSelectedWorkspaceChanged(QString const &workspaceName);
+  void emitSelectedUnitChanged(QString const &unit);
   void emitSelectedIndicesChanged();
   void emitSelectedIndicesChanged(QString const &indices);
   void emitPlotSpectraClicked();


### PR DESCRIPTION
**Description of work.**
This PR adds an option to select the unit of the output plot in the indirect diffraction interface. Users can now choose from "D-spacing" or "Q-spacing" unit options. 

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**
1- Open Indirect Diffraction interface (Interfaces->Indirect->Diffraction).
2- Change the Reflection setting to diffspec.
3- Click the Run button. 
4- Once the run is complete, verify that the unit combo box and the `Plot Spectra` button are both enabled.
5- Select the two possible units in the unit combo box and plot the spectra for each unit.
6- Verify that the plot displays the correct unit in every case.
7- Enable the `Use Manual Grouping` option and repeat the above steps.
8- Verify that the behavior of the Plot Spectra option remains the same with manual grouping enabled.

<!-- Instructions for testing. -->

Fixes #33551. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
