### PR TITLE
Allow BackgroundWorkspace to be given as an OutputName

### DIFF
--- a/docs/source/interfaces/isis_sans/Runs Tab.rst
+++ b/docs/source/interfaces/isis_sans/Runs Tab.rst
@@ -107,11 +107,11 @@ Table Columns
 +--------------------------+-------------------------------------------------------------------------------------------------+
 | **Options**              |   This column allows the user to provide row specific settings. Currently only                  |
 |                          |   **WavelengthMin**, **WavelengthMax**, **EventSlices** (see :ref:`ISIS_SANS_Settings_Tab-ref`  |
-|                          |   for details), **BackgroundWorkspace**, and **ScaleFactor** can be set (see below).            |
+|                          |   for details).                                                                                 |
 +--------------------------+-------------------------------------------------------------------------------------------------+
 | **Background Workspace** |   This column allows the user to provide a workspace for scaled background subtraction          |
-|                          |   (see below). This can either be the name of a workspace already in the ADS or math the Output |
-|                          |   Name from another row in the runs table.                                                      |
+|                          |   (see below). This can either be the name of a workspace already in the ADS or match the       |
+|                          |   Output Name from another row in the runs table.                                               |
 +--------------------------+-------------------------------------------------------------------------------------------------+
 | **Scale Factor**         |   Scale factor to be used for scaled background subtraction (see below).                        |
 +--------------------------+-------------------------------------------------------------------------------------------------+
@@ -139,18 +139,18 @@ Examples:
 
 - Given Values: Sample (Scatter, Transmission, and Direct), and Can (Scatter, Transmission, and Direct)
 
-  - OutputName = Sample - Can
+  - Output = Sample - Can
 
 - Given Values: Sample (Scatter, Transmission, and Direct), Can (Scatter, Transmission, and Direct), and  Scaled
   Background Workspace
 
-  - OutputName = Sample - Can
-  - OutputName_bgsub = Sample - Can - (Background Workspace * Scale Factor)
+  - Output = Sample - Can
+  - Output_bgsub = Sample - Can - (Background Workspace * Scale Factor)
 
 - Given Values: Sample (Scatter, Transmission, and Direct) and Scaled Background Workspace
 
-  - OutputName = Sample
-  - OutputName_bgsub = Sample - (Background Workspace * Scale Factor)
+  - Output = Sample
+  - Output_bgsub = Sample - (Background Workspace * Scale Factor)
 
 The reduction will fail if only one of ``Background Workspace`` and ``Scale Factor`` is set. Or, if the reduction mode
 is set to "All". This is because there is no way to determine if the workspace given as the ``BackgroundWorkspace`` is

--- a/docs/source/interfaces/isis_sans/Runs Tab.rst
+++ b/docs/source/interfaces/isis_sans/Runs Tab.rst
@@ -110,7 +110,8 @@ Table Columns
 |                          |   for details), **BackgroundWorkspace**, and **ScaleFactor** can be set (see below).            |
 +--------------------------+-------------------------------------------------------------------------------------------------+
 | **Background Workspace** |   This column allows the user to provide a workspace for scaled background subtraction          |
-|                          |   (see below).                                                                                  |
+|                          |   (see below). This can either be the name of a workspace already in the ADS or math the Output |
+|                          |   Name from another row in the runs table.                                                      |
 +--------------------------+-------------------------------------------------------------------------------------------------+
 | **Scale Factor**         |   Scale factor to be used for scaled background subtraction (see below).                        |
 +--------------------------+-------------------------------------------------------------------------------------------------+

--- a/scripts/SANS/sans/algorithm_detail/batch_execution.py
+++ b/scripts/SANS/sans/algorithm_detail/batch_execution.py
@@ -567,7 +567,7 @@ def check_for_background_workspace_in_ads(state, reduction_package):
     )
 
     if AnalysisDataService.doesExist(full_name):
-        background_ws_name = full_name
+        return full_name
     else:
         raise ValueError(f"BackgroundWorkspace: The workspace '{background_ws_name}' or '{full_name}' could not be found in the ADS.")
 

--- a/scripts/SANS/sans/algorithm_detail/batch_execution.py
+++ b/scripts/SANS/sans/algorithm_detail/batch_execution.py
@@ -576,6 +576,11 @@ def check_for_background_workspace_in_ads(state, reduction_package):
 
 def create_scaled_background_workspace(state, reduction_package) -> str:
     state.background_subtraction.validate()
+    if reduction_package.reduction_mode == ReductionMode.ALL:
+        raise ValueError(
+            f"Reduction Mode '{ReductionMode.ALL}' is incompatible with scaled background reduction. The "
+            f"ReductionMode must be set to '{ReductionMode.MERGED}', '{ReductionMode.HAB}', or '{ReductionMode.LAB}'."
+        )
 
     background_ws_name = check_for_background_workspace_in_ads(state, reduction_package)
 
@@ -1606,11 +1611,6 @@ def subtract_scaled_background(reduction_package, scaled_ws_name: str):
         output_workspaces_names.append(output_name)
         output_workspaces.append(get_workspace_from_algorithm(minus_alg, "OutputWorkspace"))
 
-    if reduction_package.reduction_mode == ReductionMode.ALL:
-        raise ValueError(
-            f"Reduction Mode '{ReductionMode.ALL}' is incompatible with scaled background reduction. The "
-            f"ReductionMode must be set to '{ReductionMode.MERGED}', '{ReductionMode.HAB}', or '{ReductionMode.LAB}'."
-        )
     minus_name = "Minus"
     minus_options = {"RHSWorkspace": scaled_ws_name}
     output_workspaces_names = []

--- a/scripts/SANS/sans/algorithm_detail/batch_execution.py
+++ b/scripts/SANS/sans/algorithm_detail/batch_execution.py
@@ -153,9 +153,9 @@ def single_reduction_for_batch(state, use_optimizations, output_mode, plot_resul
         # ---------------------------------------
         # Subtract the background from the slice.
         # ---------------------------------------
-        if not scaled_background_ws:
-            scaled_background_ws = create_scaled_background_workspace(state, reduction_package)
-        if scaled_background_ws:
+        if state.background_subtraction.workspace or state.background_subtraction.scale_factor:
+            if not scaled_background_ws:
+                scaled_background_ws = create_scaled_background_workspace(state, reduction_package)
             reduction_package.reduced_bgsub, reduction_package.reduced_bgsub_name = subtract_scaled_background(
                 reduction_package, scaled_background_ws
             )
@@ -575,8 +575,6 @@ def check_for_background_workspace_in_ads(state, reduction_package):
 
 
 def create_scaled_background_workspace(state, reduction_package) -> str:
-    if not state.background_subtraction.workspace:
-        return None
     state.background_subtraction.validate()
 
     background_ws_name = check_for_background_workspace_in_ads(state, reduction_package)

--- a/scripts/SANS/sans/algorithm_detail/batch_execution.py
+++ b/scripts/SANS/sans/algorithm_detail/batch_execution.py
@@ -552,7 +552,7 @@ def check_for_background_workspace_in_ads(state, reduction_package):
     background_ws_name = state.background_subtraction.workspace
     if AnalysisDataService.doesExist(background_ws_name):
         return background_ws_name
-    # Check for full one.
+    # Look for a workspace that has a reduction suffix appended (such as _merged_1D_2.2_10.0)
     reduced_name = ""
     if reduction_package.reduction_mode == ReductionMode.MERGED:
         reduced_name = reduction_package.reduced_merged_name[0]

--- a/scripts/SANS/sans/algorithm_detail/batch_execution.py
+++ b/scripts/SANS/sans/algorithm_detail/batch_execution.py
@@ -116,6 +116,7 @@ def single_reduction_for_batch(state, use_optimizations, output_mode, plot_resul
         reduction_packages,
     )
 
+    scaled_background_ws = None
     # ------------------------------------------------------------------------------------------------------------------
     # Run reductions (one at a time)
     # ------------------------------------------------------------------------------------------------------------------
@@ -149,10 +150,11 @@ def single_reduction_for_batch(state, use_optimizations, output_mode, plot_resul
         reduction_package.out_scale_factor = out_scale_factor
         reduction_package.out_shift_factor = out_shift_factor
 
-        # -----------------------------------
+        # ---------------------------------------
         # Subtract the background from the slice.
-        # -----------------------------------
-        scaled_background_ws = create_scaled_background_workspace(state, reduction_package)
+        # ---------------------------------------
+        if not scaled_background_ws:
+            scaled_background_ws = create_scaled_background_workspace(state, reduction_package)
         if scaled_background_ws:
             reduction_package.reduced_bgsub, reduction_package.reduced_bgsub_name = subtract_scaled_background(
                 reduction_package, scaled_background_ws

--- a/scripts/test/SANS/algorithm_detail/batch_execution_test.py
+++ b/scripts/test/SANS/algorithm_detail/batch_execution_test.py
@@ -382,15 +382,6 @@ class GetAllNamesToSaveTest(unittest.TestCase):
         }
         mock_alg_manager.assert_called_once_with("SANSSave", **expected_options)
 
-    def test_get_scaled_background_workspace_no_background(self):
-        state = mock.MagicMock()
-        reduction_package = mock.MagicMock()
-        state.background_subtraction.workspace = None
-
-        result = create_scaled_background_workspace(state, reduction_package)
-
-        self.assertIsNone(result, "When no background ws is set, this should return None.")
-
     @mock.patch("sans.algorithm_detail.batch_execution.AnalysisDataService", new=ADSMock(True))
     @mock.patch("sans.algorithm_detail.batch_execution.create_unmanaged_algorithm")
     def test_get_scaled_background_workspace_calls_algs(self, mock_alg_manager):

--- a/scripts/test/SANS/algorithm_detail/batch_execution_test.py
+++ b/scripts/test/SANS/algorithm_detail/batch_execution_test.py
@@ -405,19 +405,6 @@ class GetAllNamesToSaveTest(unittest.TestCase):
         mock_alg_manager.assert_called_once_with("Scale", **expected_options)
         self.assertEqual(result, expected_out_name, "Should output the scaled ws name.")
 
-    def test_subtract_scaled_background_with_all_detectors_fails(self):
-        reduction_package = mock.MagicMock()
-        scaled_ws_name = "__workspace_scaled"
-        reduction_package.reduction_mode = ReductionMode.ALL
-        self.assertRaisesRegex(
-            ValueError,
-            f"Reduction Mode '{ReductionMode.ALL}' is incompatible with scaled background reduction. The ReductionMode "
-            f"must be set to '{ReductionMode.MERGED}', '{ReductionMode.HAB}', or '{ReductionMode.LAB}'.",
-            subtract_scaled_background,
-            reduction_package,
-            scaled_ws_name,
-        )
-
     @mock.patch("sans.algorithm_detail.batch_execution.AnalysisDataService", new=ADSMock(True))
     @mock.patch("sans.algorithm_detail.batch_execution.create_unmanaged_algorithm")
     def test_subtract_background_from_merged_calls_algorithms_correctly(self, mock_alg_manager):
@@ -480,6 +467,19 @@ class GetAllNamesToSaveTest(unittest.TestCase):
 
         self.assertRaisesRegex(
             ValueError, r"The workspace .* could not be found in the ADS\.", check_for_background_workspace_in_ads, state, reduction_package
+        )
+
+    def test_create_scaled_background_with_all_detectors_fails(self):
+        reduction_package = mock.MagicMock()
+        state = mock.MagicMock()
+        reduction_package.reduction_mode = ReductionMode.ALL
+        self.assertRaisesRegex(
+            ValueError,
+            f"Reduction Mode '{ReductionMode.ALL}' is incompatible with scaled background reduction. The ReductionMode "
+            f"must be set to '{ReductionMode.MERGED}', '{ReductionMode.HAB}', or '{ReductionMode.LAB}'.",
+            create_scaled_background_workspace,
+            state,
+            reduction_package,
         )
 
 

--- a/scripts/test/SANS/algorithm_detail/batch_execution_test.py
+++ b/scripts/test/SANS/algorithm_detail/batch_execution_test.py
@@ -383,23 +383,26 @@ class GetAllNamesToSaveTest(unittest.TestCase):
 
     def test_get_scaled_background_workspace_no_background(self):
         state = mock.MagicMock()
+        reduction_package = mock.MagicMock()
         state.background_subtraction.workspace = None
 
-        result = create_scaled_background_workspace(state)
+        result = create_scaled_background_workspace(state, reduction_package)
 
-        state.background_subtraction.validate.assert_called_once()
         self.assertIsNone(result, "When no background ws is set, this should return None.")
 
+    @mock.patch("sans.algorithm_detail.batch_execution.AnalysisDataService")
     @mock.patch("sans.algorithm_detail.batch_execution.create_unmanaged_algorithm")
-    def test_get_scaled_background_workspace_calls_algs(self, mock_alg_manager):
+    def test_get_scaled_background_workspace_calls_algs(self, mock_alg_manager, ads):
         state = mock.MagicMock()
+        reduction_package = mock.MagicMock()
+        ads.doesExist.return_value = True
         ws_name = "workspace"
         scale_factor = 1.12
         expected_out_name = "__" + ws_name + "_scaled"
         state.background_subtraction.workspace = ws_name
         state.background_subtraction.scale_factor = scale_factor
 
-        result = create_scaled_background_workspace(state)
+        result = create_scaled_background_workspace(state, reduction_package)
 
         state.background_subtraction.validate.assert_called_once()
 


### PR DESCRIPTION
**Description of work**

**Purpose of work**
There was a request to allow the output name from a previous row to be given as the BackgroundWorkspace on another row. The Output Name is not often the name of the output workspace as additional information is appended to the end.
**Report to:** @smk78 

**Summary of work**
This code uses the output from the normal reduction to determine what the appended suffix would be for the background workspace. It then looks for that workspace if the given BackgroundWorkspace name could not be found in the ADS.

**Further detail of work**
Giving an arbitrary workspace was part of the design requirements for this feature, so the check for the workspace with the suffix will only be done if the given name is not present in the ADS. 
Code has also been added to avoid re-running the scaling if a scaled workspace has already been created. 


**To test:**
1. Boot up workbench and the ISIS SANS interface. 
2. Load the user file and the batch file from the LOQ Demo in the TrainingCourseData
4. Process All (this will produce your "background" workspaces, something like
5. Check the `Scaled Background Subtraction` checkbox
6. Copy and paste a new row and set `Background Workspace` to `first_time`, and `Scale Factor` to 0.9.
7. Process this new row. 
8. Check the two output workspaces you should now have. If it has worked properly, the subtracted one's values should be 10% of the unsubtracted one's. 
9. Check that the batch can be saved and loaded and the background workspace and scale factor cells are preserved between loads. 

Fixes #35953 


*This does not require release notes* because **it adjusts a feature new to this release.**


<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.