### PR TITLE
Clean up mismatch filename

### DIFF
--- a/Testing/SystemTests/lib/systemtests/systemtesting.py
+++ b/Testing/SystemTests/lib/systemtests/systemtesting.py
@@ -376,7 +376,7 @@ class MantidSystemTest(unittest.TestCase):
             else:
                 mismatchName = self.__class__.__name__ + "-mismatch.nxs"
             print(f'Saving mismatch to "{mismatchName}"')
-            SaveNexus(InputWorkspace=valNames[0], Filename=self.__class__.__name__ + mismatchName + "-mismatch.nxs")
+            SaveNexus(InputWorkspace=valNames[0], Filename=mismatchName)
             return False
 
         return True


### PR DESCRIPTION
**Description of work**

**Purpose of work**
Systemtest mismatch filenames are currently garbled and repeat themselves. See e.g. the Artifacts of this run https://builds.mantidproject.org/job/pull_requests-conda-linux/4241/

This also makes the filename inconsistent with the printed message "Saving mismatch to ..."

**Summary of work**
Removed some redundant parts of the output filename argument, so it is consistent with printed message

**Further detail of work**
This does not solve my remaining problem with systemtest mismatch files: I can no longer find the generated files! They used to appear in build/Testing/Systemtests/scripts, but lately have not been showing up....

I would strongly prefer that the user message prints the full absolute path of the generated file, but I don't know enough about how Mantid paths and SaveNexus work to implement this.

**To test:**

Fail a systemtest. Look at the name of the generated mismatch file (if you can find it). Compare before/after this change.

This might not require release notes as it doesn't affect regular users. Still, it fixes a regression so maybe wouldn't hurt.

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.