### PR TITLE
Pin `pint<0.22` to fix euphonic error

### DIFF
--- a/conda/recipes/conda_build_config.yaml
+++ b/conda/recipes/conda_build_config.yaml
@@ -75,6 +75,13 @@ libcxx:
 readline:
   - <8.2
 
+euphonic:
+  - 0.6.*
+
+# v0.22 for python 3.8 is broken. It causes an error in euphonic
+pint:
+  - '!=0.22'
+
 pin_run_as_build:
     boost:
       max_pin: x.x

--- a/conda/recipes/mantid/meta.yaml
+++ b/conda/recipes/mantid/meta.yaml
@@ -64,8 +64,8 @@ requirements:
     - pyyaml
     - scipy
     - openssl
-    - euphonic=0.6.*
-    - pint<0.22  # version 0.22 introduces a breaking change to euphonic 0.6.*
+    - euphonic {{ euphonic }}
+    - pint {{ pint }}
     - toml
     - libglu  # [linux]
 

--- a/conda/recipes/mantid/meta.yaml
+++ b/conda/recipes/mantid/meta.yaml
@@ -65,6 +65,7 @@ requirements:
     - scipy
     - openssl
     - euphonic=0.6.*
+    - pint<0.22  # version 0.22 introduces a breaking change to euphonic 0.6.*
     - toml
     - libglu  # [linux]
 

--- a/mantid-developer-linux.yml
+++ b/mantid-developer-linux.yml
@@ -24,7 +24,7 @@ dependencies:
   - ninja>=1.10.2
   - numpy<=1.23
   - occt
-  - pint<0.22 # version 0.22 introduces a breaking change to euphonic 0.6.*
+  - pint!=0.22 # version 0.22 is broken for python 3.8. pint is a euphonic dependency
   - pip>=21.0.1
   - poco=1.12.1|>=1.12.5 # 1.12.2 introduced an unguarded #define NOMINMAX which causes a compiler warning. It's resolved on their devel branch so should be fine after 1.12.4
   - psutil>=5.8.0

--- a/mantid-developer-linux.yml
+++ b/mantid-developer-linux.yml
@@ -24,6 +24,7 @@ dependencies:
   - ninja>=1.10.2
   - numpy<=1.23
   - occt
+  - pint<0.22 # version 0.22 introduces a breaking change to euphonic 0.6.*
   - pip>=21.0.1
   - poco=1.12.1|>=1.12.5 # 1.12.2 introduced an unguarded #define NOMINMAX which causes a compiler warning. It's resolved on their devel branch so should be fine after 1.12.4
   - psutil>=5.8.0

--- a/mantid-developer-osx.yml
+++ b/mantid-developer-osx.yml
@@ -23,6 +23,7 @@ dependencies:
   - ninja>=1.10.2
   - numpy<=1.23
   - occt
+  - pint<0.22 # version 0.22 introduces a breaking change to euphonic 0.6.*
   - pip>=21.0.1
   - poco=1.12.1|>=1.12.5 # 1.12.2 introduced an unguarded #define NOMINMAX which causes a compiler warning. It's resolved on their devel branch so should be fine after 1.12.4
   - psutil>=5.8.0

--- a/mantid-developer-osx.yml
+++ b/mantid-developer-osx.yml
@@ -23,7 +23,7 @@ dependencies:
   - ninja>=1.10.2
   - numpy<=1.23
   - occt
-  - pint<0.22 # version 0.22 introduces a breaking change to euphonic 0.6.*
+  - pint!=0.22 # version 0.22 is broken for python 3.8. pint is a euphonic dependency
   - pip>=21.0.1
   - poco=1.12.1|>=1.12.5 # 1.12.2 introduced an unguarded #define NOMINMAX which causes a compiler warning. It's resolved on their devel branch so should be fine after 1.12.4
   - psutil>=5.8.0

--- a/mantid-developer-win.yml
+++ b/mantid-developer-win.yml
@@ -25,7 +25,7 @@ dependencies:
   - numpy<=1.23
   - occt
   - conda-wrappers
-  - pint<0.22 # version 0.22 introduces a breaking change to euphonic 0.6.*
+  - pint!=0.22 # version 0.22 is broken for python 3.8. pint is a euphonic dependency
   - pip>=21.0.1
   - poco=1.12.1|>=1.12.5 # 1.12.2 introduced an unguarded #define NOMINMAX which causes a compiler warning. It's resolved on their devel branch so should be fine after 1.12.4
   - psutil>=5.8.0

--- a/mantid-developer-win.yml
+++ b/mantid-developer-win.yml
@@ -25,6 +25,7 @@ dependencies:
   - numpy<=1.23
   - occt
   - conda-wrappers
+  - pint<0.22 # version 0.22 introduces a breaking change to euphonic 0.6.*
   - pip>=21.0.1
   - poco=1.12.1|>=1.12.5 # 1.12.2 introduced an unguarded #define NOMINMAX which causes a compiler warning. It's resolved on their devel branch so should be fine after 1.12.4
   - psutil>=5.8.0


### PR DESCRIPTION
**Description of work**
This PR pins pint to be less than v0.22 in order to fix a breaking change causing an error in euphonic.


**To test:**
Make sure `AbinsLoadPhonopyTest` passes in our CI

Fixes #35662 

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.