### PR TITLE
Cache Poco::Glob object outside of the loop of logs

### DIFF
--- a/Framework/DataHandling/src/LoadNexusLogs.cpp
+++ b/Framework/DataHandling/src/LoadNexusLogs.cpp
@@ -780,23 +780,27 @@ void LoadNexusLogs::loadLogs(::NeXus::File &file, const std::string &absolute_en
     auto itPrefixBegin = logsSet.lower_bound(absolute_entry_name);
 
     if (allow_list.empty()) {
+      // convert the blocklist into a bunch of objects to handle globbing
+      std::vector<std::unique_ptr<Poco::Glob>> globblock_list;
+      for (const auto &block : block_list)
+        globblock_list.push_back(std::make_unique<Poco::Glob>(block));
+
       for (auto it = itPrefixBegin;
            it != logsSet.end() && it->compare(0, absolute_entry_name.size(), absolute_entry_name) == 0; ++it) {
         // must be third level entry
         if (std::count(it->begin(), it->end(), '/') == 3) {
           if (!block_list.empty()) {
             bool skip = false;
-            for (const auto &block : block_list) {
-              Poco::Glob glob(block);
-              if (glob.match((*it).substr((*it).find_last_of("/") + 1))) {
+            for (auto &block : globblock_list) {
+              if (block->match((*it).substr((*it).find_last_of("/") + 1))) {
                 skip = true;
-                break;
+                break; // from the loop of block items
               }
             }
             if (skip) {
-              continue;
+              continue; // go to next log
             }
-          }
+          } // end of looping over block_list
 
           if (isNxLog) {
             loadNXLog(file, *it, logClass, workspace);

--- a/Framework/DataHandling/src/LoadNexusLogs.cpp
+++ b/Framework/DataHandling/src/LoadNexusLogs.cpp
@@ -781,15 +781,18 @@ void LoadNexusLogs::loadLogs(::NeXus::File &file, const std::string &absolute_en
 
     if (allow_list.empty()) {
       // convert the blocklist into a bunch of objects to handle globbing
+      const bool has_block_list = (!block_list.empty());
       std::vector<std::unique_ptr<Poco::Glob>> globblock_list;
-      for (const auto &block : block_list)
-        globblock_list.push_back(std::make_unique<Poco::Glob>(block));
+      if (has_block_list) {
+        std::transform(block_list.cbegin(), block_list.cend(), std::back_inserter(globblock_list),
+                       [](const auto &block) { return std::make_unique<Poco::Glob>(block); });
+      }
 
       for (auto it = itPrefixBegin;
            it != logsSet.end() && it->compare(0, absolute_entry_name.size(), absolute_entry_name) == 0; ++it) {
         // must be third level entry
         if (std::count(it->begin(), it->end(), '/') == 3) {
-          if (!block_list.empty()) {
+          if (has_block_list) {
             bool skip = false;
             for (auto &block : globblock_list) {
               if (block->match((*it).substr((*it).find_last_of("/") + 1))) {


### PR DESCRIPTION
Since all logs are checked to see if they match the various globs, create the objects once and reuse them throughout. This has a .2s improvement (in 6s load) on loading SNAP_57514 with the list of blocked logs being `Phase*,Speed*,BL3:Chop:*,chopper*TDC`.

**To test:**

`LoadEventNexus` with the `BlockList` specifying some files. Example:
```python
# after these the big ones are frequency, proton_charge
biglogs="Phase*,Speed*,BL3:Chop:*,chopper*TDC"
       
LoadEventNexus(Filename='SNAP_57514',
               OutputWorkspace='SNAP_57514',
               Precount='True,
               LoadMonitors=False,
               BlockList=biglogs)
```

*There is no associated issue.*

*This does not require release notes* because it is a minor performance improvement that does not affect functionality.

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.