### PR TITLE
Debug TimeSplitterTest

### DIFF
--- a/Framework/DataObjects/src/TimeSplitter.cpp
+++ b/Framework/DataObjects/src/TimeSplitter.cpp
@@ -208,19 +208,30 @@ void TimeSplitter::addROI(const DateAndTime &start, const DateAndTime &stop, con
   if (start == stop)
     return;
   assertIncreasing(start, stop);
+  const DateAndTime &firstTime = m_roi_map.begin()->first;
+  const DateAndTime &lastTime = m_roi_map.rbegin()->first;
   if (m_roi_map.empty()) {
     // set the values without checks
     clearAndReplace(start, stop, value);
-  } else if ((start <= m_roi_map.begin()->first) && (stop >= m_roi_map.rbegin()->first)) {
-    // overwrite existing map
+  } else if ((start <= firstTime) && (stop >= lastTime)) {
+    // the new ROI covers the whole of the existing TimeSplitter, thus replace it
     clearAndReplace(start, stop, value);
-  } else if ((stop < m_roi_map.begin()->first) || (start > m_roi_map.rbegin()->first)) {
-    // adding to one end or the other
+  } else if ((stop < firstTime) || (start > lastTime)) {
+    // the new ROI lies outside the whole of the existing TimeSplitter, thus just add it
     if (value > NO_TARGET) { // only add non-ignore values
       m_roi_map.insert({start, value});
       m_roi_map.insert({stop, NO_TARGET});
     }
-  } else {
+  } else if (start == lastTime) { // the new ROI starts at the end of the existing TimeSplitter
+    if (value > NO_TARGET) {      // only add non-ignore values
+      m_roi_map.rbegin()->second = value;
+      m_roi_map.insert({stop, NO_TARGET});
+    }
+  } else if (stop == firstTime) { // the new ROI ends at the start of the existing TimeSplitter
+    if (value > NO_TARGET) {      // only add non-ignore values
+      m_roi_map.insert({start, value});
+    }
+  } else { // the new ROI either overlaps or is inside the existing TimeSplitter
     // do the interesting version
     g_log.debug() << "addROI(" << start << ", " << stop << ", " << value << ")\n";
 

--- a/Framework/DataObjects/test/TimeSplitterTest.h
+++ b/Framework/DataObjects/test/TimeSplitterTest.h
@@ -349,14 +349,21 @@ public:
 
   void test_toSplitters() {
     TimeSplitter splitter;
+    std::cout << std::endl << "DEBUG splitter (empty): " << std::endl << splitter.debugPrint();
+
     splitter.addROI(ONE, TWO, 1);
+    std::cout << std::endl << "DEBUG splitter.addROI(ONE, TWO, 1): " << std::endl << splitter.debugPrint();
+
     splitter.addROI(TWO, THREE, 2);
+    std::cout << std::endl << "DEBUG splitter.addROI(TWO, THREE, 2): " << std::endl << splitter.debugPrint();
+
     splitter.addROI(FOUR, FIVE, 3); // a gap with the previous ROI
-    std::cout << std::endl << "DEBUG splitter: " << std::endl << splitter.debugPrint();
+    std::cout << std::endl << "DEBUG splitter.addROI(FOUR, FIVE, 3): " << std::endl << splitter.debugPrint();
+
     const SplittingIntervalVec splitVec = splitter.toSplitters(true);
-    std::cout << "DEBUG splitVec: " << std::endl;
+    std::cout << std::endl << "DEBUG splitVec: " << std::endl;
     for (const auto &item : splitVec) {
-      std::cout << "DEBUG :" << item.debugStrPrint();
+      std::cout << std::endl << "DEBUG :" << item.debugStrPrint();
     }
     TS_ASSERT_EQUALS(splitVec.size(), 4);
     TS_ASSERT(splitVec[0] == SplittingInterval(ONE, TWO, 1));

--- a/Framework/DataObjects/test/TimeSplitterTest.h
+++ b/Framework/DataObjects/test/TimeSplitterTest.h
@@ -352,7 +352,12 @@ public:
     splitter.addROI(ONE, TWO, 1);
     splitter.addROI(TWO, THREE, 2);
     splitter.addROI(FOUR, FIVE, 3); // a gap with the previous ROI
+    std::cout << std::endl << "DEBUG splitter: " << std::endl << splitter.debugPrint();
     const SplittingIntervalVec splitVec = splitter.toSplitters(true);
+    std::cout << "DEBUG splitVec: " << std::endl;
+    for (const auto &item : splitVec) {
+      std::cout << "DEBUG :" << item.debugStrPrint();
+    }
     TS_ASSERT_EQUALS(splitVec.size(), 4);
     TS_ASSERT(splitVec[0] == SplittingInterval(ONE, TWO, 1));
     TS_ASSERT(splitVec[1] == SplittingInterval(TWO, THREE, 2));

--- a/Framework/DataObjects/test/TimeSplitterTest.h
+++ b/Framework/DataObjects/test/TimeSplitterTest.h
@@ -349,22 +349,10 @@ public:
 
   void test_toSplitters() {
     TimeSplitter splitter;
-    std::cout << std::endl << "DEBUG splitter (empty): " << std::endl << splitter.debugPrint();
-
     splitter.addROI(ONE, TWO, 1);
-    std::cout << std::endl << "DEBUG splitter.addROI(ONE, TWO, 1): " << std::endl << splitter.debugPrint();
-
     splitter.addROI(TWO, THREE, 2);
-    std::cout << std::endl << "DEBUG splitter.addROI(TWO, THREE, 2): " << std::endl << splitter.debugPrint();
-
     splitter.addROI(FOUR, FIVE, 3); // a gap with the previous ROI
-    std::cout << std::endl << "DEBUG splitter.addROI(FOUR, FIVE, 3): " << std::endl << splitter.debugPrint();
-
     const SplittingIntervalVec splitVec = splitter.toSplitters(true);
-    std::cout << std::endl << "DEBUG splitVec: " << std::endl;
-    for (const auto &item : splitVec) {
-      std::cout << std::endl << "DEBUG :" << item.debugStrPrint();
-    }
     TS_ASSERT_EQUALS(splitVec.size(), 4);
     TS_ASSERT(splitVec[0] == SplittingInterval(ONE, TWO, 1));
     TS_ASSERT(splitVec[1] == SplittingInterval(TWO, THREE, 2));

--- a/Framework/Kernel/inc/MantidKernel/SplittingInterval.h
+++ b/Framework/Kernel/inc/MantidKernel/SplittingInterval.h
@@ -38,6 +38,7 @@ public:
   SplittingInterval operator&(const SplittingInterval &b) const;
   /// @endcond
   SplittingInterval operator|(const SplittingInterval &b) const;
+  std::string debugStrPrint() const;
 
   bool operator==(const SplittingInterval &ti) const;
 

--- a/Framework/Kernel/src/SplittingInterval.cpp
+++ b/Framework/Kernel/src/SplittingInterval.cpp
@@ -55,6 +55,13 @@ bool SplittingInterval::operator==(const SplittingInterval &ti) const {
   }
 }
 
+std::string SplittingInterval::debugStrPrint() const {
+  std::stringstream ss;
+  ss << this->begin_str() << " to " << this->end_str();
+  ss << " index: " << index();
+  ss << std::endl;
+  return ss.str();
+}
 //------------------------------------------------------------------------------------------------
 /** Return true if the SplittingIntervalVec provided is a filter,
  * meaning that it only has an output index of 0.

--- a/buildconfig/Jenkins/Conda/conda-buildscript
+++ b/buildconfig/Jenkins/Conda/conda-buildscript
@@ -43,6 +43,13 @@ shift
 CMAKE_PRESET=$1
 shift
 
+if [[ $OSTYPE == 'darwin'* ]]; then
+    exit 0
+fi
+if [[ $OSTYPE == 'linux'* ]]; then
+    exit 0
+fi
+
 if [[ -z "$BUILD_THREADS" ]]; then
     if [[ $OSTYPE == 'darwin'* ]]; then
         BUILD_THREADS="$(sysctl -n hw.logicalcpu)"
@@ -71,10 +78,10 @@ EXTRA_CMAKE_FLAGS="-DENABLE_PRECOMMIT=OFF"
 while [ ! $# -eq 0 ]
 do
     case "$1" in
-        --enable-systemtests) ENABLE_SYSTEM_TESTS=true ;;
+        --enable-systemtests) ENABLE_SYSTEM_TESTS=false ;;
         --enable-package) ENABLE_PACKAGE=true ;;
         --enable-docs) ENABLE_DOCS=true ;;
-        --enable-doctests) ENABLE_DOC_TESTS=true ;;
+        --enable-doctests) ENABLE_DOC_TESTS=false ;;
         --enable-dev-docs) ENABLE_DEV_DOCS=true ;;
         --enable-coverity)
 	    ENABLE_COVERITY=true

--- a/buildconfig/Jenkins/Conda/cppcheck.sh
+++ b/buildconfig/Jenkins/Conda/cppcheck.sh
@@ -14,6 +14,9 @@
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source $SCRIPT_DIR/mamba-utils
 
+# temp skip cppcheck
+exit 0
+
 # Check 1 argument is passed, and is not optional.
 if [[ $# < 1 || $1 == "--"* ]]; then
     echo "Pass 1 argument: conda-cppcheck <path-to-workspace>"

--- a/buildconfig/Jenkins/Conda/doxygen.sh
+++ b/buildconfig/Jenkins/Conda/doxygen.sh
@@ -9,6 +9,10 @@
 # Expected args:
 #   1. WORKSPACE: path to the root of the source code. On Windows, only use / for
 #                 this argument do not use \\ or \ in the path.
+
+# temp skip doxygen
+exit 0
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source $SCRIPT_DIR/mamba-utils
 

--- a/buildconfig/Jenkins/Conda/run-tests
+++ b/buildconfig/Jenkins/Conda/run-tests
@@ -104,7 +104,8 @@ cd $WORKSPACE/build
 # mkdir for ctest log
 mkdir -p ctest_log
 if [[ $ENABLE_UNIT_TESTS == true ]]; then
-    run_with_xvfb ctest -j$BUILD_THREADS --no-compress-output -T Test -O ctest_log/$OSTYPE.log --schedule-random --output-on-failure --repeat until-pass:3 $WINDOWS_TEST_OPTIONS $WINDOWS_UNITTEST_TIMEOUT_OPTIONS
+    run_with_xvfb ctest -j$BUILD_THREADS --no-compress-output -R TimeSplitterTest -O ctest_log/$OSTYPE.log --repeat-until-fail 50 --output-on-failure $WINDOWS_TEST_OPTIONS $WINDOWS_UNITTEST_TIMEOUT_OPTIONS
+    #run_with_xvfb ctest -j$BUILD_THREADS --no-compress-output -T Test -O ctest_log/$OSTYPE.log --schedule-random --output-on-failure --repeat until-pass:3 $WINDOWS_TEST_OPTIONS $WINDOWS_UNITTEST_TIMEOUT_OPTIONS
     terminate_xvfb_sessions
 fi
 

--- a/buildconfig/Jenkins/Conda/run-tests
+++ b/buildconfig/Jenkins/Conda/run-tests
@@ -104,7 +104,7 @@ cd $WORKSPACE/build
 # mkdir for ctest log
 mkdir -p ctest_log
 if [[ $ENABLE_UNIT_TESTS == true ]]; then
-    run_with_xvfb ctest -j$BUILD_THREADS --no-compress-output -R TimeSplitterTest -O ctest_log/$OSTYPE.log --repeat-until-fail 50 --output-on-failure $WINDOWS_TEST_OPTIONS $WINDOWS_UNITTEST_TIMEOUT_OPTIONS
+    run_with_xvfb ctest -j$BUILD_THREADS --no-compress-output -R TimeSplitterTest -O ctest_log/$OSTYPE.log --repeat-until-fail 50 --output-on-failure -v $WINDOWS_TEST_OPTIONS $WINDOWS_UNITTEST_TIMEOUT_OPTIONS
     #run_with_xvfb ctest -j$BUILD_THREADS --no-compress-output -T Test -O ctest_log/$OSTYPE.log --schedule-random --output-on-failure --repeat until-pass:3 $WINDOWS_TEST_OPTIONS $WINDOWS_UNITTEST_TIMEOUT_OPTIONS
     terminate_xvfb_sessions
 fi


### PR DESCRIPTION
bugfix in https://github.com/mantidproject/mantid/pull/35793

**Description of work**
The error is the following:

```
10:12:28     Start 1069: DataObjectsTest_TimeSplitterTest
10:12:28     Test #1069: DataObjectsTest_TimeSplitterTest ...***Failed    0.32 sec
10:12:28 FrameworkManager-[Notice] Welcome to Mantid 6.7.20230703.1019.dev59
10:12:28 FrameworkManager-[Notice] Please cite: http://dx.doi.org/10.1016/j.nima.2014.07.029 and this release: http://dx.doi.org/10.5286/Software/Mantid
10:12:28 Running 16 tests.....
10:12:28 In TimeSplitterTest::test_toSplitters:
10:12:28 C:/jenkins_workdir/workspace/pull_requests-conda-windows/Framework/DataObjects/test/TimeSplitterTest.h:356: Error: Expected (splitVec.size() == 4), found (3 != 4)
10:12:28 C:/jenkins_workdir/workspace/pull_requests-conda-windows/Framework/DataObjects/test/TimeSplitterTest.h:357: Error: Assertion failed: splitVec[0] == SplittingInterval(ONE, TWO, 1)
10:12:28 C:/jenkins_workdir/workspace/pull_requests-conda-windows/Framework/DataObjects/test/TimeSplitterTest.h:358: Error: Assertion failed: splitVec[1] == SplittingInterval(TWO, THREE, 2)
10:12:28 C:/jenkins_workdir/workspace/pull_requests-conda-windows/Framework/DataObjects/test/TimeSplitterTest.h:359: Error: Assertion failed: splitVec[2] == SplittingInterval(THREE, FOUR, TimeSplitter::NO_TARGET)
10:12:28 C:/jenkins_workdir/workspace/pull_requests-conda-windows/Framework/DataObjects/test/TimeSplitterTest.h:360: Error: Assertion failed: splitVec[3] == SplittingInterval(FOUR, FIVE, 3)
10:12:28 C:/jenkins_workdir/workspace/pull_requests-conda-windows/Framework/DataObjects/test/TimeSplitterTest.h:362: Error: Expected (splitVecNoTarget.size() == 3), found (2 != 3)
10:12:28 C:/jenkins_workdir/workspace/pull_requests-conda-windows/Framework/DataObjects/test/TimeSplitterTest.h:363: Error: Assertion failed: splitVecNoTarget[0] == SplittingInterval(ONE, TWO, 1)
10:12:28 C:/jenkins_workdir/workspace/pull_requests-conda-windows/Framework/DataObjects/test/TimeSplitterTest.h:364: Error: Assertion failed: splitVecNoTarget[1] == SplittingInterval(TWO, THREE, 2)
10:12:28 C:/jenkins_workdir/workspace/pull_requests-conda-windows/Framework/DataObjects/test/TimeSplitterTest.h:365: Error: Assertion failed: splitVecNoTarget[2] == SplittingInterval(FOUR, FIVE, 3)
10:12:28 ..........
10:12:28 Failed 1 of 16 tests
```
However, I have also seen it fail with a different error:

```
     Start 1069: DataObjectsTest_TimeSplitterTest
09:41:05     Test #1069: DataObjectsTest_TimeSplitterTest ...   Passed    2.99 sec
09:41:05     Start 1069: DataObjectsTest_TimeSplitterTest
09:41:05     Test #1069: DataObjectsTest_TimeSplitterTest ...   Passed    0.33 sec
09:41:05     Start 1069: DataObjectsTest_TimeSplitterTest
09:41:05     Test #1069: DataObjectsTest_TimeSplitterTest ...   Passed    0.34 sec
09:41:05     Start 1069: DataObjectsTest_TimeSplitterTest
09:41:06     Test #1069: DataObjectsTest_TimeSplitterTest ...   Passed    0.33 sec
09:41:06     Start 1069: DataObjectsTest_TimeSplitterTest
09:41:06     Test #1069: DataObjectsTest_TimeSplitterTest ...***Failed    0.63 sec
09:41:06 FrameworkManager-[Notice] Welcome to Mantid 6.7.20230703.1019.dev58
09:41:06 FrameworkManager-[Notice] Please cite: http://dx.doi.org/10.1016/j.nima.2014.07.029 and this release: http://dx.doi.org/10.5286/Software/Mantid
09:41:06 Running 16 tests.....Exit code 0xc0000409
```

**Purpose of work**
<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
-->

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**Summary of work**
<!-- Please provide a short, high level description of the work that was done.
-->

**Further detail of work**
<!-- Please provide a more detailed description of the work that has been undertaken.
-->


**To test:**

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

Fixes #xxxx. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.