### PR TITLE
Temporarily disable `TransformToIqt` doctest

### DIFF
--- a/docs/source/algorithms/TransformToIqt-v1.rst
+++ b/docs/source/algorithms/TransformToIqt-v1.rst
@@ -98,21 +98,15 @@ Usage
     sample = Load('irs26176_graphite002_red.nxs')
     can = Load('irs26173_graphite002_red.nxs')
 
-    params, iqt = TransformToIqt(SampleWorkspace=sample,
-                                 ResolutionWorkspace=can,
-                                 EnergyMin=-0.5,
-                                 EnergyMax=0.5,
-                                 BinReductionFactor=10)
+    # Commented out while we investigate an unreliable segmentation fault
+    # params, iqt = TransformToIqt(SampleWorkspace=sample,
+    #                              ResolutionWorkspace=can,
+    #                              EnergyMin=-0.5,
+    #                              EnergyMax=0.5,
+    #                              BinReductionFactor=10)
 
-    print('Number of output bins: %d' % (params.cell('SampleOutputBins', 0)))
-    print('Resolution bins: %d' % (params.cell('ResolutionBins', 0)))
-
-Output:
-
-.. testoutput:: exTransformToIqtIRIS
-
-    Number of output bins: 172
-    Resolution bins: 6
+    # print('Number of output bins: %d' % (params.cell('SampleOutputBins', 0)))
+    # print('Resolution bins: %d' % (params.cell('ResolutionBins', 0)))
 
 .. categories::
 


### PR DESCRIPTION
**Description of work**
This PR comments out the usage example for `TransformToIqt` due to an unreliable segmentation fault when running the doctests. An issue to investigate and re-enable this example has been created: #35992

**To test:**
Code review and check an issue to re-enable the test is opened

*There is no associated issue.*

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.