### PR TITLE
Improve auto-population behaviour for Save File input in ISIS SANS GUI

### DIFF
--- a/docs/source/release/v6.7.0/SANS/Bugfixes/35604.rst
+++ b/docs/source/release/v6.7.0/SANS/Bugfixes/35604.rst
@@ -1,0 +1,1 @@
+- Fixed a bug where the Save File input on the Sum Runs tab in the ISIS SANS GUI would stop auto-populating if you simply clicked the input or pressed enter without making any text changes.

--- a/scripts/Interface/ui/sans_isis/add_runs_page.py
+++ b/scripts/Interface/ui/sans_isis/add_runs_page.py
@@ -24,7 +24,7 @@ class AddRunsPage(QtWidgets.QWidget, Ui_AddRunsPage):
 
     def _connect_signals(self):
         self.sumButton.pressed.connect(self.sum)
-        self.fileNameEdit.editingFinished.connect(self.outFileChanged)
+        self.fileNameEdit.textEdited.connect(self.outFileChanged)
         self.saveDirectoryButton.clicked.connect(self.saveDirectoryClicked)
 
     def run_selector_view(self):


### PR DESCRIPTION
**Description of work**

**Purpose of work**
<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
-->
Our scientists have been finding that the Save File input on the Sum Runs tab sometimes appears to stop auto-populating at random. This is currently difficult to reproduce and therefore debug, however we noticed that the auto-population was easy to switch off accidentally because you simply had to click into the input to trigger this. While more investigation and changes are likely to be required to provide a good long-term solution, the hope is that this PR will offer a small improvement that might help with diagnosing future problems.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**Summary of work**
<!-- Please provide a short, high level description of the work that was done.
-->
Changing the signal we connect to from `finishedEditing` to `textEdited` means that the user has to actually type in the input to trigger the signal that will switch off auto-populate. The downside is that it means more signals will be fired, however for now this seems OK.

**To test:**

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->
1) Open the ISIS SANS interface
2) Go to the Sum Runs tab
3) Click into the Save File input at the bottom. Don't type any text, but simply hit enter on your keyboard.
4) Complete the first three steps of these manual testing instructions https://developer.mantidproject.org/Testing/SANSGUI/ISISSANSGUITests.html#sum-runs. This will confirm that the auto-populate has not been disabled by the actions taken so far. Note, if you have any problems, try running through the setup instructions on the manual testing page.
5) Next make a change to the value in the Save File input.
6) Click Remove All to clear the runs added so far and then repeat step 4. This time the Save File name should not change as auto-populate will have been disabled correctly. Note that it is known existing behaviour that auto-populate still disables even if the name hasn't changed after editing.

Refs #35603. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.