### PR TITLE
Populate OutputWorkspace with LHSWorkspace value if available

### DIFF
--- a/docs/source/release/v6.8.0/Workbench/New_features/34787.rst
+++ b/docs/source/release/v6.8.0/Workbench/New_features/34787.rst
@@ -1,0 +1,1 @@
+- In an algorithm's Algorithm Dialogue, if an input workspace is named ``LHSWorkspace``, this workspace name will be used when auto-filling the ``OutputWorkspace`` property.

--- a/qt/widgets/common/src/AlgorithmPropertiesWidget.cpp
+++ b/qt/widgets/common/src/AlgorithmPropertiesWidget.cpp
@@ -279,6 +279,12 @@ bool isCalledInputWorkspace(PropertyWidget *const candidate) {
   return propertyName == "InputWorkspace";
 }
 
+bool isCalledLHSWorkspace(PropertyWidget *const candidate) {
+  Mantid::Kernel::Property const *const property = candidate->getProperty();
+  const std::string &propertyName = property->name();
+  return propertyName == "LHSWorkspace";
+}
+
 //-------------------------------------------------------------------------------------------------
 /** A slot to handle the replace workspace button click
  *
@@ -312,10 +318,11 @@ void AlgorithmPropertiesWidget::replaceWSClicked(const QString &propName) {
       // Choose from candidates, only do this if there are candidates to select
       // from.
       if (candidateReplacementSources.size() > 0) {
-        CollectionOfPropertyWidget::iterator selectedIt = std::find_if(
-            candidateReplacementSources.begin(), candidateReplacementSources.end(), isCalledInputWorkspace);
+        CollectionOfPropertyWidget::iterator selectedIt =
+            std::find_if(candidateReplacementSources.begin(), candidateReplacementSources.end(),
+                         [](const auto &prop) { return isCalledInputWorkspace(prop) || isCalledLHSWorkspace(prop); });
         if (selectedIt != candidateReplacementSources.end()) {
-          // Use the InputWorkspace property called "InputWorkspace" as the
+          // Use the InputWorkspace property called "InputWorkspace" or "LHSWorkspace" as the
           // source for the OutputWorkspace.
           propWidget->setValue((*selectedIt)->getValue());
         } else {

--- a/qt/widgets/common/src/AlgorithmPropertiesWidget.cpp
+++ b/qt/widgets/common/src/AlgorithmPropertiesWidget.cpp
@@ -273,16 +273,10 @@ void AlgorithmPropertiesWidget::propertyChanged(const QString &changedPropName) 
   this->hideOrDisableProperties(changedPropName);
 }
 
-bool isCalledInputWorkspace(PropertyWidget *const candidate) {
+bool isCalledInputWorkspaceOrLHSWorkspace(PropertyWidget *const candidate) {
   Mantid::Kernel::Property const *const property = candidate->getProperty();
   const std::string &propertyName = property->name();
-  return propertyName == "InputWorkspace";
-}
-
-bool isCalledLHSWorkspace(PropertyWidget *const candidate) {
-  Mantid::Kernel::Property const *const property = candidate->getProperty();
-  const std::string &propertyName = property->name();
-  return propertyName == "LHSWorkspace";
+  return propertyName == "InputWorkspace" || propertyName == "LHSWorkspace";
 }
 
 //-------------------------------------------------------------------------------------------------
@@ -318,9 +312,8 @@ void AlgorithmPropertiesWidget::replaceWSClicked(const QString &propName) {
       // Choose from candidates, only do this if there are candidates to select
       // from.
       if (candidateReplacementSources.size() > 0) {
-        CollectionOfPropertyWidget::iterator selectedIt =
-            std::find_if(candidateReplacementSources.begin(), candidateReplacementSources.end(),
-                         [](const auto &prop) { return isCalledInputWorkspace(prop) || isCalledLHSWorkspace(prop); });
+        const auto selectedIt = std::find_if(candidateReplacementSources.cbegin(), candidateReplacementSources.cend(),
+                                             isCalledInputWorkspaceOrLHSWorkspace);
         if (selectedIt != candidateReplacementSources.end()) {
           // Use the InputWorkspace property called "InputWorkspace" or "LHSWorkspace" as the
           // source for the OutputWorkspace.


### PR DESCRIPTION
**Description of work**

In certain algorithm dialogues (such as `Subtract`) the properties are `LHSWorkspace` and `RHSWorkspace`. When clicking the button to populate the `OutputWorkspace` property field, `LHSWorkspace` should be chosen always so the syntax is the same as `a = a - b`.
This is already done for algorithms with the property `InputWorkspace`.

**Summary of work**
Added a second check to choose any property called `LHSWorkspace`.

**To test:**

- Load or create two workspaces
- Open the `Subtract` algorithm dialogue (you could also try `Plus`, `Divide` etc)
- Set LHS and RHS workspace inputs to be different values, every time you click the button to populate the `OutputWorkspace` filed, it should be the LHS value

Fixes #34787 

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.