### PR TITLE
Remove obsolete setuptools warnings

### DIFF
--- a/Testing/SystemTests/lib/systemtests/systemtesting.py
+++ b/Testing/SystemTests/lib/systemtests/systemtesting.py
@@ -21,18 +21,6 @@ if os.environ.get("MANTID_FRAMEWORK_CONDA_SYSTEMTEST"):
     import matplotlib
 
 # =========================================================
-try:
-    import mantid
-except ModuleNotFoundError:
-    import setuptools
-    from packaging import version
-
-    if version.parse(setuptools.__version__) >= version.parse("49.0.0"):
-        raise EnvironmentError(
-            "Setup tools is v49 or greater. This is likely causing the Mantid import to fail. See \n"
-            "https://github.com/mantidproject/mantid/issues/29010"
-        )
-
 import datetime
 import difflib
 import importlib.util

--- a/buildconfig/CMake/Packaging/launch_mantidworkbench.sh.in
+++ b/buildconfig/CMake/Packaging/launch_mantidworkbench.sh.in
@@ -15,13 +15,6 @@ if [ -n "${PYTHONPATH}" ]; then
     LOCAL_PYTHONPATH=${LOCAL_PYTHONPATH}:${PYTHONPATH}
 fi
 
-SETUP_TOOLS_VERS=$(@PYTHON_EXEC_LOCAL@ -c "from setuptools import __version__; print(__version__)" | cut -d . -f1)
-if [ "${SETUP_TOOLS_VERS}" -ge "49" ]; then
-   # Print red so people notice it when they get a stack trace
-   echo "\e[31mSetup tools is >= 49. You may run into issues with a clean build.\e[0m"
-   echo "If you are failing to launch with missing modules see https://github.com/mantidproject/mantid/issues/29010"
-fi
-
 @GDB_DEFINITIONS@
 
 # Launch the workbench


### PR DESCRIPTION
**Description of work**
Removed an obsolete warning message that is output when setuptools>=49
![image](https://github.com/mantidproject/mantid/assets/8058899/e0872beb-4229-4974-be95-9783a336ba7e)
We've been running with version 68 or so for a while since the Python 3.10 migration without any issues.

**To test:**
Extract and run this linux package, verifying that the warning is no longer there:
https://builds.mantidproject.org/job/build_packages_from_branch/576/

*There is no associated issue.*

*This does not require release notes* because **there will be no change for the user since mantidworkbench 6.7**

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.