### PR TITLE
Set log level from a string in python

### DIFF
--- a/Framework/Kernel/inc/MantidKernel/ConfigService.h
+++ b/Framework/Kernel/inc/MantidKernel/ConfigService.h
@@ -205,6 +205,8 @@ public:
   void setFacility(const std::string &facilityName);
   /// Sets the log level priority for all log channels
   void setLogLevel(int logLevel, bool quiet = false);
+  /// Sets the log level priority for all log channels
+  void setLogLevel(std::string logLevel, bool quiet = false);
 
   /// Look for an instrument
   const InstrumentInfo &getInstrument(const std::string &instrumentName = "") const;

--- a/Framework/Kernel/inc/MantidKernel/Logger.h
+++ b/Framework/Kernel/inc/MantidKernel/Logger.h
@@ -13,9 +13,8 @@
 #include "MantidKernel/ThreadSafeLogStream.h"
 
 #include <Poco/Message.h>
-
+#include <array>
 #include <iosfwd>
-
 #include <memory>
 #include <string>
 
@@ -54,7 +53,7 @@ public:
   // Our logger's priority types are the same as POCO's Message's types.
   using Priority = Poco::Message::Priority;
 
-  static const std::string *PriorityNames;
+  static const std::array<std::string, 9> PriorityNames;
 
   /// Constructor giving the logger name
   Logger(const std::string &name);
@@ -121,6 +120,8 @@ public:
   /// Returns the Logger's log level.
   int getLevel() const;
 
+  std::string getLevelName() const;
+
   /// Sets the Logger's log level using a symbolic value.
   void setLevel(const std::string &level);
 
@@ -136,6 +137,7 @@ public:
   /// Sets the log level for all Loggers created so far, including the root
   /// logger.
   static void setLevelForAll(const int level);
+  static void setLevelForAll(const std::string &level);
 
   /// Shuts down the logging framework and releases all Loggers.
   static void shutdown();

--- a/Framework/Kernel/src/ConfigService.cpp
+++ b/Framework/Kernel/src/ConfigService.cpp
@@ -109,6 +109,8 @@ std::vector<std::string> splitPath(const std::string &path) {
   return splitted;
 }
 
+const std::string LOG_LEVEL_KEY("logging.loggers.root.level");
+
 } // end of anonymous namespace
 
 //-------------------------------
@@ -916,6 +918,8 @@ void ConfigServiceImpl::setString(const std::string &key, const std::string &val
   } else if (key == "logging.channels.consoleChannel.class") {
     // this key requires reloading logging for it to take effect
     configureLogging();
+  } else if (key == LOG_LEVEL_KEY) {
+    this->setLogLevel(value);
   }
 
   m_notificationCenter.postNotification(new ValueChanged(key, value, old));
@@ -1890,9 +1894,22 @@ std::string ConfigServiceImpl::getFullPath(const std::string &filename, const bo
  */
 void ConfigServiceImpl::setLogLevel(int logLevel, bool quiet) {
   Mantid::Kernel::Logger::setLevelForAll(logLevel);
+  // update the internal value to keep strings in sync
+  m_pConf->setString(LOG_LEVEL_KEY, g_log.getLevelName());
+
   if (!quiet) {
-    g_log.log("logging set to " + Logger::PriorityNames[logLevel] + " priority",
+    g_log.log("logging set to " + Logger::PriorityNames[std::size_t(logLevel)] + " priority",
               static_cast<Logger::Priority>(logLevel));
+  }
+}
+
+void ConfigServiceImpl::setLogLevel(std::string logLevel, bool quiet) {
+  Mantid::Kernel::Logger::setLevelForAll(logLevel);
+  // update the internal value to keep strings in sync
+  m_pConf->setString(LOG_LEVEL_KEY, g_log.getLevelName());
+
+  if (!quiet) {
+    g_log.log("logging set to " + logLevel + " priority", static_cast<Logger::Priority>(g_log.getLevel()));
   }
 }
 

--- a/Framework/Kernel/test/LoggerTest.h
+++ b/Framework/Kernel/test/LoggerTest.h
@@ -72,6 +72,35 @@ public:
    */
   void test_basics() { log.information() << "Information Message\n"; }
 
+  void test_setLevel() {
+    TS_ASSERT_EQUALS(log.getLevel(), 5);
+    TS_ASSERT_EQUALS(log.getLevelName(), "notice");
+
+    log.setLevel(1);
+    TS_ASSERT_EQUALS(log.getLevel(), 1);
+    TS_ASSERT_EQUALS(log.getLevelName(), "fatal");
+
+    log.setLevel("NoTiCe"); // wacky case to make sure set is case insensitive
+    TS_ASSERT_EQUALS(log.getLevel(), 5);
+    TS_ASSERT_EQUALS(log.getLevelName(), "notice");
+
+    log.setLevel("dEbUg"); // wacky case to make sure set is case insensitive
+    TS_ASSERT_EQUALS(log.getLevel(), 7);
+    TS_ASSERT_EQUALS(log.getLevelName(), "debug");
+
+    log.setLevel(-1); // value too low
+    TS_ASSERT_EQUALS(log.getLevel(), 0);
+
+    log.setLevel(42); // value too high
+    TS_ASSERT_EQUALS(log.getLevel(), 8);
+
+    log.setLevelForAll(4);
+    TS_ASSERT_EQUALS(log.getLevel(), 4);
+
+    // put the log back in it's nominal state
+    log.setLevel(5);
+    log.flush();
+  }
   //---------------------------------------------------------------------------
   /** Log very quickly from a lot of OpenMP threads*/
   void test_OpenMP_ParallelLogging() {

--- a/Framework/PythonInterface/mantid/kernel/src/Exports/ConfigService.cpp
+++ b/Framework/PythonInterface/mantid/kernel/src/Exports/ConfigService.cpp
@@ -139,9 +139,13 @@ void export_ConfigService() {
       .def("saveConfig", &ConfigServiceImpl::saveConfig, (arg("self"), arg("filename")),
            "Saves the keys that have changed from their default to the given "
            "filename")
-      .def("setLogLevel", &ConfigServiceImpl::setLogLevel, (arg("self"), arg("logLevel"), arg("quiet") = false),
-           "Sets the log level priority for all the log channels, logLevel "
-           "1 = Fatal, 6 = information, 7 = Debug")
+      .def("setLogLevel", (void (ConfigServiceImpl::*)(int, bool)) & ConfigServiceImpl::setLogLevel,
+           (arg("self"), arg("logLevel"), arg("quiet") = false),
+           "Sets the log level priority for all the log channels, logLevel 1 = Fatal, 6 = information, 7 = Debug")
+      .def("setLogLevel", (void (ConfigServiceImpl::*)(std::string, bool)) & ConfigServiceImpl::setLogLevel,
+           (arg("self"), arg("logLevel"), arg("quiet") = false),
+           "Sets the log level priority for all the log channels. Allowed values are fatal, critical, error, warning, "
+           "notice, information, debug, and trace.")
       .def("keys", &ConfigServiceImpl::keys, arg("self"))
 
       // Treat this as a dictionary

--- a/Framework/PythonInterface/test/python/mantid/kernel/ConfigServiceTest.py
+++ b/Framework/PythonInterface/test/python/mantid/kernel/ConfigServiceTest.py
@@ -132,6 +132,7 @@ class ConfigServiceTest(unittest.TestCase):
 
     def test_setting_log_channel_levels(self):
         testhelpers.assertRaisesNothing(self, config.setLogLevel, 4, True)
+        testhelpers.assertRaisesNothing(self, config.setLogLevel, "warning", True)
 
     def test_properties_documented(self):
         # location of the rst file relative to this file this will break if either moves

--- a/docs/source/concepts/PropertiesFile.rst
+++ b/docs/source/concepts/PropertiesFile.rst
@@ -167,8 +167,10 @@ The logging priority levels for the file logging and console logging can also be
 
   #Set the log to debug level or above (7=debug)
   ConfigService.setLogLevel(7)
-  #Set the log to critical level (2=critical)
-  ConfigService.setLogLevel(2)
+  #Set the log to critical level (2=critical) and do not log that it was changed
+  ConfigService.setLogLevel(2, True)
+  # Set the log to information and do not log that it was changed
+  ConfigService.setLogLevel("information", True)
 
 
 

--- a/docs/source/release/v6.7.0/Framework/Python/New_features/35475.rst
+++ b/docs/source/release/v6.7.0/Framework/Python/New_features/35475.rst
@@ -1,0 +1,1 @@
+* Add the ability to take strings to ``ConfigService.setLogLevel()``


### PR DESCRIPTION
Since the integer log levels mean very little to the average user, add a method to set the log level from a string.

**To test:**

The real test is to use the new and old functions from python. These were added to the unit tests already.

*There is no associated issue.*

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.