### PR TITLE
Handle ADS changes in the sample logs viewer

### DIFF
--- a/docs/source/release/v6.8.0/Workbench/Bugfixes/35636.rst
+++ b/docs/source/release/v6.8.0/Workbench/Bugfixes/35636.rst
@@ -1,0 +1,1 @@
+- Fix bug in the Sample Logs Viewer that causes crash when the selected workspace is modified or deleted

--- a/qt/python/mantidqt/mantidqt/widgets/samplelogs/model.py
+++ b/qt/python/mantidqt/mantidqt/widgets/samplelogs/model.py
@@ -90,9 +90,14 @@ class SampleLogsModel:
         """Stores three thing:, the workspace, which experiment info number
         to use, and the run object.
         """
+        self.set_ws(ws)
+
+    def set_ws(self, ws):
+        """Set the workspace"""
         self._ws = ws
         self._exp = 0
         self._set_run()
+        self._workspace_name = self.get_name()
 
     def _set_run(self):
         """Set run depending on workspace type and experiment info number"""
@@ -113,6 +118,13 @@ class SampleLogsModel:
     def get_ws(self):
         """Return the workspace"""
         return self._ws
+
+    def set_name(self, workspace_name):
+        """Set the workspace name to compare on ADS changes"""
+        self._workspace_name = workspace_name
+
+    def workspace_equals(self, workspace_name):
+        return workspace_name == self._workspace_name
 
     def get_name(self):
         """Return the workspace name"""

--- a/qt/python/mantidqt/mantidqt/widgets/samplelogs/test/test_samplelogs_view.py
+++ b/qt/python/mantidqt/mantidqt/widgets/samplelogs/test/test_samplelogs_view.py
@@ -10,7 +10,7 @@ import unittest
 import matplotlib as mpl
 
 mpl.use("Agg")  # noqa
-from mantid.simpleapi import CreateSampleWorkspace
+from mantid.simpleapi import CreateSampleWorkspace, RenameWorkspace, DeleteWorkspace
 from mantidqt.utils.qt.testing import start_qapplication
 from mantidqt.utils.qt.testing.qt_widget_finder import QtWidgetFinder
 from mantidqt.widgets.samplelogs.presenter import SampleLogs
@@ -28,3 +28,23 @@ class SampleLogsViewTest(unittest.TestCase, QtWidgetFinder):
         QApplication.sendPostedEvents()
 
         self.assert_no_toplevel_widgets()
+
+    def test_workspace_updates(self):
+        ws = CreateSampleWorkspace()
+        pres = SampleLogs(ws)
+
+        # check rename of workspace
+        assert pres.view.windowTitle() == "ws sample logs"
+        assert pres.model._workspace_name == "ws"
+        RenameWorkspace("ws", "new_name")
+        assert pres.view.windowTitle() == "new_name sample logs"
+        assert pres.model._workspace_name == "new_name"
+
+        # check the workspace replaced if same name
+        ws2 = CreateSampleWorkspace(OutputWorkspace="new_name", BinWidth=1000)
+        assert repr(pres.model.get_ws()) == repr(ws2)
+
+        # delete workspace and check that the widget closes
+        assert pres.view.isVisible()
+        DeleteWorkspace("new_name")
+        assert not pres.view.isVisible()

--- a/qt/python/mantidqt/mantidqt/widgets/samplelogs/view.py
+++ b/qt/python/mantidqt/mantidqt/widgets/samplelogs/view.py
@@ -24,25 +24,33 @@ from qtpy.QtWidgets import (
     QFrame,
     QSpacerItem,
 )
-from qtpy.QtCore import QItemSelectionModel, Qt
+from qtpy.QtCore import QItemSelectionModel, Qt, Signal
+from mantidqt.widgets.observers.observing_view import ObservingView
 from mantidqt.MPLwidgets import FigureCanvas
+from mantid.api import Workspace
 from matplotlib.figure import Figure
 import matplotlib.pyplot as plt
 
 
-class SampleLogsView(QSplitter):
+class SampleLogsView(QSplitter, ObservingView):
     """Sample Logs View
 
     This contains a table of the logs, a plot of the currently
     selected logs, and the statistics of the selected log.
     """
 
+    close_signal = Signal()
+    rename_signal = Signal(str)
+    replace_signal = Signal(str, Workspace)
+
     def __init__(self, presenter, parent=None, window_flags=Qt.Window, name="", isMD=False, noExp=0):
-        super(SampleLogsView, self).__init__(parent)
+        super().__init__(parent)
 
         self.presenter = presenter
 
         self.setWindowTitle("{} sample logs".format(name))
+        self.TITLE_STRING = "{} sample logs"
+
         self.setWindowFlags(window_flags)
         self.setAttribute(Qt.WA_DeleteOnClose, True)
 
@@ -137,12 +145,11 @@ class SampleLogsView(QSplitter):
         self.addWidget(self.frame_right)
         self.setStretchFactor(0, 1)
 
+        self.close_signal.connect(self.close)
+        self.rename_signal.connect(self._rename)
+
         self.resize(1200, 800)
         self.show()
-
-    def closeEvent(self, event):
-        self.deleteLater()
-        super(SampleLogsView, self).closeEvent(event)
 
     def tableMenu(self, event):
         """Right click menu for table, can plot or print selected logs"""


### PR DESCRIPTION
**Description of work**

Update workspace on replace, remove workspace on delete, window title is updated on workspace rename.

**Purpose of work**
<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
-->

There is a bug in the sample logs viewer where it didn't handle workspace changes. So if you open the sample logs viewer for a workspace and either replace or delete the workspace, when you try to plot a log workbench crashes.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**Summary of work**
<!-- Please provide a short, high level description of the work that was done.
-->

**Further detail of work**
<!-- Please provide a more detailed description of the work that has been undertaken.
-->


**To test:**

```python
ws=Load("CNCS_7860")
```

Right-click workspace -> Show sample logs

```python
DeleteWorkspace(ws)
```

Select a log to plot and the workspace show no longer crash

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

Fixes [EWM1370](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=1370)

 <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.