### PR TITLE
RemovePromptPulse performance improvements

### DIFF
--- a/Framework/Algorithms/inc/MantidAlgorithms/RemovePromptPulse.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/RemovePromptPulse.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include "MantidAPI/Algorithm.h"
+#include "MantidAPI/MatrixWorkspace_fwd.h"
 #include "MantidAPI/Run.h"
 #include "MantidAlgorithms/DllConfig.h"
 
@@ -41,6 +42,7 @@ private:
   void exec() override;
   /// Try to get the frequency from a given name.
   double getFrequency(const API::Run &run);
+  void getTofRange(const API::MatrixWorkspace_const_sptr &wksp, double &tmin, double &tmax);
   std::vector<double> calculatePulseTimes(const double tmin, const double tmax, const double period);
 };
 

--- a/Framework/Algorithms/src/MaskBins.cpp
+++ b/Framework/Algorithms/src/MaskBins.cpp
@@ -120,7 +120,11 @@ void MaskBins::execEvent() {
 
   Progress progress(this, 0.0, 1.0, outputWS->getNumberHistograms() * 2);
 
-  outputWS->sortAll(Mantid::DataObjects::TOF_SORT, &progress);
+  {
+    const auto timerStart = std::chrono::high_resolution_clock::now();
+    outputWS->sortAll(Mantid::DataObjects::TOF_SORT, &progress);
+    addTimer("sortEvents", timerStart, std::chrono::high_resolution_clock::now());
+  }
 
   PARALLEL_FOR_IF(Kernel::threadSafe(*outputWS))
   for (int i = 0; i < static_cast<int>(indexSet.size()); // NOLINT

--- a/Framework/DataObjects/src/EventList.cpp
+++ b/Framework/DataObjects/src/EventList.cpp
@@ -2803,6 +2803,21 @@ std::vector<DateAndTime> EventList::getPulseTOFTimesAtSample(const double &facto
 }
 
 // --------------------------------------------------------------------------
+
+namespace { // anonymous namespace
+template <class T> double getTofMinimumHelper(const std::vector<T> &events) {
+  const auto result = std::min_element(events.cbegin(), events.cend(),
+                                       [](const auto &left, const auto &right) { return left.tof() < right.tof(); });
+  return result->tof();
+}
+
+template <class T> double getTofMaximumHelper(const std::vector<T> &events) {
+  const auto result = std::max_element(events.cbegin(), events.cend(),
+                                       [](const auto &left, const auto &right) { return left.tof() < right.tof(); });
+  return result->tof();
+}
+} // anonymous namespace
+
 /**
  * @return The minimum tof value for the list of the events.
  */
@@ -2827,23 +2842,21 @@ double EventList::getTofMin() const {
   }
 
   // now we are stuck with a linear search
-  double temp = tMin; // start with the largest possible value
-  size_t numEvents = this->getNumberEvents();
-  for (size_t i = 0; i < numEvents; i++) {
-    switch (eventType) {
-    case TOF:
-      temp = this->events[i].tof();
-      break;
-    case WEIGHTED:
-      temp = this->weightedEvents[i].tof();
-      break;
-    case WEIGHTED_NOTIME:
-      temp = this->weightedEventsNoTime[i].tof();
-      break;
-    }
-    if (temp < tMin)
-      tMin = temp;
+  switch (eventType) {
+  case TOF: {
+    tMin = getTofMinimumHelper(this->events);
+    break;
   }
+  case WEIGHTED: {
+    tMin = getTofMinimumHelper(this->weightedEvents);
+    break;
+  }
+  case WEIGHTED_NOTIME: {
+    tMin = getTofMinimumHelper(this->weightedEventsNoTime);
+    break;
+  }
+  }
+
   return tMin;
 }
 
@@ -2871,23 +2884,21 @@ double EventList::getTofMax() const {
   }
 
   // now we are stuck with a linear search
-  size_t numEvents = this->getNumberEvents();
-  double temp = tMax; // start with the smallest possible value
-  for (size_t i = 0; i < numEvents; i++) {
-    switch (eventType) {
-    case TOF:
-      temp = this->events[i].tof();
-      break;
-    case WEIGHTED:
-      temp = this->weightedEvents[i].tof();
-      break;
-    case WEIGHTED_NOTIME:
-      temp = this->weightedEventsNoTime[i].tof();
-      break;
-    }
-    if (temp > tMax)
-      tMax = temp;
+  switch (eventType) {
+  case TOF: {
+    tMax = getTofMaximumHelper(this->events);
+    break;
   }
+  case WEIGHTED: {
+    tMax = getTofMaximumHelper(this->weightedEvents);
+    break;
+  }
+  case WEIGHTED_NOTIME: {
+    tMax = getTofMaximumHelper(this->weightedEventsNoTime);
+    break;
+  }
+  }
+
   return tMax;
 }
 

--- a/Framework/WorkflowAlgorithms/src/AlignAndFocusPowder.cpp
+++ b/Framework/WorkflowAlgorithms/src/AlignAndFocusPowder.cpp
@@ -533,6 +533,13 @@ void AlignAndFocusPowder::exec() {
       filterPAlg->setProperty("InputWorkspace", m_outputW);
       filterPAlg->setProperty("OutputWorkspace", m_outputW);
       filterPAlg->setProperty("Width", removePromptPulseWidth);
+
+      // if some of the range was known in CropWorkspace-TOF, use it again here
+      if ((xmin >= 0.))
+        filterPAlg->setProperty("TMin", xmin);
+      if ((xmax > 0.))
+        filterPAlg->setProperty("TMax", xmax);
+
       filterPAlg->executeAsChildAlg();
       m_outputW = filterPAlg->getProperty("OutputWorkspace");
       m_outputEW = std::dynamic_pointer_cast<EventWorkspace>(m_outputW);

--- a/Framework/WorkflowAlgorithms/src/AlignAndFocusPowder.cpp
+++ b/Framework/WorkflowAlgorithms/src/AlignAndFocusPowder.cpp
@@ -40,7 +40,7 @@ using API::MatrixWorkspace;
 using API::MatrixWorkspace_sptr;
 using API::WorkspaceProperty;
 
-namespace {
+namespace { // anonymous namespace
 namespace PropertyNames {
 const std::string INPUT_WKSP("InputWorkspace");
 const std::string OUTPUT_WKSP("OutputWorkspace");
@@ -81,7 +81,15 @@ const std::string UNWRAP_REF("UnwrapRef");
 const std::string LOWRES_REF("LowResRef");
 const std::string LOWRES_SPEC_OFF("LowResSpectrumOffset");
 } // namespace PropertyNames
-} // namespace
+
+void getTofRange(const MatrixWorkspace_const_sptr &wksp, double &tmin, double &tmax) {
+  if (const auto eventWksp = std::dynamic_pointer_cast<const DataObjects::EventWorkspace>(wksp)) {
+    eventWksp->getEventXMinMax(tmin, tmax);
+  } else {
+    wksp->getXMinMax(tmin, tmax);
+  }
+}
+} // anonymous namespace
 
 // Register the class into the algorithm factory
 DECLARE_ALGORITHM(AlignAndFocusPowder)
@@ -501,21 +509,27 @@ void AlignAndFocusPowder::exec() {
   }
   m_progress->report();
 
+  // hold onto over tof range for CropWorkspace(tof) and RemovePromptPulse
+  double tofmin = EMPTY_DBL();
+  double tofmax = EMPTY_DBL();
+
   // crop the workspace in time-of-flight
   if (xmin >= 0. || xmax > 0.) {
-    double tempmin;
-    double tempmax;
-    m_outputW->getXMinMax(tempmin, tempmax);
+    getTofRange(m_outputW, tofmin, tofmax);
 
     g_log.information() << "running CropWorkspace(TOFmin=" << xmin << ", TOFmax=" << xmax << ") started at "
                         << Types::Core::DateAndTime::getCurrentTime() << "\n";
     API::IAlgorithm_sptr cropAlg = createChildAlgorithm("CropWorkspace");
     cropAlg->setProperty("InputWorkspace", m_outputW);
     cropAlg->setProperty("OutputWorkspace", m_outputW);
-    if ((xmin >= 0.) && (xmin > tempmin))
+    if ((xmin >= 0.) && (xmin > tofmin)) {
       cropAlg->setProperty("Xmin", xmin);
-    if ((xmax > 0.) && (xmax < tempmax))
+      tofmin = xmin; // increase value
+    }
+    if ((xmax > 0.) && (xmax < tofmax)) {
       cropAlg->setProperty("Xmax", xmax);
+      tofmax = xmax;
+    }
     cropAlg->executeAsChildAlg();
     m_outputW = cropAlg->getProperty("OutputWorkspace");
     m_outputEW = std::dynamic_pointer_cast<EventWorkspace>(m_outputW);
@@ -535,10 +549,9 @@ void AlignAndFocusPowder::exec() {
       filterPAlg->setProperty("Width", removePromptPulseWidth);
 
       // if some of the range was known in CropWorkspace-TOF, use it again here
-      if ((xmin >= 0.))
-        filterPAlg->setProperty("TMin", xmin);
-      if ((xmax > 0.))
-        filterPAlg->setProperty("TMax", xmax);
+      // they default to EMPTY_DBL which the alg interprets as unset
+      filterPAlg->setProperty("TMin", tofmin);
+      filterPAlg->setProperty("TMax", tofmax);
 
       filterPAlg->executeAsChildAlg();
       m_outputW = filterPAlg->getProperty("OutputWorkspace");

--- a/docs/source/algorithms/RemovePromptPulse-v1.rst
+++ b/docs/source/algorithms/RemovePromptPulse-v1.rst
@@ -9,7 +9,10 @@
 Description
 -----------
 
-Remove the prompt pulse tor a time of flight measurement
+Remove the prompt pulse tor a time of flight measurement.
+
+Specifying the ``Tmin`` and ``Tmax`` parameters can speed up performance of this algorithm with EventWorkspace.
+These two parameters will only limit the possible locations of prompt pulses and are **not** used to crop the data to a range.
 
 
 Usage

--- a/docs/source/release/v6.8.0/Framework/Algorithms/New_features/35724.rst
+++ b/docs/source/release/v6.8.0/Framework/Algorithms/New_features/35724.rst
@@ -1,0 +1,1 @@
+* :ref:`RemovePromptPulse <algm-RemovePromptPulse>` now has options to specify the time range of the data. This can speed up workflows which already know the data range such as :ref:`AlignAndFocusPowder <algm-AlignAndFocusPowder>`.


### PR DESCRIPTION
`RemovePromptPulse` requires knowing the overall time-of-flight range for the data so it can determine what prompt pulse values it needs to remove. In the workflow of `AlignAndFocusPowder` there is a decent chance that the time-of-flight range is already known earlier in the workflow and this re-uses it. For event workspaces that are not sorted, this can be a significantly long time.

This modernizes `EventList` to use c++11 for finding the min/max time-of-flight for the unsorted case.

Some amount of tooling for timing was added to aid future developers.

**To test:**

This is a refactor which is decently covered by existing system tests.

*There is no associated issue,* but this is related to [EWM1852](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=1852)

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.