### PR TITLE
Close slice viewer when an original workspace is deleted

### DIFF
--- a/Framework/API/inc/MantidAPI/MDGeometry.h
+++ b/Framework/API/inc/MantidAPI/MDGeometry.h
@@ -117,7 +117,7 @@ public:
 
 protected:
   /// Function called when observer objects recieves a notification
-  void deleteNotificationReceived(const std::shared_ptr<const Workspace> &deleted);
+  void deleteNotificationReceived(const std::shared_ptr<const Workspace> &replaced);
 
   /// Function called when observer detects a workspace is replaced
   void replaceNotificationReceived(const std::shared_ptr<const Workspace> &deleted);

--- a/Framework/API/inc/MantidAPI/MDGeometry.h
+++ b/Framework/API/inc/MantidAPI/MDGeometry.h
@@ -119,6 +119,9 @@ protected:
   /// Function called when observer objects recieves a notification
   void deleteNotificationReceived(const std::shared_ptr<const Workspace> &deleted);
 
+  /// Function called when observer detects a workspace is replaced
+  void replaceNotificationReceived(const std::shared_ptr<const Workspace> &deleted);
+
   /// Vector of the dimensions used, in the order X Y Z t, etc.
   std::vector<std::shared_ptr<Geometry::IMDDimension>> m_dimensions;
 

--- a/Framework/API/src/MDGeometry.cpp
+++ b/Framework/API/src/MDGeometry.cpp
@@ -444,7 +444,7 @@ void MDGeometry::deleteNotificationReceived(const std::shared_ptr<const Workspac
  * This checks if the "original workspace" in this object is being replaced,
  * and removes the reference to it to allow it to be destructed properly.
  *
- * @param deleted :: The replaced workspace
+ * @param replaced :: The replaced workspace
  */
 void MDGeometry::replaceNotificationReceived(const std::shared_ptr<const Workspace> &replaced) {
   for (auto &original : m_originalWorkspaces) {

--- a/docs/source/release/v6.7.0/Workbench/SliceViewer/Bugfixes/33434.rst
+++ b/docs/source/release/v6.7.0/Workbench/SliceViewer/Bugfixes/33434.rst
@@ -1,0 +1,1 @@
+- The slice viewer will now close if the original workspace of the workspace it is showing is deleted.

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/models/model.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/models/model.py
@@ -51,6 +51,8 @@ class SliceViewerModel(SliceViewerBaseModel):
         else:
             raise ValueError("only works for MatrixWorkspace and MDWorkspace")
 
+        self.num_original_workspaces_at_init = self.number_of_active_original_workspaces()
+
         wsname = self.get_ws_name()
         self._rebinned_name = wsname + "_svrebinned"
         self._xcut_name, self._ycut_name = wsname + "_cut_x", wsname + "_cut_y"
@@ -500,6 +502,21 @@ class SliceViewerModel(SliceViewerBaseModel):
 
     def workspace_equals(self, ws_name):
         return self._ws_name == ws_name
+
+    def number_of_active_original_workspaces(self):
+        total = 0
+        workspace = self._get_ws()
+        for i in range(workspace.numOriginalWorkspaces()):
+            # When an original workspace is removed, the pointer to it in main workspace's geometry's
+            # list of original workspaces is reset. This does not decrease the number of items in the
+            # original workspaces list but calling hasOriginalWorkspace will show if the pointer is now empty.
+            if workspace.hasOriginalWorkspace(i):
+                total += 1
+
+        return total
+
+    def check_for_removed_original_workspace(self):
+        return self.num_original_workspaces_at_init != self.number_of_active_original_workspaces()
 
     def get_proj_matrix(self):
         ws = self._get_ws()

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/presenters/presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/presenters/presenter.py
@@ -387,7 +387,7 @@ class SliceViewer(ObservingPresenter, SliceViewerBasePresenter):
         try:
             candidate_model = SliceViewerModel(workspace)
             candidate_model_properties = candidate_model.get_properties()
-            for (property, value) in candidate_model_properties.items():
+            for property, value in candidate_model_properties.items():
                 if self.initial_model_properties[property] != value:
                     raise ValueError(f"The property {property} is different on the new workspace.")
 
@@ -424,6 +424,8 @@ class SliceViewer(ObservingPresenter, SliceViewerBasePresenter):
 
     def delete_workspace(self, ws_name):
         if self.model.workspace_equals(ws_name):
+            self.view.emit_close()
+        elif self.model.check_for_removed_original_workspace():
             self.view.emit_close()
 
     def ADS_cleared(self):

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/presenters/presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/presenters/presenter.py
@@ -382,6 +382,7 @@ class SliceViewer(ObservingPresenter, SliceViewerBasePresenter):
         """
         if self.model.check_for_removed_original_workspace():
             self._close_view_with_message("Original workspace has been replaced: Closing Slice Viewer")
+            return
 
         if not self.model.workspace_equals(workspace_name):
             # TODO this is a dead branch, since the ADS observer will call this if the

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/presenters/presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/presenters/presenter.py
@@ -380,6 +380,9 @@ class SliceViewer(ObservingPresenter, SliceViewerBasePresenter):
         @param workspace_name: the name of the workspace that has changed
         @param workspace: the workspace that has changed
         """
+        if self.model.check_for_removed_original_workspace():
+            self._close_view_with_message("Original workspace has been replaced: Closing Slice Viewer")
+
         if not self.model.workspace_equals(workspace_name):
             # TODO this is a dead branch, since the ADS observer will call this if the
             # names are the same, but the model "workspace_equals" simply checks for the same name
@@ -426,7 +429,7 @@ class SliceViewer(ObservingPresenter, SliceViewerBasePresenter):
         if self.model.workspace_equals(ws_name):
             self.view.emit_close()
         elif self.model.check_for_removed_original_workspace():
-            self.view.emit_close()
+            self._close_view_with_message("Original workspace has been deleted: Closing Slice Viewer")
 
     def ADS_cleared(self):
         if self.view:

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_sliceviewer_model.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_sliceviewer_model.py
@@ -259,6 +259,7 @@ class SliceViewerModelTest(unittest.TestCase):
         mock_ws.name = Mock(return_value="")
         mock_ws.isMDHistoWorkspace = Mock(return_value=True)
         mock_ws.getNumNonIntegratedDims = Mock(return_value=700)
+        mock_ws.numOriginalWorkspaces = Mock(return_value=0)
 
         with patch.object(SliceViewerModel, "_calculate_axes_angles"):
             self.assertIsNotNone(SliceViewerModel(mock_ws))
@@ -268,6 +269,7 @@ class SliceViewerModelTest(unittest.TestCase):
         mock_ws.name = Mock(return_value="")
         mock_ws.isMDHistoWorkspace = Mock(return_value=False)
         mock_ws.getNumDims = Mock(return_value=4)
+        mock_ws.numOriginalWorkspaces = Mock(return_value=0)
 
         with patch.object(SliceViewerModel, "_calculate_axes_angles"):
             self.assertIsNotNone(SliceViewerModel(mock_ws))

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_sliceviewer_model.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_sliceviewer_model.py
@@ -901,6 +901,19 @@ class SliceViewerModelTest(unittest.TestCase):
 
         self.assertEqual([4.0, -3.0, 12.0], list(hkl))
 
+    @patch("mantidqt.widgets.sliceviewer.models.model.SliceViewerModel.number_of_active_original_workspaces")
+    def test_check_for_removed_original_workspace(self, mock_num_original_workspaces):
+        self.ws_MDE_4D.hasOriginalWorkspace.side_effect = lambda index: True
+        mock_num_original_workspaces.return_value = 1
+
+        model = SliceViewerModel(self.ws_MDE_4D)
+
+        self.assertEqual(model.num_original_workspaces_at_init, 1)
+        self.assertFalse(model.check_for_removed_original_workspace())
+        # original workspace has been deleted
+        mock_num_original_workspaces.return_value = 0
+        self.assertTrue(model.check_for_removed_original_workspace())
+
     # private
     def _assert_supports_non_orthogonal_axes(self, expectation, ws_type, coords, has_oriented_lattice):
         model = SliceViewerModel(_create_mock_workspace(ws_type, coords, has_oriented_lattice))

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_sliceviewer_presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_sliceviewer_presenter.py
@@ -67,6 +67,7 @@ def create_mdhistoworkspace_mock():
     workspace.getDimension = lambda: mock.MagicMock()
     workspace.getNumDims = lambda: 2
     workspace.getNumNonIntegratedDims = lambda: 2
+    workspace.numOriginalWorkspaces = lambda: 0
     workspace.name = lambda: "workspace"
     workspace.readLock = mock.MagicMock()
     workspace.unlock = mock.MagicMock()
@@ -523,6 +524,7 @@ class SliceViewerTest(unittest.TestCase):
         mock_view = mock.MagicMock()
         pres = SliceViewer(mock.Mock(), model=mock_model, view=mock_view)
         mock_model.workspace_equals.return_value = True
+        mock_model.check_for_removed_original_workspace.return_value = False
         pres.delete_workspace("test_name")
         mock_view.emit_close.assert_called_once()
 
@@ -531,6 +533,7 @@ class SliceViewerTest(unittest.TestCase):
         mock_view = mock.MagicMock()
         pres = SliceViewer(mock.Mock(), model=mock_model, view=mock_view)
         mock_model.workspace_equals.return_value = False
+        mock_model.check_for_removed_original_workspace.return_value = False
         pres.delete_workspace("different_name")
         mock_view.emit_close.assert_not_called()
 

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_sliceviewer_presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_sliceviewer_presenter.py
@@ -534,6 +534,24 @@ class SliceViewerTest(unittest.TestCase):
         pres.delete_workspace("different_name")
         mock_view.emit_close.assert_not_called()
 
+    def test_delete_original_workspace(self):
+        mock_model = mock.MagicMock()
+        mock_view = mock.MagicMock()
+        pres = SliceViewer(mock.Mock(), model=mock_model, view=mock_view)
+        mock_model.workspace_equals.return_value = False
+        mock_model.check_for_removed_original_workspace.return_value = True
+        pres.delete_workspace("original_name")
+        mock_view.emit_close.assert_called_once()
+
+    def test_delete_not_original_workspace(self):
+        mock_model = mock.MagicMock()
+        mock_view = mock.MagicMock()
+        pres = SliceViewer(mock.Mock(), model=mock_model, view=mock_view)
+        mock_model.workspace_equals.return_value = False
+        mock_model.check_for_removed_original_workspace.return_value = False
+        pres.delete_workspace("not_original_name")
+        mock_view.emit_close.assert_not_called()
+
     def test_replace_workspace_does_nothing_if_workspace_is_unchanged(self):
         mock_model = mock.MagicMock()
         mock_view = mock.MagicMock()

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_sliceviewer_presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_sliceviewer_presenter.py
@@ -134,6 +134,7 @@ class SliceViewerTest(unittest.TestCase):
             "supports_dynamic_rebinning": False,
             "supports_peaks_overlays": True,
         }
+        self.model.check_for_removed_original_workspace.return_value = False
 
         self._ws_info_patcher = mock.patch.multiple(
             "mantidqt.widgets.sliceviewer.presenters.presenter", Dimensions=mock.DEFAULT, WorkspaceInfo=mock.DEFAULT
@@ -555,6 +556,16 @@ class SliceViewerTest(unittest.TestCase):
         pres.delete_workspace("not_original_name")
         mock_view.emit_close.assert_not_called()
 
+    def test_replace_original_workspace(self):
+        mock_model = mock.MagicMock()
+        mock_view = mock.MagicMock()
+        pres = SliceViewer(mock.Mock(), model=mock_model, view=mock_view)
+        mock_model.check_for_removed_original_workspace.return_value = True
+
+        pres._close_view_with_message = mock.Mock()
+        pres.replace_workspace("test1", "test2")
+        pres._close_view_with_message.assert_called_once()
+
     def test_replace_workspace_does_nothing_if_workspace_is_unchanged(self):
         mock_model = mock.MagicMock()
         mock_view = mock.MagicMock()
@@ -562,6 +573,7 @@ class SliceViewerTest(unittest.TestCase):
         # TODO The return value here should be True but there is a bug in the
         # presenter where the condition is always incorrect (see the TODO on
         # replace_workspace in the presenter)
+        mock_model.check_for_removed_original_workspace.return_value = False
         mock_model.workspace_equals.return_value = False
         pres._close_view_with_message = mock.Mock()
 
@@ -574,6 +586,7 @@ class SliceViewerTest(unittest.TestCase):
         mock_model = mock.MagicMock()
         mock_view = mock.MagicMock()
         pres = SliceViewer(mock.Mock(), model=mock_model, view=mock_view)
+        mock_model.check_for_removed_original_workspace.return_value = False
         mock_model.workspace_equals.return_value = True
         with mock.patch("mantidqt.widgets.sliceviewer.presenters.presenter.SliceViewerModel") as mock_model_class:
             pres.replace_workspace(mock.NonCallableMock(), mock.NonCallableMock())


### PR DESCRIPTION
**Description of work**

**Purpose of work**
If a `MDHistoWorkspace` has an original workspace (i.e that is has been rebinned from), the slice viewer can perform dynamic rebinning. If the slice viewer is opened on a workspace without this property, then these features are disabled. This PR adds functionality so that if the original workspace is deleted while the slice viewer open, the slice viewer will close.

**Summary of work**
Added a parameter to the slice viewer model which is the number of original workspaces upon opening the slice viewer. When a workspace is deleted from mantid, this value is recalculated and, if different, the slice viewer is closed.


**To test:**

- Run the following
```
md_4D = CreateMDWorkspace(Dimensions=4, Extents=[-2,2,-1,1,-1.5,1.5,-0.25,0.25], Names="H,K,L,E", Frames='HKL,HKL,HKL,General Frame',Units='r.l.u.,r.l.u.,r.l.u.,meV')
FakeMDEventData(InputWorkspace=md_4D, UniformParams='5e5') 
BinMD(InputWorkspace='md_4D', AxisAligned=False, BasisVector0='H,r.l.u.,1.0,0.0,0.0,0.0', BasisVector1='K,r.l.u.,0.0,1.0,0.0,0.0', BasisVector2='L,r.l.u.,0.0,0.0,1.0,0.0', BasisVector3='E,meV,0.0,0.0,0.0,1.0', OutputExtents='-2,2,-1,1,-1.535,-1.435,-0.297,-0.197', OutputBins='100,100,1,1', NormalizeBasisVectors=False, OutputWorkspace='md_4D_svrebinned')
```
- Open `md_4D_svrebinned` in the slice viewer
- [x] Delete `md_4D` and the slice viewer should close.
- Clear the ADS and run the script again
- Delete `md_4D`
- [x] Open `md_4D_svrebinned` in the slice viewer (this should work as normal)
- Clear the ADS and run the script again
- Load some unrelated data into a workspace
- Open `md_4D_svrebinned` in the slice viewer
- [x] Delete the unrelated workspace and the slice viewer should remain open

Fixes #33434

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.