### PR TITLE
Change developer docs for ~/.ssh/config inside ORNL

### DIFF
--- a/dev-docs/source/GettingStarted/GettingStarted.rst
+++ b/dev-docs/source/GettingStarted/GettingStarted.rst
@@ -38,9 +38,10 @@ Add the following lines to ``~/.ssh/config``:
 
 .. code:: bash
 
-    ProxyCommand corkscrew snowman.ornl.gov 3128 %h %p
     Host github.com
-
+        Hostname ssh.github.com
+        Port 443
+        PreferredAuthentications publickey
 
 If you need further help, ask another developer at the facility how to configure the corkscrew option.
 

--- a/dev-docs/source/GettingStarted/GettingStarted.rst
+++ b/dev-docs/source/GettingStarted/GettingStarted.rst
@@ -32,8 +32,7 @@ Custom git setup for inside the ORNL firewall:
 
 Due to security configuration at ORNL one needs to do additional configuration to access github from within the lab.
 One option is to use the ``https`` protocol listed above
-The alternative is to "corkscrew the snowman" which allows for using the ``git`` protocol by modifying the ssh configuration.
-Corkscrew can be installed from your package manager, or it is a single ``c`` file found on github.
+The alternative is to access github through ssh.github.com.
 Add the following lines to ``~/.ssh/config``:
 
 .. code:: bash
@@ -43,7 +42,7 @@ Add the following lines to ``~/.ssh/config``:
         Port 443
         PreferredAuthentications publickey
 
-If you need further help, ask another developer at the facility how to configure the corkscrew option.
+If you need further help, ask another developer at the facility how to configure ssh.
 
 
 Setting up GitHub


### PR DESCRIPTION
**Description of work**
Update the developer documentation for accessing GitHub through ssh inside the ORNL firewall. Using corkscrew is no longer needed since one can use ssh.github.com.

Fixes #35611

*This does not require release notes because minor documentation fix.*

---

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.