### PR TITLE
Fix ConvertUnits logic error in indirect data reduction interface

### DIFF
--- a/qt/scientific_interfaces/Indirect/IndirectDiffractionReduction.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectDiffractionReduction.cpp
@@ -47,7 +47,7 @@ void IndirectDiffractionReduction::initLayout() {
   m_uiForm.pbSettings->setIcon(IndirectSettings::icon());
 
   m_plotOptionsPresenter =
-      std::make_unique<IndirectPlotOptionsPresenter>(m_uiForm.ipoPlotOptions, PlotWidget::Spectra, "0");
+      std::make_unique<IndirectPlotOptionsPresenter>(m_uiForm.ipoPlotOptions, PlotWidget::SpectraUnit, "0");
 
   connect(m_uiForm.pbSettings, SIGNAL(clicked()), this, SLOT(settings()));
   connect(m_uiForm.pbHelp, SIGNAL(clicked()), this, SLOT(help()));

--- a/qt/scientific_interfaces/Indirect/IndirectPlotOptionsPresenter.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectPlotOptionsPresenter.cpp
@@ -72,6 +72,7 @@ void IndirectPlotOptionsPresenter::setupPresenter(PlotWidget const &plotType, st
   m_view->setIndices(QString::fromStdString(fixedIndices));
   m_model->setFixedIndices(fixedIndices);
 
+  m_plotType = plotType;
   setOptionsEnabled(false);
 }
 
@@ -87,6 +88,7 @@ void IndirectPlotOptionsPresenter::watchADS(bool on) {
 }
 
 void IndirectPlotOptionsPresenter::setPlotType(PlotWidget const &plotType) {
+  m_plotType = plotType;
   m_view->setPlotType(plotType, m_model->availableActions());
 }
 
@@ -141,7 +143,11 @@ void IndirectPlotOptionsPresenter::clearWorkspaces() {
   setOptionsEnabled(false);
 }
 
-void IndirectPlotOptionsPresenter::setUnit(std::string const &unit) { m_model->setUnit(unit); }
+void IndirectPlotOptionsPresenter::setUnit(std::string const &unit) {
+  if (m_plotType == PlotWidget::SpectraUnit || m_plotType == PlotWidget::SpectraContourUnit) {
+    m_model->setUnit(unit);
+  }
+}
 
 void IndirectPlotOptionsPresenter::setIndices() {
   auto const selectedIndices = m_view->selectedIndices().toStdString();

--- a/qt/scientific_interfaces/Indirect/IndirectPlotOptionsPresenter.h
+++ b/qt/scientific_interfaces/Indirect/IndirectPlotOptionsPresenter.h
@@ -69,6 +69,7 @@ private:
 
   IndirectPlotOptionsView *m_view;
   std::unique_ptr<IndirectPlotOptionsModel> m_model;
+  PlotWidget m_plotType;
 };
 
 } // namespace CustomInterfaces

--- a/qt/scientific_interfaces/Indirect/IndirectPlotOptionsView.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectPlotOptionsView.cpp
@@ -97,7 +97,7 @@ void IndirectPlotOptionsView::emitSelectedWorkspaceChanged(QString const &worksp
 }
 
 void IndirectPlotOptionsView::emitSelectedUnitChanged(QString const &unit) {
-  if (unit.toStdString() != "") {
+  if (!unit.isEmpty()) {
     emit selectedUnitChanged(displayStrToUnitId.at(unit.toStdString()));
   }
 }
@@ -153,6 +153,7 @@ void IndirectPlotOptionsView::setPlotType(PlotWidget const &plotType,
   m_plotOptions->tbPlot->setVisible(true);
   m_plotOptions->pbPlotSpectra->setVisible(true);
   m_plotOptions->pbPlotSpectra->setText(getAction(availableActions, "Plot Spectra"));
+  m_plotOptions->cbPlotUnit->setVisible(false);
 
   switch (plotType) {
   case PlotWidget::Spectra:


### PR DESCRIPTION
**Description of work**
This PR fixes the "logic error" ConvertUnits in the indirect data reduction interface. The fix involved removing the unit combo box from the output plot options as it was not intended to be present in this interface. It should only appear in the indirect diffraction interface.
**Purpose of work**
This error was discovered during the pre-release manual testing session (#35535). The goal is to fix the error for the release.
**Summary of work**
 "logic error" ConvertUnits in the indirect data reduction interface has been fixed.
**Further detail of work**
<!-- Please provide a more detailed description of the work that has been undertaken.
-->
The unit combo has been removed as it should only appear in the indirect diffraction window. Previously, attempting to plot data would result in a "Logic error" in the ConvertUnits conversation. The reason for this is the addition of the ConvertUnits call, which was implemented to include the unit options feature


**To test:**
1- Open Interfaces > Indirect > Data reduction
2- Make sure the Instrument is set to IRIS
3- Go to the ISIS calibration
4- Enter Run number 26173
5- Check the Create RES box
6- Click Run
7- This should generate a workspace with _res at the end
8- In the Output options, select the _res workspace and click Plot Spectra. This should produce a spectrum plot.
<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

Fixes #35568<!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->
*This does not require release notes* because **it is a bug fix**

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.