### PR TITLE
Fix live data listener properties section in Start Live Data Dialogue 

### DIFF
--- a/qt/widgets/plugins/algorithm_dialogs/inc/MantidQtWidgets/Plugins/AlgorithmDialogs/StartLiveDataDialog.h
+++ b/qt/widgets/plugins/algorithm_dialogs/inc/MantidQtWidgets/Plugins/AlgorithmDialogs/StartLiveDataDialog.h
@@ -38,7 +38,7 @@ private slots:
   void setDefaultAccumulationMethod(const QString & /*listener*/);
   void updateUiElements(const QString & /*inst*/);
   void accept() override;
-  void initListenerPropLayout();
+  void initListenerPropLayout(const QString &listener);
   void updateConnectionChoices(const QString &inst_name);
   void updateConnectionDetails(const QString &connection);
 

--- a/qt/widgets/plugins/algorithm_dialogs/src/StartLiveDataDialog.cpp
+++ b/qt/widgets/plugins/algorithm_dialogs/src/StartLiveDataDialog.cpp
@@ -184,7 +184,7 @@ void StartLiveDataDialog::initLayout() {
   updateConnectionChoices(ui.cmbInstrument->currentText());
   updateConnectionDetails(ui.cmbConnection->currentText());
   setDefaultAccumulationMethod(ui.cmbConnListener->currentText());
-  initListenerPropLayout();
+  initListenerPropLayout(ui.cmbConnListener->currentText());
 
   //=========== SLOTS =============
   connect(ui.processingAlgo, SIGNAL(changedAlgorithm()), this, SLOT(changeProcessingAlgorithm()));
@@ -206,7 +206,8 @@ void StartLiveDataDialog::initLayout() {
 
   connect(ui.cmbConnListener, SIGNAL(currentIndexChanged(const QString &)), this,
           SLOT(setDefaultAccumulationMethod(const QString &)));
-  connect(ui.cmbConnListener, SIGNAL(currentIndexChanged(const QString &)), this, SLOT(initListenerPropLayout()));
+  connect(ui.cmbConnListener, SIGNAL(currentIndexChanged(const QString &)), this,
+          SLOT(initListenerPropLayout(const QString &)));
   connect(ui.cmbInstrument, SIGNAL(currentIndexChanged(const QString &)), this,
           SLOT(updateUiElements(const QString &)));
   connect(ui.cmbInstrument, SIGNAL(currentIndexChanged(const QString &)), this,
@@ -391,7 +392,7 @@ void StartLiveDataDialog::accept() {
  * Update the Listener Properties group box for the current LiveListener.
  *
  */
-void StartLiveDataDialog::initListenerPropLayout() {
+void StartLiveDataDialog::initListenerPropLayout(const QString &listener) {
   // remove previous listener's properties
   auto props = m_algorithm->getPropertiesInGroup("ListenerProperties");
   for (auto &prop : props) {
@@ -416,6 +417,10 @@ void StartLiveDataDialog::initListenerPropLayout() {
       }
     }
 
+    // set the instrument and listener properties early to get the listener's properties
+    // this will be overriden by the same values in parseInput() function
+    m_algorithm->setPropertyValue("Instrument", ui.cmbInstrument->currentText().toStdString());
+    m_algorithm->setPropertyValue("Listener", listener.toStdString());
     // find the listener's properties
     props = m_algorithm->getPropertiesInGroup("ListenerProperties");
 


### PR DESCRIPTION
**Description of work**
This pull request addresses the issue with the listener properties section in the Start Live Data dialogue. The layout was incorrectly initialized, leading to crashes in Mantid.

**Purpose of work**
<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
-->
During a manual testing session, a problem was identified with the Start Live Data dialogue. It was discovered that the issue resulted from the improper initialization of the listener properties section. The purpose of this work is to fix this problem.

**Summary of work**
<!-- Please provide a short, high-level description of the work that was done.
-->
This PR fixes the broken listener section in Start Live Data Dialogue

**Further detail of work**
<!-- Please provide a more detailed description of the work that has been undertaken.
-->
This bug was unintentionally introduced in the following pull request: [PR](https://github.com/mantidproject/mantid/pull/32485/files#diff-b57d81d487e6fd4f74cc3ff2376ce3ee2c25a283b2896e58050a0abeb7893de3L403). In addition, the `listener` argument was removed from the `initListenerPropLayout` slot but was not updated in the connect call between the `ui.cmbConnListener` signal and `initListenerPropLayout` slot in this [line](https://github.com/mantidproject/mantid/pull/32485/files#diff-b57d81d487e6fd4f74cc3ff2376ce3ee2c25a283b2896e58050a0abeb7893de3R211). As a result, the listener properties section was only updated when opening the Start Live Dialog ([this line](https://github.com/mantidproject/mantid/pull/32485/files#diff-b57d81d487e6fd4f74cc3ff2376ce3ee2c25a283b2896e58050a0abeb7893de3R188)), which obscured the problem until the function signature slot call was corrected in this [PR](https://github.com/mantidproject/mantid/pull/35079). This PR was merged after the last release and this explains why this bug appeared right now.

**To test:**
Repeat this manual testing doc:
https://developer.mantidproject.org/Testing/LiveData/LiveDataTests.html

Fixes #35567. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.