### PR TITLE
Reduce precison of startx and endx

### DIFF
--- a/qt/scientific_interfaces/Indirect/IndirectFitDataView.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitDataView.cpp
@@ -49,7 +49,7 @@ public:
   }
 };
 
-QString makeNumber(double d) { return QString::number(d, 'g', 16); }
+QString makeNumber(double d) { return QString::number(d, 'g', 6); }
 
 QStringList defaultHeaders() {
   QStringList headers;


### PR DESCRIPTION
**Description of work**
This PR fixes the StartX and EndX columns in the indirect data analysis data table.

**Purpose of work**
<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
-->
To make the number appear clearer in the indirect data analysis data table.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**Summary of work**
<!-- Please provide a short, high level description of the work that was done.
-->
The precision of the columns has been reduced 

**Further detail of work**
<!-- Please provide a more detailed description of the work that has been undertaken.
-->
The precision of the columns has been decreased so that they display properly. Before, there were trailing dots because the numbers were too long.

**To test:**
1- Go to Interfaces > Indirect > Data Analysis
2- Go to the Conv Fit tab
3- Click Add Workspace
4- With the combo boxes set to File
5- Click browse and load the irs26176_graphite002_red.nxs file from the sample data
6- Click browse and load the resolution file irs26173_graphite002_res.nxs from the sample data
7- Click Add and close the dialogue.
8- You should see that StartX and EndX have 6 figures precision. 
<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

Fixes #34399. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.