### PR TITLE
Fixing sliceviewer projection matrix calculation for workspaces with basis vectors

### DIFF
--- a/Testing/SystemTests/tests/qt/SliceViewerIntegrationTest.py
+++ b/Testing/SystemTests/tests/qt/SliceViewerIntegrationTest.py
@@ -610,8 +610,6 @@ class SliceViewerTestCreateMDEvent(systemtesting.MantidSystemTest, HelperTesting
     def runTest(self):
         HelperTestingClass.__init__(self)
 
-        test_dir = tempfile.mkdtemp()
-
         ws = CreateMDWorkspace(
             Dimensions="4",
             EventType="MDEvent",
@@ -635,27 +633,20 @@ class SliceViewerTestCreateMDEvent(systemtesting.MantidSystemTest, HelperTesting
             OutputBins=[154, 100, 1, 218],
         )
 
-        UB = [-0.13829092, -0.09642086, -0.0040107, -0.00392306, -0.00138571, 0.16858273, -0.09642447, 0.13834213, -0.00110674]
-
-        AddSampleLog(binned_ws, LogName="sample")
-        SetUB(binned_ws, UB=UB)
         binned_ws.clearOriginalWorkspaces()
 
         pres = SliceViewer(binned_ws)
-        self.assertEqual(pres.get_proj_matrix().flatten().tolist(), [1, 0, 0, 0, 1, 0, 0, 0, 1])
+        proj_matrix = pres.get_proj_matrix().tolist()
+        self.assertAlmostEqual(proj_matrix[0][0], -1.4747400283813477)
+        self.assertAlmostEqual(proj_matrix[0][1], -0.2630769908428192)
+        self.assertAlmostEqual(proj_matrix[0][2], -0.025200000032782555)
+        self.assertAlmostEqual(proj_matrix[1][0], -0.03335599973797798)
+        self.assertAlmostEqual(proj_matrix[1][1], -0.01594259962439537)
+        self.assertAlmostEqual(proj_matrix[1][2], 1.0592399835586548)
+        self.assertAlmostEqual(proj_matrix[2][0], 0.26337599754333496)
+        self.assertAlmostEqual(proj_matrix[2][1], -1.4750800132751465)
+        self.assertAlmostEqual(proj_matrix[2][2], -0.006953829899430275)
         pres.view.close()
-
-        binned_ws.getExperimentInfo(0).run().addProperty("W_MATRIX", [1, 0, 1, 1, 0, -1, 0, 1, 0], True)
-
-        SaveMD(binned_ws, Filename=os.path.join(test_dir, "md_event_to_hist_4d.nxs"))
-        DeleteWorkspace(binned_ws)
-
-        binned_ws = LoadMD(os.path.join(test_dir, "md_event_to_hist_4d.nxs"))
-        pres = SliceViewer(binned_ws)
-        self.assertEqual(pres.get_proj_matrix().flatten().tolist(), [1, 0, 1, 1, 0, -1, 0, 1, 0])
-        pres.view.close()
-
-        shutil.rmtree(test_dir)
 
 
 # private helper functions

--- a/docs/source/release/v6.8.0/Workbench/SliceViewer/Bugfixes/35812.rst
+++ b/docs/source/release/v6.8.0/Workbench/SliceViewer/Bugfixes/35812.rst
@@ -1,0 +1,1 @@
+* Resolved issue with projection matrix calcluation using basis vectors with non-q dimensions

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/models/model.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/models/model.py
@@ -538,10 +538,10 @@ class SliceViewerModel(SliceViewerBaseModel):
             # exclude non-Q dim elements from basis vectors
             qflags = [ws.getDimension(idim).getMDFrame().isQ() for idim in range(ndims)]
             i_nonq = np.flatnonzero(np.invert(qflags))
-            qmask = np.invert(basis_matrix[i_nonq, :].astype(bool).sum(axis=0).astype(bool))
+            qmask = np.invert(basis_matrix[i_nonq, :].any(axis=0))
             # extract proj matrix from basis vectors of q dimension
             # note for 2D the last col/row of proj_matrix is 0,0,1 - i.e. L
-            proj_matrix[: qmask.sum(), : qmask.sum()] = basis_matrix[qmask, :][:, qflags]
+            proj_matrix[: qmask.sum(), : sum(qflags)] = basis_matrix[qmask, :][:, qflags]
         return proj_matrix
 
     def get_proj_matrix(self):

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/models/model.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/models/model.py
@@ -538,10 +538,10 @@ class SliceViewerModel(SliceViewerBaseModel):
             # exclude non-Q dim elements from basis vectors
             qflags = [ws.getDimension(idim).getMDFrame().isQ() for idim in range(ndims)]
             i_nonq = np.flatnonzero(np.invert(qflags))
-            qmask = np.invert(basis_matrix[i_nonq, :].any(axis=0))
+            qmask = np.invert(basis_matrix[:, i_nonq] == 1).ravel()
             # extract proj matrix from basis vectors of q dimension
             # note for 2D the last col/row of proj_matrix is 0,0,1 - i.e. L
-            proj_matrix[: qmask.sum(), : sum(qflags)] = basis_matrix[qmask, :][:, qflags]
+            proj_matrix[: qmask.sum(), : qmask.sum()] = basis_matrix[qmask, :][:, qflags]
         return proj_matrix
 
     def get_proj_matrix(self):

--- a/qt/python/mantidqt/mantidqt/widgets/sliceviewer/models/model.py
+++ b/qt/python/mantidqt/mantidqt/widgets/sliceviewer/models/model.py
@@ -536,12 +536,12 @@ class SliceViewerModel(SliceViewerBaseModel):
             for idim in range(ndims):
                 basis_matrix[:, idim] = list(ws.getBasisVector(idim))
             # exclude non-Q dim elements from basis vectors
-            qflags = [ws.getDimension(idim).getMDFrame().isQ() for idim in range(ndims)]
+            qflags = np.array([ws.getDimension(idim).getMDFrame().isQ() for idim in range(ndims)])
             i_nonq = np.flatnonzero(np.invert(qflags))
             qmask = np.invert(basis_matrix[:, i_nonq] == 1).ravel()
             # extract proj matrix from basis vectors of q dimension
             # note for 2D the last col/row of proj_matrix is 0,0,1 - i.e. L
-            proj_matrix[: qmask.sum(), : qmask.sum()] = basis_matrix[qmask, :][:, qflags]
+            proj_matrix[: qmask.sum(), : qflags.sum()] = basis_matrix[qmask, :][:, qflags]
         return proj_matrix
 
     def get_proj_matrix(self):


### PR DESCRIPTION
**Description of work**

Fixes an issue with the projection matrix calculation from basis vectors that prevents certain files from being loaded.

**Purpose of work**
<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
-->

Fixes the bug. Adds a relevant integration test.

**Summary of work**
<!-- Please provide a short, high level description of the work that was done.
-->

Projection matrix from basis vectors with non-Q/HKL dimensions can become incorrect.

**Further detail of work**
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

Test written from this failing example.
python 
```
from mantid.simpleapi import *

LoadMD(Filename='/home/zgf/Desktop/MDE_MaPbBr_12meV_290K.nxs', 
       OutputWorkspace='mde')
MDNorm(InputWorkspace='mde', 
       QDimension0='1,1,0', 
       QDimension1='0,0,1', 
       QDimension2='1,-1,0', 
       Dimension0Binning='0.05', 
       Dimension1Name='DeltaE', 
       Dimension1Binning='-2,0.1,8', 
       Dimension2Binning='-0.1,0.1', 
       Dimension3Name='QDimension1', 
       Dimension3Binning='0.05', 
       OutputWorkspace='o', 
       OutputDataWorkspace='d', 
       OutputNormalizationWorkspace='n')

```

**To test:**

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

Run slice viewer integration tests

*There is no associated issue.*

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.