### PR TITLE
Prevent segmentation fault when running CrystalFieldFit with multiple sites and resolution models

### DIFF
--- a/Framework/CurveFitting/src/Functions/CrystalFieldControl.cpp
+++ b/Framework/CurveFitting/src/Functions/CrystalFieldControl.cpp
@@ -58,24 +58,24 @@ void CrystalFieldControl::setAttribute(const std::string &name, const API::IFunc
     } else if (name == "FWHMs") {
       const size_t nSpec = m_temperatures.size();
       m_FWHMs = attr.asVector();
-      auto frontValue = m_FWHMs.front();
+      if (m_FWHMs.empty())
+        return;
       if (m_FWHMs.size() == 1 && m_FWHMs.size() != nSpec) {
+        auto frontValue = m_FWHMs.front();
         m_FWHMs.assign(nSpec, frontValue);
       }
-      if (!m_FWHMs.empty()) {
-        m_fwhmX.resize(nSpec);
-        m_fwhmY.resize(nSpec);
-        for (size_t i = 0; i < nSpec; ++i) {
-          m_fwhmX[i].clear();
-          m_fwhmY[i].clear();
-          if (nSpec > 1) {
-            auto &control = *getFunction(i);
-            control.setAttributeValue("FWHMX", std::vector<double>());
-            control.setAttributeValue("FWHMY", std::vector<double>());
-          } else {
-            API::IFunction::setAttributeValue("FWHMX", std::vector<double>());
-            API::IFunction::setAttributeValue("FWHMY", std::vector<double>());
-          }
+      m_fwhmX.resize(nSpec);
+      m_fwhmY.resize(nSpec);
+      for (size_t i = 0; i < nSpec; ++i) {
+        m_fwhmX[i].clear();
+        m_fwhmY[i].clear();
+        if (nSpec > 1) {
+          auto &control = *getFunction(i);
+          control.setAttributeValue("FWHMX", std::vector<double>());
+          control.setAttributeValue("FWHMY", std::vector<double>());
+        } else {
+          API::IFunction::setAttributeValue("FWHMX", std::vector<double>());
+          API::IFunction::setAttributeValue("FWHMY", std::vector<double>());
         }
       }
     } else if ((name.compare(0, 5, "FWHMX") == 0 || name.compare(0, 5, "FWHMY") == 0) && !attr.asVector().empty()) {

--- a/Framework/CurveFitting/test/Functions/CrystalFieldControlTest.h
+++ b/Framework/CurveFitting/test/Functions/CrystalFieldControlTest.h
@@ -46,7 +46,7 @@ public:
     TS_ASSERT(f0_FWHMY.empty());
   }
 
-  void test_build_1() {
+  void test_build_single_site_and_single_spectrum() {
     Mantid::CurveFitting::Functions::CrystalFieldControl cf;
     cf.setAttributeValue("Ions", "Ce");
     cf.setAttributeValue("Symmetries", " C2v");
@@ -70,7 +70,7 @@ public:
     TS_ASSERT_EQUALS(nControls, 0);
   }
 
-  void test_build_2() {
+  void test_build_multi_site_and_single_spectrum() {
     Mantid::CurveFitting::Functions::CrystalFieldControl cf;
     cf.setAttributeValue("Ions", "Ce, Yb");
     cf.setAttributeValue("Symmetries", " D3,  D6h");
@@ -94,7 +94,7 @@ public:
     TS_ASSERT_EQUALS(nControls, 0);
   }
 
-  void test_build_3() {
+  void test_build_single_site_and_multiple_spectra() {
     Mantid::CurveFitting::Functions::CrystalFieldControl cf;
     cf.setAttributeValue("Ions", "Ce");
     cf.setAttributeValue("Symmetries", " C2v");
@@ -118,7 +118,7 @@ public:
     TS_ASSERT_EQUALS(nControls, 2);
   }
 
-  void test_build_4() {
+  void test_build_multi_site_and_multiple_spectra() {
     Mantid::CurveFitting::Functions::CrystalFieldControl cf;
     cf.setAttributeValue("Ions", "Ce, Yb");
     cf.setAttributeValue("Symmetries", " D3,  D6h");
@@ -142,7 +142,7 @@ public:
     TS_ASSERT_EQUALS(nControls, 2);
   }
 
-  void test_build_5() {
+  void test_build_control_with_mismatching_FWHMs() {
     Mantid::CurveFitting::Functions::CrystalFieldControl cf;
     cf.setAttributeValue("Ions", "Ce");
     cf.setAttributeValue("Symmetries", " C2v");
@@ -155,7 +155,7 @@ public:
     TS_ASSERT_THROWS(cf.buildSource(), const std::runtime_error &);
   }
 
-  void xtest_build_7() {
+  void test_build_single_site_and_multiple_spectra_and_multiple_temperatures_and_FWHMs() {
     Mantid::CurveFitting::Functions::CrystalFieldControl cf;
     cf.setAttributeValue("Ions", "Ce");
     cf.setAttributeValue("Symmetries", " C2v");
@@ -180,7 +180,7 @@ public:
     TS_ASSERT_EQUALS(nControls, 2);
   }
 
-  void test_build_8() {
+  void test_build_multi_site_and_multiple_spectra_and_multiple_FWHMs() {
     Mantid::CurveFitting::Functions::CrystalFieldControl cf;
     cf.setAttributeValue("Ions", "Ce, Yb");
     cf.setAttributeValue("Symmetries", " D3,  D6h");
@@ -204,7 +204,7 @@ public:
     TS_ASSERT_EQUALS(nControls, 2);
   }
 
-  void test_build_9() {
+  void test_build_single_site_and_multiple_spectra_and_physical_properties() {
     Mantid::CurveFitting::Functions::CrystalFieldControl cf;
     cf.setAttributeValue("Ions", "Ce");
     cf.setAttributeValue("Symmetries", " C2v");
@@ -228,7 +228,7 @@ public:
     TS_ASSERT_EQUALS(nControls, 0);
   }
 
-  void test_build_10() {
+  void test_build_multi_site_and_multiple_spectra_and_physical_properties() {
     Mantid::CurveFitting::Functions::CrystalFieldControl cf;
     cf.setAttributeValue("Ions", "Ce, Yb");
     cf.setAttributeValue("Symmetries", " D3,  D6h");
@@ -252,7 +252,7 @@ public:
     TS_ASSERT_EQUALS(nControls, 0);
   }
 
-  void test_build_11() {
+  void test_build_single_site_and_multiple_spectra_and_physical_properties_and_multiple_temperatures() {
     Mantid::CurveFitting::Functions::CrystalFieldControl cf;
     cf.setAttributeValue("Ions", "Ce");
     cf.setAttributeValue("Symmetries", " C2v");
@@ -276,7 +276,7 @@ public:
     TS_ASSERT_EQUALS(nControls, 2);
   }
 
-  void test_build_12() {
+  void test_build_multi_site_and_multiple_spectra_and_physical_properties_and_multiple_temperatures() {
     Mantid::CurveFitting::Functions::CrystalFieldControl cf;
     cf.setAttributeValue("Ions", "Ce, Yb");
     cf.setAttributeValue("Symmetries", " D3,  D6h");
@@ -300,7 +300,7 @@ public:
     TS_ASSERT_EQUALS(nControls, 2);
   }
 
-  void test_build_15() {
+  void test_build_single_site_and_multiple_spectra_and_physical_properties_and_multiple_temperatures_and_FWHMs() {
     Mantid::CurveFitting::Functions::CrystalFieldControl cf;
     cf.setAttributeValue("Ions", "Ce");
     cf.setAttributeValue("Symmetries", " C2v");
@@ -324,7 +324,7 @@ public:
     TS_ASSERT_EQUALS(nControls, 2);
   }
 
-  void test_build_16() {
+  void test_build_multi_site_and_multiple_spectra_and_physical_properties_and_multiple_temperatures_and_FWHMs() {
     Mantid::CurveFitting::Functions::CrystalFieldControl cf;
     cf.setAttributeValue("Ions", "Ce, Yb");
     cf.setAttributeValue("Symmetries", " D3,  D6h");
@@ -348,7 +348,7 @@ public:
     TS_ASSERT_EQUALS(nControls, 2);
   }
 
-  void test_build_17() {
+  void test_build_control_with_empty_FWHMs() {
     Mantid::CurveFitting::Functions::CrystalFieldControl cf;
     cf.setAttributeValue("Ions", "Tb, Tb");
     cf.setAttributeValue("Symmetries", " C2,  C2");

--- a/Framework/CurveFitting/test/Functions/CrystalFieldControlTest.h
+++ b/Framework/CurveFitting/test/Functions/CrystalFieldControlTest.h
@@ -347,4 +347,30 @@ public:
     TS_ASSERT_EQUALS(isMultiSpectrum, true);
     TS_ASSERT_EQUALS(nControls, 2);
   }
+
+  void test_build_17() {
+    Mantid::CurveFitting::Functions::CrystalFieldControl cf;
+    cf.setAttributeValue("Ions", "Tb, Tb");
+    cf.setAttributeValue("Symmetries", " C2,  C2");
+    cf.setAttributeValue("PhysicalProperties", "");
+    cf.setAttributeValue("Temperatures", std::vector<double>({7}));
+    cf.setAttributeValue("FWHMX", std::vector<double>({17}));
+    cf.setAttributeValue("FWHMY", std::vector<double>({17}));
+    cf.setAttributeValue("FWHMs", std::vector<double>());
+    auto source = cf.buildSource();
+    std::string Ions = cf.getAttribute("Ions").asString();
+    std::string Symmetries = cf.getAttribute("Symmetries").asString();
+    std::string PhysicalProperties = cf.getAttribute("PhysicalProperties").asString();
+    bool isComposite = dynamic_cast<Mantid::API::CompositeFunction *>(source.get()) != nullptr;
+    bool isMultiSite = cf.isMultiSite();
+    bool isMultiSpectrum = cf.isMultiSpectrum();
+    int nControls = (int)cf.nFunctions();
+    TS_ASSERT_EQUALS(Ions, "\"Tb,Tb\"");
+    TS_ASSERT_EQUALS(Symmetries, "\"C2,C2\"");
+    TS_ASSERT_EQUALS(PhysicalProperties, "");
+    TS_ASSERT_EQUALS(isComposite, true);
+    TS_ASSERT_EQUALS(isMultiSite, true);
+    TS_ASSERT_EQUALS(isMultiSpectrum, false);
+    TS_ASSERT_EQUALS(nControls, 0);
+  }
 };

--- a/Framework/CurveFitting/test/Functions/CrystalFieldControlTest.h
+++ b/Framework/CurveFitting/test/Functions/CrystalFieldControlTest.h
@@ -162,7 +162,6 @@ public:
     cf.setAttributeValue("PhysicalProperties", "");
     cf.setAttributeValue("Temperatures", std::vector<double>({44, 50}));
     cf.setAttributeValue("FWHMs", std::vector<double>({1.1, 1.2}));
-    cf.buildControls();
     auto source = cf.buildSource();
     std::string Ions = cf.getAttribute("Ions").asString();
     std::string Symmetries = cf.getAttribute("Symmetries").asString();

--- a/docs/source/release/v6.8.0/Direct_Geometry/CrystalField/Bugfixes/35840.rst
+++ b/docs/source/release/v6.8.0/Direct_Geometry/CrystalField/Bugfixes/35840.rst
@@ -1,0 +1,1 @@
+- Prevent segmentation fault by only accessing FWHM values when the corresponding vector is not empty.


### PR DESCRIPTION
**Description of work**
When CrystalField objects use the resolution model FWHM values are unset as they would otherwise override the resolution model. As a consequence, the FWHMs of a CrystalField object for multiple sites can be empty. This can cause a segmentation fault in the setAttribute function as it tries to access the first FWHM value even when there are no FWHMs.

**Purpose of work**
Prevent a segmentation fault.

**Report to:** Duc Le

**To test:**

Run the script from the original issue https://github.com/mantidproject/mantid/issues/35839 and check whether there is a segmentation fault occurring.

Fixes #35839

---

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.