### PR TITLE
Fix Undocking in Engineering Diffraction Interface

### DIFF
--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/plotting/plot_view.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/fitting/plotting/plot_view.py
@@ -107,7 +107,7 @@ class FittingPlotView(QtWidgets.QWidget, Ui_plot):
             if docked_height > new_height:
                 new_height = docked_height
             new_width = new_height * aspect_ratio
-            self.plot_dock.resize(new_width, new_height)
+            self.plot_dock.resize(int(new_width), int(new_height))
             self.has_first_undock_occurred = 1
 
         self.update_axes_position()

--- a/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/gsas2/view.py
+++ b/qt/python/mantidqtinterfaces/mantidqtinterfaces/Engineering/gui/engineering_diffraction/tabs/gsas2/view.py
@@ -218,7 +218,7 @@ class GSAS2View(QtWidgets.QWidget, Ui_calib):
             if docked_height > new_height:
                 new_height = docked_height
             new_width = new_height * aspect_ratio
-            self.plot_dock.resize(new_width, new_height)
+            self.plot_dock.resize(int(new_width), int(new_height))
             self.has_first_undock_occurred = 1
 
         self.update_axes_position()


### PR DESCRIPTION
**Description of work**

**Purpose of work**
Fix an unhandled exception when a plot is undocked in the engineering diffraction interface. 

**Summary of work**
Cast the calls to qt's `resize` function to int, as the values are meant to be in whole numbers of pixels. This was uncovered by the upgrade to python 3.10, which is more picky about implicit int/float conversions.

**To test:**
1. Load the engineering diffraction interface
2. Switch to the Fitting/GSAS tabs
3. Undock the plot widget 

Fixes #36090 


*This does not require release notes* because **it fixes a regression introduced during the release.**

---

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.