### PR TITLE
Support for customizable string comparison in EnumeratedString

### DIFF
--- a/Framework/Kernel/test/EnumeratedStringTest.h
+++ b/Framework/Kernel/test/EnumeratedStringTest.h
@@ -20,7 +20,8 @@ const std::vector<std::string> cakeNames{"Lemon Cake", "Devil's Food Cake", "Ang
 typedef EnumeratedString<CoolGuys, &coolGuyNames> COOLGUY;
 typedef EnumeratedString<Cakes, &cakeNames> CAKE;
 
-bool firstLetterComparator(const std::string &x, const std::string &y) { return x[0] == y[0]; }
+std::function<bool(const std::string &, const std::string &)> firstLetterComparator =
+    [](const std::string &x, const std::string &y) { return x[0] == y[0]; };
 } // namespace
 
 class EnumeratedStringTest : public CxxTest::TestSuite {
@@ -245,7 +246,7 @@ public:
   void testCaseInsensitiveNameComparison() {
     enum TwoLettersEnum : size_t { ab, cd, enum_count };
     static const std::vector<std::string> twoLetters = {"ab", "cd"};
-    typedef EnumeratedString<TwoLettersEnum, &twoLetters, &CompareStringsCaseInsensitive> TWO_LETTERS;
+    typedef EnumeratedString<TwoLettersEnum, &twoLetters, &compareStringsCaseInsensitive> TWO_LETTERS;
 
     // 1. Test a use case with mixed-case string introduced through the constructor: EnumeratedString(const std::string
     // s)
@@ -280,7 +281,7 @@ public:
     TS_ASSERT(enTwoLetters_from_constructor != std::string("BA"));
 
     // 2. Test a use case with mixed-case string introduced through the assignment operator: EnumeratedString
-    // &operator=(std::string& s)
+    // &operator=(const td::string& s)
     TS_ASSERT_THROWS_NOTHING(TWO_LETTERS enTwoLetters_from_assignment = std::string("aB"));
     TWO_LETTERS enTwoLetters_from_assignment = std::string("aB");
     TS_ASSERT(enTwoLetters_from_assignment.c_str() == std::string("aB"))

--- a/Framework/Kernel/test/EnumeratedStringTest.h
+++ b/Framework/Kernel/test/EnumeratedStringTest.h
@@ -19,9 +19,6 @@ const std::vector<std::string> cakeNames{"Lemon Cake", "Devil's Food Cake", "Ang
                                          "Pound Cake"};
 typedef EnumeratedString<CoolGuys, &coolGuyNames> COOLGUY;
 typedef EnumeratedString<Cakes, &cakeNames> CAKE;
-
-std::function<bool(const std::string &, const std::string &)> firstLetterComparator =
-    [](const std::string &x, const std::string &y) { return x[0] == y[0]; };
 } // namespace
 
 class EnumeratedStringTest : public CxxTest::TestSuite {
@@ -315,6 +312,8 @@ public:
   void test_customNameComparator() {
     enum FirstLetterEnum : size_t { A, B, C, enum_count };
     static const std::vector<std::string> words = {"apple", "banana", "cherry"};
+    static std::function<bool(const std::string &, const std::string &)> firstLetterComparator =
+        [](const std::string &x, const std::string &y) { return x[0] == y[0]; };
     typedef EnumeratedString<FirstLetterEnum, &words, &firstLetterComparator> Fruit;
 
     Fruit apple = FirstLetterEnum::A;

--- a/Framework/Kernel/test/EnumeratedStringTest.h
+++ b/Framework/Kernel/test/EnumeratedStringTest.h
@@ -19,6 +19,8 @@ const std::vector<std::string> cakeNames{"Lemon Cake", "Devil's Food Cake", "Ang
                                          "Pound Cake"};
 typedef EnumeratedString<CoolGuys, &coolGuyNames> COOLGUY;
 typedef EnumeratedString<Cakes, &cakeNames> CAKE;
+
+bool firstLetterComparator(const std::string &x, const std::string &y) { return x[0] == y[0]; }
 } // namespace
 
 class EnumeratedStringTest : public CxxTest::TestSuite {
@@ -238,5 +240,88 @@ public:
     default:
       TS_FAIL("EnumeratedString in 'SWITCH' failed to match to enumerated value");
     }
+  }
+
+  void testCaseInsensitiveNameComparison() {
+    enum TwoLettersEnum : size_t { ab, cd, enum_count };
+    static const std::vector<std::string> twoLetters = {"ab", "cd"};
+    typedef EnumeratedString<TwoLettersEnum, &twoLetters, &CompareStringsCaseInsensitive> TWO_LETTERS;
+
+    // 1. Test a use case with mixed-case string introduced through the constructor: EnumeratedString(const std::string
+    // s)
+    TS_ASSERT_THROWS_NOTHING(TWO_LETTERS enTwoLetters("aB"));
+    TWO_LETTERS enTwoLetters_from_constructor("aB");
+    TS_ASSERT(enTwoLetters_from_constructor.c_str() == std::string("aB"))
+    TS_ASSERT(enTwoLetters_from_constructor == TwoLettersEnum::ab)
+
+    // test operator==(const char *s) const
+    TS_ASSERT(enTwoLetters_from_constructor == "ab");
+    TS_ASSERT(enTwoLetters_from_constructor == "aB");
+    TS_ASSERT(enTwoLetters_from_constructor == "Ab");
+    TS_ASSERT(enTwoLetters_from_constructor == "AB");
+
+    // test operator==(const std::string& s) const
+    TS_ASSERT(enTwoLetters_from_constructor == std::string("ab"));
+    TS_ASSERT(enTwoLetters_from_constructor == std::string("aB"));
+    TS_ASSERT(enTwoLetters_from_constructor == std::string("Ab"));
+    TS_ASSERT(enTwoLetters_from_constructor == std::string("AB"));
+
+    TS_ASSERT(!(enTwoLetters_from_constructor == "cd"));
+    TS_ASSERT(!(enTwoLetters_from_constructor == "bA"));
+    TS_ASSERT(!(enTwoLetters_from_constructor == std::string("cd")));
+    TS_ASSERT(!(enTwoLetters_from_constructor == std::string("bA")));
+
+    // test operator!=(const char *s) const
+    TS_ASSERT(enTwoLetters_from_constructor != "cd");
+    TS_ASSERT(enTwoLetters_from_constructor != "Ba");
+
+    // test operator!=(const std::string& s)
+    TS_ASSERT(enTwoLetters_from_constructor != std::string("cd"));
+    TS_ASSERT(enTwoLetters_from_constructor != std::string("BA"));
+
+    // 2. Test a use case with mixed-case string introduced through the assignment operator: EnumeratedString
+    // &operator=(std::string& s)
+    TS_ASSERT_THROWS_NOTHING(TWO_LETTERS enTwoLetters_from_assignment = std::string("aB"));
+    TWO_LETTERS enTwoLetters_from_assignment = std::string("aB");
+    TS_ASSERT(enTwoLetters_from_assignment.c_str() == std::string("aB"))
+    TS_ASSERT(enTwoLetters_from_assignment == TwoLettersEnum::ab)
+
+    // test operator==(const char *s) const
+    TS_ASSERT(enTwoLetters_from_assignment == "ab");
+    TS_ASSERT(enTwoLetters_from_assignment == "aB");
+    TS_ASSERT(enTwoLetters_from_assignment == "Ab");
+    TS_ASSERT(enTwoLetters_from_assignment == "AB");
+
+    // test operator==(const std::string& s) const
+    TS_ASSERT(enTwoLetters_from_assignment == std::string("ab"));
+    TS_ASSERT(enTwoLetters_from_assignment == std::string("aB"));
+    TS_ASSERT(enTwoLetters_from_assignment == std::string("Ab"));
+    TS_ASSERT(enTwoLetters_from_assignment == std::string("AB"));
+
+    TS_ASSERT(!(enTwoLetters_from_assignment == "cd"));
+    TS_ASSERT(!(enTwoLetters_from_assignment == "bA"));
+    TS_ASSERT(!(enTwoLetters_from_assignment == std::string("cd")));
+
+    // test operator!=(const char *s) const
+    TS_ASSERT(enTwoLetters_from_assignment != "cd");
+    TS_ASSERT(enTwoLetters_from_assignment != "Ba");
+
+    // test operator!=(const std::string& s)
+    TS_ASSERT(enTwoLetters_from_assignment != std::string("cd"));
+    TS_ASSERT(enTwoLetters_from_assignment != std::string("BA"));
+  }
+
+  void test_customNameComparator() {
+    enum FirstLetterEnum : size_t { A, B, C, enum_count };
+    static const std::vector<std::string> words = {"apple", "banana", "cherry"};
+    typedef EnumeratedString<FirstLetterEnum, &words, &firstLetterComparator> Fruit;
+
+    Fruit apple = FirstLetterEnum::A;
+    Fruit banana = FirstLetterEnum::B;
+    Fruit cherry = FirstLetterEnum::C;
+
+    TS_ASSERT_EQUALS(apple, "apricot");
+    TS_ASSERT_EQUALS(banana, "blueberry");
+    TS_ASSERT_EQUALS(cherry, "corn");
   }
 };

--- a/dev-docs/source/EnumeratedString.rst
+++ b/dev-docs/source/EnumeratedString.rst
@@ -29,8 +29,10 @@ How to use the EnumeratedString
 
 First include the ``EnumeratedString.h`` header file.
 
-This is a template class, and its two template parameters are the name of an ``enum`` type, and a *pointer* to static vector of
-``std::string`` objects.
+This is a template class, and its three template parameters are the name of an ``enum`` type, a *pointer* to static vector of
+``std::string`` objects, and an optional *pointer* to a statically defined function for comparing ``std::string`` objects. The last
+template parameter is defaulted to ``CompareStrings`` which implements a case-sensitive string comparison. A predefined function for case-insensitive
+string comparison, ``CompareStringsCaseInsensitive``, is also provided as an option.
 
 Below is an example.  Consider the mantid algorithm :code:`BakeCake`, which has a string property,
 ``CakeType``.  This algorithm only knows how to bake a few types of cakes.  The allowed types of cake the user can set for
@@ -149,3 +151,38 @@ An example of where this might be used inside an algorithm is shown below:
    }// namespace Mantid
 
 This will easily handle branching logic on the basis of a set number of possible string values, using an ``enum`` to base the set of strings.
+
+In the code examples above, if you don't want to distinguish a name "Lemon" from, say, "LEMON", you can make a case-insensitive ``CAKETYPE``:
+
+.. code-block:: cpp
+
+  #include "MantidKernel/EnumeratedString.h"
+
+  namespace Mantid {
+
+  namespace {
+  enum class CakeTypeEnum {LEMON, BUNDT, POUND, enum_count};
+  const std::vector<std::string> cakeTypeNames {"Lemon", "Bundt", "Pound"};
+  // optional typedef
+  typedef EnumeratedString<CakeEnumType, &cakeTypeNames, &CompareStringsCaseInsensitive> CAKETYPE;
+  } // namespace
+
+This might be useful, for example, if you need to enumerate some file name extensions and treat ".cpp" the same way as ".CPP".
+
+You can also provide your own string comparator like ``firstLetterComparator`` below:
+
+.. code-block:: cpp
+
+  #include "MantidKernel/EnumeratedString.h"
+
+  namespace Mantid {
+
+  namespace {
+  bool firstLetterComparator(const std::string &x, const std::string &y) { return x[0] == y[0]; }
+  enum class CakeTypeEnum {L, B, P, enum_count};
+  const std::vector<std::string> cakeTypeFirstLetters {"L", "B", "P"};
+  // optional typedef
+  typedef EnumeratedString<CakeEnumType, &cakeTypeFirstLetters, &firstLetterComparator> CAKETYPE;
+  } // namespace
+
+in which case a "Lemon" cake will get the same enumeration as a "Lime" cake.

--- a/dev-docs/source/EnumeratedString.rst
+++ b/dev-docs/source/EnumeratedString.rst
@@ -30,9 +30,9 @@ How to use the EnumeratedString
 First include the ``EnumeratedString.h`` header file.
 
 This is a template class, and its three template parameters are the name of an ``enum`` type, a *pointer* to static vector of
-``std::string`` objects, and an optional *pointer* to a statically defined function for comparing ``std::string`` objects. The last
-template parameter is defaulted to ``CompareStrings`` which implements a case-sensitive string comparison. A predefined function for case-insensitive
-string comparison, ``CompareStringsCaseInsensitive``, is also provided as an option.
+``std::string`` objects, and an optional *pointer* to a statically defined ``std::function`` for comparing ``std::string`` objects. The last
+template parameter is defaulted to ``compareStrings`` which implements a case-sensitive string comparison. A predefined function for case-insensitive
+string comparison, ``compareStringsCaseInsensitive``, is also provided as an option.
 
 Below is an example.  Consider the mantid algorithm :code:`BakeCake`, which has a string property,
 ``CakeType``.  This algorithm only knows how to bake a few types of cakes.  The allowed types of cake the user can set for
@@ -152,7 +152,7 @@ An example of where this might be used inside an algorithm is shown below:
 
 This will easily handle branching logic on the basis of a set number of possible string values, using an ``enum`` to base the set of strings.
 
-In the code examples above, if you don't want to distinguish a name "Lemon" from, say, "LEMON", you can make a case-insensitive ``CAKETYPE``:
+In the code examples above, if you don't want to distinguish between names like "Lemon" and "LEMON", you can define your ``CAKETYPE`` as case-insensitive:
 
 .. code-block:: cpp
 
@@ -164,12 +164,10 @@ In the code examples above, if you don't want to distinguish a name "Lemon" from
   enum class CakeTypeEnum {LEMON, BUNDT, POUND, enum_count};
   const std::vector<std::string> cakeTypeNames {"Lemon", "Bundt", "Pound"};
   // optional typedef
-  typedef EnumeratedString<CakeEnumType, &cakeTypeNames, &CompareStringsCaseInsensitive> CAKETYPE;
+  typedef EnumeratedString<CakeEnumType, &cakeTypeNames, &compareStringsCaseInsensitive> CAKETYPE;
   } // namespace
 
-This might be useful, for example, if you need to enumerate some file name extensions and treat ".cpp" the same way as ".CPP".
-
-You can also provide your own string comparator like ``firstLetterComparator`` below:
+You can also provide your own string comparator like ``firstLetterComparator`` shown below:
 
 .. code-block:: cpp
 
@@ -178,11 +176,12 @@ You can also provide your own string comparator like ``firstLetterComparator`` b
   namespace Mantid {
 
   namespace {
-  bool firstLetterComparator(const std::string &x, const std::string &y) { return x[0] == y[0]; }
+  std::function<bool(const std::string &, const std::string &)> firstLetterComparator =
+    [](const std::string &x, const std::string &y) { return x[0] == y[0]; };
   enum class CakeTypeEnum {L, B, P, enum_count};
   const std::vector<std::string> cakeTypeFirstLetters {"L", "B", "P"};
   // optional typedef
   typedef EnumeratedString<CakeEnumType, &cakeTypeFirstLetters, &firstLetterComparator> CAKETYPE;
   } // namespace
 
-in which case a "Lemon" cake will get the same enumeration as a "Lime" cake.
+in which case a "Lemon" cake will get the same ``enum`` value as a "Lime" cake.


### PR DESCRIPTION
**Description of work**

The current implementation of `EnumeratedString` uses case-sensitive string comparison. There are cases, however, when a case-insensitive or another, client-defined, method of string comparison may be necessary.  For example, many Mantid algorithms use `if/else` logic to perform operations based on the input file name extension.  In this case being able to enumerate all valid file name extensions in a case-insensitive fashion and use them in a `switch` statement would come in handy. 

**Summary of work**

- Implemented an optional template argument for `EnumeratedString` class: a pointer to a string comparison `std::function`. 
- Provided two statically-defined string comparison functions: case-sensitive (default) and case-insensitive
- Implemented a unit test for case-insensitive string comparison and a unit test for a client-defined string comparator 
- Updated `EnumeratedString` documentation
- Made minor improvements to `EnumeratedString` implementation:
   removed unnecessary try/catch blocks
   prevented unnecessary string copying


<!-- Please provide a short, high level description of the work that was done.
-->

**To test:**

ctest -R EnumeratedStringTest

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

**This PR does not require release notes because it does not impact user experience.**

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.