### PR TITLE
Minor fixes for isis single-crystal reduction class

### DIFF
--- a/Testing/SystemTests/tests/framework/ISIS_WISHSingleCrystalReduction.py
+++ b/Testing/SystemTests/tests/framework/ISIS_WISHSingleCrystalReduction.py
@@ -201,7 +201,7 @@ class WISHProcessVanadiumForNormalisationTest(MantidSystemTest):
         ADS.clear()
 
     def runTest(self):
-        wish = WishSX(vanadium_runno=19612, ext=".nxs")  # load .nxs that only includes spectra nums 1-19461
+        wish = WishSX(vanadium_runno=19612, file_ext=".nxs")  # load .nxs that only includes spectra nums 1-19461
         wish.process_vanadium()
         # select subset of spectra for comparision
         ExtractSpectra(InputWorkspace="WISH00019612", OutputWorkspace="WISH00019612_spec", WorkspaceIndexList="500,2500,10000")

--- a/docs/source/release/v6.8.0/Diffraction/Single_Crystal/Bugfixes/36006.rst
+++ b/docs/source/release/v6.8.0/Diffraction/Single_Crystal/Bugfixes/36006.rst
@@ -1,0 +1,3 @@
+- ISIS single crystal reduction classes now set UB before attempting to transform data to HKL using ``convert_to_MD`` method
+- Fixed bug in ISIS single crystal reduction classes where UB was not set on combined peak table when saving using ``save_all_peaks`` method.
+- Fixed bug in ISIS single crystal reduction classes when defining goniometer angles in ``process_data`` method with a sequence (i.e. not using the motor name string)

--- a/docs/source/release/v6.8.0/Diffraction/Single_Crystal/New_features/36006.rst
+++ b/docs/source/release/v6.8.0/Diffraction/Single_Crystal/New_features/36006.rst
@@ -1,0 +1,1 @@
+- ISIS single crystal reduction class for SXD now supports defining a file extension when loading data (previously available for WISH class - in both cases the argument to ``load_run`` has been renamed to ``file_ext``)

--- a/scripts/Diffraction/single_crystal/base_sx.py
+++ b/scripts/Diffraction/single_crystal/base_sx.py
@@ -30,13 +30,14 @@ class INTEGRATION_TYPE(Enum):
 
 
 class BaseSX(ABC):
-    def __init__(self, vanadium_runno: str):
+    def __init__(self, vanadium_runno: str, file_ext: str):
         self.runs = dict()
         self.van_runno = vanadium_runno
         self.van_ws = None
         self.gonio_axes = None
         self.sample_dict = None
         self.n_mcevents = 1200
+        self.file_ext = file_ext  # file extension
 
     # --- decorator to apply to all runs is run=None ---
     def default_apply_to_all_runs(func):

--- a/scripts/Diffraction/single_crystal/test/test_sxd.py
+++ b/scripts/Diffraction/single_crystal/test/test_sxd.py
@@ -154,6 +154,26 @@ class SXDTest(unittest.TestCase):
         mock_save_nxs.assert_called_once_with(InputWorkspace=self.peaks.name(), Filename=fpath + ".nxs")
         mock_save_ref.assert_called_once_with(InputWorkspace=self.peaks.name(), Filename=fpath + ".int", Format=fmt, SplitFiles=False)
 
+    @patch(sxd_path + ".mantid.SaveReflections")
+    @patch(sxd_path + ".mantid.SaveNexus")
+    def test_save_all_peaks(self, mock_save_nxs, mock_save_ref):
+        self.sxd.runs = dict()
+        for runno in range(1234, 1236):
+            self.sxd.runs[str(runno)] = {"ws": self.ws.name(), "found_int_MD_opt": self.peaks.name()}
+        SetUB(self.peaks, UB="0.25,0,0,0,0.25,0,0,0,0.1")
+
+        pk_type, int_type = PEAK_TYPE.FOUND, INTEGRATION_TYPE.MD_OPTIMAL_RADIUS
+        fmt = "SHELX"
+
+        self.sxd.save_all_peaks(pk_type, int_type, self._test_dir, fmt)
+
+        all_peaks_name = "1234-1235_found_int_MD_opt"
+        fpath = path.join(self._test_dir, f"{all_peaks_name}_{fmt}")
+        mock_save_nxs.assert_called_once_with(InputWorkspace=all_peaks_name, Filename=fpath + ".nxs")
+        mock_save_ref.assert_called_once_with(InputWorkspace=all_peaks_name, Filename=fpath + ".int", Format=fmt, SplitFiles=False)
+        self.assertTrue(HasUB(Workspace=all_peaks_name))
+        ClearUB(Workspace=self.peaks)
+
     def test_predict_peaks(self):
         # make peaks ws and set a UB
         peaks = self._make_peaks_detids(wsname="peaks_for_predict")

--- a/scripts/Diffraction/wish/wishSX.py
+++ b/scripts/Diffraction/wish/wishSX.py
@@ -17,13 +17,12 @@ lambda_min = 0.8
 
 
 class WishSX(BaseSX):
-    def __init__(self, vanadium_runno=None, ext=".raw"):
-        super().__init__(vanadium_runno)
+    def __init__(self, vanadium_runno=None, file_ext=".raw"):
+        super().__init__(vanadium_runno, file_ext)
         self.sphere_shape = """<sphere id="sphere">
                                <centre x="0.0"  y="0.0" z="0.0" />
                                <radius val="0.0025"/>
                                </sphere>"""  # sphere radius 2.5mm  - used for vanadium and NaCl
-        self.ext = ext  # allow to load .nxs for testing purposes
 
     def process_data(self, runs: Sequence[str], *args):
         """
@@ -34,7 +33,7 @@ class WishSX(BaseSX):
         """
         gonio_angles = args
         for irun, run in enumerate(runs):
-            wsname = self.load_run(run, self.ext)
+            wsname = self.load_run(run, self.file_ext)
             # set goniometer
             if self.gonio_axes is not None:
                 if len(gonio_angles) != len(self.gonio_axes):
@@ -81,7 +80,7 @@ class WishSX(BaseSX):
 
     def process_vanadium(self):
         # vanadium
-        self.van_ws = self.load_run(self.van_runno, ext=self.ext)
+        self.van_ws = self.load_run(self.van_runno, ext=self.file_ext)
         mantid.SmoothNeighbours(InputWorkspace=self.van_ws, OutputWorkspace=self.van_ws, Radius=3)
         mantid.SmoothData(InputWorkspace=self.van_ws, OutputWorkspace=self.van_ws, NPoints=301)
         # correct vanadium for absorption
@@ -97,10 +96,10 @@ class WishSX(BaseSX):
         mantid.ConvertUnits(InputWorkspace=self.van_ws, OutputWorkspace=self.van_ws, Target="TOF", EnableLogging=False)
 
     @staticmethod
-    def load_run(runno, ext=".raw"):
+    def load_run(runno, file_ext=".raw"):
         wsname = "WISH000" + str(runno)
         mon_name = wsname + "_monitors"
-        mantid.Load(Filename=wsname + ext, OutputWorkspace=wsname)
+        mantid.Load(Filename=wsname + file_ext, OutputWorkspace=wsname)
         mantid.ExtractMonitors(InputWorkspace=wsname, DetectorWorkspace=wsname, MonitorWorkspace=mon_name)
         mantid.CropWorkspace(InputWorkspace=wsname, OutputWorkspace=wsname, XMin=tof_min, XMax=tof_max)
         mantid.CropWorkspace(InputWorkspace=mon_name, OutputWorkspace=mon_name, XMin=tof_min, XMax=tof_max)

--- a/scripts/Diffraction/wish/wishSX.py
+++ b/scripts/Diffraction/wish/wishSX.py
@@ -93,7 +93,7 @@ class WishSX(BaseSX):
 
     def process_vanadium(self):
         # vanadium
-        self.van_ws = self.load_run(self.van_runno, ext=self.file_ext)
+        self.van_ws = self.load_run(self.van_runno, file_ext=self.file_ext)
         mantid.SmoothNeighbours(InputWorkspace=self.van_ws, OutputWorkspace=self.van_ws, Radius=3)
         mantid.SmoothData(InputWorkspace=self.van_ws, OutputWorkspace=self.van_ws, NPoints=301)
         # correct vanadium for absorption

--- a/scripts/Diffraction/wish/wishSX.py
+++ b/scripts/Diffraction/wish/wishSX.py
@@ -26,10 +26,16 @@ class WishSX(BaseSX):
 
     def process_data(self, runs: Sequence[str], *args):
         """
-        Loads runs, set goniometer (based on positional args), normalises by vanadium and corrects for absorption
-        :param runs: list of run numbers (string or int)
-        :param args: positonal args (require one for each goniometer axis) - can be motor names or lists of angles (one for each run)
-        :return: name of last loaded workspaces
+        Function to load and normalise a sequence of runs
+        :param runs: sequence of run numbers (can be ints or string)
+        :param args: goniometer angles - one positional arg for each goniometer axis/motor
+        :return: workspace name of last run loaded
+
+        Examples for providing goniometer angles (passed to SetGoniometer)
+        e.g. using motor names for 2 axes defined sxd.set_goniometer_axes for 3 runs
+        wish.process_data(range(3), "wccr", "ewald_pos")
+        e.g. using a sequence of angles for each motor
+        wish.process_data(range(3), [1,2,3], [4,5,6]])  # e.g. for the first run wccr=1 and ewald_pos=4
         """
         gonio_angles = args
         for irun, run in enumerate(runs):
@@ -37,13 +43,20 @@ class WishSX(BaseSX):
             # set goniometer
             if self.gonio_axes is not None:
                 if len(gonio_angles) != len(self.gonio_axes):
-                    logger.warning("No goniometer will be applied as the number of goniometer angles doesn't match the number of axes set.")
+                    logger.warning(
+                        "No goniometer will be applied as the number of goniometer angles doesn't " "match the number of axes set."
+                    )
                 elif isinstance(gonio_angles[0], str):
-                    # gonio_angles are a list of motor strings (same for all runs)
                     self._set_goniometer_on_ws(wsname, gonio_angles)
                 else:
-                    # gonio_angles is a list of individual or tuple motor angles for each run
-                    self._set_goniometer_on_ws(wsname, gonio_angles[irun])
+                    if len(gonio_angles[0]) == len(runs):
+                        # gonio_angles is a list of individual or tuple motor angles for each run
+                        self._set_goniometer_on_ws(wsname, [angles[irun] for angles in gonio_angles])
+                    else:
+                        logger.warning(
+                            "No goniometer will be applied as the number of goniometer angles for each motor doesn't "
+                            "match the number of runs."
+                        )
             # correct for empty counts and normalise by vanadium
             self._divide_workspaces(wsname, self.van_ws)  # van_ws has been converted to TOF
             # set sample (must be done after gonio to rotate shape) and correct for attenuation


### PR DESCRIPTION
**Description of work**
Fixed a few bugs in the single-crystal reduction classes

- ISIS single crystal reduction classes now set UB before attempting to transform data to HKL using ``convert_to_MD`` method
- Fixed bug in ISIS single crystal reduction classes where UB was not set on combined peak table when saving using ``save_all_peaks`` method.
- Fixed bug in ISIS single crystal reduction classes when defining multiple goniometer angles in ``process_data`` method with a sequence (i.e. not using the motor name string)
- ISIS single crystal reduction class for SXD now supports defining a file extension when loading data (previously available for WISH class - in both cases the argument to ``load_run`` has been renamed to ``file_ext``)

**To test:**

Unit tests should cover it but you can run some of these snippets

(1) Test file extension argument (check workspace history to confirm)
```
sxd = SXD()
wsname = sxd.load_run(32863, file_ext=".nxs")
```
(2) Test goniometer can be set with sequences (i.e. this executes without error)
```
sxd = SXD(vanadium_runno=32857, empty_runno=32856, detcal_path=r"\\olympic\Babylon5\Public\RWaite\SXD_demo\SXD32863_peaks_detcal.xml")
sxd.process_vanadium()
sxd.set_goniometer_axes([0,1,0,1])  # ccw rotation around vertical
runs = range(32863,32865)
sxd.process_data(runs, [-150, -145])
```
(3) Test UB is copied from peaks workspace (i.e. this executes without error)
```
ws = sxd.get_ws(runs[0])
peaks = sxd.find_sx_peaks(ws,  nstd=8)
FindUBUsingFFT(PeaksWorkspace=peaks, MinD=1, MaxD=10)
sxd.set_peaks(runs[0], peaks)
sxd.convert_to_MD(run, frame="HKL")
```

*There is no associated issue.*

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.