### PR TITLE
Add new GenerateGoniometerIndependentBackground algorithm

### DIFF
--- a/Framework/Algorithms/CMakeLists.txt
+++ b/Framework/Algorithms/CMakeLists.txt
@@ -156,6 +156,7 @@ set(SRC_FILES
     src/FlatPlateAbsorption.cpp
     src/GeneralisedSecondDifference.cpp
     src/GenerateEventsFilter.cpp
+    src/GenerateGoniometerIndependentBackground.cpp
     src/GenerateIPythonNotebook.cpp
     src/GeneratePeaks.cpp
     src/GeneratePythonFitScript.cpp
@@ -501,6 +502,7 @@ set(INC_FILES
     inc/MantidAlgorithms/GSLFunctions.h
     inc/MantidAlgorithms/GeneralisedSecondDifference.h
     inc/MantidAlgorithms/GenerateEventsFilter.h
+    inc/MantidAlgorithms/GenerateGoniometerIndependentBackground.h
     inc/MantidAlgorithms/GenerateIPythonNotebook.h
     inc/MantidAlgorithms/GeneratePeaks.h
     inc/MantidAlgorithms/GeneratePythonFitScript.h
@@ -857,6 +859,7 @@ set(TEST_FILES
     FlatPlateAbsorptionTest.h
     GeneralisedSecondDifferenceTest.h
     GenerateEventsFilterTest.h
+    GenerateGoniometerIndependentBackgroundTest.h
     GenerateIPythonNotebookTest.h
     GeneratePeaksTest.h
     GeneratePythonFitScriptTest.h

--- a/Framework/Algorithms/inc/MantidAlgorithms/GenerateGoniometerIndependentBackground.h
+++ b/Framework/Algorithms/inc/MantidAlgorithms/GenerateGoniometerIndependentBackground.h
@@ -1,0 +1,34 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2023 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#pragma once
+
+#include "MantidAPI/Algorithm.h"
+#include "MantidAlgorithms/DllConfig.h"
+#include "MantidDataObjects/EventList.h"
+
+namespace Mantid {
+namespace Algorithms {
+
+/** GenerateGoniometerIndependentBackground : TODO: DESCRIPTION
+ */
+class MANTID_ALGORITHMS_DLL GenerateGoniometerIndependentBackground : public API::Algorithm {
+public:
+  const std::string name() const override;
+  int version() const override;
+  const std::string category() const override;
+  const std::string summary() const override;
+  std::map<std::string, std::string> validateInputs() override;
+
+private:
+  void init() override;
+  void exec() override;
+  template <class T>
+  void filterAndAddEvents(const std::vector<T> &events, Mantid::DataObjects::EventList &outSpec,
+                          const Mantid::API::EventType eventType, const double start, const double end);
+};
+} // namespace Algorithms
+} // namespace Mantid

--- a/Framework/Algorithms/src/GenerateGoniometerIndependentBackground.cpp
+++ b/Framework/Algorithms/src/GenerateGoniometerIndependentBackground.cpp
@@ -37,17 +37,21 @@ const std::string GenerateGoniometerIndependentBackground::name() const {
 int GenerateGoniometerIndependentBackground::version() const { return 1; }
 
 /// Algorithm's category for identification. @see Algorithm::category
-const std::string GenerateGoniometerIndependentBackground::category() const { return "TODO: FILL IN A CATEGORY"; }
+const std::string GenerateGoniometerIndependentBackground::category() const {
+  return "CorrectionFunctions\\BackgroundCorrections";
+}
 
 /// Algorithm's summary for use in the GUI and help. @see Algorithm::summary
-const std::string GenerateGoniometerIndependentBackground::summary() const { return "TODO: FILL IN A SUMMARY"; }
+const std::string GenerateGoniometerIndependentBackground::summary() const {
+  return "Extract the background from a dataset where sample is rotated through multiple positions";
+}
 
 //----------------------------------------------------------------------------------------------
 /** Initialize the algorithm's properties.
  */
 void GenerateGoniometerIndependentBackground::init() {
   declareProperty(std::make_unique<ArrayProperty<std::string>>("InputWorkspaces", std::make_shared<ADSValidator>()),
-                  "Input workspaces");
+                  "Input workspaces. Must be :ref:`EventWorkspace` and have at least 2 input workspaces.");
 
   const std::vector<std::string> exts{".map", ".xml"};
   declareProperty(
@@ -55,13 +59,13 @@ void GenerateGoniometerIndependentBackground::init() {
       "A file that consists of lists of spectra numbers to group. To be read by :ref:`algm-LoadDetectorsGroupingFile`");
 
   declareProperty("PercentMin", 0.0, std::make_shared<BoundedValidator<double>>(0, 99.9),
-                  "Percentage of input files that will be combined to create the background");
+                  "Starting percentage range of input files that will be combined to create the background");
 
   declareProperty("PercentMax", 20.0, std::make_shared<BoundedValidator<double>>(0.1, 100),
-                  "Percentage of input files that will be combined to create the background");
+                  "Ending percentage range of input files that will be combined to create the background");
 
   declareProperty(std::make_unique<WorkspaceProperty<EventWorkspace>>("OutputWorkspace", "", Direction::Output),
-                  "An output workspace.");
+                  "Extracted background workspace.");
 }
 
 std::map<std::string, std::string> GenerateGoniometerIndependentBackground::validateInputs() {

--- a/Framework/Algorithms/src/GenerateGoniometerIndependentBackground.cpp
+++ b/Framework/Algorithms/src/GenerateGoniometerIndependentBackground.cpp
@@ -182,9 +182,7 @@ void GenerateGoniometerIndependentBackground::exec() {
   alg->executeAsChildAlg();
   GroupingWorkspace_sptr groupWS = alg->getProperty("OutputWorkspace");
 
-  const size_t numGroups = groupWS->getTotalGroups();
-
-  Progress progress(this, 0.0, 1.0, numInputs + numGroups);
+  Progress progress(this, 0.0, 1.0, numInputs + groupWS->getTotalGroups());
 
   std::vector<MatrixWorkspace_sptr> grouped_inputs;
   // Run GroupDetectors on all the input workspaces
@@ -204,6 +202,7 @@ void GenerateGoniometerIndependentBackground::exec() {
   }
 
   // all spectra for all input workspaces have same binning
+  const size_t numGroups = grouped_inputs.front()->getNumberHistograms();
   const auto blocksize = grouped_inputs.front()->blocksize();
   const auto Xvalues = grouped_inputs.front()->readX(0);
 

--- a/Framework/Algorithms/src/GenerateGoniometerIndependentBackground.cpp
+++ b/Framework/Algorithms/src/GenerateGoniometerIndependentBackground.cpp
@@ -1,0 +1,275 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2023 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+
+#include "MantidAlgorithms/GenerateGoniometerIndependentBackground.h"
+#include "MantidAPI/ADSValidator.h"
+#include "MantidAPI/AnalysisDataService.h"
+#include "MantidAPI/FileProperty.h"
+#include "MantidAPI/Run.h"
+#include "MantidAlgorithms/RunCombinationHelpers/RunCombinationHelper.h"
+#include "MantidDataObjects/EventWorkspace.h"
+#include "MantidDataObjects/GroupingWorkspace.h"
+#include "MantidDataObjects/WorkspaceCreation.h"
+#include "MantidKernel/ArrayProperty.h"
+#include "MantidKernel/BoundedValidator.h"
+
+namespace Mantid {
+namespace Algorithms {
+using namespace API;
+using namespace Kernel;
+using namespace DataObjects;
+
+// Register the algorithm into the AlgorithmFactory
+DECLARE_ALGORITHM(GenerateGoniometerIndependentBackground)
+
+//----------------------------------------------------------------------------------------------
+
+/// Algorithms name for identification. @see Algorithm::name
+const std::string GenerateGoniometerIndependentBackground::name() const {
+  return "GenerateGoniometerIndependentBackground";
+}
+
+/// Algorithm's version for identification. @see Algorithm::version
+int GenerateGoniometerIndependentBackground::version() const { return 1; }
+
+/// Algorithm's category for identification. @see Algorithm::category
+const std::string GenerateGoniometerIndependentBackground::category() const { return "TODO: FILL IN A CATEGORY"; }
+
+/// Algorithm's summary for use in the GUI and help. @see Algorithm::summary
+const std::string GenerateGoniometerIndependentBackground::summary() const { return "TODO: FILL IN A SUMMARY"; }
+
+//----------------------------------------------------------------------------------------------
+/** Initialize the algorithm's properties.
+ */
+void GenerateGoniometerIndependentBackground::init() {
+  declareProperty(std::make_unique<ArrayProperty<std::string>>("InputWorkspaces", std::make_shared<ADSValidator>()),
+                  "Input workspaces");
+
+  const std::vector<std::string> exts{".map", ".xml"};
+  declareProperty(
+      std::make_unique<FileProperty>("GroupingFile", "", FileProperty::Load, exts),
+      "A file that consists of lists of spectra numbers to group. To be read by :ref:`algm-LoadDetectorsGroupingFile`");
+
+  declareProperty("PercentMin", 0.0, std::make_shared<BoundedValidator<double>>(0, 99.9),
+                  "Percentage of input files that will be combined to create the background");
+
+  declareProperty("PercentMax", 20.0, std::make_shared<BoundedValidator<double>>(0.1, 100),
+                  "Percentage of input files that will be combined to create the background");
+
+  declareProperty(std::make_unique<WorkspaceProperty<EventWorkspace>>("OutputWorkspace", "", Direction::Output),
+                  "An output workspace.");
+}
+
+std::map<std::string, std::string> GenerateGoniometerIndependentBackground::validateInputs() {
+  std::map<std::string, std::string> issues;
+  const std::vector<std::string> inputs = RunCombinationHelper::unWrapGroups(getProperty("InputWorkspaces"));
+
+  const double percentMin = getProperty("PercentMin");
+  const double percentMax = getProperty("PercentMax");
+
+  if (percentMin >= percentMax) {
+    issues["PercentMin"] = "PercentMin must be less than PercentMax";
+    issues["PercentMax"] = "PercentMin must be less than PercentMax";
+  }
+
+  if (inputs.size() < 2) {
+    issues["InputWorkspaces"] = "Requires at least 2 input workspaces";
+    return issues;
+  }
+
+  EventWorkspace_const_sptr firstWS = AnalysisDataService::Instance().retrieveWS<EventWorkspace>(inputs.front());
+
+  if (!firstWS) {
+    issues["InputWorkspaces"] = "Workspace \"" + inputs.front() + "\" is not an EventWorkspace";
+    return issues;
+  }
+
+  if (!firstWS->isCommonBins()) {
+    issues["InputWorkspaces"] = "Workspaces require common bins.";
+    return issues;
+  }
+
+  const auto numHist = firstWS->getNumberHistograms();
+  const auto blocksize = firstWS->blocksize();
+  const auto eventType = firstWS->getEventType();
+  const auto instrumentName = firstWS->getInstrument()->getName();
+  double protonChargeMin = firstWS->run().getProtonCharge();
+  double protonChargeMax = firstWS->run().getProtonCharge();
+
+  for (const auto &input : inputs) {
+    EventWorkspace_const_sptr ws = AnalysisDataService::Instance().retrieveWS<EventWorkspace>(input);
+    if (!ws) {
+      issues["InputWorkspaces"] = "Workspace \"" + input + "\" is not an EventWorkspace";
+      break;
+    }
+
+    if (ws->getNumberHistograms() != numHist) {
+      issues["InputWorkspaces"] = "Number of spectra mismatch.";
+      break;
+    }
+
+    if (!ws->isCommonBins()) {
+      issues["InputWorkspaces"] = "Workspaces require common bins.";
+      return issues;
+    }
+
+    if (ws->blocksize() != blocksize) {
+      issues["InputWorkspaces"] = "Size mismatch.";
+      break;
+    }
+
+    if (ws->getEventType() != eventType) {
+      issues["InputWorkspaces"] = "Mismatched type of events in the EventWorkspaces.";
+      break;
+    }
+
+    if (ws->getInstrument()->getName() != instrumentName) {
+      issues["InputWorkspaces"] = "Instrument name mismatch.";
+      break;
+    }
+
+    protonChargeMin = std::min(ws->run().getProtonCharge(), protonChargeMin);
+    protonChargeMax = std::max(ws->run().getProtonCharge(), protonChargeMax);
+  }
+
+  if (issues.count("InputWorkspaces") == 0 && protonChargeMin > 0 &&
+      (protonChargeMax - protonChargeMin) / protonChargeMin > 0.01)
+    issues["InputWorkspaces"] = "Proton charge must not vary more than 1%";
+
+  return issues;
+}
+
+//----------------------------------------------------------------------------------------------
+/** Execute the algorithm.
+ */
+void GenerateGoniometerIndependentBackground::exec() {
+
+  const std::vector<std::string> inputs = RunCombinationHelper::unWrapGroups(getProperty("InputWorkspaces"));
+  std::vector<EventWorkspace_const_sptr> inputWS;
+
+  for (const auto &input : inputs) {
+    EventWorkspace_const_sptr ws = AnalysisDataService::Instance().retrieveWS<EventWorkspace>(input);
+    ws->sortAll(TOF_SORT, nullptr);
+    inputWS.push_back(ws);
+  }
+
+  // create output workspace
+  EventWorkspace_sptr outputWS = create<EventWorkspace>(*inputWS.front());
+
+  // Calculate number of workspaces to use for background
+  const auto numInputs = inputWS.size();
+
+  const double percentMin = getProperty("PercentMin");
+  const auto minN = (size_t)(percentMin / 100 * (double)numInputs);
+
+  const double percentMax = getProperty("PercentMax");
+  const auto maxN = std::max(minN + 1, (size_t)(percentMax / 100 * (double)numInputs));
+
+  g_log.information() << "background will use " << maxN - minN << " out of a total of " << inputWS.size()
+                      << " workspaces starting from " << minN << "\n";
+
+  auto alg = createChildAlgorithm("LoadDetectorsGroupingFile");
+  alg->setProperty("InputFile", getPropertyValue("GroupingFile"));
+  alg->setProperty("InputWorkspace", inputs.front());
+  alg->executeAsChildAlg();
+  GroupingWorkspace_sptr groupWS = alg->getProperty("OutputWorkspace");
+
+  const size_t numGroups = groupWS->getTotalGroups();
+
+  Progress progress(this, 0.0, 1.0, numInputs + numGroups);
+
+  std::vector<MatrixWorkspace_sptr> grouped_inputs;
+  // Run GroupDetectors on all the input workspaces
+  for (auto &input : inputs) {
+    const auto msg = "Running GroupDetectors on " + input;
+    progress.report(msg);
+    g_log.debug(msg);
+
+    auto group = createChildAlgorithm("GroupDetectors");
+    group->setPropertyValue("InputWorkspace", input);
+    group->setProperty("CopyGroupingFromWorkspace", groupWS);
+    group->executeAsChildAlg();
+
+    MatrixWorkspace_sptr output = group->getProperty("OutputWorkspace");
+
+    grouped_inputs.push_back(output);
+  }
+
+  // all spectra for all input workspaces have same binning
+  const auto blocksize = grouped_inputs.front()->blocksize();
+  const auto Xvalues = grouped_inputs.front()->readX(0);
+
+  for (size_t group = 0; group < numGroups; group++) {
+    const auto msg = "Processing group " + std::to_string(group) + " out of " + std::to_string(numGroups);
+    progress.report(msg);
+    g_log.debug(msg);
+
+    // detectors IDs for this group
+    const auto detIDlist = grouped_inputs.front()->getSpectrum(group).getDetectorIDs();
+    const std::vector<detid_t> detIDlistV(detIDlist.begin(), detIDlist.end());
+    // spectrum from the detector IDs
+    const auto indexList = inputWS.at(0)->getIndicesFromDetectorIDs(detIDlistV);
+
+    for (size_t x = 0; x < blocksize; x++) {
+      // create pair of intensity and input index to sort for every bin in this group
+      std::vector<std::pair<double, size_t>> intensity_input_map;
+      for (size_t f = 0; f < numInputs; f++) {
+        intensity_input_map.push_back(std::make_pair(grouped_inputs.at(f)->readY(group).at(x), f));
+      }
+
+      std::sort(intensity_input_map.begin(), intensity_input_map.end());
+
+      const auto start = Xvalues.at(x);
+      const auto end = Xvalues.at(x + 1);
+
+      for (size_t n = minN; n < maxN; n++) {
+        const auto inWS = inputWS.at(intensity_input_map.at(n).second);
+
+        for (auto &idx : indexList) {
+          const auto el = inWS->getSpectrum(idx);
+          auto &outSpec = outputWS->getSpectrum(idx);
+
+          switch (el.getEventType()) {
+          case TOF:
+            filterAndAddEvents(el.getEvents(), outSpec, TOF, start, end);
+            break;
+          case WEIGHTED:
+            filterAndAddEvents(el.getWeightedEvents(), outSpec, WEIGHTED, start, end);
+            break;
+          case WEIGHTED_NOTIME:
+            filterAndAddEvents(el.getWeightedEventsNoTime(), outSpec, WEIGHTED_NOTIME, start, end);
+            break;
+          }
+        }
+      }
+    }
+  }
+
+  // scale output by number of workspaces used for the background
+  outputWS /= (double)(maxN - minN);
+
+  g_log.debug() << "Output workspace has " << outputWS->getNumberEvents() << " events\n";
+
+  setProperty("OutputWorkspace", std::move(outputWS));
+}
+
+template <class T>
+void GenerateGoniometerIndependentBackground::filterAndAddEvents(const std::vector<T> &events, EventList &outSpec,
+                                                                 const EventType eventType, const double start,
+                                                                 const double end) {
+  outSpec.switchTo(eventType);
+  for (auto &event : events) {
+    if (event.tof() >= end)
+      break;
+
+    if (event.tof() >= start)
+      outSpec.addEventQuickly(event);
+  }
+}
+
+} // namespace Algorithms
+} // namespace Mantid

--- a/Framework/Algorithms/test/GenerateGoniometerIndependentBackgroundTest.h
+++ b/Framework/Algorithms/test/GenerateGoniometerIndependentBackgroundTest.h
@@ -1,0 +1,210 @@
+// Mantid Repository : https://github.com/mantidproject/mantid
+//
+// Copyright &copy; 2023 ISIS Rutherford Appleton Laboratory UKRI,
+//   NScD Oak Ridge National Laboratory, European Spallation Source,
+//   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
+// SPDX - License - Identifier: GPL - 3.0 +
+#pragma once
+
+#include <cxxtest/TestSuite.h>
+
+#include "MantidAPI/AlgorithmManager.h"
+#include "MantidAPI/AnalysisDataService.h"
+#include "MantidAlgorithms/GenerateGoniometerIndependentBackground.h"
+#include "MantidDataObjects/EventWorkspace.h"
+#include <Poco/File.h>
+
+using Mantid::Algorithms::GenerateGoniometerIndependentBackground;
+
+class GenerateGoniometerIndependentBackgroundTest : public CxxTest::TestSuite {
+public:
+  // This pair of boilerplate methods prevent the suite being created statically
+  // This means the constructor isn't called when running other tests
+  static GenerateGoniometerIndependentBackgroundTest *createSuite() {
+    return new GenerateGoniometerIndependentBackgroundTest();
+  }
+  static void destroySuite(GenerateGoniometerIndependentBackgroundTest *suite) { delete suite; }
+
+  void setUp() override {
+    createSyntheticWS(1000, "ws1");
+    createSyntheticWS(2000, "ws2");
+    createSyntheticWS(3000, "ws3");
+    createSyntheticWS(4000, "ws4");
+    createSyntheticWS(1000, "histogram", "Histogram");
+    createSyntheticWS(4000, "highPC", "Event", 1, 10000., "100.0");
+    createSyntheticWS(4000, "diffInstrument", "Event", 1, 10000., "10.0", "somethingDifferent");
+    createSyntheticWS(4000, "diffNumHist", "Event", 2, 10000.);
+    createSyntheticWS(4000, "diffNumBins", "Event", 1, 1000.);
+
+    auto create = Mantid::API::AlgorithmManager::Instance().create("CreateGroupingWorkspace");
+    create->initialize();
+    create->setProperty("InputWorkspace", "ws1");
+    create->setProperty("GroupDetectorsBy", "bank");
+    create->setProperty("OutputWorkspace", "groups");
+    create->execute();
+
+    auto saveGrouping = Mantid::API::AlgorithmManager::Instance().create("SaveDetectorsGrouping");
+    saveGrouping->initialize();
+    saveGrouping->setProperty("InputWorkspace", "groups");
+    saveGrouping->setProperty("OutputFile", "groups.xml");
+    saveGrouping->execute();
+  }
+
+  void tearDown() override {
+    Mantid::API::AnalysisDataService::Instance().clear();
+    if (Poco::File("groups.xml").exists())
+      Poco::File("groups.xml").remove();
+  }
+
+  void test_exec() {
+    // for reference the intensity in each bin for each workspace is
+    // ws1 500
+    // ws2 1000
+    // ws3 1500
+    // ws4 2000
+
+    runTest(std::vector<std::string>({"ws1", "ws2", "ws3", "ws4"}), 0., 1., 500.);     // ws1
+    runTest(std::vector<std::string>({"ws1", "ws2", "ws3", "ws4"}), 0., 50., 750.);    // (ws1+ws2)/2
+    runTest(std::vector<std::string>({"ws1", "ws2", "ws3", "ws4"}), 0., 75., 1000.);   // (ws1+ws2+ws3)/3
+    runTest(std::vector<std::string>({"ws1", "ws2", "ws3", "ws4"}), 0., 100., 1250.);  // (ws1+ws2+ws3+ws4)/4
+    runTest(std::vector<std::string>({"ws1", "ws2", "ws3", "ws4"}), 50., 100., 1750.); // (ws3+ws4)/2
+    runTest(std::vector<std::string>({"ws1", "ws2", "ws3", "ws4"}), 99., 100., 2000.); // ws4
+    runTest(std::vector<std::string>({"ws1", "ws2", "ws3", "ws4"}), 25., 75., 1250.);  // (ws2+ws3)/2
+    runTest(std::vector<std::string>({"ws1", "ws2"}), 23., 24., 500.);                 // ws1
+    runTest(std::vector<std::string>({"ws1", "ws2"}), 67., 68., 1000.);                // ws2
+  }
+
+  void test_input_workspace_number() {
+    GenerateGoniometerIndependentBackground alg;
+    TS_ASSERT_THROWS_NOTHING(alg.initialize())
+    TS_ASSERT(alg.isInitialized())
+
+    auto issues = alg.validateInputs();
+    TS_ASSERT_EQUALS(issues.size(), 1)
+    TS_ASSERT_EQUALS(issues["InputWorkspaces"], "Requires at least 2 input workspaces")
+
+    // single input workspace
+    alg.setProperty("InputWorkspaces", std::vector<std::string>({"ws1"}));
+    issues = alg.validateInputs();
+    TS_ASSERT_EQUALS(issues.size(), 1)
+    TS_ASSERT_EQUALS(issues["InputWorkspaces"], "Requires at least 2 input workspaces")
+
+    // two workspaces should have no issues
+    alg.setProperty("InputWorkspaces", std::vector<std::string>({"ws1", "ws2"}));
+    issues = alg.validateInputs();
+    TS_ASSERT_EQUALS(issues.size(), 0)
+  }
+
+  void test_input_different_proton_charge() {
+    GenerateGoniometerIndependentBackground alg;
+    TS_ASSERT_THROWS_NOTHING(alg.initialize())
+    TS_ASSERT(alg.isInitialized())
+    alg.setProperty("InputWorkspaces", std::vector<std::string>({"ws1", "highPC"}));
+
+    auto issues = alg.validateInputs();
+    TS_ASSERT_EQUALS(issues.size(), 1)
+    TS_ASSERT_EQUALS(issues["InputWorkspaces"], "Proton charge must not vary more than 1%")
+  }
+
+  void test_input_different_num_histograms() {
+    GenerateGoniometerIndependentBackground alg;
+    TS_ASSERT_THROWS_NOTHING(alg.initialize())
+    TS_ASSERT(alg.isInitialized())
+    alg.setProperty("InputWorkspaces", std::vector<std::string>({"ws1", "diffNumHist"}));
+
+    auto issues = alg.validateInputs();
+    TS_ASSERT_EQUALS(issues.size(), 1)
+    TS_ASSERT_EQUALS(issues["InputWorkspaces"], "Number of spectra mismatch.")
+  }
+
+  void test_input_different_num_bins() {
+    GenerateGoniometerIndependentBackground alg;
+    TS_ASSERT_THROWS_NOTHING(alg.initialize())
+    TS_ASSERT(alg.isInitialized())
+    alg.setProperty("InputWorkspaces", std::vector<std::string>({"ws1", "diffNumBins"}));
+
+    auto issues = alg.validateInputs();
+    TS_ASSERT_EQUALS(issues.size(), 1)
+    TS_ASSERT_EQUALS(issues["InputWorkspaces"], "Size mismatch.")
+  }
+
+  void test_input_different_instrument() {
+    GenerateGoniometerIndependentBackground alg;
+    TS_ASSERT_THROWS_NOTHING(alg.initialize())
+    TS_ASSERT(alg.isInitialized())
+    alg.setProperty("InputWorkspaces", std::vector<std::string>({"ws1", "diffInstrument"}));
+
+    auto issues = alg.validateInputs();
+    TS_ASSERT_EQUALS(issues.size(), 1)
+    TS_ASSERT_EQUALS(issues["InputWorkspaces"], "Instrument name mismatch.")
+  }
+
+  void test_input_not_event_workspace() {
+    GenerateGoniometerIndependentBackground alg;
+    TS_ASSERT_THROWS_NOTHING(alg.initialize())
+    TS_ASSERT(alg.isInitialized())
+    alg.setProperty("InputWorkspaces", std::vector<std::string>({"ws1", "histogram"}));
+
+    auto issues = alg.validateInputs();
+    TS_ASSERT_EQUALS(issues.size(), 1)
+    TS_ASSERT_EQUALS(issues["InputWorkspaces"], "Workspace \"histogram\" is not an EventWorkspace")
+  }
+
+  void test_min_greater_than_max() {
+    GenerateGoniometerIndependentBackground alg;
+    TS_ASSERT_THROWS_NOTHING(alg.initialize())
+    TS_ASSERT(alg.isInitialized())
+    alg.setProperty("InputWorkspaces", std::vector<std::string>({"ws1", "ws2"}));
+    alg.setProperty("PercentMin", 75.);
+    alg.setProperty("PercentMax", 25.);
+
+    auto issues = alg.validateInputs();
+    TS_ASSERT_EQUALS(issues.size(), 2)
+    TS_ASSERT_EQUALS(issues["PercentMin"], "PercentMin must be less than PercentMax")
+    TS_ASSERT_EQUALS(issues["PercentMax"], "PercentMin must be less than PercentMax")
+  }
+
+private:
+  void createSyntheticWS(const int numEvents, const std::string wsname, const std::string workspaceType = "Event",
+                         const int bankPixelWidth = 1, const double binWidth = 10000,
+                         const std::string protonCharge = "10.0", const std::string instrumentName = "fake") const {
+    auto create = Mantid::API::AlgorithmManager::Instance().create("CreateSampleWorkspace");
+    create->initialize();
+    create->setPropertyValue("WorkspaceType", workspaceType);
+    create->setPropertyValue("Function", "Flat background");
+    create->setProperty("NumBanks", 2);
+    create->setProperty("BankPixelWidth", bankPixelWidth);
+    create->setProperty("BinWidth", binWidth);
+    create->setProperty("NumEvents", numEvents);
+    create->setProperty("InstrumentName", instrumentName);
+    create->setPropertyValue("OutputWorkspace", wsname);
+    create->execute();
+
+    auto addLog = Mantid::API::AlgorithmManager::Instance().create("AddSampleLog");
+    addLog->initialize();
+    addLog->setProperty("Workspace", wsname);
+    addLog->setProperty("LogName", "gd_prtn_chrg");
+    addLog->setProperty("LogText", protonCharge);
+    addLog->setProperty("LogType", "Number");
+    addLog->execute();
+  }
+
+  void runTest(const std::vector<std::string> inputWS, const double percentMin, const double percentMax,
+               const double expectedResult) const {
+    GenerateGoniometerIndependentBackground alg;
+    TS_ASSERT_THROWS_NOTHING(alg.initialize())
+    TS_ASSERT(alg.isInitialized())
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("InputWorkspaces", inputWS))
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("GroupingFile", "groups.xml"))
+    TS_ASSERT_THROWS_NOTHING(alg.setPropertyValue("OutputWorkspace", "result"))
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("PercentMin", percentMin))
+    TS_ASSERT_THROWS_NOTHING(alg.setProperty("PercentMax", percentMax))
+    TS_ASSERT_THROWS_NOTHING(alg.execute())
+    TS_ASSERT(alg.isExecuted())
+
+    Mantid::DataObjects::EventWorkspace_sptr result =
+        Mantid::API::AnalysisDataService::Instance().retrieveWS<Mantid::DataObjects::EventWorkspace>("result");
+    TS_ASSERT(result)
+    TS_ASSERT_DELTA(result->readY(0).at(0), expectedResult, 1e-4)
+  }
+};

--- a/docs/source/algorithms/GenerateGoniometerIndependentBackground-v1.rst
+++ b/docs/source/algorithms/GenerateGoniometerIndependentBackground-v1.rst
@@ -1,0 +1,46 @@
+
+.. algorithm::
+
+.. summary::
+
+.. relatedalgorithms::
+
+.. properties::
+
+Description
+-----------
+
+TODO: Enter a full rst-markup description of your algorithm here.
+
+
+Usage
+-----
+..  Try not to use files in your examples,
+    but if you cannot avoid it then the (small) files must be added to
+    autotestdata\UsageData and the following tag unindented
+    .. include:: ../usagedata-note.txt
+
+**Example - GenerateGoniometerIndependentBackground**
+
+.. testcode:: GenerateGoniometerIndependentBackgroundExample
+
+   # Create a host workspace
+   ws = CreateWorkspace(DataX=range(0,3), DataY=(0,2))
+   or
+   ws = CreateSampleWorkspace()
+
+   wsOut = GenerateGoniometerIndependentBackground()
+
+   # Print the result
+   print "The output workspace has %%i spectra" %% wsOut.getNumberHistograms()
+
+Output:
+
+.. testoutput:: GenerateGoniometerIndependentBackgroundExample
+
+  The output workspace has ?? spectra
+
+.. categories::
+
+.. sourcelink::
+

--- a/docs/source/algorithms/GenerateGoniometerIndependentBackground-v1.rst
+++ b/docs/source/algorithms/GenerateGoniometerIndependentBackground-v1.rst
@@ -10,7 +10,11 @@
 Description
 -----------
 
-TODO: Enter a full rst-markup description of your algorithm here.
+This algorithm will extract the background from a dataset where sample is rotated through multiple positions, so that I don't need to make a separate background measurement.
+
+This algorithm requires at least 2 input :ref:`EventWorkspace` that are all binned identically. The proton charge of the workspaces are check to be within 1% of each other as this algorithm assume all the data was collected in the same conditions.
+
+This algorithm operates by first grouping the detectors of the input workspaces with the provided ``GroupingFile``.  Then iterating through each bin of each spectra of the grouped workspaces, selecting the range (defined by ``PercentMin`` and ``PercentMax`` properties) of workspaces sorted by intensity for that bin, copying the events from the associated ungrouped input to the output workspace. The output is then normalized by the number of input workspaces selected.
 
 
 Usage
@@ -24,21 +28,36 @@ Usage
 
 .. testcode:: GenerateGoniometerIndependentBackgroundExample
 
-   # Create a host workspace
-   ws = CreateWorkspace(DataX=range(0,3), DataY=(0,2))
-   or
-   ws = CreateSampleWorkspace()
+  # create 4 sample workspaces with different intensities
+  for n in range(1,5):
+      ws = CreateSampleWorkspace(WorkspaceType='Event', Function='Flat background', BinWidth=10000, NumEvents=n*1000, NumBanks=2, BankPixelWidth=1, OutputWorkspace=f"w{n}")
+      print(f"Input workspace w{n} intensity = ", ws.readY(0))
 
-   wsOut = GenerateGoniometerIndependentBackground()
+  # create a grouping workspace, group by bank
+  CreateGroupingWorkspace(InputWorkspace='w1', GroupDetectorsBy='bank', OutputWorkspace='groups')
+  SaveDetectorsGrouping("groups", "/tmp/groups.xml")
 
-   # Print the result
-   print "The output workspace has %%i spectra" %% wsOut.getNumberHistograms()
+  # select only the lowest 25% intensity workspaces
+  background = GenerateGoniometerIndependentBackground('w1,w2,w3,w4', GroupingFile="/tmp/groups.xml", PercentMin=0, PercentMax=25)
+  print("Background intensity, lowest 25% =", background.readY(0))
+  # select only the highest 25% intensity workspaces
+  background = GenerateGoniometerIndependentBackground('w1,w2,w3,w4', GroupingFile="/tmp/groups.xml", PercentMin=75, PercentMax=100)
+  print("Background intensity, highest 25% =", background.readY(0))
+  # select only the middle 50%intensity workspaces
+  background = GenerateGoniometerIndependentBackground('w1,w2,w3,w4', GroupingFile="/tmp/groups.xml", PercentMin=25, PercentMax=75)
+  print("Background intensity, middle 50% =", background.readY(0))
 
 Output:
 
 .. testoutput:: GenerateGoniometerIndependentBackgroundExample
 
-  The output workspace has ?? spectra
+  Input workspace w1 intensity =  [ 500.  500.]
+  Input workspace w2 intensity =  [ 1000.  1000.]
+  Input workspace w3 intensity =  [ 1500.  1500.]
+  Input workspace w4 intensity =  [ 2000.  2000.]
+  Background intensity, lowest 25% = [ 500.  500.]
+  Background intensity, highest 25% = [ 2000.  2000.]
+  Background intensity, middle 50% = [ 1250.  1250.]
 
 .. categories::
 

--- a/docs/source/release/v6.8.0/Framework/Algorithms/New_features/35971.rst
+++ b/docs/source/release/v6.8.0/Framework/Algorithms/New_features/35971.rst
@@ -1,0 +1,1 @@
+- New algorithm :ref:`GenerateGoniometerIndependentBackground <algm-GenerateGoniometerIndependentBackground>` extract the background from a dataset where sample is rotated through multiple positions.


### PR DESCRIPTION
**Description of work**

Extract background from multi-angle dataset

[899](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=899)

**Purpose of work**
<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
-->

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**Summary of work**
<!-- Please provide a short, high level description of the work that was done.
-->

**Further detail of work**
<!-- Please provide a more detailed description of the work that has been undertaken.
-->


**To test:**

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

Requires SNS data

```python
from mantid.simpleapi import *
inputdir='/SNS/SEQ/IPTS-22120/nexus/'
outputdir='/tmp/'
runs=range(263341,263518+1)    # SEQ 5 K @ 100 meV, 0 Tesla

# Load run numbers to group
for r in runs:
    LoadEventNexus(Filename=inputdir+f'SEQ_{r}.nxs.h5',OutputWorkspace=f'SEQ_{r}.nxs')
ws_ev = GroupWorkspaces(GlobExpression='SEQ_[0-9]*.nxs')

Ei=99.30775803401971
T0=29.72685640862497

ws,_=DgsReduction(SampleInputWorkspace=ws_ev,
                              SampleInputMonitorWorkspace=ws_ev,
                              IncidentEnergyGuess=Ei,
                              TimeZeroGuess=T0,
                              UseIncidentEnergyGuess=True,
                              IncidentBeamNormalisation='None',
                              EnergyTransferRange='{0},{1},{2}'.format(-0.51*Ei,0.02*Ei,0.95*Ei),
                              TimeIndepBackgroundSub=False,
                              CorrectKiKf=True,
                              SofPhiEIsDistribution=False)
# Generate grouping #
wsg=PreprocessDetectorsToMD(ws[0])
tt=np.degrees(wsg.column('TwoTheta'))
phi=np.degrees(wsg.column('Azimuthal'))
detID=wsg.column('DetectorID')

tt_step=5
phi_step=10

tt_nsteps=int(np.ceil((tt.max()-tt.min())/tt_step))
phi_nsteps=int(np.ceil((phi.max()-phi.min())/phi_step))


det_group_list=[[[] for i in range(phi_nsteps)] for j in range(tt_nsteps)]
for t,p,d in zip(tt,phi,detID):
    ind_tt=int(np.floor((t-tt.min())/tt_step))
    ind_phi=int(np.floor((p-phi.min())/phi_step))
    det_group_list[ind_tt][ind_phi].append(d)

# Save a .xml for the grouping and use only groups with detector pixels
detlist=[]
with open(outputdir+'SEQ_group_{0}x{1}.xml'.format(tt_step,phi_step),'wt+') as f:
    f.write('<?xml version="1.0" encoding="UTF-8" ?>\n<detector-grouping instrument="SEQUOIA">\n')
    det_group=-1
    for i in range(tt_nsteps):
        for j in range(phi_nsteps):
            dets=det_group_list[i][j]
            if len(dets)>0:
                detlist.append(dets)
                det_group+=1
                f.write('<group name="{}"><detids val="{}"/> </group>\n'.format(det_group,str(dets).lstrip('[').rstrip(']')))
    f.write('</detector-grouping>')

wsbkg = GenerateGoniometerIndependentBackground(ws,
                                                GroupingFile=outputdir+'SEQ_group_{0}x{1}.xml'.format(tt_step,phi_step),
                                                PercentMax=17 # this equals 30 workspace
)

#SaveNexus(InputWorkspace=wsbkg,Filename='bkg.nxs')
```


<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.