### PR TITLE
Fix the Tests Broken on macOS Ventura

### DIFF
--- a/qt/applications/workbench/workbench/plotting/figurewindow.py
+++ b/qt/applications/workbench/workbench/plotting/figurewindow.py
@@ -94,15 +94,7 @@ class FigureWindow(QMainWindow, ObservingView):
 
         # This creates a matplotlib LocationEvent so that the axis in which the
         # drop event occurred can be calculated
-        try:
-            x, y = self._canvas.mouseEventCoords(event.pos())
-        except AttributeError:  # matplotlib v1.5 does not have mouseEventCoords
-            try:
-                dpi_ratio = self._canvas.devicePixelRatio() or 1
-            except AttributeError:
-                dpi_ratio = 1
-            x = dpi_ratio * event.pos().x()
-            y = dpi_ratio * self._canvas.figure.bbox.height / dpi_ratio - event.pos().y()
+        x, y = self._canvas.mouseEventCoords(event.pos())
 
         location_event = LocationEvent("AxesGetterEvent", self._canvas, x, y)
         ax = location_event.inaxes if location_event.inaxes else self._canvas.figure.axes[0]

--- a/qt/applications/workbench/workbench/plotting/test/test_figurewindow.py
+++ b/qt/applications/workbench/workbench/plotting/test/test_figurewindow.py
@@ -40,10 +40,11 @@ class Test(unittest.TestCase):
 
     def test_drag_and_drop_adds_plot_to_correct_axes(self):
         ax = self.fig.get_axes()[1]
+        dpi_ratio = self.fig.canvas.device_pixel_ratio
         # Find the center of the axes and simulate a drop event there
         # Need to use Qt logical pixels to factor in dpi
-        ax_x_centre = ax.xaxis.clipbox.min[0] + ax.xaxis.clipbox.width * 0.5
-        ax_y_centre = ax.yaxis.clipbox.min[1] + ax.yaxis.clipbox.height * 0.5
+        ax_x_centre = (ax.xaxis.clipbox.min[0] + ax.xaxis.clipbox.width * 0.5) / dpi_ratio
+        ax_y_centre = (ax.yaxis.clipbox.min[1] + ax.yaxis.clipbox.height * 0.5) / dpi_ratio
         mock_pos = Mock(position=lambda: Mock(x=lambda: ax_x_centre, y=lambda: ax_y_centre))
         mock_event = Mock()
         mock_event.mimeData().text.return_value = "ws"

--- a/qt/applications/workbench/workbench/plotting/test/test_figurewindow.py
+++ b/qt/applications/workbench/workbench/plotting/test/test_figurewindow.py
@@ -40,11 +40,10 @@ class Test(unittest.TestCase):
 
     def test_drag_and_drop_adds_plot_to_correct_axes(self):
         ax = self.fig.get_axes()[1]
-        dpi_ratio = self.fig.canvas.devicePixelRatio() or 1
         # Find the center of the axes and simulate a drop event there
         # Need to use Qt logical pixels to factor in dpi
-        ax_x_centre = (ax.xaxis.clipbox.min[0] + ax.xaxis.clipbox.width * 0.5) / dpi_ratio
-        ax_y_centre = (ax.yaxis.clipbox.min[1] + ax.yaxis.clipbox.height * 0.5) / dpi_ratio
+        ax_x_centre = ax.xaxis.clipbox.min[0] + ax.xaxis.clipbox.width * 0.5
+        ax_y_centre = ax.yaxis.clipbox.min[1] + ax.yaxis.clipbox.height * 0.5
         mock_pos = Mock(position=lambda: Mock(x=lambda: ax_x_centre, y=lambda: ax_y_centre))
         mock_event = Mock()
         mock_event.mimeData().text.return_value = "ws"

--- a/qt/widgets/mplcpp/src/FigureCanvasQt.cpp
+++ b/qt/widgets/mplcpp/src/FigureCanvasQt.cpp
@@ -123,12 +123,11 @@ QPointF FigureCanvasQt::toDataCoords(QPoint pos) const {
   // matplotlib.backend_bases.LocationEvent where we transform first to
   // matplotlib's coordinate system, (0,0) is bottom left,
   // and then to the data coordinates
-  const int dpiRatio(devicePixelRatio());
-  const double xPosPhysical = pos.x() * dpiRatio;
+  const double xPosPhysical = pos.x();
   GlobalInterpreterLock lock;
   // Y=0 is at the bottom
   double height = PyFloat_AsDouble(Python::Object(m_figure.pyobj().attr("bbox").attr("height")).ptr());
-  const double yPosPhysical = ((height / devicePixelRatio()) - pos.y()) * dpiRatio;
+  const double yPosPhysical = height - pos.y();
   // Transform to data coordinates
   QPointF dataCoords;
   try {

--- a/qt/widgets/mplcpp/src/FigureCanvasQt.cpp
+++ b/qt/widgets/mplcpp/src/FigureCanvasQt.cpp
@@ -124,7 +124,7 @@ QPointF FigureCanvasQt::toDataCoords(QPoint pos) const {
   // matplotlib's coordinate system, (0,0) is bottom left,
   // and then to the data coordinates
   GlobalInterpreterLock lock;
-  const int dpiRatio(static_cast<const int>(
+  const int dpiRatio(static_cast<int>(
       PyFloat_AsDouble(Python::Object(m_figure.pyobj().attr("canvas").attr("device_pixel_ratio")).ptr())));
   const double xPosPhysical = pos.x() * dpiRatio;
   // Y=0 is at the bottom

--- a/qt/widgets/mplcpp/src/FigureCanvasQt.cpp
+++ b/qt/widgets/mplcpp/src/FigureCanvasQt.cpp
@@ -123,11 +123,13 @@ QPointF FigureCanvasQt::toDataCoords(QPoint pos) const {
   // matplotlib.backend_bases.LocationEvent where we transform first to
   // matplotlib's coordinate system, (0,0) is bottom left,
   // and then to the data coordinates
-  const double xPosPhysical = pos.x();
   GlobalInterpreterLock lock;
+  const int dpiRatio(static_cast<const int>(
+      PyFloat_AsDouble(Python::Object(m_figure.pyobj().attr("canvas").attr("device_pixel_ratio")).ptr())));
+  const double xPosPhysical = pos.x() * dpiRatio;
   // Y=0 is at the bottom
   double height = PyFloat_AsDouble(Python::Object(m_figure.pyobj().attr("bbox").attr("height")).ptr());
-  const double yPosPhysical = height - pos.y();
+  const double yPosPhysical = ((height / dpiRatio) - pos.y()) * dpiRatio;
   // Transform to data coordinates
   QPointF dataCoords;
   try {


### PR DESCRIPTION

RE #NONE

**Description of work**

**Purpose of work**
Fix a pair of tests stopping our use of the new mac builders. Thought this was an issue with the ARM macs, just turns out to be macOS Ventura as it was failing on developer x86 macbooks as well. 

**Summary of work**
Ventura returns 2 for the DPI ratio when called in the qt function. This was being used to protect against an issue only present in mpl v1.5, which we don't use anymore. So the exception handling of it can be safely removed. We can instead access the cached DPI ratio from matplotlib, which allows the mpl pixels to be correctly calculated. 

We should be careful this doesn't break something unexpected though. 

**To test:**
1. Tests passing on all OSs 
2. Dragging and dropping workspaces onto plots works as expected. 


*There is no associated issue.*

*This does not require release notes* because **this just fixes a test. No user-facing behaviour should have changed.**

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.