### PR TITLE
Add option to rotate UB by goniometer in SaveIsawUB

### DIFF
--- a/Framework/Crystal/src/IndexPeaks.cpp
+++ b/Framework/Crystal/src/IndexPeaks.cpp
@@ -479,6 +479,8 @@ void IndexPeaks::exec() {
       g_log.warning("empty modVector 3, skipping saving");
       lattice.setModVec3(V3D(0.0, 0.0, 0.0));
     }
+    // set modUB now mod vectors populated
+    lattice.setModUB(lattice.getUB() * lattice.getModHKL());
   }
 
   CombinedIndexingStats indexingInfo;

--- a/Framework/Crystal/test/IndexPeaksTest.h
+++ b/Framework/Crystal/test/IndexPeaksTest.h
@@ -403,6 +403,7 @@ public:
     const auto &lattice = peaksWS->sample().getOrientedLattice();
     TS_ASSERT_EQUALS(0, lattice.getMaxOrder())
     TS_ASSERT_EQUALS(false, lattice.getCrossTerm())
+    TS_ASSERT_DELTA(0.0, lattice.getModUB()[0][0], 1e-6)
   }
 
   void test_exec_with_three_mod_vectors_and_cross_terms_from_alg_input_with_lattice_update() {
@@ -425,6 +426,7 @@ public:
     TS_ASSERT_DELTA(V3D(-0.333, 0.667, 0.333).norm(), lattice.getModVec(1).norm(), 1e-8)
     TS_ASSERT_DELTA(V3D(0.333, -0.667, 0.333).norm(), lattice.getModVec(2).norm(), 1e-8)
     TS_ASSERT_EQUALS(true, lattice.getCrossTerm())
+    TS_ASSERT_DELTA(0.071918, lattice.getModUB()[0][0], 1e-6)
   }
 
   void test_exec_mod_vectors_save_cleared_across_runs() {

--- a/Framework/Crystal/test/SaveIsawUBTest.h
+++ b/Framework/Crystal/test/SaveIsawUBTest.h
@@ -193,4 +193,45 @@ public:
     auto rotated_ub = ws->sample().getOrientedLattice().getUB();
     TS_ASSERT_DELTA(1.0, rotated_ub[0][0], 1e-8); // previously 0 in original (unrotated UB)
   }
+
+  void test_exec_rotate_by_gonio_with_peaks() {
+    // create workspace
+    auto ws = WorkspaceCreationHelper::createPeaksWorkspace(1);
+    std::string wsname = "peaks_rot_gonio";
+    AnalysisDataService::Instance().addOrReplace(wsname, ws);
+    // set UB
+    auto set_ub_alg = AlgorithmFactory::Instance().create("SetUB", 1);
+    set_ub_alg->initialize();
+    set_ub_alg->setLogging(false);
+    set_ub_alg->setPropertyValue("Workspace", wsname);
+    set_ub_alg->execute();
+    // set goniomatrix
+    DblMatrix gonioMat(3, 3, true);
+    gonioMat[0][0] = -1;
+    gonioMat[1][1] = -1;
+    ws->getPeak(0).setGoniometerMatrix(gonioMat);
+
+    // save UB
+    SaveIsawUB save_ub_alg;
+    TS_ASSERT_THROWS_NOTHING(save_ub_alg.initialize())
+    TS_ASSERT(save_ub_alg.isInitialized())
+    TS_ASSERT_THROWS_NOTHING(save_ub_alg.setProperty("Filename", "SaveISawUBTest_RotGonio.mat"));
+    TS_ASSERT_THROWS_NOTHING(save_ub_alg.setPropertyValue("InputWorkspace", wsname));
+    TS_ASSERT_THROWS_NOTHING(save_ub_alg.setProperty("RotateByGoniometerMatrix", true));
+    TS_ASSERT_THROWS_NOTHING(save_ub_alg.execute(););
+    TS_ASSERT(save_ub_alg.isExecuted());
+
+    // load UB (will now be different to one orignally applied)
+    LoadIsawUB load_ub_alg;
+    TS_ASSERT_THROWS_NOTHING(load_ub_alg.initialize())
+    TS_ASSERT(load_ub_alg.isInitialized())
+    TS_ASSERT_THROWS_NOTHING(load_ub_alg.setProperty("Filename", save_ub_alg.getPropertyValue("Filename")));
+    TS_ASSERT_THROWS_NOTHING(load_ub_alg.setPropertyValue("InputWorkspace", wsname));
+    TS_ASSERT_THROWS_NOTHING(load_ub_alg.execute());
+    TS_ASSERT(load_ub_alg.isExecuted());
+
+    // check UB has changed
+    auto rotated_ub = ws->sample().getOrientedLattice().getUB();
+    TS_ASSERT_DELTA(-1.0, rotated_ub[0][1], 1e-8); // previously 1 in original (unrotated UB)
+  }
 };

--- a/docs/source/release/v6.8.0/Diffraction/Single_Crystal/Bugfixes/35776.rst
+++ b/docs/source/release/v6.8.0/Diffraction/Single_Crystal/Bugfixes/35776.rst
@@ -1,0 +1,1 @@
+- Now set ``modUB`` in :ref:`IndexPeaks <algm-IndexPeaks>` when ``SaveModulationInfo=True``

--- a/docs/source/release/v6.8.0/Diffraction/Single_Crystal/New_features/35776.rst
+++ b/docs/source/release/v6.8.0/Diffraction/Single_Crystal/New_features/35776.rst
@@ -1,0 +1,1 @@
+- New parameter in :ref:`SaveIsawUB <algm-SaveIsawUB>` to rotate the UB by the goniometer matrix.


### PR DESCRIPTION
**Report to:** Pascal (WISH)

**Summary of work**
Add option to rotate UB by goniometer in `SaveIsawUB` (for WISH scientists).

In course of this work I found a bug in `IndexPeaks`: in this PR I set the `modUB` in `IndexPeaks` when `SaveModulationInfo=True`  where previously the modulation vectors were saved but `modUB` was all zeros.

**To test:**
(1) Make the workspaces
```
Load(Filename=r'SXD23767.raw', OutputWorkspace='SXD23767')
SetGoniometer(Workspace='SXD23767', Axis0='25,0,1,0,1')
FindSXPeaks(InputWorkspace='SXD23767', PeakFindingStrategy='AllPeaks', AbsoluteBackground=50, ResolutionStrategy='AbsoluteResolution', XResolution=250, PhiResolution=2, TwoThetaResolution=2, OutputWorkspace='peaks')
FindUBUsingFFT(PeaksWorkspace='peaks', MinD=1, MaxD=10)
PredictPeaks(InputWorkspace='peaks', WavelengthMin=0.5, MinDSpacing=0.5, ReflectionCondition='All-face centred', OutputWorkspace='pp')
PredictFractionalPeaks(Peaks='pp', RequirePeaksOnDetector=False, ModVector1='0.5,0.5,0', MaxOrder=1, FracPeaks='sat_peaks')
IndexPeaks(PeaksWorkspace='sat_peaks', 
           Tolerance=0.1, ToleranceForSatellite=0.1, ModVector1='0.5,0.5,0', MaxOrder=1, SaveModulationInfo=True)
sat_peaks = mtd['sat_peaks']
```
(2) Check to `modUB` is set
```
print(sat_peaks.sample().getOrientedLattice().getModUB())
```
It should print
```
[[ 0.07369829  0.          0.        ]
 [-0.06724983  0.          0.        ]
 [-0.14646719  0.          0.        ]]
 ```
(3) Save the workspace on the peak table with/without the goniometer rotation
```
SaveIsawUB(InputWorkspace=sat_peaks, Filename='unrotated_ub.mat', RotateByGoniometerMatrix=False)
SaveIsawUB(InputWorkspace=sat_peaks, Filename='rotated_ub.mat', RotateByGoniometerMatrix=True)
```
Check the UBs save in the `.mat` files are different

Fixes #35709 
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.