### PR TITLE
Fix bug where 'Save Script as' left tab open

### DIFF
--- a/docs/source/release/v6.8.0/Workbench/Bugfixes/33369.rst
+++ b/docs/source/release/v6.8.0/Workbench/Bugfixes/33369.rst
@@ -1,0 +1,1 @@
+- Fix bug that left a tab open with the old file name in the script editor when using 'Save Script as'

--- a/qt/python/mantidqt/mantidqt/widgets/codeeditor/multifileinterpreter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/codeeditor/multifileinterpreter.py
@@ -355,7 +355,8 @@ class MultiPythonFileInterpreter(QWidget):
         saved, filename = self.current_editor().save_as()
         if saved:
             self.open_file_in_new_tab(filename)
-            current_editor_before_saving.close()
+            tab_index = self._tabs.indexOf(current_editor_before_saving)
+            self.close_tab(tab_index)
             if previous_filename:
                 self.sig_file_name_changed.emit(previous_filename, filename)
 

--- a/qt/python/mantidqt/mantidqt/widgets/codeeditor/multifileinterpreter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/codeeditor/multifileinterpreter.py
@@ -351,9 +351,11 @@ class MultiPythonFileInterpreter(QWidget):
 
     def save_current_file_as(self):
         previous_filename = self.current_editor().filename
+        current_editor_before_saving = self.current_editor()
         saved, filename = self.current_editor().save_as()
         if saved:
             self.open_file_in_new_tab(filename)
+            current_editor_before_saving.close()
             if previous_filename:
                 self.sig_file_name_changed.emit(previous_filename, filename)
 

--- a/qt/python/mantidqt/mantidqt/widgets/codeeditor/test/test_multifileinterpreter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/codeeditor/test/test_multifileinterpreter.py
@@ -92,7 +92,7 @@ class MultiPythonFileInterpreterTest(unittest.TestCase, QtWidgetFinder):
         # There's one tab when you create the editor, then another one was added when opening the mock file. Clicking
         # 'Save Script as' should close the original tab with the old name, and leave you with a tab with the new name.
         self.assertEqual(2, widget.editor_count)
-        self.assertEqual(False, widget.current_editor().editor.isModified(), msg="Orignal tab should be marked as modified")
+        self.assertEqual(False, widget.current_editor().editor.isModified(), msg="Tab should be marked as not modified")
 
 
 if __name__ == "__main__":

--- a/qt/python/mantidqt/mantidqt/widgets/codeeditor/test/test_multifileinterpreter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/codeeditor/test/test_multifileinterpreter.py
@@ -80,15 +80,16 @@ class MultiPythonFileInterpreterTest(unittest.TestCase, QtWidgetFinder):
         test_string = "Test file\n"
         widget = MultiPythonFileInterpreter()
         mock_open_func = mock.mock_open(read_data=test_string)
-        with mock.patch(widget.__module__ + ".open", mock_open_func, create=True):
-            with mock.patch(PERMISSION_BOX_FUNC, lambda: True):
-                with tempfile.TemporaryDirectory() as temp_dir:
-                    with mock.patch(
-                        "mantidqt.widgets.codeeditor.interpreter.EditorIO.ask_for_filename",
-                        lambda s: os.path.join(temp_dir, "test_save_as_leaves_original_marked_unmodified"),
-                    ):
-                        widget.open_file_in_new_tab(test_string)
-                        widget.save_current_file_as()
+        ask_for_filename = "mantidqt.widgets.codeeditor.interpreter.EditorIO.ask_for_filename"
+        test_file_name = "test_save_as_leaves_original_marked_unmodified"
+        # fmt: off
+        with mock.patch(widget.__module__ + ".open", mock_open_func, create=True), \
+                mock.patch(PERMISSION_BOX_FUNC, lambda: True), \
+                tempfile.TemporaryDirectory() as temp_dir, \
+                mock.patch(ask_for_filename, lambda s: os.path.join(temp_dir, test_file_name)):
+            widget.open_file_in_new_tab(test_string)
+            widget.save_current_file_as()
+        # fmt: on
         # There's one tab when you create the editor, then another one was added when opening the mock file. Clicking
         # 'Save Script as' should close the original tab with the old name, and leave you with a tab with the new name.
         self.assertEqual(2, widget.editor_count)

--- a/qt/python/mantidqt/mantidqt/widgets/codeeditor/test/test_multifileinterpreter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/codeeditor/test/test_multifileinterpreter.py
@@ -89,8 +89,8 @@ class MultiPythonFileInterpreterTest(unittest.TestCase, QtWidgetFinder):
                     ):
                         widget.open_file_in_new_tab(test_string)
                         widget.save_current_file_as()
-        # There's one tab when you create the editor, then another one was added when opening the mock file. Previously
-        # clicking 'Save Script as' would leave the original tab open, so you'd end up with 3 tabs instead of 2
+        # There's one tab when you create the editor, then another one was added when opening the mock file. Clicking
+        # 'Save Script as' should close the original tab with the old name, and leave you with a tab with the new name.
         self.assertEqual(2, widget.editor_count)
         self.assertEqual(False, widget.current_editor().editor.isModified(), msg="Orignal tab should be marked as modified")
 

--- a/qt/python/mantidqt/mantidqt/widgets/codeeditor/test/test_multifileinterpreter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/codeeditor/test/test_multifileinterpreter.py
@@ -92,7 +92,7 @@ class MultiPythonFileInterpreterTest(unittest.TestCase, QtWidgetFinder):
         # There's one tab when you create the editor, then another one was added when opening the mock file. Clicking
         # 'Save Script as' should close the original tab with the old name, and leave you with a tab with the new name.
         self.assertEqual(2, widget.editor_count)
-        self.assertEqual(False, widget.current_editor().editor.isModified(), msg="Tab should be marked as not modified")
+        self.assertFalse(widget.current_editor().editor.isModified(), msg="Tab should be marked as not modified")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
**Description of work**
Previously if you had a script with unsaved changes, then clicked 'Save Script as' and picked a new file name, then the original file would be left open with changes unsaved.

**Purpose of work**
Fixes #33369 

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** James Lord
-->

**Summary of work**
- Added test that checks if you click 'Save Script as' then it will close the original tab
- Changed behaviour so that if you have a script open with unsaved changes, then click 'Save Script as', then you will just end up with a tab with the new script name (and the tab with the old script name will be closed)

**To test:**
See description above or #33369 
<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.