### PR TITLE
Create a separate target for generating CxxTest sources

### DIFF
--- a/buildconfig/CMake/FindCxxTest.cmake
+++ b/buildconfig/CMake/FindCxxTest.cmake
@@ -122,6 +122,11 @@ macro(CXXTEST_ADD_TEST _cxxtest_testname)
     set(_cxxtest_h_files ${part} ${_cxxtest_h_files})
   endforeach(part ${ARGN})
 
+  if(TARGET cppcheck)
+    add_custom_target(${_cxxtest_testname}Sources SOURCES ${_cxxtest_cpp_files})
+    add_dependencies(cppcheck ${_cxxtest_testname}Sources)
+  endif()
+
   if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/PrecompiledHeader.h)
     enable_precompiled_headers(PrecompiledHeader.h _cxxtest_cpp_files)
   endif()


### PR DESCRIPTION
**Description of work**

The latest cppcheck requires all source files in the input `cmake_compile_commands.json` map to exist rather than simply issuing a warning. Here we create a separate target to run just the source cxxtest generation and and attach this as dependencies to the cppcheck target.

**Purpose of work**

To allow an upgrade of cppcheck to 2.10.

**To test:**

Try out just generating the test sources for a given library e.g.

```
ninja APITestSources
```

In Visual Studio there will now be an extra `APITestSources` (and all of the other) targets.

Refs #33510 .

*This does not require release notes* because **it is a change purely for internal use.**

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.