### PR TITLE
Update Mslice SHA and release notes

### DIFF
--- a/docs/source/release/v6.7.0/Direct_Geometry/MSlice/Bugfixes/35518.rst
+++ b/docs/source/release/v6.7.0/Direct_Geometry/MSlice/Bugfixes/35518.rst
@@ -1,0 +1,9 @@
+- Warning now omitted if a cut is taken with a higher resolution than the parent slice. This causes the appearance of missing lines between adjacent datapoints.
+- When taking a cut, if a intensity range is provided it is now applied to the plot y limits.
+- When changing intensity of a slice plot the axis limits now get reset to their original values. This solves a bug where zooming out after an intensity change was not possible.
+- Bragg peaks are now sized more appropriately on an interactive cut.
+- MSlice now correctly preserves metadata when saving NXPSE files.
+- Fixed a bug relating to intensity correction on some datasets where arrays used to transform data during correction had incorrect dimensions.
+- Fixed a bug causing a crash when cancelling an intensity correction from the temperature input pop-up.
+- When inputting waterfall limits an error is no longer caused by the invalid use of E to apply an exponent.
+- You can now save slices and cuts in an ASCII format from the MSlice command line.

--- a/scripts/ExternalInterfaces/CMakeLists.txt
+++ b/scripts/ExternalInterfaces/CMakeLists.txt
@@ -7,7 +7,7 @@ externalproject_add(
   mslice
   PREFIX ${_mslice_external_root}
   GIT_REPOSITORY "https://github.com/mantidproject/mslice.git"
-  GIT_TAG 07af50cb4e4956a71e5dfa15647ce07bdfe2de73
+  GIT_TAG 86ca2ec078907ac717da2e16e411e6255f3233e3
   EXCLUDE_FROM_ALL 1
   CONFIGURE_COMMAND ""
   BUILD_COMMAND ""


### PR DESCRIPTION
**Description of work**

This PR updates the `MSlice` SHA to the head of the `main` branch of the `MSlice` Repo.

Additionally, MSlice release notes are added.

**To test:**

- Check SHA
- Proof read release notes.