### PR TITLE
Option in MagnetismReflectometryReduction allowing the return of empty reflectivity curves

### DIFF
--- a/Testing/Data/SystemTest/REF_M_42100.nxs.md5
+++ b/Testing/Data/SystemTest/REF_M_42100.nxs.md5
@@ -1,0 +1,1 @@
+24d8e0c06c05d1109e83abbf8bb76b2b

--- a/Testing/SystemTests/tests/framework/MagnetismReflectometryReductionTest.py
+++ b/Testing/SystemTests/tests/framework/MagnetismReflectometryReductionTest.py
@@ -9,6 +9,7 @@ import systemtesting
 from mantid import *
 from mantid.simpleapi import *
 import math
+import numpy as np
 
 
 class MagnetismReflectometryReductionTest(systemtesting.MantidSystemTest):
@@ -147,6 +148,52 @@ class MagnetismReflectometryReductionConstQWLCutTest(systemtesting.MantidSystemT
     def validate(self):
         refl = mtd["r_24949"].dataY(0)
         return math.fabs(refl[1] - 0.648596877775159) < 0.002
+
+
+class MagnetismReflectometryReductionEmptyCurve(systemtesting.MantidSystemTest):
+    r"""Input data has no events for in-out spin combination On-On, yielding
+    a reflectivity curve with only zero intensity values."""
+
+    def runTest(self):
+        wsg = LoadNexusProcessed(Filename="REF_M_42100.nxs")
+        options = {
+            "NormalizationWorkspace": None,
+            "SignalPeakPixelRange": [225, 245],
+            "SubtractSignalBackground": True,
+            "SignalBackgroundPixelRange": [20, 39],
+            "ApplyNormalization": False,
+            "NormPeakPixelRange": [225, 245],
+            "SubtractNormBackground": True,
+            "NormBackgroundPixelRange": [20, 39],
+            "CutLowResDataAxis": True,
+            "LowResDataAxisPixelRange": [127, 206],
+            "CutLowResNormAxis": True,
+            "LowResNormAxisPixelRange": [127, 206],
+            "CutTimeAxis": True,
+            "FinalRebin": True,
+            "QMin": 0.001,
+            "QStep": -0.01,
+            "RoundUpPixel": False,
+            "AngleOffset": 0,
+            "UseWLTimeAxis": False,
+            "TimeAxisStep": 400,
+            "UseSANGLE": True,
+            "TimeAxisRange": [11413.560217325685, 45388.809236341694],
+            "SpecularPixel": 235.5,
+            "ConstantQBinning": False,
+            "ConstQTrim": 0.1,
+            "CropFirstAndLastPoints": False,
+            "CleanupBadData": True,
+            "AcceptNullReflectivity": True,
+            "ErrorWeightedBackground": False,
+            "SampleLength": 10.0,
+            "DAngle0Overwrite": None,
+            "DirectPixelOverwrite": None,
+        }
+        MagnetismReflectometryReduction(InputWorkspace=wsg[1], OutputWorkspace="r_42100", **options)  # component with no counts
+
+    def validate(self):
+        return np.all(mtd["r_42100"].readY(0) < 1e-9)  # reflectivity curve has only zeroes
 
 
 class MRFilterCrossSectionsTest(systemtesting.MantidSystemTest):

--- a/Testing/SystemTests/tests/framework/MagnetismReflectometryReductionTest.py
+++ b/Testing/SystemTests/tests/framework/MagnetismReflectometryReductionTest.py
@@ -155,7 +155,7 @@ class MagnetismReflectometryReductionEmptyCurve(systemtesting.MantidSystemTest):
     a reflectivity curve with only zero intensity values."""
 
     def runTest(self):
-        wsg = LoadNexusProcessed(Filename="REF_M_42100.nxs")
+        LoadNexusProcessed(Filename="REF_M_42100.nxs", OutputWorkspace="r42100")
         options = {
             "NormalizationWorkspace": None,
             "SignalPeakPixelRange": [225, 245],
@@ -190,10 +190,11 @@ class MagnetismReflectometryReductionEmptyCurve(systemtesting.MantidSystemTest):
             "DAngle0Overwrite": None,
             "DirectPixelOverwrite": None,
         }
-        MagnetismReflectometryReduction(InputWorkspace=wsg[1], OutputWorkspace="r_42100", **options)  # component with no counts
+        MagnetismReflectometryReduction(InputWorkspace="r42100", OutputWorkspace="r42100_reduced", **options)
 
     def validate(self):
-        return np.all(mtd["r_42100"].readY(0) < 1e-9)  # reflectivity curve has only zeroes
+        empty_component = mtd["r42100_reduced"][1]  # the second workspace in the GroupWorkspace is the empty one
+        return np.all(empty_component.readY(0) < 1e-9)  # reflectivity curve has only zeroes
 
 
 class MRFilterCrossSectionsTest(systemtesting.MantidSystemTest):

--- a/docs/source/release/v6.8.0/Reflectometry/New_features/35873.rst
+++ b/docs/source/release/v6.8.0/Reflectometry/New_features/35873.rst
@@ -1,0 +1,1 @@
+- :ref:`MagnetismReflectometryReduction <algm-MagnetismReflectometryReduction>` now as option allowing the return of empty reflectivity curves.


### PR DESCRIPTION
**Description and Purpose of work**
Implements [EWM Task 2074 Option inMagnetismReflectometryReduction allowing the return of empty reflectivity curves](Option inMagnetismReflectometryReduction allowing the return of empty reflectivity curves).

Option for algorithm MagnetismReflectometryReduction to become permissive when one (or more) of its reflectivity curves is empty. This could be useful when there are no events for one in-out spin combination.

**To test:**
Use file `/path/to/the/local/repo/Testing/Data/SystemTest/REF_M_42100.nxs` as input. Assuming directory `MantidExternalData/` is under your home directory, run the following script in the workbench:

```python
from mantid.simpleapi import MagnetismReflectometryReduction
import os

histogrammed_42100 = os.path.join(os.environ["HOME"], "MantidExternalData", weq32323)  # path to input file

# various algorithm options
options={
'NormalizationWorkspace': None,
'SignalPeakPixelRange': [225, 245],
'SubtractSignalBackground': True,
'SignalBackgroundPixelRange': [20, 39],
'ApplyNormalization': False,
'NormPeakPixelRange': [225, 245],
'SubtractNormBackground': True,
'NormBackgroundPixelRange': [20, 39],
'CutLowResDataAxis': True,
'LowResDataAxisPixelRange': [127, 206],
'CutLowResNormAxis': True,
'LowResNormAxisPixelRange': [127, 206],
'CutTimeAxis': True,
'FinalRebin': True,
'QMin': 0.001,
'QStep': -0.01,
'RoundUpPixel': False,
'AngleOffset': 0,
'UseWLTimeAxis': False,
'TimeAxisStep': 400,
'UseSANGLE': True,
'TimeAxisRange': [11413.560217325685, 45388.809236341694],
'SpecularPixel': 235.5,
'ConstantQBinning': False,
'ConstQTrim': 0.1,
'CropFirstAndLastPoints': False,
'CleanupBadData': True,
'AcceptNullReflectivity': True,
'ErrorWeightedBackground': False,
'SampleLength': 10.0,
'DAngle0Overwrite': None,
'DirectPixelOverwrite': None,
'OutputWorkspace': 'output_42100'}

input_42100 = LoadNexus(Filename=histogrammed_42100)
MagnetismReflectometryReduction(InputWorkspace=input_42100, **options)
```
The plotting of the two workspaces of `output_42100` should look like:
<img width="463" src="https://github.com/mantidproject/mantid/assets/1136006/51cb5dcc-3f9a-45b9-8ade-c65cff8db243">
The second workspace should have only zero intensity values.

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.