### PR TITLE
Adding DEMAND to DGSPlanner

### DIFF
--- a/docs/source/release/v6.8.0/Diffraction/Single_Crystal/New_features/35868.rst
+++ b/docs/source/release/v6.8.0/Diffraction/Single_Crystal/New_features/35868.rst
@@ -1,0 +1,1 @@
+- Constant wavelength HFIR DEMAND instrument has been added to DGSPlanner

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/DGSPlanner/DGSPlannerGUI.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/DGSPlanner/DGSPlannerGUI.py
@@ -155,7 +155,7 @@ class DGSPlannerGUI(QtWidgets.QWidget):
             self.dimensionWidget.set_editMax4(upperBound)
 
     def instrumentUpdateEvent(self):
-        changeToElastic = self.masterDict["instrument"] in ["WAND\u00B2"]
+        changeToElastic = self.masterDict["instrument"] in ["DEMAND", "WAND\u00B2"]
         if changeToElastic != self.instrumentElastic:
             self.instrumentElastic = changeToElastic
             self.dimensionWidget.toggleDeltaE(not changeToElastic)
@@ -244,7 +244,9 @@ class DGSPlannerGUI(QtWidgets.QWidget):
                 pass
 
             instrumentName = self.masterDict["instrument"]
-            if instrumentName == "WAND\u00B2":
+            if instrumentName == "DEMAND":
+                instrumentName = "HB3A"
+            elif instrumentName == "WAND\u00B2":
                 instrumentName = "WAND"
 
             mantid.simpleapi.LoadEmptyInstrument(
@@ -260,6 +262,17 @@ class DGSPlannerGUI(QtWidgets.QWidget):
                 mantid.simpleapi.RotateInstrumentComponent(
                     Workspace="__temp_instrument", ComponentName="Tank", Y=1, Angle=str(self.masterDict["S2"]), RelativeRotation=False
                 )
+            elif instrumentName == "HB3A":
+                mantid.simpleapi.AddSampleLog(
+                    Workspace="__temp_instrument", LogName="2theta", LogText=str(self.masterDict["S2"]), LogType="Number Series"
+                )
+                mantid.simpleapi.AddSampleLog(
+                    Workspace="__temp_instrument",
+                    LogName="det_trans",
+                    LogText=str(self.masterDict["DetZ"]),
+                    LogType="Number Series",
+                )
+                mantid.simpleapi.LoadInstrument(Workspace="__temp_instrument", RewriteSpectraMap=True, InstrumentName="HB3A")
             elif instrumentName == "WAND":
                 mantid.simpleapi.AddSampleLog(
                     Workspace="__temp_instrument", LogName="HB2C:Mot:s2.RBV", LogText=str(self.masterDict["S2"]), LogType="Number Series"
@@ -288,7 +301,7 @@ class DGSPlannerGUI(QtWidgets.QWidget):
                         return
             if self.masterDict["makeFast"]:
                 sp = numpy.arange(mantid.mtd["__temp_instrument"].getNumberHistograms())
-                if self.masterDict["instrument"] == "WAND\u00B2":
+                if self.masterDict["instrument"] in ["DEMAND", "WAND\u00B2"]:
                     sp = sp.reshape(-1, 512)
                     tomask = (
                         sp[:, 1::4].ravel().tolist()
@@ -328,7 +341,7 @@ class DGSPlannerGUI(QtWidgets.QWidget):
         progressDialog.setRange(0, self.iterations)
         progressDialog.setWindowTitle("DGSPlanner progress")
 
-        if self.masterDict["instrument"] == "WAND\u00B2":
+        if self.masterDict["instrument"] in ["DEMAND", "WAND\u00B2"]:
             ei = UnitConversion.run("Wavelength", "Energy", self.masterDict["Ei"], 0, 0, 0, Elastic, 0)
         else:
             ei = self.masterDict["Ei"]

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/DGSPlanner/InstrumentSetupWidget.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/DGSPlanner/InstrumentSetupWidget.py
@@ -177,6 +177,7 @@ class InstrumentSetupWidget(QtWidgets.QWidget):
             "CHESS",
             "CNCS",
             "DNS",
+            "DEMAND",
             "EXED",
             "FOCUS",
             "HET",
@@ -367,30 +368,43 @@ class InstrumentSetupWidget(QtWidgets.QWidget):
         d = dict()
         self.instrument = text
         d["instrument"] = str(self.instrument)
-        if self.instrument in ["HYSPEC", "EXED", "WAND\u00B2"]:
+        if self.instrument in ["HYSPEC", "EXED", "DEMAND", "WAND\u00B2"]:
             self.labelS2.show()
             self.editS2.show()
         else:
             self.labelS2.hide()
             self.editS2.hide()
 
-        if self.instrument in ["WAND\u00B2"]:
+        if self.instrument in ["DEMAND", "WAND\u00B2"]:
             self.labelDetZ.show()
             self.editDetZ.show()
             self.setLabelEi("Wavelength")
-            self.setEiVal(str(1.488))
-            self.goniometerNames = ["s1", "sgl", "sgu"]
-            self.goniometerDirections = ["0,1,0", "1,0,0", "0,0,1"]
-            self.goniometerRotationSense = [1, -1, -1]
+            if self.instrument == "DEMAND":
+                self.setDetZVal(str(410.258))
+                self.setLabelDetZ("DetTrans")
+                self.setEiVal(str(1.542))
+                self.goniometerNames = ["omega", "chi", "phi"]
+                self.goniometerDirections = ["0,1,0", "0,0,1", "0,1,0"]
+                self.goniometerRotationSense = [-1, -1, -1]
+            else:
+                self.setDetZVal(str(0.0))
+                self.setLabelDetZ("DetZ")
+                self.setEiVal(str(1.488))
+                self.goniometerNames = ["s1", "sgl", "sgu"]
+                self.goniometerDirections = ["0,1,0", "1,0,0", "0,0,1"]
+                self.goniometerRotationSense = [1, -1, -1]
         else:
             self.labelDetZ.hide()
             self.editDetZ.hide()
             self.setLabelEi("Incident Energy")
             self.setEiVal(str(10.0))
-            # d['gonioLabels']=['psi','gl','gs']
             self.goniometerNames = ["psi", "gl", "gs"]
             self.goniometerDirections = ["0,1,0", "0,0,1", "1,0,0"]
             self.goniometerRotationSense = [1, 1, 1]
+
+        d["gonioLabels"] = self.goniometerNames
+        d["gonioDirs"] = self.goniometerDirections
+        d["gonioSenses"] = self.goniometerRotationSense
 
         self.updateAll(**d)
         self.updateTable()
@@ -422,6 +436,14 @@ class InstrumentSetupWidget(QtWidgets.QWidget):
         self.Ei = float(val)
         self.editEi.setText(val)
         self.updateAll(Ei=float(val))
+
+    def setLabelDetZ(self, newLabel):
+        self.labelDetZ.setText(newLabel)
+
+    def setDetZVal(self, val):
+        self.DetZ = float(val)
+        self.editDetZ.setText(val)
+        self.updateAll(DetZ=float(val))
 
     def getInstrumentComboBox(self):
         return self.combo


### PR DESCRIPTION
**Description of work**

User requests diffraction instrument DEMAND be added to DGS planning tool.

**Purpose of work**
<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
-->

DEMAND is missing from the planning tool.

**Summary of work**
<!-- Please provide a short, high level description of the work that was done.
-->

Added in DEMAND with it's own goniometer settings and detector translation.

**Further detail of work**
<!-- Please provide a more detailed description of the work that has been undertaken.
-->

Exploit similarities to WAND2 in DGS reduction using constant wavelength.

**To test:**

![image](https://github.com/mantidproject/mantid/assets/13754794/9d03f2cf-2b18-43e3-b804-a9f766fa6b78)


1. Open DGSPlanner
2. Select DEMAND
3. Choose setting and verify the correctness of the reciprocal space coverage
4. Switch to other instruments to verify previous behavior.

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.