### PR TITLE
Pin importlib_resources to fix failing euphonic test

### DIFF
--- a/conda/recipes/conda_build_config.yaml
+++ b/conda/recipes/conda_build_config.yaml
@@ -82,6 +82,9 @@ readline:
 euphonic:
   - 0.6.*
 
+importlib_resources:
+  - 5.12.0
+
 pin_run_as_build:
     boost:
       max_pin: x.x

--- a/conda/recipes/mantidworkbench/meta.yaml
+++ b/conda/recipes/mantidworkbench/meta.yaml
@@ -31,6 +31,7 @@ requirements:
     - mantidqt {{ version }}
     - python {{ python }}
     - versioningit
+    - importlib_resources {{ importlib_resources }}
   run:
     - ipykernel
     - psutil

--- a/mantid-developer-linux.yml
+++ b/mantid-developer-linux.yml
@@ -46,6 +46,7 @@ dependencies:
   - texlive-core>=20180414
   - toml>=0.10.2
   - versioningit>=2.1
+  - importlib_resources==5.12.0
 
   # Not Windows, OpenGL implementation:
   - mesalib>=18.0.0

--- a/mantid-developer-osx.yml
+++ b/mantid-developer-osx.yml
@@ -52,6 +52,7 @@ dependencies:
   - pygments==2.11.2 # Had to pin back to 2.11 due to cppcheck error which is only fixed in cppcheck>=2.8
   - pre-commit>=2.12.0
   - libcxx<16 # Had to pin back below 16 to prevent an issue with boost (https://github.com/boostorg/container_hash/issues/22).
+  - importlib_resources==5.12.0
 
   # Use conda version of clang to get matching CXXFLAGS.
   # Pinned to same version as conda forge: https://github.com/conda-forge/conda-forge-pinning-feedstock/blob/main/recipe/conda_build_config.yaml

--- a/mantid-developer-win.yml
+++ b/mantid-developer-win.yml
@@ -50,3 +50,4 @@ dependencies:
   - cppcheck==2.5
   - pygments==2.11.2 # Had to pin back to 2.11 due to cppcheck error which is only fixed in cppcheck>=2.8
   - pre-commit==2.15 # Had to pin back to 2.15 as we can't handle changes made here (https://github.com/pre-commit/pre-commit/pull/2065 added in 2.16) on windows yet.
+  - importlib_resources==5.12.0


### PR DESCRIPTION
**Description of work**

This PR pins `importlib_resources` as a temporary fix to a failing euphonic system test.

It is thought that the system test now be unneeded as `euphonic` is on `conda-forge`. Hopefully this will enable us to remove the test and then the pin shortly.

Issue to remove this pin: https://github.com/mantidproject/mantid/issues/35798

**To test:**

- PR tests show developer builds work
- package builds work: https://builds.mantidproject.org/job/build_packages_from_branch/421/

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.