### PR TITLE
Fix picking up ROI Detector IDs from lookup table in preview reduction

### DIFF
--- a/docs/source/release/v6.8.0/Reflectometry/Bugfixes/35941.rst
+++ b/docs/source/release/v6.8.0/Reflectometry/Bugfixes/35941.rst
@@ -1,0 +1,1 @@
+- ROI Detector IDs that have been entered into the :ref:`Experiment Settings tab<refl_exp_instrument_settings>` lookup table should now be picked up when reducing a run on the :ref:`Preview tab <refl_preview>` with no region selected from the instrument view plot.

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchPresenter.cpp
@@ -15,6 +15,7 @@
 #include "IBatchView.h"
 #include "MantidQtWidgets/Common/HelpWindow.h"
 #include "MantidQtWidgets/Common/IMessageHandler.h"
+#include "Reduction/RowExceptions.h"
 #include <memory>
 
 namespace MantidQt::CustomInterfaces::ISISReflectometry {
@@ -371,5 +372,18 @@ void BatchPresenter::clearADSHandle() {
 void BatchPresenter::notifyPreviewApplyRequested() {
   auto const &previewRow = m_previewPresenter->getPreviewRow();
   m_experimentPresenter->notifyPreviewApplyRequested(previewRow);
+}
+
+bool BatchPresenter::hasROIDetectorIDsForPreviewRow() const {
+  auto const &previewRow = m_previewPresenter->getPreviewRow();
+  try {
+    auto const lookupRow = m_model->findLookupRow(previewRow);
+    if (!lookupRow || !lookupRow->roiDetectorIDs().has_value()) {
+      return false;
+    }
+  } catch (MultipleRowsFoundException const &) {
+    return false;
+  }
+  return true;
 }
 } // namespace MantidQt::CustomInterfaces::ISISReflectometry

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/BatchPresenter.h
@@ -95,6 +95,7 @@ public:
   int percentComplete() const override;
   std::unique_ptr<Mantid::API::IAlgorithmRuntimeProps> rowProcessingProperties() const override;
   void notifyPreviewApplyRequested() override;
+  bool hasROIDetectorIDsForPreviewRow() const override;
 
   // WorkspaceObserver overrides
   void postDeleteHandle(const std::string &wsName) override;

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/IBatchPresenter.h
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/IBatchPresenter.h
@@ -72,6 +72,8 @@ public:
   virtual void notifyChangesSaved() = 0;
   virtual Mantid::Geometry::Instrument_const_sptr instrument() const = 0;
   virtual std::string instrumentName() const = 0;
+
+  virtual bool hasROIDetectorIDsForPreviewRow() const = 0;
 };
 } // namespace ISISReflectometry
 } // namespace CustomInterfaces

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/RowProcessingAlgorithm.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Batch/RowProcessingAlgorithm.cpp
@@ -144,6 +144,7 @@ void updateLookupRowProperties(AlgorithmRuntimeProps &properties, LookupRow cons
   AlgorithmProperties::update("ProcessingInstructions", lookupRow.processingInstructions(), properties);
   AlgorithmProperties::update("BackgroundProcessingInstructions", lookupRow.backgroundProcessingInstructions(),
                               properties);
+  AlgorithmProperties::update("ROIDetectorIDs", lookupRow.roiDetectorIDs(), properties);
 }
 
 void updateWavelengthRangeProperties(AlgorithmRuntimeProps &properties,
@@ -395,7 +396,6 @@ std::unique_ptr<Mantid::API::IAlgorithmRuntimeProps> createAlgorithmRuntimeProps
   auto lookupRow = row ? findLookupRow(*row, model) : findWildcardLookupRow(model);
   if (lookupRow) {
     updateLookupRowProperties(*properties, *lookupRow);
-    AlgorithmProperties::update("ROIDetectorIDs", lookupRow->roiDetectorIDs(), *properties);
   }
   // Update properties the user has specifically set for this run
   if (row) {

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.cpp
@@ -185,13 +185,18 @@ void PreviewPresenter::notifyInstViewShapeChanged() {
   // Change to shape editing after a selection has been done to match instrument viewer default behaviour
   notifyInstViewEditRequested();
   // Get the masked workspace indices
+  boost::optional<ProcessingInstructions> detIDs = boost::none;
   auto indices = m_instViewModel->detIndicesToDetIDs(m_dockedWidgets->getSelectedDetectors());
-  auto detIDsStr = Mantid::Kernel::Strings::joinCompress(indices.cbegin(), indices.cend(), ",");
+  if (indices.size() > 0) {
+    auto detIDsStr = Mantid::Kernel::Strings::joinCompress(indices.cbegin(), indices.cend(), ",");
+    detIDs = ProcessingInstructions{detIDsStr};
+  }
 
-  if (detIDsStr == m_model->getSelectedBanks()) {
+  if (detIDs == m_model->getSelectedBanks()) {
     return;
   }
-  m_model->setSelectedBanks(ProcessingInstructions{detIDsStr});
+
+  m_model->setSelectedBanks(detIDs);
   // Execute summing the selected banks
   runSumBanks();
 }
@@ -278,7 +283,7 @@ void PreviewPresenter::plotLinePlot() {
 }
 
 void PreviewPresenter::runSumBanks() {
-  if (m_model->getSelectedBanks().get_value_or("").empty()) {
+  if (!m_model->getSelectedBanks().has_value() && !m_mainPresenter->hasROIDetectorIDsForPreviewRow()) {
     // Do not sum the workspace if no detector IDs have been selected
     m_model->setSummedWs(m_model->getLoadedWs());
     notifySumBanksCompleted();

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.cpp
@@ -286,6 +286,11 @@ void PreviewPresenter::plotLinePlot() {
 }
 
 void PreviewPresenter::runSumBanks() {
+  if (!m_model->getLoadedWs()) {
+    g_log.error("Unable to perform sum banks step because there is no run loaded");
+    return;
+  }
+
   // Ensure the angle is up to date so that we can check for matching experiment settings lookup rows
   m_model->setTheta(m_view->getAngle());
 

--- a/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.cpp
+++ b/qt/scientific_interfaces/ISISReflectometry/GUI/Preview/PreviewPresenter.cpp
@@ -132,7 +132,10 @@ void PreviewPresenter::notifyLoadWorkspaceCompleted() {
   runSumBanks();
 }
 
-void PreviewPresenter::notifyUpdateAngle() { runReduction(); }
+void PreviewPresenter::notifyUpdateAngle() {
+  // Re-run from the sum banks step to ensure the sliceviewer plot is up to date
+  runSumBanks();
+}
 
 void PreviewPresenter::notifySumBanksCompleted() {
   plotRegionSelector();
@@ -283,6 +286,9 @@ void PreviewPresenter::plotLinePlot() {
 }
 
 void PreviewPresenter::runSumBanks() {
+  // Ensure the angle is up to date so that we can check for matching experiment settings lookup rows
+  m_model->setTheta(m_view->getAngle());
+
   if (!m_model->getSelectedBanks().has_value() && !m_mainPresenter->hasROIDetectorIDsForPreviewRow()) {
     // Do not sum the workspace if no detector IDs have been selected
     m_model->setSummedWs(m_model->getLoadedWs());

--- a/qt/scientific_interfaces/ISISReflectometry/test/Batch/RowProcessingAlgorithmTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Batch/RowProcessingAlgorithmTest.h
@@ -61,7 +61,7 @@ public:
   void testExperimentSettingsWithPreviewRow() {
     auto model = Batch(m_experiment, m_instrument, m_runsTable, m_slicing);
     auto theta = 0.7;
-    auto previewRow = makePreviewRow(theta, "2-3", "4-5", "6-7");
+    auto previewRow = makePreviewRow(theta, "2-3", "4-5", "6-7", ProcessingInstructions{"10-50"});
     auto result = Reduction::createAlgorithmRuntimeProps(model, previewRow);
 
     // Check results from the experiment settings tab
@@ -70,6 +70,7 @@ public:
     TS_ASSERT_EQUALS(result->getPropertyValue("ProcessingInstructions"), "2-3");
     TS_ASSERT_EQUALS(result->getPropertyValue("BackgroundProcessingInstructions"), "4-5");
     TS_ASSERT_EQUALS(result->getPropertyValue("TransmissionProcessingInstructions"), "6-7");
+    TS_ASSERT_EQUALS(result->getPropertyValue("ROIDetectorIDs"), "10-50");
     assertProperty(*result, "ThetaIn", theta);
   }
 
@@ -321,7 +322,8 @@ private:
 
   PreviewRow makePreviewRow(double theta = 0.1, const std::string &processingInstructions = "10-11",
                             const std::string &backgroundProcessingInstructions = "",
-                            const std::string &transmissionProcessingInstructions = "") {
+                            const std::string &transmissionProcessingInstructions = "",
+                            const boost::optional<ProcessingInstructions> &roiDetectorIDs = boost::none) {
     auto previewRow = PreviewRow({"12345"});
     previewRow.setTheta(theta);
     previewRow.setProcessingInstructions(ROIType::Signal, processingInstructions);
@@ -329,6 +331,8 @@ private:
       previewRow.setProcessingInstructions(ROIType::Background, backgroundProcessingInstructions);
     if (!transmissionProcessingInstructions.empty())
       previewRow.setProcessingInstructions(ROIType::Transmission, transmissionProcessingInstructions);
+    if (roiDetectorIDs)
+      previewRow.setSelectedBanks(roiDetectorIDs);
     return previewRow;
   }
 
@@ -385,6 +389,7 @@ private:
     assertProperty(result, "ScaleFactor", 0.7);
     TS_ASSERT_EQUALS(result.getPropertyValue("ProcessingInstructions"), "1");
     TS_ASSERT_EQUALS(result.getPropertyValue("BackgroundProcessingInstructions"), "3,7");
+    TS_ASSERT_EQUALS(result.getPropertyValue("ROIDetectorIDs"), "3-22");
   }
 
   void checkMatchesWildcardRowExcludingProcessingInstructions(IAlgorithmRuntimeProps const &result) {
@@ -396,6 +401,7 @@ private:
     assertProperty(result, "MomentumTransferMax", 1.1);
     assertProperty(result, "ScaleFactor", 0.7);
     TS_ASSERT_EQUALS(result.getPropertyValue("BackgroundProcessingInstructions"), "3,7");
+    TS_ASSERT_EQUALS(result.getPropertyValue("ROIDetectorIDs"), "3-22");
   }
 
   void checkMatchesInstrument(IAlgorithmRuntimeProps const &result, bool isPreview = false) {

--- a/qt/scientific_interfaces/ISISReflectometry/test/Preview/PreviewPresenterTest.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/Preview/PreviewPresenterTest.h
@@ -187,7 +187,7 @@ public:
     auto mockJobManager = makeJobManager();
     auto mainPresenter = MockBatchPresenter();
 
-    expectLoadWorkspaceCompletedDoesNotSumBanks(*mockModel, *mockJobManager, mainPresenter, *mockView);
+    expectLoadWorkspaceCompletedDoesNotSumBanks(*mockModel, *mockJobManager, mainPresenter);
 
     auto deps = packDeps(mockView.get(), std::move(mockModel), std::move(mockJobManager));
     auto presenter = PreviewPresenter(std::move(deps));
@@ -812,7 +812,7 @@ private:
   }
 
   void expectLoadWorkspaceCompletedDoesNotSumBanks(MockPreviewModel &mockModel, MockJobManager &mockJobManager,
-                                                   MockBatchPresenter &mockMainPresenter, MockPreviewView &mockView) {
+                                                   MockBatchPresenter &mockMainPresenter) {
     auto ws = createRectangularDetectorWorkspace();
 
     EXPECT_CALL(mockModel, getLoadedWs()).Times(4).WillRepeatedly(Return(ws));

--- a/qt/scientific_interfaces/ISISReflectometry/test/ReflMockObjects.h
+++ b/qt/scientific_interfaces/ISISReflectometry/test/ReflMockObjects.h
@@ -105,6 +105,7 @@ public:
   MOCK_METHOD0(setBatchUnsaved, void());
   MOCK_METHOD0(notifyChangesSaved, void());
   MOCK_METHOD0(notifyPreviewApplyRequested, void());
+  MOCK_CONST_METHOD0(hasROIDetectorIDsForPreviewRow, bool());
 };
 
 class MockRunsPresenter : public IRunsPresenter {


### PR DESCRIPTION
**Description of work**

**Purpose of work**
<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
-->
This PR ensure that ROI Detector IDs that have been entered into the lookup table on the ISIS Reflectometry interface Experiment Settings tab are correctly applied to both the preview reduction and sum banks steps when nothing has been selected on the instrument view plot.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**Summary of work**
<!-- Please provide a short, high level description of the work that was done.
-->
This PR makes changes in `RowProcessingAlgorithm.cpp` to ensure that the ROI detector IDs from the lookup table are applied both in a normal batch reduction and a preview reduction. I have made a change in the `PreviewPresenter` so that when we delete a selected detector region from the instrument view plot on the preview tab we correctly clear the selected banks in the `PreviewModel`. This prevents us failing to use lookup table values after deleting the region selection.

On the preview tab, it should also be the case that the slice viewer plot will only display the banks as summed if there is a detector ROI available (either from the instrument view selection or the experiment settings lookup table). In the `PreviewPresenter`, changes have been made to ensure that we check the lookup table as well as the instrument viewer selection when checking whether to sum the input workspace for the slice viewer plot.


**To test:**

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->
Run through the instructions on the linked issue and test that the reduction now completes successfully and that the slice viewer plot on the preview tab shows summed data (there is one region of data rather than four). To see this clearly choose "SymmetricLog10" from the dropdown underneath the colour bar.

This is the basic functionality, but also check that when a region is selected from the instrument view plot the reduction uses that instead. Check that if all regions are deleted from the instrument view then any information entered into the experiment settings lookup table is used (note that the lookup row will only be picked up if it has no angle information or if the angle for the row matches what is on the preview tab).

Fixes #35911. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.