### PR TITLE
Nightly failure when building `docs-qthelp`

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SimulatedDensityOfStates.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/SimulatedDensityOfStates.py
@@ -17,10 +17,6 @@ from mantid.kernel import *
 from mantid.api import *
 import mantid.simpleapi as s_api
 
-from dos.load_castep import parse_castep_file
-from dos.load_euphonic import get_data_with_euphonic
-from dos.load_phonon import parse_phonon_file
-
 
 PEAK_WIDTH_ENERGY_FLAG = "energy"
 
@@ -254,6 +250,8 @@ class SimulatedDensityOfStates(PythonAlgorithm):
 
         @return file_data dictionary holding all required data from the castep or phonon file
         """
+        from dos.load_euphonic import get_data_with_euphonic
+
         castep_filename = self.getPropertyValue("CASTEPFile")
         phonon_filename = self.getPropertyValue("PHONONFile")
         euphonic_filename = self.getPropertyValue("ForceConstantsFile")
@@ -746,6 +744,9 @@ class SimulatedDensityOfStates(PythonAlgorithm):
         @param file_name - path to the file.
         @return tuple of the frequencies, ir and raman intensities and weights
         """
+        from dos.load_castep import parse_castep_file
+        from dos.load_phonon import parse_phonon_file
+
         ext = os.path.splitext(file_name)[1]
 
         if ext == ".phonon":

--- a/buildconfig/CMake/CommonSetup.cmake
+++ b/buildconfig/CMake/CommonSetup.cmake
@@ -166,7 +166,7 @@ include(PylintSetup)
 # ######################################################################################################################
 # External Data for testing
 # ######################################################################################################################
-if(CXXTEST_FOUND OR PYUNITTEST_FOUND)
+if(ENABLE_DOCS OR CXXTEST_FOUND OR PYUNITTEST_FOUND)
   include(SetupDataTargets)
 endif()
 

--- a/buildconfig/CMake/CommonSetup.cmake
+++ b/buildconfig/CMake/CommonSetup.cmake
@@ -166,7 +166,10 @@ include(PylintSetup)
 # ######################################################################################################################
 # External Data for testing
 # ######################################################################################################################
-if(ENABLE_DOCS OR CXXTEST_FOUND OR PYUNITTEST_FOUND)
+if(ENABLE_DOCS
+   OR CXXTEST_FOUND
+   OR PYUNITTEST_FOUND
+)
   include(SetupDataTargets)
 endif()
 

--- a/conda/recipes/mantiddocs/build.sh
+++ b/conda/recipes/mantiddocs/build.sh
@@ -53,7 +53,6 @@ cmake \
   -DCONDA_BUILD=True \
   -DUSE_PYTHON_DYNAMIC_LIB=OFF \
   -DPython_EXECUTABLE=$PYTHON \
-  -DSPHINX_WARNINGS_AS_ERRORS=OFF \
   -GNinja \
   ../
 

--- a/conda/recipes/mantiddocs/build.sh
+++ b/conda/recipes/mantiddocs/build.sh
@@ -58,6 +58,7 @@ cmake \
   ../
 
 cmake --build .
+cmake --build . --target StandardTestData
 run_with_xvfb cmake --build . --target docs-qthelp
 terminate_xvfb_sessions
 cmake --build . --target install

--- a/conda/recipes/mantiddocs/build.sh
+++ b/conda/recipes/mantiddocs/build.sh
@@ -58,7 +58,14 @@ cmake \
   ../
 
 cmake --build .
+
+# Build the StandardTestData target. We need this test data to build docs-qthelp
 cmake --build . --target StandardTestData
+
+# Configure the 'datasearch.directories' in the Mantid.properties file so the test data is found
+export STANDARD_TEST_DATA_DIR=$SRC_DIR/build/ExternalData/Testing/Data
+echo 'datasearch.directories = '$STANDARD_TEST_DATA_DIR'/UnitTest/;'$STANDARD_TEST_DATA_DIR'/DocTest/' >> $PREFIX/bin/Mantid.properties
+
 run_with_xvfb cmake --build . --target docs-qthelp
 terminate_xvfb_sessions
 cmake --build . --target install

--- a/docs/source/tutorials/python_in_mantid/solutions/02_pim_sol.rst
+++ b/docs/source/tutorials/python_in_mantid/solutions/02_pim_sol.rst
@@ -80,7 +80,7 @@ B - Plotting ILL Data
     import matplotlib.pyplot as plt
     import numpy as np
 
-    _164198 = Load('164198')
+    _164198 = Load('164198.nxs')
 
     fig, axes = plt.subplots(edgecolor='#ffffff', num='164198-1', subplot_kw={'projection': 'mantid'})
     axes.plot(_164198, color='#2ca02c', label='164198: spec 100', linewidth=1.0, specNum=100, zorder=2.1)

--- a/scripts/Calibration/tube_calib.py
+++ b/scripts/Calibration/tube_calib.py
@@ -558,7 +558,6 @@ def getCalibration(
 
     parameters_tables = list()  # hold the names of all the fit parameter tables
     for i in range_list:
-
         # Deal with (i+1)st tube specified
         wht, skipped = tubeSet.getTube(i)
         all_skipped.update(skipped)
@@ -658,7 +657,6 @@ def getCalibrationFromPeakFile(ws, calibTable, iTube, PeakFile):
     print("Number of tubes read from file =", n_tubes)
 
     for i in range(n_tubes):
-
         # Deal with (i+1)st tube got from file
         tube_name = peak_array[i][0]  # e.g. 'MERLIN/door3/tube_3_1'
         tube = TubeSpec(ws)

--- a/scripts/Calibration/tube_calib.py
+++ b/scripts/Calibration/tube_calib.py
@@ -412,7 +412,7 @@ def getCalibratedPixelPositions(
 
     :returns: list of pixel detector IDs, and list of their calibrated positions
     """
-    ws = mtd[str(input_workspace)]  # handle to the workspace
+    ws = ADS.retrieve(str(input_workspace))  # handle to the workspace
     # Arrays to be returned
     det_IDs = []
     det_positions = []
@@ -547,7 +547,7 @@ def getCalibration(
 
     This is the main method called from :func:`~tube.calibrate` to perform the calibration.
     """
-    ws = mtd[str(input_workspace)]  # handle to the input workspace
+    ws = ADS.retrieve(str(input_workspace))  # handle to the input workspace
     n_tubes = tubeSet.getNumTubes()
     print("Number of tubes =", n_tubes)
 

--- a/scripts/Calibration/tube_calib.py
+++ b/scripts/Calibration/tube_calib.py
@@ -26,7 +26,7 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 # Mantid
 from mantid.api import AnalysisDataService as ADS
 from mantid.dataobjects import EventWorkspace, TableWorkspace, Workspace2D
-from mantid.simpleapi import *
+from mantid.simpleapi import CloneWorkspace, CreateWorkspace, DeleteWorkspace, Fit, GroupWorkspaces, RenameWorkspace
 from mantid.kernel import *
 
 # Calibration


### PR DESCRIPTION
**Description of work**
The nightly pipeline has been failing due to a non-zero exit code when building the `docs-qthelp` target. I have been building this locally using the following command in order to find the warnings causing this issue

`./package-conda ~/Documents/mantid-development/mantid-conda/mambabuild/ --build-mantid --build-docs`

From this, I found a warning that the `SimulatedDensityOfStates` documentation page was not being generated because of dos import at the top of the python file. This import cannot be done at the moment of subscribing the algorithm to the AlgorithmFactory. As a consequence, when building the docs, the SimulatedDensityOfStates algorithm had a missing documentation file. The solution was to import dos from within the functions which use it so that it is possible to subscribe the algorithm.

There were also 29 warnings about missing test data files. This can be fixed by building the `StandardTestData` target in the `mantiddocs` recipe. This should not increase the size of the conda package for `mantiddocs`.

**To test:**
This build_package_from_branch should pass https://builds.mantidproject.org/job/build_packages_from_branch/482/

*There is no associated issue.*

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.