### PR TITLE
Ignore mantid packages in dependency spotter

### DIFF
--- a/tools/Jenkins/dependency_spotter.py
+++ b/tools/Jenkins/dependency_spotter.py
@@ -132,12 +132,12 @@ def compare_dependencies_for_file(os_name: str, first_build: int, second_build: 
     packages_changed = {}
     for package in first_output_packages:
         if package not in second_output_packages:
-            packages_removed.extend(package)
+            packages_removed.append(package)
         elif second_output_packages[package] != first_output_packages[package]:
             packages_changed[package] = first_output_packages[package] + "  ->  " + second_output_packages[package]
     for package in second_output_packages:
         if package not in first_output_packages:
-            packages_added.extend(package)
+            packages_added.append(package)
 
     # Output
     output_package_changes_to_console(packages_added, packages_removed, packages_changed)

--- a/tools/Jenkins/dependency_spotter.py
+++ b/tools/Jenkins/dependency_spotter.py
@@ -120,7 +120,10 @@ def compare_dependencies_for_file(os_name: str, first_build: int, second_build: 
     """
     # Form URLs for each build artifact file
     first_build_output_path = form_url_for_build_artifact(first_build, os_name, pipeline, log_file)
+    print(f"Path to first build: {first_build_output_path}")
     second_build_output_path = form_url_for_build_artifact(second_build, os_name, pipeline, log_file)
+    print(f"Path to second build: {second_build_output_path}")
+    print("")
 
     # Read in the packages used, with versions
     first_output_packages = extract_package_versions(first_build_output_path, os_name)

--- a/tools/Jenkins/dependency_spotter.py
+++ b/tools/Jenkins/dependency_spotter.py
@@ -131,12 +131,12 @@ def compare_dependencies_for_file(os_name: str, first_build: int, second_build: 
     packages_removed = []
     packages_changed = {}
     for package in first_output_packages:
-        if second_output_packages[package] is None:
+        if package not in second_output_packages:
             packages_removed.extend(package)
         elif second_output_packages[package] != first_output_packages[package]:
             packages_changed[package] = first_output_packages[package] + "  ->  " + second_output_packages[package]
     for package in second_output_packages:
-        if first_output_packages[package] is None:
+        if package not in first_output_packages:
             packages_added.extend(package)
 
     # Output
@@ -203,8 +203,8 @@ def extract_package_versions(url: str, os_name: str) -> Dict[str, str]:
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Script for checking dependency changes between two Jenkins builds")
     parser.add_argument("-os", help="Operating system string, e.g. linux-64", default="linux-64", type=str)
-    parser.add_argument("--first", "-f", help="First (usually passing) build number", type=int)
-    parser.add_argument("--second", "-s", help="Second (usually failing) build number", type=int)
+    parser.add_argument("--first", "-f", help="First (usually passing) build number", type=int, required=True)
+    parser.add_argument("--second", "-s", help="Second (usually failing) build number", type=int, required=True)
     parser.add_argument("--pipeline", "-p", help="Build pipeline", default="main_nightly_deployment_prototype", type=str)
     parser.add_argument(
         "--logfile",

--- a/tools/Jenkins/dependency_spotter.py
+++ b/tools/Jenkins/dependency_spotter.py
@@ -193,6 +193,8 @@ def extract_package_versions(url: str, os_name: str) -> Dict[str, str]:
             regex_result = re.search(pattern=regex_pattern, string=line.decode("utf-8"))
             if regex_result is not None and len(regex_result.groups()) == 3:
                 package_name = regex_result.group(1)
+                if package_name.startswith("mantid"):
+                    continue
                 version = regex_result.group(2)
                 package_version_dict[package_name] = version
     return package_version_dict


### PR DESCRIPTION
No need to output changes in the various mantid packages when running dependency_spotter.py

Small addition to #35866 

**Description of work**

Ignore packages whose names start with "mantid" when comparing package version changes between builds.

**To test:**

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

*This does not require release notes* because **it's for a developer tool**

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.