### PR TITLE
Pin `libopenblas!=0.3.23` to fix OSX hang

### DIFF
--- a/mantid-developer-osx.yml
+++ b/mantid-developer-osx.yml
@@ -16,6 +16,7 @@ dependencies:
   - hdf5>=1.12,<1.13
   - jemalloc>=5.2.1
   - jsoncpp>=1.9.4,<2
+  - libopenblas!=0.3.23 # v0.3.23 causes a hang for the system tests on OSX
   - librdkafka>=1.6.0
   - muparser>=2.3.2
   - matplotlib=3.6.*


### PR DESCRIPTION
**Description of work**
This PR pins the `libopenblas` version for OSX to not be 0.3.23 because this latest version causes a hang for some systemtests. We have confirmed the hang was happening for the following:

- `ConvertWANDSCDtoQTest`
- `IntegratePeaksProfileFittingTest`

**To test:**
Check the `build and test` step on this pipeline build passes:
https://builds.mantidproject.org/job/build_packages_from_branch/404/

Fixes #35691

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.