### PR TITLE
Have SaveDiffCal ensure that GroupingWorkspace's base class has a valid detector ID map

### DIFF
--- a/Framework/DataHandling/src/SaveDiffCal.cpp
+++ b/Framework/DataHandling/src/SaveDiffCal.cpp
@@ -182,8 +182,8 @@ void SaveDiffCal::exec() {
   this->generateDetidToIndex();
 
   GroupingWorkspace_sptr groupingWS = getProperty("GroupingWorkspace");
-  if (bool(groupingWS) && groupingWS->IsDetectorIDMappingEmpty())
-    groupingWS->BuildDetectorIDMapping();
+  if (bool(groupingWS) && groupingWS->isDetectorIDMappingEmpty())
+    groupingWS->buildDetectorIDMapping();
 
   MaskWorkspace_const_sptr maskWS = getProperty("MaskWorkspace");
 

--- a/Framework/DataHandling/src/SaveDiffCal.cpp
+++ b/Framework/DataHandling/src/SaveDiffCal.cpp
@@ -24,6 +24,7 @@ using Mantid::API::PropertyMode;
 using Mantid::API::WorkspaceProperty;
 using Mantid::DataObjects::GroupingWorkspace;
 using Mantid::DataObjects::GroupingWorkspace_const_sptr;
+using Mantid::DataObjects::GroupingWorkspace_sptr;
 using Mantid::DataObjects::MaskWorkspace;
 using Mantid::DataObjects::MaskWorkspace_const_sptr;
 using Mantid::Kernel::Direction;
@@ -179,9 +180,12 @@ bool SaveDiffCal::tableHasColumn(const std::string &ColumnName) const {
 void SaveDiffCal::exec() {
   m_calibrationWS = getProperty("CalibrationWorkspace");
   this->generateDetidToIndex();
-  GroupingWorkspace_const_sptr groupingWS = getProperty("GroupingWorkspace");
+
+  GroupingWorkspace_sptr groupingWS = getProperty("GroupingWorkspace");
+  if (bool(groupingWS) && groupingWS->IsDetectorIDMappingEmpty())
+    groupingWS->BuildDetectorIDMapping();
+
   MaskWorkspace_const_sptr maskWS = getProperty("MaskWorkspace");
-  std::string filename = getProperty("Filename");
 
   // initialize `m_numValues` as the minimum of (CalibrationWorkspace_row_count,
   // GroupingWorkspace_histogram_count, MaskWorkspace_histogram_count)
@@ -194,6 +198,7 @@ void SaveDiffCal::exec() {
   }
 
   // delete the file if it already exists
+  std::string filename = getProperty("Filename");
   if (Poco::File(filename).exists()) {
     Poco::File(filename).remove();
   }

--- a/Framework/DataObjects/inc/MantidDataObjects/SpecialWorkspace2D.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/SpecialWorkspace2D.h
@@ -47,6 +47,8 @@ public:
   @return Standard string name  */
   const std::string id() const override { return "SpecialWorkspace2D"; }
 
+  bool IsDetectorIDMappingEmpty() const { return detID_to_WI.empty(); }
+  void BuildDetectorIDMapping();
   double getValue(const detid_t detectorID) const;
   double getValue(const detid_t detectorID, const double defaultValue) const;
 

--- a/Framework/DataObjects/inc/MantidDataObjects/SpecialWorkspace2D.h
+++ b/Framework/DataObjects/inc/MantidDataObjects/SpecialWorkspace2D.h
@@ -47,8 +47,8 @@ public:
   @return Standard string name  */
   const std::string id() const override { return "SpecialWorkspace2D"; }
 
-  bool IsDetectorIDMappingEmpty() const { return detID_to_WI.empty(); }
-  void BuildDetectorIDMapping();
+  bool isDetectorIDMappingEmpty() const { return detID_to_WI.empty(); }
+  void buildDetectorIDMapping();
   double getValue(const detid_t detectorID) const;
   double getValue(const detid_t detectorID, const double defaultValue) const;
 

--- a/Framework/DataObjects/src/SpecialWorkspace2D.cpp
+++ b/Framework/DataObjects/src/SpecialWorkspace2D.cpp
@@ -41,13 +41,7 @@ SpecialWorkspace2D::SpecialWorkspace2D(const Geometry::Instrument_const_sptr &in
   this->MatrixWorkspace::rebuildSpectraMapping(includeMonitors);
 
   // Make the mapping, which will be used for speed later.
-  detID_to_WI.clear();
-  for (size_t wi = 0; wi < getNumberHistograms(); wi++) {
-    auto &dets = getSpectrum(wi).getDetectorIDs();
-    for (auto det : dets) {
-      detID_to_WI[det] = wi;
-    }
-  }
+  BuildDetectorIDMapping();
 }
 
 //----------------------------------------------------------------------------------------------
@@ -59,13 +53,7 @@ SpecialWorkspace2D::SpecialWorkspace2D(const API::MatrixWorkspace_const_sptr &pa
   this->initialize(parent->getNumberHistograms(), 1, 1);
   API::WorkspaceFactory::Instance().initializeFromParent(*parent, *this, false);
   // Make the mapping, which will be used for speed later.
-  detID_to_WI.clear();
-  for (size_t wi = 0; wi < getNumberHistograms(); wi++) {
-    auto &dets = getSpectrum(wi).getDetectorIDs();
-    for (auto det : dets) {
-      detID_to_WI[det] = wi;
-    }
-  }
+  BuildDetectorIDMapping();
 }
 
 //----------------------------------------------------------------------------------------------
@@ -98,6 +86,16 @@ const std::string SpecialWorkspace2D::toString() const {
   os << "Title: " << getTitle() << "\n";
   os << "Histograms: " << getNumberHistograms() << "\n";
   return os.str();
+}
+
+void SpecialWorkspace2D::BuildDetectorIDMapping() {
+  detID_to_WI.clear();
+  for (size_t wi = 0; wi < getNumberHistograms(); wi++) {
+    auto &dets = getSpectrum(wi).getDetectorIDs();
+    for (auto det : dets) {
+      detID_to_WI[det] = wi;
+    }
+  }
 }
 
 //----------------------------------------------------------------------------------------------

--- a/Framework/DataObjects/src/SpecialWorkspace2D.cpp
+++ b/Framework/DataObjects/src/SpecialWorkspace2D.cpp
@@ -41,7 +41,7 @@ SpecialWorkspace2D::SpecialWorkspace2D(const Geometry::Instrument_const_sptr &in
   this->MatrixWorkspace::rebuildSpectraMapping(includeMonitors);
 
   // Make the mapping, which will be used for speed later.
-  BuildDetectorIDMapping();
+  buildDetectorIDMapping();
 }
 
 //----------------------------------------------------------------------------------------------
@@ -53,7 +53,7 @@ SpecialWorkspace2D::SpecialWorkspace2D(const API::MatrixWorkspace_const_sptr &pa
   this->initialize(parent->getNumberHistograms(), 1, 1);
   API::WorkspaceFactory::Instance().initializeFromParent(*parent, *this, false);
   // Make the mapping, which will be used for speed later.
-  BuildDetectorIDMapping();
+  buildDetectorIDMapping();
 }
 
 //----------------------------------------------------------------------------------------------
@@ -88,7 +88,7 @@ const std::string SpecialWorkspace2D::toString() const {
   return os.str();
 }
 
-void SpecialWorkspace2D::BuildDetectorIDMapping() {
+void SpecialWorkspace2D::buildDetectorIDMapping() {
   detID_to_WI.clear();
   for (size_t wi = 0; wi < getNumberHistograms(); wi++) {
     auto &dets = getSpectrum(wi).getDetectorIDs();

--- a/Framework/DataObjects/test/SpecialWorkspace2DTest.h
+++ b/Framework/DataObjects/test/SpecialWorkspace2DTest.h
@@ -32,6 +32,27 @@ public:
     TS_ASSERT_EQUALS(ws->blocksize(), 1);
   }
 
+  void test_empty_detID_map() {
+    // Create and initailize a workspace without an instrument
+    SpecialWorkspace2D_sptr ws(new SpecialWorkspace2D());
+    TS_ASSERT_THROWS_NOTHING(ws->initialize(1, 1, 1));
+    TS_ASSERT_EQUALS(ws->getNumberHistograms(), 1);
+    TS_ASSERT_EQUALS(ws->blocksize(), 1);
+
+    // Confirm that the detector ID map is empty
+    TS_ASSERT(ws->isDetectorIDMappingEmpty());
+
+    // Set a detector ID for the spectrum. Confirm that we can't get/set value for that detector ID
+    TS_ASSERT_THROWS_NOTHING(ws->getSpectrum(0).setDetectorID(0));
+    TSM_ASSERT_THROWS_ANYTHING("Can't get value for detector ID=0", ws->getValue(0));
+    TSM_ASSERT_THROWS_ANYTHING("Can't set value for detector ID=0", ws->setValue(0, 0, 0));
+
+    // Build the detector ID map. Confirm that we now can get/set value for that detector ID
+    TS_ASSERT_THROWS_NOTHING(ws->buildDetectorIDMapping());
+    TS_ASSERT_THROWS_NOTHING(ws->getValue(0));
+    TS_ASSERT_THROWS_NOTHING(ws->setValue(0, 0, 0));
+  }
+
   void testClone() {
     // As test_setValue_getValue, set on ws, get on clone.
     Instrument_sptr inst = ComponentCreationHelper::createTestInstrumentCylindrical(5);

--- a/Framework/DataObjects/test/SpecialWorkspace2DTest.h
+++ b/Framework/DataObjects/test/SpecialWorkspace2DTest.h
@@ -33,7 +33,7 @@ public:
   }
 
   void test_empty_detID_map() {
-    // Create and initailize a workspace without an instrument
+    // Create and initialize a workspace without an instrument
     SpecialWorkspace2D_sptr ws(new SpecialWorkspace2D());
     TS_ASSERT_THROWS_NOTHING(ws->initialize(1, 1, 1));
     TS_ASSERT_EQUALS(ws->getNumberHistograms(), 1);

--- a/docs/source/release/v6.8.0/Framework/Data_Handling/New_features/35867.rst
+++ b/docs/source/release/v6.8.0/Framework/Data_Handling/New_features/35867.rst
@@ -1,0 +1,1 @@
+* :ref:`SaveDiffCal <algm-SaveDiffCal>` now ensures that the input grouping workspace is fully initialized.


### PR DESCRIPTION
**Description of work**
Currently `SpecialWorkspace2D`, the base class of `GroupingWorkspace`, builds its `detID_to_WI` map only if one of the explicit constructors is called.  If, however, `SpecialWorkspace2D` is built with a default constructor, the map is not built.  So depending on how `GroupingWorkspace` was created, the map might be null.  The purpose of this PR is to allow `SaveDiffCal` algorithm, which uses `GroupingWorkspace` as input, to ensure that the map _is_ built.
 
**To test:**
../mantid/build/bin/DataHandlingTest SaveDiffCalTest
../mantid/build/bin/DataObjectsTest SpecialWorkspace2DTest test_empty_detID_map


#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.