### PR TITLE
Remove detector list length assertion

### DIFF
--- a/Framework/API/src/MatrixWorkspace.cpp
+++ b/Framework/API/src/MatrixWorkspace.cpp
@@ -633,9 +633,6 @@ std::vector<size_t> MatrixWorkspace::getIndicesFromDetectorIDs(const std::vector
       std::copy(wsIndices->second.cbegin(), wsIndices->second.cend(), std::back_inserter(indexList));
     }
   }
-  // the number of output values should not exceed number of inputs
-  // because each detector should only be in one spectrum
-  assert(indexList.size() <= detIdList.size()); // verify size in debug builds
 
   return indexList;
 }


### PR DESCRIPTION
**Description of work**
This PR removes an assertion that compares the number of detector IDs to the number of spectra IDs in a lookup operation. We believe it is possible to have one detector ID correspond to multiple spectra, so this assertion does not hold true under all circumstances.

**To test:**
Code review and tests pass

Fixes #35891

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.