### PR TITLE
Reset row state when experiment settings are changed via the Preview tab

### DIFF
--- a/docs/source/release/v6.8.0/Reflectometry/Bugfixes/35942.rst
+++ b/docs/source/release/v6.8.0/Reflectometry/Bugfixes/35942.rst
@@ -1,0 +1,1 @@
+- The row state on the :ref:`Runs tab <refl_runs>` is now reset when settings are updated in the :ref:`Experiment tab<refl_exp_instrument_settings>` lookup table by using the Apply button on the :ref:`Preview tab <refl_preview>`.


### PR DESCRIPTION
**Description of work**

**Purpose of work**
<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
-->
This fix ensures that processed runs display the correct state when settings have been changed in the Experiment Settings lookup table via the Apply button on the Preview tab. For further details, see the linked issue.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**Summary of work**
<!-- Please provide a short, high level description of the work that was done.
-->
When the Apply button on the Preview tab is clicked, I've added a check to make sure that there are changes that need to be applied to the row. If there are then, after these are applied, I've added a call to notify the batch that experiment settings have changed. This triggers the workflow to reset the row state.

**To test:**

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->
See instructions in linked issue, although I would recommend testing with run number `11934` and angle `1.0` to avoid potentially confusing error messages. These error message are the result of recent changes that now require other settings to be present for run `45455` to reduce correctly.

Fixes #35565. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.