### PR TITLE
Fix bug where plot script generator button wouldn't show on certain tiled plots

### DIFF
--- a/docs/source/release/v6.8.0/Workbench/Bugfixes/33226.rst
+++ b/docs/source/release/v6.8.0/Workbench/Bugfixes/33226.rst
@@ -1,0 +1,1 @@
+- Fixed a bug which was causing the plot script generator button to not be shown on tiled plots with a non-square number of plots.

--- a/qt/applications/workbench/workbench/plotting/plotscriptgenerator/__init__.py
+++ b/qt/applications/workbench/workbench/plotting/plotscriptgenerator/__init__.py
@@ -73,7 +73,6 @@ def generate_script(fig, exclude_headers=False):
     """
     plot_commands = []
     plot_headers = ["import matplotlib.pyplot as plt", "from mantid.plots.utility import MantidAxType"]
-    blank_axes = []
 
     for ax in fig.get_axes():
         if not isinstance(ax, MantidAxes):
@@ -85,7 +84,8 @@ def generate_script(fig, exclude_headers=False):
             plot_headers.extend(colormap_headers)
         else:
             if not curve_in_ax(ax):
-                blank_axes.append(ax_object_var)
+                plot_commands.append(f"{ax_object_var}.axis('off')")
+                plot_commands.append("")
                 continue
             plot_commands.extend(get_plot_cmds(ax, ax_object_var))  # ax.plot
 
@@ -122,10 +122,6 @@ def generate_script(fig, exclude_headers=False):
     cmds.extend(generate_workspace_retrieval_commands(fig) + [""])
     cmds.append("{}, {} = {}".format(FIG_VARIABLE, AXES_VARIABLE, generate_subplots_command(fig)))
     cmds.extend(plot_commands)
-    if blank_axes:
-        for ax in blank_axes:
-            cmds.append(f"{ax}.axis('off')")
-        cmds.append("")
     cmds.append("plt.show()")
     cmds.append("# Scripting Plots in Mantid:")
     cmds.append("# https://docs.mantidproject.org/tutorials/python_in_mantid/plotting/02_scripting_plots.html")

--- a/qt/applications/workbench/workbench/plotting/plotscriptgenerator/__init__.py
+++ b/qt/applications/workbench/workbench/plotting/plotscriptgenerator/__init__.py
@@ -73,6 +73,7 @@ def generate_script(fig, exclude_headers=False):
     """
     plot_commands = []
     plot_headers = ["import matplotlib.pyplot as plt", "from mantid.plots.utility import MantidAxType"]
+    blank_axes = []
 
     for ax in fig.get_axes():
         if not isinstance(ax, MantidAxes):
@@ -84,6 +85,7 @@ def generate_script(fig, exclude_headers=False):
             plot_headers.extend(colormap_headers)
         else:
             if not curve_in_ax(ax):
+                blank_axes.append(ax_object_var)
                 continue
             plot_commands.extend(get_plot_cmds(ax, ax_object_var))  # ax.plot
 
@@ -120,6 +122,9 @@ def generate_script(fig, exclude_headers=False):
     cmds.extend(generate_workspace_retrieval_commands(fig) + [""])
     cmds.append("{}, {} = {}".format(FIG_VARIABLE, AXES_VARIABLE, generate_subplots_command(fig)))
     cmds.extend(plot_commands)
+    for ax in blank_axes:
+        cmds.append(f"{ax}.axis('off')")
+    cmds.append("")
     cmds.append("plt.show()")
     cmds.append("# Scripting Plots in Mantid:")
     cmds.append("# https://docs.mantidproject.org/tutorials/python_in_mantid/plotting/02_scripting_plots.html")

--- a/qt/applications/workbench/workbench/plotting/plotscriptgenerator/__init__.py
+++ b/qt/applications/workbench/workbench/plotting/plotscriptgenerator/__init__.py
@@ -122,9 +122,10 @@ def generate_script(fig, exclude_headers=False):
     cmds.extend(generate_workspace_retrieval_commands(fig) + [""])
     cmds.append("{}, {} = {}".format(FIG_VARIABLE, AXES_VARIABLE, generate_subplots_command(fig)))
     cmds.extend(plot_commands)
-    for ax in blank_axes:
-        cmds.append(f"{ax}.axis('off')")
-    cmds.append("")
+    if blank_axes:
+        for ax in blank_axes:
+            cmds.append(f"{ax}.axis('off')")
+        cmds.append("")
     cmds.append("plt.show()")
     cmds.append("# Scripting Plots in Mantid:")
     cmds.append("# https://docs.mantidproject.org/tutorials/python_in_mantid/plotting/02_scripting_plots.html")

--- a/qt/applications/workbench/workbench/plotting/test/test_toolbar.py
+++ b/qt/applications/workbench/workbench/plotting/test/test_toolbar.py
@@ -130,6 +130,19 @@ class ToolBarTest(unittest.TestCase):
         # Grid button should be OFF because not all subplots have grids.
         self.assertFalse(self._is_grid_button_checked(fig))
 
+    @patch("workbench.plotting.figuremanager.QAppThreadCall")
+    def test_plot_script_generator_is_enabled_for_non_square_tiled_plots(self, mock_qappthread):
+        mock_qappthread.return_value = mock_qappthread
+
+        fig, axes = plt.subplots(ncols=2, nrows=2, subplot_kw={"projection": "mantid"})
+        # Simulate a 2x2 grid showing three plots
+        axes[0][0].plot([-10, 10], [1, 2])
+        axes[0][1].plot([-10, 10], [1, 2])
+        axes[1][0].plot([-10, 10], [1, 2])
+        axes[1][1].axis("off")
+
+        self.assertTrue(self._is_button_enabled(fig, "generate_plot_script"))
+
     def test_is_colorbar(self):
         """Verify the functionality of _is_colorbar, which determines whether a set of axes is a colorbar."""
         ws = CreateSampleWorkspace()

--- a/qt/applications/workbench/workbench/plotting/toolbar.py
+++ b/qt/applications/workbench/workbench/plotting/toolbar.py
@@ -226,9 +226,9 @@ class WorkbenchNavigationToolbar(MantidNavigationToolbar):
                     # The artist is not tracked - ignore this one and check the rest
                     continue
 
-        # For plot-to-script button to show, every axis must be a MantidAxes with lines in it
         # Plot-to-script currently doesn't work with waterfall plots so the button is hidden for that plot type.
-        if not all((isinstance(ax, MantidAxes) and curve_in_ax(ax)) for ax in fig.get_axes()) or fig.get_axes()[0].is_waterfall():
+        # There must be at least one MantidAxis plot with data for to generate a script, others will be skipped
+        if not any((isinstance(ax, MantidAxes) and curve_in_ax(ax)) for ax in fig.get_axes()) or fig.get_axes()[0].is_waterfall():
             self.set_generate_plot_script_enabled(False)
 
         # reenable script generation for colormaps


### PR DESCRIPTION
**Description of work**

Previously, if you opened a tiled plot with a non-square number of plots, the plot script generator button would be hidden. This is because it was ensuring that every axis in the plot was a MantidAxis and also contained data. In the case of 3 plots on a 2x2 grid, the bottom right axis is blank with no data, so the button was disabled.

It turns out that the plot script generator handles this condition itself (see [here](https://github.com/mantidproject/mantid/blob/main/qt/applications/workbench/workbench/plotting/plotscriptgenerator/__init__.py#L78-L79) and [here](https://github.com/mantidproject/mantid/blob/main/qt/applications/workbench/workbench/plotting/plotscriptgenerator/__init__.py#L86-L87)), so I've changed the condition to ensure that one or more of the axes should have data.

I've also altered the plot script generator so that it hides these empty axes in the same way Mantid does.


**To test:**

- Load some data
- Plot spectra 1-3 in tiled mode
- [ ] Observe the plot script generator button is there
- Copy the script to clipboard and close the plot
- [ ] Run the copied script, and you should have a very similar looking plot with the lower right axis hidden

Fixes #33226 

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.