### PR TITLE
Adapt PowderreduceP2d to usage with SNAP data

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/PowderReduceP2D.py
+++ b/Framework/PythonInterface/plugins/algorithms/PowderReduceP2D.py
@@ -818,7 +818,7 @@ class PowderReduceP2D(DataProcessorAlgorithm):
             if self._doEdge:
                 self.binDataEdge(self._emptyWS)
             else:
-                self.binDataLog(self._sampleWS, list(self._dSpaceBinning), list(self._dPerpendicularBinning))
+                self.binDataLog(self._emptyWS, list(self._dSpaceBinning), list(self._dPerpendicularBinning))
 
         # Process vana data if given
         if self._doVana:
@@ -827,7 +827,7 @@ class PowderReduceP2D(DataProcessorAlgorithm):
             if self._doEdge:
                 self.binDataEdge(self._vanaWS)
             else:
-                self.binDataLog(self._sampleWS, list(self._dSpaceBinning), list(self._dPerpendicularBinning))
+                self.binDataLog(self._vanaWS, list(self._dSpaceBinning), list(self._dPerpendicularBinning))
             if not self._useDetCal:
                 self.postProcessVana(self._vanaWS)
             if self._doVanaEmpty:
@@ -836,7 +836,7 @@ class PowderReduceP2D(DataProcessorAlgorithm):
                 if self._doEdge:
                     self.binDataEdge(self._vanaEmptyWS)
                 else:
-                    self.binDataLog(self._sampleWS, list(self._dSpaceBinning), list(self._dPerpendicularBinning))
+                    self.binDataLog(self._vanaEmptyWS, list(self._dSpaceBinning), list(self._dPerpendicularBinning))
 
         # Check all datafiles for negative Values and correct those
         self.checkForNegatives(

--- a/Framework/PythonInterface/plugins/algorithms/PowderReduceP2D.py
+++ b/Framework/PythonInterface/plugins/algorithms/PowderReduceP2D.py
@@ -720,12 +720,12 @@ class PowderReduceP2D(DataProcessorAlgorithm):
             InputWorkspace=wsName, OutputWorkspace=wsName, BinEdgesFile=self._binEdgesFile, NormalizeByBinArea=self._normalizeByBinArea
         )
 
-    def binDataLog(self, wsName):
+    def binDataLog(self, wsName, dSpaceBinning, dPerpBinning):
         Bin2DPowderDiffraction(
             InputWorkspace=wsName,
             OutputWorkspace=wsName,
-            dSpaceBinning=[self._dMin, self._dSpaceBinning[0], self._dMax],
-            dPerpendicularBinning=[self._dpMin, self._dPerpendicularBinning[0], self._dpMax],
+            dSpaceBinning=[dSpaceBinning[0], dSpaceBinning[1], dSpaceBinning[2]],
+            dPerpendicularBinning=[dPerpBinning[0], dPerpBinning[1], dPerpBinning[2]],
         )
 
     def postProcessVana(self, wsName):
@@ -810,7 +810,7 @@ class PowderReduceP2D(DataProcessorAlgorithm):
         if self._doEdge:
             self.binDataEdge(self._sampleWS)
         else:
-            self.binDataLog(self._sampleWS)
+            self.binDataLog(self._sampleWS, list(self._dSpaceBinning), list(self._dPerpendicularBinning))
 
         # Process empty data if given
         if self._doEmpty:
@@ -818,7 +818,7 @@ class PowderReduceP2D(DataProcessorAlgorithm):
             if self._doEdge:
                 self.binDataEdge(self._emptyWS)
             else:
-                self.binDataLog(self._emptyWS)
+                self.binDataLog(self._sampleWS, list(self._dSpaceBinning), list(self._dPerpendicularBinning))
 
         # Process vana data if given
         if self._doVana:
@@ -827,7 +827,7 @@ class PowderReduceP2D(DataProcessorAlgorithm):
             if self._doEdge:
                 self.binDataEdge(self._vanaWS)
             else:
-                self.binDataLog(self._vanaWS)
+                self.binDataLog(self._sampleWS, list(self._dSpaceBinning), list(self._dPerpendicularBinning))
             if not self._useDetCal:
                 self.postProcessVana(self._vanaWS)
             if self._doVanaEmpty:
@@ -836,7 +836,7 @@ class PowderReduceP2D(DataProcessorAlgorithm):
                 if self._doEdge:
                     self.binDataEdge(self._vanaEmptyWS)
                 else:
-                    self.binDataLog(self._vanaEmptyWS)
+                    self.binDataLog(self._sampleWS, list(self._dSpaceBinning), list(self._dPerpendicularBinning))
 
         # Check all datafiles for negative Values and correct those
         self.checkForNegatives(

--- a/Framework/PythonInterface/plugins/algorithms/PowderReduceP2D.py
+++ b/Framework/PythonInterface/plugins/algorithms/PowderReduceP2D.py
@@ -720,12 +720,12 @@ class PowderReduceP2D(DataProcessorAlgorithm):
             InputWorkspace=wsName, OutputWorkspace=wsName, BinEdgesFile=self._binEdgesFile, NormalizeByBinArea=self._normalizeByBinArea
         )
 
-    def binDataLog(self, wsName, dSpaceBinning, dPerpBinning):
+    def binDataLog(self, wsName):
         Bin2DPowderDiffraction(
             InputWorkspace=wsName,
             OutputWorkspace=wsName,
-            dSpaceBinning=[dSpaceBinning[0], dSpaceBinning[1], dSpaceBinning[2]],
-            dPerpendicularBinning=[dPerpBinning[0], dPerpBinning[1], dPerpBinning[2]],
+            dSpaceBinning=[self._dMin, self._dSpaceBinning[0], self._dMax],
+            dPerpendicularBinning=[self._dpMin, self._dPerpendicularBinning[0], self._dpMax],
         )
 
     def postProcessVana(self, wsName):
@@ -810,7 +810,7 @@ class PowderReduceP2D(DataProcessorAlgorithm):
         if self._doEdge:
             self.binDataEdge(self._sampleWS)
         else:
-            self.binDataLog(self._sampleWS, list(self._dSpaceBinning), list(self._dPerpendicularBinning))
+            self.binDataLog(self._sampleWS)
 
         # Process empty data if given
         if self._doEmpty:
@@ -818,7 +818,7 @@ class PowderReduceP2D(DataProcessorAlgorithm):
             if self._doEdge:
                 self.binDataEdge(self._emptyWS)
             else:
-                self.binDataLog(self._emptyWS, list(self._dSpaceBinning), list(self._dPerpendicularBinning))
+                self.binDataLog(self._emptyWS)
 
         # Process vana data if given
         if self._doVana:
@@ -827,7 +827,7 @@ class PowderReduceP2D(DataProcessorAlgorithm):
             if self._doEdge:
                 self.binDataEdge(self._vanaWS)
             else:
-                self.binDataLog(self._vanaWS, list(self._dSpaceBinning), list(self._dPerpendicularBinning))
+                self.binDataLog(self._vanaWS)
             if not self._useDetCal:
                 self.postProcessVana(self._vanaWS)
             if self._doVanaEmpty:
@@ -836,7 +836,7 @@ class PowderReduceP2D(DataProcessorAlgorithm):
                 if self._doEdge:
                     self.binDataEdge(self._vanaEmptyWS)
                 else:
-                    self.binDataLog(self._vanaEmptyWS, list(self._dSpaceBinning), list(self._dPerpendicularBinning))
+                    self.binDataLog(self._vanaEmptyWS)
 
         # Check all datafiles for negative Values and correct those
         self.checkForNegatives(

--- a/Testing/SystemTests/tests/framework/PowderReduceP2DTest.py
+++ b/Testing/SystemTests/tests/framework/PowderReduceP2DTest.py
@@ -122,11 +122,11 @@ class PowderReduceP2DTest(systemtesting.MantidSystemTest):
 
     def _dSpaceBinning(self):
         """d binning used for testing the algorithm"""
-        return [0.1, -0.02, 2]
+        return [0.1 + 0.02, -0.02, 2 - 0.02]
 
     def _dPerpendicularBinning(self):
         """d perpendicular binning used for testing the algorithm"""
-        return [0.4, 0.1, 2]
+        return [0.4 - 0.1, 0.1, 2 + 0.1]
 
     def _FWHM(self):
         """FWHM used for testing the algorithm"""

--- a/Testing/SystemTests/tests/framework/PowderReduceP2DTest.py
+++ b/Testing/SystemTests/tests/framework/PowderReduceP2DTest.py
@@ -27,7 +27,6 @@ class PowderReduceP2DTest(systemtesting.MantidSystemTest):
         self.calFile = self._calFile()
         self.twoThetaMin = self._twoThetaMin()
         self.twoThetaMax = self._twoThetaMax()
-        self.wavelengthCenter = self._wavelengthCenter()
         self.lambdaMin = self._lambdaMin()
         self.lambdaMax = self._lambdaMax()
         self.dMin = self._dMin()
@@ -54,7 +53,6 @@ class PowderReduceP2DTest(systemtesting.MantidSystemTest):
             CalFile=self.calFile,
             TwoThetaMin=self.twoThetaMin,
             TwoThetaMax=self.twoThetaMax,
-            WavelengthCenter=self.wavelengthCenter,
             LambdaMin=self.lambdaMin,
             LambdaMax=self.lambdaMax,
             DMin=self.dMin,
@@ -98,10 +96,6 @@ class PowderReduceP2DTest(systemtesting.MantidSystemTest):
         """2theta max used for testing the algorithm"""
         return 150
 
-    def _wavelengthCenter(self):
-        """center wavelength used for testing the algorithm"""
-        return 0.566
-
     def _lambdaMin(self):
         """lambda min used for testing the algorithm"""
         return 0.1
@@ -128,11 +122,11 @@ class PowderReduceP2DTest(systemtesting.MantidSystemTest):
 
     def _dSpaceBinning(self):
         """d binning used for testing the algorithm"""
-        return -0.02
+        return [0.1, -0.02, 2]
 
     def _dPerpendicularBinning(self):
         """d perpendicular binning used for testing the algorithm"""
-        return 0.1
+        return [0.4, 0.1, 2]
 
     def _FWHM(self):
         """FWHM used for testing the algorithm"""

--- a/Testing/SystemTests/tests/framework/PowderReduceP2DTest.py
+++ b/Testing/SystemTests/tests/framework/PowderReduceP2DTest.py
@@ -106,7 +106,7 @@ class PowderReduceP2DTest(systemtesting.MantidSystemTest):
 
     def _dMin(self):
         """d min used for testing the algorithm"""
-        return 0.12
+        return 0.1
 
     def _dMax(self):
         """d max used for testing the algorithm"""

--- a/Testing/SystemTests/tests/framework/PowderReduceP2DTest.py
+++ b/Testing/SystemTests/tests/framework/PowderReduceP2DTest.py
@@ -106,27 +106,27 @@ class PowderReduceP2DTest(systemtesting.MantidSystemTest):
 
     def _dMin(self):
         """d min used for testing the algorithm"""
-        return 0.1
+        return 0.12
 
     def _dMax(self):
         """d max used for testing the algorithm"""
-        return 2
+        return 1.98
 
     def _dpMin(self):
         """dp min used for testing the algorithm"""
-        return 0.4
+        return 0.3
 
     def _dpMax(self):
         """dp max used for testing the algorithm"""
-        return 2
+        return 2.1
 
     def _dSpaceBinning(self):
         """d binning used for testing the algorithm"""
-        return [0.1 + 0.02, -0.02, 2 - 0.02]
+        return -0.02
 
     def _dPerpendicularBinning(self):
         """d perpendicular binning used for testing the algorithm"""
-        return [0.4 - 0.1, 0.1, 2 + 0.1]
+        return 0.1
 
     def _FWHM(self):
         """FWHM used for testing the algorithm"""

--- a/Testing/SystemTests/tests/framework/PowderReduceP2DTest.py
+++ b/Testing/SystemTests/tests/framework/PowderReduceP2DTest.py
@@ -110,23 +110,23 @@ class PowderReduceP2DTest(systemtesting.MantidSystemTest):
 
     def _dMax(self):
         """d max used for testing the algorithm"""
-        return 1.98
+        return 2
 
     def _dpMin(self):
         """dp min used for testing the algorithm"""
-        return 0.3
+        return 0.2
 
     def _dpMax(self):
         """dp max used for testing the algorithm"""
-        return 2.1
+        return 2
 
     def _dSpaceBinning(self):
         """d binning used for testing the algorithm"""
-        return -0.02
+        return [0.1 + 0.02, -0.02, 2 - 0.02]
 
     def _dPerpendicularBinning(self):
         """d perpendicular binning used for testing the algorithm"""
-        return 0.1
+        return [0.4 - 0.1, 0.1, 2 + 0.1]
 
     def _FWHM(self):
         """FWHM used for testing the algorithm"""

--- a/docs/source/algorithms/PowderReduceP2D-v1.rst
+++ b/docs/source/algorithms/PowderReduceP2D-v1.rst
@@ -17,14 +17,14 @@ additional measurements of Vanadium(``VanaData``) and an empty can(``EmptyData``
 but are not necessary. If an empty measurement is specified, it is substracted from the sample
 measurement. If a Vanadium measurement is specified, the sample measurement is divided by the
 vanadium measurement. If either or both are not specified these steps are skipped. It is highly
-recommended to specify both.
+recommended to specify both. Additionally, an empty vanadium measurement can be supplied.
 
 Calibration, Grouping, Masking
 ##############################
 
 The calibration is done using the Calibration File(``CalFile``). Additionally three
 implicit workspaces (``<instrument>_group``, ``<instrument>_cal``, ``<instrument>_mask``) are
-created during the algorithms execution if they do not exist already.
+created during the algorithms execution if they do not exist already. Masking can be applied by an xml file as well.
 
 Binning
 #######
@@ -57,7 +57,7 @@ Usage
 -----
 
 This is a workflow algorithm to process the results of powder diffraction experiments and create a p2d file for
-multidimensional Rietveld refinement. The algorithm is currently tested for the Instruments PG3 (POWGEN) and
+multidimensional Rietveld refinement. The algorithm is currently tested for the Instruments PG3 (POWGEN), SNAP and
 PTXatPG3 (POWTEX detector at POWGEN instrument).
 
 .. categories::

--- a/docs/source/algorithms/PowderReduceP2D-v1.rst
+++ b/docs/source/algorithms/PowderReduceP2D-v1.rst
@@ -57,7 +57,7 @@ Usage
 -----
 
 This is a workflow algorithm to process the results of powder diffraction experiments and create a p2d file for
-multidimensional Rietveld refinement. The algorithm is currently tested for the Instruments PG3 (POWGEN), SNAP and
+multidimensional Rietveld refinement. The algorithm is currently tested for the Instruments POWGEN, SNAP and
 PTXatPG3 (POWTEX detector at POWGEN instrument).
 
 .. categories::

--- a/docs/source/diagrams/PowderReduceP2D_ProcessCanRun.dot
+++ b/docs/source/diagrams/PowderReduceP2D_ProcessCanRun.dot
@@ -17,7 +17,7 @@ digraph PowderReduceP2D_ProcessCanRun {
     RemovePromptPulse           [label="RemovePromptPulse v1"]
     LoadDiffCal                 [label="LoadDiffCal v1"]
     MaskDetectors               [label="MaskDetectors v1"]
-    ApplyDiffCal              [label="ApplyDiffCal v1"]
+    ApplyDiffCal                [label="ApplyDiffCal v1"]
     ConvertUnits                [label="ConvertUnits v1\nwith target 'Wavelength'"]
     Bin2DPowderDiffraction1     [label="Bin2DPowderDiffraction v1\nusing a specified edgebinning file."]
     Bin2DPowderDiffraction2     [label="Bin2DPowderDiffraction v1\nusing logbinning."]

--- a/docs/source/diagrams/PowderReduceP2D_ProcessCanRun.dot
+++ b/docs/source/diagrams/PowderReduceP2D_ProcessCanRun.dot
@@ -27,9 +27,9 @@ digraph PowderReduceP2D_ProcessCanRun {
   subgraph decisions{
     $decision_style
     maskFile        [label="Is masking file specified?"]
-    detcal        [label="Is calibration file of type detcal?"]
-    detcal2        [label="Is calibration file of type detcal?"]
-    detcal3        [label="Is calibration file of type detcal?"]
+    detcal          [label="Is calibration file of type detcal?"]
+    detcal2         [label="Is calibration file of type detcal?"]
+    detcal3         [label="Is calibration file of type detcal?"]
     edgebinning     [label="Is edgebinning specified?"]
   }
 

--- a/docs/source/diagrams/PowderReduceP2D_ProcessCanRun.dot
+++ b/docs/source/diagrams/PowderReduceP2D_ProcessCanRun.dot
@@ -44,7 +44,7 @@ digraph PowderReduceP2D_ProcessCanRun {
   LoadMask                  -> detcal
   detcal                    -> LoadDetcal  [label="Yes"]
   detcal                    -> FindDetectorsPar  [label="No"]
-  LoadDetcal                    -> FindDetectorsPar
+  LoadDetcal                -> FindDetectorsPar
   FindDetectorsPar          -> FilterBadPulses
   FilterBadPulses           -> RemovePromptPulse
   RemovePromptPulse         -> detcal2

--- a/docs/source/diagrams/PowderReduceP2D_ProcessCanRun.dot
+++ b/docs/source/diagrams/PowderReduceP2D_ProcessCanRun.dot
@@ -4,18 +4,20 @@ digraph PowderReduceP2D_ProcessCanRun {
 
   subgraph params {
     $param_style
-    CanData
+    SampleData
     OutputWorkspace
   }
 
   subgraph algorithms {
     $algorithm_style
+    LoadMask                    [label="LoadMask v1"]
+    LoadDetcal                  [label="LoadIsawDetCal v1"]
     FindDetectorsPar            [label="FindDetectorsPar v1"]
     FilterBadPulses             [label="FilterBadPulses v1"]
     RemovePromptPulse           [label="RemovePromptPulse v1"]
     LoadDiffCal                 [label="LoadDiffCal v1"]
     MaskDetectors               [label="MaskDetectors v1"]
-    AlignDetectors              [label="AlignDetectors v1"]
+    ApplyDiffCal              [label="ApplyDiffCal v1"]
     ConvertUnits                [label="ConvertUnits v1\nwith target 'Wavelength'"]
     Bin2DPowderDiffraction1     [label="Bin2DPowderDiffraction v1\nusing a specified edgebinning file."]
     Bin2DPowderDiffraction2     [label="Bin2DPowderDiffraction v1\nusing logbinning."]
@@ -24,6 +26,10 @@ digraph PowderReduceP2D_ProcessCanRun {
 
   subgraph decisions{
     $decision_style
+    maskFile        [label="Is masking file specified?"]
+    detcal        [label="Is calibration file of type detcal?"]
+    detcal2        [label="Is calibration file of type detcal?"]
+    detcal3        [label="Is calibration file of type detcal?"]
     edgebinning     [label="Is edgebinning specified?"]
   }
 
@@ -32,13 +38,23 @@ digraph PowderReduceP2D_ProcessCanRun {
     $value_style
   }
 
-  CanData	                -> FindDetectorsPar
+  SampleData	            -> maskFile
+  maskFile   	            -> LoadMask  [label="Yes"]
+  maskFile   	            -> detcal  [label="No"]
+  LoadMask                  -> detcal
+  detcal                    -> LoadDetcal  [label="Yes"]
+  detcal                    -> FindDetectorsPar  [label="No"]
+  LoadDetcal                    -> FindDetectorsPar
   FindDetectorsPar          -> FilterBadPulses
   FilterBadPulses           -> RemovePromptPulse
-  RemovePromptPulse         -> LoadDiffCal
+  RemovePromptPulse         -> detcal2
+  detcal2                   -> LoadDiffCal [label="No"]
+  detcal2                   -> MaskDetectors [label="Yes"]
   LoadDiffCal               -> MaskDetectors
-  MaskDetectors             -> AlignDetectors
-  AlignDetectors            -> ConvertUnits
+  MaskDetectors             -> detcal3
+  detcal3                   -> ApplyDiffCal  [label="No"]
+  detcal3                   -> ConvertUnits  [label="Yes"]
+  ApplyDiffCal              -> ConvertUnits
   ConvertUnits              -> edgebinning
   edgebinning               -> Bin2DPowderDiffraction1  [label="Yes"]
   edgebinning               -> Bin2DPowderDiffraction2  [label="No"]
@@ -47,3 +63,4 @@ digraph PowderReduceP2D_ProcessCanRun {
 
 
 }
+

--- a/docs/source/diagrams/PowderReduceP2D_ProcessSampleRun.dot
+++ b/docs/source/diagrams/PowderReduceP2D_ProcessSampleRun.dot
@@ -44,7 +44,7 @@ digraph PowderReduceP2D_FocusAndSum {
   LoadMask                  -> detcal
   detcal                    -> LoadDetcal  [label="Yes"]
   detcal                    -> FindDetectorsPar  [label="No"]
-  LoadDetcal                    -> FindDetectorsPar
+  LoadDetcal                -> FindDetectorsPar
   FindDetectorsPar          -> FilterBadPulses
   FilterBadPulses           -> RemovePromptPulse
   RemovePromptPulse         -> detcal2

--- a/docs/source/diagrams/PowderReduceP2D_ProcessSampleRun.dot
+++ b/docs/source/diagrams/PowderReduceP2D_ProcessSampleRun.dot
@@ -17,7 +17,7 @@ digraph PowderReduceP2D_FocusAndSum {
     RemovePromptPulse           [label="RemovePromptPulse v1"]
     LoadDiffCal                 [label="LoadDiffCal v1"]
     MaskDetectors               [label="MaskDetectors v1"]
-    ApplyDiffCal              [label="ApplyDiffCal v1"]
+    ApplyDiffCal                [label="ApplyDiffCal v1"]
     ConvertUnits                [label="ConvertUnits v1\nwith target 'Wavelength'"]
     Bin2DPowderDiffraction1     [label="Bin2DPowderDiffraction v1\nusing a specified edgebinning file."]
     Bin2DPowderDiffraction2     [label="Bin2DPowderDiffraction v1\nusing logbinning."]

--- a/docs/source/diagrams/PowderReduceP2D_ProcessSampleRun.dot
+++ b/docs/source/diagrams/PowderReduceP2D_ProcessSampleRun.dot
@@ -27,9 +27,9 @@ digraph PowderReduceP2D_FocusAndSum {
   subgraph decisions{
     $decision_style
     maskFile        [label="Is masking file specified?"]
-    detcal        [label="Is calibration file of type detcal?"]
-    detcal2        [label="Is calibration file of type detcal?"]
-    detcal3        [label="Is calibration file of type detcal?"]
+    detcal          [label="Is calibration file of type detcal?"]
+    detcal2         [label="Is calibration file of type detcal?"]
+    detcal3         [label="Is calibration file of type detcal?"]
     edgebinning     [label="Is edgebinning specified?"]
   }
 

--- a/docs/source/diagrams/PowderReduceP2D_ProcessSampleRun.dot
+++ b/docs/source/diagrams/PowderReduceP2D_ProcessSampleRun.dot
@@ -10,12 +10,14 @@ digraph PowderReduceP2D_FocusAndSum {
 
   subgraph algorithms {
     $algorithm_style
+    LoadMask                    [label="LoadMask v1"]
+    LoadDetcal                  [label="LoadIsawDetCal v1"]
     FindDetectorsPar            [label="FindDetectorsPar v1"]
     FilterBadPulses             [label="FilterBadPulses v1"]
     RemovePromptPulse           [label="RemovePromptPulse v1"]
     LoadDiffCal                 [label="LoadDiffCal v1"]
     MaskDetectors               [label="MaskDetectors v1"]
-    AlignDetectors              [label="AlignDetectors v1"]
+    ApplyDiffCal              [label="ApplyDiffCal v1"]
     ConvertUnits                [label="ConvertUnits v1\nwith target 'Wavelength'"]
     Bin2DPowderDiffraction1     [label="Bin2DPowderDiffraction v1\nusing a specified edgebinning file."]
     Bin2DPowderDiffraction2     [label="Bin2DPowderDiffraction v1\nusing logbinning."]
@@ -24,6 +26,10 @@ digraph PowderReduceP2D_FocusAndSum {
 
   subgraph decisions{
     $decision_style
+    maskFile        [label="Is masking file specified?"]
+    detcal        [label="Is calibration file of type detcal?"]
+    detcal2        [label="Is calibration file of type detcal?"]
+    detcal3        [label="Is calibration file of type detcal?"]
     edgebinning     [label="Is edgebinning specified?"]
   }
 
@@ -32,13 +38,23 @@ digraph PowderReduceP2D_FocusAndSum {
     $value_style
   }
 
-  SampleData	            -> FindDetectorsPar
+  SampleData	            -> maskFile
+  maskFile   	            -> LoadMask  [label="Yes"]
+  maskFile   	            -> detcal  [label="No"]
+  LoadMask                  -> detcal
+  detcal                    -> LoadDetcal  [label="Yes"]
+  detcal                    -> FindDetectorsPar  [label="No"]
+  LoadDetcal                    -> FindDetectorsPar
   FindDetectorsPar          -> FilterBadPulses
   FilterBadPulses           -> RemovePromptPulse
-  RemovePromptPulse         -> LoadDiffCal
+  RemovePromptPulse         -> detcal2
+  detcal2                   -> LoadDiffCal [label="No"]
+  detcal2                   -> MaskDetectors [label="Yes"]
   LoadDiffCal               -> MaskDetectors
-  MaskDetectors             -> AlignDetectors
-  AlignDetectors            -> ConvertUnits
+  MaskDetectors             -> detcal3
+  detcal3                   -> ApplyDiffCal  [label="No"]
+  detcal3                   -> ConvertUnits  [label="Yes"]
+  ApplyDiffCal              -> ConvertUnits
   ConvertUnits              -> edgebinning
   edgebinning               -> Bin2DPowderDiffraction1  [label="Yes"]
   edgebinning               -> Bin2DPowderDiffraction2  [label="No"]

--- a/docs/source/diagrams/PowderReduceP2D_ProcessVanadiumRun.dot
+++ b/docs/source/diagrams/PowderReduceP2D_ProcessVanadiumRun.dot
@@ -1,21 +1,23 @@
-digraph PowderReduceP2D_ProcessVanRun {
-  label="Process Vanadium Run Workflow"
+digraph PowderReduceP2D_FocusAndSum {
+  label="Process Sample Run Workflow"
   $global_style
 
   subgraph params {
-    $param_style
-    VanadiumData
+    #$param_style
+    SampleData
     OutputWorkspace
   }
 
   subgraph algorithms {
     $algorithm_style
+    LoadMask                    [label="LoadMask v1"]
+    LoadDetcal                  [label="LoadIsawDetCal v1"]
     FindDetectorsPar            [label="FindDetectorsPar v1"]
     FilterBadPulses             [label="FilterBadPulses v1"]
     RemovePromptPulse           [label="RemovePromptPulse v1"]
     LoadDiffCal                 [label="LoadDiffCal v1"]
     MaskDetectors               [label="MaskDetectors v1"]
-    AlignDetectors              [label="AlignDetectors v1"]
+    ApplyDiffCal              [label="ApplyDiffCal v1"]
     ConvertUnits                [label="ConvertUnits v1\nwith target 'Wavelength'"]
     CylinderAbsorption          [label="CylinderAbsorption v1"]
     Divide                      [label="Divide v1"]
@@ -28,6 +30,10 @@ digraph PowderReduceP2D_ProcessVanRun {
 
   subgraph decisions{
     $decision_style
+    maskFile        [label="Is masking file specified?"]
+    detcal        [label="Is calibration file of type detcal?"]
+    detcal2        [label="Is calibration file of type detcal?"]
+    detcal3        [label="Is calibration file of type detcal?"]
     edgebinning     [label="Is edgebinning specified?"]
   }
 
@@ -36,13 +42,24 @@ digraph PowderReduceP2D_ProcessVanRun {
     $value_style
   }
 
-  VanadiumData	            -> FindDetectorsPar
+  SampleData	            -> maskFile
+  maskFile   	            -> LoadMask  [label="Yes"]
+  maskFile   	            -> detcal  [label="No"]
+  LoadMask                  -> detcal
+  detcal                    -> LoadDetcal  [label="Yes"]
+  detcal                    -> FindDetectorsPar  [label="No"]
+  LoadDetcal                    -> FindDetectorsPar
   FindDetectorsPar          -> FilterBadPulses
   FilterBadPulses           -> RemovePromptPulse
-  RemovePromptPulse         -> LoadDiffCal
+  RemovePromptPulse         -> detcal2
+  detcal2                   -> LoadDiffCal [label="No"]
+  detcal2                   -> MaskDetectors [label="Yes"]
   LoadDiffCal               -> MaskDetectors
-  MaskDetectors             -> AlignDetectors
-  AlignDetectors            -> ConvertUnits
+  MaskDetectors             -> detcal3
+  detcal3                   -> ApplyDiffCal  [label="No"]
+  detcal3                   -> ConvertUnits  [label="Yes"]
+  ApplyDiffCal              -> ConvertUnits
+  ConvertUnits              -> edgebinning
   ConvertUnits              -> CylinderAbsorption
   CylinderAbsorption        -> Divide
   Divide                    -> edgebinning
@@ -52,7 +69,6 @@ digraph PowderReduceP2D_ProcessVanRun {
   Bin2DPowderDiffraction2   -> StripVanadiumPeaks
   StripVanadiumPeaks        -> FFTSmooth
   FFTSmooth                 -> OutputWorkspace
-
 
 
 }

--- a/docs/source/diagrams/PowderReduceP2D_ProcessVanadiumRun.dot
+++ b/docs/source/diagrams/PowderReduceP2D_ProcessVanadiumRun.dot
@@ -17,7 +17,7 @@ digraph PowderReduceP2D_FocusAndSum {
     RemovePromptPulse           [label="RemovePromptPulse v1"]
     LoadDiffCal                 [label="LoadDiffCal v1"]
     MaskDetectors               [label="MaskDetectors v1"]
-    ApplyDiffCal              [label="ApplyDiffCal v1"]
+    ApplyDiffCal                [label="ApplyDiffCal v1"]
     ConvertUnits                [label="ConvertUnits v1\nwith target 'Wavelength'"]
     CylinderAbsorption          [label="CylinderAbsorption v1"]
     Divide                      [label="Divide v1"]

--- a/docs/source/diagrams/PowderReduceP2D_ProcessVanadiumRun.dot
+++ b/docs/source/diagrams/PowderReduceP2D_ProcessVanadiumRun.dot
@@ -31,9 +31,9 @@ digraph PowderReduceP2D_FocusAndSum {
   subgraph decisions{
     $decision_style
     maskFile        [label="Is masking file specified?"]
-    detcal        [label="Is calibration file of type detcal?"]
-    detcal2        [label="Is calibration file of type detcal?"]
-    detcal3        [label="Is calibration file of type detcal?"]
+    detcal          [label="Is calibration file of type detcal?"]
+    detcal2         [label="Is calibration file of type detcal?"]
+    detcal3         [label="Is calibration file of type detcal?"]
     edgebinning     [label="Is edgebinning specified?"]
   }
 

--- a/docs/source/diagrams/PowderReduceP2D_ProcessVanadiumRun.dot
+++ b/docs/source/diagrams/PowderReduceP2D_ProcessVanadiumRun.dot
@@ -48,7 +48,7 @@ digraph PowderReduceP2D_FocusAndSum {
   LoadMask                  -> detcal
   detcal                    -> LoadDetcal  [label="Yes"]
   detcal                    -> FindDetectorsPar  [label="No"]
-  LoadDetcal                    -> FindDetectorsPar
+  LoadDetcal                -> FindDetectorsPar
   FindDetectorsPar          -> FilterBadPulses
   FilterBadPulses           -> RemovePromptPulse
   RemovePromptPulse         -> detcal2

--- a/docs/source/release/v6.8.0/Diffraction/Powder/New_features/35872.rst
+++ b/docs/source/release/v6.8.0/Diffraction/Powder/New_features/35872.rst
@@ -1,0 +1,1 @@
+-:ref:`PowderReduceP2D <algm-PowderReduceP2D>` has been adapted to work with SNAP measuring data

--- a/docs/source/release/v6.8.0/Diffraction/Powder/New_features/35872.rst
+++ b/docs/source/release/v6.8.0/Diffraction/Powder/New_features/35872.rst
@@ -1,1 +1,1 @@
--:ref:`PowderReduceP2D <algm-PowderReduceP2D>` has been adapted to work with SNAP measuring data
+- :ref:`PowderReduceP2D <algm-PowderReduceP2D>` has been adapted to work with SNAP measuring data.


### PR DESCRIPTION
**Description of work**
The Workflow algorithm PowderreduceP2d has been modified for several reasons.
1. As the algorithm AlignDetectors was deprecated, it was replaced with the algorithm ApplyDiffCal.
2. A small Bug for the ResetNegatives2D function was fixed. 
3. The algorithm was modified to be applicable to data collected at the instrument SNAP at SNS.
4. The possibility to use a vanadium background file was added.
5. Parameter centerWavelength was removed.

**Purpose of work**
The algorithm PowderReduceP2d was developed for the creation of multidimensional neutron time of flight datasets. These datasets are necessary for the new multidimensional Rietveld refinement method that is being developed for the diffractometer POWTEX to be build at FRM-II in Garching. For more information on the multidimensional Rietveld refinement look at:

https://doi.org/10.1107/S1600576723002819

https://doi.org/10.1107/S1600576717005398

https://doi.org/10.1107/S1600576715016520

As the instrument POWTEX is not build up yet, we are testing the reduction and refinement process with data from different instruments. The extension to other instruments is interesting for others as well, as the method can be applied to all TOF instruments with large area detectors.

**Summary of work**
1. The algorithm was replaced as was recommended.
2. The resetting of negative values to a set value was done by creating a new workspace. Not setting the attribute distribution to True resulted in an error, so that was added to the function.
3. The SNAP instrument uses a different calibration method than was used before (detcal files instead of cal files), which made a different calibration routine necessary.
4. The instrument POWGEN has started using background measurements for the vanadium correction, so this has been added as an optional functionality. 
5. The parameter center wavelength was removed because it was unnecessary. 

**Further detail of work**
3. To reduce data collected at the instrument SNAP it was first necessary to implement the usage of detcal files for the calibration of the detectors. Depending on the fileextension (cal or detcal) the code automatically follows the corresponding calibration path. To make the usage of masking files easier, the missing option to use xml files via the loadMask algorithm has been implemented.


**To do:**

- [x] Check if test function for this algorithm still works
- [x] If necessary, adapt testing data
- [x] Check .rst file for any changes necessary
- [x] If necessary, make changes to flow chart
- [x] Add release notes


**To test:**
Example for testing can be found in the test function associated with this algorithm. If available, POWGEN or SNAP data should generally work but some fiddling with initial parameters might be necessary.


Closes #35943.


At this moment the base of this PR is main, if this is not correct please let me know. A fitting label for this PR would be diffraction, unfortunately I cannot add a label to the PR or I have not found the option to do this yet.

---

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.