### PR TITLE
UserFunction causing crashes

### DIFF
--- a/Framework/CurveFitting/src/Functions/UserFunction.cpp
+++ b/Framework/CurveFitting/src/Functions/UserFunction.cpp
@@ -27,7 +27,7 @@ using namespace API;
 /// Constructor
 UserFunction::UserFunction() : m_parser(new mu::Parser()), m_x(0.), m_x_set(false) {
   extraOneVarFunctions(*m_parser);
-  // declareAttribute("Formula", Attribute(""));
+  declareAttribute("Formula", Attribute(""));
 }
 
 /// Destructor

--- a/Framework/CurveFitting/src/Functions/UserFunction.cpp
+++ b/Framework/CurveFitting/src/Functions/UserFunction.cpp
@@ -25,7 +25,10 @@ using namespace Kernel;
 using namespace API;
 
 /// Constructor
-UserFunction::UserFunction() : m_parser(new mu::Parser()), m_x(0.), m_x_set(false) { extraOneVarFunctions(*m_parser); }
+UserFunction::UserFunction() : m_parser(new mu::Parser()), m_x(0.), m_x_set(false) {
+  extraOneVarFunctions(*m_parser);
+  // declareAttribute("Formula", Attribute(""));
+}
 
 /// Destructor
 UserFunction::~UserFunction() { delete m_parser; }

--- a/Framework/CurveFitting/test/Functions/UserFunctionTest.h
+++ b/Framework/CurveFitting/test/Functions/UserFunctionTest.h
@@ -31,9 +31,6 @@ public:
 
   void testIt() {
     UserFunction fun;
-    std::vector<std::string> expect = {1, "Formula"};
-    TS_ASSERT_EQUALS(fun.getAttributeNames(), expect);
-
     fun.setAttribute("Formula", UserFunction::Attribute("h*sin(a*x-c)"));
     fun.setParameter("h", 2.2);
     fun.setParameter("a", 2.0);

--- a/Framework/CurveFitting/test/Functions/UserFunctionTest.h
+++ b/Framework/CurveFitting/test/Functions/UserFunctionTest.h
@@ -31,6 +31,9 @@ public:
 
   void testIt() {
     UserFunction fun;
+    std::vector<std::string> expect = {1, "Formula"};
+    TS_ASSERT_EQUALS(fun.getAttributeNames(), expect);
+
     fun.setAttribute("Formula", UserFunction::Attribute("h*sin(a*x-c)"));
     fun.setParameter("h", 2.2);
     fun.setParameter("a", 2.0);

--- a/docs/source/release/v6.7.0/Framework/Fit_Functions/Bugfixes/35610.rst
+++ b/docs/source/release/v6.7.0/Framework/Fit_Functions/Bugfixes/35610.rst
@@ -1,0 +1,1 @@
+- Fixed a bug that prevented the `UserFunction` from being added to a composite function within custom interfaces.


### PR DESCRIPTION
**Description of work**
Mantid was crashing when the UserFunction was added to a function browser in a custom interface, after another function. This was because the user function was not correctly initialised. 

There is no test because the error occurs in the function tree view. 

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->
Report to James
**Summary of work**
<!-- Please provide a short, high level description of the work that was done.
-->

**Further detail of work**
<!-- Please provide a more detailed description of the work that has been undertaken.
-->


**To test:**
Open muon analysis
Load some data (Doesn't matter)
Go to the fitting tab
Add a FlatBackground
Add a UserFunction - this used to cause a crash
In the UserFunction's formula box, press the `...` to get a pop-up
In the big white box at the bottom enter `a*x` as the function and press `use`
Press fit
You will see a linear fit


During testing I found another unrelated bug #35621
Open muon analysis
Set the instrument to MUSR
In the run box enter 62260
Go to the fitting tab
Tick the `Simultaneous over` box
Add a FlatBackground
Add a UserFunction - this used to cause a crash
In the UserFunction's formula box, press the `...` to get a pop-up
In the big white box at the bottom enter `a*x` as the function and press `use`
Tick the global box next to the `a` parameter
Press fit
You will see a linear fit, but the value for the `a` parameter will still be 0. 
(optional) If you look at the parameter workspace you will see that `a` is not zero.

The following shows that the bug is specific to muons
Open Indirect->data analysis
Go to the ConvFit tab
Press `Add workspace`
Enter some data for the workspace and resolution (doenst matter which)
Tick `all spectra` check that there are multiple values in the Workspace Indices box
Click add, then close the pop up
Set 1 Lorentzian
Set background to flatbackground
Above the fit property browser, tick the `See full function` checkbox
Add a user function to the composite function
In the UserFunction's formula box, press the `...` to get a pop-up
In the big white box at the bottom enter `a*x` as the function and press `use`
Tick the global box next to the `a` parameter
Press Run
Notice that the a value is non-zero.


<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

Fixes #35610. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.