### PR TITLE
Powder diffraction gui DataOffset parameter

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/SNSPowderReduction.py
+++ b/Framework/PythonInterface/plugins/algorithms/SNSPowderReduction.py
@@ -358,6 +358,11 @@ class SNSPowderReduction(DataProcessorAlgorithm):
                 if bool(cache_dir) and Path(cache_dir).exists() is False:
                     issues["CacheDir"] = f"Directory {cache_dir} does not exist"
 
+        # can only specify vertical offset in one way
+        if (not self.getProperty("OffsetData").isDefault) and (not self.getProperty("PushDataPositive").isDefault):
+            issues["OffsetData"] = "Cannot specify with PushDataPositive"
+            issues["PushDataPositive"] = "Cannot specify with OffsetData"
+
         # We cannot clear the cache if property "CacheDir" has not been set
         if self.getProperty("CleanCache").value and not bool(self.getProperty("CacheDir").value):
             issues["CleanCache"] = 'Property "CacheDir" must be set in order to clean the cache'

--- a/Framework/PythonInterface/test/python/plugins/algorithms/CMakeLists.txt
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/CMakeLists.txt
@@ -107,6 +107,7 @@ set(TEST_PY_FILES
     ReflectometryReductionOneLiveDataTest.py
     ReflectometrySliceEventWorkspaceTest.py
     RetrieveRunInfoTest.py
+    SNSPowderReductionTest.py
     SANSWideAngleCorrectionTest.py
     SaveGEMMAUDParamFileTest.py
     SaveNexusPDTest.py

--- a/Framework/PythonInterface/test/python/plugins/algorithms/SNSPowderReductionTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/SNSPowderReductionTest.py
@@ -1,0 +1,24 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2023 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+import unittest
+from mantid.simpleapi import SNSPowderReduction
+from numpy import concatenate, arange, sort, array_equal, where
+
+# tests run x10 slower with this on, but it may be useful to track down issues refactoring
+CHECK_CONSISTENCY = False
+
+
+class SNSPowderReductionTest(unittest.TestCase):
+    def testValidateInputs(self):
+        # PushDataPositive and OffsetData cannot be specified together
+        self.assertRaises(
+            RuntimeError, SNSPowderReduction, Filename="PG3_46577", OutputDirectory="/tmp/", PushDataPositive="AddMinimum", OffsetData=42.0
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/source/release/v6.8.0/Diffraction/Powder/New_features/35818.rst
+++ b/docs/source/release/v6.8.0/Diffraction/Powder/New_features/35818.rst
@@ -1,0 +1,1 @@
+* Expose the OffsetData parameter in the Powder Diffraction Reduction gui

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/reduction_gui/widgets/diffraction/diffraction_adv_setup.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/reduction_gui/widgets/diffraction/diffraction_adv_setup.py
@@ -93,6 +93,13 @@ class AdvancedSetupWidget(BaseWidget):
         dv7.setBottom(0.0)
         self._content.scaledata_edit.setValidator(dv7)
 
+        self._content.pushdatapos_combo.activated.connect(self._onlyOneAdditive)
+
+        dv_offsetdata = QDoubleValidator(self._content.offsetdata_edit)
+        dv_offsetdata.setBottom(0.0)
+        self._content.offsetdata_edit.setValidator(dv_offsetdata)
+        self._content.offsetdata_edit.editingFinished.connect(self._onlyOneAdditive)
+
         dv8 = QDoubleValidator(self._content.numberdensity_edit)
         dv8.setBottom(0.0)
         self._content.numberdensity_edit.setValidator(dv8)
@@ -146,6 +153,10 @@ class AdvancedSetupWidget(BaseWidget):
         """
 
         self._content.pushdatapos_combo.setCurrentIndex(self._content.pushdatapos_combo.findText(state.pushdatapositive))
+        if state.offsetdata:
+            self._content.offsetdata_edit.setText(str(state.offsetdata).strip())
+        else:
+            self._content.offsetdata_edit.setText("0")
         self._content.unwrap_edit.setText(str(state.unwrapref))
         self._content.lowres_edit.setText(str(state.lowresref))
         self._content.removepromptwidth_edit.setText(str(state.removepropmppulsewidth))
@@ -196,6 +207,7 @@ class AdvancedSetupWidget(BaseWidget):
         # Initialize AdvancedSetupScript static variables with widget's content
         #
         s.pushdatapositive = str(self._content.pushdatapos_combo.currentText())
+        s.offsetdata = self._content.offsetdata_edit.text().strip()
         s.unwrapref = self._content.unwrap_edit.text()
         s.lowresref = self._content.lowres_edit.text()
         s.cropwavelengthmin = str(self._content.cropwavelengthmin_edit.text())
@@ -272,6 +284,23 @@ class AdvancedSetupWidget(BaseWidget):
         except ValueError as e:
             self._content.sampleformula_edit.setToolTip(str(e).replace("MaterialBuilder::setFormula() - ", ""))
             self._content.sampleformula_edit.setStyleSheet("QLineEdit{background:salmon;}")
+
+    def _onlyOneAdditive(self):
+        # enable offsetdata only when pushdatapositive is None
+        pushdatapositive = str(self._content.pushdatapos_combo.currentText())
+        if pushdatapositive == "None":
+            # can edit the offsetdata
+            self._content.offsetdata_edit.setEnabled(True)
+        else:
+            self._content.offsetdata_edit.setEnabled(False)
+            self._content.offsetdata_edit.setText("0")
+
+        # enable pushdatapositive only when offsetdata isn't set
+        offsetdata_is_set = False
+        offsetdata = self._content.offsetdata_edit.text().strip()
+        if len(offsetdata) > 0:
+            offsetdata_is_set = bool(float(offsetdata) != 0.0)
+        self._content.pushdatapos_combo.setEnabled(not offsetdata_is_set)
 
     def _calculate_packing_fraction(self):
         try:

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/ui/diffraction/diffraction_adv_setup.ui
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/ui/diffraction/diffraction_adv_setup.ui
@@ -78,8 +78,8 @@
        <rect>
         <x>0</x>
         <y>0</y>
-        <width>982</width>
-        <height>848</height>
+        <width>986</width>
+        <height>877</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout_5">
@@ -221,165 +221,8 @@
               </property>
              </widget>
             </item>
-            <item row="1" column="3">
-             <widget class="QLabel" name="label_5">
-              <property name="text">
-               <string>Maximum Cropped Wavelength</string>
-              </property>
-             </widget>
-            </item>
-            <item row="4" column="0">
-             <widget class="QLabel" name="label_3">
-              <property name="text">
-               <string>Scale Data</string>
-              </property>
-             </widget>
-            </item>
-            <item row="1" column="2">
-             <spacer name="horizontalSpacer_2">
-              <property name="orientation">
-               <enum>Qt::Horizontal</enum>
-              </property>
-              <property name="sizeType">
-               <enum>QSizePolicy::Preferred</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>40</width>
-                <height>20</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-            <item row="0" column="0">
-             <widget class="QLabel" name="label_2">
-              <property name="text">
-               <string>Output File Prefix</string>
-              </property>
-             </widget>
-            </item>
-            <item row="1" column="5">
-             <spacer name="horizontalSpacer_3">
-              <property name="orientation">
-               <enum>Qt::Horizontal</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>40</width>
-                <height>20</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-            <item row="1" column="1">
-             <widget class="QLineEdit" name="lowres_edit">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="minimumSize">
-               <size>
-                <width>200</width>
-                <height>0</height>
-               </size>
-              </property>
-              <property name="maximumSize">
-               <size>
-                <width>200</width>
-                <height>16777215</height>
-               </size>
-              </property>
-              <property name="toolTip">
-               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Enter value for reference DIFC for resolution removal.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-              </property>
-             </widget>
-            </item>
-            <item row="0" column="1">
-             <widget class="QLineEdit" name="outputfileprefix_edit">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="minimumSize">
-               <size>
-                <width>200</width>
-                <height>0</height>
-               </size>
-              </property>
-              <property name="maximumSize">
-               <size>
-                <width>200</width>
-                <height>16777215</height>
-               </size>
-              </property>
-             </widget>
-            </item>
-            <item row="1" column="0">
-             <widget class="QLabel" name="low_resolution_label">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="toolTip">
-               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Reference DIFC for resolution removal. Zero skips the correction.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-              </property>
-              <property name="text">
-               <string>Low Resolution Ref</string>
-              </property>
-             </widget>
-            </item>
-            <item row="2" column="1">
-             <widget class="QLineEdit" name="unwrap_edit">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="minimumSize">
-               <size>
-                <width>200</width>
-                <height>0</height>
-               </size>
-              </property>
-              <property name="maximumSize">
-               <size>
-                <width>200</width>
-                <height>16777215</height>
-               </size>
-              </property>
-              <property name="toolTip">
-               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Enter value for reference total flight path for frame unwrapping. Zero skips the correction. &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-              </property>
-             </widget>
-            </item>
-            <item row="3" column="0">
-             <widget class="QLabel" name="label">
-              <property name="minimumSize">
-               <size>
-                <width>200</width>
-                <height>0</height>
-               </size>
-              </property>
-              <property name="maximumSize">
-               <size>
-                <width>200</width>
-                <height>16777215</height>
-               </size>
-              </property>
-              <property name="toolTip">
-               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Specify maximum Gbytes of file to read in one chunk. Default is whole file. &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-              </property>
-              <property name="text">
-               <string>Maximum Chunk Size</string>
-              </property>
-             </widget>
+            <item row="1" column="4">
+             <widget class="QLineEdit" name="lineEdit_croppedWavelengthMax"/>
             </item>
             <item row="2" column="0">
              <widget class="QLabel" name="unwrap_label">
@@ -394,16 +237,6 @@
               </property>
               <property name="text">
                <string>Unwrap Ref</string>
-              </property>
-             </widget>
-            </item>
-            <item row="5" column="0">
-             <widget class="QLabel" name="label_bkgdsmooth">
-              <property name="toolTip">
-               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Parameters to smooth background (can run) by FFT smooth algorithm.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-              </property>
-              <property name="text">
-               <string>Background Smooth Parameters</string>
               </property>
              </widget>
             </item>
@@ -441,17 +274,52 @@
               </property>
              </widget>
             </item>
-            <item row="4" column="1">
-             <widget class="QLineEdit" name="scaledata_edit">
-              <property name="toolTip">
-               <string>Constant to multiply the data by before writing out</string>
+            <item row="1" column="5">
+             <spacer name="horizontalSpacer_3">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
               </property>
-             </widget>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>40</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
             </item>
-            <item row="5" column="1">
-             <widget class="QLineEdit" name="bkgdsmoothpar_edit">
-              <property name="toolTip">
-               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Parameters to smooth background (can run) by FFT smooth algorithm.&lt;/p&gt;&lt;p&gt;Enter 2 integers.  The suggested values are &amp;quot;20, 2&amp;quot;. &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            <item row="6" column="5">
+             <spacer name="horizontalSpacer_6">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>40</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+            <item row="1" column="2">
+             <spacer name="horizontalSpacer_2">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeType">
+               <enum>QSizePolicy::Preferred</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>40</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+            <item row="1" column="3">
+             <widget class="QLabel" name="label_5">
+              <property name="text">
+               <string>Maximum Cropped Wavelength</string>
               </property>
              </widget>
             </item>
@@ -471,6 +339,28 @@
               </property>
               <property name="text">
                <string>Minimum Cropped Wavelength</string>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="1">
+             <widget class="QLineEdit" name="outputfileprefix_edit">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="minimumSize">
+               <size>
+                <width>200</width>
+                <height>0</height>
+               </size>
+              </property>
+              <property name="maximumSize">
+               <size>
+                <width>200</width>
+                <height>16777215</height>
+               </size>
               </property>
              </widget>
             </item>
@@ -496,10 +386,92 @@
               </property>
              </widget>
             </item>
-            <item row="4" column="3">
+            <item row="2" column="1">
+             <widget class="QLineEdit" name="unwrap_edit">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="minimumSize">
+               <size>
+                <width>200</width>
+                <height>0</height>
+               </size>
+              </property>
+              <property name="maximumSize">
+               <size>
+                <width>200</width>
+                <height>16777215</height>
+               </size>
+              </property>
+              <property name="toolTip">
+               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Enter value for reference total flight path for frame unwrapping. Zero skips the correction. &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+              </property>
+             </widget>
+            </item>
+            <item row="5" column="3">
              <widget class="QLabel" name="label_4">
               <property name="text">
                <string>FilterBadPulses</string>
+              </property>
+             </widget>
+            </item>
+            <item row="2" column="4">
+             <widget class="QLineEdit" name="removepromptwidth_edit">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="minimumSize">
+               <size>
+                <width>200</width>
+                <height>0</height>
+               </size>
+              </property>
+              <property name="maximumSize">
+               <size>
+                <width>200</width>
+                <height>16777215</height>
+               </size>
+              </property>
+              <property name="toolTip">
+               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Enter value for width of events (in microseconds) near the prompt pulse to remove&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+              </property>
+             </widget>
+            </item>
+            <item row="5" column="4">
+             <widget class="QLineEdit" name="filterbadpulses_edit">
+              <property name="toolTip">
+               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Check to filter out events measured while proton charge is more than 5% below average &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="1">
+             <widget class="QLineEdit" name="lowres_edit">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="minimumSize">
+               <size>
+                <width>200</width>
+                <height>0</height>
+               </size>
+              </property>
+              <property name="maximumSize">
+               <size>
+                <width>200</width>
+                <height>16777215</height>
+               </size>
+              </property>
+              <property name="toolTip">
+               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Enter value for reference DIFC for resolution removal.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
               </property>
              </widget>
             </item>
@@ -525,31 +497,26 @@
               </property>
              </widget>
             </item>
-            <item row="1" column="4">
-             <widget class="QLineEdit" name="lineEdit_croppedWavelengthMax"/>
+            <item row="0" column="0">
+             <widget class="QLabel" name="label_2">
+              <property name="text">
+               <string>Output File Prefix</string>
+              </property>
+             </widget>
             </item>
-            <item row="2" column="4">
-             <widget class="QLineEdit" name="removepromptwidth_edit">
+            <item row="1" column="0">
+             <widget class="QLabel" name="low_resolution_label">
               <property name="sizePolicy">
-               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+               <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
                 <horstretch>0</horstretch>
                 <verstretch>0</verstretch>
                </sizepolicy>
               </property>
-              <property name="minimumSize">
-               <size>
-                <width>200</width>
-                <height>0</height>
-               </size>
-              </property>
-              <property name="maximumSize">
-               <size>
-                <width>200</width>
-                <height>16777215</height>
-               </size>
-              </property>
               <property name="toolTip">
-               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Enter value for width of events (in microseconds) near the prompt pulse to remove&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Reference DIFC for resolution removal. Zero skips the correction.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+              </property>
+              <property name="text">
+               <string>Low Resolution Ref</string>
               </property>
              </widget>
             </item>
@@ -587,14 +554,29 @@
               </item>
              </widget>
             </item>
-            <item row="4" column="4">
-             <widget class="QLineEdit" name="filterbadpulses_edit">
+            <item row="3" column="0">
+             <widget class="QLabel" name="label">
+              <property name="minimumSize">
+               <size>
+                <width>200</width>
+                <height>0</height>
+               </size>
+              </property>
+              <property name="maximumSize">
+               <size>
+                <width>200</width>
+                <height>16777215</height>
+               </size>
+              </property>
               <property name="toolTip">
-               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Check to filter out events measured while proton charge is more than 5% below average &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Specify maximum Gbytes of file to read in one chunk. Default is whole file. &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+              </property>
+              <property name="text">
+               <string>Maximum Chunk Size</string>
               </property>
              </widget>
             </item>
-            <item row="5" column="3">
+            <item row="6" column="3">
              <widget class="QCheckBox" name="preserveevents_checkbox">
               <property name="maximumSize">
                <size>
@@ -613,18 +595,50 @@
               </property>
              </widget>
             </item>
-            <item row="5" column="5">
-             <spacer name="horizontalSpacer_6">
-              <property name="orientation">
-               <enum>Qt::Horizontal</enum>
+            <item row="4" column="3">
+             <widget class="QLabel" name="offsetdata_label">
+              <property name="text">
+               <string>Offset Data</string>
               </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>40</width>
-                <height>20</height>
-               </size>
+             </widget>
+            </item>
+            <item row="4" column="0">
+             <widget class="QLabel" name="label_3">
+              <property name="text">
+               <string>Scale Data</string>
               </property>
-             </spacer>
+             </widget>
+            </item>
+            <item row="4" column="1">
+             <widget class="QLineEdit" name="scaledata_edit">
+              <property name="toolTip">
+               <string>Constant to multiply the data by before writing out</string>
+              </property>
+             </widget>
+            </item>
+            <item row="5" column="0">
+             <widget class="QLabel" name="label_bkgdsmooth">
+              <property name="toolTip">
+               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Parameters to smooth background (can run) by FFT smooth algorithm.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+              </property>
+              <property name="text">
+               <string>Background Smooth Parameters</string>
+              </property>
+             </widget>
+            </item>
+            <item row="5" column="1">
+             <widget class="QLineEdit" name="bkgdsmoothpar_edit">
+              <property name="toolTip">
+               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Parameters to smooth background (can run) by FFT smooth algorithm.&lt;/p&gt;&lt;p&gt;Enter 2 integers.  The suggested values are &amp;quot;20, 2&amp;quot;. &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+              </property>
+             </widget>
+            </item>
+            <item row="4" column="4">
+             <widget class="QLineEdit" name="offsetdata_edit">
+              <property name="toolTip">
+               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Add a constant to the data&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+              </property>
+             </widget>
             </item>
            </layout>
           </item>
@@ -1248,10 +1262,34 @@
   <tabstop>maxchunksize_edit</tabstop>
   <tabstop>scaledata_edit</tabstop>
   <tabstop>bkgdsmoothpar_edit</tabstop>
+  <tabstop>cropwavelengthmin_edit</tabstop>
+  <tabstop>lineEdit_croppedWavelengthMax</tabstop>
+  <tabstop>removepromptwidth_edit</tabstop>
+  <tabstop>pushdatapos_combo</tabstop>
+  <tabstop>offsetdata_edit</tabstop>
+  <tabstop>filterbadpulses_edit</tabstop>
+  <tabstop>preserveevents_checkbox</tabstop>
+  <tabstop>cache_dir_edit_1</tabstop>
+  <tabstop>cache_dir_browse_1</tabstop>
+  <tabstop>clean_cache_box</tabstop>
+  <tabstop>cache_dir_edit_2</tabstop>
+  <tabstop>cache_dir_browse_2</tabstop>
+  <tabstop>cache_dir_edit_3</tabstop>
+  <tabstop>cache_dir_browse_3</tabstop>
   <tabstop>stripvanpeaks_chkbox</tabstop>
   <tabstop>vanpeakfwhm_edit</tabstop>
-  <tabstop>vanpeaktol_edit</tabstop>
   <tabstop>vansmoothpar_edit</tabstop>
+  <tabstop>vanpeaktol_edit</tabstop>
+  <tabstop>sampleformula_edit</tabstop>
+  <tabstop>numberdensity_edit</tabstop>
+  <tabstop>containertype_combo</tabstop>
+  <tabstop>correctiontype_combo</tabstop>
+  <tabstop>massdensity_edit</tabstop>
+  <tabstop>packingfraction_edit</tabstop>
+  <tabstop>sampleheight_edit</tabstop>
+  <tabstop>vanadiumradius_edit</tabstop>
+  <tabstop>absorption_help_button</tabstop>
+  <tabstop>material_help_button</tabstop>
   <tabstop>scrollArea</tabstop>
  </tabstops>
  <resources/>

--- a/scripts/reduction_gui/reduction/diffraction/diffraction_adv_setup_script.py
+++ b/scripts/reduction_gui/reduction/diffraction/diffraction_adv_setup_script.py
@@ -141,9 +141,9 @@ class AdvancedSetupScript(BaseScriptElement):
             parvalue = parnamevaluedict[parname]
             if parvalue != "" and parname != "Instrument" and parname != "Facility":
                 if str(parvalue) == "True":
-                    parvalue = True
+                    parvalue = "1"
                 elif str(parvalue) == "False":
-                    parvalue = False
+                    parvalue = "0"
                 if not isinstance(parvalue, dict):
                     script += '%-10s = "%s",\n' % (parname, parvalue)
                 else:

--- a/scripts/reduction_gui/reduction/diffraction/diffraction_adv_setup_script.py
+++ b/scripts/reduction_gui/reduction/diffraction/diffraction_adv_setup_script.py
@@ -48,6 +48,7 @@ class AdvancedSetupScript(BaseScriptElement):
     # Class attributes
     #
     pushdatapositive = "None"
+    offsetdata = 0.0
     unwrapref = ""
     lowresref = ""
     cropwavelengthmin = ""
@@ -111,6 +112,7 @@ class AdvancedSetupScript(BaseScriptElement):
             "FilterBadPulses",
             "BackgroundSmoothParams",
             "PushDataPositive",
+            "OffsetData",
             "PreserveEvents",
             "OutputFilePrefix",
             "ScaleData",
@@ -139,9 +141,9 @@ class AdvancedSetupScript(BaseScriptElement):
             parvalue = parnamevaluedict[parname]
             if parvalue != "" and parname != "Instrument" and parname != "Facility":
                 if str(parvalue) == "True":
-                    parvalue = "1"
+                    parvalue = True
                 elif str(parvalue) == "False":
-                    parvalue = "0"
+                    parvalue = False
                 if not isinstance(parvalue, dict):
                     script += '%-10s = "%s",\n' % (parname, parvalue)
                 else:
@@ -162,7 +164,15 @@ class AdvancedSetupScript(BaseScriptElement):
         pardict["MaxChunkSize"] = self.maxchunksize
         pardict["FilterBadPulses"] = self.filterbadpulses
         pardict["BackgroundSmoothParams"] = self.bkgdsmoothpars
-        pardict["PushDataPositive"] = self.pushdatapositive
+        # these two parameters cannot be specified at the same time so
+        # initally set them at their default values
+        pardict["PushDataPositive"] = "None"
+        pardict["OffsetData"] = 0.0
+        if self.pushdatapositive == "None":
+            pardict["OffsetData"] = self.offsetdata
+        else:
+            pardict["PushDataPositive"] = self.pushdatapositive
+
         pardict["StripVanadiumPeaks"] = self.stripvanadiumpeaks
         pardict["VanadiumFWHM"] = self.vanadiumfwhm
         pardict["VanadiumPeakTol"] = self.vanadiumpeaktol
@@ -237,6 +247,7 @@ class AdvancedSetupScript(BaseScriptElement):
             self.pushdatapositive = BaseScriptElement.getStringElement(
                 instrument_dom, "pushdatapositive", default=AdvancedSetupScript.pushdatapositive
             )
+            self.offsetdata = BaseScriptElement.getStringElement(instrument_dom, "offsetdata", default=AdvancedSetupScript.offsetdata)
 
             self.stripvanadiumpeaks = getBooleanElement(instrument_dom, "stripvanadiumpeaks", AdvancedSetupScript.stripvanadiumpeaks)
 
@@ -306,6 +317,7 @@ class AdvancedSetupScript(BaseScriptElement):
         r"""reset instance's attributes with the values of the class' attributes"""
         class_attrs_selected = [
             "pushdatapositive",
+            "offsetdata",
             "unwrapref",
             "lowresref",
             "cropwavelengthmin",


### PR DESCRIPTION
Add the OffsetData parameter from Powder Diffraction Reduction GUI and connect to the corresponding parameter in SNSPowderReduction. This also verifies that a user doesn't specify it in combination with PushDataPositive and modifies the order in that widgets are cycled when pressing the "tab" key.

*Note:* The diff for the `.ui` file is very hard to make sense of. This is because of qtdesigner.

**To test:**

Launch the GUI with an existing reduction XML, and mess with the new parameter in the "advanced" tab.

*There is no associated issue,* but it does the work requested in [EWM854](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=854)

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.