### PR TITLE
fix missing validation case in rebin param validator

### DIFF
--- a/Framework/Algorithms/test/RebinByTimeBaseTest.h
+++ b/Framework/Algorithms/test/RebinByTimeBaseTest.h
@@ -228,9 +228,9 @@ public:
     alg.setProperty("InputWorkspace", ws);
     auto rebinArgs1List = {double(badStep)};
     Mantid::MantidVec rebinArgs1 = rebinArgs1List; // Step is zero!.
-    alg.setProperty("Params", rebinArgs1);
     alg.setPropertyValue("OutputWorkspace", "outWS");
     try {
+      alg.setProperty("Params", rebinArgs1);
       alg.execute();
     } catch (std::invalid_argument &) {
       return;

--- a/Framework/Kernel/src/RebinParamsValidator.cpp
+++ b/Framework/Kernel/src/RebinParamsValidator.cpp
@@ -40,9 +40,13 @@ std::string RebinParamsValidator::checkValidity(const std::vector<double> &value
   }
 
   // bin widths must not be zero
-  for (size_t i = 1; i < value.size(); i += 2) {
-    if (value[i] == 0.0) {
-      return "Cannot have a zero bin width";
+  if (value.size() == 1 && value[0] == 0.0) {
+    return "Cannot have a zero bin width";
+  } else {
+    for (size_t i = 1; i < value.size(); i += 2) {
+      if (value[i] == 0.0) {
+        return "Cannot have a zero bin width";
+      }
     }
   }
 


### PR DESCRIPTION
**Description of work**

Made a small patch to `RebinParamsValidator` to account for uncaught cause that should fail validation.  Additional small change to a unit test to account for this difference in where failure occurs.

**Purpose of work**

As part of [PR 35896](https://github.com/mantidproject/mantid/pull/35896) it was requested to test some bad parameter cases.  This revealed that one test case that should result in failure did not.  This change was made to fix that.

Original issue discovered by requests from @jfkcooper

**Summary of work**

Added an additional check inside the rebin params validator, to prevent the rebin params being set with only a zero binwidth.

**Further detail of work**

Rebin params may be set from:
1. a single number, the binwidth
2. a pair of numbers read as a range (if enabled)
3. an odd number (2n+1, n>0) of values, in the order xmin, width1, xmid1, width2, xmid2, width3, ..., xmax.

The validator was set to ensure that in case 3, all of the widths were nonzero.  However, nothing verified that the width in case 1 was nonzero.  This work adds an additional check for the case of only a single number as a rebin param.

One family of unit tests were setup to check failure within execution if the binwidth was only 0.  With the change, the failure occurs earlier, so this test was changed to reflect the update.

**To test:**

Try the below in python:
``` python
rebinAlgo = Rebin()
rebinAlgo.initialize()
rebinAlgo.setProperty("Params", "0.0")
```
This should fail, with a message that binwidth cannot be zero.

*There is no associated issue.*

*This does not require release notes* because it does not impact user experience

---

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.