### PR TITLE
Fix crash in muon analysis fitting interface

### DIFF
--- a/docs/source/release/v6.8.0/Muon/Muon_Analysis/Bugfixes/35505.rst
+++ b/docs/source/release/v6.8.0/Muon/Muon_Analysis/Bugfixes/35505.rst
@@ -1,0 +1,1 @@
+- Fixed crash in the muon analysis GUI fitting interface when plotting a guess with multiple fitting functions.

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/fitting_widgets/basic_fitting/basic_fitting_model.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/fitting_widgets/basic_fitting/basic_fitting_model.py
@@ -6,7 +6,7 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 from mantid import AlgorithmManager, logger
 from mantid.api import CompositeFunction, IAlgorithm, IFunction
-from mantid.simpleapi import CopyLogs, EvaluateFunction
+from mantid.simpleapi import CopyLogs
 from mantidqtinterfaces.Muon.GUI.Common.ADSHandler.workspace_group_definition import add_list_to_group
 
 from mantidqtinterfaces.Muon.GUI.Common.ADSHandler.ADS_calls import check_if_workspace_exist, retrieve_ws, make_group
@@ -31,7 +31,7 @@ from mantidqtinterfaces.Muon.GUI.Common.contexts.fitting_contexts.basic_fitting_
 )
 from mantidqtinterfaces.Muon.GUI.Common.contexts.fitting_contexts.fitting_context import FitInformation
 from mantidqtinterfaces.Muon.GUI.Common.contexts.muon_context import MuonContext
-from mantidqtinterfaces.Muon.GUI.Common.utilities.algorithm_utils import run_Fit, run_create_workspace_without_storing
+from mantidqtinterfaces.Muon.GUI.Common.utilities.algorithm_utils import run_Fit, evaluate_function, run_create_workspace
 from mantidqtinterfaces.Muon.GUI.Common.utilities.run_string_utils import run_list_to_string
 from mantidqtinterfaces.Muon.GUI.Common.utilities.workspace_data_utils import check_exclude_start_and_end_x_is_valid, x_limits_of_workspace
 from mantidqtinterfaces.Muon.GUI.Common.utilities.workspace_utils import StaticWorkspaceWrapper
@@ -848,13 +848,12 @@ class BasicFittingModel:
         else:
             raise ValueError(f"Plot guess type '{self.fitting_context.plot_guess_type}' is not recognised.")
 
-        extended_workspace = run_create_workspace_without_storing(x_data=data, y_data=data, name="extended_workspace")
-
         try:
             if self._double_pulse_enabled():
                 self._evaluate_double_pulse_function(fit_function, output_workspace)
             else:
-                EvaluateFunction(InputWorkspace=extended_workspace, Function=fit_function, OutputWorkspace=output_workspace)
+                extended_workspace = run_create_workspace(x_data=data, y_data=data, name="extended_workspace")
+                evaluate_function(extended_workspace, fit_function, output_workspace)
         except RuntimeError:
             logger.error("Failed to plot guess.")
             return ""

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/utilities/algorithm_utils.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Muon/GUI/Common/utilities/algorithm_utils.py
@@ -425,3 +425,19 @@ def run_create_workspace_without_storing(x_data, y_data, name):
     alg.setProperty("OutputWorkspace", name)
     alg.execute()
     return alg.getProperty("OutputWorkspace").value
+
+
+def evaluate_function(input_ws_name: str, fun: str, out_ws_name: str):
+    """
+    Evaluates the guess workspace for the input workspace and function
+    :param input_ws_name: Name of the workspace in the ADS
+    :param fun: Function to be evaluated
+    :param out_ws_name: Output workspace name
+    """
+    mantid.AnalysisDataService.retrieve(input_ws_name)
+    alg = mantid.AlgorithmManager.createUnmanaged("EvaluateFunction")
+    alg.initialize()
+    alg.setProperty("Function", fun)
+    alg.setProperty("InputWorkspace", input_ws_name)
+    alg.setProperty("OutputWorkspace", out_ws_name)
+    alg.execute()

--- a/qt/python/mantidqtinterfaces/test/Muon/fitting_widgets/basic_fitting/basic_fitting_model_test.py
+++ b/qt/python/mantidqtinterfaces/test/Muon/fitting_widgets/basic_fitting/basic_fitting_model_test.py
@@ -507,15 +507,15 @@ class BasicFittingModelTest(unittest.TestCase):
         self.model._double_pulse_enabled = mock.Mock(return_value=False)
         self.model._get_plot_guess_name = mock.Mock(return_value=guess_workspace_name)
         with mock.patch(
-            "mantidqtinterfaces.Muon.GUI.Common.fitting_widgets.basic_fitting." "basic_fitting_model.EvaluateFunction"
+            "mantidqtinterfaces.Muon.GUI.Common.fitting_widgets.basic_fitting.basic_fitting_model.evaluate_function", autospec=True
         ) as mock_evaluate:
             self.model._get_guess_parameters = mock.Mock(return_value=["func", "ws"])
             self.model.update_plot_guess()
             mock_evaluate.assert_called_with(
-                InputWorkspace=mock.ANY, Function=self.model.current_single_fit_function, OutputWorkspace=guess_workspace_name
+                input_ws_name=mock.ANY, fun=self.model.current_single_fit_function, out_ws_name=guess_workspace_name
             )
 
-    @mock.patch("mantidqtinterfaces.Muon.GUI.Common.fitting_widgets.basic_fitting.basic_fitting_model.EvaluateFunction")
+    @mock.patch("mantidqtinterfaces.Muon.GUI.Common.fitting_widgets.basic_fitting.basic_fitting_model.evaluate_function", autospec=True)
     def test_update_plot_guess_notifies_subscribers_with_the_guess_workspace_name_if_plot_guess_is_true(self, mock_evaluate):
         guess_workspace_name = "__frequency_domain_analysis_fitting_guessName1"
         self.model.dataset_names = self.dataset_names
@@ -532,9 +532,8 @@ class BasicFittingModelTest(unittest.TestCase):
         self.mock_context_guess_workspace_name = mock.PropertyMock(return_value=guess_workspace_name)
         type(self.model.fitting_context).guess_workspace_name = self.mock_context_guess_workspace_name
         self.model.update_plot_guess()
-
         mock_evaluate.assert_called_with(
-            InputWorkspace=mock.ANY, Function=self.model.current_single_fit_function, OutputWorkspace=guess_workspace_name
+            input_ws_name=mock.ANY, fun=self.model.current_single_fit_function, out_ws_name=guess_workspace_name
         )
 
         self.assertEqual(1, self.mock_context_guess_workspace_name.call_count)
@@ -915,7 +914,6 @@ class BasicFittingModelTest(unittest.TestCase):
         make_group.assert_called_once_with(["ws"], "group")
 
     def test_set_current_start_and_end_x_as_expected(self):
-
         self.model.dataset_names = self.dataset_names
         self.model.current_dataset_index = 0
         self.model.start_xs = [0.0, 0.0]
@@ -931,7 +929,6 @@ class BasicFittingModelTest(unittest.TestCase):
         self.assertEqual(self.model.current_end_x, new_end_x)
 
     def test_set_current_start_and_end_x_with_start_bigger_end(self):
-
         self.model.dataset_names = self.dataset_names
         self.model.current_dataset_index = 0
         self.model.start_xs = [0.0, 0.0]
@@ -947,7 +944,6 @@ class BasicFittingModelTest(unittest.TestCase):
         self.assertEqual(self.model.current_end_x, new_end_x)
 
     def test_set_current_start_and_end_x_fail(self):
-
         self.model.dataset_names = self.dataset_names
         self.model.current_dataset_index = 0
         self.model.start_xs = [0.0, 0.0]


### PR DESCRIPTION
The bug described in issue #33505 is an exception thrown in the destructor of either CreateWorkspace or EvaluateFunction. EvaluateFunction was being called directly in the muon analysis fitting GUI without going through the AlgorithmManager, which I think is the source of the problem. So I used the AlgorithmManager instead.

**Description of work**
- Used AlgorithmManager for calling EvaluateFunction
- Moved creation of workspace into smaller scope

**Purpose of work**
<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
-->
Fixes #33505 

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**Summary of work**
<!-- Please provide a short, high level description of the work that was done.
-->

**To test:**
Original bug in #33505, instructions to reproduce (they're from a comment further down the page):
1. Open Muon Analysis GUI
2. Load EMU00020884.nxs from the Training Course Data set
3. Click on the fitting tab
4. Add a Fitting function (e.g, Dynamic Kubo Toyabe)
5. Tick Plot guess
6. Untick plot guess
7. Add another fitting function
8. Click plot guess

There are other combinations of adding/removing fitting functions and plotting guesses that resulted in the same thing, so when testing probably best to try various combos.

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.