### PR TITLE
Pin `openssl!=3.1.2`

### DIFF
--- a/conda/recipes/conda_build_config.yaml
+++ b/conda/recipes/conda_build_config.yaml
@@ -74,6 +74,9 @@ gsl:
 libopenblas:
   - '!=0.3.23'
 
+openssl:
+  - '!=3.1.2'
+
 # 8.2 causing segfaults in jupyter unit tests and doc builds.
 readline:
   - <8.2

--- a/conda/recipes/mantid/meta.yaml
+++ b/conda/recipes/mantid/meta.yaml
@@ -51,7 +51,7 @@ requirements:
     - setuptools {{ setuptools }}
     - tbb-devel {{ tbb }}
     - pip
-    - openssl
+    - openssl {{ openssl }}
     - versioningit
     - libglu  # [linux]
   run:
@@ -68,7 +68,7 @@ requirements:
     - python-dateutil
     - pyyaml
     - scipy {{ scipy }}
-    - openssl
+    - openssl {{ openssl }}
     - euphonic {{ euphonic }}
     - toml
     - libglu  # [linux]


### PR DESCRIPTION
**Description of work**
This PR pins `openssl!=3.1.2`. A recent update to openssl has caused a failure after the unit tests have run, and before the system tests can run on linux.

**To test:**
Check this build package from branch pipeline passes:
https://builds.mantidproject.org/job/build_packages_from_branch/464/

*There is no associated issue.*

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.