### PR TITLE
CombineDiffCal with partial GroupedCalibration workspace

### DIFF
--- a/Framework/API/src/SpectrumInfo.cpp
+++ b/Framework/API/src/SpectrumInfo.cpp
@@ -157,15 +157,15 @@ UnitParametersMap SpectrumInfo::diffractometerConstants(const size_t index, std:
     throw std::runtime_error("Retrieval of diffractometer constants not "
                              "implemented for scanning instrument");
   }
-  auto spectrumDef = checkAndGetSpectrumDefinition(index);
+  const auto &spectrumDef = checkAndGetSpectrumDefinition(index);
   std::vector<size_t> detectorIndicesOnly;
   std::vector<detid_t> calibratedDets;
   std::vector<detid_t> uncalibratedDets;
-  std::transform(spectrumDef.begin(), spectrumDef.end(), std::back_inserter(detectorIndicesOnly),
+  std::transform(spectrumDef.cbegin(), spectrumDef.cend(), std::back_inserter(detectorIndicesOnly),
                  [](auto const &pair) { return pair.first; });
   double difa{0.}, difc{0.}, tzero{0.};
   for (const auto &detIndex : detectorIndicesOnly) {
-    auto newDiffConstants = m_detectorInfo.diffractometerConstants(detIndex, calibratedDets, uncalibratedDets);
+    const auto newDiffConstants = m_detectorInfo.diffractometerConstants(detIndex, calibratedDets, uncalibratedDets);
     difa += std::get<0>(newDiffConstants);
     difc += std::get<1>(newDiffConstants);
     tzero += std::get<2>(newDiffConstants);
@@ -179,9 +179,10 @@ UnitParametersMap SpectrumInfo::diffractometerConstants(const size_t index, std:
   if (calibratedDets.size() == 0) {
     return {{UnitParams::difc, difcUncalibrated(index)}};
   }
-  return {{UnitParams::difa, difa / static_cast<double>(spectrumDefinition(index).size())},
-          {UnitParams::difc, difc / static_cast<double>(spectrumDefinition(index).size())},
-          {UnitParams::tzero, tzero / static_cast<double>(spectrumDefinition(index).size())}};
+  const auto specDefSize = static_cast<double>(spectrumDefinition(index).size());
+  return {{UnitParams::difa, difa / specDefSize},
+          {UnitParams::difc, difc / specDefSize},
+          {UnitParams::tzero, tzero / specDefSize}};
 }
 
 /** Calculate average diffractometer constants (DIFA, DIFC, TZERO) of

--- a/Framework/Algorithms/src/CombineDiffCal.cpp
+++ b/Framework/Algorithms/src/CombineDiffCal.cpp
@@ -259,7 +259,7 @@ void CombineDiffCal::exec() {
           difcArb = difcArbMap.find(wkspIndex)->second;
         } else {
           difcArb = calibrationWS->spectrumInfo().diffractometerConstants(wkspIndex)[Kernel::UnitParams::difc];
-          difcArbMap.emplace(wkspIndex, difcArb);
+          difcArbMap[wkspIndex] = difcArb;
         }
 
         // difc and difa values from pixelCalibrationWS

--- a/Framework/Algorithms/src/CombineDiffCal.cpp
+++ b/Framework/Algorithms/src/CombineDiffCal.cpp
@@ -255,11 +255,12 @@ void CombineDiffCal::exec() {
         // get value from groupedCalibrationWS
         const auto wkspIndex = calibrationWS->getIndicesFromDetectorIDs({detid}).front();
         double difcArb;
-        if (difcArbMap.count(wkspIndex) > 0) {
-          difcArb = difcArbMap.find(wkspIndex)->second;
-        } else {
+        const auto difcArbIter = difcArbMap.find(wkspIndex);
+        if (difcArbIter == difcArbMap.end()) {
           difcArb = calibrationWS->spectrumInfo().diffractometerConstants(wkspIndex)[Kernel::UnitParams::difc];
           difcArbMap[wkspIndex] = difcArb;
+        } else {
+          difcArb = difcArbIter->second;
         }
 
         // difc and difa values from pixelCalibrationWS

--- a/Framework/Algorithms/src/CombineDiffCal.cpp
+++ b/Framework/Algorithms/src/CombineDiffCal.cpp
@@ -166,16 +166,16 @@ void CombineDiffCal::exec() {
     if (!(maskWorkspace && maskWorkspace->isMasked(detid))) {
       std::shared_ptr<Mantid::API::TableRow> pixelCalibrationRow = binarySearchForRow(pixelCalibrationWS, detid);
       if (pixelCalibrationRow) {
-        double difcPD = groupedCalibrationRow.Double(1);
-        double difcArb = calibrationWS->spectrumInfo().diffractometerConstants(
+        const double difcPD = groupedCalibrationRow.Double(1);
+        const double difcArb = calibrationWS->spectrumInfo().diffractometerConstants(
             calibrationWS->getIndicesFromDetectorIDs({detid})[0])[Kernel::UnitParams::difc];
-        double difcPrev = pixelCalibrationRow->Double(1);
-        double difaPrev = pixelCalibrationRow->Double(2);
+        const double difcPrev = pixelCalibrationRow->Double(1);
+        const double difaPrev = pixelCalibrationRow->Double(2);
 
-        double difcNew = (difcPD / difcArb) * difcPrev;
-        double difaNew = ((difcPD / difcArb) * (difcPD / difcArb)) * difaPrev;
+        const double difcNew = (difcPD / difcArb) * difcPrev;
+        const double difaNew = ((difcPD / difcArb) * (difcPD / difcArb)) * difaPrev;
 
-        double tzeroNew = pixelCalibrationRow->Double(3);
+        const double tzeroNew = pixelCalibrationRow->Double(3);
 
         Mantid::API::TableRow newRow = outputWorkspace->appendRow();
         newRow << detid << difcNew << difaNew << tzeroNew;

--- a/Framework/Algorithms/src/CombineDiffCal.cpp
+++ b/Framework/Algorithms/src/CombineDiffCal.cpp
@@ -21,6 +21,17 @@ DECLARE_ALGORITHM(CombineDiffCal)
 
 //----------------------------------------------------------------------------------------------
 
+namespace { // anonymous namespace
+namespace ColNames {
+const std::string DETID("detid");
+const std::string DIFC("difc");
+const std::string DIFA("difa");
+const std::string TZERO("tzero");
+} // namespace ColNames
+} // anonymous namespace
+
+//----------------------------------------------------------------------------------------------
+
 /// Algorithms name for identification. @see Algorithm::name
 const std::string CombineDiffCal::name() const { return "CombineDiffCal"; }
 
@@ -63,7 +74,7 @@ API::ITableWorkspace_sptr CombineDiffCal::sortTableWorkspace(DataObjects::TableW
   alg->setLoggingOffset(1);
   alg->setProperty("InputWorkspace", table);
   alg->setProperty("OutputWorkspace", table);
-  alg->setProperty("Columns", "detid");
+  alg->setProperty("Columns", ColNames::DETID);
   alg->executeAsChildAlg();
 
   return alg->getProperty("OutputWorkspace");
@@ -77,14 +88,14 @@ std::string generateErrorString(const DataObjects::TableWorkspace_sptr &ws) {
   const std::vector<std::string> columnNames = ws->getColumnNames();
 
   std::stringstream error;
-  if (!findColumn(columnNames, "detid"))
-    error << "detid ";
-  if (!findColumn(columnNames, "difc"))
-    error << "difc ";
-  if (!findColumn(columnNames, "difa"))
-    error << "difa ";
-  if (!findColumn(columnNames, "tzero"))
-    error << "tzero ";
+  if (!findColumn(columnNames, ColNames::DETID))
+    error << ColNames::DETID << " ";
+  if (!findColumn(columnNames, ColNames::DIFC))
+    error << ColNames::DIFC << " ";
+  if (!findColumn(columnNames, ColNames::DIFA))
+    error << ColNames::DIFA << " ";
+  if (!findColumn(columnNames, ColNames::TZERO))
+    error << ColNames::TZERO << " ";
 
   return error.str();
 }
@@ -153,10 +164,10 @@ void CombineDiffCal::exec() {
   const DataObjects::MaskWorkspace_sptr maskWorkspace = getProperty("MaskWorkspace");
 
   DataObjects::TableWorkspace_sptr outputWorkspace = std::make_shared<DataObjects::TableWorkspace>();
-  outputWorkspace->addColumn("int", "detid");
-  outputWorkspace->addColumn("double", "difc");
-  outputWorkspace->addColumn("double", "difa");
-  outputWorkspace->addColumn("double", "tzero");
+  outputWorkspace->addColumn("int", ColNames::DETID);
+  outputWorkspace->addColumn("double", ColNames::DIFC);
+  outputWorkspace->addColumn("double", ColNames::DIFA);
+  outputWorkspace->addColumn("double", ColNames::TZERO);
 
   Mantid::API::TableRow groupedCalibrationRow = groupedCalibrationWS->getFirstRow();
   do {

--- a/Framework/Algorithms/src/CombineDiffCal.cpp
+++ b/Framework/Algorithms/src/CombineDiffCal.cpp
@@ -64,14 +64,16 @@ const std::string CombineDiffCal::summary() const {
 void CombineDiffCal::init() {
   declareProperty(std::make_unique<WorkspaceProperty<DataObjects::TableWorkspace>>(PropertyNames::PIXEL_CALIB, "",
                                                                                    Direction::Input),
-                  "OffsetsWorkspace generated from cross-correlation. This is the source of DIFCpixel.");
-  declareProperty(std::make_unique<WorkspaceProperty<DataObjects::TableWorkspace>>(PropertyNames::GROUP_CALIB, "",
-                                                                                   Direction::Input),
-                  "DiffCal table generated from calibrating grouped spectra. This is the source of DIFCgroup.");
+                  "DiffCal TableWorkspace that will be updated. This is often generated from cross-correlation. "
+                  "These are the \"prev\" values in the documentation.");
+  declareProperty(
+      std::make_unique<WorkspaceProperty<DataObjects::TableWorkspace>>(PropertyNames::GROUP_CALIB, "",
+                                                                       Direction::Input),
+      "DiffCal table generated from calibrating grouped spectra. This is the \"DIFCpd\" value in the documentation.");
   declareProperty(
       std::make_unique<WorkspaceProperty<API::MatrixWorkspace>>(PropertyNames::ARB_CALIB, "", Direction::Input),
-      "Workspace where conversion from d-spacing to time-of-flight for each spectrum is determined from. This is the "
-      "source of DIFCarb.");
+      "Workspace where conversion from d-spacing to time-of-flight for each spectrum is determined from. "
+      "This is the \"DIFCarb\" value in the documentation.");
   declareProperty(std::make_unique<WorkspaceProperty<DataObjects::TableWorkspace>>(PropertyNames::OUTPUT_WKSP, "",
                                                                                    Direction::Output),
                   "DiffCal table generated from calibrating grouped spectra");

--- a/docs/source/algorithms/CombineDiffCal-v1.rst
+++ b/docs/source/algorithms/CombineDiffCal-v1.rst
@@ -11,11 +11,34 @@ Description
 
 This algorithm combines pixel calibration results (:math:`prev` subscript below) from the ``PixelCalibration`` workspace with the calibration of focussed data from :ref:`PDCalibration <algm-PDCalibration-v1>` (:math:`pd` subscript below).
 The :math:`arb` subscript below denotes values found in the ``CalibrationWorkspace``.
+This is part of the larger workflow for :ref:`powder diffraction calibration <Powder Diffraction Calibration>`.
 
-.. note::
+.. warning::
 
    The ``GroupedCalibration`` table is assumed to not have :math:`DIFA` or :math:`TZERO` set.
-   It is also assumed to have calibration values for **all** detector pixels.
+
+Input arguments
+---------------
+
+* ``PixelCalibration`` is the previous calibration result
+
+  * Has values for each detector pixel
+  * Provides :math:`DIFC_{prev}`, :math:`DIFA_{prev}`, and :math:`TZERO_{prev}`
+
+* ``GroupedCalibration``
+
+  * Has values for each detector pixel, but the values are generally the same within a focused group
+  * Provides :math:`DIFC_{pd}`
+  * Is the ``OutputCalibrationTable`` from previous :ref:`PDCalibration <algm-PDCalibration>` execution
+
+* ``CalibrationWorkspace``
+
+  * Has values for each spectrum which are grouped pixels
+  * Provides :math:`DIFC_{arb}`
+  * Is the ``InputWorkspace`` from previous :ref:`PDCalibration <algm-PDCalibration>` execution
+
+How values are combined
+-----------------------
 
 The effective calibration values are calculated using the following equations
 

--- a/docs/source/release/v6.8.0/Diffraction/Powder/New_features/35800.rst
+++ b/docs/source/release/v6.8.0/Diffraction/Powder/New_features/35800.rst
@@ -1,0 +1,2 @@
+* Add the ability for :ref:`CombineDiffCal <algm-CombineDiffCal>` to have a partial ``GroupedCalibration`` workspace.
+  Detectors that do not appear in the ``GroupedCalibration`` have calibration constants copied directly from the ``PixelCalibration`` workspace without change.


### PR DESCRIPTION
The way this algorithm is being used at SNAP they need to supply partial workspaces from PDCalibration. This change allows for that and greatly improves the speed (the script below went from 2 minutes to 2 seconds).

Extra changes:
* `API::MatrixWorkspaces.getIndicesFromDetectorIDs()` there is a temporary `std::map` to help calculate information. It is now modified to only hold information that will be needed later in the calculation rather than for the whole workspace.
* `API::SpectrumInfo::diffractometerConstants()` caches a value (rather than calling a method 3 times), adds `const` to a bunch of places, and gets a reference to `spectrumDef` to avoid making a copy of the object.

**To test:**

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

```python
from mantid.simpleapi import *

# prepare the cross-correlation result
LoadDiffCal(Filename="snapcalib/pixel_calibration_58882.h5", MakeGroupingWorkspace=False, MakeMaskWorkspace=False, Workspacename="difc_cc")
RenameWorkspace("difc_cc_cal", "difc_cc")

# make the data look like the input for PDCalibration
LoadEventNexus(Filename="snapcalib/SNAP_58882.lite.nxs.h5", OutputWorkspace="pd_input", MetaDataOnly=True)
Rebin(InputWorkspace="pd_input", OutputWorkspace="pd_input", Params=(0,16667,16667))
CreateGroupingWorkspace(InputWorkspace="pd_input", GroupDetectorsBy="Column", OutputWorkspace="grouping")
ApplyDiffCal(InstrumentWorkspace="pd_input", CalibrationWorkspace="difc_cc")
ConvertUnits(InputWorkspace="pd_input", OutputWorkspace="pd_input", Target="dSpacing")
DiffractionFocussing(InputWorkspace="pd_input", OutputWorkspace="pd_input", GroupingWorkspace="grouping")

# make this look like it is only one group
Load(Filename="snapcalib/grouped_calibration_58882_1.nxs", OutputWorkspace="difc_pd")
DeleteTableRows(TableWorkspace="difc_pd", Rows="1152-18432")

CombineDiffCal(PixelCalibration="difc_cc", GroupedCalibration="difc_pd", CalibrationWorkspace="pd_input", OutputWorkspace="difc_eff")
# special detid is 1535
```

*There is no associated issue,* but it is associated with [EWM1126](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=1126)

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.