### PR TITLE
Add Scaled Background Subtraction to ISIS SANS Interface

### DIFF
--- a/dev-docs/source/Testing/SANSGUI/ISISSANSGUITests.rst
+++ b/dev-docs/source/Testing/SANSGUI/ISISSANSGUITests.rst
@@ -162,6 +162,23 @@ Processing
 #. In the ``Settings`` tab, ``General, Scale, Event Slice, Sample`` sub-tab,
    change the ``Reduction Mode`` back to ``All``.
 
+*Scaled Background Subtracted Reduction*
+
+#. In the ``Settings`` tab, ``General, Scale, Event Slice, Sample`` sub-tab, set ``Reduction Mode`` to ``Merged``.
+#. Return to the ``Runs`` tab.
+#. Set the ``Save Options`` to ``Memory``.
+#. Select one of the rows and click ``Process Selected``
+#. Take note of the name of the reduced workspace with ``merged`` in the title.
+#. Make a copy of the row you just processed using the ``Copy`` and ``Paste`` buttons above the runs table.
+#. Change the ``Output Name`` of the new row to something like ``bgsub_test``.
+#. In the ``Options`` column, enter ``BackgroundWorkspace=<WS_NAME>, ScaleFactor=0.9`` (replacing <WS_NAME> with the
+   name of the merged workspace you took note of before).
+#. Select this new row and click ``Process Selected``.
+#. When it completes, two output files should have been created with ``bgsub_test`` in the name. One, which is the
+   normal output data. Another with the scaled subtraction, which should have ``_bgsub`` appended to the name.
+#. Right click on each of these and select ``Show Data``. The subtracted workspace's values should be 10% of the of the
+   unsubtracted workspace's values.
+
 Beam centre finder
 ##################
 

--- a/docs/source/interfaces/isis_sans/Runs Tab.rst
+++ b/docs/source/interfaces/isis_sans/Runs Tab.rst
@@ -106,8 +106,24 @@ Table Columns
 | **Sample Thickness**     |   Sets the sample thickness to be used in the reduction                                         |
 +--------------------------+-------------------------------------------------------------------------------------------------+
 | **Options**              |   This column allows the user to provide row specific settings. Currently only                  |
-|                          |   **WavelengthMin**, **WavelengthMax** and **EventSlices** can be set (see below for details)   |
+|                          |   **WavelengthMin**, **WavelengthMax**, **EventSlices** (see :ref:`ISIS_SANS_Settings_Tab-ref`  |
+|                          |   for details), **BackgroundWorkspace**, and **ScaleFactor** can be set (see below).            |
 +--------------------------+-------------------------------------------------------------------------------------------------+
+
+.. _ISIS_SANS_scaled_background-ref:
+
+Scaled Background Subtraction
++++++++++++++++++++++++++++++
+
+By setting **both** ``BackgroundWorkspace`` and ``ScaleFactor`` in the options a Scaled Background Subtraction will be
+performed. Giving these values will perform a background subtraction where the ``BackgroundWorkspace`` (representing a
+reduced solution run) will be multiplied by the ``ScaleFactor`` and then subtracted from the reduced HAB, LAB, or Merged
+main output workspace. It is then saved to the ADS or to a file (based on the save options below) in addition to the
+normal reduction output.
+
+The reduction will fail if only one of these values is set. Or, if the reduction mode is set to "All". This is because
+there is no way to determine if the workspace given as the ``BackgroundWorkspace`` is for the HAB or LAB, and so uses
+the value from the User File, therefore assuming that both reductions have used the same one.
 
 Save Options
 ------------

--- a/docs/source/release/v6.8.0/SANS/New_features/35446.rst
+++ b/docs/source/release/v6.8.0/SANS/New_features/35446.rst
@@ -1,0 +1,2 @@
+* ``BackgroundWorkspace`` and ``ScaleFactor`` can now be given in the ``Options`` column of the ISIS SANS Interface.
+  See :ref:`ISIS_SANS_scaled_background-ref` for more details.

--- a/scripts/SANS/sans/algorithm_detail/batch_execution.py
+++ b/scripts/SANS/sans/algorithm_detail/batch_execution.py
@@ -274,21 +274,21 @@ def plot_workspace_mantidqt(reduction_package, output_graph, plotting_module):
     plot_kwargs = {"scalex": True, "scaley": True}
     ax_options = {"xscale": "linear", "yscale": "linear"}
 
-    ws_to_plot = []
+    workspaces_to_plot = []
 
     if reduction_package.reduction_mode == ReductionMode.ALL:
-        ws_to_plot = [reduction_package.reduced_hab, reduction_package.reduced_lab]
+        workspaces_to_plot = [reduction_package.reduced_hab, reduction_package.reduced_lab]
     elif reduction_package.reduction_mode == ReductionMode.HAB:
-        ws_to_plot = [reduction_package.reduced_hab]
+        workspaces_to_plot = [reduction_package.reduced_hab]
     elif reduction_package.reduction_mode == ReductionMode.LAB:
-        ws_to_plot = [reduction_package.reduced_lab]
+        workspaces_to_plot = [reduction_package.reduced_lab]
     elif reduction_package.reduction_mode == ReductionMode.MERGED:
-        ws_to_plot = [reduction_package.reduced_merged, reduction_package.reduced_hab, reduction_package.reduced_lab]
+        workspaces_to_plot = [reduction_package.reduced_merged, reduction_package.reduced_hab, reduction_package.reduced_lab]
     if reduction_package.reduced_bgsub:
-        ws_to_plot.extend(reduction_package.reduced_bgsub)
+        workspaces_to_plot.extend(reduction_package.reduced_bgsub)
 
     plot(
-        ws_to_plot,
+        workspaces_to_plot,
         wksp_indices=[0],
         overplot=True,
         fig=output_graph,

--- a/scripts/SANS/sans/algorithm_detail/batch_execution.py
+++ b/scripts/SANS/sans/algorithm_detail/batch_execution.py
@@ -197,6 +197,9 @@ def single_reduction_for_batch(state, use_optimizations, output_mode, plot_resul
     if not use_optimizations:
         delete_optimization_workspaces(reduction_packages, workspaces, monitors, save_can)
 
+    if scaled_background_ws:
+        delete_workspace_by_name(scaled_background_ws)
+
     out_scale_factors = []
     out_shift_factors = []
     for reduction_package in reduction_packages:
@@ -1386,6 +1389,15 @@ def delete_optimization_workspaces(reduction_packages, workspaces, monitors, sav
         if not save_can:
             optimizations_to_delete.extend([reduction_package.reduced_lab_can, reduction_package.reduced_hab_can])
         _delete_workspaces(delete_alg, optimizations_to_delete)
+
+
+def delete_workspace_by_name(ws_name):
+    delete_name = "DeleteWorkspace"
+    delete_options = {}
+    delete_alg = create_unmanaged_algorithm(delete_name, **delete_options)
+    if ws_name and AnalysisDataService.doesExist(ws_name):
+        delete_alg.setProperty("Workspace", ws_name)
+        delete_alg.execute()
 
 
 def get_transmission_names_to_save(reduction_package, can):

--- a/scripts/SANS/sans/gui_logic/models/RowOptionsModel.py
+++ b/scripts/SANS/sans/gui_logic/models/RowOptionsModel.py
@@ -47,7 +47,7 @@ class RowOptionsModel(object):
             "PhiMin": float,
             "PhiMax": float,
             "UseMirror": bool,
-            "ScaleWorkspace": str,
+            "BackgroundWorkspace": str,
             "ScaleFactor": float,
         }
 

--- a/scripts/SANS/sans/gui_logic/models/RowOptionsModel.py
+++ b/scripts/SANS/sans/gui_logic/models/RowOptionsModel.py
@@ -47,6 +47,8 @@ class RowOptionsModel(object):
             "PhiMin": float,
             "PhiMax": float,
             "UseMirror": bool,
+            "ScaleWorkspace": str,
+            "ScaleFactor": float,
         }
 
         options = {}

--- a/scripts/SANS/sans/gui_logic/models/state_gui_model.py
+++ b/scripts/SANS/sans/gui_logic/models/state_gui_model.py
@@ -102,6 +102,28 @@ class StateGuiModel(ModelCommon):
     def batch_file(self, value):
         self._all_states.save.batch_file = value
 
+    # ------------------------------------------------------------------------------------------------------------------
+    # Background Subtraction Options
+    # ------------------------------------------------------------------------------------------------------------------
+
+    @property
+    def background_workspace(self):
+        val = self._all_states.background_subtraction.workspace
+        return self._get_val_or_default(val)
+
+    @background_workspace.setter
+    def background_workspace(self, value):
+        self._all_states.background_subtraction.workspace = value
+
+    @property
+    def scale_factor(self):
+        val = self._all_states.background_subtraction.scale_factor
+        return self._get_val_or_default(val, 1.0)
+
+    @scale_factor.setter
+    def scale_factor(self, value):
+        self._all_states.background_subtraction.scale_factor = value
+
     # ==================================================================================================================
     # ==================================================================================================================
     # BeamCentre TAB

--- a/scripts/SANS/sans/gui_logic/presenter/gui_state_director.py
+++ b/scripts/SANS/sans/gui_logic/presenter/gui_state_director.py
@@ -153,3 +153,9 @@ class GuiStateDirector(object):
 
         if "UseMirror" in options.keys():
             state_gui_model.phi_limit_use_mirror = options["UseMirror"]
+
+        if "BackgroundWorkspace" in options.keys():
+            state_gui_model.background_workspace = options["BackgroundWorkspace"]
+
+        if "ScaleFactor" in options.keys():
+            state_gui_model.scale_factor = options["ScaleFactor"]

--- a/scripts/SANS/sans/state/AllStates.py
+++ b/scripts/SANS/sans/state/AllStates.py
@@ -25,6 +25,7 @@ from sans.state.StateObjects.StateScale import StateScale
 from sans.state.StateObjects.StateSliceEvent import StateSliceEvent
 from sans.state.StateObjects.StateWavelength import StateWavelength
 from sans.state.StateObjects.state_instrument_info import StateInstrumentInfo
+from sans.state.StateObjects.StateBackgroundSubtraction import StateBackgroundSubtraction
 from sans.state.automatic_setters import automatic_setters
 
 
@@ -35,7 +36,6 @@ from sans.state.automatic_setters import automatic_setters
 
 class AllStates(metaclass=JsonSerializable):
     def __init__(self):
-
         super(AllStates, self).__init__()
         self.data: StateData = StateData()
         self.move: StateMove = StateMove()
@@ -49,6 +49,7 @@ class AllStates(metaclass=JsonSerializable):
         self.adjustment: StateAdjustment = StateAdjustment()
         self.convert_to_q: StateConvertToQ = StateConvertToQ()
         self.compatibility: StateCompatibility = StateCompatibility()
+        self.background_subtraction: StateBackgroundSubtraction = StateBackgroundSubtraction()
 
     def validate(self):
         is_invalid = dict()
@@ -74,6 +75,8 @@ class AllStates(metaclass=JsonSerializable):
             is_invalid.update("State: The state object needs to include a StateAdjustment object.")
         if not self.convert_to_q:
             is_invalid.update("State: The state object needs to include a StateConvertToQ object.")
+        if not self.background_subtraction:
+            is_invalid.update("State: The state object needs to include a StateBackgroundSubtraction object.")
 
         # We don't enforce a compatibility mode, we just create one if it does not exist
         if not self.compatibility:

--- a/scripts/SANS/sans/state/StateObjects/StateBackgroundSubtraction.py
+++ b/scripts/SANS/sans/state/StateObjects/StateBackgroundSubtraction.py
@@ -1,0 +1,73 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2023 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+""" Defines the state of the background which should be subtracted after the main reduction."""
+
+import json
+import copy
+
+from sans.state.JsonSerializable import JsonSerializable
+from sans.state.automatic_setters import automatic_setters
+from sans.state.state_functions import is_pure_none_or_not_none, validation_message
+from sans.common.enums import SANSFacility
+
+
+# ----------------------------------------------------------------------------------------------------------------------
+# State
+# ----------------------------------------------------------------------------------------------------------------------
+
+
+class StateBackgroundSubtraction(metaclass=JsonSerializable):
+    def __init__(self):
+        super(StateBackgroundSubtraction, self).__init__()
+
+        self.workspace = None  # : Str()
+        self.scale_factor = None  # : Float()
+
+    def validate(self):
+        is_invalid = dict()
+
+        if not is_pure_none_or_not_none([self.workspace, self.scale_factor]):
+            entry = validation_message(
+                "Missing background subtraction parameters.",
+                "Make sure that either both or none are set.",
+                {"BackGroundWorkspace": self.workspace, "ScaleFactor": self.scale_factor},
+            )
+            is_invalid.update(entry)
+
+        if is_invalid:
+            raise ValueError(
+                "StateBackgroundSubtraction: The provided inputs are illegal. " "Please see: {}".format(json.dumps(is_invalid))
+            )
+
+
+# ----------------------------------------------------------------------------------------------------------------------
+# Builder
+# ----------------------------------------------------------------------------------------------------------------------
+class StateBackgroundSubtractionBuilder(object):
+    @automatic_setters(StateBackgroundSubtraction)
+    def __init__(self):
+        super(StateBackgroundSubtractionBuilder, self).__init__()
+        self.state = StateBackgroundSubtraction()
+
+    def build(self):
+        # Make sure that the product is in a valid state, ie not incomplete
+        self.state.validate()
+        return copy.copy(self.state)
+
+
+# ------------------------------------------
+# Factory method for SANStateDataBuilder
+# ------------------------------------------
+def get_background_subtraction_builder(data_info):
+    facility = data_info.facility
+    if facility is SANSFacility.ISIS:
+        return StateBackgroundSubtractionBuilder()
+    else:
+        raise NotImplementedError(
+            f"StateBackgroundSubtraction: Could not find any valid background subtraction builder for the specified "
+            f"StateData object {data_info}"
+        )

--- a/scripts/test/SANS/algorithm_detail/batch_execution_test.py
+++ b/scripts/test/SANS/algorithm_detail/batch_execution_test.py
@@ -424,6 +424,7 @@ class GetAllNamesToSaveTest(unittest.TestCase):
             scaled_ws_name,
         )
 
+    @mock.patch("sans.algorithm_detail.batch_execution.AnalysisDataService", new=ADSMock(True))
     @mock.patch("sans.algorithm_detail.batch_execution.create_unmanaged_algorithm")
     def test_subtract_background_from_merged_calls_algorithms_correctly(self, mock_alg_manager):
         mock_minus = mock.MagicMock()
@@ -433,11 +434,12 @@ class GetAllNamesToSaveTest(unittest.TestCase):
         reduction_package.reduction_mode = ReductionMode.MERGED
         reduction_package.reduced_merged_name = ["ws1", "ws2"]
 
-        created_workspaces = subtract_scaled_background(reduction_package, scaled_ws_name)
+        created_workspaces, created_workspace_names = subtract_scaled_background(reduction_package, scaled_ws_name)
 
         mock_alg_manager.assert_any_call("Minus", **{"RHSWorkspace": scaled_ws_name, "LHSWorkspace": "ws1", "OutputWorkspace": "ws1_bgsub"})
         mock_alg_manager.assert_any_call("Minus", **{"RHSWorkspace": scaled_ws_name, "LHSWorkspace": "ws2", "OutputWorkspace": "ws2_bgsub"})
-        self.assertEqual(["ws1_bgsub", "ws2_bgsub"], created_workspaces)
+        self.assertEqual(["ws1_bgsub", "ws2_bgsub"], created_workspace_names)
+        self.assertEqual(len(created_workspaces), len(created_workspace_names))
         self.assertEqual(mock_minus.execute.call_count, 2)
 
 

--- a/scripts/test/SANS/algorithm_detail/batch_execution_test.py
+++ b/scripts/test/SANS/algorithm_detail/batch_execution_test.py
@@ -80,6 +80,7 @@ class GetAllNamesToSaveTest(unittest.TestCase):
         merged_workspace = _create_sample_ws_group("merged_workspace")
         lab_workspace = _create_sample_ws_group("lab_workspace")
         hab_workspace = _create_sample_ws_group("hab_workspace")
+        bgsub_workspace_name = ["bgsub_workspace"]
         reduced_lab_can = _create_sample_ws_group("reduced_lab_can")
         reduced_hab_can = _create_sample_ws_group("reduced_hab_can")
         reduced_lab_sample = _create_sample_ws_group("reduced_lab_sample")
@@ -90,6 +91,7 @@ class GetAllNamesToSaveTest(unittest.TestCase):
         self.reduction_package_merged.reduced_merged = merged_workspace
         self.reduction_package_merged.reduced_lab = lab_workspace
         self.reduction_package_merged.reduced_hab = hab_workspace
+        self.reduction_package_merged.reduced_bgsub_name = bgsub_workspace_name
         self.reduction_package_merged.reduced_lab_can = reduced_lab_can
         self.reduction_package_merged.reduced_hab_can = reduced_hab_can
         self.reduction_package_merged.reduced_lab_sample = reduced_lab_sample
@@ -99,6 +101,7 @@ class GetAllNamesToSaveTest(unittest.TestCase):
 
         self.reduction_package.reduced_lab = lab_workspace
         self.reduction_package.reduced_hab = hab_workspace
+        self.reduction_package.reduced_bgsub_name = bgsub_workspace_name
         self.reduction_package.reduced_lab_can = reduced_lab_can
         self.reduction_package.reduced_hab_can = reduced_hab_can
         self.reduction_package.reduced_lab_sample = reduced_lab_sample
@@ -108,6 +111,7 @@ class GetAllNamesToSaveTest(unittest.TestCase):
 
         self.reduction_package_transmissions.reduced_lab = lab_workspace
         self.reduction_package_transmissions.reduced_hab = hab_workspace
+        self.reduction_package_transmissions.reduced_bgsub_name = bgsub_workspace_name
         self.reduction_package_transmissions.reduced_lab_can = reduced_lab_can
         self.reduction_package_transmissions.reduced_hab_can = reduced_hab_can
         self.reduction_package_transmissions.reduced_lab_sample = reduced_lab_sample
@@ -119,13 +123,13 @@ class GetAllNamesToSaveTest(unittest.TestCase):
         reduction_packages = [self.reduction_package_merged]
         names_to_save = get_all_names_to_save(reduction_packages, save_can=False)
 
-        self.assertEqual(names_to_save, [(["merged_workspace"], [], [])])
+        self.assertEqual(names_to_save, [(["merged_workspace"], [], []), (["bgsub_workspace"], [], [])])
 
     def test_hab_and_lab_workspaces_returned_if_merged_workspace_not_present(self):
         reduction_packages = [self.reduction_package]
         names_to_save = get_all_names_to_save(reduction_packages, save_can=False)
 
-        self.assertEqual(names_to_save, [(["lab_workspace"], [], []), (["hab_workspace"], [], [])])
+        self.assertEqual(names_to_save, [(["lab_workspace"], [], []), (["hab_workspace"], [], []), (["bgsub_workspace"], [], [])])
 
     def test_can_workspaces_returned_if_save_can_selected(self):
         names_to_save = get_all_names_to_save([self.reduction_package_merged], True)
@@ -133,6 +137,7 @@ class GetAllNamesToSaveTest(unittest.TestCase):
             "merged_workspace",
             "lab_workspace",
             "hab_workspace",
+            "bgsub_workspace",
             "reduced_lab_can",
             "reduced_hab_can",
             "reduced_lab_sample",
@@ -145,7 +150,15 @@ class GetAllNamesToSaveTest(unittest.TestCase):
         reduction_packages = [self.reduction_package]
         names_to_save = get_all_names_to_save(reduction_packages, True)
 
-        names = {"lab_workspace", "hab_workspace", "reduced_lab_can", "reduced_hab_can", "reduced_lab_sample", "reduced_hab_sample"}
+        names = {
+            "lab_workspace",
+            "hab_workspace",
+            "bgsub_workspace",
+            "reduced_lab_can",
+            "reduced_hab_can",
+            "reduced_lab_sample",
+            "reduced_hab_sample",
+        }
         names_expected = [([name], [], []) for name in names]
         self.assertEqual(sorted(names_to_save), sorted(names_expected))
 
@@ -230,6 +243,7 @@ class GetAllNamesToSaveTest(unittest.TestCase):
         names_expected = [
             (["lab_workspace"], ["transmission"], ["transmission_can"]),
             (["hab_workspace"], ["transmission"], ["transmission_can"]),
+            (["bgsub_workspace"], ["transmission"], ["transmission_can"]),
         ]
 
         self.assertEqual(names_to_save, names_expected)
@@ -242,6 +256,7 @@ class GetAllNamesToSaveTest(unittest.TestCase):
         names_expected = [
             (["lab_workspace"], ["transmission"], ["transmission_can"]),
             (["hab_workspace"], ["transmission"], ["transmission_can"]),
+            (["bgsub_workspace"], ["transmission"], ["transmission_can"]),
             (["reduced_lab_can"], [], ["transmission_can"]),
             (["reduced_hab_can"], [], ["transmission_can"]),
             (["reduced_lab_sample"], ["transmission"], []),
@@ -372,7 +387,7 @@ class GetAllNamesToSaveTest(unittest.TestCase):
 
         result = create_scaled_background_workspace(state)
 
-        state.background_subtraction.verify.assert_called_once()
+        state.background_subtraction.validate.assert_called_once()
         self.assertIsNone(result, "When no background ws is set, this should return None.")
 
     @mock.patch("sans.algorithm_detail.batch_execution.create_unmanaged_algorithm")
@@ -386,7 +401,7 @@ class GetAllNamesToSaveTest(unittest.TestCase):
 
         result = create_scaled_background_workspace(state)
 
-        state.background_subtraction.verify.assert_called_once()
+        state.background_subtraction.validate.assert_called_once()
 
         expected_options = {
             "InputWorkspace": ws_name,

--- a/scripts/test/SANS/gui_logic/gui_state_director_test.py
+++ b/scripts/test/SANS/gui_logic/gui_state_director_test.py
@@ -98,6 +98,16 @@ class GuiStateDirectorTest(unittest.TestCase):
 
         self.assertEqual(state_model.all_states.save, new_state.all_states.save)
 
+    def test_that_background_ws_and_scale_factor_set_on_state_from_options_column(self):
+        state_model = self._get_state_gui_model()
+        director = GuiStateDirector(state_model, SANSFacility.ISIS)
+
+        state = self._get_row_entry(option_string="BackgroundWorkspace=whatever,ScaleFactor=0.9")
+        state = director.create_state(state)
+        self.assertTrue(isinstance(state, StateGuiModel))
+        self.assertEqual(state.all_states.background_subtraction.workspace, "whatever")
+        self.assertEqual(state.all_states.background_subtraction.scale_factor, 0.9)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/test/SANS/state/CMakeLists.txt
+++ b/scripts/test/SANS/state/CMakeLists.txt
@@ -3,6 +3,7 @@
 set(TEST_PY_FILES
     adjustment_test.py
     JsonSerializerTest.py
+    background_subtraction_test.py
     calculate_transmission_test.py
     convert_to_q_test.py
     data_test.py

--- a/scripts/test/SANS/state/background_subtraction_test.py
+++ b/scripts/test/SANS/state/background_subtraction_test.py
@@ -1,0 +1,68 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2023 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+import unittest
+
+from sans.common.enums import SANSFacility
+from sans.state.StateObjects.StateData import get_data_builder
+from sans.state.StateObjects.StateBackgroundSubtraction import StateBackgroundSubtraction, get_background_subtraction_builder
+from sans.test_helper.file_information_mock import SANSFileInformationMock
+
+
+# ----------------------------------------------------------------------------------------------------------------------
+# State
+# ----------------------------------------------------------------------------------------------------------------------
+class StateBackgroundSubtractionTest(unittest.TestCase):
+    def test_that_raises_when_only_bgws_is_set(self):
+        state = StateBackgroundSubtraction()
+        state.workspace = "testws"
+        with self.assertRaises(ValueError):
+            state.validate()
+
+    def test_that_raises_when_only_scale_factor_is_set(self):
+        state = StateBackgroundSubtraction()
+        state.scale_factor = 1.08
+        with self.assertRaises(ValueError):
+            state.validate()
+
+    def test_that_valid_when_none_set(self):
+        state = StateBackgroundSubtraction()
+        state.validate()
+
+    def test_that_valid_when_both_set(self):
+        state = StateBackgroundSubtraction()
+        state.scale_factor = 1.08
+        state.workspace = "testws"
+        state.validate()
+
+
+# ----------------------------------------------------------------------------------------------------------------------
+# Builder
+# ----------------------------------------------------------------------------------------------------------------------
+class StateBackgroundSubtractionBuilderTest(unittest.TestCase):
+    def test_that_background_subtraction_state_can_be_built(self):
+        # Arrange
+        facility = SANSFacility.ISIS
+        file_information = SANSFileInformationMock(run_number=74044)
+        data_builder = get_data_builder(facility, file_information)
+        data_builder.set_sample_scatter("LOQ74044")
+        data_info = data_builder.build()
+
+        # Act
+        builder = get_background_subtraction_builder(data_info)
+        self.assertTrue(builder)
+
+        builder.set_workspace("test_ws")
+        builder.set_scale_factor(1.17)
+
+        # Assert
+        state = builder.build()
+        self.assertEqual(state.workspace, "test_ws")
+        self.assertEqual(state.scale_factor, 1.17)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**Description of work**

**Purpose of work**
SANS scientists currently do this after their main reduction by running a couple of algorithms in post. Namely Scale and Minus. They want to be able to do this in the Interface instead automatically, so that the saving can be done at the same time (which is much less error prone). 

**Summary of work**
Added BackgroundWorkspace and ScaleFactor options to the Options column of the ISIS SANS interface.

**Further detail of work**
Providing these two values allows the background subtraction to take place. The BackgroundWorkspace represents a "Solution" reduction which is a run where the sample was just the solution that would normally have the sample dissolved/suspended in it. This BackgroundWorkspace is the result of a separate full reduction, and must be in the ADS prior to using it in a Scaled Background Subtraction reduction. 

The BackgroundWorkspace is multiplied by the given ScaleFactor and then subtracted from the output workspace (defined by ReductionMode (HAB, LAB, or Merged). It is expected that the Reduction Mode will be the same across both reductions). 

The result of this subtraction is then saved *in addition* to the normal output of the reduction.


**To test:**
1. Boot up workbench and the ISIS SANS interface. 
2. Load the user file and the batch file from the LOQ Demo in the TrainingCourseData
3. Process All (this will produce your "background" workspaces, something like `first_time_merged_1D_2.2_10.0` or `first_time_HAB_1D_2.2_10.0`)
4. Change the output name and add `BackgroundWorkspace=<nameOfBackgroundWorkspaceFromStep3>, ScaleFactor=0.9` to the options cell of the row. 
5. Run the reduction again (if it fails, you may need to change the value of the toml user file for the reduction mode from "All" to "Merged", but this is a good chance to check the error message shows properly.)
  5a. If you've had to make the all -> merged change, you'll need to run steps 3 and 4 again from scratch as the workspace names will be different, as will the number of spectra in the workspace. Which will throw errors from the Minus algorithm. Make sure that the workspace you select as the `BackgroundWorkspace` has `merged` in the title. 
7. Check the two output workspaces you should now have. If it has worked properly, the subtracted one's values should be 10% of the unsubtracted one's. 

Fixes #35446 

---

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.