### PR TITLE
Make CombineDiffCal more resilient against arbitrary types in the columns

### DIFF
--- a/Framework/Algorithms/inc/MantidAlgorithms/CombineDiffCal.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/CombineDiffCal.h
@@ -25,7 +25,7 @@ public:
   std::map<std::string, std::string> validateInputs() override;
 
 private:
-  API::ITableWorkspace_sptr sortTableWorkspace(DataObjects::TableWorkspace_sptr &table);
+  DataObjects::TableWorkspace_sptr sortTableWorkspace(DataObjects::TableWorkspace_sptr &table);
   void init() override;
   void exec() override;
 };


### PR DESCRIPTION
CombineDiffCal was using a function to get the values from the input tables that assumed the input types. This changes to an accessor that properly casts the value in the cell. 

**To test:**

Create a previous calibration with floats rather than doubles for the DIFC column

*There is no associated issue,* but it is related to [EWM1965](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=1965)

*This does not require release notes* because it doesn't really change the functionality that was added during this release in #35800.

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.