### PR TITLE
AlignAndFocusPowder refactor

### DIFF
--- a/Framework/DataObjects/src/EventList.cpp
+++ b/Framework/DataObjects/src/EventList.cpp
@@ -2830,7 +2830,7 @@ double EventList::getTofMin() const {
     return tMin;
 
   // when events are ordered by tof just need the first value
-  if (this->order == TOF_SORT) {
+  if (this->order == TOF_SORT || this->order == PULSETIMETOF_SORT) {
     switch (eventType) {
     case TOF:
       return this->events.begin()->tof();
@@ -2872,7 +2872,7 @@ double EventList::getTofMax() const {
     return tMax;
 
   // when events are ordered by tof just need the first value
-  if (this->order == TOF_SORT) {
+  if (this->order == TOF_SORT || this->order == PULSETIMETOF_SORT) {
     switch (eventType) {
     case TOF:
       return this->events.rbegin()->tof();

--- a/Framework/DataObjects/src/EventList.cpp
+++ b/Framework/DataObjects/src/EventList.cpp
@@ -2830,7 +2830,7 @@ double EventList::getTofMin() const {
     return tMin;
 
   // when events are ordered by tof just need the first value
-  if (this->order == TOF_SORT || this->order == PULSETIMETOF_SORT) {
+  if (this->order == TOF_SORT) {
     switch (eventType) {
     case TOF:
       return this->events.begin()->tof();
@@ -2872,7 +2872,7 @@ double EventList::getTofMax() const {
     return tMax;
 
   // when events are ordered by tof just need the first value
-  if (this->order == TOF_SORT || this->order == PULSETIMETOF_SORT) {
+  if (this->order == TOF_SORT) {
     switch (eventType) {
     case TOF:
       return this->events.rbegin()->tof();

--- a/Framework/DataObjects/src/EventWorkspace.cpp
+++ b/Framework/DataObjects/src/EventWorkspace.cpp
@@ -421,10 +421,8 @@ void EventWorkspace::getEventXMinMax(double &xmin, double &xmax) const {
 #pragma omp for nowait
     for (int64_t workspaceIndex = 0; workspaceIndex < numWorkspace; workspaceIndex++) {
       const EventList &evList = this->getSpectrum(workspaceIndex);
-      double temp = evList.getTofMin();
-      tXmin = std::min(temp, tXmin);
-      temp = evList.getTofMax();
-      tXmax = std::max(temp, tXmax);
+      tXmin = std::min(evList.getTofMin(), tXmin);
+      tXmax = std::max(evList.getTofMax(), tXmax);
     }
 #pragma omp critical
     {

--- a/Framework/PythonInterface/plugins/algorithms/AlignAndFocusPowderFromFiles.py
+++ b/Framework/PythonInterface/plugins/algorithms/AlignAndFocusPowderFromFiles.py
@@ -226,6 +226,13 @@ class AlignAndFocusPowderFromFiles(DataProcessorAlgorithm):
                     loader.setProperty("BlockList", self.getProperty("LogBlockList").value)
             except RuntimeError:
                 pass  # let it drop on the floor
+
+        # don't automatically bin the data to start
+        try:
+            loader.setProperty("NumberOfBins", 1)
+        except RuntimeError:
+            pass  # let it drop on the floor
+
         for key, value in kwargs.items():
             if isinstance(value, str):
                 loader.setPropertyValue(key, value)

--- a/Framework/PythonInterface/plugins/algorithms/SNAPReduce.py
+++ b/Framework/PythonInterface/plugins/algorithms/SNAPReduce.py
@@ -493,7 +493,13 @@ class SNAPReduce(DataProcessorAlgorithm):
     def _loadMetaWS(self, runnumber):
         # currently only event nexus files are supported
         wsname = "__meta_SNAP_{}".format(runnumber)
-        LoadEventNexus(Filename="SNAP" + str(runnumber), OutputWorkspace=wsname, MetaDataOnly=True, LoadLogs=False)
+        LoadEventNexus(
+            Filename="SNAP" + str(runnumber),
+            OutputWorkspace=wsname,
+            MetaDataOnly=True,
+            NumberOfBins=1,
+            AllowList="det_arc1,det_arc2,det_lin1,det_lin2",
+        )
         return wsname
 
     def _alignAndFocus(self, filename, wkspname, detCalFilename, withUnfocussed, progStart, progDelta):
@@ -543,7 +549,6 @@ class SNAPReduce(DataProcessorAlgorithm):
         return wkspname, unfocussed
 
     def PyExec(self):
-
         if self.getProperty("EnableConfigurator").value:
             self._create_and_save_configuration()
             return  # do not carry out the reduction
@@ -716,7 +721,7 @@ class SNAPReduce(DataProcessorAlgorithm):
                 propprefix = "OutputWorkspace_{:d}_".format(i)
                 propNames = [propprefix + it for it in ["d", "norm", "normalizer"]]
                 wkspNames = ["%s_%s_d" % (new_Tag, runnumber), basename + "_red", "%s_%s_normalizer" % (new_Tag, runnumber)]
-                for (propName, wkspName) in zip(propNames, wkspNames):
+                for propName, wkspName in zip(propNames, wkspNames):
                     self._exportWorkspace(propName, wkspName)
 
         if background:
@@ -724,7 +729,7 @@ class SNAPReduce(DataProcessorAlgorithm):
             prefix = "OutputWorkspace_{}".format(len(in_Runs))
             propNames = [prefix + it for it in ["", "_d"]]
             wkspNames = [background, unfocussedBkgd]
-            for (propName, wkspName) in zip(propNames, wkspNames):
+            for propName, wkspName in zip(propNames, wkspNames):
                 self._exportWorkspace(propName, wkspName)
 
     def _create_and_save_configuration(self):

--- a/Framework/WorkflowAlgorithms/inc/MantidWorkflowAlgorithms/AlignAndFocusPowder.h
+++ b/Framework/WorkflowAlgorithms/inc/MantidWorkflowAlgorithms/AlignAndFocusPowder.h
@@ -75,7 +75,6 @@ private:
 
   API::MatrixWorkspace_sptr m_inputW;
   API::MatrixWorkspace_sptr m_outputW;
-  DataObjects::EventWorkspace_sptr m_outputEW;
   API::ITableWorkspace_sptr m_calibrationWS;
   DataObjects::MaskWorkspace_sptr m_maskWS;
   DataObjects::GroupingWorkspace_sptr m_groupWS;
@@ -103,6 +102,7 @@ private:
   double tmax{0.0};
   bool m_preserveEvents{false};
   void doSortEvents(const Mantid::API::Workspace_sptr &ws);
+  void compressEventsOutputWS(const double compressEventsTolerance, const double wallClockTolerance);
 
   /// Low resolution TOF matrix workspace
   API::MatrixWorkspace_sptr m_lowResW;

--- a/Framework/WorkflowAlgorithms/inc/MantidWorkflowAlgorithms/AlignAndFocusPowder.h
+++ b/Framework/WorkflowAlgorithms/inc/MantidWorkflowAlgorithms/AlignAndFocusPowder.h
@@ -75,7 +75,6 @@ private:
 
   API::MatrixWorkspace_sptr m_inputW;
   API::MatrixWorkspace_sptr m_outputW;
-  DataObjects::EventWorkspace_sptr m_inputEW;
   DataObjects::EventWorkspace_sptr m_outputEW;
   API::ITableWorkspace_sptr m_calibrationWS;
   DataObjects::MaskWorkspace_sptr m_maskWS;

--- a/Framework/WorkflowAlgorithms/inc/MantidWorkflowAlgorithms/AlignAndFocusPowder.h
+++ b/Framework/WorkflowAlgorithms/inc/MantidWorkflowAlgorithms/AlignAndFocusPowder.h
@@ -91,7 +91,7 @@ private:
   std::vector<double> m_delta_ragged;
   std::vector<double> m_resonanceLower;
   std::vector<double> m_resonanceUpper;
-  bool dspace{false};
+  bool binInDspace{false};
   double xmin{0.0};
   double xmax{0.0};
   double LRef{0.0};
@@ -103,6 +103,8 @@ private:
   bool m_preserveEvents{false};
   void doSortEvents(const Mantid::API::Workspace_sptr &ws);
   void compressEventsOutputWS(const double compressEventsTolerance, const double wallClockTolerance);
+  bool shouldCompressUnfocused(const double compressTolerance, const double tofmin, const double tofmax,
+                               const bool hasWallClockTolerance);
 
   /// Low resolution TOF matrix workspace
   API::MatrixWorkspace_sptr m_lowResW;

--- a/Framework/WorkflowAlgorithms/src/AlignAndFocusPowder.cpp
+++ b/Framework/WorkflowAlgorithms/src/AlignAndFocusPowder.cpp
@@ -754,6 +754,14 @@ void AlignAndFocusPowder::exec() {
       if (m_processLowResTOF)
         m_lowResW = rebin(m_lowResW);
     } else if (!m_delta_ragged.empty()) {
+      // to speed up RebinRagged later, sort events once here
+      // making RebinRagged faster when preserveEvents=False would be better
+      if (!m_preserveEvents) {
+        doSortEvents(m_outputW);
+        if (m_processLowResTOF)
+          doSortEvents(m_lowResW);
+      }
+
       m_outputW = rebinRagged(m_outputW, true);
       if (m_processLowResTOF)
         m_lowResW = rebinRagged(m_lowResW, true);

--- a/Framework/WorkflowAlgorithms/src/AlignAndFocusPowder.cpp
+++ b/Framework/WorkflowAlgorithms/src/AlignAndFocusPowder.cpp
@@ -848,14 +848,18 @@ API::MatrixWorkspace_sptr AlignAndFocusPowder::diffractionFocus(API::MatrixWorks
     return ws;
   }
 
-  g_log.information() << "running DiffractionFocussing started at " << Types::Core::DateAndTime::getCurrentTime()
-                      << "\n";
+  // cannot convert to histogram if running with ragged bins
+  // otherwise the data is a histogram *before* the correct binning is set
+  const bool preserveEvents = m_delta_ragged.empty() ? m_preserveEvents : true;
+
+  g_log.information() << "running DiffractionFocussing(PreserveEvents=" << preserveEvents << ") started at "
+                      << Types::Core::DateAndTime::getCurrentTime() << "\n";
 
   API::IAlgorithm_sptr focusAlg = createChildAlgorithm("DiffractionFocussing");
   focusAlg->setProperty("InputWorkspace", ws);
   focusAlg->setProperty("OutputWorkspace", ws);
   focusAlg->setProperty("GroupingWorkspace", m_groupWS);
-  focusAlg->setProperty("PreserveEvents", m_preserveEvents);
+  focusAlg->setProperty("PreserveEvents", preserveEvents);
   focusAlg->executeAsChildAlg();
   ws = focusAlg->getProperty("OutputWorkspace");
 
@@ -992,6 +996,7 @@ API::MatrixWorkspace_sptr AlignAndFocusPowder::rebinRagged(API::MatrixWorkspace_
   alg->setProperty("Delta", m_delta_ragged);
   alg->setProperty("InputWorkspace", matrixws);
   alg->setProperty("OutputWorkspace", matrixws);
+  alg->setProperty("PreserveEvents", m_preserveEvents);
 
   // log the parameters used
   g_log.information() << "running RebinRagged(";

--- a/Framework/WorkflowAlgorithms/src/AlignAndFocusPowder.cpp
+++ b/Framework/WorkflowAlgorithms/src/AlignAndFocusPowder.cpp
@@ -657,10 +657,8 @@ void AlignAndFocusPowder::exec() {
     // turn off the low res stuff
     m_processLowResTOF = false;
 
-    EventWorkspace_sptr ews = std::dynamic_pointer_cast<EventWorkspace>(m_outputW);
-    if (ews)
-      g_log.information() << "Number of events = " << ews->getNumberEvents() << ". ";
-    g_log.information("\n");
+    if (const auto ews = std::dynamic_pointer_cast<EventWorkspace>(m_outputW))
+      g_log.information() << "Number of events = " << ews->getNumberEvents() << ".\n";
 
     m_outputW = convertUnits(m_outputW, "Wavelength");
 
@@ -676,15 +674,13 @@ void AlignAndFocusPowder::exec() {
     removeAlg->setProperty("XMax", maxwl);
     removeAlg->executeAsChildAlg();
     m_outputW = removeAlg->getProperty("OutputWorkspace");
-    if (ews)
+    if (const auto ews = std::dynamic_pointer_cast<EventWorkspace>(m_outputW))
       g_log.information() << "Number of events = " << ews->getNumberEvents() << ".\n";
   } else if (DIFCref > 0.) {
     g_log.information() << "running RemoveLowResTof(RefDIFC=" << DIFCref << ",K=3.22) started at "
                         << Types::Core::DateAndTime::getCurrentTime() << "\n";
-    EventWorkspace_sptr ews = std::dynamic_pointer_cast<EventWorkspace>(m_outputW);
-    if (ews)
-      g_log.information() << "Number of events = " << ews->getNumberEvents() << ". ";
-    g_log.information("\n");
+    if (const auto ews = std::dynamic_pointer_cast<EventWorkspace>(m_outputW))
+      g_log.information() << "Number of events = " << ews->getNumberEvents() << ".\n";
 
     API::IAlgorithm_sptr removeAlg = createChildAlgorithm("RemoveLowResTOF");
     removeAlg->setProperty("InputWorkspace", m_outputW);

--- a/docs/source/diagrams/AlignAndFocusPowder-v1_wkflw.dot
+++ b/docs/source/diagrams/AlignAndFocusPowder-v1_wkflw.dot
@@ -7,8 +7,8 @@ digraph AlignAndFocusPowder {
     InputWorkspace
     OutputWorkspace
     RemovePromptPulseWidth
-    CompressTolerance
-    CropWaveLengthMin
+    compressTol1 [label="CompressTolerance"]
+    compressTol2 [label="CompressTolerance"]
     MaskWorkspace
     MaskBinTable
     CalibrationWorkspace
@@ -33,7 +33,7 @@ digraph AlignAndFocusPowder {
     convertUnits6     [label="ConvertUnits v1\nd-spacing"]
     convertUnits7     [label="ConvertUnits v1\nwavelength"]
     cropWorkspaceTof  [label="CropWorkspace v1\ntof range"]
-    cropWorkspaceWL   [label="CropWorkspace v1\ntof range"]
+    cropWorkspaceWL   [label="CropWorkspace v1\nwavelength range"]
     diffFocus         [label="DiffractionFocussing v2"]
     editGeom          [label="EditInstrumentGeometry v1"]
     lorentz           [label="LorentzCorrection v1"]
@@ -46,59 +46,51 @@ digraph AlignAndFocusPowder {
     rebinRagged       [label="RebinRagged v1"]
     removeLowResTOF   [label="RemoveLowResTOF v1"]
     removePromptPulse [label="RemovePromptPulse v1"]
-    sortEvents1       [label="SortEvents v1"]
-    sortEvents2       [label="SortEvents v1"]
     unwrapSNS         [label="UnwrapSNS v1"]
   }
 
   subgraph decisions {
     $decision_style
-    isEventWorkspace1 [label="Is event workspace?"]
-    isEventWorkspace2 [label="Is event workspace?"]
-    isEventWorkspace3 [label="Is event workspace?"]
-    isCompression     [label="Have compression value?"]
+    isLarge           [label="Is large event workspace?"]
     hasCalibration    [label="Has calibration?"]
     hasResonance      [label="Has absorption\nResonances?"]
+
     isDspace1         [label="Is d-space binning?"]
     isDspace2         [label="Is d-space binning?"]
     isDspace3         [label="Is d-space binning?"]
-    ifParams          [label="LRef or\nDIFCref specified?"]
+    ifParams          [label="LRef specified?"]
+    ifParams2          [label="DIFCref specified?"]
     ifRaggedTof       [label="ragged rebin\nand tof binning"]
   }
 
 
-  InputWorkspace         -> isEventWorkspace1
-
-  isEventWorkspace1      -> isCompression       [label="Yes"]
-  isCompression          -> compressEvents      [label="Yes"]
-  isCompression          -> sortEvents1         [label="No"]
-  CompressTolerance      -> compressEvents
-
-  sortEvents1            -> cropWorkspaceTof
-  compressEvents         -> cropWorkspaceTof
-
-  isEventWorkspace1      -> cropWorkspaceTof        [label="No"]
-  CropWaveLengthMin      -> cropWorkspaceTof
-  cropWorkspaceTof       -> removePromptPulse
+  InputWorkspace         -> maskDetectors
+  MaskWorkspace          -> maskDetectors
+  maskDetectors          -> cropWorkspaceTof
 
   RemovePromptPulseWidth -> removePromptPulse
+  cropWorkspaceTof       -> removePromptPulse
 
   removePromptPulse      -> maskBinsTable
   MaskBinTable           -> maskBinsTable
 
-  maskBinsTable          -> maskDetectors
-  MaskWorkspace          -> maskDetectors
-  maskDetectors          -> isDspace1
-  isDspace1              -> rebin1            [label="Yes"]
-  rebin1                 -> hasCalibration
-  isDspace1              -> hasCalibration               [label="No"]
+  maskBinsTable          ->  isLarge
+  compressTol1           -> compressEvents
+  isLarge                -> compressEvents      [label="Yes"]
+  isLarge                -> isDspace1           [label="No"]
+  compressEvents         -> isDspace1
+
+  isDspace1              -> rebin1            [label="No"]
   params1                -> rebin1
+  rebin1                 -> hasCalibration
+  isDspace1              -> hasCalibration    [label="Yes"]
 
   hasCalibration         -> applyDiffCal         [label="Yes"]
-  hasCalibration         -> convertUnits4        [label="No"]
   CalibrationWorkspace   -> applyDiffCal
   applyDiffCal           -> convertUnits4
+  hasCalibration         -> convertUnits4        [label="No"]
   convertUnits4          -> clearDiffCal
+
   clearDiffCal           -> hasResonance
   hasResonance           -> lorentz              [label="No"]
   hasResonance           -> convertUnits5        [label="Yes"]
@@ -109,26 +101,30 @@ digraph AlignAndFocusPowder {
   lorentz                -> ifParams
 
   ifParams               -> convertUnits7            [label="No"]
-  convertUnits7          -> cropWorkspaceWL
   cropWorkspaceWL        -> convertUnits2
+
+  convertUnits2          -> isDspace2
 
   ifParams               -> convertUnits1        [label="Yes"]
   convertUnits1          -> unwrapSNS
   UnwrapRef              -> unwrapSNS
-  unwrapSNS              -> removeLowResTOF
+  unwrapSNS              -> convertUnits7
+  convertUnits7 -> ifParams2
+
+
+  ifParams2 -> cropWorkspaceWL  [label="No"]
+  ifParams2 -> removeLowResTOF  [label="Yes"]
+
   LowResRef              -> removeLowResTOF
   removeLowResTOF        -> convertUnits2
-  convertUnits2          -> isDspace2
 
   isDspace2              -> diffFocus            [label="No"]
   isDspace2              -> rebin2               [label="Yes"]
   params2                -> rebin2
   rebin2                 -> diffFocus
   GroupingWorkspace      -> diffFocus
-  diffFocus              -> isEventWorkspace2
-  isEventWorkspace2      -> sortEvents2          [label="Yes"]
-  isEventWorkspace2      -> isDspace3            [label="No"]
-  sortEvents2            -> isDspace3
+
+  diffFocus              -> isDspace3
 
 
   isDspace3              -> rebin3               [label="Yes"]
@@ -136,9 +132,10 @@ digraph AlignAndFocusPowder {
   isDspace3              -> editGeom             [label="No"]
 
   editGeom               -> convertUnits3
-  convertUnits3          -> isEventWorkspace3
-  isEventWorkspace3      -> ifRaggedTof          [label="No"]
-  isEventWorkspace3      -> compressEvents2      [label="Yes"]
+
+  convertUnits3 -> compressEvents2
+
+  compressTol2           -> compressEvents2
   compressEvents2        -> ifRaggedTof
   ifRaggedTof            -> rebinRagged          [label="Yes"]
   rebinRagged            -> OutputWorkspace

--- a/docs/source/diagrams/AlignAndFocusPowder-v1_wkflw.dot
+++ b/docs/source/diagrams/AlignAndFocusPowder-v1_wkflw.dot
@@ -25,13 +25,13 @@ digraph AlignAndFocusPowder {
     clearDiffCal      [label="ApplyDiffCal v1\nClear parameters"]
     compressEvents    [label="CompressEvents v1"]
     compressEvents2   [label="CompressEvents v1"]
-    convertUnits1     [label="ConvertUnits v1\nTime-of-Flight"]
-    convertUnits2     [label="ConvertUnits v1\nd-spacing"]
-    convertUnits3     [label="ConvertUnits v1\nTime-of-Flight"]
-    convertUnits4     [label="ConvertUnits v1\nd-spacing"]
-    convertUnits5     [label="ConvertUnits v1\nwavelength"]
-    convertUnits6     [label="ConvertUnits v1\nd-spacing"]
-    convertUnits7     [label="ConvertUnits v1\nwavelength"]
+    convertUnitsTof1     [label="ConvertUnits v1\nTime-of-Flight"]
+    convertUnitsTof2     [label="ConvertUnits v1\nTime-of-Flight"]
+    convertUnitsD1     [label="ConvertUnits v1\nd-spacing"]
+    convertUnitsD2     [label="ConvertUnits v1\nd-spacing"]
+    convertUnitsD3     [label="ConvertUnits v1\nd-spacing"]
+    convertUnitsWL1     [label="ConvertUnits v1\nwavelength"]
+    convertUnitsWL2     [label="ConvertUnits v1\nwavelength"]
     cropWorkspaceTof  [label="CropWorkspace v1\ntof range"]
     cropWorkspaceWL   [label="CropWorkspace v1\nwavelength range"]
     diffFocus         [label="DiffractionFocussing v2"]
@@ -58,8 +58,8 @@ digraph AlignAndFocusPowder {
     isDspace1         [label="Is d-space binning?"]
     isDspace2         [label="Is d-space binning?"]
     isDspace3         [label="Is d-space binning?"]
-    ifParams          [label="LRef specified?"]
-    ifParams2          [label="DIFCref specified?"]
+    ifLref          [label="LRef specified?"]
+    ifDIFCref          [label="DIFCref specified?"]
     ifRaggedTof       [label="ragged rebin\nand tof binning"]
   }
 
@@ -87,36 +87,36 @@ digraph AlignAndFocusPowder {
 
   hasCalibration         -> applyDiffCal         [label="Yes"]
   CalibrationWorkspace   -> applyDiffCal
-  applyDiffCal           -> convertUnits4
-  hasCalibration         -> convertUnits4        [label="No"]
-  convertUnits4          -> clearDiffCal
+  applyDiffCal           -> convertUnitsD2
+  hasCalibration         -> convertUnitsD2        [label="No"]
+  convertUnitsD2          -> clearDiffCal
 
   clearDiffCal           -> hasResonance
   hasResonance           -> lorentz              [label="No"]
-  hasResonance           -> convertUnits5        [label="Yes"]
-  convertUnits5          -> maskBins
-  maskBins               -> convertUnits6
-  convertUnits6          -> lorentz
+  hasResonance           -> convertUnitsWL1        [label="Yes"]
+  convertUnitsWL1          -> maskBins
+  maskBins               -> convertUnitsD3
+  convertUnitsD3          -> lorentz
 
-  lorentz                -> ifParams
+  lorentz                -> ifLref
 
-  ifParams               -> convertUnits7            [label="No"]
-  cropWorkspaceWL        -> convertUnits2
+  ifLref               -> convertUnitsWL2            [label="No"]
+  cropWorkspaceWL        -> convertUnitsD1
 
-  convertUnits2          -> isDspace2
+  convertUnitsD1          -> isDspace2
 
-  ifParams               -> convertUnits1        [label="Yes"]
-  convertUnits1          -> unwrapSNS
+  ifLref               -> convertUnitsTof1        [label="Yes"]
+  convertUnitsTof1          -> unwrapSNS
   UnwrapRef              -> unwrapSNS
-  unwrapSNS              -> convertUnits7
-  convertUnits7 -> ifParams2
+  unwrapSNS              -> convertUnitsWL2
+  convertUnitsWL2 -> ifDIFCref
 
 
-  ifParams2 -> cropWorkspaceWL  [label="No"]
-  ifParams2 -> removeLowResTOF  [label="Yes"]
+  ifDIFCref -> cropWorkspaceWL  [label="No"]
+  ifDIFCref -> removeLowResTOF  [label="Yes"]
 
   LowResRef              -> removeLowResTOF
-  removeLowResTOF        -> convertUnits2
+  removeLowResTOF        -> convertUnitsD1
 
   isDspace2              -> diffFocus            [label="No"]
   isDspace2              -> rebin2               [label="Yes"]
@@ -131,9 +131,9 @@ digraph AlignAndFocusPowder {
   rebin3                 -> editGeom
   isDspace3              -> editGeom             [label="No"]
 
-  editGeom               -> convertUnits3
+  editGeom               -> convertUnitsTof2
 
-  convertUnits3 -> compressEvents2
+  convertUnitsTof2 -> compressEvents2
 
   compressTol2           -> compressEvents2
   compressEvents2        -> ifRaggedTof


### PR DESCRIPTION
In the interest of speeding up powder diffraction processing, this reorders the algorithms inside of `AlignAndFocusPowderFromFiles` and removing unnecessary sorting of events and unit conversions. Using the script below as a guide, the remaining slow parts are `LoadEventNexus` (14.5s) and the final `SortEvents` (12.1s) to make `RebinRagged` faster (7.6s). These last two steps were compared to not sorting then rebinning which was ~1s slower. Future work can be made to speed up that part as well, but likely requires converting `RebinRagged` to a C++ algorithm or create a new variant of `ExtractSpectra` that can take the output binning as a parameter to be used when not preserving events.

Timing of the following script went from 51.6+-0.6s to 40.9+-2.9s
```python
AlignAndFocusPowderFromFiles(Filename='snapcalib/SNAP_57514.lite.nxs.h5', #MaxChunkSize=5,
                             GroupFilename='snapcalib/SNAPFocGrp_Column.lite.xml',
                             CalFilename='snapcalib/SNAP057514_calib_geom_20230324.lite.h5',
                             DMin=[0.65, 0.65, 0.65, 0.65, 0.65, 0.65],
                             DMax=[2.15, 2.43, 2.77, 2.95, 3.74, 4.9],
                             PreserveEvents=False,
                             DeltaRagged=[-0.00086, -0.00096, -0.0013, -0.00117, -0.00147, -0.00186],
                             OutputWorkspace='output')

```

**To test:**

This is a refactor for performance so none of the existing unit or system tests have been modified. Running an existing workflow through the algorithm should be sufficient.

*There is no associated issue,* but this is related to [EWM1852](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=1852)

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.