### PR TITLE
Fix bug calculating time-avg-mean with duplicates

### DIFF
--- a/Framework/Kernel/src/TimeSeriesProperty.cpp
+++ b/Framework/Kernel/src/TimeSeriesProperty.cpp
@@ -764,22 +764,25 @@ TimeSeriesProperty<TYPE>::averageAndStdDevInFilter(const std::vector<TimeInterva
         duration = DateAndTime::secondsFromDuration(m_values[index].time() - startTime);
         startTime = m_values[index].time();
       }
-      weighted_sum += duration;
       mean_prev = mean_current;
+      if (duration > 0.) {
+        weighted_sum += duration;
 
-      mean_current = mean_prev + (duration / weighted_sum) * (value - mean_prev);
-      s += duration * (value - mean_prev) * (value - mean_current);
-
+        mean_current = mean_prev + (duration / weighted_sum) * (value - mean_prev);
+        s += duration * (value - mean_prev) * (value - mean_current);
+      }
       value = static_cast<double>(m_values[index].value());
     }
 
     // Now close off with the end of the current filter range
     duration = DateAndTime::secondsFromDuration(time.stop() - startTime);
-    weighted_sum += duration;
-    mean_prev = mean_current;
+    if (duration > 0.) {
+      weighted_sum += duration;
+      mean_prev = mean_current;
 
-    mean_current = mean_prev + (duration / weighted_sum) * (value - mean_prev);
-    s += duration * (value - mean_prev) * (value - mean_current);
+      mean_current = mean_prev + (duration / weighted_sum) * (value - mean_prev);
+      s += duration * (value - mean_prev) * (value - mean_current);
+    }
   }
   variance = s / weighted_sum;
   // Normalise by the total time


### PR DESCRIPTION
Since the time-average mean and stddev is done using [Knuth's algorithm](https://gist.github.com/musically-ut/1502045/106af3cf8bd4db0c8581218759040b058da778d3) there is an issue with the case of the weight being zero causing a nan in the middle of the calculation. This is seen when the log has two values at the same time. This checks for that condition and skips those values.

**To test:**

```python
from mantid.simpleapi import *
Load(Filename='EMU00081100.nxs', OutputWorkspace='EMU00081100')
ws = mtd['EMU00081100_1']

run = ws.getRun()

data = run.getLogData('field_danfysik')
print('-'*30, data.size())
for ti,val in zip(data.times, data.value):
  print(ti,val)
print('-'*30)
field = [f for f in data.value]
tt = data.times

tmp = []
for t in tt:
    tmp.append(t)

time = []
for k in range(len(tt)-1):
    time.append(tt[k+1] - tt[k])
time.append(tt[-1] - tt[-2]) # reuse duration from second to last

numerator = 0.0
denominator = 0.0
print(type(time), type(field))

for k in range(len(time)):
    print(k, float(time[k]), float(time[k])*float(field[k]))
    numerator += float(time[k])*float(field[k])
    denominator += float(time[k])

print(numerator/denominator, data.getStatistics().time_mean)
```

Fixes #35587 and [EWM1655](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=1655)

*This does not require release notes* because it fixes a bug introduced during the release cycle.

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.