### PR TITLE
Fix Stitch1DMany child workspace names

### DIFF
--- a/Framework/Algorithms/inc/MantidAlgorithms/Stitch1DMany.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/Stitch1DMany.h
@@ -32,7 +32,7 @@ public:
 
   /// Performs the Stitch1D algorithm at a specific workspace index
   void doStitch1D(std::vector<API::MatrixWorkspace_sptr> &toStitch, const std::vector<double> &manualScaleFactors,
-                  API::Workspace_sptr &outWS, std::string &outName);
+                  API::Workspace_sptr &outWS);
 
   /// Performs the Stitch1DMany algorithm at a specific period
   void doStitch1DMany(const size_t period, const bool useManualScaleFactors, std::string &outName,

--- a/Framework/Algorithms/inc/MantidAlgorithms/Stitch1DMany.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/Stitch1DMany.h
@@ -45,6 +45,8 @@ private:
   bool checkGroups() override { return false; }
   /// Overwrites Algorithm method.
   void exec() override;
+  /// Creates a correctly formatted name for a stitched child workspace in a workspace group
+  std::string createChildWorkspaceName(const std::string &groupName, const size_t periodIndex);
 
   // A 2D matrix holding workspaces obtained from each workspace list/group
   std::vector<std::vector<API::MatrixWorkspace_sptr>> m_inputWSMatrix;

--- a/Framework/Algorithms/src/Stitch1DMany.cpp
+++ b/Framework/Algorithms/src/Stitch1DMany.cpp
@@ -258,9 +258,8 @@ void Stitch1DMany::exec() {
         std::transform(m_inputWSMatrix.begin(), m_inputWSMatrix.end(), std::back_inserter(inMatrix),
                        [i](const auto &ws) { return ws[i]; });
 
-        outName = groupName;
         Workspace_sptr outStitchedWS;
-        doStitch1D(inMatrix, periodScaleFactors, outStitchedWS, outName);
+        doStitch1D(inMatrix, periodScaleFactors, outStitchedWS);
         // Add name of stitched workspaces to group list and ADS
         outName = createChildWorkspaceName(groupName, i);
         toGroup.emplace_back(outName);
@@ -277,8 +276,7 @@ void Stitch1DMany::exec() {
 
     m_outputWorkspace = AnalysisDataService::Instance().retrieveWS<Workspace>(groupName);
   } else {
-    std::string tempOutName;
-    doStitch1D(m_inputWSMatrix.front(), m_manualScaleFactors, m_outputWorkspace, tempOutName);
+    doStitch1D(m_inputWSMatrix.front(), m_manualScaleFactors, m_outputWorkspace);
   }
   // Save output
   this->setProperty("OutputWorkspace", m_outputWorkspace);
@@ -289,20 +287,16 @@ void Stitch1DMany::exec() {
  * @param toStitch :: Vector of workspaces to be stitched
  * @param manualScaleFactors :: Provided values for scaling factors
  * @param outWS :: Output stitched workspace
- * @param outName :: Output stitched workspace name
  */
 void Stitch1DMany::doStitch1D(std::vector<MatrixWorkspace_sptr> &toStitch,
-                              const std::vector<double> &manualScaleFactors, Workspace_sptr &outWS,
-                              std::string &outName) {
+                              const std::vector<double> &manualScaleFactors, Workspace_sptr &outWS) {
 
   auto lhsWS = toStitch.front();
-  outName += "_" + lhsWS->getName();
   // Support Python list syntax for selecting the last element in the list
   auto indexOfReference = m_indexOfReference == -1 ? toStitch.size() - 1 : m_indexOfReference;
 
   for (size_t i = 1; i < toStitch.size(); i++) {
     auto rhsWS = toStitch[i];
-    outName += "_" + rhsWS->getName();
     // Scale the LHS ws until we have scaled to the reference ws. After that we scale the RHS ws to keep the scaling.
     auto scaleRHSWorkspace = i > indexOfReference;
 

--- a/Framework/Algorithms/src/Stitch1DMany.cpp
+++ b/Framework/Algorithms/src/Stitch1DMany.cpp
@@ -262,6 +262,7 @@ void Stitch1DMany::exec() {
         Workspace_sptr outStitchedWS;
         doStitch1D(inMatrix, periodScaleFactors, outStitchedWS, outName);
         // Add name of stitched workspaces to group list and ADS
+        outName = createChildWorkspaceName(groupName, i);
         toGroup.emplace_back(outName);
         AnalysisDataService::Instance().addOrReplace(outName, outStitchedWS);
       }
@@ -357,8 +358,7 @@ void Stitch1DMany::doStitch1DMany(const size_t period, const bool useManualScale
     toProcess.emplace_back(wsName);
   }
 
-  // Needed to ensure child workspace name simpler
-  outName += "_" + std::to_string(period + 1);
+  outName = createChildWorkspaceName(outName, period);
 
   auto alg = createChildAlgorithm("Stitch1DMany");
   alg->initialize();
@@ -376,6 +376,14 @@ void Stitch1DMany::doStitch1DMany(const size_t period, const bool useManualScale
   alg->execute();
 
   outScaleFactors = alg->getProperty("OutScaleFactors");
+}
+
+/** Creates a correctly formatted name for a stitched child workspace in a workspace group
+ * @param groupName :: The name of the workspace group
+ * @param periodIndex :: The period index for the child workspace
+ */
+std::string Stitch1DMany::createChildWorkspaceName(const std::string &groupName, const size_t periodIndex) {
+  return groupName + "_" + std::to_string(periodIndex + 1);
 }
 
 } // namespace Mantid::Algorithms

--- a/Framework/Algorithms/test/Stitch1DManyTest.h
+++ b/Framework/Algorithms/test/Stitch1DManyTest.h
@@ -724,7 +724,7 @@ public:
     createUniformWorkspace(0.8, 0.1, 1.6, 2.6, "ws4");
     doGroupWorkspaces("ws3, ws4", "group2");
 
-    // will produce a group outws containing outws_ws1_ws3, outws_ws2_ws4
+    // will produce a group outws containing two child workspaces
     Stitch1DMany alg;
     alg.setChild(true);
     alg.initialize();
@@ -814,7 +814,7 @@ public:
     createUniformWorkspace(0.8, 0.1, 1.6, 2.6, "ws4");
     doGroupWorkspaces("ws3, ws4", "group2");
 
-    // Will produce a group outws containing outws_ws1_ws3, outws_ws2_ws4
+    // Will produce a group outws containing two child workspaces
     Stitch1DMany alg;
     alg.setChild(true);
     alg.initialize();
@@ -914,8 +914,7 @@ public:
     createUniformWorkspace(1.6, 0.1, 1.6, 3.0, "ws6");
     doGroupWorkspaces("ws5, ws6", "group3");
 
-    // Will produce a group outws containing outws_ws1_ws3_ws5,
-    // outws_ws2_ws4_ws6
+    // Will produce a group outws containing two child workspaces
     Stitch1DMany alg;
     alg.setChild(true);
     alg.initialize();
@@ -1024,8 +1023,7 @@ public:
     createUniformWorkspace(1.6, 0.1, 1.6, 3.0, "ws6");
     doGroupWorkspaces("ws5, ws6", "group3");
 
-    // Will produce a group outws containing outws_ws1_ws3_ws5 and
-    // outws_ws2_ws4_ws6
+    // Will produce a group outws containing two child workspaces
     Stitch1DMany alg;
     alg.setChild(true);
     alg.initialize();
@@ -1110,7 +1108,6 @@ public:
     TS_ASSERT_DELTA(scales[3], 0.6249, 0.0001);
     // Check workspaces in ADS
     auto wsInADS = AnalysisDataService::Instance().getObjectNames();
-    // In ADS: group1, group2, grou3, ws1, ws2, ws3, ws4, ws5, ws6 and
     TS_ASSERT_EQUALS(wsInADS.size(), 12)
     TS_ASSERT_EQUALS(wsInADS[3], "outws")
     TS_ASSERT_EQUALS(wsInADS[4], "outws_1")
@@ -1149,8 +1146,7 @@ public:
     TS_ASSERT_THROWS(alg0.execute(), const std::runtime_error &);
     TS_ASSERT(!alg0.isExecuted())
 
-    // Will produce a group outws containing a single workspace named
-    // outws_ws1_ws3_ws5
+    // Will produce a group outws containing a single workspace
     Stitch1DMany alg;
     alg.setChild(true);
     alg.initialize();
@@ -1296,7 +1292,6 @@ public:
 
     // Check workspaces in ADS
     auto wsInADS = AnalysisDataService::Instance().getObjectNames();
-    // In ADS: group1, group2, outws_ws1_ws3, outws_ws2_ws4, ws1, ws2, ws3, ws4
     TS_ASSERT_EQUALS(wsInADS.size(), 9)
     // Remove workspaces from ADS
     AnalysisDataService::Instance().clear();
@@ -1387,8 +1382,7 @@ public:
     createUniformWorkspace(1.6, 0.1, 1.6, 3.0, "ws6");
     doGroupWorkspaces("ws5, ws6", "group3");
 
-    // Will produce a group outws containing outws_ws1_ws3_ws5 and
-    // outws_ws2_ws4_ws6
+    // Will produce a group outws containing two child workspaces
     Stitch1DMany alg;
     alg.setChild(true);
     alg.initialize();

--- a/Framework/Algorithms/test/Stitch1DManyTest.h
+++ b/Framework/Algorithms/test/Stitch1DManyTest.h
@@ -1113,8 +1113,8 @@ public:
     // In ADS: group1, group2, grou3, ws1, ws2, ws3, ws4, ws5, ws6 and
     TS_ASSERT_EQUALS(wsInADS.size(), 12)
     TS_ASSERT_EQUALS(wsInADS[3], "outws")
-    TS_ASSERT_EQUALS(wsInADS[4], "outws_ws1_ws3_ws5")
-    TS_ASSERT_EQUALS(wsInADS[5], "outws_ws2_ws4_ws6")
+    TS_ASSERT_EQUALS(wsInADS[4], "outws_1")
+    TS_ASSERT_EQUALS(wsInADS[5], "outws_2")
     // Clear the ADS
     AnalysisDataService::Instance().clear();
   }
@@ -1359,8 +1359,8 @@ public:
     // ws1, ws2, ws3, ws4, ws5, ws6 and
     TS_ASSERT_EQUALS(wsInADS.size(), 12)
     TS_ASSERT_EQUALS(wsInADS[3], "outws")
-    TS_ASSERT_EQUALS(wsInADS[4], "outws_ws1_ws3_ws5")
-    TS_ASSERT_EQUALS(wsInADS[5], "outws_ws2_ws4_ws6")
+    TS_ASSERT_EQUALS(wsInADS[4], "outws_1")
+    TS_ASSERT_EQUALS(wsInADS[5], "outws_2")
     TS_ASSERT_EQUALS(wsInADS.size(), 12)
     // Clear the ADS
     AnalysisDataService::Instance().clear();


### PR DESCRIPTION
**Description of work**

**Purpose of work**
<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
-->
This change is required to make the stitched child workspace names consistent for multi-period data regardless of whether or not we're using manual scale factors.

**Report to:** Becky at ISIS

**Summary of work**
<!-- Please provide a short, high level description of the work that was done.
-->
This PR ensures that all paths through the code should now result in the correct name format.

**Further detail of work**
<!-- Please provide a more detailed description of the work that has been undertaken.
-->
I've pulled the creation of the child workspace name into it's own method, `createChildWorkspaceName`, and then called that from all of the relevant places. Hopefully we can avoid this type of bug in the future by only having one place that defines the format.

I've updated unit tests and I've also removed/altered any comments in the tests that mentioned specific child workspace naming, as I don't think these add much for developers and easily become out of date.

I noticed that, after the changes in this PR, the `doStitch1D` method in the algorithm no longer does anything with the `outName` parameter, so I removed it.

**To test:**

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->
Run through tests on the linked issue and check the behaviour is now as expected.

Fixes #35563. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

*This does not require release notes* because **it fixes a bug from PR #35466 for a change that is new in release 6.7.**

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.