### PR TITLE
Move sum banks step and fix bug in ISIS Reflectometry workflow

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ReflectometryISISLoadAndProcess.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ReflectometryISISLoadAndProcess.py
@@ -624,7 +624,9 @@ class ReflectometryISISLoadAndProcess(DataProcessorAlgorithm):
         flood_workspace = self._loadFloodCorrectionWorkspace()
         if flood_workspace:
             alg.setProperty("FloodWorkspace", flood_workspace)
-        alg.setProperty("SumAcrossDetectorBanks", sum_banks)
+        if sum_banks:
+            alg.setProperty("SumAcrossDetectorBanks", True)
+            alg.setProperty("HideSummedWorkspaces", self.getProperty(Prop.HIDE_INPUT).value)
         efficiencies_ws = self._loadPolarizationCorrectionWorkspace()
         if efficiencies_ws:
             alg.setProperty("PolarizationEfficiencies", efficiencies_ws)

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/ReflectometryISISLoadAndProcessTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/ReflectometryISISLoadAndProcessTest.py
@@ -692,6 +692,19 @@ class ReflectometryISISLoadAndProcessTest(unittest.TestCase):
         self._check_history(reduced_ws, history)
         self._check_sum_banks(reduced_ws, is_summed=False)
 
+    def test_summed_workspaces_hidden_when_selected(self):
+        self._create_2D_detector_workspace(38415, "__TOF_")
+        self._create_2D_detector_workspace(38416, "__TRANS_")
+        self._create_2D_detector_workspace(38417, "__TRANS_")
+        args = self._default_options
+        args["InputRunList"] = "38415"
+        args["FirstTransmissionRunList"] = "38416"
+        args["SecondTransmissionRunList"] = "38417"
+        args["HideInputWorkspaces"] = True
+        outputs = ["IvsQ_38415", "IvsQ_binned_38415", "TRANS_LAM_38416_38417"]
+        self._assert_run_algorithm_succeeds(args, outputs)
+        self._check_sum_banks(AnalysisDataService.retrieve("IvsQ_binned_38415"), is_summed=True)
+
     def test_calibration_file_is_applied_when_provided(self):
         args = self._default_options
         args["InputRunList"] = "INTER45455"

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/ReflectometryISISLoadAndProcessTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/ReflectometryISISLoadAndProcessTest.py
@@ -650,12 +650,20 @@ class ReflectometryISISLoadAndProcessTest(unittest.TestCase):
 
     def test_sum_banks_is_run_for_2D_detector_workspace(self):
         self._create_2D_detector_workspace(38415, "TOF_")
+
+        def _check_num_histograms_and_first_y_value(ws_name, expected_num_histograms, expected_y_value):
+            ws = AnalysisDataService.retrieve(ws_name)
+            self.assertTrue(ws.getNumberHistograms(), expected_num_histograms)
+            self._assert_delta(ws.readY(2)[0], expected_y_value)
+
+        _check_num_histograms_and_first_y_value("TOF_38415", 6, 0.3)
         args = self._default_options
         args["InputRunList"] = "38415"
         outputs = ["IvsQ_38415", "IvsQ_binned_38415", "TOF", "TOF_38415", "TOF_38415_summed_segment"]
         self._assert_run_algorithm_succeeds(args, outputs)
         history = ["ReflectometryISISSumBanks", "ReflectometryReductionOneAuto", "GroupWorkspaces"]
         self._check_history(AnalysisDataService.retrieve("IvsQ_binned_38415"), history)
+        _check_num_histograms_and_first_y_value("TOF_38415_summed_segment", 4, 0.6)
 
     def test_sum_banks_is_not_run_for_linear_detector_workspace(self):
         self._create_workspace(38415, "TOF_")

--- a/Framework/Reflectometry/inc/MantidReflectometry/ReflectometryReductionOneAuto3.h
+++ b/Framework/Reflectometry/inc/MantidReflectometry/ReflectometryReductionOneAuto3.h
@@ -94,7 +94,9 @@ private:
   API::MatrixWorkspace_sptr getFloodWorkspace();
   void applyFloodCorrection(const API::MatrixWorkspace_sptr &flood, const std::string &propertyName);
   void applyFloodCorrections();
-  void sumBanksForWorkspace(const std::string &roiDetectorIDs, const std::string &wsPropertyName);
+  std::string getSummedWorkspaceName(const std::string &wsPropertyName, const bool isTransWs = false);
+  void sumBanksForWorkspace(const std::string &roiDetectorIDs, const std::string &wsPropertyName,
+                            const bool isTransWs = false);
   void sumBanks();
   double getPropertyOrDefault(const std::string &propertyName, const double defaultValue, bool &isDefault);
   void setTransmissionProperties(const Algorithm_sptr &alg, std::string const &propertyName);

--- a/Framework/Reflectometry/inc/MantidReflectometry/ReflectometryReductionOneAuto3.h
+++ b/Framework/Reflectometry/inc/MantidReflectometry/ReflectometryReductionOneAuto3.h
@@ -94,6 +94,8 @@ private:
   API::MatrixWorkspace_sptr getFloodWorkspace();
   void applyFloodCorrection(const API::MatrixWorkspace_sptr &flood, const std::string &propertyName);
   void applyFloodCorrections();
+  void sumBanksForWorkspace(const std::string &roiDetectorIDs, const std::string &wsPropertyName);
+  void sumBanks();
   double getPropertyOrDefault(const std::string &propertyName, const double defaultValue, bool &isDefault);
   void setTransmissionProperties(const Algorithm_sptr &alg, std::string const &propertyName);
   WorkspaceNames getOutputNamesForGroupMember(const std::vector<std::string> &inputNames, const std::string &runNumber,

--- a/Framework/Reflectometry/src/ReflectometryReductionOneAuto3.cpp
+++ b/Framework/Reflectometry/src/ReflectometryReductionOneAuto3.cpp
@@ -1205,7 +1205,7 @@ std::string ReflectometryReductionOneAuto3::getSummedWorkspaceName(const std::st
     runNumber = getRunNumberForWorkspaceGroup(getPropertyValue(wsPropertyName));
   }
 
-  auto &ws_prefix = isTransWs ? TRANS_WORKSPACE_PREFIX : TOF_WORKSPACE_PREFIX;
+  const auto &ws_prefix = isTransWs ? TRANS_WORKSPACE_PREFIX : TOF_WORKSPACE_PREFIX;
   const std::string hide_prefix = getProperty("HideSummedWorkspaces") ? "__" : "";
 
   return hide_prefix + ws_prefix + runNumber + SUMMED_WORKSPACE_SUFFIX;

--- a/Framework/Reflectometry/src/ReflectometryReductionOneAuto3.cpp
+++ b/Framework/Reflectometry/src/ReflectometryReductionOneAuto3.cpp
@@ -332,14 +332,12 @@ void ReflectometryReductionOneAuto3::init() {
                   "histograms: P1, P2, F1 and F2 in the Wildes method and Pp, Ap, Rho and Alpha for Fredrikze.");
 
   // Sum banks
-  declareProperty(
-      std::make_unique<PropertyWithValue<bool>>("SumAcrossDetectorBanks", false, Direction::Input),
-      "When set to True, the algorithm will attempt to sum counts across each row of a RectangularDetector before "
-      "performing the reduction. This will only work correctly when the instrument definition file (IDF) contains a "
-      "single RectangularDetector panel.");
-
   declareProperty(std::make_unique<PropertyWithValue<std::string>>("ROIDetectorIDs", "", Direction::Input),
-                  "List of detector IDs to include. This will only be used if SumAcrossDetectorBanks is set to True.");
+                  "When detector IDs are provided, the algorithm will attempt to sum counts across each row of a "
+                  "RectangularDetector after the flood correction step. "
+                  "Detectors not included in the given range will be masked before summing. "
+                  "This will only work correctly when the instrument definition file(IDF) contains a single "
+                  "RectangularDetector panel.");
 
   declareProperty(std::make_unique<PropertyWithValue<bool>>("HideSummedWorkspaces", false, Direction::Input),
                   "Whether to hide the workspaces created from the sum banks step, if performed.");
@@ -1240,8 +1238,7 @@ void ReflectometryReductionOneAuto3::sumBanksForWorkspace(const std::string &roi
  * the input data and the transmission runs.
  */
 void ReflectometryReductionOneAuto3::sumBanks() {
-  const bool performSum = getProperty("SumAcrossDetectorBanks");
-  if (performSum) {
+  if (!isDefault("ROIDetectorIDs")) {
     const auto roiDetectorIDs = getPropertyValue("ROIDetectorIDs");
     sumBanksForWorkspace(roiDetectorIDs, "InputWorkspace");
     if (!isDefault("FirstTransmissionRun")) {

--- a/Framework/Reflectometry/src/ReflectometryReductionOneAuto3.cpp
+++ b/Framework/Reflectometry/src/ReflectometryReductionOneAuto3.cpp
@@ -340,6 +340,9 @@ void ReflectometryReductionOneAuto3::init() {
 
   declareProperty(std::make_unique<PropertyWithValue<std::string>>("ROIDetectorIDs", "", Direction::Input),
                   "List of detector IDs to include. This will only be used if SumAcrossDetectorBanks is set to True.");
+
+  declareProperty(std::make_unique<PropertyWithValue<bool>>("HideSummedWorkspaces", false, Direction::Input),
+                  "Whether to hide the workspaces created from the sum banks step, if performed.");
 }
 
 /** Execute the algorithm.
@@ -1202,9 +1205,10 @@ std::string ReflectometryReductionOneAuto3::getSummedWorkspaceName(const std::st
     runNumber = getRunNumberForWorkspaceGroup(getPropertyValue(wsPropertyName));
   }
 
-  auto &prefix = isTransWs ? TRANS_WORKSPACE_PREFIX : TOF_WORKSPACE_PREFIX;
+  auto &ws_prefix = isTransWs ? TRANS_WORKSPACE_PREFIX : TOF_WORKSPACE_PREFIX;
+  const std::string hide_prefix = getProperty("HideSummedWorkspaces") ? "__" : "";
 
-  return prefix + runNumber + SUMMED_WORKSPACE_SUFFIX;
+  return hide_prefix + ws_prefix + runNumber + SUMMED_WORKSPACE_SUFFIX;
 }
 
 /**

--- a/docs/source/release/v6.7.0/Reflectometry/Bugfixes/35658.rst
+++ b/docs/source/release/v6.7.0/Reflectometry/Bugfixes/35658.rst
@@ -1,0 +1,1 @@
+- Move the sum banks step from :ref:`algm-ReflectometryISISLoadAndProcess` to :ref:`algm-ReflectometryReductionOneAuto` so that it takes place after flood correction. Also ensure that the summing step is only applied for instruments that require it.

--- a/docs/source/release/v6.7.0/Reflectometry/Bugfixes/35658.rst
+++ b/docs/source/release/v6.7.0/Reflectometry/Bugfixes/35658.rst
@@ -1,1 +1,1 @@
-- Move the sum banks step from :ref:`algm-ReflectometryISISLoadAndProcess` to :ref:`algm-ReflectometryReductionOneAuto` so that it takes place after flood correction. Also ensure that the summing step is only applied for instruments that require it.
+- Move the sum banks step from :ref:`algm-ReflectometryISISLoadAndProcess` to :ref:`algm-ReflectometryReductionOneAuto` so that it takes place after flood correction. Also only perform the summing step when a detector ID region has been set.

--- a/qt/python/mantidqt/mantidqt/widgets/regionselector/presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/regionselector/presenter.py
@@ -123,7 +123,7 @@ class RegionSelector(ObservingPresenter, SliceViewerBasePresenter):
         if not self.model.ws:
             self._initialise_dimensions(workspace)
 
-        self._set_workspace(workspace)
+        self._set_workspace(workspace, True)
 
     def cancel_drawing_region(self):
         """
@@ -159,10 +159,12 @@ class RegionSelector(ObservingPresenter, SliceViewerBasePresenter):
         self.view.create_dimensions(dims_info=Dimensions.get_dimensions_info(workspace))
         self.view.create_axes_orthogonal(redraw_on_zoom=not WorkspaceInfo.can_support_dynamic_rebinning(workspace))
 
-    def _set_workspace(self, workspace):
+    def _set_workspace(self, workspace, show_all_data=False):
         self.model.ws = workspace
         self.view.set_workspace(workspace)
         self.new_plot()
+        if show_all_data:
+            self.show_all_data_clicked()
 
     def _on_rectangle_selected(self, eclick, erelease):
         """

--- a/qt/python/mantidqt/mantidqt/widgets/regionselector/test/test_regionselector_presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/regionselector/test/test_regionselector_presenter.py
@@ -26,6 +26,12 @@ class RegionSelectorTest(unittest.TestCase):
     def test_matrix_workspaces_allowed(self):
         self.assertIsNotNone(RegionSelector(Mock(), view=Mock()))
 
+    def test_show_all_data_not_called_on_creation(self):
+        region_selector = RegionSelector(ws=Mock(), view=Mock())
+        region_selector.show_all_data_clicked = Mock()
+
+        region_selector.show_all_data_clicked.assert_not_called()
+
     def test_invalid_workspaces_fail(self):
         invalid_types = [WS_TYPE.MDH, WS_TYPE.MDE, None]
         mock_ws = Mock()
@@ -42,6 +48,7 @@ class RegionSelectorTest(unittest.TestCase):
 
     def test_update_workspace_updates_model(self):
         region_selector = RegionSelector(view=Mock())
+        region_selector.show_all_data_clicked = Mock()
         mock_ws = Mock()
 
         region_selector.update_workspace(mock_ws)
@@ -61,11 +68,13 @@ class RegionSelectorTest(unittest.TestCase):
     def test_update_workspace_updates_view(self):
         mock_view = Mock()
         region_selector = RegionSelector(view=mock_view)
+        region_selector.show_all_data_clicked = Mock()
         mock_ws = Mock()
 
         region_selector.update_workspace(mock_ws)
 
         mock_view.set_workspace.assert_called_once_with(mock_ws)
+        region_selector.show_all_data_clicked.assert_called_once()
 
     def test_add_rectangular_region_creates_selector(self):
         region_selector = RegionSelector(ws=Mock(), view=self.mock_view)
@@ -90,6 +99,7 @@ class RegionSelectorTest(unittest.TestCase):
 
     def test_clear_workspace_will_clear_all_the_selectors_and_model_workspace(self):
         region_selector = RegionSelector(view=self.mock_view)
+        region_selector.show_all_data_clicked = Mock()
         mock_ws = Mock()
 
         region_selector.update_workspace(mock_ws)

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewModel.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewModel.cpp
@@ -74,7 +74,6 @@ void PreviewModel::loadAndPreprocessWorkspaceAsync(std::string const &workspaceN
 
 /** Sum spectra across banks
  *
- * @param wsIndices : the workspace indices of the spectra to sum
  * @param jobManager : the job manager that will execute the algorithm
  */
 void PreviewModel::sumBanksAsync(IJobManager &jobManager) { jobManager.startSumBanks(*m_runDetails); }

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.cpp
@@ -274,7 +274,15 @@ void PreviewPresenter::plotLinePlot() {
   m_plotPresenter->plot();
 }
 
-void PreviewPresenter::runSumBanks() { m_model->sumBanksAsync(*m_jobManager); }
+void PreviewPresenter::runSumBanks() {
+  if (m_model->getSelectedBanks().get_value_or("").empty()) {
+    // Do not sum the workspace if no detector IDs have been selected
+    m_model->setSummedWs(m_model->getLoadedWs());
+    notifySumBanksCompleted();
+  } else {
+    m_model->sumBanksAsync(*m_jobManager);
+  }
+}
 
 void PreviewPresenter::runReduction() {
   m_view->disableMainWidget();

--- a/qt/scientific_interfaces/ISISReflectometry/test/Preview/PreviewPresenterTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Preview/PreviewPresenterTest.h
@@ -132,7 +132,7 @@ public:
     auto mockRegionSelector = makeRegionSelector();
     auto mockInstViewModel = makeInstViewModel();
 
-    expectLoadWorkspaceCompletedForLinearDetector(*mockModel, *mockJobManager, *mockDockedWidgets, *mockInstViewModel);
+    expectLoadWorkspaceCompletedForLinearDetector(*mockModel, *mockDockedWidgets, *mockInstViewModel);
 
     EXPECT_CALL(*mockRegionSelector, clearWorkspace()).Times(1);
 
@@ -607,7 +607,7 @@ private:
     EXPECT_CALL(linePlot, setPlotErrorBars(true)).Times(1);
   }
 
-  void expectLoadWorkspaceCompletedForLinearDetector(MockPreviewModel &mockModel, MockJobManager &mockJobManager,
+  void expectLoadWorkspaceCompletedForLinearDetector(MockPreviewModel &mockModel,
                                                      MockPreviewDockedWidgets &mockDockedWidgets,
                                                      MockInstViewModel &mockInstViewModel) {
     auto ws = createLinearDetectorWorkspace();

--- a/qt/scientific_interfaces/ISISReflectometry/test/Preview/PreviewPresenterTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Preview/PreviewPresenterTest.h
@@ -217,6 +217,20 @@ public:
     presenter.notifyInstViewShapeChanged();
   }
 
+  void test_notify_inst_view_shape_removed() {
+    auto mockView = makeView();
+    auto mockModel = makeModel();
+    auto mockInstViewModel = makeInstViewModel();
+    auto mockJobManager = makeJobManager();
+    auto mockDockedWidgets = makePreviewDockedWidgets();
+    expectInstViewSetToEditMode(*mockDockedWidgets);
+    expectSumBanksCalledNoSelectedDetectors(*mockModel, *mockInstViewModel, *mockDockedWidgets, *mockJobManager);
+    // TODO check that the model is called to sum banks
+    auto presenter = PreviewPresenter(packDeps(mockView.get(), std::move(mockModel), std::move(mockJobManager),
+                                               std::move(mockInstViewModel), std::move(mockDockedWidgets)));
+    presenter.notifyInstViewShapeChanged();
+  }
+
   void test_notify_inst_view_shape_unchanged() {
     auto mockView = makeView();
     auto mockModel = makeModel();
@@ -598,11 +612,10 @@ private:
                                                      MockInstViewModel &mockInstViewModel) {
     auto ws = createLinearDetectorWorkspace();
 
-    EXPECT_CALL(mockModel, getLoadedWs()).Times(1).WillOnce(Return(ws));
+    EXPECT_CALL(mockModel, getLoadedWs()).Times(2).WillOnce(Return(ws));
     EXPECT_CALL(mockModel, getDefaultTheta()).Times(1);
     EXPECT_CALL(mockInstViewModel, updateWorkspace(ws)).Times(1);
     EXPECT_CALL(mockDockedWidgets, setInstViewToolbarEnabled(true)).Times(1);
-    EXPECT_CALL(mockModel, sumBanksAsync(Ref(mockJobManager))).Times(1);
   }
 
   void expectLoadWorkspaceCompletedUpdatesInstrumentView(MockPreviewDockedWidgets &mockDockedWidgets,
@@ -618,7 +631,7 @@ private:
     auto ws = createRectangularDetectorWorkspace();
     auto angle = 2.3;
 
-    EXPECT_CALL(mockModel, getLoadedWs()).Times(1).WillOnce(Return(ws));
+    EXPECT_CALL(mockModel, getLoadedWs()).Times(2).WillOnce(Return(ws));
     EXPECT_CALL(mockModel, getDefaultTheta()).Times(1).WillOnce(Return(angle));
     EXPECT_CALL(mockView, setAngle(angle)).Times(1);
   }
@@ -626,7 +639,7 @@ private:
   void expectInstViewModelUpdatedWithLoadedWorkspace(MockPreviewModel &mockModel,
                                                      MockInstViewModel &mockInstViewModel) {
     auto ws = createRectangularDetectorWorkspace();
-    EXPECT_CALL(mockModel, getLoadedWs()).Times(1).WillOnce(Return(ws));
+    EXPECT_CALL(mockModel, getLoadedWs()).Times(2).WillOnce(Return(ws));
     EXPECT_CALL(mockInstViewModel, updateWorkspace(Eq(ws))).Times(1);
   }
 
@@ -635,12 +648,30 @@ private:
                                                MockJobManager &mockJobManager) {
     auto detIndices = std::vector<size_t>{44, 45, 46};
     auto detIDs = std::vector<Mantid::detid_t>{2, 3, 4};
-    auto detIDsStr = ProcessingInstructions{"2-4"};
+    auto previousDetIDsStr = boost::optional<ProcessingInstructions>{};
+    auto detIDsStr = boost::optional<ProcessingInstructions>{"2-4"};
     EXPECT_CALL(mockDockedWidgets, getSelectedDetectors()).Times(1).WillOnce(Return(detIndices));
     EXPECT_CALL(mockInstViewModel, detIndicesToDetIDs(Eq(detIndices))).Times(1).WillOnce(Return(detIDs));
-    EXPECT_CALL(mockModel, getSelectedBanks()).Times(1);
-    EXPECT_CALL(mockModel, setSelectedBanks(Eq(detIDsStr))).Times(1);
+    EXPECT_CALL(mockModel, getSelectedBanks()).WillOnce(Return(previousDetIDsStr)).WillOnce(Return(detIDsStr));
+    EXPECT_CALL(mockModel, setSelectedBanks(Eq(detIDsStr.get()))).Times(1);
     EXPECT_CALL(mockModel, sumBanksAsync(Ref(mockJobManager))).Times(1);
+  }
+
+  void expectSumBanksCalledNoSelectedDetectors(MockPreviewModel &mockModel, MockInstViewModel &mockInstViewModel,
+                                               MockPreviewDockedWidgets &mockDockedWidgets,
+                                               MockJobManager &mockJobManager) {
+    auto ws = createRectangularDetectorWorkspace();
+    auto detIndices = std::vector<size_t>{};
+    auto detIDs = std::vector<Mantid::detid_t>{};
+    auto previousDetIDsStr = boost::optional<ProcessingInstructions>{"2-4"};
+    auto detIDsStr = boost::optional<ProcessingInstructions>{""};
+    EXPECT_CALL(mockDockedWidgets, getSelectedDetectors()).Times(1).WillOnce(Return(detIndices));
+    EXPECT_CALL(mockInstViewModel, detIndicesToDetIDs(Eq(detIndices))).Times(1).WillOnce(Return(detIDs));
+    EXPECT_CALL(mockModel, getSelectedBanks()).WillOnce(Return(previousDetIDsStr)).WillOnce(Return(detIDsStr));
+    EXPECT_CALL(mockModel, setSelectedBanks(Eq(detIDsStr.get()))).Times(1);
+    EXPECT_CALL(mockModel, getLoadedWs()).Times(1).WillOnce(Return(ws));
+    EXPECT_CALL(mockModel, setSummedWs(Eq(ws))).Times(1);
+    EXPECT_CALL(mockModel, sumBanksAsync(Ref(mockJobManager))).Times(0);
   }
 
   void expectSumBanksCalledOnUnchangedDetectors(MockPreviewModel &mockModel, MockInstViewModel &mockInstViewModel,


### PR DESCRIPTION
**Description of work**

**Purpose of work**
<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
-->
To ensure that the sum banks step is in the right place in the ISIS Reflectometry reduction workflow. Also only perform summing when a detector region of interest has been passed in to ensure that other instruments do not inadvertently pick up the summing step.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**Summary of work**
<!-- Please provide a short, high level description of the work that was done.
-->
The sum banks step has been move into `ReflectometryReductionOneAuto` so that it happens after the flood correction.

I have fixed a bug in the logic that determines when to sum banks so that this only happens when the data in the workspace is exclusively from the 2D detector. After discussing with our scientists, I have also added the condition that summing will only be considered if a detector ROI has been selected. This is important because the summing step is specific to the new INTER 2D detector,  it is not necessarily relevant for all 2D detectors. This meant I needed to slightly change the workflow of the preview tab so that we don't automatically sum all banks on load. Instead the reduction is now attempted without any summing and the user can then start selecting detector banks and ROI/processing instructions to improve the result. Note that with the `INTER45455` 2D test dataset the preview reduction gives an error until either the detector banks have been summed or an appropriate set of processing instructions have been entered, but this accurately mirrors what happens if the reduction is run normally (via the Runs tab). At some point we will be updating the default processing instructions in the INTER parameter file to something that should prevent this error in normal use.

I have added tests for the changes to `ReflectometryReductionOneAuto3` via additional tests in `ReflectometryISISLoadAndProcessTest`, as the sum banks algorithm is written in Python and calling to Python algorithms from the C++ unit tests doesn't seem to work. This fix is a priority and we expect to make changes to the sum banks step in the future, so at that point it may either no longer be necessary to add tests to `ReflectometryReductionOneAuto3Test` or we can resolve the problem at that time.

Similarly I'm not convinced by the solution for hiding the summed workspaces in this PR, but a better approach can be found as part of future work.

**To test:**

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->
1) Load an INTER flood workspace file from the archive into the ADS - ask Rachel for help with finding this if needed.
1) Open the ISIS Reflectometry interface
1) On the Runs tab, enter `INTER45455` into the first row of the table and angle `2.3`.
1) In the Experiment Settings tab, ensure the Flood Correction drop-down is set to `Workspace`. In the Flood Workspace drop-down, select the workspace you loaded in step 1. In the Lookup Settings table, enter `2001-2240` into the ROIDetectorIDs column.
1) Back on the Runs tab, click the process button. The reduction should complete successfully. There should be a workspace called `TOF_45455_summed_segment` in the `TOF` workspace group. There should also be a call to `ReflectometryReductionOneAuto -> ReflectometryISISSumBanks` in the history of the `IvsQ_binned_45455` workspace, which should be after the call to `ApplyFloodWorkspace`.
1) Clear the ADS and close and re-open the GUI to start again.
1) In the Experiment Settings tab of the GUI, in the Lookup Settings table enter `6-62` in the ROI column (note, this is a different column to the ROIDetectorIDs column we set previously, which should be left blank).
1) On the Runs tab of the GUI, enter `INTER45455` into the first row of the table and angle `2.3`.
1) Click the process button. The reduction should complete successfully, but this time there should be no `TOF_45455_summed_segment` in the `TOF` workspace group and no call to `ReflectometryISISSumBanks` in the history.
1) Finally check running some reductions in the preview tab.

Fixes #35629. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.