### PR TITLE
Add support for alternate grouping definition in HDF format

### DIFF
--- a/Framework/DataHandling/test/LoadDiffCalTest.h
+++ b/Framework/DataHandling/test/LoadDiffCalTest.h
@@ -85,8 +85,9 @@ public:
       Poco::File(filename).remove();
   }
 
-  void test_override_grouping() {
-    // this is a round-trip test
+  // Override a grouping definition specified by LoadDiffCal "Filename" property.
+  // Use a grouping definition from an XML-formatted file specified by LoadDiffCal "GroupFilename" property.
+  void test_alternate_grouping_definition_xml_format() {
     std::string outWSName("LoadDiffCalTest");
     std::string filename("LoadDiffCalTest.h5");
     std::string groupingfile("LoadDiffCalTest_grp.xml");
@@ -97,6 +98,7 @@ public:
     auto groupWSIn = saveDiffCal.createGrouping(inst, false);
     auto maskWSIn = saveDiffCal.createMasking(inst);
     auto calWSIn = saveDiffCal.createCalibration(5 * 9); // nine components per bank
+
     SaveDiffCal saveAlg;
     saveAlg.initialize();
     saveAlg.setProperty("GroupingWorkspace", groupWSIn);
@@ -106,8 +108,10 @@ public:
     TS_ASSERT_THROWS_NOTHING(saveAlg.execute();); // make sure it runs
     filename = saveAlg.getPropertyValue("Filename");
 
-    // create the overriding grouping file
+    // create the overriding grouping workspace
     groupWSIn = saveDiffCal.createGrouping(inst, true);
+
+    // create a file from the grouping workspace
     SaveDetectorsGrouping saveGrouping;
     saveGrouping.initialize();
     saveGrouping.setProperty("InputWorkspace", groupWSIn);
@@ -128,6 +132,7 @@ public:
     TS_ASSERT_THROWS_NOTHING(loadAlg.execute(););
     TS_ASSERT(loadAlg.isExecuted());
 
+    // Verify that the loaded calibration workspace is the same as the input calibration workspace.
     ITableWorkspace_sptr ws;
     TS_ASSERT_THROWS_NOTHING(ws = AnalysisDataService::Instance().retrieveWS<ITableWorkspace>(outWSName + "_cal"));
     TS_ASSERT(ws);
@@ -140,6 +145,140 @@ public:
       TS_ASSERT(checkAlg->getProperty("Result"));
 
       AnalysisDataService::Instance().remove(outWSName + "_cal");
+    }
+
+    // Verify that the loaded grouping workspace is the same as the overriding grouping workspace.
+    GroupingWorkspace_sptr groupWSOut;
+    TS_ASSERT_THROWS_NOTHING(groupWSOut =
+                                 AnalysisDataService::Instance().retrieveWS<GroupingWorkspace>(outWSName + "_group"));
+    TS_ASSERT(groupWSOut);
+
+    if (groupWSOut) {
+      auto checkAlg = AlgorithmManager::Instance().create("CompareWorkspaces");
+      checkAlg->setProperty("Workspace1", groupWSIn);
+      checkAlg->setProperty("Workspace2", groupWSOut);
+      checkAlg->execute();
+      TS_ASSERT(checkAlg->getProperty("Result"));
+
+      AnalysisDataService::Instance().remove(outWSName + "_group");
+    }
+
+    // cleanup
+    if (Poco::File(filename).exists())
+      Poco::File(filename).remove();
+    if (Poco::File(groupingfile).exists())
+      Poco::File(groupingfile).remove();
+  }
+
+  // Create a zero calibration workspace consistent with an input grouping workspace.
+  TableWorkspace_sptr createZeroCalibration(GroupingWorkspace_const_sptr groupingWS) {
+    auto calibrationWS = std::make_shared<Mantid::DataObjects::TableWorkspace>();
+    calibrationWS->addColumn("int", "detid");
+    calibrationWS->addColumn("double", "difc");
+    calibrationWS->addColumn("double", "difa");
+    calibrationWS->addColumn("double", "tzero");
+    calibrationWS->addColumn("double", "tofmin");
+
+    std::vector<int> groupIDs = groupingWS->getGroupIDs();
+    for (size_t i = 0; i < groupIDs.size(); ++i) {
+      std::vector<int> detIDs = groupingWS->getDetectorIDsOfGroup(groupIDs[i]);
+      for (size_t j = 0; j < detIDs.size(); j++) {
+        Mantid::API::TableRow row = calibrationWS->appendRow();
+        row << detIDs[j] // detid
+            << 0.        // difc
+            << 0.        // difa
+            << 0.        // tzero
+            << 0.;       // tofmin
+      }
+    }
+
+    return calibrationWS;
+  }
+
+  // Override a grouping definition specified by LoadDiffCal "Filename" property.
+  // Use a grouping definition from an HDF-formatted file specified by LoadDiffCal "GroupFilename" property.
+  void test_alternate_grouping_definition_hdf_format() {
+    std::string outWSName("LoadDiffCalTest");
+    std::string filename("LoadDiffCalTest.h5");
+    // intentionally giving groupingfile a mixed-case file name extension to test the robustness of LoadDiffCal file
+    // name validation
+    std::string groupingfile("LoadDiffCalTest_grp.HdF");
+
+    // Create ingredients for a test calibration file.
+    SaveDiffCalTest saveDiffCal;
+    auto inst = saveDiffCal.createInstrument();
+    auto groupWSIn = saveDiffCal.createGrouping(inst, false);
+    auto maskWSIn = saveDiffCal.createMasking(inst);
+    auto calWSIn = saveDiffCal.createCalibration(5 * 9); // nine components per bank
+
+    // Save a test calibration file
+    SaveDiffCal saveAlg;
+    saveAlg.initialize();
+    saveAlg.setProperty("CalibrationWorkspace", calWSIn);
+    saveAlg.setProperty("GroupingWorkspace", groupWSIn);
+    saveAlg.setProperty("MaskWorkspace", maskWSIn);
+    saveAlg.setProperty("Filename", filename);    // path to the file to be created by SaveDiffCal
+    TS_ASSERT_THROWS_NOTHING(saveAlg.execute();); // make sure it runs
+    filename = saveAlg.getPropertyValue("Filename");
+
+    // Now create a new grouping definition which is supposed to override the previous one.
+    groupWSIn = saveDiffCal.createGrouping(inst, true);
+
+    // Save the new grouping definition in HDF format. Since SaveDiffCal requires an input calibration
+    // workspace, create a zero calibration workspace to serve as a place holder consistent with the grouping workspace.
+    auto zeroCalWSIn = createZeroCalibration(groupWSIn);
+
+    saveAlg.initialize();
+    saveAlg.setProperty("CalibrationWorkspace", zeroCalWSIn);
+    saveAlg.setProperty("GroupingWorkspace", groupWSIn);
+    saveAlg.setProperty("Filename", groupingfile); // path to the file to be created by SaveDiffCal
+    TS_ASSERT_THROWS_NOTHING(saveAlg.execute(););
+
+    // Run the algorithm of interest
+    LoadDiffCal loadAlg;
+    TS_ASSERT_THROWS_NOTHING(loadAlg.initialize());
+    TS_ASSERT(loadAlg.isInitialized());
+    TS_ASSERT_THROWS_NOTHING(loadAlg.setProperty("InputWorkspace", groupWSIn)); // workspace to take instrument from
+    TS_ASSERT_THROWS_NOTHING(
+        loadAlg.setPropertyValue("Filename", filename)); // file with original calibration and grouping workspaces
+    TS_ASSERT_THROWS_NOTHING(loadAlg.setPropertyValue("GroupFilename", groupingfile)); // overriding grouping definition
+    TS_ASSERT_THROWS_NOTHING(
+        loadAlg.setPropertyValue("WorkspaceName", outWSName)); // prefix for the output calibration workspace names
+    TS_ASSERT_THROWS_NOTHING(loadAlg.setProperty("MakeGroupingWorkspace", true));
+    TS_ASSERT_THROWS_NOTHING(loadAlg.setProperty("MakeMaskWorkspace", false));
+    TS_ASSERT_THROWS_NOTHING(loadAlg.execute(););
+    TS_ASSERT(loadAlg.isExecuted());
+
+    // Verify that the loaded calibration workspace is the same as the input calibration workspace.
+    ITableWorkspace_sptr calWSOut;
+    TS_ASSERT_THROWS_NOTHING(calWSOut =
+                                 AnalysisDataService::Instance().retrieveWS<ITableWorkspace>(outWSName + "_cal"));
+    TS_ASSERT(calWSOut);
+
+    if (calWSOut) {
+      auto checkAlg = AlgorithmManager::Instance().create("CompareWorkspaces");
+      checkAlg->setProperty("Workspace1", calWSIn);
+      checkAlg->setProperty("Workspace2", calWSOut);
+      checkAlg->execute();
+      TS_ASSERT(checkAlg->getProperty("Result"));
+
+      AnalysisDataService::Instance().remove(outWSName + "_cal");
+    }
+
+    // Verify that the loaded grouping workspace is the same as the overriding grouping workspace.
+    GroupingWorkspace_sptr groupWSOut;
+    TS_ASSERT_THROWS_NOTHING(groupWSOut =
+                                 AnalysisDataService::Instance().retrieveWS<GroupingWorkspace>(outWSName + "_group"));
+    TS_ASSERT(groupWSOut);
+
+    if (groupWSOut) {
+      auto checkAlg = AlgorithmManager::Instance().create("CompareWorkspaces");
+      checkAlg->setProperty("Workspace1", groupWSIn);
+      checkAlg->setProperty("Workspace2", groupWSOut);
+      checkAlg->execute();
+      TS_ASSERT(checkAlg->getProperty("Result"));
+
+      AnalysisDataService::Instance().remove(outWSName + "_group");
     }
 
     // cleanup

--- a/Framework/Kernel/test/EnumeratedStringTest.h
+++ b/Framework/Kernel/test/EnumeratedStringTest.h
@@ -278,7 +278,7 @@ public:
     TS_ASSERT(enTwoLetters_from_constructor != std::string("BA"));
 
     // 2. Test a use case with mixed-case string introduced through the assignment operator: EnumeratedString
-    // &operator=(const td::string& s)
+    // &operator=(const std::string& s)
     TS_ASSERT_THROWS_NOTHING(TWO_LETTERS enTwoLetters_from_assignment = std::string("aB"));
     TWO_LETTERS enTwoLetters_from_assignment = std::string("aB");
     TS_ASSERT(enTwoLetters_from_assignment.c_str() == std::string("aB"))

--- a/docs/source/release/v6.8.0/Framework/Data_Handling/New_features/35976.rst
+++ b/docs/source/release/v6.8.0/Framework/Data_Handling/New_features/35976.rst
@@ -1,0 +1,1 @@
+- :ref:`LoadDiffCal <algm-LoadDiffCal>` now accepts an alternate grouping definition in the HDF format.


### PR DESCRIPTION
**Description of work**

`LoadDiffCal` algorithm allows to specify an alternate detector grouping through the `GroupFilename` property. However, at the moment, only ".cal" and ".xml" formats are supported. At the same time, `SaveDiffCal` can produce grouping definitions in the HDF format. We need to expand the `GroupFilename` functionality to support these file extensions: ".h5", ".hd5", ".hdf".

**Summary of work**
<!-- Please provide a short, high level description of the work that was done.
-->

- Expanded the list of allowed `GroupFilename` name extensions to include ".h5", ".hd5", ".hdf".
- Refactored the existent `LoadDiffCal` code which uses file name extensions of `Filename` and `GroupFilename` properties. Now that code uses `EnumeratedString` with a case-insensitive string comparator.
- Expanded the existent `GroupFilename` unit test with XML-formatted grouping definition: included a check of the resultant grouping workspace. 
- Added a unit test for HDF-formatted grouping definition.
- Fixed a minor comment typo in `EnumeratedStringTest`.

**To test:**

ctest -R LoadDiffCalTest

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.