### PR TITLE
Improve readability of Jenkins nightly pipeline in Jenkins UI

### DIFF
--- a/buildconfig/Jenkins/Conda/nightly_build_and_deploy.jenkinsfile
+++ b/buildconfig/Jenkins/Conda/nightly_build_and_deploy.jenkinsfile
@@ -78,7 +78,7 @@ pipeline {
       }
     }
     // Store the git commit hash in an environment variable so that we can use
-    // the same commit for all stages of the pipeline. This is perfomed by using
+    // the same commit for all stages of the pipeline. This is performed by using
     // the following step at the start of each subsequent stage:
     //   checkout scm: [$class: 'GitSCM', branches: [[name: "${GIT_SHA}"]], extensions: [[pruneTags: true]]]
     stage('Store git commit') {
@@ -92,86 +92,161 @@ pipeline {
     // Verify developer environment build/test while also building conda packages
     // in parallel. Running both steps in parallel reduces the overall pipeline
     // time, however if either part breaks then no publishing occurs.
-    stage('Build/Test: Development, Package: Conda') {
-      matrix {
-        axes {
-          // See the agent label above when changing these. They will need to
-          // match labels on the agents
-          axis {
-            name 'PLATFORM'
-            values 'linux-64', 'win-64', 'osx-64'
+    stage('Build and test, Conda packaging') {
+      parallel {
+        stage('build and test: linux-64') {
+          when {
+            beforeAgent true
+            beforeOptions true
+              anyOf {
+                expression { env.BUILD_DEVEL == 'all' }
+                expression { env.BUILD_DEVEL == 'linux-64' }
+            }
           }
-          axis {
-            name 'BUILD_TYPE'
-            values 'conda-devel', 'conda-release'
+          agent { label 'linux-64' }
+          options { timestamps () }
+          steps {
+            checkoutSource("${GIT_SHA}")
+            build_and_test('linux-64')
+          }
+          post {
+            always {
+              archive_ctest_log()
+              publish_test_reports()
+            }
           }
         }
-        stages {
-          stage('build and test') {
-            when {
-              beforeAgent true
-              beforeOptions true
-              allOf {
-                expression { env.BUILD_TYPE == 'conda-devel' }
-                anyOf {
-                  expression { env.BUILD_DEVEL == 'all' }
-                  expression { env.BUILD_DEVEL == "${PLATFORM}" }
-                }
-              }
-            }
-            agent { label "${PLATFORM}" }
-            options { timestamps () }
-            steps {
-              checkoutSource("${GIT_SHA}")
-              build_and_test("${PLATFORM}")
-            }
-            post {
-              always {
-                archive_ctest_log()
-                publish_test_reports()
-              }
+        stage('build and test: win-64') {
+          when {
+            beforeAgent true
+            beforeOptions true
+            anyOf {
+              expression { env.BUILD_DEVEL == 'all' }
+              expression { env.BUILD_DEVEL == 'win-64' }
             }
           }
-          stage('package conda') {
-            when {
-              beforeAgent true
-              beforeOptions true
-              allOf {
-                environment name: 'BUILD_TYPE', value: 'conda-release'
-                // Messy part of the pipeline. We build mantiddocs (noarch) on
-                // Linux but this is needed to package up mantidworkbench version so
-                // we pick the simple option of always building the linux one
-                anyOf {
-                  expression { env.PLATFORM.startsWith('linux') }
-                  expression { env.BUILD_PACKAGE == "${PLATFORM}" }
-                  expression { env.BUILD_PACKAGE == 'all' }
-                }
-              }
+          agent { label 'win-64' }
+          options { timestamps () }
+          steps {
+            checkoutSource("${GIT_SHA}")
+            build_and_test('win-64')
+          }
+          post {
+            always {
+              archive_ctest_log()
+              publish_test_reports()
             }
-            agent { label "${PLATFORM}" }
-            options {
-                timestamps ()
-                retry(3)
+          }
+        }
+        stage('build and test: osx-64') {
+          when {
+            beforeAgent true
+            beforeOptions true
+              anyOf {
+                expression { env.BUILD_DEVEL == 'all' }
+                expression { env.BUILD_DEVEL == 'osx-64' }
             }
-            steps {
-              // Clean up conda-bld before we start to avoid any
-              // confusion with old packages
-              dir('conda-bld') {
-                 deleteDir()
-              }
-              checkoutSource("${GIT_SHA}")
-              // Build the base set of packages (ones not required for mantidworkbench)
-              // in parallel
-              package_conda("${PLATFORM}", "base")
-              archive_env_logs("${PLATFORM}")
-              archive_conda_packages("${PLATFORM}", false)
-              archive_conda_packages("noarch", true)
+          }
+          agent { label 'osx-64' }
+          options { timestamps () }
+          steps {
+            checkoutSource("${GIT_SHA}")
+            build_and_test('osx-64')
+          }
+          post {
+            always {
+              archive_ctest_log()
+              publish_test_reports()
             }
+          }
+        }
+        stage('package conda: linux-64') {
+          when {
+            beforeAgent true
+            beforeOptions true
+            // The mantiddocs package is built on linux so we always need to build the linux
+            // conda packages unless 'none' is specified.
+            expression { env.BUILD_PACKAGE != 'none' }
+          }
+          agent { label 'linux-64' }
+          options {
+              timestamps ()
+              retry(3)
+          }
+          steps {
+            // Clean up conda-bld before we start to avoid any
+            // confusion with old packages
+            dir('conda-bld') {
+               deleteDir()
+            }
+            checkoutSource("${GIT_SHA}")
+            // Build the base set of packages (ones not required for mantidworkbench)
+            // in parallel
+            package_conda('linux-64', 'base')
+            archive_env_logs('linux-64')
+            archive_conda_packages('linux-64')
+            archive_conda_packages('noarch')
+          }
+        }
+        stage('package conda: win-64') {
+          when {
+            beforeAgent true
+            beforeOptions true
+            anyOf {
+              expression { env.BUILD_PACKAGE == 'win-64' }
+              expression { env.BUILD_PACKAGE == 'all' }
+            }
+          }
+          agent { label 'win-64' }
+          options {
+              timestamps ()
+              retry(3)
+          }
+          steps {
+            // Clean up conda-bld before we start to avoid any
+            // confusion with old packages
+            dir('conda-bld') {
+               deleteDir()
+            }
+            checkoutSource("${GIT_SHA}")
+            // Build the base set of packages (ones not required for mantidworkbench)
+            // in parallel
+            package_conda('win-64', 'base')
+            archive_env_logs('win-64')
+            archive_conda_packages('win-64')
+          }
+        }
+        stage('package conda: osx-64') {
+          when {
+            beforeAgent true
+            beforeOptions true
+            anyOf {
+              expression { env.BUILD_PACKAGE == 'osx-64' }
+              expression { env.BUILD_PACKAGE == 'all' }
+            }
+          }
+          agent { label 'osx-64' }
+          options {
+              timestamps ()
+              retry(3)
+          }
+          steps {
+            // Clean up conda-bld before we start to avoid any
+            // confusion with old packages
+            dir('conda-bld') {
+               deleteDir()
+            }
+            checkoutSource("${GIT_SHA}")
+            // Build the base set of packages (ones not required for mantidworkbench)
+            // in parallel
+            package_conda('osx-64', 'base')
+            archive_env_logs('osx-64')
+            archive_conda_packages('osx-64')
           }
         }
       }
     }
-    stage('Package: Workbench') {
+    stage('Package workbench') {
       matrix {
         axes {
           axis {
@@ -180,7 +255,7 @@ pipeline {
           }
         }
         stages {
-          stage('') {
+          stage('package workbench') {
             when {
               beforeAgent true
               beforeOptions true
@@ -210,7 +285,7 @@ pipeline {
                 flatten: false
               package_conda("${PLATFORM}", "workbench")
               archive_env_logs("${PLATFORM}")
-              archive_conda_packages("${PLATFORM}", false)
+              archive_conda_packages("${PLATFORM}")
               package_standalone()
               archive_standalone_package("${PLATFORM}")
             }
@@ -424,9 +499,9 @@ def prerelease_option() {
   return prerelease_flag
 }
 
-def archive_conda_packages(platform, allowEmpty) {
+def archive_conda_packages(platform) {
   archiveArtifacts artifacts: "**/conda-bld/${platform}/*.tar.bz2",
-    allowEmptyArchive: allowEmpty,
+    allowEmptyArchive: false,
     fingerprint: true,
     onlyIfSuccessful: true
 }
@@ -457,7 +532,7 @@ def archive_ctest_log(){
 
 def archive_env_logs(platform) {
   env_log_dir = "**/conda-bld/${platform}/env_logs"
-  archiveArtifacts artifacts: env_log_dir += "/**/*.*",
+  archiveArtifacts artifacts: env_log_dir += "/**/*.txt",
     allowEmptyArchive: false,
     fingerprint: true,
     onlyIfSuccessful: false


### PR DESCRIPTION
**Description of work**
Removed the matrix section of the pipeline for the build/test and conda packaging (mantid, mantidqt, mantiddocs) stages and replaced it with a parallel section for all those stages.

**Purpose of work**
The previous implementation was a neat way to significantly reduce code duplication, but the stage view on the nightly pipeline in Jenkins looks like this:
![image](https://user-images.githubusercontent.com/8058899/234904552-fcaf2f45-79f1-42ea-a269-a230fe872127.png)
and it's difficult to navigate to the logs that you're interested in.
Now it is easier to understand:
![image](https://user-images.githubusercontent.com/8058899/234907524-96cf5fc4-a622-463b-8d7b-06c95ea31ae1.png)
The graph view is also much simpler. It goes from this:
https://builds.mantidproject.org/view/Nightly%20Pipelines/job/main_nightly_deployment_prototype/542/pipeline-graph/
to this:
https://builds.mantidproject.org/job/Core_Team_test_pipeline/33/pipeline-graph/

**Summary of work**
Replaced matrix section with a parallel scection in the nightly Jenkins pipeline.

**Further detail of work**
We have left the matrix section for the workbench packaging stage because that is a lot easier to follow. Also named the stage within the workbench packaging matrix to avoid it saying "error".


**To test:**
- Ensure that this pipeline build successully builds all packages:
https://builds.mantidproject.org/job/Core_Team_test_pipeline/33/
- examine the new pipeline stage view on the [Core_Team_test_pipeline](https://builds.mantidproject.org/job/Core_Team_test_pipeline/) and compare it with the [nightly pipeline](https://builds.mantidproject.org/view/Nightly%20Pipelines/job/main_nightly_deployment_prototype/)

Fixes #34651 

*This does not require release notes* because **it will not affect the users**


<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.