### PR TITLE
Change to workspace naming in PEARL reduction scripts

### DIFF
--- a/Testing/SystemTests/tests/framework/ISIS_PowderPearlTest.py
+++ b/Testing/SystemTests/tests/framework/ISIS_PowderPearlTest.py
@@ -127,7 +127,7 @@ class FocusTest(systemtesting.MantidSystemTest):
         # Gen vanadium calibration first
         setup_mantid_paths()
         inst_object = setup_inst_object(tt_mode="tt88", focus_mode="Trans")
-        self.focus_results = run_focus(inst_object, tt_mode="tt70", file_ext=".nxs", subtract_empty=True, spline_path=spline_path)
+        self.focus_results = run_focus(inst_object, tt_mode="tt70", subtract_empty=True, spline_path=spline_path)
 
         # Make sure that inst settings reverted to the default after focus
         self.assertEqual(inst_object._inst_settings.tt_mode, "tt88")
@@ -147,6 +147,35 @@ class FocusTest(systemtesting.MantidSystemTest):
 
         self.tolerance = 1e-8  # Required for difference in spline data between operating systems
         return "PRL98507_tt70-d", "ISIS_Powder-PEARL00098507_tt70Atten.nxs"
+
+    def cleanup(self):
+        try:
+            _try_delete(spline_path)
+            _try_delete(output_dir)
+        finally:
+            config["datasearch.directories"] = self.existing_config
+            mantid.mtd.clear()
+
+
+class FocusTestIncludingFileExtWorkspaceName(systemtesting.MantidSystemTest):
+    # same as FocusTest but with added argument incl_file_ext_in_wsname=True
+    focus_results = None
+    existing_config = config["datasearch.directories"]
+
+    def requiredFiles(self):
+        return _gen_required_files()
+
+    def runTest(self):
+        # Gen vanadium calibration first
+        setup_mantid_paths()
+        inst_object = setup_inst_object(tt_mode="tt88", focus_mode="Trans")
+        self.focus_results = run_focus(
+            inst_object, tt_mode="tt70", file_ext=".nxs", incl_file_ext_in_wsname=True, subtract_empty=True, spline_path=spline_path
+        )
+
+    def validate(self):
+        # just check file extension (nxs) in workspace name
+        return "PRL98507_tt70_nxs-d", "ISIS_Powder-PEARL00098507_tt70Atten.nxs"
 
     def cleanup(self):
         try:

--- a/Testing/SystemTests/tests/framework/ISIS_PowderPearlTest.py
+++ b/Testing/SystemTests/tests/framework/ISIS_PowderPearlTest.py
@@ -72,7 +72,7 @@ class _CreateVanadiumTest(systemtesting.MantidSystemTest):
     def validate(self):
         self.tolerance = 0.05  # Required for difference in spline data between operating systems
         return (
-            "PEARL98472_tt70-Results-D-Grp",
+            "PRL98472_tt70-d",
             "ISIS_Powder_PRL98472_tt70_{}.nxs".format(self.focus_mode),
             "Van_spline_data_tt70",
             "ISIS_Powder-PEARL00098472_splined.nxs",
@@ -146,7 +146,7 @@ class FocusTest(systemtesting.MantidSystemTest):
         assert_output_file_exists(xye_dSpac_outdir, "PRL98507_tt70_d.xye")
 
         self.tolerance = 1e-8  # Required for difference in spline data between operating systems
-        return "PEARL98507_tt70-Results-D-Grp", "ISIS_Powder-PEARL00098507_tt70Atten.nxs"
+        return "PRL98507_tt70-d", "ISIS_Powder-PEARL00098507_tt70Atten.nxs"
 
     def cleanup(self):
         try:
@@ -201,9 +201,9 @@ class FocusLongThenShortTest(systemtesting.MantidSystemTest):
 
         self.tolerance = 1e-8  # Required for difference in spline data between operating systems
         return (
-            "PEARL98507_tt70-Results-D-Grp",
+            "PRL98507_tt70-d",
             "ISIS_Powder-PEARL00098507_tt70Atten.nxs",
-            "PEARL98507_tt70_long-Results-D-Grp",
+            "PRL98507_tt70_long-d",
             "ISIS_Powder-PEARL00098507_tt70Long.nxs",
         )
 
@@ -228,7 +228,7 @@ class FocusWithAbsorbCorrectionsTest(systemtesting.MantidSystemTest):
         self.focus_results = run_focus_with_absorb_corrections()
 
     def validate(self):
-        return "PEARL98507_tt70-Results-D-Grp", "ISIS_Powder-PEARL00098507_tt70_absorb.nxs"
+        return "PRL98507_tt70-d", "ISIS_Powder-PEARL00098507_tt70_absorb.nxs"
 
     def cleanup(self):
         try:
@@ -251,7 +251,7 @@ class FocusWithoutEmptySubtractionTest(systemtesting.MantidSystemTest):
         self.focus_results = run_focus(inst_object, tt_mode="tt70", subtract_empty=False, spline_path=spline_path)
 
     def validate(self):
-        return "PEARL98507_tt70-Results-D-Grp", "ISIS_Powder-PEARL00098507_tt70NoEmptySub.nxs"
+        return "PRL98507_tt70-d", "ISIS_Powder-PEARL00098507_tt70NoEmptySub.nxs"
 
     def cleanup(self):
         try:

--- a/scripts/Diffraction/isis_powder/gem_routines/gem_param_mapping.py
+++ b/scripts/Diffraction/isis_powder/gem_routines/gem_param_mapping.py
@@ -61,5 +61,6 @@ attr_mapping = [
     ParamMapEntry(ext_name="user_name", int_name="user_name"),
     ParamMapEntry(ext_name="vanadium_cropping_values", int_name="vanadium_cropping_values"),
     ParamMapEntry(ext_name="vanadium_normalisation", int_name="do_van_norm"),
+    ParamMapEntry(ext_name="keep_raw_workspace", int_name="keep_raw_workspace", optional=True),
 ]
 attr_mapping.extend(COMMON_PARAM_MAPPING)

--- a/scripts/Diffraction/isis_powder/hrpd_routines/hrpd_param_mapping.py
+++ b/scripts/Diffraction/isis_powder/hrpd_routines/hrpd_param_mapping.py
@@ -43,5 +43,6 @@ attr_mapping = [
     ParamMapEntry(ext_name="vanadium_tof_cropping", int_name="van_tof_cropping"),
     ParamMapEntry(ext_name="vanadium_peaks_masking_file", int_name="masking_file_name"),
     ParamMapEntry(ext_name="window", int_name="tof_window", enum_class=HRPD_TOF_WINDOWS),
+    ParamMapEntry(ext_name="keep_raw_workspace", int_name="keep_raw_workspace", optional=True),
 ]
 attr_mapping.extend(COMMON_PARAM_MAPPING)

--- a/scripts/Diffraction/isis_powder/osiris_routines/osiris_param_mapping.py
+++ b/scripts/Diffraction/isis_powder/osiris_routines/osiris_param_mapping.py
@@ -24,5 +24,6 @@ attr_mapping = [
     ParamMapEntry(ext_name="vanadium_normalisation", int_name="van_norm"),
     ParamMapEntry(ext_name="xye_filename", int_name="xye_filename"),
     ParamMapEntry(ext_name="sample_empty_scale", int_name="sample_empty_scale", optional=True),
+    ParamMapEntry(ext_name="keep_raw_workspace", int_name="keep_raw_workspace", optional=True),
 ]
 attr_mapping.extend(PARAM_MAPPING)

--- a/scripts/Diffraction/isis_powder/pearl.py
+++ b/scripts/Diffraction/isis_powder/pearl.py
@@ -210,7 +210,7 @@ class Pearl(AbstractInst):
             attenuation_filepath=attenuation_path,
         )
 
-        group_name = "PEARL{0!s}_{1}{2}-Results-D-Grp"
+        group_name = "PEARL{0!s}_{1}{2}-d"
         mode = "_long" if self._inst_settings.long_mode else ""
         group_name = group_name.format(run_details.output_run_string, self._inst_settings.tt_mode, mode)
         grouped_d_spacing = mantid.GroupWorkspaces(InputWorkspaces=output_spectra, OutputWorkspace=group_name)

--- a/scripts/Diffraction/isis_powder/pearl.py
+++ b/scripts/Diffraction/isis_powder/pearl.py
@@ -89,6 +89,11 @@ class Pearl(AbstractInst):
     def should_subtract_empty_inst(self):
         return self._inst_settings.subtract_empty_inst
 
+    def _generate_out_file_paths(self, run_details):
+        output_file_paths = super()._generate_out_file_paths(run_details)
+        output_file_paths["output_name"] = output_file_paths["output_name"] + run_details.file_extension.replace(".", "_")
+        return output_file_paths
+
     def _get_output_formats(self, output_directory, xye_files_directory):
         return {
             "nxs_filename": output_directory,

--- a/scripts/Diffraction/isis_powder/pearl.py
+++ b/scripts/Diffraction/isis_powder/pearl.py
@@ -214,10 +214,7 @@ class Pearl(AbstractInst):
             focus_mode=output_mode,
             attenuation_filepath=attenuation_path,
         )
-
-        group_name = "PEARL{0!s}_{1}{2}-d"
-        mode = "_long" if self._inst_settings.long_mode else ""
-        group_name = group_name.format(run_details.output_run_string, self._inst_settings.tt_mode, mode)
+        group_name = self._generate_out_file_paths(run_details)["output_name"] + "-d"
         grouped_d_spacing = mantid.GroupWorkspaces(InputWorkspaces=output_spectra, OutputWorkspace=group_name)
         return grouped_d_spacing, None
 

--- a/scripts/Diffraction/isis_powder/pearl.py
+++ b/scripts/Diffraction/isis_powder/pearl.py
@@ -92,7 +92,7 @@ class Pearl(AbstractInst):
     def _generate_out_file_paths(self, run_details):
         output_file_paths = super()._generate_out_file_paths(run_details)
         file_ext = run_details.file_extension
-        if file_ext:
+        if file_ext and self._inst_settings.incl_file_ext_in_wsname:
             output_file_paths["output_name"] = output_file_paths["output_name"] + file_ext.replace(".", "_")
         return output_file_paths
 

--- a/scripts/Diffraction/isis_powder/pearl.py
+++ b/scripts/Diffraction/isis_powder/pearl.py
@@ -91,7 +91,9 @@ class Pearl(AbstractInst):
 
     def _generate_out_file_paths(self, run_details):
         output_file_paths = super()._generate_out_file_paths(run_details)
-        output_file_paths["output_name"] = output_file_paths["output_name"] + run_details.file_extension.replace(".", "_")
+        file_ext = run_details.file_extension
+        if file_ext:
+            output_file_paths["output_name"] = output_file_paths["output_name"] + file_ext.replace(".", "_")
         return output_file_paths
 
     def _get_output_formats(self, output_directory, xye_files_directory):

--- a/scripts/Diffraction/isis_powder/pearl_routines/pearl_param_mapping.py
+++ b/scripts/Diffraction/isis_powder/pearl_routines/pearl_param_mapping.py
@@ -69,5 +69,6 @@ attr_mapping = [
     ParamMapEntry(ext_name="absorb_corrections_out_filename", int_name="absorb_out_file", optional=True),
     ParamMapEntry(ext_name="vanadium_tof_cropping", int_name="van_tof_cropping"),
     ParamMapEntry(ext_name="vanadium_normalisation", int_name="van_norm"),
+    ParamMapEntry(ext_name="keep_raw_workspace", int_name="keep_raw_workspace", optional=True),
 ]
 attr_mapping.extend(PARAM_MAPPING)

--- a/scripts/Diffraction/isis_powder/pearl_routines/pearl_param_mapping.py
+++ b/scripts/Diffraction/isis_powder/pearl_routines/pearl_param_mapping.py
@@ -70,5 +70,6 @@ attr_mapping = [
     ParamMapEntry(ext_name="vanadium_tof_cropping", int_name="van_tof_cropping"),
     ParamMapEntry(ext_name="vanadium_normalisation", int_name="van_norm"),
     ParamMapEntry(ext_name="keep_raw_workspace", int_name="keep_raw_workspace", optional=True),
+    ParamMapEntry(ext_name="incl_file_ext_in_wsname", int_name="incl_file_ext_in_wsname", optional=True),
 ]
 attr_mapping.extend(PARAM_MAPPING)

--- a/scripts/Diffraction/isis_powder/polaris_routines/polaris_param_mapping.py
+++ b/scripts/Diffraction/isis_powder/polaris_routines/polaris_param_mapping.py
@@ -59,5 +59,6 @@ attr_mapping = [
     ParamMapEntry(ext_name="user_name", int_name="user_name"),
     ParamMapEntry(ext_name="vanadium_cropping_values", int_name="van_crop_values"),
     ParamMapEntry(ext_name="vanadium_peaks_masking_file", int_name="masking_file_name"),
+    ParamMapEntry(ext_name="keep_raw_workspace", int_name="keep_raw_workspace", optional=True),
 ]
 attr_mapping.extend(COMMON_PARAM_MAPPING)

--- a/scripts/Diffraction/isis_powder/routines/common.py
+++ b/scripts/Diffraction/isis_powder/routines/common.py
@@ -597,7 +597,10 @@ def load_raw_files(run_number_string, instrument, file_ext=None):
     run_number_list = generate_run_numbers(run_number_string=run_number_string)
     file_ext = "" if file_ext is None else file_ext
     file_name_list = [instrument._generate_input_file_name(run_number=run_number, file_ext=file_ext) for run_number in run_number_list]
-    load_raw_ws = _load_list_of_files(file_name_list)
+    if instrument._inst_settings.keep_raw_workspace is not None:
+        load_raw_ws = _load_list_of_files(file_name_list, keep_original=instrument._inst_settings.keep_raw_workspace)
+    else:
+        load_raw_ws = _load_list_of_files(file_name_list)
     return load_raw_ws
 
 

--- a/scripts/Diffraction/isis_powder/test/ISISPowderCommonTest.py
+++ b/scripts/Diffraction/isis_powder/test/ISISPowderCommonTest.py
@@ -349,6 +349,20 @@ class ISISPowderCommonTest(unittest.TestCase):
         self.assertAlmostEqual(summed_ws[0].readY(0)[bin_index], (first_run_bin_value + second_run_bin_value))
         mantid.DeleteWorkspace(summed_ws[0])
 
+    def test_load_raw_files_respects_keep_raw_workspace_setting(self):
+        run_num_str = "100"
+        file_ext = ".nxs"
+        mock_inst = ISISPowderMockInst()
+        ws_raw_name = f"POL{run_num_str}{file_ext}"
+        for keep_raw in [True, False]:
+            mock_inst._inst_settings.keep_raw_workspace = keep_raw
+            ws_raw_list = common.load_raw_files(run_number_string=run_num_str, instrument=mock_inst, file_ext=file_ext)
+            # check raw workspace exists
+            self.assertTrue(mantid.AnalysisDataService.doesExist(ws_raw_name))
+            # check clone of raw workspace is output in ws_raw_list is keep_raw = True
+            ws_name = ws_raw_name + "_red" if keep_raw else ws_raw_name
+            self.assertEqual(ws_raw_list[0].name(), ws_name)
+
     def test_load_current_normalised_ws_respects_ext(self):
         run_number = "102"
         file_ext_one = ".s1"

--- a/scripts/Diffraction/isis_powder/test/ISISPowderCommonTest.py
+++ b/scripts/Diffraction/isis_powder/test/ISISPowderCommonTest.py
@@ -641,6 +641,7 @@ class ISISPowderMockInst(object):
     def __init__(self, file_ext=None):
         self._file_ext = file_ext
         self._inst_prefix = "MOCK"
+        self._inst_settings = ISISPowderMockInstrumentSettings()
 
     @staticmethod
     def _get_input_batching_mode(**_):
@@ -666,6 +667,11 @@ class ISISPowderMockInst(object):
 class ISISPowderMockRunDetails(object):
     def __init__(self, file_ext):
         self.file_extension = file_ext
+
+
+class ISISPowderMockInstrumentSettings(object):
+    def __init__(self, keep_raw_workspace=None):
+        self.keep_raw_workspace = keep_raw_workspace
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
**Description of work**

1. Added option to delete raw workspace post focussing in instrument settings
2. Changed name of group of focussed workspaces (simplified and added file extension)
3. Added file extension to individual focussed workspaces

**To test:**

Use the configs in this folder `\\olympic\Babylon5\Public\RWaite\PEARLExampleForSarah.zip`

(1) Run this script - it should produce a group workspace of focussed spectra and a workspace containing the raw/instrument data
```
from isis_powder.pearl import Pearl

pearl = Pearl(user_name="Danny", vanadium_normalisation=False, 
                    output_directory=r"C:\Users\xhg73778\Desktop\PEARLExampleForSarah",   #directory above cycle number 
                    config_file=r"C:\Users\xhg73778\Desktop\PEARLExampleForSarah\User_experiment.yaml",
                    calibration_directory=r"C:\Users\xhg73778\Desktop\PEARLExampleForSarah\calib_critical_files",
                    calibration_mapping_file=r"C:\Users\xhg73778\Desktop\PEARLExampleForSarah\calib_critical_files\pearl_run_mapping.yaml",
                    incl_file_ext_in_wsname=True)


pearl.focus(run_number="116374", file_ext=".raw", perform_attenuation=False, 
                  subtract_empty_instrument=False, focus_mode="all")
```

The workspace names are as follows
![image](https://github.com/mantidproject/mantid/assets/55979119/0d64c8a8-d276-41ca-bb4a-1f6f0414567e)

(2) Add the `keep_raw_workspace=False` argument to the `focus` call (this will be set as a temporary instrument setting) - it should not produce the raw instrument workspace
```
pearl.focus(run_number="116374", keep_raw_workspace=False, file_ext=".nxs", perform_attenuation=False, 
                  subtract_empty_instrument=False, focus_mode="all")
```

(3) Set the argument `keep_raw_workspace` in the `Pearl` init and re-focus - it should not produce the raw instrument workspace
```
pearl = Pearl(user_name="Danny", vanadium_normalisation=False, keep_raw_workspace=False,
                    output_directory=r"C:\Users\xhg73778\Desktop\PEARLExampleForSarah",   #directory above cycle number 
                    config_file=r"C:\Users\xhg73778\Desktop\PEARLExampleForSarah\User_experiment.yaml",
                    calibration_directory=r"C:\Users\xhg73778\Desktop\PEARLExampleForSarah\calib_critical_files",
                    calibration_mapping_file=r"C:\Users\xhg73778\Desktop\PEARLExampleForSarah\calib_critical_files\pearl_run_mapping.yaml")

pearl.focus(run_number="116374", file_ext=".raw", perform_attenuation=False, 
                  subtract_empty_instrument=False, focus_mode="all")
```

Fixes #35616
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.