### PR TITLE
ReplaceSpecialValues after division by solid angle correction in powder script

### DIFF
--- a/scripts/Diffraction/isis_powder/routines/calibrate.py
+++ b/scripts/Diffraction/isis_powder/routines/calibrate.py
@@ -47,6 +47,15 @@ def create_van(instrument, run_details, absorb, spline=True):
     solid_angle = instrument.get_solid_angle_corrections(run_details.run_number, run_details)
     if solid_angle:
         aligned_ws = mantid.Divide(LHSWorkspace=aligned_ws, RHSWorkspace=solid_angle)
+        aligned_ws = mantid.ReplaceSpecialValues(
+            InputWorkspace=aligned_ws,
+            OutputWorkspace=aligned_ws.name(),
+            NaNValue=0,
+            InfinityValue=0,
+            BigNumberThreshold=1e15,
+            SmallNumberThreshold=-1e15,
+        )
+
         mantid.DeleteWorkspace(solid_angle)
     focused_vanadium = mantid.DiffractionFocussing(InputWorkspace=aligned_ws, GroupingFileName=run_details.grouping_file_path)
     # convert back to TOF based on engineered detector positions


### PR DESCRIPTION
**HIGH PRIORITY - HRPD CANNOT RUN THEIR CALIBRATION**

**Report to:** Chris Howard (HRPD)

**Summary of work**
Add call to `ReplaceSpecialValues` after division by solid angle correction in powder script - was leading to focussed spectrum for bank 3 of HRPD being zeroed

**To test:**
(1) Download this folder [hrpd_PR.zip](https://github.com/mantidproject/mantid/files/11918475/hrpd_PR.zip), unzip and update the paths in the config .yaml file
(2) Run this script
```
from isis_powder import hrpd
from isis_powder.routines import SampleDetails

# if using absorption correction adjust parameters here
slab_obj = SampleDetails(shape="cylinder",center=[0,0,0],height=5.1, radius=0.4)
slab_obj.set_material(number_density=0.003687,chemical_formula="Ca Ti O3")
slab_obj.set_material_properties(absorption_cross_section=4.2749, scattering_cross_section=55.703)

# config_file_path = r"C:\MantidAnalysis\Cycle_23_2\Standards\hrpd_configuration.yaml"
config_file_path = r"C:\Users\xhg73778\Desktop\hrpd\hrpd_config.yaml"
hrpd_example = hrpd.HRPD(config_file=config_file_path, 
                         do_solid_angle_corrections=True) # user_name="Standards")
hrpd_example.set_sample_details(sample=slab_obj)

# crop final data to range - only to be altered on the advice of your local contact
focused_cropping_values = (0.05, 0.95)
# negative means logarithmic in Mantid terminology
focused_bin_widths = [
        -0.0003,  # Bank 1
        -0.0007,  # Bank 2
        -0.0012  # Bank 3
]

# check tof window in the line below is correct
hrpd_example.create_vanadium(first_cycle_run_no="81031", window="10-110", do_absorb_corrections=True, 
                             multiple_scattering=False, vanadium_tof_cropping=focused_cropping_values)
```
(3) Plot third spectrum of `81031-ResultTOF` - it should not be zero but look like this
![image](https://github.com/mantidproject/mantid/assets/55979119/0075cbc0-bcc0-452e-8400-b9ca4c61eca5)


<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

*There is no associated issue.*

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.