### PR TITLE
Fix SANSTubeCalibration system test

### DIFF
--- a/Testing/SystemTests/tests/framework/ISIS/SANS/SANS2D/SANS2DTubeCalibrationTest.py
+++ b/Testing/SystemTests/tests/framework/ISIS/SANS/SANS2D/SANS2DTubeCalibrationTest.py
@@ -82,6 +82,7 @@ class SANS2DTubeCalibrationRearDetectorTest(systemtesting.MantidSystemTest, SANS
             self.assertTrue(self._tube_diagnostic_workspaces_exist(tube_id))
 
     def validate(self):
+        self.tolerance = 1e-7
         self.disableChecking.append("SpectraMap")
         self.disableChecking.append("Axes")
 
@@ -107,6 +108,7 @@ class SANS2DTubeCalibrationFrontDetectorTest(systemtesting.MantidSystemTest, SAN
                 self.assertEqual(str(e), "\"'Tube_103' does not exist.\"")
 
     def validate(self):
+        self.tolerance = 1e-7
         self.disableChecking.append("SpectraMap")
         self.disableChecking.append("Axes")
 


### PR DESCRIPTION
**Description of work**

**Purpose of work**
<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
-->
The `SANS2DTubeCalibrationFrontDetectorTest` added in PR #35984 is failing in our Jenkins Windows and OSX builds because of a mismatch in the cvalues workspace comparison. This is preventing the nightly build from completing.

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**Summary of work**
<!-- Please provide a short, high level description of the work that was done.
-->
This test was developed and tested on Windows, so it's currently unclear why the Jenkins run of the test is having a problem. One theory is whether a conda dependency has changed recently, however I've tried updating my local conda environment and still haven't been able to replicate the problem locally. The mismatch in the workspace comparison on Jenkins is not significant, so this PR adjusts the tolerance used in the tests to allow them to pass on Jenkins. During the release maintenance period, it may be worth spending some time to try and establish the underlying cause of the issue, if possible.

**To test:**

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->
Tests should pass on this PR, and also this build from branch job should pass: https://builds.mantidproject.org/job/build_packages_from_branch/570/

*There is no associated issue.*


*This does not require release notes* because **it fixes a test that was added since the last release.**

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.