### PR TITLE
Add progress for loading experiment info

### DIFF
--- a/Framework/MDAlgorithms/src/LoadMD.cpp
+++ b/Framework/MDAlgorithms/src/LoadMD.cpp
@@ -205,6 +205,8 @@ void LoadMD::execLoader() {
     }
 
     // Now the ExperimentInfo
+    auto prog = std::make_unique<Progress>(this, 0.0, 0.1, 1);
+    prog->report("Load experiment information.");
     bool lazyLoadExpt = fileBacked;
     MDBoxFlatTree::loadExperimentInfos(m_file.get(), m_filename, ws, *fileInfo.get(), "MDEventWorkspace", lazyLoadExpt);
 
@@ -289,6 +291,8 @@ void LoadMD::loadHisto() {
   }
 
   // Now the ExperimentInfo
+  auto prog = std::make_unique<Progress>(this, 0.0, 0.1, 1);
+  prog->report("Load experiment information.");
   MDBoxFlatTree::loadExperimentInfos(m_file.get(), m_filename, ws);
 
   // Coordinate system

--- a/docs/source/release/v6.8.0/Framework/Algorithms/Bugfixes/35846.rst
+++ b/docs/source/release/v6.8.0/Framework/Algorithms/Bugfixes/35846.rst
@@ -1,0 +1,1 @@
+* The progress bar for :ref:`LoadMD <algm-LoadMD>` now includes loading experiment information.


### PR DESCRIPTION
**Description of work**

Started progress bar earlier in LoadMD

**Purpose of work**

During SHIVER testing, it was pointed out that the progress bar for LoadMD starts very late in the process. This is happening due to the fact that it starts only after loading experiment infos. For files with large number of experiment infos, this means that there is no information that the algorithm is running

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->


**To test:**
Load any MD file that has many experiment infos. The progress bar should start immediately


*There is no associated issue.*

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.