### PR TITLE
Fix save section not enabled in ISIS Energy Transfer tab

### DIFF
--- a/qt/scientific_interfaces/Indirect/Reduction/ISISEnergyTransferPresenter.cpp
+++ b/qt/scientific_interfaces/Indirect/Reduction/ISISEnergyTransferPresenter.cpp
@@ -152,8 +152,11 @@ void IETPresenter::algorithmComplete(bool error) {
     m_outputWorkspaces = m_model->groupWorkspaces(m_outputGroupName, m_view->getGroupOutputOption());
     m_pythonExportWsName = m_outputWorkspaces[0];
 
-    setOutputPlotOptionsWorkspaces(m_outputWorkspaces);
-    m_view->setSaveEnabled(true);
+    if (m_outputWorkspaces.size() != 0) {
+      setOutputPlotOptionsWorkspaces(m_outputWorkspaces);
+      m_view->setOutputWorkspaces(m_outputWorkspaces);
+      m_view->setSaveEnabled(true);
+    }
   }
 }
 


### PR DESCRIPTION
**Description of work**
There is an issue with the ISIS Energy Transfer tab where the save section is consistently disabled. This pull request addresses the issue and enables the save section after a successful run, which was the expected behaviour in earlier versions.
**Purpose of work**
This is an issue reported by Spencer that happened while testing the current nightly
**Report to:** Spencer

**Summary of work**
<!-- Please provide a short, high level description of the work that was done.
-->


**Further detail of work**
<!-- Please provide a more detailed description of the work that has been undertaken.
-->


**To test:**
1- Open interfaces->Indirect->Data Reduction->ISIS Energy Transfer
2- Set the instrument to IRIS
3- Make sure you have access to ISIS data archive 
4- Enter 26184
5- Click run
6- The save section should be enabled

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

Fixes #36078

*This does not require release notes* because **This is a minor fix to code that is not visible to users**

<!-- delete this if you added release notes
*This does not require release notes* because **fill in an explanation of why**
If you add release notes please save them as a separate file using the Issue or PR number as the file name. Check the file is located in the correct directory for your note(s).
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.