### PR TITLE
Revert "Change pystog to be a conda dependency"

### DIFF
--- a/Framework/PythonInterface/plugins/algorithms/PDConvertRealSpace.py
+++ b/Framework/PythonInterface/plugins/algorithms/PDConvertRealSpace.py
@@ -8,12 +8,7 @@
 from mantid.api import PythonAlgorithm, AlgorithmFactory, MatrixWorkspace, MatrixWorkspaceProperty, WorkspaceProperty, WorkspaceFactory
 from mantid.kernel import Direction, StringListValidator, logger
 
-try:
-    from pystog.converter import Converter as StogConverter
-except ImportError:
-    logger.information("Install https://github.com/neutrons/pystog to enable PDConvertRealSpace")
-    logger.information("https://anaconda.org/neutrons/pystog")
-    StogConverter = None
+from pystog.converter import Converter
 
 Gr = "G(r)"
 GKr = "GK(r)"
@@ -87,7 +82,7 @@ class PDConvertRealSpace(PythonAlgorithm):
             logger.warning("The input and output functions are the same. Nothing to be done")
             return
 
-        c = StogConverter()
+        c = Converter()
         transformation = {Gr: {GKr: c.G_to_GK, gr: c.G_to_g}, GKr: {Gr: c.GK_to_G, gr: c.GK_to_g}, gr: {Gr: c.g_to_G, GKr: c.g_to_GK}}
 
         sample_kwargs = {
@@ -109,6 +104,5 @@ class PDConvertRealSpace(PythonAlgorithm):
             output_ws.setE(sp_num, new_e)
 
 
-# Register algorithm with Mantid if pystog is found
-if StogConverter:
-    AlgorithmFactory.subscribe(PDConvertRealSpace)
+# Register algorithm with Mantid.
+AlgorithmFactory.subscribe(PDConvertRealSpace)

--- a/Framework/PythonInterface/plugins/algorithms/PDConvertReciprocalSpace.py
+++ b/Framework/PythonInterface/plugins/algorithms/PDConvertReciprocalSpace.py
@@ -15,12 +15,7 @@ from mantid.api import (
 )
 from mantid.kernel import Direction, StringListValidator, logger
 
-try:
-    from pystog.converter import Converter as StogConverter
-except ImportError:
-    logger.information("Install https://github.com/neutrons/pystog to enable PDConvertReciprocalSpace")
-    logger.information("https://anaconda.org/neutrons/pystog")
-    StogConverter = None
+from pystog.converter import Converter
 
 SQ = "S(Q)"
 FQ = "F(Q)"
@@ -104,7 +99,7 @@ class PDConvertReciprocalSpace(PythonAlgorithm):
         if from_quantity == to_quantity:
             logger.warning("The input and output functions are the same. Nothing to be done")
             return
-        c = StogConverter()
+        c = Converter()
         transformation = {
             SQ: {FQ: c.S_to_F, FKQ: c.S_to_FK, DCS: c.S_to_DCS},
             FQ: {SQ: c.F_to_S, FKQ: c.F_to_FK, DCS: c.F_to_DCS},
@@ -134,6 +129,5 @@ class PDConvertReciprocalSpace(PythonAlgorithm):
             output_ws.setE(sp_num, new_e)
 
 
-# Register algorithm with Mantid if pystog is found
-if StogConverter:
-    AlgorithmFactory.subscribe(PDConvertReciprocalSpace)
+# Register algorithm with Mantid.
+AlgorithmFactory.subscribe(PDConvertReciprocalSpace)

--- a/buildconfig/CMake/PyStoG.cmake
+++ b/buildconfig/CMake/PyStoG.cmake
@@ -1,0 +1,87 @@
+include(ExternalProject)
+
+set(_PyStoG_VERSION 4ad6d316bb94221e52b9a57fccbb65f4959972d3)
+set(_PyStoG_download_dir ${CMAKE_CURRENT_BINARY_DIR}/../PyStoG-download)
+set(_PyStoG_source_dir ${_PyStoG_download_dir}/src/PyStoG/pystog)
+set(_PyStoG_source_test_dir ${_PyStoG_download_dir}/src/PyStoG/tests)
+set(_PyStoG_scripts_dir ${CMAKE_CURRENT_BINARY_DIR}/pystog)
+set(_PyStoG_test_root_dir ${CMAKE_CURRENT_BINARY_DIR}/test/pystog)
+set(_PyStoG_test_dir ${_PyStoG_test_root_dir}/tests)
+
+externalproject_add(
+  PyStoG
+  PREFIX ${_PyStoG_download_dir}
+  GIT_REPOSITORY "https://github.com/neutrons/pystog.git"
+  GIT_TAG ${_PyStoG_VERSION}
+  EXCLUDE_FROM_ALL 1
+  CONFIGURE_COMMAND ""
+  BUILD_COMMAND ""
+  TEST_COMMAND ""
+  INSTALL_COMMAND ""
+)
+
+# clone the git repository
+message(STATUS "Fetching/updating PyStoG")
+execute_process(
+  COMMAND ${CMAKE_COMMAND} ARGS -P ${_PyStoG_download_dir}/tmp/PyStoG-gitclone.cmake RESULT_VARIABLE _exit_code
+)
+if(_exit_code EQUAL 0)
+  execute_process(
+    COMMAND ${CMAKE_COMMAND} ARGS -P ${_PyStoG_download_dir}/tmp/PyStoG-gitupdate.cmake RESULT_VARIABLE _exit_code
+  )
+  if(NOT _exit_code EQUAL 0)
+    message(FATAL_ERROR "Unable to update PyStoG")
+  endif()
+else()
+  message(FATAL_ERROR "Unable to clone PyStoG")
+endif()
+
+set(_source_files converter.py fourier_filter.py transformer.py utils.py)
+
+set(_test_files test_converter.py test_fourier_filter.py test_transformer.py)
+
+set(_test_files_support __init__.py materials.py utils.py)
+
+# copy over the source files we want
+file(MAKE_DIRECTORY ${_PyStoG_scripts_dir})
+foreach(_py_file ${_source_files})
+  file(COPY ${_PyStoG_source_dir}/${_py_file} DESTINATION ${_PyStoG_scripts_dir})
+endforeach()
+
+# copy over the relavant tests
+file(MAKE_DIRECTORY ${_PyStoG_test_dir})
+foreach(_py_file ${_test_files})
+  file(COPY ${_PyStoG_source_test_dir}/${_py_file} DESTINATION ${_PyStoG_test_dir})
+endforeach()
+foreach(_py_file ${_test_files_support})
+  file(COPY ${_PyStoG_source_test_dir}/${_py_file} DESTINATION ${_PyStoG_test_dir})
+endforeach()
+
+# copy over the test data
+file(COPY ${_PyStoG_download_dir}/src/PyStoG/data/test_data DESTINATION ${_PyStoG_test_dir})
+
+# register the tests
+set(PYUNITTEST_PYTHONPATH_EXTRA ${_PyStoG_test_root_dir})
+pyunittest_add_test(${_PyStoG_test_dir} python.scripts.pystog ${_test_files})
+
+# create the "simple" __init__.py
+set(_PyStoG_INIT_CONTENTS
+    "from pystog.converter import Converter
+from pystog.transformer import Transformer
+from pystog.fourier_filter import FourierFilter
+
+__all__ = ['Converter', 'Transformer', 'FourierFilter', ]
+
+__version__ = '${_PyStoG_VERSION}'
+"
+)
+file(WRITE ${_PyStoG_scripts_dir}/__init__.py ${_PyStoG_INIT_CONTENTS})
+
+# install the results
+foreach(_bundle ${BUNDLES})
+  install(
+    DIRECTORY ${_PyStoG_scripts_dir}
+    DESTINATION ${_bundle}scripts
+    COMPONENT Runtime
+  )
+endforeach()

--- a/docs/source/release/v6.8.0/Diffraction/Powder/New_features/35673.rst
+++ b/docs/source/release/v6.8.0/Diffraction/Powder/New_features/35673.rst
@@ -1,1 +1,0 @@
-- `pystog <https://github.com/neutrons/pystog>`_ to use the conda package rather than ship with the source in mantid. It is an optional dependency so the user must install the `pystog conda package <https://anaconda.org/neutrons/pystog>`_ themselves.

--- a/mantid-developer-linux.yml
+++ b/mantid-developer-linux.yml
@@ -2,7 +2,6 @@ name: mantid-developer
 
 channels:
   - conda-forge
-  - neutrons
 
 dependencies:
   # Common packages
@@ -30,7 +29,6 @@ dependencies:
   - psutil>=5.8.0
   - pycifrw==4.4.1 # Force to 4.4.1 as later versions cause issues with loading CIF files
   - pyqt>=5.15,<6
-  - pystog==0.4.3
   - python-dateutil>=2.8.1
   - python=3.10.*
   - pyyaml>=5.4.1

--- a/mantid-developer-osx.yml
+++ b/mantid-developer-osx.yml
@@ -2,7 +2,6 @@ name: mantid-developer
 
 channels:
   - conda-forge
-  - neutrons
 
 dependencies:
   - boost=1.77.* # Also pulls in boost-cpp. 1.78 clashes with icu version from Qt
@@ -27,7 +26,6 @@ dependencies:
   - occt
   - pip>=21.0.1
   - poco=1.12.1|>=1.12.5 # 1.12.2 introduced an unguarded #define NOMINMAX which causes a compiler warning. It's resolved on their devel branch so should be fine after 1.12.4
-  - pystog==0.4.3
   - psutil>=5.8.0
   - pycifrw==4.4.1 # Force to 4.4.1 as later versions cause issues with loading CIF files
   - pyqt>=5.15,<6

--- a/mantid-developer-win.yml
+++ b/mantid-developer-win.yml
@@ -2,7 +2,6 @@ name: mantid-developer
 
 channels:
   - conda-forge
-  - neutrons
 
 dependencies:
   - boost=1.77.* # Also pulls in boost-cpp. 1.78 clashes with icu version from Qt
@@ -31,7 +30,6 @@ dependencies:
   - psutil>=5.8.0
   - pycifrw==4.4.1 # Force to 4.4.1 as later versions cause issues with loading CIF files
   - pyqt>=5.15,<6
-  - pystog==0.4.3
   - python-dateutil>=2.8.1
   - python=3.10.*
   - pyyaml>=5.4.1

--- a/scripts/CMakeLists.txt
+++ b/scripts/CMakeLists.txt
@@ -1,6 +1,9 @@
 # External GUIs
 add_subdirectory(ExternalInterfaces)
 
+# External projects
+include(PyStoG)
+
 # .pth files
 set(_pth_dirs
     .


### PR DESCRIPTION
This is causing the following warnings in the mantiddocs packaging, so the nightly is not completing:

```
00:49:30.379  /jenkins_workdir/workspace/main_nightly_deployment_prototype/conda-bld/mantiddocs_1692919190120/work/docs/source/release/v4.0.0/diffraction.rst:61: WARNING: undefined label: 'algm-pdconvertreciprocalspace'
00:49:30.379  /jenkins_workdir/workspace/main_nightly_deployment_prototype/conda-bld/mantiddocs_1692919190120/work/docs/source/release/v4.0.0/diffraction.rst:62: WARNING: undefined label: 'algm-pdconvertrealspace'
00:49:30.379  /jenkins_workdir/workspace/main_nightly_deployment_prototype/conda-bld/mantiddocs_1692919190120/work/docs/source/release/v4.0.0/diffraction.rst:106: WARNING: undefined label: 'algm-pdconvertreciprocalspace'
00:49:30.379  /jenkins_workdir/workspace/main_nightly_deployment_prototype/conda-bld/mantiddocs_1692919190120/work/docs/source/release/v4.0.0/diffraction.rst:107: WARNING: undefined label: 'algm-pdconvertrealspace'
```

I  suggest we revert it and fix the problem on the branch, testing it on a linux package build, before merging back into main.