### PR TITLE
Avoid bug when attempting to overplot single bin workspace

### DIFF
--- a/docs/source/release/v6.8.0/Workbench/Bugfixes/32474.rst
+++ b/docs/source/release/v6.8.0/Workbench/Bugfixes/32474.rst
@@ -1,0 +1,1 @@
+- Avoided a bug when attempting to drag and drop a single binned workspace onto an open plot. This action is now rejected an a warning logged.

--- a/qt/applications/workbench/workbench/plotting/figurewindow.py
+++ b/qt/applications/workbench/workbench/plotting/figurewindow.py
@@ -20,6 +20,7 @@ from qtpy.QtWidgets import QMainWindow
 # local imports
 from mantidqt.plotting.figuretype import FigureType, figure_type
 from mantidqt.widgets.observers.observing_view import ObservingView
+from mantid.api import AnalysisDataServiceImpl
 import mantid.kernel
 
 
@@ -29,8 +30,6 @@ def _validate_workspaces(names: List[str]) -> List[bool]:
     :param names: A list of workspace names
     :return: List of bools, True if all workspaces have multiple bins
     """
-    from mantid.api import AnalysisDataServiceImpl
-
     ads = AnalysisDataServiceImpl.Instance()
     results = []
     for name in names:

--- a/qt/applications/workbench/workbench/plotting/figurewindow.py
+++ b/qt/applications/workbench/workbench/plotting/figurewindow.py
@@ -31,7 +31,7 @@ def _validate_workspaces(names: List[str]) -> List[bool]:
     :return: List of bools, True if all workspaces have multiple bins
     """
     ads = AnalysisDataServiceImpl.Instance()
-    results = []
+    has_multiple_bins = []
     for name in names:
         result = False
         ws = ads.retrieve(name)
@@ -44,9 +44,9 @@ def _validate_workspaces(names: List[str]) -> List[bool]:
                     result = True
                     break
         finally:
-            results.append(result)
+            has_multiple_bins.append(result)
 
-    return results
+    return has_multiple_bins
 
 
 class FigureWindow(QMainWindow, ObservingView):


### PR DESCRIPTION
**Description of work**

This PR is to fix a bug when dragging a single binned workspace onto an open plot (to try and overplot it). Overplotting is disabled in the right-click context menu for these workspaces so should not be allowed via drag and drop.

This action is now rejected and a warning displayed in the log.

Also added a test.

**To test:**

Create two workspaces.
```
from mantid.simpleapi import *

CreateSampleWorkspace(OutputWorkspace='SingleBinWorkspace', WorkspaceType='Event', Function='Flat background', XMax=1, BinWidth=1, NumEvents=10, Random=True, NumBanks=10, BankPixelWidth=1, PixelSpacing=0.10000000000000001)
CreateSampleWorkspace(OutputWorkspace='NormalWorkspace', WorkspaceType='Event', Function='Flat background', XMax=10, BinWidth=1, NumEvents=10, Random=True, NumBanks=10, BankPixelWidth=1, PixelSpacing=0.10000000000000001)
```

- Plot a spectrum from `NormalWorkspace`.
- Click and drag `SingleBinWorkspace` from the ADS onto the plot.
- [ ] A warning should be logged and no changes made to the plot. 

Fixes #32474 

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.