### PR TITLE
Reset colour bar limit if syntactially invalid value is entered

### DIFF
--- a/docs/source/release/v6.8.0/Workbench/SliceViewer/Bugfixes/34997.rst
+++ b/docs/source/release/v6.8.0/Workbench/SliceViewer/Bugfixes/34997.rst
@@ -1,0 +1,1 @@
+- Entering particular values (i.e 0,111) into the colour bar limit text boxes, will no longer cause an error.

--- a/docs/source/release/v6.8.0/Workbench/SliceViewer/New_features/34997.rst
+++ b/docs/source/release/v6.8.0/Workbench/SliceViewer/New_features/34997.rst
@@ -1,0 +1,1 @@
+- Entering an invalid value into either colour bar limit text box will cause the outline to change to red.

--- a/qt/python/mantidqt/mantidqt/widgets/colorbar/colorbar.py
+++ b/qt/python/mantidqt/mantidqt/widgets/colorbar/colorbar.py
@@ -274,6 +274,8 @@ class ColorbarWidget(QWidget):
         else:
             self._manual_clim()
 
+        self._set_cmin_cmax_box_outline(self.cmin)
+        self._set_cmin_cmax_box_outline(self.cmax)
         self.colorbar.mappable.set_clim(self.cmin_value, self.cmax_value)
         self.redraw()
 

--- a/qt/python/mantidqt/mantidqt/widgets/colorbar/colorbar.py
+++ b/qt/python/mantidqt/mantidqt/widgets/colorbar/colorbar.py
@@ -334,12 +334,17 @@ class ColorbarWidget(QWidget):
                 self.cmin_value = cmin
             else:  # reset values back
                 self.update_clim_text()
+        else:  # reset values back
+            self.update_clim_text()
+
         if self.cmax.hasAcceptableInput():
             cmax = float(self.cmax.text())
             if cmax > self.cmin_value:
                 self.cmax_value = cmax
             else:  # reset values back
                 self.update_clim_text()
+        else:  # reset values back
+            self.update_clim_text()
 
     def _create_linear_normalize_object(self):
         if self.autoscale.isChecked():

--- a/qt/python/mantidqt/mantidqt/widgets/colorbar/colorbar.py
+++ b/qt/python/mantidqt/mantidqt/widgets/colorbar/colorbar.py
@@ -68,7 +68,9 @@ class ColorbarWidget(QWidget):
         self.cmin = QLineEdit()
         self.cmin_value = 0
         self.cmin.setMaximumWidth(100)
+        self.cmin_default_style_sheet = self.cmin.styleSheet()
         self.cmin.editingFinished.connect(self.clim_changed)
+        self.cmin.textEdited.connect(self._set_cmin_box_outline)
         self.cmin_layout = QHBoxLayout()
         self.cmin_layout.addStretch()
         self.cmin_layout.addWidget(self.cmin)
@@ -79,7 +81,9 @@ class ColorbarWidget(QWidget):
         self.cmax = QLineEdit()
         self.cmax_value = 1
         self.cmax.setMaximumWidth(100)
+        self.cmax_default_style_sheet = self.cmax.styleSheet()
         self.cmax.editingFinished.connect(self.clim_changed)
+        self.cmax.textEdited.connect(self._set_cmax_box_outline)
         self.cmax_layout = QHBoxLayout()
         self.cmax_layout.addStretch()
         self.cmax_layout.addWidget(self.cmax)
@@ -400,3 +404,15 @@ class ColorbarWidget(QWidget):
         if not self.norm.model().item(option_index, 0).isEnabled():
             self.norm.model().item(option_index, 0).setEnabled(True)
             self.norm.setItemData(option_index, "", Qt.ToolTipRole)
+
+    def _set_cmax_box_outline(self):
+        if not self.cmax.hasAcceptableInput():
+            self.cmax.setStyleSheet("border: 1px solid red")
+        else:
+            self.cmax.setStyleSheet(self.cmax_default_style_sheet)
+
+    def _set_cmin_box_outline(self):
+        if not self.cmin.hasAcceptableInput():
+            self.cmin.setStyleSheet("border: 1px solid red")
+        else:
+            self.cmin.setStyleSheet(self.cmin_default_style_sheet)

--- a/qt/python/mantidqt/mantidqt/widgets/colorbar/colorbar.py
+++ b/qt/python/mantidqt/mantidqt/widgets/colorbar/colorbar.py
@@ -328,23 +328,34 @@ class ColorbarWidget(QWidget):
     def _manual_clim(self):
         """Update stored colorbar limits
         The new limits are found from user input"""
-        if self.cmin.hasAcceptableInput():
-            cmin = float(self.cmin.text())
-            if cmin < self.cmax_value:
-                self.cmin_value = cmin
-            else:  # reset values back
-                self.update_clim_text()
-        else:  # reset values back
-            self.update_clim_text()
+        self._update_cmin()
+        self._update_cmax()
 
-        if self.cmax.hasAcceptableInput():
-            cmax = float(self.cmax.text())
-            if cmax > self.cmin_value:
-                self.cmax_value = cmax
-            else:  # reset values back
-                self.update_clim_text()
-        else:  # reset values back
+    def _update_cmin(self):
+        """Attempt to update cmin with user input. Reset to previous value if invalid input"""
+        if not self.cmin.hasAcceptableInput():
             self.update_clim_text()
+            return
+
+        cmin = float(self.cmin.text())
+        if cmin >= self.cmax_value:
+            self.update_clim_text()
+            return
+
+        self.cmin_value = cmin
+
+    def _update_cmax(self):
+        """Attempt to update cmax with user input. Reset to previous value if invalid input"""
+        if not self.cmax.hasAcceptableInput():
+            self.update_clim_text()
+            return
+
+        cmax = float(self.cmax.text())
+        if cmax <= self.cmin_value:
+            self.update_clim_text()
+            return
+
+        self.cmax_value = cmax
 
     def _create_linear_normalize_object(self):
         if self.autoscale.isChecked():

--- a/qt/python/mantidqt/mantidqt/widgets/colorbar/colorbar.py
+++ b/qt/python/mantidqt/mantidqt/widgets/colorbar/colorbar.py
@@ -68,22 +68,23 @@ class ColorbarWidget(QWidget):
         self.cmin = QLineEdit()
         self.cmin_value = 0
         self.cmin.setMaximumWidth(100)
-        self.cmin_default_style_sheet = self.cmin.styleSheet()
         self.cmin.editingFinished.connect(self.clim_changed)
-        self.cmin.textEdited.connect(self._set_cmin_box_outline)
+        self.cmin.textEdited.connect(lambda: self._set_cmin_cmax_box_outline(self.cmin))
         self.cmin_layout = QHBoxLayout()
         self.cmin_layout.addStretch()
         self.cmin_layout.addWidget(self.cmin)
         self.cmin_layout.addStretch()
+
+        self.cmin_cmax_default_style_sheet = self.cmin.styleSheet()
+        self.cmin_cmax_red_outline_style_sheet = "border: 1px solid red"
 
         self.linear_validator = QDoubleValidator(parent=self)
         self.log_validator = QDoubleValidator(MIN_LOG_VALUE, sys.float_info.max, 3, self)
         self.cmax = QLineEdit()
         self.cmax_value = 1
         self.cmax.setMaximumWidth(100)
-        self.cmax_default_style_sheet = self.cmax.styleSheet()
         self.cmax.editingFinished.connect(self.clim_changed)
-        self.cmax.textEdited.connect(self._set_cmax_box_outline)
+        self.cmax.textEdited.connect(lambda: self._set_cmin_cmax_box_outline(self.cmax))
         self.cmax_layout = QHBoxLayout()
         self.cmax_layout.addStretch()
         self.cmax_layout.addWidget(self.cmax)
@@ -416,14 +417,8 @@ class ColorbarWidget(QWidget):
             self.norm.model().item(option_index, 0).setEnabled(True)
             self.norm.setItemData(option_index, "", Qt.ToolTipRole)
 
-    def _set_cmax_box_outline(self):
-        if not self.cmax.hasAcceptableInput():
-            self.cmax.setStyleSheet("border: 1px solid red")
+    def _set_cmin_cmax_box_outline(self, box: QLineEdit):
+        if not box.hasAcceptableInput():
+            box.setStyleSheet(self.cmin_cmax_red_outline_style_sheet)
         else:
-            self.cmax.setStyleSheet(self.cmax_default_style_sheet)
-
-    def _set_cmin_box_outline(self):
-        if not self.cmin.hasAcceptableInput():
-            self.cmin.setStyleSheet("border: 1px solid red")
-        else:
-            self.cmin.setStyleSheet(self.cmin_default_style_sheet)
+            box.setStyleSheet(self.cmin_cmax_default_style_sheet)

--- a/qt/python/mantidqt/mantidqt/widgets/colorbar/colorbar.py
+++ b/qt/python/mantidqt/mantidqt/widgets/colorbar/colorbar.py
@@ -341,7 +341,13 @@ class ColorbarWidget(QWidget):
             self.update_clim_text()
             return
 
-        cmin = float(self.cmin.text())
+        # QDoubleValidator can let through some things like 0,111
+        try:
+            cmin = float(self.cmin.text())
+        except ValueError:
+            self.update_clim_text()
+            return
+
         if cmin >= self.cmax_value:
             self.update_clim_text()
             return
@@ -354,7 +360,12 @@ class ColorbarWidget(QWidget):
             self.update_clim_text()
             return
 
-        cmax = float(self.cmax.text())
+        try:
+            cmax = float(self.cmax.text())
+        except ValueError:
+            self.update_clim_text()
+            return
+
         if cmax <= self.cmin_value:
             self.update_clim_text()
             return

--- a/qt/python/mantidqt/mantidqt/widgets/colorbar/test/test_colorbar.py
+++ b/qt/python/mantidqt/mantidqt/widgets/colorbar/test/test_colorbar.py
@@ -111,3 +111,54 @@ class ColorbarWidgetTest(TestCase):
 
             self.assertEqual(c_min, expected_c_min)
             self.assertEqual(c_max, 99)
+
+    def test_invalid_cmax_range_is_reset(self):
+        image = plt.imshow(self.data, cmap="plasma", norm=SymLogNorm(1e-8, vmin=None, vmax=None))
+
+        self.widget.set_mappable(image)
+        self.widget.autoscale.setChecked(True)
+
+        self.widget.cmax_value = 10
+        # less than cmin_value therefore invalid
+        self.widget.cmax.setText("-10")
+        self.widget.clim_changed()
+
+        self.assertEqual("10", self.widget.cmax.text())
+
+    def test_invalid_cmin_range_is_reset(self):
+        image = plt.imshow(self.data, cmap="plasma", norm=SymLogNorm(1e-8, vmin=None, vmax=None))
+
+        self.widget.set_mappable(image)
+        self.widget.autoscale.setChecked(True)
+
+        self.widget.cmax_value = 10
+        self.widget.cmin_value = 0
+        # greater than cmax_value therefore invalid
+        self.widget.cmin.setText("20")
+        self.widget.clim_changed()
+
+        self.assertEqual("0", self.widget.cmin.text())
+
+    def test_invalid_cmax_syntax_is_reset(self):
+        image = plt.imshow(self.data, cmap="plasma", norm=SymLogNorm(1e-8, vmin=None, vmax=None))
+
+        self.widget.set_mappable(image)
+        self.widget.autoscale.setChecked(True)
+
+        self.widget.cmax_value = 10
+        self.widget.cmax.setText("0,1")
+        self.widget.clim_changed()
+
+        self.assertEqual("10", self.widget.cmax.text())
+
+    def test_invalid_cmin_syntax_is_reset(self):
+        image = plt.imshow(self.data, cmap="plasma", norm=SymLogNorm(1e-8, vmin=None, vmax=None))
+
+        self.widget.set_mappable(image)
+        self.widget.autoscale.setChecked(True)
+
+        self.widget.cmin_value = 0
+        self.widget.cmin.setText("0,1")
+        self.widget.clim_changed()
+
+        self.assertEqual("0", self.widget.cmin.text())

--- a/qt/python/mantidqt/mantidqt/widgets/colorbar/test/test_colorbar.py
+++ b/qt/python/mantidqt/mantidqt/widgets/colorbar/test/test_colorbar.py
@@ -144,21 +144,23 @@ class ColorbarWidgetTest(TestCase):
 
         self.widget.set_mappable(image)
         self.widget.autoscale.setChecked(True)
-
         self.widget.cmax_value = 10
-        self.widget.cmax.setText("0,1")
-        self.widget.clim_changed()
 
-        self.assertEqual("10.0", self.widget.cmax.text())
+        for value in ("0,1", "0,001"):
+            self.widget.cmax.setText(value)
+            self.widget.clim_changed()
+
+            self.assertEqual("10.0", self.widget.cmax.text())
 
     def test_invalid_cmin_syntax_is_reset(self):
         image = plt.imshow(self.data, cmap="plasma", norm=SymLogNorm(1e-8, vmin=None, vmax=None))
 
         self.widget.set_mappable(image)
         self.widget.autoscale.setChecked(True)
-
         self.widget.cmin_value = 0
-        self.widget.cmin.setText("0,1")
-        self.widget.clim_changed()
 
-        self.assertEqual("0.0", self.widget.cmin.text())
+        for value in ("0,1", "0,001"):
+            self.widget.cmin.setText(value)
+            self.widget.clim_changed()
+
+            self.assertEqual("0.0", self.widget.cmin.text())

--- a/qt/python/mantidqt/mantidqt/widgets/colorbar/test/test_colorbar.py
+++ b/qt/python/mantidqt/mantidqt/widgets/colorbar/test/test_colorbar.py
@@ -123,7 +123,7 @@ class ColorbarWidgetTest(TestCase):
         self.widget.cmax.setText("-10")
         self.widget.clim_changed()
 
-        self.assertEqual("10", self.widget.cmax.text())
+        self.assertEqual("10.0", self.widget.cmax.text())
 
     def test_invalid_cmin_range_is_reset(self):
         image = plt.imshow(self.data, cmap="plasma", norm=SymLogNorm(1e-8, vmin=None, vmax=None))
@@ -137,7 +137,7 @@ class ColorbarWidgetTest(TestCase):
         self.widget.cmin.setText("20")
         self.widget.clim_changed()
 
-        self.assertEqual("0", self.widget.cmin.text())
+        self.assertEqual("0.0", self.widget.cmin.text())
 
     def test_invalid_cmax_syntax_is_reset(self):
         image = plt.imshow(self.data, cmap="plasma", norm=SymLogNorm(1e-8, vmin=None, vmax=None))
@@ -149,7 +149,7 @@ class ColorbarWidgetTest(TestCase):
         self.widget.cmax.setText("0,1")
         self.widget.clim_changed()
 
-        self.assertEqual("10", self.widget.cmax.text())
+        self.assertEqual("10.0", self.widget.cmax.text())
 
     def test_invalid_cmin_syntax_is_reset(self):
         image = plt.imshow(self.data, cmap="plasma", norm=SymLogNorm(1e-8, vmin=None, vmax=None))
@@ -161,4 +161,4 @@ class ColorbarWidgetTest(TestCase):
         self.widget.cmin.setText("0,1")
         self.widget.clim_changed()
 
-        self.assertEqual("0", self.widget.cmin.text())
+        self.assertEqual("0.0", self.widget.cmin.text())


### PR DESCRIPTION
**Description of work**

In the slice viewer, if you entered "0,1" into the text box for the max value of the colour bar, it would remain there and not reset (the internal value did not change). This PR adds a call to update the text box values if there is an invalid value.

However, the text boxes are given a QDoubleValidator so when you finish inputting a syntactically invalid value, this validator blocks the edittingFinished signal from being sent (the boxes will get updated eventually if you change any other settings). So to show the user their input is not valid, the text box is outlined in red.

This has highlighted the fact that the QDoubleValidator thinks some inputs are valid doubles when infact they aren't (at least according to `float()`). For example, if you type `0,001` the text box thinks this is a valid double (not `0,01` or `0,0001` though). If you then press return, there's an error, as it can't be cast to float. I think this is because this would be a valid comma position for any number that doesn't begin with a 0. Looks like this is a bug in Qt's code? 

I tried to fix this by setting the `QLoacle` (basically the location, if you wanted to use Arabic numbers for example) of the validator 
```self.linear_validator.setLocale(QLocale.C)```
but python is complaining that `QLocale.C` is a `Language` and not a `QLocale` like all the docs say, so I'm a bit stumped in how to fix this.

For now, I've put a try except round the problem area, not an ideal solution though.

**To test:**

 - Create data
 ```
ws = CreateMDWorkspace(Dimensions='3', Extents='-3,3,-3,3,-3,3',
                       Names='H,K,L', Units='r.l.u.,r.l.u.,r.l.u.',
                       Frames='HKL,HKL,HKL',
                       SplitInto='2', SplitThreshold='10')
```
- Open in the slice viewer
- In the max and min colour bar boxes type
  - `0,1`
  - `0,11`
- The box should be outlined red
- Leave `0,11` in the box and move the slider at the top to update the plot: the value should revert box to the last valid value.
- Enter `0,111`. This is a valid value according to the QDoubleValidator (thinks it's "zero thousand one hundred and eleven") but when you press return it should reject the change and revert the value back to the previous state.

Fixes #34997

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.