### PR TITLE
Expose the high background option from FitPeaks

### DIFF
--- a/Framework/Algorithms/src/PDCalibration.cpp
+++ b/Framework/Algorithms/src/PDCalibration.cpp
@@ -244,6 +244,16 @@ void PDCalibration::init() {
                   "(highest Y value position) and "
                   "the peak width will either be estimated by observation or calculated.");
 
+  declareProperty("HighBackground", false,
+                  "Flag whether the data has high background comparing to "
+                  "peaks' intensities. "
+                  "For example, vanadium peaks usually have high background.");
+
+  declareProperty("MinimumSignalToNoiseRatio", 0.,
+                  "Minimum signal-to-noise ratio such that all the peaks with "
+                  "signal-to-noise ratio under this value will be excluded."
+                  "Note, the algorithm will not exclude a peak for which the noise cannot be estimated.");
+
   std::vector<std::string> modes{"DIFC", "DIFC+TZERO", "DIFC+TZERO+DIFA"};
   declareProperty("CalibrationParameters", "DIFC", std::make_shared<StringListValidator>(modes),
                   "Select calibration parameters to fit.");
@@ -269,11 +279,6 @@ void PDCalibration::init() {
       std::make_unique<WorkspaceProperty<API::WorkspaceGroup>>("DiagnosticWorkspaces", "", Direction::Output),
       "Workspaces to promote understanding of calibration results");
 
-  declareProperty("MinimumSignalToNoiseRatio", 0.,
-                  "Minimum signal-to-noise ratio such that all the peaks with "
-                  "signal-to-noise ratio under this value will be excluded."
-                  "Note, the algorithm will not exclude a peak for which the noise cannot be estimated.");
-
   // make group for Input properties
   std::string inputGroup("Input Options");
   setPropertyGroup("InputWorkspace", inputGroup);
@@ -292,6 +297,7 @@ void PDCalibration::init() {
   setPropertyGroup("PeakWidthPercent", fitPeaksGroup);
   setPropertyGroup("MinimumPeakHeight", fitPeaksGroup);
   setPropertyGroup("MinimumSignalToNoiseRatio", fitPeaksGroup);
+  setPropertyGroup("HighBackground", fitPeaksGroup);
   setPropertyGroup("MaxChiSq", fitPeaksGroup);
   setPropertyGroup("ConstrainPeakPositions", fitPeaksGroup);
 
@@ -488,7 +494,8 @@ void PDCalibration::exec() {
   algFitPeaks->setProperty("MinimumSignalToNoiseRatio", minSignalToNoiseRatio);
   // some fitting strategy
   algFitPeaks->setProperty("FitFromRight", true);
-  algFitPeaks->setProperty("HighBackground", false);
+  const bool highBackground = getProperty("HighBackground");
+  algFitPeaks->setProperty("HighBackground", highBackground);
   bool constrainPeakPosition = getProperty("ConstrainPeakPositions");
   algFitPeaks->setProperty("ConstrainPeakPositions",
                            constrainPeakPosition); // TODO Pete: need to test this option

--- a/docs/source/release/v6.8.0/Diffraction/Powder/New_features/35760.rst
+++ b/docs/source/release/v6.8.0/Diffraction/Powder/New_features/35760.rst
@@ -1,0 +1,1 @@
+* Expose the ``HighBackground`` option from :ref:`FitPeaks <algm-FitPeaks>` in :ref:`PDCalibration <algm-PDCalibration>`


### PR DESCRIPTION
Some users need the `HighBackground=true` option of `FitPeaks` when calling from `PDCalibration`. This exposes that parameter and connects it to the user.

**To test:**

See that setting the option to `true` changes the fit results.

*There is no associated issue,* but it is related to [EWM1126](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=1126)

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.