### PR TITLE
Improve right-click behaviour in table view

### DIFF
--- a/docs/source/release/v6.8.0/Workbench/Bugfixes/35583.rst
+++ b/docs/source/release/v6.8.0/Workbench/Bugfixes/35583.rst
@@ -1,0 +1,1 @@
+- Improved right-click behaviour in the table view (e.g. "Show Data") when right-clicking on a row/column header.

--- a/qt/python/mantidqt/mantidqt/widgets/workspacedisplay/matrix/view.py
+++ b/qt/python/mantidqt/mantidqt/widgets/workspacedisplay/matrix/view.py
@@ -172,8 +172,11 @@ class MatrixWorkspaceDisplayView(QTabWidget):
         table = self.currentWidget()
         context_menu = self.setup_bin_context_menu(table)
         header = table.horizontalHeader()
-        # If you right-click on a column header, then select that column
-        table.selectColumn(header.logicalIndexAt(position))
+        # If you right-click on a column header, then select that column, unless you're already clicking
+        # inside a selected column
+        index_of_selected_column = header.logicalIndexAt(position)
+        if index_of_selected_column not in [x.column() for x in table.selectionModel().selectedColumns()]:
+            table.selectColumn(index_of_selected_column)
         context_menu.exec_(header.mapToGlobal(position))
 
     def spectra_context_menu_opened(self, position):
@@ -185,8 +188,11 @@ class MatrixWorkspaceDisplayView(QTabWidget):
         table = self.currentWidget()
         context_menu = self.setup_spectra_context_menu(table)
         header = table.verticalHeader()
-        # If you right-click on a row header, then select that row
-        table.selectRow(header.logicalIndexAt(position))
+        # If you right-click on a row header, then select that row, unless you're already clicking
+        # inside a selected row
+        index_of_selected_row = header.logicalIndexAt(position)
+        if index_of_selected_row not in [x.row() for x in table.selectionModel().selectedRows()]:
+            table.selectRow(index_of_selected_row)
         context_menu.exec_(header.mapToGlobal(position))
 
     def setup_plot_bin_actions(self, context_menu, table):

--- a/qt/python/mantidqt/mantidqt/widgets/workspacedisplay/matrix/view.py
+++ b/qt/python/mantidqt/mantidqt/widgets/workspacedisplay/matrix/view.py
@@ -169,8 +169,12 @@ class MatrixWorkspaceDisplayView(QTabWidget):
         :param position: The position to open the menu, e.g. where
                          the mouse button was clicked
         """
-        context_menu = self.setup_bin_context_menu(self.currentWidget())
-        context_menu.exec_(self.currentWidget().horizontalHeader().mapToGlobal(position))
+        table = self.currentWidget()
+        context_menu = self.setup_bin_context_menu(table)
+        header = table.horizontalHeader()
+        # If you right-click on a column header, then select that column
+        table.selectColumn(header.logicalIndexAt(position))
+        context_menu.exec_(header.mapToGlobal(position))
 
     def spectra_context_menu_opened(self, position):
         """
@@ -178,8 +182,12 @@ class MatrixWorkspaceDisplayView(QTabWidget):
         :param position: The position to open the menu, e.g. where
                          the mouse button was clicked
         """
-        context_menu = self.setup_spectra_context_menu(self.currentWidget())
-        context_menu.exec_(self.currentWidget().verticalHeader().mapToGlobal(position))
+        table = self.currentWidget()
+        context_menu = self.setup_spectra_context_menu(table)
+        header = table.verticalHeader()
+        # If you right-click on a row header, then select that row
+        table.selectRow(header.logicalIndexAt(position))
+        context_menu.exec_(header.mapToGlobal(position))
 
     def setup_plot_bin_actions(self, context_menu, table):
         plot_bin_action = QAction(self.GRAPH_ICON, "Plot bin (values only)", self)


### PR DESCRIPTION
If you right-click on a row or column header in the table view (e.g. "Show Data"), then that row or column will be selected.

**Description of work**
In the methods that set up the header context menus, the relevant row/column is now selected.

**Purpose of work**
<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
-->
Fixes #35583 

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**Summary of work**
<!-- Please provide a short, high level description of the work that was done.
-->
When right-clicking on a row or column header in the table view, that whole row/column will be selected before opening the context menu. This stops you right-clicking on a row/column header then accidentally exporting some data selected in another place, i.e. the assumption now is that if you right-click on a header, then you want the data in that row/column.

**To test:**

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->
- See #35583 for original issue
- Maybe try selecting some data, then right clicking in various places. Export, copy, plot, etc from the context menu should all still work, (and do their thing on the correct numbers).

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.