### PR TITLE
Better output when building `docs-qthelp` and fix warnings

### DIFF
--- a/conda/recipes/mantiddocs/build.sh
+++ b/conda/recipes/mantiddocs/build.sh
@@ -37,7 +37,7 @@ cmake --build . --target StandardTestData
 export STANDARD_TEST_DATA_DIR=$SRC_DIR/build/ExternalData/Testing/Data
 echo 'datasearch.directories = '$STANDARD_TEST_DATA_DIR'/UnitTest/;'$STANDARD_TEST_DATA_DIR'/DocTest/' >> $PREFIX/bin/Mantid.properties
 
-# Set QT_APA_PLATFORM=offscreen so we do not need to run with xvfb. Xvfb hides a lot of debug output
+# Set QT_QPA_PLATFORM=offscreen so we do not need to run with xvfb. Xvfb hides a lot of debug output
 export QT_QPA_PLATFORM=offscreen
 cmake --build . --target docs-qthelp
 

--- a/conda/recipes/mantiddocs/build.sh
+++ b/conda/recipes/mantiddocs/build.sh
@@ -1,34 +1,6 @@
 #!/usr/bin/env bash
 set -ex
 
-# QtHelp docs build needs to start a QApplication so we need an X server on Linux
-XVFB_SERVER_NUM=101
-
-function run_with_xvfb {
-    if [[ $OSTYPE == "linux"* ]]; then
-        # Use -e because a bug on RHEL7 means --error-file produces an error:
-	#   https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=337703;msg=2
-        # Use -noreset because of an X Display bug caused by a race condition in xvfb:
-	#  https://gitlab.freedesktop.org/xorg/xserver/-/issues/1102
-        xvfb-run -e /dev/stderr --server-args="-core -noreset -screen 0 640x480x24" \
-        --server-num=${XVFB_SERVER_NUM} $@
-    else
-        eval $@
-    fi
-}
-
-function terminate_xvfb_sessions {
-    if [[ $OSTYPE == "linux"* ]]; then
-        echo "Terminating any existing Xvfb sessions"
-
-        # Kill Xvfb processes
-        killall Xvfb || true
-
-        # Remove Xvfb X server lock files
-        rm -f /tmp/.X${XVFB_SERVER_NUM}-lock || true
-    fi
-}
-
 parent_dir="$(dirname "$RECIPE_DIR")"
 bash "${parent_dir}"/archive_env_logs.sh "$BUILD_PREFIX" "$PREFIX" 'mantiddocs'
 
@@ -65,6 +37,8 @@ cmake --build . --target StandardTestData
 export STANDARD_TEST_DATA_DIR=$SRC_DIR/build/ExternalData/Testing/Data
 echo 'datasearch.directories = '$STANDARD_TEST_DATA_DIR'/UnitTest/;'$STANDARD_TEST_DATA_DIR'/DocTest/' >> $PREFIX/bin/Mantid.properties
 
-run_with_xvfb cmake --build . --target docs-qthelp
-terminate_xvfb_sessions
+# Set QT_APA_PLATFORM=offscreen so we do not need to run with xvfb. Xvfb hides a lot of debug output
+export QT_QPA_PLATFORM=offscreen
+cmake --build . --target docs-qthelp
+
 cmake --build . --target install

--- a/docs/source/algorithms/CalculateDIFC-v1.rst
+++ b/docs/source/algorithms/CalculateDIFC-v1.rst
@@ -18,7 +18,7 @@ an instrument.
 Or if OffsetMode is `Signed` :math:`DIFC` will be calculated with the following equation
 for logarithmically binned data:
 
-.. math:: DIFC = \frac{m_n}{h}&(L1 + L2)&2sin\theta & * & (1+|BinWidth|)^{-offset}
+.. math:: DIFC = \frac{m_n}{h} \cdot (L1 + L2) 2 \sin(\theta) \cdot (1+|BinWidth|)^{-offset}
 
 DIFC is used in the equation
 

--- a/docs/source/algorithms/ConvertDiffCal-v1.rst
+++ b/docs/source/algorithms/ConvertDiffCal-v1.rst
@@ -35,11 +35,11 @@ the following equations:
 
 Update existing calibration:
 
-.. math:: DIFC = DIFC_{old} & * & (1+|BinWidth|)^{-offset}
+.. math:: DIFC = DIFC_{old} \cdot (1+|BinWidth|)^{-offset}
 
 Calculate :math:`DIFC` from geometry of the experiment:
 
-.. math:: DIFC = \frac{m_n}{h}&(L1 + L2)&2sin\theta & * & (1+|BinWidth|)^{-offset}
+.. math:: DIFC = \frac{m_n}{h} \cdot (L1 + L2) 2 \sin(\theta) \cdot (1+|BinWidth|)^{-offset}
 
 The calculations for signed mode is appropriate for full-pattern cross-correlation with logarithmically binned data
 


### PR DESCRIPTION
**Description of work**
This PR does two things:

- Improves the output we get if building the `docs-qthelp` target fails in the packaging step. Previously we were wrapping the call in xvfb-run , but xvfb would swallow any of the useful debug information. Instead, we can just set `QT_QPA_PLATFORM=offscreen` and this will mean we receive all the info we need for debugging.
- It fixes a few sphinx warnings which have crept into main

**To test:**
Make sure this build package from branch passes:
https://builds.mantidproject.org/job/build_packages_from_branch/495/

*There is no associated issue.*

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.