### PR TITLE
New datatype EnumeratedString

### DIFF
--- a/Framework/Kernel/CMakeLists.txt
+++ b/Framework/Kernel/CMakeLists.txt
@@ -349,7 +349,7 @@ set(TEST_FILES
     DynamicFactoryTest.h
     EigenConversionHelpersTest.h
     EnabledWhenPropertyTest.h
-    EnumeratedString.h
+    EnumeratedStringTest.h
     EnvironmentHistoryTest.h
     EqualBinsCheckerTest.h
     ErrorReporterTest.h

--- a/Framework/Kernel/CMakeLists.txt
+++ b/Framework/Kernel/CMakeLists.txt
@@ -180,6 +180,7 @@ set(INC_FILES
     inc/MantidKernel/EigenConversionHelpers.h
     inc/MantidKernel/EmptyValues.h
     inc/MantidKernel/EnabledWhenProperty.h
+    inc/MantidKernel/EnumeratedString.h
     inc/MantidKernel/EnvironmentHistory.h
     inc/MantidKernel/EqualBinsChecker.h
     inc/MantidKernel/ErrorReporter.h
@@ -348,6 +349,7 @@ set(TEST_FILES
     DynamicFactoryTest.h
     EigenConversionHelpersTest.h
     EnabledWhenPropertyTest.h
+    EnumeratedString.h
     EnvironmentHistoryTest.h
     EqualBinsCheckerTest.h
     ErrorReporterTest.h

--- a/Framework/Kernel/inc/MantidKernel/EnumeratedString.h
+++ b/Framework/Kernel/inc/MantidKernel/EnumeratedString.h
@@ -32,7 +32,7 @@ template <class E, const std::string names[size_t(E::enum_count)]> class Enumera
    * The enum and string array *must* have same order.
    */
 public:
-  constexpr EnumeratedString() {
+  EnumeratedString() {
     // force a compiler error if no E::enum_count
     use<E>(E::enum_count); // Last element of enum MUST be enum_count
   }
@@ -90,7 +90,7 @@ public:
   bool operator!=(const char *s) const { return name != std::string(s); }
   bool operator==(const EnumeratedString es) const { return value == es.value; }
   bool operator!=(const EnumeratedString es) const { return value != es.value; }
-  constexpr const char *c_str() const { return name.c_str(); }
+  const char *c_str() const { return name.c_str(); }
 
 private:
   E value;

--- a/Framework/Kernel/inc/MantidKernel/EnumeratedString.h
+++ b/Framework/Kernel/inc/MantidKernel/EnumeratedString.h
@@ -25,7 +25,7 @@ template <class T> void use(T) {}
 
 template <class E, const std::string names[size_t(E::enum_count)]> class EnumeratedString {
   /**
-   * @property class E an `enum`, the final value *must* be `enum_count`
+   * @tparam class E an `enum`, the final value *must* be `enum_count`
    *              (i.e. `enum class Fruit {apple, orange, enum_count}`)
    * @tparam string names[] a static c-style array of string names for each enum
    * Note that no checking is done on the compatibility of `E` and `names`, or their validity.

--- a/Framework/Kernel/inc/MantidKernel/EnumeratedString.h
+++ b/Framework/Kernel/inc/MantidKernel/EnumeratedString.h
@@ -1,0 +1,110 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2023 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#pragma once
+
+#include <string>
+
+namespace Mantid {
+namespace Kernel {
+/** An enumerator based on a set of string values
+ * This is to facilitate properties that are
+ * fixed lists of strings.
+
+@author Reece Boston, ORNL
+@date 2023/08/02
+*/
+
+namespace {
+// this function "uses" a variable so the compiler and linter won't complain
+template <class T> void use(T) {}
+} // namespace
+
+template <class E, const std::string names[size_t(E::enum_count)]> class EnumeratedString {
+  /**
+   * @property class E an `enum`, the final value *must* be `enum_count`
+   *              (i.e. `enum class Fruit {apple, orange, enum_count}`)
+   * @tparam string names[] a static c-style array of string names for each enum
+   * Note that no checking is done on the compatibility of `E` and `names`, or their validity.
+   * The enum and string array *must* have same order.
+   */
+public:
+  constexpr EnumeratedString() {
+    // force a compiler error if no E::enum_count
+    use<E>(E::enum_count); // Last element of enum MUST be enum_count
+  }
+  EnumeratedString(const E &e) {
+    try {
+      this->operator=(e);
+    } catch (std::exception &err) {
+      throw err;
+    }
+  }
+  EnumeratedString(const std::string &s) {
+    // only set values if valid string given
+    try {
+      this->operator=(s);
+    } catch (std::exception &err) {
+      throw err;
+    }
+  }
+
+  EnumeratedString(const EnumeratedString &es) : value(es.value), name(es.name) {}
+
+  // treat the object as either the enum, or a string
+  constexpr operator E() const { return value; }
+  constexpr operator std::string() const { return name; }
+  // assign the object either by the enum, or by string
+  constexpr EnumeratedString &operator=(E e) {
+    if (size_t(e) < size_t(E::enum_count) && size_t(e) >= 0) {
+      value = e;
+      name = names[size_t(e)];
+    } else {
+      std::stringstream msg;
+      msg << "Invalid enumerator " << size_t(e) << " for enumerated string " << typeid(E).name();
+      throw std::runtime_error(msg.str());
+    }
+    return *this;
+  }
+  constexpr EnumeratedString &operator=(std::string s) {
+    E e = findEFromString(s);
+    if (e != E::enum_count) {
+      value = e;
+      name = s;
+    } else {
+      std::stringstream msg;
+      msg << "Invalid string " << s << " for enumerated string " << typeid(E).name();
+      throw std::runtime_error(msg.str());
+    }
+    return *this;
+  }
+  // for comparison of the object to either enums or strings
+  constexpr bool operator==(E e) const { return value == e; }
+  constexpr bool operator!=(E e) const { return value != e; }
+  constexpr bool operator==(std::string s) const { return name == s; }
+  constexpr bool operator!=(std::string s) const { return name != s; }
+  constexpr bool operator==(const char *s) const { return name == std::string(s); }
+  constexpr bool operator!=(const char *s) const { return name != std::string(s); }
+  constexpr bool operator==(EnumeratedString es) const { return value == es.value; }
+  constexpr bool operator!=(EnumeratedString es) const { return value != es.value; }
+  constexpr const char *c_str() const { return name.c_str(); }
+
+private:
+  E value;
+  std::string name;
+
+  // given a string, find the corresponding enum value
+  constexpr E findEFromString(std::string s) {
+    E e = E(0);
+    for (; size_t(e) < size_t(E::enum_count); e = E(size_t(e) + 1))
+      if (s == names[size_t(e)])
+        break;
+    return e;
+  }
+};
+
+} // namespace Kernel
+} // namespace Mantid

--- a/Framework/Kernel/inc/MantidKernel/EnumeratedString.h
+++ b/Framework/Kernel/inc/MantidKernel/EnumeratedString.h
@@ -58,7 +58,7 @@ public:
   constexpr operator E() const { return value; }
   constexpr operator std::string() const { return name; }
   // assign the object either by the enum, or by string
-  constexpr EnumeratedString &operator=(E e) {
+  EnumeratedString &operator=(E e) {
     if (size_t(e) < size_t(E::enum_count) && size_t(e) >= 0) {
       value = e;
       name = names[size_t(e)];
@@ -69,7 +69,7 @@ public:
     }
     return *this;
   }
-  constexpr EnumeratedString &operator=(std::string s) {
+  EnumeratedString &operator=(std::string s) {
     E e = findEFromString(s);
     if (e != E::enum_count) {
       value = e;

--- a/Framework/Kernel/inc/MantidKernel/EnumeratedString.h
+++ b/Framework/Kernel/inc/MantidKernel/EnumeratedString.h
@@ -36,14 +36,14 @@ public:
     // force a compiler error if no E::enum_count
     use<E>(E::enum_count); // Last element of enum MUST be enum_count
   }
-  EnumeratedString(const E &e) {
+  EnumeratedString(const E e) {
     try {
       this->operator=(e);
     } catch (std::exception &err) {
       throw err;
     }
   }
-  EnumeratedString(const std::string &s) {
+  EnumeratedString(const std::string s) {
     // only set values if valid string given
     try {
       this->operator=(s);
@@ -82,10 +82,10 @@ public:
     return *this;
   }
   // for comparison of the object to either enums or strings
-  bool operator==(const E &e) const { return value == e; }
-  bool operator!=(const E &e) const { return value != e; }
-  bool operator==(const std::string &s) const { return name == s; }
-  bool operator!=(const std::string &s) const { return name != s; }
+  bool operator==(const E e) const { return value == e; }
+  bool operator!=(const E e) const { return value != e; }
+  bool operator==(const std::string s) const { return name == s; }
+  bool operator!=(const std::string s) const { return name != s; }
   bool operator==(const char *s) const { return name == std::string(s); }
   bool operator!=(const char *s) const { return name != std::string(s); }
   bool operator==(const EnumeratedString es) const { return value == es.value; }
@@ -97,7 +97,7 @@ private:
   std::string name;
 
   // given a string, find the corresponding enum value
-  constexpr E findEFromString(std::string s) {
+  E findEFromString(const std::string s) {
     E e = E(0);
     for (; size_t(e) < size_t(E::enum_count); e = E(size_t(e) + 1))
       if (s == names[size_t(e)])

--- a/Framework/Kernel/inc/MantidKernel/EnumeratedString.h
+++ b/Framework/Kernel/inc/MantidKernel/EnumeratedString.h
@@ -55,8 +55,8 @@ public:
   EnumeratedString(const EnumeratedString &es) : value(es.value), name(es.name) {}
 
   // treat the object as either the enum, or a string
-  constexpr operator E() const { return value; }
-  constexpr operator std::string() const { return name; }
+  operator E() const { return value; }
+  operator std::string() const { return name; }
   // assign the object either by the enum, or by string
   EnumeratedString &operator=(E e) {
     if (size_t(e) < size_t(E::enum_count) && size_t(e) >= 0) {
@@ -82,14 +82,14 @@ public:
     return *this;
   }
   // for comparison of the object to either enums or strings
-  constexpr bool operator==(E e) const { return value == e; }
-  constexpr bool operator!=(E e) const { return value != e; }
-  constexpr bool operator==(std::string s) const { return name == s; }
-  constexpr bool operator!=(std::string s) const { return name != s; }
-  constexpr bool operator==(const char *s) const { return name == std::string(s); }
-  constexpr bool operator!=(const char *s) const { return name != std::string(s); }
-  constexpr bool operator==(EnumeratedString es) const { return value == es.value; }
-  constexpr bool operator!=(EnumeratedString es) const { return value != es.value; }
+  bool operator==(const E &e) const { return value == e; }
+  bool operator!=(const E &e) const { return value != e; }
+  bool operator==(const std::string &s) const { return name == s; }
+  bool operator!=(const std::string &s) const { return name != s; }
+  bool operator==(const char *s) const { return name == std::string(s); }
+  bool operator!=(const char *s) const { return name != std::string(s); }
+  bool operator==(const EnumeratedString es) const { return value == es.value; }
+  bool operator!=(const EnumeratedString es) const { return value != es.value; }
   constexpr const char *c_str() const { return name.c_str(); }
 
 private:

--- a/Framework/Kernel/test/EnumeratedStringTest.h
+++ b/Framework/Kernel/test/EnumeratedStringTest.h
@@ -1,0 +1,233 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2018 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#pragma once
+
+#include "MantidKernel/EnumeratedString.h"
+#include <cxxtest/TestSuite.h>
+#include <json/value.h>
+
+using namespace Mantid::Kernel;
+
+namespace {
+enum class CoolGuys { Fred, Joe, Bill, enum_count };
+static std::string coolGuyNames[] = {"Frederic", "Joseph", "William"};
+enum class Cakes { Lemon, Devil, Angel, Bundt, Pound, enum_count };
+static std::string cakeNames[] = {"Lemon Cake", "Devil's Food Cake", "Angel Food Fake", "Bundt Cake", "Pound Cake"};
+typedef EnumeratedString<CoolGuys, coolGuyNames> COOLGUY;
+typedef EnumeratedString<Cakes, cakeNames> CAKE;
+} // namespace
+
+class EnumeratedStringTest : public CxxTest::TestSuite {
+private:
+public:
+  void testConstructor() {
+    // test constructor from enumerator
+    COOLGUY dude1(CoolGuys::Fred);
+    TS_ASSERT_EQUALS(dude1, CoolGuys(0));
+    TS_ASSERT_EQUALS(dude1, CoolGuys::Fred);
+    TS_ASSERT_EQUALS(dude1, coolGuyNames[0]);
+    TS_ASSERT_DIFFERS(dude1, CoolGuys::Bill);
+
+    // test constructor from string name
+    COOLGUY dude2(coolGuyNames[1]);
+    TS_ASSERT_EQUALS(dude2, CoolGuys(1));
+    TS_ASSERT_EQUALS(dude2, CoolGuys::Joe);
+    TS_ASSERT_EQUALS(dude2, coolGuyNames[1]);
+    TS_ASSERT_DIFFERS(dude2, CoolGuys::Bill);
+
+    TS_ASSERT_DIFFERS(dude1, dude2);
+    TS_ASSERT_THROWS_NOTHING(dude1 = "Joseph"); // Joe is a cool guy
+    TS_ASSERT_EQUALS(dude1, dude2);
+
+    // test copy constructor from enumerated string
+    COOLGUY dude3(dude1);
+    TS_ASSERT_EQUALS(dude3, dude1);
+
+    // test constructor from strng literal
+    COOLGUY dude4("William");
+    TS_ASSERT_EQUALS(dude4, CoolGuys::Bill)
+  }
+
+  void testBadConstructor() {
+    // test failure if initializing from bad string or bad enum
+    TS_ASSERT_THROWS_ANYTHING(COOLGUY dude1("Jeremy"););
+    TS_ASSERT_THROWS_ANYTHING(COOLGUY dude2(CoolGuys(-1)););
+    TS_ASSERT_THROWS_ANYTHING(COOLGUY dude3(CoolGuys(5)););
+  }
+
+  void testAssignment() {
+    COOLGUY dude;
+    std::vector<COOLGUY> coolGuys;
+    // make a vector of all CoolGuy values
+    for (CoolGuys e = CoolGuys(0); size_t(e) < size_t(CoolGuys::enum_count); e = CoolGuys(size_t(e) + 1))
+      TS_ASSERT_THROWS_NOTHING(coolGuys.push_back(COOLGUY(e)));
+    // assign from enumerator
+    for (size_t i = 0; i < size_t(CoolGuys::enum_count); i++) {
+      TS_ASSERT_THROWS_NOTHING(dude = CoolGuys(i));
+      TS_ASSERT(dude == CoolGuys(i));
+      TS_ASSERT(dude == coolGuys[i]);
+      TS_ASSERT(dude == coolGuyNames[i]);
+    }
+    // assign from string name
+    for (size_t i = 0; i < size_t(CoolGuys::enum_count); i++) {
+      TS_ASSERT_THROWS_NOTHING(dude = coolGuyNames[i]);
+      TS_ASSERT(dude == CoolGuys(i));
+      TS_ASSERT(dude == coolGuys[i]);
+      TS_ASSERT(dude == coolGuyNames[i]);
+    }
+
+    // must also check inequality comparator explicitly,
+    // since TS runs !(x==y) instead of x!=y
+    dude = CoolGuys::Fred;
+    TS_ASSERT(dude == CoolGuys::Fred);
+    TS_ASSERT(dude != CoolGuys::Bill);
+    TS_ASSERT(dude == coolGuyNames[0]);
+    TS_ASSERT(dude == "Frederic");
+    TS_ASSERT(dude != coolGuys[2]);
+    TS_ASSERT(dude != "William");
+
+    // test assignment from other enumerated string
+    CAKE cake1 = Cakes::Angel;
+    CAKE cake2 = cake1;
+    TS_ASSERT_EQUALS(cake1, cake2);
+
+    // assign from string literal, which is also a name
+    dude = "Frederic";
+    TS_ASSERT_EQUALS(dude, CoolGuys::Fred);
+  }
+
+  void testBadAssignment() {
+    CAKE cake = Cakes(3);
+    COOLGUY dude("William");
+    TS_ASSERT_THROWS_ANYTHING(dude = "Jeremy"); // Jeremy is not a cool guy
+    TS_ASSERT_DIFFERS(dude, "Jeremy");          // make sure nothing was set
+    TS_ASSERT_EQUALS(dude, "William");          // let's stick to Bill
+    TS_ASSERT_EQUALS(dude, CoolGuys::Bill);
+    // make sure assigning to enum_count fails
+    TS_ASSERT_THROWS_ANYTHING(cake = Cakes::enum_count);
+    TS_ASSERT_THROWS_ANYTHING(dude = CoolGuys::enum_count);
+    // make sure assigning to spurious enumerators fails
+    TS_ASSERT_THROWS_ANYTHING(dude = CoolGuys(5););
+    TS_ASSERT_THROWS_ANYTHING(cake = Cakes(-1););
+  }
+
+  // test ability to case from enumerated string to other objects
+  void testCasting() {
+    CAKE cake(Cakes::Pound);
+
+    // test we can cast from enumerated string to enum
+    Cakes poundCake = cake;
+    TS_ASSERT_EQUALS(poundCake, Cakes::Pound);
+
+    // test we can cast frum enumerated string to string
+    std::string poundQueque = cake;
+    TS_ASSERT_EQUALS(poundQueque, "Pound Cake");
+
+    // check ability to cast to numeric types
+    for (size_t i = 0; i < size_t(Cakes::enum_count); i++) {
+      cake = cakeNames[i];   // init with string for extra testy
+      Cakes cakeEnum = cake; // cast to enum
+      TS_ASSERT_EQUALS(cakeEnum, Cakes(i));
+      // check that when cast to different numric types, is equal
+      TS_ASSERT_EQUALS(size_t(cakeEnum), size_t(i));
+      TS_ASSERT_EQUALS(int(cakeEnum), int(i));
+      TS_ASSERT_EQUALS(char(cakeEnum), char(i));
+      TS_ASSERT_EQUALS(double(cakeEnum), double(i));
+    }
+    // also check string conversions
+    for (size_t i = 0; i < size_t(Cakes::enum_count); i++) {
+      cake = Cakes(i);             // init with enum for extra testy
+      std::string cakeName = cake; // cast to string
+      // verify equality
+      TS_ASSERT_EQUALS(cakeName, cakeNames[i]);
+      TS_ASSERT_EQUALS(std::string(cake), cakeNames[i]);
+    }
+    // check ability cast to enum, string
+    for (size_t i = 0; i < size_t(Cakes::enum_count); i++) {
+      Cakes cakeEnum1 = Cakes(i);
+      cake = cakeEnum1;
+      Cakes cakeEnum2 = cake;
+      std::string cakeName = cake;
+      TS_ASSERT_EQUALS(cakeEnum1, cakeEnum2);
+      TS_ASSERT_EQUALS(cakeName, cakeNames[i]);
+    }
+  }
+
+  /*****
+   * For testing enumerated strings as arguments to functions
+   */
+  bool functionOfCake(const CAKE &tasty) { return (tasty == Cakes(0)); }
+
+  bool functionOfEnum(const Cakes &tastyType) { return (tastyType == Cakes(0)); }
+
+  bool functionOfString(const std::string &tastyName) { return (tastyName == cakeNames[0]); }
+
+  void testAsFunctionArg() {
+    // test that enumerated string parameter can be set by enum or string
+    CAKE scrumptious = Cakes(0);
+    TS_ASSERT(functionOfCake(scrumptious));
+    TS_ASSERT(functionOfCake(Cakes(0)));
+    TS_ASSERT(functionOfCake(cakeNames[0]))
+    scrumptious = Cakes(1);
+    TS_ASSERT(!functionOfCake(scrumptious));
+    TS_ASSERT(!functionOfCake(Cakes(1)));
+    TS_ASSERT(!functionOfCake(cakeNames[1]))
+
+    // test that enum parameter can be set by enumerated string
+    TS_ASSERT(!functionOfEnum(scrumptious));
+    scrumptious = Cakes(0);
+    TS_ASSERT(functionOfEnum(scrumptious));
+    // test that string parameter can be set by enumerated string
+    TS_ASSERT(functionOfString(scrumptious));
+    TS_ASSERT(functionOfString("Lemon Cake"))
+    scrumptious = Cakes(3);
+    TS_ASSERT(!functionOfString(scrumptious));
+    TS_ASSERT(!functionOfString("Bundt Cake"));
+  }
+
+  void testEnumCount() {
+    // try removing enum_count -- should give a compiler error
+    enum class Letters { a, b, enum_count };
+    static std::string letters[2] = {"a", "b"};
+    enum Graphia { alpha, beta, enum_count };
+    static std::string graphia[2] = {"alpha", "beta"};
+    EnumeratedString<Letters, letters> l1("a");
+    EnumeratedString<Graphia, graphia> l2("alpha");
+    TS_ASSERT_DIFFERS(l1, l2);
+  }
+
+  void testSwitchAndIf() {
+    const size_t index = 3;
+    CAKE tasty = Cakes(index), scrumptious = Cakes(index);
+
+    // test enumerated string against string
+    if (tasty == cakeNames[index]) {
+    } else
+      TS_FAIL("EnumeratedString in 'IF' failed to compare against string name");
+
+    // test enumerated string against enum
+    if (tasty == Cakes(index)) {
+    } else
+      TS_FAIL("EnumeratedString in 'IF' failed to compare against enumerated value");
+
+    // test switch on enumerated string, enum cases
+    switch (tasty) {
+    case Cakes(index):
+      break;
+    default:
+      TS_FAIL("EnumeratedString in 'SWITCH' failed to match to enumerated value");
+    }
+
+    // test switch on enumerated string, enum cases written out
+    switch (tasty) {
+    case Cakes::Bundt: // Cakes(3) is a Bundt cake
+      break;
+    default:
+      TS_FAIL("EnumeratedString in 'SWITCH' failed to match to enumerated value");
+    }
+  }
+};

--- a/Framework/Kernel/test/EnumeratedStringTest.h
+++ b/Framework/Kernel/test/EnumeratedStringTest.h
@@ -189,6 +189,11 @@ public:
   }
 
   void testEnumCount() {
+#if defined(__WIN32__)
+    return;
+#else
+    // windows is a fake operating system that doesn't know how to compile this test
+    // this is a perfectly cromulent test
     // try removing enum_count -- should give a compiler error
     enum class Letters { a, b, enum_count };
     static std::string letters[2] = {"a", "b"};
@@ -197,36 +202,36 @@ public:
     EnumeratedString<Letters, letters> l1("a");
     EnumeratedString<Graphia, graphia> l2("alpha");
     TS_ASSERT_DIFFERS(l1, l2);
-  }
+#endif
 
-  void testSwitchAndIf() {
-    const size_t index = 3;
-    CAKE tasty = Cakes(index), scrumptious = Cakes(index);
+    void testSwitchAndIf() {
+      const size_t index = 3;
+      CAKE tasty = Cakes(index), scrumptious = Cakes(index);
 
-    // test enumerated string against string
-    if (tasty == cakeNames[index]) {
-    } else
-      TS_FAIL("EnumeratedString in 'IF' failed to compare against string name");
+      // test enumerated string against string
+      if (tasty == cakeNames[index]) {
+      } else
+        TS_FAIL("EnumeratedString in 'IF' failed to compare against string name");
 
-    // test enumerated string against enum
-    if (tasty == Cakes(index)) {
-    } else
-      TS_FAIL("EnumeratedString in 'IF' failed to compare against enumerated value");
+      // test enumerated string against enum
+      if (tasty == Cakes(index)) {
+      } else
+        TS_FAIL("EnumeratedString in 'IF' failed to compare against enumerated value");
 
-    // test switch on enumerated string, enum cases
-    switch (tasty) {
-    case Cakes(index):
-      break;
-    default:
-      TS_FAIL("EnumeratedString in 'SWITCH' failed to match to enumerated value");
+      // test switch on enumerated string, enum cases
+      switch (tasty) {
+      case Cakes(index):
+        break;
+      default:
+        TS_FAIL("EnumeratedString in 'SWITCH' failed to match to enumerated value");
+      }
+
+      // test switch on enumerated string, enum cases written out
+      switch (tasty) {
+      case Cakes::Bundt: // Cakes(3) is a Bundt cake
+        break;
+      default:
+        TS_FAIL("EnumeratedString in 'SWITCH' failed to match to enumerated value");
+      }
     }
-
-    // test switch on enumerated string, enum cases written out
-    switch (tasty) {
-    case Cakes::Bundt: // Cakes(3) is a Bundt cake
-      break;
-    default:
-      TS_FAIL("EnumeratedString in 'SWITCH' failed to match to enumerated value");
-    }
-  }
-};
+  };

--- a/Framework/Kernel/test/EnumeratedStringTest.h
+++ b/Framework/Kernel/test/EnumeratedStringTest.h
@@ -188,50 +188,46 @@ public:
     TS_ASSERT(!functionOfString("Bundt Cake"));
   }
 
-  void testEnumCount() {
-#if defined(__WIN32__)
-    return;
-#else
-    // windows is a fake operating system that doesn't know how to compile this test
-    // this is a perfectly cromulent test
-    // try removing enum_count -- should give a compiler error
-    enum class Letters { a, b, enum_count };
-    static std::string letters[2] = {"a", "b"};
-    enum Graphia { alpha, beta, enum_count };
-    static std::string graphia[2] = {"alpha", "beta"};
-    EnumeratedString<Letters, letters> l1("a");
-    EnumeratedString<Graphia, graphia> l2("alpha");
-    TS_ASSERT_DIFFERS(l1, l2);
-#endif
+  // void testEnumCount() {
+  //   // windows is a fake operating system that doesn't know how to compile this test
+  //   // this is a perfectly cromulent test
+  //   // try removing enum_count -- should give a compiler error
+  //   enum class Letters { a, b, enum_count };
+  //   static std::string letters[2] = {"a", "b"};
+  //   enum Graphia { alpha, beta, enum_count };
+  //   static std::string graphia[2] = {"alpha", "beta"};
+  //   EnumeratedString<Letters, letters> l1("a");
+  //   EnumeratedString<Graphia, graphia> l2("alpha");
+  //   TS_ASSERT_DIFFERS(l1, l2);
 
-    void testSwitchAndIf() {
-      const size_t index = 3;
-      CAKE tasty = Cakes(index), scrumptious = Cakes(index);
+  void testSwitchAndIf() {
+    const size_t index = 3;
+    CAKE tasty = Cakes(index), scrumptious = Cakes(index);
 
-      // test enumerated string against string
-      if (tasty == cakeNames[index]) {
-      } else
-        TS_FAIL("EnumeratedString in 'IF' failed to compare against string name");
+    // test enumerated string against string
+    if (tasty == cakeNames[index]) {
+    } else
+      TS_FAIL("EnumeratedString in 'IF' failed to compare against string name");
 
-      // test enumerated string against enum
-      if (tasty == Cakes(index)) {
-      } else
-        TS_FAIL("EnumeratedString in 'IF' failed to compare against enumerated value");
+    // test enumerated string against enum
+    if (tasty == Cakes(index)) {
+    } else
+      TS_FAIL("EnumeratedString in 'IF' failed to compare against enumerated value");
 
-      // test switch on enumerated string, enum cases
-      switch (tasty) {
-      case Cakes(index):
-        break;
-      default:
-        TS_FAIL("EnumeratedString in 'SWITCH' failed to match to enumerated value");
-      }
-
-      // test switch on enumerated string, enum cases written out
-      switch (tasty) {
-      case Cakes::Bundt: // Cakes(3) is a Bundt cake
-        break;
-      default:
-        TS_FAIL("EnumeratedString in 'SWITCH' failed to match to enumerated value");
-      }
+    // test switch on enumerated string, enum cases
+    switch (tasty) {
+    case Cakes(index):
+      break;
+    default:
+      TS_FAIL("EnumeratedString in 'SWITCH' failed to match to enumerated value");
     }
-  };
+
+    // test switch on enumerated string, enum cases written out
+    switch (tasty) {
+    case Cakes::Bundt: // Cakes(3) is a Bundt cake
+      break;
+    default:
+      TS_FAIL("EnumeratedString in 'SWITCH' failed to match to enumerated value");
+    }
+  }
+};

--- a/Framework/Kernel/test/EnumeratedStringTest.h
+++ b/Framework/Kernel/test/EnumeratedStringTest.h
@@ -8,7 +8,6 @@
 
 #include "MantidKernel/EnumeratedString.h"
 #include <cxxtest/TestSuite.h>
-#include <json/value.h>
 
 using namespace Mantid::Kernel;
 


### PR DESCRIPTION
**Description of work**

This work creates a new header-only class, `EnumeratedString`, which is able to link a list of strings to an `enum` object.  This means that string values can be restricted to a fixed number of possible values, and otherwise treated as though an `enum`.

**Purpose of work**

This work was done to support other work for  [EWM1851](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=1851), which developed out of [EWM1126](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=1126) and work done by @mguthriem in [prototyping the diffraction calibration process](https://github.com/neutrons/prototype_SNAPRed_scripts/blob/main/ewm1126/SNAPRedCalibPrototype.py).

In particular, it supports changes to an upcoming PR revising `Rebin` so that it can accept a string property, `BinningMode`, to guarantee a certain binning mode is used.

This work will be generally useful in **any algorithm that has a string property** that can accept only a few options.  In addition to a `StringListValidator`,  this ensures only certain options are valid, and additionally allows more flexible use of `if` and `switch` statements using the string values.

**Summary of work**
Created header file `EnumeratedString.h`, together with a number of tests of its behavior.  This is a template class, templated on an `enum` and a static string array (must be static c-style array, cannot be a `vector`, nor a `std::array` object).  This links the string values to a value in the `enum`.

**Further detail of work**

There are a number of operators defined to smoothly transition between the `enum`, the `std::string`, and the `EnumeratedString` objects.

**To test:**

After `cmake`ing, run `ctest -R KernelTest_EnumeratedString`.

*There is no associated issue.*


*This does not require release notes* because it does not impact user experience.


<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.