### PR TITLE
Fix for colourbar plot bug

### DIFF
--- a/Framework/PythonInterface/mantid/plots/datafunctions.py
+++ b/Framework/PythonInterface/mantid/plots/datafunctions.py
@@ -1260,8 +1260,7 @@ def update_colorbar_scale(figure, image, scale, vmin, vmax):
                 mantid.kernel.logger.warning(
                     "Minor ticks on colorbar scale cannot be shown " "as the range between min value and max value is too large"
                 )
-        figure.subplots_adjust(wspace=0.5, hspace=0.5)
-        colorbar = figure.colorbar(image, ax=figure.axes, ticks=locator, pad=0.06)
+        colorbar = figure.colorbar(image, ax=figure.axes, ticks=locator, pad=0.05)
         colorbar.set_label(label)
 
 

--- a/Framework/PythonInterface/test/python/mantid/plots/plotfunctionsTest.py
+++ b/Framework/PythonInterface/test/python/mantid/plots/plotfunctionsTest.py
@@ -286,35 +286,27 @@ class FunctionsTest(unittest.TestCase):
         fig.canvas.manager.superplot.set_bin_mode.assert_called_once_with(False)
 
     def test_create_subplots_axes_shape(self):
-        self._test_subplot_axes_shape_helper(cbar=False)
+        n_plots_to_expected_shape = {1: (1, 1), 2: (1, 2), 9: (3, 3), 10: (3, 4), 15: (4, 4)}
 
-    def test_create_subplots_axes_shape_with_cbar(self):
-        self._test_subplot_axes_shape_helper(cbar=True)
+        for n_plots in n_plots_to_expected_shape:
+            _, axes, _, _ = create_subplots(n_plots)
+            shape = axes.shape
+            expected_shape = n_plots_to_expected_shape[n_plots]
+            self.assertEqual(shape, expected_shape)
 
-    def test_create_subplots_creates_tight_figure(self):
+    def test_create_subplots_creates_tight_figure_by_default(self):
         from matplotlib.layout_engine import TightLayoutEngine
 
-        fig, _, _, _, _ = create_subplots(4)
+        fig, _, _, _ = create_subplots(4)
         layout_engine = fig.get_layout_engine()
         self.assertIsInstance(layout_engine, TightLayoutEngine)
 
-    def test_create_subplots_colour_bar_is_alongside_all_rows(self):
-        _, axes, _, _, cbar_axis = create_subplots(9, add_cbar_axis=True)
-        plots_height = 0
-        cbar_height = cbar_axis.bbox.height
-        for ax in axes[:, 0]:
-            plots_height += ax.bbox.height
+    def test_create_subplots_uses_given_layout_engine(self):
+        from matplotlib.layout_engine import ConstrainedLayoutEngine
 
-        # plots_height will be a bit less because of padding around the plots
-        self.assertLessEqual(plots_height, cbar_height)
-
-    def test_create_subplots_plots_in_colour_bar_column_are_the_same_size(self):
-        _, axes, _, _, _ = create_subplots(4, add_cbar_axis=True)
-        ax1_bbox = axes[0, 0].bbox
-        ax2_bbox = axes[0, 1].bbox
-
-        self.assertAlmostEqual(ax1_bbox.height, ax2_bbox.height, delta=0.01)
-        self.assertAlmostEqual(ax1_bbox.width, ax2_bbox.width, delta=0.01)
+        fig, _, _, _ = create_subplots(4, layout_engine="constrained")
+        layout_engine = fig.get_layout_engine()
+        self.assertIsInstance(layout_engine, ConstrainedLayoutEngine)
 
     # ------------- Failure tests -------------
     def test_that_manage_workspace_names_raises_on_mix_of_workspaces_and_names(self):
@@ -337,21 +329,6 @@ class FunctionsTest(unittest.TestCase):
             self.assertEqual(ax.get_xlabel(), err_ax.get_xlabel())
             # Compare title
             self.assertEqual(ax.get_title(), err_ax.get_title())
-
-    def _test_subplot_axes_shape_helper(self, cbar):
-        n_plots_to_correct_shape = {1: (1, 1), 2: (1, 2), 9: (3, 3), 10: (3, 4), 15: (4, 4)}
-
-        for n_plots in n_plots_to_correct_shape:
-            (
-                _,
-                axes,
-                _,
-                _,
-                _,
-            ) = create_subplots(n_plots, add_cbar_axis=cbar)
-            shape = axes.shape
-            expected_shape = n_plots_to_correct_shape[n_plots]
-            self.assertEqual(shape, expected_shape)
 
 
 if __name__ == "__main__":

--- a/qt/python/mantidqt/mantidqt/plotting/functions.py
+++ b/qt/python/mantidqt/mantidqt/plotting/functions.py
@@ -251,7 +251,8 @@ def pcolormesh(workspaces, fig=None, color_norm=None, normalize_by_bin_width=Non
     # create a subplot of the appropriate number of dimensions
     # extend in number of columns if the number of plottables is not a square number
     workspaces_len = len(workspaces)
-    fig, axes, nrows, ncols, cbar_axis = create_subplots(workspaces_len, fig=fig, add_cbar_axis=True)
+    # constrained layout since adding colour bar later
+    fig, axes, nrows, ncols = create_subplots(workspaces_len, fig=fig, layout_engine="constrained")
 
     plots = []
     row_idx, col_idx = 0, 0
@@ -281,11 +282,8 @@ def pcolormesh(workspaces, fig=None, color_norm=None, normalize_by_bin_width=Non
     for pt in plots:
         pt.set_clim(colorbar_min, colorbar_max)
 
-    # Adjust locations to ensure the plots don't overlap
-    fig.subplots_adjust(wspace=SUBPLOT_WSPACE, hspace=SUBPLOT_HSPACE)
-
     axes = axes.ravel()
-    colorbar = fig.colorbar(pcm, cax=cbar_axis)
+    colorbar = fig.colorbar(pcm, ax=axes)
     add_colorbar_label(colorbar, axes)
 
     if fig.canvas.manager is not None:

--- a/qt/python/mantidqt/mantidqt/project/plotsloader.py
+++ b/qt/python/mantidqt/mantidqt/project/plotsloader.py
@@ -97,7 +97,7 @@ class PlotsLoader(object):
             for cargs_dict in sublist:
                 if "norm" in cargs_dict and type(cargs_dict["norm"]) is dict:
                     cargs_dict["norm"] = self.restore_normalise_obj_from_dict(cargs_dict["norm"])
-        fig, axes_matrix, _, _, _ = create_subplots(len(creation_args))
+        fig, axes_matrix, _, _ = create_subplots(len(creation_args))
         axes_list = axes_matrix.flatten().tolist()
         for ax, cargs_list in zip(axes_list, creation_args):
             creation_args_copy = copy.deepcopy(cargs_list)

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/cutviewer/view.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/cutviewer/view.py
@@ -168,7 +168,7 @@ class CutViewerView(QWidget):
         self.layout.addWidget(self.table)
 
     def _setup_figure_widget(self):
-        fig, _, _, _, _ = create_subplots(1)
+        fig, _, _, _ = create_subplots(1)
         self.figure = fig
         self.figure.canvas = FigureCanvas(self.figure)
         toolbar = MantidNavigationToolbar(self.figure.canvas, self)


### PR DESCRIPTION
**Purpose of work**
Fix for bug (introduced in #35195) where if you opened and applied plot setting on a colourfill (or contour) plot, the colour bar positioning would not be recognised, and the plot would draw underneath it.

**Summary of work**
Reverted my complicated changes required for using a tight layout and a colour bar. Now you can pass a layout engine to `create_subplots()` to allow the use of a `constrained` layout for plots with a colour bar. This is what's recommended.

Also altered some tests to make sense with the changes.

**To test:**

- Load `164198.nxs`, `164199.nxs`, `164200.nxs` and group them together.
- Expand the group and plot a colourfill plot for `164198.nxs`
- [ ] As you resize the window, no text should become obscured and the plot should behave as expected
- Open the plot settings (settings icon on the toolbar), change nothing, and click 'Apply'.
- [ ] Nothing on the plot should change (apart from some very minor adjustments potentially).
- Open the plot settings and change some settings (colour bar and axes limits and scales etc.)
- [ ] The plot should update according to your changes
- Now right-click the workspace group and plot a colourfill for all three workspaces.
- [ ] Repeat the checks from before.

- [ ] Also experiment with contour plots (they should be the same)
- [ ] Check that other plot types have not been affected

*There is no associated issue.*

*This does not require release notes* because **the functionality is covered by the original release note in #35195**

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.