### PR TITLE
Handle error thrown by the plot script generator when generating an unsupported plot.

### DIFF
--- a/docs/source/release/v6.8.0/Workbench/Bugfixes/34397.rst
+++ b/docs/source/release/v6.8.0/Workbench/Bugfixes/34397.rst
@@ -1,1 +1,1 @@
-- Catch unhandled exception when attempting to generate a plot script from and unsupported plot.
+- Catch unhandled exception when attempting to generate a plot script from an unsupported plot.

--- a/docs/source/release/v6.8.0/Workbench/Bugfixes/34397.rst
+++ b/docs/source/release/v6.8.0/Workbench/Bugfixes/34397.rst
@@ -1,0 +1,1 @@
+- Catch unhandled exception when attempting to generate a plot script from and unsupported plot.

--- a/qt/applications/workbench/workbench/plotting/figuremanager.py
+++ b/qt/applications/workbench/workbench/plotting/figuremanager.py
@@ -21,7 +21,7 @@ from matplotlib.collections import LineCollection
 from mpl_toolkits.mplot3d.axes3d import Axes3D
 from qtpy.QtCore import QObject, Qt
 from qtpy.QtGui import QImage
-from qtpy.QtWidgets import QApplication, QLabel, QFileDialog
+from qtpy.QtWidgets import QApplication, QLabel, QFileDialog, QMessageBox
 
 from mantid.api import AnalysisDataService, AnalysisDataServiceObserver, ITableWorkspace, MatrixWorkspace
 from mantid.kernel import logger
@@ -449,25 +449,43 @@ class FigureManagerWorkbench(FigureManagerBase, QObject):
         GlobalFigureManager.figure_visibility_changed(self.num)
 
     def generate_plot_script_clipboard(self):
-        script = generate_script(self.canvas.figure, exclude_headers=True)
-        QApplication.clipboard().setText(script)
-        logger.notice("Plotting script copied to clipboard.")
+        try:
+            script = generate_script(self.canvas.figure, exclude_headers=True)
+        except Exception as e:
+            self._handle_script_generation_exception(e)
+        else:
+            QApplication.clipboard().setText(script)
+            logger.notice("Plotting script copied to clipboard.")
 
     def generate_plot_script_file(self):
-        script = generate_script(self.canvas.figure)
-        filepath = open_a_file_dialog(
-            parent=self.canvas,
-            default_suffix=".py",
-            file_filter="Python Files (*.py)",
-            accept_mode=QFileDialog.AcceptSave,
-            file_mode=QFileDialog.AnyFile,
+        try:
+            script = generate_script(self.canvas.figure)
+        except Exception as e:
+            self._handle_script_generation_exception(e)
+        else:
+            filepath = open_a_file_dialog(
+                parent=self.canvas,
+                default_suffix=".py",
+                file_filter="Python Files (*.py)",
+                accept_mode=QFileDialog.AcceptSave,
+                file_mode=QFileDialog.AnyFile,
+            )
+            if filepath:
+                try:
+                    with open(filepath, "w") as f:
+                        f.write(script)
+                except IOError as io_error:
+                    logger.error("Could not write file: {}\n{}" "".format(filepath, io_error))
+
+    # If a user creates a plot from a script using mpl features we don't support, asking for a recreated script from the
+    # plot can lead to problems. This should only really be supported for plots created by workbench.
+    def _handle_script_generation_exception(self, e: Exception):
+        msg = (
+            "Problem encountered when generating the plot script.\n"
+            "Plot script generation is only officially supported for plots created by Mantid Workbench."
         )
-        if filepath:
-            try:
-                with open(filepath, "w") as f:
-                    f.write(script)
-            except IOError as io_error:
-                logger.error("Could not write file: {}\n{}" "".format(filepath, io_error))
+        QMessageBox.critical(self.window, "Error generating plot script", msg + "\n\n" + str(e), QMessageBox.Ok, QMessageBox.NoButton)
+        logger.error(msg)
 
     def set_figure_zoom_to_display_all(self):
         axes = self.canvas.figure.get_axes()


### PR DESCRIPTION
**Description of work**

This PR is to better handle exceptions when generating a script from a plot. The example from the issue is created using a script from one of our tutorials. It was agreed that plot script generation shouldn't be supported for any plots made by a user script (only for those created by Workbench).
This PR simply handles any exceptions that might arise and gives the user appropriate feedback.

**To test:**

Run the script
```
from mantid.simpleapi import *
import matplotlib.pyplot as plt
from matplotlib.ticker import (MultipleLocator, AutoMinorLocator)

#Example data
exp_decay = CreateSampleWorkspace(Function='User Defined',
                                  UserDefinedFunction='\
                                  name=ExpDecay,Lifetime = 20,Height = 200;name=Gaussian,\
                                  PeakCentre=50, Height=10, Sigma=3',
                                  XMax=100, BinWidth=2)

#Create figure and axes
fig, axes = plt.subplots(ncols=2,nrows=1,subplot_kw={'projection': 'mantid'})

# Plot with errorbars on the left set of axes
axes[0].plot(exp_decay, specNum=1, color='red', label='400 K', linewidth=1.0, drawstyle='steps')
axes[0].set_title('Steps and Grids')
axes[0].xaxis.set_minor_locator(AutoMinorLocator())
axes[0].grid(True, which = 'both', axis = 'both') # major/minor, x/y

# Add an inset, use trial and error to find the right location
inset = fig.add_axes([0.77, 0.70, 0.18, 0.18],projection='mantid') #[left, bottom, width, height]
inset.plot(exp_decay, specNum=5, color='blue', label='Log Peak', marker ='.')
plt.yscale('log') #only affects the most recently called axes
inset.set_xlim(40, 60), inset.set_ylim(5, 20)
inset.xaxis.set_minor_locator(AutoMinorLocator()) #inserts 5 minor b/w each major
inset.tick_params(which='minor', width = 0.5, length=4, color='b', direction='in', top='on')
inset.set_title('Inset')

#Plot on the right set of axes
axes[1].errorbar(exp_decay, specNum=1, capsize=2.0, errorevery=5, color='green', label='spec 1', linestyle='--')
axes[1].set_xlabel('Time-of-flight ($\mu s$)', fontsize = 12, fontstyle = 'italic', fontweight = 'bold')
axes[1].set_ylabel('Counts ($\mu s$)$^{-1}$')
axes[1].set_title('Errorbars')

#Use tight layout for subplots and create a legend
plt.tight_layout()
fig.legend(loc='center right')

fig.show()
```
Try to
- Generate a script and copy to clipboard.
- Generate a script and save to file

In both cases, a warning box should appear.

Also try loading some data, plotting a plot, changing some settings, and generating a script.
This should work as normal.

Fixes #34387

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.