### PR TITLE
Do not sort events in ExtractSpectra

### DIFF
--- a/docs/source/release/v6.8.0/Framework/Algorithms/Bugfixes/35687.rst
+++ b/docs/source/release/v6.8.0/Framework/Algorithms/Bugfixes/35687.rst
@@ -1,0 +1,1 @@
+* :ref:`ExtractSpectra <algm-ExtractSpectra>` no longer sorts events when doing x-range trimming. The algorithm that extracts the events does not require it. This will likely move execution time of workflows from ExtractSpectra to elsewhere, but the overall execution may be reduced.


### PR DESCRIPTION
The underlying filtering does not require the events to be sorted, so do not do that extra work. Depending on how this fits into the overall workflow, the change will push the sorting to a different part of the workflow, or it may be skipped altogether.

The other change was to change how events are checked for their x-value in range. This no longer checks both min and max by changing an `!( && )` to `( || )` which saves a small amount of execution time (~.1s for 0.7B events).

**To test:**

This is an internal refactor so no additional tests are needed.

*There is no associated issue.*

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.