### PR TITLE
Fix lookup matching from ISIS Reflectometry Preview tab

### DIFF
--- a/docs/source/release/v6.8.0/Reflectometry/Bugfixes/35826.rst
+++ b/docs/source/release/v6.8.0/Reflectometry/Bugfixes/35826.rst
@@ -1,0 +1,1 @@
+- The :ref:`Preview tab <refl_preview>` now matches rows in the :ref:`Experiment tab<refl_exp_instrument_settings>` lookup table by checking both run angle and title. Mantid will also no longer crash if a reduction is triggered on the :ref:`Preview tab <refl_preview>` when no run has been loaded.

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/IPreviewView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/IPreviewView.h
@@ -45,5 +45,6 @@ public:
   virtual double getAngle() const = 0;
   virtual void setAngle(double angle) = 0;
   virtual void setUpdateAngleButtonEnabled(bool enabled) = 0;
+  virtual void setTitle(const std::string &title) = 0;
 };
 } // namespace MantidQt::CustomInterfaces::ISISReflectometry

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.cpp
@@ -288,6 +288,10 @@ void PreviewPresenter::runSumBanks() {
 }
 
 void PreviewPresenter::runReduction() {
+  if (!m_model->getLoadedWs()) {
+    g_log.error("Unable to perform preview reduction because there is no run loaded");
+    return;
+  }
   m_view->disableMainWidget();
   m_view->setUpdateAngleButtonEnabled(false);
   // Ensure the angle is up to date

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.cpp
@@ -116,7 +116,7 @@ void PreviewPresenter::notifyLoadWorkspaceCompleted() {
     m_view->setAngle(*theta);
   }
 
-  auto runTitle = ws->getTitle();
+  auto const runTitle = ws->getTitle();
   m_view->setTitle(runTitle);
 
   // Clear the region selector to ensure all spectra are shown.

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.cpp
@@ -116,6 +116,9 @@ void PreviewPresenter::notifyLoadWorkspaceCompleted() {
     m_view->setAngle(*theta);
   }
 
+  auto runTitle = ws->getTitle();
+  m_view->setTitle(runTitle);
+
   // Clear the region selector to ensure all spectra are shown.
   m_regionSelector->clearWorkspace();
 

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewWidget.ui
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewWidget.ui
@@ -41,7 +41,14 @@
       </widget>
      </item>
      <item>
-      <widget class="QLineEdit" name="workspace_line_edit"/>
+      <widget class="QLineEdit" name="workspace_line_edit">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+      </widget>
      </item>
      <item>
       <widget class="QPushButton" name="load_button">
@@ -82,17 +89,35 @@
       </widget>
      </item>
      <item>
-      <spacer name="load_button_spacer">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
+      <widget class="QLabel" name="title_label">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
        </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>40</width>
-         <height>20</height>
-        </size>
+       <property name="font">
+        <font>
+         <pointsize>12</pointsize>
+        </font>
        </property>
-      </spacer>
+       <property name="text">
+        <string>Title:</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="title_display_label">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+      </widget>
      </item>
     </layout>
    </item>
@@ -110,7 +135,7 @@
         <x>0</x>
         <y>0</y>
         <width>980</width>
-        <height>546</height>
+        <height>551</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout_2">

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/QtPreviewView.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/QtPreviewView.cpp
@@ -25,6 +25,7 @@ QtPreviewView::QtPreviewView(QWidget *parent)
     : QWidget(parent), m_imageInfo(new MantidQt::MantidWidgets::ImageInfoWidgetMini(this)) {
   m_ui.setupUi(this);
   m_ui.statusbar_layout->addWidget(m_imageInfo);
+  m_ui.title_display_label->setWordWrap(true);
   connectSignals();
 }
 
@@ -66,4 +67,7 @@ void QtPreviewView::setAngle(double angle) {
 
 void QtPreviewView::setUpdateAngleButtonEnabled(bool enabled) { m_ui.update_button->setEnabled(enabled); }
 
+void QtPreviewView::setTitle(const std::string &title) {
+  m_ui.title_display_label->setText(QString::fromStdString(title));
+}
 } // namespace MantidQt::CustomInterfaces::ISISReflectometry

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/QtPreviewView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/QtPreviewView.h
@@ -47,6 +47,7 @@ public:
   double getAngle() const override;
   void setAngle(double angle) override;
   void setUpdateAngleButtonEnabled(bool enable) override;
+  void setTitle(const std::string &title) override;
 
 private:
   Ui::PreviewWidget m_ui;

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/SearchResult.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Runs/SearchResult.cpp
@@ -30,25 +30,20 @@ void SearchResult::parseRun(std::string const &runNumber) {
     addError("Run number is not specified");
 }
 
-/** Extract the group name and angle from the run title. Expects the title to
- * be in the format: "group_name th=angle". If it is not in this format, then
- * the group name is set to the full title, the angle is empty, and the error
- * message is set.
+/** Extract the group name and angle from the run title.
+ * If it is not in the expected format, then the group name is set to the full title
+ * the angle is empty, and the error message is set.
  */
 void SearchResult::parseMetadataFromTitle() {
-  static boost::regex titleFormatRegex("(.*)(th[:=]\\s*([0-9.\\-]+))(.*)");
-  boost::smatch matches;
-
-  if (!boost::regex_search(m_title, matches, titleFormatRegex)) {
+  auto titleAndTheta = parseTitleAndThetaFromRunTitle(m_title);
+  if (!titleAndTheta.is_initialized()) {
     m_groupName = m_title;
     addError("Theta was not specified in the run title.");
     return;
   }
 
-  constexpr auto preThetaGroup = 1;
-  constexpr auto thetaValueGroup = 3;
-  m_theta = matches[thetaValueGroup].str();
-  m_groupName = matches[preThetaGroup].str();
+  m_theta = titleAndTheta.get()[1];
+  m_groupName = titleAndTheta.get()[0];
 
   // Validate that the angle parses correctly
   auto const maybeTheta = parseTheta(m_theta);

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/LookupTable.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/LookupTable.cpp
@@ -43,7 +43,7 @@ boost::optional<LookupRow> LookupTable::findLookupRow(Row const &row, double tol
 }
 
 boost::optional<LookupRow> LookupTable::findLookupRow(PreviewRow const &previewRow, double tolerance) const {
-  auto title = previewRow.getLoadedWs()->getTitle();
+  auto title = !previewRow.getLoadedWs() ? EMPTY_SEARCH_TITLE : previewRow.getLoadedWs()->getTitle();
   auto titleAndTheta = parseTitleAndThetaFromRunTitle(title);
 
   if (titleAndTheta.is_initialized()) {

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/LookupTable.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/LookupTable.cpp
@@ -38,12 +38,12 @@ LookupTable::LookupTable(std::initializer_list<LookupRow> rowsIn) : m_lookupRows
 std::vector<LookupRow> const &LookupTable::rows() const { return m_lookupRows; }
 
 boost::optional<LookupRow> LookupTable::findLookupRow(Row const &row, double tolerance) const {
-  auto title = !row.getParent() ? EMPTY_SEARCH_TITLE : row.getParent()->name();
+  auto const &title = !row.getParent() ? EMPTY_SEARCH_TITLE : row.getParent()->name();
   return findLookupRow(title, row.theta(), tolerance);
 }
 
 boost::optional<LookupRow> LookupTable::findLookupRow(PreviewRow const &previewRow, double tolerance) const {
-  auto title = !previewRow.getLoadedWs() ? EMPTY_SEARCH_TITLE : previewRow.getLoadedWs()->getTitle();
+  auto const title = !previewRow.getLoadedWs() ? EMPTY_SEARCH_TITLE : previewRow.getLoadedWs()->getTitle();
   auto titleAndTheta = parseTitleAndThetaFromRunTitle(title);
 
   if (titleAndTheta.is_initialized()) {

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/LookupTable.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/LookupTable.h
@@ -37,9 +37,9 @@ public:
 private:
   std::vector<LookupRow> m_lookupRows;
 
+  boost::optional<LookupRow> findLookupRow(std::string const &title, boost::optional<double> const &, double) const;
   boost::optional<LookupRow> searchByTheta(std::vector<LookupRow> lookupRows, boost::optional<double> const &,
                                            double) const;
-  std::vector<LookupRow> searchByTitle(Row const &row) const;
   std::vector<LookupRow> findMatchingRegexes(std::string const &title) const;
   std::vector<LookupRow> findEmptyRegexes() const;
 };

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/ParseReflectometryStrings.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/ParseReflectometryStrings.cpp
@@ -10,6 +10,7 @@
 #include "MantidKernel/Strings.h"
 #include "MantidQtWidgets/Common/ParseKeyValueString.h"
 #include <boost/algorithm/string.hpp>
+#include <boost/regex.hpp>
 #include <set>
 namespace MantidQt::CustomInterfaces::ISISReflectometry {
 
@@ -203,6 +204,29 @@ boost::variant<TransmissionRunPair, std::vector<int>> parseTransmissionRuns(std:
       errorColumns.emplace_back(1);
     return errorColumns;
   }
+}
+
+/** Extract the group name and angle from the run title. Expects the title to
+ * be in the format: "group_name th=angle".
+ * If it is not in this format then boost::none is returned.
+ * If the format matches then the first element of the vector is the title and the second is theta.
+ */
+boost::optional<std::vector<std::string>> parseTitleAndThetaFromRunTitle(std::string const &runTitle) {
+  boost::smatch matches;
+  static const boost::regex runTitleFormatRegex("(.*)(th[:=]\\s*([0-9.\\-]+))(.*)");
+
+  if (!boost::regex_search(runTitle, matches, runTitleFormatRegex)) {
+    return boost::none;
+  }
+
+  std::vector<std::string> parsedResult;
+
+  constexpr auto preThetaGroup = 1;
+  constexpr auto thetaValueGroup = 3;
+  parsedResult.push_back(matches[preThetaGroup].str());
+  parsedResult.push_back(matches[thetaValueGroup].str());
+
+  return parsedResult;
 }
 
 } // namespace MantidQt::CustomInterfaces::ISISReflectometry

--- a/qt/scientific_interfaces/ISISReflectometry/Reduction/ParseReflectometryStrings.h
+++ b/qt/scientific_interfaces/ISISReflectometry/Reduction/ParseReflectometryStrings.h
@@ -47,6 +47,9 @@ boost::optional<std::map<std::string, std::string>> parseOptions(std::string con
 MANTIDQT_ISISREFLECTOMETRY_DLL
 boost::optional<boost::optional<std::string>> parseProcessingInstructions(std::string const &instructions);
 
+MANTIDQT_ISISREFLECTOMETRY_DLL
+boost::optional<std::vector<std::string>> parseTitleAndThetaFromRunTitle(std::string const &runTitle);
+
 } // namespace ISISReflectometry
 } // namespace CustomInterfaces
 } // namespace MantidQt

--- a/qt/scientific_interfaces/ISISReflectometry/TestHelpers/ModelCreationHelper.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/TestHelpers/ModelCreationHelper.cpp
@@ -5,12 +5,16 @@
 //   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 // SPDX - License - Identifier: GPL - 3.0 +
 #include "ModelCreationHelper.h"
+#include "MantidAPI/MatrixWorkspace.h"
+#include "MantidAPI/WorkspaceFactory.h"
 
 #include <utility>
 
 #include "../../ISISReflectometry/Reduction/Batch.h"
 
 namespace MantidQt::CustomInterfaces::ISISReflectometry::ModelCreationHelper {
+
+using namespace Mantid::API;
 
 namespace { // unnamed
 Row makeRowWithOutputNames(std::vector<std::string> const &outputNames) {
@@ -476,8 +480,25 @@ Instrument makeEmptyInstrument() {
 
 /* Preview */
 
-PreviewRow makePreviewRow(std::vector<std::string> const &runNumbers, double theta) {
+PreviewRow makePreviewRow(const double theta) {
+  const std::string title = "";
+  auto row = makePreviewRow(theta, title);
+  return row;
+}
+
+PreviewRow makePreviewRow(std::vector<std::string> const &runNumbers, const double theta) {
   auto row = PreviewRow(runNumbers);
+  row.setTheta(theta);
+  return row;
+}
+
+PreviewRow makePreviewRow(const double theta, const std::string &title) {
+  MatrixWorkspace_sptr loadedWS =
+      std::dynamic_pointer_cast<MatrixWorkspace>(WorkspaceFactory::Instance().create("Workspace2D", 1, 1, 1));
+  loadedWS->setTitle(title);
+
+  auto row = PreviewRow(std::vector<std::string>{"12345"});
+  row.setLoadedWs(loadedWS);
   row.setTheta(theta);
   return row;
 }

--- a/qt/scientific_interfaces/ISISReflectometry/TestHelpers/ModelCreationHelper.h
+++ b/qt/scientific_interfaces/ISISReflectometry/TestHelpers/ModelCreationHelper.h
@@ -105,7 +105,10 @@ MANTIDQT_ISISREFLECTOMETRY_DLL Instrument makeInstrument();
 MANTIDQT_ISISREFLECTOMETRY_DLL Instrument makeEmptyInstrument();
 
 /* Preview */
-MANTIDQT_ISISREFLECTOMETRY_DLL PreviewRow makePreviewRow(std::vector<std::string> const &runNumbers, double angle);
+MANTIDQT_ISISREFLECTOMETRY_DLL PreviewRow makePreviewRow(const double theta);
+MANTIDQT_ISISREFLECTOMETRY_DLL PreviewRow makePreviewRow(std::vector<std::string> const &runNumbers,
+                                                         const double theta);
+MANTIDQT_ISISREFLECTOMETRY_DLL PreviewRow makePreviewRow(const double theta, const std::string &title);
 
 } // namespace ModelCreationHelper
 } // namespace ISISReflectometry

--- a/qt/scientific_interfaces/ISISReflectometry/test/Preview/MockPreviewView.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Preview/MockPreviewView.h
@@ -27,5 +27,6 @@ public:
   MOCK_METHOD(double, getAngle, (), (const, override));
   MOCK_METHOD(void, setAngle, (double), (override));
   MOCK_METHOD(void, setUpdateAngleButtonEnabled, (bool), (override));
+  MOCK_METHOD(void, setTitle, (const std::string &), (override));
 };
 } // namespace MantidQt::CustomInterfaces::ISISReflectometry

--- a/qt/scientific_interfaces/ISISReflectometry/test/Preview/PreviewPresenterTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Preview/PreviewPresenterTest.h
@@ -169,6 +169,17 @@ public:
     presenter.notifyLoadWorkspaceCompleted();
   }
 
+  void test_run_title_is_set_when_workspace_loaded() {
+    auto mockModel = makeModel();
+    auto mockView = std::make_unique<MockPreviewView>();
+
+    expectLoadWorkspaceCompletedSetsRunTitle(*mockView, *mockModel);
+
+    auto deps = packDeps(mockView.get(), std::move(mockModel));
+    auto presenter = PreviewPresenter(std::move(deps));
+    presenter.notifyLoadWorkspaceCompleted();
+  }
+
   void test_notify_load_workspace_error_reenables_load_widgets() {
     auto mockModel = makeModel();
     auto mockView = std::make_unique<MockPreviewView>();
@@ -634,6 +645,13 @@ private:
     EXPECT_CALL(mockModel, getLoadedWs()).Times(2).WillOnce(Return(ws));
     EXPECT_CALL(mockModel, getDefaultTheta()).Times(1).WillOnce(Return(angle));
     EXPECT_CALL(mockView, setAngle(angle)).Times(1);
+  }
+
+  void expectLoadWorkspaceCompletedSetsRunTitle(MockPreviewView &mockView, MockPreviewModel &mockModel) {
+    auto ws = createRectangularDetectorWorkspace();
+
+    EXPECT_CALL(mockModel, getLoadedWs()).Times(2).WillOnce(Return(ws));
+    EXPECT_CALL(mockView, setTitle(ws->getTitle())).Times(1);
   }
 
   void expectInstViewModelUpdatedWithLoadedWorkspace(MockPreviewModel &mockModel,

--- a/qt/scientific_interfaces/ISISReflectometry/test/Reduction/LookupTableTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Reduction/LookupTableTest.h
@@ -335,6 +335,18 @@ public:
     TS_ASSERT_EQUALS(emptyRegexRow, foundLookupRow);
   }
 
+  void test_no_loaded_ws_matches_only_empty_regex_for_preview_row() {
+    auto constexpr angle = 2.3;
+    auto emptyRegexRow = ModelCreationHelper::makeLookupRow(angle, boost::none);
+    auto regexRow = ModelCreationHelper::makeLookupRow(angle, boost::regex("Ay"));
+    auto table = LookupTable{emptyRegexRow, regexRow};
+
+    auto row = ModelCreationHelper::makePreviewRow({"1234"}, angle);
+    const auto foundLookupRow = table.findLookupRow(row, m_exactMatchTolerance);
+    TS_ASSERT(foundLookupRow);
+    TS_ASSERT_EQUALS(emptyRegexRow, foundLookupRow);
+  }
+
   void test_get_wildcard_row_returns_wildcard_row() {
     auto constexpr angle = 2.3;
     auto wildcardRow = ModelCreationHelper::makeWildcardLookupRow();

--- a/qt/scientific_interfaces/ISISReflectometry/test/Reduction/LookupTableTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Reduction/LookupTableTest.h
@@ -14,6 +14,7 @@
 #include <cxxtest/TestSuite.h>
 
 using namespace MantidQt::CustomInterfaces::ISISReflectometry;
+using namespace std::string_literals;
 
 class LookupTableTest : public CxxTest::TestSuite {
 public:
@@ -31,7 +32,7 @@ public:
     LookupTable table = ModelCreationHelper::makeLookupTableWithTwoAnglesAndWildcard();
 
     for (const auto angle : {0.5, 2.3}) {
-      auto row = makePreviewRow(angle);
+      auto row = ModelCreationHelper::makePreviewRow(angle);
       const auto lookupRow = table.findLookupRow(row, m_exactMatchTolerance);
       assertLookupRowAngle(lookupRow, angle);
     }
@@ -53,7 +54,7 @@ public:
 
     const double matchTolerance = 0.01;
     for (const auto angle : {(0.5 - matchTolerance), (2.3 + matchTolerance)}) {
-      auto row = makePreviewRow(angle);
+      auto row = ModelCreationHelper::makePreviewRow(angle);
       const auto lookupRow = table.findLookupRow(row, matchTolerance);
       assertLookupRowAngle(lookupRow, angle, matchTolerance);
     }
@@ -76,7 +77,7 @@ public:
     LookupTable table = ModelCreationHelper::makeLookupTableWithTwoAnglesAndWildcard();
 
     for (const auto angle : {1.2, 3.4}) {
-      auto row = makePreviewRow(angle);
+      auto row = ModelCreationHelper::makePreviewRow(angle);
       const auto lookupRow = table.findLookupRow(row, m_exactMatchTolerance);
       TS_ASSERT(lookupRow)
       const auto foundAngle = lookupRow->thetaOrWildcard();
@@ -98,7 +99,7 @@ public:
     LookupTable table = ModelCreationHelper::makeLookupTableWithTwoAngles();
 
     constexpr double notThere = 999;
-    auto row = makePreviewRow(notThere);
+    auto row = ModelCreationHelper::makePreviewRow(notThere);
     const auto lookupRow = table.findLookupRow(row, m_exactMatchTolerance);
     TS_ASSERT(!lookupRow)
   }
@@ -116,7 +117,7 @@ public:
     LookupTable table = ModelCreationHelper::makeEmptyLookupTable();
 
     constexpr double notThere = 0.5;
-    auto row = makePreviewRow(notThere);
+    auto row = ModelCreationHelper::makePreviewRow(notThere);
     const auto lookupRow = table.findLookupRow(row, m_exactMatchTolerance);
     TS_ASSERT(!lookupRow)
   }
@@ -128,6 +129,19 @@ public:
 
     auto group = Group("El Em En Oh", {ModelCreationHelper::makeRow(angle)});
     const auto foundLookupRow = table.findLookupRow(*group[0], m_exactMatchTolerance);
+    TS_ASSERT(foundLookupRow)
+    if (foundLookupRow)
+      TS_ASSERT_EQUALS(*foundLookupRow, expectedLookupRow)
+  }
+
+  void test_searching_by_theta_and_title_found_for_preview_row() {
+    auto constexpr angle = 2.3;
+    auto expectedLookupRow = ModelCreationHelper::makeLookupRow(angle, boost::regex("El"));
+    auto table = LookupTable{ModelCreationHelper::makeLookupRow(angle, boost::regex("Ay")), expectedLookupRow};
+
+    auto title = "El Em En Oh"s;
+    auto row = ModelCreationHelper::makePreviewRow(angle, title);
+    const auto foundLookupRow = table.findLookupRow(row, m_exactMatchTolerance);
     TS_ASSERT(foundLookupRow)
     if (foundLookupRow)
       TS_ASSERT_EQUALS(*foundLookupRow, expectedLookupRow)
@@ -146,6 +160,19 @@ public:
       TS_ASSERT_EQUALS(*foundLookupRow, expectedLookupRow)
   }
 
+  void test_searching_by_theta_and_title_found_with_wildcard_present_for_preview_row() {
+    auto constexpr angle = 2.3;
+    auto expectedLookupRow = ModelCreationHelper::makeLookupRow(angle, boost::regex("El"));
+    auto table = LookupTable{ModelCreationHelper::makeLookupRow(angle, boost::regex("Ay")), expectedLookupRow,
+                             ModelCreationHelper::makeWildcardLookupRow()};
+
+    auto row = ModelCreationHelper::makePreviewRow(angle, "El Em En Oh"s);
+    const auto foundLookupRow = table.findLookupRow(row, m_exactMatchTolerance);
+    TS_ASSERT(foundLookupRow)
+    if (foundLookupRow)
+      TS_ASSERT_EQUALS(*foundLookupRow, expectedLookupRow)
+  }
+
   void test_searching_by_theta_found_but_title_not_found_returns_none() {
     auto constexpr angle = 2.3;
     auto table = LookupTable{ModelCreationHelper::makeLookupRow(angle, boost::regex("Ay")),
@@ -156,13 +183,35 @@ public:
     TS_ASSERT(!foundLookupRow)
   }
 
-  void test_searching_by_title_found_but_theta_not_found_returns_none() {
+  void test_searching_by_theta_found_but_title_not_found_returns_none_for_preview_row() {
     auto constexpr angle = 2.3;
     auto table = LookupTable{ModelCreationHelper::makeLookupRow(angle, boost::regex("Ay")),
                              ModelCreationHelper::makeLookupRow(angle, boost::regex("El"))};
 
-    auto group = Group("En Oh", {ModelCreationHelper::makeRow(angle)});
+    auto row = ModelCreationHelper::makePreviewRow(angle, "En Oh"s);
+    const auto foundLookupRow = table.findLookupRow(row, m_exactMatchTolerance);
+    TS_ASSERT(!foundLookupRow)
+  }
+
+  void test_searching_by_title_found_but_theta_not_found_returns_none() {
+    auto constexpr angle = 2.3;
+    auto constexpr notThere = 1.5;
+    auto table = LookupTable{ModelCreationHelper::makeLookupRow(angle, boost::regex("Ay")),
+                             ModelCreationHelper::makeLookupRow(angle, boost::regex("El"))};
+
+    auto group = Group("Ay Oh", {ModelCreationHelper::makeRow(notThere)});
     const auto foundLookupRow = table.findLookupRow(*group[0], m_exactMatchTolerance);
+    TS_ASSERT(!foundLookupRow)
+  }
+
+  void test_searching_by_title_found_but_theta_not_found_returns_none_for_preview_row() {
+    auto constexpr angle = 2.3;
+    auto constexpr notThere = 1.5;
+    auto table = LookupTable{ModelCreationHelper::makeLookupRow(angle, boost::regex("Ay")),
+                             ModelCreationHelper::makeLookupRow(angle, boost::regex("El"))};
+
+    auto row = ModelCreationHelper::makePreviewRow(notThere, "Ay Oh"s);
+    const auto foundLookupRow = table.findLookupRow(row, m_exactMatchTolerance);
     TS_ASSERT(!foundLookupRow)
   }
 
@@ -178,14 +227,40 @@ public:
     TS_ASSERT_EQUALS(wildcardRow, foundLookupRow)
   }
 
-  void test_searching_by_title_found_but_theta_not_found_returns_wildcard() {
+  void test_searching_by_theta_found_but_title_not_found_returns_wildcard_for_preview_row() {
     auto constexpr angle = 2.3;
     auto wildcardRow = ModelCreationHelper::makeWildcardLookupRow();
     auto table = LookupTable{ModelCreationHelper::makeLookupRow(angle, boost::regex("Ay")),
                              ModelCreationHelper::makeLookupRow(angle, boost::regex("El")), wildcardRow};
 
-    auto group = Group("En Oh", {ModelCreationHelper::makeRow(angle)});
+    auto row = ModelCreationHelper::makePreviewRow(angle, "En Oh"s);
+    const auto foundLookupRow = table.findLookupRow(row, m_exactMatchTolerance);
+    TS_ASSERT(foundLookupRow)
+    TS_ASSERT_EQUALS(wildcardRow, foundLookupRow)
+  }
+
+  void test_searching_by_title_found_but_theta_not_found_returns_wildcard() {
+    auto constexpr angle = 2.3;
+    auto constexpr notThere = 1.5;
+    auto wildcardRow = ModelCreationHelper::makeWildcardLookupRow();
+    auto table = LookupTable{ModelCreationHelper::makeLookupRow(angle, boost::regex("Ay")),
+                             ModelCreationHelper::makeLookupRow(angle, boost::regex("El")), wildcardRow};
+
+    auto group = Group("Ay Oh", {ModelCreationHelper::makeRow(notThere)});
     const auto foundLookupRow = table.findLookupRow(*group[0], m_exactMatchTolerance);
+    TS_ASSERT(foundLookupRow)
+    TS_ASSERT_EQUALS(wildcardRow, foundLookupRow)
+  }
+
+  void test_searching_by_title_found_but_theta_not_found_returns_wildcard_for_preview_row() {
+    auto constexpr angle = 2.3;
+    auto constexpr notThere = 1.5;
+    auto wildcardRow = ModelCreationHelper::makeWildcardLookupRow();
+    auto table = LookupTable{ModelCreationHelper::makeLookupRow(angle, boost::regex("Ay")),
+                             ModelCreationHelper::makeLookupRow(angle, boost::regex("El")), wildcardRow};
+
+    auto row = ModelCreationHelper::makePreviewRow(notThere, "Ay Oh"s);
+    const auto foundLookupRow = table.findLookupRow(row, m_exactMatchTolerance);
     TS_ASSERT(foundLookupRow)
     TS_ASSERT_EQUALS(wildcardRow, foundLookupRow)
   }
@@ -202,6 +277,18 @@ public:
     TS_ASSERT_EQUALS(regexRow, foundLookupRow)
   }
 
+  void test_searching_by_title_matches_regex_over_wildcard_for_preview_row() {
+    auto constexpr angle = 2.3;
+    auto wildcardRow = ModelCreationHelper::makeWildcardLookupRow();
+    auto regexRow = ModelCreationHelper::makeLookupRow(angle, boost::regex(".*"));
+    auto table = LookupTable{wildcardRow, regexRow};
+
+    auto row = ModelCreationHelper::makePreviewRow(angle, "En Oh"s);
+    const auto foundLookupRow = table.findLookupRow(row, m_exactMatchTolerance);
+    TS_ASSERT(foundLookupRow)
+    TS_ASSERT_EQUALS(regexRow, foundLookupRow)
+  }
+
   void test_searching_by_title_matches_empty_regex() {
     auto constexpr angle = 2.3;
     auto emptyRegexRow = ModelCreationHelper::makeLookupRow(angle, boost::none);
@@ -209,6 +296,17 @@ public:
 
     auto group = Group("En Oh", {ModelCreationHelper::makeRow(angle)});
     const auto foundLookupRow = table.findLookupRow(*group[0], m_exactMatchTolerance);
+    TS_ASSERT(foundLookupRow)
+    TS_ASSERT_EQUALS(emptyRegexRow, foundLookupRow)
+  }
+
+  void test_searching_by_title_matches_empty_regex_for_preview_row() {
+    auto constexpr angle = 2.3;
+    auto emptyRegexRow = ModelCreationHelper::makeLookupRow(angle, boost::none);
+    auto table = LookupTable{emptyRegexRow};
+
+    auto row = ModelCreationHelper::makePreviewRow(angle, "En Oh"s);
+    const auto foundLookupRow = table.findLookupRow(row, m_exactMatchTolerance);
     TS_ASSERT(foundLookupRow)
     TS_ASSERT_EQUALS(emptyRegexRow, foundLookupRow)
   }
@@ -221,6 +319,18 @@ public:
 
     auto group = Group("", {ModelCreationHelper::makeRow(angle)});
     const auto foundLookupRow = table.findLookupRow(*group[0], m_exactMatchTolerance);
+    TS_ASSERT(foundLookupRow);
+    TS_ASSERT_EQUALS(emptyRegexRow, foundLookupRow);
+  }
+
+  void test_empty_title_matches_only_empty_regex_for_preview_row() {
+    auto constexpr angle = 2.3;
+    auto emptyRegexRow = ModelCreationHelper::makeLookupRow(angle, boost::none);
+    auto regexRow = ModelCreationHelper::makeLookupRow(angle, boost::regex("Ay"));
+    auto table = LookupTable{emptyRegexRow, regexRow};
+
+    auto row = ModelCreationHelper::makePreviewRow(angle, ""s);
+    const auto foundLookupRow = table.findLookupRow(row, m_exactMatchTolerance);
     TS_ASSERT(foundLookupRow);
     TS_ASSERT_EQUALS(emptyRegexRow, foundLookupRow);
   }
@@ -257,6 +367,18 @@ public:
     TS_ASSERT_EQUALS(nonRegexRow, foundLookupRow)
   }
 
+  void test_searching_with_no_matching_title_but_matching_theta_with_matching_title_present_for_preview_row() {
+    auto angle = 0.7;
+    auto regexRow = ModelCreationHelper::makeLookupRow(2.3, boost::regex("Ay"));
+    auto nonRegexRow = ModelCreationHelper::makeLookupRow(angle, boost::none);
+    auto table = LookupTable{regexRow, nonRegexRow};
+
+    auto row = ModelCreationHelper::makePreviewRow(angle, "Ay Bee"s);
+    const auto foundLookupRow = table.findLookupRow(row, m_exactMatchTolerance);
+    TS_ASSERT(foundLookupRow)
+    TS_ASSERT_EQUALS(nonRegexRow, foundLookupRow)
+  }
+
   void test_multiple_row_title_matches_are_invalid() {
     auto constexpr angle = 2.3;
     auto table = LookupTable{ModelCreationHelper::makeLookupRow(angle, boost::regex("A.*")),
@@ -264,6 +386,15 @@ public:
 
     auto group = Group("AAA", {ModelCreationHelper::makeRow(angle)});
     TS_ASSERT_THROWS(table.findLookupRow(*group[0], m_exactMatchTolerance), MultipleRowsFoundException const &)
+  }
+
+  void test_multiple_row_title_matches_are_invalid_for_preview_row() {
+    auto constexpr angle = 2.3;
+    auto table = LookupTable{ModelCreationHelper::makeLookupRow(angle, boost::regex("A.*")),
+                             ModelCreationHelper::makeLookupRow(angle, boost::regex("AA.*"))};
+
+    auto row = ModelCreationHelper::makePreviewRow(angle, "AAA"s);
+    TS_ASSERT_THROWS(table.findLookupRow(row, m_exactMatchTolerance), MultipleRowsFoundException const &)
   }
 
   void test_get_index_for_lookup_row() {
@@ -344,11 +475,5 @@ private:
         TS_ASSERT_DELTA(*foundAngle, expected, match_tolerance)
       }
     }
-  }
-
-  PreviewRow makePreviewRow(double theta) {
-    auto previewRow = PreviewRow(std::vector<std::string>{"12345"});
-    previewRow.setTheta(theta);
-    return previewRow;
   }
 };

--- a/qt/scientific_interfaces/ISISReflectometry/test/Reduction/ParseReflectometryStringsTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Reduction/ParseReflectometryStringsTest.h
@@ -281,6 +281,34 @@ public:
     TS_ASSERT_EQUALS(boost::get<TransmissionRunPair>(result), expected);
   }
 
+  void testParseTitleAndThetaFromRunTitle() {
+    auto runTitle = "ASF SM=0.75 th=0.8 ['SM2']=0.75";
+    auto result = parseTitleAndThetaFromRunTitle(runTitle);
+    std::vector<std::string> expected = {"ASF SM=0.75 ", "0.8"};
+    TS_ASSERT(result.is_initialized());
+    TS_ASSERT_EQUALS(result.get(), expected);
+  }
+
+  void testParseTitleAndThetaFromRunTitleReturnsNoneForEmptyString() {
+    auto runTitle = "";
+    auto result = parseTitleAndThetaFromRunTitle(runTitle);
+    TS_ASSERT(!result.is_initialized());
+  }
+
+  void testParseTitleAndThetaFromRunTitleWithThetaOnly() {
+    auto runTitle = "th=0.8";
+    auto result = parseTitleAndThetaFromRunTitle(runTitle);
+    std::vector<std::string> expected = {"", "0.8"};
+    TS_ASSERT(result.is_initialized());
+    TS_ASSERT_EQUALS(result.get(), expected);
+  }
+
+  void testParseTitleAndThetaFromRunTitleReturnsNoneForNoTheta() {
+    auto runTitle = "ASF SM=0.75";
+    auto result = parseTitleAndThetaFromRunTitle(runTitle);
+    TS_ASSERT(!result.is_initialized());
+  }
+
 private:
   enum class Result : int { Value = 0, Error = 1 };
 


### PR DESCRIPTION
**Description of work**

**Purpose of work**
<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
-->
This is part two of the fix for the linked issue. This PR adds the functionality to match against lookup rows using both run title and angle, rather than just angle. During testing I also found a crash that occurs when a reduction is triggered without the loaded workspace, so this PR also implements a simple fix for that.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**Summary of work**
<!-- Please provide a short, high level description of the work that was done.
-->
This PR moves the logic for extracting the title and theta values from the logs `run_title` entry out of `SearchResult` and into `ParseReflectometryStrings`. This was to allow the logic to be re-used in the `LookupTable` class for finding the title to match against from a `PreviewRow`.

I have also changed the lookup row matching logic in `LookupTable` so that both a `Row` and `PreviewRow` share the same logic and just retrieve the title for matching in a different way.

The full run title is now displayed at the top of the Reduction Preview tab, as requested by our scientists. I have used a label to display this information, as our scientists do not need to edit it and it seemed to give the best behaviour in terms of resizing and word wrap.

Finally I have also included a small change to check if a loaded workspace is available in `PreviewPresenter::runReduction` to fix the crash described in #35825.

**To test:**

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->
- See instructions in the relevant issues.

- For #35704, the angle and title matching can be tested by selecting a region on the instrument view and slice viewer (this will need to be done to get the reduction to complete successfully anyway) and then clicking the `Apply` button at the bottom right of the dialog. This should set the `ROI` and `ROI Detector IDs` values against the correct row in the lookup table on the Experiment Settings tab. To thoroughly test the matching you will need to try different title values - i.e. using the title "seg" in the Experiment Settings lookup row will match the title of run `INTER45455`, while something like "test" will not.
 
Fixes #35704 and fixes #35825. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.