### PR TITLE
Handle errors when multiple lookup rows found from Preview tab

### DIFF
--- a/docs/source/release/v6.8.0/Reflectometry/Bugfixes/35717.rst
+++ b/docs/source/release/v6.8.0/Reflectometry/Bugfixes/35717.rst
@@ -1,0 +1,1 @@
+- Mantid no longer crashes when reducing a run on the :ref:`Preview tab <refl_preview>` that matches multiple rows in the :ref:`Experiment tab<refl_exp_instrument_settings>` lookup table. An error message is displayed instead.

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewJobManager.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewJobManager.cpp
@@ -12,6 +12,7 @@
 #include "MantidQtWidgets/Common/BatchAlgorithmRunner.h"
 #include "MantidQtWidgets/Common/IJobRunner.h"
 #include "Reduction/Item.h"
+#include "Reduction/RowExceptions.h"
 
 #include <memory>
 
@@ -36,6 +37,11 @@ AlgorithmType algorithmType(MantidQt::API::IConfiguredAlgorithm_sptr &configured
     throw std::logic_error(std::string("Preview tab error: callback from invalid algorithm ") + name);
   }
 }
+
+const std::string LOADING_ERROR_PREFIX("Error loading workspace: ");
+const std::string SUMMING_ERROR_PREFIX("Error summing banks: ");
+const std::string REDUCTION_ERROR_PREFIX("Error performing reduction: ");
+const std::string MULTIPLE_ROWS_ERROR_MSG("Matched multiple lookup rows in the Experiment Settings tab");
 } // namespace
 
 namespace MantidQt::CustomInterfaces::ISISReflectometry {
@@ -92,15 +98,15 @@ void PreviewJobManager::notifyAlgorithmError(API::IConfiguredAlgorithm_sptr algo
   // injecting IReflMessageHandler as other tabs do. This is not urgent for the initial implementation though.
   switch (algorithmType(algorithm)) {
   case AlgorithmType::PREPROCESS:
-    g_log.error(std::string("Error loading workspace: ") + message);
+    g_log.error(LOADING_ERROR_PREFIX + message);
     m_notifyee->notifyLoadWorkspaceAlgorithmError();
     break;
   case AlgorithmType::SUM_BANKS:
-    g_log.error(std::string("Error summing banks: ") + message);
+    g_log.error(SUMMING_ERROR_PREFIX + message);
     m_notifyee->notifySumBanksAlgorithmError();
     break;
   case AlgorithmType::REDUCTION:
-    g_log.error(std::string("Error performing reduction: ") + message);
+    g_log.error(REDUCTION_ERROR_PREFIX + message);
     m_notifyee->notifyReductionAlgorithmError();
     break;
   };
@@ -110,9 +116,25 @@ void PreviewJobManager::startPreprocessing(PreviewRow &row) {
   executeAlg(m_algFactory->makePreprocessingAlgorithm(row));
 }
 
-void PreviewJobManager::startSumBanks(PreviewRow &row) { executeAlg(m_algFactory->makeSumBanksAlgorithm(row)); }
+void PreviewJobManager::startSumBanks(PreviewRow &row) {
+  try {
+    executeAlg(m_algFactory->makeSumBanksAlgorithm(row));
+  } catch (MultipleRowsFoundException const &) {
+    g_log.error(SUMMING_ERROR_PREFIX + MULTIPLE_ROWS_ERROR_MSG);
+    m_notifyee->notifySumBanksAlgorithmError();
+    return;
+  }
+}
 
-void PreviewJobManager::startReduction(PreviewRow &row) { executeAlg(m_algFactory->makeReductionAlgorithm(row)); }
+void PreviewJobManager::startReduction(PreviewRow &row) {
+  try {
+    executeAlg(m_algFactory->makeReductionAlgorithm(row));
+  } catch (MultipleRowsFoundException const &) {
+    g_log.error(REDUCTION_ERROR_PREFIX + MULTIPLE_ROWS_ERROR_MSG);
+    m_notifyee->notifyReductionAlgorithmError();
+    return;
+  }
+}
 
 void PreviewJobManager::executeAlg(IConfiguredAlgorithm_sptr alg) {
   m_jobRunner->clearAlgorithmQueue();


### PR DESCRIPTION
**Description of work**

**Purpose of work**
<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
-->
To prevent a crash when using the preview tab and instead provide a relevant error message.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**Summary of work**
<!-- Please provide a short, high level description of the work that was done.
-->
This PR adds some error handling so that if multiple look up rows are found on the Experiment Settings tab for a given angle an appropriate error message is logged rather than causing Mantid to crash. This is part one of the work required for issue #35704.  Further changes are expected in a separate PR to try and avoid the look up matching against multiple rows in the first place.

**To test:**

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->
See instructions on linked issue. Speak to Rachel if you would like to test with the batch file mentioned on the issue, however testing using just the steps provided should be sufficient.

Refs #35704. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.