### PR TITLE
Add github workflow for removing old nightly pre-releases

### DIFF
--- a/.github/workflows/delete_old_nightly_releases.yml
+++ b/.github/workflows/delete_old_nightly_releases.yml
@@ -1,0 +1,19 @@
+name: 'Remove old nightly pre-releases from GitHub'
+on:
+  schedule:
+    - cron: '0 2 * * *'
+  workflow_dispatch:
+
+jobs:
+  delete-old-nightly-releases:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: thomashampson/delete-older-releases@main
+        with:
+          keep_latest: 3
+          # Nightly tags are of the form v{major}.{minor}.{date}.{time}
+          delete_tag_regex: v\d.\d.\d{8}.\d{4}
+          prerelease_only: true
+          delete_tags: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
**Description of work**
Adds a GitHub action to remove old nightyly releases and tags, leaving the three most recent ones.

**Purpose of work**
There is currently no mechanism for automatically removing old nightly releases, and we cannot or do not need to store all of them on our github releases page.

**Summary of work**
I've forked a repo with an existing action and implemented one of the open PRs to add regex and pre-release functionality:
https://github.com/thomashampson/delete-older-releases

**Further detail of work**
The regular expression `v\d.\d.\d{8}.\d{4}` is used to match only nightly tags, e.g. something like v6.6.20230606.1013.


**To test:**
Check the actions that have run in this sandbox repo:
https://github.com/thomashampson/sandbox
It should be running each day at 2AM and there should only be three releases in that repo with a nightly-like tag.

Fixes #35472 

*This does not require release notes* because **it's not a change to the software**.

---

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.