### PR TITLE
CrossCorrelate accept list of spectra as input

### DIFF
--- a/Framework/Algorithms/inc/MantidAlgorithms/CrossCorrelate.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/CrossCorrelate.h
@@ -60,6 +60,8 @@ public:
   const std::vector<std::string> seeAlso() const override { return {"GetDetectorOffsets"}; }
   /// Algorithm's category for identification
   const std::string category() const override { return "Arithmetic"; }
+  /// Input validation
+  std::map<std::string, std::string> validateInputs() override;
 
 private:
   /// Initialisation code

--- a/Framework/Algorithms/test/CrossCorrelateTest.h
+++ b/Framework/Algorithms/test/CrossCorrelateTest.h
@@ -193,8 +193,8 @@ public:
     alg.setProperty("XMax", 2.0);
     auto errorMap = alg.validateInputs();
     TS_ASSERT_EQUALS(errorMap.size(), 2);
-    TS_ASSERT_EQUALS(errorMap.begin()->first, "XMax");
-    TS_ASSERT_EQUALS(errorMap.rbegin()->first, "XMin");
+    TS_ASSERT_EQUALS(errorMap.count("XMin"), 1);
+    TS_ASSERT_EQUALS(errorMap.count("XMax"), 1);
   }
 
   void testValidateInputsXMinGreaterThanXMax() {
@@ -207,8 +207,8 @@ public:
     alg.setProperty("XMax", 2.0);
     auto errorMap = alg.validateInputs();
     TS_ASSERT_EQUALS(errorMap.size(), 2);
-    TS_ASSERT_EQUALS(errorMap.begin()->first, "XMax");
-    TS_ASSERT_EQUALS(errorMap.rbegin()->first, "XMin");
+    TS_ASSERT_EQUALS(errorMap.count("XMin"), 1);
+    TS_ASSERT_EQUALS(errorMap.count("XMax"), 1);
   }
 
   void testValidateInputsWSIndexMinEqualsWSIndexMax() {
@@ -221,8 +221,8 @@ public:
     alg.setProperty("XMax", 3.0);
     auto errorMap = alg.validateInputs();
     TS_ASSERT_EQUALS(errorMap.size(), 2);
-    TS_ASSERT_EQUALS(errorMap.begin()->first, "WorkspaceIndexMax");
-    TS_ASSERT_EQUALS(errorMap.rbegin()->first, "WorkspaceIndexMin");
+    TS_ASSERT_EQUALS(errorMap.count("WorkspaceIndexMin"), 1);
+    TS_ASSERT_EQUALS(errorMap.count("WorkspaceIndexMax"), 1);
   }
 
   void testValidateInputsWSIndexMinGreaterThanWSIndexMax() {
@@ -235,8 +235,8 @@ public:
     alg.setProperty("XMax", 3.0);
     auto errorMap = alg.validateInputs();
     TS_ASSERT_EQUALS(errorMap.size(), 2);
-    TS_ASSERT_EQUALS(errorMap.begin()->first, "WorkspaceIndexMax");
-    TS_ASSERT_EQUALS(errorMap.rbegin()->first, "WorkspaceIndexMin");
+    TS_ASSERT_EQUALS(errorMap.count("WorkspaceIndexMin"), 1);
+    TS_ASSERT_EQUALS(errorMap.count("WorkspaceIndexMax"), 1);
   }
 
   void testValidateInputsWSIndexListAndWSIndexMinMaxGiven() {
@@ -250,8 +250,9 @@ public:
     alg.setProperty("WorkspaceIndexList", "1,2,3");
     auto errorMap = alg.validateInputs();
     TS_ASSERT_EQUALS(errorMap.size(), 3);
-    TS_ASSERT_EQUALS(errorMap.begin()->first, "WorkspaceIndexList");
-    TS_ASSERT_EQUALS(errorMap.rbegin()->first, "WorkspaceIndexMin");
+    TS_ASSERT_EQUALS(errorMap.count("WorkspaceIndexMin"), 1);
+    TS_ASSERT_EQUALS(errorMap.count("WorkspaceIndexMax"), 1);
+    TS_ASSERT_EQUALS(errorMap.count("WorkspaceIndexList"), 1);
   }
 
 private:

--- a/Framework/Algorithms/test/CrossCorrelateTest.h
+++ b/Framework/Algorithms/test/CrossCorrelateTest.h
@@ -69,6 +69,44 @@ public:
     TS_ASSERT_DELTA(outY1[2], 0.456851, 1e-6);
   }
 
+  void testWorkspaceIndexListValidInput() {
+    CrossCorrelate alg;
+
+    // Create the workspace
+    const MatrixWorkspace_sptr inWS = makeFakeWorkspace();
+
+    // Set up the algorithm
+    alg.initialize();
+    alg.setChild(true);
+    alg.setProperty("InputWorkspace", inWS);
+    alg.setProperty("OutputWorkspace", "outWS");
+    alg.setProperty("XMin", 2.0);
+    alg.setProperty("XMax", 4.0);
+    alg.setProperty("WorkspaceIndexList", "0,1,2,3,4");
+
+    // Run the algorithm
+    const MatrixWorkspace_const_sptr outWS = runAlgorithm(alg, inWS);
+
+    // Specific checks
+    const MantidVec &outX = outWS->readX(0);
+    TS_ASSERT_EQUALS(outX.size(), 3);
+    TS_ASSERT_DELTA(outX[0], -1.0, 1e-6);
+    TS_ASSERT_DELTA(outX[1], 0.0, 1e-6);
+    TS_ASSERT_DELTA(outX[2], 1.0, 1e-6);
+
+    const MantidVec &outY0 = outWS->readY(0);
+    TS_ASSERT_EQUALS(outY0.size(), 3);
+    TS_ASSERT_DELTA(outY0[0], -0.018902, 1e-6);
+    TS_ASSERT_DELTA(outY0[1], 1.0, 1e-6);
+    TS_ASSERT_DELTA(outY0[2], -0.018902, 1e-6);
+
+    const MantidVec &outY1 = outWS->readY(1);
+    TS_ASSERT_EQUALS(outY1.size(), 3);
+    TS_ASSERT_DELTA(outY1[0], -0.681363, 1e-6);
+    TS_ASSERT_DELTA(outY1[1], 0.168384, 1e-6);
+    TS_ASSERT_DELTA(outY1[2], 0.456851, 1e-6);
+  }
+
   // This tests an input X length of 3, which is the minimum the algorithm can
   // handle
   void testMinimumInputXLength() {
@@ -145,18 +183,75 @@ public:
     runAlgorithmThrows(alg);
   }
 
-  void testXMinEqualsXMax() {
-    // this throws because XMin should be > XMax
+  void testValidateInputsXMinEqualsXMax() {
+    // Input validation returns a message because XMin should be < XMax
     CrossCorrelate alg;
-    setupAlgorithm(alg, 2.0, 2.0);
-    runAlgorithmThrows(alg);
+    alg.initialize();
+    alg.setProperty("WorkspaceIndexMin", 0);
+    alg.setProperty("WorkspaceIndexMax", 1);
+    alg.setProperty("XMin", 2.0);
+    alg.setProperty("XMax", 2.0);
+    auto errorMap = alg.validateInputs();
+    TS_ASSERT_EQUALS(errorMap.size(), 2);
+    TS_ASSERT_EQUALS(errorMap.begin()->first, "XMax");
+    TS_ASSERT_EQUALS(errorMap.rbegin()->first, "XMin");
   }
 
-  void testXMinGreaterThanXMax() {
-    // this throws because XMin should be < XMax
+  void testValidateInputsXMinGreaterThanXMax() {
+    // Input validation returns a message because XMin should be < XMax
     CrossCorrelate alg;
-    setupAlgorithm(alg, 3.0, 2.0);
-    runAlgorithmThrows(alg);
+    alg.initialize();
+    alg.setProperty("WorkspaceIndexMin", 0);
+    alg.setProperty("WorkspaceIndexMax", 1);
+    alg.setProperty("XMin", 3.0);
+    alg.setProperty("XMax", 2.0);
+    auto errorMap = alg.validateInputs();
+    TS_ASSERT_EQUALS(errorMap.size(), 2);
+    TS_ASSERT_EQUALS(errorMap.begin()->first, "XMax");
+    TS_ASSERT_EQUALS(errorMap.rbegin()->first, "XMin");
+  }
+
+  void testValidateInputsWSIndexMinEqualsWSIndexMax() {
+    // Input validation returns a message because WorkspaceIndexMin should be < WorkspaceIndexMax
+    CrossCorrelate alg;
+    alg.initialize();
+    alg.setProperty("WorkspaceIndexMin", 1);
+    alg.setProperty("WorkspaceIndexMax", 1);
+    alg.setProperty("XMin", 2.0);
+    alg.setProperty("XMax", 3.0);
+    auto errorMap = alg.validateInputs();
+    TS_ASSERT_EQUALS(errorMap.size(), 2);
+    TS_ASSERT_EQUALS(errorMap.begin()->first, "WorkspaceIndexMax");
+    TS_ASSERT_EQUALS(errorMap.rbegin()->first, "WorkspaceIndexMin");
+  }
+
+  void testValidateInputsWSIndexMinGreaterThanWSIndexMax() {
+    // Input validation returns a message because WorkspaceIndexMin should be < WorkspaceIndexMax
+    CrossCorrelate alg;
+    alg.initialize();
+    alg.setProperty("WorkspaceIndexMin", 2);
+    alg.setProperty("WorkspaceIndexMax", 1);
+    alg.setProperty("XMin", 2.0);
+    alg.setProperty("XMax", 3.0);
+    auto errorMap = alg.validateInputs();
+    TS_ASSERT_EQUALS(errorMap.size(), 2);
+    TS_ASSERT_EQUALS(errorMap.begin()->first, "WorkspaceIndexMax");
+    TS_ASSERT_EQUALS(errorMap.rbegin()->first, "WorkspaceIndexMin");
+  }
+
+  void testValidateInputsWSIndexListAndWSIndexMinMaxGiven() {
+    // Input validation returns a message if both WS index list AND WS index min and max are set
+    CrossCorrelate alg;
+    alg.initialize();
+    alg.setProperty("XMin", 2.0);
+    alg.setProperty("XMax", 3.0);
+    alg.setProperty("WorkspaceIndexMin", 1);
+    alg.setProperty("WorkspaceIndexMax", 2);
+    alg.setProperty("WorkspaceIndexList", "1,2,3");
+    auto errorMap = alg.validateInputs();
+    TS_ASSERT_EQUALS(errorMap.size(), 3);
+    TS_ASSERT_EQUALS(errorMap.begin()->first, "WorkspaceIndexList");
+    TS_ASSERT_EQUALS(errorMap.rbegin()->first, "WorkspaceIndexMin");
   }
 
 private:

--- a/docs/source/release/v6.7.0/Framework/Algorithms/New_features/35521.rst
+++ b/docs/source/release/v6.7.0/Framework/Algorithms/New_features/35521.rst
@@ -1,0 +1,1 @@
+- `CrossCorrelate` now accepts either a list of spectrum IDs as input, or min and max spectrum IDs


### PR DESCRIPTION
**Description of work**

This adds a new input parameter WorkspaceIndexList to the algorithm CrossCorrelate that allows the user to select the spectra using a list of workspace indices rather than a min and max index. The user can either use the new parameter WorkspaceIndexList, or the existing WorkspaceIndexMin and WorkspaceIndexMax, but not both.

**Purpose of work**

This was done per request of an Instrument Scientist

**To test:**

Test that CrossCorrelate can be run either by inputting min and max workspace indices or a list of indices. It should not be possible to give both.

*There is no associated issue.*

External issue tracker id: Ewm1183

---

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.