### PR TITLE
Fix bug when trying to select the EISFDiffSphereAlky function

### DIFF
--- a/Framework/PythonInterface/mantid/api/src/FitFunctions/IFunctionAdapter.cpp
+++ b/Framework/PythonInterface/mantid/api/src/FitFunctions/IFunctionAdapter.cpp
@@ -8,6 +8,7 @@
 #include "MantidPythonInterface/core/CallMethod.h"
 #include "MantidPythonInterface/core/Converters/PyNativeTypeExtractor.h"
 #include "MantidPythonInterface/core/Converters/WrapWithNDArray.h"
+#include "MantidPythonInterface/core/GlobalInterpreterLock.h"
 
 #include <boost/python/class.hpp>
 #include <boost/python/list.hpp>
@@ -167,6 +168,7 @@ PyObject *IFunctionAdapter::getAttributeValue(const IFunction &self, const API::
   UNUSED_ARG(self);
   std::string type = attr.type();
   PyObject *result(nullptr);
+  GlobalInterpreterLock gilLock;
   if (type == "int")
     result = to_python_value<const int &>()(attr.asInt());
   else if (type == "double")

--- a/Framework/PythonInterface/plugins/functions/EISFDiffSphereAlkyl.py
+++ b/Framework/PythonInterface/plugins/functions/EISFDiffSphereAlkyl.py
@@ -10,27 +10,7 @@
 @date December 06, 2017
 """
 import numpy as np
-
-try:
-    from scipy.special import spherical_jn
-
-    def j1(z):
-        return spherical_jn(1, z)
-
-    def j1d(z):
-        return spherical_jn(1, z, derivative=True)
-
-except ImportError:
-    # spherical_jn removed from scipy >= 1.0.0
-    from scipy.special import sph_jn
-
-    def j1(z):
-        return sph_jn(1, z)[0][1]
-
-    def j1d(z):
-        return sph_jn(1, z)[1][1]
-
-
+from scipy.special import spherical_jn
 from mantid.api import IFunction1D, FunctionFactory
 
 
@@ -39,7 +19,7 @@ class EISFDiffSphereAlkyl(IFunction1D):
     alkyl molecule.
     """
 
-    vecbessel = np.vectorize(lambda z: j1(z) / z)
+    vecbessel = np.vectorize(lambda z: spherical_jn(1, z) / z)
 
     def category(self):
         return "QuasiElastic"

--- a/docs/source/release/v6.8.0/Indirect/Bugfixes/36076.rst
+++ b/docs/source/release/v6.8.0/Indirect/Bugfixes/36076.rst
@@ -1,0 +1,1 @@
+- Fix bug when choosing the EISFDiffSphereAlkyl algorithm in the F(Q) fit tab of the Indirect - Data Analysis window.


### PR DESCRIPTION
**Description of work**
Fixes an access violation exception when selecting the `EISFDiffSphereAlky` function in the Indirect - Data Analysis window. The same problem could also occur in other ways, e.g. trying to use a `BivariateGaussian` function in a fitting window. It seemed to be any fitting function that has attributes defined could trigger the access violation.

**Purpose of work**
<!-- Why has this work been done? If there is no linked issue please provide appropriate context for this work.
-->
Fixes #36076 

<!-- If the original issue was raised by a user they should be named here. Do not leak email addresses
**Report to:** [user name]
-->

**Summary of work**
<!-- Please provide a short, high level description of the work that was done.
-->
- Acquired GIL before calling into the Boost python interface methods.
- Tidied up `EISFDiffSphereAlky.py`slightly.


**To test:**
See #36076 for the original problem. Also worth checking that the `EISFDiffSphereAlky` still works properly. Maybe some more fitting attempts would be good, to make sure everything else is still working.

<!-- Instructions for testing.
There should be sufficient instructions for someone unfamiliar with the application to test - unless a specific
reviewer is requested.
If instructions for replicating the fault are contained in the linked issue then it is OK to refer back to these.
-->

<!-- Ensure the base of this PR is correct (e.g. release-next or main)
Finally, don't forget to add the appropriate labels, milestones, etc.!  -->

---

#### Reviewer ####

Please comment on the points listed below ([full description](http://developer.mantidproject.org/ReviewingAPullRequest.html)).
**Your comments will be used as part of the gatekeeper process, so please comment clearly on what you have checked during your review.** If changes are made to the PR during the review process then your final comment will be the most important for gatekeepers. In this comment you should make it clear why any earlier review is still valid, or confirm that all requested changes have been addressed.

##### Code Review #####

- Is the code of an acceptable quality?
- Does the code conform to the [coding standards](http://developer.mantidproject.org/Standards/)?
- Are the unit tests small and test the class in isolation?
- If there is GUI work does it follow the [GUI standards](http://developer.mantidproject.org/Standards/GUIStandards.html)?
- If there are changes in the release notes then do they describe the changes appropriately?
- Are the release notes saved in a separate file, using Issue or PR number for file name and in the correct location?

##### Functional Tests #####

- Do changes function as described? Add comments below that describe the tests performed?
- Do the changes handle unexpected situations, e.g. bad input?
- Has the relevant (user and developer) documentation been added/updated?

Does everything look good? Mark the review as **Approve**. A member of `@mantidproject/gatekeepers` will take care of it.

#### Gatekeeper ####

If you need to request changes to a PR then please add a comment and set the review status to "Request changes". This will stop the PR from showing up in the list for other gatekeepers.