### PR TITLE
Remove A0 parameter from Redfield function

### DIFF
--- a/Framework/PythonInterface/plugins/functions/Redfield.py
+++ b/Framework/PythonInterface/plugins/functions/Redfield.py
@@ -10,6 +10,7 @@ from mantid.api import IFunction1D, FunctionFactory
 from mantid.kernel import PhysicalConstants
 
 import numpy as np
+from math import pi
 
 
 class Redfield(IFunction1D):
@@ -24,7 +25,8 @@ class Redfield(IFunction1D):
         Hloc = self.getParameterValue("Hloc")
         tau = self.getParameterValue("Tau")
         gmu = PhysicalConstants.MuonGyromagneticRatio
-        return 2 * np.power((gmu * Hloc), 2) * tau / (1 + np.power((gmu * x * tau), 2))
+        gama = 2 * pi * gmu
+        return 2 * np.power((gama * Hloc), 2) * tau / (1 + np.power((gama * x * tau), 2))
 
 
 FunctionFactory.subscribe(Redfield)

--- a/Framework/PythonInterface/plugins/functions/Redfield.py
+++ b/Framework/PythonInterface/plugins/functions/Redfield.py
@@ -17,16 +17,14 @@ class Redfield(IFunction1D):
         return "Muon\\MuonModelling"
 
     def init(self):
-        self.declareParameter("A0", 1)
         self.declareParameter("Hloc", 0.1, "Local magnetic field (G)")
         self.declareParameter("Tau", 0.1, "Correlation time of muon spins (microsec)")
 
     def function1D(self, x):
-        A0 = self.getParameterValue("A0")
         Hloc = self.getParameterValue("Hloc")
         tau = self.getParameterValue("Tau")
         gmu = PhysicalConstants.MuonGyromagneticRatio
-        return A0 * 2 * np.power((gmu * Hloc), 2) * tau / (1 + np.power((gmu * x * tau), 2))
+        return 2 * np.power((gmu * Hloc), 2) * tau / (1 + np.power((gmu * x * tau), 2))
 
 
 FunctionFactory.subscribe(Redfield)

--- a/Framework/PythonInterface/test/python/plugins/functions/RedfieldTest.py
+++ b/Framework/PythonInterface/test/python/plugins/functions/RedfieldTest.py
@@ -27,7 +27,7 @@ class RedfieldTest(unittest.TestCase):
             self.fail(msg.format(*[str(i) for i in (output, input, expected)]))
 
     def test_do_fit(self):
-        do_a_fit(np.arange(16, 0.2), "Redfield", guess=dict(Hloc=0.1, Tau=0.1), target=dict(Hloc=0.1, Tau=0.1), atol=0.01)
+        do_a_fit(np.arange(0.1, 16, 0.2), "Redfield", guess=dict(Hloc=0.1, Tau=0.1), target=dict(Hloc=0.1, Tau=0.1), atol=0.01)
 
 
 if __name__ == "__main__":

--- a/Framework/PythonInterface/test/python/plugins/functions/RedfieldTest.py
+++ b/Framework/PythonInterface/test/python/plugins/functions/RedfieldTest.py
@@ -18,7 +18,7 @@ class RedfieldTest(unittest.TestCase):
 
     def test_function_output(self):
         input = np.linspace(0, 1000, 4)  # Between 0-1000 Gauss
-        expected = [0.91847597, 0.76278678, 0.5056509, 0.3237545]
+        expected = [0.091847597, 0.076278678, 0.05056509, 0.03237545]
         tolerance = 1.0e-05
         function_params = {"Hloc": 50, "Tau": 0.1}
         status, output = check_output("Redfield", input, expected, tolerance, **function_params)

--- a/Framework/PythonInterface/test/python/plugins/functions/RedfieldTest.py
+++ b/Framework/PythonInterface/test/python/plugins/functions/RedfieldTest.py
@@ -20,16 +20,14 @@ class RedfieldTest(unittest.TestCase):
         input = np.linspace(0, 1000, 4)  # Between 0-1000 Gauss
         expected = [0.91847597, 0.76278678, 0.5056509, 0.3237545]
         tolerance = 1.0e-05
-        function_params = {"A0": 10, "Hloc": 50, "Tau": 0.1}
+        function_params = {"Hloc": 50, "Tau": 0.1}
         status, output = check_output("Redfield", input, expected, tolerance, **function_params)
         if not status:
             msg = "Computed output {} from input {} unequal to expected: {}"
             self.fail(msg.format(*[str(i) for i in (output, input, expected)]))
 
     def test_do_fit(self):
-        do_a_fit(
-            np.arange(0.1, 16, 0.2), "Redfield", guess=dict(A0=0.2, Hloc=0.1, Tau=0.1), target=dict(A0=0.2, Hloc=0.1, Tau=0.1), atol=0.01
-        )
+        do_a_fit(np.arange(16, 0.2), "Redfield", guess=dict(Hloc=0.1, Tau=0.1), target=dict(Hloc=0.1, Tau=0.1), atol=0.01)
 
 
 if __name__ == "__main__":

--- a/Framework/PythonInterface/test/python/plugins/functions/RedfieldTest.py
+++ b/Framework/PythonInterface/test/python/plugins/functions/RedfieldTest.py
@@ -18,7 +18,7 @@ class RedfieldTest(unittest.TestCase):
 
     def test_function_output(self):
         input = np.linspace(0, 1000, 4)  # Between 0-1000 Gauss
-        expected = [0.091847597, 0.076278678, 0.05056509, 0.03237545]
+        expected = [3.62599778, 0.40031891, 0.10911462, 0.04931991]
         tolerance = 1.0e-05
         function_params = {"Hloc": 50, "Tau": 0.1}
         status, output = check_output("Redfield", input, expected, tolerance, **function_params)

--- a/docs/source/fitting/fitfunctions/Redfield.rst
+++ b/docs/source/fitting/fitfunctions/Redfield.rst
@@ -11,11 +11,9 @@ Description
 
 The Redfield formula for the LF dependence on the muon spin relaxation rate.
 
-.. math:: \Lambda(t)= A_0\frac{2\gamma^2_\mu H^2_\text{loc}\tau}{1+\gamma^2_\mu H^2_\text{LF} \tau^2}
+.. math:: \Lambda(t)= \frac{2\gamma^2_\mu H^2_\text{loc}\tau}{1+\gamma^2_\mu H^2_\text{LF} \tau^2}
 
 where,
-
-:math:`A_0` is the amplitude of asymmetry,
 
 :math:`H_\text{loc}` is the local magnetic field,
 

--- a/docs/source/release/v6.7.0/Framework/Fit_Functions/New_features/35490.rst
+++ b/docs/source/release/v6.7.0/Framework/Fit_Functions/New_features/35490.rst
@@ -1,0 +1,1 @@
+- The A0 paramter in the Redfield function has been removed


### PR DESCRIPTION
**Description of work**
This PR removes A0 from the Redfield function.

**Purpose of work**
<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
-->
 The parameter has been removed because it causes instability in the fitting behavior. 


**Report to:** Peter

**Summary of work**
<!-- Please provide a short, high level description of the work that was done.
-->
The parameter A0 has been removed from the Redfield function

**Further detail of work**
<!-- Please provide a more detailed description of the work that has been undertaken.
-->
The parameter A0 has been removed from the fitting function Redfield function. Previously, there were three parameters (A0, Hloc, Tau) in the Redfield function including the A0 parameter. Now, the function supports only two parameters (Hloc, Tau) and the A0 parameter has been removed.
**To test:**
- make sure the unit test pass.
- try to fit a workspace with the Redfield using the fit browser

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

Fixes #35474. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.