### PR TITLE
Fix crash in instrument view when erasing peak

### DIFF
--- a/docs/source/release/v6.8.0/Workbench/InstrumentViewer/Bugfixes/35907.rst
+++ b/docs/source/release/v6.8.0/Workbench/InstrumentViewer/Bugfixes/35907.rst
@@ -1,0 +1,1 @@
+- Fix bug in instrument viewer that caused a crash if you tried to delete a peak after having selected that peak and dragged the peak workspace onto the viewer.

--- a/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/ProjectionSurface.h
+++ b/qt/widgets/instrumentview/inc/MantidQtWidgets/InstrumentView/ProjectionSurface.h
@@ -254,6 +254,7 @@ public:
   void clearAlignmentPlane();
   void clearComparisonPeaks();
   bool hasPeakOverlays() const { return !m_peakShapes.isEmpty(); }
+  int getPeakOverlayCount() const { return m_peakShapes.count(); }
   void setPeakLabelPrecision(int n);
   int getPeakLabelPrecision() const { return m_peakLabelPrecision; }
   void setShowPeakRowsFlag(bool on);

--- a/qt/widgets/instrumentview/src/UnwrappedSurface.cpp
+++ b/qt/widgets/instrumentview/src/UnwrappedSurface.cpp
@@ -444,8 +444,8 @@ void UnwrappedSurface::setPeaksWorkspace(const std::shared_ptr<Mantid::API::IPea
   po->setShowLabelsFlag(m_showPeakLabels);
   po->setShowRelativeIntensityFlag(m_showPeakRelativeIntensity);
 
-  if (!std::any_of(m_peakShapes.begin(), m_peakShapes.end(),
-                   [pws](auto pkShape) { return pkShape->getPeaksWorkspace() == pws; }))
+  if (!std::any_of(m_peakShapes.cbegin(), m_peakShapes.cend(),
+                   [&pws](auto const &pkShape) { return pkShape->getPeaksWorkspace() == pws; }))
     m_peakShapes.append(po);
 
   m_startPeakShapes = true;

--- a/qt/widgets/instrumentview/src/UnwrappedSurface.cpp
+++ b/qt/widgets/instrumentview/src/UnwrappedSurface.cpp
@@ -444,15 +444,8 @@ void UnwrappedSurface::setPeaksWorkspace(const std::shared_ptr<Mantid::API::IPea
   po->setShowLabelsFlag(m_showPeakLabels);
   po->setShowRelativeIntensityFlag(m_showPeakRelativeIntensity);
 
-  bool containsPeak = false;
-  for (auto pkShape : m_peakShapes) {
-    if (pkShape->getPeaksWorkspace() == pws) {
-      containsPeak = true;
-      break;
-    }
-  }
-
-  if (!containsPeak)
+  if (!std::any_of(m_peakShapes.begin(), m_peakShapes.end(),
+                   [pws](auto pkShape) { return pkShape->getPeaksWorkspace() == pws; }))
     m_peakShapes.append(po);
 
   m_startPeakShapes = true;

--- a/qt/widgets/instrumentview/src/UnwrappedSurface.cpp
+++ b/qt/widgets/instrumentview/src/UnwrappedSurface.cpp
@@ -443,7 +443,18 @@ void UnwrappedSurface::setPeaksWorkspace(const std::shared_ptr<Mantid::API::IPea
   po->setShowRowsFlag(m_showPeakRows);
   po->setShowLabelsFlag(m_showPeakLabels);
   po->setShowRelativeIntensityFlag(m_showPeakRelativeIntensity);
-  m_peakShapes.append(po);
+
+  bool containsPeak = false;
+  for (auto pkShape : m_peakShapes) {
+    if (pkShape->getPeaksWorkspace() == pws) {
+      containsPeak = true;
+      break;
+    }
+  }
+
+  if (!containsPeak)
+    m_peakShapes.append(po);
+
   m_startPeakShapes = true;
   connect(po, SIGNAL(executeAlgorithm(Mantid::API::IAlgorithm_sptr)), this,
           SIGNAL(executeAlgorithm(Mantid::API::IAlgorithm_sptr)));

--- a/qt/widgets/instrumentview/test/InstrumentWidgetDecoderTest.h
+++ b/qt/widgets/instrumentview/test/InstrumentWidgetDecoderTest.h
@@ -60,7 +60,7 @@ public:
   void test_adding_duplicate_peak_workspace_to_instrument_view() {
     auto pw = std::make_shared<PeaksWorkspace>();
     std::shared_ptr<PeaksWorkspace> pw2 = std::move(pw->clone());
-    m_instrumentWidget->setSurfaceType(3);
+    m_instrumentWidget->setSurfaceType(InstrumentWidget::SurfaceType::CYLINDRICAL_Z);
     auto unwrappedSurface = std::dynamic_pointer_cast<UnwrappedSurface>(m_instrumentWidget->getSurface());
 
     // Start with no peaks

--- a/qt/widgets/instrumentview/test/InstrumentWidgetDecoderTest.h
+++ b/qt/widgets/instrumentview/test/InstrumentWidgetDecoderTest.h
@@ -8,9 +8,11 @@
 
 #include "MantidAPI/AlgorithmManager.h"
 #include "MantidAPI/FrameworkManager.h"
+#include "MantidDataObjects/PeaksWorkspace.h"
 #include "MantidQtWidgets/InstrumentView/InstrumentWidget.h"
 #include "MantidQtWidgets/InstrumentView/InstrumentWidgetDecoder.h"
 #include "MantidQtWidgets/InstrumentView/InstrumentWidgetEncoder.h"
+#include "MantidQtWidgets/InstrumentView/UnwrappedSphere.h"
 
 #include <cxxtest/TestSuite.h>
 
@@ -19,6 +21,7 @@
 #include "MantidPythonInterface/core/VersionCompat.h"
 #include <QApplication>
 
+using namespace Mantid::DataObjects;
 using namespace MantidQt::MantidWidgets;
 using namespace Mantid::API;
 
@@ -52,6 +55,32 @@ public:
     TS_ASSERT_THROWS_NOTHING(m_decoder->decode(m_infoMap, *m_instrumentWidget, QString(""), false));
     // Set to 2
     TS_ASSERT_EQUALS(m_instrumentWidget->getCurrentTab(), 2)
+  }
+
+  void test_adding_duplicate_peak_workspace_to_instrument_view() {
+    auto pw = std::make_shared<PeaksWorkspace>();
+    std::shared_ptr<PeaksWorkspace> pw2 = std::move(pw->clone());
+    m_instrumentWidget->setSurfaceType(3);
+    auto unwrappedSurface = std::dynamic_pointer_cast<UnwrappedSurface>(m_instrumentWidget->getSurface());
+
+    // Start with no peaks
+    TS_ASSERT_EQUALS(unwrappedSurface->getPeakOverlayCount(), 0)
+
+    // Add a peak
+    unwrappedSurface->setPeaksWorkspace(pw);
+    TS_ASSERT_EQUALS(unwrappedSurface->getPeakOverlayCount(), 1)
+
+    // Add the same peak worspace again, shouldn't increase the number of overlays
+    unwrappedSurface->setPeaksWorkspace(pw);
+    TS_ASSERT_EQUALS(unwrappedSurface->getPeakOverlayCount(), 1)
+
+    // Add a different peak workspace
+    unwrappedSurface->setPeaksWorkspace(pw2);
+    TS_ASSERT_EQUALS(unwrappedSurface->getPeakOverlayCount(), 2)
+
+    // Clear all peak workspaces
+    unwrappedSurface->clearPeakOverlays();
+    TS_ASSERT_EQUALS(unwrappedSurface->getPeakOverlayCount(), 0)
   }
 
 private:

--- a/qt/widgets/instrumentview/test/InstrumentWidgetDecoderTest.h
+++ b/qt/widgets/instrumentview/test/InstrumentWidgetDecoderTest.h
@@ -59,7 +59,7 @@ public:
 
   void test_adding_duplicate_peak_workspace_to_instrument_view() {
     auto pw = std::make_shared<PeaksWorkspace>();
-    std::shared_ptr<PeaksWorkspace> pw2 = std::move(pw->clone());
+    std::shared_ptr<PeaksWorkspace> pw2 = pw->clone();
     m_instrumentWidget->setSurfaceType(InstrumentWidget::SurfaceType::CYLINDRICAL_Z);
     auto unwrappedSurface = std::dynamic_pointer_cast<UnwrappedSurface>(m_instrumentWidget->getSurface());
 


### PR DESCRIPTION
**Description of work**
Added check to prevent two PeakOverlay objects referring to the same IPeaksWorkspace. This causes a problem when dragging a peak workspace onto the instrument view with the same peak already selected, because if you then go to erase the peak there will be a second attempt to delete the same peak.

**Purpose of work**
<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
-->
Fixes #35907 

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**Summary of work**
<!-- Please provide a short, high level description of the work that was done.
-->
Added check to guard against a duplicate PeakOverlay wrapper around the same IPeaksWorkspace inside UnwrappedSurface.cpp. Also added a test to check for this behaviour.

**To test:**
- See #35907 for how to reproduce original bug.
- Maybe worth trying some more selecting/deleting of peaks
- Could try dragging a peaks workspace onto the instrument view, adding a peak to the workspace separately, then erasing.

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.