### PR TITLE
Fix bug discovered by usage test in tutorial

### DIFF
--- a/Framework/Kernel/src/LogFilter.cpp
+++ b/Framework/Kernel/src/LogFilter.cpp
@@ -121,10 +121,18 @@ void LogFilter::addFilter(const TimeSeriesProperty<bool> &filter) {
   // apply the filter to the property
   if (m_prop) {
     // create a TimeROI to apply
-    TimeROI timeroi(m_filter.get());
+    TimeROI timeroi;
 
     // if the end point is a open, then the last point in the TimeROI needs to be modified to make things work out
     if (filterOpenEnded) {
+      if (m_filter->size() == 1 && m_filter->lastValue()) {
+        // create a pretend ROI from the start to the year 2100
+        timeroi.addROI(m_filter->lastTime(), DateAndTime("2100-Jan-01 00:00:01"));
+      } else {
+        // default constructor is fine
+        timeroi = TimeROI(m_filter.get());
+      }
+
       // do a test filtering so the second to last interval can be inspected
       m_prop->filterWith(timeroi);
       // determine how far out to adjust the last ROI
@@ -139,6 +147,8 @@ void LogFilter::addFilter(const TimeSeriesProperty<bool> &filter) {
       else if (newEnd > oldEnd)
         timeroi.addROI(oldEnd, newEnd);
       // both ends match (lucky guess earlier) so there is nothing to adjust
+    } else {
+      timeroi = TimeROI(m_filter.get());
     }
 
     // apply the filter

--- a/docs/source/release/v6.8.0/Framework/Data_Objects/Bugfixes/35767.rst
+++ b/docs/source/release/v6.8.0/Framework/Data_Objects/Bugfixes/35767.rst
@@ -1,0 +1,1 @@
+* Fixed bug in ``mantid.kernel.LogFilter`` usage case from the tutorial site


### PR DESCRIPTION
The usage scenario in [mantid in python tutorial](https://docs.mantidproject.org/nightly/tutorials/python_in_mantid/further_alg_ws/04_run_logs.html) was broken because the "negative" `LogFilter` ended with "use" and didn't come up with enough values. This converts that usage into a unit test and fixes it.

**To test:**

Try out the usage linked to above.

*There is no associated issue,* but is described in [EWM1860](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=1860)

---

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.