### PR TITLE
Fix bug that made setting window disappear on Linux

### DIFF
--- a/docs/source/release/v6.9.0/Workbench/Bugfixes/35329.rst
+++ b/docs/source/release/v6.9.0/Workbench/Bugfixes/35329.rst
@@ -1,0 +1,1 @@
+- Fix bug that made settings window disappear behind the Workbench window on Linux when opening the font selection menu.

--- a/qt/applications/workbench/workbench/widgets/settings/general/presenter.py
+++ b/qt/applications/workbench/workbench/widgets/settings/general/presenter.py
@@ -107,7 +107,7 @@ class GeneralSettings(object):
             font_string = CONF.get(GeneralProperties.FONT.value, type=str).split(",")
             if len(font_string) > 2:
                 font = QFontDatabase().font(font_string[0], font_string[-1], int(font_string[1]))
-        font_dialog = self.view.create_font_dialog(self.parent, font)
+        font_dialog = self.view.create_font_dialog(self.view, font)
         font_dialog.fontSelected.connect(self.action_font_selected)
 
     def action_font_selected(self, font):


### PR DESCRIPTION
**Description of work**
The menu for selecting the font in Workbench now has the correct parent widget.

**Purpose of work**
<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
-->
Fixes #35329 

**Summary of work**
<!-- Please provide a short, high level description of the work that was done.
-->
The settings window widget is now the parent for the font selection menu instead of the main Workbench window.


**To test:**
- See #35329 for how to reproduce the original problem, it only happens on Linux. 
- Try opening the font menu and changing the font, maybe resizing the windows, alt+tab. No windows should be disappearing behind other ones by mistake.
- The original problem was Linux-only, but worth testing on Windows and macOS as well, if possible.

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.