### PR TITLE
Make Windows system test failures fail the build

### DIFF
--- a/Testing/SystemTests/tests/framework/FAILING_TEST.py
+++ b/Testing/SystemTests/tests/framework/FAILING_TEST.py
@@ -1,7 +1,0 @@
-from systemtesting import MantidSystemTest
-
-
-# Test that fails to test that failing system tests will end a build
-class FailingSystemTest(MantidSystemTest):
-    def runTest(self):
-        raise RuntimeError("The fake test failed!")

--- a/Testing/SystemTests/tests/framework/FAILING_TEST.py
+++ b/Testing/SystemTests/tests/framework/FAILING_TEST.py
@@ -1,0 +1,7 @@
+from systemtesting import MantidSystemTest
+
+
+# Test that fails to test that failing system tests will end a build
+class FailingSystemTest(MantidSystemTest):
+    def runTest(self):
+        raise RuntimeError("The fake test failed!")

--- a/buildconfig/Jenkins/Conda/nightly_build_and_deploy.jenkinsfile
+++ b/buildconfig/Jenkins/Conda/nightly_build_and_deploy.jenkinsfile
@@ -426,6 +426,8 @@ def publish_test_reports() {
   xunit thresholds: [failed(failureThreshold: '0')],
     tools: [CTest(excludesPattern: '', pattern: "${CHECKOUT_DIR}/build/Testing/**/*.xml", stopProcessingIfError: true)]
   junit "${CHECKOUT_DIR}/build/Testing/SystemTests/scripts/TEST-*.xml"
+  // Workaround so that a failing system test will actually fail the build
+  sh "test ${currentBuild.currentResult} != UNSTABLE"
 }
 
 def package_conda(platform, base_or_workbench) {


### PR DESCRIPTION
**Description of work**

Previously, if a system test failed on Windows (and this was the only problem) the pipeline would be marked unstable rather than failed. This PR adds a workaround ([from here](https://stackoverflow.com/questions/55910431/jenkins-junit-plugin-reports-a-build-as-unstable-even-if-test-fails)) to make sure the build fails in this case.

**To test:**

I've made two builds of this branch but with an additional failing system test

- [Before the fix](https://builds.mantidproject.org/job/build_packages_from_branch/414/)
- [After the fix](https://builds.mantidproject.org/job/build_packages_from_branch/415/)

Fixes #35307

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.