### PR TITLE
New script to identify conda package changes between builds

### DIFF
--- a/tools/Jenkins/dependency_spotter.py
+++ b/tools/Jenkins/dependency_spotter.py
@@ -122,20 +122,27 @@ def compare_dependencies_for_file(os_name: str, first_build: int, second_build: 
             packages_added.extend(package)
 
     # Output
-    if len(packages_added) > 0:
+    output_package_changes_to_console(packages_added, packages_removed, packages_changed)
+
+
+def output_package_changes_to_console(added: list, removed: list, changed: dict):
+    """
+    Format and output the packages that have been added, removed, or changed version.
+    """
+    if len(added) > 0:
         print("Packages added:")
-        for p in packages_added:
+        for p in added:
             print(p)
         print("")
-    if len(packages_removed) > 0:
+    if len(removed) > 0:
         print("Packages removed:")
-        for p in packages_removed:
+        for p in removed:
             print(p)
         print("")
-    if len(packages_changed) > 0:
+    if len(changed) > 0:
         print("Packages changed:")
-        for p in packages_changed:
-            print(p + " changed from " + packages_changed[p])
+        for p in changed:
+            print(p + " changed from " + changed[p])
 
 
 def form_url_for_build_artifact(build_number: int, os_name: str, pipeline: str, log_file: str):

--- a/tools/Jenkins/dependency_spotter.py
+++ b/tools/Jenkins/dependency_spotter.py
@@ -60,18 +60,14 @@ def dependency_spotter(os_name: str, first_build: int, second_build: int, pipeli
         return
 
     files_to_compare = input(
-        "Which files do you want to compare? (Either a single number, a comma-separated list of numbers, or 0 for all):"
+        "Which files do you want to compare? (Either a single number, a comma-separated list of numbers, or leave blank for all):"
     )
+
     if files_to_compare == "":
-        return
-    file_indices = files_to_compare.split(",")
-    if "0" in file_indices:
         file_indices = range(len(files_in_both_builds))
     else:
+        file_indices = files_to_compare.split(",")
         file_indices = [int(x) - 1 for x in file_indices]
-
-    if file_indices is None:
-        return
 
     print("")
     for file_id in file_indices:

--- a/tools/Jenkins/dependency_spotter.py
+++ b/tools/Jenkins/dependency_spotter.py
@@ -3,10 +3,63 @@ import re
 import urllib.request
 
 
-def dependency_spotter(os_name: str, first_build: int, second_build: int, pipeline: str):
+def dependency_spotter(os_name: str, first_build: int, second_build: int, pipeline: str, log_file: str):
+    if log_file:
+        compare_dependencies_for_file(os_name, first_build, second_build, pipeline, log_file)
+        return
+
+    first_build_log_files = extract_available_log_files(os_name, first_build, pipeline)
+    second_build_log_files = extract_available_log_files(os_name, second_build, pipeline)
+
+    files_in_both_builds = []
+    files_missing_from_second_build = []
+    for file in first_build_log_files:
+        list_to_append = files_in_both_builds if file in second_build_log_files else files_missing_from_second_build
+        list_to_append.append(file)
+
+    print("Files available for comparison:")
+    if len(files_in_both_builds) > 0:
+        for file in files_in_both_builds:
+            print(file)
+    else:
+        print("None")
+    print("")
+    print("Files missing from second build:")
+    if len(files_missing_from_second_build) > 0:
+        for file in files_missing_from_second_build:
+            print(file)
+    else:
+        print("None")
+    print("")
+
+    if len(files_in_both_builds) == 0:
+        return
+
+    print("")
+    for file in files_in_both_builds:
+        print(f"{file}:")
+        print("")
+        compare_dependencies_for_file(os_name, first_build, second_build, pipeline, file)
+        print("")
+
+
+def extract_available_log_files(os_name: str, build_number: int, pipeline: str) -> list:
+    url = form_url_for_build_artifact(build_number, os_name, pipeline, "")
+    build_log_files = []
+    regex_logfile = r"(mantid(docs)?[\w]+environment\.txt)"
+    # Log files for first build
+    with urllib.request.urlopen(url) as file:
+        for line in file.readlines():
+            regex_result = re.search(pattern=regex_logfile, string=line.decode("utf-8"))
+            if regex_result is not None and len(regex_result.groups()) > 0:
+                build_log_files.append(str(regex_result.group(0)))
+    return build_log_files
+
+
+def compare_dependencies_for_file(os_name: str, first_build: int, second_build: int, pipeline: str, log_file: str):
     # Form URLs for each build artifact file
-    first_build_output_path = form_url_for_build_artifact(first_build, os_name, pipeline)
-    second_build_output_path = form_url_for_build_artifact(second_build, os_name, pipeline)
+    first_build_output_path = form_url_for_build_artifact(first_build, os_name, pipeline, log_file)
+    second_build_output_path = form_url_for_build_artifact(second_build, os_name, pipeline, log_file)
 
     # Read in the packages used, with versions
     first_output_packages = extract_package_versions(first_build_output_path, os_name)
@@ -42,8 +95,8 @@ def dependency_spotter(os_name: str, first_build: int, second_build: int, pipeli
             print(p + " changed from " + packages_changed[p])
 
 
-def form_url_for_build_artifact(build_number: int, os_name: str, pipeline: str):
-    return f"https://builds.mantidproject.org/job/{pipeline}/{build_number}/artifact/conda-bld/{os_name}/env_logs/mantidworkbench_build_environment.txt"
+def form_url_for_build_artifact(build_number: int, os_name: str, pipeline: str, log_file: str):
+    return f"https://builds.mantidproject.org/job/{pipeline}/{build_number}/artifact/conda-bld/{os_name}/env_logs/{log_file}"
 
 
 def extract_package_versions(url: str, os_name: str) -> dict:
@@ -65,5 +118,6 @@ if __name__ == "__main__":
     parser.add_argument("--first", "-f", help="First (usually passing) build number", type=int)
     parser.add_argument("--second", "-s", help="Second (usually failing) build number", type=int)
     parser.add_argument("--pipeline", "-p", help="Build pipeline", default="main_nightly_deployment_prototype", type=str)
+    parser.add_argument("--logfile", "-l", help="Log file name to compare, by default all of them are compared", default="", type=str)
     args = parser.parse_args()
-    dependency_spotter(os_name=args.os, first_build=args.first, second_build=args.second, pipeline=args.pipeline)
+    dependency_spotter(os_name=args.os, first_build=args.first, second_build=args.second, pipeline=args.pipeline, log_file=args.logfile)

--- a/tools/Jenkins/dependency_spotter.py
+++ b/tools/Jenkins/dependency_spotter.py
@@ -1,3 +1,17 @@
+# Mantid Repository : https://github.com/mantidproject/mantid
+#
+# Copyright &copy; 2023 ISIS Rutherford Appleton Laboratory UKRI,
+#   NScD Oak Ridge National Laboratory, European Spallation Source,
+#   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+# SPDX - License - Identifier: GPL - 3.0 +
+"""
+Script that takes two build numbers, and optionally the OS label, the pipeline name, and the name of the file
+to compare. It will then output the changes in conda package versions used in the two builds, if there are any,
+for which it uses the build artifacts.
+Example use: dependency_spotter -f 593 -s 598
+This will compare builds 593 and 598 from the "main_nightly_deployment_prototype" pipeline
+"""
+
 import argparse
 import re
 import urllib.request

--- a/tools/Jenkins/dependency_spotter.py
+++ b/tools/Jenkins/dependency_spotter.py
@@ -56,6 +56,7 @@ def dependency_spotter(os_name: str, first_build: int, second_build: int, pipeli
     print("")
 
     if len(files_in_both_builds) == 0:
+        print("No matching pair of files was found in the two builds specified, so unable to go any further.")
         return
 
     files_to_compare = input(

--- a/tools/Jenkins/dependency_spotter.py
+++ b/tools/Jenkins/dependency_spotter.py
@@ -1,0 +1,72 @@
+import re
+import sys
+import urllib.request
+
+
+def dependency_spotter(first_build: int, second_build: int, os_name: str = "linux-64"):
+    # Form URLs for each build artifact file
+    first_build_output_path = form_url_for_build_artifact(first_build, os_name)
+    second_build_output_path = form_url_for_build_artifact(second_build, os_name)
+
+    # Read in the packages used, with versions
+    first_output_packages = extract_package_versions(first_build_output_path, os_name)
+    second_output_packages = extract_package_versions(second_build_output_path, os_name)
+
+    # Next we compare the versions of each package, or say if a package has been added/removed
+    packages_added = []
+    packages_removed = []
+    packages_changed = {}
+    for package in first_output_packages:
+        if second_output_packages[package] is None:
+            packages_removed.extend(package)
+        elif second_output_packages[package] != first_output_packages[package]:
+            packages_changed[package] = first_output_packages[package] + "  ->  " + second_output_packages[package]
+    for package in second_output_packages:
+        if first_output_packages[package] is None:
+            packages_added.extend(package)
+
+    # Output
+    if len(packages_added) > 0:
+        print("Packages added:")
+        for p in packages_added:
+            print(p)
+        print("")
+    if len(packages_removed) > 0:
+        print("Packages removed:")
+        for p in packages_removed:
+            print(p)
+        print("")
+    if len(packages_changed) > 0:
+        print("Packages changed:")
+        for p in packages_changed:
+            print(p + " changed from " + packages_changed[p])
+
+
+def form_url_for_build_artifact(build_number: int, os_name: str):
+    return (
+        "https://builds.mantidproject.org/job/main_nightly_deployment_prototype/"
+        + str(build_number)
+        + "/artifact/conda-bld/"
+        + os_name
+        + "/env_logs/mantidworkbench_build_environment.txt"
+    )
+
+
+def extract_package_versions(url: str, os_name: str) -> dict:
+    regex_pattern = os_name + "\/([\w\-]+)-([\w\-.]+)\.(conda|tar\.bz2)"  # noqa: W605
+    package_version_dict = {}
+    with urllib.request.urlopen(url) as file:
+        for line in file.readlines():
+            regex_result = re.search(pattern=regex_pattern, string=line.decode("utf-8"))
+            if regex_result is not None and len(regex_result.groups()) == 3:
+                package_name = regex_result.group(1)
+                version = regex_result.group(2)
+                package_version_dict[package_name] = version
+    return package_version_dict
+
+
+if __name__ == "__main__":
+    if len(sys.argv) == 4:
+        dependency_spotter(int(sys.argv[1]), int(sys.argv[2]), sys.argv[3])
+    else:
+        dependency_spotter(int(sys.argv[1]), int(sys.argv[2]))

--- a/tools/Jenkins/dependency_spotter.py
+++ b/tools/Jenkins/dependency_spotter.py
@@ -23,7 +23,8 @@ def dependency_spotter(os_name: str, first_build: int, second_build: int, pipeli
     """
     if second_build < first_build:
         yes_no = input("It looks like the second build is older than the first build, do you want to swap the order? (y/n)")
-        if yes_no.lower() == "y":
+        yes_no = yes_no.lower()
+        if yes_no == "y" or yes_no == "yes":
             first_build, second_build = second_build, first_build
 
     if log_file:

--- a/tools/Jenkins/dependency_spotter.py
+++ b/tools/Jenkins/dependency_spotter.py
@@ -19,8 +19,8 @@ def dependency_spotter(os_name: str, first_build: int, second_build: int, pipeli
 
     print("Files available for comparison:")
     if len(files_in_both_builds) > 0:
-        for file in files_in_both_builds:
-            print(file)
+        for i, file in enumerate(files_in_both_builds):
+            print(f"{i+1}) {file}")
     else:
         print("None")
     print("")
@@ -35,8 +35,23 @@ def dependency_spotter(os_name: str, first_build: int, second_build: int, pipeli
     if len(files_in_both_builds) == 0:
         return
 
+    files_to_compare = input(
+        "Which files do you want to compare? (Either a single number, a comma-separated list of numbers, or 0 for all):"
+    )
+    if files_to_compare == "":
+        return
+    file_indices = files_to_compare.split(",")
+    if "0" in file_indices:
+        file_indices = range(len(files_in_both_builds))
+    else:
+        file_indices = [int(x) - 1 for x in file_indices]
+
+    if file_indices is None:
+        return
+
     print("")
-    for file in files_in_both_builds:
+    for file_id in file_indices:
+        file = files_in_both_builds[file_id]
         print(f"{file}:")
         print("")
         compare_dependencies_for_file(os_name, first_build, second_build, pipeline, file)

--- a/tools/Jenkins/dependency_spotter.py
+++ b/tools/Jenkins/dependency_spotter.py
@@ -4,6 +4,11 @@ import urllib.request
 
 
 def dependency_spotter(os_name: str, first_build: int, second_build: int, pipeline: str, log_file: str):
+    if second_build < first_build:
+        yes_no = input("It looks like the second build is older than the first build, do you want to swap the order? (y/n)")
+        if yes_no.lower() == "y":
+            first_build, second_build = second_build, first_build
+
     if log_file:
         compare_dependencies_for_file(os_name, first_build, second_build, pipeline, log_file)
         return

--- a/tools/Jenkins/dependency_spotter.py
+++ b/tools/Jenkins/dependency_spotter.py
@@ -43,13 +43,7 @@ def dependency_spotter(first_build: int, second_build: int, os_name: str = "linu
 
 
 def form_url_for_build_artifact(build_number: int, os_name: str):
-    return (
-        "https://builds.mantidproject.org/job/main_nightly_deployment_prototype/"
-        + str(build_number)
-        + "/artifact/conda-bld/"
-        + os_name
-        + "/env_logs/mantidworkbench_build_environment.txt"
-    )
+    return f"https://builds.mantidproject.org/job/main_nightly_deployment_prototype/{str(build_number)}/artifact/conda-bld/{os_name}/env_logs/mantidworkbench_build_environment.txt"
 
 
 def extract_package_versions(url: str, os_name: str) -> dict:

--- a/tools/Jenkins/dependency_spotter.py
+++ b/tools/Jenkins/dependency_spotter.py
@@ -170,6 +170,12 @@ if __name__ == "__main__":
     parser.add_argument("--first", "-f", help="First (usually passing) build number", type=int)
     parser.add_argument("--second", "-s", help="Second (usually failing) build number", type=int)
     parser.add_argument("--pipeline", "-p", help="Build pipeline", default="main_nightly_deployment_prototype", type=str)
-    parser.add_argument("--logfile", "-l", help="Log file name to compare, by default all of them are compared", default="", type=str)
+    parser.add_argument(
+        "--logfile",
+        "-l",
+        help="Log file name to compare, by default all of them are compared, e.g mantid_build_environment.txt",
+        default="",
+        type=str,
+    )
     args = parser.parse_args()
     dependency_spotter(os_name=args.os, first_build=args.first, second_build=args.second, pipeline=args.pipeline, log_file=args.logfile)

--- a/tools/Jenkins/dependency_spotter.py
+++ b/tools/Jenkins/dependency_spotter.py
@@ -18,6 +18,9 @@ import urllib.request
 
 
 def dependency_spotter(os_name: str, first_build: int, second_build: int, pipeline: str, log_file: str):
+    """
+    Main entry point
+    """
     if second_build < first_build:
         yes_no = input("It looks like the second build is older than the first build, do you want to swap the order? (y/n)")
         if yes_no.lower() == "y":
@@ -78,6 +81,10 @@ def dependency_spotter(os_name: str, first_build: int, second_build: int, pipeli
 
 
 def extract_available_log_files(os_name: str, build_number: int, pipeline: str) -> list:
+    """
+    Reads the Jenkins page listing the artifacts from the specified build and extracts the
+    available files, e.g. mantid_build_environment.txt. Returns a list of these filenames
+    """
     url = form_url_for_build_artifact(build_number, os_name, pipeline, "")
     build_log_files = []
     regex_logfile = r"(mantid(docs)?[\w]+environment\.txt)"
@@ -91,6 +98,10 @@ def extract_available_log_files(os_name: str, build_number: int, pipeline: str) 
 
 
 def compare_dependencies_for_file(os_name: str, first_build: int, second_build: int, pipeline: str, log_file: str):
+    """
+    For a given file that appears in the build artifacts of the two builds specified, compare the packages and their
+    versions. It will list in the console any packages removed, added, or changed.
+    """
     # Form URLs for each build artifact file
     first_build_output_path = form_url_for_build_artifact(first_build, os_name, pipeline, log_file)
     second_build_output_path = form_url_for_build_artifact(second_build, os_name, pipeline, log_file)
@@ -130,10 +141,17 @@ def compare_dependencies_for_file(os_name: str, first_build: int, second_build: 
 
 
 def form_url_for_build_artifact(build_number: int, os_name: str, pipeline: str, log_file: str):
+    """
+    Form Jenkins URL from specified info.
+    """
     return f"https://builds.mantidproject.org/job/{pipeline}/{build_number}/artifact/conda-bld/{os_name}/env_logs/{log_file}"
 
 
 def extract_package_versions(url: str, os_name: str) -> dict:
+    """
+    Open specified URL and use a regular expression to extract the packages listed, and their versions. Returns
+    a dictionary of packages and their versions
+    """
     regex_pattern = os_name + r"\/([\w\-]+)-([\w\-.]+)\.(conda|tar\.bz2)"
     package_version_dict = {}
     with urllib.request.urlopen(url) as file:

--- a/tools/Jenkins/dependency_spotter.py
+++ b/tools/Jenkins/dependency_spotter.py
@@ -53,7 +53,7 @@ def form_url_for_build_artifact(build_number: int, os_name: str):
 
 
 def extract_package_versions(url: str, os_name: str) -> dict:
-    regex_pattern = os_name + "\/([\w\-]+)-([\w\-.]+)\.(conda|tar\.bz2)"  # noqa: W605
+    regex_pattern = os_name + r"\/([\w\-]+)-([\w\-.]+)\.(conda|tar\.bz2)"
     package_version_dict = {}
     with urllib.request.urlopen(url) as file:
         for line in file.readlines():


### PR DESCRIPTION
**Description of work**
Added a script that takes two build numbers, and optionally the OS label, the pipeline name, and the name of the file to compare. It will then output the changes in conda package versions used in the two builds, if there are any. It uses the build artifacts.

**Purpose of work**
<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
-->
Closes #35817 

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**Summary of work**
<!-- Please provide a short, high level description of the work that was done.
-->
Added script that will output the conda package changes between two Jenkins builds. The script was created and then tested with some existing builds.

**Further detail of work**
<!-- Please provide a more detailed description of the work that has been undertaken.
-->


**To test:**

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

Script is in tools/Jenkins/dependency_spotter.py. It takes 5 arguments, two of which are compulsory. 
"-os" Operating system string, e.g. linux-64 (optional)
"--first", "-f" First (usually passing) build number
"--second", "-s" Second (usually failing) build number
"--pipeline", "-p" Build pipeline, e.g. main_nightly_deployment_prototype (optional)
"--logfile", "-l" Log file name to compare, by default all of them are compared (optional)

When you run the tool it will ask you which files you want to compare interactively, unless you specified a filename as an argument.

<!-- alternative
*There is no associated issue.*
-->

*This does not require release notes* because **it's a developer tool**
<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.