### PR TITLE
Add extra unit tests for ReflectometryISISCalibration

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ReflectometryISISCalibration.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ReflectometryISISCalibration.py
@@ -39,7 +39,7 @@ class ReflectometryISISCalibration(DataProcessorAlgorithm):
 
     def summary(self):
         """Return a summary of the algorithm."""
-        return "Corrects the positions of detector pixels by applying TwoTheta offsets provided in a calibration file"
+        return "Corrects the positions of detector pixels by applying TwoTheta offsets provided in a calibration file."
 
     def seeAlso(self):
         """Return a list of related algorithm names."""


### PR DESCRIPTION
**Description of work**

**Purpose of work**
<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
-->
This PR adds the extra unit test coverage that was missing from PR #35494.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**Summary of work**
<!-- Please provide a short, high level description of the work that was done.
-->
Adds unit tests to ensure that we have coverage of the following:

- Coverage of the calibration file parsing logic. I had delayed doing this as I was keen to investigate if there was a way that didn't require lots of test calibration files to be added to our unit test data. I found a helper class within Mantid that provides a wrapper around Pythons tempfile library and seemed to offer the functionality I needed.

- I have added a unit test to cover the case where the algorithm is moving a detector pixel that has a negative theta value to start with.

**To test:**

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->
Tests should pass. Check that coverage seems sufficient.

Fixes #35352. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.