### PR TITLE
Reinstate `SPHINX_ERROR_ON_WARNINGS` and turn off for packaging

### DIFF
--- a/conda/recipes/mantiddocs/build.sh
+++ b/conda/recipes/mantiddocs/build.sh
@@ -53,6 +53,7 @@ cmake \
   -DCONDA_BUILD=True \
   -DUSE_PYTHON_DYNAMIC_LIB=OFF \
   -DPython_EXECUTABLE=$PYTHON \
+  -DSPHINX_WARNINGS_AS_ERRORS=OFF \
   -GNinja \
   ../
 

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -50,16 +50,9 @@ function(add_sphinx_build_target builder math_renderer)
     set(conf_builder ${SPHINX_CONF_DIR}/conf-${builder}.py)
   endif()
 
-  # -W turns warnings into errors, but there is an issue with getting the numpy intersphinx
-  set(sphinx_options
-      ${SPHINX_NOCOLOR}
-      ${SPHINX_KEEPGOING}
-      -W
-      -b
-      ${builder}
-      -d
-      ${DOCTREES_DIR}
-  )
+  # -W turns warnings into errors, but there is an issue with getting the numpy intersphinx. -W is temporarily disabled
+  # and should be turned back on when it works with conda packaging
+  set(sphinx_options ${SPHINX_NOCOLOR} ${SPHINX_KEEPGOING} -b ${builder} -d ${DOCTREES_DIR})
   # add a tag to differentiate between html/qthelp in conf
   if(ARGC GREATER 3)
     set(sphinx_options ${sphinx_options} -t ${ARGV3})

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -10,6 +10,7 @@ set(DOCS_MATH_EXT
 set_property(CACHE DOCS_MATH_EXT PROPERTY STRINGS "sphinx.ext.imgmath" "sphinx.ext.mathjax")
 option(DOCS_PLOTDIRECTIVE "If enabled include plots generated with the plot directive. " OFF)
 option(DOCS_QTHELP "If enabled add a target to build the qthelp documentation" ON)
+option(SPHINX_WARNINGS_AS_ERRORS "non-zero exit if there are sphinx warnings" ON)
 
 # Build layout
 set(SPHINX_CONF_DIR ${CMAKE_CURRENT_SOURCE_DIR}/source)
@@ -34,6 +35,11 @@ if(DOCS_PLOTDIRECTIVE)
 else()
   set(ENABLE_PLOTDIRECTIVE "")
 endif()
+if(SPHINX_WARNINGS_AS_ERRORS)
+  set(SPHINX_WARNINGS_AS_ERRORS_FLAG "-W")
+else()
+  set(SPHINX_WARNINGS_AS_ERRORS_FLAG "")
+endif()
 
 # Add a sphinx build target to build documentation builder - Name of the sphinx builder: html, qthelp etc target_name -
 # Optional target name. Default=docs-${builder}
@@ -50,9 +56,16 @@ function(add_sphinx_build_target builder math_renderer)
     set(conf_builder ${SPHINX_CONF_DIR}/conf-${builder}.py)
   endif()
 
-  # -W turns warnings into errors, but there is an issue with getting the numpy intersphinx. -W is temporarily disabled
-  # and should be turned back on when it works with conda packaging
-  set(sphinx_options ${SPHINX_NOCOLOR} ${SPHINX_KEEPGOING} -b ${builder} -d ${DOCTREES_DIR})
+  # -W turns warnings into errors, but there is an issue with getting the numpy intersphinx.
+  set(sphinx_options
+      ${SPHINX_NOCOLOR}
+      ${SPHINX_KEEPGOING}
+      ${SPHINX_WARNINGS_AS_ERRORS_FLAG}
+      -b
+      ${builder}
+      -d
+      ${DOCTREES_DIR}
+  )
   # add a tag to differentiate between html/qthelp in conf
   if(ARGC GREATER 3)
     set(sphinx_options ${sphinx_options} -t ${ARGV3})


### PR DESCRIPTION
**Description of work**
This PR reinstates the `SPHINX_ERROR_ON_WARNINGS` flag, but this time defaults it to on. We then turn it off when running the `mantiddocs` conda packaging recipe due to warnings about missing test data.

**To test:**
This should pass
https://builds.mantidproject.org/job/build_packages_from_branch/476/

*There is no associated issue.*

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.