### PR TITLE
Remove unused `killall` command and `use-core-dumps` option

### DIFF
--- a/buildconfig/Jenkins/Conda/conda-buildscript
+++ b/buildconfig/Jenkins/Conda/conda-buildscript
@@ -24,7 +24,6 @@
 #   --enable-coverity: Runs coverity and submits results, ignore all other options and does not run unit tests
 #   --clean-build: Clears the build folder and builds from scratch
 #   --clean-external-projects: Clear the external projects from the build folder
-#   --use-core-dumps: Activate core dumps (Linux only)
 #
 # Possible parameters:
 #   --extra-cmake-flags: Extra flags to pass directly to cmake, enclose in "", defaults to nothing
@@ -65,7 +64,6 @@ ENABLE_DEV_DOCS=false
 ENABLE_COVERITY=false
 CLEAN_BUILD=false
 CLEAN_EXTERNAL_PROJECTS=false
-USE_CORE_DUMPS=false
 EXTRA_CMAKE_FLAGS="-DENABLE_PRECOMMIT=OFF"
 
 # Handle flag inputs
@@ -86,7 +84,6 @@ do
 	    ;;
         --clean-build) CLEAN_BUILD=true ;;
         --clean-external-projects) CLEAN_EXTERNAL_PROJECTS=true ;;
-        --use-core-dumps) USE_CORE_DUMPS=true ;;
         --extra-cmake-flags)
             EXTRA_CMAKE_FLAGS="$2"
             shift
@@ -146,7 +143,7 @@ rm -rf  $BUILD_DIR/test_logs
 $SCRIPT_DIR/build $WORKSPACE $CMAKE_PRESET $ENABLE_DOCS $ENABLE_DEV_DOCS $ENABLE_BUILD_CODE $ENABLE_UNIT_TESTS $ENABLE_SYSTEM_TESTS $ENABLE_COVERITY "$EXTRA_CMAKE_FLAGS" $BUILD_THREADS
 
 # Run unit and system tests
-$SCRIPT_DIR/run-tests $WORKSPACE $ENABLE_SYSTEM_TESTS $ENABLE_UNIT_TESTS $ENABLE_DOCS $ENABLE_DOC_TESTS $BUILD_THREADS $USE_CORE_DUMPS
+$SCRIPT_DIR/run-tests $WORKSPACE $ENABLE_SYSTEM_TESTS $ENABLE_UNIT_TESTS $ENABLE_DOCS $ENABLE_DOC_TESTS $BUILD_THREADS
 
 # elapsed time with second resolution
 end_time=$(date +%s)

--- a/buildconfig/Jenkins/Conda/nightly_build_and_deploy.jenkinsfile
+++ b/buildconfig/Jenkins/Conda/nightly_build_and_deploy.jenkinsfile
@@ -437,7 +437,7 @@ def build_and_test(platform) {
     bat "\"${WIN_BASH}\" -ex -c \"${buildscript_path}\
       ${workspace_unix_style}/${CHECKOUT_DIR} ${cmake_preset} ${common_args}\""
   } else {
-    sh "${buildscript_path} ${WORKSPACE}/${CHECKOUT_DIR} ${cmake_preset} ${common_args} --enable-doctests --use-core-dumps"
+    sh "${buildscript_path} ${WORKSPACE}/${CHECKOUT_DIR} ${cmake_preset} ${common_args} --enable-doctests"
   }
 }
 

--- a/buildconfig/Jenkins/Conda/run-tests
+++ b/buildconfig/Jenkins/Conda/run-tests
@@ -31,17 +31,10 @@ function run_with_xvfb {
         # Use -noreset because of an X Display bug caused by a race condition in xvfb: https://gitlab.freedesktop.org/xorg/xserver/-/issues/1102
         xvfb-run -e /dev/stderr --server-args="-core -noreset -screen 0 640x480x24" \
         --server-num=${XVFB_SERVER_NUM} $@
+        # Remove Xvfb X server lock files after running
+        rm -f /tmp/.X${XVFB_SERVER_NUM}-lock
     else
         eval $@
-    fi
-}
-
-function terminate_xvfb_sessions {
-    if [ $(command -v xvfb-run) ]; then
-        echo "Terminating existing Xvfb sessions"
-
-        # Remove Xvfb X server lock files
-        rm -f /tmp/.X${XVFB_SERVER_NUM}-lock
     fi
 }
 
@@ -102,7 +95,6 @@ cd $WORKSPACE/build
 mkdir -p test_logs
 if [[ $ENABLE_UNIT_TESTS == true ]]; then
     run_with_xvfb ctest -j$BUILD_THREADS --no-compress-output -T Test -O test_logs/ctest_$OSTYPE.log --schedule-random --output-on-failure --repeat until-pass:3 $WINDOWS_TEST_OPTIONS $WINDOWS_UNITTEST_TIMEOUT_OPTIONS
-    terminate_xvfb_sessions
 fi
 
 if [[ $ENABLE_DOCS == true && $ENABLE_DOC_TESTS == true ]]; then
@@ -121,5 +113,4 @@ if [[ $ENABLE_SYSTEM_TESTS == true ]]; then
     echo "CheckMantidVersion.OnStartup = 0" >> $userprops
 
     run_with_xvfb $SYSTEM_TEST_EXECUTABLE $WINDOWS_TEST_OPTIONS -j$BUILD_THREADS_SYSTEM_TESTS -l information --quiet --output-on-failure
-    terminate_xvfb_sessions
 fi

--- a/buildconfig/Jenkins/Conda/run-tests
+++ b/buildconfig/Jenkins/Conda/run-tests
@@ -35,6 +35,11 @@ function run_with_xvfb {
     fi
 }
 
+function doctest_exit {
+    echo "Failed when running the DocTests. Read the doctest_${OSTYPE}.log build artifact"
+    echo "Note that Sphinx warnings are set to be treated as errors"
+}
+
 # Clean up prior to testing
 # Prevent race conditions when creating the user config directory
 if [[ $OSTYPE == "msys"* ]]; then
@@ -81,6 +86,8 @@ if [[ $ENABLE_UNIT_TESTS == true ]]; then
 fi
 
 if [[ $ENABLE_DOCS == true && $ENABLE_DOC_TESTS == true ]]; then
+    # Setup doctest failure exit message
+    trap doctest_exit INT TERM EXIT
     # Build doctests without using Xvfb for better output when things fail. Output to file due to console memory issues
     QT_QPA_PLATFORM=offscreen cmake --build . --target docs-doctest -j$BUILD_THREADS $WINDOWS_BUILD_OPTIONS > test_logs/doctest_$OSTYPE.log
 fi

--- a/buildconfig/Jenkins/Conda/run-tests
+++ b/buildconfig/Jenkins/Conda/run-tests
@@ -10,7 +10,6 @@
 #   4. ENABLE_DOCS: Whether or not the docs have been built
 #   5. ENABLE_DOC_TESTS: Whether or not the doc tests should be ran
 #   6. BUILD_THREADS: The number of threads to use during testing
-#   7. USE_CORE_DUMPS: Activate core dumps (Linux only)
 
 WORKSPACE=$1
 ENABLE_SYSTEM_TESTS=$2
@@ -18,12 +17,10 @@ ENABLE_UNIT_TESTS=$3
 ENABLE_DOCS=$4
 ENABLE_DOC_TESTS=$5
 BUILD_THREADS=$6
-USE_CORE_DUMPS=$7
 
 # Run only 3 tests at a time because of memory constraints in the system tests
 BUILD_THREADS_SYSTEM_TESTS=3
 XVFB_SERVER_NUM=101
-ULIMIT_CORE_ORIG=$(ulimit -c)
 
 function run_with_xvfb {
     if [ $(command -v xvfb-run) ]; then
@@ -35,12 +32,6 @@ function run_with_xvfb {
         rm -f /tmp/.X${XVFB_SERVER_NUM}-lock
     else
         eval $@
-    fi
-}
-
-function onexit {
-    if [[ ${USE_CORE_DUMPS} == true ]]; then
-        ulimit -c $ULIMIT_CORE_ORIG
     fi
 }
 
@@ -71,12 +62,6 @@ rm -f $workbench_ini
 # use a fixed number of openmp threads to avoid overloading the system
 echo MultiThreaded.MaxCores=2 > $userprops
 
-# Setup core dumping
-trap onexit INT TERM EXIT
-if [[ ${USE_CORE_DUMPS} == true ]]; then
-    ulimit -c unlimited
-fi
-
 if [[ $OSTYPE == "msys"* ]]; then
     WINDOWS_BUILD_OPTIONS="--config Release"
     WINDOWS_TEST_OPTIONS="-C Release"
@@ -86,8 +71,6 @@ if [[ $OSTYPE == "msys"* ]]; then
 else
     SYSTEM_TEST_EXECUTABLE=$WORKSPACE/build/systemtest
 fi
-
-
 
 # Run unit tests
 cd $WORKSPACE/build

--- a/buildconfig/Jenkins/Conda/run-tests
+++ b/buildconfig/Jenkins/Conda/run-tests
@@ -35,11 +35,6 @@ function run_with_xvfb {
     fi
 }
 
-function doctest_exit {
-    echo "Failed when running the DocTests. Read the doctest_${OSTYPE}.log build artifact"
-    echo "Note that Sphinx warnings are set to be treated as errors"
-}
-
 # Clean up prior to testing
 # Prevent race conditions when creating the user config directory
 if [[ $OSTYPE == "msys"* ]]; then
@@ -86,10 +81,13 @@ if [[ $ENABLE_UNIT_TESTS == true ]]; then
 fi
 
 if [[ $ENABLE_DOCS == true && $ENABLE_DOC_TESTS == true ]]; then
-    # Setup doctest failure exit message
-    trap doctest_exit INT TERM EXIT
     # Build doctests without using Xvfb for better output when things fail. Output to file due to console memory issues
     QT_QPA_PLATFORM=offscreen cmake --build . --target docs-doctest -j$BUILD_THREADS $WINDOWS_BUILD_OPTIONS > test_logs/doctest_$OSTYPE.log
+
+    # If the exit code is not zero then display a message
+    if [ $? -ne 0 ]; then
+        echo "Failed when running the DocTests. Read the doctest_${OSTYPE}.log build artifact"
+    fi
 fi
 
 if [[ $ENABLE_SYSTEM_TESTS == true ]]; then

--- a/buildconfig/Jenkins/Conda/run-tests
+++ b/buildconfig/Jenkins/Conda/run-tests
@@ -35,6 +35,10 @@ function run_with_xvfb {
     fi
 }
 
+function doctest_onexit {
+    echo "Error: DocTests failed. Check 'doctest_${OSTYPE}.log' in the build artifacts."
+}
+
 # Clean up prior to testing
 # Prevent race conditions when creating the user config directory
 if [[ $OSTYPE == "msys"* ]]; then
@@ -81,13 +85,14 @@ if [[ $ENABLE_UNIT_TESTS == true ]]; then
 fi
 
 if [[ $ENABLE_DOCS == true && $ENABLE_DOC_TESTS == true ]]; then
+    # Trap a doctest exit or termination
+    trap doctest_onexit INT TERM EXIT
+
     # Build doctests without using Xvfb for better output when things fail. Output to file due to console memory issues
     QT_QPA_PLATFORM=offscreen cmake --build . --target docs-doctest -j$BUILD_THREADS $WINDOWS_BUILD_OPTIONS > test_logs/doctest_$OSTYPE.log
 
-    # If the exit code is not zero then display a message
-    if [ $? -ne 0 ]; then
-        echo "Failed when running the DocTests. Read the doctest_${OSTYPE}.log build artifact"
-    fi
+    # Disable the trap if the doctests are successful
+    trap - INT TERM EXIT
 fi
 
 if [[ $ENABLE_SYSTEM_TESTS == true ]]; then

--- a/buildconfig/Jenkins/Conda/run-tests
+++ b/buildconfig/Jenkins/Conda/run-tests
@@ -40,9 +40,6 @@ function terminate_xvfb_sessions {
     if [ $(command -v xvfb-run) ]; then
         echo "Terminating existing Xvfb sessions"
 
-        # Kill Xvfb processes
-        killall Xvfb || true
-
         # Remove Xvfb X server lock files
         rm -f /tmp/.X${XVFB_SERVER_NUM}-lock
     fi

--- a/buildconfig/Jenkins/buildscript
+++ b/buildconfig/Jenkins/buildscript
@@ -41,9 +41,6 @@ function terminate_xvfb_sessions() {
     if [ $(command -v xvfb-run) ]; then
         echo "Terminating existing Xvfb sessions"
 
-        # Kill Xvfb processes
-        killall Xvfb || true
-
         # Remove Xvfb X server lock files
         rm -f /tmp/.X${XVFB_SERVER_NUM}-lock
     fi

--- a/buildconfig/Jenkins/buildscript
+++ b/buildconfig/Jenkins/buildscript
@@ -430,9 +430,8 @@ if [[ ${DO_DOCTESTS_USER} == true ]]; then
         rm -fr $BUILD_DIR/docs/doctrees/*
     fi
     # Build HTML to verify that no referencing errors have crept in.
-    run_with_xvfb ${CMAKE_EXE} --build . --target docs-html
-    terminate_xvfb_sessions
-    run_with_xvfb ${CMAKE_EXE} --build . --target docs-doctest
+    QT_QPA_PLATFORM=offscreen ${CMAKE_EXE} --build . --target docs-html
+    QT_QPA_PLATFORM=offscreen ${CMAKE_EXE} --build . --target docs-doctest
 fi
 
 ###############################################################################

--- a/buildconfig/Jenkins/buildscript
+++ b/buildconfig/Jenkins/buildscript
@@ -32,24 +32,12 @@ function run_with_xvfb {
         # Use -noreset because of an X Display bug caused by a race condition in xvfb: https://gitlab.freedesktop.org/xorg/xserver/-/issues/1102
         xvfb-run -e /dev/stderr --server-args="-core -noreset -screen 0 640x480x24" \
         --server-num=${XVFB_SERVER_NUM} $@
+	# Remove Xvfb X server lock files after running
+        rm -f /tmp/.X${XVFB_SERVER_NUM}-lock
     else
         eval $@
     fi
 }
-
-function terminate_xvfb_sessions() {
-    if [ $(command -v xvfb-run) ]; then
-        echo "Terminating existing Xvfb sessions"
-
-        # Remove Xvfb X server lock files
-        rm -f /tmp/.X${XVFB_SERVER_NUM}-lock
-    fi
-}
-
-###############################################################################
-# Terminate existing Xvfb sessions
-###############################################################################
-terminate_xvfb_sessions
 
 ###############################################################################
 # System discovery
@@ -415,7 +403,6 @@ echo MultiThreaded.MaxCores=2 > $userprops_file
 
 if [[ ${DO_UNITTESTS} == true ]]; then
     run_with_xvfb $CTEST_EXE --no-compress-output -T Test -j${BUILD_THREADS:?} --schedule-random --output-on-failure
-    terminate_xvfb_sessions
 fi
 
 ###############################################################################
@@ -430,8 +417,8 @@ if [[ ${DO_DOCTESTS_USER} == true ]]; then
         rm -fr $BUILD_DIR/docs/doctrees/*
     fi
     # Build HTML to verify that no referencing errors have crept in.
-    QT_QPA_PLATFORM=offscreen ${CMAKE_EXE} --build . --target docs-html
-    QT_QPA_PLATFORM=offscreen ${CMAKE_EXE} --build . --target docs-doctest
+    run_with_xvfb ${CMAKE_EXE} --build . --target docs-html
+    run_with_xvfb ${CMAKE_EXE} --build . --target docs-doctest
 fi
 
 ###############################################################################


### PR DESCRIPTION
**Description of work**
This PR does a few things:

- [x] It removes the `terminate_xvfb_sessions` function and moves the functionality to be the command below the xvfb command. This ensures the necessary cleanup is always run when using Xvfb. Previously, we would sometimes forget to call the terminate function after using xvfb
- [x] It removes the use of `killall`. This is not working and does not seem to be necessary for any of our pipelines
- [x] It removes the `--use-core-dumps` option from our `run-tests` script because it is unused, and not particularly useful when I tried using it for debugging purposes
- [x] It adds a message to check the `doctest_$OSTYPE.log` file in the build artifacts if the doctests fail

**To test:**
Make sure this build package from branch passes:
https://builds.mantidproject.org/job/build_packages_from_branch/528/

Check that the OSX build fails with a useful message here:
https://github.com/mantidproject/mantid/pull/36007

*There is no associated issue.*

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.