### PR TITLE
Fail the pipeline if a system test fails on Windows

### DIFF
--- a/buildconfig/Jenkins/Conda/nightly_build_and_deploy.jenkinsfile
+++ b/buildconfig/Jenkins/Conda/nightly_build_and_deploy.jenkinsfile
@@ -135,6 +135,8 @@ pipeline {
             always {
               archive_ctest_log()
               publish_test_reports()
+              // Workaround for Windows so that failing system tests will fail the build
+              bat "\"${WIN_BASH}\" -ex -c \"test ${currentBuild.currentResult} != UNSTABLE\""
             }
           }
         }
@@ -426,8 +428,6 @@ def publish_test_reports() {
   xunit thresholds: [failed(failureThreshold: '0')],
     tools: [CTest(excludesPattern: '', pattern: "${CHECKOUT_DIR}/build/Testing/**/*.xml", stopProcessingIfError: true)]
   junit "${CHECKOUT_DIR}/build/Testing/SystemTests/scripts/TEST-*.xml"
-  // Workaround so that a failing system test will actually fail the build
-  sh "test ${currentBuild.currentResult} != UNSTABLE"
 }
 
 def package_conda(platform, base_or_workbench) {


### PR DESCRIPTION
**Description of work**
The changes in this PR (#35774) did not work as intended. It was supposed to fail the pipeline if a system test failed, but instead it will just fail the pipeline every time. This is because you cannot run shell commands directly in Windows, they have to be run through git bash. This is addressed here, and tested more thoroughly.

**To test:**
We have created two spin-off branches that run only a single system test. In one branch the system test is forced to fail. The pipeline is set to run tests but not build packages.
This build should succeed:
https://builds.mantidproject.org/job/build_packages_from_branch/427/
This build should fail:
https://builds.mantidproject.org/job/build_packages_from_branch/428/

*There is no associated issue.*

*This does not require release notes* because **it is a pipeline fix.**

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.