### PR TITLE
Implement LogManager time series filtering with TimeROI.

### DIFF
--- a/Framework/API/inc/MantidAPI/LogManager.h
+++ b/Framework/API/inc/MantidAPI/LogManager.h
@@ -68,6 +68,13 @@ public:
 
   /// Filter the logs by time
   virtual void filterByTime(const Types::Core::DateAndTime start, const Types::Core::DateAndTime stop);
+
+  /// For the time series properties, remove values according to TimeROI
+  virtual void removeDataOutsideTimeROI(const Kernel::TimeROI &timeROI);
+
+  /// Create a new LogManager with a partial copy of its time series properties according to TimeROI
+  LogManager *cloneInTimeROI(const Kernel::TimeROI &timeROI);
+
   /// Filter the run by the given boolean log
   void filterByLog(const Kernel::TimeSeriesProperty<bool> &filter,
                    const std::vector<std::string> &excludedFromFiltering = std::vector<std::string>());

--- a/Framework/API/src/LogManager.cpp
+++ b/Framework/API/src/LogManager.cpp
@@ -194,7 +194,32 @@ void LogManager::filterByTime(const Types::Core::DateAndTime start, const Types:
   this->setTimeROI(TimeROI(start, stop));
 }
 
-//-----------------------------------------------------------------------------------------------
+/**
+ * Create a partial copy of this object such that every time series property is cloned according to the input TimeROI.
+ * A partially cloned time series property should include all time values enclosed by the ROI regions,
+ * each defined as [roi_start,roi_end), plus the values immediately before and after an ROI region, if available.
+ * Properties that are not time series will be cloned with no changes.
+ * @param timeROI :: a series of time regions used to determine which time series values should be included in the copy.
+ */
+LogManager *LogManager::cloneInTimeROI(const Kernel::TimeROI &timeROI) {
+  LogManager *logMgr = new LogManager();
+  logMgr->m_manager = std::make_unique<Kernel::PropertyManager>(*m_manager->cloneInTimeROI(timeROI));
+  logMgr->m_timeroi = std::make_unique<Kernel::TimeROI>(*m_timeroi),
+  logMgr->m_singleValueCache =
+      std::make_unique<Kernel::Cache<std::pair<std::string, Kernel::Math::StatisticType>, double>>(*m_singleValueCache);
+  return logMgr;
+}
+
+/**
+ * For time series properties, remove time values outside of TimeROI regions, each defined as [roi_start,roi_stop).
+ * However, keep the values immediately before and after each ROI region, if available.
+ * @param timeROI :: a series of time regions used to determine which values to remove or to keep
+ */
+void LogManager::removeDataOutsideTimeROI(const Kernel::TimeROI &timeROI) {
+  m_manager->removeDataOutsideTimeROI(timeROI);
+}
+
+//----------------------------------------------------------------------------------------------
 /**
  * Filter the run by the given boolean log. It replaces all time
  * series properties with filtered time series properties

--- a/Framework/API/test/LogManagerTest.h
+++ b/Framework/API/test/LogManagerTest.h
@@ -735,8 +735,11 @@ public:
     auto tsp = run_input.getTimeSeriesProperty<double>("time_series");
     run_expect.addProperty(tsp->cloneInTimeROI(roi), true);
 
-    // Test that a clone-in-roi copy of the original run info object is the same as expected
+    // Create a cloned-in-roi copy of the orginal run info object
     LogManager *run_result_ptr = run_input.cloneInTimeROI(roi);
+    // Make sure the copy is different from the original, i.e. the roi really filters out some data
+    TS_ASSERT(*run_result_ptr != run_input);
+    // Test that the copy is the same as expected
     TS_ASSERT_EQUALS(*run_result_ptr, run_expect);
     delete run_result_ptr;
   }

--- a/Framework/API/test/LogManagerTest.h
+++ b/Framework/API/test/LogManagerTest.h
@@ -13,6 +13,7 @@
 #include "MantidKernel/FilteredTimeSeriesProperty.h"
 #include "MantidKernel/Matrix.h"
 #include "MantidKernel/Property.h"
+#include "MantidKernel/TimeROI.h"
 #include "MantidKernel/TimeSeriesProperty.h"
 #include "MantidKernel/V3D.h"
 #include <cmath>
@@ -687,6 +688,57 @@ public:
       TS_ASSERT_DELTA(filtered->nthValue(4), 21, 1e-5);
       TS_ASSERT_DELTA(filtered->nthValue(5), 22, 1e-5);
     }
+  }
+
+  void test_removeDataOutsideTimeROI() {
+    // Build an input run info object with a few properties, including a time series
+    LogManager run_input;
+    addTestPropertyWithValue<double>(run_input, "single-double", 2023.0);
+    addTestPropertyWithValue<std::string>(run_input, "single_string", "2023");
+    addTestTimeSeries<double>(run_input, "time_series");
+
+    // Create a TimeROI
+    TimeROI roi;
+    roi.addROI(DateAndTime("2012-07-19T16:17:20"), DateAndTime("2012-07-19T16:17:35"));
+    roi.addROI(DateAndTime("2012-07-19T16:17:45"), DateAndTime("2012-07-19T16:18:10"));
+
+    // Build an expected run info object with the same properties as the input, except for the time series
+    LogManager run_expect;
+    addTestPropertyWithValue<double>(run_expect, "single-double", 2023.0);
+    addTestPropertyWithValue<std::string>(run_expect, "single_string", "2023");
+    // Use a filtered time series property instead of original
+    auto tsp = run_input.getTimeSeriesProperty<double>("time_series");
+    run_expect.addProperty(tsp->cloneInTimeROI(roi), true);
+
+    // Test that after the input run info is filtered with the same TimeROI, the result is as expected
+    run_input.removeDataOutsideTimeROI(roi);
+    TS_ASSERT_EQUALS(run_input, run_expect);
+  }
+
+  void test_cloneInTimeROI() {
+    // Build an input run info object with a few properties, including a time series
+    LogManager run_input;
+    addTestPropertyWithValue<double>(run_input, "single-double", 2023.0);
+    addTestPropertyWithValue<std::string>(run_input, "single_string", "2023");
+    addTestTimeSeries<double>(run_input, "time_series");
+
+    // Create a TimeROI
+    TimeROI roi;
+    roi.addROI(DateAndTime("2012-07-19T16:17:20"), DateAndTime("2012-07-19T16:17:35"));
+    roi.addROI(DateAndTime("2012-07-19T16:17:45"), DateAndTime("2012-07-19T16:18:10"));
+
+    // Build an expected run info object with the same properties as the input, except for the time series
+    LogManager run_expect;
+    addTestPropertyWithValue<double>(run_expect, "single-double", 2023.0);
+    addTestPropertyWithValue<std::string>(run_expect, "single_string", "2023");
+    // Use a filtered time series property instead of original
+    auto tsp = run_input.getTimeSeriesProperty<double>("time_series");
+    run_expect.addProperty(tsp->cloneInTimeROI(roi), true);
+
+    // Test that a clone-in-roi copy of the original run info object is the same as expected
+    LogManager *run_result_ptr = run_input.cloneInTimeROI(roi);
+    TS_ASSERT_EQUALS(*run_result_ptr, run_expect);
+    delete run_result_ptr;
   }
 
 private:

--- a/Framework/Kernel/inc/MantidKernel/PropertyManager.h
+++ b/Framework/Kernel/inc/MantidKernel/PropertyManager.h
@@ -21,6 +21,7 @@ namespace Kernel {
 //----------------------------------------------------------------------
 class SplittingInterval;
 template <typename T> class TimeSeriesProperty;
+class TimeROI;
 
 /**
  Property manager helper class.
@@ -56,6 +57,12 @@ public:
 
   void filterByProperty(const TimeSeriesProperty<bool> &filter,
                         const std::vector<std::string> &excludedFromFiltering = std::vector<std::string>()) override;
+
+  // Create a new PropertyManager with a partial copy of its time series properties according to TimeROI
+  PropertyManager *cloneInTimeROI(const Kernel::TimeROI &timeROI);
+
+  // For the time series properties, remove values according to TimeROI
+  void removeDataOutsideTimeROI(const Kernel::TimeROI &timeROI);
 
   virtual ~PropertyManager() override;
 

--- a/Framework/Kernel/src/PropertyManager.cpp
+++ b/Framework/Kernel/src/PropertyManager.cpp
@@ -14,6 +14,7 @@
 #include "MantidKernel/LogFilter.h"
 #include "MantidKernel/PropertyWithValueJSON.h"
 #include "MantidKernel/StringTokenizer.h"
+#include "MantidKernel/TimeROI.h"
 
 #include <json/json.h>
 
@@ -170,6 +171,43 @@ void PropertyManager::filterByProperty(const Kernel::TimeSeriesProperty<bool> &f
         this->m_properties[createKey(currentProp->name())] = std::move(filtered);
       }
     }
+  }
+}
+
+/**
+ * Create a partial copy of this object such that every time series property is cloned according to the input TimeROI.
+ * A partially cloned time series property should include all time values enclosed by the ROI regions,
+ * each defined as [roi_start,roi_end), plus the values immediately before and after an ROI region, if available.
+ * Properties that are not time series will be cloned with no changes.
+ * @param timeROI :: a series of time regions used to determine which time series values should be included in the copy.
+ */
+PropertyManager *PropertyManager::cloneInTimeROI(const Kernel::TimeROI &timeROI) {
+  PropertyManager *newMgr = new PropertyManager();
+  newMgr->m_orderedProperties.reserve(m_orderedProperties.size());
+  // We need to do a deep copy of the property pointers here
+  for (auto prop : m_orderedProperties) {
+    auto tsp = dynamic_cast<ITimeSeriesProperty *>(prop);
+    std::unique_ptr<Property> newProp;
+    if (tsp)
+      newProp = std::unique_ptr<Property>(tsp->cloneInTimeROI(timeROI));
+    else
+      newProp = std::unique_ptr<Property>(prop->clone());
+    newMgr->m_orderedProperties.emplace_back(newProp.get());
+    newMgr->m_properties[createKey(newProp->name())] = std::move(newProp);
+  }
+  return newMgr;
+}
+
+/**
+ * For time series properties, remove time values outside of TimeROI regions, each defined as [roi_start,roi_stop).
+ * However, keep the values immediately before and after each ROI region, if available.
+ * @param timeROI :: a series of time regions used to determine which values to remove or to keep
+ */
+void PropertyManager::removeDataOutsideTimeROI(const Kernel::TimeROI &timeROI) {
+  for (auto prop : m_orderedProperties) {
+    auto tsp = dynamic_cast<ITimeSeriesProperty *>(prop);
+    if (tsp)
+      tsp->removeDataOutsideTimeROI(timeROI);
   }
 }
 

--- a/Framework/Kernel/src/PropertyManager.cpp
+++ b/Framework/Kernel/src/PropertyManager.cpp
@@ -205,8 +205,7 @@ PropertyManager *PropertyManager::cloneInTimeROI(const Kernel::TimeROI &timeROI)
  */
 void PropertyManager::removeDataOutsideTimeROI(const Kernel::TimeROI &timeROI) {
   for (auto prop : m_orderedProperties) {
-    auto tsp = dynamic_cast<ITimeSeriesProperty *>(prop);
-    if (tsp)
+    if (auto tsp = dynamic_cast<ITimeSeriesProperty *>(prop))
       tsp->removeDataOutsideTimeROI(timeROI);
   }
 }

--- a/Framework/Kernel/src/TimeSeriesProperty.cpp
+++ b/Framework/Kernel/src/TimeSeriesProperty.cpp
@@ -80,9 +80,9 @@ template <typename TYPE> TimeSeriesProperty<TYPE> *TimeSeriesProperty<TYPE>::clo
 
 /**
  * Create a partial copy of this object according to a TimeROI. The partially cloned object
- * should include all time values enclosed by the ROI regions each defined as [roi_start,roi_end),
+ * should include all time values enclosed by the ROI regions, each defined as [roi_start,roi_end),
  * plus the values immediately before and after an ROI region, if available.
- * @param timeROI :: a series of time regions used to determine which values should be included in the copy
+ * @param timeROI :: a series of time regions used to determine which values should be included in the copy.
  */
 template <typename TYPE> Property *TimeSeriesProperty<TYPE>::cloneInTimeROI(const TimeROI &timeROI) const {
   TimeSeriesProperty<TYPE> *filteredTS = new TimeSeriesProperty<TYPE>(this->name());

--- a/Framework/Kernel/test/TimeSeriesPropertyTest.h
+++ b/Framework/Kernel/test/TimeSeriesPropertyTest.h
@@ -573,6 +573,11 @@ public:
     auto tsp_expected = std::make_unique<TimeSeriesProperty<double>>("three_values", times_expected, values_expected);
     auto tsp_result_base = std::shared_ptr<Property>(tsp_input->cloneInTimeROI(roi));
     auto tsp_result = std::static_pointer_cast<TimeSeriesProperty<double>>(tsp_result_base);
+
+    // Make sure the cloned-in-roi time series copy is different from the original, i.e. the roi really filters out some
+    // data
+    TS_ASSERT(*tsp_result != *tsp_input);
+    // Test that the cloned copy is the same as expected
     TS_ASSERT_EQUALS(*tsp_result, *tsp_expected);
   }
 

--- a/Framework/Kernel/test/TimeSeriesPropertyTest.h
+++ b/Framework/Kernel/test/TimeSeriesPropertyTest.h
@@ -444,10 +444,10 @@ public:
     times_expected = times;
     values = {1.};
     values_expected = values;
-    auto log_input = std::make_shared<TimeSeriesProperty<double>>("one_value", times, values);
-    auto log_expected = std::make_shared<TimeSeriesProperty<double>>("one_value", times_expected, values_expected);
-    log_input->removeDataOutsideTimeROI(roi);
-    TS_ASSERT_EQUALS(*log_input, *log_expected);
+    auto tsp_input = std::make_unique<TimeSeriesProperty<double>>("one_value", times, values);
+    auto tsp_expected = std::make_unique<TimeSeriesProperty<double>>("one_value", times_expected, values_expected);
+    tsp_input->removeDataOutsideTimeROI(roi);
+    TS_ASSERT_EQUALS(*tsp_input, *tsp_expected);
 
     // 2. TimeSeriesProperty with two values
     values = {1., 2.};
@@ -455,62 +455,62 @@ public:
     // a. TimeROI entirely between those values - no changes
     times = {DateAndTime("2007-11-30T16:00:00"), DateAndTime("2007-11-30T20:00:00")};
     times_expected = times;
-    log_input = std::make_shared<TimeSeriesProperty<double>>("two_values_a", times, values);
-    log_expected = std::make_shared<TimeSeriesProperty<double>>("two_values_a", times_expected, values_expected);
-    log_input->removeDataOutsideTimeROI(roi);
-    TS_ASSERT_EQUALS(*log_input, *log_expected);
+    tsp_input = std::make_unique<TimeSeriesProperty<double>>("two_values_a", times, values);
+    tsp_expected = std::make_unique<TimeSeriesProperty<double>>("two_values_a", times_expected, values_expected);
+    tsp_input->removeDataOutsideTimeROI(roi);
+    TS_ASSERT_EQUALS(*tsp_input, *tsp_expected);
 
     // b. TimeROI entirely includes the values - no changes
 
     // b1. First roi entirely includes the values
     times = {DateAndTime("2007-11-30T16:17:15"), DateAndTime("2007-11-30T16:17:35")};
     times_expected = times;
-    log_input = std::make_shared<TimeSeriesProperty<double>>("two_values_b1", times, values);
-    log_expected = std::make_shared<TimeSeriesProperty<double>>("two_values_b1", times_expected, values_expected);
-    log_input->removeDataOutsideTimeROI(roi);
-    TS_ASSERT_EQUALS(*log_input, *log_expected);
+    tsp_input = std::make_unique<TimeSeriesProperty<double>>("two_values_b1", times, values);
+    tsp_expected = std::make_unique<TimeSeriesProperty<double>>("two_values_b1", times_expected, values_expected);
+    tsp_input->removeDataOutsideTimeROI(roi);
+    TS_ASSERT_EQUALS(*tsp_input, *tsp_expected);
 
     // b2. First roi includes first value, second roi includes second value
     times = {DateAndTime("2007-11-30T16:17:15"), DateAndTime("2007-11-30T18:15:00")};
     times_expected = times;
-    log_input = std::make_shared<TimeSeriesProperty<double>>("two_values_b2", times, values);
-    log_expected = std::make_shared<TimeSeriesProperty<double>>("two_values_b2", times_expected, values_expected);
-    log_input->removeDataOutsideTimeROI(roi);
-    TS_ASSERT_EQUALS(*log_input, *log_expected);
+    tsp_input = std::make_unique<TimeSeriesProperty<double>>("two_values_b2", times, values);
+    tsp_expected = std::make_unique<TimeSeriesProperty<double>>("two_values_b2", times_expected, values_expected);
+    tsp_input->removeDataOutsideTimeROI(roi);
+    TS_ASSERT_EQUALS(*tsp_input, *tsp_expected);
 
     // c. TimeROI includes first value and not second - no changes
     times = {DateAndTime("2007-11-30T16:17:15"), DateAndTime("2007-11-30T16:18:25")};
     times_expected = times;
-    log_input = std::make_shared<TimeSeriesProperty<double>>("two_values_c", times, values);
-    log_expected = std::make_shared<TimeSeriesProperty<double>>("two_values_c", times_expected, values_expected);
-    log_input->removeDataOutsideTimeROI(roi);
-    TS_ASSERT_EQUALS(*log_input, *log_expected);
+    tsp_input = std::make_unique<TimeSeriesProperty<double>>("two_values_c", times, values);
+    tsp_expected = std::make_unique<TimeSeriesProperty<double>>("two_values_c", times_expected, values_expected);
+    tsp_input->removeDataOutsideTimeROI(roi);
+    TS_ASSERT_EQUALS(*tsp_input, *tsp_expected);
 
     // d. TimeROI includes second value and not first - no changes
     times = {DateAndTime("2007-11-30T16:17:00"), DateAndTime("2007-11-30T16:18:10")};
     times_expected = times;
-    log_input = std::make_shared<TimeSeriesProperty<double>>("two_values_d", times, values);
-    log_expected = std::make_shared<TimeSeriesProperty<double>>("two_values_d", times_expected, values_expected);
-    log_input->removeDataOutsideTimeROI(roi);
-    TS_ASSERT_EQUALS(*log_input, *log_expected);
+    tsp_input = std::make_unique<TimeSeriesProperty<double>>("two_values_d", times, values);
+    tsp_expected = std::make_unique<TimeSeriesProperty<double>>("two_values_d", times_expected, values_expected);
+    tsp_input->removeDataOutsideTimeROI(roi);
+    TS_ASSERT_EQUALS(*tsp_input, *tsp_expected);
 
     // e. TimeROI is before both values - keep first
     times = {DateAndTime("2007-11-30T16:18:35"), DateAndTime("2007-11-30T16:18:45")};
-    log_input = std::make_shared<TimeSeriesProperty<double>>("two_values_e", times, values);
+    tsp_input = std::make_unique<TimeSeriesProperty<double>>("two_values_e", times, values);
     times_expected = {times[0]};
     values_expected = {values[0]};
-    log_expected = std::make_shared<TimeSeriesProperty<double>>("two_values_e", times_expected, values_expected);
-    log_input->removeDataOutsideTimeROI(roi);
-    TS_ASSERT_EQUALS(*log_input, *log_expected);
+    tsp_expected = std::make_unique<TimeSeriesProperty<double>>("two_values_e", times_expected, values_expected);
+    tsp_input->removeDataOutsideTimeROI(roi);
+    TS_ASSERT_EQUALS(*tsp_input, *tsp_expected);
 
     // f. TimeROI is after both values - keep second
     times = {DateAndTime("2007-11-30T16:16:10"), DateAndTime("2007-11-30T16:16:45")};
-    log_input = std::make_shared<TimeSeriesProperty<double>>("two_values_f", times, values);
+    tsp_input = std::make_unique<TimeSeriesProperty<double>>("two_values_f", times, values);
     times_expected = {times[1]};   // second time
     values_expected = {values[1]}; // second value
-    log_expected = std::make_shared<TimeSeriesProperty<double>>("two_values_f", times_expected, values_expected);
-    log_input->removeDataOutsideTimeROI(roi);
-    TS_ASSERT_EQUALS(*log_input, *log_expected);
+    tsp_expected = std::make_unique<TimeSeriesProperty<double>>("two_values_f", times_expected, values_expected);
+    tsp_input->removeDataOutsideTimeROI(roi);
+    TS_ASSERT_EQUALS(*tsp_input, *tsp_expected);
 
     // 3. TimeSeriesProperty with three values
     values = {1., 2., 3.};
@@ -518,42 +518,42 @@ public:
     // a0 TimeROI entirely between the values - no changes
     times = {DateAndTime("2007-11-30T16:17:05"), DateAndTime("2007-11-30T16:18:00"),
              DateAndTime("2007-11-30T16:18:45")};
-    log_input = std::make_shared<TimeSeriesProperty<double>>("three_values_a0", times, values);
+    tsp_input = std::make_unique<TimeSeriesProperty<double>>("three_values_a0", times, values);
     times_expected = times;
     values_expected = values;
-    log_expected = std::make_shared<TimeSeriesProperty<double>>("three_values_a0", times_expected, values_expected);
-    log_input->removeDataOutsideTimeROI(roi);
-    TS_ASSERT_EQUALS(*log_input, *log_expected);
+    tsp_expected = std::make_unique<TimeSeriesProperty<double>>("three_values_a0", times_expected, values_expected);
+    tsp_input->removeDataOutsideTimeROI(roi);
+    TS_ASSERT_EQUALS(*tsp_input, *tsp_expected);
 
     // a. TimeROI includes first value only - keep the first two
     times = {DateAndTime("2007-11-30T16:17:15"), DateAndTime("2007-11-30T16:18:30"),
              DateAndTime("2007-11-30T16:18:45")};
-    log_input = std::make_shared<TimeSeriesProperty<double>>("three_values_a", times, values);
+    tsp_input = std::make_unique<TimeSeriesProperty<double>>("three_values_a", times, values);
     times_expected = {times[0], times[1]};
     values_expected = {values[0], values[1]};
-    log_expected = std::make_shared<TimeSeriesProperty<double>>("three_values_a", times_expected, values_expected);
-    log_input->removeDataOutsideTimeROI(roi);
-    TS_ASSERT_EQUALS(*log_input, *log_expected);
+    tsp_expected = std::make_unique<TimeSeriesProperty<double>>("three_values_a", times_expected, values_expected);
+    tsp_input->removeDataOutsideTimeROI(roi);
+    TS_ASSERT_EQUALS(*tsp_input, *tsp_expected);
 
     // b. TimeROI includes second value only - no changes
     times = {DateAndTime("2007-11-30T16:17:00"), DateAndTime("2007-11-30T16:17:15"),
              DateAndTime("2007-11-30T16:18:30")};
-    log_input = std::make_shared<TimeSeriesProperty<double>>("three_values_b", times, values);
+    tsp_input = std::make_unique<TimeSeriesProperty<double>>("three_values_b", times, values);
     times_expected = times;
     values_expected = values;
-    log_expected = std::make_shared<TimeSeriesProperty<double>>("three_values_b", times_expected, values_expected);
-    log_input->removeDataOutsideTimeROI(roi);
-    TS_ASSERT_EQUALS(*log_input, *log_expected);
+    tsp_expected = std::make_unique<TimeSeriesProperty<double>>("three_values_b", times_expected, values_expected);
+    tsp_input->removeDataOutsideTimeROI(roi);
+    TS_ASSERT_EQUALS(*tsp_input, *tsp_expected);
 
     // c. TimeROI includes third value only - keep the last two
     times = {DateAndTime("2007-11-30T16:17:00"), DateAndTime("2007-11-30T16:17:05"),
              DateAndTime("2007-11-30T16:18:20")};
-    log_input = std::make_shared<TimeSeriesProperty<double>>("three_values_c", times, values);
+    tsp_input = std::make_unique<TimeSeriesProperty<double>>("three_values_c", times, values);
     times_expected = {times[1], times[2]}; // last two
     values_expected = {values[1], values[2]};
-    log_expected = std::make_shared<TimeSeriesProperty<double>>("three_values_c", times_expected, values_expected);
-    log_input->removeDataOutsideTimeROI(roi);
-    TS_ASSERT_EQUALS(*log_input, *log_expected);
+    tsp_expected = std::make_unique<TimeSeriesProperty<double>>("three_values_c", times_expected, values_expected);
+    tsp_input->removeDataOutsideTimeROI(roi);
+    TS_ASSERT_EQUALS(*tsp_input, *tsp_expected);
   }
 
   void test_cloneInTimeROI() {
@@ -569,11 +569,11 @@ public:
     std::vector<double> values{1., 2., 3.};
     std::vector<double> values_expected{values[0], values[1]};
 
-    auto log_input = std::make_shared<TimeSeriesProperty<double>>("three_values", times, values);
-    auto log_expected = std::make_shared<TimeSeriesProperty<double>>("three_values", times_expected, values_expected);
-    auto log_result_base = std::shared_ptr<Property>(log_input->cloneInTimeROI(roi));
-    auto log_result = std::static_pointer_cast<TimeSeriesProperty<double>>(log_result_base);
-    TS_ASSERT_EQUALS(*log_result, *log_expected);
+    auto tsp_input = std::make_unique<TimeSeriesProperty<double>>("three_values", times, values);
+    auto tsp_expected = std::make_unique<TimeSeriesProperty<double>>("three_values", times_expected, values_expected);
+    auto tsp_result_base = std::shared_ptr<Property>(tsp_input->cloneInTimeROI(roi));
+    auto tsp_result = std::static_pointer_cast<TimeSeriesProperty<double>>(tsp_result_base);
+    TS_ASSERT_EQUALS(*tsp_result, *tsp_expected);
   }
 
   void test_filterByTimesN() {


### PR DESCRIPTION
**Description of work**
This PR implements filtering of time series properties managed by `LogManager`, according to a `TimeROI`. Time series values entirely within an ignore region of the supplied `TimeROI` will either be removed or not copied except for the last value before a use region and the first value after a use region.  Non-time series properties managed by `LogManager` will not be affected.

**To test:**
`../mantid/build/bin/APITest LogManagerTest test_removeDataOutsideTimeROI`
`../mantid/build/bin/APITest LogManagerTest test_cloneInTimeROI`

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->
Refs #34794
<!Fixes #xxxx.--> <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.