### PR TITLE
Remove unnecessary options for IRIS and OSIRIS in ISIS Energy Transfer

### DIFF
--- a/qt/scientific_interfaces/Indirect/Reduction/ISISEnergyTransfer.ui
+++ b/qt/scientific_interfaces/Indirect/Reduction/ISISEnergyTransfer.ui
@@ -432,19 +432,18 @@
       <property name="sizeConstraint">
        <enum>QLayout::SetDefaultConstraint</enum>
       </property>
-      <item row="0" column="0">
-       <widget class="QCheckBox" name="ckDetailedBalance">
-        <property name="text">
-         <string>Detailed Balance</string>
+      <item row="0" column="2">
+       <spacer name="horizontalSpacer_0">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
         </property>
-       </widget>
-      </item>
-      <item row="0" column="4">
-       <widget class="QCheckBox" name="ckScaleMultiplier">
-        <property name="text">
-         <string>Scale by factor:</string>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>40</width>
+          <height>20</height>
+         </size>
         </property>
-       </widget>
+       </spacer>
       </item>
       <item row="0" column="1">
        <widget class="QDoubleSpinBox" name="spDetailedBalance">
@@ -468,19 +467,6 @@
         </property>
        </widget>
       </item>
-      <item row="0" column="2">
-       <spacer name="horizontalSpacer_0">
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>40</width>
-          <height>20</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
       <item row="0" column="5">
        <widget class="QDoubleSpinBox" name="spScaleMultiplier">
         <property name="enabled">
@@ -497,6 +483,20 @@
         </property>
         <property name="value">
          <double>1.000000000000000</double>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0">
+       <widget class="QCheckBox" name="ckDetailedBalance">
+        <property name="text">
+         <string>Detailed Balance</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="4">
+       <widget class="QCheckBox" name="ckScaleMultiplier">
+        <property name="text">
+         <string>Scale by factor:</string>
         </property>
        </widget>
       </item>
@@ -1056,6 +1056,19 @@
          </spacer>
         </item>
         <item>
+         <widget class="QCheckBox" name="ckGroupOutput">
+          <property name="text">
+           <string>Group Output Workspace</string>
+          </property>
+          <property name="visible">
+           <bool>false</bool>
+          </property>
+          <property name="checked">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+        <item>
          <widget class="QComboBox" name="cbGroupOutput">
           <property name="editable">
            <bool>false</bool>
@@ -1110,7 +1123,7 @@
        </layout>
       </item>
       <item row="1" column="0">
-       <widget class="QFrame" name="frame">
+       <widget class="QFrame" name="fPlottingOptions">
         <property name="frameShape">
          <enum>QFrame::StyledPanel</enum>
         </property>

--- a/qt/scientific_interfaces/Indirect/Reduction/ISISEnergyTransferModel.cpp
+++ b/qt/scientific_interfaces/Indirect/Reduction/ISISEnergyTransferModel.cpp
@@ -359,8 +359,8 @@ double IETModel::loadDetailedBalance(std::string const &filename) {
   return detailedBalance;
 }
 
-std::vector<std::string> IETModel::groupWorkspaces(std::string groupName, std::string instrument,
-                                                   std::string groupOption, bool shouldGroup) {
+std::vector<std::string> IETModel::groupWorkspaces(std::string const &groupName, std::string const &instrument,
+                                                   std::string const &groupOption, bool const shouldGroup) {
   std::vector<std::string> outputWorkspaces;
 
   if (doesExistInADS(groupName)) {

--- a/qt/scientific_interfaces/Indirect/Reduction/ISISEnergyTransferModel.cpp
+++ b/qt/scientific_interfaces/Indirect/Reduction/ISISEnergyTransferModel.cpp
@@ -141,8 +141,8 @@ std::string IETModel::getOuputGroupName(InstrumentData const &instData, std::str
   return instrument + inputText + "_" + analyser + "_" + reflection + "_Reduced";
 }
 
-std::string IETModel::runIETAlgorithm(MantidQt::API::BatchAlgorithmRunner *batchAlgoRunner, InstrumentData instData,
-                                      IETRunData runData) {
+std::string IETModel::runIETAlgorithm(MantidQt::API::BatchAlgorithmRunner *batchAlgoRunner,
+                                      InstrumentData const &instData, IETRunData const &runData) {
   auto reductionAlg = AlgorithmManager::Instance().create("ISISIndirectEnergyTransferWrapper");
   reductionAlg->initialize();
 
@@ -183,13 +183,13 @@ std::pair<std::string, std::string> IETModel::createGrouping(const IETGroupingDa
   }
 }
 
-std::string IETModel::getDetectorGroupingString(int spectraMin, int spectraMax, int nGroups) {
+std::string IETModel::getDetectorGroupingString(int const spectraMin, int const spectraMax, int const nGroups) {
   const unsigned int nSpectra = 1 + spectraMax - spectraMin;
   return createDetectorGroupingString(static_cast<std::size_t>(nSpectra), static_cast<std::size_t>(nGroups),
                                       static_cast<std::size_t>(spectraMin));
 }
 
-std::vector<std::string> IETModel::validatePlotData(IETPlotData plotParams) {
+std::vector<std::string> IETModel::validatePlotData(IETPlotData const &plotParams) {
   std::vector<std::string> errors;
 
   const std::string inputFiles = plotParams.getInputData().getInputFiles();
@@ -216,8 +216,8 @@ std::vector<std::string> IETModel::validatePlotData(IETPlotData plotParams) {
   return errors;
 }
 
-void IETModel::plotRawFile(MantidQt::API::BatchAlgorithmRunner *batchAlgoRunner, InstrumentData instData,
-                           IETPlotData plotParams) {
+void IETModel::plotRawFile(MantidQt::API::BatchAlgorithmRunner *batchAlgoRunner, InstrumentData const &instData,
+                           IETPlotData const &plotParams) {
   using Mantid::specnum_t;
 
   const std::string inputFiles = plotParams.getInputData().getInputFiles();
@@ -285,7 +285,7 @@ void IETModel::plotRawFile(MantidQt::API::BatchAlgorithmRunner *batchAlgoRunner,
   batchAlgoRunner->executeBatchAsync();
 }
 
-void IETModel::saveWorkspace(std::string const &workspaceName, IETSaveData saveTypes) {
+void IETModel::saveWorkspace(std::string const &workspaceName, IETSaveData const &saveTypes) {
   if (saveTypes.getNexus())
     save("SaveNexusProcessed", workspaceName, workspaceName + ".nxs");
   if (saveTypes.getSPE())

--- a/qt/scientific_interfaces/Indirect/Reduction/ISISEnergyTransferModel.h
+++ b/qt/scientific_interfaces/Indirect/Reduction/ISISEnergyTransferModel.h
@@ -37,13 +37,14 @@ public:
 
   std::vector<std::string> validateRunData(IETRunData const &runData, std::size_t const &defaultSpectraMin,
                                            std::size_t const &defaultSpectraMax);
-  std::vector<std::string> validatePlotData(IETPlotData plotData);
+  std::vector<std::string> validatePlotData(IETPlotData const &plotData);
 
-  std::string runIETAlgorithm(MantidQt::API::BatchAlgorithmRunner *batchAlgoRunner, InstrumentData instData,
-                              IETRunData runParams);
-  void plotRawFile(MantidQt::API::BatchAlgorithmRunner *batchAlgoRunner, InstrumentData instData, IETPlotData plotData);
+  std::string runIETAlgorithm(MantidQt::API::BatchAlgorithmRunner *batchAlgoRunner, InstrumentData const &instData,
+                              IETRunData const &runParams);
+  void plotRawFile(MantidQt::API::BatchAlgorithmRunner *batchAlgoRunner, InstrumentData const &instData,
+                   IETPlotData const &plotData);
 
-  void saveWorkspace(std::string const &workspaceName, IETSaveData saveData);
+  void saveWorkspace(std::string const &workspaceName, IETSaveData const &saveData);
   void saveDaveGroup(std::string const &workspaceName, std::string const &outputName);
   void saveAclimax(std::string const &workspaceName, std::string const &outputName,
                    std::string const &xUnits = "DeltaE_inWavenumber");
@@ -53,13 +54,13 @@ public:
   std::pair<std::string, std::string> createGrouping(IETGroupingData const &groupingData,
                                                      IETConversionData const &conversionParams);
 
-  std::string getDetectorGroupingString(int spectraMin, int spectraMax, int nGroups);
+  std::string getDetectorGroupingString(int const spectraMin, int const spectraMax, int const nGroups);
   void createGroupingWorkspace(std::string const &instrumentName, std::string const &analyser,
                                std::string const &customGrouping, std::string const &outputName);
   double loadDetailedBalance(std::string const &filename);
 
-  std::vector<std::string> groupWorkspaces(std::string groupName, std::string intrument, std::string groupOption,
-                                           bool shouldGroup);
+  std::vector<std::string> groupWorkspaces(std::string const &groupName, std::string const &instrument,
+                                           std::string const &groupOption, bool const shouldGroup);
   void ungroupWorkspace(std::string const &workspaceName);
   void groupWorkspaceBySampleChanger(std::string const &workspaceName);
 };

--- a/qt/scientific_interfaces/Indirect/Reduction/ISISEnergyTransferModel.h
+++ b/qt/scientific_interfaces/Indirect/Reduction/ISISEnergyTransferModel.h
@@ -58,7 +58,8 @@ public:
                                std::string const &customGrouping, std::string const &outputName);
   double loadDetailedBalance(std::string const &filename);
 
-  std::vector<std::string> groupWorkspaces(std::string groupName, std::string groupOption);
+  std::vector<std::string> groupWorkspaces(std::string groupName, std::string intrument, std::string groupOption,
+                                           bool shouldGroup);
   void ungroupWorkspace(std::string const &workspaceName);
   void groupWorkspaceBySampleChanger(std::string const &workspaceName);
 };

--- a/qt/scientific_interfaces/Indirect/Reduction/ISISEnergyTransferPresenter.cpp
+++ b/qt/scientific_interfaces/Indirect/Reduction/ISISEnergyTransferPresenter.cpp
@@ -82,6 +82,29 @@ void IETPresenter::setInstrumentDefault() {
   if (validateInstrumentDetails()) {
     InstrumentData instrumentDetails = getInstrumentData();
     m_view->setInstrumentDefault(instrumentDetails);
+    if (instrumentDetails.getInstrument() == "OSIRIS" || instrumentDetails.getInstrument() == "IRIS") {
+      m_view->setBackgroundSectionVisible(false);
+      m_view->setPlotTimeSectionVisible(false);
+      m_view->setPlottingOptionsVisible(false);
+      m_view->setScaleFactorVisible(false);
+      m_view->setAclimaxSaveVisible(false);
+      m_view->setNXSPEVisible(false);
+      m_view->setFoldMultipleFramesVisible(false);
+      m_view->setOutputInCm1Visible(false);
+      m_view->setGroupOutputDropdownVisible(false);
+      m_view->setGrouptOutputCheckBoxVisible(true);
+    } else {
+      m_view->setBackgroundSectionVisible(true);
+      m_view->setPlotTimeSectionVisible(true);
+      m_view->setPlottingOptionsVisible(true);
+      m_view->setScaleFactorVisible(true);
+      m_view->setAclimaxSaveVisible(true);
+      m_view->setNXSPEVisible(true);
+      m_view->setFoldMultipleFramesVisible(true);
+      m_view->setOutputInCm1Visible(true);
+      m_view->setGroupOutputDropdownVisible(true);
+      m_view->setGrouptOutputCheckBoxVisible(false);
+    }
   }
 }
 
@@ -149,7 +172,9 @@ void IETPresenter::algorithmComplete(bool error) {
   disconnect(m_batchAlgoRunner, SIGNAL(batchComplete(bool)), this, SLOT(algorithmComplete(bool)));
 
   if (!error) {
-    m_outputWorkspaces = m_model->groupWorkspaces(m_outputGroupName, m_view->getGroupOutputOption());
+    InstrumentData instrumentData = getInstrumentData();
+    m_outputWorkspaces = m_model->groupWorkspaces(m_outputGroupName, instrumentData.getInstrument(),
+                                                  m_view->getGroupOutputOption(), m_view->getGroupOutputCheckbox());
     m_pythonExportWsName = m_outputWorkspaces[0];
 
     if (m_outputWorkspaces.size() != 0) {

--- a/qt/scientific_interfaces/Indirect/Reduction/ISISEnergyTransferPresenter.cpp
+++ b/qt/scientific_interfaces/Indirect/Reduction/ISISEnergyTransferPresenter.cpp
@@ -82,7 +82,8 @@ void IETPresenter::setInstrumentDefault() {
   if (validateInstrumentDetails()) {
     InstrumentData instrumentDetails = getInstrumentData();
     m_view->setInstrumentDefault(instrumentDetails);
-    bool const irisOrOsiris = instrumentDetails.getInstrument() == "OSIRIS" || instrumentDetails.getInstrument() == "IRIS";
+    bool const irisOrOsiris =
+        instrumentDetails.getInstrument() == "OSIRIS" || instrumentDetails.getInstrument() == "IRIS";
     m_view->setBackgroundSectionVisible(!irisOrOsiris);
     m_view->setPlotTimeSectionVisible(!irisOrOsiris);
     m_view->setPlottingOptionsVisible(!irisOrOsiris);

--- a/qt/scientific_interfaces/Indirect/Reduction/ISISEnergyTransferPresenter.cpp
+++ b/qt/scientific_interfaces/Indirect/Reduction/ISISEnergyTransferPresenter.cpp
@@ -82,29 +82,17 @@ void IETPresenter::setInstrumentDefault() {
   if (validateInstrumentDetails()) {
     InstrumentData instrumentDetails = getInstrumentData();
     m_view->setInstrumentDefault(instrumentDetails);
-    if (instrumentDetails.getInstrument() == "OSIRIS" || instrumentDetails.getInstrument() == "IRIS") {
-      m_view->setBackgroundSectionVisible(false);
-      m_view->setPlotTimeSectionVisible(false);
-      m_view->setPlottingOptionsVisible(false);
-      m_view->setScaleFactorVisible(false);
-      m_view->setAclimaxSaveVisible(false);
-      m_view->setNXSPEVisible(false);
-      m_view->setFoldMultipleFramesVisible(false);
-      m_view->setOutputInCm1Visible(false);
-      m_view->setGroupOutputDropdownVisible(false);
-      m_view->setGrouptOutputCheckBoxVisible(true);
-    } else {
-      m_view->setBackgroundSectionVisible(true);
-      m_view->setPlotTimeSectionVisible(true);
-      m_view->setPlottingOptionsVisible(true);
-      m_view->setScaleFactorVisible(true);
-      m_view->setAclimaxSaveVisible(true);
-      m_view->setNXSPEVisible(true);
-      m_view->setFoldMultipleFramesVisible(true);
-      m_view->setOutputInCm1Visible(true);
-      m_view->setGroupOutputDropdownVisible(true);
-      m_view->setGrouptOutputCheckBoxVisible(false);
-    }
+    bool const irisOrOsiris = instrumentDetails.getInstrument() == "OSIRIS" || instrumentDetails.getInstrument() == "IRIS";
+    m_view->setBackgroundSectionVisible(!irisOrOsiris);
+    m_view->setPlotTimeSectionVisible(!irisOrOsiris);
+    m_view->setPlottingOptionsVisible(!irisOrOsiris);
+    m_view->setScaleFactorVisible(!irisOrOsiris);
+    m_view->setAclimaxSaveVisible(!irisOrOsiris);
+    m_view->setNXSPEVisible(!irisOrOsiris);
+    m_view->setFoldMultipleFramesVisible(!irisOrOsiris);
+    m_view->setOutputInCm1Visible(!irisOrOsiris);
+    m_view->setGroupOutputDropdownVisible(!irisOrOsiris);
+    m_view->setGrouptOutputCheckBoxVisible(irisOrOsiris);
   }
 }
 

--- a/qt/scientific_interfaces/Indirect/Reduction/ISISEnergyTransferPresenter.cpp
+++ b/qt/scientific_interfaces/Indirect/Reduction/ISISEnergyTransferPresenter.cpp
@@ -93,7 +93,7 @@ void IETPresenter::setInstrumentDefault() {
     m_view->setFoldMultipleFramesVisible(!irisOrOsiris);
     m_view->setOutputInCm1Visible(!irisOrOsiris);
     m_view->setGroupOutputDropdownVisible(!irisOrOsiris);
-    m_view->setGrouptOutputCheckBoxVisible(irisOrOsiris);
+    m_view->setGroupOutputCheckBoxVisible(irisOrOsiris);
   }
 }
 

--- a/qt/scientific_interfaces/Indirect/Reduction/ISISEnergyTransferView.cpp
+++ b/qt/scientific_interfaces/Indirect/Reduction/ISISEnergyTransferView.cpp
@@ -167,7 +167,7 @@ void IETView::setFoldMultipleFramesVisible(bool visible) { m_uiForm.ckFold->setV
 
 void IETView::setOutputInCm1Visible(bool visible) { m_uiForm.ckCm1Units->setVisible(visible); }
 
-void IETView::setGrouptOutputCheckBoxVisible(bool visible) { m_uiForm.ckGroupOutput->setVisible(visible); }
+void IETView::setGroupOutputCheckBoxVisible(bool visible) { m_uiForm.ckGroupOutput->setVisible(visible); }
 
 void IETView::setGroupOutputDropdownVisible(bool visible) { m_uiForm.cbGroupOutput->setVisible(visible); }
 

--- a/qt/scientific_interfaces/Indirect/Reduction/ISISEnergyTransferView.cpp
+++ b/qt/scientific_interfaces/Indirect/Reduction/ISISEnergyTransferView.cpp
@@ -42,7 +42,7 @@ IETView::IETView(IETViewSubscriber *subscriber, QWidget *parent) : m_subscriber(
 
 IETView::~IETView() {}
 
-IETRunData IETView::getRunData() {
+IETRunData IETView::getRunData() const {
   IETInputData inputDetails(m_uiForm.dsRunFiles->getFilenames().join(",").toStdString(),
                             m_uiForm.dsRunFiles->getText().toStdString(), m_uiForm.ckSumFiles->isChecked(),
                             m_uiForm.ckLoadLogFiles->isChecked(), m_uiForm.ckUseCalib->isChecked(),
@@ -73,7 +73,7 @@ IETRunData IETView::getRunData() {
   return runParams;
 }
 
-IETPlotData IETView::getPlotData() {
+IETPlotData IETView::getPlotData() const {
   IETInputData inputDetails(m_uiForm.dsRunFiles->getFilenames().join(",").toStdString(),
                             m_uiForm.dsRunFiles->getText().toStdString(), m_uiForm.ckSumFiles->isChecked(),
                             m_uiForm.ckLoadLogFiles->isChecked(), m_uiForm.ckUseCalib->isChecked(),
@@ -90,7 +90,7 @@ IETPlotData IETView::getPlotData() {
   return plotParams;
 }
 
-IETSaveData IETView::getSaveData() {
+IETSaveData IETView::getSaveData() const {
   IETSaveData saveTypes(m_uiForm.ckSaveNexus->isChecked(), m_uiForm.ckSaveSPE->isChecked(),
                         m_uiForm.ckSaveNXSPE->isChecked(), m_uiForm.ckSaveASCII->isChecked(),
                         m_uiForm.ckSaveAclimax->isChecked(), m_uiForm.ckSaveDaveGrp->isChecked());
@@ -98,27 +98,27 @@ IETSaveData IETView::getSaveData() {
   return saveTypes;
 }
 
-std::string IETView::getCustomGrouping() { return m_uiForm.leCustomGroups->text().toStdString(); }
+std::string IETView::getCustomGrouping() const { return m_uiForm.leCustomGroups->text().toStdString(); }
 
-std::string IETView::getGroupOutputOption() { return m_uiForm.cbGroupOutput->currentText().toStdString(); }
+std::string IETView::getGroupOutputOption() const { return m_uiForm.cbGroupOutput->currentText().toStdString(); }
 
-bool IETView::getGroupOutputCheckbox() { return m_uiForm.ckGroupOutput->isChecked(); }
+bool IETView::getGroupOutputCheckbox() const { return m_uiForm.ckGroupOutput->isChecked(); }
 
-IndirectPlotOptionsView *IETView::getPlotOptionsView() { return m_uiForm.ipoPlotOptions; }
+IndirectPlotOptionsView *IETView::getPlotOptionsView() const { return m_uiForm.ipoPlotOptions; }
 
-std::string IETView::getFirstFilename() { return m_uiForm.dsRunFiles->getFirstFilename().toStdString(); }
+std::string IETView::getFirstFilename() const { return m_uiForm.dsRunFiles->getFirstFilename().toStdString(); }
 
-bool IETView::isRunFilesValid() { return m_uiForm.dsRunFiles->isValid(); }
+bool IETView::isRunFilesValid() const { return m_uiForm.dsRunFiles->isValid(); }
 
-void IETView::validateCalibrationFileType(UserInputValidator &uiv) {
+void IETView::validateCalibrationFileType(UserInputValidator &uiv) const {
   validateDataIsOfType(uiv, m_uiForm.dsCalibrationFile, "Calibration", DataType::Calib);
 }
 
-void IETView::validateRebinString(UserInputValidator &uiv) {
+void IETView::validateRebinString(UserInputValidator &uiv) const {
   uiv.checkFieldIsNotEmpty("Rebin string", m_uiForm.leRebinString, m_uiForm.valRebinString);
 }
 
-bool IETView::showRebinWidthPrompt() {
+bool IETView::showRebinWidthPrompt() const {
   const char *text = "The Binning width is currently negative, this suggests "
                      "you wish to use logarithmic binning.\n"
                      " Do you want to use Logarithmic Binning?";
@@ -130,7 +130,7 @@ bool IETView::showRebinWidthPrompt() {
 
 void IETView::showSaveCustomGroupingDialog(std::string const &customGroupingOutput,
                                            std::string const &defaultGroupingFilename,
-                                           std::string const &saveDirectory) {
+                                           std::string const &saveDirectory) const {
   QHash<QString, QString> props;
   props["InputWorkspace"] = QString::fromStdString(customGroupingOutput);
   props["OutputFile"] = QString::fromStdString(saveDirectory + defaultGroupingFilename);
@@ -144,22 +144,31 @@ void IETView::showSaveCustomGroupingDialog(std::string const &customGroupingOutp
   dialog->activateWindow();
 }
 
-void IETView::displayWarning(std::string const &message) {
+void IETView::displayWarning(std::string const &message) const {
   QMessageBox::warning(nullptr, "", QString::fromStdString(message));
 }
 
 void IETView::setBackgroundSectionVisible(bool visible) { m_uiForm.gbBackgroundRemoval->setVisible(visible); }
+
 void IETView::setPlotTimeSectionVisible(bool visible) { m_uiForm.gbPlotTime->setVisible(visible); }
+
 void IETView::setPlottingOptionsVisible(bool visible) { m_uiForm.fPlottingOptions->setVisible(visible); }
+
 void IETView::setScaleFactorVisible(bool visible) {
   m_uiForm.ckScaleMultiplier->setVisible(visible);
   m_uiForm.spScaleMultiplier->setVisible(visible);
 }
+
 void IETView::setAclimaxSaveVisible(bool visible) { m_uiForm.ckSaveAclimax->setVisible(visible); }
+
 void IETView::setNXSPEVisible(bool visible) { m_uiForm.ckSaveNXSPE->setVisible(visible); }
+
 void IETView::setFoldMultipleFramesVisible(bool visible) { m_uiForm.ckFold->setVisible(visible); }
+
 void IETView::setOutputInCm1Visible(bool visible) { m_uiForm.ckCm1Units->setVisible(visible); }
+
 void IETView::setGrouptOutputCheckBoxVisible(bool visible) { m_uiForm.ckGroupOutput->setVisible(visible); }
+
 void IETView::setGroupOutputDropdownVisible(bool visible) { m_uiForm.cbGroupOutput->setVisible(visible); }
 
 void IETView::setDetailedBalance(double detailedBalance) { m_uiForm.spDetailedBalance->setValue(detailedBalance); }
@@ -282,10 +291,15 @@ void IETView::updateRunButton(bool enabled, std::string const &enableOutputButto
 }
 
 void IETView::showMessageBox(const QString &message) { m_subscriber->notifyNewMessage(message); }
+
 void IETView::saveClicked() { m_subscriber->notifySaveClicked(); }
+
 void IETView::runClicked() { m_subscriber->notifyRunClicked(); }
+
 void IETView::plotRawClicked() { m_subscriber->notifyPlotRawClicked(); }
+
 void IETView::saveCustomGroupingClicked() { m_subscriber->notifySaveCustomGroupingClicked(); }
+
 void IETView::pbRunFinished() { m_subscriber->notifyRunFinished(); }
 
 void IETView::handleDataReady() {

--- a/qt/scientific_interfaces/Indirect/Reduction/ISISEnergyTransferView.cpp
+++ b/qt/scientific_interfaces/Indirect/Reduction/ISISEnergyTransferView.cpp
@@ -102,6 +102,8 @@ std::string IETView::getCustomGrouping() { return m_uiForm.leCustomGroups->text(
 
 std::string IETView::getGroupOutputOption() { return m_uiForm.cbGroupOutput->currentText().toStdString(); }
 
+bool IETView::getGroupOutputCheckbox() { return m_uiForm.ckGroupOutput->isChecked(); }
+
 IndirectPlotOptionsView *IETView::getPlotOptionsView() { return m_uiForm.ipoPlotOptions; }
 
 std::string IETView::getFirstFilename() { return m_uiForm.dsRunFiles->getFirstFilename().toStdString(); }
@@ -145,6 +147,20 @@ void IETView::showSaveCustomGroupingDialog(std::string const &customGroupingOutp
 void IETView::displayWarning(std::string const &message) {
   QMessageBox::warning(nullptr, "", QString::fromStdString(message));
 }
+
+void IETView::setBackgroundSectionVisible(bool visible) { m_uiForm.gbBackgroundRemoval->setVisible(visible); }
+void IETView::setPlotTimeSectionVisible(bool visible) { m_uiForm.gbPlotTime->setVisible(visible); }
+void IETView::setPlottingOptionsVisible(bool visible) { m_uiForm.fPlottingOptions->setVisible(visible); }
+void IETView::setScaleFactorVisible(bool visible) {
+  m_uiForm.ckScaleMultiplier->setVisible(visible);
+  m_uiForm.spScaleMultiplier->setVisible(visible);
+}
+void IETView::setAclimaxSaveVisible(bool visible) { m_uiForm.ckSaveAclimax->setVisible(visible); }
+void IETView::setNXSPEVisible(bool visible) { m_uiForm.ckSaveNXSPE->setVisible(visible); }
+void IETView::setFoldMultipleFramesVisible(bool visible) { m_uiForm.ckFold->setVisible(visible); }
+void IETView::setOutputInCm1Visible(bool visible) { m_uiForm.ckCm1Units->setVisible(visible); }
+void IETView::setGrouptOutputCheckBoxVisible(bool visible) { m_uiForm.ckGroupOutput->setVisible(visible); }
+void IETView::setGroupOutputDropdownVisible(bool visible) { m_uiForm.cbGroupOutput->setVisible(visible); }
 
 void IETView::setDetailedBalance(double detailedBalance) { m_uiForm.spDetailedBalance->setValue(detailedBalance); }
 

--- a/qt/scientific_interfaces/Indirect/Reduction/ISISEnergyTransferView.h
+++ b/qt/scientific_interfaces/Indirect/Reduction/ISISEnergyTransferView.h
@@ -61,7 +61,7 @@ public:
   void setNXSPEVisible(bool visible);
   void setFoldMultipleFramesVisible(bool visible);
   void setOutputInCm1Visible(bool visible);
-  void setGrouptOutputCheckBoxVisible(bool visible);
+  void setGroupOutputCheckBoxVisible(bool visible);
   void setGroupOutputDropdownVisible(bool visible);
 
   void setDetailedBalance(double detailedBalance);

--- a/qt/scientific_interfaces/Indirect/Reduction/ISISEnergyTransferView.h
+++ b/qt/scientific_interfaces/Indirect/Reduction/ISISEnergyTransferView.h
@@ -40,6 +40,7 @@ public:
 
   std::string getGroupOutputOption();
   IndirectPlotOptionsView *getPlotOptionsView();
+  bool getGroupOutputCheckbox();
 
   std::string getFirstFilename();
 
@@ -51,6 +52,17 @@ public:
   void showSaveCustomGroupingDialog(std::string const &customGroupingOutput, std::string const &defaultGroupingFilename,
                                     std::string const &saveDirectory);
   void displayWarning(std::string const &message);
+
+  void setBackgroundSectionVisible(bool visible);
+  void setPlotTimeSectionVisible(bool visible);
+  void setPlottingOptionsVisible(bool visible);
+  void setScaleFactorVisible(bool visible);
+  void setAclimaxSaveVisible(bool visible);
+  void setNXSPEVisible(bool visible);
+  void setFoldMultipleFramesVisible(bool visible);
+  void setOutputInCm1Visible(bool visible);
+  void setGrouptOutputCheckBoxVisible(bool visible);
+  void setGroupOutputDropdownVisible(bool visible);
 
   void setDetailedBalance(double detailedBalance);
   void setRunFilesEnabled(bool enable);

--- a/qt/scientific_interfaces/Indirect/Reduction/ISISEnergyTransferView.h
+++ b/qt/scientific_interfaces/Indirect/Reduction/ISISEnergyTransferView.h
@@ -32,26 +32,26 @@ public:
   IETView(IETViewSubscriber *subscriber, QWidget *parent = nullptr);
   ~IETView();
 
-  IETRunData getRunData();
-  IETPlotData getPlotData();
-  IETSaveData getSaveData();
+  IETRunData getRunData() const;
+  IETPlotData getPlotData() const;
+  IETSaveData getSaveData() const;
 
-  std::string getCustomGrouping();
+  std::string getCustomGrouping() const;
 
-  std::string getGroupOutputOption();
-  IndirectPlotOptionsView *getPlotOptionsView();
-  bool getGroupOutputCheckbox();
+  std::string getGroupOutputOption() const;
+  IndirectPlotOptionsView *getPlotOptionsView() const;
+  bool getGroupOutputCheckbox() const;
 
-  std::string getFirstFilename();
+  std::string getFirstFilename() const;
 
-  bool isRunFilesValid();
-  void validateCalibrationFileType(UserInputValidator &uiv);
-  void validateRebinString(UserInputValidator &uiv);
+  bool isRunFilesValid() const;
+  void validateCalibrationFileType(UserInputValidator &uiv) const;
+  void validateRebinString(UserInputValidator &uiv) const;
 
-  bool showRebinWidthPrompt();
+  bool showRebinWidthPrompt() const;
   void showSaveCustomGroupingDialog(std::string const &customGroupingOutput, std::string const &defaultGroupingFilename,
-                                    std::string const &saveDirectory);
-  void displayWarning(std::string const &message);
+                                    std::string const &saveDirectory) const;
+  void displayWarning(std::string const &message) const;
 
   void setBackgroundSectionVisible(bool visible);
   void setPlotTimeSectionVisible(bool visible);


### PR DESCRIPTION
**Description of work**
The PRs remove unnecessary options for IRIS and OSIRIS in the ISIS Energy Transfer window. The current UI has been agreed upon by the scientists. 
**Purpose of work**
<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
-->
The ISIS Energy Transfer has many options that are not commonly used by scientists. 
<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**To test:**
1- Open Interfaces->Indirect->Data Reduction->ISIS Energy Transfer
2- In the top left set the instrument to IRIS
3- Try using different options in the interface
4- Repeat that for OSIRIS

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

Fixes #36000. <!-- and fix #xxxx or close #xxxx xor resolves #xxxx -->
<!-- alternative
*There is no associated issue.*
-->

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.