### PR TITLE
Allow the Archive To Be Accessed From macOS

### DIFF
--- a/Framework/DataHandling/src/ISISDataArchive.cpp
+++ b/Framework/DataHandling/src/ISISDataArchive.cpp
@@ -27,9 +27,9 @@ DECLARE_ARCHIVESEARCH(ISISDataArchive, ISISDataSearch)
 
 namespace {
 #ifdef _WIN32
-const char *URL_PREFIX = "http://data.isis.rl.ac.uk/where.py/windir?name=";
+constexpr std::string_view URL_PREFIX = "http://data.isis.rl.ac.uk/where.py/windir?name=";
 #else
-const char *URL_PREFIX = "http://data.isis.rl.ac.uk/where.py/unixdir?name=";
+constexpr std::string_view URL_PREFIX = "http://data.isis.rl.ac.uk/where.py/unixdir?name=";
 #endif
 } // namespace
 
@@ -57,9 +57,9 @@ std::string ISISDataArchive::getArchivePath(const std::set<std::string> &filenam
     if (!path_without_extension.empty()) {
 #ifdef __APPLE__
       // Replace Linux path with macOS path if we're on a Mac.
-      constexpr char *unixString = "/archive/";
-      constexpr char *macOSString = "/Volumes/inst$/";
-      path_without_extension.replace(0, strlen(unixString), macOSString);
+      constexpr std::string_view unixString = "/archive/";
+      constexpr std::string_view macOSString = "/Volumes/inst$/";
+      path_without_extension.replace(0, unixString.length(), macOSString);
 #endif
       std::string fullPath = getCorrectExtension(path_without_extension, exts);
       if (!fullPath.empty())
@@ -97,7 +97,7 @@ std::ostringstream ISISDataArchive::sendRequest(const std::string &fName) const 
   Kernel::InternetHelper inetHelper;
   std::ostringstream os;
   try {
-    inetHelper.sendRequest(URL_PREFIX + fName, os);
+    inetHelper.sendRequest(std::string(URL_PREFIX) + fName, os);
   } catch (Kernel::Exception::InternetError &ie) {
     g_log.warning() << "Could not access archive index." << ie.what();
   }

--- a/Framework/DataHandling/src/ISISDataArchive.cpp
+++ b/Framework/DataHandling/src/ISISDataArchive.cpp
@@ -97,7 +97,7 @@ std::ostringstream ISISDataArchive::sendRequest(const std::string &fName) const 
   Kernel::InternetHelper inetHelper;
   std::ostringstream os;
   try {
-    inetHelper.sendRequest(std::string(URL_PREFIX) + fName, os);
+    inetHelper.sendRequest(URL_PREFIX.data() + fName, os);
   } catch (Kernel::Exception::InternetError &ie) {
     g_log.warning() << "Could not access archive index." << ie.what();
   }

--- a/Framework/DataHandling/src/ISISDataArchive.cpp
+++ b/Framework/DataHandling/src/ISISDataArchive.cpp
@@ -53,8 +53,14 @@ std::string ISISDataArchive::getArchivePath(const std::set<std::string> &filenam
   }
 
   for (const auto &filename : filenames) {
-    const std::string path_without_extension = getPath(filename);
+    std::string path_without_extension = getPath(filename);
     if (!path_without_extension.empty()) {
+#ifdef __APPLE__
+      // Replace Linux path with macOS path if we're on a Mac.
+      constexpr char *unixString = "/archive/";
+      constexpr char *macOSString = "/Volumes/inst$/";
+      path_without_extension.replace(0, strlen(unixString), macOSString);
+#endif
       std::string fullPath = getCorrectExtension(path_without_extension, exts);
       if (!fullPath.empty())
         return fullPath;
@@ -75,7 +81,7 @@ std::string ISISDataArchive::getPath(const std::string &fName) const {
 
   std::ostringstream os = sendRequest(fName);
   os << Poco::Path::separator() << fName;
-  const std::string expectedPath = os.str();
+  std::string expectedPath = os.str();
   return expectedPath;
 }
 

--- a/Framework/DataHandling/test/ISISDataArchiveTest.h
+++ b/Framework/DataHandling/test/ISISDataArchiveTest.h
@@ -106,8 +106,11 @@ public:
 
     MockOutRequests arch;
     const std::string actualPath = arch.getArchivePath(filenames, exts);
-
+#ifdef __APPLE__
+    std::string expectedPath = "/Volumes/inst$/default/path";
+#else
     std::string expectedPath = "/archive/default/path";
+#endif
 #ifdef _WIN32
     expectedPath += "\\";
 #else

--- a/docs/source/release/v6.8.0/Framework/Data_Objects/Bugfixes/35802.rst
+++ b/docs/source/release/v6.8.0/Framework/Data_Objects/Bugfixes/35802.rst
@@ -1,0 +1,1 @@
+- It is now possible to use the archive on macOS once it has been mounted. Follow the archive mounting instructions here: https://developer.mantidproject.org/GettingStarted/GettingStarted.html#osx


### PR DESCRIPTION
**Description of work**
When loading from the archive, replaces the linux path prefix with the appropriate one for macOS. 

**Purpose of work**
Requested by a user with a new mac. They'd like to make use of workbench with its normal archive filefinding. 

**Report to:** Ian Silverwood

**Summary of work**
Add in a simple find and replace for the beginning of the strings obtained from http://data.isis.rl.ac.uk/where.py/unixdir

**Further detail of work**
The `ISISDataArchive` class works by sending a HTTP request to
http://data.isis.rl.ac.uk/where.py/windir?name=INTER45454 on Windows and
http://data.isis.rl.ac.uk/where.py/unixdir?name=INTER45454 on everything else.

This is fine for linux, where the archive is stored at `/archive/ndx...etc` (which is what the request returns). 
But on macOS the archive is mounted as `/Volumes/inst$/ndx...`. 

Other than this start section, the rest of the path is in the same format, so the replacement allows the files to be found and the correct extensions tried and applied before being given to the FileFinder for loading. 

_Ideally_, there would be a third option for the HTTP request like `osxdir?` or `macosdir?` but I'm not sure how well this service is maintained so this will do for now. 


**To test:**
1. Mount the archive, if you haven't already: https://developer.mantidproject.org/GettingStarted/GettingStarted.html#osx
2. Launch workbench and enable the archive in Manage User Directories
3. Try to load some data that isn't already on your system (this is easiest to see using the load widget, but works in scripts too (I'd also recommend putting your logs on debug). 
4. It should be found and be able to be loaded. 

Fixes #35802 

---

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.