### PR TITLE
Fix for bug error bars plot options crash

### DIFF
--- a/docs/source/release/v6.7.0/Workbench/Bugfixes/35495.rst
+++ b/docs/source/release/v6.7.0/Workbench/Bugfixes/35495.rst
@@ -1,0 +1,1 @@
+- Fixed bug where opening the plot options for a script-created plot with error bars, would crash Workbench.

--- a/qt/python/mantidqt/mantidqt/widgets/plotconfigdialog/curvestabwidget/__init__.py
+++ b/qt/python/mantidqt/mantidqt/widgets/plotconfigdialog/curvestabwidget/__init__.py
@@ -231,7 +231,7 @@ class CurveProperties(dict):
         try:
             barlines = curve[2][0]
             props["errorevery"] = int(barlines.axes.creation_args[len(barlines.axes.creation_args) - 1]["errorevery"])
-        except (IndexError, TypeError, KeyError):
+        except (IndexError, TypeError, KeyError, AttributeError):
             props["errorevery"] = 1
         try:
             caps = curve[1]

--- a/qt/python/mantidqt/mantidqt/widgets/plotconfigdialog/curvestabwidget/test/test_curveproperties.py
+++ b/qt/python/mantidqt/mantidqt/widgets/plotconfigdialog/curvestabwidget/test/test_curveproperties.py
@@ -7,6 +7,7 @@
 #  This file is part of the mantid workbench.
 
 import unittest
+import numpy as np
 from matplotlib import use as mpl_use
 
 mpl_use("Agg")  # noqa
@@ -120,3 +121,17 @@ class CurvePropertiesTest(unittest.TestCase):
         # Now hide connecting line
         container[0].set_visible(False)
         self.assertTrue(funcs.curve_hidden(container))
+
+    def test_error_bars_with_no_creation_args_are_handled(self):
+        fig = figure()
+        x = np.arange(10)
+        y = 2.5 * np.sin(x / 20 * np.pi)
+        yerr = np.linspace(0.05, 0.2, 10)
+        ax = fig.add_subplot()
+        ax.errorbar(x, y, yerr=yerr)
+
+        try:
+            CurveProperties.from_curve(ax.get_lines()[0])
+            CurveProperties.from_curve(ax.containers[0])
+        except RuntimeError:
+            self.fail()


### PR DESCRIPTION
**Description of work**
Currently, if you make a plot from a script with error bars and try to open the plot options widget, Mantid crashes.
This PR fixes that crash by adding the correct exception type to the try block where the error occurs.

**To test:**
- Run this script in Mantid to generate a plot with error bars.

```
import numpy as np
import matplotlib.pyplot as plt

fig = plt.figure()
x = np.arange(10)
y = 2.5 * np.sin(x / 20 * np.pi)
yerr = np.linspace(0.05, 0.2, 10)

plt.errorbar(x, y + 3, yerr=yerr, label='both limits (default)')

plt.errorbar(x, y + 2, yerr=yerr, uplims=True, label='uplims=True')

plt.errorbar(x, y + 1, yerr=yerr, uplims=True, lolims=True,
             label='uplims=True, lolims=True')

upperlimits = [True, False] * 5
lowerlimits = [False, True] * 5
plt.errorbar(x, y, yerr=yerr, uplims=upperlimits, lolims=lowerlimits,
             label='subsets of uplims and lolims')

plt.legend(loc='lower right')
plt.show()
```

- [ ] Click on the settings toolbar button and the plot options should open as normal
- [ ] Changes some settings and apply to test that nothing else has broken

Fixes #35495

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.