### PR TITLE
Simplified child workspace names in stitich group

### DIFF
--- a/Framework/Algorithms/src/Stitch1DMany.cpp
+++ b/Framework/Algorithms/src/Stitch1DMany.cpp
@@ -236,7 +236,6 @@ void Stitch1DMany::exec() {
         outName = groupName;
         std::vector<double> scaleFactors;
         doStitch1DMany(i, m_useManualScaleFactors, outName, scaleFactors, m_indexOfReference);
-
         // Add the resulting workspace to the list to be grouped together
         toGroup.emplace_back(outName);
 
@@ -352,12 +351,15 @@ void Stitch1DMany::doStitch1DMany(const size_t period, const bool useManualScale
 
   // List of workspaces to stitch
   std::vector<std::string> toProcess;
+  auto groupName = outName;
 
   for (const auto &ws : m_inputWSMatrix) {
     const std::string &wsName = ws[period]->getName();
     toProcess.emplace_back(wsName);
-    outName += "_" + wsName;
   }
+
+  // Needed to ensure child workspace name simpler
+  outName += "_" + std::to_string(period + 1);
 
   auto alg = createChildAlgorithm("Stitch1DMany");
   alg->initialize();

--- a/Framework/Algorithms/src/Stitch1DMany.cpp
+++ b/Framework/Algorithms/src/Stitch1DMany.cpp
@@ -351,7 +351,6 @@ void Stitch1DMany::doStitch1DMany(const size_t period, const bool useManualScale
 
   // List of workspaces to stitch
   std::vector<std::string> toProcess;
-  auto groupName = outName;
 
   for (const auto &ws : m_inputWSMatrix) {
     const std::string &wsName = ws[period]->getName();

--- a/Framework/Algorithms/test/Stitch1DManyTest.h
+++ b/Framework/Algorithms/test/Stitch1DManyTest.h
@@ -706,7 +706,7 @@ public:
     // In ADS: group1, group2, group3, ws1, ws2, ws3 and
     TS_ASSERT_EQUALS(wsInADS.size(), 8)
     TS_ASSERT_EQUALS(wsInADS[3], "outws")
-    TS_ASSERT_EQUALS(wsInADS[4], "outws_ws1_ws2_ws3")
+    TS_ASSERT_EQUALS(wsInADS[4], "outws_1")
     // Clear the ADS
     AnalysisDataService::Instance().clear();
   }
@@ -795,8 +795,8 @@ public:
     // In ADS: group1, group2, ws1, ws2, ws3, ws4, and
     TS_ASSERT_EQUALS(wsInADS.size(), 9)
     TS_ASSERT_EQUALS(wsInADS[2], "outws")
-    TS_ASSERT_EQUALS(wsInADS[3], "outws_ws1_ws3")
-    TS_ASSERT_EQUALS(wsInADS[4], "outws_ws2_ws4")
+    TS_ASSERT_EQUALS(wsInADS[3], "outws_1")
+    TS_ASSERT_EQUALS(wsInADS[4], "outws_2")
     // Clear the ADS
     AnalysisDataService::Instance().clear();
   }
@@ -891,8 +891,8 @@ public:
     // In ADS: group1, group2, ws1, ws2, ws3, ws4 and
     TS_ASSERT_EQUALS(wsInADS.size(), 9)
     TS_ASSERT_EQUALS(wsInADS[2], "outws")
-    TS_ASSERT_EQUALS(wsInADS[3], "outws_ws1_ws3")
-    TS_ASSERT_EQUALS(wsInADS[4], "outws_ws2_ws4")
+    TS_ASSERT_EQUALS(wsInADS[3], "outws_1")
+    TS_ASSERT_EQUALS(wsInADS[4], "outws_2")
     // Clear the ADS
     AnalysisDataService::Instance().clear();
   }
@@ -1001,8 +1001,8 @@ public:
     // In ADS: group1, group2, grou3, ws1, ws2, ws3, ws4, ws5, ws6 and
     TS_ASSERT_EQUALS(wsInADS.size(), 12)
     TS_ASSERT_EQUALS(wsInADS[3], "outws")
-    TS_ASSERT_EQUALS(wsInADS[4], "outws_ws1_ws3_ws5")
-    TS_ASSERT_EQUALS(wsInADS[5], "outws_ws2_ws4_ws6")
+    TS_ASSERT_EQUALS(wsInADS[4], "outws_1")
+    TS_ASSERT_EQUALS(wsInADS[5], "outws_2")
     // Clear the ADS
     AnalysisDataService::Instance().clear();
   }
@@ -1464,8 +1464,8 @@ public:
     // In ADS: group1, group2, grou3, ws1, ws2, ws3, ws4, ws5, ws6 and
     TS_ASSERT_EQUALS(wsInADS.size(), 12)
     TS_ASSERT_EQUALS(wsInADS[3], "outws")
-    TS_ASSERT_EQUALS(wsInADS[4], "outws_ws1_ws3_ws5")
-    TS_ASSERT_EQUALS(wsInADS[5], "outws_ws2_ws4_ws6")
+    TS_ASSERT_EQUALS(wsInADS[4], "outws_1")
+    TS_ASSERT_EQUALS(wsInADS[5], "outws_2")
     // Clear the ADS
     AnalysisDataService::Instance().clear();
   }

--- a/docs/source/release/v6.7.0/Reflectometry/Bugfixes/34842.rst
+++ b/docs/source/release/v6.7.0/Reflectometry/Bugfixes/34842.rst
@@ -1,0 +1,1 @@
+- The child workspaces of a stitched group now have shorter names with a simple suffix.


### PR DESCRIPTION
**Description of work**
**Purpose of work**
The work has been done to stop extra long child workspace names from being generated unneccessarily. This was making it harder for users to work with the generated output.

**Summary of work**
The naming of child workspaces within a stitched group workspace generated by `Stitch1DMany` has been simplified.

**Further detail of work**
I have changed how child workspaces are named in the Stitch1DMany algorithm by moving the code that names them out of a loop in the `doStitch1DMany` method. This ensures only one suffix is added to each child workspace.

I have updated the `Stitch1DManyTest` as child workspace names have changed.

**To test:**
1. Ask for the test batch file
2. Open Manitd and then open the ISIS Reflectometry GUI
3. Click on the Batch menu and select Load
4. Load the test batch file provided
5. Click the process button
6. Once the processing has finished check that the child workspaces under the stitched workspace group look something like this

![Screenshot (252)](https://user-images.githubusercontent.com/55837273/233103931-61720092-077c-4227-8667-f7a7ebe23729.png)


Fixes #34842. 

---

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.