### PR TITLE
option to map monitors

### DIFF
--- a/Framework/DataHandling/src/LoadInstrument.cpp
+++ b/Framework/DataHandling/src/LoadInstrument.cpp
@@ -81,8 +81,8 @@ void LoadInstrument::init() {
                   "This property must be set to either True or False.");
   declareProperty("IncludeMonitors", true,
                   "If set to True, Monitors will be assigned spectra when rewriting the spectra map");
-  // setPropertySettings("IncludeMonitors", std::make_unique<Kernel::EnabledWhenProperty>(
-  //                                       "RewriteSpectraMap",Kernel::ePropertyCriterion::IS_EQUAL_TO, "1"));
+  setPropertySettings("IncludeMonitors", std::make_unique<Kernel::EnabledWhenProperty>(
+                                             "RewriteSpectraMap", Kernel::ePropertyCriterion::IS_EQUAL_TO, "1"));
 }
 
 //------------------------------------------------------------------------------------------------------------------------------

--- a/Framework/DataHandling/src/LoadInstrument.cpp
+++ b/Framework/DataHandling/src/LoadInstrument.cpp
@@ -15,6 +15,7 @@
 #include "MantidGeometry/Instrument/InstrumentDefinitionParser.h"
 #include "MantidKernel/ArrayProperty.h"
 #include "MantidKernel/ConfigService.h"
+#include "MantidKernel/EnabledWhenProperty.h"
 #include "MantidKernel/MandatoryValidator.h"
 #include "MantidKernel/OptionalBool.h"
 #include "MantidKernel/Strings.h"
@@ -78,6 +79,10 @@ void LoadInstrument::init() {
                   "If set to False then the spectrum numbers and detector IDs of the "
                   "workspace are not modified."
                   "This property must be set to either True or False.");
+  declareProperty("IncludeMonitors", true,
+                  "If set to True, Monitors will be assigned spectra when rewriting the spectra map");
+  // setPropertySettings("IncludeMonitors", std::make_unique<Kernel::EnabledWhenProperty>(
+  //                                       "RewriteSpectraMap",Kernel::ePropertyCriterion::IS_EQUAL_TO, "1"));
 }
 
 //------------------------------------------------------------------------------------------------------------------------------
@@ -230,8 +235,11 @@ void LoadInstrument::exec() {
   // Rebuild the spectra map for this workspace so that it matches the
   // instrument, if required
   const OptionalBool RewriteSpectraMap = getProperty("RewriteSpectraMap");
-  if (RewriteSpectraMap == OptionalBool::True)
-    ws->rebuildSpectraMapping();
+  if (RewriteSpectraMap == OptionalBool::True) {
+    const bool includeMonitors = getProperty("IncludeMonitors");
+    const specnum_t specNumOffset = 1; // Constant offset from detector ID used to derive spectrum number
+    ws->rebuildSpectraMapping(includeMonitors, specNumOffset);
+  }
 }
 
 //-----------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
**Description of work**
- when the option to rewrite the spectra map is selected, new option `IncludeMonitors` enables the user to skip assigning spectra to the monitors.

**Purpose of work**

**To test:**
The following scripts loads an events file without assigning spectra to the monitors (as customary). We override the instrument of the resulting workspace with `LoadInstrument` without including the monitors (first case) and then including monitors (second case).

Run the following script in mantid workbench:
```python
# import mantid algorithms, numpy and matplotlib
from mantid.simpleapi import *
import matplotlib.pyplot as plt
import numpy as np

LoadEventNexus(Filename="/HFIR/CG3/IPTS-29145/nexus/CG3_19128.nxs.h5",
               LoadMonitors=False,
               OutputWorkspace="CG3_19128")
# The first spectrums has associated pixel with detector ID 0. This is not a monitor
assert mtd["CG3_19128"].getSpectrum(0).getDetectorIDs()[0] == 0

LoadInstrument(Workspace="CG3_19128", Filename="CG3_Definition.xml",
               RewriteSpectraMap=True, IncludeMonitors=False)
assert mtd["CG3_19128"].getSpectrum(0).getDetectorIDs()[0] == 0
              
LoadInstrument(Workspace="CG3_19128", Filename="CG3_Definition.xml",
               RewriteSpectraMap=True, IncludeMonitors=True)
# The first spectrums has associated pixel with detector ID -2. This is a monitor
assert mtd["CG3_19128"].getSpectrum(0).getDetectorIDs()[0] == -2
```

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

Fixes #xxxx. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.