### PR TITLE
Add missing algorithm history tracking to UnGroupWorkspace

### DIFF
--- a/Framework/API/inc/MantidAPI/Algorithm.h
+++ b/Framework/API/inc/MantidAPI/Algorithm.h
@@ -401,9 +401,11 @@ protected:
 
   /// get whether we are tracking the history for this algorithm,
   bool trackingHistory();
-  /// Copy workspace history for input workspaces to output workspaces and
+  /// Copy workspace history from input workspaces to output workspaces and
   /// record the history for ths algorithm
   virtual void fillHistory();
+  /// Copy workspace history from input workspaces to provided vector of output workspaces
+  void fillHistory(const std::vector<Workspace_sptr> &outputWorkspaces);
 
   /// Set to true to stop execution
   std::atomic<bool> m_cancel;
@@ -462,8 +464,6 @@ private:
   bool executeAsyncImpl(const Poco::Void &i);
 
   bool doCallProcessGroups(Mantid::Types::Core::DateAndTime &start_time);
-
-  void fillHistory(const std::vector<Workspace_sptr> &outputWorkspaces);
 
   // Report that the algorithm has completed.
   void reportCompleted(const double &duration, const bool groupProcessing = false);

--- a/Framework/Algorithms/src/UnGroupWorkspace.cpp
+++ b/Framework/Algorithms/src/UnGroupWorkspace.cpp
@@ -7,8 +7,6 @@
 #include "MantidAlgorithms/UnGroupWorkspace.h"
 #include "MantidAPI/AnalysisDataService.h"
 #include "MantidAPI/WorkspaceGroup.h"
-#include "MantidKernel/ArrayProperty.h"
-#include "MantidKernel/InvisibleProperty.h"
 #include "MantidKernel/ListValidator.h"
 
 namespace Mantid::Algorithms {
@@ -37,11 +35,6 @@ void UnGroupWorkspace::init() {
   // values
   declareProperty("InputWorkspace", "", "Name of the input workspace to ungroup",
                   std::make_shared<StringListValidator>(groupWorkspaceList));
-  // Invisible outputworkspaces property so algorithm history can be added to the individual workspaces
-  declareProperty(std::make_unique<WorkspaceProperty<WorkspaceGroup>>("OutputWorkspaces", "", Direction::Output,
-                                                                      PropertyMode::Optional),
-                  "Workspaces to be ungrouped");
-  setPropertySettings("OutputWorkspaces", std::make_unique<InvisibleProperty>());
 }
 
 /** Executes the algorithm
@@ -60,15 +53,15 @@ void UnGroupWorkspace::exec() {
   if (!wsGrpSptr) {
     throw std::runtime_error("Selected Workspace is not a WorkspaceGroup");
   }
-  // Store workspaces in an out direction group so they are picked up by algorithm history
-  setAlwaysStoreInADS(false);
-  auto output = std::make_shared<WorkspaceGroup>();
+  // add algorithm history to the workspaces being released from the group
+  WorkspaceVector outputWorkspaces;
   const AnalysisDataServiceImpl &ads = AnalysisDataService::Instance();
   for (const auto &ws_name : wsGrpSptr->getNames()) {
     auto ws = ads.retrieve(ws_name);
-    output->addWorkspace(ws);
+    if (ws)
+      outputWorkspaces.emplace_back(ws);
   }
-  setProperty("OutputWorkspaces", output);
+  fillHistory(outputWorkspaces);
   // Notify observers that a WorkspaceGroup is about to be unrolled
   data_store.notificationCenter.postNotification(new Mantid::API::WorkspaceUnGroupingNotification(inputws, wsSptr));
   // Now remove the WorkspaceGroup from the ADS

--- a/Framework/Algorithms/src/UnGroupWorkspace.cpp
+++ b/Framework/Algorithms/src/UnGroupWorkspace.cpp
@@ -53,10 +53,7 @@ void UnGroupWorkspace::exec() {
     throw std::runtime_error("Selected Workspace is not a WorkspaceGroup");
   }
   // add algorithm history to the workspaces being released from the group
-  WorkspaceVector outputWorkspaces;
-  for (const auto &ws : wsGrpSptr->getAllItems())
-    outputWorkspaces.emplace_back(ws);
-  fillHistory(outputWorkspaces);
+  fillHistory(wsGrpSptr->getAllItems());
   // Notify observers that a WorkspaceGroup is about to be unrolled
   data_store.notificationCenter.postNotification(new Mantid::API::WorkspaceUnGroupingNotification(inputws, wsSptr));
   // Now remove the WorkspaceGroup from the ADS

--- a/Framework/Algorithms/src/UnGroupWorkspace.cpp
+++ b/Framework/Algorithms/src/UnGroupWorkspace.cpp
@@ -5,7 +5,6 @@
 //   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 // SPDX - License - Identifier: GPL - 3.0 +
 #include "MantidAlgorithms/UnGroupWorkspace.h"
-#include "MantidAPI/AnalysisDataService.h"
 #include "MantidAPI/WorkspaceGroup.h"
 #include "MantidKernel/ListValidator.h"
 
@@ -55,12 +54,8 @@ void UnGroupWorkspace::exec() {
   }
   // add algorithm history to the workspaces being released from the group
   WorkspaceVector outputWorkspaces;
-  const AnalysisDataServiceImpl &ads = AnalysisDataService::Instance();
-  for (const auto &ws_name : wsGrpSptr->getNames()) {
-    auto ws = ads.retrieve(ws_name);
-    if (ws)
-      outputWorkspaces.emplace_back(ws);
-  }
+  for (const auto &ws : wsGrpSptr->getAllItems())
+    outputWorkspaces.emplace_back(ws);
   fillHistory(outputWorkspaces);
   // Notify observers that a WorkspaceGroup is about to be unrolled
   data_store.notificationCenter.postNotification(new Mantid::API::WorkspaceUnGroupingNotification(inputws, wsSptr));

--- a/Framework/Algorithms/test/UnGroupWorkspaceTest.h
+++ b/Framework/Algorithms/test/UnGroupWorkspaceTest.h
@@ -8,6 +8,7 @@
 
 #include "MantidAPI/AnalysisDataService.h"
 #include "MantidAPI/WorkspaceGroup.h"
+#include "MantidAPI/WorkspaceHistory.h"
 #include "MantidAlgorithms/UnGroupWorkspace.h"
 #include "MantidFrameworkTestHelpers/WorkspaceCreationHelper.h"
 #include <cxxtest/TestSuite.h>
@@ -98,6 +99,28 @@ public:
     removeFromADS(std::vector<std::string>(1, wsName));
   }
 
+  void test_Leaving_Members_Are_Given_Algorithm_History() {
+    std::vector<std::string> members{"test_Leaving_Members_Are_Given_Algorithm_History_Members_1",
+                                     "test_Leaving_Members_Are_Given_Algorithm_History_Members_2"};
+    const std::string groupName = "test_Leaving_Members_Are_Given_Algorithm_History_Group";
+    addTestGroupToADS(groupName, members);
+
+    Mantid::Algorithms::UnGroupWorkspace alg;
+    alg.initialize();
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("InputWorkspace", groupName));
+    TS_ASSERT_THROWS_NOTHING(alg.execute());
+    TS_ASSERT(alg.isExecuted());
+
+    auto &ads = Mantid::API::AnalysisDataService::Instance();
+    const auto m1 = ads.retrieve(members[0]);
+    const auto m2 = ads.retrieve(members[1]);
+
+    TS_ASSERT(isAlgorithmInHistory(m1));
+    TS_ASSERT(isAlgorithmInHistory(m2));
+
+    removeFromADS(members);
+  }
+
 private:
   void addTestGroupToADS(const std::string &name, const std::vector<std::string> &inputs) {
     auto newGroup = std::make_shared<Mantid::API::WorkspaceGroup>();
@@ -124,5 +147,17 @@ private:
       if (ads.doesExist(member))
         ads.remove(member);
     }
+  }
+
+  bool isAlgorithmInHistory(const Mantid::API::Workspace_sptr ws) {
+    auto ws_histories = ws->getHistory().getAlgorithmHistories();
+    bool found = false;
+    for (auto alg_history : ws_histories) {
+      if (alg_history->name() == "UnGroupWorkspace") {
+        found = true;
+        break;
+      }
+    }
+    return found;
   }
 };

--- a/Framework/Algorithms/test/UnGroupWorkspaceTest.h
+++ b/Framework/Algorithms/test/UnGroupWorkspaceTest.h
@@ -149,15 +149,10 @@ private:
     }
   }
 
-  bool isAlgorithmInHistory(const Mantid::API::Workspace_sptr ws) {
-    auto ws_histories = ws->getHistory().getAlgorithmHistories();
-    bool found = false;
-    for (auto alg_history : ws_histories) {
-      if (alg_history->name() == "UnGroupWorkspace") {
-        found = true;
-        break;
-      }
-    }
-    return found;
+  bool isAlgorithmInHistory(const Mantid::API::Workspace_sptr &ws) {
+    auto wsHistories = ws->getHistory().getAlgorithmHistories();
+    auto iter = std::find_if(wsHistories.cbegin(), wsHistories.cend(),
+                             [](auto const &algHistory) { return algHistory->name() == "UnGroupWorkspace"; });
+    return iter != wsHistories.cend();
   }
 };

--- a/docs/source/release/v6.8.0/Framework/Algorithms/Bugfixes/34255.rst
+++ b/docs/source/release/v6.8.0/Framework/Algorithms/Bugfixes/34255.rst
@@ -1,0 +1,1 @@
+- Fixed bug in :ref:`UnGroupWorksapce <algm-UnGroupWorkspace>` where the algorithm history would not be added to the workspaces being ungrouped.


### PR DESCRIPTION
**Description of work**

Fixes a bug where workspaces which belonged to a group that was passed to `UnGroupWorkspace`, did not include the algorithm in their history.

The reason why is that when passing on algorithm history, the Algorithm base class searches for algorithm properties which are outputs and can cast to a workspace. `UnGroupWorkspace` simply removes the group workspace passed to it (releasing the child workspaces in doing so) so doesn't need an 'output' property, meaning the history is never passed on.

**Summary of work**
The simplest way has involved moving the second `fillHistory` declaration from private to protected. I don't see this as being dangerous to do anyway, just disrupts the 'correctness' a little.
Also added in a test.

**To test:**

Run this script
```
from mantid.simpleapi import *
import matplotlib.pyplot as plt
import numpy as np

ws1 = CreateSampleWorkspace()
ws2 = CreateSampleWorkspace()
group_ws = GroupWorkspaces(InputWorkspaces="ws1,ws2")
UnGroupWorkspace(group_ws)
```
Right click `ws1` and click `Show History`; `UnGroupWorkspace` should be the last algorithm on there with correct input worksapce listed.
Check again for `ws2`.

Fixes #34255

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.