### PR TITLE
fix the little issue with the group calib

### DIFF
--- a/docs/source/release/v6.8.0/Diffraction/Powder/Bugfixes/35768.rst
+++ b/docs/source/release/v6.8.0/Diffraction/Powder/Bugfixes/35768.rst
@@ -1,0 +1,1 @@
+- Fix the little issue with the documentation testing for the powder diffraction calibration.

--- a/scripts/Calibration/tofpd/group_calibration.py
+++ b/scripts/Calibration/tofpd/group_calibration.py
@@ -212,7 +212,7 @@ def cc_calibrate_groups(
             if group in SkipCrossCorrelation:
                 # set the detector offsets to zero
                 for item in ws_indices:
-                    mtd["_tmp_group_cc_main"].dataY(item)[0] = 0.0
+                    mtd["_tmp_group_cc_main"].dataY(int(item))[0] = 0.0
                 logger.notice(f"Cross correlation skipped for group-{group}.")
                 converged = True
             else:


### PR DESCRIPTION
**Description of work**

**Purpose of work**
Fix the issue causing the failing test for powder diffraction calibration. There seems to be some issue with original implementation in terms of passing the integer value of the numpy int64 type to C++ signature.