### PR TITLE
Add target to verify external links in docs

### DIFF
--- a/dev-docs/CMakeLists.txt
+++ b/dev-docs/CMakeLists.txt
@@ -15,9 +15,23 @@ add_custom_target(
   COMMENT "Building html developer documentation"
 )
 
+set(BUILDER linkcheck)
+add_custom_target(
+  dev-docs-${BUILDER}
+  COMMAND ${Python_EXECUTABLE} -m ${SPHINX_MAIN} ${SPHINX_NO_COLOR} -w dev_docs_warnings.txt ${SPHINX_KEEPGOING} -b
+          ${BUILDER} -d ${DOCTREE_DIR} ${CMAKE_CURRENT_LIST_DIR}/source ${OUT_DIR}
+  COMMENT "Checking external links in developer documentation"
+)
+
 # Group within VS and exclude from whole build
 set_target_properties(
   dev-docs-html
+  PROPERTIES FOLDER "Documentation"
+             EXCLUDE_FROM_DEFAULT_BUILD 1
+             EXCLUDE_FROM_ALL 1
+)
+set_target_properties(
+  dev-docs-linkcheck
   PROPERTIES FOLDER "Documentation"
              EXCLUDE_FROM_DEFAULT_BUILD 1
              EXCLUDE_FROM_ALL 1

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -113,6 +113,9 @@ if(DOCS_QTHELP)
   add_dependencies(docs-qthelp docs-qtassistant)
 endif()
 
+# add target for checking external links
+add_sphinx_build_target(linkcheck ${DOCS_MATH_EXT})
+
 # Installation settings
 option(PACKAGE_DOCS "If true the qthelp documentation is bundled with the package" OFF)
 if(PACKAGE_DOCS)

--- a/docs/source/release/v6.8.0/Framework/35640.rst
+++ b/docs/source/release/v6.8.0/Framework/35640.rst
@@ -1,0 +1,1 @@
+* Two new build targets ``docs-linkcheck`` and ``dev-docs-linkcheck`` run `sphinx linkcheckbuilder <https://www.sphinx-doc.org/en/master/usage/builders/index.html#sphinx.builders.linkcheck.CheckExternalLinksBuilder>`_


### PR DESCRIPTION
Sphinx already has a builder that does the work, this configures cmake to run the [linkcheck](https://www.sphinx-doc.org/en/master/usage/builders/index.html#sphinx.builders.linkcheck.CheckExternalLinksBuilder) builder. As a side-effect, poorly formed internal references will show up as invalid external links.

This is not setup to run in any of the builds because there are lots of items to fix and it takes (for me) ~4 minutes to run

**To test:**

The following take roughly 4 minutes each because they use the requests library to try each link individually.
```sh
ninja docs-linkcheck
ninja dev-docs-linkcheck
```

*There is no associated issue.*

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.