### PR TITLE
Unpin sphinx and pygments

### DIFF
--- a/buildconfig/Jenkins/Conda/conda-buildscript
+++ b/buildconfig/Jenkins/Conda/conda-buildscript
@@ -142,8 +142,10 @@ rm -f -- *.dmg *.rpm *.deb *.tar.gz *.tar.xz *.exe
 # Remove test logs from previous builds
 rm -rf  $BUILD_DIR/test_logs
 
+# Set locale to avoid problems building the docs
+# See https://unix.stackexchange.com/questions/87745/what-does-lc-all-c-do
 if [[ $ENABLE_DOCS == true ]]; then
-	export LC_ALL=C
+    export LC_ALL=C
 fi
 
 # Run the script that handles the build

--- a/buildconfig/Jenkins/Conda/conda-buildscript
+++ b/buildconfig/Jenkins/Conda/conda-buildscript
@@ -142,6 +142,10 @@ rm -f -- *.dmg *.rpm *.deb *.tar.gz *.tar.xz *.exe
 # Remove test logs from previous builds
 rm -rf  $BUILD_DIR/test_logs
 
+if [[ $ENABLE_DOCS == true ]]; then
+	export LC_ALL=C
+fi
+
 # Run the script that handles the build
 $SCRIPT_DIR/build $WORKSPACE $CMAKE_PRESET $ENABLE_DOCS $ENABLE_DEV_DOCS $ENABLE_BUILD_CODE $ENABLE_UNIT_TESTS $ENABLE_SYSTEM_TESTS $ENABLE_COVERITY "$EXTRA_CMAKE_FLAGS" $BUILD_THREADS
 

--- a/buildconfig/Jenkins/Conda/package-conda
+++ b/buildconfig/Jenkins/Conda/package-conda
@@ -97,6 +97,10 @@ if [[ -n "$GIT_TAG" ]]; then
     git tag -a $GIT_TAG -m "Tagging $GIT_TAG"
 fi
 
+# Set locale to avoid problems building the docs
+# See https://unix.stackexchange.com/questions/87745/what-does-lc-all-c-do
+export LC_ALL=C
+
 # Run conda build. Use a known path so packages built in other steps can be
 # copied to a known location and reused.
 # Use the workspace root outside of the git tree or conda-build cannot

--- a/conda/recipes/conda_build_config.yaml
+++ b/conda/recipes/conda_build_config.yaml
@@ -35,9 +35,6 @@ poco:
 pycifrw:
   - 4.4.1
 
-setuptools:
-  - 49.6
-
 sphinx_bootstrap_theme:
   - 0.8.1
 

--- a/conda/recipes/conda_build_config.yaml
+++ b/conda/recipes/conda_build_config.yaml
@@ -35,8 +35,8 @@ poco:
 pycifrw:
   - 4.4.1
 
-sphinx:
-  - 5.1.1
+setuptools:
+  - 49.6
 
 sphinx_bootstrap_theme:
   - 0.8.1

--- a/conda/recipes/mantiddocs/meta.yaml
+++ b/conda/recipes/mantiddocs/meta.yaml
@@ -32,7 +32,7 @@ requirements:
   host:
     - python {{ python }}
     - setuptools
-    - sphinx {{ sphinx }}
+    - sphinx
     - sphinx_bootstrap_theme {{ sphinx_bootstrap_theme }}
     - mantidqt {{ version }}
     - versioningit

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -98,14 +98,6 @@ function(add_sphinx_build_target builder math_renderer)
                EXCLUDE_FROM_DEFAULT_BUILD 1
                EXCLUDE_FROM_ALL 1
   )
-  if(UNIX AND NOT APPLE)
-    add_custom_command(
-      TARGET ${target_name}
-      PRE_BUILD
-      COMMAND export LC_ALL=C
-      COMMENT "This sets the locale before running sphinx"
-    )
-  endif()
 endfunction()
 
 # Documentation types

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -98,6 +98,14 @@ function(add_sphinx_build_target builder math_renderer)
                EXCLUDE_FROM_DEFAULT_BUILD 1
                EXCLUDE_FROM_ALL 1
   )
+  if(UNIX AND NOT APPLE)
+    add_custom_command(
+      TARGET ${target_name}
+      PRE_BUILD
+      COMMAND export LC_ALL=C
+      COMMENT "This sets the locale before running sphinx"
+    )
+  endif()
 endfunction()
 
 # Documentation types

--- a/docs/sphinxext/mantiddoc/directives/algorithm.py
+++ b/docs/sphinxext/mantiddoc/directives/algorithm.py
@@ -124,7 +124,6 @@ class AlgorithmDirective(AlgorithmBaseDirective):
           picture (Screenshot): A Screenshot object
         """
         env = self.state.document.settings.env
-        format_str = ".. figure:: %s\n" "   :class: screenshot\n" "   :width: %dpx\n" "   :align: right\n\n" "   %s\n\n"
 
         # Sphinx assumes that an absolute path is actually relative to the directory containing the
         # conf.py file and a relative path is relative to the directory where the current rst file
@@ -152,7 +151,9 @@ class AlgorithmDirective(AlgorithmBaseDirective):
             width = 200
             caption = "Enable screenshots using DOCS_SCREENSHOTS in CMake"
 
-        self.add_rst(format_str % (path, width, caption))
+        self.add_rst_list(
+            [f".. figure:: {path}", "   :class: screenshot", f"   :width: {width}px", "   :align: right", "", f"   {caption}", ""]
+        )
 
     def _insert_deprecation_warning(self):
         """

--- a/docs/sphinxext/mantiddoc/directives/base.py
+++ b/docs/sphinxext/mantiddoc/directives/base.py
@@ -10,6 +10,7 @@ import os
 import re
 from mantid.api import AlgorithmFactory, AlgorithmManager, FunctionFactory
 from mantiddoc import get_logger
+from typing import List
 
 ALG_DOCNAME_RE = re.compile(r"^([A-Z][a-zA-Z0-9]+)-v([0-9][0-9]*)$")
 FIT_DOCNAME_RE = re.compile(r"^([A-Z][a-zA-Z0-9]+)$")
@@ -86,10 +87,21 @@ class BaseDirective(Directive):
         Args:
           text (str): reST to track
         """
+        self.initialise_rst_lines()
+        self.rst_lines.extend(statemachine.string2lines(text))
+
+    def add_rst_list(self, text: List[str]):
+        """
+        Appends given list of strings. It is NOT inserted into the
+        document until commit_rst() is called
+        :param text: List of strings, each item in the list will be a line
+        """
+        self.initialise_rst_lines()
+        self.rst_lines.extend(text)
+
+    def initialise_rst_lines(self):
         if self.rst_lines is None:
             self.rst_lines = []
-
-        self.rst_lines.extend(statemachine.string2lines(text))
 
     def commit_rst(self):
         """

--- a/docs/sphinxext/mantiddoc/directives/interface.py
+++ b/docs/sphinxext/mantiddoc/directives/interface.py
@@ -103,11 +103,11 @@ class InterfaceDirective(BaseDirective):
             caption = "Enable screenshots using DOCS_SCREENSHOTS in CMake"
 
         if align is not None:
-            self.add_rst(
-                f".. figure:: {path}\n" f"   :class: screenshot\n" f"   :width: {width}px\n" f"   :align: {align}\n\n" f"   {caption}\n\n"
+            self.add_rst_list(
+                [f".. figure:: {path}", "   :class: screenshot", f"   :width: {width}px", f"   :align: {align}\n", "", f"   {caption}", ""]
             )
         else:
-            self.add_rst(f".. figure:: {path}\n" f"   :class: screenshot\n" f"   :width: {width}px\n\n" f"   {caption}\n\n")
+            self.add_rst_list([f".. figure:: {path}", "   :class: screenshot", f"   :width: {width}px\n", "", f"   {caption}", ""])
 
 
 # ------------------------------------------------------------------------------------------------------------

--- a/docs/sphinxext/mantiddoc/directives/plot_directive.py
+++ b/docs/sphinxext/mantiddoc/directives/plot_directive.py
@@ -79,7 +79,7 @@ def insert_placeholder_caption(state_machine):
         ".. figure:: /images/ImageNotFound.png",
         "   :class: screenshot",
         "   :width: 200px",
-        "",
+        "\n",
         "   Enable :plots: using DOCS_PLOTDIRECTIVE in CMake", ""
     ]
     # yapf: enable

--- a/mantid-developer-linux.yml
+++ b/mantid-developer-linux.yml
@@ -70,6 +70,5 @@ dependencies:
   # Development tooling
   - black  # may be out of sync with pre-commit
   - cppcheck==2.10.3
-  - pygments==2.11.2 # Had to pin back to 2.11 due to cppcheck error which is only fixed in cppcheck>=2.8
   - gcovr>=4.2
   - pre-commit>=2.12.0

--- a/mantid-developer-osx.yml
+++ b/mantid-developer-osx.yml
@@ -49,7 +49,6 @@ dependencies:
   # Needed only for development
   - black  # may be out of sync with pre-commit
   - cppcheck==2.10.3
-  - pygments==2.11.2 # Had to pin back to 2.11 due to cppcheck error which is only fixed in cppcheck>=2.8
   - pre-commit>=2.12.0
   - libcxx
 

--- a/mantid-developer-win.yml
+++ b/mantid-developer-win.yml
@@ -48,5 +48,4 @@ dependencies:
   # Needed only for development
   - black  # may be out of sync with pre-commit
   - cppcheck==2.10.3
-  - pygments==2.11.2 # Had to pin back to 2.11 due to cppcheck error which is only fixed in cppcheck>=2.8
   - pre-commit==2.15 # Had to pin back to 2.15 as we can't handle changes made here (https://github.com/pre-commit/pre-commit/pull/2065 added in 2.16) on windows yet.


### PR DESCRIPTION
Unpinning sphinx required that pygments also be unpinned, which in turn required cppcheck>=2.8, which is now the case. At the time of writing sphinx is version 7.2.*.

**Description of work**
Unpinned sphinx and pygments. To get the new version to work I had to add the definition of LC_ALL to the build and package scripts. This prevents an error about locales not being available, see #35504 for a similar problem. I also had to edit the python code that generates the rst for the "image not found" section of the doc pages. It looked like new lines were being parsed in a slightly different way.

**Purpose of work**
<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
-->
Fixes #34584 

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**
- Build docs with new version of sphinx
- Check search and rendering of LaTeX equations
- https://builds.mantidproject.org/job/build_packages_from_branch/544/ - The macOS build has a broken test but I don't think it's anything to do with these changes.
- https://builds.mantidproject.org/job/build_packages_from_branch/630/ - The above build has been automatically deleted from the history.
- https://builds.mantidproject.org/job/build_packages_from_branch/640/

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

I'm not sure if this needs release notes, #34596 didn't have them but that was just for developer docs, while this affects the user docs as well.

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.