### PR TITLE
Fix workspaces being overwritten in individual focussing mode ISIS powder scripts

### DIFF
--- a/docs/source/release/v6.8.0/Diffraction/Powder/Bugfixes/35937.rst
+++ b/docs/source/release/v6.8.0/Diffraction/Powder/Bugfixes/35937.rst
@@ -1,0 +1,1 @@
+- Fixed bug in ISIS powder reduction for workspaces being overwritten when focussing using individual batching mode (this affected POLARIS and GEM)

--- a/scripts/Diffraction/isis_powder/abstract_inst.py
+++ b/scripts/Diffraction/isis_powder/abstract_inst.py
@@ -104,7 +104,10 @@ class AbstractInst(object):
 
     def _output_focused_runs(self, focused_runs, run_number_string):
         run_details = self._get_run_details(run_number_string)
-        for focused_run in focused_runs:
+        input_batching = self._get_input_batching_mode()
+        for irun, focused_run in enumerate(focused_runs):
+            if input_batching == common_enums.INPUT_BATCHING.Individual:
+                run_details.output_run_string = str(common.generate_run_numbers(run_number_string=run_number_string)[irun])
             d_spacing_group, tof_group = self._output_focused_ws(focused_run, run_details=run_details)
             common.keep_single_ws_unit(d_spacing_group=d_spacing_group, tof_group=tof_group, unit_to_keep=self._get_unit_to_keep())
 

--- a/scripts/Diffraction/isis_powder/test/ISISPowderAbstractInstrumentTest.py
+++ b/scripts/Diffraction/isis_powder/test/ISISPowderAbstractInstrumentTest.py
@@ -77,6 +77,19 @@ class ISISPowderAbstractInstrumentTest(unittest.TestCase):
             self.fail('Could not find file "{}"'.format(name))
         return full_path
 
+    def _setup_output_focused_runs_test(self, mock_get_run_details, mock_get_mode, mock_output_ws, mock_keep_unit):
+        mock_inst = self._setup_mock_inst(calibration_dir="ignored", output_dir="ignored", yaml_file_path="ISISPowderRunDetailsTest.yaml")
+        mock_run_details = create_autospec(run_details._RunDetails)
+        runs = ["123", "124"]
+        run_string = "-".join(runs)
+        mock_run_details.output_string = run_string
+        mock_run_details.output_run_string = run_string
+        mock_get_run_details.return_value = mock_run_details
+        # produce output that allows us to test that run_details.output_run_string provided is correct
+        mock_output_ws.side_effect = lambda focused_run, run_details: 2 * [run_details.output_run_string]
+
+        return mock_get_mode, mock_inst, mock_keep_unit, run_string, runs
+
     def _setup_mock_inst(
         self,
         yaml_file_path,
@@ -233,16 +246,10 @@ class ISISPowderAbstractInstrumentTest(unittest.TestCase):
     def test_output_focused_runs_individual_batch_mode(
         self, mock_get_run_details, mock_get_mode, mock_output_ws, mock_keep_unit, mock_remove_ws
     ):
-        mock_inst = self._setup_mock_inst(calibration_dir="ignored", output_dir="ignored", yaml_file_path="ISISPowderRunDetailsTest.yaml")
+        mock_get_mode, mock_inst, mock_keep_unit, run_string, runs = self._setup_output_focused_runs_test(
+            mock_get_run_details, mock_get_mode, mock_output_ws, mock_keep_unit
+        )
         mock_get_mode.return_value = "Individual"
-        mock_run_details = create_autospec(run_details._RunDetails)
-        runs = ["123", "124"]
-        run_string = "-".join(runs)
-        mock_run_details.output_string = run_string
-        mock_run_details.output_run_string = run_string
-        mock_get_run_details.return_value = mock_run_details
-        # produce output that allows us to test that run_details.output_run_string provided is correct
-        mock_output_ws.side_effect = lambda focused_run, run_details: 2 * [run_details.output_run_string]
 
         mock_inst._output_focused_runs(focused_runs=["INST123_foc", "INST124_foc"], run_number_string=run_string)
 
@@ -257,16 +264,10 @@ class ISISPowderAbstractInstrumentTest(unittest.TestCase):
     def test_output_focused_runs_summed_batch_mode(
         self, mock_get_run_details, mock_get_mode, mock_output_ws, mock_keep_unit, mock_remove_ws
     ):
-        mock_inst = self._setup_mock_inst(calibration_dir="ignored", output_dir="ignored", yaml_file_path="ISISPowderRunDetailsTest.yaml")
+        mock_get_mode, mock_inst, mock_keep_unit, run_string, runs = self._setup_output_focused_runs_test(
+            mock_get_run_details, mock_get_mode, mock_output_ws, mock_keep_unit
+        )
         mock_get_mode.return_value = "Summed"
-        mock_run_details = create_autospec(run_details._RunDetails)
-        runs = ["123", "124"]
-        run_string = "-".join(runs)
-        mock_run_details.output_string = run_string
-        mock_run_details.output_run_string = run_string
-        mock_get_run_details.return_value = mock_run_details
-        # produce output that allows us to test that run_details.output_run_string provided is correct
-        mock_output_ws.side_effect = lambda focused_run, run_details: 2 * [run_details.output_run_string]
 
         mock_inst._output_focused_runs(focused_runs=["INST123_foc", "INST124_foc"], run_number_string=run_string)
 

--- a/scripts/Diffraction/isis_powder/test/ISISPowderAbstractInstrumentTest.py
+++ b/scripts/Diffraction/isis_powder/test/ISISPowderAbstractInstrumentTest.py
@@ -16,6 +16,7 @@ import random
 import string
 import tempfile
 import unittest
+from unittest.mock import patch, create_autospec, call
 import warnings
 
 
@@ -24,7 +25,6 @@ def _gen_random_string():
 
 
 class _MockInst(AbstractInst):
-
     _param_map = [
         ParamMapEntry(ext_name="cal_dir", int_name="calibration_dir"),
         ParamMapEntry(ext_name="cal_map", int_name="cal_mapping_path"),
@@ -62,7 +62,6 @@ class _MockInst(AbstractInst):
 
 
 class ISISPowderAbstractInstrumentTest(unittest.TestCase):
-
     _folders_to_remove = set()
     CALIB_FILE_NAME = "ISISPowderRunDetailsTest.yaml"
     GROUPING_FILE_NAME = "hrpd_new_072_01.cal"
@@ -225,6 +224,54 @@ class ISISPowderAbstractInstrumentTest(unittest.TestCase):
         # Test non-numerical input
         self.assertRaises(ValueError, mock_inst.set_beam_parameters, height="height", width=-2)
         self.assertRaises(ValueError, mock_inst.set_beam_parameters, height=-1.234, width=True)
+
+    @patch("isis_powder.routines.common.remove_intermediate_workspace")
+    @patch("isis_powder.routines.common.keep_single_ws_unit")
+    @patch("isis_powder.abstract_inst.AbstractInst._output_focused_ws")
+    @patch("isis_powder.abstract_inst.AbstractInst._get_input_batching_mode")
+    @patch("isis_powder.abstract_inst.AbstractInst._get_run_details")
+    def test_output_focused_runs_individual_batch_mode(
+        self, mock_get_run_details, mock_get_mode, mock_output_ws, mock_keep_unit, mock_remove_ws
+    ):
+        mock_inst = self._setup_mock_inst(calibration_dir="ignored", output_dir="ignored", yaml_file_path="ISISPowderRunDetailsTest.yaml")
+        mock_get_mode.return_value = "Individual"
+        mock_run_details = create_autospec(run_details._RunDetails)
+        runs = ["123", "124"]
+        run_string = "-".join(runs)
+        mock_run_details.output_string = run_string
+        mock_run_details.output_run_string = run_string
+        mock_get_run_details.return_value = mock_run_details
+        # produce output that allows us to test that run_details.output_run_string provided is correct
+        mock_output_ws.side_effect = lambda focused_run, run_details: 2 * [run_details.output_run_string]
+
+        mock_inst._output_focused_runs(focused_runs=["INST123_foc", "INST124_foc"], run_number_string=run_string)
+
+        expected_calls = [call(d_spacing_group=run, tof_group=run, unit_to_keep=None) for run in runs]
+        mock_keep_unit.assert_has_calls(expected_calls)
+
+    @patch("isis_powder.routines.common.remove_intermediate_workspace")
+    @patch("isis_powder.routines.common.keep_single_ws_unit")
+    @patch("isis_powder.abstract_inst.AbstractInst._output_focused_ws")
+    @patch("isis_powder.abstract_inst.AbstractInst._get_input_batching_mode")
+    @patch("isis_powder.abstract_inst.AbstractInst._get_run_details")
+    def test_output_focused_runs_summed_batch_mode(
+        self, mock_get_run_details, mock_get_mode, mock_output_ws, mock_keep_unit, mock_remove_ws
+    ):
+        mock_inst = self._setup_mock_inst(calibration_dir="ignored", output_dir="ignored", yaml_file_path="ISISPowderRunDetailsTest.yaml")
+        mock_get_mode.return_value = "Summed"
+        mock_run_details = create_autospec(run_details._RunDetails)
+        runs = ["123", "124"]
+        run_string = "-".join(runs)
+        mock_run_details.output_string = run_string
+        mock_run_details.output_run_string = run_string
+        mock_get_run_details.return_value = mock_run_details
+        # produce output that allows us to test that run_details.output_run_string provided is correct
+        mock_output_ws.side_effect = lambda focused_run, run_details: 2 * [run_details.output_run_string]
+
+        mock_inst._output_focused_runs(focused_runs=["INST123_foc", "INST124_foc"], run_number_string=run_string)
+
+        expected_calls = 2 * [call(d_spacing_group=run_string, tof_group=run_string, unit_to_keep=None)]
+        mock_keep_unit.assert_has_calls(expected_calls)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
**Description of work**

Now overwrite run_details.output_run_string in individual mode which as two affects: 

- Individual mode focussing produces a grouped workspace per run (as opposed to the summed mode) 
- Workspaces in the group now have only that run number in the name (previously workspaces were overwritten when the next one was added to the group as they are all given the same name including all runs).


**Report to:** Ron Smith, Paul Henry and Gabriel Perez (POLARIS)

**To test:**

(1) Follow instructions on original issue - it should now produce these workspaces

![image](https://github.com/mantidproject/mantid/assets/55979119/bb9104a9-cfa5-4320-8c49-fb8a13425c65)

(2) Check it produces the following output (on `.gsas` fil and` .nxs` per run)
![image](https://github.com/mantidproject/mantid/assets/55979119/8a961d4e-aafe-47fa-92fb-b7046036d446)

(3) Delete the `20_2` folder 

(4) Change to use `input_mode='Summed'` - it should now produce the following workspaces

![image](https://github.com/mantidproject/mantid/assets/55979119/dfea7f0b-1f30-4833-ae18-2f5cbe3ceeb2)

(5) Check it produces the following output

![image](https://github.com/mantidproject/mantid/assets/55979119/2ed25504-d4fc-499d-815c-36e5101de542)

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

Fixes #35926

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.