### PR TITLE
Fix sample log implicit conversion warning

### DIFF
--- a/docs/source/release/v6.8.0/Workbench/Bugfixes/36089.rst
+++ b/docs/source/release/v6.8.0/Workbench/Bugfixes/36089.rst
@@ -1,0 +1,1 @@
+- An implicit conversion warning which sometimes appears when opening Sample logs has been fixed.

--- a/qt/python/mantidqt/mantidqt/widgets/samplelogs/model.py
+++ b/qt/python/mantidqt/mantidqt/widgets/samplelogs/model.py
@@ -231,7 +231,7 @@ class SampleLogsModel:
                 item.setToolTip("All of the values in the log are marked invalid, none of them are filtered.")
             elif invalid_value_count > 0:
                 saturation = 10 + (170 * (invalid_value_count / (log_size + invalid_value_count)))
-                item.setData(QColor.fromHsv(0, saturation, 255), Qt.BackgroundRole)
+                item.setData(QColor.fromHsv(0, int(saturation), 255), Qt.BackgroundRole)
                 aux_verb = "is" if invalid_value_count == 1 else "are"
                 item.setToolTip(
                     f"{invalid_value_count}/{log_size+invalid_value_count} of the values in the log"


### PR DESCRIPTION
**Description of work**
This PR fixes an implicit conversion warning seen when opening the sample logs of the `ENGINX00228061_log_alarm_data` training data in v6.7 of Mantid. The move to python 3.10 means that this warning has now become an exception in Mantid v6.8.

**To test:**
Download and install the tarbar from this build package from branch into an IDAaaS workspace:
https://builds.mantidproject.org/job/build_packages_from_branch/593/

Link to IDAaaS dev site:
https://dev.analysis.stfc.ac.uk/

Then follow the testing instructions in the attached issue. There should be no exception and the sample logs should load as expected.

Fixes #36089

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.