### PR TITLE
Remove temporary workspaces created by Abins when calling SaveAscii

### DIFF
--- a/docs/source/release/v6.8.0/Indirect/Algorithms/Bugfixes/35663.rst
+++ b/docs/source/release/v6.8.0/Indirect/Algorithms/Bugfixes/35663.rst
@@ -1,0 +1,2 @@
+- Abins no longer creates persistent hidden workspaces when using SaveAscii
+

--- a/scripts/abins/abinsalgorithm.py
+++ b/scripts/abins/abinsalgorithm.py
@@ -613,7 +613,12 @@ class AbinsAlgorithm:
         num_workspaces = mtd[ws_name].getNumberOfEntries()
         for wrk_num in range(num_workspaces):
             wrk = mtd[ws_name].getItem(wrk_num)
-            SaveAscii(InputWorkspace=Scale(wrk, scale, "Multiply"), Filename=wrk.name() + ".dat", Separator="Space", WriteSpectrumID=False)
+            SaveAscii(
+                InputWorkspace=Scale(wrk, scale, "Multiply", StoreInADS=False),
+                Filename=wrk.name() + ".dat",
+                Separator="Space",
+                WriteSpectrumID=False,
+            )
 
     @staticmethod
     def get_cross_section(scattering: str = "Total", nucleons_number: Optional[int] = None, *, protons_number: int) -> float:


### PR DESCRIPTION
Abins uses the algorithm function "Scale" to re-scale the data on-the-fly when calling SaveAscii. By default this function call creates a hidden workspace which is not cleaned up.

**Purpose of work**
As identified in beta testing, when using Abins with hidden workspaces enabled, an unnecessary workspace are created as a side effect each time Abins is used with SaveAscii=True

**Summary of work**
Here we:

- Set StoreInADS=False when calling Scale, so the temporary workspace doesn't appear to the user, even if they have hidden workspaces visible
- Delete the workspace afterwards to free memory

**To test:**

On the main branch, use the Settings dialogue to "Show Invisible Workspaces". Run Algorithms/Simulation/Abins:

- set VibrationalOrPhononFile to one of the .phonon files from UnitTest data
- set AbInitioProgram to "CASTEP"
- set an output workspace
- make sure "SaveAscii" is enabled
- Other settings shouldn't matter, defaults are fine.

A mysterious workspace with a leading underscore should appear.

Repeat the process on this branch; there should be no such workspace.

Fixes #35578 

A small release note has been added.

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.