### PR TITLE
Extend Mantid's Stitch1D to return SingleValueWorkspace with scaling + scaling_error

### DIFF
--- a/Framework/Algorithms/src/Stitch1D.cpp
+++ b/Framework/Algorithms/src/Stitch1D.cpp
@@ -139,7 +139,7 @@ void Stitch1D::init() {
                   "True to use a provided value for the scale factor.");
   declareProperty(
       std::make_unique<WorkspaceProperty<WorkspaceSingleValue>>("OutputScalingWorkspace", "", Direction::Output),
-      "Output WorkspaceSingleValue containing the scale factor and its error. No creation if left empty");
+      "Output WorkspaceSingleValue containing the scale factor and its error. No workspace creation if left empty.");
   auto manualScaleFactorValidator = std::make_shared<BoundedValidator<double>>();
   manualScaleFactorValidator->setLower(0);
   manualScaleFactorValidator->setExclusive(true);

--- a/Framework/Algorithms/src/Stitch1D.cpp
+++ b/Framework/Algorithms/src/Stitch1D.cpp
@@ -9,6 +9,7 @@
 #include "MantidAPI/MatrixWorkspace.h"
 #include "MantidAPI/WorkspaceProperty.h"
 #include "MantidAlgorithms/RunCombinationHelpers/RunCombinationHelper.h"
+#include "MantidDataObjects/WorkspaceSingleValue.h"
 #include "MantidHistogramData/HistogramDx.h"
 #include "MantidHistogramData/HistogramE.h"
 #include "MantidHistogramData/HistogramX.h"
@@ -27,6 +28,7 @@
 
 using namespace Mantid::API;
 using namespace Mantid::Kernel;
+using Mantid::DataObjects::WorkspaceSingleValue;
 using Mantid::HistogramData::HistogramE;
 using Mantid::HistogramData::HistogramY;
 
@@ -135,6 +137,9 @@ void Stitch1D::init() {
                   "Scaling either with respect to LHS workspace or RHS workspace");
   declareProperty(std::make_unique<PropertyWithValue<bool>>("UseManualScaleFactor", false, Direction::Input),
                   "True to use a provided value for the scale factor.");
+  declareProperty(
+      std::make_unique<WorkspaceProperty<WorkspaceSingleValue>>("OutputScalingWorkspace", "", Direction::Output),
+      "Output WorkspaceSingleValue containing the scale factor and its error. No creation if left empty");
   auto manualScaleFactorValidator = std::make_shared<BoundedValidator<double>>();
   manualScaleFactorValidator->setLower(0);
   manualScaleFactorValidator->setExclusive(true);
@@ -583,8 +588,19 @@ void Stitch1D::exec() {
   }
   setProperty("OutputWorkspace", result);
   setProperty("OutScaleFactor", m_scaleFactor);
-}
 
+  // if required, create the output single value workspace containing the scaling factor and its error
+  const std::string scalingWsName = this->getPropertyValue("OutputScalingWorkspace");
+  if (!scalingWsName.empty()) {
+    auto createSingleAlg = createChildAlgorithm("CreateSingleValuedWorkspace");
+    createSingleAlg->setProperty("DataValue", m_scaleFactor);
+    createSingleAlg->setProperty("ErrorValue", m_errorScaleFactor);
+    createSingleAlg->executeAsChildAlg();
+    MatrixWorkspace_sptr singleWS = createSingleAlg->getProperty("OutputWorkspace");
+    AnalysisDataService::Instance().addOrReplace(scalingWsName, singleWS);
+    this->setProperty("OutputScalingWorkspace", singleWS);
+  }
+}
 /** Put special values back.
  * @param ws : MatrixWorkspace to resinsert special values into.
  */

--- a/Framework/Algorithms/src/Stitch1D.cpp
+++ b/Framework/Algorithms/src/Stitch1D.cpp
@@ -138,7 +138,7 @@ void Stitch1D::init() {
   declareProperty(std::make_unique<PropertyWithValue<bool>>("UseManualScaleFactor", false, Direction::Input),
                   "True to use a provided value for the scale factor.");
   declareProperty(
-      std::make_unique<WorkspaceProperty<WorkspaceSingleValue>>("OutputScalingWorkspace", "", Direction::Output),
+      "OutputScalingWorkspace", "",
       "Output WorkspaceSingleValue containing the scale factor and its error. No workspace creation if left empty.");
   auto manualScaleFactorValidator = std::make_shared<BoundedValidator<double>>();
   manualScaleFactorValidator->setLower(0);
@@ -598,7 +598,6 @@ void Stitch1D::exec() {
     createSingleAlg->executeAsChildAlg();
     MatrixWorkspace_sptr singleWS = createSingleAlg->getProperty("OutputWorkspace");
     AnalysisDataService::Instance().addOrReplace(scalingWsName, singleWS);
-    this->setProperty("OutputScalingWorkspace", singleWS);
   }
 }
 /** Put special values back.

--- a/Framework/Algorithms/test/Stitch1DTest.h
+++ b/Framework/Algorithms/test/Stitch1DTest.h
@@ -13,6 +13,7 @@
 #include "MantidAlgorithms/CompareWorkspaces.h"
 #include "MantidAlgorithms/Stitch1D.h"
 #include "MantidDataObjects/Workspace2D.h"
+#include "MantidDataObjects/WorkspaceSingleValue.h"
 #include "MantidHistogramData/Counts.h"
 #include "MantidHistogramData/Histogram.h"
 #include "MantidHistogramData/HistogramDx.h"
@@ -32,6 +33,8 @@ using namespace Mantid::API;
 using namespace Mantid::DataObjects;
 using namespace Mantid::Kernel;
 using Mantid::Algorithms::Stitch1D;
+using Mantid::DataObjects::WorkspaceSingleValue;
+using Mantid::DataObjects::WorkspaceSingleValue_sptr;
 using Mantid::HistogramData::Counts;
 using Mantid::HistogramData::HistogramDx;
 using Mantid::HistogramData::HistogramE;
@@ -326,6 +329,7 @@ public:
     alg.setProperty("LHSWorkspace", point_ws_1);
     alg.setProperty("RHSWorkspace", point_ws_2);
     alg.setPropertyValue("OutputWorkspace", "dummy_value");
+    alg.setPropertyValue("OutputScalingWorkspace", "scaling_workspace");
     alg.execute();
     TS_ASSERT(alg.isExecuted());
     double scaleFactor = alg.getProperty("OutScaleFactor");
@@ -337,6 +341,12 @@ public:
     TS_ASSERT_EQUALS(stitched->y(0).rawData(), y_values);
     const std::vector<double> dx_values{3., 9., 2., 9., 1., 9.};
     TS_ASSERT_EQUALS(stitched->dx(0).rawData(), dx_values);
+    // Check the single value workspace is correct
+    WorkspaceSingleValue_sptr singleWs =
+        AnalysisDataService::Instance().retrieveWS<WorkspaceSingleValue>("scaling_workspace");
+    TS_ASSERT_DELTA(singleWs->x(0)[0], 0.0, 1e-08);
+    TS_ASSERT_DELTA(singleWs->y(0)[0], 1. / 3., 1e-08);
+    TS_ASSERT_DELTA(singleWs->e(0)[0], 0.175682092, 1e-08);
   }
 
   void test_point_data_without_dx() {

--- a/docs/source/release/v6.8.0/Framework/Algorithms/New_features/35936.rst
+++ b/docs/source/release/v6.8.0/Framework/Algorithms/New_features/35936.rst
@@ -1,0 +1,1 @@
+- New ouput property "OutputScalingWorkspace" in algorithm :ref:`Stitch1D <algm-Stitch1D>` generates a WorkspaceSingleValue containing the scale factor and its error. No workspace creation if left empty.


### PR DESCRIPTION
**Description of work**

Add output property `OutputScalingWorkspace` to algorithm `Stitch1D`.   

> Output WorkspaceSingleValue containing the scale factor and its error. No creation if left empty

**Purpose of work**

Enable a way to retrieve not only the scaling factor but also its error.

**To test:**
Run the following script in Mantid's workbench:
```python
from mantid.simpleapi import CreateWorkspace, Stitch1D
import numpy as np

w1 = CreateWorkspace([1., 2, 3, 4], [2, 2, 2, 2], [1, 1, 1, 1])
w2 = CreateWorkspace([2, 3, 4, 5], [1, 1, 1, 1], [1, 1, 1, 1])
w = Stitch1D(w1, w2, OutputScalingWorkspace="scaling")
scaling_workspace = mtd["scaling"]
scaling, error = scaling_workspace.readY(0)[0], scaling_workspace.readE(0)[0]
np.testing.assert_allclose([scaling, error], [2.0, np.sqrt(5.0)])
```

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

Fixes [Task 2205 Extend Mantid's Stitch1D to return SingleValueWorkspace with scaling + scaling_error](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=2205)

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.