### PR TITLE
Adding Silicon analyser to OSIRIS

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ISISIndirectEnergyTransfer.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ISISIndirectEnergyTransfer.py
@@ -90,7 +90,7 @@ class ISISIndirectEnergyTransfer(DataProcessorAlgorithm):
         self.declareProperty(
             name="Reflection",
             defaultValue="",
-            validator=StringListValidator(["002", "004", "006", "111"]),
+            validator=StringListValidator(["002", "004", "006", "111", "333"]),
             doc="Reflection number for instrument setup during run.",
         )
 

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ISISIndirectEnergyTransfer.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/ISISIndirectEnergyTransfer.py
@@ -31,7 +31,6 @@ def add_missing_elements(from_list, to_list):
 
 
 class ISISIndirectEnergyTransfer(DataProcessorAlgorithm):
-
     _chopped_data = None
     _data_files = None
     _load_logs = None
@@ -85,13 +84,13 @@ class ISISIndirectEnergyTransfer(DataProcessorAlgorithm):
         self.declareProperty(
             name="Analyser",
             defaultValue="",
-            validator=StringListValidator(["graphite", "mica", "fmica"]),
+            validator=StringListValidator(["graphite", "mica", "fmica", "silicon"]),
             doc="Analyser bank used during run.",
         )
         self.declareProperty(
             name="Reflection",
             defaultValue="",
-            validator=StringListValidator(["002", "004", "006"]),
+            validator=StringListValidator(["002", "004", "006", "111"]),
             doc="Reflection number for instrument setup during run.",
         )
 

--- a/instrument/OSIRIS_Definition.xml
+++ b/instrument/OSIRIS_Definition.xml
@@ -760,12 +760,12 @@
   <algebra val="app-shape" />
 </type>
 
-  <component type="silica" idlist="silica">
+  <component type="silicon" idlist="silicon">
     <properties />
     <location  />
   </component>
 
-  <type name="silica">
+  <type name="silicon">
     <component type="pix2">
       <location r="1.582" t="-11."    p="0" name="g1005" />
       <location r="1.582" t="-14.82"  p="0" name="g1006" />
@@ -797,7 +797,7 @@
 <idlist idname="graphite">
   <id start="963" end="1004" />
 </idlist>
-  <idlist idname="silica">
+  <idlist idname="silicon">
     <id start="1005" end="1010" />
 </idlist>
 </instrument>

--- a/instrument/OSIRIS_Definition.xml
+++ b/instrument/OSIRIS_Definition.xml
@@ -698,12 +698,12 @@
 </type>
 
 
-<component type="graphite" idlist="graphite">
+<component type="silica" idlist="silica">
   <properties />
   <location  />
 </component>
 
-<type name="graphite">
+<type name="silica">
  <component type="pix1">
   <location r="1.5825" t="-11.5"    p="0" name="g963" />
   <location r="1.5821" t="-14.829"  p="0" name="g964" />
@@ -768,7 +768,7 @@
 <idlist idname="diffraction">
   <id start="3" end="962" />
 </idlist>
-<idlist idname="graphite">
+<idlist idname="silica">
   <id start="963" end="1004" />
 </idlist>
 

--- a/instrument/OSIRIS_Definition.xml
+++ b/instrument/OSIRIS_Definition.xml
@@ -698,12 +698,12 @@
 </type>
 
 
-<component type="silica" idlist="silica">
+<component type="graphite" idlist="graphite">
   <properties />
   <location  />
 </component>
 
-<type name="silica">
+<type name="graphite">
  <component type="pix1">
   <location r="1.5825" t="-11.5"    p="0" name="g963" />
   <location r="1.5821" t="-14.829"  p="0" name="g964" />
@@ -760,6 +760,32 @@
   <algebra val="app-shape" />
 </type>
 
+  <component type="silica" idlist="silica">
+    <properties />
+    <location  />
+  </component>
+
+  <type name="silica">
+    <component type="pix2">
+      <location r="1.582" t="-11."    p="0" name="g1005" />
+      <location r="1.582" t="-14.82"  p="0" name="g1006" />
+      <location r="1.582" t="-18.15"  p="0" name="g1007" />
+      <location r="1.582" t="-21.48"  p="0" name="g1008" />
+      <location r="1.582" t="-24.81"  p="0" name="g1009" />
+      <location r="1.582" t="-28.14"  p="0" name="g1010" />
+    </component>
+  </type>
+
+  <type name="pix2" is="detector">
+    <cuboid id="app-shape">
+      <left-front-bottom-point  x="0.004"   y="-0.12"  z="0.01"     />
+      <left-front-top-point     x="0.004"   y="-0.12"  z="0.0003"  />
+      <left-back-bottom-point   x="-0.004"  y="-0.12"  z="0.01"     />
+      <right-front-bottom-point x="0.004"   y="0.12"   z="0.01"     />
+    </cuboid>
+    <algebra val="app-shape" />
+  </type>
+  
 <!-- DETECTOR/MONITOR IDs -->
 
 <idlist idname="monitors">
@@ -768,8 +794,10 @@
 <idlist idname="diffraction">
   <id start="3" end="962" />
 </idlist>
-<idlist idname="silica">
+<idlist idname="graphite">
   <id start="963" end="1004" />
 </idlist>
-
+  <idlist idname="silica">
+    <id start="1005" end="1010" />
+</idlist>
 </instrument>

--- a/instrument/OSIRIS_Parameters.xml
+++ b/instrument/OSIRIS_Parameters.xml
@@ -8,11 +8,15 @@
 </parameter>
 
 <parameter name="analysers" type="string">
-  <value val="graphite,diffraction" />
+  <value val="graphite,silicon,diffraction" />
 </parameter>
 
 <parameter name="refl-graphite" type="string">
   <value val="002,004" />
+</parameter>
+
+<parameter name="refl-silicon" type="string">
+  <value val="111" />
 </parameter>
 
 <parameter name="refl-diffraction" type="string">

--- a/instrument/OSIRIS_Parameters.xml
+++ b/instrument/OSIRIS_Parameters.xml
@@ -16,7 +16,7 @@
 </parameter>
 
 <parameter name="refl-silicon" type="string">
-  <value val="111" />
+  <value val="111,333" />
 </parameter>
 
 <parameter name="refl-diffraction" type="string">

--- a/instrument/OSIRIS_silicon_111_Parameters.xml
+++ b/instrument/OSIRIS_silicon_111_Parameters.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<parameter-file instrument = "OSIRIS" valid-from = "2014-05-06T00:00:00">
+
+  <component-link name = "OSIRIS">
+
+    <parameter name="analysis-type" type="string">
+      <value val="spectroscopy" />
+    </parameter>
+
+    <parameter name="analyser" type="string">
+      <value val="silicon" />
+    </parameter>
+
+    <parameter name="reflection" type="string">
+      <value val="111" />
+    </parameter>
+
+    <parameter name="Efixed">
+      <value val="2.082" />
+    </parameter>
+
+    <parameter name="resolution">
+      <value val="0.00075" />
+    </parameter>
+
+  </component-link>
+
+</parameter-file>

--- a/instrument/OSIRIS_silicon_333_Parameters.xml
+++ b/instrument/OSIRIS_silicon_333_Parameters.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<parameter-file instrument = "OSIRIS" valid-from = "2014-05-06T00:00:00">
+
+  <component-link name = "OSIRIS">
+
+    <parameter name="analysis-type" type="string">
+      <value val="spectroscopy" />
+    </parameter>
+
+    <parameter name="analyser" type="string">
+      <value val="silicon" />
+    </parameter>
+
+    <parameter name="reflection" type="string">
+      <value val="333" />
+    </parameter>
+
+    <parameter name="Efixed">
+      <value val="18.7434" />
+    </parameter>
+
+    <parameter name="resolution">
+      <value val="0.0315" />
+    </parameter>
+
+  </component-link>
+
+</parameter-file>


### PR DESCRIPTION
This PR add a dummy set of values for the new Si analyser on OSIRIS. We are waiting for the true detector positions etc. Once we have received them we will update the IDF and add some tests (also need real data) https://github.com/mantidproject/mantid/issues/35777


<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->
Report to Spencer and Franz
**Summary of work**
<!-- Please provide a short, high level description of the work that was done.
-->

**Further detail of work**
<!-- Please provide a more detailed description of the work that has been undertaken.
-->


**To test:**

Run the below script
```

ws = Load(r'\\isis.cclrc.ac.uk\inst$\ndxosiris\instrument\data\cycle_12_5\OSIRIS00100320.nxs')


for j in range(5, 10):
    y = ws.readY(j)
    e = ws.readE(j)
    ws.setY(j+1000, y)
    ws.setE(j+1000, e)
    
SaveNexus(ws, "OSIRIS_test.nxs")
    
ISISIndirectEnergyTransferWrapper(InputFiles='OSIRIS_test.nxs',
    Instrument='OSIRIS', Analyser='graphite', Reflection='002', 
    SpectraRange='963,1004', FoldMultipleFrames=False, GroupingMethod='Individual', 
    OutputWorkspace='osiris100320_graphite111_Reduced')


ISISIndirectEnergyTransfer(InputFiles='OSIRIS_test.nxs', 
    Instrument='OSIRIS', Analyser='silicon', Reflection='111', 
    SpectraRange='1005,1010',
    OutputWorkspace='osiris100320_silicon111_Reduced')

ISISIndirectEnergyTransfer(InputFiles='OSIRIS_test.nxs', 
    Instrument='OSIRIS', Analyser='silicon', Reflection='333', 
    SpectraRange='1005,1010',
    OutputWorkspace='osiris100320_silicon333_Reduced')
```

For graphite you will see a nice peak at about 0
For 111 you will see the values rapidly increasing from about 0.5
For 333 you will see stuff with negative x values

![image](https://github.com/mantidproject/mantid/assets/25006392/e9970ef3-5a19-4f09-ba4e-f01d83ebf805)


Fixes #34301 . <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

No release notes as we are adding this so we have something for using in the GUI upgrades. It is not ready for users (need the real detectors) 

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.