### PR TITLE
Fix GroupingWorkspace accessors and use less memory in PD calibration

### DIFF
--- a/Framework/DataObjects/inc/MantidDataObjects/GroupingWorkspace.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/GroupingWorkspace.h
@@ -43,7 +43,7 @@ public:
   void makeDetectorIDToGroupVector(std::vector<int> &detIDToGroup, int64_t &ngroups) const;
   int getTotalGroups() const;
   std::vector<int> getGroupIDs() const;
-  std::vector<int> getDetIDsOfGroup(const int groupID) const;
+  std::vector<int> getDetectorIDsOfGroup(const int groupID) const;
 
 protected:
   /// Protected copy constructor. May be used by childs for cloning.

--- a/Framework/DataObjects/inc/MantidDataObjects/GroupingWorkspace.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/GroupingWorkspace.h
@@ -43,7 +43,7 @@ public:
   void makeDetectorIDToGroupVector(std::vector<int> &detIDToGroup, int64_t &ngroups) const;
   int getTotalGroups() const;
   std::vector<int> getGroupIDs() const;
-  std::vector<int> getGroupSpectraIDs(const int groupID) const;
+  std::vector<int> getDetIDsOfGroup(const int groupID) const;
 
 protected:
   /// Protected copy constructor. May be used by childs for cloning.

--- a/Framework/DataObjects/inc/MantidDataObjects/GroupingWorkspace.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/GroupingWorkspace.h
@@ -43,7 +43,7 @@ public:
   void makeDetectorIDToGroupVector(std::vector<int> &detIDToGroup, int64_t &ngroups) const;
   int getTotalGroups() const;
   std::vector<int> getGroupIDs() const;
-  std::vector<int> getGroupSpetraIDs(const int groupID) const;
+  std::vector<int> getGroupSpectraIDs(const int groupID) const;
 
 protected:
   /// Protected copy constructor. May be used by childs for cloning.

--- a/Framework/DataObjects/src/GroupingWorkspace.cpp
+++ b/Framework/DataObjects/src/GroupingWorkspace.cpp
@@ -114,15 +114,20 @@ int GroupingWorkspace::getTotalGroups() const {
   return static_cast<int>(groups.size());
 }
 
-std::vector<int> GroupingWorkspace::getGroupSpectraIDs(const int groupID) const {
-  std::vector<int> spectraIDs;
+std::vector<int> GroupingWorkspace::getDetIDsOfGroup(const int groupID) const {
+  std::vector<int> detectorIDs;
   for (size_t wi = 0; wi < getNumberHistograms(); ++wi) {
     // Convert the Y value to a group number
-    auto group = this->translateToGroupID(static_cast<int>(this->y(wi).front()));
-    if (group == groupID)
-      spectraIDs.push_back(static_cast<int>(wi) + 1);
+    const auto group = this->translateToGroupID(static_cast<int>(this->y(wi).front()));
+    if (group == groupID) {
+      // if the instrument isn't set no detector ids exist
+      const auto detIDs = this->getDetectorIDs(wi);
+      for (const auto detID : detIDs) {
+        detectorIDs.push_back(static_cast<int>(detID));
+      }
+    }
   }
-  return spectraIDs;
+  return detectorIDs;
 }
 
 } // namespace Mantid::DataObjects

--- a/Framework/DataObjects/src/GroupingWorkspace.cpp
+++ b/Framework/DataObjects/src/GroupingWorkspace.cpp
@@ -114,7 +114,7 @@ int GroupingWorkspace::getTotalGroups() const {
   return static_cast<int>(groups.size());
 }
 
-std::vector<int> GroupingWorkspace::getGroupSpetraIDs(const int groupID) const {
+std::vector<int> GroupingWorkspace::getGroupSpectraIDs(const int groupID) const {
   std::vector<int> spectraIDs;
   for (size_t wi = 0; wi < getNumberHistograms(); ++wi) {
     // Convert the Y value to a group number

--- a/Framework/DataObjects/src/GroupingWorkspace.cpp
+++ b/Framework/DataObjects/src/GroupingWorkspace.cpp
@@ -122,9 +122,8 @@ std::vector<int> GroupingWorkspace::getDetectorIDsOfGroup(const int groupID) con
     if (group == groupID) {
       // if the instrument isn't set no detector ids exist
       const auto detIDs = this->getDetectorIDs(wi);
-      for (const auto detID : detIDs) {
-        detectorIDs.push_back(static_cast<int>(detID));
-      }
+      std::transform(detIDs.cbegin(), detIDs.cend(), std::back_inserter(detectorIDs),
+                     [](const auto &detID) { return static_cast<int>(detID); });
     }
   }
   return detectorIDs;

--- a/Framework/DataObjects/src/GroupingWorkspace.cpp
+++ b/Framework/DataObjects/src/GroupingWorkspace.cpp
@@ -114,7 +114,7 @@ int GroupingWorkspace::getTotalGroups() const {
   return static_cast<int>(groups.size());
 }
 
-std::vector<int> GroupingWorkspace::getDetIDsOfGroup(const int groupID) const {
+std::vector<int> GroupingWorkspace::getDetectorIDsOfGroup(const int groupID) const {
   std::vector<int> detectorIDs;
   for (size_t wi = 0; wi < getNumberHistograms(); ++wi) {
     // Convert the Y value to a group number

--- a/Framework/DataObjects/test/GroupingWorkspaceTest.h
+++ b/Framework/DataObjects/test/GroupingWorkspaceTest.h
@@ -19,6 +19,11 @@ using namespace Mantid::API;
 using namespace Mantid::DataObjects;
 using namespace Mantid::Geometry;
 
+namespace { // anonymous namespace
+// copied from body of ComponentCreationHelper::createTestInstrumentCylindrical
+const std::size_t PIXELS_PER_BANK = 9;
+} // namespace
+
 class GroupingWorkspaceTest : public CxxTest::TestSuite {
 public:
   void test_default_constructor() {
@@ -32,11 +37,12 @@ public:
 
   void test_constructor_from_Instrument() {
     // Fake instrument with 5*9 pixels with ID starting at 1
-    Instrument_sptr inst = ComponentCreationHelper::createTestInstrumentCylindrical(5);
+    const std::size_t NUM_BANKS = 5;
+    Instrument_sptr inst = ComponentCreationHelper::createTestInstrumentCylindrical(NUM_BANKS);
 
     GroupingWorkspace_sptr ws(new GroupingWorkspace(inst));
 
-    TS_ASSERT_EQUALS(ws->getNumberHistograms(), 45);
+    TS_ASSERT_EQUALS(ws->getNumberHistograms(), NUM_BANKS * PIXELS_PER_BANK);
     TS_ASSERT_EQUALS(ws->blocksize(), 1);
     TS_ASSERT_EQUALS(ws->getInstrument()->getName(),
                      "basic"); // Name of the test instrument
@@ -44,16 +50,16 @@ public:
     TS_ASSERT_EQUALS(dets.size(), 1);
 
     // Set the group numbers
-    for (int group = 0; group < 5; group++)
-      for (int i = 0; i < 9; i++)
-        ws->dataY(group * 9 + i)[0] = double(group + 1);
+    for (std::size_t group = 0; group < NUM_BANKS; group++)
+      for (std::size_t i = 0; i < PIXELS_PER_BANK; i++)
+        ws->dataY(group * PIXELS_PER_BANK + i)[0] = double(group + 1);
 
     // Get the map
     std::map<detid_t, int> map;
     int64_t ngroups;
     ws->makeDetectorIDToGroupMap(map, ngroups);
 
-    TS_ASSERT_EQUALS(ngroups, 5);
+    TS_ASSERT_EQUALS(ngroups, NUM_BANKS);
 
     TS_ASSERT_EQUALS(map[1], 1);
     TS_ASSERT_EQUALS(map[9], 1);
@@ -64,12 +70,13 @@ public:
   void testClone() {
     // As test_constructor_from_Instrument(), set on ws, get on clone.
     // Fake instrument with 5*9 pixels with ID starting at 1
-    Instrument_sptr inst = ComponentCreationHelper::createTestInstrumentCylindrical(5);
+    const std::size_t NUM_BANKS = 5;
+    Instrument_sptr inst = ComponentCreationHelper::createTestInstrumentCylindrical(NUM_BANKS);
 
     GroupingWorkspace_sptr ws(new GroupingWorkspace(inst));
     auto cloned = ws->clone();
 
-    TS_ASSERT_EQUALS(cloned->getNumberHistograms(), 45);
+    TS_ASSERT_EQUALS(cloned->getNumberHistograms(), NUM_BANKS * PIXELS_PER_BANK);
     TS_ASSERT_EQUALS(cloned->blocksize(), 1);
     TS_ASSERT_EQUALS(cloned->getInstrument()->getName(),
                      "basic"); // Name of the test instrument
@@ -77,9 +84,9 @@ public:
     TS_ASSERT_EQUALS(dets.size(), 1);
 
     // Set the group numbers
-    for (int group = 0; group < 5; group++)
-      for (int i = 0; i < 9; i++)
-        ws->dataY(group * 9 + i)[0] = double(group + 1);
+    for (std::size_t group = 0; group < NUM_BANKS; group++)
+      for (std::size_t i = 0; i < PIXELS_PER_BANK; i++)
+        ws->dataY(group * PIXELS_PER_BANK + i)[0] = double(group + 1);
     cloned = ws->clone();
 
     // Get the map
@@ -87,7 +94,7 @@ public:
     int64_t ngroups;
     cloned->makeDetectorIDToGroupMap(map, ngroups);
 
-    TS_ASSERT_EQUALS(ngroups, 5);
+    TS_ASSERT_EQUALS(ngroups, NUM_BANKS);
 
     TS_ASSERT_EQUALS(map[1], 1);
     TS_ASSERT_EQUALS(map[9], 1);
@@ -148,7 +155,6 @@ public:
 
   void testDetIDsOfGroup() {
     const std::size_t NUM_BANKS = 3;
-    const std::size_t PIXELS_PER_BANK = 9;
     // As test_constructor_from_Instrument(), set on ws, get on clone.
     // Fake instrument with 3*9 pixels with ID starting at 1
     Instrument_sptr inst = ComponentCreationHelper::createTestInstrumentCylindrical(NUM_BANKS);
@@ -169,11 +175,11 @@ public:
     TS_ASSERT_EQUALS(ws->getGroupIDs(), std::vector({-1, 1, 2}));
 
     // 0 is not a valid id, -1 is not set
-    TS_ASSERT_EQUALS(ws->getDetIDsOfGroup(-1).size(), PIXELS_PER_BANK);
-    TS_ASSERT_EQUALS(ws->getDetIDsOfGroup(-1), std::vector({1, 4, 7, 10, 13, 16, 19, 22, 25}));
-    TS_ASSERT_EQUALS(ws->getDetIDsOfGroup(1).size(), PIXELS_PER_BANK);
-    TS_ASSERT_EQUALS(ws->getDetIDsOfGroup(1), std::vector({3, 6, 9, 12, 15, 18, 21, 24, 27}));
-    TS_ASSERT_EQUALS(ws->getDetIDsOfGroup(2).size(), PIXELS_PER_BANK);
-    TS_ASSERT_EQUALS(ws->getDetIDsOfGroup(2), std::vector({2, 5, 8, 11, 14, 17, 20, 23, 26}));
+    TS_ASSERT_EQUALS(ws->getDetectorIDsOfGroup(-1).size(), PIXELS_PER_BANK);
+    TS_ASSERT_EQUALS(ws->getDetectorIDsOfGroup(-1), std::vector({1, 4, 7, 10, 13, 16, 19, 22, 25}));
+    TS_ASSERT_EQUALS(ws->getDetectorIDsOfGroup(1).size(), PIXELS_PER_BANK);
+    TS_ASSERT_EQUALS(ws->getDetectorIDsOfGroup(1), std::vector({3, 6, 9, 12, 15, 18, 21, 24, 27}));
+    TS_ASSERT_EQUALS(ws->getDetectorIDsOfGroup(2).size(), PIXELS_PER_BANK);
+    TS_ASSERT_EQUALS(ws->getDetectorIDsOfGroup(2), std::vector({2, 5, 8, 11, 14, 17, 20, 23, 26}));
   }
 };

--- a/Framework/DataObjects/test/GroupingWorkspaceTest.h
+++ b/Framework/DataObjects/test/GroupingWorkspaceTest.h
@@ -146,15 +146,15 @@ public:
     TS_ASSERT_EQUALS(ws->getGroupIDs()[2], 2);
   }
 
-  void testGetGroupSpetraIDs() {
+  void testGetGroupSpectraIDs() {
     GroupingWorkspace_sptr ws(new GroupingWorkspace());
     // create a groupingworkspace with 2 groups
     ws->initialize(100, 1, 1);
     ws->dataY(0)[0] = 1;
     ws->dataY(1)[0] = 2;
     // 0 is not a valid id, -1 is null
-    TS_ASSERT_EQUALS(ws->getGroupSpetraIDs(-1).size(), 98);
-    TS_ASSERT_EQUALS(ws->getGroupSpetraIDs(1).size(), 1);
-    TS_ASSERT_EQUALS(ws->getGroupSpetraIDs(2).size(), 1);
+    TS_ASSERT_EQUALS(ws->getGroupSpectraIDs(-1).size(), 98);
+    TS_ASSERT_EQUALS(ws->getGroupSpectraIDs(1).size(), 1);
+    TS_ASSERT_EQUALS(ws->getGroupSpectraIDs(2).size(), 1);
   }
 };

--- a/Framework/PythonInterface/mantid/dataobjects/src/Exports/GroupingWorkspace.cpp
+++ b/Framework/PythonInterface/mantid/dataobjects/src/Exports/GroupingWorkspace.cpp
@@ -35,8 +35,8 @@ void export_GroupingWorkspace() {
       .def("getTotalGroups", &GroupingWorkspace::getTotalGroups, (arg("self")))
       .def("getGroupIDs", &GroupingWorkspace::getGroupIDs, return_value_policy<Policies::VectorToNumpy>(),
            (arg("self")))
-      .def("getDetIDsOfGroup", &GroupingWorkspace::getDetIDsOfGroup, return_value_policy<Policies::VectorToNumpy>(),
-           (arg("self,"), arg("groupID")));
+      .def("getDetectorIDsOfGroup", &GroupingWorkspace::getDetectorIDsOfGroup,
+           return_value_policy<Policies::VectorToNumpy>(), (arg("self,"), arg("groupID")));
 
   // register pointers
   RegisterWorkspacePtrToPython<GroupingWorkspace>();

--- a/Framework/PythonInterface/mantid/dataobjects/src/Exports/GroupingWorkspace.cpp
+++ b/Framework/PythonInterface/mantid/dataobjects/src/Exports/GroupingWorkspace.cpp
@@ -35,7 +35,7 @@ void export_GroupingWorkspace() {
       .def("getTotalGroups", &GroupingWorkspace::getTotalGroups, (arg("self")))
       .def("getGroupIDs", &GroupingWorkspace::getGroupIDs, return_value_policy<Policies::VectorToNumpy>(),
            (arg("self")))
-      .def("getGroupSpetraIDs", &GroupingWorkspace::getGroupSpetraIDs, return_value_policy<Policies::VectorToNumpy>(),
+      .def("getGroupSpectraIDs", &GroupingWorkspace::getGroupSpectraIDs, return_value_policy<Policies::VectorToNumpy>(),
            (arg("self,"), arg("groupID")));
 
   // register pointers

--- a/Framework/PythonInterface/mantid/dataobjects/src/Exports/GroupingWorkspace.cpp
+++ b/Framework/PythonInterface/mantid/dataobjects/src/Exports/GroupingWorkspace.cpp
@@ -35,7 +35,7 @@ void export_GroupingWorkspace() {
       .def("getTotalGroups", &GroupingWorkspace::getTotalGroups, (arg("self")))
       .def("getGroupIDs", &GroupingWorkspace::getGroupIDs, return_value_policy<Policies::VectorToNumpy>(),
            (arg("self")))
-      .def("getGroupSpectraIDs", &GroupingWorkspace::getGroupSpectraIDs, return_value_policy<Policies::VectorToNumpy>(),
+      .def("getDetIDsOfGroup", &GroupingWorkspace::getDetIDsOfGroup, return_value_policy<Policies::VectorToNumpy>(),
            (arg("self,"), arg("groupID")));
 
   // register pointers

--- a/Framework/PythonInterface/test/python/mantid/dataobjects/GroupingWorkspaceTest.py
+++ b/Framework/PythonInterface/test/python/mantid/dataobjects/GroupingWorkspaceTest.py
@@ -34,7 +34,7 @@ class GroupingWorkspaceTest(unittest.TestCase):
         self.assertEqual(2, len(ids))
 
     def test_get_group_spectra_IDs(self):
-        self.assertEqual(0, len(self.groupingWorkspace.getGroupSpectraIDs(-1)))  # default sws2d values are all 0
+        self.assertEqual(0, len(self.groupingWorkspace.getDetectorIDsOfGroup(-1)))  # default sws2d values are all 0
 
     def test_get_group_IDs_values(self):
         expected = np.sort(np.unique(self.groupingWorkspace.extractY()))
@@ -47,7 +47,7 @@ class GroupingWorkspaceTest(unittest.TestCase):
         for group in group_list:
             indexes = np.where(self.groupingWorkspace.extractY().flatten() == group)[0]
             expected = np.sort(np.array(self.groupingWorkspace.getSpectrumNumbers())[indexes])
-            actual = np.sort(self.groupingWorkspace.getGroupSpectraIDs(group.item()))
+            actual = np.sort(self.groupingWorkspace.getDetectorIDsOfGroup(group.item()))
             np.testing.assert_allclose(actual, expected)
 
 

--- a/Framework/PythonInterface/test/python/mantid/dataobjects/GroupingWorkspaceTest.py
+++ b/Framework/PythonInterface/test/python/mantid/dataobjects/GroupingWorkspaceTest.py
@@ -33,8 +33,8 @@ class GroupingWorkspaceTest(unittest.TestCase):
         ids = self.groupingWorkspace.getGroupIDs()
         self.assertEqual(2, len(ids))
 
-    def test_get_group_spetra_IDs(self):
-        self.assertEqual(0, len(self.groupingWorkspace.getGroupSpetraIDs(-1)))  # default sws2d values are all 0
+    def test_get_group_spectra_IDs(self):
+        self.assertEqual(0, len(self.groupingWorkspace.getGroupSpectraIDs(-1)))  # default sws2d values are all 0
 
     def test_get_group_IDs_values(self):
         expected = np.sort(np.unique(self.groupingWorkspace.extractY()))
@@ -47,7 +47,7 @@ class GroupingWorkspaceTest(unittest.TestCase):
         for group in group_list:
             indexes = np.where(self.groupingWorkspace.extractY().flatten() == group)[0]
             expected = np.sort(np.array(self.groupingWorkspace.getSpectrumNumbers())[indexes])
-            actual = np.sort(self.groupingWorkspace.getGroupSpetraIDs(group.item()))
+            actual = np.sort(self.groupingWorkspace.getGroupSpectraIDs(group.item()))
             np.testing.assert_allclose(actual, expected)
 
 

--- a/docs/source/release/v6.7.0/Framework/Data_Objects/New_features/35486.rst
+++ b/docs/source/release/v6.7.0/Framework/Data_Objects/New_features/35486.rst
@@ -1,4 +1,4 @@
 * added the following getter methods to ``GroupingWorkspace``:
   * ``getGroupIDs()``
   * ``getTotalGroups()``
-  * ``getGroupSpectraIDs()``
+  * ``getDetectorIDsOfGroup()``

--- a/docs/source/release/v6.7.0/Framework/Data_Objects/New_features/35486.rst
+++ b/docs/source/release/v6.7.0/Framework/Data_Objects/New_features/35486.rst
@@ -1,4 +1,4 @@
 * added the following getter methods to ``GroupingWorkspace``:
   * ``getGroupIDs()``
   * ``getTotalGroups()``
-  * ``getGroupSpetraIDs()``
+  * ``getGroupSpectraIDs()``

--- a/docs/source/release/v6.7.0/Framework/Python/New_features/35486.rst
+++ b/docs/source/release/v6.7.0/Framework/Python/New_features/35486.rst
@@ -1,4 +1,4 @@
 * exposed the following getter methods to ``GroupingWorkspace``:
   * ``getGroupIDs()``
   * ``getTotalGroups()``
-  * ``getGroupSpectraIDs()``
+  * ``getDetectorIDsOfGroup()``

--- a/docs/source/release/v6.7.0/Framework/Python/New_features/35486.rst
+++ b/docs/source/release/v6.7.0/Framework/Python/New_features/35486.rst
@@ -1,4 +1,4 @@
 * exposed the following getter methods to ``GroupingWorkspace``:
   * ``getGroupIDs()``
   * ``getTotalGroups()``
-  * ``getGroupSpetraIDs()``
+  * ``getGroupSpectraIDs()``

--- a/scripts/Calibration/tofpd/group_calibration.py
+++ b/scripts/Calibration/tofpd/group_calibration.py
@@ -122,7 +122,7 @@ def cc_calibrate_groups(
         snpts_group = SmoothNPoints[int(group) - 1] if type(SmoothNPoints) == list else SmoothNPoints
         cycling = OT_group < 1.0
 
-        sn = group_ws.getGroupSpetraIDs(group.item())
+        sn = group_ws.getGroupSpectraIDs(group.item())
         try:
             ws_indexes = [data_d.getIndexFromSpectrumNumber(int(i)) for i in sn]
         except RuntimeError:
@@ -227,6 +227,7 @@ def cc_calibrate_groups(
     DeleteWorkspace("_accum_cc")
     DeleteWorkspace("_tmp_group_cc")
     DeleteWorkspace("_tmp_group_cc_raw")
+    DeleteWorkspace("_tmp_group_intg")
     if cycling and "_tmp_group_cc_diffcal" in mtd:
         DeleteWorkspace("_tmp_group_cc_diffcal")
 

--- a/scripts/Calibration/tofpd/group_calibration.py
+++ b/scripts/Calibration/tofpd/group_calibration.py
@@ -310,8 +310,8 @@ def pdcalibration_groups(
     ApplyDiffCal(data_ws, CalibrationWorkspace=cc_diffcal)
     ConvertUnits(data_ws, Target="dSpacing", OutputWorkspace="_tmp_data_aligned")
     DiffractionFocussing("_tmp_data_aligned", GroupingWorkspace=group_ws, OutputWorkspace="_tmp_data_aligned")
-
     ConvertUnits("_tmp_data_aligned", Target="TOF", OutputWorkspace="_tmp_data_aligned")
+    Rebin(InputWorkspace="_tmp_data_aligned", OutputWorkspace="_tmp_data_aligned", Params=TofBinning, PreserveEvents=False)
 
     instrument = data_ws.getInstrument().getName()
 

--- a/scripts/Calibration/tofpd/group_calibration.py
+++ b/scripts/Calibration/tofpd/group_calibration.py
@@ -315,33 +315,7 @@ def pdcalibration_groups(
 
     instrument = data_ws.getInstrument().getName()
 
-    if instrument != "POWGEN":
-        PDCalibration(
-            InputWorkspace="_tmp_data_aligned",
-            TofBinning=TofBinning,
-            PreviousCalibrationTable=previous_calibration,
-            PeakFunction=PeakFunction,
-            PeakPositions=PeakPositions,
-            PeakWindow=PeakWindow,
-            PeakWidthPercent=PeakWidthPercent,
-            OutputCalibrationTable=f"{output_basename}_pd_diffcal",
-            DiagnosticWorkspaces=f"{output_basename}_pd_diag",
-        )
-        if to_skip:
-            ExtractSpectra(data_ws, WorkspaceIndexList=to_skip, OutputWorkspace="_tmp_group_to_skip")
-            ExtractUnmaskedSpectra("_tmp_group_to_skip", OutputWorkspace="_tmp_group_to_skip")
-            PDCalibration(
-                InputWorkspace="_tmp_group_to_skip",
-                TofBinning=TofBinning,
-                PreviousCalibrationTable=previous_calibration,
-                PeakFunction=PeakFunction,
-                PeakPositions=PeakPositions,
-                PeakWindow=PeakWindow,
-                PeakWidthPercent=PeakWidthPercent,
-                OutputCalibrationTable=f"{output_basename}_pd_diffcal_skip",
-                DiagnosticWorkspaces=f"{output_basename}_pd_diag_skip",
-            )
-    else:
+    if instrument == "POWGEN":
         pdcalib_for_powgen(
             mtd["_tmp_data_aligned"],
             TofBinning,
@@ -366,6 +340,32 @@ def pdcalibration_groups(
                 PeakWidthPercent,
                 f"{output_basename}_pd_diffcal_skip",
                 f"{output_basename}_pd_diag_skip",
+            )
+    else:
+        PDCalibration(
+            InputWorkspace="_tmp_data_aligned",
+            TofBinning=TofBinning,
+            PreviousCalibrationTable=previous_calibration,
+            PeakFunction=PeakFunction,
+            PeakPositions=PeakPositions,
+            PeakWindow=PeakWindow,
+            PeakWidthPercent=PeakWidthPercent,
+            OutputCalibrationTable=f"{output_basename}_pd_diffcal",
+            DiagnosticWorkspaces=f"{output_basename}_pd_diag",
+        )
+        if to_skip:
+            ExtractSpectra(data_ws, WorkspaceIndexList=to_skip, OutputWorkspace="_tmp_group_to_skip")
+            ExtractUnmaskedSpectra("_tmp_group_to_skip", OutputWorkspace="_tmp_group_to_skip")
+            PDCalibration(
+                InputWorkspace="_tmp_group_to_skip",
+                TofBinning=TofBinning,
+                PreviousCalibrationTable=previous_calibration,
+                PeakFunction=PeakFunction,
+                PeakPositions=PeakPositions,
+                PeakWindow=PeakWindow,
+                PeakWidthPercent=PeakWidthPercent,
+                OutputCalibrationTable=f"{output_basename}_pd_diffcal_skip",
+                DiagnosticWorkspaces=f"{output_basename}_pd_diag_skip",
             )
 
     CombineDiffCal(

--- a/scripts/Calibration/tofpd/group_calibration.py
+++ b/scripts/Calibration/tofpd/group_calibration.py
@@ -150,7 +150,7 @@ def cc_calibrate_groups(
 
         try:
             # detector ids that get focussed together
-            detids = group_ws.getDetIDsOfGroup(int(group))
+            detids = group_ws.getDetectorIDsOfGroup(int(group))
             # convert to workspace indices in the input data
             ws_indices = [det2WkspIndex[detid] for detid in detids]
             # remove masked spectra
@@ -162,16 +162,16 @@ def cc_calibrate_groups(
         if group in SkipCrossCorrelation:
             to_skip.extend(ws_indices)
 
+        num_spectra = len(ws_indices)  # takes masking into account
+        if num_spectra < 2:
+            to_skip.extend(ws_indices)
+            continue  # go to next group
+
         # grab out the spectra in d-space
 
         ExtractSpectra(data_d, WorkspaceIndexList=ws_indices, OutputWorkspace="_tmp_group_cc_d")
         # grab out the spectra in time-of-flight
         ExtractSpectra(data_ws, WorkspaceIndexList=ws_indices, OutputWorkspace="_tmp_group_cc_raw")
-        num_spectra = mtd["_tmp_group_cc_d"].getNumberHistograms()
-        if num_spectra < 2:
-            DeleteWorkspace("_tmp_group_cc_d")
-            DeleteWorkspace("_tmp_group_cc_raw")
-            continue  # go to next group
         Rebin("_tmp_group_cc_d", Params=f"{Xmin_group},{Step},{Xmax_group}", OutputWorkspace="_tmp_group_cc_d")
         if snpts_group >= 3:
             SmoothData("_tmp_group_cc_d", NPoints=snpts_group, OutputWorkspace="_tmp_group_cc_d")

--- a/scripts/Calibration/tofpd/group_calibration.py
+++ b/scripts/Calibration/tofpd/group_calibration.py
@@ -134,6 +134,8 @@ def cc_calibrate_groups(
     print("start loop over groups", "=" * 40)
     print("group ids=", group_ws.getGroupIDs())
     for group in group_ws.getGroupIDs():
+        if group == -1:
+            continue  # this is a group of unset pixels
         # Figure out input parameters for CrossCorrelate and GetDetectorOffset, specifically
         # for those parameters for which both a single value and a list is accepted. If a
         # list is given, that means different parameter setup will be used for different groups.
@@ -148,7 +150,7 @@ def cc_calibrate_groups(
 
         try:
             # detector ids that get focussed together
-            detids = group_ws.getGroupSpectraIDs(int(group))  # TODO current is detector ids
+            detids = group_ws.getDetIDsOfGroup(int(group))
             # convert to workspace indices in the input data
             ws_indices = [det2WkspIndex[detid] for detid in detids]
             # remove masked spectra

--- a/scripts/test/Calibration/tofpd/test_group_calibration.py
+++ b/scripts/test/Calibration/tofpd/test_group_calibration.py
@@ -30,6 +30,13 @@ def create_test_ws_and_group():
     ws = CreateSampleWorkspace(
         "Event", "User Defined", myFunc, BankPixelWidth=1, XUnit="dSpacing", XMax=5, BinWidth=0.001, NumEvents=100000, NumBanks=8
     )
+
+    # make the first spectra in each group brighter
+    # this forces an issue with np.argmax and all values being the same
+    ws.getEventList(0).multiply(1.1, 0.0)
+    ws.getEventList(4).multiply(1.1, 0.0)
+
+    # move some of the components
     for n in range(1, 5):
         MoveInstrumentComponent(ws, ComponentName=f"bank{n}", X=1 + n / 10, Y=0, Z=1 + n / 10, RelativePosition=False)
         MoveInstrumentComponent(ws, ComponentName=f"bank{n+4}", X=2 + n / 10, Y=0, Z=2 + n / 10, RelativePosition=False)

--- a/scripts/test/Calibration/tofpd/test_group_calibration.py
+++ b/scripts/test/Calibration/tofpd/test_group_calibration.py
@@ -72,7 +72,7 @@ class TestGroupCalibration(unittest.TestCase):
 
     def test_get_brightest(self):
         ws, _ = create_test_ws_and_group()
-        assert group_calibration._getBrightestWorkspaceIndex(ws) == 1
+        assert_equal(group_calibration._getBrightestWorkspaceIndex(ws), 0)
 
     def test_from_eng(self):
         ws, groups = create_test_ws_and_group()

--- a/scripts/test/Calibration/tofpd/test_group_calibration.py
+++ b/scripts/test/Calibration/tofpd/test_group_calibration.py
@@ -58,7 +58,10 @@ class TestGroupCalibration(unittest.TestCase):
         assert mapping
         assert len(mapping) == 8
         for i in range(1, 9):  # detids started at one
-            assert mapping[i] == i - 1
+            if i not in [4, 8]:
+                assert mapping[i] == i - 1
+            else:  # masked detectors get mapped to spectrum -1
+                assert mapping[i] == -1
 
     def test_from_eng(self):
         ws, groups = create_test_ws_and_group()
@@ -132,7 +135,6 @@ class TestGroupCalibration(unittest.TestCase):
         assert_equal(mtd[f"{output_workspace_basename}_pd_diffcal_mask"].extractY(), [[0], [0], [0], [1], [0], [0], [0], [1]])
 
     def test_from_prev_cal(self):
-
         ws, groups = create_test_ws_and_group()
 
         output_workspace_basename = "test_from_eng_prev_cal"

--- a/scripts/test/Calibration/tofpd/test_group_calibration.py
+++ b/scripts/test/Calibration/tofpd/test_group_calibration.py
@@ -33,8 +33,8 @@ def create_test_ws_and_group():
 
     # make the first spectra in each group brighter
     # this forces an issue with np.argmax and all values being the same
-    ws.getEventList(0).multiply(1.1, 0.0)
-    ws.getEventList(4).multiply(1.1, 0.0)
+    ws.getEventList(0).multiply(1.10, 0.0)
+    ws.getEventList(4).multiply(1.05, 0.0)
 
     # move some of the components
     for n in range(1, 5):
@@ -69,6 +69,10 @@ class TestGroupCalibration(unittest.TestCase):
                 assert mapping[i] == i - 1
             else:  # masked detectors get mapped to spectrum -1
                 assert mapping[i] == -1
+
+    def test_get_brightest(self):
+        ws, _ = create_test_ws_and_group()
+        assert group_calibration._getBrightestWorkspaceIndex(ws) == 1
 
     def test_from_eng(self):
         ws, groups = create_test_ws_and_group()

--- a/scripts/test/Calibration/tofpd/test_group_calibration.py
+++ b/scripts/test/Calibration/tofpd/test_group_calibration.py
@@ -22,6 +22,7 @@ from numpy.testing import assert_allclose, assert_equal
 
 
 def create_test_ws_and_group():
+    # create 8 spectra in d-spacing each with gaussian peaks parameterized here
     myFunc = (
         "name=Gaussian, PeakCentre=2, Height=100, Sigma=0.01;"
         + "name=Gaussian, PeakCentre=1, Height=100, Sigma=0.01;"
@@ -36,17 +37,23 @@ def create_test_ws_and_group():
     ws.getEventList(0).multiply(1.10, 0.0)
     ws.getEventList(4).multiply(1.05, 0.0)
 
-    # move some of the components
+    # the banks are named bank1...bank8
+    # move the position of the detectors
     for n in range(1, 5):
         MoveInstrumentComponent(ws, ComponentName=f"bank{n}", X=1 + n / 10, Y=0, Z=1 + n / 10, RelativePosition=False)
         MoveInstrumentComponent(ws, ComponentName=f"bank{n+4}", X=2 + n / 10, Y=0, Z=2 + n / 10, RelativePosition=False)
 
+    # mask detectors 4 and 8
+    # these are at workspace indices 3 and 7
     # masked spectra should not get calibrated
     MaskDetectors(ws, WorkspaceIndexList=[3, 7])
 
+    # modify the d-spacing of the data so the peaks are shifted from the ideal position in d-spacing
+    # these numbers are close to one since the calibration only moves from a certain percentage
+    # of the starting point
     ws = ScaleX(ws, Factor=1.05, IndexMin=1, IndexMax=1)
     ws = ScaleX(ws, Factor=0.95, IndexMin=2, IndexMax=2)
-    ws = ScaleX(ws, Factor=1.05, IndexMin=4, IndexMax=6)
+    ws = ScaleX(ws, Factor=1.05, IndexMin=4, IndexMax=6)  # QUESTION: should these be the same indices?
     ws = ScaleX(ws, Factor=1.02, IndexMin=5, IndexMax=5)
     ws = ScaleX(ws, Factor=0.98, IndexMin=6, IndexMax=6)
     ws = Rebin(ws, "0,0.001,5")
@@ -55,27 +62,26 @@ def create_test_ws_and_group():
     # detector ids are supplied here
     groups, _, _ = CreateGroupingWorkspace(InputWorkspace=ws, ComponentName="basic_rect", CustomGroupingString="1-4,5-8")
 
-    return ws, groups
+    detToSpecMap = {1: 0, 2: 1, 3: 2, 4: -1, 5: 4, 6: 5, 7: 6, 8: -1}
+
+    return ws, groups, detToSpecMap
 
 
 class TestGroupCalibration(unittest.TestCase):
     def test_spec_to_det_map(self):
-        ws, _ = create_test_ws_and_group()
+        ws, _, detToSpecMap = create_test_ws_and_group()
         mapping = group_calibration._createDetToWkspIndexMap(ws)
         assert mapping
-        assert len(mapping) == 8
-        for i in range(1, 9):  # detids started at one
-            if i not in [4, 8]:
-                assert mapping[i] == i - 1
-            else:  # masked detectors get mapped to spectrum -1
-                assert mapping[i] == -1
+        assert_equal(len(mapping), len(detToSpecMap))
+        for detid, specnum in detToSpecMap.items():
+            assert_equal(mapping[detid], specnum)
 
     def test_get_brightest(self):
-        ws, _ = create_test_ws_and_group()
+        ws, _, _ = create_test_ws_and_group()
         assert_equal(group_calibration._getBrightestWorkspaceIndex(ws), 0)
 
     def test_from_eng(self):
-        ws, groups = create_test_ws_and_group()
+        ws, groups, _ = create_test_ws_and_group()
 
         output_workspace_basename = "test_from_eng"
 
@@ -146,7 +152,7 @@ class TestGroupCalibration(unittest.TestCase):
         assert_equal(mtd[f"{output_workspace_basename}_pd_diffcal_mask"].extractY(), [[0], [0], [0], [1], [0], [0], [0], [1]])
 
     def test_from_prev_cal(self):
-        ws, groups = create_test_ws_and_group()
+        ws, groups, _ = create_test_ws_and_group()
 
         output_workspace_basename = "test_from_eng_prev_cal"
 
@@ -217,7 +223,7 @@ class TestGroupCalibration(unittest.TestCase):
         assert_equal(mtd["group_calibration_pd_diffcal_mask"].extractY(), [[0], [0], [0], [1], [0], [0], [0], [1]])
 
     def test_di_group_calibration(self):
-        ws, groups = create_test_ws_and_group()
+        ws, groups, _ = create_test_ws_and_group()
 
         starting_difc = [ws.spectrumInfo().difcUncalibrated(i) for i in range(ws.getNumberHistograms())]
 


### PR DESCRIPTION
There was a subtle bug introduced in #35486 which was returning information about spectra numbers in the GroupingWorkspace rather than detector ids. This updates the name of the method and modifies the code to collect all the detector ids. 

That issue was discovered while refactoring the code in `group_calibration.py` which has been modified to better use the information and be more efficient in both memory and processor usage. That was a refactor and is not user-facing.


**Report to:** @mguthriem

**To test:**

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

*There is no associated issue* in GitHub. [EWM1183](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=1183)

*This does not require release notes* because it is covered in (now updated) release notes.

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment, you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for the file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up on the list for other gatekeepers.