### PR TITLE
Remove incorrect steps after polarization correction in ReflectometryReductionOneAuto

### DIFF
--- a/Framework/Reflectometry/src/ReflectometryReductionOneAuto3.cpp
+++ b/Framework/Reflectometry/src/ReflectometryReductionOneAuto3.cpp
@@ -828,6 +828,10 @@ Algorithm_sptr ReflectometryReductionOneAuto3::createAlgorithmForGroupMember(std
         std::dynamic_pointer_cast<MatrixWorkspace>(AnalysisDataService::Instance().retrieve(outputNames.iVsLam));
     auto newProcInst = convertToSpectrumNumber("0", currentWorkspace);
     alg->setProperty("ProcessingInstructions", newProcInst);
+    // We only want to recalculate IvsQ, so we should not perform the sum banks or background subtraction steps
+    alg->setProperty("SubtractBackground", false);
+    alg->setProperty("BackgroundProcessingInstructions", "");
+    alg->setProperty("ROIDetectorIDs", "");
   }
 
   return alg;

--- a/Framework/Reflectometry/test/ReflectometryReductionOneAuto3Test.h
+++ b/Framework/Reflectometry/test/ReflectometryReductionOneAuto3Test.h
@@ -823,6 +823,37 @@ public:
     ADS.clear();
   }
 
+  void test_polarization_correction_with_background_subtraction() {
+
+    std::string const name = "input";
+    prepareInputGroup(name, "Fredrikze");
+    applyPolarizationEfficiencies(name);
+
+    ReflectometryReductionOneAuto3 alg;
+    alg.initialize();
+    alg.setPropertyValue("InputWorkspace", name);
+    alg.setProperty("ThetaIn", 10.0);
+    alg.setProperty("WavelengthMin", 1.0);
+    alg.setProperty("WavelengthMax", 15.0);
+    alg.setProperty("ProcessingInstructions", "2");
+    alg.setProperty("MomentumTransferStep", 0.04);
+    alg.setProperty("PolarizationAnalysis", true);
+    alg.setProperty("SubtractBackground", true);
+    alg.setProperty("BackgroundProcessingInstructions", "3-4");
+    alg.setPropertyValue("OutputWorkspace", "IvsQ");
+    alg.setPropertyValue("OutputWorkspaceBinned", "IvsQ_binned");
+    alg.setPropertyValue("OutputWorkspaceWavelength", "IvsLam");
+    alg.execute();
+
+    auto outQGroup = retrieveOutWS("IvsQ");
+    auto outLamGroup = retrieveOutWS("IvsLam");
+
+    TS_ASSERT_EQUALS(outQGroup.size(), 4);
+    TS_ASSERT_EQUALS(outLamGroup.size(), 4);
+
+    ADS.clear();
+  }
+
   void test_input_workspace_group_with_default_output_workspaces() {
     ReflectometryReductionOneAuto3 alg;
     setup_alg_on_input_workspace_group_with_run_number(alg);

--- a/docs/source/release/v6.8.0/Reflectometry/Bugfixes/35945.rst
+++ b/docs/source/release/v6.8.0/Reflectometry/Bugfixes/35945.rst
@@ -1,0 +1,1 @@
+- :ref:`algm-ReflectometryReductionOneAuto` no longer throws an error when attempting to run a reduction that applies both a background subtraction and a polarization correction.


### PR DESCRIPTION
**Description of work**

**Purpose of work**
<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
-->
To make it possible to perform a reduction using `ReflectometryReductionOneAuto` that applies both a background subtraction and polarization correction. This PR also prevents the sum banks step happening after polarization correction, although note that this currently isn't an issue in practice on POLREF as they don't perform the sum banks step for their detector type.

**Report to:** Becky at ISIS


**Summary of work**
<!-- Please provide a short, high level description of the work that was done.
-->
This PR is intended as a quick fix to get this working, but a longer term refactor is planned to address issues with the existing implementation of this part of the code (see #35922). For now, we skip the steps that should not happen after the polarization correction by setting their properties on the second run of the algorithm to values that prevent them being applied.

I have added a test that would fail if the background subtraction issue were to be re-introduced. If we were planning to stick with this implementation long-term then more comprehensive test coverage would be good, however because we plan to refactor (and this would make some tests we might write now obsolete) we can implement appropriate test coverage at that point.

**To test:**

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->
See instructions on linked issue.

Fixes #35855. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.