### PR TITLE
Add new sliceviewer method to base presenter to fix preview tab crash

### DIFF
--- a/qt/python/mantidqt/mantidqt/widgets/regionselector/presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/regionselector/presenter.py
@@ -213,3 +213,6 @@ class RegionSelector(ObservingPresenter, SliceViewerBasePresenter):
 
     def get_extra_image_info_columns(self, xdata, ydata):
         return {}
+
+    def is_integer_frame(self):
+        return False, False

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/presenters/base_presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/presenters/base_presenter.py
@@ -121,3 +121,7 @@ class SliceViewerBasePresenter(IDataViewSubscriber, ABC):
     @abc.abstractmethod
     def get_extra_image_info_columns(self, xdata, ydata):
         pass
+
+    @abc.abstractmethod
+    def is_integer_frame(self):
+        pass

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_base_presenter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/test/test_base_presenter.py
@@ -40,6 +40,9 @@ class SliceViewerBasePresenterShim(SliceViewerBasePresenter):
     def get_extra_image_info_columns(self):
         return {}
 
+    def is_integer_frame(self):
+        return False, False
+
 
 class SliceViewerBasePresenterTest(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
**Description of work**

**Purpose of work**
<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
-->
This PR fixes the crash that was introduced by new method `is_integer_frame`, which was added to the slice viewer presenter in #35594 but also needed to be added to the base presenter and region selector presenter too.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**Summary of work**
<!-- Please provide a short, high level description of the work that was done.
-->
The ISIS Reflectometry tab uses the `SliceViewerDataView` and manages it via the region selector presenter. This works because the `SliceViewerDataView` takes it's presenter as an interface, and so either the normal slice viewer presenter or the region selector presenter (which both share the same base class) can be passed in. However, the `SliceViewerDataView` makes direct calls to the presenter in a number of places, which creates a dependency that means new methods added to the slice viewer presenter that are called from the view may also need to be added to the base presenter and region selector presenter. This is not the first time this has caused an issue as it's very easy to miss and is not very easy to add a test for.

To get the tab working, this PR implements a quick fix, however I think that the more robust, long-term solution would be to reconsider the design here to break the circular dependency. For the `SliceViewerDataView` to be genuinely re-usable with different presenters I think it would need to be refactored to stop making direct calls to the presenter. This would not be an insignificant refactor so I will open a separate maintenance issue.


**To test:**

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->
See linked issue.

Fixes #35645. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

*This does not require release notes* because **it fixes a regression introduced between releases.**

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.