### PR TITLE
Fix bug that would open a duplicate tab if a file was already open

### DIFF
--- a/docs/source/release/v6.8.0/Workbench/Bugfixes/34979.rst
+++ b/docs/source/release/v6.8.0/Workbench/Bugfixes/34979.rst
@@ -1,0 +1,1 @@
+- Fix bug that would open a duplicate tab if a file was already open. Now it will select the existing tab with the file.

--- a/qt/python/mantidqt/mantidqt/widgets/codeeditor/multifileinterpreter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/codeeditor/multifileinterpreter.py
@@ -319,7 +319,8 @@ class MultiPythonFileInterpreter(QWidget):
             if self.editor_at(i).filename == filepath:
                 matching_index = i
                 break
-
+                
+        # If the file is currently open, select that tab
         if matching_index > -1:
             self._tabs.setCurrentWidget(self.editor_at(matching_index))
         else:

--- a/qt/python/mantidqt/mantidqt/widgets/codeeditor/multifileinterpreter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/codeeditor/multifileinterpreter.py
@@ -195,7 +195,6 @@ class MultiPythonFileInterpreter(QWidget):
         # are being prompted to save
         self._tabs.setCurrentIndex(idx)
         if self.current_editor().confirm_close():
-
             # If the last editor tab is being closed, its zoom level
             # is saved for the new tab which opens automatically.
             if self.editor_count == 1:
@@ -315,7 +314,17 @@ class MultiPythonFileInterpreter(QWidget):
         with open(filepath, "r") as code_file:
             content = code_file.read()
 
-        self.append_new_editor(content=content, filename=filepath)
+        matching_index = -1
+        for i in range(self.editor_count):
+            if self.editor_at(i).filename == filepath:
+                matching_index = i
+                break
+
+        if matching_index > -1:
+            self._tabs.setCurrentWidget(self.editor_at(matching_index))
+        else:
+            self.append_new_editor(content=content, filename=filepath)
+
         if startup is False and mantid_api_import_needed(content) is True:
             add_mantid_api_import(self.current_editor().editor, content)
 

--- a/qt/python/mantidqt/mantidqt/widgets/codeeditor/multifileinterpreter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/codeeditor/multifileinterpreter.py
@@ -319,7 +319,7 @@ class MultiPythonFileInterpreter(QWidget):
             if self.editor_at(i).filename == filepath:
                 matching_index = i
                 break
-                
+
         # If the file is currently open, select that tab
         if matching_index > -1:
             self._tabs.setCurrentWidget(self.editor_at(matching_index))

--- a/qt/python/mantidqt/mantidqt/widgets/codeeditor/test/test_multifileinterpreter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/codeeditor/test/test_multifileinterpreter.py
@@ -7,6 +7,8 @@
 #    This file is part of the mantid workbench.
 #
 #
+import os.path
+import tempfile
 import unittest
 
 from unittest import mock
@@ -48,6 +50,31 @@ class MultiPythonFileInterpreterTest(unittest.TestCase, QtWidgetFinder):
             with mock.patch(PERMISSION_BOX_FUNC, lambda: True):
                 widget.open_file_in_new_tab(test_string)
         self.assertNotIn(MANTID_API_IMPORT, widget.current_editor().editor.text())
+
+    def test_open_same_file_twice_no_extra_tab(self):
+        widget = MultiPythonFileInterpreter()
+        with tempfile.TemporaryDirectory() as temp_dir:
+            filename = os.path.join(temp_dir, "test_open_same_file_twice_no_extra_tab")
+            with open(filename, "w") as f:
+                f.write("Test")
+            with mock.patch("mantidqt.widgets.codeeditor.interpreter.EditorIO.ask_for_filename", lambda s: filename):
+                widget.open_file_in_new_tab(filename)
+                widget.open_file_in_new_tab(filename)
+        self.assertEqual(2, widget.editor_count, msg="Should be the original tab, plus one (not two) tabs for the file")
+
+    def test_open_same_file_twice_no_tab_even_if_modified(self):
+        widget = MultiPythonFileInterpreter()
+        with tempfile.TemporaryDirectory() as temp_dir:
+            filename = os.path.join(temp_dir, "test_open_same_file_twice_no_tab_even_if_modified")
+            with open(filename, "w") as f:
+                f.write("Test")
+            with mock.patch("mantidqt.widgets.codeeditor.interpreter.EditorIO.ask_for_filename", lambda s: filename):
+                widget.open_file_in_new_tab(filename)
+                widget.current_editor().editor.append("Some text")
+                widget.open_file_in_new_tab(filename)
+        self.assertEqual(2, widget.editor_count, msg="Should be the original tab, plus one (not two) tabs for the file")
+        # File should still be modified after attempted reopening because it was modified before reopening and we don't want to lose changes
+        self.assertEqual(True, widget.current_editor().editor.isModified(), msg="File should still be modified after attempted reopening")
 
 
 if __name__ == "__main__":

--- a/qt/python/mantidqt/mantidqt/widgets/codeeditor/test/test_multifileinterpreter.py
+++ b/qt/python/mantidqt/mantidqt/widgets/codeeditor/test/test_multifileinterpreter.py
@@ -74,7 +74,7 @@ class MultiPythonFileInterpreterTest(unittest.TestCase, QtWidgetFinder):
                 widget.open_file_in_new_tab(filename)
         self.assertEqual(2, widget.editor_count, msg="Should be the original tab, plus one (not two) tabs for the file")
         # File should still be modified after attempted reopening because it was modified before reopening and we don't want to lose changes
-        self.assertEqual(True, widget.current_editor().editor.isModified(), msg="File should still be modified after attempted reopening")
+        self.assertTrue(widget.current_editor().editor.isModified(), msg="File should still be modified after attempted reopening")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
**Description of work**
Previously if you had a file open, then opened it again, then another tab would appear with the same file. What happens now is that the tab that's already open gets selected. If you have modifications in the tab that was open initially they won't be lost.

**Purpose of work**
<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
-->
Fixes #34979 

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**Summary of work**
<!-- Please provide a short, high level description of the work that was done.
-->
- Added two tests that check if you open a file a second time then you don't get a new tab. The second test checks that if the file is modified initially then it's still modified afterwards.
- Changed behaviour so that if you open a file that's already open then the tab with that file gets selected.

**Further detail of work**
<!-- Please provide a more detailed description of the work that has been undertaken.
-->


**To test:**

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->
Intended behaviour is described above or in #34979.

<!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.