### PR TITLE
Add more information to release notes about event filtering

### DIFF
--- a/docs/source/interfaces/indirect/Inelastic Data Manipulation.rst
+++ b/docs/source/interfaces/indirect/Inelastic Data Manipulation.rst
@@ -1,7 +1,7 @@
 .. _interface-inelastic-data-manipulation:
 
 Inelastic Data Manipulation
-==========================
+===========================
 
 .. contents:: Table of Contents
   :local:

--- a/docs/source/release/v6.7.0/framework.rst
+++ b/docs/source/release/v6.7.0/framework.rst
@@ -11,12 +11,13 @@ Event Filtering
 During the v6.7 development cycle, there were major changes to the code underlying event filtering that was originally designed `here <https://github.com/mantidproject/mantid/issues/34794>`_.
 The main changes to mantid are as follows:
 
-1. A ``TimeROI`` object that contains a list of use and ignore regions in time. The times are ``[inclusive, exclusive)``.
-2. When filtering/splitting logs in the ``Run`` object, the logs are copied as is and a new ``TimeROI`` object is set on the ``Run``. Values that are active during a ROI are kept as are one before/after each ROI. The main change is that logs no longer have fake values to mimic the filtering/splitting.
-3. Code should change from asking a ``TimeSeriesProperty`` for its statistics to asking the ``Run`` object for the statistics of a log because the ``Run`` is the only place that knows the information about the ``TimeROI``.
-4. When filtering/splitting logs, the filters are now ``[inclusive, exclusive)`` where previous behavior was ``[inclusive, inclusive]``. The previous behavior was inconsistent with how events are filtered. This change, fixes issues observed with the integrated proton charge.
-5. When workspaces are added, the resulting ``TimeROI`` is the union of the individual ``TimeROI``s. If either workspace had a ``TimeROI`` with ``TimeROI.useAll()==True``, it is assumed to be from that workspace's start-time to end-time.
-6. Arithmetic statistics (e.g. simple mean rather than time weighted) will be largely unchanged and are not necesarily correct
+* A ``TimeROI`` object that contains a list of use and ignore regions in time. The times are ``[inclusive, exclusive)``.
+* When filtering/splitting logs in the ``Run`` object, the logs are copied as is and a new ``TimeROI`` object is set on the ``Run``. Values that are active during a ROI are kept as are one before/after each ROI. The main change is that logs no longer have fake values to mimic the filtering/splitting.
+* Code should change from asking a ``TimeSeriesProperty`` for its statistics to asking the ``Run`` object for the statistics of a log because the ``Run`` is the only place that knows the information about the ``TimeROI``.
+* When filtering/splitting logs, the filters are now ``[inclusive, exclusive)`` where previous behavior was ``[inclusive, inclusive]``. The previous behavior was inconsistent with how events are filtered. This change, fixes issues observed with the integrated proton charge.
+* When workspaces are added, the resulting ``TimeROI`` is the union of the individual ``TimeROI``s. If either workspace had a ``TimeROI`` with ``TimeROI.useAll()==True``, it is assumed to be from that workspace's start-time to end-time.
+* Arithmetic statistics (e.g. simple mean rather than time weighted) will be largely unchanged and are not necesarily correct
+
 
 The algorithms modified as part of this are :ref:`FilterByLogValue <algm-FilterByLogValue>`, :ref:`FilterByTime <algm-FilterByTime>`, and :ref:`FilterEvents <algm-FilterEvents>`.
 The "sample log viewer" has been modified to optionally show the ``TimeROI`` as an overlay on the logs.

--- a/docs/source/release/v6.7.0/framework.rst
+++ b/docs/source/release/v6.7.0/framework.rst
@@ -12,11 +12,11 @@ During the v6.7 development cycle, there were major changes to the code underlyi
 The main changes to mantid are as follows:
 
 1. A ``TimeROI`` object that contains a list of use and ignore regions in time. The times are ``[inclusive, exclusive)``.
-2. When filtering/splitting logs in the ``Run`` object, the logs are copied as is and a new ``TimeROI`` object is set on the ``Run``. The main change is that logs no longer have fake values to mimic the filtering/splitting.
+2. When filtering/splitting logs in the ``Run`` object, the logs are copied as is and a new ``TimeROI`` object is set on the ``Run``. Values that are active during a ROI are kept as are one before/after each ROI. The main change is that logs no longer have fake values to mimic the filtering/splitting.
 3. Code should change from asking a ``TimeSeriesProperty`` for its statistics to asking the ``Run`` object for the statistics of a log because the ``Run`` is the only place that knows the information about the ``TimeROI``.
 4. When filtering/splitting logs, the filters are now ``[inclusive, exclusive)`` where previous behavior was ``[inclusive, inclusive]``. The previous behavior was inconsistent with how events are filtered. This change, fixes issues observed with the integrated proton charge.
 5. When workspaces are added, the resulting ``TimeROI`` is the union of the individual ``TimeROI``s. If either workspace had a ``TimeROI`` with ``TimeROI.useAll()==True``, it is assumed to be from that workspace's start-time to end-time.
-
+6. Arithmetic statistics (e.g. simple mean rather than time weighted) will be largely unchanged and are not necesarily correct
 
 The algorithms modified as part of this are :ref:`FilterByLogValue <algm-FilterByLogValue>`, :ref:`FilterByTime <algm-FilterByTime>`, and :ref:`FilterEvents <algm-FilterEvents>`.
 The "sample log viewer" has been modified to optionally show the ``TimeROI`` as an overlay on the logs.


### PR DESCRIPTION
Adds clarifying comments about arithmetic statistics and how values are deleted from logs.

**To test:**

Review the release notes 

Refs #34794.

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.