### PR TITLE
Update SXD instrument definition

### DIFF
--- a/Framework/PythonInterface/test/python/mantid/geometry/IPeakTest.py
+++ b/Framework/PythonInterface/test/python/mantid/geometry/IPeakTest.py
@@ -6,7 +6,7 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 import unittest
 from mantid.kernel import V3D
-from mantid.simpleapi import CreateSimulationWorkspace, CreatePeaksWorkspace
+from mantid.simpleapi import CreateSimulationWorkspace, CreatePeaksWorkspace, LoadInstrument
 import numpy as np
 import numpy.testing as npt
 
@@ -16,6 +16,8 @@ class IPeakTest(unittest.TestCase):
         # IPeak cannot currently be instatiated so this is a quick way
         # getting a handle to a peak object
         ws = CreateSimulationWorkspace("SXD", BinParams="1,1,10")
+        # load IDF pre cycle 19_1 when bank 1 upgraded and position was changed
+        LoadInstrument(Workspace=ws, Filename="SXD_Definition.xml", RewriteSpectraMap=False)
         peaks = CreatePeaksWorkspace(ws, 1)
         self._peak = peaks.getPeak(0)
 

--- a/docs/source/release/v6.7.0/Diffraction/Single_Crystal/New_features/35467.rst
+++ b/docs/source/release/v6.7.0/Diffraction/Single_Crystal/New_features/35467.rst
@@ -1,0 +1,1 @@
+- Add new instrument definition for SXD post bank 1 detector upgrade

--- a/instrument/SXD_Definition.xml
+++ b/instrument/SXD_Definition.xml
@@ -75,7 +75,7 @@
     <rot val="0.00000" axis-x="1" axis-y="0" axis-z="0" />
   </rot>
 </location>
-<side-by-side-view-location x="0.7" y="0.7"/>
+<side-by-side-view-location x="0.85" y="0.7"/>
 </component> 
 
 <component type="panel" idstart="16385" idfillbyfirst="y" idstepbyrow="64">
@@ -84,7 +84,7 @@
     <rot val="0.00000" axis-x="1" axis-y="0" axis-z="0" />
   </rot>
 </location>
-<side-by-side-view-location x="0.9" y="0.7"/>
+<side-by-side-view-location x="1.05" y="0.7"/>
 </component> 
 
 <component type="panel1346" idstart="20481" idfillbyfirst="y" idstepbyrow="64">
@@ -93,7 +93,7 @@
     <rot val="0.00000" axis-x="1" axis-y="0" axis-z="0" />
   </rot>
 </location>
-<side-by-side-view-location x="1.1" y="0.7"/>
+<side-by-side-view-location x="1.25" y="0.7"/>
 </component> 
 
 <component type="panel" idstart="24577" idfillbyfirst="x" idstepbyrow="64">
@@ -102,14 +102,14 @@
     <rot val="45.00000" axis-x="1" axis-y="0" axis-z="0" />
   </rot>
 </location>
-<side-by-side-view-location x="0.3" y="0.4"/>
+<side-by-side-view-location x="0.3" y="0.5"/>
 </component> 
 
 <component type="panel" idstart="28673" idfillbyfirst="x" idstepbyrow="64">
 <location x="0.000" y="-0.190919" z="0.190919" name="bank8">
   <rot val="45.00000" axis-x="1" axis-y="0" axis-z="0" />
 </location>
-<side-by-side-view-location x="0.6" y="0.4"/>
+<side-by-side-view-location x="0.675" y="0.5"/>
 </component> 
 
 <component type="panel1346" idstart="32769" idfillbyfirst="x" idstepbyrow="64">
@@ -118,14 +118,14 @@
     <rot val="-45.00000" axis-x="1" axis-y="0" axis-z="0" />
  </rot>
 </location>
-<side-by-side-view-location x="0.9" y="0.4"/>
+<side-by-side-view-location x="1.05" y="0.5"/>
 </component> 
 
 <component type="panel1346" idstart="36865" idfillbyfirst="x" idstepbyrow="64">
 <location x="0.000" y="-0.190919" z="-0.190919" name="bank10">
   <rot val="-45.00000" axis-x="1" axis-y="0" axis-z="0" />
 </location>
-<side-by-side-view-location x="1.2" y="0.4"/>
+<side-by-side-view-location x="1.425" y="0.5"/>
 </component> 
 
 <component type="panel11" idstart="40961" idfillbyfirst="x" idstepbyrow="64">
@@ -134,7 +134,7 @@
     <rot val="0.00000" axis-x="1" axis-y="0" axis-z="0" />
   </rot>
 </location>
-<side-by-side-view-location x="0.6" y="0.1"/>
+<side-by-side-view-location x="0.675" y="0.3"/>
 </component> 
 
 <!--

--- a/instrument/SXD_Definition_19_1.xml
+++ b/instrument/SXD_Definition_19_1.xml
@@ -4,8 +4,7 @@
 <instrument xmlns="http://www.mantidproject.org/IDF/1.0" 
             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
             xsi:schemaLocation="http://www.mantidproject.org/IDF/1.0 http://schema.mantidproject.org/IDF/1.0/IDFSchema.xsd"
- name="SXD" valid-from   ="2011-01-01 00:00:01"
-            valid-to     ="2019-05-24 23:59:59"
+ name="SXD" valid-from   ="2019-05-25 00:00:01"
 		    last-modified="2023-04-19 16:00:00">
 
   <!--DEFAULTS-->
@@ -42,11 +41,12 @@
       <location z="-1.3" name="monitor1"/>
     </component>
   </type>
+  
 
-<component type="panel1346" idstart="1" idfillbyfirst="y" idstepbyrow="64">
+<component type="panel" idstart="1" idfillbyfirst="y" idstepbyrow="64">
 <location x="0.1369713215" y="0.000" z="-0.1785045016" name="bank1" >
   <rot val="142.50000" axis-x="0" axis-y="1" axis-z="0">
-    <rot val="0.00000" axis-x="1" axis-y="0" axis-z="0" />
+    <rot val="-90.00000" axis-x="0" axis-y="0" axis-z="1" />
   </rot>
 </location>
 <side-by-side-view-location x="0.1" y="0.7"/>

--- a/instrument/SXD_Definition_19_1.xml
+++ b/instrument/SXD_Definition_19_1.xml
@@ -44,7 +44,7 @@
   
 
 <component type="panel" idstart="1" idfillbyfirst="y" idstepbyrow="64">
-<location x="0.1369713215" y="0.000" z="-0.1785045016" name="bank1" >
+<location x="0.1369713215" y="-0.0125" z="-0.1785045016" name="bank1" >
   <rot val="142.50000" axis-x="0" axis-y="1" axis-z="0">
     <rot val="-90.00000" axis-x="0" axis-y="0" axis-z="1" />
   </rot>

--- a/instrument/SXD_Definition_19_1.xml
+++ b/instrument/SXD_Definition_19_1.xml
@@ -44,11 +44,13 @@
   
 
 <component type="panel" idstart="1" idfillbyfirst="y" idstepbyrow="64">
-<location x="0.1369713215" y="-0.0125" z="-0.1785045016" name="bank1" >
-  <rot val="142.50000" axis-x="0" axis-y="1" axis-z="0">
-    <rot val="-90.00000" axis-x="0" axis-y="0" axis-z="1" />
-  </rot>
-</location>
+  <location x="0.132736" y="-0.011329" z="-0.177596" name="bank1">
+	<rot axis-x="0" axis-y="1" axis-z="0" val="-36.49921051292514">
+	  <rot axis-x="0" axis-y="0" axis-z="1" val="89.92043334138435">
+		<rot axis-x="0" axis-y="1" axis-z="0" val="179.42437620226553"/>
+	  </rot>
+	</rot>
+  </location>
 <side-by-side-view-location x="0.1" y="0.7"/>
 </component> 
 
@@ -137,41 +139,6 @@
 </location>
 <side-by-side-view-location x="0.675" y="0.3"/>
 </component> 
-
-<!--
-<component type="panel" idstart="24601" idfillbyfirst="y" idstepbyrow="64">
-<location r="0.270" t="-90.00000" p="45.0000" name="bank7" rot="-90.0" axis-x="0" axis-y="1" axis-z="0">
-  <rot val="0.00000">
-    <rot val="45.00000" axis-x="1" axis-y="0" axis-z="0" />
-  </rot>
-</location>
-</component> 
-
-<component type="panel" idstart="28701" idfillbyfirst="y" idstepbyrow="64">
-<location r="0.270" t="180.000" p="45.0000" name="bank8" rot="180.0" axis-x="0" axis-y="1" axis-z="0">
-  <rot val="0.00000">
-    <rot val="0.00000" axis-x="1" axis-y="0" axis-z="0" />
-  </rot>
-</location>
-</component> 
-
-<component type="panel" idstart="32801" idfillbyfirst="y" idstepbyrow="64">
-<location r="0.270" t="90.00000" p="-45.0000" name="bank7" rot="-90.0" axis-x="0" axis-y="1" axis-z="0">
-  <rot val="0.00000">
-    <rot val="-45.00000" axis-x="1" axis-y="0" axis-z="0" />
-  </rot>
-</location>
-</component> 
-
-<component type="panel" idstart="36901" idfillbyfirst="y" idstepbyrow="64">
-<location r="0.270" t="0.00000" p="0.0000" name="bank7" rot="0.0" axis-x="0" axis-y="1" axis-z="0">
-  <rot val="0.00000">
-    <rot val="45.00000" axis-x="1" axis-y="0" axis-z="0" />
-  </rot>
-</location>
-</component> 
-
--->
 
 <!-- List of all the bank names:
 bank1,bank2,bank3,bank4,bank5,bank6,bank7,bank8,bank9,bank10,bank11


### PR DESCRIPTION
**Description of work**
This PR does two things:

1. Update the side-by-side positions to better represent the bank layout
2. Create a new definition for cycle 19_1 onwards with bank1 flipped since detector was upgraded between cycle 18_4 and 19_1

The new definition in (2) also has the detector shifted down in y to get better agreement with the found and predicted peaks - however a full calibration will still need to be applied (as is done for every new sample on SXD anway)

**Purpose of work**
To allow SXD to create a rough UB including peaks in bank 1 without applying an initial calibration.

**Report to:** Silvia Cappelli, Matthias Gutmann and Nick Funnell


**To test:**

(1) Run this script

```
Load(Filename='SXD31257.raw', OutputWorkspace='SXD_pre_upgrade')
Load(Filename='SXD32375.raw', OutputWorkspace='SXD_post_upgrade')
for ws in ['SXD_pre_upgrade', 'SXD_post_upgrade']:
    peaks = ws + '_peaks'
    FindSXPeaks(InputWorkspace=ws, PeakFindingStrategy='AllPeaks', AbsoluteBackground=50, 
                ResolutionStrategy='AbsoluteResolution', XResolution=250, PhiResolution=2, 
                TwoThetaResolution=2, OutputWorkspace=peaks)
    FilterPeaks(InputWorkspace=peaks, OutputWorkspace=peaks, Operator='=', Criterion='!=', BankName='bank1')
    FindUBUsingFFT(PeaksWorkspace=peaks, MinD=1, MaxD=20)
    PredictPeaks(InputWorkspace=peaks, WavelengthMin=0.4, MinDSpacing=0.4,
                 ReflectionCondition='Primitive', OutputWorkspace= peaks + '_pred')
```

(2) Open `SXD_pre_upgrade` in instrument view and overlay `SXD_pre_upgrade_peaks_pred` - it should look like this
![image](https://user-images.githubusercontent.com/55979119/233138361-58595a40-2d3c-46f9-bbf4-21023068bcaa.png)

(3) Open `SXD_post_upgrade` in instrument view and overlay `SXD_post_upgrade_peaks_pred`
![image](https://user-images.githubusercontent.com/55979119/233138873-1e706daa-440d-4363-822b-ce095933dc6c.png)
Fixes #35465 

(4) Check side-by-side view looks like this
![image](https://user-images.githubusercontent.com/55979119/233339831-9f1fe4e8-0ffe-44dc-9977-a064cf08759f.png)

--->

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.