### PR TITLE
Allow Background Subtraction to be Saved and Loaded from Batch Files

### DIFF
--- a/dev-docs/source/Testing/SANSGUI/ISISSANSGUITests.rst
+++ b/dev-docs/source/Testing/SANSGUI/ISISSANSGUITests.rst
@@ -164,8 +164,7 @@ Processing
 
 *Scaled Background Subtracted Reduction*
 
-#. In the ``Settings`` tab, ``General, Scale, Event Slice, Sample`` sub-tab, set ``Reduction Mode`` to ``Merged``.
-#. Return to the ``Runs`` tab.
+#. Click over to the ``Runs`` tab.
 #. Set the ``Save Options`` to ``Memory``.
 #. Select one of the rows and click ``Process Selected``
 #. Take note of the name of the reduced workspace with ``merged`` in the title.
@@ -174,6 +173,7 @@ Processing
 #. Check the ``Scaled Background Subtraction`` checkbox.
 #. In the ``BackgroundWorkspace`` column, enter the name of the merged workspace you took note of before.
 #. In the ``ScaleFactor`` column, enter ``0.9``.
+#. In the ``Settings`` tab, ``General, Scale, Event Slice, Sample`` sub-tab, set ``Reduction Mode`` to ``Merged``.
 #. Select this new row and click ``Process Selected``.
 #. When it completes, two output files should have been created with ``bgsub_test`` in the name. One, which is the
    normal output data. Another with the scaled subtraction, which should have ``_bgsub`` appended to the name.

--- a/dev-docs/source/Testing/SANSGUI/ISISSANSGUITests.rst
+++ b/dev-docs/source/Testing/SANSGUI/ISISSANSGUITests.rst
@@ -164,6 +164,9 @@ Processing
 
 *Scaled Background Subtracted Reduction*
 
+#. Create a new copy of the User File in your file browser.
+#. In this new copy, change the the ``Reduction Mode`` to ``Merged`` using a text editor.
+#. Back in the ISIS SANS interface, change the user file to this new file.
 #. Click over to the ``Runs`` tab.
 #. Set the ``Save Options`` to ``Memory``.
 #. Select one of the rows and click ``Process Selected``
@@ -173,7 +176,6 @@ Processing
 #. Check the ``Scaled Background Subtraction`` checkbox.
 #. In the ``BackgroundWorkspace`` column, enter the name of the merged workspace you took note of before.
 #. In the ``ScaleFactor`` column, enter ``0.9``.
-#. In the ``Settings`` tab, ``General, Scale, Event Slice, Sample`` sub-tab, set ``Reduction Mode`` to ``Merged``.
 #. Select this new row and click ``Process Selected``.
 #. When it completes, two output files should have been created with ``bgsub_test`` in the name. One, which is the
    normal output data. Another with the scaled subtraction, which should have ``_bgsub`` appended to the name.

--- a/dev-docs/source/Testing/SANSGUI/ISISSANSGUITests.rst
+++ b/dev-docs/source/Testing/SANSGUI/ISISSANSGUITests.rst
@@ -171,8 +171,9 @@ Processing
 #. Take note of the name of the reduced workspace with ``merged`` in the title.
 #. Make a copy of the row you just processed using the ``Copy`` and ``Paste`` buttons above the runs table.
 #. Change the ``Output Name`` of the new row to something like ``bgsub_test``.
-#. In the ``Options`` column, enter ``BackgroundWorkspace=<WS_NAME>, ScaleFactor=0.9`` (replacing <WS_NAME> with the
-   name of the merged workspace you took note of before).
+#. Check the ``Scaled Background Subtraction`` checkbox.
+#. In the ``BackgroundWorkspace`` column, enter the name of the merged workspace you took note of before.
+#. In the ``ScaleFactor`` column, enter ``0.9``.
 #. Select this new row and click ``Process Selected``.
 #. When it completes, two output files should have been created with ``bgsub_test`` in the name. One, which is the
    normal output data. Another with the scaled subtraction, which should have ``_bgsub`` appended to the name.

--- a/docs/source/interfaces/isis_sans/Runs Tab.rst
+++ b/docs/source/interfaces/isis_sans/Runs Tab.rst
@@ -130,9 +130,31 @@ main output workspace. It is then saved to the ADS or to a file (based on the sa
 normal reduction output. The subtracted workspace will have the same name as the normal output workspace with ``_bgsub``
 appended to its name.
 
-The reduction will fail if only one of these values is set. Or, if the reduction mode is set to "All". This is because
-there is no way to determine if the workspace given as the ``BackgroundWorkspace`` is for the HAB or LAB, and so uses
-the value from the User File, therefore assuming that both reductions have used the same one.
+**Note:** The background subtraction workspace will be subtracted **in addition** to the normal subtraction
+performed when values are given in the Can columns. If you only wish to subtract the scaled background, leave the can
+cells blank.
+
+Examples:
+
+- Given Values: Sample (Scatter, Transmission, and Direct), and Can (Scatter, Transmission, and Direct)
+
+  - OutputName = Sample - Can
+
+- Given Values: Sample (Scatter, Transmission, and Direct), Can (Scatter, Transmission, and Direct), and  Scaled
+  Background Workspace
+
+  - OutputName = Sample - Can
+  - OutputName_bgsub = Sample - Can - (Background Workspace * Scale Factor)
+
+- Given Values: Sample (Scatter, Transmission, and Direct) and Scaled Background Workspace
+
+  - OutputName = Sample
+  - OutputName_bgsub = Sample - (Background Workspace * Scale Factor)
+
+The reduction will fail if only one of ``Background Workspace`` and ``Scale Factor`` is set. Or, if the reduction mode
+is set to "All". This is because there is no way to determine if the workspace given as the ``BackgroundWorkspace`` is
+for the HAB or LAB, and so uses the value from the User File, therefore assuming that both reductions have used the same
+one.
 
 Save Options
 ------------

--- a/docs/source/interfaces/isis_sans/Runs Tab.rst
+++ b/docs/source/interfaces/isis_sans/Runs Tab.rst
@@ -109,17 +109,26 @@ Table Columns
 |                          |   **WavelengthMin**, **WavelengthMax**, **EventSlices** (see :ref:`ISIS_SANS_Settings_Tab-ref`  |
 |                          |   for details), **BackgroundWorkspace**, and **ScaleFactor** can be set (see below).            |
 +--------------------------+-------------------------------------------------------------------------------------------------+
+| **Background Workspace** |   This column allows the user to provide a workspace for scaled background subtraction          |
+|                          |   (see below).                                                                                  |
++--------------------------+-------------------------------------------------------------------------------------------------+
+| **Scale Factor**         |   Scale factor to be used for scaled background subtraction (see below).                        |
++--------------------------+-------------------------------------------------------------------------------------------------+
 
 .. _ISIS_SANS_scaled_background-ref:
 
 Scaled Background Subtraction
 +++++++++++++++++++++++++++++
 
-By setting **both** ``BackgroundWorkspace`` and ``ScaleFactor`` in the options a Scaled Background Subtraction will be
+Additional hidden columns can be shown on the table by checking the ``Scaled Background Subtraction`` checkbox above
+the table on the right hand side.
+
+By setting **both** ``Background Workspace`` and ``Scale Factor`` a Scaled Background Subtraction will be
 performed. Giving these values will perform a background subtraction where the ``BackgroundWorkspace`` (representing a
 reduced solution run) will be multiplied by the ``ScaleFactor`` and then subtracted from the reduced HAB, LAB, or Merged
 main output workspace. It is then saved to the ADS or to a file (based on the save options below) in addition to the
-normal reduction output.
+normal reduction output. The subtracted workspace will have the same name as the normal output workspace with ``_bgsub``
+appended to its name.
 
 The reduction will fail if only one of these values is set. Or, if the reduction mode is set to "All". This is because
 there is no way to determine if the workspace given as the ``BackgroundWorkspace`` is for the HAB or LAB, and so uses

--- a/docs/source/release/v6.8.0/SANS/New_features/35446.rst
+++ b/docs/source/release/v6.8.0/SANS/New_features/35446.rst
@@ -1,2 +1,2 @@
-- ``BackgroundWorkspace`` and ``ScaleFactor`` can now be given in the ``Options`` column of the ISIS SANS Interface.
+- ``Background Workspace`` and ``Scale Factor`` can now be given on the ISIS SANS Interface.
   See :ref:`ISIS_SANS_scaled_background-ref` for more details.

--- a/scripts/Interface/ui/sans_isis/sans_data_processor_gui.py
+++ b/scripts/Interface/ui/sans_isis/sans_data_processor_gui.py
@@ -67,6 +67,8 @@ class SANSDataProcessorGui(QMainWindow, Ui_SansDataProcessorWindow):
         "Sample Shape",
         "Sample Height",
         "Sample Width",
+        "Background Workspace",
+        "Scale Factor",
         "SSP",
         "STP",
         "SDP",
@@ -116,6 +118,10 @@ class SANSDataProcessorGui(QMainWindow, Ui_SansDataProcessorWindow):
 
         @abstractmethod
         def on_sample_geometry_selection(self, show_geometry):
+            pass
+
+        @abstractmethod
+        def on_background_subtraction_selection(self, show_background_subtraction):
             pass
 
         @abstractmethod
@@ -313,6 +319,7 @@ class SANSDataProcessorGui(QMainWindow, Ui_SansDataProcessorWindow):
 
         self.multi_period_check_box.stateChanged.connect(self._on_multi_period_selection)
         self.sample_geometry_checkbox.stateChanged.connect(self._on_sample_geometry_selection)
+        self.background_subtraction_checkbox.stateChanged.connect(self._on_background_subtraction_selection)
 
         self.wavelength_step_type_combo_box.currentIndexChanged.connect(self._on_wavelength_step_type_changed)
 
@@ -378,6 +385,7 @@ class SANSDataProcessorGui(QMainWindow, Ui_SansDataProcessorWindow):
 
         self.wavelength_stacked_widget.setCurrentIndex(0)
         self.hide_geometry()
+        self.hide_background_subtraction()
 
         return True
 
@@ -909,6 +917,10 @@ class SANSDataProcessorGui(QMainWindow, Ui_SansDataProcessorWindow):
         UsageService.registerFeatureUsage(FeatureType.Feature, ["ISIS SANS", "Sample Geometry Toggled"], False)
         self._call_settings_listeners(lambda listener: listener.on_sample_geometry_selection(self.is_sample_geometry()))
 
+    def _on_background_subtraction_selection(self):
+        UsageService.registerFeatureUsage(FeatureType.Feature, ["ISIS SANS", "Background Subtraction Toggled"], False)
+        self._call_settings_listeners(lambda listener: listener.on_background_subtraction_selection(self.is_background_subtraction()))
+
     def _on_manage_directories(self):
         self._call_settings_listeners(lambda listener: listener.on_manage_directories())
 
@@ -976,6 +988,12 @@ class SANSDataProcessorGui(QMainWindow, Ui_SansDataProcessorWindow):
 
     def set_sample_geometry_mode(self, mode):
         self.sample_geometry_checkbox.setChecked(mode)
+
+    def is_background_subtraction(self):
+        return self.background_subtraction_checkbox.isChecked()
+
+    def set_background_subtraction_mode(self, mode):
+        self.background_subtraction_checkbox.setChecked(mode)
 
     # $$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$
     # $$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$
@@ -2099,6 +2117,24 @@ class SANSDataProcessorGui(QMainWindow, Ui_SansDataProcessorWindow):
         """
         execute_script(text)
 
+    def hide_geometry(self):
+        self.data_processor_table.hideColumn(self._column_index_map["Sample Shape"])
+        self.data_processor_table.hideColumn(self._column_index_map["Sample Height"])
+        self.data_processor_table.hideColumn(self._column_index_map["Sample Width"])
+
+    def show_geometry(self):
+        self.data_processor_table.showColumn(self._column_index_map["Sample Shape"])
+        self.data_processor_table.showColumn(self._column_index_map["Sample Height"])
+        self.data_processor_table.showColumn(self._column_index_map["Sample Width"])
+
+    def hide_background_subtraction(self):
+        self.data_processor_table.hideColumn(self._column_index_map["Background Workspace"])
+        self.data_processor_table.hideColumn(self._column_index_map["Scale Factor"])
+
+    def show_background_subtraction(self):
+        self.data_processor_table.showColumn(self._column_index_map["Background Workspace"])
+        self.data_processor_table.showColumn(self._column_index_map["Scale Factor"])
+
     def hide_period_columns(self):
         self.multi_period_check_box.setChecked(False)
 
@@ -2133,6 +2169,9 @@ class SANSDataProcessorGui(QMainWindow, Ui_SansDataProcessorWindow):
         array[self._column_index_map["Sample Thickness"]] = row_state_obj.sample_thickness
         array[self._column_index_map["Sample Width"]] = row_state_obj.sample_width
 
+        array[self._column_index_map["Background Workspace"]] = row_state_obj.background_ws
+        array[self._column_index_map["Scale Factor"]] = row_state_obj.scale_factor
+
         array[self._column_index_map["CDP"]] = row_state_obj.can_direct_period
         array[self._column_index_map["CSP"]] = row_state_obj.can_scatter_period
         array[self._column_index_map["CTP"]] = row_state_obj.can_transmission_period
@@ -2160,6 +2199,9 @@ class SANSDataProcessorGui(QMainWindow, Ui_SansDataProcessorWindow):
         entry.sample_thickness = row_array[self._column_index_map["Sample Thickness"]]
         entry.sample_width = row_array[self._column_index_map["Sample Width"]]
 
+        entry.background_ws = row_array[self._column_index_map["Background Workspace"]]
+        entry.scale_factor = row_array[self._column_index_map["Scale Factor"]]
+
         entry.can_direct_period = row_array[self._column_index_map["CDP"]]
         entry.can_scatter_period = row_array[self._column_index_map["CSP"]]
         entry.can_transmission_period = row_array[self._column_index_map["CTP"]]
@@ -2171,16 +2213,6 @@ class SANSDataProcessorGui(QMainWindow, Ui_SansDataProcessorWindow):
         entry.options.set_user_options(row_array[self._column_index_map["Options"]])
 
         return entry
-
-    def show_geometry(self):
-        self.data_processor_table.showColumn(self._column_index_map["Sample Shape"])
-        self.data_processor_table.showColumn(self._column_index_map["Sample Height"])
-        self.data_processor_table.showColumn(self._column_index_map["Sample Width"])
-
-    def hide_geometry(self):
-        self.data_processor_table.hideColumn(self._column_index_map["Sample Shape"])
-        self.data_processor_table.hideColumn(self._column_index_map["Sample Height"])
-        self.data_processor_table.hideColumn(self._column_index_map["Sample Width"])
 
     def closeEvent(self, event):
         for child in self.children():

--- a/scripts/Interface/ui/sans_isis/sans_data_processor_window.ui
+++ b/scripts/Interface/ui/sans_isis/sans_data_processor_window.ui
@@ -95,7 +95,7 @@ QGroupBox::title {
       <item>
        <widget class="QStackedWidget" name="main_stacked_widget">
         <property name="currentIndex">
-         <number>1</number>
+         <number>0</number>
         </property>
         <widget class="QWidget" name="run_page">
          <layout class="QVBoxLayout" name="verticalLayout_3">
@@ -408,6 +408,13 @@ QGroupBox::title {
                 </property>
                </widget>
               </item>
+              <item>
+               <widget class="QCheckBox" name="background_subtraction_checkbox">
+                <property name="text">
+                 <string>Scaled Background Subtraction</string>
+                </property>
+               </widget>
+              </item>
              </layout>
             </item>
             <item>
@@ -648,7 +655,7 @@ QGroupBox::title {
           <item>
            <widget class="QTabWidget" name="settings_tab_widget">
             <property name="currentIndex">
-             <number>3</number>
+             <number>0</number>
             </property>
             <widget class="QWidget" name="general_tab">
              <attribute name="title">

--- a/scripts/SANS/sans/command_interface/batch_csv_parser.py
+++ b/scripts/SANS/sans/command_interface/batch_csv_parser.py
@@ -119,6 +119,10 @@ class BatchCsvParser(object):
             pack_val(row.sample_height),
             BatchFileKeywords.SAMPLE_WIDTH.value,
             pack_val(row.sample_width),
+            BatchFileKeywords.BACKGROUND_WORKSPACE.value,
+            pack_val(row.background_ws),
+            BatchFileKeywords.SCALE_FACTOR.value,
+            pack_val(row.scale_factor),
         ]
 
     def _parse_csv_row(self, row, row_number):

--- a/scripts/SANS/sans/command_interface/batch_csv_parser.py
+++ b/scripts/SANS/sans/command_interface/batch_csv_parser.py
@@ -26,6 +26,8 @@ class BatchFileKeywords(Enum):
     SAMPLE_THICKNESS = "sample_thickness"
     SAMPLE_HEIGHT = "sample_height"
     SAMPLE_WIDTH = "sample_width"
+    BACKGROUND_WORKSPACE = "background_workspace"
+    SCALE_FACTOR = "scale_factor"
 
 
 class BatchCsvParser(object):
@@ -178,6 +180,11 @@ class BatchCsvParser(object):
             row_entry.sample_transmission = run_number
             row_entry.sample_transmission_period = period
 
+        elif key_enum is BatchFileKeywords.BACKGROUND_WORKSPACE:
+            row_entry.background_ws = value
+        elif key_enum is BatchFileKeywords.SCALE_FACTOR:
+            row_entry.scale_factor = value
+
         elif key_enum is BatchFileKeywords.SAMPLE_HEIGHT:
             row_entry.sample_height = value
         elif key_enum is BatchFileKeywords.SAMPLE_THICKNESS:
@@ -230,7 +237,11 @@ class BatchCsvParser(object):
                 "Inconsistent can transmission settings in row {0}. Either both the transmission "
                 "and the direct beam run are set or none.".format(row_number)
             )
-
+        if bool(output.background_ws) != bool(output.scale_factor):
+            raise ValueError(
+                "Inconsistent scaled background subtraction settings in row {0}. Either both the background workspace "
+                "and the scale factor are set or none.".format(row_number)
+            )
         # Ensure that can scatter is specified if the transmissions are set
         if bool(output.can_transmission) and not bool(output.can_scatter):
             raise ValueError("The can transmission was set but not the scatter file in row {0}.".format(row_number))

--- a/scripts/SANS/sans/gui_logic/models/RowEntries.py
+++ b/scripts/SANS/sans/gui_logic/models/RowEntries.py
@@ -34,6 +34,9 @@ class _UserEntries(object):
         self.sample_thickness: float = None
         self.sample_width: float = None
 
+        self.background_ws: str = None
+        self.scale_factor: float = None
+
         self.can_direct_period: str = None
         self.can_scatter_period: str = None
         self.can_transmission_period: str = None
@@ -60,6 +63,8 @@ class _UserEntries(object):
                 self._sample_shape,
                 self.sample_thickness,
                 self.sample_width,
+                self.background_ws,
+                self.scale_factor,
                 self.can_direct_period,
                 self.can_scatter_period,
                 self.can_transmission_period,
@@ -79,6 +84,8 @@ class _UserEntries(object):
                 other._sample_shape,
                 other.sample_thickness,
                 other.sample_width,
+                other.background_ws,
+                other.scale_factor,
                 other.can_direct_period,
                 other.can_scatter_period,
                 other.can_transmission_period,

--- a/scripts/SANS/sans/gui_logic/models/RowOptionsModel.py
+++ b/scripts/SANS/sans/gui_logic/models/RowOptionsModel.py
@@ -47,8 +47,6 @@ class RowOptionsModel(object):
             "PhiMin": float,
             "PhiMax": float,
             "UseMirror": bool,
-            "BackgroundWorkspace": str,
-            "ScaleFactor": float,
         }
 
         options = {}

--- a/scripts/SANS/sans/gui_logic/presenter/gui_state_director.py
+++ b/scripts/SANS/sans/gui_logic/presenter/gui_state_director.py
@@ -70,6 +70,11 @@ class GuiStateDirector(object):
         if row_entry.sample_shape:
             gui_state.sample_shape = row_entry.sample_shape
 
+        if row_entry.background_ws:
+            gui_state.background_workspace = row_entry.background_ws
+        if row_entry.scale_factor:
+            gui_state.scale_factor = row_entry.scale_factor
+
         # 4. Create the rest of the state based on the builder.
         gui_state.all_states.data = data_builder.build()
         return gui_state
@@ -153,9 +158,3 @@ class GuiStateDirector(object):
 
         if "UseMirror" in options.keys():
             state_gui_model.phi_limit_use_mirror = options["UseMirror"]
-
-        if "BackgroundWorkspace" in options.keys():
-            state_gui_model.background_workspace = options["BackgroundWorkspace"]
-
-        if "ScaleFactor" in options.keys():
-            state_gui_model.scale_factor = options["ScaleFactor"]

--- a/scripts/SANS/sans/gui_logic/presenter/run_tab_presenter.py
+++ b/scripts/SANS/sans/gui_logic/presenter/run_tab_presenter.py
@@ -184,6 +184,9 @@ class RunTabPresenter(PresenterCommon):
         def on_sample_geometry_selection(self, show_geometry):
             self._presenter.on_sample_geometry_view_changed(show_geometry)
 
+        def on_background_subtraction_selection(self, show_background):
+            self._presenter.on_background_subtraction_view_changed(show_background)
+
         def on_field_edit(self):
             self._presenter.update_model_from_view()
 
@@ -803,6 +806,12 @@ class RunTabPresenter(PresenterCommon):
             self._view.show_geometry()
         else:
             self._view.hide_geometry()
+
+    def on_background_subtraction_view_changed(self, show_background):
+        if show_background:
+            self._view.show_background_subtraction()
+        else:
+            self._view.hide_background_subtraction()
 
     def get_row_indices(self):
         """

--- a/scripts/test/SANS/command_interface/batch_csv_file_parser_test.py
+++ b/scripts/test/SANS/command_interface/batch_csv_file_parser_test.py
@@ -297,6 +297,8 @@ class BatchCsvParserTest(unittest.TestCase):
         test_row.sample_thickness = "1.0"
         test_row.sample_height = 5.0
         test_row.sample_width = 5.4
+        test_row.background_ws = "TestWS"
+        test_row.scale_factor = 1.3
 
         expected = (
             "sample_sans,SANS2D00022025,"
@@ -309,7 +311,9 @@ class BatchCsvParserTest(unittest.TestCase):
             "user_file,a_user_file.txt,"
             "sample_thickness,1.0,"
             "sample_height,5.0,"
-            "sample_width,5.4"
+            "sample_width,5.4,"
+            "background_workspace,TestWS,"
+            "scale_factor,1.3"
         )
 
         mocked_handle = mock.mock_open()

--- a/scripts/test/SANS/command_interface/batch_csv_file_parser_test.py
+++ b/scripts/test/SANS/command_interface/batch_csv_file_parser_test.py
@@ -100,6 +100,22 @@ class BatchCsvParserTest(unittest.TestCase):
             parser.parse_batch_file(batch_file_path)
         BatchCsvParserTest._remove_csv(batch_file_path)
 
+    def test_that_raises_when_background_workspace_is_specified_but_no_scale_factor(self):
+        content = "# MANTID_BATCH_FILE add more text here\n" "sample_sans,test,output_as,test, background_workspace, test\n"
+        batch_file_path = BatchCsvParserTest._save_to_csv(content)
+        parser = BatchCsvParser()
+        with self.assertRaises(ValueError):
+            parser.parse_batch_file(batch_file_path)
+        BatchCsvParserTest._remove_csv(batch_file_path)
+
+    def test_that_raises_when_scale_factor_is_specified_but_no_background_workspace(self):
+        content = "# MANTID_BATCH_FILE add more text here\n" "sample_sans,test,output_as,test, scale_factor, 1.1\n"
+        batch_file_path = BatchCsvParserTest._save_to_csv(content)
+        parser = BatchCsvParser()
+        with self.assertRaises(ValueError):
+            parser.parse_batch_file(batch_file_path)
+        BatchCsvParserTest._remove_csv(batch_file_path)
+
     def test_that_parses_two_lines_correctly(self):
         content = (
             "# MANTID_BATCH_FILE add more text here\n"

--- a/scripts/test/SANS/gui_logic/gui_state_director_test.py
+++ b/scripts/test/SANS/gui_logic/gui_state_director_test.py
@@ -18,8 +18,13 @@ from sans.user_file.txt_parsers.UserFileReaderAdapter import UserFileReaderAdapt
 
 class GuiStateDirectorTest(unittest.TestCase):
     @staticmethod
-    def _get_row_entry(option_string="", sample_thickness=8.0):
-        row_entry = RowEntries(sample_scatter="SANS2D00022024", sample_thickness=sample_thickness)
+    def _get_row_entry(option_string="", sample_thickness=8.0, background_workspace="test", scale_factor=1.1):
+        row_entry = RowEntries(
+            sample_scatter="SANS2D00022024",
+            sample_thickness=sample_thickness,
+            background_ws=background_workspace,
+            scale_factor=scale_factor,
+        )
         row_entry.options.set_user_options(option_string)
         return row_entry
 
@@ -97,16 +102,6 @@ class GuiStateDirectorTest(unittest.TestCase):
         new_state = director.create_state(self._get_row_entry(), row_user_file="NotThere.txt")
 
         self.assertEqual(state_model.all_states.save, new_state.all_states.save)
-
-    def test_that_background_ws_and_scale_factor_set_on_state_from_options_column(self):
-        state_model = self._get_state_gui_model()
-        director = GuiStateDirector(state_model, SANSFacility.ISIS)
-
-        state = self._get_row_entry(option_string="BackgroundWorkspace=whatever,ScaleFactor=0.9")
-        state = director.create_state(state)
-        self.assertTrue(isinstance(state, StateGuiModel))
-        self.assertEqual(state.all_states.background_subtraction.workspace, "whatever")
-        self.assertEqual(state.all_states.background_subtraction.scale_factor, 0.9)
 
 
 if __name__ == "__main__":

--- a/scripts/test/SANS/gui_logic/models/test_row_entries.py
+++ b/scripts/test/SANS/gui_logic/models/test_row_entries.py
@@ -63,7 +63,7 @@ class RowEntriesTest(unittest.TestCase):
     def test_deep_copy_eq(self):
         obj = RowEntries()
         # Randomly selected subset of fields
-        for attr in ["sample_transmission", "can_direct_period", "user_file", "output_name", "tool_tip", "state"]:
+        for attr in ["sample_transmission", "can_direct_period", "user_file", "output_name", "tool_tip", "state", "background_ws"]:
             obj2 = copy.deepcopy(obj)
             self.assertEqual(obj, obj2)
             setattr(obj2, attr, 1)

--- a/scripts/test/SANS/gui_logic/test_run_tab_presenter.py
+++ b/scripts/test/SANS/gui_logic/test_run_tab_presenter.py
@@ -255,7 +255,6 @@ class RunTabPresenterTest(unittest.TestCase):
                 ConfigService=mock.DEFAULT,
                 os=mock.DEFAULT,
             ) as mock_datasearch:
-
                 mock_datasearch["add_dir_to_datasearch"].return_value = (mock.Mock(), mock.Mock())
                 self.presenter.on_batch_file_load()
 
@@ -345,7 +344,6 @@ class RunTabPresenterTest(unittest.TestCase):
         self.presenter.update_view_from_table_model.assert_called_with()
 
     def test_that_all_columns_shown_when_multi_period_is_true(self):
-
         self.presenter.set_view(mock.MagicMock())
 
         self.presenter.on_multiperiod_changed(True)
@@ -353,12 +351,25 @@ class RunTabPresenterTest(unittest.TestCase):
         self.presenter._view.show_period_columns.assert_called_once_with()
 
     def test_that_period_columns_hidden_when_multi_period_is_false(self):
-
         self.presenter.set_view(mock.MagicMock())
 
         self.presenter.on_multiperiod_changed(False)
 
         self.presenter._view.hide_period_columns.assert_called_once_with()
+
+    def test_that_all_columns_shown_when_background_subtraction_is_true(self):
+        self.presenter.set_view(mock.MagicMock())
+
+        self.presenter.on_background_subtraction_view_changed(True)
+
+        self.presenter._view.show_background_subtraction.assert_called_once_with()
+
+    def test_that_all_columns_hidden_when_background_subtraction_is_false(self):
+        self.presenter.set_view(mock.MagicMock())
+
+        self.presenter.on_background_subtraction_view_changed(False)
+
+        self.presenter._view.hide_background_subtraction.assert_called_once_with()
 
     def test_on_data_changed_updates_table_model(self):
         self.presenter._beam_centre_presenter = mock.Mock()
@@ -382,7 +393,6 @@ class RunTabPresenterTest(unittest.TestCase):
         self.presenter.update_view_from_table_model.assert_called_with()
 
     def test_setup_instrument_specific_settings(self):
-
         self.presenter.set_view(mock.MagicMock())
         self.presenter._beam_centre_presenter = mock.MagicMock()
         self.presenter._workspace_diagnostic_presenter = mock.MagicMock()
@@ -507,7 +517,6 @@ class RunTabPresenterTest(unittest.TestCase):
         self.assertEqual(self.presenter._view.progress_bar_value, 1)
 
     def test_that_update_progress_sets_correctly(self):
-
         view = mock.MagicMock()
         self.presenter.set_view(view)
 
@@ -517,7 +526,6 @@ class RunTabPresenterTest(unittest.TestCase):
         self.assertEqual(view.progress_bar_maximum, 200)
 
     def test_that_notify_progress_updates_state_and_tooltip_of_row(self):
-
         view = mock.MagicMock()
         self.presenter.set_view(view)
         self.presenter.on_row_appended()
@@ -528,7 +536,6 @@ class RunTabPresenterTest(unittest.TestCase):
         self.assertEqual(self.presenter._table_model.get_row(0).tool_tip, None)
 
     def test_that_process_selected_does_nothing_if_no_states_selected(self):
-
         view = mock.MagicMock()
         view.get_selected_rows = mock.MagicMock(return_value=[])
         self.presenter.set_view(view)
@@ -568,7 +575,6 @@ class RunTabPresenterTest(unittest.TestCase):
         self.presenter._process_rows.assert_called_with(expected)
 
     def test_that_process_selected_ignores_all_empty_rows(self):
-
         view = mock.MagicMock()
         view.get_selected_rows = mock.MagicMock(return_value=[0, 1])
         self.presenter.set_view(view)
@@ -587,7 +593,6 @@ class RunTabPresenterTest(unittest.TestCase):
         self.presenter._process_rows.assert_called_with([populated_row])
 
     def test_that_process_all_ignores_empty_rows(self):
-
         view = mock.MagicMock()
         view.get_selected_rows = mock.MagicMock(return_value=[0, 1])
         self.presenter.set_view(view)
@@ -673,7 +678,6 @@ class RunTabPresenterTest(unittest.TestCase):
         self.presenter._view.add_runs_presenter.handle_new_save_directory.assert_called_once_with("a_new_directory")
 
     def test_that_validate_output_modes_raises_if_no_file_types_selected_for_file_mode(self):
-
         view = mock.MagicMock()
 
         view.save_types = [SaveType.NO_TYPE]
@@ -698,7 +702,6 @@ class RunTabPresenterTest(unittest.TestCase):
         self.assertRaises(ValueError, self.presenter._validate_output_modes)
 
     def test_that_validate_output_modes_does_not_raise_if_no_file_types_selected_for_memory_mode(self):
-
         view = mock.MagicMock()
         view.save_types = [SaveType.NO_TYPE]
 
@@ -729,7 +732,6 @@ class RunTabPresenterTest(unittest.TestCase):
         self.presenter._view.enable_file_type_buttons.assert_called_once()
 
     def test_that_on_reduction_mode_changed_calls_update_front_if_selection_is_HAB(self):
-
         self.presenter._beam_centre_presenter = mock.MagicMock()
 
         self.presenter.on_reduction_mode_selection_has_changed("Hab")
@@ -740,7 +742,6 @@ class RunTabPresenterTest(unittest.TestCase):
         self.presenter._beam_centre_presenter.update_front_selected.assert_called_once_with()
 
     def test_that_on_reduction_mode_changed_calls_update_rear_if_selection_is_LAB(self):
-
         self.presenter._beam_centre_presenter = mock.MagicMock()
 
         self.presenter.on_reduction_mode_selection_has_changed("rear")


### PR DESCRIPTION
**Description of work**

**Purpose of work**
The original implementation of this subtraction method allowed the values for the background workspace and the scale factor to be set in an `Options` column. This column's cells are comma-separated lists of parameters. This is incompatible with the `.csv` format used for the batch files by the SANS group, and so the values in the options column are not stored in the batch files. 

This new background subtraction feature is reported to eventually be in high enough use that this information needs to be stored in the batch so that it can be edited alongside the other parameters present on the table. 

**Report to:** Robert Dalgliesh

**Summary of work**
Creates two new columns on the Runs tab of the ISIS SANS Interface for the "Background Workspace" and the "Scale Factor". In order to avoid cluttering an already busy interface, the columns do not appear on the table until the "Scaled Background Subtraction" checkbox is checked.

**Further detail of work**
- Removed the background workspace and scale factor parameters from the options box
- Allowed the new bg subtraction parameters to be saved and loaded into and out of the batch files (`.csv` format)
- Added validation when loading a batch file that both the scale factor and background workspace parameters are set (both are required for the reduction, and the batch files are often edited in excel)


**To test:**
You may need to change the value of the `.toml` user file for the reduction mode from "All" to "Merged". This is called `MaskFile.toml` in the training course data. You should confirm this 

1. Boot up workbench and the ISIS SANS interface. 
2. Load the user file and the batch file from the LOQ Demo in the TrainingCourseData
4. Process All (this will produce your "background" workspaces, something like `first_time_merged_1D_2.2_10.0` or `first_time_HAB_1D_2.2_10.0`)
5. Check the `Scaled Background Subtraction` checkbox
6. Copy and paste a new row and set `Background Workspace` to the name of the workspace you produced in step 3, and `Scale Factor` to 0.9.
7. Process this new row. 
8. Check the two output workspaces you should now have. If it has worked properly, the subtracted one's values should be 10% of the unsubtracted one's. 
9. Check that the batch can be saved and loaded and the background workspace and scale factor cells are preserved between loads. 

Fixes #35958


*This does not require release notes* because **it makes changes to a new feature for this release.**




---

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.