### PR TITLE
Fix a crash with plot guess in data analysis GUI

### DIFF
--- a/docs/source/release/v6.8.0/Indirect/Bugfixes/35920.rst
+++ b/docs/source/release/v6.8.0/Indirect/Bugfixes/35920.rst
@@ -1,0 +1,1 @@
+- The data analysis GUI will no longer crash when using plot guess if the sample data contains NAN's.

--- a/qt/scientific_interfaces/Indirect/IndirectFitPlotModel.cpp
+++ b/qt/scientific_interfaces/Indirect/IndirectFitPlotModel.cpp
@@ -308,6 +308,7 @@ MatrixWorkspace_sptr IndirectFitPlotModel::createGuessWorkspace(const MatrixWork
   createWsAlg->setChild(true);
   createWsAlg->setLogging(false);
   createWsAlg->setProperty("Function", func->asString());
+  createWsAlg->setProperty("IgnoreInvalidData", true);
   createWsAlg->setProperty("InputWorkspace", inputWorkspace);
   createWsAlg->setProperty("OutputWorkspace", "__QENSGuess");
   createWsAlg->setProperty("StartX", startX);


### PR DESCRIPTION
**Description of work**

In the data analysis GUI (indirect) there was a bug that meant the plot guess button could crash all of Mantid. This would happen when the sample data contained NAN's (I assume infs would also cause a problem), because the function could not be evaluated against the sample workspace. 

In the fitting this is avoided by having an option for "Ignore invalid values". Here we have just set "ignore invalid values" to always be true (at worst it does nothing). 

I have not added a test as it just changes the properties being set for an algorithm. 

**To test:**
Open indirect ->data analysis
Go to the conv fit tab
Load some LET data (doesnt matter which), the resolution and sample workspaces need to be different. 
Press add and then close the pop up
In the main window change the function browser so that it has 1 lorentzian. 
Click plot guess
Instead of crashing a line will appear on the plot. 

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

Fixes #35920 <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

Added a release note

---

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.