### PR TITLE
Update path to include md5 on M1 macs during mambaforge install

### DIFF
--- a/buildconfig/Jenkins/Conda/download-and-install-mambaforge
+++ b/buildconfig/Jenkins/Conda/download-and-install-mambaforge
@@ -24,6 +24,10 @@ elif [[ $OSTYPE == 'darwin'* ]]; then
     if [[ $(uname -p) == 'arm' ]]; then
       MAMBAFORGE_SCRIPT_NAME=Mambaforge-$MAMBAFORGE_VERSION-MacOSX-arm64.sh
       EXPECTED_INSTALLER_SHA=$MACARM_SHA256
+      # add sbin to path to provide access to md5 for mambaforge install script
+      if [ $(echo $PATH | grep -c "/sbin:") -eq 0 ]; then
+        export PATH=/sbin:$PATH
+      fi
     else
       MAMBAFORGE_SCRIPT_NAME=Mambaforge-$MAMBAFORGE_VERSION-MacOSX-x86_64.sh
       EXPECTED_INSTALLER_SHA=$MACX86_SHA256


### PR DESCRIPTION
**Description of work**

Following the [recent upgrade of mambaforge installer ](https://github.com/mantidproject/mantid/commit/a7fa59133e4d6f7c0ac00166b280b15bff3f07b2) the install script has `-e`. This means that the script exits after not being able to find `md5`, which causes our pipeline to abort.

To fix this, I have added `sbin`, which contains `md5` to the path on M1 macs if it is not there already.

This issue only effected the nightly pipeline on new first of the two new macs, as mambaforge gets installed anew each time. For PR builds, even clean ones, this is not the case - the mambaforge directory is excluded.

[This PR](https://builds.mantidproject.org/job/pull_requests-conda-osx/3425/) build takes place on an M1 mac, where the mambaforge folder has been delelted. Looking at the logs you can see this change in effect and no md5 error.

```
15:33:25 ++ echo /usr/bin:/bin
15:33:25 ++ grep -c /sbin:
15:33:25 + '[' 0 -eq 0 ']'
15:33:25 + export PATH=/sbin:/usr/bin:/bin
15:33:25 + PATH=/sbin:/usr/bin:/bin
```

**To test:**

Tests pass.
M1 package build passes.


<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.