### PR TITLE
Add prompt to install new version of MantidWorkbench in the error reporter

### DIFF
--- a/docs/source/release/v6.7.0/Workbench/New_features/35332.rst
+++ b/docs/source/release/v6.7.0/Workbench/New_features/35332.rst
@@ -1,0 +1,1 @@
+- The Error Reporter will now prompt the user to upgrade to the latest version of Mantid if a new version is available.

--- a/qt/python/mantidqt/mantidqt/dialogs/errorreports/errorreport.ui
+++ b/qt/python/mantidqt/mantidqt/dialogs/errorreports/errorreport.ui
@@ -45,10 +45,10 @@ p, li { white-space: pre-wrap; }
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'.SF NS Text'; font-size:12pt; color:#000000;&quot;&gt;We are really sorry that Mantid is not behaving as it should and are aware how frustrating this is. We'd be very grateful if you could provide us with some details about your problems. The more information you can give, the quicker we can fix this issue.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
      </property>
      <property name="openExternalLinks">
-      <bool>false</bool>
+      <bool>true</bool>
      </property>
      <property name="openLinks">
-      <bool>false</bool>
+      <bool>true</bool>
      </property>
     </widget>
    </item>

--- a/qt/python/mantidqt/mantidqt/dialogs/errorreports/report.py
+++ b/qt/python/mantidqt/mantidqt/dialogs/errorreports/report.py
@@ -69,6 +69,7 @@ class CrashReportPage(ErrorReportUIBase, ErrorReportUI):
                 "Warning: your version of MantidWorkbench is out of date.<br>"
                 f'<a href="{MANTID_DOWNLOAD_LINK}">Get the latest version here</a><br><br></span>'
             )
+            self.requestTextBrowser.setOpenExternalLinks(True)
             self.requestTextBrowser.insertHtml(msg)
 
         self.input_name_line_edit.textChanged.connect(self.set_button_status)

--- a/qt/python/mantidqt/mantidqt/dialogs/errorreports/report.py
+++ b/qt/python/mantidqt/mantidqt/dialogs/errorreports/report.py
@@ -11,6 +11,7 @@ from qtpy.QtWidgets import QMessageBox
 
 from mantidqt.interfacemanager import InterfaceManager
 from mantidqt.utils.qt import load_ui
+from mantid.simpleapi import CheckMantidVersion
 
 from .details import MoreDetailsDialog
 
@@ -25,6 +26,7 @@ Thank you!"""
 
 PLAIN_TEXT_MAX_LENGTH = 3200
 MAX_STACK_TRACE_LENGTH = 10000
+MANTID_DOWNLOAD_LINK = "http://download.mantidproject.org"
 
 ErrorReportUIBase, ErrorReportUI = load_ui(__file__, "errorreport.ui")
 
@@ -37,6 +39,7 @@ class CrashReportPage(ErrorReportUIBase, ErrorReportUI):
     CONTACT_INFO = "ContactInfo"
     NAME = "Name"
     EMAIL = "Email"
+    _, _, newer_version_available = CheckMantidVersion()
 
     def __init__(self, parent=None, show_continue_terminate=False):
         super(self.__class__, self).__init__(parent)
@@ -60,6 +63,13 @@ class CrashReportPage(ErrorReportUIBase, ErrorReportUI):
         self.icon.setPixmap(QtGui.QPixmap(":/images/crying_mantid.png"))
 
         self.requestTextBrowser.anchorClicked.connect(self.interface_manager.showWebPage)
+        if self.newer_version_available:
+            msg = (
+                "<span style=\" font-family:'.SF NS Text'; font-size:12pt; color:#000000;\">"
+                "Warning: your version of MantidWorkbench is out of date.<br>"
+                f'<a href="{MANTID_DOWNLOAD_LINK}">Get the latest version here</a><br><br></span>'
+            )
+            self.requestTextBrowser.insertHtml(msg)
 
         self.input_name_line_edit.textChanged.connect(self.set_button_status)
         self.input_email_line_edit.textChanged.connect(self.set_button_status)

--- a/qt/python/mantidqt/mantidqt/dialogs/errorreports/report.py
+++ b/qt/python/mantidqt/mantidqt/dialogs/errorreports/report.py
@@ -69,7 +69,6 @@ class CrashReportPage(ErrorReportUIBase, ErrorReportUI):
                 "Warning: your version of MantidWorkbench is out of date.<br>"
                 f'<a href="{MANTID_DOWNLOAD_LINK}">Get the latest version here</a><br><br></span>'
             )
-            self.requestTextBrowser.setOpenExternalLinks(True)
             self.requestTextBrowser.insertHtml(msg)
 
         self.input_name_line_edit.textChanged.connect(self.set_button_status)


### PR DESCRIPTION
**Description of work.**

If the user encounters the error reporter, and they do not have the latest version of workbench, there will now be an extra message in the main text box prompting them to install the latest version.

**To test:**

Since the check for a more recent version is done on release date, the plan for this testing was to 1) build a package from this branch 2) wait for 6.7.0 to be released 3) test the built package.

Unfortunately, the old build package from branch job has been deleted (I should've saved the exe somewhere) so to test you might have to change some code. Or you can just review the code, it's very simple and low risk.

If you want to see it in action, change `if self.newer_version_available:` to `if True:` (or just remove the if statement. Then cause a crash to get the error reporter up. Best way is to use the `SegFault` algorithm, when running from pycharm I have to remove the `--single-process` parameter from the configuration options to make this work.

Fixes #35332

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the following ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)):

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.
