### PR TITLE
Fix calculation of simple statistics of filtered logs

### DIFF
--- a/Framework/DataHandling/test/LoadEventNexusTest.h
+++ b/Framework/DataHandling/test/LoadEventNexusTest.h
@@ -963,7 +963,7 @@ public:
     TSM_ASSERT_EQUALS("Wrong number of periods extracted", nPeriods, 4);
     TSM_ASSERT_EQUALS("Groups size should be same as nperiods", outGroup->size(), nPeriods);
     // mean of proton charge for each period
-    std::array<double, 4> protonChargeMeans = {0.00110488, 0.00110392, 0.00110343, 0.00110404};
+    std::array<double, 4> protonChargeMeans = {0.00110488, 0.00110392, 0.00110336, 0.00110404};
     for (size_t i = 0; i < outGroup->size(); ++i) {
       EventWorkspace_sptr ws = std::dynamic_pointer_cast<EventWorkspace>(outGroup->getItem(i));
       TS_ASSERT(ws);

--- a/Framework/Kernel/src/TimeSeriesProperty.cpp
+++ b/Framework/Kernel/src/TimeSeriesProperty.cpp
@@ -1007,7 +1007,12 @@ template <typename TYPE> std::vector<DateAndTime> TimeSeriesProperty<TYPE>::time
 }
 
 /**
- * Return the time series's filtered times as a vector<DateAndTime>
+ * A view of the times as seen within a the TimeROI's regions.
+ * A values will be excluded if its times lie outside the ROI's regions or coincides with the upper boundary
+ * of a ROI region. For instance, time "2007-11-30T16:17:30" is excluded in the ROI
+ * ["2007-11-30T16:17:00", "2007-11-30T16:17:30"). However, a value at time "2007-11-30T16:16:00" will be included
+ * with a time of "2007-11-30T16:17:00" because that is when the ROI starts.
+ * @param roi :: ROI regions validating any query time.
  * @return A vector of DateAndTime objects
  */
 template <typename TYPE>
@@ -2164,10 +2169,11 @@ void TimeSeriesProperty<std::string>::histogramData(const Types::Core::DateAndTi
 }
 
 /**
- * Series values within the ROI's regions.
+ * A view of the times as seen within a the TimeROI's regions.
  * A values will be excluded if its times lie outside the ROI's regions or coincides with the upper boundary
  * of a ROI region. For instance, time "2007-11-30T16:17:30" is excluded in the ROI
- * [2007-11-30T16:17:00", 2007-11-30T16:17:30").
+ * ["2007-11-30T16:17:00", "2007-11-30T16:17:30"). However, a value at time "2007-11-30T16:16:00" will be included
+ * because it is valid at the beginning of the TimeROI.
  * @param roi :: ROI regions validating any query time.
  * @returns :: Vector of included values only.
  */

--- a/Framework/Kernel/src/TimeSeriesProperty.cpp
+++ b/Framework/Kernel/src/TimeSeriesProperty.cpp
@@ -1815,13 +1815,13 @@ double TimeSeriesProperty<TYPE>::extractStatistic(Math::StatisticType selection,
   double singleValue = 0;
   switch (selection) {
   case FirstValue:
-    if (roi)
+    if (roi && !roi->useAll())
       singleValue = double(this->firstValue(*roi));
     else
       singleValue = double(this->nthValue(0));
     break;
   case LastValue:
-    if (roi)
+    if (roi && !roi->useAll())
       singleValue = double(this->lastValue(*roi));
     else
       singleValue = double(this->nthValue(this->size() - 1));

--- a/Framework/Kernel/src/TimeSeriesProperty.cpp
+++ b/Framework/Kernel/src/TimeSeriesProperty.cpp
@@ -1070,7 +1070,7 @@ std::vector<DateAndTime> TimeSeriesProperty<TYPE>::filteredTimesAsVector(const K
 
     return filteredTimes;
   } else {
-    return this->filteredTimesAsVector();
+    return this->timesAsVector();
   }
 }
 
@@ -2228,7 +2228,7 @@ template <typename TYPE> std::vector<TYPE> TimeSeriesProperty<TYPE>::filteredVal
     }
     return filteredValues;
   } else {
-    return this->filteredValuesAsVector();
+    return this->valuesAsVector();
   }
 }
 

--- a/Framework/Kernel/src/TimeSeriesProperty.cpp
+++ b/Framework/Kernel/src/TimeSeriesProperty.cpp
@@ -1182,7 +1182,8 @@ template <typename TYPE> TYPE TimeSeriesProperty<TYPE>::firstValue(const Kernel:
     const auto index = std::size_t(std::distance(times.cbegin(), iter));
 
     const auto values = this->valuesAsVector();
-    return values[index];
+    const TYPE ret = values[index];
+    return ret;
   }
 }
 
@@ -1226,10 +1227,13 @@ template <typename TYPE> TYPE TimeSeriesProperty<TYPE>::lastValue(const Kernel::
     return this->lastValue();
   } else {
     auto iter = std::lower_bound(times.cbegin(), times.cend(), stopTime);
+    if ((iter != times.cbegin()) && (*iter > stopTime))
+      --iter;
     const auto index = std::size_t(std::distance(times.cbegin(), iter));
 
     const auto values = this->valuesAsVector();
-    return values[index];
+    const TYPE ret = values[index];
+    return ret;
   }
 }
 
@@ -1768,10 +1772,16 @@ double TimeSeriesProperty<TYPE>::extractStatistic(Math::StatisticType selection,
   double singleValue = 0;
   switch (selection) {
   case FirstValue:
-    singleValue = static_cast<double>(this->nthValue(0));
+    if (roi)
+      singleValue = double(this->firstValue(*roi));
+    else
+      singleValue = double(this->nthValue(0));
     break;
   case LastValue:
-    singleValue = static_cast<double>(this->nthValue(this->size() - 1));
+    if (roi)
+      singleValue = double(this->lastValue(*roi));
+    else
+      singleValue = double(this->nthValue(this->size() - 1));
     break;
   case Minimum:
     singleValue = static_cast<double>(this->getStatistics(roi).minimum);

--- a/Framework/Kernel/test/FilteredTimeSeriesPropertyTest.h
+++ b/Framework/Kernel/test/FilteredTimeSeriesPropertyTest.h
@@ -536,29 +536,31 @@ public:
   void test_getStatistics_filtered() {
     const auto &log = getFilteredTestLog();
 
-    // calculate expected values
     const std::vector<double> durations{10, 5, 5, 10, 10, 10, 10, 10, 10, 5};
     const std::vector<double> values{1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
 
-    /* this commented out code contains the values we want eventually,
-       but it would change the existing behavior and is being
-       left alone for now
+    // verify that the values in the filter are as expected
+    const auto obsValues = log->filteredValuesAsVector();
+    TS_ASSERT_EQUALS(obsValues.size(), values.size());
+    if (obsValues.size() == values.size()) {
+      for (std::size_t i = 0; i < values.size(); ++i) {
+        TS_ASSERT_EQUALS(obsValues[i], values[i]);
+      }
+    }
+
+    // calculate expected values
     double exp_mean = 0.;
-    for (const auto value: values)
-        exp_mean += value;
+    for (const auto value : values)
+      exp_mean += value;
     exp_mean /= double(values.size()); // 5.5
 
     double exp_stddev = 0.;
-    for (const auto value: values)
-        exp_stddev += (value - exp_mean) * (value - exp_mean);
+    for (const auto value : values)
+      exp_stddev += (value - exp_mean) * (value - exp_mean);
     exp_stddev = std::sqrt(exp_stddev / double(values.size())); // 2.872
 
     // median is halfway between because it is even number of values
-    const double exp_median = 0.5 * (values[5] + values[6]);
-    */
-    const double exp_mean = 5.7777777719;
-    const double exp_stddev = 2.8974232916;
-    const double exp_median = 6.;
+    const double exp_median = 0.5 * (values[4] + values[5]);
 
     // calculate from values above
     double exp_duration = 0.;
@@ -605,14 +607,13 @@ public:
 
     TS_ASSERT_DIFFERS(unfilteredValues.size(), filteredValues.size());
     TS_ASSERT_EQUALS(unfilteredValues.size(), 11);
-    TS_ASSERT_EQUALS(filteredValues.size(), 9);
 
     // the filter should return these values, but that is a change in behavior
     // from what is currently expected
-    //    const std::vector<double> EXP_FILTERED_VALUES{1,2,3,4,5,6,7,8,9,10};
-    //    TS_ASSERT_EQUALS(filteredValues.size(), EXP_FILTERED_VALUES.size());
-    //    for (std::size_t i = 0; i < EXP_FILTERED_VALUES.size(); ++i)
-    //        TS_ASSERT_EQUALS(filteredValues[i], EXP_FILTERED_VALUES[i]);
+    const std::vector<double> EXP_FILTERED_VALUES{1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
+    TS_ASSERT_EQUALS(filteredValues.size(), EXP_FILTERED_VALUES.size());
+    for (std::size_t i = 0; i < EXP_FILTERED_VALUES.size(); ++i)
+      TS_ASSERT_EQUALS(filteredValues[i], EXP_FILTERED_VALUES[i]);
   }
 
   void test_getSplittingIntervals_repeatedEntries() {
@@ -751,7 +752,7 @@ private:
     const double incrementSecs(10.0);
     for (int i = 1; i < 12; ++i) {
       const double val = static_cast<double>(i);
-      log->addValue(logTime.toISO8601String(), val);
+      log->addValue(logTime, val);
       logTime += incrementSecs;
     }
     return log;

--- a/Framework/Kernel/test/TimeSeriesPropertyTest.h
+++ b/Framework/Kernel/test/TimeSeriesPropertyTest.h
@@ -386,33 +386,35 @@ public:
     // no filter
     this->assert_two_vectors(log->filteredValuesAsVector(), log->valuesAsVector(), 0.01);
     // filter encompassing all the time domain
-    TimeROI *rois = new TimeROI;
-    rois->addROI("2007-11-30T16:17:00", "2007-11-30T16:17:31");
-    this->assert_two_vectors(log->filteredValuesAsVector(rois), log->valuesAsVector(), 0.01);
-    this->assert_two_vectors(log->filteredTimesAsVector(rois), log->timesAsVector());
+    TimeROI rois;
+    rois.addROI("2007-11-30T16:17:00", "2007-11-30T16:17:31");
+    this->assert_two_vectors(log->filteredValuesAsVector(&rois), log->valuesAsVector(), 0.01);
+    this->assert_two_vectors(log->filteredTimesAsVector(&rois), log->timesAsVector());
     TS_ASSERT_EQUALS(log->valuesAsVector().size(), log->timesAsVector().size());
 
     // times are outside the ROI's. Some times are at the upper boundaries of the ROI's, thus are excluded
-    rois->clear();
-    rois->addROI("2007-11-30T16:16:00", "2007-11-30T16:17:00"); // before the first time, including the first time
-    rois->addROI("2007-11-30T16:17:01", "2007-11-30T16:17:09"); // between times 1st and 2nd
-    rois->addROI("2007-11-30T16:17:15", "2007-11-30T16:17:20"); // between times 2nd and 3rd, including time 3rd
-    rois->addROI("2007-11-30T16:17:45", "2007-11-30T16:18:00"); // after last time
+    rois.clear();
+    rois.addROI("2007-11-30T16:16:00", "2007-11-30T16:17:00");  // before the first time, including the first time
+    rois.addROI("2007-11-30T16:17:01", "2007-11-30T16:17:09");  // between times 1st and 2nd
+    rois.addROI("2007-11-30T16:17:15", "2007-11-30T16:17:20");  // between times 2nd and 3rd, including time 3rd
+    rois.addROI("2007-11-30T16:17:45", "2007-11-30T16:18:00");  // after last time
     std::vector<double> expected_values_one{9.99, 7.55, 10.55}; // 3rd value is notched out
     std::vector<DateAndTime> expected_times_one{DateAndTime("2007-11-30T16:17:01"), DateAndTime("2007-11-30T16:17:15"),
                                                 DateAndTime("2007-11-30T16:17:45")};
-    this->assert_two_vectors(log->filteredValuesAsVector(rois), expected_values_one, 0.01);
-    this->assert_two_vectors(log->filteredTimesAsVector(rois), expected_times_one);
+    this->assert_two_vectors(log->filteredValuesAsVector(&rois), expected_values_one, 0.01);
+    this->assert_two_vectors(log->filteredTimesAsVector(&rois), expected_times_one);
 
-    rois->clear();
-    rois->addROI("2007-11-30T16:16:30", "2007-11-30T16:17:05"); // capture the first time
-    rois->addROI("2007-11-30T16:17:10", "2007-11-30T16:17:20"); // capture second time, exclude the third
-    rois->addROI("2007-11-30T16:17:30", "2007-11-30T16:18:00"); // ROI after last time, including last time
+    rois.clear();
+    rois.addROI("2007-11-30T16:16:30", "2007-11-30T16:17:05"); // capture the first time
+    rois.addROI("2007-11-30T16:17:10", "2007-11-30T16:17:20"); // capture second time, exclude the third
+    rois.addROI("2007-11-30T16:17:30", "2007-11-30T16:18:00"); // ROI after last time, including last time
     std::vector<double> expected_values_two{9.99, 7.55, 10.55};
     std::vector<DateAndTime> expected_times_two{DateAndTime("2007-11-30T16:17:00"), DateAndTime("2007-11-30T16:17:10"),
                                                 DateAndTime("2007-11-30T16:17:30")};
-    this->assert_two_vectors(log->filteredValuesAsVector(rois), expected_values_two, 0.01);
-    this->assert_two_vectors(log->filteredTimesAsVector(rois), expected_times_two);
+    this->assert_two_vectors(log->filteredValuesAsVector(&rois), expected_values_two, 0.01);
+    this->assert_two_vectors(log->filteredTimesAsVector(&rois), expected_times_two);
+
+    delete log;
   }
 
   //----------------------------------------------------------------------------
@@ -625,6 +627,8 @@ public:
     TS_ASSERT_EQUALS(statsSingleValue.time_mean, 1.);
     TS_ASSERT_EQUALS(statsSingleValue.time_standard_deviation, 0.);
     TS_ASSERT_EQUALS(statsSingleValue.duration, 10.);
+
+    delete prop;
   }
 
   void test_multi_value_roi_mean() {
@@ -648,7 +652,7 @@ public:
     TS_ASSERT_EQUALS(statsEmptyRoi.time_standard_deviation, STDDEV_SIMPLE);
     TS_ASSERT_EQUALS(statsEmptyRoi.duration, 18.);
 
-    std::cout << "\n" << prop->value() << "\n"; // TODO REMOVE
+    //    std::cout << "\n" << prop->value() << "\n"; // TODO REMOVE
 
     // with TimeROI including everything
     TimeROI roi(EPOCH, EPOCH + 18.);
@@ -673,6 +677,8 @@ public:
     TS_ASSERT_EQUALS(statsROIOne.mean, 3);
     TS_ASSERT_EQUALS(statsROIOne.time_mean, 3);
     TS_ASSERT_EQUALS(statsROIOne.duration, 4.);
+
+    delete prop;
   }
 
   void test_extractStatistic() {
@@ -702,6 +708,8 @@ public:
     TS_ASSERT_EQUALS(prop->extractStatistic(Math::StatisticType::FirstValue, &roi), 2.);
     TS_ASSERT_EQUALS(prop->lastValue(roi), 3.);
     TS_ASSERT_EQUALS(prop->extractStatistic(Math::StatisticType::LastValue, &roi), 3.);
+
+    delete prop;
   }
 
   void test_filterByTimesN() {

--- a/Framework/Kernel/test/TimeSeriesPropertyTest.h
+++ b/Framework/Kernel/test/TimeSeriesPropertyTest.h
@@ -1162,7 +1162,7 @@ public:
     log.splitByTimeVector(split_time_vec, split_target_vec, outputs);
 
     // check
-    for (int i = 0; i < 4; ++i) {
+    for (std::size_t i = 0; i < 4; ++i) {
       TimeSeriesProperty<int> *out_i = outputs[i];
       TS_ASSERT_EQUALS(out_i->size(), 0);
       delete out_i;
@@ -1217,7 +1217,7 @@ public:
     log.splitByTimeVector(split_time_vec, split_target_vec, outputs);
 
     // check
-    for (int i = 0; i < 4; ++i) {
+    for (std::size_t i = 0; i < 4; ++i) {
       TimeSeriesProperty<int> *out_i = outputs[i];
       TS_ASSERT_EQUALS(out_i->size(), 1);
       delete out_i;
@@ -1321,7 +1321,7 @@ public:
     int_log.splitByTimeVector(split_time_vec, split_target_vec, outputs);
 
     // check
-    for (int i = 0; i < 2; ++i) {
+    for (std::size_t i = 0; i < 2; ++i) {
       TimeSeriesProperty<int> *out_i = outputs[i];
       TS_ASSERT_EQUALS(out_i->size(), 1);
       delete out_i;

--- a/Framework/Kernel/test/TimeSeriesPropertyTest.h
+++ b/Framework/Kernel/test/TimeSeriesPropertyTest.h
@@ -581,6 +581,112 @@ public:
     TS_ASSERT_EQUALS(*tsp_result, *tsp_expected);
   }
 
+  void test_single_value_roi_mean() {
+    DateAndTime firstLogTime("2007-11-30T16:17:00");
+    TimeSeriesProperty<double> *prop = new TimeSeriesProperty<double>("doubleProp");
+    TS_ASSERT_THROWS_NOTHING(prop->addValue(firstLogTime, 1.)); // value that isn't zero
+
+    // single value no TimeROI
+    const auto statsEmptySingleValue = prop->getStatistics();
+    TS_ASSERT_EQUALS(statsEmptySingleValue.minimum, 1.);
+    TS_ASSERT_EQUALS(statsEmptySingleValue.maximum, 1.);
+    TS_ASSERT_EQUALS(statsEmptySingleValue.median, 1.);
+    TS_ASSERT_EQUALS(statsEmptySingleValue.mean, 1.);
+    TS_ASSERT_EQUALS(statsEmptySingleValue.standard_deviation, 0.);
+    TS_ASSERT_EQUALS(statsEmptySingleValue.time_mean, 1.);
+    TS_ASSERT_EQUALS(statsEmptySingleValue.time_standard_deviation, 0.);
+    TS_ASSERT_EQUALS(statsEmptySingleValue.duration, 0.);
+
+    // with TimeROI
+    TimeROI left(firstLogTime, firstLogTime + 10.);
+    const auto statsSingleValue = prop->getStatistics(&left);
+    TS_ASSERT_EQUALS(statsSingleValue.minimum, 1.);
+    TS_ASSERT_EQUALS(statsSingleValue.maximum, 1.);
+    TS_ASSERT_EQUALS(statsSingleValue.median, 1.);
+    TS_ASSERT_EQUALS(statsSingleValue.mean, 1.);
+    TS_ASSERT_EQUALS(statsSingleValue.standard_deviation, 0.);
+    TS_ASSERT_EQUALS(statsSingleValue.time_mean, 1.);
+    TS_ASSERT_EQUALS(statsSingleValue.time_standard_deviation, 0.);
+    TS_ASSERT_EQUALS(statsSingleValue.duration, 10.);
+  }
+
+  void test_multi_value_roi_mean() {
+    DateAndTime EPOCH("2007-11-30T16:17:00");
+    TimeSeriesProperty<double> *prop = new TimeSeriesProperty<double>("doubleProp");
+    for (size_t i = 1; i < 10; ++i) { // values are 1-9, times are first at 16:17:00, last at 16:17:16
+      TS_ASSERT_THROWS_NOTHING(prop->addValue(EPOCH + double(2 * (i - 1)), double(i))); // value that isn't zero
+    }
+
+    // these values are calculated by hand
+    const double MEAN_SIMPLE(5);
+    const double STDDEV_SIMPLE(2.581988897471611);
+    // single value no TimeROI
+    const auto statsEmptyRoi = prop->getStatistics();
+    TS_ASSERT_EQUALS(statsEmptyRoi.minimum, 1.);
+    TS_ASSERT_EQUALS(statsEmptyRoi.maximum, 9.);
+    TS_ASSERT_EQUALS(statsEmptyRoi.median, MEAN_SIMPLE);
+    TS_ASSERT_EQUALS(statsEmptyRoi.mean, MEAN_SIMPLE);
+    TS_ASSERT_EQUALS(statsEmptyRoi.standard_deviation, STDDEV_SIMPLE);
+    TS_ASSERT_EQUALS(statsEmptyRoi.time_mean, MEAN_SIMPLE);
+    TS_ASSERT_EQUALS(statsEmptyRoi.time_standard_deviation, STDDEV_SIMPLE);
+    TS_ASSERT_EQUALS(statsEmptyRoi.duration, 18.);
+
+    std::cout << "\n" << prop->value() << "\n"; // TODO REMOVE
+
+    // with TimeROI including everything
+    TimeROI roi(EPOCH, EPOCH + 18.);
+    const auto statsRoiAll = prop->getStatistics(&roi);
+    TS_ASSERT_EQUALS(statsRoiAll.minimum, 1.);
+    TS_ASSERT_EQUALS(statsRoiAll.maximum, 9.);
+    TS_ASSERT_EQUALS(statsRoiAll.median, MEAN_SIMPLE);
+    TS_ASSERT_EQUALS(statsRoiAll.mean, MEAN_SIMPLE);
+    TS_ASSERT_EQUALS(statsRoiAll.standard_deviation, STDDEV_SIMPLE);
+    TS_ASSERT_EQUALS(statsRoiAll.time_mean, MEAN_SIMPLE);
+    TS_ASSERT_EQUALS(statsRoiAll.time_standard_deviation, STDDEV_SIMPLE);
+    TS_ASSERT_EQUALS(statsRoiAll.duration, 18.);
+
+    // single TimeROI to include values [3,4] with the preceeding 2 being implicit
+    roi.clear();
+    roi.addROI(EPOCH + 3., EPOCH + 7.);
+    const auto statsROIOne = prop->getStatistics(&roi);
+    // not bothering with stddev
+    TS_ASSERT_EQUALS(statsROIOne.minimum, 2.);
+    TS_ASSERT_EQUALS(statsROIOne.maximum, 4.);
+    TS_ASSERT_EQUALS(statsROIOne.median, 3);
+    TS_ASSERT_EQUALS(statsROIOne.mean, 3);
+    TS_ASSERT_EQUALS(statsROIOne.time_mean, 3);
+    TS_ASSERT_EQUALS(statsROIOne.duration, 4.);
+  }
+
+  void test_extractStatistic() {
+    // same as
+    DateAndTime firstLogTime("2007-11-30T16:17:00");
+    TimeSeriesProperty<double> *prop = new TimeSeriesProperty<double>("doubleProp");
+    for (size_t i = 1; i < 10; ++i) { // values are 1-9, times are first at 16:17:00, last at 16:17:16
+      TS_ASSERT_THROWS_NOTHING(prop->addValue(firstLogTime + double(2 * (i - 1)), double(i))); // value that isn't zero
+    }
+
+    // no TimeROI
+    TS_ASSERT_EQUALS(prop->firstValue(), 1.);
+    TS_ASSERT_EQUALS(prop->extractStatistic(Math::StatisticType::FirstValue), 1.);
+    TS_ASSERT_EQUALS(prop->lastValue(), 9.);
+    TS_ASSERT_EQUALS(prop->extractStatistic(Math::StatisticType::LastValue), 9.);
+
+    // notch around the second value at EPOCH+2s which is 2
+    TimeROI roi(firstLogTime + 2., firstLogTime + 3.); // only a single value
+    TS_ASSERT_EQUALS(prop->firstValue(roi), 2.);
+    TS_ASSERT_EQUALS(prop->extractStatistic(Math::StatisticType::FirstValue, &roi), 2.);
+    TS_ASSERT_EQUALS(prop->lastValue(roi), 2.);
+    TS_ASSERT_EQUALS(prop->extractStatistic(Math::StatisticType::LastValue, &roi), 2.);
+
+    // add a second to include time=166:17:04, 3
+    roi.addROI(firstLogTime + 2., firstLogTime + 4.);
+    TS_ASSERT_EQUALS(prop->firstValue(roi), 2.);
+    TS_ASSERT_EQUALS(prop->extractStatistic(Math::StatisticType::FirstValue, &roi), 2.);
+    TS_ASSERT_EQUALS(prop->lastValue(roi), 3.);
+    TS_ASSERT_EQUALS(prop->extractStatistic(Math::StatisticType::LastValue, &roi), 3.);
+  }
+
   void test_filterByTimesN() {
     TimeSeriesProperty<int> *log = createIntegerTSP(10);
     TS_ASSERT_EQUALS(log->realSize(), 10);


### PR DESCRIPTION
Change back the old behavior that the simple statistical measures were calculated from faked values and times. These are only temporary. This also fixes a bug where `filteredValuesAsVector()` and `filteredTimesAsVector()` weren't always returning the same length.


**Further detail of work**

You will see that there is two tests that were commented out that are now back.


**To test:**

```python
# import mantid algorithms
from mantid.simpleapi import *

Load(Filename="HYS_13656-13658", OutputWorkspace="sum")  # in system test data
FilterByLogValue(InputWorkspace="sum", OutputWorkspace="sum", LogName="s1", MinimumValue=0, MaximumValue=24.5, LogBoundary="Left")
runObj = mtd['sum'].run()
print(f"min={runObj.getStatistics('s1').minimum} max={runObj.getStatistics('s1').maximum}")
```
Where the minimum value is no longer negative even though `FilterByLogValue` was configure to remove negative values.

Refs #34794

*This does not require release notes* because it is already covered in a previous set of release notes.

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.