### PR TITLE
Add missing regex escape in delete old nightly releases workflow

### DIFF
--- a/.github/workflows/delete_old_nightly_releases.yml
+++ b/.github/workflows/delete_old_nightly_releases.yml
@@ -12,7 +12,7 @@ jobs:
         with:
           keep_latest: 3
           # Nightly tags are of the form v{major}.{minor}.{date}.{time}
-          delete_tag_regex: v\d.\d.\d{8}.\d{4}
+          delete_tag_regex: v\d\.\d\.\d{8}\.\d{4}
           prerelease_only: true
           delete_tags: true
         env:


### PR DESCRIPTION
**Description of work**
Added missing escape characters for dots in version string. We want it to match version numbers of the form:
v1.2.123456789.1234
but the dot in the regex was missing an escape character, so it could match this kind of thing too:
v1a2b123456789c1234

**To test:**
I've run the workflow on a sandbox repository:
https://github.com/thomashampson/sandbox/actions/runs/6048329206/job/16413468524
It has removed all but the three most recent pre-release versions which have a nightly-like tag:
https://github.com/thomashampson/sandbox/releases
and left the one without dots in intact.

*There is no associated issue.*

*This does not require release notes* because it does not affect the end user.


---

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.