### PR TITLE
Fixing 4d workspace projection issue for SliceViewer

### DIFF
--- a/Testing/SystemTests/tests/qt/SliceViewerIntegrationTest.py
+++ b/Testing/SystemTests/tests/qt/SliceViewerIntegrationTest.py
@@ -8,7 +8,10 @@
 from functools import partial
 import io
 import systemtesting
+import os
 import sys
+import shutil
+import tempfile
 from threading import Thread
 from unittest.mock import patch
 

--- a/Testing/SystemTests/tests/qt/SliceViewerIntegrationTest.py
+++ b/Testing/SystemTests/tests/qt/SliceViewerIntegrationTest.py
@@ -28,6 +28,10 @@ from mantid.simpleapi import (
     SetUB,
     RenameWorkspace,
     ClearUB,
+    LoadMD,
+    SaveMD,
+    AddSampleLog,
+    SetMDFrame,
 )
 from mantid.api import AnalysisDataService
 from mantidqt.utils.qt.testing import get_application
@@ -511,6 +515,37 @@ class SliceViewerTestAxesLimitsRespectNonorthogonalTransform(systemtesting.Manti
         self.assertEqual(limits_nonorthog[1], limits[2:])
 
         pres.view.close()
+
+
+class SliceViewerTestLoadMD(systemtesting.MantidSystemTest, HelperTestingClass):
+    def runTest(self):
+        HelperTestingClass.__init__(self)
+
+        test_dir = tempfile.mkdtemp()
+
+        ws = CreateMDHistoWorkspace(
+            Dimensionality=4,
+            Extents="-3,3,-10,10,-5,5,0,2",
+            SignalInput=[1] * 11**4,
+            ErrorInput=[1] * 11**4,
+            NumberOfBins="11,11,11,11",
+            Names="values,[H,0,0],[0,K,0],[0,0,L]",
+            Units="a.b.u.,r.l.u.,r.l.u.,r.l.u.",
+            Frames="General Frame,HKL,HKL,HKL",
+        )
+
+        SetMDFrame("ws", MDFrame="HKL", Axes=[1, 2, 3])
+        AddSampleLog("ws", LogName="sample")
+        ws.getExperimentInfo(0).run().addProperty("W_MATRIX", [1, 0, 0, 0, 1, 0, 0, 0, 1], True)
+        SaveMD("ws", Filename=os.path.join(test_dir, "mdhist_4d.nxs"))
+        DeleteWorkspace("ws")
+
+        ws = LoadMD(os.path.join(test_dir, "mdhist_4d.nxs"))
+        pres = SliceViewer(ws)
+        self.assertAlmostEqual(pres.get_proj_matrix().flatten().tolist(), [1, 0, 0, 0, 1, 0, 0, 0, 1])
+        pres.view.close()
+
+        shutil.rmtree(test_dir)
 
 
 # private helper functions

--- a/docs/source/release/v6.7.0/Workbench/SliceViewer/Bugfixes/35529.rst
+++ b/docs/source/release/v6.7.0/Workbench/SliceViewer/Bugfixes/35529.rst
@@ -1,0 +1,1 @@
+- Fixed issue with projection matrix calculation when workspaces are loaded. This affected 4d workspaces.

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/models/model.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/models/model.py
@@ -518,41 +518,45 @@ class SliceViewerModel(SliceViewerBaseModel):
     def check_for_removed_original_workspace(self):
         return self.num_original_workspaces_at_init != self.number_of_active_original_workspaces()
 
+    def projection_matrix_from_log(self, ws):
+        try:
+            expt_info = ws.getExperimentInfo(0)
+            proj_matrix = np.array(expt_info.run().get(PROJ_MATRIX_LOG_NAME).value, dtype=float).reshape(3, 3)
+        except (AttributeError, KeyError, ValueError):  # run can be None so no .get()
+            # assume orthogonal projection if no log exists (i.e. proj_matrix is identity)
+            # needs to be 3x3 even if 2D ws as columns passed to recAngle when calc axes angles
+            proj_matrix = np.eye(3)
+        return proj_matrix
+
+    def projection_matrix_from_basis(self, ws):
+        proj_matrix = np.zeros((3, 3))
+        ndims = ws.getNumDims()
+        basis_matrix = np.zeros((ndims, ndims))
+        if len(list(ws.getBasisVector(0))) == ndims:  # basis vectors valid
+            for idim in range(ndims):
+                basis_matrix[:, idim] = list(ws.getBasisVector(idim))
+            # exclude non-Q dim elements from basis vectors
+            qflags = [ws.getDimension(idim).getMDFrame().isQ() for idim in range(ndims)]
+            i_nonq = np.flatnonzero(np.invert(qflags))
+            qmask = np.invert(basis_matrix[i_nonq, :].astype(bool).sum(axis=0).astype(bool))
+            # extract proj matrix from basis vectors of q dimension
+            # note for 2D the last col/row of proj_matrix is 0,0,1 - i.e. L
+            proj_matrix[: qmask.sum(), : qmask.sum()] = basis_matrix[qmask, :][:, qflags]
+        return proj_matrix
+
     def get_proj_matrix(self):
         ws = self._get_ws()
         ws_type = WorkspaceInfo.get_ws_type(ws)
         if ws_type != WS_TYPE.MATRIX:
-            proj_matrix = np.eye(3)  # needs to be 3x3 even if 2D ws as columns passed to recAngle when calc axes angles
             if ws_type == WS_TYPE.MDH:
                 # get basis vectors from workspace
-                ndims = ws.getNumDims()
-                basis_matrix = np.zeros((ndims, ndims))
-                for idim in range(ndims):
-                    basis_matrix[:, idim] = list(ws.getBasisVector(idim))
-                # exclude non-Q dim elements from basis vectors
-                qflags = [ws.getDimension(idim).getMDFrame().isQ() for idim in range(ndims)]
-                i_nonq = np.flatnonzero(np.invert(qflags))
-                qmask = np.invert(basis_matrix[i_nonq, :].astype(bool).sum(axis=0).astype(bool))
-                # extract proj matrix from basis vectors of q dimension
-                # note for 2D the last col/row of proj_matrix is 0,0,1 - i.e. L
-                proj_matrix[: qmask.sum(), : qmask.sum()] = basis_matrix[qmask, :][:, qflags]
+                proj_matrix = self.projection_matrix_from_basis(ws)
                 # if determinant is zero, try to get the info from log or revert back to identity matrix
                 if np.isclose(np.linalg.det(proj_matrix), 0):
-                    # for histo try to find axes from log
-                    try:
-                        expt_info = ws.getExperimentInfo(0)
-                        proj_matrix = np.array(expt_info.run().get(PROJ_MATRIX_LOG_NAME).value, dtype=float).reshape(3, 3)
-                    except (AttributeError, KeyError, ValueError):
-                        # revert back to orthogonal projection
-                        proj_matrix = np.eye(3)
+                    proj_matrix = self.projection_matrix_from_log(ws)
             else:
                 # for event try to find axes from log
-                try:
-                    expt_info = ws.getExperimentInfo(0)
-                    proj_matrix = np.array(expt_info.run().get(PROJ_MATRIX_LOG_NAME).value, dtype=float).reshape(3, 3)
-                except (AttributeError, KeyError, ValueError):  # run can be None so no .get()
-                    # assume orthogonal projection if no log exists (i.e. proj_matrix is identity)
-                    pass
+                proj_matrix = self.projection_matrix_from_log(ws)
             return proj_matrix
         else:
             return None

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_sliceviewer_model.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_sliceviewer_model.py
@@ -509,7 +509,7 @@ class SliceViewerModelTest(unittest.TestCase):
 
         # should revert to orthogonal
         axes_angles = model.get_axes_angles()
-        self.assertAlmostEqual(axes_angles[1, 2], np.pi / 2, delta=1e-10)
+        self.assertAlmostEqual(axes_angles[1, 2], np.pi / 4, delta=1e-10)
         for iy in range(1, 3):
             self.assertAlmostEqual(axes_angles[0, iy], np.pi / 2, delta=1e-10)
 


### PR DESCRIPTION
**Description of work**

Cherry-picked changes from #35425 that addresses only the bug fixes

**Purpose of work**
<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
-->

Latest version of slice viewer has issue with 4d workspaces due to incorrect projection matrix in non-ortho view preventing the its opening..

**Summary of work**
<!-- Please provide a short, high level description of the work that was done.
-->

Refactored the calculation into two parts- one inferring from the log and the other from the basis vectors. 

**Further detail of work**
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

Code was simplified into two functions to make it more readable.

**To test:**

Run `SliceViewerIntegrationTest` with the new `LoadMD` test

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.