### PR TITLE
Remove ZenHub references from dev docs

### DIFF
--- a/dev-docs/source/GettingStarted/GettingStarted.rst
+++ b/dev-docs/source/GettingStarted/GettingStarted.rst
@@ -44,11 +44,6 @@ Add the following lines to ``~/.ssh/config``:
 
 If you need further help, ask another developer at the facility how to configure ssh.
 
-
-Setting up GitHub
-#################
-Please install the ZenHub Browser extension from this `page <https://www.zenhub.com/extension>`_.
-
 Building Mantid
 ###############
 See :ref:`BuildingWithCMake` for information about building Mantid.

--- a/dev-docs/source/IssueTracking.rst
+++ b/dev-docs/source/IssueTracking.rst
@@ -113,19 +113,6 @@ to refer to either an issue or a PR on this page*)
   PR is still ongoing, and you don't want a review yet. **REMEMBER TO
   REMOVE IT ONCE YOUR WORK IS READY FOR REVIEW**
 
-
-.. _IssueTrackingZenHub:
-
-ZenHub
-^^^^^^
-
-Using the ZenHub browser extension set an estimate, this should be the number of
-days you expect to take from begining to work on an issue, to opening a pull-request about it.
-Once you actually begin working on the issue change the pipeline to In Progress,
-then again to Review/QA when you open a pull-request for it. This will be used to to aid with
-future estimations of time for an issue.
-
-
 Filtering Issues
 ^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
**Description of work**
We're not using ZenHub any more, so here it's removed from our developer documentation.

**To test:**
Check no warnings when building `dev-docs-html`

*There is no associated issue.*


*This does not require release notes* because **it's a change to developer documentation only**


#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper pr0cess, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.