### PR TITLE
Refactor singleton python cleanup functions to remove error messages

### DIFF
--- a/Framework/PythonInterface/mantid/api/src/Exports/AlgorithmManager.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/AlgorithmManager.cpp
@@ -34,8 +34,10 @@ AlgorithmManagerImpl &instance() {
   auto &mgr = AlgorithmManager::Instance();
   std::call_once(INIT_FLAG, []() {
     PyRun_SimpleString("import atexit\n"
-                       "from mantid.api import AlgorithmManager\n"
-                       "atexit.register(lambda: AlgorithmManager.clear())");
+                       "def cleanupAlgorithmManager():\n"
+                       "    from mantid.api import AlgorithmManager\n"
+                       "    AlgorithmManager.clear()\n"
+                       "atexit.register(cleanupAlgorithmManager)");
   });
   return mgr;
 }

--- a/Framework/PythonInterface/mantid/api/src/Exports/FrameworkManager.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/FrameworkManager.cpp
@@ -71,8 +71,10 @@ FrameworkManagerImpl &instance() {
     // delete any python objects still stored in other singletons like the
     // ADS or AlgorithmManager.
     PyRun_SimpleString("import atexit\n"
-                       "from mantid.api import FrameworkManager\n"
-                       "atexit.register(lambda: FrameworkManager.shutdown())");
+                       "def cleanpFrameworkManager():\n"
+                       "    from mantid.api import FrameworkManager\n"
+                       "    FrameworkManager.shutdown()\n"
+                       "atexit.register(cleanpFrameworkManager)");
   });
   return frameworkMgr;
 }

--- a/Framework/PythonInterface/mantid/api/src/Exports/FrameworkManager.cpp
+++ b/Framework/PythonInterface/mantid/api/src/Exports/FrameworkManager.cpp
@@ -71,10 +71,10 @@ FrameworkManagerImpl &instance() {
     // delete any python objects still stored in other singletons like the
     // ADS or AlgorithmManager.
     PyRun_SimpleString("import atexit\n"
-                       "def cleanpFrameworkManager():\n"
+                       "def cleanupFrameworkManager():\n"
                        "    from mantid.api import FrameworkManager\n"
                        "    FrameworkManager.shutdown()\n"
-                       "atexit.register(cleanpFrameworkManager)");
+                       "atexit.register(cleanupFrameworkManager)");
   });
   return frameworkMgr;
 }

--- a/buildconfig/CMake/CppCheck_Suppressions.txt.in
+++ b/buildconfig/CMake/CppCheck_Suppressions.txt.in
@@ -346,7 +346,7 @@ unknownMacro:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/mantid/geometry/src/E
 unknownMacro:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/mantid/api/src/Exports/Algorithm.cpp:74
 unknownMacro:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/mantid/api/src/Exports/InstrumentFileFinder.cpp:36
 unknownMacro:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/mantid/api/src/Exports/AlgorithmFactory.cpp:148
-unknownMacro:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/mantid/api/src/Exports/AlgorithmManager.cpp:108
+unknownMacro:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/mantid/api/src/Exports/AlgorithmManager.cpp:110
 constParameterCallback:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/core/inc/MantidPythonInterface/core/DataServiceExporter.h:153
 unknownMacro:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/mantid/api/src/Exports/ITableWorkspace.cpp:251
 unknownMacro:${CMAKE_SOURCE_DIR}/Framework/PythonInterface/mantid/api/src/Exports/MatrixWorkspace.cpp:65


### PR DESCRIPTION
To reproduce the issue
```sh
$ ipython
In [1]: from mantid.simpleapi import mtd
FrameworkManager-[Notice] Welcome to Mantid 6.7.20230703.1019
FrameworkManager-[Notice] Please cite: http://dx.doi.org/10.1016/j.nima.2014.07.029 and this release: http://dx.doi.org/10.5286/Software/Mantid
DownloadInstrument-[Notice] All instrument definitions up to date

In [2]: quit
Error in atexit._run_exitfuncs:
Traceback (most recent call last):
  File "<string>", line 3, in <lambda>
NameError: name 'AlgorithmManager' is not defined
Error in atexit._run_exitfuncs:
Traceback (most recent call last):
  File "<string>", line 3, in <lambda>
NameError: name 'FrameworkManager' is not defined
```

It appears that this way of starting/stopping mantid does not get all of the necessary objects into place for the cleanup functions to work. The minor refactor of the cleanup code gets rid of this issue. The error is not normally seen by users, but is often seen in CI for software that uses mantid.

*There is no associated issue.*


*This does not require release notes* because it is a minor issue on exit.

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.