### PR TITLE
Fix a couple bugs in the docs plotting code

### DIFF
--- a/docs/source/plotting/3DPlotsHelp.rst
+++ b/docs/source/plotting/3DPlotsHelp.rst
@@ -82,7 +82,7 @@ Basic example of plotting a `Surface <https://matplotlib.org/mpl_toolkits/mplot3
     data = mtd['data_1'] # Extract individual workspace from group
 
     fig, ax = plt.subplots(subplot_kw={'projection':'mantid3d'})
-    ax.plot_surface(data)
+    ax.plot_surface(data, cmap='viridis')
     plt.show()
 
 For more advice: :ref:`02_scripting_plots`

--- a/docs/source/plotting/index.rst
+++ b/docs/source/plotting/index.rst
@@ -729,7 +729,7 @@ of the logs that are being excluded by the TimeROI.
 
    import matplotlib.pyplot as plt
    from mantid import plots
-   from mantid.simpleapi import Load
+   from mantid.simpleapi import Load, FilterByTime
 
    w=Load('CNCS_7860')
    ws_filtered=FilterByTime(w, StartTime=60, StopTime=120)

--- a/docs/source/tutorials/python_in_mantid/plotting/01_basic_plot_scripting.rst
+++ b/docs/source/tutorials/python_in_mantid/plotting/01_basic_plot_scripting.rst
@@ -174,7 +174,7 @@ To overplot on the same window:
     data = mtd['data_1'] # Extract individual workspace from group
 
     fig, ax = plt.subplots(subplot_kw={'projection':'mantid3d'})
-    ax.plot_surface(data)
+    ax.plot_surface(data, cmap='viridis')
     #plt.show()
 
 .. plot::


### PR DESCRIPTION
**Description of work**

Fixed the bug listed in #35033 (needed to specify a value for `cmap`) and another one I found in `plotting/index.rst` (missing import statement).

**To test:**
 - Run cmake with `-DDOCS_PLOTDIRECTIVE=ON`
 - Build `docs-qtassistant` then `docs-athelp` then `docs-html`
 - There should be no warnings about exceptions in any code (maybe these exceptions should've been failing builds?)
 - Affected plots should display properly in the html

Fixes #35033

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.