### PR TITLE
distutils.LooseVersion deprecated in Python 3.10

### DIFF
--- a/Framework/PythonInterface/mantid/plots/legend.py
+++ b/Framework/PythonInterface/mantid/plots/legend.py
@@ -10,7 +10,7 @@
 """
 Functionality for dealing with legends on plots
 """
-from distutils.version import LooseVersion
+from packaging.version import Version
 
 import matplotlib
 from matplotlib.patches import BoxStyle
@@ -68,7 +68,7 @@ class LegendProperties(dict):
         else:
             props["round_edges"] = False
 
-        if LooseVersion(matplotlib.__version__) >= LooseVersion("3.6.0"):
+        if Version(matplotlib.__version__) >= Version("3.6.0"):
             props["columns"] = legend._ncols
         else:
             props["columns"] = legend._ncol
@@ -133,7 +133,7 @@ class LegendProperties(dict):
         if "loc" in props.keys():
             loc = props["loc"]
 
-        if LooseVersion(matplotlib.__version__) >= LooseVersion("3.6.0"):
+        if Version(matplotlib.__version__) >= Version("3.6.0"):
             legend = ax.legend(
                 handles=get_legend_handles(ax),
                 ncols=props["columns"],

--- a/Framework/PythonInterface/mantid/plots/scales.py
+++ b/Framework/PythonInterface/mantid/plots/scales.py
@@ -8,7 +8,6 @@
 """
 Defines a set of custom axis scales
 """
-from mantid.plots.utility import mpl_version_info
 from matplotlib.scale import ScaleBase
 from matplotlib.ticker import AutoLocator, NullFormatter, NullLocator, ScalarFormatter
 from matplotlib.transforms import Transform
@@ -30,10 +29,7 @@ class PowerScale(ScaleBase):
 
         gamma: The power used to scale the data.
         """
-        if mpl_version_info() > (3,):
-            super(PowerScale, self).__init__(_axis)
-        else:
-            super(PowerScale, self).__init__()
+        super(PowerScale, self).__init__(_axis)
         gamma = kwargs.pop("gamma", None)
         if gamma is None:
             raise ValueError("power scale must specify gamma value")

--- a/Framework/PythonInterface/mantid/plots/utility.py
+++ b/Framework/PythonInterface/mantid/plots/utility.py
@@ -6,24 +6,18 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 #  This file is part of the mantid package
 # std imports
-import collections
 from contextlib import contextmanager
 from enum import Enum
-from distutils.version import LooseVersion
 
 # 3rd party imports
 from matplotlib import colors
 from matplotlib.legend import Legend
-from matplotlib import colormaps, __version__ as mpl_version_str
+from matplotlib import colormaps
 from matplotlib.container import ErrorbarContainer
 
 # -----------------------------------------------------------------------------
 # Constants
 # -----------------------------------------------------------------------------
-# matplotlib version information
-MPLVersionInfo = collections.namedtuple("MPLVersionInfo", ("major", "minor", "patch"))
-MATPLOTLIB_VERSION_INFO = MPLVersionInfo._make(map(int, mpl_version_str.split(".")))
-
 # Restrict zooming out of plots.
 ZOOM_LIMIT = 1e300
 
@@ -152,35 +146,20 @@ def get_current_cmap(object):
         return object.get_cmap()
 
 
-def mpl_version_info():
-    """Returns a namedtuple of (major,minor,patch)"""
-    return MATPLOTLIB_VERSION_INFO
-
-
 def row_num(ax):
     """
     Returns the row number of an input axes with relation to a gridspec
-    Version check to avoid calling depreciated method in matplotlib > 3.2
     """
-    if LooseVersion(mpl_version_str) >= LooseVersion("3.2.0"):
-        # An 'inset' axes does not have a subplotspec, so return None
-        return ax.get_subplotspec().rowspan.start if hasattr(ax, "get_subplotspec") else None
-    else:
-        # An 'inset' axes does not have a rowNum, so return None
-        return ax.rowNum if hasattr(ax, "rowNum") else None
+    # An 'inset' axes does not have a subplotspec, so return None
+    return ax.get_subplotspec().rowspan.start if hasattr(ax, "get_subplotspec") else None
 
 
 def col_num(ax):
     """
     Returns the column number of an input axes with relation to a gridspec
-    Version check to avoid calling depreciated method in matplotlib > 3.2
     """
-    if LooseVersion(mpl_version_str) >= LooseVersion("3.2.0"):
-        # An 'inset' axes does not have a subplotspec, so return None
-        return ax.get_subplotspec().colspan.start if hasattr(ax, "get_subplotspec") else None
-    else:
-        # An 'inset' axes does not have a colNum, so return None
-        return ax.colNum if hasattr(ax, "colNum") else None
+    # An 'inset' axes does not have a subplotspec, so return None
+    return ax.get_subplotspec().colspan.start if hasattr(ax, "get_subplotspec") else None
 
 
 def zoom_axis(ax, coord, x_or_y, factor):

--- a/Framework/PythonInterface/plugins/algorithms/ExportSampleLogsToCSVFile.py
+++ b/Framework/PythonInterface/plugins/algorithms/ExportSampleLogsToCSVFile.py
@@ -7,7 +7,6 @@
 # pylint: disable=no-init,invalid-name,too-many-instance-attributes
 from mantid.api import *
 from mantid.kernel import *
-from distutils.version import LooseVersion
 import numpy as np
 import os
 
@@ -202,9 +201,6 @@ class ExportSampleLogsToCSVFile(PythonAlgorithm):
             localtimediff = np.timedelta64(0, "s")
 
         epoch = "1990-01-01T00:00"
-        # older numpy assumes local timezone
-        if LooseVersion(np.__version__) < LooseVersion("1.9"):
-            epoch = epoch + "Z"
         return np.datetime64(epoch) + localtimediff
 
     def _getLogsInfo(self, logtimeslist):

--- a/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/FindPeaksAutomatic.py
+++ b/Framework/PythonInterface/plugins/algorithms/WorkflowAlgorithms/FindPeaksAutomatic.py
@@ -378,23 +378,17 @@ class FindPeaksAutomatic(DataProcessorAlgorithm):
         )
         prog_reporter.report("Removed background")
 
-        # Find all the peaks. find_peaks was introduced in scipy 1.1.0, if using an older version use find_peaks_cwt
-        # however this will not do an equally good job as it cannot sort by prominence (also added in 1.1.0)
-        from distutils.version import LooseVersion
+        # Find all the peaks. find_peaks was introduced in scipy 1.1.0
         import scipy
 
-        if LooseVersion(scipy.__version__) >= LooseVersion("1.1.0"):
-            raw_peaks, _ = scipy.signal.find_peaks(raw_yvals)
-            flat_peaks, params = scipy.signal.find_peaks(flat_yvals, prominence=(None, None))
-            prominence = params["prominences"]
-            flat_peaks = sorted(zip(flat_peaks, prominence), key=lambda x: x[1], reverse=True)
-            if fit_to_baseline:
-                flat_peaks = [peak_idx for peak_idx, prom in flat_peaks if peak_idx]
-            else:
-                flat_peaks = [peak_idx for peak_idx, prom in flat_peaks if peak_idx in raw_peaks]
+        raw_peaks, _ = scipy.signal.find_peaks(raw_yvals)
+        flat_peaks, params = scipy.signal.find_peaks(flat_yvals, prominence=(None, None))
+        prominence = params["prominences"]
+        flat_peaks = sorted(zip(flat_peaks, prominence), key=lambda x: x[1], reverse=True)
+        if fit_to_baseline:
+            flat_peaks = [peak_idx for peak_idx, prom in flat_peaks if peak_idx]
         else:
-            flat_peaks = scipy.signal.find_peaks_cwt(flat_yvals, widths=np.array([0.1]))
-            flat_peaks = sorted(flat_peaks, key=lambda peak_idx: flat_yvals[peak_idx], reverse=True)
+            flat_peaks = [peak_idx for peak_idx, prom in flat_peaks if peak_idx in raw_peaks]
 
         return (
             self.find_good_peaks(

--- a/Framework/PythonInterface/test/python/mantid/kernel/DateAndTimeTest.py
+++ b/Framework/PythonInterface/test/python/mantid/kernel/DateAndTimeTest.py
@@ -6,13 +6,10 @@
 # SPDX - License - Identifier: GPL - 3.0 +
 import unittest
 from mantid.kernel import DateAndTime
-import numpy
 from numpy import timedelta64, datetime64
-from distutils.version import LooseVersion
 
 
 class DateAndTimeTest(unittest.TestCase):
-
     iso_str = "2008-12-18T17:58:38"
     # We had to add a space to the end of the string representation to get around an IPython bug (#8351)
     iso_str_plus_space = iso_str + " "
@@ -36,10 +33,8 @@ class DateAndTimeTest(unittest.TestCase):
         self.assertEqual(dt, dt_np)
 
     def test_convert_from_np(self):
-        if LooseVersion(numpy.__version__) < LooseVersion("1.9"):
-            dt_np = datetime64("2000-01-01T00:00Z")
-        else:  # newer numpy only uses UTC and warns on specifying timezones
-            dt_np = datetime64("2000-01-01T00:00")
+        # newer numpy only uses UTC and warns on specifying timezones
+        dt_np = datetime64("2000-01-01T00:00")
         dt = DateAndTime(dt_np)
 
         # convert both into ISO8601 strings up to the minutes b/c time was only specified that much

--- a/Framework/PythonInterface/test/python/mantid/plots/ScalesTest.py
+++ b/Framework/PythonInterface/test/python/mantid/plots/ScalesTest.py
@@ -16,7 +16,7 @@ import unittest
 from matplotlib.scale import scale_factory
 from mantid.plots.scales import PowerScale, SquareScale
 import numpy as np
-import testhelpers
+from numpy.testing import assert_almost_equal
 
 
 class ScalesTest(unittest.TestCase):
@@ -28,28 +28,28 @@ class ScalesTest(unittest.TestCase):
         scale = PowerScale(None, gamma=gamma)
         x = np.linspace(0, 10)
         transform = scale.get_transform()
-        testhelpers.assert_almost_equal(np.power(x, gamma), transform.transform_non_affine(x))
+        assert_almost_equal(np.power(x, gamma), transform.transform_non_affine(x))
 
     def test_power_transform_mix_positive_negative(self):
         gamma = 3
         scale = PowerScale(None, gamma=gamma)
         x = np.linspace(-5, 5)
         transform = scale.get_transform()
-        testhelpers.assert_almost_equal(np.power(x, gamma), transform.transform_non_affine(x))
+        assert_almost_equal(np.power(x, gamma), transform.transform_non_affine(x))
 
     def test_power_transform_all_negative(self):
         gamma = 3
         scale = PowerScale(None, gamma=gamma)
         x = np.linspace(-10, 0)
         transform = scale.get_transform()
-        testhelpers.assert_almost_equal(np.power(x, gamma), transform.transform_non_affine(x))
+        assert_almost_equal(np.power(x, gamma), transform.transform_non_affine(x))
 
     def test_power_inverse_transform_all_positive(self):
         gamma = 3
         scale = PowerScale(None, gamma=gamma)
         x = np.linspace(0, 10)
         inv_transform = scale.get_transform().inverted()
-        testhelpers.assert_almost_equal(np.power(x, 1.0 / gamma), inv_transform.transform_non_affine(x))
+        assert_almost_equal(np.power(x, 1.0 / gamma), inv_transform.transform_non_affine(x))
 
     def test_power_inverse_transform_mix_positive_negative(self):
         gamma = 3
@@ -62,7 +62,7 @@ class ScalesTest(unittest.TestCase):
         np.negative(expected, where=negative_pos, out=expected)
         inv_transform = scale.get_transform().inverted()
 
-        testhelpers.assert_almost_equal(expected, inv_transform.transform_non_affine(x))
+        assert_almost_equal(expected, inv_transform.transform_non_affine(x))
 
     def test_power_inverse_transform_all_negative(self):
         gamma = 3
@@ -70,7 +70,7 @@ class ScalesTest(unittest.TestCase):
         x = np.linspace(-10, 0)
         expected = np.negative(np.power(np.negative(x), 1.0 / gamma))
         inv_transform = scale.get_transform().inverted()
-        testhelpers.assert_almost_equal(expected, inv_transform.transform_non_affine(x))
+        assert_almost_equal(expected, inv_transform.transform_non_affine(x))
 
     def test_square_scale_registered_in_factory(self):
         self.assertTrue(isinstance(scale_factory("square", axis=None), SquareScale))
@@ -79,13 +79,13 @@ class ScalesTest(unittest.TestCase):
         scale = SquareScale(None)
         x = np.linspace(0, 10, 1)
         transform = scale.get_transform()
-        testhelpers.assert_almost_equal(np.power(x, 2), transform.transform_non_affine(x))
+        assert_almost_equal(np.power(x, 2), transform.transform_non_affine(x))
 
     def test_square_inverse_transform(self):
         scale = SquareScale(None)
         x = np.linspace(0, 10, 1)
         inv_transform = scale.get_transform().inverted()
-        testhelpers.assert_almost_equal(np.sqrt(x), inv_transform.transform_non_affine(x))
+        assert_almost_equal(np.sqrt(x), inv_transform.transform_non_affine(x))
 
 
 if __name__ == "__main__":

--- a/Framework/PythonInterface/test/python/plugins/algorithms/CalculateFluxTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/CalculateFluxTest.py
@@ -7,13 +7,9 @@
 import unittest
 from mantid.simpleapi import CalculateFlux, CreateSampleWorkspace, FindDetectorsInShape, mtd
 import numpy as np
-import testhelpers
 
 
 class CalculateFluxTest(unittest.TestCase):
-
-    pixels_in_shape = 0
-
     def setUp(self):
         ws = CreateSampleWorkspace(XUnit="Wavelength", NumBanks=1, Function="One Peak")
         shape = FindDetectorsInShape(
@@ -28,7 +24,6 @@ class CalculateFluxTest(unittest.TestCase):
         mtd.clear()
 
     def testTOF(self):
-
         CalculateFlux(InputWorkspace="ws", BeamRadius=0.05, OutputWorkspace="flux")
         self.assertTrue(mtd["flux"])
         self.assertEqual(mtd["flux"].getNumberHistograms(), 1)
@@ -38,7 +33,7 @@ class CalculateFluxTest(unittest.TestCase):
         expectation.fill(self.pixels_in_shape * 0.3)
         expectation[50] = self.pixels_in_shape * 10.3
         reality = mtd["flux"].readY(0)
-        testhelpers.assert_almost_equal(reality, expectation, decimal=6)
+        np.testing.assert_almost_equal(reality, expectation, decimal=6)
 
 
 if __name__ == "__main__":

--- a/Framework/PythonInterface/test/python/plugins/algorithms/ExportSampleLogsToCSVFileTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/ExportSampleLogsToCSVFileTest.py
@@ -10,7 +10,6 @@ import mantid.kernel as kernel
 from testhelpers import run_algorithm
 from mantid.api import AnalysisDataService
 import os
-from distutils.version import LooseVersion
 
 
 class ExportVulcanSampleLogTest(unittest.TestCase):
@@ -310,9 +309,6 @@ class ExportVulcanSampleLogTest(unittest.TestCase):
         dtimesec = 0.0010
         timefluc = 0.0001
         runstart = "2014-02-15T13:34:03"
-        # older numpy assumes local timezone
-        if LooseVersion(numpy.__version__) < LooseVersion("1.9"):
-            runstart = runstart + "Z"
         runstart = datetime64(runstart, "us")  # microsecond needed for deltas
 
         AddSampleLog(Workspace=wksp, LogName="run_start", LogText=str(runstart))

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/DirectILLApplySelfShieldingTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/DirectILLApplySelfShieldingTest.py
@@ -7,8 +7,8 @@
 
 from mantid.api import mtd
 from mantid.simpleapi import CloneWorkspace
-import numpy.testing
-from testhelpers import assert_almost_equal, illhelpers, run_algorithm
+from numpy.testing import assert_almost_equal
+from testhelpers import illhelpers, run_algorithm
 import unittest
 
 

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/DirectILLCollectDataTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/DirectILLCollectDataTest.py
@@ -5,8 +5,8 @@
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
 from mantid.api import mtd
-import numpy.testing
-from testhelpers import assert_almost_equal, illhelpers, run_algorithm
+from numpy.testing import assert_almost_equal
+from testhelpers import illhelpers, run_algorithm
 import unittest
 
 

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/DirectILLReductionTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/DirectILLReductionTest.py
@@ -8,8 +8,8 @@ import collections
 from mantid.api import mtd
 from mantid.simpleapi import SetSample, DirectILLReduction
 import numpy
-import numpy.testing
-from testhelpers import assert_almost_equal, illhelpers, run_algorithm
+from numpy.testing import assert_almost_equal
+from testhelpers import illhelpers, run_algorithm
 import unittest
 
 

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/DirectILLSelfShieldingTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/DirectILLSelfShieldingTest.py
@@ -4,7 +4,8 @@
 #   NScD Oak Ridge National Laboratory, European Spallation Source,
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
-from testhelpers import assert_almost_equal, illhelpers, run_algorithm
+from numpy.testing import assert_almost_equal
+from testhelpers import illhelpers, run_algorithm
 from mantid.api import mtd
 import unittest
 

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/FindPeakAutomaticTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/FindPeakAutomaticTest.py
@@ -398,9 +398,8 @@ class FindPeaksAutomaticTest(unittest.TestCase):
         self.assertPeakFound(peak1, self.centre[0], self.height[0] + 10, self.width[0], 0.05)
         self.assertPeakFound(peak2, self.centre[1], self.height[1] + 10, self.width[1], 0.05)
 
-    def test_find_peaks_is_called_if_scipy_version_higher_1_1_0(self):
+    def test_find_peaks_is_called_correctly(self):
         mock_scipy = mock.MagicMock()
-        mock_scipy.__version__ = "1.1.0"
         mock_scipy.signal.find_peaks.return_value = (self.peakids, {"prominences": self.peakids})
         with mock.patch.dict("sys.modules", scipy=mock_scipy):
             self.alg_instance.process(
@@ -418,27 +417,6 @@ class FindPeaksAutomaticTest(unittest.TestCase):
 
             self.assertEqual(2, mock_scipy.signal.find_peaks.call_count)
             self.assertEqual(0, mock_scipy.signal.find_peaks_cwt.call_count)
-
-    def test_find_peaks_cwt_is_called_if_scipy_version_lower_1_1_0(self):
-        mock_scipy = mock.MagicMock()
-        mock_scipy.__version__ = "1.0.0"
-        mock_scipy.signal.find_peaks.return_value = (self.peakids, {"prominences": self.peakids})
-        with mock.patch.dict("sys.modules", scipy=mock_scipy):
-            self.alg_instance.process(
-                self.x_values,
-                self.y_values,
-                raw_error=np.sqrt(self.y_values),
-                acceptance=0,
-                average_window=50,
-                bad_peak_to_consider=2,
-                use_poisson=False,
-                peak_width_estimate=5,
-                fit_to_baseline=False,
-                prog_reporter=mock.Mock(),
-            )
-
-            self.assertEqual(0, mock_scipy.signal.find_peaks.call_count)
-            self.assertEqual(1, mock_scipy.signal.find_peaks_cwt.call_count)
 
     def test_process_calls_find_good_peaks(self):
         with mock.patch("plugins.algorithms.WorkflowAlgorithms.FindPeaksAutomatic.CreateWorkspace") as mock_create_ws:

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/ReflectometryILLPreprocessTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/ReflectometryILLPreprocessTest.py
@@ -8,8 +8,7 @@
 from mantid.kernel import config
 from mantid.api import mtd
 from mantid.simpleapi import ReflectometryILLPreprocess
-import numpy.testing
-from testhelpers import assertRaisesNothing, assert_almost_equal, create_algorithm, illhelpers
+from testhelpers import assertRaisesNothing, create_algorithm, illhelpers
 import unittest
 import ReflectometryILL_common as common
 import math

--- a/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/ReflectometryILLPreprocessTest.py
+++ b/Framework/PythonInterface/test/python/plugins/algorithms/WorkflowAlgorithms/ReflectometryILLPreprocessTest.py
@@ -4,14 +4,14 @@
 #   NScD Oak Ridge National Laboratory, European Spallation Source,
 #   Institut Laue - Langevin & CSNS, Institute of High Energy Physics, CAS
 # SPDX - License - Identifier: GPL - 3.0 +
+import math
+import numpy
+import unittest
 
 from mantid.kernel import config
 from mantid.api import mtd
-from mantid.simpleapi import ReflectometryILLPreprocess
 from testhelpers import assertRaisesNothing, create_algorithm, illhelpers
-import unittest
 import ReflectometryILL_common as common
-import math
 
 
 class ReflectometryILLPreprocessTest(unittest.TestCase):

--- a/Framework/PythonInterface/test/testhelpers/__init__.py
+++ b/Framework/PythonInterface/test/testhelpers/__init__.py
@@ -10,12 +10,9 @@ are for use in unit tests only!
 
 
 from contextlib import contextmanager
-from distutils.version import LooseVersion
 
 # Import mantid to set MANTIDPATH for any ConfigService call that may be done
 import mantid  # noqa
-
-import numpy
 
 # Define some pure-Python functions to add to the mix
 
@@ -150,122 +147,6 @@ def can_be_instantiated(cls):
     except RuntimeError:
         result = False
     return result
-
-
-# Work around for slow testhelpers.assert_almost_equal that was fixed in 1.9.0:
-#   - https://github.com/numpy/numpy/commit/79d3a94f41b7e3c661eceed2f26ba6cce362ba4f
-# Running assert_almost_equal in a tight loop with v<1.9.0 causes major slows (read minutes)
-if LooseVersion(numpy.__version__) >= LooseVersion("1.9.0"):
-    assert_almost_equal = numpy.testing.assert_almost_equal
-else:
-
-    def assert_almost_equal(actual, desired, decimal=7, err_msg="", verbose=True):
-        """
-        Raises an AssertionError if two items are not equal up to desired
-        precision.
-        .. note:: It is recommended to use one of `assert_allclose`,
-                  `assert_array_almost_equal_nulp` or `assert_array_max_ulp`
-                  instead of this function for more consistent floating point
-                  comparisons.
-        The test is equivalent to ``abs(desired-actual) < 0.5 * 10**(-decimal)``.
-        Given two objects (numbers or ndarrays), check that all elements of these
-        objects are almost equal. An exception is raised at conflicting values.
-        For ndarrays this delegates to assert_array_almost_equal
-        Parameters
-        ----------
-        actual : array_like
-            The object to check.
-        desired : array_like
-            The expected object.
-        decimal : int, optional
-            Desired precision, default is 7.
-        err_msg : str, optional
-            The error message to be printed in case of failure.
-        verbose : bool, optional
-            If True, the conflicting values are appended to the error message.
-        Raises
-        ------
-        AssertionError
-          If actual and desired are not equal up to specified precision.
-        See Also
-        --------
-        assert_allclose: Compare two array_like objects for equality with desired
-                         relative and/or absolute precision.
-        assert_array_almost_equal_nulp, assert_array_max_ulp, assert_equal
-        Examples
-        --------
-        >>> import numpy.testing as npt
-        >>> npt.assert_almost_equal(2.3333333333333, 2.33333334)
-        >>> npt.assert_almost_equal(2.3333333333333, 2.33333334, decimal=10)
-        ...
-        <type 'exceptions.AssertionError'>:
-        Items are not equal:
-         ACTUAL: 2.3333333333333002
-         DESIRED: 2.3333333399999998
-        >>> npt.assert_almost_equal(np.array([1.0,2.3333333333333]),
-        ...                         np.array([1.0,2.33333334]), decimal=9)
-        ...
-        <type 'exceptions.AssertionError'>:
-        Arrays are not almost equal
-        <BLANKLINE>
-        (mismatch 50.0%)
-         x: array([ 1.        ,  2.33333333])
-         y: array([ 1.        ,  2.33333334])
-        """
-        __tracebackhide__ = True  # Hide traceback for py.test
-        from numpy.core import ndarray
-        from numpy.lib import iscomplexobj, real, imag
-        from numpy.testing import assert_array_almost_equal, build_err_msg, gisfinite, gisnan
-
-        # Handle complex numbers: separate into real/imag to handle
-        # nan/inf/negative zero correctly
-        # XXX: catch ValueError for subclasses of ndarray where iscomplex fail
-        try:
-            usecomplex = iscomplexobj(actual) or iscomplexobj(desired)
-        except ValueError:
-            usecomplex = False
-
-        def _build_err_msg():
-            header = "Arrays are not almost equal to %d decimals" % decimal
-            return build_err_msg([actual, desired], err_msg, verbose=verbose, header=header)
-
-        if usecomplex:
-            if iscomplexobj(actual):
-                actualr = real(actual)
-                actuali = imag(actual)
-            else:
-                actualr = actual
-                actuali = 0
-            if iscomplexobj(desired):
-                desiredr = real(desired)
-                desiredi = imag(desired)
-            else:
-                desiredr = desired
-                desiredi = 0
-            try:
-                assert_almost_equal(actualr, desiredr, decimal=decimal)
-                assert_almost_equal(actuali, desiredi, decimal=decimal)
-            except AssertionError:
-                raise AssertionError(_build_err_msg())
-
-        if isinstance(actual, (ndarray, tuple, list)) or isinstance(desired, (ndarray, tuple, list)):
-            return assert_array_almost_equal(actual, desired, decimal, err_msg)
-        try:
-            # If one of desired/actual is not finite, handle it specially here:
-            # check that both are nan if any is a nan, and test for equality
-            # otherwise
-            if not (gisfinite(desired) and gisfinite(actual)):
-                if gisnan(desired) or gisnan(actual):
-                    if not (gisnan(desired) and gisnan(actual)):
-                        raise AssertionError(_build_err_msg())
-                else:
-                    if not desired == actual:
-                        raise AssertionError(_build_err_msg())
-                return
-        except (NotImplementedError, TypeError):
-            pass
-        if round(abs(desired - actual), decimal) != 0:
-            raise AssertionError(_build_err_msg())
 
 
 @contextmanager

--- a/Testing/SystemTests/tests/framework/ILLDetectorEfficiencyCorUserTest.py
+++ b/Testing/SystemTests/tests/framework/ILLDetectorEfficiencyCorUserTest.py
@@ -7,7 +7,7 @@
 import numpy
 import systemtesting
 from mantid.simpleapi import ConvertUnits, DetectorEfficiencyCorUser, DirectILLCollectData
-from testhelpers import assert_almost_equal
+from numpy.testing import assert_almost_equal
 
 
 class IN4(systemtesting.MantidSystemTest):

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -12,12 +12,10 @@ import sys
 # dangling references in the notification centre that cause a segfault
 import qtpy.QtCore  # noqa: F401
 
-from distutils.version import LooseVersion
 import os
 
 import mantid
 from mantid.kernel import ConfigService
-from sphinx import __version__ as sphinx_version
 import sphinx_bootstrap_theme
 
 # Workaround a segfault importing readline with doctests and PyQt5.
@@ -38,14 +36,10 @@ sys.path.insert(0, os.path.abspath(os.path.join("..", "sphinxext")))
 
 # -- General configuration ------------------------------------------------
 
-if LooseVersion(sphinx_version) > LooseVersion("1.6"):
 
-    def setup(app):
-        """Called automatically by Sphinx when starting the build process"""
-        if hasattr(app, "add_css_file"):  # >=v1.8
-            app.add_css_file("custom.css")
-        else:
-            app.add_stylesheet("custom.css")  # v1.6-1.8
+def setup(app):
+    """Called automatically by Sphinx when starting the build process"""
+    app.add_css_file("custom.css")
 
 
 # Add any Sphinx extension module names here, as strings. They can be
@@ -72,12 +66,8 @@ extensions = [
     "mantiddoc.doctest",
 ]
 # Deal with math extension. Can be overridden with MATH_EXT environment variable
-# If set to imgmath we deal with the fact that < 1.8 is was called pngmath
 mathext = os.environ.get("MATH_EXT", "sphinx.ext.imgmath")
-if mathext.endswith("imgmath") and LooseVersion(sphinx_version) <= LooseVersion("1.8"):
-    extensions.append("sphinx.ext.pngmath")
-else:
-    extensions.append(mathext)
+extensions.append(mathext)
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]
@@ -198,10 +188,7 @@ html_static_path = ["_static"]
 
 # If true, Smart Quotes will be used to convert quotes and dashes to
 # typographically correct entities.
-if sphinx_version < "1.7":
-    html_use_smartypants = True
-else:
-    smartquotes = True
+smartquotes = True
 
 # Hide the Sphinx usage as we reference it on github instead.
 html_show_sphinx = False

--- a/docs/sphinxext/mantiddoc/directives/plot_directive.py
+++ b/docs/sphinxext/mantiddoc/directives/plot_directive.py
@@ -8,10 +8,8 @@
     :copyright: Copyright 2020
         ISIS Rutherford Appleton Laboratory & NScD Oak Ridge National Laboratory
 """
-from distutils.version import LooseVersion
 import os
 import matplotlib.sphinxext.plot_directive as mpl_plot_directive_module
-import sphinx
 
 if hasattr(mpl_plot_directive_module, "PlotDirective"):
 
@@ -30,8 +28,7 @@ if hasattr(mpl_plot_directive_module, "PlotDirective"):
         metadata = mpl_plot_directive_module.setup(app)
         kwargs = dict()
         # avoid warning overwriting directive
-        if LooseVersion(sphinx.__version__) >= "1.8":
-            kwargs["override"] = True
+        kwargs["override"] = True
         app.add_directive("plot", PlotDirectivePatch, **kwargs)
         return metadata
 

--- a/qt/applications/workbench/workbench/plotting/test/test_figureinteraction.py
+++ b/qt/applications/workbench/workbench/plotting/test/test_figureinteraction.py
@@ -19,7 +19,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 from qtpy.QtCore import Qt
 from qtpy.QtWidgets import QMenu
-from testhelpers import assert_almost_equal
+from numpy.testing import assert_almost_equal
 
 # local package imports
 from mantid.plots import MantidAxes

--- a/qt/python/mantidqt/mantidqt/utils/qt/__init__.py
+++ b/qt/python/mantidqt/mantidqt/utils/qt/__init__.py
@@ -217,9 +217,9 @@ def force_layer_backing_BigSur():
     # https://codereview.qt-project.org/gitweb?p=qt/qtbase.git;a=commitdiff;h=c5d904639dbd690a36306e2b455610029704d821
     # A complication with Big Sur numbering means we check for 10.16 and 11:
     #   https://eclecticlight.co/2020/08/13/macos-version-numbering-isnt-so-simple/
-    from distutils.version import LooseVersion
+    from packaging.version import Version
     import platform
 
-    mac_vers = LooseVersion(platform.mac_ver()[0])
+    mac_vers = Version(platform.mac_ver()[0])
     if mac_vers >= "11" or mac_vers == "10.16":
         os.environ["QT_MAC_WANTS_LAYER"] = "1"

--- a/qt/python/mantidqt/mantidqt/widgets/codeeditor/test/test_completion.py
+++ b/qt/python/mantidqt/mantidqt/widgets/codeeditor/test/test_completion.py
@@ -7,7 +7,6 @@
 #  This file is part of the mantid workbench.
 import re
 import unittest
-from distutils.version import LooseVersion
 
 import matplotlib.pyplot as plt  # noqa # Needs importing so it's availiabe in the tests, but isn't actually used.
 import numpy as np
@@ -55,8 +54,7 @@ class CodeCompletionTest(unittest.TestCase):
         self._run_check_call_tip_generated("import numpy as np\n# My code", r"np\.asarray\(a, \[dtype\], .*\)")
 
     def test_numpy_call_tips_generated_handling_wildcards_properly_if_numpy_imported_in_script(self):
-        if LooseVersion(np.__version__) >= LooseVersion("1.21"):
-            self._run_check_call_tip_generated("import numpy as np\n# My code", r"np\.asarray\(a, \[dtype\], \[order\], \*, \[like\]\)")
+        self._run_check_call_tip_generated("import numpy as np\n# My code", r"np\.asarray\(a, \[dtype\], \[order\], \*, \[like\]\)")
 
     def test_call_tips_generated_if_syntax_errors_in_script(self):
         self._run_check_call_tip_generated("from mantid.simpleapi import *\n print 'Hello', 'World'", "Rebin")

--- a/qt/python/mantidqt/mantidqt/widgets/colorbar/colorbar.py
+++ b/qt/python/mantidqt/mantidqt/widgets/colorbar/colorbar.py
@@ -11,7 +11,7 @@ import sys
 import glob
 import os
 from mantid.kernel import ConfigService
-from mantid.plots.utility import mpl_version_info, get_current_cmap
+from mantid.plots.utility import get_current_cmap
 from mantidqt.MPLwidgets import FigureCanvas
 from matplotlib.colorbar import Colorbar
 from matplotlib.figure import Figure
@@ -189,10 +189,7 @@ class ColorbarWidget(QWidget):
         if rev:
             name += "_r"
         self.colorbar.mappable.set_cmap(name)
-        if mpl_version_info() >= (3, 1):
-            self.colorbar.update_normal(self.colorbar.mappable)
-        else:
-            self.colorbar.set_cmap(name)
+        self.colorbar.update_normal(self.colorbar.mappable)
         self.redraw()
 
     def mappable_changed(self):

--- a/scripts/test/CrystalFieldMultiSiteTest.py
+++ b/scripts/test/CrystalFieldMultiSiteTest.py
@@ -8,7 +8,6 @@ import numpy as np
 import re
 import unittest
 
-import testhelpers
 import CrystalField
 from mantid.simpleapi import CalculateChiSquared, CreateWorkspace, FlatBackground, FunctionFactory, Gaussian, LinearBackground
 
@@ -148,7 +147,7 @@ class CrystalFieldMultiSiteTests(unittest.TestCase):
         y = y / c_mbsr
         expected_y = [12.474955, 1.190169, 0.122781, 0.042940, 10.837438]
         np.testing.assert_equal(x, r)
-        testhelpers.assert_almost_equal(y, expected_y, 6)
+        np.testing.assert_almost_equal(y, expected_y, 6)
 
     def test_get_spectrum_ws(self):
         cfms = CrystalField.CrystalFieldMultiSite(
@@ -231,13 +230,13 @@ class CrystalFieldMultiSiteTests(unittest.TestCase):
         y = y / c_mbsr
         expected_y = [12.474946, 1.190160, 0.122785, 0.042940, 10.837170]
         np.testing.assert_equal(x, r)
-        testhelpers.assert_almost_equal(y, expected_y, 6)
+        np.testing.assert_almost_equal(y, expected_y, 6)
 
         x, y = cfms.getSpectrum(1, r)
         y = y / c_mbsr
         expected_y = [6.304662, 0.331218, 1.224681, 0.078540, 2.638049]
         np.testing.assert_equal(x, r)
-        testhelpers.assert_almost_equal(y, expected_y, 6)
+        np.testing.assert_almost_equal(y, expected_y, 6)
 
     def test_get_spectrum_ws_multi_spectra(self):
         cfms = CrystalField.CrystalFieldMultiSite(
@@ -304,13 +303,13 @@ class CrystalFieldMultiSiteTests(unittest.TestCase):
         y = y / c_mbsr
         expected_y = [3.904037, 0.744519, 0.274897, 0.175713, 0.106540]
         np.testing.assert_equal(x, r)
-        testhelpers.assert_almost_equal(y, expected_y, 6)
+        np.testing.assert_almost_equal(y, expected_y, 6)
 
         x, y = cfms.getSpectrum(1, r)
         y = y / c_mbsr
         expected_y = [3.704726, 0.785600, 0.296255, 0.190176, 0.115650]
         np.testing.assert_equal(x, r)
-        testhelpers.assert_almost_equal(y, expected_y, 6)
+        np.testing.assert_almost_equal(y, expected_y, 6)
 
     def test_fit_multi_ion_single_spectrum(self):
         params = {"B20": 0.37737, "B22": 3.9770, "B40": -0.031787, "B42": -0.11611, "B44": -0.12544, "Temperature": 44.0, "FWHM": 1.1}


### PR DESCRIPTION
**Description of work**
`distutils.LooseVersion` is deprecated in Python 3.10. Here we change to `packaging.Version`:
`DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.`
In doing this, it was noticed that many of the version checks were obsolete, so those ones have been removed. We currently require:
- `matplotlib >= 3.6.0` (although it's an optional dependency in `mantid`, where we say anything >= 3.5.2 is acceptable)
- `scipy >=1.10`
- `numpy >=1.21`
- `sphinx == 5.1.1`
which is why we can remove the old checks.

Note that we leave the checks for `matplotlib >= 3.6.0` because we specify that `matplotlib >= 3.5.2` at runtime for the mantid package (see [here](https://github.com/mantidproject/mantid/blob/20e8e18946eeefde6fa3fe5e21dd6a8aa47cf287/conda/recipes/mantid/meta.yaml#L81)).

**To test:**
No functional testing required, just thoroughly review the changes.

*There is no associated issue.*

*This does not require release notes* because **it is part of the Python 3.10 migration, which already has release notes.**


<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.