### PR TITLE
Output doctest logs on nightly

### DIFF
--- a/buildconfig/Jenkins/Conda/conda-buildscript
+++ b/buildconfig/Jenkins/Conda/conda-buildscript
@@ -139,8 +139,8 @@ fi
 
 # Clean up artifacts from previous builds
 rm -f -- *.dmg *.rpm *.deb *.tar.gz *.tar.xz *.exe
-# Remove ctest logs from previous builds
-rm -rf  $BUILD_DIR/ctest_log
+# Remove test logs from previous builds
+rm -rf  $BUILD_DIR/test_logs
 
 # Run the script that handles the build
 $SCRIPT_DIR/build $WORKSPACE $CMAKE_PRESET $ENABLE_DOCS $ENABLE_DEV_DOCS $ENABLE_BUILD_CODE $ENABLE_UNIT_TESTS $ENABLE_SYSTEM_TESTS $ENABLE_COVERITY "$EXTRA_CMAKE_FLAGS" $BUILD_THREADS

--- a/buildconfig/Jenkins/Conda/nightly_build_and_deploy.jenkinsfile
+++ b/buildconfig/Jenkins/Conda/nightly_build_and_deploy.jenkinsfile
@@ -112,6 +112,7 @@ pipeline {
           post {
             always {
               archive_ctest_log()
+	      archive_doctest_log()
               publish_test_reports()
             }
           }
@@ -134,6 +135,7 @@ pipeline {
           post {
             always {
               archive_ctest_log()
+	      archive_doctest_log()
               publish_test_reports()
               // Workaround for Windows so that failing system tests will fail the build
               bat "\"${WIN_BASH}\" -ex -c \"test ${currentBuild.currentResult} != UNSTABLE\""
@@ -158,6 +160,7 @@ pipeline {
           post {
             always {
               archive_ctest_log()
+	      archive_doctest_log()
               publish_test_reports()
             }
           }
@@ -555,6 +558,10 @@ def archive_standalone_package(platform) {
 
 def archive_ctest_log(){
   archiveArtifacts artifacts: "${CHECKOUT_DIR}/build/ctest_log/*.log", fingerprint: true
+}
+
+def archive_doctest_log() {
+  archiveArtifacts artifacts: "${CHECKOUT_DIR}/build/doctest_log.log", fingerprint: true
 }
 
 def archive_env_logs(platform) {

--- a/buildconfig/Jenkins/Conda/nightly_build_and_deploy.jenkinsfile
+++ b/buildconfig/Jenkins/Conda/nightly_build_and_deploy.jenkinsfile
@@ -111,8 +111,7 @@ pipeline {
           }
           post {
             always {
-              archive_ctest_log()
-	      archive_doctest_log()
+              archive_test_logs()
               publish_test_reports()
             }
           }
@@ -134,8 +133,7 @@ pipeline {
           }
           post {
             always {
-              archive_ctest_log()
-	      archive_doctest_log()
+              archive_test_logs()
               publish_test_reports()
               // Workaround for Windows so that failing system tests will fail the build
               bat "\"${WIN_BASH}\" -ex -c \"test ${currentBuild.currentResult} != UNSTABLE\""
@@ -159,8 +157,7 @@ pipeline {
           }
           post {
             always {
-              archive_ctest_log()
-	      archive_doctest_log()
+              archive_test_logs()
               publish_test_reports()
             }
           }
@@ -556,12 +553,8 @@ def archive_standalone_package(platform) {
   }
 }
 
-def archive_ctest_log(){
-  archiveArtifacts artifacts: "${CHECKOUT_DIR}/build/ctest_log/*.log", fingerprint: true
-}
-
-def archive_doctest_log() {
-  archiveArtifacts artifacts: "${CHECKOUT_DIR}/build/doctest_log.log", fingerprint: true
+def archive_test_logs(){
+  archiveArtifacts artifacts: "${CHECKOUT_DIR}/build/test_logs/*.log", fingerprint: true
 }
 
 def archive_env_logs(platform) {

--- a/buildconfig/Jenkins/Conda/run-tests
+++ b/buildconfig/Jenkins/Conda/run-tests
@@ -109,8 +109,8 @@ if [[ $ENABLE_UNIT_TESTS == true ]]; then
 fi
 
 if [[ $ENABLE_DOCS == true && $ENABLE_DOC_TESTS == true ]]; then
-    run_with_xvfb cmake --build . --target docs-doctest -j$BUILD_THREADS $WINDOWS_BUILD_OPTIONS
-    terminate_xvfb_sessions
+    # Build doctests without using Xvfb for better output when things fail
+    QT_QPA_PLATFORM=offscreen cmake --build . --target docs-doctest -j$BUILD_THREADS $WINDOWS_BUILD_OPTIONS
 fi
 
 if [[ $ENABLE_SYSTEM_TESTS == true ]]; then

--- a/buildconfig/Jenkins/Conda/run-tests
+++ b/buildconfig/Jenkins/Conda/run-tests
@@ -101,16 +101,16 @@ fi
 
 # Run unit tests
 cd $WORKSPACE/build
-# mkdir for ctest log
-mkdir -p ctest_log
+# mkdir for test logs
+mkdir -p test_logs
 if [[ $ENABLE_UNIT_TESTS == true ]]; then
-    run_with_xvfb ctest -j$BUILD_THREADS --no-compress-output -T Test -O ctest_log/$OSTYPE.log --schedule-random --output-on-failure --repeat until-pass:3 $WINDOWS_TEST_OPTIONS $WINDOWS_UNITTEST_TIMEOUT_OPTIONS
+    run_with_xvfb ctest -j$BUILD_THREADS --no-compress-output -T Test -O test_logs/ctest_$OSTYPE.log --schedule-random --output-on-failure --repeat until-pass:3 $WINDOWS_TEST_OPTIONS $WINDOWS_UNITTEST_TIMEOUT_OPTIONS
     terminate_xvfb_sessions
 fi
 
 if [[ $ENABLE_DOCS == true && $ENABLE_DOC_TESTS == true ]]; then
     # Build doctests without using Xvfb for better output when things fail. Output to file due to console memory issues
-    QT_QPA_PLATFORM=offscreen cmake --build . --target docs-doctest -j$BUILD_THREADS $WINDOWS_BUILD_OPTIONS > doctest_log.log
+    QT_QPA_PLATFORM=offscreen cmake --build . --target docs-doctest -j$BUILD_THREADS $WINDOWS_BUILD_OPTIONS > test_logs/doctest_$OSTYPE.log
 fi
 
 if [[ $ENABLE_SYSTEM_TESTS == true ]]; then

--- a/buildconfig/Jenkins/Conda/run-tests
+++ b/buildconfig/Jenkins/Conda/run-tests
@@ -109,8 +109,8 @@ if [[ $ENABLE_UNIT_TESTS == true ]]; then
 fi
 
 if [[ $ENABLE_DOCS == true && $ENABLE_DOC_TESTS == true ]]; then
-    # Build doctests without using Xvfb for better output when things fail
-    QT_QPA_PLATFORM=offscreen cmake --build . --target docs-doctest -j$BUILD_THREADS $WINDOWS_BUILD_OPTIONS
+    # Build doctests without using Xvfb for better output when things fail. Output to file due to console memory issues
+    QT_QPA_PLATFORM=offscreen cmake --build . --target docs-doctest -j$BUILD_THREADS $WINDOWS_BUILD_OPTIONS > doctest_log.log
 fi
 
 if [[ $ENABLE_SYSTEM_TESTS == true ]]; then

--- a/conda/recipes/mantiddocs/build.sh
+++ b/conda/recipes/mantiddocs/build.sh
@@ -37,8 +37,7 @@ cmake --build . --target StandardTestData
 export STANDARD_TEST_DATA_DIR=$SRC_DIR/build/ExternalData/Testing/Data
 echo 'datasearch.directories = '$STANDARD_TEST_DATA_DIR'/UnitTest/;'$STANDARD_TEST_DATA_DIR'/DocTest/' >> $PREFIX/bin/Mantid.properties
 
-# Set QT_QPA_PLATFORM=offscreen so we do not need to run with xvfb. Xvfb hides a lot of debug output
-export QT_QPA_PLATFORM=offscreen
-cmake --build . --target docs-qthelp
+# Use QT_QPA_PLATFORM instead of Xvfb because Xvfb hides a lot of the useful output
+QT_QPA_PLATFORM=offscreen cmake --build . --target docs-qthelp
 
 cmake --build . --target install


### PR DESCRIPTION
**Description of work**
This PR should make it easier to debug issues with our nightly pipeline when it fails building the `docs-doctest` target. The output from this will now be put into a file in the build directory called `doctest_$OS_TYPE.log`, and then uploaded as an artifact at the end of the pipeline. This will mean it will appear in the "build artifacts" screen for the job. Previously, Xvfb would swallow any output from the building of docs-doctest and not show us anything. This has been avoided by using the `QT_QPA_PLATFORM=offscreen` variable instead of Xvfb.

**To test:**
Code review, and check that you can see a `doctest_$OS_TYPE.log` files in the build artefacts for this run. There will be no `doctest_msys.log` for windows because the doc tests do not get run on windows.
https://builds.mantidproject.org/job/build_packages_from_branch/509/

*There is no associated issue.*

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.