### PR TITLE
IgnorePartialOverlaps property for SofQWNormalisedPolygon

### DIFF
--- a/Framework/Algorithms/src/SofQWNormalisedPolygon.cpp
+++ b/Framework/Algorithms/src/SofQWNormalisedPolygon.cpp
@@ -271,7 +271,11 @@ const std::string SofQWNormalisedPolygon::category() const { return "Inelastic\\
 /**
  * Initialize the algorithm
  */
-void SofQWNormalisedPolygon::init() { SofQW::createCommonInputProperties(*this); }
+void SofQWNormalisedPolygon::init() {
+  SofQW::createCommonInputProperties(*this);
+  declareProperty(std::make_unique<PropertyWithValue<bool>>("IgnorePartialOverlaps", false),
+                  "If true, all output bins where the sum of all weights is not unity (1.0) will be replaced by NaNs.");
+}
 
 /** Checks that the input workspace and table have compatible dimensions
  * @return a map with the corresponding error messages
@@ -387,7 +391,8 @@ void SofQWNormalisedPolygon::exec() {
       }
 
       using FractionalRebinning::rebinToFractionalOutput;
-      rebinToFractionalOutput(Quadrilateral(ll, lr, ur, ul), inputWS, i, j, *outputWS, m_Qout);
+      rebinToFractionalOutput(Quadrilateral(ll, lr, ur, ul), inputWS, i, j, *outputWS, m_Qout, nullptr,
+                              this->getProperty("IgnorePartialOverlaps"));
 
       // Find which q bin this point lies in
       const MantidVec::difference_type qIndex = std::upper_bound(m_Qout.begin(), m_Qout.end(), lrQ) - m_Qout.begin();

--- a/Framework/DataObjects/inc/MantidDataObjects/FractionalRebinning.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/FractionalRebinning.h
@@ -55,7 +55,8 @@ MANTID_DATAOBJECTS_DLL void rebinToFractionalOutput(const Geometry::Quadrilatera
                                                     const API::MatrixWorkspace_const_sptr &inputWS, const size_t i,
                                                     const size_t j, DataObjects::RebinnedOutput &outputWS,
                                                     const std::vector<double> &verticalAxis,
-                                                    const DataObjects::RebinnedOutput_const_sptr &inputRB = nullptr);
+                                                    const DataObjects::RebinnedOutput_const_sptr &inputRB = nullptr,
+                                                    const bool ignorePartialOverlaps = false);
 
 /// Set finalize flag after fractional rebinning loop
 MANTID_DATAOBJECTS_DLL void finalizeFractionalRebin(DataObjects::RebinnedOutput &outputWS);

--- a/Framework/DataObjects/src/FractionalRebinning.cpp
+++ b/Framework/DataObjects/src/FractionalRebinning.cpp
@@ -567,6 +567,8 @@ void rebinToOutput(const Quadrilateral &inputQ, const MatrixWorkspace_const_sptr
  * It is used to take into account the input area fractions when calcuting
  * the final output fractions.
  * This can be null to indicate that the input was a standard 2D workspace.
+ * @param ignorePartialOverlaps A boolean indicating whether partial detector
+ * overlaps should be ignored.
  */
 void rebinToFractionalOutput(const Quadrilateral &inputQ, const MatrixWorkspace_const_sptr &inputWS, const size_t i,
                              const size_t j, RebinnedOutput &outputWS, const std::vector<double> &verticalAxis,


### PR DESCRIPTION
**Description of work**
This PR adds an `IgnorePartialOverlaps` option to the `SofQWNormalisedPolygon` algorithm. It is defaulted to false, but when true, the bins in which the sum of the weights is not unity (1.0) are set to nan. This option will be used to fix a bug in MSlice.
See #901

**To test:**
1. Open MSlice interface
2. Load `MARI28540_80meV.nxspe`
3. On the Cut tab, choose 0 to 10 for `|Q|`, and -2 to 2 for `DeltaE`
4. Click Plot
5. You should get a plot like this:

*There is no associated issue.*

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.