### PR TITLE
Create less temporary objects

### DIFF
--- a/Framework/DataHandling/test/LoadNexusLogsTest.h
+++ b/Framework/DataHandling/test/LoadNexusLogsTest.h
@@ -221,7 +221,13 @@ public:
     TimeSeriesProperty<double> *pclog = dynamic_cast<TimeSeriesProperty<double> *>(run.getLogData("proton_charge"));
     TS_ASSERT(pclog);
     TS_ASSERT_EQUALS(pclog->size(), 23806);
-    TS_ASSERT(pclog->getStatistics().duration > 4e9);
+    // interesting behavior shown
+    // last time in seconds is 4.29497e+09 which is 2147-Oct-11 03:51:09
+    // but the maximum DateAndTime to be represented is 2136-Feb-20 23:53:38.427387903
+    // so the final time in the log ends up being DateAndTime::maximum()
+    const double DURATION_EXP =
+        DateAndTime::secondsFromDuration(DateAndTime::maximum() - DateAndTime("2011-Sep-03 21:22:53"));
+    TS_ASSERT_EQUALS(pclog->getStatistics().duration, DURATION_EXP);
 
     // 3rd entry On-Off
     testWS = createTestWorkspace();

--- a/Framework/Kernel/src/PropertyManager.cpp
+++ b/Framework/Kernel/src/PropertyManager.cpp
@@ -185,10 +185,9 @@ PropertyManager *PropertyManager::cloneInTimeROI(const Kernel::TimeROI &timeROI)
   PropertyManager *newMgr = new PropertyManager();
   newMgr->m_orderedProperties.reserve(m_orderedProperties.size());
   // We need to do a deep copy of the property pointers here
-  for (auto prop : m_orderedProperties) {
-    auto tsp = dynamic_cast<ITimeSeriesProperty *>(prop);
+  for (const auto &prop : m_orderedProperties) {
     std::unique_ptr<Property> newProp;
-    if (tsp)
+    if (const auto tsp = dynamic_cast<const ITimeSeriesProperty *>(prop))
       newProp = std::unique_ptr<Property>(tsp->cloneInTimeROI(timeROI));
     else
       newProp = std::unique_ptr<Property>(prop->clone());

--- a/Framework/Kernel/src/TimeSeriesProperty.cpp
+++ b/Framework/Kernel/src/TimeSeriesProperty.cpp
@@ -1416,8 +1416,10 @@ void TimeSeriesProperty<TYPE>::create(const Types::Core::DateAndTime &start_time
   else
     m_propSortedFlag = TimeSeriesSortStatus::TSUNSORTED;
   // set the values
+  constexpr double SEC_TO_NANO{1000000000.0};
+  const uint64_t start_time_ns = static_cast<uint64_t>(start_time.totalNanoseconds());
   for (std::size_t i = 0; i < num; i++) {
-    m_values.emplace_back(start_time + static_cast<int64_t>(time_sec[i] * 1000000000.), new_values[i]);
+    m_values.emplace_back(start_time_ns + static_cast<uint64_t>(time_sec[i] * SEC_TO_NANO), new_values[i]);
   }
 
   // reset the size

--- a/Framework/Kernel/src/TimeSeriesProperty.cpp
+++ b/Framework/Kernel/src/TimeSeriesProperty.cpp
@@ -1406,10 +1406,22 @@ void TimeSeriesProperty<TYPE>::create(const Types::Core::DateAndTime &start_time
     throw std::invalid_argument(msg.str());
   }
 
-  // Make the times(as seconds) into a vector of DateAndTime in one go.
-  std::vector<DateAndTime> times;
-  DateAndTime::createVector(start_time, time_sec, times);
-  this->create(times, new_values);
+  clear();
+  const std::size_t num = new_values.size();
+  m_values.reserve(num);
+
+  // set the sorted flag
+  if (std::is_sorted(time_sec.cbegin(), time_sec.cend()))
+    m_propSortedFlag = TimeSeriesSortStatus::TSSORTED;
+  else
+    m_propSortedFlag = TimeSeriesSortStatus::TSUNSORTED;
+  // set the values
+  for (std::size_t i = 0; i < num; i++) {
+    m_values.emplace_back(start_time + static_cast<int64_t>(time_sec[i] * 1000000000.), new_values[i]);
+  }
+
+  // reset the size
+  m_size = static_cast<int>(m_values.size());
 }
 
 //--------------------------------------------------------------------------------------------


### PR DESCRIPTION
Rather than create a temporary vector of log times, create the times on-the-fly while adding time/value pairs to the `TimeSeriesProperty`. This does save ~.2s in the workflow below.

**Summary of work**
<!-- Please provide a short, high level description of the work that was done.
-->

**Further detail of work**
<!-- Please provide a more detailed description of the work that has been undertaken.
-->


**To test:**

Run the following before and after (part of a system test) and see that it is significantly faster
```python
from mantid.simpleapi import *
# add the system test data directory to the search path
# set the default facility to SNS
Load(Filename="HYS_13656-13658", OutputWorkspace="sum")
SetGoniometer(Workspace="sum", Axis0="s1,0,1,0,1")
GenerateEventsFilter(
    InputWorkspace="sum",
    OutputWorkspace="splboth",
    InformationWorkspace="info",
    UnitOfTime="Nanoseconds",
    LogName="s1",
    MaximumLogValue=90,
    LogValueInterval=1,
)
FilterEvents(
    InputWorkspace="sum",
    SplitterWorkspace="splboth",
    InformationWorkspace="info",
    FilterByPulseTime=True,
    GroupWorkspaces=True,
    OutputWorkspaceIndexedFrom1=True,
    OutputWorkspaceBaseName="split",
)
```

*There is no associated issue.*

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.