### PR TITLE
Copy column of ragged workspace without crashing

### DIFF
--- a/docs/source/release/v6.7.0/Workbench/Bugfixes/34376.rst
+++ b/docs/source/release/v6.7.0/Workbench/Bugfixes/34376.rst
@@ -1,0 +1,1 @@
+- Fixed a bug where copying a column with blank values from a ragged workspace data table could crash Mantid Workbench.

--- a/qt/python/mantidqt/mantidqt/widgets/workspacedisplay/data_copier.py
+++ b/qt/python/mantidqt/mantidqt/widgets/workspacedisplay/data_copier.py
@@ -61,11 +61,18 @@ class DataCopier(UserNotifier):
 
         selected_columns = selection_model.selectedColumns()  # type: list
 
+        # introduced since a row from a ragged workspace row may not read the selected column index
+        def safe_index(row_index, column_index):
+            row = ws_read(row_index)
+            if column_index < len(row):
+                return row[column_index]
+            return ""
+
         # Qt gives back a QModelIndex, we need to extract the column from it
         column_data = []
         for index in selected_columns:
             column = index.column()
-            data = [str(ws_read(row)[column]) for row in range(num_rows)]
+            data = [str(safe_index(row, column)) for row in range(num_rows)]
             column_data.append(data)
 
         all_string_rows = []

--- a/qt/python/mantidqt/mantidqt/widgets/workspacedisplay/matrix/presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/workspacedisplay/matrix/presenter.py
@@ -181,15 +181,15 @@ class MatrixWorkspaceDisplay(ObservingPresenter, DataCopier):
                         table_ws.setCell(j, 0, ws.getAxis(1).getValue(j))
                     else:
                         table_ws.setCell(j, 0, j)
-                _set_cell_if_exists(table_ws, data_e, col_e, col, j)
-                _set_cell_if_exists(table_ws, data_y, col_y, col, j)
+                _set_cell_if_exists(table_ws, j, col_e, data_e, col)
+                _set_cell_if_exists(table_ws, j, col_y, data_y, col)
 
             if self.hasDx:
                 table_ws.addColumn("double", "XE" + str(col))
                 col_dx = num_cols * i + 3
                 for j in range(num_rows):
                     data_dx = ws.readDx(j)
-                    _set_cell_if_exists(table_ws, data_dx, col_dx, col, j)
+                    _set_cell_if_exists(table_ws, j, col_dx, data_dx, col)
 
     def action_copy_cells(self, table):
         self.copy_cells(table)
@@ -287,12 +287,12 @@ def _create_empty_table_workspace(name: str, num_rows: int) -> ITableWorkspace:
 
 
 def _set_cell_if_exists(
-    table,
-    data,
-    col,
-    col_n,
-    row_n,
+    target_table_ws,
+    target_row_index,
+    target_col_index,
+    data_col,
+    data_col_index,
 ):
     # ragged workspaces could have data rows shorter than the number of columns
-    if col_n < len(data):
-        table.setCell(row_n, col, data[col_n])
+    if data_col_index < len(data_col):
+        target_table_ws.setCell(target_row_index, target_col_index, data_col[data_col_index])

--- a/qt/python/mantidqt/mantidqt/widgets/workspacedisplay/matrix/presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/workspacedisplay/matrix/presenter.py
@@ -181,19 +181,15 @@ class MatrixWorkspaceDisplay(ObservingPresenter, DataCopier):
                         table_ws.setCell(j, 0, ws.getAxis(1).getValue(j))
                     else:
                         table_ws.setCell(j, 0, j)
-                # ragged workspaces could have data rows shorter than the number of columns
-                if col < len(data_e):
-                    table_ws.setCell(j, col_e, data_e[col])
-                if col < len(data_y):
-                    table_ws.setCell(j, col_y, data_y[col])
+                _set_cell_if_exists(table_ws, data_e, col_e, col, j)
+                _set_cell_if_exists(table_ws, data_y, col_y, col, j)
 
             if self.hasDx:
                 table_ws.addColumn("double", "XE" + str(col))
                 col_dx = num_cols * i + 3
                 for j in range(num_rows):
                     data_dx = ws.readDx(j)
-                    if col < len(data_dx):
-                        table_ws.setCell(j, col_dx, data_dx[col])
+                    _set_cell_if_exists(table_ws, data_dx, col_dx, col, j)
 
     def action_copy_cells(self, table):
         self.copy_cells(table)
@@ -288,3 +284,15 @@ def _create_empty_table_workspace(name: str, num_rows: int) -> ITableWorkspace:
     table = CreateEmptyTableWorkspace(OutputWorkspace=name)
     table.setRowCount(num_rows)
     return table
+
+
+def _set_cell_if_exists(
+    table,
+    data,
+    col,
+    col_n,
+    row_n,
+):
+    # ragged workspaces could have data rows shorter than the number of columns
+    if col_n < len(data):
+        table.setCell(row_n, col, data[col_n])

--- a/qt/python/mantidqt/mantidqt/widgets/workspacedisplay/matrix/presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/workspacedisplay/matrix/presenter.py
@@ -181,15 +181,19 @@ class MatrixWorkspaceDisplay(ObservingPresenter, DataCopier):
                         table_ws.setCell(j, 0, ws.getAxis(1).getValue(j))
                     else:
                         table_ws.setCell(j, 0, j)
-                table_ws.setCell(j, col_e, data_e[col])
-                table_ws.setCell(j, col_y, data_y[col])
+                # ragged workspaces could have data rows shorter than the number of columns
+                if col < len(data_e):
+                    table_ws.setCell(j, col_e, data_e[col])
+                if col < len(data_y):
+                    table_ws.setCell(j, col_y, data_y[col])
 
             if self.hasDx:
                 table_ws.addColumn("double", "XE" + str(col))
                 col_dx = num_cols * i + 3
                 for j in range(num_rows):
                     data_dx = ws.readDx(j)
-                    table_ws.setCell(j, col_dx, data_dx[col])
+                    if col < len(data_dx):
+                        table_ws.setCell(j, col_dx, data_dx[col])
 
     def action_copy_cells(self, table):
         self.copy_cells(table)


### PR DESCRIPTION
**Description of work**

![image](https://user-images.githubusercontent.com/35813666/235102942-edcb12e5-1960-41d6-935e-b3549646f405.png)

Previously, when copying a column from a ragged with missing values (like above) Workbench would crash. This PR adds a safe index check to ensure no out of range exceptions occur.

**To test:**

Run this script

```
from mantid.simpleapi import *
import matplotlib.pyplot as plt
import numpy as np
ws = CreateWorkspace([0,1,2,3,4,2,3,4,5,6],[0,1,2,3,4,3,4,5,6,7], NSpec=2)
ws2 = CreateWorkspace([0,1,2,3],[0,1,2,3])
ws3 = CreateWorkspace([0,1,2,3,4],[0,1,2,3,7])

ConjoinWorkspaces(ws, ws2, CheckOverlapping=False)
ConjoinWorkspaces(ws, ws3, CheckOverlapping=False)
```

- Right-click on the workspace and select 'Show Data'.
- Make a copy of the final column and check Workbench doesn't crash and that what is copied is sensible.
- Try copying a combination of rows and columns as well as the whole table and again check that this works as expected.

Fixes #34376 

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.