### PR TITLE
Fix bug in save/load grouping workspace

### DIFF
--- a/Framework/Algorithms/src/CompareWorkspaces.cpp
+++ b/Framework/Algorithms/src/CompareWorkspaces.cpp
@@ -382,6 +382,11 @@ void CompareWorkspaces::doComparison() {
     if ((ews1 && !ews2) || (!ews1 && ews2)) {
       recordMismatch("One workspace is an EventWorkspace and the other is not.");
       return;
+    } else if (w1 && w2 && (w1->id() != w2->id())) {
+      std::stringstream msg;
+      msg << "Workspace ids do not match: \"" << w1->id() << "\" != \"" << w2->id() << "\"";
+      recordMismatch(msg.str());
+      return;
     }
   }
 

--- a/Framework/DataHandling/src/LoadNexusProcessed.cpp
+++ b/Framework/DataHandling/src/LoadNexusProcessed.cpp
@@ -1737,6 +1737,9 @@ API::Workspace_sptr LoadNexusProcessed::loadEntry(NXRoot &root, const std::strin
   } else if (mtd_entry.containsGroup("mask_workspace")) {
     workspaceType = "MaskWorkspace";
     group_name = "mask_workspace";
+  } else if (mtd_entry.containsGroup("grouping_workspace")) {
+    workspaceType = "GroupingWorkspace";
+    group_name = "grouping_workspace";
   }
 
   // Get workspace characteristics

--- a/Framework/DataHandling/src/SaveNexusProcessed.cpp
+++ b/Framework/DataHandling/src/SaveNexusProcessed.cpp
@@ -13,6 +13,7 @@
 #include "MantidAPI/IMDHistoWorkspace.h"
 #include "MantidAPI/WorkspaceHistory.h"
 #include "MantidDataObjects/EventWorkspace.h"
+#include "MantidDataObjects/GroupingWorkspace.h"
 #include "MantidDataObjects/MaskWorkspace.h"
 #include "MantidDataObjects/OffsetsWorkspace.h"
 #include "MantidDataObjects/PeaksWorkspace.h"
@@ -300,6 +301,8 @@ void SaveNexusProcessed::doExec(const Workspace_sptr &inputWorkspace,
         workspaceTypeGroupName = "offsets_workspace";
       else if (maskWorkspace)
         workspaceTypeGroupName = "mask_workspace";
+      else if (std::dynamic_pointer_cast<const GroupingWorkspace>(inputWorkspace))
+        workspaceTypeGroupName = "grouping_workspace";
       else
         workspaceTypeGroupName = "workspace";
 


### PR DESCRIPTION
This was not discovered until more recently because `CompareWorkspaces` only checked that the pointers could be cast for event and matrix workspaces. This introduces a stricter check that the workspace id matches for the case of `MatrixWorkspace`. Then the bug in `SaveNexusProcessed` and `LoadNexusProcessed` was fixed.

**To test:**

This is already covered by a systemtest
```sh
./systemtest -R SaveLoadNexusProcessed.SaveLoadNexusProcessedGroupingWorkspaceTest
```

*There is no associated issue,* but this was discovered while working on [EWM1532](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=1532)

*This does not require release notes* because it is a bugfix of a feature added during the release cycle.

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.