### PR TITLE
Improvements and bug fixes for the TOF Converter window

### DIFF
--- a/docs/source/interfaces/utility/TOF Converter.rst
+++ b/docs/source/interfaces/utility/TOF Converter.rst
@@ -11,7 +11,7 @@ Input
 -----
 
 ToF Converter will take an Input value i.e the value you wish to convert.
-If you wish to convert Momentum Transfer or d-spacing then a Scattering angle :math:`\theta` will need to be specified.
+If you wish to convert to/from Momentum Transfer or d-spacing to/from another unit, then a Scattering angle :math:`\theta` will need to be specified.
 If you wish to convert Time of Flight then you will need to specify a Total Flight path in meters.
 
 Output

--- a/docs/source/release/v6.8.0/Workbench/Bugfixes/35885.rst
+++ b/docs/source/release/v6.8.0/Workbench/Bugfixes/35885.rst
@@ -1,1 +1,1 @@
-- Fix some minor usability bugs and improve the layout of the TOF Converter window. It no longer requires a scattering angle to convert between momentum transfer and d-spacing.
+- Fix some minor usability bugs and improve the layout of the TOF Converter window. It can now take an input value from any single valued workspace. It no longer requires a scattering angle to convert between momentum transfer and d-spacing.

--- a/docs/source/release/v6.8.0/Workbench/Bugfixes/35885.rst
+++ b/docs/source/release/v6.8.0/Workbench/Bugfixes/35885.rst
@@ -1,0 +1,1 @@
+- Fix some minor usability bugs and improve the layout of the TOF Converter window. It no longer requires a scattering angle to convert between momentum transfer and d-spacing.

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/TofConverter/convertUnits.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/TofConverter/convertUnits.py
@@ -23,11 +23,7 @@ UNIT_LIST = [ENERGY_MEV, WAVELENGTH, NU, VELOCITY, MOMENTUM, TEMPERATURE, ENERGY
 
 
 def doConversion(inputval, inOption, outOption, theta, flightpath):
-    if (
-        (inOption == MOMENTUM_TRANSFER or inOption == D_SPACING)
-        and (outOption == MOMENTUM_TRANSFER or outOption == D_SPACING)
-        and inOption != outOption
-    ):
+    if is_momentum_dspacing_transform(inOption, outOption):
         return convert_momentum_transfer_to_dspacing_or_back(float(inputval))
     stage1output = input2energy(float(inputval), inOption, theta, flightpath)
     stage2output = energy2output(stage1output, outOption, theta, flightpath)
@@ -146,3 +142,7 @@ def energy2output(Energy, outOption, theta, flightpath):
 
 def convert_momentum_transfer_to_dspacing_or_back(q_or_d: float) -> float:
     return 2 * math.pi / q_or_d
+
+
+def is_momentum_dspacing_transform(inOption: str, outOption: str) -> bool:
+    return (inOption == MOMENTUM_TRANSFER and outOption == D_SPACING) or (inOption == D_SPACING and outOption == MOMENTUM_TRANSFER)

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/TofConverter/convertUnits.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/TofConverter/convertUnits.py
@@ -11,6 +11,12 @@ import math
 
 
 def doConversion(inputval, inOption, outOption, theta, flightpath):
+    if (
+        (inOption == MOMENTUM_TRANSFER or inOption == D_SPACING)
+        and (outOption == MOMENTUM_TRANSFER or outOption == D_SPACING)
+        and inOption != outOption
+    ):
+        return convert_momentum_transfer_to_dspacing_or_back(float(inputval))
     stage1output = input2energy(float(inputval), inOption, theta, flightpath)
     stage2output = energy2output(stage1output, outOption, theta, flightpath)
     return stage2output
@@ -124,6 +130,10 @@ def energy2output(Energy, outOption, theta, flightpath):
         OutputVal = Energy
 
     return OutputVal
+
+
+def convert_momentum_transfer_to_dspacing_or_back(q_or_d: float) -> float:
+    return 2 * math.pi / q_or_d
 
 
 ENERGY_MEV = "Energy (meV)"

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/TofConverter/convertUnits.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/TofConverter/convertUnits.py
@@ -28,42 +28,42 @@ def input2energy(inputval, inOption, theta, flightpath):
     e2cm = 0.123975  # cm = 8.06554465*E E:energy
     iv2 = inputval**2
 
-    if inOption == "Wavelength (Angstroms)":
+    if inOption == WAVELENGTH:
         Energy = e2lam / iv2
 
-    elif inOption == "Energy (meV)":
+    elif inOption == ENERGY_MEV:
         Energy = inputval
 
-    elif inOption == "Nu (THz)":
+    elif inOption == NU:
         Energy = e2nu * inputval
 
-    elif inOption == "Velocity (m/s)":
+    elif inOption == VELOCITY:
         Energy = e2v * iv2
 
-    elif inOption == "Momentum (k Angstroms^-1)":
+    elif inOption == MOMENTUM:
         Energy = e2k * iv2
 
-    elif inOption == "Temperature (K)":
+    elif inOption == TEMPERATURE:
         Energy = e2t * inputval
 
-    elif inOption == "Energy (cm^-1)":
+    elif inOption == ENERGY_CMINV:
         Energy = e2cm * inputval
 
-    elif inOption == "Momentum transfer (Q Angstroms^-1)":
+    elif inOption == MOMENTUM_TRANSFER:
         if theta >= 0.0:
             k = inputval * 0.5 / math.sin(theta)
             Energy = e2k * k * k
         else:
             raise RuntimeError("Theta > 0 is required for conversion from Q")
 
-    elif inOption == "d-spacing (Angstroms)":
+    elif inOption == D_SPACING:
         if theta >= 0.0:
             lam = 2 * inputval * math.sin(theta)
             Energy = e2lam / (lam * lam)
         else:
             raise RuntimeError("Theta > 0 is required for conversion from Q")
 
-    elif inOption == "Time of flight (microseconds)":
+    elif inOption == TIME_OF_FLIGHT:
         if flightpath >= 0.0:
             Energy = 1000000 * flightpath
             Energy = e2v * Energy * Energy / iv2
@@ -82,45 +82,58 @@ def energy2output(Energy, outOption, theta, flightpath):
     e2t = 0.086165  # using t = (m*v^2)/(2kb) kb: Boltzmann const
     e2cm = 0.123975  # cm = 8.06554465*E E:energy
 
-    if outOption == "Wavelength (Angstroms)":
+    if outOption == WAVELENGTH:
         OutputVal = (e2lam / Energy) ** 0.5
 
-    elif outOption == "Nu (Thz)":
+    elif outOption == NU:
         OutputVal = Energy / e2nu
 
-    elif outOption == "Velocity (m/s)":
+    elif outOption == VELOCITY:
         OutputVal = (Energy / e2v) ** 0.5
 
-    elif outOption == "Momentum (k Angstroms^-1)":
+    elif outOption == MOMENTUM:
         OutputVal = (Energy / e2k) ** 0.5
 
-    elif outOption == "Temperature (K)":
+    elif outOption == TEMPERATURE:
         OutputVal = Energy / e2t
 
-    elif outOption == "Energy (cm^-1)":
+    elif outOption == ENERGY_CMINV:
         OutputVal = Energy / e2cm
 
-    elif outOption == "Momentum transfer (Q Angstroms^-1)":
+    elif outOption == MOMENTUM_TRANSFER:
         if theta >= 0.0:
             k = (Energy / e2k) ** 0.5
             OutputVal = 2 * k * math.sin(theta)
         else:
             raise RuntimeError("Theta > 0 is required for conversion to Q")
 
-    elif outOption == "d-spacing (Angstroms)":
+    elif outOption == D_SPACING:
         if theta >= 0.0:
             lam = (e2lam / Energy) ** 0.5
             OutputVal = lam * 0.5 / math.sin(theta)
         else:
             raise RuntimeError("Theta > 0 is required for conversion to d-Spacing")
 
-    elif outOption == "Time of flight (microseconds)":
+    elif outOption == TIME_OF_FLIGHT:
         if flightpath >= 0.0:
             OutputVal = flightpath * 1000 * ((e2v * 1000000 / Energy) ** 0.5)
         else:
             raise RuntimeError("Flight path >= 0 is required for conversion to TOF")
 
-    elif outOption == "Energy (meV)":
+    elif outOption == ENERGY_MEV:
         OutputVal = Energy
 
     return OutputVal
+
+
+ENERGY_MEV = "Energy (meV)"
+WAVELENGTH = "Wavelength (Angstroms)"
+NU = "Nu (THz)"
+VELOCITY = "Velocity (m/s)"
+MOMENTUM = "Momentum (k Angstroms^-1)"
+TEMPERATURE = "Temperature (K)"
+ENERGY_CMINV = "Energy (cm^-1)"
+MOMENTUM_TRANSFER = "Momentum transfer (Q Angstroms^-1)"
+D_SPACING = "d-spacing (Angstroms)"
+TIME_OF_FLIGHT = "Time of flight (microseconds)"
+UNIT_LIST = [ENERGY_MEV, WAVELENGTH, NU, VELOCITY, MOMENTUM, TEMPERATURE, ENERGY_CMINV, MOMENTUM_TRANSFER, D_SPACING, TIME_OF_FLIGHT]

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/TofConverter/convertUnits.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/TofConverter/convertUnits.py
@@ -7,6 +7,18 @@
 # pylint: disable=invalid-name,too-many-branches
 import math
 
+ENERGY_MEV = "Energy (meV)"
+WAVELENGTH = "Wavelength (Angstroms)"
+NU = "Nu (THz)"
+VELOCITY = "Velocity (m/s)"
+MOMENTUM = "Momentum (k Angstroms^-1)"
+TEMPERATURE = "Temperature (K)"
+ENERGY_CMINV = "Energy (cm^-1)"
+MOMENTUM_TRANSFER = "Momentum transfer (Q Angstroms^-1)"
+D_SPACING = "d-spacing (Angstroms)"
+TIME_OF_FLIGHT = "Time of flight (microseconds)"
+UNIT_LIST = [ENERGY_MEV, WAVELENGTH, NU, VELOCITY, MOMENTUM, TEMPERATURE, ENERGY_CMINV, MOMENTUM_TRANSFER, D_SPACING, TIME_OF_FLIGHT]
+
 # Used by converter GUI to do unit conversions
 
 
@@ -134,16 +146,3 @@ def energy2output(Energy, outOption, theta, flightpath):
 
 def convert_momentum_transfer_to_dspacing_or_back(q_or_d: float) -> float:
     return 2 * math.pi / q_or_d
-
-
-ENERGY_MEV = "Energy (meV)"
-WAVELENGTH = "Wavelength (Angstroms)"
-NU = "Nu (THz)"
-VELOCITY = "Velocity (m/s)"
-MOMENTUM = "Momentum (k Angstroms^-1)"
-TEMPERATURE = "Temperature (K)"
-ENERGY_CMINV = "Energy (cm^-1)"
-MOMENTUM_TRANSFER = "Momentum transfer (Q Angstroms^-1)"
-D_SPACING = "d-spacing (Angstroms)"
-TIME_OF_FLIGHT = "Time of flight (microseconds)"
-UNIT_LIST = [ENERGY_MEV, WAVELENGTH, NU, VELOCITY, MOMENTUM, TEMPERATURE, ENERGY_CMINV, MOMENTUM_TRANSFER, D_SPACING, TIME_OF_FLIGHT]

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/TofConverter/converter.ui
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/TofConverter/converter.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>410</width>
-    <height>422</height>
+    <width>423</width>
+    <height>495</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -18,14 +18,14 @@
   </property>
   <property name="minimumSize">
    <size>
-    <width>410</width>
-    <height>422</height>
+    <width>423</width>
+    <height>450</height>
    </size>
   </property>
   <property name="maximumSize">
    <size>
-    <width>410</width>
-    <height>422</height>
+    <width>423</width>
+    <height>495</height>
    </size>
   </property>
   <property name="windowTitle">
@@ -56,245 +56,164 @@
       <property name="title">
        <string/>
       </property>
-      <widget class="QComboBox" name="inputUnits">
-       <property name="geometry">
-        <rect>
-         <x>200</x>
-         <y>50</y>
-         <width>181</width>
-         <height>21</height>
-        </rect>
-       </property>
-       <property name="toolTip">
-        <string>A list of the units for the input value</string>
-       </property>
-       <property name="whatsThis">
-        <string>Drop down menu of the units for the input value</string>
-       </property>
-      </widget>
-      <widget class="QLineEdit" name="InputVal">
-       <property name="geometry">
-        <rect>
-         <x>10</x>
-         <y>50</y>
-         <width>141</width>
-         <height>21</height>
-        </rect>
-       </property>
-       <property name="toolTip">
-        <string>The value that you wish to convert</string>
-       </property>
-       <property name="whatsThis">
-        <string>An input box for entering the value that you wish to convert</string>
-       </property>
-      </widget>
-      <widget class="QLabel" name="label">
-       <property name="geometry">
-        <rect>
-         <x>10</x>
-         <y>30</y>
-         <width>91</width>
-         <height>20</height>
-        </rect>
-       </property>
-       <property name="text">
-        <string>Input value:</string>
-       </property>
-      </widget>
-      <widget class="QLabel" name="label_2">
-       <property name="geometry">
-        <rect>
-         <x>170</x>
-         <y>50</y>
-         <width>16</width>
-         <height>20</height>
-        </rect>
-       </property>
-       <property name="font">
-        <font>
-         <pointsize>10</pointsize>
-        </font>
-       </property>
-       <property name="text">
-        <string>in</string>
-       </property>
-      </widget>
-      <widget class="QLabel" name="label_3">
-       <property name="geometry">
-        <rect>
-         <x>200</x>
-         <y>30</y>
-         <width>46</width>
-         <height>13</height>
-        </rect>
-       </property>
-       <property name="text">
-        <string>Units:</string>
-       </property>
-      </widget>
-      <widget class="QLineEdit" name="scatteringAngleInput">
-       <property name="geometry">
-        <rect>
-         <x>80</x>
-         <y>110</y>
-         <width>201</width>
-         <height>21</height>
-        </rect>
-       </property>
-       <property name="toolTip">
-        <string>The angle through which a scattered particle or beam is deflected in degrees</string>
-       </property>
-       <property name="whatsThis">
-        <string>An input box for entering the scattering angle in Degrees (if necessary)</string>
-       </property>
-       <property name="accessibleName">
-        <string/>
-       </property>
-       <property name="text">
-        <string/>
-       </property>
-      </widget>
-      <widget class="QComboBox" name="outputUnits">
-       <property name="geometry">
-        <rect>
-         <x>80</x>
-         <y>220</y>
-         <width>201</width>
-         <height>21</height>
-        </rect>
-       </property>
-       <property name="toolTip">
-        <string>The units that you wish to convert your input value to.</string>
-       </property>
-       <property name="whatsThis">
-        <string>Drop down menu of the units for the input value to be converted to</string>
-       </property>
-      </widget>
-      <widget class="QLabel" name="label_4">
-       <property name="geometry">
-        <rect>
-         <x>80</x>
-         <y>200</y>
-         <width>71</width>
-         <height>16</height>
-        </rect>
-       </property>
-       <property name="text">
-        <string>Convert To:</string>
-       </property>
-      </widget>
-      <widget class="QPushButton" name="convertButton">
-       <property name="geometry">
-        <rect>
-         <x>130</x>
-         <y>260</y>
-         <width>111</width>
-         <height>31</height>
-        </rect>
-       </property>
-       <property name="whatsThis">
-        <string>A button to produce the converted value</string>
-       </property>
-       <property name="text">
-        <string>Convert</string>
-       </property>
-      </widget>
-      <widget class="QLineEdit" name="convertedVal">
-       <property name="geometry">
-        <rect>
-         <x>80</x>
-         <y>320</y>
-         <width>201</width>
-         <height>21</height>
-        </rect>
-       </property>
-       <property name="toolTip">
-        <string>The converted value produced</string>
-       </property>
-       <property name="whatsThis">
-        <string>A output box for displaying the converted value</string>
-       </property>
-      </widget>
-      <widget class="QLabel" name="label_6">
-       <property name="geometry">
-        <rect>
-         <x>80</x>
-         <y>90</y>
-         <width>201</width>
-         <height>16</height>
-        </rect>
-       </property>
-       <property name="text">
-        <string>Scattering Angle (Degrees):</string>
-       </property>
-      </widget>
-      <widget class="QLineEdit" name="totalFlightPathInput">
-       <property name="geometry">
-        <rect>
-         <x>80</x>
-         <y>170</y>
-         <width>201</width>
-         <height>21</height>
-        </rect>
-       </property>
-       <property name="toolTip">
-        <string>The distance travelled by the object measured in meters</string>
-       </property>
-       <property name="statusTip">
-        <string/>
-       </property>
-       <property name="whatsThis">
-        <string>An input box for entering the total flight path in meters (if necessary)</string>
-       </property>
-       <property name="text">
-        <string/>
-       </property>
-      </widget>
-      <widget class="QLabel" name="label_5">
-       <property name="geometry">
-        <rect>
-         <x>80</x>
-         <y>150</y>
-         <width>201</width>
-         <height>16</height>
-        </rect>
-       </property>
-       <property name="text">
-        <string>Total flight path (Meters):</string>
-       </property>
-      </widget>
-      <widget class="QPushButton" name="helpButton">
-       <property name="geometry">
-        <rect>
-         <x>10</x>
-         <y>340</y>
-         <width>31</width>
-         <height>23</height>
-        </rect>
-       </property>
-       <property name="toolTip">
-        <string>Help</string>
-       </property>
-       <property name="whatsThis">
-        <string>Help button</string>
-       </property>
-       <property name="text">
-        <string>?</string>
-       </property>
-      </widget>
-      <widget class="QLabel" name="label_7">
-       <property name="geometry">
-        <rect>
-         <x>80</x>
-         <y>300</y>
-         <width>201</width>
-         <height>16</height>
-        </rect>
-       </property>
-       <property name="text">
-        <string>Converted value:</string>
-       </property>
-      </widget>
+      <layout class="QVBoxLayout" name="verticalLayout">
+       <item>
+        <widget class="QLabel" name="label">
+         <property name="text">
+          <string>Input value:</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLineEdit" name="InputVal">
+         <property name="toolTip">
+          <string>The value that you wish to convert</string>
+         </property>
+         <property name="whatsThis">
+          <string>An input box for entering the value that you wish to convert</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QComboBox" name="inputUnits">
+         <property name="toolTip">
+          <string>A list of the units for the input value</string>
+         </property>
+         <property name="whatsThis">
+          <string>Drop down menu of the units for the input value</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLabel" name="label_6">
+         <property name="text">
+          <string>Scattering Angle (Degrees):</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLineEdit" name="scatteringAngleInput">
+         <property name="toolTip">
+          <string>The angle through which a scattered particle or beam is deflected in degrees</string>
+         </property>
+         <property name="whatsThis">
+          <string>An input box for entering the scattering angle in Degrees (if necessary)</string>
+         </property>
+         <property name="accessibleName">
+          <string/>
+         </property>
+         <property name="text">
+          <string/>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLabel" name="label_5">
+         <property name="text">
+          <string>Total flight path (Meters):</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLineEdit" name="totalFlightPathInput">
+         <property name="toolTip">
+          <string>The distance travelled by the object measured in meters</string>
+         </property>
+         <property name="statusTip">
+          <string/>
+         </property>
+         <property name="whatsThis">
+          <string>An input box for entering the total flight path in meters (if necessary)</string>
+         </property>
+         <property name="text">
+          <string/>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="Line" name="line">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLabel" name="label_4">
+         <property name="text">
+          <string>Convert To:</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QComboBox" name="outputUnits">
+         <property name="toolTip">
+          <string>The units that you wish to convert your input value to.</string>
+         </property>
+         <property name="whatsThis">
+          <string>Drop down menu of the units for the input value to be converted to</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QPushButton" name="convertButton">
+         <property name="whatsThis">
+          <string>A button to produce the converted value</string>
+         </property>
+         <property name="text">
+          <string>Convert</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="Line" name="line_2">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLabel" name="label_7">
+         <property name="text">
+          <string>Converted value:</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLineEdit" name="convertedVal">
+         <property name="toolTip">
+          <string>The converted value produced</string>
+         </property>
+         <property name="whatsThis">
+          <string>A output box for displaying the converted value</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QPushButton" name="helpButton">
+         <property name="minimumSize">
+          <size>
+           <width>20</width>
+           <height>20</height>
+          </size>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>40</width>
+           <height>40</height>
+          </size>
+         </property>
+         <property name="toolTip">
+          <string>Help</string>
+         </property>
+         <property name="whatsThis">
+          <string>Help button</string>
+         </property>
+         <property name="text">
+          <string>?</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
      </widget>
     </item>
    </layout>
@@ -304,8 +223,8 @@
     <rect>
      <x>0</x>
      <y>0</y>
-     <width>410</width>
-     <height>21</height>
+     <width>423</width>
+     <height>26</height>
     </rect>
    </property>
   </widget>

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/TofConverter/converter.ui
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/TofConverter/converter.ui
@@ -71,56 +71,6 @@
        <property name="whatsThis">
         <string>Drop down menu of the units for the input value</string>
        </property>
-       <item>
-        <property name="text">
-         <string>Energy (meV)</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>Wavelength (Angstroms)</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>Nu (THz)</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>Velocity (m/s)</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>Momentum (k Angstroms^-1)</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>Temperature (K)</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>Energy (cm^-1)</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>Momentum transfer (Q Angstroms^-1)</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>d-spacing (Angstroms)</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>Time of flight (microseconds)</string>
-        </property>
-       </item>
       </widget>
       <widget class="QLineEdit" name="InputVal">
        <property name="geometry">
@@ -219,56 +169,6 @@
        <property name="whatsThis">
         <string>Drop down menu of the units for the input value to be converted to</string>
        </property>
-       <item>
-        <property name="text">
-         <string>Energy (meV)</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>Wavelength (Angstroms)</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>Nu (Thz)</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>Velocity (m/s)</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>Momentum (k Angstroms^-1)</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>Temperature (K)</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>Energy (cm^-1)</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>Momentum transfer (Q Angstroms^-1)</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>d-spacing (Angstroms)</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>Time of flight (microseconds)</string>
-        </property>
-       </item>
       </widget>
       <widget class="QLabel" name="label_4">
        <property name="geometry">

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/TofConverter/converter.ui
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/TofConverter/converter.ui
@@ -65,6 +65,9 @@
         </widget>
        </item>
        <item>
+        <widget class="QComboBox" name="inputWorkspace"/>
+       </item>
+       <item>
         <widget class="QLineEdit" name="InputVal">
          <property name="toolTip">
           <string>The value that you wish to convert</string>

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/TofConverter/converterGUI.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/TofConverter/converterGUI.py
@@ -123,6 +123,7 @@ class MainWindow(QMainWindow):
         if input_option in self.input_val_dict:
             self.ui.InputVal.setText(str(self.input_val_dict[input_option]))
 
+        # Don't allow alteration of the input value if it's from a workspace
         self.ui.InputVal.setEnabled(input_option == "User specified")
 
     def input_val_editing_finished(self):

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/TofConverter/converterGUI.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/TofConverter/converterGUI.py
@@ -40,19 +40,29 @@ class MainWindow(QMainWindow):
         inOption = self.ui.inputUnits.currentText()
         outOption = self.ui.outputUnits.currentText()
 
-        # for theta: enable if input or output unit requires it
-        if inOption in self.needsThetaInputList:
-            self.thetaEnable(True)
+        if inOption == outOption:
+            self.thetaEnable(False)
+            self.flightPathEnable(False)
+            self.ui.convertButton.setEnabled(False)
+            self.ui.convertedVal.setEnabled(False)
+            self.ui.convertedVal.setText("Input and output units are the same")
+        else:
+            self.ui.convertButton.setEnabled(True)
+            self.ui.convertedVal.setEnabled(True)
+            self.ui.convertedVal.clear()
+            # for theta: enable if input or output unit requires it
+            if inOption in self.needsThetaInputList:
+                self.thetaEnable(True)
 
-        if outOption in self.needsThetaOutputList:
-            self.thetaEnable(True)
+            if outOption in self.needsThetaOutputList:
+                self.thetaEnable(True)
 
-        # for flightpath: enable if input or output unit requires it
-        if inOption in self.needsFlightPathInputList:
-            self.flightPathEnable(True)
+            # for flightpath: enable if input or output unit requires it
+            if inOption in self.needsFlightPathInputList:
+                self.flightPathEnable(True)
 
-        if outOption in self.needsFlightPathOutputList:
-            self.flightPathEnable(True)
+            if outOption in self.needsFlightPathOutputList:
+                self.flightPathEnable(True)
 
     def __init__(self, parent=None, window_flags=None):
         QMainWindow.__init__(self, parent)

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/TofConverter/converterGUI.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/TofConverter/converterGUI.py
@@ -10,14 +10,9 @@ from qtpy.QtGui import QDoubleValidator
 from qtpy import QtCore
 from mantid.kernel import Logger
 from mantidqt.gui_helper import show_interface_help
+from mantidqt.utils.qt import load_ui
 import math
 from mantidqtinterfaces.TofConverter import convertUnits
-
-try:
-    from mantidqt.utils.qt import load_ui
-except ImportError:
-    Logger("TofConverter").information("Using legacy ui importer")
-    from mantidplot import load_ui
 
 
 class MainWindow(QMainWindow):

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/TofConverter/converterGUI.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/TofConverter/converterGUI.py
@@ -111,7 +111,11 @@ class MainWindow(QMainWindow):
             else:
                 self.flightpath = -1.0
             if self.ui.scatteringAngleInput.text():
-                self.Theta = float(self.ui.scatteringAngleInput.text()) * math.pi / 360.0
+                # This Theta is the Bragg scattering angle, which is half the angle from the spherical coordinate system
+                # directed along the Mantid z-axis. See https://docs.mantidproject.org/nightly/concepts/UnitFactory.html.
+                # That's why there's a factor of 0.5 when converting to radians.
+                normalised_angle = (float(self.ui.scatteringAngleInput.text()) + 360) % 360
+                self.Theta = normalised_angle * math.pi / 360.0
             else:
                 self.Theta = -1.0
 

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/TofConverter/converterGUI.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/TofConverter/converterGUI.py
@@ -32,10 +32,6 @@ class MainWindow(QMainWindow):
             self.ui.totalFlightPathInput.clear()
 
     def setInstrumentInputs(self):
-        # disable both
-        self.thetaEnable(False)
-        self.flightPathEnable(False)
-
         # get the values of the two unit strings
         inOption = self.ui.inputUnits.currentText()
         outOption = self.ui.outputUnits.currentText()
@@ -51,18 +47,9 @@ class MainWindow(QMainWindow):
             self.ui.convertedVal.setEnabled(True)
             self.ui.convertedVal.clear()
             # for theta: enable if input or output unit requires it
-            if inOption in self.needsThetaInputList:
-                self.thetaEnable(True)
-
-            if outOption in self.needsThetaOutputList:
-                self.thetaEnable(True)
-
+            self.thetaEnable(inOption in self.needsThetaInputList or outOption in self.needsThetaOutputList)
             # for flightpath: enable if input or output unit requires it
-            if inOption in self.needsFlightPathInputList:
-                self.flightPathEnable(True)
-
-            if outOption in self.needsFlightPathOutputList:
-                self.flightPathEnable(True)
+            self.flightPathEnable(inOption in self.needsFlightPathInputList or outOption in self.needsFlightPathOutputList)
 
     def __init__(self, parent=None, window_flags=None):
         QMainWindow.__init__(self, parent)

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/TofConverter/converterGUI.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/TofConverter/converterGUI.py
@@ -47,7 +47,10 @@ class MainWindow(QMainWindow):
             self.ui.convertedVal.setEnabled(True)
             self.ui.convertedVal.clear()
             # for theta: enable if input or output unit requires it
-            self.thetaEnable(inOption in self.needsThetaInputList or outOption in self.needsThetaOutputList)
+            is_momentum_dspacing_transform = convertUnits.MOMENTUM_TRANSFER and outOption == convertUnits.D_SPACING
+            self.thetaEnable(
+                not is_momentum_dspacing_transform and (inOption in self.needsThetaInputList or outOption in self.needsThetaOutputList)
+            )
             # for flightpath: enable if input or output unit requires it
             self.flightPathEnable(inOption in self.needsFlightPathInputList or outOption in self.needsFlightPathOutputList)
 

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/TofConverter/converterGUI.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/TofConverter/converterGUI.py
@@ -50,9 +50,9 @@ class MainWindow(QMainWindow):
             self.ui.convertedVal.setEnabled(True)
             self.ui.convertedVal.clear()
             # for theta: enable if input or output unit requires it
-            is_momentum_dspacing_transform = convertUnits.MOMENTUM_TRANSFER and outOption == convertUnits.D_SPACING
             self.thetaEnable(
-                not is_momentum_dspacing_transform and (inOption in self.needsThetaInputList or outOption in self.needsThetaOutputList)
+                not convertUnits.is_momentum_dspacing_transform(inOption, outOption)
+                and (inOption in self.needsThetaInputList or outOption in self.needsThetaOutputList)
             )
             # for flightpath: enable if input or output unit requires it
             self.flightPathEnable(inOption in self.needsFlightPathInputList or outOption in self.needsFlightPathOutputList)

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/TofConverter/converterGUI.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/TofConverter/converterGUI.py
@@ -21,10 +21,10 @@ except ImportError:
 
 
 class MainWindow(QMainWindow):
-    needsThetaInputList = ["Momentum transfer (Q Angstroms^-1)", "d-spacing (Angstroms)"]
-    needsThetaOutputList = ["Momentum transfer (Q Angstroms^-1)", "d-spacing (Angstroms)"]
-    needsFlightPathInputList = ["Time of flight (microseconds)"]
-    needsFlightPathOutputList = ["Time of flight (microseconds)"]
+    needsThetaInputList = [convertUnits.MOMENTUM_TRANSFER, convertUnits.D_SPACING]
+    needsThetaOutputList = [convertUnits.MOMENTUM_TRANSFER, convertUnits.D_SPACING]
+    needsFlightPathInputList = [convertUnits.TIME_OF_FLIGHT]
+    needsFlightPathOutputList = [convertUnits.TIME_OF_FLIGHT]
 
     def thetaEnable(self, enabled):
         self.ui.scatteringAngleInput.setEnabled(enabled)
@@ -82,6 +82,10 @@ class MainWindow(QMainWindow):
         self.assistant_process = QtCore.QProcess(self)
         # pylint: disable=protected-access
         self.mantidplot_name = "TOF Converter"
+
+        # Add combo box options
+        self.ui.inputUnits.addItems(convertUnits.UNIT_LIST)
+        self.ui.outputUnits.addItems(convertUnits.UNIT_LIST)
 
         try:
             import mantid


### PR DESCRIPTION
Some work on the TOF Converter window that's a combination of an improved layout, some refactoring, and some bug fixes. These changes fix a couple of issues (#33898 and #35585)

**Purpose of work**
<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
-->
Fixes #33898 and fixes #35585 

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**Summary of work**
<!-- Please provide a short, high level description of the work that was done.
-->
- Changed layout of window so the boxes are now centred.
- If the input and output units are the same then the convert button is disabled.
- The inputs for scattering angle and TOF are not cleared when changing units, unless you change to a unit that does not require those values.
- The scattering angle is normalised to [0, 360) degrees before use in the calculation, which prevents oddities like negative d-spacing noted in #33898.
- Disable scattering angle input when converting between d-spacing and momentum transfer, because in this case the angle is not required.
- Option added to take input value from any single-value workspace.

**To test:**

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->
- Check that unit conversions match previous version. Can also check that 1  meV = 1.6 × 10-22 J = 0.24 THz = 8.1 cm-1 = 11.6 K, which is from some notes.
- Try inputting angles outside the range [0, 360).
- Try converting between d-spacing and momentum transfer and check the scatting angle and TOF boxes are disabled.
- Try adding some single-value workspaces, some other workspaces, then check that the input option behaves correctly.

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.