### PR TITLE
Fix bugs related to fit limits in GSAS2 tab in EngDiff UI

### DIFF
--- a/docs/source/release/v6.7.0/Diffraction/Engineering/Bugfixes/35619.rst
+++ b/docs/source/release/v6.7.0/Diffraction/Engineering/Bugfixes/35619.rst
@@ -1,0 +1,2 @@
+- Check GSAS-II reflection file output exists before loading results in GSAS-II tab of :ref:`Engineering Diffraction interface<Engineering_Diffraction-ref>` (this can happen if no reflections are within the TOF limits specified)
+- Prevent TOF limits having min > max in GSAS-II tab of :ref:`Engineering Diffraction interface<Engineering_Diffraction-ref>`

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/gsas2/call_G2sc.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/gsas2/call_G2sc.py
@@ -90,10 +90,8 @@ def enable_unit_cell(refine, override_unit_cell_lengths, project):
 
 def enable_limits(x_limits, project):
     if x_limits:
-        x_min, x_max = x_limits
-        if x_min and x_max:
-            for loop_index, loop_histogram in enumerate(project.histograms()):
-                loop_histogram.set_refinements({"Limits": [x_min[loop_index], x_max[loop_index]]})
+        for ihist, xlim in enumerate(zip(*x_limits)):
+            project.histograms()[ihist].set_refinements({"Limits": [min(xlim), max(xlim)]})  # ensure min <= max
 
 
 def run_microstrain_refinement(refine, project, path_to_project):

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/gsas2/model.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/gsas2/model.py
@@ -728,8 +728,11 @@ class GSAS2Model(object):
             result_reflections_txt = os.path.join(
                 self.user_save_directory, self.project_name + f"_reflections_{histogram_index}_{phase_name}.txt"
             )
-            loaded_reflections.append(np.genfromtxt(result_reflections_txt)[2:])
-            # first 2 lines iin file are histogram and phase name
+            if os.path.exists(result_reflections_txt):
+                # omit first 2 lines in file (which are histogram and phase name)
+                loaded_reflections.append(np.genfromtxt(result_reflections_txt)[2:])
+            else:
+                logger.warning(f"No reflections found for phase {phase_name} within x-limits of the fit.")
         return loaded_reflections
 
     def load_gsas_reflections_all_histograms_for_table(self):

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/gsas2/test/test_gsas2_model.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/gsas2/test/test_gsas2_model.py
@@ -388,6 +388,13 @@ class TestGSAS2Model(unittest.TestCase):
         # check all values in two numpy arrays are the same
         self.assertTrue((reflections[0] - expected_reflections[0]).all())
 
+    @patch(model_path + ".os.path.exists")
+    def test_load_gsas2_reflections_file_not_exist(self, mock_path_exists):
+        mock_path_exists.return_value = False
+        self.model.phase_names_list = ["Fe_gamma"]
+        reflections = self.model.load_gsas_reflections_per_histogram_for_plot(1)
+        self.assertTrue(len(reflections) == 0)
+
     def test_create_lattice_parameter_table(self):
         self.model.phase_names_list = ["Fe_gamma"]
         table_ws = self.model.create_lattice_parameter_table(test=True)

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/gsas2/view.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/gsas2/view.py
@@ -323,26 +323,18 @@ class GSAS2View(QtWidgets.QWidget, Ui_calib):
             self.max_releaser = self.figure.canvas.mpl_connect("button_release_event", self.max_release)
 
     def min_follow_mouse(self, event):
-        if event.xdata:
-            if self.initial_x_limits[0] <= float(event.xdata) <= self.initial_x_limits[1]:
-                self.min_line.set_xdata([event.xdata, event.xdata])
-                self.set_x_min_line_edit(event.xdata)
-            else:
-                self.min_line.set_xdata([self.initial_x_limits[0], self.initial_x_limits[0]])
-                self.set_x_min_line_edit(self.initial_x_limits[0])
+        if event.xdata and self.initial_x_limits[0] <= float(event.xdata) <= float(self.x_max_line_edit.text()):
+            self.min_line.set_xdata([event.xdata, event.xdata])
+            self.set_x_min_line_edit(event.xdata)
         else:
             self.min_line.set_xdata([self.initial_x_limits[0], self.initial_x_limits[0]])
             self.set_x_min_line_edit(self.initial_x_limits[0])
         self.figure.canvas.draw_idle()
 
     def max_follow_mouse(self, event):
-        if event.xdata:
-            if self.initial_x_limits[0] <= float(event.xdata) <= self.initial_x_limits[1]:
-                self.max_line.set_xdata([event.xdata, event.xdata])
-                self.set_x_max_line_edit(event.xdata)
-            else:
-                self.max_line.set_xdata([self.initial_x_limits[1], self.initial_x_limits[1]])
-                self.set_x_max_line_edit(self.initial_x_limits[1])
+        if event.xdata and float(self.x_min_line_edit.text()) <= float(event.xdata) <= self.initial_x_limits[1]:
+            self.max_line.set_xdata([event.xdata, event.xdata])
+            self.set_x_max_line_edit(event.xdata)
         else:
             self.max_line.set_xdata([self.initial_x_limits[1], self.initial_x_limits[1]])
             self.set_x_max_line_edit(self.initial_x_limits[1])
@@ -370,20 +362,22 @@ class GSAS2View(QtWidgets.QWidget, Ui_calib):
         new_value = self.x_min_line_edit.text()
         if self.min_line and new_value != "":
             new_value = float(new_value)
-            if self.initial_x_limits[0] <= new_value <= self.initial_x_limits[1]:
+            if self.initial_x_limits[0] <= new_value <= float(self.x_max_line_edit.text()):
                 self.min_line.set_xdata([new_value, new_value])
             else:
                 self.min_line.set_xdata([self.initial_x_limits[0], self.initial_x_limits[0]])
+                self.set_x_min_line_edit(self.initial_x_limits[0])
             self.figure.canvas.draw_idle()
 
     def set_max_line_from_line_edit(self):
         new_value = self.x_max_line_edit.text()
         if self.max_line and new_value != "":
             new_value = float(new_value)
-            if self.initial_x_limits[0] <= new_value <= self.initial_x_limits[1]:
+            if float(self.x_min_line_edit.text()) <= new_value <= self.initial_x_limits[1]:
                 self.max_line.set_xdata([new_value, new_value])
             else:
                 self.max_line.set_xdata([self.initial_x_limits[1], self.initial_x_limits[1]])
+                self.set_x_max_line_edit(self.initial_x_limits[1])
             self.figure.canvas.draw_idle()
 
     def set_x_limits(self, x_minimum, x_maximum):


### PR DESCRIPTION
**Description of work**
Fixes 2 bugs (not regressions - hence the release notes -  but it would be nice to get into 6.7 as they are easy to trigger):

1. Checks reflections file exists before trying to read it (this happens if no reflections in TOF limits - but there may be other reasons - e.g. if refinement fails?)
2. Stop users entering min > max using sliders or edit boxes (atm it doesn't do anything fancy it just resets the slider and box to the data min/max)

Long term it would be good to only generate reflections within limits of the data/sliders (also the max d-spacing is hard-coded to 3 Ang)
https://github.com/mantidproject/mantid/blob/df7bfd91c8df842f0327afdc06b4756cf3eca05a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/gsas2/model.py#L455

Also I think the slider code could be made a bit more concise and tidied up a  bit - but that can wait till after the release.

**To test:**

Follow instructions on original issue.

After refining data in GSAS-II the data and fit will be plotted along with sliders for the fitting range. 
1. Move the sliders to check min < max (slider position reset to data min.max) and check the edit box is correct
2. Check that that trying to set min > max in the edit boxes will reset the slider position to data min/max

Fixes #35597 


<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.