### PR TITLE
change to SaveNexusProcessed for GroupingWorkspace

### DIFF
--- a/Framework/DataHandling/src/SaveNexusProcessed.cpp
+++ b/Framework/DataHandling/src/SaveNexusProcessed.cpp
@@ -239,10 +239,12 @@ void SaveNexusProcessed::doExec(const Workspace_sptr &inputWorkspace,
   const std::string workspaceID = inputWorkspace->id();
   if ((workspaceID.find("Workspace2D") == std::string::npos) &&
       (workspaceID.find("RebinnedOutput") == std::string::npos) &&
-      (workspaceID.find("WorkspaceSingleValue") == std::string::npos) && !m_eventWorkspace && !tableWorkspace &&
+      (workspaceID.find("WorkspaceSingleValue") == std::string::npos) &&
+      (workspaceID.find("GroupingWorkspace") == std::string::npos) && !m_eventWorkspace && !tableWorkspace &&
       !offsetsWorkspace && !maskWorkspace)
     throw Exception::NotImplementedError("SaveNexusProcessed passed invalid workspaces. Must be Workspace2D, "
-                                         "EventWorkspace, ITableWorkspace, OffsetsWorkspace or MaskWorkspace.");
+                                         "EventWorkspace, ITableWorkspace, OffsetsWorkspace, "
+                                         "GroupingWorkspace, or MaskWorkspace.");
 
   // Create progress object for initial part - depends on whether events are
   // processed

--- a/Testing/SystemTests/tests/framework/SaveLoadNexusProcessed.py
+++ b/Testing/SystemTests/tests/framework/SaveLoadNexusProcessed.py
@@ -94,9 +94,6 @@ class SaveLoadNexusProcessedEmptySampleNameTest(SaveLoadNexusProcessedTestBase):
     def savedFilename(self):
         return "tmp_saveload_nexusprocessed_emptysamplename"
 
-    def validate(self):
-        return self.compareWorkspaces()
-
 
 class SaveLoadNexusProcessedNoDetectorsSpectraNumbersTest(SaveLoadNexusProcessedTestBase):
     def createTestWorkspace(self):
@@ -106,9 +103,6 @@ class SaveLoadNexusProcessedNoDetectorsSpectraNumbersTest(SaveLoadNexusProcessed
     def savedFilename(self):
         return "tmp_saveload_nexusprocessed_nodetectorsspectranumbers"
 
-    def validate(self):
-        return self.compareWorkspaces()
-
 
 class SaveLoadNexusProcessedGroupingWorkspaceTest(SaveLoadNexusProcessedTestBase):
     def createTestWorkspace(self):
@@ -117,6 +111,3 @@ class SaveLoadNexusProcessedGroupingWorkspaceTest(SaveLoadNexusProcessedTestBase
 
     def savedFilename(self):
         return "tmp_saveload_nexusprocessed_emptygroup"
-
-    def validate(self):
-        return self.compareWorkspaces()

--- a/Testing/SystemTests/tests/framework/SaveLoadNexusProcessed.py
+++ b/Testing/SystemTests/tests/framework/SaveLoadNexusProcessed.py
@@ -106,8 +106,13 @@ class SaveLoadNexusProcessedNoDetectorsSpectraNumbersTest(SaveLoadNexusProcessed
 
 class SaveLoadNexusProcessedGroupingWorkspaceTest(SaveLoadNexusProcessedTestBase):
     def createTestWorkspace(self):
-        LoadEmptyInstrument(InstrumentName="SNAP", OutputWorkspace="test_in")
-        CreateGroupingWorkspace(InputWorkspace="test_in", GroupDetectorsBy="Column", OutputWorkspace=self.test_ws_name)
+        CreateWorkspace(OutputWorkspace="idf", DataX="1", DataY="1", WorkspaceTitle="SNAP")
+
+        LoadInstrument(Workspace="idf", InstrumentName="SNAP", MonitorList="-2--1", RewriteSpectraMap="False")
+
+        CreateGroupingWorkspace(InputWorkspace="idf", GroupDetectorsBy="Column", OutputWorkspace=self.test_ws_name)
+        # title must be manually added for logs to match
+        mtd[self.test_ws_name].setTitle("empty grouping workspace")
 
     def savedFilename(self):
         return "tmp_saveload_nexusprocessed_emptygroup"

--- a/Testing/SystemTests/tests/framework/SaveLoadNexusProcessed.py
+++ b/Testing/SystemTests/tests/framework/SaveLoadNexusProcessed.py
@@ -21,7 +21,6 @@ def create_file_path(base_name):
 
 
 class SaveLoadNexusProcessedTestBase(systemtesting.MantidSystemTest, metaclass=ABCMeta):
-
     filename = None
     test_ws_name = "input_ws"
     loaded_ws_name = "loaded"
@@ -106,6 +105,18 @@ class SaveLoadNexusProcessedNoDetectorsSpectraNumbersTest(SaveLoadNexusProcessed
 
     def savedFilename(self):
         return "tmp_saveload_nexusprocessed_nodetectorsspectranumbers"
+
+    def validate(self):
+        return self.compareWorkspaces()
+
+
+class SaveLoadNexusProcessedGroupingWorkspaceTest(SaveLoadNexusProcessedTestBase):
+    def createTestWorkspace(self):
+        LoadEmptyInstrument(InstrumentName="SNAP", OutputWorkspace="test_in")
+        CreateGroupingWorkspace(InputWorkspace="test_in", GroupDetectorsBy="Column", OutputWorkspace=self.test_ws_name)
+
+    def savedFilename(self):
+        return "tmp_saveload_nexusprocessed_emptygroup"
 
     def validate(self):
         return self.compareWorkspaces()

--- a/docs/source/release/v6.7.0/Framework/Data_Objects/New_features/35493.rst
+++ b/docs/source/release/v6.7.0/Framework/Data_Objects/New_features/35493.rst
@@ -1,0 +1,1 @@
+- :ref:`SaveNexusProcessed` will now save `Groupingworkspace`s.

--- a/docs/source/release/v6.7.0/Framework/Data_Objects/New_features/35493.rst
+++ b/docs/source/release/v6.7.0/Framework/Data_Objects/New_features/35493.rst
@@ -1,1 +1,1 @@
-- :ref:`SaveNexusProcessed` will now save `Groupingworkspace`s.
+- :ref:`SaveNexusProcessed <algm-SaveNexusProcessed>` will now save ``Groupingworkspace``s.


### PR DESCRIPTION
**Description of work**
This was an edit to `SaveNexusProcessed` to allow for saving `GroupingWorkspace`s through this method.

**Purpose of work**
<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
-->

This is relates to [EWM1172](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=1172) for SNAPRed, where it is necessary to save files in binary to avoid the large overhead of massive XML files.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

This issue was raised originally by @mguthriem.

**Summary of work**
<!-- Please provide a short, high level description of the work that was done.
-->

I edited the `if` in lines 240ff to allow for `GroupingWorkspace` as a type ID.

**Further detail of work**
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

Also added a save/load test.

**To test:**

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

Test was added into `Testing/systemTests/tests/framework/SaveLoadNexusProcessed.py`

*There is no associated issue.*

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.