### PR TITLE
Set font on non-ubuntu linux

### DIFF
--- a/Framework/PythonInterface/mantid/kernel/environment.py
+++ b/Framework/PythonInterface/mantid/kernel/environment.py
@@ -13,6 +13,7 @@
 """
 import platform as _platform
 import sys as _sys
+import os.path as _osp
 
 
 def is_windows():
@@ -35,6 +36,23 @@ def is_linux():
     Variant on is_apple
     """
     return _sys.platform.startswith("linux")
+
+
+def is_ubuntu() -> bool:
+    """Return True if we're running an Ubuntu distro else return False"""
+    if is_linux():
+        # first try platform module
+        version_info = _platform.uname().version.lower()
+        if "ubuntu" in version_info or "neon" in version_info:
+            return True
+        # then try release file
+        if _osp.isfile("/etc/lsb-release"):
+            with open("/etc/lsb-release") as handle:
+                release_info = handle.read()
+                return bool("Ubuntu" in release_info or "neon" in release_info)
+
+    # none of the previous checks worked
+    return False
 
 
 def is_32bit():

--- a/docs/source/release/v6.7.0/framework.rst
+++ b/docs/source/release/v6.7.0/framework.rst
@@ -38,7 +38,7 @@ Bugfixes
 - :ref:`LoadAndMerge <algm-LoadAndMerge>` now cleans up intermediate loaded workspaces if the ``OutputBehaviour`` was set to 'Concatenate' these inputs.
 - Corrected issue in :ref:`GenerateEventsFilter <algm-GenerateEventsFilter>` where run end time was being determined incorrectly.
 - Corrected issue in :ref:`FilterByTime <algm-FilterByTime>` where filter stop time was being determined incorrectly.
-
+- Default to monospace font on non-ubuntu linuxes
 
 Beamline
 --------

--- a/docs/source/release/v6.7.0/framework.rst
+++ b/docs/source/release/v6.7.0/framework.rst
@@ -38,7 +38,7 @@ Bugfixes
 - :ref:`LoadAndMerge <algm-LoadAndMerge>` now cleans up intermediate loaded workspaces if the ``OutputBehaviour`` was set to 'Concatenate' these inputs.
 - Corrected issue in :ref:`GenerateEventsFilter <algm-GenerateEventsFilter>` where run end time was being determined incorrectly.
 - Corrected issue in :ref:`FilterByTime <algm-FilterByTime>` where filter stop time was being determined incorrectly.
-- Default to monospace font on non-ubuntu linuxes
+
 
 Beamline
 --------

--- a/docs/source/release/v6.7.0/mantidworkbench.rst
+++ b/docs/source/release/v6.7.0/mantidworkbench.rst
@@ -27,6 +27,7 @@ Bugfixes
 - Fixed an issue in :ref:`DrILL <DrILL-ref>` with loading rundexes related to an issue in processing the export algorithm name and the extension simultaneously.
 - The performance of the ``Show Sample Shape`` window has been improved for workspaces with complex CSG shapes for either the sample or the container.
 - Fixed a bug where opening the plot options for a script-created plot with error bars, would crash Workbench.
+- Default to monospace font on non-ubuntu linuxes
 
 
 InstrumentViewer

--- a/qt/applications/workbench/workbench/config/fonts.py
+++ b/qt/applications/workbench/workbench/config/fonts.py
@@ -9,25 +9,10 @@
 #
 """ Utility functions to deal with fetching fonts
 """
-# std imports
-import os
-import os.path as osp
-import sys
-
 # third-party imports
 from qtpy.QtGui import QFont, QFontDatabase
 
-
-def is_ubuntu() -> bool:
-    """Return True if we're running an Ubuntu distro else return False"""
-    # platform.linux_distribution doesn't exist in Python 3.5
-    if sys.platform.startswith("linux") and osp.isfile("/etc/lsb-release"):
-        with open("/etc/lsb-release") as handle:
-            release_info = handle.read()
-            return bool("Ubuntu" in release_info or "neon" in release_info)
-    else:
-        return False
-
+import mantid.kernel.environment as mtd_env
 
 # Plain-text fonts
 MONOSPACE = [
@@ -46,14 +31,18 @@ MONOSPACE = [
 
 
 # Define reasonable point sizes on various OSes
-if sys.platform == "darwin":
+if mtd_env.is_mac():
     MONOSPACE = ["Menlo"] + MONOSPACE
     PT_SIZE = 12
-elif os.name == "nt":
+elif mtd_env.is_windows():
     PT_SIZE = 10
-elif is_ubuntu():
-    MONOSPACE = ["Ubuntu Mono"] + MONOSPACE
-    PT_SIZE = 11
+elif mtd_env.is_linux():
+    if mtd_env.is_ubuntu():
+        MONOSPACE = ["Ubuntu Mono"] + MONOSPACE
+        PT_SIZE = 11
+    else:
+        MONOSPACE = ["Ubuntu Mono", "DejaVu Sans Mono"] + MONOSPACE
+        PT_SIZE = 10
 else:
     PT_SIZE = 9
 


### PR DESCRIPTION
On linuxes other than ubuntu, the fall through behavior for default font produced a non-monospace font on RHEL7. This fixes that by setting font options that are available on RHEL.

Additionally, the os inspection behavior was a repeat of functionality in `mantid.kernel.environment` and was changed to use that central version.

**To test:**

On the ornl analysis cluster, connect via thinlinc and bring up mantidworkbench. Before this patch, any file will have very strange spacing, after this one, everything should be spaced reasonably.

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

Fixes #35681. 

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.