### PR TITLE
Group Background Subtracted Workspaces Correctly

### DIFF
--- a/scripts/SANS/sans/algorithm_detail/batch_execution.py
+++ b/scripts/SANS/sans/algorithm_detail/batch_execution.py
@@ -1179,6 +1179,9 @@ def group_workspaces_if_required(reduction_package, output_mode, save_can, event
             add_to_group(reduced_lab, reduction_package.reduced_lab_base_name)
             add_to_group(reduced_hab, reduction_package.reduced_hab_base_name)
 
+    if requires_grouping:
+        group_bgsub_if_required(reduction_package)
+
     # Can group workspace depends on if save_can is checked and output_mode
     # Logic table for which group to save CAN into
     # CAN | FILE | In OPTIMIZATION group
@@ -1209,6 +1212,22 @@ def group_workspaces_if_required(reduction_package, output_mode, save_can, event
     add_to_group(reduction_package.calculated_transmission_can, reduction_package.calculated_transmission_can_base_name)
     add_to_group(reduction_package.unfitted_transmission, reduction_package.unfitted_transmission_base_name)
     add_to_group(reduction_package.unfitted_transmission_can, reduction_package.unfitted_transmission_can_base_name)
+
+
+def group_bgsub_if_required(reduction_package):
+    reduced_bgsub = reduction_package.reduced_bgsub
+    is_bgsub_reduction = reduced_bgsub is not None
+
+    if is_bgsub_reduction:
+        base_names = []
+        if reduction_package.reduction_mode == ReductionMode.HAB:
+            base_names = reduction_package.reduced_lab_base_name
+        if reduction_package.reduction_mode == ReductionMode.LAB:
+            base_names = reduction_package.reduced_lab_base_name
+        if reduction_package.reduction_mode == ReductionMode.MERGED:
+            base_names = reduction_package.reduced_merged_base_name
+        for ws, base_name in zip(reduced_bgsub, base_names):
+            add_to_group(ws, base_name)
 
 
 def add_to_group(workspace, name_of_group_workspace):

--- a/scripts/test/SANS/algorithm_detail/batch_execution_test.py
+++ b/scripts/test/SANS/algorithm_detail/batch_execution_test.py
@@ -383,6 +383,8 @@ class GetAllNamesToSaveTest(unittest.TestCase):
         }
         mock_alg_manager.assert_called_once_with("SANSSave", **expected_options)
 
+
+class ScaledBackgroundSubtractionTest(unittest.TestCase):
     @mock.patch("sans.algorithm_detail.batch_execution.AnalysisDataService", new=ADSMock(True))
     @mock.patch("sans.algorithm_detail.batch_execution.create_unmanaged_algorithm")
     def test_get_scaled_background_workspace_calls_algs(self, mock_alg_manager):

--- a/scripts/test/SANS/algorithm_detail/batch_execution_test.py
+++ b/scripts/test/SANS/algorithm_detail/batch_execution_test.py
@@ -20,6 +20,7 @@ from sans.algorithm_detail.batch_execution import (
     create_scaled_background_workspace,
     subtract_scaled_background,
     check_for_background_workspace_in_ads,
+    group_bgsub_if_required,
 )
 from sans.common.enums import SaveType, ReductionMode
 
@@ -481,6 +482,19 @@ class GetAllNamesToSaveTest(unittest.TestCase):
             state,
             reduction_package,
         )
+
+    @mock.patch("sans.algorithm_detail.batch_execution.add_to_group")
+    def test_group_bgsub_if_required(self, mock_add):
+        reduction_package = mock.MagicMock()
+        reduction_package.reduction_mode = ReductionMode.MERGED
+        mock_bgsub_ws_1 = mock.MagicMock()
+        mock_bgsub_ws_2 = mock.MagicMock()
+        reduction_package.reduced_bgsub = [mock_bgsub_ws_1, mock_bgsub_ws_2]
+        reduction_package.reduced_merged_base_name = ["merged", "merged_2"]
+        group_bgsub_if_required(reduction_package)
+
+        mock_add.assert_any_call(reduction_package.reduced_bgsub[0], reduction_package.reduced_merged_base_name[0])
+        mock_add.assert_called_with(reduction_package.reduced_bgsub[1], reduction_package.reduced_merged_base_name[1])
 
 
 class DeleteMethodsTest(unittest.TestCase):


### PR DESCRIPTION
**Description of work**

**Purpose of work**
When time slicing, many workspaces are created which are grouped together at the end of the reduction. The background subtracted workspaces (workspaces with `_bgsub` appended), were not included in this output group and so were making the Workspaces tracker messy. 

**Summary of work**
Adds checks to the reduction to see if a background subtraction has been done and groups the background subtracted workspaces in with the rest of the time slicing output. 

**Further detail of work**
Assumes that the reduction mode is set to HAB, LAB, or MERGED as the reduction fails if set to ALL and the background subtraction parameters are set. Uses the base name based on the reduction mode setting, as this is the primary output the user cares about. 
Also moves tests out of the `GetAllNamesToSave` class and into a new one concerning the background subtraction functionality. 

**To test:**
1. Boot up workbench and the ISIS SANS interface. 
2. Check that the reduction mode value in the User File is set to Merged.
3. Load the user file and the batch file from the LOQ Demo in the TrainingCourseData
4. Process One of the rows. 
5. Check the `Scaled Background Subtraction` checkbox
6. Copy and paste a new row, give it a new output name, and set `Background Workspace` to an the `merged` output from the previous run, and `Scale Factor` to 0.9.
7. Switch to settings and enter `8-10,12:2:16,20-22` into the time slicing box. 
8. Process this new row. 
9. Check that the `_bgsub` output workspaces are present in the group workspaces

Fixes #35997 


*This does not require release notes* because **it is a part of a feature new to this release.**


<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.