### PR TITLE
PDCalibration spectrumnumber

### DIFF
--- a/Framework/Algorithms/inc/MantidAlgorithms/PDCalibration.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/PDCalibration.h
@@ -39,6 +39,8 @@ private:
   API::MatrixWorkspace_sptr loadAndBin();
   API::MatrixWorkspace_sptr rebin(API::MatrixWorkspace_sptr wksp);
   API::MatrixWorkspace_sptr load(const std::string &filename);
+  std::set<detid_t> detIdsForTable();
+  void createCalTableHeader();
   void createCalTableFromExisting();
   void createCalTableNew();
   void createInformationWorkspaces();
@@ -64,8 +66,10 @@ private:
   API::ITableWorkspace_sptr m_peakHeightTable{nullptr};
   std::vector<double> m_peaksInDspacing;
   std::map<detid_t, size_t> m_detidToRow;
-  double m_tofMin{0.}; // first bin boundary when rebinning in TOF (user input)
-  double m_tofMax{0.}; // last bin boundary when rebinning in TOF (user input)
+  int m_startWorkspaceIndex; ///< start index
+  int m_stopWorkspaceIndex;  ///< stop index (workspace index of the last spectrum included)
+  double m_tofMin{0.};       ///< first bin boundary when rebinning in TOF (user input)
+  double m_tofMax{0.};       ///< last bin boundary when rebinning in TOF (user input)
   double m_tzeroMin{0.};
   double m_tzeroMax{0.};
   double m_difaMin{0.};

--- a/Framework/Algorithms/src/CombineDiffCal.cpp
+++ b/Framework/Algorithms/src/CombineDiffCal.cpp
@@ -190,7 +190,7 @@ std::shared_ptr<Mantid::API::TableRow> binarySearchForRow(const API::ITableWorks
 }
 
 void addRowFromPreviousCalibration(DataObjects::TableWorkspace_sptr &ws,
-                                   const DataObjects::TableWorkspace_sptr &previousTable, const int rowNum) {
+                                   const DataObjects::TableWorkspace_sptr &previousTable, const std::size_t rowNum) {
   // get the old values
   const int detid = previousTable->cell_cast<int>(rowNum, 0);
   const double difc = previousTable->cell_cast<double>(rowNum, 1);

--- a/Framework/Algorithms/src/FitPeaks.cpp
+++ b/Framework/Algorithms/src/FitPeaks.cpp
@@ -281,7 +281,9 @@ void FitPeaks::init() {
       "and -3 for non-converged fitting.");
 
   // properties about fitting range and criteria
-  declareProperty(PropertyNames::START_WKSP_INDEX, EMPTY_INT(), "Starting workspace index for fit");
+  auto mustBePositive = std::make_shared<BoundedValidator<int>>();
+  mustBePositive->setLower(0);
+  declareProperty(PropertyNames::START_WKSP_INDEX, 0, mustBePositive, "Starting workspace index for fit");
   declareProperty(PropertyNames::STOP_WKSP_INDEX, EMPTY_INT(),
                   "Last workspace index to fit (which is included). "
                   "If a value larger than the workspace index of last spectrum, "
@@ -558,10 +560,7 @@ void FitPeaks::processInputs() {
 
   // spectra to fit
   int start_wi = getProperty(PropertyNames::START_WKSP_INDEX);
-  if (isEmpty(start_wi))
-    m_startWorkspaceIndex = 0;
-  else
-    m_startWorkspaceIndex = static_cast<size_t>(start_wi);
+  m_startWorkspaceIndex = static_cast<size_t>(start_wi);
 
   // last spectrum's workspace index, which is included
   int stop_wi = getProperty(PropertyNames::STOP_WKSP_INDEX);

--- a/Framework/Algorithms/src/FitPeaks.cpp
+++ b/Framework/Algorithms/src/FitPeaks.cpp
@@ -442,6 +442,18 @@ void FitPeaks::init() {
 std::map<std::string, std::string> FitPeaks::validateInputs() {
   map<std::string, std::string> issues;
 
+  // check that min/max spectra indices make sense - only matters if both are specified
+  if (!(isDefault(PropertyNames::START_WKSP_INDEX) && isDefault(PropertyNames::START_WKSP_INDEX))) {
+    const int startIndex = getProperty(PropertyNames::START_WKSP_INDEX);
+    const int stopIndex = getProperty(PropertyNames::STOP_WKSP_INDEX);
+    if (startIndex > stopIndex) {
+      const std::string msg =
+          PropertyNames::START_WKSP_INDEX + " must be less than or equal to " + PropertyNames::STOP_WKSP_INDEX;
+      issues[PropertyNames::START_WKSP_INDEX] = msg;
+      issues[PropertyNames::STOP_WKSP_INDEX] = msg;
+    }
+  }
+
   // check that the peak parameters are in parallel properties
   bool haveCommonPeakParameters(false);
   std::vector<string> suppliedParameterNames = getProperty(PropertyNames::PEAK_PARAM_NAMES);

--- a/Framework/Algorithms/src/PDCalibration.cpp
+++ b/Framework/Algorithms/src/PDCalibration.cpp
@@ -188,7 +188,9 @@ const std::string PDCalibration::summary() const {
 void PDCalibration::init() {
   declareProperty(std::make_unique<WorkspaceProperty<MatrixWorkspace>>("InputWorkspace", "", Direction::InOut),
                   "Input signal workspace");
-  declareProperty("StartWorkspaceIndex", EMPTY_INT(), "Starting workspace index for fit");
+  auto mustBePositive = std::make_shared<BoundedValidator<int>>();
+  mustBePositive->setLower(0);
+  declareProperty("StartWorkspaceIndex", 0, mustBePositive, "Starting workspace index for fit");
   declareProperty("StopWorkspaceIndex", EMPTY_INT(),
                   "Last workspace index to fit (which is included). "
                   "If a value larger than the workspace index of last spectrum, "
@@ -439,10 +441,9 @@ void PDCalibration::exec() {
   m_uncalibratedWS = loadAndBin();
   setProperty("InputWorkspace", m_uncalibratedWS);
 
-  m_startWorkspaceIndex = isDefault("StartWorkspaceIndex") ? 0 : getProperty("StartWorkspaceIndex");
-  m_stopWorkspaceIndex = isDefault("StartWorkspaceIndex")
-                             ? static_cast<int>(m_uncalibratedWS->getNumberHistograms() - 1)
-                             : getProperty("StopWorkspaceIndex");
+  m_startWorkspaceIndex = getProperty("StartWorkspaceIndex");
+  m_stopWorkspaceIndex = isDefault("StopWorkspaceIndex") ? static_cast<int>(m_uncalibratedWS->getNumberHistograms() - 1)
+                                                         : getProperty("StopWorkspaceIndex");
 
   auto uncalibratedEWS = std::dynamic_pointer_cast<EventWorkspace>(m_uncalibratedWS);
   auto isEvent = bool(uncalibratedEWS);

--- a/docs/source/algorithms/PDCalibration-v1.rst
+++ b/docs/source/algorithms/PDCalibration-v1.rst
@@ -39,7 +39,7 @@ If more than one constant is requested, the result that has the lowest
 <https://en.wikipedia.org/wiki/Reduced_chi-squared_statistic>`_ is
 returned. This favors using less parameters.
 
-A mask workspace is created, named "OutputCalibrationTable" + '_mask',
+A mask workspace is created, named with the ``OutputCalibrationTable`` parameter + ``_mask``,
 with uncalibrated pixels masked.
 
 The resulting calibration table can be saved with
@@ -47,12 +47,14 @@ The resulting calibration table can be saved with
 applied to a workspace with :ref:`algm-AlignDetectors`. There are also
 three workspaces placed in the ``DiagnosticWorkspace`` group. They are:
 
-* evaluated fit functions (``_fitted``)
-* raw peak fit values (``_fitparam``)
-* contain the fitted positions in dspace( ``_dspacing``)
-* peak widths (``_width``)
-* peak heights (``_height``)
-* instrument resolution (delta-d/d ``_resolution``)
+* evaluated fit functions (``_fitted``) which is the ``OutputPeakParametersWorkspace`` from :ref:`FitPeaks <algm-FitPeaks>`
+* raw peak fit values (``_fitparam``) which is the ``FittedPeaksWorkspace`` from :ref:`FitPeaks <algm-FitPeaks>`
+* uncertainties in raw fit values (``_fiterror``) which is the ``OutputParameterFitErrorsWorkspace`` from :ref:`FitPeaks <algm-FitPeaks>` when ``UseChisSq=True`` is set
+* contain the fitted positions in dspace( ``_dspacing``) derived from the effective peak parameters
+* peak widths (``_width``) derived from the effective peak parameters
+* peak heights (``_height``) derived from the effective peak parameters
+* instrument resolution (delta-d/d ``_resolution``) derived from the average of effective width/height of each peak.
+  This is only correct for Gaussian and Lorentzian peak shapes
 
 Since multiple peak shapes can be used,
 see the documentation for the individual :ref:`fit functions
@@ -61,6 +63,14 @@ values displayed in the diagnostic tables. For ``Gaussian`` and
 ``Lorentzian``, the widths and resolution are converted to values that
 can be directly compared with the results of
 :ref:`algm-EstimateResolutionDiffraction`.
+
+Limiting Spectra Calibrated
+---------------------------
+
+Supplying ``StartWorkspaceIndex`` and/or ``StopWorkspaceIndex`` will limit the spectra that are fitted.
+Only those that are fitted will exist in the output table, ``OutputCalibrationTable``.
+:ref:`CombineDiffCal <algm-CombineDiffCal>` can accept input of partial instrument calibration as the ``GroupedCalibration`` and will copy all other values fom the ``PixelCalibration``.
+In this mode, the ``CalibrationWorkspace`` supplied to :ref:`CombineDiffCal <algm-CombineDiffCal>`  should still be the ``InputWorkspace`` supplied to ``PDCalibration``.
 
 Usage
 -----

--- a/docs/source/release/v6.8.0/Diffraction/Powder/New_features/35837.rst
+++ b/docs/source/release/v6.8.0/Diffraction/Powder/New_features/35837.rst
@@ -1,0 +1,1 @@
+:ref:`PDCalibration <algm-PDCalibration>` has two new parameters, ``StartWorkspaceIndex`` and ``StopWorkspaceIndex``, which limit which spectra are calibrated


### PR DESCRIPTION
For use at SNAP, `PDCalibration` gets run multiple times for individual portions of the instrument. Rather than requiring the user to `ExtractSpectra` + `PDCalibration`, this adds the ability for users to supply the range of workspace indices directly to `PDCalibration`.

There is also a fix for a casting issue in `CombineDiffCal` that was partially fixed in #35834.

**To test:**

Run `PDCalibration` on a single spectrum of a grouped input workspace.

*There is no associated issue,* but this is associated with [EWM1965](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=1965)

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.