### PR TITLE
Pin libopenblas in osx packaging step

### DIFF
--- a/conda/recipes/conda_build_config.yaml
+++ b/conda/recipes/conda_build_config.yaml
@@ -71,6 +71,10 @@ gsl:
 libcxx:
   - <16
 
+# v0.3.23 causes a hang on osx for some systemtests
+libopenblas:
+  - '!=0.3.23'
+
 # 8.2 causing segfaults in jupyter unit tests and doc builds.
 readline:
   - <8.2

--- a/conda/recipes/mantid/meta.yaml
+++ b/conda/recipes/mantid/meta.yaml
@@ -67,6 +67,7 @@ requirements:
     - euphonic {{ euphonic }}
     - toml
     - libglu  # [linux]
+    - libopenblas {{ libopenblas }}  # [osx]
 
 about:
   home: https://github.com/mantidproject/mantid


### PR DESCRIPTION
**Description of work**
This PR pins the `libopenblas` package in the OSX packaging step. Last week, we fixed a hang for our system tests on OSX by pinning libopenblas in the build and test step. We want this packaging step to be identical to the build and test step.

**To test:**
Code review and make sure the following pipeline run passes:
https://builds.mantidproject.org/job/build_packages_from_branch/405/

*There is no associated issue.*

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.